### PR TITLE
feat(credits): rent for numbers and inboxes, a month up front, with a seven-day grace (#1086 phase 4b)

### DIFF
--- a/apps/fountain/lib/fountain/team/comms.ex
+++ b/apps/fountain/lib/fountain/team/comms.ex
@@ -166,6 +166,9 @@ defmodule Fountain.Team.Comms do
          %{name: name} = teammate <- Team.get_teammate(user_id, agent_id) || {:error, :not_found},
          :ok <- ensure_no_contact(user_id, agent_id),
          :ok <- check_contact_ceiling(user_id),
+         # A month of rent up front (ADR 0030 decision 4); refuses only
+         # under enforcement when the balance cannot cover it.
+         :ok <- Fountain.Credits.Rent.check_provision(user_id),
          {:ok, requested} <-
            Ecto.Changeset.apply_action(Contact.request_changeset(attrs), :insert),
          {:ok, inbox} <- create_inbox(name, teammate, opts),
@@ -191,6 +194,7 @@ defmodule Fountain.Team.Comms do
           })
 
           bill_contacts(user_id)
+          contact = charge_first_month(contact)
           Team.broadcast_changed(user_id)
           {:ok, contact}
 
@@ -389,6 +393,23 @@ defmodule Fountain.Team.Comms do
   # computed from the rows and re-set on every change, so the next
   # provision or release repairs a drop — and `Fountain.Plans`' ceiling
   # bounds how far it can drift before someone notices.
+  # The first month's rent, after the row is committed (ADR 0030 decision
+  # 4). Best-effort by rescuing, like the add-on sync: the providers have
+  # already handed over a number, and a ledger hiccup must not strand it.
+  defp charge_first_month(%Contact{} = contact) do
+    case Fountain.Credits.Rent.charge(contact, contact.inserted_at, actor: "system:credit_rent") do
+      {:ok, %Contact{} = charged} -> charged
+      _ -> contact
+    end
+  rescue
+    error ->
+      Logger.warning(
+        "first month rent failed for contact #{contact.id}: #{Exception.message(error)}"
+      )
+
+      contact
+  end
+
   defp bill_contacts(user_id) do
     Fountain.Billing.sync_contact_addon(user_id)
   rescue

--- a/apps/fountain/lib/fountain/team/contact.ex
+++ b/apps/fountain/lib/fountain/team/contact.ex
@@ -18,6 +18,8 @@ defmodule Fountain.Team.Contact do
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
 
+  @type t :: %__MODULE__{}
+
   schema "team_contacts" do
     field :email_address, :string
     field :email_inbox_id, :string
@@ -30,6 +32,11 @@ defmodule Fountain.Team.Contact do
     # Set when the registered number texted STOP; cleared by START or by a
     # fresh number (new consent). While set, its texts are not prompts.
     field :prompt_opted_out_at, :utc_datetime
+    # Rent (ADR 0030 decision 4): when the next month is due, and when a
+    # missed debit started the grace period. Written by
+    # `Fountain.Credits.Rent`, never cast from user input.
+    field :rent_paid_through, :utc_datetime
+    field :rent_due_at, :utc_datetime
 
     belongs_to :user, Fountain.Accounts.User
     belongs_to :agent, Fountain.Agents.Agent

--- a/apps/fountain/priv/repo/migrations/20260824110000_add_rent_to_team_contacts.exs
+++ b/apps/fountain/priv/repo/migrations/20260824110000_add_rent_to_team_contacts.exs
@@ -1,0 +1,18 @@
+defmodule Fountain.Repo.Migrations.AddRentToTeamContacts do
+  use Ecto.Migration
+
+  # ADR 0030 decision 4: a number and an inbox are rented a month up front.
+  # `rent_paid_through` is the instant the next month is due; `rent_due_at`
+  # is set when that debit could not be made because the balance was short,
+  # and starts the seven-day grace before the contact is released. Additive:
+  # nil on every existing row, and nothing reads either until the collector
+  # runs.
+  def change do
+    alter table(:team_contacts) do
+      add :rent_paid_through, :utc_datetime
+      add :rent_due_at, :utc_datetime
+    end
+
+    create index(:team_contacts, [:rent_paid_through])
+  end
+end

