### PR TITLE
feat(marketing): a case study, an estate that answers its own alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,18 @@ upgrade, is in
   no asset pipeline behind it. Since #1008 `/docs` is the only place the
   manual is published, which left it as the one copy with no way to search.
 
+- **A case study, `/case-studies/self-healing-infrastructure`.** A Kubernetes
+  estate that answers its own alerts. Prometheus fires, a webhook opens a
+  Fountain conversation, and the agent reads the cluster through a read-only
+  API, names the commit that broke it, and opens one minimal pull request. It
+  cannot merge that pull request, and the page is mostly about why: the
+  identity it pushes as is one GitHub refuses to let approve its own work. The
+  numbers are counted from one production estate over a stated window, 78
+  incidents in fifteen days, and the page quotes the agent's own root-cause
+  paragraph rather than a summary of it. Like `/integrations`, `/built-with`
+  and `/self-hosted`, it is sales copy, so an instance that is not the
+  marketing site redirects into the manual.
+
 - **A landing page for running it yourself, `/self-hosted`.** The case for
   an instance of your own, next to the case for ours: the bring-up in five
   commands, the three licences and what each one asks of you, four rungs of

--- a/apps/fountain/lib/fountain_web/components/layouts/marketing.html.heex
+++ b/apps/fountain/lib/fountain_web/components/layouts/marketing.html.heex
@@ -97,6 +97,13 @@
         </a>
         <a
           :if={Fountain.Marketing.site?()}
+          href={~p"/case-studies/self-healing-infrastructure"}
+          class="hover:text-[var(--color-text-secondary)] transition-colors"
+        >
+          Case study
+        </a>
+        <a
+          :if={Fountain.Marketing.site?()}
           href={~p"/self-hosted"}
           class="hover:text-[var(--color-text-secondary)] transition-colors"
         >

