### PR TITLE
feat(brand): BRAND_ASSETS_URL serves the icon, favicons and card from any static host

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -130,6 +130,13 @@ SPRITES_TOKEN=
 # manual page opens with a line explaining the split. Default: Fountain.
 # PRODUCT_NAME=Managoat
 
+# Where this deployment's brand assets are served from: a directory holding
+# app-icon.png, apple-touch-icon.png, favicon-32x32.png, favicon-16x16.png,
+# favicon.ico and og-card.png (1200x630), on any static host. Unset, the
+# engine's own files ship in the image. The origin is added to the CSP's
+# img-src. Must be an absolute http(s) URL; a trailing slash is ignored.
+# BRAND_ASSETS_URL=https://assets.example.com/brand
+
 # ── Legal pages ──────────────────────────────────────────────────────────────
 
 # The legal identity /terms and /privacy render — yours, not the Fountain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ upgrade, is in
 
 ## [Unreleased]
 
+### Added
+
+- **`BRAND_ASSETS_URL`.** A deployment can serve its own app icon, favicons
+  and Open Graph card from any static host instead of the files in the
+  release image: point the variable at a directory holding the six files
+  `Fountain.Brand.assets/0` names and the chrome links them, the card
+  unfurls with them and the CSP admits the origin on `img-src`. Unset,
+  nothing changes. Changing a brand's pixels no longer means rebuilding the
+  engine.
+
 ## [0.14.0] — 2026-08-25
 
 ### Upgrade notes

--- a/apps/fountain/lib/fountain/brand.ex
+++ b/apps/fountain/lib/fountain/brand.ex
@@ -42,4 +42,78 @@ defmodule Fountain.Brand do
   @doc "True when the deployment is branded as something other than the engine."
   @spec hosted?() :: boolean()
   def hosted?, do: name() != @engine
+
+  # The files a brand supplies, and nothing else: the console header and the
+  # marketing chrome use the app icon, the root layout links the favicons and
+  # the touch icon, and every Open Graph card carries the 1200×630 card. The
+  # names are fixed so that a bundle is a directory with these six files in
+  # it, whatever brand it is for.
+  @assets ~w(app-icon.png apple-touch-icon.png favicon-32x32.png favicon-16x16.png favicon.ico og-card.png)
+
+  @doc "The six files a brand asset bundle holds."
+  @spec assets() :: [String.t()]
+  def assets, do: @assets
+
+  @doc """
+  The base URL of this deployment's brand assets (`BRAND_ASSETS_URL`, no
+  trailing slash), or `nil` when the deployment uses the built-in files.
+
+  The icon and the card are pixels, and pixels do not belong in an env var
+  the way a name does — but they do not belong in the release image either,
+  where swapping them means a rebuild of the engine for a change to the
+  chrome. A hosted deployment points this at a directory it serves (any
+  static host will do) holding `assets/0`; the engine's own files stay the
+  default for everyone else.
+  """
+  @spec assets_url() :: String.t() | nil
+  def assets_url do
+    case Application.get_env(:fountain, :brand_assets_url) do
+      value when is_binary(value) ->
+        case String.trim(value) do
+          "" -> nil
+          trimmed -> String.trim_trailing(trimmed, "/")
+        end
+
+      _ ->
+        nil
+    end
+  end
+
+  @doc """
+  Where one of `assets/0` is served from: an absolute URL under
+  `assets_url/0` when a bundle is configured, else the built-in path the
+  release serves from `priv/static`.
+  """
+  @spec asset(String.t()) :: String.t()
+  def asset(name) when name in @assets do
+    case assets_url() do
+      nil -> builtin(name)
+      base -> base <> "/" <> name
+    end
+  end
+
+  @doc """
+  The origin a brand bundle is served from, for the CSP's `img-src`, or `nil`
+  when the built-in files (same origin) are in use.
+  """
+  @spec assets_origin() :: String.t() | nil
+  def assets_origin do
+    case assets_url() do
+      nil ->
+        nil
+
+      base ->
+        case URI.parse(base) do
+          %URI{scheme: scheme, host: host, port: port} when is_binary(host) ->
+            origin = "#{scheme}://#{host}"
+            if port in [nil, URI.default_port(scheme)], do: origin, else: "#{origin}:#{port}"
+
+          _ ->
+            nil
+        end
+    end
+  end
+
+  defp builtin("favicon.ico"), do: "/favicon.ico"
+  defp builtin(name), do: "/images/" <> name
 end

