### PR TITLE
feat(brand): PRODUCT_NAME brands the chrome; the manual stays Fountain and says why

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -117,6 +117,12 @@ SPRITES_TOKEN=
 # deployment, and nobody else's.
 # MARKETING_SITE=true
 
+# What the console, the sign-in page, the OAuth consent screen and every email
+# subject call this deployment. The CLI, the API and the manual keep saying
+# Fountain (that is the engine's name); with a different brand set, every
+# manual page opens with a line explaining the split. Default: Fountain.
+# PRODUCT_NAME=Managoat
+
 # ── Legal pages ──────────────────────────────────────────────────────────────
 
 # The legal identity /terms and /privacy render — yours, not the Fountain

--- a/apps/fountain/lib/fountain/brand.ex
+++ b/apps/fountain/lib/fountain/brand.ex
@@ -1,0 +1,45 @@
+defmodule Fountain.Brand do
+  @moduledoc """
+  The name this deployment goes by.
+
+  Fountain is the engine: the CLI, the API, the SDK, the env vars and the
+  manual all carry its name, and none of that changes per deployment. What
+  does change is what the *chrome* says: the sidebar header, the `<title>`,
+  the sign-in page, the OAuth consent screen and the subject line of every
+  email. A hosted deployment sold under another brand (`PRODUCT_NAME`) puts
+  that brand there and nowhere else, the way GitLab.com is GitLab and Grafana
+  Cloud is Grafana.
+
+  The manual is the one place both names show up, on purpose: a reader of the
+  hosted docs types `fountain auth login`, so the word Fountain has to be on
+  the page. `hosted?/0` is what lets the docs layout explain that once, at the
+  top, rather than the reader working it out.
+  """
+
+  @engine "Fountain"
+
+  @doc "The engine's name. Never configurable; it is what the code is called."
+  @spec engine() :: String.t()
+  def engine, do: @engine
+
+  @doc """
+  The deployment's brand: `PRODUCT_NAME`, or `"Fountain"` when unset or blank.
+  """
+  @spec name() :: String.t()
+  def name do
+    case Application.get_env(:fountain, :product_name) do
+      value when is_binary(value) ->
+        case String.trim(value) do
+          "" -> @engine
+          trimmed -> trimmed
+        end
+
+      _ ->
+        @engine
+    end
+  end
+
+  @doc "True when the deployment is branded as something other than the engine."
+  @spec hosted?() :: boolean()
+  def hosted?, do: name() != @engine
+end

--- a/apps/fountain/lib/fountain/emails/user_emails.ex
+++ b/apps/fountain/lib/fountain/emails/user_emails.ex
@@ -34,7 +34,7 @@ defmodule Fountain.Emails.UserEmails do
     new()
     |> from(from_address())
     |> to({user.email, user.email})
-    |> subject("Verify your Fountain account")
+    |> subject("Verify your #{brand()} account")
     |> html_body(verification_html(verify_url))
     |> text_body(verification_text(verify_url))
     |> Mailer.deliver()
@@ -54,7 +54,7 @@ defmodule Fountain.Emails.UserEmails do
     new()
     |> from(from_address())
     |> to({user.email, user.email})
-    |> subject("Reset your Fountain password")
+    |> subject("Reset your #{brand()} password")
     |> html_body(reset_html(reset_url))
     |> text_body(reset_text(reset_url))
     |> Mailer.deliver()
@@ -73,7 +73,7 @@ defmodule Fountain.Emails.UserEmails do
     new()
     |> from(from_address())
     |> to({user.email, user.email})
-    |> subject("Your Fountain account has been suspended")
+    |> subject("Your #{brand()} account has been suspended")
     |> html_body(account_suspended_html())
     |> text_body(account_suspended_text())
     |> Mailer.deliver()
@@ -87,7 +87,7 @@ defmodule Fountain.Emails.UserEmails do
     new()
     |> from(from_address())
     |> to({user.email, user.email})
-    |> subject("Your Fountain account is available again")
+    |> subject("Your #{brand()} account is available again")
     |> html_body(account_unsuspended_html(login_url))
     |> text_body(account_unsuspended_text(login_url))
     |> Mailer.deliver()
@@ -109,7 +109,7 @@ defmodule Fountain.Emails.UserEmails do
     new()
     |> from(from_address())
     |> to({user.email, user.email})
