### PR TITLE
feat(credits): price closed turns and comms messages into the ledger (#1086 phase 2, step 2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -285,6 +285,7 @@ STRIPE_PRICE_MONTHLY_CENTS=
 # placeholder until a provider invoice has been reconciled. The four comms
 # prices default to unset, and unset burns nothing: turning one on is a price
 # increase. Packs are the amounts a tenant can buy, ascending.
+# CREDIT_PRICING_SINCE=2026-09-01T00:00:00Z
 # CREDIT_TURN_HOUR_CENTS=25
 # CREDIT_NUMBER_CENTS=
 # CREDIT_INBOX_CENTS=

--- a/config/config.exs
+++ b/config/config.exs
@@ -41,7 +41,12 @@ config :fountain, Oban,
        # Every minute: the tick for user-defined team schedules. Cheap — one
        # indexed query, usually empty — and a minute is the cron grain the
        # schedules are written in.
-       {"* * * * *", Fountain.Workers.TeamScheduler}
+       {"* * * * *", Fountain.Workers.TeamScheduler},
+       # Every 10 minutes: price closed turns and comms messages into the
+       # credit ledger (ADR 0030). Idempotent per turn and per event, so the
+       # cadence only sets how stale a balance can read. No-ops until
+       # CREDIT_PRICING_SINCE is set.
+       {"*/10 * * * *", Fountain.Workers.CreditPricer}
      ]}
   ]
 
@@ -63,6 +68,9 @@ config :fountain,
 # of one hour of turn time; the comms prices are nil until an operator sets
 # them, and nil burns nothing (#1042). runtime.exs overrides from CREDIT_*.
 config :fountain, :credits,
+  # When set, turns that ended at or after this instant are priced into the
+  # ledger; nil means the pricer no-ops. runtime.exs reads CREDIT_PRICING_SINCE.
+  pricing_since: nil,
   turn_hour_cents: 25,
   number_cents: nil,
   inbox_cents: nil,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -779,7 +779,24 @@ credit_packs =
       |> Enum.sort()
   end
 
+# CREDIT_PRICING_SINCE is the instant burning starts, as ISO 8601
+# ("2026-09-01T00:00:00Z"). Unset, nothing is ever priced into the ledger:
+# the switch exists so a deploy that adds the pricer does not bill every
+# tenant for last week's turns before anyone has a grant (#1086 phase 5).
+credit_pricing_since =
+  case System.get_env("CREDIT_PRICING_SINCE") do
+    value when value in [nil, ""] ->
+      nil
+
+    value ->
+      case DateTime.from_iso8601(String.trim(value)) do
+        {:ok, at, _} -> at
+        _ -> raise "CREDIT_PRICING_SINCE must be an ISO 8601 instant, got #{inspect(value)}"
+      end
+  end
+
 config :fountain, :credits,
+  pricing_since: credit_pricing_since,
   turn_hour_cents: credit_cents.("CREDIT_TURN_HOUR_CENTS") || 25,
   number_cents: credit_cents.("CREDIT_NUMBER_CENTS"),
   inbox_cents: credit_cents.("CREDIT_INBOX_CENTS"),

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -131,7 +131,7 @@ at a dead end, with no error to see. Read [Email](guides/operate/email.md).
 | `AGENTPHONE_NUMBER_CENTS` | — | No. | What AgentPhone charges for one number each month, in cents. |
 | `AGENTMAIL_MESSAGE_CENTS` | — | No. | What AgentMail charges for one email, in cents. Give the fraction, such as `0.2` for $2 per 1,000 emails. A whole number rounds this rate to zero. |
 | `AGENTPHONE_MESSAGE_CENTS` | — | No. | What AgentPhone charges for one SMS, in cents. Fountain counts an inbound message too, because AgentPhone charges for it. |
-| `CREDIT_PRICING_SINCE` | — | No. | The instant from which Fountain prices turns and messages into the prepaid ledger, as ISO 8601. Unset means nothing is priced. |
+| `CREDIT_PRICING_SINCE` | — | No. | The instant from which Fountain prices turns and messages into the prepaid ledger, as ISO 8601. Unset, Fountain prices nothing. |
 | `CREDIT_TURN_HOUR_CENTS` | `25` | No. | What a tenant pays for one hour of turn time, in whole cents, from their prepaid balance. |
 | `CREDIT_NUMBER_CENTS` | — | No. | What a tenant pays for one phone number each month, in whole cents. Unset means the number burns nothing. |
 | `CREDIT_INBOX_CENTS` | — | No. | What a tenant pays for one inbox each month, in whole cents. Unset means the inbox burns nothing. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -131,6 +131,7 @@ at a dead end, with no error to see. Read [Email](guides/operate/email.md).
 | `AGENTPHONE_NUMBER_CENTS` | — | No. | What AgentPhone charges for one number each month, in cents. |
 | `AGENTMAIL_MESSAGE_CENTS` | — | No. | What AgentMail charges for one email, in cents. Give the fraction, such as `0.2` for $2 per 1,000 emails. A whole number rounds this rate to zero. |
 | `AGENTPHONE_MESSAGE_CENTS` | — | No. | What AgentPhone charges for one SMS, in cents. Fountain counts an inbound message too, because AgentPhone charges for it. |
