### PR TITLE
feat(marketing): a gallery of what people built on the API, at /built-with

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,18 @@ upgrade, is in
   no asset pipeline behind it. Since #1008 `/docs` is the only place the
   manual is published, which left it as the one copy with no way to search.
 
+- **A gallery of the applications built on the API, `/built-with`.**
+  Thirteen products, grouped by who they are for: a researcher that returns
+  cited briefs, an analyst that runs Python on a CSV, a personal assistant you
+  text, repository question-answering with file-and-line citations, a fleet
+  coordinator, a shared dev workbench, a DNS desk behind an approval gate, an
+  SRE on a cron, two config-audit products, a blind model bake-off, and the
+  team and conversation clients. Each card carries a live link and a source
+  link, and the suite checks that every entry names an absolute URL and a
+  repository, so no card can sell something nobody can open. The homepage
+  carries a band naming them all. Off the marketing site the page redirects
+  to the manual's build guide.
+
 - **An integrations page on the marketing site, `/integrations`.** The
   protocols Fountain answers (AG-UI, the Agent Client Protocol, OpenAI chat
   completions, MCP, its own REST API and webhooks, and Buzz over Nostr), what

--- a/apps/fountain/lib/fountain_web/components/layouts/marketing.html.heex
+++ b/apps/fountain/lib/fountain_web/components/layouts/marketing.html.heex
@@ -17,6 +17,13 @@
           Integrations
         </a>
         <a
+          :if={Fountain.Marketing.site?()}
+          href={~p"/built-with"}
+          class="text-sm text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors px-3 py-1.5 rounded-md hover:bg-[var(--color-bg-2)]"
+        >
+          Built with
+        </a>
+        <a
           href="/docs"
           class="text-sm text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors px-3 py-1.5 rounded-md hover:bg-[var(--color-bg-2)]"
         >
@@ -73,6 +80,13 @@
           class="hover:text-[var(--color-text-secondary)] transition-colors"
         >
           Integrations
+        </a>
+        <a
+          :if={Fountain.Marketing.site?()}
+          href={~p"/built-with"}
+          class="hover:text-[var(--color-text-secondary)] transition-colors"
+        >
+          Built with
         </a>
         <a href="/docs" class="hover:text-[var(--color-text-secondary)] transition-colors">
           Docs

