### PR TITLE
fix(conversations): wake a dead server before giving up on interrupt

### DIFF
--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -181,15 +181,50 @@ defmodule Fountain.Conversations.ConversationServer do
     GenServer.cast(pid, {:initial_prompt, prompt, images})
   end
 
+  @doc """
+  Interrupt the turn in flight, if any.
+
+  If no server answers for this conversation, that alone doesn't mean there
+  is nothing to interrupt: the process can have exited (deploy, Horde
+  rebalance, a plain `{:stop, :normal, _}` return) while a turn was still
+  marked `running`, with nothing left to close it (#1179 — an autonomous
+  "background task follow-up" turn stuck this way for 4+ hours, `interrupt`
+  404ing the whole time, indistinguishable from hitting a conversation that
+  doesn't exist). Mirror `send_prompt/4`'s wake-on-miss fallback, but only
+  when the row says `running` — an idle/terminated/unknown conversation has
+  nothing running regardless, and must not pay for a wake it doesn't need.
+  Waking reattaches to a live sprite session if one exists (and this second
+  `interrupt` call then really does end it), or reconciles the orphaned turn
+  itself when none does.
+  """
   def interrupt(conv_id, opts \\ []) do
     result =
       case whereis(conv_id) do
-        nil -> {:error, :not_running}
+        nil -> interrupt_dead(conv_id)
         pid -> call_server(pid, :interrupt)
       end
 
     audit_lifecycle(conv_id, "conversation.interrupted", result, opts)
     result
+  end
+
+  defp interrupt_dead(conv_id) do
+    case Conversations._unsafe_get_conversation(conv_id) do
+      %Conversation{status: "running"} ->
+        case Conversations.wake_conversation(conv_id) do
+          {:ok, conv} ->
+            case whereis(conv.id) do
+              nil -> {:error, :not_running}
+              pid -> call_server(pid, :interrupt)
+            end
+
+          {:error, _} ->
+            {:error, :not_running}
+        end
+
+      _ ->
+        {:error, :not_running}
+    end
   end
 
   @doc """

--- a/apps/fountain/test/fountain/conversations/conversation_server_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_test.exs
@@ -1197,4 +1197,55 @@ defmodule Fountain.Conversations.ConversationServerTest do
       assert {:error, :gone} = ConversationServer.send_prompt(conv.id, "hi", [])
     end
   end
+
+  describe "interrupt/1 against a dead server holding a running turn (#1179)" do
+    # An autonomous turn ("background task follow-up") — or any turn — can be
+    # left `status: "running"` in the DB with no ConversationServer left to
+    # answer for it: the process exited (deploy, rebalance, a plain
+    # `{:stop, :normal, _}` return) without closing the turn first, and
+    # nothing wakes the conversation again until the next prompt. Before this
+    # fix, `interrupt/2` only ever checked `whereis/1` and gave up with
+    # `{:error, :not_running}` — indistinguishable, from the API, to a caller
+    # hitting a conversation that plain does not exist. The fix mirrors
+    # `send_prompt/4`'s existing wake-on-miss fallback: reattach, which
+    # either resumes the real session or (as here, with no active sprite
+    # session) reconciles the orphaned turn.
+    test "wakes the conversation; reattach finds no live session and reconciles the stuck turn" do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      sandbox = insert_sandbox(user_id: user.id, status: "ready")
+
+      conv =
+        insert_conversation(user_id: user.id, agent: agent, sandbox: sandbox, status: "running")
+
+      {:ok, turn} =
+        Conversations._unsafe_create_turn(%{
+          conversation_id: conv.id,
+          turn_number: 1,
+          prompt: "(background task follow-up)",
+          origin: "autonomous",
+          status: "running",
+          started_at: DateTime.utc_now() |> DateTime.truncate(:second)
+        })
+
+      stub_happy_sprite()
+
+      on_exit(fn ->
+        case ConversationServer.whereis(conv.id) do
+          nil -> :ok
+          pid -> if Process.alive?(pid), do: GenServer.stop(pid, :normal)
+        end
+      end)
+
+      # No server is registered for this conversation at all — exactly the
+      # state a dead process leaves behind. `list_sessions` (stubbed to `[]`
+      # by stub_happy_sprite/1) means reattach finds nothing to resume.
+      assert {:error, :idle} = ConversationServer.interrupt(conv.id)
+
+      assert Conversations._unsafe_get_conversation!(conv.id).status == "idle"
+
+      assert [%{id: turn_id, status: "interrupted"}] = Conversations._unsafe_list_turns(conv.id)
+      assert turn_id == turn.id
+    end
+  end
 end


### PR DESCRIPTION
## What

`ConversationServer.interrupt/2` only checked `whereis/1`; if no process was registered it answered `{:error, :not_running}` → a plain 404, indistinguishable from "conversation doesn't exist." Now, when `whereis` misses on a conversation whose row says `status: "running"`, it wakes the conversation (mirroring `send_prompt/4`'s existing fallback) before giving up. Waking either reattaches to a still-live sprite session (so a second `interrupt` really ends it) or reconciles the orphaned turn itself when no session is found — the same reattach path a server restart already takes. Idle/terminated/unknown conversations skip the wake entirely and keep today's `{:error, :not_running}`.

## Why

#1179: an autonomous "background task follow-up" turn got stuck `status: running` for 4+ hours with no server left to answer for it (the process died holding the turn open, and nothing re-wakes a conversation nobody is prompting). `interrupt` 404'd the entire time — the only workaround was retiring the conversation and starting a fresh one, abandoning the stuck turn rather than closing it. This gives `interrupt` a real recovery path.

## How verified

Added a test in `conversation_server_test.exs` that drives the real `wake_conversation → reattach → mark_orphan` path with no `ConversationServer` registered for the conversation, and asserts the stuck turn is closed (`status: "interrupted"`) and the conversation returns to `idle`. Traced every other caller of `interrupt/2` — the controller and the provisioning-timeout regression test (`conversation_call_timeout_test.exs`) — to confirm the `whereis`-hit branch (unchanged) is what they exercise, so this is additive on the miss branch only.

**Local `mix test` could not run.** `mix deps.get` never completes in this sandbox: Erlang's `:httpc` can't complete the CONNECT tunnel through the environment's authenticated HTTPS proxy (`curl` and `git` traverse the same proxy fine, so this looks like an `:httpc`-specific gap, not a real network-policy block). I verified by reading instead — both changed files parse cleanly, and I checked the exact reattach/mark_orphan/wake_conversation code paths this exercises. CI is the real gate here; flagging it explicitly per the "green local run is necessary, CI is sufficient" rule.

## Left out on purpose

This closes the *"interrupt works on a running conversation regardless of turn origin"* half of #1179's ask. The other half — *"the autonomous turn ends when the background task does (or times out)"* — is not fixed here: the 10-minute `autonomous_quiet` watchdog lives purely in the GenServer's process memory and is lost if the process exits before it fires, and nothing sweeps for turns stuck `running` mid-uptime (only app boot and a new prompt/interrupt trigger reconciliation now). Making the turn close itself automatically touches `terminate/2` and/or a new periodic sweep — a materially bigger, separate change. Happy to open a follow-up issue for that if useful; didn't want to bundle it into this PR.