### PR TITLE
fix(compose): forward the four app-facing vars, and guard what a guide tells you to set

### DIFF
--- a/.env.compose.example
+++ b/.env.compose.example
@@ -7,8 +7,15 @@
 #   echo "SECRET_KEY_BASE=$(openssl rand -base64 48 | tr -d '\n')" >> .env
 #   echo "MASTER_SECRETS_KEY=$(openssl rand 32 | base64 | tr '+/' '-_' | tr -d '=\n')" >> .env
 
+# Both keys are left commented out because the two lines above append them.
+# A blank `SECRET_KEY_BASE=` here plus an appended one leaves two copies of
+# the key in the file: compose takes the last, so it works, but the file
+# reads as broken and the obvious repair — filling in the blank at the top —
+# leaves the real value below it still winning. Uncomment and paste instead
+# of appending if you prefer; do one or the other, not both.
+
 # Phoenix session/cookie signing. Any long random string.
-SECRET_KEY_BASE=
+# SECRET_KEY_BASE=
 
 # Wraps every tenant's data encryption key. 32 bytes, url-safe base64, no
 # padding.
@@ -16,7 +23,7 @@ SECRET_KEY_BASE=
 # BACK THIS UP, AND DO NOT CHANGE IT. Every encrypted environment and vault
 # value in the database is unreadable without it — losing it is equivalent to
 # losing the secrets themselves, and rotating it has the same effect.
-MASTER_SECRETS_KEY=
+# MASTER_SECRETS_KEY=
 
 # Required to run conversations. Fountain provisions sandboxes through
 # sprites.dev; the app starts without a token but every conversation fails.
@@ -78,6 +85,26 @@ FOUNTAIN_IMAGE_TAG=v0.14.0
 # DAYTONA_API_KEY=
 # DAYTONA_API_URL=https://app.daytona.io/api
 # DAYTONA_SNAPSHOT=fountain
+
+# The browser apps that talk to this server's /api. Fountain's own UI is a
+# console; watching a conversation and messaging a teammate are separate
+# single-page apps, and the console links to the hosted builds by default.
+#
+# Those hosted builds take your Fountain's URL as input, so they work against
+# this deployment as soon as it admits their origin. Until then the console
+# offers links that fail CORS in the browser and log nothing here.
+# API_CORS_ORIGINS=https://jakegaylor.com
+
+# Register the same apps here to replace the API-key paste with a "Sign in
+# with Fountain" button. JSON array of {id, name, redirect_uris}, and a
+# redirect URI must match exactly (decisions/0021).
+# OAUTH_CLIENTS=[{"id":"fountain-conversations","name":"Fountain Conversations","redirect_uris":["https://jakegaylor.com/fountain-conversations/"]}]
+
+# Point the console at your own build of either app. Leave both unset for the
+# hosted defaults, or set one to the empty string to tell the console this
+# deployment has no such app, which removes the offer.
+# CONVERSATIONS_APP_URL=https://apps.example.com/fountain-conversations/
+# TEAM_APP_URL=https://apps.example.com/fountain-team/
 
 # Extra origins allowed to open a LiveView websocket, comma-separated. Your own
 # PUBLIC_URL host is always allowed.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -898,9 +898,11 @@ jobs:
 
       # The exact commands the quick start documents (cp, the two openssl
       # lines, up) rather than a synthetic env — the job exists to run what
-      # a fresh user runs, so any divergence here would defeat it. The
-      # appended keys shadow the blank ones from the example file; that
-      # last-value-wins reliance is part of the documented flow under test.
+      # a fresh user runs, so any divergence here would defeat it. The two
+      # appended keys are now the only definition of each: the example file
+      # ships them commented out, so a followed quick start no longer leaves
+      # two copies of every secret in .env, shadowing each other and relying
+      # on last-value-wins to pick the real one (#1215).
       - name: Run the documented quick start
         run: |
           set -euo pipefail

