### PR TITLE
feat(brand): the marketing and legal pages name the brand, and credit the engine

### DIFF
--- a/apps/fountain/lib/fountain_web/components/layouts/marketing.html.heex
+++ b/apps/fountain/lib/fountain_web/components/layouts/marketing.html.heex
@@ -49,10 +49,14 @@
   <%!-- Footer --%>
   <footer class="border-t border-[var(--color-border)] bg-[var(--color-bg-1)]">
     <div class="max-w-5xl mx-auto px-6 py-6 flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-[var(--color-text-muted)]">
-      <%!-- The project's copyright line and its one-line pitch belong on the
-        project's own site. Somebody else's deployment gets an attribution. --%>
+      <%!-- The hosted site's copyright line names the brand, and credits the
+        engine, which is open source. Somebody else's deployment gets an
+        attribution. --%>
       <span :if={Fountain.Marketing.site?()}>
-        © 2026 Fountain. Managed agent infrastructure for teams who'd rather build than configure.
+        © 2026 {Fountain.Brand.name()}. Managed agent infrastructure for teams who'd rather build than configure.
+        <span :if={Fountain.Brand.hosted?()}>
+          Built on {Fountain.Brand.engine()}, open source.
+        </span>
       </span>
       <span :if={!Fountain.Marketing.site?()}>Powered by Fountain.</span>
       <div class="flex items-center gap-4">

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -4,7 +4,7 @@
     Have the conversation. Skip the infrastructure.
   </h1>
   <p class="text-lg sm:text-xl text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-10">
-    Fountain runs an agent on a cloud sandbox and hands your app a conversation with it. Send a prompt, read the reply. The sandbox parks between messages and wakes with its work intact — and you never provision, secure, or pay for an idle machine.
+    {Fountain.Brand.name()} runs an agent on a cloud sandbox and hands your app a conversation with it. Send a prompt, read the reply. The sandbox parks between messages and wakes with its work intact — and you never provision, secure, or pay for an idle machine.
   </p>
   <div class="flex flex-col sm:flex-row gap-3 justify-center mb-4">
     <a
@@ -107,7 +107,7 @@
         Credentials that never reach the prompt
       </h3>
       <p class="text-sm text-[var(--color-text-secondary)] leading-relaxed">
-        Environments and Vaults merge when the sandbox spawns and arrive as ordinary environment variables. They stay out of the prompt and the model's context, and Fountain scrubs them from the output it stores.
+        Environments and Vaults merge when the sandbox spawns and arrive as ordinary environment variables. They stay out of the prompt and the model's context, and {Fountain.Brand.name()} scrubs them from the output it stores.
       </p>
     </div>
 
@@ -195,7 +195,7 @@
     </h2>
     <p class="mt-3 mb-12 text-center text-[var(--color-text-secondary)] max-w-xl mx-auto">
       No plans, no seats, no monthly fee. Buy credit, and every hour an agent
-      works comes out of it. Bring your own model keys — Fountain never bills
+      works comes out of it. Bring your own model keys — {Fountain.Brand.name()} never bills
       you for inference.
     </p>
 
@@ -299,7 +299,7 @@
           <span class="font-medium text-[var(--color-text-primary)]">
             Inference is never on our bill.
           </span>
-          Bring your own model keys; Fountain does not charge for tokens.
+          Bring your own model keys; {Fountain.Brand.name()} does not charge for tokens.
         </p>
         <p class="text-xs text-[var(--color-text-muted)]">
           No card to start. Buy credit when the opening grant runs out, and only then.

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/privacy.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/privacy.html.heex
@@ -8,8 +8,8 @@
     <div>
       <h2 class="text-lg font-semibold text-[var(--color-text-primary)] mb-2">1. Who we are</h2>
       <p>
-        Fountain is operated by {@legal.entity} ("we", "us"). This policy describes what
-        personal data we collect when you use the Fountain service, why we collect it, and the
+        {Fountain.Brand.name()} is operated by {@legal.entity} ("we", "us"). This policy describes what
+        personal data we collect when you use the {Fountain.Brand.name()} service, why we collect it, and the
         choices you have. For questions or requests, contact <a
           href={"mailto:#{@legal.contact_email}"}
           class="underline"
