### PR TITLE
skills: /build-fountain-app, the contributor guide for apps on the API

### DIFF
--- a/.claude/skills/build-fountain-app/SKILL.md
+++ b/.claude/skills/build-fountain-app/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: build-fountain-app
+description: Build an application on top of the Fountain API — a browser app, a bot, an internal tool, anything that hires agents, sends them prompts and renders what they do. Use whenever the user says "build an app on Fountain", "a client for Fountain", "another fountain-team / workbench / demo app", "Sign in with Fountain", or wants to ship something that talks to /api from its own origin. Covers the shape (static SPA on the SDK, or a small server in front), auth (OAuth code + PKCE, tokens are API keys), streaming, the server-side registration an app needs (API_CORS_ORIGINS, OAUTH_CLIENTS), the home-cloud hosting recipe, and the traps every previous app hit.
+---
+
+# Build an app on Fountain
+
+Fountain's own UI is a console. Every product surface that talks to a person
+is a separate app on `/api`, on its own origin, with no privileged access.
+Three of them are the reference implementations — clone their shape rather
+than inventing one:
+
+| Example | Local checkout | Shape | Study it for |
+|---|---|---|---|
+| [fountain-team](https://github.com/jhgaylor/fountain-team) | `~/dev/jhgaylor/fountain-team` | static SPA, raw `fetch` (predates the SDK) | roster + thread + queue, team stream, PKCE sign-in (`src/lib/oauth.ts`) |
+| [fountain-workbench](https://github.com/BinaryBourbon/fountain-workbench) | `~/dev/BinaryBourbon/fountain-workbench` | SPA **plus a Bun server** (`server/`) | when an app needs its own backend: shared projects, a member never holds the owner's key, project-scoped proxy of `/api`, an MCP surface for the agent |
+| [fountain-demos](https://github.com/jhgaylor/fountain-demos) + the `*.inevitable.fyi` suite | `~/dev/jhgaylor/fountain-demos` (landing page only), `~/dev/jhgaylor/{briefing-room,table-talk,repo-sage,mission-control,watchtower,arena,mend,rounds}` | one static app per repo, all cloned from `jhgaylor/dns-desk`; Mend and Rounds add a Bun `server/` because a GitHub App private key cannot live in a browser | the hosting recipe (Dockerfile + build.yml + `k8s/`), the `lib/spec.ts` + `lib/protocol.ts` pair (the prompt asks for a fenced answer block, the parser reads it back; change one, change both), lazy hiring on first use |
+
+The public manual already explains the domain; **read it before writing
+code, do not re-derive it**:
+
+- `docs/build/index.md` — why the app is static files + a bearer token
+- `docs/build/pieces.md` — agent / conversation / sandbox / environment / vault, what happens between Enter and the first word, the two streams, where tenancy lives
+- `docs/build/team-chat.md` — the whole app in SDK calls, in order (hire, roster, message, stream, thread, busy/stop/images/search, connectors, routines, ship)
+- `docs/sdk.md` — the SDK surface, the error table, the browser section
+- `docs/api.md` — every route, incl. *Sign in with Fountain*
+- `sdk/typescript/examples/*.ts` — compiled in CI, so they are true
+
+## 1. Decide the shape
+
+Ask one question: **does anyone besides the key's owner need to see the
+data?**
+
+- **No** → a static SPA. No backend. Key in `localStorage`, OAuth for
+  sign-in, `@agentshit/fountain-sdk` in the browser. This is fountain-team,
+  fountain-conversations, dns-desk and all six demo apps. Default here.
+- **Yes** (sharing, cross-user rooms, a credential the browser must not
+  hold, your own data model) → the workbench shape: a small server that
+  holds the owner's key encrypted, authenticates its own users by asking
+  Fountain whose key it is (`GET /api/auth/me`), and **proxies a narrowed
+  `/api`** so the browser still runs an ordinary SDK client with the proxy as
+  `baseUrl` (`server/proxy.ts`). Fountain has no team/org/sharing primitive
+  and no per-user prefs store; anything of that kind is the app's own table.
+
+Persist app-only structure (projects, work items, pinned things) in the
+app, but make membership **durable on Fountain** via `channel_id`
+(`<app>:<scope>/<id>`), so the tree can be rebuilt from
+`GET /api/conversations` after a wipe. Pass `fresh: true` on create when a
+channel must not *resume* an existing conversation.
+
+## 2. Stack
+
+bun + vite + react + TypeScript, `@agentshit/fountain-sdk` (current
+`1.0.0`; the `browser` export condition works under Vite, no runtime deps).
+Use the SDK. fountain-team and the demo apps predate it and vendor a
+hand-rolled `src/api/client.ts` + `lib/sse.ts` + `lib/acp.ts` from dns-desk;
+the SDK is those three files done once, with `blocks` on by default. Copy
+`package.json` / `tsconfig.json` / `vite.config.ts` from fountain-workbench.
+Scripts: `dev`, `build` (`tsc --noEmit && vite build`), `test` (`bun test`).
+A mock/fake Fountain in tests, not the real one (`server/app.test.ts` in the
+workbench is the pattern; see the envelope trap in
+[references/traps.md](references/traps.md)).
+
+Settings the user must be able to change at runtime: **base URL** (defaults
+to `https://fountain.inevitable.fyi`) and the key. The hosted builds work
+against any Fountain that admits the origin.
+
+## 3. Auth: Sign in with Fountain, paste-a-key as fallback
+
+OAuth 2.0 authorization code + PKCE (S256), public client, no secret, no
+refresh token. The token **is** a 30-day full-scope API key named
+`oauth:<client_id>` (ADR 0021). Sign-out is `POST /api/oauth/revoke` with
+the token. ~80 lines, copied verbatim in
+[references/sign-in.md](references/sign-in.md).
+
+The client id and the **exact** redirect URI must be registered on the
+server — a client nobody registered renders an error page and redirects
+nowhere. Registration is a Fountain PR, not something the app can do
+(§5). Keep the pasted-key path: the CLI, sandboxes (`$FOUNTAIN_TOKEN`) and
+a dev instance with no client registered all use it.
+
+## 4. The four things people judge an app on
+
+1. **The 202 is not the answer.** `POST …/messages` and `POST /api/conversations` queue a turn; the words arrive on a stream. Await the SDK `Run`, iterate `run.textStream`, or read the team/events stream.
+2. **Render blocks, never a dialect.** `?blocks=true` (the SDK sets it) folds ACP/stdout into `text | thinking | tool_use | tool_result | init | result | error | raw`. fountain-team once shipped a 200-line ACP parser — do not.
+3. **Busy is not an error toast.** Catch `ConversationBusyError`, queue locally, flush on the `turn/done` event. Branch on `error.code`, never on status.
+4. **Show the real error.** A banner with `status` + `code` (`describeError`) instead of "could not be reached" — the workbench's generic line cost Jake a round trip on a CORS failure. `ConnectionError` in a browser is almost always CORS.
+
+Plus: an `<img src>` at `/api/agents/:id/avatar` is a 401 — fetch with the
+bearer and use an object URL. Secrets are write-only (`secrets.list()`
+returns keys); say so in the UI when someone pastes a token.
+
+## 5. Register the app on the server (a Fountain PR)
+
+Two env vars on the Fountain deployment, both exact-match lists:
+
+| Var | Where | What |
+|---|---|---|
+| `API_CORS_ORIGINS` | home-cloud `platform/fountain-site/patches/deployment.yaml` | one exact origin per app (`https://<host>`, no path) |
+| `OAUTH_CLIENTS` | same file, JSON | `{"id":"<repo-name>","name":"…","redirect_uris":["https://<host>/"]}` — trailing slash, exact |
+| `config/dev.exs` `:oauth_clients` | this repo | add the client with `http://localhost:5173/` and `:5174/` so `bunx vite` can sign in against a local server |
+
+Convention: `client_id` = repo name. If the app *replaces* a first-party
+surface (conversations or team), it is also wired through `Fountain.Apps`
+(`CONVERSATIONS_APP_URL` / `TEAM_APP_URL`) — that seam is the only place the
+server knows where an app lives.
+
+Local dev against a local Fountain:
+`API_CORS_ORIGINS=http://localhost:5173 PORT=4000 mix phx.server`. A dev
+instance has no `SPRITES_TOKEN`, so a real turn needs prod or a runner.
+
+## 6. Ship it
+
+Static → nginx image → GHCR → Flux on home-cloud, at `<name>.inevitable.fyi`
+(wildcard DNS already resolves; GHCR packages under jhgaylor are public).
+The full recipe, file by file, is
+[references/ship.md](references/ship.md). GitHub Pages is the older path
+(`jakegaylor.com/<app>/`) and still works for a pure SPA; the workbench
+moved off it because the demo suite shape is what home-cloud already runs.
+
+## 7. Before calling it done
+
+- Sign-in tested in **Firefox**, not only headless Chrome (the User-Agent preflight trap).
+- One real turn on prod: hire, message, see blocks render, see `turn/done` on the stream.
+- `bun test` + `tsc --noEmit` green; CI = build.yml on push to main.
+- The Fountain PR (CORS + OAuth client) merged **and deployed** — check `build.yml` on main, then the pod env, before testing sign-in; a green PR gate proves nothing shipped.
+- Read [references/traps.md](references/traps.md) once; every entry cost a previous app real hours.

--- a/.claude/skills/build-fountain-app/SKILL.md
+++ b/.claude/skills/build-fountain-app/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: build-fountain-app
-description: Build an application on top of the Fountain API — a browser app, a bot, an internal tool, anything that hires agents, sends them prompts and renders what they do. Use whenever the user says "build an app on Fountain", "a client for Fountain", "another fountain-team / workbench / demo app", "Sign in with Fountain", or wants to ship something that talks to /api from its own origin. Covers the shape (static SPA on the SDK, or a small server in front), auth (OAuth code + PKCE, tokens are API keys), streaming, the server-side registration an app needs (API_CORS_ORIGINS, OAUTH_CLIENTS), the home-cloud hosting recipe, and the traps every previous app hit.
+description: Build an application on top of the Fountain API — a browser app, a bot, an internal tool, anything that hires agents, sends them prompts and renders what they do. Use whenever the user says "build an app on Fountain", "a client for Fountain", "another fountain-team / workbench / demo app", "Sign in with Fountain", or wants to ship something that talks to /api from its own origin. Covers the shape (static SPA on the SDK, or a small server in front), auth (OAuth code + PKCE, tokens are API keys), streaming, the server-side registration an app needs (API_CORS_ORIGINS, OAUTH_CLIENTS), a hosting recipe for any static host or container, and the traps every previous app hit.
 ---
 
 # Build an app on Fountain
@@ -10,11 +10,13 @@ is a separate app on `/api`, on its own origin, with no privileged access.
 Three of them are the reference implementations — clone their shape rather
 than inventing one:
 
-| Example | Local checkout | Shape | Study it for |
-|---|---|---|---|
-| [fountain-team](https://github.com/jhgaylor/fountain-team) | `~/dev/jhgaylor/fountain-team` | static SPA, raw `fetch` (predates the SDK) | roster + thread + queue, team stream, PKCE sign-in (`src/lib/oauth.ts`) |
-| [fountain-workbench](https://github.com/BinaryBourbon/fountain-workbench) | `~/dev/BinaryBourbon/fountain-workbench` | SPA **plus a Bun server** (`server/`) | when an app needs its own backend: shared projects, a member never holds the owner's key, project-scoped proxy of `/api`, an MCP surface for the agent |
-| [fountain-demos](https://github.com/jhgaylor/fountain-demos) + the `*.inevitable.fyi` suite | `~/dev/jhgaylor/fountain-demos` (landing page only), `~/dev/jhgaylor/{briefing-room,table-talk,repo-sage,mission-control,watchtower,arena,mend,rounds}` | one static app per repo, all cloned from `jhgaylor/dns-desk`; Mend and Rounds add a Bun `server/` because a GitHub App private key cannot live in a browser | the hosting recipe (Dockerfile + build.yml + `k8s/`), the `lib/spec.ts` + `lib/protocol.ts` pair (the prompt asks for a fenced answer block, the parser reads it back; change one, change both), lazy hiring on first use |
+| Example | Shape | Study it for |
+|---|---|---|
+| [fountain-team](https://github.com/jhgaylor/fountain-team) | static SPA, raw `fetch` (predates the SDK) | roster + thread + queue, team stream, PKCE sign-in (`src/lib/oauth.ts`) |
+| [fountain-workbench](https://github.com/BinaryBourbon/fountain-workbench) | SPA **plus a Bun server** (`server/`) | when an app needs its own backend: shared projects, a member never holds the owner's key, project-scoped proxy of `/api`, an MCP surface for the agent |
+| [fountain-demos](https://github.com/jhgaylor/fountain-demos), an index of [briefing-room](https://github.com/jhgaylor/briefing-room), [table-talk](https://github.com/jhgaylor/table-talk), [repo-sage](https://github.com/jhgaylor/repo-sage), [mission-control](https://github.com/jhgaylor/mission-control), [watchtower](https://github.com/jhgaylor/watchtower), [arena](https://github.com/jhgaylor/arena), [mend](https://github.com/jhgaylor/mend), [rounds](https://github.com/jhgaylor/rounds) | one static app per repo, all cloned from [dns-desk](https://github.com/jhgaylor/dns-desk); Mend and Rounds add a Bun `server/` because a GitHub App private key cannot live in a browser | a container recipe (Dockerfile + nginx + build workflow), the `lib/spec.ts` + `lib/protocol.ts` pair (the prompt asks for a fenced answer block, the parser reads it back; change one, change both), lazy hiring on first use |
+
+Clone whichever you want to read; none of this depends on a local checkout.
 
 The public manual already explains the domain; **read it before writing
 code, do not re-derive it**:
@@ -61,9 +63,9 @@ A mock/fake Fountain in tests, not the real one (`server/app.test.ts` in the
 workbench is the pattern; see the envelope trap in
 [references/traps.md](references/traps.md)).
 
-Settings the user must be able to change at runtime: **base URL** (defaults
-to `https://fountain.inevitable.fyi`) and the key. The hosted builds work
-against any Fountain that admits the origin.
+Settings the user must be able to change at runtime: **base URL** and the
+key. The SDK's default base URL is the hosted instance; a build that lets
+the person type another works against any Fountain that admits the origin.
 
 ## 3. Auth: Sign in with Fountain, paste-a-key as fallback
 
@@ -75,53 +77,54 @@ the token. ~80 lines, copied verbatim in
 
 The client id and the **exact** redirect URI must be registered on the
 server — a client nobody registered renders an error page and redirects
-nowhere. Registration is a Fountain PR, not something the app can do
+nowhere. Registration is the operator's, not something the app can do
 (§5). Keep the pasted-key path: the CLI, sandboxes (`$FOUNTAIN_TOKEN`) and
-a dev instance with no client registered all use it.
+an instance where your client is not registered all use it.
 
 ## 4. The four things people judge an app on
 
 1. **The 202 is not the answer.** `POST …/messages` and `POST /api/conversations` queue a turn; the words arrive on a stream. Await the SDK `Run`, iterate `run.textStream`, or read the team/events stream.
 2. **Render blocks, never a dialect.** `?blocks=true` (the SDK sets it) folds ACP/stdout into `text | thinking | tool_use | tool_result | init | result | error | raw`. fountain-team once shipped a 200-line ACP parser — do not.
 3. **Busy is not an error toast.** Catch `ConversationBusyError`, queue locally, flush on the `turn/done` event. Branch on `error.code`, never on status.
-4. **Show the real error.** A banner with `status` + `code` (`describeError`) instead of "could not be reached" — the workbench's generic line cost Jake a round trip on a CORS failure. `ConnectionError` in a browser is almost always CORS.
+4. **Show the real error.** A banner with `status` + `code` (`describeError`) instead of "could not be reached" — the workbench's generic line hid a CORS failure for a whole round trip. `ConnectionError` in a browser is almost always CORS.
 
 Plus: an `<img src>` at `/api/agents/:id/avatar` is a 401 — fetch with the
 bearer and use an object URL. Secrets are write-only (`secrets.list()`
 returns keys); say so in the UI when someone pastes a token.
 
-## 5. Register the app on the server (a Fountain PR)
+## 5. Register the app with the Fountain it talks to
 
-Two env vars on the Fountain deployment, both exact-match lists:
+Two settings on the Fountain deployment, both exact-match lists
+(`docs/configuration.md`, ADR 0021):
 
-| Var | Where | What |
-|---|---|---|
-| `API_CORS_ORIGINS` | home-cloud `platform/fountain-site/patches/deployment.yaml` | one exact origin per app (`https://<host>`, no path) |
-| `OAUTH_CLIENTS` | same file, JSON | `{"id":"<repo-name>","name":"…","redirect_uris":["https://<host>/"]}` — trailing slash, exact |
-| `config/dev.exs` `:oauth_clients` | this repo | add the client with `http://localhost:5173/` and `:5174/` so `bunx vite` can sign in against a local server |
+| Setting | What |
+|---|---|
+| `API_CORS_ORIGINS` | one exact origin per app: `https://<host>` — scheme and host, no path. Off by default; it only ever admits a presented bearer key, since no cookie crosses an origin. |
+| `OAUTH_CLIENTS` | JSON array: `{"id":"<app>","name":"<Title>","redirect_uris":["https://<host>/"]}`. Redirect URIs match exactly, trailing slash included. |
 
-Convention: `client_id` = repo name. If the app *replaces* a first-party
-surface (conversations or team), it is also wired through `Fountain.Apps`
-(`CONVERSATIONS_APP_URL` / `TEAM_APP_URL`) — that seam is the only place the
-server knows where an app lives.
+Who sets them:
 
-Local dev against a local Fountain:
-`API_CORS_ORIGINS=http://localhost:5173 PORT=4000 mix phx.server`. A dev
-instance has no `SPRITES_TOKEN`, so a real turn needs prod or a runner.
+- **Your own Fountain** (self-hosted, `docker compose`, a dev server): you do. For a local server, add the client to `config/dev.exs` `:oauth_clients` with `http://localhost:5173/` and `:5174/` — that is a PR to this repo and benefits every contributor — and run `API_CORS_ORIGINS=http://localhost:5173 mix phx.server`. A dev instance has no sandbox provider token, so a real turn needs a real one.
+- **The hosted instance** (the SDK's default base URL): the operator. Open an issue on this repo with the app's origin and redirect URI; the registration is an env change on their deployment, not a code change.
+
+Convention: `client_id` = repo name. An app that *replaces* a first-party
+surface (conversations or team) is also wired through `Fountain.Apps`
+(`CONVERSATIONS_APP_URL` / `TEAM_APP_URL`) — the only place the server knows
+where an app lives.
 
 ## 6. Ship it
 
-Static → nginx image → GHCR → Flux on home-cloud, at `<name>.inevitable.fyi`
-(wildcard DNS already resolves; GHCR packages under jhgaylor are public).
-The full recipe, file by file, is
-[references/ship.md](references/ship.md). GitHub Pages is the older path
-(`jakegaylor.com/<app>/`) and still works for a pure SPA; the workbench
-moved off it because the demo suite shape is what home-cloud already runs.
+A static SPA needs a static host and nothing else: GitHub Pages
+(`VITE_BASE=/<repo>/`, the redirect URI then carries that path), any CDN, or
+an nginx container. An app with a server ships as one container. The recipe
+the reference apps use, file by file, is
+[references/ship.md](references/ship.md); the only server-side facts are the
+two settings in §5.
 
 ## 7. Before calling it done
 
 - Sign-in tested in **Firefox**, not only headless Chrome (the User-Agent preflight trap).
-- One real turn on prod: hire, message, see blocks render, see `turn/done` on the stream.
-- `bun test` + `tsc --noEmit` green; CI = build.yml on push to main.
-- The Fountain PR (CORS + OAuth client) merged **and deployed** — check `build.yml` on main, then the pod env, before testing sign-in; a green PR gate proves nothing shipped.
+- One real turn against a real instance: hire, message, see blocks render, see `turn/done` on the stream.
+- `bun test` + `tsc --noEmit` green in CI.
+- The CORS + OAuth registration is **live on the instance**, not merely agreed: an `OPTIONS` preflight from your origin returns `access-control-allow-origin` before you test sign-in.
 - Read [references/traps.md](references/traps.md) once; every entry cost a previous app real hours.

--- a/.claude/skills/build-fountain-app/SKILL.md
+++ b/.claude/skills/build-fountain-app/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: build-fountain-app
-description: Build an application on top of the Fountain API — a browser app, a bot, an internal tool, anything that hires agents, sends them prompts and renders what they do. Use whenever the user says "build an app on Fountain", "a client for Fountain", "another fountain-team / workbench / demo app", "Sign in with Fountain", or wants to ship something that talks to /api from its own origin. Covers the shape (static SPA on the SDK, or a small server in front), auth (OAuth code + PKCE, tokens are API keys), streaming, the server-side registration an app needs (API_CORS_ORIGINS, OAUTH_CLIENTS), a hosting recipe for any static host or container, and the traps every previous app hit.
+description: Build an application on top of the Fountain API — a browser app, a bot, an internal tool, anything that hires agents, sends them prompts and renders what they do. Use whenever the user says "build an app on Fountain", "a client for Fountain", "another fountain-team / workbench / demo app", "Sign in with Fountain", or wants to ship something that talks to /api from its own origin. Covers the published TypeScript SDK (@agentshit/fountain-sdk), the shape (static SPA on the SDK, or a small server in front), auth (OAuth code + PKCE, tokens are API keys), streaming, the server-side registration an app needs (API_CORS_ORIGINS, OAUTH_CLIENTS), a hosting recipe for any static host or container, and the traps every previous app hit.
 ---
 
 # Build an app on Fountain
@@ -27,6 +27,59 @@ code, do not re-derive it**:
 - `docs/sdk.md` — the SDK surface, the error table, the browser section
 - `docs/api.md` — every route, incl. *Sign in with Fountain*
 - `sdk/typescript/examples/*.ts` — compiled in CI, so they are true
+
+## The SDK is the client
+
+[`@agentshit/fountain-sdk`](https://www.npmjs.com/package/@agentshit/fountain-sdk)
+is published on npm (1.0.0, Apache-2.0, no runtime dependencies, Node ≥ 20.19,
+browser-safe by default). Its source is `sdk/typescript/` in this repo;
+`docs/sdk.md` is the manual and `sdk/typescript/examples/*.ts` are compiled
+in CI. Do not hand-roll a `fetch` wrapper, an SSE parser or an ACP block
+parser — the SDK is those, done once, and its types are generated from the
+server's OpenAPI document so they cannot drift.
+
+```bash
+npm install @agentshit/fountain-sdk
+```
+
+```ts
+import { Fountain, ConversationBusyError } from "@agentshit/fountain-sdk";
+
+const fountain = new Fountain({ baseUrl, apiKey });   // in a browser: what the person gave you
+const me = await fountain.me();                        // the cheapest check that a key works
+
+// one-shot: an agent on a machine, streamed
+const run = fountain.run("Any disks over 80%?", { agent: "watchtower" });
+for await (const chunk of run.textStream) append(chunk);
+const result = await run;                              // state: done | failed | interrupted | timeout
+
+// a team: hire, message, one stream for the whole roster
+await fountain.team.add("watchtower", { name: "Watchtower" });
+try { await fountain.team.message("watchtower", text); }
+catch (e) { if (e instanceof ConversationBusyError) queue.push(text); else throw e; }
+for await (const ev of fountain.team.stream({ streams: ["stage"] })) route(ev);
+
+// a thread: prompts + parsed blocks, paged to the end
+const conv = fountain.resume(conversationId);
+const [turns, events] = await Promise.all([conv.turns(), conv.history({ streams: ["acp", "stdout"] })]);
+
+// anything the SDK does not wrap
+await fountain.request("GET", "/api/audit", { query: { limit: 50 } });
+```
+
+What it gives you that raw `fetch` does not: `Run` handles you can await or
+stream; `blocks: true` on every feed; reconnect from the last event id; the
+name-or-id resolver on agents/environments/vaults; and one error class per
+server `code` (`ConversationBusyError`, `NotReadyError` with `retryAfter`,
+`QuotaExceededError`, `SubscriptionRequiredError` with `upgradeUrl`,
+`ValidationError` with `fieldErrors`, `ConnectionError` — in a browser,
+CORS). In Node the credentials resolve from `FOUNTAIN_API_KEY` /
+`FOUNTAIN_BASE_URL` and `~/.fountain/credentials`, same as the CLI; in a
+browser you pass them. Add nothing to its headers (see the Firefox trap).
+
+The SDK versions independently of the server; the API is additive, so an
+older SDK keeps working against a newer Fountain. Other languages: the
+OpenAPI document at `GET /api/openapi.json` is the contract.
 
 ## 1. Decide the shape
 

--- a/.claude/skills/build-fountain-app/references/ship.md
+++ b/.claude/skills/build-fountain-app/references/ship.md
@@ -1,53 +1,43 @@
-# Ship an app to home-cloud (`<name>.inevitable.fyi`)
+# Ship an app
 
-The demo-suite shape: every app is its own repo under `jhgaylor/`, builds an
-nginx (or Bun) image on GitHub Actions, pushes to GHCR, pins the sha into its
-own `k8s/deployment.yaml`, and Flux in `jhgaylor/home-cloud` rolls it. Copy
-the files from `~/dev/jhgaylor/fountain-demos` (pure static) or
-`~/dev/BinaryBourbon/fountain-workbench` (static + Bun server + SQLite PVC).
+The only server-side facts an app depends on are `API_CORS_ORIGINS` and
+`OAUTH_CLIENTS` on the Fountain it talks to (SKILL.md §5). Everything below
+is about hosting the app itself, which needs nothing from Fountain.
 
-## Files
+## Static SPA
 
-| File | Notes |
+`bun run build` → `dist/`. Host it anywhere that serves files:
+
+| Host | Notes |
 |---|---|
-| `Dockerfile` | `nginx:alpine` + `COPY dist/` (static) or `oven/bun:1-alpine` + `COPY server/ shared/ dist/`. **Build the SPA on the runner, not in the image** — the image stage is a plain copy, so multi-arch costs nothing and no QEMU bun. |
-| `nginx.conf` | SPA fallback to `index.html`; `/assets/*` immutable 1y; everything else `no-cache`; `/healthz` 200. |
-| `.dockerignore` | `node_modules`, `.git`, `src` (dist is what ships). |
-| `.github/workflows/ci.yml` | on PR + main: `bun install --frozen-lockfile`, `typecheck`, `bun test`, `build`, upload `dist`. |
-| `.github/workflows/build.yml` | on push to main (`paths-ignore: k8s/**, README.md`): buildx `linux/amd64,linux/arm64` (home-cloud's k3s nodes are arm64 Lima VMs) → `ghcr.io/jhgaylor/<name>:{latest,sha-<sha>}` → `sed` the sha into `k8s/deployment.yaml` → bot commit `deploy: pin image sha-…`. `concurrency: build-main`, `cancel-in-progress: false`. |
-| `k8s/namespace.yaml`, `deployment.yaml`, `service.yaml`, `ingressroute.yaml` (websecure + web→https redirect, Traefik), `certificates.yaml` (`letsencrypt-production`), `kustomization.yaml` | Probes on `/healthz`. A server with SQLite: `replicas: 1`, `strategy: Recreate`, 1Gi Longhorn RWO PVC, `envFrom` secretRef `optional: true`. |
+| GitHub Pages | `VITE_BASE=/<repo>/`; the redirect URI is `https://<user>.github.io/<repo>/` (or the custom domain), path included. fountain-team's `.github/workflows/pages.yml` is the template. |
+| A CDN / object bucket | Nothing special; SPA fallback to `index.html` if the app uses path routing (hash routing avoids the need). |
+| An nginx container | `nginx:alpine` + `COPY dist/`, `try_files $uri $uri/ /index.html`, `/assets/*` immutable 1y, everything else `no-cache`, a `/healthz` that returns 200. fountain-demos' `Dockerfile` + `nginx.conf` is the template. |
 
-Wildcard DNS `*.inevitable.fyi` already resolves. GHCR packages under
-`jhgaylor` are born public. Static-only apps can alternatively stay on GitHub
-Pages at `jakegaylor.com/<repo>/` (fountain-team does; `VITE_BASE=/<repo>/`,
-`pages.yml`) — the redirect URI then has that path.
+**Build the SPA on the CI runner, not inside the image.** The image stage is
+then a plain copy, so a multi-arch build costs nothing and no emulated bun
+runs under QEMU.
 
-## Onboarding to home-cloud (a home-cloud PR)
+CI (`ci.yml`, on PR + main): `bun install --frozen-lockfile`, `typecheck`,
+`bun test`, `build`, upload `dist`. A release workflow (`build.yml`, on push
+to main) builds and pushes the image tagged `latest` and `sha-<commit>`;
+pinning the sha into your deployment manifest from the workflow is what
+makes a rollout reproducible. `paths-ignore` the manifest you pin into, or
+the pin commit re-triggers the build.
 
-`chant/src/apps.ts` + `names.ts` → `npm run build` in `chant/` regenerates
-`clusters/home/control-plane/manifests.yaml` (a `GitRepository` + a
-`Kustomization` per app). After merge, a new Kustomization can sit on
-`dependency cert-manager is not ready` with stale status until
-`flux reconcile kustomization flux-system` cascades; the pods are usually fine.
+## An app with a server
 
-## Registering with Fountain (a fountain PR)
+One container: `oven/bun:1-alpine` + `COPY server/ shared/ dist/`, the server
+serving `dist/` itself (hashed assets immutable, the rest `no-cache`, unknown
+paths → `index.html`). Env: `FOUNTAIN_URL`, `PORT`, `DATA_DIR` (a volume, if
+SQLite), a secret for session/cookie signing that is generated to `DATA_DIR`
+when unset. One replica with `Recreate` if the state is a local SQLite file.
+fountain-workbench's `Dockerfile`, `server/config.ts` and `k8s/` are the
+template; the Kubernetes files there (Deployment, Service, ingress, cert) are
+ordinary and translate to any cluster or a single VM with a reverse proxy.
 
-`~/dev/jhgaylor/home-cloud/platform/fountain-site/patches/deployment.yaml`:
+## Verify after deploy
 
-- append `https://<name>.inevitable.fyi` to `API_CORS_ORIGINS` (exact origin, comma-separated, no path);
-- append `{"id":"<name>","name":"<Title>","redirect_uris":["https://<name>.inevitable.fyi/"]}` to the `OAUTH_CLIENTS` JSON.
-
-And in this repo, `config/dev.exs` `:oauth_clients` gets the same id with
-`http://localhost:5173/` and `http://localhost:5174/`.
-
-Deploy is a Flux reconcile of `fountain-site`; confirm the pod env before
-testing sign-in (`kubectl -n fountain exec deploy/fountain -- env | grep OAUTH`).
-A deploy rolls the pods, which kills any provision in flight — check for
-`starting` sandboxes first.
-
-## Verify
-
-1. `curl -sI -H 'Origin: https://<name>.inevitable.fyi' -H 'Access-Control-Request-Method: GET' -X OPTIONS https://fountain.inevitable.fyi/api/auth/me` → `access-control-allow-origin` present.
-2. Sign in from the hosted build in **Firefox** and Chrome; a stray `oauth:<name>` key per failed attempt under Account → API keys means the callback threw after the exchange.
+1. `curl -sI -X OPTIONS -H 'Origin: https://<host>' -H 'Access-Control-Request-Method: GET' https://<fountain>/api/auth/me` → an `access-control-allow-origin` header. Without it, every call from the app fails before it starts.
+2. Sign in from the hosted build in **Firefox** and Chrome. A stray `oauth:<app>` key per failed attempt under Account → API keys means the callback threw *after* the token exchange — look at what ran next, usually `me()`.
 3. Hire a teammate, send one message, watch `turn/done` arrive on the stream.
-4. Traps from previous rollouts: `build.yml` sometimes doesn't fire on the repo-creation push (`gh workflow run build`); `ImagePullBackOff` on the `sha-000…` placeholder means Flux hasn't fetched the pin commit (`flux reconcile source git <name>`).

--- a/.claude/skills/build-fountain-app/references/ship.md
+++ b/.claude/skills/build-fountain-app/references/ship.md
@@ -1,0 +1,53 @@
+# Ship an app to home-cloud (`<name>.inevitable.fyi`)
+
+The demo-suite shape: every app is its own repo under `jhgaylor/`, builds an
+nginx (or Bun) image on GitHub Actions, pushes to GHCR, pins the sha into its
+own `k8s/deployment.yaml`, and Flux in `jhgaylor/home-cloud` rolls it. Copy
+the files from `~/dev/jhgaylor/fountain-demos` (pure static) or
+`~/dev/BinaryBourbon/fountain-workbench` (static + Bun server + SQLite PVC).
+
+## Files
+
+| File | Notes |
+|---|---|
+| `Dockerfile` | `nginx:alpine` + `COPY dist/` (static) or `oven/bun:1-alpine` + `COPY server/ shared/ dist/`. **Build the SPA on the runner, not in the image** — the image stage is a plain copy, so multi-arch costs nothing and no QEMU bun. |
+| `nginx.conf` | SPA fallback to `index.html`; `/assets/*` immutable 1y; everything else `no-cache`; `/healthz` 200. |
+| `.dockerignore` | `node_modules`, `.git`, `src` (dist is what ships). |
+| `.github/workflows/ci.yml` | on PR + main: `bun install --frozen-lockfile`, `typecheck`, `bun test`, `build`, upload `dist`. |
+| `.github/workflows/build.yml` | on push to main (`paths-ignore: k8s/**, README.md`): buildx `linux/amd64,linux/arm64` (home-cloud's k3s nodes are arm64 Lima VMs) → `ghcr.io/jhgaylor/<name>:{latest,sha-<sha>}` → `sed` the sha into `k8s/deployment.yaml` → bot commit `deploy: pin image sha-…`. `concurrency: build-main`, `cancel-in-progress: false`. |
+| `k8s/namespace.yaml`, `deployment.yaml`, `service.yaml`, `ingressroute.yaml` (websecure + web→https redirect, Traefik), `certificates.yaml` (`letsencrypt-production`), `kustomization.yaml` | Probes on `/healthz`. A server with SQLite: `replicas: 1`, `strategy: Recreate`, 1Gi Longhorn RWO PVC, `envFrom` secretRef `optional: true`. |
+
+Wildcard DNS `*.inevitable.fyi` already resolves. GHCR packages under
+`jhgaylor` are born public. Static-only apps can alternatively stay on GitHub
+Pages at `jakegaylor.com/<repo>/` (fountain-team does; `VITE_BASE=/<repo>/`,
+`pages.yml`) — the redirect URI then has that path.
+
+## Onboarding to home-cloud (a home-cloud PR)
+
+`chant/src/apps.ts` + `names.ts` → `npm run build` in `chant/` regenerates
+`clusters/home/control-plane/manifests.yaml` (a `GitRepository` + a
+`Kustomization` per app). After merge, a new Kustomization can sit on
+`dependency cert-manager is not ready` with stale status until
+`flux reconcile kustomization flux-system` cascades; the pods are usually fine.
+
+## Registering with Fountain (a fountain PR)
+
+`~/dev/jhgaylor/home-cloud/platform/fountain-site/patches/deployment.yaml`:
+
+- append `https://<name>.inevitable.fyi` to `API_CORS_ORIGINS` (exact origin, comma-separated, no path);
+- append `{"id":"<name>","name":"<Title>","redirect_uris":["https://<name>.inevitable.fyi/"]}` to the `OAUTH_CLIENTS` JSON.
+
+And in this repo, `config/dev.exs` `:oauth_clients` gets the same id with
+`http://localhost:5173/` and `http://localhost:5174/`.
+
+Deploy is a Flux reconcile of `fountain-site`; confirm the pod env before
+testing sign-in (`kubectl -n fountain exec deploy/fountain -- env | grep OAUTH`).
+A deploy rolls the pods, which kills any provision in flight — check for
+`starting` sandboxes first.
+
+## Verify
+
+1. `curl -sI -H 'Origin: https://<name>.inevitable.fyi' -H 'Access-Control-Request-Method: GET' -X OPTIONS https://fountain.inevitable.fyi/api/auth/me` → `access-control-allow-origin` present.
+2. Sign in from the hosted build in **Firefox** and Chrome; a stray `oauth:<name>` key per failed attempt under Account → API keys means the callback threw after the exchange.
+3. Hire a teammate, send one message, watch `turn/done` arrive on the stream.
+4. Traps from previous rollouts: `build.yml` sometimes doesn't fire on the repo-creation push (`gh workflow run build`); `ImagePullBackOff` on the `sha-000…` placeholder means Flux hasn't fetched the pin commit (`flux reconcile source git <name>`).

--- a/.claude/skills/build-fountain-app/references/sign-in.md
+++ b/.claude/skills/build-fountain-app/references/sign-in.md
@@ -1,0 +1,120 @@
+# Sign in with Fountain (OAuth 2.0 code + PKCE)
+
+This is `src/lib/oauth.ts` from fountain-team, which the workbench and every
+demo app copied. Change `CLIENT_ID` and the stash key; nothing else.
+
+Facts that shape it (ADR 0021, `docs/api.md`):
+
+- Public client, S256 only, **no client secret, no scope parameter, no refresh token**.
+- `redirect_uri` must match a registered entry **exactly** (trailing slash and all). The app's own page with the hash cleared is the convention.
+- The code lives 5 minutes and works once. Consent is at `GET /oauth/authorize`; a signed-out user round-trips through login and comes back.
+- The `access_token` **is an `ftn_…` API key**: full scope, 30 days, listed under Account → API keys as `oauth:<client_id>`. Store it exactly as you would a pasted key (`localStorage`, `{baseUrl, apiKey, via: "paste" | "oauth"}`), and on sign-out `POST /api/oauth/revoke` when `via === "oauth"`.
+- Nothing refreshes. When the key expires, the next 401 sends the person back to sign-in. A 401 should show "That key was not accepted", not loop.
+- The token endpoint says `invalid_grant` for every wrong grant and is rate-limited per IP. It never says which check failed.
+
+```ts
+import { normalizeBaseUrl } from "./settings";
+
+const CLIENT_ID = "my-app";            // = the repo name, registered in OAUTH_CLIENTS
+const STASH = "my-app.oauth";
+
+function base64url(bytes: ArrayBuffer): string {
+  let s = "";
+  const b = new Uint8Array(bytes);
+  for (let i = 0; i < b.length; i++) s += String.fromCharCode(b[i]!);
+  return btoa(s).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function randomString(bytes = 32): string {
+  const a = new Uint8Array(bytes);
+  crypto.getRandomValues(a);
+  return base64url(a.buffer);
+}
+
+async function challengeFor(verifier: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(verifier));
+  return base64url(digest);
+}
+
+/** Must match a `redirect_uris` entry registered for the client on the server. */
+export function redirectUri(): string {
+  return window.location.origin + window.location.pathname;
+}
+
+export async function beginLogin(baseUrl: string): Promise<void> {
+  const verifier = randomString();
+  const state = randomString(16);
+  const challenge = await challengeFor(verifier);
+  const base = normalizeBaseUrl(baseUrl);
+  sessionStorage.setItem(STASH, JSON.stringify({ verifier, state, baseUrl: base }));
+  const q = new URLSearchParams({
+    client_id: CLIENT_ID,
+    redirect_uri: redirectUri(),
+    response_type: "code",
+    code_challenge: challenge,
+    code_challenge_method: "S256",
+    state,
+  });
+  window.location.href = `${base}/oauth/authorize?${q}`;
+}
+
+export interface CallbackResult { baseUrl: string; apiKey: string }
+
+/** null when this page load is not an OAuth callback; throws on a real failure. */
+export async function completeLoginIfCallback(): Promise<CallbackResult | null> {
+  const params = new URLSearchParams(window.location.search);
+  const code = params.get("code");
+  const error = params.get("error");
+  const state = params.get("state");
+  if (!code && !error) return null;
+
+  const stashed = sessionStorage.getItem(STASH);
+  sessionStorage.removeItem(STASH);
+  clearOAuthParams();
+
+  if (error) throw new Error(error === "access_denied" ? "Sign-in was denied." : `Sign-in failed: ${error}`);
+  if (!stashed) throw new Error("Sign-in could not be completed (no pending request in this browser).");
+
+  const { verifier, state: expected, baseUrl } = JSON.parse(stashed) as { verifier: string; state: string; baseUrl: string };
+  if (!state || state !== expected) throw new Error("Sign-in state did not match — try again.");
+
+  const res = await fetch(`${baseUrl}/api/oauth/token`, {
+    method: "POST",
+    headers: { "content-type": "application/json", accept: "application/json" },
+    body: JSON.stringify({ grant_type: "authorization_code", code, code_verifier: verifier, client_id: CLIENT_ID, redirect_uri: redirectUri() }),
+  });
+  if (!res.ok) throw new Error("Fountain rejected the sign-in. Try again.");
+  const body = (await res.json()) as { access_token: string };
+  return { baseUrl, apiKey: body.access_token };
+}
+
+export async function revoke(baseUrl: string, apiKey: string): Promise<void> {
+  try {
+    await fetch(`${baseUrl}/api/oauth/revoke`, { method: "POST", headers: { authorization: `Bearer ${apiKey}` } });
+  } catch { /* signing out locally is what matters */ }
+}
+
+function clearOAuthParams(): void {
+  const url = new URL(window.location.href);
+  ["code", "state", "error", "error_description"].forEach((k) => url.searchParams.delete(k));
+  window.history.replaceState({}, "", url.pathname + url.search + url.hash);
+}
+```
+
+App-side wiring (fountain-team `src/App.tsx`): seed an `oauthBusy` flag
+synchronously from `/[?&](code|error)=/.test(location.search)` so the
+settings screen never flashes during the callback; then
+`completeLoginIfCallback()` → `GET /api/auth/me` → save settings. **Keep the
+minted token even if `me()` fails** — otherwise a CORS mistake orphans a key
+per attempt.
+
+## The workbench variant (an app with a server)
+
+The browser runs the same PKCE code, but only to obtain a key it then hands to
+its own server once (`POST /api/session { apiKey }`) and forgets. The server
+verifies with `GET /api/auth/me`, keys the identity on the lowercased email,
+stores the key AES-256-GCM encrypted, and issues an `HttpOnly; SameSite=Lax`
+session cookie. Sign-out keeps the stored key on purpose: a shared project
+does not stop when its owner closes a tab. The browser then builds
+`new Fountain({ baseUrl: "<origin>/f/<project>", apiKey: "session" })` — the
+placeholder is swapped by the proxy — and CORS is not involved at all.

--- a/.claude/skills/build-fountain-app/references/traps.md
+++ b/.claude/skills/build-fountain-app/references/traps.md
@@ -1,0 +1,49 @@
+# Traps every previous app hit
+
+Read once. Each entry cost real hours in fountain-team, fountain-workbench,
+dns-desk or the demo suite. Issue numbers are BinaryBourbon/fountain unless
+noted.
+
+## Transport
+
+- **`ConnectionError` / "Failed to fetch" in a browser is CORS**, not your code. The origin is missing from `API_CORS_ORIGINS`. Show it as such (fountain-team: "Check the URL, and that API_CORS_ORIGINS on the server includes this site").
+- **Firefox sends a page-set `User-Agent`; Chrome drops it.** Any custom header turns every call into a preflight, and the server's allow-list is static. SDK ≥ 0.1.5 no longer stamps UA in a browser and the plug admits `user-agent` (#1062), but **do not add custom headers of your own** and smoke in Firefox, not only headless Chrome. The workbench server uses plain `fetch` rather than the SDK on proxied calls precisely so it stamps nothing.
+- **`EventSource` cannot send `Authorization`.** Streams are read with `fetch` and parsed by hand (SSE spec: blank-line records, `id:`/`event:`/`data:`, `:` heartbeats). The SDK's `stream()`/`team.stream()` do this and reconnect from their own last id; if you hand-roll, send `Last-Event-ID`, back off 1s→×2→15s cap, and `refresh()` on every open because a reconnect can miss a turn-end.
+- **`/api/events/stream` follows unfinished conversations only** (#1060): one that fails or finishes before the debounced re-follow leaves a gap the stream never fills. Workaround: on any change to `turn_count` / `status` / `sandbox.status`, re-read `history({ after: lastSeenId })` and merge by event id — and merge live events into an in-flight history fetch, or the live ones get overwritten.
+- **The Vite `FOUNTAIN_PROXY` dev trick breaks OAuth** — the redirect goes to the real origin. With the proxy, paste a key.
+- Raise the SDK `timeoutMs` (30s default) to ~120s for terminate — it waits on sprite teardown. Mutations should ignore a client abort; a terminate half-way through must finish whether or not the tab is still there.
+
+## Data model
+
+- **A channel binds exactly one conversation.** A second create on the same `channel_id` with `fresh: true` *steals* the binding; without `fresh` it *resumes*. Mint a per-conversation tag (`app:<scope>/<id>/<tag>`) and read the scope off the prefix.
+- **A pending conversation lies about its sandbox** (#839): opened without a prompt it stays `pending`, and `presence` reads "starting computer" even once the sandbox is `ready`. Read `conversation.sandbox.status` too. The conversation list carries only `sandbox_id`; fetch the sandbox record separately, re-read when a conversation on it changes status.
+- **There is no "destroy sandbox".** A sprite dies with the last live conversation on it; a machine something else still holds stays up. Report what actually went.
+- **Two "fresh thread" semantics.** `POST /api/team/:id/conversations` retires the thread and keeps the computer; to get a *new* computer, `terminate` first, then the same call.
+- **Sharing a sandbox** is `sandbox_id` on the create body (ADR 0023); unknown keys are ignored by older servers, so compare the returned `conversation.sandbox_id` with what you asked for and say so when it differs. Identity is `(agent, environment, vault)`.
+- Fountain has **no pins, mutes, drafts, prefs, projects, or sharing**. Per-browser things go in `localStorage`; cross-user things need your own server. An app with a server should return **404, not 403**, for a resource the caller isn't a member of.
+- **Secret values are write-only.** `secrets.list()` returns keys. Connectors reference `${VAR}`; the token never reaches the model, and any sandbox env value ≥ 8 bytes persists as `[REDACTED]`.
+
+## Rendering
+
+- **Use `?blocks=true`** (the SDK sets it). fountain-team predates it and carries a 200-line port of the server's ACP parser (`src/lib/acp.ts`); do not copy that.
+- **Permission requests**: never synthesise an option the agent did not offer (the server 422s `unknown_option`); first answer wins so a 409 `permission_request_resolved` is normal; read the `outcome` field, not `state` — `state` is `done` for a deny too. Log events are immutable, so the resolution arrives as a separate `request` stage event paired on `request_id`. "Always allow" (claude-agent-acp) is a rule for the exact command line, in the sandbox, and dies with it.
+- Parse markdown to React elements, never HTML; agent output is untrusted.
+- An `<img src>` at `/api/agents/:id/avatar` or a turn image is a 401 — fetch with the bearer, `URL.createObjectURL`, revoke later.
+- Older Fountains have no `catalog.apps`; a transcript deep-link is `<apps.conversations>/#/c/<id>` with the `/conversations/:id` redirect as fallback.
+
+## Errors
+
+- Branch on `code`, not status: `conversation_busy` 400, `provisioning` / `sprite_probe_failed` / `fleet_full` 503 (carry `Retry-After`), `sandbox_quota_exceeded` 429, `insufficient_credits` 402 (`upgrade_url`), 422 `fieldErrors`. `starting` is deliberately *not* busy: attempt the send and let the server decide.
+- Both fountain-team and the workbench keep a `describeError(err)` table mapping codes to copy (`environment_not_allowed`, `runner_offline`, `no_runner_online`, `team_comms_not_enabled`, `provider_error` with `body.channel`, …). Start from theirs.
+
+## Testing
+
+- Test against a **fake Fountain**, but shape its responses from the real API: the SDK's fake once wrapped a response in an envelope the real API omits, and the suite was green while prod returned null. Verify the shape with one real call before writing the fake.
+- A dev Fountain has no `SPRITES_TOKEN`; a real turn needs prod (or a self-hosted runner). Dev login for a local server smoke: create a user via the UI; consent buttons are `Deny` / `Allow`.
+- Headless-Chrome CDP smokes set React inputs via the native value setter + `input`/`change` events. Then run it again in Firefox (Marionette).
+
+## SDK
+
+- `@agentshit/fountain-sdk` 1.0.0 (2026-08-25): credits vocabulary; `402 insufficient_credits` maps to `SubscriptionRequiredError` (name kept); `fleet_full` → `NotReadyError`.
+- Anything the SDK does not wrap: `fountain.request(method, path, { query, body })` or `fountain.api.raw(...)` for bytes.
+- An OpenAPI property with a `default:` generates as **required** in the SDK types; if a call won't typecheck for a field the server defaults, that is why (fix in `schemas.ex` → regenerate, not in the app).


### PR DESCRIPTION
## What

A Claude Code skill at `.claude/skills/build-fountain-app/` for building an application on top of the Fountain API, in the shape the three reference apps already share:

- **fountain-team** — static SPA, raw fetch, PKCE sign-in
- **fountain-workbench** — SPA + Bun server that holds the owner's key and proxies a narrowed `/api`
- **fountain-demos** + the `*.inevitable.fyi` suite — one static app per repo, the hosting recipe

`SKILL.md` is the router (shape decision, stack, auth, the four things a chat app is judged on, server-side registration, ship, done-checklist) and points at `docs/build/*`, `docs/sdk.md` and the SDK examples rather than restating them. Three references:

- `references/sign-in.md` — the ~80-line PKCE flow the apps ship, verbatim, plus the workbench's server-session variant
- `references/ship.md` — Dockerfile / build.yml / k8s / home-cloud onboarding / the fountain-side `API_CORS_ORIGINS` + `OAUTH_CLIENTS` + `dev.exs` entries, and how to verify
- `references/traps.md` — the things that cost previous apps hours (Firefox User-Agent preflight, the `/api/events/stream` gap #1060, channel binding steals on `fresh`, #839 pending sandbox, permission `outcome` vs `state`, the fake-server envelope, SDK `default:` → required)

## Why

Every new app so far has been built by re-reading the previous one. The demo suite copied dns-desk's client eight times; the workbench hit the Firefox CORS trap the SDK had just fixed. The skill is where that knowledge stops being re-derived.

No code or docs paths change; nothing in CI reads `.claude/skills`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)