### PR TITLE
fix(connections): gmail_search 500 — Gmail's multi-valued params are repeated keys

### DIFF
--- a/apps/fountain/lib/fountain/connections/gmail.ex
+++ b/apps/fountain/lib/fountain/connections/gmail.ex
@@ -9,16 +9,18 @@ defmodule Fountain.Connections.Gmail do
 
   @base_url "https://gmail.googleapis.com/gmail/v1/users/me"
 
+  @metadata_headers ~w(From To Cc Subject Date Message-ID)
+
   @doc "Threads matching a Gmail search query (`q`), newest first."
   def list_threads(token, opts \\ []) do
     params =
       [
         q: Keyword.get(opts, :query),
         maxResults: Keyword.get(opts, :max_results, 10),
-        pageToken: Keyword.get(opts, :page_token),
-        labelIds: Keyword.get(opts, :label_ids)
+        pageToken: Keyword.get(opts, :page_token)
       ]
       |> Enum.reject(fn {_, v} -> is_nil(v) end)
+      |> Kernel.++(repeated(:labelIds, Keyword.get(opts, :label_ids)))
 
     get(token, "/threads", params: params)
   end
@@ -26,9 +28,15 @@ defmodule Fountain.Connections.Gmail do
   @doc "One thread with every message, in `format`: `metadata` (headers + snippet) or `full`."
   def get_thread(token, thread_id, format \\ "metadata") do
     get(token, "/threads/#{enc(thread_id)}",
-      params: [format: format, metadataHeaders: ~w(From To Cc Subject Date Message-ID)]
+      params: [format: format] ++ repeated(:metadataHeaders, @metadata_headers)
     )
   end
+
+  # Gmail takes a multi-valued parameter as a repeated key
+  # (`metadataHeaders=From&metadataHeaders=To`); `URI.encode_query/1`
+  # refuses a list value, so each value gets its own pair.
+  defp repeated(_key, nil), do: []
+  defp repeated(key, values) when is_list(values), do: Enum.map(values, &{key, &1})
 
   @doc "One message, in `full` format (headers, snippet and body parts)."
   def get_message(token, message_id, format \\ "full") do
@@ -85,8 +93,12 @@ defmodule Fountain.Connections.Gmail do
   defp get(token, path), do: request(token, :get, path, [])
   defp post(token, path, opts), do: request(token, :post, path, opts)
 
+  # The query is encoded here rather than through Req's `params`, which
+  # folds a keyword list into a map and so keeps one value per key.
   defp request(token, method, path, opts) do
-    req = Req.merge(req(), [url: path, auth: {:bearer, token}, method: method] ++ opts)
+    {params, opts} = Keyword.pop(opts, :params, [])
+    url = if params == [], do: path, else: path <> "?" <> URI.encode_query(params)
+    req = Req.merge(req(), [url: url, auth: {:bearer, token}, method: method] ++ opts)
 
     case Req.request(req) do
       {:ok, %{status: status, body: body}} when status in 200..299 -> {:ok, body}

--- a/apps/fountain/test/fountain_web/controllers/gmail_mcp_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/gmail_mcp_controller_test.exs
@@ -77,6 +77,59 @@ defmodule FountainWeb.GmailMcpControllerTest do
     assert %{"labels" => [%{"id" => "INBOX"}]} = Jason.decode!(text)
   end
 
+  test "gmail_search lists threads and reads each one's headers with repeated query keys", ctx do
+    test_pid = self()
+
+    Req.Test.stub(Gmail, fn req ->
+      send(test_pid, {:gmail, req.request_path, req.query_string})
+
+      case req.request_path do
+        "/gmail/v1/users/me/threads" ->
+          Req.Test.json(req, %{"threads" => [%{"id" => "t1"}], "resultSizeEstimate" => 1})
+
+        "/gmail/v1/users/me/threads/t1" ->
+          Req.Test.json(req, %{
+            "id" => "t1",
+            "messages" => [
+              %{
+                "id" => "m1",
+                "snippet" => "hello there",
+                "labelIds" => ["INBOX"],
+                "payload" => %{
+                  "headers" => [
+                    %{"name" => "Subject", "value" => "Hi"},
+                    %{"name" => "From", "value" => "a@example.com"}
+                  ]
+                }
+              }
+            ]
+          })
+      end
+    end)
+
+    body =
+      rpc(ctx.conn, ctx.raw_key, ctx.conv, ctx.connection, "tools/call", %{
+        "name" => "gmail_search",
+        "arguments" => %{"query" => "newer_than:7d", "max_results" => 3}
+      })
+      |> json_response(200)
+
+    assert body["result"]["isError"] == false, inspect(body)
+    assert [%{"text" => text}] = body["result"]["content"]
+
+    assert %{"threads" => [%{"id" => "t1", "subject" => "Hi", "from" => "a@example.com"}]} =
+             Jason.decode!(text)
+
+    assert_received {:gmail, "/gmail/v1/users/me/threads", q}
+    assert URI.decode_query(q) == %{"q" => "newer_than:7d", "maxResults" => "3"}
+
+    # Gmail wants a multi-valued parameter as a repeated key; a list value
+    # used to raise in URI.encode_query and surface as a 500 (prod, day one).
+    assert_received {:gmail, "/gmail/v1/users/me/threads/t1", q}
+    assert q =~ "metadataHeaders=From&metadataHeaders=To"
+    assert q =~ "format=metadata"
+  end
+
   test "a send is audited as a use of the connection, without the content", ctx do
     Req.Test.stub(Gmail, fn req ->
       assert req.request_path == "/gmail/v1/users/me/messages/send"


### PR DESCRIPTION
Follow-up to #1182, found on the first prod run (#1178).

`gmail_search` answered `Internal Server Error`: `get_thread/3` passed `metadataHeaders` as a list value, which `URI.encode_query/2` refuses (`values cannot be lists`). Gmail wants repeated keys (`metadataHeaders=From&metadataHeaders=To`), and Req's `params` folds a keyword list into a map, so the query is now encoded by hand. Same fix for `labelIds`.

The controller test now walks `gmail_search` → `threads/:id` and asserts the query string, which is what would have caught this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)