-    |> subject("Your Fountain webhook to #{host} was switched off")
+    |> subject("Your #{brand()} webhook to #{host} was switched off")
     |> html_body(webhook_disabled_html(host, reason, url))
     |> text_body(webhook_disabled_text(host, reason, url))
     |> Mailer.deliver()
@@ -163,7 +163,7 @@ defmodule Fountain.Emails.UserEmails do
     new()
     |> from(from_address())
     |> to({email, email})
-    |> subject("Your Fountain account has been deleted")
+    |> subject("Your #{brand()} account has been deleted")
     |> html_body(account_deleted_html())
     |> text_body(account_deleted_text())
     |> Mailer.deliver()
@@ -183,7 +183,7 @@ defmodule Fountain.Emails.UserEmails do
     new()
     |> from(from_address())
     |> to({new_email, new_email})
-    |> subject("Confirm your new Fountain email address")
+    |> subject("Confirm your new #{brand()} email address")
     |> html_body(email_change_html(confirm_url))
     |> text_body(email_change_text(confirm_url))
     |> Mailer.deliver()
@@ -200,7 +200,7 @@ defmodule Fountain.Emails.UserEmails do
     new()
     |> from(from_address())
     |> to({old_email, old_email})
-    |> subject("Your Fountain email address was changed")
+    |> subject("Your #{brand()} email address was changed")
     |> html_body(email_changed_notice_html(new_email))
     |> text_body(email_changed_notice_text(new_email))
     |> Mailer.deliver()
@@ -213,9 +213,9 @@ defmodule Fountain.Emails.UserEmails do
     <!DOCTYPE html>
     <html>
     <body style="font-family: sans-serif; max-width: 600px; margin: 0 auto; padding: 24px;">
-      <h2>Confirm your new Fountain email address</h2>
+      <h2>Confirm your new #{brand()} email address</h2>
       <p>
-        A Fountain account asked to change its email address to this one.
+        A #{brand()} account asked to change its email address to this one.
         Click the button below to confirm — the change only happens when you
         do. The link expires in 24 hours.
       </p>
@@ -240,9 +240,9 @@ defmodule Fountain.Emails.UserEmails do
 
   defp email_change_text(url) do
     """
-    Confirm your new Fountain email address
+    Confirm your new #{brand()} email address
 
-    A Fountain account asked to change its email address to this one. Open
+    A #{brand()} account asked to change its email address to this one. Open
     the link below to confirm — the change only happens when you do. The link
     expires in 24 hours.
 
@@ -258,9 +258,9 @@ defmodule Fountain.Emails.UserEmails do
     <!DOCTYPE html>
     <html>
     <body style="font-family: sans-serif; max-width: 600px; margin: 0 auto; padding: 24px;">
-      <h2>Your Fountain email address was changed</h2>
+      <h2>Your #{brand()} email address was changed</h2>
       <p>
-        The email address on your Fountain account was changed to
+        The email address on your #{brand()} account was changed to
         <strong>#{new_email}</strong>. This address can no longer be used to
         sign in.
       </p>
@@ -275,15 +275,20 @@ defmodule Fountain.Emails.UserEmails do
 
   defp email_changed_notice_text(new_email) do
     """
-    Your Fountain email address was changed
+    Your #{brand()} email address was changed
 
-    The email address on your Fountain account was changed to #{new_email}.
+    The email address on your #{brand()} account was changed to #{new_email}.
     This address can no longer be used to sign in.
 
     If you made this change, no action is needed. If you did not,
     #{support_phrase()} immediately — do not wait.
     """
   end
+
+  # The deployment's brand (PRODUCT_NAME), which is what every subject line and
+  # body calls the service. Public: BillingEmails (ee/) shares it too.
+  @doc false
+  def brand, do: Fountain.Brand.name()
 
   # Public (not defp): Fountain.Emails.BillingEmails (ee/) shares the sender
   # and support-contact policy rather than duplicating it.
@@ -315,7 +320,7 @@ defmodule Fountain.Emails.UserEmails do
     <body style="font-family: sans-serif; max-width: 600px; margin: 0 auto; padding: 24px;">
       <h2>A webhook endpoint was switched off</h2>
       <p>
-        Fountain stopped delivering events to <strong>#{host}</strong> after
+        #{brand()} stopped delivering events to <strong>#{host}</strong> after
         repeated failures. The last one was: #{reason}.
       </p>
       <p>
@@ -337,7 +342,7 @@ defmodule Fountain.Emails.UserEmails do
     """
     A webhook endpoint was switched off
 
