### PR TITLE
feat(broker): inference credentials through the broker; substitution as the default shape (ADR 0019 gate 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,18 @@ upgrade, is in
 
 ### Added
 
+- **Inference credentials through the broker, ADR 0019 gate 3.** On a
+  brokered account the runtime's credential (`CLAUDE_CODE_OAUTH_TOKEN` or
+  `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`) is a vendor-shaped
+  placeholder in the sandbox and the broker substitutes the value on
+  requests to the provider's host. The OAuth-refused fallback re-prepares
+  the broker instead of injecting a plaintext key.
+- **`substitute`, the default binding shape.** A binding now needs only a
+  host: the broker replaces the secret's placeholder wherever it appears in
+  a request (header, query, path, body), so the agent sends the shape the
+  API wants. Every binding shape carries the substitution; the header
+  shapes remain for an API the agent cannot address itself, and basic auth
+  for a value the client encodes.
 - **`limited` environments at the broker, ADR 0019 gate 2.** On a brokered
   account a `limited` environment is no longer refused: the sandbox's policy
   stays the broker-only floor, and the broker enforces `allowed_hosts`

--- a/apps/fountain/lib/fountain/broker.ex
+++ b/apps/fountain/lib/fountain/broker.ex
@@ -22,9 +22,24 @@ defmodule Fountain.Broker do
     built-in catalog to `api.github.com` (bearer) and `github.com` (git over
     HTTPS, basic `x-access-token`) — gate 1a's default, kept so a tenant who
     never opens the bindings page keeps working.
+  * The runtime's **inference credential** (gate 3): `CLAUDE_CODE_OAUTH_TOKEN`
+    or `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`. The runtime
+    gets a vendor-shaped placeholder and the broker substitutes the value on
+    requests to the provider's host. A tenant secret of the same name with a
+    binding of its own wins, as it wins in the environment.
   * Every other secret reaches the sandbox exactly as before.
 
-  ## The network policy (gate 2)
+  ## How a value is attached
+
+  Every service carries a **substitution** for its key: the broker replaces
+  the placeholder wherever it appears in a request to that host — header,
+  query, path, body — so the agent sends the shape the API wants and nothing
+  has to be told how. A binding's explicit shape (bearer, api-key, custom)
+  additionally sets a header the agent did not send; `basic` is the one case
+  substitution cannot reach, because the client base64-encodes the value
+  before it leaves.
+
+  ## The network policy (gate 2, built)
 
   The sandbox's own policy is always the floor, `allow: [broker]`. What the
   environment's `networking_type` says is enforced **at the broker**:
@@ -124,16 +139,76 @@ defmodule Fountain.Broker do
   @spec catalog_keys() :: [String.t()]
   def catalog_keys, do: Map.keys(@catalog)
 
+  @inference_prefix %{
+    "CLAUDE_CODE_OAUTH_TOKEN" => "sk-ant-oat01-",
+    "ANTHROPIC_API_KEY" => "sk-ant-api03-",
+    "OPENAI_API_KEY" => "sk-",
+    "GEMINI_API_KEY" => "AIza"
+  }
+
   @doc """
   The placeholder a brokered key carries in the sandbox.
 
-  Lowercase, wrapped in double underscores, so it is visibly not a token and
-  so a client that validates its own token's shape (some do) still sends it.
-  The broker replaces the whole auth header, so the value never has to match
-  anything on the other side.
+  Lowercase, wrapped in double underscores: visibly not a token, and exactly
+  the string the broker's substitution looks for. An inference credential
+  keeps its vendor prefix in front (`sk-ant-oat01-__claude_code_oauth_token__`)
+  for a CLI that checks the shape of its own token before sending it; the
+  substitution then replaces the whole prefixed string.
   """
   @spec placeholder(String.t()) :: String.t()
