### PR TITLE
feat(credits): every credit row is a lot; debits consume lots in a fixed order (#1086 batch 2, 3 of 4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,8 @@ Five rules that are easy to get wrong:
 - **Credits are the usage currency, and two switches turn them on.**
   ADR 0030: `Fountain.Credits` keeps a cents ledger (`credit_ledger`, cached
   on `users.credit_balance_cents`, idempotent per row, never summed on a
-  gate). `CreditPricer` burns closed turns at `CREDIT_TURN_HOUR_CENTS`
+  gate; every credit row is a lot with `remaining_cents`, and a debit
+  consumes lots in order: the lot it names, earliest expiry, then purchased). `CreditPricer` burns closed turns at `CREDIT_TURN_HOUR_CENTS`
   (default 25) and comms messages when priced; `CreditGranter` puts
   `Plans.included_credit_cents` in each period and expires the unspent part
   (granted first, oldest expiry first, then purchased); `Credits.Purchases`

--- a/apps/fountain/lib/fountain/release.ex
+++ b/apps/fountain/lib/fountain/release.ex
@@ -476,6 +476,27 @@ defmodule Fountain.Release do
     end
   end
 
+  @doc """
+  Fill `credit_ledger.remaining_cents` for every tenant by replaying each
+  ledger in order (ADR 0030, batch 2). Idempotent; safe to rerun.
+
+      bin/fountain_server eval 'Fountain.Release.rebuild_credit_lots()'
+  """
+  def rebuild_credit_lots do
+    with_repo(fn ->
+      import Ecto.Query
+
+      users =
+        Fountain.Repo.all(
+          from e in Fountain.Credits.LedgerEntry, distinct: true, select: e.user_id
+        )
+
+      lots = users |> Enum.map(&Fountain.Credits.rebuild_lots/1) |> Enum.sum()
+      IO.puts("Rebuilt #{lots} lot(s) across #{length(users)} tenant(s).")
+      {:ok, lots}
+    end)
+  end
+
   defp repos do
     Application.fetch_env!(@app, :ecto_repos)
   end

--- a/apps/fountain/priv/repo/migrations/20260825010000_add_remaining_cents_to_credit_ledger.exs
+++ b/apps/fountain/priv/repo/migrations/20260825010000_add_remaining_cents_to_credit_ledger.exs
@@ -1,0 +1,24 @@
+defmodule Fountain.Repo.Migrations.AddRemainingCentsToCreditLedger do
+  use Ecto.Migration
+
+  # ADR 0030, batch 2: every row that puts money in is a lot, and
+  # `remaining_cents` is how much of it is still unspent. Debits consume lots
+  # in a fixed order (a named lot, then the earliest expiry, then purchased),
+  # so an expiry or a clawback takes exactly what its own lot still holds
+  # instead of inferring it from the balance. Nil on debit rows and on rows
+  # written before this column; `Fountain.Credits.rebuild_lots/1` replays a
+  # tenant's ledger to fill it.
+  def change do
+    alter table(:credit_ledger) do
+      add :remaining_cents, :integer
+      # Insertion order, for replaying a ledger: `inserted_at` is a second and
+      # a grant and its burn can share one.
+      add :seq, :bigserial
+    end
+
+    create index(:credit_ledger, [:user_id, :expires_at, :inserted_at],
+             where: "remaining_cents > 0",
+             name: :credit_ledger_open_lots_index
+           )
+  end
+end

