### PR TITLE
feat(credits): tier grants, the trial's opening grant, and expiry (#1086 phase 2, step 3)

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -46,7 +46,12 @@ config :fountain, Oban,
        # credit ledger (ADR 0030). Idempotent per turn and per event, so the
        # cadence only sets how stale a balance can read. No-ops until
        # CREDIT_PRICING_SINCE is set.
-       {"*/10 * * * *", Fountain.Workers.CreditPricer}
+       {"*/10 * * * *", Fountain.Workers.CreditPricer},
+       # 06:23 UTC daily: tier and trial grants, and expiry of unspent grants
+       # (ADR 0030 decision 2). Idempotent per period and per grant. The
+       # webhook will grant at renewal directly (phase 4); this is the
+       # backstop. No-ops until CREDIT_PRICING_SINCE is set.
+       {"23 6 * * *", Fountain.Workers.CreditGranter}
      ]}
   ]
 

--- a/ee/lib/fountain/workers/credit_granter.ex
+++ b/ee/lib/fountain/workers/credit_granter.ex
@@ -1,0 +1,309 @@
+defmodule Fountain.Workers.CreditGranter do
+  @moduledoc """
+  Puts the free money in, and takes the unused free money back out (ADR 0030
+  decision 2).
+
+  Three passes, all idempotent, all no-ops until `credits.pricing_since` is
+  set and billing is on:
+
+    * **Tier grant.** Every subscriber whose subscription names a billing
+      period gets `Plans.included_turn_hours × turn-hour price` once per
+      period, under `grant_tier:<user_id>:<period_start>`, expiring at the
+      period's end. Solo 40 h → $10, Team 100 h → $25, Scale 200 h → $50.
+      A period that began before `pricing_since` is pro-rated to the part
+      that falls after it, so the switch never grants a month that was
+      already mostly spent unmetered (#1086 phase 5).
+    * **Trial grant.** A trialing account gets the trial plan's hours once,
+      ever, under `grant_trial:<user_id>`, expiring when the trial ends.
+    * **Expiry.** A grant whose `expires_at` has passed loses whatever of it
+      is unspent, under `expire:<grant_id>`. Burn order is granted first,
+      oldest expiry first, then purchased (see `unspent_of/2`), so a
+      customer never loses paid money while free money sat unused.
+
+  Comped accounts get no grant: nothing is enforced on them and a grant
+  would only inflate the deferred-balance liability `Finance` reports.
+
+  Daily is late by up to a day at a renewal. `grant_for_user/2` is the
+  same pass for one tenant, for the webhook to call when a period changes
+  (#1086 phase 4) and for phase 5's release task.
+  """
+
+  use Oban.Worker, queue: :billing, max_attempts: 3, unique: [period: 60]
+
+  import Ecto.Query
+
+  alias Fountain.Accounts.User
+  alias Fountain.Billing
+  alias Fountain.Credits
+  alias Fountain.Credits.LedgerEntry
+  alias Fountain.Plans
+  alias Fountain.Repo
+
+  require Logger
+
+  @batch 500
+
+  @impl Oban.Worker
+  def perform(_job) do
+    case run() do
+      %{tier: 0, trial: 0, expired: 0} ->
+        :ok
+
+      c ->
+        Logger.info(
+          "credit granter: #{c.tier} tier grants, #{c.trial} trial grants, #{c.expired} expiries"
+        )
+    end
+
+    :ok
+  end
+
+  @doc """
+  Run all three passes now. `:now` pins the clock; `:since` overrides the
+  configured floor. Counts rows written.
+  """
+  @spec run(keyword()) :: %{
+          tier: non_neg_integer(),
+          trial: non_neg_integer(),
+          expired: non_neg_integer()
+        }
+  def run(opts \\ []) do
+    since = Keyword.get(opts, :since) || Fountain.Workers.CreditPricer.pricing_since()
+    now = Keyword.get(opts, :now) || DateTime.utc_now()
+
+    cond do
+      not Billing.enabled?() ->
+        %{tier: 0, trial: 0, expired: 0}
+
+      is_nil(since) ->
+        %{tier: 0, trial: 0, expired: 0}
+
+      true ->
+        %{
+          tier: grant_tiers(since, now),
+          trial: grant_trials(since, now),
+          expired: expire_grants(now)
+        }
+    end
+  end
+
+  @doc """
+  The tier and trial passes for one tenant. Returns the rows written, `0..2`.
+  Same floor rules as `run/1`.
+  """
+  @spec grant_for_user(User.t(), keyword()) :: non_neg_integer()
+  def grant_for_user(%User{} = user, opts \\ []) do
+    since = Keyword.get(opts, :since) || Fountain.Workers.CreditPricer.pricing_since()
+    now = Keyword.get(opts, :now) || DateTime.utc_now()
+
+    if Billing.enabled?() and not is_nil(since) do
+      Enum.count([tier_grant(user, since, now), trial_grant(user, since, now)], & &1)
+    else
+      0
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Tier grants
+  # ---------------------------------------------------------------------------
+
+  defp grant_tiers(since, now) do
+    from(u in User,
+      where: u.subscription_status == "active",
+      where: not is_nil(u.current_period_start) and not is_nil(u.current_period_end),
+      where: u.current_period_start <= ^now and u.current_period_end > ^now,
+      left_join: l in LedgerEntry,
+      on:
+        l.idempotency_key ==
+          fragment("'grant_tier:' || ?::text || ':' || ?::text", u.id, u.current_period_start),
+      where: is_nil(l.id),
+      limit: @batch
+    )
+    |> Repo.all()
+    |> Enum.count(&tier_grant(&1, since, now))
+  end
+
+  defp tier_grant(
+         %User{
+           subscription_status: "active",
+           current_period_start: %DateTime{} = ps,
+           current_period_end: %DateTime{} = pe
+         } = user,
+         since,
+         now
+       ) do
+    in_period? = DateTime.compare(ps, now) != :gt and DateTime.compare(pe, now) == :gt
+    hours = Plans.included_turn_hours(user)
+    cents = prorate(hours * Credits.price_card().turn_hour, ps, pe, since)
+
+    if in_period? and cents > 0 do
+      key = "grant_tier:#{user.id}:#{DateTime.to_iso8601(ps)}"
+      # `to_iso8601` on a second-truncated value matches Postgres's `::text`
+      # only for the anti-join's purposes if both sides normalise the same
+      # way; the key is built here, in Elixir, on both the grant and the
+      # lookup path, so the fragment above is a fast filter and this is the
+      # decider.
+      grant(user, cents, "grant_tier", key,
+        expires_at: pe,
+        resource_type: "billing_period",
+        resource_id: DateTime.to_iso8601(ps),
+        metadata: %{"plan" => Plans.resolve(user).slug, "hours" => hours}
+      )
+    else
+      false
+    end
+  end
+
+  defp tier_grant(_user, _since, _now), do: false
+
+  # Whole cents of `cents` for the part of [ps, pe) that falls at or after
+  # `since`; the whole amount when the period started after the switch.
+  defp prorate(cents, ps, pe, since) do
+    if DateTime.compare(since, ps) != :gt do
+      cents
+    else
+      total = DateTime.diff(pe, ps, :second)
+      left = DateTime.diff(pe, since, :second)
+      if total <= 0 or left <= 0, do: 0, else: div(cents * left + div(total, 2), total)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Trial grants
+  # ---------------------------------------------------------------------------
+
+  defp grant_trials(since, now) do
+    from(u in User,
+      where: u.subscription_status == "trialing",
+      where: not is_nil(u.trial_ends_at) and u.trial_ends_at > ^now,
+      left_join: l in LedgerEntry,
+      on: l.idempotency_key == fragment("'grant_trial:' || ?::text", u.id),
+      where: is_nil(l.id),
+      limit: @batch
+    )
+    |> Repo.all()
+    |> Enum.count(&trial_grant(&1, since, now))
+  end
+
+  defp trial_grant(
+         %User{subscription_status: "trialing", trial_ends_at: %DateTime{} = ends} = user,
+         _since,
+         now
+       ) do
+    hours = Plans.fetch!("trial").included_turn_hours
+    cents = hours * Credits.price_card().turn_hour
+
+    if DateTime.compare(ends, now) == :gt and cents > 0 do
+      grant(user, cents, "grant_trial", "grant_trial:#{user.id}",
+        expires_at: ends,
+        resource_type: "trial",
+        resource_id: user.id,
+        metadata: %{"hours" => hours}
+      )
+    else
+      false
+    end
+  end
+
+  defp trial_grant(_user, _since, _now), do: false
+
+  defp grant(user, cents, reason, key, opts) do
+    case Credits.grant(
+           user.id,
+           cents,
+           reason,
+           [idempotency_key: key, actor: "system:credit_granter"] ++ opts
+         ) do
+      {:ok, _} ->
+        true
+
+      {:ok, :duplicate, _} ->
+        false
+
+      {:error, why} ->
+        Logger.warning("credit granter: #{reason} for #{user.id} not written: #{inspect(why)}")
+        false
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Expiry
+  # ---------------------------------------------------------------------------
+
+  defp expire_grants(now) do
+    from(g in LedgerEntry,
+      where: g.amount_cents > 0 and not is_nil(g.expires_at) and g.expires_at <= ^now,
+      left_join: x in LedgerEntry,
+      on: x.idempotency_key == fragment("'expire:' || ?::text", g.id),
+      where: is_nil(x.id),
+      order_by: [asc: g.expires_at],
+      limit: @batch
+    )
+    |> Repo.all()
+    |> Enum.count(&expire_grant/1)
+  end
+
+  # Zero unspent is still "handled": a zero-amount row is invalid, so the
+  # grant would be re-examined every run. Mark it with a no-op-sized row?
+  # No — instead the anti-join stays and the cost is one row per fully-spent
+  # grant per run, bounded by how many grants a tenant has ever had. Cheap.
+  defp expire_grant(%LedgerEntry{} = grant) do
+    case unspent_of(grant, Credits.balance(grant.user_id)) do
+      0 ->
+        false
+
+      cents ->
+        case Credits.debit(grant.user_id, cents, "expire",
+               idempotency_key: "expire:#{grant.id}",
+               resource_type: "credit_ledger",
+               resource_id: grant.id,
+               actor: "system:credit_granter",
+               metadata: %{"grant_reason" => grant.reason, "granted_cents" => grant.amount_cents}
+             ) do
+          {:ok, _} ->
+            true
+
+          {:ok, :duplicate, _} ->
+            false
+
+          {:error, why} ->
+            Logger.warning("credit granter: expire #{grant.id} failed: #{inspect(why)}")
+            false
+        end
+    end
+  end
+
+  @doc """
+  How much of `grant` is still unspent, given the tenant's `balance`, under
+  the burn order *granted first, oldest expiry first, then purchased*.
+
+  Purchased money that remains is `min(purchases − clawbacks, balance)`,
+  because burns only reach it once every grant is gone. What is left after
+  that is spread over the live grants from the earliest expiry: this grant's
+  share is whatever exceeds the sum of the grants expiring after it, capped
+  at its own amount and floored at zero.
+  """
+  @spec unspent_of(LedgerEntry.t(), integer()) :: non_neg_integer()
+  def unspent_of(%LedgerEntry{} = grant, balance) when is_integer(balance) do
+    purchased_net =
+      from(e in LedgerEntry,
+        where: e.user_id == ^grant.user_id,
+        where: (e.amount_cents > 0 and is_nil(e.expires_at)) or like(e.reason, "clawback_%"),
+        select: coalesce(sum(e.amount_cents), 0)
+      )
+      |> Repo.one()
+
+    purchased_remaining = purchased_net |> max(0) |> min(max(balance, 0))
+    expirable = max(balance, 0) - purchased_remaining
+
+    later_grants =
+      from(e in LedgerEntry,
+        where: e.user_id == ^grant.user_id and e.amount_cents > 0,
+        where: not is_nil(e.expires_at) and e.expires_at > ^grant.expires_at,
+        select: coalesce(sum(e.amount_cents), 0)
+      )
+      |> Repo.one()
+
+    (expirable - later_grants) |> max(0) |> min(grant.amount_cents)
+  end
+end

