### PR TITLE
fix(broker): brokered sandboxes trust the MITM CA across uv/pip/cargo, not just Node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,19 @@ upgrade, is in
 
 - None yet.
 
+### Fixed
+
+- **Brokered sandboxes now trust the egress broker's MITM certificate across
+  the Python and Rust toolchains, not only Node.** A brokered `uv sync`,
+  `uv python install`, `pip install` or `cargo fetch` failed with
+  `invalid peer certificate: UnknownIssuer` the moment it reached a
+  MITM'd host, because those tools carry their own bundled roots and ignore
+  the OS trust store where the broker CA is installed. `Fountain.Broker.sandbox_env/1`
+  now also sets `SSL_CERT_FILE`, `REQUESTS_CA_BUNDLE` and `CARGO_HTTP_CAINFO`
+  to the full system CA bundle (real roots plus the broker CA — never the
+  broker CA alone, which would break non-brokered hosts like PyPI), and
+  `UV_NATIVE_TLS=1` so uv reads that store instead of its bundled webpki roots.
+
 ## [0.13.0] — 2026-08-25
 
 ### Upgrade notes

--- a/apps/fountain/lib/fountain/broker.ex
+++ b/apps/fountain/lib/fountain/broker.ex
@@ -81,6 +81,12 @@ defmodule Fountain.Broker do
 
   @ca_path "/usr/local/share/ca-certificates/agent-vault.crt"
 
