### PR TITLE
feat(marketing): a code review bot, whole, on one screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,18 @@ upgrade, is in
 
 ### Added
 
+- **A code review bot, whole, at `/code-review-bot`.** The shortest useful
+  program anybody writes on this API, shown unabridged rather than described:
+  a GitHub webhook handler that upserts the reviewer for the repository it
+  just heard from and hires it. Two snippets, one 36 lines and one 39, and
+  the argument the page makes is the absent half. No runner pool, no queue,
+  no container image per repository and no per-pull-request state, because
+  an Environment carries the checkout, a Vault carries the credential and a
+  channel id carries the pull request. Both lengths are counted off the
+  snippets rather than typed, and the controller test pins every annotated
+  line to a line of the file above it. Like the other pitch pages, an
+  instance that is not the marketing site is sent to the manual's tour.
+
 - **A self-hosted runner can put each sandbox in its own Firecracker microVM.**
   `fountain runner --backend firecracker` replaces the sandbox directory with
   a microVM booted from a private copy of a base image, on a tap device

--- a/apps/fountain/lib/fountain_web/components/layouts/marketing.html.heex
+++ b/apps/fountain/lib/fountain_web/components/layouts/marketing.html.heex
@@ -97,6 +97,13 @@
         </a>
         <a
           :if={Fountain.Marketing.site?()}
+          href={~p"/code-review-bot"}
+          class="hover:text-[var(--color-text-secondary)] transition-colors"
+        >
+          Review bot
+        </a>
+        <a
+          :if={Fountain.Marketing.site?()}
           href={~p"/case-studies/self-healing-infrastructure"}
           class="hover:text-[var(--color-text-secondary)] transition-colors"
         >

--- a/apps/fountain/lib/fountain_web/controllers/marketing_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_controller.ex
@@ -1,13 +1,13 @@
 defmodule FountainWeb.MarketingController do
   @moduledoc """
   The public pages: `/`, `/integrations`, `/built-with`, `/self-hosted`,
-  `/case-studies/*`, `/terms` and `/privacy`.
+  `/code-review-bot`, `/case-studies/*`, `/terms` and `/privacy`.
 
   None of them is the same page on every deployment. `/` serves the
   product pitch on the marketing site and a plain front door everywhere else
-  (`Fountain.Marketing`); `/integrations`, `/built-with`, `/self-hosted` and
-  the case studies are the pitch's other pages and redirect into the manual on
-  any other instance;
+  (`Fountain.Marketing`); `/integrations`, `/built-with`, `/self-hosted`,
+  `/code-review-bot` and the case studies are the pitch's other pages and
+  redirect into the manual on any other instance;
   the legal pages render the operator's identity, or nothing at all
   (`Fountain.Legal`). A deployment is not the Fountain project, and these
   pages are the ones that would claim otherwise.
@@ -55,6 +55,24 @@ defmodule FountainWeb.MarketingController do
       )
     else
       redirect(conn, to: ~p"/docs/build")
+    end
+  end
+
+  # The shortest useful program anybody writes on this API, shown whole. Sales
+  # copy like the rest, so another deployment gets the manual's longer version
+  # of the same job rather than a page selling the hosted product.
+  def code_review_bot(conn, _params) do
+    if Fountain.Marketing.site?() do
+      render(conn, :code_review_bot,
+        layout: {FountainWeb.Layouts, :marketing},
+        page_title: "A code review bot · #{Fountain.Brand.name()}",
+        meta_description:
+          "A pull request opens, GitHub posts a webhook, and one API call hires " <>
+            "an agent that already has the checkout. The whole program is on the " <>
+            "page: no runner pool, no queue, no container image per repository."
+      )
+    else
+      redirect(conn, to: ~p"/docs/tour")
     end
   end
 

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
@@ -1216,4 +1216,253 @@ defmodule FountainWeb.MarketingHTML do
     });\
     """
   end
