### PR TITLE
docs: the manual catches up with the sandbox, team and contact APIs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -377,10 +377,11 @@ POST   /api/conversations                  # start (agent_id; optional vault_id,
 GET    /api/conversations/:id
 DELETE /api/conversations/:id
 POST   /api/conversations/:id/read         # clear unread state
+POST   /api/conversations/:id/requests/:request_id   # answer a permission request ({option_id})
 GET    /api/conversations/:id/tree         # the whole spawn tree this conversation belongs to
 POST   /api/conversations/:id/prompts      # follow-up turn
 POST   /api/conversations/:id/interrupt    # stop the running turn
-POST   /api/conversations/:id/terminate    # end the conversation and sandbox
+POST   /api/conversations/:id/terminate    # end the conversation; destroys the sandbox unless it is persistent or shared
 GET    /api/conversations/:id/turns
 GET    /api/conversations/:id/events       # log events as JSON (?streams=  ?after=  ?limit=)
 GET    /api/conversations/:id/stream       # SSE log stream (?streams=stdout,stderr,stage  ?wait=false)
@@ -420,6 +421,15 @@ default for this conversation. A persistent conversation lands on the agent's
 own machine. Fountain makes that machine on the first persistent launch of an
 agent, environment and vault. A second launch while the first still builds
 it gets `503 provisioning`, so send again shortly.
+
+`POST /api/conversations/:id/requests/:request_id` answers a permission
+request that blocks the agent. The request and its options arrive as a
+`permission_request` block on the event stream. Send `{option_id}`, and
+choose one of the `optionId` values that the block carried. The first answer
+wins. A request that another client, the timeout or the end of the turn
+resolved gets `409 permission_request_resolved`. An option the agent did not
+offer gets `422 unknown_option`. A sandbox's own token cannot answer, and
+gets `403 sprite_may_not_answer`.
 
 Whatever does not resolve is a `404`, so nobody can probe for an id.
 
@@ -717,11 +727,13 @@ From its next turn, the teammate holds seven MCP tools. Those are
 token. So no provider key enters the sandbox. The audit trail records each
 send as `team.contact.sent`, and never the content.
 
-There are four refusals. You get `404 team_comms_not_enabled` when the flag is
+There are five refusals. You get `404 team_comms_not_enabled` when the flag is
 off for the caller. You get `503 team_comms_not_configured` when the instance
-holds no keys. You get `409` for a second contact. You get
-`424 provider_error` when a provider refuses, where `channel` names which one.
-A provision is all or nothing.
+holds no keys. You get `409 contact_already_provisioned` for a second contact.
+You get `402 contact_limit_reached` when the account holds as many contacts
+as `TEAM_CONTACT_CEILING` permits, and the body carries `count` and `limit`.
+You get `424 provider_error` when a provider refuses, where `channel` names
+which one. A provision is all or nothing.
 
 `DELETE` releases both upstream, then forgets them. `GET /api/team/comms`
 answers `{enabled, configured}`, so a client knows whether to offer it. Read
@@ -995,10 +1007,10 @@ to walk the whole trail.
 |---|---|
 | `400` | The request body is invalid. |
 | `401` | The auth is absent or invalid. |
-| `402` | Your credit balance is zero or below. The code is `insufficient_credits`, and the body carries `upgrade_url`. The old `subscription_required` code does not occur. |
+| `402` | Your credit balance is zero or below. The code is `insufficient_credits`, and the body carries `upgrade_url`. The old `subscription_required` code does not occur. A teammate contact past the account's ceiling is `contact_limit_reached`. |
 | `403` | The wrong tenant. |
 | `404` | Nothing found. |
-| `409` | The request conflicts with the current state. The codes are `no_runner_online`, `sandbox_at_capacity` and `sandbox_not_attachable`. |
+| `409` | The request conflicts with the current state. The codes are `no_runner_online`, `sandbox_at_capacity`, `sandbox_not_attachable`, `sandbox_mid_turn`, `permission_request_resolved` and `contact_already_provisioned`. |
 | `410` | Somebody terminated the conversation. The code is `conversation_terminated`. Stop, and do not try again. |
 | `422` | A validation error. |
 | `429` | The rate limit stopped you. |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -176,9 +176,12 @@ a state of `started`, `done`, `failed` or `interrupted`.
     `terminated`, or *parks* a persistent home. The conversation goes back to
     `idle`, and it is resumable at the #649 price. The hourly reaper applies
     the same split to whatever a crashed server left behind.
