### PR TITLE
feat(examples): Deep Agents orchestrator with Fountain agents as subagents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ upgrade, is in
 
 ### Added
 
+- **LangChain and Deep Agents example.** `examples/deepagents-contractor`:
+  a Deep Agent orchestrator whose subagents are Fountain agents, over the
+  OpenAI-compatible API. `fountain_langchain.py` makes one agent a
+  `CompiledSubAgent`, a LangChain tool or a bare runnable, keyed to the
+  LangGraph `thread_id` so one thread keeps one sandbox per agent. Docs page
+  `docs/integrations/langchain.md`.
 - **OpenAI-compatible chat completions (alpha, flag `openai_compat`).**
   `POST /v1/chat/completions` and
   `GET /v1/models`, where the `model` is one of the tenant's agents (by name

--- a/docs/integrations/clients.md
+++ b/docs/integrations/clients.md
@@ -21,6 +21,7 @@ mail, OAuth, billing and error reports, read <!-- vale disable-line STE.IngForms
 | [Hermes Agent](hermes.md) | The HTTP API, through a plugin. | The Hermes host. |
 | [OpenBot](openbot.md) | [AG-UI](https://github.com/ag-ui-protocol/ag-ui) over HTTP. | The OpenBot host. |
 | [OpenAI-compatible API](openai-compatible.md) (alpha) | OpenAI chat completions over HTTP. | The client or the gateway. |
+| [LangChain and Deep Agents](langchain.md) (alpha) | The OpenAI-compatible API, from one Python file. | Your LangChain code. |
 | [Buzz](buzz.md) | A Nostr relay, hosted by Fountain. | The Buzz desktop, or `POST /api/buzz/agents`. |
 | [Agentic IDEs](../llm-integration.md) | `/skill` and the discovery endpoints. | The IDE. |
 | Your own code | The [HTTP API](../api.md), the [TypeScript SDK](../sdk.md), the [CLI](../cli.md). | Wherever you want. |
@@ -61,6 +62,11 @@ only a base URL too. This one is alpha, behind the `openai_compat` flag. Fountai
 LibreChat, LiteLLM and the `openai` SDK all speak that shape. A header, or the
 request's `user` field, binds each chat to one conversation, so the sandbox is
 the memory here as well.
+
+[**LangChain and Deep Agents**](langchain.md) ride on that endpoint. A
+Fountain agent becomes a Deep Agents subagent, or a LangChain tool, from one
+Python file that the example ships. The orchestrator plans, and the Fountain
+agent does the work in its own sandbox and reports back once.
 
 Everything that plugin does is available to you directly. Read the
 [API reference](../api.md), the [TypeScript SDK](../sdk.md) and the

--- a/docs/integrations/langchain.md
+++ b/docs/integrations/langchain.md
@@ -1,0 +1,133 @@
+# LangChain and Deep Agents
+
+[LangChain](https://github.com/langchain-ai/langchain) is the agent framework,
+and [Deep Agents](https://github.com/langchain-ai/deepagents) is its harness
+for an orchestrator that plans and delegates to subagents. Fountain fits
+there as a **subagent**. The orchestrator plans. A Fountain agent does the
+work in a sandbox of its own, with its own repositories and credentials, and
+reports back once.
+
+```
+  Deep Agent (LangGraph)  ──task tool──▶  FountainAgent runnable  ──HTTPS──▶  Fountain  ──▶  sandbox
+    plans, reads reports                    POST /v1/chat/completions             /v1        the Fountain agent
+                                            X-Fountain-Thread: <thread_id>:<agent>
+```
+
+It rides on the [OpenAI-compatible API](openai-compatible.md), so it is
+alpha, behind the `openai_compat` flag. There is no package to install from
+us. One file, `fountain_langchain.py`, is the whole integration, and the
+example ships it.
+
+## At a glance
+
+| | |
+|---|---|
+| Direction | Inbound. LangChain drives Fountain. |
+| Talks over | OpenAI chat completions, at `POST /v1/chat/completions`. |
+| Configured on | Your LangChain code. |
+| Plugin | None. One Python file, in the example. |
+| Credential | A Fountain API key, as the bearer token. |
+| Scope | One LangGraph `thread_id` is one sandbox per Fountain agent. |
+| Status | Alpha, with the endpoint under it. Read [Feature status](../reference/feature-status.md). |
+
+## Set it up
+
+Make an API key.
+
+```bash
+fountain keys create langchain
+```
+
+Clone the example and install it.
+
+```bash
+git clone https://github.com/BinaryBourbon/fountain
+cd fountain/examples/deepagents-contractor
+pip install -r requirements.txt
+export FOUNTAIN_TOKEN=ftn_...
+export ANTHROPIC_API_KEY=sk-ant-...      # the orchestrator's model, not Fountain's
+```
+
+Run it.
+
+```bash
+python main.py --list                                  # the agents on your account
+python main.py -a reflex-1 -a pr-reviewer \
+  "Ask pr-reviewer to review the open PRs on jhgaylor/rounds, then summarise."
+```
+
+The orchestrator is an ordinary model that returns tool calls. Each `-a` names a Fountain
+agent it can delegate to. `--thread` keeps the same sandboxes on a second
+run.
+
+## Three shapes
+
+`FountainAgent(name)` has three shapes. All three send one prompt, wait for
+the turn, and return the text.
+
+A **Deep Agents subagent**, for `create_deep_agent`.
+
+```python
+from deepagents import create_deep_agent
+from fountain_langchain import FountainAgent
+
+agent = create_deep_agent(
+    model="anthropic:claude-sonnet-5",
+    subagents=[
+        FountainAgent("pr-reviewer").as_subagent(
+            "Reviews and fixes pull requests. Its sandbox has the repository."
+        ),
+    ],
+)
+agent.invoke({"messages": [("user", "...")]}, {"configurable": {"thread_id": "t1"}})
+```
+
+A **tool**, for `create_agent` or for a loop of your own.
+
+```python
+from langchain.agents import create_agent
+
+agent = create_agent(model="anthropic:claude-sonnet-5",
+                     tools=[FountainAgent("pr-reviewer").as_tool()])
+```
+
+A **runnable**, for a graph of your own. The input and the output both hold
+`messages`, which is the shape a Deep Agents subagent must have.
+
+```python
+runnable = FountainAgent("pr-reviewer").as_runnable()
+```
+
+## The thread
+
+The thread key is what keeps a conversation in one sandbox. The runnable reads
+the LangGraph `thread_id` from the ambient config and appends the agent's
+name. Thus one Deep Agents thread holds one sandbox per Fountain agent,
+across turns and across runs. Pass `thread="..."` to fix it yourself. Without
+either, the `FountainAgent` makes one random key and keeps it.
+
+A busy thread is a `409` with `Retry-After`. The runnable waits and sends
+again. Fountain does not queue a second prompt behind a turn that is in
+progress.
+
+## Why not `ChatOpenAI`
+
+`ChatOpenAI(base_url="https://your-fountain/v1", model="pr-reviewer")` does
+work, and it is the wrong tool. Two reasons.
+
+- A Fountain agent never emits `tool_calls`. Its tools ran in the sandbox
+  and the result is in the text. A LangGraph agent loop needs a model that
+  returns tool calls, so a Fountain agent cannot be the model in the loop. It
+  is a leaf that returns one report, which is what a subagent is.
+- `langchain-openai` drops `reasoning_content`, the field Fountain streams
+  while a sandbox provisions. A first turn looks silent for a minute. The
+  example uses the stock `openai` client and prints those stages to stderr.
+
+## What it does not do
+
+- A sandbox backend for Deep Agents. That protocol needs `execute` inside
+  the sandbox, and Fountain's unit is a conversation, not a shell.
+- A package on PyPI. The file is small enough to copy.
+
+The example is
+[`examples/deepagents-contractor`](https://github.com/BinaryBourbon/fountain/tree/main/examples/deepagents-contractor).

--- a/docs/integrations/openai-compatible.md
+++ b/docs/integrations/openai-compatible.md
@@ -88,6 +88,8 @@ curl https://your-fountain/v1/chat/completions \
 A complete terminal chat on the `openai` package, with the model picker and
 the thread header in place, is in the repository at
 [`examples/openai-chat`](https://github.com/BinaryBourbon/fountain/tree/main/examples/openai-chat).
+For LangChain and Deep Agents, where a Fountain agent is a subagent, read
+[LangChain and Deep Agents](langchain.md).
 
 ## One thread is one conversation is one sandbox
 

--- a/docs/nav.yml
+++ b/docs/nav.yml
@@ -114,6 +114,7 @@ nav:
       - Hermes Agent (plugin): integrations/hermes.md
       - OpenBot (AG-UI): integrations/openbot.md
       - OpenAI-compatible API: integrations/openai-compatible.md
+      - LangChain and Deep Agents: integrations/langchain.md
       - Buzz (Nostr): integrations/buzz.md
       - LLM integration: llm-integration.md
   - Changelog: changelog.md

--- a/examples/deepagents-contractor/README.md
+++ b/examples/deepagents-contractor/README.md
@@ -1,0 +1,42 @@
+# deepagents-contractor
+
+A [Deep Agent](https://github.com/langchain-ai/deepagents) that plans, and
+Fountain agents that do the work. The orchestrator is an ordinary
+tool-calling model; every Fountain agent you name becomes a subagent it can
+delegate to with the built-in `task` tool. The subagent runs in its own
+Fountain sandbox with the repositories and credentials it was hired with, and
+returns one report.
+
+`fountain_langchain.py` is the whole integration: a `FountainAgent` that is a
+Deep Agents subagent (`as_subagent`), a LangChain tool (`as_tool`) or a bare
+runnable (`as_runnable`), all over Fountain's
+[OpenAI-compatible API](https://managoat.com/docs/integrations/openai-compatible)
+with the stock `openai` client. Copy the file into your own project.
+
+The endpoint is alpha, behind the `openai_compat` flag. On the hosted
+platform ask for it on your account; self-hosted, set
+`FEATURE_FLAGS_ON=openai_compat`.
+
+```bash
+pip install -r requirements.txt
+export FOUNTAIN_TOKEN=ftn_...            # Account -> API keys, or `fountain keys create`
+export ANTHROPIC_API_KEY=sk-ant-...      # the orchestrator's model (any langchain model string works: --model)
+
+python main.py --list                    # the agents on your account
+python main.py -a reflex-1 -a "pr-reviewer=Reviews and fixes PRs; its sandbox has the repo." \
+  "Have pr-reviewer list the open PRs on jhgaylor/rounds and ask reflex-1 what day it is."
+python main.py --thread yesterday ...    # same thread, same sandboxes, same memory
+```
+
+What to notice while it runs:
+
+- Each delegation prints as `→ agent: task`, and each report as `← report`.
+  Between them the sandbox's provisioning stages stream dim on stderr as
+  `reasoning_content`; set `FOUNTAIN_QUIET=1` to hide them.
+- The thread key is `<thread_id>:<agent>`, so one Deep Agents thread keeps
+  one sandbox per Fountain agent, and a second `task` to the same agent lands
+  in a sandbox that remembers the first.
+- Why not `ChatOpenAI(base_url=...)`: a Fountain agent never returns
+  `tool_calls`, so it cannot be the model inside the loop, and
+  `langchain-openai` drops `reasoning_content`. It is a leaf, which is what a
+  subagent is.

--- a/examples/deepagents-contractor/fountain_langchain.py
+++ b/examples/deepagents-contractor/fountain_langchain.py
@@ -1,0 +1,197 @@
+"""A Fountain agent as a LangChain runnable, tool, or Deep Agents subagent.
+
+Everything here rides on Fountain's OpenAI-compatible API
+(``POST /v1/chat/completions``, ADR 0035). The ``model`` is a Fountain agent.
+The newest user message is the prompt; the sandbox keeps the rest of the
+context, so nothing is replayed. One ``X-Fountain-Thread`` value is one
+conversation is one sandbox.
+
+Three shapes, one transport:
+
+- ``FountainAgent(name)`` is a LangGraph-style runnable over ``{"messages"}``.
+- ``FountainAgent(name).as_subagent(description)`` is a Deep Agents
+  ``CompiledSubAgent`` the orchestrator delegates to with its ``task`` tool.
+- ``FountainAgent(name).as_tool()`` is a plain LangChain tool for
+  ``create_agent`` users who do not run Deep Agents.
+
+Why not ``ChatOpenAI(base_url=...)``? Two reasons. A Fountain agent never
+emits ``tool_calls`` (the tools ran in the sandbox; the answer is text), so it
+cannot be the model inside a tool-calling loop; it is a leaf that returns one
+report. And ``langchain-openai`` drops the non-standard ``reasoning_content``
+deltas Fountain streams while a sandbox provisions, so a first turn looks hung
+for a minute. The stock ``openai`` client keeps both honest.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+import uuid
+from collections.abc import Callable
+from typing import Any
+
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
+from langchain_core.runnables import RunnableConfig, RunnableLambda
+from langchain_core.tools import BaseTool, tool
+from openai import APIStatusError, OpenAI
+
+__all__ = ["FountainAgent", "list_fountain_agents"]
+
+THREAD_HEADER = "X-Fountain-Thread"
+
+
+def _client(base_url: str | None, api_key: str | None) -> OpenAI:
+    base_url = base_url or os.environ.get("FOUNTAIN_OPENAI_BASE_URL")
+    if not base_url:
+        host = os.environ.get("FOUNTAIN_BASE_URL", "https://managoat.com").rstrip("/")
+        base_url = f"{host}/v1"
+    api_key = api_key or os.environ.get("FOUNTAIN_TOKEN") or os.environ.get("FOUNTAIN_API_KEY")
+    if not api_key:
+        raise RuntimeError("set FOUNTAIN_TOKEN (a Fountain API key) or pass api_key=")
+    return OpenAI(base_url=base_url, api_key=api_key)
+
+
+def list_fountain_agents(*, base_url: str | None = None, api_key: str | None = None) -> list[dict[str, Any]]:
+    """The tenant's agents, as ``GET /v1/models`` reports them."""
+    return [m.model_dump() for m in _client(base_url, api_key).models.list().data]
+
+
+class FountainAgent:
+    """One Fountain agent, addressable from LangChain.
+
+    ``thread`` fixes the sandbox for the life of this object. Without it, the
+    LangGraph ``thread_id`` in the ambient config is used (so one Deep Agents
+    thread keeps one sandbox per Fountain agent across turns), and without
+    that a random key is minted once per ``FountainAgent``.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        thread: str | None = None,
+        system: str | None = None,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        on_reasoning: Callable[[str], None] | None = None,
+        timeout: float = 3600.0,
+    ) -> None:
+        self.name = name
+        self.system = system
+        self._thread = thread
+        self._fallback_thread = f"langchain-{uuid.uuid4().hex[:12]}"
+        self._client = _client(base_url, api_key).with_options(timeout=timeout)
+        self._on_reasoning = on_reasoning if on_reasoning is not None else _dim_stderr
+        self._threads_seen: set[str] = set()
+
+    # -- the three shapes ---------------------------------------------------
+
+    def as_runnable(self) -> RunnableLambda:
+        """``{"messages": [...]} -> {"messages": [AIMessage]}``, the shape Deep Agents reads."""
+        return RunnableLambda(self._invoke_state, name=f"fountain:{self.name}")
+
+    def as_subagent(self, description: str, *, name: str | None = None) -> dict[str, Any]:
+        """A Deep Agents ``CompiledSubAgent``: ``name``, ``description``, ``runnable``.
+
+        The subagent ``name`` is what the orchestrator types into ``task``, so
+        it defaults to a slug of the agent's name (``Mend: a/b`` is easy to
+        misspell; ``mend_a_b`` is not). The real name rides in the description.
+        """
+        return {
+            "name": name or _slug(self.name),
+            "description": f"{description} (Fountain agent '{self.name}')",
+            "runnable": self.as_runnable(),
+        }
+
+    def as_tool(self, description: str | None = None) -> BaseTool:
+        """A LangChain tool: ``prompt -> str``. Works with ``create_agent`` and any tool-calling loop."""
+        agent = self
+        doc = description or (
+            f"Delegate a task to the Fountain agent '{self.name}'. It runs in its own sandbox "
+            "with its own repositories and credentials and returns one report when it is done. "
+            "Give it the whole task in one message; it remembers earlier tasks on the same thread."
+        )
+
+        @tool(f"fountain_{_slug(self.name)}", description=doc)
+        def delegate(prompt: str, config: RunnableConfig) -> str:
+            return agent.run(prompt, config=config)
+
+        return delegate
+
+    # -- the transport ------------------------------------------------------
+
+    def run(self, prompt: str, *, config: RunnableConfig | None = None) -> str:
+        """Send one prompt to the agent and return what it said, once the turn is over."""
+        thread = self.thread_key(config)
+        messages: list[dict[str, str]] = []
+        if self.system and thread not in self._threads_seen:
+            # Fountain delivers system only with the first prompt of a new thread.
+            messages.append({"role": "system", "content": self.system})
+        messages.append({"role": "user", "content": prompt})
+        self._threads_seen.add(thread)
+
+        for attempt in range(60):
+            try:
+                return self._stream(messages, thread)
+            except APIStatusError as e:
+                if e.status_code != 409:
+                    raise
+                # The thread is mid-turn. Fountain says how long to wait; it does not queue.
+                wait = float(e.response.headers.get("Retry-After", "5"))
+                self._on_reasoning(f"[{self.name} is busy; retrying in {wait:.0f}s]\n")
+                time.sleep(wait)
+        raise RuntimeError(f"{self.name}: thread {thread} stayed busy")
+
+    def thread_key(self, config: RunnableConfig | None) -> str:
+        if self._thread:
+            return self._thread
+        configurable = (config or {}).get("configurable") or {}
+        thread_id = configurable.get("thread_id")
+        if thread_id:
+            return f"{thread_id}:{_slug(self.name)}"
+        return self._fallback_thread
+
+    def _stream(self, messages: list[dict[str, str]], thread: str) -> str:
+        parts: list[str] = []
+        stream = self._client.chat.completions.create(
+            model=self.name,
+            messages=messages,
+            stream=True,
+            extra_headers={THREAD_HEADER: thread},
+        )
+        for chunk in stream:
+            if not chunk.choices:
+                continue
+            delta = chunk.choices[0].delta
+            reasoning = getattr(delta, "reasoning_content", None) or (
+                delta.model_extra or {}
+            ).get("reasoning_content")
+            if reasoning:
+                self._on_reasoning(reasoning)
+            if delta.content:
+                parts.append(delta.content)
+        return "".join(parts).strip()
+
+    def _invoke_state(self, state: dict[str, Any], config: RunnableConfig) -> dict[str, Any]:
+        prompt = _newest_human(state.get("messages", []))
+        reply = self.run(prompt, config=config)
+        return {"messages": [AIMessage(content=reply, name=self.name)]}
+
+
+def _newest_human(messages: list[BaseMessage]) -> str:
+    for m in reversed(messages):
+        if isinstance(m, HumanMessage):
+            return m.content if isinstance(m.content, str) else str(m.content)
+    raise ValueError("no HumanMessage to send to Fountain")
+
+
+def _slug(name: str) -> str:
+    return "".join(c if c.isalnum() else "_" for c in name).strip("_").lower()
+
+
+def _dim_stderr(text: str) -> None:
+    if os.environ.get("FOUNTAIN_QUIET"):
+        return
+    sys.stderr.write(f"\033[2m{text}\033[0m")
+    sys.stderr.flush()

--- a/examples/deepagents-contractor/main.py
+++ b/examples/deepagents-contractor/main.py
@@ -1,0 +1,86 @@
+"""A Deep Agent that plans, and Fountain agents that do the work.
+
+    python main.py "Audit github.com/you/repo for stale docs and have fountain-contributor fix them"
+
+The orchestrator is an ordinary tool-calling model (Anthropic here). Each
+Fountain agent named on the command line becomes a subagent it can delegate to
+with the built-in ``task`` tool. The subagent runs in its own Fountain sandbox
+with its own repositories and credentials, and returns one report.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import uuid
+
+from deepagents import create_deep_agent
+from fountain_langchain import FountainAgent, list_fountain_agents
+from langchain_core.messages import AIMessage, ToolMessage
+
+INSTRUCTIONS = """You are a project lead. You do not write code or run commands yourself.
+You have contractors: the Fountain agents listed as subagents. Each one runs in its own
+sandbox with the repositories and credentials it was hired with, works for as long as it
+needs, and reports back once. Delegate concrete, self-contained tasks to them with the
+`task` tool, read what comes back, and decide what to do next. When the job is done,
+answer the user with what was delegated, what each contractor reported, and any links
+(pull requests, commits) they gave you."""
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("prompt", nargs="?", help="what the lead should get done")
+    p.add_argument("--agent", "-a", action="append", default=[], metavar="NAME[=DESCRIPTION]",
+                   help="a Fountain agent to hire (repeatable); default: every agent on the account")
+    p.add_argument("--model", default=os.environ.get("DEEPAGENTS_MODEL", "anthropic:claude-sonnet-5"),
+                   help="the orchestrator model (a tool-calling model, not a Fountain agent)")
+    p.add_argument("--thread", default=None, help="reuse a thread: same sandboxes, same memory")
+    p.add_argument("--list", action="store_true", help="list the account's agents and exit")
+    args = p.parse_args()
+
+    if args.list or not args.prompt:
+        for m in list_fountain_agents():
+            f = m.get("fountain", {})
+            print(f"{m['id']:40}  {f.get('runtime', ''):8}  {f.get('model', '')}")
+        return
+
+    hired = _hire(args.agent)
+    agent = create_deep_agent(
+        model=args.model,
+        system_prompt=INSTRUCTIONS,
+        subagents=[h.as_subagent(d) for h, d in hired],
+    )
+
+    thread_id = args.thread or f"contractor-{uuid.uuid4().hex[:8]}"
+    config = {"configurable": {"thread_id": thread_id}, "recursion_limit": 100}
+    print(f"thread {thread_id}  contractors: {', '.join(h.name for h, _ in hired)}\n", file=sys.stderr)
+
+    final = None
+    for chunk in agent.stream({"messages": [("user", args.prompt)]}, config=config, stream_mode="updates"):
+        for node, update in chunk.items():
+            for m in (update or {}).get("messages", []):
+                if isinstance(m, AIMessage):
+                    for call in m.tool_calls:
+                        if call["name"] == "task":
+                            a = call["args"]
+                            print(f"\n→ {a.get('subagent_type')}: {a.get('description')}\n", file=sys.stderr)
+                    if m.content:
+                        final = m.content if isinstance(m.content, str) else str(m.content)
+                elif isinstance(m, ToolMessage) and m.name == "task":
+                    print(f"\n← report:\n{m.content}\n", file=sys.stderr)
+    print(final or "(no final answer)")
+
+
+def _hire(specs: list[str]) -> list[tuple[FountainAgent, str]]:
+    if not specs:
+        specs = [m["id"] for m in list_fountain_agents()]
+    hired = []
+    for spec in specs:
+        name, _, desc = spec.partition("=")
+        hired.append((FountainAgent(name), desc or f"The Fountain agent '{name}'. Delegate self-contained tasks to it."))
+    return hired
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/deepagents-contractor/requirements.txt
+++ b/examples/deepagents-contractor/requirements.txt
@@ -1,0 +1,3 @@
+deepagents>=0.7
+langchain-anthropic>=1.0
+openai>=1.0


### PR DESCRIPTION
Follows #1199. The LangChain answer to "how does a framework reach a Fountain agent" is **a subagent, not a model**: the orchestrator (any tool-calling model) plans, and a Fountain agent does the work in its own sandbox and reports back once. Deep Agents has exactly that seam (`CompiledSubAgent` with a `runnable`).

## What

- `examples/deepagents-contractor/fountain_langchain.py` — `FountainAgent(name)` with three shapes over `POST /v1/chat/completions`: `.as_subagent(description)` (Deep Agents), `.as_tool()` (`create_agent` / any loop), `.as_runnable()` (`{"messages"} -> {"messages"}`). Thread key is `<langgraph thread_id>:<agent slug>` from the ambient config, so one Deep Agents thread keeps one sandbox per Fountain agent across turns and runs; `409` is retried on `Retry-After`; `reasoning_content` (provisioning stages) goes to stderr. Subagent `name` is a slug of the agent name because the orchestrator mistyped `Mend: github.com/...` on the first try in the smoke.
- `main.py` — `--list`, `-a NAME[=DESCRIPTION]` to hire agents, `--thread` to resume, prints each delegation and report.
- Uses the stock `openai` client, not `ChatOpenAI`, on purpose: a Fountain agent never emits `tool_calls` so it cannot be the model inside a LangGraph loop, and `langchain-openai` documents that it drops non-standard `reasoning_content`. The docs page says both.
- `docs/integrations/langchain.md`, a clients-overview row and paragraph, nav, a pointer from the OpenAI-compatible page, CHANGELOG. Also states what it is not: a Deep Agents sandbox backend needs `execute` in the sandbox, which Fountain does not expose.

## Verified

- Both docs test files (29, 0 failures), `vale lint docs` (no gated findings on the new page), `docs-style.py` clean.
- Against **prod** (managoat.com, `openai_compat` on for my account): runnable + subagent shape, two turns on one thread against `reflex-1` — turn 1 51s with provisioning streamed as reasoning, turn 2 2s and the sandbox remembered turn 1. Full `create_deep_agent` run with two hired agents: results in the comment below.

## Noticed on the way

- The `openai_compat` PostHog flag was created with `evaluation_runtime: server`, which Fountain's `/flags/?v=2` (project token) never matches — it read as flag-off. Switched to `all` like `team_comms`. Worth a line in the flag-flipping runbook.
- `fountain-contributor`'s setup script fails on prod (`setup failed: no reason given`) — surfaced cleanly as an `APIError` through the stream, unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)