### PR TITLE
copy(marketing): the self-healing case study says the same thing in fewer words

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
@@ -946,12 +946,12 @@ defmodule FountainWeb.MarketingHTML do
       %{
         value: "4m 27s",
         label: "from alert to open pull request",
-        note: "Measured on the incident below. The second one took 4m 08s."
+        note: "The incident below. The second took 4m 08s."
       },
       %{
         value: "7.5 min",
         label: "median incident, start to verdict",
-        note: "Half finish faster. The longest ran 50 minutes."
+        note: "The longest ran 50 minutes."
       },
       %{
         value: "0",
@@ -968,78 +968,70 @@ defmodule FountainWeb.MarketingHTML do
         step: "1",
         title: "Prometheus notices",
         mono: "KubePodCrashLooping · PodOOMKilled · CPUThrottlingHigh · PodRestartChurn",
-        body:
-          "The same alert rules the estate already had. Nothing was written to make " <>
-            "an agent happy, and nothing about the agent is wired into Prometheus."
+        body: "The estate's existing alert rules. Prometheus knows nothing about the agent."
       },
       %{
         step: "2",
         title: "Alertmanager forks the page",
         mono: "continue: true",
         body:
-          "One copy goes to the operator's phone, exactly as before. A sibling copy " <>
-            "goes to a webhook. The human is added to, never replaced."
+          "One copy to the phone, as before. One to a webhook. " <>
+            "The human is added to, not replaced."
       },
       %{
         step: "3",
         title: "A webhook hires an agent",
         mono: "POST /api/conversations",
         body:
-          "Two hundred lines of Node with an API key, an agent id, a vault id and the " <>
-            "alert text. It has no cluster access of its own, and needs none. Hiring the " <>
-            "agent is one call."
+          "Two hundred lines of Node, posting an agent id, a vault id and the " <>
+            "alert text. It needs no cluster access."
       },
       %{
         step: "4",
         title: "The agent reads the estate",
         mono: "Authorization: Bearer … (GET only)",
         body:
-          "A read-only service answers with each node's health verdict, its drift " <>
-            "against source, and the controller's own conditions. Every other method " <>
-            "returns 405, so the token cannot be turned into a write."
+          "A read-only service answers with node health, drift from source, and " <>
+            "controller conditions. Every other method returns 405."
       },
       %{
         step: "5",
         title: "It finds the wrong fact in git",
         mono: "gh api · git log -S",
         body:
-          "The cluster is a repository, so a bad cluster is a bad commit. The agent " <>
-            "reads the source and its history and names the change that introduced the " <>
-            "fault, before it edits anything."
+          "A bad cluster is a bad commit. The agent reads the history and " <>
+            "names the one at fault before editing."
       },
       %{
         step: "6",
         title: "It opens one minimal pull request",
         mono: "symptom · root cause · why this diff is the whole fix",
         body:
-          "Source and regenerated manifests in one commit, under a separate GitHub " <>
-            "identity with push rights and nothing more. If no change to the repository " <>
-            "can fix the alert, it writes that instead and opens nothing."
+          "Source and regenerated manifests in one commit, from an identity " <>
+            "with push rights and nothing else. If the repository cannot fix the " <>
+            "alert, it opens nothing."
       },
       %{
         step: "7",
         title: "A human approves",
         mono: "422 on self-approval · 405 on self-merge",
         body:
-          "The one gate. The agent pushes as an identity that GitHub refuses to let " <>
-            "approve its own work, and the branch requires a review from somebody else. " <>
-            "The gate is not a policy the agent is asked to respect. It cannot reach it."
+          "The one gate. GitHub blocks self-approval, and the branch needs a " <>
+            "review from another account."
       },
       %{
         step: "8",
         title: "Flux applies the merge",
         mono: "reconcile on webhook",
-        body:
-          "Git was always the apply path, so there is no apply button for the agent to " <>
-            "be trusted with. The merge is the deploy."
+        body: "Git was always the apply path. There is no apply button to trust it with."
       },
       %{
         step: "9",
         title: "The agent verifies and reports",
         mono: "poll until healthy",
         body:
-          "It watches the degraded node come back, checks that nothing else regressed, " <>
-            "and posts the incident summary. Then it stops."
+          "It watches the node come back, checks nothing else regressed, " <>
+            "posts the summary, and stops."
       }
     ]
   end