-7. **`terminate`.** An explicit `POST .../terminate` destroys the sprite and
-   marks the conversation `terminated`. That is one of the two terminal
-   states, next to `failed`.
+7. **`terminate`.** An explicit `POST .../terminate` marks the conversation
+   `terminated`. That is one of the two terminal states, next to `failed`.
+   It destroys an ephemeral sprite that no other conversation holds. A
+   shared machine, or a persistent home, stays for the conversations that
+   remain on it. `DELETE /api/sandboxes/:id` resets a persistent home. Read
+   the [Sandboxes section](api.md#sandboxes) of the API reference.
 
 Here are the two status vocabularies, side by side.
 

--- a/docs/build/pieces.md
+++ b/docs/build/pieces.md
@@ -43,8 +43,9 @@ The team is a reserved channel, `fountain:team`. Any other string is yours.
 await fountain.run(text, { agent: "watchtower", channelId: `slack:${channel}` });
 ```
 
-You get the same behaviour, and one sandbox for each thread, with no team API
-at all. [AG-UI](../integrations/openbot.md) binds one coworker channel to one
+You get the same behaviour, and one sandbox for each thread, and you use none
+of the [team API](../api.md#team) for it.
+[AG-UI](../integrations/openbot.md) binds one coworker channel to one
 conversation this way, and [Buzz](../integrations/buzz.md) binds a Nostr
 thread.
 
@@ -101,7 +102,8 @@ states around its lifecycle.
                                        │      └── next message ┘
                                        │          wakes it, memory intact
                                        │
-                                       │  24 h running (default)
+                                       │  a terminate, or a configured
+                                       │  max-lifetime ceiling (off by default)
                                        ▼
                                    terminated — the thread stays readable and
                                    resumable; the next turn starts a new

--- a/docs/catalog/mcp-servers/fountain-comms.md
+++ b/docs/catalog/mcp-servers/fountain-comms.md
@@ -30,6 +30,12 @@ AgentPhone keys.** Give a teammate a contact, and Fountain creates an inbox
 and a number under those keys. The teammate reaches them through these tools
 alone, and the sandbox never sees a key.
 
+You give the contact from the team app, or with
+`POST /api/team/:agent_id/contact`. A `PATCH` changes the number that may
+prompt it. A `DELETE` releases the inbox and the number.
+`GET /api/team/comms` says whether this caller and this instance can offer
+one. Read [Team](../../api.md#team).
+
 This is the shape [fountain-buzz](fountain-buzz.md) has, and the argument
 holds more widely. When an agent needs a capability that a credential would
 grant, serve the capability. Do not ship the credential.
@@ -72,5 +78,6 @@ keys. If that is the wrong trade for your data, grant no contact.
 ## Related
 
 - [Agents as teammates](../../concepts/teammates.md).
+- [Team](../../api.md#team), the contact routes on the REST API.
 - [fountain-buzz](fountain-buzz.md), the same pattern for Nostr.
 - [MCP servers](index.md).

--- a/docs/catalog/mcp-servers/fountain-team.md
+++ b/docs/catalog/mcp-servers/fountain-team.md
@@ -35,6 +35,11 @@ A message sent this way lands in the thread of the teammate who gets it. It
 lands exactly as a message typed on the team page does, and the reader sees
 who sent it. There is no back channel.
 
+The same roster is on the REST API, for a caller outside the sandbox.
+`GET /api/team` lists it, and `POST /api/team/:agent_id/messages` sends a
+turn. Read [Team](../../api.md#team). These tools are the view from inside
+a teammate's own conversation, and they add no capability of their own.
+
 ## Two things that catch agents out
 
 **`send_to_teammate` can fail with `busy` or `starting`.** A teammate in the
@@ -63,6 +68,7 @@ you listed can be busy when you send.
 ## Related
 
 - [Agents as teammates](../../concepts/teammates.md), what this acts on.
+- [Team](../../api.md#team), the same roster over the REST API.
 - [MCP servers](index.md).
 - [create-team](../skills/create-team.md), which builds the roster these tools
   read.

--- a/docs/catalog/mcp-servers/index.md
+++ b/docs/catalog/mcp-servers/index.md
@@ -34,7 +34,8 @@ the token reaches only that conversation's owner.
 
 **Fountain recomputes the injection at each turn.** A capability granted
 mid-session appears on the next turn, and not at the next provision. Give a
-teammate a contact while it works, and it can send mail on its next reply.
+teammate a contact while it works, with `POST /api/team/:agent_id/contact`,
+and it can send mail on its next reply. Read [Team](../../api.md#team).
 
 Fountain scopes each call to one tenant. A message that goes through a tool
 lands in the thread of the teammate who gets it. It lands exactly as a message

--- a/docs/catalog/runtimes/index.md
+++ b/docs/catalog/runtimes/index.md
@@ -72,5 +72,5 @@ different paths.
 
 - [About agents](../../concepts/agent.md), where you set `runtime`.
 - [Skills](../skills/index.md).
-- [`fountain acp`](../../integrations/acp.md), the adapter that three of the
-  four speak through.
+- [`fountain acp`](../../integrations/acp.md), the adapter that drives all
+  four from an editor or a chat surface.

--- a/docs/catalog/skills/create-team.md
+++ b/docs/catalog/skills/create-team.md
@@ -40,11 +40,16 @@ that teammates can reach each other.
 ## What it creates
 
 For each teammate it creates an [Agent](../../concepts/agent.md), then a
-[team membership](../../concepts/teammates.md). The membership opens that
-agent's one conversation and provisions its sandbox.
+[team membership](../../concepts/teammates.md), with `POST /api/team`. The
+membership opens that agent's one conversation and provisions its sandbox.
 
-You can edit everything it sets afterwards, from the team app. Brain, role and
-name are not decisions you are stuck with.
+When the team has a job that repeats, such as triage or a daily report, it
+can also create a [schedule](../../api.md#schedules) for a teammate. That is
+a cron line and a prompt, and the teammate runs it on its own.
+
+You can edit everything it sets afterwards, from the team app or with the
+[Team](../../api.md#team) routes. Brain, role and name are not decisions you
+are stuck with.
 
 ## Its own rules
 
@@ -61,10 +66,14 @@ helpful flow and a destructive one.
 ## Limits
 
 **It only adds.** It will not remove a teammate, rename one, or reorganise a
-team that already exists.
+team that already exists. The team app does those, and so do
+`DELETE /api/team/:agent_id` and `PATCH /api/team/:agent_id`. Read
+[Team](../../api.md#team).
 
-**It needs your inference credentials in place first.** It checks, then tells
-you what is absent. It does not create agents that cannot run.
+**It needs your inference credentials in place first.** It reads
+`GET /api/account/inference-credentials`, then tells you what is absent. It
+does not create agents that cannot run. Read
+[Inference credentials](../../api.md#inference-credentials).
 
 **Each teammate it creates provisions a sandbox.** A roster of five is five
 machines. Read
@@ -73,5 +82,6 @@ machines. Read
 ## Related
 
 - [Agents as teammates](../../concepts/teammates.md), what it builds.
+- [Team](../../api.md#team), the routes it calls.
 - [About agents](../../concepts/agent.md).
 - [Skills](index.md).

--- a/docs/catalog/skills/fountain.md
+++ b/docs/catalog/skills/fountain.md
@@ -52,6 +52,10 @@ persistent mode, the child gets that machine instead. To name the other mode
 for one child, send `sandbox_mode` on the same call. See
 [Sandboxes](../../concepts/sandboxes.md).
 
+`GET /api/sandboxes` lists the machines the token's owner has, with the
+conversations on each. Read [Sandboxes](../../api.md#sandboxes) and
+[Conversations](../../api.md#conversations) for the fields.
+
 ## Limits
 
 **A spawned agent has the same skill.** Nothing stops recursion, so the skill

--- a/docs/concepts/agent.md
+++ b/docs/concepts/agent.md
@@ -10,7 +10,7 @@ An Agent is a named configuration for a coding agent that you can run again
 and again. It is config, and not a process. Nothing runs until a
 [Conversation](conversation.md) runs it.
 
-An Agent decides seven things.
+An Agent decides eight things.
 
 - **`model`**, as `provider/model-id`. An example is
   `anthropic/claude-sonnet-4-6`.
@@ -22,6 +22,8 @@ An Agent decides seven things.
 - **`mcp_servers`**, the MCP server definitions, with `${VAR}` substitution in
   their env.
 - **`metadata`**, a free-form map for your own records.
+- **`sandbox_mode`**, `ephemeral` or `persistent`. Read
+  [About sandboxes](sandboxes.md).
 
 ## Why it exists
 

--- a/docs/concepts/conversation.md
+++ b/docs/concepts/conversation.md
@@ -3,7 +3,8 @@
 This page explains what a Conversation is, and what happens to its sandbox
 over time. For the state table, read
 [Conversation states](../reference/conversation-states.md). For the endpoints,
-read the [API reference](../api.md).
+read the [Conversations section](../api.md#conversations) of the API
+reference.
 
 ## What a conversation is
 
@@ -94,9 +95,12 @@ conversations. You watch one work in the
 [conversations app](https://github.com/jhgaylor/fountain-conversations),
 a separate application on `/api`.
 
-**Not a sandbox you manage.** You never create, name or address a sandbox.
-Fountain provisions it when the Conversation starts, and reclaims it on the
-rules above.
+**Not a sandbox you create.** Fountain provisions the sandbox when the
+Conversation starts, and reclaims it on the rules above. You can still address
+one. `GET /api/sandboxes` lists them, `sandbox_id` on a launch puts a second
+Conversation on one, and `DELETE /api/sandboxes/:id` resets a persistent one.
+Read [About sandboxes](sandboxes.md) and the
+[Sandboxes section](../api.md#sandboxes) of the API reference.
 
 ## When to use something else
 
@@ -105,7 +109,7 @@ continues, and not one run for each task. A teammate is still a Conversation,
 bound to a reserved channel.
 
 Use a schedule when the run must happen without you. Read the
-[API reference](../api.md).
+[Schedules section](../api.md#schedules) of the API reference.
 
 ## Where to go next
 

--- a/docs/concepts/environment.md
+++ b/docs/concepts/environment.md
@@ -92,7 +92,7 @@ reach only the broker. The broker then applies your policy. With
 `unrestricted`, a request goes through to any host, with only the credentials
 you bound. With `limited`, the broker refuses a request to a host that is not
 in `allowed_hosts`. The refusal is a 403 that names the host. The broker's
-request log shows each decision. List what the setup of the sandbox needs, such as
+request log, `GET /api/conversations/:id/egress`, shows each decision. List what the setup of the sandbox needs, such as
 `registry.npmjs.org` for the agent's adapter. A host with a bound credential,
 such as the model's API, needs no entry.
 
@@ -130,7 +130,8 @@ get a value that nobody can ever read back to check.
 
 Use [inference credentials](../integrations/index.md) for model API keys.
 Those belong to one user. An operator never sets them, and an Environment
-never stores them.
+never stores them. You set them in the console or over the
+[inference credentials API](../api.md#inference-credentials).
 
 ## Where to go next
 

--- a/docs/concepts/sandboxes.md
+++ b/docs/concepts/sandboxes.md
@@ -4,7 +4,9 @@ This page explains what a sandbox is, why Fountain does not let you create
 one, and what changes when you move to a different provider. For the
 executable contract a backend must meet, read
 [the sandbox contract](../integrations/sandbox-contract.md). To choose and
-configure one, read [Self-host Fountain](../self-hosting.md).
+configure one, read [Self-host Fountain](../self-hosting.md). For the
+endpoints, read the [Sandboxes section](../api.md#sandboxes) of the API
+reference.
 
 ## What a sandbox is
 
@@ -15,7 +17,8 @@ with its own transcript.
 You never create one on its own. Fountain provisions a sandbox when a
 conversation starts. Fountain reclaims it when every conversation on it goes
 quiet, or when it runs too long. You can name one, with `sandbox_id`, to put
-a second conversation on it.
+a second conversation on it. `GET /api/sandboxes` lists them, and
+`fountain sandbox` does the same from the CLI.
 
 That is deliberate. A sandbox you could create on its own would be a resource
 you could leak. The machine that nobody remembered to stop is what makes agent

--- a/docs/concepts/secrets.md
+++ b/docs/concepts/secrets.md
@@ -188,10 +188,13 @@ sandbox through the broker. Each row shows the host, the binding that matched
 and so the credential attached, the status, and the latency. A refused host
 shows the refusal. The list stays for `BROKER_LOG_RETENTION_HOURS` after the
 conversation ends. The route needs a key with full scope. The token a sandbox
-holds cannot read it.
+holds cannot read it. Read the
+[Conversations section](../api.md#conversations) of the API reference.
 
 You manage bindings on Account, then Credential bindings, or with
-`GET /api/secret-bindings` and its siblings. The page and the routes are only
+`GET /api/secret-bindings` and its siblings, in the
+[Secret bindings section](../api.md#secret-bindings) of the API reference.
+The page and the routes are only
 there when the broker is on for the account. A binding is about the name of
 a secret. So it applies to every environment and vault that holds a secret
 of that name.

--- a/docs/concepts/teammates.md
+++ b/docs/concepts/teammates.md
@@ -1,7 +1,8 @@
 # Agents as teammates
 
 This page explains what a teammate is, and why it is not a fifth primitive.
-For the endpoints, read the [API reference](../api.md).
+For the endpoints, read the [Team section](../api.md#team) of the API
+reference.
 
 ## What a teammate is
 
@@ -80,18 +81,24 @@ teammate was busy for half an hour, or when the sandbox quota was full.
 
 Remove a teammate and Fountain deletes its schedules.
 
+The team app, `fountain.team.schedules` in the SDK, and the
+[Schedules API](../api.md#schedules) all manage the same rows.
+
 ## A teammate can have an email address and a phone number
 
 This is an alpha feature, and it is off by default on the hosted platform.
 Give a teammate a contact, and it gets an address and a number under keys
-that Fountain holds. Its sandbox never sees a key. Read
-[fountain-comms](../catalog/mcp-servers/fountain-comms.md) for the tools, and
+that Fountain holds. Its sandbox never sees a key. The team app and
+`POST /api/team/:agent_id/contact` both give a teammate a contact. Read
+[fountain-comms](../catalog/mcp-servers/fountain-comms.md) for the tools,
+the [Team section](../api.md#team) of the API reference for the routes, and
 [Feature status](../reference/feature-status.md) for how to get it on.
 
 ## What a teammate is not
 
-**Not a primitive.** Nothing in the API creates a teammate. You bind a
-conversation to a channel.
+**Not a primitive.** `POST /api/team` adds a teammate, and it creates no new
+kind of object. It binds a conversation to the channel. The rest of the
+[Team API](../api.md#team) reads and writes that conversation.
 
 **Not a shared inbox.** One Agent has one team conversation. Two people who
 message the same teammate talk to the same thread and the same machine.
@@ -104,4 +111,5 @@ survives without it. Read [About conversations](conversation.md).
 
 - [About conversations](conversation.md), for the lifecycle below this one.
 - [About agents](agent.md).
-- [API reference](../api.md), for the team endpoints and schedules.
+- [Team](../api.md#team) and [Schedules](../api.md#schedules) in the API
+  reference, for the endpoints.

--- a/docs/concepts/vault.md
+++ b/docs/concepts/vault.md
@@ -114,8 +114,9 @@ Use `env_vars` on an Environment for a value that is not sensitive. A Vault
 that holds one non-secret is a Vault that somebody later assumes is secret.
 
 Use [inference credentials](../integrations/index.md) for model API keys.
-Those belong to one user, you enter them in the app, and they never belong in
-a Vault.
+Those belong to one user, and they never belong in a Vault. You enter them in
+the console or over the
+[inference credentials API](../api.md#inference-credentials).
 
 ## Secret expiry
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,7 +62,7 @@ message.
 | `DAYTONA_API_KEY` | — | For the `daytona` provider. | The [Daytona](https://daytona.io) API key. Its presence turns the provider on. |
 | `DAYTONA_API_URL` | `https://app.daytona.io/api` | — | Repoints the Daytona API, for a Daytona you host yourself. |
 | `DAYTONA_SNAPSHOT` | The org default. | — | The snapshot, which is an image, that Fountain creates a new Daytona sandbox from. The organization must hold it. The default image has no agent CLI, so build one from `images/daytona/` for real use. |
-| `SANDBOX_IDLE_TIMEOUT_MINUTES` | `60` | — | No turn activity for this long, and Fountain reclaims the sandbox. The conversation stays [resumable](guides/operate/sandbox-lifetime.md). A `0` turns the bound off, and boot refuses whatever is not a non-negative integer. |
+| `SANDBOX_IDLE_TIMEOUT_MINUTES` | `60` | — | No turn activity for this long, and Fountain parks the sandbox. A provider without `:suspend` destroys it instead. The conversation stays [resumable](guides/operate/sandbox-lifetime.md) either way. A `0` turns the bound off, and boot refuses whatever is not a non-negative integer. |
 | `SANDBOX_MAX_LIFETIME_HOURS` | `0` (off) | — | A ceiling on one continuous run, whatever the activity. Off by default: nothing stops a sandbox that stays busy. Set it to park a persistent home, or destroy an ephemeral sandbox, after this many hours. The same boot refusal applies. |
 | `CHECKPOINT_CREATION_ENABLED` | `false` | — | Set to `true`, and Fountain takes a checkpoint of each persistent home when it parks, on a provider that has checkpoints (Sprites). The checkpoint belongs to that one machine. It can roll the machine back, and it cannot rebuild a machine that the provider lost. Each park adds one checkpoint, and Fountain does not delete old ones. The same flag also makes Fountain checkpoint each environment after it provisions a sandbox, which Sprites cannot restore into a new sandbox. |
 | `LOG_OUTPUT_BUDGET_MB` | `50` | — | The durable log volume for one conversation. Once a conversation has persisted this much sandbox output, Fountain writes one truncation marker and discards the rest. Retention bounds age, and this bounds rate. The same `0` rule and the same boot refusal apply. |
@@ -384,7 +384,9 @@ and read on both.
 
 Fountain holds the provider keys and serves the tools itself, so a key never
 enters a sandbox. With either key unset, the feature reports itself
-unavailable, even where the flag is on.
+unavailable, even where the flag is on. `GET /api/team/comms` reports that
+state, and `POST /api/team/:agent_id/contact` provisions a contact. Read
+[Team](api.md#team).
 
 | Variable | Default | Required | Effect |
 |---|---|---|---|

--- a/docs/guides/operate/plans-and-prices.md
+++ b/docs/guides/operate/plans-and-prices.md
@@ -83,8 +83,9 @@ tells the caller to try again in a minute.
 ## Give someone free credit
 
 To make an account pay **nothing at all**, comp the account. Open
-`/admin/users` and select `comp` on the row. Fountain never checks that
-account's balance.
+`/admin/users` and select `comp` on the row, or send
+`POST /api/admin/users/{id}/comp` with `{"comped": true}`. Fountain never
+checks that account's balance.
 
 To give an account credit that never expires, use the admin API:
 `POST /api/admin/users/{id}/credits` with `{"cents": 1000, "note": "why"}`.

--- a/docs/guides/operate/sandbox-lifetime.md
+++ b/docs/guides/operate/sandbox-lifetime.md
@@ -35,6 +35,14 @@ home keeps its disk.
 
 Fountain never ages a suspended sandbox out. Its sprite stays at the provider
 until you terminate the conversation, or until somebody deletes the account.
+A user can also reset a persistent sandbox with `DELETE /api/sandboxes/:id`,
+and an admin can reap one with `POST /api/admin/sandboxes/:id/reap`.
+`GET /api/sandboxes?status=suspended` lists the parked ones. Read
+[Sandboxes](../../api.md#sandboxes).
+
+With `CHECKPOINT_CREATION_ENABLED=true`, Fountain takes a checkpoint of a
+persistent sandbox each time it parks, on a provider that has checkpoints.
+Read the [configuration reference](../../configuration.md#sandboxes).
 
 ## Not every provider can suspend
 

--- a/docs/guides/operate/sandbox-spend.md
+++ b/docs/guides/operate/sandbox-spend.md
@@ -44,6 +44,9 @@ names the accounts with the most hours, each with its own idle share.
 The panel is there whether or not you turn billing on. A self-hosted instance <!-- vale disable-line STE.IngForms -->
 still pays a provider.
 
+The list under the cards is also `GET /api/admin/sandboxes`, for a script.
+Read [Admin](../../api.md#admin).
+
 ## Record the invoice next to the figure
 
 The computed cost is a model. Until a real invoice sits next to it, the

--- a/docs/integrations/acp.md
+++ b/docs/integrations/acp.md
@@ -119,7 +119,9 @@ other field in `_meta`.
 | `freshSession` | With `channelId`, it skips the resume this one time. It unbinds the current conversation, which continues and then retires like any other idle one. It opens a new conversation, and binds the channel to that. A Buzz owner's `!rotate` turns into this ([#788](https://github.com/BinaryBourbon/fountain/pull/788)). Fountain ignores it without `channelId`. |
 
 The same knobs exist on the API, as `channel_id`, `fresh`, `sandbox_mode` and
-`sandbox_id` on `POST /api/conversations`.
+`sandbox_id` on `POST /api/conversations`. Read
+[Conversations](../api.md#conversations), and
+[Sandboxes](../api.md#sandboxes) for the list a `sandboxId` comes from.
 
 ## Permission prompts
 

--- a/docs/integrations/daytona.md
+++ b/docs/integrations/daytona.md
@@ -1,8 +1,8 @@
 # Daytona
 
-[Daytona](https://daytona.io) is one of the three
-[sandbox providers](sandbox-contract.md), and of the three it matches the
-contract most closely.
+[Daytona](https://daytona.io) is one of the four
+[sandbox providers](sandbox-contract.md), and of the three hosted ones it
+matches the contract most closely.
 
 `DAYTONA_API_KEY` turns it on. `SANDBOX_PROVIDER=daytona` makes it the default
 for a new sandbox, and one agent can pin it with `sandbox_provider`. A sandbox

--- a/docs/integrations/e2b.md
+++ b/docs/integrations/e2b.md
@@ -1,6 +1,6 @@
 # E2B
 
-[E2B](https://e2b.dev) is one of the three
+[E2B](https://e2b.dev) is one of the four
 [sandbox providers](sandbox-contract.md). `E2B_API_KEY` turns it on, and
 `SANDBOX_PROVIDER=e2b` makes it the default for a new sandbox. One agent can
 also pin it with `sandbox_provider`. A sandbox that already exists always

--- a/docs/integrations/hermes.md
+++ b/docs/integrations/hermes.md
@@ -141,16 +141,19 @@ on the environment's setup script.
 ## Limits
 
 - **No permission prompts.** A Fountain agent runs under the sandbox's own
-  policy, so there is nothing for Hermes to approve. #643 forwards a
-  permission request to a client, and it lands for `fountain acp` clients
-  first. This plugin polls the log feed, so neither outcome changes it.
+  policy, so there is nothing for Hermes to approve. Fountain forwards a
+  permission request to an ACP client, and the API answers one at
+  `POST /api/conversations/:id/requests/:request_id`. This plugin polls the
+  log feed and answers none, so an `ask` policy waits until the server's
+  timeout refuses it. Read [Conversations](../api.md#conversations).
 - **Text only, and one direction.** The plugin returns the agent's text and
   the names of the tools it used. A file the agent wrote stays in the sandbox.
   Push it from the environment's repo, or ask the agent to print it. A prompt
   cannot carry an image through the plugin.
 - **You choose an agent, and you do not manage one here.** To create or edit
-  an agent, an environment or a vault, use Fountain's console, the CLI or
-  `fountain apply`. The plugin lists what exists, and runs it.
+  an agent, an environment or a vault, use Fountain's console, the
+  [API](../api.md), the CLI or `fountain apply`. The plugin lists what
+  exists, and runs it.
 
 The plugin's source and its tests are at
 [`integrations/hermes/`](https://github.com/BinaryBourbon/fountain/tree/main/integrations/hermes)

--- a/docs/integrations/openbot.md
+++ b/docs/integrations/openbot.md
@@ -39,8 +39,8 @@ against, and nothing more.
 You need two things from Fountain. The agent's id, and an API key.
 
 ```bash
-fountain agents list                 # the id
-fountain auth api-keys create openbot
+fountain agent list                  # the id
+fountain keys create openbot
 ```
 
 In OpenBot, open `/agents`, create a coworker, then complete four fields.
@@ -104,10 +104,12 @@ The results are the ones you would want.
   mint the same thread id share nothing.
 
 The conversations appear in Fountain like any others, with a `channel_id` of
-`agui:<threadId>`.
+`agui:<threadId>`. The API filters on it. Read
+[Conversations](../api.md#conversations).
 
 ```bash
-fountain conversations list --channel "agui:<threadId>"
+curl -H "Authorization: Bearer ftn_..." \
+  "https://your-fountain/api/conversations?channel_id=agui:<threadId>"
 ```
 
 ### The standing role
@@ -202,7 +204,10 @@ Fountain has no platform-level model key, on purpose
   OpenBot user in a deployment reaches Fountain as the account that owns it.
   OpenBot's own `actor.id` does not travel.
 - **No approvals.** OpenBot can hand control to a person mid-run. A Fountain
-  agent that asks permission for a tool call has nowhere to ask
+  agent that asks permission for a tool call has nowhere to ask on this
+  protocol. The API answers such a request at
+  `POST /api/conversations/:id/requests/:request_id`, and the AG-UI endpoint
+  does not carry it to the host
   ([#643](https://github.com/BinaryBourbon/fountain/issues/643)).
 - **Attachments do not travel.** An attachment on an OpenBot message does not
   reach Fountain. The prompt is text.

--- a/docs/integrations/sprites.md
+++ b/docs/integrations/sprites.md
@@ -1,6 +1,6 @@
 # Sprites
 
-[sprites.dev](https://sprites.dev) is the first of the three
+[sprites.dev](https://sprites.dev) is the first of the four
 [sandbox providers](sandbox-contract.md), and the instance default
 (`SANDBOX_PROVIDER=sprites`). It is a hosted service. A Fountain instance
 needs at least one provider credential. With none configured, each
@@ -45,7 +45,8 @@ recovers it. On yours, you pay. Two results follow.
   registration, or restrict it, before you put an instance on the internet.
 - Fountain caps concurrency for each user. The credit balance sets the cap,
   between a floor of 2 and a ceiling of 20. An admin can override it for one
-  user from the admin panel. A sandbox counts from the moment a provision starts, because that is
+  user from the admin panel, or with `POST /api/admin/users/:id/sandbox-limit`.
+  A sandbox counts from the moment a provision starts, because that is
   the moment it starts to cost money.
 
 Fountain never shows the token to a tenant, to the admin UI, or to a sandbox.

--- a/docs/integrations/stripe.md
+++ b/docs/integrations/stripe.md
@@ -55,7 +55,7 @@ real money.
   event. A transient failure returns a 500, so that Stripe delivers it again.
 - A refund removes the refunded amount from the balance, and the balance can
   go below zero. A won dispute puts nothing back by itself. Add it by hand
-  from the admin panel.
+  from the admin panel, or with `POST /api/admin/users/:id/credits`.
 - A comped account cannot buy. It has nothing to pay for.
 
 ## Verify

--- a/docs/llm-integration.md
+++ b/docs/llm-integration.md
@@ -33,18 +33,27 @@ curl $FOUNTAIN_URL/llms.txt
 curl $FOUNTAIN_URL/llms-full.txt
 ```
 
-## There is no first-party MCP server
+## There is no MCP server for your IDE
 
 **Nobody built one.** An MCP server that exposes the four primitives as tools
-is an idea that Fountain discussed and did not build. No package exists to
-install, and no config block works. Use the `/skill` file above. It gives an
-agentic IDE the full API surface in one fetch.
+to an IDE is an idea that Fountain discussed and did not build. No package
+exists to install, and no config block works. Use the `/skill` file above. It
+gives an agentic IDE the full API surface in one fetch.
+
+Fountain does host three MCP servers, and each one serves a conversation's own
+sandbox, with that conversation's token. They are
+[fountain-team](catalog/mcp-servers/fountain-team.md),
+[fountain-comms](catalog/mcp-servers/fountain-comms.md) and
+[fountain-buzz](catalog/mcp-servers/fountain-buzz.md). An IDE cannot connect
+to them. Everything they do is also on the [REST API](api.md#team).
 
 ## How to use the API from an agent
 
 1. Load the skill from `/skill` when the session starts.
 2. Authenticate with a Fountain API key from the agent's environment.
-3. Start sub-agents with the CLI or the REST API.
+3. Start sub-agents with the CLI or the REST API. The
+   [team](api.md#team), [schedule](api.md#schedules) and
+   [sandbox](api.md#sandboxes) routes are on the same surface.
 
 Here is an example prompt.
 

--- a/docs/primitives.md
+++ b/docs/primitives.md
@@ -149,8 +149,11 @@ channel `fountain:team`. Read
 [Agents as teammates](concepts/teammates.md).
 
 A **sandbox** is not an object you create. Fountain gives you one when a
-Conversation starts, and takes it back when the Conversation ends. Read
-[About conversations](concepts/conversation.md).
+Conversation starts. An ephemeral sandbox ends with its Conversation, and a
+persistent one stays as the Agent's own machine. You can list a sandbox, put
+a second Conversation on it with `sandbox_id`, and reset a persistent one.
+Read [About sandboxes](concepts/sandboxes.md) and the
+[Sandboxes section](api.md#sandboxes) of the API reference.
 
 ## Where to go next
 

--- a/docs/reference/conversation-states.md
+++ b/docs/reference/conversation-states.md
@@ -56,9 +56,10 @@ new one.
 An interrupt applies to the turn in flight, and not to the conversation. The
 conversation returns to `idle` and stays usable.
 
-Do not terminate a conversation you want back. Termination destroys the
-sandbox, and the memory the agent works from goes with it. The transcript
-stays.
+Do not terminate a conversation you want back. On an ephemeral sandbox that
+no other conversation holds, termination destroys the sandbox, and the memory
+the agent works from goes with it. A persistent or shared sandbox stays up
+for the conversations that remain on it. The transcript stays in both cases.
 
 A sandbox that a configured ceiling reclaims leaves the conversation
 resumable, and leaves the agent without its earlier context. State what

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -67,7 +67,7 @@ on. The docs say **sandbox**.
 | **Reaper** | The background sweep that suspends an idle sandbox, and destroys one that passed a configured ceiling. |
 | **Runner** | A machine you own that runs `fountain runner` and acts as a sandbox provider. Read [Self-hosted runners](../integrations/runners.md). |
 | **Runtime** | The coding-agent CLI that a sandbox runs. One of `claude`, `codex`, `gemini`, `opencode`. |
-| **Sandbox** | The isolated machine that one Conversation runs in. Fountain provisions it at launch and reclaims it on the lifetime rules. |
+| **Sandbox** | The isolated machine that a Conversation runs in. Several Conversations can share one. Fountain provisions it at launch and reclaims it on the lifetime rules. `GET /api/sandboxes` lists them. |
 | **Sandbox provider** | A backend that Fountain provisions sandboxes on. Sprites, E2B, Daytona, or a self-hosted runner. Read [the sandbox contract](../integrations/sandbox-contract.md). |
 | **Skill** | A `SKILL.md` that Fountain writes into the sandbox, inline or from GitHub. |
 | **Sprite** | One sandbox on the Sprites provider. Not a Fountain concept. Read [Sprites](../integrations/sprites.md). |
@@ -82,5 +82,7 @@ A **team** is not an object. Read
 [Agents as teammates](../concepts/teammates.md).
 
 A **sandbox** is not an object you create. Fountain provisions it when a
-Conversation starts, and reclaims it when the Conversation ends. Read
+Conversation starts. You can list one, put a second Conversation on it with
+`sandbox_id`, and reset a persistent one. Read
+[Sandboxes](../api.md#sandboxes) and
 [About conversations](../concepts/conversation.md).

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -303,6 +303,27 @@ checkout is where the first turn left it, and the agent's session still holds
 what it learned. A [suspended](reference/conversation-states.md) sandbox wakes
 for it.
 
+## Sandboxes
+
+A sandbox is the machine a conversation runs on, and several conversations
+can share one. Two options on `run()` control that. The `sandbox` option
+names a sandbox you already have, by id, and the new conversation lands on
+it. The `sandboxMode` option is `"ephemeral"` or `"persistent"`, and it
+replaces the agent's default.
+
+```ts
+const first = await fountain.run("Clone the repo and run the tests", { agent: "reposage" });
+const { sandbox_id } = await fountain.resume(first.conversationId).get();
+await fountain.run("Now fix the failures", { agent: "reposage", sandbox: sandbox_id! });
+
+await fountain.sandboxes({ status: ["ready", "suspended"] });  // the list, with the conversations on each
+await fountain.sandbox(id);
+await fountain.resetSandbox(id);   // destroy a persistent machine; the conversations stay
+```
+
+`resetSandbox()` refuses an ephemeral sandbox, and one with a turn in flight.
+The [API reference](api.md#sandboxes) has the rules.
+
 ## Timeouts
 
 `run()` waits as long as the turn takes, and agent work fairly runs for hours.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -15,9 +15,9 @@ Start with [Deploy an instance](guides/operate/deploy.md).
 | **A sandbox provider** | [sprites.dev](https://sprites.dev) is the default. [E2B](integrations/e2b.md) and [Daytona](integrations/daytona.md) are two more hosts. A user can also bring their own machine with [`fountain runner`](integrations/runners.md), which needs no credential. The app boots without a provider, but then each conversation fails. |
 | **A mail provider** | Resend, or any SMTP server. Read [Configure email](guides/operate/email.md). It is a decision, and not an optional extra. |
 
-A sandbox runs on one of three backends. Somebody else runs all three of
-them as a service, so a Fountain instance is not self-contained. Self-hosted
-Daytona comes closest.
+A sandbox runs on one of three hosted backends, or on a user's own runner.
+Somebody else runs all three hosted backends as a service, so a Fountain
+instance is not self-contained. Self-hosted Daytona comes closest.
 
 | Provider | Turned on by | When idle | Notes |
 |---|---|---|---|

--- a/docs/troubleshooting/conversation-stuck-or-failed.md
+++ b/docs/troubleshooting/conversation-stuck-or-failed.md
@@ -29,6 +29,12 @@ fountain conv interrupt <conv-id>     # stop the in-flight turn, keep the sandbo
 fountain conv terminate <conv-id>     # destroy the sandbox, end the conversation
 ```
 
+The sandbox itself has an API. `GET /api/sandboxes/:id` shows its status,
+its provider and each conversation on it. `DELETE /api/sandboxes/:id` resets
+a persistent sandbox. Fountain destroys the machine and keeps the
+conversations, and the next prompt builds a clean machine. Read
+[Sandboxes](../api.md#sandboxes).
+
 ## The provider refused the model
 
 A turn fails when the model provider refuses the agent's model. Fountain
@@ -60,8 +66,10 @@ further prompt.
 error. The sandbox parks and scales to zero. The next prompt wakes it, and the
 agent's memory is intact.
 
-`idle` with a *destroyed* sandbox is what an explicit reap leaves, or what a
-configured max-lifetime ceiling leaves behind. The next prompt provisions a fresh
+`idle` with a *destroyed* sandbox is what a reset, an admin reap or a
+configured max-lifetime ceiling leaves behind. A reset is
+`DELETE /api/sandboxes/:id`. An admin reap is
+`POST /api/admin/sandboxes/:id/reap`, or the admin page. The next prompt provisions a fresh
 sandbox. Fountain leaves the stored transcript alone, but the agent starts a
 fresh session. Read [About conversations](../concepts/conversation.md), and
 the full table in [Conversation states](../reference/conversation-states.md).
@@ -73,7 +81,11 @@ row. That row counts against the user's quota, which is 2 concurrent sandboxes
 by default.
 
 The reaper runs each hour at :07 and releases a row that has been stuck for
-more than 60 minutes. An admin can raise a user's cap from `/admin/users` at once.
+more than 60 minutes. An admin can raise a user's cap at once, from
+`/admin/users` or with `POST /api/admin/users/:id/sandbox-limit`. An admin
+can also see every sandbox with `GET /api/admin/sandboxes`, and release a
+stuck one with `POST /api/admin/sandboxes/:id/reap`. Read
+[Admin](../api.md#admin).
 
 The reaper logs one summary line for each run.
 

--- a/docs/troubleshooting/sandbox-errors.md
+++ b/docs/troubleshooting/sandbox-errors.md
@@ -45,8 +45,11 @@ If you scrape metrics, a failure to provision shows as
 
 A user at their quota for concurrent sandboxes, which is 2 by default, sees a
 provision fail while the provider is healthy. A crashed provision leaves a row
-that counts until the reaper releases it, each hour at :07. Read
-[A conversation is stuck or failed](conversation-stuck-or-failed.md).
+that counts until the reaper releases it, each hour at :07. An admin can
+release it now with `POST /api/admin/sandboxes/:id/reap`, or raise the cap
+with `POST /api/admin/users/:id/sandbox-limit`. Read
+[A conversation is stuck or failed](conversation-stuck-or-failed.md) and
+[Admin](../api.md#admin).
 
 ## Related
 


### PR DESCRIPTION
## Why

Since the docs rewrite the API grew `GET/DELETE /api/sandboxes`, the whole `/api/team` surface (roster, messages, history, `/contact`, `/comms`, `/stream`, schedules), `sandbox_id`/`sandbox_mode` on launch, `POST .../requests/:request_id` and the egress log. Pages still said there was no way to address a sandbox, that "nothing in the API creates a teammate", that terminate always destroys the sandbox, that there were three sandbox providers, and quoted CLI commands that do not exist.

## What

Every page under `docs/` was read against `router.ex`, the controllers, the SDK and the CLI. 34 pages change; each edit is local and links the matching `api.md` anchor rather than restating it.

Highlights, by kind:

- **Wrong claims fixed** — `concepts/teammates.md` ("nothing in the API creates a teammate" → `POST /api/team`), `concepts/conversation.md` / `primitives.md` / `reference/glossary.md` ("you never address a sandbox" → list, `sandbox_id`, reset), `architecture.md` / `reference/conversation-states.md` / `api.md` (terminate keeps a persistent or shared sandbox — verified in `conversation_server.ex`), `integrations/{sprites,e2b,daytona}.md` + `self-hosting.md` (three providers → four), `integrations/openbot.md` (`fountain agents list` / `auth api-keys create` / `conversations list --channel` → the real commands or a curl), `llm-integration.md` ("no first-party MCP server" → three sandbox-facing ones exist; none for an IDE), `catalog/runtimes/index.md` (acp drives all four), `build/pieces.md` (lifecycle diagram said 24 h default; the ceiling is off by default).
- **api.md completeness** — adds `POST /api/conversations/:id/requests/:request_id` with its codes; the contact provision's `409 contact_already_provisioned` and `402 contact_limit_reached`; the error table gains `sandbox_mid_turn`, `permission_request_resolved`, `contact_already_provisioned`, `contact_limit_reached`. Team/Schedules/Sandboxes route lists verified against the router: complete.
- **sdk.md** — a Sandboxes section for `sandboxes()`, `sandbox()`, `resetSandbox()`, and the `sandbox` / `sandboxMode` run options, which the SDK already shipped.
- **Pointers added** — concepts, catalog, operate and troubleshooting pages that described a console-only or MCP-only path now name the route (`/api/team/:agent_id/contact`, `/api/team/comms`, `/api/sandboxes`, `/api/admin/sandboxes`, `.../reap`, `.../sandbox-limit`, `.../comp`, `.../credits`, `/api/conversations/:id/egress`, `/api/account/inference-credentials`).
- `configuration.md`: `SANDBOX_IDLE_TIMEOUT_MINUTES` parks rather than reclaims (destroy only on a provider without `:suspend`); team-comms section names the routes.

## Not changed, on purpose

- `docs/integrations/sprites-contract.md` "what destroys a sprite" list reads as examples, not a closed set; left.
- `docs/integrations/editors.md` does not mention `--sandbox` / `--sandbox-mode` (acp.md does); incomplete rather than wrong.
- `api.md` still lists nothing for `/api/runners`, `/api/agui/:agent_id`, `/api/mcp/*` — a separate gap.

## Gates

`mix test apps/fountain/test/fountain/docs_test.exs` 29/29, `python3 scripts/docs-style.py` clean, `vale --config .vale-ste.yml docs` 0 errors / 0 warnings, `go test ./internal/cmd` (docs/cli.md diff) ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