--- a/config/config.exs
+++ b/config/config.exs
@@ -51,7 +51,11 @@ config :fountain, Oban,
        # (ADR 0030 decision 2). Idempotent per period and per grant. The
        # webhook will grant at renewal directly (phase 4); this is the
        # backstop. No-ops until CREDIT_PRICING_SINCE is set.
-       {"23 6 * * *", Fountain.Workers.CreditGranter}
+       {"23 6 * * *", Fountain.Workers.CreditGranter},
+       # 06:47 UTC daily: rent for numbers and inboxes, the grace reminders,
+       # and the release on day seven (ADR 0030 decision 4). No-ops until a
+       # rent price is set.
+       {"47 6 * * *", Fountain.Workers.CreditRentCollector}
      ]}
   ]
 

--- a/docs/guides/operate/plans-and-prices.md
+++ b/docs/guides/operate/plans-and-prices.md
@@ -116,8 +116,8 @@ contact costs one month of rent up front, then one month on each monthly
 anniversary. Fountain takes the rent from the credit balance. With
 enforcement off, Fountain takes the rent even when the balance goes below
 zero. With enforcement on, Fountain refuses a new contact when the balance
-cannot cover the first month, and a contact with unpaid rent gets seven
-days of grace. Fountain sends a reminder on day 0, day 3 and day 6. On day 7
+cannot cover the first month. A contact with unpaid rent gets seven days of
+grace. Fountain sends a reminder on day 0, day 3 and day 6. On day 7
 it releases the number and the inbox. You cannot recover a released
 number. A top-up during the grace pays the rent and keeps the number.
 

