### PR TITLE
feat(broker): secret bindings — which hosts a secret goes to, and how (ADR 0019 gate 1b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,16 @@ upgrade, is in
 
 ### Added
 
+- **Secret bindings, ADR 0019 gate 1b.** On an account the broker is on for,
+  a secret can be bound to the hosts it is a credential for and the way it
+  is sent (bearer, basic, API-key header, custom headers). A bound secret
+  reaches the sandbox as a placeholder and the broker attaches the value; an
+  unbound one reaches it in the clear as before. A console page at
+  Account, Credential bindings (only shown when the broker is on), the
+  `/api/secret-bindings` routes with a 35-entry preset catalog, and every
+  binding change in the audit trail. Replaces gate 1a's hardcoded GitHub
+  catalog, which stays as the default for `GITHUB_TOKEN` / `GH_TOKEN` with
+  no bindings.
 - **Egress credential brokerage, gate 1a (ADR 0019, #1090).** `Fountain.Broker`
   and the provisioning wiring for an Agent Vault forward proxy: a brokered
   sandbox holds `__github_token__` where `GITHUB_TOKEN` was, the real value is

--- a/apps/fountain/lib/fountain/broker.ex
+++ b/apps/fountain/lib/fountain/broker.ex
@@ -14,12 +14,15 @@ defmodule Fountain.Broker do
   module with the vendor client inside it on purpose (ADR 0019 §8) — the
   abstraction is worth building on the day there is a second broker.
 
-  ## What gate 1a brokers, and what it does not
+  ## What is brokered
 
-  * Only `GITHUB_TOKEN` and `GH_TOKEN`, bound by the catalog to
-    `api.github.com` (bearer) and `github.com` (git over HTTPS, basic
-    `x-access-token`). Every other secret reaches the sandbox exactly as
-    before. The per-secret `exposure` label is gate 1b.
+  * A secret with an enabled **binding** (`Fountain.SecretBindings`, gate 1b):
+    the tenant said which host it goes to and how. One service per binding.
+  * `GITHUB_TOKEN` and `GH_TOKEN` with no binding of their own, bound by the
+    built-in catalog to `api.github.com` (bearer) and `github.com` (git over
+    HTTPS, basic `x-access-token`) — gate 1a's default, kept so a tenant who
+    never opens the bindings page keeps working.
+  * Every other secret reaches the sandbox exactly as before.
   * Only tenants listed in `BROKER_TENANTS`: the operator ratchet of §9.
   * Only `unrestricted` environments. Translating `limited`'s `allowed_hosts`
     into broker rules is gate 2; a brokered `limited` environment is refused
@@ -121,20 +124,24 @@ defmodule Fountain.Broker do
   @spec placeholder(String.t()) :: String.t()
   def placeholder(key), do: "__" <> String.downcase(key) <> "__"
 
+  @typedoc "Enabled bindings grouped by secret key, as `Fountain.SecretBindings.enabled_by_key/1` returns them."
+  @type bindings :: %{String.t() => [Fountain.SecretBindings.Binding.t()]}
+
   @doc """
   Split a merged secrets map into what the sandbox gets and what the broker
   gets. Runs on the merged map, so the vault-wins rule has already applied
   (ADR 0019 §9: brokering happens after the merge).
 
-  Returns `{sandbox_secrets, brokered}` where every catalog key present is a
-  placeholder in the first map and its real value is in the second. Keys with
-  an empty value are left alone: there is nothing to broker.
+  A key is brokered when it has an enabled binding, or when it is a catalog
+  key (`GITHUB_TOKEN`, `GH_TOKEN`) with none. Returns `{sandbox_secrets,
+  brokered}`: a placeholder in the first map, the value in the second. Keys
+  with an empty value are left alone: there is nothing to broker.
   """
-  @spec split(%{String.t() => String.t()}) ::
+  @spec split(%{String.t() => String.t()}, bindings()) ::
           {%{String.t() => String.t()}, %{String.t() => String.t()}}
-  def split(secrets) when is_map(secrets) do
+  def split(secrets, bindings \\ %{}) when is_map(secrets) and is_map(bindings) do
     Enum.reduce(secrets, {%{}, %{}}, fn {k, v}, {sandbox, brokered} ->
-      if Map.has_key?(@catalog, k) and is_binary(v) and v != "" do
+      if brokered?(k, bindings) and is_binary(v) and v != "" do
         {Map.put(sandbox, k, placeholder(k)), Map.put(brokered, k, v)}
       else
         {Map.put(sandbox, k, v), brokered}
@@ -142,52 +149,110 @@ defmodule Fountain.Broker do
     end)
   end
 
-  # The services a set of brokered keys turns into. One host per service is
-  # the Agent Vault shape; `api.github.com` takes a bearer, and git over HTTPS
-  # on `github.com` sends basic auth, which the broker rewrites wholesale.
-  defp services_for(brokered) do
-    brokered
-    |> Map.keys()
-    |> Enum.map(&Map.get(@catalog, &1))
-    |> Enum.uniq()
-    |> Enum.flat_map(fn
-      :github ->
-        key = github_key(brokered)
+  defp brokered?(key, bindings), do: Map.has_key?(bindings, key) or Map.has_key?(@catalog, key)
+
+  # The services a set of brokered keys turns into: one per binding, in the
+  # broker's shape (one host per service, only the fields of the auth type),
+  # plus the catalog pair for a GitHub key that has no bindings of its own.
+  defp services_for(brokered, bindings) do
+    bound =
+      brokered
+      |> Map.keys()
+      |> Enum.flat_map(fn key ->
+        bindings |> Map.get(key, []) |> Enum.map(&binding_service(key, &1))
+      end)
+
+    catalog =
+      if Enum.any?(brokered, fn {k, _} ->
+           Map.get(@catalog, k) == :github and not Map.has_key?(bindings, k)
+         end) do
+        key = github_key(brokered, bindings)
 
         [
-          %{
-            name: "github-api",
-            host: "api.github.com",
-            auth: %{type: "bearer", token: key}
-          },
+          %{name: "github-api", host: "api.github.com", auth: %{type: "bearer", token: key}},
           %{
             name: "github-git",
             host: "github.com",
-            auth: %{type: "basic", username: "GITHUB_BASIC_USER", password: key}
+            auth: %{type: "basic", username: basic_user_key(key), password: key}
           }
         ]
-
-      _ ->
+      else
         []
-    end)
+      end
+
+    bound ++ catalog
   end
 
   # Both names may be present after the merge; the git URL is written with
   # whichever one `repositories[].secret_key` names, and the broker needs a
   # single credential per service. Prefer the canonical name.
-  defp github_key(brokered) do
-    if Map.has_key?(brokered, "GITHUB_TOKEN"), do: "GITHUB_TOKEN", else: "GH_TOKEN"
+  defp github_key(brokered, bindings) do
+    cond do
+      Map.has_key?(brokered, "GITHUB_TOKEN") and not Map.has_key?(bindings, "GITHUB_TOKEN") ->
+        "GITHUB_TOKEN"
+
+      true ->
+        "GH_TOKEN"
+    end
   end
 
-  # Credentials the services above reference beyond the tenant's own. The
-  # basic-auth username for git is a constant GitHub documents, stored as a
-  # credential because that is the only place a service may read one from.
-  defp credentials_for(brokered) do
-    if Enum.any?(brokered, fn {k, _} -> Map.get(@catalog, k) == :github end) do
-      Map.put(brokered, "GITHUB_BASIC_USER", "x-access-token")
-    else
+  defp binding_service(key, binding) do
+    auth =
+      case binding.auth_type do
+        "bearer" -> %{type: "bearer", token: key}
+        "basic" -> %{type: "basic", username: basic_user_key(key), password: key}
+        "api_key" -> %{type: "api-key", key: key, header: binding.header, prefix: binding.prefix}
+        "custom" -> %{type: "custom", headers: binding.headers}
+      end
+      |> Enum.reject(fn {_, v} -> is_nil(v) or v == "" end)
+      |> Map.new()
+
+    %{name: service_name(key, binding.host), host: binding.host, auth: auth}
+  end
+
+  # A slug the broker accepts (`[a-z0-9-]{3,64}`, no `--`, no edge hyphen)
+  # that is stable for a key+host pair, so a re-prepare upserts rather than
+  # accumulates.
+  @doc false
+  def service_name(key, host) do
+    base =
+      (key <> "-" <> host)
+      |> String.downcase()
+      |> String.replace(~r/[^a-z0-9]+/, "-")
+      |> String.replace(~r/-+/, "-")
+      |> String.trim("-")
+
+    base = if String.length(base) < 3, do: base <> "-svc", else: base
+    String.slice(base, 0, 64) |> String.trim("-")
+  end
+
+  # The basic-auth username lives beside the password as a credential, because
+  # that is the only place a service may read one from. Its name derives from
+  # the key so two basic bindings of different keys never collide.
+  defp basic_user_key(key), do: key <> "_BASIC_USER"
+
+  # Credentials the services reference beyond the tenant's own values: one
+  # basic-auth username per basic binding (the tenant's literal), and GitHub's
+  # constant `x-access-token` for the catalog default.
+  defp credentials_for(brokered, bindings) do
+    from_bindings =
       brokered
-    end
+      |> Map.keys()
+      |> Enum.flat_map(fn key ->
+        bindings
+        |> Map.get(key, [])
+        |> Enum.filter(&(&1.auth_type == "basic"))
+        |> Enum.map(fn b -> {basic_user_key(key), b.username} end)
+      end)
+      |> Map.new()
+
+    from_catalog =
+      brokered
+      |> Map.keys()
+      |> Enum.filter(&(Map.get(@catalog, &1) == :github and not Map.has_key?(bindings, &1)))
+      |> Map.new(fn key -> {basic_user_key(key), "x-access-token"} end)
+
+    brokered |> Map.merge(from_bindings) |> Map.merge(from_catalog)
   end
 
   # ---------------------------------------------------------------------------
@@ -276,15 +341,16 @@ defmodule Fountain.Broker do
   provision and reattach, so an edited secret reaches the broker on the next
   wake, the same way the `.env` file is refreshed.
   """
-  @spec prepare(String.t(), %{String.t() => String.t()}) ::
+  @spec prepare(String.t(), %{String.t() => String.t()}, bindings()) ::
           {:ok, session()} | {:error, term()}
-  def prepare(conversation_id, brokered) when is_binary(conversation_id) and is_map(brokered) do
+  def prepare(conversation_id, brokered, bindings \\ %{})
+      when is_binary(conversation_id) and is_map(brokered) and is_map(bindings) do
     vault = vault_name(conversation_id)
 
     with :ok <- ensure_vault(vault),
          :ok <- set_policy(vault, "passthrough"),
-         :ok <- put_credentials(vault, credentials_for(brokered)),
-         :ok <- put_services(vault, services_for(brokered)) do
+         :ok <- put_credentials(vault, credentials_for(brokered, bindings)),
+         :ok <- put_services(vault, services_for(brokered, bindings)) do
       mint_session(vault, conversation_id)
     end
   end

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -362,6 +362,9 @@ defmodule Fountain.Conversations.ConversationServer do
       # never sees (the broker gets them); `broker` is the minted session.
       # Both stay empty/nil on an unbrokered conversation.
       brokered: %{},
+      # The tenant's enabled bindings by key (gate 1b), loaded once per
+      # provision; what the broker's services are built from.
+      broker_bindings: %{},
       broker: nil,
       current_command: nil,
       current_command_ref: nil,
@@ -571,7 +574,10 @@ defmodule Fountain.Conversations.ConversationServer do
 
     case load_tenant_state(conv.user_id) do
       {:ok, dek, inference_creds} ->
-        {secrets, brokered} = split_brokered(conv.user_id, merge_secrets(env, vault, dek))
+        bindings = broker_bindings(conv.user_id)
+
+        {secrets, brokered} =
+          split_brokered(conv.user_id, merge_secrets(env, vault, dek), bindings)
 
         state =
           %{
@@ -580,7 +586,8 @@ defmodule Fountain.Conversations.ConversationServer do
               runtime_session_id: conv.runtime_session_id,
               tenant_key: dek,
               inference_credentials: inference_creds,
-              brokered: brokered
+              brokered: brokered,
+              broker_bindings: bindings
           }
 
         dispatch_provision(state, conv, sandbox, agent, env, vault, secrets)
@@ -1366,10 +1373,18 @@ defmodule Fountain.Conversations.ConversationServer do
   # On a brokered conversation the catalog keys leave the secrets map here,
   # before the MCP substitution and the env are built from it, so both see
   # the placeholder and neither sees the value.
-  defp split_brokered(user_id, secrets) do
+  defp split_brokered(user_id, secrets, bindings) do
     if Fountain.Broker.enabled_for?(user_id),
-      do: Fountain.Broker.split(secrets),
+      do: Fountain.Broker.split(secrets, bindings),
       else: {secrets, %{}}
+  end
+
+  # Only read for a brokered tenant: for everyone else the table is rows
+  # nobody consults, and this path stays free of a query.
+  defp broker_bindings(user_id) do
+    if Fountain.Broker.enabled_for?(user_id),
+      do: Fountain.SecretBindings.enabled_by_key(user_id),
+      else: %{}
   end
 
   defp broker_env(%{broker: nil}), do: []
@@ -1383,7 +1398,7 @@ defmodule Fountain.Conversations.ConversationServer do
         keys: state.brokered |> Map.keys() |> Enum.sort()
       })
 
-      case Fountain.Broker.prepare(state.conversation_id, state.brokered) do
+      case Fountain.Broker.prepare(state.conversation_id, state.brokered, state.broker_bindings) do
         {:ok, session} ->
           publish_stage(state.conversation_id, "broker", "done", %{
             vault: session.vault,
@@ -1412,7 +1427,7 @@ defmodule Fountain.Conversations.ConversationServer do
 
   defp broker_refresh(%{broker: session} = state) do
     if Fountain.Broker.expiring?(session) do
-      case Fountain.Broker.prepare(state.conversation_id, state.brokered) do
+      case Fountain.Broker.prepare(state.conversation_id, state.brokered, state.broker_bindings) do
         {:ok, fresh} ->
           keys = Fountain.Broker.env_keys()
           kept = Enum.reject(state.sprite_env, fn {k, _} -> to_string(k) in keys end)

--- a/apps/fountain/lib/fountain/secret_bindings.ex
+++ b/apps/fountain/lib/fountain/secret_bindings.ex
@@ -1,0 +1,115 @@
+defmodule Fountain.SecretBindings do
+  @moduledoc """
+  Secret bindings: which hosts a tenant's secret is attached to at the egress
+  broker, and how (ADR 0019 gate 1b, #1090).
+
+  A secret with at least one enabled binding is **brokered**: the sandbox
+  gets a placeholder, the broker gets the value and one service per binding.
+  A secret with none reaches the sandbox in the clear, exactly as before the
+  broker existed. That is the whole `exposure` label gate 1b asked for,
+  without a second field: the presence of a binding is the declaration.
+
+  Everything here is tenant-scoped by `user_id`. Bindings are only consulted
+  for tenants the broker is on for (`Fountain.Broker.enabled_for?/1`); for
+  everyone else they are rows nobody reads.
+  """
+
+  import Ecto.Query, warn: false
+
+  alias Fountain.Audit
+  alias Fountain.Repo
+  alias Fountain.SecretBindings.Binding
+
+  @doc "Every binding of a tenant, by key then host."
+  @spec list_bindings(String.t()) :: [Binding.t()]
+  def list_bindings(user_id) when is_binary(user_id) do
+    Repo.all(from b in Binding, where: b.user_id == ^user_id, order_by: [asc: b.key, asc: b.host])
+  end
+
+  @doc "The enabled bindings of a tenant, grouped by key. What provisioning reads."
+  @spec enabled_by_key(String.t()) :: %{String.t() => [Binding.t()]}
+  def enabled_by_key(user_id) when is_binary(user_id) do
+    user_id |> list_bindings() |> Enum.filter(& &1.enabled) |> Enum.group_by(& &1.key)
+  end
+
+  @spec get_binding(String.t(), String.t()) :: Binding.t() | nil
+  def get_binding(id, user_id) when is_binary(id) and is_binary(user_id) do
+    Repo.get_by(Binding, id: id, user_id: user_id)
+  end
+
+  @doc """
+  Create a binding for a tenant. `attrs` is string-keyed; the tenant comes
+  from the first argument, never from the attrs.
+  """
+  @spec create_binding(String.t(), map(), keyword()) ::
+          {:ok, Binding.t()} | {:error, Ecto.Changeset.t()}
+  def create_binding(user_id, attrs, opts \\ []) when is_binary(user_id) and is_map(attrs) do
+    %Binding{}
+    |> Binding.changeset(Map.put(attrs, "user_id", user_id))
+    |> Repo.insert()
+    |> audited("secret_binding.created", opts)
+  end
+
+  @spec update_binding(Binding.t(), map(), keyword()) ::
+          {:ok, Binding.t()} | {:error, Ecto.Changeset.t()}
+  def update_binding(%Binding{} = binding, attrs, opts \\ []) when is_map(attrs) do
+    changeset = Binding.changeset(binding, Map.delete(attrs, "user_id"))
+
+    changeset
+    |> Repo.update()
+    |> audited(
+      "secret_binding.updated",
+      Keyword.put(opts, :metadata, %{"fields" => Audit.changed_fields(changeset)})
+    )
+  end
+
+  @spec delete_binding(Binding.t(), keyword()) ::
+          {:ok, Binding.t()} | {:error, Ecto.Changeset.t()}
+  def delete_binding(%Binding{} = binding, opts \\ []) do
+    binding |> Repo.delete() |> audited("secret_binding.deleted", opts)
+  end
+
+  @doc """
+  The secret keys a tenant has anywhere — every environment and every vault —
+  so the console can offer them for binding without ever reading a value.
+  """
+  @spec known_keys(String.t()) :: [String.t()]
+  def known_keys(user_id) when is_binary(user_id) do
+    env_keys =
+      from(s in Fountain.Environments.Secret,
+        join: e in assoc(s, :environment),
+        where: e.user_id == ^user_id,
+        select: s.key
+      )
+
+    vault_keys =
+      from(s in Fountain.Vaults.VaultSecret,
+        join: v in assoc(s, :vault),
+        where: v.user_id == ^user_id,
+        select: s.key
+      )
+
+    (Repo.all(env_keys) ++ Repo.all(vault_keys)) |> Enum.uniq() |> Enum.sort()
+  end
+
+  # ── audit ────────────────────────────────────────────────────────────────
+
+  # Never the value — there is none here — but the host and the shape are
+  # what an incident wants to know.
+  defp audited({:ok, %Binding{} = binding} = ok, action, opts) do
+    metadata =
+      %{"key" => binding.key, "host" => binding.host, "auth_type" => binding.auth_type}
+      |> Map.merge(Keyword.get(opts, :metadata, %{}))
+
+    Audit.record_resource(
+      action,
+      "secret_binding",
+      binding,
+      Keyword.put(opts, :metadata, metadata)
+    )
+
+    ok
+  end
+
+  defp audited(other, _action, _opts), do: other
+end

--- a/apps/fountain/lib/fountain/secret_bindings/binding.ex
+++ b/apps/fountain/lib/fountain/secret_bindings/binding.ex
@@ -1,0 +1,257 @@
+defmodule Fountain.SecretBindings.Binding do
+  @moduledoc """
+  One host a tenant's secret is attached to at the egress broker, and how
+  (ADR 0019 gate 1b).
+
+  Keyed by the secret's *name*, not by a row in `secrets` or `vault_secrets`:
+  brokering runs on the merged map, where only the name survives, and a
+  binding is a fact about the credential wherever it is stored. Several rows
+  per key are normal — GitHub is `api.github.com` as a bearer *and*
+  `github.com` as basic `x-access-token`.
+
+  The validation mirrors Agent Vault 0.39.1's `broker.Validate` so a binding
+  that saves here is one the broker accepts; the messages are ours, the rules
+  are theirs.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+
+  @auth_types ~w(bearer basic api_key custom)
+  @key_re ~r/^[A-Z][A-Z0-9_]*$/
+  @header_name_re ~r/^[a-zA-Z0-9-]+$/
+  @host_label_re ~r/^([a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$/
+  @template_ref_re ~r/\{\{\s*(\w+)\s*\}\}/
+  @internal_hosts ~w(localhost localhost.localdomain internal kubernetes kubernetes.default metadata.google.internal metadata.google instance-data)
+  @path_forbidden [" ", "?", "#", "[", "]", "\\", "|", "<", ">", "\""]
+
+  @type t :: %__MODULE__{}
+
+  schema "secret_bindings" do
+    field :key, :string
+    field :host, :string
+    field :auth_type, :string
+    field :header, :string
+    field :prefix, :string
+    field :username, :string
+    field :headers, :map, default: %{}
+    field :enabled, :boolean, default: true
+    belongs_to :user, Fountain.Accounts.User
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc "The auth shapes gate 1b supports. `passthrough` is a network rule, not a credential; that is gate 2."
+  def auth_types, do: @auth_types
+
+  def changeset(binding, attrs) do
+    binding
+    |> cast(attrs, [
+      :key,
+      :host,
+      :auth_type,
+      :header,
+      :prefix,
+      :username,
+      :headers,
+      :enabled,
+      :user_id
+    ])
+    |> validate_required([:key, :host, :auth_type, :user_id])
+    |> update_change(:key, &String.trim/1)
+    |> update_change(:host, &(&1 |> String.trim() |> String.downcase()))
+    |> validate_format(:key, @key_re, message: "must be UPPER_SNAKE_CASE, like STRIPE_KEY")
+    |> validate_length(:key, max: 200)
+    |> validate_inclusion(:auth_type, @auth_types)
+    |> validate_host()
+    |> validate_auth_fields()
+    |> unique_constraint([:user_id, :key, :host],
+      error_key: :host,
+      message: "this secret is already bound to that host"
+    )
+  end
+
+  # ── host: `host[:port][/path]`, the one box the broker itself takes ──────
+
+  defp validate_host(changeset) do
+    case get_change(changeset, :host) do
+      nil -> changeset
+      pattern -> validate_host_pattern(changeset, pattern)
+    end
+  end
+
+  defp validate_host_pattern(changeset, pattern) do
+    {host_port, path} = split_path(pattern)
+    {host, port} = split_port(host_port)
+
+    errors =
+      host_errors(host) ++ port_errors(port) ++ path_errors(path)
+
+    Enum.reduce(errors, changeset, &add_error(&2, :host, &1))
+  end
+
+  defp split_path(pattern) do
+    case String.split(pattern, "/", parts: 2) do
+      [host] -> {host, ""}
+      [host, rest] -> {host, "/" <> rest}
+    end
+  end
+
+  defp split_port(host_port) do
+    case String.split(host_port, ":", parts: 2) do
+      [host] -> {host, nil}
+      [host, port] -> {host, port}
+    end
+  end
+
+  defp host_errors(""), do: ["host is required"]
+
+  defp host_errors(host) do
+    cond do
+      String.contains?(host, ["@", "?", "#", " "]) or String.match?(host, ~r/[[:cntrl:]]/) ->
+        ["host contains a character that is not allowed"]
+
+      ip?(host) ->
+        ["host must be a hostname, not an IP address"]
+
+      host == "*" ->
+        ["a bare wildcard is not allowed"]
+
+      String.starts_with?(host, "*") and not String.starts_with?(host, "*.") ->
+        ["a wildcard must be in the form *.example.com"]
+
+      String.starts_with?(host, "*.") ->
+        rest = String.trim_leading(host, "*.")
+
+        cond do
+          length(String.split(rest, ".")) < 2 ->
+            ["a wildcard must have at least two domain levels, like *.example.com"]
+
+          not String.match?(rest, @host_label_re) ->
+            ["invalid hostname in the wildcard pattern"]
+
+          true ->
+            []
+        end
+
+      host in @internal_hosts ->
+        ["host is a local or internal name and is not allowed"]
+
+      not String.match?(host, @host_label_re) ->
+        ["host must be a hostname with a domain, like api.example.com"]
+
+      true ->
+        []
+    end
+  end
+
+  defp ip?(host), do: match?({:ok, _}, :inet.parse_address(String.to_charlist(host)))
+
+  defp port_errors(nil), do: []
+
+  defp port_errors(port) do
+    case Integer.parse(port) do
+      {n, ""} when n in 1..65_535 -> []
+      _ -> ["port must be a number between 1 and 65535"]
+    end
+  end
+
+  defp path_errors(""), do: []
+
+  defp path_errors(path) do
+    cond do
+      String.length(path) > 256 -> ["path is too long (256 characters at most)"]
+      String.contains?(path, "**") -> ["path must not contain ** (only a single * glob)"]
+      String.match?(path, ~r/[[:cntrl:]]/) -> ["path must not contain control characters"]
+      String.contains?(path, @path_forbidden) -> ["path contains a character that is not allowed"]
+      true -> []
+    end
+  end
+
+  # ── auth: only the fields of the chosen type, which is what the broker
+  # insists on (a stale field from a previous choice is a 400 there) ────────
+
+  defp validate_auth_fields(changeset) do
+    case get_field(changeset, :auth_type) do
+      "bearer" ->
+        changeset |> clear([:header, :prefix, :username]) |> put_change(:headers, %{})
+
+      "basic" ->
+        changeset
+        |> validate_required([:username])
+        |> clear([:header, :prefix])
+        |> put_change(:headers, %{})
+
+      "api_key" ->
+        changeset
+        |> default_header()
+        |> validate_header_name()
+        |> clear([:username])
+        |> put_change(:headers, %{})
+
+      "custom" ->
+        changeset |> clear([:header, :prefix, :username]) |> validate_custom_headers()
+
+      _ ->
+        changeset
+    end
+  end
+
+  defp clear(changeset, fields), do: Enum.reduce(fields, changeset, &put_change(&2, &1, nil))
+
+  defp default_header(changeset) do
+    case get_field(changeset, :header) do
+      nil -> put_change(changeset, :header, "Authorization")
+      "" -> put_change(changeset, :header, "Authorization")
+      _ -> changeset
+    end
+  end
+
+  defp validate_header_name(changeset) do
+    validate_format(changeset, :header, @header_name_re,
+      message: "only letters, digits and hyphens are allowed"
+    )
+  end
+
+  defp validate_custom_headers(changeset) do
+    headers = get_field(changeset, :headers) || %{}
+
+    cond do
+      headers == %{} ->
+        add_error(changeset, :headers, "custom auth needs at least one header")
+
+      not Enum.all?(headers, fn {k, v} -> is_binary(k) and is_binary(v) end) ->
+        add_error(changeset, :headers, "must be header names to templates")
+
+      true ->
+        Enum.reduce(headers, changeset, fn {name, template}, cs ->
+          cond do
+            not String.match?(name, @header_name_re) ->
+              add_error(
+                cs,
+                :headers,
+                "header #{inspect(name)}: only letters, digits and hyphens are allowed"
+              )
+
+            Enum.any?(template_refs(template), &(not String.match?(&1, @key_re))) ->
+              add_error(
+                cs,
+                :headers,
+                "header #{inspect(name)}: every {{ KEY }} must be UPPER_SNAKE_CASE"
+              )
+
+            true ->
+              cs
+          end
+        end)
+    end
+  end
+
+  @doc "The credential keys a custom header template refers to, `{{ KEY }}`."
+  @spec template_refs(String.t()) :: [String.t()]
+  def template_refs(template) when is_binary(template) do
+    @template_ref_re |> Regex.scan(template) |> Enum.map(fn [_, k] -> k end)
+  end
+end

--- a/apps/fountain/lib/fountain/secret_bindings/catalog.ex
+++ b/apps/fountain/lib/fountain/secret_bindings/catalog.ex
@@ -1,0 +1,76 @@
+defmodule Fountain.SecretBindings.Catalog do
+  @moduledoc """
+  Agent Vault's service catalog (35 presets, 0.39.1), embedded so the console
+  can prefill a binding from a secret's name: `STRIPE_SECRET_KEY` suggests
+  `api.stripe.com` as a bearer, and so on.
+
+  Suggestions, never rules: the tenant still saves the binding, and can
+  change any field. Three presets are not directly usable as bindings and
+  are marked `usable: false` — `aws-s3` needs SigV4 signing, `jira` and
+  `twilio` are basic auth where the suggested key is the password and the
+  username is the tenant's own.
+
+  Read at compile time from `priv/broker/service_catalog.json`, which ships
+  in the release like the rest of `priv`.
+  """
+
+  @path Path.join(:code.priv_dir(:fountain) |> to_string(), "broker/service_catalog.json")
+  @external_resource @path
+
+  @unusable ~w(aws-s3 jira twilio)
+
+  @presets @path
+           |> File.read!()
+           |> Jason.decode!()
+           |> Enum.map(fn e ->
+             %{
+               id: e["id"],
+               name: e["name"],
+               host: e["host"],
+               description: e["description"],
+               auth_type: String.replace(e["auth_type"], "-", "_"),
+               suggested_key: e["suggested_credential_key"],
+               header: e["header"],
+               prefix: e["prefix"],
+               headers: e["headers"] || %{},
+               usable: e["id"] not in @unusable
+             }
+           end)
+
+  @type preset :: %{
+          id: String.t(),
+          name: String.t(),
+          host: String.t(),
+          description: String.t() | nil,
+          auth_type: String.t(),
+          suggested_key: String.t() | nil,
+          header: String.t() | nil,
+          prefix: String.t() | nil,
+          headers: map(),
+          usable: boolean()
+        }
+
+  @doc "Every preset, in the catalog's order."
+  @spec presets() :: [preset()]
+  def presets, do: @presets
+
+  @spec get(String.t()) :: preset() | nil
+  def get(id), do: Enum.find(@presets, &(&1.id == id))
+
+  @doc "Presets whose suggested credential key is this one. Usually zero or one."
+  @spec for_key(String.t()) :: [preset()]
+  def for_key(key) when is_binary(key), do: Enum.filter(@presets, &(&1.suggested_key == key))
+
+  @doc "The binding attributes a preset prefills, string-keyed for a changeset."
+  @spec attrs(preset(), String.t()) :: map()
+  def attrs(preset, key) do
+    %{
+      "key" => key,
+      "host" => preset.host,
+      "auth_type" => preset.auth_type,
+      "header" => preset.header,
+      "prefix" => preset.prefix,
+      "headers" => preset.headers
+    }
+  end
+end

--- a/apps/fountain/lib/fountain_web/components/layouts.ex
+++ b/apps/fountain/lib/fountain_web/components/layouts.ex
@@ -99,6 +99,12 @@ defmodule FountainWeb.Layouts do
                 current={@current_path}
               />
               <.nav_link href={~p"/account/runners"} label="Runners" current={@current_path} />
+              <.nav_link
+                :if={assigns[:current_user] && Fountain.Broker.enabled_for?(assigns.current_user.id)}
+                href={~p"/account/bindings"}
+                label="Credential bindings"
+                current={@current_path}
+              />
               <.nav_link href={~p"/account/webhooks"} label="Webhooks" current={@current_path} />
               <.nav_link
                 :if={Fountain.Credits.enabled?()}

--- a/apps/fountain/lib/fountain_web/controllers/secret_binding_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/secret_binding_controller.ex
@@ -1,0 +1,157 @@
+defmodule FountainWeb.SecretBindingController do
+  @moduledoc """
+  Secret bindings (ADR 0019 gate 1b): which hosts a secret is attached to at
+  the egress broker, and how.
+
+      GET    /api/secret-bindings            — the account's bindings
+      GET    /api/secret-bindings/presets    — the catalog the console prefills from
+      POST   /api/secret-bindings            — bind a secret to a host
+      PATCH  /api/secret-bindings/:id        — change one
+      DELETE /api/secret-bindings/:id        — unbind
+
+  Every route answers 404 `brokerage_not_enabled` for an account the broker
+  is not on for: the feature does not exist there, and the console does not
+  show it either.
+  """
+
+  use FountainWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Fountain.Broker
+  alias Fountain.SecretBindings
+  alias Fountain.SecretBindings.Catalog
+  alias FountainWeb.Audited
+  alias FountainWeb.Schemas
+
+  action_fallback FountainWeb.FallbackController
+
+  plug :require_brokerage
+
+  tags(["Secret bindings"])
+
+  operation(:index,
+    summary: "List secret bindings",
+    description:
+      "Every binding on the account: a secret name, the host it is attached " <>
+        "to at the egress broker, and the auth shape. A secret with at least " <>
+        "one enabled binding reaches the sandbox as a placeholder; one with " <>
+        "none reaches it in the clear. Only for accounts the broker is on for " <>
+        "(ADR 0019); 404 otherwise.",
+    responses: [
+      ok: {"Bindings", "application/json", Schemas.SecretBindingListResponse},
+      not_found: {"Brokerage is not enabled for this account", "application/json", Schemas.Error},
+      unauthorized: {"Missing or invalid key", "application/json", Schemas.Error}
+    ]
+  )
+
+  def index(conn, _params) do
+    user = conn.assigns.current_user
+    render(conn, :index, bindings: SecretBindings.list_bindings(user.id))
+  end
+
+  operation(:presets,
+    summary: "List binding presets",
+    description:
+      "The broker's service catalog: known hosts with their auth shape and " <>
+        "the secret name each usually goes by. Suggestions the console " <>
+        "prefills from; a binding is still yours to save.",
+    responses: [
+      ok: {"Presets", "application/json", Schemas.SecretBindingPresetListResponse},
+      not_found: {"Brokerage is not enabled for this account", "application/json", Schemas.Error},
+      unauthorized: {"Missing or invalid key", "application/json", Schemas.Error}
+    ]
+  )
+
+  def presets(conn, _params) do
+    render(conn, :presets, presets: Catalog.presets())
+  end
+
+  operation(:create,
+    summary: "Bind a secret to a host",
+    request_body: {"Binding", "application/json", Schemas.SecretBindingRequest, required: true},
+    responses: [
+      created: {"Binding", "application/json", Schemas.SecretBinding},
+      unprocessable_entity: {"Validation error", "application/json", Schemas.Error},
+      not_found: {"Brokerage is not enabled for this account", "application/json", Schemas.Error},
+      unauthorized: {"Missing or invalid key", "application/json", Schemas.Error}
+    ]
+  )
+
+  def create(conn, params) do
+    user = conn.assigns.current_user
+
+    with {:ok, binding} <-
+           SecretBindings.create_binding(
+             user.id,
+             binding_attrs(params),
+             Audited.attribution(conn)
+           ) do
+      conn |> put_status(:created) |> render(:show, binding: binding)
+    end
+  end
+
+  operation(:update,
+    summary: "Change a binding",
+    parameters: [id: [in: :path, type: :string, description: "Binding id"]],
+    request_body: {"Binding", "application/json", Schemas.SecretBindingRequest, required: true},
+    responses: [
+      ok: {"Binding", "application/json", Schemas.SecretBinding},
+      unprocessable_entity: {"Validation error", "application/json", Schemas.Error},
+      not_found:
+        {"No such binding, or brokerage is not enabled", "application/json", Schemas.Error},
+      unauthorized: {"Missing or invalid key", "application/json", Schemas.Error}
+    ]
+  )
+
+  def update(conn, %{"id" => id} = params) do
+    user = conn.assigns.current_user
+
+    with %{} = binding <- SecretBindings.get_binding(id, user.id) || {:error, :not_found},
+         {:ok, binding} <-
+           SecretBindings.update_binding(
+             binding,
+             binding_attrs(params),
+             Audited.attribution(conn)
+           ) do
+      render(conn, :show, binding: binding)
+    end
+  end
+
+  operation(:delete,
+    summary: "Unbind a secret from a host",
+    parameters: [id: [in: :path, type: :string, description: "Binding id"]],
+    responses: [
+      no_content: "Deleted",
+      not_found:
+        {"No such binding, or brokerage is not enabled", "application/json", Schemas.Error},
+      unauthorized: {"Missing or invalid key", "application/json", Schemas.Error}
+    ]
+  )
+
+  def delete(conn, %{"id" => id}) do
+    user = conn.assigns.current_user
+
+    with %{} = binding <- SecretBindings.get_binding(id, user.id) || {:error, :not_found},
+         {:ok, _} <- SecretBindings.delete_binding(binding, Audited.attribution(conn)) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+
+  @fields ~w(key host auth_type header prefix username headers enabled)
+
+  defp binding_attrs(params), do: Map.take(params, @fields)
+
+  defp require_brokerage(conn, _opts) do
+    if Broker.enabled_for?(conn.assigns.current_user.id) do
+      conn
+    else
+      conn
+      |> put_status(:not_found)
+      |> json(%{
+        error: "brokerage_not_enabled",
+        message: "Egress credential brokerage is not enabled for this account."
+      })
+      |> halt()
+    end
+  end
+end

--- a/apps/fountain/lib/fountain_web/controllers/secret_binding_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/secret_binding_json.ex
@@ -1,0 +1,42 @@
+defmodule FountainWeb.SecretBindingJSON do
+  @moduledoc "JSON views for secret bindings (ADR 0019 gate 1b)."
+
+  alias Fountain.SecretBindings.Binding
+
+  def index(%{bindings: bindings}), do: %{data: Enum.map(bindings, &summary/1)}
+
+  def show(%{binding: b}), do: summary(b)
+
+  def presets(%{presets: presets}), do: %{data: Enum.map(presets, &preset/1)}
+
+  defp summary(%Binding{} = b) do
+    %{
+      id: b.id,
+      key: b.key,
+      host: b.host,
+      auth_type: b.auth_type,
+      header: b.header,
+      prefix: b.prefix,
+      username: b.username,
+      headers: b.headers,
+      enabled: b.enabled,
+      created_at: b.inserted_at,
+      updated_at: b.updated_at
+    }
+  end
+
+  defp preset(p) do
+    %{
+      id: p.id,
+      name: p.name,
+      host: p.host,
+      description: p.description,
+      auth_type: p.auth_type,
+      suggested_key: p.suggested_key,
+      header: p.header,
+      prefix: p.prefix,
+      headers: p.headers,
+      usable: p.usable
+    }
+  end
+end

--- a/apps/fountain/lib/fountain_web/live/secret_bindings_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/secret_bindings_live/index.ex
@@ -213,7 +213,9 @@ defmodule FountainWeb.SecretBindingsLive.Index do
   defp changeset_error(changeset) do
     changeset
     |> Ecto.Changeset.traverse_errors(fn {msg, opts} ->
-      Regex.replace(~r"%{(\w+)}", msg, fn _, key -> to_string(opts[String.to_atom(key)]) end)
+      Regex.replace(~r"%{(\w+)}", msg, fn _, key ->
+        Enum.find_value(opts, "", fn {k, v} -> if Atom.to_string(k) == key, do: to_string(v) end)
+      end)
     end)
     |> Enum.map_join("; ", fn {field, msgs} -> "#{field} #{Enum.join(msgs, ", ")}" end)
   end

--- a/apps/fountain/lib/fountain_web/live/secret_bindings_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/secret_bindings_live/index.ex
@@ -1,0 +1,465 @@
+defmodule FountainWeb.SecretBindingsLive.Index do
+  @moduledoc """
+  `/account/bindings` — which hosts each secret is attached to at the egress
+  broker, and how (ADR 0019 gate 1b).
+
+  Only for accounts the broker is on for: the nav link is hidden otherwise,
+  and a direct visit is sent to `/account`. The page never sees a value —
+  it lists the names of the secrets the account holds anywhere, and the
+  bindings on each name.
+  """
+
+  use FountainWeb, :live_view
+
+  alias Fountain.Broker
+  alias Fountain.SecretBindings
+  alias Fountain.SecretBindings.Binding
+  alias Fountain.SecretBindings.Catalog
+
+  @impl true
+  def mount(_params, _session, socket) do
+    user = socket.assigns.current_user
+
+    if Broker.enabled_for?(user.id) do
+      {:ok,
+       socket
+       |> assign(:page_title, "Credential bindings")
+       |> assign(:user_id, user.id)
+       |> assign(:proxy_host, Broker.proxy_host())
+       |> assign(:presets, Catalog.presets())
+       |> assign(:form_version, 0)
+       |> assign(:draft, blank_draft())
+       |> reload()}
+    else
+      {:ok,
+       socket
+       |> put_flash(:error, "Egress credential brokerage is not enabled for this account.")
+       |> push_navigate(to: ~p"/account")}
+    end
+  end
+
+  # ── events ───────────────────────────────────────────────────────────────
+
+  # Keeps the form's shape in step with the auth type and the preset pick,
+  # so only the fields of the chosen type are shown and submitted — the
+  # broker rejects a stale field from a previous choice.
+  @impl true
+  def handle_event("draft", %{"binding" => attrs}, socket) do
+    draft =
+      Map.merge(
+        socket.assigns.draft,
+        Map.take(attrs, ~w(key host auth_type header prefix username headers_text))
+      )
+
+    {:noreply, assign(socket, :draft, draft)}
+  end
+
+  def handle_event("pick_key", %{"key" => key}, socket) do
+    draft = Map.put(socket.assigns.draft, "key", key)
+
+    # A preset that usually goes by this name prefills the rest.
+    draft =
+      case Catalog.for_key(key) do
+        [preset | _] ->
+          Map.merge(draft, %{
+            "host" => preset.host,
+            "auth_type" => preset.auth_type,
+            "header" => preset.header || "",
+            "prefix" => preset.prefix || "",
+            "headers_text" => headers_to_text(preset.headers)
+          })
+
+        [] ->
+          draft
+      end
+
+    {:noreply, socket |> assign(:draft, draft) |> update(:form_version, &(&1 + 1))}
+  end
+
+  def handle_event("preset", %{"id" => id}, socket) do
+    case Catalog.get(id) do
+      nil ->
+        {:noreply, socket}
+
+      preset ->
+        key = presence(socket.assigns.draft["key"]) || preset.suggested_key || ""
+
+        draft = %{
+          "key" => key,
+          "host" => preset.host,
+          "auth_type" => preset.auth_type,
+          "header" => preset.header || "",
+          "prefix" => preset.prefix || "",
+          "username" => "",
+          "headers_text" => headers_to_text(preset.headers)
+        }
+
+        {:noreply, socket |> assign(:draft, draft) |> update(:form_version, &(&1 + 1))}
+    end
+  end
+
+  def handle_event("save", %{"binding" => attrs}, socket) do
+    attrs = to_attrs(attrs)
+
+    case SecretBindings.create_binding(
+           socket.assigns.user_id,
+           attrs,
+           FountainWeb.Audited.attribution(socket)
+         ) do
+      {:ok, binding} ->
+        {:noreply,
+         socket
+         |> assign(:draft, blank_draft())
+         |> update(:form_version, &(&1 + 1))
+         |> reload()
+         |> put_flash(:info, "#{binding.key} is now attached to #{binding.host}")}
+
+      {:error, changeset} ->
+        {:noreply,
+         socket
+         |> assign(:draft, Map.merge(socket.assigns.draft, attrs_to_draft(attrs)))
+         |> put_flash(:error, changeset_error(changeset))}
+    end
+  end
+
+  def handle_event("toggle", %{"id" => id}, socket) do
+    with %Binding{} = binding <- SecretBindings.get_binding(id, socket.assigns.user_id),
+         {:ok, updated} <-
+           SecretBindings.update_binding(
+             binding,
+             %{"enabled" => not binding.enabled},
+             FountainWeb.Audited.attribution(socket)
+           ) do
+      word = if updated.enabled, do: "enabled", else: "disabled"
+
+      {:noreply,
+       socket |> reload() |> put_flash(:info, "#{updated.key} → #{updated.host} #{word}")}
+    else
+      _ -> {:noreply, put_flash(socket, :error, "Binding not found")}
+    end
+  end
+
+  def handle_event("delete", %{"id" => id}, socket) do
+    case SecretBindings.get_binding(id, socket.assigns.user_id) do
+      nil ->
+        {:noreply, put_flash(socket, :error, "Binding not found")}
+
+      binding ->
+        {:ok, _} = SecretBindings.delete_binding(binding, FountainWeb.Audited.attribution(socket))
+
+        {:noreply,
+         socket |> reload() |> put_flash(:info, "Unbound #{binding.key} from #{binding.host}")}
+    end
+  end
+
+  # ── helpers ──────────────────────────────────────────────────────────────
+
+  defp reload(socket) do
+    user_id = socket.assigns.user_id
+    bindings = SecretBindings.list_bindings(user_id)
+    known = SecretBindings.known_keys(user_id)
+    bound = bindings |> Enum.map(& &1.key) |> Enum.uniq()
+
+    socket
+    |> assign(:bindings, bindings)
+    |> assign(:by_key, Enum.group_by(bindings, & &1.key))
+    |> assign(:known_keys, known)
+    |> assign(:unbound_keys, Enum.reject(known, &(&1 in bound)))
+    |> assign(:catalog_keys, Broker.catalog_keys())
+  end
+
+  defp blank_draft do
+    %{
+      "key" => "",
+      "host" => "",
+      "auth_type" => "bearer",
+      "header" => "",
+      "prefix" => "",
+      "username" => "",
+      "headers_text" => ""
+    }
+  end
+
+  defp presence(nil), do: nil
+  defp presence(""), do: nil
+  defp presence(s), do: s
+
+  defp to_attrs(params) do
+    params
+    |> Map.take(~w(key host auth_type header prefix username))
+    |> Map.put("headers", text_to_headers(params["headers_text"] || ""))
+  end
+
+  defp attrs_to_draft(attrs) do
+    attrs
+    |> Map.take(~w(key host auth_type header prefix username))
+    |> Map.put("headers_text", headers_to_text(attrs["headers"] || %{}))
+  end
+
+  # One `Name: template` per line. `{{ KEY }}` in a template is replaced by
+  # the secret at the broker.
+  defp text_to_headers(text) do
+    text
+    |> String.split(~r/\r?\n/, trim: true)
+    |> Enum.map(&String.split(&1, ":", parts: 2))
+    |> Enum.filter(&match?([_, _], &1))
+    |> Map.new(fn [name, value] -> {String.trim(name), String.trim(value)} end)
+  end
+
+  defp headers_to_text(headers) when is_map(headers) do
+    headers |> Enum.map(fn {k, v} -> "#{k}: #{v}" end) |> Enum.sort() |> Enum.join("\n")
+  end
+
+  defp changeset_error(changeset) do
+    changeset
+    |> Ecto.Changeset.traverse_errors(fn {msg, opts} ->
+      Regex.replace(~r"%{(\w+)}", msg, fn _, key -> to_string(opts[String.to_atom(key)]) end)
+    end)
+    |> Enum.map_join("; ", fn {field, msgs} -> "#{field} #{Enum.join(msgs, ", ")}" end)
+  end
+
+  defp auth_label("bearer"), do: "Bearer token"
+  defp auth_label("basic"), do: "Basic auth (secret is the password)"
+  defp auth_label("api_key"), do: "API key header"
+  defp auth_label("custom"), do: "Custom headers"
+
+  defp auth_summary(%Binding{auth_type: "bearer"}), do: "Authorization: Bearer <secret>"
+  defp auth_summary(%Binding{auth_type: "basic", username: u}), do: "Basic #{u}:<secret>"
+  defp auth_summary(%Binding{auth_type: "api_key", header: h, prefix: nil}), do: "#{h}: <secret>"
+  defp auth_summary(%Binding{auth_type: "api_key", header: h, prefix: ""}), do: "#{h}: <secret>"
+
+  defp auth_summary(%Binding{auth_type: "api_key", header: h, prefix: p}),
+    do: "#{h}: #{p}<secret>"
+
+  defp auth_summary(%Binding{auth_type: "custom", headers: hs}),
+    do: hs |> Map.keys() |> Enum.sort() |> Enum.join(", ")
+
+  # ── render ───────────────────────────────────────────────────────────────
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="space-y-8 max-w-4xl">
+      <div>
+        <h1 class="text-2xl font-semibold">Credential bindings</h1>
+        <p class="text-sm text-[var(--color-text-secondary)] mt-1 max-w-2xl">
+          Your sandboxes reach the internet only through the egress broker at <code class="font-mono">{@proxy_host}</code>. A secret you bind here never enters a
+          sandbox: the agent sees a placeholder, and the broker attaches the real value to
+          requests for the hosts you name. A secret with no binding reaches the sandbox in the
+          clear, as before.
+        </p>
+      </div>
+
+      <section class="space-y-3">
+        <h2 class="text-lg font-medium">Bound secrets</h2>
+        <div :if={@bindings == []} class="text-sm text-[var(--color-text-secondary)]">
+          No bindings yet. <code class="font-mono">GITHUB_TOKEN</code>
+          and <code class="font-mono">GH_TOKEN</code>
+          are attached to GitHub by default until you
+          bind them yourself.
+        </div>
+        <div
+          :for={{key, bindings} <- @by_key}
+          id={"key-#{key}"}
+          class="rounded border border-[var(--color-border)]"
+        >
+          <div class="px-3 py-2 border-b border-[var(--color-border)] flex items-center gap-2">
+            <span class="font-mono text-sm">{key}</span>
+            <span
+              :if={key not in @known_keys}
+              class="text-xs text-amber-600"
+              title="No environment or vault holds a secret of this name right now"
+            >
+              not stored anywhere yet
+            </span>
+          </div>
+          <table class="w-full text-sm">
+            <tbody>
+              <tr
+                :for={b <- bindings}
+                id={"binding-#{b.id}"}
+                class={[
+                  "border-b border-[var(--color-border)] last:border-0",
+                  !b.enabled && "opacity-60"
+                ]}
+              >
+                <td class="px-3 py-2 font-mono">{b.host}</td>
+                <td class="px-3 py-2 text-[var(--color-text-secondary)]">{auth_summary(b)}</td>
+                <td class="px-3 py-2 text-xs">
+                  <span :if={b.enabled} class="text-emerald-600">enabled</span>
+                  <span :if={!b.enabled} class="text-zinc-500">disabled</span>
+                </td>
+                <td class="px-3 py-2 text-right whitespace-nowrap space-x-2">
+                  <.btn_secondary phx-click="toggle" phx-value-id={b.id}>
+                    {if b.enabled, do: "Disable", else: "Enable"}
+                  </.btn_secondary>
+                  <.btn_danger phx-click="delete" phx-value-id={b.id} data-confirm="Unbind?">
+                    Unbind
+                  </.btn_danger>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section :if={@unbound_keys != []} class="space-y-2">
+        <h2 class="text-lg font-medium">Secrets with no binding</h2>
+        <p class="text-sm text-[var(--color-text-secondary)]">
+          These reach the sandbox in the clear. Bind the ones that are credentials for a host.
+        </p>
+        <div class="flex flex-wrap gap-2">
+          <button
+            :for={key <- @unbound_keys}
+            type="button"
+            phx-click="pick_key"
+            phx-value-key={key}
+            class="font-mono text-xs rounded border border-[var(--color-border)] px-2 py-1"
+            title={if key in @catalog_keys, do: "Attached to GitHub by default", else: "Not brokered"}
+            id={"unbound-#{key}"}
+          >
+            {key}<span :if={key in @catalog_keys} class="ml-1 text-emerald-600">(GitHub default)</span>
+          </button>
+        </div>
+      </section>
+
+      <section class="space-y-3">
+        <h2 class="text-lg font-medium">Bind a secret to a host</h2>
+        <div class="flex flex-wrap gap-1 items-center text-xs">
+          <span class="text-[var(--color-text-secondary)] mr-1">Start from a known service:</span>
+          <button
+            :for={p <- @presets}
+            :if={p.usable}
+            type="button"
+            phx-click="preset"
+            phx-value-id={p.id}
+            class="rounded border border-[var(--color-border)] px-2 py-0.5 hover:bg-[var(--color-bg-1)]"
+            title={"#{p.host} · #{p.auth_type}" <> if(p.suggested_key, do: " · usually #{p.suggested_key}", else: "")}
+            id={"preset-#{p.id}"}
+          >
+            {p.name}
+          </button>
+        </div>
+
+        <form
+          id={"binding-form-#{@form_version}"}
+          phx-change="draft"
+          phx-submit="save"
+          class="space-y-3 rounded border border-[var(--color-border)] p-4"
+        >
+          <div class="grid gap-3 sm:grid-cols-2">
+            <div class="space-y-1">
+              <label for="binding_key" class="block text-sm font-medium">Secret name</label>
+              <input
+                id="binding_key"
+                name="binding[key]"
+                type="text"
+                list="known-keys"
+                value={@draft["key"]}
+                placeholder="STRIPE_SECRET_KEY"
+                pattern="[A-Z][A-Z0-9_]*"
+                required
+                class="block w-full rounded-md border px-3 py-2 text-sm font-mono bg-[var(--color-bg-1)]"
+              />
+              <datalist id="known-keys">
+                <option :for={k <- @known_keys} value={k} />
+              </datalist>
+            </div>
+            <div class="space-y-1">
+              <label for="binding_host" class="block text-sm font-medium">Host</label>
+              <input
+                id="binding_host"
+                name="binding[host]"
+                type="text"
+                value={@draft["host"]}
+                placeholder="api.example.com, *.example.com, host:port, host/path/*"
+                required
+                class="block w-full rounded-md border px-3 py-2 text-sm font-mono bg-[var(--color-bg-1)]"
+              />
+            </div>
+          </div>
+
+          <fieldset class="space-y-1">
+            <legend class="text-sm font-medium">How the secret is sent</legend>
+            <div class="flex flex-wrap gap-3 text-sm">
+              <label :for={t <- Binding.auth_types()} class="flex items-center gap-1">
+                <input
+                  type="radio"
+                  name="binding[auth_type]"
+                  value={t}
+                  checked={@draft["auth_type"] == t}
+                />
+                {auth_label(t)}
+              </label>
+            </div>
+          </fieldset>
+
+          <div :if={@draft["auth_type"] == "basic"} class="space-y-1">
+            <label for="binding_username" class="block text-sm font-medium">Username</label>
+            <input
+              id="binding_username"
+              name="binding[username]"
+              type="text"
+              value={@draft["username"]}
+              placeholder="x-access-token"
+              class="block w-full rounded-md border px-3 py-2 text-sm font-mono bg-[var(--color-bg-1)]"
+            />
+            <p class="text-xs text-[var(--color-text-secondary)]">The secret is the password.</p>
+          </div>
+
+          <div :if={@draft["auth_type"] == "api_key"} class="grid gap-3 sm:grid-cols-2">
+            <div class="space-y-1">
+              <label for="binding_header" class="block text-sm font-medium">Header</label>
+              <input
+                id="binding_header"
+                name="binding[header]"
+                type="text"
+                value={@draft["header"]}
+                placeholder="Authorization"
+                class="block w-full rounded-md border px-3 py-2 text-sm font-mono bg-[var(--color-bg-1)]"
+              />
+            </div>
+            <div class="space-y-1">
+              <label for="binding_prefix" class="block text-sm font-medium">Prefix</label>
+              <input
+                id="binding_prefix"
+                name="binding[prefix]"
+                type="text"
+                value={@draft["prefix"]}
+                placeholder="Token "
+                class="block w-full rounded-md border px-3 py-2 text-sm font-mono bg-[var(--color-bg-1)]"
+              />
+              <p class="text-xs text-[var(--color-text-secondary)]">
+                Text placed before the value, with its trailing space.
+              </p>
+            </div>
+          </div>
+
+          <div :if={@draft["auth_type"] == "custom"} class="space-y-1">
+            <label for="binding_headers_text" class="block text-sm font-medium">Headers</label>
+            <textarea
+              id="binding_headers_text"
+              name="binding[headers_text]"
+              rows="3"
+              placeholder="X-Api-Key: {{ STRIPE_SECRET_KEY }}\nX-Account: acct_123"
+              class="block w-full rounded-md border px-3 py-2 text-sm font-mono bg-[var(--color-bg-1)]"
+            >{@draft["headers_text"]}</textarea>
+            <p class="text-xs text-[var(--color-text-secondary)]">
+              One <code>Name: value</code>
+              per line. <code>{"{{ KEY }}"}</code>
+              is replaced by that secret at the broker.
+            </p>
+          </div>
+
+          <div class="flex items-center gap-3">
+            <.btn type="submit">Bind</.btn>
+            <span class="text-xs text-[var(--color-text-secondary)]">
+              The secret's name is enough; its value stays where it is stored.
+            </span>
+          </div>
+        </form>
+      </section>
+    </div>
+    """
+  end
+end

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -322,6 +322,19 @@ defmodule FountainWeb.Router do
     delete "/:id", RunnerController, :delete
   end
 
+  # Secret bindings (ADR 0019 gate 1b). Full scope for the same reason as
+  # runners: a conversation-scoped token must not be able to redirect the
+  # account's credentials to another host.
+  scope "/api/secret-bindings", FountainWeb do
+    pipe_through [:accepts_json, :api, :require_full_scope]
+
+    get "/", SecretBindingController, :index
+    get "/presets", SecretBindingController, :presets
+    post "/", SecretBindingController, :create
+    patch "/:id", SecretBindingController, :update
+    delete "/:id", SecretBindingController, :delete
+  end
+
   # The daemon's socket skips content negotiation like the SSE routes do: a
   # WebSocket client sends no JSON `Accept`, and the upgrade is not a JSON
   # response.
@@ -611,6 +624,9 @@ defmodule FountainWeb.Router do
 
       # ── Self-hosted runners (ADR 0022) ─────────────────────────────────────────────────────
       live "/account/runners", RunnersLive.Index, :index
+
+      # ── Secret bindings at the egress broker (ADR 0019 gate 1b) ────────────────────────────
+      live "/account/bindings", SecretBindingsLive.Index, :index
 
       # ── Outbound webhooks (#700) ───────────────────────────────────────────────────────────
       live "/account/webhooks", WebhooksLive.Index, :index

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -3245,6 +3245,111 @@ defmodule FountainWeb.Schemas do
 
   list_response(RunnerListResponse, of: Runner)
 
+  defmodule SecretBinding do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "SecretBinding",
+      description:
+        "Which host a secret is attached to at the egress broker, and how " <>
+          "(ADR 0019). Keyed by the secret's name: it applies wherever an " <>
+          "environment or vault holds a secret of that name. A secret with at " <>
+          "least one enabled binding reaches the sandbox as a placeholder " <>
+          "(`__key__`); one with none reaches it in the clear.",
+      type: :object,
+      properties: %{
+        id: %Schema{type: :string, format: :uuid},
+        key: %Schema{type: :string, description: "The secret's name, UPPER_SNAKE_CASE."},
+        host: %Schema{
+          type: :string,
+          description:
+            "Host pattern: `api.example.com`, a one-level wildcard `*.example.com`, " <>
+              "optionally `:port` and a `/path/*` glob."
+        },
+        auth_type: %Schema{type: :string, enum: ["bearer", "basic", "api_key", "custom"]},
+        header: %Schema{
+          type: :string,
+          nullable: true,
+          description: "api_key only: the header the value is sent in. Defaults to Authorization."
+        },
+        prefix: %Schema{
+          type: :string,
+          nullable: true,
+          description: "api_key only: text placed before the value, such as `Token `."
+        },
+        username: %Schema{
+          type: :string,
+          nullable: true,
+          description: "basic only: the username; the secret is the password."
+        },
+        headers: %Schema{
+          type: :object,
+          additionalProperties: %Schema{type: :string},
+          description:
+            "custom only: header name to template, `{{ KEY }}` is replaced by the secret."
+        },
+        enabled: %Schema{type: :boolean},
+        created_at: %Schema{type: :string, format: :"date-time"},
+        updated_at: %Schema{type: :string, format: :"date-time"}
+      },
+      required: [:id, :key, :host, :auth_type, :headers, :enabled, :created_at, :updated_at]
+    })
+  end
+
+  defmodule SecretBindingRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "SecretBindingRequest",
+      type: :object,
+      properties: %{
+        key: %Schema{type: :string},
+        host: %Schema{type: :string},
+        auth_type: %Schema{type: :string, enum: ["bearer", "basic", "api_key", "custom"]},
+        header: %Schema{type: :string, nullable: true},
+        prefix: %Schema{type: :string, nullable: true},
+        username: %Schema{type: :string, nullable: true},
+        headers: %Schema{type: :object, additionalProperties: %Schema{type: :string}},
+        enabled: %Schema{type: :boolean}
+      },
+      required: [:key, :host, :auth_type],
+      example: %{key: "STRIPE_SECRET_KEY", host: "api.stripe.com", auth_type: "bearer"}
+    })
+  end
+
+  defmodule SecretBindingPreset do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "SecretBindingPreset",
+      description: "A known service from the broker's catalog, to prefill a binding from.",
+      type: :object,
+      properties: %{
+        id: %Schema{type: :string},
+        name: %Schema{type: :string},
+        host: %Schema{type: :string},
+        description: %Schema{type: :string, nullable: true},
+        auth_type: %Schema{type: :string},
+        suggested_key: %Schema{type: :string, nullable: true},
+        header: %Schema{type: :string, nullable: true},
+        prefix: %Schema{type: :string, nullable: true},
+        headers: %Schema{type: :object, additionalProperties: %Schema{type: :string}},
+        usable: %Schema{
+          type: :boolean,
+          description:
+            "False for the few presets a binding cannot express on its own (request signing, a username of yours)."
+        }
+      },
+      required: [:id, :name, :host, :auth_type, :usable]
+    })
+  end
+
+  list_response(SecretBindingListResponse, of: SecretBinding)
+  list_response(SecretBindingPresetListResponse, of: SecretBindingPreset)
+
   defmodule ApiKeyRequest do
     @moduledoc false
     require OpenApiSpex

--- a/apps/fountain/priv/broker/service_catalog.json
+++ b/apps/fountain/priv/broker/service_catalog.json
@@ -1,0 +1,304 @@
+[
+  {
+    "id": "anthropic",
+    "name": "Anthropic",
+    "host": "api.anthropic.com",
+    "description": "Claude API",
+    "auth_type": "api-key",
+    "suggested_credential_key": "ANTHROPIC_API_KEY",
+    "header": "x-api-key"
+  },
+  {
+    "id": "aws-s3",
+    "name": "AWS S3",
+    "host": "s3.amazonaws.com",
+    "description": "Amazon S3 object storage",
+    "auth_type": "custom",
+    "suggested_credential_key": "AWS_SECRET_ACCESS_KEY"
+  },
+  {
+    "id": "cloudflare",
+    "name": "Cloudflare",
+    "host": "api.cloudflare.com",
+    "description": "Cloudflare API",
+    "auth_type": "bearer",
+    "suggested_credential_key": "CLOUDFLARE_API_TOKEN"
+  },
+  {
+    "id": "cohere",
+    "name": "Cohere",
+    "host": "api.cohere.com",
+    "description": "Cohere language models",
+    "auth_type": "bearer",
+    "suggested_credential_key": "CO_API_KEY"
+  },
+  {
+    "id": "datadog",
+    "name": "Datadog",
+    "host": "api.datadoghq.com",
+    "description": "Monitoring and analytics",
+    "auth_type": "api-key",
+    "suggested_credential_key": "DATADOG_API_KEY",
+    "header": "DD-API-KEY"
+  },
+  {
+    "id": "deepseek",
+    "name": "DeepSeek",
+    "host": "api.deepseek.com",
+    "description": "DeepSeek chat and reasoning models",
+    "auth_type": "bearer",
+    "suggested_credential_key": "DEEPSEEK_API_KEY"
+  },
+  {
+    "id": "discord",
+    "name": "Discord",
+    "host": "discord.com/api/*",
+    "description": "Discord bot and REST API",
+    "auth_type": "api-key",
+    "suggested_credential_key": "DISCORD_BOT_TOKEN",
+    "header": "Authorization",
+    "prefix": "Bot "
+  },
+  {
+    "id": "fireworks",
+    "name": "Fireworks AI",
+    "host": "api.fireworks.ai",
+    "description": "Fast open-model inference",
+    "auth_type": "bearer",
+    "suggested_credential_key": "FIREWORKS_API_KEY"
+  },
+  {
+    "id": "gemini",
+    "name": "Google Gemini",
+    "host": "generativelanguage.googleapis.com",
+    "description": "Google Gemini models",
+    "auth_type": "api-key",
+    "suggested_credential_key": "GEMINI_API_KEY",
+    "header": "x-goog-api-key"
+  },
+  {
+    "id": "github",
+    "name": "GitHub",
+    "host": "api.github.com",
+    "description": "GitHub REST API",
+    "auth_type": "bearer",
+    "suggested_credential_key": "GITHUB_TOKEN"
+  },
+  {
+    "id": "gitlab",
+    "name": "GitLab",
+    "host": "gitlab.com/api/*",
+    "description": "GitLab repos and pipelines",
+    "auth_type": "api-key",
+    "suggested_credential_key": "GITLAB_TOKEN",
+    "header": "PRIVATE-TOKEN"
+  },
+  {
+    "id": "groq",
+    "name": "Groq",
+    "host": "api.groq.com",
+    "description": "Fast model inference from Groq",
+    "auth_type": "bearer",
+    "suggested_credential_key": "GROQ_API_KEY"
+  },
+  {
+    "id": "jira",
+    "name": "Jira",
+    "host": "*.atlassian.net",
+    "description": "Atlassian Jira project tracking",
+    "auth_type": "basic",
+    "suggested_credential_key": "JIRA_API_TOKEN"
+  },
+  {
+    "id": "linear",
+    "name": "Linear",
+    "host": "api.linear.app",
+    "description": "Project management and issue tracking",
+    "auth_type": "api-key",
+    "suggested_credential_key": "LINEAR_API_KEY",
+    "header": "Authorization"
+  },
+  {
+    "id": "mistral",
+    "name": "Mistral AI",
+    "host": "api.mistral.ai",
+    "description": "Mistral chat and embedding models",
+    "auth_type": "bearer",
+    "suggested_credential_key": "MISTRAL_API_KEY"
+  },
+  {
+    "id": "notion",
+    "name": "Notion",
+    "host": "api.notion.com",
+    "description": "Notion workspace API",
+    "auth_type": "bearer",
+    "suggested_credential_key": "NOTION_TOKEN"
+  },
+  {
+    "id": "npm",
+    "name": "NPM",
+    "host": "registry.npmjs.org",
+    "description": "NPM Default registry",
+    "auth_type": "bearer",
+    "suggested_credential_key": "NPM_TOKEN"
+  },
+  {
+    "id": "npmgh",
+    "name": "Github NPM registry",
+    "host": "npm.pkg.github.com",
+    "description": "Github's NPM registry",
+    "auth_type": "bearer",
+    "suggested_credential_key": "NPM_GH_TOKEN"
+  },
+  {
+    "id": "openai",
+    "name": "OpenAI",
+    "host": "api.openai.com",
+    "description": "OpenAI / ChatGPT API",
+    "auth_type": "bearer",
+    "suggested_credential_key": "OPENAI_API_KEY"
+  },
+  {
+    "id": "openrouter",
+    "name": "OpenRouter",
+    "host": "openrouter.ai",
+    "description": "One key for many AI models",
+    "auth_type": "bearer",
+    "suggested_credential_key": "OPENROUTER_API_KEY"
+  },
+  {
+    "id": "pagerduty",
+    "name": "PagerDuty",
+    "host": "api.pagerduty.com",
+    "description": "Incident management",
+    "auth_type": "custom",
+    "suggested_credential_key": "PAGERDUTY_TOKEN",
+    "headers": {
+      "Authorization": "Token token={{ PAGERDUTY_TOKEN }}"
+    }
+  },
+  {
+    "id": "perplexity",
+    "name": "Perplexity",
+    "host": "api.perplexity.ai",
+    "description": "Perplexity answer engine",
+    "auth_type": "bearer",
+    "suggested_credential_key": "PERPLEXITY_API_KEY"
+  },
+  {
+    "id": "postmark",
+    "name": "Postmark",
+    "host": "api.postmarkapp.com",
+    "description": "Transactional email service",
+    "auth_type": "api-key",
+    "suggested_credential_key": "POSTMARK_SERVER_TOKEN",
+    "header": "X-Postmark-Server-Token"
+  },
+  {
+    "id": "resend",
+    "name": "Resend",
+    "host": "api.resend.com",
+    "description": "Email API for developers",
+    "auth_type": "bearer",
+    "suggested_credential_key": "RESEND_API_KEY"
+  },
+  {
+    "id": "sendgrid",
+    "name": "SendGrid",
+    "host": "api.sendgrid.com",
+    "description": "Email delivery API",
+    "auth_type": "bearer",
+    "suggested_credential_key": "SENDGRID_API_KEY"
+  },
+  {
+    "id": "sentry",
+    "name": "Sentry",
+    "host": "sentry.io",
+    "description": "Error tracking and performance monitoring",
+    "auth_type": "bearer",
+    "suggested_credential_key": "SENTRY_AUTH_TOKEN"
+  },
+  {
+    "id": "shopify",
+    "name": "Shopify",
+    "host": "*.myshopify.com",
+    "description": "Shopify e-commerce API",
+    "auth_type": "api-key",
+    "suggested_credential_key": "SHOPIFY_ACCESS_TOKEN",
+    "header": "X-Shopify-Access-Token"
+  },
+  {
+    "id": "slack",
+    "name": "Slack",
+    "host": "slack.com",
+    "description": "Slack Web API",
+    "auth_type": "bearer",
+    "suggested_credential_key": "SLACK_TOKEN"
+  },
+  {
+    "id": "stripe",
+    "name": "Stripe",
+    "host": "api.stripe.com",
+    "description": "Payment processing API",
+    "auth_type": "bearer",
+    "suggested_credential_key": "STRIPE_SECRET_KEY"
+  },
+  {
+    "id": "supabase",
+    "name": "Supabase",
+    "host": "*.supabase.co",
+    "description": "Supabase backend-as-a-service",
+    "auth_type": "api-key",
+    "suggested_credential_key": "SUPABASE_KEY",
+    "header": "apikey"
+  },
+  {
+    "id": "telegram",
+    "name": "Telegram",
+    "host": "api.telegram.org",
+    "description": "Telegram bot API",
+    "auth_type": "passthrough",
+    "suggested_credential_key": "TELEGRAM_BOT_TOKEN",
+    "substitutions": [
+      {
+        "key": "TELEGRAM_BOT_TOKEN",
+        "placeholder": "__TELEGRAM_BOT_TOKEN__",
+        "in": [
+          "path"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "together",
+    "name": "Together AI",
+    "host": "api.together.ai",
+    "description": "Open models on Together AI",
+    "auth_type": "bearer",
+    "suggested_credential_key": "TOGETHER_API_KEY"
+  },
+  {
+    "id": "twilio",
+    "name": "Twilio",
+    "host": "api.twilio.com",
+    "description": "Communication APIs (SMS, voice, email)",
+    "auth_type": "basic",
+    "suggested_credential_key": "TWILIO_AUTH_TOKEN"
+  },
+  {
+    "id": "vercel",
+    "name": "Vercel",
+    "host": "api.vercel.com",
+    "description": "Vercel deployment platform",
+    "auth_type": "bearer",
+    "suggested_credential_key": "VERCEL_TOKEN"
+  },
+  {
+    "id": "xai",
+    "name": "xAI (Grok)",
+    "host": "api.x.ai",
+    "description": "Grok models from xAI",
+    "auth_type": "bearer",
+    "suggested_credential_key": "XAI_API_KEY"
+  }
+]

--- a/apps/fountain/priv/repo/migrations/20260826020000_create_secret_bindings.exs
+++ b/apps/fountain/priv/repo/migrations/20260826020000_create_secret_bindings.exs
@@ -1,0 +1,29 @@
+defmodule Fountain.Repo.Migrations.CreateSecretBindings do
+  use Ecto.Migration
+
+  # ADR 0019 gate 1b: which hosts a tenant's secret is attached to at the
+  # egress broker, and how. Keyed by secret *name* per tenant, because
+  # brokering runs on the merged environment ∪ vault map (§9) where only the
+  # name survives, and because "my GITHUB_TOKEN goes to api.github.com as a
+  # bearer" is true of every environment that holds one.
+  def change do
+    create table(:secret_bindings, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :user_id, references(:users, type: :binary_id, on_delete: :delete_all), null: false
+      add :key, :string, null: false
+      # One box, as the broker itself takes it: host, `*.` wildcard, optional
+      # `:port`, optional `/path/*` glob.
+      add :host, :string, null: false
+      add :auth_type, :string, null: false
+      add :header, :string
+      add :prefix, :string
+      add :username, :string
+      add :headers, :map, null: false, default: %{}
+      add :enabled, :boolean, null: false, default: true
+      timestamps(type: :utc_datetime)
+    end
+
+    create unique_index(:secret_bindings, [:user_id, :key, :host])
+    create index(:secret_bindings, [:user_id, :key])
+  end
+end

--- a/apps/fountain/test/fountain/audit_guardrail_test.exs
+++ b/apps/fountain/test/fountain/audit_guardrail_test.exs
@@ -108,6 +108,11 @@ defmodule Fountain.AuditGuardrailTest do
     {"webhook endpoint enable", &__MODULE__.do_webhook_enable/1, "webhook_endpoint.enabled"},
     # Prepaid credits (ADR 0030). Money in and money out are the two shapes;
     # every reason family maps onto one of five `credit.*` actions.
+    # Secret bindings (ADR 0019 gate 1b): where a credential goes is as
+    # auditable as the credential's existence.
+    {"secret binding create", &__MODULE__.do_binding_create/1, "secret_binding.created"},
+    {"secret binding update", &__MODULE__.do_binding_update/1, "secret_binding.updated"},
+    {"secret binding delete", &__MODULE__.do_binding_delete/1, "secret_binding.deleted"},
     {"credit grant", &__MODULE__.do_credit_grant/1, "credit.granted"},
     {"credit debit", &__MODULE__.do_credit_debit/1, "credit.burned"}
   ]
@@ -282,6 +287,37 @@ defmodule Fountain.AuditGuardrailTest do
       "name" => "buzz-#{System.unique_integer([:positive])}",
       "relay_url" => "wss://relay.test"
     }
+  end
+
+  def do_binding_create(user) do
+    {:ok, _} =
+      Fountain.SecretBindings.create_binding(user.id, %{
+        "key" => "K",
+        "host" => "api.example.com",
+        "auth_type" => "bearer"
+      })
+  end
+
+  def do_binding_update(user) do
+    {:ok, b} =
+      Fountain.SecretBindings.create_binding(user.id, %{
+        "key" => "K2",
+        "host" => "api.example.com",
+        "auth_type" => "bearer"
+      })
+
+    {:ok, _} = Fountain.SecretBindings.update_binding(b, %{"enabled" => false})
+  end
+
+  def do_binding_delete(user) do
+    {:ok, b} =
+      Fountain.SecretBindings.create_binding(user.id, %{
+        "key" => "K3",
+        "host" => "api.example.com",
+        "auth_type" => "bearer"
+      })
+
+    {:ok, _} = Fountain.SecretBindings.delete_binding(b)
   end
 
   def do_runner_register(user) do

--- a/apps/fountain/test/fountain/broker_test.exs
+++ b/apps/fountain/test/fountain/broker_test.exs
@@ -169,7 +169,11 @@ defmodule Fountain.BrokerTest do
 
       # The tenant's value plus the constant git username, in one upsert.
       assert_received {:post, "/v1/credentials", %{vault: ^vault, credentials: creds}, _}
-      assert creds == %{"GITHUB_TOKEN" => "ghp_real", "GITHUB_BASIC_USER" => "x-access-token"}
+
+      assert creds == %{
+               "GITHUB_TOKEN" => "ghp_real",
+               "GITHUB_TOKEN_BASIC_USER" => "x-access-token"
+             }
 
       # api.github.com takes a bearer; git over HTTPS on github.com sends basic.
       assert_received {:put, "/v1/vaults/" <> _, %{services: services}}
@@ -183,7 +187,11 @@ defmodule Fountain.BrokerTest do
                %{
                  name: "github-git",
                  host: "github.com",
-                 auth: %{type: "basic", username: "GITHUB_BASIC_USER", password: "GITHUB_TOKEN"}
+                 auth: %{
+                   type: "basic",
+                   username: "GITHUB_TOKEN_BASIC_USER",
+                   password: "GITHUB_TOKEN"
+                 }
                }
              ] = services
 
@@ -239,6 +247,174 @@ defmodule Fountain.BrokerTest do
     test "a transport error surfaces as-is" do
       stub(Req, :post, fn _r, _o -> {:error, :econnrefused} end)
       assert {:error, {:broker, :vault, :econnrefused}} = Broker.prepare(@conv, %{})
+    end
+  end
+
+  describe "bindings (gate 1b)" do
+    setup do
+      configure(["u1"])
+      :ok
+    end
+
+    defp bound(attrs) do
+      struct(
+        Fountain.SecretBindings.Binding,
+        Map.merge(
+          %{
+            auth_type: "bearer",
+            header: nil,
+            prefix: nil,
+            username: nil,
+            headers: %{},
+            enabled: true
+          },
+          attrs
+        )
+      )
+    end
+
+    defp capture_services do
+      test = self()
+
+      stub(Req, :post, fn _r, opts ->
+        if opts[:url] == "/v1/credentials",
+          do: send(test, {:credentials, opts[:json].credentials})
+
+        if opts[:url] == "/v1/sessions",
+          do: {:ok, %{status: 201, body: %{"token" => "t"}}},
+          else: {:ok, %{status: 200, body: %{}}}
+      end)
+
+      stub(Req, :patch, fn _r, _o -> {:ok, %{status: 200, body: %{}}} end)
+
+      stub(Req, :put, fn _r, opts ->
+        send(test, {:services, opts[:json].services})
+        {:ok, %{status: 200, body: %{}}}
+      end)
+    end
+
+    test "split/2 brokers a key with a binding, and leaves an unbound non-catalog key alone" do
+      bindings = %{
+        "STRIPE_SECRET_KEY" => [bound(%{key: "STRIPE_SECRET_KEY", host: "api.stripe.com"})]
+      }
+
+      assert {sandbox, brokered} =
+               Broker.split(
+                 %{
+                   "STRIPE_SECRET_KEY" => "sk",
+                   "DATABASE_URL" => "pg://",
+                   "GITHUB_TOKEN" => "gh"
+                 },
+                 bindings
+               )
+
+      assert sandbox == %{
+               "STRIPE_SECRET_KEY" => "__stripe_secret_key__",
+               "DATABASE_URL" => "pg://",
+               "GITHUB_TOKEN" => "__github_token__"
+             }
+
+      assert brokered == %{"STRIPE_SECRET_KEY" => "sk", "GITHUB_TOKEN" => "gh"}
+    end
+
+    test "one service per binding, in the broker's shape, only the fields of the type" do
+      capture_services()
+
+      bindings = %{
+        "STRIPE_SECRET_KEY" => [
+          bound(%{key: "STRIPE_SECRET_KEY", host: "api.stripe.com"}),
+          bound(%{
+            key: "STRIPE_SECRET_KEY",
+            host: "files.stripe.com",
+            auth_type: "api_key",
+            header: "x-api-key",
+            prefix: "Token "
+          })
+        ],
+        "JIRA_TOKEN" => [
+          bound(%{
+            key: "JIRA_TOKEN",
+            host: "acme.atlassian.net",
+            auth_type: "basic",
+            username: "me@acme.com"
+          })
+        ],
+        "CUSTOM_KEY" => [
+          bound(%{
+            key: "CUSTOM_KEY",
+            host: "api.custom.example",
+            auth_type: "custom",
+            headers: %{"X-Key" => "{{ CUSTOM_KEY }}"}
+          })
+        ]
+      }
+
+      brokered = %{"STRIPE_SECRET_KEY" => "sk", "JIRA_TOKEN" => "jt", "CUSTOM_KEY" => "ck"}
+      assert {:ok, _} = Broker.prepare(@conv, brokered, bindings)
+
+      assert_received {:services, services}
+      by_host = Map.new(services, &{&1.host, &1})
+
+      assert %{
+               name: "stripe-secret-key-api-stripe-com",
+               auth: %{type: "bearer", token: "STRIPE_SECRET_KEY"}
+             } = by_host["api.stripe.com"]
+
+      assert %{
+               auth: %{
+                 type: "api-key",
+                 key: "STRIPE_SECRET_KEY",
+                 header: "x-api-key",
+                 prefix: "Token "
+               }
+             } = by_host["files.stripe.com"]
+
+      assert %{auth: %{type: "basic", username: "JIRA_TOKEN_BASIC_USER", password: "JIRA_TOKEN"}} =
+               by_host["acme.atlassian.net"]
+
+      assert %{auth: %{type: "custom", headers: %{"X-Key" => "{{ CUSTOM_KEY }}"}}} =
+               by_host["api.custom.example"]
+
+      refute Map.has_key?(by_host["api.stripe.com"].auth, :header)
+      assert Enum.all?(services, &Regex.match?(~r/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/, &1.name))
+
+      # The basic username rides beside the password as a credential.
+      assert_received {:credentials, creds}
+      assert creds["JIRA_TOKEN_BASIC_USER"] == "me@acme.com"
+      assert creds["JIRA_TOKEN"] == "jt"
+    end
+
+    test "a GitHub key with its own binding drops the catalog pair" do
+      capture_services()
+      bindings = %{"GITHUB_TOKEN" => [bound(%{key: "GITHUB_TOKEN", host: "api.github.com"})]}
+
+      assert {:ok, _} = Broker.prepare(@conv, %{"GITHUB_TOKEN" => "gh"}, bindings)
+
+      assert_received {:services,
+                       [%{host: "api.github.com", name: "github-token-api-github-com"}]}
+
+      assert_received {:credentials, creds}
+      refute Map.has_key?(creds, "GITHUB_TOKEN_BASIC_USER")
+    end
+
+    test "a GitHub key with no binding keeps the catalog pair" do
+      capture_services()
+      assert {:ok, _} = Broker.prepare(@conv, %{"GITHUB_TOKEN" => "gh"}, %{})
+
+      assert_received {:services,
+                       [
+                         %{name: "github-api"},
+                         %{name: "github-git", auth: %{username: "GITHUB_TOKEN_BASIC_USER"}}
+                       ]}
+
+      assert_received {:credentials, %{"GITHUB_TOKEN_BASIC_USER" => "x-access-token"}}
+    end
+
+    test "service_name/2 is a stable broker slug" do
+      assert Broker.service_name("STRIPE_SECRET_KEY", "api.stripe.com:443/v1/*") ==
+               "stripe-secret-key-api-stripe-com-443-v1"
+
+      assert String.length(Broker.service_name(String.duplicate("K", 80), "a.b.c")) <= 64
     end
   end
 

--- a/apps/fountain/test/fountain/conversations/conversation_server_broker_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_broker_test.exs
@@ -79,7 +79,7 @@ defmodule Fountain.Conversations.ConversationServerBrokerTest do
       _ref = stub_turn_boundary()
 
       reject(Fountain.Broker, :preflight, 0)
-      reject(Fountain.Broker, :prepare, 2)
+      reject(Fountain.Broker, :prepare, 3)
       reject(Fountain.Broker, :ca_pem, 0)
       reject(Fountain.Broker, :release, 1)
       reject(Req, :get, 2)
@@ -104,7 +104,7 @@ defmodule Fountain.Conversations.ConversationServerBrokerTest do
       stub_happy_sprite()
       _ref = stub_turn_boundary()
 
-      reject(Fountain.Broker, :prepare, 2)
+      reject(Fountain.Broker, :prepare, 3)
 
       {pid, _mon, :alive} = start_server(conv, initial_prompt: "hello")
       on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
@@ -133,7 +133,7 @@ defmodule Fountain.Conversations.ConversationServerBrokerTest do
       stub(Fountain.Broker, :preflight, fn -> :ok end)
       stub(Fountain.Broker, :ca_pem, fn -> {:ok, "PEM"} end)
 
-      stub(Fountain.Broker, :prepare, fn conv_id, brokered ->
+      stub(Fountain.Broker, :prepare, fn conv_id, brokered, _bindings ->
         send(test, {:prepared, conv_id, brokered})
         {:ok, @session}
       end)
@@ -216,7 +216,7 @@ defmodule Fountain.Conversations.ConversationServerBrokerTest do
       stub(Fountain.Broker, :preflight, fn -> {:error, {:broker, :unreachable, :econnrefused}} end)
 
       reject(Fountain.Sandbox.Sprites, :create, 2)
-      reject(Fountain.Broker, :prepare, 2)
+      reject(Fountain.Broker, :prepare, 3)
 
       {_pid, _mon, :stopped} = start_server(conv)
 
@@ -253,7 +253,10 @@ defmodule Fountain.Conversations.ConversationServerBrokerTest do
 
       stub_happy_sprite()
       stub(Fountain.Broker, :preflight, fn -> :ok end)
-      stub(Fountain.Broker, :prepare, fn _c, _b -> {:error, {:broker, :session, :timeout}} end)
+
+      stub(Fountain.Broker, :prepare, fn _c, _b, _bindings ->
+        {:error, {:broker, :session, :timeout}}
+      end)
 
       stub(Fountain.Broker, :release, fn conv_id ->
         send(test, {:released, conv_id})
@@ -281,7 +284,7 @@ defmodule Fountain.Conversations.ConversationServerBrokerTest do
       _ref = stub_turn_boundary()
       stub(Fountain.Broker, :preflight, fn -> :ok end)
       stub(Fountain.Broker, :ca_pem, fn -> {:ok, "PEM"} end)
-      stub(Fountain.Broker, :prepare, fn _c, _b -> {:ok, @session} end)
+      stub(Fountain.Broker, :prepare, fn _c, _b, _bindings -> {:ok, @session} end)
 
       stub(Fountain.Broker, :release, fn conv_id ->
         send(test, {:released, conv_id})

--- a/apps/fountain/test/fountain/secret_bindings_test.exs
+++ b/apps/fountain/test/fountain/secret_bindings_test.exs
@@ -1,0 +1,274 @@
+defmodule Fountain.SecretBindingsTest do
+  # Secret bindings (ADR 0019 gate 1b): the context, and the validation that
+  # mirrors Agent Vault 0.39.1's `broker.Validate` so a binding that saves
+  # here is one the broker accepts.
+  use Fountain.DataCase, async: true
+
+  alias Fountain.SecretBindings
+  alias Fountain.SecretBindings.Catalog
+
+  defp bind(user, attrs) do
+    SecretBindings.create_binding(
+      user.id,
+      Map.merge(
+        %{"key" => "STRIPE_SECRET_KEY", "host" => "api.stripe.com", "auth_type" => "bearer"},
+        attrs
+      )
+    )
+  end
+
+  describe "create_binding/3" do
+    test "a bearer binding, tenant-scoped, enabled by default" do
+      user = insert_verified_user()
+      other = insert_verified_user()
+
+      assert {:ok, b} = bind(user, %{})
+      assert b.enabled
+      assert b.user_id == user.id
+      assert [^b] = SecretBindings.list_bindings(user.id)
+      assert SecretBindings.list_bindings(other.id) == []
+      assert SecretBindings.get_binding(b.id, other.id) == nil
+    end
+
+    test "the tenant comes from the argument, never the attrs" do
+      user = insert_verified_user()
+      other = insert_verified_user()
+      assert {:ok, b} = bind(user, %{"user_id" => other.id})
+      assert b.user_id == user.id
+    end
+
+    test "several hosts per key; the same host twice is refused" do
+      user = insert_verified_user()
+      assert {:ok, _} = bind(user, %{"key" => "GITHUB_TOKEN", "host" => "api.github.com"})
+
+      assert {:ok, _} =
+               bind(user, %{
+                 "key" => "GITHUB_TOKEN",
+                 "host" => "github.com",
+                 "auth_type" => "basic",
+                 "username" => "x-access-token"
+               })
+
+      assert {:error, cs} = bind(user, %{"key" => "GITHUB_TOKEN", "host" => "api.github.com"})
+      assert "this secret is already bound to that host" in errors_on(cs).host
+
+      assert %{"GITHUB_TOKEN" => [_, _]} = SecretBindings.enabled_by_key(user.id)
+    end
+
+    test "the key must be UPPER_SNAKE_CASE" do
+      user = insert_verified_user()
+      assert {:error, cs} = bind(user, %{"key" => "stripe-key"})
+      assert errors_on(cs).key != []
+    end
+  end
+
+  describe "host rules (the broker's own)" do
+    setup do
+      {:ok, user: insert_verified_user()}
+    end
+
+    test "accepts a host, a one-level wildcard, a port, and a path glob", %{user: user} do
+      for host <-
+            ~w(api.stripe.com *.github.com api.example.com:8443 slack.com/api/* Api.Example.COM) do
+        assert {:ok, b} = bind(user, %{"host" => host}), host
+        assert b.host == String.downcase(host)
+      end
+    end
+
+    test "rejects what the broker rejects", %{user: user} do
+      for {host, fragment} <- [
+            {"10.0.0.1", "IP address"},
+            {"*", "bare wildcard"},
+            {"*github.com", "*.example.com"},
+            {"*.com", "two domain levels"},
+            {"localhost", "internal"},
+            {"kubernetes.default", "internal"},
+            {"single-label", "domain"},
+            {"bad host.com", "not allowed"},
+            {"api.example.com:99999", "65535"},
+            {"api.example.com/a/**", "**"},
+            {"api.example.com/a b", "not allowed"}
+          ] do
+        assert {:error, cs} = bind(user, %{"host" => host}), host
+
+        assert Enum.any?(errors_on(cs).host, &String.contains?(&1, fragment)),
+               "#{host}: #{inspect(errors_on(cs).host)}"
+      end
+    end
+  end
+
+  describe "auth shapes" do
+    setup do
+      {:ok, user: insert_verified_user()}
+    end
+
+    test "basic needs a username; the other type's fields are cleared", %{user: user} do
+      assert {:error, cs} = bind(user, %{"auth_type" => "basic"})
+      assert "can't be blank" in errors_on(cs).username
+
+      assert {:ok, b} =
+               bind(user, %{
+                 "auth_type" => "basic",
+                 "username" => "x-access-token",
+                 "header" => "stale"
+               })
+
+      assert b.username == "x-access-token"
+      assert b.header == nil
+    end
+
+    test "api_key defaults the header and validates its name", %{user: user} do
+      assert {:ok, b} = bind(user, %{"auth_type" => "api_key"})
+      assert b.header == "Authorization"
+
+      assert {:ok, b} =
+               bind(user, %{
+                 "auth_type" => "api_key",
+                 "host" => "b.example.com",
+                 "header" => "x-api-key",
+                 "prefix" => "Token "
+               })
+
+      assert {b.header, b.prefix} == {"x-api-key", "Token "}
+
+      assert {:error, cs} =
+               bind(user, %{
+                 "auth_type" => "api_key",
+                 "host" => "c.example.com",
+                 "header" => "x api"
+               })
+
+      assert errors_on(cs).header != []
+    end
+
+    test "custom needs headers whose templates reference UPPER_SNAKE keys", %{user: user} do
+      assert {:error, cs} = bind(user, %{"auth_type" => "custom"})
+      assert errors_on(cs).headers != []
+
+      assert {:ok, b} =
+               bind(user, %{
+                 "auth_type" => "custom",
+                 "headers" => %{"X-Api-Key" => "{{ STRIPE_SECRET_KEY }}", "X-Account" => "acct_1"}
+               })
+
+      assert b.headers["X-Api-Key"] == "{{ STRIPE_SECRET_KEY }}"
+
+      assert {:error, cs} =
+               bind(user, %{
+                 "auth_type" => "custom",
+                 "host" => "d.example.com",
+                 "headers" => %{"X-Key" => "{{stripe}}"}
+               })
+
+      assert Enum.any?(errors_on(cs).headers, &String.contains?(&1, "UPPER_SNAKE_CASE"))
+
+      assert {:error, cs} =
+               bind(user, %{
+                 "auth_type" => "custom",
+                 "host" => "e.example.com",
+                 "headers" => %{"bad header" => "x"}
+               })
+
+      assert Enum.any?(errors_on(cs).headers, &String.contains?(&1, "hyphens"))
+    end
+
+    test "an unknown auth type is refused", %{user: user} do
+      assert {:error, cs} = bind(user, %{"auth_type" => "passthrough"})
+      assert errors_on(cs).auth_type != []
+    end
+  end
+
+  describe "update and delete" do
+    test "disabling drops a binding from enabled_by_key; deleting removes it", %{} do
+      user = insert_verified_user()
+      {:ok, b} = bind(user, %{})
+
+      assert {:ok, b} = SecretBindings.update_binding(b, %{"enabled" => false})
+      refute b.enabled
+      assert SecretBindings.enabled_by_key(user.id) == %{}
+
+      assert {:ok, _} = SecretBindings.delete_binding(b)
+      assert SecretBindings.list_bindings(user.id) == []
+    end
+
+    test "every mutation leaves an audit event naming the host, never a value" do
+      user = insert_verified_user()
+      {:ok, b} = bind(user, %{})
+      {:ok, b} = SecretBindings.update_binding(b, %{"host" => "api.stripe.com:443"})
+      {:ok, _} = SecretBindings.delete_binding(b)
+
+      events =
+        user.id
+        |> Fountain.Audit.list_recent_for_user(20)
+        |> Enum.filter(&String.starts_with?(&1.action, "secret_binding."))
+
+      actions = Enum.map(events, & &1.action)
+
+      for a <- ~w(secret_binding.created secret_binding.updated secret_binding.deleted),
+          do: assert(a in actions)
+
+      assert Enum.all?(events, &(&1.metadata["key"] == "STRIPE_SECRET_KEY"))
+    end
+  end
+
+  describe "known_keys/1" do
+    test "the names of the account's secrets, from every environment and vault, never a value" do
+      user = insert_verified_user()
+      other = insert_verified_user()
+      dek = <<1::256>>
+      env = insert_env(user_id: user.id)
+      vault = insert_vault(user_id: user.id)
+      other_env = insert_env(user_id: other.id)
+
+      {:ok, _} =
+        Fountain.Environments.upsert_secret(
+          env,
+          %{"key" => "GITHUB_TOKEN", "value" => "ghp"},
+          dek
+        )
+
+      {:ok, _} =
+        Fountain.Vaults.upsert_secret(
+          vault,
+          %{"key" => "STRIPE_SECRET_KEY", "value" => "sk"},
+          dek
+        )
+
+      {:ok, _} =
+        Fountain.Vaults.upsert_secret(vault, %{"key" => "GITHUB_TOKEN", "value" => "ghp2"}, dek)
+
+      {:ok, _} =
+        Fountain.Environments.upsert_secret(other_env, %{"key" => "OTHERS", "value" => "x"}, dek)
+
+      assert SecretBindings.known_keys(user.id) == ["GITHUB_TOKEN", "STRIPE_SECRET_KEY"]
+    end
+  end
+
+  describe "the catalog" do
+    test "carries the 35 presets, github first among them, three marked unusable" do
+      presets = Catalog.presets()
+      assert length(presets) == 35
+
+      assert %{
+               host: "api.github.com",
+               auth_type: "bearer",
+               suggested_key: "GITHUB_TOKEN",
+               usable: true
+             } = Catalog.get("github")
+
+      assert Enum.map(Enum.reject(presets, & &1.usable), & &1.id) |> Enum.sort() ==
+               ~w(aws-s3 jira twilio)
+
+      assert [%{id: "stripe"}] = Catalog.for_key("STRIPE_SECRET_KEY")
+      assert Enum.all?(presets, &(&1.auth_type in ~w(bearer basic api_key custom passthrough)))
+    end
+
+    test "attrs/2 prefills a binding that the changeset accepts" do
+      user = insert_verified_user()
+      attrs = Catalog.attrs(Catalog.get("stripe"), "STRIPE_SECRET_KEY")
+
+      assert {:ok, %{host: "api.stripe.com", auth_type: "bearer"}} =
+               SecretBindings.create_binding(user.id, attrs)
+    end
+  end
+end

--- a/apps/fountain/test/fountain_web/controllers/secret_binding_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/secret_binding_controller_test.exs
@@ -1,0 +1,116 @@
+defmodule FountainWeb.SecretBindingControllerTest do
+  use FountainWeb.ConnCase, async: false
+
+  alias Fountain.SecretBindings
+
+  setup %{conn: conn} do
+    user = insert_verified_user()
+    {:ok, {_key, raw}} = Fountain.Accounts.create_api_key(user.id, "t")
+
+    previous =
+      for k <- [:broker_url, :broker_token, :broker_proxy_url, :broker_tenants],
+          do: {k, Application.get_env(:fountain, k)}
+
+    on_exit(fn ->
+      for {k, v} <- previous,
+          do:
+            if(is_nil(v),
+              do: Application.delete_env(:fountain, k),
+              else: Application.put_env(:fountain, k, v)
+            )
+    end)
+
+    Application.put_env(:fountain, :broker_url, "http://broker.test:14321")
+    Application.put_env(:fountain, :broker_token, "t")
+    Application.put_env(:fountain, :broker_proxy_url, "http://broker.test:14322")
+    Application.put_env(:fountain, :broker_tenants, [user.id])
+
+    conn =
+      conn
+      |> put_req_header("authorization", "Bearer #{raw}")
+      |> put_req_header("accept", "application/json")
+
+    {:ok, conn: conn, user: user}
+  end
+
+  test "an account the broker is not on for gets 404 on every route", %{conn: conn} do
+    Application.put_env(:fountain, :broker_tenants, [])
+
+    assert %{"error" => "brokerage_not_enabled"} =
+             conn |> get("/api/secret-bindings") |> json_response(404)
+
+    assert %{"error" => "brokerage_not_enabled"} =
+             conn |> get("/api/secret-bindings/presets") |> json_response(404)
+
+    assert %{"error" => "brokerage_not_enabled"} =
+             conn
+             |> post("/api/secret-bindings", %{
+               key: "K",
+               host: "api.example.com",
+               auth_type: "bearer"
+             })
+             |> json_response(404)
+  end
+
+  test "create, list, update, delete", %{conn: conn, user: user} do
+    assert %{
+             "id" => id,
+             "key" => "STRIPE_SECRET_KEY",
+             "host" => "api.stripe.com",
+             "auth_type" => "bearer",
+             "enabled" => true
+           } =
+             conn
+             |> post("/api/secret-bindings", %{
+               key: "STRIPE_SECRET_KEY",
+               host: "api.stripe.com",
+               auth_type: "bearer"
+             })
+             |> json_response(201)
+
+    assert %{"data" => [%{"id" => ^id}]} =
+             conn |> get("/api/secret-bindings") |> json_response(200)
+
+    assert %{"enabled" => false, "host" => "api.stripe.com:443"} =
+             conn
+             |> patch("/api/secret-bindings/#{id}", %{enabled: false, host: "api.stripe.com:443"})
+             |> json_response(200)
+
+    assert SecretBindings.enabled_by_key(user.id) == %{}
+
+    assert conn |> delete("/api/secret-bindings/#{id}") |> response(204)
+    assert %{"data" => []} = conn |> get("/api/secret-bindings") |> json_response(200)
+  end
+
+  test "validation errors are 422", %{conn: conn} do
+    assert %{"errors" => errors} =
+             conn
+             |> post("/api/secret-bindings", %{key: "K", host: "10.0.0.1", auth_type: "basic"})
+             |> json_response(422)
+
+    assert Map.has_key?(errors, "host")
+    assert Map.has_key?(errors, "username")
+  end
+
+  test "another tenant's binding is not found", %{conn: conn} do
+    other = insert_verified_user()
+
+    {:ok, b} =
+      SecretBindings.create_binding(other.id, %{
+        "key" => "K",
+        "host" => "api.example.com",
+        "auth_type" => "bearer"
+      })
+
+    assert conn |> patch("/api/secret-bindings/#{b.id}", %{enabled: false}) |> json_response(404)
+    assert conn |> delete("/api/secret-bindings/#{b.id}") |> json_response(404)
+  end
+
+  test "presets carry the catalog", %{conn: conn} do
+    assert %{"data" => presets} =
+             conn |> get("/api/secret-bindings/presets") |> json_response(200)
+
+    assert length(presets) == 35
+    assert Enum.any?(presets, &(&1["id"] == "github" and &1["suggested_key"] == "GITHUB_TOKEN"))
+  end
+end

--- a/apps/fountain/test/fountain_web/live/secret_bindings_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/secret_bindings_live_test.exs
@@ -1,0 +1,101 @@
+defmodule FountainWeb.SecretBindingsLiveTest do
+  use FountainWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  alias Fountain.SecretBindings
+
+  setup do
+    previous =
+      for k <- [:broker_url, :broker_token, :broker_proxy_url, :broker_tenants],
+          do: {k, Application.get_env(:fountain, k)}
+
+    on_exit(fn ->
+      for {k, v} <- previous,
+          do:
+            if(is_nil(v),
+              do: Application.delete_env(:fountain, k),
+              else: Application.put_env(:fountain, k, v)
+            )
+    end)
+
+    Application.put_env(:fountain, :broker_url, "http://broker.test:14321")
+    Application.put_env(:fountain, :broker_token, "t")
+    Application.put_env(:fountain, :broker_proxy_url, "http://broker.test:14322")
+    :ok
+  end
+
+  test "hidden and redirected for an account the broker is not on for", %{conn: conn} do
+    user = insert_verified_user()
+    Application.put_env(:fountain, :broker_tenants, [])
+    conn = login_user(conn, user)
+
+    refute conn |> get(~p"/account") |> html_response(200) =~ "Credential bindings"
+    assert {:error, {:live_redirect, %{to: "/account"}}} = live(conn, ~p"/account/bindings")
+  end
+
+  test "lists, binds from a preset, toggles and unbinds", %{conn: conn} do
+    user = insert_verified_user()
+    Application.put_env(:fountain, :broker_tenants, [user.id])
+    env = insert_env(user_id: user.id)
+
+    {:ok, _} =
+      Fountain.Environments.upsert_secret(
+        env,
+        %{"key" => "STRIPE_SECRET_KEY", "value" => "sk_live_never_shown_9f3"},
+        <<1::256>>
+      )
+
+    conn = login_user(conn, user)
+
+    assert conn |> get(~p"/account") |> html_response(200) =~ "Credential bindings"
+
+    {:ok, lv, html} = live(conn, ~p"/account/bindings")
+    assert html =~ "broker.test"
+    assert html =~ "No bindings yet"
+    # The stored-but-unbound key is offered, and never a value.
+    assert html =~ "STRIPE_SECRET_KEY"
+    refute html =~ "sk_live_never_shown_9f3"
+
+    # A preset prefills the host and shape; the name stays the one typed.
+    lv |> element("#preset-stripe") |> render_click()
+    html = render(lv)
+    assert html =~ ~s(value="api.stripe.com")
+
+    html =
+      lv
+      |> form("form[phx-submit=save]",
+        binding: %{key: "STRIPE_SECRET_KEY", host: "api.stripe.com", auth_type: "bearer"}
+      )
+      |> render_submit()
+
+    assert html =~ "STRIPE_SECRET_KEY is now attached to api.stripe.com"
+
+    assert [%{key: "STRIPE_SECRET_KEY", host: "api.stripe.com", enabled: true} = b] =
+             SecretBindings.list_bindings(user.id)
+
+    assert html =~ "Authorization: Bearer &lt;secret&gt;"
+
+    lv |> element("#binding-#{b.id} button", "Disable") |> render_click()
+    refute SecretBindings.get_binding(b.id, user.id).enabled
+
+    lv |> element("#binding-#{b.id} button", "Unbind") |> render_click()
+    assert SecretBindings.list_bindings(user.id) == []
+  end
+
+  test "a bad host is refused with the reason", %{conn: conn} do
+    user = insert_verified_user()
+    Application.put_env(:fountain, :broker_tenants, [user.id])
+    {:ok, lv, _} = conn |> login_user(user) |> live(~p"/account/bindings")
+
+    html =
+      lv
+      |> form("form[phx-submit=save]",
+        binding: %{key: "K", host: "10.0.0.1", auth_type: "bearer"}
+      )
+      |> render_submit()
+
+    assert html =~ "IP address"
+    assert SecretBindings.list_bindings(user.id) == []
+  end
+end

--- a/apps/fountain/test/fountain_web/schema_enum_guardrail_test.exs
+++ b/apps/fountain/test/fountain_web/schema_enum_guardrail_test.exs
@@ -123,6 +123,11 @@ defmodule FountainWeb.SchemaEnumGuardrailTest do
       {Fountain.Support.Report, :categories},
     {FountainWeb.Schemas.SupportReportCreateRequest, "screenshot.media_type"} =>
       {Fountain.Images, :valid_media_types},
+    # Secret bindings (ADR 0019 gate 1b): the auth shapes the broker can carry.
+    {FountainWeb.Schemas.SecretBinding, "auth_type"} =>
+      {Fountain.SecretBindings.Binding, :auth_types},
+    {FountainWeb.Schemas.SecretBindingRequest, "auth_type"} =>
+      {Fountain.SecretBindings.Binding, :auth_types},
     {FountainWeb.Schemas.WebhookEndpoint, "status"} => {Fountain.Webhooks.Endpoint, :statuses},
     {FountainWeb.Schemas.WebhookEndpointUpdateRequest, "status"} =>
       {Fountain.Webhooks.Endpoint, :statuses}

--- a/decisions/0019-egress-credential-brokerage.md
+++ b/decisions/0019-egress-credential-brokerage.md
@@ -23,8 +23,8 @@ published at `broker.inevitable.fyi` by the Traefik TCP router of §11), and
 the hosted deployment names **one** tenant, the maintainer's own account
 (home-cloud#131, 2026-08-25). Its done-when was observed on a production
 Sprites conversation the same day — see *Gate 1a* under *Gates*. Everyone else
-is byte-for-byte on the old path. Gates 1b–4 are not built; #1090 is closed
-and each later gate gets its own tracker.
+is byte-for-byte on the old path. Gate 1b (bindings) is built; gates 2–4 are not. #1090 is closed and each
+later gate gets its own tracker.
 
 **Revised 2026-08-25 (gate 1a).** Building it changed three things below,
 each marked in place: §11 is a vault per *conversation*, not per tenant; the
@@ -598,6 +598,18 @@ proxy as passthrough, which is gate 3's shape already visible in the broker's
 request log. The placeholder is **not** a lookup key — the broker
 replaces the auth header wholesale — so the "contract" below reduces to a
 plausibility rule.
+
+**Gate 1b — built 2026-08-25: bindings.** The binding model #1090 named as
+the real cost. `Fountain.SecretBindings`: per tenant, per secret *name*, one
+row per host with the auth shape (bearer, basic with a username, API-key
+header with an optional prefix, custom headers with `{{ KEY }}`), validated
+by the broker's own rules so what saves here is what it accepts. A secret
+with an enabled binding is brokered; one with none is injected in the clear
+as before — the presence of a binding is the `exposure` label §7 asked for,
+without a second field. A console page (`/account/bindings`, shown only to
+brokered tenants) and `/api/secret-bindings`, with the vendor's 35-entry
+catalog as prefills. Gate 1a's hardcoded GitHub pair stays as the default for
+`GITHUB_TOKEN` / `GH_TOKEN` that have no bindings of their own.
 
 **Gate 1 — the placeholder contract.** Naming scheme, versioning, and a test that
 fails when the two sides disagree. Then all environment and vault secrets that

--- a/docs/concepts/secrets.md
+++ b/docs/concepts/secrets.md
@@ -152,6 +152,29 @@ pass them to each caller. The scrubber this replaced ran on the HTTPS clone
 path and not on the SSH one. A redaction that each caller must remember is a
 redaction that a new caller will one day forget.
 
+## Bindings, when the broker is on
+
+<!-- vale STE.IngForms = NO -->
+On a hosted account with the egress credential broker on, a secret can have
+one or more **bindings**. A binding names a host. It also names the way the
+broker attaches the secret to a request for that host. There are four shapes.
+A bearer token. Basic auth with a username of yours. A header with an optional
+prefix. Custom headers with `{{ KEY }}` in them.
+
+A secret with a binding does not enter the sandbox. The agent sees a
+placeholder, `__stripe_secret_key__` for `STRIPE_SECRET_KEY`. The broker puts
+the real value on each request to the bound host. A secret with no binding
+enters the sandbox in the clear. The four hops above describe that path.
+`GITHUB_TOKEN` and `GH_TOKEN` have a built-in binding to GitHub. It applies
+until you make one of your own.
+
+You manage bindings on Account, then Credential bindings, or with
+`GET /api/secret-bindings` and its siblings. The page and the routes are only
+there when the broker is on for the account. A binding is about the name of
+a secret. So it applies to every environment and vault that holds a secret
+of that name.
+<!-- vale STE.IngForms = YES -->
+
 ## Where to go next
 
 - [About environments](environment.md), the baseline half of the merge.

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -10,6 +10,16 @@ server releases.
 
 ---
 
+## [1.3.0] — 2026-08-25
+
+### Added
+
+- Generated types for `/api/secret-bindings` (list, create, update, delete,
+  presets): which hosts a secret is attached to at the egress broker, and how
+  (ADR 0019 gate 1b). Only answers on an account the broker is on for; 404
+  `brokerage_not_enabled` otherwise. No client wrapper yet — use the raw
+  types with `client.request`.
+
 ## [1.2.0] — 2026-08-25
 
 ### Added

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "1.0.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentshit/fountain-sdk",
-      "version": "1.0.0",
+      "version": "1.3.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Run a coding agent on a real computer, with your repos and your credentials, in one call.",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -41,6 +41,27 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/secret-bindings": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List secret bindings
+         * @description Every binding on the account: a secret name, the host it is attached to at the egress broker, and the auth shape. A secret with at least one enabled binding reaches the sandbox as a placeholder; one with none reaches it in the clear. Only for accounts the broker is on for (ADR 0019); 404 otherwise.
+         */
+        get: operations["FountainWeb.SecretBindingController.index"];
+        put?: never;
+        /** Bind a secret to a host */
+        post: operations["FountainWeb.SecretBindingController.create"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/sandboxes": {
         parameters: {
             query?: never;
@@ -136,6 +157,24 @@ export interface paths {
         options?: never;
         head?: never;
         patch?: never;
+        trace?: never;
+    };
+    "/api/secret-bindings/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Unbind a secret from a host */
+        delete: operations["FountainWeb.SecretBindingController.delete"];
+        options?: never;
+        head?: never;
+        /** Change a binding */
+        patch: operations["FountainWeb.SecretBindingController.update"];
         trace?: never;
     };
     "/api/environments/{id}": {
@@ -327,6 +366,26 @@ export interface paths {
          *     Errors before the stream opens are ordinary JSON responses (404 for an unknown agent, 402 with no credit); once it is open, failure arrives as `RUN_ERROR`.
          */
         post: operations["FountainWeb.AguiController.run"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/secret-bindings/presets": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List binding presets
+         * @description The broker's service catalog: known hosts with their auth shape and the secret name each usually goes by. Suggestions the console prefills from; a binding is still yours to save.
+         */
+        get: operations["FountainWeb.SecretBindingController.presets"];
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -2721,6 +2780,25 @@ export interface components {
             prompt: string;
         };
         /**
+         * SecretBindingPreset
+         * @description A known service from the broker's catalog, to prefill a binding from.
+         */
+        SecretBindingPreset: {
+            auth_type: string;
+            description?: string | null;
+            header?: string | null;
+            headers?: {
+                [key: string]: string;
+            };
+            host: string;
+            id: string;
+            name: string;
+            prefix?: string | null;
+            suggested_key?: string | null;
+            /** @description False for the few presets a binding cannot express on its own (request signing, a username of yours). */
+            usable: boolean;
+        };
+        /**
          * AdminSandbox
          * @description A live sandbox, cross-tenant. Metadata only — never contents.
          */
@@ -2739,6 +2817,10 @@ export interface components {
             user_email?: string | null;
             /** Format: uuid */
             user_id?: string | null;
+        };
+        /** SecretBindingListResponse */
+        SecretBindingListResponse: {
+            data: components["schemas"]["SecretBinding"][];
         };
         /**
          * ChangesetError
@@ -3153,6 +3235,10 @@ export interface components {
                 [key: string]: unknown;
             };
         };
+        /** SecretBindingPresetListResponse */
+        SecretBindingPresetListResponse: {
+            data: components["schemas"]["SecretBindingPreset"][];
+        };
         /** AdminSandboxListResponse */
         AdminSandboxListResponse: {
             data: components["schemas"]["AdminSandbox"][];
@@ -3300,6 +3386,27 @@ export interface components {
                 /** Format: uri */
                 url: string;
             };
+        };
+        /**
+         * SecretBindingRequest
+         * @example {
+         *       "auth_type": "bearer",
+         *       "host": "api.stripe.com",
+         *       "key": "STRIPE_SECRET_KEY"
+         *     }
+         */
+        SecretBindingRequest: {
+            /** @enum {string} */
+            auth_type: "bearer" | "basic" | "api_key" | "custom";
+            enabled?: boolean;
+            header?: string | null;
+            headers?: {
+                [key: string]: string;
+            };
+            host: string;
+            key: string;
+            prefix?: string | null;
+            username?: string | null;
         };
         /** VaultRequest */
         VaultRequest: {
@@ -3840,6 +3947,35 @@ export interface components {
         ApplyRequest: {
             resources: components["schemas"]["ManifestResource"][];
         };
+        /**
+         * SecretBinding
+         * @description Which host a secret is attached to at the egress broker, and how (ADR 0019). Keyed by the secret's name: it applies wherever an environment or vault holds a secret of that name. A secret with at least one enabled binding reaches the sandbox as a placeholder (`__key__`); one with none reaches it in the clear.
+         */
+        SecretBinding: {
+            /** @enum {string} */
+            auth_type: "bearer" | "basic" | "api_key" | "custom";
+            /** Format: date-time */
+            created_at: string;
+            enabled: boolean;
+            /** @description api_key only: the header the value is sent in. Defaults to Authorization. */
+            header?: string | null;
+            /** @description custom only: header name to template, `{{ KEY }}` is replaced by the secret. */
+            headers: {
+                [key: string]: string;
+            };
+            /** @description Host pattern: `api.example.com`, a one-level wildcard `*.example.com`, optionally `:port` and a `/path/*` glob. */
+            host: string;
+            /** Format: uuid */
+            id: string;
+            /** @description The secret's name, UPPER_SNAKE_CASE. */
+            key: string;
+            /** @description api_key only: text placed before the value, such as `Token `. */
+            prefix?: string | null;
+            /** Format: date-time */
+            updated_at: string;
+            /** @description basic only: the username; the secret is the password. */
+            username?: string | null;
+        };
         /** TeamScheduleUpdateRequest */
         TeamScheduleUpdateRequest: {
             /** @example 0 9 * * 1-5 */
@@ -3910,6 +4046,96 @@ export interface operations {
             };
             /** @description Not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    "FountainWeb.SecretBindingController.index": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Bindings */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SecretBindingListResponse"];
+                };
+            };
+            /** @description Missing or invalid key */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Brokerage is not enabled for this account */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    "FountainWeb.SecretBindingController.create": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Binding */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SecretBindingRequest"];
+            };
+        };
+        responses: {
+            /** @description Binding */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SecretBinding"];
+                };
+            };
+            /** @description Missing or invalid key */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Brokerage is not enabled for this account */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Validation error */
+            422: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -4052,6 +4278,100 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HealthResponse"];
+                };
+            };
+        };
+    };
+    "FountainWeb.SecretBindingController.delete": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Binding id */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Deleted */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Missing or invalid key */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No such binding, or brokerage is not enabled */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    "FountainWeb.SecretBindingController.update": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Binding id */
+                id: string;
+            };
+            cookie?: never;
+        };
+        /** @description Binding */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SecretBindingRequest"];
+            };
+        };
+        responses: {
+            /** @description Binding */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SecretBinding"];
+                };
+            };
+            /** @description Missing or invalid key */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No such binding, or brokerage is not enabled */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Validation error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
                 };
             };
         };
@@ -4632,6 +4952,44 @@ export interface operations {
                 };
             };
             /** @description No such agent */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    "FountainWeb.SecretBindingController.presets": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Presets */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SecretBindingPresetListResponse"];
+                };
+            };
+            /** @description Missing or invalid key */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Brokerage is not enabled for this account */
             404: {
                 headers: {
                     [name: string]: unknown;

--- a/sdk/typescript/src/http.ts
+++ b/sdk/typescript/src/http.ts
@@ -19,7 +19,7 @@ export interface RequestOptions {
  * this string is already what Fountain's request logs are keyed on. The
  * version half is asserted against `package.json` by a test.
  */
-export const USER_AGENT = "fountain-sdk-js/1.2.0";
+export const USER_AGENT = "fountain-sdk-js/1.3.0";
 
 /**
  * The thin layer everything else is built on: one bearer token, JSON in and


### PR DESCRIPTION
Gate 1b of [ADR 0019](decisions/0019-egress-credential-brokerage.md): the binding model #1090 called the real cost, and the console for it. Follows #1136 (gate 1a) and the live flip (home-cloud#131).

## What a user gets

On an account the broker is on for, a new page **Account → Credential bindings** (nav link and page are hidden/redirected for everyone else): the secrets the account holds anywhere (names only, never a value), the bindings on each, and a form to bind a secret name to a host with one of four shapes — bearer token, basic auth (secret is the password, username of theirs), API-key header with optional prefix, custom headers with `{{ KEY }}`. 35 presets from the vendor's catalog prefill host and shape from a secret's name (`STRIPE_SECRET_KEY` → `api.stripe.com`, bearer). Enable/disable/unbind per host.

**A secret with an enabled binding is brokered** (placeholder in the sandbox, one broker service per binding); **one with none is injected in the clear as before.** That is §7's `exposure` label without a second field. `GITHUB_TOKEN` / `GH_TOKEN` keep gate 1a's built-in GitHub pair until the user binds them.

## What's in it

- `Fountain.SecretBindings` + `secret_bindings` table (per tenant, per secret *name*, unique per host; several hosts per key). Validation mirrors Agent Vault 0.39.1's `broker.Validate` (host/wildcard/port/path rules, no IPs or internal names, per-type auth fields only — the broker 400s a stale field) so what saves here is what it accepts.
- `Fountain.Broker`: `split/2` and `prepare/3` take the bindings; services built per binding, basic usernames ride as `<KEY>_BASIC_USER` credentials, stable slugs per key+host.
- `/api/secret-bindings` (index/create/update/delete/presets), full scope, 404 `brokerage_not_enabled` off-ratchet; OpenAPI schemas; SDK types regenerated.
- Audit: `secret_binding.created/updated/deleted` with key, host and shape (never a value); guardrail entries.
- Docs: `docs/concepts/secrets.md` gets a Bindings section (STE-clean); CHANGELOG; ADR 0019 gate 1b paragraph.

## Not in it

`passthrough` bindings (that's a network rule → gate 2), substitutions (placeholder-in-URL rewriting), per-row bindings on `secrets`/`vault_secrets` (by design: brokering runs on the merged map where only the name survives).

## Gates

158 tests across the new and touched files; compile `-Werror`, credo, dialyzer, format (from `apps/fountain`), docs-style, vale 0/0, `okf validate`, SDK typecheck/test/build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)