### PR TITLE
feat(credits): buy a pack, and claw it back on refund or dispute (#1086 phase 3)

### DIFF
--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -352,6 +352,7 @@ defmodule FountainWeb.Router do
     get "/billing", BillingApiController, :show
     post "/billing/portal", BillingApiController, :portal
     post "/billing/checkout", BillingApiController, :checkout
+    post "/billing/credits/checkout", BillingApiController, :credits_checkout
 
     # Export and deletion (#523). Deletion is irreversible and takes the
     # tenant key with it, so it wants the strongest credential the account has.

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -1867,6 +1867,11 @@ defmodule FountainWeb.Schemas do
                 turn_hour_cents: %Schema{
                   type: :integer,
                   description: "What one hour of turn time costs."
+                },
+                packs_cents: %Schema{
+                  type: :array,
+                  items: %Schema{type: :integer},
+                  description: "The packs on sale, ascending. Pass one to the credits checkout."
                 }
               }
             },
@@ -1908,6 +1913,24 @@ defmodule FountainWeb.Schemas do
         }
       },
       required: [:data]
+    })
+  end
+
+  defmodule CreditsCheckoutRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "CreditsCheckoutRequest",
+      type: :object,
+      properties: %{
+        cents: %Schema{
+          type: :integer,
+          description: "The pack to buy, in cents. Must be one of credits.packs_cents."
+        }
+      },
+      required: [:cents],
+      example: %{"cents" => 2500}
     })
   end
 