+
+  ## ─── /code-review-bot ──────────────────────────────────────────────────────
+  #
+  # The shortest useful thing anybody builds on this API, shown whole. Both
+  # snippets live here rather than in the template, because HEEx would read
+  # their braces, and the lengths the page quotes are counted off these
+  # strings so an edit cannot leave the prose claiming the old one.
+
+  @doc "The webhook handler. The page shows every line of it."
+  def review_bot_webhook do
+    """
+    // api/github/webhook.ts
+    import { Fountain } from "@agentshit/fountain-sdk";
+    import { verify } from "@octokit/webhooks-methods";
+
+    export async function POST(req: Request) {
+      const body = await req.text();
+      const signature = req.headers.get("x-hub-signature-256") ?? "";
+      const secret = process.env.GITHUB_WEBHOOK_SECRET!;
+      if (!(await verify(secret, body, signature))) {
+        return new Response("bad signature", { status: 401 });
+      }
+
+      const { action, pull_request: pr, repository: repo } = JSON.parse(body);
+      if (action !== "opened" && action !== "synchronize") {
+        return new Response("skipped");
+      }
+
+      // One client per request. It memoises name lookups, and the reviewer
+      // on the next line may be one line old.
+      const fountain = new Fountain();          // FOUNTAIN_API_KEY
+      await ensureReviewer(fountain, repo);
+
+      const run = fountain.run(
+        `Review pull request #${pr.number}. The checkout is at /work/repo. ` +
+          `Read the diff against origin/${pr.base.ref}, then leave one ` +
+          `review with inline comments on the lines you mean.`,
+        {
+          agent: `reviewer/${repo.full_name}`,  // model, machine, house rules
+          vault: "github-bot",                  // the identity it reviews as
+          channelId: `pr/${repo.full_name}/${pr.number}`,
+        },
+      );
+
+      await run.conversationId;   // booked, not finished
+      return new Response("reviewing");
+    }\
+    """
+  end
+
+  @doc "The reviewer itself, upserted by name on every event."
+  def review_bot_reviewer do
+    """
+    // Reconciled by name, so this is safe to run on every event: the first
+    // pull request out of a repository builds the reviewer, and every pull
+    // request after it changes nothing.
+    type Repo = { full_name: string; clone_url: string };
+
+    const ensureReviewer = (fountain: Fountain, repo: Repo) =>
+      fountain.api.request("POST", "/api/apply", {
+        body: {
+          resources: [
+            {
+              kind: "Environment",
+              name: `reviewer/${repo.full_name}`,
+              spec: {
+                repositories: [
+                  {
+                    url: repo.clone_url,
+                    mount_path: "/work/repo",
+                    secret_key: "GITHUB_TOKEN",
+                  },
+                ],
+              },
+            },
+            {
+              kind: "Agent",
+              name: `reviewer/${repo.full_name}`,
+              spec: {
+                runtime: "claude",
+                model: "anthropic/claude-opus-5",
+                environment: `reviewer/${repo.full_name}`,
+                system:
+                  "You review pull requests, and you post the review with " +
+                  "`gh`. Read the diff, not the whole repository. Name the " +
+                  "specific thing that is wrong and the line it is on. One " +
+                  "review per turn. Never approve.",
+              },
+            },
+          ],
+        },
+      });\
+    """
+  end
+
+  @doc "How long a snippet on this page is, counted rather than typed."
+  def review_bot_length(snippet) when is_binary(snippet),
+    do: snippet |> String.split("\n") |> length()
+
+  @doc "The five lines that are the product, with what each one buys."
+  def review_bot_anatomy do
+    [
+      %{
+        code: "ensureReviewer(fountain, repo)",
+        title: "The reviewer is a record, not a deployment.",
+        body:
+          "One POST to /api/apply, reconciled by name. The first pull request " <>
+            "out of a repository writes an Environment holding that checkout and " <>
+            "an Agent pointed at it. Every pull request after it is a no-op. " <>
+            "Point the webhook at a second repository and there is no second step."
+      },
+      %{
+        code: ~s(agent: "reviewer/<owner>/<repo>"),
+        title: "One name carries the whole configuration.",
+        body:
+          "Which model reads the diff, which machine it wakes up on, which " <>
+            "repository is already cloned on that machine, and the house rules " <>
+            "it reviews by. Change any of them and no handler is redeployed."
+      },
+      %{
+        code: ~s(vault: "github-bot"),
+        title: "The credential goes to the machine, not to the model.",
+        body:
+          "Fountain decrypts the vault into the sandbox as the sandbox spawns. " <>
+            "The token never enters the prompt, the model's context or the stored " <>
+            "transcript. Put a read-only token in that vault and the same bot can " <>
+            "comment and nothing else."
+      },
+      %{
+        code: "channelId: `pr/<repo>/<number>`",
+        title: "The second push lands on the first machine.",
+        body:
+          "A channel id resumes the live conversation bound to it instead of " <>
+            "opening a new one. The checkout is still there, on the branch, and " <>
+            "the reviewer still holds what it said about the last commit and why."
+      },
+      %{
+        code: "await run.conversationId",
+        title: "It returns once the work is booked.",
+        body:
+          "Not once the review is written. GitHub allows a webhook ten seconds " <>
+            "and this answers in the time of one API call. The turn carries on in " <>
+            "the sandbox after the handler has returned."
+      }
+    ]
+  end
+
+  @doc "What a review bot usually needs, against what this one needed."
+  def review_bot_absent do
+    [
+      %{
+        normally: "A machine, and something that decides how many to keep warm.",
+        here: "A sandbox lasts as long as the review does. Nothing is warm between pull requests."
+      },
+      %{
+        normally: "A container image per repository, rebuilt when the toolchain moves.",
+        here:
+          "An Environment names the repository and the packages. The bot writes it the first time it sees the repo."
+      },
+      %{
+        normally: "A checkout on that machine, and a token that is allowed to fetch it.",
+        here:
+          "repositories[] clones before the agent wakes. secret_key names the secret the clone authenticates with."
+      },
+      %{
+        normally: "Somewhere for the GitHub token to sit that the worker can read.",
+        here:
+          "A Vault, decrypted into the sandbox at spawn and redacted out of anything the run prints."
+      },
+      %{
+        normally: "A queue, so a busy morning drops no pull request.",
+        here:
+          "One HTTP call per pull request. Concurrency is funded by the balance, and a full fleet answers 503."
+      },
+      %{
+        normally:
+          "Per-pull-request state, so a second push reviews the branch rather than the world.",
+        here: "channel_id. The same pull request resumes the same conversation on the same disk."
+      },
+      %{
+        normally: "A reaper, because what you forget to clean up is what you pay for.",
+        here: "Idle sandboxes park themselves, and the reaper destroys what the ceiling says to."
+      }
+    ]
+  end
+
+  @doc "Everything between reading this page and the first review."
+  def review_bot_setup do
+    [
+      %{
+        step: "1",
+        title: "Give it a token.",
+        body:
+          "One fine-grained GitHub token, scoped to the repositories you want " <>
+            "reviewed. Set it under two keys, because two things read it: the " <>
+            "clone reads GITHUB_TOKEN and gh reads GH_TOKEN.",
+        mono: "fountain vault create github-bot"
+      },
+      %{
+        step: "2",
+        title: "Deploy the handler.",
+        body:
+          "Anywhere that serves one HTTP POST. It holds no state, so one instance " <>
+            "and fifty behave the same. Two environment variables, and neither of " <>
+            "them is a GitHub credential.",
+        mono: "FOUNTAIN_API_KEY=...  GITHUB_WEBHOOK_SECRET=..."
+      },
+      %{
+        step: "3",
+        title: "Add the webhook.",
+        body:
+          "Repository settings, Webhooks, Add webhook. Pull request events, " <>
+            "content type application/json, the same secret. The next pull " <>
+            "request opened is the first one reviewed.",
+        mono: "Settings → Webhooks → Pull requests"
+      }
+    ]
+  end
+
+  @doc "The variations that are one field rather than one rewrite."
+  def review_bot_variations do
+    [
+      %{
+        want: "It comments, and can never push.",
+        change:
+          "A read-only token in the vault. The sandbox holds the rights the credential holds."
+      },
+      %{
+        want: "A harder reader on the risky directories.",
+        change: "model on the Agent. Nothing else in the program knows which model it was."
+      },
+      %{
+        want: "Two opinions on one diff.",
+        change: "Call run() twice with two agent names. Each opinion gets its own sandbox."
+      },
+      %{
+        want: "It runs the suite before it comments.",
+        change: "setup_script on the Environment, and one more sentence in system."
+      },
+      %{
+        want: "A clean reviewer for one pull request.",
+        change: "fresh: true beside the channel id. The conversation it skips stays where it is."
+      },
+      %{
+        want: "A review on a schedule rather than on a push.",
+        change: "The same call, from cron. A conversation does not care what opened it."
+      }
+    ]
+  end
 end

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/code_review_bot.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/code_review_bot.html.heex
@@ -1,0 +1,269 @@
+<%!-- Hero. The code is the hero, so it is above the fold and unabridged.
+      The length is counted off the snippet in review_bot_length/1 rather
+      than typed here, because a page that boasts a line count is the one
+      page where the count must not drift. --%>
+<section class="max-w-5xl mx-auto px-6 pt-16 pb-10 text-center">
+  <p class="mb-4 text-sm font-medium uppercase tracking-wide text-[var(--color-text-muted)]">
+    One webhook · one API call · no runner
+  </p>
+  <h1 class="text-4xl sm:text-5xl font-bold tracking-tight text-[var(--color-text-primary)] mb-5 leading-tight">
+    A code review bot, whole, on one screen.
+  </h1>
+  <p class="text-lg sm:text-xl text-[var(--color-text-secondary)] max-w-2xl mx-auto">
+    A pull request opens. GitHub posts a webhook. Your handler makes one call, and an agent wakes up on a machine that already has the checkout on it, reads the diff and leaves a review with inline comments. Below is the program. All of it.
+  </p>
+</section>
+
+<section class="max-w-4xl mx-auto px-6 pb-6">
+  <pre
+    class="rounded-xl border border-[var(--color-border)] bg-[var(--color-code-bg)] text-[var(--color-code-text)] p-5 sm:p-6 text-xs sm:text-sm leading-relaxed overflow-x-auto"
+    phx-no-format
+  ><code>{review_bot_webhook()}</code></pre>
+  <p class="mt-4 text-center text-sm text-[var(--color-text-muted)]">
+    {review_bot_length(review_bot_webhook())} lines, blank ones included. There is no worker, no queue and no second service. The one function it calls that you have not seen yet is <a
+      href="#reviewer"
+      class="underline underline-offset-2 hover:text-[var(--color-text-secondary)]"
+    >further down the page</a>, and it is a single POST.
+  </p>
+  <div class="mt-8 flex flex-col sm:flex-row gap-3 justify-center">
+    <a
+      href={~p"/auth/register"}
+      class="inline-flex items-center justify-center px-6 py-3 rounded-lg bg-[var(--color-brand)] text-white font-medium hover:bg-[var(--color-brand-hover)] transition-colors text-sm"
+    >
+      Get an API key
+    </a>
+    <a
+      href="#setup"
+      class="inline-flex items-center justify-center px-6 py-3 rounded-lg border border-[var(--color-border)] text-[var(--color-text-primary)] font-medium hover:bg-[var(--color-bg-2)] transition-colors text-sm"
+    >
+      What setting it up takes
+    </a>
+  </div>
+</section>
+
+<%!-- Anatomy. Five lines out of the file above, each with what it bought. --%>
+<section class="bg-[var(--color-bg-1)] border-y border-[var(--color-border)] mt-10">
+  <div class="max-w-5xl mx-auto px-6 py-16">
+    <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-3 text-center">
+      Five of those lines are the product.
+    </h2>
+    <p class="text-center text-[var(--color-text-secondary)] max-w-xl mx-auto mb-12">
+      The rest is reading a webhook body. Here is what each of the five buys.
+    </p>
+    <div class="max-w-3xl mx-auto space-y-4">
+      <div
+        :for={line <- review_bot_anatomy()}
+        class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-5 sm:p-6"
+        data-role="anatomy-line"
+      >
+        <div class="overflow-x-auto">
+          <code
+            class="inline-block whitespace-nowrap text-xs text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1.5 py-0.5"
+            phx-no-format
+          >{line.code}</code>
+        </div>
+        <h3 class="mt-3 font-semibold text-[var(--color-text-primary)]">{line.title}</h3>
+        <p class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">{line.body}</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<%!-- The reviewer itself. The handler above hires it; this writes it down. --%>
+<section id="reviewer" class="max-w-5xl mx-auto px-6 py-16 scroll-mt-6">
+  <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-3 text-center">
+    The reviewer, written down.
+  </h2>
+  <p class="text-center text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-12">
+    A machine with the repository on it, and an agent pointed at that machine. Applying it is an upsert keyed on the name, so the handler can do it on every event and mean it only on the first.
+  </p>
+  <div class="max-w-4xl mx-auto">
+    <pre
+      class="rounded-xl border border-[var(--color-border)] bg-[var(--color-code-bg)] text-[var(--color-code-text)] p-5 sm:p-6 text-xs sm:text-sm leading-relaxed overflow-x-auto"
+      phx-no-format
+    ><code>{review_bot_reviewer()}</code></pre>
+    <p class="mt-4 text-center text-sm text-[var(--color-text-muted)]">
+      {review_bot_length(review_bot_reviewer())} lines, sent on every pull request and acted on for the first.
+    </p>
+    <div class="mt-10 grid md:grid-cols-3 gap-6 text-sm text-[var(--color-text-secondary)]">
+      <div>
+        <p class="font-medium text-[var(--color-text-primary)] mb-2">
+          A private repository needs secret_key.
+        </p>
+        <p class="leading-relaxed">
+          It names the secret the clone authenticates with, and that secret comes off the vault attached at launch. Leave it out on a private repository and the conversation still starts, on an empty directory, with an agent that tells you it cannot find the code.
+        </p>
+      </div>
+      <div>
+        <p class="font-medium text-[var(--color-text-primary)] mb-2">
+          The system prompt is the review policy.
+        </p>
+        <p class="leading-relaxed">
+          It is the one place that says what a review is here. Read the diff and not the repository, name the line, never approve. Editing it changes every repository the bot watches, and redeploys nothing.
+        </p>
+      </div>
+      <div>
+        <p class="font-medium text-[var(--color-text-primary)] mb-2">Prefer this in YAML?</p>
+        <p class="leading-relaxed">
+          The same two records are a fountain.yml you apply once from CI. The handler is then the whole program, with the call to ensureReviewer deleted.
+        </p>
+        <a
+          href={~p"/docs/primitives"}
+          class="mt-3 inline-block font-medium text-[var(--color-text-primary)] underline underline-offset-2 hover:text-[var(--color-brand)]"
+        >
+          The four primitives →
+        </a>
+      </div>
+    </div>
+  </div>
+</section>
+
+<%!-- The absent half. What the reader would have built instead. --%>
+<section class="bg-[var(--color-bg-1)] border-y border-[var(--color-border)]">
+  <div class="max-w-5xl mx-auto px-6 py-16">
+    <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-3 text-center">
+      The short version is short because of what is missing.
+    </h2>
+    <p class="text-center text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-12">
+      None of the left-hand column is hard. All of it is a week, and then it is yours to keep running.
+    </p>
+    <div class="max-w-3xl mx-auto space-y-4">
+      <div
+        :for={row <- review_bot_absent()}
+        class="grid sm:grid-cols-2 gap-4 sm:gap-6 rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-5"
+        data-role="absent-row"
+      >
+        <div>
+          <p class="text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)] mb-1.5">
+            You would build
+          </p>
+          <p class="text-sm text-[var(--color-text-secondary)] leading-relaxed">{row.normally}</p>
+        </div>
+        <div class="sm:border-l sm:border-[var(--color-border)] sm:pl-6">
+          <p class="text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)] mb-1.5">
+            You wrote
+          </p>
+          <p class="text-sm text-[var(--color-text-primary)] leading-relaxed">{row.here}</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<%!-- The follow-up push. The tour measures the same mechanism on a different
+      job, and the numbers stay attributed to it rather than being restated
+      here as if this bot had been timed. --%>
+<section class="max-w-5xl mx-auto px-6 py-16">
+  <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-3 text-center">
+    The second push is where it pays.
+  </h2>
+  <div class="max-w-2xl mx-auto space-y-5 text-[var(--color-text-secondary)] leading-relaxed">
+    <p>
+      A review bot that starts from nothing on every push is a bot that reads the whole branch every time, forgets what it already said, and says it again. The channel id is what stops that. The same pull request resumes the same conversation, and the conversation still has its machine.
+    </p>
+    <p>
+      The checkout is on disk, on the branch, with the last commit already fetched. The agent's own session still holds what it flagged an hour ago and why it let the rest through. So the second review is about the second push, which is what a person reviewing the same pull request twice would do.
+    </p>
+    <p>
+      The
+      <a
+        href={~p"/docs/tour"}
+        class="underline underline-offset-2 hover:text-[var(--color-text-primary)]"
+      >
+        guided tour
+      </a>
+      measures this mechanism on a different job. Opening a pull request from cold took 43 seconds. Revising it on the same machine took 13 more.
+    </p>
+  </div>
+</section>
+
+<%!-- Setup. --%>
+<section
+  id="setup"
+  class="bg-[var(--color-bg-1)] border-y border-[var(--color-border)] scroll-mt-6"
+>
+  <div class="max-w-5xl mx-auto px-6 py-16">
+    <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-3 text-center">
+      Three steps, and the third one is on GitHub.
+    </h2>
+    <p class="text-center text-[var(--color-text-secondary)] max-w-xl mx-auto mb-12">
+      Nothing here is provisioned in advance. The reviewer for a repository is written the first time a pull request from it arrives.
+    </p>
+    <ol class="max-w-3xl mx-auto space-y-4">
+      <li
+        :for={step <- review_bot_setup()}
+        class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-5 sm:p-6 flex items-start gap-4"
+        data-role="setup-step"
+      >
+        <span class="flex-shrink-0 size-7 rounded-full bg-[var(--color-brand)] text-white text-sm font-semibold flex items-center justify-center">
+          {step.step}
+        </span>
+        <div class="min-w-0">
+          <h3 class="font-semibold text-[var(--color-text-primary)]">{step.title}</h3>
+          <p class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">
+            {step.body}
+          </p>
+          <div class="mt-3 overflow-x-auto">
+            <code
+              class="inline-block whitespace-nowrap text-xs text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1.5 py-0.5"
+              phx-no-format
+            >{step.mono}</code>
+          </div>
+        </div>
+      </li>
+    </ol>
+    <p class="mt-8 text-center text-sm text-[var(--color-text-muted)]">
+      For the second repository, do step three again. There is no step four.
+    </p>
+  </div>
+</section>
+
+<%!-- Variations. Each one is a field, which is the argument the page is
+      making: the program stopped being where the behaviour lives. --%>
+<section class="max-w-5xl mx-auto px-6 py-16">
+  <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-3 text-center">
+    Everything you would want next is a field.
+  </h2>
+  <p class="text-center text-[var(--color-text-secondary)] max-w-xl mx-auto mb-12">
+    The handler above does not change for any of these.
+  </p>
+  <div class="max-w-3xl mx-auto divide-y divide-[var(--color-border)] rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)]">
+    <div
+      :for={row <- review_bot_variations()}
+      class="grid sm:grid-cols-[1fr_1.3fr] gap-2 sm:gap-6 p-5"
+      data-role="variation-row"
+    >
+      <p class="text-sm font-medium text-[var(--color-text-primary)]">{row.want}</p>
+      <p class="text-sm text-[var(--color-text-secondary)] leading-relaxed">{row.change}</p>
+    </div>
+  </div>
+</section>
+
+<%!-- Footer CTA --%>
+<section class="bg-[var(--color-bg-1)] border-t border-[var(--color-border)]">
+  <div class="max-w-5xl mx-auto px-6 py-20 text-center">
+    <h2 class="text-2xl sm:text-3xl font-bold text-[var(--color-text-primary)] mb-4">
+      The review bot is the small one.
+    </h2>
+    <p class="text-[var(--color-text-secondary)] mb-8 max-w-lg mx-auto">
+      Same handler, different prompt: the migration that nobody wants to write, the flaky test that fails once a week, the dependency bump with the changelog read. Each one is an agent with a machine and a credential.
+    </p>
+    <div class="flex flex-col sm:flex-row gap-3 justify-center">
+      <a
+        href={~p"/auth/register"}
+        class="inline-flex items-center justify-center px-6 py-3 rounded-lg bg-[var(--color-brand)] text-white font-medium hover:bg-[var(--color-brand-hover)] transition-colors text-sm"
+      >
+        Run your first agent free
+      </a>
+      <a
+        href={~p"/case-studies/self-healing-infrastructure"}
+        class="inline-flex items-center justify-center px-6 py-3 rounded-lg border border-[var(--color-border)] text-[var(--color-text-primary)] font-medium hover:bg-[var(--color-bg-2)] transition-colors text-sm"
+      >
+        The same shape, in production
+      </a>
+    </div>
+    <p class="mt-10 text-xs text-[var(--color-text-muted)] max-w-2xl mx-auto leading-relaxed">
+      The code on this page is the shortest form of the job rather than a hardened one. It trusts the payload once the signature checks out, it reviews every pull request a repository opens, and it says nothing back to GitHub about how the review went. Each of those is a few more lines in the same handler.
+    </p>
+  </div>
+</section>

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -335,10 +335,20 @@
         </span>
       </li>
     </ol>
