### PR TITLE
feat(plans): a plan is denominated in credit, and Finance reads the ledger (#1086 batch 2, 1 of 4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ every plan.
 | | trial | solo | team | scale | legacy |
 |---|---|---|---|---|---|
 | concurrent sandboxes | 2 | 2 | 5 | 10 | 5 |
-| included turn hours | 40 | 40 | 100 | 200 | 100 |
+| credit a month | $10 | $10 | $25 | $50 | $25 |
 | teammate contacts | 0 | 1 | 3 | 10 | 3 |
 | price | free | $29 | $79 | $199 | $29 (closed) |
 
@@ -70,7 +70,7 @@ Five rules that are easy to get wrong:
 - **A trialing account gets `trial`'s numbers, not its tier's.**
   `Plans.effective/1` is what applies today; `Plans.resolve/1` is the tier the
   subscription names and what it converts into. Every entitlement reader
-  (`concurrent_sandboxes/1`, `included_turn_hours/1`, `team_contacts/1`) routes
+  (`concurrent_sandboxes/1`, `included_credit_cents/1`, `team_contacts/1`) routes
   through `effective/1` **when handed a `%User{}`** — hand it a bare slug and
   it cannot know the status, which is how `turn_hour_allowance/2` first got it
   wrong. The trial now *ties* Solo on concurrency and hours — the guardrail
@@ -101,24 +101,21 @@ Five rules that are easy to get wrong:
   `users.comped_contacts` takes N off the billed quantity for a tenant who
   still pays for their tier.
 
-- **A turn hour is not a sandbox hour, and nothing enforces either.**
-  `included_turn_hours` is 20 per concurrent slot, measured against
+- **A turn hour is not a sandbox hour.** Turns burn credit against
   `SandboxUsage`'s `turn_seconds` (the turns summed, each clipped to the
   period) on platform-paid providers only — an idle sandbox and a self-hosted
   runner spend none of it. `busy_seconds` is the *union* of the same intervals
   (how long the machine had any turn in flight) and is what a provider bill
   relates to; several conversations share one sandbox (ADR 0023), so the two
-  differ and must not be swapped.
-  `Billing.turn_hours_used/2` is the meter; nothing renders an "allowance"
-  any more (removed with the enforcement flip, ADR 0030). What acts is the
-  prepaid balance — see the next rule.
+  differ and must not be swapped. `Billing.turn_hours_used/2` is the meter;
+  what acts is the prepaid balance — see the next rule.
 
 - **Credits are the usage currency, and two switches turn them on.**
   ADR 0030: `Fountain.Credits` keeps a cents ledger (`credit_ledger`, cached
   on `users.credit_balance_cents`, idempotent per row, never summed on a
   gate). `CreditPricer` burns closed turns at `CREDIT_TURN_HOUR_CENTS`
   (default 25) and comms messages when priced; `CreditGranter` puts
-  `included_turn_hours × price` in each period and expires the unspent part
+  `Plans.included_credit_cents` in each period and expires the unspent part
   (granted first, oldest expiry first, then purchased); `Credits.Purchases`
   sells packs and claws back on refund or dispute; `Credits.Rent` takes a
   month up front per contact. Nothing prices, grants or shows a balance

--- a/apps/fountain/lib/fountain/plans.ex
+++ b/apps/fountain/lib/fountain/plans.ex
@@ -19,35 +19,23 @@ defmodule Fountain.Plans do
 
   ## Included turn hours
 
-  `included_turn_hours` is derived, not chosen per tier: **20 turn hours per
-  concurrent sandbox the plan allows**, so Solo's 2 slots carry 40 hours and
-  Scale's 10 carry 200. Deriving it keeps the ladder on one axis — a plan
-  cannot end up with more capacity and less work to do with it.
-
-  A *turn* hour is time with a prompt actually in flight
-  (`Fountain.Billing.SandboxUsage`'s `busy_seconds`), not wall-clock sandbox
-  time. The distinction is the whole point: a sandbox left running overnight
-  with nobody prompting it burns `active_seconds` and no allowance, so the
-  meter measures work rather than forgetfulness. Hours on a tenant's own
-  runner (ADR 0022) do not count either — Fountain pays nothing for them.
-
-  **The hours are now a credit grant (ADR 0030).** `included_turn_hours` is
-  what `Fountain.Workers.CreditGranter` multiplies by the turn-hour price at
-  the start of each billing period; turns burn that balance at the same
-  price, and `Billing.check_spend/1` refuses new spend at zero once
-  `CREDIT_ENFORCE` is on. `Fountain.Billing.turn_hour_allowance/2` still
-  reports used against included on every surface, and stays until
-  enforcement flips on the hosted deployment.
+  `included_credit_cents` is derived, not chosen per tier: **$5 of credit
+  per concurrent slot**, so Solo carries $10, Team $25 and Scale $50. It is
+  the monthly grant `Fountain.Workers.CreditGranter` puts into the prepaid
+  balance at the start of each billing period (ADR 0030); turns burn that
+  balance at the turn-hour price, and `Billing.check_spend/1` refuses new
+  spend at zero once `CREDIT_ENFORCE` is on. Hours on a tenant's own runner
+  (ADR 0022) burn nothing, and neither does a parked or idle sandbox.
 
   ## The catalog
 
-  | Plan | Concurrent | Turn hours | Teammate contacts | Price |
+  | Plan | Concurrent | Credit a month | Teammate contacts | Price |
   |---|---|---|---|---|
-  | `solo` | 2 | 40 | 1 | $29/mo |
-  | `team` | 5 | 100 | 3 | $79/mo |
-  | `scale` | 10 | 200 | 10 | $199/mo |
-  | `legacy` | 5 | 100 | 3 | $29/mo (closed) |
-  | `trial` | 2 | 40 | 0 | free (closed) |
+  | `solo` | 2 | $10 | 1 | $29/mo |
+  | `team` | 5 | $25 | 3 | $79/mo |
+  | `scale` | 10 | $50 | 10 | $199/mo |
+  | `legacy` | 5 | $25 | 3 | $29/mo (closed) |
+  | `trial` | 2 | $10 | 0 | free (closed) |
 
   ## The trial is a plan, and never a larger one
 
@@ -111,7 +99,7 @@ defmodule Fountain.Plans do
     :tagline,
     :monthly_cents,
     :concurrent_sandboxes,
-    :included_turn_hours,
+    :included_credit_cents,
     :team_contacts,
     :order,
     public?: true
@@ -123,10 +111,12 @@ defmodule Fountain.Plans do
   # module that is defining it. `all/0` is what turns these into `%Plans{}`,
   # and with four of them the cost of doing so per call is not worth caching.
   #
-  # `included_turn_hours` is 20 per concurrent slot, written out per plan
-  # rather than computed, so the catalog stays a table you can read every
-  # entitlement off. `plans_test.exs` asserts the ratio, so breaking it for a
-  # future plan is a deliberate act rather than a typo.
+  # `included_credit_cents` is $5 of credit per concurrent slot, written out
+  # per plan rather than computed, so the catalog stays a table you can read
+  # every entitlement off. `plans_test.exs` asserts the ratio, so breaking it
+  # for a future plan is a deliberate act rather than a typo. It is cents,
+  # not hours (ADR 0030): a change to the turn-hour price changes what an
+  # hour costs, never what a plan includes.
   @plan_specs [
     %{
       slug: "solo",
@@ -134,7 +124,7 @@ defmodule Fountain.Plans do
       tagline: "One person, a couple of agents at a time.",
       monthly_cents: 2_900,
       concurrent_sandboxes: 2,
-      included_turn_hours: 40,
+      included_credit_cents: 1_000,
       team_contacts: 1,
       order: 1
     },
@@ -144,7 +134,7 @@ defmodule Fountain.Plans do
       tagline: "A standing team of agents, working in parallel.",
       monthly_cents: 7_900,
       concurrent_sandboxes: 5,
-      included_turn_hours: 100,
+      included_credit_cents: 2_500,
       team_contacts: 3,
       order: 2
     },
@@ -154,7 +144,7 @@ defmodule Fountain.Plans do
       tagline: "Fleet-sized fan-out, without asking first.",
       monthly_cents: 19_900,
       concurrent_sandboxes: 10,
-      included_turn_hours: 200,
+      included_credit_cents: 5_000,
       team_contacts: 10,
       order: 3
     },
