### PR TITLE
fix(test): async modules must not write global application env

### DIFF
--- a/apps/fountain/test/fountain/async_global_config_guardrail_test.exs
+++ b/apps/fountain/test/fountain/async_global_config_guardrail_test.exs
@@ -1,0 +1,124 @@
+defmodule Fountain.AsyncGlobalConfigGuardrailTest do
+  use ExUnit.Case, async: true
+
+  @moduledoc """
+  An `async: true` test module must not write `Application.put_env(:fountain, ...)`.
+
+  Application env is global. ExUnit runs async modules concurrently, so a
+  module that writes config changes it for every test running beside it, for
+  as long as the write is held. When production code reads that key on a hot
+  path, the result is a failure in a *different* file, on some seeds only, and
+  usually not on the machine of whoever has to explain it.
+
+  Two of these were live in the suite before this guardrail:
+
+    * `quotas_test.exs` held `:sandboxes` `fleet_ceiling` at 2, and
+      `conversations_start_test.exs` lost its tenant-cap assertions to
+      `{:error, :fleet_full}`.
+    * `user_emails_test.exs` held `:public_url` at `fountain.example.com`, and
+      every `og:url` assertion in the suite failed while it did.
+
+  Both now live in sibling `async: false` modules. ExUnit runs every async
+  module first and the sync ones one at a time afterwards, so a sync module
+  cannot overlap an async one — which is the whole fix, and the reason the
+  answer here is "move it", not "add a lock".
+
+  The allowlist is not a blessing. Each entry writes a key no concurrent test
+  has been shown to read; none has been proven safe. Moving one into an
+  `async: false` module is always correct, and is what to do the moment one of
+  them is suspected in a flake. The list only shrinks.
+  """
+
+  # Paths are relative to the umbrella root, the way CLAUDE.md names them.
+  #
+  # Not a blessing. Each entry writes a key that no concurrent test has been
+  # shown to read, which is weaker than "safe": the two that were moved out
+  # were only caught because a reader happened to assert on the key. The keys
+  # to fear are the ones production reads on a hot path — `:public_url` on
+  # every render, `:sandboxes` on every reservation, `:credits_enabled` on
+  # every gate. `:credits_enabled` is on this list three times; a seed sweep
+  # did not reproduce a failure from it, so it stays here rather than being
+  # moved on a hunch. It is the first place to look when a `:fleet_full` or a
+  # balance assertion fails somewhere unrelated.
+  #
+  # The list only shrinks. Moving a file into a sibling `async: false` module
+  # is always correct.
+  @allowed [
+    # :feature_flag_overrides — read by the flag lookup.
+    "apps/fountain/test/fountain/audit_guardrail_test.exs",
+    # :broker_allow_unenforced — read while provisioning a brokered sandbox.
+    "apps/fountain/test/fountain/conversations/provisioning_test.exs",
+    # :sprites_public_urls — read by the sandbox URL lookup.
+    "apps/fountain/test/fountain/sandbox/sprites_test.exs",
+    # :webhook_allow_http — read when a webhook URL is validated.
+    "apps/fountain/test/fountain/webhooks/url_test.exs",
+    # :webhooks_enabled — read on every webhook dispatch.
+    "apps/fountain/test/fountain/webhooks_test.exs",
+    # :retention_days — read only by the pruner under test.
+    "apps/fountain/test/fountain/workers/retention_pruner_test.exs",
+    # :secret_expiry_notice_days — read only by the sweeper under test.
+    "apps/fountain/test/fountain/workers/secret_expiry_sweeper_test.exs",
+    # :callback_key_ttl_seconds — read when a callback key is minted.
+    "apps/fountain/test/fountain_web/api_key_scope_test.exs",
+    # :buzz_cli_bin — read only by the buzz paths under test.
+    "apps/fountain/test/fountain_web/controllers/buzz_mcp_controller_test.exs",
+    # :runners_enabled — read by the agent surfaces.
+    "apps/fountain/test/fountain_web/live/agents_live_test.exs",
+    # :credits_enabled — read by every spend gate and by Quotas.sandbox_limit.
+    "ee/test/fountain/credits_test.exs",
+    # :credits_enabled — as above, for the whole module.
+    "ee/test/fountain/workers/credit_expirer_test.exs",
+    # :credits_enabled and :credits — as above, for the whole module.
+    "ee/test/fountain/workers/credit_pricer_test.exs"
+  ]
+
+  # The module's own `use` line, not the words anywhere in the file: these
+  # modules explain in a comment which async module they were moved out of,
+  # and a substring match reads that as a declaration.
+  @async_use ~r/^\s*use\s+[\w.]+,\s*async:\s*true/m
+
+  test "no async test module writes global application env" do
+    root = Path.expand("../../../..", __DIR__)
+
+    files =
+      ["apps/fountain/test", "ee/test"]
+      |> Enum.flat_map(&Path.wildcard(Path.join([root, &1, "**/*_test.exs"])))
+
+    assert files != [], "the guardrail found no test files — it would pass over anything"
+
+    self = Path.relative_to(Path.expand(__ENV__.file), root)
+
+    offenders =
+      files
+      |> Enum.reject(&(Path.relative_to(&1, root) == self))
+      |> Enum.filter(fn abs ->
+        body = File.read!(abs)
+
+        Regex.match?(@async_use, body) and writes_env?(body)
+      end)
+      |> Enum.map(&Path.relative_to(&1, root))
+      |> Enum.reject(&(&1 in @allowed))
+      |> Enum.sort()
+
+    assert offenders == [], """
+    These async test modules write global application env:
+
+    #{Enum.map_join(offenders, "\n", &"  #{&1}")}
+
+    Move the tests that write config into a sibling `async: false` module —
+    see quotas_fleet_ceiling_test.exs — or, if the key is genuinely read by
+    nothing that runs concurrently, add the file to @allowed here with a
+    comment naming the key.
+    """
+  end
+
+  # A commented-out or quoted call is not a call. Comment lines are dropped
+  # before the match, which is also what keeps the sibling modules' own
+  # explanations from reading as offences.
+  defp writes_env?(body) do
+    body
+    |> String.split("\n")
+    |> Enum.reject(&String.starts_with?(String.trim_leading(&1), "#"))
+    |> Enum.any?(&String.contains?(&1, "Application.put_env(:fountain,"))
+  end
+end

