### PR TITLE
feat(sandboxes): the last three launch doors take sandbox_mode and sandbox_id

### DIFF
--- a/.claude/skills/fountain/SKILL.md
+++ b/.claude/skills/fountain/SKILL.md
@@ -182,6 +182,28 @@ Vault values override the environment's baseline on key collision. Most fan-outs
 don't need this — only reach for it when you specifically want different
 credentials per spawned conversation.
 
+## Children on this machine
+
+`FOUNTAIN_SANDBOX_ID` is the sandbox you are running on. Pass it as
+`sandbox_id` and the child runs on this same machine — same disk, same
+checkouts, at the same time as you. Only a child of the same agent, environment
+and vault can attach; anything else is refused with `sandbox_identity_mismatch`.
+
+```bash
+# Spawn a child onto this machine (shares /workspace with you):
+curl -s -X POST "$FOUNTAIN_BASE_URL/api/conversations" \
+  -H "Authorization: Bearer $FOUNTAIN_TOKEN" -H "Content-Type: application/json" \
+  -H "X-Fountain-Parent-Conversation-Id: $FOUNTAIN_CONVERSATION_ID" \
+  -d "$(jq -n --arg a "$AGENT_ID" --arg s "$FOUNTAIN_SANDBOX_ID" --arg p "$PROMPT" \
+        '{agent_id:$a, sandbox_id:$s, prompt:$p}')"
+```
+
+Without `sandbox_id` each child gets what the agent's `sandbox_mode` says: a
+fresh sandbox (`ephemeral`, the default) or the agent's one persistent machine.
+`sandbox_mode` on the create call names the other mode for that one child —
+`{"agent_id":..., "sandbox_mode":"ephemeral", "prompt":...}` fans out onto
+fresh disks from a persistent parent.
+
 ## Multi-turn
 
 Send a follow-up prompt to an existing conversation:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,17 @@ upgrade, is in
 
 ### Added
 
+- **The last three launch doors take `sandbox_mode` and `sandbox_id`.**
+  `fountain acp` gets `--sandbox-mode` and `--sandbox` for every session it
+  opens, and a client may name either per session in `session/new` `_meta`
+  (`sandboxMode`, `sandboxId`). A hosted Buzz agent carries `sandbox_mode`
+  on its identity (`POST /api/buzz/agents`, the provider's settings form),
+  passed to its harness as `--sandbox-mode`; a change restarts the harness
+  like the other launch fields. The sandbox exports `FOUNTAIN_SANDBOX_ID`
+  beside `FOUNTAIN_CONVERSATION_ID`, so the `fountain` skill can put a child
+  onto the parent's own machine with `sandbox_id`. Channel resume still takes
+  the agent's default, on purpose. ADR 0023 step 8, #1070.
+
 - **Reset a persistent sandbox.** `DELETE /api/sandboxes/:id` destroys an
   agent's home so the next launch on the same agent, environment and vault
   builds a clean machine — the conversations on it are kept, idle, and each

--- a/apps/fountain/lib/fountain/buzz.ex
+++ b/apps/fountain/lib/fountain/buzz.ex
@@ -90,6 +90,7 @@ defmodule Fountain.Buzz do
   def provision_identity(user_id, params, opts \\ []) when is_binary(user_id) do
     with {:ok, fields} <- validate_provision(params),
          :ok <- check_environment(fields.environment_id, user_id),
+         :ok <- check_sandbox_mode(fields.sandbox_mode),
          {:ok, dek} <- Crypto.load_tenant_key(user_id),
          {:ok, vault} <- ensure_vault(user_id, fields, dek, opts),
          :ok <- write_buzz_secrets(vault, fields, dek, opts) do
@@ -113,6 +114,7 @@ defmodule Fountain.Buzz do
          auth_tag: params["auth_tag"],
          display_name: params["display_name"],
          environment_id: presence(params["environment_id"]),
+         sandbox_mode: presence(params["sandbox_mode"]),
          respond_to: presence(params["respond_to"]) || "owner-only",
          respond_to_allowlist: allowlist(params["respond_to_allowlist"])
        }}
@@ -143,6 +145,16 @@ defmodule Fountain.Buzz do
 
   # Scoped fetch: the environment's secrets materialise in this identity's
   # sandboxes, so a pointer at another tenant's must never be stored.
+  # Checked before the vault is created so a typo does not leave a half-
+  # provisioned identity behind; nil is the agent's own default.
+  defp check_sandbox_mode(nil), do: :ok
+
+  defp check_sandbox_mode(mode) do
+    if mode in Fountain.Agents.Agent.sandbox_modes(),
+      do: :ok,
+      else: {:error, :invalid_sandbox_mode}
+  end
+
   defp check_environment(nil, _user_id), do: :ok
 
   defp check_environment(id, user_id) do
@@ -186,6 +198,7 @@ defmodule Fountain.Buzz do
       "agent_id" => fields.agent_id,
       "vault_id" => vault.id,
       "environment_id" => fields.environment_id,
+      "sandbox_mode" => fields.sandbox_mode,
       "name" => fields.name,
       "relay_url" => fields.relay_url,
       "pubkey" => fields.pubkey,
@@ -202,7 +215,7 @@ defmodule Fountain.Buzz do
   end
 
   # Every identity field that ends up in the harness env or the ACP child's argv.
