### PR TITLE
copy(marketing): /self-hosted sells the platform, not the machine

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/marketing_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_controller.ex
@@ -68,10 +68,11 @@ defmodule FountainWeb.MarketingController do
         layout: {FountainWeb.Layouts, :marketing},
         page_title: "Self-host #{Fountain.Brand.engine()} · #{Fountain.Brand.name()}",
         meta_description:
-          "#{Fountain.Brand.engine()} is open source and the whole product is in the " <>
-            "repo: the server, the console, the API, the CLI and the SDK. Bring an " <>
-            "instance up with Docker Compose or plain Kubernetes manifests, on your " <>
-            "hardware, under your own keys, with no licence key and no seat count."
+          "Define an agent once and every app you build can hire it over one API. " <>
+            "#{Fountain.Brand.engine()} is open source and the whole platform is in " <>
+            "the repo. Bring an instance up with Docker Compose or plain Kubernetes " <>
+            "manifests, on your hardware, under your own keys, with no licence key " <>
+            "and no seat count."
       )
     else
       redirect(conn, to: ~p"/docs/self-hosting")

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
@@ -672,6 +672,25 @@ defmodule FountainWeb.MarketingHTML do
   @doc "The project's repository. The self-hosted page links it from four places."
   def repo_url, do: @repo_url
 
