### PR TITLE
copy(marketing): the homepage sells infrastructure to builders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,34 @@ upgrade, is in
 
 ### Changed
 
+- **The homepage sells infrastructure to builders, not an agent to a
+  consumer.** The pitch read as a coworker product ("hire an agent by role",
+  "close the laptop", "build a roster"), which is the wrong reader. The one
+  who arrives is building something whose users will meet the agent, and the
+  agent is the afternoon while the machine under it is the quarter. That line
+  is now the headline. The problem section is the six questions between a
+  working demo and a shipped feature, each answered with the mechanism that
+  settles it: where it runs, how it gets a token that can push, how the work
+  gets out, how you get an answer instead of a transcript, who turns the
+  machines off, and what starts one when nobody is at a keyboard. The SDK call
+  moves up to sit directly under them. The teammate section becomes the
+  durable thread a builder maps onto ids they already hold, the roster section
+  becomes how a hundred tickets get worked at once, and both new objections
+  are the ones a builder asks first: whether their own users need accounts
+  here, and whether any of this works outside writing code. The apps are
+  reframed as reference implementations of the thing the reader is about to
+  write. The scale section states the hosted ceiling out loud and sends
+  anybody who needs more to `/self-hosted`, which now names that as the second
+  reason to go there.
+
+- **Two snippets on the marketing site were not runnable.** The homepage's SDK
+  call printed `run.output`, which is not a field on `RunResult`; a reader who
+  pasted it got `undefined`. It now prints `run.text` and passes a
+  `channelId`, which is the option that binds a conversation to an id the
+  caller already has. The `/integrations` pipeline scenario ran
+  `fountain conversations create --external-id`; neither the command nor the
+  flag exists, and the real one is `fountain run <agent> --prompt`.
+
 - **The marketing footer wraps into groups instead of one long row.** Ten
   links on one line had gone cramped as pages were added, and the row was
   ordered by nothing. They sit under Product, Learn and Account now, with the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,28 @@ upgrade, is in
   anybody who needs more to `/self-hosted`, which now names that as the second
   reason to go there.
 
+- **The homepage answers the security review.** A builder cannot ship an agent
+  without somebody asking where the customer data goes and what the model can
+  see, and the material for that answer was three feature bullets scattered
+  across the page. `/` now carries a section written to be forwarded whole.
+  Seven questions, each answered with the mechanism rather than the intention,
+  and each answer that has a limit carrying it in the same breath: the
+  per-account AES-256-GCM key and the write-only rule, the fact that a secret
+  reaches the process environment and never the model's context, the 8-byte
+  literal match that redacts a log row before it is written and what that match
+  misses, the `_unsafe_` convention and the cross-tenant suite that enforces
+  it, what the audit trail records and for how long, `ask` and the runtimes
+  that cannot enforce it, and the two ways to keep everything inside your own
+  perimeter with the runner's trusted-mode caveat beside them.
+
+  It ends with **What we do not have**, on the page rather than in week three
+  of somebody's review. No SOC 2, no ISO 27001, no HIPAA posture, no DPA, no
+  sub-processor list, no penetration test, no single sign-on, and an egress
+  broker that runs for one account and is not yet a thing you can turn on. Each
+  row was verified absent from the repository. The suite pins every question,
+  every limit and all five absences, so a row cannot quietly go missing and the
+  broker cannot be upgraded to a general claim by accident.
+
 - **Two snippets on the marketing site were not runnable.** The homepage's SDK
   call printed `run.output`, which is not a field on `RunResult`; a reader who
   pasted it got `undefined`. It now prints `run.text` and passes a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,8 +55,9 @@ upgrade, is in
   consumer.** The pitch read as a coworker product ("hire an agent by role",
   "close the laptop", "build a roster"), which is the wrong reader. The one
   who arrives is building something whose users will meet the agent, and the