--- a/apps/fountain/test/fountain/config_reference_test.exs
+++ b/apps/fountain/test/fountain/config_reference_test.exs
@@ -166,10 +166,7 @@ defmodule Fountain.ConfigReferenceTest do
 
     unpassed =
       Enum.reject(advertised, fn var ->
-        # Passed through as `VAR: ${VAR...}` (any default), or interpolated
-        # directly by compose.
-        Regex.match?(~r/#{var}:\s*.*\$\{#{var}[:}]/, compose) or
-          var in @interpolation_only
+        passed_through?(compose, var) or var in @interpolation_only
       end)
 
     assert unpassed == [],
@@ -181,5 +178,51 @@ defmodule Fountain.ConfigReferenceTest do
            Add the key to the app service's environment block, or to
            @interpolation_only with a reason.
            """
+  end
+
+  test "every variable a guide tells the reader to append to .env is passed to the app" do
+    # The two tests above both run "declared, therefore it must be real": they
+    # start from what compose sets or what the example file advertises. Neither
+    # starts from what a *guide* tells an operator to do, which is how
+    # API_CORS_ORIGINS came to be documented, read by runtime.exs, instructed
+    # by the deploy guide — and never forwarded by compose, so following the
+    # guide changed nothing and logged nothing (#1215).
+    compose = File.read!(Path.join(@repo_root, "docker-compose.yml"))
+
+    instructed =
+      Path.join(@repo_root, "docs/**/*.md")
+      |> Path.wildcard()
+      |> Enum.flat_map(fn path ->
+        path
+        |> File.read!()
+        |> then(&Regex.scan(~r/^echo\s+"([A-Z][A-Z0-9_]*)=.*>>\s*\.env\s*$/m, &1))
+        |> Enum.map(fn [_, var] -> {var, Path.relative_to(path, @repo_root)} end)
+      end)
+      |> Enum.uniq()
+
+    assert instructed != [],
+           "found no `>> .env` lines in docs/ — the guides changed shape, so this guard is blind"
+
+    unpassed = Enum.reject(instructed, fn {var, _} -> passed_through?(compose, var) end)
+
+    assert unpassed == [],
+           """
+           A guide tells the reader to append variables that compose never passes to the app,
+           so following it silently does nothing:
+
+             #{Enum.map_join(unpassed, "\n  ", fn {var, path} -> "#{var} (#{path})" end)}
+
+           Add the key to the app service's environment block in docker-compose.yml.
+           """
+  end
+
+  # Two legitimate pass-through forms in the app service's environment block:
+  # `VAR: ${VAR...}` with any default, and a bare `VAR:` with no value at all.
+  # The second one forwards the variable only when .env sets it, which is the
+  # only way to distinguish "unset, use the app's default" from "set to empty
+  # on purpose" — see the app-URL block in docker-compose.yml.
+  defp passed_through?(compose, var) do
+    Regex.match?(~r/^\s*#{var}:\s*.*\$\{#{var}[:}-]/m, compose) or
+      Regex.match?(~r/^\s*#{var}:\s*$/m, compose)
   end
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,6 +92,26 @@ services:
       DAYTONA_API_URL: ${DAYTONA_API_URL:-}
       DAYTONA_SNAPSHOT: ${DAYTONA_SNAPSHOT:-}
 
+      # The browser apps on top of this server's /api. The console is not an
+      # interactive client: watching a conversation and messaging a teammate
+      # live in separate single-page apps, and CONVERSATIONS_APP_URL and
+      # TEAM_APP_URL already default to the hosted builds. Those defaults link
+      # somewhere real, so a deployment that does not admit their origin in
+      # API_CORS_ORIGINS shows working links that fail CORS in the reader's
+      # browser with nothing in the server log to explain it (#1215).
+      #
+      # These four are written with no value on purpose. That form passes the
+      # variable through only when .env actually sets it, which is the only
+      # way to keep all three states the app distinguishes: unset keeps the
+      # app's own default, `CONVERSATIONS_APP_URL=` passes "" and means this
+      # deployment has no such app, and a URL points at your own build.
+      # `${VAR:-}` cannot express the first state — it would send "" for an
+      # absent key and silently retire both hosted apps.
+      API_CORS_ORIGINS:
+      OAUTH_CLIENTS:
+      CONVERSATIONS_APP_URL:
+      TEAM_APP_URL:
+
       # Empty means the app's defaults apply. Advertised in
       # .env.compose.example; a key listed there but not passed through here
       # is silently ignored, which is what the drift test now refuses.


### PR DESCRIPTION
From a self-hosting walkthrough someone ran against `main` at v0.14.0. They got as
far as the image pull (their own egress allowlist blocked ghcr.io) and checked the
rest statically, which is why the findings hold regardless of their environment.

## The bug

`docs/guides/operate/deploy.md:77` tells an operator to:

```bash
echo "API_CORS_ORIGINS=https://jakegaylor.com" >> .env
```

`docker-compose.yml` never passed `API_CORS_ORIGINS` to the app service. Following
the guide changed nothing and logged nothing. `OAUTH_CLIENTS`,
`CONVERSATIONS_APP_URL` and `TEAM_APP_URL` were in the same position — read by
`config/runtime.exs`, documented in `docs/configuration.md`, forwarded by nothing.

The sharpest edge is that `CONVERSATIONS_APP_URL` and `TEAM_APP_URL` **default to
the hosted builds**. The console therefore rendered working links to apps that
could not possibly reach the instance, and the failure surfaced only as a CORS
error in someone's browser console — nothing server-side to find.

## Why the existing guards missed it

All four tests in `config_reference_test.exs` run *declared, therefore it must be
real*: every var runtime.exs reads is documented, every documented var is read,
every var compose sets is read, every var the example file advertises is passed
through. None of them starts from **what a guide tells an operator to do**.
`API_CORS_ORIGINS` sat in the blind spot: documented, read, absent from compose,
so neither compose-facing guard fired.

## The fix

The four keys are written **with no value**, not `${VAR:-}`:

```yaml
      API_CORS_ORIGINS:
      OAUTH_CLIENTS:
      CONVERSATIONS_APP_URL:
      TEAM_APP_URL:
```

That form forwards a variable only when `.env` actually sets it, which is the only
way to preserve the three states the app distinguishes. `${VAR:-}` would send `""`
for an absent key and **silently retire both hosted apps** for every existing
compose user. Verified in a real container:

| `.env` | container | app sees |
|---|---|---|
| omits the key | absent | its own default (hosted build) |
| `CONVERSATIONS_APP_URL=` | `""` | this deployment has no such app |
| `CONVERSATIONS_APP_URL=https://…` | the value | your own build |

Also in here:

- `.env.compose.example` advertises all four, so the existing drift guard holds them.
- `SECRET_KEY_BASE` / `MASTER_SECRETS_KEY` ship **commented out**. The quick start
  appends both, and a blank assignment plus an appended one left two copies of every
  secret in `.env` — working only by last-value-wins, reading as broken, and the
  obvious repair (filling in the blank at the top) left the real value below it still
  winning. The `compose-pinned-image-boot` comment that described the shadowing as
  deliberate is updated to match.
- **A fifth guard** reads the `>> .env` lines out of `docs/**/*.md` and asserts
  compose forwards each key.

## Verification

Reverting just the compose hunk makes both guards fail, the new one naming the
original bug with its source:

```
A guide tells the reader to append variables that compose never passes to the app,
so following it silently does nothing:

  API_CORS_ORIGINS (docs/guides/operate/deploy.md)
```

`config_reference_test.exs`, `compose_passthrough_config_test.exs` and
`master_key_config_test.exs` pass (25 tests). The documented quick start now yields
one definition of each secret instead of two, both resolving non-empty, and the
no-`.env` dev path (`docker compose up -d postgres`) still loads.

Prose fixes to the deploy guide itself follow in a second PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
