### PR TITLE
feat(credits): BILLING_ENABLED is CREDITS_ENABLED; the credit surfaces are named for what they are

### DIFF
--- a/.env.compose.example
+++ b/.env.compose.example
@@ -61,7 +61,7 @@ FOUNTAIN_IMAGE_TAG=v0.12.0
 # The subscription gate. Off by default — it exists for the hosted service
 # and is a lock with no key on your own instance. Set true (with Stripe
 # configured) to enforce it.
-# BILLING_ENABLED=true
+# CREDITS_ENABLED=true
 
 # Point at a different Sprites endpoint. Defaults to the hosted service.
 # SPRITES_BASE_URL=https://api.sprites.dev

--- a/.env.example
+++ b/.env.example
@@ -134,7 +134,7 @@ SPRITES_TOKEN=
 
 # The legal identity /terms and /privacy render — yours, not the Fountain
 # project's. All four or none: partially set refuses to boot. Unset, the pages
-# are hidden and their links removed (or, with BILLING_ENABLED=true, served
+# are hidden and their links removed (or, with CREDITS_ENABLED=true, served
 # with loud {{...}} placeholders — an instance charging money should publish
 # terms).
 # LEGAL_ENTITY=Example Corp Inc.
@@ -237,9 +237,10 @@ GITHUB_OAUTH_CLIENT_SECRET=
 # shown. On, every account is prepaid — an opening credit at verification,
 # packs sold through Stripe Checkout, a 402 at zero. That is meaningful for
 # the hosted instance and a lock with no key on a self-hosted one.
-# BILLING_ENABLED=true
+# CREDITS_ENABLED=true
+# (BILLING_ENABLED is the old name and still read, with a warning, for one release.)
 
-# Stripe billing (only with BILLING_ENABLED=true)
+# Stripe billing (only with CREDITS_ENABLED=true)
 STRIPE_SECRET_KEY=
 STRIPE_WEBHOOK_SECRET=
 

--- a/.github/workflows/release-bump.yml
+++ b/.github/workflows/release-bump.yml
@@ -93,7 +93,7 @@ jobs:
           # Pre-1.0, a minor may break; the changelog header promises such a
           # release carries an "Upgrade notes" section. The heading-exists
           # check above cannot see a missing section, which is how the
-          # BILLING_ENABLED flip nearly shipped without one. A minor with
+          # CREDITS_ENABLED flip nearly shipped without one. A minor with
           # genuinely nothing to note still gets the section, saying so —
           # explicit beats absent.
           section="$(awk -v ver="## [${NEXT}]" '

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ upgrade, is in
 
 ## [Unreleased]
 
