### PR TITLE
copy(marketing): unlist /code-review-bot until somebody has run it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ upgrade, is in
   snippets rather than typed, and the controller test pins every annotated
   line to a line of the file above it. Like the other pitch pages, an
   instance that is not the marketing site is sent to the manual's tour.
+  The page is **unlisted**: it answers at its URL and nothing on the site
+  links to it, because the handler it shows has never been run against a live
+  webhook.
 
 - **A self-hosted runner can put each sandbox in its own Firecracker microVM.**
   `fountain runner --backend firecracker` replaces the sandbox directory with

--- a/apps/fountain/lib/fountain_web/components/layouts/marketing.html.heex
+++ b/apps/fountain/lib/fountain_web/components/layouts/marketing.html.heex
@@ -97,13 +97,6 @@
         </a>
         <a
           :if={Fountain.Marketing.site?()}
-          href={~p"/code-review-bot"}
-          class="hover:text-[var(--color-text-secondary)] transition-colors"
-        >
-          Review bot
-        </a>
-        <a
-          :if={Fountain.Marketing.site?()}
           href={~p"/case-studies/self-healing-infrastructure"}
           class="hover:text-[var(--color-text-secondary)] transition-colors"
         >

--- a/apps/fountain/lib/fountain_web/controllers/marketing_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_controller.ex
@@ -61,6 +61,13 @@ defmodule FountainWeb.MarketingController do
   # The shortest useful program anybody writes on this API, shown whole. Sales
   # copy like the rest, so another deployment gets the manual's longer version
   # of the same job rather than a page selling the hosted product.
+  #
+  # UNLISTED. Nothing on the site links here, and that is deliberate rather
+  # than an oversight: the handler the page shows has never been run against a
+  # live webhook. The page says so and claims no measurement, but an unrun
+  # program is not something to put in the footer. Relink it once somebody has
+  # smoked it end to end. `marketing_controller_test.exs` asserts the absence,
+  # so a link cannot creep back beside an unrelated edit.
   def code_review_bot(conn, _params) do
     if Fountain.Marketing.site?() do
       render(conn, :code_review_bot,

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -335,20 +335,10 @@
         </span>
       </li>
     </ol>
-    <div>
-      <pre
-        class="rounded-xl border border-[var(--color-border)] bg-[var(--color-code-bg)] text-[var(--color-code-text)] p-5 text-sm leading-relaxed overflow-x-auto"
-        phx-no-format
-      ><code>{sdk_example()}</code></pre>
-      <%!-- The shortest finished program on the API, for the reader who wants
-            to see the call in a job rather than on its own. --%>
-      <a
-        href={~p"/code-review-bot"}
-        class="mt-4 inline-block text-sm font-medium text-[var(--color-text-primary)] underline underline-offset-2 hover:text-[var(--color-brand)]"
-      >
-        See it finished: a code review bot in one file →
-      </a>
-    </div>
+    <pre
+      class="rounded-xl border border-[var(--color-border)] bg-[var(--color-code-bg)] text-[var(--color-code-text)] p-5 text-sm leading-relaxed overflow-x-auto"
+      phx-no-format
+    ><code>{sdk_example()}</code></pre>
   </div>
 </section>
 

--- a/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
@@ -360,10 +360,23 @@ defmodule FountainWeb.MarketingControllerTest do
       end
     end
 
-    test "the homepage and the marketing footer link to it", %{conn: conn} do
-      body = conn |> get(~p"/") |> html_response(200)
-      assert body =~ ~p"/code-review-bot"
-      assert body =~ "a code review bot in one file"
+    # Unlisted on purpose: the page is reachable at its URL and nothing on the
+    # site points at it, because the program it shows has never been run. The
+    # assertion is the absence, so restoring a link is a deliberate edit here
+    # rather than something that creeps back in beside an unrelated change.
+    test "nothing on the marketing site links to it", %{conn: conn} do
+      home = conn |> get(~p"/") |> html_response(200)
+      refute home =~ ~p"/code-review-bot"
+      refute home =~ "a code review bot in one file"
+
+      # The footer and nav are the shared marketing layout, so any page that
+      # renders it would relink the page. Check one that is not the homepage.
+      refute conn |> get(~p"/built-with") |> html_response(200) =~ ~p"/code-review-bot"
+    end
+
+    test "the page itself still answers, for anyone holding the link", %{conn: conn} do
+      assert conn |> get(~p"/code-review-bot") |> html_response(200) =~
+               "A code review bot, whole, on one screen."
     end
   end
 

--- a/apps/fountain/test/fountain_web/controllers/marketing_instance_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_instance_test.exs
@@ -117,8 +117,9 @@ defmodule FountainWeb.MarketingInstanceTest do
       conn = get(conn, ~p"/code-review-bot")
       assert redirected_to(conn) == ~p"/docs/tour"
 
-      # The layout drops the link too: a nav entry to a redirect is a dead end.
-      refute conn |> get(~p"/") |> html_response(200) =~ ~p"/code-review-bot"
+      # No "the layout drops the link" assertion here, unlike its neighbours:
+      # the page is unlisted on the marketing site too, so there is no link for
+      # a non-marketing deployment to drop. The marketing-site test owns that.
     end
   end
 


### PR DESCRIPTION
The page answers at its URL and nothing on the site points at it any more.
Both links go: the footer entry in the shared marketing layout, and the line
under the homepage's SDK snippet.

The reason is the caveat the page already carries. The handler it shows has
never been run against a live webhook. Every primitive in it is the verified
one from `docs/tour.md` and the page claims no measurement, but an unrun
program does not belong in the footer of the marketing site. The page is
still worth having for anyone holding the link, and it costs nothing to keep
serving.

Unlisted, not withdrawn: the route, the controller action, the snippets and
their guardrails are untouched.

## What holds it unlisted

The test that asserted the two links now asserts their absence, on the
homepage and on a second page that renders the same shared layout, so a link
cannot creep back beside an unrelated edit. A companion test keeps the page
itself answering 200 with its headline. The instance test loses its "the
layout drops the link" assertion, which went vacuous the moment the marketing
site stopped linking it, and says so in its place.

The comment above the controller action records that the unlinking is
deliberate and what would justify relinking, so the next reader does not
"fix" it.

## Not done here

The page is still crawlable. With no sitemap and no inbound links it is
unlikely to be found, but if you want it out of search as well, that is a
`noindex` meta on this one action. I left it off deliberately: it is a second
switch that has to be remembered and removed when the page is relinked, and
forgetting it would keep the page out of search silently.

`mix precommit` green: 4110 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