-    <pre
-      class="rounded-xl border border-[var(--color-border)] bg-[var(--color-code-bg)] text-[var(--color-code-text)] p-5 text-sm leading-relaxed overflow-x-auto"
-      phx-no-format
-    ><code>{sdk_example()}</code></pre>
+    <div>
+      <pre
+        class="rounded-xl border border-[var(--color-border)] bg-[var(--color-code-bg)] text-[var(--color-code-text)] p-5 text-sm leading-relaxed overflow-x-auto"
+        phx-no-format
+      ><code>{sdk_example()}</code></pre>
+      <%!-- The shortest finished program on the API, for the reader who wants
+            to see the call in a job rather than on its own. --%>
+      <a
+        href={~p"/code-review-bot"}
+        class="mt-4 inline-block text-sm font-medium text-[var(--color-text-primary)] underline underline-offset-2 hover:text-[var(--color-brand)]"
+      >
+        See it finished: a code review bot in one file →
+      </a>
+    </div>
   </div>
 </section>
 

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -158,6 +158,7 @@ defmodule FountainWeb.Router do
     get "/integrations", MarketingController, :integrations
     get "/built-with", MarketingController, :built_with
     get "/self-hosted", MarketingController, :self_hosted
+    get "/code-review-bot", MarketingController, :code_review_bot
     # One study today, so the bare path redirects to it rather than 404ing on
     # the segment a reader will inevitably chop off the URL.
     get "/case-studies", MarketingController, :case_studies

