### PR TITLE
fix(web): env edit page 500s when a package value is not a list

### DIFF
--- a/apps/fountain/lib/fountain_web/live/environments_live/form.ex
+++ b/apps/fountain/lib/fountain_web/live/environments_live/form.ex
@@ -55,11 +55,19 @@ defmodule FountainWeb.EnvironmentsLive.Form do
     Enum.map(env_vars, fn {k, v} -> %{"key" => k, "value" => v} end)
   end
 
+  # `packages` is a free map on the schema and the API accepts whatever shape a
+  # manifest sends, so a value is not always a list: eight environments carried
+  # `"node" => "24"` (a version, from an apply manifest) and the edit page
+  # answered 500 for each of them. Provisioning reads only apt/npm, so an odd
+  # value is inert there; here it is shown as it is, and a save round-trips it
+  # as a one-item list.
   defp env_to_packages_strings(packages) do
-    Map.new(packages, fn {manager, pkgs} ->
-      {manager, Enum.join(pkgs, "\n")}
-    end)
+    Map.new(packages, fn {manager, pkgs} -> {manager, packages_string(pkgs)} end)
   end
+
+  defp packages_string(pkgs) when is_list(pkgs), do: Enum.map_join(pkgs, "\n", &to_string/1)
+  defp packages_string(pkgs) when is_binary(pkgs), do: pkgs
+  defp packages_string(pkgs), do: inspect(pkgs)
 
   defp available_managers(packages) do
     @supported_managers -- Map.keys(packages)

--- a/apps/fountain/test/fountain_web/live/environments_form_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/environments_form_live_test.exs
@@ -1,0 +1,105 @@
+defmodule FountainWeb.EnvironmentsFormLiveTest do
+  use FountainWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias Fountain.{Crypto, Environments}
+
+  setup %{conn: conn} do
+    user = insert_verified_user()
+    {:ok, conn: login_user(conn, user), user: user}
+  end
+
+  defp put_secret(user, env) do
+    {:ok, dek} = Crypto.load_tenant_key(user.id)
+
+    {:ok, _} =
+      Environments.upsert_secret(env, %{"key" => "GITHUB_TOKEN", "value" => "ghp_x"}, dek)
+
+    env
+  end
+
+  test "renders env whose package value is not a list (node: \"24\")", %{conn: conn, user: user} do
+    env = insert_env(user_id: user.id)
+
+    {:ok, env} =
+      Environments.update_environment(env, %{"packages" => %{"apt" => ["jq"], "node" => "24"}})
+
+    {:ok, _v, html} = live(conn, ~p"/environments/#{env.id}/edit")
+    assert html =~ ~s(name="env[packages][node]")
+  end
+
+  test "renders fountain-dev exact shape", %{conn: conn, user: user} do
+    env = insert_env(user_id: user.id)
+
+    {:ok, env} =
+      Environments.update_environment(env, %{
+        "packages" => %{
+          "apt" => [
+            "jq",
+            "ripgrep",
+            "make",
+            "erlang-nox",
+            "elixir",
+            "postgresql",
+            "postgresql-contrib",
+            "inotify-tools",
+            "golang-go"
+          ]
+        },
+        "env_vars" => %{
+          "MIX_ENV" => "dev",
+          "DATABASE_URL" => "postgres://postgres:postgres@localhost:5432/fountain_dev",
+          "MASTER_SECRETS_KEY" => "dev-only"
+        },
+        "repositories" => [
+          %{
+            "url" => "https://github.com/BinaryBourbon/fountain",
+            "mount_path" => "/workspace/fountain",
+            "secret_key" => "GITHUB_TOKEN"
+          }
+        ]
+      })
+
+    put_secret(user, env)
+    {:ok, _v, html} = live(conn, ~p"/environments/#{env.id}/edit")
+    assert html =~ "GITHUB_TOKEN"
+  end
+
+  test "renders fountain-contributor exact shape", %{conn: conn, user: user} do
+    env = insert_env(user_id: user.id)
+
+    {:ok, env} =
+      Environments.update_environment(env, %{
+        "packages" => %{
+          "apt" => [
+            "build-essential",
+            "autoconf",
+            "m4",
+            "libncurses-dev",
+            "libssl-dev",
+            "unzip",
+            "jq",
+            "ripgrep",
+            "postgresql",
+            "postgresql-contrib",
+            "python3"
+          ]
+        },
+        "env_vars" => %{
+          "DATABASE_URL" => "postgres://postgres:postgres@localhost:5432/fountain_dev",
+          "LANG" => "C.UTF-8"
+        },
+        "repositories" => [
+          %{
+            "url" => "https://github.com/BinaryBourbon/fountain",
+            "mount_path" => "/workspace/fountain",
+            "secret_key" => "GITHUB_TOKEN"
+          }
+        ]
+      })
+
+    put_secret(user, env)
+    {:ok, _v, _html} = live(conn, ~p"/environments/#{env.id}/edit")
+  end
+end


### PR DESCRIPTION
## What

The environment edit page (`/environments/:id/edit`) answers **500** for any environment whose `packages` map has a value that is not a list. `env_to_packages_strings/1` runs `Enum.join/2` over every value, so a `"node" => "24"` entry (a version string, written by an `apply` manifest) raises `Protocol.UndefinedError (Enumerable not implemented for BitString)` at mount.

Confirmed live against prod (v0.13.0): fountain-workbench, fountain-team, ravioli-web-ui → HTTP 500; environments with clean apt-only lists → 200. Eight of one tenant's environments carry the shape.

## Fix

Render a non-list value as-is — a binary passes through, anything else is `inspect`ed — and round-trip it as a one-item list on save. Provisioning is unaffected; it reads only `apt`/`npm`.

## Test

`environments_form_live_test.exs` renders the `node: "24"` shape plus two real-world shapes; the first was **proven by reverting the fix** (reintroduces the exact `Protocol.UndefinedError`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)