-    Fountain stopped delivering events to #{host} after repeated failures.
+    #{brand()} stopped delivering events to #{host} after repeated failures.
     The last one was: #{reason}.
 
     Nothing else changed. Your agents and conversations carry on; only the
@@ -369,7 +374,7 @@ defmodule Fountain.Emails.UserEmails do
         #{rows}
       </ul>
       <p>
-        Nothing stops on that date on Fountain's side — but an agent handed an
+        Nothing stops on that date on #{brand()}'s side — but an agent handed an
         expired credential fails mid-conversation, which is a worse place to
         find out. Rotate the value and record the new expiry.
       </p>
@@ -396,7 +401,7 @@ defmodule Fountain.Emails.UserEmails do
 
     #{rows}
 
-    Nothing stops on that date on Fountain's side — but an agent handed an
+    Nothing stops on that date on #{brand()}'s side — but an agent handed an
     expired credential fails mid-conversation, which is a worse place to
     find out. Rotate the value and record the new expiry.
 
@@ -414,7 +419,7 @@ defmodule Fountain.Emails.UserEmails do
     <!DOCTYPE html>
     <html>
     <body style="font-family: sans-serif; max-width: 600px; margin: 0 auto; padding: 24px;">
-      <h2>Your Fountain account has been suspended</h2>
+      <h2>Your #{brand()} account has been suspended</h2>
       <p>
         Your account has been suspended: existing sessions are signed out, API
         keys stop working, and running conversations have been stopped.
@@ -434,7 +439,7 @@ defmodule Fountain.Emails.UserEmails do
 
   defp account_suspended_text do
     """
-    Your Fountain account has been suspended
+    Your #{brand()} account has been suspended
 
     Your account has been suspended: existing sessions are signed out, API
     keys stop working, and running conversations have been stopped.
@@ -452,7 +457,7 @@ defmodule Fountain.Emails.UserEmails do
     <!DOCTYPE html>
     <html>
     <body style="font-family: sans-serif; max-width: 600px; margin: 0 auto; padding: 24px;">
-      <h2>Your Fountain account is available again</h2>
+      <h2>Your #{brand()} account is available again</h2>
       <p>
         The suspension on your account has been lifted. Sign in to pick up
         where you left off — everything is as you left it.
@@ -474,7 +479,7 @@ defmodule Fountain.Emails.UserEmails do
 
   defp account_unsuspended_text(login_url) do
     """
-    Your Fountain account is available again
+    Your #{brand()} account is available again
 
     The suspension on your account has been lifted. Sign in to pick up where
     you left off — everything is as you left it:
@@ -488,9 +493,9 @@ defmodule Fountain.Emails.UserEmails do
     <!DOCTYPE html>
     <html>
     <body style="font-family: sans-serif; max-width: 600px; margin: 0 auto; padding: 24px;">
-      <h2>Your Fountain account has been deleted</h2>
+      <h2>Your #{brand()} account has been deleted</h2>
       <p>
-        This confirms your Fountain account and its data — agents,
+        This confirms your #{brand()} account and its data — agents,
         environments, vaults, conversations and stored secrets — have been
         permanently deleted. Any subscription was cancelled first; you will
         not be charged again.
@@ -510,9 +515,9 @@ defmodule Fountain.Emails.UserEmails do
 
   defp account_deleted_text do
     """
-    Your Fountain account has been deleted
+    Your #{brand()} account has been deleted
 
-    This confirms your Fountain account and its data — agents, environments,
+    This confirms your #{brand()} account and its data — agents, environments,
     vaults, conversations and stored secrets — have been permanently deleted.
     Any subscription was cancelled first; you will not be charged again.
 
@@ -528,7 +533,7 @@ defmodule Fountain.Emails.UserEmails do
     <!DOCTYPE html>
     <html>
     <body style="font-family: sans-serif; max-width: 600px; margin: 0 auto; padding: 24px;">
-      <h2>Verify your Fountain account</h2>
+      <h2>Verify your #{brand()} account</h2>
       <p>Click the button below to verify your email address. This link expires in 24 hours.</p>
       <p style="margin: 32px 0;">
         <a href="#{url}"
@@ -541,7 +546,7 @@ defmodule Fountain.Emails.UserEmails do
         <a href="#{url}" style="color: #3b82f6;">#{url}</a>
       </p>
       <p style="color: #71717a; font-size: 13px;">
-        If you didn't sign up for Fountain, you can safely ignore this email.
+        If you didn't sign up for #{brand()}, you can safely ignore this email.
       </p>
     </body>
     </html>
@@ -550,14 +555,14 @@ defmodule Fountain.Emails.UserEmails do
 
   defp verification_text(url) do
     """