--- a/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
@@ -266,6 +266,107 @@ defmodule FountainWeb.MarketingControllerTest do
     end
   end
 
+  describe "GET /code-review-bot" do
+    test "shows the whole program and every line it annotates", %{conn: conn} do
+      body = conn |> get(~p"/code-review-bot") |> html_response(200)
+
+      assert body =~ "A code review bot, whole, on one screen."
+
+      # The page's claim is that the program is all there, so assert the
+      # snippets themselves rather than a sentence about them. Both are kept
+      # out of the template because HEEx would read their braces.
+      webhook = FountainWeb.MarketingHTML.review_bot_webhook()
+      assert body =~ "x-hub-signature-256"
+      assert body =~ "/api/apply"
+      assert body =~ "await run.conversationId"
+
+      # The length is counted off the snippet, never typed. An edit that adds
+      # a line and leaves the prose behind fails here.
+      assert body =~ "#{FountainWeb.MarketingHTML.review_bot_length(webhook)} lines"
+
+      for line <- FountainWeb.MarketingHTML.review_bot_anatomy() do
+        assert body =~ line.title, "missing anatomy line #{line.title}"
+      end
+
+      # Every annotated line is a line of the file above it. A card that
+      # explains code the page does not show is worse than no card.
+      assert String.contains?(webhook, "ensureReviewer(fountain, repo)")
+      assert String.contains?(webhook, ~s(vault: "github-bot"))
+      assert String.contains?(webhook, "await run.conversationId")
+    end
+
+    test "keeps setup, the absent half and the one-field changes on the page", %{conn: conn} do
+      body = conn |> get(~p"/code-review-bot") |> html_response(200)
+
+      for step <- FountainWeb.MarketingHTML.review_bot_setup() do
+        assert body =~ step.title, "missing setup step #{step.title}"
+      end
+
+      for row <- FountainWeb.MarketingHTML.review_bot_absent() do
+        assert body =~ row.here, "missing absent row #{row.here}"
+      end
+
+      for row <- FountainWeb.MarketingHTML.review_bot_variations() do
+        assert body =~ row.want, "missing variation #{row.want}"
+      end
+    end
+
+    test "the reviewer it applies is one the API would accept", %{conn: conn} do
+      body = conn |> get(~p"/code-review-bot") |> html_response(200)
+      reviewer = FountainWeb.MarketingHTML.review_bot_reviewer()
+
+      # The kinds the manifest endpoint reconciles, and the field names it
+      # actually reads. `system`, not `system_prompt`; `environment`, which
+      # Fountain.Manifest resolves to an environment_id by name.
+      for kind <- ~w(Environment Agent) do
+        assert kind in Fountain.Manifest.kinds()
+        assert String.contains?(reviewer, ~s(kind: "#{kind}"))
+      end
+
+      assert String.contains?(reviewer, "system:")
+      assert String.contains?(reviewer, "environment:")
+      assert String.contains?(reviewer, "secret_key:")
+
+      # The model has to satisfy the provider/model format the agent
+      # changeset enforces, or the first pull request applies nothing.
+      assert [[model]] = Regex.scan(~r/model: "([^"]+)"/, reviewer, capture: :all_but_first)
+      assert model =~ ~r{^[a-z0-9_-]+/[a-z0-9._-]+$}
+
+      assert body =~ "The reviewer, written down."
+    end
+
+    test "carries its own card", %{conn: conn} do
+      body = conn |> get(~p"/code-review-bot") |> html_response(200)
+
+      assert body =~ ~s(<meta property="og:title" content="A code review bot · Fountain")
+
+      assert body =~
+               ~s(<meta property="og:url" content="http://localhost:4000/code-review-bot")
+    end
+
+    test "every link into the manual resolves to a page", %{conn: conn} do
+      body = conn |> get(~p"/code-review-bot") |> html_response(200)
+
+      links =
+        ~r/href="\/docs\/([^"#]+)/
+        |> Regex.scan(body)
+        |> Enum.map(fn [_, slug] -> slug end)
+        |> Enum.uniq()
+
+      assert links != []
+
+      for slug <- links do
+        assert match?({:ok, _}, Fountain.Docs.get(slug)), "/docs/#{slug} is not a page"
+      end
+    end
+
+    test "the homepage and the marketing footer link to it", %{conn: conn} do
+      body = conn |> get(~p"/") |> html_response(200)
+      assert body =~ ~p"/code-review-bot"
+      assert body =~ "a code review bot in one file"
+    end
+  end
+
   describe "GET /case-studies/self-healing-infrastructure" do
     test "renders the loop, the guardrails and the incident", %{conn: conn} do
       body = conn |> get(~p"/case-studies/self-healing-infrastructure") |> html_response(200)

