### PR TITLE
docs: the one-picture explainer — three templates, one machine, the broker (#1129)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 A multi-tenant API and UI for managing agents, repos, secrets, and conversations. It's for people who want to create sandboxed coding agent instances with preconfigured sets of env vars, MCP servers, skills, repos, and packages. Users treat Fountain as a building block for their own workflows, but also use the UI to get started and to debug. It exists because running Claude instances with worktrees locally — and shuffling MCP configurations and skill setups by hand — is painful.
 
+## In one picture
+
+<img src="docs/images/primitives.svg" alt="Three templates and one machine: Agent, Environment and Vault are rows written once; a Conversation runs the Agent on a sandbox that Fountain builds from the Environment; secrets merge, the Vault winning; on a hosted account with the egress broker on, a bound secret goes to the broker and the sandbox gets a placeholder." width="740">
+
+Agent, Environment and Vault are templates: rows you write once and use many
+times. A Conversation is a run of an Agent on a machine that Fountain builds,
+warms, meters and reclaims. Secrets merge at launch, the Vault winning; on a
+hosted account with the egress broker on, a bound secret never enters the
+sandbox at all. [The four primitives](docs/primitives.md) says why there are
+four.
+
 ## Self-hosting
 
 Run your own instance: [docs/self-hosting.md](docs/self-hosting.md).

--- a/docs/images/primitives.svg
+++ b/docs/images/primitives.svg
@@ -1,0 +1,62 @@
+<svg viewBox="0 0 740 352" role="img" aria-label="Three templates and one machine. Agent, Environment and Vault are rows a tenant writes once. When a conversation starts, Fountain builds a sandbox from the Environment, runs the Agent on it as a conversation, and merges the Environment's and the Vault's secrets, the Vault winning. On a hosted account with the egress broker on, a bound secret goes to the broker and the sandbox gets a placeholder; the sandbox reaches the internet only through the broker, which attaches the value. On any other account the secrets enter the sandbox as environment variables." xmlns="http://www.w3.org/2000/svg">
+  <rect width="740" height="352" fill="#ffffff"/>
+  <defs>
+    <marker id="pr-a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#1b2530"/></marker>
+    <marker id="pr-b" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#c98a2b"/></marker>
+  </defs>
+  <g fill="none" stroke="#1b2530" stroke-width="1.4">
+    <rect x="14" y="30" width="196" height="52" rx="8" stroke="#8a93a3"/>
+    <rect x="14" y="110" width="196" height="52" rx="8" stroke="#8a93a3"/>
+    <rect x="14" y="190" width="196" height="52" rx="8" stroke="#8a93a3"/>
+    <rect x="270" y="176" width="196" height="66" rx="8" stroke="#2f8fb3" stroke-width="1.8"/>
+    <rect x="510" y="16" width="216" height="196" rx="8" stroke="#2f8fb3" stroke-width="1.8"/>
+    <rect x="522" y="44" width="96" height="42" rx="6"/>
+    <rect x="626" y="44" width="88" height="42" rx="6"/>
+    <rect x="522" y="110" width="192" height="42" rx="6" stroke-dasharray="4 3"/>
+    <rect x="522" y="160" width="192" height="40" rx="6" stroke-dasharray="4 3"/>
+    <rect x="510" y="262" width="216" height="52" rx="8" stroke="#c98a2b" stroke-width="1.8" stroke-dasharray="6 4"/>
+  </g>
+  <g font-family="ui-monospace, Menlo, monospace" fill="#1b2530">
+    <text x="14" y="20" font-size="10.5" fill="#8a93a3">TEMPLATES · rows, written once</text>
+    <text x="24" y="50" font-size="12.5" font-weight="600">Agent</text>
+    <text x="24" y="66" font-size="10" fill="#8a93a3">model, runtime, skills</text>
+    <text x="24" y="130" font-size="12.5" font-weight="600">Environment</text>
+    <text x="24" y="146" font-size="10" fill="#8a93a3">packages, repos, secrets</text>
+    <text x="24" y="210" font-size="12.5" font-weight="600">Vault</text>
+    <text x="24" y="226" font-size="10" fill="#8a93a3">secret overrides, per run</text>
+    <text x="282" y="196" font-size="12.5" font-weight="600" fill="#2f8fb3">Fountain, at launch</text>
+    <text x="282" y="212" font-size="10">merge env ∪ vault, vault wins</text>
+    <text x="282" y="228" font-size="10">split: broker or sandbox</text>
+    <text x="510" y="8" font-size="10.5" fill="#8a93a3">RUNS · the machine</text>
+    <text x="522" y="36" font-size="12.5" font-weight="600" fill="#2f8fb3">Sandbox</text>
+    <text x="530" y="62" font-size="10">Conversation</text>
+    <text x="530" y="76" font-size="10" fill="#8a93a3">transcript</text>
+    <text x="634" y="62" font-size="10">Conversation</text>
+    <text x="634" y="76" font-size="10" fill="#8a93a3">shares it</text>
+    <text x="530" y="128" font-size="10">env: config, placeholders</text>
+    <text x="530" y="142" font-size="9.5" fill="#8a93a3">GITHUB_TOKEN=__github_token__</text>
+    <text x="530" y="177" font-size="10">machine: built, warm,</text>
+    <text x="530" y="191" font-size="10" fill="#8a93a3">metered, reclaimed</text>
+    <text x="522" y="282" font-size="12.5" font-weight="600" fill="#c98a2b">Egress broker</text>
+    <text x="522" y="298" font-size="10" fill="#c98a2b">hosted, when the broker is on</text>
+    <text x="522" y="332" font-size="10" fill="#8a93a3">→ GitHub, model APIs, yours</text>
+  </g>
+  <g fill="none" stroke="#1b2530" stroke-width="1.4" marker-end="url(#pr-a)">
+    <path d="M210,56 H508"/>
+    <path d="M210,136 H488 V180"/>
+    <path d="M210,150 H244 V190 H268"/>
+    <path d="M210,216 H244 V222 H268"/>
+    <path d="M466,200 H496 V130 H520"/>
+  </g>
+  <g fill="none" stroke="#c98a2b" stroke-width="1.6" marker-end="url(#pr-b)">
+    <path d="M368,242 V290 H508"/>
+    <path d="M618,212 V260"/>
+  </g>
+  <g font-family="ui-monospace, Menlo, monospace" font-size="10" fill="#8a93a3">
+    <text x="300" y="50">runs as a conversation</text>
+    <text x="300" y="130">builds the machine</text>
+    <text x="418" y="120">placeholders</text>
+    <text x="380" y="284" fill="#c98a2b">values, per conversation</text>
+    <text x="612" y="244" fill="#c98a2b" text-anchor="end">HTTPS_PROXY, only exit</text>
+  </g>
+</svg>

--- a/docs/primitives.md
+++ b/docs/primitives.md
@@ -36,19 +36,95 @@ objects on purpose, and that division is the product.
 An Agent names an Environment. A Conversation runs an Agent. That Conversation
 can name a different Environment, and it can attach a Vault for that one run.
 
-```
- Environment  ----->  Agent  ----->  Conversation
-      ^                                   |
-      +---- overridden per run -----------+
-                                          |
- Vault  ------------ attached per run ----+
-```
+Three of the four are templates. They are rows that you write once and use
+many times. The fourth, the Conversation, is a run on a machine. The machine
+is the heavy work, and Fountain does it for you.
+
+<figure>
+<svg viewBox="0 0 740 352" role="img" aria-label="Three templates and one machine. Agent, Environment and Vault are rows a tenant writes once. When a conversation starts, Fountain builds a sandbox from the Environment, runs the Agent on it as a conversation, and merges the Environment's and the Vault's secrets, the Vault winning. On a hosted account with the egress broker on, a bound secret goes to the broker and the sandbox gets a placeholder; the sandbox reaches the internet only through the broker, which attaches the value. On any other account the secrets enter the sandbox as environment variables." style="max-width:100%;height:auto">
+  <defs>
+    <marker id="pr-a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="currentColor"/></marker>
+    <marker id="pr-b" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#c98a2b"/></marker>
+  </defs>
+  <g fill="none" stroke="currentColor" stroke-width="1.4">
+    <rect x="14" y="30" width="196" height="52" rx="8" stroke="#8a93a3"/>
+    <rect x="14" y="110" width="196" height="52" rx="8" stroke="#8a93a3"/>
+    <rect x="14" y="190" width="196" height="52" rx="8" stroke="#8a93a3"/>
+    <rect x="270" y="176" width="196" height="66" rx="8" stroke="#2f8fb3" stroke-width="1.8"/>
+    <rect x="510" y="16" width="216" height="196" rx="8" stroke="#2f8fb3" stroke-width="1.8"/>
+    <rect x="522" y="44" width="96" height="42" rx="6"/>
+    <rect x="626" y="44" width="88" height="42" rx="6"/>
+    <rect x="522" y="110" width="192" height="42" rx="6" stroke-dasharray="4 3"/>
+    <rect x="522" y="160" width="192" height="40" rx="6" stroke-dasharray="4 3"/>
+    <rect x="510" y="262" width="216" height="52" rx="8" stroke="#c98a2b" stroke-width="1.8" stroke-dasharray="6 4"/>
+  </g>
+  <g font-family="ui-monospace, Menlo, monospace" fill="currentColor">
+    <text x="14" y="20" font-size="10.5" fill="#8a93a3">TEMPLATES · rows, written once</text>
+    <text x="24" y="50" font-size="12.5" font-weight="600">Agent</text>
+    <text x="24" y="66" font-size="10" fill="#8a93a3">model, runtime, skills</text>
+    <text x="24" y="130" font-size="12.5" font-weight="600">Environment</text>
+    <text x="24" y="146" font-size="10" fill="#8a93a3">packages, repos, secrets</text>
+    <text x="24" y="210" font-size="12.5" font-weight="600">Vault</text>
+    <text x="24" y="226" font-size="10" fill="#8a93a3">secret overrides, per run</text>
+    <text x="282" y="196" font-size="12.5" font-weight="600" fill="#2f8fb3">Fountain, at launch</text>
+    <text x="282" y="212" font-size="10">merge env ∪ vault, vault wins</text>
+    <text x="282" y="228" font-size="10">split: broker or sandbox</text>
+    <text x="510" y="8" font-size="10.5" fill="#8a93a3">RUNS · the machine</text>
+    <text x="522" y="36" font-size="12.5" font-weight="600" fill="#2f8fb3">Sandbox</text>
+    <text x="530" y="62" font-size="10">Conversation</text>
+    <text x="530" y="76" font-size="10" fill="#8a93a3">transcript</text>
+    <text x="634" y="62" font-size="10">Conversation</text>
+    <text x="634" y="76" font-size="10" fill="#8a93a3">shares it</text>
+    <text x="530" y="128" font-size="10">env: config, placeholders</text>
+    <text x="530" y="142" font-size="9.5" fill="#8a93a3">GITHUB_TOKEN=__github_token__</text>
+    <text x="530" y="177" font-size="10">machine: built, warm,</text>
+    <text x="530" y="191" font-size="10" fill="#8a93a3">metered, reclaimed</text>
+    <text x="522" y="282" font-size="12.5" font-weight="600" fill="#c98a2b">Egress broker</text>
+    <text x="522" y="298" font-size="10" fill="#c98a2b">hosted, when the broker is on</text>
+    <text x="522" y="332" font-size="10" fill="#8a93a3">→ GitHub, model APIs, yours</text>
+  </g>
+  <g fill="none" stroke="currentColor" stroke-width="1.4" marker-end="url(#pr-a)">
+    <path d="M210,56 H508"/>
+    <path d="M210,136 H488 V180"/>
+    <path d="M210,150 H244 V190 H268"/>
+    <path d="M210,216 H244 V222 H268"/>
+    <path d="M466,200 H496 V130 H520"/>
+  </g>
+  <g fill="none" stroke="#c98a2b" stroke-width="1.6" marker-end="url(#pr-b)">
+    <path d="M368,242 V290 H508"/>
+    <path d="M618,212 V260"/>
+  </g>
+  <g font-family="ui-monospace, Menlo, monospace" font-size="10" fill="#8a93a3">
+    <text x="300" y="50">runs as a conversation</text>
+    <text x="300" y="130">builds the machine</text>
+    <text x="418" y="120">placeholders</text>
+    <text x="380" y="284" fill="#c98a2b">values, per conversation</text>
+    <text x="612" y="244" fill="#c98a2b" text-anchor="end">HTTPS_PROXY, only exit</text>
+  </g>
+</svg>
+<figcaption><b>Three templates, one machine.</b> Agent, Environment and Vault are rows you write once. When a Conversation starts, Fountain builds the sandbox from the Environment and runs the Agent on it. Several Conversations can share one machine. On a hosted account with the egress broker on, a bound secret goes to the broker and the sandbox gets a placeholder; the sandbox reaches the internet only through the broker, which attaches the value. On any other account, the merged secrets enter the sandbox as environment variables.</figcaption>
+</figure>
 
 A Conversation starts. At that moment Fountain merges the Environment's
-secrets with the Vault's secrets, then hands the result to the sandbox as
-environment variables. **The Vault wins on a key collision.** That one rule is
-what makes the division into four usable and not merely tidy.
+secrets with the Vault's secrets. **The Vault wins on a key collision.** That
+one rule is what makes the division into four usable and not merely tidy.
 [About vaults](concepts/vault.md) sets it out.
+
+What happens next depends on the account. On a self-hosted instance, and on a
+hosted account without the egress broker, the merged secrets enter the
+sandbox as environment variables. On a hosted account with the broker on, a
+bound secret does not. The sandbox gets a placeholder, such as
+`__github_token__`, and the broker puts the real value on each request to the
+bound host. [Where a secret comes from](concepts/secrets.md) follows one
+secret through both paths.
+
+Why an API for this, when you can run an agent in a sandbox by hand? Because
+the templates outlive the run. The machine, the secrets and the agent are
+rows you can list, diff, share and launch from code. Because the identity and
+the machine are separate, so one Environment can run as you, as a bot user,
+or as a customer. And because a run is a thing with an id, a status, a
+transcript and an event stream. A webhook, a cron job or another agent can
+start one and follow it.
 
 ## Substitution
 


### PR DESCRIPTION
Closes #1129. For the reader who knows Claude and knows sandboxes and asks why they'd want an API for that.

**`docs/primitives.md`** — the "How they compose" section's ASCII line (`Environment -> Agent -> Conversation`, no sandbox, no vault, no credential path) becomes an inline SVG in the house style of `docs/integrations/buzz.md` (`currentColor`, 740-wide `viewBox`, `figure` + `aria-label` + `figcaption`): the three templates on the left, the one machine on the right with two conversations on it, Fountain's merge-then-split in the middle, and the egress broker on the exit, labelled "hosted, when the broker is on". New prose says which of the four are templates, what happens to secrets on each kind of account (in the clear vs. placeholder + broker), and the "why an API" argument in three sentences — templates outlive the run, identity and machine are separable, a run is addressable.

**`README.md`** — a new "In one picture" section right under the lede, using `docs/images/primitives.svg` (the same drawing exported with explicit colours and a white ground, because GitHub renders SVG only as an image and `currentColor` would go black on its dark theme). Ships in the image via the existing `COPY docs`.

Honest about the state of the world: the broker is drawn dashed and labelled as hosted-and-opt-in; the caption and prose both describe the unbrokered path.

Gates: vale 0 errors / 0 warnings, docs-style clean, `docs_test` (links, anchors, nav) 29/29. Rendered and eyeballed at 2× — no overflow, no collisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)