### PR TITLE
feat(broker): the egress trail — a conversation's broker log, kept and readable (ADR 0019 gate 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,13 @@ upgrade, is in
 
 ### Added
 
+- **The egress trail, ADR 0019 gate 4.** `GET /api/conversations/:id/egress`
+  lists what a brokered conversation actually sent out: each request's
+  host, the binding that matched (and so the credential attached), the
+  status and latency, refusals included. A conversation's vault on the
+  broker now keeps its request log after the conversation ends (credentials,
+  services and sessions are stripped; the vault stays) for
+  `BROKER_LOG_RETENTION_HOURS`, and a daily job deletes older ones.
 - **Inference credentials through the broker, ADR 0019 gate 3.** On a
   brokered account the runtime's credential (`CLAUDE_CODE_OAUTH_TOKEN` or
   `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`) is a vendor-shaped

--- a/apps/fountain/lib/fountain/broker.ex
+++ b/apps/fountain/lib/fountain/broker.ex
@@ -111,6 +111,10 @@ defmodule Fountain.Broker do
   @spec proxy_host() :: String.t()
   def proxy_host, do: URI.parse(proxy_url()).host
 
+  @doc "How long a released conversation's vault keeps its request log before the reaper deletes it."
+  @spec log_retention_hours() :: pos_integer()
+  def log_retention_hours, do: Application.get_env(:fountain, :broker_log_retention_hours, 168)
+
   @doc "Whether a provider without `:network_policy` may host a brokered conversation."
   @spec allow_unenforced?() :: boolean()
   def allow_unenforced?, do: Application.get_env(:fountain, :broker_allow_unenforced, false)
@@ -492,14 +496,160 @@ defmodule Fountain.Broker do
 
   def network_for(_), do: :unrestricted
 
-  @doc "Delete the conversation's vault: its credentials, services and sessions go with it."
+  @doc """
+  Release a conversation's vault at the end of its life: every credential,
+  service and session goes, so nothing brokers on its behalf again — but
+  the vault itself stays, because its request log is the effect half of the
+  audit trail (gate 4) and deleting the vault would take it. A missing vault
+  is already released. `Fountain.Workers.BrokerVaultReaper` deletes the vault
+  once the log is past `BROKER_LOG_RETENTION_HOURS`.
+  """
   @spec release(String.t()) :: :ok | {:error, term()}
   def release(conversation_id) when is_binary(conversation_id) do
     vault = vault_name(conversation_id)
 
+    with {:ok, true} <- vault_exists?(vault),
+         :ok <- revoke_sessions(vault),
+         :ok <- clear_services(vault),
+         :ok <- clear_credentials(vault) do
+      :ok
+    else
+      {:ok, false} -> :ok
+      {:error, _} = err -> err
+    end
+  end
+
+  @doc "Delete a vault outright, log and all. The reaper's call, never provisioning's."
+  @spec delete_vault(String.t()) :: :ok | {:error, term()}
+  def delete_vault(vault) when is_binary(vault) do
     case Req.delete(req(), url: "/v1/vaults/#{vault}") do
       {:ok, %{status: status}} when status in 200..299 -> :ok
       {:ok, %{status: 404}} -> :ok