--- a/apps/fountain/lib/fountain_web/controllers/marketing_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_controller.ex
@@ -1,13 +1,13 @@
 defmodule FountainWeb.MarketingController do
   @moduledoc """
-  The public pages: `/`, `/integrations`, `/built-with`, `/self-hosted`, `/terms`
-  and `/privacy`.
+  The public pages: `/`, `/integrations`, `/built-with`, `/self-hosted`,
+  `/case-studies/*`, `/terms` and `/privacy`.
 
-  None of the four is the same page on every deployment. `/` serves the
+  None of them is the same page on every deployment. `/` serves the
   product pitch on the marketing site and a plain front door everywhere else
-  (`Fountain.Marketing`); `/integrations`, `/built-with` and `/self-hosted` are
-  the pitch's other three pages and redirect into the manual on any other
-  instance;
+  (`Fountain.Marketing`); `/integrations`, `/built-with`, `/self-hosted` and
+  the case studies are the pitch's other pages and redirect into the manual on
+  any other instance;
   the legal pages render the operator's identity, or nothing at all
   (`Fountain.Legal`). A deployment is not the Fountain project, and these
   pages are the ones that would claim otherwise.
@@ -76,6 +76,35 @@ defmodule FountainWeb.MarketingController do
       )
     else
       redirect(conn, to: ~p"/docs/self-hosting")
+    end
+  end
+
+  # There is one case study, so `/case-studies` is a shortcut to it rather
+  # than an index of one. It becomes a real index when there is a second.
+  def case_studies(conn, _params) do
+    if Fountain.Marketing.site?() do
+      redirect(conn, to: ~p"/case-studies/self-healing-infrastructure")
+    else
+      redirect(conn, to: ~p"/docs")
+    end
+  end
+
+  # An estate that pages an agent instead of a person, and what stops the
+  # agent from merging its own work. Sales copy, so it follows `/`: another
+  # deployment gets the manual's tour of the same shape.
+  def case_study(conn, _params) do
+    if Fountain.Marketing.site?() do
+      render(conn, :case_study_self_healing,
+        layout: {FountainWeb.Layouts, :marketing},
+        page_title: "Self-healing infrastructure · #{Fountain.Brand.name()}",
+        meta_description:
+          "A Kubernetes estate that answers its own alerts. Prometheus fires, " <>
+            "#{Fountain.Brand.name()} hires an agent, the agent finds the commit that " <>
+            "broke the cluster and opens one pull request. A human still approves every " <>
+            "merge, because the agent is built so that it cannot."
+      )
+    else
+      redirect(conn, to: ~p"/docs/tour")
     end
   end
 

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
@@ -873,4 +873,298 @@ defmodule FountainWeb.MarketingHTML do
       }
     ]
   end
+
+  ## /case-studies/self-healing-infrastructure
+
+  # The case study is data first, like /integrations above. Every number here
+  # was counted once, by hand, over the window `case_window/0` names: the
+  # dispatch counts and turn durations from this deployment's own database,
+  # the pull requests and their timestamps from the estate's repository. They
+  # are literals on purpose. A figure that recomputed at request time would
+  # quietly widen its own window and end up claiming something nobody checked.
+
+  @doc "The window every number on the case study covers."
+  def case_window, do: "11 to 25 August 2026"
+
+  @doc "The four headline numbers, counted over `case_window/0`."
+  def case_stats do
+    [
+      %{
+        value: "78",
+        label: "incidents handled by an agent",
+        note: "Fifteen days, one estate, one agent, no rota."
+      },
+      %{
+        value: "4m 27s",
+        label: "from alert to open pull request",
+        note: "Measured on the incident below. The second one took 4m 08s."
+      },
+      %{
+        value: "7.5 min",
+        label: "median incident, start to verdict",
+        note: "Half finish faster. The longest ran 50 minutes."
+      },
+      %{
+        value: "0",
+        label: "cluster credentials the agent holds",
+        note: "No kubectl, no kubeconfig, no write anywhere."
+      }
+    ]
+  end
+
+  @doc "The loop, in the order it runs."
+  def case_loop do
+    [
+      %{
+        step: "1",
+        title: "Prometheus notices",
+        mono: "KubePodCrashLooping · PodOOMKilled · CPUThrottlingHigh · PodRestartChurn",
+        body:
+          "The same alert rules the estate already had. Nothing was written to make " <>
+            "an agent happy, and nothing about the agent is wired into Prometheus."
+      },
+      %{
+        step: "2",
+        title: "Alertmanager forks the page",
+        mono: "continue: true",
+        body:
+          "One copy goes to the operator's phone, exactly as before. A sibling copy " <>
+            "goes to a webhook. The human is added to, never replaced."
+      },
+      %{
+        step: "3",
+        title: "A webhook hires an agent",
+        mono: "POST /api/conversations",
+        body:
+          "Two hundred lines of Node with an API key, an agent id, a vault id and the " <>
+            "alert text. It has no cluster access of its own, and needs none. Hiring the " <>
+            "agent is one call."
+      },
+      %{
+        step: "4",
+        title: "The agent reads the estate",
+        mono: "Authorization: Bearer … (GET only)",
+        body:
+          "A read-only service answers with each node's health verdict, its drift " <>
+            "against source, and the controller's own conditions. Every other method " <>
+            "returns 405, so the token cannot be turned into a write."
+      },
+      %{
+        step: "5",
+        title: "It finds the wrong fact in git",
+        mono: "gh api · git log -S",
+        body:
+          "The cluster is a repository, so a bad cluster is a bad commit. The agent " <>
+            "reads the source and its history and names the change that introduced the " <>
+            "fault, before it edits anything."
+      },
+      %{
+        step: "6",
+        title: "It opens one minimal pull request",
+        mono: "symptom · root cause · why this diff is the whole fix",
+        body:
+          "Source and regenerated manifests in one commit, under a separate GitHub " <>
+            "identity with push rights and nothing more. If no change to the repository " <>
+            "can fix the alert, it writes that instead and opens nothing."
+      },
+      %{
+        step: "7",
+        title: "A human approves",
+        mono: "422 on self-approval · 405 on self-merge",
+        body:
+          "The one gate. The agent pushes as an identity that GitHub refuses to let " <>
+            "approve its own work, and the branch requires a review from somebody else. " <>
+            "The gate is not a policy the agent is asked to respect. It cannot reach it."
+      },
+      %{
+        step: "8",
+        title: "Flux applies the merge",
+        mono: "reconcile on webhook",
+        body:
+          "Git was always the apply path, so there is no apply button for the agent to " <>
+            "be trusted with. The merge is the deploy."
+      },
+      %{
+        step: "9",
+        title: "The agent verifies and reports",
+        mono: "poll until healthy",
+        body:
+          "It watches the degraded node come back, checks that nothing else regressed, " <>
+            "and posts the incident summary. Then it stops."
+      }
+    ]
+  end
+
+  @doc "What the agent may do, and the mechanism that stops the rest."
+  def case_guardrails do
+    [
+      %{
+        can: "Read the whole estate graph, including every controller's conditions.",
+        cannot: "Change anything in the cluster. The token is refused on any method but GET."
+      },
+      %{
+        can: "Clone the infrastructure repository and push a branch.",
+        cannot: "Push to the default branch. It is protected, and a pull request is required."
+      },
+      %{
+        can: "Open a pull request and answer review comments on it.",
+        cannot:
+          "Approve or merge that pull request. GitHub blocks self-approval, " <>
+            "and the branch needs one review from another account."
+      },
+      %{
+        can: "Reference a secret by name, so the fix restores the reference.",
+        cannot:
+          "Read a secret value. The material never leaves the cluster, " <>
+            "and no diff it writes contains one."
+      },
+      %{
+        can: "Say that no change to the repository can fix this, and stop.",
+        cannot: "Reach the cluster directly. The sandbox has no kubectl and no kubeconfig."
+      }
+    ]
+  end
+
+  @doc """
+  One real incident, in the order it happened. All times UTC, 25 August 2026.
+  """
+  def case_timeline do
+    [
+      %{
+        time: "06:58:15",
+        title: "A sidecar is killed for memory",
+        body:
+          "Alertmanager posts PodOOMKilled on a container that keeps a checkout in " <>
+            "sync. The operator's phone buzzes. So does a webhook, which opens a " <>
+            "conversation with the agent."
+      },
+      %{
+        time: "06:59:34",
+        title: "A second alert, same container",
+        body:
+          "CPUThrottlingHigh, at 94.44%. It opens its own incident, and a second agent " <>
+            "starts work on it."
+      },
+      %{
+        time: "07:02:42",
+        title: "The first pull request opens",
+        body:
+          "Two files, nine lines added and four removed. The agent had traced the kill " <>
+            "to a code path the container's limit was never sized for, and to the commit " <>
+            "that first made the estate take it."
+      },
+      %{
+        time: "07:03:42",
+        title: "The second pull request opens",
+        body:
+          "Six lines added, two removed. The throttling had the same cause seen from " <>
+            "the other side, and the agent said so rather than repeating the diagnosis."
+      },
+      %{
+        time: "08:50:27",
+        title: "A human wakes up and reads two pull requests",
+        body:
+          "The throttling fix is approved and merged. Flux reconciles on the merge " <>
+            "webhook, and the agent watches the container come back."
+      },
+      %{
+        time: "23:46:01",
+        title: "The memory fix follows",
+        body:
+          "Nothing was on fire, so it waited for a proper read. That is what the gate " <>
+            "is for."
+      }
+    ]
+  end
+
+  @doc """
+  The agent's own words, quoted from the pull request it opened at 07:02.
+
+  Segmented rather than one string, because the source is a Markdown pull
+  request body and rendering its backticks as literal characters in a
+  blockquote reads as a mistake. `{:code, _}` becomes a code span, so the
+  quote stays word for word.
+  """
+  def case_quote do
+    [
+      {:text, "Both modes call "},
+      {:code, "install_members()"},
+      {:text, " ("},
+      {:code, "make install"},
+      {:text, " → "},
+      {:code, "npm ci"},
+      {:text, " across every member) whenever a fetched commit touches a "},
+      {:code, "package-lock.json"},
+      {:text, ". The "},
+      {:code, "repo-sync"},
+      {:text,
+       " sidecar's limit was sized only for its cheap steady-state git-fetch loop and " <>
+         "never accounted for this shared, memory-heavy reinstall path — a gap latent " <>
+         "since the container was authored and invisible until a commit actually moved " <>
+         "a lockfile."}
+    ]
+  end
+
+  @doc "What each Fountain primitive did in this loop."
+  def case_primitives do
+    [
+      %{
+        title: "Agent",
+        body:
+          "The runtime, the model, the runbook and the tools, written once as a file in " <>
+            "a public repository and applied to Fountain. The runbook is the whole " <>
+            "product: diagnose, fix by pull request, wait for the human, verify, report."
+      },
+      %{
+        title: "Environment",
+        body:
+          "The machine the agent wakes up on, with the repository, the CLI it needs, and " <>
+            "the address of the read-only estate service. Described once, rebuilt per " <>
+            "incident, never patched by hand."
+      },
+      %{
+        title: "Vault",
+        body:
+          "The bot identity, kept apart from the environment on purpose. Swap the vault " <>
+            "and the same agent acts as a different GitHub account. The token arrives as " <>
+            "an environment variable and stays out of the prompt, the model's context and " <>
+            "the stored transcript."
+      },
+      %{
+        title: "Conversation",
+        body:
+          "One incident, one sandbox, one transcript, addressable by the alert it came " <>
+            "from. It survives a diagnosis that runs for an hour, and it is a link a " <>
+            "human can open at 08:50 to see everything the agent did at 07:02."
+      }
+    ]
+  end
+
+  @doc "The dispatcher, reduced to the part that matters. Kept out of the template."
+  def case_dispatch_example do
+    """
+    // Alertmanager POSTs here.
+    // This is the entire integration.
+    await fetch(`${FOUNTAIN_URL}/api/conversations`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${FOUNTAIN_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        agent_id: agentId,  // estate-medic
+        vault_id: vaultId,  // the identity it acts as
+        prompt: [
+          `The estate is alerting.`,
+          alertLines,
+          `Diagnose it. If a change to the repo can`,
+          `fix it, open one minimal PR, wait for the`,
+          `human merge, verify healthy, and report.`,
+          `If nothing in the repo can fix it, do not`,
+          `open a PR. Say so and stop.`,
+        ].join("\\n\\n"),
+      }),
+    });\
+    """
+  end
 end

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/case_study_self_healing.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/case_study_self_healing.html.heex
@@ -1,0 +1,310 @@
+<%!-- Hero --%>
+<section class="max-w-5xl mx-auto px-6 py-20 text-center">
+  <p class="mb-4 text-sm font-medium uppercase tracking-wide text-[var(--color-text-muted)]">
+    Case study · Self-healing infrastructure
+  </p>
+  <h1 class="text-4xl sm:text-5xl font-bold tracking-tight text-[var(--color-text-primary)] mb-5 leading-tight">
+    The alert stopped waking him up. It opens a pull request instead.
+  </h1>
+  <p class="text-lg sm:text-xl text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-10">
+    A Kubernetes estate pages a person when a workload breaks. This one pages a person and hires an agent. The agent reads the cluster, finds the commit that broke it, and opens one small pull request. A human still approves every merge, because the agent is built so that it cannot.
+  </p>
+  <div class="flex flex-col sm:flex-row gap-3 justify-center">
+    <a
+      href="#loop"
+      class="inline-flex items-center justify-center px-6 py-3 rounded-lg bg-[var(--color-brand)] text-white font-medium hover:bg-[var(--color-brand-hover)] transition-colors text-sm"
+    >
+      See the loop
+    </a>
+    <a
+      href="#build"
+      class="inline-flex items-center justify-center px-6 py-3 rounded-lg border border-[var(--color-border)] text-[var(--color-text-primary)] font-medium hover:bg-[var(--color-bg-2)] transition-colors text-sm"
+    >
+      Build the same thing
+    </a>
+  </div>
+</section>
+
+<%!-- The numbers, counted once over a stated window (see case_window/0). --%>
+<section class="bg-[var(--color-bg-1)] border-y border-[var(--color-border)]">
+  <div class="max-w-5xl mx-auto px-6 py-14">
+    <div class="grid sm:grid-cols-2 lg:grid-cols-4 gap-6">
+      <div :for={stat <- case_stats()} data-role="case-stat">
+        <p class="text-3xl font-semibold text-[var(--color-text-primary)]">{stat.value}</p>
+        <p class="mt-1 text-sm font-medium text-[var(--color-text-primary)]">{stat.label}</p>
+        <p class="mt-2 text-xs text-[var(--color-text-muted)] leading-relaxed">{stat.note}</p>
+      </div>
+    </div>
+    <p class="mt-8 text-center text-xs text-[var(--color-text-muted)]">
+      Counted on one production estate over {case_window()}.
+    </p>
+  </div>
+</section>
+
+<%!-- The failure class --%>
+<section class="max-w-5xl mx-auto px-6 py-16">
+  <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-3 text-center">
+    Some breakage reconciliation cannot fix.
+  </h2>
+  <p class="text-center text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-12">
+    GitOps promises that the cluster matches the repository. It keeps that promise even when the repository is wrong. Drop an environment variable, lose a secret reference, pin a bad image, and the controller reports perfect agreement with a broken source.
+  </p>
+  <div class="grid md:grid-cols-2 gap-6 max-w-3xl mx-auto">
+    <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6">
+      <p class="text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)] mb-2">
+        Drift
+      </p>
+      <p class="text-lg font-semibold text-[var(--color-text-primary)]">Green</p>
+      <p class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">
+        The cluster is exactly what the repository says. Reconciliation has nothing left to do, and reports success every time it runs.
+      </p>
+    </div>
+    <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6">
+      <p class="text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)] mb-2">
+        Health
+      </p>
+      <p class="text-lg font-semibold text-[var(--color-text-primary)]">Red</p>
+      <p class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">
+        The workload is crashing anyway, because the thing the repository says is false. The fix is not another apply. The fix is knowledge.
+      </p>
+    </div>
+  </div>
+  <p class="text-center text-[var(--color-text-secondary)] max-w-2xl mx-auto mt-12">
+    That gap is where the pager lives. It is also, exactly, the shape of work a coding agent is good at. Read the evidence, find the commit, write the smallest correct diff. The reason nobody automated it before is not the diagnosis. It is that shipping the diff needs a machine, a checkout, a credential that can push, and a human who is still allowed to say no.
+  </p>
+</section>
+
+<%!-- The loop --%>
+<section
+  id="loop"
+  class="bg-[var(--color-bg-1)] border-y border-[var(--color-border)] scroll-mt-6"
+>
+  <div class="max-w-5xl mx-auto px-6 py-16">
+    <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-3 text-center">
+      Nine steps, one of them a person.
+    </h2>
+    <p class="text-center text-[var(--color-text-secondary)] max-w-xl mx-auto mb-12">
+      Every piece except the agent was already in the estate. The integration is one webhook and one API call.
+    </p>
+    <ol class="max-w-3xl mx-auto space-y-4">
+      <li
+        :for={step <- case_loop()}
+        class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-5 sm:p-6 flex items-start gap-4"
+        data-role="loop-step"
+      >
+        <span class={[
+          "flex-shrink-0 size-7 rounded-full text-sm font-semibold flex items-center justify-center",
+          if(step.step == "7",
+            do: "bg-[var(--color-text-primary)] text-[var(--color-bg-0)]",
+            else: "bg-[var(--color-brand)] text-white"
+          )
+        ]}>
+          {step.step}
+        </span>
+        <div class="min-w-0">
+          <h3 class="font-semibold text-[var(--color-text-primary)]">{step.title}</h3>
+          <p class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">
+            {step.body}
+          </p>
+          <div class="mt-3 overflow-x-auto">
+            <code
+              class="inline-block whitespace-nowrap text-xs text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1.5 py-0.5"
+              phx-no-format
+            >{step.mono}</code>
+          </div>
+        </div>
+      </li>
+    </ol>
+  </div>
+</section>
+
+<%!-- The guardrails --%>
+<section class="max-w-5xl mx-auto px-6 py-16">
+  <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-3 text-center">
+    The gate is a mechanism, not a promise.
+  </h2>
+  <p class="text-center text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-12">
+    An agent that opens infrastructure pull requests is only as safe as the smallest thing it is able to do. Nothing here rests on the agent choosing well, on a system prompt holding, or on a model behaving. Each refusal below is somebody else's 405.
+  </p>
+  <div class="max-w-3xl mx-auto space-y-4">
+    <div
+      :for={rule <- case_guardrails()}
+      class="grid sm:grid-cols-2 gap-4 sm:gap-6 rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-5"
+      data-role="guardrail"
+    >
+      <div>
+        <p class="text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)] mb-1.5">
+          It can
+        </p>
+        <p class="text-sm text-[var(--color-text-primary)] leading-relaxed">{rule.can}</p>
+      </div>
+      <div class="sm:border-l sm:border-[var(--color-border)] sm:pl-6">
+        <p class="text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)] mb-1.5">
+          It cannot
+        </p>
+        <p class="text-sm text-[var(--color-text-secondary)] leading-relaxed">{rule.cannot}</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<%!-- One real incident --%>
+<section class="bg-[var(--color-bg-1)] border-y border-[var(--color-border)]">
+  <div class="max-w-5xl mx-auto px-6 py-16">
+    <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-3 text-center">
+      One morning, end to end.
+    </h2>
+    <p class="text-center text-[var(--color-text-secondary)] max-w-xl mx-auto mb-12">
+      25 August 2026, all times UTC. Nobody was awake for the first half of this.
+    </p>
+    <ol class="max-w-3xl mx-auto">
+      <li
+        :for={event <- case_timeline()}
+        class="grid sm:grid-cols-[6.5rem_1fr] gap-x-6 gap-y-1 border-l border-[var(--color-border)] pl-6 pb-8 relative"
+        data-role="timeline-event"
+      >
+        <span
+          class="absolute -left-[5px] top-1.5 size-2.5 rounded-full bg-[var(--color-brand)]"
+          aria-hidden="true"
+        >
+        </span>
+        <span
+          class="text-sm font-medium text-[var(--color-text-muted)] tabular-nums"
+          phx-no-format
+        >{event.time}</span>
+        <div>
+          <h3 class="font-semibold text-[var(--color-text-primary)]">{event.title}</h3>
+          <p class="mt-1.5 text-sm text-[var(--color-text-secondary)] leading-relaxed">
+            {event.body}
+          </p>
+        </div>
+      </li>
+    </ol>
+
+    <%!-- The agent's own words. Quoted verbatim from the pull request body,
+          so the reader judges the diagnosis rather than our summary of it. --%>
+    <figure class="max-w-3xl mx-auto mt-4" data-role="case-quote">
+      <blockquote class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6 text-sm text-[var(--color-text-secondary)] leading-relaxed">
+        <span :for={part <- case_quote()}>
+          <%= case part do %>
+            <% {:code, text} -> %>
+              <code
+                class="text-xs text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1 py-0.5"
+                phx-no-format
+              >{text}</code>
+            <% {:text, text} -> %>
+              {text}
+          <% end %>
+        </span>
+      </blockquote>
+      <figcaption class="mt-3 text-xs text-[var(--color-text-muted)]">
+        The agent's root-cause paragraph, quoted from the pull request it opened at 07:02. The gap it names had been in the repository for months. No alert had ever reached it, because no commit had moved a lockfile until that week.
+      </figcaption>
+    </figure>
+  </div>
+</section>
+
+<%!-- What Fountain supplied --%>
+<section class="max-w-5xl mx-auto px-6 py-16">
+  <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-3 text-center">
+    What {Fountain.Brand.name()} was for.
+  </h2>
+  <p class="text-center text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-12">
+    The alerting, the repository and the reconciler were already there. The missing piece was somewhere for an agent to live between alerts. Four things, and the fourth is the API call.
+  </p>
+  <div class="grid sm:grid-cols-2 gap-6 max-w-3xl mx-auto">
+    <div
+      :for={item <- case_primitives()}
+      class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6"
+      data-role="case-primitive"
+    >
+      <h3 class="font-semibold text-[var(--color-text-primary)]">{item.title}</h3>
+      <p class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">{item.body}</p>
+    </div>
+  </div>
+  <p class="text-center text-[var(--color-text-secondary)] max-w-2xl mx-auto mt-12">
+    The operator never provisions a machine for an incident, and never pays for one between incidents. A sandbox exists for as long as the incident does. <a
+      href={~p"/docs/primitives"}
+      class="underline underline-offset-2 hover:text-[var(--color-text-primary)]"
+    >Read about the four primitives</a>.
+  </p>
+</section>
+
+<%!-- Build it --%>
+<section
+  id="build"
+  class="bg-[var(--color-bg-1)] border-y border-[var(--color-border)] scroll-mt-6"
+>
+  <div class="max-w-5xl mx-auto px-6 py-16">
+    <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-3 text-center">
+      Point your own alerts at an agent.
+    </h2>
+    <p class="text-center text-[var(--color-text-secondary)] max-w-xl mx-auto mb-12">
+      Whatever pages you today can post a webhook. This is the whole handoff.
+    </p>
+    <div class="grid md:grid-cols-2 gap-8 items-start max-w-4xl mx-auto">
+      <pre
+        class="rounded-xl border border-[var(--color-border)] bg-[var(--color-code-bg)] text-[var(--color-code-text)] p-5 text-xs leading-relaxed overflow-x-auto"
+        phx-no-format
+      ><code>{case_dispatch_example()}</code></pre>
+      <div class="space-y-5 text-sm text-[var(--color-text-secondary)]">
+        <p>
+          <span class="font-medium text-[var(--color-text-primary)]">
+            Write the agent down first.
+          </span>
+          The runbook, the tools and the model belong in a file you review, not in a webhook handler. Apply it once and the dispatcher only needs its id.
+        </p>
+        <p>
+          <span class="font-medium text-[var(--color-text-primary)]">
+            Put the identity in a Vault.
+          </span>
+          The token that pushes should be a separate account with the least rights that still work. Swapping which account an agent acts as is then a field, not a redeploy.
+        </p>
+        <p>
+          <span class="font-medium text-[var(--color-text-primary)]">
+            Make the last step refuse you.
+          </span>
+          Find the place in your pipeline where a human already signs off and let the agent stop there. A gate the agent is unable to pass beats a gate it is asked not to.
+        </p>
+        <p class="pt-1">
+          <a
+            href={~p"/docs/tour"}
+            class="font-medium text-[var(--color-text-primary)] underline underline-offset-2 hover:text-[var(--color-brand)]"
+          >
+            Read the tour, an agent that opens a pull request →
+          </a>
+        </p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<%!-- Footer CTA --%>
+<section class="max-w-5xl mx-auto px-6 py-20 text-center">
+  <h2 class="text-2xl sm:text-3xl font-bold text-[var(--color-text-primary)] mb-4">
+    Your on-call has a queue of small, obvious fixes.
+  </h2>
+  <p class="text-[var(--color-text-secondary)] mb-8 max-w-lg mx-auto">
+    They all start with reading the evidence and end with a diff somebody has to approve. Hire an agent for the middle.
+  </p>
+  <div class="flex flex-col sm:flex-row gap-3 justify-center">
+    <a
+      href={~p"/auth/register"}
+      class="inline-flex items-center justify-center px-6 py-3 rounded-lg bg-[var(--color-brand)] text-white font-medium hover:bg-[var(--color-brand-hover)] transition-colors text-sm"
+    >
+      Run your first agent free
+    </a>
+    <a
+      href={~p"/docs/concepts/teammates"}
+      class="inline-flex items-center justify-center px-6 py-3 rounded-lg border border-[var(--color-border)] text-[var(--color-text-primary)] font-medium hover:bg-[var(--color-bg-2)] transition-colors text-sm"
+    >
+      Agents as teammates
+    </a>
+  </div>
+  <p class="mt-10 text-xs text-[var(--color-text-muted)] max-w-2xl mx-auto leading-relaxed">
+    The estate is a private Kubernetes cluster run by one person, and the numbers are its own. Twelve fix pull requests were opened over the window and eight were merged, four of them the same rehearsal fault raised on purpose. Most incidents end with no pull request at all, because the agent decides the repository cannot fix them and says so. The agent's definition is public at <a
+      href="https://github.com/jhgaylor/agent-specs/blob/main/src/agents/specialists/engineering/estate-medic.ts"
+      class="underline underline-offset-2 hover:text-[var(--color-text-secondary)]"
+    >jhgaylor/agent-specs</a>.
+  </p>
+</section>

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -235,6 +235,36 @@
   </div>
 </section>
 
+<%!-- Proof. One deployment, in production, with its own numbers. --%>
+<section class="max-w-5xl mx-auto px-6 py-16">
+  <div
+    class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-1)] p-8 sm:p-10"
+    data-role="case-study-callout"
+  >
+    <p class="text-sm font-medium uppercase tracking-wide text-[var(--color-text-muted)]">
+      Case study
+    </p>
+    <h2 class="mt-2 text-2xl font-semibold text-[var(--color-text-primary)]">
+      An estate that answers its own alerts.
+    </h2>
+    <p class="mt-3 text-[var(--color-text-secondary)] max-w-2xl leading-relaxed">
+      A Kubernetes cluster used to page a person when a workload broke. Now it pages a person and hires an agent. The agent reads the cluster, finds the commit that broke it, and opens one small pull request. It cannot merge that pull request, and the mechanism that stops it is not a system prompt.
+    </p>
+    <dl class="mt-6 flex flex-wrap gap-x-10 gap-y-4">
+      <div :for={stat <- case_stats()}>
+        <dt class="text-2xl font-semibold text-[var(--color-text-primary)]">{stat.value}</dt>
+        <dd class="text-xs text-[var(--color-text-muted)]">{stat.label}</dd>
+      </div>
+    </dl>
+    <a
+      href={~p"/case-studies/self-healing-infrastructure"}
+      class="mt-8 inline-flex items-center justify-center px-5 py-2.5 rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-0)] text-[var(--color-text-primary)] text-sm font-medium hover:bg-[var(--color-bg-2)] transition-colors"
+    >
+      Read the case study →
+    </a>
+  </div>
+</section>
+
 <%!-- Built with: proof that the API carries whole products, not just calls. --%>
 <section class="bg-[var(--color-bg-1)] border-y border-[var(--color-border)]">
   <div class="max-w-5xl mx-auto px-6 py-16 text-center">

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -158,6 +158,10 @@ defmodule FountainWeb.Router do
     get "/integrations", MarketingController, :integrations
     get "/built-with", MarketingController, :built_with
     get "/self-hosted", MarketingController, :self_hosted
+    # One study today, so the bare path redirects to it rather than 404ing on
+    # the segment a reader will inevitably chop off the URL.
+    get "/case-studies", MarketingController, :case_studies
+    get "/case-studies/self-healing-infrastructure", MarketingController, :case_study
     get "/terms", MarketingController, :terms
     get "/privacy", MarketingController, :privacy
     # The public manual, and since #1008 the only place it is published —

--- a/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
@@ -266,6 +266,79 @@ defmodule FountainWeb.MarketingControllerTest do
     end
   end
 
+  describe "GET /case-studies/self-healing-infrastructure" do
+    test "renders the loop, the guardrails and the incident", %{conn: conn} do
+      body = conn |> get(~p"/case-studies/self-healing-infrastructure") |> html_response(200)
+
+      assert body =~ "The alert stopped waking him up."
+
+      # Every step of the loop, and the human gate among them.
+      for step <- FountainWeb.MarketingHTML.case_loop() do
+        assert body =~ step.title, "missing loop step #{step.title}"
+      end
+
+      assert body =~ "422 on self-approval"
+      assert body =~ "The sandbox has no kubectl and no kubeconfig."
+      assert body =~ "install_members()"
+
+      # The incident is told with its own timestamps, not rounded prose.
+      for event <- FountainWeb.MarketingHTML.case_timeline() do
+        assert body =~ event.time, "missing timeline entry #{event.time}"
+      end
+
+      # The snippet is kept out of the template so its braces are not HEEx.
+      assert body =~ "POST"
+      assert body =~ "/api/conversations"
+    end
+
+    test "every number names the window it was counted over", %{conn: conn} do
+      body = conn |> get(~p"/case-studies/self-healing-infrastructure") |> html_response(200)
+
+      for stat <- FountainWeb.MarketingHTML.case_stats() do
+        assert body =~ stat.value, "missing headline number #{stat.value}"
+      end
+
+      assert body =~ FountainWeb.MarketingHTML.case_window()
+    end
+
+    test "carries its own card", %{conn: conn} do
+      body = conn |> get(~p"/case-studies/self-healing-infrastructure") |> html_response(200)
+
+      assert body =~
+               ~s(<meta property="og:title" content="Self-healing infrastructure · Fountain")
+
+      assert body =~
+               ~s(<meta property="og:url" content="http://localhost:4000/case-studies/self-healing-infrastructure")
+    end
+
+    test "every link into the manual resolves to a page", %{conn: conn} do
+      body = conn |> get(~p"/case-studies/self-healing-infrastructure") |> html_response(200)
+
+      links =
+        ~r/href="\/docs\/([^"#]+)/
+        |> Regex.scan(body)
+        |> Enum.map(fn [_, slug] -> slug end)
+        |> Enum.uniq()
+
+      assert links != []
+
+      for slug <- links do
+        assert match?({:ok, _}, Fountain.Docs.get(slug)), "/docs/#{slug} is not a page"
+      end
+    end
+
+    test "the bare path is a shortcut to the one study", %{conn: conn} do
+      assert redirected_to(get(conn, ~p"/case-studies")) ==
+               ~p"/case-studies/self-healing-infrastructure"
+    end
+
+    test "the homepage and the marketing footer link to it", %{conn: conn} do
+      body = conn |> get(~p"/") |> html_response(200)
+      assert body =~ ~p"/case-studies/self-healing-infrastructure"
+      assert body =~ "An estate that answers its own alerts."
+    end
+  end
+
   describe "legal links" do
     test "registration form links to terms and privacy", %{conn: conn} do
       body = conn |> get(~p"/auth/register") |> html_response(200)

--- a/apps/fountain/test/fountain_web/controllers/marketing_instance_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_instance_test.exs
@@ -110,6 +110,21 @@ defmodule FountainWeb.MarketingInstanceTest do
     end
   end
 
+  describe "GET /case-studies where the deployment is not the marketing site" do
+    test "sends the visitor to the manual rather than somebody else's sales copy", %{conn: conn} do
+      Application.put_env(:fountain, :marketing_site, false)
+
+      assert redirected_to(get(conn, ~p"/case-studies/self-healing-infrastructure")) ==
+               ~p"/docs/tour"
+
+      assert redirected_to(get(conn, ~p"/case-studies")) == "/docs"
+
+      # The layout drops the footer link too, for the same reason as
+      # /integrations above.
+      refute conn |> get(~p"/") |> html_response(200) =~ ~p"/case-studies"
+    end
+  end
+
   describe "GET / on the marketing site" do
     test "still serves the pitch", %{conn: conn} do
       Application.put_env(:fountain, :marketing_site, true)


### PR DESCRIPTION
`/case-studies/self-healing-infrastructure` on the marketing site.

A Kubernetes estate used to page a person when a workload broke. It now pages a person **and** hires an agent. Prometheus fires, Alertmanager forks the page with `continue: true`, a webhook opens one Fountain conversation, and the agent reads the cluster through a GET-only estate API, names the commit that introduced the fault, and opens one minimal pull request.

The page is mostly about the gate. An agent that opens infrastructure pull requests is only as safe as the smallest thing it is able to do, and none of the refusals here rest on a system prompt holding:

| It can | It cannot |
|---|---|
| Read the estate graph | Change anything in the cluster. The token is refused on any method but GET |
| Push a branch | Push to the default branch |
| Open a pull request | Approve or merge it. Self-approval is a 422, self-merge a 405 |
| Reference a secret by name | Read a secret value |
| Say no change can fix this, and stop | Reach the cluster. No kubectl, no kubeconfig |

## The numbers are real, and counted once

Data first in `MarketingHTML`, like `/integrations`. Every figure is a literal beside the window it covers (11 to 25 August 2026), read once from this deployment's own database and the estate's pull requests:

- **78** incidents dispatched in fifteen days
- **4m 27s** from the alert to the open pull request (conversation created 06:58:15Z, PR opened 07:02:42Z on 25 Aug)
- **7.5 min** median incident, start to written verdict
- **12** fix pull requests opened, **8** merged

Deliberately not recomputed at request time. A figure that widened its own window would end up claiming something nobody checked. The footnote says plainly that four of the merged eight are the same rehearsal fault raised on purpose, and that most incidents end with no pull request at all because the agent decides the repository cannot fix them.

## One incident carries the page

An OOMKilled sidecar whose memory limit was sized for its cheap steady-state git-fetch loop and never for the reinstall path it shares with an initContainer. Latent for months, invisible until a commit moved a lockfile. The agent's root-cause paragraph is quoted word for word, segmented so the source Markdown's backticks render as code spans rather than literal characters.

## Routing and the instance rule

`/case-studies` redirects to the one study rather than 404ing on the segment a reader will chop off the URL. It becomes a real index when there is a second one.

Like `/integrations`, `/built-with` and `/self-hosted` this is sales copy, so an instance that is not the marketing site redirects into the manual (`/docs/tour`) and the footer drops the link. The homepage carries a callout with the same four numbers, placed ahead of the `/built-with` band.

## Tests

Twelve new cases. The controller test resolves every `/docs` link through `Fountain.Docs.get/1`, asserts every loop step and every timestamp reaches the page, and pins the window string alongside the numbers so one cannot be updated without the other. `MarketingInstanceTest` covers the non-marketing-site redirects and the dropped footer link.

`mix credo --strict` clean; 889 tests across `test/fountain_web/controllers/` and `docs_test.exs` pass. Every section was checked in a browser at desktop and narrow widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
