### PR TITLE
feat(credits): the soft stop, the renewal grant, admin grants and runway emails (#1086 phase 4a)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -286,6 +286,7 @@ STRIPE_PRICE_MONTHLY_CENTS=
 # prices default to unset, and unset burns nothing: turning one on is a price
 # increase. Packs are the amounts a tenant can buy, ascending.
 # CREDIT_PRICING_SINCE=2026-09-01T00:00:00Z
+# CREDIT_ENFORCE=true
 # CREDIT_TURN_HOUR_CENTS=25
 # CREDIT_NUMBER_CENTS=
 # CREDIT_INBOX_CENTS=

--- a/apps/fountain/lib/fountain/audit/admin_event.ex
+++ b/apps/fountain/lib/fountain/audit/admin_event.ex
@@ -52,6 +52,7 @@ defmodule Fountain.Audit.AdminEvent do
     admin.stripe.resynced
     admin.plan.changed
     admin.comped_contacts.changed
+    admin.credits.granted
   )
 
   def event_types, do: @event_types

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -1716,7 +1716,7 @@ defmodule Fountain.Conversations do
          {:ok, perm_policy} <- resolve_permission_policy(attrs["permission_policy"], agent),
          {:ok, parent_id} <- resolve_parent_id(attrs["parent_conversation_id"], user_id),
          :ok <- Fountain.Accounts.check_not_suspended(user_id),
-         :ok <- Fountain.Billing.check_active(user_id),
+         :ok <- Fountain.Billing.check_spend(user_id),
          # A persistent launch lands on the identity's home when there is one
          # (ADR 0023 gate 6): `{:home, sandbox}` leaves the `with` and attaches
          # below. Only when there is none does a machine get provisioned, and
@@ -2221,7 +2221,7 @@ defmodule Fountain.Conversations do
          {:ok, perm_policy} <- resolve_permission_policy(attrs["permission_policy"], agent),
          {:ok, parent_id} <- resolve_parent_id(attrs["parent_conversation_id"], user_id),
          :ok <- Fountain.Accounts.check_not_suspended(user_id),
-         :ok <- Fountain.Billing.check_active(user_id),
+         :ok <- Fountain.Billing.check_spend(user_id),
          %Sandbox{} = sandbox <- get_sandbox(sandbox_id, user_id) || {:error, :sandbox_not_found},
          :ok <- check_attachable(sandbox, agent, vault_id, env_id),
          :ok <- check_attach_capacity(sandbox, agent, attrs["prompt"]),
@@ -2681,7 +2681,7 @@ defmodule Fountain.Conversations do
           # the quota gate. The per-turn gate in ConversationServer is the
           # backstop; this one makes the refusal synchronous at the API door.
           with :ok <- Fountain.Accounts.check_not_suspended(conv.user_id),
-               :ok <- Fountain.Billing.check_active(conv.user_id),
+               :ok <- Fountain.Billing.check_spend(conv.user_id),
                {:ok, _} <- wake_suspended_sandbox(conv.user_id, sandbox_id) do
             case start_conversation_server(conv, sandbox_id, runtime_module, initial_prompt) do
               {:error, {:already_started, winner_pid}} ->
@@ -2939,7 +2939,7 @@ defmodule Fountain.Conversations do
     if mode == "persistent", do: _ = mark_old_sandbox_terminated(conv.sandbox_id)
 
     with :ok <- Fountain.Accounts.check_not_suspended(conv.user_id),
-         :ok <- Fountain.Billing.check_active(conv.user_id),
+         :ok <- Fountain.Billing.check_spend(conv.user_id),
          # A fresh sandbox is a fresh placement decision — re-resolve from
          # the agent, so a conversation whose old sandbox died can migrate
          # providers naturally.

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -3826,7 +3826,7 @@ defmodule Fountain.Conversations.ConversationServer do
   # continued service per live sandbox (#313). Suspension is the same shape.
   defp turn_gate(user_id) do
     with :ok <- Fountain.Accounts.check_not_suspended(user_id) do
-      Fountain.Billing.check_active(user_id)
+      Fountain.Billing.check_spend(user_id)
     end
   end
 

--- a/apps/fountain/lib/fountain/quotas.ex
+++ b/apps/fountain/lib/fountain/quotas.ex
@@ -195,7 +195,12 @@ defmodule Fountain.Quotas do
         :erlang.phash2(user_id)
       ])
 
+      # The balance precheck lives under the same lock as the cap (ADR 0030
+      # decision 6): two requests at $0.01 must not both read "positive" and
+      # both provision. The turn that then burns it may still go negative;
+      # that is the soft stop, not a hole.
       with :ok <- check_sandbox_quota(user_id, quota_opts),
+           :ok <- Fountain.Credits.gate(user_id),
            {:ok, value} <- fun.() do
         value
       else

--- a/apps/fountain/lib/fountain_web/controllers/admin_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/admin_controller.ex
@@ -248,6 +248,56 @@ defmodule FountainWeb.AdminController do
   def set_comp(conn, _params),
     do: refuse(conn, "invalid_request", "Send {\"comped\": true} or {\"comped\": false}.")
 
