### PR TITLE
fix(provision): retry the runtime config write, and fail cleanly if it still cannot land

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,17 @@ upgrade, is in
 
 ### Fixed
 
+- **A transient Sprites timeout while writing the runtime's config no longer
+  fails the conversation.** The first filesystem call into a freshly created
+  sprite timed out once in prod (`Req.TransportError{reason: :timeout}`) and
+  `Claude.write_config/2` crashed on it, marking the sandbox and conversation
+  `failed` at the very step the provision `with` had marked best-effort. The
+  `.mcp.json` and settings writes (and gemini's) are idempotent and now retry
+  through `Fountain.Retry` like every other sandbox write; a write that still
+  fails returns `{:error, {:runtime_config, path, reason}}`, which the fresh
+  provision treats as a real failure (an agent must not run without its MCP
+  servers under a `provision/done`) and the wake path logs and continues.
+
 - **Brokered sandboxes now trust the egress broker's MITM certificate across
   the Python and Rust toolchains, not only Node.** A brokered `uv sync`,
   `uv python install`, `pip install` or `cargo fetch` failed with

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -823,7 +823,10 @@ defmodule Fountain.Conversations.ConversationServer do
         # because nothing dials out without it (ADR 0019 gate 1a).
         with {:ok, state} <- broker_prepare(state),
              sprite_env = build_sprite_env(state, agent, env, secrets, sandbox_url),
-             _ =
+             # A real step, not best effort: an agent whose MCP servers could
+             # not be written would otherwise run without them and report
+             # `provision/done`. The runtimes retry the write themselves.
+             :ok <-
                write_runtime_config(
                  handle,
                  state.runtime_module,
@@ -1066,8 +1069,16 @@ defmodule Fountain.Conversations.ConversationServer do
       # The callback token just rotated, and for claude the connection MCP
       # servers carry it in `.mcp.json` (#1178): rewrite the file so the
       # next turn's tools authenticate. Idempotent for an agent without one.
-      _ =
-        write_runtime_config(handle, state.runtime_module, with_connection_servers(agent, state))
+      # Best effort here, like the CA below: the turn's own failure says more
+      # than a refused wake would.
+      case write_runtime_config(
+             handle,
+             state.runtime_module,
+             with_connection_servers(agent, state)
+           ) do
+        :ok -> :ok
+        {:error, reason} -> Logger.warning("runtime config write on wake: #{inspect(reason)}")
+      end
 
       # A machine provisioned before its tenant was brokered has no CA yet;
       # on one that has it this is an idempotent rewrite. Best effort here:
@@ -1805,6 +1816,8 @@ defmodule Fountain.Conversations.ConversationServer do
 
     if function_exported?(runtime_module, :write_config, 2) do
       runtime_module.write_config(handle, agent)
+    else
+      :ok
     end
   end
 

--- a/apps/fountain/lib/fountain/runtimes.ex
+++ b/apps/fountain/lib/fountain/runtimes.ex
@@ -96,7 +96,8 @@ defmodule Fountain.Runtimes do
   provision time (e.g. claude's `~/.claude.json` for MCP servers).
   No-op by default.
   """
-  @callback write_config(handle :: Fountain.Sandbox.Handle.t(), agent :: %Agent{} | nil) :: :ok
+  @callback write_config(handle :: Fountain.Sandbox.Handle.t(), agent :: %Agent{} | nil) ::
+              :ok | {:error, term()}
 
   @doc """
   Optionally run any sprite-side bootstrap that has to happen *before*

--- a/apps/fountain/lib/fountain/runtimes/claude.ex
+++ b/apps/fountain/lib/fountain/runtimes/claude.ex
@@ -84,28 +84,34 @@ defmodule Fountain.Runtimes.Claude do
     # Project-scope config the CLI reads via settingSources; `mcp_servers` is
     # already the Claude-Code shape (`%{name => %{"command"/"args"/"env"...}}`)
     # with `${VAR}` refs resolved by the caller.
-    :ok =
-      Fountain.Sandbox.write_file(
-        handle,
-        @mcp_config,
-        Jason.encode!(%{"mcpServers" => mcp_servers}, pretty: true)
-      )
+    #
+    # Both writes are idempotent, so a transport blip on a sprite that has
+    # only just booted is retried rather than failing the provision: the
+    # first filesystem call into a fresh sprite timed out once in prod and
+    # took the whole conversation with it.
+    mcp_json = Jason.encode!(%{"mcpServers" => mcp_servers}, pretty: true)
 
-    # Pre-approve the project's servers so the first turn does not stall on an
-    # approval the sandbox has no human to answer. (Fountain's ACP peer also
-    # auto-allows `session/request_permission`, but that only fires mid-turn;
-    # pre-approval keeps the server connected from session start.)
-    :ok =
-      Fountain.Sandbox.write_file(
-        handle,
-        @settings,
-        Jason.encode!(%{"enableAllProjectMcpServers" => true}, pretty: true)
-      )
+    # Pre-approve the project's servers so the first turn does not stall on
+    # an approval the sandbox has no human to answer. (Fountain's ACP peer
+    # also auto-allows `session/request_permission`, but that only fires
+    # mid-turn; pre-approval keeps the server connected from session start.)
+    settings = Jason.encode!(%{"enableAllProjectMcpServers" => true}, pretty: true)
 
-    :ok
+    with :ok <- write_retrying(handle, @mcp_config, mcp_json) do
+      write_retrying(handle, @settings, settings)
+    end
   end
 
   def write_config(_handle, _agent), do: :ok
+
+  defp write_retrying(handle, path, body) do
+    case Fountain.Retry.with_backoff(fn -> Fountain.Sandbox.write_file(handle, path, body) end,
+           label: "claude config write #{path}"
+         ) do
+      :ok -> :ok
+      {:error, reason} -> {:error, {:runtime_config, path, reason}}
+    end
+  end
 
   @doc """
   Swaps `CLAUDE_CODE_OAUTH_TOKEN` for `ANTHROPIC_API_KEY` in an already-built

--- a/apps/fountain/lib/fountain/runtimes/gemini.ex
+++ b/apps/fountain/lib/fountain/runtimes/gemini.ex
@@ -84,8 +84,17 @@ defmodule Fountain.Runtimes.Gemini do
 
   def write_config(handle, %{mcp_servers: mcp_servers}) do
     payload = Jason.encode!(%{"mcpServers" => mcp_servers}, pretty: true)
-    Fountain.Sandbox.write_file(handle, @settings, payload)
-    :ok
+
+    # Idempotent, so a transport blip on a fresh sprite is retried; a write
+    # that still fails is reported, not swallowed — the agent would otherwise
+    # start with none of its servers and no record of why.
+    case Fountain.Retry.with_backoff(
+           fn -> Fountain.Sandbox.write_file(handle, @settings, payload) end,
+           label: "gemini config write"
+         ) do
+      :ok -> :ok
+      {:error, reason} -> {:error, {:runtime_config, @settings, reason}}
+    end
   end
 
   # Make sure the workspace exists and is a git repo; gemini's

--- a/apps/fountain/test/fountain/conversations/conversation_server_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_test.exs
@@ -489,6 +489,23 @@ defmodule Fountain.Conversations.ConversationServerTest do
       assert Conversations._unsafe_get_sandbox!(sandbox.id).status == "failed"
     end
 
+    test "a runtime whose config cannot be written marks the sandbox failed", %{
+      conv: conv,
+      sandbox: sandbox
+    } do
+      # Used to be `_ =` in the provision `with`: a config-write error was
+      # meant to be non-fatal, but the runtime crashed on it instead, and had
+      # it not, the agent would have run without its MCP servers under a
+      # `provision/done`. Now it is a step like any other.
+      stub_happy_sprite()
+
+      {_pid, ref, _} = start_server(conv, runtime: Fountain.Test.ConfigFailingRuntime)
+      assert_stopped(ref)
+
+      assert Conversations._unsafe_get_sandbox!(sandbox.id).status == "failed"
+      assert Conversations._unsafe_get_conversation!(conv.id).status == "failed"
+    end
+
     test "an unexpected exception is caught and does not leave the sandbox pending", %{
       conv: conv,
       sandbox: sandbox

--- a/apps/fountain/test/fountain/runtimes/claude_test.exs
+++ b/apps/fountain/test/fountain/runtimes/claude_test.exs
@@ -52,6 +52,32 @@ defmodule Fountain.Runtimes.ClaudeTest do
     assert %{"enableAllProjectMcpServers" => true} = Jason.decode!(settings)
   end
 
+  test "a transient write error is retried, then the config lands", %{handle: handle} do
+    # The first filesystem call into a freshly created sprite timed out once
+    # in prod and, with no retry, failed the whole provision. Both writes are
+    # idempotent, so they go through Fountain.Retry.
+    {:ok, calls} = Agent.start_link(fn -> 0 end)
+
+    Mimic.stub(Fountain.Sandbox, :write_file, fn _h, _path, _body ->
+      case Agent.get_and_update(calls, &{&1, &1 + 1}) do
+        0 -> {:error, {:unavailable, %Req.TransportError{reason: :timeout}}}
+        _ -> :ok
+      end
+    end)
+
+    assert Claude.write_config(handle, %{mcp_servers: %{"fs" => %{"command" => "npx"}}}) == :ok
+    assert Agent.get(calls, & &1) == 3
+  end
+
+  test "a write that keeps failing is a tagged error, not a crash", %{handle: handle} do
+    Mimic.stub(Fountain.Sandbox, :write_file, fn _h, _path, _body ->
+      {:error, {:unavailable, %Req.TransportError{reason: :timeout}}}
+    end)
+
+    assert {:error, {:runtime_config, "/home/sprite/.mcp.json", {:unavailable, _}}} =
+             Claude.write_config(handle, %{mcp_servers: %{"fs" => %{"command" => "npx"}}})
+  end
+
   describe "default_env/2" do
     test "prefers the oauth token over the api key" do
       env =

--- a/apps/fountain/test/support/fake_runtime.ex
+++ b/apps/fountain/test/support/fake_runtime.ex
@@ -71,3 +71,31 @@ defmodule Fountain.Test.FailingRuntime do
   @impl true
   def skills_sh_agent, do: "fake"
 end
+
+defmodule Fountain.Test.ConfigFailingRuntime do
+  @moduledoc """
+  A runtime whose `write_config/2` fails: the sandbox never took the runtime's
+  config file. Provisioning must treat that as a failure rather than run the
+  agent without its MCP servers.
+  """
+
+  @behaviour Fountain.Runtimes
+
+  @impl true
+  def build_command(_agent, prompt, _mode, _session_id, _opts), do: {"echo", [prompt], []}
+
+  @impl true
+  def default_env(_agent, _credentials), do: []
+
+  @impl true
+  def write_config(_sprite, _agent), do: {:error, {:runtime_config, "/x/.mcp.json", :timeout}}
+
+  @impl true
+  def prepare_sandbox(_sprite, _agent, _sprite_env), do: :ok
+
+  @impl true
+  def skills_root, do: "/home/sprite/.fake/skills"
+
+  @impl true
+  def skills_sh_agent, do: "fake"
+end


### PR DESCRIPTION
## Why

Conversation `f4231af9-0f7f-48f6-83d8-7b8a3d716d9a` failed to provision on prod at 2026-08-26 01:25 UTC. The `log_events` row:

```
no match of right hand side value:
    {:error, {:unavailable, %Req.TransportError{reason: :timeout}}}
  lib/fountain/runtimes/claude.ex:87: Fountain.Runtimes.Claude.write_config/2
  lib/fountain/conversations/conversation_server.ex:827: do_fresh_provision_inner/6
```

The sprite took ~60s to come up, the broker session minted fine, and then the **first filesystem call into the sprite** — the `.mcp.json` write — timed out after 30s. `write_config/2` crashed on its `:ok =` match. The provision `with` had that step as `_ =`, i.e. meant to be best effort, so the crash defeated the intent both ways: the conversation died on a transient blip, and had the write merely returned an error the agent would have run without its MCP servers under a `provision/done`. No other provision failure in the last three days has this shape; it was a one-off Sprites hiccup that a retry would very likely have absorbed.

## What

- `Claude.write_config/2` and `Gemini.write_config/2` retry their idempotent writes through `Fountain.Retry` like every other sandbox write, and return `{:error, {:runtime_config, path, reason}}` once retries are spent (gemini previously swallowed the error silently).
- The `write_config/2` callback is now `:ok | {:error, term()}`.
- Fresh provision treats the write as a real step (`:ok <-`); the wake path stays best effort and logs a warning, like the CA install beside it.
- CHANGELOG entry under Unreleased / Fixed.

## Tests

- `claude_test.exs`: a transient write error is retried and the config lands (3 calls: fail, ok, ok); a write that keeps failing is a tagged error, not a crash.
- `conversation_server_test.exs`: a runtime whose config cannot be written marks both the sandbox and the conversation `failed`, via a new `Fountain.Test.ConfigFailingRuntime`.

All three fail with the source changes stashed and pass with them. `mix format`, `credo --strict`, `dialyzer`, and the runtimes + conversation_server suites (267 tests) are green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
