### PR TITLE
refactor(runner): what a sandbox is made of becomes a Backend

### DIFF
--- a/cli/internal/runner/backend.go
+++ b/cli/internal/runner/backend.go
@@ -1,0 +1,87 @@
+package runner
+
+// Backend is what a sandbox is made of on this machine.
+//
+// The daemon owns the wire — it frames requests, routes them, and renders
+// replies — and a Backend owns the substance: what `create` brings into
+// being, where a command runs, and what a session's output is journaled
+// into. `fountain runner` ships one (Process, a directory and local
+// processes, ADR 0022); a microVM backend is the reason this seam exists.
+//
+// Every method returns the same triple as Daemon.Handle: the reply's
+// result, an optional `after` to run once the reply has been written, and
+// an error. Errors must be *OpError with one of the contract's codes
+// (notFound, invalid, unavailable, …); anything else reaches Fountain as
+// `provider`, which the taxonomy classifies transient.
+//
+// The obligations below are Fountain's, not Go's — no compiler checks them
+// and getting one wrong is how a sandbox holding an agent's memory gets
+// destroyed. `Fountain.Sandbox`'s moduledoc is the normative statement and
+// `Fountain.SandboxConformanceCase` is its executable form; this is the
+// same contract, said once more on the side that has to honour it.
+type Backend interface {
+	// Create brings a sandbox into being, or adopts the one already there.
+	// Idempotent by contract: Fountain retries a create whose reply it lost,
+	// and a second create must never discard the first one's disk.
+	Create(req Request) (map[string]any, func(), error)
+
+	// Get reports {"status": "running"|"suspended"}. It must answer
+	// not_found only for a sandbox that definitively is not there, and
+	// unavailable for everything transient — Fountain gives up a parked
+	// disk on not_found, so a flaky answer here loses the agent's memory.
+	Get(req Request) (map[string]any, func(), error)
+
+	// Destroy removes the sandbox and stops whatever it was running.
+	// Already-gone is success.
+	Destroy(req Request) (map[string]any, func(), error)
+
+	// List names every sandbox this backend holds, or refuses. Fountain's
+	// reaper deletes against this view, so a partial list that looks whole
+	// is the worst shape of wrong available here.
+	List() (map[string]any, func(), error)
+
+	// Suspend parks the sandbox: stop what runs, keep the disk. Resume
+	// wakes it with the same disk — a resume onto a fresh one is data loss,
+	// not a degradation.
+	Suspend(req Request) (map[string]any, func(), error)
+	Resume(req Request) (map[string]any, func(), error)
+
+	// WriteFile writes req.Data (base64) to req.Path, creating parents. A
+	// requested mode is a promise, not a hint.
+	WriteFile(req Request) (map[string]any, func(), error)
+
+	// Exec runs a command to completion and returns {"output", "code"}. It
+	// never reports failure as an error: a command that exits nonzero, that
+	// times out, or that could not start at all is a readable exit code.
+	// An error means the sandbox was unreachable.
+	Exec(req Request) (map[string]any, func(), error)
+
+	// Spawn starts a streaming command and returns {"session_id"}. Its
+	// `after` attaches the requester, which replays the session's journal
+	// from byte zero tagged `replay_for` — never before the reply is on the
+	// wire. Exactly one terminal frame per session, and it carries the
+	// command's real exit code: a stream that ends without one is read by
+	// Fountain as exit 0, which turns a failure into a success.
+	Spawn(req Request, emit Emitter) (map[string]any, func(), error)
+
+	// Stdin writes to a live session. Total: a write to a session that has
+	// already exited is command_exited, never a crash and never a hang.
+	Stdin(req Request) (map[string]any, func(), error)
+	StdinClose(req Request) (map[string]any, func(), error)
+
+	// Detach stops emitting a session's frames without stopping the
+	// session. Detaching from something already gone is success.
+	Detach(req Request) (map[string]any, func(), error)
+
+	// ListSessions describes the sandbox's sessions, newest first — a
+	// reattach after a Fountain deploy takes the first one.
+	ListSessions(req Request) (map[string]any, func(), error)
+
+	// Attach re-joins a session; like Spawn, the replay is in `after`.
+	Attach(req Request, emit Emitter) (map[string]any, func(), error)
+
+	// StopAll terminates every live session. The daemon calls it on the way
+	// down: sessions belong to this process, and saying so beats leaving
+	// orphans writing into a closed pipe.
+	StopAll()
+}

