### PR TITLE
docs(decisions): the wake policy for a parked home — any prompt wakes it, for that conversation alone

### DIFF
--- a/apps/fountain/test/fountain/conversations/wake_policy_test.exs
+++ b/apps/fountain/test/fountain/conversations/wake_policy_test.exs
@@ -12,7 +12,10 @@ defmodule Fountain.Conversations.WakePolicyTest do
   defp parked_home do
     user = insert_verified_user()
     agent = insert_agent(user_id: user.id, runtime: "claude")
-    sandbox = insert_sandbox(user_id: user.id, sprite_name: "test-sprite-home", mode: "persistent")
+
+    sandbox =
+      insert_sandbox(user_id: user.id, sprite_name: "test-sprite-home", mode: "persistent")
+
     {:ok, sandbox} = Conversations.update_sandbox(sandbox, %{status: "suspended"})
     a = insert_conversation(user_id: user.id, agent: agent, sandbox: sandbox, status: "idle")
     b = insert_conversation(user_id: user.id, agent: agent, sandbox: sandbox, status: "idle")

--- a/apps/fountain/test/fountain/conversations/wake_policy_test.exs
+++ b/apps/fountain/test/fountain/conversations/wake_policy_test.exs
@@ -1,0 +1,74 @@
+defmodule Fountain.Conversations.WakePolicyTest do
+  # The wake policy for a parked home (ADR 0023, decided 2026-08-24): a
+  # prompt to any conversation on the machine wakes it, for that
+  # conversation alone. A co-tenant's server comes back on its own first
+  # prompt, and that prompt attaches to the machine that is already awake
+  # rather than resuming it again.
+  use Fountain.DataCase, async: true
+  use Mimic
+
+  alias Fountain.Conversations
+
+  defp parked_home do
+    user = insert_verified_user()
+    agent = insert_agent(user_id: user.id, runtime: "claude")
+    sandbox = insert_sandbox(user_id: user.id, sprite_name: "test-sprite-home", mode: "persistent")
+    {:ok, sandbox} = Conversations.update_sandbox(sandbox, %{status: "suspended"})
+    a = insert_conversation(user_id: user.id, agent: agent, sandbox: sandbox, status: "idle")
+    b = insert_conversation(user_id: user.id, agent: agent, sandbox: sandbox, status: "idle")
+    %{sandbox: sandbox, a: a, b: b}
+  end
+
+  # The wake starts a server through Horde; here only *which* conversation
+  # got one matters, so record the child spec and start nothing.
+  defp record_server_starts do
+    test = self()
+
+    stub(Horde.DynamicSupervisor, :start_child, fn _supervisor, child_spec ->
+      send(test, {:server_started, inspect(child_spec)})
+      {:ok, spawn(fn -> :ok end)}
+    end)
+  end
+
+  defp stub_parked_sprite do
+    stub(Fountain.Sandbox.Sprites, :get, fn _handle ->
+      {:ok, %{status: :suspended, raw: %{name: "test-sprite-home"}}}
+    end)
+
+    stub(Fountain.Sandbox.Sprites, :resume, fn handle -> {:ok, handle} end)
+  end
+
+  test "a prompt to one conversation wakes the parked home for that conversation alone" do
+    %{sandbox: sandbox, a: a, b: b} = parked_home()
+    stub_parked_sprite()
+    record_server_starts()
+
+    assert {:ok, woken} = Conversations.wake_conversation(b.id)
+    assert woken.sandbox_id == sandbox.id
+    assert Repo.reload(sandbox).status == "ready"
+
+    assert_receive {:server_started, spec}
+    assert spec =~ b.id
+    refute_receive {:server_started, _}
+    assert Repo.reload(a).status == "idle"
+  end
+
+  test "a co-tenant's first prompt attaches to the awake machine without a second resume" do
+    %{sandbox: sandbox, a: a, b: b} = parked_home()
+    stub_parked_sprite()
+    record_server_starts()
+
+    assert {:ok, _} = Conversations.wake_conversation(b.id)
+    assert_receive {:server_started, _}
+    assert Repo.reload(sandbox).status == "ready"
+
+    # The machine is up. Waking A must reuse it: no resume, no new row.
+    reject(&Fountain.Sandbox.Sprites.resume/1)
+    stub(Fountain.Sandbox.Sprites, :get, fn _handle -> {:ok, %{status: :running, raw: %{}}} end)
+
+    assert {:ok, woken} = Conversations.wake_conversation(a.id)
+    assert woken.sandbox_id == sandbox.id
+    assert_receive {:server_started, spec}
+    assert spec =~ a.id
+  end
+end