--- a/docs/guides/operate/plans-and-prices.md
+++ b/docs/guides/operate/plans-and-prices.md
@@ -109,7 +109,21 @@ records the decisions, and
 [issue 1086](https://github.com/BinaryBourbon/fountain/issues/1086) tracks
 the build.
 
-### The billing period
+### Sell credit packs
+
+A subscriber can buy credit on the billing page, or with
+`POST /api/account/billing/credits/checkout`. The packs are the amounts in
+`CREDIT_PACKS_CENTS`, $10, $25 and $100 by default. Each purchase is a
+one-time Stripe Checkout. Stripe reports the payment on the webhook, and
+Fountain adds the credit then, not before.
+
+Subscribe your webhook endpoint to two more events, `charge.refunded` and
+`charge.dispute.created`. On each one, Fountain removes the refunded or
+disputed amount from the balance, and the balance can go below zero. If you
+do not subscribe to them, a refund leaves the credit in place, and the
+tenant keeps what they did not pay for. Fountain does not add a disputed
+amount back when you win the dispute. Add it by hand from the admin page.
+
 
 Fountain measures the hours over the period that Stripe invoices. The
 `users.current_period_start` column holds the start of that period, and

--- a/ee/lib/fountain/billing.ex
+++ b/ee/lib/fountain/billing.ex
@@ -1172,7 +1172,15 @@ defmodule Fountain.Billing do
   Returns `{:ok, :duplicate}` for an event already seen.
   """
   @spec handle_event(Stripe.Event.t()) ::
-          {:ok, User.t() | :ignored | :duplicate | :stale | :comped_ignored | :other_subscription}
+          {:ok,
+           User.t()
+           | :ignored
+           | :duplicate
+           | :stale
+           | :comped_ignored
+           | :other_subscription
+           | :credits_purchased
+           | :credits_clawed_back}
           | {:error, term()}
   def handle_event(%Stripe.Event{id: id, type: type} = event) when is_binary(id) do
     # Stripe side effects run BEFORE the claim transaction opens (#393):
@@ -1350,7 +1358,14 @@ defmodule Fountain.Billing do
   All other event types return `{:ok, :ignored}` without touching the DB.
   """
   @spec sync_subscription(Stripe.Event.t()) ::
-          {:ok, User.t() | :ignored | :stale | :comped_ignored | :other_subscription}
+          {:ok,
+           User.t()
+           | :ignored
+           | :stale
+           | :comped_ignored
+           | :other_subscription
+           | :credits_purchased
+           | :credits_clawed_back}
           | {:error, term()}
   def sync_subscription(
         %Stripe.Event{
@@ -1358,18 +1373,40 @@ defmodule Fountain.Billing do
           data: %{object: session}
         } = event
       ) do
-    customer_id = extract_stripe_id(Map.get(session, :customer))
-    subscription_id = extract_stripe_id(Map.get(session, :subscription))
-    user_id = Map.get(session, :client_reference_id)
+    if Fountain.Credits.Purchases.credits_session?(session) do
+      # A credit pack (ADR 0030), not a subscription: grant and stop. The
+      # session carries no subscription id, so the subscription path below
+      # would only backfill the customer id and ignore the money.
+      case Fountain.Credits.Purchases.complete(session) do
+        {:ok, _entry} -> {:ok, :credits_purchased}
+        {:ok, :duplicate, _entry} -> {:ok, :credits_purchased}
+        {:error, :user_not_found} -> {:error, :user_not_found}
+        {:error, reason} -> {:error, reason}
+      end
+    else
+      sync_subscription_checkout(session, event)
+    end
+  end
 
-    user =
-      get_user_by_stripe_customer_id(customer_id, :for_update) ||
-        get_user_for_update(user_id)
+  # charge.refunded and charge.dispute.created only matter for a credit pack
+  # (ADR 0030 decision 5); a refund on a subscription invoice is Stripe's to
+  # reconcile and changes no entitlement here. Neither names a customer we
+  # need to look up: the purchase row does.
+  def sync_subscription(%Stripe.Event{type: "charge.refunded", data: %{object: charge}}) do
+    case Fountain.Credits.Purchases.refund(charge) do
+      {:ok, :nothing} -> {:ok, :ignored}
+      {:ok, _entry} -> {:ok, :credits_clawed_back}
+      {:ok, :duplicate, _} -> {:ok, :credits_clawed_back}
+      {:error, reason} -> {:error, reason}
+    end
+  end
 
-    cond do
-      is_nil(customer_id) -> {:ok, :ignored}
-      is_nil(user) -> {:error, :user_not_found}
-      true -> complete_checkout(user, customer_id, subscription_id, event_created_at(event))
+  def sync_subscription(%Stripe.Event{type: "charge.dispute.created", data: %{object: dispute}}) do
+    case Fountain.Credits.Purchases.dispute(dispute) do
+      {:ok, :nothing} -> {:ok, :ignored}
+      {:ok, _entry} -> {:ok, :credits_clawed_back}
+      {:ok, :duplicate, _} -> {:ok, :credits_clawed_back}
+      {:error, reason} -> {:error, reason}
     end
   end
 
@@ -1587,6 +1624,22 @@ defmodule Fountain.Billing do
   end
 
   def sync_subscription(_event), do: {:ok, :ignored}
+
+  defp sync_subscription_checkout(session, event) do
+    customer_id = extract_stripe_id(Map.get(session, :customer))
+    subscription_id = extract_stripe_id(Map.get(session, :subscription))
+    user_id = Map.get(session, :client_reference_id)
+
+    user =
+      get_user_by_stripe_customer_id(customer_id, :for_update) ||
+        get_user_for_update(user_id)
+
+    cond do
+      is_nil(customer_id) -> {:ok, :ignored}
+      is_nil(user) -> {:error, :user_not_found}
+      true -> complete_checkout(user, customer_id, subscription_id, event_created_at(event))
+    end
+  end
 
   # ─── Lifecycle emails (#283) ────────────────────────────────────────────────
 

--- a/ee/lib/fountain/credits/purchases.ex
+++ b/ee/lib/fountain/credits/purchases.ex
@@ -1,0 +1,222 @@
+defmodule Fountain.Credits.Purchases do
+  @moduledoc """
+  Buying credits, and taking them back when the money goes back (ADR 0030
+  decision 5): Fountain owns the ledger, Stripe is the till.
+
+    * `checkout_url/3` opens a one-time Stripe Checkout in `mode: :payment`
+      for one of `Credits.packs/0`. Only a subscriber may buy — a trialing
+      account is refused (`{:error, :subscription_required}`), because
+      buying is a spend and the gate for spend is "subscribe first" (ADR
+      0006); a comped account is refused (`{:error, :comped}`) because it
+      has nothing to pay for.
+    * `complete/1` grants the pack when `checkout.session.completed` arrives
+      for a payment-mode session Fountain opened, under `purchase:<session>`.
+      The payment intent id is kept on the row so a refund can find it.
+    * `refund/1` claws back on `charge.refunded`. Refunds are cumulative and
+      can be partial, so the debit is the charge's `amount_refunded` less
+      what this charge has already been clawed back, under
+      `clawback_refund:<charge>:<amount_refunded>`.
+    * `dispute/1` claws back the disputed amount on `charge.dispute.created`
+      under `clawback_dispute:<dispute>`. A dispute later won is not credited
+      back automatically — that is an operator's `grant_admin`, on purpose,
+      because a won dispute is rare and a wrong automatic re-grant is free
+      money.
+
+  A clawback may take the balance below zero. That is the point: a refunded
+  pack that was already spent is a debt, and hiding it would be the
+  free-money bug the ADR names.
+
+  The Stripe endpoint must be subscribed to `charge.refunded` and
+  `charge.dispute.created` for the clawbacks to arrive; the operator docs say
+  so.
+  """
+
+  import Ecto.Query
+
+  alias Fountain.Accounts.User
+  alias Fountain.Billing
+  alias Fountain.Credits
+  alias Fountain.Credits.LedgerEntry
+  alias Fountain.Repo
+
+  require Logger
+
+  @metadata_marker "fountain_credits_cents"
+
+  @doc """
+  A Stripe Checkout URL for `cents` of credit. `cents` must be one of
+  `Credits.packs/0`.
+  """
+  @spec checkout_url(User.t(), pos_integer(), String.t()) ::
+          {:ok, String.t()} | {:error, term()}
+  def checkout_url(%User{subscription_status: "comped"}, _cents, _return_url),
+    do: {:error, :comped}
+
+  def checkout_url(%User{subscription_status: status}, _cents, _return_url)
+      when status not in ~w(active past_due),
+      do: {:error, :subscription_required}
+
+  def checkout_url(%User{} = user, cents, return_url) when is_integer(cents) do
+    if cents in Credits.packs() do
+      with {:ok, user} <- Billing.ensure_stripe_customer(user) do
+        metadata = %{@metadata_marker => Integer.to_string(cents), "fountain_user_id" => user.id}
+
+        params = %{
+          mode: :payment,
+          line_items: [
+            %{
+              price_data: %{
+                currency: "usd",
+                unit_amount: cents,
+                product_data: %{name: "Fountain credits, #{Credits.format_cents(cents)}"}
+              },
+              quantity: 1
+            }
+          ],
+          success_url: return_url <> "?credits=success",
+          cancel_url: return_url,
+          customer: user.stripe_customer_id,
+          client_reference_id: user.id,
+          metadata: metadata,
+          # Copied onto the PaymentIntent so the charge a refund names can be
+          # traced back even if the session is gone.
+          payment_intent_data: %{metadata: metadata}
+        }
+
+        case Stripe.Checkout.Session.create(params) do
+          {:ok, session} -> {:ok, session.url}
+          {:error, reason} -> {:error, reason}
+        end
+      end
+    else
+      {:error, :unknown_pack}
+    end
+  end
+
+  @doc "Whether a Checkout session is one of ours in payment mode."
+  @spec credits_session?(map()) :: boolean()
+  def credits_session?(session) do
+    Map.get(session, :mode) in ["payment", :payment] and is_map(Map.get(session, :metadata)) and
+      Map.has_key?(Map.get(session, :metadata), @metadata_marker)
+  end
+
+  @doc """
+  Grant the pack a completed payment-mode session paid for. Returns
+  `{:ok, entry}`, `{:ok, :duplicate, entry}`, or an error when the session
+  is not ours or names no user.
+  """
+  @spec complete(map()) :: Credits.post_result() | {:error, :not_credits | :user_not_found}
+  def complete(session) do
+    with true <- credits_session?(session) || {:error, :not_credits},
+         {:ok, cents} <- pack_cents(session),
+         %User{} = user <- session_user(session) || {:error, :user_not_found} do
+      Credits.grant(user.id, cents, "purchase",
+        idempotency_key: "purchase:#{Map.get(session, :id)}",
+        resource_type: "stripe_checkout_session",
+        resource_id: Map.get(session, :id),
+        actor: "system:stripe_webhook",
+        metadata: %{
+          "payment_intent" => stripe_id(Map.get(session, :payment_intent)),
+          "amount_total" => Map.get(session, :amount_total)
+        }
+      )
+    end
+  end
+
+  defp pack_cents(session) do
+    case Integer.parse(Map.get(session.metadata, @metadata_marker, "")) do
+      {cents, ""} when cents > 0 -> {:ok, cents}
+      _ -> {:error, :not_credits}
+    end
+  end
+
+  defp session_user(session) do
+    customer_id = stripe_id(Map.get(session, :customer))
+
+    user_id =
+      Map.get(session, :client_reference_id) || get_in(session, [:metadata, "fountain_user_id"])
+
+    (is_binary(customer_id) && Repo.get_by(User, stripe_customer_id: customer_id)) ||
+      (is_binary(user_id) && Repo.get(User, user_id)) || nil
+  end
+
+  @doc """
+  Claw back what a refunded charge has returned to the customer, less what
+  was already clawed back for that charge. `{:ok, :nothing}` when the charge
+  is not a credits purchase or nothing new was refunded.
+  """
+  @spec refund(map()) :: Credits.post_result() | {:ok, :nothing}
+  def refund(charge) do
+    charge_id = Map.get(charge, :id)
+    refunded = Map.get(charge, :amount_refunded) || 0
+
+    case purchase_for(stripe_id(Map.get(charge, :payment_intent))) do
+      nil ->
+        {:ok, :nothing}
+
+      %LedgerEntry{} = purchase ->
+        already = clawed_back(purchase.user_id, "clawback_refund", charge_id)
+        delta = refunded - already
+
+        if delta > 0 do
+          Credits.debit(purchase.user_id, delta, "clawback_refund",
+            idempotency_key: "clawback_refund:#{charge_id}:#{refunded}",
+            resource_type: "stripe_charge",
+            resource_id: charge_id,
+            actor: "system:stripe_webhook",
+            metadata: %{"purchase_id" => purchase.id, "amount_refunded" => refunded}
+          )
+        else
+          {:ok, :nothing}
+        end
+    end
+  end
+
+  @doc "Claw back a disputed amount. `{:ok, :nothing}` when the charge is not a credits purchase."
+  @spec dispute(map()) :: Credits.post_result() | {:ok, :nothing}
+  def dispute(dispute) do
+    amount = Map.get(dispute, :amount) || 0
+
+    case purchase_for(stripe_id(Map.get(dispute, :payment_intent))) do
+      %LedgerEntry{} = purchase when amount > 0 ->
+        Credits.debit(purchase.user_id, amount, "clawback_dispute",
+          idempotency_key: "clawback_dispute:#{Map.get(dispute, :id)}",
+          resource_type: "stripe_dispute",
+          resource_id: Map.get(dispute, :id),
+          actor: "system:stripe_webhook",
+          metadata: %{
+            "purchase_id" => purchase.id,
+            "charge" => stripe_id(Map.get(dispute, :charge)),
+            "reason" => Map.get(dispute, :reason)
+          }
+        )
+
+      _ ->
+        {:ok, :nothing}
+    end
+  end
+
+  defp purchase_for(nil), do: nil
+
+  defp purchase_for(payment_intent) when is_binary(payment_intent) do
+    from(e in LedgerEntry,
+      where: e.reason == "purchase",
+      where: fragment("? ->> 'payment_intent' = ?", e.metadata, ^payment_intent),
+      limit: 1
+    )
+    |> Repo.one()
+  end
+
+  defp clawed_back(user_id, reason, resource_id) do
+    from(e in LedgerEntry,
+      where: e.user_id == ^user_id and e.reason == ^reason and e.resource_id == ^resource_id,
+      select: coalesce(sum(e.amount_cents), 0)
+    )
+    |> Repo.one()
+    |> Kernel.-()
+  end
+
+  defp stripe_id(value) when is_binary(value), do: value
+  defp stripe_id(%{id: id}) when is_binary(id), do: id
+  defp stripe_id(_), do: nil
+end

--- a/ee/lib/fountain_web/controllers/billing_api_controller.ex
+++ b/ee/lib/fountain_web/controllers/billing_api_controller.ex
@@ -140,6 +140,47 @@ defmodule FountainWeb.BillingApiController do
 
   ## Private
 
+  operation(:credits_checkout,
+    summary: "Mint a Stripe Checkout URL for a credit pack",
+    description:
+      "A one-time payment for one of the packs this deployment sells " <>
+        "(`GET /api/account/billing` lists them under `credits.packs_cents`). " <>
+        "The balance moves when Stripe's webhook confirms payment, not when " <>
+        "this returns. Refused for a trialing account with " <>
+        "`subscription_required`, for a comped one with `comped`, and for an " <>
+        "amount that is not a pack with `unknown_pack`.",
+    request_body: {"Pack", "application/json", Schemas.CreditsCheckoutRequest, required: true},
+    responses: [
+      ok: {"Stripe URL", "application/json", Schemas.StripeUrlResponse},
+      forbidden: {"Insufficient scope", "application/json", Schemas.Error},
+      not_found: {"Billing disabled", "application/json", Schemas.Error},
+      unprocessable_entity: {"Refused", "application/json", Schemas.Error},
+      bad_gateway: {"Stripe unreachable", "application/json", Schemas.Error}
+    ]
+  )
+
+  def credits_checkout(conn, params) do
+    user = conn.assigns.current_user
+
+    with :ok <- require_billing(),
+         {:ok, cents} <- pack_param(params) do
+      user
+      |> Fountain.Credits.Purchases.checkout_url(cents, return_url())
+      |> render_url(conn)
+    else
+      {:error, :bad_cents} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> json(%{error: "unknown_pack", message: "cents must be one of the packs on offer."})
+
+      other ->
+        other
+    end
+  end
+
+  defp pack_param(%{"cents" => cents}) when is_integer(cents) and cents > 0, do: {:ok, cents}
+  defp pack_param(_), do: {:error, :bad_cents}
+
   defp require_billing do
     if Billing.enabled?(), do: :ok, else: {:error, :billing_disabled}
   end
@@ -162,6 +203,21 @@ defmodule FountainWeb.BillingApiController do
       error: "comped",
       message: "This account is comped — there is nothing to pay and nothing to manage."
     })