-  def placeholder(key), do: "__" <> String.downcase(key) <> "__"
+  def placeholder(key) do
+    Map.get(@inference_prefix, key, "") <> "__" <> String.downcase(key) <> "__"
+  end
+
+  # Inference credentials (gate 3): the env var each runtime reads, the host
+  # it talks to, and the prefix its vendor's tokens carry. Substitution covers
+  # every shape at once — Anthropic's `x-api-key`, the OAuth bearer, OpenAI's
+  # bearer and Gemini's `?key=` query parameter alike.
+  @inference %{
+    "CLAUDE_CODE_OAUTH_TOKEN" => %{cred: :claude_code_oauth_token, hosts: ["api.anthropic.com"]},
+    "ANTHROPIC_API_KEY" => %{cred: :anthropic_api_key, hosts: ["api.anthropic.com"]},
+    "OPENAI_API_KEY" => %{cred: :openai_api_key, hosts: ["api.openai.com"]},
+    "GEMINI_API_KEY" => %{cred: :gemini_api_key, hosts: ["generativelanguage.googleapis.com"]}
+  }
+
+  @doc "The env var names that carry inference credentials, and the credential each comes from."
+  @spec inference_keys() :: %{String.t() => atom()}
+  def inference_keys, do: Map.new(@inference, fn {k, v} -> {k, v.cred} end)
+
+  @doc """
+  Split the runtime's inference credentials (gate 3): the map handed to
+  `default_env/2` gets placeholders, the broker gets the values under the
+  env var names, and each gets an implicit `substitute` binding to its
+  provider's host. A tenant's own binding for the same name wins.
+  """
+  @spec split_inference(map(), bindings()) :: {map(), %{String.t() => String.t()}, bindings()}
+  def split_inference(credentials, bindings \\ %{}) when is_map(credentials) do
+    Enum.reduce(@inference, {credentials, %{}, %{}}, fn {key, %{cred: cred, hosts: hosts}},
+                                                        {creds, brokered, implicit} ->
+      case Map.get(creds, cred) do
+        value when is_binary(value) and value != "" ->
+          implicit =
+            if Map.has_key?(bindings, key),
+              do: implicit,
+              else: Map.put(implicit, key, Enum.map(hosts, &implicit_binding(key, &1)))
+
+          {Map.put(creds, cred, placeholder(key)), Map.put(brokered, key, value), implicit}
+
+        _ ->
+          {creds, brokered, implicit}
+      end
+    end)
+  end
+
+  defp implicit_binding(key, host) do
+    %Fountain.SecretBindings.Binding{
+      key: key,
+      host: host,
+      auth_type: "substitute",
+      headers: %{},
+      enabled: true
+    }
+  end
 
   @typedoc "Enabled bindings grouped by secret key, as `Fountain.SecretBindings.enabled_by_key/1` returns them."
   @type bindings :: %{String.t() => [Fountain.SecretBindings.Binding.t()]}
@@ -180,11 +255,17 @@ defmodule Fountain.Broker do
         key = github_key(brokered, bindings)
 
         [
-          %{name: "github-api", host: "api.github.com", auth: %{type: "bearer", token: key}},
+          %{
+            name: "github-api",
+            host: "api.github.com",
+            auth: %{type: "bearer", token: key},
+            substitutions: [substitution(key)]
+          },
           %{
             name: "github-git",
             host: "github.com",
-            auth: %{type: "basic", username: basic_user_key(key), password: key}
+            auth: %{type: "basic", username: basic_user_key(key), password: key},
+            substitutions: [substitution(key)]
           }
         ]
       else
@@ -210,6 +291,7 @@ defmodule Fountain.Broker do
   defp binding_service(key, binding) do
     auth =
       case binding.auth_type do
+        "substitute" -> %{type: "passthrough"}
         "bearer" -> %{type: "bearer", token: key}
         "basic" -> %{type: "basic", username: basic_user_key(key), password: key}
         "api_key" -> %{type: "api-key", key: key, header: binding.header, prefix: binding.prefix}
@@ -218,7 +300,18 @@ defmodule Fountain.Broker do
       |> Enum.reject(fn {_, v} -> is_nil(v) or v == "" end)
       |> Map.new()
 
-    %{name: service_name(key, binding.host), host: binding.host, auth: auth}
+    %{
+      name: service_name(key, binding.host),
+      host: binding.host,
+      auth: auth,
+      substitutions: [substitution(key)]
+    }
+  end
+
+  # The placeholder, replaced on every surface the broker can reach. Present
+  # on every service so "the placeholder anywhere" holds whatever the shape.
+  defp substitution(key) do
+    %{key: key, placeholder: placeholder(key), in: ~w(path query header body websocket)}
   end
 
   # A slug the broker accepts (`[a-z0-9-]{3,64}`, no `--`, no edge hyphen)

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -367,6 +367,9 @@ defmodule Fountain.Conversations.ConversationServer do
       broker_bindings: %{},
       # The environment's networking shape, enforced at the broker (gate 2).
       broker_network: :unrestricted,
+      # What the runtime's default_env/2 is handed (gate 3): the real
+      # credentials, or placeholders when the conversation is brokered.
+      env_credentials: %{},
       broker: nil,
       current_command: nil,
       current_command_ref: nil,
@@ -581,6 +584,9 @@ defmodule Fountain.Conversations.ConversationServer do
         {secrets, brokered} =
           split_brokered(conv.user_id, merge_secrets(env, vault, dek), bindings)
 