+      other -> {:error, {:broker, :delete_vault, normalize(other)}}
+    end
+  end
+
+  @doc "Every vault on the broker, by name. The owner token sees them all."
+  @spec list_vaults() :: {:ok, [String.t()]} | {:error, term()}
+  def list_vaults do
+    case Req.get(req(), url: "/v1/vaults") do
+      {:ok, %{status: 200, body: %{"vaults" => vaults}}} -> {:ok, Enum.map(vaults, & &1["name"])}
+      other -> {:error, {:broker, :list_vaults, normalize(other)}}
+    end
+  end
+
+  @doc "The conversation id a vault name was made from, or nil for a vault that is not ours."
+  @spec conversation_id_for_vault(String.t()) :: String.t() | nil
+  def conversation_id_for_vault("c-" <> hex) when byte_size(hex) == 32 do
+    case Ecto.UUID.cast(
+           String.replace(hex, ~r/(.{8})(.{4})(.{4})(.{4})(.{12})/, "\\1-\\2-\\3-\\4-\\5")
+         ) do
+      {:ok, id} -> id
+      :error -> nil
+    end
+  end
+
+  def conversation_id_for_vault(_), do: nil
+
+  @typedoc "One outbound request the broker handled for a conversation."
+  @type egress_event :: %{
+          id: integer(),
+          at: DateTime.t() | nil,
+          method: String.t(),
+          host: String.t(),
+          path: String.t(),
+          service: String.t() | nil,
+          credential_keys: [String.t()],
+          status: integer() | nil,
+          latency_ms: integer() | nil,
+          error: String.t() | nil
+        }
+
+  @doc """
+  The broker's request log for a conversation, newest first (gate 4): what
+  actually left the sandbox, to which host, with which credential attached,
+  and what came back. `before:` pages by the previous page's oldest `id`.
+  """
+  @spec request_log(String.t(), keyword()) ::
+          {:ok, %{events: [egress_event()], next: integer() | nil}} | {:error, term()}
+  def request_log(conversation_id, opts \\ []) when is_binary(conversation_id) do
+    vault = vault_name(conversation_id)
+
+    params =
+      [limit: Keyword.get(opts, :limit, 100)] ++ if(b = opts[:before], do: [before: b], else: [])
+
+    case Req.get(req(), url: "/v1/vaults/#{vault}/logs", params: params) do
+      {:ok, %{status: 200, body: %{"logs" => logs} = body}} ->
+        {:ok, %{events: Enum.map(logs, &egress_event/1), next: body["next_cursor"]}}
+
+      {:ok, %{status: 404}} ->
+        {:ok, %{events: [], next: nil}}
+
+      other ->
+        {:error, {:broker, :request_log, normalize(other)}}
+    end
+  end
+
+  defp egress_event(row) do
+    %{
+      id: row["id"],
+      at: parse_time(row["created_at"]),
+      method: row["method"],
+      host: row["host"],
+      path: row["path"],
+      service: presence(row["matched_service"]),
+      credential_keys: row["credential_keys"] || [],
+      status: row["status"],
+      latency_ms: row["latency_ms"],
+      error: presence(row["error_code"])
+    }
+  end
+
+  defp presence(nil), do: nil
+  defp presence(""), do: nil
+  defp presence(v), do: v
+
+  defp vault_exists?(vault) do
+    case Req.get(req(), url: "/v1/vaults/#{vault}/settings") do
+      {:ok, %{status: 200}} -> {:ok, true}
+      {:ok, %{status: 404}} -> {:ok, false}
+      other -> {:error, {:broker, :release, normalize(other)}}
+    end
+  end
+
+  defp revoke_sessions(vault) do
+    with {:ok, %{status: 200, body: %{"sessions" => sessions}}} <-
+           Req.get(req(), url: "/v1/sessions", params: [vault: vault]) do
+      Enum.reduce_while(sessions, :ok, fn %{"id" => id}, :ok ->
+        case Req.delete(req(), url: "/v1/sessions/#{id}", params: [vault: vault]) do
+          {:ok, %{status: status}} when status in 200..299 or status == 404 -> {:cont, :ok}
+          other -> {:halt, {:error, {:broker, :release, normalize(other)}}}
+        end
+      end)
+    else
+      other -> {:error, {:broker, :release, normalize(other)}}
+    end
+  end
+
+  defp clear_services(vault) do
+    case Req.delete(req(), url: "/v1/vaults/#{vault}/services") do
+      {:ok, %{status: status}} when status in 200..299 or status == 404 -> :ok
+      other -> {:error, {:broker, :release, normalize(other)}}
+    end
+  end
+
+  defp clear_credentials(vault) do
+    with {:ok, %{status: 200, body: %{"keys" => keys}}} <-
+           Req.get(req(), url: "/v1/credentials", params: [vault: vault]) do
+      if keys == [] do
+        :ok
+      else
+        case Req.delete(req(), url: "/v1/credentials", json: %{vault: vault, keys: keys}) do
+          {:ok, %{status: status}} when status in 200..299 -> :ok
+          other -> {:error, {:broker, :release, normalize(other)}}
+        end
+      end
+    else
       other -> {:error, {:broker, :release, normalize(other)}}
     end
   end

--- a/apps/fountain/lib/fountain/workers/broker_vault_reaper.ex
+++ b/apps/fountain/lib/fountain/workers/broker_vault_reaper.ex
@@ -1,0 +1,107 @@
+defmodule Fountain.Workers.BrokerVaultReaper do
+  @moduledoc """
+  Deletes a conversation's vault on the egress broker once its request log
+  has outlived `BROKER_LOG_RETENTION_HOURS` (ADR 0019 gate 4).
+
+  `Fountain.Broker.release/1` strips a vault at the end of a conversation but
+  keeps it, because the request log in it is the effect half of the audit
+  trail. Left alone, one vault per conversation would accumulate forever;
+  this pass, daily, deletes the ones whose conversation ended long enough
+  ago, and any vault of ours whose conversation no longer exists at all.
+
+  A no-op when the broker is not configured.
+  """
+
+  use Oban.Worker, queue: :maintenance, max_attempts: 1
+
+  import Ecto.Query
+
+  alias Fountain.Broker
+  alias Fountain.Conversations.Conversation
+  alias Fountain.Repo
+
+  require Logger
+
+  @ended ~w(terminated failed)
+
+  @impl Oban.Worker
+  def perform(_job) do
+    %{deleted: deleted, failed: failed} = run()
+
+    if deleted > 0 or failed > 0 do
+      Logger.info("broker vault reaper: deleted #{deleted} vault(s), #{failed} failed")
+    end
+
+    :ok
+  end
+
+  @doc "Reap now. `now:` pins the clock; `vaults:` skips the broker's vault listing (tests)."
+  @spec run(keyword()) :: %{
+          deleted: non_neg_integer(),
+          failed: non_neg_integer(),
+          kept: non_neg_integer()
+        }
+  def run(opts \\ []) do
+    if Broker.configured?() do
+      now = Keyword.get(opts, :now) || DateTime.utc_now()
+      cutoff = DateTime.add(now, -Broker.log_retention_hours() * 3600, :second)
+
+      case Keyword.get(opts, :vaults) || vaults() do
+        {:error, reason} ->
+          Logger.warning("broker vault reaper: could not list vaults: #{inspect(reason)}")
+          %{deleted: 0, failed: 0, kept: 0}
+
+        names ->
+          names |> Enum.filter(&Broker.conversation_id_for_vault/1) |> reap(cutoff)
+      end
+    else
+      %{deleted: 0, failed: 0, kept: 0}
+    end
+  end
+
+  defp vaults do
+    case Broker.list_vaults() do
+      {:ok, names} -> names
+      {:error, _} = err -> err
+    end
+  end
+
+  defp reap(names, cutoff) do
+    by_conv = Map.new(names, &{Broker.conversation_id_for_vault(&1), &1})
+    ids = Map.keys(by_conv)
+
+    live =
+      Repo.all(
+        from c in Conversation,
+          where: c.id in ^ids,
+          select: {c.id, c.status, c.updated_at}
+      )
+      |> Map.new(fn {id, status, at} -> {id, {status, at}} end)
+
+    Enum.reduce(by_conv, %{deleted: 0, failed: 0, kept: 0}, fn {conv_id, vault}, acc ->
+      case Map.get(live, conv_id) do
+        nil ->
+          delete(vault, acc)
+
+        {status, at} when status in @ended ->
+          if(DateTime.before?(at, cutoff), do: delete(vault, acc), else: keep(acc))
+
+        _ ->
+          keep(acc)
+      end
+    end)
+  end
+
+  defp keep(acc), do: %{acc | kept: acc.kept + 1}
+
+  defp delete(vault, acc) do
+    case Broker.delete_vault(vault) do
+      :ok ->
+        %{acc | deleted: acc.deleted + 1}
+
+      {:error, reason} ->
+        Logger.warning("broker vault reaper: #{vault}: #{inspect(reason)}")
+        %{acc | failed: acc.failed + 1}
+    end
+  end
+end

