### PR TITLE
feat(brand): the hosted site says it is the hosted enterprise edition of Fountain

### DIFF
--- a/apps/fountain/lib/fountain_web/components/layouts/marketing.html.heex
+++ b/apps/fountain/lib/fountain_web/components/layouts/marketing.html.heex
@@ -55,7 +55,7 @@
       <span :if={Fountain.Marketing.site?()}>
         © 2026 {Fountain.Brand.name()}. Managed agent infrastructure for teams who'd rather build than configure.
         <span :if={Fountain.Brand.hosted?()}>
-          Built on {Fountain.Brand.engine()}, open source.
+          The hosted enterprise edition of {Fountain.Brand.engine()}, which is open source.
         </span>
       </span>
       <span :if={!Fountain.Marketing.site?()}>Powered by Fountain.</span>

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -1,5 +1,14 @@
 <%!-- Hero --%>
 <section class="max-w-5xl mx-auto px-6 py-20 text-center">
+  <%!-- On a branded hosted site, say what this is before the pitch: the
+        hosted, enterprise edition of the open-source engine. --%>
+  <p
+    :if={Fountain.Brand.hosted?()}
+    class="mb-4 text-sm font-medium uppercase tracking-wide text-[var(--color-text-muted)]"
+    data-role="hosted-enterprise"
+  >
+    {Fountain.Brand.name()} is the hosted enterprise edition of {Fountain.Brand.engine()}
+  </p>
   <h1 class="text-4xl sm:text-5xl font-bold tracking-tight text-[var(--color-text-primary)] mb-5 leading-tight">
     Have the conversation. Skip the infrastructure.
   </h1>

--- a/apps/fountain/test/fountain_web/brand_chrome_test.exs
+++ b/apps/fountain/test/fountain_web/brand_chrome_test.exs
@@ -44,7 +44,9 @@ defmodule FountainWeb.BrandChromeTest do
     assert home =~ "Managoat scrubs them from the output"
     assert home =~ ">fountain</code> CLI"
     assert home =~ "© 2026 Managoat."
-    assert home =~ "Built on Fountain, open source."
+    assert home =~ ~s(data-role="hosted-enterprise")
+    assert home =~ "Managoat is the hosted enterprise edition of Fountain"
+    assert home =~ "The hosted enterprise edition of Fountain, which is open source."
 
     for path <- [~p"/terms", ~p"/privacy"] do
       html = conn |> get(path) |> html_response(200)
@@ -59,7 +61,7 @@ defmodule FountainWeb.BrandChromeTest do
     Application.delete_env(:fountain, :product_name)
     home = conn |> get(~p"/") |> html_response(200)
     assert home =~ "© 2026 Fountain."
-    refute home =~ "Built on Fountain"
+    refute home =~ "hosted enterprise edition"
   end
 
   test "without the brand the docs show no note", %{conn: conn} do


### PR DESCRIPTION
An eyebrow line above the hero headline ("Managoat is the hosted enterprise edition of Fountain") and the footer credit reworded to match. Both render only on a branded hosted site; the project's own site and other deployments are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)