### PR TITLE
docs(primitives): redraw the diagram as three stages, and pin its two copies

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A multi-tenant API and UI for managing agents, repos, secrets, and conversations
 
 ## In one picture
 
-<img src="docs/images/primitives.svg" alt="Three templates and one machine: Agent, Environment and Vault are rows written once; a Conversation runs the Agent on a sandbox that Fountain builds from the Environment; secrets merge, the Vault winning; on a hosted account with the egress broker on, a bound secret goes to the broker and the sandbox gets a placeholder." width="740">
+<img src="docs/images/primitives.svg" alt="Three templates, one machine, in three stages. Stage one, write once: Agent, Environment and Vault are rows a tenant writes and reuses. Stage two, at launch: Fountain builds the machine, merges the Environment's secrets with the Vault's and the Vault wins, and starts the agent's runtime. Stage three, the machine: a sandbox holds the merged secrets as environment variables and runs one or more Conversations, each with its own transcript, on that one machine. The next turn lands on the same machine, an idle machine parks, and the concurrency ceiling reclaims it. On a hosted account with the egress broker on, the real values go to the broker instead, the sandbox gets a placeholder, and the sandbox reaches the internet only through the broker." width="740">
 
 Agent, Environment and Vault are templates: rows you write once and use many
 times. A Conversation is a run of an Agent on a machine that Fountain builds,

--- a/apps/fountain/test/fountain/docs_test.exs
+++ b/apps/fountain/test/fountain/docs_test.exs
@@ -419,6 +419,84 @@ defmodule Fountain.DocsTest do
     end
   end
 
+  # The primitives diagram exists twice: as a file for the README, which GitHub
+  # renders on a page whose theme an <img> cannot read, and inline in
+  # docs/primitives.md, where `currentColor` follows the manual's theme. Two
+  # copies of one drawing drift, and the drift is invisible until somebody
+  # opens the other one. These pin the copies to each other and to the exact
+  # three differences that are allowed.
+  describe "the primitives diagram, in both its copies" do
+    @svg_file Path.join(@repo_root, "docs/images/primitives.svg")
+    @svg_page Path.join(@repo_root, "docs/primitives.md")
+
+    test "the inline copy is the file, minus the background and in currentColor" do
+      file = File.read!(@svg_file)
+      inline = inline_svg()
+
+      expected =
+        file
+        |> String.replace(~r/\A<svg\b[^>]*>/, "")
+        |> String.replace(~r|\n\s*<rect width="740" height="336" fill="#ffffff"/>|, "",
+          global: false
+        )
+        |> String.replace("#1b2530", "currentColor")
+        |> String.trim()
+
+      actual = inline |> String.replace(~r/\A<svg\b[^>]*>/, "") |> String.trim()
+
+      assert actual == expected,
+             "docs/primitives.md's inline SVG has drifted from docs/images/primitives.svg"
+    end
+
+    test "the file paints its own background, and the inline copy does not" do
+      # An <img> on github.com cannot inherit a theme, so the file carries a
+      # white ground rather than turning into invisible dark-on-dark.
+      assert File.read!(@svg_file) =~ ~s(<rect width="740" height="336" fill="#ffffff"/>)
+      refute inline_svg() =~ ~s(fill="#ffffff")
+      refute inline_svg() =~ "#1b2530"
+    end
+
+    test "one description serves the file, the inline copy and the README" do
+      label = aria_label(File.read!(@svg_file))
+
+      assert String.length(label) > 200,
+             "the description is the whole picture for a screen reader"
+
+      assert label == aria_label(inline_svg())
+
+      readme = File.read!(Path.join(@repo_root, "README.md"))
+      assert readme =~ ~s(alt="#{label}"), "README.md's alt text has drifted from the drawing"
+    end
+
+    test "the drawing names every stage the caption and the page describe" do
+      file = File.read!(@svg_file)
+
+      for stage <- ["1 · WRITE ONCE", "2 · AT LAUNCH", "3 · THE MACHINE"] do
+        assert file =~ stage, "the diagram lost stage #{stage}"
+      end
+
+      # The four primitives this page exists to explain, plus the one rule the
+      # prose below the figure calls the reason the division works.
+      for primitive <- ~w(Agent Environment Vault Conversation Sandbox) do
+        assert file =~ ">#{primitive}<", "the diagram lost #{primitive}"
+      end
+
+      assert file =~ "vault wins"
+    end
+
+    defp inline_svg do
+      page = File.read!(@svg_page)
+      start = :binary.match(page, "<svg") |> elem(0)
+      {stop, len} = :binary.match(page, "</svg>")
+      binary_part(page, start, stop + len - start)
+    end
+
+    defp aria_label(svg) do
+      [_, label] = Regex.run(~r/aria-label="([^"]*)"/, svg)
+      label
+    end
+  end
+
   describe "Compiler" do
     test "slug_for strips .md and index" do
       assert Compiler.slug_for("index.md") == ""

