### PR TITLE
feat(quotas): the concurrency cap is funded by the balance, under a fleet ceiling (ADR 0031)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -274,6 +274,14 @@ STRIPE_PRICE_MONTHLY_CENTS=
 # AGENTMAIL_MESSAGE_CENTS=0.2
 # AGENTPHONE_MESSAGE_CENTS=2
 
+# Concurrency (ADR 0031). A tenant may run clamp(balance / reserve, floor,
+# ceiling) sandboxes at once; an admin override on the account wins. The
+# fleet ceiling is the provider plan's number: Sprites' $20 plan is ~20.
+# SANDBOX_RESERVE_CENTS=200
+# SANDBOX_CAP_FLOOR=2
+# SANDBOX_CAP_CEILING=20
+# SANDBOX_FLEET_CEILING=20
+
 # Prepaid credits (ADR 0030): what the customer pays, in whole cents. Distinct
 # from the provider costs above. The turn-hour price defaults to 25 and is a
 # placeholder until a provider invoice has been reconciled. The four comms

--- a/apps/fountain/lib/fountain/quotas.ex
+++ b/apps/fountain/lib/fountain/quotas.ex
@@ -7,11 +7,17 @@ defmodule Fountain.Quotas do
   concurrency cap is the primary defence against one account — whether abusive,
   scripted, or merely enthusiastic — consuming the platform's capacity.
 
-  The cap comes from the tenant's plan (`Fountain.Plans`) — that is the axis
-  the tiers are sold on. `users.sandbox_limit_override` wins when it is set,
-  which is the admin lever the plan cannot express: raise it for a trusted
-  tenant, drop it to zero during abuse. A null override means "whatever the
-  plan says", so an upgrade takes effect without anyone touching the column.
+  The cap is funded by the balance (ADR 0031): a tenant may run
+  `clamp(balance ÷ reserve, floor, ceiling)` sandboxes at once, so nobody can
+  start a fleet they cannot pay for, and a bigger balance unlocks more. A
+  comped account, and a deployment with billing off, get the ceiling.
+  `users.sandbox_limit_override` wins when it is set, which is the admin
+  lever the rule cannot express: raise it for a trusted tenant, drop it to
+  zero during abuse. A null override means "whatever the balance funds".
+
+  A fleet ceiling bounds the sum across every tenant to what the providers
+  allow; `with_sandbox_reservation/3` checks it under a global lock and
+  refuses with `:fleet_full`, which is capacity, not a billing state.
 
   ## What counts
 
@@ -30,7 +36,6 @@ defmodule Fountain.Quotas do
 
   alias Fountain.Accounts.User
   alias Fountain.Conversations.Sandbox
-  alias Fountain.Plans
   alias Fountain.Repo
 
   @active_statuses ~w(pending starting ready)
@@ -84,24 +89,21 @@ defmodule Fountain.Quotas do
 
   @doc """
   The concurrency cap for `user_id`: the override if it has one, otherwise
-  the plan's.
+  what the balance funds (ADR 0031).
 
-  A user who cannot be found at all falls back to the default plan's cap, so a
-  lookup failure tightens rather than removes the limit.
+  A user who cannot be found at all gets the floor, so a lookup failure
+  tightens rather than removes the limit.
   """
   @spec sandbox_limit(binary()) :: non_neg_integer()
   def sandbox_limit(user_id) when is_binary(user_id) do
-    # `subscription_status` is selected because a trial is capped lower than
-    # the tier it trials (`Plans.effective/1`). Selecting only the plan slug
-    # would hand a trialing account the paid number.
     query =
       from u in User,
         where: u.id == ^user_id,
-        select: {u.sandbox_limit_override, u.plan, u.subscription_status}
+        select: {u.sandbox_limit_override, u.credit_balance_cents, u.subscription_status}
 
     case Repo.one(query) do
-      {override, plan, status} -> resolve_limit(override, plan, status)
-      nil -> Plans.concurrent_sandboxes(nil)
+      {override, balance, status} -> resolve_limit(override, balance, status)
+      nil -> settings().cap_floor
     end
   end
 