+  # The four apps /self-hosted leads with, chosen for four different shapes of
+  # front door: an assistant you text, a shared workstation, an unattended
+  # repair loop, and a fan-out. Selected from `built_apps/0` by id rather than
+  # restated, so a card here cannot drift from /built-with, and an app that is
+  # renamed or retired there raises at render instead of linking nowhere.
+  @showcase_ids ~w(reflex fountain-workbench rounds mission-control)
+
+  @doc """
+  The applications /self-hosted shows above the bring-up. The page's claim is
+  that an agent defined once gets hired by anything, and these are the anything.
+  """
+  def self_host_showcase do
+    by_id = Map.new(built_apps_flat(), &{&1.id, &1})
+    Enum.map(@showcase_ids, &Map.fetch!(by_id, &1))
+  end
+
+  @doc "How many applications the roster holds. Both marketing pages quote it."
+  def built_app_count, do: length(built_apps_flat())
+
   @doc """
   The bring-up, verbatim from the deploy guide, so the page cannot drift into
   showing commands the manual does not. Kept out of the template because

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/self_hosted.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/self_hosted.html.heex
@@ -4,20 +4,20 @@
     Self-hosted
   </p>
   <h1 class="text-4xl sm:text-5xl font-bold tracking-tight text-[var(--color-text-primary)] mb-5 leading-tight">
-    Give your app a coding agent. Own every machine it touches.
+    Define your agents once. Let every app you build hire them.
   </h1>
   <p class="text-lg sm:text-xl text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-4">
-    {Fountain.Brand.engine()} runs Claude Code, Codex, Gemini and OpenCode on sandboxes it builds for you, behind one API.
+    An agent is a row you write once. The model, the skills, the MCP servers, the repository it wakes up in, the secrets it may use. After that anything you build hires it over one API, and it arrives on a machine {Fountain.Brand.engine()} builds, warms and reclaims.
     <span :if={Fountain.Brand.hosted?()}>
-      {Fountain.Brand.name()} is one instance of it, the one we happen to run.
+      {Fountain.Brand.name()} is one instance of that platform, the one we happen to run.
     </span>
     <span :if={!Fountain.Brand.hosted?()}>
-      This site is one instance of it, the one we happen to run.
+      This site is one instance of that platform, the one we happen to run.
     </span>
-    Clone the same repository, set two secrets, and yours answers the same API in six commands, on your hardware, under your own keys.
+    Yours answers the same API in six commands.
   </p>
   <p class="text-lg sm:text-xl font-medium text-[var(--color-text-primary)] max-w-2xl mx-auto mb-10">
-    There are no tiers to buy. The features we ration on this site are a line of config on yours.
+    Run it yourself and the whole platform is yours. Your roster, your machines, your keys, and the features we ration on this site are a line of config on yours.
   </p>
   <div class="flex flex-col sm:flex-row gap-3 justify-center mb-4">
     <a
@@ -35,6 +35,42 @@
   </div>
   <p class="text-xs text-[var(--color-text-muted)]">
     AGPL-3.0-or-later. No licence key, no seat count, no call with us.
+  </p>
+</section>
+
+<%!-- The apps are the argument. The claim above the fold is that an agent
+      defined once gets hired by anything, and these are the anything. Cards
+      come from built_apps/0 so the page cannot drift from /built-with. --%>
+<section class="max-w-5xl mx-auto px-6 pb-16">
+  <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-3 text-center">
+    {built_app_count()} applications already hire from one roster.
+  </h2>
+  <p class="text-center text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-10">
+    Here are four of them, and they are four different front doors onto the same idea. Nobody wrote an agent into any of these apps. The teammate was defined once and the app is the part somebody built on top of it. All of them are open source, and each one points at whichever instance you configure.
+  </p>
+  <div class="grid sm:grid-cols-2 gap-6">
+    <a
+      :for={app <- self_host_showcase()}
+      href={app.url}
+      rel="noopener"
+      data-role="showcase"
+      class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6 hover:border-[var(--color-brand)] transition-colors"
+    >
+      <span class="text-2xl" aria-hidden="true">{app.glyph}</span>
+      <h3 class="mt-3 font-semibold text-[var(--color-text-primary)]">{app.name}</h3>
+      <p class="mt-0.5 text-xs text-[var(--color-text-muted)]">{app.host}</p>
+      <p class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">
+        {app.blurb}
+      </p>
+    </a>
+  </div>
+  <p class="text-center text-sm text-[var(--color-text-muted)] mt-8">
+    <a
+      href={~p"/built-with"}
+      class="underline underline-offset-2 hover:text-[var(--color-text-secondary)]"
+    >
+      All {built_app_count()} of them, and what each one proves
+    </a>
   </p>
 </section>
 

--- a/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
@@ -181,7 +181,7 @@ defmodule FountainWeb.MarketingControllerTest do
     test "makes the case and shows the whole bring-up", %{conn: conn} do
       body = conn |> get(~p"/self-hosted") |> html_response(200)
 
-      assert body =~ "Give your app a coding agent. Own every machine it touches."
+      assert body =~ "Define your agents once. Let every app you build hire them."
       assert body =~ "Six commands and a token."
       assert body =~ "The features we ration, you switch on."
       assert body =~ "What it costs you instead."
@@ -214,10 +214,33 @@ defmodule FountainWeb.MarketingControllerTest do
       end
     end
 
+    test "shows apps that already hire from the roster, and links every one", %{conn: conn} do
+      body = conn |> get(~p"/self-hosted") |> html_response(200)
+
+      # The hero's claim is that an agent defined once gets hired by anything.
+      # The cards are the evidence, so each has to be a working pair of links
+      # into the same roster /built-with renders.
+      showcase = FountainWeb.MarketingHTML.self_host_showcase()
+      assert length(showcase) == 4
+
+      for app <- showcase do
+        assert body =~ app.name, "missing app #{app.name}"
+        assert body =~ app.url, "missing live link for #{app.name}"
+        assert app in FountainWeb.MarketingHTML.built_apps_flat(), "#{app.name} left the roster"
+      end
+
+      count = to_string(FountainWeb.MarketingHTML.built_app_count())
+      assert body =~ "#{count} applications already hire from one roster."
+      assert body =~ ~p"/built-with"
+    end
+
     test "carries its own card", %{conn: conn} do
       body = conn |> get(~p"/self-hosted") |> html_response(200)
       assert body =~ ~s(<meta property="og:title" content="Self-host Fountain · Fountain")
-      assert body =~ ~s(<meta name="description" content="Fountain is open source)
+
+      assert body =~
+               ~s(<meta name="description" content="Define an agent once and every app)
+
       assert body =~ ~s(<meta property="og:url" content="http://localhost:4000/self-hosted")
     end
 


### PR DESCRIPTION
The hero sold a property. *"Give your app a coding agent. Own every machine it touches"* mirrors the homepage's *"Skip the machine it needs"*, which is a good parallel for a reader who arrived from the homepage and a poor opening for the ones who do not. It also pitches the plumbing. Owning a machine is a fact about the deployment, not a reason to run one.

The reason to run one is that an agent defined once gets hired by anything. The model, the skills, the MCP servers, the repository and the secrets are a row you write in the platform, and after that a Slack bot, an alert pipeline, an internal dashboard and a text message all reach the same teammate over one API. That is what the thirteen applications on `/built-with` are evidence of, and none of them were reachable from this page.

## What changed

- **The hero leads with the platform claim**, and the ownership beat follows it in the line that already carried the inversion. *"Run it yourself and the whole platform is yours. Your roster, your machines, your keys, and the features we ration on this site are a line of config on yours."*
- **A new section above the bring-up shows four of the thirteen**, chosen for four shapes of front door: an assistant you text (Reflex), a shared workstation (Workbench), an unattended repair loop (Rounds), and a fan-out (Mission Control). Cards come from `built_apps/0` by id rather than restating anything, so this page cannot drift from `/built-with`, and an app renamed or retired there raises at render instead of linking nowhere.
- **The meta description leads with the same claim.** It also loses a colon-introduced list, which the voice standard bans in docs and which was doing the usual thing here, standing in for a verb nobody chose.

The count in the heading is `length(built_apps_flat())`, so adding the fourteenth app updates the page.

## Guards

A test asserts the four render with live links, that each is still on the roster, and that the heading quotes the real count. Verified by deleting the section: the test fails with `missing app Reflex`.

## What did not change

The bring-up, the rationed features, the licences, the rungs, the four costs and the FAQ were arguing for ownership correctly. They were just doing it under a headline that opened with plumbing.

## Checks

- `mix compile --warnings-as-errors`, `mix format --check-formatted`, `mix credo --strict` clean
- `mix test test/fountain_web/controllers` green (843 tests, 0 failures)
- Rendered locally with `MARKETING_SITE=true` and read top to bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)