@@ -164,7 +154,7 @@ defmodule Fountain.Plans do
       tagline: "The original flat plan, at Team capacity.",
       monthly_cents: 2_900,
       concurrent_sandboxes: 5,
-      included_turn_hours: 100,
+      included_credit_cents: 2_500,
       team_contacts: 3,
       order: 0,
       public?: false
@@ -175,7 +165,7 @@ defmodule Fountain.Plans do
       tagline: "Enough to judge it by, for fourteen days.",
       monthly_cents: 0,
       concurrent_sandboxes: 2,
-      included_turn_hours: 40,
+      included_credit_cents: 1_000,
       team_contacts: 0,
       order: -1,
       public?: false
@@ -335,9 +325,9 @@ defmodule Fountain.Plans do
   Reported everywhere, enforced nowhere — no code path refuses anything
   because a tenant is over.
   """
-  @spec included_turn_hours(term()) :: non_neg_integer()
-  def included_turn_hours(%__MODULE__{included_turn_hours: n}), do: n
-  def included_turn_hours(subject), do: effective(subject).included_turn_hours
+  @spec included_credit_cents(term()) :: non_neg_integer()
+  def included_credit_cents(%__MODULE__{included_credit_cents: n}), do: n
+  def included_credit_cents(subject), do: effective(subject).included_credit_cents
 
   @doc """
   The most teammate contacts a user, slug or plan may hold at once.

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
@@ -44,10 +44,8 @@ defmodule FountainWeb.MarketingHTML do
   in flight, so an agent left sitting idle does not spend one — which is the
   part worth being explicit about on a pricing page.
   """
-  def plan_turn_hours(plan) do
-    cents = plan.included_turn_hours * Fountain.Credits.price_card().turn_hour
-    "#{Fountain.Credits.format_cents(cents)} of credit a month"
-  end
+  def plan_turn_hours(plan),
+    do: "#{Fountain.Credits.format_cents(plan.included_credit_cents)} of credit a month"
 
   @doc """
   The trial plan, so the page can state what fourteen days actually gets you.

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -1833,12 +1833,11 @@ defmodule FountainWeb.Schemas do
                   type: :integer,
                   description: "The plan's concurrency cap."
                 },