--- a/apps/fountain/lib/fountain_web/components/layouts.ex
+++ b/apps/fountain/lib/fountain_web/components/layouts.ex
@@ -48,7 +48,7 @@ defmodule FountainWeb.Layouts do
           <%!-- Sidebar header --%>
           <div class="flex items-center justify-between p-4 border-b border-[var(--color-border)] shrink-0">
             <.link href={~p"/dashboard"} class="flex items-center gap-2">
-              <img src="/images/app-icon.png" alt="" class="size-7 rounded-md" />
+              <img src={Fountain.Brand.asset("app-icon.png")} alt="" class="size-7 rounded-md" />
               <span class="font-semibold text-sm text-[var(--color-text-primary)]">
                 {Fountain.Brand.name()}
               </span>

--- a/apps/fountain/lib/fountain_web/components/layouts/marketing.html.heex
+++ b/apps/fountain/lib/fountain_web/components/layouts/marketing.html.heex
@@ -3,7 +3,7 @@
   <header class="border-b border-[var(--color-border)] bg-[var(--color-bg-0)]">
     <div class="max-w-5xl mx-auto px-6 py-4 flex items-center justify-between">
       <a href="/" class="flex items-center gap-2">
-        <img src="/images/app-icon.png" alt="" class="size-7 rounded-md" />
+        <img src={Fountain.Brand.asset("app-icon.png")} alt="" class="size-7 rounded-md" />
         <span class="font-semibold text-sm text-[var(--color-text-primary)]">
           {Fountain.Brand.name()}
         </span>

--- a/apps/fountain/lib/fountain_web/components/layouts/root.html.heex
+++ b/apps/fountain/lib/fountain_web/components/layouts/root.html.heex
@@ -31,10 +31,24 @@
     <meta name="twitter:title" content={FountainWeb.OpenGraph.title(assigns)} />
     <meta name="twitter:description" content={FountainWeb.OpenGraph.description(assigns)} />
     <meta name="twitter:image" content={FountainWeb.OpenGraph.image()} />
-    <link rel="icon" href="/favicon.ico" sizes="any" />
-    <link rel="icon" type="image/png" sizes="32x32" href="/images/favicon-32x32.png" />
-    <link rel="icon" type="image/png" sizes="16x16" href="/images/favicon-16x16.png" />
-    <link rel="apple-touch-icon" sizes="180x180" href="/images/apple-touch-icon.png" />
+    <link rel="icon" href={Fountain.Brand.asset("favicon.ico")} sizes="any" />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href={Fountain.Brand.asset("favicon-32x32.png")}
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href={Fountain.Brand.asset("favicon-16x16.png")}
+    />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href={Fountain.Brand.asset("apple-touch-icon.png")}
+    />
     <%!--
       PostHog, on the public surface only — the landing and legal pages, the
       manual and the auth flow. `FountainWeb.Plugs.WebAnalytics` sets this

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/instance.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/instance.html.heex
@@ -5,7 +5,11 @@
 --%>
 <section class="max-w-xl mx-auto px-6 py-24">
   <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-1)] p-8 text-center">
-    <img src="/images/app-icon.png" alt="" class="size-12 rounded-xl mx-auto mb-5" />
+    <img
+      src={Fountain.Brand.asset("app-icon.png")}
+      alt=""
+      class="size-12 rounded-xl mx-auto mb-5"
+    />
     <h1 class="text-2xl font-semibold tracking-tight text-[var(--color-text-primary)] mb-3">
       {Fountain.Brand.name()}
     </h1>

