### PR TITLE
docs: drop the MIT-through-v0.12.0 history from the README and the open-source page

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,9 +198,8 @@ Fountain. The long form of the split, and where everything lives, is
 (`decisions/0034-project-site-is-the-product-site.md` says why there is no
 separate project site).
 
-Fountain was MIT licensed through v0.12.0 (2026-08-17) and those releases stay
-MIT. See [`NOTICE`](NOTICE) for the relicensing record and third-party
-attribution, [`CONTRIBUTING.md`](CONTRIBUTING.md) for how this applies to
+See [`NOTICE`](NOTICE) for third-party attribution,
+[`CONTRIBUTING.md`](CONTRIBUTING.md) for how the licences apply to
 contributions, and
 [`decisions/0027-agpl-relicensing.md`](decisions/0027-agpl-relicensing.md) for
 the reasoning.

--- a/docs/open-source.md
+++ b/docs/open-source.md
@@ -29,10 +29,9 @@ service owes those improvements to everyone else who runs it. The licence does
 not stop a commercial host, in competition with Managoat or not. It stops a
 private one.
 
-Fountain was MIT through v0.12.0 (2026-08-17), and those releases stay MIT.
 The
 [NOTICE](https://github.com/BinaryBourbon/fountain/blob/main/NOTICE) file
-holds the relicence record and the third-party attribution.
+holds the third-party attribution.
 
 ## Where things live
 


### PR DESCRIPTION
NOTICE and ADR 0027 keep the record; the front pages no longer need it.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