+### Upgrade notes
+
+- **`BILLING_ENABLED` is `CREDITS_ENABLED`** (#1144). The old name is still
+  read for one release and logs a deprecation warning at boot; rename it in
+  your environment before the next minor. The Oban queue `billing` is
+  `credits` (a migration moves any waiting job). `FountainWeb.Live.BillingLive`,
+  `BillingApiController` and `Fountain.Emails.BillingEmails` are
+  `CreditsLive`, `CreditsApiController` and `CreditsEmails`; routes and API
+  paths are unchanged.
+
 ### Changed
 
 - `Billing.provider_spend/1` (the `/admin` and `/admin/sandboxes` hours) and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ fountain/                  umbrella root
 
 ## Credits are the product (ADR 0031)
 
-There are no plans, no tiers and no subscription. `BILLING_ENABLED` means
+There are no plans, no tiers and no subscription. `CREDITS_ENABLED` means
 "credits on"; off, nothing is priced, granted, gated or shown. Six rules
 that are easy to get wrong:
 
@@ -412,7 +412,7 @@ See `.env.example` for the full list. Key ones for local dev:
 | `MASTER_SECRETS_KEY` | Platform master key for envelope encryption |
 | `SPRITES_TOKEN` | Token for the Sprites sandbox platform |
 | `GITHUB_OAUTH_CLIENT_ID/SECRET` | GitHub OAuth app |
-| `STRIPE_SECRET_KEY` / `STRIPE_WEBHOOK_SECRET` | Credit-pack Checkout and the three credit webhooks (`BILLING_ENABLED=true` only) |
+| `STRIPE_SECRET_KEY` / `STRIPE_WEBHOOK_SECRET` | Credit-pack Checkout and the three credit webhooks (`CREDITS_ENABLED=true` only) |
 | `RESEND_API_KEY` | Transactional email |
 
 ## Docs (`docs/`)

--- a/apps/fountain/lib/fountain/emails/user_emails.ex
+++ b/apps/fountain/lib/fountain/emails/user_emails.ex
@@ -9,7 +9,7 @@ defmodule Fountain.Emails.UserEmails do
   - Email-change confirmation + notice (from `Workers.EmailChangeEmail`)
 
   The welcome and the credit emails (credits low, exhausted, rent due) live
-  in `Fountain.Emails.BillingEmails` under ee/ (#475) — it borrows
+  in `Fountain.Emails.CreditsEmails` under ee/ (#475) — it borrows
   `from_address/0` and `support_phrase/0` from here so the whole mail
   surface keeps one sender and one support-contact policy.
   """
@@ -286,11 +286,11 @@ defmodule Fountain.Emails.UserEmails do
   end
 
   # The deployment's brand (PRODUCT_NAME), which is what every subject line and
-  # body calls the service. Public: BillingEmails (ee/) shares it too.
+  # body calls the service. Public: CreditsEmails (ee/) shares it too.
   @doc false
   def brand, do: Fountain.Brand.name()
 
-  # Public (not defp): Fountain.Emails.BillingEmails (ee/) shares the sender
+  # Public (not defp): Fountain.Emails.CreditsEmails (ee/) shares the sender
   # and support-contact policy rather than duplicating it.
   @doc false
   def from_address do

--- a/apps/fountain/lib/fountain/funnel.ex
+++ b/apps/fountain/lib/fountain/funnel.ex
@@ -89,7 +89,7 @@ defmodule Fountain.Funnel do
     # nothing is granted or sold, so the stage stays in the list at 0 to keep
     # the telemetry gauge's shape — the admin panel hides the tile (#481).
     funded =
-      if Fountain.Billing.enabled?(),
+      if Fountain.Credits.enabled?(),
         do: Enum.filter(users, &(&1.credit_balance_cents > 0)),
         else: []
 

--- a/apps/fountain/lib/fountain/legal.ex
+++ b/apps/fountain/lib/fountain/legal.ex
@@ -38,13 +38,13 @@ defmodule Fountain.Legal do
   True when the operator configured a legal identity, or when billing is
   enabled (placeholders stay loud rather than the pages going dark).
   """
-  def published?, do: configured() != nil or Fountain.Billing.enabled?()
+  def published?, do: configured() != nil or Fountain.Credits.enabled?()
 
   @doc """
   The map the legal templates render: the configured identity, the loud
   placeholders on a billing-enabled instance, or `nil` (pages unpublished).
   """
   def content do
-    configured() || if Fountain.Billing.enabled?(), do: @placeholders
+    configured() || if Fountain.Credits.enabled?(), do: @placeholders
   end
 end

--- a/apps/fountain/lib/fountain/marketing.ex
+++ b/apps/fountain/lib/fountain/marketing.ex
@@ -13,9 +13,9 @@ defmodule Fountain.Marketing do
 
   Off unless `MARKETING_SITE=true` (config/runtime.exs), so a self-host is
   right by default and the hosted deployment opts in — the same shape, for the
-  same reason, as `BILLING_ENABLED` (#336).
+  same reason, as `CREDITS_ENABLED` (#336).
 
-  Deliberately *not* `Fountain.Billing.enabled?/0`, the closest existing flag.
+  Deliberately *not* `Fountain.Credits.enabled?/0`, the closest existing flag.
   Billing says "this instance charges money", which an operator running
   Fountain commercially inside their own company may well turn on. That must
   not hand them a homepage selling somebody else's product.

--- a/apps/fountain/lib/fountain/quotas.ex
+++ b/apps/fountain/lib/fountain/quotas.ex
@@ -117,7 +117,7 @@ defmodule Fountain.Quotas do
     %{reserve_cents: reserve, cap_floor: floor, cap_ceiling: ceiling} = settings()
 
     cond do
-      not Fountain.Billing.enabled?() -> ceiling
+      not Fountain.Credits.enabled?() -> ceiling
       comped == true -> ceiling
       # Nothing in the balance funds nothing. The credit gate runs before the
       # quota check under the reservation lock, so this account is refused as

--- a/apps/fountain/lib/fountain_web/components/layouts.ex
+++ b/apps/fountain/lib/fountain_web/components/layouts.ex
@@ -101,7 +101,7 @@ defmodule FountainWeb.Layouts do
               <.nav_link href={~p"/account/runners"} label="Runners" current={@current_path} />
               <.nav_link href={~p"/account/webhooks"} label="Webhooks" current={@current_path} />
               <.nav_link
-                :if={Fountain.Billing.enabled?()}
+                :if={Fountain.Credits.enabled?()}
                 href={~p"/account/billing"}
                 label="Billing"
                 current={@current_path}

--- a/apps/fountain/lib/fountain_web/controllers/admin_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/admin_controller.ex
@@ -12,7 +12,7 @@ defmodule FountainWeb.AdminController do
     * the same self-action refusals — no suspending or deleting yourself, and
       (new here) no revoking your own admin role, which over an API is a
       lockout one typo away rather than a button you can see;
-    * billing actions refuse when `billing_enabled` is false, because they talk
+    * billing actions refuse when `credits_enabled` is false, because they talk
       to Stripe;
     * the same `admin.*` privilege-trail events, so an action taken with curl
       is as visible as one taken with a mouse.
@@ -569,7 +569,7 @@ defmodule FountainWeb.AdminController do
   # The UI hides billing buttons on a billing-disabled instance, but events can
   # still be sent by hand (#399's lesson) — and these all talk to Stripe.
   defp require_billing do
-    if Billing.enabled?(), do: :ok, else: {:error, :billing_disabled}
+    if Fountain.Credits.enabled?(), do: :ok, else: {:error, :billing_disabled}
   end
 
   defp refuse(conn, error, message) do

--- a/apps/fountain/lib/fountain_web/controllers/auth_me_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/auth_me_controller.ex
@@ -39,7 +39,7 @@ defmodule FountainWeb.AuthMeController do
       # Null on a billing-disabled instance, even for an account that was
       # comped before billing was turned off — there is no balance for the
       # flag to be about (#480).
-      comped: if(Fountain.Billing.enabled?(), do: user.comped, else: nil)
+      comped: if(Fountain.Credits.enabled?(), do: user.comped, else: nil)
     })
   end
 end

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
@@ -5,7 +5,7 @@ defmodule FountainWeb.MarketingHTML do
   embed_templates "marketing_html/*"
 
   @doc "Whether the pricing section renders at all: only where the deployment bills."
-  def pricing?, do: Fountain.Billing.enabled?()
+  def pricing?, do: Fountain.Credits.enabled?()
 
   @doc "The opening credit a new account gets, and how long it lasts."
   def opening_credit do

--- a/apps/fountain/lib/fountain_web/live/account_live.ex
+++ b/apps/fountain/lib/fountain_web/live/account_live.ex
@@ -2,7 +2,7 @@ defmodule FountainWeb.Live.AccountLive do
   @moduledoc """
   `/account` — data export and account deletion.
 
-  Extracted from `FountainWeb.Live.BillingLive` (#479): export and deletion
+  Extracted from `FountainWeb.Live.CreditsLive` (#479): export and deletion
   are core account features a billing-disabled instance still needs, so they
   cannot live on a page that only exists when billing does. The handlers
   delegate to `Fountain.Exports` and `Fountain.Accounts.Deletion`.

--- a/apps/fountain/lib/fountain_web/live/admin_live/activity.ex
+++ b/apps/fountain/lib/fountain_web/live/admin_live/activity.ex
@@ -17,7 +17,7 @@ defmodule FountainWeb.AdminLive.Activity do
   import FountainWeb.AdminLive.Helpers
   import FountainWeb.AdminLive.Shell
 
-  alias Fountain.{Audit, Billing}
+  alias Fountain.Audit
 
   @per_page 50
 
@@ -26,7 +26,7 @@ defmodule FountainWeb.AdminLive.Activity do
     {:ok,
      socket
      |> assign(:page_title, "Admin · Activity")
-     |> assign(:billing_enabled, Billing.enabled?())}
+     |> assign(:credits_enabled, Fountain.Credits.enabled?())}
   end
 
   # The page lives in the URL so a link to "what happened last week" is a link
@@ -58,7 +58,7 @@ defmodule FountainWeb.AdminLive.Activity do
   def render(assigns) do
     ~H"""
     <div class="space-y-6">
-      <.admin_header title="Activity" current={:activity} billing_enabled={@billing_enabled}>
+      <.admin_header title="Activity" current={:activity} credits_enabled={@credits_enabled}>
         <:subtitle>
           Role grants, quota changes, comps, suspensions and deletions — who did what to whom.
         </:subtitle>

--- a/apps/fountain/lib/fountain_web/live/admin_live/conversation_detail.ex
+++ b/apps/fountain/lib/fountain_web/live/admin_live/conversation_detail.ex
@@ -50,7 +50,7 @@ defmodule FountainWeb.AdminLive.ConversationDetail do
         {:ok,
          socket
          |> assign(:page_title, "Admin · conversation #{String.slice(conv.id, 0, 8)}")
-         |> assign(:billing_enabled, Fountain.Billing.enabled?())
+         |> assign(:credits_enabled, Fountain.Credits.enabled?())
          |> assign(:conv, conv)
          |> assign(:turn_count, turn_count)
          |> assign(:log_event_count, log_event_count)
@@ -63,7 +63,7 @@ defmodule FountainWeb.AdminLive.ConversationDetail do
     ~H"""
     <div class="space-y-8">
       <div>
-        <.admin_tabs current={:sandboxes} billing_enabled={@billing_enabled} />
+        <.admin_tabs current={:sandboxes} credits_enabled={@credits_enabled} />
         <h1 class="text-2xl font-semibold mt-4">
           <span class="font-mono">{String.slice(@conv.id, 0, 8)}</span>
           <span :if={@conv.title} class="text-zinc-500 text-lg ml-2">{@conv.title}</span>

--- a/apps/fountain/lib/fountain_web/live/admin_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/admin_live/index.ex
@@ -28,7 +28,7 @@ defmodule FountainWeb.AdminLive.Index do
     {:ok,
      socket
      |> assign(:page_title, "Admin")
-     |> assign(:billing_enabled, Billing.enabled?())
+     |> assign(:credits_enabled, Fountain.Credits.enabled?())
      |> assign_overview()}
   end
 
@@ -50,7 +50,7 @@ defmodule FountainWeb.AdminLive.Index do
   # webhook events);
   # on a billing-disabled instance nothing renders them, so don't run them.
   defp assign_billing_overview(socket) do
-    if socket.assigns.billing_enabled do
+    if socket.assigns.credits_enabled do
       assign(socket, :billing_overview, Billing.overview_admin())
     else
       assign(socket, :billing_overview, nil)
@@ -61,7 +61,7 @@ defmodule FountainWeb.AdminLive.Index do
   def render(assigns) do
     ~H"""
     <div class="space-y-6">
-      <.admin_header title="Admin" current={:overview} billing_enabled={@billing_enabled}>
+      <.admin_header title="Admin" current={:overview} credits_enabled={@credits_enabled}>
         <:subtitle>System overview. Refreshes every 10s.</:subtitle>
       </.admin_header>
 
@@ -69,7 +69,7 @@ defmodule FountainWeb.AdminLive.Index do
             count is not the point: which webhooks, and how long they have
             been failing, is on the billing page. --%>
       <.link
-        :if={@billing_enabled and @billing_overview.failed_events != []}
+        :if={@credits_enabled and @billing_overview.failed_events != []}
         navigate={~p"/admin/finance"}
         class="block bg-red-50 border border-red-200 rounded px-4 py-3 text-sm text-red-900 hover:border-red-400"
       >
@@ -88,7 +88,7 @@ defmodule FountainWeb.AdminLive.Index do
         <div class="grid grid-cols-2 sm:grid-cols-5 gap-3">
           <div
             :for={stage <- @funnel.stages}
-            :if={stage.key != :funded or @billing_enabled}
+            :if={stage.key != :funded or @credits_enabled}
             class="bg-white rounded shadow border border-zinc-200 px-4 py-3"
           >
             <div class="text-xs text-zinc-500">{stage_label(stage.key)}</div>
@@ -124,7 +124,7 @@ defmodule FountainWeb.AdminLive.Index do
         <h2 class="text-lg font-medium">At a glance</h2>
         <div class="grid grid-cols-2 sm:grid-cols-4 gap-3">
           <.link
-            :if={@billing_enabled}
+            :if={@credits_enabled}
             navigate={~p"/admin/finance"}
             class="bg-white rounded shadow border border-zinc-200 px-4 py-3 hover:border-zinc-400"
           >
@@ -138,7 +138,7 @@ defmodule FountainWeb.AdminLive.Index do
           </.link>
 
           <.link
-            :if={@billing_enabled}
+            :if={@credits_enabled}
             navigate={~p"/admin/finance"}
             class="bg-white rounded shadow border border-zinc-200 px-4 py-3 hover:border-zinc-400"
           >

--- a/apps/fountain/lib/fountain_web/live/admin_live/sandboxes.ex
+++ b/apps/fountain/lib/fountain_web/live/admin_live/sandboxes.ex
@@ -30,7 +30,7 @@ defmodule FountainWeb.AdminLive.Sandboxes do
     {:ok,
      socket
      |> assign(:page_title, "Admin · Sandboxes")
-     |> assign(:billing_enabled, Billing.enabled?())
+     |> assign(:credits_enabled, Fountain.Credits.enabled?())
      |> assign_sandboxes()}
   end
 
@@ -75,7 +75,7 @@ defmodule FountainWeb.AdminLive.Sandboxes do
   def render(assigns) do
     ~H"""
     <div class="space-y-6">
-      <.admin_header title="Sandboxes" current={:sandboxes} billing_enabled={@billing_enabled}>
+      <.admin_header title="Sandboxes" current={:sandboxes} credits_enabled={@credits_enabled}>
         <:subtitle>
           {length(@sandboxes)} active. Refreshes every 10s.
         </:subtitle>
@@ -155,7 +155,7 @@ defmodule FountainWeb.AdminLive.Sandboxes do
           Active sandbox time {Calendar.strftime(@provider_spend.period_start, "%b %-d")} – now,
           parked time excluded. Minutes on different providers cost different amounts — hold these
           next to the invoice, they are not money.
-          <.link :if={@billing_enabled} navigate={~p"/admin/finance"} class="underline">
+          <.link :if={@credits_enabled} navigate={~p"/admin/finance"} class="underline">
             Finance prices them ↗
           </.link>
         </p>

--- a/apps/fountain/lib/fountain_web/live/admin_live/shell.ex
+++ b/apps/fountain/lib/fountain_web/live/admin_live/shell.ex
@@ -27,7 +27,7 @@ defmodule FountainWeb.AdminLive.Shell do
   """
   attr :title, :string, required: true
   attr :current, :atom, required: true
-  attr :billing_enabled, :boolean, default: false
+  attr :credits_enabled, :boolean, default: false
   slot :subtitle
   slot :actions
 
@@ -44,7 +44,7 @@ defmodule FountainWeb.AdminLive.Shell do
         <div :if={@actions != []} class="flex items-center gap-2">{render_slot(@actions)}</div>
       </div>
 
-      <.admin_tabs current={@current} billing_enabled={@billing_enabled} />
+      <.admin_tabs current={@current} credits_enabled={@credits_enabled} />
     </div>
     """
   end
@@ -54,10 +54,10 @@ defmodule FountainWeb.AdminLive.Shell do
   page titles itself with the record it is showing).
   """
   attr :current, :atom, required: true
-  attr :billing_enabled, :boolean, default: false
+  attr :credits_enabled, :boolean, default: false
 
   def admin_tabs(assigns) do
-    assigns = assign(assigns, :tabs, tabs(assigns.billing_enabled))
+    assigns = assign(assigns, :tabs, tabs(assigns.credits_enabled))
 
     ~H"""
     <nav
@@ -84,9 +84,9 @@ defmodule FountainWeb.AdminLive.Shell do
 
   # Finance is the money page: credit, cost, invoices, webhook failures. It is
   # hidden on a deployment with billing off, where it has nothing to say.
-  defp tabs(billing_enabled) do
+  defp tabs(credits_enabled) do
     billing =
-      if billing_enabled do
+      if credits_enabled do
         [{:finance, "Finance", ~p"/admin/finance"}]
       else
         []

--- a/apps/fountain/lib/fountain_web/live/admin_live/user_detail.ex
+++ b/apps/fountain/lib/fountain_web/live/admin_live/user_detail.ex
@@ -38,12 +38,12 @@ defmodule FountainWeb.AdminLive.UserDetail do
           })
         end
 
-        billing_enabled = Fountain.Billing.enabled?()
+        credits_enabled = Fountain.Credits.enabled?()
 
         {:ok,
          socket
          |> assign(:page_title, "Admin · #{user.email}")
-         |> assign(:billing_enabled, billing_enabled)
+         |> assign(:credits_enabled, credits_enabled)
          |> load_user(user)}
     end
   end
@@ -81,7 +81,7 @@ defmodule FountainWeb.AdminLive.UserDetail do
     ~H"""
     <div class="space-y-8">
       <div>
-        <.admin_tabs current={:users} billing_enabled={@billing_enabled} />
+        <.admin_tabs current={:users} credits_enabled={@credits_enabled} />
         <h1 class="text-2xl font-semibold font-mono mt-4">{@user.email}</h1>
         <div class="flex flex-wrap items-center gap-2 mt-2 text-xs">
           <span class={[
@@ -94,7 +94,7 @@ defmodule FountainWeb.AdminLive.UserDetail do
             {@user.role}
           </span>
           <span
-            :if={@billing_enabled}
+            :if={@credits_enabled}
             class={[
               "inline-flex items-center rounded px-1.5 py-0.5 font-medium border",
               account_badge_class(@user.comped)
@@ -117,7 +117,7 @@ defmodule FountainWeb.AdminLive.UserDetail do
             suspended since {format_ts(@user.suspended_at)}
           </span>
           <a
-            :if={@billing_enabled and @user.stripe_customer_id not in [nil, ""]}
+            :if={@credits_enabled and @user.stripe_customer_id not in [nil, ""]}
             href={"https://dashboard.stripe.com/customers/#{@user.stripe_customer_id}"}
             target="_blank"
             rel="noopener"
@@ -138,7 +138,7 @@ defmodule FountainWeb.AdminLive.UserDetail do
           </div>
         </div>
         <div
-          :if={not @billing_enabled}
+          :if={not @credits_enabled}
           class="bg-white rounded shadow border border-zinc-200 px-4 py-3"
         >
           <div class="text-xs text-zinc-500">Onboarding</div>

--- a/apps/fountain/lib/fountain_web/live/admin_live/users.ex
+++ b/apps/fountain/lib/fountain_web/live/admin_live/users.ex
@@ -33,7 +33,7 @@ defmodule FountainWeb.AdminLive.Users do
      socket
      |> FountainWeb.Audited.put_client_ip()
      |> assign(:page_title, "Admin · Users")
-     |> assign(:billing_enabled, Billing.enabled?())}
+     |> assign(:credits_enabled, Fountain.Credits.enabled?())}
   end
 
   # Filter/sort/page state lives in the URL, so the 10s refresh, admin
@@ -118,7 +118,7 @@ defmodule FountainWeb.AdminLive.Users do
   # The buttons are hidden when billing is disabled, but events can still be
   # sent by hand (#399's lesson) — and all of these actions talk to Stripe.
   @impl true
-  def handle_event(event, _params, %{assigns: %{billing_enabled: false}} = socket)
+  def handle_event(event, _params, %{assigns: %{credits_enabled: false}} = socket)
       when event in ~w(toggle_comp) do
     {:noreply, put_flash(socket, :error, "Billing is disabled on this instance")}
   end
@@ -427,7 +427,7 @@ defmodule FountainWeb.AdminLive.Users do
   def render(assigns) do
     ~H"""
     <div class="space-y-6">
-      <.admin_header title="Users" current={:users} billing_enabled={@billing_enabled}>
+      <.admin_header title="Users" current={:users} credits_enabled={@credits_enabled}>
         <:subtitle>
           {@total_users} {if @total_users == 1, do: "account", else: "accounts"}. Refreshes every 10s.
         </:subtitle>
@@ -445,7 +445,7 @@ defmodule FountainWeb.AdminLive.Users do
             class="w-48 rounded border border-zinc-200 px-2 py-1 text-xs"
           />
           <select
-            :if={@billing_enabled}
+            :if={@credits_enabled}
             name="comped"
             class="rounded border border-zinc-200 px-1 py-1 text-xs"
           >
@@ -472,11 +472,11 @@ defmodule FountainWeb.AdminLive.Users do
                 <.sort_header label="Email" col="email" filters={@filters} />
               </th>
               <th class="px-4 py-2">Role</th>
-              <th :if={@billing_enabled} class="px-4 py-2">
+              <th :if={@credits_enabled} class="px-4 py-2">
                 Billing
               </th>
               <th
-                :if={@billing_enabled}
+                :if={@credits_enabled}
                 class="px-4 py-2"
                 title="The balance, or comped: an operator made this account free"
               >
@@ -502,7 +502,7 @@ defmodule FountainWeb.AdminLive.Users do
           <tbody>
             <tr :if={@users == []}>
               <td
-                colspan={if @billing_enabled, do: "10", else: "8"}
+                colspan={if @credits_enabled, do: "10", else: "8"}
                 class="px-4 py-6 text-center text-sm text-zinc-500"
               >
                 No users match.
@@ -538,7 +538,7 @@ defmodule FountainWeb.AdminLive.Users do
                   {u.role}
                 </span>
               </td>
-              <td :if={@billing_enabled} class="px-4 py-2">
+              <td :if={@credits_enabled} class="px-4 py-2">
                 <div class="flex flex-col gap-1">
                   <span class={[
                     "inline-flex w-fit items-center rounded px-1.5 py-0.5 text-xs font-medium border",

--- a/apps/fountain/lib/fountain_web/live/dashboard_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/dashboard_live/index.ex
@@ -57,7 +57,7 @@ defmodule FountainWeb.DashboardLive.Index do
   # billing is switched on, so a self-hosted console still sees what its
   # agents have been doing.
   defp assign_usage(socket, user) do
-    billing_enabled? = Fountain.Billing.enabled?()
+    credits_enabled? = Fountain.Credits.enabled?()
     period = Fountain.Billing.month_range()
 
     socket
@@ -65,7 +65,7 @@ defmodule FountainWeb.DashboardLive.Index do
     |> assign(:tokens, Conversations.token_usage(user.id, period.start, period.end))
     |> assign(:period, period)
     |> assign(:period_start, period.start)
-    |> assign(:billing_enabled?, billing_enabled?)
+    |> assign(:credits_enabled?, credits_enabled?)
     |> assign(:credits, Fountain.Credits.summary(user))
   end
 
@@ -142,7 +142,7 @@ defmodule FountainWeb.DashboardLive.Index do
           <span class="text-xs text-[var(--color-text-muted)]">
             since {Calendar.strftime(@period_start, "%-d %B")}
             <a
-              :if={@billing_enabled?}
+              :if={@credits_enabled?}
               href={~p"/account/billing"}
               class="ml-2 text-[var(--color-brand)] hover:underline"
             >

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -349,8 +349,8 @@ defmodule FountainWeb.Router do
 
     # Billing self-serve (#524). The controller lives in ee/ with the rest of
     # billing; the route has to be here, like the Stripe webhook above.
-    get "/billing", BillingApiController, :show
-    post "/billing/credits/checkout", BillingApiController, :credits_checkout
+    get "/billing", CreditsApiController, :show
+    post "/billing/credits/checkout", CreditsApiController, :credits_checkout
 
     # Export and deletion (#523). Deletion is irreversible and takes the
     # tenant key with it, so it wants the strongest credential the account has.
@@ -604,7 +604,7 @@ defmodule FountainWeb.Router do
       live "/account", Live.AccountLive, :index
 
       # ── Credits: account/billing. Redirects to /account when billing is disabled ────────────
-      live "/account/billing", Live.BillingLive, :index
+      live "/account/billing", Live.CreditsLive, :index
 
       # ── BYO inference credentials (ADR 0008) ───────────────────────────────────────────────
       live "/account/inference-credentials", InferenceCredentialsLive.Index, :index

--- a/apps/fountain/priv/repo/migrations/20260826010000_rename_billing_queue_to_credits.exs
+++ b/apps/fountain/priv/repo/migrations/20260826010000_rename_billing_queue_to_credits.exs
@@ -1,0 +1,14 @@
+defmodule Fountain.Repo.Migrations.RenameBillingQueueToCredits do
+  use Ecto.Migration
+
+  # #1144: the `:billing` Oban queue ran only the Credit* workers and is now
+  # `:credits`. A job still waiting under the old name would never run (a
+  # queue nothing is configured to drain is silent, not an error), so move it.
+  def up do
+    execute "UPDATE oban_jobs SET queue = 'credits' WHERE queue = 'billing'"
+  end
+
+  def down do
+    execute "UPDATE oban_jobs SET queue = 'billing' WHERE queue = 'credits'"
+  end
+end

--- a/apps/fountain/test/fountain/ops_gauges_test.exs
+++ b/apps/fountain/test/fountain/ops_gauges_test.exs
@@ -47,7 +47,7 @@ defmodule Fountain.OpsGaugesTest do
     end
 
     # Every configured queue × watched state, zeros included.
-    for queue <- ~w(maintenance billing exports),
+    for queue <- ~w(maintenance credits exports),
         state <- ~w(available scheduled executing retryable discarded) do
       assert_receive {:telemetry, [:fountain, :oban_queue], %{depth: _},
                       %{queue: ^queue, state: ^state}}

--- a/apps/fountain/test/fountain/self_host_switches_test.exs
+++ b/apps/fountain/test/fountain/self_host_switches_test.exs
@@ -28,7 +28,7 @@ defmodule Fountain.SelfHostSwitchesTest do
     "PUBLIC_URL" => "https://fountain.example.com"
   }
 
-  @switch_vars ~w(BILLING_ENABLED REGISTRATION_ENABLED REGISTRATION_ALLOWED_EMAIL_DOMAINS STRIPE_WEBHOOK_SECRET EMAIL_DELIVERY FIRST_USER_ADMIN)
+  @switch_vars ~w(CREDITS_ENABLED BILLING_ENABLED REGISTRATION_ENABLED REGISTRATION_ALLOWED_EMAIL_DOMAINS STRIPE_WEBHOOK_SECRET EMAIL_DELIVERY FIRST_USER_ADMIN)
 
   defp read_prod_config(extra) do
     previous = System.get_env()
@@ -75,25 +75,35 @@ defmodule Fountain.SelfHostSwitchesTest do
   end
 
   describe "the env-var side, read the way the release config provider does" do
-    # runtime.exs skips the BILLING_ENABLED mapping under :test (the suite
-    # pins :billing_enabled in config/test.exs), and the domain-list tests
+    # runtime.exs skips the CREDITS_ENABLED mapping under :test (the suite
+    # pins :credits_enabled in config/test.exs), and the domain-list tests
     # below inject the parsed application env directly — so without these,
     # nothing fails if the runtime.exs default flips or the parsing breaks.
 
-    test "BILLING_ENABLED defaults off — a bare self-host must not lock itself out (#336)" do
+    test "CREDITS_ENABLED defaults off — a bare self-host must not lock itself out (#336)" do
       cfg = read_prod_config(%{})
-      assert cfg[:fountain][:billing_enabled] == false
+      assert cfg[:fountain][:credits_enabled] == false
     end
 
-    test "BILLING_ENABLED=true opts the hosted deployment in" do
-      # Billing on requires the webhook secret at boot (#416), so supply one.
+    test "CREDITS_ENABLED=true opts the hosted deployment in" do
+      # Credits on requires the webhook secret at boot (#416), so supply one.
       cfg =
         read_prod_config(%{
-          "BILLING_ENABLED" => "true",
+          "CREDITS_ENABLED" => "true",
           "STRIPE_WEBHOOK_SECRET" => "whsec_test"
         })
 
-      assert cfg[:fountain][:billing_enabled] == true
+      assert cfg[:fountain][:credits_enabled] == true
+    end
+
+    test "BILLING_ENABLED is read as an alias for one release, and CREDITS_ENABLED wins (#1144)" do
+      legacy =
+        read_prod_config(%{"BILLING_ENABLED" => "true", "STRIPE_WEBHOOK_SECRET" => "whsec_test"})
+
+      assert legacy[:fountain][:credits_enabled] == true
+
+      both = read_prod_config(%{"CREDITS_ENABLED" => "false", "BILLING_ENABLED" => "true"})
+      assert both[:fountain][:credits_enabled] == false
     end
 
     test "REGISTRATION_ALLOWED_EMAIL_DOMAINS is split, trimmed and downcased" do
@@ -150,7 +160,7 @@ defmodule Fountain.SelfHostSwitchesTest do
     end
   end
 
-  describe "BILLING_ENABLED" do
+  describe "CREDITS_ENABLED" do
     test "the gate is enforced by default" do
       assert {:error, :insufficient_credits} = Billing.check_spend(cancelled_user())
     end
@@ -158,7 +168,7 @@ defmodule Fountain.SelfHostSwitchesTest do
     test "disabling it lets a cancelled account through" do
       user = cancelled_user()
 
-      with_env([billing_enabled: false], fn ->
+      with_env([credits_enabled: false], fn ->
         assert :ok = Billing.check_spend(user)
       end)
     end
@@ -169,7 +179,7 @@ defmodule Fountain.SelfHostSwitchesTest do
       user = cancelled_user()
       agent = insert_agent(user_id: user.id)
 
-      with_env([billing_enabled: false], fn ->
+      with_env([credits_enabled: false], fn ->
         Mimic.stub(Horde.DynamicSupervisor, :start_child, fn _s, _spec ->
           {:ok, spawn(fn -> :ok end)}
         end)

--- a/apps/fountain/test/fountain_web/controllers/admin_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/admin_controller_test.exs
@@ -10,9 +10,9 @@ defmodule FountainWeb.AdminControllerTest do
   """
 
   # async: false — the "billing actions when billing is disabled" block below
-  # flips `:billing_enabled`, which is application env and therefore global to
+  # flips `:credits_enabled`, which is application env and therefore global to
   # the VM, not to this test. Run async, it made every concurrent test that
-  # reads `Billing.enabled?/0` see `false` for the duration, which is how
+  # reads `Credits.enabled?/0` see `false` for the duration, which is how
   # AdminUserDetailLiveTest's billing section intermittently vanished
   # (#576). Every other module that mutates this env is already async: false.
   use FountainWeb.ConnCase, async: false
@@ -333,9 +333,9 @@ defmodule FountainWeb.AdminControllerTest do
 
   describe "billing actions when billing is disabled" do
     setup do
-      previous = Application.get_env(:fountain, :billing_enabled)
-      Application.put_env(:fountain, :billing_enabled, false)
-      on_exit(fn -> Application.put_env(:fountain, :billing_enabled, previous) end)
+      previous = Application.get_env(:fountain, :credits_enabled)
+      Application.put_env(:fountain, :credits_enabled, false)
+      on_exit(fn -> Application.put_env(:fountain, :credits_enabled, previous) end)
       :ok
     end
 

--- a/apps/fountain/test/fountain_web/controllers/auth_me_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/auth_me_controller_test.exs
@@ -3,13 +3,13 @@ defmodule FountainWeb.AuthMeControllerTest do
   use FountainWeb.ConnCase, async: false
 
   defp with_billing_disabled(fun) do
-    previous = Application.get_env(:fountain, :billing_enabled)
-    Application.put_env(:fountain, :billing_enabled, false)
+    previous = Application.get_env(:fountain, :credits_enabled)
+    Application.put_env(:fountain, :credits_enabled, false)
 
     try do
       fun.()
     after
-      Application.put_env(:fountain, :billing_enabled, previous)
+      Application.put_env(:fountain, :credits_enabled, previous)
     end
   end
 

--- a/apps/fountain/test/fountain_web/controllers/marketing_legal_unpublished_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_legal_unpublished_test.exs
@@ -1,15 +1,15 @@
-# async: false — these tests mutate the global :legal / :billing_enabled app
+# async: false — these tests mutate the global :legal / :credits_enabled app
 # env, which concurrent tests (marketing pages, billing gate) also read.
 defmodule FountainWeb.MarketingLegalUnpublishedTest do
   use FountainWeb.ConnCase, async: false
 
   setup do
     legal = Application.get_env(:fountain, :legal)
-    billing = Application.get_env(:fountain, :billing_enabled)
+    billing = Application.get_env(:fountain, :credits_enabled)
 
     on_exit(fn ->
       Application.put_env(:fountain, :legal, legal)
-      Application.put_env(:fountain, :billing_enabled, billing)
+      Application.put_env(:fountain, :credits_enabled, billing)
     end)
 
     :ok
@@ -18,7 +18,7 @@ defmodule FountainWeb.MarketingLegalUnpublishedTest do
   describe "legal identity unset, billing disabled (self-host default)" do
     setup do
       Application.put_env(:fountain, :legal, nil)
-      Application.put_env(:fountain, :billing_enabled, false)
+      Application.put_env(:fountain, :credits_enabled, false)
       :ok
     end
 
@@ -53,7 +53,7 @@ defmodule FountainWeb.MarketingLegalUnpublishedTest do
   describe "legal identity unset, billing enabled" do
     setup do
       Application.put_env(:fountain, :legal, nil)
-      Application.put_env(:fountain, :billing_enabled, true)
+      Application.put_env(:fountain, :credits_enabled, true)
       :ok
     end
 

--- a/apps/fountain/test/fountain_web/controllers/marketing_pricing_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_pricing_test.exs
@@ -1,14 +1,14 @@
-# async: false — these tests mutate the global :billing_enabled / :credits app
+# async: false — these tests mutate the global :credits_enabled / :credits app
 # env, which concurrent tests read.
 defmodule FountainWeb.MarketingPricingTest do
   use FountainWeb.ConnCase, async: false
 
   setup do
-    billing = Application.get_env(:fountain, :billing_enabled)
+    billing = Application.get_env(:fountain, :credits_enabled)
     credits = Application.get_env(:fountain, :credits)
 
     on_exit(fn ->
-      Application.put_env(:fountain, :billing_enabled, billing)
+      Application.put_env(:fountain, :credits_enabled, billing)
       Application.put_env(:fountain, :credits, credits)
     end)
 
@@ -69,7 +69,7 @@ defmodule FountainWeb.MarketingPricingTest do
   end
 
   test "omits pricing when billing is disabled", %{conn: conn} do
-    Application.put_env(:fountain, :billing_enabled, false)
+    Application.put_env(:fountain, :credits_enabled, false)
 
     body = conn |> get(~p"/") |> html_response(200)
     refute body =~ "Pay for what your agents do"

--- a/apps/fountain/test/fountain_web/live/account_deletion_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/account_deletion_live_test.exs
@@ -31,9 +31,9 @@ defmodule FountainWeb.AccountDeletionLiveTest do
     test "billing disabled: the deletion warning does not mention a subscription", %{conn: conn} do
       # There is no subscription to cancel on a billing-disabled instance —
       # the last billing reference the #513 walkthrough sweep found.
-      previous = Application.get_env(:fountain, :billing_enabled)
-      Application.put_env(:fountain, :billing_enabled, false)
-      on_exit(fn -> Application.put_env(:fountain, :billing_enabled, previous) end)
+      previous = Application.get_env(:fountain, :credits_enabled)
+      Application.put_env(:fountain, :credits_enabled, false)
+      on_exit(fn -> Application.put_env(:fountain, :credits_enabled, previous) end)
 
       user = insert_verified_user()
       {:ok, _lv, html} = live(login_user(conn, user), ~p"/account")
@@ -44,9 +44,9 @@ defmodule FountainWeb.AccountDeletionLiveTest do
 
     test "billing enabled: the warning is the same, there is no subscription to cancel (ADR 0031)",
          %{conn: conn} do
-      previous = Application.get_env(:fountain, :billing_enabled)
-      Application.put_env(:fountain, :billing_enabled, true)
-      on_exit(fn -> Application.put_env(:fountain, :billing_enabled, previous) end)
+      previous = Application.get_env(:fountain, :credits_enabled)
+      Application.put_env(:fountain, :credits_enabled, true)
+      on_exit(fn -> Application.put_env(:fountain, :credits_enabled, previous) end)
 
       user = insert_verified_user()
       {:ok, _lv, html} = live(login_user(conn, user), ~p"/account")

--- a/apps/fountain/test/fountain_web/live/console_nav_test.exs
+++ b/apps/fountain/test/fountain_web/live/console_nav_test.exs
@@ -66,7 +66,7 @@ defmodule FountainWeb.ConsoleNavTest do
     test "billing only when billing is on", %{conn: conn} do
       {:ok, _lv, html} = live(conn, ~p"/dashboard")
 
-      if Fountain.Billing.enabled?() do
+      if Fountain.Credits.enabled?() do
         assert html =~ ~s|href="/account/billing"|
       else
         refute html =~ ~s|href="/account/billing"|

--- a/apps/fountain/test/fountain_web/live/dashboard_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/dashboard_live_test.exs
@@ -264,7 +264,7 @@ defmodule FountainWeb.DashboardLiveTest do
     test "the billing link is there only when billing is on", %{conn: conn} do
       {:ok, _lv, html} = live(conn, ~p"/dashboard")
 
-      if Fountain.Billing.enabled?() do
+      if Fountain.Credits.enabled?() do
         assert html =~ ~p"/account/billing"
       else
         refute html =~ ~s|href="/account/billing"|

--- a/config/config.exs
+++ b/config/config.exs
@@ -11,7 +11,7 @@ config :fountain, Oban,
   # webhooks is its own queue so a tenant's slow receiver never sits in front
   # of a maintenance sweep or an email, and so its concurrency can be tuned
   # against outbound HTTP rather than against database work (#700).
-  queues: [maintenance: 1, billing: 5, exports: 1, mailer: 5, schedules: 5, webhooks: 10],
+  queues: [maintenance: 1, credits: 5, exports: 1, mailer: 5, schedules: 5, webhooks: 10],
   plugins: [
     # Oban's own job-table pruning: completed jobs older than 7 days.
     {Oban.Plugins.Pruner, max_age: 7 * 24 * 60 * 60},
@@ -52,13 +52,13 @@ config :fountain, Oban,
      ]}
   ]
 
-# Self-hosting switches. In dev and prod, runtime.exs overrides billing from
-# BILLING_ENABLED — off unless set (#336); the hosted deployment opts in via
+# Self-hosting switches. In dev and prod, runtime.exs overrides credits from
+# CREDITS_ENABLED — off unless set (#336); the hosted deployment opts in via
 # the hosted overlay. The `true` here reaches only :test (runtime.exs skips
 # the override there), where config/test.exs also pins it, so the suite
 # exercises the gate as enforced and flips it off per-test.
 config :fountain,
-  billing_enabled: true,
+  credits_enabled: true,
   registration_enabled: true,
   registration_allowed_email_domains: [],
   # Which page `/` serves. False everywhere but the hosted deployment, which

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -377,15 +377,36 @@ config :sentry,
 # ADR 0031 made the credit gate a product invariant. For a self-hosted
 # instance it is just a lock on the front door with no key, so it is config
 # rather than a source patch — and off by default (#336): an operator
-# exporting env by hand who never hears of BILLING_ENABLED must not lock
+# exporting env by hand who never hears of CREDITS_ENABLED must not lock
 # themselves out of their own instance. The hosted deployment is the one that
-# opts in (its overlay sets BILLING_ENABLED=true explicitly).
+# opts in (its overlay sets CREDITS_ENABLED=true explicitly).
+#
+# BILLING_ENABLED was the name until #1144; it is read as an alias for one
+# release, with a warning, so a deployment can flip at its own pace.
 #
 # Skipped in :test — the suite pins the gate on in config/test.exs and
 # toggles it per-test through the application env, independent of whatever
-# BILLING_ENABLED happens to be in the developer's shell or .env.
+# CREDITS_ENABLED happens to be in the developer's shell or .env.
+credits_enabled? =
+  case {System.get_env("CREDITS_ENABLED"), System.get_env("BILLING_ENABLED")} do
+    {nil, nil} ->
+      false
+
+    {nil, legacy} ->
+      IO.puts(:stderr, """
+
+      WARNING: BILLING_ENABLED is deprecated; set CREDITS_ENABLED=#{legacy} instead.
+      The alias will be removed in a later release.
+      """)
+
+      legacy != "false"
+
+    {value, _} ->
+      value != "false"
+  end
+
 if config_env() != :test do
-  config :fountain, :billing_enabled, System.get_env("BILLING_ENABLED", "false") != "false"
+  config :fountain, :credits_enabled, credits_enabled?
 end
 
 # What the chrome calls this deployment (Fountain.Brand): the sidebar header,
@@ -451,10 +472,10 @@ if config_env() != :test do
       # the loud {{COMPANY_LEGAL_NAME}} placeholders, which is the visible
       # enforcement, and a raise here would take down a running deployment
       # over copy rather than correctness.
-      if env == :prod and System.get_env("BILLING_ENABLED", "false") != "false" do
+      if env == :prod and credits_enabled? do
         IO.puts(:stderr, """
 
-        WARNING: BILLING_ENABLED is set but no legal identity is configured.
+        WARNING: CREDITS_ENABLED is set but no legal identity is configured.
         /terms and /privacy are rendering {{COMPANY_LEGAL_NAME}} placeholders
         to your paying users. Set LEGAL_ENTITY, LEGAL_CONTACT_EMAIL,
         LEGAL_JURISDICTION, and LEGAL_EFFECTIVE_DATE.
@@ -658,9 +679,9 @@ config :stripity_stripe, api_key: System.get_env("STRIPE_SECRET_KEY")
 # every webhook 400 quietly.
 case System.get_env("STRIPE_WEBHOOK_SECRET") do
   blank when blank in [nil, ""] ->
-    if config_env() == :prod and System.get_env("BILLING_ENABLED", "false") != "false" do
+    if config_env() == :prod and credits_enabled? do
       raise """
-      BILLING_ENABLED is set but STRIPE_WEBHOOK_SECRET is empty or unset.
+      CREDITS_ENABLED is set but STRIPE_WEBHOOK_SECRET is empty or unset.
       Set it to the signing secret of your Stripe webhook endpoint
       (Stripe dashboard → Developers → Webhooks).
       """

--- a/config/test.exs
+++ b/config/test.exs
@@ -25,10 +25,10 @@ config :ueberauth, Ueberauth.Strategy.Github.OAuth,
   client_id: "test-github-client-id",
   client_secret: "test-github-client-secret"
 
-# The runtime BILLING_ENABLED switch defaults to off (#336) but is not applied
+# The runtime CREDITS_ENABLED switch defaults to off (#336) but is not applied
 # in :test (see config/runtime.exs) — the suite pins the gate on here and
 # toggles it per-test via the application env.
-config :fountain, :billing_enabled, true
+config :fountain, :credits_enabled, true
 
 # `/` serves the marketing page in :test (MARKETING_SITE is not read in :test —
 # see config/runtime.exs), so the existing homepage tests keep covering the

--- a/decisions/0030-prepaid-credits.md
+++ b/decisions/0030-prepaid-credits.md
@@ -27,7 +27,7 @@ reservation lock, the 402, admin grants and the runway emails (6, 7),
 `Credits.Rent` with the seven-day grace (4, 6), and `Billing.Reconciliation`
 on `/admin/finance` (8, #1038 steps 1 and 2). Every surface shows the balance.
 
-There are no operator switches: `BILLING_ENABLED` means credits on —
+There are no operator switches: `CREDITS_ENABLED` means credits on —
 priced, granted, gated and shown — and off means none of it.
 `CREDIT_PRICING_SINCE` and `CREDIT_ENFORCE` (#1104, #1105) and
 `Release.start_credits/1` were the phase-5 migration levers and were deleted

--- a/decisions/0031-credits-are-the-product.md
+++ b/decisions/0031-credits-are-the-product.md
@@ -31,7 +31,7 @@ ADR 0030 then built the usage meter — a prepaid ledger burned by turn-hours,
 rent and messages — and kept the tiers beside it, each tier now also sizing
 a monthly credit grant. After a day in production the seam between the two
 was clean in concept but not in practice: credits were switched on by
-`BILLING_ENABLED`, grants were keyed on Stripe's `current_period_start`,
+`CREDITS_ENABLED`, grants were keyed on Stripe's `current_period_start`,
 buying required an `active` subscription, and the concurrency cap was still
 a thing sold in three sizes.
 
@@ -86,7 +86,7 @@ exactly the customers who spend the most.
 
 6. **Stripe is the till, nothing more.** One-time Checkout for packs, and the
    `checkout.session.completed`, `charge.refunded` and
-   `charge.dispute.created` webhooks. `BILLING_ENABLED` now means exactly
+   `charge.dispute.created` webhooks. `CREDITS_ENABLED` now means exactly
    "credits are on": off, nothing is priced, granted, gated or shown, and
    the caps fall back to floor and ceiling. `CREDIT_ENFORCE` and
    `CREDIT_PRICING_SINCE` are retired as switches: pricing starts when

--- a/deploy/k8s/configmap.yaml
+++ b/deploy/k8s/configmap.yaml
@@ -15,7 +15,7 @@ data:
 
   # Credits (ADR 0031) are a lock with no key on a self-hosted instance
   # unless you configure Stripe. Leave them off.
-  BILLING_ENABLED: "false"
+  CREDITS_ENABLED: "false"
 
   # An instance on the public internet with registration open will be found.
   # Open it just long enough to register yourself, or scope it:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,7 +103,7 @@ services:
       # Off by default (the app's own default since #336, pinned here too):
       # credits (ADR 0031) are meaningful for the hosted service and a lock
       # with no key on a self-hosted instance.
-      BILLING_ENABLED: ${BILLING_ENABLED:-false}
+      CREDITS_ENABLED: ${CREDITS_ENABLED:-false}
 
       # No mail by default, so a first run needs nothing external. Accounts
       # self-verify at registration in this mode (ADR 0011); set

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -82,7 +82,7 @@ the key is half of that sentence.
 |---|---|---|
 | **Postgres** | Everything. | `GET /health/ready` returns 503, and a load balancer drains the instance. The app stays up and does not restart, because a restart does not fix Postgres. That is why [the restart check deliberately checks nothing](guides/operate/observability.md#health-endpoints). Recovery happens on its own. A replica that *boots* against a database that is down fails instead, because migrations run at boot. |
 | **sprites.dev** | Conversations. | A new provision and a wake both fail, after bounded retries with backoff. Fountain then marks the conversation `failed`, or leaves it resumable if it was a wake. Everything else still works, which is sign-in, dashboards, agent, environment and vault management, and past logs. Readiness deliberately leaves it out, because a third party's uptime does not belong on the request path. |
-| **Stripe** | Payment for credit packs, which is optional under `BILLING_ENABLED`. | Checkout fails with a visible error. The account page itself still renders, from local state. Stripe delivers a webhook again until Fountain acknowledges it. Fountain expires the opening credit against the local clock, so an outage delays a purchase and does not open the gate. |
+| **Stripe** | Payment for credit packs, which is optional under `CREDITS_ENABLED`. | Checkout fails with a visible error. The account page itself still renders, from local state. Stripe delivers a webhook again until Fountain acknowledges it. Fountain expires the opening credit against the local clock, so an outage delays a purchase and does not open the gate. |
 | **Mail**, from Resend or SMTP. | Signup verification, and password reset. | Both dead-end while the provider is down. The escape hatch is `Fountain.Release.verify_email/1`. Read [Email](guides/operate/email.md). `EMAIL_DELIVERY=none` is a different thing, because an account then self-verifies (ADR 0011). |
 | **GitHub OAuth** | The OAuth login button, which is optional. | That button, and nothing else. Email and password auth still works. |
 | **Sentry** | Error reports, which are optional. | It is inert without a DSN, and nothing depends on it. |
@@ -133,7 +133,7 @@ a state of `started`, `done`, `failed` or `interrupted`.
    client on it. Four gates apply, in order. The agent must exist *and belong
    to you*, because Fountain scopes each query in the system to one tenant.
    The vault must be on the agent's allowlist. The credit gate applies when
-   `BILLING_ENABLED` is on, and answers `402` at a zero balance. The quota for
+   `CREDITS_ENABLED` is on, and answers `402` at a zero balance. The quota for
    concurrent sandboxes applies. The balance funds it, between a floor of 2
    and a ceiling of 20 for each user by default. <!-- vale disable-line STE.IngForms -->
 2. **`provision`.** Fountain creates the sandbox and conversation rows, as
@@ -206,5 +206,5 @@ level, which says what to run and what the output means, is
 | A container restarts in a loop at boot. | Migrations cannot reach Postgres, so the boot fails before it opens a listener. |
 | The stream is dead for some viewers and correct for others, on several replicas. | The Erlang cluster, through `CLUSTER_DNS_QUERY`. |
 | A signup never completes. | Mail delivery. Read [Email](guides/operate/email.md). |
-| `402 insufficient_credits` on a self-hosted instance. | `BILLING_ENABLED` must be `false`. |
+| `402 insufficient_credits` on a self-hosted instance. | `CREDITS_ENABLED` must be `false`. |
 | A sandbox suspends between prompts, and the work resumes on the next one. | That is the design. Read [lifecycle bounds](guides/operate/sandbox-lifetime.md). |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -113,14 +113,14 @@ at a dead end, with no error to see. Read [Email](guides/operate/email.md).
 
 ## Payment
 
-<!-- "billing" is a Technical Name here: BILLING_ENABLED is the flag, and the
+<!-- "billing" is a Technical Name here: CREDITS_ENABLED is the flag, and the
      Elixir context carries the word. STE exempts a Technical Name from Rule
      3.4, and the linter has no vocabulary hook for that rule. -->
 <!-- vale STE.IngForms = NO -->
 
 | Variable | Default | Required | Effect |
 |---|---|---|---|
-| `BILLING_ENABLED` | `false` | — | Credits on. Off by default: on a self-hosted instance there is nothing to sell. On, every account holds a credit balance, turns and contacts burn it, and a zero balance refuses new work. |
+| `CREDITS_ENABLED` | `false` | — | Credits on. Off by default: on a self-hosted instance there is nothing to sell. On, every account holds a credit balance, turns and contacts burn it, and a zero balance refuses new work. |
 | `STRIPE_SECRET_KEY` | — | For billing. | The Stripe API key. |
 | `STRIPE_WEBHOOK_SECRET` | — | For billing. | Verifies the signature on a `POST /api/stripe/webhook`. |
 | `PROVIDER_HOURLY_CENTS` | — | No. | What you pay each sandbox provider, in cents per sandbox hour, as `sprites=10.76,e2b=5.45`. Rates can be fractional. A provider you leave out stays unpriced. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -121,6 +121,7 @@ at a dead end, with no error to see. Read [Email](guides/operate/email.md).
 | Variable | Default | Required | Effect |
 |---|---|---|---|
 | `CREDITS_ENABLED` | `false` | — | Credits on. Off by default: on a self-hosted instance there is nothing to sell. On, every account holds a credit balance, turns and contacts burn it, and a zero balance refuses new work. |
+| `BILLING_ENABLED` | — | — | The old name of `CREDITS_ENABLED`. Fountain reads it for one release and writes a warning at boot. `CREDITS_ENABLED` wins when you set both. |
 | `STRIPE_SECRET_KEY` | — | For billing. | The Stripe API key. |
 | `STRIPE_WEBHOOK_SECRET` | — | For billing. | Verifies the signature on a `POST /api/stripe/webhook`. |
 | `PROVIDER_HOURLY_CENTS` | — | No. | What you pay each sandbox provider, in cents per sandbox hour, as `sprites=10.76,e2b=5.45`. Rates can be fractional. A provider you leave out stays unpriced. |

--- a/docs/guides/operate/billing.md
+++ b/docs/guides/operate/billing.md
@@ -1,7 +1,7 @@
 # Start billing
 
 <!-- "billing" is a Technical Name here: the product surface, the
-     BILLING_ENABLED flag and the Elixir context all carry it. STE exempts a
+     CREDITS_ENABLED flag and the Elixir context all carry it. STE exempts a
      Technical Name from the -ing rule, and the linter has no vocabulary
      hook for that rule, so the exemption is declared for the page. -->
 <!-- vale STE.IngForms = NO -->
@@ -10,7 +10,7 @@ This guide shows you how to start billing, and why you probably must not.
 
 ## Leave it off unless you run Fountain commercially
 
-Billing is off by default (`BILLING_ENABLED=false`), and the compose file pins
+Billing is off by default (`CREDITS_ENABLED=false`), and the compose file pins
 it off as well. On your own instance it is a meter with no till. Leave it
 off, unless you run Fountain commercially and you configured Stripe.
 
@@ -41,7 +41,7 @@ provider plan allows.
 2. Configure Stripe. The [Stripe integration guide](../../integrations/stripe.md)
    covers `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET` and the three webhook
    events.
-3. Set `BILLING_ENABLED=true` and deploy. The pricer looks back seven days,
+3. Set `CREDITS_ENABLED=true` and deploy. The pricer looks back seven days,
    so it prices the turns from the last week too. Comp or credit the
    accounts you do not want to charge for them.
 

--- a/docs/guides/operate/plans-and-prices.md
+++ b/docs/guides/operate/plans-and-prices.md
@@ -1,7 +1,7 @@
 # Prices
 
 <!-- "billing" is a Technical Name here: the product surface, the
-     BILLING_ENABLED flag and the Elixir context all carry it. -->
+     CREDITS_ENABLED flag and the Elixir context all carry it. -->
 <!-- vale STE.IngForms = NO -->
 
 This page explains what a tenant pays and what the variables control. There

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -16,7 +16,7 @@ such as editors, chat surfaces, plugins and SDKs, read
 | [A sandbox provider](sandbox-contract.md) | **Yes, one of four.** | `SPRITES_TOKEN` *or* `E2B_API_KEY` *or* `DAYTONA_API_KEY`, or a user's own machine through [`fountain runner`](runners.md), which needs no credential. Add `SANDBOX_PROVIDER` to choose the default. | The app boots, and each conversation fails at provision time. |
 | [Mail](mail.md) | **Yes, as a decision.** | `RESEND_API_KEY` *or* `SMTP_*` *or* `EMAIL_DELIVERY=none`, and `EMAIL_FROM`. | Production refuses to boot with none of the three set. |
 | [GitHub OAuth](github-oauth.md) | Optional. | `GITHUB_OAUTH_CLIENT_ID`, `GITHUB_OAUTH_CLIENT_SECRET` | Email and password auth alone. |
-| [Stripe](stripe.md) | Optional. | `BILLING_ENABLED`, `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET` | No billing. That is correct for most self-hosted instances, so leave the gate off. | <!-- vale disable-line STE.IngForms -->
+| [Stripe](stripe.md) | Optional. | `CREDITS_ENABLED`, `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET` | No billing. That is correct for most self-hosted instances, so leave the gate off. | <!-- vale disable-line STE.IngForms -->
 | [Sentry](sentry.md) | Optional. | `SENTRY_DSN`, `SENTRY_ENVIRONMENT` | Fountain reports no error. The SDK is inert, and nothing leaves the instance. |
 
 The sandbox providers are Sprites, E2B, Daytona and a user's own machine. They

--- a/docs/integrations/mail.md
+++ b/docs/integrations/mail.md
@@ -60,7 +60,7 @@ account is the operator.
 Here is what sends email today. Account verification, with a 24-hour link.
 Password reset, with a 1-hour link.
 
-With `BILLING_ENABLED` on, three credit emails go out as well. Credits low.
+With `CREDITS_ENABLED` on, three credit emails go out as well. Credits low.
 Credits exhausted. Rent due for a teammate number or inbox.
 
 An OAuth signup skips verification, so [GitHub OAuth](github-oauth.md) with

--- a/docs/integrations/stripe.md
+++ b/docs/integrations/stripe.md
@@ -1,14 +1,14 @@
 # Stripe
 
 <!-- "billing" is a Technical Name here: the product surface, the
-     BILLING_ENABLED flag and the Elixir context carry it. STE exempts a
+     CREDITS_ENABLED flag and the Elixir context carry it. STE exempts a
      Technical Name from Rule 3.4, and the linter has no vocabulary hook for
      that rule, so the exemption is declared for the page. -->
 <!-- vale STE.IngForms = NO -->
 
 **Optional.** Stripe is the till: it takes the payment for a credit pack and
 tells Fountain about refunds and disputes. Nothing else. Billing is off by
-default (`BILLING_ENABLED=false`), and that is the right setting for most
+default (`CREDITS_ENABLED=false`), and that is the right setting for most
 self-hosted instances. Set this up only if you run Fountain commercially.
 
 ## At a glance
@@ -17,7 +17,7 @@ self-hosted instances. Set this up only if you run Fountain commercially.
 |---|---|
 | Required | No, and off by default. |
 | Provider | Stripe. |
-| Env vars | `BILLING_ENABLED`, `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET` |
+| Env vars | `CREDITS_ENABLED`, `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET` |
 | Webhook | `<PUBLIC_URL>/api/stripe/webhook` |
 | Without it | No way to buy credit. Admin grants still work. |
 
@@ -42,7 +42,7 @@ real money.
 
 | Variable | Effect |
 |---|---|
-| `BILLING_ENABLED` | `false` by default. `true` turns credits on. |
+| `CREDITS_ENABLED` | `false` by default. `true` turns credits on. |
 | `STRIPE_SECRET_KEY` | The API key. |
 | `STRIPE_WEBHOOK_SECRET` | Verifies a webhook signature. Fountain rejects a bad signature with a 400. |
 

--- a/ee/lib/fountain/billing.ex
+++ b/ee/lib/fountain/billing.ex
@@ -1,5 +1,11 @@
 defmodule Fountain.Billing do
   @moduledoc """
+  The money side that is not the ledger: the Stripe customer and webhooks,
+  usage summaries, provider spend and the admin overview. The name stays
+  (#1144) — this is billing in the sense of "what Fountain is billed and
+  reports", not the retired subscription; the switch, the gate and the
+  customer-facing surfaces are `Fountain.Credits` and `Credits*`.
+
   Billing context (ADR 0031): the credit gate, the Stripe till, and usage
   aggregation.
 
@@ -20,9 +26,6 @@ defmodule Fountain.Billing do
   alias Fountain.Billing.SandboxUsage
   alias Fountain.Billing.UsageEvent
   alias Fountain.Repo
-
-  @doc "Whether this deployment bills at all: credits on (ADR 0031)."
-  def enabled?, do: Application.get_env(:fountain, :billing_enabled, true)
 
   @doc """
   The gate every spend passes (ADR 0031): the balance. `:ok` when billing is

--- a/ee/lib/fountain/credits.ex
+++ b/ee/lib/fountain/credits.ex
@@ -53,7 +53,6 @@ defmodule Fountain.Credits do
 
   alias Fountain.Accounts.User
   alias Fountain.Audit
-  alias Fountain.Billing
   alias Fountain.Credits.LedgerEntry
   alias Fountain.Repo
 
@@ -61,6 +60,14 @@ defmodule Fountain.Credits do
 
   @type post_result ::
           {:ok, LedgerEntry.t()} | {:ok, :duplicate, LedgerEntry.t()} | {:error, term()}
+
+  @doc """
+  Whether credits are on for this deployment (`CREDITS_ENABLED`, ADR 0031).
+  Off, nothing is priced, granted, gated or shown: a self-hosted install
+  runs with no money in it at all.
+  """
+  @spec enabled?() :: boolean()
+  def enabled?, do: Application.get_env(:fountain, :credits_enabled, true)
 
   # ---------------------------------------------------------------------------
   # Prices
@@ -154,7 +161,7 @@ defmodule Fountain.Credits do
     min = Keyword.get(opts, :min, 1)
 
     cond do
-      not Billing.enabled?() -> :ok
+      not enabled?() -> :ok
       comped?(subject) -> :ok
       spendable(subject, Keyword.get(opts, :now) || DateTime.utc_now()) >= min -> :ok
       true -> {:error, :insufficient_credits}
@@ -209,7 +216,7 @@ defmodule Fountain.Credits do
   @spec burned_between(binary(), DateTime.t(), DateTime.t()) :: non_neg_integer()
   def burned_between(user_id, %DateTime{} = period_start, %DateTime{} = period_end)
       when is_binary(user_id) do
-    if Billing.enabled?() do
+    if enabled?() do
       from(e in LedgerEntry,
         where: e.user_id == ^user_id and like(e.reason, "burn_%"),
         where: e.inserted_at >= ^period_start and e.inserted_at < ^period_end,
@@ -274,7 +281,7 @@ defmodule Fountain.Credits do
   `GET /api/account/billing`, the admin account view), so they cannot
   disagree.
 
-    * `:active?` — `Billing.enabled?/0`; when false the other numbers are
+    * `:active?` — `Credits.enabled?/0`; when false the other numbers are
       zero and should not be shown
     * `:balance_cents` — the cached balance, possibly negative
     * `:expiring_cents` / `:expires_at` — what the earliest live grant still
@@ -296,7 +303,7 @@ defmodule Fountain.Credits do
     now = Keyword.get(opts, :now) || DateTime.utc_now()
     card = price_card()
 
-    if Billing.enabled?() do
+    if enabled?() do
       balance = balance(user)
       purchased = purchased_remaining(user.id)
 
@@ -373,7 +380,7 @@ defmodule Fountain.Credits do
     days = Keyword.get(cfg, :opening_days, 14)
     now = Keyword.get(opts, :now) || DateTime.utc_now()
 
-    if Billing.enabled?() and cents > 0 do
+    if enabled?() and cents > 0 do
       grant(user_id, cents, "grant_opening",
         idempotency_key: "grant_opening:#{user_id}",
         expires_at: now |> DateTime.add(days * 86_400, :second) |> DateTime.truncate(:second),

--- a/ee/lib/fountain/credits/rent.ex
+++ b/ee/lib/fountain/credits/rent.ex
@@ -42,7 +42,7 @@ defmodule Fountain.Credits.Rent do
 
   @doc "Whether rent is charged at all: credits active and a price set."
   @spec charging?() :: boolean()
-  def charging?, do: Fountain.Billing.enabled?() and month_cents() > 0
+  def charging?, do: Fountain.Credits.enabled?() and month_cents() > 0
 
   @doc """
   Whether a tenant may provision a contact: the credit gate

--- a/ee/lib/fountain/emails/credits_emails.ex
+++ b/ee/lib/fountain/emails/credits_emails.ex
@@ -1,4 +1,4 @@
-defmodule Fountain.Emails.BillingEmails do
+defmodule Fountain.Emails.CreditsEmails do
   @moduledoc """
   Swoosh templates for the credit emails and the welcome (EE).
 
@@ -55,7 +55,7 @@ defmodule Fountain.Emails.BillingEmails do
   # The opening grant (ADR 0031), in the welcome: what they start with and
   # how long it lasts. Nothing when billing is off.
   defp welcome_opening_phrase(%User{}) do
-    if Fountain.Billing.enabled?() do
+    if Fountain.Credits.enabled?() do
       cfg = Application.get_env(:fountain, :credits, [])
       cents = Keyword.get(cfg, :opening_cents, 500)
       days = Keyword.get(cfg, :opening_days, 14)

--- a/ee/lib/fountain/workers/credit_expirer.ex
+++ b/ee/lib/fountain/workers/credit_expirer.ex
@@ -8,11 +8,10 @@ defmodule Fountain.Workers.CreditExpirer do
   operator's grant never expires.
   """
 
-  use Oban.Worker, queue: :billing, max_attempts: 3, unique: [period: 60]
+  use Oban.Worker, queue: :credits, max_attempts: 3, unique: [period: 60]
 
   import Ecto.Query
 
-  alias Fountain.Billing
   alias Fountain.Credits
   alias Fountain.Credits.LedgerEntry
   alias Fountain.Repo
@@ -35,7 +34,7 @@ defmodule Fountain.Workers.CreditExpirer do
   @spec run(keyword()) :: %{expired: non_neg_integer()}
   def run(opts \\ []) do
     now = Keyword.get(opts, :now) || DateTime.utc_now()
-    if Billing.enabled?(), do: %{expired: expire_grants(now)}, else: %{expired: 0}
+    if Credits.enabled?(), do: %{expired: expire_grants(now)}, else: %{expired: 0}
   end
 
   # ---------------------------------------------------------------------------

--- a/ee/lib/fountain/workers/credit_pricer.ex
+++ b/ee/lib/fountain/workers/credit_pricer.ex
@@ -31,11 +31,10 @@ defmodule Fountain.Workers.CreditPricer do
   ledger of fractional cents is a ledger nobody can reconcile.
   """
 
-  use Oban.Worker, queue: :billing, max_attempts: 3, unique: [period: 60]
+  use Oban.Worker, queue: :credits, max_attempts: 3, unique: [period: 60]
 
   import Ecto.Query
 
-  alias Fountain.Billing
   alias Fountain.Billing.SandboxUsage
   alias Fountain.Billing.UsageEvent
   alias Fountain.Conversations.Conversation
@@ -91,7 +90,7 @@ defmodule Fountain.Workers.CreditPricer do
           lookback
       end
 
-    if Billing.enabled?(),
+    if Credits.enabled?(),
       do: do_run(floor, now),
       else: %{turns: 0, messages: 0, expired: 0}
   end

--- a/ee/lib/fountain/workers/credit_rent_collector.ex
+++ b/ee/lib/fountain/workers/credit_rent_collector.ex
@@ -1,7 +1,7 @@
 defmodule Fountain.Workers.CreditRentCollector do
   @moduledoc "Daily shell over `Fountain.Credits.Rent.collect/1`."
 
-  use Oban.Worker, queue: :billing, max_attempts: 3, unique: [period: 60]
+  use Oban.Worker, queue: :credits, max_attempts: 3, unique: [period: 60]
 
   require Logger
 

--- a/ee/lib/fountain/workers/credits_email.ex
+++ b/ee/lib/fountain/workers/credits_email.ex
@@ -13,13 +13,13 @@ defmodule Fountain.Workers.CreditsEmail do
   """
 
   use Oban.Worker,
-    queue: :billing,
+    queue: :credits,
     max_attempts: 5,
     unique: [period: 30 * 86_400, fields: [:args]]
 
   require Logger
 
-  alias Fountain.{Accounts, Credits, Emails.BillingEmails}
+  alias Fountain.{Accounts, Credits, Emails.CreditsEmails}
 
   @emails ~w(credits_low credits_exhausted rent_due)
 
@@ -53,7 +53,7 @@ defmodule Fountain.Workers.CreditsEmail do
   """
   @spec notify_after_burn(String.t()) :: :ok
   def notify_after_burn(user_id) when is_binary(user_id) do
-    with true <- Fountain.Billing.enabled?(),
+    with true <- Fountain.Credits.enabled?(),
          %{comped: false} = user <-
            Accounts.get_user(user_id) do
       balance = Credits.balance(user)
@@ -87,7 +87,7 @@ defmodule Fountain.Workers.CreditsEmail do
     with %{} = user <- Accounts.get_user(user_id),
          %{rent_due_at: %DateTime{}} = contact <-
            Fountain.Repo.get(Fountain.Team.Contact, contact_id) do
-      BillingEmails.deliver_rent_due_email(user, contact, days_left) |> log(user, "rent_due")
+      CreditsEmails.deliver_rent_due_email(user, contact, days_left) |> log(user, "rent_due")
     else
       # Paid or released in the meantime: the reminder would be a lie.
       _ -> :ok
@@ -107,10 +107,10 @@ defmodule Fountain.Workers.CreditsEmail do
             :ok
 
           email == "credits_exhausted" and balance <= 0 ->
-            BillingEmails.deliver_credits_exhausted_email(user, balance) |> log(user, email)
+            CreditsEmails.deliver_credits_exhausted_email(user, balance) |> log(user, email)
 
           email == "credits_low" and balance > 0 and balance <= runway_line() ->
-            BillingEmails.deliver_credits_low_email(user, balance) |> log(user, email)
+            CreditsEmails.deliver_credits_low_email(user, balance) |> log(user, email)
 
           true ->
             :ok

--- a/ee/lib/fountain/workers/welcome_email.ex
+++ b/ee/lib/fountain/workers/welcome_email.ex
@@ -21,7 +21,7 @@ defmodule Fountain.Workers.WelcomeEmail do
 
   require Logger
 
-  alias Fountain.{Accounts, Emails.BillingEmails}
+  alias Fountain.{Accounts, Emails.CreditsEmails}
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"user_id" => user_id}}) do
@@ -40,7 +40,7 @@ defmodule Fountain.Workers.WelcomeEmail do
         :ok
 
       user ->
-        case BillingEmails.deliver_welcome_email(user) do
+        case CreditsEmails.deliver_welcome_email(user) do
           {:ok, _} ->
             :ok
 

--- a/ee/lib/fountain_web/controllers/credits_api_controller.ex
+++ b/ee/lib/fountain_web/controllers/credits_api_controller.ex
@@ -1,8 +1,8 @@
-defmodule FountainWeb.BillingApiController do
+defmodule FountainWeb.CreditsApiController do
   @moduledoc """
   Billing self-serve over the API (#524).
 
-  All user-facing billing lived in `BillingLive`: the balance, the usage
+  All user-facing billing lived in `CreditsLive`: the balance, the usage
   summary and Checkout minting. `GET /api/auth/me` exposed nothing about
   money, so a CLI user who hit the credit gate got a 402 with no programmatic
   way out of it. This is the way out: read the balance, mint a Checkout URL.
@@ -97,7 +97,7 @@ defmodule FountainWeb.BillingApiController do
   defp pack_param(_), do: {:error, :bad_cents}
 
   defp require_billing do
-    if Billing.enabled?(), do: :ok, else: {:error, :billing_disabled}
+    if Fountain.Credits.enabled?(), do: :ok, else: {:error, :billing_disabled}
   end
 
   defp render_url({:ok, url}, conn), do: render(conn, :url, url: url)

--- a/ee/lib/fountain_web/controllers/credits_api_controller.ex
+++ b/ee/lib/fountain_web/controllers/credits_api_controller.ex
@@ -26,7 +26,11 @@ defmodule FountainWeb.CreditsApiController do
 
   tags(["Billing"])
 
+  # The operation ids are keys in the SDK's generated `operations` map, so
+  # they keep the module's old name (#1144) rather than breaking a consumer
+  # over a rename.
   operation(:show,
+    operation_id: "FountainWeb.BillingApiController.show",
     summary: "Credit balance and current-month usage",
     description:
       "The credit balance, what of it expires and when, and the usage numbers " <>
@@ -57,6 +61,7 @@ defmodule FountainWeb.CreditsApiController do
   end
 
   operation(:credits_checkout,
+    operation_id: "FountainWeb.BillingApiController.credits_checkout",
     summary: "Mint a Stripe Checkout URL for a credit pack",
     description:
       "A one-time payment for one of the packs this deployment sells " <>

--- a/ee/lib/fountain_web/controllers/credits_api_json.ex
+++ b/ee/lib/fountain_web/controllers/credits_api_json.ex
@@ -1,4 +1,4 @@
-defmodule FountainWeb.BillingApiJSON do
+defmodule FountainWeb.CreditsApiJSON do
   @moduledoc false
 
   def show(%{user: user, usage: usage, credits: credits, sandbox_cap: cap, period: period}) do
@@ -13,7 +13,7 @@ defmodule FountainWeb.BillingApiJSON do
           conversations: usage.conversations,
           turns: usage.turns,
           # What the ledger took this month, in cents; null with billing off.
-          credit_burned_cents: if(Fountain.Billing.enabled?(), do: usage.credit_burned_cents),
+          credit_burned_cents: if(Fountain.Credits.enabled?(), do: usage.credit_burned_cents),
           # Hours with a prompt in flight, on providers Fountain pays for —
           # what burns credit (ADR 0030). Distinct from `sandbox_minutes`,
           # which is wall-clock and includes idle.

--- a/ee/lib/fountain_web/live/admin_finance_live.ex
+++ b/ee/lib/fountain_web/live/admin_finance_live.ex
@@ -46,7 +46,7 @@ defmodule FountainWeb.Live.AdminFinanceLive do
     {:ok,
      socket
      |> assign(:page_title, "Admin · Finance")
-     |> assign(:billing_enabled, Billing.enabled?())
+     |> assign(:credits_enabled, Fountain.Credits.enabled?())
      |> assign(:months_ago, 0)
      |> assign(:basis, Finance.default_basis())
      |> assign_finance()}
@@ -158,7 +158,7 @@ defmodule FountainWeb.Live.AdminFinanceLive do
     ~H"""
     <div class="space-y-8">
       <div>
-        <.admin_header title="Finance" current={:finance} billing_enabled={@billing_enabled}>
+        <.admin_header title="Finance" current={:finance} credits_enabled={@credits_enabled}>
           <:subtitle>
             Revenue against platform spend, per tenant, for {Calendar.strftime(
               @finance.period_start,
@@ -271,7 +271,7 @@ defmodule FountainWeb.Live.AdminFinanceLive do
       </section>
 
       <%!-- ── Revenue: credit (ADR 0031) ── --%>
-      <section :if={@billing_enabled} class="space-y-3">
+      <section :if={@credits_enabled} class="space-y-3">
         <h2 class="text-lg font-medium">Revenue</h2>
         <div class="grid grid-cols-2 lg:grid-cols-3 gap-3">
           <div class="bg-white rounded shadow border border-zinc-200 px-4 py-3">

--- a/ee/lib/fountain_web/live/credits_live.ex
+++ b/ee/lib/fountain_web/live/credits_live.ex
@@ -1,4 +1,4 @@
-defmodule FountainWeb.Live.BillingLive do
+defmodule FountainWeb.Live.CreditsLive do
   @moduledoc """
   `/account/billing` — the credit balance, what of it expires and when, the
   ledger, this month's usage, and the buttons that open Stripe Checkout for
@@ -19,7 +19,7 @@ defmodule FountainWeb.Live.BillingLive do
 
   @impl true
   def mount(_params, _session, socket) do
-    if Billing.enabled?() do
+    if Credits.enabled?() do
       user = socket.assigns.current_user
       period = Billing.month_range()
 

--- a/ee/test/fountain/credits_enforcement_test.exs
+++ b/ee/test/fountain/credits_enforcement_test.exs
@@ -51,10 +51,10 @@ defmodule Fountain.CreditsEnforcementTest do
 
   describe "check_spend/1 with billing off" do
     test "a zero balance refuses nothing" do
-      Application.put_env(:fountain, :billing_enabled, false)
-      on_exit(fn -> Application.put_env(:fountain, :billing_enabled, true) end)
+      Application.put_env(:fountain, :credits_enabled, false)
+      on_exit(fn -> Application.put_env(:fountain, :credits_enabled, true) end)
       user = subscriber()
-      refute Fountain.Billing.enabled?()
+      refute Fountain.Credits.enabled?()
       assert :ok = Credits.gate(user)
       assert :ok = Billing.check_spend(user)
     end
@@ -63,7 +63,7 @@ defmodule Fountain.CreditsEnforcementTest do
   describe "check_spend/1 with billing on" do
     test "zero refuses, positive passes" do
       user = drained(subscriber())
-      assert Fountain.Billing.enabled?()
+      assert Fountain.Credits.enabled?()
       assert {:error, :insufficient_credits} = Billing.check_spend(user)
       assert {:error, :insufficient_credits} = Billing.check_spend(user.id)
 
@@ -72,8 +72,8 @@ defmodule Fountain.CreditsEnforcementTest do
     end
 
     test "billing off funds the ceiling, whatever the balance" do
-      Application.put_env(:fountain, :billing_enabled, false)
-      on_exit(fn -> Application.put_env(:fountain, :billing_enabled, true) end)
+      Application.put_env(:fountain, :credits_enabled, false)
+      on_exit(fn -> Application.put_env(:fountain, :credits_enabled, true) end)
       assert Quotas.sandbox_limit(insert_empty_user().id) == Quotas.settings().cap_ceiling
     end
 
@@ -82,8 +82,8 @@ defmodule Fountain.CreditsEnforcementTest do
       {:ok, comped} = Billing.comp_account(insert_empty_user())
       assert :ok = Billing.check_spend(comped)
 
-      Application.put_env(:fountain, :billing_enabled, false)
-      on_exit(fn -> Application.put_env(:fountain, :billing_enabled, true) end)
+      Application.put_env(:fountain, :credits_enabled, false)
+      on_exit(fn -> Application.put_env(:fountain, :credits_enabled, true) end)
       assert :ok = Billing.check_spend(subscriber())
     end
 

--- a/ee/test/fountain/credits_test.exs
+++ b/ee/test/fountain/credits_test.exs
@@ -147,8 +147,8 @@ defmodule Fountain.CreditsTest do
   describe "check_balance/1" do
     test "answers ok with billing off before reading anything" do
       user = insert_empty_user()
-      Application.put_env(:fountain, :billing_enabled, false)
-      on_exit(fn -> Application.put_env(:fountain, :billing_enabled, true) end)
+      Application.put_env(:fountain, :credits_enabled, false)
+      on_exit(fn -> Application.put_env(:fountain, :credits_enabled, true) end)
       assert :ok = Credits.check_balance(user)
       assert :ok = Credits.check_balance(user.id)
     end

--- a/ee/test/fountain/emails/credits_emails_test.exs
+++ b/ee/test/fountain/emails/credits_emails_test.exs
@@ -1,15 +1,15 @@
-defmodule Fountain.Emails.BillingEmailsTest do
+defmodule Fountain.Emails.CreditsEmailsTest do
   use Fountain.DataCase, async: true
 
   import Swoosh.TestAssertions
 
-  alias Fountain.Emails.BillingEmails
+  alias Fountain.Emails.CreditsEmails
 
   describe "deliver_welcome_email/1" do
     test "welcomes the user and points at the console" do
       user = insert_verified_user()
 
-      assert {:ok, _email} = BillingEmails.deliver_welcome_email(user)
+      assert {:ok, _email} = CreditsEmails.deliver_welcome_email(user)
 
       assert_email_sent(fn email ->
         assert email.subject == "Welcome to Fountain"
@@ -26,7 +26,7 @@ defmodule Fountain.Emails.BillingEmailsTest do
       {:ok, user} =
         user |> Ecto.Changeset.change(onboarding_completed_at: now) |> Repo.update()
 
-      assert {:ok, _email} = BillingEmails.deliver_welcome_email(user)
+      assert {:ok, _email} = CreditsEmails.deliver_welcome_email(user)
 
       assert_email_sent(fn email ->
         refute email.text_body =~ "/onboarding"

--- a/ee/test/fountain/workers/credit_expirer_test.exs
+++ b/ee/test/fountain/workers/credit_expirer_test.exs
@@ -19,8 +19,8 @@ defmodule Fountain.Workers.CreditExpirerTest do
     {:ok, _} =
       Credits.grant(user.id, 1000, "grant_opening", idempotency_key: "g", expires_at: @expires)
 
-    Application.put_env(:fountain, :billing_enabled, false)
-    on_exit(fn -> Application.put_env(:fountain, :billing_enabled, true) end)
+    Application.put_env(:fountain, :credits_enabled, false)
+    on_exit(fn -> Application.put_env(:fountain, :credits_enabled, true) end)
     assert %{expired: 0} = CreditExpirer.run(now: @day_after)
   end
 

--- a/ee/test/fountain/workers/credit_pricer_test.exs
+++ b/ee/test/fountain/workers/credit_pricer_test.exs
@@ -31,8 +31,8 @@ defmodule Fountain.Workers.CreditPricerTest do
     conv = setup_conv(user)
     closed_turn(conv, ~U[2026-08-02 10:00:00Z], 3600)
 
-    Application.put_env(:fountain, :billing_enabled, false)
-    on_exit(fn -> Application.put_env(:fountain, :billing_enabled, true) end)
+    Application.put_env(:fountain, :credits_enabled, false)
+    on_exit(fn -> Application.put_env(:fountain, :credits_enabled, true) end)
     assert %{turns: 0, messages: 0} = CreditPricer.run(since: @since, now: @now)
     assert Credits.balance(user.id) == 0
   end

--- a/ee/test/fountain_web/controllers/credits_api_controller_test.exs
+++ b/ee/test/fountain_web/controllers/credits_api_controller_test.exs
@@ -1,12 +1,12 @@
-defmodule FountainWeb.BillingApiControllerTest do
+defmodule FountainWeb.CreditsApiControllerTest do
   @moduledoc """
   Billing self-serve over the API (#524).
 
   A CLI user who hit the credit gate got a 402 and no programmatic route out
-  of it: usage numbers and Checkout lived in `BillingLive`.
+  of it: usage numbers and Checkout lived in `CreditsLive`.
   """
 
-  # async: false — billing_enabled is application env.
+  # async: false — credits_enabled is application env.
   use FountainWeb.ConnCase, async: false
   use Mimic
 
@@ -17,13 +17,13 @@ defmodule FountainWeb.BillingApiControllerTest do
   end
 
   defp with_billing_disabled(fun) do
-    previous = Application.get_env(:fountain, :billing_enabled)
-    Application.put_env(:fountain, :billing_enabled, false)
+    previous = Application.get_env(:fountain, :credits_enabled)
+    Application.put_env(:fountain, :credits_enabled, false)
 
     try do
       fun.()
     after
-      Application.put_env(:fountain, :billing_enabled, previous)
+      Application.put_env(:fountain, :credits_enabled, previous)
     end
   end
 

--- a/ee/test/fountain_web/credits_surfaces_test.exs
+++ b/ee/test/fountain_web/credits_surfaces_test.exs
@@ -39,10 +39,10 @@ defmodule FountainWeb.CreditsSurfacesTest do
 
   describe "billing off" do
     test "no balance anywhere, and the API says 404", %{conn: conn} do
-      Application.put_env(:fountain, :billing_enabled, false)
-      on_exit(fn -> Application.put_env(:fountain, :billing_enabled, true) end)
+      Application.put_env(:fountain, :credits_enabled, false)
+      on_exit(fn -> Application.put_env(:fountain, :credits_enabled, true) end)
       user = subscriber()
-      refute Fountain.Billing.enabled?()
+      refute Fountain.Credits.enabled?()
       assert %{active?: false, balance_cents: 0} = Credits.summary(user)
 
       # The billing page does not exist on a billing-off instance; the


### PR DESCRIPTION
Closes #1144. The one self-hoster is the maintainer, so the rename is a clean one with a one-release alias rather than a long deprecation.

- **`CREDITS_ENABLED`** replaces `BILLING_ENABLED` in `runtime.exs`, `.env.example`, `.env.compose.example`, `docker-compose.yml`, `deploy/k8s/configmap.yaml`, CLAUDE.md, the manual and the two ADRs that describe the current state (0030, 0031; 0006/0026 are history and untouched). `BILLING_ENABLED` is still read for one release and logs `WARNING: BILLING_ENABLED is deprecated; set CREDITS_ENABLED=… instead` at boot; `CREDITS_ENABLED` wins when both are set. The legal-identity warning and the webhook-secret boot check read the same resolved value.
- **`:credits_enabled`** is the config key; **`Credits.enabled?/0`** is the predicate (`Billing.enabled?/0` deleted, ~36 call sites; every `billing_enabled` identifier/assign is `credits_enabled`).
- **Oban queue `:billing` → `:credits`** (config + the four Credit* workers), with migration `20260826010000` moving any job still waiting under the old name — a queue nothing drains is silent, not an error.
- **Modules**: `FountainWeb.Live.BillingLive` → `CreditsLive`, `BillingApiController`/`BillingApiJSON` → `CreditsApiController`/`CreditsApiJSON`, `Fountain.Emails.BillingEmails` → `CreditsEmails` (files renamed, tests renamed). `/account/billing` and `/api/account/billing` are unchanged — they're on the wire and in the SDK. `Fountain.Billing` keeps its name and its moduledoc now says why (it is what Fountain is billed and reports: Stripe, usage, provider spend, finance).
- `self_host_switches_test` covers the new name, the alias, and precedence.

**Operator action (that's you):** set `CREDITS_ENABLED=true` in the home-cloud overlay where `BILLING_ENABLED=true` is today. Until then the boot log warns and behaviour is identical.

Format/credo/dialyzer/sobelow/vale/docs-style/okf green; affected suites 589 + 22 tests, 0 failures; full suite running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