+        {env_creds, brokered, bindings} =
+          split_inference(conv.user_id, inference_creds, brokered, bindings)
+
         state =
           %{
             state
@@ -588,6 +594,7 @@ defmodule Fountain.Conversations.ConversationServer do
               runtime_session_id: conv.runtime_session_id,
               tenant_key: dek,
               inference_credentials: inference_creds,
+              env_credentials: env_creds,
               brokered: brokered,
               broker_bindings: bindings,
               broker_network: Fountain.Broker.network_for(env)
@@ -1354,7 +1361,7 @@ defmodule Fountain.Conversations.ConversationServer do
   end
 
   defp do_build_sprite_env(state, agent, env, secrets, sandbox_url) do
-    (state.runtime_module.default_env(agent, state.inference_credentials) || []) ++
+    (state.runtime_module.default_env(agent, state.env_credentials) || []) ++
       fountain_callback_env(state.callback_token) ++
       conversation_env(state.conversation_id) ++
       sandbox_id_env(state.sandbox_id) ++
@@ -1390,6 +1397,21 @@ defmodule Fountain.Conversations.ConversationServer do
       else: %{}
   end
 
+  # Gate 3: the runtime is handed placeholders for its inference credentials
+  # and the broker gets the values, with an implicit binding to the provider's
+  # host. A tenant's own secret of the same name (already split above) wins
+  # over the inference credential, as it wins in the environment.
+  defp split_inference(user_id, inference_creds, brokered, bindings) do
+    if Fountain.Broker.enabled_for?(user_id) do
+      {env_creds, inference_brokered, implicit} =
+        Fountain.Broker.split_inference(inference_creds, bindings)
+
+      {env_creds, Map.merge(inference_brokered, brokered), Map.merge(implicit, bindings)}
+    else
+      {inference_creds, brokered, bindings}
+    end
+  end
+
   defp broker_env(%{broker: nil}), do: []
   defp broker_env(%{broker: session}), do: Fountain.Broker.sandbox_env(session)
 
@@ -1418,6 +1440,45 @@ defmodule Fountain.Conversations.ConversationServer do
       end
     else
       {:ok, state}
+    end
+  end
+
+  # The OAuth token was refused: forget it on both sides and, when brokered,
+  # re-prepare the vault so the API key is what the substitution carries.
+  # Best effort — a broker error here leaves the turn to fail at the proxy,
+  # which names the cause, rather than silently injecting a plaintext key.
+  defp broker_switch_to_api_key(%{broker: nil} = state), do: state
+
+  defp broker_switch_to_api_key(state) do
+    creds = Map.delete(state.inference_credentials, :claude_code_oauth_token)
+
+    {env_creds, inference_brokered, implicit} =
+      Fountain.Broker.split_inference(creds, state.broker_bindings)
+
+    brokered =
+      state.brokered
+      |> Map.delete("CLAUDE_CODE_OAUTH_TOKEN")
+      |> Map.merge(inference_brokered)
+
+    bindings =
+      state.broker_bindings |> Map.delete("CLAUDE_CODE_OAUTH_TOKEN") |> Map.merge(implicit)
+
+    state = %{state | brokered: brokered, broker_bindings: bindings, env_credentials: env_creds}
+
+    case Fountain.Broker.prepare(state.conversation_id, brokered, bindings,
+           network: state.broker_network
+         ) do
+      {:ok, session} ->
+        keys = Fountain.Broker.env_keys()
+        kept = Enum.reject(state.sprite_env, fn {k, _} -> to_string(k) in keys end)
+        %{state | broker: session, sprite_env: kept ++ Fountain.Broker.sandbox_env(session)}
+
+      {:error, reason} ->
+        Logger.warning(
+          "conv #{state.conversation_id}: broker re-prepare after OAuth refusal failed: #{inspect(reason)}"
+        )
+
+        state
     end
   end
 
@@ -2085,8 +2146,13 @@ defmodule Fountain.Conversations.ConversationServer do
       ) do
     Logger.warning("conv #{state.conversation_id}: Claude OAuth token refused by org: #{detail}")
 
+    # On a brokered conversation the API key is a placeholder in the env and
+    # the value moves to the broker; the vault is re-prepared so its
+    # substitution now carries the key instead of the refused OAuth token.
+    state = broker_switch_to_api_key(state)
+
     fallback_env =
-      Fountain.Runtimes.Claude.fall_back_to_api_key(state.sprite_env, state.inference_credentials)
+      Fountain.Runtimes.Claude.fall_back_to_api_key(state.sprite_env, state.env_credentials)
 
     switched? = fallback_env != state.sprite_env
 
@@ -2104,7 +2170,8 @@ defmodule Fountain.Conversations.ConversationServer do
     state = %{
       state
       | sprite_env: fallback_env,
-        inference_credentials: Map.delete(state.inference_credentials, :claude_code_oauth_token)
+        inference_credentials: Map.delete(state.inference_credentials, :claude_code_oauth_token),
+        env_credentials: Map.delete(state.env_credentials, :claude_code_oauth_token)
     }
 
     message =