+| `CREDIT_PRICING_SINCE` | — | No. | The instant from which Fountain prices turns and messages into the prepaid ledger, as ISO 8601. Unset means nothing is priced. |
 | `CREDIT_TURN_HOUR_CENTS` | `25` | No. | What a tenant pays for one hour of turn time, in whole cents, from their prepaid balance. |
 | `CREDIT_NUMBER_CENTS` | — | No. | What a tenant pays for one phone number each month, in whole cents. Unset means the number burns nothing. |
 | `CREDIT_INBOX_CENTS` | — | No. | What a tenant pays for one inbox each month, in whole cents. Unset means the inbox burns nothing. |

--- a/ee/lib/fountain/workers/credit_pricer.ex
+++ b/ee/lib/fountain/workers/credit_pricer.ex
@@ -1,0 +1,243 @@
+defmodule Fountain.Workers.CreditPricer do
+  @moduledoc """
+  Prices what a tenant used into the credit ledger (ADR 0030 decision 3).
+
+  Two passes, both idempotent, both bounded by `credits.pricing_since`:
+
+    * **Turns.** Every closed turn (`ended_at` set) on a provider Fountain pays
+      for burns `Credits.turn_cost_cents(ended - started)` under the key
+      `burn_turn:<turn_id>`. A turn is priced once, when it closes: an
+      in-flight turn that crosses zero finishes and lands as debt, which is
+      the soft stop of decision 6. Runner turns cost Fountain nothing and burn
+      nothing (ADR 0022); a turn with no sandbox never ran.
+    * **Messages.** Every `comms_email_sent`, `comms_sms_sent` and
+      `comms_sms_received` usage event burns the matching price under
+      `burn_message:<event_id>`. A `nil` price burns nothing (#1042).
+
+  Rows are written for every tenant, comped included: the ledger is also how
+  `Finance` sees what a comp cost. Enforcement is `check_balance/1`'s job and
+  is not wired yet (#1086 phase 4).
+
+  No-ops when billing is off or `pricing_since` is unset. The look-back is
+  `pricing_since` or seven days, whichever is later, so a restart after an
+  outage catches up without scanning the whole table; a turn older than that
+  which somehow escaped pricing is a reconciliation job, not this one's.
+
+  Rounding is to the nearest cent per turn. A one-minute turn at $0.25/hour is
+  0.4 cents and burns nothing; the error is symmetric and averages out, and a
+  ledger of fractional cents is a ledger nobody can reconcile.
+  """
+
+  use Oban.Worker, queue: :billing, max_attempts: 3, unique: [period: 60]
+
+  import Ecto.Query
+
+  alias Fountain.Billing
+  alias Fountain.Billing.SandboxUsage
+  alias Fountain.Billing.UsageEvent
+  alias Fountain.Conversations.Conversation
+  alias Fountain.Conversations.Sandbox
+  alias Fountain.Conversations.Turn
+  alias Fountain.Credits
+  alias Fountain.Credits.LedgerEntry
+  alias Fountain.Repo
+
+  require Logger
+
+  @lookback_days 7
+  @batch 500
+  @message_events ~w(comms_email_sent comms_sms_sent comms_sms_received)
+
+  @impl Oban.Worker
+  def perform(_job) do
+    case run() do
+      %{turns: 0, messages: 0} ->
+        :ok
+
+      counts ->
+        Logger.info("credit pricer: burned #{counts.turns} turns, #{counts.messages} messages")
+    end
+
+    :ok
+  end
+
+  @doc """
+  Run both passes now. `:now` pins the clock; `:since` overrides the
+  configured floor. Returns `%{turns: n, messages: n}` — rows written, not
+  rows seen.
+  """
+  @spec run(keyword()) :: %{turns: non_neg_integer(), messages: non_neg_integer()}
+  def run(opts \\ []) do
+    since = Keyword.get(opts, :since) || pricing_since()
+
+    cond do
+      not Billing.enabled?() -> %{turns: 0, messages: 0}
+      is_nil(since) -> %{turns: 0, messages: 0}
+      true -> do_run(floor(since, Keyword.get(opts, :now) || DateTime.utc_now()))
+    end
+  end
+
+  @doc "The configured instant burning starts, or nil."
+  @spec pricing_since() :: DateTime.t() | nil
+  def pricing_since do
+    Application.get_env(:fountain, :credits, []) |> Keyword.get(:pricing_since)
+  end
+
+  defp floor(since, now) do
+    lookback = DateTime.add(now, -@lookback_days * 86_400, :second)
+    if DateTime.compare(since, lookback) == :gt, do: since, else: lookback
+  end
+
+  defp do_run(floor) do
+    %{turns: price_turns(floor), messages: price_messages(floor)}
+  end
+
+  # ---------------------------------------------------------------------------
+  # Turns
+  # ---------------------------------------------------------------------------
+
+  defp price_turns(floor), do: price_turns(floor, 0)
+
+  defp price_turns(floor, written) do
+    case unpriced_turns(floor) do
+      [] ->
+        written
+
+      turns ->
+        n = Enum.count(turns, &price_turn/1)
+        # The anti-join hides what was just written, so the next page is the
+        # next unpriced batch. A page that wrote nothing (every turn was free,
+        # or a duplicate) would loop forever; stop on it.
+        if n == 0 or length(turns) < @batch,
+          do: written + n,
+          else: price_turns(floor, written + n)
+    end
+  end
+
+  defp unpriced_turns(floor) do
+    providers = SandboxUsage.platform_paid_providers()
+
+    from(t in Turn,
+      join: c in Conversation,
+      on: c.id == t.conversation_id,
+      join: s in Sandbox,
+      on: s.id == c.sandbox_id,
+      left_join: l in LedgerEntry,
+      on: l.idempotency_key == fragment("'burn_turn:' || ?::text", t.id),
+      where: is_nil(l.id),
+      where: not is_nil(t.started_at) and not is_nil(t.ended_at),
+      where: t.ended_at >= ^floor,
+      where: s.provider in ^providers,
+      where: not is_nil(c.user_id),
+      order_by: [asc: t.ended_at],
+      limit: @batch,
+      select: %{
+        id: t.id,
+        user_id: c.user_id,
+        conversation_id: c.id,
+        provider: s.provider,
+        started_at: t.started_at,
+        ended_at: t.ended_at
+      }
+    )
+    |> Repo.all()
+  end
+
+  # True when a row was written. A turn that rounds to nothing is not written
+  # at all, so it will be seen again next run and skipped again; that costs
+  # one anti-join row per free turn per run, and the look-back bounds it.
+  defp price_turn(turn) do
+    seconds = max(DateTime.diff(turn.ended_at, turn.started_at, :second), 0)
+
+    case Credits.turn_cost_cents(seconds) do
+      0 ->
+        false
+
+      cents ->
+        case Credits.debit(turn.user_id, cents, "burn_turn",
+               idempotency_key: "burn_turn:#{turn.id}",
+               resource_type: "turn",
+               resource_id: turn.id,
+               actor: "system:credit_pricer",
+               metadata: %{
+                 "turn_seconds" => seconds,
+                 "provider" => turn.provider,
+                 "conversation_id" => turn.conversation_id
+               }
+             ) do
+          {:ok, _} ->
+            true
+
+          {:ok, :duplicate, _} ->
+            false
+
+          {:error, reason} ->
+            Logger.warning("credit pricer: turn #{turn.id} not priced: #{inspect(reason)}")
+            false
+        end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Messages
+  # ---------------------------------------------------------------------------
+
+  defp price_messages(floor) do
+    card = Credits.price_card()
+
+    prices = %{
+      "comms_email_sent" => card.email_message,
+      "comms_sms_sent" => card.sms_message,
+      "comms_sms_received" => card.sms_message
+    }
+
+    priced_types = for {type, cents} <- prices, is_integer(cents) and cents > 0, do: type
+
+    if priced_types == [] do
+      0
+    else
+      floor
+      |> unpriced_messages(priced_types)
+      |> Enum.count(&price_message(&1, Map.fetch!(prices, &1.event_type)))
+    end
+  end
+
+  defp unpriced_messages(floor, types) do
+    from(e in UsageEvent,
+      left_join: l in LedgerEntry,
+      on: l.idempotency_key == fragment("'burn_message:' || ?::text", e.id),
+      where: is_nil(l.id),
+      where: e.event_type in ^types and e.event_type in ^@message_events,
+      where: e.inserted_at >= ^floor,
+      order_by: [asc: e.inserted_at],
+      limit: @batch,
+      select: %{
+        id: e.id,
+        user_id: e.user_id,
+        event_type: e.event_type,
+        resource_id: e.resource_id
+      }
+    )
+    |> Repo.all()
+  end
+
+  defp price_message(event, cents) do
+    case Credits.debit(event.user_id, cents, "burn_message",
+           idempotency_key: "burn_message:#{event.id}",
+           resource_type: "usage_event",
+           resource_id: Integer.to_string(event.id),
+           actor: "system:credit_pricer",
+           metadata: %{"event_type" => event.event_type, "contact_id" => event.resource_id}
+         ) do
+      {:ok, _} ->
+        true
+
+      {:ok, :duplicate, _} ->
+        false
+
+      {:error, reason} ->
+        Logger.warning("credit pricer: message #{event.id} not priced: #{inspect(reason)}")
+        false
+    end
+  end
+end