--- a/docs/images/primitives.svg
+++ b/docs/images/primitives.svg
@@ -1,62 +1,61 @@
-<svg viewBox="0 0 740 352" role="img" aria-label="Three templates and one machine. Agent, Environment and Vault are rows a tenant writes once. When a conversation starts, Fountain builds a sandbox from the Environment, runs the Agent on it as a conversation, and merges the Environment's and the Vault's secrets, the Vault winning. On a hosted account with the egress broker on, a bound secret goes to the broker and the sandbox gets a placeholder; the sandbox reaches the internet only through the broker, which attaches the value. On any other account the secrets enter the sandbox as environment variables." xmlns="http://www.w3.org/2000/svg">
-  <rect width="740" height="352" fill="#ffffff"/>
+<svg viewBox="0 0 740 336" role="img" aria-label="Three templates, one machine, in three stages. Stage one, write once: Agent, Environment and Vault are rows a tenant writes and reuses. Stage two, at launch: Fountain builds the machine, merges the Environment's secrets with the Vault's and the Vault wins, and starts the agent's runtime. Stage three, the machine: a sandbox holds the merged secrets as environment variables and runs one or more Conversations, each with its own transcript, on that one machine. The next turn lands on the same machine, an idle machine parks, and the concurrency ceiling reclaims it. On a hosted account with the egress broker on, the real values go to the broker instead, the sandbox gets a placeholder, and the sandbox reaches the internet only through the broker." xmlns="http://www.w3.org/2000/svg">
+  <rect width="740" height="336" fill="#ffffff"/>
   <defs>
     <marker id="pr-a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#1b2530"/></marker>
     <marker id="pr-b" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#c98a2b"/></marker>
   </defs>
   <g fill="none" stroke="#1b2530" stroke-width="1.4">
-    <rect x="14" y="30" width="196" height="52" rx="8" stroke="#8a93a3"/>
-    <rect x="14" y="110" width="196" height="52" rx="8" stroke="#8a93a3"/>
-    <rect x="14" y="190" width="196" height="52" rx="8" stroke="#8a93a3"/>
-    <rect x="270" y="176" width="196" height="66" rx="8" stroke="#2f8fb3" stroke-width="1.8"/>
-    <rect x="510" y="16" width="216" height="196" rx="8" stroke="#2f8fb3" stroke-width="1.8"/>
-    <rect x="522" y="44" width="96" height="42" rx="6"/>
-    <rect x="626" y="44" width="88" height="42" rx="6"/>
-    <rect x="522" y="110" width="192" height="42" rx="6" stroke-dasharray="4 3"/>
-    <rect x="522" y="160" width="192" height="40" rx="6" stroke-dasharray="4 3"/>
-    <rect x="510" y="262" width="216" height="52" rx="8" stroke="#c98a2b" stroke-width="1.8" stroke-dasharray="6 4"/>
+    <rect x="14" y="32" width="192" height="50" rx="8" stroke="#8a93a3"/>
+    <rect x="14" y="96" width="192" height="50" rx="8" stroke="#8a93a3"/>
+    <rect x="14" y="160" width="192" height="50" rx="8" stroke="#8a93a3"/>
+    <rect x="252" y="74" width="190" height="94" rx="8" stroke="#2f8fb3" stroke-width="1.8"/>
+    <rect x="490" y="32" width="236" height="182" rx="8" stroke="#2f8fb3" stroke-width="1.8"/>
+    <rect x="502" y="62" width="212" height="40" rx="6" stroke-dasharray="4 3"/>
+    <rect x="502" y="112" width="102" height="48" rx="6"/>
+    <rect x="612" y="112" width="102" height="48" rx="6"/>
+    <rect x="502" y="170" width="212" height="34" rx="6" stroke-dasharray="4 3"/>
+    <rect x="490" y="252" width="236" height="50" rx="8" stroke="#c98a2b" stroke-width="1.8" stroke-dasharray="6 4"/>
   </g>
   <g font-family="ui-monospace, Menlo, monospace" fill="#1b2530">
