### PR TITLE
refactor(billing): provider_spend and Finance.cost read one fold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ upgrade, is in
 
 ### Changed
 
+- `Billing.provider_spend/1` (the `/admin` and `/admin/sandboxes` hours) and
+  `Finance.cost/3` (the money on `/admin/finance`) read one fold,
+  `Finance.platform_totals/1`, instead of each summing the attribution rows
+  their own way.
+
+### Changed
+
 - **Billing debt 3/3: the billing page shows what was charged.**
   `usage_summary/3` (billing page, dashboard, `GET /api/account/billing`)
   and the admin table count conversations as the ones that ran a turn in

--- a/ee/lib/fountain/billing.ex
+++ b/ee/lib/fountain/billing.ex
@@ -515,15 +515,17 @@ defmodule Fountain.Billing do
       end
 
     rows = SandboxUsage.attribution(period_start, period_end, attribution_opts)
-    paid = Enum.filter(rows, &SandboxUsage.platform_cost?(&1.provider))
+    # The same fold `Finance.cost/3` reads, so the hours here and the money
+    # on /admin/finance are one computation.
+    totals = Finance.platform_totals(rows)
 
     %{
       period_start: period_start,
       period_end: period_end,
-      by_provider: SandboxUsage.by_provider(rows),
-      platform_seconds: paid |> Enum.map(& &1.active_seconds) |> Enum.sum(),
-      platform_idle_seconds: paid |> Enum.map(& &1.idle_seconds) |> Enum.sum(),
-      top_tenants: top_tenants(paid, Keyword.get(opts, :top, 10)),
+      by_provider: totals.by_provider,
+      platform_seconds: totals.active_seconds,
+      platform_idle_seconds: totals.idle_seconds,
+      top_tenants: top_tenants(totals.paid, Keyword.get(opts, :top, 10)),
       attribution: rows
     }
   end

--- a/ee/lib/fountain/billing/finance.ex
+++ b/ee/lib/fountain/billing/finance.ex
@@ -313,11 +313,11 @@ defmodule Fountain.Billing.Finance do
   """
   @spec cost([tenant_row()], [SandboxUsage.row()], map()) :: map()
   def cost(tenants, rows, card) do
-    paid = Enum.filter(rows, &SandboxUsage.platform_cost?(&1.provider))
+    %{paid: paid, active_seconds: active, idle_seconds: idle} = platform_totals(rows)
 
     %{
-      active_hours: paid |> Enum.map(& &1.active_seconds) |> Enum.sum() |> SandboxUsage.hours(),
-      idle_hours: paid |> Enum.map(& &1.idle_seconds) |> Enum.sum() |> SandboxUsage.hours(),
+      active_hours: SandboxUsage.hours(active),
+      idle_hours: SandboxUsage.hours(idle),
       basis: card.basis,
       sandbox_cents:
         sum_or_nil(paid, &provider_cost_cents(billed_seconds(&1, card.basis), &1.provider, card)),
@@ -335,6 +335,30 @@ defmodule Fountain.Billing.Finance do
       emails_sent: tenants |> Enum.map(& &1.emails_sent) |> Enum.sum(),
       sms_sent: tenants |> Enum.map(& &1.sms_sent) |> Enum.sum(),
       sms_received: tenants |> Enum.map(& &1.sms_received) |> Enum.sum(),
+      by_provider: SandboxUsage.by_provider(rows)
+    }
+  end
+
+  @doc """
+  The platform-paid part of an attribution: the rows on providers Fountain
+  pays for, their active and idle seconds summed, and the per-provider split
+  of every row. The one fold behind both `cost/3` and
+  `Billing.provider_spend/1`, so the finance page and the `/admin` tiles
+  cannot disagree about what Fountain was billed for.
+  """
+  @spec platform_totals([SandboxUsage.row()]) :: %{
+          paid: [SandboxUsage.row()],
+          active_seconds: non_neg_integer(),
+          idle_seconds: non_neg_integer(),
+          by_provider: map()
+        }
+  def platform_totals(rows) when is_list(rows) do
+    paid = Enum.filter(rows, &SandboxUsage.platform_cost?(&1.provider))
+
+    %{
+      paid: paid,
+      active_seconds: paid |> Enum.map(& &1.active_seconds) |> Enum.sum(),
+      idle_seconds: paid |> Enum.map(& &1.idle_seconds) |> Enum.sum(),
       by_provider: SandboxUsage.by_provider(rows)
     }
   end


### PR DESCRIPTION
The last code item from the post-ADR-0031 billing review (after #1138–#1140). `Billing.provider_spend/1` and `Finance.cost/3` each filtered the attribution rows to platform-paid providers and summed active/idle seconds their own way; `Finance.platform_totals/1` is now the one fold behind both, so the hours on `/admin` and the money on `/admin/finance` cannot drift. No behaviour change; same keys, same numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)