--- a/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
@@ -165,6 +165,75 @@ defmodule FountainWeb.ConversationController do
     ]
   )
 
+  operation(:egress,
+    summary: "List what the conversation sent out through the egress broker",
+    description:
+      "The broker's request log for this conversation, newest first: each " <>
+        "outbound HTTP request the sandbox made, the host, the service that " <>
+        "matched (and so which credential was attached), the status and " <>
+        "latency (ADR 0019 gate 4). Empty, with `brokered: false`, for a " <>
+        "conversation that was not brokered. The log outlives the conversation " <>
+        "for `BROKER_LOG_RETENTION_HOURS`.",
+    parameters: [
+      conversation_id: [in: :path, type: :string, required: true],
+      limit: [in: :query, type: :integer, description: "1 to 500, default 100"],
+      before: [
+        in: :query,
+        type: :integer,
+        description: "Page: the `next` value of the previous page"
+      ]
+    ],
+    responses: [
+      ok: {"Egress", "application/json", Schemas.EgressListResponse},
+      not_found: {"Not found", "application/json", Schemas.Error},
+      bad_gateway: {"The broker did not answer", "application/json", Schemas.Error}
+    ]
+  )
+
+  def egress(conn, %{"conversation_id" => id} = params) do
+    user = conn.assigns.current_user
+
+    case Conversations.get_conversation(id, user.id) do
+      nil ->
+        {:error, :not_found}
+
+      conv ->
+        if Fountain.Broker.enabled_for?(user.id) do
+          opts = [limit: egress_limit(params["limit"])] ++ egress_before(params["before"])
+
+          case Fountain.Broker.request_log(conv.id, opts) do
+            {:ok, %{events: events, next: next}} ->
+              render(conn, :egress, events: events, next: next, brokered: true)
+
+            {:error, reason} ->
+              conn
+              |> put_status(:bad_gateway)
+              |> json(%{error: "broker_unavailable", message: inspect(reason)})
+          end
+        else
+          render(conn, :egress, events: [], next: nil, brokered: false)
+        end
+    end
+  end
+
+  defp egress_limit(nil), do: 100
+
+  defp egress_limit(raw) do
+    case Integer.parse(to_string(raw)) do
+      {n, ""} when n in 1..500 -> n
+      _ -> 100
+    end
+  end
+
+  defp egress_before(nil), do: []
+
+  defp egress_before(raw) do
+    case Integer.parse(to_string(raw)) do
+      {n, ""} when n > 0 -> [before: n]
+      _ -> []
+    end
+  end
+
   def turns(conn, %{"conversation_id" => id}) do
     user = conn.assigns.current_user
 

--- a/apps/fountain/lib/fountain_web/controllers/conversation_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_json.ex
@@ -10,6 +10,10 @@ defmodule FountainWeb.ConversationJSON do
   def show(%{conversation: conv}), do: %{data: data(conv)}
   def turns(%{turns: turns}), do: %{data: Enum.map(turns, &turn_data/1)}
 
+  def egress(%{events: events, next: next, brokered: brokered}) do
+    %{data: events, next: next, brokered: brokered}
+  end
+
   def events(%{events: events, has_more: has_more?, limit: limit} = assigns) do
     blocks_runtime = Map.get(assigns, :blocks_runtime)
 

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -488,6 +488,8 @@ defmodule FountainWeb.Router do
       # the conversation is tenant-scoped before the request id is looked at.
       post "/requests/:request_id", ConversationController, :answer_request, as: :answer_request
       get "/tree", ConversationController, :tree, as: :tree