-  agent is the afternoon while the machine under it is the quarter. That line
-  is now the headline. The problem section is the six questions between a
+  cost they are weighing is not how long the machine takes to build but that
+  they would own it afterwards. The headline says so, and the subheadline
+  names the maintaining. The problem section is the six questions between a
   working demo and a shipped feature, each answered with the mechanism that
   settles it: where it runs, how it gets a token that can push, how the work
   gets out, how you get an answer instead of a transcript, who turns the

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
@@ -31,6 +31,137 @@ defmodule FountainWeb.MarketingHTML do
     """
   end
 
+  ## The security review
+  #
+  # What a builder's security reviewer asks, answered on the page. Every answer
+  # names a mechanism that exists in this repo today, and every one that has a
+  # limit carries it in `:limit` rather than leaving the reader to find it.
+  # That field is not decoration: a reviewer who discovers an unstated limit
+  # stops believing the answers above it too.
+  #
+  # Sources, so a later edit can be checked rather than guessed:
+  #   crypto.ex + docs/concepts/secrets.md      the DEK and the write-only rule
+  #   conversations/redaction.ex                the 8-byte literal match
+  #   cross_tenant_isolation_test.exs           the scoping guardrail
+  #   decisions/0013-audit-trail.md             what is recorded, and what is not
+  #   docs/concepts/permissions.md              `ask`, and opencode's 422
+  #   workers/retention_pruner.ex               the retention windows
+  #   decisions/0009 + account deletion         export, deletion, crypto-shred
+  #
+  # The egress broker (ADR 0019) is deliberately absent. Its status is
+  # Proposed and it runs for one account, so it belongs in `security_absent/0`
+  # rather than in an answer.
+
+  @doc "The questions a security reviewer asks, and the mechanism that answers each."
+  def security_answers do
+    [
+      %{
+        question: "Where do the credentials live, and who can read them?",
+        answer:
+          "An Environment holds the machine's own variables and a Vault holds a small " <>
+            "bag of overrides for one run. The name collides with HashiCorp's and means " <>
+            "close to the opposite here. A Vault is a per-run override layer rather " <>
+            "than a central store. " <>
+            "Both are encrypted at rest with AES-256-GCM under a key derived for your " <>
+            "account alone. Values are write-only. No endpoint returns one, to anybody, " <>
+            "including an operator.",
+        limit:
+          "Deleting your account destroys that key with it, so what any backup still " <>
+            "holds is unreadable rather than merely deleted."
+      },
+      %{
+        question: "Does the model ever see them?",
+        answer:
+          "No. Secrets merge into the sandbox's process environment when it spawns, " <>
+            "and reach an agent's configuration through ${VAR} substitution. Nothing " <>
+            "puts them in the prompt, the system prompt or the model's context.",
+        limit:
+          "An agent that reads its own environment and says the value out loud has " <>
+            "said it. The next answer is what happens to that line."
+      },
+      %{
+        question: "What ends up in your logs?",
+        answer:
+          "Every secret value you registered that is eight bytes or longer is replaced " <>
+            "with [REDACTED] before the log row is written, not after. The transcript " <>
+            "we store never held it.",
+        limit:
+          "The match is on exact bytes. A value the agent re-encodes, splits or prints " <>
+            "in pieces is not caught, and neither is one shorter than eight bytes."
+      },
+      %{
+        question: "Can one account's agent reach another's?",
+        answer:
+          "Every user-facing query is scoped by account. The few unscoped internal " <>
+            "reads carry an _unsafe_ prefix so a reviewer can grep for all of them in " <>
+            "one command, and a cross-tenant isolation suite in CI asserts the scoped " <>
+            "endpoints answer 404 on somebody else's row.",
+        limit: nil
+      },
+      %{
+        question: "What is recorded when something changes, and for how long?",
+        answer:
+          "The event is written where the change happens rather than where the request " <>
+            "arrived, so the console, the API and a background worker are covered by one " <>
+            "rule. An update names the fields that moved and never their values; a secret " <>
+            "event records the key, the size and the provider. Read your own trail at " <>
+            "GET /api/audit, filtered by action, resource or time.",
+        limit:
+          "Conversation log events are kept 90 days, audit events a year, usage 400 " <>
+            "days. On your own instance every window is a setting."
+      },
+      %{
+        question: "Can the agent do something nobody approved?",
+        answer:
+          "Set an agent's permission policy to ask and a tool call stops for a human " <>
+            "before it runs, not after. The stronger pattern is the one the case study " <>
+            "uses. Build the last gate somewhere the agent cannot reach, so refusing " <>
+            "is somebody else's job rather than the model's.",
+        limit:
+          "Asking is not the default, and it is not universal. claude, codex and gemini " <>
+            "enforce it. opencode cannot, and refuses anything stricter than auto-allow " <>
+            "with a 422 rather than pretending to hold the line."
+      },
+      %{
+        question: "What if none of this may leave our network?",
+        answer:
+          "Run the server yourself, or keep the platform and put the sandboxes on your " <>
+            "own hardware with a runner. Either way the code and the secrets stay inside " <>
+            "your perimeter.",
+        limit:
+          "Read the runner's trust model first. It runs in trusted mode, the agent's " <>
+            "processes run as the daemon's user, and no container or VM stands between " <>
+            "them. An opt-in Firecracker backend exists and is not the default."
+      }
+    ]
+  end
+
+  @doc """
+  What this platform does not have, said on the page.
+
+  A security reviewer asks for the first two of these in week one. Finding out
+  then is cheaper for both sides than finding out in a questionnaire, and the
+  voice standard's "concede the failure case in the same breath" applies to a
+  product's posture as much as to a feature. Every row was verified absent
+  from the repo. Do not soften one into "coming soon", and do not add a row
+  that has not been checked.
+  """
+  def security_absent do
+    [
+      "No SOC 2 report, no ISO 27001 certificate, and no HIPAA posture. " <>
+        "None of that work has been done. A review that requires one of them is a " <>
+        "review this platform cannot pass.",
+      "No data processing agreement on file and no published sub-processor list.",
+      "No single sign-on, no organisations and no seats. An account is one person, " <>
+        "and a team shares one or runs an instance of its own.",
+      "No independent penetration test. The security work in the repo is the " <>
+        "security work there is, and it is open source, so you can read all of it.",
+      "The egress broker that keeps a credential out of the sandbox entirely is " <>
+        "built and running for one account. It is not something you can turn on yet, " <>
+        "so assume the sandbox holds the values you give it."
+    ]
+  end
+
   @doc "Whether the pricing section renders at all: only where the deployment bills."
   def pricing?, do: Fountain.Credits.enabled?()
 

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
@@ -5,7 +5,17 @@ defmodule FountainWeb.MarketingHTML do
 
   embed_templates "marketing_html/*"
 
-  @doc "The SDK call on the homepage, kept out of the template so its braces are not HEEx."
+  @doc """
+  The SDK call on the homepage, kept out of the template so its braces are not
+  HEEx.
+
+  It is the whole builder pitch in nine lines, so every identifier in it has to
+  be one the published SDK exports. `channelId` binds the conversation to an id
+  the caller already has (`RunConfig.channelId`), and `text` is the answer with
+  the tool noise removed (`RunResult.text`). An earlier draft printed
+  `run.output`, which is not a field, and a reader who pasted it got
+  `undefined`.
+  """
   def sdk_example do
     """
     import { Fountain } from "@agentshit/fountain-sdk";
@@ -14,10 +24,10 @@ defmodule FountainWeb.MarketingHTML do
 
     const run = await fountain.run(
       "Fix the failing test and open a PR",
-      { agent: "reviewer" }
+      { agent: "reviewer", channelId: ticket.id }
     );
 
-    console.log(run.output);\
+    console.log(run.text);\
     """
   end
 
@@ -448,9 +458,10 @@ defmodule FountainWeb.MarketingHTML do
         how: "The CLI in a step, a signed webhook to a URL you own.",
         lang: "bash",
         docs: "/docs/reference/webhooks",
+        # Both commands are real. An earlier draft ran `fountain conversations
+        # create --external-id`, and neither the command nor the flag exists.
         code: """
-        fountain conversations create --agent reviewer \\
-          --prompt "Review PR #$PR" --external-id "pr-$PR"
+        fountain run reviewer --prompt "Review PR #$PR"
 
         fountain webhooks create https://example.com/hooks/fountain \\
           --event conversation.turn.done --event conversation.turn.failed

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -64,7 +64,7 @@
           How does it get a token that can push?
         </h3>
         <p class="text-sm text-[var(--color-text-secondary)]">
-          A GitHub token that can open a pull request, an API key that can charge. None of it may reach the prompt, the model's context or the transcript you keep. Vaults hold those, encrypted per account, and hand them to the machine rather than to the model.
+          A GitHub token that can open a pull request, an API key that can charge. None of it may reach the prompt, the model's context or the transcript you keep. Here they are held encrypted under a key derived for your account, and handed to the machine rather than to the model.
         </p>
       </div>
       <div class="p-5 rounded-lg bg-[var(--color-bg)] border border-[var(--color-border)]">
@@ -514,6 +514,73 @@
   </div>
 </section>
 