@@ -1048,28 +1040,26 @@ defmodule FountainWeb.MarketingHTML do
   def case_guardrails do
     [
       %{
-        can: "Read the whole estate graph, including every controller's conditions.",
-        cannot: "Change anything in the cluster. The token is refused on any method but GET."
+        can: "Read the whole estate graph, including controller conditions.",
+        cannot: "Change anything. The token is refused on any method but GET."
       },
       %{
         can: "Clone the infrastructure repository and push a branch.",
-        cannot: "Push to the default branch. It is protected, and a pull request is required."
+        cannot: "Push to the default branch. It is protected, and needs a pull request."
       },
       %{
-        can: "Open a pull request and answer review comments on it.",
+        can: "Open a pull request and answer its review comments.",
         cannot:
-          "Approve or merge that pull request. GitHub blocks self-approval, " <>
-            "and the branch needs one review from another account."
+          "Approve or merge it. GitHub blocks self-approval, and the branch " <>
+            "needs another account's review."
       },
       %{
-        can: "Reference a secret by name, so the fix restores the reference.",
-        cannot:
-          "Read a secret value. The material never leaves the cluster, " <>
-            "and no diff it writes contains one."
+        can: "Name a secret, so the fix restores the reference.",
+        cannot: "Read a secret value. The material never leaves the cluster."
       },
       %{
-        can: "Say that no change to the repository can fix this, and stop.",
-        cannot: "Reach the cluster directly. The sandbox has no kubectl and no kubeconfig."
+        can: "Say the repository cannot fix this, and stop.",
+        cannot: "Reach the cluster. The sandbox has no kubectl and no kubeconfig."
       }
     ]
   end
@@ -1083,45 +1073,40 @@ defmodule FountainWeb.MarketingHTML do
         time: "06:58:15",
         title: "A sidecar is killed for memory",
         body:
-          "Alertmanager posts PodOOMKilled on a container that keeps a checkout in " <>
-            "sync. The operator's phone buzzes. So does a webhook, which opens a " <>
-            "conversation with the agent."
+          "PodOOMKilled on a container that syncs a checkout. The phone buzzes. " <>
+            "So does a webhook, which hires the agent."
       },
       %{
         time: "06:59:34",
         title: "A second alert, same container",
-        body:
-          "CPUThrottlingHigh, at 94.44%. It opens its own incident, and a second agent " <>
-            "starts work on it."
+        body: "CPUThrottlingHigh, at 94.44%. Its own incident, its own agent."
       },
       %{
         time: "07:02:42",
         title: "The first pull request opens",
         body:
-          "Two files, nine lines added and four removed. The agent had traced the kill " <>
-            "to a code path the container's limit was never sized for, and to the commit " <>
-            "that first made the estate take it."
+          "Two files, nine lines added and four removed. The agent traced the " <>
+            "kill to a code path the limit never covered, and to the commit that " <>
+            "introduced it."
       },
       %{
         time: "07:03:42",
         title: "The second pull request opens",
         body:
-          "Six lines added, two removed. The throttling had the same cause seen from " <>
-            "the other side, and the agent said so rather than repeating the diagnosis."
+          "Six lines added, two removed. The same cause from the other side, " <>
+            "said rather than diagnosed again."
       },
       %{
         time: "08:50:27",
         title: "A human wakes up and reads two pull requests",
         body:
-          "The throttling fix is approved and merged. Flux reconciles on the merge " <>
-            "webhook, and the agent watches the container come back."
+          "The throttling fix is merged. Flux reconciles on the webhook, and " <>
+            "the agent watches the container come back."
       },
       %{
         time: "23:46:01",
         title: "The memory fix follows",
-        body:
-          "Nothing was on fire, so it waited for a proper read. That is what the gate " <>
-            "is for."
+        body: "Nothing was on fire, so it waited for a proper read. That is the gate working."
       }
     ]
   end