--- a/apps/fountain/lib/fountain_web/csp.ex
+++ b/apps/fountain/lib/fountain_web/csp.ex
@@ -1,0 +1,54 @@
+defmodule FountainWeb.CSP do
+  @moduledoc """
+  Widens the `content-security-policy` header the `:browser` pipeline sets
+  with origins that are only known at runtime.
+
+  `FountainWeb.Router`'s `@csp` is a compile-time attribute, so anything read
+  from the environment in `config/runtime.exs` cannot appear in it: a release
+  would carry whatever the *build* saw, which is nothing. Two plugs widen it
+  per response instead — `FountainWeb.Plugs.WebAnalytics` for the PostHog
+  origins on the public pages, `FountainWeb.Plugs.BrandAssets` for the origin
+  a brand bundle is served from — and both go through here so the header has
+  one rewriter.
+  """
+
+  import Plug.Conn
+
+  @doc """
+  Appends `origins` to each of the named `directives` of the response's
+  policy. A response with no policy is returned untouched: adding one here
+  would be inventing a second source of truth for a header the `:browser`
+  pipeline owns.
+  """
+  @spec widen(Plug.Conn.t(), [String.t()], [String.t()]) :: Plug.Conn.t()
+  def widen(conn, _directives, []), do: conn
+
+  def widen(conn, directives, origins) do
+    case get_resp_header(conn, "content-security-policy") do
+      [csp | _] ->
+        put_resp_header(conn, "content-security-policy", widen_policy(csp, directives, origins))
+
+      [] ->
+        conn
+    end
+  end
+
+  defp widen_policy(csp, directives, origins) do
+    csp
+    |> String.split(";")
+    |> Enum.map_join("; ", &widen_directive(String.trim(&1), directives, origins))
+  end
+
+  defp widen_directive(directive, directives, origins) do
+    [name | sources] = String.split(directive, " ")
+
+    if name in directives do
+      # `--` rather than a blind append: the header is rewritten on every
+      # response, and a proxy or a future plug that has already added one of
+      # these origins must not make the directive grow each time.
+      Enum.join([directive | origins -- sources], " ")
+    else
+      directive
+    end
+  end
+end

--- a/apps/fountain/lib/fountain_web/open_graph.ex
+++ b/apps/fountain/lib/fountain_web/open_graph.ex
@@ -54,9 +54,17 @@ defmodule FountainWeb.OpenGraph do
   def url(%Plug.Conn{request_path: path}), do: public_url() <> path
   def url(_), do: public_url()
 
-  @doc "Absolute URL of the card image."
+  @doc """
+  Absolute URL of the card image: the brand bundle's card when
+  `BRAND_ASSETS_URL` is set, else the built-in one under `:public_url`.
+  """
   @spec image() :: String.t()
-  def image, do: public_url() <> @image_path
+  def image do
+    case Fountain.Brand.assets_url() do
+      nil -> public_url() <> @image_path
+      _ -> Fountain.Brand.asset("og-card.png")
+    end
+  end
 
   defp public_url do
     Fountain.PublicUrl.absolute(Application.get_env(:fountain, :public_url))

--- a/apps/fountain/lib/fountain_web/plugs/brand_assets.ex
+++ b/apps/fountain/lib/fountain_web/plugs/brand_assets.ex
@@ -1,0 +1,25 @@
+defmodule FountainWeb.Plugs.BrandAssets do
+  @moduledoc """
+  Lets the browser load the brand's icon and card from `BRAND_ASSETS_URL`.
+
+  The `:browser` pipeline's policy allows images from `'self'` and `data:`
+  only, which is right for the built-in files. A deployment that serves its
+  bundle from another origin (`Fountain.Brand.assets_url/0`) needs that origin
+  on `img-src`, and for the reason `FountainWeb.CSP` gives it is added here at
+  runtime rather than in the router's attribute. With no bundle configured
+  the header is untouched.
+  """
+
+  @behaviour Plug
+
+  @impl Plug
+  def init(opts), do: opts
+
+  @impl Plug
+  def call(conn, _opts) do
+    case Fountain.Brand.assets_origin() do
+      nil -> conn
+      origin -> FountainWeb.CSP.widen(conn, ["img-src"], [origin])
+    end
+  end
+end

