### PR TITLE
fix(runner): a microVM's sandbox path is /home/sprite, not the host's state directory

### DIFF
--- a/cli/internal/runner/firecracker.go
+++ b/cli/internal/runner/firecracker.go
@@ -157,6 +157,16 @@ func (f *Firecracker) Create(req Request) (map[string]any, func(), error) {
 // from anything the daemon remembers, and a sandbox whose disk is present
 // with no VM behind it is parked, not missing — reporting not_found there
 // would tell Fountain to give up a disk that is sitting on this machine.
+//
+// `path` is what a process *inside* this sandbox calls its home, which is
+// the one thing Fountain uses it for: `Fountain.Sandbox.Runner.host_path/2`
+// rewrites the ACP `cwd` through it, and an agent CLI validates that path in
+// band before it will start a session. On the process backend the two
+// coincide, because the sandbox is a directory and /home/sprite is an alias
+// for it. In a microVM they do not: /home/sprite is literal, and handing
+// over the host's state directory names something that exists on the wrong
+// side of the machine boundary. The host directory rides along under
+// `host_dir` for an operator reading a log; nothing consumes it.
 func (f *Firecracker) Get(req Request) (map[string]any, func(), error) {
 	dir, err := f.dir(req.Name)
 	if err != nil {
@@ -180,7 +190,7 @@ func (f *Firecracker) Get(req Request) (map[string]any, func(), error) {
 			status = "running"
 		}
 	}
-	return map[string]any{"status": status, "path": dir}, nil, nil
+	return map[string]any{"status": status, "path": spriteHome, "host_dir": dir}, nil, nil
 }
 
 // Destroy implements Backend. Already-gone is success.

--- a/cli/internal/runner/firecracker_net_test.go
+++ b/cli/internal/runner/firecracker_net_test.go
@@ -269,3 +269,27 @@ func TestBootGateIsOnePerSandbox(t *testing.T) {
 		t.Fatal("two sandboxes share one boot gate")
 	}
 }
+
+// `path` is the path a process inside the sandbox sees as its home, not the
+// host directory holding the disk. Fountain rewrites the ACP `cwd` through
+// it (Fountain.Sandbox.Runner.host_path/2), and an agent CLI validates that
+// path in band before it starts a session — so naming the host's state
+// directory fails the turn with an invalid-cwd error, after a microVM has
+// booted and provisioned perfectly. Found on hardware, not in a test.
+func TestGetReportsTheInGuestHomeAsThePath(t *testing.T) {
+	f := newTestFirecracker(t)
+	dir := filepath.Join(f.cfg.Root, "runner-a-1")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	result, _, err := f.Get(Request{Name: "runner-a-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result["path"] != spriteHome {
+		t.Fatalf("path = %v, want %s — the ACP cwd is rewritten through this", result["path"], spriteHome)
+	}
+	if result["host_dir"] != dir {
+		t.Fatalf("host_dir = %v, want %s", result["host_dir"], dir)
+	}
+}


### PR DESCRIPTION
Found by running #1225 on hardware against a real conversation.

## The failure

A Firecracker-backed runner booted its microVM and provisioned cleanly, then failed the first turn:

```
acp: {:acp_error, :new_session, %{"code" => -32602,
  "data" => %{"cwd" => "/var/lib/firecracker/sandboxes/runner-9d…"}}}
```

## Why

`Fountain.Sandbox.Runner.host_path/2` rewrites the ACP `cwd` through the `path` the daemon reports in its `get` reply, because an agent CLI validates that path **in band** before it will open a session.

On the process backend the sandbox *is* a directory and `/home/sprite` is an alias for it, so reporting the host directory is exactly right. In a microVM it is not — `/home/sprite` is literal, and the host's state directory names something on the wrong side of the machine boundary. It holds `rootfs.ext4` and two sockets, not the agent's files.

I called this out in #1225's design table ("delete `mapPath`; paths become literal again, so drop `host_path/2` for this backend") and then didn't act on it, because `host_path/2` lives on the Fountain side. It doesn't need to: the daemon just has to report the right path.

## The fix

The Firecracker backend reports `/home/sprite`, which makes `host_path/2` the identity for this backend without Fountain having to know there are two kinds of runner. The host directory rides along as `host_dir` for an operator reading a log; nothing consumes it.

What makes this safe is that `path` has exactly one consumer — `host_path/2`. The runner path a client displays (`runner.path` on a conversation) comes from `Fountain.Runners` joining the runners row's `root`, not from this reply.

## Verified

On `fireball`, the turn now reaches `session/update` with a live session id inside the guest and gets to a real `401 API key is invalid` from api.anthropic.com — the test account holds a placeholder key on purpose. That is the whole path: boot, provision, ACP handshake, egress through the tap and NAT, and the answer streamed back over vsock.

Terminate was exercised too: both microVMs destroyed, taps deleted, sandbox directories gone.

## Also seen, not fixed here

The claude runtime rejects the model id Fountain passes it — `Invalid value for config option model: claude-sonnet-4-6` — and falls back to the runtime default for the turn. Not backend-specific and not in scope; flagging it because it shows up in every event stream from that runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)