### PR TITLE
chore(db): drop users.comped_contacts, dead since #1109

### DIFF
--- a/apps/fountain/priv/repo/migrations/20260825020000_drop_comped_contacts_from_users.exs
+++ b/apps/fountain/priv/repo/migrations/20260825020000_drop_comped_contacts_from_users.exs
@@ -1,0 +1,18 @@
+defmodule Fountain.Repo.Migrations.DropCompedContactsFromUsers do
+  use Ecto.Migration
+
+  # #1109 retired the Stripe teammate-contact add-on and removed the Ecto
+  # field; the column stayed one release so a rolling deploy never selected
+  # a column that was gone. Nothing has read it since, so it goes.
+  def up do
+    alter table(:users) do
+      remove :comped_contacts
+    end
+  end
+
+  def down do
+    alter table(:users) do
+      add :comped_contacts, :integer, null: false, default: 0
+    end
+  end
+end


### PR DESCRIPTION
#1109 removed the Ecto field and every reader; the column stayed one release so the rolling deploy never selected a dropped column. That release is out (pods on #1110), so the column goes. `down` restores it with its old default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)