+  end
+
+  defp render_url({:error, :subscription_required}, conn) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{
+      error: "subscription_required",
+      message: "Subscribe first, then you can buy credits."
+    })
+  end
+
+  defp render_url({:error, :unknown_pack}, conn) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{error: "unknown_pack", message: "cents must be one of the packs on offer."})
   end
 
   defp render_url({:error, :no_customer}, conn) do

--- a/ee/lib/fountain_web/controllers/billing_api_json.ex
+++ b/ee/lib/fountain_web/controllers/billing_api_json.ex
@@ -50,7 +50,8 @@ defmodule FountainWeb.BillingApiJSON do
       expiring_cents: c.expiring_cents,
       expires_at: c.expires_at,
       purchased_cents: c.purchased_cents,
-      turn_hour_cents: c.turn_hour_cents
+      turn_hour_cents: c.turn_hour_cents,
+      packs_cents: Fountain.Credits.packs()
     }
   end
 

--- a/ee/lib/fountain_web/live/billing_live.ex
+++ b/ee/lib/fountain_web/live/billing_live.ex
@@ -117,6 +117,37 @@ defmodule FountainWeb.Live.BillingLive do
     end
   end
 
+  # A credit pack is a one-time Checkout (ADR 0030 decision 5). Stripe's
+  # webhook grants it; the page reloads on return and shows the new balance.
+  @impl true
+  def handle_event("buy_credits", %{"cents" => cents}, socket) do
+    user = socket.assigns.current_user
+    socket = assign(socket, :stripe_url_loading, true)
+
+    with {cents, ""} <- Integer.parse(to_string(cents)),
+         {:ok, url} <- Credits.Purchases.checkout_url(user, cents, billing_return_url()) do
+      {:noreply, redirect(socket, external: url)}
+    else
+      {:error, :subscription_required} ->
+        {:noreply,
+         socket
+         |> assign(:stripe_url_loading, false)
+         |> put_flash(:error, "Subscribe first, then you can buy credits.")}
+
+      {:error, :comped} ->
+        {:noreply,
+         socket
+         |> assign(:stripe_url_loading, false)
+         |> put_flash(:info, "This account is comped — there is nothing to buy.")}
+
+      _ ->
+        {:noreply,
+         socket
+         |> assign(:stripe_url_loading, false)
+         |> put_flash(:error, "Unable to reach Stripe. Please try again.")}
+    end
+  end
+
   @impl true
   def handle_event("manage_subscription", _params, socket) do
     user = socket.assigns.current_user
