### PR TITLE
feat(credits): the opening credit is $5, not $10

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -270,7 +270,7 @@ STRIPE_WEBHOOK_SECRET=
 # placeholder until a provider invoice has been reconciled. The four comms
 # prices default to unset, and unset burns nothing: turning one on is a price
 # increase. Packs are the amounts a tenant can buy, ascending.
-# CREDIT_OPENING_CENTS=1000
+# CREDIT_OPENING_CENTS=500
 # CREDIT_OPENING_DAYS=14
 # CREDIT_TURN_HOUR_CENTS=25
 # CREDIT_NUMBER_CENTS=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,9 +77,9 @@ that are easy to get wrong:
   `Quotas.with_sandbox_reservation/3` checks it too. In-flight turns finish
   and may go negative (ADR 0030 decision 6). There is no `check_active/1`.
 - **The opening credit lands at verification.** `Accounts.verify_email/2`
-  posts `Credits.grant_opening/2` — `CREDIT_OPENING_CENTS` ($10) expiring
+  posts `Credits.grant_opening/2` — `CREDIT_OPENING_CENTS` ($5) expiring
   `CREDIT_OPENING_DAYS` (14) later, idempotent per account. In tests
-  `insert_verified_user/1` therefore holds $10 and may spend; drain it with a
+  `insert_verified_user/1` therefore holds $5 and may spend; drain it with a
   `burn_turn` debit to test refusal. `insert_active_user/1` is the same
   function, kept for readability.
 - **Concurrency is funded by the balance, under a fleet ceiling.**

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
@@ -11,7 +11,7 @@ defmodule FountainWeb.MarketingHTML do
   def opening_credit do
     cfg = Application.get_env(:fountain, :credits, [])
 