-    Verify your Fountain account
+    Verify your #{brand()} account
 
     Click the link below to verify your email address.
     This link expires in 24 hours.
 
     #{url}
 
-    If you didn't sign up for Fountain, you can safely ignore this email.
+    If you didn't sign up for #{brand()}, you can safely ignore this email.
     """
   end
 
@@ -566,7 +571,7 @@ defmodule Fountain.Emails.UserEmails do
     <!DOCTYPE html>
     <html>
     <body style="font-family: sans-serif; max-width: 600px; margin: 0 auto; padding: 24px;">
-      <h2>Reset your Fountain password</h2>
+      <h2>Reset your #{brand()} password</h2>
       <p>Someone requested a password reset for your account. Click the button below to set a new password. This link expires in 1 hour.</p>
       <p style="margin: 32px 0;">
         <a href="#{url}"
@@ -589,7 +594,7 @@ defmodule Fountain.Emails.UserEmails do
 
   defp reset_text(url) do
     """
-    Reset your Fountain password
+    Reset your #{brand()} password
 
     Someone requested a password reset for your account.
     Click the link below to set a new password.

--- a/apps/fountain/lib/fountain_web/components/layouts.ex
+++ b/apps/fountain/lib/fountain_web/components/layouts.ex
@@ -49,7 +49,9 @@ defmodule FountainWeb.Layouts do
           <div class="flex items-center justify-between p-4 border-b border-[var(--color-border)] shrink-0">
             <.link href={~p"/dashboard"} class="flex items-center gap-2">
               <img src="/images/app-icon.png" alt="" class="size-7 rounded-md" />
-              <span class="font-semibold text-sm text-[var(--color-text-primary)]">Fountain</span>
+              <span class="font-semibold text-sm text-[var(--color-text-primary)]">
+                {Fountain.Brand.name()}
+              </span>
             </.link>
             <label
               for="sidebar-toggle"
@@ -190,7 +192,9 @@ defmodule FountainWeb.Layouts do
                 />
               </svg>
             </label>
-            <span class="font-semibold text-sm text-[var(--color-text-primary)]">Fountain</span>
+            <span class="font-semibold text-sm text-[var(--color-text-primary)]">
+              {Fountain.Brand.name()}
+            </span>
           </div>
 
           <main class="flex-1 p-6">

--- a/apps/fountain/lib/fountain_web/components/layouts/marketing.html.heex
+++ b/apps/fountain/lib/fountain_web/components/layouts/marketing.html.heex
@@ -4,7 +4,9 @@
     <div class="max-w-5xl mx-auto px-6 py-4 flex items-center justify-between">
       <a href="/" class="flex items-center gap-2">
         <img src="/images/app-icon.png" alt="" class="size-7 rounded-md" />
-        <span class="font-semibold text-sm text-[var(--color-text-primary)]">Fountain</span>
+        <span class="font-semibold text-sm text-[var(--color-text-primary)]">
+          {Fountain.Brand.name()}
+        </span>
       </a>
       <nav class="flex items-center gap-3">
         <a

--- a/apps/fountain/lib/fountain_web/components/layouts/root.html.heex
+++ b/apps/fountain/lib/fountain_web/components/layouts/root.html.heex
@@ -11,7 +11,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="csrf-token" content={get_csrf_token()} />
-    <title>{assigns[:page_title] || "Fountain"}</title>
+    <title>{assigns[:page_title] || Fountain.Brand.name()}</title>
     <link rel="icon" href="/favicon.ico" sizes="any" />
     <link rel="icon" type="image/png" sizes="32x32" href="/images/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/images/favicon-16x16.png" />