+      # What left the sandbox through the egress broker (ADR 0019 gate 4).
+      get "/egress", ConversationController, :egress, as: :egress
     end
   end
 

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -3353,6 +3353,64 @@ defmodule FountainWeb.Schemas do
     })
   end
 
+  defmodule EgressEvent do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "EgressEvent",
+      description:
+        "One outbound HTTP request the sandbox made through the egress broker " <>
+          "(ADR 0019). `service` names the binding that matched, and so which " <>
+          "credential was attached; null means the request passed through with none.",
+      type: :object,
+      properties: %{
+        id: %Schema{type: :integer},
+        at: %Schema{type: :string, format: :"date-time", nullable: true},
+        method: %Schema{type: :string},
+        host: %Schema{type: :string, description: "Host and port, as the sandbox dialed it."},
+        path: %Schema{type: :string},
+        service: %Schema{type: :string, nullable: true},
+        credential_keys: %Schema{type: :array, items: %Schema{type: :string}},
+        status: %Schema{
+          type: :integer,
+          nullable: true,
+          description: "The upstream status, or the broker's refusal."
+        },
+        latency_ms: %Schema{type: :integer, nullable: true},
+        error: %Schema{
+          type: :string,
+          nullable: true,
+          description: "The broker's error code, such as `no_match`, when it refused."
+        }
+      },
+      required: [:id, :method, :host, :path, :credential_keys]
+    })
+  end
+
+  defmodule EgressListResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "EgressListResponse",
+      type: :object,
+      properties: %{
+        data: %Schema{type: :array, items: EgressEvent},
+        next: %Schema{
+          type: :integer,
+          nullable: true,
+          description: "Pass as `before` for the next page; null at the end."
+        },
+        brokered: %Schema{
+          type: :boolean,
+          description: "False when the conversation was not brokered; `data` is then empty."
+        }
+      },
+      required: [:data, :brokered]
+    })
+  end
+
   list_response(SecretBindingListResponse, of: SecretBinding)
   list_response(SecretBindingPresetListResponse, of: SecretBindingPreset)
 

--- a/apps/fountain/test/fountain/broker_test.exs
+++ b/apps/fountain/test/fountain/broker_test.exs
@@ -586,19 +586,131 @@ defmodule Fountain.BrokerTest do
       assert {:ok, "-----BEGIN CERTIFICATE-----\n"} = Broker.ca_pem()
     end
 
-    test "release deletes the conversation's vault, and a missing one is already released" do
+    test "release revokes sessions, clears services and credentials, and keeps the vault" do
+      test = self()
+      vault = Broker.vault_name(@conv)
+
+      stub(Req, :get, fn _r, opts ->
+        case opts[:url] do
+          "/v1/vaults/" <> _ ->
+            {:ok, %{status: 200, body: %{"unmatched_host_policy" => "deny"}}}
+
+          "/v1/sessions" ->
+            {:ok, %{status: 200, body: %{"sessions" => [%{"id" => "s1"}, %{"id" => "s2"}]}}}
+
+          "/v1/credentials" ->
+            {:ok, %{status: 200, body: %{"keys" => ["GITHUB_TOKEN", "GITHUB_TOKEN_BASIC_USER"]}}}
+        end
+      end)
+
       stub(Req, :delete, fn _r, opts ->
-        assert opts[:url] == "/v1/vaults/" <> Broker.vault_name(@conv)
-        {:ok, %{status: 200, body: %{"deleted" => true}}}
+        send(test, {:deleted, opts[:url], opts[:params], opts[:json]})
+        {:ok, %{status: 200, body: %{}}}
       end)
 
       assert :ok = Broker.release(@conv)
 
-      stub(Req, :delete, fn _r, _o -> {:ok, %{status: 404, body: %{}}} end)
+      assert_received {:deleted, "/v1/sessions/s1", [vault: ^vault], nil}
+      assert_received {:deleted, "/v1/sessions/s2", [vault: ^vault], nil}
+      assert_received {:deleted, "/v1/vaults/" <> _ = svc, nil, nil}
+      assert String.ends_with?(svc, "/services")
+
+      assert_received {:deleted, "/v1/credentials", nil,
+                       %{vault: ^vault, keys: ["GITHUB_TOKEN", "GITHUB_TOKEN_BASIC_USER"]}}
+
+      # The vault itself is never deleted here: its request log is the trail.
+      refute_received {:deleted, "/v1/vaults/" <> ^vault, _, _}
+    end
+
+    test "release of a vault that is gone is already done; a transport error surfaces" do
+      stub(Req, :get, fn _r, _o -> {:ok, %{status: 404, body: %{}}} end)
       assert :ok = Broker.release(@conv)
 
-      stub(Req, :delete, fn _r, _o -> {:error, :timeout} end)
+      stub(Req, :get, fn _r, _o -> {:error, :timeout} end)
       assert {:error, {:broker, :release, :timeout}} = Broker.release(@conv)
