### PR TITLE
fix(sandboxes): a change that moves a home's identity retires the home

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,28 @@ upgrade, is in
   one conversation the two numbers are equal, so nothing changes for
   today's accounts. ADR 0026 addendum; ADR 0023 step 6.
 
+- **A change that moves a home's identity retires the home.** A persistent
+  sandbox is keyed on `(user, agent, environment, vault)`. Moving an agent's
+  `environment_id`, deleting an environment, or deleting a vault moved that
+  key and left the machine `ready` under an identity nothing looks up — it
+  held a concurrency slot and a disk carrying the old environment's or
+  vault's secrets. All three now retire the affected homes the way
+  `DELETE /api/sandboxes/:id` does: the machine is destroyed, the
+  conversations on it are kept and told why (`sandbox`/`reset` with
+  `environment_changed`, `environment_deleted` or `vault_deleted`), and the
+  next prompt builds a machine on the identity that exists now. Audited as
+  `sandbox.reset` with the reason in the metadata. Each request is refused
+  with `409 sandbox_mid_turn` (a flash in the console) while a conversation
+  on one of those machines runs a turn, and nothing is written.
+
+  Deleting an environment or a vault was additionally broken outright: the
+  `ON DELETE SET NULL` on `sandboxes.environment_id` / `sandboxes.vault_id`
+  either turned the home into the *no environment* or *no vault* home for
+  its identity — so the next launch that asked for neither landed on a disk
+  holding the deleted secrets — or collided with
+  `sandboxes_home_identity_index` (`NULLS NOT DISTINCT`) and failed the
+  delete with an unhandled constraint error. #1084.
+
 - **A sandbox that is gone is gone for every conversation on it.** When a
   prompt wakes a conversation and finds its sandbox has vanished, the fresh
   machine it provisions now takes every live conversation that shared the old

--- a/apps/fountain/lib/fountain/agents.ex
+++ b/apps/fountain/lib/fountain/agents.ex
@@ -134,6 +134,24 @@ defmodule Fountain.Agents do
       |> Agent.changeset(attrs)
       |> validate_environment_owner()
 
+    # A home is keyed on (user, agent, environment, vault), so moving the
+    # agent's environment orphans every home built on the old one: the next
+    # launch looks under the new key and provisions a fresh machine, while the
+    # old one stays `ready` — holding a concurrency slot and a disk carrying
+    # the old environment's secrets (#1084). Asked here, before anything is
+    # written, so a mid-turn refusal costs the caller nothing.
+    # Ownership: `agent` came from the caller's scoped fetch, and every home
+    # in `orphans` is keyed on that agent id.
+    orphans = homes_orphaned_by_update(changeset, agent)
+
+    if Fountain.Conversations._unsafe_any_home_mid_turn?(orphans) do
+      {:error, :sandbox_mid_turn}
+    else
+      do_update_agent(changeset, orphans, opts)
+    end
+  end
+
+  defp do_update_agent(changeset, orphans, opts) do
     result =
       if snapshot_needed?(changeset) do
         Repo.transaction(fn ->
@@ -165,8 +183,46 @@ defmodule Fountain.Agents do
         Repo.update(changeset)
       end
 
+    result =
+      result
+      |> audited("agent.updated", merge_metadata(opts, Audit.changed_fields(changeset)))
+
+    # Only once the new identity is the committed one: a home torn down
+    # against an update that then failed would be rebuilt for nothing.
+    # Ownership: established above, by the scoped fetch that produced the agent
+    # these homes belong to.
+    case result do
+      {:ok, _} ->
+        _ =
+          Fountain.Conversations._unsafe_retire_orphaned_homes(
+            orphans,
+            "environment_changed",
+            opts
+          )
+
+      _ ->
+        :ok
+    end
+
     result
-    |> audited("agent.updated", merge_metadata(opts, Audit.changed_fields(changeset)))
+  end
+
+  # The homes an update orphans — only an `environment_id` that actually moves
+  # does it, and a vault is chosen per launch rather than stored on the agent.
+  # `[]` for a changeset that will not commit: nothing is orphaned by an
+  # update that does not happen, so nothing should be refused either.
+  defp homes_orphaned_by_update(%Ecto.Changeset{valid?: false}, _agent), do: []
+
+  # Ownership: `agent_id` comes from the struct the caller fetched scoped; the
+  # homes returned are the ones keyed on it.
+  defp homes_orphaned_by_update(changeset, %Agent{id: agent_id}) do
+    case Ecto.Changeset.fetch_change(changeset, :environment_id) do
+      {:ok, env_id} ->
+        Fountain.Conversations._unsafe_homes_orphaned_by_environment(agent_id, env_id)
+
+      :error ->
+        []
+    end
   end
 
   # An agent may only reference an environment owned by the same tenant —

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -1930,6 +1930,91 @@ defmodule Fountain.Conversations do
   end
 
   @doc """
+  Every live home built on `environment_id`, across the agents that name it.
+  `_unsafe_`: the caller owns the environment, and a home carries the same
+  `user_id` as the environment its identity names.
+  """
+  def _unsafe_homes_for_environment(environment_id) when is_binary(environment_id) do
+    live_homes(from(s in Sandbox, where: s.environment_id == ^environment_id))
+  end
+
+  @doc """
+  Every live home built on `vault_id`. Same ownership note as
+  `_unsafe_homes_for_environment/1`.
+  """
+  def _unsafe_homes_for_vault(vault_id) when is_binary(vault_id) do
+    live_homes(from(s in Sandbox, where: s.vault_id == ^vault_id))
+  end
+
+  @doc """
+  The homes of `agent_id` that moving it to `env_id` orphans: built for a
+  different environment, so the next launch looks under the new identity key,
+  finds nothing and provisions a fresh machine while these stay `ready` —
+  holding a concurrency slot and a disk with the old environment's secrets on
+  it (#1084). `nil` is an environment like any other here: an agent that
+  loses its environment orphans the homes that had one.
+  """
+  def _unsafe_homes_orphaned_by_environment(agent_id, env_id) when is_binary(agent_id) do
+    from(s in Sandbox, where: s.agent_id == ^agent_id)
+    |> where_environment_differs(env_id)
+    |> live_homes()
+  end
+
+  defp where_environment_differs(query, nil),
+    do: from(s in query, where: not is_nil(s.environment_id))
+
+  # `!=` is null-returning in SQL, so a home with no environment has to be
+  # named explicitly or it reads as "not different" and survives.
+  defp where_environment_differs(query, env_id),
+    do: from(s in query, where: is_nil(s.environment_id) or s.environment_id != ^env_id)
+
+  defp live_homes(query) do
+    from(s in query,
+      where: s.mode == "persistent" and s.status not in ["terminated", "failed"],
+      order_by: [asc: s.inserted_at]
+    )
+    |> Repo.all()
+  end
+
+  @doc """
+  Whether any of `homes` is running a turn — asked *before* a change that
+  would pull the machine out from under a working agent, so the refusal costs
+  nothing (#1084). Advisory only: each retirement re-checks under the
+  per-sandbox advisory lock, which is what actually makes a teardown safe.
+  """
+  def _unsafe_any_home_mid_turn?(homes) when is_list(homes) do
+    Enum.any?(homes, &(_unsafe_running_turns_elsewhere(&1.id, nil) > 0))
+  end
+
+  @doc """
+  Retire `homes` whose identity moved out from under them — the agent's
+  environment changed, or the environment or vault the key names was deleted
+  (#1084). Each goes through `reset_sandbox/2`, so the conversations on it are
+  kept and their next prompt builds a machine on the identity that exists now.
+
+  Best-effort per home, and deliberately so: a turn that starts between the
+  caller's check and this call leaves that one machine standing rather than
+  cutting the turn. The orphan is then what it was before this existed — a
+  `ready` row `fountain sandbox reset` clears — and the warning says which.
+  Returns the number retired.
+  """
+  def _unsafe_retire_orphaned_homes(homes, reason, opts \\ []) when is_list(homes) do
+    Enum.count(homes, fn home ->
+      case reset_sandbox(home, Keyword.put(opts, :reason, reason)) do
+        {:ok, _} ->
+          true
+
+        {:error, err} ->
+          Logger.warning(
+            "home #{home.id} orphaned by #{reason} was left standing: #{inspect(err)}"
+          )
+
+          false
+      end
+    end)
+  end
+
+  @doc """
   Tear down every home of `agent_id` — what deleting the agent does, since
   the identity the homes were built for is gone (ADR 0023 step 5). Each live
   conversation on a home is terminated (a home survives that on its own), then
@@ -1997,7 +2082,12 @@ defmodule Fountain.Conversations do
   check and the row flip share the per-sandbox advisory lock that turn
   creation takes, so a turn cannot slip in between them.
 
-  See `create_agent/2` for `opts` (`:actor`, `:request_ip`).
+  `opts[:reason]` says *why*, and reaches every transcript on the machine and
+  the audit row: `"home_reset"` (the owner asked — the default),
+  `"environment_changed"`, `"environment_deleted"` or `"vault_deleted"` when
+  the identity moved out from under the home (#1084).
+
+  See `create_agent/2` for the rest of `opts` (`:actor`, `:request_ip`).
   """
   def reset_sandbox(%Sandbox{} = sandbox, opts \\ []) do
     cond do
@@ -2042,9 +2132,8 @@ defmodule Fountain.Conversations do
       end)
 
     with {:ok, ids} <- result do
