### PR TITLE
feat(credits): show the balance on every surface (#1086 phase 2, step 4)

### DIFF
--- a/apps/fountain/lib/fountain_web/live/admin_live/user_detail.ex
+++ b/apps/fountain/lib/fountain_web/live/admin_live/user_detail.ex
@@ -88,6 +88,8 @@ defmodule FountainWeb.AdminLive.UserDetail do
     |> assign(:audit_events, Audit.list_recent_for_user(user.id, 50))
     |> assign(:admin_events, Audit._unsafe_list_admin_events_for_target(user.id, 50))
     |> assign(:allowance, turn_hour_allowance(user))
+    |> assign(:credits, Fountain.Credits.summary(user))
+    |> assign(:ledger, Fountain.Credits.list_entries(user.id, limit: 20))
   end
 
   # Two DB queries against the sandbox and turn rows, so it is skipped
@@ -209,6 +211,20 @@ defmodule FountainWeb.AdminLive.UserDetail do
             used / included · {if @allowance.period.source == :subscription,
               do: "billing period",
               else: "calendar month"}
+          </div>
+        </div>
+        <div :if={@credits.active?} class="bg-white rounded shadow border border-zinc-200 px-4 py-3">
+          <div class="text-xs text-zinc-500">Credits</div>
+          <div class={[
+            "text-sm font-medium tabular-nums",
+            @credits.balance_cents < 0 && "text-amber-700"
+          ]}>
+            {Fountain.Credits.format_cents(@credits.balance_cents)}
+          </div>
+          <div class="text-xs text-zinc-500">
+            {Fountain.Credits.format_cents(@credits.purchased_cents)} bought · {Fountain.Credits.format_cents(
+              @credits.expiring_cents
+            )} expiring
           </div>
         </div>
         <div class="bg-white rounded shadow border border-zinc-200 px-4 py-3">

--- a/apps/fountain/lib/fountain_web/live/dashboard_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/dashboard_live/index.ex
@@ -76,6 +76,7 @@ defmodule FountainWeb.DashboardLive.Index do
       :allowance,
       billing_enabled? && Fountain.Billing.turn_hour_allowance(user, period: period)
     )
+    |> assign(:credits, Fountain.Credits.summary(user))
   end
 
   @impl true
@@ -174,6 +175,13 @@ defmodule FountainWeb.DashboardLive.Index do
             hint={turn_hours_hint(assigns)}
           />
           <.metric
+            :if={@credits.active?}
+            label="Credits"
+            value={Fountain.Credits.format_cents(@credits.balance_cents)}
+            sub={credits_sub(@credits)}
+            hint={"Conversation time costs #{Fountain.Credits.format_cents(@credits.turn_hour_cents)} per turn hour. Your plan adds credit every billing period; what you buy never expires."}
+          />
+          <.metric
             label="Tokens"
             value={format_tokens(@tokens)}
             sub={token_sub(@tokens)}
@@ -246,7 +254,13 @@ defmodule FountainWeb.DashboardLive.Index do
   defp turn_hours_value(%{usage: usage}), do: format_hours(billable_turn_hours(usage))
 
   defp turn_hours_sub(%{allowance: %{included: included}}), do: "of #{included} included"
+
   defp turn_hours_sub(_assigns), do: nil
+
+  defp credits_sub(%{expires_at: nil}), do: "remaining"
+
+  defp credits_sub(%{expiring_cents: cents, expires_at: at}),
+    do: "#{Fountain.Credits.format_cents(cents)} expires #{Calendar.strftime(at, "%b %-d")}"
 
   defp turn_hours_hint(assigns) do
     base =

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -1841,6 +1841,35 @@ defmodule FountainWeb.Schemas do
                 }
               }
             },
