### PR TITLE
fix(broker): one service per host, carrying every bound key's substitution

### DIFF
--- a/apps/fountain/lib/fountain/broker.ex
+++ b/apps/fountain/lib/fountain/broker.ex
@@ -276,7 +276,30 @@ defmodule Fountain.Broker do
         []
       end
 
-    bound ++ catalog
+    merge_by_host(bound ++ catalog)
+  end
+
+  # The broker matches exactly one service per host, so two keys bound to
+  # the same host must share one entry: the first declared keeps its name
+  # and auth shape, and the substitutions of every key are carried together.
+  # Found live: an account with both an Anthropic API key and an OAuth token
+  # got two services for api.anthropic.com, the API-key one won, and the
+  # OAuth placeholder went through unreplaced — a 401.
+  defp merge_by_host(services) do
+    services
+    |> Enum.reduce([], fn svc, acc ->
+      case Enum.find_index(acc, &(&1.host == svc.host)) do
+        nil ->
+          acc ++ [svc]
+
+        i ->
+          List.update_at(acc, i, fn kept ->
+            subs = Enum.uniq_by(kept.substitutions ++ svc.substitutions, & &1.key)
+            auth = if kept.auth == %{type: "passthrough"}, do: svc.auth, else: kept.auth
+            %{kept | substitutions: subs, auth: auth}
+          end)
+      end
+    end)
   end
 
   # Both names may be present after the merge; the git URL is written with

--- a/apps/fountain/test/fountain/broker_test.exs
+++ b/apps/fountain/test/fountain/broker_test.exs
@@ -545,6 +545,47 @@ defmodule Fountain.BrokerTest do
       assert Broker.placeholder("GITHUB_TOKEN") == "__github_token__"
     end
 
+    test "two keys bound to one host share one service carrying both substitutions" do
+      capture_services()
+
+      creds = %{
+        claude_code_oauth_token: "sk-ant-oat01-real",
+        anthropic_api_key: "sk-ant-api03-real"
+      }
+
+      {_env_creds, brokered, implicit} = Broker.split_inference(creds)
+
+      assert {:ok, _} = Broker.prepare(@conv, brokered, implicit)
+      assert_received {:services, services}
+
+      assert [%{host: "api.anthropic.com", substitutions: subs}] = services
+
+      assert Enum.sort(Enum.map(subs, & &1.placeholder)) ==
+               ["sk-ant-api03-__anthropic_api_key__", "sk-ant-oat01-__claude_code_oauth_token__"]
+    end
+
+    test "merging keeps a header shape over a substitute-only twin" do
+      capture_services()
+
+      bindings = %{
+        "A_KEY" => [bound(%{key: "A_KEY", host: "api.example.com", auth_type: "substitute"})],
+        "B_KEY" => [bound(%{key: "B_KEY", host: "api.example.com", auth_type: "bearer"})]
+      }
+
+      assert {:ok, _} = Broker.prepare(@conv, %{"A_KEY" => "a", "B_KEY" => "b"}, bindings)
+
+      assert_received {:services,
+                       [
+                         %{
+                           host: "api.example.com",
+                           auth: %{type: "bearer", token: "B_KEY"},
+                           substitutions: subs
+                         }
+                       ]}
+
+      assert Enum.sort(Enum.map(subs, & &1.key)) == ["A_KEY", "B_KEY"]
+    end
+
     test "service_name/2 is a stable broker slug" do
       assert Broker.service_name("STRIPE_SECRET_KEY", "api.stripe.com:443/v1/*") ==
                "stripe-secret-key-api-stripe-com-443-v1"


### PR DESCRIPTION
Found by the gate 3 production smoke on my account: with both an Anthropic API key and a Claude OAuth token on file, `split_inference/2` produced two implicit bindings for `api.anthropic.com`. The broker matches exactly one service per host and kept the API-key one, so the OAuth placeholder (`sk-ant-oat01-__claude_code_oauth_token__`) went upstream unreplaced — `401 OAuth access token is invalid`. The placeholder was in the sandbox and the real token was not, so the custody half was right; the substitution half wasn't.

`services_for/2` now merges services by host: the first declared keeps its name and auth shape (a header shape wins over a substitute-only twin), and the substitutions of every key bound to that host ride together. Two tests cover both merges. Same applies to any two tenant bindings on one host.

Static gates green; I'll re-run the production smoke once this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)