### PR TITLE
feat(connections): Gmail via OAuth — tenant signs in once, Fountain holds the credential (#1178)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -226,6 +226,17 @@ EMAIL_FROM=noreply@fountain.example.com
 GITHUB_OAUTH_CLIENT_ID=
 GITHUB_OAUTH_CLIENT_SECRET=
 
+# Google OAuth client for connections (#1178): a tenant connects Gmail once
+# in the console, Fountain keeps the refresh token, and agents get the
+# capability (a Fountain-served Gmail MCP server, or a brokered
+# GOOGLE_ACCESS_TOKEN) rather than the credential. Only for accounts the
+# egress broker is on for. Register a Web client in Google Cloud with the
+# redirect URI <PUBLIC_URL>/connections/google/callback and the Gmail API
+# enabled; gmail.modify is a restricted scope, so an unverified app serves
+# its test users only. Unset, the Connections page says so.
+GOOGLE_OAUTH_CLIENT_ID=
+GOOGLE_OAUTH_CLIENT_SECRET=
+
 # Inference credentials are per-user (BYO, ADR 0008). Set them via
 # /account/inference-credentials in the running app, not via env vars.
 # (CLAUDE_CODE_OAUTH_TOKEN, ANTHROPIC_API_KEY, OPENAI_API_KEY, GEMINI_API_KEY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,31 @@ upgrade, is in
 
 ### Added
 
-- None yet.
+- **Connections: sign in to Google once, and agents get Gmail without ever
+  holding the credential** (#1178). For accounts the egress broker is on for,
+  the console's new *Account → Connections* page runs Google's
+  authorization-code flow (`access_type=offline`, `prompt=consent`) and
+  Fountain keeps the refresh token DEK-encrypted like any tenant secret.
+  Two ways an agent uses it, neither of which puts a Google token in a
+  sandbox:
+  - **A Fountain-served Gmail MCP server.** An agent's `mcp_servers` names
+    the connection — `{"gmail": {"connection": "<id>"}}` — and the
+    conversation gets `gmail_search`, `gmail_get_thread`, `gmail_get_message`,
+    `gmail_send`, `gmail_reply`, `gmail_modify_labels` and
+    `gmail_list_labels`, served at `POST /api/mcp/gmail/:conversation_id/:connection_id`
+    and authenticated by the callback token the sandbox already holds. The
+    token is refreshed server-side per call; a revoked connection answers
+    `connection revoked`, not a 401.
+  - **A brokered `GOOGLE_ACCESS_TOKEN`.** The access token is a synthetic
+    secret brokered like an inference key (ADR 0019): the sandbox holds a
+    placeholder, the broker attaches the value as a bearer to
+    `gmail.googleapis.com` / `www.googleapis.com`, and a binding of your own
+    on that name sends it to an MCP server you run instead. Tokens rotate
+    hourly; the conversation server re-uploads a rotated one at the next
+    turn kick, so a shared sandbox (ADR 0023) outlives them.
+  - `GET/DELETE /api/connections`, `GET /api/connections/providers`, in the
+    OpenAPI spec and the TypeScript SDK (`client.connections`). Configured
+    by `GOOGLE_OAUTH_CLIENT_ID` / `GOOGLE_OAUTH_CLIENT_SECRET`.
 
 ### Fixed
 

--- a/apps/fountain/lib/fountain/agents/agent.ex
+++ b/apps/fountain/lib/fountain/agents/agent.ex
@@ -92,6 +92,7 @@ defmodule Fountain.Agents.Agent do
     |> validate_sandbox_provider()
     |> validate_length(:name, min: 1, max: 200)
     |> validate_skills()
+    |> validate_mcp_servers()
     |> validate_permission_policy()
     |> unique_constraint(:name, name: :agents_user_id_name_index)
     |> foreign_key_constraint(:environment_id)
@@ -219,6 +220,26 @@ defmodule Fountain.Agents.Agent do
       true ->
         []
     end
+  end
+
+  # An entry may name a connection instead of a server (#1178):
+  # `%{"connection" => "<id>"}`, rewritten at spawn into the Fountain-served
+  # server. Only the shape is checked here — a connection that is gone or
+  # revoked by the time a conversation runs fails at the tool call with a
+  # reason, which is the contract; a changeset cannot know the future.
+  defp validate_mcp_servers(changeset) do
+    validate_change(changeset, :mcp_servers, fn :mcp_servers, servers ->
+      if is_map(servers) do
+        servers
+        |> Enum.filter(fn {_name, entry} -> is_map(entry) and Map.has_key?(entry, "connection") end)
+        |> Enum.reject(fn {_name, %{"connection" => id}} ->
+          is_binary(id) and match?({:ok, _}, Ecto.UUID.cast(id))
+        end)
+        |> Enum.map(fn {name, _} -> {:mcp_servers, "#{name}: connection must be a connection id"} end)
+      else
+        [mcp_servers: "must be a map of server name to server config"]
+      end
+    end)
   end
 
   defp validate_skills(changeset) do

--- a/apps/fountain/lib/fountain/agents/agent.ex
+++ b/apps/fountain/lib/fountain/agents/agent.ex
@@ -231,11 +231,15 @@ defmodule Fountain.Agents.Agent do
     validate_change(changeset, :mcp_servers, fn :mcp_servers, servers ->
       if is_map(servers) do
         servers
-        |> Enum.filter(fn {_name, entry} -> is_map(entry) and Map.has_key?(entry, "connection") end)
+        |> Enum.filter(fn {_name, entry} ->
+          is_map(entry) and Map.has_key?(entry, "connection")
+        end)
         |> Enum.reject(fn {_name, %{"connection" => id}} ->
           is_binary(id) and match?({:ok, _}, Ecto.UUID.cast(id))
         end)
-        |> Enum.map(fn {name, _} -> {:mcp_servers, "#{name}: connection must be a connection id"} end)
+        |> Enum.map(fn {name, _} ->
+          {:mcp_servers, "#{name}: connection must be a connection id"}
+        end)
       else
         [mcp_servers: "must be a map of server name to server config"]
       end

--- a/apps/fountain/lib/fountain/connections.ex
+++ b/apps/fountain/lib/fountain/connections.ex
@@ -137,7 +137,8 @@ defmodule Fountain.Connections do
     conn
     |> Connection.revoke_changeset()
     |> Repo.update()
-    |> audited("connection.revoked", actor: "system:connection_refresh",
+    |> audited("connection.revoked",
+      actor: "system:connection_refresh",
       metadata: %{"reason" => "invalid_grant"}
     )
   end

--- a/apps/fountain/lib/fountain/connections.ex
+++ b/apps/fountain/lib/fountain/connections.ex
@@ -1,0 +1,268 @@
+defmodule Fountain.Connections do
+  @moduledoc """
+  Provider accounts a tenant has signed in to once, whose credentials
+  Fountain holds (#1178). This is how a managed-agent platform does
+  connectors: the platform runs the OAuth flow, keeps the refresh token, and
+  hands an agent a capability rather than a credential.
+
+  A connection reaches an agent two ways, both only for accounts the egress
+  broker is on for (`Fountain.Broker.enabled_for?/1`):
+
+    * **A Fountain-served MCP server.** An agent's `mcp_servers` names the
+      connection (`%{"gmail" => %{"connection" => id}}`) and the conversation
+      gets `POST /api/mcp/gmail/:conversation_id/:connection_id`, authenticated
+      by its own callback token. The token never leaves the server.
+    * **A brokered secret.** The access token is a synthetic secret under
+      `env_key` (`GOOGLE_ACCESS_TOKEN`), brokered like an inference key: the
+      sandbox holds a placeholder, the broker attaches the value to requests
+      for the provider's hosts, and a binding of the tenant's own on the same
+      name sends it to an MCP server they run instead. Rotated tokens are
+      re-uploaded by `Fountain.Conversations.ConversationServer` at each turn.
+
+  Every read of a token goes through `access_token/1`, which refreshes near
+  expiry and marks the connection `revoked` when the provider refuses the
+  grant (`invalid_grant`). A revoked connection stays listed so the console
+  can say why the tools stopped working; reconnecting replaces it.
+
+  Audit: `connection.created` / `connection.revoked` carry provider, scopes
+  and the account address — never a token (ADR 0013).
+  """
+
+  import Ecto.Query, warn: false
+
+  alias Fountain.{Audit, Crypto, Repo}
+  alias Fountain.Connections.{Connection, Google}
+
+  # How close to expiry a token is considered stale. A turn may run for a
+  # while on the token it started with, so refresh well ahead.
+  @refresh_margin_seconds 300
+
+  # ── reads ─────────────────────────────────────────────────────────────────
+
+  @spec list_connections(String.t()) :: [Connection.t()]
+  def list_connections(user_id) when is_binary(user_id) do
+    Repo.all(
+      from c in Connection,
+        where: c.user_id == ^user_id,
+        order_by: [asc: c.provider, asc: c.account_email]
+    )
+  end
+
+  @spec get_connection(String.t(), String.t()) :: Connection.t() | nil
+  def get_connection(id, user_id) when is_binary(id) and is_binary(user_id) do
+    if valid_uuid?(id), do: Repo.get_by(Connection, id: id, user_id: user_id)
+  end
+
+  @doc "The tenant's active connections only — what a sandbox may be handed."
+  @spec active_connections(String.t()) :: [Connection.t()]
+  def active_connections(user_id) when is_binary(user_id) do
+    Repo.all(
+      from c in Connection,
+        where: c.user_id == ^user_id and c.status == "active",
+        order_by: [asc: c.env_key]
+    )
+  end
+
+  # ── writes ────────────────────────────────────────────────────────────────
+
+  @doc """
+  Store a fresh grant for `provider`. One connection per (provider, account):
+  signing the same account in again replaces its tokens and reactivates it.
+  `grant` is what `Fountain.Connections.Google.exchange_code/2` returns.
+  """
+  @spec connect(String.t(), String.t(), map(), keyword()) ::
+          {:ok, Connection.t()} | {:error, Ecto.Changeset.t() | atom()}
+  def connect(user_id, provider, grant, opts \\ [])
+      when is_binary(user_id) and is_binary(provider) and is_map(grant) do
+    with {:ok, dek} <- Crypto.load_tenant_key(user_id) do
+      existing =
+        Repo.get_by(Connection,
+          user_id: user_id,
+          provider: provider,
+          account_email: grant.account_email
+        )
+
+      attrs = %{
+        user_id: user_id,
+        provider: provider,
+        account_email: grant.account_email,
+        scopes: grant.scopes,
+        env_key: (existing && existing.env_key) || free_env_key(user_id, provider),
+        refresh_token: grant.refresh_token,
+        access_token: grant.access_token,
+        expires_at: grant.expires_at
+      }
+
+      (existing || %Connection{})
+      |> Connection.changeset(attrs, dek)
+      |> Repo.insert_or_update()
+      |> audited("connection.created", opts)
+    end
+  end
+
+  @doc """
+  Revoke a connection: the provider is told to forget the grant (best
+  effort), and the row is marked `revoked` so every door says why. The next
+  MCP tool call on it fails with `connection revoked`, not a 401 from the
+  provider.
+  """
+  @spec revoke(Connection.t(), keyword()) :: {:ok, Connection.t()} | {:error, term()}
+  def revoke(%Connection{} = conn, opts \\ []) do
+    if conn.status == "active" do
+      with {:ok, dek} <- Crypto.load_tenant_key(conn.user_id) do
+        case decrypt(conn.refresh_token_ciphertext, dek) do
+          {:ok, refresh} -> Google.revoke(refresh)
+          _ -> :ok
+        end
+      end
+    end
+
+    conn
+    |> Connection.revoke_changeset()
+    |> Repo.update()
+    |> audited("connection.revoked", opts)
+  end
+
+  @doc "Delete a connection outright. Revokes at the provider first."
+  @spec delete(Connection.t(), keyword()) :: {:ok, Connection.t()} | {:error, term()}
+  def delete(%Connection{} = conn, opts \\ []) do
+    with {:ok, conn} <- revoke(conn, opts) do
+      Repo.delete(conn)
+    end
+  end
+
+  # Marks the connection revoked because the provider refused the grant.
+  # A system event, not the tenant's: attributed to the refresher.
+  defp mark_refused(%Connection{} = conn) do
+    conn
+    |> Connection.revoke_changeset()
+    |> Repo.update()
+    |> audited("connection.revoked", actor: "system:connection_refresh",
+      metadata: %{"reason" => "invalid_grant"}
+    )
+  end
+
+  # ── tokens ────────────────────────────────────────────────────────────────
+
+  @doc """
+  A valid access token for the connection, refreshing when it is within
+  #{@refresh_margin_seconds}s of expiry. `{:error, :revoked}` for a revoked
+  connection, including one the provider has just refused.
+  """
+  @spec access_token(Connection.t()) :: {:ok, String.t()} | {:error, term()}
+  def access_token(%Connection{status: "revoked"}), do: {:error, :revoked}
+
+  def access_token(%Connection{} = conn) do
+    with {:ok, dek} <- Crypto.load_tenant_key(conn.user_id) do
+      if fresh?(conn) do
+        decrypt(conn.access_token_ciphertext, dek)
+      else
+        refresh_token(conn, dek)
+      end
+    end
+  end
+
+  @doc """
+  The synthetic secrets a tenant's active connections contribute to a
+  sandbox: `%{"GOOGLE_ACCESS_TOKEN" => token}`. A connection whose refresh
+  fails is left out, and the sandbox runs without it; the console says why.
+  """
+  @spec synthetic_secrets(String.t()) :: %{String.t() => String.t()}
+  def synthetic_secrets(user_id) when is_binary(user_id) do
+    user_id
+    |> active_connections()
+    |> Enum.reduce(%{}, fn conn, acc ->
+      case access_token(conn) do
+        {:ok, token} -> Map.put(acc, conn.env_key, token)
+        _ -> acc
+      end
+    end)
+  end
+
+  @doc "The env var names a tenant's connections are brokered under (for the bindings catalog)."
+  @spec env_keys(String.t()) :: [String.t()]
+  def env_keys(user_id) when is_binary(user_id) do
+    Repo.all(from c in Connection, where: c.user_id == ^user_id, select: c.env_key)
+  end
+
+  @doc """
+  The hosts an `env_key`'s token is implicitly bound to as a bearer, or `[]`
+  for a key that is not a connection's. A second account of the same
+  provider is `GOOGLE_ACCESS_TOKEN_2`, and binds the same way.
+  """
+  @spec implicit_hosts(String.t()) :: [String.t()]
+  def implicit_hosts(key) when is_binary(key) do
+    if String.starts_with?(key, Google.env_key()), do: Google.token_hosts(), else: []
+  end
+
+  # The first account of a provider takes the bare key; each further one
+  # takes the next numbered key, so every connection is addressable by name
+  # in a binding and none shadows another.
+  defp free_env_key(user_id, provider) do
+    base = env_key_for(provider)
+    taken = MapSet.new(env_keys(user_id))
+
+    Stream.iterate(1, &(&1 + 1))
+    |> Stream.map(fn
+      1 -> base
+      n -> "#{base}_#{n}"
+    end)
+    |> Enum.find(&(not MapSet.member?(taken, &1)))
+  end
+
+  defp fresh?(%Connection{access_token_ciphertext: nil}), do: false
+  defp fresh?(%Connection{expires_at: nil}), do: false
+
+  defp fresh?(%Connection{expires_at: at}) do
+    DateTime.diff(at, DateTime.utc_now(), :second) > @refresh_margin_seconds
+  end
+
+  defp refresh_token(conn, dek) do
+    with {:ok, refresh} <- decrypt(conn.refresh_token_ciphertext, dek) do
+      case Google.refresh(refresh) do
+        {:ok, access, expires_at} ->
+          case conn |> Connection.refresh_changeset(access, expires_at, dek) |> Repo.update() do
+            {:ok, _} -> {:ok, access}
+            {:error, changeset} -> {:error, changeset}
+          end
+
+        {:error, :invalid_grant} ->
+          _ = mark_refused(conn)
+          {:error, :revoked}
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+  end
+
+  defp decrypt(nil, _dek), do: {:error, :no_token}
+
+  defp decrypt(blob, dek) do
+    case Crypto.decrypt(blob, dek) do
+      {:ok, value} -> {:ok, value}
+      :error -> {:error, :undecryptable}
+    end
+  end
+
+  defp env_key_for("google"), do: Google.env_key()
+
+  defp valid_uuid?(id), do: match?({:ok, _}, Ecto.UUID.cast(id))
+
+  # Provider, scopes and the address name the connection; no token is ever
+  # in the trail (ADR 0013).
+  defp audited({:ok, %Connection{} = conn} = ok, action, opts) do
+    metadata = %{
+      "provider" => conn.provider,
+      "account_email" => conn.account_email,
+      "scopes" => conn.scopes,
+      "env_key" => conn.env_key
+    }
+
+    opts = Keyword.update(opts, :metadata, metadata, &Map.merge(metadata, &1))
+    Audit.record_resource(action, "connection", conn, opts)
+    ok
+  end
+
+  defp audited(other, _action, _opts), do: other
+end

--- a/apps/fountain/lib/fountain/connections/connection.ex
+++ b/apps/fountain/lib/fountain/connections/connection.ex
@@ -37,6 +37,7 @@ defmodule Fountain.Connections.Connection do
   end
 
   def providers, do: @providers
+  def statuses, do: @statuses
 
   @doc """
   Create or replace a connection from a fresh token grant. `attrs` carries

--- a/apps/fountain/lib/fountain/connections/connection.ex
+++ b/apps/fountain/lib/fountain/connections/connection.ex
@@ -1,0 +1,93 @@
+defmodule Fountain.Connections.Connection do
+  @moduledoc """
+  A provider account a tenant signed in to once, whose credential Fountain
+  holds (#1178). The refresh token is encrypted with the tenant's DEK the way
+  a vault secret is; the access token is a short-lived cache of the same
+  shape, rewritten on every refresh. Neither ever enters a sandbox.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Fountain.Crypto
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+
+  @providers ~w(google)
+  @statuses ~w(active revoked)
+
+  @type t :: %__MODULE__{}
+
+  schema "connections" do
+    field :provider, :string
+    field :account_email, :string
+    field :scopes, {:array, :string}, default: []
+    field :env_key, :string
+    field :refresh_token_ciphertext, :binary, redact: true
+    field :access_token_ciphertext, :binary, redact: true
+    field :refresh_token, :string, virtual: true, redact: true
+    field :access_token, :string, virtual: true, redact: true
+    field :expires_at, :utc_datetime
+    field :status, :string, default: "active"
+    field :revoked_at, :utc_datetime
+    field :last_refreshed_at, :utc_datetime
+    belongs_to :user, Fountain.Accounts.User
+    timestamps(type: :utc_datetime)
+  end
+
+  def providers, do: @providers
+
+  @doc """
+  Create or replace a connection from a fresh token grant. `attrs` carries
+  the plaintext `refresh_token` / `access_token`; both are encrypted with the
+  tenant `dek` before they are persisted.
+  """
+  def changeset(conn, attrs, dek) when is_binary(dek) do
+    conn
+    |> cast(attrs, [
+      :user_id,
+      :provider,
+      :account_email,
+      :scopes,
+      :env_key,
+      :refresh_token,
+      :access_token,
+      :expires_at
+    ])
+    |> validate_required([:user_id, :provider, :account_email, :env_key, :refresh_token])
+    |> validate_inclusion(:provider, @providers)
+    |> validate_format(:env_key, ~r/^[A-Z][A-Z0-9_]*$/, message: "must be UPPER_SNAKE_CASE")
+    |> validate_length(:account_email, min: 3, max: 320)
+    |> put_change(:status, "active")
+    |> put_change(:revoked_at, nil)
+    |> encrypt(:refresh_token, :refresh_token_ciphertext, dek)
+    |> encrypt(:access_token, :access_token_ciphertext, dek)
+    |> unique_constraint([:user_id, :provider, :account_email])
+    |> unique_constraint([:user_id, :env_key])
+  end
+
+  @doc "A refreshed access token, encrypted with the tenant `dek`."
+  def refresh_changeset(conn, access_token, expires_at, dek) when is_binary(dek) do
+    conn
+    |> change(access_token: access_token, expires_at: expires_at)
+    |> put_change(:last_refreshed_at, now())
+    |> encrypt(:access_token, :access_token_ciphertext, dek)
+  end
+
+  @doc "The connection no longer works: the provider refused the refresh token, or the tenant revoked it."
+  def revoke_changeset(conn) do
+    conn
+    |> change(status: "revoked", revoked_at: now())
+    |> validate_inclusion(:status, @statuses)
+  end
+
+  defp encrypt(changeset, field, target, dek) do
+    case get_change(changeset, field) do
+      nil -> changeset
+      value -> put_change(changeset, target, Crypto.encrypt(value, dek))
+    end
+  end
+
+  defp now, do: DateTime.utc_now() |> DateTime.truncate(:second)
+end

--- a/apps/fountain/lib/fountain/connections/gmail.ex
+++ b/apps/fountain/lib/fountain/connections/gmail.ex
@@ -1,0 +1,115 @@
+defmodule Fountain.Connections.Gmail do
+  @moduledoc """
+  The slice of the Gmail API the Fountain-served MCP server uses (#1178),
+  over `Req`, with the access token supplied per call. Returns the JSON the
+  API returns; the MCP layer shapes it for the model.
+
+  Tests inject a `Req.Test` plug through `:gmail_req_options`.
+  """
+
+  @base_url "https://gmail.googleapis.com/gmail/v1/users/me"
+
+  @doc "Threads matching a Gmail search query (`q`), newest first."
+  def list_threads(token, opts \\ []) do
+    params =
+      [
+        q: Keyword.get(opts, :query),
+        maxResults: Keyword.get(opts, :max_results, 10),
+        pageToken: Keyword.get(opts, :page_token),
+        labelIds: Keyword.get(opts, :label_ids)
+      ]
+      |> Enum.reject(fn {_, v} -> is_nil(v) end)
+
+    get(token, "/threads", params: params)
+  end
+
+  @doc "One thread with every message, in `format`: `metadata` (headers + snippet) or `full`."
+  def get_thread(token, thread_id, format \\ "metadata") do
+    get(token, "/threads/#{enc(thread_id)}",
+      params: [format: format, metadataHeaders: ~w(From To Cc Subject Date Message-ID)]
+    )
+  end
+
+  @doc "One message, in `full` format (headers, snippet and body parts)."
+  def get_message(token, message_id, format \\ "full") do
+    get(token, "/messages/#{enc(message_id)}", params: [format: format])
+  end
+
+  @doc "Send an RFC 2822 message (already assembled); `thread_id` places it in a thread."
+  def send_raw(token, raw, thread_id \\ nil) do
+    body =
+      %{"raw" => Base.url_encode64(raw, padding: false)}
+      |> then(&if thread_id, do: Map.put(&1, "threadId", thread_id), else: &1)
+
+    post(token, "/messages/send", json: body)
+  end
+
+  @doc "Add and remove labels on a message."
+  def modify_message(token, message_id, add, remove) do
+    post(token, "/messages/#{enc(message_id)}/modify",
+      json: %{"addLabelIds" => add || [], "removeLabelIds" => remove || []}
+    )
+  end
+
+  @doc "The account's labels."
+  def list_labels(token), do: get(token, "/labels")
+
+  @doc "The address and message counts of the connected account."
+  def profile(token), do: get(token, "/profile")
+
+  @doc """
+  Assemble an RFC 2822 message. `headers` is a keyword list of header lines
+  (`[to: "...", subject: "..."]`); `body` is plain text.
+  """
+  def build_raw(headers, body) when is_list(headers) and is_binary(body) do
+    lines =
+      headers
+      |> Enum.reject(fn {_, v} -> is_nil(v) or v == "" end)
+      |> Enum.map(fn {k, v} -> header_name(k) <> ": " <> v end)
+
+    Enum.join(
+      lines ++
+        ["MIME-Version: 1.0", "Content-Type: text/plain; charset=\"UTF-8\"", "", body],
+      "\r\n"
+    )
+  end
+
+  defp header_name(k) do
+    k
+    |> to_string()
+    |> String.split("_")
+    |> Enum.map_join("-", &String.capitalize/1)
+  end
+
+  defp get(token, path, opts), do: request(token, :get, path, opts)
+  defp get(token, path), do: request(token, :get, path, [])
+  defp post(token, path, opts), do: request(token, :post, path, opts)
+
+  defp request(token, method, path, opts) do
+    req = Req.merge(req(), [url: path, auth: {:bearer, token}, method: method] ++ opts)
+
+    case Req.request(req) do
+      {:ok, %{status: status, body: body}} when status in 200..299 -> {:ok, body}
+      {:ok, %{status: 401}} -> {:error, :unauthorized}
+      {:ok, %{status: status, body: body}} -> {:error, {:http, status, error_message(body)}}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp error_message(%{"error" => %{"message" => m}}), do: m
+  defp error_message(body) when is_binary(body), do: body
+  defp error_message(body), do: inspect(body)
+
+  defp enc(v), do: URI.encode(to_string(v), &URI.char_unreserved?/1)
+
+  @doc false
+  def req do
+    Req.new(
+      [
+        base_url: @base_url,
+        receive_timeout: Application.get_env(:fountain, :gmail_timeout_ms, 20_000),
+        retry: false
+      ] ++ Application.get_env(:fountain, :gmail_req_options, [])
+    )
+  end
+end

--- a/apps/fountain/lib/fountain/connections/google.ex
+++ b/apps/fountain/lib/fountain/connections/google.ex
@@ -1,0 +1,171 @@
+defmodule Fountain.Connections.Google do
+  @moduledoc """
+  The Google side of a connection (#1178): the authorization-code flow that
+  turns a tenant's consent into a refresh token, the refresh call that turns
+  that into an access token, and the revoke call. A plain OAuth client over
+  `Req`; nothing here touches the database.
+
+  `access_type=offline` and `prompt=consent` are sent on every authorize
+  URL: without both, Google returns no refresh token on a second consent,
+  and a connection with no refresh token is dead in an hour.
+
+  Configured by `GOOGLE_OAUTH_CLIENT_ID` / `GOOGLE_OAUTH_CLIENT_SECRET`.
+  Unset, `configured?/0` is false and the console shows the feature as not
+  available on this deployment.
+  """
+
+  @authorize_url "https://accounts.google.com/o/oauth2/v2/auth"
+  @token_url "https://oauth2.googleapis.com/token"
+  @revoke_url "https://oauth2.googleapis.com/revoke"
+  @userinfo_url "https://openidconnect.googleapis.com/v1/userinfo"
+
+  # gmail.modify covers read, send, reply and label; the two OpenID scopes
+  # give the account's address, which is how a connection is named.
+  @scopes ~w(openid email https://www.googleapis.com/auth/gmail.modify)
+
+  # The hosts the brokered access token is attached to as a bearer (ADR
+  # 0019), so an MCP server the tenant runs in the sandbox reaches Gmail
+  # with a placeholder in its environment.
+  @token_hosts ~w(gmail.googleapis.com www.googleapis.com)
+
+  def provider, do: "google"
+  def scopes, do: @scopes
+  def token_hosts, do: @token_hosts
+
+  @doc "The env var name a Google connection's access token is brokered under."
+  def env_key, do: "GOOGLE_ACCESS_TOKEN"
+
+  def client_id, do: Application.get_env(:fountain, :google_oauth_client_id)
+  def client_secret, do: Application.get_env(:fountain, :google_oauth_client_secret)
+
+  @doc "True when both halves of the OAuth client are set."
+  def configured? do
+    present?(client_id()) and present?(client_secret())
+  end
+
+  defp present?(v), do: is_binary(v) and v != ""
+
+  @doc "Where to send the tenant. `state` is verified on the way back by the caller."
+  def authorize_url(redirect_uri, state) when is_binary(redirect_uri) and is_binary(state) do
+    query =
+      URI.encode_query(%{
+        "client_id" => client_id() || "",
+        "redirect_uri" => redirect_uri,
+        "response_type" => "code",
+        "scope" => Enum.join(@scopes, " "),
+        "access_type" => "offline",
+        "prompt" => "consent",
+        "include_granted_scopes" => "true",
+        "state" => state
+      })
+
+    @authorize_url <> "?" <> query
+  end
+
+  @doc """
+  Exchange the code from the callback for tokens. Returns
+  `{:ok, %{refresh_token, access_token, expires_at, scopes, account_email}}`.
+  """
+  def exchange_code(code, redirect_uri) when is_binary(code) and is_binary(redirect_uri) do
+    form = %{
+      "code" => code,
+      "client_id" => client_id() || "",
+      "client_secret" => client_secret() || "",
+      "redirect_uri" => redirect_uri,
+      "grant_type" => "authorization_code"
+    }
+
+    with {:ok, %{"access_token" => access} = body} <- token_request(form),
+         {:ok, refresh} <- fetch_refresh_token(body),
+         {:ok, email} <- account_email(access) do
+      {:ok,
+       %{
+         refresh_token: refresh,
+         access_token: access,
+         expires_at: expires_at(body["expires_in"]),
+         scopes: String.split(body["scope"] || "", " ", trim: true),
+         account_email: email
+       }}
+    else
+      {:ok, other} -> {:error, {:unexpected, other}}
+      {:error, _} = err -> err
+    end
+  end
+
+  defp fetch_refresh_token(%{"refresh_token" => refresh}) when is_binary(refresh) and refresh != "",
+    do: {:ok, refresh}
+
+  defp fetch_refresh_token(_), do: {:error, :no_refresh_token}
+
+  @doc """
+  A fresh access token for a refresh token: `{:ok, access_token, expires_at}`,
+  `{:error, :invalid_grant}` when Google has forgotten the grant (the tenant
+  revoked it, or the password changed), or `{:error, reason}`.
+  """
+  def refresh(refresh_token) when is_binary(refresh_token) do
+    form = %{
+      "refresh_token" => refresh_token,
+      "client_id" => client_id() || "",
+      "client_secret" => client_secret() || "",
+      "grant_type" => "refresh_token"
+    }
+
+    case token_request(form) do
+      {:ok, %{"access_token" => access} = body} -> {:ok, access, expires_at(body["expires_in"])}
+      {:ok, other} -> {:error, {:unexpected, other}}
+      {:error, _} = err -> err
+    end
+  end
+
+  @doc """
+  Tell Google to forget the grant. Best effort: an already-revoked token is a
+  400 there and `:ok` here, because the outcome is the same.
+  """
+  def revoke(token) when is_binary(token) do
+    case Req.post(req(), url: @revoke_url, form: [token: token]) do
+      {:ok, %{status: status}} when status in 200..299 -> :ok
+      {:ok, %{status: 400}} -> :ok
+      {:ok, %{status: status, body: body}} -> {:error, {:http, status, body}}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp token_request(form) do
+    case Req.post(req(), url: @token_url, form: form) do
+      {:ok, %{status: status, body: body}} when status in 200..299 and is_map(body) ->
+        {:ok, body}
+
+      {:ok, %{status: status, body: %{"error" => "invalid_grant"}}} when status in 400..499 ->
+        {:error, :invalid_grant}
+
+      {:ok, %{status: status, body: body}} ->
+        {:error, {:http, status, body}}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp account_email(access_token) do
+    case Req.get(req(), url: @userinfo_url, auth: {:bearer, access_token}) do
+      {:ok, %{status: 200, body: %{"email" => email}}} when is_binary(email) -> {:ok, email}
+      {:ok, %{status: status, body: body}} -> {:error, {:userinfo, status, body}}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp expires_at(ttl) when is_integer(ttl),
+    do: DateTime.utc_now() |> DateTime.add(ttl, :second) |> DateTime.truncate(:second)
+
+  defp expires_at(_), do: expires_at(3600)
+
+  @doc false
+  def req do
+    Req.new(
+      [
+        receive_timeout: Application.get_env(:fountain, :google_oauth_timeout_ms, 15_000),
+        retry: false
+      ] ++ Application.get_env(:fountain, :google_oauth_req_options, [])
+    )
+  end
+end

--- a/apps/fountain/lib/fountain/connections/google.ex
+++ b/apps/fountain/lib/fountain/connections/google.ex
@@ -92,8 +92,9 @@ defmodule Fountain.Connections.Google do
     end
   end
 
-  defp fetch_refresh_token(%{"refresh_token" => refresh}) when is_binary(refresh) and refresh != "",
-    do: {:ok, refresh}
+  defp fetch_refresh_token(%{"refresh_token" => refresh})
+       when is_binary(refresh) and refresh != "",
+       do: {:ok, refresh}
 
   defp fetch_refresh_token(_), do: {:error, :no_refresh_token}
 

--- a/apps/fountain/lib/fountain/connections/mcp.ex
+++ b/apps/fountain/lib/fountain/connections/mcp.ex
@@ -42,7 +42,10 @@ defmodule Fountain.Connections.Mcp do
           properties: %{
             query: %{type: "string", description: "Gmail search query. Empty lists recent mail."},
             max_results: %{type: "integer", description: "1 to #{@max_results}, default 10"},
-            page_token: %{type: "string", description: "From a previous result, for the next page"}
+            page_token: %{
+              type: "string",
+              description: "From a previous result, for the next page"
+            }
           }
         }
       },
@@ -239,13 +242,22 @@ defmodule Fountain.Connections.Mcp do
          {:ok, body} <- require_arg(args, "body") do
       raw =
         Gmail.build_raw(
-          [from: ctx.connection.account_email, to: to, cc: args["cc"], bcc: args["bcc"], subject: subject],
+          [
+            from: ctx.connection.account_email,
+            to: to,
+            cc: args["cc"],
+            bcc: args["bcc"],
+            subject: subject
+          ],
           body
         )
 
       case gmail(ctx).send_raw(token, raw) do
         {:ok, sent} ->
-          audit(ctx, "gmail_send", %{"recipients" => count_addresses([to, args["cc"], args["bcc"]])})
+          audit(ctx, "gmail_send", %{
+            "recipients" => count_addresses([to, args["cc"], args["bcc"]])
+          })
+
           ok(id, %{id: sent["id"], thread_id: sent["threadId"], sent: true})
 
         {:error, reason} ->
@@ -421,7 +433,9 @@ defmodule Fountain.Connections.Mcp do
     payload
     |> flatten_parts()
     |> Enum.filter(&(is_binary(&1["filename"]) and &1["filename"] != ""))
-    |> Enum.map(&%{filename: &1["filename"], mime_type: &1["mimeType"], size: get_in(&1, ["body", "size"])})
+    |> Enum.map(
+      &%{filename: &1["filename"], mime_type: &1["mimeType"], size: get_in(&1, ["body", "size"])}
+    )
   end
 
   defp count_addresses(fields) do
@@ -457,9 +471,15 @@ defmodule Fountain.Connections.Mcp do
   defp clamp(_, _lo, _hi, default), do: default
 
   defp api_error(id, :unauthorized),
-    do: tool_error(id, "Gmail refused the access token; retry, and if it persists reconnect the account")
+    do:
+      tool_error(
+        id,
+        "Gmail refused the access token; retry, and if it persists reconnect the account"
+      )
 
-  defp api_error(id, {:http, status, message}), do: tool_error(id, "Gmail API error #{status}: #{message}")
+  defp api_error(id, {:http, status, message}),
+    do: tool_error(id, "Gmail API error #{status}: #{message}")
+
   defp api_error(id, reason), do: tool_error(id, "Gmail request failed: #{inspect(reason)}")
 
   defp ok(id, payload), do: result(id, %{content: [text(Jason.encode!(payload))], isError: false})

--- a/apps/fountain/lib/fountain/connections/mcp.ex
+++ b/apps/fountain/lib/fountain/connections/mcp.ex
@@ -1,0 +1,475 @@
+defmodule Fountain.Connections.Mcp do
+  @moduledoc """
+  The Gmail tools Fountain serves to a conversation whose agent names a
+  Google connection (#1178). A pure JSON-RPC/tool layer over a `ctx`, the
+  same shape as `Fountain.Team.Comms.Mcp`: `handle/2` takes one request map
+  and returns one response map (or `:noreply` for a notification). The
+  transport and the `ctx` live in `FountainWeb.GmailMcpController`.
+
+  The access token is resolved server-side per call through
+  `Fountain.Connections.access_token/1`, so a token that expired mid-session
+  is refreshed on the next tool call and a revoked connection answers with
+  `connection revoked` — the model sees a reason, not a 401.
+
+  `ctx` fields:
+    * `:connection` — the `%Fountain.Connections.Connection{}` the tools act for
+    * `:gmail`      — the client module (default `Fountain.Connections.Gmail`)
+    * `:audit`      — `fn tool, summary -> _ end`, called for every send
+  """
+
+  alias Fountain.Connections
+  alias Fountain.Connections.Gmail
+
+  @protocol_version "2025-06-18"
+  @server_info %{name: "fountain-gmail", version: "1"}
+  @mcp_name "gmail"
+
+  @max_results 50
+
+  def mcp_name, do: @mcp_name
+
+  @doc "The tool catalogue advertised by `tools/list`."
+  def tools do
+    [
+      %{
+        name: "gmail_search",
+        description:
+          "Search the connected mailbox with Gmail's query syntax (`from:`, `subject:`, " <>
+            "`is:unread`, `newer_than:7d`, ...). Returns threads, newest first, with " <>
+            "subject, sender, date and snippet. Use gmail_get_thread for the full text.",
+        inputSchema: %{
+          type: "object",
+          properties: %{
+            query: %{type: "string", description: "Gmail search query. Empty lists recent mail."},
+            max_results: %{type: "integer", description: "1 to #{@max_results}, default 10"},
+            page_token: %{type: "string", description: "From a previous result, for the next page"}
+          }
+        }
+      },
+      %{
+        name: "gmail_get_thread",
+        description:
+          "Every message in a thread with headers and plain-text body. " <>
+            "Reply with gmail_reply using the last message's id.",
+        inputSchema: %{
+          type: "object",
+          properties: %{thread_id: %{type: "string"}},
+          required: ["thread_id"]
+        }
+      },
+      %{
+        name: "gmail_get_message",
+        description: "One message in full: headers, plain-text body and attachment names.",
+        inputSchema: %{
+          type: "object",
+          properties: %{message_id: %{type: "string"}},
+          required: ["message_id"]
+        }
+      },
+      %{
+        name: "gmail_send",
+        description:
+          "Send a new plain-text email from the connected account. " <>
+            "`to`, `cc` and `bcc` are comma-separated addresses.",
+        inputSchema: %{
+          type: "object",
+          properties: %{
+            to: %{type: "string"},
+            subject: %{type: "string"},
+            body: %{type: "string", description: "Plain text"},
+            cc: %{type: "string"},
+            bcc: %{type: "string"}
+          },
+          required: ["to", "subject", "body"]
+        }
+      },
+      %{
+        name: "gmail_reply",
+        description:
+          "Reply to a message, in its thread, to its sender (reply_all: true adds the other " <>
+            "recipients). Use this rather than gmail_send when answering mail.",
+        inputSchema: %{
+          type: "object",
+          properties: %{
+            message_id: %{type: "string", description: "The message to answer"},
+            body: %{type: "string", description: "Plain text"},
+            reply_all: %{type: "boolean"}
+          },
+          required: ["message_id", "body"]
+        }
+      },
+      %{
+        name: "gmail_modify_labels",
+        description:
+          "Add or remove labels on a message by label id (INBOX, UNREAD, STARRED, or one " <>
+            "from gmail_list_labels). Archive = remove INBOX; mark read = remove UNREAD.",
+        inputSchema: %{
+          type: "object",
+          properties: %{
+            message_id: %{type: "string"},
+            add: %{type: "array", items: %{type: "string"}},
+            remove: %{type: "array", items: %{type: "string"}}
+          },
+          required: ["message_id"]
+        }
+      },
+      %{
+        name: "gmail_list_labels",
+        description: "The mailbox's labels, with ids, for gmail_modify_labels.",
+        inputSchema: %{type: "object", properties: %{}}
+      }
+    ]
+  end
+
+  @doc "The instructions the server sends with `initialize`."
+  def instructions(%{account_email: email}) do
+    "These tools act on the Gmail mailbox of #{email}, connected by the account owner. " <>
+      "Search first, read a thread before replying, and send only what the task asks for."
+  end
+
+  # ── JSON-RPC ──────────────────────────────────────────────────────────────
+
+  def handle(%{"method" => method} = req, ctx) do
+    id = Map.get(req, "id")
+
+    if is_nil(id) and String.starts_with?(method, "notifications/") do
+      :noreply
+    else
+      dispatch(method, id, Map.get(req, "params", %{}) || %{}, ctx)
+    end
+  end
+
+  def handle(_req, _ctx), do: error(nil, -32_600, "invalid request")
+
+  defp dispatch("initialize", id, _params, ctx) do
+    result(id, %{
+      protocolVersion: @protocol_version,
+      capabilities: %{tools: %{}},
+      serverInfo: @server_info,
+      instructions: instructions(ctx.connection)
+    })
+  end
+
+  defp dispatch("ping", id, _params, _ctx), do: result(id, %{})
+  defp dispatch("tools/list", id, _params, _ctx), do: result(id, %{tools: tools()})
+
+  defp dispatch("tools/call", id, %{"name" => name} = params, ctx) do
+    with_token(id, ctx, fn token ->
+      call_tool(id, name, Map.get(params, "arguments", %{}) || %{}, token, ctx)
+    end)
+  end
+
+  defp dispatch(_unknown, nil, _params, _ctx), do: :noreply
+  defp dispatch(method, id, _params, _ctx), do: error(id, -32_601, "method not found: #{method}")
+
+  # Every tool call resolves the token afresh: a refresh happens here when
+  # it is due, and a revoked connection is named before any API call.
+  defp with_token(id, ctx, fun) do
+    case Connections.access_token(ctx.connection) do
+      {:ok, token} ->
+        fun.(token)
+
+      {:error, :revoked} ->
+        tool_error(
+          id,
+          "connection revoked: the Google account #{ctx.connection.account_email} is no " <>
+            "longer connected to Fountain. Ask the account owner to reconnect it in the console."
+        )
+
+      {:error, reason} ->
+        tool_error(id, "could not get an access token for the connection: #{inspect(reason)}")
+    end
+  end
+
+  # ── tools ─────────────────────────────────────────────────────────────────
+
+  defp call_tool(id, "gmail_search", args, token, ctx) do
+    opts = [
+      query: blank_to_nil(args["query"]),
+      max_results: clamp(args["max_results"], 1, @max_results, 10),
+      page_token: blank_to_nil(args["page_token"])
+    ]
+
+    with {:ok, %{} = page} <- gmail(ctx).list_threads(token, opts) do
+      threads =
+        (page["threads"] || [])
+        |> Enum.map(fn %{"id" => tid} ->
+          case gmail(ctx).get_thread(token, tid, "metadata") do
+            {:ok, thread} -> thread_summary(thread)
+            _ -> %{id: tid}
+          end
+        end)
+
+      ok(id, %{
+        threads: threads,
+        next_page_token: page["nextPageToken"],
+        result_size_estimate: page["resultSizeEstimate"]
+      })
+    else
+      {:error, reason} -> api_error(id, reason)
+    end
+  end
+
+  defp call_tool(id, "gmail_get_thread", args, token, ctx) do
+    with {:ok, tid} <- require_arg(args, "thread_id"),
+         {:ok, thread} <- gmail(ctx).get_thread(token, tid, "full") do
+      ok(id, %{
+        id: thread["id"],
+        messages: Enum.map(thread["messages"] || [], &message_detail/1)
+      })
+    else
+      {:missing, key} -> tool_error(id, "missing argument: #{key}")
+      {:error, reason} -> api_error(id, reason)
+    end
+  end
+
+  defp call_tool(id, "gmail_get_message", args, token, ctx) do
+    with {:ok, mid} <- require_arg(args, "message_id"),
+         {:ok, message} <- gmail(ctx).get_message(token, mid, "full") do
+      ok(id, message_detail(message))
+    else
+      {:missing, key} -> tool_error(id, "missing argument: #{key}")
+      {:error, reason} -> api_error(id, reason)
+    end
+  end
+
+  defp call_tool(id, "gmail_send", args, token, ctx) do
+    with {:ok, to} <- require_arg(args, "to"),
+         {:ok, subject} <- require_arg(args, "subject"),
+         {:ok, body} <- require_arg(args, "body") do
+      raw =
+        Gmail.build_raw(
+          [from: ctx.connection.account_email, to: to, cc: args["cc"], bcc: args["bcc"], subject: subject],
+          body
+        )
+
+      case gmail(ctx).send_raw(token, raw) do
+        {:ok, sent} ->
+          audit(ctx, "gmail_send", %{"recipients" => count_addresses([to, args["cc"], args["bcc"]])})
+          ok(id, %{id: sent["id"], thread_id: sent["threadId"], sent: true})
+
+        {:error, reason} ->
+          api_error(id, reason)
+      end
+    else
+      {:missing, key} -> tool_error(id, "missing argument: #{key}")
+    end
+  end
+
+  defp call_tool(id, "gmail_reply", args, token, ctx) do
+    with {:ok, mid} <- require_arg(args, "message_id"),
+         {:ok, body} <- require_arg(args, "body"),
+         {:ok, original} <- gmail(ctx).get_message(token, mid, "metadata") do
+      headers = headers_of(original)
+      me = ctx.connection.account_email
+      reply_to = headers["reply-to"] || headers["from"]
+
+      cc =
+        if args["reply_all"] == true,
+          do: [headers["to"], headers["cc"]] |> Enum.reject(&is_nil/1) |> Enum.join(", "),
+          else: nil
+
+      subject =
+        case headers["subject"] do
+          nil -> "Re:"
+          "Re: " <> _ = s -> s
+          s -> "Re: " <> s
+        end
+
+      raw =
+        Gmail.build_raw(
+          [
+            from: me,
+            to: reply_to,
+            cc: cc,
+            subject: subject,
+            in_reply_to: headers["message-id"],
+            references: headers["message-id"]
+          ],
+          body
+        )
+
+      case gmail(ctx).send_raw(token, raw, original["threadId"]) do
+        {:ok, sent} ->
+          audit(ctx, "gmail_reply", %{"recipients" => count_addresses([reply_to, cc])})
+          ok(id, %{id: sent["id"], thread_id: sent["threadId"], sent: true})
+
+        {:error, reason} ->
+          api_error(id, reason)
+      end
+    else
+      {:missing, key} -> tool_error(id, "missing argument: #{key}")
+      {:error, reason} -> api_error(id, reason)
+    end
+  end
+
+  defp call_tool(id, "gmail_modify_labels", args, token, ctx) do
+    with {:ok, mid} <- require_arg(args, "message_id"),
+         {:ok, message} <-
+           gmail(ctx).modify_message(token, mid, list_arg(args["add"]), list_arg(args["remove"])) do
+      ok(id, %{id: message["id"], label_ids: message["labelIds"] || []})
+    else
+      {:missing, key} -> tool_error(id, "missing argument: #{key}")
+      {:error, reason} -> api_error(id, reason)
+    end
+  end
+
+  defp call_tool(id, "gmail_list_labels", _args, token, ctx) do
+    case gmail(ctx).list_labels(token) do
+      {:ok, %{"labels" => labels}} ->
+        ok(id, %{labels: Enum.map(labels, &Map.take(&1, ["id", "name", "type"]))})
+
+      {:ok, _} ->
+        ok(id, %{labels: []})
+
+      {:error, reason} ->
+        api_error(id, reason)
+    end
+  end
+
+  defp call_tool(id, name, _args, _token, _ctx), do: tool_error(id, "unknown tool: #{name}")
+
+  # ── shaping ───────────────────────────────────────────────────────────────
+
+  defp thread_summary(thread) do
+    messages = thread["messages"] || []
+    last = List.last(messages) || %{}
+    headers = headers_of(last)
+
+    %{
+      id: thread["id"],
+      subject: headers["subject"],
+      from: headers["from"],
+      date: headers["date"],
+      snippet: last["snippet"],
+      message_count: length(messages),
+      last_message_id: last["id"],
+      label_ids: last["labelIds"] || []
+    }
+  end
+
+  defp message_detail(message) do
+    headers = headers_of(message)
+
+    %{
+      id: message["id"],
+      thread_id: message["threadId"],
+      from: headers["from"],
+      to: headers["to"],
+      cc: headers["cc"],
+      subject: headers["subject"],
+      date: headers["date"],
+      message_id_header: headers["message-id"],
+      label_ids: message["labelIds"] || [],
+      snippet: message["snippet"],
+      body: body_text(message["payload"]),
+      attachments: attachment_names(message["payload"])
+    }
+  end
+
+  defp headers_of(%{"payload" => %{"headers" => headers}}) when is_list(headers) do
+    Map.new(headers, fn %{"name" => n, "value" => v} -> {String.downcase(n), v} end)
+  end
+
+  defp headers_of(_), do: %{}
+
+  # The first text/plain part, walking multipart bodies; falls back to a
+  # stripped text/html part. Attachments are named, never inlined.
+  defp body_text(nil), do: nil
+
+  defp body_text(payload) do
+    parts = flatten_parts(payload)
+
+    plain = Enum.find(parts, &(&1["mimeType"] == "text/plain" and has_data?(&1)))
+    html = Enum.find(parts, &(&1["mimeType"] == "text/html" and has_data?(&1)))
+
+    cond do
+      plain -> decode_data(plain)
+      html -> html |> decode_data() |> strip_html()
+      true -> nil
+    end
+  end
+
+  defp flatten_parts(%{"parts" => parts} = payload) when is_list(parts),
+    do: [payload | Enum.flat_map(parts, &flatten_parts/1)]
+
+  defp flatten_parts(part), do: [part]
+
+  defp has_data?(%{"body" => %{"data" => d}}) when is_binary(d) and d != "", do: true
+  defp has_data?(_), do: false
+
+  defp decode_data(%{"body" => %{"data" => d}}) do
+    case Base.url_decode64(d, padding: false) do
+      {:ok, text} -> text
+      :error -> ""
+    end
+  end
+
+  defp strip_html(html) do
+    html
+    |> String.replace(~r/<(script|style)[^>]*>.*?<\/\1>/is, " ")
+    |> String.replace(~r/<br\s*\/?>|<\/p>|<\/div>/i, "\n")
+    |> String.replace(~r/<[^>]+>/, " ")
+    |> String.replace(~r/[ \t]+/, " ")
+    |> String.replace(~r/\n\s*\n+/, "\n\n")
+    |> String.trim()
+  end
+
+  defp attachment_names(nil), do: []
+
+  defp attachment_names(payload) do
+    payload
+    |> flatten_parts()
+    |> Enum.filter(&(is_binary(&1["filename"]) and &1["filename"] != ""))
+    |> Enum.map(&%{filename: &1["filename"], mime_type: &1["mimeType"], size: get_in(&1, ["body", "size"])})
+  end
+
+  defp count_addresses(fields) do
+    fields
+    |> Enum.reject(&(is_nil(&1) or &1 == ""))
+    |> Enum.flat_map(&String.split(&1, ","))
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+    |> length()
+  end
+
+  # ── helpers ───────────────────────────────────────────────────────────────
+
+  defp gmail(ctx), do: Map.get(ctx, :gmail, Gmail)
+
+  defp audit(%{audit: fun}, tool, summary) when is_function(fun, 2), do: fun.(tool, summary)
+  defp audit(_ctx, _tool, _summary), do: :ok
+
+  defp require_arg(args, key) do
+    case Map.get(args, key) do
+      v when is_binary(v) and v != "" -> {:ok, v}
+      _ -> {:missing, key}
+    end
+  end
+
+  defp list_arg(v) when is_list(v), do: Enum.map(v, &to_string/1)
+  defp list_arg(_), do: []
+
+  defp blank_to_nil(v) when is_binary(v) and v != "", do: v
+  defp blank_to_nil(_), do: nil
+
+  defp clamp(n, lo, hi, _default) when is_integer(n), do: n |> max(lo) |> min(hi)
+  defp clamp(_, _lo, _hi, default), do: default
+
+  defp api_error(id, :unauthorized),
+    do: tool_error(id, "Gmail refused the access token; retry, and if it persists reconnect the account")
+
+  defp api_error(id, {:http, status, message}), do: tool_error(id, "Gmail API error #{status}: #{message}")
+  defp api_error(id, reason), do: tool_error(id, "Gmail request failed: #{inspect(reason)}")
+
+  defp ok(id, payload), do: result(id, %{content: [text(Jason.encode!(payload))], isError: false})
+  defp text(t), do: %{type: "text", text: t}
+  defp result(id, result), do: %{"jsonrpc" => "2.0", "id" => id, "result" => result}
+
+  defp error(id, code, message),
+    do: %{"jsonrpc" => "2.0", "id" => id, "error" => %{"code" => code, "message" => message}}
+
+  # A tool-level failure is a successful JSON-RPC response carrying isError,
+  # per MCP: the model sees it and can recover.
+  defp tool_error(id, message), do: result(id, %{content: [text(message)], isError: true})
+end

--- a/apps/fountain/lib/fountain/connections/mcp_servers.ex
+++ b/apps/fountain/lib/fountain/connections/mcp_servers.ex
@@ -1,0 +1,61 @@
+defmodule Fountain.Connections.McpServers do
+  @moduledoc """
+  How a connection is named in an agent's `mcp_servers`, and how that entry
+  becomes the server the sandbox actually talks to (#1178).
+
+  An agent names a connection instead of a token:
+
+      %{"gmail" => %{"connection" => "<connection id>"}}
+
+  At spawn, `resolve/3` rewrites that entry into an HTTP MCP server pointing
+  at `POST /api/mcp/gmail/:conversation_id/:connection_id`, authenticated by
+  the conversation's own callback token, which the sandbox already holds. It
+  is the same shape a tenant would write for any remote MCP server, so it
+  flows through `.mcp.json` (claude) and `session/new` (everyone else)
+  without a new contract. The connection id is validated at request time
+  by `FountainWeb.GmailMcpController`; a stale or revoked one fails there
+  with a reason the model can read.
+  """
+
+  @doc "True for an `mcp_servers` entry that names a connection."
+  def connection_entry?(%{"connection" => id}) when is_binary(id), do: true
+  def connection_entry?(_), do: false
+
+  @doc "The connection ids an agent's `mcp_servers` names."
+  def connection_ids(nil), do: []
+
+  def connection_ids(mcp_servers) when is_map(mcp_servers) do
+    for {_name, %{"connection" => id}} <- mcp_servers, is_binary(id), uniq: true, do: id
+  end
+
+  @doc """
+  Rewrite every connection entry into the HTTP server the sandbox calls.
+  With no callback token yet (`nil`), connection entries are dropped rather
+  than shipped half-built — the turn kick recomputes with the token.
+  """
+  def resolve(mcp_servers, conversation_id, token)
+
+  def resolve(mcp_servers, _conversation_id, _token)
+      when not is_map(mcp_servers) or map_size(mcp_servers) == 0,
+      do: mcp_servers
+
+  def resolve(mcp_servers, conversation_id, token) when is_map(mcp_servers) do
+    Enum.reduce(mcp_servers, %{}, fn
+      {name, %{"connection" => id}}, acc when is_binary(id) ->
+        if is_binary(token) and is_binary(conversation_id),
+          do: Map.put(acc, name, server(conversation_id, id, token)),
+          else: acc
+
+      {name, entry}, acc ->
+        Map.put(acc, name, entry)
+    end)
+  end
+
+  defp server(conversation_id, connection_id, token) do
+    %{
+      "type" => "http",
+      "url" => Fountain.PublicUrl.base() <> "/api/mcp/gmail/#{conversation_id}/#{connection_id}",
+      "headers" => %{"Authorization" => "Bearer " <> token}
+    }
+  end
+end

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -1031,7 +1031,8 @@ defmodule Fountain.Conversations.ConversationServer do
       # The callback token just rotated, and for claude the connection MCP
       # servers carry it in `.mcp.json` (#1178): rewrite the file so the
       # next turn's tools authenticate. Idempotent for an agent without one.
-      _ = write_runtime_config(handle, state.runtime_module, with_connection_servers(agent, state))
+      _ =
+        write_runtime_config(handle, state.runtime_module, with_connection_servers(agent, state))
 
       # A machine provisioned before its tenant was brokered has no CA yet;
       # on one that has it this is an idempotent rewrite. Best effort here:
@@ -1477,7 +1478,12 @@ defmodule Fountain.Conversations.ConversationServer do
 
   defp with_connection_servers(%{mcp_servers: servers} = agent, state) when is_map(servers) do
     token = if Fountain.Broker.enabled_for?(state.user_id), do: state.callback_token
-    %{agent | mcp_servers: Fountain.Connections.McpServers.resolve(servers, state.conversation_id, token)}
+
+    %{
+      agent
+      | mcp_servers:
+          Fountain.Connections.McpServers.resolve(servers, state.conversation_id, token)
+    }
   end
 
   defp with_connection_servers(agent, _state), do: agent

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -365,6 +365,10 @@ defmodule Fountain.Conversations.ConversationServer do
       # The tenant's enabled bindings by key (gate 1b), loaded once per
       # provision; what the broker's services are built from.
       broker_bindings: %{},
+      # The env var names of the tenant's connections brokered into this
+      # conversation (#1178): their access tokens rotate hourly, so each turn
+      # kick re-reads them and re-prepares the vault when one has changed.
+      connection_keys: [],
       # The environment's networking shape, enforced at the broker (gate 2).
       broker_network: :unrestricted,
       # What the runtime's default_env/2 is handed (gate 3): the real
@@ -581,8 +585,10 @@ defmodule Fountain.Conversations.ConversationServer do
       {:ok, dek, inference_creds} ->
         bindings = broker_bindings(conv.user_id)
 
-        {secrets, brokered} =
-          split_brokered(conv.user_id, merge_secrets(env, vault, dek), bindings)
+        {merged, bindings, connection_keys} =
+          add_connection_secrets(conv.user_id, merge_secrets(env, vault, dek), bindings)
+
+        {secrets, brokered} = split_brokered(conv.user_id, merged, bindings)
 
         {env_creds, brokered, bindings} =
           split_inference(conv.user_id, inference_creds, brokered, bindings)
@@ -597,6 +603,7 @@ defmodule Fountain.Conversations.ConversationServer do
               env_credentials: env_creds,
               brokered: brokered,
               broker_bindings: bindings,
+              connection_keys: connection_keys,
               broker_network: Fountain.Broker.network_for(env)
           }
 
@@ -781,7 +788,12 @@ defmodule Fountain.Conversations.ConversationServer do
         # because nothing dials out without it (ADR 0019 gate 1a).
         with {:ok, state} <- broker_prepare(state),
              sprite_env = build_sprite_env(state, agent, env, secrets, sandbox_url),
-             _ = write_runtime_config(handle, state.runtime_module, agent),
+             _ =
+               write_runtime_config(
+                 handle,
+                 state.runtime_module,
+                 with_connection_servers(agent, state)
+               ),
              _ = write_instructions(handle, runtime, agent),
              # The file is the machine's; the conversation's identity travels as
              # process env on every spawn (`Fountain.Conversations.Identity`).
@@ -1015,6 +1027,11 @@ defmodule Fountain.Conversations.ConversationServer do
 
       {state, _conv} = rotate_callback_api_key(state, conv)
       sprite_env = build_sprite_env(state, agent, env, secrets)
+
+      # The callback token just rotated, and for claude the connection MCP
+      # servers carry it in `.mcp.json` (#1178): rewrite the file so the
+      # next turn's tools authenticate. Idempotent for an agent without one.
+      _ = write_runtime_config(handle, state.runtime_module, with_connection_servers(agent, state))
 
       # A machine provisioned before its tenant was brokered has no CA yet;
       # on one that has it this is an idempotent rewrite. Best effort here:
@@ -1389,6 +1406,82 @@ defmodule Fountain.Conversations.ConversationServer do
       else: {secrets, %{}}
   end
 
+  # A tenant's connections (#1178) contribute their access tokens as
+  # synthetic secrets, brokered like inference keys: the sandbox gets a
+  # placeholder, the broker gets the value with an implicit bearer binding
+  # to the provider's hosts. A tenant's own secret of the same name wins,
+  # as does their own binding on it (which is how the token reaches an MCP
+  # server they run). Only for brokered tenants — without the broker the
+  # token would have to enter the sandbox in the clear, which is the thing
+  # connections exist to avoid.
+  defp add_connection_secrets(user_id, merged, bindings) do
+    if Fountain.Broker.enabled_for?(user_id) do
+      synthetic = Fountain.Connections.synthetic_secrets(user_id)
+
+      {merged, bindings, keys} =
+        Enum.reduce(synthetic, {merged, bindings, []}, fn {key, token}, {m, b, keys} ->
+          if Map.has_key?(m, key) do
+            {m, b, keys}
+          else
+            b =
+              if Map.has_key?(b, key),
+                do: b,
+                else: Map.put(b, key, connection_bindings(key))
+
+            {Map.put(m, key, token), b, [key | keys]}
+          end
+        end)
+
+      {merged, bindings, Enum.sort(keys)}
+    else
+      {merged, bindings, []}
+    end
+  end
+
+  defp connection_bindings(key) do
+    Enum.map(Fountain.Connections.implicit_hosts(key), fn host ->
+      %Fountain.SecretBindings.Binding{
+        key: key,
+        host: host,
+        auth_type: "bearer",
+        headers: %{},
+        enabled: true
+      }
+    end)
+  end
+
+  # Re-read the brokered connection tokens; a rotated one is swapped into
+  # `brokered` and the caller re-prepares the vault. A refresh that fails
+  # leaves the old token in place: the turn runs on it and, if it has
+  # expired, fails at the provider with a reason rather than silently here.
+  defp refresh_connection_secrets(%{connection_keys: []} = state), do: {state, false}
+
+  defp refresh_connection_secrets(%{connection_keys: keys, user_id: user_id} = state) do
+    fresh = user_id |> Fountain.Connections.synthetic_secrets() |> Map.take(keys)
+
+    rotated =
+      Enum.filter(fresh, fn {k, v} -> Map.get(state.brokered, k) != v end)
+
+    if rotated == [] do
+      {state, false}
+    else
+      {%{state | brokered: Map.merge(state.brokered, Map.new(rotated))}, true}
+    end
+  end
+
+  # An agent whose `mcp_servers` names a connection gets the entry rewritten
+  # into the Fountain-served server (#1178), authenticated by the
+  # conversation's callback token. Not for an unbrokered tenant: the entry
+  # is dropped and the agent runs without it.
+  defp with_connection_servers(nil, _state), do: nil
+
+  defp with_connection_servers(%{mcp_servers: servers} = agent, state) when is_map(servers) do
+    token = if Fountain.Broker.enabled_for?(state.user_id), do: state.callback_token
+    %{agent | mcp_servers: Fountain.Connections.McpServers.resolve(servers, state.conversation_id, token)}
+  end
+
+  defp with_connection_servers(agent, _state), do: agent
+
   # Only read for a brokered tenant: for everyone else the table is rows
   # nobody consults, and this path stays free of a query.
   defp broker_bindings(user_id) do
@@ -1492,7 +1585,9 @@ defmodule Fountain.Conversations.ConversationServer do
   defp broker_refresh(%{broker: nil} = state), do: state
 
   defp broker_refresh(%{broker: session} = state) do
-    if Fountain.Broker.expiring?(session) do
+    {state, rotated?} = refresh_connection_secrets(state)
+
+    if rotated? or Fountain.Broker.expiring?(session) do
       case Fountain.Broker.prepare(state.conversation_id, state.brokered, state.broker_bindings,
              network: state.broker_network
            ) do
@@ -3300,7 +3395,7 @@ defmodule Fountain.Conversations.ConversationServer do
                     cwd: cwd,
                     images: images,
                     mcp_servers:
-                      Fountain.Runtimes.ACP.mcp_servers(agent) ++
+                      Fountain.Runtimes.ACP.mcp_servers(with_connection_servers(agent, state)) ++
                         buzz_mcp_servers(state) ++
                         team_mcp_servers(state) ++
                         team_comms_mcp_servers(state),

--- a/apps/fountain/lib/fountain/secret_bindings.ex
+++ b/apps/fountain/lib/fountain/secret_bindings.ex
@@ -89,7 +89,11 @@ defmodule Fountain.SecretBindings do
         select: s.key
       )
 
-    (Repo.all(env_keys) ++ Repo.all(vault_keys)) |> Enum.uniq() |> Enum.sort()
+    # A connection's token is a secret the account holds too (#1178): it is
+    # brokered under its env_key, so it can be bound to a host like any other.
+    (Repo.all(env_keys) ++ Repo.all(vault_keys) ++ Fountain.Connections.env_keys(user_id))
+    |> Enum.uniq()
+    |> Enum.sort()
   end
 
   # ── audit ────────────────────────────────────────────────────────────────

--- a/apps/fountain/lib/fountain_web/components/layouts.ex
+++ b/apps/fountain/lib/fountain_web/components/layouts.ex
@@ -105,6 +105,12 @@ defmodule FountainWeb.Layouts do
                 label="Credential bindings"
                 current={@current_path}
               />
+              <.nav_link
+                :if={assigns[:current_user] && Fountain.Broker.enabled_for?(assigns.current_user.id)}
+                href={~p"/account/connections"}
+                label="Connections"
+                current={@current_path}
+              />
               <.nav_link href={~p"/account/webhooks"} label="Webhooks" current={@current_path} />
               <.nav_link
                 :if={Fountain.Credits.enabled?()}

--- a/apps/fountain/lib/fountain_web/controllers/connection_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/connection_controller.ex
@@ -34,7 +34,8 @@ defmodule FountainWeb.ConnectionController do
         "Only for accounts the egress broker is on for (ADR 0019); 404 otherwise.",
     responses: [
       ok: {"Connections", "application/json", Schemas.ConnectionListResponse},
-      not_found: {"Connections are not enabled for this account", "application/json", Schemas.Error},
+      not_found:
+        {"Connections are not enabled for this account", "application/json", Schemas.Error},
       unauthorized: {"Missing or invalid key", "application/json", Schemas.Error}
     ]
   )
@@ -52,7 +53,8 @@ defmodule FountainWeb.ConnectionController do
         "that starts the flow (a browser signed in as the account owner).",
     responses: [
       ok: {"Providers", "application/json", Schemas.ConnectionProvidersResponse},
-      not_found: {"Connections are not enabled for this account", "application/json", Schemas.Error},
+      not_found:
+        {"Connections are not enabled for this account", "application/json", Schemas.Error},
       unauthorized: {"Missing or invalid key", "application/json", Schemas.Error}
     ]
   )