--- a/apps/fountain/test/fountain_web/controllers/marketing_instance_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_instance_test.exs
@@ -110,6 +110,18 @@ defmodule FountainWeb.MarketingInstanceTest do
     end
   end
 
+  describe "GET /code-review-bot where the deployment is not the marketing site" do
+    test "sends the visitor to the manual's own walkthrough of the job", %{conn: conn} do
+      Application.put_env(:fountain, :marketing_site, false)
+
+      conn = get(conn, ~p"/code-review-bot")
+      assert redirected_to(conn) == ~p"/docs/tour"
+
+      # The layout drops the link too: a nav entry to a redirect is a dead end.
+      refute conn |> get(~p"/") |> html_response(200) =~ ~p"/code-review-bot"
+    end
+  end
+
   describe "GET /case-studies where the deployment is not the marketing site" do
     test "sends the visitor to the manual rather than somebody else's sales copy", %{conn: conn} do
       Application.put_env(:fountain, :marketing_site, false)


### PR DESCRIPTION
`/code-review-bot`, the influence being Stripe's old `/dev/payments`: the code
is the hero and the page is mostly the code.

A pull request opens, GitHub posts a webhook, the handler upserts the reviewer
for the repository it just heard from and hires it. Both halves are on the
page unabridged: a 36-line handler and a 39-line `ensureReviewer`. The
argument is the absent half. There is no runner pool, no queue, no container
image per repository and no per-pull-request state, because an Environment
carries the checkout, a Vault carries the credential and a channel id carries
the pull request.

