### PR TITLE
fix(billing): half-open month, one gate, one cap rule (billing debt 1/3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,23 @@ upgrade, is in
   Off unless `BROKER_URL` is set, and then only for the tenants in
   `BROKER_TENANTS`; an unbrokered conversation provisions byte-for-byte as
   before. No broker is deployed and no tenant is flipped by this change.
+
+### Fixed
+
+- **Billing debt 1/3: the month is half-open, one gate, one cap rule.**
+  `Billing.month_range/2` replaces four hand-rolled month windows; its `end`
+  is the first instant of the next month, so the last second of every month
+  is no longer dropped from every usage query (`GET /api/account/billing`'s
+  `period.end` moves accordingly; SDK 1.1.1). `Credits.Rent` runs through
+  `Credits.check_balance/2` (`min:` a month's rent) instead of its own
+  balance read, so an expired-but-unswept grant funds a contact no more than
+  it funds a turn. Under the reservation lock the credit gate now runs
+  before the sandbox quota, so an unfunded account's cap is 0 everywhere
+  (`sandbox_limit/1` and `sandbox_limit_for/1` agree) and it is refused as
+  `insufficient_credits`, never as a 0/0 quota. `Credits.gate/1` is
+  `check_balance/2`; `Credits.active?/0` is gone (it was `Billing.enabled?/0`).
+  `Finance.deferred_cents/0` is the one deferred-balance query.
+
 ### Changed
 
 - **Credits cleanup 3/3 (#1128).** The prose catches up with ADR 0031. ADR

--- a/apps/fountain/lib/fountain/quotas.ex
+++ b/apps/fountain/lib/fountain/quotas.ex
@@ -98,7 +98,7 @@ defmodule Fountain.Quotas do
 
     case Repo.one(query) do
       {override, balance, comped} -> resolve_limit(override, balance, comped)
-      nil -> settings().cap_floor
+      nil -> 0
     end
   end
 
@@ -106,24 +106,10 @@ defmodule Fountain.Quotas do
   The same answer as `sandbox_limit/1` for a user already loaded — for the
   admin table, which shows the cap on every row and must not run a query per
   row (the same contract as `active_sandbox_counts/0`).
-
-  One deliberate difference: an account with nothing in its balance is shown
-  `0`, not the floor. The floor is what `sandbox_limit/1` enforces so the
-  quota check under the reservation lock never fires ahead of the credit gate
-  (`insufficient_credits` is the right answer, not `sandbox_quota_exceeded`),
-  but the gate refuses that account anyway, and a display that says "2" for
-  an account that can start nothing is a lie (#1127).
   """
   @spec sandbox_limit_for(User.t()) :: non_neg_integer()
-  def sandbox_limit_for(%User{} = user) do
-    unfunded? =
-      is_nil(user.sandbox_limit_override) and Fountain.Billing.enabled?() and
-        user.comped != true and (user.credit_balance_cents || 0) <= 0
-
-    if unfunded?,
-      do: 0,
-      else: resolve_limit(user.sandbox_limit_override, user.credit_balance_cents, user.comped)
-  end
+  def sandbox_limit_for(%User{} = user),
+    do: resolve_limit(user.sandbox_limit_override, user.credit_balance_cents, user.comped)
 
   defp resolve_limit(override, _balance, _comped) when is_integer(override), do: override
 
@@ -133,11 +119,14 @@ defmodule Fountain.Quotas do
     cond do
       not Fountain.Billing.enabled?() -> ceiling
       comped == true -> ceiling
+      # Nothing in the balance funds nothing. The credit gate runs before the
+      # quota check under the reservation lock, so this account is refused as
+      # `insufficient_credits`, never as a 0/0 quota.
+      (balance || 0) <= 0 -> 0
       true -> balance |> funded(reserve) |> max(floor) |> min(ceiling)
     end
   end
 
-  defp funded(balance, _reserve) when balance <= 0, do: 0
   defp funded(_balance, 0), do: 0
   defp funded(balance, reserve), do: div(balance, reserve)
 
@@ -252,9 +241,11 @@ defmodule Fountain.Quotas do
       # last slot or the last cent must not both read "room" and both
       # provision. The turn that then burns the balance may still go
       # negative; that is the soft stop, not a hole.
+      # Balance before cap: an unfunded account's cap is 0, and "out of
+      # credit" is the answer it should hear, not "0/0 sandboxes".
       with :ok <- check_fleet_ceiling(quota_opts),
-           :ok <- check_sandbox_quota(user_id, quota_opts),
            :ok <- Fountain.Credits.gate(user_id),
+           :ok <- check_sandbox_quota(user_id, quota_opts),
            {:ok, value} <- fun.() do
         value
       else

--- a/apps/fountain/lib/fountain_web/live/dashboard_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/dashboard_live/index.ex
@@ -58,8 +58,7 @@ defmodule FountainWeb.DashboardLive.Index do
   # agents have been doing.
   defp assign_usage(socket, user) do
     billing_enabled? = Fountain.Billing.enabled?()
-    {period_start, period_end} = Fountain.Billing.current_month_range()
-    period = %{start: period_start, end: period_end}
+    period = Fountain.Billing.month_range()
 
     socket
     |> assign(:usage, Fountain.Billing.usage_summary(user.id, period.start, period.end))

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -1792,7 +1792,9 @@ defmodule FountainWeb.Schemas do
             has_stripe_customer: %Schema{type: :boolean},
             period: %Schema{
               type: :object,
-              description: "The calendar month the usage numbers cover.",
+              description:
+                "The calendar month the usage numbers cover, half-open: `end` is " <>
+                  "the first instant of the next month.",
               properties: %{
                 start: %Schema{type: :string, format: :"date-time"},
                 end: %Schema{type: :string, format: :"date-time"}

--- a/apps/fountain/test/fountain/quotas_test.exs
+++ b/apps/fountain/test/fountain/quotas_test.exs
@@ -72,15 +72,17 @@ defmodule Fountain.QuotasTest do
       user
     end
 
-    # Every verified account holds the $10 opening grant: five sandboxes.
-    test "the opening grant funds the floor; so does nothing at all" do
+    # Every verified account holds the $5 opening grant: the floor. Spent to
+    # nothing, it funds nothing — the gate refuses first, so the cap is never
+    # the answer that account hears.
+    test "the opening grant funds the floor; nothing at all funds nothing" do
       user = insert_active_user()
       assert Quotas.sandbox_limit(user.id) == 2
 
       {:ok, _} =
         Fountain.Credits.debit(user.id, 1_000, "burn_turn", idempotency_key: "drain-#{user.id}")
 
-      assert Quotas.sandbox_limit(user.id) == 2
+      assert Quotas.sandbox_limit(user.id) == 0
     end
 
     test "the cap follows the balance, one sandbox per reserve" do
@@ -123,8 +125,8 @@ defmodule Fountain.QuotasTest do
       assert Quotas.sandbox_limit(user.id) == 7
     end
 
-    test "an unknown user gets the floor rather than being unlimited" do
-      assert Quotas.sandbox_limit(Ecto.UUID.generate()) == 2
+    test "an unknown user funds nothing rather than being unlimited" do
+      assert Quotas.sandbox_limit(Ecto.UUID.generate()) == 0
     end
   end
 
@@ -174,7 +176,7 @@ defmodule Fountain.QuotasTest do
       end
     end
 
-    test "an unfunded account is shown 0, though the enforced floor stays (#1127)" do
+    test "an unfunded account is 0 on both, not the floor (#1127)" do
       user = insert_active_user()
 
       {:ok, _} =
@@ -182,7 +184,7 @@ defmodule Fountain.QuotasTest do
 
       user = Fountain.Repo.reload!(user)
       assert Quotas.sandbox_limit_for(user) == 0
-      assert Quotas.sandbox_limit(user.id) == 2
+      assert Quotas.sandbox_limit(user.id) == 0
 
       {:ok, comped} = Fountain.Billing.comp_account(user)
       assert Quotas.sandbox_limit_for(comped) == Quotas.sandbox_limit(comped.id)

--- a/ee/lib/fountain/billing.ex
+++ b/ee/lib/fountain/billing.ex
@@ -295,21 +295,34 @@ defmodule Fountain.Billing do
   """
   @spec current_month_range() :: {DateTime.t(), DateTime.t()}
   def current_month_range do
-    now = DateTime.utc_now()
-    period_start = %DateTime{now | day: 1, hour: 0, minute: 0, second: 0, microsecond: {0, 0}}
-    last_day = :calendar.last_day_of_the_month(now.year, now.month)
-
-    period_end = %DateTime{
-      now
-      | day: last_day,
-        hour: 23,
-        minute: 59,
-        second: 59,
-        microsecond: {0, 0}
-    }
-
+    %{start: period_start, end: period_end} = month_range()
     {period_start, period_end}
   end
+
+  @doc """
+  One whole UTC calendar month as a **half-open** `%{start, end}`:
+  `months_ago` back from the running month (0, the default, is this month;
+  `:now` pins the clock).
+  `end` is the first instant of the next month, so every consumer that
+  filters `>= start and < end` covers the whole month — the old inclusive
+  `23:59:59` end (a Stripe `current_period_end` habit) dropped the last
+  second of every month from every query. A surface that prints the window
+  shows `end` minus a second, or its date minus a day.
+  """
+  @spec month_range(non_neg_integer(), keyword()) :: %{start: DateTime.t(), end: DateTime.t()}
+  def month_range(months_ago \\ 0, opts \\ []) when is_integer(months_ago) and months_ago >= 0 do
+    now = Keyword.get(opts, :now) || DateTime.utc_now()
+    total = now.year * 12 + (now.month - 1) - months_ago
+    {year, month} = {div(total, 12), rem(total, 12) + 1}
+
+    %{
+      start: month_start(year, month),
+      end: month_start(year + div(month, 12), rem(month, 12) + 1)
+    }
+  end
+
+  defp month_start(year, month),
+    do: DateTime.new!(Date.new!(year, month, 1), ~T[00:00:00], "Etc/UTC")
 
   @doc """
   Returns a usage summary for `user_id` over the given period.
@@ -577,15 +590,8 @@ defmodule Fountain.Billing do
     funded =
       Repo.one(from(u in User, where: u.credit_balance_cents > 0, select: count(u.id))) || 0
 
-    deferred =
-      Repo.one(
-        from(u in User,
-          where: u.credit_balance_cents > 0,
-          select: coalesce(sum(u.credit_balance_cents), 0)
-        )
-      )
-
-    month_start = %{now | day: 1, hour: 0, minute: 0, second: 0, microsecond: {0, 6}}
+    deferred = Fountain.Billing.Finance.deferred_cents()
+    %{start: month_start} = month_range(0, now: now)
 
     purchases_this_month =
       Repo.one(

--- a/ee/lib/fountain/billing/finance.ex
+++ b/ee/lib/fountain/billing/finance.ex
@@ -372,9 +372,13 @@ defmodule Fountain.Billing.Finance do
     }
   end
 
-  # Every positive balance, whoever holds it — a deleted account's ledger is
-  # gone with the account (ADR 0009), so this is what is owed today.
-  defp deferred_cents do
+  @doc """
+  Every positive balance, whoever holds it — a deleted account's ledger is
+  gone with the account (ADR 0009), so this is what is owed today. The one
+  query behind both the finance page and the `/admin` tile.
+  """
+  @spec deferred_cents() :: non_neg_integer()
+  def deferred_cents do
     Repo.one(
       from u in User,
         where: u.credit_balance_cents > 0,

--- a/ee/lib/fountain/credits.ex
+++ b/ee/lib/fountain/credits.ex
@@ -144,13 +144,19 @@ defmodule Fountain.Credits do
   past its date stops funding new work the moment it passes, not when the
   expiry sweep gets round to writing the row (`Workers.CreditExpirer`).
   `Billing.check_spend/1` is the door; every spend calls that.
+
+  Options: `:now` pins the clock for the expiry read; `:min` is the least
+  spendable balance that passes (default 1 cent — "positive"). Rent passes a
+  month's rent, so a contact is refused unless its first month is covered.
   """
   @spec check_balance(User.t() | binary(), keyword()) :: :ok | {:error, :insufficient_credits}
   def check_balance(subject, opts \\ []) do
+    min = Keyword.get(opts, :min, 1)
+
     cond do
       not Billing.enabled?() -> :ok
       comped?(subject) -> :ok
-      spendable(subject, Keyword.get(opts, :now) || DateTime.utc_now()) > 0 -> :ok
+      spendable(subject, Keyword.get(opts, :now) || DateTime.utc_now()) >= min -> :ok
       true -> {:error, :insufficient_credits}
     end
   end
@@ -234,30 +240,19 @@ defmodule Fountain.Credits do
   end
 
   @doc """
-  Whether credits are live on this deployment: billing is on (ADR 0031).
-  Off, no surface shows a balance — there is nothing to show, and a "$0.00"
-  on a self-hosted console would be a lie.
-  """
-  @spec active?() :: boolean()
-  def active?, do: Billing.enabled?()
-
-  @doc """
-  The spend gate (ADR 0030 decision 6, ADR 0031): `:ok` unless credits are
-  active and `check_balance/1` says the tenant is out. `Billing.check_spend/1`
-  is this; call that, not this, from a door.
+  The spend gate (ADR 0030 decision 6, ADR 0031): `check_balance/2` with the
+  defaults. `Billing.check_spend/1` is this; call that, not this, from a door.
   """
   @spec gate(User.t() | binary()) :: :ok | {:error, :insufficient_credits}
-  def gate(subject) do
-    if active?(), do: check_balance(subject), else: :ok
-  end
+  def gate(subject), do: check_balance(subject)
 
   @doc """
   The one shape every surface renders (the billing page, the dashboard,
   `GET /api/account/billing`, the admin account view), so they cannot
   disagree.
 
-    * `:active?` — `active?/0`; when false the other numbers are zero and
-      should not be shown
+    * `:active?` — `Billing.enabled?/0`; when false the other numbers are
+      zero and should not be shown
     * `:balance_cents` — the cached balance, possibly negative
     * `:expiring_cents` / `:expires_at` — what the earliest live grant still
       has unspent, and when it goes
@@ -279,7 +274,7 @@ defmodule Fountain.Credits do
     now = Keyword.get(opts, :now) || DateTime.utc_now()
     card = price_card()
 
-    if active?() do
+    if Billing.enabled?() do
       balance = balance(user)
       purchased = purchased_remaining(user.id)
 

--- a/ee/lib/fountain/credits/rent.ex
+++ b/ee/lib/fountain/credits/rent.ex
@@ -5,13 +5,15 @@ defmodule Fountain.Credits.Rent do
 
     * `month_cents/0` is `CREDIT_NUMBER_CENTS + CREDIT_INBOX_CENTS`; unset
       prices are zero, and zero rent means nothing here does anything.
-    * `check_provision/1` refuses a new contact when enforcement is on and
-      the balance is short of one month (`{:error, :insufficient_credits}`).
+    * `check_provision/1` refuses a new contact when the spendable balance is
+      short of one month (`{:error, :insufficient_credits}`); it is the same
+      gate every other spend passes (`Credits.check_balance/2`), so a comped
+      account and a billing-off deployment are never refused.
     * `charge/3` debits one month for a contact under
       `burn_rent:<contact>:<period_start>` and moves `rent_paid_through` one
-      month on. With enforcement off the debit always lands, negative or not.
-      With it on, a short balance leaves the row unpaid and stamps
-      `rent_due_at`, which starts the grace.
+      month on. A comped account is charged whatever its balance (the ledger
+      is how Finance sees a comp's cost). A short balance leaves the row
+      unpaid and stamps `rent_due_at`, which starts the grace.
     * `collect/1` is the daily pass: charge every contact whose month is up,
       email the tenant at day 0, 3 and 6 of the grace, and release the
       contact on day 7 through `Team.Comms.release_contact/3`. Release is
@@ -40,25 +42,24 @@ defmodule Fountain.Credits.Rent do
 
   @doc "Whether rent is charged at all: credits active and a price set."
   @spec charging?() :: boolean()
-  def charging?, do: Credits.active?() and month_cents() > 0
+  def charging?, do: Fountain.Billing.enabled?() and month_cents() > 0
 
   @doc """
-  Whether a tenant may provision a contact. Only refuses under enforcement,
-  and only when the balance cannot cover the first month.
+  Whether a tenant may provision a contact: the credit gate
+  (`Credits.check_balance/2`, so billing-off and comped pass, and an expired
+  lot does not count) with the first month's rent as the minimum. `:ok` when
+  nothing is charged.
   """
   @spec check_provision(binary()) :: :ok | {:error, :insufficient_credits}
   def check_provision(user_id) when is_binary(user_id) do
-    if Credits.active?() and not comped?(user_id) and month_cents() > 0 and
-         Credits.balance(user_id) < month_cents(),
-       do: {:error, :insufficient_credits},
-       else: :ok
+    if charging?(), do: Credits.check_balance(user_id, min: month_cents()), else: :ok
   end
 
   @doc """
   Debit one month starting at `period_start` for `contact`. Returns
   `{:ok, contact}` with `rent_paid_through` advanced, `{:ok, :duplicate,
   contact}` when that month was already charged, `{:error,
-  :insufficient_credits}` when enforcement refused it (and `rent_due_at` is
+  :insufficient_credits}` when the gate refused it (and `rent_due_at` is
   now set), or `{:ok, :free}` when nothing is charged on this deployment.
   """
   @spec charge(Contact.t(), DateTime.t(), keyword()) ::
@@ -80,8 +81,7 @@ defmodule Fountain.Credits.Rent do
 
         {:ok, :duplicate, contact}
 
-      Credits.active?() and not comped?(contact.user_id) and
-          Credits.balance(contact.user_id) < cents ->
+      Credits.check_balance(contact.user_id, min: cents) != :ok ->
         {:ok, _} = stamp(contact, rent_due_at: contact.rent_due_at || truncate(now))
         {:error, :insufficient_credits}
 
@@ -223,15 +223,6 @@ defmodule Fountain.Credits.Rent do
     day = min(date.day, Date.days_in_month(Date.new!(y, m, 1)))
     {:ok, next} = DateTime.new(Date.new!(y, m, day), DateTime.to_time(at), "Etc/UTC")
     truncate(next)
-  end
-
-  # A comped account is never refused anything (Billing.comp_account/2), rent
-  # included: the month is still written, so Finance sees the cost.
-  defp comped?(user_id) do
-    case Fountain.Accounts.get_user(user_id) do
-      %{comped: true} -> true
-      _ -> false
-    end
   end
 
   defp truncate(dt), do: DateTime.truncate(dt, :second)

--- a/ee/lib/fountain/emails/billing_emails.ex
+++ b/ee/lib/fountain/emails/billing_emails.ex
@@ -124,7 +124,7 @@ defmodule Fountain.Emails.BillingEmails do
 
   @doc """
   The prepaid balance is at or below zero. Whether anything is refused
-  depends on `Fountain.Credits.active?/0`; the email says so either way.
+  depends on `Fountain.Billing.enabled?/0`; the email says so either way.
   """
   @spec deliver_credits_exhausted_email(User.t(), integer()) :: {:ok, term()} | {:error, term()}
   def deliver_credits_exhausted_email(%User{} = user, balance_cents) do
@@ -141,7 +141,7 @@ defmodule Fountain.Emails.BillingEmails do
   end
 
   defp credits_consequence(true) do
-    if Fountain.Credits.active?(),
+    if Fountain.Billing.enabled?(),
       do:
         "New conversations and new turns are paused until the balance is positive again. Anything already running finishes.",
       else: "Nothing is paused yet. Your balance will keep going down until you top up."

--- a/ee/lib/fountain/workers/credits_email.ex
+++ b/ee/lib/fountain/workers/credits_email.ex
@@ -53,7 +53,7 @@ defmodule Fountain.Workers.CreditsEmail do
   """
   @spec notify_after_burn(String.t()) :: :ok
   def notify_after_burn(user_id) when is_binary(user_id) do
-    with true <- Credits.active?(),
+    with true <- Fountain.Billing.enabled?(),
          %{comped: false} = user <-
            Accounts.get_user(user_id) do
       balance = Credits.balance(user)

--- a/ee/lib/fountain_web/controllers/billing_api_controller.ex
+++ b/ee/lib/fountain_web/controllers/billing_api_controller.ex
@@ -44,8 +44,7 @@ defmodule FountainWeb.BillingApiController do
   def show(conn, _params) do
     with :ok <- require_billing() do
       user = conn.assigns.current_user
-      {period_start, period_end} = Billing.current_month_range()
-      period = %{start: period_start, end: period_end}
+      period = Billing.month_range()
 
       render(conn, :show,
         user: user,

--- a/ee/lib/fountain_web/live/admin_finance_live.ex
+++ b/ee/lib/fountain_web/live/admin_finance_live.ex
@@ -123,7 +123,7 @@ defmodule FountainWeb.Live.AdminFinanceLive do
              %{
                "provider" => provider,
                "period_start" => DateTime.to_date(period_start),
-               "period_end" => DateTime.to_date(period_end),
+               "period_end" => period_end |> DateTime.add(-1, :second) |> DateTime.to_date(),
                "amount_cents" => cents,
                "note" => params["note"]
              },
@@ -146,34 +146,11 @@ defmodule FountainWeb.Live.AdminFinanceLive do
     end
   end
 
-  # `months_ago` back from the current month, as a whole UTC month. Zero is
-  # the running month, which is the default and the only one still moving.
-  defp month_range(0), do: Billing.current_month_range()
-
+  # `months_ago` back from the current month, as a whole half-open UTC month
+  # (`Billing.month_range/1`). Zero is the running month, the only one moving.
   defp month_range(months_ago) do
-    now = DateTime.utc_now()
-    total = now.year * 12 + (now.month - 1) - months_ago
-    {year, month} = {div(total, 12), rem(total, 12) + 1}
-
-    start = %DateTime{
-      now
-      | year: year,
-        month: month,
-        day: 1,
-        hour: 0,
-        minute: 0,
-        second: 0,
-        microsecond: {0, 0}
-    }
-
-    %DateTime{
-      start
-      | day: :calendar.last_day_of_the_month(year, month),
-        hour: 23,
-        minute: 59,
-        second: 59
-    }
-    |> then(&{start, &1})
+    %{start: period_start, end: period_end} = Billing.month_range(months_ago)
+    {period_start, period_end}
   end
 
   @impl true

--- a/ee/lib/fountain_web/live/billing_live.ex
+++ b/ee/lib/fountain_web/live/billing_live.ex
@@ -21,8 +21,7 @@ defmodule FountainWeb.Live.BillingLive do
   def mount(_params, _session, socket) do
     if Billing.enabled?() do
       user = socket.assigns.current_user
-      {period_start, period_end} = Billing.current_month_range()
-      period = %{start: period_start, end: period_end}
+      period = Billing.month_range()
 
       {:ok,
        assign(socket,
@@ -154,7 +153,10 @@ defmodule FountainWeb.Live.BillingLive do
       <div class="rounded-lg border bg-white p-6 shadow-sm">
         <h2 class="mb-1 text-lg font-medium">Usage this period</h2>
         <p class="mb-4 text-xs text-gray-400">
-          {Calendar.strftime(@period.start, "%b %-d")} – {Calendar.strftime(@period.end, "%b %-d, %Y")}
+          {Calendar.strftime(@period.start, "%b %-d")} – {Calendar.strftime(
+            DateTime.add(@period.end, -1, :second),
+            "%b %-d, %Y"
+          )}
         </p>
         <dl class="grid grid-cols-3 gap-4">
           <div class="rounded-md bg-gray-50 p-4 text-center">

--- a/ee/test/fountain/billing_test.exs
+++ b/ee/test/fountain/billing_test.exs
@@ -74,6 +74,36 @@ defmodule Fountain.BillingTest do
     end
   end
 
+  describe "month_range/2" do
+    test "is half-open: the last second of the month is inside it" do
+      now = ~U[2026-02-14 12:00:00Z]
+      %{start: s, end: e} = Billing.month_range(0, now: now)
+      assert s == ~U[2026-02-01 00:00:00Z]
+      assert e == ~U[2026-03-01 00:00:00Z]
+      assert DateTime.compare(~U[2026-02-28 23:59:59Z], e) == :lt
+
+      assert %{start: ~U[2025-12-01 00:00:00Z], end: ~U[2026-01-01 00:00:00Z]} =
+               Billing.month_range(2, now: now)
+
+      {ts, te} = Billing.current_month_range()
+      assert ts.day == 1 and te.day == 1 and te.hour == 0
+    end
+
+    test "usage_summary/3 counts an event in the month's last second" do
+      user = insert_verified_user()
+      %{start: s, end: e} = Billing.month_range(0, now: ~U[2026-02-14 12:00:00Z])
+
+      {:ok, _} =
+        Billing.record_usage(user.id, "turn_started", Ecto.UUID.generate(), "conversation")
+
+      Repo.update_all(Fountain.Billing.UsageEvent,
+        set: [inserted_at: ~U[2026-02-28 23:59:59Z]]
+      )
+
+      assert Billing.usage_summary(user.id, s, e).turns == 1
+    end
+  end
+
   describe "emit/5" do
     setup do
       {:ok, user: insert_verified_user()}

--- a/ee/test/fountain/credits_enforcement_test.exs
+++ b/ee/test/fountain/credits_enforcement_test.exs
@@ -54,7 +54,7 @@ defmodule Fountain.CreditsEnforcementTest do
       Application.put_env(:fountain, :billing_enabled, false)
       on_exit(fn -> Application.put_env(:fountain, :billing_enabled, true) end)
       user = subscriber()
-      refute Credits.active?()
+      refute Fountain.Billing.enabled?()
       assert :ok = Credits.gate(user)
       assert :ok = Billing.check_spend(user)
     end
@@ -63,7 +63,7 @@ defmodule Fountain.CreditsEnforcementTest do
   describe "check_spend/1 with billing on" do
     test "zero refuses, positive passes" do
       user = drained(subscriber())
-      assert Credits.active?()
+      assert Fountain.Billing.enabled?()
       assert {:error, :insufficient_credits} = Billing.check_spend(user)
       assert {:error, :insufficient_credits} = Billing.check_spend(user.id)
 

--- a/ee/test/fountain/credits_rent_test.exs
+++ b/ee/test/fountain/credits_rent_test.exs
@@ -110,6 +110,19 @@ defmodule Fountain.Credits.RentTest do
       assert Credits.balance(user.id) == -500
     end
 
+    test "an expired but unswept grant does not fund a contact (the same gate as a turn)" do
+      user = insert_empty_user()
+
+      {:ok, _} =
+        Credits.grant(user.id, 5_000, "grant_opening",
+          idempotency_key: "old",
+          expires_at: ~U[2026-01-01 00:00:00Z]
+        )
+
+      assert Credits.balance(user.id) == 5_000
+      assert {:error, :insufficient_credits} = Rent.check_provision(user.id)
+    end
+
     test "provisioning is refused below a month, and allowed at it" do
       user = insert_empty_user()
       assert {:error, :insufficient_credits} = Rent.check_provision(user.id)

--- a/ee/test/fountain/credits_test.exs
+++ b/ee/test/fountain/credits_test.exs
@@ -179,6 +179,14 @@ defmodule Fountain.CreditsTest do
       assert :ok = Credits.check_balance(user.id, now: ~U[2026-09-01 00:00:01Z])
     end
 
+    test "`:min` raises the bar: rent needs a month, not a cent" do
+      user = insert_empty_user()
+      {:ok, _} = Credits.grant(user.id, 300, "purchase", idempotency_key: "p")
+      assert :ok = Credits.check_balance(user.id)
+      assert :ok = Credits.check_balance(user.id, min: 300)
+      assert {:error, :insufficient_credits} = Credits.check_balance(user.id, min: 301)
+    end
+
     test "zero and negative are insufficient, positive is ok" do
       user = insert_empty_user()
       assert {:error, :insufficient_credits} = Credits.check_balance(user)

--- a/ee/test/fountain_web/credits_surfaces_test.exs
+++ b/ee/test/fountain_web/credits_surfaces_test.exs
@@ -42,7 +42,7 @@ defmodule FountainWeb.CreditsSurfacesTest do
       Application.put_env(:fountain, :billing_enabled, false)
       on_exit(fn -> Application.put_env(:fountain, :billing_enabled, true) end)
       user = subscriber()
-      refute Credits.active?()
+      refute Fountain.Billing.enabled?()
       assert %{active?: false, balance_cents: 0} = Credits.summary(user)
 
       # The billing page does not exist on a billing-off instance; the

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -10,6 +10,14 @@ server releases.
 
 ---
 
+## [1.1.1] — 2026-08-25
+
+### Changed
+
+- `GET /api/account/billing` `period.end` is now the first instant of the
+  next month (a half-open window) rather than `23:59:59` of the last day.
+  Render the window as `end` minus a second.
+
 ## [1.1.0] — 2026-08-25
 
 ### Removed

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Run a coding agent on a real computer, with your repos and your credentials, in one call.",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -3768,7 +3768,7 @@ export interface components {
                     turn_hour_cents?: number;
                 } | null;
                 has_stripe_customer?: boolean;
-                /** @description The calendar month the usage numbers cover. */
+                /** @description The calendar month the usage numbers cover, half-open: `end` is the first instant of the next month. */
                 period?: {
                     /** Format: date-time */
                     end?: string;

--- a/sdk/typescript/src/http.ts
+++ b/sdk/typescript/src/http.ts
@@ -19,7 +19,7 @@ export interface RequestOptions {
  * this string is already what Fountain's request logs are keyed on. The
  * version half is asserted against `package.json` by a test.
  */
-export const USER_AGENT = "fountain-sdk-js/1.1.0";
+export const USER_AGENT = "fountain-sdk-js/1.1.1";
 
 /**
  * The thin layer everything else is built on: one bearer token, JSON in and


### PR DESCRIPTION
First of three PRs from the post-ADR-0031 billing review (the "doing it weirdly because of how we used to" list). Correctness only; 2/3 is deletions and wording, 3/3 is the billing-page usage numbers.

- **The month is half-open.** `Billing.month_range/2` (`%{start, end}`, `:now` pinnable) replaces the hand-rolled windows in the billing API, the billing page, the dashboard, `AdminFinanceLive.month_range/1` and `overview_admin`. `end` is the first instant of the next month; every consumer already filtered `< end`, so the old `23:59:59` end (a Stripe `current_period_end` habit) dropped the last second of every month from every usage query. Displays render `end − 1s`. `GET /api/account/billing` `period.end` moves accordingly — **SDK 1.1.1**, types regenerated, schema description says so.
- **Rent uses the real gate.** `Credits.check_balance/2` takes `min:`; `Rent.check_provision/1` and `charge/3` call it with a month's rent instead of reading `Credits.balance/1` raw (which ignored expired-but-unswept lots) with a private `comped?/1` that loaded the whole user. Billing-off and comped pass by the same short-circuit every other spend uses.
- **Gate before quota, one cap rule.** `with_sandbox_reservation/3` runs `Credits.gate/1` before `check_sandbox_quota/2`, so an unfunded account's cap can be 0 without it ever hearing "0/0 sandboxes": `resolve_limit/3` returns 0 at `balance <= 0`, `sandbox_limit/1` and `sandbox_limit_for/1` agree again (the display-only 0 from #1132 is gone), an unknown id is 0 not the floor.
- **One gate name.** `Credits.gate/1` is `check_balance/2` with defaults; `Credits.active?/0` deleted (it was `Billing.enabled?/0`); the double `enabled?` check is gone.
- `Finance.deferred_cents/0` is public and `overview_admin` uses it instead of its own copy of the query.

Tests: half-open window (an event at 23:59:59 counts; `month_range(2)`), `min:`, an expired grant not funding a contact, the quota tests updated for 0. Full suite locally 3823 tests, one concurrency flake in `CreditsTest` that passes 3/3 alone. Format/credo/sobelow/dialyzer/SDK (72) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