-    <text x="14" y="20" font-size="10.5" fill="#8a93a3">TEMPLATES · rows, written once</text>
-    <text x="24" y="50" font-size="12.5" font-weight="600">Agent</text>
-    <text x="24" y="66" font-size="10" fill="#8a93a3">model, runtime, skills</text>
-    <text x="24" y="130" font-size="12.5" font-weight="600">Environment</text>
-    <text x="24" y="146" font-size="10" fill="#8a93a3">packages, repos, secrets</text>
-    <text x="24" y="210" font-size="12.5" font-weight="600">Vault</text>
-    <text x="24" y="226" font-size="10" fill="#8a93a3">secret overrides, per run</text>
-    <text x="282" y="196" font-size="12.5" font-weight="600" fill="#2f8fb3">Fountain, at launch</text>
-    <text x="282" y="212" font-size="10">merge env ∪ vault, vault wins</text>
-    <text x="282" y="228" font-size="10">split: broker or sandbox</text>
-    <text x="510" y="8" font-size="10.5" fill="#8a93a3">RUNS · the machine</text>
-    <text x="522" y="36" font-size="12.5" font-weight="600" fill="#2f8fb3">Sandbox</text>
-    <text x="530" y="62" font-size="10">Conversation</text>
-    <text x="530" y="76" font-size="10" fill="#8a93a3">transcript</text>
-    <text x="634" y="62" font-size="10">Conversation</text>
-    <text x="634" y="76" font-size="10" fill="#8a93a3">shares it</text>
-    <text x="530" y="128" font-size="10">env: config, placeholders</text>
-    <text x="530" y="142" font-size="9.5" fill="#8a93a3">GITHUB_TOKEN=__github_token__</text>
-    <text x="530" y="177" font-size="10">machine: built, warm,</text>
-    <text x="530" y="191" font-size="10" fill="#8a93a3">metered, reclaimed</text>
-    <text x="522" y="282" font-size="12.5" font-weight="600" fill="#c98a2b">Egress broker</text>
-    <text x="522" y="298" font-size="10" fill="#c98a2b">hosted, when the broker is on</text>
-    <text x="522" y="332" font-size="10" fill="#8a93a3">→ GitHub, model APIs, yours</text>
+    <text x="14" y="20" font-size="10.5" fill="#8a93a3"><tspan font-weight="600">1 · WRITE ONCE</tspan> · reusable rows</text>
+    <text x="252" y="20" font-size="10.5" fill="#8a93a3"><tspan font-weight="600">2 · AT LAUNCH</tspan> · one API call</text>
+    <text x="490" y="20" font-size="10.5" fill="#8a93a3"><tspan font-weight="600">3 · THE MACHINE</tspan> · one per launch</text>
+    <text x="26" y="53" font-size="12.5" font-weight="600">Agent</text>
+    <text x="26" y="69" font-size="10" fill="#8a93a3">model, runtime, skills</text>
+    <text x="26" y="117" font-size="12.5" font-weight="600">Environment</text>
+    <text x="26" y="133" font-size="10" fill="#8a93a3">packages, repos, secrets</text>
+    <text x="26" y="181" font-size="12.5" font-weight="600">Vault</text>
+    <text x="26" y="197" font-size="10" fill="#8a93a3">secret overrides, per run</text>
+    <text x="264" y="96" font-size="12.5" font-weight="600" fill="#2f8fb3">Fountain</text>
+    <text x="264" y="116" font-size="10">builds the machine</text>
+    <text x="264" y="132" font-size="10">merges secrets, vault wins</text>
+    <text x="264" y="148" font-size="10">starts the agent's runtime</text>
+    <text x="502" y="52" font-size="12.5" font-weight="600" fill="#2f8fb3">Sandbox</text>
+    <text x="510" y="79" font-size="10">env: config and secrets</text>
+    <text x="510" y="93" font-size="9" fill="#8a93a3">GITHUB_TOKEN=ghp_… or a placeholder</text>
+    <text x="510" y="131" font-size="10">Conversation</text>
+    <text x="510" y="145" font-size="9" fill="#8a93a3">own transcript</text>
+    <text x="620" y="131" font-size="10">Conversation</text>
+    <text x="620" y="145" font-size="9" fill="#8a93a3">same machine</text>
+    <text x="510" y="187" font-size="10">the next turn lands on it</text>
+    <text x="510" y="199" font-size="9" fill="#8a93a3">idle parks it, the ceiling reclaims</text>
+    <text x="502" y="272" font-size="12.5" font-weight="600" fill="#c98a2b">Egress broker</text>
+    <text x="502" y="288" font-size="10" fill="#c98a2b">hosted, when the broker is on</text>
+    <text x="502" y="320" font-size="10" fill="#8a93a3">→ GitHub, model APIs, yours</text>
   </g>
   <g fill="none" stroke="#1b2530" stroke-width="1.4" marker-end="url(#pr-a)">