--- a/apps/fountain/lib/fountain_web/controllers/docs_html/show.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/docs_html/show.html.heex
@@ -48,6 +48,17 @@
   </aside>
 
   <article class="flex-1 min-w-0 bg-[var(--color-bg-1)] border border-[var(--color-border)] rounded-lg shadow-sm p-8">
+    <%!-- On a deployment sold under another brand (PRODUCT_NAME), say once,
+    on every page, why the manual, the CLI and the API all say Fountain: the
+    reader lands on any page from a search, not only the index. --%>
+    <p
+      :if={Fountain.Brand.hosted?()}
+      class="mb-6 rounded-md border border-[var(--color-border)] bg-[var(--color-bg-2)] px-4 py-3 text-sm text-[var(--color-text-secondary)]"
+      data-role="brand-note"
+    >
+      <span class="font-medium text-[var(--color-text-primary)]">{Fountain.Brand.name()}</span>
+      is the hosted {Fountain.Brand.engine()}. {Fountain.Brand.engine()} is the open-source engine, and its name is on the CLI, the API, the SDK and this manual. Everything here applies to {Fountain.Brand.name()} unless a page says it is for a self-hosted server.
+    </p>
     <%!-- The `prose-code:` chip (background, padding, rounding) is for *inline*
     code; Tailwind Typography's `code` variant also matches the `<code>` inside
     a `<pre>`, which paints a light box behind every line of every code block.

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/instance.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/instance.html.heex
@@ -7,7 +7,7 @@
   <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-1)] p-8 text-center">
     <img src="/images/app-icon.png" alt="" class="size-12 rounded-xl mx-auto mb-5" />
     <h1 class="text-2xl font-semibold tracking-tight text-[var(--color-text-primary)] mb-3">
-      Fountain
+      {Fountain.Brand.name()}
     </h1>
     <p class="text-[var(--color-text-secondary)] leading-relaxed mb-8">
       This instance runs agents on sandboxes and serves their conversations over an API. Sign in to reach the console.

--- a/apps/fountain/lib/fountain_web/controllers/oauth_authorize_html.ex
+++ b/apps/fountain/lib/fountain_web/controllers/oauth_authorize_html.ex
@@ -13,11 +13,11 @@ defmodule FountainWeb.OAuthAuthorizeHTML do
         <input type="hidden" name="_csrf_token" value={get_csrf_token()} />
         <input :for={{k, v} <- @params} type="hidden" name={k} value={v} />
         <div class="space-y-1">
-          <div class="text-xs uppercase tracking-wide text-zinc-500">Fountain</div>
+          <div class="text-xs uppercase tracking-wide text-zinc-500">{Fountain.Brand.name()}</div>
           <h1 class="text-xl font-semibold">Sign in to {@client.name}?</h1>
           <p class="text-sm text-zinc-600">
             <span class="font-medium">{@client.name}</span>
-            is asking to use your Fountain account. Allowing it issues an API key it will use to
+            is asking to use your {Fountain.Brand.name()} account. Allowing it issues an API key it will use to
             act as you — start conversations, run agents, read your environments and vaults. You can
             revoke it any time under <a href={~p"/api-keys"} class="underline">Account → API keys</a>.
           </p>

--- a/apps/fountain/lib/fountain_web/controllers/session_html.ex
+++ b/apps/fountain/lib/fountain_web/controllers/session_html.ex
@@ -14,7 +14,7 @@ defmodule FountainWeb.SessionHTML do
       >
         <input type="hidden" name="_csrf_token" value={get_csrf_token()} />
         <div>
-          <h1 class="text-xl font-semibold">Sign in to Fountain</h1>
+          <h1 class="text-xl font-semibold">Sign in to {Fountain.Brand.name()}</h1>
           <p class="text-sm text-zinc-500">
             New here?
             <a href={~p"/auth/register"} class="text-zinc-900 underline">Create an account</a>

