### PR TITLE
The hosted Fountain is managoat.com (#1177)

### DIFF
--- a/.env.compose.example
+++ b/.env.compose.example
@@ -43,7 +43,7 @@ SPRITES_TOKEN=
 # the time this checkout was cut; set this to upgrade (never to `latest` —
 # it moves under you on every merge). Releases publish vX.Y.Z (immutable)
 # and vX.Y (newest patch in the line) tags:
-# https://fountain.inevitable.fyi/docs/guides/operate/upgrade#how-versions-work
+# https://managoat.com/docs/guides/operate/upgrade#how-versions-work
 FOUNTAIN_IMAGE_TAG=v0.13.0
 
 # Mail. The default (EMAIL_DELIVERY=none) sends nothing; accounts self-verify

--- a/.github/workflows/pages-tombstone.yml
+++ b/.github/workflows/pages-tombstone.yml
@@ -6,7 +6,7 @@
 # drifting further from /docs with every docs PR.
 #
 # So the site becomes a tombstone. Every URL it used to answer still answers
-# and redirects to the same page at https://fountain.inevitable.fyi/docs.
+# and redirects to the same page at https://managoat.com/docs.
 #
 # DELIBERATELY `workflow_dispatch` ONLY. This is not a docs publishing path
 # and must not become one — nothing here reads a page's content, only the nav.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ upgrade, is in
 
 ## [Unreleased]
 
+### Changed
+
+- **The hosted Fountain is `managoat.com`** (#1177). The CLI's and the
+  TypeScript SDK's compile-time default base URL, the docs, the sample
+  compose and k8s files and the hermes plugin now name the new host; the
+  old `fountain.inevitable.fyi` keeps answering and redirects. Self-hosters
+  who set `FOUNTAIN_BASE_URL` are unaffected. SDK 1.8.0 carries the change.
+
 ### Added
 
 - **Connections: sign in to Google once, and agents get Gmail without ever

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ console.log(run.text, run.url);
 
 The sandbox is still there afterwards: `fountain.resume(run.conversationId).send("...")`
 continues on the same machine, with the same checkout and the same session.
-See [`sdk/typescript/`](sdk/typescript/) or the [SDK docs](https://fountain.inevitable.fyi/docs/sdk).
+See [`sdk/typescript/`](sdk/typescript/) or the [SDK docs](https://managoat.com/docs/sdk).
 
 ## Get started with the CLI
 

--- a/apps/fountain/priv/external_skills/fountain/SKILL.md
+++ b/apps/fountain/priv/external_skills/fountain/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fountain
-description: Operate Fountain (https://fountain.inevitable.fyi) — a multi-tenant service that runs sandboxed coding agents (claude/codex/gemini/opencode) inside per-conversation sprites. Use this skill whenever the user asks you to spin up an agent on Fountain, delegate work to another agent, fan out a task across N agents, manage Fountain agents/environments/vaults declaratively, or drive the `fountain` CLI. Reads `FOUNTAIN_API_KEY` (required) and `FOUNTAIN_BASE_URL` (defaults to https://fountain.inevitable.fyi).
+description: Operate Fountain (https://managoat.com) — a multi-tenant service that runs sandboxed coding agents (claude/codex/gemini/opencode) inside per-conversation sprites. Use this skill whenever the user asks you to spin up an agent on Fountain, delegate work to another agent, fan out a task across N agents, manage Fountain agents/environments/vaults declaratively, or drive the `fountain` CLI. Reads `FOUNTAIN_API_KEY` (required) and `FOUNTAIN_BASE_URL` (defaults to https://managoat.com).
 ---
 
 # Fountain — driving the API, CLI, and manifest from outside a sprite
@@ -33,7 +33,7 @@ stream for the final answer.
 Everything under `/api/*` requires `Authorization: Bearer <FOUNTAIN_API_KEY>`.
 
 ```bash
-export FOUNTAIN_BASE_URL=https://fountain.inevitable.fyi
+export FOUNTAIN_BASE_URL=https://managoat.com
 export FOUNTAIN_API_KEY=<key>
 ```
 

--- a/apps/fountain/priv/help/for-llms.md
+++ b/apps/fountain/priv/help/for-llms.md
@@ -14,7 +14,7 @@ Point your agent at Fountain in one command:
 
 ```sh
 mkdir -p ~/.claude/skills/fountain
-curl -fsSL https://fountain.inevitable.fyi/skill > ~/.claude/skills/fountain/SKILL.md
+curl -fsSL https://managoat.com/skill > ~/.claude/skills/fountain/SKILL.md
 ```
 
 Self-hosted instance? Substitute your base URL. The skill text itself reads `$FOUNTAIN_BASE_URL` and `$FOUNTAIN_API_KEY` from the agent's environment, so it's not pinned to one host.

--- a/apps/fountain/priv/help/quickstart.md
+++ b/apps/fountain/priv/help/quickstart.md
@@ -21,7 +21,7 @@ For one-off scripting you can skip the credentials file and export the key direc
 
 ```bash
 export FOUNTAIN_API_KEY=...                        # an API key from `fountain keys create`
-export FOUNTAIN_BASE_URL=http://localhost:4000     # only if not pointing at fountain.inevitable.fyi
+export FOUNTAIN_BASE_URL=http://localhost:4000     # only if not pointing at managoat.com
 ```
 
 ## 2. Create an environment

--- a/apps/fountain/priv/help/spawning.md
+++ b/apps/fountain/priv/help/spawning.md
@@ -2,7 +2,7 @@
 
 Every conversation gets three env vars in its sprite:
 
-- `FOUNTAIN_BASE_URL` — your Fountain server's public URL (e.g. `https://fountain.inevitable.fyi`)
+- `FOUNTAIN_BASE_URL` — your Fountain server's public URL (e.g. `https://managoat.com`)
 - `FOUNTAIN_TOKEN` — an API key the conversation can use to call back
 - `FOUNTAIN_CONVERSATION_ID` — the spawning conversation's UUID, used to record provenance via `X-Fountain-Parent-Conversation-Id`
 

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -7,7 +7,7 @@
 // Base URL precedence:
 //  1. FOUNTAIN_BASE_URL env var
 //  2. base_url from ~/.fountain/credentials (active profile)
-//  3. compile-time default (https://fountain.inevitable.fyi)
+//  3. compile-time default (https://managoat.com)
 package config
 
 import (
@@ -23,7 +23,7 @@ import (
 // the CLI at their own instance (FOUNTAIN_BASE_URL, recorded by `auth login`)
 // before exporting FOUNTAIN_API_KEY — docs/cli.md and docs/self-hosting.md
 // call the footgun out.
-const DefaultBaseURL = "https://fountain.inevitable.fyi"
+const DefaultBaseURL = "https://managoat.com"
 
 // ErrNoAPIKey signals that no API key is configured.
 var ErrNoAPIKey = errors.New("FOUNTAIN_API_KEY is not set. Run `fountain auth login` or export the FOUNTAIN_API_KEY environment variable.")

--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -6,7 +6,7 @@ cluster (CNPG, Traefik, Infisical, Flux) is this baseline plus a private
 overlay that lives outside the repo (decisions/0032); there is no other
 Kubernetes directory here.
 
-The [compose path](https://fountain.inevitable.fyi/docs/self-hosting) is
+The [compose path](https://managoat.com/docs/self-hosting) is
 simpler if you don't already live on Kubernetes — start there.
 
 ## What this does not include
@@ -57,7 +57,7 @@ kubectl exec -n fountain deploy/fountain -- \
 Edit the tag in `kustomization.yaml`'s `images:` block and re-apply. `vX.Y.Z`
 tags are immutable; `vX.Y` follows patches. Patch releases are always safe;
 pre-1.0 minor bumps may carry **Upgrade notes** in the
-[changelog](https://fountain.inevitable.fyi/docs/changelog). Migrations
+[changelog](https://managoat.com/docs/changelog). Migrations
 run at boot, idempotently, under an advisory lock. Downgrades are not
 supported once a newer version's migrations have run — restore from a backup.
 
@@ -124,6 +124,6 @@ needs the new column.
 - **Backups**: `backup-cronjob.yaml` ships a nightly `pg_dump` to any
   S3-compatible bucket — commented out of `kustomization.yaml` until you
   create its secret; setup is at the top of the file, the restore drill in
-  [the docs](https://fountain.inevitable.fyi/docs/guides/operate/back-up-and-restore).
+  [the docs](https://managoat.com/docs/guides/operate/back-up-and-restore).
   `MASTER_SECRETS_KEY` must still be backed up separately — a database backup
   alone cannot decrypt itself.

--- a/deploy/k8s/backup-cronjob.yaml
+++ b/deploy/k8s/backup-cronjob.yaml
@@ -25,7 +25,7 @@
 # truncated one looking valid.
 #
 # A backup nobody has restored is a hypothesis. The restore drill:
-# https://fountain.inevitable.fyi/docs/guides/operate/back-up-and-restore
+# https://managoat.com/docs/guides/operate/back-up-and-restore
 #
 # And the standing rule: a database backup alone cannot decrypt itself.
 # MASTER_SECRETS_KEY is backed up separately, and a restore needs the same

--- a/deploy/k8s/kustomization.yaml
+++ b/deploy/k8s/kustomization.yaml
@@ -25,6 +25,6 @@ resources:
 images:
   # Pin a release, not `latest` — `latest` moves on every merge to main.
   # Released tags: vX.Y.Z (immutable) and vX.Y (newest patch in the line).
-  # https://fountain.inevitable.fyi/docs/guides/operate/upgrade#how-versions-work
+  # https://managoat.com/docs/guides/operate/upgrade#how-versions-work
   - name: ghcr.io/binarybourbon/fountain
     newTag: v0.13.0

--- a/deploy/k8s/prometheusrule.yaml
+++ b/deploy/k8s/prometheusrule.yaml
@@ -14,8 +14,8 @@
 # them just doubles the paging.
 #
 # Every alert says what it means and what to do. The symptom → component map
-# is https://fountain.inevitable.fyi/docs/architecture and the actions
-# are https://fountain.inevitable.fyi/docs/operations.
+# is https://managoat.com/docs/architecture and the actions
+# are https://managoat.com/docs/operations.
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -187,7 +187,7 @@ spec:
               Likely causes, in the order to check them: SPRITES_TOKEN invalid
               or rate-limited, the Sprites API unhealthy, or tenants at their
               concurrency cap. Triage:
-              https://fountain.inevitable.fyi/docs/troubleshooting/sandbox-errors
+              https://managoat.com/docs/troubleshooting/sandbox-errors
 
         - alert: FountainProvisionDeadlineExceeded
           # The provision watchdog (#329) declared a provision wedged and

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -165,7 +165,7 @@ services:
   # against bad migrations and fat fingers, not a dead machine — copy dumps
   # off-host too, and back up MASTER_SECRETS_KEY separately: a database
   # backup alone cannot decrypt itself. Restore drill:
-  # https://fountain.inevitable.fyi/docs/guides/operate/back-up-and-restore
+  # https://managoat.com/docs/guides/operate/back-up-and-restore
   backup:
     image: postgres:16
     profiles: ["backup"]

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -349,7 +349,7 @@ one section for each profile. It writes each value in double quotes.
 ```ini
 [default]
 api_key = "ftn_..."
-base_url = "https://fountain.inevitable.fyi"
+base_url = "https://managoat.com"
 ```
 
 The CLI writes the file `0600`, and the directory `0700`.
@@ -370,12 +370,12 @@ FOUNTAIN_API_KEY=ftn_... FOUNTAIN_BASE_URL=https://other.example.com fountain ag
 The CLI resolves both the key and the URL in the same order. It reads the
 environment variable, then the active profile in the credentials file. For the
 URL alone it then falls back to the built-in default,
-`https://fountain.inevitable.fyi`.
+`https://managoat.com`.
 
 **Do you self-host?** That built-in default is the hosted instance, and not
 yours.
 
 Run `fountain auth login` with `FOUNTAIN_BASE_URL` pointed at your instance.
 Do that first, before each other command. A CLI with no config, and `FOUNTAIN_API_KEY`
-exported, sends that key to `fountain.inevitable.fyi`. Configure the URL
+exported, sends that key to `managoat.com`. Configure the URL
 before the key.

--- a/docs/guides/operate/upgrade.md
+++ b/docs/guides/operate/upgrade.md
@@ -61,7 +61,7 @@ The CLI and the server come from the same tag. The two versions that match are
 the pair we test.
 
 The CLI's built-in default `base_url` is the hosted instance,
-`https://fountain.inevitable.fyi`, and not yours. Point it at your instance
+`https://managoat.com`, and not yours. Point it at your instance
 before you export an API key. Otherwise the first command you run without a
 config sends that key to the hosted domain.
 

--- a/integrations/hermes/fountain/client.py
+++ b/integrations/hermes/fountain/client.py
@@ -22,7 +22,7 @@ import urllib.request
 from pathlib import Path
 from typing import Any
 
-DEFAULT_BASE_URL = "https://fountain.inevitable.fyi"
+DEFAULT_BASE_URL = "https://managoat.com"
 USER_AGENT = "hermes-fountain-plugin/0.1.0"
 
 

--- a/integrations/hermes/fountain/plugin.yaml
+++ b/integrations/hermes/fountain/plugin.yaml
@@ -19,7 +19,7 @@ config_schema:
   base_url:
     type: str
     default: ""
-    description: Fountain instance URL. Falls back to FOUNTAIN_BASE_URL, then ~/.fountain/credentials, then https://fountain.inevitable.fyi.
+    description: Fountain instance URL. Falls back to FOUNTAIN_BASE_URL, then ~/.fountain/credentials, then https://managoat.com.
   api_key:
     type: str
     default: ""

--- a/integrations/hermes/tests/test_plugin.py
+++ b/integrations/hermes/tests/test_plugin.py
@@ -101,7 +101,7 @@ class SettingsTests(unittest.TestCase):
 
     def test_no_key_anywhere(self):
         self.creds.unlink()
-        self.assertEqual(resolve_settings(), ("https://fountain.inevitable.fyi", ""))
+        self.assertEqual(resolve_settings(), ("https://managoat.com", ""))
         with self.assertRaises(FountainError):
             FountainClient("https://x", "")
 

--- a/scripts/build-pages-tombstone.py
+++ b/scripts/build-pages-tombstone.py
@@ -8,7 +8,7 @@ stale, drifting further from `/docs` with every docs PR.
 
 This builds a site of redirects instead. Every URL the old site answered keeps
 answering, and sends the reader to the same page at
-https://fountain.inevitable.fyi/docs. It is published once, by hand, from
+https://managoat.com/docs. It is published once, by hand, from
 `.github/workflows/pages-tombstone.yml`.
 
 MkDocs served directory URLs, so `setup.md` was `/fountain/setup/` and
@@ -28,7 +28,7 @@ import sys
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 NAV = ROOT / "docs" / "nav.yml"
-DOCS = "https://fountain.inevitable.fyi/docs"
+DOCS = "https://managoat.com/docs"
 
 # The two line shapes docs/nav.yml uses, same as the Elixir parser. A page
 # entry at any indent; a section header carries no file and is skipped.

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -10,6 +10,15 @@ server releases.
 
 ---
 
+## [1.8.0] — 2026-08-25
+
+### Changed
+
+- `DEFAULT_BASE_URL` is `https://managoat.com`, the hosted Fountain's new
+  domain (fountain#1177). The old host redirects, so an SDK pinned before
+  this release keeps working; set `baseUrl` explicitly for a self-hosted
+  instance either way.
+
 ## [1.7.0] — 2026-08-25
 
 ### Added

--- a/sdk/typescript/examples/chat.ts
+++ b/sdk/typescript/examples/chat.ts
@@ -6,7 +6,7 @@
  * Every piece here is what a roster-and-threads UI actually needs: a roster
  * row, a live router for the team's one connection, and a transcript folded
  * out of server-parsed blocks. The docs walk through it at
- * https://fountain.inevitable.fyi/docs/build/team-chat — this file is the
+ * https://managoat.com/docs/build/team-chat — this file is the
  * copy CI typechecks, so the page cannot drift from the SDK.
  *
  * Creates a temporary agent and removes everything on the way out.

--- a/sdk/typescript/examples/pull-request.ts
+++ b/sdk/typescript/examples/pull-request.ts
@@ -11,7 +11,7 @@
  * Everything it creates — environment, vault, agent, sandbox — is deleted on
  * the way out, including when a step throws.
  *
- * Walkthrough: https://fountain.inevitable.fyi/docs/tour
+ * Walkthrough: https://managoat.com/docs/tour
  *
  * (Inside this repository the import below resolves to the SDK itself, so run
  * `npm run build` in sdk/typescript first. Installed from npm it just works.)

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentshit/fountain-sdk",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Run a coding agent on a real computer, with your repos and your credentials, in one call.",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/sdk/typescript/src/config.ts
+++ b/sdk/typescript/src/config.ts
@@ -1,4 +1,4 @@
-export const DEFAULT_BASE_URL = "https://fountain.inevitable.fyi";
+export const DEFAULT_BASE_URL = "https://managoat.com";
 
 /** Where a human reads a transcript. Fountain's own UI is a console (see CLAUDE.md). */
 export const DEFAULT_APP_URL = "https://jakegaylor.com/fountain-conversations/";

--- a/sdk/typescript/src/http.ts
+++ b/sdk/typescript/src/http.ts
@@ -19,7 +19,7 @@ export interface RequestOptions {
  * this string is already what Fountain's request logs are keyed on. The
  * version half is asserted against `package.json` by a test.
  */
-export const USER_AGENT = "fountain-sdk-js/1.7.0";
+export const USER_AGENT = "fountain-sdk-js/1.8.0";
 
 /**
  * The thin layer everything else is built on: one bearer token, JSON in and


### PR DESCRIPTION
Part of #1177 (repo half). **Do not merge before the home-cloud flip PR is live** — merging publishes SDK 1.8.0 with `DEFAULT_BASE_URL = https://managoat.com`, and the CLI's next release picks up `DefaultBaseURL`.

- `sdk/typescript/src/config.ts`, `cli/internal/config/config.go`, `integrations/hermes/fountain/client.py`: default base URL → `https://managoat.com`
- SDK 1.7.0 → 1.8.0 (`package.json`, lock, `USER_AGENT`, SDK CHANGELOG)
- docs, README, `.env.compose.example`, `docker-compose.yml`, `deploy/k8s/*`, `priv/help/*`, the external skill, the pages-tombstone script: doc links → new host
- `CHANGELOG.md` Unreleased entry; historical entries and `decisions/0032` untouched on purpose
- Test fixtures in `public_url_test.exs` keep the old host as an arbitrary example

Checks run locally: `go test ./...` (0 FAIL), SDK `npm test` (73 pass), `sdk-release.mjs guard` well-formed, hermes 19 pass, `docs_test.exs` 29/0, docs-style and vale clean, `mix format`.

Note: `scripts/build-pages-tombstone.py` now redirects the github.io URLs straight to the new host; re-run `pages-tombstone.yml` after the flip if you want to skip the double hop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)