### PR TITLE
fix(credits): the pricer priced nothing on the cron, and rent ignored comp

### DIFF
--- a/ee/lib/fountain/credits/rent.ex
+++ b/ee/lib/fountain/credits/rent.ex
@@ -48,9 +48,10 @@ defmodule Fountain.Credits.Rent do
   """
   @spec check_provision(binary()) :: :ok | {:error, :insufficient_credits}
   def check_provision(user_id) when is_binary(user_id) do
-    if Credits.enforcing?() and month_cents() > 0 and Credits.balance(user_id) < month_cents(),
-      do: {:error, :insufficient_credits},
-      else: :ok
+    if Credits.enforcing?() and not comped?(user_id) and month_cents() > 0 and
+         Credits.balance(user_id) < month_cents(),
+       do: {:error, :insufficient_credits},
+       else: :ok
   end
 
   @doc """
@@ -70,7 +71,8 @@ defmodule Fountain.Credits.Rent do
       not charging?() ->
         {:ok, :free}
 
-      Credits.enforcing?() and Credits.balance(contact.user_id) < cents ->
+      Credits.enforcing?() and not comped?(contact.user_id) and
+          Credits.balance(contact.user_id) < cents ->
         {:ok, _} = stamp(contact, rent_due_at: contact.rent_due_at || truncate(now))
         {:error, :insufficient_credits}
 
@@ -214,6 +216,15 @@ defmodule Fountain.Credits.Rent do
     day = min(date.day, Date.days_in_month(Date.new!(y, m, 1)))
     {:ok, next} = DateTime.new(Date.new!(y, m, day), DateTime.to_time(at), "Etc/UTC")
     truncate(next)
+  end
+
+  # A comped account is never refused anything (Billing.comp_account/2), rent
+  # included: the month is still written, so Finance sees the cost.
+  defp comped?(user_id) do
+    case Fountain.Accounts.get_user(user_id) do
+      %{comped: true} -> true
+      _ -> false
+    end
   end
 
   defp truncate(dt), do: DateTime.truncate(dt, :second)

--- a/ee/lib/fountain/workers/credit_pricer.ex
+++ b/ee/lib/fountain/workers/credit_pricer.ex
@@ -67,18 +67,20 @@ defmodule Fountain.Workers.CreditPricer do
   """
   @spec run(keyword()) :: %{turns: non_neg_integer(), messages: non_neg_integer()}
   def run(opts \\ []) do
-    since = Keyword.get(opts, :since)
-
-    cond do
-      not Billing.enabled?() -> %{turns: 0, messages: 0}
-      is_nil(since) -> %{turns: 0, messages: 0}
-      true -> do_run(floor(since, Keyword.get(opts, :now) || DateTime.utc_now()))
-    end
-  end
-
-  defp floor(since, now) do
+    now = Keyword.get(opts, :now) || DateTime.utc_now()
     lookback = DateTime.add(now, -@lookback_days * 86_400, :second)
-    if DateTime.compare(since, lookback) == :gt, do: since, else: lookback
+
+    # `:since` is a test override that can only narrow the window.
+    floor =
+      case Keyword.get(opts, :since) do
+        %DateTime{} = since ->
+          if DateTime.compare(since, lookback) == :gt, do: since, else: lookback
+
+        nil ->
+          lookback
+      end
+
+    if Billing.enabled?(), do: do_run(floor), else: %{turns: 0, messages: 0}
   end
 
   defp do_run(floor) do

--- a/ee/test/fountain/credits_rent_test.exs
+++ b/ee/test/fountain/credits_rent_test.exs
@@ -99,6 +99,17 @@ defmodule Fountain.Credits.RentTest do
       :ok
     end
 
+    test "a comped account is never refused rent, and never enters the grace" do
+      {:ok, user} = Fountain.Billing.comp_account(insert_empty_user())
+      assert :ok = Rent.check_provision(user.id)
+      c = contact(user, %{rent_paid_through: ~U[2026-08-01 00:00:00Z]})
+
+      assert {:ok, %Contact{rent_due_at: nil}} =
+               Rent.charge(c, ~U[2026-08-01 00:00:00Z], now: ~U[2026-08-02 00:00:00Z])
+
+      assert Credits.balance(user.id) == -500
+    end
+
     test "provisioning is refused below a month, and allowed at it" do
       user = insert_empty_user()
       assert {:error, :insufficient_credits} = Rent.check_provision(user.id)

--- a/ee/test/fountain/workers/credit_pricer_test.exs
+++ b/ee/test/fountain/workers/credit_pricer_test.exs
@@ -31,8 +31,6 @@ defmodule Fountain.Workers.CreditPricerTest do
     conv = setup_conv(user)
     closed_turn(conv, ~U[2026-08-02 10:00:00Z], 3600)
 
-    assert %{turns: 0, messages: 0} = CreditPricer.run(now: @now)
-
     Application.put_env(:fountain, :billing_enabled, false)
     on_exit(fn -> Application.put_env(:fountain, :billing_enabled, true) end)
     assert %{turns: 0, messages: 0} = CreditPricer.run(since: @since, now: @now)
@@ -142,7 +140,17 @@ defmodule Fountain.Workers.CreditPricerTest do
     end
   end
 
-  test "perform/1 is a thin shell over run/1" do
+  test "perform/1 prices a turn closed within the last seven days — no option needed" do
+    user = insert_empty_user()
+    conv = setup_conv(user)
+
+    closed_turn(
+      conv,
+      DateTime.add(DateTime.utc_now(), -3600, :second) |> DateTime.truncate(:second),
+      3600
+    )
+
     assert :ok = CreditPricer.perform(%Oban.Job{args: %{}})
+    assert Credits.balance(user.id) == -25
   end
 end


### PR DESCRIPTION
Two bugs the billing review surfaced; both mine.

1. **Nothing has burned since #1121 deployed.** `CreditPricer.run/1` kept the `is_nil(since) -> zeros` branch after the env var went away, and `perform/1` passes no `:since`. Every ten-minute run returned `%{turns: 0, messages: 0}`. Now the seven-day look-back is the floor and `:since` only narrows it; the `perform/1` test closes a real turn and asserts −25¢. The next cron run after deploy prices the backlog from the last seven days (nine hours' worth, at most).
2. **A comped account could lose its number.** `Credits.Rent.check_provision/1` and `charge/3` checked only enforcement and the balance; a comped tenant at $0 would be refused a contact, stamped into the grace, emailed, and released on day 7. Comp is never refused anything: rent is still written (Finance sees the cost) and never refused. Test added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)