@@ -71,7 +71,7 @@
         4. Who we share it with
       </h2>
       <p class="mb-2">
-        We share data with service providers only as needed to run Fountain:
+        We share data with service providers only as needed to run {Fountain.Brand.name()}:
       </p>
       <ul class="list-disc pl-6 space-y-1">
         <li>

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/terms.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/terms.html.heex
@@ -8,7 +8,7 @@
     <div>
       <h2 class="text-lg font-semibold text-[var(--color-text-primary)] mb-2">1. Agreement</h2>
       <p>
-        These Terms of Service ("Terms") are an agreement between you and {@legal.entity} ("Fountain", "we", "us") governing your use of the Fountain service — the web
+        These Terms of Service ("Terms") are an agreement between you and {@legal.entity} ("{Fountain.Brand.name()}", "we", "us") governing your use of the {Fountain.Brand.name()} service — the web
         application, API, and command-line tools available through this site (the "Service").
         By creating an account or using the Service you agree to these Terms. If you are using
         the Service on behalf of an organization, you represent that you have authority to bind
@@ -19,7 +19,7 @@
     <div>
       <h2 class="text-lg font-semibold text-[var(--color-text-primary)] mb-2">2. The Service</h2>
       <p>
-        Fountain lets you configure and run AI agents in isolated, sandboxed environments. You
+        {Fountain.Brand.name()} lets you configure and run AI agents in isolated, sandboxed environments. You
         define agent configurations, environments, and encrypted credential vaults; the Service
         provisions sandboxes, runs conversations, and streams logs back to you. Sandboxes are
         provisioned on third-party infrastructure, and agents may call third-party AI model

--- a/apps/fountain/test/fountain_web/brand_chrome_test.exs
+++ b/apps/fountain/test/fountain_web/brand_chrome_test.exs
@@ -38,6 +38,30 @@ defmodule FountainWeb.BrandChromeTest do
     assert_email_sent(subject: "Verify your Managoat account")
   end
 
+  test "the marketing page and legal pages name the brand; the CLI stays fountain", %{conn: conn} do
+    home = conn |> get(~p"/") |> html_response(200)
+    assert home =~ "Managoat runs an agent on a cloud sandbox"
+    assert home =~ "Managoat scrubs them from the output"
+    assert home =~ ">fountain</code> CLI"
+    assert home =~ "© 2026 Managoat."
+    assert home =~ "Built on Fountain, open source."
+
+    for path <- [~p"/terms", ~p"/privacy"] do
+      html = conn |> get(path) |> html_response(200)
+      assert html =~ "Managoat"
+      refute html =~ "the Fountain service"
+      refute html =~ "Fountain is operated by"
+      refute html =~ "Fountain lets you"
+    end
+  end
+
+  test "without the brand the marketing site credits nobody", %{conn: conn} do
+    Application.delete_env(:fountain, :product_name)
+    home = conn |> get(~p"/") |> html_response(200)
+    assert home =~ "© 2026 Fountain."
+    refute home =~ "Built on Fountain"
+  end
+
   test "without the brand the docs show no note", %{conn: conn} do
     Application.delete_env(:fountain, :product_name)
     html = conn |> get(~p"/docs") |> html_response(200)


### PR DESCRIPTION
Follows #1134, which branded the chrome. The product page, /terms and
/privacy still said Fountain in prose, and they only ever render on the
hosted site (MARKETING_SITE, LEGAL_*), so on Managoat that was the wrong
name in the pitch and in the contract.

Brand (Fountain.Brand.name/0), because it is the product or the party:
- "<brand> runs an agent on a cloud sandbox", "<brand> scrubs them from
  the output it stores", "<brand> never bills you for inference", the
  © line.
- Terms: the defined party ("<brand>", "we", "us") and "the <brand>
  service"; "<brand> lets you configure and run AI agents".
- Privacy: "<brand> is operated by", "the <brand> service", "to run <brand>".

Fountain, because it is the engine:
- the `fountain` CLI in the integrations card;
- a new "Built on Fountain, open source." beside the © line on a
  branded hosted site; the default site and the "Powered by Fountain."
  attribution on other deployments are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)