### PR TITLE
docs(adr): persistent-home rent is machine pricing, not a price on a mode

### DIFF
--- a/decisions/0023-persistent-agent-sandbox.md
+++ b/decisions/0023-persistent-agent-sandbox.md
@@ -144,7 +144,10 @@ should not answer at 3am is an agent whose channel is muted, not a machine
 that refuses to boot. `wake_policy_test.exs` states it.
 
 Open from the questions list: pricing the mode rather than the
-sandbox-minutes (#798).
+sandbox-minutes (#798). Now tracked as #1120 (rent for a persistent home,
+ADR 0031 decision 7). Note the framing there: the two modes are one
+lifecycle policy on the machine (#805), so the price goes on the machine's
+kept time, not on `persistent` as a product.
 
 ## Context
 

--- a/decisions/0031-credits-are-the-product.md
+++ b/decisions/0031-credits-are-the-product.md
@@ -92,9 +92,15 @@ exactly the customers who spend the most.
    `CREDIT_PRICING_SINCE` are retired as switches: pricing starts when
    billing is on.
 
-7. **Persistent-home rent is a follow-up.** Idle time on a parked home
-   (ADR 0023) is Fountain's cost and the fleet ceiling is what bounds it for
-   now; pricing the mode (#798) is decided separately.
+7. **Persistent-home rent is a follow-up (#1120).** Idle time on a parked
+   home (ADR 0023) is Fountain's cost and the fleet ceiling is what bounds it
+   for now. The question is not "rent for a mode": `ephemeral` and
+   `persistent` are one lifecycle policy on the machine, not two products
+   (#805, the design note 0023 is the incremental step toward), and a parked
+   ephemeral sandbox costs Fountain the same storage as a parked home. What
+   #1120 has to choose is whether the machine's *kept* time is priced as rent
+   per machine (the `Credits.Rent` shape) or metered per parked minute (#798,
+   what `SandboxUsage` is halfway to). Read #805 before deciding.
 
 ## Consequences
 


### PR DESCRIPTION
Docs only. Amends ADR 0031 decision 7 and ADR 0023's open pricing line so the trail says what #1120 is actually deciding: the two `sandbox_mode` values are one lifecycle policy on the machine (#805, which 0023 is the incremental step toward), so persistent-home rent is a question about pricing a machine's *kept* time (rent per machine vs metering per parked minute, #798), not a price on `persistent` as a product. Matching comments are on #1120 and #805.

`okf validate decisions` passes; the index did not change.

Refs #1120, #805, #798.

🤖 Generated with [Claude Code](https://claude.com/claude-code)