### PR TITLE
ops: enforce credits, and price numbers, inboxes and messages

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -180,6 +180,23 @@ spec:
             # provider invoices has been reconciled on /admin/finance.
             - name: CREDIT_PRICING_SINCE
               value: "2026-08-24T23:45:00Z"
+            # The soft stop: a zero balance refuses new sandboxes and turns;
+            # in-flight turns finish. Two users, both known, so no month of
+            # reconciled invoices before this (ADR 0030 §8 waived by the
+            # operator on 2026-08-24).
+            - name: CREDIT_ENFORCE
+              value: "true"
+            # What a tenant pays, in whole cents: a phone number $3/month, an
+            # inbox $2/month, and 2c per email or SMS (each way). Rent is a
+            # month up front with a seven-day grace before release.
+            - name: CREDIT_NUMBER_CENTS
+              value: "300"
+            - name: CREDIT_INBOX_CENTS
+              value: "200"
+            - name: CREDIT_EMAIL_MESSAGE_CENTS
+              value: "2"
+            - name: CREDIT_SMS_MESSAGE_CENTS
+              value: "2"
             # AgentPhone: "$3.00/month" a number, "$0.02/message (inbound and
             # outbound)" — both directions, which is why inbound is metered.
             - name: AGENTPHONE_NUMBER_CENTS


### PR DESCRIPTION
Step 5 of the rollout, early by the operator's call (two known users; no month of reconciled invoices first).

- `CREDIT_ENFORCE=true`: a zero balance refuses new sandboxes and new turns (402 `insufficient_credits`); in-flight turns finish; comped accounts exempt.
- `CREDIT_NUMBER_CENTS=300`, `CREDIT_INBOX_CENTS=200`: $5/month per teammate contact, a month up front; existing contacts start their first month at the next 06:47Z sweep, never retroactively; 7-day grace then release.
- `CREDIT_EMAIL_MESSAGE_CENTS=2`, `CREDIT_SMS_MESSAGE_CENTS=2`: per message, SMS both ways.

Balances today cover all of it (Scale $26.53, trials $10). Follow-up PR removes the turn-hour allowance surfaces so there is one path.

Refs #1086, ADR 0030.

🤖 Generated with [Claude Code](https://claude.com/claude-code)