### PR TITLE
ops: credits go live at 2026-08-24T23:45Z (CREDIT_PRICING_SINCE)

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -171,6 +171,15 @@ spec:
             # and no rate takes that whole tenant's cost to nil.
             - name: PROVIDER_HOURLY_CENTS
               value: sprites=10.76,e2b=5.45,daytona=5.45
+            # Prepaid credits (ADR 0030) went live at this instant: from here
+            # on, closed turns burn CREDIT_TURN_HOUR_CENTS (default 25) from
+            # the tenant's balance and each period's tier grant lands. Set to
+            # the deploy time, never earlier, or every tenant is billed for
+            # turns they ran before they held a grant. Enforcement is a
+            # separate switch (CREDIT_ENFORCE) and stays off until a month of
+            # provider invoices has been reconciled on /admin/finance.
+            - name: CREDIT_PRICING_SINCE
+              value: "2026-08-24T23:45:00Z"
             # AgentPhone: "$3.00/month" a number, "$0.02/message (inbound and
             # outbound)" — both directions, which is why inbound is metered.
             - name: AGENTPHONE_NUMBER_CENTS


### PR DESCRIPTION
Step 1 of the rollout in `docs/guides/operate/billing.md` ("Start prepaid credits"). Sets the floor to the deploy time on the hosted deployment; the pods already run #1094–#1103, so from this instant the pricer burns closed turns and the granter lands tier and trial grants. Nothing is refused: `CREDIT_ENFORCE` stays unset.

After rollout: `Fountain.Release.start_credits()` in a pod for the opening grants (1 subscriber, 2 live trials as of now). The Stripe webhook already has `charge.refunded` and `charge.dispute.created`.

Refs #1086, ADR 0030.

🤖 Generated with [Claude Code](https://claude.com/claude-code)