+    end
+
+    test "delete_vault and list_vaults are the reaper's calls" do
+      stub(Req, :delete, fn _r, opts ->
+        assert opts[:url] == "/v1/vaults/c-abc"
+        {:ok, %{status: 200, body: %{"deleted" => true}}}
+      end)
+
+      assert :ok = Broker.delete_vault("c-abc")
+
+      stub(Req, :get, fn _r, _o ->
+        {:ok, %{status: 200, body: %{"vaults" => [%{"name" => "default"}, %{"name" => "c-x"}]}}}
+      end)
+
+      assert {:ok, ["default", "c-x"]} = Broker.list_vaults()
+    end
+
+    test "conversation_id_for_vault/1 reverses vault_name/1" do
+      assert Broker.conversation_id_for_vault(Broker.vault_name(@conv)) == @conv
+      assert Broker.conversation_id_for_vault("default") == nil
+      assert Broker.conversation_id_for_vault("c-nothex") == nil
+    end
+
+    test "request_log/2 normalises the broker's rows, newest first, with a cursor" do
+      stub(Req, :get, fn _r, opts ->
+        assert opts[:url] == "/v1/vaults/" <> Broker.vault_name(@conv) <> "/logs"
+        assert opts[:params] == [limit: 2, before: 9]
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "latest_id" => 8,
+             "next_cursor" => 6,
+             "logs" => [
+               %{
+                 "id" => 8,
+                 "created_at" => "2026-08-25T10:00:00Z",
+                 "method" => "GET",
+                 "host" => "api.github.com:443",
+                 "path" => "/user",
+                 "matched_service" => "github-api",
+                 "credential_keys" => ["GITHUB_TOKEN"],
+                 "status" => 200,
+                 "latency_ms" => 120,
+                 "error_code" => ""
+               },
+               %{
+                 "id" => 7,
+                 "created_at" => "2026-08-25T09:59:00Z",
+                 "method" => "CONNECT",
+                 "host" => "example.com:443",
+                 "path" => "",
+                 "matched_service" => "",
+                 "credential_keys" => [],
+                 "status" => 403,
+                 "latency_ms" => 1,
+                 "error_code" => "no_match"
+               }
+             ]
+           }
+         }}
+      end)
+
+      assert {:ok, %{events: [a, b], next: 6}} = Broker.request_log(@conv, limit: 2, before: 9)
+
+      assert %{
+               id: 8,
+               host: "api.github.com:443",
+               service: "github-api",
+               credential_keys: ["GITHUB_TOKEN"],
+               status: 200,
+               error: nil
+             } = a
+
+      assert %DateTime{hour: 10} = a.at
+      assert %{id: 7, service: nil, status: 403, error: "no_match"} = b
+
+      stub(Req, :get, fn _r, _o ->
+        {:ok, %{status: 404, body: %{"error" => "Vault not found"}}}
+      end)
+
+      assert {:ok, %{events: [], next: nil}} = Broker.request_log(@conv)
     end
   end
 end

--- a/apps/fountain/test/fountain/workers/broker_vault_reaper_test.exs
+++ b/apps/fountain/test/fountain/workers/broker_vault_reaper_test.exs
@@ -1,0 +1,78 @@
+defmodule Fountain.Workers.BrokerVaultReaperTest do
+  use Fountain.DataCase, async: false
+  use Mimic
+
+  alias Fountain.Broker
+  alias Fountain.Workers.BrokerVaultReaper
+
+  setup do
+    previous =
+      for k <- [:broker_url, :broker_token, :broker_proxy_url],
+          do: {k, Application.get_env(:fountain, k)}
+
+    on_exit(fn ->
+      for {k, v} <- previous,
+          do:
+            if(is_nil(v),
+              do: Application.delete_env(:fountain, k),
+              else: Application.put_env(:fountain, k, v)
+            )
+    end)
+
+    :ok
+  end
+
+  test "a no-op with the broker off" do
+    Application.delete_env(:fountain, :broker_url)
+    reject(Broker, :list_vaults, 0)
+    assert %{deleted: 0, failed: 0, kept: 0} = BrokerVaultReaper.run()
+  end
+
+  test "deletes vaults of conversations ended past retention, and orphans; keeps the rest" do
+    Application.put_env(:fountain, :broker_url, "http://broker.test:14321")
+    Application.put_env(:fountain, :broker_token, "t")
+    Application.put_env(:fountain, :broker_proxy_url, "http://broker.test:14322")
+
+    user = insert_verified_user()
+    now = ~U[2026-08-25 12:00:00Z]
+    old = DateTime.add(now, -200 * 3600, :second)
+
+    ended_long_ago = insert_conversation(user_id: user.id, status: "terminated")
+
+    Repo.update_all(
+      from(c in Fountain.Conversations.Conversation, where: c.id == ^ended_long_ago.id),
+      set: [updated_at: old]
+    )
+
+    ended_recently = insert_conversation(user_id: user.id, status: "failed")
+    running = insert_conversation(user_id: user.id, status: "running")
+
+    Repo.update_all(from(c in Fountain.Conversations.Conversation, where: c.id == ^running.id),
+      set: [updated_at: old]
+    )
+
+    orphan = Broker.vault_name(Ecto.UUID.generate())
+
+    test = self()
+
+    stub(Broker, :delete_vault, fn v ->
+      send(test, {:deleted, v})
+      :ok
+    end)
+
+    vaults = [
+      "default",
+      Broker.vault_name(ended_long_ago.id),
+      Broker.vault_name(ended_recently.id),
+      Broker.vault_name(running.id),
+      orphan
+    ]
+
+    assert %{deleted: 2, failed: 0, kept: 2} = BrokerVaultReaper.run(now: now, vaults: vaults)
+
+    assert_received {:deleted, v1}
+    assert_received {:deleted, v2}
+    assert Enum.sort([v1, v2]) == Enum.sort([Broker.vault_name(ended_long_ago.id), orphan])
+    refute_received {:deleted, _}
+  end
+end

