### PR TITLE
copy(marketing): a headline for /self-hosted that is true and sells something

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/self_hosted.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/self_hosted.html.heex
@@ -4,7 +4,7 @@
     Self-hosted
   </p>
   <h1 class="text-4xl sm:text-5xl font-bold tracking-tight text-[var(--color-text-primary)] mb-5 leading-tight">
-    There is no Enterprise edition. There is the repo.
+    Give your app a coding agent. Own every machine it touches.
   </h1>
   <p class="text-lg sm:text-xl text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-4">
     {Fountain.Brand.engine()} runs Claude Code, Codex, Gemini and OpenCode on sandboxes it builds for you, behind one API.
@@ -14,10 +14,10 @@
     <span :if={!Fountain.Brand.hosted?()}>
       This site is one instance of it, the one we happen to run.
     </span>
-    Clone the same code, set two secrets, and yours is up in five commands, on your hardware, under your keys.
+    Clone the same repository, set two secrets, and yours answers the same API in five commands, on your hardware, under your own keys.
   </p>
   <p class="text-lg sm:text-xl font-medium text-[var(--color-text-primary)] max-w-2xl mx-auto mb-10">
-    Nothing is held back for the people who pay.
+    There are no tiers to buy. The features we ration on this site are a line of config on yours.
   </p>
   <div class="flex flex-col sm:flex-row gap-3 justify-center mb-4">
     <a

--- a/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
@@ -181,7 +181,7 @@ defmodule FountainWeb.MarketingControllerTest do
     test "makes the case and shows the whole bring-up", %{conn: conn} do
       body = conn |> get(~p"/self-hosted") |> html_response(200)
 
-      assert body =~ "There is no Enterprise edition. There is the repo."
+      assert body =~ "Give your app a coding agent. Own every machine it touches."
       assert body =~ "Five commands and a token."
       assert body =~ "The features we ration, you switch on."
       assert body =~ "What it costs you instead."


### PR DESCRIPTION
## The problem

`/self-hosted` opened with **"There is no Enterprise edition. There is the repo."**

That is not true, in three places at once:

- `home.html.heex` renders **"{Brand} is the hosted enterprise edition of {Engine}"** as the eyebrow above the homepage headline, on any branded hosted site.
- `ee/` exists, and the page's own licence table names it: Elastic 2.0.
- The page's own middle section is headed **"The features we ration, you switch on."**

The kicker under it, "Nothing is held back for the people who pay," is contradicted by that same section three screens later.

It also sells nothing. Both lines are anti-headlines. They name a thing that does not exist and leave the reader to convert a negative into a value on their own. Somebody who clicked "Self-host" wants an outcome; our licensing posture is not one.

## The replacement

| | |
|---|---|
| Home | Give your app a coding agent. **Skip the machine it needs.** |
| Self-hosted | Give your app a coding agent. **Own every machine it touches.** |

Same first clause, so the two pages read as one product with one objection removed. The second clause is what the reader came for, and **"How far down do you want to own it?"** three sections down pays it off rung by rung, down to the case where no third-party account is left in the loop.

The kicker keeps the original instinct and makes it accurate:

> There are no tiers to buy. The features we ration on this site are a line of config on yours.

"There are no tiers to buy" is ADR 0031 said out loud, and it hands straight off to the inversion the page exists for. A true specific beats a false absolute, and it is the sharper sentence anyway.

## What I did not write

**"The whole product is in the repository"** was the first draft of that kicker, and it is the same species of overclaim: the conversations and team UIs are two other repositories (public, MIT, but not this one), and `ee/` is Elastic 2.0, which is not OSI-open. The licence table below would have caught it out the same way.

## Also

- "Clone the same code" is now "Clone the same repository, and yours answers the same API" — the claim is that your instance serves the same API, not that the source matches.
- "under your keys" is now "under your own keys", the phrase the meta description already uses.

Nothing else on the page changed. The rationed features, the licences, the rungs and the four costs were already honest, which is why the headline stood out.

## Test

`marketing_controller_test.exs` asserted the old H1 verbatim; it now asserts the new one. 34 tests in `marketing_controller_test.exs` + `brand_chrome_test.exs`, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)