-  @launch_fields ~w(agent_id relay_url display_name environment_id respond_to respond_to_allowlist)a
+  @launch_fields ~w(agent_id relay_url display_name environment_id sandbox_mode respond_to respond_to_allowlist)a
 
   @doc """
   Whether a re-provision changed anything the running harness was launched
@@ -477,13 +490,16 @@ defmodule Fountain.Buzz do
   defp maybe_put_allowlist(env, _identity), do: env
 
   # Point the harness's ACP child at this Fountain agent + vault (+ environment
-  # override, #783), and keep the pool to one (the desktop's 10 is not our
-  # assumption).
+  # override, #783; + sandbox mode, ADR 0023), and keep the pool to one (the
+  # desktop's 10 is not our assumption).
   defp acp_wiring_env(%BuzzIdentity{} = identity, fountain_bin, agents) do
     args =
       ["acp", "--agent", identity.agent_id, "--vault", identity.vault_id]
       |> Kernel.++(
         if identity.environment_id, do: ["--environment", identity.environment_id], else: []
+      )
+      |> Kernel.++(
+        if identity.sandbox_mode, do: ["--sandbox-mode", identity.sandbox_mode], else: []
       )
       |> Enum.join(",")
 

--- a/apps/fountain/lib/fountain/buzz/buzz_identity.ex
+++ b/apps/fountain/lib/fountain/buzz/buzz_identity.ex
@@ -52,6 +52,9 @@ defmodule Fountain.Buzz.BuzzIdentity do
     field :enabled, :boolean, default: true
     field :respond_to, :string, default: "owner-only"
     field :respond_to_allowlist, {:array, :string}, default: []
+    # Where this identity's conversations run (ADR 0023): `ephemeral`,
+    # `persistent`, or nil for the agent's own default.
+    field :sandbox_mode, :string
 
     belongs_to :user, User
     belongs_to :agent, Agent
@@ -69,6 +72,7 @@ defmodule Fountain.Buzz.BuzzIdentity do
     :enabled,
     :respond_to,
     :respond_to_allowlist,
+    :sandbox_mode,
     :user_id,
     :agent_id,
     :vault_id,
@@ -83,6 +87,7 @@ defmodule Fountain.Buzz.BuzzIdentity do
     |> validate_relay_url()
     |> validate_pubkey()
     |> validate_inclusion(:respond_to, @respond_to_modes)
+    |> validate_inclusion(:sandbox_mode, Fountain.Agents.Agent.sandbox_modes())
     |> validate_respond_to_allowlist()
     |> unique_constraint(:name, name: :buzz_identities_user_id_name_index)
     |> unique_constraint(:pubkey, name: :buzz_identities_user_id_pubkey_index)

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -1266,6 +1266,7 @@ defmodule Fountain.Conversations.ConversationServer do
     (state.runtime_module.default_env(agent, state.inference_credentials) || []) ++
       fountain_callback_env(state.callback_token) ++
       conversation_env(state.conversation_id) ++
+      sandbox_id_env(state.sandbox_id) ++
       sandbox_url_env(sandbox_url) ++
       otel_propagation_env() ++
       git_author_env() ++
@@ -1318,6 +1319,15 @@ defmodule Fountain.Conversations.ConversationServer do
 
   defp conversation_env(conv_id) when is_binary(conv_id),
     do: [{"FOUNTAIN_CONVERSATION_ID", conv_id}]
+
+  # The machine's own id, so the bundled fountain skill can put a child
+  # conversation onto this same sandbox (`sandbox_id` on the create, ADR 0023).
+  # Machine-scoped, not conversation-scoped: every conversation on the sandbox
+  # sees the same value, so unlike the conversation id it may live on the disk.
+  defp sandbox_id_env(nil), do: []
+
+  defp sandbox_id_env(sandbox_id) when is_binary(sandbox_id),
+    do: [{"FOUNTAIN_SANDBOX_ID", sandbox_id}]
 
   @doc false
   def git_author_env do

--- a/apps/fountain/lib/fountain_web/controllers/buzz_agent_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/buzz_agent_controller.ex
@@ -48,7 +48,7 @@ defmodule FountainWeb.BuzzAgentController do
       Map.take(
         params,
         ~w(name relay_url agent_id pubkey private_key_nsec auth_tag display_name environment_id
-           respond_to respond_to_allowlist)
+           sandbox_mode respond_to respond_to_allowlist)
       )
 
     # A converging deploy may change what the harness was launched with; the
@@ -76,6 +76,14 @@ defmodule FountainWeb.BuzzAgentController do
       # cannot be used to probe which ids exist.
       {:error, :environment_not_found} ->
         conn |> put_status(:not_found) |> json(%{error: "environment_not_found"})
+
+      {:error, :invalid_sandbox_mode} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> json(%{
+          error: "invalid_sandbox_mode",
+          detail: "sandbox_mode must be ephemeral or persistent"
+        })
 
       # Field errors — an empty allowlist in allowlist mode, a malformed pubkey —
       # so a provider deploy can say *why* it was refused, not a bare 422.
@@ -187,6 +195,7 @@ defmodule FountainWeb.BuzzAgentController do
       agent_id: i.agent_id,
       vault_id: i.vault_id,
       environment_id: i.environment_id,
+      sandbox_mode: i.sandbox_mode,
       respond_to: i.respond_to,
       respond_to_allowlist: i.respond_to_allowlist,
       enabled: i.enabled,

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -698,6 +698,15 @@ defmodule FountainWeb.Schemas do
             "Environment this identity's conversations are provisioned from instead of " <>
               "the agent's own; null means the agent's."
         },
+        sandbox_mode: %Schema{
+          type: :string,
+          enum: ~w(ephemeral persistent),
+          nullable: true,
+          description:
+            "Where this identity's conversations run (ADR 0023): a sandbox per " <>
+              "conversation, or the agent's one persistent machine. null means the " <>
+              "agent's own default."
+        },
         respond_to: %Schema{
           type: :string,
           enum: ~w(owner-only allowlist anyone nobody),
@@ -751,6 +760,16 @@ defmodule FountainWeb.Schemas do
               "owned by the caller (404 otherwise) and, when the agent sets " <>
               "allowed_environment_ids, on that list (checked at conversation start). " <>
               "Omitted on a re-provision clears a previously set one."
+        },
+        sandbox_mode: %Schema{
+          type: :string,
+          enum: ~w(ephemeral persistent),
+          nullable: true,
+          description:
+            "Where this identity's conversations run (ADR 0023), passed to the harness " <>
+              "as fountain acp --sandbox-mode. Omitted means the agent's own default; " <>
+              "omitted on a re-provision clears a previously set one. A re-provision that " <>
+              "changes it restarts a running harness."
         },
         respond_to: %Schema{
           type: :string,

--- a/apps/fountain/priv/repo/migrations/20260824030000_add_sandbox_mode_to_buzz_identities.exs
+++ b/apps/fountain/priv/repo/migrations/20260824030000_add_sandbox_mode_to_buzz_identities.exs
@@ -1,0 +1,13 @@
+defmodule Fountain.Repo.Migrations.AddSandboxModeToBuzzIdentities do
+  use Ecto.Migration
+
+  # A hosted Buzz agent may name where its conversations run (ADR 0023 step
+  # 8): `ephemeral`, `persistent`, or NULL for the agent's own default. The
+  # harness passes it to `fountain acp --sandbox-mode`, so it is a launch
+  # field — a change bounces the harness.
+  def change do
+    alter table(:buzz_identities) do
+      add :sandbox_mode, :string, null: true
+    end
+  end
+end

--- a/apps/fountain/priv/sprite_skills/fountain/SKILL.md
+++ b/apps/fountain/priv/sprite_skills/fountain/SKILL.md
@@ -162,6 +162,28 @@ Vault values override the environment's baseline on key collision. Most fan-outs
 don't need this — only reach for it when you specifically want different
 credentials per spawned conversation.
 
+## Children on this machine
+
+`FOUNTAIN_SANDBOX_ID` is the sandbox you are running on. Pass it as
+`sandbox_id` and the child runs on this same machine — same disk, same
+checkouts, at the same time as you. Only a child of the same agent, environment
+and vault can attach; anything else is refused with `sandbox_identity_mismatch`.
+
+```bash
+# Spawn a child onto this machine (shares /workspace with you):
+curl -s -X POST "$FOUNTAIN_BASE_URL/api/conversations" \
+  -H "Authorization: Bearer $FOUNTAIN_TOKEN" -H "Content-Type: application/json" \
+  -H "X-Fountain-Parent-Conversation-Id: $FOUNTAIN_CONVERSATION_ID" \
+  -d "$(jq -n --arg a "$AGENT_ID" --arg s "$FOUNTAIN_SANDBOX_ID" --arg p "$PROMPT" \
+        '{agent_id:$a, sandbox_id:$s, prompt:$p}')"
+```
+
+Without `sandbox_id` each child gets what the agent's `sandbox_mode` says: a
+fresh sandbox (`ephemeral`, the default) or the agent's one persistent machine.
+`sandbox_mode` on the create call names the other mode for that one child —
+`{"agent_id":..., "sandbox_mode":"ephemeral", "prompt":...}` fans out onto
+fresh disks from a persistent parent.
+
 ## Multi-turn
 
 Send a follow-up prompt to an existing conversation:

--- a/apps/fountain/test/fountain/buzz_test.exs
+++ b/apps/fountain/test/fountain/buzz_test.exs
@@ -281,6 +281,32 @@ defmodule Fountain.BuzzTest do
                })
     end
 
+    # ADR 0023 step 8: an identity may name where its conversations run. It is
+    # a launch field like the environment override: stored, cleared when a
+    # re-provision omits it, and refused before the vault exists when invalid.
+    test "stores a sandbox_mode, and a re-provision without one clears it", %{
+      user: user,
+      params: params
+    } do
+      assert {:ok, identity} =
+               Buzz.provision_identity(user.id, Map.put(params, "sandbox_mode", "persistent"))
+
+      assert identity.sandbox_mode == "persistent"
+
+      assert {:ok, again} = Buzz.provision_identity(user.id, params)
+      assert is_nil(again.sandbox_mode)
+    end
+
+    test "an unknown sandbox_mode is refused and nothing is provisioned", %{
+      user: user,
+      params: params
+    } do
+      assert {:error, :invalid_sandbox_mode} =
+               Buzz.provision_identity(user.id, Map.put(params, "sandbox_mode", "forever"))
+
+      assert is_nil(Buzz.get_identity_by_pubkey(params["pubkey"], user.id))
+    end
+
     test "a foreign or unknown environment_id is not stored", %{user: user, params: params} do
       other = insert_verified_user()
       foreign = insert_env(user_id: other.id)
@@ -388,6 +414,23 @@ defmodule Fountain.BuzzTest do
                "acp,--agent,#{agent.id},--vault,#{vault.id},--environment,#{env.id}"
     end
 
+    # ADR 0023: the mode reaches the ACP child as --sandbox-mode, so every
+    # conversation the harness opens lands where the identity says.
+    test "a sandbox_mode is passed to the ACP child",
+         %{identity: identity, agent: agent, vault: vault} do
+      {:ok, identity} = Buzz.update_identity(identity, %{"sandbox_mode" => "persistent"})
+
+      assert {:ok, launch} =
+               Buzz.harness_launch(identity,
+                 buzz_acp_path: "/opt/buzz-acp",
+                 base_url: "https://fountain.example",
+                 fountain_bin: "fountain"
+               )
+
+      assert Map.new(launch.env)["BUZZ_ACP_AGENT_ARGS"] ==
+               "acp,--agent,#{agent.id},--vault,#{vault.id},--sandbox-mode,persistent"
+    end
+
     # #790: without BUZZ_ACP_RESPOND_TO the harness runs owner-only whatever the
     # desktop's record says; the identity's gate must reach the env.
     test "the author gate is set on the harness env",
@@ -428,6 +471,9 @@ defmodule Fountain.BuzzTest do
       env = insert_env(user_id: user.id)
       {:ok, moved} = Buzz.update_identity(identity, %{"environment_id" => env.id})
       assert Buzz.launch_config_changed?(identity, moved)
+
+      {:ok, homed} = Buzz.update_identity(identity, %{"sandbox_mode" => "persistent"})
+      assert Buzz.launch_config_changed?(identity, homed)
 
       # A field the harness never reads at launch is not a reason to bounce it.
       {:ok, disabled} = Buzz.update_identity(identity, %{"enabled" => false})

--- a/apps/fountain/test/fountain/conversations/conversation_server_identity_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_identity_test.exs
@@ -56,11 +56,16 @@ defmodule Fountain.Conversations.ConversationServerIdentityTest do
       refute "FOUNTAIN_CONVERSATION_ID" in file_keys
       refute "TRACEPARENT" in file_keys
 
+      # The machine's own id is machine-scoped, so it may sit beside the
+      # environment values on disk (ADR 0023: a child onto this sandbox).
+      assert {"FOUNTAIN_SANDBOX_ID", conv.sandbox_id} in file_env
+
       # The process is the conversation's: identity as env, and the session
       # tagged on its own command line.
       assert_receive {:spawned, cmd, args, opts}, 2_000
       spawn_env = Keyword.fetch!(opts, :env)
       assert {"FOUNTAIN_CONVERSATION_ID", conv.id} in spawn_env
+      assert {"FOUNTAIN_SANDBOX_ID", conv.sandbox_id} in spawn_env
       assert Enum.any?(spawn_env, &match?({"FOUNTAIN_TOKEN", token} when is_binary(token), &1))
       assert {"FROM_ENVIRONMENT", "yes"} in spawn_env
 

--- a/apps/fountain/test/fountain_web/controllers/buzz_agent_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/buzz_agent_controller_test.exs
@@ -117,6 +117,37 @@ defmodule FountainWeb.BuzzAgentControllerTest do
     assert json_response(conn, 201)["data"]["environment_id"] == env.id
   end
 
+  test "POST stores a sandbox_mode and returns it", %{
+    conn: conn,
+    raw_key: raw_key,
+    agent: agent
+  } do
+    conn =
+      conn
+      |> authed_with_key(raw_key)
+      |> put_req_header("content-type", "application/json")
+      |> post("/api/buzz/agents", Map.put(params(agent), "sandbox_mode", "persistent"))
+
+    assert json_response(conn, 201)["data"]["sandbox_mode"] == "persistent"
+  end
+
+  # The OpenAPI cast refuses the enum before the context sees it, the same way
+  # a bad respond_to is refused; the context's own check (buzz_test) covers a
+  # caller that reaches provision_identity another way.
+  test "POST with an unknown sandbox_mode is a 422 that names the field", %{
+    conn: conn,
+    raw_key: raw_key,
+    agent: agent
+  } do
+    conn =
+      conn
+      |> authed_with_key(raw_key)
+      |> put_req_header("content-type", "application/json")
+      |> post("/api/buzz/agents", Map.put(params(agent), "sandbox_mode", "forever"))
+
+    assert inspect(json_response(conn, 422)) =~ "sandbox_mode"
+  end
+
   test "POST with a foreign environment_id is a 404, and nothing is provisioned", %{
     conn: conn,
     raw_key: raw_key,

--- a/apps/fountain/test/fountain_web/schema_enum_guardrail_test.exs
+++ b/apps/fountain/test/fountain_web/schema_enum_guardrail_test.exs
@@ -67,6 +67,8 @@ defmodule FountainWeb.SchemaEnumGuardrailTest do
     {FountainWeb.Schemas.BillingResponse, "data.plan.slug"} => {Fountain.Plans, :slugs},
     {FountainWeb.Schemas.BuzzIdentity, "respond_to"} => {BuzzIdentity, :respond_to_modes},
     {FountainWeb.Schemas.BuzzProvisionRequest, "respond_to"} => {BuzzIdentity, :respond_to_modes},
+    {FountainWeb.Schemas.BuzzIdentity, "sandbox_mode"} => {Agent, :sandbox_modes},
+    {FountainWeb.Schemas.BuzzProvisionRequest, "sandbox_mode"} => {Agent, :sandbox_modes},
     {FountainWeb.Schemas.BuzzAccessUpdateRequest, "respond_to"} =>
       {BuzzIdentity, :respond_to_modes},
     # The permission verdicts a policy may actually name today. Deliberately

--- a/cli/internal/acp/session.go
+++ b/cli/internal/acp/session.go
@@ -14,12 +14,14 @@ type API interface {
 	// Agent resolves a name or id to the agent it names.
 	Agent(ctx context.Context, target string) (AgentRef, error)
 	// CreateConversation starts a conversation for an agent and returns its id.
+	// opts carries what the client's `session/new` said out of band: the
+	// channel key and rotation flag, and the per-session sandbox override.
 	// With a non-empty channelID the server resumes the latest live conversation
 	// already bound to that channel for the same agent and vault instead of
 	// opening a new one (#774); resumed reports which happened. fresh asks the
 	// server to skip that resume and open a new conversation that becomes the
 	// channel's binding — the client's owner rotated the channel.
-	CreateConversation(ctx context.Context, agentID, channelID string, fresh bool) (id string, resumed bool, err error)
+	CreateConversation(ctx context.Context, agentID string, opts SessionOptions) (id string, resumed bool, err error)
 	// StreamHead returns the conversation's current last event id, so a follow
 	// can skip the history. Called BEFORE a prompt is sent — see prompt.go.
 	StreamHead(ctx context.Context, convID string) (string, error)
@@ -116,6 +118,20 @@ func (s *sessions) get(id string) (Session, bool) {
 	return sess, ok
 }
 
+// SessionOptions is what one `session/new` asks for beyond the agent: the
+// channel it serves (and whether to skip the resume this once), and where the
+// conversation runs. An empty field means "not asked" — the API layer then
+// falls back to its process-wide flags, or omits the key so the server
+// applies the agent's default.
+type SessionOptions struct {
+	ChannelID string
+	Fresh     bool
+	// SandboxMode is `ephemeral` or `persistent` (ADR 0023); SandboxID attaches
+	// the session to a machine the caller already has.
+	SandboxMode string
+	SandboxID   string
+}
+
 type newSessionParams struct {
 	Cwd        string            `json:"cwd"`
 	MCPServers []json.RawMessage `json:"mcpServers"`
@@ -125,11 +141,15 @@ type newSessionParams struct {
 	// harness forgets its sessions on every restart. `freshSession` rides
 	// with it on the first session/new after the harness's owner rotated the
 	// channel (`!rotate`): the resume must be skipped this once, or rotation
-	// is a no-op behind a channel-keyed server. Anything else in _meta is
-	// ignored here.
+	// is a no-op behind a channel-keyed server. `sandboxMode` and `sandboxId`
+	// say where this one session's conversation runs (ADR 0023), overriding
+	// the process's --sandbox-mode / --sandbox for the session. Anything else
+	// in _meta is ignored here.
 	Meta struct {
 		ChannelID    string `json:"channelId"`
 		FreshSession bool   `json:"freshSession"`
+		SandboxMode  string `json:"sandboxMode"`
+		SandboxID    string `json:"sandboxId"`
 	} `json:"_meta"`
 }
 
@@ -188,7 +208,12 @@ func (a *Agent) newSession(ctx context.Context, raw json.RawMessage) (any, error
 	// to the people in the channel (#774). Unless the harness says the owner
 	// rotated the channel — then a new conversation is opened and becomes
 	// the binding.
-	convID, resumed, err := a.api.CreateConversation(ctx, ref.ID, params.Meta.ChannelID, params.Meta.FreshSession)
+	convID, resumed, err := a.api.CreateConversation(ctx, ref.ID, SessionOptions{
+		ChannelID:   params.Meta.ChannelID,
+		Fresh:       params.Meta.FreshSession,
+		SandboxMode: params.Meta.SandboxMode,
+		SandboxID:   params.Meta.SandboxID,
+	})
 	if err != nil {
 		return nil, Errorf(CodeInternalError, "could not start a conversation for %q: %s", ref.Name, err)
 	}

--- a/cli/internal/acp/session_test.go
+++ b/cli/internal/acp/session_test.go
@@ -18,6 +18,7 @@ type fakeAPI struct {
 	created  []string
 	channels []string
 	fresh    []bool
+	sandbox  []SessionOptions
 	convID   string
 	resumed  bool
 
@@ -72,10 +73,11 @@ func (f *fakeAPI) Agent(_ context.Context, target string) (AgentRef, error) {
 	return f.ref, nil
 }
 
-func (f *fakeAPI) CreateConversation(_ context.Context, agentID, channelID string, fresh bool) (string, bool, error) {
+func (f *fakeAPI) CreateConversation(_ context.Context, agentID string, opts SessionOptions) (string, bool, error) {
 	f.created = append(f.created, agentID)
-	f.channels = append(f.channels, channelID)
-	f.fresh = append(f.fresh, fresh)
+	f.channels = append(f.channels, opts.ChannelID)
+	f.fresh = append(f.fresh, opts.Fresh)
+	f.sandbox = append(f.sandbox, opts)
 	if f.createErr != nil {
 		return "", false, f.createErr
 	}
@@ -486,5 +488,29 @@ func TestSetConfigOptionOnAnUnknownSessionIsRefused(t *testing.T) {
 	}
 	if rpcErr.Code != CodeInvalidParams {
 		t.Errorf("code = %d, want CodeInvalidParams (%d)", rpcErr.Code, CodeInvalidParams)
+	}
+}
+
+// ADR 0023: a client may say per session where its conversation runs. Both
+// keys ride to the API layer as they were sent; absent means "not asked".
+func TestNewSessionForwardsTheSandboxOverrides(t *testing.T) {
+	api := &fakeAPI{ref: acpAgentRef(), convID: "conv-home"}
+	a := sessionAgent(t, api, "researcher")
+
+	if _, rpcErr := request(t, a, "session/new", map[string]any{
+		"cwd":   "/home/dev/proj",
+		"_meta": map[string]any{"sandboxMode": "persistent", "sandboxId": "sb-1"},
+	}); rpcErr != nil {
+		t.Fatalf("session/new failed: %v", rpcErr)
+	}
+	if len(api.sandbox) != 1 || api.sandbox[0].SandboxMode != "persistent" || api.sandbox[0].SandboxID != "sb-1" {
+		t.Errorf("sandbox options forwarded = %+v, want persistent / sb-1", api.sandbox)
+	}
+
+	if _, rpcErr := request(t, a, "session/new", map[string]any{"cwd": "/home/dev/proj"}); rpcErr != nil {
+		t.Fatalf("session/new failed: %v", rpcErr)
+	}
+	if len(api.sandbox) != 2 || api.sandbox[1].SandboxMode != "" || api.sandbox[1].SandboxID != "" {
+		t.Errorf("sandbox options forwarded = %+v, want empty for a session that asked nothing", api.sandbox[1:])
 	}
 }

--- a/cli/internal/backend/backend.go
+++ b/cli/internal/backend/backend.go
@@ -103,6 +103,10 @@ type ProvisionBody struct {
 	// Optional per-identity environment override (#783): the environment this
 	// identity's conversations are provisioned from instead of the agent's own.
 	EnvironmentID string `json:"environment_id,omitempty"`
+	// Optional per-identity sandbox mode (ADR 0023): `ephemeral` or
+	// `persistent`, where this identity's conversations run. Omitted means
+	// the agent's default.
+	SandboxMode string `json:"sandbox_mode,omitempty"`
 	// The harness's inbound author gate (#790). Omitted when the desktop sent
 	// none, so Fountain applies its own owner-only default.
 	RespondTo          string   `json:"respond_to,omitempty"`
@@ -127,6 +131,12 @@ func Info() InfoResponse {
       "type": "string",
       "title": "Fountain environment (optional)",
       "description": "Name or id of a Fountain environment to provision this identity's conversations from, instead of the agent's own. Leave blank to use the agent's."
+    },
+    "sandbox_mode": {
+      "type": "string",
+      "title": "Sandbox mode (optional)",
+      "enum": ["ephemeral", "persistent"],
+      "description": "Where this identity's conversations run: a sandbox per conversation, or the agent's one persistent machine. Leave blank to use the agent's default."
     }
   },
   "required": ["agent"]
@@ -191,6 +201,7 @@ func Deploy(req Request, f Fountain) DeployResponse {
 		AuthTag:        req.Agent.AuthTag,
 		DisplayName:    req.Agent.Name,
 		EnvironmentID:  envID,
+		SandboxMode:    cfg.SandboxMode,
 		// Pass the author gate through verbatim; Fountain validates the mode and
 		// the pubkeys and refuses an allowlist with nothing on it.
 		RespondTo:          strings.TrimSpace(req.Agent.RespondTo),
@@ -231,6 +242,7 @@ func derivePubkey(key string) (string, error) {
 type providerConfigFields struct {
 	Agent       string `json:"agent"`
 	Environment string `json:"environment"`
+	SandboxMode string `json:"sandbox_mode"`
 }
 
 func providerConfig(raw json.RawMessage) (providerConfigFields, error) {
@@ -240,8 +252,14 @@ func providerConfig(raw json.RawMessage) (providerConfigFields, error) {
 	}
 	cfg.Agent = strings.TrimSpace(cfg.Agent)
 	cfg.Environment = strings.TrimSpace(cfg.Environment)
+	cfg.SandboxMode = strings.TrimSpace(cfg.SandboxMode)
 	if cfg.Agent == "" {
 		return cfg, fmt.Errorf("no Fountain agent configured — set the `agent` field")
+	}
+	// Refused here, not at Fountain: the desktop shows this message, and a
+	// half-provisioned identity is worse than a rejected form.
+	if cfg.SandboxMode != "" && cfg.SandboxMode != "ephemeral" && cfg.SandboxMode != "persistent" {
+		return cfg, fmt.Errorf("sandbox_mode must be ephemeral or persistent, got %q", cfg.SandboxMode)
 	}
 	return cfg, nil
 }

--- a/cli/internal/backend/backend_test.go
+++ b/cli/internal/backend/backend_test.go
@@ -234,3 +234,28 @@ func TestDeployRejectsABadKey(t *testing.T) {
 		t.Fatalf("expected a key-derivation error, got %+v", resp)
 	}
 }
+
+// ADR 0023: the optional sandbox mode rides as sandbox_mode; blank sends
+// nothing; anything else is refused before Fountain is asked.
+func TestDeployPassesTheSandboxMode(t *testing.T) {
+	f := &fakeFountain{resolveTo: "agent-uuid"}
+	resp := Deploy(deployReq(`{"agent":"my-agent","sandbox_mode":"persistent"}`), f)
+	if !resp.OK {
+		t.Fatalf("deploy failed: %+v", resp)
+	}
+	if f.gotBody.SandboxMode != "persistent" {
+		t.Fatalf("sandbox_mode = %q, want persistent", f.gotBody.SandboxMode)
+	}
+
+	f = &fakeFountain{resolveTo: "agent-uuid"}
+	resp = Deploy(deployReq(`{"agent":"my-agent","sandbox_mode":" "}`), f)
+	if !resp.OK || f.gotBody.SandboxMode != "" {
+		t.Fatalf("blank sandbox_mode: ok=%v body=%q, want ok and nothing sent", resp.OK, f.gotBody.SandboxMode)
+	}
+
+	f = &fakeFountain{resolveTo: "agent-uuid"}
+	resp = Deploy(deployReq(`{"agent":"my-agent","sandbox_mode":"forever"}`), f)
+	if resp.OK || f.gotBody.AgentID != "" {
+		t.Fatalf("bad sandbox_mode: ok=%v provisioned=%q, want a refusal before any call", resp.OK, f.gotBody.AgentID)
+	}
+}

--- a/cli/internal/cmd/acp.go
+++ b/cli/internal/cmd/acp.go
@@ -27,6 +27,8 @@ var (
 	acpAgent       string
 	acpVault       string
 	acpEnvironment string
+	acpSandboxMode string
+	acpSandbox     string
 	acpPermission  string
 )
 
@@ -76,6 +78,8 @@ not on your machine.`,
 	acpCmd.Flags().StringVar(&acpAgent, "agent", "", "Fountain agent name or id to open sessions against")
 	acpCmd.Flags().StringVar(&acpVault, "vault", "", "vault name or id to attach to each session's conversation")
 	acpCmd.Flags().StringVar(&acpEnvironment, "environment", "", "environment name or id to provision each session's conversation from, instead of the agent's own")
+	acpCmd.Flags().StringVar(&acpSandboxMode, "sandbox-mode", "", "ephemeral or persistent: where each session's conversation runs, instead of the agent's default")
+	acpCmd.Flags().StringVar(&acpSandbox, "sandbox", "", "sandbox id to attach each session's conversation to, instead of provisioning a new one")
 	acpCmd.Flags().StringVar(&acpPermission, "permission", "", `what happens before the agent runs a tool: auto_allow, ask, auto_deny, or key=verdict pairs (for example "execute=ask")`)
 	acpCmd.Flags().StringVar(&acpLogLevel, "log-level", "info", "stderr log level: debug, info, warn, error")
 	rootCmd.AddCommand(acpCmd)
@@ -100,6 +104,11 @@ func runACP() error {
 	if err != nil {
 		return err
 	}
+	// Same rule the server applies, so a typo fails at startup rather than at
+	// the first session/new inside the editor.
+	if acpSandboxMode != "" && acpSandboxMode != "ephemeral" && acpSandboxMode != "persistent" {
+		return fmt.Errorf("--sandbox-mode must be ephemeral or persistent, got %q", acpSandboxMode)
+	}
 
 	opts := activeOpts()
 	agent := acp.NewAgent(
@@ -109,6 +118,8 @@ func runACP() error {
 			log:         log,
 			vault:       acpVault,
 			environment: acpEnvironment,
+			sandboxMode: acpSandboxMode,
+			sandboxID:   acpSandbox,
 			permission:  permission,
 		},
 		acpAgent,
@@ -187,6 +198,11 @@ type fountainAPI struct {
 	log         *slog.Logger
 	vault       string
 	environment string
+	// sandboxMode and sandboxID are the process-wide defaults for where each
+	// session's conversation runs (ADR 0023); a session's `_meta` may name
+	// its own. Empty means the agent's default, and the key is omitted.
+	sandboxMode string
+	sandboxID   string
 	// permission is the per-launch policy every conversation this process
 	// opens is started with (#939), already parsed. nil leaves the agent's own
 	// policy alone.
@@ -278,7 +294,8 @@ func agentRef(data map[string]any) acp.AgentRef {
 	}
 }
 
-func (f fountainAPI) CreateConversation(_ context.Context, agentID, channelID string, fresh bool) (string, bool, error) {
+func (f fountainAPI) CreateConversation(_ context.Context, agentID string, opts acp.SessionOptions) (string, bool, error) {
+	channelID, fresh := opts.ChannelID, opts.Fresh
 	var resp struct {
 		Data map[string]any `json:"data"`
 		Meta map[string]any `json:"meta"`
@@ -319,6 +336,16 @@ func (f fountainAPI) CreateConversation(_ context.Context, agentID, channelID st
 			return "", false, err
 		}
 		body["environment_id"] = envID
+	}
+
+	// Where the conversation runs (ADR 0023). The session's own `_meta` wins
+	// over the process flags; either way an empty value is omitted so the
+	// server applies the agent's default rather than refusing "".
+	if mode := firstNonEmpty(opts.SandboxMode, f.sandboxMode); mode != "" {
+		body["sandbox_mode"] = mode
+	}
+	if id := firstNonEmpty(opts.SandboxID, f.sandboxID); id != "" {
+		body["sandbox_id"] = id
 	}
 
 	// The permission policy this entry runs under (#939). A launch may only
@@ -470,6 +497,15 @@ func (f fountainAPI) vaultID() (string, error) {
 		}
 	}
 	return "", fmt.Errorf("no vault named %q", f.vault)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
 }
 
 func (f fountainAPI) environmentID() (string, error) {

--- a/cli/internal/cmd/acp_test.go
+++ b/cli/internal/cmd/acp_test.go
@@ -189,7 +189,7 @@ func TestCreateConversationAttachesTheVault(t *testing.T) {
 	api := acpTestAPI(t, srv.URL)
 	api.vault = "buzz-philo"
 
-	id, _, err := api.CreateConversation(context.Background(), "agent-1", "", false)
+	id, _, err := api.CreateConversation(context.Background(), "agent-1", acp.SessionOptions{})
 	if err != nil {
 		t.Fatalf("CreateConversation: %v", err)
 	}
@@ -215,7 +215,7 @@ func TestCreateConversationOmitsTheVaultWhenUnset(t *testing.T) {
 
 	api := acpTestAPI(t, srv.URL)
 
-	if _, _, err := api.CreateConversation(context.Background(), "agent-1", "", false); err != nil {
+	if _, _, err := api.CreateConversation(context.Background(), "agent-1", acp.SessionOptions{}); err != nil {
 		t.Fatalf("CreateConversation: %v", err)
 	}
 	if _, present := body["vault_id"]; present {
@@ -245,7 +245,7 @@ func TestCreateConversationAttachesTheEnvironment(t *testing.T) {
 	api := acpTestAPI(t, srv.URL)
 	api.environment = "buzz-env"
 
-	if _, _, err := api.CreateConversation(context.Background(), "agent-1", "", false); err != nil {
+	if _, _, err := api.CreateConversation(context.Background(), "agent-1", acp.SessionOptions{}); err != nil {
 		t.Fatalf("CreateConversation: %v", err)
 	}
 	if body["environment_id"] != "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" {
@@ -266,7 +266,7 @@ func TestCreateConversationOmitsTheEnvironmentWhenUnset(t *testing.T) {
 
 	api := acpTestAPI(t, srv.URL)
 
-	if _, _, err := api.CreateConversation(context.Background(), "agent-1", "", false); err != nil {
+	if _, _, err := api.CreateConversation(context.Background(), "agent-1", acp.SessionOptions{}); err != nil {
 		t.Fatalf("CreateConversation: %v", err)
 	}
 	if _, present := body["environment_id"]; present {
@@ -288,7 +288,7 @@ func TestCreateConversationSendsTheChannelKeyAndReadsResumed(t *testing.T) {
 
 	api := acpTestAPI(t, srv.URL)
 
-	id, resumed, err := api.CreateConversation(context.Background(), "agent-1", "chan-1", false)
+	id, resumed, err := api.CreateConversation(context.Background(), "agent-1", acp.SessionOptions{ChannelID: "chan-1"})
 	if err != nil {
 		t.Fatalf("CreateConversation: %v", err)
 	}
@@ -314,7 +314,7 @@ func TestCreateConversationOmitsTheChannelKeyWhenEmpty(t *testing.T) {
 	defer srv.Close()
 
 	api := acpTestAPI(t, srv.URL)
-	_, resumed, err := api.CreateConversation(context.Background(), "agent-1", "", false)
+	_, resumed, err := api.CreateConversation(context.Background(), "agent-1", acp.SessionOptions{})
 	if err != nil {
 		t.Fatalf("CreateConversation: %v", err)
 	}
@@ -340,7 +340,7 @@ func TestCreateConversationSendsFreshWithTheChannelKey(t *testing.T) {
 
 	api := acpTestAPI(t, srv.URL)
 
-	id, resumed, err := api.CreateConversation(context.Background(), "agent-1", "chan-1", true)
+	id, resumed, err := api.CreateConversation(context.Background(), "agent-1", acp.SessionOptions{ChannelID: "chan-1", Fresh: true})
 	if err != nil {
 		t.Fatalf("CreateConversation: %v", err)
 	}
@@ -353,7 +353,7 @@ func TestCreateConversationSendsFreshWithTheChannelKey(t *testing.T) {
 
 	// fresh without a channel key is meaningless and must not be sent.
 	body = nil
-	if _, _, err := api.CreateConversation(context.Background(), "agent-1", "", true); err != nil {
+	if _, _, err := api.CreateConversation(context.Background(), "agent-1", acp.SessionOptions{Fresh: true}); err != nil {
 		t.Fatalf("CreateConversation: %v", err)
 	}
 	if _, ok := body["fresh"]; ok {
@@ -370,7 +370,7 @@ func TestUnknownEnvironmentNameIsReported(t *testing.T) {
 	api := acpTestAPI(t, srv.URL)
 	api.environment = "not-an-env"
 
-	_, _, err := api.CreateConversation(context.Background(), "agent-1", "", false)
+	_, _, err := api.CreateConversation(context.Background(), "agent-1", acp.SessionOptions{})
 	if err == nil || !strings.Contains(err.Error(), "not-an-env") {
 		t.Fatalf("want an error naming the environment, got %v", err)
 	}
@@ -385,7 +385,7 @@ func TestUnknownVaultNameIsReported(t *testing.T) {
 	api := acpTestAPI(t, srv.URL)
 	api.vault = "not-a-vault"
 
-	_, _, err := api.CreateConversation(context.Background(), "agent-1", "", false)
+	_, _, err := api.CreateConversation(context.Background(), "agent-1", acp.SessionOptions{})
 	if err == nil || !strings.Contains(err.Error(), "not-a-vault") {
 		t.Fatalf("want an error naming the vault, got %v", err)
 	}
@@ -407,7 +407,7 @@ func TestCreateConversationCarriesThePermissionPolicy(t *testing.T) {
 	api := acpTestAPI(t, srv.URL)
 	api.permission = map[string]string{"default": "ask"}
 
-	if _, _, err := api.CreateConversation(context.Background(), "agent-1", "", false); err != nil {
+	if _, _, err := api.CreateConversation(context.Background(), "agent-1", acp.SessionOptions{}); err != nil {
 		t.Fatalf("CreateConversation: %v", err)
 	}
 
@@ -431,7 +431,7 @@ func TestCreateConversationOmitsThePermissionPolicyWhenUnset(t *testing.T) {
 
 	api := acpTestAPI(t, srv.URL)
 
-	if _, _, err := api.CreateConversation(context.Background(), "agent-1", "", false); err != nil {
+	if _, _, err := api.CreateConversation(context.Background(), "agent-1", acp.SessionOptions{}); err != nil {
 		t.Fatalf("CreateConversation: %v", err)
 	}
 	if _, present := body["permission_policy"]; present {
@@ -479,5 +479,80 @@ func TestParsePermissionPolicyRejectsAnUnknownVerdict(t *testing.T) {
 	}
 	if _, err := parsePermissionPolicy("=ask"); err == nil {
 		t.Error("accepted an empty tool key")
+	}
+}
+
+// ADR 0023: --sandbox-mode / --sandbox are the process defaults for where each
+// session's conversation runs, sent as sandbox_mode / sandbox_id.
+func TestCreateConversationCarriesTheSandboxFlags(t *testing.T) {
+	var body map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"data":{"id":"conv-1"}}`))
+	}))
+	defer srv.Close()
+
+	api := acpTestAPI(t, srv.URL)
+	api.sandboxMode = "persistent"
+	api.sandboxID = "11111111-2222-3333-4444-555555555555"
+
+	if _, _, err := api.CreateConversation(context.Background(), "agent-1", acp.SessionOptions{}); err != nil {
+		t.Fatalf("CreateConversation: %v", err)
+	}
+	if body["sandbox_mode"] != "persistent" {
+		t.Errorf("sandbox_mode = %v, want persistent", body["sandbox_mode"])
+	}
+	if body["sandbox_id"] != "11111111-2222-3333-4444-555555555555" {
+		t.Errorf("sandbox_id = %v, want the flag's id", body["sandbox_id"])
+	}
+}
+
+// A session's own _meta wins over the process flags, for that session.
+func TestCreateConversationLetsTheSessionOverrideTheSandboxFlags(t *testing.T) {
+	var body map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"data":{"id":"conv-1"}}`))
+	}))
+	defer srv.Close()
+
+	api := acpTestAPI(t, srv.URL)
+	api.sandboxMode = "persistent"
+
+	opts := acp.SessionOptions{SandboxMode: "ephemeral", SandboxID: "aaaaaaaa-0000-0000-0000-000000000000"}
+	if _, _, err := api.CreateConversation(context.Background(), "agent-1", opts); err != nil {
+		t.Fatalf("CreateConversation: %v", err)
+	}
+	if body["sandbox_mode"] != "ephemeral" {
+		t.Errorf("sandbox_mode = %v, want the session's ephemeral", body["sandbox_mode"])
+	}
+	if body["sandbox_id"] != "aaaaaaaa-0000-0000-0000-000000000000" {
+		t.Errorf("sandbox_id = %v, want the session's id", body["sandbox_id"])
+	}
+}
+
+// No flag, no _meta: no key, so the server applies the agent's default.
+func TestCreateConversationOmitsTheSandboxKeysWhenUnset(t *testing.T) {
+	var body map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"data":{"id":"conv-1"}}`))
+	}))
+	defer srv.Close()
+
+	api := acpTestAPI(t, srv.URL)
+	if _, _, err := api.CreateConversation(context.Background(), "agent-1", acp.SessionOptions{}); err != nil {
+		t.Fatalf("CreateConversation: %v", err)
+	}
+	for _, key := range []string{"sandbox_mode", "sandbox_id"} {
+		if _, present := body[key]; present {
+			t.Errorf("%s sent as %v, want the key omitted", key, body[key])
+		}
 	}
 }

--- a/decisions/0023-persistent-agent-sandbox.md
+++ b/decisions/0023-persistent-agent-sandbox.md
@@ -82,13 +82,14 @@ Shipped as seven gates, one PR each, in dependency order:
   fix (the PR after #1069). An operator who sets `SANDBOX_MAX_LIFETIME_HOURS`
   gets the table's interim behaviour: a home at the ceiling is parked, not
   destroyed (`Lifecycle`); an ephemeral sprite is destroyed.
-- Of the step 8 doors, `POST /api/conversations`, `fountain run`, the SDK
-  and the agent form take the override. The ACP editor door
-  (`session/new` `_meta`), Buzz provision and the `fountain` skill's fan-out
-  take the agent's default and have no per-launch override yet. The
-  conversations app shows no "home" badge and there is no "reset home"
-  action; `GET /api/sandboxes/:id` is the sandbox's detail, and deleting the
-  agent is the reset.
+- Every step 8 door takes the override since #1070: `POST /api/conversations`,
+  `fountain run`, the SDK, the agent form, `fountain acp` (`--sandbox-mode` /
+  `--sandbox`, and `sandboxMode` / `sandboxId` in `session/new` `_meta`),
+  the Buzz identity's `sandbox_mode`, and the `fountain` skill through
+  `FOUNTAIN_SANDBOX_ID`. Channel resume takes the agent's default, as the
+  step says. The conversations app shows no "home" badge and there is no
+  "reset home" action; `GET /api/sandboxes/:id` is the sandbox's detail, and
+  deleting the agent is the reset.
 
 **Gate 7, run 2026-08-24 against production** (server `sha-94b6022f`,
 Sprites, a throwaway `claude` agent on haiku with no environment or vault):

--- a/docs/catalog/skills/fountain.md
+++ b/docs/catalog/skills/fountain.md
@@ -10,7 +10,7 @@
 | Bundled | Yes, in each sandbox. |
 | Declared by | Nobody. Fountain always adds it. |
 | Source | `apps/fountain/priv/sprite_skills/fountain/SKILL.md` |
-| Reads | `FOUNTAIN_BASE_URL`, `FOUNTAIN_TOKEN`, `FOUNTAIN_CONVERSATION_ID` |
+| Reads | `FOUNTAIN_BASE_URL`, `FOUNTAIN_TOKEN`, `FOUNTAIN_CONVERSATION_ID`, `FOUNTAIN_SANDBOX_ID` |
 
 ## What it gives the agent
 
@@ -39,6 +39,18 @@ stale copy. The agent must read the variable from its environment again.
 `X-Fountain-Parent-Conversation-Id: $FOUNTAIN_CONVERSATION_ID` on a
 `POST /api/conversations`, and Fountain records the parent. An operator can
 then rebuild the whole spawn chain.
+
+## A child on the same machine
+
+`FOUNTAIN_SANDBOX_ID` is the id of the sandbox the agent runs on. Send it as
+`sandbox_id` on a `POST /api/conversations`. The child conversation then runs
+on that same machine, with the same disk, at the same time. That only works
+for a child of the same agent, environment and vault.
+
+Without it, each child gets a sandbox of its own. When the agent runs in
+persistent mode, the child gets that machine instead. To name the other mode
+for one child, send `sandbox_mode` on the same call. See
+[Sandboxes](../../concepts/sandboxes.md).
 
 ## Limits
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -195,7 +195,7 @@ fountain conv stream <conversation-id>
 ## Editor integration (ACP)
 
 ```bash
-fountain acp --agent <name-or-id> [--vault <name-or-id>] [--environment <name-or-id>] [--log-level debug]
+fountain acp --agent <name-or-id> [--vault <name-or-id>] [--environment <name-or-id>] [--sandbox-mode persistent] [--sandbox <id>] [--log-level debug]
 ```
 
 This speaks the [Agent Client Protocol](https://agentclientprotocol.com) on

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -63,11 +63,13 @@ fountain acp [flags]
 Options:
 
 ```
-      --agent string         Fountain agent name or id to open sessions against
-      --environment string   environment name or id to provision each session's conversation from, instead of the agent's own
-      --log-level string     stderr log level: debug, info, warn, error (default "info")
-      --permission string    what happens before the agent runs a tool: auto_allow, ask, auto_deny, or key=verdict pairs (for example "execute=ask")
-      --vault string         vault name or id to attach to each session's conversation
+      --agent string          Fountain agent name or id to open sessions against
+      --environment string    environment name or id to provision each session's conversation from, instead of the agent's own
+      --log-level string      stderr log level: debug, info, warn, error (default "info")
+      --permission string     what happens before the agent runs a tool: auto_allow, ask, auto_deny, or key=verdict pairs (for example "execute=ask")
+      --sandbox string        sandbox id to attach each session's conversation to, instead of provisioning a new one
+      --sandbox-mode string   ephemeral or persistent: where each session's conversation runs, instead of the agent's default
+      --vault string          vault name or id to attach to each session's conversation
 ```
 
 ## `fountain agent list`

--- a/docs/integrations/acp.md
+++ b/docs/integrations/acp.md
@@ -19,7 +19,7 @@ and the CLI's credentials. Each path it reports is inside the sandbox.
 ## Invocation
 
 ```bash
-fountain acp --agent <name-or-id> [--vault <name-or-id>] [--environment <name-or-id>] [--permission ask] [--log-level debug]
+fountain acp --agent <name-or-id> [--vault <name-or-id>] [--environment <name-or-id>] [--sandbox-mode persistent] [--sandbox <id>] [--permission ask] [--log-level debug]
 ```
 
 | Flag | Meaning |
@@ -27,6 +27,8 @@ fountain acp --agent <name-or-id> [--vault <name-or-id>] [--environment <name-or
 | `--agent` | **Required, in practice.** The Fountain agent that each session runs. ACP has no field for it, so you configure it for each process. Use one client entry for each agent you want to reach. |
 | `--vault` | A vault that attaches to each conversation this process opens. Vault values override the agent's environment, so a secret for one entry belongs here. An identity the agent posts under is the example. Two entries on the same agent with different vaults stay apart. |
 | `--environment` | Provisions each conversation from this environment, and not from the agent's own. One agent config then runs under several environments, with one entry for each. The vault still wins on a key collision. When the agent sets `allowed_environment_ids`, the environment must be on that list. |
+| `--sandbox-mode` | Where each conversation this process opens runs. `ephemeral` gives each conversation a sandbox of its own. `persistent` puts each one on the agent's own machine. Without the flag, the agent's default applies. See [Sandboxes](../concepts/sandboxes.md). |
+| `--sandbox` | A sandbox id to attach each conversation to, instead of a new one. It must be yours, and it must have the same agent, environment and vault. |
 | `--permission` | What happens before the agent runs a tool. `ask` sends the question to your client, as an approval prompt. `auto_deny` refuses. The default, `auto_allow`, runs the tool. To narrow it for one kind of tool, give `key=verdict` pairs, such as `execute=ask`. See [Permission prompts](#permission-prompts). |
 | `--log-level` | The verbosity on stderr. One of `debug`, `info`, which is the default, `warn` and `error`. |
 | `--profile` | Which saved CLI credentials to use. It is a global flag. |
@@ -112,10 +114,12 @@ other field in `_meta`.
 | Field | Meaning |
 |---|---|
 | `channelId` | Names the external channel that this session serves. With it, `session/new` **resumes** the conversation already bound to that channel, for this user, agent and vault. That is the same conversation, the same sandbox and the same runtime session, with a fresh ACP id on the client's side. A harness that forgets its sessions on restart therefore lands back where it was ([#774](https://github.com/BinaryBourbon/fountain/issues/774)). A destroyed sandbox also stops the resume. The workspace does not survive it, so Fountain opens a new conversation on a new sandbox ([#779](https://github.com/BinaryBourbon/fountain/issues/779)). Without it, each `session/new` is a new conversation. |
+| `sandboxMode` | Where this one session's conversation runs, `ephemeral` or `persistent`. It replaces `--sandbox-mode` for the session. See [Sandboxes](../concepts/sandboxes.md). |
+| `sandboxId` | A sandbox id to attach this one session's conversation to. It replaces `--sandbox` for the session. |
 | `freshSession` | With `channelId`, it skips the resume this one time. It unbinds the current conversation, which continues and then retires like any other idle one. It opens a new conversation, and binds the channel to that. A Buzz owner's `!rotate` turns into this ([#788](https://github.com/BinaryBourbon/fountain/pull/788)). Fountain ignores it without `channelId`. |
 
-The same knobs exist on the API, as `channel_id` and `fresh` on
-`POST /api/conversations`.
+The same knobs exist on the API, as `channel_id`, `fresh`, `sandbox_mode` and
+`sandbox_id` on `POST /api/conversations`.
 
 ## Permission prompts
 

--- a/docs/integrations/buzz.md
+++ b/docs/integrations/buzz.md
@@ -107,6 +107,11 @@ stands the hosted agent up on your Fountain instance, then returns.
   secret. The environment stands in for the agent's own at provision, so one
   Fountain agent can back several Buzz identities, each on a different
   baseline. Leave it blank to use the agent's own.
+- They optionally ask **where the conversations run**, with
+  `"sandbox_mode": "persistent"` or `"ephemeral"`. A persistent identity keeps
+  one machine across its channels, so what one channel leaves on disk is there
+  for the next. Leave it blank to use the agent's default. See
+  [Sandboxes](../concepts/sandboxes.md).
 - The Fountain credentials are **ambient**. They are `FOUNTAIN_API_KEY` and
   `FOUNTAIN_BASE_URL`, from the environment or from the `fountain` CLI creds
   file. The provider refuses to carry a secret in its config, so your Fountain

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -10,6 +10,14 @@ server releases.
 
 ---
 
+## [0.1.9] — 2026-08-24
+
+### Changed
+
+- Generated types follow the server's Buzz identity schema: `sandbox_mode`
+  on `POST /api/buzz/agents` and in the identity JSON (server #1070). No
+  client method changed.
+
 ## [0.1.8] — 2026-08-24
 
 ### Added

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentshit/fountain-sdk",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Run a coding agent on a real computer, with your repos and your credentials, in one call.",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -2038,6 +2038,11 @@ export interface components {
             respond_to?: "owner-only" | "allowlist" | "anyone" | "nobody" | null;
             /** @description 64-hex pubkeys admitted in allowlist mode (BUZZ_ACP_RESPOND_TO_ALLOWLIST). Required non-empty when respond_to is allowlist; ignored otherwise. */
             respond_to_allowlist?: string[] | null;
+            /**
+             * @description Where this identity's conversations run (ADR 0023), passed to the harness as fountain acp --sandbox-mode. Omitted means the agent's own default; omitted on a re-provision clears a previously set one. A re-provision that changes it restarts a running harness.
+             * @enum {string|null}
+             */
+            sandbox_mode?: "ephemeral" | "persistent" | null;
         };
         /** ConversationCreateRequest */
         ConversationCreateRequest: {
@@ -2155,6 +2160,11 @@ export interface components {
             respond_to?: "owner-only" | "allowlist" | "anyone" | "nobody";
             /** @description 64-hex pubkeys admitted in allowlist mode. */
             respond_to_allowlist?: string[];
+            /**
+             * @description Where this identity's conversations run (ADR 0023): a sandbox per conversation, or the agent's one persistent machine. null means the agent's own default.
+             * @enum {string|null}
+             */
+            sandbox_mode?: "ephemeral" | "persistent" | null;
             /** Format: date-time */
             updated_at?: string;
             /** Format: uuid */

--- a/sdk/typescript/src/http.ts
+++ b/sdk/typescript/src/http.ts
@@ -19,7 +19,7 @@ export interface RequestOptions {
  * this string is already what Fountain's request logs are keyed on. The
  * version half is asserted against `package.json` by a test.
  */
-export const USER_AGENT = "fountain-sdk-js/0.1.8";
+export const USER_AGENT = "fountain-sdk-js/0.1.9";
 
 /**
  * The thin layer everything else is built on: one bearer token, JSON in and


### PR DESCRIPTION
## Summary
ADR 0023 step 8 says every launch door accepts a per-launch `sandbox_mode` / `sandbox_id`. After #1068 three still took only the agent's default. Now:

- **ACP editor door** — `fountain acp --sandbox-mode <ephemeral|persistent>` and `--sandbox <id>` apply to every session the process opens (validated at startup, like `--permission`); a client may name either per session in `session/new` `_meta` (`sandboxMode`, `sandboxId`), which wins over the flags for that session. Unset means the key is omitted and the server applies the agent's default. `CreateConversation` now takes an `acp.SessionOptions` instead of a growing positional list.
- **Buzz provision** — `buzz_identities.sandbox_mode` (nullable; migration), accepted on `POST /api/buzz/agents` (OpenAPI enum, so a bad value is a 422 from the cast; the context also refuses `:invalid_sandbox_mode` before the vault is created), returned on the identity, and in `@launch_fields` so a re-provision that changes it restarts the harness. The harness passes it to the ACP child as `--sandbox-mode`. The `buzz-backend-fountain` provider exposes it in its settings form (`sandbox_mode`) and refuses a bad value before calling Fountain.
- **`fountain` skill fan-out** — the sandbox now exports `FOUNTAIN_SANDBOX_ID` (machine-scoped, so it sits on the disk beside the environment values and in each process env). Both copies of the skill document "Children on this machine": pass it as `sandbox_id` to run a child on the parent's own disk, or `sandbox_mode` to fan out onto fresh disks from a persistent parent.
- **Left on the agent default, on purpose:** channel resume (Team / Buzz channel-bound conversations resuming an existing binding) — ADR 0023 step 8 says a channel identity stays stable. The team-schedule and team-fresh-start paths go through `start_conversation` without a mode and so take the agent default too.
- ADR 0023's Outcome section no longer lists the three doors as a deviation; CHANGELOG entry; docs for `fountain acp` (flags + `_meta`), the Buzz provider settings, the skill page.

## Test plan
- [x] `go test ./... && go vet ./...` in `cli/` (new: flag → body, `_meta` override, keys omitted when unset, session forwards overrides, provider passes/refuses `sandbox_mode`; `docs/cli/commands.md` regenerated)
- [x] `mix test` on buzz_test, buzz_agent_controller_test, conversation_server_identity_test, audit_guardrail_test, schema_enum_guardrail_test, docs_test — 128 tests, 0 failures (new: stores/clears/refuses `sandbox_mode`, harness argv carries `--sandbox-mode`, `launch_config_changed?`, POST returns it / 422 on a bad one, `FOUNTAIN_SANDBOX_ID` on disk and in the spawn env)
- [x] `mix compile --warnings-as-errors`, `mix credo --strict`, `mix format`
- [x] `python3 scripts/docs-style.py`, `vale lint docs` (0 errors, 0 warnings), `okf validate decisions`
- [ ] CI

Closes #1070

🤖 Generated with [Claude Code](https://claude.com/claude-code)