+<%!-- The security review, answered on the page rather than in a questionnaire.
+      A builder cannot ship an agent without somebody asking where the customer
+      data went, and the material for that answer was scattered across three
+      feature bullets before this section existed.
+
+      Two rules hold this section together. Every answer names the mechanism
+      rather than the intention, which is the case study's "the mechanism that
+      stops it is not a system prompt" applied to the platform. And every
+      answer that has a limit states it in the same breath, because a security
+      reader who finds the limit themselves stops believing the rest.
+
+      `security_answers/0` and `security_absent/0` carry the copy. The second
+      is the list of things this platform does not have, and it is on the page
+      on purpose: a reviewer asks for a SOC 2 report in week one, and finding
+      out then is cheaper for both sides than finding out in a questionnaire.
+      Do not soften it into "coming soon", and do not add a row to it that is
+      not verified absent. --%>
+<section class="bg-[var(--color-bg-1)] border-y border-[var(--color-border)]">
+  <div class="max-w-5xl mx-auto px-6 py-16">
+    <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-3 text-center">
+      The part you forward to your security reviewer.
+    </h2>
+    <p class="text-center text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-10">
+      Putting an agent in front of your users means somebody asks where the credentials sit, what the model can see and what lands in the logs. Here are the answers, each one a mechanism rather than an intention, and each limit stated beside the thing it limits.
+    </p>
+    <dl class="max-w-3xl mx-auto space-y-6" data-role="security-answers">
+      <div :for={item <- security_answers()}>
+        <dt class="font-medium text-[var(--color-text-primary)]">{item.question}</dt>
+        <dd class="mt-1 text-sm text-[var(--color-text-secondary)] leading-relaxed">
+          {item.answer}
+        </dd>
+        <dd :if={item.limit} class="mt-1 text-sm text-[var(--color-text-muted)] leading-relaxed">
+          {item.limit}
+        </dd>
+      </div>
+    </dl>
+    <div class="max-w-3xl mx-auto mt-10 rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6">
+      <h3 class="font-semibold text-[var(--color-text-primary)] mb-2">
+        What we do not have.
+      </h3>
+      <p class="text-sm text-[var(--color-text-secondary)] leading-relaxed mb-4">
+        Here rather than in week three of your review.
+      </p>
+      <ul class="space-y-3 text-sm text-[var(--color-text-secondary)]">
+        <li :for={item <- security_absent()} class="flex items-start gap-3">
+          <span class="mt-1.5 size-1.5 rounded-full bg-[var(--color-text-muted)] flex-shrink-0">
+          </span>
+          <span>{item}</span>
+        </li>
+      </ul>
+    </div>
+    <p class="text-center text-sm text-[var(--color-text-muted)] mt-8">
+      The manual goes further on
+      <a
+        href={~p"/docs/concepts/secrets"}
+        class="underline underline-offset-2 hover:text-[var(--color-text-primary)]"
+      >
+        where a secret comes from
+      </a>
+      and on <a
+        href={~p"/docs/concepts/permissions"}
+        class="underline underline-offset-2 hover:text-[var(--color-text-primary)]"
+      >what happens before a tool runs</a>.
+    </p>
+  </div>
+</section>
+
 <%!-- The flagship three: the apps this project builds itself, and the fastest
       answer to "what does using it look like". Cards come from built_apps/0,
       so the homepage cannot name an app /built-with has renamed or retired. --%>
@@ -687,7 +754,7 @@
         Is this only good for writing code?
       </dt>
       <dd class="mt-1 text-sm leading-relaxed">
-        The runtimes are coding agents, which is to say a shell, a filesystem and a network. One of the apps above runs Python over a CSV you drop in. Another reads real sources and hands back a cited brief. If the job fits on a computer, it fits here.
+        The runtimes are coding agents, which is to say a shell, a filesystem and a network. One of the apps above runs Python over a CSV you drop in. Another reads real sources and hands back a cited brief. If you would do the job at a terminal, it fits here.
       </dd>
     </div>
     <div>

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -12,10 +12,10 @@
     {Fountain.Brand.name()} is the hosted {Fountain.Brand.engine()}. The engine is open source and you can run it yourself.
   </p>
   <h1 class="text-4xl sm:text-5xl font-bold tracking-tight text-[var(--color-text-primary)] mb-5 leading-tight">
-    Every agent gets a brief, a budget, and a boundary.
+    The agent took an afternoon. The machine under it takes a quarter.
   </h1>
   <p class="text-lg sm:text-xl text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-10">
-    Hire an agent by role. It picks up where it left off, and it can hand work to the others on your roster. Run it on our infrastructure, or on hardware inside your own network.
+    You are shipping a product, not an agent platform. {Fountain.Brand.name()} is the API under the agents inside it. One call gets a sandbox with a checkout, credentials the model never sees, and the answer back instead of the transcript.
   </p>
   <div class="flex flex-col sm:flex-row gap-3 justify-center mb-4">
     <a
@@ -39,61 +39,136 @@
   </p>
 </section>
 
-<%!-- Problem --%>
+<%!-- The problem, stated as the questions a builder hits between a working
+      demo and a shipped feature. Every answer names the mechanism that
+      settles it, and every mechanism has its own section further down. --%>
 <section class="bg-[var(--color-bg-1)] border-y border-[var(--color-border)]">
   <div class="max-w-5xl mx-auto px-6 py-16">
     <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-3 text-center">
-      The agent takes an afternoon. The machine under it takes a quarter.
+      Six questions between a demo and a product.
     </h2>
-    <p class="text-center text-[var(--color-text-secondary)] max-w-xl mx-auto mb-8">
-      Want an agent that fixes a failing test, answers a customer, or opens a pull request from inside your product? Before it can, somebody has to build all of this:
+    <p class="text-center text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-10">
+      The agent works on your laptop. Putting it in front of your users means answering all of these first, and not one of them is the thing you set out to build.
     </p>
-    <ul class="max-w-xl mx-auto space-y-4 text-[var(--color-text-secondary)]">
-      <li class="flex items-start gap-3">
-        <span class="mt-2 size-1.5 rounded-full bg-[var(--color-brand)] flex-shrink-0"></span>
-        <span>
-          <span class="font-medium text-[var(--color-text-primary)]">A machine.</span>
-          A filesystem, a shell, a package manager, a checkout, a network. Real infrastructure, and not the thing you set out to ship.
-        </span>
-      </li>
-      <li class="flex items-start gap-3">
-        <span class="mt-2 size-1.5 rounded-full bg-[var(--color-brand)] flex-shrink-0"></span>
-        <span>
-          <span class="font-medium text-[var(--color-text-primary)]">
-            A way to hand it secrets.
-          </span>
-          A GitHub token that can push, an API key that can charge. None of it may reach the prompt, the model's context, or the transcript you keep.
-        </span>
-      </li>
-      <li class="flex items-start gap-3">
-        <span class="mt-2 size-1.5 rounded-full bg-[var(--color-brand)] flex-shrink-0"></span>
-        <span>
-          <span class="font-medium text-[var(--color-text-primary)]">An owner.</span>
-          Something that starts the machine, parks it when the talk stops, wakes it on the next message, keeps every account's work apart, and stops it before the bill notices.
-        </span>
-      </li>
-    </ul>
-    <p class="text-center text-[var(--color-text-secondary)] max-w-xl mx-auto mt-8">
-      {Fountain.Brand.name()} is that machine, that vault and that owner. You keep the conversation.
+    <div class="grid sm:grid-cols-2 gap-6">
+      <div class="p-5 rounded-lg bg-[var(--color-bg)] border border-[var(--color-border)]">
+        <h3 class="font-medium text-[var(--color-text-primary)] mb-2">
+          Where does it run?
+        </h3>
+        <p class="text-sm text-[var(--color-text-secondary)]">
+          An agent needs a filesystem, a shell, a package manager, a checkout and a network. That is a machine, and somebody has to build the thing that builds machines. Here an Environment describes one, and a conversation spawns it.
+        </p>
+      </div>
+      <div class="p-5 rounded-lg bg-[var(--color-bg)] border border-[var(--color-border)]">
+        <h3 class="font-medium text-[var(--color-text-primary)] mb-2">
+          How does it get a token that can push?
+        </h3>
+        <p class="text-sm text-[var(--color-text-secondary)]">
+          A GitHub token that can open a pull request, an API key that can charge. None of it may reach the prompt, the model's context or the transcript you keep. Vaults hold those, encrypted per account, and hand them to the machine rather than to the model.
+        </p>
+      </div>
+      <div class="p-5 rounded-lg bg-[var(--color-bg)] border border-[var(--color-border)]">
+        <h3 class="font-medium text-[var(--color-text-primary)] mb-2">
+          How does the work get out?
+        </h3>
+        <p class="text-sm text-[var(--color-text-secondary)]">
+          It does not have to. The agent already holds the checkout and the credential, so it opens the pull request itself. Nothing of yours copies a diff out of somebody else's cloud.
+        </p>
+      </div>
+      <div class="p-5 rounded-lg bg-[var(--color-bg)] border border-[var(--color-border)]">
+        <h3 class="font-medium text-[var(--color-text-primary)] mb-2">
+          How do I get an answer instead of a transcript?
+        </h3>
+        <p class="text-sm text-[var(--color-text-secondary)]">
+          Your users want the reply, not a harness dumping tool calls at them. Await the run and read one field. When you do want the stream, the server parses each runtime's dialect first, so you render one shape whether the agent is Claude Code or Codex.
+        </p>
+      </div>
+      <div class="p-5 rounded-lg bg-[var(--color-bg)] border border-[var(--color-border)]">
+        <h3 class="font-medium text-[var(--color-text-primary)] mb-2">
+          Who turns the machines off?
+        </h3>
+        <p class="text-sm text-[var(--color-text-secondary)]">
+          Something has to start a sandbox, park it when the talk stops, wake it on the next message, keep every thread's work apart and stop it before the bill notices. That owner is the platform, and you do not write it.
+        </p>
+      </div>
+      <div class="p-5 rounded-lg bg-[var(--color-bg)] border border-[var(--color-border)]">
+        <h3 class="font-medium text-[var(--color-text-primary)] mb-2">
+          What starts one when nobody is at a keyboard?
+        </h3>
+        <p class="text-sm text-[var(--color-text-secondary)]">
+          An alert fires, a ticket opens, a cron comes round. Each of those is one HTTP call that hires an agent, and a signed webhook tells your system when the turn is done.
+        </p>
+      </div>
+    </div>
+    <p class="text-center text-[var(--color-text-secondary)] max-w-xl mx-auto mt-10">
+      {Fountain.Brand.name()} is that machine, that vault and that owner. You keep the product.
     </p>
   </div>
 </section>
 