+  operation(:grant_credits,
+    summary: "Add prepaid credit to an account",
+    description:
+      "A `grant_admin` ledger row (ADR 0030): goodwill, a won dispute, an " <>
+        "outage. It never expires and is spent after the tier's grant. There " <>
+        "is deliberately no negative form here; a clawback is what a refund " <>
+        "or dispute does through Stripe.",
+    parameters: [id: [in: :path, type: :string, required: true]],
+    request_body: {"Credit", "application/json", Schemas.AdminCreditsRequest},
+    responses: [
+      ok: {"Account", "application/json", Schemas.AdminUserResponse},
+      forbidden: {"Admin required", "application/json", Schemas.Error},
+      not_found: {"Not found", "application/json", Schemas.Error},
+      unprocessable_entity: {"Refused", "application/json", Schemas.Error}
+    ]
+  )
+
+  def grant_credits(conn, %{"id" => id, "cents" => cents} = params)
+      when is_integer(cents) and cents > 0 do
+    admin = conn.assigns.current_user
+    note = params["note"]
+
+    with :ok <- require_billing() do
+      with_user(conn, id, fn user ->
+        case Fountain.Credits.grant(user.id, cents, "grant_admin",
+               idempotency_key: "grant_admin:#{Ecto.UUID.generate()}",
+               actor: "admin:#{admin.id}",
+               metadata: %{"note" => note}
+             ) do
+          {:ok, entry} ->
+            record_admin(admin, user, "admin.credits.granted", %{
+              "email" => user.email,
+              "cents" => cents,
+              "note" => note,
+              "ledger_entry_id" => entry.id
+            })
+
+            render_user(conn, Accounts.get_user(user.id))
+
+          {:error, _} ->
+            refuse(conn, "invalid_request", "Could not write the credit.")
+        end
+      end)
+    end
+  end
+
+  def grant_credits(conn, _params),
+    do:
+      refuse(conn, "invalid_request", "Send {\"cents\": <positive integer>, \"note\": \"...\"}.")
+
   operation(:set_suspended,
     summary: "Suspend or unsuspend an account",
     description:

--- a/apps/fountain/lib/fountain_web/controllers/admin_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/admin_json.ex
@@ -57,6 +57,9 @@ defmodule FountainWeb.AdminJSON do
       # Teammate contacts this account is not charged for. Distinct from a
       # `comped` subscription_status, which makes everything free.
       comped_contacts: u.comped_contacts,
+      # The prepaid balance (ADR 0030); meaningful only while credits are
+      # active on the deployment, zero otherwise.
+      credit_balance_cents: u.credit_balance_cents,
       active_sandboxes: Map.get(sandbox_counts, u.id, 0),
       onboarding_completed_at: u.onboarding_completed_at,
       last_activity_at: Map.get(u, :last_activity_at),

--- a/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
@@ -151,6 +151,14 @@ defmodule FountainWeb.FallbackController do
     |> json(%{error: "subscription_required", upgrade_url: "/account/billing"})
   end
 
+  # Prepaid balance exhausted (ADR 0030 decision 6). Same 402 shape as the
+  # subscription gate, so a client with one handler covers both.
+  def call(conn, {:error, :insufficient_credits}) do
+    conn
+    |> put_status(:payment_required)
+    |> json(%{error: "insufficient_credits", upgrade_url: "/account/billing"})
+  end
+
   # Operator suspension (#287). 403 rather than 402: there is nothing the
   # caller can buy their way out of.
   def call(conn, {:error, :account_suspended}) do

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -534,6 +534,7 @@ defmodule FountainWeb.Router do
     post "/users/:id/sandbox-limit", AdminController, :set_sandbox_limit
     post "/users/:id/extend-trial", AdminController, :extend_trial
     post "/users/:id/comp", AdminController, :set_comp
+    post "/users/:id/credits", AdminController, :grant_credits
     post "/users/:id/suspend", AdminController, :set_suspended
     post "/users/:id/resync-stripe", AdminController, :resync_stripe
     delete "/users/:id", AdminController, :delete_user

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -1555,6 +1555,11 @@ defmodule FountainWeb.Schemas do
             "Teammate contacts this account is not charged for. Distinct from a " <>
               "`comped` subscription_status, which makes everything free."
         },
+        credit_balance_cents: %Schema{
+          type: :integer,
+          description:
+            "Prepaid balance in cents (ADR 0030). May be negative. Zero while credits are not active on this deployment."
+        },
         active_sandboxes: %Schema{type: :integer},
         onboarding_completed_at: %Schema{type: :string, format: :"date-time", nullable: true},
         last_activity_at: %Schema{type: :string, format: :"date-time", nullable: true},
@@ -1643,6 +1648,30 @@ defmodule FountainWeb.Schemas do
       type: :object,
       properties: %{comped: %Schema{type: :boolean}},
       required: [:comped]
+    })
+  end
+
+  defmodule AdminCreditsRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "AdminCreditsRequest",
+      type: :object,
+      properties: %{
+        cents: %Schema{
+          type: :integer,
+          minimum: 1,
+          description: "Credit to add, in cents. Never expires and is spent last."
+        },
+        note: %Schema{
+          type: :string,
+          nullable: true,
+          description: "Why, for the audit trail. A won dispute, a goodwill credit, an outage."
+        }
+      },
+      required: [:cents],
+      example: %{"cents" => 1000, "note" => "won dispute dp_123"}
     })
   end
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -76,6 +76,9 @@ config :fountain, :credits,
   # When set, turns that ended at or after this instant are priced into the
   # ledger; nil means the pricer no-ops. runtime.exs reads CREDIT_PRICING_SINCE.
   pricing_since: nil,