--- a/cli/internal/runner/backend_test.go
+++ b/cli/internal/runner/backend_test.go
@@ -1,0 +1,146 @@
+package runner
+
+import (
+	"errors"
+	"log/slog"
+	"os"
+	"testing"
+)
+
+// recordingBackend answers every op by naming itself, so the routing can be
+// checked without a filesystem.
+type recordingBackend struct {
+	calls    []string
+	gotEmit  Emitter
+	stopped  bool
+	lastName string
+}
+
+func (b *recordingBackend) note(op string, req Request) (map[string]any, func(), error) {
+	b.calls = append(b.calls, op)
+	b.lastName = req.Name
+	return map[string]any{"called": op}, nil, nil
+}
+
+func (b *recordingBackend) Create(req Request) (map[string]any, func(), error) {
+	return b.note("Create", req)
+}
+func (b *recordingBackend) Get(req Request) (map[string]any, func(), error) {
+	return b.note("Get", req)
+}
+func (b *recordingBackend) Destroy(req Request) (map[string]any, func(), error) {
+	return b.note("Destroy", req)
+}
+func (b *recordingBackend) List() (map[string]any, func(), error) {
+	return b.note("List", Request{})
+}
+func (b *recordingBackend) Suspend(req Request) (map[string]any, func(), error) {
+	return b.note("Suspend", req)
+}
+func (b *recordingBackend) Resume(req Request) (map[string]any, func(), error) {
+	return b.note("Resume", req)
+}
+func (b *recordingBackend) WriteFile(req Request) (map[string]any, func(), error) {
+	return b.note("WriteFile", req)
+}
+func (b *recordingBackend) Exec(req Request) (map[string]any, func(), error) {
+	return b.note("Exec", req)
+}
+func (b *recordingBackend) Spawn(req Request, emit Emitter) (map[string]any, func(), error) {
+	b.gotEmit = emit
+	return b.note("Spawn", req)
+}
+func (b *recordingBackend) Stdin(req Request) (map[string]any, func(), error) {
+	return b.note("Stdin", req)
+}
+func (b *recordingBackend) StdinClose(req Request) (map[string]any, func(), error) {
+	return b.note("StdinClose", req)
+}
+func (b *recordingBackend) Detach(req Request) (map[string]any, func(), error) {
+	return b.note("Detach", req)
+}
+func (b *recordingBackend) ListSessions(req Request) (map[string]any, func(), error) {
+	return b.note("ListSessions", req)
+}
+func (b *recordingBackend) Attach(req Request, emit Emitter) (map[string]any, func(), error) {
+	b.gotEmit = emit
+	return b.note("Attach", req)
+}
+func (b *recordingBackend) StopAll() { b.stopped = true }
+
+// Every op in the wire protocol reaches exactly one Backend method. The
+// table is the protocol: an op added to Fountain.Runners.Connection without
+// a case here answers not_supported, which is why the default is tested too.
+func TestHandleRoutesEveryOpToTheBackend(t *testing.T) {
+	ops := []struct{ op, method string }{
+		{"create", "Create"},
+		{"get", "Get"},
+		{"destroy", "Destroy"},
+		{"list", "List"},
+		{"suspend", "Suspend"},
+		{"resume", "Resume"},
+		{"write_file", "WriteFile"},
+		{"exec", "Exec"},
+		{"spawn", "Spawn"},
+		{"stdin", "Stdin"},
+		{"stdin_close", "StdinClose"},
+		{"detach", "Detach"},
+		{"list_sessions", "ListSessions"},
+		{"attach", "Attach"},
+	}
+	for _, tc := range ops {
+		b := &recordingBackend{}
+		d := NewWithBackend(b, slog.New(slog.NewTextHandler(os.Stderr, nil)))
+		rec := newRecorder()
+		result, _, err := d.Handle(Request{Op: tc.op, Name: "runner-x-1"}, rec)
+		if err != nil {
+			t.Fatalf("%s: %v", tc.op, err)
+		}
+		if len(b.calls) != 1 || b.calls[0] != tc.method {
+			t.Fatalf("op %q called %v, want [%s]", tc.op, b.calls, tc.method)
+		}
+		if result["called"] != tc.method {
+			t.Fatalf("op %q returned %v", tc.op, result)
+		}
+	}
+}
+
+// spawn and attach are the two ops that stream, so they are the two that
+// must be handed the emitter the reply is going out on.
+func TestStreamingOpsReceiveTheEmitter(t *testing.T) {
+	for _, op := range []string{"spawn", "attach"} {
+		b := &recordingBackend{}
+		d := NewWithBackend(b, slog.New(slog.NewTextHandler(os.Stderr, nil)))
+		rec := newRecorder()
+		if _, _, err := d.Handle(Request{Op: op, Name: "runner-x-1"}, rec); err != nil {
+			t.Fatal(err)
+		}
+		if b.gotEmit != Emitter(rec) {
+			t.Fatalf("%s did not receive the request's emitter", op)
+		}
+	}
+}
+
+func TestUnknownOpIsNotSupported(t *testing.T) {
+	b := &recordingBackend{}
+	d := NewWithBackend(b, slog.New(slog.NewTextHandler(os.Stderr, nil)))
+	_, _, err := d.Handle(Request{Op: "teleport"}, newRecorder())
+	var op *OpError
+	if err == nil {
+		t.Fatal("want an error")
+	}
+	if !errors.As(err, &op) || op.Code != "not_supported" {
+		t.Fatalf("err = %v", err)
+	}
+	if len(b.calls) != 0 {
+		t.Fatalf("backend was called: %v", b.calls)
+	}
+}
+
+func TestStopAllReachesTheBackend(t *testing.T) {
+	b := &recordingBackend{}
+	NewWithBackend(b, slog.New(slog.NewTextHandler(os.Stderr, nil))).StopAll()
+	if !b.stopped {
+		t.Fatal("StopAll did not reach the backend")
+	}
+}

--- a/cli/internal/runner/daemon.go
+++ b/cli/internal/runner/daemon.go
@@ -3,10 +3,10 @@
 //
 // The daemon dials Fountain, holds the socket, and answers JSON requests —
 // create/get/destroy a sandbox, write a file, run a command, spawn a
-// streaming one and pump its output back, re-attach with replay — against a
-// root directory on the local disk. A sandbox is a directory; commands run
-// as the daemon's user with HOME pointed at that directory. There is no
-// isolation beyond that, on purpose and documented: this is trusted mode.
+// streaming one and pump its output back, re-attach with replay. What a
+// sandbox *is* belongs to a Backend: `Process` makes it a directory on this
+// machine and its commands local processes, with no isolation beyond that,
+// on purpose and documented — this is trusted mode.
 //
 // The wire protocol is the one Fountain.Runners.Connection speaks (and the
 // one Fountain.Runners.FakeDaemon executes in Fountain's own test suite):
@@ -21,30 +21,9 @@
 package runner
 
 import (
-	"context"
-	"encoding/base64"
 	"encoding/json"
 	"errors"
-	"fmt"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"sort"
-	"strings"
-	"sync"
-	"time"
 )