--- a/ee/test/fountain/workers/credit_pricer_test.exs
+++ b/ee/test/fountain/workers/credit_pricer_test.exs
@@ -1,0 +1,148 @@
+defmodule Fountain.Workers.CreditPricerTest do
+  @moduledoc """
+  The pricer writes one burn per closed turn and per message, once, only on
+  providers Fountain pays for, only from the configured instant.
+  """
+
+  use Fountain.DataCase, async: true
+
+  alias Fountain.Billing
+  alias Fountain.Credits
+  alias Fountain.Workers.CreditPricer
+
+  @since ~U[2026-08-01 00:00:00Z]
+  @now ~U[2026-08-03 12:00:00Z]
+
+  defp closed_turn(conv, started, seconds) do
+    insert_turn(conv, %{
+      status: "completed",
+      started_at: started,
+      ended_at: DateTime.add(started, seconds, :second)
+    })
+  end
+
+  defp setup_conv(user, provider \\ "sprites") do
+    sandbox = insert_sandbox(user_id: user.id, provider: provider, status: "ready")
+    insert_conversation(user_id: user.id, sandbox: sandbox)
+  end
+
+  test "no-ops with no pricing_since and with billing off" do
+    user = insert_active_user()
+    conv = setup_conv(user)
+    closed_turn(conv, ~U[2026-08-02 10:00:00Z], 3600)
+
+    assert %{turns: 0, messages: 0} = CreditPricer.run(now: @now)
+
+    Application.put_env(:fountain, :billing_enabled, false)
+    on_exit(fn -> Application.put_env(:fountain, :billing_enabled, true) end)
+    assert %{turns: 0, messages: 0} = CreditPricer.run(since: @since, now: @now)
+    assert Credits.balance(user.id) == 0
+  end
+
+  test "a closed hour on sprites burns 25 cents, once, with the turn as the resource" do
+    user = insert_active_user()
+    conv = setup_conv(user)
+    turn = closed_turn(conv, ~U[2026-08-02 10:00:00Z], 3600)
+
+    assert %{turns: 1, messages: 0} = CreditPricer.run(since: @since, now: @now)
+    assert Credits.balance(user.id) == -25
+
+    [entry] = Credits.list_entries(user.id)
+    assert entry.reason == "burn_turn"
+    assert entry.resource_type == "turn"
+    assert entry.resource_id == turn.id
+    assert entry.idempotency_key == "burn_turn:#{turn.id}"
+    assert entry.metadata["turn_seconds"] == 3600
+    assert entry.metadata["provider"] == "sprites"
+
+    # Second run: nothing new.
+    assert %{turns: 0, messages: 0} = CreditPricer.run(since: @since, now: @now)
+    assert Credits.balance(user.id) == -25
+  end
+
+  test "open turns, runner turns, and turns before pricing_since are not priced" do
+    user = insert_active_user()
+    conv = setup_conv(user)
+    # Still running.
+    insert_turn(conv, %{status: "running", started_at: ~U[2026-08-02 10:00:00Z]})
+    # Closed before the floor.
+    closed_turn(conv, ~U[2026-07-30 10:00:00Z], 7200)
+    # The tenant's own machine.
+    runner_conv = setup_conv(user, "runner")
+    closed_turn(runner_conv, ~U[2026-08-02 11:00:00Z], 7200)
+
+    assert %{turns: 0, messages: 0} = CreditPricer.run(since: @since, now: @now)
+    assert Credits.balance(user.id) == 0
+  end
+
+  test "a turn that rounds to zero cents writes nothing and is not an error" do
+    user = insert_active_user()
+    conv = setup_conv(user)
+    closed_turn(conv, ~U[2026-08-02 10:00:00Z], 60)
+
+    assert %{turns: 0, messages: 0} = CreditPricer.run(since: @since, now: @now)
+    assert Credits.list_entries(user.id) == []
+  end
+
+  test "a comped tenant's turns are still written to the ledger" do
+    user = insert_active_user()
+    {:ok, user} = Billing.comp_account(user)
+    conv = setup_conv(user)
+    closed_turn(conv, ~U[2026-08-02 10:00:00Z], 3600)
+
+    assert %{turns: 1} = CreditPricer.run(since: @since, now: @now)
+    assert Credits.balance(user.id) == -25
+    assert :ok = Credits.check_balance(user.id)
+  end
+
+  test "the look-back never reaches further than seven days before now" do
+    user = insert_active_user()
+    conv = setup_conv(user)
+    closed_turn(conv, ~U[2026-07-20 10:00:00Z], 3600)
+    closed_turn(conv, ~U[2026-08-02 10:00:00Z], 3600)
+
+    assert %{turns: 1} = CreditPricer.run(since: ~U[2026-01-01 00:00:00Z], now: @now)
+  end
+
+  describe "messages" do
+    setup do
+      cfg = Application.get_env(:fountain, :credits)
+      on_exit(fn -> Application.put_env(:fountain, :credits, cfg) end)
+      :ok
+    end
+
+    test "an unpriced message burns nothing" do
+      user = insert_active_user()
+      {:ok, _} = Billing.record_usage(user.id, "comms_email_sent", nil, "contact", %{})
+      assert %{messages: 0} = CreditPricer.run(since: @since, now: @now)
+    end
+
+    test "a priced message burns once, inbound SMS included" do
+      user = insert_active_user()
+      cfg = Application.get_env(:fountain, :credits)
+
+      Application.put_env(
+        :fountain,
+        :credits,
+        Keyword.merge(cfg, email_message_cents: 1, sms_message_cents: 2)
+      )
+
+      {:ok, _} = Billing.record_usage(user.id, "comms_email_sent", nil, "contact", %{})
+      {:ok, _} = Billing.record_usage(user.id, "comms_sms_sent", nil, "contact", %{})
+      {:ok, _} = Billing.record_usage(user.id, "comms_sms_received", nil, "contact", %{})
+      # Not a message.
+      {:ok, _} = Billing.record_usage(user.id, "turn_started", nil, "conversation", %{})
+
+      assert %{messages: 3} = CreditPricer.run(since: @since, now: DateTime.utc_now())
+      assert Credits.balance(user.id) == -5
+      assert %{messages: 0} = CreditPricer.run(since: @since, now: DateTime.utc_now())
+
+      reasons = Credits.list_entries(user.id) |> Enum.map(& &1.reason) |> Enum.uniq()
+      assert reasons == ["burn_message"]
+    end
+  end
+
+  test "perform/1 is a thin shell over run/1" do
+    assert :ok = CreditPricer.perform(%Oban.Job{args: %{}})
+  end
+end


