### PR TITLE
fix(broker): a refused vault create is checked against the vault list before it fails a prepare

### DIFF
--- a/apps/fountain/lib/fountain/broker.ex
+++ b/apps/fountain/lib/fountain/broker.ex
@@ -699,11 +699,28 @@ defmodule Fountain.Broker do
     end
   end
 
+  # A duplicate name is 409 by the broker's contract, but Agent Vault was
+  # seen answering 500 "Failed to create vault" for one on prod
+  # (2026-08-25), which failed every reattach of a brokered conversation
+  # after its first idle. A refused create is therefore checked against the
+  # vault list before it counts as a failure: the vault we wanted is there,
+  # and that is all `ensure` promises.
   defp ensure_vault(vault) do
     case Req.post(req(), url: "/v1/vaults", json: %{name: vault}) do
-      {:ok, %{status: status}} when status in 200..299 -> :ok
-      {:ok, %{status: 409}} -> :ok
-      other -> {:error, {:broker, :vault, normalize(other)}}
+      {:ok, %{status: status}} when status in 200..299 ->
+        :ok
+
+      {:ok, %{status: 409}} ->
+        :ok
+
+      other ->
+        case list_vaults() do
+          {:ok, names} ->
+            if vault in names, do: :ok, else: {:error, {:broker, :vault, normalize(other)}}
+
+          {:error, _} ->
+            {:error, {:broker, :vault, normalize(other)}}
+        end
     end
   end
 

--- a/apps/fountain/test/fountain/broker_test.exs
+++ b/apps/fountain/test/fountain/broker_test.exs
@@ -240,6 +240,45 @@ defmodule Fountain.BrokerTest do
       assert {:ok, %{token: "t", expires_at: nil}} = Broker.prepare(@conv, %{"GH_TOKEN" => "g"})
     end
 
+    # Agent Vault answered 500 "Failed to create vault" for a duplicate name
+    # on prod (2026-08-25); the contract says 409. The vault list is the
+    # tiebreaker: present means ensured.
+    test "a refused create still counts when the vault is in the list" do
+      vault = Broker.vault_name(@conv)
+
+      stub(Req, :post, fn _req, opts ->
+        case Keyword.fetch!(opts, :url) do
+          "/v1/vaults" -> {:ok, %{status: 500, body: %{"error" => "Failed to create vault"}}}
+          "/v1/credentials" -> {:ok, %{status: 200, body: %{}}}
+          "/v1/sessions" -> {:ok, %{status: 201, body: %{"token" => "t", "expires_at" => "x"}}}
+        end
+      end)
+
+      stub(Req, :get, fn _req, opts ->
+        assert Keyword.fetch!(opts, :url) == "/v1/vaults"
+        {:ok, %{status: 200, body: %{"vaults" => [%{"name" => vault}, %{"name" => "other"}]}}}
+      end)
+
+      stub(Req, :patch, fn _r, _o -> {:ok, %{status: 200, body: %{}}} end)
+      stub(Req, :put, fn _r, _o -> {:ok, %{status: 200, body: %{}}} end)
+
+      assert {:ok, %{token: "t"}} = Broker.prepare(@conv, %{"GH_TOKEN" => "g"})
+    end
+
+    test "a refused create for a vault that is not there is the broker's error" do
+      stub(Req, :post, fn _req, opts ->
+        case Keyword.fetch!(opts, :url) do
+          "/v1/vaults" -> {:ok, %{status: 500, body: %{"error" => "Failed to create vault"}}}
+        end
+      end)
+
+      stub(Req, :get, fn _req, _opts ->
+        {:ok, %{status: 200, body: %{"vaults" => [%{"name" => "other"}]}}}
+      end)
+
+      assert {:error, {:broker, :vault, _}} = Broker.prepare(@conv, %{"GH_TOKEN" => "g"})
+    end
+
     test "GH_TOKEN alone binds the github services to GH_TOKEN" do
       test = self()
 


### PR DESCRIPTION
Found while verifying #1178 on prod: after the first idle, every reattach of a brokered conversation failed with

```
{:broker, :vault, {:api_error, 500, %{"error" => "Failed to create vault"}}}
```

Agent Vault answers **500** to a duplicate vault name (probed directly: fresh name → 201, same name again → 500, name present in `GET /v1/vaults`); the contract, and `ensure_vault/1`, expect 409. Three conversations hit it today, two of them before #1182 deployed, so it is a broker-side regression rather than something the connections work introduced — but it makes the brokered `GOOGLE_ACCESS_TOKEN` path (and every other brokered secret) fail on reattach until the broker is fixed.

`ensure_vault/1` now treats a refused create as "check the list": present means ensured, absent is the broker's error as before. Two tests pin both branches.

Follow-up for the broker itself: the 500 on duplicate should be a 409.

🤖 Generated with [Claude Code](https://claude.com/claude-code)