-                included_turn_hours: %Schema{
+                included_credit_cents: %Schema{
                   type: :integer,
                   description:
-                    "Turn hours the plan's monthly credit grant is sized on: " <>
-                      "this times credits.turn_hour_cents lands at the start of " <>
-                      "each billing period."
+                    "Credit the plan puts into the balance at the start of each " <>
+                      "billing period, in cents. Unused plan credit expires with the period."
                 },
                 sandbox_limit: %Schema{
                   type: :integer,

--- a/apps/fountain/test/fountain/plans_test.exs
+++ b/apps/fountain/test/fountain/plans_test.exs
@@ -50,21 +50,21 @@ defmodule Fountain.PlansTest do
     # The allowance is derived, not chosen per tier (#1016). Asserting the
     # ratio is what makes breaking it a deliberate act rather than a typo in
     # one of four near-identical literals.
-    test "included turn hours are 20 per concurrent slot, on every plan" do
+    test "included credit is $5 per concurrent slot, on every plan" do
       for plan <- Plans.all() do
-        assert plan.included_turn_hours == plan.concurrent_sandboxes * 20,
-               "#{plan.slug} carries #{plan.included_turn_hours} hours for " <>
+        assert plan.included_credit_cents == plan.concurrent_sandboxes * 500,
+               "#{plan.slug} carries #{plan.included_credit_cents} cents for " <>
                  "#{plan.concurrent_sandboxes} slots"
       end
     end
 
     test "the closed plan carries Team's hours, as it carries Team's capacity" do
-      assert Plans.fetch!("legacy").included_turn_hours ==
-               Plans.fetch!("team").included_turn_hours
+      assert Plans.fetch!("legacy").included_credit_cents ==
+               Plans.fetch!("team").included_credit_cents
     end
 
     test "each public plan includes strictly more hours than the one below" do
-      hours = Enum.map(Plans.public(), & &1.included_turn_hours)
+      hours = Enum.map(Plans.public(), & &1.included_credit_cents)
       assert hours == Enum.sort(hours)
       assert length(Enum.uniq(hours)) == length(hours)
     end
@@ -150,7 +150,7 @@ defmodule Fountain.PlansTest do
 
       for subject <- [plan, "scale", %{plan: "scale"}] do
         assert Plans.concurrent_sandboxes(subject) == plan.concurrent_sandboxes
-        assert Plans.included_turn_hours(subject) == plan.included_turn_hours
+        assert Plans.included_credit_cents(subject) == plan.included_credit_cents
         assert Plans.team_contacts(subject) == plan.team_contacts
         assert Plans.monthly_cents(subject) == plan.monthly_cents
       end

--- a/apps/fountain/test/fountain/plans_trial_test.exs
+++ b/apps/fountain/test/fountain/plans_trial_test.exs
@@ -34,7 +34,7 @@ defmodule Fountain.PlansTrialTest do
 
       for plan <- Plans.public() do
         assert trial.concurrent_sandboxes <= plan.concurrent_sandboxes
-        assert trial.included_turn_hours <= plan.included_turn_hours
+        assert trial.included_credit_cents <= plan.included_credit_cents
         assert trial.team_contacts <= plan.team_contacts
       end
     end
@@ -59,9 +59,9 @@ defmodule Fountain.PlansTrialTest do
       assert trial.monthly_cents == 0
     end
 
-    test "holds the 20-hours-per-slot ratio the other plans do" do
+    test "holds the $5-per-slot ratio the other plans do" do
       trial = Plans.fetch!("trial")
-      assert trial.included_turn_hours == trial.concurrent_sandboxes * 20
+      assert trial.included_credit_cents == trial.concurrent_sandboxes * 500
     end
 
     # `users.plan` is written only from the Stripe price on a subscription and
@@ -98,7 +98,7 @@ defmodule Fountain.PlansTrialTest do
 
       assert Plans.effective(user).slug == "trial"
       assert Plans.concurrent_sandboxes(user) == 2
-      assert Plans.included_turn_hours(user) == 40
+      assert Plans.included_credit_cents(user) == 1000
       assert Plans.team_contacts(user) == 0
     end
 
@@ -124,7 +124,7 @@ defmodule Fountain.PlansTrialTest do
     # the paid allowance.
     test "a bare slug is the plan's own number, trial or not" do
       assert Plans.concurrent_sandboxes("scale") == 10
-      assert Plans.included_turn_hours("scale") == 200
+      assert Plans.included_credit_cents("scale") == 5000
     end
 
     # `subscription_status` defaults to "trialing" in the schema, so without

--- a/apps/fountain/test/fountain_web/controllers/marketing_pricing_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_pricing_test.exs
@@ -45,7 +45,7 @@ defmodule FountainWeb.MarketingPricingTest do
       assert body =~ "#{plan.concurrent_sandboxes} agents at once"
 
       assert body =~
-               "#{Fountain.Credits.format_cents(plan.included_turn_hours * 25)} of credit a month"
+               "#{Fountain.Credits.format_cents(plan.included_credit_cents)} of credit a month"
     end
   end
 
@@ -112,7 +112,7 @@ defmodule FountainWeb.MarketingPricingTest do
     assert body =~ "#{trial.concurrent_sandboxes} agents at once"
 
     assert body =~
-             "with #{Fountain.Credits.format_cents(trial.included_turn_hours * 25)} of credit"
+             "with #{Fountain.Credits.format_cents(trial.included_credit_cents)} of credit"
 
     assert body =~ "so you can judge it before paying"
   end

--- a/docs/guides/operate/plans-and-prices.md
+++ b/docs/guides/operate/plans-and-prices.md
@@ -16,12 +16,12 @@ commercial instance with `BILLING_ENABLED=true`. Read
 A plan sets one number that Fountain enforces. That number is the count of
 sandboxes a tenant can run at the same time.
 
-| Plan | Concurrent sandboxes | Turn hours | Contact ceiling | Price |
+| Plan | Concurrent sandboxes | Credit a month | Contact ceiling | Price |
 |---|---|---|---|---|
-| Solo | 2 | 40 | 1 | $29/mo |
-| Team | 5 | 100 | 3 | $79/mo |
-| Scale | 10 | 200 | 10 | $199/mo |
-| Legacy | 5 | 100 | 3 | $29/mo |
+| Solo | 2 | $10 | 1 | $29/mo |
+| Team | 5 | $25 | 3 | $79/mo |
+| Scale | 10 | $50 | 10 | $199/mo |
+| Legacy | 5 | $25 | 3 | $29/mo |
 
 Every plan carries the whole product. Only the cap differs. See
 [ADR 0026](https://github.com/jhgaylor/fountain/blob/main/decisions/0026-plans-and-entitlements.md)
@@ -36,11 +36,11 @@ keep it, at Team capacity.
 A trial is not one of the plans above. It is its own plan, and an account gets
 it for the first 14 days whatever tier the subscription names.
 
-| Plan | Concurrent sandboxes | Turn hours | Contact ceiling | Price |
+| Plan | Concurrent sandboxes | Credit a month | Contact ceiling | Price |
 |---|---|---|---|---|
-| Trial | 2 | 40 | 0 | free |
+| Trial | 2 | $10 | 0 | free |
 
-The trial matches Solo on capacity and hours. It stays below Team and Scale.
+The trial matches Solo on capacity and credit. It stays below Team and Scale.
 No trial is larger than a plan that a customer pays for, so a subscription is
 never a downgrade. This is also why the customer portal ends the trial on a
 plan change instead of continuing it.
@@ -57,16 +57,17 @@ bound, not an allowance. Fountain charges for each contact separately.
 
 ### Turn hours measure work, not clock time
 
-Each plan includes 20 turn hours for each concurrent sandbox. A turn hour is
-one hour with a prompt in flight. An agent that waits for a person spends no
+Each plan includes $5 of credit a month for each concurrent sandbox, which
+is 20 turn hours at the default price. A turn hour is one hour with a prompt
+in flight. An agent that waits for a person spends no
 turn hours. Time on a self-hosted runner also spends none, because Fountain
 pays nothing for that machine. Turn hours add up for each turn. Two
 conversations that each run for an hour on one sandbox spend two turn hours,
 on a sandbox that was busy for one.
 
-The hours are a credit grant. At the start of each billing period, Fountain
-puts the plan's hours, at the turn-hour price, into the tenant's balance.
-Each turn takes its time out at the same price. The two limits behave
+The credit is a grant. At the start of each billing period, Fountain puts
+the plan's credit into the tenant's balance. Each turn takes its time out at
+the turn-hour price. The two limits behave
 differently. Fountain refuses the next start for a tenant at the concurrency
 cap. A tenant at a zero balance gets a refusal for new sandboxes and new
 turns, and turns in flight finish. See "Prepaid credits" below.
@@ -86,9 +87,9 @@ instant Fountain starts to price turns. Set it to the time of the deploy,
 never earlier, or every tenant pays for a week of turns before they hold a
 grant.
 
-Each plan puts credit in at the start of every billing period. The amount is
-the plan's turn hours at the turn-hour price. Solo puts in $10, Team $25 and
-Scale $50. That credit expires at the end of the period. A trial gets $10
+Each plan puts credit in at the start of every billing period. Solo puts in
+$10, Team $25 and Scale $50. A change to the turn-hour price changes what an
+hour costs, not what a plan puts in. That credit expires at the end of the period. A trial gets $10
 once, and that credit expires with the trial. Credit a tenant buys never
 expires, and Fountain spends it last.
 

--- a/ee/lib/fountain/billing.ex
+++ b/ee/lib/fountain/billing.ex
@@ -2149,7 +2149,7 @@ defmodule Fountain.Billing do
     step 6), not the sandbox's busy time. The same number
     `turn_hours_used/2` computes, carried here so a surface showing usage does
     not need a second pass over the same rows to show the unit a plan is
-    denominated in (`Fountain.Plans.included_turn_hours/1`).
+    denominated in (`Fountain.Credits.turn_cost_cents/1`).
   """
   @spec usage_summary(binary(), DateTime.t(), DateTime.t()) ::
           %{
@@ -2212,7 +2212,7 @@ defmodule Fountain.Billing do
   the admin table shows both. `sandbox_minutes` is wall-clock sandbox time —
   what a provider bills Fountain, so minutes, per provider, because the
   providers charge differently. `turn_hours` is time with a prompt in flight —
-  what a *plan* includes (`Fountain.Plans.included_turn_hours/1`), so hours,
+  what a *plan* includes (`Fountain.Credits.turn_cost_cents/1`), so hours,
   and summed only over the providers Fountain pays for, exactly as
   `turn_hours_used/2` computes it for one tenant.
   """

--- a/ee/lib/fountain/billing/finance.ex
+++ b/ee/lib/fountain/billing/finance.ex
@@ -90,10 +90,14 @@ defmodule Fountain.Billing.Finance do
 
   Every row carries active hours **and** turn hours whichever basis is
   chosen, because the gap between them is the tenant's idle time and it is
-  the single largest lever on the bill. Note that turn hours are also the
-  unit revenue is measured in (`Plans.included_turn_hours/1`) — so on the
-  `:turn` basis, cost and allowance move together, and on `:active` they do
-  not.
+  the single largest lever on the bill. Turn hours are also what burns a
+  tenant's prepaid credit (ADR 0030), so on the `:turn` basis cost and burn
+  move together, and on `:active` they do not.
+
+  **Credits** are the usage revenue: what a period's tier grants put in, what
+  turns and contacts burned, what packs sold, and the deferred balance —
+  money taken and not yet burned, which is a liability rather than revenue
+  until it is.
 
   **Contacts** are a monthly recurring charge per inbox and per number, so
   they are pro-rated against the period rather than charged whole: a panel
@@ -147,8 +151,10 @@ defmodule Fountain.Billing.Finance do
           plan_cents: non_neg_integer(),
           contact_revenue_cents: non_neg_integer(),
           turn_hours: float(),
-          included_turn_hours: non_neg_integer(),
-          allowance_used: float() | nil,
+          credit_granted_cents: non_neg_integer(),
+          credit_burned_cents: non_neg_integer(),
+          credit_sold_cents: non_neg_integer(),
+          credit_balance_cents: integer(),
           active_hours: float(),
           idle_hours: float(),
           inboxes: non_neg_integer(),
@@ -276,6 +282,7 @@ defmodule Fountain.Billing.Finance do
     channels = Comms.channel_counts()
     messages = message_counts(period_start, period_end)
     contacts = billable_contacts(users)
+    ledger = ledger_by_user(period_start, period_end)
 
     tenants =
       users
@@ -286,6 +293,7 @@ defmodule Fountain.Billing.Finance do
           Map.get(channels, &1.id, %{inboxes: 0, numbers: 0}),
           Map.get(messages, &1.id, empty_messages()),
           Map.get(contacts, &1.id, 0),
+          Map.get(ledger, &1.id, empty_ledger()),
           card,
           fraction
         )
@@ -300,7 +308,7 @@ defmodule Fountain.Billing.Finance do
       rate_card: card,
       revenue: revenue(tenants),
       cost: cost(tenants, rows, card),
-      turn_hours: turn_hours(tenants),
+      credits: credits(tenants),
       tenants: tenants,
       unattributed_cost_cents: unattributed_cost_cents(rows, card)
     }