+  # When true, a zero balance refuses new sandboxes and turns (ADR 0030
+  # decision 6). Off, the ledger is reported and nothing is refused.
+  enforce: false,
   turn_hour_cents: 25,
   number_cents: nil,
   inbox_cents: nil,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -797,6 +797,9 @@ credit_pricing_since =
 
 config :fountain, :credits,
   pricing_since: credit_pricing_since,
+  # CREDIT_ENFORCE=true turns the soft stop on. Keep it off until a month of
+  # computed-versus-invoice deltas has been recorded (#1038, ADR 0030 §8).
+  enforce: System.get_env("CREDIT_ENFORCE") == "true",
   turn_hour_cents: credit_cents.("CREDIT_TURN_HOUR_CENTS") || 25,
   number_cents: credit_cents.("CREDIT_NUMBER_CENTS"),
   inbox_cents: credit_cents.("CREDIT_INBOX_CENTS"),

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -132,6 +132,7 @@ at a dead end, with no error to see. Read [Email](guides/operate/email.md).
 | `AGENTMAIL_MESSAGE_CENTS` | — | No. | What AgentMail charges for one email, in cents. Give the fraction, such as `0.2` for $2 per 1,000 emails. A whole number rounds this rate to zero. |
 | `AGENTPHONE_MESSAGE_CENTS` | — | No. | What AgentPhone charges for one SMS, in cents. Fountain counts an inbound message too, because AgentPhone charges for it. |
 | `CREDIT_PRICING_SINCE` | — | No. | The instant from which Fountain prices turns and messages into the prepaid ledger, as ISO 8601. Unset, Fountain prices nothing. |
+| `CREDIT_ENFORCE` | `false` | No. | Set `true` to refuse new sandboxes and new turns when the balance is zero or less. Turns in flight finish. Comped accounts and instances with billing off are never refused. |
 | `CREDIT_TURN_HOUR_CENTS` | `25` | No. | What a tenant pays for one hour of turn time, in whole cents, from their prepaid balance. |
 | `CREDIT_NUMBER_CENTS` | — | No. | What a tenant pays for one phone number each month, in whole cents. Unset means the number burns nothing. |
 | `CREDIT_INBOX_CENTS` | — | No. | What a tenant pays for one inbox each month, in whole cents. Unset means the inbox burns nothing. |

--- a/ee/lib/fountain/billing.ex
+++ b/ee/lib/fountain/billing.ex
@@ -79,6 +79,17 @@ defmodule Fountain.Billing do
   def enabled?, do: Application.get_env(:fountain, :billing_enabled, true)
 
   @doc """
+  The gate every spend passes: `check_active/1` (subscribe first, ADR 0006)
+  and then the credit balance (ADR 0030 decision 6). One function so a new
+  door cannot pick up one half and forget the other.
+  """
+  @spec check_spend(User.t() | binary()) ::
+          :ok | {:error, :subscription_required | :insufficient_credits}
+  def check_spend(subject) do
+    with :ok <- check_active(subject), do: Fountain.Credits.gate(subject)
+  end
+
+  @doc """
   Non-raising gate, for `with` pipelines in contexts.
 
   Accepts a user or a user id. An unknown id fails closed: a caller that cannot
@@ -1526,8 +1537,12 @@ defmodule Fountain.Billing do
             )
             |> Repo.update()
             |> tap(fn
-              {:ok, updated} -> enqueue_lifecycle_email(user.subscription_status, updated)
-              _ -> :ok
+              {:ok, updated} ->
+                enqueue_lifecycle_email(user.subscription_status, updated)
+                grant_on_renewal(user, updated)
+
+              _ ->
+                :ok
             end)
             |> audit_billing(user, "billing.subscription.synced", "webhook", %{
               "event_type" => type
@@ -1624,6 +1639,24 @@ defmodule Fountain.Billing do
   end
 
   def sync_subscription(_event), do: {:ok, :ignored}
+
+  # A new billing period is the moment the tier grant is due (ADR 0030
+  # decision 2). The daily CreditGranter is the backstop; granting here means
+  # the customer is not negative for up to a day after renewing. Best-effort
+  # by rescuing: a ledger hiccup must not fail the subscription sync, and the
+  # sweep catches whatever this missed.
+  defp grant_on_renewal(
+         %User{current_period_start: before},
+         %User{current_period_start: after_} = updated
+       )
+       when not is_nil(after_) and before != after_ do
+    Fountain.Workers.CreditGranter.grant_for_user(updated)
+    :ok
+  rescue
+    e -> Logger.warning("credits: grant on renewal failed for #{updated.id}: #{inspect(e)}")
+  end
+
+  defp grant_on_renewal(_before, _after), do: :ok
 
   defp sync_subscription_checkout(session, event) do
     customer_id = extract_stripe_id(Map.get(session, :customer))

--- a/ee/lib/fountain/credits.ex
+++ b/ee/lib/fountain/credits.ex
@@ -215,6 +215,27 @@ defmodule Fountain.Credits do
   end
 
   @doc """
