### PR TITLE
copy(marketing): the homepage becomes a funnel, lane by lane

### DIFF
--- a/apps/fountain/lib/fountain_web/components/layouts/marketing.html.heex
+++ b/apps/fountain/lib/fountain_web/components/layouts/marketing.html.heex
@@ -76,7 +76,7 @@
       <span :if={Fountain.Marketing.site?()}>
         © 2026 {Fountain.Brand.name()}. Managed agent infrastructure for teams who'd rather build than configure.
         <span :if={Fountain.Brand.hosted?()}>
-          The hosted enterprise edition of {Fountain.Brand.engine()}, which is open source.
+          It runs {Fountain.Brand.engine()}, which is open source.
         </span>
       </span>
       <span :if={!Fountain.Marketing.site?()}>Powered by Fountain.</span>

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
@@ -790,7 +790,7 @@ defmodule FountainWeb.MarketingHTML do
         step: "03",
         title: "The machines",
         body:
-          "A Mac mini, a home server or a GPU box becomes a sandbox backend with one daemon. It dials out, holds one connection, wants no inbound port and no credential."
+          "A Mac mini, a home server or a GPU box becomes a sandbox backend with one daemon. It dials out and holds one connection. There is no inbound port to open and no credential to hand it."
       },
       %{
         step: "04",
@@ -817,7 +817,7 @@ defmodule FountainWeb.MarketingHTML do
       %{
         title: "Email is a decision, not an optional extra",
         body:
-          "Verification, password resets and anything a teammate sends go through Resend or an SMTP server of yours. The compose defaults skip delivery so the first account can register, and that default is for day one only.",
+          "Verification and password resets go through Resend, or an SMTP server of yours. So does anything a teammate sends. The compose defaults skip delivery so the first account can register, and that default is for day one only.",
         docs: "/docs/guides/operate/email",
         docs_label: "Configure email"
       },
@@ -854,7 +854,7 @@ defmodule FountainWeb.MarketingHTML do
       %{
         q: "What do I pay for the software?",
         a:
-          "Nothing. There is no licence key, no seat count and no call with us. Leave credits off and the instance prices nothing, gates nothing and shows nobody a bill. Turn credits on and it bills your users, not you."
+          "Nothing. There is no licence key and no seat count, and nobody has to talk to us first. Leave credits off and the instance prices nothing and shows nobody a bill. Turn credits on and it bills your users rather than you."
       },
       %{
         q: "Do I still bring a model key?",
@@ -864,7 +864,7 @@ defmodule FountainWeb.MarketingHTML do
       %{
         q: "Can I try the hosted one first?",
         a:
-          "Yes, and none of it is wasted. The console, the CLI, the API, the SDK and the manual are the same on both. What changes is whose machine it runs on."
+          "Yes, and none of it is wasted. The console, the CLI and the API are the same on both, and so are the SDK and the manual. What changes is whose machine it runs on."
       },
       %{
         q: "How much of an instance is one person?",

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -15,7 +15,7 @@
     Every agent gets a brief, a budget, and a boundary.
   </h1>
   <p class="text-lg sm:text-xl text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-10">
-    Hire an agent by role. It remembers the last time. It can hand work to the others on your roster, and it runs on our infrastructure or on hardware inside your own network.
+    Hire an agent by role. It picks up where it left off, and it can hand work to the others on your roster. Run it on our infrastructure, or on hardware inside your own network.
   </p>
   <div class="flex flex-col sm:flex-row gap-3 justify-center mb-4">
     <a
@@ -162,6 +162,125 @@
       </p>
     </div>
   </section>
+</section>
+
+<%!-- Bring your own stack. Four protocols, one of which is behind a flag, so
+      this is where the badge legend lives: it is the first badge a reader
+      meets, and everything above it is generally available. --%>
+<section class="max-w-5xl mx-auto px-6 py-16">
+  <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-3 text-center">
+    Bring the stack you already have.
+  </h2>
+  <p class="text-center text-[var(--color-text-secondary)] max-w-xl mx-auto mb-3">
+    Fountain answers four protocols on top of its own REST API. The editor, chat surface, gateway or framework you use today can hire an agent with a URL and a key, and there is nothing to install on our side.
+  </p>
+  <p class="text-center text-xs text-[var(--color-text-muted)] max-w-xl mx-auto mb-10">
+    Anything without a badge is on for every account. Alpha means it works end to end and its shape can still change between releases.
+  </p>
+
+  <dl class="max-w-2xl mx-auto space-y-6">
+    <div>
+      <dt class="font-medium text-[var(--color-text-primary)]">
+        Agent Client Protocol
+      </dt>
+      <dd class="mt-1 text-sm text-[var(--color-text-secondary)] leading-relaxed">
+        For an editor or a chat surface.
+        <code class="text-xs px-1 py-0.5 rounded bg-[var(--color-bg-2)]">fountain acp</code>
+        makes any agent on your roster the one the client is talking to.
+      </dd>
+    </div>
+
+    <div>
+      <dt class="font-medium text-[var(--color-text-primary)]">
+        AG-UI
+      </dt>
+      <dd class="mt-1 text-sm text-[var(--color-text-secondary)] leading-relaxed">
+        The Agent-User Interaction Protocol, for a coworker platform. One endpoint per agent, and the steps stream as the agent takes them.
+      </dd>
+    </div>
+
+    <div>
+      <dt class="font-medium text-[var(--color-text-primary)]">
+        MCP, both directions
+      </dt>
+      <dd class="mt-1 text-sm text-[var(--color-text-secondary)] leading-relaxed">
+        Your agents reach the servers you declare on them. Fountain injects its own on top. A teammate can read the roster and message the others without you wiring anything.
+      </dd>
+    </div>
+
+    <div>
+      <dt class="font-medium text-[var(--color-text-primary)]">
+        OpenAI chat completions
+        <span class="ml-1 align-middle inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide bg-[var(--color-bg-2)] text-[var(--color-text-muted)]">
+          Alpha
+        </span>
+      </dt>
+      <dd class="mt-1 text-sm text-[var(--color-text-secondary)] leading-relaxed">
+        The request shape every gateway already speaks, where the model is an agent.
+        <code class="text-xs px-1 py-0.5 rounded bg-[var(--color-bg-2)]">GET /v1/models</code>
+        fills a client's picker with your roster, and your own tools come back as tool calls. A Fountain agent can therefore sit inside a LangChain loop or a Deep Agents plan as a subagent.
+      </dd>
+      <dd class="mt-2 text-xs text-[var(--color-text-muted)] leading-relaxed">
+        We turn it on for your account here when you ask. On your own instance, add
+        <code class="text-xs px-1 py-0.5 rounded bg-[var(--color-bg-2)]">openai_compat</code>
+        to <code class="text-xs px-1 py-0.5 rounded bg-[var(--color-bg-2)]">FEATURE_FLAGS_ON</code>.
+      </dd>
+    </div>
+  </dl>
+
+  <p class="mt-8 text-center text-sm text-[var(--color-text-secondary)]">
+    Under all four is the REST API. A TypeScript SDK and a CLI sit over it. <a
+      href={~p"/integrations"}
+      class="text-[var(--color-brand)] hover:underline"
+    >
+      See what already speaks them
+    </a>.
+  </p>
+</section>
+
+<%!-- The limits, stated before the price rather than discovered after it. Every
+      number here reads from the same settings the quota enforces. --%>
+<section class="bg-[var(--color-bg-1)] border-y border-[var(--color-border)]">
+  <div class="max-w-5xl mx-auto px-6 py-16">
+    <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-10 text-center">
+      The limits, before you build on them.
+    </h2>
+
+    <dl class="max-w-2xl mx-auto space-y-6">
+      <div :if={pricing?()}>
+        <dt class="font-medium text-[var(--color-text-primary)]">How many can run at once</dt>
+        <dd class="mt-1 text-sm text-[var(--color-text-secondary)] leading-relaxed">
+          Your balance sets it. One more agent for every {elem(cap_rule(), 0)} you hold, from {elem(
+            cap_rule(),
+            1
+          )}, up to {elem(cap_rule(), 2)}. A separate ceiling bounds how many sandboxes run across the whole platform, and when it is reached you get a plain refusal rather than a charge.
+        </dd>
+      </div>
+
+      <div>
+        <dt class="font-medium text-[var(--color-text-primary)]">Recursion is yours to bound</dt>
+        <dd class="mt-1 text-sm text-[var(--color-text-secondary)] leading-relaxed">
+          An agent that can hire agents can do it again from inside the one it hired. Nothing caps the depth on our side. The skill instructs each agent to cap its own, and the balance is the backstop under that.
+        </dd>
+      </div>
+
+      <div>
+        <dt class="font-medium text-[var(--color-text-primary)]">
+          A teammate is not a shared inbox
+        </dt>
+        <dd class="mt-1 text-sm text-[var(--color-text-secondary)] leading-relaxed">
+          One agent has one thread on one computer. Two people who message the same teammate are talking to the same thread and the same machine.
+        </dd>
+      </div>
+
+      <div>
+        <dt class="font-medium text-[var(--color-text-primary)]">An account is one person</dt>
+        <dd class="mt-1 text-sm text-[var(--color-text-secondary)] leading-relaxed">
+          There are no organisations and no seats. Sign-in is an email address or GitHub, and there is no single sign-on. A team shares an account, or runs an instance of its own.
+        </dd>
+      </div>
+    </dl>
+  </div>
 </section>
 
 <%!-- How it works --%>
@@ -349,6 +468,41 @@
   </div>
 </section>
 
+<%!-- Lane three's section on the homepage. One question sorts the reader, and
+      the runner concession sits beside the runner claim rather than a page
+      away, because the hero promises a boundary and a runner has none. --%>
+<section class="bg-[var(--color-bg-1)] border-y border-[var(--color-border)]">
+  <div class="max-w-5xl mx-auto px-6 py-16">
+    <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-3 text-center">
+      Or run the whole thing yourself.
+    </h2>
+    <p class="text-center text-[var(--color-text-secondary)] max-w-xl mx-auto mb-10">
+      One question decides it. If your code and your secrets cannot leave your own infrastructure, this platform was never the answer for you.
+    </p>
+
+    <div class="max-w-2xl mx-auto space-y-4 text-[var(--color-text-secondary)]">
+      <p>
+        {Fountain.Brand.engine()} is open source, and nothing is held back from the copy you run. The server this platform runs on is the one you would run, and so are the CLI and the SDK. A compose file brings an instance up, and a portable Kubernetes baseline is in the repo for anyone who already lives there.
+      </p>
+      <p>
+        Your own hardware can serve the sandboxes too. A runner is a machine you own that dials out to {Fountain.Brand.name()} and holds one connection. There is no inbound port, and it works behind NAT. It burns no credit at all.
+      </p>
+      <p class="text-sm text-[var(--color-text-muted)]">
+        A runner runs in trusted mode. The agent's processes run as you. They get your network and your tools, and no container or VM stands between them. Run one on a machine where you would hand a capable colleague a shell.
+      </p>
+    </div>
+
+    <p class="mt-8 text-center">
+      <a
+        href={~p"/self-hosted"}
+        class="inline-flex items-center justify-center px-5 py-2.5 rounded-lg border border-[var(--color-border)] text-[var(--color-text-primary)] text-sm font-medium hover:bg-[var(--color-bg-2)] transition-colors"
+      >
+        What it takes to run it yourself
+      </a>
+    </p>
+  </div>
+</section>
+
 <%!-- Objections --%>
 <section class="max-w-5xl mx-auto px-6 py-16">
   <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-10 text-center">
@@ -359,6 +513,15 @@
       <dt class="font-medium text-[var(--color-text-primary)]">Do I need a model key?</dt>
       <dd class="mt-1 text-sm leading-relaxed">
         Yes. Bring an Anthropic, OpenAI or Google key and the agent bills your own account for tokens. {Fountain.Brand.name()} charges for the sandbox hours, never for inference, so there is no markup on the model.
+      </dd>
+    </div>
+
+    <div>
+      <dt class="font-medium text-[var(--color-text-primary)]">
+        I have no API key. I pay for Claude.
+      </dt>
+      <dd class="mt-1 text-sm leading-relaxed">
+        That is a credential {Fountain.Brand.name()} accepts. A Claude Pro or Team subscription works in place of a metered API key, and when you hold both, the subscription is the one your agents spend. It is usually the one you want spent.
       </dd>
     </div>
     <div>

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -7,7 +7,7 @@
   <p
     :if={Fountain.Brand.hosted?()}
     class="mb-4 text-sm font-medium uppercase tracking-wide text-[var(--color-text-muted)]"
-    data-role="hosted-enterprise"
+    data-role="hosted-brand"
   >
     {Fountain.Brand.name()} is the hosted {Fountain.Brand.engine()}. The engine is open source and you can run it yourself.
   </p>

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -77,91 +77,106 @@
       {Fountain.Brand.name()} is that machine, that vault and that owner. You keep the conversation.
     </p>
   </div>
+</section>
 
-  <%!-- One teammate. Lane one's whole promise, and every claim in it is
+<%!-- One teammate. Lane one's whole promise, and every claim in it is
       generally available, so nothing here carries a status badge. --%>
-  <section class="max-w-5xl mx-auto px-6 py-16">
-    <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-8 text-center">
-      Close the laptop. The work is still there.
-    </h2>
-    <div class="max-w-2xl mx-auto space-y-4 text-[var(--color-text-secondary)]">
-      <p>
-        A teammate is an agent with a thread that keeps going. Give it a name and a one-line brief.
-      </p>
-      <p>
-        It parks when you stop typing, and a parked teammate costs nothing. The next message wakes it with its files and its checkout intact. The second message costs a sentence, not a re-explanation of the first.
-      </p>
-      <p>
-        Give it a schedule and it works while you are not there. "Each weekday at nine" is a cron, and the reply lands in the thread when it is done.
-      </p>
-      <p>
-        Its memory is the disk it runs on. End the conversation and the memory goes with it, and the thread survives without it.
-      </p>
-    </div>
-  </section>
+<section class="max-w-5xl mx-auto px-6 py-16">
+  <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-8 text-center">
+    Close the laptop. The work is still there.
+  </h2>
+  <div class="max-w-2xl mx-auto space-y-4 text-[var(--color-text-secondary)]">
+    <p>
+      A teammate is an agent with a thread that keeps going. Give it a name and a one-line brief.
+    </p>
+    <p>
+      It parks when you stop typing, and a parked teammate costs nothing. The next message wakes it with its files and its checkout intact. The second message costs a sentence, not a re-explanation of the first.
+    </p>
+    <p>
+      Give it a schedule and it works while you are not there. "Each weekday at nine" is a cron, and the reply lands in the thread when it is done.
+    </p>
+    <p>
+      Its memory is the disk it runs on. End the conversation and the memory goes with it, and the thread survives without it.
+    </p>
+  </div>
+  <p class="mt-8 text-center">
+    <a
+      href={~p"/auth/register"}
+      class="inline-flex items-center justify-center px-5 py-2.5 rounded-lg border border-[var(--color-border)] text-[var(--color-text-primary)] text-sm font-medium hover:bg-[var(--color-bg-2)] transition-colors"
+    >
+      Hire your first teammate
+    </a>
+  </p>
+</section>
 
-  <%!-- The roster. Every mechanism named here ships unflagged, which is why none
+<%!-- The roster. Every mechanism named here ships unflagged, which is why none
       of it carries a badge. The closing concession is the hero's "budget"
       doing its work: recursion has no server-side cap, and the balance is what
       bounds it. --%>
-  <section class="bg-[var(--color-bg-1)] border-y border-[var(--color-border)]">
-    <div class="max-w-5xl mx-auto px-6 py-16">
-      <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-3 text-center">
-        Agents that cooperate contractually.
-      </h2>
-      <p class="text-center text-[var(--color-text-secondary)] max-w-xl mx-auto mb-10">
-        A roster is not a list of bots. Each agent is hired for a role, and it can hand work to the others.
-      </p>
+<section class="bg-[var(--color-bg-1)] border-y border-[var(--color-border)]">
+  <div class="max-w-5xl mx-auto px-6 py-16">
+    <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-3 text-center">
+      Agents that cooperate contractually.
+    </h2>
+    <p class="text-center text-[var(--color-text-secondary)] max-w-xl mx-auto mb-10">
+      A roster is not a list of bots. Each agent is hired for a role, and it can hand work to the others.
+    </p>
 
-      <div class="grid sm:grid-cols-2 gap-6">
-        <%!-- create-team --%>
-        <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6">
-          <h3 class="font-semibold text-[var(--color-text-primary)] mb-2">
-            Five questions, then a roster
-          </h3>
-          <p class="text-sm text-[var(--color-text-secondary)] leading-relaxed">
-            Say
-            <code class="text-xs px-1 py-0.5 rounded bg-[var(--color-bg-2)]">/create-team</code>
-            to any teammate. It asks five questions about the work and the repos in scope. The model keys you hold decide which brains it can offer. It proposes nothing you cannot run, and creates nothing until you say yes.
-          </p>
-        </div>
-
-        <%!-- fountain-team MCP --%>
-        <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6">
-          <h3 class="font-semibold text-[var(--color-text-primary)] mb-2">
-            They reach each other by role
-          </h3>
-          <p class="text-sm text-[var(--color-text-secondary)] leading-relaxed">
-            A teammate resolves another by description. "The engineer" or "whoever handles support" returns a match, and the message lands in that teammate's thread with the sender named in front. A lead routes work, and nobody has to relay it.
-          </p>
-        </div>
-
-        <%!-- the fountain skill --%>
-        <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6">
-          <h3 class="font-semibold text-[var(--color-text-primary)] mb-2">
-            Any agent can fan out
-          </h3>
-          <p class="text-sm text-[var(--color-text-secondary)] leading-relaxed">
-            Every sandbox carries the skill that starts more conversations. An agent runs a batch of them in parallel and collects the answers. Each child takes its own computer, or shares the one its parent is on.
-          </p>
-        </div>
-
-        <%!-- allowlists, versions, provenance --%>
-        <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6">
-          <h3 class="font-semibold text-[var(--color-text-primary)] mb-2">
-            What makes it contractual
-          </h3>
-          <p class="text-sm text-[var(--color-text-secondary)] leading-relaxed">
-            An agent may only launch with the environments and vaults on its allowlist. Every shape it has had is kept as a version, and each conversation records the version it ran under. A spawned conversation carries its parent's id, so the whole chain can be rebuilt afterwards.
-          </p>
-        </div>
+    <div class="grid sm:grid-cols-2 gap-6">
+      <%!-- create-team --%>
+      <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6">
+        <h3 class="font-semibold text-[var(--color-text-primary)] mb-2">
+          Five questions, then a roster
+        </h3>
+        <p class="text-sm text-[var(--color-text-secondary)] leading-relaxed">
+          Say <code class="text-xs px-1 py-0.5 rounded bg-[var(--color-bg-2)]">/create-team</code>
+          to any teammate. It asks five questions about the work and the repos in scope. The model keys you hold decide which brains it can offer. It proposes nothing you cannot run, and creates nothing until you say yes.
+        </p>
       </div>
 
-      <p class="mt-10 max-w-2xl mx-auto text-sm text-[var(--color-text-secondary)] leading-relaxed">
-        Nothing stops recursion on our side. The skill tells the agent to cap its own depth, and a runaway fan-out is a real way to spend money. What bounds it is the budget. Your balance sets how many agents can run at once, and an agent cannot spend past it.
-      </p>
+      <%!-- fountain-team MCP --%>
+      <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6">
+        <h3 class="font-semibold text-[var(--color-text-primary)] mb-2">
+          They reach each other by role
+        </h3>
+        <p class="text-sm text-[var(--color-text-secondary)] leading-relaxed">
+          A teammate resolves another by description. "The engineer" or "whoever handles support" returns a match, and the message lands in that teammate's thread with the sender named in front. A lead routes work, and nobody has to relay it.
+        </p>
+      </div>
+
+      <%!-- the fountain skill --%>
+      <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6">
+        <h3 class="font-semibold text-[var(--color-text-primary)] mb-2">
+          Any agent can fan out
+        </h3>
+        <p class="text-sm text-[var(--color-text-secondary)] leading-relaxed">
+          Every sandbox carries the skill that starts more conversations. An agent runs a batch of them in parallel and collects the answers. Each child takes its own computer, or shares the one its parent is on.
+        </p>
+      </div>
+
+      <%!-- allowlists, versions, provenance --%>
+      <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6">
+        <h3 class="font-semibold text-[var(--color-text-primary)] mb-2">
+          What makes it contractual
+        </h3>
+        <p class="text-sm text-[var(--color-text-secondary)] leading-relaxed">
+          An agent may only launch with the environments and vaults on its allowlist. Every shape it has had is kept as a version, and each conversation records the version it ran under. A spawned conversation carries its parent's id, so the whole chain can be rebuilt afterwards.
+        </p>
+      </div>
     </div>
-  </section>
+
+    <p class="mt-10 max-w-2xl mx-auto text-sm text-[var(--color-text-secondary)] leading-relaxed">
+      Nothing stops recursion on our side. The skill tells the agent to cap its own depth, and a runaway fan-out is a real way to spend money. What bounds it is the budget. Your balance sets how many agents can run at once, and an agent cannot spend past it.
+    </p>
+    <p class="mt-8 text-center">
+      <a
+        href={~p"/auth/register"}
+        class="inline-flex items-center justify-center px-5 py-2.5 rounded-lg border border-[var(--color-border)] text-[var(--color-text-primary)] text-sm font-medium hover:bg-[var(--color-bg-2)] transition-colors"
+      >
+        Build a roster
+      </a>
+    </p>
+  </div>
 </section>
 
 <%!-- Bring your own stack. Four protocols, one of which is behind a flag, so
@@ -459,6 +474,34 @@
     >
       See what people built
     </a>
+  </div>
+</section>
+
+<%!-- The teammate contact. Deep on the page on purpose. It is the most
+      quotable thing here and the only one gated on asking us, so down here it
+      reads as a bonus rather than a barrier on the way in. --%>
+<section class="max-w-5xl mx-auto px-6 py-16">
+  <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-6 text-center">
+    Give one a phone number.
+    <span class="ml-1 align-middle inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide bg-[var(--color-bg-2)] text-[var(--color-text-muted)]">
+      Alpha
+    </span>
+  </h2>
+  <div class="max-w-2xl mx-auto space-y-4 text-center text-[var(--color-text-secondary)]">
+    <p>
+      A teammate can hold an email address and a number of its own. Text it and it answers in its thread, on the same computer it has been working on all week.
+    </p>
+    <p>
+      {Fountain.Brand.name()} holds the keys to that inbox and that number. The sandbox is handed tools, and never a credential.
+    </p>
+    <p :if={pricing?() and rent_line()} class="text-sm text-[var(--color-text-muted)]">
+      A contact rents from your balance. {String.capitalize(rent_line())}, a month up front.
+    </p>
+    <p class="text-xs text-[var(--color-text-muted)]">
+      Ask us and we turn it on for your account. On your own instance, set the AgentMail and AgentPhone keys. Then add
+      <code class="text-xs px-1 py-0.5 rounded bg-[var(--color-bg-2)]">team_comms</code>
+      to <code class="text-xs px-1 py-0.5 rounded bg-[var(--color-bg-2)]">FEATURE_FLAGS_ON</code>.
+    </p>
   </div>
 </section>
 

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -1,19 +1,21 @@
 <%!-- Hero --%>
 <section class="max-w-5xl mx-auto px-6 py-20 text-center">
-  <%!-- On a branded hosted site, say what this is before the pitch: the
-        hosted, enterprise edition of the open-source engine. --%>
+  <%!-- On a branded hosted site, say what this is before the pitch. The engine
+        is open source and nothing is held back from it (ADR 0034), so a reader
+        who will never use the hosted product learns that in the first line
+        rather than at the bottom of the page. --%>
   <p
     :if={Fountain.Brand.hosted?()}
     class="mb-4 text-sm font-medium uppercase tracking-wide text-[var(--color-text-muted)]"
     data-role="hosted-enterprise"
   >
-    {Fountain.Brand.name()} is the hosted enterprise edition of {Fountain.Brand.engine()}
+    {Fountain.Brand.name()} is the hosted {Fountain.Brand.engine()}. The engine is open source and you can run it yourself.
   </p>
   <h1 class="text-4xl sm:text-5xl font-bold tracking-tight text-[var(--color-text-primary)] mb-5 leading-tight">
-    Give your app a coding agent. Skip the machine it needs.
+    Every agent gets a brief, a budget, and a boundary.
   </h1>
   <p class="text-lg sm:text-xl text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-10">
-    {Fountain.Brand.name()} runs Claude Code, Codex, Gemini or OpenCode on a cloud sandbox it builds for you. Send a prompt over the API, read the reply. The sandbox parks between messages and wakes with its work intact, so there is no box to provision, lock down, or pay for while nobody is talking.
+    Hire an agent by role. It remembers the last time. It can hand work to the others on your roster, and it runs on our infrastructure or on hardware inside your own network.
   </p>
   <div class="flex flex-col sm:flex-row gap-3 justify-center mb-4">
     <a
@@ -30,7 +32,7 @@
     </a>
   </div>
   <p :if={pricing?()} class="text-xs text-[var(--color-text-muted)]">
-    {elem(opening_credit(), 0)} of credit to start, no card. Bring your own model key; you pay for machine time, never for tokens.
+    {elem(opening_credit(), 0)} of credit to start, no card. Bring your own model key. You pay for agent time, never for tokens.
   </p>
   <p :if={!pricing?()} class="text-xs text-[var(--color-text-muted)]">
     Free to use on this install.
@@ -75,6 +77,91 @@
       {Fountain.Brand.name()} is that machine, that vault and that owner. You keep the conversation.
     </p>
   </div>
+
+  <%!-- One teammate. Lane one's whole promise, and every claim in it is
+      generally available, so nothing here carries a status badge. --%>
+  <section class="max-w-5xl mx-auto px-6 py-16">
+    <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-8 text-center">
+      Close the laptop. The work is still there.
+    </h2>
+    <div class="max-w-2xl mx-auto space-y-4 text-[var(--color-text-secondary)]">
+      <p>
+        A teammate is an agent with a thread that keeps going. Give it a name and a one-line brief.
+      </p>
+      <p>
+        It parks when you stop typing, and a parked teammate costs nothing. The next message wakes it with its files and its checkout intact. The second message costs a sentence, not a re-explanation of the first.
+      </p>
+      <p>
+        Give it a schedule and it works while you are not there. "Each weekday at nine" is a cron, and the reply lands in the thread when it is done.
+      </p>
+      <p>
+        Its memory is the disk it runs on. End the conversation and the memory goes with it, and the thread survives without it.
+      </p>
+    </div>
+  </section>
+
+  <%!-- The roster. Every mechanism named here ships unflagged, which is why none
+      of it carries a badge. The closing concession is the hero's "budget"
+      doing its work: recursion has no server-side cap, and the balance is what
+      bounds it. --%>
+  <section class="bg-[var(--color-bg-1)] border-y border-[var(--color-border)]">
+    <div class="max-w-5xl mx-auto px-6 py-16">
+      <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-3 text-center">
+        Agents that cooperate contractually.
+      </h2>
+      <p class="text-center text-[var(--color-text-secondary)] max-w-xl mx-auto mb-10">
+        A roster is not a list of bots. Each agent is hired for a role, and it can hand work to the others.
+      </p>
+
+      <div class="grid sm:grid-cols-2 gap-6">
+        <%!-- create-team --%>
+        <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6">
+          <h3 class="font-semibold text-[var(--color-text-primary)] mb-2">
+            Five questions, then a roster
+          </h3>
+          <p class="text-sm text-[var(--color-text-secondary)] leading-relaxed">
+            Say
+            <code class="text-xs px-1 py-0.5 rounded bg-[var(--color-bg-2)]">/create-team</code>
+            to any teammate. It asks five questions about the work and the repos in scope. The model keys you hold decide which brains it can offer. It proposes nothing you cannot run, and creates nothing until you say yes.
+          </p>
+        </div>
+
+        <%!-- fountain-team MCP --%>
+        <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6">
+          <h3 class="font-semibold text-[var(--color-text-primary)] mb-2">
+            They reach each other by role
+          </h3>
+          <p class="text-sm text-[var(--color-text-secondary)] leading-relaxed">
+            A teammate resolves another by description. "The engineer" or "whoever handles support" returns a match, and the message lands in that teammate's thread with the sender named in front. A lead routes work, and nobody has to relay it.
+          </p>
+        </div>
+
+        <%!-- the fountain skill --%>
+        <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6">
+          <h3 class="font-semibold text-[var(--color-text-primary)] mb-2">
+            Any agent can fan out
+          </h3>
+          <p class="text-sm text-[var(--color-text-secondary)] leading-relaxed">
+            Every sandbox carries the skill that starts more conversations. An agent runs a batch of them in parallel and collects the answers. Each child takes its own computer, or shares the one its parent is on.
+          </p>
+        </div>
+
+        <%!-- allowlists, versions, provenance --%>
+        <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6">
+          <h3 class="font-semibold text-[var(--color-text-primary)] mb-2">
+            What makes it contractual
+          </h3>
+          <p class="text-sm text-[var(--color-text-secondary)] leading-relaxed">
+            An agent may only launch with the environments and vaults on its allowlist. Every shape it has had is kept as a version, and each conversation records the version it ran under. A spawned conversation carries its parent's id, so the whole chain can be rebuilt afterwards.
+          </p>
+        </div>
+      </div>
+
+      <p class="mt-10 max-w-2xl mx-auto text-sm text-[var(--color-text-secondary)] leading-relaxed">
+        Nothing stops recursion on our side. The skill tells the agent to cap its own depth, and a runaway fan-out is a real way to spend money. What bounds it is the budget. Your balance sets how many agents can run at once, and an agent cannot spend past it.
+      </p>
+    </div>
+  </section>
 </section>
 
 <%!-- How it works --%>

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -286,7 +286,7 @@
 <%!-- How it works --%>
 <section class="max-w-5xl mx-auto px-6 py-16">
   <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-10 text-center">
-    Three rows and one call.
+    Everything above is three rows and one call.
   </h2>
   <div class="grid md:grid-cols-2 gap-10 items-start">
     <ol class="space-y-6 text-[var(--color-text-secondary)]">
@@ -298,7 +298,7 @@
           <span class="font-medium text-[var(--color-text-primary)]">
             Describe the machine once.
           </span>
-          An Environment names the repositories, packages, setup scripts and env vars an agent wakes up with. Write it in the console, the CLI, or a YAML manifest.
+          An Environment describes the machine an agent wakes up on. It names repositories, packages and env vars, and the scripts that run first. Write it in the console, or apply it as YAML from the CLI.
         </span>
       </li>
       <li class="flex items-start gap-4">
@@ -316,7 +316,7 @@
         </span>
         <span>
           <span class="font-medium text-[var(--color-text-primary)]">Send a prompt.</span>
-          A sandbox spawns, the agent works, the reply streams back. Send another and it picks up where it left off. That is the whole integration.
+          A sandbox spawns and the agent works. The reply streams back as it goes. Send another prompt and the same machine is still there, with its work on it.
         </span>
       </li>
     </ol>
@@ -333,6 +333,9 @@
     <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-10 text-center">
       What you stop building.
     </h2>
+    <p class="text-center text-[var(--color-text-secondary)] max-w-xl mx-auto mb-10 -mt-6">
+      The roster above runs on four things you would otherwise have written yourself.
+    </p>
     <div class="grid sm:grid-cols-2 gap-6">
       <%!-- Per-user threads --%>
       <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6">
@@ -405,11 +408,11 @@
           Output and lifecycle events stream over SSE. Ask for <code
             class="text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1 py-0.5 text-xs"
             phx-no-format
-          >?blocks=true</code> and the server parses each runtime's dialect for you, so your client renders one shape whether the agent is Claude Code or Codex.
+          >?blocks=true</code> and the server parses each runtime's dialect for you. Your client renders one shape whether the agent is Claude Code or Codex.
         </p>
       </div>
 
-      <%!-- Surfaces --%>
+      <%!-- Audit trail --%>
       <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6">
         <div class="size-9 rounded-lg bg-[var(--color-bg-2)] flex items-center justify-center mb-4">
           <svg
@@ -418,23 +421,14 @@
             fill="currentColor"
             aria-hidden="true"
           >
-            <path d="M3.25 4A2.25 2.25 0 0 0 1 6.25v7.5A2.25 2.25 0 0 0 3.25 16h7.5A2.25 2.25 0 0 0 13 13.75v-7.5A2.25 2.25 0 0 0 10.75 4h-7.5ZM19 4.75a.75.75 0 0 0-1.28-.53l-3 3a.75.75 0 0 0-.22.53v4.5c0 .199.079.39.22.53l3 3a.75.75 0 0 0 1.28-.53V4.75Z" />
+            <path d="M2 4.75A.75.75 0 0 1 2.75 4h14.5a.75.75 0 0 1 0 1.5H2.75A.75.75 0 0 1 2 4.75ZM2 10a.75.75 0 0 1 .75-.75h14.5a.75.75 0 0 1 0 1.5H2.75A.75.75 0 0 1 2 10Zm0 5.25a.75.75 0 0 1 .75-.75h14.5a.75.75 0 0 1 0 1.5H2.75a.75.75 0 0 1-.75-.75Z" />
           </svg>
         </div>
         <h3 class="font-semibold text-[var(--color-text-primary)] mb-2">
-          Reach it from wherever you already are
+          Every change leaves a record
         </h3>
         <p class="text-sm text-[var(--color-text-secondary)] leading-relaxed">
-          REST and SSE for your own code, a TypeScript SDK, a <code
-            class="text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1 py-0.5 text-xs"
-            phx-no-format
-          >fountain</code> CLI, ACP for your editor, AG-UI for a coworker platform. Everything the SDK does, <code
-            class="text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1 py-0.5 text-xs"
-            phx-no-format
-          >curl</code> can do. <a
-            href={~p"/integrations"}
-            class="underline underline-offset-2 hover:text-[var(--color-text-primary)]"
-          >See every protocol and what speaks it</a>.
+          The event is written where the change happens rather than where the request arrived, so the console, the API and a background worker are all covered by the same rule. An update names the fields that moved and never their values. Filter the trail by action, resource or time.
         </p>
       </div>
     </div>

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/privacy.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/privacy.html.heex
@@ -75,23 +75,23 @@
       </p>
       <ul class="list-disc pl-6 space-y-1">
         <li>
-          <strong class="text-[var(--color-text-primary)]">Stripe</strong> — payment processing;
+          <strong class="text-[var(--color-text-primary)]">Stripe</strong>: payment processing;
         </li>
         <li>
           <strong class="text-[var(--color-text-primary)]">our email provider</strong>
-          — transactional email delivery;
+          : transactional email delivery;
         </li>
         <li>
           <strong class="text-[var(--color-text-primary)]">sandbox infrastructure</strong>
-          — the isolated compute environments your conversations run in, which receive the
+          : the isolated compute environments your conversations run in, which receive the
           configuration and decrypted credentials needed to run each conversation;
         </li>
         <li>
-          <strong class="text-[var(--color-text-primary)]" phx-no-format>AI model providers you configure</strong> — your agents call them with credentials you supply, under those providers' terms;
+          <strong class="text-[var(--color-text-primary)]" phx-no-format>AI model providers you configure</strong>: your agents call them with credentials you supply, under those providers' terms;
         </li>
         <li>
           <strong class="text-[var(--color-text-primary)]">GitHub</strong>
-          — only if you choose GitHub sign-in.
+          : only if you choose GitHub sign-in.
         </li>
       </ul>
       <p class="mt-2">
@@ -127,7 +127,7 @@
         From your account page you can, at any time and without asking us: export your data in a
         machine-readable format, and permanently delete your account. Depending on where you
         live you may have additional rights (access, correction, erasure, portability,
-        objection); we honor these regardless of location — email
+        objection); we honor these regardless of location. Email
         <a href={"mailto:#{@legal.contact_email}"} class="underline">{@legal.contact_email}</a>
         and we will respond within 30 days.
       </p>

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/self_hosted.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/self_hosted.html.heex
@@ -7,7 +7,7 @@
     Define your agents once. Let every app you build hire them.
   </h1>
   <p class="text-lg sm:text-xl text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-4">
-    An agent is a row you write once. The model, the skills, the MCP servers, the repository it wakes up in, the secrets it may use. After that anything you build hires it over one API, and it arrives on a machine {Fountain.Brand.engine()} builds, warms and reclaims.
+    An agent is a row you write once. The model, the skills, the MCP servers, the repository it wakes up in, the secrets it may use. After that anything you build hires it over one API. It arrives on a machine {Fountain.Brand.engine()} builds, warms and takes back.
     <span :if={Fountain.Brand.hosted?()}>
       {Fountain.Brand.name()} is one instance of that platform, the one we happen to run.
     </span>
@@ -17,7 +17,7 @@
     Yours answers the same API in six commands.
   </p>
   <p class="text-lg sm:text-xl font-medium text-[var(--color-text-primary)] max-w-2xl mx-auto mb-10">
-    Run it yourself and the whole platform is yours. Your roster, your machines, your keys, and the features we ration on this site are a line of config on yours.
+    Run it yourself and the whole platform is yours. Your roster runs on your machines with your keys, and the features we ration on this site are a line of config on yours.
   </p>
   <div class="flex flex-col sm:flex-row gap-3 justify-center mb-4">
     <a

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/terms.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/terms.html.heex
@@ -8,7 +8,7 @@
     <div>
       <h2 class="text-lg font-semibold text-[var(--color-text-primary)] mb-2">1. Agreement</h2>
       <p>
-        These Terms of Service ("Terms") are an agreement between you and {@legal.entity} ("{Fountain.Brand.name()}", "we", "us") governing your use of the {Fountain.Brand.name()} service — the web
+        These Terms of Service ("Terms") are an agreement between you and {@legal.entity} ("{Fountain.Brand.name()}", "we", "us") governing your use of the {Fountain.Brand.name()} service: the web
         application, API, and command-line tools available through this site (the "Service").
         By creating an account or using the Service you agree to these Terms. If you are using
         the Service on behalf of an organization, you represent that you have authority to bind
@@ -94,7 +94,7 @@
     <div>
       <h2 class="text-lg font-semibold text-[var(--color-text-primary)] mb-2">6. Your content</h2>
       <p class="mb-2">
-        You retain all rights to the content you bring to the Service — agent configurations,
+        You retain all rights to the content you bring to the Service: agent configurations,
         environment variables, secrets, prompts, and the output of your conversations ("Customer
         Content"). You grant us the limited rights needed to operate the Service: to store,
         encrypt, transmit, and process Customer Content on your behalf, including passing it to
@@ -112,7 +112,7 @@
       <p>
         Agent conversations produce output from third-party AI models. AI output can be wrong,
         incomplete, or unsuitable for your purpose, and the same prompt can produce different
-        results. You are responsible for reviewing output before relying on it — including any
+        results. You are responsible for reviewing output before relying on it, including any
         code an agent writes or actions an agent takes against systems you connect it to.
       </p>
     </div>
@@ -122,7 +122,7 @@
         8. Third-party services
       </h2>
       <p>
-        The Service depends on third parties — payment processing (Stripe), transactional email,
+        The Service depends on third parties: payment processing (Stripe), transactional email,
         sandbox infrastructure, and the model providers you configure. Their services are
         governed by their own terms, and we are not responsible for their acts or omissions,
         though we choose and monitor them with reasonable care.

--- a/apps/fountain/test/fountain_web/brand_chrome_test.exs
+++ b/apps/fountain/test/fountain_web/brand_chrome_test.exs
@@ -40,12 +40,12 @@ defmodule FountainWeb.BrandChromeTest do
 
   test "the marketing page and legal pages name the brand; the CLI stays fountain", %{conn: conn} do
     home = conn |> get(~p"/") |> html_response(200)
-    assert home =~ "Managoat runs Claude Code, Codex, Gemini or OpenCode on a cloud sandbox"
+    assert home =~ "Every agent gets a brief, a budget, and a boundary."
     assert home =~ "Managoat scrubs them from every line of output"
     assert home =~ ">fountain</code> CLI"
     assert home =~ "© 2026 Managoat."
     assert home =~ ~s(data-role="hosted-enterprise")
-    assert home =~ "Managoat is the hosted enterprise edition of Fountain"
+    assert home =~ "Managoat is the hosted Fountain. The engine is open source"
     assert home =~ "The hosted enterprise edition of Fountain, which is open source."
 
     for path <- [~p"/terms", ~p"/privacy"] do

--- a/apps/fountain/test/fountain_web/brand_chrome_test.exs
+++ b/apps/fountain/test/fountain_web/brand_chrome_test.exs
@@ -44,9 +44,9 @@ defmodule FountainWeb.BrandChromeTest do
     assert home =~ "Managoat scrubs them from every line of output"
     assert home =~ ">fountain</code> CLI"
     assert home =~ "© 2026 Managoat."
-    assert home =~ ~s(data-role="hosted-enterprise")
+    assert home =~ ~s(data-role="hosted-brand")
     assert home =~ "Managoat is the hosted Fountain. The engine is open source"
-    assert home =~ "The hosted enterprise edition of Fountain, which is open source."
+    assert home =~ "It runs Fountain, which is open source."
 
     for path <- [~p"/terms", ~p"/privacy"] do
       html = conn |> get(path) |> html_response(200)
@@ -61,7 +61,7 @@ defmodule FountainWeb.BrandChromeTest do
     Application.delete_env(:fountain, :product_name)
     home = conn |> get(~p"/") |> html_response(200)
     assert home =~ "© 2026 Fountain."
-    refute home =~ "hosted enterprise edition"
+    refute home =~ "It runs Fountain, which is open source."
   end
 
   test "without the brand the docs show no note", %{conn: conn} do

--- a/apps/fountain/test/fountain_web/brand_chrome_test.exs
+++ b/apps/fountain/test/fountain_web/brand_chrome_test.exs
@@ -42,7 +42,9 @@ defmodule FountainWeb.BrandChromeTest do
     home = conn |> get(~p"/") |> html_response(200)
     assert home =~ "Every agent gets a brief, a budget, and a boundary."
     assert home =~ "Managoat scrubs them from every line of output"
-    assert home =~ ">fountain</code> CLI"
+    # The CLI keeps the engine's name on a branded deployment. The anchor moved
+    # to the protocols section when the surfaces card was replaced.
+    assert home =~ ">fountain acp</code>"
     assert home =~ "© 2026 Managoat."
     assert home =~ ~s(data-role="hosted-brand")
     assert home =~ "Managoat is the hosted Fountain. The engine is open source"

--- a/apps/fountain/test/fountain_web/controllers/marketing_instance_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_instance_test.exs
@@ -28,7 +28,7 @@ defmodule FountainWeb.MarketingInstanceTest do
       assert body =~ ~p"/auth/login"
       assert body =~ "/docs"
 
-      refute body =~ "Give your app a coding agent. Skip the machine it needs."
+      refute body =~ "Every agent gets a brief, a budget, and a boundary."
       refute body =~ "What you stop building."
       refute body =~ "14-day trial"
       refute body =~ "Managed agent infrastructure"
@@ -115,7 +115,7 @@ defmodule FountainWeb.MarketingInstanceTest do
       Application.put_env(:fountain, :marketing_site, true)
 
       body = conn |> get(~p"/") |> html_response(200)
-      assert body =~ "Give your app a coding agent. Skip the machine it needs."
+      assert body =~ "Every agent gets a brief, a budget, and a boundary."
       assert body =~ "Managed agent infrastructure"
       refute body =~ "This instance runs agents on sandboxes"
     end

--- a/apps/fountain/test/fountain_web/controllers/marketing_pricing_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_pricing_test.exs
@@ -32,7 +32,9 @@ defmodule FountainWeb.MarketingPricingTest do
     assert body =~ "agents at once, at most"
     assert body =~ "One more for every $2.00 you hold, from 2"
     assert body =~ "Start with $5.00 free"
-    refute body =~ "/mo"
+    # A monthly price renders as a number attached to "/mo". The bare string
+    # would now match GET /v1/models in the protocols section.
+    refute body =~ ~r"\$[\d,.]+\s*/\s*mo"
   end
 
   # Scale-to-zero (0017) is the strongest claim the rest of the page makes. A

--- a/docs/reference/feature-status.md
+++ b/docs/reference/feature-status.md
@@ -1,8 +1,8 @@
 # Feature status
 
 Most of Fountain is on for every account. Three features are not. This page
-lists them, says who has them on the hosted platform, and says how to get
-them.
+lists them. Each row says who has the feature on the hosted platform, and
+how to turn it on.
 
 A note with the same title as the row sits at the top of each page that
 describes one of these features.


### PR DESCRIPTION
The homepage sold one reader, the developer embedding an agent in their own product. The orchestration Fountain already ships (`create-team`, teammate-to-teammate messaging, the fan-out skill, allowlists, `agent_versions`) was on none of it. This rebuilds `/` to run lane by lane, and cleans the pages the same pass touched.

8 commits, readable in order.

## Homepage

- New hero: "Every agent gets a brief, a budget, and a boundary." Every noun points at something shipped.
- Dropped "the hosted enterprise edition of Fountain" from the eyebrow and the footer. There is no edition (ADR 0027, 0034).
- Added "Close the laptop. The work is still there." Persistence, memory, cron. CTA: hire your first teammate.
- Added "Agents that cooperate contractually." The roster, delegation, fan-out, and the allowlist plus version plus provenance trail. CTA: build a roster.
- Added "Bring the stack you already have." Four protocols, the page's first badge, and the badge legend.
- Added "The limits, before you build on them." Concurrency, no recursion cap, not a shared inbox, one account is one person. Sits before the price.
- Added "Give one a phone number." Alpha, badged, placed deep so the ask-us gate reads as a bonus.
- Added "Or run the whole thing yourself." Sorts on whether data can leave, and concedes a runner has no isolation.
- Rewrote the two middle sections that still addressed the embedder, and replaced the surfaces card (it duplicated the new protocols section, link and all) with the audit trail.
- Added an objection for the reader who pays for Claude and holds no API key.
- Fixed a structural bug from this branch's first commit: the Problem section's closing tag had drifted past two sections, nesting them inside it.

## Other pages

- `/terms` and `/privacy`: em dashes removed, punctuation only. No word added, removed or moved. Word multiset unchanged, one capital where a sentence now begins. These carry legal effect, so a rewrite wants sign-off.
- `/self-hosted`: six sentences of rhetorical rhythm removed, including one answer stacking two tricolons.
- `docs/reference/feature-status.md`: intro opens with a claim instead of three verbs.

## Notes

- No feature flags touched. `team_comms` and `openai_compat` still resolve per user through PostHog, and anyone who needs an alpha flipped still asks. Both badged sections say so next to the name.
- 4086 tests, 0 failures. Format clean, compile clean under `--warnings-as-errors`, `scripts/docs-style.py` clean.
- 6 assertions moved because they pinned replaced copy. One real catch: `marketing_pricing_test` refuted a bare `"/mo"` to guard ADR 0031, and `GET /v1/models` contains `/mo`. The assertion now matches an actual price pattern.
- Running the suite locally on a high-core box exceeds the DB pool of 20 and produces several hundred spurious failures. `mix test --max-cases 10` is green.

## Copy scores

Stink per 1000 words, via [lex00/sentences](https://github.com/lex00/sentences).

| | before | after |
|---|---|---|
| `/` | 27.2 | 13.2 |
| `/self-hosted` | 31.3 | 27.3 |
| `/terms` | 42.3 | 38.6 |
| `/privacy` | 89.8 | 64.2 |

Sections written from scratch here score 2.9. Left deliberately: the headline tricolon, "agent" recurring, and comma series that enumerate real things. A prose linter also reads a FAQ as self-posed questions and a table as near-duplicate text, so the remaining `/self-hosted` score is mostly structure.

## Not in here

Prod sets `CREDITS_ENABLED=true` with no `LEGAL_ENTITY`, so `/terms` and `/privacy` render `{{COMPANY_LEGAL_NAME}}` placeholders. TODO #500 in the home-cloud overlay, a config change rather than code.
