### PR TITLE
design(marketing): the footer wraps into groups instead of one long row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,14 @@ upgrade, is in
 
 ### Changed
 
+- **The marketing footer wraps into groups instead of one long row.** Ten
+  links on one line had gone cramped as pages were added, and the row was
+  ordered by nothing. They sit under Product, Learn and Account now, with the
+  brand and its one-line description in the first column and the copyright,
+  Terms and Privacy on a rule below. A deployment that is not the marketing
+  site drops the Product group whole rather than heading an empty column, so
+  a self-host still gets a footer with only the two groups it can fill.
+
 - **`/self-hosted` leads with the bring-up.** The compose block is on the
   first screen beside the argument rather than three sections down, the
   headline is the reason to run it yourself, and the four things a bring-up

--- a/apps/fountain/lib/fountain_web/components/layouts/marketing.html.heex
+++ b/apps/fountain/lib/fountain_web/components/layouts/marketing.html.heex
@@ -67,84 +67,142 @@
     {@inner_content}
   </main>
 
-  <%!-- Footer --%>
-  <footer class="border-t border-[var(--color-border)] bg-[var(--color-bg-1)]">
-    <div class="max-w-5xl mx-auto px-6 py-6 flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-[var(--color-text-muted)]">
+  <%!-- Footer. One row of ten links had gone cramped, so the links wrap into
+    groups by meaning rather than by whatever the viewport allows. A deployment
+    that is not the marketing site keeps only the two groups it can honour. --%>
+  <footer class="border-t border-[var(--color-border)] bg-[var(--color-bg-1)] text-sm">
+    <div class="max-w-5xl mx-auto px-6 py-10">
+      <div class="grid grid-cols-2 gap-x-8 gap-y-10 md:grid-cols-4">
+        <div class="col-span-2 md:col-span-1">
+          <a href="/" class="flex items-center gap-2">
+            <img src={Fountain.Brand.asset("app-icon.png")} alt="" class="size-6 rounded-md" />
+            <span class="font-semibold text-[var(--color-text-primary)]">
+              {Fountain.Brand.name()}
+            </span>
+          </a>
+          <p class="mt-3 max-w-xs text-[var(--color-text-muted)]">
+            <span :if={Fountain.Marketing.site?()}>
+              Managed agent infrastructure for teams who'd rather build than configure.
+            </span>
+            <span :if={!Fountain.Marketing.site?()}>Powered by Fountain.</span>
+          </p>
+        </div>
+
+        <div :if={Fountain.Marketing.site?()} data-role="footer-product">
+          <h2 class="text-xs font-semibold uppercase tracking-wider text-[var(--color-text-secondary)]">
+            Product
+          </h2>
+          <ul class="mt-4 space-y-2.5 text-[var(--color-text-muted)]">
+            <li>
+              <a
+                href={~p"/integrations"}
+                class="hover:text-[var(--color-text-primary)] transition-colors"
+              >
+                Integrations
+              </a>
+            </li>
+            <li>
+              <a
+                href={~p"/built-with"}
+                class="hover:text-[var(--color-text-primary)] transition-colors"
+              >
+                Built with
+              </a>
+            </li>
+            <li>
+              <a
+                href={~p"/case-studies/self-healing-infrastructure"}
+                class="hover:text-[var(--color-text-primary)] transition-colors"
+              >
+                Case study
+              </a>
+            </li>
+          </ul>
+        </div>
+
+        <div data-role="footer-learn">
+          <h2 class="text-xs font-semibold uppercase tracking-wider text-[var(--color-text-secondary)]">
+            Learn
+          </h2>
+          <ul class="mt-4 space-y-2.5 text-[var(--color-text-muted)]">
+            <li>
+              <a href="/docs" class="hover:text-[var(--color-text-primary)] transition-colors">
+                Docs
+              </a>
+            </li>
+            <li :if={Fountain.Marketing.site?()}>
+              <a
+                href={~p"/self-hosted"}
+                class="hover:text-[var(--color-text-primary)] transition-colors"
+              >
+                Self-host
+              </a>
+            </li>
+            <li :if={Fountain.Marketing.site?()}>
+              <a
+                href="/docs/open-source"
+                class="hover:text-[var(--color-text-primary)] transition-colors"
+              >
+                Open source
+              </a>
+            </li>
+          </ul>
+        </div>
+
+        <div data-role="footer-account">
+          <h2 class="text-xs font-semibold uppercase tracking-wider text-[var(--color-text-secondary)]">
+            Account
+          </h2>
+          <ul class="mt-4 space-y-2.5 text-[var(--color-text-muted)]">
+            <%= if @current_user do %>
+              <li>
+                <a
+                  href={~p"/dashboard"}
+                  class="hover:text-[var(--color-text-primary)] transition-colors"
+                >
+                  Go to app
+                </a>
+              </li>
+            <% else %>
+              <li>
+                <a
+                  href={~p"/auth/login"}
+                  class="hover:text-[var(--color-text-primary)] transition-colors"
+                >
+                  Sign in
+                </a>
+              </li>
+              <li :if={Fountain.Accounts.registration_enabled?()}>
+                <a
+                  href={~p"/auth/register"}
+                  class="hover:text-[var(--color-text-primary)] transition-colors"
+                >
+                  Register
+                </a>
+              </li>
+            <% end %>
+          </ul>
+        </div>
+      </div>
+
       <%!-- The hosted site's copyright line names the brand, and credits the
         engine, which is open source. Somebody else's deployment gets an
         attribution. --%>
