### PR TITLE
fix(test): the caller-tool stage row is read after the server has written it

### DIFF
--- a/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
@@ -1251,7 +1251,14 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
       insert_conversation(user_id: user.id, agent: acp_agent(user), caller_tools: @caller_tools)
     end
 
-    defp caller_stages(conv_id, state) do
+    # `resolve_caller_tool/4` answers the waiter first and writes the stage row
+    # second, so a result message in hand does not mean the row has landed —
+    # the timeout and turn-ended paths resolve from a handler nobody waits on.
+    # One call through the server's mailbox is the barrier: it is served only
+    # after the handler that sent that message has returned.
+    defp caller_stages(pid, conv_id, state) do
+      _ = :sys.get_state(pid)
+
       conv_id
       |> Conversations._unsafe_list_log_events()
       |> Enum.filter(&(&1.kind == "stage" and &1.stage == "caller_tool" and &1.state == state))
@@ -1289,7 +1296,7 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
                GenServer.call(pid, {:park_caller_tool, "lookup_order", %{"id" => "A-17"}, self()})
 
       assert [%{"call_id" => ^id, "name" => "lookup_order", "arguments" => %{"id" => "A-17"}}] =
-               caller_stages(conv.id, "started")
+               caller_stages(pid, conv.id, "started")
 
       assert [%{id: ^id, name: "lookup_order"}] = GenServer.call(pid, :pending_caller_calls)
       assert :pending = GenServer.call(pid, {:await_caller_tool, id, self()})
@@ -1300,7 +1307,7 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
       assert turn_id == :sys.get_state(pid).current_turn.id
       assert_receive {:caller_tool_result, ^id, {:ok, "shipped"}}
 
-      assert [%{"call_id" => ^id, "outcome" => "answered"}] = caller_stages(conv.id, "done")
+      assert [%{"call_id" => ^id, "outcome" => "answered"}] = caller_stages(pid, conv.id, "done")
       assert [] = GenServer.call(pid, :pending_caller_calls)
 
       # Kept for a waiter that asks after the fact.
@@ -1331,7 +1338,7 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
       {:ok, id} = GenServer.call(pid, {:park_caller_tool, "lookup_order", %{}, self()})
       assert_receive {:caller_tool_result, ^id, {:error, reason}}, 3_000
       assert reason =~ "did not answer"
-      assert [%{"call_id" => ^id, "outcome" => "timeout"}] = caller_stages(conv.id, "done")
+      assert [%{"call_id" => ^id, "outcome" => "timeout"}] = caller_stages(pid, conv.id, "done")
 
       # The turn is still running: the agent carries on.
       assert :sys.get_state(pid).current_turn.status == "running"
@@ -1347,7 +1354,10 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
       reply(pid, ref, prompt_id, %{"stopReason" => "end_turn"})
 
       assert_receive {:caller_tool_result, ^id, {:error, _}}
-      assert [%{"call_id" => ^id, "outcome" => "turn_ended"}] = caller_stages(conv.id, "done")
+
+      assert [%{"call_id" => ^id, "outcome" => "turn_ended"}] =
+               caller_stages(pid, conv.id, "done")
+
       assert :sys.get_state(pid).caller_calls == %{}
     end
 


### PR DESCRIPTION
## What broke

The post-merge CI run on `cd2745fa` (#1222) went red in partition 6, so `build` and `publish-manifests` were skipped and prod is still on `sha-6fe54f28`. The PR's own run was green — this is the merge-order lottery, not the marketing copy.

```
1) test the tool bridge (#1202) the deadline resolves a call the caller never answered
   test/fountain/conversations/conversation_server_acp_test.exs:1334
   code:  assert [%{"call_id" => ^id, "outcome" => "timeout"}] = caller_stages(conv.id, "done")
   right: []
```

## Why

`resolve_caller_tool/4` sends `{:caller_tool_result, id, result}` to the waiter, *then* calls `publish_stage(... "done" ...)`, which is what inserts the log row. The `answered` path is safe because the test's `answer_caller_tools` is a `GenServer.call` that returns after the write. The **timeout** path resolves from a `handle_info` nobody waits on, so `assert_receive` returns inside that handler and the next line reads the log before the row exists. Under CI load the window loses.

The ordering in the server is deliberate — the caller gets its answer without waiting on a write — so the test is what changes.

## The fix

`caller_stages/3` takes the server pid and calls `:sys.get_state/1` before reading. That call is served only after the handler that sent the result has returned, so the row has landed. It is a barrier, not a sleep, and it is harmless on the paths that were already synchronous.

## Verification

Held the write for 200ms between the `send` and `publish_stage/4` in `resolve_caller_tool/4`:

- without the barrier: `51 tests, 1 failure` — the same assertion, same message
- with the barrier: `51 tests, 0 failures`

The delay was then reverted; this PR touches no product code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)