### PR TITLE
design(tokens): brand color matches the managoat logo's blue

### DIFF
--- a/apps/fountain/priv/static/assets/tokens.css
+++ b/apps/fountain/priv/static/assets/tokens.css
@@ -4,8 +4,8 @@
  */
 
 :root {
-  --color-brand:       #6366f1;
-  --color-brand-hover: #4f46e5;
+  --color-brand:       #0b5acc;
+  --color-brand-hover: #094cb2;
   --color-brand-text:  #ffffff;
 
   --color-bg-0: #f9fafb;
@@ -50,12 +50,12 @@
   --status-failed-bg:       #fef2f2;
   --status-failed-text:     #b91c1c;
 
-  --color-focus-ring: #6366f1;
+  --color-focus-ring: #0b5acc;
 }
 
 [data-theme="dark"] {
-  --color-brand:       #818cf8;
-  --color-brand-hover: #6366f1;
+  --color-brand:       #5796f4;
+  --color-brand-hover: #0b5acc;
 
   --color-bg-0: #09090b;
   --color-bg-1: #18181b;
@@ -99,7 +99,7 @@
   --status-failed-bg:       #2d0a0a;
   --status-failed-text:     #fca5a5;
 
-  --color-focus-ring: #818cf8;
+  --color-focus-ring: #5796f4;
 }
 
 *:focus-visible {

--- a/assets/css/tokens.css
+++ b/assets/css/tokens.css
@@ -7,9 +7,9 @@
  */
 
 :root {
-  /* Brand */
-  --color-brand:       #6366f1;
-  --color-brand-hover: #4f46e5;
+  /* Brand — matches the blue in the managoat logo */
+  --color-brand:       #0b5acc;
+  --color-brand-hover: #094cb2;
   --color-brand-text:  #ffffff;
 
   /* Surfaces */
@@ -64,14 +64,14 @@
   --status-failed-text:     #b91c1c;
 
   /* Focus ring */
-  --color-focus-ring: #6366f1;
+  --color-focus-ring: #0b5acc;
 }
 
 /* Dark mode — activated by data-theme="dark" on <html> */
 [data-theme="dark"] {
-  /* Brand */
-  --color-brand:       #818cf8;
-  --color-brand-hover: #6366f1;
+  /* Brand — matches the blue in the managoat logo */
+  --color-brand:       #5796f4;
+  --color-brand-hover: #0b5acc;
 
   /* Surfaces */
   --color-bg-0: #09090b;
@@ -125,7 +125,7 @@
   --status-failed-text:     #fca5a5;
 
   /* Focus ring */
-  --color-focus-ring: #818cf8;
+  --color-focus-ring: #5796f4;
 }
 
 /* Accessible focus ring for all interactive elements */


### PR DESCRIPTION
## Summary
- Swap the indigo/purple brand tokens (`--color-brand`, `--color-brand-hover`, `--color-focus-ring`, light and dark) for blues sampled from the fountain app icon's gradient (`#0b5acc` → `#05337d`), used as the favicon/app-icon on the hosted managoat.com deployment.
- Preserves the same relative contrast between default/hover/dark-mode values the old indigo tokens had — verified against WCAG contrast ratios.
- Updated `assets/css/tokens.css` and the served copy at `apps/fountain/priv/static/assets/tokens.css`. These two files are separately committed and nothing currently syncs them — the endpoint (`Plug.Static`, `from: :fountain`) serves the latter directly. Worth wiring up a real sync/build step as a follow-up.

## Test plan
- [x] Ran the app locally (`mix phx.server`, `MARKETING_SITE=true`) and visually verified the marketing home page in both light and dark mode — buttons, feature-bullet dots, and icon tiles all render the new blue with good contrast.
- [x] `git diff --stat` confirms only the two token files changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)