### PR TITLE
docs: mark teammate contacts alpha and brokered credentials limited access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ upgrade, is in
 
 ### Changed
 
+- **Feature status page.** `/docs/reference/feature-status` names the two
+  features that are not on for every hosted account, teammate email and
+  phone (alpha, `team_comms`) and brokered credentials (limited access,
+  `BROKER_TENANTS`), and each page that describes one now opens with a note
+  saying so. `api.md` gains the egress and secret-bindings routes.
+
 - `Billing.provider_spend/1` (the `/admin` and `/admin/sandboxes` hours) and
   `Finance.cost/3` (the money on `/admin/finance`) read one fold,
   `Finance.platform_totals/1`, instead of each summing the attribution rows

--- a/docs/api.md
+++ b/docs/api.md
@@ -313,6 +313,27 @@ DELETE /api/vaults/:id/secrets/:key
 
 The same write-only rule covers a vault secret value.
 
+## Secret bindings
+
+<!-- vale STE.IngForms = NO -->
+Limited access. These routes answer only when the credential broker is on
+for the account. Read [Feature status](reference/feature-status.md), and
+[Where a secret comes from](concepts/secrets.md#bindings-when-the-broker-is-on)
+for what a binding does.
+
+```
+GET    /api/secret-bindings                # each binding: secret name, host, shape
+GET    /api/secret-bindings/presets        # the shapes a binding can take
+POST   /api/secret-bindings
+PATCH  /api/secret-bindings/:id
+DELETE /api/secret-bindings/:id
+```
+
+A binding is about the name of a secret, so it applies to every environment
+and vault that holds a secret of that name. A conversation-scoped token
+cannot reach these routes. They need a full-scope key.
+<!-- vale STE.IngForms = YES -->
+
 ## Bulk apply
 
 ```
@@ -362,7 +383,17 @@ GET    /api/conversations/:id/turns
 GET    /api/conversations/:id/events       # log events as JSON (?streams=  ?after=  ?limit=)
 GET    /api/conversations/:id/stream       # SSE log stream (?streams=stdout,stderr,stage  ?wait=false)
 GET    /api/conversations/:id/turns/:turn_id/images/:position   # image bytes
+GET    /api/conversations/:id/egress       # what left the sandbox through the broker (limited access)
 ```
+
+<!-- vale STE.IngForms = NO -->
+`GET /api/conversations/:id/egress` is there only when the credential broker
+is on for the account. Read [Feature status](reference/feature-status.md). It
+lists each request that left the sandbox through the broker, with the host,
+the binding that matched, the status and the latency. A refused host shows
+the refusal. The list stays for `BROKER_LOG_RETENTION_HOURS` after the
+conversation ends.
+<!-- vale STE.IngForms = YES -->
 
 A turn carries `image_count`. The image endpoint takes a `position` into that
 count, which starts at zero, and returns the raw bytes with the stored media
@@ -669,7 +700,8 @@ the daemon reconnects.
 The conversation's `sandbox` carries `provider`. On a runner it also carries
 `runner: {id, name, hostname, online, path}`.
 
-**Email and phone. A proof of concept, behind the `team_comms` flag.**
+**Email and phone. Alpha, behind the `team_comms` flag.** Off by default on
+the hosted platform. Read [Feature status](reference/feature-status.md).
 
 `POST /api/team/:agent_id/contact` gives the teammate an inbox, from
 [AgentMail](https://agentmail.to), and a number, from

--- a/docs/catalog/mcp-servers/fountain-comms.md
+++ b/docs/catalog/mcp-servers/fountain-comms.md
@@ -12,7 +12,12 @@
 | Injected when | The teammate has a contact, and the `team_comms` flag is on. |
 | Endpoint | `POST /api/mcp/team-comms/:conversation_id` |
 | Auth | The sandbox's own callback token, for that one conversation. |
-| Status | Behind a feature flag. |
+| Status | Alpha. Behind the `team_comms` flag, off by default on the hosted platform. Read [Feature status](../../reference/feature-status.md). |
+
+!!! note "Alpha"
+    On the hosted platform the flag is off by default.
+    [Ask us](../../api.md#support) to turn it on for your account. The tools
+    and the routes can change between releases.
 
 ## Why it exists in this shape
 

--- a/docs/concepts/environment.md
+++ b/docs/concepts/environment.md
@@ -83,6 +83,10 @@ out. That is deliberate, and it is not a defect. An empty allowlist that
 quietly meant "allow everything" would be the worst default for a policy whose
 whole purpose is restriction.
 
+!!! note "Limited access"
+    The broker is on for the hosted accounts we enrol by hand. Read
+    [Feature status](../reference/feature-status.md).
+
 On a hosted account with the egress credential broker on, the sandbox can
 reach only the broker. The broker then applies your policy. With
 `unrestricted`, a request goes through to any host, with only the credentials

--- a/docs/concepts/secrets.md
+++ b/docs/concepts/secrets.md
@@ -154,6 +154,12 @@ redaction that a new caller will one day forget.
 
 ## Bindings, when the broker is on
 
+!!! note "Limited access"
+    On the hosted platform the broker is on for the accounts we enrol by
+    hand. Without it, a secret enters the sandbox in the clear, and the
+    bindings page and routes are absent. Read
+    [Feature status](../reference/feature-status.md).
+
 <!-- vale STE.IngForms = NO -->
 On a hosted account with the egress credential broker on, a secret can have
 one or more **bindings**. A binding names a host. By default the broker

--- a/docs/concepts/teammates.md
+++ b/docs/concepts/teammates.md
@@ -80,6 +80,14 @@ teammate was busy for half an hour, or when the sandbox quota was full.
 
 Remove a teammate and Fountain deletes its schedules.
 
+## A teammate can have an email address and a phone number
+
+This is an alpha feature, and it is off by default on the hosted platform.
+Give a teammate a contact, and it gets an address and a number under keys
+that Fountain holds. Its sandbox never sees a key. Read
+[fountain-comms](../catalog/mcp-servers/fountain-comms.md) for the tools, and
+[Feature status](../reference/feature-status.md) for how to get it on.
+
 ## What a teammate is not
 
 **Not a primitive.** Nothing in the API creates a teammate. You bind a

--- a/docs/index.md
+++ b/docs/index.md
@@ -124,3 +124,4 @@ in full.
 - [Configuration reference](configuration.md), each environment variable
 - [Conversation states](reference/conversation-states.md)
 - [Glossary](reference/glossary.md), with the five overloaded words
+- [Feature status](reference/feature-status.md), the two features that are not on for every account

--- a/docs/nav.yml
+++ b/docs/nav.yml
@@ -99,6 +99,7 @@ nav:
       - TypeScript SDK: sdk.md
       - Conversation states: reference/conversation-states.md
       - Glossary: reference/glossary.md
+      - Feature status: reference/feature-status.md
   - Build a chat app:
       - The shape everyone clones: build/index.md
       - A team chat, end to end: build/team-chat.md

--- a/docs/reference/feature-status.md
+++ b/docs/reference/feature-status.md
@@ -1,0 +1,31 @@
+# Feature status
+
+Most of Fountain is on for every account. Two features are not. This page
+lists them, says who has them on the hosted platform, and says how to get
+them.
+
+A note with the same title as the row sits at the top of each page that
+describes one of these features.
+
+| Feature | Status | On the hosted platform | On your own instance |
+|---|---|---|---|
+| [Teammate email and phone](../catalog/mcp-servers/fountain-comms.md) | Alpha | Off by default. Behind the `team_comms` flag. [Ask us](../api.md#support) to turn it on for your account. | Set the AgentMail and AgentPhone keys, and add `team_comms` to `FEATURE_FLAGS_ON`. Read the [configuration reference](../configuration.md#teammate-email-and-phone). |
+| [Brokered credentials](../concepts/secrets.md#bindings-when-the-broker-is-on) | Limited access | Off by default. We enrol an account by hand. [Ask us](../api.md#support) to enrol yours. | Set `BROKER_URL` and its siblings, and list the user ids in `BROKER_TENANTS`. Read the [configuration reference](../configuration.md). |
+
+## What each status means
+
+**Alpha.** The feature works end to end, and we have not yet decided its final
+shape. Its API and its tools can change between releases without an upgrade
+note. Fountain refuses a call to it with a `404` when the flag is off.
+
+**Limited access.** The feature works, and it changes what a sandbox can
+reach. We turn it on for one account at a time, and we watch the first
+conversations with you. Without it, a secret enters the sandbox in the clear,
+and the pages and routes that manage bindings are absent.
+
+## Where to go next
+
+- [Where a secret comes from](../concepts/secrets.md), for what the broker
+  changes.
+- [fountain-comms](../catalog/mcp-servers/fountain-comms.md), for the tools a
+  contact adds.


### PR DESCRIPTION
## What

Two features are not on for every hosted account, and the manual did not say so.

- **Teammate email and phone** (`team_comms` flag, off by default). The pages said "behind a feature flag" without saying who has it or how to get it.
- **Brokered credentials** (`BROKER_TENANTS` allowlist, enrolled by hand). Outside the operator configuration reference, "on a hosted account with the broker on" was the only hint.

## Changes

- New page **Reference → Feature status** (`docs/reference/feature-status.md`): one table with both features, their status (*alpha* / *limited access*), how to get them on the hosted platform, and how to turn them on for your own instance; plus a definition of what each status means. Linked from the home page.
- A `!!! note "Alpha"` / `!!! note "Limited access"` admonition at the top of each section that describes one: `concepts/secrets.md` (bindings), `concepts/environment.md` (limited networking through the broker), `catalog/mcp-servers/fountain-comms.md`, `api.md` (contacts). The renderer already supports any admonition type, so no code change.
- `concepts/teammates.md` now mentions contacts at all, pointing at fountain-comms.
- `api.md` gains the routes `secrets.md` already referred to but the reference omitted: `GET /api/conversations/:id/egress` and the five `/api/secret-bindings` routes.
- CHANGELOG entry under Unreleased.

## Verification

- `mix test apps/fountain/test/fountain/docs_test.exs`: 29 tests, 0 failures (nav round-trip, links, anchors, Dockerfile external_resource).
- `python3 scripts/docs-style.py`: clean.
- `vale lint docs`: 0 errors, 0 warnings (main has 1 warning; `binding` is suppressed in `api.md` the same way `secrets.md` does).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