@@ -405,6 +436,27 @@ defmodule FountainWeb.Live.BillingLive do
         <p :if={@credits.balance_cents < 0} class="mt-2 text-xs text-amber-700">
           Your balance is below zero. Nothing is limited yet; the next grant or purchase
           brings it back up.
+        </p>
+        <div
+          :if={@current_user.subscription_status in ~w(active past_due)}
+          class="mt-4 flex flex-wrap items-center gap-2"
+        >
+          <button
+            :for={cents <- Credits.packs()}
+            phx-click="buy_credits"
+            phx-value-cents={cents}
+            disabled={@stripe_url_loading}
+            class="rounded-md border border-indigo-600 px-3 py-1.5 text-sm font-medium text-indigo-700 hover:bg-indigo-50 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            Buy {Credits.format_cents(cents)}
+          </button>
+          <span class="text-xs text-gray-500">One-time payment. Never expires.</span>
+        </div>
+        <p
+          :if={@current_user.subscription_status == "trialing"}
+          class="mt-4 text-xs text-gray-500"
+        >
+          Subscribe to buy credits. Your trial credit is what you have until then.
         </p>
         <table :if={@ledger != []} class="mt-4 w-full text-xs">
           <thead class="text-left text-gray-500">

--- a/ee/test/fountain/credits_purchases_test.exs
+++ b/ee/test/fountain/credits_purchases_test.exs
@@ -1,0 +1,249 @@
+defmodule Fountain.Credits.PurchasesTest do
+  @moduledoc """
+  Buying a pack and taking it back (ADR 0030 decision 5). What is pinned:
+  who may buy, that the grant lands once per session however many times
+  Stripe delivers it, that refunds are cumulative and partial, and that a
+  clawback may go below zero.
+  """
+
+  use Fountain.DataCase, async: true
+  use Mimic
+
+  alias Fountain.Accounts.User
+  alias Fountain.Billing
+  alias Fountain.Credits
+  alias Fountain.Credits.Purchases
+  alias Fountain.Repo
+
+  @return "https://fountain.test/account/billing"
+
+  defp with_status(user, status) do
+    {:ok, user} =
+      user
+      |> User.billing_changeset(%{
+        subscription_status: status,
+        stripe_customer_id: "cus_#{user.id}"
+      })
+      |> Repo.update()
+
+    user
+  end
+
+  defp session(user, cents, opts \\ []) do
+    %{
+      id: Keyword.get(opts, :id, "cs_test_1"),
+      mode: "payment",
+      customer: user.stripe_customer_id,
+      client_reference_id: user.id,
+      payment_intent: Keyword.get(opts, :pi, "pi_1"),
+      amount_total: cents,
+      metadata: %{
+        "fountain_credits_cents" => Integer.to_string(cents),
+        "fountain_user_id" => user.id
+      }
+    }
+  end
+
+  describe "checkout_url/3" do
+    test "opens a payment-mode session for a pack, with the pack in the metadata" do
+      user = insert_active_user() |> with_status("active")
+      test = self()
+
+      expect(Stripe.Checkout.Session, :create, fn params ->
+        send(test, {:params, params})
+        {:ok, %Stripe.Checkout.Session{url: "https://checkout.stripe.com/x"}}
+      end)
+
+      assert {:ok, "https://checkout.stripe.com/x"} = Purchases.checkout_url(user, 2500, @return)
+      assert_receive {:params, params}
+      assert params.mode == :payment
+
+      assert [%{price_data: %{unit_amount: 2500, currency: "usd"}, quantity: 1}] =
+               params.line_items
+
+      assert params.metadata["fountain_credits_cents"] == "2500"
+      assert params.payment_intent_data.metadata["fountain_credits_cents"] == "2500"
+      assert params.customer == user.stripe_customer_id
+      assert params.client_reference_id == user.id
+      assert params.success_url == @return <> "?credits=success"
+    end
+
+    test "a trialing account cannot buy, a comped one has nothing to buy, and only packs sell" do
+      reject(&Stripe.Checkout.Session.create/1)
+
+      trial = insert_verified_user()
+      assert {:error, :subscription_required} = Purchases.checkout_url(trial, 1000, @return)
+
+      canceled = insert_active_user() |> with_status("canceled")
+      assert {:error, :subscription_required} = Purchases.checkout_url(canceled, 1000, @return)
+
+      comped = insert_active_user()
+      {:ok, comped} = Billing.comp_account(comped)
+      assert {:error, :comped} = Purchases.checkout_url(comped, 1000, @return)
+
+      active = insert_active_user() |> with_status("active")
+      assert {:error, :unknown_pack} = Purchases.checkout_url(active, 1234, @return)
+    end
+  end
+
+  describe "complete/1" do
+    test "grants the pack once, keyed by the session, with the payment intent on the row" do
+      user = insert_active_user() |> with_status("active")
+      s = session(user, 2500)
+
+      assert {:ok, entry} = Purchases.complete(s)
+      assert entry.reason == "purchase"
+      assert entry.amount_cents == 2500
+      assert entry.idempotency_key == "purchase:cs_test_1"
+      assert entry.metadata["payment_intent"] == "pi_1"
+      assert is_nil(entry.expires_at)
+
+      assert {:ok, :duplicate, ^entry} = Purchases.complete(s)
+      assert Credits.balance(user.id) == 2500
+    end
+
+    test "a subscription-mode session is not ours" do
+      user = insert_active_user() |> with_status("active")
+
+      assert {:error, :not_credits} =
+               Purchases.complete(%{
+                 id: "cs_sub",
+                 mode: "subscription",
+                 customer: user.stripe_customer_id,
+                 metadata: %{}
+               })
+
+      assert {:error, :user_not_found} =
+               Purchases.complete(%{
+                 session(user, 1000)
+                 | customer: "cus_nobody",
+                   client_reference_id: nil,
+                   metadata: %{"fountain_credits_cents" => "1000"}
+               })
+    end
+  end
+
+  describe "refund/1 and dispute/1" do
+    setup do
+      user = insert_active_user() |> with_status("active")
+      {:ok, _} = Purchases.complete(session(user, 2500))
+      %{user: user}
+    end
+
+    test "a partial refund claws back the delta, cumulatively, once per amount", %{user: user} do
+      charge = %{id: "ch_1", payment_intent: "pi_1", amount_refunded: 1000}
+      assert {:ok, entry} = Purchases.refund(charge)
+      assert entry.amount_cents == -1000
+      assert entry.idempotency_key == "clawback_refund:ch_1:1000"
+      assert Credits.balance(user.id) == 1500
+
+      # Redelivered: the cumulative amount is already clawed back, nothing new.
+      assert {:ok, :nothing} = Purchases.refund(charge)
+      assert Credits.balance(user.id) == 1500
+
+      # The rest is refunded: Stripe reports the cumulative 2500.
+      assert {:ok, entry} = Purchases.refund(%{charge | amount_refunded: 2500})
+      assert entry.amount_cents == -1500
+      assert Credits.balance(user.id) == 0
+    end
+
+    test "a refund of a spent pack goes below zero", %{user: user} do
+      {:ok, _} = Credits.debit(user.id, 2000, "burn_turn", idempotency_key: "spent")
+
+      assert {:ok, _} =
+               Purchases.refund(%{id: "ch_1", payment_intent: "pi_1", amount_refunded: 2500})
+
+      assert Credits.balance(user.id) == -2000
+    end
+
+    test "a charge that is not a credits purchase is nothing to us" do
+      assert {:ok, :nothing} =
+               Purchases.refund(%{id: "ch_x", payment_intent: "pi_other", amount_refunded: 500})
+
+      assert {:ok, :nothing} =
+               Purchases.refund(%{id: "ch_y", payment_intent: nil, amount_refunded: 500})
+    end
+
+    test "a dispute claws back its amount once", %{user: user} do
+      d = %{
+        id: "dp_1",
+        charge: "ch_1",
+        payment_intent: "pi_1",
+        amount: 2500,
+        reason: "fraudulent"
+      }
+
+      assert {:ok, entry} = Purchases.dispute(d)
+      assert entry.reason == "clawback_dispute"
+      assert entry.metadata["reason"] == "fraudulent"
+      assert {:ok, :duplicate, _} = Purchases.dispute(d)
+      assert Credits.balance(user.id) == 0
+      assert {:ok, :nothing} = Purchases.dispute(%{d | payment_intent: "pi_other"})
+    end
+  end
+
+  describe "through the webhook" do
+    test "checkout.session.completed in payment mode grants; refund and dispute claw back", %{} do
+      user = insert_active_user() |> with_status("active")
+
+      grant = %Stripe.Event{
+        id: "evt_credits_1",
+        type: "checkout.session.completed",
+        created: DateTime.utc_now() |> DateTime.to_unix(),
+        data: %{object: session(user, 1000, id: "cs_hook")}
+      }
+
+      assert {:ok, :credits_purchased} = Billing.handle_event(grant)
+      assert {:ok, :duplicate} = Billing.handle_event(grant)
+      assert Credits.balance(user.id) == 1000
+
+      refund = %Stripe.Event{
+        id: "evt_refund_1",
+        type: "charge.refunded",
+        created: DateTime.utc_now() |> DateTime.to_unix(),
+        data: %{object: %{id: "ch_hook", payment_intent: "pi_1", amount_refunded: 400}}
+      }
+
+      assert {:ok, :credits_clawed_back} = Billing.handle_event(refund)
+      assert Credits.balance(user.id) == 600
+
+      dispute = %Stripe.Event{
+        id: "evt_dispute_1",
+        type: "charge.dispute.created",
+        created: DateTime.utc_now() |> DateTime.to_unix(),
+        data: %{object: %{id: "dp_hook", charge: "ch_hook", payment_intent: "pi_1", amount: 600}}
+      }
+
+      assert {:ok, :credits_clawed_back} = Billing.handle_event(dispute)
+      assert Credits.balance(user.id) == 0
+
+      # Not a credits charge: acknowledged, ignored.
+      other = %{
+        refund
+        | id: "evt_refund_2",
+          data: %{object: %{id: "ch_o", payment_intent: "pi_sub", amount_refunded: 1}}
+      }
+
+      assert {:ok, :ignored} = Billing.handle_event(other)
+    end
+
+    test "a subscription checkout still takes the subscription path" do
+      user = insert_verified_user()
+
+      event = %Stripe.Event{
+        type: "checkout.session.completed",
+        data: %{
+          object: %{
+            customer: "cus_orphan",
+            client_reference_id: user.id,
+            mode: "subscription",
+            metadata: %{}
+          }
+        }
+      }
+
+      assert {:ok, %User{stripe_customer_id: "cus_orphan"}} = Billing.sync_subscription(event)
+      assert Credits.balance(user.id) == 0
+    end
+  end
+end