-    <path d="M210,56 H508"/>
-    <path d="M210,136 H488 V180"/>
-    <path d="M210,150 H244 V190 H268"/>
-    <path d="M210,216 H244 V222 H268"/>
-    <path d="M466,200 H496 V130 H520"/>
+    <path d="M206,57 C228,57 232,100 250,100"/>
+    <path d="M206,121 H250"/>
+    <path d="M206,185 C228,185 232,142 250,142"/>
+    <path d="M442,121 H486"/>
   </g>
   <g fill="none" stroke="#c98a2b" stroke-width="1.6" marker-end="url(#pr-b)">
-    <path d="M368,242 V290 H508"/>
-    <path d="M618,212 V260"/>
+    <path d="M347,168 V292 H486"/>
+    <path d="M600,214 V248"/>
   </g>
-  <g font-family="ui-monospace, Menlo, monospace" font-size="10" fill="#8a93a3">
-    <text x="300" y="50">runs as a conversation</text>
-    <text x="300" y="130">builds the machine</text>
-    <text x="418" y="120">placeholders</text>
-    <text x="380" y="284" fill="#c98a2b">values, per conversation</text>
-    <text x="612" y="244" fill="#c98a2b" text-anchor="end">HTTPS_PROXY, only exit</text>
+  <g font-family="ui-monospace, Menlo, monospace" font-size="9.5" fill="#8a93a3">
+    <text x="447" y="114">spawns</text>
+    <text x="356" y="284" fill="#c98a2b">the real values</text>
+    <text x="592" y="232" fill="#c98a2b" text-anchor="end">HTTPS_PROXY, the only exit</text>
   </g>
 </svg>

--- a/docs/primitives.md
+++ b/docs/primitives.md
@@ -41,68 +41,67 @@ many times. The fourth, the Conversation, is a run on a machine. The machine
 is the heavy work, and Fountain does it for you.
 
 <figure>
-<svg viewBox="0 0 740 352" role="img" aria-label="Three templates and one machine. Agent, Environment and Vault are rows a tenant writes once. When a conversation starts, Fountain builds a sandbox from the Environment, runs the Agent on it as a conversation, and merges the Environment's and the Vault's secrets, the Vault winning. On a hosted account with the egress broker on, a bound secret goes to the broker and the sandbox gets a placeholder; the sandbox reaches the internet only through the broker, which attaches the value. On any other account the secrets enter the sandbox as environment variables." style="max-width:100%;height:auto">
+<svg viewBox="0 0 740 336" role="img" aria-label="Three templates, one machine, in three stages. Stage one, write once: Agent, Environment and Vault are rows a tenant writes and reuses. Stage two, at launch: Fountain builds the machine, merges the Environment's secrets with the Vault's and the Vault wins, and starts the agent's runtime. Stage three, the machine: a sandbox holds the merged secrets as environment variables and runs one or more Conversations, each with its own transcript, on that one machine. The next turn lands on the same machine, an idle machine parks, and the concurrency ceiling reclaims it. On a hosted account with the egress broker on, the real values go to the broker instead, the sandbox gets a placeholder, and the sandbox reaches the internet only through the broker." style="max-width:100%;height:auto">
   <defs>
     <marker id="pr-a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="currentColor"/></marker>
     <marker id="pr-b" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#c98a2b"/></marker>
   </defs>
   <g fill="none" stroke="currentColor" stroke-width="1.4">