--- a/docs/guides/operate/plans-and-prices.md
+++ b/docs/guides/operate/plans-and-prices.md
@@ -109,6 +109,18 @@ records the decisions, and
 [issue 1086](https://github.com/BinaryBourbon/fountain/issues/1086) tracks
 the build.
 
+### Rent for numbers and inboxes
+
+Set `CREDIT_NUMBER_CENTS` and `CREDIT_INBOX_CENTS`, and each teammate
+contact costs one month of rent up front, then one month on each monthly
+anniversary. Fountain takes the rent from the credit balance. With
+enforcement off, Fountain takes the rent even when the balance goes below
+zero. With enforcement on, Fountain refuses a new contact when the balance
+cannot cover the first month, and a contact with unpaid rent gets seven
+days of grace. Fountain sends a reminder on day 0, day 3 and day 6. On day 7
+it releases the number and the inbox. You cannot recover a released
+number. A top-up during the grace pays the rent and keeps the number.
+
 ### Sell credit packs
 
 A subscriber can buy credit on the billing page, or with

--- a/ee/lib/fountain/credits/rent.ex
+++ b/ee/lib/fountain/credits/rent.ex
@@ -1,0 +1,223 @@
+defmodule Fountain.Credits.Rent do
+  @moduledoc """
+  Rent for a teammate's number and inbox (ADR 0030 decision 4): a month up
+  front at provisioning, and again on each monthly anniversary.
+
+    * `month_cents/0` is `CREDIT_NUMBER_CENTS + CREDIT_INBOX_CENTS`; unset
+      prices are zero, and zero rent means nothing here does anything.
+    * `check_provision/1` refuses a new contact when enforcement is on and
+      the balance is short of one month (`{:error, :insufficient_credits}`).
+    * `charge/3` debits one month for a contact under
+      `burn_rent:<contact>:<period_start>` and moves `rent_paid_through` one
+      month on. With enforcement off the debit always lands, negative or not.
+      With it on, a short balance leaves the row unpaid and stamps
+      `rent_due_at`, which starts the grace.
+    * `collect/1` is the daily pass: charge every contact whose month is up,
+      email the tenant at day 0, 3 and 6 of the grace, and release the
+      contact on day 7 through `Team.Comms.release_contact/3`. Release is
+      irreversible — the number is gone — which is why it is the only spend
+      that waits (decision 6).
+  """
+
+  import Ecto.Query
+
+  alias Fountain.Credits
+  alias Fountain.Repo
+  alias Fountain.Team.Comms
+  alias Fountain.Team.Contact
+
+  require Logger
+
+  @grace_days 7
+  @reminder_days [0, 3, 6]
+
+  @doc "One month of rent for a contact that holds a number and an inbox, in cents."
+  @spec month_cents() :: non_neg_integer()
+  def month_cents do
+    card = Credits.price_card()
+    (card.number_month || 0) + (card.inbox_month || 0)
+  end
+
+  @doc "Whether rent is charged at all: credits active and a price set."
+  @spec charging?() :: boolean()
+  def charging?, do: Credits.active?() and month_cents() > 0
+
+  @doc """
+  Whether a tenant may provision a contact. Only refuses under enforcement,
+  and only when the balance cannot cover the first month.
+  """
+  @spec check_provision(binary()) :: :ok | {:error, :insufficient_credits}
+  def check_provision(user_id) when is_binary(user_id) do
+    if Credits.enforcing?() and month_cents() > 0 and Credits.balance(user_id) < month_cents(),
+      do: {:error, :insufficient_credits},
+      else: :ok
+  end
+
+  @doc """
+  Debit one month starting at `period_start` for `contact`. Returns
+  `{:ok, contact}` with `rent_paid_through` advanced, `{:ok, :duplicate,
+  contact}` when that month was already charged, `{:error,
+  :insufficient_credits}` when enforcement refused it (and `rent_due_at` is
+  now set), or `{:ok, :free}` when nothing is charged on this deployment.
+  """
+  @spec charge(Contact.t(), DateTime.t(), keyword()) ::
+          {:ok, Contact.t()} | {:ok, :duplicate, Contact.t()} | {:ok, :free} | {:error, term()}
+  def charge(%Contact{} = contact, %DateTime{} = period_start, opts \\ []) do
+    cents = month_cents()
+    now = Keyword.get(opts, :now) || DateTime.utc_now()
+
+    cond do
+      not charging?() ->
+        {:ok, :free}
+
+      Credits.enforcing?() and Credits.balance(contact.user_id) < cents ->
+        {:ok, _} = stamp(contact, rent_due_at: contact.rent_due_at || truncate(now))
+        {:error, :insufficient_credits}
+
+      true ->
+        key = "burn_rent:#{contact.id}:#{DateTime.to_iso8601(period_start)}"
+
+        case Credits.debit(contact.user_id, cents, "burn_rent",
+               idempotency_key: key,
+               resource_type: "team_contact",
+               resource_id: contact.id,
+               actor: Keyword.get(opts, :actor, "system:credit_rent"),
+               metadata: %{
+                 "period_start" => DateTime.to_iso8601(period_start),
+                 "agent_id" => contact.agent_id
+               }
+             ) do
+          {:ok, _} ->
+            stamp(contact, rent_paid_through: add_month(period_start), rent_due_at: nil)
+
+          {:ok, :duplicate, _} ->
+            {:ok, contact} =
+              stamp(contact, rent_paid_through: add_month(period_start), rent_due_at: nil)
+
+            {:ok, :duplicate, contact}
+
+          {:error, reason} ->
+            {:error, reason}
+        end
+    end
+  end
+
+  @doc """
+  The daily pass. Returns `%{charged: n, reminded: n, released: n}`.
+  `:now` pins the clock.
+  """
+  @spec collect(keyword()) :: %{
+          charged: non_neg_integer(),
+          reminded: non_neg_integer(),
+          released: non_neg_integer()
+        }
+  def collect(opts \\ []) do
+    now = Keyword.get(opts, :now) || DateTime.utc_now()
+
+    if charging?() do
+      due = due_contacts(now)
+
+      charged =
+        Enum.count(due, &match?({:ok, %Contact{}}, charge(&1, period_start(&1, now), now: now)))
+
+      overdue = overdue_contacts(now)
+      released = Enum.count(overdue, &release_if_expired(&1, now))
+      reminded = overdue |> Enum.reject(&expired?(&1, now)) |> Enum.count(&remind(&1, now))
+      %{charged: charged, reminded: reminded, released: released}
+    else
+      %{charged: 0, reminded: 0, released: 0}
+    end
+  end
+
+  # A contact never charged (provisioned before rent existed) starts its
+  # first month at the sweep, not at provisioning: the tenant was not told
+  # about rent then, and back-charging months would be the phase 5 trap.
+  defp period_start(%Contact{rent_paid_through: nil}, now), do: truncate(now)
+  defp period_start(%Contact{rent_paid_through: at}, _now), do: at
+
+  defp due_contacts(now) do
+    from(c in Contact,
+      where: is_nil(c.rent_paid_through) or c.rent_paid_through <= ^now,
+      where: is_nil(c.rent_due_at),
+      order_by: [asc: c.inserted_at]
+    )
+    |> Repo.all()
+  end
+
+  defp overdue_contacts(now) do
+    from(c in Contact, where: not is_nil(c.rent_due_at) and c.rent_due_at <= ^now)
+    |> Repo.all()
+  end
+
+  defp expired?(%Contact{rent_due_at: due}, now),
+    do: DateTime.diff(now, due, :second) >= @grace_days * 86_400
+
+  defp release_if_expired(%Contact{} = contact, now) do
+    if expired?(contact, now) do
+      # One more try first: a top-up during the grace pays the rent and
+      # keeps the number.
+      case charge(contact, period_start(contact, now), now: now) do
+        {:ok, %Contact{}} ->
+          false
+
+        _ ->
+          case Comms.release_contact(contact.user_id, contact.agent_id,
+                 actor: "system:credit_rent"
+               ) do
+            :ok ->
+              Logger.info(
+                "credit rent: released contact #{contact.id} after #{@grace_days} days unpaid"
+              )
+
+              true
+
+            {:error, reason} ->
+              Logger.warning("credit rent: could not release #{contact.id}: #{inspect(reason)}")
+              false
+          end
+      end
+    else
+      false
+    end
+  end
+
+  # Days 0, 3 and 6 of the grace. The worker's uniqueness (two days per
+  # contact and day) is what stops a daily sweep sending day 0 twice.
+  defp remind(%Contact{} = contact, now) do
+    # Pay first if the balance has come back; the reminder is then moot.
+    case charge(contact, period_start(contact, now), now: now) do
+      {:ok, %Contact{}} ->
+        false
+
+      _ ->
+        day = div(DateTime.diff(now, contact.rent_due_at, :second), 86_400)
+
+        if day in @reminder_days do
+          days_left = @grace_days - day
+          Fountain.Workers.CreditsEmail.enqueue_rent_due(contact.user_id, contact.id, days_left)
+          true
+        else
+          false
+        end
+    end
+  end
+
+  defp stamp(%Contact{} = contact, changes) do
+    contact |> Ecto.Changeset.change(changes) |> Repo.update()
+  end
+
+  @doc "One calendar month on, clamped to the shorter month's last day."
+  @spec add_month(DateTime.t()) :: DateTime.t()
+  def add_month(%DateTime{} = at) do
+    date = DateTime.to_date(at)
+    {y, m} = if date.month == 12, do: {date.year + 1, 1}, else: {date.year, date.month + 1}
+    day = min(date.day, Date.days_in_month(Date.new!(y, m, 1)))
+    {:ok, next} = DateTime.new(Date.new!(y, m, day), DateTime.to_time(at), "Etc/UTC")
+    truncate(next)
+  end
+
+  defp truncate(dt), do: DateTime.truncate(dt, :second)
+
+  @doc false
+  def grace_days, do: @grace_days
+end

--- a/ee/lib/fountain/emails/billing_emails.ex
+++ b/ee/lib/fountain/emails/billing_emails.ex
@@ -615,4 +615,75 @@ defmodule Fountain.Emails.BillingEmails do
     Credits you buy never expire and are spent after the credit your plan includes.
     """
   end
+
+  @doc """
+  Rent for a teammate's number and inbox could not be paid; `days_left` of
+  the grace remain before the contact is released (ADR 0030 decision 4).
+  """
+  @spec deliver_rent_due_email(User.t(), Fountain.Team.Contact.t(), non_neg_integer()) ::
+          {:ok, term()} | {:error, term()}
+  def deliver_rent_due_email(%User{} = user, contact, days_left) do
+    billing_url = "#{Fountain.PublicUrl.base()}/account/billing"
+
+    what =
+      [contact.phone_number, contact.email_address]
+      |> Enum.reject(&is_nil/1)
+      |> Enum.join(" and ")
+
+    rent = Fountain.Credits.format_cents(Fountain.Credits.Rent.month_cents())
+
+    when_ =
+      case days_left do
+        0 -> "today"
+        1 -> "tomorrow"
+        n -> "in #{n} days"
+      end
+
+    new()
+    |> from(UserEmails.from_address())
+    |> to({user.email, user.email})
+    |> subject("Your teammate's number will be released #{when_}")
+    |> html_body(rent_due_html(what, rent, when_, billing_url))
+    |> text_body(rent_due_text(what, rent, when_, billing_url))
+    |> Mailer.deliver()
+  end
+
+  defp rent_due_html(what, rent, when_, billing_url) do
+    """
+    <!DOCTYPE html>
+    <html>
+    <body style="font-family: sans-serif; max-width: 600px; margin: 0 auto; padding: 24px;">
+      <h2>Your teammate's number will be released #{when_}</h2>
+      <p>
+        The monthly rent of <strong>#{rent}</strong> for <strong>#{what}</strong> could
+        not be taken from your credit balance. If the balance is still short #{when_},
+        the number and inbox are released, and a released number cannot be recovered.
+      </p>
+      <p style="margin: 32px 0;">
+        <a href="#{billing_url}"
+           style="background: #18181b; color: #fff; padding: 12px 24px; border-radius: 6px; text-decoration: none; font-size: 14px;">
+          Buy credits
+        </a>
+      </p>
+      <p style="color: #71717a; font-size: 13px;">
+        As soon as the balance covers the rent, it is paid and the number stays.
+      </p>
+    </body>
+    </html>
+    """
+  end
+
+  defp rent_due_text(what, rent, when_, billing_url) do
+    """
+    Your teammate's number will be released #{when_}
+
+    The monthly rent of #{rent} for #{what} could not be taken from your
+    credit balance. If the balance is still short #{when_}, the number and
+    inbox are released, and a released number cannot be recovered.
+
+    Buy credits: #{billing_url}
+
+    As soon as the balance covers the rent, it is paid and the number stays.
+    """
+  end
 end

--- a/ee/lib/fountain/workers/credit_rent_collector.ex
+++ b/ee/lib/fountain/workers/credit_rent_collector.ex
@@ -1,0 +1,22 @@
+defmodule Fountain.Workers.CreditRentCollector do
+  @moduledoc "Daily shell over `Fountain.Credits.Rent.collect/1`."
+
+  use Oban.Worker, queue: :billing, max_attempts: 3, unique: [period: 60]
+
+  require Logger
+
+  @impl Oban.Worker
+  def perform(_job) do
+    case Fountain.Credits.Rent.collect() do
+      %{charged: 0, reminded: 0, released: 0} ->
+        :ok
+
+      c ->
+        Logger.info(
+          "credit rent: charged #{c.charged}, reminded #{c.reminded}, released #{c.released}"
+        )
+    end
+
+    :ok
+  end
+end

--- a/ee/lib/fountain/workers/credits_email.ex
+++ b/ee/lib/fountain/workers/credits_email.ex
@@ -21,13 +21,30 @@ defmodule Fountain.Workers.CreditsEmail do
 
   alias Fountain.{Accounts, Credits, Emails.BillingEmails}
 
-  @emails ~w(credits_low credits_exhausted)
+  @emails ~w(credits_low credits_exhausted rent_due)
 
   def emails, do: @emails
 
   @spec enqueue(String.t(), String.t()) :: {:ok, Oban.Job.t()} | {:error, term()}
   def enqueue(user_id, email) when is_binary(user_id) and email in @emails do
     %{"user_id" => user_id, "email" => email} |> new() |> Oban.insert()
+  end
+
+  @doc """
+  A rent reminder for one contact: `days_left` of the grace remain. Unique
+  per contact and day so the daily sweep cannot double-send.
+  """
+  @spec enqueue_rent_due(String.t(), String.t(), non_neg_integer()) ::
+          {:ok, Oban.Job.t()} | {:error, term()}
+  def enqueue_rent_due(user_id, contact_id, days_left) do
+    %{
+      "user_id" => user_id,
+      "email" => "rent_due",
+      "contact_id" => contact_id,
+      "days_left" => days_left
+    }
+    |> new(unique: [period: 2 * 86_400, fields: [:args]])
+    |> Oban.insert()
   end
 
   @doc """
@@ -59,6 +76,24 @@ defmodule Fountain.Workers.CreditsEmail do
   end
 
   @impl Oban.Worker
+  def perform(%Oban.Job{
+        args: %{
+          "user_id" => user_id,
+          "email" => "rent_due",
+          "contact_id" => contact_id,
+          "days_left" => days_left
+        }
+      }) do
+    with %{} = user <- Accounts.get_user(user_id),
+         %{rent_due_at: %DateTime{}} = contact <-
+           Fountain.Repo.get(Fountain.Team.Contact, contact_id) do
+      BillingEmails.deliver_rent_due_email(user, contact, days_left) |> log(user, "rent_due")
+    else
+      # Paid or released in the meantime: the reminder would be a lie.
+      _ -> :ok
+    end
+  end
+
   def perform(%Oban.Job{args: %{"user_id" => user_id, "email" => email}}) when email in @emails do
     case Accounts.get_user(user_id) do
       nil ->

--- a/ee/test/fountain/credits_rent_test.exs
+++ b/ee/test/fountain/credits_rent_test.exs
@@ -1,0 +1,198 @@
+defmodule Fountain.Credits.RentTest do
+  @moduledoc """
+  Rent a month up front, the anniversary, and the seven-day grace (ADR 0030
+  decision 4). `async: false`: the switches and prices are global config.
+  """
+
+  use Fountain.DataCase, async: false
+  use Mimic
+
+  alias Fountain.Credits
+  alias Fountain.Credits.Rent
+  alias Fountain.Repo
+  alias Fountain.Team.Contact
+  alias Fountain.Workers.CreditsEmail
+
+  @since ~U[2026-07-01 00:00:00Z]
+
+  defp switch(opts) do
+    cfg = Application.get_env(:fountain, :credits)
+    Application.put_env(:fountain, :credits, Keyword.merge(cfg, opts))
+    on_exit(fn -> Application.put_env(:fountain, :credits, cfg) end)
+  end
+
+  defp contact(user, attrs \\ %{}) do
+    agent = insert_agent(user_id: user.id)
+
+    %Contact{}
+    |> Contact.changeset(%{
+      user_id: user.id,
+      agent_id: agent.id,
+      email_address: "ada@agentmail.to",
+      email_inbox_id: "inbox_1",
+      phone_number: "+15551234567",
+      phone_number_id: "num_1"
+    })
+    |> Repo.insert!()
+    |> Ecto.Changeset.change(Map.to_list(attrs))
+    |> Repo.update!()
+  end
+
+  test "no rent when no price is set" do
+    switch(pricing_since: @since)
+    assert Rent.month_cents() == 0
+    refute Rent.charging?()
+    user = insert_active_user()
+    assert {:ok, :free} = Rent.charge(contact(user), ~U[2026-08-01 00:00:00Z])
+    assert %{charged: 0, reminded: 0, released: 0} = Rent.collect(now: ~U[2026-08-10 00:00:00Z])
+  end
+
+  test "add_month clamps to the shorter month" do
+    assert Rent.add_month(~U[2026-01-31 12:00:00Z]) == ~U[2026-02-28 12:00:00Z]
+    assert Rent.add_month(~U[2026-12-15 00:00:00Z]) == ~U[2027-01-15 00:00:00Z]
+  end
+
+  describe "with a price and enforcement off" do
+    setup do
+      switch(pricing_since: @since, enforce: false, number_cents: 300, inbox_cents: 200)
+      :ok
+    end
+
+    test "charge takes a month up front, once per period, and moves the paid-through date" do
+      user = insert_active_user()
+      c = contact(user)
+      start = ~U[2026-08-05 10:00:00Z]
+
+      assert {:ok, %Contact{rent_paid_through: ~U[2026-09-05 10:00:00Z]}} = Rent.charge(c, start)
+      assert Credits.balance(user.id) == -500
+      [entry] = Credits.list_entries(user.id)
+      assert entry.reason == "burn_rent" and entry.resource_id == c.id
+
+      assert {:ok, :duplicate, _} = Rent.charge(c, start)
+      assert Credits.balance(user.id) == -500
+    end
+
+    test "collect charges every contact whose month is up, starting a never-charged one now" do
+      user = insert_active_user()
+      fresh = contact(user)
+      due = contact(user, %{rent_paid_through: ~U[2026-08-01 00:00:00Z]})
+      paid = contact(user, %{rent_paid_through: ~U[2026-09-01 00:00:00Z]})
+
+      assert %{charged: 2} = Rent.collect(now: ~U[2026-08-10 00:00:00Z])
+      assert Repo.reload!(fresh).rent_paid_through == ~U[2026-09-10 00:00:00Z]
+      assert Repo.reload!(due).rent_paid_through == ~U[2026-09-01 00:00:00Z]
+      assert Repo.reload!(paid).rent_paid_through == ~U[2026-09-01 00:00:00Z]
+      assert Credits.balance(user.id) == -1000
+
+      assert %{charged: 0} = Rent.collect(now: ~U[2026-08-11 00:00:00Z])
+    end
+  end
+
+  describe "with enforcement on" do
+    setup do
+      switch(pricing_since: @since, enforce: true, number_cents: 300, inbox_cents: 200)
+      :ok
+    end
+
+    test "provisioning is refused below a month, and allowed at it" do
+      user = insert_active_user()
+      assert {:error, :insufficient_credits} = Rent.check_provision(user.id)
+      {:ok, _} = Credits.grant(user.id, 500, "purchase", idempotency_key: "p")
+      assert :ok = Rent.check_provision(user.id)
+    end
+
+    test "a short balance leaves the month unpaid and starts the grace" do
+      user = insert_active_user()
+      c = contact(user, %{rent_paid_through: ~U[2026-08-01 00:00:00Z]})
+      now = ~U[2026-08-02 00:00:00Z]
+
+      assert {:error, :insufficient_credits} = Rent.charge(c, ~U[2026-08-01 00:00:00Z], now: now)
+      assert Repo.reload!(c).rent_due_at == now
+      assert Credits.balance(user.id) == 0
+    end
+
+    test "grace: reminders on day 0, 3 and 6; a top-up pays; release on day 7" do
+      user = insert_active_user()
+      c = contact(user, %{rent_paid_through: ~U[2026-08-01 00:00:00Z]})
+      day0 = ~U[2026-08-02 00:00:00Z]
+
+      # Day 0: the sweep cannot charge, stamps the grace, and reminds in the
+      # same pass.
+      assert %{charged: 0, reminded: 1, released: 0} = Rent.collect(now: day0)
+      assert Repo.reload!(c).rent_due_at == day0
+
+      assert_enqueued(
+        worker: CreditsEmail,
+        args: %{"email" => "rent_due", "contact_id" => c.id, "days_left" => 7}
+      )
+
+      # Day 1 and 2: nothing.
+      assert %{reminded: 0, released: 0} = Rent.collect(now: DateTime.add(day0, 86_400, :second))
+      # Day 3.
+      assert %{reminded: 1} = Rent.collect(now: DateTime.add(day0, 3 * 86_400 + 60, :second))
+
+      assert_enqueued(
+        worker: CreditsEmail,
+        args: %{"email" => "rent_due", "contact_id" => c.id, "days_left" => 4}
+      )
+
+      # Day 6: nothing sent yet — then a top-up lands; the sweep pays and clears the grace.
+      {:ok, _} = Credits.grant(user.id, 500, "purchase", idempotency_key: "p")
+
+      assert %{reminded: 0, released: 0} =
+               Rent.collect(now: DateTime.add(day0, 6 * 86_400, :second))
+
+      assert %Contact{rent_due_at: nil, rent_paid_through: ~U[2026-09-01 00:00:00Z]} =
+               Repo.reload!(c)
+
+      assert Credits.balance(user.id) == 0
+    end
+
+    test "day 7 with no top-up releases the contact" do
+      user = insert_active_user()
+
+      c =
+        contact(user, %{
+          rent_paid_through: ~U[2026-08-01 00:00:00Z],
+          rent_due_at: ~U[2026-08-02 00:00:00Z]
+        })
+
+      test = self()
+
+      Mimic.copy(Fountain.Team.Comms)
+
+      Mimic.stub(Fountain.Team.Comms, :release_contact, fn user_id, agent_id, opts ->
+        send(test, {:released, user_id, agent_id, opts[:actor]})
+        :ok
+      end)
+
+      assert %{released: 0} = Rent.collect(now: ~U[2026-08-08 23:00:00Z])
+      assert %{released: 1} = Rent.collect(now: ~U[2026-08-09 00:00:01Z])
+      assert_receive {:released, uid, aid, "system:credit_rent"}
+      assert uid == user.id and aid == c.agent_id
+    end
+  end
+
+  test "the rent email is dropped once the contact is paid or gone" do
+    switch(pricing_since: @since, number_cents: 300, inbox_cents: 200)
+    user = insert_active_user()
+    c = contact(user, %{rent_due_at: ~U[2026-08-02 00:00:00Z]})
+    test = self()
+
+    stub(Fountain.Mailer, :deliver, fn email ->
+      send(test, {:sent, email.subject})
+      {:ok, %{}}
+    end)
+
+    job = %Oban.Job{
+      args: %{"user_id" => user.id, "email" => "rent_due", "contact_id" => c.id, "days_left" => 4}
+    }
+
+    assert :ok = CreditsEmail.perform(job)
+    assert_receive {:sent, "Your teammate's number will be released in 4 days"}
+
+    c |> Ecto.Changeset.change(rent_due_at: nil) |> Repo.update!()
+    assert :ok = CreditsEmail.perform(job)
+    refute_receive {:sent, _}
+  end
+end


### PR DESCRIPTION
Stacked on #1099 (diff includes it until it merges).

ADR 0030 decision 4 (rent a month up front) and the rent half of decision 6 (7-day grace, because release is irreversible).

**Adds**
- Migration: `team_contacts.rent_paid_through` / `rent_due_at` (nil on every existing row; inert until a rent price is set).
- `Fountain.Credits.Rent`: `month_cents/0` = `CREDIT_NUMBER_CENTS + CREDIT_INBOX_CENTS` (unset → free, nothing runs); `check_provision/1` refuses a new contact under enforcement when the balance is short of a month; `charge/3` debits `burn_rent:<contact>:<period_start>` once per period and advances `rent_paid_through` by a calendar month (clamped: Jan 31 → Feb 28); under enforcement a short balance stamps `rent_due_at` instead. `collect/1` is the daily pass.
- `Team.Comms.provision_contact/4`: the refusal sits beside the contact ceiling; the first month is charged after the row commits, best-effort like the add-on sync.
- `Fountain.Workers.CreditRentCollector` (06:47 UTC daily): charge anniversaries; remind at day 0, 3, 6 (`rent_due` kind on `CreditsEmail`, unique per contact per 2 days); any sweep during the grace retries the charge first, so a top-up pays and clears; day 7 releases via `Team.Comms.release_contact/3` as `system:credit_rent`.
- A contact that predates rent starts its first month at the first sweep, never retroactively (the phase 5 trap, applied to rent).
- Docs paragraph on the plans page.

**Tests** (9): free when unpriced; `add_month` clamping; charge once per period and paid-through moves; collect charges due and never-charged contacts and skips paid ones; provisioning refusal below a month; short balance starts the grace; full grace timeline (day 0 → 3 → top-up at day 6 pays and clears); day 7 release with the system actor; rent email dropped once paid/gone.

Refs #1086, ADR 0030.

🤖 Generated with [Claude Code](https://claude.com/claude-code)