--- a/apps/fountain/test/fountain/brand_test.exs
+++ b/apps/fountain/test/fountain/brand_test.exs
@@ -1,0 +1,34 @@
+defmodule Fountain.BrandTest do
+  use ExUnit.Case, async: false
+
+  alias Fountain.Brand
+
+  setup do
+    previous = Application.get_env(:fountain, :product_name)
+
+    on_exit(fn ->
+      if previous,
+        do: Application.put_env(:fountain, :product_name, previous),
+        else: Application.delete_env(:fountain, :product_name)
+    end)
+
+    :ok
+  end
+
+  test "unset or blank falls back to the engine, which is never hosted" do
+    Application.delete_env(:fountain, :product_name)
+    assert Brand.name() == "Fountain"
+    refute Brand.hosted?()
+
+    Application.put_env(:fountain, :product_name, "   ")
+    assert Brand.name() == "Fountain"
+    refute Brand.hosted?()
+  end
+
+  test "a brand is trimmed, used, and marks the deployment hosted" do
+    Application.put_env(:fountain, :product_name, " Managoat ")
+    assert Brand.name() == "Managoat"
+    assert Brand.engine() == "Fountain"
+    assert Brand.hosted?()
+  end
+end

--- a/apps/fountain/test/fountain_web/brand_chrome_test.exs
+++ b/apps/fountain/test/fountain_web/brand_chrome_test.exs
@@ -1,0 +1,47 @@
+defmodule FountainWeb.BrandChromeTest do
+  use FountainWeb.ConnCase, async: false
+
+  # PRODUCT_NAME is a per-deployment brand for the chrome only: the manual
+  # keeps saying Fountain (the engine) and explains the split once per page.
+  setup do
+    previous = Application.get_env(:fountain, :product_name)
+    Application.put_env(:fountain, :product_name, "Managoat")
+
+    on_exit(fn ->
+      if previous,
+        do: Application.put_env(:fountain, :product_name, previous),
+        else: Application.delete_env(:fountain, :product_name)
+    end)
+
+    :ok
+  end
+
+  test "the docs header carries the brand and each page explains the split", %{conn: conn} do
+    html = conn |> get(~p"/docs") |> html_response(200)
+    assert html =~ ~s(<title>Docs · )
+    assert html =~ ~r/>\s*Managoat\s*<\/span>/
+    assert html =~ ~s(data-role="brand-note")
+    assert html =~ ~r/Managoat<\/span>\s*is the hosted Fountain/
+    # The page body is the engine's manual, untouched.
+    assert html =~ "Fountain runs an agent on a cloud sandbox"
+  end
+
+  test "the sign-in page and default title use the brand", %{conn: conn} do
+    html = conn |> get(~p"/auth/login") |> html_response(200)
+    assert html =~ "Sign in to Managoat"
+  end
+
+  test "email subjects use the brand" do
+    import Swoosh.TestAssertions
+    user = Fountain.Factory.insert_verified_user()
+    {:ok, _} = Fountain.Emails.UserEmails.deliver_verification_email(user, "tok")
+    assert_email_sent(subject: "Verify your Managoat account")
+  end
+
+  test "without the brand the docs show no note", %{conn: conn} do
+    Application.delete_env(:fountain, :product_name)
+    html = conn |> get(~p"/docs") |> html_response(200)
+    refute html =~ ~s(data-role="brand-note")
+    assert html =~ ~r/>\s*Fountain\s*<\/span>/
+  end
+end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -347,6 +347,16 @@ if config_env() != :test do
   config :fountain, :billing_enabled, System.get_env("BILLING_ENABLED", "false") != "false"
 end
 
+# What the chrome calls this deployment (Fountain.Brand): the sidebar header,
+# the <title>, the sign-in and consent pages and every email subject. The
+# engine stays Fountain everywhere it is named as the engine — the CLI, the
+# API, the manual — so a hosted deployment under another brand sets this and
+# the manual explains the split at the top of every page.
+case System.get_env("PRODUCT_NAME") do
+  nil -> :ok
+  value -> config :fountain, :product_name, String.trim(value)
+end
+
 # Which page `/` serves. The hosted deployment shows the product pitch; every
 # other deployment shows a plain front door, for the reason a self-hosted
 # instance does not serve the upstream project's legal terms either. Off by

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -169,6 +169,7 @@ Your deployment is not the Fountain project, so the front door is the default.
 
 | Variable | Default | Required | Effect |
 |---|---|---|---|
+| `PRODUCT_NAME` | `Fountain` | — | The name the console, the sign-in page, the OAuth consent screen and each email subject use for this deployment. Set it when you sell a hosted deployment under a different brand. The CLI, the API and this manual keep the name Fountain, because that is the name of the engine. When the two differ, each manual page opens with one line that says so. |
 | `MARKETING_SITE` | `false` | — | A `true` serves the Fountain project's product page at `/`. It also puts the project's copyright line in the footer. Turn it on only if you operate the project's own site. |
 
 ## Legal pages