-<%!-- One teammate. Lane one's whole promise, and every claim in it is
-      generally available, so nothing here carries a status badge. --%>
+<%!-- How it works --%>
+<section class="max-w-5xl mx-auto px-6 py-16">
+  <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-10 text-center">
+    Everything above is three rows and one call.
+  </h2>
+  <div class="grid md:grid-cols-2 gap-10 items-start">
+    <ol class="space-y-6 text-[var(--color-text-secondary)]">
+      <li class="flex items-start gap-4">
+        <span class="flex-shrink-0 size-7 rounded-full bg-[var(--color-brand)] text-white text-sm font-semibold flex items-center justify-center">
+          1
+        </span>
+        <span>
+          <span class="font-medium text-[var(--color-text-primary)]">
+            Describe the machine once.
+          </span>
+          An Environment describes the machine an agent wakes up on. It names repositories, packages and env vars, and the scripts that run first. Write it in the console, or apply it as YAML from the CLI.
+        </span>
+      </li>
+      <li class="flex items-start gap-4">
+        <span class="flex-shrink-0 size-7 rounded-full bg-[var(--color-brand)] text-white text-sm font-semibold flex items-center justify-center">
+          2
+        </span>
+        <span>
+          <span class="font-medium text-[var(--color-text-primary)]">Name the agent.</span>
+          Pick the runtime and the model, add skills and MCP servers, attach the Environment. Or start from a ready-made one and change what you need.
+        </span>
+      </li>
+      <li class="flex items-start gap-4">
+        <span class="flex-shrink-0 size-7 rounded-full bg-[var(--color-brand)] text-white text-sm font-semibold flex items-center justify-center">
+          3
+        </span>
+        <span>
+          <span class="font-medium text-[var(--color-text-primary)]">Send a prompt.</span>
+          A sandbox spawns and the agent works. The reply streams back as it goes. Send another prompt and the same machine is still there, with its work on it.
+        </span>
+      </li>
+    </ol>
+    <pre
+      class="rounded-xl border border-[var(--color-border)] bg-[var(--color-code-bg)] text-[var(--color-code-text)] p-5 text-sm leading-relaxed overflow-x-auto"
+      phx-no-format
+    ><code>{sdk_example()}</code></pre>
+  </div>
+</section>
+
+<%!-- The durable thread, told as the thing a builder maps onto their own ids
+      rather than as a coworker they message. Every claim here is generally
+      available, so nothing carries a status badge. The key is `channel_id`
+      (`Conversations.create/2`); it resumes a conversation for the same agent,
+      vault and environment, so the copy says "the same agent" rather than
+      claiming a global unique key. --%>
 <section class="max-w-5xl mx-auto px-6 py-16">
   <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-8 text-center">
-    Close the laptop. The work is still there.
+    One user, one machine, one thread that survives.
   </h2>
   <div class="max-w-2xl mx-auto space-y-4 text-[var(--color-text-secondary)]">
     <p>
-      A teammate is an agent with a thread that keeps going. Give it a name and a one-line brief.
+      Bind a conversation to an id you already have. A customer, a ticket, a Slack channel, a row in your database. The next prompt you send for the same id and the same agent continues that conversation, so there is no lookup table and nothing to carry between messages.
     </p>
     <p>
-      It parks when you stop typing, and a parked teammate costs nothing. The next message wakes it with its files and its checkout intact. The second message costs a sentence, not a re-explanation of the first.
+      It parks when nobody is typing, and a parked sandbox costs nothing and takes none of your concurrency. The next message wakes it with its files and its checkout intact. The second prompt costs a sentence, not a re-explanation of the first.
     </p>
     <p>
-      Give it a schedule and it works while you are not there. "Each weekday at nine" is a cron, and the reply lands in the thread when it is done.
+      Put one on a schedule and it runs when nobody is there. "Each weekday at nine" is a cron, and the reply lands in the thread when it is done.
     </p>
     <p>
       Its memory is the disk it runs on. End the conversation and the memory goes with it, and the thread survives without it.
@@ -101,79 +176,81 @@
   </div>
   <p class="mt-8 text-center">
     <a
-      href={~p"/auth/register"}
+      href={~p"/docs/api"}
       class="inline-flex items-center justify-center px-5 py-2.5 rounded-lg border border-[var(--color-border)] text-[var(--color-text-primary)] text-sm font-medium hover:bg-[var(--color-bg-2)] transition-colors"
     >
-      Hire your first teammate
+      Read the API reference
     </a>
   </p>
 </section>
 
