### PR TITLE
feat(marketing): a landing page for running it yourself, at /self-hosted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,16 @@ upgrade, is in
   no asset pipeline behind it. Since #1008 `/docs` is the only place the
   manual is published, which left it as the one copy with no way to search.
 
+- **A landing page for running it yourself, `/self-hosted`.** The case for
+  an instance of your own, next to the case for ours: the bring-up in five
+  commands, the three licences and what each one asks of you, four rungs of
+  ownership down to the case where no third-party account is left in the loop,
+  and the four costs that land on the operator instead. The middle of it is
+  the inversion worth a page: the three features the hosted platform rations
+  are an env var on an instance of your own. Like `/integrations` and
+  `/built-with`, it is sales copy, so an instance that is not the marketing
+  site redirects to the manual's own `Self-host Fountain`.
+
 - **A gallery of the applications built on the API, `/built-with`.**
   Thirteen products, grouped by who they are for: a researcher that returns
   cited briefs, an analyst that runs Python on a CSV, a personal assistant you

--- a/apps/fountain/lib/fountain_web/components/layouts/marketing.html.heex
+++ b/apps/fountain/lib/fountain_web/components/layouts/marketing.html.heex
@@ -24,6 +24,13 @@
           Built with
         </a>
         <a
+          :if={Fountain.Marketing.site?()}
+          href={~p"/self-hosted"}
+          class="text-sm text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors px-3 py-1.5 rounded-md hover:bg-[var(--color-bg-2)]"
+        >
+          Self-host
+        </a>
+        <a
           href="/docs"
           class="text-sm text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors px-3 py-1.5 rounded-md hover:bg-[var(--color-bg-2)]"
         >
@@ -87,6 +94,13 @@
           class="hover:text-[var(--color-text-secondary)] transition-colors"
         >
           Built with
+        </a>
+        <a
+          :if={Fountain.Marketing.site?()}
+          href={~p"/self-hosted"}
+          class="hover:text-[var(--color-text-secondary)] transition-colors"
+        >
+          Self-host
         </a>
         <a href="/docs" class="hover:text-[var(--color-text-secondary)] transition-colors">
           Docs

