### PR TITLE
dev: register the reflex OAuth client

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -47,6 +47,11 @@ config :fountain, :oauth_clients, [
     id: "fountain-workbench",
     name: "Fountain Workbench",
     redirect_uris: ["http://localhost:5173/", "http://localhost:5174/"]
+  },
+  %{
+    id: "reflex",
+    name: "Reflex",
+    redirect_uris: ["http://localhost:5183/"]
   }
 ]
 


### PR DESCRIPTION
Adds `reflex` (redirect `http://localhost:5183/`) to `:oauth_clients` in `config/dev.exs` so [jhgaylor/reflex](https://github.com/jhgaylor/reflex) can sign in against a local Fountain. The hosted registration (CORS origin + OAuth client for `reflex.inevitable.fyi`) is in the home-cloud fountain-site patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)