### PR TITLE
fix(broker): sudo keeps the proxy variables, so setup scripts can apt-get

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,7 @@ upgrade, is in
 
 ### Fixed
 
-- A brokered sandbox lets `sudo` keep the proxy variables (a sudoers `env_keep` drop-in, installed beside the broker CA), so a setup script's `sudo apt-get install` reaches a mirror. Before, sudo's `env_reset` stripped `http_proxy`, apt resolved the mirror directly and the broker floor refused it with `Temporary failure resolving`; the first brokered provisions of real environments failed there. (#1156)
+- A brokered sandbox lets `sudo` keep the proxy variables (a sudoers `env_keep` drop-in, installed beside the broker CA), so a setup script's `sudo apt-get install` reaches a mirror. Before, sudo's `env_reset` stripped `http_proxy`, apt resolved the mirror directly and the broker floor refused it with `Temporary failure resolving`; the first brokered provisions of real environments failed there. (#1158)
 
 - **Billing debt 1/3: the month is half-open, one gate, one cap rule.**
   `Billing.month_range/2` replaces four hand-rolled month windows; its `end`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,8 @@ upgrade, is in
 
 ### Fixed
 
+- A brokered sandbox lets `sudo` keep the proxy variables (a sudoers `env_keep` drop-in, installed beside the broker CA), so a setup script's `sudo apt-get install` reaches a mirror. Before, sudo's `env_reset` stripped `http_proxy`, apt resolved the mirror directly and the broker floor refused it with `Temporary failure resolving`; the first brokered provisions of real environments failed there. (#1156)
+
 - **Billing debt 1/3: the month is half-open, one gate, one cap rule.**
   `Billing.month_range/2` replaces four hand-rolled month windows; its `end`
   is the first instant of the next month, so the last second of every month

--- a/apps/fountain/lib/fountain/conversations/provisioning.ex
+++ b/apps/fountain/lib/fountain/conversations/provisioning.ex
@@ -393,11 +393,23 @@ defmodule Fountain.Conversations.Provisioning do
   end
 
   @doc """
-  Put the broker's root CA in the sandbox's operating-system trust store.
+  Put the broker's root CA in the sandbox's operating-system trust store,
+  and let `sudo` keep the proxy variables.
+
   Gate 0 found that one `update-ca-certificates` satisfies curl, git and npm
   at once, where per-tool variables each fail in their own way. Node is the
   exception and reads `NODE_EXTRA_CA_CERTS`, which `Fountain.Broker.sandbox_env/1`
   points at the same file.
+
+  The sudoers drop-in is what lets a setup script's `sudo apt-get install`
+  reach a mirror at all: sudo's `env_reset` strips `http_proxy` and friends,
+  apt then resolves the mirror directly, and the broker floor (only the
+  broker's host is reachable) refuses it as `Temporary failure resolving`.
+  The first brokered provisions of a real environment failed exactly there.
+  `env_keep` preserves the variables for the sudo'd process without writing
+  the session token anywhere, which an `apt.conf` proxy entry would do. The
+  file is checked with `visudo -c` before it is installed, since a bad
+  sudoers fragment disables sudo outright.
   """
   @spec install_broker_ca(Handle.t(), String.t()) :: :ok | {:error, term()}
   def install_broker_ca(handle, conv_id) do
@@ -408,7 +420,7 @@ defmodule Fountain.Conversations.Provisioning do
     # trust directory the way `install_packages/4` reaches apt: through sudo.
     install =
       "sudo install -D -m 644 #{shell_quote(staging)} #{shell_quote(path)} && " <>
-        "sudo update-ca-certificates"
+        "sudo update-ca-certificates && " <> sudo_env_keep_command()
 
     with {:ok, pem} <- Fountain.Broker.ca_pem(),
          :ok <-
@@ -436,6 +448,22 @@ defmodule Fountain.Conversations.Provisioning do
         publish_stage(conv_id, "broker", "failed", %{reason: inspect(reason)})
         err
     end
+  end
+
+  @sudoers_staging "/tmp/fountain-broker-proxy.sudoers"
+  @sudoers_path "/etc/sudoers.d/fountain-broker-proxy"
+
+  @doc "The sudoers drop-in that keeps `Fountain.Broker.env_keys/0` across `sudo`."
+  @spec sudoers_path() :: String.t()
+  def sudoers_path, do: @sudoers_path
+
+  defp sudo_env_keep_command do
+    keep = Enum.join(Fountain.Broker.env_keys(), " ")
+    line = ~s(Defaults env_keep += "#{keep}")
+
+    "printf '%s\\n' #{shell_quote(line)} > #{shell_quote(@sudoers_staging)} && " <>
+      "sudo visudo -cf #{shell_quote(@sudoers_staging)} && " <>
+      "sudo install -m 440 #{shell_quote(@sudoers_staging)} #{shell_quote(@sudoers_path)}"
   end
 
   @doc """

--- a/apps/fountain/test/fountain/conversations/provisioning_test.exs
+++ b/apps/fountain/test/fountain/conversations/provisioning_test.exs
@@ -181,7 +181,33 @@ defmodule Fountain.Conversations.ProvisioningTest do
 
       assert cmd ==
                "sudo install -D -m 644 '/tmp/agent-vault-ca.crt' " <>
-                 "'/usr/local/share/ca-certificates/agent-vault.crt' && sudo update-ca-certificates"
+                 "'/usr/local/share/ca-certificates/agent-vault.crt' && sudo update-ca-certificates && " <>
+                 "printf '%s\\n' 'Defaults env_keep += \"HTTPS_PROXY HTTP_PROXY https_proxy http_proxy " <>
+                 "NO_PROXY NODE_EXTRA_CA_CERTS\"' > '/tmp/fountain-broker-proxy.sudoers' && " <>
+                 "sudo visudo -cf '/tmp/fountain-broker-proxy.sudoers' && " <>
+                 "sudo install -m 440 '/tmp/fountain-broker-proxy.sudoers' '/etc/sudoers.d/fountain-broker-proxy'"
+    end
+
+    test "sudo keeps every proxy variable the broker sets, so `sudo apt-get` reaches a mirror" do
+      conv = insert_conversation()
+      test = self()
+
+      stub(Fountain.Broker, :ca_pem, fn -> {:ok, "PEM"} end)
+      Mimic.stub(Fountain.Sandbox.Sprites, :write_file, fn _h, _p, _d, _o -> :ok end)
+
+      Mimic.stub(Fountain.Sandbox.Sprites, :exec, fn _h, _cmd, [_, script], _opts ->
+        send(test, {:script, script})
+        {:ok, "", 0}
+      end)
+
+      assert :ok = Provisioning.install_broker_ca(sandbox_handle(), conv.id)
+      assert_received {:script, script}
+
+      # The token-bearing variables must survive sudo for apt's sake, but the
+      # drop-in itself carries only names, never the proxy URL.
+      for key <- Fountain.Broker.env_keys(), do: assert(script =~ key)
+      refute script =~ "@"
+      assert script =~ "visudo -cf"
     end
 
     test "a failed install is a broker failure, by name" do


### PR DESCRIPTION
## What broke

Since the tenant flip (home-cloud#131, 07:17Z today), every provision of a real environment on the brokered tenant fails in `setup` with exit 100 — conversations `6ebb1823`, `1db65cca`, `a514c7bc`. The script's own `curl` calls succeed (bun installs, the gh keyring downloads) but every `sudo apt-get` reports `Temporary failure resolving 'archive.ubuntu.com'`.

Cause: the sandbox user has `HTTPS_PROXY`/`http_proxy` set, but `sudo`'s `env_reset` strips them, so apt resolves the mirror directly — and after `apply_broker_floor/2` the sandbox can reach nothing but the broker's host. The `packages` stage is unaffected because it deliberately runs before the floor.

## Fix

`install_broker_ca/2` now also installs `/etc/sudoers.d/fountain-broker-proxy` with `Defaults env_keep += "<Fountain.Broker.env_keys()>"`, validated by `visudo -cf` before `install -m 440` (a bad fragment would disable sudo outright). The drop-in names variables only; the token-bearing proxy URL never lands on disk, which an `apt.conf` proxy entry would have required.

Verified the generated line parses with `visudo -c` locally; the two provisioning/broker test files pass (33 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)