-    <rect x="14" y="30" width="196" height="52" rx="8" stroke="#8a93a3"/>
-    <rect x="14" y="110" width="196" height="52" rx="8" stroke="#8a93a3"/>
-    <rect x="14" y="190" width="196" height="52" rx="8" stroke="#8a93a3"/>
-    <rect x="270" y="176" width="196" height="66" rx="8" stroke="#2f8fb3" stroke-width="1.8"/>
-    <rect x="510" y="16" width="216" height="196" rx="8" stroke="#2f8fb3" stroke-width="1.8"/>
-    <rect x="522" y="44" width="96" height="42" rx="6"/>
-    <rect x="626" y="44" width="88" height="42" rx="6"/>
-    <rect x="522" y="110" width="192" height="42" rx="6" stroke-dasharray="4 3"/>
-    <rect x="522" y="160" width="192" height="40" rx="6" stroke-dasharray="4 3"/>
-    <rect x="510" y="262" width="216" height="52" rx="8" stroke="#c98a2b" stroke-width="1.8" stroke-dasharray="6 4"/>
+    <rect x="14" y="32" width="192" height="50" rx="8" stroke="#8a93a3"/>
+    <rect x="14" y="96" width="192" height="50" rx="8" stroke="#8a93a3"/>
+    <rect x="14" y="160" width="192" height="50" rx="8" stroke="#8a93a3"/>
+    <rect x="252" y="74" width="190" height="94" rx="8" stroke="#2f8fb3" stroke-width="1.8"/>
+    <rect x="490" y="32" width="236" height="182" rx="8" stroke="#2f8fb3" stroke-width="1.8"/>
+    <rect x="502" y="62" width="212" height="40" rx="6" stroke-dasharray="4 3"/>
+    <rect x="502" y="112" width="102" height="48" rx="6"/>
+    <rect x="612" y="112" width="102" height="48" rx="6"/>
+    <rect x="502" y="170" width="212" height="34" rx="6" stroke-dasharray="4 3"/>
+    <rect x="490" y="252" width="236" height="50" rx="8" stroke="#c98a2b" stroke-width="1.8" stroke-dasharray="6 4"/>
   </g>
   <g font-family="ui-monospace, Menlo, monospace" fill="currentColor">
