### PR TITLE
feat(broker): limited environments enforced at the broker (ADR 0019 gate 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,12 @@ upgrade, is in
 
 ### Added
 
+- **`limited` environments at the broker, ADR 0019 gate 2.** On a brokered
+  account a `limited` environment is no longer refused: the sandbox's policy
+  stays the broker-only floor, and the broker enforces `allowed_hosts`
+  (unmatched-host policy `deny`, one passthrough service per listed host) so
+  an unlisted host is refused with a 403 that names it. `unrestricted` is
+  passthrough at the broker, as before.
 - **Secret bindings, ADR 0019 gate 1b.** On an account the broker is on for,
   a secret can be bound to the hosts it is a credential for and the way it
   is sent (bearer, basic, API-key header, custom headers). A bound secret

--- a/apps/fountain/lib/fountain/broker.ex
+++ b/apps/fountain/lib/fountain/broker.ex
@@ -23,6 +23,17 @@ defmodule Fountain.Broker do
     HTTPS, basic `x-access-token`) — gate 1a's default, kept so a tenant who
     never opens the bindings page keeps working.
   * Every other secret reaches the sandbox exactly as before.
+
+  ## The network policy (gate 2)
+
+  The sandbox's own policy is always the floor, `allow: [broker]`. What the
+  environment's `networking_type` says is enforced **at the broker**:
+  `unrestricted` sets the vault's unmatched-host policy to `passthrough`, so
+  the agent may reach any host but only ever with the credentials it was
+  granted; `limited` sets it to `deny` and turns `allowed_hosts` into
+  passthrough services, so an unlisted host is refused with a 403 that names
+  the host. Tenant intent is preserved and gains per-host visibility in the
+  broker's request log.
   * Only tenants listed in `BROKER_TENANTS`: the operator ratchet of §9.
   * Only `unrestricted` environments. Translating `limited`'s `allowed_hosts`
     into broker rules is gate 2; a brokered `limited` environment is refused