-    {Fountain.Credits.format_cents(Keyword.get(cfg, :opening_cents, 1_000)),
+    {Fountain.Credits.format_cents(Keyword.get(cfg, :opening_cents, 500)),
      Keyword.get(cfg, :opening_days, 14)}
   end
 

--- a/apps/fountain/test/fountain/quotas_test.exs
+++ b/apps/fountain/test/fountain/quotas_test.exs
@@ -73,9 +73,9 @@ defmodule Fountain.QuotasTest do
     end
 
     # Every verified account holds the $10 opening grant: five sandboxes.
-    test "the opening grant funds five; nothing in the balance funds the floor" do
+    test "the opening grant funds the floor; so does nothing at all" do
       user = insert_active_user()
-      assert Quotas.sandbox_limit(user.id) == 5
+      assert Quotas.sandbox_limit(user.id) == 2
 
       {:ok, _} =
         Fountain.Credits.debit(user.id, 1_000, "burn_turn", idempotency_key: "drain-#{user.id}")
@@ -84,9 +84,9 @@ defmodule Fountain.QuotasTest do
     end
 
     test "the cap follows the balance, one sandbox per reserve" do
-      assert Quotas.sandbox_limit(with_balance(insert_active_user(), 1_000).id) == 10
-      assert Quotas.sandbox_limit(with_balance(insert_active_user(), 1_199).id) == 10
-      assert Quotas.sandbox_limit(with_balance(insert_active_user(), 100).id) == 5
+      assert Quotas.sandbox_limit(with_balance(insert_active_user(), 1_000).id) == 7
+      assert Quotas.sandbox_limit(with_balance(insert_active_user(), 1_199).id) == 8
+      assert Quotas.sandbox_limit(with_balance(insert_active_user(), 100).id) == 3
     end
 
     test "the ceiling bounds it however large the balance" do
@@ -120,7 +120,7 @@ defmodule Fountain.QuotasTest do
       user = with_balance(insert_active_user(), 1_000)
       {:ok, user} = Fountain.Accounts.update_sandbox_limit(user, 1)
       {:ok, user} = Fountain.Accounts.update_sandbox_limit(user, nil)
-      assert Quotas.sandbox_limit(user.id) == 10
+      assert Quotas.sandbox_limit(user.id) == 7
     end
 
     test "an unknown user gets the floor rather than being unlimited" do

--- a/apps/fountain/test/fountain_web/controllers/marketing_pricing_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_pricing_test.exs
@@ -26,12 +26,12 @@ defmodule FountainWeb.MarketingPricingTest do
     assert body =~ "Pay for what your agents do"
     assert body =~ "$0.25"
     assert body =~ "per agent hour"
-    assert body =~ "$10.00"
+    assert body =~ "$5.00"
     assert body =~ "to start, free"
     assert body =~ "Good for 14 days"
     assert body =~ "agents at once, at most"
     assert body =~ "One more for every $2.00 you hold, from 2"
-    assert body =~ "Start with $10.00 free"
+    assert body =~ "Start with $5.00 free"
     refute body =~ "/mo"
   end
 
@@ -65,7 +65,7 @@ defmodule FountainWeb.MarketingPricingTest do
 
   test "the hero quotes the opening credit", %{conn: conn} do
     body = conn |> get(~p"/") |> html_response(200)
-    assert body =~ "$10.00 of credit to start"
+    assert body =~ "$5.00 of credit to start"
   end
 
   test "omits pricing when billing is disabled", %{conn: conn} do

--- a/config/config.exs
+++ b/config/config.exs
@@ -86,7 +86,7 @@ config :fountain, :sandboxes,
 config :fountain, :credits,
   # The opening grant a new account gets (ADR 0031 decision 3), and how
   # long it lasts.
-  opening_cents: 1_000,
+  opening_cents: 500,
   opening_days: 14,
   turn_hour_cents: 25,
   number_cents: nil,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -743,7 +743,7 @@ config :fountain, :team_contact_ceiling, sandbox_int.("TEAM_CONTACT_CEILING", 10
 
 config :fountain, :credits,
   # The opening grant a new account gets, and how many days it lasts.
-  opening_cents: credit_cents.("CREDIT_OPENING_CENTS") || 1_000,
+  opening_cents: credit_cents.("CREDIT_OPENING_CENTS") || 500,
   opening_days: credit_cents.("CREDIT_OPENING_DAYS") || 14,
   turn_hour_cents: credit_cents.("CREDIT_TURN_HOUR_CENTS") || 25,
   number_cents: credit_cents.("CREDIT_NUMBER_CENTS"),

--- a/decisions/0031-credits-are-the-product.md
+++ b/decisions/0031-credits-are-the-product.md
@@ -64,7 +64,7 @@ exactly the customers who spend the most.
    used to be.
 
 3. **The trial is an opening grant.** Registration posts `grant_trial` of
-   `CREDIT_OPENING_CENTS` (default $10) expiring `CREDIT_OPENING_DAYS`
+   `CREDIT_OPENING_CENTS` (default $5; the ADR said $10, the operator set $5 on 2026-08-25) expiring `CREDIT_OPENING_DAYS`
    (default 14) later. Nothing else about a "trial" exists: no status, no
    clock, no sweep.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -127,7 +127,7 @@ at a dead end, with no error to see. Read [Email](guides/operate/email.md).
 | `SANDBOX_CAP_FLOOR` | `2` | No. | The fewest sandboxes a tenant with a positive balance may run at once. |
 | `SANDBOX_CAP_CEILING` | `20` | No. | The most sandboxes one tenant may run at once, unless an admin override raises it. |
 | `SANDBOX_FLEET_CEILING` | `20` | No. | The most live sandboxes across every tenant. Set it to what your sandbox provider plan allows. A start beyond it gets `503 fleet_full`. |
-| `CREDIT_OPENING_CENTS` | `1000` | No. | The credit a new account starts with, in cents. |
+| `CREDIT_OPENING_CENTS` | `500` | No. | The credit a new account starts with, in cents. |
 | `CREDIT_OPENING_DAYS` | `14` | No. | How many days the opening credit lasts. |
 | `TEAM_CONTACT_CEILING` | `10` | No. | The most teammate contacts one account may hold at once. |
 | `CREDIT_TURN_HOUR_CENTS` | `25` | No. | What a tenant pays for one hour of turn time, in whole cents, from their prepaid balance. |

--- a/docs/guides/operate/billing.md
+++ b/docs/guides/operate/billing.md
@@ -21,7 +21,7 @@ admin panel or in the API.
 ## What billing is
 
 Credits are the product. Each account holds a balance in cents. A new account
-starts with `CREDIT_OPENING_CENTS` ($10) for `CREDIT_OPENING_DAYS` (14). Each
+starts with `CREDIT_OPENING_CENTS` ($5) for `CREDIT_OPENING_DAYS` (14). Each
 turn burns `CREDIT_TURN_HOUR_CENTS` an hour. A phone number and an inbox each
 cost a month of rent up front. A message costs its price. A tenant buys more
 credit in packs. There are no plans and no subscription. See

--- a/docs/guides/operate/plans-and-prices.md
+++ b/docs/guides/operate/plans-and-prices.md
@@ -28,7 +28,7 @@ hours, on a sandbox that was busy for one.
 
 ## The opening credit
 
-A new account gets `CREDIT_OPENING_CENTS` ($10) when it verifies its email.
+A new account gets `CREDIT_OPENING_CENTS` ($5) when it verifies its email.
 That credit expires `CREDIT_OPENING_DAYS` (14) days later. Credit a tenant
 buys never expires, and Fountain spends it last.
 

--- a/ee/lib/fountain/credits.ex
+++ b/ee/lib/fountain/credits.ex
@@ -344,7 +344,7 @@ defmodule Fountain.Credits do
 
   def grant_opening(user_id, opts) when is_binary(user_id) do
     cfg = Application.get_env(:fountain, :credits, [])
-    cents = Keyword.get(cfg, :opening_cents, 1_000)
+    cents = Keyword.get(cfg, :opening_cents, 500)
     days = Keyword.get(cfg, :opening_days, 14)
     now = Keyword.get(opts, :now) || DateTime.utc_now()
 

--- a/ee/lib/fountain/emails/billing_emails.ex
+++ b/ee/lib/fountain/emails/billing_emails.ex
@@ -56,7 +56,7 @@ defmodule Fountain.Emails.BillingEmails do
   defp welcome_trial_phrase(%User{}) do
     if Fountain.Billing.enabled?() do
       cfg = Application.get_env(:fountain, :credits, [])
-      cents = Keyword.get(cfg, :opening_cents, 1_000)
+      cents = Keyword.get(cfg, :opening_cents, 500)
       days = Keyword.get(cfg, :opening_days, 14)
 
       "Your account starts with #{Fountain.Credits.format_cents(cents)} of credit, good for " <>

--- a/ee/lib/fountain/workers/credits_email.ex
+++ b/ee/lib/fountain/workers/credits_email.ex
@@ -71,7 +71,7 @@ defmodule Fountain.Workers.CreditsEmail do
   @doc "Cents under which a balance is 'low': 20 % of the opening grant, or $2."
   @spec runway_line(Accounts.User.t()) :: pos_integer()
   def runway_line(_user) do
-    opening = Application.get_env(:fountain, :credits, []) |> Keyword.get(:opening_cents, 1_000)
+    opening = Application.get_env(:fountain, :credits, []) |> Keyword.get(:opening_cents, 500)
     max(div(opening, 5), 200)
   end
 

--- a/ee/test/fountain/credits_rent_test.exs
+++ b/ee/test/fountain/credits_rent_test.exs
@@ -86,7 +86,8 @@ defmodule Fountain.Credits.RentTest do
       assert Repo.reload!(fresh).rent_paid_through == ~U[2026-09-10 00:00:00Z]
       assert Repo.reload!(due).rent_paid_through == ~U[2026-09-01 00:00:00Z]
       assert Repo.reload!(paid).rent_paid_through == ~U[2026-09-01 00:00:00Z]
-      assert Credits.balance(user.id) == 500
+      # $10 held, two months charged.
+      assert Credits.balance(user.id) == 0
 
       assert %{charged: 0} = Rent.collect(now: ~U[2026-08-11 00:00:00Z])
     end

--- a/ee/test/fountain/credits_rent_test.exs
+++ b/ee/test/fountain/credits_rent_test.exs
@@ -61,6 +61,8 @@ defmodule Fountain.Credits.RentTest do
     # The opening credit ($10) funds two months of rent.
     test "charge takes a month up front, once per period, and moves the paid-through date" do
       user = insert_verified_user()
+      # $5 opening credit plus $5 bought: one month of rent, with $5 to spare.
+      {:ok, _} = Credits.grant(user.id, 500, "purchase", idempotency_key: "top-up")
       c = contact(user)
       start = ~U[2026-08-05 10:00:00Z]
 
@@ -75,6 +77,7 @@ defmodule Fountain.Credits.RentTest do
 
     test "collect charges every contact whose month is up, starting a never-charged one now" do
       user = insert_verified_user()
+      {:ok, _} = Credits.grant(user.id, 500, "purchase", idempotency_key: "top-up")
       fresh = contact(user)
       due = contact(user, %{rent_paid_through: ~U[2026-08-01 00:00:00Z]})
       paid = contact(user, %{rent_paid_through: ~U[2026-09-01 00:00:00Z]})
@@ -83,7 +86,7 @@ defmodule Fountain.Credits.RentTest do
       assert Repo.reload!(fresh).rent_paid_through == ~U[2026-09-10 00:00:00Z]
       assert Repo.reload!(due).rent_paid_through == ~U[2026-09-01 00:00:00Z]
       assert Repo.reload!(paid).rent_paid_through == ~U[2026-09-01 00:00:00Z]
-      assert Credits.balance(user.id) == 0
+      assert Credits.balance(user.id) == 500
 
       assert %{charged: 0} = Rent.collect(now: ~U[2026-08-11 00:00:00Z])
     end

--- a/ee/test/fountain/workers/welcome_email_test.exs
+++ b/ee/test/fountain/workers/welcome_email_test.exs
@@ -25,7 +25,7 @@ defmodule Fountain.Workers.WelcomeEmailTest do
       assert :ok = perform_job(WelcomeEmail, %{"user_id" => user.id})
 
       assert_email_sent(fn email ->
-        assert email.text_body =~ "starts with $10.00 of credit, good for 14 days"
+        assert email.text_body =~ "starts with $5.00 of credit, good for 14 days"
       end)
     end
 

--- a/ee/test/fountain_web/controllers/billing_api_controller_test.exs
+++ b/ee/test/fountain_web/controllers/billing_api_controller_test.exs
@@ -38,7 +38,7 @@ defmodule FountainWeb.BillingApiControllerTest do
       assert body["data"]["comped"] == false
       assert body["data"]["has_stripe_customer"] == false
       # The opening credit funds five sandboxes (ADR 0031).
-      assert body["data"]["sandbox_cap"] == 5
+      assert body["data"]["sandbox_cap"] == 2
       refute Map.has_key?(body["data"], "status")
       refute Map.has_key?(body["data"], "plan")
       assert body["data"]["usage"]["conversations"] == 0


### PR DESCRIPTION
Default `CREDIT_OPENING_CENTS` 1000 → 500 in config and every fallback; docs, CLAUDE.md, the ADR 0031 status note and `.env.example` follow. Consequences the tests now pin: a fresh account's cap is the floor (2) rather than 5; one month of contact rent ($5) is exactly the opening credit; the welcome email and the pricing page quote $5.00. Packs unchanged ($10/$25/$100).

🤖 Generated with [Claude Code](https://claude.com/claude-code)