-    <text x="14" y="20" font-size="10.5" fill="#8a93a3">TEMPLATES · rows, written once</text>
-    <text x="24" y="50" font-size="12.5" font-weight="600">Agent</text>
-    <text x="24" y="66" font-size="10" fill="#8a93a3">model, runtime, skills</text>
-    <text x="24" y="130" font-size="12.5" font-weight="600">Environment</text>
-    <text x="24" y="146" font-size="10" fill="#8a93a3">packages, repos, secrets</text>
-    <text x="24" y="210" font-size="12.5" font-weight="600">Vault</text>
-    <text x="24" y="226" font-size="10" fill="#8a93a3">secret overrides, per run</text>
-    <text x="282" y="196" font-size="12.5" font-weight="600" fill="#2f8fb3">Fountain, at launch</text>
-    <text x="282" y="212" font-size="10">merge env ∪ vault, vault wins</text>
-    <text x="282" y="228" font-size="10">split: broker or sandbox</text>
-    <text x="510" y="8" font-size="10.5" fill="#8a93a3">RUNS · the machine</text>
-    <text x="522" y="36" font-size="12.5" font-weight="600" fill="#2f8fb3">Sandbox</text>
-    <text x="530" y="62" font-size="10">Conversation</text>
-    <text x="530" y="76" font-size="10" fill="#8a93a3">transcript</text>
-    <text x="634" y="62" font-size="10">Conversation</text>
-    <text x="634" y="76" font-size="10" fill="#8a93a3">shares it</text>
-    <text x="530" y="128" font-size="10">env: config, placeholders</text>
-    <text x="530" y="142" font-size="9.5" fill="#8a93a3">GITHUB_TOKEN=__github_token__</text>
-    <text x="530" y="177" font-size="10">machine: built, warm,</text>
-    <text x="530" y="191" font-size="10" fill="#8a93a3">metered, reclaimed</text>
-    <text x="522" y="282" font-size="12.5" font-weight="600" fill="#c98a2b">Egress broker</text>
-    <text x="522" y="298" font-size="10" fill="#c98a2b">hosted, when the broker is on</text>
-    <text x="522" y="332" font-size="10" fill="#8a93a3">→ GitHub, model APIs, yours</text>
+    <text x="14" y="20" font-size="10.5" fill="#8a93a3"><tspan font-weight="600">1 · WRITE ONCE</tspan> · reusable rows</text>
+    <text x="252" y="20" font-size="10.5" fill="#8a93a3"><tspan font-weight="600">2 · AT LAUNCH</tspan> · one API call</text>
+    <text x="490" y="20" font-size="10.5" fill="#8a93a3"><tspan font-weight="600">3 · THE MACHINE</tspan> · one per launch</text>
+    <text x="26" y="53" font-size="12.5" font-weight="600">Agent</text>
+    <text x="26" y="69" font-size="10" fill="#8a93a3">model, runtime, skills</text>
+    <text x="26" y="117" font-size="12.5" font-weight="600">Environment</text>
+    <text x="26" y="133" font-size="10" fill="#8a93a3">packages, repos, secrets</text>
+    <text x="26" y="181" font-size="12.5" font-weight="600">Vault</text>
+    <text x="26" y="197" font-size="10" fill="#8a93a3">secret overrides, per run</text>
+    <text x="264" y="96" font-size="12.5" font-weight="600" fill="#2f8fb3">Fountain</text>
+    <text x="264" y="116" font-size="10">builds the machine</text>
+    <text x="264" y="132" font-size="10">merges secrets, vault wins</text>
+    <text x="264" y="148" font-size="10">starts the agent's runtime</text>
+    <text x="502" y="52" font-size="12.5" font-weight="600" fill="#2f8fb3">Sandbox</text>
+    <text x="510" y="79" font-size="10">env: config and secrets</text>
+    <text x="510" y="93" font-size="9" fill="#8a93a3">GITHUB_TOKEN=ghp_… or a placeholder</text>
+    <text x="510" y="131" font-size="10">Conversation</text>
+    <text x="510" y="145" font-size="9" fill="#8a93a3">own transcript</text>
+    <text x="620" y="131" font-size="10">Conversation</text>
+    <text x="620" y="145" font-size="9" fill="#8a93a3">same machine</text>
+    <text x="510" y="187" font-size="10">the next turn lands on it</text>
+    <text x="510" y="199" font-size="9" fill="#8a93a3">idle parks it, the ceiling reclaims</text>
+    <text x="502" y="272" font-size="12.5" font-weight="600" fill="#c98a2b">Egress broker</text>
+    <text x="502" y="288" font-size="10" fill="#c98a2b">hosted, when the broker is on</text>
+    <text x="502" y="320" font-size="10" fill="#8a93a3">→ GitHub, model APIs, yours</text>
   </g>
   <g fill="none" stroke="currentColor" stroke-width="1.4" marker-end="url(#pr-a)">
-    <path d="M210,56 H508"/>
-    <path d="M210,136 H488 V180"/>
-    <path d="M210,150 H244 V190 H268"/>
-    <path d="M210,216 H244 V222 H268"/>
-    <path d="M466,200 H496 V130 H520"/>
+    <path d="M206,57 C228,57 232,100 250,100"/>
+    <path d="M206,121 H250"/>
+    <path d="M206,185 C228,185 232,142 250,142"/>
+    <path d="M442,121 H486"/>
   </g>
   <g fill="none" stroke="#c98a2b" stroke-width="1.6" marker-end="url(#pr-b)">
-    <path d="M368,242 V290 H508"/>
-    <path d="M618,212 V260"/>
+    <path d="M347,168 V292 H486"/>
+    <path d="M600,214 V248"/>
   </g>