--- a/apps/fountain/lib/fountain_web/controllers/marketing_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_controller.ex
@@ -1,11 +1,11 @@
 defmodule FountainWeb.MarketingController do
   @moduledoc """
-  The public pages: `/`, `/integrations`, `/terms` and `/privacy`.
+  The public pages: `/`, `/integrations`, `/built-with`, `/terms` and `/privacy`.
 
   None of the four is the same page on every deployment. `/` serves the
   product pitch on the marketing site and a plain front door everywhere else
-  (`Fountain.Marketing`); `/integrations` is the pitch's second page and
-  redirects to the manual's own integrations section on any other instance;
+  (`Fountain.Marketing`); `/integrations` and `/built-with` are the pitch's other two
+  pages and redirect into the manual on any other instance;
   the legal pages render the operator's identity, or nothing at all
   (`Fountain.Legal`). A deployment is not the Fountain project, and these
   pages are the ones that would claim otherwise.
@@ -33,6 +33,26 @@ defmodule FountainWeb.MarketingController do
       )
     else
       redirect(conn, to: ~p"/docs/integrations/clients")
+    end
+  end
+
+  # The applications people have built on the API. Sales copy again, so a
+  # self-hosted instance gets the manual's build guide rather than a page
+  # selling somebody else's hosted product with somebody else's apps.
+  def built_with(conn, _params) do
+    if Fountain.Marketing.site?() do
+      render(conn, :built_with,
+        layout: {FountainWeb.Layouts, :marketing},
+        page_title: "Built with #{Fountain.Brand.name()} · #{Fountain.Brand.name()}",
+        meta_description:
+          "#{length(FountainWeb.MarketingHTML.built_apps_flat())} open-source " <>
+            "applications built on the #{Fountain.Brand.name()} API: research briefs, " <>
+            "CSV analysis, repository Q&A, agent fleets, DNS and infrastructure " <>
+            "patrols, model bake-offs and the team clients. Most have no backend " <>
+            "of their own."
+      )
+    else
+      redirect(conn, to: ~p"/docs/build")
     end
   end
 

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
@@ -464,6 +464,7 @@ defmodule FountainWeb.MarketingHTML do
       }
     ]
   end
+
   ## /built-with
   #
   # The apps people have built on the API, grouped by who they are for. Every
@@ -594,7 +595,8 @@ defmodule FountainWeb.MarketingHTML do
             source: "https://github.com/jhgaylor/mend",
             blurb:
               "What an audit finds across a repository's CI, manifests, Dockerfiles and cloud templates, and what an agent does once you hand it that tool. Mechanical fixes applied, judgement calls argued, one patch back.",
-            shows: "a real CLI in the sandbox, and the restraint to leave the ambiguous ones alone"
+            shows:
+              "a real CLI in the sandbox, and the restraint to leave the ambiguous ones alone"
           },
           %{
             id: "rounds",
@@ -612,8 +614,7 @@ defmodule FountainWeb.MarketingHTML do
       %{
         id: "ai-engineers",
         title: "For AI engineers",
-        blurb:
-          "Several agents at once, side by side, with the numbers underneath.",
+        blurb: "Several agents at once, side by side, with the numbers underneath.",
         apps: [
           %{
             id: "arena",

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
@@ -464,4 +464,203 @@ defmodule FountainWeb.MarketingHTML do
       }
     ]
   end
+  ## /built-with
+  #
+  # The apps people have built on the API, grouped by who they are for. Every
+  # one is a real deployment against the hosted instance, and every one is
+  # open source, so a card carries two links and the page carries no claim
+  # that cannot be clicked. The controller test asserts both are absolute and
+  # that no app is listed twice.
+
+  @doc "The applications built on the API, in the order and grouping the page shows."
+  def built_apps do
+    [
+      %{
+        id: "everyone",
+        title: "For everyone",
+        blurb:
+          "No agent, no sandbox and no prompt box on screen. The product is the document, the chart or the text message.",
+        apps: [
+          %{
+            id: "briefing-room",
+            glyph: "\u{1F4F0}",
+            name: "Briefing Room",
+            host: "briefs.inevitable.fyi",
+            url: "https://briefs.inevitable.fyi",
+            source: "https://github.com/jhgaylor/briefing-room",
+            blurb:
+              "Say what you need to understand and why. A researcher with its own computer reads real sources and hands back a clean, cited brief. A document, not a chat.",
+            shows: "web research behind a UI with none of the AI-chat furniture"
+          },
+          %{
+            id: "table-talk",
+            glyph: "\u{1F4CA}",
+            name: "Table Talk",
+            host: "tables.inevitable.fyi",
+            url: "https://tables.inevitable.fyi",
+            source: "https://github.com/jhgaylor/table-talk",
+            blurb:
+              "Drop a CSV in. An analyst runs Python on its sandbox and comes back with charts and plain-English findings. Then keep asking questions of your data.",
+            shows: "a real computer as the engine under a zero-jargon UI"
+          },
+          %{
+            id: "reflex",
+            glyph: "\u{1F4AC}",
+            name: "Reflex",
+            host: "reflex.inevitable.fyi",
+            url: "https://reflex.inevitable.fyi",
+            source: "https://github.com/jhgaylor/reflex",
+            blurb:
+              "A personal assistant you text. It keeps a computer, your accounts and a memory, and it works while you do something else: books the dentist, sweeps the inbox at two, texts you when the tickets come back.",
+            shows: "a persistent teammate, its own phone number, and routines on a schedule"
+          }
+        ]
+      },
+      %{
+        id: "engineers",
+        title: "For engineers",
+        blurb:
+          "The sandbox is the point. Each of these hands an agent a checkout, a shell and a task list, then shows you the work.",
+        apps: [
+          %{
+            id: "repo-sage",
+            glyph: "\u{1F33F}",
+            name: "Repo Sage",
+            host: "reposage.inevitable.fyi",
+            url: "https://reposage.inevitable.fyi",
+            source: "https://github.com/jhgaylor/repo-sage",
+            blurb:
+              "Name any public GitHub repository. An agent clones it on its own machine and answers with file-and-line citations that link back to the source.",
+            shows: "the sandbox as a workstation: clone, grep, read, cite"
+          },
+          %{
+            id: "mission-control",
+            glyph: "\u{1F680}",
+            name: "Mission Control",
+            host: "mission.inevitable.fyi",
+            url: "https://mission.inevitable.fyi",
+            source: "https://github.com/jhgaylor/mission-control",
+            blurb:
+              "Describe a mission. A coordinator plans it, you approve the plan, and the app starts one sandboxed agent per task. Watch the fleet work and take one report.",
+            shows: "plan, approve, fan out, multiplex the streams, synthesize"
+          },
+          %{
+            id: "fountain-workbench",
+            glyph: "\u{1F9F0}",
+            name: "Workbench",
+            host: "workbench.inevitable.fyi",
+            url: "https://workbench.inevitable.fyi",
+            source: "https://github.com/jhgaylor/fountain-workbench",
+            blurb:
+              "A dev workstation the team shares. A project is an environment and a vault, work items live in it, and putting a teammate on one is a first prompt rather than four steps of setup.",
+            shows: "projects over environments and vaults, agents as staff"
+          },
+          %{
+            id: "dns-desk",
+            glyph: "\u{1F5C2}\u{FE0F}",
+            name: "DNS Desk",
+            host: "jakegaylor.com/dns-desk",
+            url: "https://jakegaylor.com/dns-desk/",
+            source: "https://github.com/jhgaylor/dns-desk",
+            blurb:
+              "A DNS operator for your Cloudflare zones. Ask in plain words, read the plan as a diff, approve. The zone tables stay on screen while the agent does the work.",
+            shows: "plan, approve, apply on a live system, with a vault as the blast radius"
+          }
+        ]
+      },
+      %{
+        id: "infrastructure",
+        title: "For infrastructure",
+        blurb:
+          "Nobody is watching these. A schedule wakes the agent, it decides whether anything needs doing, and most of the time the answer is no.",
+        apps: [
+          %{
+            id: "watchtower",
+            glyph: "\u{1F5FC}",
+            name: "Watchtower",
+            host: "watchtower.inevitable.fyi",
+            url: "https://watchtower.inevitable.fyi",
+            source: "https://github.com/jhgaylor/watchtower",
+            blurb:
+              "An SRE teammate on a cron: uptime, latency, TLS expiry and DNS for every site you name. When a tile turns red, ask it to investigate. It has real tools.",
+            shows: "schedules as a product heartbeat, the conversation as the store"
+          },
+          %{
+            id: "mend",
+            glyph: "\u{1F526}",
+            name: "Mend",
+            host: "mend.inevitable.fyi",
+            url: "https://mend.inevitable.fyi",
+            source: "https://github.com/jhgaylor/mend",
+            blurb:
+              "What an audit finds across a repository's CI, manifests, Dockerfiles and cloud templates, and what an agent does once you hand it that tool. Mechanical fixes applied, judgement calls argued, one patch back.",
+            shows: "a real CLI in the sandbox, and the restraint to leave the ambiguous ones alone"
+          },
+          %{
+            id: "rounds",
+            glyph: "\u{1F501}",
+            name: "Rounds",
+            host: "rounds.inevitable.fyi",
+            url: "https://rounds.inevitable.fyi",
+            source: "https://github.com/jhgaylor/rounds",
+            blurb:
+              "Dependabot for infrastructure config. Enrol a repository and it gets audited on a schedule; an agent fixes what it can verify and opens the pull request. Never twice for the same finding, never again for one you closed.",
+            shows: "an unattended product, and an agent that knows when to do nothing"
+          }
+        ]
+      },
+      %{
+        id: "ai-engineers",
+        title: "For AI engineers",
+        blurb:
+          "Several agents at once, side by side, with the numbers underneath.",
+        apps: [
+          %{
+            id: "arena",
+            glyph: "\u{1F94A}",
+            name: "Arena",
+            host: "arena.inevitable.fyi",
+            url: "https://arena.inevitable.fyi",
+            source: "https://github.com/jhgaylor/arena",
+            blurb:
+              "One prompt, several brains, side by side. Blind columns, live streams, latency and token counts, and your vote on the scoreboard.",
+            shows: "parallel conversations, the model catalog, per-turn usage"
+          }
+        ]
+      },
+      %{
+        id: "clients",
+        title: "The clients",
+        blurb:
+          "The two apps this project ships itself. The console stays a console; watching an agent work and messaging a teammate are these, on their own origins, built on the same public API as everything above.",
+        apps: [
+          %{
+            id: "fountain-team",
+            glyph: "\u{1F465}",
+            name: "Team",
+            host: "jakegaylor.com/fountain-team",
+            url: "https://jakegaylor.com/fountain-team/",
+            source: "https://github.com/jhgaylor/fountain-team",
+            blurb:
+              "Your agents as teammates in a messaging app. Roster on the left, thread on the right, routines on a schedule, images and search. Enter to send.",
+            shows: "the team API, SSE streaming, schedules, usage"
+          },
+          %{
+            id: "fountain-conversations",
+            glyph: "\u{1F9F5}",
+            name: "Conversations",
+            host: "jakegaylor.com/fountain-conversations",
+            url: "https://jakegaylor.com/fountain-conversations/",
+            source: "https://github.com/jhgaylor/fountain-conversations",
+            blurb:
+              "Start a run, watch the agent work turn by turn, and drive it. Chat, timeline and raw views of the same conversation, plus the machine it shares with its siblings.",
+            shows: "the event stream as blocks, and one sandbox behind many conversations"
+          }
+        ]
+      }
+    ]
+  end
+
+  @doc "Every app on /built-with, flattened. The count the page quotes comes from here."
+  def built_apps_flat, do: Enum.flat_map(built_apps(), & &1.apps)
 end

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/built_with.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/built_with.html.heex
@@ -1,0 +1,146 @@
+<%!-- Hero --%>
+<section class="max-w-5xl mx-auto px-6 py-20 text-center">
+  <p class="mb-4 text-sm font-medium uppercase tracking-wide text-[var(--color-text-muted)]">
+    Built with {Fountain.Brand.name()}
+  </p>
+  <h1 class="text-4xl sm:text-5xl font-bold tracking-tight text-[var(--color-text-primary)] mb-5 leading-tight">
+    {length(built_apps_flat())} products. One API behind all of them.
+  </h1>
+  <p class="text-lg sm:text-xl text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-10">
+    Every app below is a small product built almost entirely on the {Fountain.Brand.name()} API. Most have no backend of their own at all: static files in a browser, the API, and an agent with a real computer. That is the whole stack. All of them are open source, and all of them are running right now.
+  </p>
+  <div class="flex flex-wrap gap-2 justify-center" data-role="group-chips">
+    <a
+      :for={group <- built_apps()}
+      href={"##{group.id}"}
+      class="inline-flex items-center gap-1.5 rounded-full border border-[var(--color-border)] px-3 py-1 text-sm text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-2)] transition-colors"
+    >
+      <span class="size-1.5 rounded-full bg-[var(--color-brand)]"></span>
+      {group.title}
+    </a>
+  </div>
+</section>
+
+<%!-- How they all connect --%>
+<section class="bg-[var(--color-bg-1)] border-y border-[var(--color-border)]">
+  <div class="max-w-5xl mx-auto px-6 py-16">
+    <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-3 text-center">
+      They all connect the same way.
+    </h2>
+    <p class="text-center text-[var(--color-text-secondary)] max-w-xl mx-auto mb-12">
+      Open one, give it the address of a {Fountain.Brand.name()} server, then sign in with your account or paste an API key. The app runs in your browser against your own agents, your own sandboxes and your own credit. Nothing of yours reaches whoever wrote it.
+    </p>
+    <div class="grid sm:grid-cols-3 gap-6">
+      <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6">
+        <p class="text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)]">
+          Step one
+        </p>
+        <h3 class="mt-1 font-semibold text-[var(--color-text-primary)]">Point it at a server</h3>
+        <p class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">
+          The hosted instance, or the one you self-host. The app asks for the URL on first load.
+        </p>
+      </div>
+      <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6">
+        <p class="text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)]">
+          Step two
+        </p>
+        <h3 class="mt-1 font-semibold text-[var(--color-text-primary)]">
+          Sign in with {Fountain.Brand.name()}
+        </h3>
+        <p class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">
+          OAuth with PKCE. The token it gets is an ordinary API key, so it lists and revokes under Account.
+        </p>
+      </div>
+      <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6">
+        <p class="text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)]">
+          Step three
+        </p>
+        <h3 class="mt-1 font-semibold text-[var(--color-text-primary)]">Your agents show up</h3>
+        <p class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">
+          Whatever the app hires runs on a sandbox on your account, and every run is a conversation you already own.
+        </p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<%!-- The apps --%>
+<section class="max-w-5xl mx-auto px-6 py-16 space-y-16">
+  <div
+    :for={group <- built_apps()}
+    id={group.id}
+    class="scroll-mt-6"
+    data-role="group"
+  >
+    <h2 class="text-2xl font-semibold text-[var(--color-text-primary)]">{group.title}</h2>
+    <p class="mt-2 text-[var(--color-text-secondary)] max-w-2xl">{group.blurb}</p>
+    <div class="mt-8 grid md:grid-cols-2 gap-6">
+      <article
+        :for={app <- group.apps}
+        id={app.id}
+        class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6 flex flex-col scroll-mt-6"
+        data-role="app"
+      >
+        <div class="text-3xl leading-none" aria-hidden="true">{app.glyph}</div>
+        <div class="mt-3 flex flex-wrap items-baseline gap-x-3 gap-y-1">
+          <h3 class="text-lg font-semibold text-[var(--color-text-primary)]">{app.name}</h3>
+          <code
+            class="text-xs text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1.5 py-0.5"
+            phx-no-format
+          >{app.host}</code>
+        </div>
+        <p class="mt-3 text-sm text-[var(--color-text-secondary)] leading-relaxed flex-1">
+          {app.blurb}
+        </p>
+        <p class="mt-4 text-xs text-[var(--color-text-muted)]">
+          <span class="font-medium text-[var(--color-text-secondary)]">Shows</span> {app.shows}
+        </p>
+        <div class="mt-5 flex flex-wrap gap-3">
+          <a
+            href={app.url}
+            rel="noopener"
+            class="inline-flex items-center px-4 py-2 rounded-lg bg-[var(--color-brand)] text-white font-medium hover:bg-[var(--color-brand-hover)] transition-colors text-sm"
+          >
+            Open it
+          </a>
+          <a
+            href={app.source}
+            rel="noopener"
+            class="inline-flex items-center px-4 py-2 rounded-lg border border-[var(--color-border)] text-[var(--color-text-primary)] font-medium hover:bg-[var(--color-bg-2)] transition-colors text-sm"
+          >
+            Source
+          </a>
+        </div>
+      </article>
+    </div>
+  </div>
+</section>
+
+<%!-- Footer CTA --%>
+<section class="bg-[var(--color-bg-1)] border-t border-[var(--color-border)]">
+  <div class="max-w-5xl mx-auto px-6 py-20 text-center">
+    <h2 class="text-2xl sm:text-3xl font-bold text-[var(--color-text-primary)] mb-4">
+      Build the next one.
+    </h2>
+    <p class="text-[var(--color-text-secondary)] mb-8 max-w-lg mx-auto">
+      A static page, the TypeScript SDK and Sign in with {Fountain.Brand.name()} is the whole recipe. The manual walks a team chat end to end, and the apps above are the working copies to read.
+    </p>
+    <div class="flex flex-col sm:flex-row gap-3 justify-center">
+      <a
+        href={~p"/docs/build"}
+        class="inline-flex items-center justify-center px-6 py-3 rounded-lg bg-[var(--color-brand)] text-white font-medium hover:bg-[var(--color-brand-hover)] transition-colors text-sm"
+      >
+        Build a chat app
+      </a>
+      <a
+        href={~p"/integrations"}
+        class="inline-flex items-center justify-center px-6 py-3 rounded-lg border border-[var(--color-border)] text-[var(--color-text-primary)] font-medium hover:bg-[var(--color-bg-2)] transition-colors text-sm"
+      >
+        Or plug in what you already run
+      </a>
+    </div>
+    <p class="mt-8 text-xs text-[var(--color-text-muted)] max-w-xl mx-auto">
+      Each app is MIT licensed and hosted by its author, not by {Fountain.Brand.name()}. Signing in hands it a key scoped to your account, which you can revoke at any time under Account and API keys.
+    </p>
+  </div>
+</section>

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -235,6 +235,33 @@
   </div>
 </section>
 
+<%!-- Built with: proof that the API carries whole products, not just calls. --%>
+<section class="bg-[var(--color-bg-1)] border-y border-[var(--color-border)]">
+  <div class="max-w-5xl mx-auto px-6 py-16 text-center">
+    <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-3">
+      People build whole products on it.
+    </h2>
+    <p class="text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-8">
+      {length(built_apps_flat())} of them are open source and running right now: a researcher that returns cited briefs, an analyst that runs Python on your CSV, an SRE on a cron, a DNS desk with an approval gate. Most have no backend of their own.
+    </p>
+    <ul class="flex flex-wrap justify-center gap-2 mb-8">
+      <li
+        :for={app <- built_apps_flat()}
+        class="inline-flex items-center gap-1.5 rounded-full border border-[var(--color-border)] bg-[var(--color-bg-0)] px-3 py-1 text-sm text-[var(--color-text-secondary)]"
+      >
+        <span aria-hidden="true">{app.glyph}</span>
+        {app.name}
+      </li>
+    </ul>
+    <a
+      href={~p"/built-with"}
+      class="inline-flex items-center justify-center px-6 py-3 rounded-lg border border-[var(--color-border)] text-[var(--color-text-primary)] font-medium hover:bg-[var(--color-bg-2)] transition-colors text-sm"
+    >
+      See what people built
+    </a>
+  </div>
+</section>
+
 <%!-- Objections --%>
 <section class="max-w-5xl mx-auto px-6 py-16">
   <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-10 text-center">

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -156,6 +156,7 @@ defmodule FountainWeb.Router do
     pipe_through [:browser, :browser_optional_auth, :public_analytics]
     get "/", MarketingController, :home
     get "/integrations", MarketingController, :integrations
+    get "/built-with", MarketingController, :built_with
     get "/terms", MarketingController, :terms
     get "/privacy", MarketingController, :privacy
     # The public manual, and since #1008 the only place it is published —

--- a/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
@@ -98,6 +98,85 @@ defmodule FountainWeb.MarketingControllerTest do
     end
   end
 
+  describe "GET /built-with" do
+    test "renders every app, grouped", %{conn: conn} do
+      body = conn |> get(~p"/built-with") |> html_response(200)
+
+      assert body =~ "One API behind all of them."
+
+      for group <- FountainWeb.MarketingHTML.built_apps() do
+        assert body =~ group.title, "missing group #{group.title}"
+      end
+
+      for app <- FountainWeb.MarketingHTML.built_apps_flat() do
+        assert body =~ app.name, "missing app #{app.name}"
+        assert body =~ app.host, "missing host for #{app.name}"
+        assert body =~ app.url, "missing live link for #{app.name}"
+        assert body =~ app.source, "missing source link for #{app.name}"
+      end
+    end
+
+    test "every app is live somewhere and open somewhere, exactly once", _ do
+      apps = FountainWeb.MarketingHTML.built_apps_flat()
+
+      # The page's whole claim is that each card is two working links, so an
+      # entry with a relative or placeholder URL would sell something nobody
+      # can click.
+      for app <- apps do
+        assert String.starts_with?(app.url, "https://"), "#{app.name} has no absolute URL"
+
+        assert String.starts_with?(app.source, "https://github.com/"),
+               "#{app.name} does not name a repository"
+
+        assert app.shows != "" and app.blurb != ""
+      end
+
+      ids = Enum.map(apps, & &1.id)
+      assert ids == Enum.uniq(ids), "an app is listed twice"
+
+      group_ids = Enum.map(FountainWeb.MarketingHTML.built_apps(), & &1.id)
+      assert group_ids == Enum.uniq(group_ids), "a group anchor is used twice"
+    end
+
+    test "every chip in the hero reaches a group on the page", %{conn: conn} do
+      body = conn |> get(~p"/built-with") |> html_response(200)
+
+      for group <- FountainWeb.MarketingHTML.built_apps() do
+        assert body =~ ~s(href="##{group.id}"), "no chip for #{group.title}"
+        assert body =~ ~s(id="#{group.id}"), "no anchor for #{group.title}"
+      end
+    end
+
+    test "carries its own card", %{conn: conn} do
+      body = conn |> get(~p"/built-with") |> html_response(200)
+      assert body =~ ~s(<meta property="og:title" content="Built with Fountain · Fountain")
+      assert body =~ ~s(<meta property="og:url" content="http://localhost:4000/built-with")
+      assert body =~ ~s(<meta name="description" content="13 open-source applications)
+    end
+
+    test "every link into the manual resolves to a page", %{conn: conn} do
+      body = conn |> get(~p"/built-with") |> html_response(200)
+
+      links =
+        ~r/href="\/docs\/([^"#]+)/
+        |> Regex.scan(body)
+        |> Enum.map(fn [_, slug] -> slug end)
+        |> Enum.uniq()
+
+      assert links != []
+
+      for slug <- links do
+        assert match?({:ok, _}, Fountain.Docs.get(slug)), "/docs/#{slug} is not a page"
+      end
+    end
+
+    test "the marketing nav and the homepage link to it", %{conn: conn} do
+      body = conn |> get(~p"/") |> html_response(200)
+      assert body =~ ~p"/built-with"
+      assert body =~ "People build whole products on it."
+    end
+  end
+
   describe "legal links" do
     test "registration form links to terms and privacy", %{conn: conn} do
       body = conn |> get(~p"/auth/register") |> html_response(200)

--- a/apps/fountain/test/fountain_web/controllers/marketing_instance_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_instance_test.exs
@@ -86,6 +86,18 @@ defmodule FountainWeb.MarketingInstanceTest do
     end
   end
 
+  describe "GET /built-with where the deployment is not the marketing site" do
+    test "sends the visitor to the build guide rather than somebody else's apps", %{conn: conn} do
+      Application.put_env(:fountain, :marketing_site, false)
+
+      conn = get(conn, ~p"/built-with")
+      assert redirected_to(conn) == ~p"/docs/build"
+
+      # The layout drops the link too: a nav entry to a redirect is a dead end.
+      refute conn |> get(~p"/") |> html_response(200) =~ ~p"/built-with"
+    end
+  end
+
   describe "GET / on the marketing site" do
     test "still serves the pitch", %{conn: conn} do
       Application.put_env(:fountain, :marketing_site, true)


### PR DESCRIPTION
`/integrations` answers "will it talk to my stack". This answers the question after it: **what does a whole product on this API look like?**

Thirteen apps, grouped by who they are for. Every one is open source, and every one is running right now against the hosted instance.

| Group | Apps |
|---|---|
| For everyone | Briefing Room, Table Talk, Reflex |
| For engineers | Repo Sage, Mission Control, Workbench, DNS Desk |
| For infrastructure | Watchtower, Mend, Rounds |
| For AI engineers | Arena |
| The clients | Team, Conversations |

A card is a glyph, its host, what the app is, what it demonstrates, and two links: **Open it** and **Source**.

## Shape

Same data-first shape as `/integrations`: the roster is `built_apps/0` in `MarketingHTML`, not markup. The guardrails hold the page to its own claim:

- every entry names an absolute URL and a `github.com` repository (a card that cannot be clicked is the failure being prevented);
- no app id and no group anchor is used twice;
- every hero chip reaches a group that exists on the page;
- every link into the manual resolves to a page, the check `/integrations` already carries.

Both new guardrails were confirmed to bite by breaking an entry on purpose and watching them fail.

## Homepage

A band between the feature grid and the objections, naming all thirteen. "People build whole products on it" is a stronger line than any feature bullet and had nowhere to live.

## Off the marketing site

`/built-with` redirects to `/docs/build`, for the reason `/integrations` redirects to the manual: a self-hosted instance has no business serving the upstream project's sales copy, and less business advertising somebody else's hosted apps.

## Verified

- `mix precommit` green end to end: credo clean, dialyzer `Total errors: 0`, sobelow passed, **4076 tests, 0 failures**.
- All **26** outbound links on the rendered page fetched: 26 × `200`.
- All 13 repositories confirmed `MIT` via the GitHub API, since the page says so.
- Every app's origin is already in `API_CORS_ORIGINS` and `OAUTH_CLIENTS` on the deployment, so "Sign in with Fountain" works from each card today. No infrastructure change needed.
- Rendered locally with `MARKETING_SITE=true` and read at full height, plus the homepage band.

🤖 Generated with [Claude Code](https://claude.com/claude-code)