-      <span :if={Fountain.Marketing.site?()}>
-        © 2026 {Fountain.Brand.name()}. Managed agent infrastructure for teams who'd rather build than configure.
-        <span :if={Fountain.Brand.hosted?()}>
-          It runs {Fountain.Brand.engine()}, which is open source.
+      <div class="mt-10 pt-6 border-t border-[var(--color-border)] flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3 text-[var(--color-text-muted)]">
+        <span>
+          © 2026 {Fountain.Brand.name()}.
+          <span :if={Fountain.Brand.hosted?()}>
+            It runs {Fountain.Brand.engine()}, which is open source.
+          </span>
         </span>
-      </span>
-      <span :if={!Fountain.Marketing.site?()}>Powered by Fountain.</span>
-      <div class="flex items-center gap-4">
-        <a
-          :if={Fountain.Marketing.site?()}
-          href={~p"/integrations"}
-          class="hover:text-[var(--color-text-secondary)] transition-colors"
-        >
-          Integrations
-        </a>
-        <a
-          :if={Fountain.Marketing.site?()}
-          href={~p"/built-with"}
-          class="hover:text-[var(--color-text-secondary)] transition-colors"
-        >
-          Built with
-        </a>
-        <a
-          :if={Fountain.Marketing.site?()}
-          href={~p"/case-studies/self-healing-infrastructure"}
-          class="hover:text-[var(--color-text-secondary)] transition-colors"
-        >
-          Case study
-        </a>
-        <a
-          :if={Fountain.Marketing.site?()}
-          href={~p"/self-hosted"}
-          class="hover:text-[var(--color-text-secondary)] transition-colors"
-        >
-          Self-host
-        </a>
-        <a href="/docs" class="hover:text-[var(--color-text-secondary)] transition-colors">
-          Docs
-        </a>
-        <%= if Fountain.Legal.published?() do %>
-          <a href={~p"/terms"} class="hover:text-[var(--color-text-secondary)] transition-colors">
+        <div :if={Fountain.Legal.published?()} class="flex items-center gap-6">
+          <a href={~p"/terms"} class="hover:text-[var(--color-text-primary)] transition-colors">
             Terms
           </a>
-          <a
-            href={~p"/privacy"}
-            class="hover:text-[var(--color-text-secondary)] transition-colors"
-          >
+          <a href={~p"/privacy"} class="hover:text-[var(--color-text-primary)] transition-colors">
             Privacy
           </a>
-        <% end %>
-        <%= if @current_user do %>
-          <a
-            href={~p"/dashboard"}
-            class="hover:text-[var(--color-text-secondary)] transition-colors"
-          >
-            Go to app
-          </a>
-        <% else %>
-          <a
-            href={~p"/auth/login"}
-            class="hover:text-[var(--color-text-secondary)] transition-colors"
-          >
-            Sign in
-          </a>
-          <a
-            :if={Fountain.Accounts.registration_enabled?()}
-            href={~p"/auth/register"}
-            class="hover:text-[var(--color-text-secondary)] transition-colors"
-          >
-            Register
-          </a>
-        <% end %>
+        </div>
       </div>
     </div>
   </footer>