@@ -1160,31 +1145,30 @@ defmodule FountainWeb.MarketingHTML do
       %{
         title: "Agent",
         body:
-          "The runtime, the model, the runbook and the tools, written once as a file in " <>
-            "a public repository and applied to Fountain. The runbook is the whole " <>
-            "product: diagnose, fix by pull request, wait for the human, verify, report."
+          "Runtime, model, runbook and tools, written once as a file in a " <>
+            "public repository. The runbook is the product: diagnose, fix by " <>
+            "pull request, wait for the human, verify, report."
       },
       %{
         title: "Environment",
         body:
-          "The machine the agent wakes up on, with the repository, the CLI it needs, and " <>
-            "the address of the read-only estate service. Described once, rebuilt per " <>
+          "The machine it wakes up on, with the repository, the CLI and the " <>
+            "read-only estate service's address. Described once, rebuilt per " <>
             "incident, never patched by hand."
       },
       %{
         title: "Vault",
         body:
-          "The bot identity, kept apart from the environment on purpose. Swap the vault " <>
-            "and the same agent acts as a different GitHub account. The token arrives as " <>
-            "an environment variable and stays out of the prompt, the model's context and " <>
-            "the stored transcript."
+          "The bot identity, kept apart from the environment. Swap it and the " <>
+            "agent acts as a different GitHub account. The token is an environment " <>
+            "variable, never in the prompt, the context or the transcript."
       },
       %{
         title: "Conversation",
         body:
-          "One incident, one sandbox, one transcript, addressable by the alert it came " <>
-            "from. It survives a diagnosis that runs for an hour, and it is a link a " <>
-            "human can open at 08:50 to see everything the agent did at 07:02."
+          "One incident, one sandbox, one transcript, addressed by its alert. " <>
+            "It survives an hour-long diagnosis, and a human opens it at 08:50 " <>
+            "to see 07:02."
       }
     ]
   end

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/case_study_self_healing.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/case_study_self_healing.html.heex
@@ -11,7 +11,7 @@
     The pager still goes off at 06:58. The pull request is open by 07:02.
   </h1>
   <p class="text-lg sm:text-xl text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-10">
-    A Kubernetes estate pages a person when a workload breaks. This one pages a person and hires an agent. The agent reads the cluster, finds the commit that broke it, and opens one small pull request. A human still approves every merge, because the agent is built so that it cannot.
+    This Kubernetes estate pages a person and hires an agent. The agent reads the cluster, finds the commit at fault, and opens one small pull request it is unable to merge.
   </p>
   <div class="flex flex-col sm:flex-row gap-3 justify-center">
     <a
@@ -51,7 +51,7 @@
     Some breakage reconciliation cannot fix.
   </h2>
   <p class="text-center text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-12">
-    GitOps promises that the cluster matches the repository. It keeps that promise even when the repository is wrong. Drop an environment variable, lose a secret reference, pin a bad image, and the controller reports perfect agreement with a broken source.
+    GitOps makes the cluster match the repository, and keeps doing it when the repository is wrong.
   </p>
   <div class="grid md:grid-cols-2 gap-6 max-w-3xl mx-auto">
     <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6">
@@ -60,7 +60,7 @@
       </p>
       <p class="text-lg font-semibold text-[var(--color-text-primary)]">Green</p>
       <p class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">
-        The cluster is exactly what the repository says. Reconciliation has nothing left to do, and reports success every time it runs.
+        The cluster is exactly what the repository says. Reconciliation has nothing left to do, and reports success.
       </p>
     </div>
     <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6">
@@ -69,12 +69,12 @@
       </p>
       <p class="text-lg font-semibold text-[var(--color-text-primary)]">Red</p>
       <p class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">
-        The workload is crashing anyway, because the thing the repository says is false. The fix is not another apply. The fix is knowledge.
+        The workload crashes anyway, because what the repository says is false: a dropped variable, a lost secret reference, a bad image pin. No apply fixes that. Knowledge does.
       </p>
     </div>
   </div>
   <p class="text-center text-[var(--color-text-secondary)] max-w-2xl mx-auto mt-12">
-    That gap is where the pager lives. It is also, exactly, the shape of work a coding agent is good at. Read the evidence, find the commit, write the smallest correct diff. The reason nobody automated it before is not the diagnosis. It is that shipping the diff needs a machine, a checkout, a credential that can push, and a human who is still allowed to say no.
+    That gap is where the pager lives, and it is the shape of work a coding agent is good at. What was missing was never the diagnosis. It was a machine, a checkout, a push credential, and a human still allowed to say no.
   </p>
 </section>
 