--- a/apps/fountain/lib/fountain_web/plugs/web_analytics.ex
+++ b/apps/fountain/lib/fountain_web/plugs/web_analytics.ex
@@ -93,36 +93,6 @@ defmodule FountainWeb.Plugs.WebAnalytics do
     end
   end
 
-  defp allow_posthog(conn, []), do: conn
-
-  defp allow_posthog(conn, origins) do
-    case Plug.Conn.get_resp_header(conn, "content-security-policy") do
-      [csp | _] ->
-        Plug.Conn.put_resp_header(conn, "content-security-policy", widen(csp, origins))
-
-      # No policy to widen. Adding one here would be inventing a second source
-      # of truth for a header the :browser pipeline owns.
-      [] ->
-        conn
-    end
-  end
-
-  defp widen(csp, origins) do
-    csp
-    |> String.split(";")
-    |> Enum.map_join("; ", &widen_directive(String.trim(&1), origins))
-  end
-
-  defp widen_directive(directive, origins) do
-    case String.split(directive, " ") do
-      [name | sources] when name in @widened ->
-        # `--` rather than a blind append: the header is rewritten on every
-        # public response, and a proxy or a future plug that has already added
-        # one of these origins must not make the directive grow each time.
-        Enum.join([directive | origins -- sources], " ")
-
-      _ ->
-        directive
-    end
-  end
+  defp allow_posthog(conn, origins),
+    do: FountainWeb.CSP.widen(conn, @widened, origins)
 end

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -73,6 +73,9 @@ defmodule FountainWeb.Router do
     plug :put_root_layout, html: {FountainWeb.Layouts, :root}
     plug :protect_from_forgery
     plug :put_secure_browser_headers, %{"content-security-policy" => @csp}
+    # After the policy is set: widens img-src with the brand bundle's origin
+    # (BRAND_ASSETS_URL), which is read at runtime and so cannot be in @csp.
+    plug FountainWeb.Plugs.BrandAssets
     # After :fetch_session — it reads the session on both sides of the
     # request to spot a sign-in. On every browser route on purpose: the merge
     # has to happen wherever a session is established, and five controllers do

--- a/apps/fountain/test/fountain/brand_test.exs
+++ b/apps/fountain/test/fountain/brand_test.exs
@@ -5,15 +5,18 @@ defmodule Fountain.BrandTest do
 
   setup do
     previous = Application.get_env(:fountain, :product_name)
+    previous_assets = Application.get_env(:fountain, :brand_assets_url)
 
     on_exit(fn ->
-      if previous,
-        do: Application.put_env(:fountain, :product_name, previous),
-        else: Application.delete_env(:fountain, :product_name)
+      restore(:product_name, previous)
+      restore(:brand_assets_url, previous_assets)
     end)
 
     :ok
   end
+
+  defp restore(key, nil), do: Application.delete_env(:fountain, key)
+  defp restore(key, value), do: Application.put_env(:fountain, key, value)
 
   test "unset or blank falls back to the engine, which is never hosted" do
     Application.delete_env(:fountain, :product_name)
@@ -30,5 +33,39 @@ defmodule Fountain.BrandTest do
     assert Brand.name() == "Managoat"
     assert Brand.engine() == "Fountain"
     assert Brand.hosted?()