--- a/apps/fountain/test/fountain/emails/user_emails_public_url_test.exs
+++ b/apps/fountain/test/fountain/emails/user_emails_public_url_test.exs
@@ -1,0 +1,63 @@
+# async: false — these tests write the global `:public_url`, and
+# `FountainWeb.OpenGraph.url/1` reads it on every page render in the suite.
+#
+# They used to sit in `user_emails_test.exs`, which is `async: true`. While
+# one of them held `:public_url` at `fountain.example.com`, a controller test
+# rendering a page beside it saw that host in its `og:url` and failed an
+# assertion about `http://localhost:4000`. Same shape as the fleet ceiling in
+# `quotas_fleet_ceiling_test.exs`: an async module writing global config that
+# production code reads on a hot path.
+defmodule Fountain.Emails.UserEmailsPublicUrlTest do
+  use Fountain.DataCase, async: false
+
+  import Swoosh.TestAssertions
+
+  alias Fountain.Emails.UserEmails
+
+  describe "link absoluteness" do
+    # These assert on the scheme, not just the path. The original tests only
+    # checked "/users/confirm/<token>", which passed happily while production
+    # was emitting "fountain.inevitable.fyi/users/confirm/<token>" — a string
+    # no mail client will render as a link.
+    setup do
+      original = Application.get_env(:fountain, :public_url)
+      on_exit(fn -> Application.put_env(:fountain, :public_url, original) end)
+      :ok
+    end
+
+    test "verification link is absolute even if :public_url is set to a bare host" do
+      Application.put_env(:fountain, :public_url, "fountain.example.com")
+      user = insert_verified_user()
+
+      assert {:ok, _} = UserEmails.deliver_verification_email(user, "tok")
+
+      assert_email_sent(fn email ->
+        assert email.html_body =~ "https://fountain.example.com/users/confirm/tok"
+        assert email.text_body =~ "https://fountain.example.com/users/confirm/tok"
+      end)
+    end
+
+    test "reset link is absolute even if :public_url is set to a bare host" do
+      Application.put_env(:fountain, :public_url, "fountain.example.com")
+      user = insert_verified_user()
+
+      assert {:ok, _} = UserEmails.deliver_password_reset_email(user, "tok")
+
+      assert_email_sent(fn email ->
+        assert email.html_body =~ "https://fountain.example.com/auth/reset/tok"
+        assert email.text_body =~ "https://fountain.example.com/auth/reset/tok"
+      end)
+    end
+
+    test "an absolute :public_url is preserved verbatim" do
+      Application.put_env(:fountain, :public_url, "https://custom.example.org")
+      user = insert_verified_user()
+
+      assert {:ok, _} = UserEmails.deliver_verification_email(user, "tok")
+
+      assert_email_sent(fn email ->
+        assert email.html_body =~ "https://custom.example.org/users/confirm/tok"
+      end)
+    end
+  end
+end