@@ -341,19 +352,52 @@ defmodule Fountain.Broker do
   provision and reattach, so an edited secret reaches the broker on the next
   wake, the same way the `.env` file is refreshed.
   """
-  @spec prepare(String.t(), %{String.t() => String.t()}, bindings()) ::
+  @typedoc "What the environment's `networking_type` asks for: reach anything, or only these hosts."
+  @type network :: :unrestricted | {:limited, [String.t()]}
+
+  @spec prepare(String.t(), %{String.t() => String.t()}, bindings(), keyword()) ::
           {:ok, session()} | {:error, term()}
-  def prepare(conversation_id, brokered, bindings \\ %{})
+  def prepare(conversation_id, brokered, bindings \\ %{}, opts \\ [])
       when is_binary(conversation_id) and is_map(brokered) and is_map(bindings) do
     vault = vault_name(conversation_id)
+    network = Keyword.get(opts, :network, :unrestricted)
+    credentialed = services_for(brokered, bindings)
 
     with :ok <- ensure_vault(vault),
-         :ok <- set_policy(vault, "passthrough"),
+         :ok <- set_policy(vault, policy_for(network)),
          :ok <- put_credentials(vault, credentials_for(brokered, bindings)),
-         :ok <- put_services(vault, services_for(brokered, bindings)) do
+         :ok <- put_services(vault, credentialed ++ allow_services(network, credentialed)) do
       mint_session(vault, conversation_id)
     end
   end
+
+  defp policy_for(:unrestricted), do: "passthrough"
+  defp policy_for({:limited, _hosts}), do: "deny"
+
+  # `limited`: one passthrough service per allowed host, so the deny policy
+  # has something to match. A host that already carries a credential service
+  # is skipped — the credentialed entry is the one that must win there.
+  defp allow_services(:unrestricted, _credentialed), do: []
+
+  defp allow_services({:limited, hosts}, credentialed) do
+    taken = MapSet.new(credentialed, & &1.host)
+
+    hosts
+    |> Enum.map(&(&1 |> to_string() |> String.trim() |> String.downcase()))
+    |> Enum.reject(&(&1 == "" or MapSet.member?(taken, &1)))
+    |> Enum.uniq()
+    |> Enum.map(fn host ->
+      %{name: service_name("ALLOW", host), host: host, auth: %{type: "passthrough"}}
+    end)
+  end
+
+  @doc "The network shape an environment asks for, as `prepare/4` takes it."
+  @spec network_for(map() | nil) :: network()
+  def network_for(%{networking_type: "limited", networking_config: config}) do
+    {:limited, (config && (config["allowed_hosts"] || config[:allowed_hosts])) || []}
+  end
+
+  def network_for(_), do: :unrestricted
 
   @doc "Delete the conversation's vault: its credentials, services and sessions go with it."
   @spec release(String.t()) :: :ok | {:error, term()}

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -365,6 +365,8 @@ defmodule Fountain.Conversations.ConversationServer do
       # The tenant's enabled bindings by key (gate 1b), loaded once per
       # provision; what the broker's services are built from.
       broker_bindings: %{},
+      # The environment's networking shape, enforced at the broker (gate 2).
+      broker_network: :unrestricted,
       broker: nil,
       current_command: nil,
       current_command_ref: nil,
@@ -587,7 +589,8 @@ defmodule Fountain.Conversations.ConversationServer do
               tenant_key: dek,
               inference_credentials: inference_creds,
               brokered: brokered,
-              broker_bindings: bindings
+              broker_bindings: bindings,
+              broker_network: Fountain.Broker.network_for(env)
           }
 
         dispatch_provision(state, conv, sandbox, agent, env, vault, secrets)
@@ -1398,7 +1401,9 @@ defmodule Fountain.Conversations.ConversationServer do
         keys: state.brokered |> Map.keys() |> Enum.sort()
       })
 
-      case Fountain.Broker.prepare(state.conversation_id, state.brokered, state.broker_bindings) do
+      case Fountain.Broker.prepare(state.conversation_id, state.brokered, state.broker_bindings,
+             network: state.broker_network
+           ) do
         {:ok, session} ->
           publish_stage(state.conversation_id, "broker", "done", %{
             vault: session.vault,
@@ -1427,7 +1432,9 @@ defmodule Fountain.Conversations.ConversationServer do
 
   defp broker_refresh(%{broker: session} = state) do
     if Fountain.Broker.expiring?(session) do
-      case Fountain.Broker.prepare(state.conversation_id, state.brokered, state.broker_bindings) do
+      case Fountain.Broker.prepare(state.conversation_id, state.brokered, state.broker_bindings,
+             network: state.broker_network
+           ) do
         {:ok, fresh} ->
           keys = Fountain.Broker.env_keys()
           kept = Enum.reject(state.sprite_env, fn {k, _} -> to_string(k) in keys end)

--- a/apps/fountain/lib/fountain/conversations/provisioning.ex
+++ b/apps/fountain/lib/fountain/conversations/provisioning.ex
@@ -318,23 +318,19 @@ defmodule Fountain.Conversations.Provisioning do
   Refuse a brokered pairing that cannot be enforced, before a sandbox exists
   (ADR 0019 gate 1a). Same shape and reason as `check_network_policy_support/3`.
 
-  Three refusals, each by name: a `limited` environment (its `allowed_hosts`
-  become broker rules in gate 2, and a floor that ignored them would be a
-  policy the author did not write); a provider with no `:network_policy`,
-  unless `BROKER_ALLOW_UNENFORCED` says a development box may run advisory;
-  and a broker that does not answer `/health`, so an outage is reported as
-  one rather than as the install failure it would otherwise wear (§6).
+  Two refusals, each by name: a provider with no `:network_policy`, unless
+  `BROKER_ALLOW_UNENFORCED` says a development box may run advisory; and a
+  broker that does not answer `/health`, so an outage is reported as one
+  rather than as the install failure it would otherwise wear (§6). A
+  `limited` environment is not refused since gate 2: its `allowed_hosts` are
+  enforced at the broker (`Fountain.Broker.network_for/1`).
   """
   @spec check_broker_support(boolean(), atom(), Environment.t() | nil, String.t()) ::
           :ok | {:error, {:broker, atom()} | {:broker, :unreachable, term()}}
   def check_broker_support(false, _provider, _env, _conv_id), do: :ok
 