@@ -112,15 +114,77 @@ defmodule Fountain.Quotas do
   """
   @spec sandbox_limit_for(User.t()) :: non_neg_integer()
   def sandbox_limit_for(%User{} = user),
-    do: resolve_limit(user.sandbox_limit_override, user.plan, user.subscription_status)
+    do:
+      resolve_limit(
+        user.sandbox_limit_override,
+        user.credit_balance_cents,
+        user.subscription_status
+      )
 
-  # An explicit override beats everything, the trial included: it is the
-  # operator saying "this account, this number", and a trial is not a reason
-  # to second-guess that.
-  defp resolve_limit(override, _plan, _status) when is_integer(override), do: override
+  defp resolve_limit(override, _balance, _status) when is_integer(override), do: override
 
-  defp resolve_limit(_override, plan, status),
-    do: Plans.concurrent_sandboxes(%{plan: plan, subscription_status: status})
+  defp resolve_limit(_override, balance, status) do
+    %{reserve_cents: reserve, cap_floor: floor, cap_ceiling: ceiling} = settings()
+
+    cond do
+      not Fountain.Billing.enabled?() -> ceiling
+      status == "comped" -> ceiling
+      true -> balance |> funded(reserve) |> max(floor) |> min(ceiling)
+    end
+  end
+
+  defp funded(balance, _reserve) when balance <= 0, do: 0
+  defp funded(_balance, 0), do: 0
+  defp funded(balance, reserve), do: div(balance, reserve)
+
+  @doc "Live sandboxes across every tenant, against the fleet ceiling."
+  @spec fleet_count() :: non_neg_integer()
+  def fleet_count do
+    Repo.one(from(s in Sandbox, where: s.status in @active_statuses, select: count(s.id))) || 0
+  end
+
+  @doc "The reserve, floor, ceiling and fleet ceiling in force."
+  @spec settings() :: %{
+          reserve_cents: non_neg_integer(),
+          cap_floor: non_neg_integer(),
+          cap_ceiling: non_neg_integer(),
+          fleet_ceiling: non_neg_integer()
+        }
+  def settings do
+    cfg = Application.get_env(:fountain, :sandboxes, [])
+
+    %{
+      reserve_cents: Keyword.get(cfg, :reserve_cents, 200),
+      cap_floor: Keyword.get(cfg, :cap_floor, 2),
+      cap_ceiling: Keyword.get(cfg, :cap_ceiling, 20),
+      fleet_ceiling: Keyword.get(cfg, :fleet_ceiling, 20)
+    }
+  end
+
+  @doc """
+  Check the deployment against the fleet ceiling. `:ok`, or
+  `{:error, :fleet_full}` — every provider slot is in use, whoever holds them.
+  """
+  @spec check_fleet_ceiling(keyword()) :: :ok | {:error, :fleet_full}
+  def check_fleet_ceiling(opts \\ []) do
+    ceiling = settings().fleet_ceiling
+
+    count =
+      case Keyword.get(opts, :exclude) do
+        nil ->
+          fleet_count()
+
+        excluded ->
+          Repo.one(
+            from(s in Sandbox,
+              where: s.status in @active_statuses and s.id != ^excluded,
+              select: count(s.id)
+            )
+          ) || 0
+      end
+
+    if count < ceiling, do: :ok, else: {:error, :fleet_full}
+  end
 
   @doc """
   Check `user_id` against the sandbox concurrency cap.
@@ -172,6 +236,10 @@ defmodule Fountain.Quotas do
   # of the user id. A hash collision between users only over-serializes two
   # tenants' creations — never under-counts.
   @lock_namespace 4315