--- a/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
@@ -476,6 +476,33 @@ defmodule FountainWeb.MarketingControllerTest do
     end
   end
 
+  # The footer used to be one row of ten links, which went cramped as pages
+  # were added. It is groups now, so the test is that every destination the
+  # single row carried is still reachable from one of them.
+  describe "the marketing footer" do
+    test "groups every link it used to carry in one row", %{conn: conn} do
+      body = conn |> get(~p"/") |> html_response(200)
+
+      for group <- ~w(product learn account) do
+        assert body =~ ~s(data-role="footer-#{group}")
+      end
+
+      for path <- [
+            ~p"/integrations",
+            ~p"/built-with",
+            ~p"/case-studies/self-healing-infrastructure",
+            ~p"/self-hosted",
+            "/docs",
+            "/docs/open-source",
+            ~p"/terms",
+            ~p"/privacy",
+            ~p"/auth/login"
+          ] do
+        assert body =~ path
+      end
+    end
+  end
+
   # The three apps this project builds itself lead every page that shows the
   # roster (#1219). Each is one entry in built_apps/0 carrying a :flagship
   # key, so these tests are what stops a page naming them by hand and drifting.

--- a/apps/fountain/test/fountain_web/controllers/marketing_instance_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_instance_test.exs
@@ -40,6 +40,22 @@ defmodule FountainWeb.MarketingInstanceTest do
       assert body =~ ~s(<meta property="og:image:alt" content="Fountain")
     end
 
+    # The footer groups its links now. A deployment that is not the marketing
+    # site has nothing to put under Product, so the whole group goes rather
+    # than leaving a heading over an empty column.
+    test "keeps only the footer groups it can fill", %{conn: conn} do
+      body = conn |> get(~p"/") |> html_response(200)
+
+      refute body =~ ~s(data-role="footer-product")
+      assert body =~ ~s(data-role="footer-learn")
+      assert body =~ ~s(data-role="footer-account")
+
+      refute body =~ ~p"/integrations"
+      refute body =~ ~p"/built-with"
+      refute body =~ ~p"/self-hosted"
+      refute body =~ ~p"/case-studies/self-healing-infrastructure"
+    end
+
     test "keeps the price off the page even with a price configured", %{conn: conn} do
       Application.put_env(:fountain, :stripe_price_monthly_cents, 2900)
       on_exit(fn -> Application.delete_env(:fountain, :stripe_price_monthly_cents) end)


### PR DESCRIPTION
The marketing footer was one row of ten links, and it had gone cramped as
pages were added — Integrations, Built with, Case study, Self-host, Docs,
Terms, Privacy, Sign in, Register, all on one line, ordered by nothing.

They wrap into groups now.

## What it looks like

Four columns: the brand mark and its one-line description first, then
**Product** (Integrations, Built with, Case study), **Learn** (Docs,
Self-host, Open source) and **Account** (Sign in / Register, or Go to
app). Below a rule: the copyright on the left, Terms and Privacy on the
right. Two columns at small widths, one row of link groups at `md`.

No wordmark and no newsletter block. It is the same footer, wrapped.

Two smaller things fall out of it:

- The one-line description moves out of the copyright sentence, which was
  carrying both the credit and the pitch.
- `/docs/open-source` joins the Learn group. ADR 0034 makes it the
  project's front door and nothing in the footer pointed at it.

## The self-host case

A deployment that is not the marketing site has nothing to put under
Product — every link in it is gated on `Fountain.Marketing.site?()` — so
the whole group drops rather than heading an empty column. That render is
brand, Learn (Docs) and Account.

## Tests

Each group carries a `data-role="footer-*"`, so a test can name one
without matching a word that appears elsewhere on the page.

- `marketing_controller_test.exs` asserts every destination the single row
  carried is still reachable from one of the groups.
- `marketing_instance_test.exs` asserts the instance render drops Product
  and keeps Learn and Account.

The second was checked by ungating the group: it fails, along with three
existing instance tests.

## Verification

Shot on a dev server in three configurations — hosted with `PRODUCT_NAME`
and the legal vars set, hosted bare, and `MARKETING_SITE` off — at 1349px
and at 390px. `mix precommit` is green end to end: dialyzer 0 errors,
4112 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019B2Qm8mqhFeadXDDVB2CKo