+            credits: %Schema{
+              type: :object,
+              nullable: true,
+              description:
+                "The prepaid balance, in cents. Null while this deployment has " <>
+                  "not started burning credits; a client must not show a zero " <>
+                  "balance then. Nothing is refused at zero yet.",
+              properties: %{
+                balance_cents: %Schema{
+                  type: :integer,
+                  description: "May be negative: an in-flight turn that crosses zero finishes."
+                },
+                expiring_cents: %Schema{
+                  type: :integer,
+                  description:
+                    "Unspent credit from the earliest live grant, which expires at expires_at."
+                },
+                expires_at: %Schema{type: :string, format: :"date-time", nullable: true},
+                purchased_cents: %Schema{
+                  type: :integer,
+                  description:
+                    "The part of the balance that was bought. It never expires and is spent last."
+                },
+                turn_hour_cents: %Schema{
+                  type: :integer,
+                  description: "What one hour of turn time costs."
+                }
+              }
+            },
             usage: %Schema{
               type: :object,
               properties: %{

--- a/docs/guides/operate/plans-and-prices.md
+++ b/docs/guides/operate/plans-and-prices.md
@@ -80,6 +80,35 @@ billing page shows it to the tenant. The API reports it at
 `GET /api/account/billing`. The admin page for one account shows it beside the
 sandbox count.
 
+### Prepaid credits
+
+A tenant also holds a balance of prepaid credit, in cents. Fountain shows it
+in dollars. Conversation time comes out of that balance at a fixed price for
+each turn hour. The default price is $0.25, from `CREDIT_TURN_HOUR_CENTS`.
+Messages and monthly rent for a number or an inbox can also come out of it,
+at the prices `CREDIT_EMAIL_MESSAGE_CENTS`, `CREDIT_SMS_MESSAGE_CENTS`,
+`CREDIT_NUMBER_CENTS` and `CREDIT_INBOX_CENTS` set. Leave one unset, and
+that line costs nothing.
+
+Nothing moves until you set `CREDIT_PRICING_SINCE`. That variable is the
+instant Fountain starts to price turns. Set it to the time of the deploy,
+never earlier, or every tenant pays for a week of turns before they hold a
+grant.
+
+Each plan puts credit in at the start of every billing period. The amount is
+the plan's turn hours at the turn-hour price. Solo puts in $10, Team $25 and
+Scale $50. That credit expires at the end of the period. A trial gets $10
+once, and that credit expires with the trial. Credit a tenant buys never
+expires, and Fountain spends it last.
+
+Fountain refuses nothing at a zero balance yet. A balance can go below zero,
+because a turn that crosses zero finishes. The next grant or purchase brings
+it back.
+[ADR 0030](https://github.com/BinaryBourbon/fountain/blob/main/decisions/0030-prepaid-credits.md)
+records the decisions, and
+[issue 1086](https://github.com/BinaryBourbon/fountain/issues/1086) tracks
+the build.
+
 ### The billing period
 
 Fountain measures the hours over the period that Stripe invoices. The

--- a/ee/lib/fountain/credits.ex
+++ b/ee/lib/fountain/credits.ex
@@ -203,6 +203,125 @@ defmodule Fountain.Credits do
     |> Repo.all()
   end
 
+  @doc """
+  Whether credits are live on this deployment: billing is on and
+  `credits.pricing_since` is set. Off, no surface shows a balance — there is
+  nothing to show, and a "$0.00" on a self-hosted console would be a lie.
+  """
+  @spec active?() :: boolean()
+  def active? do
+    Billing.enabled?() and
+      not is_nil(Keyword.get(Application.get_env(:fountain, :credits, []), :pricing_since))
+  end
+
+  @doc """
+  The one shape every surface renders (the billing page, the dashboard,
+  `GET /api/account/billing`, the admin account view), so they cannot
+  disagree.
+
+    * `:active?` — `active?/0`; when false the other numbers are zero and
+      should not be shown
+    * `:balance_cents` — the cached balance, possibly negative
+    * `:expiring_cents` / `:expires_at` — what the earliest live grant still
+      has unspent, and when it goes
+    * `:purchased_cents` — how much of the balance is paid-for money, which
+      never expires
+    * `:turn_hour_cents` — the price of one turn hour
+    * `:price_card` — `price_card/0`
+  """
+  @spec summary(User.t(), keyword()) :: %{
+          active?: boolean(),
+          balance_cents: integer(),
+          expiring_cents: non_neg_integer(),
+          expires_at: DateTime.t() | nil,
+          purchased_cents: non_neg_integer(),
+          turn_hour_cents: non_neg_integer(),
+          price_card: map()
+        }
+  def summary(%User{} = user, opts \\ []) do
+    now = Keyword.get(opts, :now) || DateTime.utc_now()
+    card = price_card()
+
+    if active?() do
+      balance = balance(user)
+      purchased = purchased_remaining(user.id, balance)
+
+      {expiring, expires_at} =
+        case live_grants(user.id, now) do
+          [] -> {0, nil}
+          [first | _] -> {unspent_of(first, balance), first.expires_at}
+        end
+
+      %{
+        active?: true,
+        balance_cents: balance,
+        expiring_cents: expiring,
+        expires_at: expires_at,
+        purchased_cents: purchased,
+        turn_hour_cents: card.turn_hour,
+        price_card: card
+      }
+    else
+      %{
+        active?: false,
+        balance_cents: 0,
+        expiring_cents: 0,
+        expires_at: nil,
+        purchased_cents: 0,
+        turn_hour_cents: card.turn_hour,
+        price_card: card
+      }
+    end
+  end
+
+  @doc "Grants that have not yet expired, earliest expiry first."
+  @spec live_grants(binary(), DateTime.t()) :: [LedgerEntry.t()]
+  def live_grants(user_id, %DateTime{} = now) when is_binary(user_id) do
+    from(e in LedgerEntry,
+      where: e.user_id == ^user_id and e.amount_cents > 0,
+      where: not is_nil(e.expires_at) and e.expires_at > ^now,
+      order_by: [asc: e.expires_at, asc: e.inserted_at]
+    )
+    |> Repo.all()
+  end
+
+  @doc """
+  How much of `grant` is still unspent, given the tenant's `balance`, under
+  the burn order *granted first, oldest expiry first, then purchased*.
+
+  Purchased money that remains is `min(purchases − clawbacks, balance)`,
+  because burns only reach it once every grant is gone. What is left after
+  that is spread over the live grants from the earliest expiry: this grant's
+  share is whatever exceeds the sum of the grants expiring after it, capped
+  at its own amount and floored at zero.
+  """
+  @spec unspent_of(LedgerEntry.t(), integer()) :: non_neg_integer()
+  def unspent_of(%LedgerEntry{} = grant, balance) when is_integer(balance) do
+    expirable = max(balance, 0) - purchased_remaining(grant.user_id, balance)
+
+    later_grants =
+      from(e in LedgerEntry,
+        where: e.user_id == ^grant.user_id and e.amount_cents > 0,
+        where: not is_nil(e.expires_at) and e.expires_at > ^grant.expires_at,
+        select: coalesce(sum(e.amount_cents), 0)
+      )
+      |> Repo.one()
+
+    (expirable - later_grants) |> max(0) |> min(grant.amount_cents)
+  end
+
+  defp purchased_remaining(user_id, balance) do
+    purchased_net =
+      from(e in LedgerEntry,
+        where: e.user_id == ^user_id,
+        where: (e.amount_cents > 0 and is_nil(e.expires_at)) or like(e.reason, "clawback_%"),
+        select: coalesce(sum(e.amount_cents), 0)
+      )
+      |> Repo.one()
+
+    purchased_net |> max(0) |> min(max(balance, 0))
+  end
+
   # ---------------------------------------------------------------------------
   # Writes
   # ---------------------------------------------------------------------------

--- a/ee/lib/fountain/workers/credit_granter.ex
+++ b/ee/lib/fountain/workers/credit_granter.ex
@@ -248,7 +248,7 @@ defmodule Fountain.Workers.CreditGranter do
   # No — instead the anti-join stays and the cost is one row per fully-spent
   # grant per run, bounded by how many grants a tenant has ever had. Cheap.
   defp expire_grant(%LedgerEntry{} = grant) do
-    case unspent_of(grant, Credits.balance(grant.user_id)) do
+    case Credits.unspent_of(grant, Credits.balance(grant.user_id)) do
       0 ->
         false
 
@@ -273,37 +273,7 @@ defmodule Fountain.Workers.CreditGranter do
     end
   end
 
-  @doc """
-  How much of `grant` is still unspent, given the tenant's `balance`, under
-  the burn order *granted first, oldest expiry first, then purchased*.
-
-  Purchased money that remains is `min(purchases − clawbacks, balance)`,
-  because burns only reach it once every grant is gone. What is left after
-  that is spread over the live grants from the earliest expiry: this grant's
-  share is whatever exceeds the sum of the grants expiring after it, capped
-  at its own amount and floored at zero.
-  """
+  @doc "See `Fountain.Credits.unspent_of/2`; kept here for the tests that grew up with it."
   @spec unspent_of(LedgerEntry.t(), integer()) :: non_neg_integer()
-  def unspent_of(%LedgerEntry{} = grant, balance) when is_integer(balance) do
-    purchased_net =
-      from(e in LedgerEntry,
-        where: e.user_id == ^grant.user_id,
-        where: (e.amount_cents > 0 and is_nil(e.expires_at)) or like(e.reason, "clawback_%"),
-        select: coalesce(sum(e.amount_cents), 0)
-      )
-      |> Repo.one()
-
-    purchased_remaining = purchased_net |> max(0) |> min(max(balance, 0))
-    expirable = max(balance, 0) - purchased_remaining
-
-    later_grants =
-      from(e in LedgerEntry,
-        where: e.user_id == ^grant.user_id and e.amount_cents > 0,
-        where: not is_nil(e.expires_at) and e.expires_at > ^grant.expires_at,
-        select: coalesce(sum(e.amount_cents), 0)
-      )
-      |> Repo.one()
-
-    (expirable - later_grants) |> max(0) |> min(grant.amount_cents)
-  end
+  def unspent_of(%LedgerEntry{} = grant, balance), do: Credits.unspent_of(grant, balance)
 end

--- a/ee/lib/fountain_web/controllers/billing_api_controller.ex
+++ b/ee/lib/fountain_web/controllers/billing_api_controller.ex
@@ -51,6 +51,7 @@ defmodule FountainWeb.BillingApiController do
         user: user,
         usage: Billing.usage_summary(user.id, period.start, period.end),
         allowance: Billing.turn_hour_allowance(user, period: period),
+        credits: Fountain.Credits.summary(user),
         period: period
       )
     end

--- a/ee/lib/fountain_web/controllers/billing_api_json.ex
+++ b/ee/lib/fountain_web/controllers/billing_api_json.ex
@@ -1,7 +1,7 @@
 defmodule FountainWeb.BillingApiJSON do
   @moduledoc false
 
-  def show(%{user: user, usage: usage, allowance: allowance, period: period}) do
+  def show(%{user: user, usage: usage, allowance: allowance, credits: credits, period: period}) do
     %{
       data: %{
         status: user.subscription_status,
@@ -18,6 +18,10 @@ defmodule FountainWeb.BillingApiJSON do
         # cover a window the customer is not invoiced over, which a client
         # showing an allowance has to be able to say.
         period: %{start: period.start, end: period.end, source: period.source},
+        # The prepaid balance (ADR 0030), or null while the deployment has
+        # not started burning — a client must not render "$0.00" for an
+        # instance that has no ledger in play.
+        credits: credits_data(credits),
         usage: %{
           conversations: usage.conversations,
           turns: usage.turns,
@@ -37,6 +41,18 @@ defmodule FountainWeb.BillingApiJSON do
   end
 
   def url(%{url: url}), do: %{data: %{url: url}}
+
+  defp credits_data(%{active?: false}), do: nil
+
+  defp credits_data(c) do
+    %{
+      balance_cents: c.balance_cents,
+      expiring_cents: c.expiring_cents,
+      expires_at: c.expires_at,
+      purchased_cents: c.purchased_cents,
+      turn_hour_cents: c.turn_hour_cents
+    }
+  end
 
   # `concurrent_sandboxes` is the plan's number; `sandbox_limit` is what is
   # actually enforced for this account. They differ when an operator has set

--- a/ee/lib/fountain_web/live/billing_live.ex
+++ b/ee/lib/fountain_web/live/billing_live.ex
@@ -14,6 +14,7 @@ defmodule FountainWeb.Live.BillingLive do
   use FountainWeb, :live_view
 
   alias Fountain.Billing
+  alias Fountain.Credits
   alias Fountain.Plans
   alias Fountain.Quotas
 
@@ -34,6 +35,10 @@ defmodule FountainWeb.Live.BillingLive do
          usage: usage,
          allowance: Billing.turn_hour_allowance(user, period: period),
          period: period,
+         # The prepaid balance (ADR 0030). `active?` false means the switch is
+         # off and the card is not rendered at all.
+         credits: Credits.summary(user),
+         ledger: Credits.list_entries(user.id, limit: 10),
          stripe_url_loading: false,
          # Two plans, deliberately. `plan` is the tier the subscription names
          # — what Stripe charges for, what the picker highlights. `effective_plan`
@@ -366,6 +371,66 @@ defmodule FountainWeb.Live.BillingLive do
         </p>
       </div>
 
+      <%!-- Prepaid credits (ADR 0030). Shown only once burning has started on
+            this deployment. Nothing refuses anything at zero yet (phase 4). --%>
+      <div :if={@credits.active?} class="rounded-lg border bg-white p-6 shadow-sm" id="credits">
+        <div class="flex items-baseline justify-between">
+          <h2 class="text-lg font-medium">Credits</h2>
+          <p class="text-sm tabular-nums">
+            <span class={[
+              "font-semibold",
+              @credits.balance_cents < 0 && "text-amber-700"
+            ]}>
+              {Credits.format_cents(@credits.balance_cents)}
+            </span>
+            <span class="text-gray-500">remaining</span>
+          </p>
+        </div>
+        <p class="mt-3 text-xs text-gray-500">
+          Conversation time costs {Credits.format_cents(@credits.turn_hour_cents)} per turn hour
+          and comes out of this balance. Your plan puts {Credits.format_cents(
+            Plans.included_turn_hours(@current_user) * @credits.turn_hour_cents
+          )} in at the start of every billing period; what is unused expires with the period.
+          Credits you buy never expire and are spent last.
+        </p>
+        <p :if={@credits.expires_at} class="mt-2 text-xs text-gray-500">
+          {Credits.format_cents(@credits.expiring_cents)} of this expires on {Calendar.strftime(
+            @credits.expires_at,
+            "%b %-d"
+          )}.
+          <span :if={@credits.purchased_cents > 0}>
+            {Credits.format_cents(@credits.purchased_cents)} is money you bought and keeps.
+          </span>
+        </p>
+        <p :if={@credits.balance_cents < 0} class="mt-2 text-xs text-amber-700">
+          Your balance is below zero. Nothing is limited yet; the next grant or purchase
+          brings it back up.
+        </p>
+        <table :if={@ledger != []} class="mt-4 w-full text-xs">
+          <thead class="text-left text-gray-500">
+            <tr>
+              <th class="py-1 font-normal">When</th>
+              <th class="py-1 font-normal">What</th>
+              <th class="py-1 text-right font-normal">Amount</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr :for={entry <- @ledger} class="border-t">
+              <td class="py-1 tabular-nums text-gray-500">
+                {Calendar.strftime(entry.inserted_at, "%b %-d")}
+              </td>
+              <td class="py-1">{ledger_label(entry)}</td>
+              <td class={[
+                "py-1 text-right tabular-nums",
+                entry.amount_cents < 0 && "text-gray-500"
+              ]}>
+                {Credits.format_cents(entry.amount_cents)}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
       <%!-- Turn hours against the plan's allowance. Reported only; nothing
             refuses anything because a tenant is over it (#1016 step 4). --%>
       <div class="rounded-lg border bg-white p-6 shadow-sm">
@@ -520,4 +585,26 @@ defmodule FountainWeb.Live.BillingLive do
   # 100, which Float.round/2 refuses — an over-allowance account 500s the page.
   defp meter_width(%{used: used, included: included}),
     do: (used / included * 100) |> Float.round(1) |> min(100.0)
+
+  defp ledger_label(%{reason: "grant_tier", metadata: %{"plan" => plan}}),
+    do: "#{String.capitalize(plan)} plan credit"
+
+  defp ledger_label(%{reason: "grant_tier"}), do: "Plan credit"
+  defp ledger_label(%{reason: "grant_trial"}), do: "Trial credit"
+  defp ledger_label(%{reason: "grant_admin"}), do: "Credit from Fountain"
+  defp ledger_label(%{reason: "purchase"}), do: "Purchase"
+
+  defp ledger_label(%{reason: "burn_turn", metadata: %{"turn_seconds" => s}}),
+    do: "Conversation time, #{format_seconds(s)}"
+
+  defp ledger_label(%{reason: "burn_turn"}), do: "Conversation time"
+  defp ledger_label(%{reason: "burn_rent"}), do: "Number or inbox, one month"
+  defp ledger_label(%{reason: "burn_message"}), do: "Message"
+  defp ledger_label(%{reason: "expire"}), do: "Expired with the period"
+  defp ledger_label(%{reason: "clawback_" <> _}), do: "Refund reversed"
+  defp ledger_label(%{reason: reason}), do: reason
+
+  defp format_seconds(s) when is_integer(s) and s < 60, do: "#{s}s"
+  defp format_seconds(s) when is_integer(s) and s < 3600, do: "#{div(s, 60)}m"
+  defp format_seconds(s) when is_integer(s), do: "#{Float.round(s / 3600, 1)}h"
 end

--- a/ee/test/fountain_web/credits_surfaces_test.exs
+++ b/ee/test/fountain_web/credits_surfaces_test.exs
@@ -1,0 +1,150 @@
+defmodule FountainWeb.CreditsSurfacesTest do
+  @moduledoc """
+  The four surfaces that show the prepaid balance render the one shape
+  `Credits.summary/2` returns, and render nothing at all while the switch
+  is off (ADR 0030). `async: false` because the switch is global config.
+  """
+
+  use FountainWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  alias Fountain.Accounts.User
+  alias Fountain.Credits
+  alias Fountain.Repo
+
+  @since ~U[2026-07-01 00:00:00Z]
+
+  defp switch_on do
+    cfg = Application.get_env(:fountain, :credits)
+    Application.put_env(:fountain, :credits, Keyword.put(cfg, :pricing_since, @since))
+    on_exit(fn -> Application.put_env(:fountain, :credits, cfg) end)
+  end
+
+  defp insert_admin do
+    {:ok, admin} = Fountain.Accounts.update_user_role(insert_active_user(), "admin")
+    admin
+  end
+
+  defp subscriber do
+    user = insert_active_user()
+    {:ok, user} = user |> User.billing_changeset(%{plan: "solo"}) |> Repo.update()
+    user
+  end
+
+  describe "switch off" do
+    test "no balance anywhere, and the API says null", %{conn: conn} do
+      user = subscriber()
+      refute Credits.active?()
+      assert %{active?: false, balance_cents: 0} = Credits.summary(user)
+
+      {:ok, _lv, html} = live(login_user(conn, user), ~p"/account/billing")
+      refute html =~ "id=\"credits\""
+
+      {:ok, _lv, html} = live(login_user(conn, user), ~p"/dashboard")
+      refute html =~ "Credits"
+
+      {_rec, key} = insert_api_key(user)
+      body = conn |> authed_with_key(key) |> get("/api/account/billing") |> json_response(200)
+      assert Map.has_key?(body["data"], "credits")
+      assert body["data"]["credits"] == nil
+    end
+  end
+
+  describe "switch on" do
+    setup do
+      switch_on()
+      :ok
+    end
+
+    test "summary carries the balance, the expiring grant and the purchased part" do
+      user = subscriber()
+      expires = ~U[2026-09-01 00:00:00Z]
+
+      {:ok, _} =
+        Credits.grant(user.id, 1000, "grant_tier", idempotency_key: "g", expires_at: expires)
+
+      {:ok, _} = Credits.grant(user.id, 2500, "purchase", idempotency_key: "p")
+      {:ok, _} = Credits.debit(user.id, 300, "burn_turn", idempotency_key: "b")
+
+      user = Repo.reload!(user)
+      summary = Credits.summary(user, now: ~U[2026-08-10 00:00:00Z])
+      assert summary.active?
+      assert summary.balance_cents == 3200
+      assert summary.expiring_cents == 700
+      assert summary.expires_at == expires
+      assert summary.purchased_cents == 2500
+      assert summary.turn_hour_cents == 25
+    end
+
+    test "the billing page shows the balance, the price, the expiry and the ledger", %{conn: conn} do
+      user = subscriber()
+
+      {:ok, _} =
+        Credits.grant(user.id, 1000, "grant_tier",
+          idempotency_key: "g",
+          expires_at: ~U[2099-09-01 00:00:00Z],
+          metadata: %{"plan" => "solo"}
+        )
+
+      {:ok, _} =
+        Credits.debit(user.id, 25, "burn_turn",
+          idempotency_key: "b",
+          metadata: %{"turn_seconds" => 3600}
+        )
+
+      {:ok, _lv, html} = live(login_user(conn, user), ~p"/account/billing")
+      assert html =~ "id=\"credits\""
+      assert html =~ "$9.75"
+      assert html =~ "$0.25 per turn hour"
+      assert html =~ "expires on Sep 1"
+      assert html =~ "Solo plan credit"
+      assert html =~ "Conversation time, 1.0h"
+      refute html =~ "below zero"
+    end
+
+    test "a negative balance is called out, not hidden", %{conn: conn} do
+      user = subscriber()
+      {:ok, _} = Credits.debit(user.id, 40, "burn_turn", idempotency_key: "b")
+
+      {:ok, _lv, html} = live(login_user(conn, user), ~p"/account/billing")
+      assert html =~ "-$0.40"
+      assert html =~ "below zero"
+    end
+
+    test "the dashboard tile and the admin tile show the same number", %{conn: conn} do
+      user = subscriber()
+      {:ok, _} = Credits.grant(user.id, 1234, "purchase", idempotency_key: "p")
+
+      {:ok, _lv, html} = live(login_user(conn, user), ~p"/dashboard")
+      assert html =~ "Credits"
+      assert html =~ "$12.34"
+
+      admin = insert_admin()
+      {:ok, _lv, html} = live(login_user(conn, admin), ~p"/admin/users/#{user.id}")
+      assert html =~ "Credits"
+      assert html =~ "$12.34"
+      assert html =~ "$12.34 bought"
+    end
+
+    test "the API carries the same shape", %{conn: conn} do
+      user = subscriber()
+      expires = ~U[2099-09-01 00:00:00Z]
+
+      {:ok, _} =
+        Credits.grant(user.id, 1000, "grant_tier", idempotency_key: "g", expires_at: expires)
+
+      {_rec, key} = insert_api_key(user)
+
+      body = conn |> authed_with_key(key) |> get("/api/account/billing") |> json_response(200)
+
+      assert body["data"]["credits"] == %{
+               "balance_cents" => 1000,
+               "expiring_cents" => 1000,
+               "expires_at" => "2099-09-01T00:00:00Z",
+               "purchased_cents" => 0,
+               "turn_hour_cents" => 25
+             }
+    end
+  end
+end

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -10,6 +10,16 @@ server releases.
 
 ---
 
+## [0.1.13] — 2026-08-24
+
+### Added
+
+- `GET /api/account/billing` carries `credits`: the prepaid balance in
+  cents, what expires and when, the purchased part, and the turn-hour
+  price. It is `null` while the deployment has not started burning
+  credits, so do not render a zero balance then. Nothing is refused at
+  zero yet (ADR 0030).
+
 ## [0.1.12] — 2026-08-24
 
 ### Changed

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "0.1.11",
+  "version": "0.1.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentshit/fountain-sdk",
-      "version": "0.1.11",
+      "version": "0.1.13",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Run a coding agent on a real computer, with your repos and your credentials, in one call.",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -3787,6 +3787,19 @@ export interface components {
             data: {
                 /** @description Access continues until current_period_end. */
                 cancel_at_period_end?: boolean;
+                /** @description The prepaid balance, in cents. Null while this deployment has not started burning credits; a client must not show a zero balance then. Nothing is refused at zero yet. */
+                credits?: {
+                    /** @description May be negative: an in-flight turn that crosses zero finishes. */
+                    balance_cents?: number;
+                    /** Format: date-time */
+                    expires_at?: string | null;
+                    /** @description Unspent credit from the earliest live grant, which expires at expires_at. */
+                    expiring_cents?: number;
+                    /** @description The part of the balance that was bought. It never expires and is spent last. */
+                    purchased_cents?: number;
+                    /** @description What one hour of turn time costs. */
+                    turn_hour_cents?: number;
+                } | null;
                 /** Format: date-time */
                 current_period_end?: string | null;
                 /**

--- a/sdk/typescript/src/http.ts
+++ b/sdk/typescript/src/http.ts
@@ -19,7 +19,7 @@ export interface RequestOptions {
  * this string is already what Fountain's request logs are keyed on. The
  * version half is asserted against `package.json` by a test.
  */
-export const USER_AGENT = "fountain-sdk-js/0.1.12";
+export const USER_AGENT = "fountain-sdk-js/0.1.13";
 
 /**
  * The thin layer everything else is built on: one bearer token, JSON in and


### PR DESCRIPTION
Stacked on #1096 (diff includes #1095 and #1096 until they merge).

**Adds**
- `Credits.active?/0` (billing on **and** `CREDIT_PRICING_SINCE` set) and `Credits.summary/2` — the one shape every surface renders: `balance_cents`, `expiring_cents` + `expires_at` (the earliest live grant's unspent part), `purchased_cents` (never expires, spent last), `turn_hour_cents`.
- `Credits.unspent_of/2` and `live_grants/2` move into the context; the granter delegates.
- **Billing page:** a Credits card (balance, price, expiry line, purchased line, negative-balance note, last ten ledger rows with human labels). Rendered only when active.
- **Dashboard:** a Credits tile. **Admin user detail:** a Credits tile with bought/expiring.
- **API:** `GET /api/account/billing` gains `credits` — an object when active, **`null` when not**, so a client never shows "$0.00" for an instance with no ledger in play. Schema + `sdk/typescript/src/generated/openapi.ts` regenerated.
- **Docs:** "Prepaid credits" section on `plans-and-prices.md` (vale/STE clean, docs-style clean, anchors checked).

The turn-hour allowance surfaces stay as they are for now; they come out when enforcement flips (phase 4/5), so the page never shows two contradicting stories.

**Tests** (6, `async: false` because the switch is global): everything hidden and API `null` with the switch off; summary arithmetic with a grant + purchase + burn; billing page content incl. ledger labels; negative balance called out; dashboard and admin agree; API shape exact.

Refs #1086, ADR 0030.

🤖 Generated with [Claude Code](https://claude.com/claude-code)