+  # The OS trust bundle update-ca-certificates rebuilds — real roots plus the
+  # broker CA install_broker_ca added. Point replacement-style CA vars here,
+  # never at @ca_path alone: that is one cert, and a tool told to trust only it
+  # rejects every non-brokered host (pypi, crates.io) it also has to reach.
+  @system_ca_bundle "/etc/ssl/certs/ca-certificates.crt"
+
   @typedoc "A minted proxy session for one conversation."
   @type session :: %{
           vault: String.t(),
@@ -400,6 +406,16 @@ defmodule Fountain.Broker do
   session token (as `http://<token>:<vault>@host:port`), so it is process-only
   (`Identity.@process_only`); the lower case twins are for apt and the tools
   that only read those.
+
+  The CA variables make each toolchain trust the broker's MITM certificate.
+  `install_broker_ca` puts the CA in the OS trust store, which curl, git and
+  anything on OpenSSL then read — but a tool with its own bundled roots does
+  not. Node is told through `NODE_EXTRA_CA_CERTS` (additive, so the broker CA
+  alone); the rest replace their bundle and so must name the full system bundle
+  (`@system_ca_bundle`), not the broker CA on its own. `UV_NATIVE_TLS` turns uv
+  off its bundled webpki roots and onto that same OS store. Without these, a
+  brokered `uv sync`, `pip install`, or `cargo fetch` fails with
+  `invalid peer certificate: UnknownIssuer` the moment it reaches a MITM'd host.
   """
   @spec sandbox_env(session()) :: [{String.t(), String.t()}]
   def sandbox_env(%{token: token, vault: vault}) do
@@ -411,13 +427,19 @@ defmodule Fountain.Broker do
       {"https_proxy", url},
       {"http_proxy", url},
       {"NO_PROXY", "localhost,127.0.0.1"},
-      {"NODE_EXTRA_CA_CERTS", @ca_path}
+      {"NODE_EXTRA_CA_CERTS", @ca_path},
+      {"SSL_CERT_FILE", @system_ca_bundle},
+      {"REQUESTS_CA_BUNDLE", @system_ca_bundle},
+      {"CARGO_HTTP_CAINFO", @system_ca_bundle},
+      {"UV_NATIVE_TLS", "1"}
     ]
   end
 
   @doc "Every variable `sandbox_env/1` sets, for a refresh to replace."
   @spec env_keys() :: [String.t()]
-  def env_keys, do: ~w(HTTPS_PROXY HTTP_PROXY https_proxy http_proxy NO_PROXY NODE_EXTRA_CA_CERTS)
+  def env_keys,
+    do:
+      ~w(HTTPS_PROXY HTTP_PROXY https_proxy http_proxy NO_PROXY NODE_EXTRA_CA_CERTS SSL_CERT_FILE REQUESTS_CA_BUNDLE CARGO_HTTP_CAINFO UV_NATIVE_TLS)
 
   @doc "The variables that carry the session token, which `Identity` keeps off the shared `.env`."
   @spec process_only_keys() :: [String.t()]

--- a/apps/fountain/test/fountain/broker_test.exs
+++ b/apps/fountain/test/fountain/broker_test.exs
@@ -103,6 +103,30 @@ defmodule Fountain.BrokerTest do
       assert Enum.map(env, &elem(&1, 0)) -- Broker.env_keys() == []
     end
 
+    test "sandbox_env points the non-Node toolchains at the full system CA bundle" do
+      configure()
+      env = Broker.sandbox_env(%{vault: "c-x", token: "av_sess_t", expires_at: nil})
+      bundle = "/etc/ssl/certs/ca-certificates.crt"
+
+      # Replacement-style CA vars must name the system bundle (real roots + the
+      # broker CA), never Broker.ca_path() alone — that one cert would make the
+      # tool reject every non-brokered host it also reaches.
+      assert {"SSL_CERT_FILE", bundle} in env
+      assert {"REQUESTS_CA_BUNDLE", bundle} in env
+      assert {"CARGO_HTTP_CAINFO", bundle} in env
+      refute {"SSL_CERT_FILE", Broker.ca_path()} in env
+
+      # uv reads its own webpki roots unless told to use the OS store.
+      assert {"UV_NATIVE_TLS", "1"} in env
+
+      # These are paths, not the session token, so they belong on the shared
+      # .env and must not be classed process-only.
+      for k <- ~w(SSL_CERT_FILE REQUESTS_CA_BUNDLE CARGO_HTTP_CAINFO UV_NATIVE_TLS) do
+        assert k in Broker.env_keys()
+        refute k in Broker.process_only_keys()
+      end
+    end
+
     test "every token-carrying variable is process-only" do
       for key <- Broker.process_only_keys(), do: assert(key in Broker.env_keys())
       assert "HTTPS_PROXY" in Broker.process_only_keys()

--- a/apps/fountain/test/fountain/conversations/provisioning_test.exs
+++ b/apps/fountain/test/fountain/conversations/provisioning_test.exs
@@ -183,7 +183,8 @@ defmodule Fountain.Conversations.ProvisioningTest do
                "sudo install -D -m 644 '/tmp/agent-vault-ca.crt' " <>
                  "'/usr/local/share/ca-certificates/agent-vault.crt' && sudo update-ca-certificates && " <>
                  "printf '%s\\n' 'Defaults env_keep += \"HTTPS_PROXY HTTP_PROXY https_proxy http_proxy " <>
-                 "NO_PROXY NODE_EXTRA_CA_CERTS\"' > '/tmp/fountain-broker-proxy.sudoers' && " <>
+                 "NO_PROXY NODE_EXTRA_CA_CERTS SSL_CERT_FILE REQUESTS_CA_BUNDLE CARGO_HTTP_CAINFO " <>
+                 "UV_NATIVE_TLS\"' > '/tmp/fountain-broker-proxy.sudoers' && " <>
                  "sudo visudo -cf '/tmp/fountain-broker-proxy.sudoers' && " <>
                  "sudo install -m 440 '/tmp/fountain-broker-proxy.sudoers' '/etc/sudoers.d/fountain-broker-proxy'"
     end


### PR DESCRIPTION
## What

`install_broker_ca` installs the egress broker's MITM CA into the sandbox **OS trust store**, so `curl` and `git` (OpenSSL/GnuTLS) trust brokered HTTPS. Tools that carry their **own** bundled roots do not:

- **uv** (rustls + bundled webpki) — every brokered download from a MITM'd host fails with `invalid peer certificate: UnknownIssuer`
- **pip / requests / httpx** (certifi)
- **cargo**

Only Node was wired, through `NODE_EXTRA_CA_CERTS`. This bit a real user: `ravioli-backend`'s setup (`uv python install` → github release asset, a MITM'd host) failed **every** run at `UnknownIssuer`.

## Change

`Fountain.Broker.sandbox_env/1` also sets, for brokered sandboxes:

| var | value | for |
|---|---|---|
| `SSL_CERT_FILE` | `/etc/ssl/certs/ca-certificates.crt` | OpenSSL-based tooling, pip |
| `REQUESTS_CA_BUNDLE` | `/etc/ssl/certs/ca-certificates.crt` | requests/httpx/pip |
| `CARGO_HTTP_CAINFO` | `/etc/ssl/certs/ca-certificates.crt` | cargo |
| `UV_NATIVE_TLS` | `1` | uv → OS trust store |

Replacement-style CA vars point at the **full system bundle** (real roots **plus** the broker CA that `update-ca-certificates` appended) — deliberately **not** `Broker.ca_path()`, which is the broker CA alone and would make a tool reject every non-brokered host it also reaches (PyPI, crates.io). `NODE_EXTRA_CA_CERTS` stays the broker CA alone because Node treats it as additive.

The vars are paths, not the session token, so they are **not** `process_only` — they ride the shared `.env` and reach the agent's turns, not just provisioning.

## Verification

- Live on prod, in a brokered sandbox: `uv python install` fails `UnknownIssuer` without the flag and **exits 0 with `UV_NATIVE_TLS=1`** (and with `SSL_CERT_FILE` at the system bundle). Two runs, deterministic.
- `broker_test.exs`: new assertions that the replacement vars name the system bundle (and never `ca_path/0`), that `UV_NATIVE_TLS=1` is set, and that all four are in `env_keys/0` but not `process_only_keys/0`.

## Note

Separate from this: the egress broker (agent-vault) is currently failing MITM handshakes intermittently (`unknown certificate authority`), which blocks some clones outright — tracked separately; not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)