+  end
+
+  test "without a bundle the assets are the built-in files, on the same origin" do
+    Application.delete_env(:fountain, :brand_assets_url)
+    assert Brand.assets_url() == nil
+    assert Brand.assets_origin() == nil
+    assert Brand.asset("favicon.ico") == "/favicon.ico"
+    assert Brand.asset("app-icon.png") == "/images/app-icon.png"
+    assert Brand.asset("og-card.png") == "/images/og-card.png"
+
+    Application.put_env(:fountain, :brand_assets_url, "  ")
+    assert Brand.assets_url() == nil
+    assert Brand.asset("app-icon.png") == "/images/app-icon.png"
+  end
+
+  test "a bundle URL is trimmed, its trailing slash dropped, and every asset resolved under it" do
+    Application.put_env(:fountain, :brand_assets_url, " https://cdn.example.com:8443/brand/ ")
+    assert Brand.assets_url() == "https://cdn.example.com:8443/brand"
+    assert Brand.assets_origin() == "https://cdn.example.com:8443"
+    assert Brand.asset("favicon.ico") == "https://cdn.example.com:8443/brand/favicon.ico"
+    assert Brand.asset("og-card.png") == "https://cdn.example.com:8443/brand/og-card.png"
+
+    for name <- Brand.assets() do
+      assert Brand.asset(name) == "https://cdn.example.com:8443/brand/" <> name
+    end
+  end
+
+  test "the origin omits a default port" do
+    Application.put_env(:fountain, :brand_assets_url, "https://cdn.example.com:443/brand")
+    assert Brand.assets_origin() == "https://cdn.example.com"
+  end
+
+  test "only the six bundle files resolve" do
+    assert_raise FunctionClauseError, fn -> Brand.asset("logo.svg") end
   end
 end

--- a/apps/fountain/test/fountain_web/brand_chrome_test.exs
+++ b/apps/fountain/test/fountain_web/brand_chrome_test.exs
@@ -70,4 +70,57 @@ defmodule FountainWeb.BrandChromeTest do
     refute html =~ ~s(data-role="brand-note")
     assert html =~ ~r/>\s*Fountain\s*<\/span>/
   end
+
+  describe "BRAND_ASSETS_URL" do
+    setup do
+      previous = Application.get_env(:fountain, :brand_assets_url)
+      Application.put_env(:fountain, :brand_assets_url, "https://cdn.example.com/brand")
+
+      on_exit(fn ->
+        if previous,
+          do: Application.put_env(:fountain, :brand_assets_url, previous),
+          else: Application.delete_env(:fountain, :brand_assets_url)
+      end)
+
+      :ok
+    end
+
+    test "the chrome, the favicons and the card come from the bundle", %{conn: conn} do
+      conn = get(conn, ~p"/")
+      html = html_response(conn, 200)
+      assert html =~ ~s(src="https://cdn.example.com/brand/app-icon.png")
+      assert html =~ ~s(href="https://cdn.example.com/brand/favicon.ico")
+      assert html =~ ~s(href="https://cdn.example.com/brand/favicon-32x32.png")
+      assert html =~ ~s(href="https://cdn.example.com/brand/favicon-16x16.png")
+      assert html =~ ~s(href="https://cdn.example.com/brand/apple-touch-icon.png")
+
+      assert html =~
+               ~s(<meta property="og:image" content="https://cdn.example.com/brand/og-card.png")
+
+      assert html =~
+               ~s(<meta name="twitter:image" content="https://cdn.example.com/brand/og-card.png")
+
+      refute html =~ "/images/app-icon.png"
+      refute html =~ "/images/og-card.png"
+    end
+
+    test "the console header uses the bundle too", %{conn: conn} do
+      user = Fountain.Factory.insert_verified_user()
+      html = conn |> login_user(user) |> get(~p"/dashboard") |> html_response(200)
+      assert html =~ ~s(src="https://cdn.example.com/brand/app-icon.png")
+    end
+
+    test "the CSP admits the bundle's origin on img-src, once, and nowhere else", %{conn: conn} do
+      [csp] = conn |> get(~p"/") |> get_resp_header("content-security-policy")
+      assert csp =~ "img-src 'self' data: https://cdn.example.com"
+      refute csp =~ "script-src 'self' 'unsafe-inline' https://cdn.example.com"
+      assert length(String.split(csp, "https://cdn.example.com")) == 2
+    end
+  end
+
+  test "without a bundle the CSP is untouched", %{conn: conn} do
+    Application.delete_env(:fountain, :brand_assets_url)
+    [csp] = conn |> get(~p"/") |> get_resp_header("content-security-policy")
+    assert csp =~ "img-src 'self' data:;"
+  end
 end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -433,6 +433,26 @@ case System.get_env("PRODUCT_NAME") do
   value -> config :fountain, :product_name, String.trim(value)
 end
 