--- a/ee/test/fountain/workers/credit_granter_test.exs
+++ b/ee/test/fountain/workers/credit_granter_test.exs
@@ -1,0 +1,234 @@
+defmodule Fountain.Workers.CreditGranterTest do
+  @moduledoc """
+  Grants land once per period and once per trial, pro-rate across the
+  switch, and expire under the granted-first, oldest-first, then-purchased
+  burn order.
+  """
+
+  use Fountain.DataCase, async: true
+
+  alias Fountain.Accounts.User
+  alias Fountain.Billing
+  alias Fountain.Credits
+  alias Fountain.Repo
+  alias Fountain.Workers.CreditGranter
+
+  @ps ~U[2026-08-01 00:00:00Z]
+  @pe ~U[2026-09-01 00:00:00Z]
+  @now ~U[2026-08-10 12:00:00Z]
+  @since ~U[2026-07-01 00:00:00Z]
+
+  defp subscriber(plan, attrs \\ %{}) do
+    user = insert_active_user()
+
+    {:ok, user} =
+      user
+      |> User.billing_changeset(
+        Map.merge(%{plan: plan, current_period_start: @ps, current_period_end: @pe}, attrs)
+      )
+      |> Repo.update()
+
+    user
+  end
+
+  defp trialer(ends) do
+    user = insert_verified_user()
+
+    {:ok, user} =
+      user
+      |> User.billing_changeset(%{subscription_status: "trialing", trial_ends_at: ends})
+      |> Repo.update()
+
+    user
+  end
+
+  test "no-ops with no floor and with billing off" do
+    subscriber("solo")
+    assert %{tier: 0, trial: 0, expired: 0} = CreditGranter.run(now: @now)
+
+    Application.put_env(:fountain, :billing_enabled, false)
+    on_exit(fn -> Application.put_env(:fountain, :billing_enabled, true) end)
+    assert %{tier: 0, trial: 0, expired: 0} = CreditGranter.run(since: @since, now: @now)
+  end
+
+  describe "tier grants" do
+    test "each plan gets its hours at the turn-hour price, once per period, expiring at period end" do
+      solo = subscriber("solo")
+      team = subscriber("team")
+      scale = subscriber("scale")
+      legacy = subscriber("legacy")
+
+      assert %{tier: 4} = CreditGranter.run(since: @since, now: @now)
+      assert Credits.balance(solo.id) == 1000
+      assert Credits.balance(team.id) == 2500
+      assert Credits.balance(scale.id) == 5000
+      assert Credits.balance(legacy.id) == 2500
+
+      [entry] = Credits.list_entries(solo.id)
+      assert entry.reason == "grant_tier"
+      assert entry.expires_at == @pe
+      assert entry.idempotency_key == "grant_tier:#{solo.id}:#{DateTime.to_iso8601(@ps)}"
+      assert entry.metadata == %{"plan" => "solo", "hours" => 40}
+
+      assert %{tier: 0} = CreditGranter.run(since: @since, now: @now)
+      assert Credits.balance(solo.id) == 1000
+    end
+
+    test "a new period is a new grant" do
+      user = subscriber("solo")
+      assert %{tier: 1} = CreditGranter.run(since: @since, now: @now)
+
+      {:ok, _} =
+        user
+        |> User.billing_changeset(%{
+          current_period_start: @pe,
+          current_period_end: ~U[2026-10-01 00:00:00Z]
+        })
+        |> Repo.update()
+
+      # The old period's grant expires in the same sweep, unspent.
+      assert %{tier: 1, expired: 1} =
+               CreditGranter.run(since: @since, now: ~U[2026-09-02 00:00:00Z])
+
+      assert Credits.balance(user.id) == 1000
+
+      assert Enum.map(Credits.list_entries(user.id), & &1.reason) |> Enum.sort() ==
+               ~w(expire grant_tier grant_tier)
+    end
+
+    test "a period that began before the switch is pro-rated to the part after it" do
+      user = subscriber("solo")
+      # Switch on at the 16th: 16 of 31 days remain.
+      since = ~U[2026-08-16 00:00:00Z]
+      assert %{tier: 1} = CreditGranter.run(since: since, now: ~U[2026-08-16 06:00:00Z])
+      assert Credits.balance(user.id) == div(1000 * 16 + 15, 31)
+    end
+
+    test "no grant outside the period, for comped, canceled, trialing or period-less accounts" do
+      subscriber("solo", %{
+        current_period_start: ~U[2026-06-01 00:00:00Z],
+        current_period_end: ~U[2026-07-01 00:00:00Z]
+      })
+
+      comped = subscriber("solo")
+      {:ok, _} = Billing.comp_account(comped)
+      subscriber("solo", %{subscription_status: "canceled"})
+      subscriber("solo", %{subscription_status: "trialing", trial_ends_at: nil})
+
+      no_period = insert_active_user()
+      {:ok, _} = no_period |> User.billing_changeset(%{plan: "solo"}) |> Repo.update()
+
+      assert %{tier: 0, trial: 0} = CreditGranter.run(since: @since, now: @now)
+    end
+  end
+
+  describe "trial grants" do
+    test "a live trial gets the trial plan's hours once, expiring with the trial" do
+      ends = ~U[2026-08-20 00:00:00Z]
+      user = trialer(ends)
+
+      assert %{trial: 1} = CreditGranter.run(since: @since, now: @now)
+      assert Credits.balance(user.id) == 1000
+      [entry] = Credits.list_entries(user.id)
+      assert entry.reason == "grant_trial"
+      assert entry.expires_at == ends
+
+      assert %{trial: 0} = CreditGranter.run(since: @since, now: @now)
+    end
+
+    test "an expired or open-ended trial gets nothing" do
+      trialer(~U[2026-08-01 00:00:00Z])
+      trialer(nil)
+      assert %{trial: 0} = CreditGranter.run(since: @since, now: @now)
+    end
+  end
+
+  describe "grant_for_user/2" do
+    test "does both passes for one tenant" do
+      user = subscriber("team")
+      assert 1 = CreditGranter.grant_for_user(user, since: @since, now: @now)
+      assert 0 = CreditGranter.grant_for_user(user, since: @since, now: @now)
+      assert Credits.balance(user.id) == 2500
+    end
+  end
+
+  describe "expiry" do
+    test "an unspent grant expires in full; a spent one expires nothing" do
+      full = subscriber("solo")
+      spent = subscriber("solo")
+      assert %{tier: 2} = CreditGranter.run(since: @since, now: @now)
+      {:ok, _} = Credits.debit(spent.id, 1000, "burn_turn", idempotency_key: "spent-all")
+
+      assert %{expired: 1} = CreditGranter.run(since: @since, now: ~U[2026-09-01 00:00:01Z])
+      assert Credits.balance(full.id) == 0
+      assert Credits.balance(spent.id) == 0
+
+      x = Credits.list_entries(full.id) |> Enum.find(&(&1.reason == "expire"))
+      assert x.amount_cents == -1000
+      assert x.metadata["granted_cents"] == 1000
+
+      # A second sweep writes nothing.
+      assert %{expired: 0} = CreditGranter.run(since: @since, now: ~U[2026-09-02 00:00:00Z])
+    end
+
+    test "purchased money survives an expiry; only the granted remainder goes" do
+      user = subscriber("solo")
+      assert %{tier: 1} = CreditGranter.run(since: @since, now: @now)
+      {:ok, _} = Credits.grant(user.id, 2500, "purchase", idempotency_key: "buy")
+      # 3500 total; burn 600, which comes out of the grant first.
+      {:ok, _} = Credits.debit(user.id, 600, "burn_turn", idempotency_key: "b")
+
+      assert %{expired: 1} = CreditGranter.run(since: @since, now: ~U[2026-09-01 00:00:01Z])
+      # 400 of the grant was unspent and is gone; the 2500 purchase stays.
+      assert Credits.balance(user.id) == 2500
+    end
+
+    test "a clawback reduces what counts as purchased" do
+      user = subscriber("solo")
+      assert %{tier: 1} = CreditGranter.run(since: @since, now: @now)
+      {:ok, _} = Credits.grant(user.id, 2500, "purchase", idempotency_key: "buy")
+      {:ok, _} = Credits.debit(user.id, 2500, "clawback_refund", idempotency_key: "refund")
+      # Balance 1000, all of it grant.
+      assert %{expired: 1} = CreditGranter.run(since: @since, now: ~U[2026-09-01 00:00:01Z])
+      assert Credits.balance(user.id) == 0
+    end
+
+    test "burns consume the earliest-expiring grant first" do
+      user = insert_active_user()
+
+      {:ok, a} =
+        Credits.grant(user.id, 1000, "grant_admin",
+          idempotency_key: "a",
+          expires_at: ~U[2026-09-01 00:00:00Z]
+        )
+
+      {:ok, b} =
+        Credits.grant(user.id, 1000, "grant_admin",
+          idempotency_key: "b",
+          expires_at: ~U[2026-10-01 00:00:00Z]
+        )
+
+      {:ok, _} = Credits.debit(user.id, 1500, "burn_turn", idempotency_key: "burn")
+      # 500 left: A is fully consumed, B has 500.
+      assert CreditGranter.unspent_of(a, 500) == 0
+      assert CreditGranter.unspent_of(b, 500) == 500
+
+      assert %{expired: 0} = CreditGranter.run(since: @since, now: ~U[2026-09-01 00:00:01Z])
+      assert Credits.balance(user.id) == 500
+      assert %{expired: 1} = CreditGranter.run(since: @since, now: ~U[2026-10-01 00:00:01Z])
+      assert Credits.balance(user.id) == 0
+    end
+
+    test "a negative balance has nothing to expire" do
+      user = subscriber("solo")
+      assert %{tier: 1} = CreditGranter.run(since: @since, now: @now)
+      {:ok, _} = Credits.debit(user.id, 1200, "burn_turn", idempotency_key: "over")
+      assert %{expired: 0} = CreditGranter.run(since: @since, now: ~U[2026-09-01 00:00:01Z])
+      assert Credits.balance(user.id) == -200
+    end
+  end
+
+  test "perform/1 is a thin shell over run/1" do
+    assert :ok = CreditGranter.perform(%Oban.Job{args: %{}})
+  end
+end