-<%!-- The roster. Every mechanism named here ships unflagged, which is why none
-      of it carries a badge. The closing concession is the hero's "budget"
-      doing its work: recursion has no server-side cap, and the balance is what
-      bounds it. --%>
+<%!-- Scale, which is the question a builder asks third and which this platform
+      answers with a real ceiling rather than a promise. Every mechanism named
+      here ships unflagged, so none of it carries a badge. The concession at
+      the end is the honest half: the hosted ceiling is low today, and a
+      hundred at once is the self-hosted lane. Do not put a number on the
+      fleet ceiling here; the limits section already refuses to, because it is
+      an operator setting rather than a published product promise. --%>
 <section class="bg-[var(--color-bg-1)] border-y border-[var(--color-border)]">
   <div class="max-w-5xl mx-auto px-6 py-16">
     <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-3 text-center">
-      Agents that cooperate contractually.
+      A hundred tickets is a hundred calls, not an architecture.
     </h2>
     <p class="text-center text-[var(--color-text-secondary)] max-w-xl mx-auto mb-10">
-      A roster is not a list of bots. Each agent is hired for a role, and it can hand work to the others.
+      There is no queue for you to run, no worker pool to size and no image to bake per repository. There is a ceiling, and we would rather you read it here than find it in production.
     </p>
 
     <div class="grid sm:grid-cols-2 gap-6">
-      <%!-- create-team --%>
+      <%!-- fan-out: from your code, or from inside an agent --%>
       <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6">
         <h3 class="font-semibold text-[var(--color-text-primary)] mb-2">
-          Five questions, then a roster
+          Fan out from your code, or from inside an agent
         </h3>
         <p class="text-sm text-[var(--color-text-secondary)] leading-relaxed">
-          Say <code class="text-xs px-1 py-0.5 rounded bg-[var(--color-bg-2)]">/create-team</code>
-          to any teammate. It asks five questions about the work and the repos in scope. The model keys you hold decide which brains it can offer. It proposes nothing you cannot run, and creates nothing until you say yes.
+          One call starts one conversation, so a batch is a loop. Every sandbox also carries the skill that starts more conversations, so an agent can split its own work, run the pieces in parallel and collect the answers. Each child takes its own machine, or shares the one its parent is on.
         </p>
       </div>
 
-      <%!-- fountain-team MCP --%>
+      <%!-- ADR 0023: many conversations, one sandbox, with the real capacities --%>
       <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6">
         <h3 class="font-semibold text-[var(--color-text-primary)] mb-2">
-          They reach each other by role
+          Or put many conversations on one machine
         </h3>
         <p class="text-sm text-[var(--color-text-secondary)] leading-relaxed">
-          A teammate resolves another by description. "The engineer" or "whoever handles support" returns a match, and the message lands in that teammate's thread with the sender named in front. A lead routes work, and nobody has to relay it.
+          Several conversations can share one sandbox and take turns at the same time, with a separate transcript each. Claude Code and Codex run as many as you send. opencode and gemini run one at a time, and a turn past that is refused rather than queued.
         </p>
       </div>
 
-      <%!-- the fountain skill --%>
+      <%!-- The cap, said out loud. --%>
       <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6">
         <h3 class="font-semibold text-[var(--color-text-primary)] mb-2">
-          Any agent can fan out
+          The ceiling is published, not discovered
         </h3>
         <p class="text-sm text-[var(--color-text-secondary)] leading-relaxed">
-          Every sandbox carries the skill that starts more conversations. An agent runs a batch of them in parallel and collects the answers. Each child takes its own computer, or shares the one its parent is on.
+          On this platform your balance sets how many run at once, up to a stated maximum, under a ceiling for the whole fleet. Both refuse in plain words rather than charging you or silently queueing. Need a higher one? Ask, and we raise it on your account.
         </p>
       </div>
 
       <%!-- allowlists, versions, provenance --%>
       <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6">
         <h3 class="font-semibold text-[var(--color-text-primary)] mb-2">
-          What makes it contractual
+          Every run can be reconstructed afterwards
         </h3>
         <p class="text-sm text-[var(--color-text-secondary)] leading-relaxed">
-          An agent may only launch with the environments and vaults on its allowlist. Every shape it has had is kept as a version, and each conversation records the version it ran under. A spawned conversation carries its parent's id, so the whole chain can be rebuilt afterwards.
+          An agent may only launch with the environments and vaults on its allowlist. Every shape it has had is kept as a version, and each conversation records the version it ran under. A conversation an agent spawned carries its parent's id, so the whole chain can be rebuilt.
         </p>
       </div>
     </div>
 
     <p class="mt-10 max-w-2xl mx-auto text-sm text-[var(--color-text-secondary)] leading-relaxed">
-      Nothing stops recursion on our side. The skill tells the agent to cap its own depth, and a runaway fan-out is a real way to spend money. What bounds it is the budget. Your balance sets how many agents can run at once, and an agent cannot spend past it.
+      Two honest limits. Nothing stops recursion on our side, so the skill tells each agent to cap its own depth and your balance is the backstop under a runaway fan-out. And the hosted ceiling is set for a platform this size, so a hundred machines at once means asking us to raise it, or running the sandboxes on hardware you own.
     </p>
     <p class="mt-8 text-center">
       <a
-        href={~p"/auth/register"}
+        href={~p"/self-hosted"}
         class="inline-flex items-center justify-center px-5 py-2.5 rounded-lg border border-[var(--color-border)] text-[var(--color-text-primary)] text-sm font-medium hover:bg-[var(--color-bg-2)] transition-colors"
       >
-        Build a roster
+        Run the sandboxes yourself
       </a>
     </p>
   </div>
@@ -219,7 +296,7 @@
         MCP, both directions
       </dt>
       <dd class="mt-1 text-sm text-[var(--color-text-secondary)] leading-relaxed">
-        Your agents reach the servers you declare on them. Fountain injects its own on top. A teammate can read the roster and message the others without you wiring anything.
+        Your agents reach the servers you declare on them. {Fountain.Brand.name()} injects its own on top, so one of your agents can read the roster and message the others without you wiring anything.
       </dd>
     </div>
 
@@ -281,10 +358,10 @@
 
       <div>
         <dt class="font-medium text-[var(--color-text-primary)]">
-          A teammate is not a shared inbox
+          A conversation is not a shared inbox
         </dt>
         <dd class="mt-1 text-sm text-[var(--color-text-secondary)] leading-relaxed">
-          One agent has one thread on one computer. Two people who message the same teammate are talking to the same thread and the same machine.
+          One conversation is one thread on one machine. Two of your users pointed at the same conversation share both, and see each other's work. Give each of them an id of their own.
         </dd>
       </div>
 
@@ -298,50 +375,6 @@
   </div>
 </section>
 