@@ -348,6 +356,9 @@ defmodule Fountain.Billing.Finance do
       mrr_cents: paying |> Enum.map(& &1.revenue_cents) |> Enum.sum(),
       plan_cents: paying |> Enum.map(& &1.plan_cents) |> Enum.sum(),
       contact_cents: paying |> Enum.map(& &1.contact_revenue_cents) |> Enum.sum(),
+      # Packs sold in the period, by anyone. Not MRR: one-time, and a
+      # liability until burned (`credits/1` carries the deferred balance).
+      credit_sales_cents: tenants |> Enum.map(& &1.credit_sold_cents) |> Enum.sum(),
       by_plan: by_plan,
       at_risk_cents: status_cents(tenants, "past_due"),
       comped_cents: status_cents(tenants, "comped"),
@@ -510,46 +521,51 @@ defmodule Fountain.Billing.Finance do
     |> sum_or_nil(&provider_cost_cents(billed_seconds(&1, card.basis), &1.provider, card))
   end
 
-  ## ── turn hours ──────────────────────────────────────────────────────────
+  ## ── credits ─────────────────────────────────────────────────────────────
 
   @doc """
-  Turn hours sold against turn hours used — the utilization of the thing the
-  plans actually include.
-
-  Sold counts every account whose plan is live for them, trials included at
-  the trial plan's smaller allowance (#1022) rather than at the tier they are
-  trialling — a trial that has not converted has not sold those hours. Utilization
-  is what says whether the included hours are priced anywhere near what
-  tenants do with them, which is the number #1016 step 4 was left open for.
+  The prepaid ledger over the period (ADR 0030): what the tier grants put in,
+  what burned, what packs sold, and the deferred balance — the sum of every
+  positive balance today, which is money already taken for work not yet
+  done. Burned against granted-plus-sold is the utilisation of what tenants
+  hold; a deferred balance that only grows is revenue that is not arriving.
   """
