### PR TITLE
copy(marketing): trim the self-hosted hero to one line before the CTA

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/self_hosted.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/self_hosted.html.heex
@@ -6,18 +6,8 @@
   <h1 class="text-4xl sm:text-5xl font-bold tracking-tight text-[var(--color-text-primary)] mb-5 leading-tight">
     Define your agents once. Let every app you build hire them.
   </h1>
-  <p class="text-lg sm:text-xl text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-4">
-    An agent is a row you write once. The model, the skills, the MCP servers, the repository it wakes up in, the secrets it may use. After that anything you build hires it over one API. It arrives on a machine {Fountain.Brand.engine()} builds, warms and takes back.
-    <span :if={Fountain.Brand.hosted?()}>
-      {Fountain.Brand.name()} is one instance of that platform, the one we happen to run.
-    </span>
-    <span :if={!Fountain.Brand.hosted?()}>
-      This site is one instance of that platform, the one we happen to run.
-    </span>
-    Yours answers the same API in six commands.
-  </p>
-  <p class="text-lg sm:text-xl font-medium text-[var(--color-text-primary)] max-w-2xl mx-auto mb-10">
-    Run it yourself and the whole platform is yours. Your roster runs on your machines with your keys, and the features we ration on this site are a line of config on yours.
+  <p class="text-lg sm:text-xl text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-10">
+    Run it yourself and the whole platform is yours. Your machines, your keys, nothing rationed.
   </p>
   <div class="flex flex-col sm:flex-row gap-3 justify-center mb-4">
     <a


### PR DESCRIPTION
## Summary
- The `/self-hosted` hero had two paragraphs (~95 words) between the headline and the "Bring up an instance" CTA: an explanation of what an agent primitive is, and an ownership/parity pitch.
- Both are already covered elsewhere on the page — the 13 app cards right below the hero show what "define once, any app hires it" means in practice, and the "The features we ration, you switch on" section carries the full ration/config claim.
- Cut the hero copy to one line so the primary CTA isn't gated behind two paragraphs of scroll.

**Before:**
> An agent is a row you write once. The model, the skills, the MCP servers, the repository it wakes up in, the secrets it may use. After that anything you build hires it over one API. It arrives on a machine Fountain builds, warms and takes back. This site is one instance of that platform, the one we happen to run. Yours answers the same API in six commands.
>
> Run it yourself and the whole platform is yours. Your roster runs on your machines with your keys, and the features we ration on this site are a line of config on yours.

**After:**
> Run it yourself and the whole platform is yours. Your machines, your keys, nothing rationed.

## Test plan
- [x] Ran the app locally (`MARKETING_SITE=true mix phx.server`) and visually compared the rendered `/self-hosted` page before/after — CTA and the app-proof section move ~184px closer to the top of the viewport; no other section changed.
- [x] Grepped `marketing_controller_test.exs` for the removed copy — no test asserts on it.
- [x] `git diff --stat` confirms only the hero paragraph in `self_hosted.html.heex` changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)