### PR TITLE
fix(broker): egress log is full-scope, the 502 is a sentence, networking_config says where limited is enforced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,21 @@ upgrade, is in
 
 ## [Unreleased]
 
+### Fixed
+
+- **Broker, three findings from wiring the workbench to gate 4.**
+  `GET /api/conversations/:id/egress` needs full scope, like
+  `/api/secret-bindings`: a sandbox's sprite-scoped token could read the
+  request log — which secrets went to which host — for any conversation on
+  the tenant (#1152). Its 502 no longer leaks an inspected Elixir term as
+  `message`; the client gets "The egress broker did not answer." plus a
+  stable `reason` word (`econnrefused`, `api_error_503`, ...) and the detail
+  goes to the server log (#1153). The OpenAPI description of
+  `networking_config` says where `limited` is enforced (the broker on a
+  brokered account, the sandbox otherwise) instead of the pre-gate-2 sandbox
+  story, and `GET /api/auth/me` carries a read-only `brokered` so a client
+  can label the mode without probing `/api/secret-bindings` (#1154).
+
 ### Upgrade notes
 
 - **`BILLING_ENABLED` is `CREDITS_ENABLED`** (#1144). The old name is still

--- a/apps/fountain/lib/fountain_web/controllers/auth_me_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/auth_me_controller.ex
@@ -39,7 +39,11 @@ defmodule FountainWeb.AuthMeController do
       # Null on a billing-disabled instance, even for an account that was
       # comped before billing was turned off — there is no balance for the
       # flag to be about (#480).
-      comped: if(Fountain.Credits.enabled?(), do: user.comped, else: nil)
+      comped: if(Fountain.Credits.enabled?(), do: user.comped, else: nil),
+      # Read-only: whether this account is on the broker ratchet (ADR 0019),
+      # so a client can label the mode instead of probing
+      # /api/secret-bindings for a 200 vs 404 (#1154).
+      brokered: Fountain.Broker.enabled_for?(user.id)
     })
   end
 end

--- a/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
@@ -229,16 +229,14 @@ defmodule FountainWeb.ConversationController do
     end
   end
 
-  # `{:broker, :request_log, :econnrefused}` -> "econnrefused";
+  # What `Broker.request_log/2` can fail with: the broker answered with a
+  # non-200 (`{:api_error, status, body}`), or Req could not reach it
+  # (`%Req.TransportError{reason: :econnrefused | :timeout | :nxdomain}`).
   # `{:broker, :request_log, {:api_error, 503, _}}` -> "api_error_503".
   defp broker_reason({:broker, _call, inner}), do: broker_reason(inner)
   defp broker_reason({:api_error, status, _body}), do: "api_error_#{status}"
-  defp broker_reason(atom) when is_atom(atom), do: Atom.to_string(atom)
-
-  defp broker_reason(%{__exception__: true} = e),
-    do: e.__struct__ |> inspect() |> Macro.underscore()
-
-  defp broker_reason(_), do: "unknown"
+  defp broker_reason(%Req.TransportError{reason: r}) when is_atom(r), do: Atom.to_string(r)
+  defp broker_reason(%{__struct__: mod}), do: mod |> inspect() |> Macro.underscore()
 
   defp egress_limit(nil), do: 100
 

--- a/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
@@ -3,6 +3,8 @@ defmodule FountainWeb.ConversationController do
   use FountainWeb, :controller
   use OpenApiSpex.ControllerSpecs
 
+  require Logger
+
   alias Fountain.Billing
   alias Fountain.Conversations
   alias Fountain.Conversations.{ConversationServer, LogEvent}
@@ -186,7 +188,9 @@ defmodule FountainWeb.ConversationController do
     responses: [
       ok: {"Egress", "application/json", Schemas.EgressListResponse},
       not_found: {"Not found", "application/json", Schemas.Error},
-      bad_gateway: {"The broker did not answer", "application/json", Schemas.Error}
+      forbidden: {"The key lacks full scope", "application/json", Schemas.Error},
+      bad_gateway:
+        {"The broker did not answer", "application/json", Schemas.BrokerUnavailableError}
     ]
   )
 
@@ -206,15 +210,35 @@ defmodule FountainWeb.ConversationController do
               render(conn, :egress, events: events, next: next, brokered: true)
 
             {:error, reason} ->
+              # The inspected term is an internal shape, not an API message;
+              # it goes to the log, and the client gets a sentence plus a
+              # stable `reason` word it can branch on (#1153).
+              Logger.warning("broker request_log failed for #{conv.id}: #{inspect(reason)}")
+
               conn
               |> put_status(:bad_gateway)
-              |> json(%{error: "broker_unavailable", message: inspect(reason)})
+              |> json(%{
+                error: "broker_unavailable",
+                message: "The egress broker did not answer.",
+                reason: broker_reason(reason)
+              })
           end
         else
           render(conn, :egress, events: [], next: nil, brokered: false)
         end
     end
   end
+
+  # `{:broker, :request_log, :econnrefused}` -> "econnrefused";
+  # `{:broker, :request_log, {:api_error, 503, _}}` -> "api_error_503".
+  defp broker_reason({:broker, _call, inner}), do: broker_reason(inner)
+  defp broker_reason({:api_error, status, _body}), do: "api_error_#{status}"
+  defp broker_reason(atom) when is_atom(atom), do: Atom.to_string(atom)
+
+  defp broker_reason(%{__exception__: true} = e),
+    do: e.__struct__ |> inspect() |> Macro.underscore()
+
+  defp broker_reason(_), do: "unknown"
 
   defp egress_limit(nil), do: 100
 

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -335,6 +335,16 @@ defmodule FountainWeb.Router do
     delete "/:id", SecretBindingController, :delete
   end
 
+  # What left the sandbox through the egress broker (ADR 0019 gate 4). Full
+  # scope, like the bindings that put the credentials there: the log names
+  # which secrets went to which host, and a sandbox's per-conversation token
+  # must not be able to map another conversation's traffic (#1152).
+  scope "/api/conversations/:conversation_id", FountainWeb do
+    pipe_through [:accepts_json, :api, :require_full_scope]
+
+    get "/egress", ConversationController, :egress, as: :conversation_egress
+  end
+
   # The daemon's socket skips content negotiation like the SSE routes do: a
   # WebSocket client sends no JSON `Accept`, and the upgrade is not a JSON
   # response.
@@ -488,8 +498,6 @@ defmodule FountainWeb.Router do
       # the conversation is tenant-scoped before the request id is looked at.
       post "/requests/:request_id", ConversationController, :answer_request, as: :answer_request
       get "/tree", ConversationController, :tree, as: :tree
-      # What left the sandbox through the egress broker (ADR 0019 gate 4).
-      get "/egress", ConversationController, :egress, as: :egress
     end
   end
 

--- a/apps/fountain/lib/fountain_web/schema_wrappers.ex
+++ b/apps/fountain/lib/fountain_web/schema_wrappers.ex
@@ -70,6 +70,25 @@ defmodule FountainWeb.SchemaWrappers do
   end
 
   @doc """
+  The one description of `networking_config`, shared by `Environment`,
+  `EnvironmentRequest` and `EnvironmentUpdate`. It lives here rather than as
+  a module attribute because each `Schemas.*` module is its own `defmodule`
+  and attributes do not cross that boundary; three copies is how it went
+  stale at ADR 0019 gate 2 (#1154).
+  """
+  def networking_config_description do
+    "Refines networking_type: limited. allowed_hosts is the only key honored " <>
+      "today; unknown keys are ignored. Where the policy is enforced depends on " <>
+      "the account: on a brokered account (`brokered: true` on GET /api/auth/me) " <>
+      "the sandbox can reach only the egress broker, and under limited the " <>
+      "broker refuses any host not in allowed_hosts with a 403 that names it, " <>
+      "while a host with a bound credential needs no entry. On an unbrokered " <>
+      "account the sandbox itself allows only the allowlisted domains. Either " <>
+      "way, limited with no allowed_hosts (or an empty list) is a deny-all, " <>
+      "not an allow-all."
+  end
+
+  @doc """
   Build the envelope map `OpenApiSpex.schema/1` expects.
 
   The title is the module's own last segment, which is what all twenty-two

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -2968,7 +2968,7 @@ defmodule FountainWeb.Schemas do
       description: "The egress broker did not answer the request log call.",
       type: :object,
       properties: %{
-        error: %Schema{type: :string, enum: ["broker_unavailable"]},
+        error: %Schema{type: :string, description: "Always `broker_unavailable`."},
         message: %Schema{type: :string, description: "A sentence for a human."},
         reason: %Schema{
           type: :string,

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -5,7 +5,8 @@ defmodule FountainWeb.Schemas do
   `Schemas.Agent`).
   """
 
-  import FountainWeb.SchemaWrappers, only: [list_response: 2, item_response: 2]
+  import FountainWeb.SchemaWrappers,
+    only: [list_response: 2, item_response: 2, networking_config_description: 0]
 
   alias OpenApiSpex.Schema
 
@@ -1130,12 +1131,7 @@ defmodule FountainWeb.Schemas do
         networking_type: %Schema{type: :string, enum: ~w(unrestricted limited)},
         networking_config: %Schema{
           type: :object,
-          description:
-            "Refines networking_type: limited. allowed_hosts is the only key " <>
-              "honored today; unknown keys are ignored. Under limited, egress is " <>
-              "restricted to the allowlisted domains. With no allowed_hosts (or an " <>
-              "empty list), the sandbox denies all egress by default — this is a " <>
-              "deny-all, not an allow-all.",
+          description: networking_config_description(),
           properties: %{
             allowed_hosts: %Schema{
               type: :array,
@@ -1190,12 +1186,7 @@ defmodule FountainWeb.Schemas do
         networking_type: %Schema{type: :string, enum: ~w(unrestricted limited)},
         networking_config: %Schema{
           type: :object,
-          description:
-            "Refines networking_type: limited. allowed_hosts is the only key " <>
-              "honored today; unknown keys are ignored. Under limited, egress is " <>
-              "restricted to the allowlisted domains. With no allowed_hosts (or an " <>
-              "empty list), the sandbox denies all egress by default — this is a " <>
-              "deny-all, not an allow-all.",
+          description: networking_config_description(),
           properties: %{
             allowed_hosts: %Schema{
               type: :array,
@@ -1231,12 +1222,7 @@ defmodule FountainWeb.Schemas do
         networking_type: %Schema{type: :string, enum: ~w(unrestricted limited)},
         networking_config: %Schema{
           type: :object,
-          description:
-            "Refines networking_type: limited. allowed_hosts is the only key " <>
-              "honored today; unknown keys are ignored. Under limited, egress is " <>
-              "restricted to the allowlisted domains. With no allowed_hosts (or an " <>
-              "empty list), the sandbox denies all egress by default — this is a " <>
-              "deny-all, not an allow-all.",
+          description: networking_config_description(),
           properties: %{
             allowed_hosts: %Schema{
               type: :array,
@@ -2973,6 +2959,29 @@ defmodule FountainWeb.Schemas do
     })
   end
 
+  defmodule BrokerUnavailableError do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "BrokerUnavailableError",
+      description: "The egress broker did not answer the request log call.",
+      type: :object,
+      properties: %{
+        error: %Schema{type: :string, enum: ["broker_unavailable"]},
+        message: %Schema{type: :string, description: "A sentence for a human."},
+        reason: %Schema{
+          type: :string,
+          description:
+            "A stable word for a client to branch on: `econnrefused`, `timeout`, " <>
+              "`nxdomain`, `api_error_<status>`, or `unknown`. The detail is in " <>
+              "the server log, not here."
+        }
+      },
+      required: [:error, :message, :reason]
+    })
+  end
+
   defmodule ManifestResource do
     @moduledoc false
     require OpenApiSpex
@@ -3174,6 +3183,15 @@ defmodule FountainWeb.Schemas do
         },
         onboarding_completed: %Schema{type: :boolean},
         comped: %Schema{type: :boolean, nullable: true, description: "Null when billing is off."},
+        brokered: %Schema{
+          type: :boolean,
+          description:
+            "Whether this account's conversations run behind the egress credential " <>
+              "broker (ADR 0019): secrets with bindings stay at the broker, a limited " <>
+              "environment is enforced there, and /api/secret-bindings and " <>
+              "/api/conversations/:id/egress have content. Read-only; an operator " <>
+              "sets it."
+        },
         expires_at: %Schema{type: :string, format: :"date-time", nullable: true}
       },
       required: [:id, :name, :prefix, :created_at]

--- a/apps/fountain/test/fountain_web/controllers/auth_me_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/auth_me_controller_test.exs
@@ -36,6 +36,35 @@ defmodule FountainWeb.AuthMeControllerTest do
       assert comped == false
     end
 
+    test "carries brokered, false off the broker ratchet and true on it", %{conn: conn} do
+      user = insert_verified_user()
+      {_key_record, raw_key} = insert_api_key(user)
+
+      assert %{"brokered" => false} =
+               conn |> authed_with_key(raw_key) |> get("/api/auth/me") |> json_response(200)
+
+      previous =
+        for k <- [:broker_url, :broker_token, :broker_proxy_url, :broker_tenants],
+            do: {k, Application.get_env(:fountain, k)}
+
+      on_exit(fn ->
+        for {k, v} <- previous,
+            do:
+              if(is_nil(v),
+                do: Application.delete_env(:fountain, k),
+                else: Application.put_env(:fountain, k, v)
+              )
+      end)
+
+      Application.put_env(:fountain, :broker_url, "http://broker.test:14321")
+      Application.put_env(:fountain, :broker_token, "t")
+      Application.put_env(:fountain, :broker_proxy_url, "http://broker.test:14322")
+      Application.put_env(:fountain, :broker_tenants, [user.id])
+
+      assert %{"brokered" => true} =
+               conn |> authed_with_key(raw_key) |> get("/api/auth/me") |> json_response(200)
+    end
+
     test "returns 401 when no API key is provided", %{conn: conn} do
       conn = get(conn, "/api/auth/me")
       assert conn.status == 401

--- a/apps/fountain/test/fountain_web/controllers/conversation_egress_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/conversation_egress_test.exs
@@ -87,12 +87,42 @@ defmodule FountainWeb.ConversationEgressTest do
            } = row
   end
 
-  test "a broker that does not answer is a 502, not a 500", %{conn: conn, conv: conv} do
+  test "a broker that does not answer is a 502 with a sentence, not an inspected term",
+       %{conn: conn, conv: conv} do
     expect(Broker, :request_log, fn _id, _opts ->
       {:error, {:broker, :request_log, :econnrefused}}
     end)
 
-    assert %{"error" => "broker_unavailable"} =
-             conn |> get("/api/conversations/#{conv.id}/egress") |> json_response(502)
+    assert %{
+             "error" => "broker_unavailable",
+             "message" => "The egress broker did not answer.",
+             "reason" => "econnrefused"
+           } = conn |> get("/api/conversations/#{conv.id}/egress") |> json_response(502)
+  end
+
+  test "a broker API error is a 502 that carries the status as its reason",
+       %{conn: conn, conv: conv} do
+    expect(Broker, :request_log, fn _id, _opts ->
+      {:error, {:broker, :request_log, {:api_error, 503, %{"error" => "draining"}}}}
+    end)
+
+    body = conn |> get("/api/conversations/#{conv.id}/egress") |> json_response(502)
+    assert body["reason"] == "api_error_503"
+    refute body["message"] =~ "api_error"
+  end
+
+  # The log names which secrets went to which host: a sandbox's own token
+  # must not be able to read it, for its conversation or any other (#1152).
+  test "a sprite-scoped token cannot read the egress log", %{conn: conn, user: user, conv: conv} do
+    {_rec, sprite_key} = insert_sprite_api_key(user)
+    reject(Broker, :request_log, 2)
+
+    body =
+      conn
+      |> authed_with_key(sprite_key)
+      |> get("/api/conversations/#{conv.id}/egress")
+      |> json_response(403)
+
+    assert body["reason"] == "insufficient_scope"
   end
 end

--- a/apps/fountain/test/fountain_web/controllers/conversation_egress_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/conversation_egress_test.exs
@@ -90,7 +90,7 @@ defmodule FountainWeb.ConversationEgressTest do
   test "a broker that does not answer is a 502 with a sentence, not an inspected term",
        %{conn: conn, conv: conv} do
     expect(Broker, :request_log, fn _id, _opts ->
-      {:error, {:broker, :request_log, :econnrefused}}
+      {:error, {:broker, :request_log, %Req.TransportError{reason: :econnrefused}}}
     end)
 
     assert %{

--- a/docs/api.md
+++ b/docs/api.md
@@ -157,7 +157,9 @@ count is the conversations that ran a turn in the month. The
 pricer charges a turn when it ends.
 
 `GET /api/auth/me` carries `comped`. It is `true` for an account an operator
-made free, and `null` when payment is off.
+made free, and `null` when payment is off. It also carries `brokered`. It is
+`true` when the account runs behind the egress credential broker. See
+[Secrets](concepts/secrets.md).
 
 ### Data export and deletion
 

--- a/docs/concepts/secrets.md
+++ b/docs/concepts/secrets.md
@@ -181,7 +181,8 @@ After a conversation, `GET /api/conversations/:id/egress` lists what left the
 sandbox through the broker. Each row shows the host, the binding that matched
 and so the credential attached, the status, and the latency. A refused host
 shows the refusal. The list stays for `BROKER_LOG_RETENTION_HOURS` after the
-conversation ends.
+conversation ends. The route needs a key with full scope. The token a sandbox
+holds cannot read it.
 
 You manage bindings on Account, then Credential bindings, or with
 `GET /api/secret-bindings` and its siblings. The page and the routes are only

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -10,6 +10,23 @@ server releases.
 
 ---
 
+## [1.6.0] — 2026-08-25
+
+### Added
+
+- `brokered` on `GET /api/auth/me`: whether the account runs behind the egress
+  credential broker, so a client can label the mode without probing
+  `/api/secret-bindings` (#1154).
+- `BrokerUnavailableError`: the 502 from `/egress` carries a sentence in
+  `message` and a stable `reason` word (`econnrefused`, `api_error_503`, ...)
+  instead of an inspected server term (#1153).
+
+### Changed
+
+- `GET /api/conversations/:id/egress` needs a full-scope key; a sprite-scoped
+  token gets `403 insufficient_scope` (#1152). The `networking_config`
+  description says where `limited` is enforced.
+
 ## [1.5.0] — 2026-08-25
 
 ### Added

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentshit/fountain-sdk",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Run a coding agent on a real computer, with your repos and your credentials, in one call.",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -3742,8 +3742,8 @@ export interface components {
          * @description The egress broker did not answer the request log call.
          */
         BrokerUnavailableError: {
-            /** @enum {string} */
-            error: "broker_unavailable";
+            /** @description Always `broker_unavailable`. */
+            error: string;
             /** @description A sentence for a human. */
             message: string;
             /** @description A stable word for a client to branch on: `econnrefused`, `timeout`, `nxdomain`, `api_error_<status>`, or `unknown`. The detail is in the server log, not here. */

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -2277,7 +2277,7 @@ export interface components {
                 [key: string]: unknown;
             };
             name?: string;
-            /** @description Refines networking_type: limited. allowed_hosts is the only key honored today; unknown keys are ignored. Under limited, egress is restricted to the allowlisted domains. With no allowed_hosts (or an empty list), the sandbox denies all egress by default — this is a deny-all, not an allow-all. */
+            /** @description Refines networking_type: limited. allowed_hosts is the only key honored today; unknown keys are ignored. Where the policy is enforced depends on the account: on a brokered account (`brokered: true` on GET /api/auth/me) the sandbox can reach only the egress broker, and under limited the broker refuses any host not in allowed_hosts with a 403 that names it, while a host with a bound credential needs no entry. On an unbrokered account the sandbox itself allows only the allowlisted domains. Either way, limited with no allowed_hosts (or an empty list) is a deny-all, not an allow-all. */
             networking_config?: {
                 /** @description Domains the sandbox may reach when networking_type is limited. */
                 allowed_hosts?: string[];
@@ -2962,6 +2962,8 @@ export interface components {
          * @description Identity of the account the bearer token belongs to.
          */
         AuthMeResponse: {
+            /** @description Whether this account's conversations run behind the egress credential broker (ADR 0019): secrets with bindings stay at the broker, a limited environment is enforced there, and /api/secret-bindings and /api/conversations/:id/egress have content. Read-only; an operator sets it. */
+            brokered?: boolean;
             /** @description Null when billing is off. */
             comped?: boolean | null;
             /** Format: email */
@@ -3716,7 +3718,7 @@ export interface components {
                 [key: string]: unknown;
             };
             name: string;
-            /** @description Refines networking_type: limited. allowed_hosts is the only key honored today; unknown keys are ignored. Under limited, egress is restricted to the allowlisted domains. With no allowed_hosts (or an empty list), the sandbox denies all egress by default — this is a deny-all, not an allow-all. */
+            /** @description Refines networking_type: limited. allowed_hosts is the only key honored today; unknown keys are ignored. Where the policy is enforced depends on the account: on a brokered account (`brokered: true` on GET /api/auth/me) the sandbox can reach only the egress broker, and under limited the broker refuses any host not in allowed_hosts with a 403 that names it, while a host with a bound credential needs no entry. On an unbrokered account the sandbox itself allows only the allowlisted domains. Either way, limited with no allowed_hosts (or an empty list) is a deny-all, not an allow-all. */
             networking_config?: {
                 /** @description Domains the sandbox may reach when networking_type is limited. */
                 allowed_hosts?: string[];
@@ -3734,6 +3736,18 @@ export interface components {
         /** AdminUserResponse */
         AdminUserResponse: {
             data: components["schemas"]["AdminUser"];
+        };
+        /**
+         * BrokerUnavailableError
+         * @description The egress broker did not answer the request log call.
+         */
+        BrokerUnavailableError: {
+            /** @enum {string} */
+            error: "broker_unavailable";
+            /** @description A sentence for a human. */
+            message: string;
+            /** @description A stable word for a client to branch on: `econnrefused`, `timeout`, `nxdomain`, `api_error_<status>`, or `unknown`. The detail is in the server log, not here. */
+            reason: string;
         };
         /** SearchResponse */
         SearchResponse: {
@@ -3813,7 +3827,7 @@ export interface components {
                 [key: string]: unknown;
             };
             name: string;
-            /** @description Refines networking_type: limited. allowed_hosts is the only key honored today; unknown keys are ignored. Under limited, egress is restricted to the allowlisted domains. With no allowed_hosts (or an empty list), the sandbox denies all egress by default — this is a deny-all, not an allow-all. */
+            /** @description Refines networking_type: limited. allowed_hosts is the only key honored today; unknown keys are ignored. Where the policy is enforced depends on the account: on a brokered account (`brokered: true` on GET /api/auth/me) the sandbox can reach only the egress broker, and under limited the broker refuses any host not in allowed_hosts with a 403 that names it, while a host with a bound credential needs no entry. On an unbrokered account the sandbox itself allows only the allowlisted domains. Either way, limited with no allowed_hosts (or an empty list) is a deny-all, not an allow-all. */
             networking_config?: {
                 /** @description Domains the sandbox may reach when networking_type is limited. */
                 allowed_hosts?: string[];
@@ -7377,6 +7391,15 @@ export interface operations {
                     "application/json": components["schemas"]["EgressListResponse"];
                 };
             };
+            /** @description The key lacks full scope */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not found */
             404: {
                 headers: {
@@ -7392,7 +7415,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["Error"];
+                    "application/json": components["schemas"]["BrokerUnavailableError"];
                 };
             };
         };

--- a/sdk/typescript/src/http.ts
+++ b/sdk/typescript/src/http.ts
@@ -19,7 +19,7 @@ export interface RequestOptions {
  * this string is already what Fountain's request logs are keyed on. The
  * version half is asserted against `package.json` by a test.
  */
-export const USER_AGENT = "fountain-sdk-js/1.5.0";
+export const USER_AGENT = "fountain-sdk-js/1.6.0";
 
 /**
  * The thin layer everything else is built on: one bearer token, JSON in and


### PR DESCRIPTION
Three findings from wiring the workbench to ADR 0019 gate 4 (#1151).

## #1152 — egress log is scope-gated
`GET /api/conversations/:id/egress` moves out of the `resources "/conversations"` block into its own scope on `[:accepts_json, :api, :require_full_scope]`, matching `/api/secret-bindings`. A sprite-scoped key now gets `403 insufficient_scope`. The new test was verified to fail with the router change reverted.

## #1153 — the 502 is a sentence
`message` is `"The egress broker did not answer."`; a new `reason` field carries a stable word (`econnrefused`, `timeout`, `api_error_503`, `unknown`) and the inspected term goes to `Logger.warning`. The spec gets a `BrokerUnavailableError` schema for the 502 and a 403 on the operation.

## #1154 — `networking_config` description + `brokered` on `/api/auth/me`
The three copies of the description collapse into `SchemaWrappers.networking_config_description/0` (module attributes don't cross nested `defmodule`s, which is how three copies went stale). It now says the broker enforces `limited` on a brokered account (`brokered: true` on `GET /api/auth/me`, new read-only field) and the sandbox does otherwise. `docs/api.md` and `docs/concepts/secrets.md` updated; vale/docs-style clean.

SDK regenerated, bumped to 1.6.0 (merging publishes it).

Closes #1152, closes #1153, closes #1154.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