--- a/apps/fountain/test/fountain/emails/user_emails_test.exs
+++ b/apps/fountain/test/fountain/emails/user_emails_test.exs
@@ -40,52 +40,9 @@ defmodule Fountain.Emails.UserEmailsTest do
     end
   end
 
-  describe "link absoluteness" do
-    # These assert on the scheme, not just the path. The original tests only
-    # checked "/users/confirm/<token>", which passed happily while production
-    # was emitting "fountain.inevitable.fyi/users/confirm/<token>" — a string
-    # no mail client will render as a link.
-    setup do
-      original = Application.get_env(:fountain, :public_url)
-      on_exit(fn -> Application.put_env(:fountain, :public_url, original) end)
-      :ok
-    end
-
-    test "verification link is absolute even if :public_url is set to a bare host" do
-      Application.put_env(:fountain, :public_url, "fountain.example.com")
-      user = insert_verified_user()
-
-      assert {:ok, _} = UserEmails.deliver_verification_email(user, "tok")
-
-      assert_email_sent(fn email ->
-        assert email.html_body =~ "https://fountain.example.com/users/confirm/tok"
-        assert email.text_body =~ "https://fountain.example.com/users/confirm/tok"
-      end)
-    end
-
-    test "reset link is absolute even if :public_url is set to a bare host" do
-      Application.put_env(:fountain, :public_url, "fountain.example.com")
-      user = insert_verified_user()
-
-      assert {:ok, _} = UserEmails.deliver_password_reset_email(user, "tok")
-
-      assert_email_sent(fn email ->
-        assert email.html_body =~ "https://fountain.example.com/auth/reset/tok"
-        assert email.text_body =~ "https://fountain.example.com/auth/reset/tok"
-      end)
-    end
-
-    test "an absolute :public_url is preserved verbatim" do
-      Application.put_env(:fountain, :public_url, "https://custom.example.org")
-      user = insert_verified_user()
-
-      assert {:ok, _} = UserEmails.deliver_verification_email(user, "tok")
-
-      assert_email_sent(fn email ->
-        assert email.html_body =~ "https://custom.example.org/users/confirm/tok"
-      end)
-    end
-  end
+  # "link absoluteness" lives in `user_emails_public_url_test.exs`, which is
+  # `async: false`. It has to be: those tests write the global `:public_url`,
+  # and every rendered page reads it through `FountainWeb.OpenGraph`.
 
   describe "deliver_password_reset_email/2" do
     test "delivers an email with the correct subject to the user" do