### PR DESCRIPTION
Stacked on #1095 (diff includes it until that merges).

**Adds** `Fountain.Workers.CreditGranter` (Oban cron, 06:23 UTC daily, `billing` queue), three idempotent passes:
- **Tier grant:** every `active` subscriber inside a named billing period gets `Plans.included_turn_hours × turn-hour price` once per period — Solo $10, Team/legacy $25, Scale $50 — as `grant_tier:<user>:<period_start>`, expiring at period end. A period that began before `CREDIT_PRICING_SINCE` is pro-rated to the part after it (the phase 5 rollout story: nobody is granted a month already spent unmetered).
- **Trial grant:** a live trial gets the trial plan's 40 h ($10) once as `grant_trial:<user>`, expiring with the trial. Decision 2's "a trial never exceeds a paid plan" holds by construction.
- **Expiry:** a grant past `expires_at` loses what is unspent as `expire:<grant_id>`. `unspent_of/2` encodes the burn order **granted first, oldest expiry first, then purchased**: purchased-remaining = `min(purchases − clawbacks, balance)`, and a grant's share is what exceeds the sum of later-expiring grants, capped at its own amount.
- Comped accounts get no grant (nothing enforced; a grant would only inflate the deferred-balance liability).
- `grant_for_user/2`: the same pass for one tenant, for the renewal webhook (phase 4) and the phase 5 release task.

**Tests** (14): all four plans' amounts; once per period; new period = new grant and the old one expires; pro-rating at a mid-month switch; no grant for comped/canceled/trialing/period-less/out-of-period; trial once, none when expired or open-ended; expiry in full vs. nothing when spent; purchased survives; clawback reduces purchased; FIFO across two grants; negative balance expires nothing.

Still enforcing nothing. Next: show the balance everywhere (BillingLive, `/api/account/billing`, admin, docs), replacing the turn-hour allowance surfaces.

Refs #1086, ADR 0030.

🤖 Generated with [Claude Code](https://claude.com/claude-code)