--- a/decisions/0023-persistent-agent-sandbox.md
+++ b/decisions/0023-persistent-agent-sandbox.md
@@ -109,8 +109,19 @@ Sprites, a throwaway `claude` agent on haiku with no environment or vault):
   it and read three lines.
 - Deleting the agent terminated the home (`204`, row `terminated`).
 
-Open from the questions list: wake-on-any-inbound policy, and pricing the
-mode rather than the sandbox-minutes (#798).
+**Wake policy, decided 2026-08-24 (#1072):** a prompt to *any* conversation
+on a parked home wakes the machine — a Buzz message, a schedule firing, an
+API prompt, an AG-UI run all go through `ConversationServer.send_prompt/4`,
+and that is the one door — and it wakes it for that conversation alone. A
+co-tenant's server comes back on its own next prompt, which attaches to the
+machine that is already awake (no second resume, no new row). The idle clock
+is the union of every conversation's activity, so a wake for one keeps the
+machine up for all. There is no "owner's turns only" mode: an agent that
+should not answer at 3am is an agent whose channel is muted, not a machine
+that refuses to boot. `wake_policy_test.exs` states it.
+
+Open from the questions list: pricing the mode rather than the
+sandbox-minutes (#798).
 
 ## Context
 
@@ -421,10 +432,12 @@ to show something a conversation-centric view cannot.
 
 ## Open questions
 
-- Should a persistent home wake on **any** inbound (Buzz mention at 3am) or
-  only on the owner's turns? Today wake is per prompt; a home makes "the
-  agent is asleep" a visible product state.
 - Pricing: mode-based (always-on agent) vs sandbox-minutes as today (#798).
+
+### Resolved 2026-08-24
+
+- Wake on any inbound prompt, for that conversation alone; co-tenants
+  attach on their own next prompt. See the Outcome section (#1072).
 
 ### Resolved 2026-08-23
 

--- a/docs/concepts/sandboxes.md
+++ b/docs/concepts/sandboxes.md
@@ -55,6 +55,12 @@ disk. To suspend and wake the machine is therefore the same act as to pause
 and resume the conversations on it. Read
 [About conversations](conversation.md).
 
+A prompt to any conversation on a parked machine wakes it. The wake serves
+that conversation only. The other conversations on the machine start again
+on their own next prompt, and that prompt lands on the machine that is
+already awake. The idle clock counts the activity of every conversation on
+the machine, so one active conversation keeps the machine up for all of them.
+
 ## One seam, four backends
 
 Each backend plugs into the same seam, `Fountain.Sandbox`. The contract is


### PR DESCRIPTION
## Summary
- Decides ADR 0023's open wake question by codifying what the code does: every launch door funnels into `ConversationServer.send_prompt/4`, so a prompt to **any** conversation on a parked home (API, Buzz, schedule, AG-UI) wakes the machine, for that conversation alone; co-tenants' servers return on their own next prompt and attach to the already-awake machine; the idle clock is the union of every conversation's activity.
- No "owner's turns only" mode — muting a channel is the right lever, not a machine that refuses to boot.
- `wake_policy_test.exs` states the two halves (wake for one; co-tenant attaches without a second resume). ADR Outcome + Resolved sections updated; `docs/concepts/sandboxes.md` gets the paragraph.

## Test plan
- [x] `mix test apps/fountain/test/fountain/conversations/wake_policy_test.exs` → 2 tests, 0 failures
- [x] docs_test 29/0, docs-style clean, vale 0 warnings, `okf validate decisions` 0 errors
- [ ] CI

Closes #1072

🤖 Generated with [Claude Code](https://claude.com/claude-code)