-  <g font-family="ui-monospace, Menlo, monospace" font-size="10" fill="#8a93a3">
-    <text x="300" y="50">runs as a conversation</text>
-    <text x="300" y="130">builds the machine</text>
-    <text x="418" y="120">placeholders</text>
-    <text x="380" y="284" fill="#c98a2b">values, per conversation</text>
-    <text x="612" y="244" fill="#c98a2b" text-anchor="end">HTTPS_PROXY, only exit</text>
+  <g font-family="ui-monospace, Menlo, monospace" font-size="9.5" fill="#8a93a3">
+    <text x="447" y="114">spawns</text>
+    <text x="356" y="284" fill="#c98a2b">the real values</text>
+    <text x="592" y="232" fill="#c98a2b" text-anchor="end">HTTPS_PROXY, the only exit</text>
   </g>
 </svg>
-<figcaption><b>Three templates, one machine.</b> Agent, Environment and Vault are rows you write once. When a Conversation starts, Fountain builds the sandbox from the Environment and runs the Agent on it. Several Conversations can share one machine. On a hosted account with the egress broker on, a bound secret goes to the broker and the sandbox gets a placeholder; the sandbox reaches the internet only through the broker, which attaches the value. On any other account, the merged secrets enter the sandbox as environment variables.</figcaption>
+<figcaption><b>Three templates, one machine.</b> Agent, Environment and Vault are rows you write once. At launch Fountain builds the sandbox from the Environment, merges the secrets with the Vault winning, and starts the Agent's runtime. Several Conversations can share one machine, and the next turn lands on the machine the last one left. An idle machine parks and the concurrency ceiling reclaims it. On a hosted account with the egress broker on, the real values go to the broker and the sandbox gets a placeholder, such as <code>__github_token__</code>; the sandbox reaches the internet only through the broker, which attaches the value. On any other account, the merged secrets enter the sandbox as environment variables.</figcaption>
 </figure>
 
 A Conversation starts. At that moment Fountain merges the Environment's


### PR DESCRIPTION
The picture at the top of the README, and the same picture in
`docs/primitives.md`.

## What was wrong

Two arrows pointed at nothing in particular. One left the Environment, ran
right and turned down into the gap between the launch box and the sandbox.
Another climbed backwards out of the launch box to reach the sandbox's env
row. Between them the Environment had two outgoing edges carrying different
meanings, and nothing in the drawing gave the reader an order to follow, so
it read as a topology rather than as a life.

## What it is now

A left-to-right time axis with the stages named: **1 WRITE ONCE**,
**2 AT LAUNCH**, **3 THE MACHINE**.

- The three templates converge on one launch box, one arrow each.
- That box says what launch *does*, instead of the arrows around it carrying
  the words: builds the machine, merges secrets with the vault winning,
  starts the agent's runtime. One arrow leaves it, into the sandbox.
- The lifecycle fact the old drawing never showed now sits inside the
  sandbox, where it belongs: the next turn lands on the same machine, an idle
  machine parks, and the ceiling reclaims it.
- The broker keeps its lane and stays visibly an aside, which is what it is.
  The sandbox's env row reads `GITHUB_TOKEN=ghp_… or a placeholder`, and the
  amber arrow into the broker is labelled `the real values`, so the two halves
  of that story read as one.

Nothing was invented for the picture. Every claim on it is one the page below
it already makes.

## The second copy was undefended

The drawing exists twice, on purpose. `docs/images/primitives.svg` is what the
README's `<img>` loads, and GitHub gives an `<img>` no theme to inherit, so
that copy paints a white ground and draws in `#1b2530`. The manual inlines the
same drawing with `currentColor`, so it follows the page's theme. That works,
and the dark-mode render of `/docs/primitives` confirms it.

Two copies of one picture drift, and the drift is invisible until somebody
opens the other one. Four tests in `docs_test.exs` now hold them together:

- the inline copy equals the file, minus the background rect and with
  `currentColor` for the ink, and nothing else;
- the file paints its own ground and the inline copy does not;
- one `aria-label` serves the file, the inline copy and the README's `alt`;
- the drawing still names all three stages and all five boxes.

Both drift tests were confirmed the honest way, by breaking each copy in turn
and watching the right test fail with the right message.

## Gates

`mix precommit` green: 4102 tests, 0 failures; credo strict clean; dialyzer 0
errors; format clean. `python3 scripts/docs-style.py` clean, and `vale lint
docs` reports 0 errors and 0 warnings (only the advisory `STE.Vocabulary`
suggestions, which do not gate). Rendered at the README's real 740px width,
and in the manual in dark mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