--- a/apps/fountain/test/fountain_web/controllers/conversation_egress_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/conversation_egress_test.exs
@@ -1,0 +1,98 @@
+defmodule FountainWeb.ConversationEgressTest do
+  use FountainWeb.ConnCase, async: false
+  use Mimic
+
+  alias Fountain.Broker
+
+  setup %{conn: conn} do
+    user = insert_verified_user()
+    {:ok, {_key, raw}} = Fountain.Accounts.create_api_key(user.id, "t")
+    conv = insert_conversation(user_id: user.id)
+
+    previous =
+      for k <- [:broker_url, :broker_token, :broker_proxy_url, :broker_tenants],
+          do: {k, Application.get_env(:fountain, k)}
+
+    on_exit(fn ->
+      for {k, v} <- previous,
+          do:
+            if(is_nil(v),
+              do: Application.delete_env(:fountain, k),
+              else: Application.put_env(:fountain, k, v)
+            )
+    end)
+
+    Application.put_env(:fountain, :broker_url, "http://broker.test:14321")
+    Application.put_env(:fountain, :broker_token, "t")
+    Application.put_env(:fountain, :broker_proxy_url, "http://broker.test:14322")
+    Application.put_env(:fountain, :broker_tenants, [user.id])
+
+    conn =
+      conn
+      |> put_req_header("authorization", "Bearer #{raw}")
+      |> put_req_header("accept", "application/json")
+
+    {:ok, conn: conn, user: user, conv: conv}
+  end
+
+  test "another tenant's conversation is not found", %{conn: conn} do
+    other = insert_conversation(user_id: insert_verified_user().id)
+    reject(Broker, :request_log, 2)
+    assert conn |> get("/api/conversations/#{other.id}/egress") |> json_response(404)
+  end
+
+  test "an unbrokered account gets an empty page that says so", %{conn: conn, conv: conv} do
+    Application.put_env(:fountain, :broker_tenants, [])
+    reject(Broker, :request_log, 2)
+
+    assert %{"data" => [], "brokered" => false} =
+             conn |> get("/api/conversations/#{conv.id}/egress") |> json_response(200)
+  end
+
+  test "a brokered conversation gets the broker's rows and a cursor", %{conn: conn, conv: conv} do
+    expect(Broker, :request_log, fn id, opts ->
+      assert id == conv.id
+      assert opts == [limit: 2, before: 9]
+
+      {:ok,
+       %{
+         events: [
+           %{
+             id: 8,
+             at: ~U[2026-08-25 10:00:00Z],
+             method: "GET",
+             host: "api.github.com:443",
+             path: "/user",
+             service: "github-api",
+             credential_keys: ["GITHUB_TOKEN"],
+             status: 200,
+             latency_ms: 120,
+             error: nil
+           }
+         ],
+         next: 6
+       }}
+    end)
+
+    assert %{"data" => [row], "next" => 6, "brokered" => true} =
+             conn
+             |> get("/api/conversations/#{conv.id}/egress?limit=2&before=9")
+             |> json_response(200)
+
+    assert %{
+             "host" => "api.github.com:443",
+             "service" => "github-api",
+             "credential_keys" => ["GITHUB_TOKEN"],
+             "status" => 200
+           } = row
+  end
+
+  test "a broker that does not answer is a 502, not a 500", %{conn: conn, conv: conv} do
+    expect(Broker, :request_log, fn _id, _opts ->
+      {:error, {:broker, :request_log, :econnrefused}}
+    end)
+
+    assert %{"error" => "broker_unavailable"} =
+             conn |> get("/api/conversations/#{conv.id}/egress") |> json_response(502)
+  end
+end

--- a/config/config.exs
+++ b/config/config.exs
@@ -33,6 +33,7 @@ config :fountain, Oban,
        # credential; the notice window is days wide, so the hour is about
        # being read, not about precision.
        {"7 17 * * *", Fountain.Workers.SecretExpirySweeper},
+       {"31 3 * * *", Fountain.Workers.BrokerVaultReaper},
        # Every minute: the tick for user-defined team schedules. Cheap — one
        # indexed query, usually empty — and a minute is the cron grain the
        # schedules are written in.

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -215,6 +215,20 @@ config :fountain, :broker_tenants, broker_tenants
 config :fountain, :broker_session_ttl_seconds, broker_session_ttl
 config :fountain, :broker_allow_unenforced, System.get_env("BROKER_ALLOW_UNENFORCED") == "true"
 