-  @spec turn_hours([tenant_row()]) :: map()
-  def turn_hours(tenants) do
-    live = Enum.reject(tenants, &(&1.subscription_status == "canceled"))
-    sold = live |> Enum.map(& &1.included_turn_hours) |> Enum.sum()
-    used = tenants |> Enum.map(& &1.turn_hours) |> Enum.sum() |> Float.round(2)
+  @spec credits([tenant_row()]) :: map()
+  def credits(tenants) do
+    granted = tenants |> Enum.map(& &1.credit_granted_cents) |> Enum.sum()
+    burned = tenants |> Enum.map(& &1.credit_burned_cents) |> Enum.sum()
+    sold = tenants |> Enum.map(& &1.credit_sold_cents) |> Enum.sum()
 
     %{
-      sold: sold,
-      used: used,
-      over_allowance: Enum.count(tenants, &over_allowance?/1),
-      utilization: if(sold > 0, do: Float.round(used / sold, 4))
+      granted_cents: granted,
+      burned_cents: burned,
+      sold_cents: sold,
+      deferred_cents: deferred_cents(),
+      negative_balances: Enum.count(tenants, &(&1.credit_balance_cents < 0)),
+      utilization: if(granted + sold > 0, do: Float.round(burned / (granted + sold), 4))
     }
   end
 
-  defp over_allowance?(%{turn_hours: used, included_turn_hours: included}),
-    do: included > 0 and used > included
+  # Every positive balance, whoever holds it — a deleted account's ledger is
+  # gone with the account (ADR 0009), so this is what is owed today.
+  defp deferred_cents do
+    Repo.one(
+      from u in User,
+        where: u.credit_balance_cents > 0,
+        select: coalesce(sum(u.credit_balance_cents), 0)
+    )
+  end
 
   ## ── one tenant ──────────────────────────────────────────────────────────
 
-  defp tenant_row(user, usage, channels, messages, contacts, card, fraction) do
+  defp tenant_row(user, usage, channels, messages, contacts, ledger, card, fraction) do
     # `plan` is the tier the subscription is for — what Stripe charges, and
     # what a trial converts into. `effective_plan` is whose numbers apply
     # today, which during a trial is the smaller `trial` plan (#1022).
     #
-    # Revenue reads the first and the allowance reads the second, and using
-    # one for the other is the specific mistake this split exists to prevent:
-    # a trialing account measured against its future tier's 100 hours would
-    # look comfortably inside an allowance it is actually over.
+    # Revenue reads the first and the grant reads the second, and using one
+    # for the other is the specific mistake this split exists to prevent: a
+    # trialing account is granted the trial's $10, not its future tier's $50.
     plan = Plans.resolve(user)
     effective_plan = Plans.effective(user)
     paying? = user.subscription_status in @paying
@@ -586,8 +602,10 @@ defmodule Fountain.Billing.Finance do
       contact_revenue_cents: contact_revenue_cents,
       turn_hours: SandboxUsage.hours(turn_seconds),
       effective_plan: effective_plan,
-      included_turn_hours: effective_plan.included_turn_hours,
-      allowance_used: allowance_used(turn_seconds, effective_plan.included_turn_hours),
+      credit_granted_cents: ledger.granted,
+      credit_burned_cents: ledger.burned,
+      credit_sold_cents: ledger.sold,
+      credit_balance_cents: user.credit_balance_cents,
       active_hours: SandboxUsage.hours(usage.active_seconds),
       idle_hours: SandboxUsage.hours(usage.idle_seconds),
       inboxes: channels.inboxes,
@@ -616,11 +634,8 @@ defmodule Fountain.Billing.Finance do
     |> Enum.sum()
   end
 
-  defp allowance_used(_turn_seconds, 0), do: nil
-
-  defp allowance_used(turn_seconds, included),
-    do: Float.round(SandboxUsage.hours(turn_seconds) / included, 4)
-
+  # Monthly charges, pro-rated to the window. Zero units costs zero whether or
+  # not there is a rate — a tenant with no inbox is not unpriced.
   ## ── pricing helpers ─────────────────────────────────────────────────────
 
   # Which seconds a provider rate multiplies. The two row shapes in play name
@@ -701,6 +716,7 @@ defmodule Fountain.Billing.Finance do
           email: u.email,
           plan: u.plan,
           subscription_status: u.subscription_status,
+          credit_balance_cents: u.credit_balance_cents,
           # Not decoration: an account with no subscription has no item for
           # the contact add-on to sit on, so `sync_contact_addon/1` bills it
           # nothing however many contacts it holds.
@@ -787,6 +803,42 @@ defmodule Fountain.Billing.Finance do
   end
 
   defp empty_messages, do: %{emails_sent: 0, sms_sent: 0, sms_received: 0}
+
+  # One pass over the ledger for the period: cents granted, burned and sold
+  # per tenant. Expiries and clawbacks are neither — an expiry is credit that
+  # was never earned, a clawback is money that went back.
+  defp ledger_by_user(period_start, period_end) do
+    from(e in Fountain.Credits.LedgerEntry,
+      where: e.inserted_at >= ^period_start and e.inserted_at < ^period_end,
+      group_by: e.user_id,
+      select:
+        {e.user_id,
+         %{
+           granted:
+             fragment(
+               "coalesce(sum(case when ? like 'grant_%' then ? end), 0)",
+               e.reason,
+               e.amount_cents
+             ),
+           burned:
+             fragment(
+               "coalesce(sum(case when ? like 'burn_%' then -? end), 0)",
+               e.reason,
+               e.amount_cents
+             ),
+           sold:
+             fragment(
+               "coalesce(sum(case when ? = 'purchase' then ? end), 0)",
+               e.reason,
+               e.amount_cents
+             )
+         }}
+    )
+    |> Repo.all()
+    |> Map.new()
+  end
+
+  defp empty_ledger, do: %{granted: 0, burned: 0, sold: 0}
 
   defp empty_usage,
     do: %{active_seconds: 0, busy_seconds: 0, idle_seconds: 0, by_provider: []}

--- a/ee/lib/fountain/billing/sandbox_usage.ex
+++ b/ee/lib/fountain/billing/sandbox_usage.ex
@@ -291,7 +291,7 @@ defmodule Fountain.Billing.SandboxUsage do
   the sum over its turns, each clipped to the period.
 
   This is the unit a plan's included hours are measured in
-  (`Fountain.Plans.included_turn_hours/1`): an idle sandbox costs Fountain
+  (`Fountain.Credits.turn_cost_cents/1`): an idle sandbox costs Fountain
   money and is reported by `for_user/3`, but spending nothing of a customer's
   allowance is the deliberate choice — the allowance measures work, not
   forgetfulness. And it is a sum, not a union: two conversations each running

