### PR TITLE
feat(acp): the peer outlives its prompt — idle between turns, closed by its owner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,15 @@ upgrade, is in
 
 ### Changed
 
+- **The ACP peer outlives its prompt.** `Fountain.Runtimes.ACP.Peer` no
+  longer ends when the prompt is answered: it reports the stop reason and
+  waits in `:idle` for the next `prompt/3` on the same connection (no second
+  handshake, no `session/resume`, no model pin), reports an autonomous
+  cycle's end as `{:cycle_end, kind}` from the adapter's origin-marked
+  `usage_update`, and closes on `close/1`. Part 1 of 3 for #817. Nothing
+  changes in production yet: `ConversationServer` still stops the peer at
+  turn end, until part 3 moves the connection to the wake.
+
 - **A running sandbox is no longer destroyed at 24 hours.** The continuous-run
   ceiling (`SANDBOX_MAX_LIFETIME_HOURS`, ADR 0017) now defaults to `0`, off,
   for every sandbox mode: a tenant who wants a machine running all day is not

--- a/apps/fountain/lib/fountain/runtimes/acp/peer.ex
+++ b/apps/fountain/lib/fountain/runtimes/acp/peer.ex
@@ -1,11 +1,13 @@
 defmodule Fountain.Runtimes.ACP.Peer do
   @moduledoc """
-  One ACP connection, for exactly one turn.
+  One ACP connection, for as many turns as its owner sends it.
 
-  Gate 2 of [0014](decisions/0014-agent-client-protocol.md). The peer drives
-  `initialize` → (`session/new` | `session/resume` | `session/load`) →
-  `session/prompt` over the sprite's stdio, translates nothing itself, and
-  ends when the prompt is answered.
+  Gate 2 of [0014](decisions/0014-agent-client-protocol.md), widened by #817.
+  The peer drives `initialize` → (`session/new` | `session/resume` |
+  `session/load`) → `session/prompt` over the sprite's stdio, translates
+  nothing itself, and — once the prompt is answered — waits in `:idle` for
+  the next `prompt/3` rather than ending. The connection ends when the owner
+  calls `close/1`, when the owner dies, or when a write fails.
 
   ## Why this is not in `ConversationServer`
 
@@ -16,13 +18,32 @@ defmodule Fountain.Runtimes.ACP.Peer do
   conversation with states and a correlation table. They fail differently and
   should not share a mailbox.
 
-  ## Lifetime is the turn, and that is the economics
+  ## Lifetime is the wake, not the turn
 
-  0014's *Session lifetime* section is the load-bearing constraint: the ACP
-  connection is scoped to the turn, never to the session, so nothing is
-  attached between turns and `Lifecycle`/`SandboxReaper` keep reclaiming idle
-  sprites on exactly today's terms. The durable identity is
-  `conversation.runtime_session_id`, which we hand to `session/resume`.
+  0014 as first written scoped the connection to the turn: one `session/prompt`,
+  take the `stopReason`, close. #817 measured what that costs. The adapter
+  treats the connection as the session, so closing it at `end_turn` kills
+  everything Claude Code left running in the background — a `Monitor`, a
+  `run_in_background` shell, a `ScheduleWakeup` — and throws away codex's
+  "Allow for Session" grant; and ACP allows `session/update` *out of turn*,
+  which a client that stops reading at the prompt response never sees.
+
+  So the peer now outlives its prompt. After the prompt's response it reports
+  `{:done, stop, usage}` exactly as before and moves to `:idle`, where the
+  owner may send the next turn with `prompt/3` on the same connection — no
+  second `initialize`, no `session/resume`, no model pin. Updates that arrive
+  while idle are still reported as `{:lines, "acp", …}`; an autonomous cycle
+  (a background task's follow-up) is marked at its end by `{:cycle_end, kind}`
+  when the adapter's `usage_update` carries an origin from its autonomous set.
+  The owner decides what a turn is; the peer only parses the protocol.
+
+  What stays scoped to the turn is the *server's* accounting — the turn row,
+  the log budget, `busy?` — and what bounds the connection is the owner: it
+  closes the peer with `close/1` when the sandbox stops being its own (idle
+  park, terminate, release, server shutdown), never at turn end. The durable
+  identity is still `conversation.runtime_session_id`, handed to
+  `session/resume` on the next wake. The economics 0014 protects are
+  unchanged: a parked sprite has no peer.
 
   The peer is deliberately unlinked from its owner in both directions and
   monitored instead. A protocol bug here must fail a *turn*; linking would make
@@ -95,6 +116,12 @@ defmodule Fountain.Runtimes.ACP.Peer do
   @replay_quiet_ms 250
   @replay_max_ms 10_000
 
+  # The adapter's own set (claude-agent-acp `AUTONOMOUS_RESULT_ORIGINS`,
+  # re-verified at 0.70.0 in #817): a result whose origin is one of these
+  # "must never touch the user-turn lifecycle" — it is a background task's
+  # follow-up, not the answer to a prompt.
+  @autonomous_origins ~w(task-notification peer coordinator observer observer-activity)
+
   @typedoc "What the peer reports upward. `ref` is the sprite command's ref."
   @type payload ::
           {:lines, stream :: String.t(), data :: String.t()}
@@ -103,6 +130,7 @@ defmodule Fountain.Runtimes.ACP.Peer do
           | {:model_rejected, requested :: String.t(), detail :: String.t()}
           | {:handshake_ms, non_neg_integer(), method :: String.t()}
           | {:done, stop_reason :: String.t(), usage :: map() | nil}
+          | {:cycle_end, kind :: String.t()}
           | {:failed, term()}
 
   defmodule State do
@@ -154,7 +182,7 @@ defmodule Fountain.Runtimes.ACP.Peer do
   # ── public api ────────────────────────────────────────────────────────────
 
   @doc """
