### PR TITLE
fix(conversations): the caller's tools ride on the attach create path too (#1202)

### DIFF
--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -2308,7 +2308,10 @@ defmodule Fountain.Conversations do
              parent_conversation_id: parent_id,
              channel_id: attrs["channel_id"],
              title: attrs["title"],
-             permission_policy: perm_policy
+             permission_policy: perm_policy,
+             # The bridge's tools (#1202) ride on both create paths: this
+             # one is what a home sandbox's second conversation takes.
+             caller_tools: attrs["caller_tools"] || []
            }) do
       Audit.record(%{
         user_id: user_id,

--- a/apps/fountain/test/fountain/conversations/attach_test.exs
+++ b/apps/fountain/test/fountain/conversations/attach_test.exs
@@ -43,6 +43,14 @@ defmodule Fountain.Conversations.AttachTest do
     assert Conversations._unsafe_list_cotenant_ids(ctx.sandbox.id, conv.id) == [ctx.first.id]
   end
 
+  test "the caller's tools ride on this create path too (#1202)", ctx do
+    # A home sandbox's second conversation takes this path, not the
+    # provisioning one; the prod smoke found the bridge's list dropped here.
+    tools = [%{"name" => "lookup", "description" => "", "parameters" => %{"type" => "object"}}]
+    assert {:ok, conv} = attach(ctx, %{"caller_tools" => tools})
+    assert Conversations._unsafe_get_conversation!(conv.id).caller_tools == tools
+  end
+
   test "a foreign or malformed sandbox reads as not found", ctx do
     foreign = insert_sandbox(user_id: insert_active_user().id, status: "ready")
 


### PR DESCRIPTION
Follow-up to #1203. The prod smoke registered no tools: `reflex-1` lives on a home sandbox, so its conversation came through `attach_conversation/3` (ADR 0023), which builds its own row and never read `caller_tools`. Both create paths carry it now; `attach_test.exs` pins it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)