--- a/apps/fountain/lib/fountain/secret_bindings/binding.ex
+++ b/apps/fountain/lib/fountain/secret_bindings/binding.ex
@@ -20,7 +20,7 @@ defmodule Fountain.SecretBindings.Binding do
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
 
-  @auth_types ~w(bearer basic api_key custom)
+  @auth_types ~w(substitute bearer basic api_key custom)
   @key_re ~r/^[A-Z][A-Z0-9_]*$/
   @header_name_re ~r/^[a-zA-Z0-9-]+$/
   @host_label_re ~r/^([a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$/
@@ -43,7 +43,15 @@ defmodule Fountain.SecretBindings.Binding do
     timestamps(type: :utc_datetime)
   end
 
-  @doc "The auth shapes gate 1b supports. `passthrough` is a network rule, not a credential; that is gate 2."
+  @doc """
+  The shapes a binding can take. `substitute` is the default and needs no
+  other field: the broker replaces the secret's placeholder wherever it
+  appears in a request to the host (header, query, path, body), so the
+  agent sends whatever shape the API wants and never has to be told how. The
+  explicit shapes add a header the agent did not send, or, for `basic`,
+  cover the one case substitution cannot: a value the client base64-encodes
+  before it leaves.
+  """
   def auth_types, do: @auth_types
 
   def changeset(binding, attrs) do
@@ -175,6 +183,9 @@ defmodule Fountain.SecretBindings.Binding do
 
   defp validate_auth_fields(changeset) do
     case get_field(changeset, :auth_type) do
+      "substitute" ->
+        changeset |> clear([:header, :prefix, :username]) |> put_change(:headers, %{})
+
       "bearer" ->
         changeset |> clear([:header, :prefix, :username]) |> put_change(:headers, %{})
 

--- a/apps/fountain/lib/fountain/secret_bindings/catalog.ex
+++ b/apps/fountain/lib/fountain/secret_bindings/catalog.ex
@@ -8,7 +8,9 @@ defmodule Fountain.SecretBindings.Catalog do
   change any field. Three presets are not directly usable as bindings and
   are marked `usable: false` — `aws-s3` needs SigV4 signing, `jira` and
   `twilio` are basic auth where the suggested key is the password and the
-  username is the tenant's own.
+  username is the tenant's own. A vendor `passthrough` preset, one that
+  substitutes a placeholder rather than adding a header, maps to our
+  `substitute` shape.
 
   Read at compile time from `priv/broker/service_catalog.json`, which ships
   in the release like the rest of `priv`.
@@ -28,7 +30,10 @@ defmodule Fountain.SecretBindings.Catalog do
                name: e["name"],
                host: e["host"],
                description: e["description"],
-               auth_type: String.replace(e["auth_type"], "-", "_"),
+               auth_type:
+                 e["auth_type"]
+                 |> String.replace("-", "_")
+                 |> String.replace("passthrough", "substitute"),
                suggested_key: e["suggested_credential_key"],
                header: e["header"],
                prefix: e["prefix"],

--- a/apps/fountain/lib/fountain_web/live/secret_bindings_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/secret_bindings_live/index.ex
@@ -172,7 +172,7 @@ defmodule FountainWeb.SecretBindingsLive.Index do
     %{
       "key" => "",
       "host" => "",
-      "auth_type" => "bearer",
+      "auth_type" => "substitute",
       "header" => "",
       "prefix" => "",
       "username" => "",
@@ -220,10 +220,14 @@ defmodule FountainWeb.SecretBindingsLive.Index do
     |> Enum.map_join("; ", fn {field, msgs} -> "#{field} #{Enum.join(msgs, ", ")}" end)
   end
 
-  defp auth_label("bearer"), do: "Bearer token"
+  defp auth_label("substitute"), do: "Replace the placeholder wherever it appears"
+  defp auth_label("bearer"), do: "Add a bearer header"
   defp auth_label("basic"), do: "Basic auth (secret is the password)"
   defp auth_label("api_key"), do: "API key header"
   defp auth_label("custom"), do: "Custom headers"
+
+  defp auth_summary(%Binding{auth_type: "substitute"}),
+    do: "placeholder → <secret>, anywhere in the request"
 
   defp auth_summary(%Binding{auth_type: "bearer"}), do: "Authorization: Bearer <secret>"
   defp auth_summary(%Binding{auth_type: "basic", username: u}), do: "Basic #{u}:<secret>"
@@ -383,6 +387,13 @@ defmodule FountainWeb.SecretBindingsLive.Index do
 
           <fieldset class="space-y-1">
             <legend class="text-sm font-medium">How the secret is sent</legend>
+            <p class="text-xs text-[var(--color-text-secondary)]">
+              The agent sees <code class="font-mono">__key__</code>
+              in place of the secret. By default the
+              broker swaps it for the real value wherever it turns up in a request to this host, so the
+              agent uses it exactly as it would the secret. Pick a header shape only for an API the agent
+              cannot address itself, or basic auth, which the client encodes before it leaves.
+            </p>
             <div class="flex flex-wrap gap-3 text-sm">
               <label :for={t <- Binding.auth_types()} class="flex items-center gap-1">
                 <input

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -3267,7 +3267,10 @@ defmodule FountainWeb.Schemas do
             "Host pattern: `api.example.com`, a one-level wildcard `*.example.com`, " <>
               "optionally `:port` and a `/path/*` glob."
         },
-        auth_type: %Schema{type: :string, enum: ["bearer", "basic", "api_key", "custom"]},
+        auth_type: %Schema{
+          type: :string,
+          enum: ["substitute", "bearer", "basic", "api_key", "custom"]
+        },
         header: %Schema{
           type: :string,
           nullable: true,
@@ -3307,7 +3310,10 @@ defmodule FountainWeb.Schemas do
       properties: %{
         key: %Schema{type: :string},
         host: %Schema{type: :string},
-        auth_type: %Schema{type: :string, enum: ["bearer", "basic", "api_key", "custom"]},
+        auth_type: %Schema{
+          type: :string,
+          enum: ["substitute", "bearer", "basic", "api_key", "custom"]
+        },
         header: %Schema{type: :string, nullable: true},
         prefix: %Schema{type: :string, nullable: true},
         username: %Schema{type: :string, nullable: true},

--- a/apps/fountain/test/fountain/broker_test.exs
+++ b/apps/fountain/test/fountain/broker_test.exs
@@ -482,6 +482,69 @@ defmodule Fountain.BrokerTest do
       assert Broker.network_for(nil) == :unrestricted
     end
 
+    test "every service carries a substitution for its key; substitute is passthrough plus that" do
+      capture_services()
+
+      bindings = %{
+        "STRIPE_SECRET_KEY" => [
+          bound(%{key: "STRIPE_SECRET_KEY", host: "api.stripe.com", auth_type: "substitute"}),
+          bound(%{key: "STRIPE_SECRET_KEY", host: "files.stripe.com"})
+        ]
+      }
+
+      assert {:ok, _} = Broker.prepare(@conv, %{"STRIPE_SECRET_KEY" => "sk"}, bindings)
+      assert_received {:services, [sub, bearer]}
+
+      assert sub.auth == %{type: "passthrough"}
+      assert bearer.auth == %{type: "bearer", token: "STRIPE_SECRET_KEY"}
+
+      for svc <- [sub, bearer] do
+        assert [%{key: "STRIPE_SECRET_KEY", placeholder: "__stripe_secret_key__", in: surfaces}] =
+                 svc.substitutions
+
+        assert Enum.sort(surfaces) == ~w(body header path query websocket)
+      end
+    end
+
+    test "split_inference/2: placeholders to the runtime, values to the broker, implicit bindings" do
+      creds = %{
+        claude_code_oauth_token: "sk-ant-oat01-real",
+        openai_api_key: "sk-real",
+        gemini_api_key: nil
+      }
+
+      assert {env_creds, brokered, implicit} = Broker.split_inference(creds)
+
+      assert env_creds == %{
+               claude_code_oauth_token: "sk-ant-oat01-__claude_code_oauth_token__",
+               openai_api_key: "sk-__openai_api_key__",
+               gemini_api_key: nil
+             }
+
+      assert brokered == %{
+               "CLAUDE_CODE_OAUTH_TOKEN" => "sk-ant-oat01-real",
+               "OPENAI_API_KEY" => "sk-real"
+             }
+
+      assert %{
+               "CLAUDE_CODE_OAUTH_TOKEN" => [
+                 %{host: "api.anthropic.com", auth_type: "substitute"}
+               ],
+               "OPENAI_API_KEY" => [%{host: "api.openai.com", auth_type: "substitute"}]
+             } = implicit
+
+      # A tenant's own binding for the name wins: no implicit one beside it.
+      own = %{"OPENAI_API_KEY" => [bound(%{key: "OPENAI_API_KEY", host: "proxy.example.com"})]}
+      assert {_, _, implicit} = Broker.split_inference(creds, own)
+      refute Map.has_key?(implicit, "OPENAI_API_KEY")
+    end
+
+    test "an inference placeholder keeps the vendor prefix; a secret's does not" do
+      assert Broker.placeholder("ANTHROPIC_API_KEY") == "sk-ant-api03-__anthropic_api_key__"
+      assert Broker.placeholder("GEMINI_API_KEY") == "AIza__gemini_api_key__"
+      assert Broker.placeholder("GITHUB_TOKEN") == "__github_token__"
+    end
+
     test "service_name/2 is a stable broker slug" do
       assert Broker.service_name("STRIPE_SECRET_KEY", "api.stripe.com:443/v1/*") ==
                "stripe-secret-key-api-stripe-com-443-v1"

--- a/apps/fountain/test/fountain/conversations/conversation_server_broker_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_broker_test.exs
@@ -227,6 +227,49 @@ defmodule Fountain.Conversations.ConversationServerBrokerTest do
       assert Conversations._unsafe_get_conversation!(conv.id).status == "failed"
     end
 
+    test "the runtime's inference credential is a placeholder; the value goes to the broker", %{
+      user: user,
+      agent: agent
+    } do
+      conv = insert_conversation(user_id: user.id, agent: agent)
+      test = self()
+
+      stub_happy_sprite()
+      _ref = stub_turn_boundary()
+
+      Mimic.stub(Fountain.InferenceCredentials, :decrypted_for_user, fn _u, _k ->
+        {:ok, %{claude_code_oauth_token: "sk-ant-oat01-realtoken"}}
+      end)
+
+      stub(Fountain.Broker, :preflight, fn -> :ok end)
+      stub(Fountain.Broker, :ca_pem, fn -> {:ok, "PEM"} end)
+
+      stub(Fountain.Broker, :prepare, fn _c, brokered, bindings, _opts ->
+        send(test, {:prepared, brokered, bindings})
+        {:ok, @session}
+      end)
+
+      {pid, _mon, :alive} = start_server(conv, initial_prompt: "hello")
+      on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+
+      assert_receive {:prepared, brokered, bindings}, 2_000
+      assert brokered["CLAUDE_CODE_OAUTH_TOKEN"] == "sk-ant-oat01-realtoken"
+
+      assert [%{host: "api.anthropic.com", auth_type: "substitute"}] =
+               bindings["CLAUDE_CODE_OAUTH_TOKEN"]
+
+      # The harness runtime ignores credentials; the real one is handed the
+      # placeholder (see the Broker unit tests), and the value is nowhere in
+      # what reaches the sandbox.
+      assert_receive {:spawned, _cmd, _args, opts}, 2_000
+      spawn_env = Keyword.fetch!(opts, :env)
+      refute Enum.any?(spawn_env, fn {_, v} -> v == "sk-ant-oat01-realtoken" end)
+
+      assert Fountain.Runtimes.Claude.default_env(nil, %{
+               claude_code_oauth_token: "sk-ant-oat01-__claude_code_oauth_token__"
+             }) == [{"CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat01-__claude_code_oauth_token__"}]
+    end
+
     test "a limited environment is brokered with its allowlist enforced at the broker", %{
       user: user
     } do

--- a/apps/fountain/test/fountain/secret_bindings_test.exs
+++ b/apps/fountain/test/fountain/secret_bindings_test.exs
@@ -172,6 +172,17 @@ defmodule Fountain.SecretBindingsTest do
       assert Enum.any?(errors_on(cs).headers, &String.contains?(&1, "hyphens"))
     end
 
+    test "substitute is the shape with no other field", %{user: user} do
+      assert {:ok, b} =
+               bind(user, %{
+                 "auth_type" => "substitute",
+                 "header" => "stale",
+                 "username" => "stale"
+               })
+
+      assert {b.header, b.username, b.headers} == {nil, nil, %{}}
+    end
+
     test "an unknown auth type is refused", %{user: user} do
       assert {:error, cs} = bind(user, %{"auth_type" => "passthrough"})
       assert errors_on(cs).auth_type != []
@@ -260,7 +271,8 @@ defmodule Fountain.SecretBindingsTest do
                ~w(aws-s3 jira twilio)
 
       assert [%{id: "stripe"}] = Catalog.for_key("STRIPE_SECRET_KEY")
-      assert Enum.all?(presets, &(&1.auth_type in ~w(bearer basic api_key custom passthrough)))
+      assert Enum.all?(presets, &(&1.auth_type in ~w(substitute bearer basic api_key custom)))
+      assert %{auth_type: "substitute", usable: true} = Catalog.get("telegram")
     end
 
     test "attrs/2 prefills a binding that the changeset accepts" do

--- a/decisions/0019-egress-credential-brokerage.md
+++ b/decisions/0019-egress-credential-brokerage.md
@@ -23,8 +23,8 @@ published at `broker.inevitable.fyi` by the Traefik TCP router of §11), and
 the hosted deployment names **one** tenant, the maintainer's own account
 (home-cloud#131, 2026-08-25). Its done-when was observed on a production
 Sprites conversation the same day — see *Gate 1a* under *Gates*. Everyone else
-is byte-for-byte on the old path. Gates 1b (bindings) and 2 (`limited` at the broker) are built; 3 and 4 are
-not. #1090 is closed and each
+is byte-for-byte on the old path. Gates 1b (bindings), 2 (`limited` at the broker) and 3 (inference
+credentials) are built; 4 is not. #1090 is closed and each
 later gate gets its own tracker.
 
 **Revised 2026-08-25 (gate 1a).** Building it changed three things below,
@@ -634,11 +634,22 @@ gate 0 warned about: under `deny` the tenant lists what provisioning and the
 runtime need (`registry.npmjs.org`, the model host), exactly as a Sprites
 `limited` environment already required.
 
-**Gate 3 — inference credentials through the same path.** This absorbs 0016 gate
-3 and closes its base-URL question: brokering inference through the proxy needs no
-override survey. Includes `Claude.fall_back_to_api_key/2`, the second injection
-site 0023's Context subsection names. 0016 §4's second purpose (metering)
-becomes available here and remains a separate decision.
+**Gate 3 — built 2026-08-25.** The runtime's inference credential is handed
+to `default_env/2` as a vendor-shaped placeholder
+(`sk-ant-oat01-__claude_code_oauth_token__`) and the value goes to the broker
+with an implicit binding to the provider's host, where a **substitution**
+replaces the placeholder wherever it appears — which is why one mechanism
+covers Anthropic's `x-api-key`, the OAuth bearer, OpenAI's bearer and Gemini's
+`?key=` query parameter alike, and why no base-URL survey was needed (this
+absorbs 0016 gate 3). `Claude.fall_back_to_api_key/2`, the second injection
+site, now re-prepares the vault so the substitution carries the API key
+instead of injecting one in the clear. Substitution also became the default
+shape for tenant bindings: a binding is "this secret may go to this host",
+and the explicit header shapes are for an API the agent cannot address
+itself; `basic` is the one shape substitution cannot reach, since the client
+encodes the value. 0016 §4's second purpose (metering) remains a separate
+decision. Not verified live yet: whether `codex login --with-api-key` accepts
+the placeholder, and OpenCode's own gateway host.
 
 **Gate 4 — the joined trail.** Broker request log correlated to Conversation, and
 whatever surface makes the effect half readable next to the intent half. Gate 0

--- a/docs/concepts/environment.md
+++ b/docs/concepts/environment.md
@@ -88,7 +88,9 @@ reach only the broker. The broker then applies your policy. With
 `unrestricted`, a request goes through to any host, with only the credentials
 you bound. With `limited`, the broker refuses a request to a host that is not
 in `allowed_hosts`. The refusal is a 403 that names the host. The broker's
-request log shows each decision.
+request log shows each decision. List what the setup of the sandbox needs, such as
+`registry.npmjs.org` for the agent's adapter. A host with a bound credential,
+such as the model's API, needs no entry.
 
 Not every backend can hold egress. Sprites, E2B and Daytona can. A
 [self-hosted runner](../integrations/runners.md) cannot. The agent selects the

--- a/docs/concepts/secrets.md
+++ b/docs/concepts/secrets.md
@@ -156,17 +156,26 @@ redaction that a new caller will one day forget.
 
 <!-- vale STE.IngForms = NO -->
 On a hosted account with the egress credential broker on, a secret can have
-one or more **bindings**. A binding names a host. It also names the way the
-broker attaches the secret to a request for that host. There are four shapes.
-A bearer token. Basic auth with a username of yours. A header with an optional
-prefix. Custom headers with `{{ KEY }}` in them.
+one or more **bindings**. A binding names a host. By default the broker
+replaces the secret's placeholder wherever it appears in a request to that
+host. The agent uses the placeholder as it would use the secret, in any
+header, query, path or body. It never has to know the shape the API wants.
+Four other shapes are there for an API the agent cannot address itself. A
+bearer header. Basic auth with a username of yours, which the client encodes
+before it leaves. A header with an optional prefix. Custom headers with
+`{{ KEY }}` in them.
 
 A secret with a binding does not enter the sandbox. The agent sees a
 placeholder, `__stripe_secret_key__` for `STRIPE_SECRET_KEY`. The broker puts
 the real value on each request to the bound host. A secret with no binding
 enters the sandbox in the clear. The four hops above describe that path.
 `GITHUB_TOKEN` and `GH_TOKEN` have a built-in binding to GitHub. It applies
-until you make one of your own.
+until you make one of your own. The runtime's inference credential has one
+too. `CLAUDE_CODE_OAUTH_TOKEN` and `ANTHROPIC_API_KEY` go to
+`api.anthropic.com`, `OPENAI_API_KEY` to `api.openai.com`, and
+`GEMINI_API_KEY` to `generativelanguage.googleapis.com`. The runtime sees a
+placeholder that keeps the vendor's prefix, such as
+`sk-ant-oat01-__claude_code_oauth_token__`.
 
 You manage bindings on Account, then Credential bindings, or with
 `GET /api/secret-bindings` and its siblings. The page and the routes are only

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -10,6 +10,14 @@ server releases.
 
 ---
 
+## [1.4.0] — 2026-08-25
+
+### Changed
+
+- `SecretBinding.auth_type` gains `substitute`, now the default shape: the
+  broker replaces the secret's placeholder wherever it appears in a request to
+  the bound host.
+
 ## [1.3.0] — 2026-08-25
 
 ### Added

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentshit/fountain-sdk",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Run a coding agent on a real computer, with your repos and your credentials, in one call.",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -3397,7 +3397,7 @@ export interface components {
          */
         SecretBindingRequest: {
             /** @enum {string} */
-            auth_type: "bearer" | "basic" | "api_key" | "custom";
+            auth_type: "substitute" | "bearer" | "basic" | "api_key" | "custom";
             enabled?: boolean;
             header?: string | null;
             headers?: {
@@ -3953,7 +3953,7 @@ export interface components {
          */
         SecretBinding: {
             /** @enum {string} */
-            auth_type: "bearer" | "basic" | "api_key" | "custom";
+            auth_type: "substitute" | "bearer" | "basic" | "api_key" | "custom";
             /** Format: date-time */
             created_at: string;
             enabled: boolean;

--- a/sdk/typescript/src/http.ts
+++ b/sdk/typescript/src/http.ts
@@ -19,7 +19,7 @@ export interface RequestOptions {
  * this string is already what Fountain's request logs are keyed on. The
  * version half is asserted against `package.json` by a test.
  */
-export const USER_AGENT = "fountain-sdk-js/1.3.0";
+export const USER_AGENT = "fountain-sdk-js/1.4.0";
 
 /**
  * The thin layer everything else is built on: one bearer token, JSON in and


### PR DESCRIPTION
Gate 3 of [ADR 0019](decisions/0019-egress-credential-brokerage.md), plus the simplification Jake asked for mid-build.

## Substitution: a binding is "this secret may go to this host"

Verified against Agent Vault 0.39.1: a service `substitution` replaces a placeholder string wherever it appears in a request — header (even inside `Bearer sk-ant-oat01-__x__`), query, path, body. So:
- **Every** binding service now carries a substitution for its key.
- **`substitute` is the new default shape** — no auth fields at all; the agent uses `__key__` exactly as it would use the secret and the broker swaps it. The header shapes (bearer/api-key/custom) remain for an API the agent cannot address itself; **`basic` stays explicit** because the client base64-encodes `user:password` before it leaves (verified: 401 with substitution alone).
- Vendor `passthrough` presets (telegram) map to `substitute`.

## Inference credentials (gate 3 proper)

`default_env/2` is handed **vendor-shaped placeholders** (`sk-ant-oat01-__claude_code_oauth_token__`, `sk-ant-api03-__anthropic_api_key__`, `sk-__openai_api_key__`, `AIza__gemini_api_key__`) and the broker gets the values with an implicit `substitute` binding to the provider's host (`api.anthropic.com`, `api.openai.com`, `generativelanguage.googleapis.com`). One mechanism covers `x-api-key`, the OAuth bearer, OpenAI's bearer and Gemini's `?key=` alike — no base-URL survey (absorbs 0016 gate 3). A tenant secret of the same name with its own binding wins, as it wins in the env.

`Claude.fall_back_to_api_key/2` (the second injection site) now re-prepares the vault so the substitution carries the API key, instead of putting one in the sandbox in the clear.

Under `limited` (gate 2) the model host has a credential service, so it needs no `allowed_hosts` entry; docs now say to list `registry.npmjs.org`.

## Not verified live yet (says so in the ADR)

Whether `codex login --with-api-key` accepts the placeholder, and OpenCode's own gateway host. I'll verify Claude on production on my account after merge (the flip is live there), which is the runtime that matters today.

Tests: broker (split_inference, prefixes, substitutions on every service, substitute shape), bindings, ConversationServer (inference credential → broker, value absent from the env), enum guardrail, api spec, docs. compile `-Werror`, credo, dialyzer, format, vale 0/0, docs-style, sobelow, `okf validate`, SDK 1.4.0 guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)