-  Start a peer for one turn.
+  Start a peer and send its first turn.
 
   Required opts: `:owner`, `:command`, `:ref`, `:prompt`, `:mode`,
   `:session_id`, `:cwd`.
@@ -168,6 +196,32 @@ defmodule Fountain.Runtimes.ACP.Peer do
 
   @doc "Feed a stdout chunk from the sprite. Chunks respect no message boundary."
   def stdout(pid, data), do: GenServer.cast(pid, {:stdout, data})
+
+  @doc """
+  Send the next turn on a connection that is `:idle` — the previous prompt was
+  answered and the peer stayed up (#817).
+
+  Reuses the session already open on this connection: no handshake, no
+  `session/resume`, no model pin. Reports `{:prompt_sent, id}` exactly as the
+  first prompt did, so the reattach contract is unchanged. Refused with
+  `{:error, {:not_idle, phase}}` while a prompt is outstanding or the
+  connection is still being set up — never a silent second prompt on the wire.
+  """
+  @spec prompt(pid(), String.t(), [map()]) :: :ok | {:error, {:not_idle, atom()}}
+  def prompt(pid, prompt, images \\ []) when is_binary(prompt) do
+    GenServer.call(pid, {:prompt, prompt, images})
+  end
+
+  @doc """
+  Close the connection cleanly.
+
+  The owner calls this when the sandbox stops being its own — idle park,
+  terminate, release, its own shutdown. The peer stops with `:normal`; the
+  sprite command is the owner's to stop. Safe to call on a peer that has
+  already gone.
+  """
+  @spec close(pid()) :: :ok
+  def close(pid), do: GenServer.cast(pid, :close)
 
   @doc """
   Ask the agent to stop the current turn.
@@ -289,6 +343,8 @@ defmodule Fountain.Runtimes.ACP.Peer do
 
   def handle_cast(:cancel, state), do: {:noreply, state}
 
+  def handle_cast(:close, state), do: {:stop, :normal, state}
+
   def handle_cast({:deny_permission, request_id}, state) do
     case state.pending_permission do
       %{request_id: ^request_id, id: id, options: options} ->
@@ -305,6 +361,18 @@ defmodule Fountain.Runtimes.ACP.Peer do
   end
 
   @impl true
+  def handle_call({:prompt, prompt, images}, _from, %State{phase: :idle} = state) do
+    state = send_prompt(%{state | prompt: prompt, images: images})
+
+    if state.phase == :failed,
+      do: {:reply, {:error, {:not_idle, :failed}}, state},
+      else: {:reply, :ok, state}
+  end
+
+  def handle_call({:prompt, _prompt, _images}, _from, state) do
+    {:reply, {:error, {:not_idle, state.phase}}, state}
+  end
+
   # Answering is a `call` so the caller learns whether the answer landed: the
   # request may already have been resolved by another attached client, by the
   # timeout, or by the turn ending, and "too late" and "wrong option" are
@@ -366,7 +434,9 @@ defmodule Fountain.Runtimes.ACP.Peer do
       # moduledoc. The timestamp is what the quiet period below measures.
       %{state | replay_last_ms: now_ms()}
     else
-      persist(state, "acp", Protocol.notification("session/update", params))
+      state
+      |> persist("acp", Protocol.notification("session/update", params))
+      |> report_cycle_end(params)
     end
   end
 
@@ -503,6 +573,32 @@ defmodule Fountain.Runtimes.ACP.Peer do
   # stdout. Those are output, not protocol, and the transcript is more useful
   # with them in it.
   defp handle_message({:invalid, line}, state), do: persist(state, "stdout", [line, "\n"])
+
+  # A `usage_update` whose origin is in the adapter's autonomous set marks the
+  # end of a background cycle (#817). Reported as its own payload so the owner
+  # can close the autonomous turn it opened without re-parsing persisted
+  # lines. A plain `usage_update` — the user turn's own — reports nothing.
+  defp report_cycle_end(state, params) do
+    case autonomous_origin(params) do
+      nil -> state
+      kind -> tap(state, &report(&1, {:cycle_end, kind}))
+    end
+  end
+
+  defp autonomous_origin(params) do
+    update = Map.get(params, "update") || %{}
+
+    with "usage_update" <- Map.get(update, "sessionUpdate"),
+         kind when is_binary(kind) <- origin_kind(update) || origin_kind(params),
+         true <- kind in @autonomous_origins do
+      kind
+    else
+      _ -> nil
+    end
+  end
+
+  defp origin_kind(%{"_meta" => %{"_claude/origin" => %{"kind" => kind}}}), do: kind
+  defp origin_kind(_), do: nil
 
   # Whether this is the request the peer is already holding open. An agent
   # cannot have two requests outstanding under one JSON-RPC id, so a matching
@@ -651,10 +747,13 @@ defmodule Fountain.Runtimes.ACP.Peer do
   # The turn's usage rides along with the stop reason (#827): it is the one
   # end-of-turn figure the runtime reports, and the response is the only place
   # it appears. nil when the runtime reports none.
+  #
+  # The turn is over; the connection is not (#817). `:idle` is where the next
+  # `prompt/3` is accepted, and where out-of-turn updates keep flowing up.
   defp handle_response(:prompt, result, state) do
     stop = Map.get(result, "stopReason") || "end_turn"
     report(state, {:done, stop, Usage.from_prompt_result(result)})
-    %{state | phase: :done}
+    %{state | phase: :idle}
   end
 
   # ── authentication ────────────────────────────────────────────────────────

--- a/apps/fountain/test/fountain/runtimes/acp/peer_test.exs
+++ b/apps/fountain/test/fountain/runtimes/acp/peer_test.exs
@@ -509,6 +509,122 @@ defmodule Fountain.Runtimes.ACP.PeerTest do
     end
   end
 
+  describe "the connection outlives the prompt (#817)" do
+    # Drive one full turn to its stop reason and hand back the pid.
+    defp answered_turn(ctx) do
+      pid = start_peer(ctx, [])
+      %{"id" => init_id} = next_write()
+      send_response(pid, init_id, %{"agentCapabilities" => caps()})
+      assert_receive {:acp, _ref, {:handshake_ms, _, "session/new"}}
+      %{"id" => new_id} = next_write()
+      send_response(pid, new_id, %{"sessionId" => "s"})
+      %{"id" => prompt_id} = next_write()
+      send_response(pid, prompt_id, %{"stopReason" => "end_turn"})
+      assert_receive {:acp, _ref, {:done, "end_turn", nil}}
+      pid
+    end
+
+    defp usage_update_line(meta) do
+      update = Map.merge(%{"sessionUpdate" => "usage_update", "used" => 10}, meta)
+      update_line(update)
+    end
+
+    test "the peer stays up after the stop reason", ctx do
+      pid = answered_turn(ctx)
+      assert Process.alive?(pid)
+    end
+
+    test "a second prompt reuses the connection — no second handshake", ctx do
+      pid = answered_turn(ctx)
+
+      assert :ok = Peer.prompt(pid, "again")
+
+      # The very next thing on the wire is the prompt itself: no initialize,
+      # no session/resume, no model pin.
+      assert %{"method" => "session/prompt", "id" => id, "params" => params} = next_write()
+      assert params["sessionId"] == "s"
+      assert [%{"type" => "text", "text" => "again"}] = params["prompt"]
+      assert_receive {:acp, _ref, {:prompt_sent, ^id}}
+      refute_received {:acp, _ref, {:handshake_ms, _, _}}
+
+      send_response(pid, id, %{"stopReason" => "end_turn"})
+      assert_receive {:acp, _ref, {:done, "end_turn", nil}}
+      assert Process.alive?(pid)
+    end
+
+    test "a second prompt carries its own images", ctx do
+      pid = answered_turn(ctx)
+
+      assert :ok = Peer.prompt(pid, "look", [%{media_type: "image/png", data: "abc"}])
+
+      assert %{"params" => %{"prompt" => [_text, image]}} = next_write()
+      assert image["type"] == "image" and image["data"] == Base.encode64("abc")
+    end
+
+    test "a prompt while one is outstanding is refused, not sent", ctx do
+      pid = start_peer(ctx, [])
+      %{"id" => init_id} = next_write()
+      send_response(pid, init_id, %{"agentCapabilities" => caps()})
+      %{"id" => new_id} = next_write()
+      send_response(pid, new_id, %{"sessionId" => "s"})
+      %{"method" => "session/prompt"} = next_write()
+
+      assert {:error, {:not_idle, :prompting}} = Peer.prompt(pid, "too soon")
+      refute_received {:wrote, _}
+    end
+
+    test "a prompt during the handshake is refused too", ctx do
+      pid = start_peer(ctx, [])
+      %{"method" => "initialize"} = next_write()
+
+      assert {:error, {:not_idle, :initializing}} = Peer.prompt(pid, "too soon")
+    end
+
+    test "an out-of-turn update is still reported", ctx do
+      pid = answered_turn(ctx)
+
+      Peer.stdout(pid, update_line(%{"sessionUpdate" => "agent_message_chunk"}))
+
+      assert_receive {:acp, _ref, {:lines, "acp", line}}
+      assert line =~ "agent_message_chunk"
+    end
+
+    test "cycle_end fires on a usage_update from the autonomous set", ctx do
+      pid = answered_turn(ctx)
+
+      Peer.stdout(
+        pid,
+        usage_update_line(%{"_meta" => %{"_claude/origin" => %{"kind" => "task-notification"}}})
+      )
+
+      assert_receive {:acp, _ref, {:cycle_end, "task-notification"}}
+    end
+
+    test "cycle_end does not fire on a plain usage_update, nor on a user origin", ctx do
+      pid = answered_turn(ctx)
+
+      Peer.stdout(pid, usage_update_line(%{}))
+
+      Peer.stdout(
+        pid,
+        usage_update_line(%{"_meta" => %{"_claude/origin" => %{"kind" => "user"}}})
+      )
+
+      assert_receive {:acp, _ref, {:lines, "acp", _}}
+      assert_receive {:acp, _ref, {:lines, "acp", _}}
+      refute_received {:acp, _ref, {:cycle_end, _}}
+    end
+
+    test "close stops the peer cleanly", ctx do
+      pid = answered_turn(ctx)
+      mon = Process.monitor(pid)
+
+      Peer.close(pid)
+
+      assert_receive {:DOWN, ^mon, :process, ^pid, :normal}
+    end
+  end
+
   describe "agent → client requests" do
     test "a permission request is auto-allowed, matching the legacy bypass flags", ctx do
       # Gate 2 keeps parity with `--dangerously-skip-permissions`: answering is


### PR DESCRIPTION
## Summary
Part 1 of 3 for #817 (the approved plan's "PR 1 — `Peer`: a connection that outlives its prompt"). `apps/fountain/lib/fountain/runtimes/acp/peer.ex` only; **no caller changes, so nothing changes in production yet** — `ConversationServer` still stops the peer at turn end until part 3 moves the connection to the wake.

- `handle_response(:prompt, …)` moves to `phase: :idle` instead of `:done`, still reporting `{:done, stop, usage}`. The peer stays up.
- New `prompt(pid, prompt, images \\ [])` — valid only in `:idle`; reuses `send_prompt/1`, so `{:prompt_sent, id}` (the reattach contract) is unchanged. Anywhere else it answers `{:error, {:not_idle, phase}}` — never a silent second prompt on the wire.
- New `close(pid)` for a clean teardown from the server (`:normal` stop).
- The `session/update` handler reports `{:cycle_end, kind}` when the update is a `usage_update` whose `_meta["_claude/origin"].kind` is in the adapter's autonomous set (`task-notification`, `peer`, `coordinator`, `observer`, `observer-activity` — `AUTONOMOUS_RESULT_ORIGINS`, re-verified at 0.70.0 in the plan). Accepts the `_meta` on the update or on the params. The peer parses protocol; the server must not re-parse persisted lines.
- Moduledoc: *"One ACP connection, for exactly one turn"* and the *Lifetime is the turn* section are replaced with the wake-scoped rule and why (this is the ACP campaign's "turn-scoped connection" rule being retired). ADR 0014's *Session lifetime* section is left for part 3, per the plan, because it still describes what production does until then.

The re-plan comments on #817 (one adapter per *conversation*, reap by tag) change nothing in this part; both apply to part 3.

## Test plan
- [x] `peer_test.exs`: peer alive after the stop reason; second prompt reuses the connection (next write is `session/prompt` on the same session, no `handshake_ms`); second prompt carries its own images; `prompt/3` refused while a prompt is outstanding and during the handshake; out-of-turn update still reported; `cycle_end` on an origin-marked `usage_update` and not on a plain one or a `user` origin; `close/1` stops with `:normal`. 72 tests / 0 failures.
- [x] ACP + conversation-server + identity + permissions + audit guardrail: 340 tests / 0 failures.
- [x] `mix compile --warnings-as-errors`, `mix credo --strict` (no issues), `mix format`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)