### PR DESCRIPTION
Stacked on #1094 (will rebase once that merges; the diff includes it until then).

**Adds** `Fountain.Workers.CreditPricer` (Oban cron, every 10 min, `billing` queue):
- **Turns:** each closed turn on `sprites`/`e2b`/`daytona` burns `Credits.turn_cost_cents(ended_at - started_at)` as `burn_turn:<turn_id>` with the turn as the resource. Open turns, runner turns and turns before the floor are skipped. Priced once at close, which is how "in-flight turns finish and may go negative" (ADR 0030 decision 6) falls out.
- **Messages:** each `comms_email_sent` / `comms_sms_sent` / `comms_sms_received` usage event burns its configured price as `burn_message:<event_id>`; a `nil` price burns nothing (#1042).
- Both passes are anti-joins against `credit_ledger.idempotency_key`, batched at 500, bounded by `max(pricing_since, now - 7d)`.
- Comped tenants are written to (Finance needs to see what a comp costs) and never refused.

**The switch:** `CREDIT_PRICING_SINCE` (ISO 8601). Unset = the worker no-ops. This is so the deploy that adds the pricer does not bill every tenant for last week's turns before anyone holds a grant; phase 5 sets it alongside the opening grants.

**Tests** (9): no-op with no floor / billing off; one hour on sprites → −25¢ once with the turn as resource, rerun writes nothing; open/runner/pre-floor turns skipped; sub-cent turn writes nothing; comped tenant priced but `check_balance` still ok; 7-day look-back; messages unpriced by default, priced once each incl. inbound SMS.

Still enforcing nothing. Next: tier grants + trial grant + expiry.

Refs #1086, ADR 0030.

🤖 Generated with [Claude Code](https://claude.com/claude-code)