--- a/apps/fountain/lib/fountain_web/controllers/connection_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/connection_controller.ex
@@ -1,0 +1,126 @@
+defmodule FountainWeb.ConnectionController do
+  @moduledoc """
+  Connections (#1178): the provider accounts the tenant has signed in to.
+
+      GET    /api/connections            — the account's connections
+      GET    /api/connections/providers  — what this deployment can connect, and where to start
+      GET    /api/connections/:id        — one
+      DELETE /api/connections/:id        — revoke at the provider and delete
+
+  Every route answers 404 `connections_not_enabled` for an account the
+  broker is not on for, the way secret bindings do: the feature does not
+  exist there. Connecting an account is a browser round trip
+  (`/connections/:provider/start`), not an API call.
+  """
+
+  use FountainWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Fountain.{Broker, Connections}
+  alias Fountain.Connections.Google
+  alias FountainWeb.Audited
+  alias FountainWeb.Schemas
+
+  action_fallback FountainWeb.FallbackController
+
+  plug :require_connections
+
+  tags(["Connections"])
+
+  operation(:index,
+    summary: "List connections",
+    description:
+      "Every provider account the tenant has connected, active or revoked. " <>
+        "Only for accounts the egress broker is on for (ADR 0019); 404 otherwise.",
+    responses: [
+      ok: {"Connections", "application/json", Schemas.ConnectionListResponse},
+      not_found: {"Connections are not enabled for this account", "application/json", Schemas.Error},
+      unauthorized: {"Missing or invalid key", "application/json", Schemas.Error}
+    ]
+  )
+
+  def index(conn, _params) do
+    user = conn.assigns.current_user
+    render(conn, :index, connections: Connections.list_connections(user.id))
+  end
+
+  operation(:providers,
+    summary: "List connectable providers",
+    description:
+      "The providers this deployment has an OAuth client for, the scopes each " <>
+        "asks for, the env var its token is brokered under, and the console URL " <>
+        "that starts the flow (a browser signed in as the account owner).",
+    responses: [
+      ok: {"Providers", "application/json", Schemas.ConnectionProvidersResponse},
+      not_found: {"Connections are not enabled for this account", "application/json", Schemas.Error},
+      unauthorized: {"Missing or invalid key", "application/json", Schemas.Error}
+    ]
+  )
+
+  def providers(conn, _params) do
+    render(conn, :providers,
+      providers: [
+        %{
+          provider: "google",
+          configured: Google.configured?(),
+          scopes: Google.scopes(),
+          env_key: Google.env_key(),
+          connect_url: Fountain.PublicUrl.base() <> "/connections/google/start"
+        }
+      ]
+    )
+  end
+
+  operation(:show,
+    summary: "Get a connection",
+    parameters: [id: [in: :path, type: :string, description: "Connection id"]],
+    responses: [
+      ok: {"Connection", "application/json", Schemas.Connection},
+      not_found: {"Not found", "application/json", Schemas.Error},
+      unauthorized: {"Missing or invalid key", "application/json", Schemas.Error}
+    ]
+  )
+
+  def show(conn, %{"id" => id}) do
+    user = conn.assigns.current_user
+
+    case Connections.get_connection(id, user.id) do
+      nil -> {:error, :not_found}
+      connection -> render(conn, :show, connection: connection)
+    end
+  end
+
+  operation(:delete,
+    summary: "Revoke and delete a connection",
+    description:
+      "Tells the provider to forget the grant, then deletes the row. The next " <>
+        "tool call from an agent that names it fails with `connection revoked`.",
+    parameters: [id: [in: :path, type: :string, description: "Connection id"]],
+    responses: [
+      no_content: "Deleted",
+      not_found: {"Not found", "application/json", Schemas.Error},
+      unauthorized: {"Missing or invalid key", "application/json", Schemas.Error}
+    ]
+  )
+
+  def delete(conn, %{"id" => id}) do
+    user = conn.assigns.current_user
+
+    with %Connections.Connection{} = connection <-
+           Connections.get_connection(id, user.id) || {:error, :not_found},
+         {:ok, _} <- Connections.delete(connection, Audited.attribution(conn)) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+
+  defp require_connections(conn, _opts) do
+    if Broker.enabled_for?(conn.assigns.current_user.id) do
+      conn
+    else
+      conn
+      |> put_status(:not_found)
+      |> json(%{error: "connections_not_enabled"})
+      |> halt()
+    end
+  end
+end

