### PR TITLE
feat(credits): the ledger, the balance cache and the price card (#1086 phase 2, step 1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -280,6 +280,18 @@ STRIPE_PRICE_MONTHLY_CENTS=
 # AGENTMAIL_MESSAGE_CENTS=0.2
 # AGENTPHONE_MESSAGE_CENTS=2
 
+# Prepaid credits (ADR 0030): what the customer pays, in whole cents. Distinct
+# from the provider costs above. The turn-hour price defaults to 25 and is a
+# placeholder until a provider invoice has been reconciled. The four comms
+# prices default to unset, and unset burns nothing: turning one on is a price
+# increase. Packs are the amounts a tenant can buy, ascending.
+# CREDIT_TURN_HOUR_CENTS=25
+# CREDIT_NUMBER_CENTS=
+# CREDIT_INBOX_CENTS=
+# CREDIT_EMAIL_MESSAGE_CENTS=
+# CREDIT_SMS_MESSAGE_CENTS=
+# CREDIT_PACKS_CENTS=1000,2500,10000
+
 # The plan an account with no plan of its own gets — every account on a
 # self-hosted instance. `scale` lifts the concurrency cap for everyone at
 # once, which is usually what a self-hoster paying their own provider bill

--- a/apps/fountain/lib/fountain/accounts/user.ex
+++ b/apps/fountain/lib/fountain/accounts/user.ex
@@ -36,6 +36,10 @@ defmodule Fountain.Accounts.User do
     # `comped` subscription_status, which makes everything free: this is the
     # tenant who pays for their tier and holds a number Fountain eats.
     field :comped_contacts, :integer, default: 0
+    # Cached sum of `credit_ledger` (ADR 0030). Written only by
+    # `Fountain.Credits`, in the same transaction as the ledger row; never
+    # cast from user input.
+    field :credit_balance_cents, :integer, default: 0
     field :role, :string, default: "user"
     field :stripe_customer_id, :string
     # The subscription of record. Webhook sync applies events for this

--- a/apps/fountain/priv/repo/migrations/20260824100000_create_credit_ledger.exs
+++ b/apps/fountain/priv/repo/migrations/20260824100000_create_credit_ledger.exs
@@ -1,0 +1,37 @@
+defmodule Fountain.Repo.Migrations.CreateCreditLedger do
+  use Ecto.Migration
+
+  # ADR 0030 phase 2, step 1. The ledger is append-only and every row carries a
+  # signed amount in cents; `users.credit_balance_cents` caches the sum so a
+  # gate never sums the ledger. Additive and inert: nothing writes a row until
+  # the pricing and grant workers land, and nothing reads the balance to
+  # refuse anything until phase 4.
+  def change do
+    create table(:credit_ledger, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :user_id, references(:users, type: :binary_id, on_delete: :delete_all), null: false
+      add :amount_cents, :integer, null: false
+      add :reason, :string, null: false
+      add :resource_type, :string
+      add :resource_id, :string
+      # One row per fact. A worker that prices the same turn twice, a webhook
+      # Stripe delivers twice, an expiry sweep that restarts: all collapse
+      # onto this key instead of onto the customer's balance.
+      add :idempotency_key, :string, null: false
+      # Set on a grant that stops being spendable at a point in time (the
+      # monthly tier grant, the trial's opening grant). Nil on money the
+      # customer paid for, which never expires.
+      add :expires_at, :utc_datetime
+      add :metadata, :map, null: false, default: %{}
+      add :inserted_at, :utc_datetime, null: false
+    end
+
+    create unique_index(:credit_ledger, [:idempotency_key])
+    create index(:credit_ledger, [:user_id, :inserted_at])
+    create index(:credit_ledger, [:expires_at], where: "expires_at IS NOT NULL")
+
+    alter table(:users) do
+      add :credit_balance_cents, :integer, null: false, default: 0
+    end
+  end
+end

--- a/apps/fountain/test/fountain/audit_guardrail_test.exs
+++ b/apps/fountain/test/fountain/audit_guardrail_test.exs
@@ -105,7 +105,11 @@ defmodule Fountain.AuditGuardrailTest do
     {"webhook endpoint delete", &__MODULE__.do_webhook_delete/1, "webhook_endpoint.deleted"},
     {"webhook secret rotate", &__MODULE__.do_webhook_rotate/1, "webhook_endpoint.secret_rotated"},
     {"webhook endpoint disable", &__MODULE__.do_webhook_disable/1, "webhook_endpoint.disabled"},
-    {"webhook endpoint enable", &__MODULE__.do_webhook_enable/1, "webhook_endpoint.enabled"}
+    {"webhook endpoint enable", &__MODULE__.do_webhook_enable/1, "webhook_endpoint.enabled"},
+    # Prepaid credits (ADR 0030). Money in and money out are the two shapes;
+    # every reason family maps onto one of five `credit.*` actions.
+    {"credit grant", &__MODULE__.do_credit_grant/1, "credit.granted"},
+    {"credit debit", &__MODULE__.do_credit_debit/1, "credit.burned"}
   ]
 
   # Documented non-coverage. Mirrors the `Fountain.Audit` moduledoc; if the two
@@ -551,4 +555,14 @@ defmodule Fountain.AuditGuardrailTest do
   end
 
   def do_verify_email(user), do: {:ok, _} = Fountain.Accounts.verify_email(user)
+
+  def do_credit_grant(user) do
+    {:ok, _} =
+      Fountain.Credits.grant(user.id, 100, "grant_admin", idempotency_key: "guard-#{user.id}")
+  end
+
+  def do_credit_debit(user) do
+    {:ok, _} =
+      Fountain.Credits.debit(user.id, 1, "burn_turn", idempotency_key: "guard-b-#{user.id}")
+  end
 end

--- a/config/config.exs
+++ b/config/config.exs
@@ -59,6 +59,17 @@ config :fountain,
   # the suite covers the pitch and flips it off per-test. See Fountain.Marketing.
   marketing_site: false
 
+# Prepaid credits (ADR 0030). Cents. `turn_hour_cents` is the customer price
+# of one hour of turn time; the comms prices are nil until an operator sets
+# them, and nil burns nothing (#1042). runtime.exs overrides from CREDIT_*.
+config :fountain, :credits,
+  turn_hour_cents: 25,
+  number_cents: nil,
+  inbox_cents: nil,
+  email_message_cents: nil,
+  sms_message_cents: nil,
+  packs_cents: [1_000, 2_500, 10_000]
+
 # Sandbox lifetime bounds. Crossing the idle bound SUSPENDS the sandbox — the
 # sprite stays (scaled to zero) and the next prompt resumes the agent with its
 # memory intact, so this bound is free to be aggressive. The max-lifetime

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -743,6 +743,50 @@ config :fountain, :agentphone_number_cents, contact_rate.("AGENTPHONE_NUMBER_CEN
 config :fountain, :agentmail_message_cents, contact_rate.("AGENTMAIL_MESSAGE_CENTS")
 config :fountain, :agentphone_message_cents, contact_rate.("AGENTPHONE_MESSAGE_CENTS")
 
+# Prepaid credits (ADR 0030): what the *customer* pays, in whole cents, as
+# distinct from the provider costs above. CREDIT_TURN_HOUR_CENTS is one hour
+# of turn time (default 25, a placeholder until #1038 gives a cost number).
+# The four comms prices default to unset, and unset burns nothing: contacts
+# bill nothing today and turning a price on is a price increase (#1042).
+# CREDIT_PACKS_CENTS lists the packs a tenant can buy, e.g. "1000,2500,10000".
+credit_cents = fn var ->
+  case System.get_env(var) do
+    value when value in [nil, ""] ->
+      nil
+
+    value ->
+      case Integer.parse(String.trim(value)) do
+        {cents, ""} when cents >= 0 -> cents
+        _ -> raise "#{var} must be a whole number of cents, 0 or more, got #{inspect(value)}"
+      end
+  end
+end
+
+credit_packs =
+  case System.get_env("CREDIT_PACKS_CENTS") do
+    value when value in [nil, ""] ->
+      [1_000, 2_500, 10_000]
+
+    value ->
+      value
+      |> String.split(",", trim: true)
+      |> Enum.map(fn cents ->
+        case Integer.parse(String.trim(cents)) do
+          {n, ""} when n > 0 -> n
+          _ -> raise "CREDIT_PACKS_CENTS: #{inspect(cents)} is not a positive number of cents"
+        end
+      end)
+      |> Enum.sort()
+  end
+
+config :fountain, :credits,
+  turn_hour_cents: credit_cents.("CREDIT_TURN_HOUR_CENTS") || 25,
+  number_cents: credit_cents.("CREDIT_NUMBER_CENTS"),
+  inbox_cents: credit_cents.("CREDIT_INBOX_CENTS"),
+  email_message_cents: credit_cents.("CREDIT_EMAIL_MESSAGE_CENTS"),
+  sms_message_cents: credit_cents.("CREDIT_SMS_MESSAGE_CENTS"),
+  packs_cents: credit_packs
+
 # Mail delivery.
 #
 # With no adapter configured this used to silently fall back to

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -131,6 +131,12 @@ at a dead end, with no error to see. Read [Email](guides/operate/email.md).
 | `AGENTPHONE_NUMBER_CENTS` | — | No. | What AgentPhone charges for one number each month, in cents. |
 | `AGENTMAIL_MESSAGE_CENTS` | — | No. | What AgentMail charges for one email, in cents. Give the fraction, such as `0.2` for $2 per 1,000 emails. A whole number rounds this rate to zero. |
 | `AGENTPHONE_MESSAGE_CENTS` | — | No. | What AgentPhone charges for one SMS, in cents. Fountain counts an inbound message too, because AgentPhone charges for it. |
+| `CREDIT_TURN_HOUR_CENTS` | `25` | No. | What a tenant pays for one hour of turn time, in whole cents, from their prepaid balance. |
+| `CREDIT_NUMBER_CENTS` | — | No. | What a tenant pays for one phone number each month, in whole cents. Unset means the number burns nothing. |
+| `CREDIT_INBOX_CENTS` | — | No. | What a tenant pays for one inbox each month, in whole cents. Unset means the inbox burns nothing. |
+| `CREDIT_EMAIL_MESSAGE_CENTS` | — | No. | What a tenant pays for one email, in whole cents. Unset means an email burns nothing. |
+| `CREDIT_SMS_MESSAGE_CENTS` | — | No. | What a tenant pays for one SMS, sent or received, in whole cents. Unset means an SMS burns nothing. |
+| `CREDIT_PACKS_CENTS` | `1000,2500,10000` | No. | The credit packs a tenant can buy, in cents, as a list. |
 
 <!-- vale STE.IngForms = YES -->
 

--- a/ee/lib/fountain/credits.ex
+++ b/ee/lib/fountain/credits.ex
@@ -1,0 +1,347 @@
+defmodule Fountain.Credits do
+  @moduledoc """
+  The prepaid credit ledger (ADR 0030).
+
+  A tenant's balance is a number of **cents**, cached on
+  `users.credit_balance_cents` and backed by the append-only `credit_ledger`.
+  Money comes in as a grant (the tier's monthly allowance, the trial's opening
+  grant, an operator's comp) or a purchase, and goes out as a burn (turn
+  hours, rent, messages), an expiry, or a clawback after a refund or dispute.
+
+  Three properties every writer relies on:
+
+    * **Idempotent.** Every row carries a unique `idempotency_key`. Posting the
+      same key twice returns the original row and writes nothing, so a worker
+      can re-price a turn, a webhook can arrive twice, and a sweep can restart
+      without touching the balance.
+    * **The cache is the balance.** The row and the `UPDATE users SET
+      credit_balance_cents = credit_balance_cents + amount` land in one
+      transaction; a gate reads the column and never sums the ledger.
+      `recompute_balance/1` exists for reconciliation, not for reads.
+    * **Short-circuit before the ledger.** `check_balance/1` answers `:ok` for
+      a deployment with billing off and for a comped tenant *before* reading
+      the balance, so a self-hosted install and a comp never brick at zero
+      (the `turn_hour_allowance/2` trialing-defaults failure class, ADR 0030
+      decision 7).
+
+  ## What is built
+
+  This module: post, grant, debit, balance, check_balance, list, recompute,
+  and the price card. **Nothing calls `check_balance/1` to refuse anything
+  yet** — that is #1086 phase 4 — and nothing writes burn rows until the
+  pricing workers land (phase 2, steps 2 and 3). The ledger exists so that
+  they have somewhere to write.
+
+  ## Audit
+
+  Every posted row leaves one `credit.*` event: `credit.granted`,
+  `credit.purchased`, `credit.burned`, `credit.expired`, `credit.clawed_back`.
+  Metadata carries the amount, reason and resource reference — cents are not
+  tenant data — never a balance, which is derivable and would go stale.
+  """
+
+  import Ecto.Query
+
+  alias Ecto.Multi
+  alias Fountain.Accounts.User
+  alias Fountain.Audit
+  alias Fountain.Billing
+  alias Fountain.Credits.LedgerEntry
+  alias Fountain.Repo
+
+  require Logger
+
+  @type post_result ::
+          {:ok, LedgerEntry.t()} | {:ok, :duplicate, LedgerEntry.t()} | {:error, term()}
+
+  # ---------------------------------------------------------------------------
+  # Prices
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  The customer price card, in cents. `:turn_hour` is what one hour of
+  `turn_seconds` burns (ADR 0030 decision 3; the number is a placeholder until
+  #1038 produces a provider cost). The four comms prices are `nil` until an
+  operator sets them, and a `nil` price burns nothing — turning one on is a
+  price increase and an explicit act (#1042).
+
+  Read from `config :fountain, :credits`; runtime.exs fills it from
+  `CREDIT_TURN_HOUR_CENTS`, `CREDIT_NUMBER_CENTS`, `CREDIT_INBOX_CENTS`,
+  `CREDIT_EMAIL_MESSAGE_CENTS` and `CREDIT_SMS_MESSAGE_CENTS`.
+  """
+  @spec price_card() :: %{
+          turn_hour: non_neg_integer(),
+          number_month: non_neg_integer() | nil,
+          inbox_month: non_neg_integer() | nil,
+          email_message: non_neg_integer() | nil,
+          sms_message: non_neg_integer() | nil
+        }
+  def price_card do
+    cfg = Application.get_env(:fountain, :credits, [])
+
+    %{
+      turn_hour: Keyword.get(cfg, :turn_hour_cents, 25),
+      number_month: Keyword.get(cfg, :number_cents),
+      inbox_month: Keyword.get(cfg, :inbox_cents),
+      email_message: Keyword.get(cfg, :email_message_cents),
+      sms_message: Keyword.get(cfg, :sms_message_cents)
+    }
+  end
+
+  @doc """
+  The credit packs a tenant can buy, in cents, ascending. Default
+  $10 / $25 / $100 (`CREDIT_PACKS_CENTS="1000,2500,10000"`).
+  """
+  @spec packs() :: [pos_integer()]
+  def packs do
+    Application.get_env(:fountain, :credits, [])
+    |> Keyword.get(:packs_cents, [1_000, 2_500, 10_000])
+  end
+
+  @doc """
+  Cents that `turn_seconds` of conversation time burns, rounded to the
+  nearest cent. Integer arithmetic on purpose: a ledger of fractional cents
+  is a ledger nobody can reconcile.
+  """
+  @spec turn_cost_cents(non_neg_integer()) :: non_neg_integer()
+  def turn_cost_cents(turn_seconds) when is_integer(turn_seconds) and turn_seconds >= 0 do
+    div(turn_seconds * price_card().turn_hour + 1_800, 3_600)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Reads
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  The tenant's balance in cents, from the cache. Negative is possible: an
+  in-flight turn that crosses zero finishes and lands as debt (ADR 0030
+  decision 6), and a clawback after a refund can take a spent balance below
+  zero.
+  """
+  @spec balance(User.t() | binary()) :: integer()
+  def balance(%User{credit_balance_cents: cents}) when is_integer(cents), do: cents
+
+  def balance(user_id) when is_binary(user_id) do
+    from(u in User, where: u.id == ^user_id, select: u.credit_balance_cents)
+    |> Repo.one()
+    |> Kernel.||(0)
+  end
+
+  @doc """
+  Whether the tenant may spend. `:ok` when billing is off or the account is
+  comped, before any balance read; `:ok` when the cached balance is positive;
+  `{:error, :insufficient_credits}` otherwise.
+
+  Nothing calls this to refuse anything yet (#1086 phase 4).
+  """
+  @spec check_balance(User.t() | binary()) :: :ok | {:error, :insufficient_credits}
+  def check_balance(subject) do
+    cond do
+      not Billing.enabled?() -> :ok
+      comped?(subject) -> :ok
+      balance(subject) > 0 -> :ok
+      true -> {:error, :insufficient_credits}
+    end
+  end
+
+  defp comped?(%User{subscription_status: status}), do: status == "comped"
+
+  defp comped?(user_id) when is_binary(user_id) do
+    from(u in User, where: u.id == ^user_id, select: u.subscription_status)
+    |> Repo.one() == "comped"
+  end
+
+  @doc "The ledger for one tenant, newest first. `:limit` defaults to 100."
+  @spec list_entries(binary(), keyword()) :: [LedgerEntry.t()]
+  def list_entries(user_id, opts \\ []) when is_binary(user_id) do
+    limit = Keyword.get(opts, :limit, 100)
+
+    from(e in LedgerEntry,
+      where: e.user_id == ^user_id,
+      order_by: [desc: e.inserted_at, desc: e.id],
+      limit: ^limit
+    )
+    |> Repo.all()
+  end
+
+  @doc "One entry by idempotency key, or nil."
+  @spec get_by_key(String.t()) :: LedgerEntry.t() | nil
+  def get_by_key(key) when is_binary(key), do: Repo.get_by(LedgerEntry, idempotency_key: key)
+
+  @doc """
+  Sum the ledger for one tenant and write it to the cache. For reconciliation
+  (a release task, a test); never on a request path. Returns the recomputed
+  balance.
+  """
+  @spec recompute_balance(binary()) :: integer()
+  def recompute_balance(user_id) when is_binary(user_id) do
+    total =
+      from(e in LedgerEntry,
+        where: e.user_id == ^user_id,
+        select: coalesce(sum(e.amount_cents), 0)
+      )
+      |> Repo.one()
+
+    from(u in User, where: u.id == ^user_id)
+    |> Repo.update_all(set: [credit_balance_cents: total])
+
+    total
+  end
+
+  @doc """
+  Tenants whose cached balance disagrees with their ledger — `[{user_id,
+  cached, actual}]`. Empty is the invariant.
+  """
+  @spec drift() :: [{binary(), integer(), integer()}]
+  def drift do
+    from(u in User,
+      left_join: e in LedgerEntry,
+      on: e.user_id == u.id,
+      group_by: u.id,
+      having: u.credit_balance_cents != coalesce(sum(e.amount_cents), 0),
+      select: {u.id, u.credit_balance_cents, coalesce(sum(e.amount_cents), 0)}
+    )
+    |> Repo.all()
+  end
+
+  # ---------------------------------------------------------------------------
+  # Writes
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Put money in. `reason` is one of `LedgerEntry.credit_reasons/0`; `cents` is
+  positive.
+
+  Options: `:idempotency_key` (required), `:expires_at` (a grant that stops
+  being spendable), `:resource_type` / `:resource_id`, `:metadata`, and the
+  usual audit attribution (`:actor`, `:request_ip`).
+  """
+  @spec grant(binary(), pos_integer(), String.t(), keyword()) :: post_result()
+  def grant(user_id, cents, reason, opts) when is_integer(cents) and cents > 0 do
+    post(user_id, cents, reason, opts)
+  end
+
+  @doc """
+  Take money out. `reason` is one of `LedgerEntry.debit_reasons/0`; `cents` is
+  positive and is stored negated. A debit may drive the balance below zero;
+  refusing to spend is the gate's job, not the ledger's.
+  """
+  @spec debit(binary(), pos_integer(), String.t(), keyword()) :: post_result()
+  def debit(user_id, cents, reason, opts) when is_integer(cents) and cents > 0 do
+    post(user_id, -cents, reason, opts)
+  end
+
+  @doc """
+  Post one signed row and move the cached balance by the same amount, in one
+  transaction. Returns `{:ok, entry}`, `{:ok, :duplicate, entry}` when the
+  idempotency key was already posted (nothing written), or an error.
+
+  Prefer `grant/4` and `debit/4`, which fix the sign.
+  """
+  @spec post(binary(), integer(), String.t(), keyword()) :: post_result()
+  def post(user_id, amount_cents, reason, opts)
+      when is_binary(user_id) and is_integer(amount_cents) do
+    key = Keyword.fetch!(opts, :idempotency_key)
+
+    attrs = %{
+      user_id: user_id,
+      amount_cents: amount_cents,
+      reason: reason,
+      idempotency_key: key,
+      resource_type: Keyword.get(opts, :resource_type),
+      resource_id: Keyword.get(opts, :resource_id),
+      expires_at: Keyword.get(opts, :expires_at),
+      metadata: Keyword.get(opts, :metadata, %{})
+    }
+
+    changeset = LedgerEntry.changeset(%LedgerEntry{}, attrs)
+
+    if changeset.valid? do
+      changeset |> insert_and_move() |> audited(opts)
+    else
+      {:error, changeset}
+    end
+  end
+
+  # The unique index is the idempotency guard, and the duplicate is detected
+  # *after* attempting the insert rather than by a lookup first: two workers
+  # posting the same key at once must not both see "absent" and both move the
+  # balance. A duplicate aborts the transaction, so the balance is untouched.
+  defp insert_and_move(changeset) do
+    key = Ecto.Changeset.get_field(changeset, :idempotency_key)
+    user_id = Ecto.Changeset.get_field(changeset, :user_id)
+    amount = Ecto.Changeset.get_field(changeset, :amount_cents)
+
+    Multi.new()
+    |> Multi.insert(:entry, changeset)
+    |> Multi.update_all(
+      :balance,
+      from(u in User, where: u.id == ^user_id),
+      inc: [credit_balance_cents: amount]
+    )
+    |> Repo.transaction()
+    |> case do
+      {:ok, %{entry: entry, balance: {1, _}}} ->
+        {:ok, entry}
+
+      {:ok, %{balance: {0, _}}} ->
+        # Cannot happen while the FK holds, but a ledger row without a user
+        # row to carry its balance would be a silent drift.
+        {:error, :user_not_found}
+
+      {:error, :entry, %Ecto.Changeset{errors: errors} = cs, _} ->
+        if Keyword.has_key?(errors, :idempotency_key) do
+          case get_by_key(key) do
+            nil -> {:error, cs}
+            existing -> {:ok, :duplicate, existing}
+          end
+        else
+          {:error, cs}
+        end
+
+      {:error, _step, reason, _} ->
+        {:error, reason}
+    end
+  end
+
+  # Recorded outside the transaction (ADR 0013): a best-effort audit write
+  # inside it would take the ledger row down with it.
+  defp audited({:ok, %LedgerEntry{} = entry} = ok, opts) do
+    Audit.record(%{
+      user_id: entry.user_id,
+      action: audit_action(entry.reason),
+      resource_type: "credit_ledger",
+      resource_id: entry.id,
+      actor: Keyword.get(opts, :actor, "self"),
+      request_ip: Keyword.get(opts, :request_ip),
+      metadata:
+        %{
+          "amount_cents" => entry.amount_cents,
+          "reason" => entry.reason,
+          "target_type" => entry.resource_type,
+          "target_id" => entry.resource_id
+        }
+        |> Map.reject(fn {_, v} -> is_nil(v) end)
+    })
+
+    ok
+  end
+
+  defp audited(other, _opts), do: other
+
+  defp audit_action("purchase"), do: "credit.purchased"
+  defp audit_action("grant_" <> _), do: "credit.granted"
+  defp audit_action("burn_" <> _), do: "credit.burned"
+  defp audit_action("expire"), do: "credit.expired"
+  defp audit_action("clawback_" <> _), do: "credit.clawed_back"
+
+  @doc ~S|Cents as a dollar string for display: `1240` → `"$12.40"`, `-5` → `"-$0.05"`.|
+  @spec format_cents(integer()) :: String.t()
+  def format_cents(cents) when is_integer(cents) do
+    sign = if cents < 0, do: "-", else: ""
+    abs = abs(cents)
+    dollars = div(abs, 100)
+    rem = rem(abs, 100)
+    "#{sign}$#{dollars}.#{String.pad_leading(Integer.to_string(rem), 2, "0")}"
+  end
+end

--- a/ee/lib/fountain/credits.ex
+++ b/ee/lib/fountain/credits.ex
@@ -42,7 +42,6 @@ defmodule Fountain.Credits do
 
   import Ecto.Query
 
-  alias Ecto.Multi
   alias Fountain.Accounts.User
   alias Fountain.Audit
   alias Fountain.Billing
@@ -272,24 +271,25 @@ defmodule Fountain.Credits do
     user_id = Ecto.Changeset.get_field(changeset, :user_id)
     amount = Ecto.Changeset.get_field(changeset, :amount_cents)
 
-    Multi.new()
-    |> Multi.insert(:entry, changeset)
-    |> Multi.update_all(
-      :balance,
-      from(u in User, where: u.id == ^user_id),
-      inc: [credit_balance_cents: amount]
-    )
-    |> Repo.transaction()
-    |> case do
-      {:ok, %{entry: entry, balance: {1, _}}} ->
-        {:ok, entry}
-
-      {:ok, %{balance: {0, _}}} ->
+    Repo.transaction(fn ->
+      with {:ok, entry} <- Repo.insert(changeset),
+           {1, _} <-
+             Repo.update_all(from(u in User, where: u.id == ^user_id),
+               inc: [credit_balance_cents: amount]
+             ) do
+        entry
+      else
         # Cannot happen while the FK holds, but a ledger row without a user
         # row to carry its balance would be a silent drift.
-        {:error, :user_not_found}
+        {0, _} -> Repo.rollback(:user_not_found)
+        {:error, %Ecto.Changeset{} = cs} -> Repo.rollback(cs)
+      end
+    end)
+    |> case do
+      {:ok, entry} ->
+        {:ok, entry}
 
-      {:error, :entry, %Ecto.Changeset{errors: errors} = cs, _} ->
+      {:error, %Ecto.Changeset{errors: errors} = cs} ->
         if Keyword.has_key?(errors, :idempotency_key) do
           case get_by_key(key) do
             nil -> {:error, cs}
@@ -299,7 +299,7 @@ defmodule Fountain.Credits do
           {:error, cs}
         end
 
-      {:error, _step, reason, _} ->
+      {:error, reason} ->
         {:error, reason}
     end
   end

--- a/ee/lib/fountain/credits/ledger_entry.ex
+++ b/ee/lib/fountain/credits/ledger_entry.ex
@@ -1,0 +1,85 @@
+defmodule Fountain.Credits.LedgerEntry do
+  @moduledoc """
+  One row of the credit ledger (ADR 0030).
+
+  Append-only. `amount_cents` is signed: positive rows put money in
+  (a grant, a purchase), negative rows take it out (a burn, an expiry, a
+  clawback). `reason` is a closed vocabulary — see `Fountain.Credits` — and
+  `idempotency_key` is unique, which is what makes every writer safe to
+  retry.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @type t :: %__MODULE__{}
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  schema "credit_ledger" do
+    field :amount_cents, :integer
+    field :reason, :string
+    field :resource_type, :string
+    field :resource_id, :string
+    field :idempotency_key, :string
+    field :expires_at, :utc_datetime
+    field :metadata, :map, default: %{}
+    field :inserted_at, :utc_datetime
+
+    belongs_to :user, Fountain.Accounts.User
+  end
+
+  @credit_reasons ~w(grant_tier grant_trial grant_admin purchase)
+  @debit_reasons ~w(burn_turn burn_rent burn_message expire clawback_refund clawback_dispute)
+
+  @doc "Reasons that put money in. Every one is a positive row."
+  def credit_reasons, do: @credit_reasons
+
+  @doc "Reasons that take money out. Every one is a negative row."
+  def debit_reasons, do: @debit_reasons
+
+  def changeset(entry, attrs) do
+    entry
+    |> cast(attrs, [
+      :user_id,
+      :amount_cents,
+      :reason,
+      :resource_type,
+      :resource_id,
+      :idempotency_key,
+      :expires_at,
+      :metadata
+    ])
+    |> validate_required([:user_id, :amount_cents, :reason, :idempotency_key])
+    |> validate_inclusion(:reason, @credit_reasons ++ @debit_reasons)
+    |> validate_sign()
+    |> validate_length(:idempotency_key, max: 255)
+    |> put_change(:inserted_at, DateTime.utc_now() |> DateTime.truncate(:second))
+    |> unique_constraint(:idempotency_key)
+    |> foreign_key_constraint(:user_id)
+  end
+
+  # The sign is implied by the reason, so a caller cannot write a negative
+  # grant or a positive burn by passing the wrong number.
+  defp validate_sign(changeset) do
+    reason = get_field(changeset, :reason)
+    amount = get_field(changeset, :amount_cents)
+
+    cond do
+      is_nil(reason) or is_nil(amount) ->
+        changeset
+
+      amount == 0 ->
+        add_error(changeset, :amount_cents, "must not be zero")
+
+      reason in @credit_reasons and amount < 0 ->
+        add_error(changeset, :amount_cents, "a credit must be positive")
+
+      reason in @debit_reasons and amount > 0 ->
+        add_error(changeset, :amount_cents, "a debit must be negative")
+
+      true ->
+        changeset
+    end
+  end
+end

--- a/ee/test/fountain/credits_test.exs
+++ b/ee/test/fountain/credits_test.exs
@@ -1,0 +1,215 @@
+defmodule Fountain.CreditsTest do
+  @moduledoc """
+  The credit ledger (ADR 0030, #1086 phase 2 step 1).
+
+  What is tested hard: the cache moves with the row and only with the row,
+  posting a key twice writes nothing, the sign follows the reason, and the
+  two short-circuits answer before the balance is read.
+  """
+
+  use Fountain.DataCase, async: true
+
+  alias Fountain.Accounts.User
+  alias Fountain.Audit
+  alias Fountain.Credits
+  alias Fountain.Credits.LedgerEntry
+  alias Fountain.Repo
+
+  defp reload(user), do: Repo.get!(User, user.id)
+
+  describe "grant/4 and debit/4" do
+    test "a grant moves the cached balance by exactly the row" do
+      user = insert_active_user()
+      assert Credits.balance(user) == 0
+
+      assert {:ok, %LedgerEntry{amount_cents: 1000, reason: "grant_tier"}} =
+               Credits.grant(user.id, 1000, "grant_tier", idempotency_key: "t1")
+
+      assert Credits.balance(reload(user)) == 1000
+      assert Credits.balance(user.id) == 1000
+    end
+
+    test "a debit is stored negative and may take the balance below zero" do
+      user = insert_active_user()
+      {:ok, _} = Credits.grant(user.id, 100, "purchase", idempotency_key: "p1")
+
+      assert {:ok, %LedgerEntry{amount_cents: -250}} =
+               Credits.debit(user.id, 250, "burn_turn", idempotency_key: "b1")
+
+      assert Credits.balance(reload(user)) == -150
+    end
+
+    test "posting the same idempotency key twice writes nothing" do
+      user = insert_active_user()
+      {:ok, first} = Credits.grant(user.id, 500, "purchase", idempotency_key: "dup")
+
+      assert {:ok, :duplicate, ^first} =
+               Credits.grant(user.id, 999, "purchase", idempotency_key: "dup")
+
+      assert Credits.balance(reload(user)) == 500
+      assert length(Credits.list_entries(user.id)) == 1
+    end
+
+    test "the sign follows the reason" do
+      user = insert_active_user()
+
+      assert {:error, %Ecto.Changeset{} = cs} =
+               Credits.post(user.id, -5, "grant_tier", idempotency_key: "neg-grant")
+
+      assert "a credit must be positive" in errors_on(cs).amount_cents
+
+      assert {:error, %Ecto.Changeset{} = cs} =
+               Credits.post(user.id, 5, "burn_turn", idempotency_key: "pos-burn")
+
+      assert "a debit must be negative" in errors_on(cs).amount_cents
+
+      assert {:error, %Ecto.Changeset{} = cs} =
+               Credits.post(user.id, 0, "purchase", idempotency_key: "zero")
+
+      assert "must not be zero" in errors_on(cs).amount_cents
+
+      assert {:error, %Ecto.Changeset{}} =
+               Credits.post(user.id, 5, "made_up", idempotency_key: "bad-reason")
+
+      assert Credits.balance(reload(user)) == 0
+    end
+
+    test "a rejected row leaves no audit event, a posted one leaves exactly one" do
+      user = insert_active_user()
+      {:error, _} = Credits.post(user.id, 0, "purchase", idempotency_key: "z")
+
+      assert Audit.list_recent_for_user(user.id, 50) |> Enum.filter(&(&1.action =~ "credit.")) ==
+               []
+
+      {:ok, entry} = Credits.grant(user.id, 1000, "grant_trial", idempotency_key: "g")
+      {:ok, :duplicate, _} = Credits.grant(user.id, 1000, "grant_trial", idempotency_key: "g")
+
+      [event] =
+        Audit.list_recent_for_user(user.id, 50) |> Enum.filter(&(&1.action == "credit.granted"))
+
+      assert event.resource_type == "credit_ledger"
+      assert event.resource_id == entry.id
+      assert event.metadata["amount_cents"] == 1000
+      assert event.metadata["reason"] == "grant_trial"
+      refute Map.has_key?(event.metadata, "balance")
+    end
+
+    test "each reason family has its own audit action" do
+      user = insert_active_user()
+      {:ok, _} = Credits.grant(user.id, 10, "purchase", idempotency_key: "a1")
+      {:ok, _} = Credits.debit(user.id, 1, "burn_rent", idempotency_key: "a2")
+      {:ok, _} = Credits.debit(user.id, 1, "expire", idempotency_key: "a3")
+      {:ok, _} = Credits.debit(user.id, 1, "clawback_refund", idempotency_key: "a4")
+
+      actions = Audit.list_recent_for_user(user.id, 50) |> Enum.map(& &1.action)
+
+      for a <- ~w(credit.purchased credit.burned credit.expired credit.clawed_back) do
+        assert a in actions
+      end
+    end
+
+    test "a grant can carry an expiry and a resource reference" do
+      user = insert_active_user()
+      at = ~U[2026-09-01 00:00:00Z]
+
+      {:ok, entry} =
+        Credits.grant(user.id, 1000, "grant_tier",
+          idempotency_key: "exp",
+          expires_at: at,
+          resource_type: "billing_period",
+          resource_id: "2026-08"
+        )
+
+      assert entry.expires_at == at
+      assert entry.resource_id == "2026-08"
+    end
+
+    test "concurrent posts of one key move the balance once" do
+      user = insert_active_user()
+
+      results =
+        1..8
+        |> Task.async_stream(
+          fn _ ->
+            Ecto.Adapters.SQL.Sandbox.allow(Repo, self(), self())
+            Credits.grant(user.id, 100, "purchase", idempotency_key: "race")
+          end,
+          max_concurrency: 8
+        )
+        |> Enum.map(fn {:ok, r} -> r end)
+
+      assert Enum.count(results, &match?({:ok, %LedgerEntry{}}, &1)) == 1
+      assert Enum.count(results, &match?({:ok, :duplicate, _}, &1)) == 7
+      assert Credits.balance(reload(user)) == 100
+    end
+  end
+
+  describe "check_balance/1" do
+    test "answers ok with billing off before reading anything" do
+      user = insert_active_user()
+      Application.put_env(:fountain, :billing_enabled, false)
+      on_exit(fn -> Application.put_env(:fountain, :billing_enabled, true) end)
+      assert :ok = Credits.check_balance(user)
+      assert :ok = Credits.check_balance(user.id)
+    end
+
+    test "a comped tenant is never short of credits" do
+      user = insert_active_user()
+      {:ok, user} = Fountain.Billing.comp_account(user)
+      assert user.subscription_status == "comped"
+      assert :ok = Credits.check_balance(user)
+      assert :ok = Credits.check_balance(user.id)
+    end
+
+    test "zero and negative are insufficient, positive is ok" do
+      user = insert_active_user()
+      assert {:error, :insufficient_credits} = Credits.check_balance(user)
+      {:ok, _} = Credits.grant(user.id, 1, "purchase", idempotency_key: "one")
+      assert :ok = Credits.check_balance(user.id)
+      {:ok, _} = Credits.debit(user.id, 2, "burn_turn", idempotency_key: "two")
+      assert {:error, :insufficient_credits} = Credits.check_balance(user.id)
+    end
+  end
+
+  describe "recompute_balance/1 and drift/0" do
+    test "repairs a cache that disagrees with the ledger" do
+      user = insert_active_user()
+      {:ok, _} = Credits.grant(user.id, 300, "purchase", idempotency_key: "r1")
+      {:ok, _} = Credits.debit(user.id, 120, "burn_turn", idempotency_key: "r2")
+
+      Repo.update_all(from(u in User, where: u.id == ^user.id), set: [credit_balance_cents: 999])
+      assert [{id, 999, 180}] = Credits.drift() |> Enum.filter(&(elem(&1, 0) == user.id))
+      assert id == user.id
+
+      assert 180 = Credits.recompute_balance(user.id)
+      assert Credits.balance(reload(user)) == 180
+      refute Enum.any?(Credits.drift(), &(elem(&1, 0) == user.id))
+    end
+  end
+
+  describe "prices" do
+    test "turn cost rounds to the nearest cent at the configured rate" do
+      assert Credits.price_card().turn_hour == 25
+      assert Credits.turn_cost_cents(3600) == 25
+      assert Credits.turn_cost_cents(0) == 0
+      # 72 s at 25c/h = 0.5c, rounds up; 71 s rounds down.
+      assert Credits.turn_cost_cents(72) == 1
+      assert Credits.turn_cost_cents(71) == 0
+      assert Credits.turn_cost_cents(10 * 3600) == 250
+    end
+
+    test "comms prices are unset by default and the packs ascend" do
+      card = Credits.price_card()
+      assert card.number_month == nil and card.inbox_month == nil
+      assert card.email_message == nil and card.sms_message == nil
+      assert Credits.packs() == [1_000, 2_500, 10_000]
+    end
+
+    test "format_cents" do
+      assert Credits.format_cents(1240) == "$12.40"
+      assert Credits.format_cents(5) == "$0.05"
+      assert Credits.format_cents(-150) == "-$1.50"
+      assert Credits.format_cents(0) == "$0.00"
+    end
+  end
+end


### PR DESCRIPTION
First code PR of ADR 0030 (#1086 phase 2). Additive and inert.

**Adds**
- `credit_ledger` migration + `users.credit_balance_cents` cache
- `Fountain.Credits` (ee/): `grant/4`, `debit/4`, `post/4`, `balance/1`, `check_balance/1`, `list_entries/2`, `recompute_balance/1`, `drift/0`, `price_card/0`, `packs/0`, `turn_cost_cents/1`, `format_cents/1`
- `Fountain.Credits.LedgerEntry`: closed reason vocabulary (`grant_tier grant_trial grant_admin purchase` / `burn_turn burn_rent burn_message expire clawback_refund clawback_dispute`); the changeset enforces the sign from the reason
- `config :fountain, :credits` from `CREDIT_TURN_HOUR_CENTS` (default 25), `CREDIT_{NUMBER,INBOX,EMAIL_MESSAGE,SMS_MESSAGE}_CENTS` (default unset = burns nothing, #1042), `CREDIT_PACKS_CENTS`
- audit: `credit.granted / purchased / burned / expired / clawed_back`, recorded outside the transaction; guardrail entries added
- `.env.example` and `docs/configuration.md` rows

**Properties tested** (15 tests): cache moves with the row; duplicate key writes nothing (including 8 concurrent posts of one key → one row, balance moved once); sign follows reason; rejected row leaves no audit event; `check_balance/1` short-circuits on billing-off and comped before any read; `drift/0` + `recompute_balance/1` repair a bad cache; rounding to the nearest cent.

**Not in this PR:** nothing writes burn rows, grants a tier, sells a pack or refuses anything. Next: the turn-pricing worker.

Refs #1086, ADR 0030.

🤖 Generated with [Claude Code](https://claude.com/claude-code)