--- a/ee/lib/fountain/emails/billing_emails.ex
+++ b/ee/lib/fountain/emails/billing_emails.ex
@@ -23,6 +23,8 @@ defmodule Fountain.Emails.BillingEmails do
   alias Fountain.Emails.UserEmails
   alias Fountain.Mailer
 
+  defp brand, do: UserEmails.brand()
+
   @doc """
   Welcome a just-verified user (#449).
 
@@ -45,7 +47,7 @@ defmodule Fountain.Emails.BillingEmails do
     new()
     |> from(UserEmails.from_address())
     |> to({user.email, user.email})
-    |> subject("Welcome to Fountain")
+    |> subject("Welcome to #{brand()}")
     |> html_body(welcome_html(start_url, trial_text))
     |> text_body(welcome_text(start_url, trial_text))
     |> Mailer.deliver()
@@ -69,7 +71,7 @@ defmodule Fountain.Emails.BillingEmails do
     <!DOCTYPE html>
     <html>
     <body style="font-family: sans-serif; max-width: 600px; margin: 0 auto; padding: 24px;">
-      <h2>Welcome to Fountain</h2>
+      <h2>Welcome to #{brand()}</h2>
       <p>
         Your account is verified and ready. Set up an agent, give it an
         environment, and start a conversation — it runs in an isolated sandbox
@@ -93,7 +95,7 @@ defmodule Fountain.Emails.BillingEmails do
 
   defp welcome_text(start_url, trial_text) do
     """
-    Welcome to Fountain
+    Welcome to #{brand()}
 
     Your account is verified and ready. Set up an agent, give it an
     environment, and start a conversation — it runs in an isolated sandbox
@@ -115,7 +117,7 @@ defmodule Fountain.Emails.BillingEmails do
     new()
     |> from(UserEmails.from_address())
     |> to({user.email, user.email})
-    |> subject("Your Fountain credit is running low")
+    |> subject("Your #{brand()} credit is running low")
     |> html_body(credits_html("Your credit is running low", balance, billing_url, false))
     |> text_body(credits_text("Your credit is running low", balance, billing_url, false))
     |> Mailer.deliver()
@@ -133,7 +135,7 @@ defmodule Fountain.Emails.BillingEmails do
     new()
     |> from(UserEmails.from_address())
     |> to({user.email, user.email})
-    |> subject("Your Fountain credit has run out")
+    |> subject("Your #{brand()} credit has run out")
     |> html_body(credits_html("Your credit has run out", balance, billing_url, true))
     |> text_body(credits_text("Your credit has run out", balance, billing_url, true))
     |> Mailer.deliver()


### PR DESCRIPTION
The hosted deployment launches as Managoat, and the manual it serves at
/docs opens with "Fountain". Renaming the manual is wrong: the CLI is
`fountain`, the env var is FOUNTAIN_BASE_URL, the apiVersion is
fountain.dev/v1, and a reader on the hosted docs needs to see that name.
Forking it is worse (two manuals, #1008 just retired the second publisher).

So the split is the one GitLab.com/GitLab and Grafana Cloud/Grafana use:
Fountain is the engine, and the deployment's brand is chrome only.

- Fountain.Brand: name/0 reads PRODUCT_NAME (default "Fountain"),
  engine/0 is always "Fountain", hosted?/0 says whether they differ.
- The brand drives the console and marketing headers, the <title>
  fallback, the front door, the sign-in page, the OAuth consent screen,
  and every email subject and body (core and ee/).
- With a brand set, every /docs page opens with one line: "<brand> is the
  hosted Fountain. Fountain is the open-source engine, and its name is on
  the CLI, the API, the SDK and this manual." Readers land on any page
  from a search, not the index, so it is on each page, not just the first.
  Without a brand nothing changes: no note, and every existing assertion
  on "Fountain" still holds.
- docs/configuration.md row (the config_reference guard) and .env.example.

Left alone on purpose: the OpenAPI title, the CLI, the SDK, the footer's
"Powered by Fountain.", the "© Fountain" line on the project's own site,
and every one of the ~870 mentions in docs/*.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)