--- a/ee/lib/fountain/workers/credit_granter.ex
+++ b/ee/lib/fountain/workers/credit_granter.ex
@@ -7,7 +7,7 @@ defmodule Fountain.Workers.CreditGranter do
   set and billing is on:
 
     * **Tier grant.** Every subscriber whose subscription names a billing
-      period gets `Plans.included_turn_hours × turn-hour price` once per
+      period gets `Plans.included_credit_cents` once per
       period, under `grant_tier:<user_id>:<period_start>`, expiring at the
       period's end. Solo 40 h → $10, Team 100 h → $25, Scale 200 h → $50.
       A period that began before `pricing_since` is pro-rated to the part
@@ -133,8 +133,7 @@ defmodule Fountain.Workers.CreditGranter do
          now
        ) do
     in_period? = DateTime.compare(ps, now) != :gt and DateTime.compare(pe, now) == :gt
-    hours = Plans.included_turn_hours(user)
-    cents = prorate(hours * Credits.price_card().turn_hour, ps, pe, since)
+    cents = prorate(Plans.included_credit_cents(user), ps, pe, since)
 
     if in_period? and cents > 0 do
       key = "grant_tier:#{user.id}:#{DateTime.to_iso8601(ps)}"
@@ -147,7 +146,7 @@ defmodule Fountain.Workers.CreditGranter do
         expires_at: pe,
         resource_type: "billing_period",
         resource_id: DateTime.to_iso8601(ps),
-        metadata: %{"plan" => Plans.resolve(user).slug, "hours" => hours}
+        metadata: %{"plan" => Plans.resolve(user).slug}
       )
     else
       false
@@ -190,15 +189,14 @@ defmodule Fountain.Workers.CreditGranter do
          _since,
          now
        ) do
-    hours = Plans.fetch!("trial").included_turn_hours
-    cents = hours * Credits.price_card().turn_hour
+    cents = Plans.fetch!("trial").included_credit_cents
 
     if DateTime.compare(ends, now) == :gt and cents > 0 do
       grant(user, cents, "grant_trial", "grant_trial:#{user.id}",
         expires_at: ends,
         resource_type: "trial",
         resource_id: user.id,
-        metadata: %{"hours" => hours}
+        metadata: %{}
       )
     else
       false

--- a/ee/lib/fountain/workers/credits_email.ex
+++ b/ee/lib/fountain/workers/credits_email.ex
@@ -71,8 +71,7 @@ defmodule Fountain.Workers.CreditsEmail do
   @doc "Cents under which a balance is 'low': 20 % of the tier grant, or $2."
   @spec runway_line(Accounts.User.t()) :: pos_integer()
   def runway_line(user) do
-    grant = Fountain.Plans.included_turn_hours(user) * Credits.price_card().turn_hour
-    max(div(grant, 5), 200)
+    max(div(Fountain.Plans.included_credit_cents(user), 5), 200)
   end
 
   @impl Oban.Worker

--- a/ee/lib/fountain_web/controllers/billing_api_json.ex
+++ b/ee/lib/fountain_web/controllers/billing_api_json.ex
@@ -64,7 +64,7 @@ defmodule FountainWeb.BillingApiJSON do
       name: plan.name,
       monthly_cents: plan.monthly_cents,
       concurrent_sandboxes: plan.concurrent_sandboxes,
-      included_turn_hours: plan.included_turn_hours,
+      included_credit_cents: plan.included_credit_cents,
       sandbox_limit: Fountain.Quotas.sandbox_limit_for(user),
       team_contacts: plan.team_contacts
     }

--- a/ee/lib/fountain_web/live/admin_finance_live.ex
+++ b/ee/lib/fountain_web/live/admin_finance_live.ex
@@ -277,17 +277,19 @@ defmodule FountainWeb.Live.AdminFinanceLive do
           </div>
         </div>
         <div class="bg-white rounded shadow border border-zinc-200 px-4 py-3">
-          <div class="text-xs text-zinc-500">Turn hours used / sold</div>
+          <div class="text-xs text-zinc-500">Credits burned / granted + sold</div>
           <div class="text-2xl font-semibold tabular-nums">
-            {Float.round(@finance.turn_hours.used, 1)}
-            <span class="text-base text-zinc-400">/ {@finance.turn_hours.sold}</span>
+            {money(@finance.credits.burned_cents)}
+            <span class="text-base text-zinc-400">
+              / {money(@finance.credits.granted_cents + @finance.credits.sold_cents)}
+            </span>
           </div>
           <div class="text-xs text-zinc-500">
-            {if @finance.turn_hours.utilization,
-              do: "#{round(@finance.turn_hours.utilization * 100)}% of the allowance sold",
-              else: "nothing sold"}
-            <span :if={@finance.turn_hours.over_allowance > 0} class="text-amber-700">
-              · {@finance.turn_hours.over_allowance} over
+            {if @finance.credits.utilization,
+              do: "#{round(@finance.credits.utilization * 100)}% of what tenants hold",
+              else: "nothing granted or sold"} · {money(@finance.credits.deferred_cents)} deferred
+            <span :if={@finance.credits.negative_balances > 0} class="text-amber-700">
+              · {@finance.credits.negative_balances} below zero
             </span>
           </div>
         </div>
@@ -317,7 +319,9 @@ defmodule FountainWeb.Live.AdminFinanceLive do
               <td class="px-4 py-2">
                 {line.plan.name}
                 <span class="text-xs text-zinc-400">
-                  {Fountain.Plans.format_usd(line.plan.monthly_cents)}/mo · {line.plan.included_turn_hours}h
+                  {Fountain.Plans.format_usd(line.plan.monthly_cents)}/mo · {money(
+                    line.plan.included_credit_cents
+                  )} credit
                 </span>
               </td>
               <td class="px-4 py-2 text-right tabular-nums">{line.accounts}</td>
@@ -525,7 +529,7 @@ defmodule FountainWeb.Live.AdminFinanceLive do
         <p class="text-xs text-zinc-500">
           Worst margin first. <strong>Active hours</strong>
           is what a provider charges for; <strong>turn hours</strong>
-          is the part with a prompt in flight, which is what the plan includes. The gap is idle time.
+          is the part with a prompt in flight, which is what burns credit. The gap is idle time.
         </p>
         <div class="overflow-x-auto">
           <table class="w-full text-sm bg-white rounded shadow border border-zinc-200">
@@ -534,11 +538,14 @@ defmodule FountainWeb.Live.AdminFinanceLive do
                 <th class="px-3 py-2">Account</th>
                 <th class="px-3 py-2">Plan</th>
                 <th class="px-3 py-2 text-right">Revenue</th>