-<%!-- How it works --%>
-<section class="max-w-5xl mx-auto px-6 py-16">
-  <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-10 text-center">
-    Everything above is three rows and one call.
-  </h2>
-  <div class="grid md:grid-cols-2 gap-10 items-start">
-    <ol class="space-y-6 text-[var(--color-text-secondary)]">
-      <li class="flex items-start gap-4">
-        <span class="flex-shrink-0 size-7 rounded-full bg-[var(--color-brand)] text-white text-sm font-semibold flex items-center justify-center">
-          1
-        </span>
-        <span>
-          <span class="font-medium text-[var(--color-text-primary)]">
-            Describe the machine once.
-          </span>
-          An Environment describes the machine an agent wakes up on. It names repositories, packages and env vars, and the scripts that run first. Write it in the console, or apply it as YAML from the CLI.
-        </span>
-      </li>
-      <li class="flex items-start gap-4">
-        <span class="flex-shrink-0 size-7 rounded-full bg-[var(--color-brand)] text-white text-sm font-semibold flex items-center justify-center">
-          2
-        </span>
-        <span>
-          <span class="font-medium text-[var(--color-text-primary)]">Name the agent.</span>
-          Pick the runtime and the model, add skills and MCP servers, attach the Environment. Or start from a ready-made one and change what you need.
-        </span>
-      </li>
-      <li class="flex items-start gap-4">
-        <span class="flex-shrink-0 size-7 rounded-full bg-[var(--color-brand)] text-white text-sm font-semibold flex items-center justify-center">
-          3
-        </span>
-        <span>
-          <span class="font-medium text-[var(--color-text-primary)]">Send a prompt.</span>
-          A sandbox spawns and the agent works. The reply streams back as it goes. Send another prompt and the same machine is still there, with its work on it.
-        </span>
-      </li>
-    </ol>
-    <pre
-      class="rounded-xl border border-[var(--color-border)] bg-[var(--color-code-bg)] text-[var(--color-code-text)] p-5 text-sm leading-relaxed overflow-x-auto"
-      phx-no-format
-    ><code>{sdk_example()}</code></pre>
-  </div>
-</section>
-
 <%!-- Feature cards --%>
 <section class="bg-[var(--color-bg-1)] border-y border-[var(--color-border)]">
   <div class="max-w-5xl mx-auto px-6 py-16">
@@ -349,10 +382,11 @@
       What you stop building.
     </h2>
     <p class="text-center text-[var(--color-text-secondary)] max-w-xl mx-auto mb-10 -mt-6">
-      The roster above runs on four things you would otherwise have written yourself.
+      Four things you would otherwise have written yourself, and then owned.
     </p>
     <div class="grid sm:grid-cols-2 gap-6">
-      <%!-- Per-user threads --%>
+      <%!-- One seam over the runtimes and the sandbox providers. The card the
+            durable-thread section used to duplicate. --%>
       <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6">
         <div class="size-9 rounded-lg bg-[var(--color-bg-2)] flex items-center justify-center mb-4">
           <svg
@@ -369,10 +403,10 @@
           </svg>
         </div>
         <h3 class="font-semibold text-[var(--color-text-primary)] mb-2">
-          One machine per user, one thread per user
+          One integration, not eight
         </h3>
         <p class="text-sm text-[var(--color-text-secondary)] leading-relaxed">
-          Bind a conversation to any id you already have, such as a Slack channel, a customer, or a row in your database. Each one gets a durable thread on its own sandbox. No lookup table, and nothing to carry between messages.
+          Claude Code, Codex, opencode and Gemini sit behind one API, and so do the sandbox platforms under them. Change the runtime an agent runs, or the platform its machine comes from, and your code does not move.
         </p>
       </div>
 
@@ -488,7 +522,7 @@
     Or use the apps we built on it.
   </h2>
   <p class="text-center text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-10">
-    {Fountain.Brand.name()}'s own UI is a console for accounts, keys and agents. The apps you work in are these three. Each is static files in a browser talking to the same API you get, so each one runs against your account the moment you sign in.
+    {Fountain.Brand.name()}'s own UI is a console for accounts, keys and agents, and it is not the app your users meet. These three are. Each is static files in a browser calling the same public API your key opens, with no backend of its own, so each is a worked example of the thing you are about to write. Open one, read its source, take the parts you need.
   </p>
   <div class="grid md:grid-cols-3 gap-6">
     <article
@@ -532,7 +566,7 @@
       People build whole products on it.
     </h2>
     <p class="text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-8">
-      {length(built_apps_flat())} are open source and running right now. Beside the three above: a researcher that returns cited briefs, an analyst that runs Python on your CSV, an SRE on a cron, a DNS desk with an approval gate. Most have no backend of their own.
+      {length(built_apps_flat())} are open source and running right now. A researcher that returns cited briefs, an analyst that runs Python on your CSV, an SRE on a cron, a DNS desk with an approval gate. Most have no backend of their own, and in several of them nothing on screen says the word agent. The product is the document, the chart or the text message.
     </p>
     <ul class="flex flex-wrap justify-center gap-2 mb-8">
       <li
@@ -564,7 +598,7 @@
   </h2>
   <div class="max-w-2xl mx-auto space-y-4 text-center text-[var(--color-text-secondary)]">
     <p>
-      A teammate can hold an email address and a number of its own. Text it and it answers in its thread, on the same computer it has been working on all week.
+      An agent can hold an email address and a number of its own. A message to either arrives as a prompt in its thread, on the same machine it has been working on all week, and the reply goes back the same way. Your product gets an inbound channel, and you do not run an inbox.
     </p>
     <p>
       {Fountain.Brand.name()} holds the keys to that inbox and that number. The sandbox is handed tools, and never a credential.
@@ -589,7 +623,7 @@
       Or run the whole thing yourself.
     </h2>
     <p class="text-center text-[var(--color-text-secondary)] max-w-xl mx-auto mb-10">
-      One question decides it. If your code and your secrets cannot leave your own infrastructure, this platform was never the answer for you.
+      Two questions send you here. If your customers' code and secrets cannot leave your own infrastructure, this platform was never the answer for you. And if you need more machines at once than the ceiling above allows, the ceiling is a setting in a config file you own.
     </p>
 
     <div class="max-w-2xl mx-auto space-y-4 text-[var(--color-text-secondary)]">
@@ -618,7 +652,7 @@
 <%!-- Objections --%>
 <section class="max-w-5xl mx-auto px-6 py-16">
   <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-10 text-center">
-    Things you would ask before signing up.
+    Things you would ask before building on it.
   </h2>
   <dl class="max-w-2xl mx-auto space-y-6 text-[var(--color-text-secondary)]">
     <div>
@@ -636,12 +670,32 @@
         That is a credential {Fountain.Brand.name()} accepts. A Claude Pro or Team subscription works in place of a metered API key, and when you hold both, the subscription is the one your agents spend. It is usually the one you want spent.
       </dd>
     </div>
+    <%!-- The one a builder asks first and the page owes an honest answer to.
+          There are no organisations and no seats (see the limits section), so
+          say plainly which of the two shapes they get rather than implying a
+          multi-tenant model that does not exist. --%>
     <div>
       <dt class="font-medium text-[var(--color-text-primary)]">
-        What happens to the sandbox when I stop talking?
+        My product has users. Do they each need an account here?
       </dt>
       <dd class="mt-1 text-sm leading-relaxed">