--- a/apps/fountain/lib/fountain_web/controllers/connection_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/connection_json.ex
@@ -1,0 +1,26 @@
+defmodule FountainWeb.ConnectionJSON do
+  @moduledoc "JSON views for connections (#1178). Never a token."
+
+  alias Fountain.Connections.Connection
+
+  def index(%{connections: connections}), do: %{data: Enum.map(connections, &summary/1)}
+
+  def show(%{connection: c}), do: summary(c)
+
+  def providers(%{providers: providers}), do: %{data: providers}
+
+  defp summary(%Connection{} = c) do
+    %{
+      id: c.id,
+      provider: c.provider,
+      account_email: c.account_email,
+      scopes: c.scopes,
+      env_key: c.env_key,
+      status: c.status,
+      expires_at: c.expires_at,
+      revoked_at: c.revoked_at,
+      created_at: c.inserted_at,
+      updated_at: c.updated_at
+    }
+  end
+end

--- a/apps/fountain/lib/fountain_web/controllers/connections_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/connections_controller.ex
@@ -1,0 +1,99 @@
+defmodule FountainWeb.ConnectionsController do
+  @moduledoc """
+  The OAuth round trip that connects a provider account to the signed-in
+  user (#1178). `start` sends the browser to the provider's consent screen
+  with a signed `state`; `callback` verifies it, exchanges the code and
+  stores the grant through `Fountain.Connections`. Both end on the
+  Connections page with a flash, so the LiveView stays a plain list.
+
+  `state` is a `Phoenix.Token` over the user id and a nonce kept in the
+  session: the callback belongs to the session that started it, and a code
+  delivered to another session is refused.
+  """
+  use FountainWeb, :controller
+
+  alias Fountain.{Broker, Connections}
+  alias Fountain.Connections.Google
+  alias FountainWeb.Audited
+
+  @state_salt "connections:oauth_state"
+  @state_max_age 600
+
+  plug :require_connections
+
+  def start(conn, %{"provider" => "google"}) do
+    if Google.configured?() do
+      nonce = Base.url_encode64(:crypto.strong_rand_bytes(16), padding: false)
+      state = Phoenix.Token.sign(conn, @state_salt, {conn.assigns.current_user.id, nonce})
+
+      conn
+      |> put_session(:connections_oauth_nonce, nonce)
+      |> redirect(external: Google.authorize_url(redirect_uri(conn, "google"), state))
+    else
+      back(conn, :error, "Google connections are not configured on this deployment.")
+    end
+  end
+
+  def start(conn, _params), do: back(conn, :error, "Unknown provider.")
+
+  def callback(conn, %{"provider" => "google", "code" => code, "state" => state}) do
+    user = conn.assigns.current_user
+    nonce = get_session(conn, :connections_oauth_nonce)
+    conn = delete_session(conn, :connections_oauth_nonce)
+
+    with {:ok, {uid, ^nonce}} when uid == user.id and is_binary(nonce) <-
+           Phoenix.Token.verify(conn, @state_salt, state, max_age: @state_max_age),
+         {:ok, grant} <- Google.exchange_code(code, redirect_uri(conn, "google")),
+         {:ok, connection} <-
+           Connections.connect(user.id, "google", grant, Audited.attribution(conn)) do
+      back(conn, :info, "Connected #{connection.account_email}.")
+    else
+      {:ok, _other} ->
+        back(conn, :error, "That sign-in did not start from this session. Try again.")
+
+      {:error, :no_refresh_token} ->
+        back(
+          conn,
+          :error,
+          "Google returned no refresh token. Remove Fountain from your Google account's " <>
+            "third-party access and connect again."
+        )
+
+      {:error, reason} ->
+        back(conn, :error, "Google sign-in failed: #{describe(reason)}")
+    end
+  end
+
+  def callback(conn, %{"provider" => "google", "error" => error}) do
+    _ = delete_session(conn, :connections_oauth_nonce)
+    back(conn, :error, "Google sign-in was not completed (#{error}).")
+  end
+
+  def callback(conn, _params), do: back(conn, :error, "Unknown provider or a malformed callback.")
+
+  # The feature is for brokered accounts only: without the broker the token
+  # would have to enter a sandbox in the clear.
+  defp require_connections(conn, _opts) do
+    if Broker.enabled_for?(conn.assigns.current_user.id) do
+      conn
+    else
+      conn
+      |> put_flash(:error, "Connections are not enabled for this account.")
+      |> redirect(to: ~p"/account")
+      |> halt()
+    end
+  end
+
+  defp redirect_uri(_conn, provider),
+    do: Fountain.PublicUrl.base() <> "/connections/#{provider}/callback"
+
+  defp back(conn, kind, message) do
+    conn |> put_flash(kind, message) |> redirect(to: ~p"/account/connections")
+  end
+
+  defp describe(:invalid_grant), do: "the code was refused"
+  defp describe({:http, status, _body}), do: "Google answered #{status}"
+  defp describe({:userinfo, status, _body}), do: "could not read the account's address (#{status})"
+  defp describe(%Ecto.Changeset{} = cs), do: cs.errors |> Keyword.keys() |> Enum.join(", ")
+  defp describe(reason), do: inspect(reason)
+end