@@ -88,7 +88,7 @@
       Nine steps, one of them a person.
     </h2>
     <p class="text-center text-[var(--color-text-secondary)] max-w-xl mx-auto mb-12">
-      Every piece except the agent was already in the estate. The integration is one webhook and one API call.
+      Everything but the agent was already in the estate. One webhook, one API call.
     </p>
     <ol class="max-w-3xl mx-auto space-y-4">
       <li
@@ -128,7 +128,7 @@
     The gate is a mechanism, not a promise.
   </h2>
   <p class="text-center text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-12">
-    An agent that opens infrastructure pull requests is only as safe as the smallest thing it is able to do. Nothing here rests on the agent choosing well, on a system prompt holding, or on a model behaving. Each refusal below is somebody else's 405.
+    Such an agent is only as safe as the least it can do. Nothing rests on a good choice, a prompt holding, or a model behaving. Each refusal below is somebody else's 405.
   </p>
   <div class="max-w-3xl mx-auto space-y-4">
     <div
@@ -159,7 +159,7 @@
       One morning, end to end.
     </h2>
     <p class="text-center text-[var(--color-text-secondary)] max-w-xl mx-auto mb-12">
-      25 August 2026, all times UTC. Nobody was awake for the first half of this.
+      25 August 2026, UTC. Nobody was awake for the first half.
     </p>
     <ol class="max-w-3xl mx-auto">
       <li
@@ -202,7 +202,7 @@
         </span>
       </blockquote>
       <figcaption class="mt-3 text-xs text-[var(--color-text-muted)]">
-        The agent's root-cause paragraph, quoted from the pull request it opened at 07:02. The gap it names had been in the repository for months. No alert had ever reached it, because no commit had moved a lockfile until that week.
+        Its root-cause paragraph, quoted from the 07:02 pull request. The gap had sat there for months unalerted, because no commit had moved a lockfile until that week.
       </figcaption>
     </figure>
   </div>
@@ -214,7 +214,7 @@
     What {Fountain.Brand.name()} was for.
   </h2>
   <p class="text-center text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-12">
-    The alerting, the repository and the reconciler were already there. The missing piece was somewhere for an agent to live between alerts. Four things, and the fourth is the API call.
+    The alerting, the repository and the reconciler were already there. Missing was somewhere for an agent to live between alerts.
   </p>
   <div class="grid sm:grid-cols-2 gap-6 max-w-3xl mx-auto">
     <div
@@ -227,7 +227,7 @@
     </div>
   </div>
   <p class="text-center text-[var(--color-text-secondary)] max-w-2xl mx-auto mt-12">
-    The operator never provisions a machine for an incident, and never pays for one between incidents. A sandbox exists for as long as the incident does. <a
+    Nobody provisions a machine for an incident, or pays for one between them. A sandbox lasts as long as the incident. <a
       href={~p"/docs/primitives"}
       class="underline underline-offset-2 hover:text-[var(--color-text-primary)]"
     >Read about the four primitives</a>.
@@ -244,7 +244,7 @@
       Point your own alerts at an agent.
     </h2>
     <p class="text-center text-[var(--color-text-secondary)] max-w-xl mx-auto mb-12">
-      Whatever pages you today can post a webhook. This is the whole handoff.
+      Whatever pages you today can post a webhook. That is the whole handoff.
     </p>
     <div class="grid md:grid-cols-2 gap-8 items-start max-w-4xl mx-auto">
       <pre
@@ -256,19 +256,19 @@
           <span class="font-medium text-[var(--color-text-primary)]">
             Write the agent down first.
           </span>
-          The runbook, the tools and the model belong in a file you review, not in a webhook handler. Apply it once and the dispatcher only needs its id.
+          Runbook, tools and model belong in a file you review, not a webhook handler. Apply it once and the dispatcher needs only its id.
         </p>
         <p>
           <span class="font-medium text-[var(--color-text-primary)]">
             Put the identity in a Vault.
           </span>
-          The token that pushes should be a separate account with the least rights that still work. Swapping which account an agent acts as is then a field, not a redeploy.
+          The token that pushes should be its own account with the least rights that work, so changing identity is a field, not a redeploy.
         </p>
         <p>
           <span class="font-medium text-[var(--color-text-primary)]">
             Make the last step refuse you.
           </span>