-        It parks. The filesystem, the checkout and the agent's memory survive, and a parked sandbox costs nothing. The next message wakes it in seconds instead of minutes.
+        Usually not. Your account holds the agents and the key, and each of your users gets their own conversation on their own machine, keyed by an id you already have for them. When you would rather they held their own account and their own model key, Sign in with {Fountain.Brand.name()} is OAuth with PKCE and the token it hands back is an ordinary API key.
+      </dd>
+    </div>
+    <div>
+      <dt class="font-medium text-[var(--color-text-primary)]">
+        Is this only good for writing code?
+      </dt>
+      <dd class="mt-1 text-sm leading-relaxed">
+        The runtimes are coding agents, which is to say a shell, a filesystem and a network. One of the apps above runs Python over a CSV you drop in. Another reads real sources and hands back a cited brief. If the job fits on a computer, it fits here.
+      </dd>
+    </div>
+    <div>
+      <dt class="font-medium text-[var(--color-text-primary)]">
+        What happens to the sandbox between messages?
+      </dt>
+      <dd class="mt-1 text-sm leading-relaxed">
+        It parks. The filesystem, the checkout and the agent's memory survive, a parked sandbox costs nothing, and it takes none of your concurrency. The next message wakes it in seconds instead of minutes.
       </dd>
     </div>
     <div>
@@ -649,7 +703,7 @@
         Is my work separate from everyone else's?
       </dt>
       <dd class="mt-1 text-sm leading-relaxed">
-        Every query is scoped to your account, every sandbox belongs to one conversation, and your secrets are encrypted with a key derived for your tenant alone.
+        Every query is scoped to your account, every sandbox belongs to one conversation unless you put another on it, and your secrets are encrypted with a key derived for your tenant alone.
       </dd>
     </div>
     <div>
@@ -672,10 +726,10 @@
 <section class="bg-[var(--color-bg-1)] border-t border-[var(--color-border)]">
   <div class="max-w-5xl mx-auto px-6 py-20 text-center">
     <h2 class="text-2xl sm:text-3xl font-bold text-[var(--color-text-primary)] mb-4">
-      Your first agent runs in minutes.
+      A key, a call, and a machine you did not build.
     </h2>
     <p class="text-[var(--color-text-secondary)] mb-8 max-w-lg mx-auto">
-      Sign up, paste a model key, send a prompt. No machine to provision, no card to enter, nothing that renews.
+      Sign up, paste a model key, send a prompt. No machine to provision, no card to enter, nothing that renews. Then go back to the part that is actually your product.
     </p>
     <a
       href={~p"/auth/register"}
@@ -705,7 +759,7 @@
     </h2>
     <p class="mt-3 mb-12 text-center text-[var(--color-text-secondary)] max-w-xl mx-auto">
       No plans, no seats, no monthly fee. Buy credit, and every hour an agent
-      works comes out of it. Bring your own model keys — {Fountain.Brand.name()} never bills
+      works comes out of it. Bring your own model keys. {Fountain.Brand.name()} never bills
       you for inference.
     </p>
 

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -12,10 +12,10 @@
     {Fountain.Brand.name()} is the hosted {Fountain.Brand.engine()}. The engine is open source and you can run it yourself.
   </p>
   <h1 class="text-4xl sm:text-5xl font-bold tracking-tight text-[var(--color-text-primary)] mb-5 leading-tight">
-    The agent took an afternoon. The machine under it takes a quarter.
+    You did not set out to run a sandbox platform.
   </h1>
   <p class="text-lg sm:text-xl text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-10">
-    You are shipping a product, not an agent platform. {Fountain.Brand.name()} is the API under the agents inside it. One call gets a sandbox with a checkout, credentials the model never sees, and the answer back instead of the transcript.
+    But an agent in front of your users needs one, and then you maintain it. {Fountain.Brand.name()} is that half. One call gets a sandbox with a checkout, credentials the model never sees, a lifecycle that parks and wakes itself, and the answer back instead of the transcript.
   </p>
   <div class="flex flex-col sm:flex-row gap-3 justify-center mb-4">
     <a

--- a/apps/fountain/test/fountain_web/brand_chrome_test.exs
+++ b/apps/fountain/test/fountain_web/brand_chrome_test.exs
@@ -40,7 +40,7 @@ defmodule FountainWeb.BrandChromeTest do
 
   test "the marketing page and legal pages name the brand; the CLI stays fountain", %{conn: conn} do
     home = conn |> get(~p"/") |> html_response(200)
-    assert home =~ "Every agent gets a brief, a budget, and a boundary."
+    assert home =~ "You did not set out to run a sandbox platform."
     assert home =~ "Managoat scrubs them from every line of output"
     # The CLI keeps the engine's name on a branded deployment. The anchor moved
     # to the protocols section when the surfaces card was replaced.

--- a/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
@@ -506,6 +506,66 @@ defmodule FountainWeb.MarketingControllerTest do
   # The three apps this project builds itself lead every page that shows the
   # roster (#1219). Each is one entry in built_apps/0 carrying a :flagship
   # key, so these tests are what stops a page naming them by hand and drifting.
+  describe "the security section on /" do
+    test "renders every answer and every limit", %{conn: conn} do
+      body = conn |> get(~p"/") |> html_response(200)
+
+      assert body =~ "The part you forward to your security reviewer."
+      assert body =~ ~s(data-role="security-answers")
+
+      for item <- FountainWeb.MarketingHTML.security_answers() do
+        assert body =~ escape(item.question), "the page drops #{inspect(item.question)}"
+
+        # A limit that never reaches the page is worse than no limit: the
+        # answer above it then reads as unqualified.
+        if item.limit, do: assert(body =~ escape(item.limit), "the page drops its limit")
+      end
+    end
+
+    test "says out loud what the platform does not have", %{conn: conn} do
+      body = conn |> get(~p"/") |> html_response(200)
+
+      assert body =~ "What we do not have."
+
+      for item <- FountainWeb.MarketingHTML.security_absent() do
+        assert body =~ escape(item), "the page drops #{inspect(String.slice(item, 0, 40))}"
+      end
+
+      # The four a reviewer asks for first. If one of these ever ships, this
+      # test is the reminder to delete its row rather than leave the page
+      # disclaiming something the platform now has.
+      assert body =~ "No SOC 2 report"
+      assert body =~ "no published sub-processor list"
+      assert body =~ "No single sign-on"
+      assert body =~ "No independent penetration test"
+    end
+
+    test "claims nothing for the egress broker, which runs for one account", %{conn: conn} do
+      body = conn |> get(~p"/") |> html_response(200)
+
+      # ADR 0019 is Proposed and live for the maintainer alone. The page may
+      # only name it among the things you cannot turn on.
+      assert body =~ "It is not something you can turn on yet"
+      refute body =~ "the sandbox never holds"
+    end
+
+    test "every link into the manual resolves to a page", %{conn: conn} do
+      body = conn |> get(~p"/") |> html_response(200)
+
+      links =
+        ~r/href="\/docs\/([^"#]+)/
+        |> Regex.scan(body)
+        |> Enum.map(fn [_, slug] -> slug end)
+        |> Enum.uniq()
+
+      assert links != []
+
+      for slug <- links do
+        assert match?({:ok, _}, Fountain.Docs.get(slug)), "/docs/#{slug} is not a page"
+      end
+    end
+  end
+
   describe "the flagship three" do
     test "the roster holds exactly three, each with the lines a featured card needs" do
       flagship = FountainWeb.MarketingHTML.flagship_apps()