+                <th class="px-3 py-2 text-right" title="Turn hours with a prompt in flight">
+                  Turn h
+                </th>
                 <th
                   class="px-3 py-2 text-right"
-                  title="Turn hours used against the plan's included hours"
+                  title="Credit burned this period, and the balance held now"
                 >
-                  Turn h
+                  Credits
                 </th>
                 <th
                   class="px-3 py-2 text-right"
@@ -554,7 +561,7 @@ defmodule FountainWeb.Live.AdminFinanceLive do
             </thead>
             <tbody>
               <tr :if={@finance.tenants == []}>
-                <td colspan="9" class="px-3 py-6 text-center text-sm text-zinc-500">No accounts.</td>
+                <td colspan="10" class="px-3 py-6 text-center text-sm text-zinc-500">No accounts.</td>
               </tr>
               <tr
                 :for={t <- @finance.tenants}
@@ -582,12 +589,15 @@ defmodule FountainWeb.Live.AdminFinanceLive do
                     incl. {money(t.contact_revenue_cents)} contacts
                   </div>
                 </td>
+                <td class="px-3 py-2 text-right tabular-nums text-xs">
+                  {Float.round(t.turn_hours, 1)}
+                </td>
                 <td class={[
                   "px-3 py-2 text-right tabular-nums text-xs",
-                  t.allowance_used && t.allowance_used > 1.0 && "text-amber-700 font-medium"
+                  t.credit_balance_cents < 0 && "text-amber-700 font-medium"
                 ]}>
-                  {Float.round(t.turn_hours, 1)}
-                  <span class="text-zinc-400">/ {t.included_turn_hours}</span>
+                  {money(t.credit_burned_cents)}
+                  <div class="text-zinc-400">{money(t.credit_balance_cents)} held</div>
                 </td>
                 <td class="px-3 py-2 text-right tabular-nums text-xs">
                   {Float.round(t.active_hours, 1)}
@@ -707,9 +717,9 @@ defmodule FountainWeb.Live.AdminFinanceLive do
 
   # The hours the reported cost was actually computed from, so the tile's
   # subtitle cannot claim one basis while its number came from the other.
-  defp billed_hours(%{cost: cost, turn_hours: turn_hours}) do
+  defp billed_hours(%{cost: cost, tenants: tenants}) do
     case cost.basis do
-      :turn -> turn_hours.used
+      :turn -> tenants |> Enum.map(& &1.turn_hours) |> Enum.sum() |> Float.round(2)
       :active -> cost.active_hours
     end
   end

--- a/ee/lib/fountain_web/live/billing_live.ex
+++ b/ee/lib/fountain_web/live/billing_live.ex
@@ -66,7 +66,7 @@ defmodule FountainWeb.Live.BillingLive do
     tier = Plans.resolve(user.plan)
     now = Plans.effective(user)
 
-    tier.included_turn_hours > now.included_turn_hours or
+    tier.included_credit_cents > now.included_credit_cents or
       tier.concurrent_sandboxes > now.concurrent_sandboxes
   end
 
@@ -375,7 +375,7 @@ defmodule FountainWeb.Live.BillingLive do
               {plan.concurrent_sandboxes} agents at once
             </p>
             <p class="mt-0.5 text-xs text-gray-500">
-              {Credits.format_cents(plan.included_turn_hours * Credits.price_card().turn_hour)} of credit a month
+              {Credits.format_cents(plan.included_credit_cents)} of credit a month
             </p>
             <div class="mt-3">
               <span :if={plan.slug == @plan.slug} class="text-xs font-medium text-indigo-700">
@@ -419,7 +419,7 @@ defmodule FountainWeb.Live.BillingLive do
         <p class="mt-3 text-xs text-gray-500">
           Conversation time costs {Credits.format_cents(@credits.turn_hour_cents)} per turn hour
           and comes out of this balance. Your plan puts {Credits.format_cents(
-            Plans.included_turn_hours(@current_user) * @credits.turn_hour_cents
+            Plans.included_credit_cents(@current_user)
           )} in at the start of every billing period; what is unused expires with the period.
           Credits you buy never expire and are spent last.
         </p>

--- a/ee/test/fountain/billing_finance_test.exs
+++ b/ee/test/fountain/billing_finance_test.exs
@@ -551,49 +551,44 @@ defmodule Fountain.Billing.FinanceTest do
   ## ── the totals ───────────────────────────────────────────────────────────
 
   describe "summary/1" do
-    test "turn hours sold counts live accounts, used counts everybody" do
-      subscriber("solo")
-      trialing = subscriber("team", "trialing")
-      ran(trialing, "sprites", 5, 5)
-      cancelled = subscriber("scale", "canceled")
-      ran(cancelled, "sprites", 3, 3)
+    test "credits: granted, burned and sold over the period, deferred balance today" do
+      user = subscriber("solo")
+      other = subscriber("team")
+      at = DateTime.add(@period_start, 3600, :second)
 
-      turn_hours = summary().turn_hours
+      {:ok, _} = Fountain.Credits.grant(user.id, 1000, "grant_tier", idempotency_key: "g1")
+      {:ok, _} = Fountain.Credits.grant(user.id, 2500, "purchase", idempotency_key: "p1")
+      {:ok, _} = Fountain.Credits.debit(user.id, 700, "burn_turn", idempotency_key: "b1")
+      {:ok, _} = Fountain.Credits.grant(other.id, 2500, "grant_tier", idempotency_key: "g2")
+      # An expiry is neither granted nor burned.
+      {:ok, _} = Fountain.Credits.debit(other.id, 2500, "expire", idempotency_key: "x1")
 
-      # The trialing account is sold the *trial's* hours, not the tier's it is
-      # trialling (#1022): hours it has not bought are not hours sold. A
-      # cancelled account is sold nothing at all.
-      assert turn_hours.sold ==
-               Plans.included_turn_hours("solo") + Plans.included_turn_hours("trial")
+      # The ledger stamps now; the summary is over a fixed past month, so
+      # place the rows inside it.
+      Repo.update_all(Fountain.Credits.LedgerEntry, set: [inserted_at: at])
 