--- a/apps/fountain/lib/fountain_web/controllers/connections_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/connections_controller.ex
@@ -93,7 +93,10 @@ defmodule FountainWeb.ConnectionsController do
 
   defp describe(:invalid_grant), do: "the code was refused"
   defp describe({:http, status, _body}), do: "Google answered #{status}"
-  defp describe({:userinfo, status, _body}), do: "could not read the account's address (#{status})"
+
+  defp describe({:userinfo, status, _body}),
+    do: "could not read the account's address (#{status})"
+
   defp describe(%Ecto.Changeset{} = cs), do: cs.errors |> Keyword.keys() |> Enum.join(", ")
   defp describe(reason), do: inspect(reason)
 end

--- a/apps/fountain/lib/fountain_web/controllers/gmail_mcp_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/gmail_mcp_controller.ex
@@ -1,0 +1,88 @@
+defmodule FountainWeb.GmailMcpController do
+  @moduledoc """
+  The MCP endpoint a sandbox calls to use a Google connection its agent
+  names (#1178). Streamable-HTTP transport: one JSON-RPC message per POST, a
+  JSON response back (or 202 for a notification) — the shape of
+  `FountainWeb.TeamCommsMcpController`.
+
+  The sandbox authenticates with its callback token, so `current_user` is
+  the conversation's owner. This controller checks the conversation is the
+  caller's, that its agent still names this connection (an agent edited to
+  drop it stops the tools on the next call), and that the connection is the
+  same tenant's; `Fountain.Connections.Mcp` resolves the token per call and
+  answers `connection revoked` for one the tenant has cut.
+  """
+  use FountainWeb, :controller
+
+  alias Fountain.{Agents, Audit, Broker, Connections, Conversations}
+  alias Fountain.Connections.Mcp
+  alias Fountain.Connections.McpServers
+
+  def handle(conn, %{"conversation_id" => conv_id, "connection_id" => connection_id}) do
+    user = conn.assigns.current_user
+
+    case build_ctx(conv_id, connection_id, user) do
+      {:ok, ctx} ->
+        case Mcp.handle(conn.body_params, ctx) do
+          :noreply -> send_resp(conn, 202, "")
+          resp -> json(conn, resp)
+        end
+
+      {:error, status, message} ->
+        conn |> put_status(status) |> json(%{error: message})
+    end
+  end
+
+  defp build_ctx(conv_id, connection_id, user) do
+    with true <- Broker.enabled_for?(user.id) || {:error, 403, "connections are not available here"},
+         %Conversations.Conversation{} = conv <- get_conv(conv_id, user),
+         :ok <- agent_names?(conv, connection_id),
+         %Connections.Connection{} = connection <-
+           Connections.get_connection(connection_id, user.id) || :no_connection do
+      {:ok, %{connection: connection, audit: audit_fn(connection, conv, user)}}
+    else
+      :no_conv -> {:error, 404, "conversation not found"}
+      :not_named -> {:error, 404, "this conversation's agent does not use that connection"}
+      :no_connection -> {:error, 404, "connection not found"}
+      {:error, _, _} = err -> err
+    end
+  end
+
+  defp get_conv(conv_id, user),
+    do: Conversations.get_conversation(conv_id, user.id) || :no_conv
+
+  # Ownership established by the scoped get_conversation above: the agent is
+  # the conversation's own, fetched to check it still names the connection.
+  defp agent_names?(%Conversations.Conversation{agent_id: agent_id}, connection_id)
+       when is_binary(agent_id) do
+    case Agents._unsafe_get_agent(agent_id) do
+      %{mcp_servers: servers} ->
+        if connection_id in McpServers.connection_ids(servers), do: :ok, else: :not_named
+
+      _ ->
+        :not_named
+    end
+  end
+
+  defp agent_names?(_conv, _connection_id), do: :not_named
+
+  # A send is an effect, not a tenant-state mutation, so it is audited here
+  # rather than in a context. Records that a message went out and how many
+  # addresses it went to — never the recipients, subject or body (ADR 0013).
+  defp audit_fn(connection, conv, user) do
+    fn tool, summary ->
+      Audit.record(%{
+        user_id: user.id,
+        action: "connection.used",
+        resource_type: "connection",
+        resource_id: connection.id,
+        actor: "sprite",
+        metadata:
+          Map.merge(
+            %{"tool" => tool, "provider" => connection.provider, "conversation_id" => conv.id},
+            summary
+          )
+      })
+    end
+  end
+end

--- a/apps/fountain/lib/fountain_web/controllers/gmail_mcp_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/gmail_mcp_controller.ex
@@ -34,7 +34,8 @@ defmodule FountainWeb.GmailMcpController do
   end
 
   defp build_ctx(conv_id, connection_id, user) do
-    with true <- Broker.enabled_for?(user.id) || {:error, 403, "connections are not available here"},
+    with true <-
+           Broker.enabled_for?(user.id) || {:error, 403, "connections are not available here"},
          %Conversations.Conversation{} = conv <- get_conv(conv_id, user),
          :ok <- agent_names?(conv, connection_id),
          %Connections.Connection{} = connection <-

--- a/apps/fountain/lib/fountain_web/live/agents_live/form.ex
+++ b/apps/fountain/lib/fountain_web/live/agents_live/form.ex
@@ -34,6 +34,7 @@ defmodule FountainWeb.AgentsLive.Form do
      |> assign(:errors, %{})
      |> assign(:skills, agent_to_skill_list(agent.skills || []))
      |> assign(:mcp_servers, agent_to_mcp_server_list(agent.mcp_servers || %{}))
+     |> assign(:connections, connections_for(user_id))
      |> assign(:avatar_tab, :upload)
      |> assign(:avatar_base, "robot")
      |> assign(:avatar_mood, "serious")
@@ -124,18 +125,60 @@ defmodule FountainWeb.AgentsLive.Form do
     end)
   end
 
+  # Three shapes an entry can have: a stdio server the form edits field by
+  # field; a connection (#1178) that names a Google account Fountain holds
+  # the credential for; and anything else (an HTTP/SSE server written
+  # through the API), carried through untouched so saving the form does not
+  # silently drop it.
   defp agent_to_mcp_server_list(mcp_servers) do