-
-// spriteHome is the home directory every Fountain provisioning script and
-// runtime assumes (the Sprites base image; the E2B/Daytona images recreate
-// it). The daemon maps it to the sandbox directory in file paths, working
-// directories, and command arguments, so those scripts land inside the
-// sandbox without a Linux user of that name existing on this machine.
-const spriteHome = "/home/sprite"
-
-// suspendedMarker sits in a sandbox directory while it is parked: suspend
-// stops its processes and leaves the marker, resume removes it.
-const suspendedMarker = ".fountain-suspended"
 
 // Request is one frame from Fountain.
 type Request struct {
@@ -90,17 +69,6 @@ type Emitter interface {
 	Emit(Frame)
 }
 
-// Daemon owns the sandbox root and the live sessions.
-type Daemon struct {
-	Root     string
-	RealHome string
-	Log      Logger
-
-	mu       sync.Mutex
-	sessions map[string]*Session // by session id
-	seq      int
-}
-
 // Logger is the slice of *slog.Logger the daemon uses.
 type Logger interface {
 	Info(msg string, args ...any)
@@ -108,13 +76,24 @@ type Logger interface {
 	Debug(msg string, args ...any)
 }
 
-// New builds a daemon over root, creating it if needed.
+// Daemon routes requests to a Backend.
+type Daemon struct {
+	Backend Backend
+	Log     Logger
+}
+
+// New builds a daemon over the process backend, rooted at root.
 func New(root string, log Logger) (*Daemon, error) {
-	if err := os.MkdirAll(root, 0o700); err != nil {
-		return nil, fmt.Errorf("create sandbox root %s: %w", root, err)
+	p, err := NewProcess(root, log)
+	if err != nil {
+		return nil, err
 	}
-	home, _ := os.UserHomeDir()
-	return &Daemon{Root: root, RealHome: home, Log: log, sessions: map[string]*Session{}}, nil
+	return NewWithBackend(p, log), nil
+}
+
+// NewWithBackend builds a daemon over any backend.
+func NewWithBackend(b Backend, log Logger) *Daemon {
+	return &Daemon{Backend: b, Log: log}
 }
 
 // Handle answers one request. It returns the reply's result and, for spawn
@@ -123,492 +102,40 @@ func New(root string, log Logger) (*Daemon, error) {
 func (d *Daemon) Handle(req Request, emit Emitter) (result map[string]any, after func(), err error) {
 	switch req.Op {
 	case "create":
-		return d.create(req)
+		return d.Backend.Create(req)
 	case "get":
-		return d.get(req)
+		return d.Backend.Get(req)
 	case "destroy":
-		return d.destroy(req)
+		return d.Backend.Destroy(req)
 	case "list":
-		return d.list()
+		return d.Backend.List()
 	case "suspend":
-		return d.suspend(req)
+		return d.Backend.Suspend(req)
 	case "resume":
-		return d.resume(req)
+		return d.Backend.Resume(req)
 	case "write_file":
-		return d.writeFile(req)
+		return d.Backend.WriteFile(req)
 	case "exec":
-		return d.exec(req)
+		return d.Backend.Exec(req)
 	case "spawn":
-		return d.spawn(req, emit)
+		return d.Backend.Spawn(req, emit)
 	case "stdin":
-		return d.stdin(req)
+		return d.Backend.Stdin(req)
 	case "stdin_close":
-		return d.stdinClose(req)
+		return d.Backend.StdinClose(req)
 	case "detach":
-		return d.detach(req)
+		return d.Backend.Detach(req)
 	case "list_sessions":
-		return d.listSessions(req)
+		return d.Backend.ListSessions(req)
 	case "attach":
-		return d.attach(req, emit)
+		return d.Backend.Attach(req, emit)
 	default:
 		return nil, nil, notSupported(req.Op)
 	}
 }
 
-// ── sandboxes ────────────────────────────────────────────────────────────────
-
-func (d *Daemon) dir(name string) (string, error) {
-	if name == "" || strings.ContainsAny(name, "/\\") || name == "." || name == ".." ||
-		strings.HasPrefix(name, ".") {
-		return "", invalid("bad sandbox name")
-	}
-	return filepath.Join(d.Root, name), nil
-}
-
-// existingDir is dir plus a presence check.
-func (d *Daemon) existingDir(name string) (string, error) {
-	dir, err := d.dir(name)
-	if err != nil {
-		return "", err
-	}
-	if st, err := os.Stat(dir); err != nil || !st.IsDir() {
-		return "", notFound("no sandbox " + name)
-	}
-	return dir, nil
-}
-
-func (d *Daemon) create(req Request) (map[string]any, func(), error) {
-	dir, err := d.dir(req.Name)
-	if err != nil {
-		return nil, nil, err
-	}
-	// Idempotent-adopting: an existing directory is the same sandbox.
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return nil, nil, unavailable(err.Error())
-	}
-	return map[string]any{}, nil, nil
-}
-
-func (d *Daemon) get(req Request) (map[string]any, func(), error) {
-	dir, err := d.existingDir(req.Name)
-	if err != nil {
-		return nil, nil, err
-	}
-	status := "running"
-	if _, err := os.Stat(filepath.Join(dir, suspendedMarker)); err == nil {
-		status = "suspended"
-	}
-	return map[string]any{"status": status, "path": dir}, nil, nil
-}
-
-func (d *Daemon) destroy(req Request) (map[string]any, func(), error) {
-	dir, err := d.dir(req.Name)
-	if err != nil {
-		return nil, nil, err
-	}
-	d.stopSessions(req.Name)
-	d.mu.Lock()
-	for id, s := range d.sessions {
-		if s.sandbox == req.Name {
-			delete(d.sessions, id)
-		}
-	}
-	d.mu.Unlock()
-	// Already gone is ok.
-	if err := os.RemoveAll(dir); err != nil {
-		return nil, nil, unavailable(err.Error())
-	}
-	return map[string]any{}, nil, nil
-}
-
-func (d *Daemon) list() (map[string]any, func(), error) {
-	entries, err := os.ReadDir(d.Root)
-	if err != nil {
-		return nil, nil, unavailable(err.Error())
-	}
-	names := []string{}
-	for _, e := range entries {
-		if e.IsDir() && !strings.HasPrefix(e.Name(), ".") {
-			names = append(names, e.Name())
-		}
-	}
-	sort.Strings(names)
-	return map[string]any{"names": names}, nil, nil
-}
-
-func (d *Daemon) suspend(req Request) (map[string]any, func(), error) {
-	dir, err := d.existingDir(req.Name)
-	if err != nil {
-		return nil, nil, err
-	}
-	// Parking = stop what is running, keep the disk. Nothing else costs
-	// anything on a machine that stays up.
-	d.stopSessions(req.Name)
-	if err := os.WriteFile(filepath.Join(dir, suspendedMarker), nil, 0o600); err != nil {
-		return nil, nil, unavailable(err.Error())
-	}
-	return map[string]any{}, nil, nil
-}
-
-func (d *Daemon) resume(req Request) (map[string]any, func(), error) {
-	dir, err := d.existingDir(req.Name)
-	if err != nil {
-		return nil, nil, err
-	}
-	_ = os.Remove(filepath.Join(dir, suspendedMarker))
-	return map[string]any{}, nil, nil
-}
-
-// ── files ────────────────────────────────────────────────────────────────────
-
-// mapPath resolves a path Fountain names into the sandbox: `/home/sprite/…`
-// and relative paths land inside the sandbox directory; other absolute paths
-// are the host's (trusted mode — /tmp is /tmp).
-func mapPath(dir, p string) string {
-	switch {
-	case p == spriteHome:
-		return dir
-	case strings.HasPrefix(p, spriteHome+"/"):
-		return filepath.Join(dir, strings.TrimPrefix(p, spriteHome+"/"))
-	case p == "~":
-		return dir
-	case strings.HasPrefix(p, "~/"):
-		return filepath.Join(dir, p[2:])
-	case filepath.IsAbs(p):
-		return p
-	case p == "":
-		return dir
-	default:
-		return filepath.Join(dir, p)
-	}
-}
-
-// mapArg rewrites the literal /home/sprite wherever it appears in a command
-// or argument, so `bin=/home/sprite/.local/bin/x` in a `bash -lc` script
-// resolves inside the sandbox too.
-func mapArg(dir, arg string) string {
-	return strings.ReplaceAll(arg, spriteHome, dir)
-}
-
-func (d *Daemon) writeFile(req Request) (map[string]any, func(), error) {
-	dir, err := d.existingDir(req.Name)
-	if err != nil {
-		return nil, nil, err
-	}
-	data, err := base64.StdEncoding.DecodeString(req.Data)
-	if err != nil {
-		return nil, nil, invalid("data is not base64")
-	}
-	target := mapPath(dir, req.Path)
-	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
-		return nil, nil, writeFailed(err.Error())
-	}
-	mode := os.FileMode(0o644)
-	if req.Mode != nil {
-		mode = os.FileMode(*req.Mode)
-	}
-	if err := os.WriteFile(target, data, mode); err != nil {
-		return nil, nil, writeFailed(err.Error())
-	}
-	// WriteFile's mode is subject to umask; a requested mode is a promise.
-	if req.Mode != nil {
-		_ = os.Chmod(target, mode)
-	}
-	return map[string]any{}, nil, nil
-}
-
-// ── commands ─────────────────────────────────────────────────────────────────
-
-// command builds the exec.Cmd for a request inside a sandbox: HOME is the
-// sandbox, PATH gains the sandbox's own bin dirs, npm installs globally into
-// the sandbox, and the request's env pairs win over all of it.
-func (d *Daemon) command(ctx context.Context, dir string, req Request) *exec.Cmd {
-	args := make([]string, len(req.Args))
-	for i, a := range req.Args {
-		args[i] = mapArg(dir, a)
-	}
-	env := d.env(dir, req.Env)
-	// os/exec resolves a bare command name against the *daemon's* PATH; the
-	// agent CLIs provisioning installs live on the sandbox's PATH
-	// (`<sandbox>/.local/bin`, `.npm-global/bin`), so resolve there.
-	cmd := exec.CommandContext(ctx, lookPath(mapArg(dir, req.Cmd), env), args...)
-	cmd.Dir = mapPath(dir, req.Dir)
-	if st, err := os.Stat(cmd.Dir); err != nil || !st.IsDir() {
-		cmd.Dir = dir
-	}
-	cmd.Env = env
-	return cmd
-}
-
-// lookPath resolves name against the PATH inside env (not the process's).
-// A name that resolves nowhere is returned unchanged so the failure reads
-// as "not found" when the command runs.
-func lookPath(name string, env []string) string {
-	if strings.Contains(name, "/") {
-		return name
-	}
-	for _, kv := range env {
-		if !strings.HasPrefix(kv, "PATH=") {
-			continue
-		}
-		for _, p := range filepath.SplitList(strings.TrimPrefix(kv, "PATH=")) {
-			if p == "" {
-				continue
-			}
-			candidate := filepath.Join(p, name)
-			if st, err := os.Stat(candidate); err == nil && !st.IsDir() && st.Mode()&0o111 != 0 {
-				return candidate
-			}
-		}
-		break
-	}
-	return name
-}
-
-func (d *Daemon) env(dir string, pairs [][]string) []string {
-	base := map[string]string{}
-	order := []string{}
-	set := func(k, v string) {
-		if _, ok := base[k]; !ok {
-			order = append(order, k)
-		}
-		base[k] = v
-	}
-	for _, kv := range os.Environ() {
-		if i := strings.IndexByte(kv, '='); i > 0 {
-			set(kv[:i], kv[i+1:])
-		}
-	}
-	sandboxBins := strings.Join([]string{
-		filepath.Join(dir, ".local", "bin"),
-		filepath.Join(dir, ".npm-global", "bin"),
-		filepath.Join(dir, ".bun", "bin"),
-	}, string(os.PathListSeparator))
-	extra := []string{}
-	for _, p := range []string{"/opt/homebrew/bin", "/usr/local/bin", filepath.Join(d.RealHome, ".local", "bin"), filepath.Join(d.RealHome, ".bun", "bin")} {
-		if st, err := os.Stat(p); err == nil && st.IsDir() && !strings.Contains(base["PATH"], p) {
-			extra = append(extra, p)
-		}
-	}
-	path := sandboxBins + string(os.PathListSeparator) + base["PATH"]
-	if len(extra) > 0 {
-		path += string(os.PathListSeparator) + strings.Join(extra, string(os.PathListSeparator))
-	}
-	set("PATH", path)
-	set("HOME", dir)
-	set("npm_config_prefix", filepath.Join(dir, ".npm-global"))
-	if _, ok := base["npm_config_cache"]; !ok && d.RealHome != "" {
-		set("npm_config_cache", filepath.Join(d.RealHome, ".npm"))
-	}
-	set("FOUNTAIN_SANDBOX_DIR", dir)
-	for _, kv := range pairs {
-		if len(kv) == 2 {
-			set(kv[0], kv[1])
-		}
-	}
-	out := make([]string, 0, len(order))
-	for _, k := range order {
-		out = append(out, k+"="+base[k])
-	}
-	return out
-}
-
-func (d *Daemon) exec(req Request) (map[string]any, func(), error) {
-	dir, err := d.existingDir(req.Name)
-	if err != nil {
-		return nil, nil, err
-	}
-	ctx := context.Background()
-	if req.TimeoutMS != nil && *req.TimeoutMS > 0 {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, time.Duration(*req.TimeoutMS)*time.Millisecond)
-		defer cancel()
-	}
-	cmd := d.command(ctx, dir, req)
-	var out []byte
-	var runErr error
-	if req.StderrToStdout {
-		out, runErr = cmd.CombinedOutput()
-	} else {
-		out, runErr = cmd.Output()
-	}
-	code := 0
-	if runErr != nil {
-		var exitErr *exec.ExitError
-		switch {
-		case errors.As(runErr, &exitErr):
-			code = exitErr.ExitCode()
-			if code < 0 {
-				code = 137 // killed (timeout)
-			}
-		case errors.Is(ctx.Err(), context.DeadlineExceeded):
-			code = 124
-			out = append(out, []byte("\nfountain runner: command timed out\n")...)
-		default:
-			// Could not start at all (not found, not executable): data, not a
-			// raise — the contract's "nonzero exit is readable".
-			code = 127
-			out = append(out, []byte(runErr.Error()+"\n")...)
-		}
-	}
-	return map[string]any{
-		"output": base64.StdEncoding.EncodeToString(out),
-		"code":   code,
-	}, nil, nil
-}
-
-// ── sessions ─────────────────────────────────────────────────────────────────
-
-func (d *Daemon) spawn(req Request, emit Emitter) (map[string]any, func(), error) {
-	dir, err := d.existingDir(req.Name)
-	if err != nil {
-		return nil, nil, err
-	}
-	d.mu.Lock()
-	d.seq++
-	id := fmt.Sprintf("s-%d-%d", time.Now().Unix(), d.seq)
-	d.mu.Unlock()
-
-	cmd := d.command(context.Background(), dir, req)
-	s, err := startSession(id, req.Name, cmd, req.Stdin, emit, d.Log)
-	if err != nil {
-		// Never a raise: a command that cannot start is a session that exited
-		// 127 with the reason on stdout, so the owner reads it like any other
-		// failed process.
-		s = failedSession(id, req.Name, req.Cmd, err, emit)
-	}
-	d.mu.Lock()
-	d.sessions[id] = s
-	d.pruneLocked(req.Name)
-	d.mu.Unlock()
-
-	reqID := req.ID
-	after := func() { s.attach(reqID) }
-	return map[string]any{"session_id": id}, after, nil
-}
-
-// pruneLocked bounds the finished sessions retained per sandbox for replay.
-func (d *Daemon) pruneLocked(sandbox string) {
-	const keep = 100
-	var finished []*Session
-	for _, s := range d.sessions {
-		if s.sandbox == sandbox && s.exited() {
-			finished = append(finished, s)
-		}
-	}
-	if len(finished) <= keep {
-		return
-	}
-	sort.Slice(finished, func(i, j int) bool { return finished[i].createdAt.Before(finished[j].createdAt) })
-	for _, s := range finished[:len(finished)-keep] {
-		delete(d.sessions, s.id)
-	}
-}
-
-func (d *Daemon) session(id string) (*Session, error) {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-	s, ok := d.sessions[id]
-	if !ok {
-		return nil, notFound("no session " + id)
-	}
-	return s, nil
-}
-
-func (d *Daemon) stdin(req Request) (map[string]any, func(), error) {
-	s, err := d.session(req.SessionID)
-	if err != nil {
-		return nil, nil, err
-	}
-	data, err := base64.StdEncoding.DecodeString(req.Data)
-	if err != nil {
-		return nil, nil, invalid("data is not base64")
-	}
-	if err := s.write(data); err != nil {
-		return nil, nil, err
-	}
-	return map[string]any{}, nil, nil
-}
-
-func (d *Daemon) stdinClose(req Request) (map[string]any, func(), error) {
-	s, err := d.session(req.SessionID)
-	if err != nil {
-		return nil, nil, err
-	}
-	s.closeStdin()
-	return map[string]any{}, nil, nil
-}
-
-func (d *Daemon) detach(req Request) (map[string]any, func(), error) {
-	s, err := d.session(req.SessionID)
-	if err != nil {
-		// Detaching from something that is gone is fine.
-		return map[string]any{}, nil, nil
-	}
-	s.detach()
-	return map[string]any{}, nil, nil
-}
-
-func (d *Daemon) listSessions(req Request) (map[string]any, func(), error) {
-	if _, err := d.existingDir(req.Name); err != nil {
-		return nil, nil, err
-	}
-	d.mu.Lock()
-	var list []*Session
-	for _, s := range d.sessions {
-		if s.sandbox == req.Name {
-			list = append(list, s)
-		}
-	}
-	d.mu.Unlock()
-	// Newest first: reattach takes the first session, and the turn in flight
-	// is the most recent spawn.
-	sort.Slice(list, func(i, j int) bool { return list[i].createdAt.After(list[j].createdAt) })
-	out := make([]map[string]any, 0, len(list))
-	for _, s := range list {
-		out = append(out, s.describe())
-	}
-	return map[string]any{"sessions": out}, nil, nil
-}
-
-func (d *Daemon) attach(req Request, emit Emitter) (map[string]any, func(), error) {
-	s, err := d.session(req.SessionID)
-	if err != nil {
-		return nil, nil, err
-	}
-	reqID := req.ID
-	return map[string]any{"session_id": s.id}, func() { s.attach(reqID) }, nil
-}
-
-// stopSessions terminates every live session of a sandbox (suspend/destroy).
-func (d *Daemon) stopSessions(sandbox string) {
-	d.mu.Lock()
-	var live []*Session
-	for _, s := range d.sessions {
-		if s.sandbox == sandbox && !s.exited() {
-			live = append(live, s)
-		}
-	}
-	d.mu.Unlock()
-	for _, s := range live {
-		s.terminate(5 * time.Second)
-	}
-}
-
 // StopAll terminates every live session (daemon shutdown).
-func (d *Daemon) StopAll() {
-	d.mu.Lock()
-	var live []*Session
-	for _, s := range d.sessions {
-		if !s.exited() {
-			live = append(live, s)
-		}
-	}
-	d.mu.Unlock()
-	for _, s := range live {
-		s.terminate(3 * time.Second)
-	}
-}
+func (d *Daemon) StopAll() { d.Backend.StopAll() }
 
 // Reply renders a request's outcome as the reply frame.
 func Reply(id int, result map[string]any, err error) Frame {

--- a/cli/internal/runner/daemon_test.go
+++ b/cli/internal/runner/daemon_test.go
@@ -83,6 +83,10 @@ func newDaemon(t *testing.T) *Daemon {
 	return d
 }
 
+// sandboxRoot is the process backend's root — the tests reach through the
+// Backend seam because they are testing that backend, not the routing.
+func sandboxRoot(d *Daemon) string { return d.Backend.(*Process).Root }
+
 func do(t *testing.T, d *Daemon, req Request, emit Emitter) map[string]any {
 	t.Helper()
 	result, _, err := d.Handle(req, emit)
@@ -143,7 +147,7 @@ func TestWriteFileMapsSpriteHome(t *testing.T) {
 		Op: "write_file", Name: "sb", Path: "/home/sprite/.env",
 		Data: base64.StdEncoding.EncodeToString([]byte("A=1\n")), Mode: &mode,
 	}, rec)
-	target := filepath.Join(d.Root, "sb", ".env")
+	target := filepath.Join(sandboxRoot(d), "sb", ".env")
 	body, err := os.ReadFile(target)
 	if err != nil || string(body) != "A=1\n" {
 		t.Fatalf("file not written inside the sandbox: %v %q", err, body)
@@ -154,7 +158,7 @@ func TestWriteFileMapsSpriteHome(t *testing.T) {
 	// Parent directories are created; relative paths are sandbox-relative.
 	do(t, d, Request{Op: "write_file", Name: "sb", Path: ".claude/skills/x/SKILL.md",
 		Data: base64.StdEncoding.EncodeToString([]byte("# x"))}, rec)
-	if _, err := os.Stat(filepath.Join(d.Root, "sb", ".claude", "skills", "x", "SKILL.md")); err != nil {
+	if _, err := os.Stat(filepath.Join(sandboxRoot(d), "sb", ".claude", "skills", "x", "SKILL.md")); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -179,7 +183,7 @@ func TestExec(t *testing.T) {
 	// HOME is the sandbox and /home/sprite maps into it, in args too.
 	got = do(t, d, Request{Op: "exec", Name: "sb", Cmd: "sh", Args: []string{"-c", "echo $HOME; echo /home/sprite/x; pwd -P"}}, rec)
 	out, _ = base64.StdEncoding.DecodeString(got["output"].(string))
-	sb := filepath.Join(d.Root, "sb")
+	sb := filepath.Join(sandboxRoot(d), "sb")
 	realSb, _ := filepath.EvalSymlinks(sb) // macOS: /var → /private/var
 	want := sb + "\n" + sb + "/x\n" + realSb + "\n"
 	if string(out) != want {
@@ -314,7 +318,7 @@ func TestSpawnResolvesCommandOnSandboxPath(t *testing.T) {
 	d := newDaemon(t)
 	rec := newRecorder()
 	do(t, d, Request{Op: "create", Name: "sb"}, rec)
-	bin := filepath.Join(d.Root, "sb", ".local", "bin")
+	bin := filepath.Join(sandboxRoot(d), "sb", ".local", "bin")
 	if err := os.MkdirAll(bin, 0o755); err != nil {
 		t.Fatal(err)
 	}

--- a/cli/internal/runner/process.go
+++ b/cli/internal/runner/process.go
@@ -1,0 +1,521 @@
+package runner
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// spriteHome is the home directory every Fountain provisioning script and
+// runtime assumes (the Sprites base image; the E2B/Daytona images recreate
+// it). The backend maps it to the sandbox directory in file paths, working
+// directories, and command arguments, so those scripts land inside the
+// sandbox without a Linux user of that name existing on this machine.
+const spriteHome = "/home/sprite"
+
+// suspendedMarker sits in a sandbox directory while it is parked: suspend
+// stops its processes and leaves the marker, resume removes it.
+const suspendedMarker = ".fountain-suspended"
+
+// Process is the Backend of ADR 0022: a sandbox is a directory under Root,
+// and its commands are processes on this machine, run as the daemon's user
+// with HOME pointed at that directory.
+//
+// Trusted mode, and the only mode this backend has. There is no VM, no
+// container, no egress policy between the agent and the machine — which is
+// documented rather than mitigated, because the machine is the user's own.
+type Process struct {
+	Root     string
+	RealHome string
+	Log      Logger
+
+	mu       sync.Mutex
+	sessions map[string]*Session // by session id
+	seq      int
+}
+
+// NewProcess builds the process backend over root, creating it if needed.
+func NewProcess(root string, log Logger) (*Process, error) {
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		return nil, fmt.Errorf("create sandbox root %s: %w", root, err)
+	}
+	home, _ := os.UserHomeDir()
+	return &Process{Root: root, RealHome: home, Log: log, sessions: map[string]*Session{}}, nil
+}
+
+// ── sandboxes ────────────────────────────────────────────────────────────────
+
+func (p *Process) dir(name string) (string, error) {
+	if name == "" || strings.ContainsAny(name, "/\\") || name == "." || name == ".." ||
+		strings.HasPrefix(name, ".") {
+		return "", invalid("bad sandbox name")
+	}
+	return filepath.Join(p.Root, name), nil
+}
+
+// existingDir is dir plus a presence check.
+func (p *Process) existingDir(name string) (string, error) {
+	dir, err := p.dir(name)
+	if err != nil {
+		return "", err
+	}
+	if st, err := os.Stat(dir); err != nil || !st.IsDir() {
+		return "", notFound("no sandbox " + name)
+	}
+	return dir, nil
+}
+
+// Create implements Backend.
+func (p *Process) Create(req Request) (map[string]any, func(), error) {
+	dir, err := p.dir(req.Name)
+	if err != nil {
+		return nil, nil, err
+	}
+	// Idempotent-adopting: an existing directory is the same sandbox.
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, nil, unavailable(err.Error())
+	}
+	return map[string]any{}, nil, nil
+}
+
+// Get implements Backend.
+func (p *Process) Get(req Request) (map[string]any, func(), error) {
+	dir, err := p.existingDir(req.Name)
+	if err != nil {
+		return nil, nil, err
+	}
+	status := "running"
+	if _, err := os.Stat(filepath.Join(dir, suspendedMarker)); err == nil {
+		status = "suspended"
+	}
+	return map[string]any{"status": status, "path": dir}, nil, nil
+}
+
+// Destroy implements Backend.
+func (p *Process) Destroy(req Request) (map[string]any, func(), error) {
+	dir, err := p.dir(req.Name)
+	if err != nil {
+		return nil, nil, err
+	}
+	p.stopSessions(req.Name)
+	p.mu.Lock()
+	for id, s := range p.sessions {
+		if s.sandbox == req.Name {
+			delete(p.sessions, id)
+		}
+	}
+	p.mu.Unlock()
+	// Already gone is ok.
+	if err := os.RemoveAll(dir); err != nil {
+		return nil, nil, unavailable(err.Error())
+	}
+	return map[string]any{}, nil, nil
+}
+
+// List implements Backend.
+func (p *Process) List() (map[string]any, func(), error) {
+	entries, err := os.ReadDir(p.Root)
+	if err != nil {
+		return nil, nil, unavailable(err.Error())
+	}
+	names := []string{}
+	for _, e := range entries {
+		if e.IsDir() && !strings.HasPrefix(e.Name(), ".") {
+			names = append(names, e.Name())
+		}
+	}
+	sort.Strings(names)
+	return map[string]any{"names": names}, nil, nil
+}
+
+// Suspend implements Backend.
+func (p *Process) Suspend(req Request) (map[string]any, func(), error) {
+	dir, err := p.existingDir(req.Name)
+	if err != nil {
+		return nil, nil, err
+	}
+	// Parking = stop what is running, keep the disk. Nothing else costs
+	// anything on a machine that stays up.
+	p.stopSessions(req.Name)
+	if err := os.WriteFile(filepath.Join(dir, suspendedMarker), nil, 0o600); err != nil {
+		return nil, nil, unavailable(err.Error())
+	}
+	return map[string]any{}, nil, nil
+}
+
+// Resume implements Backend.
+func (p *Process) Resume(req Request) (map[string]any, func(), error) {
+	dir, err := p.existingDir(req.Name)
+	if err != nil {
+		return nil, nil, err
+	}
+	_ = os.Remove(filepath.Join(dir, suspendedMarker))
+	return map[string]any{}, nil, nil
+}
+
+// ── files ────────────────────────────────────────────────────────────────────
+
+// mapPath resolves a path Fountain names into the sandbox: `/home/sprite/…`
+// and relative paths land inside the sandbox directory; other absolute paths
+// are the host's (trusted mode — /tmp is /tmp).
+func mapPath(dir, p string) string {
+	switch {
+	case p == spriteHome:
+		return dir
+	case strings.HasPrefix(p, spriteHome+"/"):
+		return filepath.Join(dir, strings.TrimPrefix(p, spriteHome+"/"))
+	case p == "~":
+		return dir
+	case strings.HasPrefix(p, "~/"):
+		return filepath.Join(dir, p[2:])
+	case filepath.IsAbs(p):
+		return p
+	case p == "":
+		return dir
+	default:
+		return filepath.Join(dir, p)
+	}
+}
+
+// mapArg rewrites the literal /home/sprite wherever it appears in a command
+// or argument, so `bin=/home/sprite/.local/bin/x` in a `bash -lc` script
+// resolves inside the sandbox too.
+func mapArg(dir, arg string) string {
+	return strings.ReplaceAll(arg, spriteHome, dir)
+}
+
+// WriteFile implements Backend.
+func (p *Process) WriteFile(req Request) (map[string]any, func(), error) {
+	dir, err := p.existingDir(req.Name)
+	if err != nil {
+		return nil, nil, err
+	}
+	data, err := base64.StdEncoding.DecodeString(req.Data)
+	if err != nil {
+		return nil, nil, invalid("data is not base64")
+	}
+	target := mapPath(dir, req.Path)
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		return nil, nil, writeFailed(err.Error())
+	}
+	mode := os.FileMode(0o644)
+	if req.Mode != nil {
+		mode = os.FileMode(*req.Mode)
+	}
+	if err := os.WriteFile(target, data, mode); err != nil {
+		return nil, nil, writeFailed(err.Error())
+	}
+	// WriteFile's mode is subject to umask; a requested mode is a promise.
+	if req.Mode != nil {
+		_ = os.Chmod(target, mode)
+	}
+	return map[string]any{}, nil, nil
+}
+
+// ── commands ─────────────────────────────────────────────────────────────────
+
+// command builds the exec.Cmd for a request inside a sandbox: HOME is the
+// sandbox, PATH gains the sandbox's own bin dirs, npm installs globally into
+// the sandbox, and the request's env pairs win over all of it.
+func (p *Process) command(ctx context.Context, dir string, req Request) *exec.Cmd {
+	args := make([]string, len(req.Args))
+	for i, a := range req.Args {
+		args[i] = mapArg(dir, a)
+	}
+	env := p.env(dir, req.Env)
+	// os/exec resolves a bare command name against the *daemon's* PATH; the
+	// agent CLIs provisioning installs live on the sandbox's PATH
+	// (`<sandbox>/.local/bin`, `.npm-global/bin`), so resolve there.
+	cmd := exec.CommandContext(ctx, lookPath(mapArg(dir, req.Cmd), env), args...)
+	cmd.Dir = mapPath(dir, req.Dir)
+	if st, err := os.Stat(cmd.Dir); err != nil || !st.IsDir() {
+		cmd.Dir = dir
+	}
+	cmd.Env = env
+	return cmd
+}
+
+// lookPath resolves name against the PATH inside env (not the process's).
+// A name that resolves nowhere is returned unchanged so the failure reads
+// as "not found" when the command runs.
+func lookPath(name string, env []string) string {
+	if strings.Contains(name, "/") {
+		return name
+	}
+	for _, kv := range env {
+		if !strings.HasPrefix(kv, "PATH=") {
+			continue
+		}
+		for _, p := range filepath.SplitList(strings.TrimPrefix(kv, "PATH=")) {
+			if p == "" {
+				continue
+			}
+			candidate := filepath.Join(p, name)
+			if st, err := os.Stat(candidate); err == nil && !st.IsDir() && st.Mode()&0o111 != 0 {
+				return candidate
+			}
+		}
+		break
+	}
+	return name
+}
+
+func (p *Process) env(dir string, pairs [][]string) []string {
+	base := map[string]string{}
+	order := []string{}
+	set := func(k, v string) {
+		if _, ok := base[k]; !ok {
+			order = append(order, k)
+		}
+		base[k] = v
+	}
+	for _, kv := range os.Environ() {
+		if i := strings.IndexByte(kv, '='); i > 0 {
+			set(kv[:i], kv[i+1:])
+		}
+	}
+	sandboxBins := strings.Join([]string{
+		filepath.Join(dir, ".local", "bin"),
+		filepath.Join(dir, ".npm-global", "bin"),
+		filepath.Join(dir, ".bun", "bin"),
+	}, string(os.PathListSeparator))
+	extra := []string{}
+	for _, path := range []string{"/opt/homebrew/bin", "/usr/local/bin", filepath.Join(p.RealHome, ".local", "bin"), filepath.Join(p.RealHome, ".bun", "bin")} {
+		if st, err := os.Stat(path); err == nil && st.IsDir() && !strings.Contains(base["PATH"], path) {
+			extra = append(extra, path)
+		}
+	}
+	path := sandboxBins + string(os.PathListSeparator) + base["PATH"]
+	if len(extra) > 0 {
+		path += string(os.PathListSeparator) + strings.Join(extra, string(os.PathListSeparator))
+	}
+	set("PATH", path)
+	set("HOME", dir)
+	set("npm_config_prefix", filepath.Join(dir, ".npm-global"))
+	if _, ok := base["npm_config_cache"]; !ok && p.RealHome != "" {
+		set("npm_config_cache", filepath.Join(p.RealHome, ".npm"))
+	}
+	set("FOUNTAIN_SANDBOX_DIR", dir)
+	for _, kv := range pairs {
+		if len(kv) == 2 {
+			set(kv[0], kv[1])
+		}
+	}
+	out := make([]string, 0, len(order))
+	for _, k := range order {
+		out = append(out, k+"="+base[k])
+	}
+	return out
+}
+
+// Exec implements Backend.
+func (p *Process) Exec(req Request) (map[string]any, func(), error) {
+	dir, err := p.existingDir(req.Name)
+	if err != nil {
+		return nil, nil, err
+	}
+	ctx := context.Background()
+	if req.TimeoutMS != nil && *req.TimeoutMS > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(*req.TimeoutMS)*time.Millisecond)
+		defer cancel()
+	}
+	cmd := p.command(ctx, dir, req)
+	var out []byte
+	var runErr error
+	if req.StderrToStdout {
+		out, runErr = cmd.CombinedOutput()
+	} else {
+		out, runErr = cmd.Output()
+	}
+	code := 0
+	if runErr != nil {
+		var exitErr *exec.ExitError
+		switch {
+		case errors.As(runErr, &exitErr):
+			code = exitErr.ExitCode()
+			if code < 0 {
+				code = 137 // killed (timeout)
+			}
+		case errors.Is(ctx.Err(), context.DeadlineExceeded):
+			code = 124
+			out = append(out, []byte("\nfountain runner: command timed out\n")...)
+		default:
+			// Could not start at all (not found, not executable): data, not a
+			// raise — the contract's "nonzero exit is readable".
+			code = 127
+			out = append(out, []byte(runErr.Error()+"\n")...)
+		}
+	}
+	return map[string]any{
+		"output": base64.StdEncoding.EncodeToString(out),
+		"code":   code,
+	}, nil, nil
+}
+
+// ── sessions ─────────────────────────────────────────────────────────────────
+
+// Spawn implements Backend.
+func (p *Process) Spawn(req Request, emit Emitter) (map[string]any, func(), error) {
+	dir, err := p.existingDir(req.Name)
+	if err != nil {
+		return nil, nil, err
+	}
+	p.mu.Lock()
+	p.seq++
+	id := fmt.Sprintf("s-%d-%d", time.Now().Unix(), p.seq)
+	p.mu.Unlock()
+
+	cmd := p.command(context.Background(), dir, req)
+	s, err := startSession(id, req.Name, cmd, req.Stdin, emit, p.Log)
+	if err != nil {
+		// Never a raise: a command that cannot start is a session that exited
+		// 127 with the reason on stdout, so the owner reads it like any other
+		// failed process.
+		s = failedSession(id, req.Name, req.Cmd, err, emit)
+	}
+	p.mu.Lock()
+	p.sessions[id] = s
+	p.pruneLocked(req.Name)
+	p.mu.Unlock()
+
+	reqID := req.ID
+	after := func() { s.attach(reqID) }
+	return map[string]any{"session_id": id}, after, nil
+}
+
+// pruneLocked bounds the finished sessions retained per sandbox for replay.
+func (p *Process) pruneLocked(sandbox string) {
+	const keep = 100
+	var finished []*Session
+	for _, s := range p.sessions {
+		if s.sandbox == sandbox && s.exited() {
+			finished = append(finished, s)
+		}
+	}
+	if len(finished) <= keep {
+		return
+	}
+	sort.Slice(finished, func(i, j int) bool { return finished[i].createdAt.Before(finished[j].createdAt) })
+	for _, s := range finished[:len(finished)-keep] {
+		delete(p.sessions, s.id)
+	}
+}
+
+func (p *Process) session(id string) (*Session, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	s, ok := p.sessions[id]
+	if !ok {
+		return nil, notFound("no session " + id)
+	}
+	return s, nil
+}
+
+// Stdin implements Backend.
+func (p *Process) Stdin(req Request) (map[string]any, func(), error) {
+	s, err := p.session(req.SessionID)
+	if err != nil {
+		return nil, nil, err
+	}
+	data, err := base64.StdEncoding.DecodeString(req.Data)
+	if err != nil {
+		return nil, nil, invalid("data is not base64")
+	}
+	if err := s.write(data); err != nil {
+		return nil, nil, err
+	}
+	return map[string]any{}, nil, nil
+}
+
+// StdinClose implements Backend.
+func (p *Process) StdinClose(req Request) (map[string]any, func(), error) {
+	s, err := p.session(req.SessionID)
+	if err != nil {
+		return nil, nil, err
+	}
+	s.closeStdin()
+	return map[string]any{}, nil, nil
+}
+
+// Detach implements Backend.
+func (p *Process) Detach(req Request) (map[string]any, func(), error) {
+	s, err := p.session(req.SessionID)
+	if err != nil {
+		// Detaching from something that is gone is fine.
+		return map[string]any{}, nil, nil
+	}
+	s.detach()
+	return map[string]any{}, nil, nil
+}
+
+// ListSessions implements Backend.
+func (p *Process) ListSessions(req Request) (map[string]any, func(), error) {
+	if _, err := p.existingDir(req.Name); err != nil {
+		return nil, nil, err
+	}
+	p.mu.Lock()
+	var list []*Session
+	for _, s := range p.sessions {
+		if s.sandbox == req.Name {
+			list = append(list, s)
+		}
+	}
+	p.mu.Unlock()
+	// Newest first: reattach takes the first session, and the turn in flight
+	// is the most recent spawn.
+	sort.Slice(list, func(i, j int) bool { return list[i].createdAt.After(list[j].createdAt) })
+	out := make([]map[string]any, 0, len(list))
+	for _, s := range list {
+		out = append(out, s.describe())
+	}
+	return map[string]any{"sessions": out}, nil, nil
+}
+
+// Attach implements Backend.
+func (p *Process) Attach(req Request, emit Emitter) (map[string]any, func(), error) {
+	s, err := p.session(req.SessionID)
+	if err != nil {
+		return nil, nil, err
+	}
+	reqID := req.ID
+	return map[string]any{"session_id": s.id}, func() { s.attach(reqID) }, nil
+}
+
+// stopSessions terminates every live session of a sandbox (suspend/destroy).
+func (p *Process) stopSessions(sandbox string) {
+	p.mu.Lock()
+	var live []*Session
+	for _, s := range p.sessions {
+		if s.sandbox == sandbox && !s.exited() {
+			live = append(live, s)
+		}
+	}
+	p.mu.Unlock()
+	for _, s := range live {
+		s.terminate(5 * time.Second)
+	}
+}
+
+// StopAll implements Backend.
+func (p *Process) StopAll() {
+	p.mu.Lock()
+	var live []*Session
+	for _, s := range p.sessions {
+		if !s.exited() {
+			live = append(live, s)
+		}
+	}
+	p.mu.Unlock()
+	for _, s := range live {
+		s.terminate(3 * time.Second)
+	}
+}


### PR DESCRIPTION
Groundwork for a Firecracker microVM backend on `fountain runner`. Split out so the seam can be reviewed on its own; the backend that uses it is the next PR.

## Why

ADR 0022 shipped the runner as trusted mode and said what was missing, in as many words:

> A container/VM mode (Apple's `container`, Tart, a Linux runner under Docker) is compatible with the protocol (the daemon would translate `create` into a container and `HOME` into a mount) and is **not built**.

It is compatible with the protocol because the protocol never mentions directories. `Daemon` did — it held the wire *and* the substance in one file, so there was nowhere to put a second answer to "what is a sandbox".

## What

- **`backend.go`** — the `Backend` interface: the fourteen ops plus `StopAll`. Each method carries the contract obligation it has to honour, because those obligations are Fountain's rather than Go's. Nothing in the type system checks that `Get` tells a definitively-absent sandbox apart from an unreachable one, and that is the distinction protecting a parked disk from a teardown on one flaky call.
- **`process.go`** — today's behaviour, moved verbatim. `Process` is ADR 0022's runner: a directory under `--root`, the `/home/sprite` path mapping, the sandbox-scoped `PATH`, local processes, session journals.
- **`daemon.go`** — the wire only: `Request`, `Frame`, the error taxonomy, the op switch, `Reply`.

`New(root, log)` still builds the process backend, so `cmd/runner.go` is untouched. `NewWithBackend(b, log)` is the new door.

## No behaviour change, and how that was checked

Every existing daemon test passes as written. The only test edit is four `d.Root` reads becoming `sandboxRoot(d)`, since the root belongs to the backend now.

Passing tests alone would not prove a move, so I diffed it: normalising the receiver rename, every line of the old `daemon.go` appears in the new `daemon.go` + `process.go`. The 32 that do not are the method renames (`create` → `Create`), the routing lines, the constructor, and one loop variable renamed off a now-shadowed receiver.

`backend_test.go` pins the routing itself — each op reaches exactly one method, `spawn` and `attach` are handed the emitter their reply goes out on, an unknown op answers `not_supported` without touching the backend.

## Not here

- No CHANGELOG entry. Nothing an operator can observe changed; the entry comes with the backend that uses this.
- The runner adapter's advertised capabilities are unchanged (`:suspend`, `:attach`). Per-runner capability negotiation — so a VM-backed runner could honestly advertise `:network_policy` — is a Fountain-side change and is not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)