### PR TITLE
feat(credits): the opening grant on the day credits go live (#1086 phase 5)

### DIFF
--- a/apps/fountain/lib/fountain/release.ex
+++ b/apps/fountain/lib/fountain/release.ex
@@ -388,6 +388,94 @@ defmodule Fountain.Release do
 
   defp unix_datetime(_), do: nil
 
+  @doc """
+  Give every tenant their opening credit the day credits go live (ADR 0030,
+  #1086 phase 5): the current period's tier grant, pro-rated to the part of
+  the period after `CREDIT_PRICING_SINCE`, for every active subscriber, and
+  the trial's opening grant for every live trial. Nobody starts at zero.
+
+  Idempotent: each grant is keyed on the tenant and period, so a rerun writes
+  nothing new, and the daily `CreditGranter` would have done the same within
+  a day. Refuses to run while `CREDIT_PRICING_SINCE` is unset, because the
+  pro-rating needs it and a grant with no floor would hand out a full month
+  already spent unmetered.
+
+      bin/fountain_server eval 'Fountain.Release.start_credits(dry_run: true)'
+      bin/fountain_server eval 'Fountain.Release.start_credits()'
+  """
+  def start_credits(opts \\ []) do
+    with_repo(fn -> do_start_credits(opts) end)
+  end
+
+  defp do_start_credits(opts) do
+    import Ecto.Query
+    dry_run? = Keyword.get(opts, :dry_run, false)
+    since = Keyword.get(opts, :since) || Fountain.Workers.CreditPricer.pricing_since()
+    now = Keyword.get(opts, :now) || DateTime.utc_now()
+
+    cond do
+      not Fountain.Billing.enabled?() ->
+        IO.puts("Billing is off on this instance; credits do not apply. Nothing to do.")
+        {:ok, 0}
+
+      is_nil(since) ->
+        IO.warn("CREDIT_PRICING_SINCE is unset. Set it to the deploy time, then rerun.")
+        {:error, :pricing_since_unset}
+
+      true ->
+        subscribers =
+          Fountain.Repo.all(
+            from u in Fountain.Accounts.User,
+              where: u.subscription_status == "active",
+              where: not is_nil(u.current_period_start) and not is_nil(u.current_period_end),
+              where: u.current_period_start <= ^now and u.current_period_end > ^now
+          )
+
+        trials =
+          Fountain.Repo.all(
+            from u in Fountain.Accounts.User,
+              where: u.subscription_status == "trialing",
+              where: not is_nil(u.trial_ends_at) and u.trial_ends_at > ^now
+          )
+
+        if dry_run? do
+          IO.puts(
+            "#{length(subscribers)} active subscriber(s) inside a billing period and " <>
+              "#{length(trials)} live trial(s) would be granted, pro-rated from #{DateTime.to_iso8601(since)}."
+          )
+
+          {:ok, length(subscribers) + length(trials)}
+        else
+          granted =
+            (subscribers ++ trials)
+            |> Enum.map(
+              &Fountain.Workers.CreditGranter.grant_for_user(&1, since: since, now: now)
+            )
+            |> Enum.sum()
+
+          Fountain.Audit.record(%{
+            user_id: nil,
+            action: "release.credits_started",
+            resource_type: "release_task",
+            actor: "system:release_task",
+            metadata: %{
+              "subscribers" => length(subscribers),
+              "trials" => length(trials),
+              "granted" => granted,
+              "since" => DateTime.to_iso8601(since)
+            }
+          })
+
+          IO.puts(
+            "Granted #{granted} opening credit(s) across #{length(subscribers)} subscriber(s) " <>
+              "and #{length(trials)} trial(s). Reruns write nothing."
+          )
+
+          {:ok, granted}
+        end
+    end
+  end
+
   defp repos do
     Application.fetch_env!(@app, :ecto_repos)
   end

--- a/docs/guides/operate/billing.md
+++ b/docs/guides/operate/billing.md
@@ -48,6 +48,36 @@ bin/fountain_server eval 'Fountain.Release.expire_legacy_trials(days: 14)'
 
 Run the dry run first. It reports, and it changes nothing.
 
+## Start prepaid credits
+
+Credits are off until you set `CREDIT_PRICING_SINCE`. Do these steps in
+this order, because each one protects the next.
+
+1. Set `CREDIT_PRICING_SINCE` to the time of the deploy, in ISO 8601. Do
+   not set an earlier time. An earlier time bills every tenant for turns
+   they ran before they held a grant.
+2. Deploy. From that instant, Fountain prices turns into the ledger and
+   shows the balance on the billing page. Fountain refuses nothing.
+3. Give every tenant their opening credit, so nobody starts at zero.
+
+   ```bash
+   # See who would be granted, change nothing:
+   bin/fountain_server eval 'Fountain.Release.start_credits(dry_run: true)'
+
+   # Grant the current period, pro-rated from CREDIT_PRICING_SINCE:
+   bin/fountain_server eval 'Fountain.Release.start_credits()'
+   ```
+
+   Run the dry run first. A rerun of the real task writes nothing new.
+4. Add `charge.refunded` and `charge.dispute.created` to your Stripe webhook
+   endpoint, so a refund takes the credit back.
+5. After a month of provider invoices reconciled on `/admin/finance`, set
+   `CREDIT_ENFORCE=true`. From then, a zero balance refuses new sandboxes and
+   new turns.
+
+[Launch plans and prices](plans-and-prices.md) covers the prices and the
+packs.
+
 ## Verify it worked
 
 Sign in as an account that is not an admin, then confirm it can still reach a

--- a/ee/test/fountain/release_credits_test.exs
+++ b/ee/test/fountain/release_credits_test.exs
@@ -1,0 +1,86 @@
+defmodule Fountain.Release.CreditsTest do
+  @moduledoc """
+  `Fountain.Release.start_credits/1` (#1086 phase 5): the opening grants on
+  the day credits go live. `async: false` because it reads the global switch.
+  """
+
+  use Fountain.DataCase, async: false
+
+  import ExUnit.CaptureIO
+
+  alias Fountain.Accounts.User
+  alias Fountain.Credits
+  alias Fountain.Release
+
+  @since ~U[2026-08-16 00:00:00Z]
+  @now ~U[2026-08-16 06:00:00Z]
+
+  defp subscriber(plan) do
+    {:ok, user} =
+      insert_active_user()
+      |> User.billing_changeset(%{
+        plan: plan,
+        current_period_start: ~U[2026-08-01 00:00:00Z],
+        current_period_end: ~U[2026-09-01 00:00:00Z]
+      })
+      |> Repo.update()
+
+    user
+  end
+
+  defp trialer do
+    {:ok, user} =
+      insert_verified_user()
+      |> User.billing_changeset(%{
+        subscription_status: "trialing",
+        trial_ends_at: ~U[2026-08-25 00:00:00Z]
+      })
+      |> Repo.update()
+
+    user
+  end
+
+  test "refuses with no floor, counts on a dry run, grants once for real" do
+    solo = subscriber("solo")
+    team = subscriber("team")
+    trial = trialer()
+    # Canceled and comped get nothing.
+    {:ok, _} =
+      insert_active_user()
+      |> User.billing_changeset(%{subscription_status: "canceled"})
+      |> Repo.update()
+
+    cfg = Application.get_env(:fountain, :credits)
+    on_exit(fn -> Application.put_env(:fountain, :credits, cfg) end)
+    Application.put_env(:fountain, :credits, Keyword.put(cfg, :pricing_since, nil))
+
+    capture_io(:stderr, fn ->
+      assert {:error, :pricing_since_unset} = Release.start_credits(now: @now)
+    end)
+
+    assert Credits.balance(solo.id) == 0
+
+    out =
+      capture_io(fn ->
+        assert {:ok, 3} = Release.start_credits(dry_run: true, since: @since, now: @now)
+      end)
+
+    assert out =~ "2 active subscriber(s)"
+    assert out =~ "1 live trial(s)"
+    assert Credits.balance(solo.id) == 0
+
+    capture_io(fn -> assert {:ok, 3} = Release.start_credits(since: @since, now: @now) end)
+    # 16 of 31 days remain.
+    assert Credits.balance(solo.id) == div(1000 * 16 + 15, 31)
+    assert Credits.balance(team.id) == div(2500 * 16 + 15, 31)
+    assert Credits.balance(trial.id) == 1000
+
+    capture_io(fn -> assert {:ok, 0} = Release.start_credits(since: @since, now: @now) end)
+    assert Credits.balance(solo.id) == div(1000 * 16 + 15, 31)
+
+    assert [_] =
+             Repo.all(
+               from(e in Fountain.Audit.Event, where: e.action == "release.credits_started")
+             )
+  end
+end

--- a/ee/test/fountain/release_credits_test.exs
+++ b/ee/test/fountain/release_credits_test.exs
@@ -78,9 +78,11 @@ defmodule Fountain.Release.CreditsTest do
     capture_io(fn -> assert {:ok, 0} = Release.start_credits(since: @since, now: @now) end)
     assert Credits.balance(solo.id) == div(1000 * 16 + 15, 31)
 
-    assert [_] =
-             Repo.all(
-               from(e in Fountain.Audit.Event, where: e.action == "release.credits_started")
+    # One row per real run, the rerun included: the task ran, even if it wrote nothing.
+    assert 2 ==
+             Repo.aggregate(
+               from(e in Fountain.Audit.Event, where: e.action == "release.credits_started"),
+               :count
              )
   end
 end


### PR DESCRIPTION
Independent of the open stack (#1099, #1100); branches from main.

**Adds** `Fountain.Release.start_credits/1` — the phase 5 migration:
- every `active` subscriber inside a billing period gets the current period's tier grant, **pro-rated from `CREDIT_PRICING_SINCE`** (the same arithmetic the daily granter uses, so a rerun or the sweep writes nothing new);
- every live trial gets its opening grant;
- refuses with `{:error, :pricing_since_unset}` when the floor is unset (a grant with no floor would hand out a month already spent unmetered);
- `dry_run: true` counts and changes nothing; the real run records `release.credits_started` with the tally.

**Docs:** `billing.md` gains "Start prepaid credits" — the five steps in the order that keeps each safe: set the floor to the deploy time → deploy → `start_credits` → add the two Stripe webhook events → after a reconciled month, `CREDIT_ENFORCE=true`.

**Test:** refuses with no floor; dry run counts 2 subscribers + 1 trial; real run grants Solo/Team pro-rated to 16/31 and the trial $10; rerun grants 0; canceled gets nothing; audit rows.

Refs #1086, ADR 0030.

🤖 Generated with [Claude Code](https://claude.com/claude-code)