-      # ...but hours a cancelled account burned this period are still hours.
-      assert turn_hours.used == 8.0
-    end
-
-    test "a trialing account is measured against the trial's allowance (#1022)" do
-      # The specific trap the resolve/effective split exists for: 50 turn
-      # hours is comfortably inside Team's 100 and well over a trial's 40. Read
-      # through `resolve/1` this account looks fine; it is not.
-      user = subscriber("team", "trialing")
-      ran(user, "sprites", 50, 50)
+      credits = summary().credits
+      assert credits.granted_cents == 3500
+      assert credits.burned_cents == 700
+      assert credits.sold_cents == 2500
+      # user holds 2800, other holds 0.
+      assert credits.deferred_cents == 2800
+      assert credits.negative_balances == 0
+      assert credits.utilization == Float.round(700 / 6000, 4)
 
       row = row_for(summary(), user)
-
-      assert row.included_turn_hours == Plans.included_turn_hours("trial")
-      assert row.effective_plan.slug == "trial"
-      # `plan` stays the tier the trial converts into — that is what its
-      # revenue lines are priced at.
-      assert row.plan.slug == "team"
-      assert row.allowance_used > 1.0
-      assert summary().turn_hours.over_allowance == 1
+      assert row.credit_granted_cents == 1000
+      assert row.credit_burned_cents == 700
+      assert row.credit_sold_cents == 2500
+      assert row.credit_balance_cents == 2800
+      assert summary().revenue.credit_sales_cents == 2500
     end
 
-    test "an over-allowance tenant is counted" do
+    test "a balance below zero is counted" do
       user = subscriber("solo")
-      ran(user, "sprites", 150, 150)
-
-      assert summary().turn_hours.over_allowance == 1
-      assert row_for(summary(), user).allowance_used > 1.0
+      {:ok, _} = Fountain.Credits.debit(user.id, 5, "burn_turn", idempotency_key: "neg")
+      assert summary().credits.negative_balances == 1
+      assert row_for(summary(), user).credit_balance_cents == -5
     end
 
     test "spend by a deleted account stays in the total and out of the rows" do

--- a/ee/test/fountain/workers/credit_granter_test.exs
+++ b/ee/test/fountain/workers/credit_granter_test.exs
@@ -68,7 +68,7 @@ defmodule Fountain.Workers.CreditGranterTest do
       assert entry.reason == "grant_tier"
       assert entry.expires_at == @pe
       assert entry.idempotency_key == "grant_tier:#{solo.id}:#{DateTime.to_iso8601(@ps)}"
-      assert entry.metadata == %{"plan" => "solo", "hours" => 40}
+      assert entry.metadata == %{"plan" => "solo"}
 
       assert %{tier: 0} = CreditGranter.run(since: @since, now: @now)
       assert Credits.balance(solo.id) == 1000

--- a/ee/test/fountain_web/controllers/billing_api_controller_test.exs
+++ b/ee/test/fountain_web/controllers/billing_api_controller_test.exs
@@ -118,10 +118,10 @@ defmodule FountainWeb.BillingApiControllerTest do
         |> get("/api/account/billing")
         |> json_response(200)
 
-      included = Fountain.Plans.included_turn_hours(Fountain.Plans.default_slug())
+      included = Fountain.Plans.included_credit_cents(Fountain.Plans.default_slug())
 
       assert body["data"]["usage"]["turn_hours"] == expected
-      assert body["data"]["plan"]["included_turn_hours"] == included
+      assert body["data"]["plan"]["included_credit_cents"] == included
       # The allowance shape is gone (ADR 0030): credits are what act.
       refute Map.has_key?(body["data"]["usage"], "turn_hours_included")
     end

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -10,6 +10,15 @@ server releases.
 
 ---
 
+## [0.3.0] — 2026-08-25
+
+### Changed
+
+- `plan.included_turn_hours` on `GET /api/account/billing` is now
+  `plan.included_credit_cents`: what the plan puts into the prepaid balance
+  each billing period, in cents. A plan is denominated in credit, not hours,
+  so a change to the turn-hour price never changes what a plan includes.
+
 ## [0.2.0] — 2026-08-24
 
 ### Removed

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentshit/fountain-sdk",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Run a coding agent on a real computer, with your repos and your credentials, in one call.",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -3891,8 +3891,8 @@ export interface components {
                 plan?: {
                     /** @description The plan's concurrency cap. */
                     concurrent_sandboxes?: number;
-                    /** @description Turn hours the plan's monthly credit grant is sized on: this times credits.turn_hour_cents lands at the start of each billing period. */
-                    included_turn_hours?: number;
+                    /** @description Credit the plan puts into the balance at the start of each billing period, in cents. Unused plan credit expires with the period. */
+                    included_credit_cents?: number;
                     monthly_cents?: number;
                     name?: string;
                     /** @description The cap actually enforced for this account. Differs from concurrent_sandboxes when an operator has set an override. */

--- a/sdk/typescript/src/http.ts
+++ b/sdk/typescript/src/http.ts
@@ -19,7 +19,7 @@ export interface RequestOptions {
  * this string is already what Fountain's request logs are keyed on. The
  * version half is asserted against `package.json` by a test.
  */
-export const USER_AGENT = "fountain-sdk-js/0.2.0";
+export const USER_AGENT = "fountain-sdk-js/0.3.0";
 
 /**
  * The thin layer everything else is built on: one bearer token, JSON in and


### PR DESCRIPTION
First of the four follow-ups from the post-rollout review.

**Plans in credit, not hours.** `Plans.included_turn_hours` → `included_credit_cents`: $5 per concurrent slot (Solo $10, Team $25, Scale/legacy as before, trial $10; `plans_test` asserts the ratio). Every consumer reads cents directly — `CreditGranter`, the runway line, `/account/billing` copy, the pricing page, the API. A change to `CREDIT_TURN_HOUR_CENTS` now changes what an hour costs and never what a plan includes. API `plan.included_credit_cents` replaces `plan.included_turn_hours` → **SDK 0.3.0**.

**Finance on the ledger.** `Finance.turn_hours/1` (sold vs used, `over_allowance`) and the per-tenant `included_turn_hours`/`allowance_used` are gone. In their place `Finance.credits/1`: granted, burned and sold over the period (one grouped query over `credit_ledger`; expiries and clawbacks are neither), the **deferred balance** (sum of positive balances today — money taken for work not done), balances below zero, and utilisation = burned / (granted + sold). `revenue.credit_sales_cents` sits beside MRR (one-time, not MRR). The panel's fourth tile and the per-tenant table follow (burned this period + balance held; negative in amber).

Docs tables and CLAUDE.md say "credit a month". Tests: plans ratio, API field, marketing copy, granter metadata, two new Finance tests (aggregates + row + negative count).

Refs #1086, #1037, ADR 0030.

🤖 Generated with [Claude Code](https://claude.com/claude-code)