@@ -598,6 +658,13 @@ defmodule FountainWeb.MarketingControllerTest do
         assert body =~ app.name, "/integrations does not name #{app.name}"
       end
     end
+  end
+
+  # Copy held in `marketing_html.ex` is plain text; the rendered page has been
+  # through HEEx, so an apostrophe is `&#39;` by the time it lands. Compare
+  # like with like rather than writing the entity into the expectation.
+  defp escape(text) do
+    text |> Phoenix.HTML.html_escape() |> Phoenix.HTML.safe_to_string()
   end
 end
 

--- a/apps/fountain/test/fountain_web/controllers/marketing_instance_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_instance_test.exs
@@ -28,7 +28,7 @@ defmodule FountainWeb.MarketingInstanceTest do
       assert body =~ ~p"/auth/login"
       assert body =~ "/docs"
 
-      refute body =~ "Every agent gets a brief, a budget, and a boundary."
+      refute body =~ "You did not set out to run a sandbox platform."
       refute body =~ "What you stop building."
       refute body =~ "14-day trial"
       refute body =~ "Managed agent infrastructure"
@@ -159,7 +159,7 @@ defmodule FountainWeb.MarketingInstanceTest do
       Application.put_env(:fountain, :marketing_site, true)
 
       body = conn |> get(~p"/") |> html_response(200)
-      assert body =~ "The agent took an afternoon. The machine under it takes a quarter."
+      assert body =~ "You did not set out to run a sandbox platform."
       assert body =~ "Managed agent infrastructure"
       refute body =~ "This instance runs agents on sandboxes"
     end

--- a/apps/fountain/test/fountain_web/controllers/marketing_instance_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_instance_test.exs
@@ -159,7 +159,7 @@ defmodule FountainWeb.MarketingInstanceTest do
       Application.put_env(:fountain, :marketing_site, true)
 
       body = conn |> get(~p"/") |> html_response(200)
-      assert body =~ "Every agent gets a brief, a budget, and a boundary."
+      assert body =~ "The agent took an afternoon. The machine under it takes a quarter."
       assert body =~ "Managed agent infrastructure"
       refute body =~ "This instance runs agents on sandboxes"
     end


### PR DESCRIPTION
The pitch read as a coworker product. "Hire an agent by role", "close the
laptop, the work is still there", "build a roster": every one of those puts the
reader in the seat of the person the agent works *for*. That is not who
arrives. The reader is building something, their users are the ones who will
meet the agent, and Fountain is a component of their system rather than the
product they are buying. Workbench is the clearest example we ship: a team's
dev workstation where Fountain is an enabling feature nobody on screen names.

The card the site unfurls with has said the builder thing all along ("hand your
app a conversation with it"). The page had drifted away from it.

## The page

**The headline** names the reader rather than estimating the work. The cost a
builder is weighing is not how long a sandbox platform takes to write. It is
that the platform is not on their value stream, that they would maintain it,
that it is made of edge cases, and that security and compliance will have
questions they have to answer.

> You did not set out to run a sandbox platform.
>
> But an agent in front of your users needs one, and then you maintain it.
> Fountain is that half.

**The problem section** becomes the six questions between a working demo and a
shipped feature, each answered with the mechanism that settles it. Where does
it run, how does it get a token that can push, how does the work get out, how
do I get an answer instead of a transcript, who turns the machines off, and
what starts one when nobody is at a keyboard. The SDK call moves up to sit
directly under them, because a builder wants the code before the features.

**"Close the laptop"** becomes the durable thread mapped onto ids the caller
already holds. **The roster section** becomes how a hundred tickets get worked
at once. **The phone number** becomes an inbound channel for the reader's
product. **The apps** stop being "the apps you work in" and become reference
implementations of the thing the reader is about to write: static files, no
backend, the same public API, source linked.

Two new objections, the ones a builder asks first. Whether their own users need
accounts here (they do not, and the alternative is Sign in with Fountain), and
whether any of this works outside writing code.

## The security review, answered on the page

A builder cannot put an agent in front of users without somebody asking where
the customer data goes and what the model can see. That material was already
here as three feature bullets in three sections, and none of it could be
forwarded to a reviewer.

`/` now carries a section written to be forwarded whole. Seven questions, each
answered with the mechanism rather than the intention. Every answer that has a
limit carries it directly underneath, which is the point of the section rather
than a footnote: the 8-byte redaction matches exact bytes so a re-encoded value
escapes it, `ask` is not the default and opencode cannot enforce it at all, and
a runner is trusted mode with no container between the agent and the machine.

It ends with **What we do not have**. No SOC 2, no ISO 27001, no HIPAA posture,
no DPA, no sub-processor list, no penetration test, no single sign-on, and an
egress broker that runs for one account and is not a thing anybody can turn on.
Every absence was verified against the repository rather than assumed. ADR 0019
is Proposed, and a page implying otherwise would be the exact failure the ADR
rule exists to prevent. `.agents/product-marketing.md` names the buyer who
needs orgs, seats, roles or SSO as the anti-persona, so this block sorts that
reader out on the first read instead of three calls in.

The suite pins every question, every limit and all five absences, asserts the
broker is only named among the things you cannot turn on, and checks that every
`/docs` link on the homepage resolves. That last check existed for the other
pitch pages and not for `/`.

Also fixed here: the Vault primitive is now introduced with the HashiCorp
collision stated before the feature, per `standards/voice-and-style.md`, which
the page was breaking at its first mention.

## Two snippets on the site were not runnable

Which is the worst thing a page aimed at builders can do.

- The homepage SDK call printed `run.output`. There is no such field on
  `RunResult`; a reader who pasted it got `undefined`. It prints `run.text`
  now, and passes the `channelId` that binds a conversation to a caller's own
  id.
- The `/integrations` pipeline scenario ran
  `fountain conversations create --external-id`. Neither the command nor the
  flag exists. The real one is `fountain run <agent> --prompt`.

## Nothing here claims a mechanism that is not built

Every claim was checked against the code before it went on the page. The
concurrency ceiling, the per-runtime capacity for a shared sandbox, the
unbounded recursion and the one-person account all stay on the page as limits.

One of them is worth a maintainer's attention rather than a reviewer's. **A
hundred concurrent sandboxes is not possible on the hosted platform today**:
the per-tenant ceiling is 20 and `SANDBOX_FLEET_CEILING` defaults to 20 as
well, so a `sandbox_limit_override` alone does not reach it. The scale section
therefore states the ceiling, says to ask for a higher one, and sends anybody
who needs more to `/self-hosted`, which now names that as its second reason to
go there. If scale should be a headline claim rather than a caveat, the fleet
ceiling is the thing to raise first.

## Gates

- the whole of `test/fountain_web/controllers` plus `brand_chrome_test`: 920 tests, 0 failures
- `docs_test`: 43 tests, 0 failures; `python3 scripts/docs-style.py` clean
- `mix credo --strict` clean, `mix format --check-formatted` clean

`marketing_instance_test.exs:146` pinned the old h1 and is updated to the new
one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C2cuxpjcAX3rr8HkuTR3Us