+  # One key for the whole fleet, so the ceiling is counted by one reservation
+  # at a time. Taken before the per-user lock, always, so two reservations
+  # cannot deadlock on each other.
+  @fleet_lock_key 0
 
   @doc """
   Check the cap and run `fun` (which must create the sandbox row) atomically,
@@ -190,16 +258,20 @@ defmodule Fountain.Quotas do
           {:ok, term()} | {:error, term()}
   def with_sandbox_reservation(user_id, quota_opts \\ [], fun) when is_binary(user_id) do
     Repo.transaction(fn ->
+      Repo.query!("SELECT pg_advisory_xact_lock($1, $2)", [@lock_namespace, @fleet_lock_key])
+
       Repo.query!("SELECT pg_advisory_xact_lock($1, $2)", [
         @lock_namespace,
         :erlang.phash2(user_id)
       ])
 
-      # The balance precheck lives under the same lock as the cap (ADR 0030
-      # decision 6): two requests at $0.01 must not both read "positive" and
-      # both provision. The turn that then burns it may still go negative;
-      # that is the soft stop, not a hole.
-      with :ok <- check_sandbox_quota(user_id, quota_opts),
+      # The fleet ceiling, the tenant's cap and the balance precheck all live
+      # under the locks (ADR 0030 decision 6, ADR 0031): two requests at the
+      # last slot or the last cent must not both read "room" and both
+      # provision. The turn that then burns the balance may still go
+      # negative; that is the soft stop, not a hole.
+      with :ok <- check_fleet_ceiling(quota_opts),
+           :ok <- check_sandbox_quota(user_id, quota_opts),
            :ok <- Fountain.Credits.gate(user_id),
            {:ok, value} <- fun.() do
         value
@@ -209,8 +281,8 @@ defmodule Fountain.Quotas do
     end)
   end
 
-  @doc "Cap applied to a user on this deployment's default plan with no override."
-  def default_limit, do: Plans.concurrent_sandboxes(nil)
+  @doc "The cap a fresh account with nothing in its balance gets: the floor."
+  def default_limit, do: settings().cap_floor
 
   @doc "Sandbox statuses that count against the cap."
   def active_statuses, do: @active_statuses

--- a/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
@@ -183,6 +183,19 @@ defmodule FountainWeb.FallbackController do
     })
   end
 
+  # Every provider slot the deployment has is in use, whoever holds them
+  # (ADR 0031). 503 with a retry hint: capacity, not the caller's quota and
+  # not a billing state.
+  def call(conn, {:error, :fleet_full}) do
+    conn
+    |> put_resp_header("retry-after", "60")
+    |> put_status(:service_unavailable)
+    |> json(%{
+      error: "fleet_full",
+      message: "Every sandbox slot is in use right now. Try again in a minute."
+    })
+  end
+
   # The ConversationServer did not answer within the call timeout — almost
   # always a server still inside handle_continue(:provision), whose blocked
   # mailbox makes every call wait the full 30s and exit (#412). 503 with

--- a/apps/fountain/test/fountain/plans_trial_test.exs
+++ b/apps/fountain/test/fountain/plans_trial_test.exs
@@ -152,17 +152,17 @@ defmodule Fountain.PlansTrialTest do
     # The cap is the balance's, not the plan's (ADR 0031); the plan tests
     # above are about what a trial is, and this one is about what it may run.
     test "a trialing account with nothing in its balance gets the floor, whatever its tier" do
-      user = trialing("scale")
+      user = insert_verified_user(plan: "scale")
       assert Quotas.sandbox_limit(user.id) == Quotas.default_limit()
       assert Quotas.sandbox_limit_for(reload(user)) == Quotas.default_limit()
     end
 
     test "an operator override beats the balance, in both directions" do
-      up = trialing("solo")
+      up = insert_verified_user(plan: "solo")
       {:ok, up} = Fountain.Accounts.update_sandbox_limit(up, 25)
       assert Quotas.sandbox_limit(up.id) == 25
 
-      down = trialing("scale")
+      down = insert_verified_user(plan: "scale")
       {:ok, down} = Fountain.Accounts.update_sandbox_limit(down, 0)
       assert Quotas.sandbox_limit(down.id) == 0
     end

--- a/apps/fountain/test/fountain/plans_trial_test.exs
+++ b/apps/fountain/test/fountain/plans_trial_test.exs
@@ -149,35 +149,22 @@ defmodule Fountain.PlansTrialTest do
   end
 
   describe "the cap actually enforced" do
-    test "a trialing account is capped at the trial's concurrency" do
-      user = insert_verified_user(plan: "scale")
-      assert Quotas.sandbox_limit(user.id) == 2
-      assert Quotas.sandbox_limit_for(reload(user)) == 2
+    # The cap is the balance's, not the plan's (ADR 0031); the plan tests
+    # above are about what a trial is, and this one is about what it may run.
+    test "a trialing account with nothing in its balance gets the floor, whatever its tier" do
+      user = trialing("scale")
+      assert Quotas.sandbox_limit(user.id) == Quotas.default_limit()
+      assert Quotas.sandbox_limit_for(reload(user)) == Quotas.default_limit()
     end
 
-    test "converting to active lifts it the same day, with no migration" do
-      user = insert_verified_user(plan: "scale")
-      assert Quotas.sandbox_limit(user.id) == 2
-
-      {:ok, _} = activate(user)
-      assert Quotas.sandbox_limit(user.id) == 10
-    end
-
-    # An override is the operator saying "this account, this number". A trial
-    # is not a reason to second-guess that.
-    test "an operator override beats the trial, in both directions" do
-      up = insert_verified_user(plan: "solo")
+    test "an operator override beats the balance, in both directions" do
+      up = trialing("solo")
       {:ok, up} = Fountain.Accounts.update_sandbox_limit(up, 25)
       assert Quotas.sandbox_limit(up.id) == 25
 
-      down = insert_verified_user(plan: "scale")
+      down = trialing("scale")
       {:ok, down} = Fountain.Accounts.update_sandbox_limit(down, 0)
       assert Quotas.sandbox_limit(down.id) == 0
-    end
-
-    test "sandbox_limit_for/1 agrees with sandbox_limit/1 for a trialing account" do
-      user = insert_verified_user(plan: "team")
-      assert Quotas.sandbox_limit_for(reload(user)) == Quotas.sandbox_limit(user.id)
     end
   end
 

--- a/apps/fountain/test/fountain/quotas_test.exs
+++ b/apps/fountain/test/fountain/quotas_test.exs
@@ -86,13 +86,11 @@ defmodule Fountain.QuotasTest do
       assert Quotas.sandbox_limit(with_balance(insert_active_user(), 100_000).id) == 20
     end
 
-    test "a comped account gets the ceiling, and so does everyone with billing off" do
+    # Billing off is covered in credits_enforcement_test (async: false): it
+    # flips global config, which an async module must not do.
+    test "a comped account gets the ceiling" do
       {:ok, comped} = Fountain.Billing.comp_account(insert_active_user())
       assert Quotas.sandbox_limit(comped.id) == 20
-
-      Application.put_env(:fountain, :billing_enabled, false)
-      on_exit(fn -> Application.put_env(:fountain, :billing_enabled, true) end)
-      assert Quotas.sandbox_limit(insert_active_user().id) == 20
     end
 
     test "an override beats the balance, in either direction" do

--- a/apps/fountain/test/fountain/quotas_test.exs
+++ b/apps/fountain/test/fountain/quotas_test.exs
@@ -63,57 +63,88 @@ defmodule Fountain.QuotasTest do
   end
 
   describe "sandbox_limit/1" do
-    # Every literal below is deliberate: comparing against
-    # Quotas.default_limit() would compare the function under test to its own
-    # source and pass for any value (#406). The same reasoning applies to the
-    # plan caps — writing them out is what pins the ladder the tiers are sold
-    # on, so changing a cap in the catalog has to be a deliberate edit here.
+    # The balance rule (ADR 0031): clamp(balance / reserve, floor, ceiling),
+    # with reserve $2, floor 2 and ceiling 20 in test config.
+    defp with_balance(user, cents) do
+      {:ok, _} =
+        Fountain.Credits.grant(user.id, cents, "purchase", idempotency_key: "q-#{user.id}")
 
-    test "a user with no plan gets the default plan's cap, which is 2" do
+      user
+    end
+
+    test "nothing in the balance funds the floor" do
       assert Quotas.sandbox_limit(insert_active_user().id) == 2
     end
 
-    test "the cap follows the plan" do
-      assert Quotas.sandbox_limit(insert_active_user(plan: "solo").id) == 2
-      assert Quotas.sandbox_limit(insert_active_user(plan: "team").id) == 5
-      assert Quotas.sandbox_limit(insert_active_user(plan: "scale").id) == 10
+    test "the cap follows the balance, one sandbox per reserve" do
+      assert Quotas.sandbox_limit(with_balance(insert_active_user(), 1_000).id) == 5
+      assert Quotas.sandbox_limit(with_balance(insert_active_user(), 2_199).id) == 10
+      assert Quotas.sandbox_limit(with_balance(insert_active_user(), 100).id) == 2
     end
 
-    # Grandfathering, in one assertion: the closed plan is priced like Solo
-    # and capped like Team, so nobody lost capacity at the changeover.
-    test "the closed legacy plan carries Team's cap" do
-      assert Quotas.sandbox_limit(insert_active_user(plan: "legacy").id) == 5
+    test "the ceiling bounds it however large the balance" do
+      assert Quotas.sandbox_limit(with_balance(insert_active_user(), 100_000).id) == 20
     end
 
-    test "an override beats the plan, in either direction" do
-      up = insert_active_user(plan: "solo")
+    test "a comped account gets the ceiling, and so does everyone with billing off" do
+      {:ok, comped} = Fountain.Billing.comp_account(insert_active_user())
+      assert Quotas.sandbox_limit(comped.id) == 20
+
+      Application.put_env(:fountain, :billing_enabled, false)
+      on_exit(fn -> Application.put_env(:fountain, :billing_enabled, true) end)
+      assert Quotas.sandbox_limit(insert_active_user().id) == 20
+    end
+
+    test "an override beats the balance, in either direction" do
+      up = insert_active_user()
       {:ok, up} = Fountain.Accounts.update_sandbox_limit(up, 25)
       assert Quotas.sandbox_limit(up.id) == 25
 
-      down = insert_active_user(plan: "scale")
+      down = with_balance(insert_active_user(), 100_000)
       {:ok, down} = Fountain.Accounts.update_sandbox_limit(down, 1)
       assert Quotas.sandbox_limit(down.id) == 1
     end
 
-    # Zero is the abuse lever and must survive the "is there an override?"
-    # test, which a truthiness check would get wrong.
     test "an override of zero is an override, not an absent one" do
-      user = insert_active_user(plan: "scale")
+      user = with_balance(insert_active_user(), 100_000)
       {:ok, user} = Fountain.Accounts.update_sandbox_limit(user, 0)
-
       assert Quotas.sandbox_limit(user.id) == 0
     end
 
-    test "clearing the override hands the cap back to the plan" do
-      user = insert_active_user(plan: "team")
+    test "clearing the override hands the cap back to the balance" do
+      user = with_balance(insert_active_user(), 1_000)
       {:ok, user} = Fountain.Accounts.update_sandbox_limit(user, 1)
       {:ok, user} = Fountain.Accounts.update_sandbox_limit(user, nil)
-
       assert Quotas.sandbox_limit(user.id) == 5
     end
 
-    test "an unknown user falls back to the default plan rather than being unlimited" do
+    test "an unknown user gets the floor rather than being unlimited" do
       assert Quotas.sandbox_limit(Ecto.UUID.generate()) == 2
+    end
+  end
+
+  describe "the fleet ceiling" do
+    test "refuses the reservation once every slot is live, whoever holds them" do
+      cfg = Application.get_env(:fountain, :sandboxes)
+      on_exit(fn -> Application.put_env(:fountain, :sandboxes, cfg) end)
+      Application.put_env(:fountain, :sandboxes, Keyword.put(cfg, :fleet_ceiling, 2))
+
+      other = insert_active_user()
+      insert_sandbox(user_id: other.id, status: "ready")
+      insert_sandbox(user_id: other.id, status: "starting")
+
+      user = insert_active_user()
+      {:ok, _} = Fountain.Credits.grant(user.id, 1_000, "purchase", idempotency_key: "fleet")
+
+      assert {:error, :fleet_full} = Quotas.check_fleet_ceiling()
+
+      assert {:error, :fleet_full} =
+               Quotas.with_sandbox_reservation(user.id, [], fn -> {:ok, :never} end)
+
+      # A suspended sandbox is not compute and does not hold a slot.
+      Fountain.Repo.update_all(Fountain.Conversations.Sandbox, set: [status: "suspended"])
+      assert :ok = Quotas.check_fleet_ceiling()
+      assert {:ok, :ran} = Quotas.with_sandbox_reservation(user.id, [], fn -> {:ok, :ran} end)
     end
   end
 

--- a/apps/fountain/test/fountain_web/live/admin_users_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/admin_users_live_test.exs
@@ -154,9 +154,6 @@ defmodule FountainWeb.AdminUsersLiveTest do
 
       assert Fountain.Accounts.get_user(target.id).plan == "scale"
 
-      assert Fountain.Quotas.sandbox_limit(target.id) ==
-               Fountain.Plans.concurrent_sandboxes("scale")
-
       # The privilege trail, not just the effect: record_admin/1 is
       # best-effort and silently drops an event type missing from its closed
       # allowlist, which is how admin actions have shipped unaudited before.
@@ -174,7 +171,7 @@ defmodule FountainWeb.AdminUsersLiveTest do
                "the type is probably missing from AdminEvent's allowlist"
     end
 
-    test "an empty field clears the override and the cap follows the plan", %{conn: conn} do
+    test "an empty field clears the override and the cap follows the balance", %{conn: conn} do
       admin = insert_admin()
       target = insert_active_user(plan: "team")
       {:ok, _} = Fountain.Accounts.update_sandbox_limit(target, 25, actor: "admin")
@@ -188,8 +185,7 @@ defmodule FountainWeb.AdminUsersLiveTest do
 
       assert render(lv) =~ "Override cleared"
 
-      assert Fountain.Quotas.sandbox_limit(target.id) ==
-               Fountain.Plans.fetch!("team").concurrent_sandboxes
+      assert Fountain.Quotas.sandbox_limit(target.id) == Fountain.Quotas.default_limit()
 
       assert Fountain.Accounts.get_user(target.id).sandbox_limit_override == nil
     end

--- a/config/config.exs
+++ b/config/config.exs
@@ -73,6 +73,17 @@ config :fountain,
   # the suite covers the pitch and flips it off per-test. See Fountain.Marketing.
   marketing_site: false
 
+# Concurrency (ADR 0031). A tenant may run as many sandboxes at once as
+# their balance funds: clamp(balance / reserve_cents, cap_floor, cap_ceiling),
+# with users.sandbox_limit_override winning when set. fleet_ceiling bounds
+# the sum across every tenant to what the providers allow. runtime.exs
+# overrides from SANDBOX_*.
+config :fountain, :sandboxes,
+  reserve_cents: 200,
+  cap_floor: 2,
+  cap_ceiling: 20,
+  fleet_ceiling: 20
+
 # Prepaid credits (ADR 0030). Cents. `turn_hour_cents` is the customer price
 # of one hour of turn time; the comms prices are nil until an operator sets
 # them, and nil burns nothing (#1042). runtime.exs overrides from CREDIT_*.

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -639,6 +639,29 @@ config :fountain,
        |> Enum.reject(fn {_slug, id} -> id in [nil, ""] end)
        |> Map.new()
 
+# Concurrency (ADR 0031): the reserve one live sandbox needs in the balance,
+# the per-account floor and ceiling the balance rule is clamped to, and the
+# fleet ceiling — the most live sandboxes the deployment will run in total,
+# which is the provider plan's number (Sprites' $20 plan allows about 20).
+sandbox_int = fn var, default ->
+  case System.get_env(var) do
+    value when value in [nil, ""] ->
+      default
+
+    value ->
+      case Integer.parse(String.trim(value)) do
+        {n, ""} when n >= 0 -> n
+        _ -> raise "#{var} must be a whole number, 0 or more, got #{inspect(value)}"
+      end
+  end
+end
+
+config :fountain, :sandboxes,
+  reserve_cents: sandbox_int.("SANDBOX_RESERVE_CENTS", 200),
+  cap_floor: sandbox_int.("SANDBOX_CAP_FLOOR", 2),
+  cap_ceiling: sandbox_int.("SANDBOX_CAP_CEILING", 20),
+  fleet_ceiling: sandbox_int.("SANDBOX_FLEET_CEILING", 20)
+
 # The plan a user with no plan of their own gets — the tenants a self-hosted
 # instance never subscribed, and every account on a deployment with billing
 # off. `DEFAULT_PLAN=scale` is how a self-hoster paying their own provider

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -129,6 +129,10 @@ at a dead end, with no error to see. Read [Email](guides/operate/email.md).
 | `AGENTPHONE_NUMBER_CENTS` | — | No. | What AgentPhone charges for one number each month, in cents. |
 | `AGENTMAIL_MESSAGE_CENTS` | — | No. | What AgentMail charges for one email, in cents. Give the fraction, such as `0.2` for $2 per 1,000 emails. A whole number rounds this rate to zero. |
 | `AGENTPHONE_MESSAGE_CENTS` | — | No. | What AgentPhone charges for one SMS, in cents. Fountain counts an inbound message too, because AgentPhone charges for it. |
+| `SANDBOX_RESERVE_CENTS` | `200` | No. | The credit one live sandbox needs in the balance. A tenant may run `balance / reserve` sandboxes at once, between the floor and the ceiling. |
+| `SANDBOX_CAP_FLOOR` | `2` | No. | The fewest sandboxes a tenant with a positive balance may run at once. |
+| `SANDBOX_CAP_CEILING` | `20` | No. | The most sandboxes one tenant may run at once, unless an admin override raises it. |
+| `SANDBOX_FLEET_CEILING` | `20` | No. | The most live sandboxes across every tenant. Set it to what your sandbox provider plan allows. A start beyond it gets `503 fleet_full`. |
 | `CREDIT_PRICING_SINCE` | — | No. | The instant from which Fountain prices turns and messages into the prepaid ledger, as ISO 8601. Unset, Fountain prices nothing. |
 | `CREDIT_ENFORCE` | `false` | No. | Set `true` to refuse new sandboxes and new turns when the balance is zero or less. Turns in flight finish. Comped accounts and instances with billing off are never refused. |
 | `CREDIT_TURN_HOUR_CENTS` | `25` | No. | What a tenant pays for one hour of turn time, in whole cents, from their prepaid balance. |

--- a/ee/test/fountain/credits_enforcement_test.exs
+++ b/ee/test/fountain/credits_enforcement_test.exs
@@ -72,6 +72,12 @@ defmodule Fountain.CreditsEnforcementTest do
       assert {:error, :subscription_required} = Billing.check_spend(canceled)
     end
 
+    test "billing off funds the ceiling, whatever the balance" do
+      Application.put_env(:fountain, :billing_enabled, false)
+      on_exit(fn -> Application.put_env(:fountain, :billing_enabled, true) end)
+      assert Quotas.sandbox_limit(insert_active_user().id) == Quotas.settings().cap_ceiling
+    end
+
     test "comped and billing-off never refuse" do
       # No Stripe customer, so comping cancels nothing upstream.
       {:ok, comped} = Billing.comp_account(insert_active_user())


### PR DESCRIPTION
First of three for ADR 0031.

- **Per-account cap:** `sandbox_limit_override` wins; otherwise `clamp(balance ÷ SANDBOX_RESERVE_CENTS, SANDBOX_CAP_FLOOR, SANDBOX_CAP_CEILING)` — defaults $2 / 2 / 20. $10 funds 5, $100 funds 20 (ceiling), ≤ $0 funds the floor but the credit gate refuses first. Comped accounts and billing-off deployments get the ceiling. `Quotas` no longer reads `Plans`.
- **Fleet ceiling:** `SANDBOX_FLEET_CEILING` (default 20 — the Sprites $20 plan) bounds live sandboxes across every tenant. `with_sandbox_reservation/3` takes one global advisory lock (always before the per-user lock, so no deadlock) and checks it first; `{:error, :fleet_full}` → **503** `fleet_full` with `Retry-After: 60`. Suspended sandboxes don't hold a slot (ADR 0017).
- Config + `.env.example` + `docs/configuration.md` rows.

**Tests:** the balance ladder, the ceiling, comped/billing-off, override both ways and zero, clearing the override, unknown user → floor; the fleet ceiling refusing and then admitting after a suspend. The admin plan test no longer asserts the plan sets the cap (it doesn't; the plan column retires in PR 3). The `DBConnection.OwnershipError` noise in the conversation test files is identical on `main` (101 lines each) — pre-existing.

Refs ADR 0031, #1086.

🤖 Generated with [Claude Code](https://claude.com/claude-code)