+  Whether a zero balance refuses spend: `active?/0` and `credits.enforce`
+  (`CREDIT_ENFORCE=true`). Off, `gate/1` is always `:ok`.
+  """
+  @spec enforcing?() :: boolean()
+  def enforcing? do
+    active?() and
+      Keyword.get(Application.get_env(:fountain, :credits, []), :enforce, false) == true
+  end
+
+  @doc """
+  The spend gate (ADR 0030 decision 6): `:ok` unless enforcement is on and
+  `check_balance/1` says the tenant is out. Sits beside
+  `Billing.check_active/1` in `Billing.check_spend/1`; call that, not this,
+  from a door.
+  """
+  @spec gate(User.t() | binary()) :: :ok | {:error, :insufficient_credits}
+  def gate(subject) do
+    if enforcing?(), do: check_balance(subject), else: :ok
+  end
+
+  @doc """
   The one shape every surface renders (the billing page, the dashboard,
   `GET /api/account/billing`, the admin account view), so they cannot
   disagree.

--- a/ee/lib/fountain/emails/billing_emails.ex
+++ b/ee/lib/fountain/emails/billing_emails.ex
@@ -533,4 +533,86 @@ defmodule Fountain.Emails.BillingEmails do
     Fountain a try.
     """
   end
+
+  @doc """
+  The prepaid balance is under the runway line (ADR 0030 decision 6).
+  """
+  @spec deliver_credits_low_email(User.t(), integer()) :: {:ok, term()} | {:error, term()}
+  def deliver_credits_low_email(%User{} = user, balance_cents) do
+    billing_url = "#{Fountain.PublicUrl.base()}/account/billing"
+    balance = Fountain.Credits.format_cents(balance_cents)
+
+    new()
+    |> from(UserEmails.from_address())
+    |> to({user.email, user.email})
+    |> subject("Your Fountain credit is running low")
+    |> html_body(credits_html("Your credit is running low", balance, billing_url, false))
+    |> text_body(credits_text("Your credit is running low", balance, billing_url, false))
+    |> Mailer.deliver()
+  end
+
+  @doc """
+  The prepaid balance is at or below zero. Whether anything is refused
+  depends on `Fountain.Credits.enforcing?/0`; the email says so either way.
+  """
+  @spec deliver_credits_exhausted_email(User.t(), integer()) :: {:ok, term()} | {:error, term()}
+  def deliver_credits_exhausted_email(%User{} = user, balance_cents) do
+    billing_url = "#{Fountain.PublicUrl.base()}/account/billing"
+    balance = Fountain.Credits.format_cents(balance_cents)
+
+    new()
+    |> from(UserEmails.from_address())
+    |> to({user.email, user.email})
+    |> subject("Your Fountain credit has run out")
+    |> html_body(credits_html("Your credit has run out", balance, billing_url, true))
+    |> text_body(credits_text("Your credit has run out", balance, billing_url, true))
+    |> Mailer.deliver()
+  end
+
+  defp credits_consequence(true) do
+    if Fountain.Credits.enforcing?(),
+      do:
+        "New conversations and new turns are paused until the balance is positive again. Anything already running finishes.",
+      else: "Nothing is paused yet. Your balance will keep going down until you top up."
+  end
+
+  defp credits_consequence(false),
+    do:
+      "Your plan adds credit at the start of every billing period. Top up now if you need more before then."
+
+  defp credits_html(title, balance, billing_url, exhausted?) do
+    """
+    <!DOCTYPE html>
+    <html>
+    <body style="font-family: sans-serif; max-width: 600px; margin: 0 auto; padding: 24px;">
+      <h2>#{title}</h2>
+      <p>Your prepaid balance is <strong>#{balance}</strong>.</p>
+      <p>#{credits_consequence(exhausted?)}</p>
+      <p style="margin: 32px 0;">
+        <a href="#{billing_url}"
+           style="background: #18181b; color: #fff; padding: 12px 24px; border-radius: 6px; text-decoration: none; font-size: 14px;">
+          Buy credits
+        </a>
+      </p>
+      <p style="color: #71717a; font-size: 13px;">
+        Credits you buy never expire and are spent after the credit your plan includes.
+      </p>
+    </body>
+    </html>
+    """
+  end
+
+  defp credits_text(title, balance, billing_url, exhausted?) do
+    """
+    #{title}
+
+    Your prepaid balance is #{balance}.
+
+    #{credits_consequence(exhausted?)}
+
+    Buy credits: #{billing_url}
+
+    Credits you buy never expire and are spent after the credit your plan includes.
+    """
+  end
 end

--- a/ee/lib/fountain/workers/credit_pricer.ex
+++ b/ee/lib/fountain/workers/credit_pricer.ex
@@ -89,28 +89,34 @@ defmodule Fountain.Workers.CreditPricer do
   end
 
   defp do_run(floor) do
-    %{turns: price_turns(floor), messages: price_messages(floor)}
+    {turns, touched} = price_turns(floor)
+    messages = price_messages(floor)
+    Enum.each(touched, &Fountain.Workers.CreditsEmail.notify_after_burn/1)
+    %{turns: turns, messages: messages}
   end
 
   # ---------------------------------------------------------------------------
   # Turns
   # ---------------------------------------------------------------------------
 
-  defp price_turns(floor), do: price_turns(floor, 0)
+  # Returns `{rows_written, user_ids_touched}`; the second is who to warn.
+  defp price_turns(floor), do: price_turns(floor, 0, MapSet.new())
 
-  defp price_turns(floor, written) do
+  defp price_turns(floor, written, touched) do
     case unpriced_turns(floor) do
       [] ->
-        written
+        {written, MapSet.to_list(touched)}
 
       turns ->
-        n = Enum.count(turns, &price_turn/1)
+        priced = Enum.filter(turns, &price_turn/1)
+        n = length(priced)
+        touched = Enum.reduce(priced, touched, &MapSet.put(&2, &1.user_id))
         # The anti-join hides what was just written, so the next page is the
         # next unpriced batch. A page that wrote nothing (every turn was free,
         # or a duplicate) would loop forever; stop on it.
         if n == 0 or length(turns) < @batch,
-          do: written + n,
-          else: price_turns(floor, written + n)
+          do: {written + n, MapSet.to_list(touched)},
+          else: price_turns(floor, written + n, touched)
     end
   end
 

--- a/ee/lib/fountain/workers/credits_email.ex
+++ b/ee/lib/fountain/workers/credits_email.ex
@@ -1,0 +1,95 @@
+defmodule Fountain.Workers.CreditsEmail do
+  @moduledoc """
+  Runway warnings for the prepaid balance (ADR 0030 decision 6).
+
+  Two kinds: `"credits_low"` when the balance drops under the runway line
+  (20 % of the period's tier grant, or $2, whichever is larger) and
+  `"credits_exhausted"` when it reaches zero. Enqueued by the pricer after a
+  burn; unique per user and kind for thirty days, so a tenant hovering at
+  the line gets one email a period, not one a burn.
+
+  Only sends while the state still holds: a top-up between the enqueue and
+  the send makes the email a lie, and it is dropped.
+  """
+
+  use Oban.Worker,
+    queue: :billing,
+    max_attempts: 5,
+    unique: [period: 30 * 86_400, fields: [:args]]
+
+  require Logger
+
+  alias Fountain.{Accounts, Credits, Emails.BillingEmails}
+
+  @emails ~w(credits_low credits_exhausted)
+
+  def emails, do: @emails
+
+  @spec enqueue(String.t(), String.t()) :: {:ok, Oban.Job.t()} | {:error, term()}
+  def enqueue(user_id, email) when is_binary(user_id) and email in @emails do
+    %{"user_id" => user_id, "email" => email} |> new() |> Oban.insert()
+  end
+
+  @doc """
+  Look at one tenant's balance after a burn and enqueue whichever warning
+  applies. Nothing when credits are not active, or the tenant is comped.
+  """
+  @spec notify_after_burn(String.t()) :: :ok
+  def notify_after_burn(user_id) when is_binary(user_id) do
+    with true <- Credits.active?(),
+         %{subscription_status: status} = user when status != "comped" <-
+           Accounts.get_user(user_id) do
+      balance = Credits.balance(user)
+
+      cond do
+        balance <= 0 -> enqueue(user.id, "credits_exhausted")
+        balance <= runway_line(user) -> enqueue(user.id, "credits_low")
+        true -> :ok
+      end
+    end
+
+    :ok
+  end
+
+  @doc "Cents under which a balance is 'low': 20 % of the tier grant, or $2."
+  @spec runway_line(Accounts.User.t()) :: pos_integer()
+  def runway_line(user) do
+    grant = Fountain.Plans.included_turn_hours(user) * Credits.price_card().turn_hour
+    max(div(grant, 5), 200)
+  end
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"user_id" => user_id, "email" => email}}) when email in @emails do
+    case Accounts.get_user(user_id) do
+      nil ->
+        :ok
+
+      user ->
+        balance = Credits.balance(user)
+
+        cond do
+          user.subscription_status == "comped" ->
+            :ok
+
+          email == "credits_exhausted" and balance <= 0 ->
+            BillingEmails.deliver_credits_exhausted_email(user, balance) |> log(user, email)
+
+          email == "credits_low" and balance > 0 and balance <= runway_line(user) ->
+            BillingEmails.deliver_credits_low_email(user, balance) |> log(user, email)
+
+          true ->
+            :ok
+        end
+    end
+  end
+
+  defp log({:ok, _}, user, email) do
+    Logger.info("credits_email: sent #{email} to #{user.id}")
+    :ok
+  end
+
+  defp log({:error, reason}, user, email) do
+    Logger.error("credits_email: #{email} to #{user.id} failed: #{inspect(reason)}")
+    {:error, reason}
+  end
+end

--- a/ee/test/fountain/credits_enforcement_test.exs
+++ b/ee/test/fountain/credits_enforcement_test.exs
@@ -1,0 +1,289 @@
+defmodule Fountain.CreditsEnforcementTest do
+  @moduledoc """
+  The soft stop (ADR 0030 decision 6), the renewal grant, the admin grant
+  and the runway emails. `async: false`: the two switches are global config.
+  """
+
+  use FountainWeb.ConnCase, async: false
+  use Mimic
+  use Oban.Testing, repo: Fountain.Repo
+
+  alias Fountain.Accounts
+  alias Fountain.Accounts.User
+  alias Fountain.Billing
+  alias Fountain.Conversations
+  alias Fountain.Credits
+  alias Fountain.Quotas
+  alias Fountain.Repo
+  alias Fountain.Workers.CreditsEmail
+
+  @since ~U[2026-07-01 00:00:00Z]
+
+  defp switch(opts) do
+    cfg = Application.get_env(:fountain, :credits)
+    Application.put_env(:fountain, :credits, Keyword.merge(cfg, opts))
+    on_exit(fn -> Application.put_env(:fountain, :credits, cfg) end)
+  end
+
+  defp subscriber(attrs \\ %{}) do
+    user = insert_active_user()
+
+    {:ok, user} =
+      user
+      |> User.billing_changeset(
+        Map.merge(%{plan: "solo", stripe_customer_id: "cus_#{user.id}"}, attrs)
+      )
+      |> Repo.update()
+
+    user
+  end
+
+  describe "check_spend/1 with enforcement off" do
+    setup do
+      switch(pricing_since: @since, enforce: false)
+      :ok
+    end
+
+    test "a zero balance refuses nothing" do
+      user = subscriber()
+      refute Credits.enforcing?()
+      assert :ok = Credits.gate(user)
+      assert :ok = Billing.check_spend(user)
+      assert {:error, :insufficient_credits} = Credits.check_balance(user)
+    end
+  end
+
+  describe "check_spend/1 with enforcement on" do
+    setup do
+      switch(pricing_since: @since, enforce: true)
+      :ok
+    end
+
+    test "zero refuses, positive passes, subscription comes first" do
+      user = subscriber()
+      assert Credits.enforcing?()
+      assert {:error, :insufficient_credits} = Billing.check_spend(user)
+      assert {:error, :insufficient_credits} = Billing.check_spend(user.id)
+
+      {:ok, _} = Credits.grant(user.id, 1, "purchase", idempotency_key: "p")
+      assert :ok = Billing.check_spend(user.id)
+
+      canceled = subscriber(%{subscription_status: "canceled"})
+      assert {:error, :subscription_required} = Billing.check_spend(canceled)
+    end
+
+    test "comped and billing-off never refuse" do
+      # No Stripe customer, so comping cancels nothing upstream.
+      {:ok, comped} = Billing.comp_account(insert_active_user())
+      assert :ok = Billing.check_spend(comped)
+
+      Application.put_env(:fountain, :billing_enabled, false)
+      on_exit(fn -> Application.put_env(:fountain, :billing_enabled, true) end)
+      assert :ok = Billing.check_spend(subscriber())
+    end
+
+    test "a conversation is refused at the door and no sandbox is allocated" do
+      user = subscriber()
+      agent = insert_agent(user_id: user.id)
+
+      assert {:error, :insufficient_credits} =
+               Conversations.start_conversation(%{"agent_id" => agent.id, "user_id" => user.id})
+
+      assert Quotas.active_sandbox_counts() |> Map.get(user.id, 0) == 0
+    end
+
+    test "the reservation lock refuses under the same lock as the cap" do
+      user = subscriber()
+      test = self()
+
+      assert {:error, :insufficient_credits} =
+               Quotas.with_sandbox_reservation(user.id, [], fn ->
+                 send(test, :ran)
+                 {:ok, :never}
+               end)
+
+      refute_receive :ran
+
+      {:ok, _} = Credits.grant(user.id, 1, "purchase", idempotency_key: "p")
+      assert {:ok, :ran} = Quotas.with_sandbox_reservation(user.id, [], fn -> {:ok, :ran} end)
+    end
+
+    test "the API says 402 insufficient_credits", %{conn: conn} do
+      user = subscriber()
+      agent = insert_agent(user_id: user.id)
+      {_rec, key} = insert_api_key(user)
+
+      body =
+        conn
+        |> authed_with_key(key)
+        |> put_req_header("content-type", "application/json")
+        |> post("/api/conversations", %{"agent_id" => agent.id})
+        |> json_response(402)
+
+      assert body["error"] == "insufficient_credits"
+      assert body["upgrade_url"] == "/account/billing"
+    end
+  end
+
+  describe "the renewal grant" do
+    setup do
+      switch(pricing_since: @since, enforce: false)
+      :ok
+    end
+
+    test "a new period on the subscription webhook grants the tier at once" do
+      user = subscriber(%{stripe_subscription_id: "sub_r"})
+      # A period that contains now: the grant is only due inside the period.
+      ps = DateTime.utc_now() |> DateTime.add(-5 * 86_400, :second) |> DateTime.truncate(:second)
+      pe = DateTime.add(ps, 30 * 86_400, :second)
+
+      event = %Stripe.Event{
+        id: "evt_renew_#{user.id}",
+        type: "customer.subscription.updated",
+        created: DateTime.utc_now() |> DateTime.to_unix(),
+        data: %{
+          object: %{
+            id: "sub_r",
+            customer: user.stripe_customer_id,
+            status: "active",
+            trial_end: nil,
+            cancel_at_period_end: false,
+            current_period_start: DateTime.to_unix(ps),
+            current_period_end: DateTime.to_unix(pe)
+          }
+        }
+      }
+
+      assert {:ok, %User{current_period_start: ^ps}} = Billing.handle_event(event)
+      assert Credits.balance(user.id) == 1000
+      [entry] = Credits.list_entries(user.id)
+      assert entry.reason == "grant_tier" and entry.expires_at == pe
+    end
+  end
+
+  describe "the admin grant" do
+    setup do
+      switch(pricing_since: @since, enforce: false)
+      admin = insert_verified_user()
+      {:ok, admin} = Accounts.update_user_role(admin, "admin")
+      {_rec, key} = insert_api_key(admin)
+      %{admin: admin, key: key}
+    end
+
+    test "adds a non-expiring grant_admin row and an admin event", %{
+      conn: conn,
+      key: key,
+      admin: admin
+    } do
+      user = subscriber()
+
+      body =
+        conn
+        |> authed_with_key(key)
+        |> put_req_header("content-type", "application/json")
+        |> post("/api/admin/users/#{user.id}/credits", %{"cents" => 1500, "note" => "won dp_1"})
+        |> json_response(200)
+
+      assert body["data"]["credit_balance_cents"] == 1500
+      [entry] = Credits.list_entries(user.id)
+      assert entry.reason == "grant_admin" and is_nil(entry.expires_at)
+      assert entry.metadata["note"] == "won dp_1"
+
+      [ev] =
+        Repo.all(Fountain.Audit.AdminEvent)
+        |> Enum.filter(&(&1.event_type == "admin.credits.granted"))
+
+      assert ev.actor_user_id == admin.id
+      assert ev.metadata["cents"] == 1500
+
+      body =
+        conn
+        |> authed_with_key(key)
+        |> put_req_header("content-type", "application/json")
+        |> post("/api/admin/users/#{user.id}/credits", %{"cents" => -5})
+        |> json_response(422)
+
+      # The spec's `minimum: 1` refuses it before the action does.
+      assert body["error"] == "invalid_request" or is_list(body["errors"])
+    end
+  end
+
+  describe "runway emails" do
+    setup do
+      switch(pricing_since: @since, enforce: false)
+      :ok
+    end
+
+    test "the runway line is 20% of the tier grant or $2" do
+      assert CreditsEmail.runway_line(subscriber()) == 200
+      assert CreditsEmail.runway_line(subscriber(%{plan: "scale"})) == 1000
+    end
+
+    test "notify_after_burn enqueues low then exhausted, once each" do
+      user = subscriber()
+
+      {:ok, _} =
+        Credits.grant(user.id, 1000, "grant_tier",
+          idempotency_key: "g",
+          expires_at: ~U[2099-01-01 00:00:00Z]
+        )
+
+      assert :ok = CreditsEmail.notify_after_burn(user.id)
+      refute_enqueued(worker: CreditsEmail)
+
+      {:ok, _} = Credits.debit(user.id, 850, "burn_turn", idempotency_key: "b1")
+      assert :ok = CreditsEmail.notify_after_burn(user.id)
+
+      assert_enqueued(
+        worker: CreditsEmail,
+        args: %{"user_id" => user.id, "email" => "credits_low"}
+      )
+
+      {:ok, _} = Credits.debit(user.id, 200, "burn_turn", idempotency_key: "b2")
+      assert :ok = CreditsEmail.notify_after_burn(user.id)
+
+      assert_enqueued(
+        worker: CreditsEmail,
+        args: %{"user_id" => user.id, "email" => "credits_exhausted"}
+      )
+
+      assert length(all_enqueued(worker: CreditsEmail)) == 2
+
+      # Again: unique for thirty days.
+      assert :ok = CreditsEmail.notify_after_burn(user.id)
+      assert length(all_enqueued(worker: CreditsEmail)) == 2
+    end
+
+    test "the send is dropped when the state no longer holds" do
+      user = subscriber()
+      {:ok, _} = Credits.debit(user.id, 10, "burn_turn", idempotency_key: "b")
+      test = self()
+
+      stub(Fountain.Mailer, :deliver, fn email ->
+        send(test, {:sent, email.subject})
+        {:ok, %{}}
+      end)
+
+      assert :ok =
+               CreditsEmail.perform(%Oban.Job{
+                 args: %{"user_id" => user.id, "email" => "credits_exhausted"}
+               })
+
+      assert_receive {:sent, "Your Fountain credit has run out"}
+
+      {:ok, _} = Credits.grant(user.id, 5000, "purchase", idempotency_key: "p")
+
+      assert :ok =
+               CreditsEmail.perform(%Oban.Job{
+                 args: %{"user_id" => user.id, "email" => "credits_exhausted"}
+               })
+
+      assert :ok =
+               CreditsEmail.perform(%Oban.Job{
+                 args: %{"user_id" => user.id, "email" => "credits_low"}
+               })
+
+      refute_receive {:sent, _}
+    end
+  end
+end

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -10,6 +10,17 @@ server releases.
 
 ---
 
+## [0.1.15] — 2026-08-24
+
+### Added
+
+- `POST /api/admin/users/{id}/credits` adds prepaid credit to an account
+  (`grant_admin`, never expires). Admin user objects carry
+  `credit_balance_cents`.
+- A `402 insufficient_credits` response (same shape as
+  `subscription_required`, with `upgrade_url`) on every door that spends,
+  once the operator turns enforcement on.
+
 ## [0.1.14] — 2026-08-24
 
 ### Added

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentshit/fountain-sdk",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Run a coding agent on a real computer, with your repos and your credentials, in one call.",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -543,6 +543,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/admin/users/{id}/credits": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Add prepaid credit to an account
+         * @description A `grant_admin` ledger row (ADR 0030): goodwill, a won dispute, an outage. It never expires and is spent after the tier's grant. There is deliberately no negative form here; a clawback is what a refund or dispute does through Stripe.
+         */
+        post: operations["FountainWeb.AdminController.grant_credits"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/team/{agent_id}/contact": {
         parameters: {
             query?: never;
@@ -2718,6 +2738,19 @@ export interface components {
         TokenRequest: {
             token: string;
         };
+        /**
+         * AdminCreditsRequest
+         * @example {
+         *       "cents": 1000,
+         *       "note": "won dispute dp_123"
+         *     }
+         */
+        AdminCreditsRequest: {
+            /** @description Credit to add, in cents. Never expires and is spent last. */
+            cents: number;
+            /** @description Why, for the audit trail. A won dispute, a goodwill credit, an outage. */
+            note?: string | null;
+        };
         /** TeamAddRequest */
         TeamAddRequest: {
             /** Format: uuid */
@@ -3578,6 +3611,8 @@ export interface components {
             cancel_at_period_end?: boolean | null;
             /** @description Teammate contacts this account is not charged for. Distinct from a `comped` subscription_status, which makes everything free. */
             comped_contacts?: number;
+            /** @description Prepaid balance in cents (ADR 0030). May be negative. Zero while credits are not active on this deployment. */
+            credit_balance_cents?: number;
             /** Format: date-time */
             current_period_end?: string | null;
             email: string;
@@ -5202,6 +5237,60 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["MessageResponse"];
+                };
+            };
+        };
+    };
+    "FountainWeb.AdminController.grant_credits": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        /** @description Credit */
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["AdminCreditsRequest"];
+            };
+        };
+        responses: {
+            /** @description Account */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminUserResponse"];
+                };
+            };
+            /** @description Admin required */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Refused */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
                 };
             };
         };

--- a/sdk/typescript/src/http.ts
+++ b/sdk/typescript/src/http.ts
@@ -19,7 +19,7 @@ export interface RequestOptions {
  * this string is already what Fountain's request logs are keyed on. The
  * version half is asserted against `package.json` by a test.
  */
-export const USER_AGENT = "fountain-sdk-js/0.1.14";
+export const USER_AGENT = "fountain-sdk-js/0.1.15";
 
 /**
  * The thin layer everything else is built on: one bearer token, JSON in and


### PR DESCRIPTION
Stacked on #1098 (diff includes #1097–#1098 until they merge).

Enforcement, **behind its own switch**: `CREDIT_ENFORCE=true` (default off). ADR 0030 §8 says this stays off until #1038 has a month of computed-vs-invoice deltas; the code ships now so that flip is an env var, not a deploy.

**Adds**
- `Credits.enforcing?/0`, `Credits.gate/1`, and **`Billing.check_spend/1`** = `check_active/1` then `gate/1`. One function so a new door cannot take half. All five doors now call it: `start_conversation`, attach-to-sandbox, resume, replace-sandbox, and `ConversationServer`'s per-turn gate. Comped and billing-off short-circuit before any balance read (decision 7).
- The balance precheck inside `Quotas.with_sandbox_reservation/3`, under the same advisory lock as the concurrency cap — two requests at $0.01 cannot both provision.
- `FallbackController`: `{:error, :insufficient_credits}` → **402** `{error: "insufficient_credits", upgrade_url}` — same shape as `subscription_required`, one client handler covers both.
- **Renewal grant:** `sync_subscription` grants the tier the moment `current_period_start` changes (best-effort, rescued; the daily granter remains the backstop), so a renewing customer is never negative for a day.
- **Admin grant:** `POST /api/admin/users/:id/credits {cents, note}` → `grant_admin` (never expires, spent last), `admin.credits.granted` admin event; `credit_balance_cents` on admin user objects. No negative form on purpose: clawbacks come through Stripe.
- **Runway emails:** `Fountain.Workers.CreditsEmail` — `credits_low` (≤ 20 % of the tier grant or $2) and `credits_exhausted` (≤ 0), enqueued by the pricer after a burn, unique per tenant per 30 days, dropped at send time if a top-up made them stale. The exhausted email says whether anything is paused (reads `enforcing?/0`).
- SDK **0.1.15**.

**Tests** (11, `async: false`): enforce-off refuses nothing at zero; enforce-on refuses at zero and passes at 1¢, subscription refusal comes first; comped/billing-off exempt; `start_conversation` refused at the door with no sandbox allocated; reservation lock refuses before `fun` runs; API 402 shape; renewal webhook grants $10 at once; admin grant row + event + 422 on bad input; runway line arithmetic; low→exhausted enqueue once each; stale sends dropped.

**Not here:** rent for numbers/inboxes and the 7-day grace (4b), the phase 5 migration task.

Refs #1086, ADR 0030.

🤖 Generated with [Claude Code](https://claude.com/claude-code)