--- a/ee/lib/fountain/credits.ex
+++ b/ee/lib/fountain/credits.ex
@@ -18,6 +18,15 @@ defmodule Fountain.Credits do
       credit_balance_cents = credit_balance_cents + amount` land in one
       transaction; a gate reads the column and never sums the ledger.
       `recompute_balance/1` exists for reconciliation, not for reads.
+    * **Every credit row is a lot.** `remaining_cents` on a grant or a
+      purchase is what is still unspent of it. A debit consumes lots in a
+      fixed order — the lot it names (`:lot_id`: an expiry takes from its own
+      grant, a clawback from its own purchase), then the earliest expiry,
+      then purchased money — under a row lock on the user, so two debits
+      cannot both consume the same cent. A credit posted against a negative
+      balance repays the debt first and only the rest becomes a lot. What a
+      surface calls "expiring" or "purchased" is read off the lots, never
+      inferred from the balance.
     * **Short-circuit before the ledger.** `check_balance/1` answers `:ok` for
       a deployment with billing off and for a comped tenant *before* reading
       the balance, so a self-hosted install and a comp never brick at zero
@@ -295,52 +304,36 @@ defmodule Fountain.Credits do
     end
   end
 
-  @doc "Grants that have not yet expired, earliest expiry first."
+  @doc "Open lots that expire, earliest first: grants with something left."
   @spec live_grants(binary(), DateTime.t()) :: [LedgerEntry.t()]
   def live_grants(user_id, %DateTime{} = now) when is_binary(user_id) do
     from(e in LedgerEntry,
-      where: e.user_id == ^user_id and e.amount_cents > 0,
+      where: e.user_id == ^user_id and e.remaining_cents > 0,
       where: not is_nil(e.expires_at) and e.expires_at > ^now,
-      order_by: [asc: e.expires_at, asc: e.inserted_at]
+      order_by: [asc: e.expires_at, asc: e.seq]
     )
     |> Repo.all()
   end
 
   @doc """
-  How much of `grant` is still unspent, given the tenant's `balance`, under
-  the burn order *granted first, oldest expiry first, then purchased*.
-
-  Purchased money that remains is `min(purchases − clawbacks, balance)`,
-  because burns only reach it once every grant is gone. What is left after
-  that is spread over the live grants from the earliest expiry: this grant's
-  share is whatever exceeds the sum of the grants expiring after it, capped
-  at its own amount and floored at zero.
+  How much of `grant` is still unspent: its lot, read fresh. The second
+  argument is ignored and kept for the callers that passed a balance before
+  lots existed.
   """
   @spec unspent_of(LedgerEntry.t(), integer()) :: non_neg_integer()
-  def unspent_of(%LedgerEntry{} = grant, balance) when is_integer(balance) do
-    expirable = max(balance, 0) - purchased_remaining(grant.user_id, balance)
-
-    later_grants =
-      from(e in LedgerEntry,
-        where: e.user_id == ^grant.user_id and e.amount_cents > 0,
-        where: not is_nil(e.expires_at) and e.expires_at > ^grant.expires_at,
-        select: coalesce(sum(e.amount_cents), 0)
-      )
-      |> Repo.one()
-
-    (expirable - later_grants) |> max(0) |> min(grant.amount_cents)
+  def unspent_of(%LedgerEntry{id: id}, _balance) do
+    from(e in LedgerEntry, where: e.id == ^id, select: e.remaining_cents)
+    |> Repo.one()
+    |> Kernel.||(0)
   end
 
-  defp purchased_remaining(user_id, balance) do
-    purchased_net =
-      from(e in LedgerEntry,
-        where: e.user_id == ^user_id,
-        where: (e.amount_cents > 0 and is_nil(e.expires_at)) or like(e.reason, "clawback_%"),
-        select: coalesce(sum(e.amount_cents), 0)
-      )
-      |> Repo.one()
-
-    purchased_net |> max(0) |> min(max(balance, 0))
+  # Non-expiring lots with something left: bought money, and admin grants.
+  defp purchased_remaining(user_id, _balance) do
+    from(e in LedgerEntry,
+      where: e.user_id == ^user_id and e.remaining_cents > 0 and is_nil(e.expires_at),
+      select: coalesce(sum(e.remaining_cents), 0)
+    )
+    |> Repo.one()
   end
 
   # ---------------------------------------------------------------------------
@@ -396,7 +389,7 @@ defmodule Fountain.Credits do
     changeset = LedgerEntry.changeset(%LedgerEntry{}, attrs)
 
     if changeset.valid? do
-      changeset |> insert_and_move() |> audited(opts)
+      changeset |> insert_and_move(Keyword.get(opts, :lot_id)) |> audited(opts)
     else
       {:error, changeset}
     end
@@ -406,23 +399,39 @@ defmodule Fountain.Credits do
   # *after* attempting the insert rather than by a lookup first: two workers
   # posting the same key at once must not both see "absent" and both move the
   # balance. A duplicate aborts the transaction, so the balance is untouched.
-  defp insert_and_move(changeset) do
+  defp insert_and_move(changeset, lot_id) do
     key = Ecto.Changeset.get_field(changeset, :idempotency_key)
     user_id = Ecto.Changeset.get_field(changeset, :user_id)
     amount = Ecto.Changeset.get_field(changeset, :amount_cents)
 
     Repo.transaction(fn ->
-      with {:ok, entry} <- Repo.insert(changeset),
-           {1, _} <-
-             Repo.update_all(from(u in User, where: u.id == ^user_id),
-               inc: [credit_balance_cents: amount]
-             ) do
-        entry
-      else
-        # Cannot happen while the FK holds, but a ledger row without a user
-        # row to carry its balance would be a silent drift.
-        {0, _} -> Repo.rollback(:user_not_found)
-        {:error, %Ecto.Changeset{} = cs} -> Repo.rollback(cs)
+      # The user row is the lock for this tenant's lots: every post takes it,
+      # so consumption and the balance move together and in order.
+      case Repo.one(from(u in User, where: u.id == ^user_id, lock: "FOR UPDATE")) do
+        nil ->
+          Repo.rollback(:user_not_found)
+
+        %User{credit_balance_cents: before} ->
+          changeset =
+            if amount > 0,
+              do:
+                Ecto.Changeset.put_change(changeset, :remaining_cents, lot_size(amount, before)),
+              else: changeset
+
+          case Repo.insert(changeset) do
+            {:ok, entry} ->
+              if amount < 0, do: consume_lots(user_id, -amount, lot_id)
+
+              {1, _} =
+                Repo.update_all(from(u in User, where: u.id == ^user_id),
+                  inc: [credit_balance_cents: amount]
+                )
+
+              entry
+
+            {:error, %Ecto.Changeset{} = cs} ->
+              Repo.rollback(cs)
+          end
       end
     end)
     |> case do
@@ -443,6 +452,92 @@ defmodule Fountain.Credits do
         {:error, reason}
     end
   end
+
+  # A credit posted into debt repays it first; only the rest is spendable.
+  defp lot_size(amount, balance_before), do: amount - min(amount, max(-balance_before, 0))
+
+  # Take `cents` from the open lots in order: the named lot, then the
+  # earliest expiry, then non-expiring money. Whatever no lot covers is debt,
+  # which the balance carries and the next credit repays.
+  defp consume_lots(user_id, cents, lot_id) do
+    open =
+      from(e in LedgerEntry,
+        where: e.user_id == ^user_id and e.remaining_cents > 0,
+        order_by: [
+          asc:
+            fragment("case when ? then 0 else 1 end", e.id == ^(lot_id || Ecto.UUID.generate())),
+          asc: fragment("case when ? is null then 1 else 0 end", e.expires_at),
+          asc: e.expires_at,
+          asc: e.seq
+        ],
+        select: {e.id, e.remaining_cents}
+      )
+      |> Repo.all()
+
+    # What is left after the lots is debt, carried by the balance.
+    _debt =
+      Enum.reduce_while(open, cents, fn {id, remaining}, left ->
+        take = min(remaining, left)
+
+        Repo.update_all(from(e in LedgerEntry, where: e.id == ^id),
+          set: [remaining_cents: remaining - take]
+        )
+
+        if left - take == 0, do: {:halt, 0}, else: {:cont, left - take}
+      end)
+
+    :ok
+  end
+
+  @doc """
+  Replay one tenant's ledger in order and rewrite every lot's
+  `remaining_cents` from scratch. For the rows written before lots existed
+  and for reconciliation; the live path keeps lots current by itself.
+  Returns the number of lots.
+  """
+  @spec rebuild_lots(binary()) :: non_neg_integer()
+  def rebuild_lots(user_id) when is_binary(user_id) do
+    Repo.transaction(fn ->
+      Repo.one(from(u in User, where: u.id == ^user_id, lock: "FOR UPDATE"))
+
+      entries =
+        from(e in LedgerEntry,
+          where: e.user_id == ^user_id,
+          order_by: [asc: e.seq]
+        )
+        |> Repo.all()
+
+      Repo.update_all(from(e in LedgerEntry, where: e.user_id == ^user_id),
+        set: [remaining_cents: nil]
+      )
+
+      {_balance, lots} =
+        Enum.reduce(entries, {0, 0}, fn entry, {balance, lots} ->
+          if entry.amount_cents > 0 do
+            Repo.update_all(from(e in LedgerEntry, where: e.id == ^entry.id),
+              set: [remaining_cents: lot_size(entry.amount_cents, balance)]
+            )
+
+            {balance + entry.amount_cents, lots + 1}
+          else
+            consume_lots(user_id, -entry.amount_cents, replay_lot_id(entry))
+            {balance + entry.amount_cents, lots}
+          end
+        end)
+
+      lots
+    end)
+    |> then(fn {:ok, n} -> n end)
+  end
+
+  # The lot a historical debit was aimed at: an expiry names its grant as
+  # the resource, a clawback keeps the purchase id in its metadata.
+  defp replay_lot_id(%LedgerEntry{reason: "expire", resource_id: id}), do: id
+
+  defp replay_lot_id(%LedgerEntry{reason: "clawback_" <> _, metadata: %{"purchase_id" => id}}),
+    do: id
+
+  defp replay_lot_id(_), do: nil
 
   # Recorded outside the transaction (ADR 0013): a best-effort audit write
   # inside it would take the ledger row down with it.

--- a/ee/lib/fountain/credits/ledger_entry.ex
+++ b/ee/lib/fountain/credits/ledger_entry.ex
@@ -23,6 +23,12 @@ defmodule Fountain.Credits.LedgerEntry do
     field :resource_id, :string
     field :idempotency_key, :string
     field :expires_at, :utc_datetime
+    # How much of a credit row is still unspent (a lot). Nil on debit rows.
+    # Written only by `Fountain.Credits`, in the same transaction as the row
+    # that consumed it.
+    field :remaining_cents, :integer
+    # Insertion order, assigned by the database.
+    field :seq, :integer, read_after_writes: true
     field :metadata, :map, default: %{}
     field :inserted_at, :utc_datetime
 

--- a/ee/lib/fountain/credits/purchases.ex
+++ b/ee/lib/fountain/credits/purchases.ex
@@ -161,6 +161,7 @@ defmodule Fountain.Credits.Purchases do
         if delta > 0 do
           Credits.debit(purchase.user_id, delta, "clawback_refund",
             idempotency_key: "clawback_refund:#{charge_id}:#{refunded}",
+            lot_id: purchase.id,
             resource_type: "stripe_charge",
             resource_id: charge_id,
             actor: "system:stripe_webhook",
@@ -181,6 +182,7 @@ defmodule Fountain.Credits.Purchases do
       %LedgerEntry{} = purchase when amount > 0 ->
         Credits.debit(purchase.user_id, amount, "clawback_dispute",
           idempotency_key: "clawback_dispute:#{Map.get(dispute, :id)}",
+          lot_id: purchase.id,
           resource_type: "stripe_dispute",
           resource_id: Map.get(dispute, :id),
           actor: "system:stripe_webhook",

--- a/ee/lib/fountain/workers/credit_granter.ex
+++ b/ee/lib/fountain/workers/credit_granter.ex
@@ -253,6 +253,7 @@ defmodule Fountain.Workers.CreditGranter do
       cents ->
         case Credits.debit(grant.user_id, cents, "expire",
                idempotency_key: "expire:#{grant.id}",
+               lot_id: grant.id,
                resource_type: "credit_ledger",
                resource_id: grant.id,
                actor: "system:credit_granter",

--- a/ee/test/fountain/credits_test.exs
+++ b/ee/test/fountain/credits_test.exs
@@ -212,4 +212,91 @@ defmodule Fountain.CreditsTest do
       assert Credits.format_cents(0) == "$0.00"
     end
   end
+
+  describe "lots" do
+    defp remaining(entry), do: Credits.unspent_of(entry, 0)
+
+    test "a debit consumes the earliest-expiring lot first, then purchased money" do
+      user = insert_active_user()
+
+      {:ok, late} =
+        Credits.grant(user.id, 1000, "grant_tier",
+          idempotency_key: "late",
+          expires_at: ~U[2099-02-01 00:00:00Z]
+        )
+
+      {:ok, bought} = Credits.grant(user.id, 500, "purchase", idempotency_key: "bought")
+
+      {:ok, early} =
+        Credits.grant(user.id, 1000, "grant_tier",
+          idempotency_key: "early",
+          expires_at: ~U[2099-01-01 00:00:00Z]
+        )
+
+      {:ok, _} = Credits.debit(user.id, 1200, "burn_turn", idempotency_key: "b1")
+      assert remaining(early) == 0
+      assert remaining(late) == 800
+      assert remaining(bought) == 500
+
+      {:ok, _} = Credits.debit(user.id, 1000, "burn_turn", idempotency_key: "b2")
+      assert remaining(late) == 0
+      assert remaining(bought) == 300
+      assert Credits.balance(user.id) == 300
+    end
+
+    test "a named lot is consumed first, and debt beyond the lots is carried by the balance" do
+      user = insert_active_user()
+
+      {:ok, a} =
+        Credits.grant(user.id, 100, "grant_tier",
+          idempotency_key: "a",
+          expires_at: ~U[2099-01-01 00:00:00Z]
+        )
+
+      {:ok, b} = Credits.grant(user.id, 100, "purchase", idempotency_key: "b")
+
+      {:ok, _} = Credits.debit(user.id, 60, "clawback_refund", idempotency_key: "c", lot_id: b.id)
+      assert remaining(a) == 100
+      assert remaining(b) == 40
+
+      {:ok, _} = Credits.debit(user.id, 200, "burn_turn", idempotency_key: "d")
+      assert remaining(a) == 0 and remaining(b) == 0
+      assert Credits.balance(user.id) == -60
+    end
+
+    test "a credit posted into debt repays it first" do
+      user = insert_active_user()
+      {:ok, _} = Credits.debit(user.id, 30, "burn_turn", idempotency_key: "debt")
+      {:ok, lot} = Credits.grant(user.id, 100, "purchase", idempotency_key: "p")
+      assert remaining(lot) == 70
+      assert Credits.balance(user.id) == 70
+    end
+
+    test "rebuild_lots replays the ledger to the same lots the live path wrote" do
+      user = insert_active_user()
+
+      {:ok, g} =
+        Credits.grant(user.id, 1000, "grant_tier",
+          idempotency_key: "g",
+          expires_at: ~U[2099-01-01 00:00:00Z]
+        )
+
+      {:ok, p} = Credits.grant(user.id, 500, "purchase", idempotency_key: "p")
+      {:ok, _} = Credits.debit(user.id, 1200, "burn_turn", idempotency_key: "b")
+
+      {:ok, _} =
+        Credits.debit(user.id, 100, "clawback_refund",
+          idempotency_key: "c",
+          lot_id: p.id,
+          metadata: %{"purchase_id" => p.id}
+        )
+
+      before = {remaining(g), remaining(p)}
+
+      Repo.update_all(Fountain.Credits.LedgerEntry, set: [remaining_cents: nil])
+      assert 2 = Credits.rebuild_lots(user.id)
+      assert {remaining(g), remaining(p)} == before
+      assert before == {0, 200}
+    end
+  end
 end

--- a/ee/test/fountain/workers/credit_granter_test.exs
+++ b/ee/test/fountain/workers/credit_granter_test.exs
@@ -186,8 +186,14 @@ defmodule Fountain.Workers.CreditGranterTest do
     test "a clawback reduces what counts as purchased" do
       user = subscriber("solo")
       assert %{tier: 1} = CreditGranter.run(since: @since, now: @now)
-      {:ok, _} = Credits.grant(user.id, 2500, "purchase", idempotency_key: "buy")
-      {:ok, _} = Credits.debit(user.id, 2500, "clawback_refund", idempotency_key: "refund")
+      {:ok, bought} = Credits.grant(user.id, 2500, "purchase", idempotency_key: "buy")
+      # A clawback names its purchase lot, as Purchases does.
+      {:ok, _} =
+        Credits.debit(user.id, 2500, "clawback_refund",
+          idempotency_key: "refund",
+          lot_id: bought.id
+        )
+
       # Balance 1000, all of it grant.
       assert %{expired: 1} = CreditGranter.run(since: @since, now: ~U[2026-09-01 00:00:01Z])
       assert Credits.balance(user.id) == 0


### PR DESCRIPTION
Third of four (the Finance half of the fourth shipped inside #1108). Closes the "expiry is inferred, not tracked" concession.

**Adds**
- `credit_ledger.remaining_cents` on every credit row (grant, purchase): the lot's unspent part. `seq` (bigserial) for a replay order that `inserted_at`'s one-second grain cannot give.
- `Credits.post/4` now runs under `SELECT … FOR UPDATE` on the user row. A **debit** consumes open lots in a fixed order — the lot it names via `lot_id:` (an expiry takes from its own grant; a refund/dispute clawback from its own purchase), then the earliest-expiring, then non-expiring money — in the same transaction as the row and the balance move. What no lot covers is debt, carried by the balance. A **credit** posted into debt repays it first; only the rest becomes a lot.
- `unspent_of/2`, `live_grants/2` and `summary/2`'s `expiring_cents`/`purchased_cents` read off the lots. No more "purchases − clawbacks, min balance" arithmetic.
- `Credits.rebuild_lots/1` replays one tenant's ledger in `seq` order to the same lots the live path writes (expiries and clawbacks re-target their lot from `resource_id`/`metadata.purchase_id`); `Release.rebuild_credit_lots/0` does every tenant. **Operator step after deploy:** run it once for the rows written before this column existed.
- The granter's expiry and `Purchases`' clawbacks pass `lot_id`.

**Tests:** FIFO across two grants and a purchase; a named lot first and debt beyond the lots; debt repaid by the next credit; rebuild reproduces the live lots. The pre-existing FIFO/expiry/clawback tests pass unchanged except one that now names its purchase lot the way `Purchases` does. Fresh-DB migrate verified (82 migrations).

Refs #1086, ADR 0030.

🤖 Generated with [Claude Code](https://claude.com/claude-code)