+broker_log_retention =
+  case System.get_env("BROKER_LOG_RETENTION_HOURS") do
+    blank when blank in [nil, ""] ->
+      168
+
+    raw ->
+      case Integer.parse(raw) do
+        {n, ""} when n >= 1 -> n
+        _ -> raise "BROKER_LOG_RETENTION_HOURS must be a positive integer"
+      end
+  end
+
+config :fountain, :broker_log_retention_hours, broker_log_retention
+
 # Self-hosted runners (ADR 0022) need no platform credential; the switch is an
 # operator opt-out. Blank counts as unset (enabled).
 runners_enabled =

--- a/decisions/0019-egress-credential-brokerage.md
+++ b/decisions/0019-egress-credential-brokerage.md
@@ -23,8 +23,8 @@ published at `broker.inevitable.fyi` by the Traefik TCP router of §11), and
 the hosted deployment names **one** tenant, the maintainer's own account
 (home-cloud#131, 2026-08-25). Its done-when was observed on a production
 Sprites conversation the same day — see *Gate 1a* under *Gates*. Everyone else
-is byte-for-byte on the old path. Gates 1b (bindings), 2 (`limited` at the broker) and 3 (inference
-credentials) are built; 4 is not. #1090 is closed and each
+is byte-for-byte on the old path. Every gate is built: 1a and 1b (placeholders, bindings), 2 (`limited` at the
+broker), 3 (inference credentials) and 4 (the egress trail). #1090 is closed and each
 later gate gets its own tracker.
 
 **Revised 2026-08-25 (gate 1a).** Building it changed three things below,
@@ -651,14 +651,18 @@ encodes the value. 0016 §4's second purpose (metering) remains a separate
 decision. Not verified live yet: whether `codex login --with-api-key` accepts
 the placeholder, and OpenCode's own gateway host.
 
-**Gate 4 — the joined trail.** Broker request log correlated to Conversation, and
-whatever surface makes the effect half readable next to the intent half. Gate 0
-read that log: it carries `matched_service`, `credential_keys`, `status` and
-`latency_ms`, and it carries `actor_type` and `actor_id` that come back
-**empty** for a vault-scoped session. So the join needs something the session
-alone does not give — an agent entity per conversation, or a vault per
-conversation — and that choice belongs at the front of this gate rather than
-at the end of it.
+**Gate 4 — built 2026-08-25.** The join is the vault name: §11's vault per
+conversation is exactly what the empty `actor_*` fields on a session-scoped
+row needed. `GET /api/conversations/:id/egress` returns the broker's request
+log for the conversation, newest first — host, matched service (and so which
+credential was attached), status, latency, and the broker's refusal code —
+beside the intent half in `/events`. To keep the log, `Broker.release/1` no
+longer deletes the vault at the end of a conversation: it revokes the
+sessions and clears the credentials and services, and
+`Fountain.Workers.BrokerVaultReaper` deletes the vault once the conversation
+has been over for `BROKER_LOG_RETENTION_HOURS` (168 by default, at or below
+the broker's own retention), along with any vault of ours whose conversation
+no longer exists.
 
 Gates 0–2 are the security argument and are worth building on their own. Gates 3
 and 4 are where this ADR meets 0016, and neither is blocked on any ACP work.

--- a/docs/concepts/secrets.md
+++ b/docs/concepts/secrets.md
@@ -177,6 +177,12 @@ too. `CLAUDE_CODE_OAUTH_TOKEN` and `ANTHROPIC_API_KEY` go to
 placeholder that keeps the vendor's prefix, such as
 `sk-ant-oat01-__claude_code_oauth_token__`.
 
+After a conversation, `GET /api/conversations/:id/egress` lists what left the
+sandbox through the broker. Each row shows the host, the binding that matched
+and so the credential attached, the status, and the latency. A refused host
+shows the refusal. The list stays for `BROKER_LOG_RETENTION_HOURS` after the
+conversation ends.
+
 You manage bindings on Account, then Credential bindings, or with
 `GET /api/secret-bindings` and its siblings. The page and the routes are only
 there when the broker is on for the account. A binding is about the name of

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -53,6 +53,7 @@ message.
 | `BROKER_PROXY_URL` | — | With `BROKER_URL`. | The proxy address a sandbox dials, for example `http://broker.example.com:14322`. It is not the same as `BROKER_URL` when the sandboxes are on a different network from Fountain. Its host is the one host a brokered sandbox may reach. |
 | `BROKER_TENANTS` | — | — | A comma separated list of user ids. Fountain brokers the conversations of these users. All other users provision as before. This is the operator ratchet of ADR 0019, and it is not a tenant setting. |
 | `BROKER_SESSION_TTL_SECONDS` | `21600` | — | How long a proxy session token lives. Fountain mints a new one on each provision and each reattach, and again before a turn when the current one is near its end. Agent Vault accepts 300 to 604800. |
+| `BROKER_LOG_RETENTION_HOURS` | `168` | — | How long a conversation's vault on the broker keeps its request log after the conversation ends. `GET /api/conversations/:id/egress` reads it. A daily job deletes older vaults. Keep it at or below the broker's own log retention. |
 | `BROKER_ALLOW_UNENFORCED` | `false` | — | A `true` lets a brokered conversation run on a provider that has no network policy, for example a self-hosted runner. The sandbox then holds placeholders and a proxy address, but nothing stops a process from a direct connection that avoids the proxy. For development only. |
 | `E2B_API_KEY` | — | For the `e2b` provider. | The [E2B](https://e2b.dev) API key. Its presence turns the provider on. |
 | `E2B_BASE_URL` | `https://api.e2b.app` | — | Repoints the E2B control plane. |

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -10,6 +10,13 @@ server releases.
 
 ---
 
+## [1.5.0] — 2026-08-25
+
+### Added
+
+- Generated types for `GET /api/conversations/:id/egress`: what a brokered
+  conversation sent out through the egress broker (ADR 0019 gate 4).
+
 ## [1.4.0] — 2026-08-25
 
 ### Changed

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentshit/fountain-sdk",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Run a coding agent on a real computer, with your repos and your credentials, in one call.",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -1251,6 +1251,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/conversations/{conversation_id}/egress": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List what the conversation sent out through the egress broker
+         * @description The broker's request log for this conversation, newest first: each outbound HTTP request the sandbox made, the host, the service that matched (and so which credential was attached), the status and latency (ADR 0019 gate 4). Empty, with `brokered: false`, for a conversation that was not brokered. The log outlives the conversation for `BROKER_LOG_RETENTION_HOURS`.
+         */
+        get: operations["FountainWeb.ConversationController.egress"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/conversations/{conversation_id}/events": {
         parameters: {
             query?: never;
@@ -2406,6 +2426,26 @@ export interface components {
             data: components["schemas"]["Turn"][];
         };
         /**
+         * EgressEvent
+         * @description One outbound HTTP request the sandbox made through the egress broker (ADR 0019). `service` names the binding that matched, and so which credential was attached; null means the request passed through with none.
+         */
+        EgressEvent: {
+            /** Format: date-time */
+            at?: string | null;
+            credential_keys: string[];
+            /** @description The broker's error code, such as `no_match`, when it refused. */
+            error?: string | null;
+            /** @description Host and port, as the sandbox dialed it. */
+            host: string;
+            id: number;
+            latency_ms?: number | null;
+            method: string;
+            path: string;
+            service?: string | null;
+            /** @description The upstream status, or the broker's refusal. */
+            status?: number | null;
+        };
+        /**
          * Export
          * @description An account data export. Built asynchronously; the payload is fetched from the download endpoint, never embedded here.
          */
@@ -3218,6 +3258,14 @@ export interface components {
                 per_page: number;
                 total: number;
             };
+        };
+        /** EgressListResponse */
+        EgressListResponse: {
+            /** @description False when the conversation was not brokered; `data` is then empty. */
+            brokered: boolean;
+            data: components["schemas"]["EgressEvent"][];
+            /** @description Pass as `before` for the next page; null at the end. */
+            next?: number | null;
         };
         /** VaultResponse */
         VaultResponse: {
@@ -7295,6 +7343,51 @@ export interface operations {
             };
             /** @description No such endpoint on this account */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    "FountainWeb.ConversationController.egress": {
+        parameters: {
+            query?: {
+                /** @description 1 to 500, default 100 */
+                limit?: number;
+                /** @description Page: the `next` value of the previous page */
+                before?: number;
+            };
+            header?: never;
+            path: {
+                conversation_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Egress */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EgressListResponse"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description The broker did not answer */
+            502: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/sdk/typescript/src/http.ts
+++ b/sdk/typescript/src/http.ts
@@ -19,7 +19,7 @@ export interface RequestOptions {
  * this string is already what Fountain's request logs are keyed on. The
  * version half is asserted against `package.json` by a test.
  */
-export const USER_AGENT = "fountain-sdk-js/1.4.0";
+export const USER_AGENT = "fountain-sdk-js/1.5.0";
 
 /**
  * The thin layer everything else is built on: one bearer token, JSON in and


### PR DESCRIPTION
Gate 4 of [ADR 0019](decisions/0019-egress-credential-brokerage.md): the effect half of the audit trail, joined to the conversation.

- **The join is the vault name** — §11's vault per conversation is exactly what the empty `actor_*` fields on session-scoped log rows needed.
- **`GET /api/conversations/:id/egress`**: the broker's request log for the conversation, newest first — host, matched service (and so which credential was attached), status, latency, and the broker's refusal code (`no_match` under `limited`). `limit`/`before` paging. `brokered: false` with an empty page for an unbrokered account; 404 for someone else's conversation; 502 `broker_unavailable` when the broker doesn't answer.
- **The log survives the conversation**: `Broker.release/1` now revokes sessions and clears credentials and services but keeps the vault. `Fountain.Workers.BrokerVaultReaper` (Oban, daily) deletes vaults whose conversation ended more than `BROKER_LOG_RETENTION_HOURS` (168) ago, and any vault of ours whose conversation no longer exists. No-op with the broker off.
- OpenAPI schemas, SDK 1.5.0 (types only), docs section, CHANGELOG, ADR gate 4 paragraph — the ADR's status block now says every gate is built.

Tests: broker (release strips-and-keeps, request_log normalisation, list/delete vault, name↔id), reaper (ended-past-retention + orphan deleted; recent and running kept; no-op off), controller (404 / unbrokered / rows+cursor / 502), api spec, config reference. compile `-Werror`, credo, dialyzer, format, vale 0/0, docs-style, sobelow, `okf validate`, SDK guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)