Sections: the file, the five lines that are the product, the reviewer written
down, what you did not build, why the second push pays, three setup steps, six
one-field variations.

## The code on the page is real API shape

Checked against the code rather than written from memory:

- `system`, not `system_prompt`, and `environment` by name, which
  `Fountain.Manifest` resolves to an `environment_id` on apply.
- `secret_key` on the repository entry, which the tour learned the hard way is
  what a private clone needs.
- `anthropic/claude-opus-5`, which satisfies the `provider/model` format the
  agent changeset enforces.
- `POST /api/apply` is reconciled by name, so calling it on every event is a
  no-op after the first pull request out of a repository.

One trap the snippet handles on purpose: the SDK's name→id resolver memoizes
its listing per client and only `Collection.create` invalidates it, so a
long-lived process that applies an agent through the raw escape hatch and then
resolves it by name reads a stale list. The handler builds one client per
request, and the comment on that line says why.

## Guardrails

- Both snippets live in `MarketingHTML`, not the template, because HEEx reads
  their braces.
- The two line counts are counted off the strings by `review_bot_length/1`.
  An edit that adds a line cannot leave the prose claiming the old count.
- The controller test asserts every annotated line is a line of the file above
  it, that the manifest uses the field names `Fountain.Manifest` reads, and
  that the model matches the changeset's format.
- Same rule as the other pitch pages: an instance that is not the marketing
  site redirects to `/docs/tour`, and the layout drops the link rather than
  pointing at a redirect.

## Honest about what is not claimed

The code is unrun. Every primitive it uses is the verified one from
`docs/tour.md`, but nobody has pointed this handler at a live webhook, and
nothing on the page says otherwise. The only timings quoted (43 seconds cold,
13 more on the same machine) stay attributed to the tour, which measured them
on a different job.

## Gates

`mix precommit` green: 4105 tests, 0 failures; credo strict clean; dialyzer 0
errors; format clean. `docs_test` re-run after the CHANGELOG edit, since a
relative link there resolves under `/docs`. Rendered and read end to end in
light and dark at 1280px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