+# Where the brand's icon, favicons and Open Graph card are served from
+# (Fountain.Brand.assets/0 names the six files). Unset, the release serves the
+# engine's own files from priv/static; set, the chrome links this directory
+# instead and the CSP's img-src admits its origin. Pixels do not belong in an
+# env var, and rebuilding the engine to change the chrome's icon is the wrong
+# size of change, so the bundle lives on any static host and this points at it.
+case System.get_env("BRAND_ASSETS_URL") do
+  nil ->
+    :ok
+
+  value ->
+    trimmed = value |> String.trim() |> String.trim_trailing("/")
+
+    if trimmed != "" and not String.starts_with?(trimmed, ["http://", "https://"]) do
+      raise "BRAND_ASSETS_URL must be an absolute http(s) URL, got: #{inspect(value)}"
+    end
+
+    config :fountain, :brand_assets_url, trimmed
+end
+
 # Which page `/` serves. The hosted deployment shows the product pitch; every
 # other deployment shows a plain front door, for the reason a self-hosted
 # instance does not serve the upstream project's legal terms either. Off by

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -175,6 +175,7 @@ Your deployment is not the Fountain project, so the front door is the default.
 | Variable | Default | Required | Effect |
 |---|---|---|---|
 | `PRODUCT_NAME` | `Fountain` | — | The name the console, the sign-in page, the OAuth consent screen and each email subject use for this deployment. Set it when you sell a hosted deployment under a different brand. The CLI, the API and this manual keep the name Fountain, because that is the name of the engine. When the two differ, each manual page opens with one line that says so. |
+| `BRAND_ASSETS_URL` | unset | — | The URL of the directory with the brand's image files. The directory must contain six files. They are `app-icon.png`, `apple-touch-icon.png`, `favicon-32x32.png`, `favicon-16x16.png`, `favicon.ico` and `og-card.png` (1200 by 630 pixels). Unset, the pages use the files in the release image. Set, the pages link the files in this directory, and the CSP permits images from its origin. The value must be an absolute URL. |
 | `MARKETING_SITE` | `false` | — | A `true` serves the Fountain project's product page at `/`. It also puts the project's copyright line in the footer. Turn it on only if you operate the project's own site. |
 
 ## Legal pages


### PR DESCRIPTION
`PRODUCT_NAME` brands the chrome's words; the pixels were still baked into the release image, so changing a hosted deployment's icon meant rebuilding the engine.

- `Fountain.Brand.asset/1` resolves the six brand files (`app-icon.png`, `apple-touch-icon.png`, `favicon-32x32.png`, `favicon-16x16.png`, `favicon.ico`, `og-card.png`) against `BRAND_ASSETS_URL` when set, else the built-in `/images` paths. The root layout, the console and marketing headers, the instance front door and `FountainWeb.OpenGraph` go through it.
- `FountainWeb.Plugs.BrandAssets` widens the CSP `img-src` with the bundle's origin at runtime (the router's `@csp` is compile-time). The widening helper moves out of `WebAnalytics` into `FountainWeb.CSP` so the header has one rewriter.
- `config/runtime.exs` validates the value is an absolute http(s) URL; docs row, `.env.example` and CHANGELOG added.
- Unset, nothing changes: the engine's own files ship in the image as before.

Deployment side: the Managoat bundle is in the share bucket at `https://share.files.inevitable.fyi/managoat/brand/v1/` and jhgaylor/home-cloud#137 sets the variable.

Tests: `Fountain.BrandTest` (+4), `FountainWeb.BrandChromeTest` (+4: chrome, console header, CSP once-and-only-img-src, untouched without a bundle); docs/config-reference guards green; `vale lint docs` and `docs-style.py` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)