-      message =
-        "The sandbox was reset by its owner. The transcript is kept; the next prompt " <>
-          "builds a fresh machine, and the agent starts a new session there."
+      reason = Keyword.get(opts, :reason, "home_reset")
+      message = reset_message(reason)
 
       # A conversation with a live server is told through it — the server
       # cuts nothing (no turn is running), records the event on its own
@@ -2055,13 +2144,13 @@ defmodule Fountain.Conversations do
           nil ->
             publish_stage(id, "sandbox", "done", %{
               event: "reset",
-              reason: "home_reset",
+              reason: reason,
               by: "owner",
               message: message
             })
 
           pid ->
-            GenServer.cast(pid, {:machine_gone, "reset", "home_reset", message})
+            GenServer.cast(pid, {:machine_gone, "reset", reason, message})
         end
       end)
 
@@ -2077,13 +2166,33 @@ defmodule Fountain.Conversations do
         metadata: %{
           "agent_id" => sandbox.agent_id,
           "provider" => sandbox.provider,
-          "conversations" => length(ids)
+          "conversations" => length(ids),
+          "reason" => reason
         }
       })
 
       {:ok, _unsafe_get_sandbox!(sandbox.id)}
     end
   end
+
+  # What each transcript on a reset home is told. The tail is the same every
+  # time — the transcript survives, the next prompt builds a machine — because
+  # that is the part a reader needs; the head says whose decision it was.
+  @reset_tail "The transcript is kept; the next prompt builds a fresh machine, " <>
+                "and the agent starts a new session there."
+
+  defp reset_message("environment_changed"),
+    do:
+      "The agent moved to a different environment, so this machine is no longer its " <>
+        @reset_tail
+
+  defp reset_message("environment_deleted"),
+    do: "The environment this machine was built for was deleted. " <> @reset_tail
+
+  defp reset_message("vault_deleted"),
+    do: "The vault this machine was built for was deleted. " <> @reset_tail
+
+  defp reset_message(_owner), do: "The sandbox was reset by its owner. " <> @reset_tail
 
   # A conversation on a machine the caller already has (ADR 0023 gate 3).
   #

--- a/apps/fountain/lib/fountain/environments.ex
+++ b/apps/fountain/lib/fountain/environments.ex
@@ -140,9 +140,31 @@ defmodule Fountain.Environments do
     |> audited("environment.updated", merge_metadata(opts, Audit.changed_fields(changeset)))
   end
 
-  @doc "Delete an environment. See `create_environment/2` for `opts`."
-  def delete_environment(%Environment{} = env, opts \\ []),
-    do: env |> Repo.delete() |> audited("environment.deleted", opts)
+  @doc """
+  Delete an environment. See `create_environment/2` for `opts`.
+
+  The homes built on it go first (#1084), for the reason spelled out in
+  `Fountain.Vaults.delete_vault/2`: `sandboxes.environment_id` is
+  `ON DELETE SET NULL`, so a home left behind either becomes the *no
+  environment* home for its identity — next launch lands on a disk holding the
+  deleted environment's secrets — or collides with
+  `sandboxes_home_identity_index` and fails the delete outright.
+
+  Refused with `:sandbox_mid_turn` while a conversation on one of those homes
+  is running a turn.
+  """
+  def delete_environment(%Environment{} = env, opts \\ []) do
+    # Ownership: `env` came from the caller's scoped fetch, and a home carries
+    # the same `user_id` as the environment its identity names.
+    homes = Fountain.Conversations._unsafe_homes_for_environment(env.id)
+
+    if Fountain.Conversations._unsafe_any_home_mid_turn?(homes) do
+      {:error, :sandbox_mid_turn}
+    else
+      _ = Fountain.Conversations._unsafe_retire_orphaned_homes(homes, "environment_deleted", opts)
+      env |> Repo.delete() |> audited("environment.deleted", opts)
+    end
+  end
 
   # See the note in `Fountain.Agents.audited/3`: this runs outside any
   # enclosing transaction, because best-effort audit recording is only

--- a/apps/fountain/lib/fountain/manifest.ex
+++ b/apps/fountain/lib/fountain/manifest.ex
@@ -133,8 +133,24 @@ defmodule Fountain.Manifest do
           end
 
         case outcome do
-          {action, {:ok, _agent}} -> result("Agent", name, action, nil, [])
-          {_action, {:error, cs}} -> result("Agent", name, :error, changeset_errors(cs), [])
+          {action, {:ok, _agent}} ->
+            result("Agent", name, action, nil, [])
+
+          # Moving the agent's environment rebuilds its machine, which a
+          # running turn blocks (#1084). Reported against the field that
+          # caused it so `fountain apply` says what to do about it.
+          {_action, {:error, :sandbox_mid_turn}} ->
+            errors = %{
+              "environment" => [
+                "the agent is running a turn on its own machine; changing its " <>
+                  "environment rebuilds that machine — retry once the turn ends"
+              ]
+            }
+
+            result("Agent", name, :error, errors, [])
+
+          {_action, {:error, cs}} ->
+            result("Agent", name, :error, changeset_errors(cs), [])
         end
 
       {:error, ref} ->

