### PR TITLE
docs(deploy): the prerequisites an operator needs, and a cold start that is not a failure

### DIFF
--- a/docs/guides/operate/deploy.md
+++ b/docs/guides/operate/deploy.md
@@ -10,9 +10,18 @@ instance that stays up.
 
 ## Before you start
 
-You must have Postgres 16 or newer, which the compose file runs for you. You
-must also have a sandbox provider token. Read
-[Self-host Fountain](../../self-hosting.md) for what each provider needs.
+You must have Docker Engine with Compose v2, and `openssl` for the two key
+lines below. The compose file runs Postgres 16 for you, so you do not install
+a database yourself.
+
+Your machine must also reach `ghcr.io`, the registry that holds the published
+image. Does your network block it? Then comment the `image:` line in
+`docker-compose.yml`, uncomment the `build: .` line under it, and compose
+builds the image from this checkout.
+
+You must also have a sandbox provider token. Read
+[Self-host Fountain](../../self-hosting.md) for what each provider needs, and
+for where a token comes from.
 
 ## Bring it up
 
@@ -27,6 +36,12 @@ echo "MASTER_SECRETS_KEY=$(openssl rand 32 | base64 | tr '+/' '-_' | tr -d '=\n'
 
 docker compose up -d
 ```
+
+Do you reach this instance by a host other than `localhost`? Then set
+`PUBLIC_URL` in `.env` as well. It defaults to `http://localhost:4000`, it
+builds the links in verification emails, and every sandbox reads it as
+`FOUNTAIN_BASE_URL`. [Put it on the internet](put-it-on-the-internet.md)
+covers the rest of a public deployment.
 
 Back `MASTER_SECRETS_KEY` up now, before you have data. It is not in the
 database, so a database backup alone does not protect you. Read
@@ -98,14 +113,35 @@ internet that has registration open.
 
 ## Verify it worked
 
+The app applies database migrations before it opens a listener, so a cold
+start takes up to a minute. Wait for the app container to report `healthy`,
+then probe it.
+
 ```bash
+docker compose ps
+# wait for the app to report healthy, then:
 curl -sS localhost:4000/health/ready
 # {"checks":{"database":"ok"},"status":"ok"}
 ```
 
+A refused connection means the app has not opened its listener yet. That is
+the normal state during a cold start, and not a failed install. Read
+`docker compose logs -f app` if it stays refused.
+
 Then sign in and create a conversation. A run that reaches its first turn
 proves that the database, the secrets key and the sandbox provider are all
 wired up.
+
+## Start over
+
+```bash
+docker compose down -v
+```
+
+The `-v` flag deletes the database volume, and every account and conversation
+in it. Keep the same `MASTER_SECRETS_KEY` when you keep the volume. A new key
+cannot unwrap what the old key wrapped. Every stored environment and vault
+value then becomes unreadable.
 
 ## If it did not work
 


### PR DESCRIPTION
The prose half of the self-hosting walkthrough findings. The code half is #1215
(compose never forwarded `API_CORS_ORIGINS` and three siblings); these two touch
disjoint files and can land in either order.

Four gaps in the compose quick start.

### Prerequisites named the app's dependencies, not the operator's

"Before you start" listed Postgres 16, which the compose file runs for you, and a
sandbox provider token. It did not name Docker Engine with Compose v2, `openssl`,
or outbound access to **ghcr.io** — which is the step that actually failed for the
reader. The `build: .` fallback already sitting commented in `docker-compose.yml`
is now mentioned right there, for anyone on a network that cannot reach the
registry.

### `PUBLIC_URL` was missing entirely

The guide opens by saying this is for "an instance that stays up", then never
mentions `PUBLIC_URL`. It defaults to `http://localhost:4000`, builds the links in
verification emails, and is handed to every sandbox as `FOUNTAIN_BASE_URL`. It was
covered one page later in *Put it on the internet*, which is one page too late for
a reader who deploys somewhere real.

### "Verify it worked" failed on a cold start

```bash
curl -sS localhost:4000/health/ready
```

Boot applies migrations before the listener opens — that is exactly why the compose
healthcheck allows a 40s `start_period`. Run immediately after `up -d`, this curl
gets connection refused and reads as a failed install. It now waits for `healthy`
via `docker compose ps` first, and says plainly that a refused connection during a
cold start is normal.

### No teardown or start-over path

`docker compose down -v` is now documented, with the warning that matters next to
it: a new `MASTER_SECRETS_KEY` against a volume you kept cannot unwrap what the old
key wrapped, so every stored environment and vault value becomes unreadable.

## Gates

`python3 scripts/docs-style.py` reports clean (87 files). `vale lint docs` holds at
**0 errors, 0 warnings**, which was the file's baseline before this change —
`deploy.md` is on neither backlog, so it is fully checked. Two real STE warnings I
introduced (an `-ing` form, a passive "is gone") are reworded rather than
suppressed. `docs_test.exs` passes, 39 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