--- a/apps/fountain/test/fountain/public_url_test.exs
+++ b/apps/fountain/test/fountain/public_url_test.exs
@@ -6,7 +6,13 @@ defmodule Fountain.PublicUrlTest do
   every generated link came out schemeless.
   """
 
-  use ExUnit.Case, async: true
+  # async: false — `describe "base/0"` writes the global `:public_url`, and
+  # `FountainWeb.OpenGraph.url/1` reads it on every page render in the suite.
+  # The same write in `user_emails_test.exs` was failing every `og:url`
+  # assertion in the suite on some seeds; this module holds it for a much
+  # shorter window and was never caught doing it, which is not a reason to
+  # keep it in the async set.
+  use ExUnit.Case, async: false
 
   doctest Fountain.PublicUrl
 

--- a/apps/fountain/test/fountain/quotas_fleet_ceiling_test.exs
+++ b/apps/fountain/test/fountain/quotas_fleet_ceiling_test.exs
@@ -1,0 +1,47 @@
+# async: false — the one test here rewrites the global `:sandboxes` config,
+# and `Quotas.check_fleet_ceiling/1` reads it on every sandbox reservation in
+# the suite.
+#
+# It used to sit in `quotas_test.exs`, which is `async: true`. While it held
+# the ceiling at 2, every async test running beside it saw a ceiling of 2, and
+# any of them that reserved a sandbox with two already live got
+# `{:error, :fleet_full}` instead of what it asserted. That surfaced as
+# `conversations_start_test.exs` failing on the tenant-cap assertions — a
+# different one each time, on some seeds and not others, and never locally,
+# because CI runs the partition under `--cover` and the timing decides who is
+# in the window.
+#
+# ExUnit runs every async module first and the sync ones one at a time
+# afterwards, so a sync module cannot overlap an async one. That is the whole
+# fix. Keep this module sync, and keep global-config tests out of
+# `quotas_test.exs`.
+defmodule Fountain.QuotasFleetCeilingTest do
+  use Fountain.DataCase, async: false
+
+  alias Fountain.Quotas
+
+  describe "the fleet ceiling" do
+    test "refuses the reservation once every slot is live, whoever holds them" do
+      cfg = Application.get_env(:fountain, :sandboxes)
+      on_exit(fn -> Application.put_env(:fountain, :sandboxes, cfg) end)
+      Application.put_env(:fountain, :sandboxes, Keyword.put(cfg, :fleet_ceiling, 2))
+
+      other = insert_active_user()
+      insert_sandbox(user_id: other.id, status: "ready")
+      insert_sandbox(user_id: other.id, status: "starting")
+
+      user = insert_active_user()
+      {:ok, _} = Fountain.Credits.grant(user.id, 1_000, "purchase", idempotency_key: "fleet")
+
+      assert {:error, :fleet_full} = Quotas.check_fleet_ceiling()
+
+      assert {:error, :fleet_full} =
+               Quotas.with_sandbox_reservation(user.id, [], fn -> {:ok, :never} end)
+
+      # A suspended sandbox is not compute and does not hold a slot.
+      Fountain.Repo.update_all(Fountain.Conversations.Sandbox, set: [status: "suspended"])
+      assert :ok = Quotas.check_fleet_ceiling()
+      assert {:ok, :ran} = Quotas.with_sandbox_reservation(user.id, [], fn -> {:ok, :ran} end)
+    end
+  end
+end

--- a/apps/fountain/test/fountain/quotas_test.exs
+++ b/apps/fountain/test/fountain/quotas_test.exs
@@ -130,30 +130,10 @@ defmodule Fountain.QuotasTest do
     end
   end
 
-  describe "the fleet ceiling" do
-    test "refuses the reservation once every slot is live, whoever holds them" do
-      cfg = Application.get_env(:fountain, :sandboxes)
-      on_exit(fn -> Application.put_env(:fountain, :sandboxes, cfg) end)
-      Application.put_env(:fountain, :sandboxes, Keyword.put(cfg, :fleet_ceiling, 2))
-
-      other = insert_active_user()
-      insert_sandbox(user_id: other.id, status: "ready")
-      insert_sandbox(user_id: other.id, status: "starting")
-
-      user = insert_active_user()
-      {:ok, _} = Fountain.Credits.grant(user.id, 1_000, "purchase", idempotency_key: "fleet")
-
-      assert {:error, :fleet_full} = Quotas.check_fleet_ceiling()
-
-      assert {:error, :fleet_full} =
-               Quotas.with_sandbox_reservation(user.id, [], fn -> {:ok, :never} end)
-
-      # A suspended sandbox is not compute and does not hold a slot.
-      Fountain.Repo.update_all(Fountain.Conversations.Sandbox, set: [status: "suspended"])
-      assert :ok = Quotas.check_fleet_ceiling()
-      assert {:ok, :ran} = Quotas.with_sandbox_reservation(user.id, [], fn -> {:ok, :ran} end)
-    end
-  end
+  # The fleet ceiling lives in `quotas_fleet_ceiling_test.exs`, which is
+  # `async: false`. It has to be: the only way to test a different ceiling is
+  # to write the global `:sandboxes` config, and an async module that does
+  # that changes the ceiling for every test running beside it.
 
   describe "sandbox_limit_for/1" do
     # The admin table renders it per row and must not query per row, so it has


### PR DESCRIPTION
Partition 6 failed twice on #1212 with `{:error, :fleet_full}` where
`conversations_start_test.exs` asserts a tenant cap — a different test each
time, on some seeds and not others, and never locally. The cause is not in
that file.

## What it is

Application env is global. ExUnit runs `async: true` modules concurrently, so
a module that writes config changes it for every test beside it, for as long
as the write is held. When production reads that key on a hot path, the
result is a failure in a **different** file, on some seeds only.

Two were live in the suite.

| Module | Key it held | What broke beside it |
|---|---|---|
| `quotas_test.exs` | `:sandboxes` `fleet_ceiling` at 2 | any test reserving a sandbox with two already live got `:fleet_full` |
| `user_emails_test.exs` | `:public_url` at `fountain.example.com` | every `og:url` assertion in the suite, via `OpenGraph.url/1` |

Both reproduce on two files alone, without CI:

```
# on main — 1 in 8 seeds, and it is the exact assertion CI reported
mix test --seed 6 --max-cases 8 \
  test/fountain/quotas_test.exs test/fountain/conversations_start_test.exs
#   1) test start_conversation/1 one tenant at its cap does not block another
#      left:  {:ok, _}
#      right: {:error, :fleet_full}

# on main — 3 in 10 seeds, 5 failures each
mix test --seed 3 --max-cases 8 \
  test/fountain/emails/user_emails_test.exs \
  test/fountain_web/controllers/marketing_controller_test.exs
```

The second one predates #1212 — two of its five failures are `og:url`
assertions that have been in the suite for months. #1212 added a third page
with a card, so it widened the target rather than creating it.

## The fix

Each moves to a sibling `async: false` module. ExUnit runs every async module
first and the sync ones one at a time afterwards, so a sync module cannot
overlap an async one. That is the whole fix, and the reason the answer is
"move it" rather than a lock or a retry.

`public_url_test.exs` writes the same proven key and goes sync too. No
reproduction there — its window is short, which is not the same as its write
being safe.

## The guardrail

`async_global_config_guardrail_test.exs` fails when an `async: true` module
writes `Application.put_env(:fountain, ...)`. It reads the module's own `use`
line rather than the words anywhere in the file, and skips comment lines, so
a module that explains in a comment which async module it was moved out of is
not read as a declaration. Verified by reintroduction: flipping a moved
module back to `async: true` fails it.

Thirteen more modules are allowlisted, each with the key it writes. The list
is not a blessing — the two that bit were only caught because a reader
happened to assert on the key. `:credits_enabled` is on it three times and is
read by every spend gate and by `Quotas.sandbox_limit`; a seed sweep did not
reproduce a failure from it, so it stays on the list rather than being moved
on a hunch, and it is the first place to look when a `:fleet_full` or a
balance assertion fails somewhere unrelated. The list only shrinks.

## Verification

Full suite 4083 tests, 0 failures. `credo --strict` and format clean. Both
reproductions above pass on this branch across every seed that failed on
`main`, with the same test counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)