### PR TITLE
feat(finance): the provider invoice next to the computed figure, and the dropped-event count (#1038 steps 1 and 2)

### DIFF
--- a/apps/fountain/lib/fountain/application.ex
+++ b/apps/fountain/lib/fountain/application.ex
@@ -20,6 +20,9 @@ defmodule Fountain.Application do
       Fountain.Telemetry.attach_otel_bridge()
     end
 
+    # Counts metering events this node drops, for /admin/finance (#1038).
+    Fountain.Billing.Reconciliation.attach_drop_counter()
+
     cluster_topologies = Application.get_env(:libcluster, :topologies, [])
 
     children =

--- a/apps/fountain/priv/repo/migrations/20260824120000_create_provider_invoices.exs
+++ b/apps/fountain/priv/repo/migrations/20260824120000_create_provider_invoices.exs
@@ -1,0 +1,20 @@
+defmodule Fountain.Repo.Migrations.CreateProviderInvoices do
+  use Ecto.Migration
+
+  # #1038 step 1: what a provider actually charged for a month, recorded by
+  # hand from the invoice, so /admin/finance can hold it next to the computed
+  # figure. One row per provider per month; recording again replaces it.
+  def change do
+    create table(:provider_invoices, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :provider, :string, null: false
+      add :period_start, :date, null: false
+      add :period_end, :date, null: false
+      add :amount_cents, :integer, null: false
+      add :note, :string
+      timestamps(type: :utc_datetime)
+    end
+
+    create unique_index(:provider_invoices, [:provider, :period_start])
+  end
+end

--- a/docs/guides/operate/sandbox-spend.md
+++ b/docs/guides/operate/sandbox-spend.md
@@ -53,7 +53,7 @@ delta. Use the form under the table to record what a provider charged for
 the month the page shows. A positive delta means the model under-reports.
 Record every month. After a month of deltas, you know which gaps in the
 model matter, and you know enough to turn credit enforcement on. The order
-of steps is in [Start billing](billing.md).
+of steps is in [the guide that starts it](billing.md).
 
 The same section shows how many usage events this node dropped since it
 booted. A dropped event makes the figures for that period approximate. The

--- a/docs/guides/operate/sandbox-spend.md
+++ b/docs/guides/operate/sandbox-spend.md
@@ -52,8 +52,8 @@ Fountain pays. Each row shows the computed cost, the invoiced cost, and the
 delta. Use the form under the table to record what a provider charged for
 the month the page shows. A positive delta means the model under-reports.
 Record every month. After a month of deltas, you know which gaps in the
-model matter, and you know enough to turn credit enforcement on. The
-[billing guide](billing.md) has the order of steps.
+model matter, and you know enough to turn credit enforcement on. The order
+of steps is in [Start billing](billing.md).
 
 The same section shows how many usage events this node dropped since it
 booted. A dropped event makes the figures for that period approximate. The

--- a/docs/guides/operate/sandbox-spend.md
+++ b/docs/guides/operate/sandbox-spend.md
@@ -44,6 +44,21 @@ names the accounts with the most hours, each with its own idle share.
 The panel is there whether or not you turn billing on. A self-hosted instance <!-- vale disable-line STE.IngForms -->
 still pays a provider.
 
+## Record the invoice next to the figure
+
+The computed cost is a model. Until a real invoice sits next to it, the
+error is unknown. The panel has a table with one row for each provider
+Fountain pays. Each row shows the computed cost, the invoiced cost, and the
+delta. Use the form under the table to record what a provider charged for
+the month the page shows. A positive delta means the model under-reports.
+Record every month. After a month of deltas, you know which gaps in the
+model matter, and you know enough to turn credit enforcement on. The
+[billing guide](billing.md) has the order of steps.
+
+The same section shows how many usage events this node dropped since it
+booted. A dropped event makes the figures for that period approximate. The
+count is for one node and resets when the node restarts.
+
 ## What each provider means for your bill
 
 | Provider | Who pays |

--- a/ee/lib/fountain/billing/provider_invoice.ex
+++ b/ee/lib/fountain/billing/provider_invoice.ex
@@ -1,0 +1,33 @@
+defmodule Fountain.Billing.ProviderInvoice do
+  @moduledoc "One provider's bill for one month, as invoiced (#1038)."
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @type t :: %__MODULE__{}
+
+  @providers ~w(sprites e2b daytona agentmail agentphone)
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  schema "provider_invoices" do
+    field :provider, :string
+    field :period_start, :date
+    field :period_end, :date
+    field :amount_cents, :integer
+    field :note, :string
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc "The providers an invoice can be recorded for."
+  def providers, do: @providers
+
+  def changeset(invoice, attrs) do
+    invoice
+    |> cast(attrs, [:provider, :period_start, :period_end, :amount_cents, :note])
+    |> validate_required([:provider, :period_start, :period_end, :amount_cents])
+    |> validate_inclusion(:provider, @providers)
+    |> validate_number(:amount_cents, greater_than_or_equal_to: 0)
+    |> validate_length(:note, max: 500)
+    |> unique_constraint([:provider, :period_start])
+  end
+end

--- a/ee/lib/fountain/billing/reconciliation.ex
+++ b/ee/lib/fountain/billing/reconciliation.ex
@@ -1,0 +1,184 @@
+defmodule Fountain.Billing.Reconciliation do
+  @moduledoc """
+  Computed spend held next to what the provider actually charged (#1038
+  step 1), and the count of metering events this node has dropped (step 2).
+
+  `Finance.summary/1` is a plausible number with an unknown error until a
+  real invoice sits beside it. `record_invoice/2` stores one per provider
+  per month; `lines/2` produces, for every provider Fountain pays, the
+  computed cents, the recorded cents, and the delta. A month of deltas is
+  what turns each gap in the model from a silent bias into a measured one,
+  and is what gates enforcement (ADR 0030 §8).
+
+  Recording an invoice is an admin act on platform data, not on a tenant, so
+  the audit row carries no `user_id` and an `admin:<id>` actor.
+  """
+
+  import Ecto.Query
+
+  alias Fountain.Audit
+  alias Fountain.Billing.ProviderInvoice
+  alias Fountain.Repo
+
+  @doc """
+  Record (or replace) what `provider` charged for the month starting
+  `period_start`. `attrs` is string-keyed: `provider`, `period_start`,
+  `period_end`, `amount_cents`, `note`. Options carry the audit attribution.
+  """
+  @spec record_invoice(map(), keyword()) ::
+          {:ok, ProviderInvoice.t()} | {:error, Ecto.Changeset.t()}
+  def record_invoice(attrs, opts \\ []) do
+    changeset = ProviderInvoice.changeset(%ProviderInvoice{}, attrs)
+
+    with {:ok, invoice} <-
+           Repo.insert(changeset,
+             on_conflict: {:replace, [:period_end, :amount_cents, :note, :updated_at]},
+             conflict_target: [:provider, :period_start],
+             returning: true
+           ) do
+      Audit.record(%{
+        user_id: nil,
+        action: "finance.invoice.recorded",
+        resource_type: "provider_invoice",
+        resource_id: invoice.id,
+        actor: Keyword.get(opts, :actor, "admin"),
+        request_ip: Keyword.get(opts, :request_ip),
+        metadata: %{
+          "provider" => invoice.provider,
+          "period_start" => Date.to_iso8601(invoice.period_start),
+          "amount_cents" => invoice.amount_cents
+        }
+      })
+
+      {:ok, invoice}
+    end
+  end
+
+  @doc "Invoices recorded for the month starting `period_start`, by provider."
+  @spec invoices_for(Date.t()) :: %{optional(String.t()) => ProviderInvoice.t()}
+  def invoices_for(%Date{} = period_start) do
+    from(i in ProviderInvoice, where: i.period_start == ^period_start)
+    |> Repo.all()
+    |> Map.new(&{&1.provider, &1})
+  end
+
+  @typedoc "One provider's computed-versus-invoiced line."
+  @type line :: %{
+          provider: String.t(),
+          computed_cents: integer() | nil,
+          recorded_cents: integer() | nil,
+          delta_cents: integer() | nil,
+          note: String.t() | nil
+        }
+
+  @doc """
+  One line per provider Fountain pays, from a `Finance.summary/1` and the
+  invoices recorded for its month. `computed_cents` is nil where the rate
+  card cannot price the provider; `delta_cents` is recorded minus computed,
+  so a positive delta means the model under-reports.
+  """
+  @spec lines(map(), %{optional(String.t()) => ProviderInvoice.t()}) :: [line()]
+  def lines(summary, invoices) do
+    computed = computed_by_provider(summary)
+
+    for provider <- ProviderInvoice.providers() do
+      c = Map.get(computed, provider)
+      r = invoices[provider] && invoices[provider].amount_cents
+
+      %{
+        provider: provider,
+        computed_cents: c,
+        recorded_cents: r,
+        delta_cents: if(is_integer(c) and is_integer(r), do: r - c),
+        note: invoices[provider] && invoices[provider].note
+      }
+    end
+  end
+
+  # Sandbox providers from the attribution roll-up at the summary's basis;
+  # AgentMail is inboxes plus email, AgentPhone numbers plus SMS, pro-rated
+  # and rounded the way `Finance` does it so the two never disagree.
+  defp computed_by_provider(summary) do
+    card = summary.rate_card
+    cost = summary.cost
+    fraction = summary.period_fraction
+
+    sandboxes =
+      Map.new(cost.by_provider, fn {provider, totals} ->
+        seconds = if(card.basis == :turn, do: totals.busy_seconds, else: totals.active_seconds)
+
+        cents =
+          case Map.get(card.providers, provider) do
+            nil -> nil
+            rate -> round(seconds / 3600 * rate)
+          end
+
+        {provider, cents}
+      end)
+
+    agentmail =
+      add([
+        monthly(cost.inboxes, card.inbox_month, fraction),
+        per_message(cost.emails_sent, card.email)
+      ])
+
+    agentphone =
+      add([
+        monthly(cost.numbers, card.number_month, fraction),
+        per_message(cost.sms_sent + cost.sms_received, card.sms)
+      ])
+
+    sandboxes |> Map.put("agentmail", agentmail) |> Map.put("agentphone", agentphone)
+  end
+
+  defp monthly(0, _cents, _fraction), do: 0
+  defp monthly(_units, nil, _fraction), do: nil
+  defp monthly(units, cents, fraction), do: units * cents * fraction
+
+  defp per_message(0, _cents), do: 0
+  defp per_message(_n, nil), do: nil
+  defp per_message(n, cents), do: n * cents
+
+  defp add(parts) do
+    if Enum.any?(parts, &is_nil/1), do: nil, else: parts |> Enum.sum() |> round()
+  end
+
+  @doc """
+  Metering events dropped on this node since it booted (`[:fountain, :usage,
+  :dropped]`). A non-zero count means the period's figures rest on an
+  incomplete record. Per node and since boot — a fleet-wide, durable count is
+  what a metric backend is for; this is the number that belongs beside the
+  figures it undermines.
+  """
+  @spec dropped_on_this_node() :: non_neg_integer()
+  def dropped_on_this_node do
+    case :persistent_term.get({__MODULE__, :dropped}, nil) do
+      nil -> 0
+      ref -> :counters.get(ref, 1)
+    end
+  end
+
+  @doc false
+  def attach_drop_counter do
+    ref = :counters.new(1, [:write_concurrency])
+    :persistent_term.put({__MODULE__, :dropped}, ref)
+
+    :telemetry.attach(
+      "fountain-usage-dropped-counter",
+      [:fountain, :usage, :dropped],
+      &__MODULE__.handle_drop/4,
+      ref
+    )
+  end
+
+  @doc false
+  def handle_drop(_event, %{count: n}, _meta, ref), do: :counters.add(ref, 1, n)
+
+  @doc false
+  def reset_drop_counter do
+    case :persistent_term.get({__MODULE__, :dropped}, nil) do
+      nil -> :ok
+      ref -> :counters.put(ref, 1, 0)
+    end
+  end
+end

--- a/ee/lib/fountain_web/live/admin_finance_live.ex
+++ b/ee/lib/fountain_web/live/admin_finance_live.ex
@@ -37,6 +37,7 @@ defmodule FountainWeb.Live.AdminFinanceLive do
 
   alias Fountain.Billing
   alias Fountain.Billing.Finance
+  alias Fountain.Billing.Reconciliation
   alias Fountain.Billing.SandboxUsage
 
   @impl true
@@ -92,14 +93,59 @@ defmodule FountainWeb.Live.AdminFinanceLive do
   # queries), so it runs on 30s rather than 10s, and a closed month is not
   # recomputed at all — nothing in it can change.
   defp assign_finance(socket) do
-    assign(
-      socket,
-      :finance,
+    {period_start, _} = month_range(socket.assigns.months_ago)
+
+    finance =
       Finance.summary(
         period: month_range(socket.assigns.months_ago),
         basis: socket.assigns.basis
       )
-    )
+
+    invoices = Reconciliation.invoices_for(DateTime.to_date(period_start))
+
+    socket
+    |> assign(:finance, finance)
+    |> assign(:invoice_lines, Reconciliation.lines(finance, invoices))
+    |> assign(:dropped, Reconciliation.dropped_on_this_node())
+  end
+
+  # An invoice is typed in dollars and stored in cents; the month is the one
+  # the page is showing, so a closed month's bill lands on that month.
+  @impl true
+  def handle_event(
+        "record_invoice",
+        %{"provider" => provider, "amount" => amount} = params,
+        socket
+      ) do
+    {period_start, period_end} = month_range(socket.assigns.months_ago)
+
+    with {:ok, cents} <- parse_dollars(amount),
+         {:ok, _} <-
+           Reconciliation.record_invoice(
+             %{
+               "provider" => provider,
+               "period_start" => DateTime.to_date(period_start),
+               "period_end" => DateTime.to_date(period_end),
+               "amount_cents" => cents,
+               "note" => params["note"]
+             },
+             FountainWeb.Audited.attribution(socket)
+           ) do
+      {:noreply,
+       socket
+       |> put_flash(:info, "Recorded #{provider}'s invoice for the month.")
+       |> assign_finance()}
+    else
+      _ ->
+        {:noreply, put_flash(socket, :error, "Enter the invoice total in dollars, like 123.45.")}
+    end
+  end
+
+  defp parse_dollars(raw) when is_binary(raw) do
+    case Float.parse(String.trim(String.replace(raw, ["$", ","], ""))) do
+      {dollars, ""} when dollars >= 0 -> {:ok, round(dollars * 100)}
+      _ -> :error
+    end
   end
 
   # `months_ago` back from the current month, as a whole UTC month. Zero is
@@ -396,6 +442,81 @@ defmodule FountainWeb.Live.AdminFinanceLive do
           {money(@finance.unattributed_cost_cents)} of that belongs to deleted accounts and is in
           no tenant row below — spend nobody can be charged for.
         </div>
+      </section>
+
+      <%!-- ── Computed against invoiced (#1038) ── --%>
+      <section class="space-y-3" id="reconciliation">
+        <h2 class="text-lg font-medium">Provider invoices</h2>
+        <p class="text-xs text-zinc-500">
+          The computed cost is a model with an unknown error until a real invoice sits beside it.
+          Record each provider's bill for this month; the delta is invoiced minus computed, so a
+          positive number means the model under-reports.
+        </p>
+        <div
+          :if={@dropped > 0}
+          class="bg-amber-50 border border-amber-200 rounded px-4 py-2 text-xs text-amber-900"
+        >
+          {@dropped} metering {pluralize(@dropped, "event", "events")} dropped on this node since it
+          booted. The figures for any period that overlaps are approximate.
+        </div>
+        <table class="w-full text-sm bg-white rounded shadow border border-zinc-200">
+          <thead class="text-left text-xs text-zinc-500">
+            <tr>
+              <th class="px-3 py-2 font-normal">Provider</th>
+              <th class="px-3 py-2 font-normal text-right">Computed</th>
+              <th class="px-3 py-2 font-normal text-right">Invoiced</th>
+              <th class="px-3 py-2 font-normal text-right">Delta</th>
+              <th class="px-3 py-2 font-normal">Note</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr :for={line <- @invoice_lines} class="border-t border-zinc-100">
+              <td class="px-3 py-2">{line.provider}</td>
+              <td class="px-3 py-2 text-right tabular-nums">{money(line.computed_cents)}</td>
+              <td class="px-3 py-2 text-right tabular-nums">{money(line.recorded_cents)}</td>
+              <td class={[
+                "px-3 py-2 text-right tabular-nums",
+                line.delta_cents && line.delta_cents != 0 && "text-amber-700"
+              ]}>
+                {money(line.delta_cents)}
+              </td>
+              <td class="px-3 py-2 text-xs text-zinc-500">{line.note}</td>
+            </tr>
+          </tbody>
+        </table>
+        <form phx-submit="record_invoice" class="flex flex-wrap items-end gap-2 text-sm">
+          <label class="flex flex-col text-xs text-zinc-500">
+            Provider
+            <select
+              name="provider"
+              class="rounded border border-zinc-300 px-2 py-1 text-sm text-zinc-900"
+            >
+              <option :for={p <- Fountain.Billing.ProviderInvoice.providers()} value={p}>{p}</option>
+            </select>
+          </label>
+          <label class="flex flex-col text-xs text-zinc-500">
+            Invoice total ($)
+            <input
+              name="amount"
+              type="text"
+              inputmode="decimal"
+              placeholder="123.45"
+              class="rounded border border-zinc-300 px-2 py-1 text-sm text-zinc-900 w-28"
+            />
+          </label>
+          <label class="flex flex-col text-xs text-zinc-500">
+            Note
+            <input
+              name="note"
+              type="text"
+              placeholder="invoice number"
+              class="rounded border border-zinc-300 px-2 py-1 text-sm text-zinc-900 w-48"
+            />
+          </label>
+          <button type="submit" class="rounded bg-zinc-900 px-3 py-1.5 text-xs font-medium text-white">
+            Record for {Calendar.strftime(@finance.period_start, "%B")}
+          </button>
+        </form>
       </section>
 
       <%!-- ── The row that matters ── --%>

--- a/ee/test/fountain/billing_reconciliation_test.exs
+++ b/ee/test/fountain/billing_reconciliation_test.exs
@@ -1,0 +1,145 @@
+defmodule Fountain.Billing.ReconciliationTest do
+  @moduledoc """
+  Computed against invoiced (#1038 step 1) and the dropped-events count
+  (step 2). `async: false`: the rate card is global config.
+  """
+
+  use FountainWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  alias Fountain.Accounts
+  alias Fountain.Audit
+  alias Fountain.Billing
+  alias Fountain.Billing.Finance
+  alias Fountain.Billing.Reconciliation
+  alias Fountain.Repo
+
+  @rate_keys ~w(provider_hourly_cents agentmail_inbox_cents agentphone_number_cents agentmail_message_cents agentphone_message_cents)a
+
+  setup do
+    original = Map.new(@rate_keys, &{&1, Application.get_env(:fountain, &1)})
+
+    on_exit(fn ->
+      Enum.each(original, fn
+        {key, nil} -> Application.delete_env(:fountain, key)
+        {key, value} -> Application.put_env(:fountain, key, value)
+      end)
+    end)
+
+    Enum.each(@rate_keys, &Application.delete_env(:fountain, &1))
+    Reconciliation.reset_drop_counter()
+    :ok
+  end
+
+  defp insert_admin do
+    {:ok, admin} = Accounts.update_user_role(insert_verified_user(), "admin")
+    admin
+  end
+
+  defp month_start do
+    now = DateTime.utc_now()
+    %DateTime{now | day: 1, hour: 0, minute: 0, second: 0, microsecond: {0, 0}}
+  end
+
+  defp ran(user, hours) do
+    started = month_start()
+
+    insert_sandbox(
+      user_id: user.id,
+      provider: "sprites",
+      status: "terminated",
+      inserted_at: started,
+      terminated_at: DateTime.add(started, hours * 3600, :second)
+    )
+  end
+
+  test "record_invoice upserts per provider and month, and audits without a tenant" do
+    attrs = %{
+      "provider" => "sprites",
+      "period_start" => ~D[2026-07-01],
+      "period_end" => ~D[2026-07-31],
+      "amount_cents" => 12_345,
+      "note" => "inv_1"
+    }
+
+    assert {:ok, first} = Reconciliation.record_invoice(attrs, actor: "admin:x")
+
+    assert {:ok, second} =
+             Reconciliation.record_invoice(%{attrs | "amount_cents" => 20_000}, actor: "admin:x")
+
+    assert first.id == second.id
+    assert Reconciliation.invoices_for(~D[2026-07-01])["sprites"].amount_cents == 20_000
+    assert Reconciliation.invoices_for(~D[2026-06-01]) == %{}
+
+    assert {:error, %Ecto.Changeset{}} =
+             Reconciliation.record_invoice(%{attrs | "provider" => "aws"})
+
+    events = Repo.all(Audit.Event) |> Enum.filter(&(&1.action == "finance.invoice.recorded"))
+    assert length(events) == 2
+    assert Enum.all?(events, &(is_nil(&1.user_id) and &1.actor == "admin:x"))
+    assert hd(events).metadata["amount_cents"] in [12_345, 20_000]
+  end
+
+  test "lines: computed per provider at the rate card, delta against the invoice, nil where unpriced" do
+    Application.put_env(:fountain, :provider_hourly_cents, %{"sprites" => 100})
+    Application.put_env(:fountain, :agentmail_inbox_cents, 200)
+    user = insert_verified_user()
+    ran(user, 10)
+
+    {ps, pe} = Billing.current_month_range()
+    summary = Finance.summary(period: {ps, pe}, basis: :active)
+
+    {:ok, _} =
+      Reconciliation.record_invoice(%{
+        "provider" => "sprites",
+        "period_start" => DateTime.to_date(ps),
+        "period_end" => DateTime.to_date(pe),
+        "amount_cents" => 1_100
+      })
+
+    lines = Reconciliation.lines(summary, Reconciliation.invoices_for(DateTime.to_date(ps)))
+    by = Map.new(lines, &{&1.provider, &1})
+
+    assert by["sprites"].computed_cents == 1_000
+    assert by["sprites"].recorded_cents == 1_100
+    assert by["sprites"].delta_cents == 100
+    # No inboxes, so AgentMail computes to zero even though only the inbox rate is set.
+    assert by["agentmail"].computed_cents == 0
+    assert by["agentmail"].recorded_cents == nil and by["agentmail"].delta_cents == nil
+    # No e2b hours and no e2b rate: nothing to compute.
+    assert by["e2b"].computed_cents == nil
+    assert Enum.map(lines, & &1.provider) == ~w(sprites e2b daytona agentmail agentphone)
+  end
+
+  test "the panel shows the lines, records an invoice from the form, and surfaces dropped events",
+       %{conn: conn} do
+    Application.put_env(:fountain, :provider_hourly_cents, %{"sprites" => 100})
+    admin = insert_admin()
+    ran(insert_verified_user(), 10)
+
+    {:ok, lv, html} = live(login_user(conn, admin), ~p"/admin/finance")
+    assert html =~ "Provider invoices"
+    assert html =~ "$10.00"
+    refute html =~ "dropped on this node"
+
+    html =
+      render_submit(lv, "record_invoice", %{
+        "provider" => "sprites",
+        "amount" => "$12.50",
+        "note" => "inv_9"
+      })
+
+    assert html =~ "$12.50"
+    assert html =~ "$2.50"
+    assert html =~ "inv_9"
+
+    html = render_submit(lv, "record_invoice", %{"provider" => "sprites", "amount" => "lots"})
+    assert html =~ "Enter the invoice total in dollars"
+
+    :telemetry.execute([:fountain, :usage, :dropped], %{count: 3}, %{event_type: "x", kind: "y"})
+    assert Reconciliation.dropped_on_this_node() == 3
+    {:ok, _lv, html} = live(login_user(conn, admin), ~p"/admin/finance")
+    assert html =~ "3 metering events dropped on this node"
+  end
+end


### PR DESCRIPTION
Phase 1 of #1086 — the two #1038 steps that gate enforcement (ADR 0030 §8). Independent of the open stack; branches from main.

**Adds**
- `provider_invoices` (one row per provider per month; recording again replaces) and `Fountain.Billing.ProviderInvoice`.
- `Fountain.Billing.Reconciliation`: `record_invoice/2` (audited as `finance.invoice.recorded` with no tenant and an `admin:<id>` actor), `invoices_for/1`, and `lines/2` — for each of `sprites e2b daytona agentmail agentphone`: computed cents (sandbox providers at the rate card on the page's basis; AgentMail = inboxes + email; AgentPhone = numbers + SMS both ways; pro-rated and rounded the way `Finance` does so the two cannot disagree), invoiced cents, and the **delta = invoiced − computed** (positive ⇒ the model under-reports). `nil` wherever the rate card cannot price a line — never `$0`.
- `/admin/finance` gains a "Provider invoices" section: the table, and a form to record this month's bill in dollars (a closed month's bill lands on that month via the existing month selector).
- **Dropped events:** a `:counters` ref attached to `[:fountain, :usage, :dropped]` at app start; the panel shows "N metering events dropped on this node since it booted" when non-zero. Per node, since boot, labelled as such — a fleet-wide durable count is a metric backend's job; this is the number that belongs beside the figures it undermines.
- Docs: "Record the invoice next to the figure" on the spend page.

**Tests** (3): upsert + audit shape + provider validation; the line arithmetic (sprites 10 h × $1 = $10.00 vs $11.00 invoiced → +$1.00; AgentMail computes 0 with no inboxes; unpriced e2b is nil); the panel end-to-end including a bad amount and the dropped banner.

Refs #1038, #1086, ADR 0030.

🤖 Generated with [Claude Code](https://claude.com/claude-code)