-  def check_broker_support(true, provider, env, conv_id) do
+  def check_broker_support(true, provider, _env, conv_id) do
     cond do
-      match?(%Environment{networking_type: "limited"}, env) ->
-        publish_stage(conv_id, "broker", "failed", %{reason: "limited_environment_unsupported"})
-        {:error, {:broker, :limited_environment_unsupported}}
-
       not Sandbox.supports?(provider, :network_policy) and not Fountain.Broker.allow_unenforced?() ->
         publish_stage(conv_id, "broker", "failed", %{
           provider: to_string(provider),

--- a/apps/fountain/test/fountain/broker_test.exs
+++ b/apps/fountain/test/fountain/broker_test.exs
@@ -410,6 +410,78 @@ defmodule Fountain.BrokerTest do
       assert_received {:credentials, %{"GITHUB_TOKEN_BASIC_USER" => "x-access-token"}}
     end
 
+    test "limited: deny at the broker, one passthrough service per allowed host" do
+      test = self()
+
+      stub(Req, :post, fn _r, opts ->
+        if opts[:url] == "/v1/sessions",
+          do: {:ok, %{status: 201, body: %{"token" => "t"}}},
+          else: {:ok, %{status: 200, body: %{}}}
+      end)
+
+      stub(Req, :patch, fn _r, opts ->
+        send(test, {:policy, opts[:json].unmatched_host_policy})
+        {:ok, %{status: 200, body: %{}}}
+      end)
+
+      stub(Req, :put, fn _r, opts ->
+        send(test, {:services, opts[:json].services})
+        {:ok, %{status: 200, body: %{}}}
+      end)
+
+      bindings = %{
+        "STRIPE_SECRET_KEY" => [bound(%{key: "STRIPE_SECRET_KEY", host: "api.stripe.com"})]
+      }
+
+      hosts = ["registry.npmjs.org", "API.Stripe.com", "*.github.com", " ", "registry.npmjs.org"]
+
+      assert {:ok, _} =
+               Broker.prepare(@conv, %{"STRIPE_SECRET_KEY" => "sk"}, bindings,
+                 network: {:limited, hosts}
+               )
+
+      assert_received {:policy, "deny"}
+      assert_received {:services, services}
+
+      # The credentialed host keeps its credential service; the rest pass through, once each.
+      assert [%{host: "api.stripe.com", auth: %{type: "bearer"}} | allow] = services
+
+      assert Enum.map(allow, &{&1.host, &1.auth}) == [
+               {"registry.npmjs.org", %{type: "passthrough"}},
+               {"*.github.com", %{type: "passthrough"}}
+             ]
+
+      assert Enum.all?(allow, &String.starts_with?(&1.name, "allow-"))
+    end
+
+    test "unrestricted: passthrough at the broker, no allow services" do
+      capture_services()
+
+      stub(Req, :patch, fn _r, opts ->
+        send(self(), {:policy, opts[:json].unmatched_host_policy})
+        {:ok, %{status: 200, body: %{}}}
+      end)
+
+      assert {:ok, _} = Broker.prepare(@conv, %{}, %{}, network: :unrestricted)
+      assert_received {:policy, "passthrough"}
+      assert_received {:services, []}
+    end
+
+    test "network_for/1 reads the environment's shape" do
+      assert Broker.network_for(%{
+               networking_type: "limited",
+               networking_config: %{"allowed_hosts" => ["a.example.com"]}
+             }) == {:limited, ["a.example.com"]}
+
+      assert Broker.network_for(%{networking_type: "limited", networking_config: %{}}) ==
+               {:limited, []}
+
+      assert Broker.network_for(%{networking_type: "unrestricted", networking_config: %{}}) ==
+               :unrestricted
+
+      assert Broker.network_for(nil) == :unrestricted
+    end
+
     test "service_name/2 is a stable broker slug" do
       assert Broker.service_name("STRIPE_SECRET_KEY", "api.stripe.com:443/v1/*") ==
                "stripe-secret-key-api-stripe-com-443-v1"

--- a/apps/fountain/test/fountain/conversations/conversation_server_broker_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_broker_test.exs
@@ -79,7 +79,7 @@ defmodule Fountain.Conversations.ConversationServerBrokerTest do
       _ref = stub_turn_boundary()
 
       reject(Fountain.Broker, :preflight, 0)
-      reject(Fountain.Broker, :prepare, 3)
+      reject(Fountain.Broker, :prepare, 4)
       reject(Fountain.Broker, :ca_pem, 0)
       reject(Fountain.Broker, :release, 1)
       reject(Req, :get, 2)
@@ -104,7 +104,7 @@ defmodule Fountain.Conversations.ConversationServerBrokerTest do
       stub_happy_sprite()
       _ref = stub_turn_boundary()
 
-      reject(Fountain.Broker, :prepare, 3)
+      reject(Fountain.Broker, :prepare, 4)
 
       {pid, _mon, :alive} = start_server(conv, initial_prompt: "hello")
       on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
@@ -133,7 +133,7 @@ defmodule Fountain.Conversations.ConversationServerBrokerTest do
       stub(Fountain.Broker, :preflight, fn -> :ok end)
       stub(Fountain.Broker, :ca_pem, fn -> {:ok, "PEM"} end)
 
-      stub(Fountain.Broker, :prepare, fn conv_id, brokered, _bindings ->
+      stub(Fountain.Broker, :prepare, fn conv_id, brokered, _bindings, _opts ->
         send(test, {:prepared, conv_id, brokered})
         {:ok, @session}
       end)
@@ -216,7 +216,7 @@ defmodule Fountain.Conversations.ConversationServerBrokerTest do
       stub(Fountain.Broker, :preflight, fn -> {:error, {:broker, :unreachable, :econnrefused}} end)
 
       reject(Fountain.Sandbox.Sprites, :create, 2)
-      reject(Fountain.Broker, :prepare, 3)
+      reject(Fountain.Broker, :prepare, 4)
 
       {_pid, _mon, :stopped} = start_server(conv)
 
@@ -227,21 +227,44 @@ defmodule Fountain.Conversations.ConversationServerBrokerTest do
       assert Conversations._unsafe_get_conversation!(conv.id).status == "failed"
     end
 
-    test "a limited environment is refused before any sandbox is created", %{
+    test "a limited environment is brokered with its allowlist enforced at the broker", %{
       user: user
     } do
-      env = insert_env(user_id: user.id, networking_type: "limited")
+      env =
+        insert_env(
+          user_id: user.id,
+          networking_type: "limited",
+          networking_config: %{"allowed_hosts" => ["registry.npmjs.org", "api.anthropic.com"]}
+        )
+
       agent = insert_agent(user_id: user.id, runtime: "claude", environment_id: env.id)
       conv = insert_conversation(user_id: user.id, agent: agent)
+      test = self()
 
       stub_happy_sprite()
-      reject(Fountain.Broker, :preflight, 0)
-      reject(Fountain.Sandbox.Sprites, :create, 2)
+      _ref = stub_turn_boundary()
+      stub(Fountain.Broker, :preflight, fn -> :ok end)
+      stub(Fountain.Broker, :ca_pem, fn -> {:ok, "PEM"} end)
 
-      {_pid, _mon, :stopped} = start_server(conv)
+      stub(Fountain.Broker, :prepare, fn _c, _b, _bindings, opts ->
+        send(test, {:prepared_with, opts[:network]})
+        {:ok, @session}
+      end)
 
-      assert [event] = stage_events(conv.id, "broker")
-      assert %{"reason" => "limited_environment_unsupported"} = Jason.decode!(event.data)
+      Mimic.stub(Fountain.Sandbox.Sprites, :apply_network_policy, fn _h, policy ->
+        send(test, {:policy, policy})
+        :ok
+      end)
+
+      {pid, _mon, :alive} = start_server(conv, initial_prompt: "hello")
+      on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+
+      assert_receive {:prepared_with, {:limited, ["registry.npmjs.org", "api.anthropic.com"]}},
+                     2_000
+
+      # The sandbox's own policy is still the floor, whatever the environment listed.
+      assert_receive {:policy, %Fountain.Sandbox.NetworkPolicy{allow: ["broker.test"]}}, 2_000
+      assert_receive {:spawned, _, _, _}, 2_000
     end
 
     test "a failed session mint tears the sandbox down and releases the vault", %{
@@ -254,7 +277,7 @@ defmodule Fountain.Conversations.ConversationServerBrokerTest do
       stub_happy_sprite()
       stub(Fountain.Broker, :preflight, fn -> :ok end)
 
-      stub(Fountain.Broker, :prepare, fn _c, _b, _bindings ->
+      stub(Fountain.Broker, :prepare, fn _c, _b, _bindings, _opts ->
         {:error, {:broker, :session, :timeout}}
       end)
 
@@ -284,7 +307,7 @@ defmodule Fountain.Conversations.ConversationServerBrokerTest do
       _ref = stub_turn_boundary()
       stub(Fountain.Broker, :preflight, fn -> :ok end)
       stub(Fountain.Broker, :ca_pem, fn -> {:ok, "PEM"} end)
-      stub(Fountain.Broker, :prepare, fn _c, _b, _bindings -> {:ok, @session} end)
+      stub(Fountain.Broker, :prepare, fn _c, _b, _bindings, _opts -> {:ok, @session} end)
 
       stub(Fountain.Broker, :release, fn conv_id ->
         send(test, {:released, conv_id})

--- a/apps/fountain/test/fountain/conversations/provisioning_test.exs
+++ b/apps/fountain/test/fountain/conversations/provisioning_test.exs
@@ -86,18 +86,13 @@ defmodule Fountain.Conversations.ProvisioningTest do
       assert stage_events(conv.id, "broker") == []
     end
 
-    test "a limited environment is refused by name: its allowlist is gate 2" do
+    test "a limited environment passes: its allowlist is enforced at the broker (gate 2)" do
       env = insert_env(%{"networking_type" => "limited"})
       conv = insert_conversation()
 
-      reject(Fountain.Broker, :preflight, 0)
-
-      assert {:error, {:broker, :limited_environment_unsupported}} =
-               Provisioning.check_broker_support(true, :sprites, env, conv.id)
-
-      assert [event] = stage_events(conv.id, "broker")
-      assert event.state == "failed"
-      assert %{"reason" => "limited_environment_unsupported"} = Jason.decode!(event.data)
+      expect(Fountain.Broker, :preflight, fn -> :ok end)
+      assert :ok = Provisioning.check_broker_support(true, :sprites, env, conv.id)
+      assert stage_events(conv.id, "broker") == []
     end
 
     test "a backend without :network_policy is refused: placeholders without a floor are half a control" do

--- a/decisions/0019-egress-credential-brokerage.md
+++ b/decisions/0019-egress-credential-brokerage.md
@@ -23,7 +23,8 @@ published at `broker.inevitable.fyi` by the Traefik TCP router of §11), and
 the hosted deployment names **one** tenant, the maintainer's own account
 (home-cloud#131, 2026-08-25). Its done-when was observed on a production
 Sprites conversation the same day — see *Gate 1a* under *Gates*. Everyone else
-is byte-for-byte on the old path. Gate 1b (bindings) is built; gates 2–4 are not. #1090 is closed and each
+is byte-for-byte on the old path. Gates 1b (bindings) and 2 (`limited` at the broker) are built; 3 and 4 are
+not. #1090 is closed and each
 later gate gets its own tracker.
 
 **Revised 2026-08-25 (gate 1a).** Building it changed three things below,
@@ -623,10 +624,15 @@ the proxy URL shape above, the CA into the trust store rather than into six
 variables, and a broker preflight at provision time so an unreachable broker
 says so.
 
-**Gate 2 — `networking_type` migration.** `allowed_hosts` translated into broker
-service rules; both modes enforced at the broker; the floor made
-non-negotiable. Cheap today precisely because zero environments use `limited`;
-this gate gets harder the longer it waits.
+**Gate 2 — built 2026-08-25.** `allowed_hosts` translated into broker
+passthrough services under `unmatched_host_policy=deny`; `unrestricted` is
+`passthrough`; the sandbox's own policy is the `allow: [broker]` floor in both
+cases, and the preflight no longer refuses a `limited` environment on a
+brokered tenant. A host that carries a credential binding keeps its credential
+service rather than gaining a passthrough twin. What §3 asked for, and what
+gate 0 warned about: under `deny` the tenant lists what provisioning and the
+runtime need (`registry.npmjs.org`, the model host), exactly as a Sprites
+`limited` environment already required.
 
 **Gate 3 — inference credentials through the same path.** This absorbs 0016 gate
 3 and closes its base-URL question: brokering inference through the proxy needs no

--- a/docs/concepts/environment.md
+++ b/docs/concepts/environment.md
@@ -83,6 +83,13 @@ out. That is deliberate, and it is not a defect. An empty allowlist that
 quietly meant "allow everything" would be the worst default for a policy whose
 whole purpose is restriction.
 
+On a hosted account with the egress credential broker on, the sandbox can
+reach only the broker. The broker then applies your policy. With
+`unrestricted`, a request goes through to any host, with only the credentials
+you bound. With `limited`, the broker refuses a request to a host that is not
+in `allowed_hosts`. The refusal is a 403 that names the host. The broker's
+request log shows each decision.
+
 Not every backend can hold egress. Sprites, E2B and Daytona can. A
 [self-hosted runner](../integrations/runners.md) cannot. The agent selects the
 backend, and the environment sets the policy. Fountain therefore compares the


### PR DESCRIPTION
Gate 2 of [ADR 0019](decisions/0019-egress-credential-brokerage.md): `networking_type` enforced at the broker for brokered tenants.

- The sandbox's own policy is unchanged: the `allow: [broker]` floor.
- `unrestricted` → the conversation's vault gets `unmatched_host_policy=passthrough` (as gate 1a already did).
- `limited` → `deny`, plus one passthrough service per `allowed_hosts` entry, so an unlisted host is refused at the broker with a 403 that names it and lands in the request log. A host that carries a credential binding keeps its credential service (no passthrough twin).
- The gate-1a preflight refusal of `limited` on a brokered tenant is removed; `backend_lacks_network_policy` and `broker_unreachable` stay.
- `Fountain.Broker.prepare/4` takes `network:`; `network_for/1` reads it off the environment; ConversationServer carries it in state.

As on a Sprites `limited` environment today, the tenant lists what provisioning and the runtime need (`registry.npmjs.org`, the model host); the docs say so.

Tests: broker (limited/unrestricted/network_for), provisioning preflight, ConversationServer (limited env → `{:limited, hosts}` reaches the broker while the sandbox floor stays `[broker]`). compile `-Werror`, credo, dialyzer, format, vale 0/0, docs-style, `okf validate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)