-          Find the place in your pipeline where a human already signs off and let the agent stop there. A gate the agent is unable to pass beats a gate it is asked not to.
+          Let the agent stop where a human already signs off. A gate it is unable to pass beats one it is asked not to.
         </p>
         <p class="pt-1">
           <a
@@ -289,7 +289,7 @@
     Your on-call has a queue of small, obvious fixes.
   </h2>
   <p class="text-[var(--color-text-secondary)] mb-8 max-w-lg mx-auto">
-    They all start with reading the evidence and end with a diff somebody has to approve. Hire an agent for the middle.
+    Each starts with reading the evidence and ends with a diff somebody approves. Hire an agent for the middle.
   </p>
   <div class="flex flex-col sm:flex-row gap-3 justify-center">
     <a
@@ -306,7 +306,7 @@
     </a>
   </div>
   <p class="mt-10 text-xs text-[var(--color-text-muted)] max-w-2xl mx-auto leading-relaxed">
-    The estate is a private Kubernetes cluster run by one person, and the numbers are its own. Twelve fix pull requests were opened over the window and eight were merged, four of them the same rehearsal fault raised on purpose. Most incidents end with no pull request at all, because the agent decides the repository cannot fix them and says so. The agent's definition is public at <a
+    A private Kubernetes cluster run by one person, and the numbers are its own. Twelve fix pull requests opened in the window and eight merged, four of them the same rehearsal fault raised on purpose. Most incidents end with no pull request, because the agent decides the repository cannot fix them. Its definition is public at <a
       href="https://github.com/jhgaylor/agent-specs/blob/main/src/agents/specialists/engineering/estate-medic.ts"
       class="underline underline-offset-2 hover:text-[var(--color-text-secondary)]"
     >jhgaylor/agent-specs</a>.


### PR DESCRIPTION
The case study at `/case-studies/self-healing-infrastructure` carried 1,660 words of rendered prose. Every claim on it earns its place, so this is a compression rather than a cut: **1,290 words, 22% off**, with each number, mechanism and argument still stated once.

## Why not further

Of the 1,290 words that remain, roughly 350 are not prose: headings, button labels, the nine `mono` code fragments, six timestamps, four stat values, and the agent's 61-word verbatim quote. The movable prose went 1,311 → 941, a 28% cut, and past that every word left was carrying a fact. Halving the page would mean deleting propositions (the guardrails section, the primitives section, the "why nobody automated it" argument), which is a different change from this one.

## Where the words came from

| Block | Before | After |
|---|---|---|
| Hero subhead | 50 | 29 |
| Failure-class prose | 159 | 101 |
| Loop step bodies (9) | 269 | 154 |
| Guardrail rows (10) | 134 | 101 |
| Timeline bodies (6) | 143 | 106 |
| Primitive cards (4) | 161 | 117 |
| Build advice (3) | 110 | 69 |
| Footer note | 66 | 54 |

Three moves did most of it.

Sentences that shared a subject became one. Qualifiers that restated their own sentence went: "It is also, *exactly*, the shape of work…", "Most incidents end with no pull request *at all*".

Where a proposition appeared twice on the page, the weaker statement of it went and the stronger stayed. The hero no longer spells out that a human approves every merge, because "one small pull request it is unable to merge" says it and the guardrails prove it. Loop step 4 no longer explains that a GET-only token cannot be turned into a write, because the guardrail beside it does. Loop step 7 no longer argues that the gate is a mechanism rather than a policy, because that sentence is the heading over the section immediately below it.

The failure-class intro handed its three examples (a dropped variable, a lost secret reference, a bad image pin) to the Red card, where they now sit against the symptom they cause instead of ahead of it.

## Nothing factual moved

The headline clock, the six timeline stamps, the four headline numbers, the window they were counted over, the agent's verbatim root-cause quote and the disclosure footer are unchanged. `case_dispatch_example/0` is untouched.

## Checks

`mix format --check-formatted`, `mix compile --warnings-as-errors` and `mix credo --strict` are clean. `marketing_controller_test.exs` and `marketing_instance_test.exs` are green (46 tests) — they pin the hero clock against the timeline data, every loop-step title, every timestamp, every stat value, and the verbatim strings `422 on self-approval`, `install_members()` and `The sandbox has no kubectl and no kubeconfig.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)