### PR TITLE
feat(billing): the billing page shows what was charged (billing debt 3/3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ upgrade, is in
 
 ## [Unreleased]
 
+### Changed
+
+- **Billing debt 3/3: the billing page shows what was charged.**
+  `usage_summary/3` (billing page, dashboard, `GET /api/account/billing`)
+  and the admin table count conversations as the ones that ran a turn in
+  the month — from `turn_started` events, which survive a deleted
+  conversation and cover a persistent home that provisions nothing — rather
+  than as sandbox provisions, and carry `credit_burned_cents`: what the
+  ledger actually took for the window, shown as "Spent" beside the metered
+  hours. SDK 1.2.0.
+
 ### Removed
 
 - **Billing debt 2/3: dead Stripe plumbing and the last plan-era wording.**

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -1837,8 +1837,19 @@ defmodule FountainWeb.Schemas do
             usage: %Schema{
               type: :object,
               properties: %{
-                conversations: %Schema{type: :integer},
+                conversations: %Schema{
+                  type: :integer,
+                  description: "Conversations that ran a turn in the month, deleted or not."
+                },
                 turns: %Schema{type: :integer},
+                credit_burned_cents: %Schema{
+                  type: :integer,
+                  nullable: true,
+                  description:
+                    "Cents the ledger took this month: turns, rent and messages. " <>
+                      "The charged number, where turn_hours is the metered one. " <>
+                      "Null with billing off."
+                },
                 turn_hours: %Schema{
                   type: :number,
                   description:

--- a/apps/fountain/test/fountain_web/live/admin_users_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/admin_users_live_test.exs
@@ -446,8 +446,11 @@ defmodule FountainWeb.AdminUsersLiveTest do
     test "shows 30-day usage per user", %{conn: conn} do
       admin = insert_admin()
       user = insert_active_user()
-      {:ok, _} = Fountain.Billing.record_usage(user.id, "turn_started", nil, nil)
-      {:ok, _} = Fountain.Billing.record_usage(user.id, "sandbox_provisioned", nil, nil)
+
+      {:ok, _} =
+        Fountain.Billing.record_usage(user.id, "turn_started", nil, nil, %{
+          "conversation_id" => Ecto.UUID.generate()
+        })
 
       conn = login_user(conn, admin)
       {:ok, _lv, html} = live(conn, ~p"/admin/users")

--- a/docs/api.md
+++ b/docs/api.md
@@ -150,6 +150,12 @@ The checkout refuses a comped account with `422`. It answers `502` when
 Stripe is unreachable, and guesses nothing. On an instance with payment off,
 both endpoints are a `404` with `"billing": "disabled"`.
 
+`GET /api/account/billing` reports the month as `usage`. The `conversations`
+count is the conversations that ran a turn in the month. The
+`credit_burned_cents` value is the credit the ledger took in the month, and
+`turn_hours` is the metered time. The two do not agree to the cent, because the
+pricer charges a turn when it ends.
+
 `GET /api/auth/me` carries `comped`. It is `true` for an account an operator
 made free, and `null` when payment is off.
 

--- a/ee/lib/fountain/billing.ex
+++ b/ee/lib/fountain/billing.ex
@@ -340,26 +340,28 @@ defmodule Fountain.Billing do
           %{
             conversations: non_neg_integer(),
             turns: non_neg_integer(),
+            credit_burned_cents: non_neg_integer(),
             sandbox_minutes: float(),
             sandbox_minutes_by_provider: %{optional(String.t()) => float()},
             turn_hours: float()
           }
   def usage_summary(user_id, %DateTime{} = period_start, %DateTime{} = period_end) do
-    events =
+    # Counted from `turn_started` events, which survive a deleted
+    # conversation: a conversation is one that ran a turn in the window,
+    # whichever sandbox it ran on (a conversation on a persistent home
+    # provisions nothing, ADR 0023, so a provision count missed it).
+    {turns, conversations} =
       from(e in UsageEvent,
         where:
           e.user_id == ^user_id and
             e.inserted_at >= ^period_start and
             e.inserted_at < ^period_end and
-            e.event_type in ["sandbox_provisioned", "sandbox_provision_failed", "turn_started"],
-        select: e.event_type
+            e.event_type == "turn_started",
+        select: {count(e.id), count(fragment("distinct ? ->> 'conversation_id'", e.metadata))}
       )
-      |> Repo.all()
+      |> Repo.one()
 
-    conversations =
-      Enum.count(events, &(&1 in ["sandbox_provisioned", "sandbox_provision_failed"]))
-
-    turns = Enum.count(events, &(&1 == "turn_started"))
+    burned = Fountain.Credits.burned_between(user_id, period_start, period_end)
 
     # One attribution pass, read two ways. `for_user/3` and `busy_for_user/3`
     # would each run it again; this is the same two queries once.
@@ -368,6 +370,10 @@ defmodule Fountain.Billing do
     %{
       conversations: conversations,
       turns: turns,
+      # What the ledger actually took for the window: the number the customer
+      # was charged, as opposed to `turn_hours`, which is what will be charged
+      # when the in-flight turns close.
+      credit_burned_cents: burned,
       # Rounded once, from the total — summing rounded per-provider minutes
       # would let the parts disagree with the whole.
       sandbox_minutes:
@@ -391,7 +397,9 @@ defmodule Fountain.Billing do
 
   Returns `%{user_id => %{conversations: n, turns: n, sandbox_minutes: f,
   sandbox_minutes_by_provider: %{provider => f}, turn_hours: f}}`; users with
-  neither events nor sandbox time in the period are absent.
+  neither turns nor sandbox time in the period are absent. Conversations are
+  the ones that ran a turn in the window, as in `usage_summary/3`; the
+  ledger's burn is `Finance`'s to report, not this table's.
 
   Carries two units on purpose, because they answer different questions and
   the admin table shows both. `sandbox_minutes` is wall-clock sandbox time —
@@ -415,27 +423,15 @@ defmodule Fountain.Billing do
       from(e in UsageEvent,
         where:
           e.inserted_at >= ^period_start and e.inserted_at < ^period_end and
-            e.event_type in ["sandbox_provisioned", "sandbox_provision_failed", "turn_started"],
-        group_by: [e.user_id, e.event_type],
-        select: {e.user_id, e.event_type, count(e.id)}
+            e.event_type == "turn_started",
+        group_by: e.user_id,
+        select:
+          {e.user_id, count(e.id),
+           count(fragment("distinct ? ->> 'conversation_id'", e.metadata))}
       )
       |> Repo.all()
-      |> Enum.reduce(%{}, fn {user_id, type, count}, acc ->
-        summary = Map.get(acc, user_id, empty)
-
-        summary =
-          case type do
-            "sandbox_provisioned" ->
-              %{summary | conversations: summary.conversations + count}
-
-            "sandbox_provision_failed" ->
-              %{summary | conversations: summary.conversations + count}
-
-            "turn_started" ->
-              %{summary | turns: count}
-          end
-
-        Map.put(acc, user_id, summary)
+      |> Map.new(fn {user_id, turns, conversations} ->
+        {user_id, %{empty | turns: turns, conversations: conversations}}
       end)
 
     # Both sandbox figures come from the sandbox rows, not from these events —

--- a/ee/lib/fountain/credits.ex
+++ b/ee/lib/fountain/credits.ex
@@ -199,6 +199,29 @@ defmodule Fountain.Credits do
     |> Repo.all()
   end
 
+  @doc """
+  Cents the ledger took from one tenant in `[period_start, period_end)`:
+  every `burn_*` row by `inserted_at`, as a positive number. Zero with
+  billing off. This is what the customer was charged for the window; the
+  usage numbers beside it are what will be charged when in-flight turns
+  close, and the two are not expected to agree to the cent.
+  """
+  @spec burned_between(binary(), DateTime.t(), DateTime.t()) :: non_neg_integer()
+  def burned_between(user_id, %DateTime{} = period_start, %DateTime{} = period_end)
+      when is_binary(user_id) do
+    if Billing.enabled?() do
+      from(e in LedgerEntry,
+        where: e.user_id == ^user_id and like(e.reason, "burn_%"),
+        where: e.inserted_at >= ^period_start and e.inserted_at < ^period_end,
+        select: coalesce(sum(e.amount_cents), 0)
+      )
+      |> Repo.one()
+      |> Kernel.-()
+    else
+      0
+    end
+  end
+
   @doc "One entry by idempotency key, or nil."
   @spec get_by_key(String.t()) :: LedgerEntry.t() | nil
   def get_by_key(key) when is_binary(key), do: Repo.get_by(LedgerEntry, idempotency_key: key)

--- a/ee/lib/fountain_web/controllers/billing_api_json.ex
+++ b/ee/lib/fountain_web/controllers/billing_api_json.ex
@@ -12,6 +12,8 @@ defmodule FountainWeb.BillingApiJSON do
         usage: %{
           conversations: usage.conversations,
           turns: usage.turns,
+          # What the ledger took this month, in cents; null with billing off.
+          credit_burned_cents: if(Fountain.Billing.enabled?(), do: usage.credit_burned_cents),
           # Hours with a prompt in flight, on providers Fountain pays for —
           # what burns credit (ADR 0030). Distinct from `sandbox_minutes`,
           # which is wall-clock and includes idle.

--- a/ee/lib/fountain_web/live/billing_live.ex
+++ b/ee/lib/fountain_web/live/billing_live.ex
@@ -158,7 +158,13 @@ defmodule FountainWeb.Live.BillingLive do
             "%b %-d, %Y"
           )}
         </p>
-        <dl class="grid grid-cols-3 gap-4">
+        <dl class="grid grid-cols-4 gap-4">
+          <div class="rounded-md bg-gray-50 p-4 text-center">
+            <dt class="text-xs text-gray-500">Spent</dt>
+            <dd class="mt-1 text-2xl font-semibold">
+              {Credits.format_cents(@usage.credit_burned_cents)}
+            </dd>
+          </div>
           <div class="rounded-md bg-gray-50 p-4 text-center">
             <dt class="text-xs text-gray-500">Conversations</dt>
             <dd class="mt-1 text-2xl font-semibold">{@usage.conversations}</dd>

--- a/ee/test/fountain/billing_test.exs
+++ b/ee/test/fountain/billing_test.exs
@@ -22,33 +22,32 @@ defmodule Fountain.BillingTest do
       assert summary.sandbox_minutes == 0.0
     end
 
-    test "counts sandbox_provisioned events as conversations", %{user: user} do
-      insert_event(user, "sandbox_provisioned", ~U[2026-05-10 12:00:00Z])
-      insert_event(user, "sandbox_provisioned", ~U[2026-05-15 09:00:00Z])
-
-      summary = Billing.usage_summary(user.id, @period_start, @period_end)
-
-      assert summary.conversations == 2
-      assert summary.turns == 0
-    end
-
-    test "counts sandbox_provision_failed events as conversations too", %{user: user} do
+    test "a conversation is one that ran a turn; a provision alone is not one", %{user: user} do
+      c1 = Ecto.UUID.generate()
+      c2 = Ecto.UUID.generate()
       insert_event(user, "sandbox_provisioned", ~U[2026-05-10 12:00:00Z])
       insert_event(user, "sandbox_provision_failed", ~U[2026-05-11 12:00:00Z])
+      insert_event(user, "turn_started", ~U[2026-05-10 12:00:00Z], %{"conversation_id" => c1})
+      insert_event(user, "turn_started", ~U[2026-05-10 12:05:00Z], %{"conversation_id" => c1})
+      insert_event(user, "turn_started", ~U[2026-05-12 12:10:00Z], %{"conversation_id" => c2})
 
       summary = Billing.usage_summary(user.id, @period_start, @period_end)
 
       assert summary.conversations == 2
+      assert summary.turns == 3
     end
 
-    test "counts turn_started events as turns", %{user: user} do
-      insert_event(user, "turn_started", ~U[2026-05-10 12:00:00Z])
-      insert_event(user, "turn_started", ~U[2026-05-10 12:05:00Z])
-      insert_event(user, "turn_started", ~U[2026-05-10 12:10:00Z])
+    test "credit_burned_cents is what the ledger took in the window", %{user: user} do
+      {:ok, _} =
+        Fountain.Credits.debit(user.id, 40, "burn_turn", idempotency_key: "in-#{user.id}")
 
-      summary = Billing.usage_summary(user.id, @period_start, @period_end)
+      {:ok, _} =
+        Fountain.Credits.debit(user.id, 7, "burn_message", idempotency_key: "in2-#{user.id}")
 
-      assert summary.turns == 3
+      now = DateTime.utc_now()
+      %{start: s, end: e} = Billing.month_range(0, now: now)
+      assert Billing.usage_summary(user.id, s, e).credit_burned_cents == 47
+      assert Billing.usage_summary(user.id, @period_start, @period_end).credit_burned_cents == 0
     end
 
     test "sums the sandboxes' active time into sandbox_minutes", %{user: user} do
@@ -62,9 +61,9 @@ defmodule Fountain.BillingTest do
 
     test "excludes events outside the period", %{user: user} do
       # One second before period start - excluded
-      insert_event(user, "turn_started", ~U[2026-04-30 23:59:59Z])
+      insert_event(user, "turn_started", ~U[2026-04-30 23:59:59Z], %{"conversation_id" => "a"})
       # Exactly at period_end - excluded (query uses `< ^period_end`)
-      insert_event(user, "sandbox_provisioned", ~U[2026-06-01 00:00:00Z])
+      insert_event(user, "turn_started", ~U[2026-06-01 00:00:00Z], %{"conversation_id" => "b"})
 
       summary = Billing.usage_summary(user.id, @period_start, @period_end)
 
@@ -276,10 +275,11 @@ defmodule Fountain.BillingTest do
       b = insert_verified_user()
       quiet = insert_verified_user()
 
+      c = Ecto.UUID.generate()
       {:ok, _} = Billing.record_usage(a.id, "sandbox_provisioned", nil, nil)
-      {:ok, _} = Billing.record_usage(a.id, "turn_started", nil, nil)
-      {:ok, _} = Billing.record_usage(a.id, "turn_started", nil, nil)
-      {:ok, _} = Billing.record_usage(b.id, "turn_started", nil, nil)
+      {:ok, _} = Billing.record_usage(a.id, "turn_started", nil, nil, %{"conversation_id" => c})
+      {:ok, _} = Billing.record_usage(a.id, "turn_started", nil, nil, %{"conversation_id" => c})
+      {:ok, _} = Billing.record_usage(b.id, "turn_started", nil, nil, %{"conversation_id" => c})
 
       now = DateTime.utc_now() |> DateTime.truncate(:second)
 
@@ -298,7 +298,7 @@ defmodule Fountain.BillingTest do
              }
 
       assert summaries[b.id] == %{
-               conversations: 0,
+               conversations: 1,
                turns: 1,
                sandbox_minutes: 0.0,
                sandbox_minutes_by_provider: %{},
@@ -308,16 +308,20 @@ defmodule Fountain.BillingTest do
       refute Map.has_key?(summaries, quiet.id)
     end
 
-    test "failed provisioning attempts count as conversations" do
+    test "a conversation is one that ran a turn; provisions, failed or not, are not counted" do
       a = insert_verified_user()
+      c = Ecto.UUID.generate()
 
       {:ok, _} = Billing.record_usage(a.id, "sandbox_provisioned", nil, nil)
       {:ok, _} = Billing.record_usage(a.id, "sandbox_provision_failed", nil, nil)
+      {:ok, _} = Billing.record_usage(a.id, "turn_started", nil, nil, %{"conversation_id" => c})
+      {:ok, _} = Billing.record_usage(a.id, "turn_started", nil, nil, %{"conversation_id" => c})
 
       now = DateTime.utc_now()
       summaries = Billing.usage_summaries(DateTime.add(now, -1, :day), DateTime.add(now, 1, :day))
 
-      assert summaries[a.id].conversations == 2
+      assert summaries[a.id].conversations == 1
+      assert summaries[a.id].turns == 2
     end
 
     test "subtracts parked time per sandbox, per user (#665)" do

--- a/ee/test/fountain/usage_metering_test.exs
+++ b/ee/test/fountain/usage_metering_test.exs
@@ -201,10 +201,11 @@ defmodule Fountain.UsageMeteringTest do
       assert events_for(user.id, "sandbox_provision_failed") == []
     end
 
-    test "keeps the two billing-page numbers in agreement when provisioning fails" do
-      # Before this event existed, a sandbox that died during provisioning
-      # contributed sandbox minutes but no conversation, so the billing page
-      # diverged for exactly the accounts where something was going wrong.
+    test "a sandbox that died provisioning is minutes with no conversation, and says so" do
+      # A conversation is one that ran a turn (billing debt 3/3). A sandbox
+      # that died during provisioning ran none, so it is sandbox minutes with
+      # no conversation beside them — which is the honest reading of "cost
+      # with nothing to show for it" — and its death is still on record.
       user = insert_verified_user()
       sandbox = insert_sandbox(user_id: user.id, status: "starting")
 
@@ -221,7 +222,7 @@ defmodule Fountain.UsageMeteringTest do
           DateTime.utc_now() |> DateTime.add(3600, :second)
         )
 
-      assert summary.conversations == 1
+      assert summary.conversations == 0
       assert length(events_for(user.id, "sandbox_terminated")) == 1
     end
   end
@@ -306,6 +307,11 @@ defmodule Fountain.UsageMeteringTest do
 
       insert_sandbox(user_id: a.id, status: "pending")
       |> Conversations.update_sandbox(%{status: "ready"})
+
+      {:ok, _} =
+        Billing.record_usage(a.id, "turn_started", nil, nil, %{
+          "conversation_id" => Ecto.UUID.generate()
+        })
 
       window = {
         DateTime.utc_now() |> DateTime.add(-3600, :second),

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -10,6 +10,20 @@ server releases.
 
 ---
 
+## [1.2.0] — 2026-08-25
+
+### Added
+
+- `GET /api/account/billing` `usage.credit_burned_cents`: what the ledger
+  took this month (turns, rent, messages) — the charged number, where
+  `usage.turn_hours` is the metered one. Null with billing off.
+
+### Changed
+
+- `usage.conversations` counts conversations that ran a turn in the month,
+  deleted or not, rather than sandbox provisions; a conversation on a
+  persistent home is now counted.
+
 ## [1.1.1] — 2026-08-25
 
 ### Changed

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Run a coding agent on a real computer, with your repos and your credentials, in one call.",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -3778,7 +3778,10 @@ export interface components {
                 /** @description How many sandboxes this account may run at once: an admin override, or what the balance funds (ADR 0031). */
                 sandbox_cap?: number;
                 usage: {
+                    /** @description Conversations that ran a turn in the month, deleted or not. */
                     conversations?: number;
+                    /** @description Cents the ledger took this month: turns, rent and messages. The charged number, where turn_hours is the metered one. Null with billing off. */
+                    credit_burned_cents?: number | null;
                     /** @description Active sandbox minutes inside the period, parked time excluded. */
                     sandbox_minutes?: number;
                     /** @description sandbox_minutes split by sandbox provider (sprites, e2b, daytona, runner). Providers not used in the period are absent. */

--- a/sdk/typescript/src/http.ts
+++ b/sdk/typescript/src/http.ts
@@ -19,7 +19,7 @@ export interface RequestOptions {
  * this string is already what Fountain's request logs are keyed on. The
  * version half is asserted against `package.json` by a test.
  */
-export const USER_AGENT = "fountain-sdk-js/1.1.1";
+export const USER_AGENT = "fountain-sdk-js/1.2.0";
 
 /**
  * The thin layer everything else is built on: one bearer token, JSON in and


### PR DESCRIPTION
Last of three from the post-ADR-0031 billing review; follows #1138 and #1139.

The billing page's usage numbers came from three stores that disagreed by construction: `conversations` was a count of sandbox provisions (a conversation on a persistent home under ADR 0023 provisions nothing and was never counted), and nothing showed what the ledger actually took — the only number the customer was charged.

- **A conversation is one that ran a turn in the month.** `usage_summary/3` and `usage_summaries/2` count distinct `conversation_id`s among `turn_started` events in the window: it survives a deleted conversation (the original reason for counting from events) and covers shared/persistent sandboxes. A sandbox that died provisioning is minutes with no conversation beside them, which is the honest reading; its `sandbox_terminated` row is still the record.
- **`credit_burned_cents`** — `Credits.burned_between/3`, every `burn_*` row in `[start, end)` — is on `usage_summary/3`, shown as **Spent** on the billing page beside the metered hours, and returned by `GET /api/account/billing` (`usage.credit_burned_cents`, null with billing off). The docs say the two do not agree to the cent because a turn is charged when it ends. **SDK 1.2.0** (additive), types regenerated.

Tests updated for the new definition (`billing_test`, `usage_metering_test`, admin users table) plus new ones for the burn figure. Full suite locally 3858 tests; format/credo/dialyzer/sobelow/vale/docs-style/SDK (72) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