--- a/apps/fountain/lib/fountain/vaults.ex
+++ b/apps/fountain/lib/fountain/vaults.ex
@@ -120,9 +120,32 @@ defmodule Fountain.Vaults do
   The secrets inside go with it by cascade, and the trail already carries a
   `vault.secret.write` for each one that was ever set — so a single
   `vault.deleted` row is enough to explain their disappearance.
+
+  The homes built on it go first (#1084). `sandboxes.vault_id` is
+  `ON DELETE SET NULL`, so leaving them is not a stray-orphan problem but two
+  concrete ones: the row becomes the *no-vault* home for that identity, and
+  the next launch that asks for no vault lands on a disk with this vault's
+  secrets still materialised on it — or, when such a home already exists, the
+  nilify collides with `sandboxes_home_identity_index` (`NULLS NOT DISTINCT`)
+  and the delete fails with a constraint error the caller cannot act on.
+  Torn down while `vault_id` still names them, for the same reason
+  `delete_agent/2` tears homes down before the agent row goes.
+
+  Refused with `:sandbox_mid_turn` while a conversation on one of those homes
+  is running a turn.
   """
-  def delete_vault(%Vault{} = vault, opts \\ []),
-    do: vault |> Repo.delete() |> audited("vault.deleted", opts)
+  def delete_vault(%Vault{} = vault, opts \\ []) do
+    # Ownership: `vault` came from the caller's scoped fetch, and a home
+    # carries the same `user_id` as the vault its identity names.
+    homes = Fountain.Conversations._unsafe_homes_for_vault(vault.id)
+
+    if Fountain.Conversations._unsafe_any_home_mid_turn?(homes) do
+      {:error, :sandbox_mid_turn}
+    else
+      _ = Fountain.Conversations._unsafe_retire_orphaned_homes(homes, "vault_deleted", opts)
+      vault |> Repo.delete() |> audited("vault.deleted", opts)
+    end
+  end
 
   # See the note in `Fountain.Agents.audited/3`: this runs outside any
   # enclosing transaction, because best-effort audit recording is only

--- a/apps/fountain/lib/fountain_web/controllers/agent_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/agent_controller.ex
@@ -126,12 +126,19 @@ defmodule FountainWeb.AgentController do
 
   operation(:update,
     summary: "Update an agent (partial)",
-    description: "Every field is optional; the server merges into the existing record.",
+    description:
+      "Every field is optional; the server merges into the existing record. Moving " <>
+        "`environment_id` retires the agent's persistent sandboxes built on the old " <>
+        "environment, so the update is refused with `409 sandbox_mid_turn` while a " <>
+        "conversation on one of them is running a turn.",
     parameters: [id: [in: :path, type: :string, required: true]],
     request_body: {"Partial agent attributes", "application/json", Schemas.AgentUpdate},
     responses: [
       ok: {"Agent", "application/json", Schemas.AgentResponse},
       not_found: {"Not found", "application/json", Schemas.Error},
+      conflict:
+        {"An agent is mid-turn on a persistent sandbox the change retires", "application/json",
+         Schemas.Error},
       unprocessable_entity: {"Validation error", "application/json", Schemas.ChangesetError}
     ]
   )

--- a/apps/fountain/lib/fountain_web/controllers/buzz_agent_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/buzz_agent_controller.ex
@@ -11,6 +11,8 @@ defmodule FountainWeb.BuzzAgentController do
   use FountainWeb, :controller
   use OpenApiSpex.ControllerSpecs
 
+  require Logger
+
   alias Fountain.Buzz
   alias Fountain.Buzz.{BuzzIdentity, Manager}
   alias Fountain.Vaults
@@ -179,10 +181,19 @@ defmodule FountainWeb.BuzzAgentController do
   defp ensure_harness(nil, %BuzzIdentity{} = identity), do: Manager.start_harness(identity)
 
   defp delete_vault(%BuzzIdentity{vault_id: vault_id}, user_id) do
-    case Vaults.get_vault(vault_id, user_id) do
-      %Vaults.Vault{} = vault -> Vaults.delete_vault(vault, actor: "api")
-      _ -> :ok
+    with %Vaults.Vault{} = vault <- Vaults.get_vault(vault_id, user_id),
+         # A home built on this vault is retired first, and a running turn on
+         # one refuses the delete (#1084). The harness is stopped above, so
+         # this is a turn some other conversation is running on the same
+         # machine; the identity still goes and the vault is left for the
+         # owner rather than failing the request.
+         {:error, reason} <- Vaults.delete_vault(vault, actor: "api") do
+      Logger.warning(
+        "buzz identity deleted but its vault #{vault_id} was kept: #{inspect(reason)}"
+      )
     end
+
+    :ok
   end
 
   defp identity_json(%BuzzIdentity{} = i) do

--- a/apps/fountain/lib/fountain_web/controllers/environment_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/environment_controller.ex
@@ -102,7 +102,10 @@ defmodule FountainWeb.EnvironmentController do
     parameters: [id: [in: :path, type: :string, required: true]],
     responses: [
       no_content: "Deleted",
-      not_found: {"Not found", "application/json", Schemas.Error}
+      not_found: {"Not found", "application/json", Schemas.Error},
+      conflict:
+        {"An agent is mid-turn on a persistent sandbox built on this environment",
+         "application/json", Schemas.Error}
     ]
   )
 
@@ -114,8 +117,9 @@ defmodule FountainWeb.EnvironmentController do
         {:error, :not_found}
 
       env ->
-        {:ok, _} = Environments.delete_environment(env, Audited.attribution(conn))
-        send_resp(conn, :no_content, "")
+        with {:ok, _} <- Environments.delete_environment(env, Audited.attribution(conn)) do
+          send_resp(conn, :no_content, "")
+        end
     end
   end
 end

--- a/apps/fountain/lib/fountain_web/controllers/vault_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/vault_controller.ex
@@ -98,7 +98,10 @@ defmodule FountainWeb.VaultController do
     parameters: [id: [in: :path, type: :string, required: true]],
     responses: [
       no_content: "Deleted",
-      not_found: {"Not found", "application/json", Schemas.Error}
+      not_found: {"Not found", "application/json", Schemas.Error},
+      conflict:
+        {"An agent is mid-turn on a persistent sandbox built on this vault", "application/json",
+         Schemas.Error}
     ]
   )
 
@@ -110,8 +113,9 @@ defmodule FountainWeb.VaultController do
         {:error, :not_found}
 
       vault ->
-        {:ok, _} = Vaults.delete_vault(vault, Audited.attribution(conn))
-        send_resp(conn, :no_content, "")
+        with {:ok, _} <- Vaults.delete_vault(vault, Audited.attribution(conn)) do
+          send_resp(conn, :no_content, "")
+        end
     end
   end
 end

--- a/apps/fountain/lib/fountain_web/live/agents_live/form.ex
+++ b/apps/fountain/lib/fountain_web/live/agents_live/form.ex
@@ -441,6 +441,19 @@ defmodule FountainWeb.AgentsLive.Form do
          |> put_flash(:info, "Agent updated")
          |> push_navigate(to: ~p"/agents")}
 
+      # Moving the environment retires the homes built on the old one, and
+      # that cannot happen under a running turn (#1084). Not a field error —
+      # the form is fine, the timing is not.
+      {:error, :sandbox_mid_turn} ->
+        {:error,
+         put_flash(
+           socket,
+           :error,
+           "This agent is running a turn on its own machine right now. Changing its " <>
+             "environment rebuilds that machine, so wait for the turn to finish, or " <>
+             "interrupt it, then save again."
+         )}
+
       {:error, cs} ->
         {:error, assign(socket, :errors, changeset_errors(cs))}
     end

--- a/apps/fountain/lib/fountain_web/live/agents_live/versions.ex
+++ b/apps/fountain/lib/fountain_web/live/agents_live/versions.ex
@@ -37,6 +37,17 @@ defmodule FountainWeb.AgentsLive.Versions do
         # silently restored.
         {:noreply, put_flash(socket, :error, "Cannot roll back: #{rollback_error(cs)}")}
 
+      # A rollback that moves the environment back retires the homes built on
+      # the current one, which a running turn blocks (#1084).
+      {:error, :sandbox_mid_turn} ->
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           "Cannot roll back: the agent is running a turn on its own machine. Wait for " <>
+             "it to finish, or interrupt it, then roll back again."
+         )}
+
       # Integer.parse :error / trailing garbage, or no such version (nil).
       # Same user-facing answer either way.
       _ ->

--- a/apps/fountain/lib/fountain_web/live/environments_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/environments_live/index.ex
@@ -39,13 +39,26 @@ defmodule FountainWeb.EnvironmentsLive.Index do
          |> put_flash(:error, "Environment not found — it may already be deleted")}
 
       env ->
-        {:ok, _} = Environments.delete_environment(env, FountainWeb.Audited.attribution(socket))
+        # An environment whose home is mid-turn cannot go yet (#1084) — the
+        # machine would be pulled out from under a running turn.
+        flash =
+          case Environments.delete_environment(env, FountainWeb.Audited.attribution(socket)) do
+            {:ok, _} -> {:info, "Deleted #{env.name}"}
+            {:error, :sandbox_mid_turn} -> {:error, mid_turn_message(env.name)}
+          end
 
         {:noreply,
          socket
          |> assign(:envs, load_envs(socket.assigns.user_id, socket.assigns.filter_search))
-         |> put_flash(:info, "Deleted #{env.name}")}
+         |> put_flash(elem(flash, 0), elem(flash, 1))}
     end
+  end
+
+  # An agent is working on the machine this row's identity names; the caller
+  # waits for the turn or interrupts it, then deletes again.
+  defp mid_turn_message(name) do
+    "#{name} is in use by an agent that is running a turn right now — wait for it to " <>
+      "finish, or interrupt it, then delete again"
   end
 
   defp load_envs(user_id, search) do

--- a/apps/fountain/lib/fountain_web/live/vaults_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/vaults_live/index.ex
@@ -39,13 +39,26 @@ defmodule FountainWeb.VaultsLive.Index do
          |> put_flash(:error, "Vault not found — it may already be deleted")}
 
       vault ->
-        {:ok, _} = Vaults.delete_vault(vault, FountainWeb.Audited.attribution(socket))
+        # A vault whose home is mid-turn cannot go yet (#1084) — the machine
+        # would be pulled out from under a running turn.
+        flash =
+          case Vaults.delete_vault(vault, FountainWeb.Audited.attribution(socket)) do
+            {:ok, _} -> {:info, "Deleted #{vault.name}"}
+            {:error, :sandbox_mid_turn} -> {:error, mid_turn_message(vault.name)}
+          end
 
         {:noreply,
          socket
          |> assign(:vaults, load_vaults(socket.assigns.user_id, socket.assigns.filter_search))
-         |> put_flash(:info, "Deleted #{vault.name}")}
+         |> put_flash(elem(flash, 0), elem(flash, 1))}
     end
+  end
+
+  # An agent is working on the machine this row's identity names; the caller
+  # waits for the turn or interrupts it, then deletes again.
+  defp mid_turn_message(name) do
+    "#{name} is in use by an agent that is running a turn right now — wait for it to " <>
+      "finish, or interrupt it, then delete again"
   end
 
   defp load_vaults(user_id, search) do

--- a/apps/fountain/test/fountain/conversations/orphaned_home_test.exs
+++ b/apps/fountain/test/fountain/conversations/orphaned_home_test.exs
@@ -1,0 +1,362 @@
+defmodule Fountain.Conversations.OrphanedHomeTest do
+  # #1084: a home is keyed on (user, agent, environment, vault). When the key
+  # moves out from under it — the agent's environment changes, or the
+  # environment or vault the key names is deleted — the home is retired rather
+  # than left `ready` under an identity nothing looks up any more.
+  use Fountain.DataCase, async: true
+  use Mimic
+
+  alias Fountain.Agents
+  alias Fountain.Conversations
+  alias Fountain.Environments
+  alias Fountain.Vaults
+
+  setup do
+    user = insert_active_user()
+    {:ok, user} = Fountain.Accounts.update_sandbox_limit(user, 10)
+    env = insert_env(user_id: user.id)
+    other_env = insert_env(user_id: user.id)
+    vault = insert_vault(user_id: user.id)
+
+    agent =
+      insert_agent(
+        user_id: user.id,
+        runtime: "claude",
+        environment_id: env.id,
+        sandbox_mode: "persistent"
+      )
+
+    stub(Horde.DynamicSupervisor, :start_child, fn _s, _spec -> {:ok, spawn(fn -> :ok end)} end)
+
+    {:ok, user: user, env: env, other_env: other_env, vault: vault, agent: agent}
+  end
+
+  defp home(ctx, overrides \\ []) do
+    attrs =
+      [
+        user_id: ctx.user.id,
+        status: "ready",
+        mode: "persistent",
+        agent_id: ctx.agent.id,
+        environment_id: ctx.env.id,
+        provider: "sprites"
+      ]
+      |> Keyword.merge(overrides)
+
+    insert_sandbox(attrs)
+  end
+
+  defp expect_destroy do
+    test = self()
+    stub(Fountain.Sandbox.Sprites, :destroy, fn h -> send(test, {:destroyed, h.name}) && :ok end)
+  end
+
+  describe "the agent's environment changes" do
+    test "the home built on the old environment is destroyed and retired", ctx do
+      expect_destroy()
+      old = home(ctx)
+
+      assert {:ok, agent} =
+               Agents.update_agent(ctx.agent, %{"environment_id" => ctx.other_env.id})
+
+      assert agent.environment_id == ctx.other_env.id
+
+      assert_received {:destroyed, name}
+      assert name == old.sprite_name
+      assert Conversations._unsafe_get_sandbox!(old.id).status == "terminated"
+    end
+
+    test "the conversations on it are kept, and their next prompt has no session to resume",
+         ctx do
+      expect_destroy()
+      old = home(ctx)
+
+      conv =
+        insert_conversation(
+          user_id: ctx.user.id,
+          agent: ctx.agent,
+          sandbox: old,
+          status: "idle",
+          runtime_session_id: "sess-1"
+        )
+
+      assert {:ok, _} = Agents.update_agent(ctx.agent, %{"environment_id" => ctx.other_env.id})
+
+      reloaded = Conversations._unsafe_get_conversation!(conv.id)
+      assert reloaded.status == "idle"
+      assert is_nil(reloaded.runtime_session_id)
+    end
+
+    test "each transcript says the environment moved, not that the owner reset it", ctx do
+      expect_destroy()
+      old = home(ctx)
+
+      conv =
+        insert_conversation(user_id: ctx.user.id, agent: ctx.agent, sandbox: old, status: "idle")
+
+      assert {:ok, _} = Agents.update_agent(ctx.agent, %{"environment_id" => ctx.other_env.id})
+
+      assert [event] =
+               conv.id
+               |> Conversations._unsafe_list_log_events()
+               |> Enum.filter(&(&1.kind == "stage" and &1.stage == "sandbox"))
+
+      assert %{"event" => "reset", "reason" => "environment_changed", "message" => message} =
+               Jason.decode!(event.data)
+
+      assert message =~ "different environment"
+    end
+
+    test "a home already on the new environment is left alone", ctx do
+      expect_destroy()
+      keeper = home(ctx, environment_id: ctx.other_env.id)
+
+      assert {:ok, _} = Agents.update_agent(ctx.agent, %{"environment_id" => ctx.other_env.id})
+
+      refute_received {:destroyed, _}
+      assert Conversations._unsafe_get_sandbox!(keeper.id).status == "ready"
+    end
+
+    test "an agent losing its environment orphans the home that had one", ctx do
+      expect_destroy()
+      old = home(ctx)
+
+      assert {:ok, agent} = Agents.update_agent(ctx.agent, %{"environment_id" => nil})
+      assert is_nil(agent.environment_id)
+      assert Conversations._unsafe_get_sandbox!(old.id).status == "terminated"
+    end
+
+    test "an update that does not touch the environment leaves the home standing", ctx do
+      expect_destroy()
+      standing = home(ctx)
+
+      assert {:ok, _} = Agents.update_agent(ctx.agent, %{"name" => "renamed"})
+
+      refute_received {:destroyed, _}
+      assert Conversations._unsafe_get_sandbox!(standing.id).status == "ready"
+    end
+
+    test "an ephemeral sandbox of the same agent is not a home and is untouched", ctx do
+      expect_destroy()
+
+      ephemeral =
+        insert_sandbox(
+          user_id: ctx.user.id,
+          status: "ready",
+          mode: "ephemeral",
+          agent_id: ctx.agent.id,
+          environment_id: ctx.env.id
+        )
+
+      assert {:ok, _} = Agents.update_agent(ctx.agent, %{"environment_id" => ctx.other_env.id})
+
+      refute_received {:destroyed, _}
+      assert Conversations._unsafe_get_sandbox!(ephemeral.id).status == "ready"
+    end
+
+    test "refused mid-turn, and nothing is written", ctx do
+      standing = home(ctx)
+
+      conv =
+        insert_conversation(
+          user_id: ctx.user.id,
+          agent: ctx.agent,
+          sandbox: standing,
+          status: "running"
+        )
+
+      insert_turn(conv, status: "running")
+      before = Agents.list_agent_versions(ctx.agent.id, ctx.user.id)
+
+      assert {:error, :sandbox_mid_turn} =
+               Agents.update_agent(ctx.agent, %{"environment_id" => ctx.other_env.id})
+
+      # The refusal is the whole answer: the agent did not move, the machine
+      # is still there, and the change left no version behind.
+      assert Agents._unsafe_get_agent(ctx.agent.id).environment_id == ctx.env.id
+      assert Conversations._unsafe_get_sandbox!(standing.id).status == "ready"
+      assert Agents.list_agent_versions(ctx.agent.id, ctx.user.id) == before
+    end
+
+    test "an invalid change is still a changeset error, not a mid-turn refusal", ctx do
+      standing = home(ctx)
+
+      conv =
+        insert_conversation(
+          user_id: ctx.user.id,
+          agent: ctx.agent,
+          sandbox: standing,
+          status: "running"
+        )
+
+      insert_turn(conv, status: "running")
+
+      # A foreign environment id: the update cannot commit, so nothing is
+      # orphaned and the mid-turn check must not pre-empt the real error.
+      foreign = insert_env().id
+
+      assert {:error, %Ecto.Changeset{} = cs} =
+               Agents.update_agent(ctx.agent, %{"environment_id" => foreign})
+
+      assert %{environment_id: ["does not exist"]} = errors_on(cs)
+    end
+
+    test "the audit row names the reason", ctx do
+      expect_destroy()
+      old = home(ctx)
+
+      assert {:ok, _} =
+               Agents.update_agent(ctx.agent, %{"environment_id" => ctx.other_env.id},
+                 actor: "api"
+               )
+
+      assert [row] =
+               Fountain.Audit.list_for_user(ctx.user.id)
+               |> Enum.filter(&(&1.action == "sandbox.reset"))
+
+      assert row.resource_id == old.id
+      assert row.actor == "api"
+      assert row.metadata["reason"] == "environment_changed"
+    end
+  end
+
+  describe "the environment is deleted" do
+    test "the home is retired instead of silently becoming the no-environment home", ctx do
+      expect_destroy()
+      old = home(ctx)
+
+      assert {:ok, _} = Environments.delete_environment(ctx.env)
+
+      assert_received {:destroyed, _}
+      retired = Conversations._unsafe_get_sandbox!(old.id)
+      assert retired.status == "terminated"
+
+      # The FK nilify still lands, which is exactly why the row had to be
+      # retired first: a live row here would be the no-environment home.
+      assert is_nil(retired.environment_id)
+      assert is_nil(Conversations._unsafe_find_home(ctx.user.id, ctx.agent.id, nil, nil))
+    end
+
+    test "a delete that would collide with an existing no-environment home succeeds", ctx do
+      expect_destroy()
+      # Before #1084 the ON DELETE SET NULL collided with
+      # sandboxes_home_identity_index (NULLS NOT DISTINCT) and the delete
+      # raised Ecto.ConstraintError — the owner could not delete at all.
+      no_env = home(ctx, environment_id: nil)
+      keyed = home(ctx)
+
+      assert {:ok, _} = Environments.delete_environment(ctx.env)
+
+      assert Conversations._unsafe_get_sandbox!(keyed.id).status == "terminated"
+      assert Conversations._unsafe_get_sandbox!(no_env.id).status == "ready"
+    end
+
+    test "refused mid-turn, and the environment stays", ctx do
+      standing = home(ctx)
+
+      conv =
+        insert_conversation(
+          user_id: ctx.user.id,
+          agent: ctx.agent,
+          sandbox: standing,
+          status: "running"
+        )
+
+      insert_turn(conv, status: "running")
+
+      assert {:error, :sandbox_mid_turn} = Environments.delete_environment(ctx.env)
+      assert Environments.get_environment(ctx.env.id, ctx.user.id)
+      assert Conversations._unsafe_get_sandbox!(standing.id).status == "ready"
+    end
+
+    test "an environment with no home deletes as before", ctx do
+      assert {:ok, _} = Environments.delete_environment(ctx.other_env)
+      refute Environments.get_environment(ctx.other_env.id, ctx.user.id)
+    end
+  end
+
+  describe "the vault is deleted" do
+    test "the home is retired instead of becoming the no-vault home", ctx do
+      expect_destroy()
+      old = home(ctx, vault_id: ctx.vault.id)
+
+      assert {:ok, _} = Vaults.delete_vault(ctx.vault)
+
+      assert_received {:destroyed, _}
+      retired = Conversations._unsafe_get_sandbox!(old.id)
+      assert retired.status == "terminated"
+      assert is_nil(retired.vault_id)
+
+      # The point of retiring it: a launch that asks for no vault must not
+      # land on a disk holding the deleted vault's secrets.
+      assert is_nil(Conversations._unsafe_find_home(ctx.user.id, ctx.agent.id, ctx.env.id, nil))
+    end
+
+    test "a delete that would collide with an existing no-vault home succeeds", ctx do
+      expect_destroy()
+      no_vault = home(ctx)
+      keyed = home(ctx, vault_id: ctx.vault.id)
+
+      assert {:ok, _} = Vaults.delete_vault(ctx.vault)
+
+      assert Conversations._unsafe_get_sandbox!(keyed.id).status == "terminated"
+      assert Conversations._unsafe_get_sandbox!(no_vault.id).status == "ready"
+    end
+
+    test "the transcript names the vault, and the audit row carries the reason", ctx do
+      expect_destroy()
+      old = home(ctx, vault_id: ctx.vault.id)
+
+      conv =
+        insert_conversation(user_id: ctx.user.id, agent: ctx.agent, sandbox: old, status: "idle")
+
+      assert {:ok, _} = Vaults.delete_vault(ctx.vault, actor: "api")
+
+      assert [event] =
+               conv.id
+               |> Conversations._unsafe_list_log_events()
+               |> Enum.filter(&(&1.kind == "stage" and &1.stage == "sandbox"))
+
+      assert %{"reason" => "vault_deleted"} = Jason.decode!(event.data)
+
+      assert [row] =
+               Fountain.Audit.list_for_user(ctx.user.id)
+               |> Enum.filter(&(&1.action == "sandbox.reset"))
+
+      assert row.metadata["reason"] == "vault_deleted"
+    end
+
+    test "refused mid-turn, and the vault stays", ctx do
+      standing = home(ctx, vault_id: ctx.vault.id)
+
+      conv =
+        insert_conversation(
+          user_id: ctx.user.id,
+          agent: ctx.agent,
+          sandbox: standing,
+          status: "running"
+        )
+
+      insert_turn(conv, status: "running")
+
+      assert {:error, :sandbox_mid_turn} = Vaults.delete_vault(ctx.vault)
+      assert Vaults.get_vault(ctx.vault.id, ctx.user.id)
+      assert Conversations._unsafe_get_sandbox!(standing.id).status == "ready"
+    end
+
+    test "a vault with no home deletes as before", ctx do
+      assert {:ok, _} = Vaults.delete_vault(ctx.vault)
+      refute Vaults.get_vault(ctx.vault.id, ctx.user.id)
+    end
+  end
+
+  describe "a provider that cannot destroy" do
+    test "the row still retires, so the reaper sees a terminal row", ctx do
+      stub(Fountain.Sandbox.Sprites, :destroy, fn _h -> {:error, :boom} end)
+      old = home(ctx)
+
+      assert {:ok, _} = Agents.update_agent(ctx.agent, %{"environment_id" => ctx.other_env.id})
+      assert Conversations._unsafe_get_sandbox!(old.id).status == "terminated"
+    end
+  end
+end

--- a/apps/fountain/test/fountain_web/controllers/orphaned_home_door_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/orphaned_home_door_test.exs
@@ -1,0 +1,185 @@
+defmodule FountainWeb.OrphanedHomeDoorTest do
+  # #1084 at the doors: the three requests that move a home's identity key out
+  # from under it answer 409 rather than 500 or a silent orphan.
+  use FountainWeb.ConnCase, async: true
+  use Mimic
+
+  import Phoenix.LiveViewTest
+
+  alias Fountain.Conversations
+  alias Fountain.Environments
+  alias Fountain.Vaults
+
+  setup do
+    user = insert_active_user()
+    {:ok, user} = Fountain.Accounts.update_sandbox_limit(user, 10)
+    {_key_record, raw_key} = insert_api_key(user)
+    env = insert_env(user_id: user.id)
+    other_env = insert_env(user_id: user.id)
+    vault = insert_vault(user_id: user.id)
+
+    agent =
+      insert_agent(
+        user_id: user.id,
+        runtime: "claude",
+        environment_id: env.id,
+        sandbox_mode: "persistent"
+      )
+
+    home =
+      insert_sandbox(
+        user_id: user.id,
+        status: "ready",
+        mode: "persistent",
+        agent_id: agent.id,
+        environment_id: env.id,
+        vault_id: vault.id,
+        provider: "sprites"
+      )
+
+    conv = insert_conversation(user_id: user.id, agent: agent, sandbox: home, status: "idle")
+    stub(Fountain.Sandbox.Sprites, :destroy, fn _h -> :ok end)
+    stub(Horde.DynamicSupervisor, :start_child, fn _s, _spec -> {:ok, spawn(fn -> :ok end)} end)
+
+    {:ok,
+     user: user,
+     raw_key: raw_key,
+     env: env,
+     other_env: other_env,
+     vault: vault,
+     agent: agent,
+     home: home,
+     conv: conv}
+  end
+
+  defp authed(ctx), do: authed_with_key(ctx.conn, ctx.raw_key)
+
+  # The spec-validated PATCH refuses a body without a declared content type.
+  defp patch_agent(ctx, attrs) do
+    ctx
+    |> authed()
+    |> Plug.Conn.put_req_header("content-type", "application/json")
+    |> patch("/api/agents/#{ctx.agent.id}", attrs)
+  end
+
+  describe "PATCH /api/agents/:id" do
+    test "200: moving the environment retires the home built on the old one", ctx do
+      conn = patch_agent(ctx, %{"environment_id" => ctx.other_env.id})
+
+      assert json_response(conn, 200)["data"]["environment_id"] == ctx.other_env.id
+      assert Conversations._unsafe_get_sandbox!(ctx.home.id).status == "terminated"
+      # The transcript is the point of a reset over a teardown.
+      assert Conversations._unsafe_get_conversation!(ctx.conv.id).status == "idle"
+    end
+
+    test "409 sandbox_mid_turn while a conversation on the home is running a turn", ctx do
+      insert_turn(ctx.conv, status: "running")
+
+      conn = patch_agent(ctx, %{"environment_id" => ctx.other_env.id})
+
+      assert json_response(conn, 409)["error"] == "sandbox_mid_turn"
+      assert Conversations._unsafe_get_sandbox!(ctx.home.id).status == "ready"
+      assert Fountain.Agents._unsafe_get_agent(ctx.agent.id).environment_id == ctx.env.id
+    end
+
+    test "an unrelated field still updates while a turn runs", ctx do
+      insert_turn(ctx.conv, status: "running")
+
+      conn = patch_agent(ctx, %{"name" => "renamed"})
+
+      assert json_response(conn, 200)["data"]["name"] == "renamed"
+    end
+  end
+
+  describe "DELETE /api/vaults/:id" do
+    test "204: the home built on the vault is retired first", ctx do
+      assert ctx |> authed() |> delete("/api/vaults/#{ctx.vault.id}") |> response(204)
+      refute Vaults.get_vault(ctx.vault.id, ctx.user.id)
+      assert Conversations._unsafe_get_sandbox!(ctx.home.id).status == "terminated"
+    end
+
+    test "409 while a conversation on that home is mid-turn, and the vault stays", ctx do
+      insert_turn(ctx.conv, status: "running")
+
+      conn = ctx |> authed() |> delete("/api/vaults/#{ctx.vault.id}")
+
+      assert json_response(conn, 409)["error"] == "sandbox_mid_turn"
+      assert Vaults.get_vault(ctx.vault.id, ctx.user.id)
+      assert Conversations._unsafe_get_sandbox!(ctx.home.id).status == "ready"
+    end
+  end
+
+  describe "DELETE /api/environments/:id" do
+    test "204: the home built on the environment is retired first", ctx do
+      assert ctx |> authed() |> delete("/api/environments/#{ctx.env.id}") |> response(204)
+      refute Environments.get_environment(ctx.env.id, ctx.user.id)
+      assert Conversations._unsafe_get_sandbox!(ctx.home.id).status == "terminated"
+    end
+
+    test "409 while a conversation on that home is mid-turn, and the environment stays", ctx do
+      insert_turn(ctx.conv, status: "running")
+
+      conn = ctx |> authed() |> delete("/api/environments/#{ctx.env.id}")
+
+      assert json_response(conn, 409)["error"] == "sandbox_mid_turn"
+      assert Environments.get_environment(ctx.env.id, ctx.user.id)
+      assert Conversations._unsafe_get_sandbox!(ctx.home.id).status == "ready"
+    end
+  end
+
+  # The console's three doors. Each hard-matched `{:ok, _}` before #1084, so a
+  # refusal was a MatchError and a dead LiveView rather than a flash.
+  describe "the operator console" do
+    setup ctx do
+      {:ok, conn: login_user(ctx.conn, ctx.user)}
+    end
+
+    test "deleting a vault mid-turn flashes instead of crashing the LiveView", ctx do
+      insert_turn(ctx.conv, status: "running")
+
+      {:ok, lv, _html} = live(ctx.conn, ~p"/vaults")
+      html = render_click(lv, "delete", %{"id" => ctx.vault.id})
+
+      assert html =~ "running a turn"
+      assert Vaults.get_vault(ctx.vault.id, ctx.user.id)
+    end
+
+    test "deleting an environment mid-turn flashes instead of crashing the LiveView", ctx do
+      insert_turn(ctx.conv, status: "running")
+
+      {:ok, lv, _html} = live(ctx.conn, ~p"/environments")
+      html = render_click(lv, "delete", %{"id" => ctx.env.id})
+
+      assert html =~ "running a turn"
+      assert Environments.get_environment(ctx.env.id, ctx.user.id)
+    end
+
+    test "a delete with no turn running still succeeds and says so", ctx do
+      {:ok, lv, _html} = live(ctx.conn, ~p"/vaults")
+      html = render_click(lv, "delete", %{"id" => ctx.vault.id})
+
+      assert html =~ "Deleted"
+      refute Vaults.get_vault(ctx.vault.id, ctx.user.id)
+      assert Conversations._unsafe_get_sandbox!(ctx.home.id).status == "terminated"
+    end
+
+    test "moving an agent's environment mid-turn flashes on the form", ctx do
+      insert_turn(ctx.conv, status: "running")
+
+      {:ok, lv, _html} = live(ctx.conn, ~p"/agents/#{ctx.agent.id}/edit")
+
+      html =
+        render_submit(lv, "submit", %{
+          "agent" => %{
+            "name" => ctx.agent.name,
+            "runtime" => ctx.agent.runtime,
+            "model" => ctx.agent.model,
+            "environment_id" => ctx.other_env.id
+          }
+        })
+
+      assert html =~ "running a turn"
+      assert Fountain.Agents._unsafe_get_agent(ctx.agent.id).environment_id == ctx.env.id
+    end
+  end
+end

--- a/decisions/0023-persistent-agent-sandbox.md
+++ b/decisions/0023-persistent-agent-sandbox.md
@@ -94,9 +94,25 @@ Shipped as seven gates, one PR each, in dependency order:
   `--sandbox`, and `sandboxMode` / `sandboxId` in `session/new` `_meta`),
   the Buzz identity's `sandbox_mode`, and the `fountain` skill through
   `FOUNTAIN_SANDBOX_ID`. Channel resume takes the agent's default, as the
-  step says. The conversations app shows no "home" badge and there is no
-  "reset home" action; `GET /api/sandboxes/:id` is the sandbox's detail, and
-  deleting the agent is the reset.
+  step says. The conversations app shows no "home" badge;
+  `GET /api/sandboxes/:id` is the sandbox's detail, and the on-demand reset
+  the step-5 table names is `DELETE /api/sandboxes/:id` plus
+  `fountain sandbox reset` (#1077).
+- The step-5 table's "vault or env changed" row was half-built until #1084:
+  deleting the agent destroyed its homes (#1068), but moving the agent's
+  `environment_id`, or deleting the environment or vault the key names, left
+  the home `ready` under an identity nothing looks up. All three now retire
+  the affected homes through the same path as the on-demand reset, with the
+  cause on each transcript and in the audit row
+  (`environment_changed` / `environment_deleted` / `vault_deleted`), and are
+  refused with `sandbox_mid_turn` while a conversation on one runs a turn.
+  The two deletion doors were worse than an orphan: `sandboxes.environment_id`
+  and `sandboxes.vault_id` are `ON DELETE SET NULL`, so a home left behind
+  became the *no environment* or *no vault* home for its identity — the next
+  launch that named neither landed on a disk still holding the deleted
+  secrets — or collided with `sandboxes_home_identity_index` and failed the
+  delete with a constraint error. Retiring the homes before the row goes is
+  the same ordering `delete_agent/2` already used.
 
 **Gate 7, run 2026-08-24 against production** (server `sha-94b6022f`,
 Sprites, a throwaway `claude` agent on haiku with no environment or vault):

--- a/docs/api.md
+++ b/docs/api.md
@@ -520,6 +520,15 @@ An ephemeral sandbox, or one that is already `terminated` or `failed`, gets
 `422 sandbox_not_resettable`. While a conversation on the sandbox runs a
 turn, the request gets `409 sandbox_mid_turn`.
 
+Three other requests retire a persistent sandbox, because each one moves the
+identity that the sandbox belongs to. A `PATCH /api/agents/:id` with a new
+`environment_id` retires the sandboxes built on the old environment. A
+`DELETE` on `/api/environments/:id` or on `/api/vaults/:id` retires the
+sandboxes built on that environment or that vault. Each request behaves like
+a reset. Fountain destroys the machine, keeps the conversations, and builds a
+new machine on the next prompt. A request also gets `409 sandbox_mid_turn`
+while a conversation on one of those sandboxes runs a turn.
+
 ## Search
 
 This is full-text search across the caller's conversations. A command palette

--- a/docs/concepts/sandboxes.md
+++ b/docs/concepts/sandboxes.md
@@ -38,6 +38,14 @@ agent, Fountain destroys the machine. A reset (`DELETE /api/sandboxes/:id`)
 also destroys the machine, and keeps the conversations. The next prompt builds
 a clean one.
 
+The machine belongs to one identity. Three changes move that identity. You
+move the agent to a different environment. You delete the environment. You
+delete the vault. Fountain retires the machine for each of them, and keeps the
+conversations, so the next prompt builds a machine on the identity that exists
+now. Fountain refuses each change with `409 sandbox_mid_turn` while a
+conversation on that machine runs a turn. Let the turn end, or stop it, then
+send the request again.
+
 When a home parks, Fountain can take a checkpoint of its disk. The operator
 turns this on with `CHECKPOINT_CREATION_ENABLED`, and only a provider with
 checkpoints (Sprites) does it. The checkpoint belongs to that one machine.

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -10,6 +10,19 @@ server releases.
 
 ---
 
+## [0.1.12] — 2026-08-24
+
+### Changed
+
+- `PATCH /api/agents/{id}`, `DELETE /api/environments/{id}` and
+  `DELETE /api/vaults/{id}` now carry a `409` response in the generated
+  types. Each of those requests can move a persistent home's identity key,
+  so the server retires the machine and refuses the request while a
+  conversation on it runs a turn (#1084). `FountainError` already maps 409
+  to `conflict`; the error body's `error` is `sandbox_mid_turn`.
+
+---
+
 ## [0.1.11] — 2026-08-24
 
 ### Added

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Run a coding agent on a real computer, with your repos and your credentials, in one call.",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -1932,7 +1932,7 @@ export interface paths {
         get: operations["FountainWeb.AgentController.show"];
         /**
          * Update an agent (partial)
-         * @description Every field is optional; the server merges into the existing record.
+         * @description Every field is optional; the server merges into the existing record. Moving `environment_id` retires the agent's persistent sandboxes built on the old environment, so the update is refused with `409 sandbox_mid_turn` while a conversation on one of them is running a turn.
          */
         put: operations["FountainWeb.AgentController.update"];
         post?: never;
@@ -1942,7 +1942,7 @@ export interface paths {
         head?: never;
         /**
          * Update an agent (partial)
-         * @description Every field is optional; the server merges into the existing record.
+         * @description Every field is optional; the server merges into the existing record. Moving `environment_id` retires the agent's persistent sandboxes built on the old environment, so the update is refused with `409 sandbox_mid_turn` while a conversation on one of them is running a turn.
          */
         patch: operations["FountainWeb.AgentController.update (2)"];
         trace?: never;
@@ -4202,6 +4202,15 @@ export interface operations {
             };
             /** @description Not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description An agent is mid-turn on a persistent sandbox built on this environment */
+            409: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -8832,6 +8841,15 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description An agent is mid-turn on a persistent sandbox built on this vault */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
         };
     };
     "FountainWeb.VaultController.update (2)": {
@@ -8996,6 +9014,15 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description An agent is mid-turn on a persistent sandbox the change retires */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Validation error */
             422: {
                 headers: {
@@ -9063,6 +9090,15 @@ export interface operations {
             };
             /** @description Not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description An agent is mid-turn on a persistent sandbox the change retires */
+            409: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/sdk/typescript/src/http.ts
+++ b/sdk/typescript/src/http.ts
@@ -19,7 +19,7 @@ export interface RequestOptions {
  * this string is already what Fountain's request logs are keyed on. The
  * version half is asserted against `package.json` by a test.
  */
-export const USER_AGENT = "fountain-sdk-js/0.1.11";
+export const USER_AGENT = "fountain-sdk-js/0.1.12";
 
 /**
  * The thin layer everything else is built on: one bearer token, JSON in and


### PR DESCRIPTION
## Summary

A persistent sandbox is keyed on `(user, agent, environment, vault)`. Three changes moved that key and left the machine `ready` under an identity nothing looks up — holding a concurrency slot and a disk carrying the old environment's or vault's secrets. ADR 0023 step 5 names *"agent deleted / vault or env changed"* as one row (destroy the home); only the agent-delete half was built (#1068).

All three now retire the affected homes through `reset_sandbox/2`, the same path `DELETE /api/sandboxes/:id` uses (#1077): machine destroyed, conversations kept and told the cause, next prompt builds on the identity that exists now.

| door | reason recorded |
|---|---|
| `PATCH /api/agents/:id` moving `environment_id` | `environment_changed` |
| `DELETE /api/environments/:id` | `environment_deleted` |
| `DELETE /api/vaults/:id` | `vault_deleted` |

Each is refused with `409 sandbox_mid_turn` while a conversation on an affected machine runs a turn, checked **before** anything is written, so the refusal costs nothing. Audited as `sandbox.reset` with the reason in the metadata.

## The two deletion doors were worse than an orphan

Found while building this, and confirmed against the test DB before writing the fix. `sandboxes.vault_id` and `sandboxes.environment_id` are `ON DELETE SET NULL`, so a home left behind either:

1. **became the *no-vault* / *no-environment* home for its identity** — the next launch that named neither landed on a disk still holding the deleted secrets; or
2. **collided with `sandboxes_home_identity_index`** (`NULLS NOT DISTINCT`) where such a home already existed, raising `Ecto.ConstraintError` — an unhandled 500, and the owner could not delete their vault at all.

Both are covered by tests. The homes are retired while the pointer still names them, the ordering `delete_agent/2` already used.

## Call sites

Five hard-matched `{:ok, _}` on the deletes and would have answered a refusal with a 500 or a dead LiveView. Each now flashes or falls through to the fallback controller's existing 409 handler: both index LiveViews, both API controllers, the agent form, the versions rollback, `fountain apply` (manifest), and the Buzz identity delete (which logs and keeps the vault rather than failing the request).

The CLI needed no change — it already prefers the server's `message`, same as `fountain sandbox reset`.

## Test plan

- [x] `orphaned_home_test.exs` (20) — retire/keep semantics, transcript reason per cause, the no-op cases (unchanged env, ephemeral sandbox, home already on the new env), mid-turn refusal writes nothing, invalid changeset still beats the mid-turn check, both nilify hazards, provider-error still retires, audit reason
- [x] `orphaned_home_door_test.exs` (11) — 200/204/409 on all three API doors, and the console's LiveView flashes
- [x] **Reverted the fix and re-ran**: 14/20 and 2/11 fail, surfacing the exact `MatchError` and `ConstraintError`. The tests catch the bug, not themselves.
- [x] Full suite: **4145 tests, 0 failures**
- [x] `credo --strict`, `dialyzer`, `sobelow --config`, `format --check`, `deps.unlock --unused`
- [x] `vale lint docs` (0 errors), `python3 scripts/docs-style.py`, `docs_test.exs`, `okf validate decisions`
- [x] SDK regenerated with CI's flags (`--vendor-extensions=false`) — identical output; typecheck + 72 tests pass

## Notes

- **SDK 0.1.12** — merging publishes it. Type-only: the `409` now appears on the three operations.
- ADR 0023's Outcome section gains the step-5 row's status, and a stale line claiming there is no reset action (#1077 built one) is corrected.
- `mise` is not installed on this workstation, so `mix format` ran under Elixir 1.19.5 rather than the pinned 1.19.2. The touched code is plain, but if CI's format gate disagrees, its hunks win.

Closes #1084

🤖 Generated with [Claude Code](https://claude.com/claude-code)