--- a/ee/test/fountain_web/credits_surfaces_test.exs
+++ b/ee/test/fountain_web/credits_surfaces_test.exs
@@ -28,7 +28,12 @@ defmodule FountainWeb.CreditsSurfacesTest do
 
   defp subscriber do
     user = insert_active_user()
-    {:ok, user} = user |> User.billing_changeset(%{plan: "solo"}) |> Repo.update()
+
+    {:ok, user} =
+      user
+      |> User.billing_changeset(%{plan: "solo", stripe_customer_id: "cus_#{user.id}"})
+      |> Repo.update()
+
     user
   end
 
@@ -127,6 +132,71 @@ defmodule FountainWeb.CreditsSurfacesTest do
       assert html =~ "$12.34 bought"
     end
 
+    test "a subscriber sees the packs and buying redirects to Stripe; a trialist is told to subscribe",
+         %{conn: conn} do
+      user = subscriber()
+      {:ok, _lv, html} = live(login_user(conn, user), ~p"/account/billing")
+      assert html =~ "Buy $10.00"
+      assert html =~ "Buy $100.00"
+
+      Mimic.copy(Stripe.Checkout.Session)
+
+      Mimic.stub(Stripe.Checkout.Session, :create, fn _ ->
+        {:ok, %Stripe.Checkout.Session{url: "https://checkout.stripe.com/pack"}}
+      end)
+
+      {:ok, lv, _} = live(login_user(conn, user), ~p"/account/billing")
+
+      assert {:error, {:redirect, %{to: "https://checkout.stripe.com/pack"}}} =
+               render_click(lv, "buy_credits", %{"cents" => "2500"})
+
+      trial = insert_verified_user()
+      {:ok, _lv, html} = live(login_user(conn, trial), ~p"/account/billing")
+      refute html =~ "Buy $10.00"
+      assert html =~ "Subscribe to buy credits"
+    end
+
+    test "the credits checkout endpoint", %{conn: conn} do
+      user = subscriber()
+      {_rec, key} = insert_api_key(user)
+
+      Mimic.copy(Stripe.Checkout.Session)
+
+      Mimic.stub(Stripe.Checkout.Session, :create, fn _ ->
+        {:ok, %Stripe.Checkout.Session{url: "https://checkout.stripe.com/api"}}
+      end)
+
+      body =
+        conn
+        |> authed_with_key(key)
+        |> put_req_header("content-type", "application/json")
+        |> post("/api/account/billing/credits/checkout", %{"cents" => 1000})
+        |> json_response(200)
+
+      assert body["data"]["url"] == "https://checkout.stripe.com/api"
+
+      body =
+        conn
+        |> authed_with_key(key)
+        |> put_req_header("content-type", "application/json")
+        |> post("/api/account/billing/credits/checkout", %{"cents" => 999})
+        |> json_response(422)
+
+      assert body["error"] == "unknown_pack"
+
+      trial = insert_verified_user()
+      {_rec, tkey} = insert_api_key(trial)
+
+      body =
+        conn
+        |> authed_with_key(tkey)
+        |> put_req_header("content-type", "application/json")
+        |> post("/api/account/billing/credits/checkout", %{"cents" => 1000})
+        |> json_response(422)
+
+      assert body["error"] == "subscription_required"
+    end
+
     test "the API carries the same shape", %{conn: conn} do
       user = subscriber()
       expires = ~U[2099-09-01 00:00:00Z]
