### PR TITLE
copy(marketing): every line of the case study defends itself, or changes

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
@@ -941,7 +941,7 @@ defmodule FountainWeb.MarketingHTML do
       %{
         value: "78",
         label: "incidents handled by an agent",
-        note: "Fifteen days, one estate, one agent, no rota."
+        note: "Fifteen days, one estate, one runbook, no rota."
       },
       %{
         value: "4m 27s",
@@ -956,7 +956,7 @@ defmodule FountainWeb.MarketingHTML do
       %{
         value: "0",
         label: "cluster credentials the agent holds",
-        note: "No kubectl, no kubeconfig, no write anywhere."
+        note: "No kubectl, no kubeconfig, no write path of its own."
       }
     ]
   end
@@ -975,7 +975,7 @@ defmodule FountainWeb.MarketingHTML do
         title: "Alertmanager forks the page",
         mono: "continue: true",
         body:
-          "One copy to the phone, as before. One to a webhook. " <>
+          "One copy to the operator's phone, as before. One to a webhook. " <>
             "The human is added to, not replaced."
       },
       %{
@@ -991,8 +991,8 @@ defmodule FountainWeb.MarketingHTML do
         title: "The agent reads the estate",
         mono: "Authorization: Bearer … (GET only)",
         body:
-          "A read-only service answers with node health, drift from source, and " <>
-            "controller conditions. Every other method returns 405."
+          "A read-only estate service answers with node health, drift from " <>
+            "source, and controller conditions. Every other method returns 405."
       },
       %{
         step: "5",
@@ -1008,8 +1008,8 @@ defmodule FountainWeb.MarketingHTML do
         mono: "symptom · root cause · why this diff is the whole fix",
         body:
           "Source and regenerated manifests in one commit, from an identity " <>
-            "with push rights and nothing else. If the repository cannot fix the " <>
-            "alert, it opens nothing."
+            "with push rights and nothing else. If no change to the repository " <>
+            "can fix the alert, it opens nothing."
       },
       %{
         step: "7",
@@ -1058,8 +1058,10 @@ defmodule FountainWeb.MarketingHTML do
         cannot: "Read a secret value. The material never leaves the cluster."
       },
       %{
-        can: "Say the repository cannot fix this, and stop.",
-        cannot: "Reach the cluster. The sandbox has no kubectl and no kubeconfig."
+        can: "Decide the repository cannot fix this, and stop.",
+        cannot:
+          "Reach past the repository and fix it anyway. " <>
+            "The sandbox has no kubectl and no kubeconfig."
       }
     ]
   end
@@ -1093,8 +1095,8 @@ defmodule FountainWeb.MarketingHTML do
         time: "07:03:42",
         title: "The second pull request opens",
         body:
-          "Six lines added, two removed. The same cause from the other side, " <>
-            "said rather than diagnosed again."
+          "Six lines added, two removed. The same root cause seen from the " <>
+            "other side, and the second agent said so rather than diagnose it again."
       },
       %{
         time: "08:50:27",
@@ -1152,9 +1154,9 @@ defmodule FountainWeb.MarketingHTML do
       %{
         title: "Environment",
         body:
-          "The machine it wakes up on, with the repository, the CLI and the " <>
-            "read-only estate service's address. Described once, rebuilt per " <>
-            "incident, never patched by hand."
+          "The machine the agent wakes up on, with the repository, the CLI and " <>
+            "the read-only estate service's address. Described once, rebuilt " <>
+            "per incident, never patched by hand."
       },
       %{
         title: "Vault",

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/case_study_self_healing.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/case_study_self_healing.html.heex
@@ -11,7 +11,7 @@
     The pager still goes off at 06:58. The pull request is open by 07:02.
   </h1>
   <p class="text-lg sm:text-xl text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-10">
-    This Kubernetes estate pages a person and hires an agent. The agent reads the cluster, finds the commit at fault, and opens one small pull request it is unable to merge.
+    A Kubernetes estate pages a person when a workload breaks. This one also hires an agent. It reads the cluster, finds the commit at fault, and opens one small pull request it is unable to merge.
   </p>
   <div class="flex flex-col sm:flex-row gap-3 justify-center">
     <a
@@ -69,12 +69,12 @@
       </p>
       <p class="text-lg font-semibold text-[var(--color-text-primary)]">Red</p>
       <p class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">
-        The workload crashes anyway, because what the repository says is false: a dropped variable, a lost secret reference, a bad image pin. No apply fixes that. Knowledge does.
+        The workload crashes anyway, because what the repository says is false: a dropped variable, a lost secret reference, a bad image pin. No apply fixes that. Somebody has to read the evidence and change the source.
       </p>
     </div>
   </div>
   <p class="text-center text-[var(--color-text-secondary)] max-w-2xl mx-auto mt-12">
-    That gap is where the pager lives, and it is the shape of work a coding agent is good at. What was missing was never the diagnosis. It was a machine, a checkout, a push credential, and a human still allowed to say no.
+    That gap is where the pager lives, and reading evidence to write a small diff is exactly what a coding agent is good at. What was missing was never the diagnosis. It was a machine, a checkout, a push credential, and a human still allowed to say no.
   </p>
 </section>
 
@@ -128,7 +128,7 @@
     The gate is a mechanism, not a promise.
   </h2>
   <p class="text-center text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-12">
-    Such an agent is only as safe as the least it can do. Nothing rests on a good choice, a prompt holding, or a model behaving. Each refusal below is somebody else's 405.
+    An agent that opens infrastructure pull requests is only as safe as the least it can do. Nothing rests on a good choice, a prompt holding, or a model behaving. Each refusal below is somebody else's 405.
   </p>
   <div class="max-w-3xl mx-auto space-y-4">
     <div
@@ -202,7 +202,7 @@
         </span>
       </blockquote>
       <figcaption class="mt-3 text-xs text-[var(--color-text-muted)]">
-        Its root-cause paragraph, quoted from the 07:02 pull request. The gap had sat there for months unalerted, because no commit had moved a lockfile until that week.
+        The agent's root-cause paragraph, quoted from the pull request it opened at 07:02. The gap had sat there for months unalerted, because no commit had moved a lockfile until that week.
       </figcaption>
     </figure>
   </div>
@@ -214,7 +214,7 @@
     What {Fountain.Brand.name()} was for.
   </h2>
   <p class="text-center text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-12">
-    The alerting, the repository and the reconciler were already there. Missing was somewhere for an agent to live between alerts.
+    The alerting, the repository and the reconciler were already there. What was missing was somewhere for an agent to live between alerts.
   </p>
   <div class="grid sm:grid-cols-2 gap-6 max-w-3xl mx-auto">
     <div
@@ -306,7 +306,7 @@
     </a>
   </div>
   <p class="mt-10 text-xs text-[var(--color-text-muted)] max-w-2xl mx-auto leading-relaxed">
-    A private Kubernetes cluster run by one person, and the numbers are its own. Twelve fix pull requests opened in the window and eight merged, four of them the same rehearsal fault raised on purpose. Most incidents end with no pull request, because the agent decides the repository cannot fix them. Its definition is public at <a
+    The estate is a private Kubernetes cluster run by one person, and the numbers are its own. Twelve fix pull requests opened in the window and eight merged, four of them the same rehearsal fault raised on purpose. Most incidents end with no pull request, because the agent decides the repository cannot fix them. The agent's definition is public at <a
       href="https://github.com/jhgaylor/agent-specs/blob/main/src/agents/specialists/engineering/estate-medic.ts"
       class="underline underline-offset-2 hover:text-[var(--color-text-secondary)]"
     >jhgaylor/agent-specs</a>.


### PR DESCRIPTION
An audit of `/case-studies/self-healing-infrastructure`, line by line. Of each line I asked: what job does it do, does anything else on the page already do that job, and does it survive a hostile reading. Most lines held. **Fifteen did not.** The page goes 1,290 → 1,343 words; that 53 is the price of the compression in #1228.

## Wrong, not merely weak

**"Fifteen days, one estate, one agent, no rota."** contradicted the page's own timeline. At 06:59:34 a second alert "opens its own incident, its own agent" — two agents alive at once. What is singular is the *runbook*. → `one runbook`.

**"No kubectl, no kubeconfig, no write anywhere."** was false. The agent writes: it pushes a branch, as the guardrail table two screens down says outright. The claim that survives a hostile reading is that it holds no write path **of its own** — the merge is somebody else's. → `no write path of its own`.

**The Red card contradicted the paragraph below it.** The card said knowledge is what fixes a wrong repository ("No apply fixes that. Knowledge does."); the closing paragraph said "What was missing was never the diagnosis." Both cannot be true. The card now names what the fix *requires* — "Somebody has to read the evidence and change the source" — and the paragraph picks that thread up ("reading evidence to write a small diff is exactly what a coding agent is good at") instead of cutting it. This one is my fault: #1228 removed the bridging sentence and left the two ends facing each other.

## Pointing at nothing

Four openers had no antecedent, three of them introduced by my own trim:

| Was | Now | Why |
|---|---|---|
| "**This** Kubernetes estate pages a person…" | "A Kubernetes estate pages a person when a workload breaks. **This one also** hires an agent." | The demonstrative pointed at an estate not yet mentioned, and took the page's central contrast with it: estates page people, and this one *also* hires |
| "**Such an agent** is only as safe as…" | "**An agent that opens infrastructure pull requests** is only as safe as…" | Opened the guardrails section under a heading that had not named an agent |
| "**Its** root-cause paragraph…" | "**The agent's** root-cause paragraph…" | Followed a sentence about lockfiles |
| "The machine **it** wakes up on…" | "The machine **the agent** wakes up on…" | Each primitive card is read on its own |

## Compressed past sense

- **"The same cause from the other side, said rather than diagnosed again."** meant that the second agent recognised the first agent's root cause instead of re-deriving it. No reader could recover that. → "The same root cause seen from the other side, and the second agent said so rather than diagnose it again."
- **"If the repository cannot fix the alert, it opens nothing."** hands agency to a repository. It is a *change* to the repository that fixes things. → "If no change to the repository can fix the alert…"

## A guardrail row that was not a pair

The table's contract is one object, two halves. Row 5 broke it: the "can" was a behaviour (*say* it cannot be fixed) and the "cannot" was a different object entirely (*reach the cluster*), so the row taught nothing about a boundary. Both halves now speak about the same thing:

> **It can** Decide the repository cannot fix this, and stop.
> **It cannot** Reach past the repository and fix it anyway. The sandbox has no kubectl and no kubeconfig.

The refusal claim it used to carry is still made twice elsewhere (loop step 6, and the disclosure footer's "Most incidents end with no pull request").

## Consistency

Step 4 now calls the read-only service by the name the Environment card already gives it ("a read-only estate service") — my first draft of this pass said "in front of the cluster", which implied the reader must build one and quietly fought the loop's "Everything but the agent was already in the estate". Step 2 gives the phone back to the operator. The disclosure footer gets its subjects back ("**The estate is** a private Kubernetes cluster…", "**The agent's** definition is public").

## What I defended, and why

Nothing structural moved. Every section was tested for whether it could be cut:

- **Stats band stays above the fold.** "78 incidents" is meaningless before the loop, but the h1 has already framed pager → pull request, so it lands. Skimmers need the number early.
- **Guardrails stay between the loop and the incident.** The loop raises the safety fear at steps 6 and 7. Close it there and the reader can enjoy the story; move the table after the incident and they read the story defensively. Three of its five rows restate the loop, but the can/cannot layout is the only place the page shows the *shape* of the boundary rather than narrating it, and it is the one block a skeptical infra reader will scan.
- **All four primitive cards earn their place.** Each carries a claim made nowhere else: the runbook *is* the product (Agent); rebuilt per incident, never patched by hand (Environment); the token never enters the prompt, the context or the transcript (Vault); a human opens it at 08:50 to see 07:02 (Conversation). Vault's is the one a security reader is looking for.
- **`7.5 min median` and the disclosure footer are the page's moral authority.** The median admits the distribution instead of quoting only the 4m 27s best case, and the footer volunteers that four of the eight merged fixes were the same rehearsal fault raised on purpose. Both stay untouched.
- **`continue: true`, `git log -S`, `422 on self-approval`.** The three most valuable strings on the page — a real Alertmanager route key, the right tool for finding when a fact entered a repo, and GitHub's own refusal code. Each proves the story is real in a way prose cannot.

## Two gaps I did not fill

Both need data I cannot derive, and inventing either would break the page's own standard (every number a literal, counted once, over a stated window):

1. **No cost figure.** Credits are the product, and the page never says what 78 incidents cost. Note the trap for whoever does this: it is not `78 × 7.5 min × CREDIT_TURN_HOUR_CENTS`. `turn_seconds` is not sandbox wall time, and this page's incidents include a 15-hour wait for a human between 08:50 and 23:46.
2. **No transcript link.** "a human opens it at 08:50 to see 07:02" implies a link that the page does not offer. A public conversation link would be the strongest artifact here.

## Checks

`mix format --check-formatted`, `mix compile --warnings-as-errors` and `mix credo --strict` clean. `marketing_controller_test.exs` + `marketing_instance_test.exs` green (54 tests) — they pin the hero clock against the timeline data, every loop-step title, every timestamp, every stat value, and the strings `422 on self-approval`, `install_members()` and `The sandbox has no kubectl and no kubeconfig.` (that last one survives inside the rewritten guardrail row).

🤖 Generated with [Claude Code](https://claude.com/claude-code)