--- a/apps/fountain/lib/fountain_web/controllers/marketing_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_controller.ex
@@ -1,11 +1,13 @@
 defmodule FountainWeb.MarketingController do
   @moduledoc """
-  The public pages: `/`, `/integrations`, `/built-with`, `/terms` and `/privacy`.
+  The public pages: `/`, `/integrations`, `/built-with`, `/self-hosted`, `/terms`
+  and `/privacy`.
 
   None of the four is the same page on every deployment. `/` serves the
   product pitch on the marketing site and a plain front door everywhere else
-  (`Fountain.Marketing`); `/integrations` and `/built-with` are the pitch's other two
-  pages and redirect into the manual on any other instance;
+  (`Fountain.Marketing`); `/integrations`, `/built-with` and `/self-hosted` are
+  the pitch's other three pages and redirect into the manual on any other
+  instance;
   the legal pages render the operator's identity, or nothing at all
   (`Fountain.Legal`). A deployment is not the Fountain project, and these
   pages are the ones that would claim otherwise.
@@ -53,6 +55,26 @@ defmodule FountainWeb.MarketingController do
       )
     else
       redirect(conn, to: ~p"/docs/build")
+    end
+  end
+
+  # The case for running it yourself. Sales copy for the other choice, which
+  # is still sales copy, so it follows the same rule: an instance that is not
+  # the marketing site sends the reader to the manual, where the operator's
+  # own answer lives.
+  def self_hosted(conn, _params) do
+    if Fountain.Marketing.site?() do
+      render(conn, :self_hosted,
+        layout: {FountainWeb.Layouts, :marketing},
+        page_title: "Self-host #{Fountain.Brand.engine()} · #{Fountain.Brand.name()}",
+        meta_description:
+          "#{Fountain.Brand.engine()} is open source and the whole product is in the " <>
+            "repo: the server, the console, the API, the CLI and the SDK. Bring an " <>
+            "instance up with Docker Compose or plain Kubernetes manifests, on your " <>
+            "hardware, under your own keys, with no licence key and no seat count."
+      )
+    else
+      redirect(conn, to: ~p"/docs/self-hosting")
     end
   end
 

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
@@ -664,4 +664,193 @@ defmodule FountainWeb.MarketingHTML do
 
   @doc "Every app on /built-with, flattened. The count the page quotes comes from here."
   def built_apps_flat, do: Enum.flat_map(built_apps(), & &1.apps)
+
+  ## /self-hosted
+
+  @repo_url "https://github.com/BinaryBourbon/fountain"
+
+  @doc "The project's repository. The self-hosted page links it from four places."
+  def repo_url, do: @repo_url
+
+  @doc """
+  The bring-up, verbatim from the deploy guide, so the page cannot drift into
+  showing commands the manual does not. Kept out of the template because
+  `$(...)` and `${...}` are not HEEx.
+  """
+  def compose_example do
+    """
+    git clone https://github.com/BinaryBourbon/fountain
+    cd fountain
+
+    cp .env.compose.example .env
+    echo "SECRET_KEY_BASE=$(openssl rand -base64 48 | tr -d '\\n')" >> .env
+    echo "MASTER_SECRETS_KEY=$(openssl rand 32 | base64 | tr '+/' '-_' | tr -d '=\\n')" >> .env
+    # ... and your sandbox provider token
+
+    docker compose up -d\
+    """
+  end
+
+  @doc """
+  The three features the hosted platform rations, and what they cost on an
+  instance of your own. The rows track `docs/reference/feature-status.md`; a
+  feature that comes off that page comes off this one.
+  """
+  def rationed_features do
+    [
+      %{
+        name: "Teammate email and phone",
+        blurb: "An agent with its own inbox and its own number, that answers what arrives.",
+        hosted: "Behind a flag. Ask us to turn it on for your account.",
+        yours: "Set the AgentMail and AgentPhone keys, add team_comms to FEATURE_FLAGS_ON.",
+        docs: "/docs/catalog/mcp-servers/fountain-comms"
+      },
+      %{
+        name: "OpenAI-compatible API",
+        blurb:
+          "Point anything that speaks chat completions at your instance, where the model is an agent.",
+        hosted: "Behind a flag. Ask us to turn it on for your account.",
+        yours: "Add openai_compat to FEATURE_FLAGS_ON.",
+        docs: "/docs/integrations/openai-compatible"
+      },
+      %{
+        name: "Brokered credentials",
+        blurb:
+          "The real token never enters the sandbox. The broker attaches it on the way out, and the transcript keeps a placeholder.",
+        hosted: "Limited access. We enrol an account by hand.",
+        yours: "Set BROKER_URL and its siblings, and list the tenants you want brokered.",
+        docs: "/docs/concepts/secrets"
+      }
+    ]
+  end
+
+  @doc "What each licence lets you do, in the order that matters to somebody deciding."
+  def licence_parts do
+    [
+      %{
+        part: "The server",
+        scope: "apps/fountain",
+        licence: "AGPL-3.0-or-later",
+        means:
+          "Run it, change it, host it, charge for it. Offer a changed server to other people over a network and they have a right to your source."
+      },
+      %{
+        part: "Credits and Stripe",
+        scope: "ee/",
+        licence: "Elastic 2.0",
+        means:
+          "Free to run in your own instance, and your changes stay yours. The one thing it forbids is selling this code to third parties as a hosted service."
+      },
+      %{
+        part: "The CLI and the SDK",
+        scope: "cli/, sdk/typescript",
+        licence: "Apache-2.0",
+        means:
+          "Ship them inside a closed product. An application that calls your instance takes on no obligation at all."
+      }
+    ]
+  end
+
+  @doc "The four rungs of ownership, from the app down to the last vendor."
+  def ownership_rungs do
+    [
+      %{
+        step: "01",
+        title: "The app",
+        body:
+          "Your container, your Postgres, your domain. Conversations, transcripts, audit rows and API keys live in a database you can open with psql."
+      },
+      %{
+        step: "02",
+        title: "The secrets",
+        body:
+          "Every tenant's env vars are encrypted with a key derived from a master key you generate. It is not in the database, which is also why a database backup on its own does not save you."
+      },
+      %{
+        step: "03",
+        title: "The machines",
+        body:
+          "A Mac mini, a home server or a GPU box becomes a sandbox backend with one daemon. It dials out, holds one connection, wants no inbound port and no credential."
+      },
+      %{
+        step: "04",
+        title: "The last vendor",
+        body:
+          "Server on your hardware, sandboxes on your machines, and no third-party account is left in the loop. Not a sandbox host's, and not ours."
+      }
+    ]
+  end
+
+  @doc """
+  What self-hosting costs, said plainly. A page that sells an instance and
+  hides the bill for it gets found out in week three.
+  """
+  def self_host_costs do
+    [
+      %{
+        title: "A sandbox backend is somebody's service, unless you bring machines",
+        body:
+          "Sprites, E2B and Daytona are all hosted. Daytona you can run yourself, and your own runners need no vendor at all. Pick one before your first conversation, because without one every conversation fails.",
+        docs: "/docs/integrations/runners",
+        docs_label: "Runners on your own hardware"
+      },
+      %{
+        title: "Email is a decision, not an optional extra",
+        body:
+          "Verification, password resets and anything a teammate sends go through Resend or an SMTP server of yours. The compose defaults skip delivery so the first account can register, and that default is for day one only.",
+        docs: "/docs/guides/operate/email",
+        docs_label: "Configure email"
+      },
+      %{
+        title: "The master key is yours to lose",
+        body:
+          "Back it up before you have data. Lose it and every encrypted secret in the instance is gone, and no database restore brings them back.",
+        docs: "/docs/guides/operate/back-up-and-restore",
+        docs_label: "Back up and restore"
+      },
+      %{
+        title: "Upgrades are yours to run",
+        body:
+          "Pull the tag, run the migrations, read the note. There is no window where somebody else does it for you, and no window where somebody else does it to you.",
+        docs: "/docs/guides/operate/upgrade",
+        docs_label: "Upgrade an instance"
+      }
+    ]
+  end
+
+  @doc "The questions somebody asks between reading this page and running the clone."
+  def self_host_faq do
+    [
+      %{
+        q: "Is it really the same code?",
+        a:
+          "The same image and the same manifests. Every merge publishes deploy/ as an OCI artifact, and the hosted instance deploys from that artifact. There is no private overlay, and no patch that only we have."
+      },
+      %{
+        q: "Does the AGPL reach my application?",
+        a:
+          "No. Your application talks to your instance over HTTP, and the CLI and the SDK are Apache-2.0 for exactly that reason. The copyleft has one target: somebody who changes the server and then offers the changed server to other people as a service."
+      },
+      %{
+        q: "What do I pay for the software?",
+        a:
+          "Nothing. There is no licence key, no seat count and no call with us. Leave credits off and the instance prices nothing, gates nothing and shows nobody a bill. Turn credits on and it bills your users, not you."
+      },
+      %{
+        q: "Do I still bring a model key?",
+        a:
+          "Yes, and you always did. The agent bills your Anthropic, OpenAI or Google account for tokens. Nothing in the middle takes a cut of inference, hosted or not."
+      },
+      %{
+        q: "Can I try the hosted one first?",
+        a:
+          "Yes, and none of it is wasted. The console, the CLI, the API, the SDK and the manual are the same on both. What changes is whose machine it runs on."
+      },
+      %{
+        q: "How much of an instance is one person?",
+        a:
+          "A container, a Postgres and a sandbox token. It ships with a compose file that brings the database with it, and plain Kubernetes manifests for when it outgrows that."
+      }
+    ]
+  end
 end

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -297,10 +297,10 @@
         <span :if={Fountain.Brand.hosted?()}>
           {Fountain.Brand.name()} is the hosted edition of {Fountain.Brand.engine()}, an open-source server
         </span>
-        <span :if={!Fountain.Brand.hosted?()}>{Fountain.Brand.engine()} is open source</span>, and you can run it on your own hardware, with your own sandboxes. <a
-          href={~p"/docs/open-source"}
+        <span :if={!Fountain.Brand.hosted?()}>{Fountain.Brand.engine()} is open source</span>, and you can run it on your own hardware, with your own sandboxes. Nothing is held back for the people who pay. <a
+          href={~p"/self-hosted"}
           class="underline underline-offset-2 hover:text-[var(--color-text-primary)]"
-        >Read about the open-source engine</a>.
+        >See the case for running it yourself</a>.
       </dd>
     </div>
   </dl>

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/self_hosted.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/self_hosted.html.heex
@@ -1,0 +1,271 @@
+<%!-- Hero --%>
+<section class="max-w-5xl mx-auto px-6 py-20 text-center">
+  <p class="mb-4 text-sm font-medium uppercase tracking-wide text-[var(--color-text-muted)]">
+    Self-hosted
+  </p>
+  <h1 class="text-4xl sm:text-5xl font-bold tracking-tight text-[var(--color-text-primary)] mb-5 leading-tight">
+    There is no Enterprise edition. There is the repo.
+  </h1>
+  <p class="text-lg sm:text-xl text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-4">
+    {Fountain.Brand.engine()} runs Claude Code, Codex, Gemini and OpenCode on sandboxes it builds for you, behind one API.
+    <span :if={Fountain.Brand.hosted?()}>
+      {Fountain.Brand.name()} is one instance of it, the one we happen to run.
+    </span>
+    <span :if={!Fountain.Brand.hosted?()}>
+      This site is one instance of it, the one we happen to run.
+    </span>
+    Clone the same code, set two secrets, and yours is up in five commands, on your hardware, under your keys.
+  </p>
+  <p class="text-lg sm:text-xl font-medium text-[var(--color-text-primary)] max-w-2xl mx-auto mb-10">
+    Nothing is held back for the people who pay.
+  </p>
+  <div class="flex flex-col sm:flex-row gap-3 justify-center mb-4">
+    <a
+      href={~p"/docs/guides/operate/deploy"}
+      class="inline-flex items-center justify-center px-6 py-3 rounded-lg bg-[var(--color-brand)] text-white font-medium hover:bg-[var(--color-brand-hover)] transition-colors text-sm"
+    >
+      Bring up an instance
+    </a>
+    <a
+      href={repo_url()}
+      class="inline-flex items-center justify-center px-6 py-3 rounded-lg border border-[var(--color-border)] text-[var(--color-text-primary)] font-medium hover:bg-[var(--color-bg-2)] transition-colors text-sm"
+    >
+      Read the source
+    </a>
+  </div>
+  <p class="text-xs text-[var(--color-text-muted)]">
+    AGPL-3.0. No licence key, no seat count, no call with us.
+  </p>
+</section>
+
+<%!-- Bring-up: the whole install, shown rather than described. --%>
+<section class="bg-[var(--color-bg-1)] border-y border-[var(--color-border)]">
+  <div class="max-w-5xl mx-auto px-6 py-16">
+    <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-3 text-center">
+      Five commands and a token.
+    </h2>
+    <p class="text-center text-[var(--color-text-secondary)] max-w-xl mx-auto mb-10">
+      The compose file brings its own Postgres. Back the master key up before you have data, because it is not in the database.
+    </p>
+    <pre
+      class="rounded-xl border border-[var(--color-border)] bg-[var(--color-code-bg)] text-[var(--color-code-text)] p-5 text-sm leading-relaxed overflow-x-auto"
+      phx-no-format
+    ><code>{compose_example()}</code></pre>
+    <div class="grid md:grid-cols-2 gap-6 mt-8">
+      <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6">
+        <h3 class="font-semibold text-[var(--color-text-primary)] mb-2">Then register.</h3>
+        <p class="text-sm text-[var(--color-text-secondary)] leading-relaxed">
+          Open the instance and sign up. The first account verifies itself and takes the admin role, so there is no bootstrap ritual and no console of ours in the path. Close registration behind you when you are done.
+        </p>
+      </div>
+      <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6">
+        <h3 class="font-semibold text-[var(--color-text-primary)] mb-2">Kubernetes instead?</h3>
+        <p
+          class="text-sm text-[var(--color-text-secondary)] leading-relaxed"
+          phx-no-format
+        >Plain manifests in <code class="text-xs text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1.5 py-0.5">deploy/k8s/</code>, with no operators and no CRDs. Every merge publishes them as an OCI artifact, and the hosted instance deploys from it. You apply what we apply.</p>
+        <a
+          href={~p"/docs/guides/operate/kubernetes"}
+          class="inline-block mt-3 text-sm font-medium text-[var(--color-text-primary)] underline underline-offset-2 hover:text-[var(--color-brand)]"
+        >
+          Deploy on Kubernetes →
+        </a>
+      </div>
+    </div>
+  </div>
+</section>
+
+<%!-- The inversion: what is rationed on the hosted platform is an env var on
+      your own. The rows track docs/reference/feature-status.md. --%>
+<section class="max-w-5xl mx-auto px-6 py-16">
+  <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-3 text-center">
+    The features we ration, you switch on.
+  </h2>
+  <p class="text-center text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-12">
+    Three things are not on for everyone here. Two are alpha and one changes what a sandbox can reach, so on the hosted platform each of them means an email to us and a wait. On an instance of your own they are a line in a config file, and nobody has to approve you.
+  </p>
+  <div class="space-y-4">
+    <article
+      :for={feature <- rationed_features()}
+      class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6 sm:p-8"
+      data-role="rationed"
+    >
+      <div class="grid md:grid-cols-3 gap-6">
+        <div>
+          <h3 class="font-semibold text-[var(--color-text-primary)]">{feature.name}</h3>
+          <p class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">
+            {feature.blurb}
+          </p>
+          <a
+            href={feature.docs}
+            class="inline-block mt-3 text-sm font-medium text-[var(--color-text-primary)] underline underline-offset-2 hover:text-[var(--color-brand)]"
+          >
+            Read the page →
+          </a>
+        </div>
+        <div>
+          <p class="text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)] mb-2">
+            Here
+          </p>
+          <p class="text-sm text-[var(--color-text-secondary)] leading-relaxed">
+            {feature.hosted}
+          </p>
+        </div>
+        <div>
+          <p class="text-xs font-medium uppercase tracking-wide text-[var(--color-brand)] mb-2">
+            On yours
+          </p>
+          <p class="text-sm text-[var(--color-text-primary)] leading-relaxed font-medium">
+            {feature.yours}
+          </p>
+        </div>
+      </div>
+    </article>
+  </div>
+  <p class="text-center text-sm text-[var(--color-text-muted)] max-w-2xl mx-auto mt-8">
+    The rest of the product has no flag on it. The hosted instance adds nothing that is not in the repo. It runs the release image with switches set, and the
+    <a
+      href={~p"/docs/configuration"}
+      class="underline underline-offset-2 hover:text-[var(--color-text-secondary)]"
+    >
+      configuration reference
+    </a>
+    lists every one of them.
+  </p>
+</section>
+
+<%!-- Licences --%>
+<section class="bg-[var(--color-bg-1)] border-y border-[var(--color-border)]">
+  <div class="max-w-5xl mx-auto px-6 py-16">
+    <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-3 text-center">
+      Three licences, and what each one asks of you.
+    </h2>
+    <p class="text-center text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-12">
+      The parts your code touches are permissive on purpose. A connection to {Fountain.Brand.engine()} must never put an obligation on your application.
+    </p>
+    <div class="grid md:grid-cols-3 gap-6">
+      <div
+        :for={part <- licence_parts()}
+        class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6 flex flex-col"
+        data-role="licence"
+      >
+        <h3 class="font-semibold text-[var(--color-text-primary)]">{part.part}</h3>
+        <code
+          class="inline-block self-start mt-1 text-xs text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1.5 py-0.5"
+          phx-no-format
+        >{part.scope}</code>
+        <p class="mt-3 text-sm font-medium text-[var(--color-brand)]">{part.licence}</p>
+        <p class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">
+          {part.means}
+        </p>
+      </div>
+    </div>
+    <p class="text-center text-sm text-[var(--color-text-muted)] mt-8">
+      <a
+        href={~p"/docs/open-source"}
+        class="underline underline-offset-2 hover:text-[var(--color-text-secondary)]"
+      >
+        What is open, what is not, and where each thing lives
+      </a>
+    </p>
+  </div>
+</section>
+
+<%!-- The ownership ladder --%>
+<section class="max-w-5xl mx-auto px-6 py-16">
+  <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-3 text-center">
+    How far down do you want to own it?
+  </h2>
+  <p class="text-center text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-12">
+    Most people stop at the first rung and are happy there. The point is that the next three exist, and that none of them is a sales conversation.
+  </p>
+  <div class="grid sm:grid-cols-2 lg:grid-cols-4 gap-6">
+    <div
+      :for={rung <- ownership_rungs()}
+      class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6"
+      data-role="rung"
+    >
+      <p class="text-xs font-semibold text-[var(--color-brand)] tracking-wide">{rung.step}</p>
+      <h3 class="mt-2 font-semibold text-[var(--color-text-primary)]">{rung.title}</h3>
+      <p class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">{rung.body}</p>
+    </div>
+  </div>
+  <p class="text-center text-[var(--color-text-secondary)] max-w-2xl mx-auto mt-10">
+    A model key is the one thing you still bring, and you always did. The agent bills your own provider account for tokens, so nothing in the middle takes a cut of inference. <a
+      href={~p"/docs/integrations/runners"}
+      class="underline underline-offset-2 hover:text-[var(--color-text-primary)]"
+    >Read how a machine of yours becomes a sandbox</a>.
+  </p>
+</section>
+
+<%!-- The bill, said out loud. --%>
+<section class="bg-[var(--color-bg-1)] border-y border-[var(--color-border)]">
+  <div class="max-w-5xl mx-auto px-6 py-16">
+    <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-3 text-center">
+      What it costs you instead.
+    </h2>
+    <p class="text-center text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-12">
+      Self-hosting is not free, it is paid in a different currency. Better you know the four line items now than in week three.
+    </p>
+    <div class="grid md:grid-cols-2 gap-6">
+      <div
+        :for={cost <- self_host_costs()}
+        class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6 flex flex-col"
+        data-role="cost"
+      >
+        <h3 class="font-semibold text-[var(--color-text-primary)]">{cost.title}</h3>
+        <p class="mt-2 flex-1 text-sm text-[var(--color-text-secondary)] leading-relaxed">
+          {cost.body}
+        </p>
+        <a
+          href={cost.docs}
+          class="mt-4 text-sm font-medium text-[var(--color-text-primary)] underline underline-offset-2 hover:text-[var(--color-brand)]"
+        >
+          {cost.docs_label} →
+        </a>
+      </div>
+    </div>
+  </div>
+</section>
+
+<%!-- Objections --%>
+<section class="max-w-5xl mx-auto px-6 py-16">
+  <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-10 text-center">
+    Things you would ask before the clone.
+  </h2>
+  <dl class="max-w-2xl mx-auto space-y-6 text-[var(--color-text-secondary)]">
+    <div :for={item <- self_host_faq()} data-role="faq">
+      <dt class="font-medium text-[var(--color-text-primary)]">{item.q}</dt>
+      <dd class="mt-1 text-sm leading-relaxed">{item.a}</dd>
+    </div>
+  </dl>
+</section>
+
+<%!-- Footer CTA --%>
+<section class="bg-[var(--color-bg-1)] border-t border-[var(--color-border)]">
+  <div class="max-w-5xl mx-auto px-6 py-20 text-center">
+    <h2 class="text-2xl sm:text-3xl font-bold text-[var(--color-text-primary)] mb-4">
+      Clone it tonight.
+    </h2>
+    <p class="text-[var(--color-text-secondary)] mb-8 max-w-lg mx-auto">
+      A container, a Postgres and a sandbox token. The manual has the whole path, the repo has the issues, and neither of them has a sales form in it.
+    </p>
+    <div class="flex flex-col sm:flex-row gap-3 justify-center">
+      <a
+        href={~p"/docs/guides/operate/deploy"}
+        class="inline-flex items-center justify-center px-8 py-3 rounded-lg bg-[var(--color-brand)] text-white font-medium hover:bg-[var(--color-brand-hover)] transition-colors"
+      >
+        Bring up an instance
+      </a>
+      <a
+        href={~p"/docs/self-hosting"}
+        class="inline-flex items-center justify-center px-8 py-3 rounded-lg border border-[var(--color-border)] text-[var(--color-text-primary)] font-medium hover:bg-[var(--color-bg-2)] transition-colors"
+      >
+        Read the operator's manual
+      </a>
+    </div>
+    <p class="mt-8 text-xs text-[var(--color-text-muted)] max-w-xl mx-auto">
+      Prefer that somebody else runs it? That is what this site is for, and the two are the same product.
+    </p>
+  </div>
+</section>

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -157,6 +157,7 @@ defmodule FountainWeb.Router do
     get "/", MarketingController, :home
     get "/integrations", MarketingController, :integrations
     get "/built-with", MarketingController, :built_with
+    get "/self-hosted", MarketingController, :self_hosted
     get "/terms", MarketingController, :terms
     get "/privacy", MarketingController, :privacy
     # The public manual, and since #1008 the only place it is published —

--- a/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
@@ -177,6 +177,72 @@ defmodule FountainWeb.MarketingControllerTest do
     end
   end
 
+  describe "GET /self-hosted" do
+    test "makes the case and shows the whole bring-up", %{conn: conn} do
+      body = conn |> get(~p"/self-hosted") |> html_response(200)
+
+      assert body =~ "There is no Enterprise edition. There is the repo."
+      assert body =~ "Five commands and a token."
+      assert body =~ "The features we ration, you switch on."
+      assert body =~ "What it costs you instead."
+
+      # The bring-up is kept out of the template so its $(...) is not HEEx.
+      assert body =~ "docker compose up -d"
+      assert body =~ "MASTER_SECRETS_KEY"
+
+      for licence <- ["AGPL-3.0-or-later", "Elastic 2.0", "Apache-2.0"] do
+        assert body =~ licence, "missing licence #{licence}"
+      end
+
+      assert body =~ FountainWeb.MarketingHTML.repo_url()
+    end
+
+    test "names every feature the manual says is rationed", %{conn: conn} do
+      body = conn |> get(~p"/self-hosted") |> html_response(200)
+
+      # The page's whole argument is that these three are an env var on an
+      # instance of your own. A feature that comes off the manual's status
+      # page has to come off this one, or the argument quotes a gate that no
+      # longer exists.
+      {:ok, status} = Fountain.Docs.get("reference/feature-status")
+
+      for %{name: name} <- FountainWeb.MarketingHTML.rationed_features() do
+        assert body =~ name, "missing feature #{name}"
+
+        assert status.body =~ name,
+               "#{name} is not on the manual's feature-status page any more"
+      end
+    end
+
+    test "carries its own card", %{conn: conn} do
+      body = conn |> get(~p"/self-hosted") |> html_response(200)
+      assert body =~ ~s(<meta property="og:title" content="Self-host Fountain · Fountain")
+      assert body =~ ~s(<meta name="description" content="Fountain is open source)
+      assert body =~ ~s(<meta property="og:url" content="http://localhost:4000/self-hosted")
+    end
+
+    test "every link into the manual resolves to a page", %{conn: conn} do
+      body = conn |> get(~p"/self-hosted") |> html_response(200)
+
+      links =
+        ~r/href="\/docs\/([^"#]+)/
+        |> Regex.scan(body)
+        |> Enum.map(fn [_, slug] -> slug end)
+        |> Enum.uniq()
+
+      assert links != []
+
+      for slug <- links do
+        assert match?({:ok, _}, Fountain.Docs.get(slug)), "/docs/#{slug} is not a page"
+      end
+    end
+
+    test "the marketing nav and the homepage link to it", %{conn: conn} do
+      body = conn |> get(~p"/") |> html_response(200)
+      assert body =~ ~p"/self-hosted"
+    end
+  end
+
   describe "legal links" do
     test "registration form links to terms and privacy", %{conn: conn} do
       body = conn |> get(~p"/auth/register") |> html_response(200)

--- a/apps/fountain/test/fountain_web/controllers/marketing_instance_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_instance_test.exs
@@ -98,6 +98,18 @@ defmodule FountainWeb.MarketingInstanceTest do
     end
   end
 
+  describe "GET /self-hosted where the deployment is not the marketing site" do
+    test "sends the visitor to the operator's manual rather than the pitch", %{conn: conn} do
+      Application.put_env(:fountain, :marketing_site, false)
+
+      conn = get(conn, ~p"/self-hosted")
+      assert redirected_to(conn) == ~p"/docs/self-hosting"
+
+      # The layout drops the link too: a nav entry to a redirect is a dead end.
+      refute conn |> get(~p"/") |> html_response(200) =~ ~p"/self-hosted"
+    end
+  end
+
   describe "GET / on the marketing site" do
     test "still serves the pitch", %{conn: conn} do
       Application.put_env(:fountain, :marketing_site, true)


### PR DESCRIPTION
The pitch has had one answer for "can I run it myself": an FAQ line on the
homepage pointing into the manual. The manual is the right place for *how*,
and the wrong place for *why*. Somebody deciding between our instance and
their own wants the case, not a deploy guide.

So `/self-hosted`, the pitch's fourth page, on the same rule as the other
three. It is sales copy for the other choice, so an instance that is not the
marketing site redirects to `/docs/self-hosting` rather than serving the
project's argument as its own.

## The argument

The page is built on the one claim only this repo can make honestly: the
hosted instance runs the same image from the same manifests and adds nothing
that is not in the repo. Every section is downstream of that.

- **Hero.** "There is no Enterprise edition. There is the repo." Then the
  three objections in one line of fine print: AGPL-3.0, no licence key, no
  seat count, no call with us.
- **Five commands and a token.** The bring-up verbatim from the deploy guide,
  so the page cannot drift into showing commands the manual does not, plus
  the Kubernetes card: every merge publishes `deploy/` as an OCI artifact and
  the hosted instance deploys from it, so you apply what we apply.
- **"The features we ration, you switch on."** The section worth having a
  page for. The three features gated on the hosted platform are an email to
  us and a wait; on an instance of your own they are a line in a config file.
- **Three licences and what each one asks of you.** Including the part that
  matters to a reader with an application to ship: the CLI and the SDK are
  Apache-2.0, so a connection to Fountain puts no obligation on their code.
- **Four rungs of ownership**, down to the case where no third-party account
  is left in the loop at all.
- **"What it costs you instead."** Said out loud: the sandbox backend is
  somebody's service unless you bring machines, email is a decision, the
  master key is yours to lose, upgrades are yours to run. A page that sells an
  instance and hides the bill for it gets found out in week three, and the
  honesty is what makes the rest of the page credible.

## Shape

Data-first in `MarketingHTML`, as on `/integrations` and `/built-with`, so
the licences, the rungs, the costs and the FAQ are lists rather than markup.
The homepage's "Can I run it myself?" answer now points here, and the nav and
footer carry the page wherever the marketing site is on.

## Guardrails

- Every link into the manual resolves to a page, the check `/integrations`
  and `/built-with` already carry.
- Every feature the rationed-features section names is still on
  `docs/reference/feature-status.md`. The section's whole argument is that
  those three are a config line on your own instance; a feature that comes
  off the manual's status page has to come off this one, or the page quotes a
  gate that no longer exists.
- The non-marketing instance redirects to `/docs/self-hosting`, and the
  layout drops the nav entry, because a nav link to a redirect is a dead end.

## Verification

Rendered and read end to end in a browser (that is where a collapsed space
after an inline `<code>` turned up, since fixed). Full suite 4082 tests, 0
failures. `credo --strict`, sobelow and dialyzer clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)