@@ -143,7 +213,8 @@ defmodule FountainWeb.CreditsSurfacesTest do
                "expiring_cents" => 1000,
                "expires_at" => "2099-09-01T00:00:00Z",
                "purchased_cents" => 0,
-               "turn_hour_cents" => 25
+               "turn_hour_cents" => 25,
+               "packs_cents" => [1000, 2500, 10_000]
              }
     end
   end

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -10,6 +10,16 @@ server releases.
 
 ---
 
+## [0.1.14] — 2026-08-24
+
+### Added
+
+- `POST /api/account/billing/credits/checkout` mints a one-time Stripe
+  Checkout URL for a credit pack; `credits.packs_cents` on
+  `GET /api/account/billing` lists the packs. Refused with
+  `subscription_required` for a trialing account and `unknown_pack` for an
+  amount that is not on sale.
+
 ## [0.1.13] — 2026-08-24
 
 ### Added

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentshit/fountain-sdk",
-      "version": "0.1.13",
+      "version": "0.1.14",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Run a coding agent on a real computer, with your repos and your credentials, in one call.",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -861,6 +861,26 @@ export interface paths {
         patch: operations["FountainWeb.BuzzAgentController.update (2)"];
         trace?: never;
     };
+    "/api/account/billing/credits/checkout": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Mint a Stripe Checkout URL for a credit pack
+         * @description A one-time payment for one of the packs this deployment sells (`GET /api/account/billing` lists them under `credits.packs_cents`). The balance moves when Stripe's webhook confirms payment, not when this returns. Refused for a trialing account with `subscription_required`, for a comped one with `comped`, and for an amount that is not a pack with `unknown_pack`.
+         */
+        post: operations["FountainWeb.BillingApiController.credits_checkout"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/admin/users": {
         parameters: {
             query?: never;
@@ -3346,6 +3366,16 @@ export interface components {
         AdminAuditListResponse: {
             data: components["schemas"]["AuditEvent"][];
         };
+        /**
+         * CreditsCheckoutRequest
+         * @example {
+         *       "cents": 2500
+         *     }
+         */
+        CreditsCheckoutRequest: {
+            /** @description The pack to buy, in cents. Must be one of credits.packs_cents. */
+            cents: number;
+        };
         /** TeamScheduleResponse */
         TeamScheduleResponse: {
             data: components["schemas"]["TeamSchedule"];
@@ -3795,6 +3825,8 @@ export interface components {
                     expires_at?: string | null;
                     /** @description Unspent credit from the earliest live grant, which expires at expires_at. */
                     expiring_cents?: number;
+                    /** @description The packs on sale, ascending. Pass one to the credits checkout. */
+                    packs_cents?: number[];
                     /** @description The part of the balance that was bought. It never expires and is spent last. */
                     purchased_cents?: number;
                     /** @description What one hour of turn time costs. */
@@ -6167,6 +6199,67 @@ export interface operations {
             };
             /** @description Validation error */
             422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    "FountainWeb.BillingApiController.credits_checkout": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Pack */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreditsCheckoutRequest"];
+            };
+        };
+        responses: {
+            /** @description Stripe URL */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["StripeUrlResponse"];
+                };
+            };
+            /** @description Insufficient scope */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Billing disabled */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Refused */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Stripe unreachable */
+            502: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/sdk/typescript/src/http.ts
+++ b/sdk/typescript/src/http.ts
@@ -19,7 +19,7 @@ export interface RequestOptions {
  * this string is already what Fountain's request logs are keyed on. The
  * version half is asserted against `package.json` by a test.
  */
-export const USER_AGENT = "fountain-sdk-js/0.1.13";
+export const USER_AGENT = "fountain-sdk-js/0.1.14";
 
 /**
  * The thin layer everything else is built on: one bearer token, JSON in and


### PR DESCRIPTION
Stacked on #1097 (diff includes #1095–#1097 until they merge).

**Adds** `Fountain.Credits.Purchases` (ADR 0030 decision 5: Fountain owns the ledger, Stripe is the till):
- `checkout_url/3`: one-time `mode: :payment` Checkout for one of `Credits.packs/0`. Refused for **trialing** (`subscription_required` — buying is a spend, the gate is subscribe-first) and **comped** (`comped`); non-pack amounts → `unknown_pack`. Pack size travels in session **and** `payment_intent_data` metadata.
- `complete/1` on `checkout.session.completed` (payment mode): grants `purchase:<session_id>`, payment intent kept on the row. Redelivery is a duplicate, balance moves once.
- `refund/1` on `charge.refunded`: cumulative `amount_refunded` minus what that charge already clawed back → `clawback_refund:<charge>:<amount_refunded>`. Partial and repeated refunds handled.
- `dispute/1` on `charge.dispute.created`: `clawback_dispute:<dispute_id>`. A won dispute is **not** auto-re-granted (operator `grant_admin`), by design.
- Clawbacks may go below zero — a refunded pack already spent is a debt; hiding it is the free-money bug.
- `Billing.sync_subscription/1`: payment-mode sessions branch before the subscription path; two new clauses for the charge events; `{:ok, :credits_purchased | :credits_clawed_back}` results.

**Surfaces:** "Buy $10 / $25 / $100" on `/account/billing` for a subscriber (trialist sees "Subscribe to buy credits"); `POST /api/account/billing/credits/checkout {cents}`; `credits.packs_cents`; schema + SDK regenerated, **SDK 0.1.14**. Docs: "Sell credit packs" section, including the two webhook events to subscribe to.

**Tests** (12 new): params of the Checkout call; who may buy; grant once per session; subscription-mode sessions untouched; partial/cumulative/redelivered refunds; refund of a spent pack goes negative; dispute once; the three events end-to-end through `Billing.handle_event/1` with the `stripe_events` claim; LiveView buttons + redirect; API 200/422/422.

**Operator step after deploy:** add `charge.refunded` and `charge.dispute.created` to the Stripe webhook endpoint.

Refs #1086, ADR 0030.

🤖 Generated with [Claude Code](https://claude.com/claude-code)