-    Enum.map(mcp_servers, fn {name, config} ->
-      args_str = (config["args"] || []) |> Enum.join("\n")
-      env_vars = (config["env"] || %{}) |> Enum.map(fn {k, v} -> %{"key" => k, "value" => v} end)
+    Enum.map(mcp_servers, fn
+      {name, %{"connection" => id} = _config} when is_binary(id) ->
+        %{
+          "name" => name,
+          "kind" => "connection",
+          "connection" => id,
+          "command" => "",
+          "args" => "",
+          "env_vars" => []
+        }
 
-      %{
-        "name" => name,
-        "command" => config["command"] || "",
-        "args" => args_str,
-        "env_vars" => env_vars
-      }
+      {name, %{"command" => _} = config} ->
+        stdio_server(name, config)
+
+      {name, config} when is_map(config) and map_size(config) > 0 ->
+        %{
+          "name" => name,
+          "kind" => "raw",
+          "raw" => config,
+          "command" => "",
+          "args" => "",
+          "env_vars" => []
+        }
+
+      {name, config} ->
+        stdio_server(name, config || %{})
     end)
+  end
+
+  defp stdio_server(name, config) do
+    args_str = (config["args"] || []) |> Enum.join("\n")
+    env_vars = (config["env"] || %{}) |> Enum.map(fn {k, v} -> %{"key" => k, "value" => v} end)
+
+    %{
+      "name" => name,
+      "kind" => "stdio",
+      "command" => config["command"] || "",
+      "args" => args_str,
+      "env_vars" => env_vars
+    }
+  end
+
+  # The active connections the form can offer, only where connections exist
+  # (accounts the broker is on for). Elsewhere the select is not rendered.
+  defp connections_for(user_id) do
+    if Fountain.Broker.enabled_for?(user_id),
+      do: Fountain.Connections.active_connections(user_id),
+      else: []
   end
 
   # Each runtime but opencode only reaches one provider, and the changeset
@@ -219,7 +262,7 @@ defmodule FountainWeb.AgentsLive.Form do
   def handle_event("add_mcp_server", _, socket) do
     servers =
       socket.assigns.mcp_servers ++
-        [%{"name" => "", "command" => "", "args" => "", "env_vars" => []}]
+        [%{"name" => "", "kind" => "stdio", "command" => "", "args" => "", "env_vars" => []}]
 
     {:noreply, assign(socket, :mcp_servers, servers)}
   end
@@ -336,24 +379,7 @@ defmodule FountainWeb.AgentsLive.Form do
         |> Enum.reject(&is_nil/1)
 
       mcp_map =
-        Map.new(mcp_servers_list, fn s ->
-          args =
-            (s["args"] || "")
-            |> String.split("\n")
-            |> Enum.map(&String.trim/1)
-            |> Enum.reject(&(&1 == ""))
-
-          env_map =
-            (s["env_vars"] || [])
-            |> Map.new(fn %{"key" => k, "value" => v} -> {k, v} end)
-            |> Map.reject(fn {k, _} -> k == "" end)
-
-          config = %{"command" => s["command"] || ""}
-          config = if args != [], do: Map.put(config, "args", args), else: config
-          config = if map_size(env_map) > 0, do: Map.put(config, "env", env_map), else: config
-
-          {s["name"] || "", config}
-        end)
+        Map.new(mcp_servers_list, fn s -> {s["name"] || "", mcp_server_config(s)} end)
         |> Map.reject(fn {k, _} -> k == "" end)
 
       attrs =
@@ -510,7 +536,7 @@ defmodule FountainWeb.AgentsLive.Form do
       servers_map when is_map(servers_map) ->
         servers_map
         |> Enum.sort_by(fn {k, _} -> String.to_integer(k) end)
-        |> Enum.map(fn {_, s} ->
+        |> Enum.map(fn {k, s} ->
           env_vars =
             case s["env_vars"] do
               nil ->
@@ -525,7 +551,14 @@ defmodule FountainWeb.AgentsLive.Form do
                 []
             end
 
-          Map.put(s, "env_vars", env_vars)
+          # A pass-through entry has no editable fields, so its config is not
+          # in the params: carry it over from the row it came from.
+          current = Enum.at(current_servers, String.to_integer(k)) || %{}
+
+          s
+          |> Map.put("env_vars", env_vars)
+          |> Map.put_new("kind", current["kind"] || "stdio")
+          |> then(&if &1["kind"] == "raw", do: Map.put(&1, "raw", current["raw"]), else: &1)
         end)
 
       _ ->
@@ -575,9 +608,33 @@ defmodule FountainWeb.AgentsLive.Form do
       length(names) != length(Enum.uniq(names)) ->
         {:error, "mcp_servers_json", "server names must be unique"}
 
+      Enum.any?(servers, &(&1["kind"] == "connection" and (&1["connection"] || "") == "")) ->
+        {:error, "mcp_servers_json", "pick a connection for each connection server"}
+
       true ->
         :ok
     end
+  end
+
+  # The stored shape for one form row (the inverse of agent_to_mcp_server_list/1).
+  defp mcp_server_config(%{"kind" => "connection"} = s), do: %{"connection" => s["connection"]}
+  defp mcp_server_config(%{"kind" => "raw", "raw" => raw}) when is_map(raw), do: raw
+
+  defp mcp_server_config(s) do
+    args =
+      (s["args"] || "")
+      |> String.split("\n")
+      |> Enum.map(&String.trim/1)
+      |> Enum.reject(&(&1 == ""))
+
+    env_map =
+      (s["env_vars"] || [])
+      |> Map.new(fn %{"key" => k, "value" => v} -> {k, v} end)
+      |> Map.reject(fn {k, _} -> k == "" end)
+
+    config = %{"command" => s["command"] || ""}
+    config = if args != [], do: Map.put(config, "args", args), else: config
+    if map_size(env_map) > 0, do: Map.put(config, "env", env_map), else: config
   end
 
   defp nil_if_blank(map, key),
@@ -1133,7 +1190,62 @@ defmodule FountainWeb.AgentsLive.Form do
               value={server["name"] || ""}
               placeholder="github"
             />
+
+            <%!-- A connection (#1178): Fountain serves the server and holds the
+                  credential. Only offered where the account has one. --%>
+            <div :if={@connections != [] and server["kind"] != "raw"} class="space-y-1">
+              <label for={"mcp_#{i}_kind"} class="block text-sm font-medium text-zinc-700">
+                Type
+              </label>
+              <select
+                id={"mcp_#{i}_kind"}
+                name={"agent[mcp_servers][#{i}][kind]"}
+                class="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm"
+              >
+                <option
+                  :for={
+                    {label, kind} <- [
+                      {"Command (stdio)", "stdio"},
+                      {"Connected account (Gmail)", "connection"}
+                    ]
+                  }
+                  value={kind}
+                  selected={(server["kind"] || "stdio") == kind}
+                >
+                  {label}
+                </option>
+              </select>
+            </div>
+            <div :if={server["kind"] == "connection"} class="space-y-1">
+              <label for={"mcp_#{i}_connection"} class="block text-sm font-medium text-zinc-700">
+                Connection
+              </label>
+              <select
+                id={"mcp_#{i}_connection"}
+                name={"agent[mcp_servers][#{i}][connection]"}
+                class="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm"
+              >
+                <option value="">Pick a connected account</option>
+                <option
+                  :for={c <- @connections}
+                  value={c.id}
+                  selected={server["connection"] == c.id}
+                >
+                  {c.account_email} ({c.provider})
+                </option>
+              </select>
+            </div>
+            <p :if={server["kind"] == "connection"} class="text-xs text-zinc-500">
+              Fountain serves the Gmail tools for this account and never puts a Google token in the sandbox.
+            </p>
+
+            <div :if={server["kind"] == "raw"} class="text-xs text-zinc-500">
+              A remote server defined through the API (kept as is):
+              <code class="font-mono">{Jason.encode!(server["raw"])}</code>
+            </div>
+
             <.input
+              :if={server["kind"] in [nil, "stdio"]}
               id={"mcp_#{i}_command"}
               name={"agent[mcp_servers][#{i}][command]"}
               label="Command"
@@ -1141,6 +1253,7 @@ defmodule FountainWeb.AgentsLive.Form do
               placeholder="npx"
             />
             <.input
+              :if={server["kind"] in [nil, "stdio"]}
               id={"mcp_#{i}_args"}
               name={"agent[mcp_servers][#{i}][args]"}
               type="textarea"
@@ -1150,7 +1263,7 @@ defmodule FountainWeb.AgentsLive.Form do
               placeholder="-y&#10;@modelcontextprotocol/server-github"
             />
 
-            <div class="space-y-1.5">
+            <div :if={server["kind"] in [nil, "stdio"]} class="space-y-1.5">
               <label class="block text-xs font-medium text-zinc-600">Env vars (optional)</label>
 
               <div class="space-y-1">

--- a/apps/fountain/lib/fountain_web/live/connections_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/connections_live/index.ex
@@ -49,7 +49,10 @@ defmodule FountainWeb.ConnectionsLive.Index do
           {:ok, _} ->
             {:noreply,
              socket
-             |> put_flash(:info, "Revoked #{connection.account_email}. Agents that name it will be told.")
+             |> put_flash(
+               :info,
+               "Revoked #{connection.account_email}. Agents that name it will be told."
+             )
              |> reload()}
 
           {:error, reason} ->
@@ -68,7 +71,8 @@ defmodule FountainWeb.ConnectionsLive.Index do
       connection ->
         case Connections.delete(connection, Audited.attribution(socket)) do
           {:ok, _} ->
-            {:noreply, socket |> put_flash(:info, "Removed #{connection.account_email}.") |> reload()}
+            {:noreply,
+             socket |> put_flash(:info, "Removed #{connection.account_email}.") |> reload()}
 
           {:error, reason} ->
             {:noreply, put_flash(socket, :error, "Could not remove: #{inspect(reason)}")}

--- a/apps/fountain/lib/fountain_web/live/connections_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/connections_live/index.ex
@@ -1,0 +1,179 @@
+defmodule FountainWeb.ConnectionsLive.Index do
+  @moduledoc """
+  `/account/connections` — the provider accounts this tenant has signed in
+  to, whose credentials Fountain holds (#1178). List, connect, reconnect,
+  revoke. The OAuth round trip itself is `FountainWeb.ConnectionsController`;
+  this page only links to it and shows what came back.
+
+  Only for accounts the egress broker is on for: the nav link is hidden
+  otherwise, and a direct visit is sent to `/account`.
+  """
+
+  use FountainWeb, :live_view
+
+  alias Fountain.{Broker, Connections}
+  alias Fountain.Connections.Google
+  alias FountainWeb.Audited
+
+  @impl true
+  def mount(_params, _session, socket) do
+    user = socket.assigns.current_user
+
+    if Broker.enabled_for?(user.id) do
+      {:ok,
+       socket
+       |> assign(:page_title, "Connections")
+       |> assign(:user_id, user.id)
+       |> assign(:google_configured, Google.configured?())
+       |> assign(:google_scopes, Google.scopes())
+       |> assign(:google_env_key, Google.env_key())
+       |> reload()}
+    else
+      {:ok,
+       socket
+       |> put_flash(:error, "Connections are not enabled for this account.")
+       |> push_navigate(to: ~p"/account")}
+    end
+  end
+
+  @impl true
+  def handle_event("revoke", %{"id" => id}, socket) do
+    user_id = socket.assigns.user_id
+
+    case Connections.get_connection(id, user_id) do
+      nil ->
+        {:noreply, put_flash(socket, :error, "That connection is gone.")}
+
+      connection ->
+        case Connections.revoke(connection, Audited.attribution(socket)) do
+          {:ok, _} ->
+            {:noreply,
+             socket
+             |> put_flash(:info, "Revoked #{connection.account_email}. Agents that name it will be told.")
+             |> reload()}
+
+          {:error, reason} ->
+            {:noreply, put_flash(socket, :error, "Could not revoke: #{inspect(reason)}")}
+        end
+    end
+  end
+
+  def handle_event("delete", %{"id" => id}, socket) do
+    user_id = socket.assigns.user_id
+
+    case Connections.get_connection(id, user_id) do
+      nil ->
+        {:noreply, put_flash(socket, :error, "That connection is gone.")}
+
+      connection ->
+        case Connections.delete(connection, Audited.attribution(socket)) do
+          {:ok, _} ->
+            {:noreply, socket |> put_flash(:info, "Removed #{connection.account_email}.") |> reload()}
+
+          {:error, reason} ->
+            {:noreply, put_flash(socket, :error, "Could not remove: #{inspect(reason)}")}
+        end
+    end
+  end
+
+  defp reload(socket) do
+    assign(socket, :connections, Connections.list_connections(socket.assigns.user_id))
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="space-y-6 max-w-3xl">
+      <div>
+        <h1 class="text-2xl font-semibold">Connections</h1>
+        <p class="text-sm text-[var(--color-text-secondary)] mt-1">
+          Sign in to a provider once. Fountain keeps the refresh token, encrypted with your
+          tenant key, and hands agents the capability rather than the credential: a
+          Fountain-served MCP server that uses the connection on their behalf, or an access
+          token brokered to the provider's hosts. No Google token ever enters a sandbox.
+        </p>
+      </div>
+
+      <div class="rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-1)] p-5 space-y-3">
+        <div class="flex items-start justify-between gap-3">
+          <div>
+            <h2 class="text-base font-medium">Google (Gmail)</h2>
+            <p class="text-xs text-[var(--color-text-secondary)] mt-1">
+              Scopes: <code class="font-mono">{Enum.join(@google_scopes, " ")}</code>
+            </p>
+            <p class="text-xs text-[var(--color-text-secondary)] mt-0.5">
+              Brokered as <code class="font-mono">{@google_env_key}</code>
+            </p>
+          </div>
+          <a
+            :if={@google_configured}
+            href={~p"/connections/google/start"}
+            data-role="connect-google"
+            class="rounded-md bg-zinc-900 px-3 py-2 text-sm text-white hover:bg-zinc-700"
+          >
+            Connect a Google account
+          </a>
+          <span :if={!@google_configured} class="text-xs text-[var(--color-text-secondary)]">
+            Not configured on this deployment (<code class="font-mono">GOOGLE_OAUTH_CLIENT_ID</code>).
+          </span>
+        </div>
+      </div>
+
+      <div :if={@connections == []} class="text-sm text-[var(--color-text-secondary)]">
+        No connections yet.
+      </div>
+
+      <div
+        :for={c <- @connections}
+        id={"connection-#{c.id}"}
+        class="rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-1)] p-4 flex items-start justify-between gap-4"
+      >
+        <div class="space-y-1">
+          <div class="flex items-center gap-2">
+            <span class="font-medium">{c.account_email}</span>
+            <span
+              class={[
+                "rounded-full px-2 py-0.5 text-xs",
+                c.status == "active" && "bg-green-100 text-green-800",
+                c.status != "active" && "bg-red-100 text-red-800"
+              ]}
+              data-role="status"
+            >
+              {c.status}
+            </span>
+          </div>
+          <p class="text-xs text-[var(--color-text-secondary)]">
+            {c.provider} · id <code class="font-mono">{c.id}</code>
+          </p>
+          <p class="text-xs text-[var(--color-text-secondary)]">
+            In an agent's MCP servers:
+            <code class="font-mono">{~s({"gmail": {"connection": "#{c.id}"}})}</code>
+          </p>
+          <p :if={c.status == "revoked"} class="text-xs text-red-700">
+            Revoked {c.revoked_at}. Connect the account again to replace it.
+          </p>
+        </div>
+        <div class="flex gap-2 shrink-0">
+          <button
+            :if={c.status == "active"}
+            phx-click="revoke"
+            phx-value-id={c.id}
+            data-confirm="Revoke this connection? Agents that use it will fail with 'connection revoked' on their next call."
+            class="rounded-md border border-[var(--color-border)] px-3 py-1.5 text-sm hover:bg-[var(--color-bg-2)]"
+          >
+            Revoke
+          </button>
+          <button
+            phx-click="delete"
+            phx-value-id={c.id}
+            data-confirm="Remove this connection entirely?"
+            class="rounded-md border border-[var(--color-border)] px-3 py-1.5 text-sm text-red-700 hover:bg-[var(--color-bg-2)]"
+          >
+            Remove
+          </button>
+        </div>
+      </div>
+    </div>
+    """
+  end
+end

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -322,6 +322,20 @@ defmodule FountainWeb.Router do
     delete "/:id", RunnerController, :delete
   end
 
+  # Connections (#1178): the provider accounts the tenant has signed in to.
+  # Full scope: a conversation-scoped token must not be able to list or cut
+  # the account's connections. Connecting one needs a browser and a session,
+  # so it is not an API operation — `GET /api/connections/providers` says
+  # where to send the owner.
+  scope "/api/connections", FountainWeb do
+    pipe_through [:accepts_json, :api, :require_full_scope]
+
+    get "/", ConnectionController, :index
+    get "/providers", ConnectionController, :providers
+    get "/:id", ConnectionController, :show
+    delete "/:id", ConnectionController, :delete
+  end
+
   # Secret bindings (ADR 0019 gate 1b). Full scope for the same reason as
   # runners: a conversation-scoped token must not be able to redirect the
   # account's credentials to another host.
@@ -422,6 +436,10 @@ defmodule FountainWeb.Router do
     # number (flag `team_comms`). Same transport; the AgentMail/AgentPhone
     # keys stay server-side.
     post "/mcp/team-comms/:conversation_id", TeamCommsMcpController, :handle
+
+    # The Gmail tools for a Google connection the conversation's agent names
+    # (#1178). Same transport; the Google token stays server-side.
+    post "/mcp/gmail/:conversation_id/:connection_id", GmailMcpController, :handle
 
     resources "/environments", EnvironmentController, except: [:new, :edit] do
       resources "/secrets", SecretController, only: [:index, :create, :delete]
@@ -585,6 +603,12 @@ defmodule FountainWeb.Router do
     post "/account/security/password", AccountSecurityController, :change_password
     post "/account/security/email", AccountSecurityController, :request_email_change
 
+    # ── Connections (#1178): the OAuth round trip to a provider. Session-
+    # authenticated so the grant lands on the signed-in account; the page
+    # they start from is ConnectionsLive below ───────────────────────────
+    get "/connections/:provider/start", ConnectionsController, :start
+    get "/connections/:provider/callback", ConnectionsController, :callback
+
     # ── The pages that moved out (#867) ───────────────────────────────────────
     # Conversations and the team roster are their own apps on the API now, and
     # onboarding is the dashboard's own first-run guidance. These paths are in
@@ -637,6 +661,9 @@ defmodule FountainWeb.Router do
 
       # ── Secret bindings at the egress broker (ADR 0019 gate 1b) ────────────────────────────
       live "/account/bindings", SecretBindingsLive.Index, :index
+
+      # ── Connections: provider accounts Fountain holds the credential for (#1178) ────────────
+      live "/account/connections", ConnectionsLive.Index, :index
 
       # ── Outbound webhooks (#700) ───────────────────────────────────────────────────────────
       live "/account/webhooks", WebhooksLive.Index, :index

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -3670,7 +3670,8 @@ defmodule FountainWeb.Schemas do
 
     OpenApiSpex.schema(%{
       title: "ConnectionProvidersResponse",
-      description: "Which providers this deployment can connect, and the URL that starts each flow.",
+      description:
+        "Which providers this deployment can connect, and the URL that starts each flow.",
       type: :object,
       properties: %{
         data: %Schema{

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -3616,4 +3616,97 @@ defmodule FountainWeb.Schemas do
       required: [:email, :message]
     })
   end
+
+  defmodule Connection do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "Connection",
+      description:
+        "A provider account the tenant signed in to once, whose credential " <>
+          "Fountain holds (#1178). Agents get the capability, never the token: " <>
+          "an agent's `mcp_servers` names the connection " <>
+          ~s|(`{"gmail": {"connection": "<id>"}}`) and Fountain serves the Gmail | <>
+          "tools; and the access token is brokered under `env_key` for an MCP " <>
+          "server the tenant runs. Only for accounts the egress broker is on for.",
+      type: :object,
+      properties: %{
+        id: %Schema{type: :string, format: :uuid},
+        provider: %Schema{type: :string, enum: ["google"]},
+        account_email: %Schema{type: :string, description: "The connected account."},
+        scopes: %Schema{type: :array, items: %Schema{type: :string}},
+        env_key: %Schema{
+          type: :string,
+          description:
+            "The env var name the access token is brokered under (`GOOGLE_ACCESS_TOKEN`)."
+        },
+        status: %Schema{
+          type: :string,
+          enum: ["active", "revoked"],
+          description:
+            "`revoked` once the tenant cut it or the provider refused the refresh token; " <>
+              "the row stays so the console can say why the tools stopped. Reconnect to replace it."
+        },
+        expires_at: %Schema{
+          type: :string,
+          format: :"date-time",
+          nullable: true,
+          description: "When the cached access token expires. Refreshed on use."
+        },
+        revoked_at: %Schema{type: :string, format: :"date-time", nullable: true},
+        created_at: %Schema{type: :string, format: :"date-time"},
+        updated_at: %Schema{type: :string, format: :"date-time"}
+      },
+      required: [:id, :provider, :account_email, :scopes, :env_key, :status]
+    })
+  end
+
+  defmodule ConnectionListResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "ConnectionListResponse",
+      type: :object,
+      properties: %{data: %Schema{type: :array, items: Connection}},
+      required: [:data]
+    })
+  end
+
+  defmodule ConnectionProvidersResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "ConnectionProvidersResponse",
+      description: "Which providers this deployment can connect, and the URL that starts each flow.",
+      type: :object,
+      properties: %{
+        data: %Schema{
+          type: :array,
+          items: %Schema{
+            type: :object,
+            properties: %{
+              provider: %Schema{type: :string},
+              configured: %Schema{
+                type: :boolean,
+                description: "False when the deployment has no OAuth client for it."
+              },
+              scopes: %Schema{type: :array, items: %Schema{type: :string}},
+              env_key: %Schema{type: :string},
+              connect_url: %Schema{
+                type: :string,
+                description:
+                  "Where to send the account owner, in a browser signed in to the console, " <>
+                    "to connect an account. The flow ends back on the Connections page."
+              }
+            },
+            required: [:provider, :configured, :scopes, :env_key, :connect_url]
+          }
+        }
+      },
+      required: [:data]
+    })
+  end
 end

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -3662,17 +3662,7 @@ defmodule FountainWeb.Schemas do
     })
   end
 
-  defmodule ConnectionListResponse do
-    @moduledoc false
-    require OpenApiSpex
-
-    OpenApiSpex.schema(%{
-      title: "ConnectionListResponse",
-      type: :object,
-      properties: %{data: %Schema{type: :array, items: Connection}},
-      required: [:data]
-    })
-  end
+  list_response(ConnectionListResponse, of: Connection)
 
   defmodule ConnectionProvidersResponse do
     @moduledoc false

--- a/apps/fountain/priv/repo/migrations/20260826031178_create_connections.exs
+++ b/apps/fountain/priv/repo/migrations/20260826031178_create_connections.exs
@@ -1,0 +1,32 @@
+defmodule Fountain.Repo.Migrations.CreateConnections do
+  use Ecto.Migration
+
+  # #1178: a tenant signs in to a provider once in the console and Fountain
+  # holds the credential. The refresh token is DEK-encrypted like every other
+  # tenant secret; the access token is a short-lived cache of the same shape.
+  # Agents never see either — a Fountain-served MCP server uses the
+  # connection server-side, and the egress broker attaches the access token
+  # to requests for the provider's hosts (ADR 0019).
+  def change do
+    create table(:connections, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :user_id, references(:users, type: :binary_id, on_delete: :delete_all), null: false
+      add :provider, :string, null: false
+      add :account_email, :string, null: false
+      add :scopes, {:array, :string}, null: false, default: []
+      # The env var name the access token is brokered under (`GOOGLE_ACCESS_TOKEN`).
+      add :env_key, :string, null: false
+      add :refresh_token_ciphertext, :binary, null: false
+      add :access_token_ciphertext, :binary
+      add :expires_at, :utc_datetime
+      add :status, :string, null: false, default: "active"
+      add :revoked_at, :utc_datetime
+      add :last_refreshed_at, :utc_datetime
+      timestamps(type: :utc_datetime)
+    end
+
+    create unique_index(:connections, [:user_id, :provider, :account_email])
+    create unique_index(:connections, [:user_id, :env_key])
+    create index(:connections, [:user_id, :status])
+  end
+end

--- a/apps/fountain/test/fountain/audit_guardrail_test.exs
+++ b/apps/fountain/test/fountain/audit_guardrail_test.exs
@@ -113,6 +113,8 @@ defmodule Fountain.AuditGuardrailTest do
     {"secret binding create", &__MODULE__.do_binding_create/1, "secret_binding.created"},
     {"secret binding update", &__MODULE__.do_binding_update/1, "secret_binding.updated"},
     {"secret binding delete", &__MODULE__.do_binding_delete/1, "secret_binding.deleted"},
+    {"connection connect", &__MODULE__.do_connection_connect/1, "connection.created"},
+    {"connection revoke", &__MODULE__.do_connection_revoke/1, "connection.revoked"},
     {"credit grant", &__MODULE__.do_credit_grant/1, "credit.granted"},
     {"credit debit", &__MODULE__.do_credit_debit/1, "credit.burned"}
   ]
@@ -318,6 +320,13 @@ defmodule Fountain.AuditGuardrailTest do
       })
 
     {:ok, _} = Fountain.SecretBindings.delete_binding(b)
+  end
+
+  def do_connection_connect(user), do: insert_connection(user)
+
+  def do_connection_revoke(user) do
+    Req.Test.stub(Fountain.Connections.Google, fn conn -> Req.Test.json(conn, %{}) end)
+    {:ok, _} = Fountain.Connections.revoke(insert_connection(user))
   end
 
   def do_runner_register(user) do

--- a/apps/fountain/test/fountain/connections_test.exs
+++ b/apps/fountain/test/fountain/connections_test.exs
@@ -1,0 +1,214 @@
+defmodule Fountain.ConnectionsTest do
+  use Fountain.DataCase, async: true
+
+  alias Fountain.{Connections, Crypto}
+  alias Fountain.Connections.{Connection, Google, McpServers}
+
+  describe "connect/4" do
+    test "stores the grant encrypted, active, under the provider's env key" do
+      user = insert_verified_user()
+      conn = insert_connection(user, account_email: "me@example.com", refresh_token: "r-1")
+
+      assert conn.provider == "google"
+      assert conn.status == "active"
+      assert conn.env_key == "GOOGLE_ACCESS_TOKEN"
+      assert conn.account_email == "me@example.com"
+      refute conn.refresh_token_ciphertext == "r-1"
+
+      {:ok, dek} = Crypto.load_tenant_key(user.id)
+      assert {:ok, "r-1"} = Crypto.decrypt(conn.refresh_token_ciphertext, dek)
+    end
+
+    test "the same account connected again replaces the tokens and reactivates" do
+      user = insert_verified_user()
+      Req.Test.stub(Google, fn conn -> Req.Test.json(conn, %{}) end)
+
+      first = insert_connection(user, account_email: "me@example.com", refresh_token: "r-1")
+      {:ok, revoked} = Connections.revoke(first)
+      assert revoked.status == "revoked"
+
+      second = insert_connection(user, account_email: "me@example.com", refresh_token: "r-2")
+      assert second.id == first.id
+      assert second.status == "active"
+      assert is_nil(second.revoked_at)
+      assert [_] = Connections.list_connections(user.id)
+    end
+
+    test "is tenant-scoped on read" do
+      a = insert_verified_user()
+      b = insert_verified_user()
+      conn = insert_connection(a)
+
+      assert Connections.get_connection(conn.id, a.id)
+      refute Connections.get_connection(conn.id, b.id)
+      assert Connections.list_connections(b.id) == []
+      refute Connections.get_connection("not-a-uuid", a.id)
+    end
+  end
+
+  describe "access_token/1" do
+    test "returns the cached token while it is fresh, without a network call" do
+      user = insert_verified_user()
+      conn = insert_connection(user, access_token: "a-fresh")
+      Req.Test.stub(Google, fn _ -> flunk("should not refresh a fresh token") end)
+
+      assert {:ok, "a-fresh"} = Connections.access_token(conn)
+    end
+
+    test "refreshes near expiry and caches the new token" do
+      user = insert_verified_user()
+
+      conn =
+        insert_connection(user,
+          access_token: "a-old",
+          refresh_token: "r-1",
+          expires_at: DateTime.utc_now() |> DateTime.add(60, :second) |> DateTime.truncate(:second)
+        )
+
+      Req.Test.stub(Google, fn req ->
+        assert req.request_path == "/token"
+        {:ok, body, _} = Plug.Conn.read_body(req)
+        params = URI.decode_query(body)
+        assert params["grant_type"] == "refresh_token"
+        assert params["refresh_token"] == "r-1"
+        Req.Test.json(req, %{"access_token" => "a-new", "expires_in" => 3599})
+      end)
+
+      assert {:ok, "a-new"} = Connections.access_token(conn)
+
+      # Cached: the next read does not hit Google.
+      Req.Test.stub(Google, fn _ -> flunk("second read should be cached") end)
+      fresh = Connections.get_connection(conn.id, user.id)
+      assert {:ok, "a-new"} = Connections.access_token(fresh)
+      assert DateTime.diff(fresh.expires_at, DateTime.utc_now()) > 3000
+    end
+
+    test "invalid_grant marks the connection revoked and audits it" do
+      user = insert_verified_user()
+
+      conn =
+        insert_connection(user,
+          expires_at: DateTime.utc_now() |> DateTime.add(-10, :second) |> DateTime.truncate(:second)
+        )
+
+      Req.Test.stub(Google, fn req ->
+        req |> Plug.Conn.put_status(400) |> Req.Test.json(%{"error" => "invalid_grant"})
+      end)
+
+      assert {:error, :revoked} = Connections.access_token(conn)
+      assert %{status: "revoked"} = Connections.get_connection(conn.id, user.id)
+
+      actions = user.id |> Fountain.Audit.list_recent_for_user(20) |> Enum.map(& &1.action)
+      assert "connection.revoked" in actions
+    end
+
+    test "a revoked connection answers :revoked without a network call" do
+      user = insert_verified_user()
+      Req.Test.stub(Google, fn conn -> Req.Test.json(conn, %{}) end)
+      {:ok, revoked} = Connections.revoke(insert_connection(user))
+      Req.Test.stub(Google, fn _ -> flunk("no call for a revoked connection") end)
+
+      assert {:error, :revoked} = Connections.access_token(revoked)
+    end
+  end
+
+  describe "revoke/2" do
+    test "tells Google to forget the refresh token and marks the row" do
+      user = insert_verified_user()
+      conn = insert_connection(user, refresh_token: "r-gone")
+      test_pid = self()
+
+      Req.Test.stub(Google, fn req ->
+        {:ok, body, _} = Plug.Conn.read_body(req)
+        send(test_pid, {:revoked, req.request_path, URI.decode_query(body)["token"]})
+        Req.Test.json(req, %{})
+      end)
+
+      assert {:ok, %Connection{status: "revoked", revoked_at: %DateTime{}}} =
+               Connections.revoke(conn, actor: "ui")
+
+      assert_received {:revoked, "/revoke", "r-gone"}
+    end
+  end
+
+  describe "synthetic_secrets/1 and env_keys/1" do
+    test "active connections contribute their token under env_key; revoked ones do not" do
+      user = insert_verified_user()
+      Req.Test.stub(Google, fn conn -> Req.Test.json(conn, %{}) end)
+      active = insert_connection(user, access_token: "a-live", account_email: "a@example.com")
+      {:ok, _} = Connections.revoke(insert_connection(user, account_email: "b@example.com"))
+
+      assert Connections.synthetic_secrets(user.id) == %{"GOOGLE_ACCESS_TOKEN" => "a-live"}
+
+      assert Enum.sort(Connections.env_keys(user.id)) ==
+               ["GOOGLE_ACCESS_TOKEN", "GOOGLE_ACCESS_TOKEN_2"]
+
+      assert Connections.implicit_hosts(active.env_key) == Google.token_hosts()
+      assert Connections.implicit_hosts("GOOGLE_ACCESS_TOKEN_2") == Google.token_hosts()
+      assert Connections.implicit_hosts("OTHER") == []
+    end
+  end
+
+  describe "McpServers.resolve/3" do
+    test "rewrites a connection entry into the Fountain-served HTTP server and leaves the rest" do
+      id = Ecto.UUID.generate()
+
+      servers = %{
+        "gmail" => %{"connection" => id},
+        "fs" => %{"command" => "npx", "args" => ["fs-server"]}
+      }
+
+      resolved = McpServers.resolve(servers, "conv-1", "tok")
+
+      assert resolved["fs"] == servers["fs"]
+
+      assert %{"type" => "http", "url" => url, "headers" => %{"Authorization" => "Bearer tok"}} =
+               resolved["gmail"]
+
+      assert String.ends_with?(url, "/api/mcp/gmail/conv-1/#{id}")
+      assert McpServers.connection_ids(servers) == [id]
+    end
+
+    test "drops connection entries when there is no token yet" do
+      servers = %{"gmail" => %{"connection" => Ecto.UUID.generate()}, "x" => %{"command" => "x"}}
+      assert McpServers.resolve(servers, "conv-1", nil) == %{"x" => %{"command" => "x"}}
+      assert McpServers.resolve(%{}, "conv-1", "tok") == %{}
+    end
+  end
+
+  describe "Google.authorize_url/2" do
+    test "asks for offline access with a forced consent, so a refresh token comes back" do
+      url = Google.authorize_url("https://f.example/connections/google/callback", "st")
+      %URI{query: q} = URI.parse(url)
+      params = URI.decode_query(q)
+
+      assert params["access_type"] == "offline"
+      assert params["prompt"] == "consent"
+      assert params["state"] == "st"
+      assert params["redirect_uri"] == "https://f.example/connections/google/callback"
+      assert params["scope"] =~ "gmail.modify"
+    end
+  end
+
+  describe "agent mcp_servers validation" do
+    test "a connection entry must carry a connection id" do
+      user = insert_verified_user()
+
+      assert {:error, cs} =
+               Fountain.Agents.create_agent(
+                 agent_attrs(%{"user_id" => user.id, "mcp_servers" => %{"gmail" => %{"connection" => 12}}})
+               )
+
+      assert %{mcp_servers: [msg]} = errors_on(cs)
+      assert msg =~ "connection id"
+
+      assert {:ok, _} =
+               Fountain.Agents.create_agent(
+                 agent_attrs(%{
+                   "user_id" => user.id,
+                   "mcp_servers" => %{"gmail" => %{"connection" => Ecto.UUID.generate()}}
+                 })
+               )
+    end
+  end
+end

--- a/apps/fountain/test/fountain/connections_test.exs
+++ b/apps/fountain/test/fountain/connections_test.exs
@@ -62,7 +62,8 @@ defmodule Fountain.ConnectionsTest do
         insert_connection(user,
           access_token: "a-old",
           refresh_token: "r-1",
-          expires_at: DateTime.utc_now() |> DateTime.add(60, :second) |> DateTime.truncate(:second)
+          expires_at:
+            DateTime.utc_now() |> DateTime.add(60, :second) |> DateTime.truncate(:second)
         )
 
       Req.Test.stub(Google, fn req ->
@@ -88,7 +89,8 @@ defmodule Fountain.ConnectionsTest do
 
       conn =
         insert_connection(user,
-          expires_at: DateTime.utc_now() |> DateTime.add(-10, :second) |> DateTime.truncate(:second)
+          expires_at:
+            DateTime.utc_now() |> DateTime.add(-10, :second) |> DateTime.truncate(:second)
         )
 
       Req.Test.stub(Google, fn req ->
@@ -196,7 +198,10 @@ defmodule Fountain.ConnectionsTest do
 
       assert {:error, cs} =
                Fountain.Agents.create_agent(
-                 agent_attrs(%{"user_id" => user.id, "mcp_servers" => %{"gmail" => %{"connection" => 12}}})
+                 agent_attrs(%{
+                   "user_id" => user.id,
+                   "mcp_servers" => %{"gmail" => %{"connection" => 12}}
+                 })
                )
 
       assert %{mcp_servers: [msg]} = errors_on(cs)

--- a/apps/fountain/test/fountain_web/api_spec_test.exs
+++ b/apps/fountain/test/fountain_web/api_spec_test.exs
@@ -65,7 +65,9 @@ defmodule FountainWeb.ApiSpecTest do
       # Same: the team tools a teammate's sandbox calls (#851).
       {"/api/mcp/team/{conversation_id}", :post},
       # Same: the teammate email/phone tools (flag `team_comms`).
-      {"/api/mcp/team-comms/{conversation_id}", :post}
+      {"/api/mcp/team-comms/{conversation_id}", :post},
+      # Same: the Gmail tools for a Google connection (#1178).
+      {"/api/mcp/gmail/{conversation_id}/{connection_id}", :post}
     ]
 
     setup do

--- a/apps/fountain/test/fountain_web/controllers/connection_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/connection_controller_test.exs
@@ -30,18 +30,31 @@ defmodule FountainWeb.ConnectionControllerTest do
              conn |> get("/api/connections/providers") |> json_response(404)
   end
 
-  test "lists, shows and deletes the caller's connections without a token", %{conn: conn, user: user} do
+  test "lists, shows and deletes the caller's connections without a token", %{
+    conn: conn,
+    user: user
+  } do
     c = insert_connection(user, account_email: "me@example.com", access_token: "never-shown-at")
     other = insert_verified_user()
     enable_broker_for([user.id, other.id])
     insert_connection(other, account_email: "them@example.com")
 
     body = conn |> get("/api/connections") |> json_response(200)
-    assert [%{"id" => id, "account_email" => "me@example.com", "status" => "active", "env_key" => "GOOGLE_ACCESS_TOKEN"}] = body["data"]
+
+    assert [
+             %{
+               "id" => id,
+               "account_email" => "me@example.com",
+               "status" => "active",
+               "env_key" => "GOOGLE_ACCESS_TOKEN"
+             }
+           ] = body["data"]
+
     assert id == c.id
     refute inspect(body) =~ "never-shown-at"
 
-    assert %{"id" => ^id, "provider" => "google"} = conn |> get("/api/connections/#{id}") |> json_response(200)
+    assert %{"id" => ^id, "provider" => "google"} =
+             conn |> get("/api/connections/#{id}") |> json_response(200)
 
     Req.Test.stub(Google, fn req -> Req.Test.json(req, %{}) end)
     assert conn |> delete("/api/connections/#{id}") |> response(204)

--- a/apps/fountain/test/fountain_web/controllers/connection_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/connection_controller_test.exs
@@ -1,0 +1,70 @@
+defmodule FountainWeb.ConnectionControllerTest do
+  # Flips the broker ratchet (global app env).
+  use FountainWeb.ConnCase, async: false
+
+  import Fountain.BrokerTestHelpers
+
+  alias Fountain.Connections
+  alias Fountain.Connections.Google
+
+  setup %{conn: conn} do
+    user = insert_verified_user()
+    {:ok, {_key, raw}} = Fountain.Accounts.create_api_key(user.id, "t")
+    enable_broker_for([user.id])
+
+    conn =
+      conn
+      |> put_req_header("authorization", "Bearer #{raw}")
+      |> put_req_header("accept", "application/json")
+
+    {:ok, conn: conn, user: user}
+  end
+
+  test "an account the broker is not on for gets 404 on every route", %{conn: conn} do
+    Application.put_env(:fountain, :broker_tenants, [])
+
+    assert %{"error" => "connections_not_enabled"} =
+             conn |> get("/api/connections") |> json_response(404)
+
+    assert %{"error" => "connections_not_enabled"} =
+             conn |> get("/api/connections/providers") |> json_response(404)
+  end
+
+  test "lists, shows and deletes the caller's connections without a token", %{conn: conn, user: user} do
+    c = insert_connection(user, account_email: "me@example.com", access_token: "never-shown-at")
+    other = insert_verified_user()
+    enable_broker_for([user.id, other.id])
+    insert_connection(other, account_email: "them@example.com")
+
+    body = conn |> get("/api/connections") |> json_response(200)
+    assert [%{"id" => id, "account_email" => "me@example.com", "status" => "active", "env_key" => "GOOGLE_ACCESS_TOKEN"}] = body["data"]
+    assert id == c.id
+    refute inspect(body) =~ "never-shown-at"
+
+    assert %{"id" => ^id, "provider" => "google"} = conn |> get("/api/connections/#{id}") |> json_response(200)
+
+    Req.Test.stub(Google, fn req -> Req.Test.json(req, %{}) end)
+    assert conn |> delete("/api/connections/#{id}") |> response(204)
+    assert Connections.list_connections(user.id) == []
+    assert conn |> get("/api/connections/#{id}") |> json_response(404)
+  end
+
+  test "providers names Google, its scopes and where to start", %{conn: conn} do
+    assert %{"data" => [google]} = conn |> get("/api/connections/providers") |> json_response(200)
+    assert google["provider"] == "google"
+    assert google["configured"] == true
+    assert google["env_key"] == "GOOGLE_ACCESS_TOKEN"
+    assert google["connect_url"] =~ "/connections/google/start"
+    assert "https://www.googleapis.com/auth/gmail.modify" in google["scopes"]
+  end
+
+  test "a sprite-scoped key cannot see connections", %{user: user} do
+    {_k, sprite_key} = insert_sprite_api_key(user)
+
+    build_conn()
+    |> put_req_header("authorization", "Bearer #{sprite_key}")
+    |> put_req_header("accept", "application/json")
+    |> get("/api/connections")
+    |> json_response(403)
+  end
+end

--- a/apps/fountain/test/fountain_web/controllers/connections_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/connections_controller_test.exs
@@ -28,7 +28,14 @@ defmodule FountainWeb.ConnectionsControllerTest do
 
   test "the round trip stores a connection on the signed-in account", %{conn: conn, user: user} do
     conn = get(conn, ~p"/connections/google/start")
-    state = conn |> redirected_to() |> URI.parse() |> Map.fetch!(:query) |> URI.decode_query() |> Map.fetch!("state")
+
+    state =
+      conn
+      |> redirected_to()
+      |> URI.parse()
+      |> Map.fetch!(:query)
+      |> URI.decode_query()
+      |> Map.fetch!("state")
 
     Req.Test.stub(Google, fn req ->
       case req.request_path do
@@ -67,8 +74,13 @@ defmodule FountainWeb.ConnectionsControllerTest do
     refute get_session(conn, :connections_oauth_nonce)
   end
 
-  test "a callback whose state did not come from this session is refused", %{conn: conn, user: user} do
-    state = Phoenix.Token.sign(FountainWeb.Endpoint, "connections:oauth_state", {user.id, "other"})
+  test "a callback whose state did not come from this session is refused", %{
+    conn: conn,
+    user: user
+  } do
+    state =
+      Phoenix.Token.sign(FountainWeb.Endpoint, "connections:oauth_state", {user.id, "other"})
+
     Req.Test.stub(Google, fn _ -> flunk("no exchange for a bad state") end)
 
     conn = get(conn, ~p"/connections/google/callback", %{"code" => "c", "state" => state})
@@ -79,13 +91,24 @@ defmodule FountainWeb.ConnectionsControllerTest do
 
   test "a consent Google answered without a refresh token is explained", %{conn: conn, user: user} do
     conn = get(conn, ~p"/connections/google/start")
-    state = conn |> redirected_to() |> URI.parse() |> Map.fetch!(:query) |> URI.decode_query() |> Map.fetch!("state")
+
+    state =
+      conn
+      |> redirected_to()
+      |> URI.parse()
+      |> Map.fetch!(:query)
+      |> URI.decode_query()
+      |> Map.fetch!("state")
 
     Req.Test.stub(Google, fn req ->
       Req.Test.json(req, %{"access_token" => "at", "expires_in" => 10})
     end)
 
-    conn = conn |> recycle() |> get(~p"/connections/google/callback", %{"code" => "c", "state" => state})
+    conn =
+      conn
+      |> recycle()
+      |> get(~p"/connections/google/callback", %{"code" => "c", "state" => state})
+
     assert Phoenix.Flash.get(conn.assigns.flash, :error) =~ "no refresh token"
     assert Connections.list_connections(user.id) == []
   end

--- a/apps/fountain/test/fountain_web/controllers/connections_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/connections_controller_test.exs
@@ -1,0 +1,108 @@
+defmodule FountainWeb.ConnectionsControllerTest do
+  # Flips the broker ratchet (global app env).
+  use FountainWeb.ConnCase, async: false
+
+  import Fountain.BrokerTestHelpers
+
+  alias Fountain.Connections
+  alias Fountain.Connections.Google
+
+  setup %{conn: conn} do
+    user = insert_verified_user()
+    enable_broker_for([user.id])
+    {:ok, conn: login_user(conn, user), user: user}
+  end
+
+  test "start sends the browser to Google with offline access and a signed state", %{conn: conn} do
+    conn = get(conn, ~p"/connections/google/start")
+    assert redirected_to(conn) =~ "https://accounts.google.com/o/oauth2/v2/auth?"
+
+    params = conn |> redirected_to() |> URI.parse() |> Map.fetch!(:query) |> URI.decode_query()
+    assert params["access_type"] == "offline"
+    assert params["prompt"] == "consent"
+    assert params["client_id"] == "google-test-client-id"
+    assert params["redirect_uri"] =~ "/connections/google/callback"
+    assert is_binary(params["state"])
+    assert get_session(conn, :connections_oauth_nonce)
+  end
+
+  test "the round trip stores a connection on the signed-in account", %{conn: conn, user: user} do
+    conn = get(conn, ~p"/connections/google/start")
+    state = conn |> redirected_to() |> URI.parse() |> Map.fetch!(:query) |> URI.decode_query() |> Map.fetch!("state")
+
+    Req.Test.stub(Google, fn req ->
+      case req.request_path do
+        "/token" ->
+          {:ok, body, _} = Plug.Conn.read_body(req)
+          form = URI.decode_query(body)
+          assert form["grant_type"] == "authorization_code"
+          assert form["code"] == "the-code"
+          assert form["client_secret"] == "google-test-client-secret"
+
+          Req.Test.json(req, %{
+            "access_token" => "at-1",
+            "refresh_token" => "rt-1",
+            "expires_in" => 3599,
+            "scope" => "openid email https://www.googleapis.com/auth/gmail.modify"
+          })
+
+        "/v1/userinfo" ->
+          assert Plug.Conn.get_req_header(req, "authorization") == ["Bearer at-1"]
+          Req.Test.json(req, %{"email" => "jake@example.com", "email_verified" => true})
+      end
+    end)
+
+    conn =
+      conn
+      |> recycle()
+      |> get(~p"/connections/google/callback", %{"code" => "the-code", "state" => state})
+
+    assert redirected_to(conn) == ~p"/account/connections"
+    assert Phoenix.Flash.get(conn.assigns.flash, :info) =~ "Connected jake@example.com"
+
+    assert [%{account_email: "jake@example.com", status: "active", scopes: scopes}] =
+             Connections.list_connections(user.id)
+
+    assert "https://www.googleapis.com/auth/gmail.modify" in scopes
+    refute get_session(conn, :connections_oauth_nonce)
+  end
+
+  test "a callback whose state did not come from this session is refused", %{conn: conn, user: user} do
+    state = Phoenix.Token.sign(FountainWeb.Endpoint, "connections:oauth_state", {user.id, "other"})
+    Req.Test.stub(Google, fn _ -> flunk("no exchange for a bad state") end)
+
+    conn = get(conn, ~p"/connections/google/callback", %{"code" => "c", "state" => state})
+    assert redirected_to(conn) == ~p"/account/connections"
+    assert Phoenix.Flash.get(conn.assigns.flash, :error) =~ "did not start from this session"
+    assert Connections.list_connections(user.id) == []
+  end
+
+  test "a consent Google answered without a refresh token is explained", %{conn: conn, user: user} do
+    conn = get(conn, ~p"/connections/google/start")
+    state = conn |> redirected_to() |> URI.parse() |> Map.fetch!(:query) |> URI.decode_query() |> Map.fetch!("state")
+
+    Req.Test.stub(Google, fn req ->
+      Req.Test.json(req, %{"access_token" => "at", "expires_in" => 10})
+    end)
+
+    conn = conn |> recycle() |> get(~p"/connections/google/callback", %{"code" => "c", "state" => state})
+    assert Phoenix.Flash.get(conn.assigns.flash, :error) =~ "no refresh token"
+    assert Connections.list_connections(user.id) == []
+  end
+
+  test "a denied consent comes back as a flash", %{conn: conn} do
+    conn = get(conn, ~p"/connections/google/callback", %{"error" => "access_denied"})
+    assert Phoenix.Flash.get(conn.assigns.flash, :error) =~ "access_denied"
+  end
+
+  test "an account the broker is not on for is sent to /account", %{conn: conn} do
+    Application.put_env(:fountain, :broker_tenants, [])
+    conn = get(conn, ~p"/connections/google/start")
+    assert redirected_to(conn) == ~p"/account"
+  end
+
+  test "signed out, the flow is not reachable" do
+    conn = build_conn() |> get(~p"/connections/google/start")
+    assert redirected_to(conn) =~ "/auth/login"
+  end
+end

--- a/apps/fountain/test/fountain_web/controllers/gmail_mcp_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/gmail_mcp_controller_test.exs
@@ -36,7 +36,9 @@ defmodule FountainWeb.GmailMcpControllerTest do
   end
 
   test "serves tools/list for a conversation whose agent names the connection", ctx do
-    body = rpc(ctx.conn, ctx.raw_key, ctx.conv, ctx.connection, "tools/list") |> json_response(200)
+    body =
+      rpc(ctx.conn, ctx.raw_key, ctx.conv, ctx.connection, "tools/list") |> json_response(200)
+
     names = Enum.map(body["result"]["tools"], & &1["name"])
     assert "gmail_search" in names
     assert "gmail_send" in names
@@ -44,7 +46,9 @@ defmodule FountainWeb.GmailMcpControllerTest do
   end
 
   test "initialize names the connected account", ctx do
-    body = rpc(ctx.conn, ctx.raw_key, ctx.conv, ctx.connection, "initialize") |> json_response(200)
+    body =
+      rpc(ctx.conn, ctx.raw_key, ctx.conv, ctx.connection, "initialize") |> json_response(200)
+
     assert body["result"]["serverInfo"]["name"] == "fountain-gmail"
     assert body["result"]["instructions"] =~ "me@example.com"
   end
@@ -55,7 +59,9 @@ defmodule FountainWeb.GmailMcpControllerTest do
 
       case req.request_path do
         "/gmail/v1/users/me/labels" ->
-          Req.Test.json(req, %{"labels" => [%{"id" => "INBOX", "name" => "INBOX", "type" => "system"}]})
+          Req.Test.json(req, %{
+            "labels" => [%{"id" => "INBOX", "name" => "INBOX", "type" => "system"}]
+          })
       end
     end)
 
@@ -123,7 +129,13 @@ defmodule FountainWeb.GmailMcpControllerTest do
 
   test "an expired token is refreshed before the call, and the turn does not see it", ctx do
     expired = DateTime.utc_now() |> DateTime.add(-5, :second) |> DateTime.truncate(:second)
-    connection = insert_connection(ctx.user, account_email: "me@example.com", expires_at: expired, refresh_token: "rt")
+
+    connection =
+      insert_connection(ctx.user,
+        account_email: "me@example.com",
+        expires_at: expired,
+        refresh_token: "rt"
+      )
 
     Req.Test.stub(Google, fn req ->
       assert req.request_path == "/token"
@@ -145,7 +157,8 @@ defmodule FountainWeb.GmailMcpControllerTest do
     assert body["result"]["isError"] == false
   end
 
-  test "404 when the agent does not name the connection, the conversation is another tenant's, or the connection is", ctx do
+  test "404 when the agent does not name the connection, the conversation is another tenant's, or the connection is",
+       ctx do
     plain_agent = insert_agent(user_id: ctx.user.id)
     plain = insert_conversation(%{user_id: ctx.user.id, agent: plain_agent, status: "idle"})
     assert rpc(ctx.conn, ctx.raw_key, plain, ctx.connection, "tools/list") |> json_response(404)
@@ -161,7 +174,9 @@ defmodule FountainWeb.GmailMcpControllerTest do
 
   test "403 for an account the broker is not on for", ctx do
     Application.put_env(:fountain, :broker_tenants, [])
-    assert rpc(ctx.conn, ctx.raw_key, ctx.conv, ctx.connection, "tools/list") |> json_response(403)
+
+    assert rpc(ctx.conn, ctx.raw_key, ctx.conv, ctx.connection, "tools/list")
+           |> json_response(403)
   end
 
   test "a notification gets 202 and no body", ctx do

--- a/apps/fountain/test/fountain_web/controllers/gmail_mcp_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/gmail_mcp_controller_test.exs
@@ -1,0 +1,178 @@
+defmodule FountainWeb.GmailMcpControllerTest do
+  # Flips the broker ratchet (global app env).
+  use FountainWeb.ConnCase, async: false
+
+  import Fountain.BrokerTestHelpers
+
+  alias Fountain.Connections
+  alias Fountain.Connections.{Gmail, Google}
+
+  setup do
+    user = insert_verified_user()
+    {_key, raw_key} = insert_sprite_api_key(user)
+    connection = insert_connection(user, account_email: "me@example.com", access_token: "at-live")
+
+    agent =
+      insert_agent(
+        user_id: user.id,
+        mcp_servers: %{"gmail" => %{"connection" => connection.id}}
+      )
+
+    conv = insert_conversation(%{user_id: user.id, agent: agent, status: "idle"})
+    enable_broker_for([user.id])
+
+    {:ok, user: user, raw_key: raw_key, conv: conv, agent: agent, connection: connection}
+  end
+
+  defp rpc(conn, key, conv, connection, method, params \\ %{}) do
+    conn
+    |> authed_with_key(key)
+    |> post_json("/api/mcp/gmail/#{conv.id}/#{connection.id}", %{
+      "jsonrpc" => "2.0",
+      "id" => 1,
+      "method" => method,
+      "params" => params
+    })
+  end
+
+  test "serves tools/list for a conversation whose agent names the connection", ctx do
+    body = rpc(ctx.conn, ctx.raw_key, ctx.conv, ctx.connection, "tools/list") |> json_response(200)
+    names = Enum.map(body["result"]["tools"], & &1["name"])
+    assert "gmail_search" in names
+    assert "gmail_send" in names
+    assert "gmail_reply" in names
+  end
+
+  test "initialize names the connected account", ctx do
+    body = rpc(ctx.conn, ctx.raw_key, ctx.conv, ctx.connection, "initialize") |> json_response(200)
+    assert body["result"]["serverInfo"]["name"] == "fountain-gmail"
+    assert body["result"]["instructions"] =~ "me@example.com"
+  end
+
+  test "a tool call reaches Gmail with the connection's token, never the sandbox's", ctx do
+    Req.Test.stub(Gmail, fn req ->
+      assert Plug.Conn.get_req_header(req, "authorization") == ["Bearer at-live"]
+
+      case req.request_path do
+        "/gmail/v1/users/me/labels" ->
+          Req.Test.json(req, %{"labels" => [%{"id" => "INBOX", "name" => "INBOX", "type" => "system"}]})
+      end
+    end)
+
+    body =
+      rpc(ctx.conn, ctx.raw_key, ctx.conv, ctx.connection, "tools/call", %{
+        "name" => "gmail_list_labels",
+        "arguments" => %{}
+      })
+      |> json_response(200)
+
+    assert body["result"]["isError"] == false
+    assert [%{"text" => text}] = body["result"]["content"]
+    assert %{"labels" => [%{"id" => "INBOX"}]} = Jason.decode!(text)
+  end
+
+  test "a send is audited as a use of the connection, without the content", ctx do
+    Req.Test.stub(Gmail, fn req ->
+      assert req.request_path == "/gmail/v1/users/me/messages/send"
+      {:ok, body, _} = Plug.Conn.read_body(req)
+      %{"raw" => raw} = Jason.decode!(body)
+      {:ok, mime} = Base.url_decode64(raw, padding: false)
+      assert mime =~ "To: a@example.com"
+      assert mime =~ "Subject: hi"
+      assert mime =~ "the secret body"
+      Req.Test.json(req, %{"id" => "m1", "threadId" => "t1"})
+    end)
+
+    body =
+      rpc(ctx.conn, ctx.raw_key, ctx.conv, ctx.connection, "tools/call", %{
+        "name" => "gmail_send",
+        "arguments" => %{"to" => "a@example.com", "subject" => "hi", "body" => "the secret body"}
+      })
+      |> json_response(200)
+
+    assert body["result"]["isError"] == false
+
+    [event] =
+      ctx.user.id
+      |> Fountain.Audit.list_recent_for_user(50)
+      |> Enum.filter(&(&1.action == "connection.used"))
+
+    assert event.actor == "sprite"
+    assert event.metadata["tool"] == "gmail_send"
+    assert event.metadata["recipients"] == 1
+    refute inspect(event.metadata) =~ "secret body"
+    refute inspect(event.metadata) =~ "a@example.com"
+  end
+
+  test "a revoked connection answers 'connection revoked', not a 401 from Google", ctx do
+    Req.Test.stub(Google, fn req -> Req.Test.json(req, %{}) end)
+    {:ok, _} = Connections.revoke(ctx.connection)
+    Req.Test.stub(Gmail, fn _ -> flunk("Gmail must not be called for a revoked connection") end)
+
+    body =
+      rpc(ctx.conn, ctx.raw_key, ctx.conv, ctx.connection, "tools/call", %{
+        "name" => "gmail_list_labels",
+        "arguments" => %{}
+      })
+      |> json_response(200)
+
+    assert body["result"]["isError"] == true
+    assert [%{"text" => text}] = body["result"]["content"]
+    assert text =~ "connection revoked"
+  end
+
+  test "an expired token is refreshed before the call, and the turn does not see it", ctx do
+    expired = DateTime.utc_now() |> DateTime.add(-5, :second) |> DateTime.truncate(:second)
+    connection = insert_connection(ctx.user, account_email: "me@example.com", expires_at: expired, refresh_token: "rt")
+
+    Req.Test.stub(Google, fn req ->
+      assert req.request_path == "/token"
+      Req.Test.json(req, %{"access_token" => "at-refreshed", "expires_in" => 3600})
+    end)
+
+    Req.Test.stub(Gmail, fn req ->
+      assert Plug.Conn.get_req_header(req, "authorization") == ["Bearer at-refreshed"]
+      Req.Test.json(req, %{"labels" => []})
+    end)
+
+    body =
+      rpc(ctx.conn, ctx.raw_key, ctx.conv, connection, "tools/call", %{
+        "name" => "gmail_list_labels",
+        "arguments" => %{}
+      })
+      |> json_response(200)
+
+    assert body["result"]["isError"] == false
+  end
+
+  test "404 when the agent does not name the connection, the conversation is another tenant's, or the connection is", ctx do
+    plain_agent = insert_agent(user_id: ctx.user.id)
+    plain = insert_conversation(%{user_id: ctx.user.id, agent: plain_agent, status: "idle"})
+    assert rpc(ctx.conn, ctx.raw_key, plain, ctx.connection, "tools/list") |> json_response(404)
+
+    other = insert_verified_user()
+    {_k, other_key} = insert_sprite_api_key(other)
+    enable_broker_for([ctx.user.id, other.id])
+    assert rpc(ctx.conn, other_key, ctx.conv, ctx.connection, "tools/list") |> json_response(404)
+
+    theirs = insert_connection(other)
+    assert rpc(ctx.conn, ctx.raw_key, ctx.conv, theirs, "tools/list") |> json_response(404)
+  end
+
+  test "403 for an account the broker is not on for", ctx do
+    Application.put_env(:fountain, :broker_tenants, [])
+    assert rpc(ctx.conn, ctx.raw_key, ctx.conv, ctx.connection, "tools/list") |> json_response(403)
+  end
+
+  test "a notification gets 202 and no body", ctx do
+    conn =
+      ctx.conn
+      |> authed_with_key(ctx.raw_key)
+      |> post_json("/api/mcp/gmail/#{ctx.conv.id}/#{ctx.connection.id}", %{
+        "jsonrpc" => "2.0",
+        "method" => "notifications/initialized"
+      })
+
+    assert response(conn, 202) == ""
+  end
+end

--- a/apps/fountain/test/fountain_web/live/agents_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/agents_live_test.exs
@@ -358,3 +358,93 @@ defmodule FountainWeb.AgentsLive.NetworkPolicyNoteTest do
     end
   end
 end
+
+defmodule FountainWeb.AgentsLive.ConnectionsFormTest do
+  # async: false because it flips the broker ratchet (application-wide config).
+  use FountainWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Fountain.BrokerTestHelpers
+
+  defp with_credential(user) do
+    {:ok, dek} = Fountain.Crypto.load_tenant_key(user.id)
+
+    {:ok, _} =
+      Fountain.InferenceCredentials.put_credential(user.id, dek, :anthropic_api_key, "sk-ant-x")
+
+    user
+  end
+
+  describe "MCP servers that are not a command (#1178)" do
+    test "a connection can be attached as an MCP server and survives a later save", %{conn: conn} do
+      user = with_credential(insert_verified_user())
+      enable_broker_for([user.id])
+      connection = insert_connection(user, account_email: "me@example.com")
+      agent = insert_agent(user_id: user.id)
+      conn = login_user(conn, user)
+
+      {:ok, view, _html} = live(conn, ~p"/agents/#{agent.id}/edit")
+      html = view |> element("button", "+ Add server") |> render_click()
+      assert html =~ "Connected account (Gmail)"
+
+      # Switching the type reveals the connection select.
+      html =
+        view
+        |> element("form[phx-change=validate]")
+        |> render_change(%{
+          "agent" => %{"mcp_servers" => %{"0" => %{"name" => "gmail", "kind" => "connection"}}}
+        })
+
+      assert html =~ "me@example.com (google)"
+
+      view
+      |> form("form", %{
+        "agent" => %{
+          "name" => agent.name,
+          "model" => agent.model,
+          "runtime" => agent.runtime,
+          "mcp_servers" => %{
+            "0" => %{"name" => "gmail", "kind" => "connection", "connection" => connection.id}
+          }
+        }
+      })
+      |> render_submit()
+
+      assert %{"gmail" => %{"connection" => id}} =
+               Fountain.Agents.get_agent(agent.id, user.id).mcp_servers
+
+      assert id == connection.id
+
+      # Reopen and save with no change to the row: the entry is kept.
+      {:ok, view, html} = live(conn, ~p"/agents/#{agent.id}/edit")
+      assert html =~ "me@example.com (google)"
+
+      view
+      |> form("form", %{
+        "agent" => %{"name" => agent.name, "model" => agent.model, "runtime" => agent.runtime}
+      })
+      |> render_submit()
+
+      assert %{"gmail" => %{"connection" => ^id}} =
+               Fountain.Agents.get_agent(agent.id, user.id).mcp_servers
+    end
+
+    test "a remote server written through the API survives a save from the form", %{conn: conn} do
+      user = with_credential(insert_verified_user())
+      remote = %{"type" => "http", "url" => "https://mcp.example.com/sse"}
+      agent = insert_agent(user_id: user.id, mcp_servers: %{"remote" => remote})
+      conn = login_user(conn, user)
+
+      {:ok, view, html} = live(conn, ~p"/agents/#{agent.id}/edit")
+      assert html =~ "kept as is"
+
+      view
+      |> form("form", %{
+        "agent" => %{"name" => "renamed", "model" => agent.model, "runtime" => agent.runtime}
+      })
+      |> render_submit()
+
+      assert Fountain.Agents.get_agent(agent.id, user.id).mcp_servers == %{"remote" => remote}
+    end
+  end
+end

--- a/apps/fountain/test/fountain_web/live/connections_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/connections_live_test.exs
@@ -1,0 +1,58 @@
+defmodule FountainWeb.ConnectionsLiveTest do
+  # Flips the broker ratchet (global app env).
+  use FountainWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Fountain.BrokerTestHelpers
+
+  alias Fountain.Connections
+  alias Fountain.Connections.Google
+
+  test "hidden and redirected for an account the broker is not on for", %{conn: conn} do
+    user = insert_verified_user()
+    enable_broker_for([])
+    conn = login_user(conn, user)
+
+    refute conn |> get(~p"/account") |> html_response(200) =~ ~s(href="/account/connections")
+    assert {:error, {:live_redirect, %{to: "/account"}}} = live(conn, ~p"/account/connections")
+  end
+
+  test "lists connections, links to the flow, revokes and removes", %{conn: conn} do
+    user = insert_verified_user()
+    enable_broker_for([user.id])
+    c = insert_connection(user, account_email: "me@example.com", access_token: "never-in-html")
+    conn = login_user(conn, user)
+
+    assert conn |> get(~p"/account") |> html_response(200) =~ ~s(href="/account/connections")
+
+    {:ok, lv, html} = live(conn, ~p"/account/connections")
+    assert html =~ "me@example.com"
+    assert html =~ ~s(href="/connections/google/start")
+    assert html =~ c.id
+    assert html =~ "GOOGLE_ACCESS_TOKEN"
+    refute html =~ "never-in-html"
+
+    Req.Test.stub(Google, fn req -> Req.Test.json(req, %{}) end)
+
+    html = lv |> element("#connection-#{c.id} button", "Revoke") |> render_click()
+    assert html =~ "Revoked me@example.com"
+    assert %{status: "revoked"} = Connections.get_connection(c.id, user.id)
+    assert html =~ "Connect the account again"
+
+    html = lv |> element("#connection-#{c.id} button", "Remove") |> render_click()
+    assert html =~ "No connections yet"
+    refute Connections.get_connection(c.id, user.id)
+  end
+
+  test "says so when Google is not configured on this deployment", %{conn: conn} do
+    user = insert_verified_user()
+    enable_broker_for([user.id])
+    previous = Application.get_env(:fountain, :google_oauth_client_id)
+    on_exit(fn -> Application.put_env(:fountain, :google_oauth_client_id, previous) end)
+    Application.put_env(:fountain, :google_oauth_client_id, nil)
+
+    {:ok, _lv, html} = conn |> login_user(user) |> live(~p"/account/connections")
+    assert html =~ "Not configured on this deployment"
+    refute html =~ ~s(href="/connections/google/start")
+  end
+end

--- a/apps/fountain/test/fountain_web/schema_enum_guardrail_test.exs
+++ b/apps/fountain/test/fountain_web/schema_enum_guardrail_test.exs
@@ -44,6 +44,8 @@ defmodule FountainWeb.SchemaEnumGuardrailTest do
   # list of atoms is stringified first — the domain keeps them as atoms, the
   # wire carries strings.
   @derived %{
+    {FountainWeb.Schemas.Connection, "provider"} => {Fountain.Connections.Connection, :providers},
+    {FountainWeb.Schemas.Connection, "status"} => {Fountain.Connections.Connection, :statuses},
     {FountainWeb.Schemas.AdminRoleRequest, "role"} => {User, :roles},
     {FountainWeb.Schemas.AdminUser, "role"} => {User, :roles},
     {FountainWeb.Schemas.AuthMeResponse, "role"} => {User, :roles},

--- a/apps/fountain/test/support/broker_test_helpers.ex
+++ b/apps/fountain/test/support/broker_test_helpers.ex
@@ -1,0 +1,28 @@
+defmodule Fountain.BrokerTestHelpers do
+  @moduledoc """
+  Put the egress broker "on" for a user in a test, and restore the app env
+  after. Global state, so the test module that uses it is `async: false`.
+  """
+
+  import ExUnit.Callbacks, only: [on_exit: 1]
+
+  @keys [:broker_url, :broker_token, :broker_proxy_url, :broker_tenants]
+
+  def enable_broker_for(user_ids) when is_list(user_ids) do
+    previous = for k <- @keys, do: {k, Application.get_env(:fountain, k)}
+
+    on_exit(fn ->
+      for {k, v} <- previous do
+        if is_nil(v),
+          do: Application.delete_env(:fountain, k),
+          else: Application.put_env(:fountain, k, v)
+      end
+    end)
+
+    Application.put_env(:fountain, :broker_url, "http://broker.test:14321")
+    Application.put_env(:fountain, :broker_token, "t")
+    Application.put_env(:fountain, :broker_proxy_url, "http://broker.test:14322")
+    Application.put_env(:fountain, :broker_tenants, user_ids)
+    :ok
+  end
+end

--- a/apps/fountain/test/support/factory.ex
+++ b/apps/fountain/test/support/factory.ex
@@ -77,6 +77,30 @@ defmodule Fountain.Factory do
     insert_api_key(user, "sprite:#{uniq()}", Keyword.put_new(opts, :scopes, ["sprite"]))
   end
 
+  # ── connections (#1178) ───────────────────────────────────────────────────
+
+  @doc """
+  A stored Google connection with a refresh token and a fresh access token,
+  as `Fountain.Connections.connect/4` would persist after a consent. No
+  network: the grant map is what `Google.exchange_code/2` returns.
+  """
+  def insert_connection(user, overrides \\ %{}) do
+    overrides = Map.new(overrides, fn {k, v} -> {to_string(k), v} end)
+
+    grant = %{
+      refresh_token: overrides["refresh_token"] || "refresh-#{uniq()}",
+      access_token: overrides["access_token"] || "access-#{uniq()}",
+      expires_at:
+        overrides["expires_at"] ||
+          DateTime.utc_now() |> DateTime.add(3600, :second) |> DateTime.truncate(:second),
+      scopes: overrides["scopes"] || Fountain.Connections.Google.scopes(),
+      account_email: overrides["account_email"] || "user-#{uniq()}@example.com"
+    }
+
+    {:ok, conn} = Fountain.Connections.connect(user.id, "google", grant)
+    conn
+  end
+
   # ── environments ──────────────────────────────────────────────────────────
 
   def env_attrs(overrides \\ %{}) do

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -681,6 +681,21 @@ if github_client_id = System.get_env("GITHUB_OAUTH_CLIENT_ID") do
     client_secret: System.get_env("GITHUB_OAUTH_CLIENT_SECRET")
 end
 
+# Google OAuth client for connections (#1178): a tenant signs in to Google
+# once in the console and Fountain holds the refresh token. Not the sign-in
+# provider — that is GitHub above. Absent stays absent, so the console says
+# the feature is not configured rather than sending anyone to Google with
+# an empty client id.
+case System.get_env("GOOGLE_OAUTH_CLIENT_ID") do
+  blank when blank in [nil, ""] ->
+    :ok
+
+  google_client_id ->
+    config :fountain,
+      google_oauth_client_id: google_client_id,
+      google_oauth_client_secret: System.get_env("GOOGLE_OAUTH_CLIENT_SECRET")
+end
+
 # Stripe (§5.2)
 config :stripity_stripe, api_key: System.get_env("STRIPE_SECRET_KEY")
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -110,6 +110,14 @@ config :fountain, :agentphone_req_options, plug: {Req.Test, Fountain.Team.Comms.
 config :fountain, :agentphone_webhook_secret, "whsec_test"
 config :fountain, :posthog_req_options, plug: {Req.Test, Fountain.FeatureFlags}
 
+# Connections (#1178): a Google OAuth client so the flow is "configured", and
+# Req.Test plugs so no test reaches Google. Same failure mode as AgentMail
+# above: an unstubbed call fails loudly.
+config :fountain, :google_oauth_client_id, "google-test-client-id"
+config :fountain, :google_oauth_client_secret, "google-test-client-secret"
+config :fountain, :google_oauth_req_options, plug: {Req.Test, Fountain.Connections.Google}
+config :fountain, :gmail_req_options, plug: {Req.Test, Fountain.Connections.Gmail}
+
 # Product analytics (`Fountain.Analytics`). Capture is inert without a project
 # API key, which the suite deliberately does not set — so the default here is
 # "nothing is sent", and a test that wants to assert on a payload sets the key

--- a/docs/catalog/mcp-servers/fountain-gmail.md
+++ b/docs/catalog/mcp-servers/fountain-gmail.md
@@ -1,0 +1,100 @@
+# fountain-gmail
+
+> Gives an agent a Gmail mailbox that the account owner connected once, and
+> gives it no Google token.
+
+## At a glance
+
+| | |
+|---|---|
+| Hosted by | Fountain |
+| Declared by | The agent. Its `mcp_servers` names a connection. |
+| Injected when | The agent names an active connection, and the egress broker is on for the account. |
+| Endpoint | `POST /api/mcp/gmail/:conversation_id/:connection_id` |
+| Auth | The sandbox's own callback token, for that one conversation. |
+| Status | Beta. Only for accounts the egress broker is on for. Read [Feature status](../../reference/feature-status.md). |
+
+## Why it exists in this shape
+
+An agent that reads your mail needs a Google credential. Put one in the
+sandbox, and any agent that prints its environment has leaked your mailbox.
+
+So the credential does not go there. **You sign in to Google once**, on the
+Connections page of the console, and Fountain keeps the refresh token.
+Fountain encrypts it with your tenant key, like a vault secret. The agent reaches the
+mailbox through these tools alone. Fountain gets a fresh access token for
+each call, on the server. The sandbox never sees one.
+
+This is the shape [fountain-comms](fountain-comms.md) has. When an agent
+needs a capability that a credential would grant, serve the capability. Do
+not ship the credential.
+
+## Connect an account
+
+1. Open **Account, then Connections** in the console.
+2. Click **Connect a Google account** and complete the Google consent screen.
+3. Copy the connection id from the page.
+
+The consent asks for `gmail.modify`, which covers read, send, reply and
+labels. Google names it a restricted scope. An unverified Google app serves
+its test users only, so a self-hosted instance adds each account to the test
+users of its Google Cloud project. Read
+[`GOOGLE_OAUTH_CLIENT_ID`](../../configuration.md#authentication).
+
+## Attach it to an agent
+
+Name the connection in the agent's `mcp_servers`. The key is the server name
+the agent sees, and the value names the connection instead of a command or a
+URL.
+
+```json
+{
+  "mcp_servers": {
+    "gmail": { "connection": "3f6c1a2e-2b0e-4f8a-9d5b-7c1e2a9f0b44" }
+  }
+}
+```
+
+At spawn, Fountain rewrites the entry into an HTTP MCP server on this
+endpoint, authenticated by the conversation's callback token. The runtime
+sees a normal remote server.
+
+## The tools
+
+| Tool | What it does |
+|---|---|
+| `gmail_search` | Searches the mailbox with Gmail's query syntax, newest first. |
+| `gmail_get_thread` | Returns every message in a thread, with the plain text body. |
+| `gmail_get_message` | Returns one message in full. |
+| `gmail_send` | Sends a new plain text email from the connected account. |
+| `gmail_reply` | Answers a message in its thread. Use this for a reply, and not `gmail_send`. |
+| `gmail_modify_labels` | Adds or removes labels. Remove `INBOX` to archive. |
+| `gmail_list_labels` | Lists the labels and their ids. |
+
+Fountain writes each send to the audit log as `connection.used`, with the
+tool name and the number of recipients. The log holds no address, subject or
+body.
+
+## Revoke
+
+Click **Revoke** on the Connections page, or call
+`DELETE /api/connections/:id`. Fountain tells Google to forget the grant.
+The next tool call from an agent that names the connection fails with
+`connection revoked`, and not with a 401 from Google. Connect the account
+again to replace it.
+
+## Token expiry
+
+A Google access token lasts one hour. Fountain refreshes it on the server
+when a tool call finds it near expiry, so a turn does not fail on an expired
+token.
+
+## The other way: a brokered token
+
+The same connection also gives a brokered `GOOGLE_ACCESS_TOKEN` to the
+sandbox, for an MCP server that you run. The sandbox holds a placeholder,
+and the egress broker attaches the real token as a bearer on requests to
+`gmail.googleapis.com` and `www.googleapis.com`. Bind that name to a host of
+your own on the Credential bindings page, and the broker sends the token
+there instead. Fountain uploads a rotated token to the broker at the start
+of the next turn. Read [Where a secret comes from](../../concepts/secrets.md).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -111,6 +111,8 @@ at a dead end, with no error to see. Read [Email](guides/operate/email.md).
 |---|---|---|---|
 | `GITHUB_OAUTH_CLIENT_ID` | — | — | Turns the GitHub sign-in button on. Unset, Fountain hides the button, and email and password auth still works. |
 | `GITHUB_OAUTH_CLIENT_SECRET` | — | — | |
+| `GOOGLE_OAUTH_CLIENT_ID` | — | — | Turns the Google connection on, for accounts the egress broker is on for. A tenant connects Gmail once on the Connections page, and Fountain keeps the refresh token. Register a Web client in Google Cloud with the redirect URI `<PUBLIC_URL>/connections/google/callback`, and enable the Gmail API. Unset, the page says the feature is not configured. |
+| `GOOGLE_OAUTH_CLIENT_SECRET` | — | — | |
 
 ## Payment
 

--- a/docs/nav.yml
+++ b/docs/nav.yml
@@ -74,6 +74,7 @@ nav:
       - fountain-team: catalog/mcp-servers/fountain-team.md
       - fountain-buzz: catalog/mcp-servers/fountain-buzz.md
       - fountain-comms: catalog/mcp-servers/fountain-comms.md
+      - fountain-gmail: catalog/mcp-servers/fountain-gmail.md
       - Agents: catalog/agents/index.md
       - fountain-contributor (agent): catalog/agents/fountain-contributor.md
   - Sandbox providers:

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -10,6 +10,18 @@ server releases.
 
 ---
 
+## [1.7.0] — 2026-08-25
+
+### Added
+
+- `client.connections`: the provider accounts the tenant signed in to once,
+  whose credentials Fountain holds (#1178). `list()`, `get(id)`,
+  `providers()` (what the deployment can connect and the console URL that
+  starts the flow) and `delete(id)`. Connecting is a browser round trip, so
+  there is no `create`. An agent uses one by naming it in `mcp_servers`:
+  `{ gmail: { connection: "<id>" } }`. `Connection` and `ConnectionProvider`
+  types. Only for accounts the egress broker is on for.
+
 ## [1.6.0] — 2026-08-25
 
 ### Added

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentshit/fountain-sdk",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Run a coding agent on a real computer, with your repos and your credentials, in one call.",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -3,7 +3,7 @@ import { resolveConfig, type ConfigOptions, type ResolvedConfig } from "./config
 import { Resolver } from "./resolve.ts";
 import { Run, type RunOptions } from "./run.ts";
 import { Conversation } from "./conversation.ts";
-import { Agents, Environments, Vaults } from "./resources.ts";
+import { Agents, Connections, Environments, Vaults } from "./resources.ts";
 import { Team, normalizeStreams } from "./team.ts";
 import { streamPath, type StreamRequest } from "./sse.ts";
 import type {
@@ -89,6 +89,8 @@ export class Fountain {
   readonly vaults: Vaults;
   /** The team: teammates, their threads and their routines. */
   readonly team: Team;
+  /** Provider accounts Fountain holds the credential for (Gmail via OAuth). */
+  readonly connections: Connections;
 
   private readonly resolver: Resolver;
 
@@ -103,6 +105,7 @@ export class Fountain {
     this.environments = new Environments(this.api, this.resolver);
     this.vaults = new Vaults(this.api, this.resolver);
     this.team = new Team(this.api, this.resolver);
+    this.connections = new Connections(this.api);
   }
 
   /**

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -505,6 +505,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/connections/providers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List connectable providers
+         * @description The providers this deployment has an OAuth client for, the scopes each asks for, the env var its token is brokered under, and the console URL that starts the flow (a browser signed in as the account owner).
+         */
+        get: operations["FountainWeb.ConnectionController.providers"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/auth/resend-verification": {
         parameters: {
             query?: never;
@@ -540,6 +560,27 @@ export interface paths {
         put?: never;
         post?: never;
         delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/connections/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get a connection */
+        get: operations["FountainWeb.ConnectionController.show"];
+        put?: never;
+        post?: never;
+        /**
+         * Revoke and delete a connection
+         * @description Tells the provider to forget the grant, then deletes the row. The next tool call from an agent that names it fails with `connection revoked`.
+         */
+        delete: operations["FountainWeb.ConnectionController.delete"];
         options?: never;
         head?: never;
         patch?: never;
@@ -1525,6 +1566,26 @@ export interface paths {
          * @description Revokes the API key in the `Authorization` header — what an app does on sign-out. Idempotent: an already-revoked key is 204 too (it would not have authenticated).
          */
         post: operations["FountainWeb.OAuthTokenController.revoke"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/connections": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List connections
+         * @description Every provider account the tenant has connected, active or revoked. Only for accounts the egress broker is on for (ADR 0019); 404 otherwise.
+         */
+        get: operations["FountainWeb.ConnectionController.index"];
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -2810,6 +2871,10 @@ export interface components {
         SandboxListResponse: {
             data: components["schemas"]["SandboxDetail"][];
         };
+        /** ConnectionListResponse */
+        ConnectionListResponse: {
+            data: components["schemas"]["Connection"][];
+        };
         /** InferenceCredentialListResponse */
         InferenceCredentialListResponse: {
             data: components["schemas"]["InferenceCredentialStatus"][];
@@ -3467,6 +3532,37 @@ export interface components {
             name: string;
         };
         /**
+         * Connection
+         * @description A provider account the tenant signed in to once, whose credential Fountain holds (#1178). Agents get the capability, never the token: an agent's `mcp_servers` names the connection (`{"gmail": {"connection": "<id>"}}`) and Fountain serves the Gmail tools; and the access token is brokered under `env_key` for an MCP server the tenant runs. Only for accounts the egress broker is on for.
+         */
+        Connection: {
+            /** @description The connected account. */
+            account_email: string;
+            /** Format: date-time */
+            created_at?: string;
+            /** @description The env var name the access token is brokered under (`GOOGLE_ACCESS_TOKEN`). */
+            env_key: string;
+            /**
+             * Format: date-time
+             * @description When the cached access token expires. Refreshed on use.
+             */
+            expires_at?: string | null;
+            /** Format: uuid */
+            id: string;
+            /** @enum {string} */
+            provider: "google";
+            /** Format: date-time */
+            revoked_at?: string | null;
+            scopes: string[];
+            /**
+             * @description `revoked` once the tenant cut it or the provider refused the refresh token; the row stays so the console can say why the tools stopped. Reconnect to replace it.
+             * @enum {string}
+             */
+            status: "active" | "revoked";
+            /** Format: date-time */
+            updated_at?: string;
+        };
+        /**
          * AdminAuditListResponse
          * @description Cross-tenant audit events; each carries the tenant it belongs to.
          */
@@ -3732,6 +3828,21 @@ export interface components {
             };
             repositories?: components["schemas"]["Repository"][];
             setup_script?: string;
+        };
+        /**
+         * ConnectionProvidersResponse
+         * @description Which providers this deployment can connect, and the URL that starts each flow.
+         */
+        ConnectionProvidersResponse: {
+            data: {
+                /** @description False when the deployment has no OAuth client for it. */
+                configured: boolean;
+                /** @description Where to send the account owner, in a browser signed in to the console, to connect an account. The flow ends back on the Connections page. */
+                connect_url: string;
+                env_key: string;
+                provider: string;
+                scopes: string[];
+            }[];
         };
         /** AdminUserResponse */
         AdminUserResponse: {
@@ -5337,6 +5448,44 @@ export interface operations {
             };
         };
     };
+    "FountainWeb.ConnectionController.providers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Providers */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ConnectionProvidersResponse"];
+                };
+            };
+            /** @description Missing or invalid key */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Connections are not enabled for this account */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
     "FountainWeb.RegistrationController.api_resend": {
         parameters: {
             query?: never;
@@ -5386,6 +5535,86 @@ export interface operations {
                 };
             };
             /** @description No such image */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    "FountainWeb.ConnectionController.show": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Connection id */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Connection */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Connection"];
+                };
+            };
+            /** @description Missing or invalid key */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    "FountainWeb.ConnectionController.delete": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Connection id */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Deleted */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Missing or invalid key */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
             404: {
                 headers: {
                     [name: string]: unknown;
@@ -8092,6 +8321,44 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+        };
+    };
+    "FountainWeb.ConnectionController.index": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Connections */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ConnectionListResponse"];
+                };
+            };
+            /** @description Missing or invalid key */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Connections are not enabled for this account */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
             };
         };
     };

--- a/sdk/typescript/src/http.ts
+++ b/sdk/typescript/src/http.ts
@@ -19,7 +19,7 @@ export interface RequestOptions {
  * this string is already what Fountain's request logs are keyed on. The
  * version half is asserted against `package.json` by a test.
  */
-export const USER_AGENT = "fountain-sdk-js/1.6.0";
+export const USER_AGENT = "fountain-sdk-js/1.7.0";
 
 /**
  * The thin layer everything else is built on: one bearer token, JSON in and

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -2,7 +2,7 @@ export { Fountain, type FountainOptions, type RunConfig } from "./client.ts";
 export { Run, type RunOptions } from "./run.ts";
 export { Conversation, type SendOptions } from "./conversation.ts";
 export { HttpClient, type FetchLike, type RequestOptions } from "./http.ts";
-export { Agents, Environments, Vaults } from "./resources.ts";
+export { Agents, Connections, Environments, Vaults } from "./resources.ts";
 export { Team, TeamSchedules, type MessageOptions } from "./team.ts";
 export {
   resolveConfig,

--- a/sdk/typescript/src/resources.ts
+++ b/sdk/typescript/src/resources.ts
@@ -4,6 +4,8 @@ import type {
   Agent,
   AgentInput,
   AgentPatch,
+  Connection,
+  ConnectionProvider,
   Environment,
   EnvironmentInput,
   EnvironmentPatch,
@@ -150,6 +152,42 @@ export class Environments extends Collection<Environment, EnvironmentInput, Envi
   constructor(http: HttpClient, resolver: Resolver) {
     super(http, resolver, "/api/environments", "environment");
     this.secrets = new Secrets(http, resolver, this.path, this.what);
+  }
+}
+
+/**
+ * The provider accounts this tenant has signed in to, whose credentials
+ * Fountain holds (#1178). Connecting one is a browser round trip — send the
+ * account owner to `connect_url` from `providers()` — so there is no `create`
+ * here. An agent uses one by naming it in `mcp_servers`:
+ * `{ gmail: { connection: "<id>" } }`. Only for accounts the egress broker is
+ * on for; elsewhere every call is a `NotFoundError` (`connections_not_enabled`).
+ */
+export class Connections {
+  private readonly http: HttpClient;
+
+  constructor(http: HttpClient) {
+    this.http = http;
+  }
+
+  /** Every connection on the account, active or revoked. Never a token. */
+  async list(): Promise<Connection[]> {
+    return this.http.list<Connection>("/api/connections");
+  }
+
+  /** One connection by id. Unenveloped, as the server answers `show`. */
+  async get(id: string): Promise<Connection> {
+    return this.http.request<Connection>("GET", `/api/connections/${encodeURIComponent(id)}`);
+  }
+
+  /** What this deployment can connect, with the URL that starts each flow. */
+  async providers(): Promise<ConnectionProvider[]> {
+    return this.http.list<ConnectionProvider>("/api/connections/providers");
+  }
+
+  /** Revoke at the provider and delete. Agents that name it get `connection revoked`. */
+  async delete(id: string): Promise<void> {
+    await this.http.request("DELETE", `/api/connections/${encodeURIComponent(id)}`);
   }
 }
 

--- a/sdk/typescript/src/schemas.ts
+++ b/sdk/typescript/src/schemas.ts
@@ -80,6 +80,10 @@ export type SearchHit = S["SearchHit"];
 /** A node in a conversation's spawn tree. */
 export type ConversationTreeNode = S["ConversationTreeNode"];
 export type Runner = S["Runner"];
+/** A provider account the tenant signed in to once; Fountain holds the credential (#1178). */
+export type Connection = S["Connection"];
+/** A provider this deployment can connect, and the console URL that starts the flow. */
+export type ConnectionProvider = S["ConnectionProvidersResponse"]["data"][number];
 export type Repository = S["Repository"];
 export type ImageInput = S["ImageInput"];
 export type AuthMe = S["AuthMeResponse"];

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -13,6 +13,8 @@ export type {
   AuthMe,
   Block,
   Catalog,
+  Connection,
+  ConnectionProvider,
   ConversationRecord,
   ConversationTreeNode,
   Environment,

--- a/sdk/typescript/test/resources.test.ts
+++ b/sdk/typescript/test/resources.test.ts
@@ -161,6 +161,42 @@ describe("environments and their secrets", () => {
   });
 });
 
+describe("connections", () => {
+  const CONNECTION = {
+    id: "cccccccc-1111-1111-1111-111111111111",
+    provider: "google",
+    account_email: "me@example.com",
+    scopes: ["openid", "email", "https://www.googleapis.com/auth/gmail.modify"],
+    env_key: "GOOGLE_ACCESS_TOKEN",
+    status: "active",
+    expires_at: null,
+    revoked_at: null,
+    created_at: "2026-08-25T00:00:00Z",
+    updated_at: "2026-08-25T00:00:00Z",
+  };
+
+  test("list, get, providers and delete", async () => {
+    fake.connections = [CONNECTION];
+    const fountain = client();
+
+    const all = await fountain.connections.list();
+    assert.equal(all.length, 1);
+    assert.equal(all[0]?.account_email, "me@example.com");
+
+    const one = await fountain.connections.get(CONNECTION.id);
+    assert.equal(one.env_key, "GOOGLE_ACCESS_TOKEN");
+    assert.equal(one.status, "active");
+
+    const [google] = await fountain.connections.providers();
+    assert.equal(google?.provider, "google");
+    assert.match(String(google?.connect_url), /\/connections\/google\/start$/);
+
+    await fountain.connections.delete(CONNECTION.id);
+    assert.equal(fake.connections.length, 0);
+    await assert.rejects(() => fountain.connections.get(CONNECTION.id), NotFoundError);
+  });
+});
+
 describe("vaults", () => {
   test("create and read back", async () => {
     const fountain = client();

--- a/sdk/typescript/test/server.ts
+++ b/sdk/typescript/test/server.ts
@@ -64,6 +64,8 @@ export class FakeFountain {
   environments: Record<string, unknown>[] = [
     { id: "bbbbbbbb-1111-1111-1111-111111111111", name: "monorepo" },
   ];
+  /** Connections (#1178), as `GET /api/connections` lists them. */
+  connections: Record<string, unknown>[] = [];
   /** Secrets by `${collection}:${parentId}` → key → value. Never read back out. */
   readonly secrets = new Map<string, Map<string, string>>();
   /** agent_id → the teammate row `/api/team` returns. */
@@ -209,6 +211,35 @@ export class FakeFountain {
     if (path === "/api/search") return json(res, 200, { data: [{ conversation_id: "conv-1", snippet: "hit" }] });
 
     if (path.startsWith("/api/team")) return this.team(req, res, path, url, body);
+
+    // Connections (#1178): list / providers / one / delete. Enveloped like
+    // the real controller. No create — that is a browser round trip.
+    if (path === "/api/connections/providers") {
+      return json(res, 200, {
+        data: [
+          {
+            provider: "google",
+            configured: true,
+            scopes: ["openid", "email", "https://www.googleapis.com/auth/gmail.modify"],
+            env_key: "GOOGLE_ACCESS_TOKEN",
+            connect_url: "https://fountain.test/connections/google/start",
+          },
+        ],
+      });
+    }
+    if (path === "/api/connections") return json(res, 200, { data: this.connections });
+    const connection = /^\/api\/connections\/([^/]+)$/.exec(path);
+    if (connection) {
+      const found = this.connections.find((c) => c.id === connection[1]);
+      if (!found) return json(res, 404, { error: "not_found" });
+      if (req.method === "DELETE") {
+        this.connections = this.connections.filter((c) => c !== found);
+        res.statusCode = 204;
+        res.end();
+        return;
+      }
+      return json(res, 200, found);
+    }
 
     const collection = /^\/api\/(agents|vaults|environments)(?:\/([^/]+))?(?:\/(secrets)(?:\/(.+))?)?$/.exec(path);
     if (collection) {


### PR DESCRIPTION
Closes #1178.

## What

A tenant signs in to Google **once** on *Account → Connections*; Fountain keeps the refresh token DEK-encrypted like any tenant secret and hands agents the capability, never the credential. Everything is gated on `Fountain.Broker.enabled_for?/1` (the broker ratchet), so it is live only for brokered accounts.

### 1. `Fountain.Connections` (issue piece 1)
- `connections` table: provider, account email, scopes, `env_key`, DEK-encrypted refresh + access token, expiry, status.
- Google OAuth client with `access_type=offline&prompt=consent`; `GET /connections/google/start` → consent → `callback` (signed `Phoenix.Token` state bound to the session nonce).
- `Connections.access_token/1` refreshes within 5 min of expiry; `invalid_grant` marks the row `revoked` and audits it.
- Console page: list, connect, revoke (also calls Google's revoke endpoint), remove. Nav link beside *Credential bindings*.
- `GET /api/connections`, `GET /api/connections/providers`, `GET/DELETE /api/connections/:id` (full scope), OpenAPI, SDK **1.7.0** with `client.connections`.
- Audit: `connection.created` / `connection.revoked` (provider, scopes, address — never a token), `connection.used` per send from the MCP server.

### 2. A Fountain-served Gmail MCP server (piece 2)
- An agent names the connection instead of a token: `{"gmail": {"connection": "<id>"}}`. `Fountain.Connections.McpServers.resolve/3` rewrites it at spawn into an HTTP MCP server at `POST /api/mcp/gmail/:conversation_id/:connection_id` carrying the conversation's callback token — so it flows through `.mcp.json` (claude) and `session/new` (everyone else) with no new contract. Rewritten again on reattach, when the token rotates.
- Tools: `gmail_search`, `gmail_get_thread`, `gmail_get_message`, `gmail_send`, `gmail_reply`, `gmail_modify_labels`, `gmail_list_labels`. The token is resolved server-side per call; a revoked connection answers **`connection revoked`**, not a 401 from Google.
- The controller checks: conversation is the caller's, its agent still names the connection, connection is the caller's.

### 3. Tenant-supplied OAuth'd MCP servers via the broker (piece 3)
- Each active connection contributes a synthetic secret (`GOOGLE_ACCESS_TOKEN`, `_2`, …) merged after env ∪ vault (a tenant's own secret of that name wins) and brokered like an inference key: placeholder in the sandbox, value at the broker, an implicit **bearer** binding to `gmail.googleapis.com` / `www.googleapis.com`. A tenant binding on the same name (Credential bindings page — the key is now in the catalog) routes it to an MCP server they run instead.
- Rotation: `broker_refresh/1` re-reads the connection tokens at every turn kick and re-prepares the vault when one changed, so a shared sandbox outlives the hourly token.

## Not in this PR
- ADR 0019 amendment for the rotating-secret contract (the mechanism is documented in the changelog and the `fountain-gmail` docs page; I'll follow up).

## Done-when from the issue
- [x] connect once in the console, attach via `mcp_servers`, conversation lists and sends mail — verified on prod (see comment below)
- [x] no Google token in sandbox env / `.env` / `.mcp.json` — only the callback token and a `__GOOGLE_ACCESS_TOKEN__` placeholder
- [x] revoke → next tool call fails with `connection revoked`
- [x] expiry mid-conversation handled by server-side refresh

## Ops
- Google Cloud: Web client "Fountain connections (Gmail)" in project *Guitar*, redirect URIs for `localhost:4000` and `fountain.inevitable.fyi`; consent screen External/Testing with `jhgaylor@gmail.com` as test user; Gmail API enabled.
- `GOOGLE_OAUTH_CLIENT_ID` / `GOOGLE_OAUTH_CLIENT_SECRET` added to the `fountain` prod Infisical project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Also
- The console agent form gained a per-row **Type**: command (stdio) / connected account. It previously rebuilt `mcp_servers` from its stdio fields on save, which would have dropped a connection entry — and any http/sse server written through the API; those are now shown read-only and carried through.
