### PR TITLE
fix(runtimes): opencode is pinned by its canonical model id over ACP

### DIFF
--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -3304,7 +3304,12 @@ defmodule Fountain.Conversations.ConversationServer do
                         buzz_mcp_servers(state) ++
                         team_mcp_servers(state) ++
                         team_comms_mcp_servers(state),
-                    model: agent && Fountain.Runtimes.Model.id(agent.model),
+                    model:
+                      agent &&
+                        Fountain.Runtimes.Model.acp_model(
+                          conv.runtime || agent.runtime,
+                          agent.model
+                        ),
                     permission_policy: effective_permission_policy(conv, agent)
                   )
                 else

--- a/apps/fountain/lib/fountain/runtimes/model.ex
+++ b/apps/fountain/lib/fountain/runtimes/model.ex
@@ -189,4 +189,24 @@ defmodule Fountain.Runtimes.Model do
   end
 
   def model_args(_agent), do: []
+
+  @doc """
+  The id to pin over ACP (`session/set_model` or the `model` config option).
+
+  A single-provider runtime names its models bare (`claude-sonnet-4-6`); a
+  multi-provider one (opencode) only knows them by the canonical
+  `provider/model_id`, and a bare id is "model not found" there — after which
+  opencode quietly falls back to its own default over its own gateway, and
+  the provider the tenant configured is never called. Measured live on
+  2026-08-25 with the egress broker's log in front of it.
+  """
+  def acp_model(runtime, model) when is_binary(runtime) do
+    case {provider_for_runtime(runtime), split(model)} do
+      {_, {nil, nil}} -> nil
+      {nil, _} -> model
+      {_provider, {_, id}} -> id
+    end
+  end
+
+  def acp_model(_runtime, model), do: id(model)
 end

--- a/apps/fountain/test/fountain/runtimes/model_test.exs
+++ b/apps/fountain/test/fountain/runtimes/model_test.exs
@@ -100,6 +100,25 @@ defmodule Fountain.Runtimes.ModelTest do
     end
   end
 
+  describe "acp_model/2" do
+    test "a single-provider runtime gets the bare id" do
+      assert Runtimes.Model.acp_model("claude", "anthropic/claude-sonnet-4-6") ==
+               "claude-sonnet-4-6"
+
+      assert Runtimes.Model.acp_model("codex", "openai/gpt-5.3-codex") == "gpt-5.3-codex"
+    end
+
+    test "opencode gets the canonical id, the only name it knows a model by" do
+      assert Runtimes.Model.acp_model("opencode", "anthropic/claude-sonnet-4-6") ==
+               "anthropic/claude-sonnet-4-6"
+    end
+
+    test "no parseable model, nothing to pin" do
+      assert Runtimes.Model.acp_model("opencode", "claude-sonnet-4-6") == nil
+      assert Runtimes.Model.acp_model("claude", nil) == nil
+    end
+  end
+
   describe "model_args/1" do
     test "strips the provider prefix" do
       assert Runtimes.Model.model_args(agent("claude", "anthropic/claude-sonnet-4-6")) ==


### PR DESCRIPTION
Found while verifying ADR 0019 gate 3 on opencode. Fountain pins the model over ACP with `Model.id(agent.model)` — the bare id — for every runtime. opencode is the one multi-provider runtime and only knows a model as `provider/model_id`; it answered `Invalid params: model not found: claude-sonnet-4-6`, then quietly fell back to its own default over its own gateway (`opencode.ai/zen/v1/chat/completions`, no credential). The provider the tenant configured was never called. The broker's request log is what made this visible.

`Model.acp_model/2`: bare id for a single-provider runtime, the canonical string for opencode, nil when there is nothing parseable. Used at the ACP spawn with `conv.runtime || agent.runtime`. Three unit tests; peer and ACP server suites unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)