### PR TITLE
Docs CI: a third prose gate, for AI-writing tells

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -851,6 +851,21 @@ jobs:
         if: ${{ needs.changes.outputs.docs_touched == 'true' }}
         run: vale lint docs
 
+      # AI-writing tells, the third prose gate beside the style sheet and STE.
+      # The engine is vendored from lex00/sentences (MIT) under
+      # scripts/destink/vendor; scripts/destink/sync.mjs re-copies it and
+      # scripts/destink/destink.mjs holds the rule set, with the count each
+      # enabled and disabled rule produced over docs/. Node, because the engine
+      # is TypeScript and runs on Node's own type stripping, which needs >=23.
+      # No setup-node here: this job already installed Node 24 for the SDK
+      # steps above, unconditionally. A second setup-node would re-point the
+      # npm cache at a different lockfile for the rest of the job.
+      - name: Docs de-stink
+        if: ${{ needs.changes.outputs.docs_touched == 'true' }}
+        run: |
+          npm ci --prefix scripts/destink
+          node scripts/destink/destink.mjs
+
   compose-fresh-clone:
     name: Compose fresh-clone check
     runs-on: ubuntu-24.04
@@ -1099,6 +1114,24 @@ jobs:
 
       - name: Docs Simplified Technical English
         run: vale lint docs
+
+      # AI-writing tells, the third prose gate beside the style sheet and STE.
+      # The engine is vendored from lex00/sentences (MIT) under
+      # scripts/destink/vendor; scripts/destink/sync.mjs re-copies it and
+      # scripts/destink/destink.mjs holds the rule set, with the count each
+      # enabled and disabled rule produced over docs/. Node, because the engine
+      # is TypeScript and runs on Node's own type stripping, which needs >=23.
+      - name: Set up Node for the de-stink gate
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: scripts/destink/package-lock.json
+
+      - name: Docs de-stink
+        run: |
+          npm ci --prefix scripts/destink
+          node scripts/destink/destink.mjs
 
       - name: Set up Go
         if: ${{ needs.changes.outputs.cli_docs == 'true' }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -487,6 +487,28 @@ Guardrails that trip people who only edit markdown:
   the standard before you fight the linter — it lists the three traps (joined
   table cells, a code span opening a sentence, `anything` matching the -ing
   rule) and where a suppression comment is legitimate.
+- **`node scripts/destink/destink.mjs` looks for AI-writing tells.** The third
+  prose gate. The engine is vendored from
+  [lex00/sentences](https://github.com/lex00/sentences) (MIT) under
+  `scripts/destink/vendor`, pinned by the SHA in `vendor/UPSTREAM` and re-copied
+  by `scripts/destink/sync.mjs`. **Nothing in `vendor/` is edited** — the sync
+  overwrites it wholesale, so a local fix there is reverted silently.
+  `scripts/destink/allow.txt` is the backlog and is **empty**, like the other
+  two. Two things to know before fighting it:
+  - **It lints prose, not markdown.** `extract-prose.mjs` blanks code fences,
+    tables, inline code, link targets, HTML blocks and admonition directives,
+    replacing each character with a space so every offset still indexes the
+    real file. Run whole over raw markdown the linter reported 2,721 findings,
+    of which ~1,750 were markdown mistaken for writing: `--` in a CLI flag read
+    as an em dash, table rows read as sentence fragments, and `guides` and
+    `operate` read as words because they sat in a URL. If a finding points at
+    something that is not prose, the fix is in the extractor, not the page.
+  - **The rule set is opt-in, and each entry carries its count.** `ENABLED` and
+    `DISABLED` in `scripts/destink/destink.mjs` list all 46 vendored rules with
+    the number each produced over `docs/` and, for the disabled ones, why. Opt-in
+    is the safety property: a rule added upstream between syncs arrives off. The
+    gate refuses to run if an id named there is missing from the vendored
+    registry, which is what a rename upstream looks like from here.
 - **`docs/cli.md` is diffed against the CLI.** `cli/internal/cmd/docs_test.go`
   fails if a command exists that the page does not mention, or the page
   mentions one that does not exist. Add a CLI command → add it to `docs/cli.md`

--- a/docs/api.md
+++ b/docs/api.md
@@ -29,7 +29,7 @@ that somebody remembered to document.
 
 **An API key. Use this for a script and for CI.**
 
-Create a key under Account → API Keys. Or exchange your credentials at
+Create a key under Account, then API Keys. Or exchange your credentials at
 `POST /api/auth/token`, which is what `fountain auth login` does. Then pass
 the key as a Bearer token.
 
@@ -115,7 +115,7 @@ URIs. A client or a redirect that nobody registered renders an error page, and
 Fountain redirects nowhere.
 
 A code lives five minutes, and it works once. The key is full-scope, it
-expires in 30 days, and it lists under Account → API keys as
+expires in 30 days, and it lists under Account, then API keys, as
 `oauth:<client_id>`.
 
 ## Account state
@@ -278,7 +278,7 @@ somewhere else can read it, and hard-code nothing.
 A model list is a set of suggestions, and not an allowlist. Fountain accepts
 any `provider/model` under a provider it knows.
 
-`package_managers` names what Fountain truly installs from an environment's
+`package_managers` names what Fountain installs from an environment's
 `packages`, which is `apt` and `npm`. It stores another key and ignores it.
 
 To draw an avatar, Fountain uses the tenant's own OpenAI credential. Without

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -144,7 +144,7 @@ a state of `started`, `done`, `failed` or `interrupted`.
 
     Then one of two things happens. **`checkpoint_restore`** is a warm start
     from an environment checkpoint, and it skips the rest. Or the cold
-    pipeline runs, which is **`packages` → `network` → `clone` → `setup`**.
+    pipeline runs, which is **`packages`, then `network`, then `clone`, then `setup`**.
     The sandbox is then `ready`. A step that fails destroys the sprite, and
     marks the sandbox and the conversation `failed`.
 3. **`turn`.** Fountain spawns the runtime, which is claude, codex, gemini or

--- a/docs/build/index.md
+++ b/docs/build/index.md
@@ -112,7 +112,7 @@ appears in both threads. Read [Team](../api.md#team).
 [Nostr](../integrations/buzz.md). Where the instance allows it, the teammate
 also answers from its own email address and phone number.
 
-Each of those surfaces binds its own durable thread, through the mechanism
+Each of those surfaces binds its own durable thread, by the mechanism
 your app uses. Your UI is one door onto something that exists whether or not
 the tab is open.
 

--- a/docs/build/pieces.md
+++ b/docs/build/pieces.md
@@ -74,7 +74,7 @@ thread.
 
 **The 202 is not the answer.** `POST /messages` queues a turn and returns the
 conversation id. Everything after that arrives on the stream. So an app that
-awaits a reply really awaits stream events. The SDK's `Run` handle does that
+awaits a reply must await stream events. The SDK's `Run` handle does that
 wait for you.
 
 **Secrets arrive at spawn, and not at the prompt.** Fountain merges the

--- a/docs/build/team-chat.md
+++ b/docs/build/team-chat.md
@@ -392,7 +392,7 @@ instance.
 
 [Sign in with Fountain](../api.md#sign-in-with-fountain-oauth-20-for-browser-apps)
 is OAuth 2.0 authorization code with PKCE. The token it returns *is* an API
-key. It lists and revokes under Account → API keys, and a sign-out revokes it.
+key. It lists and revokes under Account, then API keys, and a sign-out revokes it.
 For an app with no backend, that is the whole authentication story.
 
 ## The whole thing, runnable

--- a/docs/catalog/agents/fountain-contributor.md
+++ b/docs/catalog/agents/fountain-contributor.md
@@ -3,7 +3,7 @@
 > An agent that contributes to Fountain itself, configured to work the way a
 > maintainer's laptop session does.
 
-## At a glance
+## Summary
 
 | | |
 |---|---|
@@ -55,7 +55,7 @@ test, so the suite runs without it.
       -p "Read issue #NNN and fix it"
     ```
 
-The `--vault` flag is not optional in practice. The repo clone, `gh`, and the
+The `--vault` flag is not optional. The repo clone, `gh`, and the
 DCO identity all come from the vault.
 
 ## Verify

--- a/docs/catalog/mcp-servers/fountain-buzz.md
+++ b/docs/catalog/mcp-servers/fountain-buzz.md
@@ -2,7 +2,7 @@
 
 > Lets a hosted Buzz agent publish its reply to a Nostr channel.
 
-## At a glance
+## Summary
 
 | | |
 |---|---|

--- a/docs/catalog/mcp-servers/fountain-comms.md
+++ b/docs/catalog/mcp-servers/fountain-comms.md
@@ -3,7 +3,7 @@
 > Gives a teammate its own email address and phone number, and gives it no
 > keys.
 
-## At a glance
+## Summary
 
 | | |
 |---|---|

--- a/docs/catalog/mcp-servers/fountain-gmail.md
+++ b/docs/catalog/mcp-servers/fountain-gmail.md
@@ -3,7 +3,7 @@
 > Gives an agent a Gmail mailbox that the account owner connected once, and
 > gives it no Google token.
 
-## At a glance
+## Summary
 
 | | |
 |---|---|

--- a/docs/catalog/mcp-servers/fountain-team.md
+++ b/docs/catalog/mcp-servers/fountain-team.md
@@ -2,7 +2,7 @@
 
 > Lets a teammate see who else is on the team, and message them.
 
-## At a glance
+## Summary
 
 | | |
 |---|---|

--- a/docs/catalog/runtimes/claude.md
+++ b/docs/catalog/runtimes/claude.md
@@ -2,7 +2,7 @@
 
 > Anthropic's Claude Code CLI, headless in the sandbox.
 
-## At a glance
+## Summary
 
 | | |
 |---|---|

--- a/docs/catalog/runtimes/codex.md
+++ b/docs/catalog/runtimes/codex.md
@@ -2,7 +2,7 @@
 
 > OpenAI's Codex CLI, headless in the sandbox.
 
-## At a glance
+## Summary
 
 | | |
 |---|---|

--- a/docs/catalog/runtimes/gemini.md
+++ b/docs/catalog/runtimes/gemini.md
@@ -3,7 +3,7 @@
 > Google's Gemini CLI. The last runtime to reach ACP, and it reached it on
 > 2026-08-22.
 
-## At a glance
+## Summary
 
 | | |
 |---|---|

--- a/docs/catalog/runtimes/opencode.md
+++ b/docs/catalog/runtimes/opencode.md
@@ -2,7 +2,7 @@
 
 > The opencode CLI. The only runtime that can reach more than one provider.
 
-## At a glance
+## Summary
 
 | | |
 |---|---|

--- a/docs/catalog/skills/create-team.md
+++ b/docs/catalog/skills/create-team.md
@@ -3,7 +3,7 @@
 > A five-question conversation that proposes a roster of teammates, creates
 > them, and hands them over.
 
-## At a glance
+## Summary
 
 | | |
 |---|---|
@@ -19,14 +19,14 @@ Say `/create-team` to any teammate. Or ask it what the team must look like.
 **It asks at most five questions**, one at a time. It offers a default with
 each one, so "yes" is a complete answer.
 
-1. What must the team get done?
-2. Which repos or services are in scope, and which need a token?
-3. How many teammates, roughly? Two to five is usual. Past three, a lead
-   earns its place.
-4. Any brain preference? It reads `GET /api/catalog` for the models, and your
+1. The work the team must get done.
+2. The repos or services in scope, and which of them need a token.
+3. How many teammates. Two to five is usual. Past three, a lead earns its
+   place.
+4. Any brain preference. It reads `GET /api/catalog` for the models, and your
    inference credentials for the providers you hold a key for. It proposes
    nothing you cannot run.
-5. What names? Role names such as `repo-maintainer`, or a themed set.
+5. The names. Role names such as `repo-maintainer`, or a themed set.
 
 **Then it proposes.** You get a table of name, brain, a one-line role, and the
 first thing it would send each teammate.

--- a/docs/catalog/skills/fountain.md
+++ b/docs/catalog/skills/fountain.md
@@ -3,7 +3,7 @@
 > Lets an agent start more Fountain conversations from inside its own sandbox,
 > and stream them.
 
-## At a glance
+## Summary
 
 | | |
 |---|---|

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -162,8 +162,8 @@ wins on a collision. `--environment` provisions from that environment, and not
 from the agent's own.
 
 The `--sandbox` flag attaches the conversation to a sandbox you already have,
-by id. Two conversations then share one disk. A conversation's `sandbox_id`
-names its sandbox.
+by id. Two conversations then share one disk. The `sandbox_id` field names
+that disk.
 
 The `--sandbox-mode` flag is `ephemeral` or `persistent`. It replaces the
 agent's default for this conversation. A persistent conversation lands on the

--- a/docs/concepts/sandboxes.md
+++ b/docs/concepts/sandboxes.md
@@ -97,7 +97,7 @@ deny-all.
 
 ## Capabilities are honest, and that has consequences
 
-An adapter advertises what it can truly do, from `:suspend`,
+An adapter advertises only what it can do, from `:suspend`,
 `:network_policy`, `:attach`, `:tty`, `:checkpoint` and `:public_url`. The
 lifecycle then degrades to match, and it pretends nothing.
 

--- a/docs/concepts/secrets.md
+++ b/docs/concepts/secrets.md
@@ -127,7 +127,7 @@ value. It cannot audit the read, because that read happens in the sandbox.
 everything in the merged map. That is why the value is there at all. Scope the
 credential. Do not scope the agent.
 
-## Hop 5, which is really a hop back: Fountain scrubs the output
+## Hop 5, a hop back: Fountain scrubs the output
 
 Fountain writes everything a sandbox sends to stdout or stderr into
 `log_events`, word for word, and streams it over SSE. That table has none of

--- a/docs/concepts/surfaces.md
+++ b/docs/concepts/surfaces.md
@@ -104,6 +104,6 @@ that it can move and break no link.
 
 - [Plug into Fountain](../integrations/clients.md), for editors, chat
   surfaces, plugins and SDKs.
-- [Build a chat app](../build/index.md), the case for the API below it.
+- [Build a chat app](../build/index.md), and why the API below it exists.
 - [API reference](../api.md).
 - [Agents as teammates](teammates.md), which is what the Team app renders.

--- a/docs/guides/operate/dashboards.md
+++ b/docs/guides/operate/dashboards.md
@@ -210,7 +210,7 @@ above, so the repo stays the description of record.
 
 ## Related
 
-- [Wire up observability](observability.md), for the scrape, the alerts and the
+- [Configure observability](observability.md), for the scrape, the alerts and the
   health endpoints.
 - [See what sandboxes cost](sandbox-spend.md), for the per-account view.
 - [Operations overview](../../operations.md).

--- a/docs/guides/operate/deploy.md
+++ b/docs/guides/operate/deploy.md
@@ -64,8 +64,7 @@ any other role change (ADR 0011).
 Register **before** you expose the instance to a network you do not trust.
 While no admin exists, the first verified account takes the role.
 
-Do you want the manual path instead? Set `FIRST_USER_ADMIN=false` and use a
-release task. Read [Run a release task](run-a-release-task.md).
+For the manual path, set `FIRST_USER_ADMIN=false` and use a release task. Read [Run a release task](run-a-release-task.md).
 
 ```bash
 docker compose exec app bin/fountain_server eval \
@@ -148,7 +147,7 @@ value then becomes unreadable.
 Does the app serve while a sandbox fails to start? The sandbox provider is the
 usual cause. Read [Sandbox errors](../../troubleshooting/sandbox-errors.md).
 
-Does the container never open a listener? Migrations cannot reach the
+If the container never opens a listener, migrations cannot reach the
 database. Read
 [Pods restart or never go ready](../../troubleshooting/pods-restarting.md).
 

--- a/docs/guides/operate/kubernetes.md
+++ b/docs/guides/operate/kubernetes.md
@@ -86,6 +86,6 @@ work.
 
 ## Related
 
-- [Wire up observability](observability.md), for the PrometheusRule.
+- [Configure observability](observability.md), for the PrometheusRule.
 - [Back up and restore](back-up-and-restore.md).
 - [Architecture](../../architecture.md), for the cluster picture.

--- a/docs/guides/operate/observability.md
+++ b/docs/guides/operate/observability.md
@@ -1,4 +1,4 @@
-# Wire up observability
+# Configure observability
 
 This guide shows you how to scrape metrics. It also shows you how to import
 the dashboard and alerts that ship with the repo, and where to point your
@@ -19,7 +19,7 @@ observability pack, built from a real run of the hosted instance.
   says what it means and what to do. It needs the PrometheusRule CRD, and it
   sits commented out of the kustomization until you turn it on.
 - **A starter dashboard**, in `deploy/grafana/fountain-dashboard.json`. It is
-  built from metrics the app truly exports, and from nothing else. Import it
+  built from metrics the app exports, and from nothing else. Import it
   into Grafana, then choose your Prometheus datasource. On compose, point any
   Prometheus at the metrics port and import the same file.
 - **Three team dashboards**, in `deploy/grafana/`, one each for ops, product

--- a/docs/guides/operate/sandbox-spend.md
+++ b/docs/guides/operate/sandbox-spend.md
@@ -97,7 +97,7 @@ account tag, because one time series per account would grow without a bound.
 Per-account numbers belong in the admin panel and the API, where they are a
 column.
 
-See [Wire up observability](observability.md) for how to scrape the endpoint.
+See [Configure observability](observability.md) for how to scrape the endpoint.
 
 ## When to distrust the parked figures
 
@@ -125,4 +125,4 @@ credentials and never reaches a Fountain invoice.
 - [Start billing](billing.md), to charge for what you measure here. <!-- vale disable-line STE.IngForms -->
 - [Change sandbox lifetimes](sandbox-lifetime.md), the main lever on the total.
 - [About sandboxes](../../concepts/sandboxes.md), for what a sandbox is.
-- [Wire up observability](observability.md), for the metrics endpoint.
+- [Configure observability](observability.md), for the metrics endpoint.

--- a/docs/index.md
+++ b/docs/index.md
@@ -90,8 +90,8 @@ in full.
   an agent somewhere else
 - [Architecture](architecture.md), what runs, what it talks to, and what breaks
   when a dependency is down
-- [Why a bot needs more than a chat UI](build/index.md), the case for the API
-  below it
+- [Why a bot needs more than a chat UI](build/index.md), and why the API below
+  it exists
 
 ## Build with it
 

--- a/docs/integrations/buzz.md
+++ b/docs/integrations/buzz.md
@@ -59,7 +59,7 @@ stays inside Fountain, which signs with it. The sandbox never holds it.
 <figcaption><b>Four parties, and Fountain in the middle.</b> The owner provisions once; then Fountain speaks Nostr to the relay <em>as the agent</em>, drives the coding agent in a sandbox over ACP, and the sandbox asks Fountain to publish through an MCP tool, so it never touches the relay or the key itself.</figcaption>
 </figure>
 
-## At a glance
+## Summary
 
 | | |
 |---|---|
@@ -379,7 +379,7 @@ different parties**, govern those two things.
 | kind **30177** | The **owner**, from Buzz Desktop at deploy. | The policy that Desktop builds its own agent directory from. |
 
 The harness publishes its 10100 at startup, and at each change of channel
-membership. It builds the event from the channels it truly subscribes to, and
+membership. It builds the event from the channels it subscribes to, and
 from its real `respond_to`. That entry is accurate about the harness.
 
 **Buzz Desktop 0.5.17 and newer ignores it when a 30177 exists.** It builds

--- a/docs/integrations/daytona.md
+++ b/docs/integrations/daytona.md
@@ -15,7 +15,7 @@ DAYTONA_SNAPSHOT=fountain          # a snapshot built from images/daytona/ (unse
 # SANDBOX_PROVIDER=daytona
 ```
 
-## At a glance
+## Summary
 
 | | |
 |---|---|

--- a/docs/integrations/e2b.md
+++ b/docs/integrations/e2b.md
@@ -13,7 +13,7 @@ E2B_TEMPLATE=fountain        # a template built from images/e2b/ (see below)
 # SANDBOX_PROVIDER=e2b       # make it the instance default
 ```
 
-## At a glance
+## Summary
 
 | | |
 |---|---|

--- a/docs/integrations/editors.md
+++ b/docs/integrations/editors.md
@@ -13,7 +13,7 @@ the pipe. That process talks HTTP and SSE to your Fountain instance.
    (ACP over stdio)                                                  (the agent)
 ```
 
-## At a glance
+## Summary
 
 | | |
 |---|---|

--- a/docs/integrations/github-oauth.md
+++ b/docs/integrations/github-oauth.md
@@ -3,7 +3,7 @@
 **Optional.** It adds "Continue with GitHub" to the login and registration
 pages. Email and password auth works without it.
 
-## At a glance
+## Summary
 
 | | |
 |---|---|

--- a/docs/integrations/hermes.md
+++ b/docs/integrations/hermes.md
@@ -35,7 +35,7 @@ Four reasons to reach for it.
   conversation is open in the Fountain conversations app while it runs.
 - **Fan-out is a loop of tool calls**, and not orchestration code.
 
-## At a glance
+## Summary
 
 | | |
 |---|---|

--- a/docs/integrations/langchain.md
+++ b/docs/integrations/langchain.md
@@ -18,7 +18,7 @@ alpha, behind the `openai_compat` flag. There is no package to install from
 us. One file, `fountain_langchain.py`, is the whole integration, and the
 example ships it.
 
-## At a glance
+## Summary
 
 | | |
 |---|---|

--- a/docs/integrations/mail.md
+++ b/docs/integrations/mail.md
@@ -5,7 +5,7 @@ verification email that Fountain throws away leaves signup at a dead end, with
 no error to see. There are exactly three options, and Fountain checks them in
 the order below.
 
-## At a glance
+## Summary
 
 | | |
 |---|---|

--- a/docs/integrations/openai-compatible.md
+++ b/docs/integrations/openai-compatible.md
@@ -18,7 +18,7 @@ needs to in a sandbox of its own.
 There is no plugin and no code on the client. The base URL, a key, and one
 header are the whole integration.
 
-## At a glance
+## Summary
 
 | | |
 |---|---|

--- a/docs/integrations/openbot.md
+++ b/docs/integrations/openbot.md
@@ -2,8 +2,7 @@
 
 [OpenBot](https://copilotkit.ai/openbot) is CopilotKit's self-hosted agent
 platform. It has channels, a coworker roster, an audit trail, and a browser
-computer for each bot. A "Bot" there is not a framework and not an SDK. It is
-**any HTTP endpoint that speaks
+computer for each bot. A "Bot" there is **any HTTP endpoint that speaks
 [AG-UI](https://github.com/ag-ui-protocol/ag-ui)**, the open protocol for
 interaction between an agent and a user.
 
@@ -23,7 +22,7 @@ agent the same way, whether it is a hand-written client or another product
 built on the protocol. OpenBot is the host we built it against and verified it
 against, and nothing more.
 
-## At a glance
+## Summary
 
 | | |
 |---|---|

--- a/docs/integrations/openclaw.md
+++ b/docs/integrations/openclaw.md
@@ -19,7 +19,7 @@ speaks ACP over stdio. So the integration is a config block, and not code.
    (a chat channel)   (ACP over stdio)                                        (the agent)
 ```
 
-## At a glance
+## Summary
 
 | | |
 |---|---|
@@ -264,7 +264,7 @@ level at the harness on the way. That is the case that used to abort the turn
 [#760](https://github.com/BinaryBourbon/fountain/issues/760)).
 
 When you test through `openclaw agent`, or with a prompt that must delegate,
-check that the harness truly ran. OpenClaw's own model will happily answer a
+check that the harness ran. OpenClaw's own model will happily answer a
 "reply with X" prompt itself, and report success. The tell is a
 `sessions_spawn` call in the tool summary, and a new conversation on the
 Fountain agent. From the Fountain side, `fountain conv list` shows it, with

--- a/docs/integrations/platform-requirements.md
+++ b/docs/integrations/platform-requirements.md
@@ -255,7 +255,7 @@ desirable.
 
 !!! note "Advertise or refuse, never pretend"
 
-    An orchestrator can degrade gracefully around a capability that is absent.
+    An orchestrator can degrade around a capability that is absent.
     It cannot degrade around a capability that you claim and that then quietly
     does nothing.
 
@@ -286,14 +286,14 @@ list.
   platforms can differ. Three honest platforms with three shapes beat three
   identical ones.
 
-## Where this list leans
+## The bias in this list
 
 One consumer with one workload wrote it, and it shows.
 
 We over-specify sessions and streams, because an agent turn is a long
 conversation with a process. We under-specify scheduling, burst behaviour,
 cold-start latency, and everything else that a hundred-thousand-short-jobs
-workload cares about. A truly neutral contract needs another kind of customer
+workload cares about. A neutral contract needs another kind of customer
 in the room.
 
 The capability vocabulary also does more work than it should. `:suspend` today

--- a/docs/integrations/runners.md
+++ b/docs/integrations/runners.md
@@ -27,7 +27,7 @@ Three reasons to want one.
 [ADR 0022](https://github.com/BinaryBourbon/fountain/blob/main/decisions/0022-self-hosted-runner-provider.md)
 holds the design.
 
-## At a glance
+## Summary
 
 | | |
 |---|---|
@@ -70,14 +70,14 @@ processes belong to the daemon. It reconnects with backoff on any drop. It
 gives up only when Fountain refuses the key, rejects the name, or has runners
 switched off.
 
-Then pin an agent to it. Use **Agents → edit → Sandbox provider → runner**,
+Then pin an agent to it. Use **Agents**, then **edit**, then **Sandbox provider**, then **runner**,
 or send `sandbox_provider: "runner"` to `POST /api/agents`.
 
 Fountain places a new conversation for that agent on your **most recently
 connected online runner**. Start one while no runner is online and it fails
 plainly, with `no_runner_online` and HTTP 409. It does not queue.
 
-Account → Runners, or `GET /api/runners`, lists each machine that has
+Account, then Runners, or `GET /api/runners`, lists each machine that has
 connected, with live online status. `DELETE /api/runners/:id` forgets one. A
 daemon that you left up reconnects and registers itself again.
 

--- a/docs/integrations/sandbox-contract.md
+++ b/docs/integrations/sandbox-contract.md
@@ -48,7 +48,7 @@ conversation fails at provision time.
 
 ## What the contract guarantees
 
-- **Capabilities are honest.** An adapter advertises what it can truly do,
+- **Capabilities are honest.** An adapter advertises only what it can do,
   from `:suspend`, `:network_policy`, `:attach`, `:tty`, `:checkpoint` and
   `:public_url`. The lifecycle then degrades to match. A provider without
   `:suspend` destroys on idle, and does not fake a park. The agent's memory

--- a/docs/integrations/sentry.md
+++ b/docs/integrations/sentry.md
@@ -3,7 +3,7 @@
 **Optional, and inert until you opt in.** With no DSN set, the SDK sits there
 and does nothing. No account, no events, and nothing leaves your instance.
 
-## At a glance
+## Summary
 
 | | |
 |---|---|
@@ -69,7 +69,7 @@ report carries less context than a stock Sentry integration would.
 
 ## Related
 
-- [Wire up observability](../guides/operate/observability.md), and the alert
+- [Configure observability](../guides/operate/observability.md), and the alert
   pack.
 - [Back up and restore](../guides/operate/back-up-and-restore.md), which uses
   the Crons pattern above.

--- a/docs/integrations/sprites-contract.md
+++ b/docs/integrations/sprites-contract.md
@@ -2,14 +2,14 @@
 
 This page documents the **Sprites adapter's** transport contract. It covers
 each endpoint that `Fountain.Sandbox.Sprites` calls, the semantics it depends
-on, and the operational assumptions baked into it.
+on, and the operational assumptions it makes.
 
 [The sandbox contract](sandbox-contract.md) is the provider-neutral contract
 that each backend must meet. That is the `Fountain.Sandbox` behaviour and its
 conformance suite, `Fountain.SandboxConformanceCase`, which the
 [E2B](e2b.md) and [Daytona](daytona.md) adapters also satisfy. To evaluate a
 new backend, start there. This page is the reference for what the first
-backend truly provides.
+backend provides.
 
 The [Sprites integration guide](sprites.md) holds the setup and the cost
 model.
@@ -155,7 +155,7 @@ One that ignores a deny rule fails the whole `limited` feature open.
   unique for each token, as `fountain-<tenant-prefix>-<8 hex>`. A 409 on
   create means the sprite already exists. Fountain then adopts it, and raises
   no error. Destroy tolerates a 404. The hourly reaper converges
-  whatever the happy path leaked. A replacement needs stable name-keyed create
+  whatever the successful path leaked. A replacement needs stable name-keyed create
   and destroy semantics, and no more.
 - **Errors.** Any non-2xx surfaces as a status plus the decoded body. A
   rate-limit response carries a structured body, with
@@ -185,7 +185,7 @@ Here is the checklist. It needs the twelve operations above and bearer auth.
 It needs name-keyed idempotent create and destroy, with a 409 on a duplicate
 and a delete that tolerates a 404. It needs the stream-id frame protocol with
 a real exit frame, and detachable sessions that replay from the start. It
-needs NDJSON checkpoints that truly restore filesystem state, a network policy
+needs NDJSON checkpoints that restore filesystem state, a network policy
 that can deny, and `has_more` and `next_continuation_token` pagination.
 
 Get those semantics right, and the four subtle ones above with them.

--- a/docs/integrations/sprites.md
+++ b/docs/integrations/sprites.md
@@ -10,7 +10,7 @@ conversation fails at provision time.
 API surface Fountain consumes. It also says what a compatible replacement
 behind `SPRITES_BASE_URL` would have to provide.
 
-## At a glance
+## Summary
 
 | | |
 |---|---|

--- a/docs/integrations/stripe.md
+++ b/docs/integrations/stripe.md
@@ -11,7 +11,7 @@ tells Fountain about refunds and disputes. Nothing else. Billing is off by
 default (`CREDITS_ENABLED=false`), and that is the right setting for most
 self-hosted instances. Set this up only if you run Fountain commercially.
 
-## At a glance
+## Summary
 
 | | |
 |---|---|
@@ -23,7 +23,7 @@ self-hosted instances. Set this up only if you run Fountain commercially.
 
 ## The provider side
 
-1. **An API key**, from Developers → API keys, as `STRIPE_SECRET_KEY`.
+1. **An API key**, from Developers, then API keys, as `STRIPE_SECRET_KEY`.
 2. **A webhook endpoint** pointed at `<PUBLIC_URL>/api/stripe/webhook`,
    subscribed to these three events.
     - `checkout.session.completed`, which adds the credit a pack paid for.

--- a/docs/nav.yml
+++ b/docs/nav.yml
@@ -50,7 +50,7 @@ nav:
       - Prices: guides/operate/plans-and-prices.md
       - Back up and restore: guides/operate/back-up-and-restore.md
       - Upgrade an instance: guides/operate/upgrade.md
-      - Wire up observability: guides/operate/observability.md
+      - Configure observability: guides/operate/observability.md
       - Read the dashboards: guides/operate/dashboards.md
       - Run a release task: guides/operate/run-a-release-task.md
       - Operations overview: operations.md

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -25,7 +25,7 @@ Start from the symptom in [Troubleshoot a problem](troubleshooting/index.md).
   restore drill
 - [Upgrade an instance](guides/operate/upgrade.md), and what to do when one
   goes wrong
-- [Wire up observability](guides/operate/observability.md), which covers
+- [Configure observability](guides/operate/observability.md), which covers
   metrics, alerts, logs and the health endpoints
 
 ## How to stand one up

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -50,7 +50,7 @@ what breaks when a dependency is down.
 
 - [Back up and restore](guides/operate/back-up-and-restore.md)
 - [Upgrade an instance](guides/operate/upgrade.md)
-- [Wire up observability](guides/operate/observability.md)
+- [Configure observability](guides/operate/observability.md)
 - [Run a release task](guides/operate/run-a-release-task.md)
 
 When something is wrong, start from

--- a/docs/tour.md
+++ b/docs/tour.md
@@ -10,7 +10,7 @@ real run.
 
 ## What you must have
 
-- A Fountain API key (Account → API keys, or `fountain auth login`).
+- A Fountain API key (Account, then API keys, or `fountain auth login`).
 - A repository that you let an agent push a branch to.
 - A GitHub token that can push to it. Use a
   [fine-grained token](https://github.com/settings/personal-access-tokens)

--- a/docs/troubleshooting/pods-restarting.md
+++ b/docs/troubleshooting/pods-restarting.md
@@ -43,7 +43,7 @@ against a database problem that is older than the deploy. Read
 
 ## Related
 
-- [Wire up observability](../guides/operate/observability.md), for what each
+- [Configure observability](../guides/operate/observability.md), for what each
   health endpoint is for.
 - [Deploy on Kubernetes](../guides/operate/kubernetes.md).
 - [Architecture](../architecture.md), for which component owns which symptom.

--- a/docs/troubleshooting/sandbox-errors.md
+++ b/docs/troubleshooting/sandbox-errors.md
@@ -28,8 +28,8 @@ Fountain does **not** retry these, and that is deliberate.
 
 ## During a provider outage
 
-A new conversation fails, and so does a wake. A fresh provision marks the
-conversation `failed`. A wake leaves it resumable for later.
+A new conversation fails, and so does a wake. A fresh provision sets the
+conversation to `failed`. A wake leaves it resumable for later.
 
 Sign-in, dashboards, configuration and past logs all still work.
 
@@ -56,5 +56,5 @@ with `POST /api/admin/users/:id/sandbox-limit`. Read
 - [A conversation is stuck or failed](conversation-stuck-or-failed.md).
 - [The sandbox contract](../integrations/sandbox-contract.md), for the shared
   error taxonomy.
-- [Wire up observability](../guides/operate/observability.md), for the alert
+- [Configure observability](../guides/operate/observability.md), for the alert
   on a failure to provision.

--- a/scripts/destink/.gitignore
+++ b/scripts/destink/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/scripts/destink/allow.txt
+++ b/scripts/destink/allow.txt
@@ -1,0 +1,18 @@
+# The de-stink backlog. IT IS EMPTY.
+#
+# A page listed here is SKIPPED by scripts/destink/destink.mjs. Every page
+# under docs/ passes, so nothing is listed and every page is checked.
+#
+# Keep this file. Its emptiness is the point: adding a line is how you park a
+# page you have not cleaned yet, and an empty list says there are none. This
+# mirrors scripts/docs-style-allow.txt and .valeignore, which are empty for
+# the same reason.
+#
+# One line per path, relative to the repo root:
+#
+#   docs/guides/operate/deploy.md
+#
+# Prefer fixing the page. A whole page skipped is 33 rules off, not one, so a
+# line here is a big hammer. If a RULE rather than a page is the problem, the
+# right move is a DISABLED entry in scripts/destink/destink.mjs with the count
+# and the reason, so the decision is recorded once instead of per page.

--- a/scripts/destink/destink.mjs
+++ b/scripts/destink/destink.mjs
@@ -1,0 +1,239 @@
+#!/usr/bin/env node
+// The de-stink gate for docs/**/*.md. Third prose gate, beside scripts/docs-style.py (the
+// style sheet) and `vale lint docs` (ASD-STE100). This one looks for AI-writing tells.
+//
+//   node scripts/destink/destink.mjs              # every page under docs/
+//   node scripts/destink/destink.mjs docs/api.md  # named pages
+//   node scripts/destink/destink.mjs --json       # the full report, for tooling
+//
+// Exits 1 if any enabled rule fires on a page that is not on the allow list.
+//
+// THE ENGINE IS VENDORED, NOT WRITTEN HERE. vendor/ is a verbatim copy of the lint subtree of
+// github.com/lex00/sentences (MIT), pinned by the SHA in vendor/UPSTREAM. scripts/destink/sync.mjs
+// re-copies it. Nothing in vendor/ is edited: a local fix there would be silently reverted by the
+// next sync, so it belongs upstream.
+//
+// WHY ONLY SOME RULES ARE ON. The linter ships 40-odd rules aimed at prose in general. Run whole
+// over docs/ it reported 2,721 findings, and most were markdown or ordinary technical writing
+// rather than AI tells. ENABLED below is an explicit opt-in list with the measured count beside
+// each entry, and DISABLED records what was left off and why, so the next person does not have to
+// re-derive it. Opt-IN rather than opt-out is the safety property: a rule added upstream between
+// syncs arrives off, and turning it on is a deliberate edit with a number attached.
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { register } from "node:module";
+
+const HERE = fileURLToPath(new URL(".", import.meta.url));
+const ROOT = resolve(HERE, "../..");
+const DOCS = join(ROOT, "docs");
+const ALLOW = join(HERE, "allow.txt");
+
+// Rules that gate. The count is what the rule found over docs/ when it was turned on, so a
+// future reader can tell "this rule is quiet here" from "this rule was cleaned up".
+const ENABLED = new Set([
+  // --- found real tells, and the pages were fixed ---
+  "claude-fiction-gestures", //      27  "at a glance" as a section heading
+  "claude-technical-vocabulary", //  13  "Wire up", which is also a phrasal verb STE bans
+  "demo/intensifier", //             11  "truly", "really" as filler
+  "formatting/unicode-decoration", // 8  a bare arrow standing in for a verb
+  "syntactic/self-posed-question", // 7  asking the reader a question, then answering it
+  "claude-stock-frames", //           3  "the case for", "baked into"
+  "claude-discourse-markers", //      1
+  "claude/mirrored-clauses", //       1
+  "reframe", //                       1
+  "serves-as-dodge", //               1
+  // --- quiet on docs/ today, so they cost nothing and cover what gets written next ---
+  "claude/ai-leakage", //                    0  assistant boilerplate, leaked artifact strings
+  "claude-assistant-voice", //        0
+  "claude-fiction-frames", //         0
+  "claude/figurative-suffixes", //    0
+  "claude/aphoristic-ender", //       0
+  "corporate-jargon", //              0
+  "discourse/countdown", //           0
+  "repetition/dilution", //            0
+  "claude/elegant-variation", //   0
+  "excess-vocabulary", //             0
+  "formatting/listicle-in-trench-coat", // 0
+  "lex-delve-family", //              0
+  "lex-false-suspense", //            0
+  "lex-filler-transitions", //        0
+  "lex-invented-concept-labels", //   0
+  "lex-magic-adverbs", //             0
+  "lex-ornate-nouns", //              0
+  "lex-pedagogical-voice", //         0
+  "lex-signposts", //                 0
+  "lex-stakes-inflation", //          0
+  "lex-vague-attribution", //         0
+  "claude/sounds-like-claude", //            0
+  "ing-tackon", //          0
+]);
+
+// Left off, with the count each produced and the reason. A line moves from here to ENABLED by
+// cleaning the pages first, the same way scripts/docs-style-allow.txt only ever shrinks.
+const DISABLED = new Map([
+  ["tricolon/comma-series", "478 — 'a Postgres, an ingress controller, and the Secret' is a list, not a tricolon"],
+  ["anaphora/repeated-opening", "128 — parallel openings are deliberate here, and it reads link lists as sentences"],
+  ["repetition/near-duplicate", "98 — 'Read the X' repeats on purpose across Related sections"],
+  ["dead-metaphor/rare-lemma", "74 — no Technical Names list, so it flags 'agent', 'console', 'token'"],
+  ["formatting/em-dash-density", "39 — docs-style.py already bans em dashes; here '--' is a CLI flag"],
+  ["discourse/punchy-fragments", "24 — table cells and short procedural steps are not fragments"],
+  ["false-range/from-to", "21 — all candidate severity; 'from the key to the string' is ordinary English"],
+  ["claude/colon-reveal", "18 — docs-style.py already owns the colon that introduces a list"],
+  ["tricolon/density", "6 — same family as tricolon/comma-series"],
+  ["claude/contrast-tail", "6 — all candidate; 'X, not Y' is house style, including in CLAUDE.md"],
+  [
+    "formatting/bold-first-bullet",
+    "5 — every hit is a term-definition list (`- **`runtime`**, one of ...`). The bold IS the " +
+      "field name, not a run-in label the sentence could carry instead.",
+  ],
+  [
+    "discourse/staccato-register",
+    "1 — only reference/glossary.md, whose paragraphs are single definitions by construction. " +
+      "The measure (sentences per paragraph) does not mean the same thing on a glossary.",
+  ],
+  [
+    "discourse/setup-turn",
+    "1 — concepts/conversation.md, where it pairs the last sentence of one paragraph with the " +
+      "first of the next. The vendored splitter has no paragraph concept, so adjacency crosses " +
+      "a blank line. Fixing that belongs upstream, not in a rewrite of the page.",
+  ],
+]);
+
+const isMd = (p) => p.endsWith(".md");
+
+function walk(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const p = join(dir, entry);
+    if (statSync(p).isDirectory()) out.push(...walk(p));
+    else if (isMd(p)) out.push(p);
+  }
+  return out.sort();
+}
+
+// The ratchet, same shape and same rule as scripts/docs-style-allow.txt: a page listed here is
+// skipped, a page not listed is checked, and a line naming a page that no longer exists is an
+// error so a rename cannot quietly re-exempt one.
+function loadAllow() {
+  let raw;
+  try {
+    raw = readFileSync(ALLOW, "utf8");
+  } catch {
+    return new Set();
+  }
+  const out = new Set();
+  for (const line of raw.split("\n")) {
+    const trimmed = line.split("#", 1)[0].trim();
+    if (trimmed) out.add(trimmed);
+  }
+  return out;
+}
+
+// Line and column for an offset, 1-based, so output is clickable in an editor and in CI logs.
+function locate(text, offset) {
+  const before = text.slice(0, offset);
+  const line = before.split("\n").length;
+  const col = offset - (before.lastIndexOf("\n") + 1) + 1;
+  return { line, col };
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const json = args.includes("--json");
+  const paths = args.filter((a) => !a.startsWith("--"));
+
+  register(new URL("./ts-loader.mjs", import.meta.url));
+  const { extractProse } = await import("./extract-prose.mjs");
+  const { buildDocAnalysis } = await import("./vendor/lint/build-doc.js");
+  const { RULES } = await import("./vendor/lint/registry.js");
+  const { runRules } = await import("./vendor/lint/engine.js");
+
+  // An id in ENABLED or DISABLED that the registry no longer has means upstream renamed or
+  // deleted a rule. Fail loudly: the alternative is a gate that silently stops checking
+  // something, which is the failure this whole file is arranged to avoid. `demo/intensifier` in
+  // particular is one upstream calls a placeholder and plans to delete.
+  const known = new Set(RULES.map((r) => r.id));
+  const stale = [...ENABLED, ...DISABLED.keys()].filter((id) => !known.has(id));
+  if (stale.length) {
+    console.error(
+      `destink: these rule ids are named here but are not in the vendored registry:\n` +
+        stale.map((id) => `  ${id}`).join("\n") +
+        `\nUpstream renamed or removed them. Reconcile ENABLED/DISABLED in scripts/destink/destink.mjs\n` +
+        `against vendor/lint/registry.ts, then re-run.`,
+    );
+    process.exit(2);
+  }
+  // The other direction: a rule the registry has that this file does not mention at all. It
+  // arrived in a sync and nobody decided about it. Off is the safe default, but say so.
+  const undecided = RULES.filter((r) => !ENABLED.has(r.id) && !DISABLED.has(r.id)).map((r) => r.id);
+  if (undecided.length && !json) {
+    console.error(`destink: note — ${undecided.length} vendored rule(s) not yet triaged, left off:`);
+    for (const id of undecided) console.error(`  ${id}`);
+    console.error("");
+  }
+
+  const rules = RULES.filter((r) => ENABLED.has(r.id));
+  const allow = loadAllow();
+  const files = paths.length ? paths.map((p) => resolve(p)) : walk(DOCS);
+
+  const skipped = [];
+  const reports = [];
+  let findingCount = 0;
+
+  for (const file of files) {
+    const rel = relative(ROOT, file);
+    if (allow.has(rel)) {
+      skipped.push(rel);
+      continue;
+    }
+    const source = readFileSync(file, "utf8");
+    // Generated pages quote the world rather than describing it, and an edit here is undone by
+    // the next regeneration. docs-style.py and .vale-ste.yml make the same exemption.
+    if (source.slice(0, 2048).includes("<!-- GENERATED FILE")) {
+      skipped.push(rel);
+      continue;
+    }
+    const prose = extractProse(source);
+    const { findings, errors } = runRules(rules, buildDocAnalysis(prose));
+    for (const e of errors) console.error(`destink: rule ${e.ruleId} failed on ${rel}: ${e.message}`);
+    findingCount += findings.length;
+    reports.push({ file: rel, source, findings });
+  }
+
+  if (json) {
+    console.log(
+      JSON.stringify(
+        reports.map((r) => ({
+          file: r.file,
+          findings: r.findings.map((f) => ({ ...f, ...locate(r.source, f.span.start) })),
+        })),
+        null,
+        2,
+      ),
+    );
+    process.exit(findingCount ? 1 : 0);
+  }
+
+  for (const { file, source, findings } of reports) {
+    for (const f of findings) {
+      const { line, col } = locate(source, f.span.start);
+      const quoted = source.slice(f.span.start, f.span.end).replace(/\s+/g, " ").trim();
+      console.log(`${file}:${line}:${col}: ${f.ruleId} [${f.severity}] ${f.message}`);
+      console.log(`    ${quoted.length > 100 ? quoted.slice(0, 100) + "…" : quoted}`);
+      console.log(`    ${f.explanation}`);
+    }
+  }
+
+  const checked = files.length - skipped.length;
+  if (findingCount === 0) {
+    console.log(`destink: ${checked} page(s) clean, ${rules.length} rules.`);
+    return;
+  }
+  console.log(`\ndestink: ${findingCount} finding(s) across ${checked} page(s), ${rules.length} rules.`);
+  console.log("Fix the pages. To park one, add it to scripts/destink/allow.txt with a reason.");
+  process.exit(1);
+}
+
+main();

--- a/scripts/destink/extract-prose.mjs
+++ b/scripts/destink/extract-prose.mjs
@@ -1,0 +1,102 @@
+// Markdown -> prose, preserving byte offsets.
+//
+// The de-stink linter (vendor/) is a PROSE linter. Its document splitter breaks on
+// `. ! ? ; :` and its rules read sentences. Markdown structure is not prose, and feeding
+// a page to it raw produces mostly false findings: over docs/ it reported 2,721, of which
+// ~1,750 were markdown being mistaken for writing.
+//
+// The three that mattered, all measured on this repo's docs/:
+//
+//   1. `--` is a dash to the em-dash rule (vendor/lint/rules/formatting.ts: /—|--/g). Here it
+//      is a CLI flag (`--config`) or a table separator (`|---|`). 788 findings, all false.
+//   2. Table rows and link lists split into verbless units, so the fragment, anaphora and
+//      near-duplicate rules fire on them. ~700 findings.
+//   3. URL path segments are words to the lexicon rules, so `guides` and `operate` came back
+//      as dead metaphors.
+//
+// So: blank the non-prose, keep the prose. BLANK, not delete — every character is replaced
+// with a space (newlines kept, so paragraph grouping and line classification survive), which
+// means every offset in the linter's output still indexes the ORIGINAL file. A finding's
+// span slices out of the source page unchanged, and the reported line number is the real one.
+// Deleting instead would be shorter and would make every span a lie.
+//
+// This is deliberately not a markdown parser, for the same reason vendor/lint/markdown.ts
+// is not one: the input is this repo's docs/, the shapes are known, and a dependency that
+// understands all of CommonMark buys nothing a line scan does not already get right. What
+// it does NOT handle is documented per-rule below rather than in a list at the end.
+
+// Replace [a, b) with spaces, keeping newlines so line and paragraph structure survives.
+function blank(text, a, b) {
+  let out = "";
+  for (let i = a; i < b; i++) out += text[i] === "\n" ? "\n" : " ";
+  return text.slice(0, a) + out + text.slice(b);
+}
+
+// Each entry blanks one kind of non-prose. Order matters where two could overlap: fences go
+// first so a table or a backtick INSIDE a code block is already blank by the time the later
+// patterns run, and cannot re-match across the hole they left.
+const PATTERNS = [
+  // Fenced code. Matches the opener's own fence characters so a ``` inside a ~~~ block does
+  // not close it. An unterminated fence runs to end of file, matching what the vendored
+  // markdown.ts does, and for the same reason: over-suppress rather than lint broken input.
+  //
+  // The indent is ` *`, not CommonMark's ` {0,3}`. That bound is the rule for a fence at the
+  // TOP level; a fence inside a list item is indented to the item's content column, which is
+  // 4+ spaces. docs/build/team-chat.md has two of them, and with the tighter bound neither the
+  // opener nor the closer was recognised, so ~60 lines of TypeScript leaked into the prose and
+  // came back as fragment and near-duplicate findings.
+  { name: "code fence", re: /^ *(```+|~~~+)[^\n]*\n[\s\S]*?^ *\1[^\n]*$/gm },
+  { name: "unterminated code fence", re: /^ *(```+|~~~+)[^\n]*\n[\s\S]*$/gm },
+  // HTML comments, including the `<!-- GENERATED FILE` marker docs-style.py reads.
+  { name: "html comment", re: /<!--[\s\S]*?-->/g },
+  // A block-level HTML element opened at the start of a line, through its matching close tag.
+  // docs/primitives.md inlines a whole SVG diagram this way, and docs/integrations/buzz.md uses
+  // <table> and <b>. The text inside an SVG is labels on a picture, not sentences: the arrow in
+  // that diagram's "→ GitHub, model APIs, yours" came back as a unicode-decoration finding, and
+  // "fixing" it would have broken docs_test.exs, which pins that SVG byte-for-byte against the
+  // copy in README.md. Nesting of the SAME tag is not handled (no <div> inside a <div>); nothing
+  // under docs/ does that, and the alternative is a real HTML parser.
+  { name: "html block", re: /^<(svg|div|table|details|figure|picture|p|blockquote)\b[\s\S]*?<\/\1>/gim },
+  // Any line starting with a pipe is a table row. Cell CONTENT is often real prose, but it is
+  // prose in fragments with no sentence structure, and the rules that read it produce noise
+  // (see (2) above). Tables are checked by docs-style.py's placeholder-cell rule and by vale.
+  { name: "table row", re: /^ {0,3}\|.*$/gm },
+  // Inline code spans. docs-style.py exempts these too, and for the reason its docstring
+  // gives: they quote the world rather than describe it.
+  { name: "inline code", re: /(`+)[^\n]*?\1/g },
+  // A link's target, not its text: `[Deploy an instance](guides/operate/deploy.md)` keeps
+  // "Deploy an instance" and loses the path. This is what stopped `guides` and `operate`
+  // being read as prose words.
+  { name: "link target", re: /\]\([^)\s]*(?:\s+"[^"]*")?\)/g },
+  // Reference-style link definitions and bare URLs.
+  { name: "link definition", re: /^ {0,3}\[[^\]]+\]:\s*\S+.*$/gm },
+  { name: "bare url", re: /<https?:\/\/[^>\s]+>|https?:\/\/\S+/g },
+  // A list item that is nothing but a link is navigation, not a sentence. These are what the
+  // anaphora and near-duplicate rules kept finding: a "Related" section of six links reads as
+  // six sentences with the same opening.
+  { name: "nav list item", re: /^ {0,3}[-*+] +\[[^\]]*\][.,]?\s*$/gm },
+  // Image tags carry alt text that is not prose in the flow of the page.
+  { name: "image", re: /!\[[^\]]*\]/g },
+  // The admonition directive line of the MkDocs dialect the renderer inherited
+  // (`!!! tip "In a hurry?"`). The BODY is prose and stays; the marker and its quoted title are a
+  // widget label. docs/index.md's `!!! tip "In a hurry?"` came back as a self-posed question,
+  // which is exactly what the title on a callout is supposed to be.
+  { name: "admonition directive", re: /^ *(?:!!!|\?\?\?\+?) +[a-z-]+(?: +"[^"\n]*")? *$/gim },
+];
+
+// Blank every non-prose construct in `text`, returning a string of identical length whose
+// prose characters are unchanged and everything else is a space.
+export function extractProse(text) {
+  let out = text;
+  for (const { re } of PATTERNS) {
+    re.lastIndex = 0;
+    // Collect before blanking: mutating the string under an active regex would move offsets.
+    const spans = [];
+    for (let m = re.exec(out); m; m = re.exec(out)) {
+      spans.push([m.index, m.index + m[0].length]);
+      if (m[0].length === 0) re.lastIndex++; // a zero-width match would spin forever
+    }
+    for (const [a, b] of spans.reverse()) out = blank(out, a, b);
+  }
+  return out;
+}

--- a/scripts/destink/extract-prose.mjs
+++ b/scripts/destink/extract-prose.mjs
@@ -64,6 +64,11 @@ const PATTERNS = [
   // Inline code spans. docs-style.py exempts these too, and for the reason its docstring
   // gives: they quote the world rather than describe it.
   { name: "inline code", re: /(`+)[^\n]*?\1/g },
+  // A list item that is nothing but a link is navigation, not a sentence. These are what the
+  // anaphora and near-duplicate rules kept finding: a "Related" section of six links reads as
+  // six sentences with the same opening. This runs BEFORE "link target" and matches the whole
+  // item, because that pattern consumes the closing `]` and would leave nothing to recognise.
+  { name: "nav list item", re: /^ {0,3}[-*+] +\[[^\]]*\]\([^)\s]*(?:\s+"[^"]*")?\)[.,]?[ \t]*$/gm },
   // A link's target, not its text: `[Deploy an instance](guides/operate/deploy.md)` keeps
   // "Deploy an instance" and loses the path. This is what stopped `guides` and `operate`
   // being read as prose words.
@@ -71,10 +76,6 @@ const PATTERNS = [
   // Reference-style link definitions and bare URLs.
   { name: "link definition", re: /^ {0,3}\[[^\]]+\]:\s*\S+.*$/gm },
   { name: "bare url", re: /<https?:\/\/[^>\s]+>|https?:\/\/\S+/g },
-  // A list item that is nothing but a link is navigation, not a sentence. These are what the
-  // anaphora and near-duplicate rules kept finding: a "Related" section of six links reads as
-  // six sentences with the same opening.
-  { name: "nav list item", re: /^ {0,3}[-*+] +\[[^\]]*\][.,]?\s*$/gm },
   // Image tags carry alt text that is not prose in the flow of the page.
   { name: "image", re: /!\[[^\]]*\]/g },
   // The admonition directive line of the MkDocs dialect the renderer inherited

--- a/scripts/destink/package-lock.json
+++ b/scripts/destink/package-lock.json
@@ -1,0 +1,51 @@
+{
+  "name": "fountain-destink",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "fountain-destink",
+      "dependencies": {
+        "compromise": "^14.15.1"
+      }
+    },
+    "node_modules/compromise": {
+      "version": "14.16.0",
+      "resolved": "https://registry.npmjs.org/compromise/-/compromise-14.16.0.tgz",
+      "integrity": "sha512-4DFYl/Hl7sW4XWUDfx9S5vxqyYKpZDwwqrpXsQv5acdbVP+joKceIcIaLb0lhVWUpDBV0OnExk/o/dnYUwXnhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "efrt": "2.7.0",
+        "grad-school": "0.0.5",
+        "suffix-thumb": "5.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/efrt": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/efrt/-/efrt-2.7.0.tgz",
+      "integrity": "sha512-/RInbCy1d4P6Zdfa+TMVsf/ufZVotat5hCw3QXmWtjU+3pFEOvOQ7ibo3aIxyCJw2leIeAMjmPj+1SLJiCpdrQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/grad-school": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/grad-school/-/grad-school-0.0.5.tgz",
+      "integrity": "sha512-rXunEHF9M9EkMydTBux7+IryYXEZinRk6g8OBOGDBzo/qWJjhTxy86i5q7lQYpCLHN8Sqv1XX3OIOc7ka2gtvQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/suffix-thumb": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/suffix-thumb/-/suffix-thumb-5.0.2.tgz",
+      "integrity": "sha512-I5PWXAFKx3FYnI9a+dQMWNqTxoRt6vdBdb0O+BJ1sxXCWtSoQCusc13E58f+9p4MYx/qCnEMkD5jac6K2j3dgA==",
+      "license": "MIT"
+    }
+  }
+}

--- a/scripts/destink/package.json
+++ b/scripts/destink/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "fountain-destink",
+  "private": true,
+  "type": "module",
+  "description": "Docs de-stink gate. Engine vendored from lex00/sentences; see vendor/UPSTREAM.",
+  "dependencies": {
+    "compromise": "^14.15.1"
+  }
+}

--- a/scripts/destink/sync.mjs
+++ b/scripts/destink/sync.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+// Re-copy the vendored lint engine from a checkout of lex00/sentences.
+//
+//   node scripts/destink/sync.mjs ../sentences
+//
+// Recomputes the import closure rather than copying a hardcoded file list, so a module the
+// upstream rules start importing comes along on its own. The alternative — a list in this file —
+// goes stale silently, and the failure is a missing module at gate time on someone else's PR.
+//
+// After a sync, run the gate. It refuses to start if an id named in destink.mjs is not in the
+// vendored registry, which is what an upstream rename looks like from here, and it prints any
+// rule the registry has that destink.mjs does not mention (arrived in this sync, nobody has
+// decided about it, currently off).
+
+import { execFileSync } from "node:child_process";
+import { copyFileSync, mkdirSync, readFileSync, rmSync, existsSync, writeFileSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = fileURLToPath(new URL(".", import.meta.url));
+const VENDOR = join(HERE, "vendor");
+
+// The four modules destink.mjs imports. Everything else is reached from them.
+const ENTRY = ["src/lint/build-doc.ts", "src/lint/registry.ts", "src/lint/engine.ts", "src/lint/report.ts"];
+
+// Follow relative imports only. A ".js" specifier means the ".ts" file beside it (this project
+// writes the name the compiler WOULD emit), which is the same remap ts-loader.mjs does at run
+// time. Bare specifiers are real npm packages and belong in package.json, not here.
+// Comments out, so a sentence in a doc comment cannot look like an import. `//` is only treated
+// as a comment when it does not follow a colon, which keeps the "https://" inside a string intact.
+const strip = (src) => src.replace(/\/\*[\s\S]*?\*\//g, "").replace(/(^|[^:])\/\/[^\n]*/g, "$1");
+
+function closure(root) {
+  const seen = new Set();
+  const bare = new Set();
+  const visit = (file) => {
+    if (seen.has(file)) return;
+    seen.add(file);
+    const src = strip(readFileSync(file, "utf8"));
+    // Import and export forms that name a module. Deliberately not a parser: this runs against
+    // one known repo, and a missed edge shows up as a missing file on the next gate run. It DOES
+    // have to see past comments, though: upstream's doc comments are long and prose-heavy, and
+    // scanning them raw reported "The building is not" as an npm dependency, because a sentence
+    // in a comment happened to put the word `from` before a quoted phrase.
+    for (const m of src.matchAll(/(?:^|\n)\s*(?:import|export)[\s\S]*?from\s+["']([^"']+)["']/g)) {
+      const spec = m[1];
+      if (!spec.startsWith(".")) {
+        bare.add(spec);
+        continue;
+      }
+      const p = spec.endsWith(".js") ? resolve(dirname(file), spec).slice(0, -3) + ".ts" : resolve(dirname(file), spec);
+      if (existsSync(p)) visit(p);
+      else throw new Error(`${relative(root, file)} imports ${spec}, which does not resolve`);
+    }
+  };
+  for (const e of ENTRY) visit(join(root, e));
+  return { files: [...seen].sort(), bare: [...bare].sort() };
+}
+
+const src = resolve(process.argv[2] ?? "");
+if (!process.argv[2] || !existsSync(join(src, "src/lint/registry.ts"))) {
+  console.error("usage: node scripts/destink/sync.mjs <path-to-a-lex00/sentences-checkout>");
+  process.exit(1);
+}
+
+const sha = execFileSync("git", ["-C", src, "rev-parse", "HEAD"], { encoding: "utf8" }).trim();
+const dirty = execFileSync("git", ["-C", src, "status", "--porcelain"], { encoding: "utf8" }).trim();
+if (dirty) {
+  console.error(`refusing to sync: ${src} has uncommitted changes, so the pin below would name a\ncommit that is not what was copied.`);
+  process.exit(1);
+}
+
+const { files, bare } = closure(src);
+const kept = files.filter((f) => !f.endsWith(".test.ts"));
+
+rmSync(VENDOR, { recursive: true, force: true });
+for (const file of kept) {
+  const rel = relative(join(src, "src"), file);
+  const dest = join(VENDOR, rel);
+  mkdirSync(dirname(dest), { recursive: true });
+  copyFileSync(file, dest);
+}
+copyFileSync(join(src, "LICENSE"), join(VENDOR, "LICENSE"));
+copyFileSync(join(src, "scripts/ts-loader.mjs"), join(HERE, "ts-loader.mjs"));
+
+const upstream = readFileSync(join(VENDOR, "..", "vendor.UPSTREAM.tmpl"), "utf8").replace("__COMMIT__", sha);
+writeFileSync(join(VENDOR, "UPSTREAM"), upstream);
+
+console.log(`synced ${kept.length} file(s) from ${src} @ ${sha.slice(0, 12)}`);
+console.log(`npm dependencies upstream needs: ${bare.filter((b) => !b.startsWith("node:")).join(", ") || "none"}`);
+console.log(`\nCheck those against scripts/destink/package.json, then run:\n  node scripts/destink/destink.mjs`);

--- a/scripts/destink/ts-loader.mjs
+++ b/scripts/destink/ts-loader.mjs
@@ -1,0 +1,31 @@
+// Module customization hook for scripts/destink-score.mjs. Node's own TypeScript type-stripping
+// (--experimental-strip-types on Node >=22.6, on by default on Node >=23) runs .ts files fine, but
+// its module resolver is strict ESM: it does not remap a ".js" specifier to a sibling ".ts" file.
+// This project's TS source imports its own modules with ".js" specifiers (NodeNext-style — the
+// specifier names the file the compiler WOULD emit, not the file on disk), which vite and tsc
+// resolve but plain Node does not.
+//
+// So: try the default resolution first: if a specifier ending in ".js" fails with
+// ERR_MODULE_NOT_FOUND, retry it as ".ts", and only use that result if the file actually exists.
+// Anything that isn't a relative/absolute ".js" specifier (bare imports like "compromise",
+// "node:fs", or a real ".js" file that does exist) is untouched.
+//
+// This is Node's stable module.register() customization-hooks API (node:module) — no bundler, no
+// transpiler, no new dependency.
+
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+export async function resolve(specifier, context, nextResolve) {
+  if (!specifier.endsWith(".js") || !context.parentURL) return nextResolve(specifier, context);
+
+  try {
+    return await nextResolve(specifier, context);
+  } catch (err) {
+    if (!(err && typeof err === "object" && "code" in err && err.code === "ERR_MODULE_NOT_FOUND")) throw err;
+    const asTs = `${specifier.slice(0, -".js".length)}.ts`;
+    const candidateUrl = new URL(asTs, context.parentURL);
+    if (!existsSync(fileURLToPath(candidateUrl))) throw err;
+    return nextResolve(asTs, context);
+  }
+}

--- a/scripts/destink/vendor.UPSTREAM.tmpl
+++ b/scripts/destink/vendor.UPSTREAM.tmpl
@@ -1,0 +1,27 @@
+lex00/sentences — the de-stink lint engine, vendored.
+
+  repo    https://github.com/lex00/sentences
+  commit  __COMMIT__
+  licence MIT (see LICENSE beside this file)
+
+WHAT IS HERE. The import closure of four entry points — lint/build-doc.ts,
+lint/registry.ts, lint/engine.ts and lint/report.ts — with *.test.ts removed.
+That is 75 files. A few of them (layout.ts, scene.ts, theme.ts, inspect.ts) are
+the diagram renderer, which this gate never calls; they are here because
+document.ts type-imports analyze.ts, which imports them. Type imports are
+erased at run time, so they are never loaded. They are copied anyway to keep
+the tree self-consistent TypeScript rather than a set that only works because
+of what Node happens to strip.
+
+DO NOT EDIT ANYTHING IN THIS DIRECTORY. sync.mjs overwrites it wholesale, so a
+local fix is silently reverted on the next sync and the gate quietly changes
+behaviour. A rule that is wrong for this repo goes in DISABLED in
+../destink.mjs with the reason; a rule that is wrong for everyone goes upstream.
+
+TO UPDATE: node scripts/destink/sync.mjs <path-to-a-sentences-checkout>
+Then run the gate. It fails loudly if a rule id named in destink.mjs no longer
+exists, which is what a rename upstream looks like from here.
+
+../ts-loader.mjs is also upstream's, copied from scripts/ts-loader.mjs at the
+same commit. It is what lets plain Node resolve this tree's ".js" specifiers
+to the ".ts" files actually on disk.

--- a/scripts/destink/vendor/LICENSE
+++ b/scripts/destink/vendor/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 lex00
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/scripts/destink/vendor/UPSTREAM
+++ b/scripts/destink/vendor/UPSTREAM
@@ -1,0 +1,27 @@
+lex00/sentences — the de-stink lint engine, vendored.
+
+  repo    https://github.com/lex00/sentences
+  commit  8356899769eb9bf90b5e9b4a579b223f1f1564be
+  licence MIT (see LICENSE beside this file)
+
+WHAT IS HERE. The import closure of four entry points — lint/build-doc.ts,
+lint/registry.ts, lint/engine.ts and lint/report.ts — with *.test.ts removed.
+That is 75 files. A few of them (layout.ts, scene.ts, theme.ts, inspect.ts) are
+the diagram renderer, which this gate never calls; they are here because
+document.ts type-imports analyze.ts, which imports them. Type imports are
+erased at run time, so they are never loaded. They are copied anyway to keep
+the tree self-consistent TypeScript rather than a set that only works because
+of what Node happens to strip.
+
+DO NOT EDIT ANYTHING IN THIS DIRECTORY. sync.mjs overwrites it wholesale, so a
+local fix is silently reverted on the next sync and the gate quietly changes
+behaviour. A rule that is wrong for this repo goes in DISABLED in
+../destink.mjs with the reason; a rule that is wrong for everyone goes upstream.
+
+TO UPDATE: node scripts/destink/sync.mjs <path-to-a-sentences-checkout>
+Then run the gate. It fails loudly if a rule id named in destink.mjs no longer
+exists, which is what a rename upstream looks like from here.
+
+../ts-loader.mjs is also upstream's, copied from scripts/ts-loader.mjs at the
+same commit. It is what lets plain Node resolve this tree's ".js" specifiers
+to the ".ts" files actually on disk.

--- a/scripts/destink/vendor/analyze.ts
+++ b/scripts/destink/vendor/analyze.ts
@@ -1,0 +1,33 @@
+// analyze — the game-facing "what did the player write?" call. Parse a sentence, lay it out, and
+// return its role-labeled elements in one step. The direction a game uses the neural parser: a
+// fill-your-own-words or free-write mode re-parses the player's sentence and checks the roles that
+// came back (does a direct object exist? did the word land in the slot the prompt asked for?).
+//
+// Depends only on a minimal Parser (text -> Tree), which ModelParser satisfies. So this module is
+// pure at runtime — no onnxruntime — and testable with a stub; the caller supplies the real model.
+
+import type { Tree } from "./ptb.js";
+import type { Scene } from "./scene.js";
+import { lowerSentence } from "./lower.js";
+import { layout, type TextMetrics } from "./layout.js";
+import { describeAll, type SceneElement } from "./inspect.js";
+import { defaultLayoutStyle } from "./theme.js";
+
+export interface Parser {
+  parse(text: string): Promise<Tree>;
+}
+
+export type Analysis = { tree: Tree; scene: Scene; elements: SceneElement[] };
+
+// Parse `text` with the supplied parser (typically ModelParser) and return the parse tree (which
+// keeps the fine POS tags), the diagram, and every word/line with its grammatical role + geometry.
+export async function analyze(parser: Parser, text: string, m: TextMetrics, sizePx: number = defaultLayoutStyle.em): Promise<Analysis> {
+  const tree = await parser.parse(text);
+  const scene = layout(lowerSentence(tree), m, defaultLayoutStyle);
+  return { tree, scene, elements: describeAll(scene, m, sizePx) };
+}
+
+// The fillable word slots (the leaf words), left-to-right — what a fill-your-own / drag mode maps
+// its inputs onto, and what a criteria check counts over.
+export const wordSlots = (a: Analysis): Extract<SceneElement, { kind: "word" }>[] =>
+  a.elements.filter((e): e is Extract<SceneElement, { kind: "word" }> => e.kind === "word").sort((p, q) => p.anchor.x - q.anchor.x);

--- a/scripts/destink/vendor/document.ts
+++ b/scripts/destink/vendor/document.ts
@@ -1,0 +1,168 @@
+// Document splitter: break input on sentence boundaries (. ! ? ; :) into units and parse each
+// independently. Two callers, one scan:
+//
+//   readDocument(text) -> DocUnit[]  — every unit, with its exact source span and what happened to
+//     it. A unit that doesn't lower is KEPT as a "fragment" or "unparseable" record, because for
+//     the linter a verbless fragment ("Not a bug. Not a feature.") IS the signal, not a failure.
+//   parseDocument(text) -> Sentence  — the diagram path: merge the lowered units into one Sentence
+//     whose clauses stack, dropping the rest. Coordinated clauses inside a unit keep their
+//     conjunction; the gap BETWEEN units is null (separate sentences, drawn with no connector).
+//
+// Both are rule-based and synchronous — the zero-download default. The *With variants take the
+// same async Parser seam analyze() uses ({ parse(text): Promise<Tree> }), so a loaded ModelParser
+// gives the whole document neural-quality parses through one code path, falling back to the
+// rule-based chunker per unit rather than declaring the unit unparseable. readDocumentUnitsWith
+// additionally hands back each unit's parse tree — the lint layer reads fine POS tags off it and
+// inspects the FRAG trees, and re-parsing to recover it would double the model's work.
+//
+// Boundaries are found by scanning rather than String.split so every unit carries accurate char
+// offsets into the ORIGINAL text: text.slice(span.start, span.end) === unit, terminating
+// punctuation and surrounding whitespace excluded.
+
+import { parse } from "./nlp/parse.js";
+import { tag } from "./nlp/tagger.js";
+import { lowerSentence } from "./lower.js";
+import type { Sentence, Clause, Word } from "./ir.js";
+import type { Tree } from "./ptb.js";
+import type { Parser } from "./analyze.js";
+import type { DocUnit, Span } from "./lint/types.js";
+
+const isBoundary = (ch: string): boolean => ch === "." || ch === "!" || ch === "?" || ch === ";" || ch === ":";
+const isSpace = (ch: string): boolean => /\s/.test(ch);
+
+// Split on runs of boundary punctuation, keeping exact spans. Empty units (a run of terminators,
+// "?!", or leading whitespace) are dropped — they carry no text to parse.
+export function splitUnits(text: string): Array<{ unit: string; span: Span }> {
+  const out: Array<{ unit: string; span: Span }> = [];
+  let i = 0;
+  while (i < text.length) {
+    let end = i;
+    while (end < text.length && !isBoundary(text[end]!)) end++;
+    let start = i;
+    while (start < end && isSpace(text[start]!)) start++; // trim, adjusting the span with it
+    let stop = end;
+    while (stop > start && isSpace(text[stop - 1]!)) stop--;
+    if (stop > start) out.push({ unit: text.slice(start, stop), span: { start, end: stop } });
+    while (end < text.length && isBoundary(text[end]!)) end++; // eat the terminator run
+    i = end;
+  }
+  return out;
+}
+
+// --- fragment vs. parser failure ---
+
+// Verb-like by the tagger's own reckoning: a forced verb, a modal, a copula, or an auxiliary.
+// A unit with none of these is verbless — a fragment, not a parse we botched.
+const VERBAL = new Set(["MD", "COP", "AUX"]);
+const hasVerb = (unit: string): boolean => tag(unit).some((t) => t.forced === "V" || VERBAL.has(t.tag));
+
+const hasVP = (t: Tree): boolean => t.label === "VP" || t.children.some(hasVP);
+const rootLabel = (t: Tree): string => {
+  let n = t;
+  while (["ROOT", "TOP", "S1", ""].includes(n.label) && n.children.length === 1 && n.children[0]) n = n.children[0];
+  return n.label;
+};
+
+// The evidence a rule keys on: "no-VP" / "no-verb" mark a structurally verbless unit; anything
+// else is the parser or the lowering falling over on a unit that does have a predicate.
+const treeReason = (t: Tree, err: Error): string => `${rootLabel(t)}${hasVP(t) ? "" : "/no-VP"}: ${err.message}`;
+
+// A unit's outcome plus what produced it: the parse tree (whenever one was obtained, fragments
+// included — rules read fine POS tags off it and want to inspect FRAG trees) and, when it lowered,
+// the Sentence. DocUnit carries the clauses but not their conjunctions; the diagram path needs
+// those, so they ride along here instead of widening the shared type.
+type UnitResult = { doc: DocUnit; tree?: Tree; sentence?: Sentence };
+
+// Lower one already-parsed unit, or say why it didn't. Either way the tree comes back.
+function fromTree(unit: string, span: Span, tree: Tree): UnitResult {
+  try {
+    const sentence = lowerSentence(tree);
+    return { doc: { unit, span, outcome: "lowered", clauses: sentence.clauses }, tree, sentence };
+  } catch (e) {
+    const reason = treeReason(tree, e as Error);
+    return { doc: { unit, span, outcome: hasVP(tree) ? "unparseable" : "fragment", reason }, tree };
+  }
+}
+
+// One unit through the rule-based path: parse, lower, and classify whatever went wrong.
+function readUnit(unit: string, span: Span): UnitResult {
+  let tree: Tree;
+  try {
+    tree = parse(unit);
+  } catch (e) {
+    const msg = (e as Error).message;
+    const doc: DocUnit = hasVerb(unit)
+      ? { unit, span, outcome: "unparseable", reason: msg }
+      : { unit, span, outcome: "fragment", reason: `no-verb: ${msg}` };
+    return { doc };
+  }
+  return fromTree(unit, span, tree);
+}
+
+// Every unit of the document in order, whatever happened to it. Zero silent drops.
+export const readDocument = (text: string): DocUnit[] =>
+  splitUnits(text).map((u) => readUnit(u.unit, u.span).doc);
+
+// --- diagram path ---
+
+// Stack the lowered units into one Sentence. Units that didn't lower are the ones the diagram
+// can't draw, so they drop out here (and only here).
+function mergeUnits(results: UnitResult[]): Sentence {
+  const clauses: Clause[] = [];
+  const conjunctions: Array<Word | null> = [];
+  for (const { sentence } of results) {
+    if (!sentence) continue;
+    if (clauses.length > 0) conjunctions.push(null); // boundary between separate sentences
+    clauses.push(...sentence.clauses);
+    conjunctions.push(...sentence.conjunctions); // intra-unit coordination keeps its conjunctions
+  }
+  if (clauses.length === 0) throw new Error("nothing diagrammable");
+  return { clauses, conjunctions };
+}
+
+export const parseDocument = (text: string): Sentence =>
+  mergeUnits(splitUnits(text).map((u) => readUnit(u.unit, u.span)));
+
+// --- parser-agnostic path ---
+
+// The rule-based chunker behind the async Parser seam: the zero-download default, and the
+// per-unit fallback when a supplied parser can't produce something that lowers.
+export const ruleBasedParser: Parser = { parse: async (text: string) => parse(text) };
+
+// One unit through a supplied parser, with the rule-based chunker as the fallback. A neural tree
+// that failed to lower is still better evidence than the chunker's guess (it labels the root
+// FRAG), so we keep its reason unless the fallback actually lowered the unit.
+async function readUnitWith(parser: Parser, unit: string, span: Span): Promise<UnitResult> {
+  let tree: Tree;
+  try {
+    tree = await parser.parse(unit);
+  } catch {
+    return readUnit(unit, span); // parser refused the input (or the model isn't there)
+  }
+  const r = fromTree(unit, span, tree);
+  if (r.sentence) return r;
+  const fallback = readUnit(unit, span);
+  return fallback.sentence ? fallback : r;
+}
+
+// Units run one at a time: a ModelParser is a single ONNX session, and document order is the
+// order rules read.
+async function readResultsWith(parser: Parser, text: string): Promise<UnitResult[]> {
+  const out: UnitResult[] = [];
+  for (const u of splitUnits(text)) out.push(await readUnitWith(parser, u.unit, u.span));
+  return out;
+}
+
+// A unit's outcome together with the parse it came from. The tree is the one whose lowering
+// produced `doc.clauses` (so lowerSentence(tree) reproduces them); when nothing lowered it is
+// whatever parse we did get, FRAG root and all, and it is absent only when no parser produced one.
+export type DocUnitParse = { doc: DocUnit; tree?: Tree };
+
+export const readDocumentUnitsWith = async (parser: Parser, text: string): Promise<DocUnitParse[]> =>
+  (await readResultsWith(parser, text)).map((r) => (r.tree ? { doc: r.doc, tree: r.tree } : { doc: r.doc }));
+
+export const readDocumentWith = async (parser: Parser, text: string): Promise<DocUnit[]> =>
+  (await readResultsWith(parser, text)).map((r) => r.doc);
+
+export const parseDocumentWith = async (parser: Parser, text: string): Promise<Sentence> =>
+  mergeUnits(await readResultsWith(parser, text));

--- a/scripts/destink/vendor/inspect.ts
+++ b/scripts/destink/vendor/inspect.ts
@@ -1,0 +1,160 @@
+// Inspector — read a laid-out Scene and describe its parts by grammatical role. Two entry points
+// over one walk:
+//   describeAll(scene) -> every word and line, with role + geometry + owning node id. The
+//     game-agnostic "truth" layer: an "identify the type" mode picks quiz targets from it; a
+//     "drag the words in" or "fill your own words" mode reads word slots (anchor + role) from it.
+//   describeAt(scene, point) -> the single element under a point (hover tooltips).
+// Pure and renderer-agnostic: role comes from each element's own role plus its ancestor node roles.
+
+import type { Scene, SceneNode, Pt, NodeRole, Role, NodeId, BBox } from "./scene.js";
+import { isNode } from "./scene.js";
+import type { TextMetrics } from "./layout.js";
+
+export type Inspection = { title: string; detail: string; kind: "word" | "line" };
+
+// A word slot: its correct text, its role, where it sits, and its owning node.
+export type WordElement = {
+  kind: "word";
+  text: string;
+  pos?: string; // Penn-Treebank POS tag (NN, JJ, RB…) when the word is a single leaf
+  role: string; // human name, e.g. "Direct object"
+  roleKey: NodeRole; // machine key of the nearest role, e.g. "object"
+  roles: NodeRole[]; // full ancestor chain (root -> element), so callers can tell a direct object from a preposition's object
+  detail: string;
+  nodeId: NodeId;
+  anchor: Pt;
+  angle: number;
+  width: number;
+  bbox: BBox; // axis-aligned bounds (hotspots / drop targets)
+};
+export type LineElement = {
+  kind: "line";
+  role: string;
+  roleKey: Role;
+  roles: NodeRole[];
+  detail: string;
+  nodeId: NodeId;
+  a: Pt;
+  b: Pt;
+  bbox: BBox;
+};
+export type SceneElement = WordElement | LineElement;
+
+// What each grammatical slot means, keyed by the node role a word sits in.
+const ROLE: Partial<Record<NodeRole, { name: string; detail: string }>> = {
+  subject: { name: "Subject", detail: "The noun or pronoun the sentence is about." },
+  verb: { name: "Verb", detail: "The predicate — the action or state, right of the subject divider." },
+  object: { name: "Direct object", detail: "Receives the action of the verb, after the verb–object divider." },
+  complement: { name: "Complement", detail: "A predicate noun/adjective or an objective complement." },
+  modifier: { name: "Modifier", detail: "An adjective, adverb, or article, on a slant under the word it modifies." },
+  pp: { name: "Prepositional phrase", detail: "A preposition on the slant, its object on the line below." },
+  subclause: { name: "Subordinate clause", detail: "A clause used as a modifier or noun, on a dotted connector." },
+  compound: { name: "Compound", detail: "Coordinated parts joined by a conjunction on a fork." },
+  clause: { name: "Clause", detail: "A subject–predicate unit." },
+  sentence: { name: "Sentence", detail: "The whole diagram." },
+};
+
+// What each line means, keyed by the segment role (slant refined by context below).
+const LINE: Record<Role, { name: string; detail: string }> = {
+  baseline: { name: "Baseline", detail: "The horizontal line the words sit on." },
+  rail: { name: "Rail", detail: "A supporting horizontal line (a stand or a raised platform)." },
+  "divider.full": { name: "Subject | Predicate divider", detail: "The full vertical bar splitting subject from verb." },
+  "divider.half": { name: "Verb | Object divider", detail: "The half bar before a direct object." },
+  "divider.lean": { name: "Complement divider", detail: "The back-slanting line before a predicate noun/adjective or objective complement." },
+  slant: { name: "Modifier line", detail: "Slants down from a word to the modifier hanging on it." },
+  word: { name: "Word", detail: "A diagrammed word." },
+  "connector.dotted": { name: "Connector", detail: "Links a subordinate/relative clause or a conjunction." },
+  fork: { name: "Fork", detail: "Joins the coordinated parts of a compound." },
+};
+const PREP_LINE = { name: "Preposition line", detail: "Carries the preposition; its object sits on the line at the foot." };
+
+// Friendly name for a Penn-Treebank POS tag (prefix-matched), for tooltips and "what part of
+// speech is this?" prompts.
+const POS_NAMES: Array<[string, string]> = [
+  ["NNP", "proper noun"], ["NN", "noun"], ["JJ", "adjective"], ["RB", "adverb"],
+  ["PRP$", "possessive"], ["PRP", "pronoun"], ["VB", "verb"], ["MD", "modal verb"],
+  ["DT", "article"], ["IN", "preposition"], ["TO", "to"], ["CC", "conjunction"],
+  ["CD", "number"], ["WP", "wh-word"], ["WDT", "wh-word"], ["WRB", "wh-word"],
+];
+export const posName = (tag?: string): string | undefined => (tag ? POS_NAMES.find(([p]) => tag.startsWith(p))?.[1] : undefined);
+
+const nearestRole = (chain: NodeRole[]): NodeRole => {
+  for (let i = chain.length - 1; i >= 0; i--) if (ROLE[chain[i]!]) return chain[i]!;
+  return "sentence";
+};
+
+function wordCorners(anchor: Pt, angle: number, width: number, ascent: number, descent: number): Pt[] {
+  const c = Math.cos(angle), s = Math.sin(angle);
+  const local: Array<[number, number]> = [[0, -ascent], [width, -ascent], [width, descent], [0, descent]];
+  return local.map(([lx, ly]) => ({ x: anchor.x + lx * c - ly * s, y: anchor.y + lx * s + ly * c }));
+}
+
+const aabb = (pts: Pt[]): BBox => ({
+  left: Math.min(...pts.map((p) => p.x)),
+  top: Math.min(...pts.map((p) => p.y)),
+  right: Math.max(...pts.map((p) => p.x)),
+  bottom: Math.max(...pts.map((p) => p.y)),
+});
+
+function pointInQuad(p: Pt, q: Pt[]): boolean {
+  let sign = 0;
+  for (let i = 0; i < 4; i++) {
+    const a = q[i]!, b = q[(i + 1) % 4]!;
+    const cross = (b.x - a.x) * (p.y - a.y) - (b.y - a.y) * (p.x - a.x);
+    if (cross !== 0) {
+      const sg = Math.sign(cross);
+      if (sign === 0) sign = sg;
+      else if (sg !== sign) return false;
+    }
+  }
+  return true;
+}
+
+function distToSeg(p: Pt, a: Pt, b: Pt): number {
+  const dx = b.x - a.x, dy = b.y - a.y;
+  const len2 = dx * dx + dy * dy || 1;
+  const t = Math.max(0, Math.min(1, ((p.x - a.x) * dx + (p.y - a.y) * dy) / len2));
+  return Math.hypot(p.x - (a.x + t * dx), p.y - (a.y + t * dy));
+}
+
+// Every word and line in the scene, with its role and geometry.
+export function describeAll(scene: Scene, m: TextMetrics, sizePx: number): SceneElement[] {
+  const out: SceneElement[] = [];
+  (function walk(n: SceneNode, roles: NodeRole[]): void {
+    const chain = [...roles, n.role];
+    for (const c of n.children) {
+      if (isNode(c)) walk(c, chain);
+      else if (c.kind === "lbl" && c.text) {
+        const rk = nearestRole(chain);
+        const r = ROLE[rk]!;
+        const { width, ascent, descent } = m.measure(c.text, sizePx);
+        const corners = wordCorners(c.anchor, c.angle, width, ascent, descent);
+        out.push({ kind: "word", text: c.text, ...(c.pos ? { pos: c.pos } : {}), role: r.name, roleKey: rk, roles: chain, detail: r.detail, nodeId: n.id, anchor: c.anchor, angle: c.angle, width, bbox: aabb(corners) });
+      } else if (c.kind === "seg") {
+        const r = c.role === "slant" && chain.includes("pp") ? PREP_LINE : LINE[c.role];
+        out.push({ kind: "line", role: r.name, roleKey: c.role, roles: chain, detail: r.detail, nodeId: n.id, a: c.a, b: c.b, bbox: aabb([c.a, c.b]) });
+      }
+    }
+  })(scene.root, []);
+  return out;
+}
+
+// The element under a point (word boxes win over nearby lines). Reuses describeAll's records.
+export function describeAt(scene: Scene, p: Pt, m: TextMetrics, sizePx: number, lineTol = 5): Inspection | null {
+  const state: { best: { d: number; el: SceneElement } | null } = { best: null };
+  const consider = (d: number, el: SceneElement) => { if (!state.best || d < state.best.d) state.best = { d, el }; };
+  for (const el of describeAll(scene, m, sizePx)) {
+    if (el.kind === "word") {
+      const { ascent, descent } = m.measure(el.text, sizePx);
+      if (pointInQuad(p, wordCorners(el.anchor, el.angle, el.width, ascent, descent))) consider(0, el);
+    } else {
+      const d = distToSeg(p, el.a, el.b);
+      if (d <= lineTol) consider(1 + d, el); // words (d=0) win over lines
+    }
+  }
+  const el = state.best?.el;
+  if (!el) return null;
+  if (el.kind === "line") return { title: el.role, detail: el.detail, kind: "line" };
+  const pn = posName(el.pos);
+  return { title: `${el.text} · ${el.role}`, detail: pn ? `${pn} — ${el.detail}` : el.detail, kind: "word" };
+}

--- a/scripts/destink/vendor/ir.ts
+++ b/scripts/destink/vendor/ir.ts
@@ -1,0 +1,78 @@
+// IR — the semantic layer. What *roles* exist, not where pixels go.
+// The constituency parse is lowered to this before any layout happens.
+
+export type Word = {
+  text: string;
+  pos?: string; // Penn-Treebank POS tag from the parse (NN, JJ, RB, VBD…), when the word is a single leaf
+};
+
+// Head slots may be single or compound ("dogs and cats run"). A subject may also be a verbal or a
+// whole clause used nominally ("Running marathons is fun", "Whoever made this did a good job"),
+// drawn raised on a stand.
+export type Subject = Nominal | Compound<Nominal> | Clause | Infinitive | Gerund;
+// A compound predicate forks into parts, each carrying its OWN complement ("[has black fur] and
+// [can jump high]") — a single clause-level complement can't hold per-conjunct objects.
+export type PredicatePart = { verb: Verbal; complement: Complement | null };
+export type Predicate = Verbal | Compound<PredicatePart>;
+
+export type Clause = {
+  subject: Subject;
+  verb: Predicate;
+  complement: Complement | null; // direct object, predicate noun/adj, or null (intransitive)
+  detached?: Word[]; // interjections / nominatives of address — floating line above, unconnected
+  absolutes?: Nominal[]; // absolute phrases ("Smoke alarms screaming, ...") — detached noun+participle above
+};
+
+export type Nominal = {
+  head: Word;
+  modifiers: Modifier[]; // hang below the head
+  appositive?: Word; // drawn in parens on the baseline
+};
+
+export type Verbal = {
+  head: Word; // may be a verb phrase ("has been running")
+  modifiers: Modifier[];
+  indirectObject?: Nominal; // hangs below on a slant + rail
+};
+
+// A verbal: a verb form used as another part of speech, with its own R-K notation.
+// Infinitive ("to take a walk") sits on a stand. (Gerund/participle to follow.)
+export type Infinitive = {
+  kind: "infinitive";
+  verb: Word; // "take"
+  object: Nominal | null; // "a walk"
+  modifiers: Modifier[]; // adverbs / PPs on the infinitive verb
+};
+
+// A gerund phrase ("Running marathons") used as a noun — verb + optional object + modifiers,
+// drawn on a raised rail (on a stand when it fills a subject/object slot).
+export type Gerund = {
+  kind: "gerund";
+  verb: Word; // "Running"
+  object: Nominal | null; // "marathons"
+  modifiers: Modifier[];
+};
+
+export type Complement =
+  | { kind: "directObject"; value: Nominal | Compound<Nominal> | Infinitive | Clause } // half-vertical (Clause = a causative small clause on a stand)
+  | { kind: "predicateNoun"; value: Nominal | Compound<Nominal> } // divider: lean-left
+  | { kind: "predicateAdj"; value: Word | Compound<Word> } // divider: lean-left ("tiny and loud" -> fork)
+  // objective complement ("elected my uncle mayor", "painted my room red"): the direct object,
+  // then a back-leaning divider, then the complement noun/adjective — all on the baseline.
+  | { kind: "objectComplement"; object: Nominal | Compound<Nominal>; oc: Nominal | Word; ocIsAdj: boolean };
+
+export type Modifier =
+  | { kind: "word"; value: Word } // adj/article/adverb/possessive -> slant
+  | { kind: "prep"; prep: Word; object: Nominal } // slant carries prep, sub-rail carries object  (recursion)
+  | { kind: "clause"; value: Clause; connector: Word } // relative/subordinate, dotted connection  (recursion)
+  // participial phrase ("the dog barking furiously") -> the participle on a curved line under the
+  // noun, carrying its own object and modifiers.
+  | { kind: "participle"; verb: Word; object: Nominal | null; modifiers: Modifier[] };
+
+// Compound wrapper (compound subject/predicate/object): fork + dotted conjunction line.
+export type Compound<T> = { items: T[]; conjunction: Word };
+
+// One or more clauses laid out together. conjunctions[i] joins clauses[i] and clauses[i+1]:
+// a Word for a coordinated compound sentence ("Birds sing and dogs bark"), or null for two
+// independent sentences stacked from split input ("A. B" / "A: B" — no connector drawn).
+export type Sentence = { clauses: Clause[]; conjunctions: Array<Word | null> };

--- a/scripts/destink/vendor/layout.ts
+++ b/scripts/destink/vendor/layout.ts
@@ -1,0 +1,517 @@
+// Layout — measure/arrange with a 2-D footprint. The novel, risky core (Phase 3), extended
+// in Phase 4 with compounds (forks) and subordinate clauses (nesting).
+//
+// Key Phase-4 refactor: clause arrangement is itself a `Measured`, so a clause nests inside a
+// clause with no special-casing. Every Measured bakes its id + NodeRole at measure time and
+// exposes place(x, y) -> SceneNode. The engine is closed over an injected TextMetrics port.
+
+import type { Clause, Nominal, Verbal, Modifier, Word, Compound, Sentence, Infinitive, Subject, PredicatePart } from "./ir.js";
+import type { Scene, SceneNode, Prim, BBox, Pt, NodeId, NodeRole } from "./scene.js";
+import type { LayoutStyle } from "./theme.js";
+import { defaultLayoutStyle } from "./theme.js";
+
+// The one genuinely backend-specific concern in layout; inject it as a port.
+export interface TextMetrics {
+  measure(text: string, sizePx: number): { width: number; ascent: number; descent: number };
+}
+
+// Browser adapter — shared by every renderer (same fonts -> same coordinates).
+export class CanvasTextMetrics implements TextMetrics {
+  private g: CanvasRenderingContext2D;
+  constructor(private family = "Tinos, Georgia, 'Times New Roman', serif") {
+    const c = document.createElement("canvas");
+    const ctx = c.getContext("2d");
+    if (!ctx) throw new Error("2D canvas context unavailable for text metrics");
+    this.g = ctx;
+  }
+  measure(text: string, sizePx: number) {
+    this.g.font = `${sizePx}px ${this.family}`;
+    const m = this.g.measureText(text);
+    return {
+      width: m.width,
+      ascent: m.actualBoundingBoxAscent ?? sizePx * 0.8,
+      descent: m.actualBoundingBoxDescent ?? sizePx * 0.2,
+    };
+  }
+}
+
+// measure() result: horizontal room on the rail + the below-cluster bbox (relative to the
+// left anchor at (0,0), baseline y=0) + a closure that emits absolute geometry. id + role baked.
+export type Measured = {
+  width: number;
+  below: BBox;
+  place: (x: number, y: number) => SceneNode;
+};
+
+const BASE_Y = 250;
+const START_X = 200;
+
+const box = (l: number, t: number, r: number, b: number): BBox => ({ left: l, top: t, right: r, bottom: b });
+const unionB = (a: BBox, b: BBox): BBox => ({
+  left: Math.min(a.left, b.left),
+  top: Math.min(a.top, b.top),
+  right: Math.max(a.right, b.right),
+  bottom: Math.max(a.bottom, b.bottom),
+});
+
+export function layout(input: Clause | Sentence, metrics: TextMetrics, style: LayoutStyle = defaultLayoutStyle): Scene {
+  const SZ = style.em;
+  const w = (t: string) => metrics.measure(t, SZ).width;
+  const cos = Math.cos(style.slantAngle);
+  const sin = Math.sin(style.slantAngle);
+  const MARGIN = style.pad;
+
+  const lblBox = (anchor: Pt, text: string, angle: number): BBox => {
+    const tw = w(text);
+    const ex = anchor.x + tw * Math.cos(angle);
+    const ey = anchor.y + tw * Math.sin(angle);
+    return box(Math.min(anchor.x, ex), Math.min(anchor.y - SZ, ey - SZ), Math.max(anchor.x, ex), Math.max(anchor.y + 2, ey + 2));
+  };
+  const primBox = (p: Prim): BBox =>
+    p.kind === "seg"
+      ? box(Math.min(p.a.x, p.b.x), Math.min(p.a.y, p.b.y), Math.max(p.a.x, p.b.x), Math.max(p.a.y, p.b.y))
+      : lblBox(p.anchor, p.text, p.angle);
+  const childrenBox = (cs: Array<SceneNode | Prim>): BBox =>
+    cs.map((c) => ("children" in c ? c.bounds : primBox(c))).reduce(unionB);
+
+  // --- a modifier hanging below a head, measured relative to its attach point at (0,0) ---
+  type MeasuredMod = { below: BBox; place: (ax: number, by: number) => SceneNode };
+
+  function measureMod(m: Modifier, idPath: NodeId): MeasuredMod {
+    if (m.kind === "word") {
+      const text = m.value.text;
+      const pos = m.value.pos;
+      const L = w(text) + style.pad;
+      const dx = L * cos;
+      const dy = L * sin;
+      return {
+        below: box(0, 0, dx, dy),
+        place: (ax, by) => {
+          const slant: Prim = { kind: "seg", a: { x: ax, y: by }, b: { x: ax + dx, y: by + dy }, role: "slant" };
+          const lbl: Prim = { kind: "lbl", text, anchor: { x: ax + 6 * cos, y: by + 6 * sin }, angle: style.slantAngle, role: "word", ...(pos ? { pos } : {}) };
+          const ch: Array<SceneNode | Prim> = [slant, lbl];
+          return { id: idPath, role: "modifier", children: ch, bounds: childrenBox(ch) };
+        },
+      };
+    }
+    if (m.kind === "prep") {
+      const prep = m.prep.text;
+      // slant must be LONGER than the preposition label so the object on the horizontal at its
+      // foot doesn't collide with the label ("of" overlapping "Request").
+      const L = w(prep) + style.em * 1.6;
+      const dx = L * cos;
+      const dy = L * sin;
+      const obj = measureHead(m.object.head.text, m.object.modifiers, `${idPath}/obj`, "object"); // recursion
+      const objBelow = box(dx + obj.below.left, dy + obj.below.top, dx + obj.below.right, dy + obj.below.bottom);
+      return {
+        below: unionB(box(0, 0, dx, dy), objBelow),
+        place: (ax, by) => {
+          const P = { x: ax + dx, y: by + dy };
+          const slant: Prim = { kind: "seg", a: { x: ax, y: by }, b: P, role: "slant" };
+          const prepLbl: Prim = { kind: "lbl", text: prep, anchor: { x: ax + 6 * cos, y: by + 6 * sin }, angle: style.slantAngle, role: "word" };
+          const ch: Array<SceneNode | Prim> = [slant, prepLbl, obj.place(P.x, P.y)];
+          return { id: idPath, role: "pp", children: ch, bounds: childrenBox(ch) };
+        },
+      };
+    }
+    if (m.kind === "participle") {
+      // a participle hangs under the noun on a bent line: a short slant down to a horizontal rail
+      // carrying the participle verb (+ object) with its own modifiers below.
+      const core = measureVerbalCore(m.verb.text, m.modifiers, m.object, `${idPath}/p`);
+      const L = style.em * 1.6;
+      const dx = L * cos;
+      const dy = L * sin;
+      const coreBelow = box(dx + core.below.left, dy + core.below.top, dx + core.below.right, dy + core.below.bottom);
+      return {
+        below: unionB(box(0, 0, dx, dy), coreBelow),
+        place: (ax, by) => {
+          const P = { x: ax + dx, y: by + dy };
+          const slant: Prim = { kind: "seg", a: { x: ax, y: by }, b: P, role: "slant" };
+          const ch: Array<SceneNode | Prim> = [slant, core.place(P.x, P.y)];
+          return { id: idPath, role: "pp", children: ch, bounds: childrenBox(ch) };
+        },
+      };
+    }
+    // subordinate / relative clause: nested clause below the head on a dotted connector.
+    const nested = measureClause(m.value, `${idPath}/c`, "subclause");
+    const conn = m.connector.text;
+    const DROP = style.em * 3.6; // clear sibling modifier slants on the same head
+    return {
+      below: unionB(box(0, 0, 0, DROP), box(nested.below.left, DROP + nested.below.top, Math.max(nested.width, nested.below.right), DROP + nested.below.bottom)),
+      place: (ax, by) => {
+        const drop: Pt = { x: ax, y: by + DROP };
+        const dotted: Prim = { kind: "seg", a: { x: ax, y: by }, b: drop, role: "connector.dotted" };
+        const connLbl: Prim = { kind: "lbl", text: conn, anchor: { x: ax + 4, y: by + DROP * 0.5 }, angle: 0, role: "word" };
+        const ch: Array<SceneNode | Prim> = [dotted, connLbl, nested.place(ax, by + DROP)];
+        return { id: idPath, role: "subclause", children: ch, bounds: childrenBox(ch) };
+      },
+    };
+  }
+
+  // --- a head word + its hanging modifiers, occupying [x, x+width] on the baseline ---
+  function measureHead(headText: string, mods: Modifier[], idPath: NodeId, role: NodeRole, appositive?: string, headPos?: string): Measured {
+    if (appositive) headText = `${headText} (${appositive})`; // R-K: apposition in parens on the rail
+    const headW = w(headText);
+    const mm = mods.map((m, i) => ({ i, m: measureMod(m, `${idPath}/m${i}`) }));
+    // Place modifiers left-to-right, each reserving its OWN footprint width, so a wide modifier
+    // (a PP or a relative clause) doesn't overlap its neighbors.
+    const attaches: number[] = [];
+    let ax = style.pad;
+    for (const { m } of mm) {
+      attaches.push(ax);
+      ax += Math.max(style.minSlantSpacing, m.below.right - m.below.left) + style.pad; // breathing room between modifiers
+    }
+    // The rail spans at least to the last modifier's attach point, so the divider that follows the
+    // word lands clear of the modifier fan (a short adjective slant must not cross the divider).
+    // Wide modifiers (PP/clause) still overhang further via `below`, so they keep pushing neighbors.
+    const lastAttach = attaches.length ? attaches[attaches.length - 1]! : 0;
+    const segW = Math.max(headW, lastAttach + style.minSlantSpacing) + style.pad;
+
+    let below = box(0, 0, segW, 0);
+    mm.forEach(({ m }, k) => {
+      const a = attaches[k]!;
+      below = unionB(below, box(a + m.below.left, m.below.top, a + m.below.right, m.below.bottom));
+    });
+
+    return {
+      width: segW,
+      below,
+      place: (x, y) => {
+        const rail: Prim = { kind: "seg", a: { x, y }, b: { x: x + segW, y }, role: "baseline" };
+        const headLbl: Prim = { kind: "lbl", text: headText, anchor: { x: x + segW / 2 - headW / 2, y: y - 4 }, angle: 0, role: "word", ...(headPos ? { pos: headPos } : {}) };
+        const modNodes = mm.map(({ m }, k) => m.place(x + attaches[k]!, y));
+        const ch: Array<SceneNode | Prim> = [rail, headLbl, ...modNodes];
+        return { id: idPath, role, children: ch, bounds: childrenBox(ch) };
+      },
+    };
+  }
+
+  // --- a compound head slot: N branches forked to a single apex on the main rail ---
+  // openRight=true  -> apex on the right (a SUBJECT connects rightward to the divider).
+  // openRight=false -> apex on the left  (an OBJECT/COMPLEMENT/VERB connects leftward to it).
+  function measureCompound(branches: Measured[], conj: string, idPath: NodeId, openRight: boolean): Measured {
+    const n = branches.length;
+    // Adjacent branches must clear each other's hanging modifiers: a branch whose adjectives fan
+    // below needs the next branch's rail placed past that fan, else "strong" collides with "figure".
+    const maxDrop = Math.max(0, ...branches.map((b) => b.below.bottom));
+    const SP = Math.max(style.em * 2.2, maxDrop + style.em * 1.6); // vertical gap between adjacent branches
+    const offAt = (i: number) => (i - (n - 1) / 2) * SP;
+    const maxW = Math.max(...branches.map((b) => b.width));
+    // The fork region between the branches and the apex must be long enough to hold the conjunction
+    // label, so a long correlative ("both...and") fits there instead of spilling into the divider.
+    const forkLen = Math.max(style.em * 1.6, w(conj) + style.pad * 2);
+    const width = maxW + forkLen;
+    const bx0 = openRight ? 0 : forkLen; // branch baseline left offset
+
+    let below = box(0, offAt(0), width, offAt(n - 1));
+    branches.forEach((b, i) => {
+      const off = offAt(i);
+      below = unionB(below, box(bx0 + b.below.left, off + b.below.top, bx0 + b.below.right, off + b.below.bottom));
+    });
+
+    return {
+      width,
+      below,
+      place: (x, y) => {
+        const apex: Pt = openRight ? { x: x + width, y } : { x, y };
+        const ch: Array<SceneNode | Prim> = [];
+        branches.forEach((b, i) => {
+          const by = y + offAt(i);
+          ch.push(b.place(x + bx0, by));
+          const connect: Pt = openRight ? { x: x + bx0 + b.width, y: by } : { x: x + bx0, y: by };
+          ch.push({ kind: "seg", a: connect, b: apex, role: "fork" });
+        });
+        const bx = x + bx0 + (openRight ? maxW : 0); // dotted conjunction bridge near the fork
+        ch.push({ kind: "seg", a: { x: bx, y: y + offAt(0) }, b: { x: bx, y: y + offAt(n - 1) }, role: "connector.dotted" });
+        // label sits in the fork region, away from the apex: rightward for a subject (apex right),
+        // leftward for an object (apex left) — so it clears both the divider and the branches.
+        const conjX = openRight ? bx + 4 : bx - w(conj) - 4;
+        ch.push({ kind: "lbl", text: conj, anchor: { x: conjX, y }, angle: 0, role: "word" });
+        return { id: idPath, role: "compound", children: ch, bounds: childrenBox(ch) };
+      },
+    };
+  }
+
+  // Mount an inner diagram on a stand: a base rail on the main line, a stilt rising to the raised
+  // inner diagram. Used for a verbal/clause filling a nominal slot ("Running marathons is fun").
+  function measureOnStand(inner: Measured, idPath: NodeId, role: NodeRole, connectRight: boolean): Measured {
+    // Raise the platform above everything that hangs below the inner diagram, so its modifiers
+    // clear the base rail and the main clause's divider.
+    const STAND_H = Math.max(style.em * 3.6, inner.below.bottom + style.em * 1.4);
+    return {
+      width: inner.width,
+      below: box(Math.min(0, inner.below.left), -STAND_H + inner.below.top - SZ, Math.max(inner.width, inner.below.right), Math.max(0, inner.below.bottom - STAND_H)),
+      place: (x, y) => {
+        const ry = y - STAND_H;
+        // A subject stand's base runs to the divider on its right; an object/complement stand
+        // connects on its LEFT (via the half-divider), so it needs only a short foot — not a
+        // full-width bar under the whole raised clause.
+        const baseRight = connectRight ? x + inner.width : x + style.pad * 2;
+        const ch: Array<SceneNode | Prim> = [
+          { kind: "seg", a: { x, y }, b: { x: baseRight, y }, role: "baseline" }, // base / foot on the main line
+          { kind: "seg", a: { x: x + style.pad, y }, b: { x: x + style.pad, y: ry }, role: "rail" }, // stilt at the left
+          inner.place(x, ry),
+        ];
+        return { id: idPath, role, children: ch, bounds: childrenBox(ch) };
+      },
+    };
+  }
+
+  // A verbal core "verb [│ object]" with modifiers below the verb — the raised content of a gerund.
+  function measureVerbalCore(headText: string, mods: Modifier[], object: Nominal | null, idPath: NodeId): Measured {
+    const headM = measureHead(headText, mods, `${idPath}/h`, "verb");
+    if (!object) return headM;
+    const objM = measureHead(object.head.text, object.modifiers, `${idPath}/o`, "object");
+    const objLeft = headM.width + style.dividerGap;
+    const width = objLeft + objM.width;
+    const below = unionB(headM.below, box(objLeft + objM.below.left, objM.below.top, objLeft + objM.below.right, objM.below.bottom));
+    return {
+      width,
+      below,
+      place: (x, y) => {
+        const dx = x + headM.width + style.dividerGap / 2;
+        const ch: Array<SceneNode | Prim> = [
+          headM.place(x, y),
+          { kind: "seg", a: { x: dx, y: y - style.halfDividerRise }, b: { x: dx, y }, role: "divider.half" },
+          objM.place(x + objLeft, y),
+        ];
+        return { id: idPath, role: "verb", children: ch, bounds: childrenBox(ch) };
+      },
+    };
+  }
+
+  // A compound-predicate branch: a verb rail then its OWN complement (each conjunct of "has black
+  // fur and can jump high" carries its object). Mirrors the verb+complement spacing of a clause.
+  function measurePredicatePart(part: PredicatePart, idPath: NodeId): Measured {
+    const verbM = measureHead(part.verb.head.text, part.verb.modifiers, `${idPath}/v`, "verb");
+    if (!part.complement) return verbM;
+    const c = measureComplement(part.complement, idPath);
+    const cLeft = Math.max(verbM.width + style.dividerGap, verbM.below.right + MARGIN - c.measured.below.left);
+    const dx = (verbM.width + cLeft) / 2;
+    const below = unionB(verbM.below, box(cLeft + c.measured.below.left, c.measured.below.top, cLeft + c.measured.below.right, c.measured.below.bottom));
+    return {
+      width: cLeft + c.measured.width,
+      below,
+      place: (x, y) => {
+        const ch: Array<SceneNode | Prim> = [verbM.place(x, y)];
+        const dxa = x + dx;
+        if (c.divider === "half") ch.push({ kind: "seg", a: { x: dxa, y: y - style.halfDividerRise }, b: { x: dxa, y }, role: "divider.half" });
+        else {
+          const len = style.halfDividerRise / Math.sin(style.leanLeftAngle);
+          ch.push({ kind: "seg", a: { x: dxa, y }, b: { x: dxa - len * Math.cos(style.leanLeftAngle), y: y - len * Math.sin(style.leanLeftAngle) }, role: "divider.lean" });
+        }
+        ch.push(c.measured.place(x + cLeft, y));
+        return { id: idPath, role: "verb", children: ch, bounds: childrenBox(ch) };
+      },
+    };
+  }
+
+  // --- a head slot that may be single or compound, or a stand-mounted verbal/clause ---
+  function measureFiller(slot: Subject | Verbal | Compound<PredicatePart>, idPath: NodeId, role: NodeRole, openRight: boolean): Measured {
+    if ("kind" in slot) {
+      // gerund / infinitive filling a nominal slot: a verbal core raised on a stand.
+      const head = slot.kind === "infinitive" ? `to ${slot.verb.text}` : slot.verb.text;
+      return measureOnStand(measureVerbalCore(head, slot.modifiers, slot.object, `${idPath}/v`), idPath, role, openRight);
+    }
+    if ("subject" in slot) return measureOnStand(measureClause(slot, `${idPath}/nc`, "clause"), idPath, role, openRight); // noun clause
+    if ("items" in slot) {
+      const items = slot.items;
+      // compound predicate: each branch is a verb + its own complement
+      if (items.length && "verb" in items[0]!) {
+        const parts = items as PredicatePart[];
+        if (parts.length === 1) return measurePredicatePart(parts[0]!, idPath);
+        const branches = parts.map((p, i) => measurePredicatePart(p, `${idPath}/b${i}`));
+        return measureCompound(branches, slot.conjunction.text, idPath, openRight);
+      }
+      // compound of nominals (subject / object)
+      const noms = items as Nominal[];
+      const appOf = (it: Nominal): string | undefined => it.appositive?.text;
+      if (noms.length === 1) return measureHead(noms[0]!.head.text, noms[0]!.modifiers, idPath, role, appOf(noms[0]!), noms[0]!.head.pos);
+      const branches = noms.map((it, i) => measureHead(it.head.text, it.modifiers, `${idPath}/b${i}`, role, appOf(it), it.head.pos));
+      return measureCompound(branches, slot.conjunction.text, idPath, openRight);
+    }
+    // An indirect object hangs below the verb on a slant + rail — an implied-preposition PP.
+    const io = "indirectObject" in slot ? slot.indirectObject : undefined;
+    const mods: Modifier[] = io ? [...slot.modifiers, { kind: "prep", prep: { text: "" }, object: io }] : slot.modifiers;
+    return measureHead(slot.head.text, mods, idPath, role, "appositive" in slot ? slot.appositive?.text : undefined, slot.head.pos);
+  }
+
+  // An infinitive object on a STAND: a post rises from the object slot to a raised rail that
+  // carries "to" (on a slant) + the verb, with the verb's own object after a half-divider.
+  function measureInfinitive(inf: Infinitive, idPath: NodeId): Measured {
+    const STAND_H = style.em * 3.4;
+    const verbW = w(inf.verb.text);
+    const toW = w("to");
+    const objM = inf.object ? measureHead(inf.object.head.text, inf.object.modifiers, `${idPath}/o`, "object") : null;
+    const railW = style.pad + verbW + (objM ? style.dividerGap + objM.width : 0) + style.pad;
+    return {
+      width: railW,
+      below: box(-toW, -(STAND_H + SZ * 2), railW, 0), // sits entirely above the baseline
+      place: (x, y) => {
+        const ry = y - STAND_H; // raised rail of the infinitive
+        const sx = x + style.pad; // stand post + rail left
+        const ch: Array<SceneNode | Prim> = [];
+        ch.push({ kind: "seg", a: { x: sx, y }, b: { x: sx, y: ry }, role: "rail" }); // stand post
+        ch.push({ kind: "seg", a: { x: sx - 5, y }, b: { x: sx + 5, y }, role: "rail" }); // foot
+        ch.push({ kind: "seg", a: { x: sx, y: ry }, b: { x: sx + railW, y: ry }, role: "baseline" }); // raised rail
+        ch.push({ kind: "seg", a: { x: sx - toW * 0.7, y: ry + toW * 0.7 }, b: { x: sx, y: ry }, role: "slant" }); // "to" slant
+        ch.push({ kind: "lbl", text: "to", anchor: { x: sx - toW * 0.7 + 2, y: ry + toW * 0.7 - 3 }, angle: style.slantAngle, role: "word" });
+        ch.push({ kind: "lbl", text: inf.verb.text, anchor: { x: sx + style.pad, y: ry - 4 }, angle: 0, role: "word" });
+        if (objM) {
+          const dx = sx + style.pad + verbW + style.dividerGap / 2;
+          ch.push({ kind: "seg", a: { x: dx, y: ry - style.halfDividerRise }, b: { x: dx, y: ry }, role: "divider.half" });
+          ch.push(objM.place(sx + style.pad + verbW + style.dividerGap, ry));
+        }
+        return { id: idPath, role: "object", children: ch, bounds: childrenBox(ch) };
+      },
+    };
+  }
+
+  // An objective complement lays out as one horizontal unit: the direct object, a back-leaning
+  // divider (tilting toward the object it describes), then the complement noun/adjective.
+  function measureObjectComplement(oc: Extract<NonNullable<Clause["complement"]>, { kind: "objectComplement" }>, idPath: NodeId): Measured {
+    const objM = measureFiller(oc.object, `${idPath}/do`, "object", false);
+    const ocM = oc.ocIsAdj
+      ? measureHead((oc.oc as Word).text, [], `${idPath}/oc`, "complement")
+      : measureFiller(oc.oc as Nominal, `${idPath}/oc`, "complement", false);
+    const ocLeft = objM.width + style.dividerGap;
+    const width = ocLeft + ocM.width;
+    const below = unionB(objM.below, box(ocLeft + ocM.below.left, ocM.below.top, ocLeft + ocM.below.right, ocM.below.bottom));
+    return {
+      width,
+      below,
+      place: (x, y) => {
+        const dx = x + objM.width + style.dividerGap / 2;
+        const len = style.halfDividerRise / Math.sin(style.leanLeftAngle);
+        const ch: Array<SceneNode | Prim> = [
+          objM.place(x, y),
+          { kind: "seg", a: { x: dx, y }, b: { x: dx - len * Math.cos(style.leanLeftAngle), y: y - len * Math.sin(style.leanLeftAngle) }, role: "divider.lean" },
+          ocM.place(x + ocLeft, y),
+        ];
+        return { id: idPath, role: "complement", children: ch, bounds: childrenBox(ch) };
+      },
+    };
+  }
+
+  type CompM = { divider: "half" | "lean"; measured: Measured };
+  function measureComplement(c: NonNullable<Clause["complement"]>, idPrefix: NodeId): CompM {
+    if (c.kind === "objectComplement") return { divider: "half", measured: measureObjectComplement(c, `${idPrefix}/oc`) };
+    if (c.kind === "directObject") {
+      if ("kind" in c.value) return { divider: "half", measured: measureInfinitive(c.value, `${idPrefix}/inf`) }; // only Infinitive has `kind`
+      return { divider: "half", measured: measureFiller(c.value, `${idPrefix}/obj`, "object", false) };
+    }
+    if (c.kind === "predicateNoun") return { divider: "lean", measured: measureFiller(c.value, `${idPrefix}/pn`, "complement", false) };
+    // predicate adjective — single word, or a fork ("tiny and loud")
+    if ("items" in c.value) {
+      const branches = c.value.items.map((wd, i) => measureHead(wd.text, [], `${idPrefix}/pa/b${i}`, "complement"));
+      return { divider: "lean", measured: measureCompound(branches, c.value.conjunction.text, `${idPrefix}/pa`, false) };
+    }
+    return { divider: "lean", measured: measureHead(c.value.text, [], `${idPrefix}/pa`, "complement") };
+  }
+
+  // --- a whole clause as a placeable unit (so clauses nest in clauses) ---
+  function measureClause(clause: Clause, idPrefix: NodeId, role: NodeRole): Measured {
+    const subj = measureFiller(clause.subject, `${idPrefix}/subj`, "subject", true); // apex right -> divider
+    const verb = measureFiller(clause.verb, `${idPrefix}/verb`, "verb", false); // apex left <- divider
+    const comp = clause.complement ? measureComplement(clause.complement, idPrefix) : null;
+
+    const subjRight = subj.width;
+    // THE CRUX: spacing respects both the divider minimum AND below-cluster overlap. The full
+    // divider must also sit clear of anything hanging below the subject (a wide participle/PP),
+    // so no modifier line crosses it; the verb then follows the divider.
+    const fullX = Math.max(subjRight + style.dividerGap / 2, subj.below.right + style.pad);
+    const verbLeft = Math.max(fullX + style.dividerGap / 2, subj.below.right + MARGIN - verb.below.left);
+    const verbRight = verbLeft + verb.width;
+
+    let compLeft = 0;
+    let compDx = 0;
+    let totalRight = verbRight;
+    if (comp) {
+      const verbClusterR = verbLeft + verb.below.right;
+      compLeft = Math.max(verbRight + style.dividerGap, verbClusterR + MARGIN - comp.measured.below.left);
+      compDx = (verbRight + compLeft) / 2;
+      totalRight = compLeft + comp.measured.width;
+    }
+
+    let below = unionB(subj.below, box(verbLeft + verb.below.left, verb.below.top, verbLeft + verb.below.right, verb.below.bottom));
+    if (comp) below = unionB(below, box(compLeft + comp.measured.below.left, comp.measured.below.top, compLeft + comp.measured.below.right, comp.measured.below.bottom));
+
+    return {
+      width: totalRight,
+      below,
+      place: (x, y) => {
+        const ch: Array<SceneNode | Prim> = [
+          subj.place(x, y),
+          { kind: "seg", a: { x: x + fullX, y: y - style.fullDividerRise }, b: { x: x + fullX, y: y + style.fullDividerRise }, role: "divider.full" },
+          verb.place(x + verbLeft, y),
+        ];
+        if (comp) {
+          const dx = x + compDx;
+          if (comp.divider === "half") {
+            ch.push({ kind: "seg", a: { x: dx, y: y - style.halfDividerRise }, b: { x: dx, y }, role: "divider.half" });
+          } else {
+            const len = style.halfDividerRise / Math.sin(style.leanLeftAngle);
+            ch.push({ kind: "seg", a: { x: dx, y }, b: { x: dx - len * Math.cos(style.leanLeftAngle), y: y - len * Math.sin(style.leanLeftAngle) }, role: "divider.lean" });
+          }
+          ch.push(comp.measured.place(x + compLeft, y));
+        }
+        // Absolute phrases: a detached noun + participle diagram floating above the subject.
+        let absTop = y;
+        (clause.absolutes ?? []).forEach((abs, i) => {
+          const am = measureHead(abs.head.text, abs.modifiers, `${idPrefix}/abs${i}`, "subject", abs.appositive?.text);
+          const ay = absTop - am.below.bottom - style.em * 2.5;
+          ch.push(am.place(x, ay));
+          absTop = ay - SZ;
+        });
+        // Interjections / nominatives of address: a short horizontal line floating above the
+        // subject, carrying the word, with no line connecting it to the rest of the diagram.
+        (clause.detached ?? []).forEach((d, i) => {
+          const lineW = w(d.text) + style.pad * 2;
+          const ly = y - style.em * 3 - i * style.em * 1.8; // stack multiples upward
+          ch.push({ kind: "seg", a: { x, y: ly }, b: { x: x + lineW, y: ly }, role: "baseline" });
+          ch.push({ kind: "lbl", text: d.text, anchor: { x: x + style.pad, y: ly - 4 }, angle: 0, role: "word" });
+        });
+        return { id: idPrefix, role, children: ch, bounds: childrenBox(ch) };
+      },
+    };
+  }
+
+  const sentence: Sentence = "clauses" in input ? input : { clauses: [input], conjunctions: [] };
+
+  // Single clause: unchanged (root id "c").
+  if (sentence.clauses.length <= 1) {
+    const root = measureClause(sentence.clauses[0] ?? (input as Clause), "c", "clause").place(START_X, BASE_Y);
+    return { root, bounds: root.bounds };
+  }
+
+  // Compound sentence: stack the clause diagrams, joined by a dashed step with the conjunction.
+  const nodes: SceneNode[] = [];
+  const baselineYs: number[] = [];
+  let y = BASE_Y - (sentence.clauses.length - 1) * style.em * 3.5;
+  sentence.clauses.forEach((clause, i) => {
+    const placed = measureClause(clause, `c${i}`, "clause").place(START_X, y);
+    nodes.push(placed);
+    baselineYs.push(y);
+    y = placed.bounds.bottom + style.em * 3.5;
+  });
+
+  const extra: Prim[] = [];
+  // Join the clauses at the left, clear of every clause's content (a wide subject must not be
+  // crossed by the connector).
+  const cx = Math.min(...nodes.map((n) => n.bounds.left)) - style.pad;
+  for (let i = 0; i < nodes.length - 1; i++) {
+    const conj = sentence.conjunctions[i];
+    if (!conj) continue; // separate sentences (split input): just stack, no connector
+    const y0 = baselineYs[i]!;
+    const y1 = baselineYs[i + 1]!;
+    extra.push({ kind: "seg", a: { x: cx, y: y0 }, b: { x: cx, y: y1 }, role: "connector.dotted" });
+    extra.push({ kind: "lbl", text: conj.text, anchor: { x: cx + 4, y: (y0 + y1) / 2 }, angle: 0, role: "word" });
+  }
+
+  const children: Array<SceneNode | Prim> = [...nodes, ...extra];
+  const root: SceneNode = { id: "s", role: "sentence", children, bounds: childrenBox(children) };
+  return { root, bounds: root.bounds };
+}
+
+// Convenience: a Word -> single-word Nominal.
+export const wordNominal = (word: Word): Nominal => ({ head: word, modifiers: [] });

--- a/scripts/destink/vendor/lint/build-doc.ts
+++ b/scripts/destink/vendor/lint/build-doc.ts
@@ -1,0 +1,38 @@
+// TODO(#9): replace with analyzeDocument when it lands. This function is the seam: score.ts,
+// report.ts and the CLI all consume DocAnalysis, never this function directly, so swapping the
+// analyzer for #9's real one (which additionally fills in `tree` per unit) is a one-line change at
+// each call site — this file, and nothing downstream of it, changes.
+//
+// Builds a DocAnalysis from readDocument's synchronous, rule-based per-unit split (document.ts) —
+// the zero-download path the app already uses when no model is loaded. Word-scanning mirrors
+// stub-doc.ts's approach (one regex over each unit's span, offsets carried through from the
+// source) rather than importing it: stub-doc.ts is documented test/fixture code, this is product
+// code, and the two are allowed to drift independently.
+
+import { readDocument } from "../document.js";
+import type { DocAnalysis, DocUnit, Span, UnitAnalysis, WordSpan } from "./types.js";
+
+// A word: letters/digits, with internal apostrophes and hyphens kept ("don't", "well-known",
+// "won't" stay whole). Curly and straight apostrophes both count as internal. Mirrors stub-doc.ts's
+// wordRe — see that file for the rationale.
+const wordRe = (): RegExp => /[\p{L}\p{N}]+(?:['‘’ʼ-][\p{L}\p{N}]+)*/gu;
+
+// Every word inside `span`, in order, with offsets into the whole text.
+function wordSpans(text: string, span: Span): WordSpan[] {
+  const slice = text.slice(span.start, span.end);
+  const words: WordSpan[] = [];
+  const re = wordRe();
+  for (let m = re.exec(slice); m; m = re.exec(slice)) {
+    words.push({ text: m[0], span: { start: span.start + m.index, end: span.start + m.index + m[0].length } });
+  }
+  return words;
+}
+
+const toUnitAnalysis = (text: string, unit: DocUnit): UnitAnalysis => ({ ...unit, words: wordSpans(text, unit.span) });
+
+// The CLI's (and any other non-browser caller's) document analysis: real DocUnits from the
+// rule-based chunker/parser, plus word spans scanned per unit. No tree, no POS tags — readDocument
+// already says why a unit didn't lower, and nothing here parses further.
+export function buildDocAnalysis(text: string): DocAnalysis {
+  return { text, units: readDocument(text).map((u) => toUnitAnalysis(text, u)) };
+}

--- a/scripts/destink/vendor/lint/engine.ts
+++ b/scripts/destink/vendor/lint/engine.ts
@@ -1,0 +1,86 @@
+// The rule runner. Rules are predicates over the WHOLE document that return located findings —
+// the game's Condition with the polarity flipped: instead of "does this sentence pass?", it is
+// "where does this document tell on itself?".
+//
+// Seeing the whole document is the point. A prompt-based judge reading sentence by sentence cannot
+// say "one tricolon is style, three in a row is a pattern"; a rule holding every unit can, so
+// density thresholds live inside detect() and the runner stays dumb.
+//
+// What the runner guarantees, so rules do not have to:
+//
+//   Order      Findings come back in document order: span.start asc, then span.end asc (a nested
+//              finding precedes the wider one around it), then ruleId by code point. Never
+//              localeCompare — the order must not depend on the machine's locale. Those three keys
+//              are a total order after dedupe, so two runs over the same input produce the exact
+//              same array. No secondary sort on message or severity is needed or applied.
+//
+//   Dedupe     Identical ruleId AND identical span = the same tell reported twice; the first one
+//              wins (first in the order the rules were passed in) and the rest are dropped. That
+//              is the ONLY thing dropped. Overlapping spans survive — from different rules, because
+//              two tells can legitimately land on the same words ("It's not X — it's Y" is both
+//              negative parallelism and an em dash), and from the SAME rule, because a rule may
+//              nest findings (a tricolon inside a tricolon). A rule that wants to report two
+//              different things about the exact same span must split into two rule ids.
+//
+//   Isolation  A rule that throws does not kill the run. Its exception is caught, recorded in
+//              result.errors, and every other rule still reports. A rule that throws contributes
+//              NO findings, not even the ones it returned before throwing — detect() is
+//              all-or-nothing, so a half-finished rule cannot half-report.
+//
+//   Sanity     A finding whose span does not fit the document (start > end, or outside
+//              [0, text.length]) is dropped and recorded as an error against its rule. A bad span
+//              would otherwise surface as a broken highlight in the UI, far from the rule that
+//              caused it.
+
+import type { DocAnalysis, Finding, TropeRule } from "./types.js";
+import { compareSpans } from "./span.js";
+
+// A rule that misbehaved. `message` is a one-liner safe to show in the UI; `error` is the thrown
+// value (usually an Error, with its stack) for the console.
+export type RuleError = { ruleId: string; message: string; error: unknown };
+
+// Findings in document order plus whatever went wrong, in the order the rules were run. Callers
+// that only want the findings read `.findings`; the app surfaces `.errors` so a broken rule is
+// visible instead of silently producing nothing.
+export type LintResult = { findings: Finding[]; errors: RuleError[] };
+
+// Exported so a UI that re-groups findings (by tier, by severity) can restore document order.
+export const compareFindings = (a: Finding, b: Finding): number =>
+  compareSpans(a.span, b.span) || (a.ruleId < b.ruleId ? -1 : a.ruleId > b.ruleId ? 1 : 0);
+
+const describe = (err: unknown): string => (err instanceof Error ? err.message : String(err));
+
+// The dedupe key. Length-prefixed so no id containing the separator can collide with another's
+// key, and keyed on the FINDING's own ruleId, not the rule's — one module may emit under sub-ids.
+const dedupeKey = (f: Finding): string => `${f.ruleId.length}:${f.ruleId}:${f.span.start}:${f.span.end}`;
+
+export function runRules(rules: readonly TropeRule[], doc: DocAnalysis): LintResult {
+  const findings: Finding[] = [];
+  const errors: RuleError[] = [];
+  const seen = new Set<string>(); // first finding for a key wins
+
+  for (const rule of rules) {
+    let produced: Finding[];
+    try {
+      produced = rule.detect(doc);
+    } catch (err) {
+      errors.push({ ruleId: rule.id, message: `rule threw: ${describe(err)}`, error: err });
+      continue; // all-or-nothing: a throwing rule reports nothing
+    }
+    for (const f of produced) {
+      const { start, end } = f.span;
+      if (!Number.isInteger(start) || !Number.isInteger(end) || start < 0 || end < start || end > doc.text.length) {
+        const bad = `span [${start}, ${end}) does not fit a ${doc.text.length}-char document`;
+        errors.push({ ruleId: rule.id, message: `dropped a finding: ${bad}`, error: new Error(bad) });
+        continue;
+      }
+      const key = dedupeKey(f);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      findings.push(f);
+    }
+  }
+
+  findings.sort(compareFindings);
+  return { findings, errors };
+}

--- a/scripts/destink/vendor/lint/ir-query.ts
+++ b/scripts/destink/vendor/lint/ir-query.ts
@@ -1,0 +1,229 @@
+// Structural query helpers over the Clause IR (#10). The reframe rules (#11) need to ask
+// questions the IR almost answers already — is this clause copular, is it negated, what's the
+// complement head, what's the subject head — without re-deriving them from the parse tree each
+// time. Pure functions over Clause; no layout, no parsing, no knowledge of source spans (that
+// lives in DocAnalysis, see ./types.ts).
+
+import type { Clause, Compound, Nominal, Predicate, Subject, Verbal, Word } from "../ir.js";
+
+// --- copula ---
+
+// Strict be-forms only ("is", "are", "was", "were", "am", "be", "been", "being"). seem/become/
+// feel/look/appear/remain are copula-LIKE (linking verbs) but deliberately excluded: the issue
+// scopes isCopular to be-forms, and folding in the wider linking-verb set would make the
+// predicate's meaning caller-dependent. A rule that wants the wider set can test
+// `clause.verb.head.text` itself against its own list; leaving this narrow keeps isCopular's
+// contract unambiguous.
+const BE_FORMS = new Set(["be", "am", "is", "are", "was", "were", "been", "being"]);
+
+const lastWord = (text: string): string => {
+  const parts = text.trim().split(/\s+/);
+  return (parts[parts.length - 1] ?? "").toLowerCase();
+};
+
+// "isn't" / "wasn't" / "aren't" / "weren't": the rule-based tagger (src/nlp/tagger.ts) folds the
+// negative contraction into the verb token itself rather than splitting it into its own word (see
+// isNegated below for why), so the be-form check has to look past a trailing "n't" too. Modal
+// contractions ("won't", "can't") strip to a non-be-form stem and correctly stay unmatched.
+const stripContractedNegation = (word: string): string => (/n't$/i.test(word) ? word.slice(0, -3) : word);
+
+/**
+ * Is this clause copular — a be-form verb linking the subject to a predicate noun/adjective?
+ *
+ * The verb head is checked by its LAST word, so a verb-phrase head ("has been", "will be")
+ * counts when the auxiliary chain actually ends in a be-form (predicating the complement), but
+ * "has been running" does not (the head ends in "running", a participle, not a copula).
+ *
+ * Compound predicates ("has black fur and can jump high") are NOT inspected per-conjunct: each
+ * conjunct's complement lives on its own PredicatePart (see PredicatePart in ../ir.ts), not on
+ * Clause.complement, so there is no single clause-level complement to test against here.
+ * isCopular bails to `false` for those rather than guessing which conjunct the caller means — a
+ * rule that needs per-conjunct copularity can walk `clause.verb.items` itself.
+ */
+export function isCopular(clause: Clause): boolean {
+  if (!("head" in clause.verb)) return false; // Compound predicate — see doc comment
+  const last = lastWord(clause.verb.head.text);
+  if (!BE_FORMS.has(last) && !BE_FORMS.has(stripContractedNegation(last))) return false;
+  return clause.complement?.kind === "predicateNoun" || clause.complement?.kind === "predicateAdj";
+}
+
+// --- negation ---
+
+// Per the original issue: "not" / "n't" only. #34 (the temporal-absolute reframe, "It was never X.
+// It was always Y.") widens this to "never" too — "never" is a denial exactly the way "not" is,
+// just placed in time rather than in the moment, and the reframe rule needs isNegated(a) to see it
+// so the ordinary "copular, negated, then copular, affirmative, coreferent" pair check picks up the
+// never/always shape for free, with no new predicate of its own. "always" stays OUT of this set: it
+// marks the affirmative side, not a negation, and isNegated(b) must stay false there for the pair to
+// register as a denial-then-replacement at all. A rule wanting to tell "never" apart from "not" (the
+// reframe rule does, for its severity bonus) reads hasAbsoluteAdverb below instead of guessing from
+// this set.
+const NEGATORS = new Set(["not", "n't", "never"]);
+
+const verbalHeads = (verb: Predicate): Verbal[] => ("items" in verb ? verb.items.map((p) => p.verb) : [verb]);
+
+const hasNegationModifier = (verbal: Verbal): boolean =>
+  verbal.modifiers.some((m) => m.kind === "word" && NEGATORS.has(m.value.text.toLowerCase()));
+
+// A verb head can carry the negation fused into its own text ("isn't", "doesn't run") instead of
+// as a separate modifier: compromise (the tagger's POS backend) splits "isn't" into an "isn't"
+// term plus a SEPARATE zero-width term tagged Negative, and the tagger drops empty-text terms —
+// so the rule-based chunker (src/nlp/tagger.ts + parse.ts) never sees "n't" as its own token for
+// a contraction, and it ends up baked into the verb head instead (see lower.ts's verbHead, which
+// joins multi-word verb chains with spaces). A tree from a different source (e.g. a gold PTB
+// parse using the standard "is n't" leaf split) hits the modifier path above instead; this
+// handles both shapes.
+const headHasContractedNegation = (head: Word): boolean => head.text.split(/\s+/).some((tok) => /n't$/i.test(tok));
+
+/**
+ * Is this clause negated — a "not"/"n't"/"never" on the verb, spelled out or contracted?
+ *
+ * "never" is always its own "word" modifier in the rule-based tagger's output (unlike "n't", it
+ * never fuses into the verb head's text — there is no "wasnever" to strip), so only the modifier
+ * path in hasNegationModifier ever catches it; headHasContractedNegation stays "n't"-only.
+ *
+ * Unlike isCopular, this DOES look across every conjunct of a compound predicate: negation is a
+ * per-Verbal fact (modifiers live on each PredicatePart's own verb), so `true` here means at
+ * least one conjunct is negated. A rule wanting per-conjunct precision can inspect
+ * `clause.verb.items[i].verb` directly.
+ */
+export function isNegated(clause: Clause): boolean {
+  return verbalHeads(clause.verb).some((v) => hasNegationModifier(v) || headHasContractedNegation(v.head));
+}
+
+// --- absolute adverbs ("never" / "always") ---
+
+// The bare word list "never"/"always" checks against, kept separate from NEGATORS above (isNegated
+// only ever wants the negative half of this pair).
+const ABSOLUTE_ADVERBS = new Set(["never", "always"]);
+
+/**
+ * Does the clause's verb carry "never" or "always" as a bare adverb modifier — the temporal-absolute
+ * pair the reframe rule's never/always variant looks for (#34)? Returns whichever one is present, or
+ * null for neither. Only ever one of the two can be true of a given clause in practice (a verb
+ * doesn't carry both), so the first hit found across compound-predicate conjuncts is returned.
+ *
+ * Deliberately narrower than isNegated: this does not also catch "not" (that's what isNegated is
+ * for), and it does not look past a fused verb head — the rule-based tagger never fuses "never" or
+ * "always" into the verb the way it fuses "n't", so there is no equivalent fused-head shape to check.
+ */
+export function hasAbsoluteAdverb(clause: Clause): "never" | "always" | null {
+  for (const v of verbalHeads(clause.verb)) {
+    for (const m of v.modifiers) {
+      if (m.kind === "word") {
+        const w = m.value.text.toLowerCase();
+        if (ABSOLUTE_ADVERBS.has(w)) return w as "never" | "always";
+      }
+    }
+  }
+  return null;
+}
+
+// --- heads ---
+
+// A compound's head-of-record is its first item; see the plural `*Heads` variants below for all
+// conjuncts. This mirrors lower.ts's own convention of treating the first/last item as
+// significant (e.g. ditransitive resolution) rather than inventing a new rule here.
+const firstOf = <T>(items: T[]): T | undefined => items[0];
+
+const nominalOrCompoundHead = (n: Nominal | Compound<Nominal>): Word | null => ("head" in n ? n.head : (firstOf(n.items)?.head ?? null));
+const wordOrCompoundHead = (v: Word | Compound<Word>): Word | null => ("items" in v ? (firstOf(v.items) ?? null) : v);
+
+/**
+ * The head word of a clause's complement, descending through Compound (first conjunct) and
+ * through the verbal/clausal complement shapes:
+ *  - predicateNoun / predicateAdj: the noun/adjective head itself.
+ *  - directObject: the object's head; for an infinitive object ("wanted to leave"), the
+ *    infinitive's own verb stands in as its head (there's no noun to point to).
+ *  - directObject holding a full Clause (a causative small clause, "made her students read four
+ *    novels"): no single head word describes that — returns null; a caller wanting more should
+ *    read `clause.complement.value` directly.
+ *  - objectComplement ("elected my uncle mayor"): the complement noun/adjective (the `oc`), not
+ *    the object it's predicated of — that's what a caller means by "the complement" here.
+ */
+export function complementHead(clause: Clause): Word | null {
+  const c = clause.complement;
+  if (!c) return null;
+  switch (c.kind) {
+    case "predicateAdj":
+      return wordOrCompoundHead(c.value);
+    case "predicateNoun":
+      return nominalOrCompoundHead(c.value);
+    case "directObject":
+      if ("head" in c.value) return c.value.head; // Nominal
+      if ("items" in c.value) return nominalOrCompoundHead(c.value); // Compound<Nominal>
+      if ("kind" in c.value) return c.value.verb; // Infinitive: its own verb stands in as the head
+      return null; // Clause complement — see doc comment
+    case "objectComplement":
+      return c.ocIsAdj ? (c.oc as Word) : nominalOrCompoundHead(c.oc as Nominal);
+  }
+}
+
+/** Every complement head, for a Compound predicateNoun/predicateAdj ("tiny and loud"). */
+export function complementHeads(clause: Clause): Word[] {
+  const c = clause.complement;
+  if (!c) return [];
+  if (c.kind === "predicateAdj") return "items" in c.value ? c.value.items : [c.value];
+  if (c.kind === "predicateNoun") return "items" in c.value ? c.value.items.map((i) => i.head) : [c.value.head];
+  const head = complementHead(clause);
+  return head ? [head] : [];
+}
+
+const subjectHeadOf = (s: Subject): Word | null => {
+  if ("head" in s) return s.head; // Nominal
+  if ("items" in s) return firstOf(s.items)?.head ?? null; // Compound<Nominal>
+  if ("kind" in s) return s.verb; // Infinitive | Gerund: its own verb is the head
+  return null; // a noun clause used as subject ("Whoever made this...") has no single head word —
+  // see doc comment on subjectHead.
+};
+
+/**
+ * The head word of a clause's subject, descending through Compound (first conjunct — see
+ * subjectHeads for all). A gerund/infinitive subject ("Running marathons is fun") uses its own
+ * verb as the head, mirroring complementHead's treatment of a verbal complement. A full clause
+ * used nominally as the subject ("Whoever made this pottery did a good job") has no single head
+ * word — this returns null; a caller wanting the embedded subject can read
+ * `(clause.subject as Clause).subject` (or recurse: `subjectHead(clause.subject as Clause)`).
+ */
+export function subjectHead(clause: Clause): Word | null {
+  return subjectHeadOf(clause.subject);
+}
+
+/** Every subject head, for a Compound subject ("Both Max and I"). */
+export function subjectHeads(clause: Clause): Word[] {
+  const s = clause.subject;
+  if ("items" in s) return s.items.map((i) => i.head);
+  const head = subjectHeadOf(s);
+  return head ? [head] : [];
+}
+
+// --- pronominal subject ---
+
+// Kept local rather than importing src/nlp/lexicon.ts's PRON: this module works from the Clause
+// IR alone (the lint layer's contract, see ./types.ts), without a dependency on the English
+// parser seam. The lists deliberately overlap — both describe the same closed class of English
+// function words — but lint's copy is free to grow independently of the parser's.
+const PRONOUNS = new Set(["i", "you", "he", "she", "it", "we", "they", "me", "him", "her", "us", "them"]);
+const DEMONSTRATIVES = new Set(["this", "that", "these", "those"]);
+
+/**
+ * Is the clause's subject a bare pronoun or demonstrative ("It", "This", "They") rather than a
+ * full noun phrase? Used by rules like the negative-parallelism reframe, where "This is not
+ * bold" (demonstrative subject, thin referent) reads differently from "The building is not
+ * bold" (concrete subject).
+ *
+ * Prefers the POS tag (PRP for personal pronouns) when the parse supplied one; falls back to a
+ * word-list check when it didn't. The fallback matters in practice: the rule-based chunker's
+ * lowering (lowerNP in ../lower.ts) leaves the head Word's `pos` unset when a bare NP has no
+ * noun to serve as head (e.g. "This" alone, with nothing else in its NP) — the DT tag lands on a
+ * *modifier* copy of the same word, not on the head we return here.
+ */
+export function subjectIsPronominal(clause: Clause): boolean {
+  const head = subjectHead(clause);
+  if (!head) return false;
+  const lc = head.text.toLowerCase();
+  if (head.pos === "PRP") return true;
+  if (head.pos === "DT") return DEMONSTRATIVES.has(lc);
+  if (head.pos) return false; // some other, non-pronominal tag (NN, NNP, ...): trust it over the word list
+  return PRONOUNS.has(lc) || DEMONSTRATIVES.has(lc); // no POS tag at all: word-list fallback
+}

--- a/scripts/destink/vendor/lint/lexicons/claude-assistant-voice.ts
+++ b/scripts/destink/vendor/lint/lexicons/claude-assistant-voice.ts
@@ -1,0 +1,52 @@
+// The chat register leaking into prose (issue #34) — reflexive validation and customer-service
+// phrases from Claude's assistant voice, showing up in a written document instead of a live
+// back-and-forth with a user. Wired through the claude-lexicon factory (rules/claude-lexicon.ts):
+// ONE hit already fires, visibly, per that tier's inverted severity philosophy — see that file's
+// header for why this lexicon does NOT get the generic lexical tier's below-threshold step-down.
+//
+// Severity shape:
+//   - "you're absolutely right" / "you are absolutely right" / "you're absolutely correct" are
+//     pinned at "high" — the canonical Claudeism (anthropics/claude-code#3382, an HN front-page
+//     thread, a dedicated joke site). Fires even when the user made no factual claim; unmistakable,
+//     never used by accident.
+//   - "production-ready" is pinned at "low" — a real, dev-legit phrase most of the time, but a
+//     known Claude-Code overclaim tell (premature "it's production-ready!" after one green test
+//     run) worth flagging quietly rather than loudly.
+//   - Everything else rides the lexicon's defaultSeverity ("medium") and escalates to "high" once
+//     the document racks up densityThreshold (3) hits from this lexicon — escalation only, per
+//     rules/claude-lexicon.ts; a lone hit never gets stepped DOWN the way the generic lexical tier
+//     would.
+import type { Lexicon } from "./types.js";
+
+export const claudeAssistantVoice: Lexicon = {
+  id: "claude-assistant-voice",
+  name: "Claude assistant voice",
+  defaultSeverity: "medium",
+  densityThreshold: 3,
+  entries: [
+    { match: ["you're", "absolutely", "right"], severity: "high" },
+    { match: ["you", "are", "absolutely", "right"], severity: "high" },
+    { match: ["you're", "absolutely", "correct"], severity: "high" },
+    { match: ["great", "question"] },
+    { match: ["excellent", "question"] },
+    { match: ["that's", "a", "great", "point"] },
+    { match: ["great", "catch"] },
+    { match: ["i", "appreciate", "your", "patience"] },
+    { match: ["i", "apologize", "for", "the", "confusion"] },
+    { match: ["happy", "to", "elaborate"] },
+    { match: ["feel", "free", "to"] },
+    { match: ["would", "you", "like", "me", "to"] },
+    { match: ["a", "good", "starting", "point"] },
+    { match: ["a", "solid", "starting", "point"] },
+    { match: ["a", "great", "starting", "point"] },
+    { match: ["there's", "no", "one-size-fits-all"] },
+    { match: ["your", "mileage", "may", "vary"] },
+    { match: ["reasonable", "people", "can", "disagree"] },
+    {
+      match: "production-ready",
+      severity: "low",
+      note: "dev-legit most of the time; flagged low as a known Claude-Code overclaim tell, not an accusation",
+    },
+    { match: ["this", "matters", "because"] },
+  ],
+};

--- a/scripts/destink/vendor/lint/lexicons/claude-discourse-markers.ts
+++ b/scripts/destink/vendor/lint/lexicons/claude-discourse-markers.ts
@@ -1,0 +1,77 @@
+// Claude's default connective tissue (issue #34) — phrase openers and transitions that announce a
+// rhetorical move (restating, widening the lens, hedging, flagging an aside) instead of just making
+// it. Wired through the claude-lexicon factory (rules/claude-lexicon.ts): ONE hit already fires,
+// visibly; density only escalates the whole lexicon's defaultSeverity ("low") up to "medium" once
+// the document reaches densityThreshold (3) hits — never a step-down.
+//
+// Two deliberate departures from the research thread's candidate list (issue #34 comments), noted
+// here so the exclusion isn't silently lost:
+//
+//   - Bare "ultimately", "critically", "crucially", "subtly" are left OUT of this lexicon. They're
+//     single adverbs reached for to make a claim sound weightier — the exact trope lex-magic-adverbs
+//     (src/lint/lexicons/magic-adverbs.ts: "quietly", "deeply", "fundamentally", "remarkably",
+//     "arguably") already covers, just with different words. Adding them here would just be the same
+//     family under a different rule id; if magic-adverbs grows a Claude-specific variant later, that
+//     lexicon is the place, not this one.
+//
+//   - "tl;dr" is written here as the single token "tldr", not the two-word phrase ["tl", "dr"]. The
+//     tokenizer (stub-doc.ts's wordRe) never sees the semicolon as part of a word, and the unit
+//     splitter (splitUnitSpans) treats ";" as a unit TERMINATOR — "TL;DR: ship it" splits into two
+//     separate units ("TL;" and "DR: ship it") before word-scanning ever runs, so "tl" and "dr" can
+//     never land in the same unit.words array for a multi-word entry to match contiguously. "tldr"
+//     (no punctuation) is the form this matching engine can actually see; the semicolon spelling is
+//     a known gap, not silently dropped.
+//
+// Consolidation-pass addition (issue #34): six more entries sourced from claudisms.ai (CC0), a
+// crowdsourced list of Claude's written tics. "sit with" / "worth sitting with" and "double-click
+// on" / "lean into" are Claude's reach for a physical-action metaphor over a plain verb ("consider",
+// "look more closely at", "focus on"); "the question I keep coming back to" and "what I'd leave you
+// with" are first-person framing devices for, respectively, opening on an unresolved thread and
+// closing with one — connective tissue exactly like the rest of this file, so they join the same
+// lexicon rather than starting a new one.
+import type { Lexicon } from "./types.js";
+
+export const claudeDiscourseMarkers: Lexicon = {
+  id: "claude-discourse-markers",
+  name: "Claude discourse markers",
+  defaultSeverity: "low",
+  densityThreshold: 3,
+  entries: [
+    { match: ["the", "key", "insight", "is"] },
+    { match: ["the", "trick", "is"] },
+    { match: ["the", "catch", "is"] },
+    { match: ["the", "upshot"] },
+    { match: ["put", "differently"] },
+    { match: ["said", "differently"] },
+    { match: ["in", "other", "words"] },
+    { match: ["more", "concretely"] },
+    { match: "concretely" },
+    { match: ["zooming", "out"] },
+    { match: ["taking", "a", "step", "back"] },
+    { match: ["at", "a", "high", "level"] },
+    { match: ["that", "said"] },
+    { match: ["to", "be", "clear"] },
+    { match: ["to", "be", "fair"] },
+    { match: ["to", "be", "direct"] },
+    { match: ["to", "be", "frank"] },
+    { match: ["in", "practice"] },
+    { match: ["in", "short"] },
+    { match: ["in", "essence"] },
+    { match: ["simply", "put"] },
+    { match: ["long", "story", "short"] },
+    { match: "net-net" },
+    { match: ["worth", "calling", "out"] },
+    { match: ["worth", "flagging"] },
+    { match: ["one", "thing", "to", "note"] },
+    { match: ["a", "few", "things", "to", "note"] },
+    { match: ["key", "takeaways"] },
+    { match: "tldr", note: "written form of \"tl;dr\" the tokenizer can actually see — see header comment" },
+    { match: ["better", "posed"] },
+    { match: ["sit", "with"], note: "claudisms.ai (CC0) — \"sit with that for a moment\"" },
+    { match: ["worth", "sitting", "with"], note: "claudisms.ai (CC0)" },
+    { match: ["the", "question", "i", "keep", "coming", "back", "to"], note: "claudisms.ai (CC0)" },
+    { match: ["what", "i'd", "leave", "you", "with"], note: "claudisms.ai (CC0)" },
+    { match: ["double-click", "on"], note: "claudisms.ai (CC0)" },
+    { match: ["lean", "into"], note: "claudisms.ai (CC0)" },
+  ],
+};

--- a/scripts/destink/vendor/lint/lexicons/claude-fiction-frames.ts
+++ b/scripts/destink/vendor/lint/lexicons/claude-fiction-frames.ts
@@ -1,0 +1,75 @@
+// Claude fiction frames (issue #34) — stock sentence frames measured across Claude's fiction
+// generations. Sourced from EQ-Bench's per-model creative-writing slop profiles
+// (https://eqbench.com — the "Claude" model cards list these exact frames among the most
+// over-represented phrases in Claude's fiction output) and cross-checked against sam-paech's
+// slop-forensics corpus tooling (https://github.com/sam-paech/slop-forensics), which builds the
+// EQ-Bench slop lists from bulk model generations. Paraphrase-informed, not vendored: nothing here
+// is copied verbatim from a slop-forensics data file as a bulk list — each entry below was picked
+// by hand because it recurs in Claude fiction specifically, then checked against the two data
+// files fetched for this task (see corroboration notes below). Do not treat this file as a mirror
+// of any upstream list.
+//
+// Corroboration against the two fetched files (both consulted, neither vendored wholesale):
+//   - antislop-sampler's slop_phrase_prob_adjustments.json (Apache-2.0): floor-adjustment entries
+//     (probability multiplier 0.03125, its lowest/most-confident value) that exactly match entries
+//     below: "barely above a whisper", "for what seemed like an eternity", "little did he know",
+//     and (as the 2-word core of the frame here) "shivers down"/"shivers up".
+//   - slop-forensics' data/slop_list_trigrams.json (MIT), trigrams mined from bulk generations
+//     with stopwords stripped: "voice barely audible" appears verbatim; "could shake feeling" and
+//     "shake feeling something" corroborate the held-feeling frame; "something else something"
+//     sits next to (not identical to) "something else entirely".
+// Both lists are dominated by fantasy-name slop (elara, kael, oakhaven...) and single-word
+// atmosphere nouns (tapestry, labyrinth, cacophony) that belong to other lexicons or aren't
+// sentence frames at all — none of that is pulled in here; this file stays scoped to multi-word
+// frames a Claude-written scene reaches for at a beat change.
+//
+// Every entry is a fixed multi-word phrase, not a common word — the false-positive rate for
+// "little did she know" showing up by accident in ordinary prose is close to zero, which is why
+// this lexicon (unlike claude-fiction-gestures) fires at "medium" on a single hit: see
+// rules/claude-lexicon.ts for the single-hit-fires, escalation-only severity model this and its
+// sibling lexicon both use.
+import type { Lexicon } from "./types.js";
+
+export const claudeFictionFrames: Lexicon = {
+  id: "claude-fiction-frames",
+  name: "Claude fiction frames",
+  defaultSeverity: "medium",
+  densityThreshold: 3,
+  entries: [
+    { match: ["something", "else", "entirely"] },
+    { match: ["barely", "above", "a", "whisper"], note: "antislop floor entry (0.03125) — near-unmistakable" },
+    { match: ["voice", "barely", "audible"], note: "verbatim in slop-forensics' trigram list" },
+    {
+      match: ["didn't", "know", "she", "was", "holding"],
+      note: "the held-breath frame — \"a breath she didn't know she was holding\"",
+    },
+    { match: ["didn't", "know", "he", "was", "holding"], note: "the held-breath frame, he-variant" },
+    { match: ["a", "breath", "she", "didn't", "know"], note: "the held-breath frame's opening half" },
+    { match: ["smile", "didn't", "reach"] },
+    { match: ["didn't", "reach", "his", "eyes"] },
+    { match: ["didn't", "reach", "her", "eyes"] },
+    { match: ["quiet", "for", "a", "long", "moment"] },
+    { match: ["a", "sound", "like"] },
+    { match: ["like", "a", "held", "breath"] },
+    { match: ["trying", "to", "sound", "casual"] },
+    { match: ["something", "flickered", "across"] },
+    { match: ["something", "shifted", "in"] },
+    { match: ["seen", "better", "days"] },
+    {
+      match: ["couldn't", "shake", "the", "feeling"],
+      note: "slop-forensics trigrams: \"could shake feeling\", \"shake feeling something\"",
+    },
+    { match: ["for", "what", "seemed", "like", "an", "eternity"], note: "antislop floor entry (0.03125)" },
+    { match: ["little", "did", "she", "know"] },
+    { match: ["little", "did", "he", "know"], note: "antislop floor entry (0.03125)" },
+    { match: ["the", "air", "was", "thick", "with"] },
+    { match: ["sent", "shivers", "down"], note: "antislop floor entry \"shivers down\" (0.03125) is the 2-word core of this frame" },
+    {
+      match: ["a", "mix", "of"],
+      note: "the weakest entry here — ordinary in non-fiction prose too — but the fiction-register cluster it keeps company with makes it worth flagging at the lexicon's default severity",
+    },
+    { match: ["eyes", "gleamed", "with"] },
+    { match: ["knuckles", "whitened"] },
+    { match: ["let", "out", "a", "breath"] },
+  ],
+};

--- a/scripts/destink/vendor/lint/lexicons/claude-fiction-gestures.ts
+++ b/scripts/destink/vendor/lint/lexicons/claude-fiction-gestures.ts
@@ -1,0 +1,68 @@
+// Claude fiction gesture cluster (issue #34) — the small set of gesture/atmosphere verbs and
+// adverbs that recur, together, in Claude's fiction voice: dialogue-tag verbs (murmured, glanced,
+// tilted...), micro-gestures (blinked, nodded, clutched...) and a handful of atmosphere words that
+// ride along with them (stillness, unhurried, faintly). Every single entry is an ordinary English
+// word with plenty of innocent everyday uses — that's WHY this is its own lexicon rather than
+// folded into claude-fiction-frames: the tell isn't any one of these words, it's several of them
+// showing up on the same page. See rules/claude-lexicon.ts for the severity model this earns:
+// "candidate" by default (visible but weakest), escalating only once density crosses the
+// threshold — never suppressed to nothing, because issue #34 wants a single hit to stay visible.
+//
+// Sourced from the same two places as claude-fiction-frames.ts, informing rather than being
+// vendored (see that file for the full attribution). Corroboration found for this cluster
+// specifically: slop-forensics' data/slop_list_trigrams.json (MIT) has "leaned back chair", "voice
+// trembling slightly", "said voice trembling" and "voice low rumble" — all built around entries
+// kept here (leaned, trembling). antislop-sampler's slop_phrase_prob_adjustments.json (Apache-2.0)
+// floor list (0.03125) has "thrummed", "chuckles darkly", "hesitantly" and "eyes never leaving",
+// which are close kin to this cluster but were left OUT: they're rarer / more distinctive words
+// than the ones kept, and this lexicon deliberately sticks to the common, low-signal-per-hit words
+// that only become a tell in a cluster — see #34's brief for the exact word list.
+//
+// lemma:true is used only where the regular-inflection suffix matcher (lemmaMatches, in
+// rules/lexical.ts) actually gets the inflected forms right: plain -s/-es and -ed/-ing with e-drop.
+// Three of the given inflected forms are consonant-doubling irregulars that matcher can't
+// derive from their base (grin -> grinned/grinning, not "grined"/"grining"; same for nod, hum), so
+// those three are listed as the literal past-tense form instead of base+lemma:true — matching only
+// the exact attested inflection rather than silently mis-deriving the rest of the paradigm.
+//
+// PRECISION CALL (documented per #34's brief): obsidian, sternum, forearm-adjacent nouns like
+// stillness are atmosphere words with an entirely literal, non-fiction sense ("the obsidian rock
+// formation", "sternum" in an anatomy text). They're kept in, not dropped, because at "candidate"
+// severity a lone literal hit is the weakest, most easily-ignored signal the linter produces, and
+// this cluster's whole design already treats a single hit as low-stakes evidence — see
+// claude-fiction-gestures.test.ts's severity assertion for the literal-rock case, which pins that
+// single hit at "candidate" rather than asserting it doesn't fire at all.
+import type { Lexicon } from "./types.js";
+
+export const claudeFictionGestures: Lexicon = {
+  id: "claude-fiction-gestures",
+  name: "Claude fiction gesture cluster",
+  defaultSeverity: "candidate",
+  densityThreshold: 5,
+  entries: [
+    { match: "flicker", lemma: true, note: "covers flicker/flickers/flickered/flickering" },
+    { match: "lean", lemma: true, note: "covers lean/leans/leaned/leaning" },
+    { match: "blink", lemma: true, note: "covers blink/blinks/blinked/blinking" },
+    { match: "gesture", lemma: true, note: "covers gesture/gestures/gestured/gesturing" },
+    { match: "grinned", note: "consonant-doubling irregular (grin -> grinned); literal form only, see header" },
+    { match: "nodded", note: "consonant-doubling irregular (nod -> nodded); literal form only, see header" },
+    { match: "hummed", note: "consonant-doubling irregular (hum -> hummed); literal form only, see header" },
+    { match: "murmur", lemma: true, note: "covers murmur/murmurs/murmured/murmuring" },
+    { match: "whisper", lemma: true, note: "covers whisper/whispers/whispered/whispering" },
+    { match: "glance", lemma: true, note: "covers glance/glances/glanced/glancing" },
+    { match: "mutter", lemma: true, note: "covers mutter/mutters/muttered/muttering" },
+    { match: "tilt", lemma: true, note: "covers tilt/tilts/tilted/tilting" },
+    { match: "flinch", lemma: true, note: "covers flinch/flinches/flinched/flinching" },
+    { match: "tremble", lemma: true, note: "covers tremble/trembles/trembled/trembling" },
+    { match: "clutch", lemma: true, note: "covers clutch/clutches/clutched/clutching" },
+    { match: "hiss", lemma: true, note: "covers hiss/hisses/hissed/hissing" },
+    { match: "breathe", lemma: true, note: "covers breathe/breathes/breathed/breathing" },
+    { match: "sternum", note: "atmosphere noun; literal-anatomy sense possible — see PRECISION CALL above" },
+    { match: "stillness" },
+    { match: "unhurried" },
+    { match: "obsidian", note: "atmosphere noun; literal-rock sense possible — see PRECISION CALL above" },
+    { match: "impossibly" },
+    { match: "faintly" },
+    { match: "momentarily" },
+  ],
+};

--- a/scripts/destink/vendor/lint/lexicons/claude-stock-frames.ts
+++ b/scripts/destink/vendor/lint/lexicons/claude-stock-frames.ts
@@ -1,0 +1,139 @@
+// Claude stock frames (issue #34) — the LinkedIn/tech-post broetry register: urgency hooks,
+// significance frames, process frames, and verdict/CTA closers that the existing claude-* lexicons
+// miss. Motivated by a real post that scored near zero against claude-assistant-voice,
+// claude-discourse-markers and claude-technical-vocabulary despite reading unmistakably
+// AI-flavored. Wired through the claude-lexicon factory (rules/claude-lexicon.ts): ONE hit already
+// fires, visibly, at defaultSeverity ("low"); density only ESCALATES the whole lexicon up to
+// "medium" once the document reaches densityThreshold (3) hits — never a step-down. The four
+// unmistakable broetry closers below are pinned "medium" (immune to escalation in both directions,
+// same convention as every other claude-* lexicon's pinned entries).
+//
+// --- DEDUP: grepped against every existing lexicon's data file before adding anything here -------
+//
+//   - "matters because" (2-token: ["matters","because"]) OVERLAPS claude-assistant-voice's
+//     ["this","matters","because"] (3-token) — the given brief's "matters because" bigram is the
+//     generalized form of that lexicon's fixed opener ("This matters because...", "The shift
+//     matters because...", "That matters because..." all share the tail two tokens). Verified
+//     against the fixture battery's actual enforcement (fixture-battery.test.ts's "cross-rule
+//     precision" describe block, and src/lint/fixtures/claude-assistant-voice.ts): the battery only
+//     forbids a rule firing on ANOTHER rule's NEGATIVE fixtures; it does not check whether other
+//     rules also fire on a POSITIVE fixture. claude-assistant-voice's fixtures.ts has exactly one
+//     "matters because" occurrence and it is a POSITIVE ("This matters because the migration
+//     touches billing data."), not a negative — grepped the whole src/lint tree for "matters
+//     because" to confirm there is no negative fixture anywhere containing the phrase. Kept the
+//     bigram as specified: both rules firing side-by-side on "This matters because X" is allowed by
+//     the battery's actual contract and is arguably correct (the sentence really does carry both
+//     tells at once).
+//   - claude-discourse-markers.ts's "in other words" / "to be clear" / "at a high level" family,
+//     claude-technical-vocabulary.ts's dev-vernacular, claude-fiction-frames.ts /
+//     claude-fiction-gestures.ts's fiction-register frames, and every lex-* lexicon in
+//     lexicons/index.ts's LEXICONS barrel (delve-family, false-suspense, filler-transitions,
+//     invented-concept-labels, magic-adverbs, ornate-nouns, pedagogical-voice, serves-as-verbs,
+//     signposts, stakes-inflation, superficial-ing-verbs, vague-attribution): grepped for every
+//     phrase below (case-insensitive, substring) — no collisions.
+//
+// --- PRECISION CALLS made against the brief's raw candidate list --------------------------------
+//
+//   - Standalone "on the sidelines" was DROPPED as a separate entry from "stay on the sidelines".
+//     Two reasons: (1) it is a strict token-subsequence of "stay on the sidelines", so on the
+//     motivating sample ("...can't afford to stay on the sidelines.") both would fire at once,
+//     producing 4 raw hits instead of the specified 3; (2) bare "on the sidelines" collides hard
+//     with the ubiquitous LITERAL sports sense ("the coach stood on the sidelines", "she watched
+//     from the sidelines") with no "stay" anywhere nearby. Keeping only the fuller "stay on the
+//     sidelines" phrase both fixes the count and dodges the literal collision — see the
+//     fixtures file's negative for "she sat on the sidelines during the match" (no "stay", so no
+//     fire; a genuine negative, not a documented false-positive trade-off).
+//   - "agree?" and "thoughts?" (bare one-word CTA questions) were DROPPED entirely. stub-doc.ts's
+//     wordRe only tokenizes `[\p{L}\p{N}]+` runs (plus internal apostrophes/hyphens) — "?" is never
+//     part of any WordSpan, so a literal `match: "agree?"` could never match anything and the only
+//     way to catch the CTA sense at all would be the bare words "agree" / "thoughts". Both are
+//     ordinary high-frequency words ("I agree with the plan", "sharing my thoughts on the merger",
+//     and claude-fiction-frames.ts's own fixture text contains "agreed", one lemma-step from
+//     "agree") — matching them bare would be a severe precision regression this tier's
+//     never-steps-down severity model can't absorb. No token-level rule can distinguish "Agree?" as
+//     a standalone one-word sentence from ordinary prose use without punctuation- or
+//     position-awareness this lexicon layer doesn't have; left out rather than guessed at.
+//   - Gapped forms ("bake governance into", "bake X into Y") are impossible for this engine — entries
+//     are contiguous token runs (see lexicons/types.ts's matching-strategy note) and there is no
+//     fixed word count between "bake" and "into" to fill. Skipped per the brief; kept only the
+//     literal contiguous forms that actually recur: "baked into" and "built in from the start".
+//   - Bare "baked in" (no "into") was DROPPED, not just left as "baked into" per the brief's
+//     suggestion, because it collides with the literal cooking sense with nothing to gate on:
+//     "the cake was baked in a pan" matches the bigram ["baked","in"] exactly as well as "the bias
+//     was baked in from day one" does. "baked into" doesn't share that collision — English doesn't
+//     say a cake was "baked into a pan" — so it stands in for the idiom alone. See the fixtures
+//     file's negative for the cake sentence.
+//   - "the case for" and "makes the case for" are BOTH kept, per the brief, even though "makes the
+//     case for X" contains "the case for X" as a token subsequence and so double-fires on that
+//     exact phrasing (two findings, nested spans, on one sentence). Unlike the sidelines case above,
+//     nothing in the brief pins an exact finding count on a sentence containing both, so this is
+//     left as an accepted, documented overlap rather than dropping either phrase — "the case for"
+//     on its own ("there's a strong case for caution") is common enough in ordinary prose to be the
+//     weakest entry in this lexicon, which is exactly why it rides plain defaultSeverity with no
+//     escalation exemption, same trade-off claude-fiction-frames.ts documents for "a mix of".
+import type { Lexicon } from "./types.js";
+
+export const claudeStockFrames: Lexicon = {
+  id: "claude-stock-frames",
+  name: "Claude stock frames",
+  defaultSeverity: "low",
+  densityThreshold: 3,
+  entries: [
+    // --- urgency hooks --------------------------------------------------------------------
+    { match: ["isn't", "slowing", "down"] },
+    { match: ["isn't", "going", "anywhere"] },
+    { match: ["can't", "afford", "to"] },
+    {
+      match: ["stay", "on", "the", "sidelines"],
+      note: "the literal head verb \"stay\" is required — dodges the ubiquitous literal sports " +
+        "sense (\"stood on the sidelines\") without it; see DEDUP header for why bare \"on the " +
+        "sidelines\" isn't its own entry",
+    },
+    { match: ["wake-up", "call"] },
+    { match: ["the", "stakes", "couldn't", "be", "higher"] },
+
+    // --- significance frames ---------------------------------------------------------------
+    {
+      match: ["matters", "because"],
+      note: "generalized form of claude-assistant-voice's \"this matters because\" — see DEDUP " +
+        "header; also fires on \"the shift matters because\", \"that matters because\", etc.",
+    },
+    { match: ["makes", "the", "case", "for"] },
+    {
+      match: ["the", "case", "for"],
+      note: "weakest entry here — ordinary in non-AI prose too (\"there's a strong case for " +
+        "caution\") — kept per the brief; see DEDUP header for the deliberate overlap with " +
+        "\"makes the case for\"",
+    },
+    { match: ["wasn't", "built", "for"] },
+    { match: ["wasn't", "designed", "for"] },
+    { match: ["the", "pace", "it", "brings"] },
+    { match: ["here's", "why", "that", "matters"] },
+
+    // --- process frames ----------------------------------------------------------------------
+    { match: ["from", "day", "one"] },
+    { match: ["after", "the", "fact"] },
+    { match: ["humans", "in", "the", "loop"] },
+    { match: ["human", "in", "the", "loop"] },
+    {
+      match: ["baked", "into"],
+      note: "\"baked in\" (no \"into\") is deliberately absent — see DEDUP header's cake-pan " +
+        "collision",
+    },
+    { match: ["built", "in", "from", "the", "start"] },
+
+    // --- verdict / CTA frames ----------------------------------------------------------------
+    { match: ["full", "stop"] },
+    { match: ["plain", "and", "simple"] },
+    { match: ["it's", "that", "simple"] },
+    { match: ["let", "that", "sink", "in"], severity: "medium", note: "unmistakable broetry closer" },
+    { match: ["read", "that", "again"], severity: "medium", note: "unmistakable broetry closer" },
+    {
+      match: ["most", "people", "won't", "read", "this", "far"],
+      severity: "medium",
+      note: "unmistakable broetry closer",
+    },
+    { match: ["if", "this", "resonates"] },
+    { match: ["repost", "if"], severity: "medium", note: "unmistakable broetry closer" },
+  ],
+};

--- a/scripts/destink/vendor/lint/lexicons/claude-technical-vocabulary.ts
+++ b/scripts/destink/vendor/lint/lexicons/claude-technical-vocabulary.ts
@@ -1,0 +1,88 @@
+// Claude's dev-prose idiolect (issue #34) — real engineering vocabulary that shows up so often in
+// AI-written docs, PRs and READMEs that a single occurrence already reads as machine-flavored,
+// regardless of who typed it. This is NOT the generic lexical tier's data shape reused as-is: it is
+// consumed by rules/claude-lexicon.ts's buildClaudeLexiconRule (single-hit fires, density only
+// ESCALATES — see that file's header), not rules/lexical.ts's buildLexiconRule (density
+// STEPS DOWN a sparse hit). Deliberately NOT added to lexicons/index.ts's LEXICONS barrel: that
+// array feeds lexical.ts's LEXICAL_RULES, which builds one step-down rule per entry and would both
+// mis-score this lexicon's findings and break lexical.test.ts's hardcoded "exactly 10 rules" count.
+//
+// Severity tiers (owner call on #34, by how load-bearing/strong the phrase reads as a Claude tell):
+//   - entries with their own `severity: "high"` are pinned there — the strongest tells, immune to
+//     density in both directions, same convention as lex-delve-family's "delve".
+//   - entries with no `severity` ride defaultSeverity ("medium") and ESCALATE to "high" once the
+//     document's total hits from this lexicon reach densityThreshold (4) — see claude-lexicon.ts.
+//   - entries with their own `severity: "low"` are pinned there — dev-vernacular overlap that still
+//     fires on a single hit, but never escalates past low on its own density signal alone.
+//
+// "load-bearing" is deliberately ABSENT from this file. It needs a literal-sense gate (clean before
+// a structural noun: "the load-bearing wall") that a plain word-list entry can't express — it lives
+// in rules/claude-figurative.ts instead, alongside the other pattern-shaped Claude-isms.
+//
+// A handful of entries are marked "(figurative)" in their note: they have an innocent literal sense
+// (a "guardrail" on a highway, "moving parts" in an engine) that this lexicon does not attempt to
+// exclude, same accepted trade-off as lex-ornate-nouns' "landscape" — see lexicons/types.ts's
+// matching-strategy note. Unlike "load-bearing", these don't get a custom gate: the literal reading
+// is rare enough in ordinary prose that the false-positive rate is low, and this lexicon's lack of
+// any density step-down means an occasional literal hit reads as low-stakes on its own.
+
+import type { Lexicon } from "./types.js";
+
+export const claudeTechnicalVocabulary: Lexicon = {
+  id: "claude-technical-vocabulary",
+  name: "Claude's dev-prose idiolect",
+  defaultSeverity: "medium",
+  densityThreshold: 4,
+  entries: [
+    // --- high: pinned, the strongest single-hit tells --------------------------------------
+    { match: ["worth", "stating", "plainly"], severity: "high" },
+
+    // --- medium: no severity override, rides defaultSeverity, escalates at density 4 -------
+    { match: "battle-tested" },
+    { match: "footgun" },
+    { match: ["escape", "hatch"], note: "figurative — an actual physical escape hatch is rare in dev prose" },
+    { match: ["happy", "path"] },
+    { match: ["blast", "radius"], note: "figurative" },
+    { match: ["table", "stakes"] },
+    { match: ["north", "star"], note: "figurative" },
+    { match: ["single", "source", "of", "truth"] },
+    { match: ["paper", "cut"], note: "figurative" },
+    { match: ["paper", "cuts"], note: "figurative" },
+    { match: ["sharp", "edges"], note: "figurative" },
+    { match: ["cognitive", "load"] },
+    { match: ["mental", "model"] },
+    { match: ["first-class", "citizen"] },
+    { match: ["batteries", "included"] },
+
+    // --- low: pinned, dev-vernacular overlap that still fires on a single hit --------------
+    { match: "guardrails", severity: "low", note: "figurative" },
+    { match: ["moving", "parts"], severity: "low", note: "figurative" },
+    { match: "seamless", severity: "low" },
+    { match: "seamlessly", severity: "low" },
+    { match: "performant", severity: "low" },
+    { match: "idiomatic", severity: "low" },
+    { match: "opinionated", severity: "low" },
+    { match: "principled", severity: "low" },
+    { match: "pragmatic", severity: "low" },
+    { match: "composable", severity: "low" },
+    { match: "ergonomics", severity: "low" },
+    { match: "ergonomic", severity: "low" },
+    { match: "affordance", severity: "low" },
+    { match: ["surface", "area"], severity: "low", note: "figurative" },
+    { match: "future-proof", severity: "low" },
+    { match: "non-trivial", severity: "low" },
+    { match: "meticulously", severity: "low" },
+    { match: "thoughtfully", severity: "low" },
+    { match: "gracefully", severity: "low" },
+    { match: "holistic", severity: "low" },
+    { match: "orthogonal", severity: "low", note: "figurative" },
+    { match: ["flesh", "out"], severity: "low" },
+    { match: ["round", "out"], severity: "low" },
+    { match: ["wire", "up"], severity: "low" },
+    { match: ["thread", "through"], severity: "low" },
+    { match: ["plumb", "through"], severity: "low" },
+    { match: "spiritually", severity: "low" },
+    { match: ["morally", "equivalent"], severity: "low" },
+    { match: "modulo", severity: "low", note: "as \"except for\", not the arithmetic operator" },
+  ],
+};

--- a/scripts/destink/vendor/lint/lexicons/corporate-jargon.ts
+++ b/scripts/destink/vendor/lint/lexicons/corporate-jargon.ts
@@ -1,0 +1,46 @@
+// Corporate jargon (issue #34, consolidation pass) — boardroom/business-speak clichés. Not
+// LLM-specific on their own (people said "circle back" long before ChatGPT), but they show up
+// constantly in AI-generated business writing because the model has seen so much of it, and
+// they're exactly the kind of thing CLAUDE.md's word-choice section is aimed at: a fancy stand-in
+// for a plain statement. Wired through the standard step-down factory (rules/excess-vocabulary.ts's
+// buildStandardLexiconRule), same as lexicons/excess-vocabulary.ts.
+//
+// Every entry is a fixed multi-word (or hyphen-compound) phrase, not a common standalone word — the
+// false-positive rate for "move the needle" or "take this offline" showing up by accident is close
+// to zero, so this fires at "medium" on a single hit with no density gating, the same design point
+// as lex-filler-transitions/lex-false-suspense (see lexicons/types.ts's densityThreshold doc).
+//
+// DEDUP against lex-pedagogical-voice and lex-ornate-nouns (rules/lexical.ts, both ACTIVE): neither
+// lexicon has any of the multi-word phrases below. Two entries share a PREFIX with an existing
+// single-word ornate-nouns entry — "paradigm shift" starts with ornate-nouns' bare "paradigm", and
+// claude-technical-vocabulary's "north star" is the first two tokens of "north star metric" — but a
+// prefix match from an unrelated lexicon is expected, allowed overlap (engine.ts: "two tells can
+// legitimately land on the same words... from different rules"), not the same lexicon entry fired
+// twice. A literal duplicate would be adding a bare "paradigm" or "synergy" entry here; neither is
+// present, since ornate-nouns already owns those.
+import type { Lexicon } from "./types.js";
+
+export const corporateJargon: Lexicon = {
+  id: "corporate-jargon",
+  name: "Corporate jargon",
+  defaultSeverity: "medium",
+  entries: [
+    { match: ["actionable", "insights"] },
+    { match: ["thought", "leadership"] },
+    { match: ["pain", "points"] },
+    { match: ["pain", "point"] },
+    { match: ["move", "the", "needle"] },
+    { match: ["low-hanging", "fruit"] },
+    { match: ["paradigm", "shift"] },
+    { match: ["deep", "dive"] },
+    { match: ["value", "proposition"] },
+    { match: ["key", "learnings"] },
+    { match: ["circle", "back"] },
+    { match: ["double", "down"] },
+    { match: ["take", "this", "offline"] },
+    { match: ["north", "star", "metric"] },
+    { match: ["boil", "the", "ocean"] },
+    { match: "best-in-class" },
+    { match: ["at", "the", "end", "of", "the", "day"] },
+  ],
+};

--- a/scripts/destink/vendor/lint/lexicons/delve-family.ts
+++ b/scripts/destink/vendor/lint/lexicons/delve-family.ts
@@ -1,0 +1,34 @@
+// "Delve" and friends — CLAUDE.md's "Delve and Friends" section: delve went from an uncommon word
+// to a staggering share of AI text, alongside a family of similarly overused vocabulary.
+import type { Lexicon } from "./types.js";
+
+export const delveFamily: Lexicon = {
+  id: "lex-delve-family",
+  name: "Delve and friends",
+  defaultSeverity: "low",
+  densityThreshold: 2,
+  entries: [
+    {
+      match: "delve",
+      lemma: true,
+      severity: "medium",
+      note: "the most infamous AI tell; strong signal even on a single occurrence",
+    },
+    { match: "certainly", note: "filler intensifier, as in \"we certainly need to...\"" },
+    { match: "utilize", lemma: true, note: "plain \"use\" almost always reads better" },
+    {
+      match: "leverage",
+      posGate: "verb",
+      lemma: true,
+      note: "as a verb (\"leverage these frameworks\"); the noun (financial leverage) is fine",
+    },
+    { match: "robust", note: "vague intensifier standing in for a specific quality" },
+    { match: "streamline", lemma: true },
+    {
+      match: "harness",
+      posGate: "verb",
+      lemma: true,
+      note: "as a verb (\"harness the power of...\"); the noun (a climbing harness) is fine",
+    },
+  ],
+};

--- a/scripts/destink/vendor/lint/lexicons/excess-vocabulary.ts
+++ b/scripts/destink/vendor/lint/lexicons/excess-vocabulary.ts
@@ -1,0 +1,206 @@
+// Generic-LLM excess vocabulary (issue #34, consolidation pass) — ordinary-looking words that
+// showed up disproportionately more often in text written with LLM assistance than in matched
+// human baselines, per two independent word-frequency studies. Unlike the claude-* lexicons in
+// this directory, this is NOT Claude-specific: both source studies measured GPT-family output
+// (ChatGPT-era papers, bulk GPT completions), so this lexicon is wired through the STANDARD
+// lexical-tier rule (rules/excess-vocabulary.ts's buildStandardLexiconRule, the same density
+// STEP-DOWN semantics as rules/lexical.ts's buildLexiconRule — see that file for why this couldn't
+// just be added to LEXICONS and picked up by lexical.ts directly).
+//
+// Sources (both fetched directly for this file; no bulk vendoring — see per-bucket notes below):
+//   - Kobak, González-Márquez, Horváth & Lause (2025), "Delving into LLM-assisted writing in
+//     biomedical publications through excess vocabulary", Science Advances 11(27). Data + code:
+//     https://github.com/berenslab/llm-excess-vocab (MIT License, Copyright (c) 2024 Dmitry Kobak,
+//     Rita González-Márquez). Word list: results/excess_words.csv — every word below tagged
+//     type=="style" in that file (as opposed to type=="content", domain/topic words like
+//     "coronavirus", or type=="other", database/citation artifacts — neither belongs in a prose
+//     style lexicon). The CSV itself does not carry the paper's per-word excess-usage ratio as a
+//     column; the medium/low/candidate buckets below encode the paper's published ratio bands by
+//     hand (the specific >=8x word list is the paper's own highest-ratio set).
+//   - Juzek & Ward (2025), "Why Does ChatGPT 'Delve' So Much? Exploring the Sources of Lexical
+//     Overrepresentation in Large Language Models", COLING 2025, pp. 6397-6411
+//     (https://aclanthology.org/2025.coling-main.426/). Code + data:
+//     https://github.com/tjuzek/delve (CC0 1.0 Universal — LICENSE-DATA). Focal words: the target
+//     word list in code/other_datasets/count_keywords.py, filtered down to the actual AI-tell
+//     vocabulary (that file also counts ordinary high-frequency words like "the"/"data"/"patients"
+//     as a frequency baseline — those are not trope words and are excluded here).
+//
+// --- severity bands (owner call on #34, mapped from the two studies' reported effect sizes) -----
+//
+//   medium (pinned, no density gating): the paper's own highest-overrepresentation band, reported
+//     at roughly 8x or more the expected rate. A single occurrence is already the signal these
+//     words were chosen for.
+//   low (pinned, no density gating): a real but smaller excess-usage effect (roughly 3-8x),
+//     covering most of the CSV's type=="style" rows plus the Juzek & Ward focal words not already
+//     in the medium band. Ordinary words with legitimate everyday uses, so pinned at the tier's
+//     softest non-candidate rung rather than escalating.
+//   candidate (NOT pinned — rides the lexicon's defaultSeverity so the standard step-down applies):
+//     a small set of very high-volume, very ordinary words the paper still measured as elevated.
+//     Alone, one of these is barely worth mentioning (see CLAUDE.md: "a single pattern... might be
+//     fine"); rules/excess-vocabulary.ts's density step-down is what actually enforces that — see
+//     that file's header for the mechanism.
+//
+// --- DEDUP against every existing lexicon (this tier's whole point per #34's consolidation ask —
+// verified by running the fixture battery's cross-rule check, not just by inspection) ------------
+//
+//   EXCLUDED, already covered by lex-delve-family (rules/lexical.ts): delve, delves, delved,
+//   delving (that lexicon's "delve" entry is lemma:true and already matches all four surface
+//   forms) — despite "delve"/"delves"/"delved"/"delving" being literally in the paper's own
+//   >=8x example list, adding them here would fire the SAME word twice under two different rule
+//   ids for no added signal. Also excluded for the same reason: streamline/streamlined/streamlines
+//   /streamlining, harness/harnesses/harnessing, utilize/utilized/utilizes/utilizing, and
+//   leverage/leverages/leveraging (delve-family's streamline/harness/utilize/leverage entries are
+//   all lemma:true or already cover the relevant inflections).
+//   EXCLUDED, already in claude-technical-vocabulary (rules/claude-lexicon.ts, ACTIVE rule):
+//   meticulously (pinned "low" there) and seamless/seamlessly (pinned "low" there) — despite
+//   "meticulously" being in the paper's own >=8x example list, it already has an active rule.
+//   EXCLUDED, already in lex-filler-transitions (rules/lexical.ts, ACTIVE rule): notably (exact
+//   word, no lemma, already fires at "medium" with no density gate there) — "notable" (the
+//   adjective, a different surface token) is NOT excluded, since that lexicon only matches the
+//   literal string "notably".
+//   EXCLUDED, thematically owned by lex-superficial-ing-verbs (data exists in lexicons/
+//   superficial-ing-verbs.ts for issue #18's future rule, even though that lexicon isn't wired to
+//   an active TropeRule yet — see rules/lexical.ts's STRUCTURAL_LEXICON_IDS): highlighting
+//   (highlight/lemma:true already claims this inflection) and contributing/shaping (contribute/
+//   shape, both lemma:true, already claim theirs). Adding them here would be redundant the moment
+//   #18 lands its rule, so they're left out now instead of landing pre-broken.
+//   EXCLUDED, generic function/grammar words the source CSV includes as raw frequency deltas but
+//   that carry no distinguishable trope signal on their own (across, between, however, into, like,
+//   these, this, were, while, within, both, need, hold/holds, based, offer/offers/offering, role,
+//   approach, analysis, research, complex, impact, statement, findings, techniques, strategies,
+//   various, valuable, individuals, understanding, using, thereby, ultimately, subsequent,
+//   primarily/primary, particularly, potentially/potential, precise, predominantly, presents,
+//   providing, despite, during, amid/amidst, alongside, midst, consequently, inquiries,
+//   limitations, necessity, outcomes, resulting, remains, seeks, serves/serving, spanning,
+//   struggle, swift/swiftly, thorough, urging, varying, verifies, wandering, yielding, warranting,
+//   postponed, overwhelmed, persist, assess*, capabilities, categoriz*, challenge*, combating,
+//   complicat*, comprising, demonstrat*, dependab*, detailing, diminish*, displaying, disrupts,
+//   distinct*, diverse, easing, effectively, emerged/emerges, employed/employing/employs) — a
+//   curation call, not an omission; a linter that fires "medium" on the word "however" is not
+//   useful. "remarkable" is ALSO excluded even though it is a genuine CSV style word: it collides
+//   with an existing NEGATIVE fixture in formatting-em-dash-density.ts ("nothing else remarkable at
+//   all here today"), which the cross-rule battery caught.
+import type { Lexicon } from "./types.js";
+
+export const excessVocabulary: Lexicon = {
+  id: "excess-vocabulary",
+  name: "Excess LLM vocabulary",
+  defaultSeverity: "low",
+  densityThreshold: 3,
+  entries: [
+    // --- medium: pinned, the paper's own >=8x band (minus the delve-family/claude-technical- ---
+    // --- vocabulary overlaps documented above) -----------------------------------------------
+    { match: "showcasing", severity: "medium" },
+    { match: "underscores", severity: "medium" },
+    { match: "underscoring", severity: "medium" },
+    { match: "surpassing", severity: "medium" },
+    { match: "commendable", severity: "medium" },
+
+    // --- low: pinned, the paper's ~3-8x band plus Juzek & Ward's focal words -------------------
+    { match: "advancement", severity: "low" },
+    { match: "advancements", severity: "low" },
+    { match: "aligns", severity: "low", note: "Juzek & Ward focal word" },
+    { match: "avenue", severity: "low" },
+    { match: "avenues", severity: "low" },
+    { match: "bolster", severity: "low" },
+    { match: "bolstered", severity: "low" },
+    { match: "bolstering", severity: "low" },
+    { match: "boasts", severity: "low", note: "Juzek & Ward focal word" },
+    { match: "burgeoning", severity: "low" },
+    { match: "comprehending", severity: "low", note: "Juzek & Ward focal word" },
+    { match: "compelling", severity: "low" },
+    { match: "crafted", severity: "low" },
+    { match: "crafting", severity: "low" },
+    { match: "culminating", severity: "low" },
+    { match: "delineates", severity: "low" },
+    { match: "discern", severity: "low" },
+    { match: "discernible", severity: "low" },
+    { match: "elucidate", severity: "low" },
+    { match: "elucidates", severity: "low" },
+    { match: "elucidating", severity: "low" },
+    { match: "embracing", severity: "low" },
+    { match: "emphasizing", severity: "low", note: "Juzek & Ward focal word" },
+    { match: "emulating", severity: "low" },
+    { match: "encapsulates", severity: "low" },
+    { match: "encompass", severity: "low" },
+    { match: "encompassing", severity: "low" },
+    { match: "endeavors", severity: "low" },
+    { match: "endeavours", severity: "low" },
+    { match: "exceptional", severity: "low" },
+    { match: "exceptionally", severity: "low" },
+    { match: "foundational", severity: "low" },
+    { match: "formidable", severity: "low" },
+    { match: "garnered", severity: "low", note: "Juzek & Ward focal word" },
+    { match: "garnering", severity: "low" },
+    { match: "groundbreaking", severity: "low", note: "Juzek & Ward focal word" },
+    { match: "grappling", severity: "low" },
+    { match: "groundwork", severity: "low" },
+    { match: "hinges", severity: "low" },
+    { match: "illuminates", severity: "low" },
+    { match: "illuminating", severity: "low" },
+    { match: "imperative", severity: "low" },
+    { match: "impressive", severity: "low" },
+    { match: "innovative", severity: "low" },
+    { match: "interconnectedness", severity: "low" },
+    { match: "interplay", severity: "low" },
+    { match: "intricate", severity: "low", note: "Juzek & Ward focal word" },
+    { match: "intricacies", severity: "low", note: "Juzek & Ward focal word" },
+    { match: "intricately", severity: "low" },
+    { match: "invaluable", severity: "low" },
+    { match: "juxtaposed", severity: "low" },
+    { match: "multifaceted", severity: "low" },
+    { match: "necessitate", severity: "low" },
+    { match: "necessitating", severity: "low" },
+    { match: "noteworthy", severity: "low" },
+    { match: "nuanced", severity: "low" },
+    { match: "nuances", severity: "low" },
+    { match: "orchestrating", severity: "low" },
+    { match: "paving", severity: "low" },
+    { match: "pinpoint", severity: "low" },
+    { match: "pinpointing", severity: "low" },
+    { match: "pioneering", severity: "low" },
+    { match: "pivotal", severity: "low" },
+    { match: "poised", severity: "low" },
+    { match: "propelling", severity: "low" },
+    { match: "pronounced", severity: "low" },
+    { match: "realm", severity: "low", note: "Juzek & Ward focal word" },
+    { match: "realms", severity: "low" },
+    { match: "renowned", severity: "low" },
+    { match: "revolutionize", severity: "low" },
+    { match: "revolutionizing", severity: "low" },
+    { match: "scrutinize", severity: "low" },
+    { match: "scrutinizing", severity: "low" },
+    { match: "showcase", severity: "low" },
+    { match: "showcased", severity: "low" },
+    { match: "showcases", severity: "low", note: "Juzek & Ward focal word (as \"showcases\")" },
+    { match: "spurred", severity: "low" },
+    { match: "substantiated", severity: "low" },
+    { match: "surmount", severity: "low" },
+    { match: "surpass", severity: "low" },
+    { match: "surpassed", severity: "low" },
+    { match: "surpasses", severity: "low", note: "Juzek & Ward focal word" },
+    { match: "transformative", severity: "low" },
+    { match: "unparalleled", severity: "low" },
+    { match: "unraveling", severity: "low" },
+    { match: "underexplored", severity: "low" },
+    { match: "underscore", severity: "low" },
+    { match: "underscored", severity: "low" },
+    { match: "unexplored", severity: "low" },
+    { match: "uncharted", severity: "low" },
+    { match: "unveil", severity: "low" },
+    { match: "unveiling", severity: "low" },
+    { match: "unveils", severity: "low" },
+    { match: "unveiled", severity: "low" },
+    { match: "unlock", severity: "low" },
+    { match: "unlocking", severity: "low" },
+    { match: "versatility", severity: "low" },
+
+    // --- candidate: NOT pinned — rides defaultSeverity ("low"), so the standard step-down in ---
+    // --- rules/excess-vocabulary.ts demotes a below-threshold hit to "candidate" (see header) ---
+    { match: "notable" },
+    { match: "comprehensive" },
+    { match: "crucial" },
+    { match: "insights" },
+    { match: "enhancing" },
+  ],
+};

--- a/scripts/destink/vendor/lint/lexicons/false-suspense.ts
+++ b/scripts/destink/vendor/lint/lexicons/false-suspense.ts
@@ -1,0 +1,16 @@
+// "Here's the Kicker" — false-suspense transitions promising a revelation before an unremarkable
+// observation. Fixed phrases, essentially never used by accident.
+import type { Lexicon } from "./types.js";
+
+export const falseSuspense: Lexicon = {
+  id: "lex-false-suspense",
+  name: "False suspense",
+  defaultSeverity: "medium",
+  entries: [
+    { match: ["here's", "the", "kicker"] },
+    { match: ["here's", "the", "thing"] },
+    { match: ["here's", "where", "it", "gets", "interesting"] },
+    { match: ["here's", "what", "most", "people", "miss"] },
+    { match: ["here's", "the", "deal"] },
+  ],
+};

--- a/scripts/destink/vendor/lint/lexicons/filler-transitions.ts
+++ b/scripts/destink/vendor/lint/lexicons/filler-transitions.ts
@@ -1,0 +1,16 @@
+// "It's Worth Noting" — filler transitions that introduce a point without connecting it to
+// anything. Distinctive enough that a single occurrence is already a decent signal.
+import type { Lexicon } from "./types.js";
+
+export const fillerTransitions: Lexicon = {
+  id: "lex-filler-transitions",
+  name: "Filler transitions",
+  defaultSeverity: "medium",
+  entries: [
+    { match: ["it's", "worth", "noting"] },
+    { match: ["it", "bears", "mentioning"] },
+    { match: "importantly" },
+    { match: "interestingly" },
+    { match: "notably" },
+  ],
+};

--- a/scripts/destink/vendor/lint/lexicons/index.ts
+++ b/scripts/destink/vendor/lint/lexicons/index.ts
@@ -1,0 +1,48 @@
+// Barrel for the lexical tier of the de-stink linter (issue #20). Wave-2 rules import LEXICONS
+// (and the shape types) from here rather than reaching into individual files.
+export type { PosGate, LexiconEntry, Lexicon } from "./types.js";
+export { POS_GATE_PREFIX } from "./types.js";
+
+import type { Lexicon } from "./types.js";
+import { delveFamily } from "./delve-family.js";
+import { ornateNouns } from "./ornate-nouns.js";
+import { fillerTransitions } from "./filler-transitions.js";
+import { falseSuspense } from "./false-suspense.js";
+import { pedagogicalVoice } from "./pedagogical-voice.js";
+import { signposts } from "./signposts.js";
+import { stakesInflation } from "./stakes-inflation.js";
+import { vagueAttribution } from "./vague-attribution.js";
+import { inventedConceptLabels } from "./invented-concept-labels.js";
+import { magicAdverbs } from "./magic-adverbs.js";
+import { servesAsVerbs } from "./serves-as-verbs.js";
+import { superficialIngVerbs } from "./superficial-ing-verbs.js";
+
+export {
+  delveFamily,
+  ornateNouns,
+  fillerTransitions,
+  falseSuspense,
+  pedagogicalVoice,
+  signposts,
+  stakesInflation,
+  vagueAttribution,
+  inventedConceptLabels,
+  magicAdverbs,
+  servesAsVerbs,
+  superficialIngVerbs,
+};
+
+export const LEXICONS: readonly Lexicon[] = [
+  delveFamily,
+  ornateNouns,
+  fillerTransitions,
+  falseSuspense,
+  pedagogicalVoice,
+  signposts,
+  stakesInflation,
+  vagueAttribution,
+  inventedConceptLabels,
+  magicAdverbs,
+  servesAsVerbs,
+  superficialIngVerbs,
+];

--- a/scripts/destink/vendor/lint/lexicons/invented-concept-labels.ts
+++ b/scripts/destink/vendor/lint/lexicons/invented-concept-labels.ts
@@ -1,0 +1,22 @@
+// Invented Concept Labels — abstract problem-nouns appended to a domain word to fake an
+// established term ("the supervision paradox", "workload creep"). This lexicon holds only the
+// suffix nouns; the domain-word + suffix adjacency pattern is a structural check wave-2 owns.
+// These are common ordinary nouns with plenty of legitimate uses (including established compounds
+// like "digital divide" or "power vacuum" that are NOT AI inventions), so they stay low severity
+// with density required.
+import type { Lexicon } from "./types.js";
+
+export const inventedConceptLabels: Lexicon = {
+  id: "lex-invented-concept-labels",
+  name: "Invented concept labels",
+  defaultSeverity: "low",
+  densityThreshold: 2,
+  entries: [
+    { match: "paradox", posGate: "noun" },
+    { match: "trap", posGate: "noun" },
+    { match: "creep", posGate: "noun" },
+    { match: "divide", posGate: "noun", note: "watch for the established compound \"digital divide\"" },
+    { match: "vacuum", posGate: "noun", note: "watch for the established compound \"power vacuum\"" },
+    { match: "inversion", posGate: "noun" },
+  ],
+};

--- a/scripts/destink/vendor/lint/lexicons/magic-adverbs.ts
+++ b/scripts/destink/vendor/lint/lexicons/magic-adverbs.ts
@@ -1,0 +1,22 @@
+// "Quietly" and Other Magic Adverbs — adverbs reached for to make a mundane description feel
+// significant. All common words with plenty of literal, non-figurative uses, so low severity with
+// density required.
+import type { Lexicon } from "./types.js";
+
+export const magicAdverbs: Lexicon = {
+  id: "lex-magic-adverbs",
+  name: "Magic adverbs",
+  defaultSeverity: "low",
+  densityThreshold: 2,
+  entries: [
+    {
+      match: "quietly",
+      posGate: "adverb",
+      note: "figurative sense (\"quietly powerful\"), not literal (\"spoke quietly\")",
+    },
+    { match: "deeply", posGate: "adverb" },
+    { match: "fundamentally", posGate: "adverb" },
+    { match: "remarkably", posGate: "adverb" },
+    { match: "arguably", posGate: "adverb" },
+  ],
+};

--- a/scripts/destink/vendor/lint/lexicons/ornate-nouns.ts
+++ b/scripts/destink/vendor/lint/lexicons/ornate-nouns.ts
@@ -1,0 +1,20 @@
+// "Tapestry" and "Landscape" — ornate or grandiose nouns standing in for something plainer.
+import type { Lexicon } from "./types.js";
+
+export const ornateNouns: Lexicon = {
+  id: "lex-ornate-nouns",
+  name: "Ornate nouns",
+  defaultSeverity: "low",
+  densityThreshold: 2,
+  entries: [
+    { match: "tapestry", severity: "medium", note: "\"the rich tapestry of X\"; rarely used literally" },
+    {
+      match: "landscape",
+      note: "figurative sense only (\"the landscape of modern AI\"); wave-2 needs to exclude " +
+        "literal geography/terrain uses — see the matching-strategy note in ./types.ts",
+    },
+    { match: "paradigm" },
+    { match: "synergy" },
+    { match: "ecosystem" },
+  ],
+};

--- a/scripts/destink/vendor/lint/lexicons/pedagogical-voice.ts
+++ b/scripts/destink/vendor/lint/lexicons/pedagogical-voice.ts
@@ -1,0 +1,22 @@
+// "Let's Break This Down" / "Think of It As..." — the teacher-student voice AI defaults to even
+// for expert readers. "it's like a" is generic enough to need density; the rest are distinctive.
+import type { Lexicon } from "./types.js";
+
+export const pedagogicalVoice: Lexicon = {
+  id: "lex-pedagogical-voice",
+  name: "Pedagogical voice",
+  defaultSeverity: "medium",
+  entries: [
+    { match: ["let's", "break", "this", "down"] },
+    { match: ["let's", "unpack"] },
+    { match: ["let's", "dive", "in"] },
+    { match: ["let's", "explore"] },
+    { match: ["think", "of", "it", "as"] },
+    {
+      match: ["it's", "like", "a"],
+      severity: "low",
+      note: "generic analogy opener; also appears in ordinary non-AI writing, so treat as low " +
+        "confidence alone",
+    },
+  ],
+};

--- a/scripts/destink/vendor/lint/lexicons/serves-as-verbs.ts
+++ b/scripts/destink/vendor/lint/lexicons/serves-as-verbs.ts
@@ -1,0 +1,22 @@
+// The "Serves As" Dodge — replacing a plain "is"/"are" with a pompous stand-in. Feeds issue #18's
+// copular-dodge rule (src/lint's syntactic tier), which pairs this lexicon with the copular query
+// helpers from #10 to confirm the word is standing in for a copula rather than used literally
+// ("the sign marks the trailhead" is fine; "the plaque marks a turning point" is the dodge).
+import type { Lexicon } from "./types.js";
+
+export const servesAsVerbs: Lexicon = {
+  id: "lex-serves-as-verbs",
+  name: "Serves-as verbs",
+  defaultSeverity: "low",
+  densityThreshold: 2,
+  entries: [
+    {
+      match: ["serve", "as"],
+      lemma: true,
+      note: "lemma applies to the head verb: serves as / served as / serving as",
+    },
+    { match: ["stand", "as"], lemma: true, note: "lemma applies to the head verb: stands as / stood as" },
+    { match: "mark", posGate: "verb", lemma: true },
+    { match: "represent", posGate: "verb", lemma: true },
+  ],
+};

--- a/scripts/destink/vendor/lint/lexicons/signposts.ts
+++ b/scripts/destink/vendor/lint/lexicons/signposts.ts
@@ -1,0 +1,15 @@
+// The Signposted Conclusion — explicitly announcing a conclusion instead of letting the reader
+// feel it. Legitimate in some formal essay conventions, so kept at low severity with density.
+import type { Lexicon } from "./types.js";
+
+export const signposts: Lexicon = {
+  id: "lex-signposts",
+  name: "Signposted conclusions",
+  defaultSeverity: "low",
+  densityThreshold: 2,
+  entries: [
+    { match: ["in", "conclusion"] },
+    { match: ["to", "sum", "up"] },
+    { match: ["in", "summary"] },
+  ],
+};

--- a/scripts/destink/vendor/lint/lexicons/stakes-inflation.ts
+++ b/scripts/destink/vendor/lint/lexicons/stakes-inflation.ts
@@ -1,0 +1,13 @@
+// Grandiose Stakes Inflation — every argument gets inflated to world-historical significance.
+import type { Lexicon } from "./types.js";
+
+export const stakesInflation: Lexicon = {
+  id: "lex-stakes-inflation",
+  name: "Stakes inflation",
+  defaultSeverity: "medium",
+  entries: [
+    { match: ["fundamentally", "reshape"] },
+    { match: ["will", "define", "the", "next", "era"] },
+    { match: ["entirely", "new"] },
+  ],
+};

--- a/scripts/destink/vendor/lint/lexicons/superficial-ing-verbs.ts
+++ b/scripts/destink/vendor/lint/lexicons/superficial-ing-verbs.ts
@@ -1,0 +1,23 @@
+// Superficial Analyses — a dangling present-participle ("-ing") phrase tacked onto a sentence to
+// inject shallow significance ("contributing to the region's rich cultural heritage"). Feeds issue
+// #18's rule family: the trope is specifically the trailing VBG form, not the verb in general, so
+// posGate: "verb" (which already covers VBG under the VB prefix) narrows the part of speech and
+// wave-2's rule should further check the tag is exactly VBG and the participle phrase trails a
+// clause. Low severity alone — these are ordinary verbs; the syntactic position is the real signal.
+import type { Lexicon } from "./types.js";
+
+export const superficialIngVerbs: Lexicon = {
+  id: "lex-superficial-ing-verbs",
+  name: "Superficial -ing verbs",
+  defaultSeverity: "low",
+  densityThreshold: 2,
+  entries: [
+    { match: "highlight", posGate: "verb", lemma: true, note: "e.g. \"highlighting its importance\"" },
+    { match: "underscore", posGate: "verb", lemma: true, note: "e.g. \"underscoring its role\"" },
+    { match: "reflect", posGate: "verb", lemma: true, note: "e.g. \"reflecting broader trends\"" },
+    { match: "contribute", posGate: "verb", lemma: true, note: "e.g. \"contributing to the development of...\"" },
+    { match: "cement", posGate: "verb", lemma: true },
+    { match: "shape", posGate: "verb", lemma: true, note: "\"shape\" is also a common noun; posGate restricts to verb use" },
+    { match: "solidify", posGate: "verb", lemma: true },
+  ],
+};

--- a/scripts/destink/vendor/lint/lexicons/types.ts
+++ b/scripts/destink/vendor/lint/lexicons/types.ts
@@ -1,0 +1,92 @@
+// Shared data shape for the lexical tier of the de-stink linter (issue #20, wave 1). Data only —
+// no matching logic, no rule wiring. Wave-2's TropeRules (issue #18 and friends) import LEXICONS
+// from ./index.js, walk DocAnalysis/UnitAnalysis themselves, and decide how each entry becomes a
+// Finding. Nothing here touches src/lint/types.ts or the rule engine.
+
+import type { Severity } from "../types.js";
+
+// POS gate, mapped onto the Penn Treebank tagset used by src/ptb.ts (the tags that appear at the
+// leaves of a Tree, and on WordSpan.pos once a wave-2 rule threads POS through to word spans). A
+// gate matches when the observed tag's first two letters equal the gate's PTB prefix below:
+//
+//   gate         PTB prefix   covers
+//   "verb"       VB           VB, VBD, VBG, VBN, VBP, VBZ
+//   "noun"       NN           NN, NNS, NNP, NNPS
+//   "adverb"     RB           RB, RBR, RBS
+//   "adjective"  JJ           JJ, JJR, JJS
+//
+// Ungated entries (no posGate) match regardless of tag. That's the right default for multi-word
+// phrases — POS-gating a single token inside a fixed phrase rarely buys anything — and for words
+// whose trope sense isn't tied to one part of speech.
+export type PosGate = "verb" | "noun" | "adverb" | "adjective";
+
+// The authoritative gate -> PTB-prefix mapping described above. The lexicon hygiene test asserts
+// every PosGate value used anywhere in LEXICONS has an entry here, so this table can't silently
+// drift out of sync with the entries that reference it.
+export const POS_GATE_PREFIX: Record<PosGate, string> = {
+  verb: "VB",
+  noun: "NN",
+  adverb: "RB",
+  adjective: "JJ",
+};
+
+// One trigger inside a lexicon.
+export type LexiconEntry = {
+  // A single word, or a multi-word phrase given as a lowercase token sequence, e.g.
+  // ["here's", "the", "kicker"]. This field fixes *what* the phrase is, not how it's tokenized or
+  // located in source text — see the matching-strategy note below, which is wave-2's job to act on.
+  match: string | string[];
+  // Restricts the match to a word carrying this POS — e.g. "leverage" as a verb, not the finance
+  // noun. Only meaningful for single-word `match`; ignored (and should be omitted) for phrases.
+  posGate?: PosGate;
+  // When true, match inflections of the word (delve/delves/delving/delved), not just the literal
+  // string. For a phrase, this applies to the phrase's head verb (see per-file notes). Wave-2 owns
+  // the actual lemmatizer/stemmer call — this is a boolean data flag, nothing more.
+  lemma?: boolean;
+  // Per-entry severity override. Falls back to the lexicon's defaultSeverity when omitted.
+  severity?: Severity;
+  // Short human-readable gloss. Wave-2 can fold this into Finding.explanation.
+  note?: string;
+};
+
+// A themed group of entries: one AI-writing trope family from /Users/alex/.claude/CLAUDE.md
+// (the tropes.fyi list).
+export type Lexicon = {
+  // Stable slug, referenced by TropeRule.id in wave-2 (e.g. "lex-delve-family"). Must be unique
+  // across LEXICONS — enforced by the hygiene test.
+  id: string;
+  // Human label, e.g. "Delve and friends".
+  name: string;
+  // Severity for entries that don't specify their own `severity`.
+  defaultSeverity: Severity;
+  // A single hit is often fine — CLAUDE.md itself says as much: "any of these patterns used once
+  // might be fine... the problem is when multiple appear together or a single trope is used
+  // repeatedly." That's sharpest for lexicons built from ordinary words ("robust", "quietly",
+  // "represent") that have plenty of innocent, non-trope uses. densityThreshold is a hint for
+  // wave-2's scoring — the minimum occurrence count within one document before this lexicon's
+  // entries (that don't carry their own high-confidence `severity` override) should be scored at
+  // all. Omitted means every occurrence is already a strong enough signal on its own — typical for
+  // lexicons built from distinctive multi-word phrases ("here's the kicker") that rarely occur by
+  // accident.
+  densityThreshold?: number;
+  entries: LexiconEntry[];
+};
+
+// Matching-strategy note for wave-2 (proposed here, not implemented — the rule engine owns this):
+//
+//  - Case: all lexicon data below is lowercase. Match case-insensitively by lowercasing source
+//    tokens before comparing; don't require the lexicon data itself to carry variants.
+//  - Word boundaries: single-word entries should match whole words only, not substrings — "robust"
+//    must not match inside "robustness". Use the tokenizer's word boundaries (WordSpan / Tree
+//    leaves), not a raw regex \b, so offsets line up with Span.
+//  - Multi-word entries (`match: string[]`) are contiguous token sequences. Pick one tokenization
+//    convention for contractions (e.g. "here's" as one token, matching this data) and apply it
+//    consistently on both sides — the lexicon data and whatever tokenizer produces WordSpan[].
+//  - lemma:true entries should match the entry's inflections via whatever lemmatizer/stemmer
+//    wave-2 already has on hand (compromise is already a dependency and does this).
+//  - posGate should be checked against WordSpan.pos / the Tree leaf tag using POS_GATE_PREFIX,
+//    e.g. `tag.startsWith(POS_GATE_PREFIX[entry.posGate])`.
+//  - Figurative-sense notes (e.g. "landscape (figurative)", "quietly (figurative)") flag word
+//    senses no POS tag distinguishes. Wave-2 will need either a heuristic (collocation list,
+//    embedding check) or to accept some false positives/negatives here — that's a design call for
+//    the rule author, not resolved by this data module.

--- a/scripts/destink/vendor/lint/lexicons/vague-attribution.ts
+++ b/scripts/destink/vendor/lint/lexicons/vague-attribution.ts
@@ -1,0 +1,15 @@
+// Vague Attributions — claims pinned on unnamed "experts" or "observers" instead of a named
+// source.
+import type { Lexicon } from "./types.js";
+
+export const vagueAttribution: Lexicon = {
+  id: "lex-vague-attribution",
+  name: "Vague attribution",
+  defaultSeverity: "medium",
+  entries: [
+    { match: ["experts", "argue"] },
+    { match: ["experts", "say"] },
+    { match: ["observers", "have", "cited"] },
+    { match: ["industry", "reports", "suggest"] },
+  ],
+};

--- a/scripts/destink/vendor/lint/markdown.ts
+++ b/scripts/destink/vendor/lint/markdown.ts
@@ -1,0 +1,257 @@
+// Markdown-aware pre-scan (epic #28, #21). Parser-free: no remark/markdown-it dependency, just
+// line-based classification. This is the shared structural context that the formatting tier reads
+// directly and that #15/#16's rules will call into for suppression ("don't fire inside a code
+// fence", "this negative-parallelism hit is in a heading, downweight it"). Keep the API small and
+// stable — two other agents build against it after this lands.
+//
+// markdownContext(text) is pure: same input, same output, no I/O. It never re-slices doc.text for
+// rules — every Span it hands back slices cleanly from the ORIGINAL text passed in.
+//
+// What counts as what (documented because none of this is a real markdown parser):
+//   heading     ATX only: /^ {0,3}#{1,6}(\s|$)/. Setext headings (underlined with ===/---) are not
+//               detected — a === or --- line reads as prose. Rare enough in prose docs to skip.
+//   bullet      A line starting (after up to 3 leading spaces) with one of the ASCII markers
+//               (-, *, +), one of the GLYPH markers (see BULLET_RE), or a decimal number followed
+//               by . or ) — in every case followed by whitespace ("- ", "\u2022 ", "1. ", "2) ").
+//   codeFence   A line starting (after up to 3 leading spaces) with 3+ backticks or 3+ tildes opens
+//               a fence; every line up to and including the matching close (same character, count
+//               >= the opener's) is "codeFence", closer included. An unterminated fence runs to the
+//               end of the document — better to over-suppress than to lint inside broken fences.
+//               Fences do not nest and are not recognized inside another fence.
+//   blockquote  A line starting (after up to 3 leading spaces) with '>'.
+//   prose       Everything else that isn't blank.
+//   (blank)     Whitespace-only lines are not classified at all — they don't appear in `lines`, they
+//               only act as separators when grouping paragraphs and lists.
+//
+// Precedence when a line could match more than one thing: fence state wins first (checked before
+// anything else, and while a fence is open every line is "codeFence" regardless of shape), then
+// heading, then blockquote, then bullet, then prose. So "> # not a heading" is a blockquote line,
+// not a heading — only the leading marker is used to classify.
+
+import type { Span } from "./types.js";
+
+export type MarkdownKind = "heading" | "bullet" | "codeFence" | "blockquote" | "prose";
+
+type BaseLine = { span: Span; lineIndex: number };
+
+export type HeadingLine = BaseLine & { kind: "heading"; level: number };
+export type BulletLine = BaseLine & {
+  kind: "bullet";
+  ordered: boolean;
+  markerSpan: Span; // the marker itself: "-", "*", "+", or "3."/"3)"
+  contentSpan: Span; // the item's text after the marker and its following whitespace
+};
+export type CodeFenceLine = BaseLine & { kind: "codeFence"; fenceChar: "`" | "~"; isDelimiter: boolean };
+export type BlockquoteLine = BaseLine & { kind: "blockquote" };
+export type ProseLine = BaseLine & { kind: "prose" };
+
+export type MarkdownLine = HeadingLine | BulletLine | CodeFenceLine | BlockquoteLine | ProseLine;
+
+// A run of consecutive bullet lines with nothing (not even a blank line) between them. Loose lists
+// (blank line between items) are deliberately NOT merged into one block — that's a simplification
+// documented here, not an oversight: it means two "tight" runs separated by a blank line count as
+// two lists for fraction purposes. Revisit if a real fixture needs otherwise.
+export type ListItem = { span: Span; contentSpan: Span; ordered: boolean };
+export type ListBlock = { span: Span; items: ListItem[] };
+
+// A run of consecutive prose lines with nothing between them (blank lines, or a heading/bullet/
+// blockquote/code line, end the paragraph).
+export type Paragraph = { span: Span; lines: Span[] };
+
+export type MarkdownContext = {
+  text: string;
+  lines: MarkdownLine[]; // non-blank lines only, in document order
+  codeFences: Span[]; // whole fenced blocks, opening fence line through closing fence line
+  lists: ListBlock[];
+  paragraphs: Paragraph[];
+};
+
+// Split into raw line spans. Handles a trailing CRLF by excluding the \r from the span so slices
+// never carry it; a final line with no trailing newline is still included.
+function splitLines(text: string): Span[] {
+  const spans: Span[] = [];
+  let start = 0;
+  for (let i = 0; i < text.length; i++) {
+    if (text[i] !== "\n") continue;
+    const end = i > start && text[i - 1] === "\r" ? i - 1 : i;
+    spans.push({ start, end });
+    start = i + 1;
+  }
+  spans.push({ start, end: text.length });
+  return spans;
+}
+
+const FENCE_RE = /^ {0,3}(`{3,}|~{3,})/;
+const HEADING_RE = /^ {0,3}(#{1,6})(\s|$)/;
+const BLOCKQUOTE_RE = /^ {0,3}>/;
+// Bullet markers. The ASCII set (-, *, +) is CommonMark's. The glyph set is not: CommonMark reads
+// a line opening with \u2022 or \u2192 as an ordinary paragraph. That is the right call for a
+// renderer and the wrong one for a linter that reasons about document SHAPE — a writer pasting a
+// list out of a word processor, or a chat model asked for a list and reaching for a decorative
+// marker, produces a list either way. Classifying those lines as prose silently blinded
+// bold-first-bullet, listicle-in-trench-coat, and the paragraph grouping every discourse rule reads
+// (rules/staccato-register.ts counts one-sentence paragraphs; eight arrow-marked lines used to
+// group into one 8-line "paragraph").
+//
+// The glyph set is deliberately narrow — a marker has to be unambiguous at the START of a line with
+// whitespace after it. Included: \u2022 \u2023 \u25AA \u25B8 \u25E6 \u00B7 (bullet glyphs proper)
+// and \u2192 \u21D2 \u279C \u27A4 (arrows used as markers, the shape a de-punctuated document
+// reaches for). NOT included: emoji and dingbats (formatting/unicode-decoration reports those as
+// decoration, and a leading emoji is as often ornament as it is a marker), and the astral ranges
+// generally, so every marker here is one UTF-16 code unit and markerSpan arithmetic stays honest.
+const BULLET_RE = /^( {0,3})([-*+\u2022\u2023\u25AA\u25B8\u25E6\u00B7\u2192\u21D2\u279C\u27A4])(\s+)(?=\S|$)/;
+const ORDERED_BULLET_RE = /^( {0,3})(\d{1,9}[.)])(\s+)(?=\S|$)/;
+
+export function markdownContext(text: string): MarkdownContext {
+  const rawLines = splitLines(text);
+  const lines: MarkdownLine[] = [];
+  const codeFences: Span[] = [];
+
+  let fence: { char: "`" | "~"; len: number; openIndex: number } | null = null;
+
+  for (let i = 0; i < rawLines.length; i++) {
+    const span = rawLines[i]!;
+    const raw = text.slice(span.start, span.end);
+
+    if (fence) {
+      const closeMatch = raw.match(FENCE_RE);
+      const isClose =
+        !!closeMatch &&
+        closeMatch[1]![0] === fence.char &&
+        closeMatch[1]!.length >= fence.len &&
+        raw.trim() === closeMatch[1];
+      lines.push({ kind: "codeFence", span, lineIndex: i, fenceChar: fence.char, isDelimiter: isClose });
+      if (isClose) {
+        codeFences.push({ start: rawLines[fence.openIndex]!.start, end: span.end });
+        fence = null;
+      }
+      continue;
+    }
+
+    if (raw.trim() === "") continue; // blank — not classified, just a separator
+
+    const openMatch = raw.match(FENCE_RE);
+    if (openMatch) {
+      const marker = openMatch[1]!;
+      fence = { char: marker[0] as "`" | "~", len: marker.length, openIndex: i };
+      lines.push({ kind: "codeFence", span, lineIndex: i, fenceChar: fence.char, isDelimiter: true });
+      continue;
+    }
+
+    const heading = raw.match(HEADING_RE);
+    if (heading) {
+      lines.push({ kind: "heading", span, lineIndex: i, level: heading[1]!.length });
+      continue;
+    }
+
+    if (BLOCKQUOTE_RE.test(raw)) {
+      lines.push({ kind: "blockquote", span, lineIndex: i });
+      continue;
+    }
+
+    const bullet = raw.match(BULLET_RE);
+    const orderedBullet = raw.match(ORDERED_BULLET_RE);
+    const m = bullet ?? orderedBullet;
+    if (m) {
+      const markerStart = span.start + m[1]!.length;
+      const markerEnd = markerStart + m[2]!.length;
+      const contentStart = markerEnd + m[3]!.length;
+      lines.push({
+        kind: "bullet",
+        span,
+        lineIndex: i,
+        ordered: !bullet,
+        markerSpan: { start: markerStart, end: markerEnd },
+        contentSpan: { start: contentStart, end: span.end },
+      });
+      continue;
+    }
+
+    lines.push({ kind: "prose", span, lineIndex: i });
+  }
+
+  // An unterminated fence runs to the end of the document.
+  if (fence) codeFences.push({ start: rawLines[fence.openIndex]!.start, end: rawLines[rawLines.length - 1]!.end });
+
+  return { text, lines, codeFences, lists: groupLists(lines), paragraphs: groupParagraphs(lines) };
+}
+
+function groupLists(lines: readonly MarkdownLine[]): ListBlock[] {
+  const lists: ListBlock[] = [];
+  let current: ListItem[] = [];
+  let lastLineIndex = -2;
+
+  const flush = () => {
+    if (current.length > 0) lists.push({ span: { start: current[0]!.span.start, end: current[current.length - 1]!.span.end }, items: current });
+    current = [];
+  };
+
+  for (const line of lines) {
+    if (line.kind === "bullet" && line.lineIndex === lastLineIndex + 1) {
+      current.push({ span: line.span, contentSpan: line.contentSpan, ordered: line.ordered });
+      lastLineIndex = line.lineIndex;
+      continue;
+    }
+    flush();
+    if (line.kind === "bullet") {
+      current.push({ span: line.span, contentSpan: line.contentSpan, ordered: line.ordered });
+      lastLineIndex = line.lineIndex;
+    } else {
+      lastLineIndex = -2;
+    }
+  }
+  flush();
+  return lists;
+}
+
+function groupParagraphs(lines: readonly MarkdownLine[]): Paragraph[] {
+  const paragraphs: Paragraph[] = [];
+  let current: Span[] = [];
+  let lastLineIndex = -2;
+
+  const flush = () => {
+    if (current.length > 0) paragraphs.push({ span: { start: current[0]!.start, end: current[current.length - 1]!.end }, lines: current });
+    current = [];
+  };
+
+  for (const line of lines) {
+    if (line.kind === "prose" && line.lineIndex === lastLineIndex + 1) {
+      current.push(line.span);
+      lastLineIndex = line.lineIndex;
+      continue;
+    }
+    flush();
+    if (line.kind === "prose") {
+      current.push(line.span);
+      lastLineIndex = line.lineIndex;
+    } else {
+      lastLineIndex = -2;
+    }
+  }
+  flush();
+  return paragraphs;
+}
+
+// The classification of the line containing `offset`, or undefined for a blank line (or an offset
+// past the end of the document). Uses the line whose span contains offset, with the last line's end
+// treated as inclusive so an offset exactly at end-of-text still resolves.
+export function kindAt(ctx: MarkdownContext, offset: number): MarkdownKind | undefined {
+  for (const line of ctx.lines) {
+    if (offset >= line.span.start && offset <= line.span.end) return line.kind;
+  }
+  return undefined;
+}
+
+// True when every line `span` touches is classified as `kind`. False for a span that straddles a
+// blank line, straddles two different kinds, or touches no classified line at all (e.g. entirely
+// inside a blank line) — inKind is meant for "is this safely and entirely inside a fence/heading/
+// etc.", not a fuzzy overlap test.
+export function inKind(ctx: MarkdownContext, span: Span, kind: MarkdownKind): boolean {
+  let touched = false;
+  for (const line of ctx.lines) {
+    if (line.span.start >= span.end || line.span.end <= span.start) continue;
+    touched = true;
+    if (line.kind !== kind) return false;
+  }
+  return touched;
+}

--- a/scripts/destink/vendor/lint/registry.ts
+++ b/scripts/destink/vendor/lint/registry.ts
@@ -1,0 +1,131 @@
+// The rule registry: one array, in the order findings are attributed when two rules tie, plus the
+// per-rule on/off the app's toggles (#25) read and write.
+//
+// Adding a rule is two lines — import it, append it to RULES. Keep the array grouped by tier and
+// alphabetical inside a tier, so a merge between two wave-3 branches conflicts on one line instead
+// of reordering the file.
+
+import type { TropeRule } from "./types.js";
+import { aiLeakageRule } from "./rules/ai-leakage.js";
+import { claudeFictionFramesRule, claudeFictionGesturesRule } from "./rules/claude-fiction.js";
+import { demoIntensifierRule } from "./rules/demo.js";
+import { claudeTechnicalVocabularyRule } from "./rules/claude-lexicon.js";
+import { claudeFigurativeSuffixesRule } from "./rules/claude-figurative.js";
+import {
+  boldFirstBulletRule,
+  emDashDensityRule,
+  listicleInTrenchCoatRule,
+  unicodeDecorationRule,
+} from "./rules/formatting.js";
+import { claudeAssistantVoiceRule } from "./rules/claude-assistant-voice.js";
+import { claudeDiscourseMarkersRule } from "./rules/claude-discourse-markers.js";
+import { claudeStockFramesRule } from "./rules/claude-stock-frames.js";
+import { corporateJargonRule } from "./rules/corporate-jargon.js";
+import { excessVocabularyRule } from "./rules/excess-vocabulary.js";
+import { soundsLikeClaudeRule } from "./rules/sounds-like-claude.js";
+import {
+  lexDelveFamilyRule,
+  lexFalseSuspenseRule,
+  lexFillerTransitionsRule,
+  lexInventedConceptLabelsRule,
+  lexMagicAdverbsRule,
+  lexOrnateNounsRule,
+  lexPedagogicalVoiceRule,
+  lexSignpostsRule,
+  lexStakesInflationRule,
+  lexVagueAttributionRule,
+} from "./rules/lexical.js";
+import { colonRevealRule } from "./rules/colon-reveal.js";
+import { contrastTailRule } from "./rules/contrast-tail.js";
+import { mirroredClausesRule } from "./rules/mirrored-clauses.js";
+import { reframeRule } from "./rules/reframe.js";
+import { tricolonRule } from "./rules/tricolon.js";
+import { tricolonSeriesRule } from "./rules/tricolon-series.js";
+import { anaphoraRule } from "./rules/anaphora.js";
+import { aphoristicEnderRule } from "./rules/aphoristic-ender.js";
+import { deadMetaphorRule } from "./rules/dead-metaphor.js";
+import { elegantVariationRule } from "./rules/elegant-variation.js";
+import { dilutionRule, nearDuplicateRule } from "./rules/repetition.js";
+import { selfPosedQuestionRule } from "./rules/self-posed-question.js";
+import { falseRangeRule } from "./rules/false-range.js";
+import { countdownRule, punchyFragmentsRule } from "./rules/fragments.js";
+import { ingTackOnRule } from "./rules/ing-tackon.js";
+import { setupTurnRule } from "./rules/setup-turn.js";
+import { staccatoRegisterRule } from "./rules/staccato-register.js";
+import { servesAsDodgeRule } from "./rules/serves-as.js";
+
+export const RULES: readonly TropeRule[] = [
+  // --- lexical ---
+  aiLeakageRule, // claude-isms (#34) — assistant/tool boilerplate + leaked artifact strings
+  claudeFictionFramesRule,
+  claudeFictionGesturesRule,
+  demoIntensifierRule, // DEMO — delete once the first real lexical rule lands (see rules/demo.ts)
+  claudeAssistantVoiceRule,
+  claudeDiscourseMarkersRule,
+  claudeStockFramesRule,
+  claudeFigurativeSuffixesRule,
+  claudeTechnicalVocabularyRule,
+  corporateJargonRule,
+  excessVocabularyRule,
+  lexDelveFamilyRule,
+  lexFalseSuspenseRule,
+  lexFillerTransitionsRule,
+  lexInventedConceptLabelsRule,
+  lexMagicAdverbsRule,
+  lexOrnateNounsRule,
+  lexPedagogicalVoiceRule,
+  lexSignpostsRule,
+  lexStakesInflationRule,
+  lexVagueAttributionRule,
+  // --- syntactic ---
+  colonRevealRule, // claude-isms (#34) — the setup-label colon
+  contrastTailRule, // claude-isms (#34) — the trailing ", not X" dismissal
+  falseRangeRule,
+  ingTackOnRule,
+  mirroredClausesRule,
+  reframeRule,
+  selfPosedQuestionRule,
+  servesAsDodgeRule,
+  tricolonRule,
+  tricolonSeriesRule, // #34 — the comma series the IR rule's Compound path never sees
+  // --- formatting ---
+  boldFirstBulletRule,
+  emDashDensityRule,
+  listicleInTrenchCoatRule,
+  unicodeDecorationRule,
+  // --- discourse ---
+  anaphoraRule,
+  aphoristicEnderRule,
+  countdownRule,
+  deadMetaphorRule,
+  dilutionRule,
+  elegantVariationRule,
+  nearDuplicateRule,
+  punchyFragmentsRule,
+  setupTurnRule, // #34 — "3 rules. And none you set.": a frame that never becomes a claim
+  soundsLikeClaudeRule, // claude-isms capstone (#34) — see rules/sounds-like-claude.ts
+  staccatoRegisterRule, // #34 — the de-punctuated document: the scrub relocated the tells
+];
+
+// Two rules sharing an id would make findings indistinguishable and dedupe against each other.
+// Checked at import time so a collision between wave-3 branches fails the first test that runs,
+// naming the id, instead of quietly halving someone's findings.
+export function assertUniqueRuleIds(rules: readonly TropeRule[] = RULES): void {
+  const seen = new Set<string>();
+  for (const r of rules) {
+    if (seen.has(r.id)) throw new Error(`duplicate rule id: ${r.id}`);
+    seen.add(r.id);
+  }
+}
+assertUniqueRuleIds(RULES);
+
+// Saved per-rule preferences, keyed by rule id. Absent means on: a rule added after the user's
+// prefs were stored is enabled by default, and an id for a rule that no longer exists is ignored
+// rather than throwing, so stale settings never break a run.
+export type RuleToggles = Readonly<Record<string, boolean>>;
+
+export const enabledRules = (toggles: RuleToggles = {}, rules: readonly TropeRule[] = RULES): TropeRule[] =>
+  rules.filter((r) => toggles[r.id] !== false);
+
+export const getRule = (id: string, rules: readonly TropeRule[] = RULES): TropeRule | undefined =>
+  rules.find((r) => r.id === id);

--- a/scripts/destink/vendor/lint/report.ts
+++ b/scripts/destink/vendor/lint/report.ts
@@ -1,0 +1,136 @@
+// The stable JSON report: findings + score + per-rule/per-tier counts, in a shape stable enough
+// for external tooling. This is a public contract — the eventual out-of-repo LLM patch loop (the
+// point of epic #28) parses this JSON, not the TropeRule/Finding types directly, so:
+//
+//   - Key order is explicit. Every object below is constructed field-by-field in the order shown
+//     here, never produced by spreading a Finding or by `Object.fromEntries` over an unsorted map.
+//     JSON.stringify walks an object's own keys in insertion order, so construction order IS output
+//     order — this is what makes two runs over the same input byte-identical.
+//   - Nothing here may vary between two runs over the same input: no timestamps, no absolute paths,
+//     no environment-dependent values (hostnames, cwd, process.version). Determinism and privacy
+//     both fall out of that one rule.
+//   - `version` is the schema version. Bump it when a key is removed, renamed, or changes meaning.
+//     Adding a new optional key is not a breaking change and does not require a bump.
+//
+// Schema (version 1):
+//   {
+//     version: 1,
+//     wordCount: number,                  // countWords(source) — see score.ts
+//     score: {
+//       total: number,                    // weighted findings per 1000 words
+//       byTier: { lexical, syntactic, formatting, discourse: number },
+//       byRule: { [ruleId]: number },     // keys sorted ascending
+//     },
+//     counts: {
+//       findings: number,                 // findings.length, unweighted
+//       bySeverity: { candidate, low, medium, high: number },
+//       byTier: { lexical, syntactic, formatting, discourse: number },
+//       byRule: { [ruleId]: number },     // keys sorted ascending
+//     },
+//     findings: [{
+//       ruleId: string,
+//       tier: "lexical" | "syntactic" | "formatting" | "discourse" | null,  // null iff ruleId
+//         // is not in the rule set the report was built from (should not happen in practice —
+//         // engine.ts only calls detect() on rules it was given — but the field stays nullable
+//         // rather than lying with a made-up tier if it ever does)
+//       severity: "candidate" | "low" | "medium" | "high",
+//       span: { start: number, end: number },  // half-open [start, end) into the source text
+//       message: string,
+//       explanation: string,
+//     }],                                 // same order as LintResult.findings (engine.ts):
+//                                          // span.start asc, span.end asc, ruleId asc
+//     errors: [{ ruleId: string, message: string }],  // rule failures (engine.ts's RuleError),
+//                                          // minus the raw `error` value — not guaranteed
+//                                          // JSON-safe or stable across runs, console-only there
+//   }
+
+import type { Finding, Severity, TropeRule, TropeTier } from "./types.js";
+import type { RuleError } from "./engine.js";
+import { countWords, scoreFindings, TIERS, type ScoreBreakdown } from "./score.js";
+
+const SEVERITIES: readonly Severity[] = ["candidate", "low", "medium", "high"];
+
+export type ReportFinding = {
+  ruleId: string;
+  tier: TropeTier | null;
+  severity: Severity;
+  span: { start: number; end: number };
+  message: string;
+  explanation: string;
+};
+
+export type ReportError = { ruleId: string; message: string };
+
+export type Report = {
+  version: 1;
+  wordCount: number;
+  score: ScoreBreakdown;
+  counts: {
+    findings: number;
+    bySeverity: Readonly<Record<Severity, number>>;
+    byTier: Readonly<Record<TropeTier, number>>;
+    byRule: Readonly<Record<string, number>>;
+  };
+  findings: ReportFinding[];
+  errors: ReportError[];
+};
+
+const tierLookup = (rules: readonly TropeRule[]): ((ruleId: string) => TropeTier | undefined) => {
+  const byId = new Map(rules.map((r) => [r.id, r.tier]));
+  return (ruleId) => byId.get(ruleId);
+};
+
+// Sorted-key count map, built the same way score.ts sorts byRule weights — a shared helper would
+// save four lines and cost the reader a jump between files for something this small.
+function countsByRule(items: readonly { ruleId: string }[]): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const item of items) counts[item.ruleId] = (counts[item.ruleId] ?? 0) + 1;
+  const sorted: Record<string, number> = {};
+  for (const id of Object.keys(counts).sort()) sorted[id] = counts[id]!;
+  return sorted;
+}
+
+// Build the stable report from a lint run. `rules` is whatever TropeRule[] actually ran (normally
+// `enabledRules()`'s result) — needed to look up each finding's tier, since Finding itself doesn't
+// carry one (types.ts).
+export function buildReport(
+  text: string,
+  findings: readonly Finding[],
+  errors: readonly RuleError[],
+  rules: readonly TropeRule[],
+): Report {
+  const tierOf = tierLookup(rules);
+  const wordCount = countWords(text);
+  const score = scoreFindings(findings, wordCount, tierOf);
+
+  const bySeverity = {} as Record<Severity, number>;
+  for (const s of SEVERITIES) bySeverity[s] = 0;
+  const byTier = {} as Record<TropeTier, number>;
+  for (const t of TIERS) byTier[t] = 0;
+  for (const f of findings) {
+    bySeverity[f.severity]++;
+    const tier = tierOf(f.ruleId);
+    if (tier) byTier[tier]++;
+  }
+
+  return {
+    version: 1,
+    wordCount,
+    score,
+    counts: {
+      findings: findings.length,
+      bySeverity,
+      byTier,
+      byRule: countsByRule(findings),
+    },
+    findings: findings.map((f) => ({
+      ruleId: f.ruleId,
+      tier: tierOf(f.ruleId) ?? null,
+      severity: f.severity,
+      span: { start: f.span.start, end: f.span.end },
+      message: f.message,
+      explanation: f.explanation,
+    })),
+    errors: errors.map((e) => ({ ruleId: e.ruleId, message: e.message })),
+  };
+}

--- a/scripts/destink/vendor/lint/rules/ai-leakage.ts
+++ b/scripts/destink/vendor/lint/rules/ai-leakage.ts
@@ -1,0 +1,237 @@
+// claude/ai-leakage (issue #34) — assistant/tool boilerplate and leaked artifact strings.
+//
+// This scans doc.text DIRECTLY, not doc.units[].words. Every other tier's word-list matching
+// (lexical.ts's entryHits, claude-lexicon.ts's factory) assumes the thing being matched tokenizes
+// cleanly — whole words or contiguous runs of them. Half of what this rule looks for doesn't:
+// "[cite: ", "(start_span)", the lenticular brackets 【】, a query string's "utm_source=" — these
+// are punctuation-bearing substrings and a URL fragment, not word tokens. Scanning the raw string
+// keeps the matching honest instead of forcing it through a tokenizer it wasn't built for.
+//
+// Tier: filed as "lexical", not "formatting". The formatting tier (formatting.ts) is organized
+// around the document's SHAPE — headings, lists, fences, paragraphs. This rule doesn't care about
+// shape; it's a phrase/string presence check, the same organizing idea as every other file in the
+// lexical tier, just matched over raw text instead of tokens because the tokenizer can't carry
+// these particular strings. The markdown-fence awareness below is a borrowed cross-cutting concern
+// (formatting.ts and this file both call into markdown.ts), not the reason this rule exists.
+//
+// Two families, deliberately different severity philosophies:
+//
+// FAMILY A — leaked tool/citation artifacts (oaicite, contentReference, turn0search, lenticular
+// brackets, a tracked "utm_source=" pasted in from a share link...). These are copy-paste residue
+// from an assistant's UI chrome or a citation renderer, not something a person would type. Per
+// #34's sensitivity decision: SINGLE HIT FIRES, no density gating anywhere in this family, severity
+// "high". Inside a fenced code block the same string is still worth flagging — a leaked citation
+// tag pasted into a code sample is still a leak — so family A is NOT suppressed in code fences, it
+// is only downgraded to "low" there (documented per-artifact below).
+//
+// FAMILY B — assistant-register boilerplate ("as an AI language model", "I hope this helps"...).
+// These are English phrases a human could in principle type, just not ones a person drafting their
+// own prose usually does — they're the shape of a chat reply, not of writing. Matched
+// case-insensitively over raw text. Severity splits in two:
+//   high    unambiguous machine-only phrasing: self-description ("as an AI language model"),
+//           knowledge-cutoff disclosure (a chat assistant's job to say, never a writer's),
+//           refusal/capability boilerplate, and the "certainly, here is/are" reply-opener.
+//   medium  sign-off closers a human could plausibly write in their own words ("I hope this
+//           helps", "let me know if you'd like me to...") — still a tell in finished prose, but a
+//           softer one than the others, so it scores lower.
+// Family B IS suppressed entirely inside code fences (a comment inside a code sample saying "I
+// hope this helps" is not leakage, it's a comment).
+//
+// Quoted-mention decision (documented per #34's ask): a sentence that mentions one of these phrases
+// in quotes to talk ABOUT AI detection ("the phrase 'as an AI language model' is a classic tell")
+// still fires. This rule flags the STRING, not the author's intent — a linter that tried to guess
+// "is this quoted-and-therefore-meta" would need to parse quotation scope reliably, which raw
+// substring matching can't do without a lot of new surface area for a rare case. The recommended
+// call from #34 is the simple one: the linter points at the string, the author decides whether it's
+// actually a problem in context. See fixtures/claude-ai-leakage.ts's "fires even when the phrase is
+// being discussed, not authored" positive.
+
+import type { DocAnalysis, Finding, Severity, Span, TropeRule } from "../types.js";
+import { textAt, contains } from "../span.js";
+import { markdownContext, inKind } from "../markdown.js";
+
+const RULE_ID = "claude/ai-leakage";
+
+// --- generic substring/regex finders -----------------------------------------------------------
+
+type Finder = (text: string) => Span[];
+
+// Every non-overlapping occurrence of `needle`. Case-folds both sides when `caseSensitive` is
+// false; `needle.length` is used for the span end either way, which is only safe for ASCII
+// needles (true of every literal below) since case-folding never changes an ASCII string's length.
+function literal(needle: string, caseSensitive: boolean): Finder {
+  return (text) => {
+    const hay = caseSensitive ? text : text.toLowerCase();
+    const n = caseSensitive ? needle : needle.toLowerCase();
+    const hits: Span[] = [];
+    let from = 0;
+    for (;;) {
+      const at = hay.indexOf(n, from);
+      if (at < 0) break;
+      hits.push({ start: at, end: at + needle.length });
+      from = at + needle.length;
+    }
+    return hits;
+  };
+}
+
+function regex(re: RegExp): Finder {
+  return (text) => {
+    const g = new RegExp(re.source, re.flags.includes("g") ? re.flags : re.flags + "g");
+    const hits: Span[] = [];
+    for (const m of text.matchAll(g)) hits.push({ start: m.index!, end: m.index! + m[0].length });
+    return hits;
+  };
+}
+
+// "utm_source=" is only a tell when it sits inside a URL — a bare mention of the string in prose
+// (documentation about tracking parameters, say) isn't a leaked link. A URL is approximated as an
+// http(s):// run up to the first whitespace or an enclosing bracket/quote character, which is the
+// same rough shape formatting.ts and markdown-adjacent code in this repo use for "a URL-looking
+// token". The reported span is just the "utm_source=" substring, not the whole URL, so the finding
+// points at the exact tell rather than the whole (possibly long) link.
+const URL_RE = /https?:\/\/[^\s)\]}>"']+/g;
+const UTM_KEY = "utm_source=";
+const utmSourceInUrl: Finder = (text) => {
+  const hits: Span[] = [];
+  for (const m of text.matchAll(URL_RE)) {
+    const url = m[0];
+    const idx = url.indexOf(UTM_KEY);
+    if (idx < 0) continue;
+    const start = m.index! + idx;
+    hits.push({ start, end: start + UTM_KEY.length });
+  }
+  return hits;
+};
+
+// --- family A: leaked tool/citation artifacts ---------------------------------------------------
+
+const ARTIFACT_EXPLANATION =
+  `This is a raw citation or file-upload tag from an assistant's UI (or a share-link tracking ` +
+  `parameter) that got pasted straight into the text instead of being rendered or stripped out. ` +
+  `It's not a style choice to fix, it's debris — delete the tag (and, for a tracking link, the ` +
+  `"?utm_source=..." tail) and keep whatever it was attached to.`;
+
+const ARTIFACTS: readonly { label: string; find: Finder }[] = [
+  { label: "oaicite", find: literal("oaicite", true) },
+  { label: "contentReference", find: literal("contentReference", true) },
+  { label: "oai_citation", find: literal("oai_citation", true) },
+  { label: "turn0search", find: literal("turn0search", true) },
+  { label: "attributableIndex", find: literal("attributableIndex", true) },
+  { label: "[cite: ", find: literal("[cite: ", true) },
+  { label: "[span_", find: literal("[span_", true) },
+  { label: "(start_span)", find: literal("(start_span)", true) },
+  { label: "grok_card", find: literal("grok_card", true) },
+  { label: "grok_render_citation_card_json", find: literal("grok_render_citation_card_json", true) },
+  { label: "ppl-ai-file-upload", find: literal("ppl-ai-file-upload", true) },
+  { label: "attached_file", find: literal("attached_file", true) },
+  { label: ":::writing", find: literal(":::writing", true) },
+  { label: "regenerate response", find: literal("regenerate response", false) }, // case-insensitive, per #34
+  { label: "lenticular bracket", find: regex(/[【】]/g) }, // 【 】
+  { label: "utm_source= in a URL", find: utmSourceInUrl },
+];
+
+// --- family B: assistant-register boilerplate ---------------------------------------------------
+
+const KNOWLEDGE_CUTOFF_EXPLANATION =
+  `A chat assistant discloses its training boundary; a person writing their own prose doesn't need ` +
+  `to. This exact family of phrase is common enough to be a named tell — "as of my last knowledge ` +
+  `update" alone showed up in roughly 49% of the flagged-paper sample in the Academ-AI study of ` +
+  `AI-tells in scholarly writing (arXiv 2411.15218). Cut the disclosure; state what you know, or ` +
+  `cite the source's actual date if that's what you mean.`;
+
+const SELF_DESCRIPTION_EXPLANATION =
+  `"As an AI language model..." announces what's speaking instead of answering — a leftover from a ` +
+  `chat reply pasted in whole. Delete the sentence; what follows usually stands on its own.`;
+
+const REFUSAL_EXPLANATION =
+  `This is refusal or capability boilerplate a chat assistant produces when it can't or won't do ` +
+  `something. It has no place in finished writing — its presence means a whole reply (or an error ` +
+  `message) got copied in along with the part that was actually wanted.`;
+
+const CERTAINLY_EXPLANATION =
+  `"Certainly, here is/are..." is a chat assistant's stock reply opener, still stapled to the answer ` +
+  `that followed it. Cut the opener and start with the sentence that was actually meant.`;
+
+const CLOSER_EXPLANATION =
+  `"I hope this helps", "let me know if you'd like me to...", "would you like me to expand" are how ` +
+  `a chat assistant signs off and offers to keep going. A person could type one of these too, which ` +
+  `is why it scores softer than the rest of this rule — but in finished prose it's still an ` +
+  `unanswered invitation nobody asked for. Cut the line.`;
+
+const BOILERPLATE: readonly { text: string; severity: Severity; explanation: string }[] = [
+  // high — unambiguous machine-only phrasing
+  { text: "as an AI language model", severity: "high", explanation: SELF_DESCRIPTION_EXPLANATION },
+  { text: "as a language model, I", severity: "high", explanation: SELF_DESCRIPTION_EXPLANATION },
+  { text: "as of my last knowledge update", severity: "high", explanation: KNOWLEDGE_CUTOFF_EXPLANATION },
+  { text: "my last knowledge update", severity: "high", explanation: KNOWLEDGE_CUTOFF_EXPLANATION },
+  { text: "up to my last training update", severity: "high", explanation: KNOWLEDGE_CUTOFF_EXPLANATION },
+  { text: "my knowledge cutoff", severity: "high", explanation: KNOWLEDGE_CUTOFF_EXPLANATION },
+  { text: "I don't have access to real-time", severity: "high", explanation: REFUSAL_EXPLANATION },
+  { text: "I do not have personal", severity: "high", explanation: REFUSAL_EXPLANATION },
+  { text: "I cannot fulfill this request", severity: "high", explanation: REFUSAL_EXPLANATION },
+  { text: "I'm sorry, but as an AI", severity: "high", explanation: SELF_DESCRIPTION_EXPLANATION },
+  { text: "certainly, here is", severity: "high", explanation: CERTAINLY_EXPLANATION },
+  { text: "certainly, here are", severity: "high", explanation: CERTAINLY_EXPLANATION },
+  // medium — closers a human could conceivably write
+  { text: "I hope this helps", severity: "medium", explanation: CLOSER_EXPLANATION },
+  { text: "let me know if you'd like me to", severity: "medium", explanation: CLOSER_EXPLANATION },
+  { text: "would you like me to expand", severity: "medium", explanation: CLOSER_EXPLANATION },
+];
+
+// --- overlap cleanup -----------------------------------------------------------------------------
+
+// "as of my last knowledge update" contains "my last knowledge update" as a substring, so both
+// entries match the same sentence at overlapping offsets. Keep the outer (longer, more specific)
+// finding and drop anything another finding fully contains — one tell, one finding, not two
+// stacked on the same words.
+function dropContained(findings: readonly Finding[]): Finding[] {
+  return findings.filter(
+    (f, i) =>
+      !findings.some((g, j) => {
+        if (i === j) return false;
+        if (g.span.start === f.span.start && g.span.end === f.span.end) return i > j; // exact dupe: keep first
+        return contains(g.span, f.span);
+      }),
+  );
+}
+
+export const aiLeakageRule: TropeRule = {
+  id: RULE_ID,
+  name: "AI leakage (artifacts + assistant boilerplate)",
+  tier: "lexical",
+  detect(doc: DocAnalysis): Finding[] {
+    const ctx = markdownContext(doc.text);
+    const findings: Finding[] = [];
+
+    for (const artifact of ARTIFACTS) {
+      for (const span of artifact.find(doc.text)) {
+        const inFence = inKind(ctx, span, "codeFence");
+        findings.push({
+          ruleId: RULE_ID,
+          span,
+          severity: inFence ? "low" : "high",
+          message: `leaked artifact — “${textAt(doc, span)}”${inFence ? " (in a code block)" : ""}`,
+          explanation: ARTIFACT_EXPLANATION,
+        });
+      }
+    }
+
+    for (const phrase of BOILERPLATE) {
+      for (const span of literal(phrase.text, false)(doc.text)) {
+        if (inKind(ctx, span, "codeFence")) continue; // family B is suppressed in fences, not downgraded
+        findings.push({
+          ruleId: RULE_ID,
+          span,
+          severity: phrase.severity,
+          message: `assistant boilerplate — “${textAt(doc, span)}”`,
+          explanation: phrase.explanation,
+        });
+      }
+    }
+
+    const deduped = dropContained(findings);
+    deduped.sort((a, b) => a.span.start - b.span.start || a.span.end - b.span.end);
+    return deduped;
+  },
+};

--- a/scripts/destink/vendor/lint/rules/anaphora.ts
+++ b/scripts/destink/vendor/lint/rules/anaphora.ts
@@ -1,0 +1,97 @@
+// Anaphora abuse — repeated sentence-initial openings across NEARBY units ("They assume... They
+// assume... They assume..."). Tier: "discourse", not "syntactic" — no single sentence carries this
+// tell; it only exists as a relationship between units, the same shape as the epic's other
+// cross-sentence rules (density counters, the reframe pattern). A single unit can never trigger
+// this rule on its own, which is the test for "discourse" over "syntactic" tier.
+//
+// "Nearby" = a sliding window of WINDOW (5) consecutive units. Two matching openings extend the
+// same run as long as no more than WINDOW-1 non-matching (or non-participating) units separate
+// them; once a candidate falls outside that window it starts a fresh run instead of joining the
+// old one. Three sentences that open a document, a middle section and a conclusion a page apart
+// share a word but are not anaphora in the stylistic sense this rule polices — the window is what
+// keeps that case clean.
+//
+// Comparison key, per unit:
+//   - lowered units: the subject head's text (subjectHead, ir-query.ts), lowercased. This beats a
+//     raw string compare — "The question isn't bold." and "The question is backwards." share a
+//     subject even though the copula and complement differ, so two of those in a row correctly
+//     read as a deliberate reframe (2 repeats), not anaphora (which needs 3+).
+//   - fragments/unparseable units (no Clause to ask): fall back to the unit's own first word,
+//     lowercased. A bare function word ("a", "the", "not", "this"...) is ambiguous alone — "Not a
+//     bug" and "Not the point" do not open the same way — so those pull in a second word to
+//     disambiguate; a content word ("They", "Products") stands on its own.
+//
+// One finding per maximal run (not one per overlapping window, not one per unit): the run is
+// consumed in full once it fires, so the next scan starts past its last member.
+
+import { subjectHead } from "../ir-query.js";
+import { spanning } from "../span.js";
+import type { DocAnalysis, Finding, TropeRule } from "../types.js";
+
+const WINDOW = 5; // consecutive-unit sliding window — see header comment
+const HIGH_AT = 5; // a run this long or longer is more than a tic; bump severity
+
+// Closed-class openers that mean nothing on their own and need a second word to form a real key.
+const AMBIGUOUS_OPENERS = new Set(["a", "an", "the", "this", "that", "these", "those", "not"]);
+
+type OpeningKey = { display: string; norm: string };
+
+function firstWords(text: string, n: number): string {
+  return text.trim().split(/\s+/).filter(Boolean).slice(0, n).join(" ");
+}
+
+function openingKey(unit: DocAnalysis["units"][number]): OpeningKey | null {
+  if (unit.clauses && unit.clauses.length > 0) {
+    const head = subjectHead(unit.clauses[0]!);
+    if (head) return { display: head.text, norm: head.text.toLowerCase() };
+  }
+  const words = unit.unit.trim().split(/\s+/).filter(Boolean);
+  if (words.length === 0) return null;
+  const bareFirst = (words[0] ?? "").toLowerCase().replace(/[^\p{L}\p{N}']/gu, "");
+  const n = AMBIGUOUS_OPENERS.has(bareFirst) && words.length > 1 ? 2 : 1;
+  const display = firstWords(unit.unit, n);
+  return { display, norm: display.toLowerCase() };
+}
+
+export const anaphoraRule: TropeRule = {
+  id: "anaphora/repeated-opening",
+  name: "Anaphora abuse (repeated sentence openings)",
+  tier: "discourse",
+  detect(doc: DocAnalysis): Finding[] {
+    const keys = doc.units.map(openingKey);
+    const findings: Finding[] = [];
+    let i = 0;
+    while (i < keys.length) {
+      const k = keys[i];
+      if (!k) {
+        i++;
+        continue;
+      }
+      const members = [i];
+      let last = i;
+      for (let j = i + 1; j < keys.length && j - last < WINDOW; j++) {
+        const kj = keys[j];
+        if (kj && kj.norm === k.norm) {
+          members.push(j);
+          last = j;
+        }
+      }
+      if (members.length >= 3) {
+        const first = doc.units[members[0]!]!;
+        const lastUnit = doc.units[members[members.length - 1]!]!;
+        const count = members.length;
+        findings.push({
+          ruleId: "anaphora/repeated-opening",
+          span: spanning([first, lastUnit]),
+          severity: count >= HIGH_AT ? "high" : "medium",
+          message: `${count} sentences in a row open with “${k.display}” — anaphora abuse`,
+          explanation: `Repeating the same opening (“${k.display}”) ${count} times in a stretch reads like a drumbeat, not a style — real writers vary how sentences start. Rewrite at least two of these so they don't lead with the same word.`,
+        });
+        i = last + 1; // consume the whole run — no overlapping windows, no double count
+        continue;
+      }
+      i++;
+    }
+    return findings;
+  },
+};

--- a/scripts/destink/vendor/lint/rules/aphoristic-ender.ts
+++ b/scripts/destink/vendor/lint/rules/aphoristic-ender.ts
@@ -1,0 +1,185 @@
+// THE APHORISTIC ENDER (claude-isms tier, #34) — the compact quotable line a paragraph is parked
+// on. Three or four ordinary sentences of argument, then a short verbless or copular tail shaped
+// like a fortune cookie:
+//
+//   "…We rewrote the scheduler twice before the numbers finally moved. A choice, not an accident."
+//   "…and the rollout landed a quarter late. Big promises, small results."
+//
+// It is not the fragment that gives it away (fragments.ts already counts those) and it is not the
+// negation (reframe.ts owns denied-then-replaced pairs). What this rule keys on is the POSITION:
+// last unit of a paragraph, short, verbless-or-copular, and carrying one of a small set of
+// rhetorical shapes — after the paragraph has already spent two or more full-length sentences
+// saying the thing. That combination is what turns a sentence into a pull-quote, and doing it at
+// the end of paragraph after paragraph is the tell.
+//
+// --- what has to line up ---
+//   position   the LAST unit of a markdown paragraph (markdown.ts's markdownContext paragraphs;
+//              a document with no blank lines is one paragraph, which is the right answer).
+//   runway     at least MIN_LONGER_UNITS earlier units in the same paragraph, each strictly longer
+//              than the ender's own word ceiling. A two-sentence paragraph has no runway to land
+//              from, so it never fires.
+//   length     at most ENDER_MAX_WORDS word tokens.
+//   grammar    verbless (document.ts already decided this: outcome === "fragment") OR copular
+//              (ir-query.ts's isCopular on any of the unit's clauses). A short ender with a real
+//              transitive verb ("The build passed.") is a plain statement and stays clean — that
+//              is the near-miss this rule is measured against.
+//   shape      one of the two below. Without a shape the line is just short.
+//
+// --- the shapes ---
+//   comma-inverted contrast / bare "X, not Y" tail
+//              a comma followed by "not"/"never": "a stance, not its absence", "the work, never
+//              the title". One regex covers both the inverted-contrast form and the bare tail;
+//              they are the same punctuation move, and splitting them would only duplicate the
+//              explanation.
+//   mirrored pair
+//              two comma-separated halves of EQUAL word count, 2-4 words each, in a verbless
+//              ender: "Big promises, small results." The equal-count requirement is what keeps an
+//              ordinary appositive fragment ("Tuesday, the day after the outage") out.
+//
+// --- what it deliberately does not catch ---
+//   * a short ender in dialogue or a pull-quote — a unit dominated by a quoted span is suppressed
+//     (the same half-its-own-length test fragments.ts uses), because quoting an aphorism is not
+//     writing one.
+//   * headings, bullets and code — an ender inside them is a label, not a landing.
+//   * the copular ender with no comma at all ("The result was inevitable."). Real, but nothing
+//     structural separates it from an ordinary short conclusion, and firing there would bury the
+//     shaped hits underneath it.
+//
+// Severity is per document, not per hit: one aphoristic ender can be earned, two is a habit, three
+// or more is the rhythm the reader starts hearing. Per #34 a single instance still reports (low)
+// rather than being swallowed by a density floor.
+
+import { isCopular } from "../ir-query.js";
+import { inKind, markdownContext } from "../markdown.js";
+import type { DocAnalysis, Finding, Severity, Span, TropeRule, UnitAnalysis, WordSpan } from "../types.js";
+
+const RULE_ID = "claude/aphoristic-ender";
+
+const ENDER_MAX_WORDS = 8; // "a stance, not its absence" and friends all sit well inside this
+const LONGER_MIN_WORDS = ENDER_MAX_WORDS + 1; // a "longer" unit is one the ender could not be
+const MIN_LONGER_UNITS = 2; // the runway the ender lands from
+
+// --- word tokens ---------------------------------------------------------------------------
+// Both doc builders can appear in `words` (stub-doc's letters/digits scan, the real pipeline's
+// tokenizer that peels quotes into their own token), so count only tokens carrying a letter or
+// digit — the same idiom rules/fragments.ts uses.
+const isWordToken = (w: WordSpan): boolean => /[\p{L}\p{N}]/u.test(w.text);
+const wordCount = (u: UnitAnalysis): number => u.words.filter(isWordToken).length;
+
+// --- suppression ---------------------------------------------------------------------------
+
+const SUPPRESSED_KINDS = ["heading", "bullet", "codeFence", "blockquote"] as const;
+const QUOTE_CHARS = new Set(['"', "“", "”"]);
+
+// Quote characters paired by simple alternation (1st opens, 2nd closes). Deliberately not a quote
+// parser — enough to recognize "a quoted line", which is all the suppression needs.
+function quotedIntervals(text: string): Span[] {
+  const at: number[] = [];
+  for (let i = 0; i < text.length; i++) if (QUOTE_CHARS.has(text[i]!)) at.push(i);
+  const out: Span[] = [];
+  for (let i = 0; i + 1 < at.length; i += 2) out.push({ start: at[i]!, end: at[i + 1]! + 1 });
+  return out;
+}
+
+const overlapLength = (a: Span, b: Span): number => Math.max(0, Math.min(a.end, b.end) - Math.max(a.start, b.start));
+
+// At least half the unit sits inside a quoted interval: dialogue, or an aphorism someone else wrote.
+function dominatedByQuote(intervals: readonly Span[], span: Span): boolean {
+  const len = span.end - span.start;
+  return len > 0 && intervals.some((q) => overlapLength(q, span) * 2 >= len);
+}
+
+// --- grammar -------------------------------------------------------------------------------
+
+// Verbless is document.ts's own answer, not something re-derived here: outcome === "fragment"
+// means the unit had no predicate to lower (see document.ts's readUnit / treeReason).
+const isVerbless = (u: UnitAnalysis): boolean => u.outcome === "fragment";
+const isCopularUnit = (u: UnitAnalysis): boolean => (u.clauses ?? []).some(isCopular);
+
+// --- the shapes ----------------------------------------------------------------------------
+
+// "a stance, not its absence" / "the work, never the title" — the comma-inverted contrast and the
+// bare "X, not Y" tail, which are the same punctuation move.
+const COMMA_CONTRAST = /,\s+(?:not|never)\b/i;
+
+const HALF_MIN_WORDS = 2;
+const HALF_MAX_WORDS = 4;
+const countWords = (s: string): number => (s.match(/[\p{L}\p{N}]+(?:['’-][\p{L}\p{N}]+)*/gu) ?? []).length;
+
+// "Big promises, small results." — one comma, two halves of equal length, no verb anywhere. The
+// equal-count test is the whole precision story: an appositive fragment ("Tuesday, the day after
+// the outage") has lopsided halves and stays clean.
+function isMirroredPair(text: string): boolean {
+  const halves = text.split(",");
+  if (halves.length !== 2) return false;
+  const [a, b] = [countWords(halves[0]!), countWords(halves[1]!)];
+  return a === b && a >= HALF_MIN_WORDS && a <= HALF_MAX_WORDS;
+}
+
+type Shape = { key: "contrast" | "mirror"; label: string };
+
+function shapeOf(text: string, verbless: boolean): Shape | null {
+  if (COMMA_CONTRAST.test(text)) return { key: "contrast", label: "a comma-inverted contrast" };
+  if (verbless && isMirroredPair(text)) return { key: "mirror", label: "a mirrored pair" };
+  return null;
+}
+
+// --- paragraphs ----------------------------------------------------------------------------
+
+// The units wholly inside a paragraph's span, in document order. Whole-span containment, so a unit
+// that straddles a paragraph boundary (document.ts's splitUnits does not break on newlines) simply
+// belongs to neither — being blunt here is better than attributing an ender to the wrong paragraph.
+const unitsIn = (units: readonly UnitAnalysis[], span: Span): UnitAnalysis[] =>
+  units.filter((u) => u.span.start >= span.start && u.span.end <= span.end);
+
+const severityFor = (count: number): Severity => (count >= 3 ? "high" : count === 2 ? "medium" : "low");
+
+type Hit = { unit: UnitAnalysis; shape: Shape };
+
+export const aphoristicEnderRule: TropeRule = {
+  id: RULE_ID,
+  name: "Aphoristic ender (the quotable closing line)",
+  tier: "discourse",
+  detect(doc: DocAnalysis): Finding[] {
+    const ctx = markdownContext(doc.text);
+    const quotes = quotedIntervals(doc.text);
+    const hits: Hit[] = [];
+
+    for (const paragraph of ctx.paragraphs) {
+      const units = unitsIn(doc.units, paragraph.span);
+      if (units.length < MIN_LONGER_UNITS + 1) continue;
+
+      const ender = units[units.length - 1]!;
+      if (wordCount(ender) < 1 || wordCount(ender) > ENDER_MAX_WORDS) continue;
+
+      const runway = units.slice(0, -1).filter((u) => wordCount(u) >= LONGER_MIN_WORDS).length;
+      if (runway < MIN_LONGER_UNITS) continue;
+
+      const verbless = isVerbless(ender);
+      if (!verbless && !isCopularUnit(ender)) continue;
+      if (dominatedByQuote(quotes, ender.span)) continue;
+      if (SUPPRESSED_KINDS.some((k) => inKind(ctx, ender.span, k))) continue;
+
+      const shape = shapeOf(ender.unit, verbless);
+      if (shape) hits.push({ unit: ender, shape });
+    }
+
+    const severity = severityFor(hits.length);
+    const density = hits.length >= 2 ? ` ${hits.length} of this piece's paragraphs land this way; that cadence is the tell.` : "";
+
+    return hits.map(({ unit, shape }) => ({
+      ruleId: RULE_ID,
+      span: unit.span,
+      severity,
+      message: `Aphoristic ender: “${unit.unit}” closes the paragraph on ${shape.label}`,
+      explanation:
+        `You spend the paragraph making the argument, then park it on a short quotable line — ` +
+        `“${unit.unit}” — that adds no new information, only cadence. ` +
+        (shape.key === "contrast"
+          ? `The comma-and-"not" turn makes the last four words sound like a verdict the reader has to accept rather than a claim you argued for. `
+          : `The two matched halves sound composed, which is exactly why they read as written-to-be-quoted rather than written-to-be-read. `) +
+        `Either fold it back into the sentence before it, or end on the concrete thing you actually established — "The scheduler rewrite cost us two quarters."` +
+        density,
+    }));
+  },
+};

--- a/scripts/destink/vendor/lint/rules/claude-assistant-voice.ts
+++ b/scripts/destink/vendor/lint/rules/claude-assistant-voice.ts
@@ -1,0 +1,14 @@
+// Claude assistant voice (issue #34) — wires the claude-assistant-voice Lexicon (lexicons/
+// claude-assistant-voice.ts) through the claude-lexicon factory (single-hit fires visibly, density
+// only escalates — see claude-lexicon.ts). All rule logic lives in the factory; this file only
+// supplies the lexicon and the taught explanation.
+import { buildClaudeLexiconRule } from "./claude-lexicon.js";
+import { claudeAssistantVoice } from "../lexicons/claude-assistant-voice.js";
+
+const EXPLANATION =
+  `"You're absolutely right", "great question", "happy to elaborate", "feel free to" are Claude's ` +
+  `chat register — reflexive validation and customer-service phrases meant for a live back-and-forth ` +
+  `with a user, not a written document. Even one reads as a bot's voice bleeding through; cut the ` +
+  `phrase and state the point directly instead of validating or offering to help.`;
+
+export const claudeAssistantVoiceRule = buildClaudeLexiconRule(claudeAssistantVoice, EXPLANATION);

--- a/scripts/destink/vendor/lint/rules/claude-discourse-markers.ts
+++ b/scripts/destink/vendor/lint/rules/claude-discourse-markers.ts
@@ -1,0 +1,15 @@
+// Claude discourse markers (issue #34) — wires the claude-discourse-markers Lexicon (lexicons/
+// claude-discourse-markers.ts) through the claude-lexicon factory (single-hit fires visibly, density
+// only escalates — see claude-lexicon.ts). All rule logic lives in the factory; this file only
+// supplies the lexicon and the taught explanation.
+import { buildClaudeLexiconRule } from "./claude-lexicon.js";
+import { claudeDiscourseMarkers } from "../lexicons/claude-discourse-markers.js";
+
+const EXPLANATION =
+  `"The key insight is", "put differently", "zooming out", "to be clear" are Claude's default ` +
+  `connective tissue — they announce a rhetorical move (restating, widening the lens, hedging) ` +
+  `instead of just making it. One is easy to miss on its own; a page full of them reads like it was ` +
+  `narrated by the same assistant every time. Cut the marker and let the sentence do the work it was ` +
+  `announcing.`;
+
+export const claudeDiscourseMarkersRule = buildClaudeLexiconRule(claudeDiscourseMarkers, EXPLANATION);

--- a/scripts/destink/vendor/lint/rules/claude-fiction.ts
+++ b/scripts/destink/vendor/lint/rules/claude-fiction.ts
@@ -1,0 +1,32 @@
+// The two claude-isms fiction-tier rules (issue #34), wired via claude-lexicon.ts's
+// buildClaudeLexiconRule factory (single-hit-fires, escalation-only severity — see that file's
+// header for the full model). Kept out of the shared LEXICONS barrel (lexicons/index.ts) and out
+// of rules/lexical.ts's generic per-lexicon builder on purpose: that path downgrades sparse hits
+// toward "candidate", which is the opposite of what #34 wants for a rule built on distinctive
+// fiction-register phrases and a deliberately-common gesture-verb cluster.
+//
+// Explanations (free.ts hint voice: concrete, second person, no lecture) name the pattern and
+// point at the fix without accusing the writer of anything — a finding is a claim about the
+// PHRASE, never the author (see claude-lexicon.ts's file header, "non-goals").
+
+import type { TropeRule } from "../types.js";
+import { buildClaudeLexiconRule } from "./claude-lexicon.js";
+import { claudeFictionFrames } from "../lexicons/claude-fiction-frames.js";
+import { claudeFictionGestures } from "../lexicons/claude-fiction-gestures.js";
+
+export const claudeFictionFramesRule: TropeRule = buildClaudeLexiconRule(
+  claudeFictionFrames,
+  `"Barely above a whisper," "something else entirely," "little did she know" — these are stock ` +
+    `scene-beat frames that show up over and over in Claude's fiction output. One is already the ` +
+    `tell; a reader who's seen a few AI stories will clock it immediately. Write the actual ` +
+    `sensory detail or the specific beat instead of reaching for the ready-made frame.`,
+);
+
+export const claudeFictionGesturesRule: TropeRule = buildClaudeLexiconRule(
+  claudeFictionGestures,
+  `Flickered, leaned, blinked, murmured, tilted, trembling, faintly — ordinary words on their own. ` +
+    `What gives Claude's fiction voice away is several of them landing on the same page: a ` +
+    `dialogue tag here, a micro-gesture there, until every beat gets the same handful of moves. ` +
+    `One is normal; if this fires more than once or twice in a scene, swap the repeats for an ` +
+    `action specific to that character and that moment.`,
+);

--- a/scripts/destink/vendor/lint/rules/claude-figurative.ts
+++ b/scripts/destink/vendor/lint/rules/claude-figurative.ts
@@ -1,0 +1,145 @@
+// claude/figurative-suffixes (issue #34) — pattern-shaped Claude-isms the plain word-list lexicon
+// factory (claude-lexicon.ts) can't express: a productive suffix turning an abstract noun into a
+// figurative descriptor, a narrative frame borrowed for a technical process, and the literal-sense
+// gate for "load-bearing" (deliberately excluded from lexicons/claude-technical-vocabulary.ts — see
+// that file's header comment). All four checks share this file because none of them is a fixed
+// phrase; each needs either a suffix decomposition or a look at a neighboring word.
+//
+// Tokenization note: stub-doc's wordRe (src/lint/stub-doc.ts) keeps an internal hyphen attached to
+// its neighbors, so "agent-shaped", "load-bearing", "crypto-adjacent" and "JSON-flavored" each
+// arrive as ONE WordSpan, not two tokens split on the hyphen. Every check below relies on that —
+// there is no token-splitting here, just a suffix check on the single word's text.
+//
+// Allowlists are small and hand-picked, same spirit as dead-metaphor.ts's COMMON_WORDS: good enough
+// to keep the obvious literal cases ("a star-shaped cookie", "cherry-flavored candy") clean without
+// pretending to be exhaustive.
+
+import type { DocAnalysis, Finding, Severity, Span, TropeRule, WordSpan } from "../types.js";
+import { spanning, textAt } from "../span.js";
+
+const RULE_ID = "claude/figurative-suffixes";
+
+// Real physical shapes stay clean before "-shaped": "a star-shaped cookie", "an L-shaped desk".
+// Anything else riding "-shaped" onto an abstract noun ("agent-shaped", "API-shaped", "a Y-shaped
+// hole in the org") is the figurative tell.
+const SHAPE_ALLOWLIST = new Set(["star", "heart", "egg", "pear", "l", "u", "v", "wedge"]);
+
+// Food words before "-flavored" stay clean: "cherry-flavored candy". Anything else
+// ("JSON-flavored") borrows "flavor" for something with no actual flavor.
+const FLAVOR_ALLOWLIST = new Set([
+  "cherry", "vanilla", "chocolate", "strawberry", "mint", "lemon", "lime", "orange", "grape",
+  "banana", "coconut", "caramel", "cinnamon", "coffee", "raspberry", "blueberry", "apple",
+  "peach", "mango", "watermelon", "honey", "maple",
+]);
+
+// "the X story" stays clean when X names an actual narrative genre. Anything else ("the deployment
+// story", "the error-handling story") is a technical process wearing a narrative frame.
+const STORY_LEGIT = new Set(["love", "ghost", "origin", "news", "cover", "short", "bedtime", "document"]);
+
+// "load-bearing" stays literal — and clean — immediately before a structural noun.
+const STRUCTURAL_NOUNS = new Set([
+  "wall", "walls", "beam", "beams", "column", "columns",
+  "pillar", "pillars", "structure", "structures", "member", "members",
+]);
+
+// True when `lower` ends in `suffix` and has at least one character of base left before it.
+function stripSuffix(lower: string, suffix: string): string | null {
+  if (lower.length <= suffix.length || !lower.endsWith(suffix)) return null;
+  return lower.slice(0, -suffix.length);
+}
+
+type Kind = "shaped" | "adjacent" | "flavored" | "story" | "loadBearing";
+
+const EXPLANATIONS: Record<Kind, string> = {
+  shaped:
+    `A productive "-shaped" bolted onto an abstract noun ("agent-shaped", "a Y-shaped hole in the ` +
+    `org") describes a gap or a role by analogy to geometry it doesn't have. Name the actual gap ` +
+    `instead — what's missing, or what would fill it.`,
+  adjacent:
+    `"-adjacent" tacked onto a domain word ("crypto-adjacent") gestures at a relationship without ` +
+    `naming it. Say how the two things actually relate.`,
+  flavored:
+    `"-flavored" borrowed for something with no actual flavor ("JSON-flavored", "Rust-flavored") ` +
+    `stands in for a real comparison. Say what it specifically resembles, or drop the metaphor.`,
+  story:
+    `"the X story" borrows a narrative frame for a technical process ("the deployment story", ` +
+    `"the error-handling story"). Describe the process directly — there's usually a checklist, not ` +
+    `a story.`,
+  loadBearing:
+    `"load-bearing" applied to code, a decision, or a person — not an actual wall or beam — is ` +
+    `reached for to make "important" sound structural. Say what specifically breaks if it's removed.`,
+};
+
+const LABELS: Record<Kind, string> = {
+  shaped: `"-shaped"`,
+  adjacent: `"-adjacent"`,
+  flavored: `"-flavored"`,
+  story: `"the X story"`,
+  loadBearing: `"load-bearing" (figurative)`,
+};
+
+function makeFinding(span: Span, severity: Severity, matchedText: string, kind: Kind): Finding {
+  return {
+    ruleId: RULE_ID,
+    span,
+    severity,
+    message: `${LABELS[kind]}: "${matchedText}"`,
+    explanation: EXPLANATIONS[kind],
+  };
+}
+
+export const claudeFigurativeSuffixesRule: TropeRule = {
+  id: RULE_ID,
+  name: "Figurative suffixes and the load-bearing gate",
+  tier: "lexical",
+  detect(doc: DocAnalysis): Finding[] {
+    const findings: Finding[] = [];
+
+    for (const unit of doc.units) {
+      const words: WordSpan[] = unit.words;
+
+      for (let i = 0; i < words.length; i++) {
+        const w = words[i]!;
+        const lower = w.text.toLowerCase();
+
+        const shapeBase = stripSuffix(lower, "-shaped");
+        if (shapeBase !== null) {
+          if (!SHAPE_ALLOWLIST.has(shapeBase)) findings.push(makeFinding(w.span, "medium", w.text, "shaped"));
+          continue;
+        }
+
+        const adjacentBase = stripSuffix(lower, "-adjacent");
+        if (adjacentBase !== null) {
+          findings.push(makeFinding(w.span, "medium", w.text, "adjacent"));
+          continue;
+        }
+
+        const flavorBase = stripSuffix(lower, "-flavored");
+        if (flavorBase !== null) {
+          if (!FLAVOR_ALLOWLIST.has(flavorBase)) findings.push(makeFinding(w.span, "medium", w.text, "flavored"));
+          continue;
+        }
+
+        if (lower === "load-bearing") {
+          const next = words[i + 1];
+          const nextIsStructural = next !== undefined && STRUCTURAL_NOUNS.has(next.text.toLowerCase());
+          if (!nextIsStructural) findings.push(makeFinding(w.span, "high", w.text, "loadBearing"));
+          continue;
+        }
+      }
+
+      for (let i = 0; i + 2 < words.length; i++) {
+        const a = words[i]!;
+        const b = words[i + 1]!;
+        const c = words[i + 2]!;
+        if (a.text.toLowerCase() !== "the" || c.text.toLowerCase() !== "story") continue;
+        if (STORY_LEGIT.has(b.text.toLowerCase())) continue;
+        const span = spanning([a, b, c]);
+        findings.push(makeFinding(span, "medium", textAt(doc, span), "story"));
+      }
+    }
+
+    findings.sort((p, q) => p.span.start - q.span.start || p.span.end - q.span.end);
+    return findings;
+  },
+};

--- a/scripts/destink/vendor/lint/rules/claude-lexicon.ts
+++ b/scripts/destink/vendor/lint/rules/claude-lexicon.ts
@@ -1,0 +1,79 @@
+// Factory for the claude-isms lexicon rules (issue #34). Same matching semantics as the generic
+// lexical tier (entryHits from lexical.ts: case-folded whole tokens, contiguous phrases, narrow
+// lemma suffixes, fail-closed posGate) — but the OPPOSITE severity philosophy, by owner decision
+// on #34:
+//
+//   ONE HIT FIRES, VISIBLY. Claude's dialect has spread widely enough into human prose that a
+//   single marker phrase is already the tell. There is NO below-threshold step-down (the generic
+//   tier demotes sparse hits toward "candidate"; this tier never does). Density only ESCALATES:
+//   when a lexicon declares densityThreshold N and the document reaches N total hits from that
+//   lexicon, every hit riding the lexicon's defaultSeverity steps UP one level, capped at "high".
+//   Entries with an explicit severity are pinned there in both directions, same as the generic
+//   tier.
+//
+// The claim a finding makes is about the PHRASE, never the author: "this reads as Claude-flavored
+// and is worth rewording" — explanations must teach, not accuse (see #34's non-goals).
+
+import type { DocAnalysis, Finding, Severity, Span, TropeRule } from "../types.js";
+import { textAt } from "../span.js";
+import type { Lexicon, LexiconEntry } from "../lexicons/index.js";
+import { entryHits } from "./lexical.js";
+import { claudeTechnicalVocabulary } from "../lexicons/claude-technical-vocabulary.js";
+
+const SEVERITY_STEPS: readonly Severity[] = ["candidate", "low", "medium", "high"];
+
+function stepUp(s: Severity): Severity {
+  const i = SEVERITY_STEPS.indexOf(s);
+  return SEVERITY_STEPS[Math.min(SEVERITY_STEPS.length - 1, i + 1)]!;
+}
+
+export function buildClaudeLexiconRule(lexicon: Lexicon, explanation: string): TropeRule {
+  return {
+    id: lexicon.id,
+    name: lexicon.name,
+    tier: "lexical",
+    detect(doc: DocAnalysis): Finding[] {
+      const rawHits: { entry: LexiconEntry; span: Span }[] = [];
+      for (const unit of doc.units) {
+        for (const entry of lexicon.entries) {
+          for (const span of entryHits(entry, unit.words)) rawHits.push({ entry, span });
+        }
+      }
+      if (rawHits.length === 0) return [];
+
+      const escalate = lexicon.densityThreshold !== undefined && rawHits.length >= lexicon.densityThreshold;
+      const findings: Finding[] = rawHits.map(({ entry, span }) => {
+        const base = entry.severity ?? lexicon.defaultSeverity;
+        const severity = entry.severity === undefined && escalate ? stepUp(base) : base;
+        return {
+          ruleId: lexicon.id,
+          span,
+          severity,
+          message: `${lexicon.name}: “${textAt(doc, span)}”`,
+          explanation,
+        };
+      });
+
+      findings.sort((a, b) => a.span.start - b.span.start || a.span.end - b.span.end);
+      return findings;
+    },
+  };
+}
+
+// --- the concrete rule (issue #34) ------------------------------------------------------------
+// "load-bearing" is deliberately absent from claudeTechnicalVocabulary's data (see that file's
+// header) — its literal-sense gate lives in rules/claude-figurative.ts, which the ungated entries
+// below don't need.
+
+const CLAUDE_TECHNICAL_VOCABULARY_EXPLANATION =
+  `"Battle-tested", "footgun", "escape hatch", "happy path", "blast radius", "table stakes", ` +
+  `"north star", "single source of truth", "cognitive load", "mental model", "guardrails", ` +
+  `"seamless", "idiomatic", "opinionated" — this is Claude's dev-prose idiolect: real engineering ` +
+  `words that show up so often in AI-written docs and PRs that one instance already reads as ` +
+  `machine-flavored, whoever typed it. Swap in the plainer word your own voice would reach for, or ` +
+  `just say what the thing does.`;
+
+export const claudeTechnicalVocabularyRule: TropeRule = buildClaudeLexiconRule(
+  claudeTechnicalVocabulary,
+  CLAUDE_TECHNICAL_VOCABULARY_EXPLANATION,
+);

--- a/scripts/destink/vendor/lint/rules/claude-stock-frames.ts
+++ b/scripts/destink/vendor/lint/rules/claude-stock-frames.ts
@@ -1,0 +1,15 @@
+// Claude stock frames (issue #34) — wires the claude-stock-frames Lexicon (lexicons/
+// claude-stock-frames.ts) through the claude-lexicon factory (single-hit fires visibly, density
+// only escalates — see claude-lexicon.ts). All rule logic lives in the factory; this file only
+// supplies the lexicon and the taught explanation.
+import { buildClaudeLexiconRule } from "./claude-lexicon.js";
+import { claudeStockFrames } from "../lexicons/claude-stock-frames.js";
+
+const EXPLANATION =
+  `"Isn't slowing down", "can't afford to", "makes the case for", "from day one", "let that sink ` +
+  `in" — the LinkedIn/tech-post broetry register: a hook that manufactures urgency, a frame that ` +
+  `announces significance instead of showing it, and a closer built to farm engagement. Even one of ` +
+  `these reads as a template running rather than a person writing. Say the actual claim, skip the ` +
+  `hook and the sign-off.`;
+
+export const claudeStockFramesRule = buildClaudeLexiconRule(claudeStockFrames, EXPLANATION);

--- a/scripts/destink/vendor/lint/rules/colon-reveal.ts
+++ b/scripts/destink/vendor/lint/rules/colon-reveal.ts
@@ -1,0 +1,204 @@
+// COLON REVEAL (#34) — the setup-label colon. "Mazal's take:" / "The result:" / "The fix:" and the
+// appositive "…an engineering-first security model: one where security teams contribute code…".
+//
+// The colon is doing what "The result? Devastating." does with a question mark (see
+// rules/self-posed-question.ts): it promises a payoff, holds a beat, then delivers. Two or three
+// per piece and the whole document reads as a series of announcements.
+//
+// --- reading the colon at all ---
+//
+// document.ts's splitUnits treats ":" as a UNIT BOUNDARY, so nothing here ever sees a colon inside a
+// unit: the label and the reveal arrive as two consecutive units and the ":" itself sits in the GAP
+// between their spans. stub-doc.ts's makeDoc splits the same way but folds the terminator INTO the
+// unit, so there the colon is the label unit's last character. Both are legitimate DocAnalysis
+// producers, so colonAfter() checks the unit's own trailing punctuation run first and the gap
+// second — the same two-convention dance self-posed-question.ts does for "?".
+//
+// --- two arms ---
+//
+//   LABEL       a unit of at most LABEL_MAX_WORDS words, ending in ":", followed by a unit of at
+//               least REVEAL_MIN_WORDS words. "Mazal's take: automate everything you safely can…"
+//               The label is not a sentence; it is a nameplate on one.
+//   APPOSITIVE  any unit ending in ":" whose next unit OPENS with one of REVEAL_OPENERS — "one
+//               where…", "a place where…", "the kind that…". Mid-sentence, the colon here restates
+//               the noun it just introduced, at length, as a reveal. Held to a fixed opener list on
+//               purpose: without one, every explanatory colon in technical prose would fire.
+//
+// --- suppressions ---
+//
+//   markdown    a label sitting on a heading or bullet line is document structure, not rhetoric
+//               ("## Results:", "- Timeout: 30s"). Code fences too.
+//   convention  "Note:", "Warning:", "Example:", "TL;DR:", "Source:", "Update:" and friends are
+//               conventional labels with no reveal in them. Matched against the WHOLE label, so
+//               "The note he left:" is not exempted by "note". ("TL;DR" arrives as two units, "TL"
+//               and "DR", because ";" is also a unit boundary — hence both halves in the list.)
+//   timestamps  "3:30" — the label ends in a digit and the reveal starts with one.
+//   URLs        "https://example.com" and "mailto:someone" — the label's last word is a scheme, or
+//               the colon is immediately followed by "//".
+//
+// Severity: low for a single reveal, medium once the document does it twice or more. The label form
+// is visible on its own hit (#34), which is why one is "low" and not "candidate".
+
+import type { DocAnalysis, Finding, Severity, Span, TropeRule, UnitAnalysis } from "../types.js";
+import { markdownContext, kindAt } from "../markdown.js";
+import type { MarkdownContext } from "../markdown.js";
+import { spanning } from "../span.js";
+
+const RULE_ID = "claude/colon-reveal";
+
+const LABEL_MAX_WORDS = 4; // "Mazal's take" / "The result" / "His argument" / "The fix"
+const REVEAL_MIN_WORDS = 3; // a one-word payoff after a label is a caption, not a reveal beat
+
+const TERMINATORS = ".!?;:";
+
+// Openers that make a colon an appositive reveal rather than an ordinary explanatory colon.
+const REVEAL_OPENERS = [
+  "one where", "one that", "one in which",
+  "a place where", "a world where", "a kind of",
+  "the kind that", "the sort that", "the one that",
+];
+
+// Conventional labels — structure, not rhetoric. Compared against the whole label, letters only.
+const CONVENTIONAL_LABELS = new Set([
+  "note", "notes", "warning", "warnings", "caution", "important", "example", "examples",
+  "tip", "tips", "tl", "dr", "tldr", "source", "sources", "reference", "references",
+  "update", "updates", "edit", "disclaimer", "todo", "fixme", "input", "output", "usage",
+  "see also", "context", "status", "author", "date", "version",
+]);
+
+const URL_SCHEMES = new Set(["http", "https", "ftp", "ftps", "mailto", "file", "data", "tel"]);
+
+// --- terminator-gap helpers (see the file header) ---
+
+const gapAfter = (doc: DocAnalysis, i: number): Span => ({
+  start: doc.units[i]!.span.end,
+  end: i + 1 < doc.units.length ? doc.units[i + 1]!.span.start : doc.text.length,
+});
+
+// The run of terminator punctuation at the very end of a unit's own span, e.g. "The result:" -> ":".
+function trailingTerminators(text: string, span: Span): string {
+  let end = span.end;
+  while (end > span.start && /\s/.test(text[end - 1]!)) end--;
+  let start = end;
+  while (start > span.start && TERMINATORS.includes(text[start - 1]!)) start--;
+  return text.slice(start, end);
+}
+
+// The offset of the ":" that ends unit `i`, or -1. Checks the unit's own trailing run first (makeDoc)
+// and then the gap to the next unit (readDocument).
+function colonAfter(doc: DocAnalysis, i: number): number {
+  const u = doc.units[i]!;
+  const own = trailingTerminators(doc.text, u.span);
+  if (own.includes(":")) return doc.text.lastIndexOf(":", u.span.end - 1);
+  const gap = gapAfter(doc, i);
+  const at = doc.text.indexOf(":", gap.start);
+  return at >= 0 && at < gap.end ? at : -1;
+}
+
+// --- guards ---
+
+const labelKey = (u: UnitAnalysis): string => u.words.map((w) => w.text.toLowerCase()).join(" ");
+
+function isUrlColon(doc: DocAnalysis, label: UnitAnalysis, colon: number): boolean {
+  if (doc.text.startsWith("//", colon + 1)) return true;
+  const last = label.words[label.words.length - 1];
+  return !!last && URL_SCHEMES.has(last.text.toLowerCase());
+}
+
+// "at 3:30" — a digit on each side of the colon, with no space between. Both sides are required:
+// "The count: 42 machines went down" has a digit only after it and is a real label.
+const isTimestamp = (doc: DocAnalysis, colon: number): boolean =>
+  /\d/.test(doc.text[colon - 1] ?? "") && /\d/.test(doc.text[colon + 1] ?? "");
+
+function inMarkdownStructure(ctx: MarkdownContext, span: Span): boolean {
+  const kind = kindAt(ctx, span.start);
+  return kind === "heading" || kind === "bullet" || kind === "codeFence";
+}
+
+const revealOpener = (doc: DocAnalysis, reveal: UnitAnalysis): string | null => {
+  const opening = doc.text.slice(reveal.span.start, reveal.span.end).toLowerCase();
+  return REVEAL_OPENERS.find((o) => opening.startsWith(o)) ?? null;
+};
+
+// --- collect ---
+
+type Arm = "label" | "appositive";
+type Hit = { arm: Arm; span: Span; label: string; reveal: string };
+
+function collect(doc: DocAnalysis, ctx: MarkdownContext): Hit[] {
+  const hits: Hit[] = [];
+  for (let i = 0; i + 1 < doc.units.length; i++) {
+    const label = doc.units[i]!;
+    const reveal = doc.units[i + 1]!;
+    if (label.words.length === 0 || reveal.words.length === 0) continue;
+
+    const colon = colonAfter(doc, i);
+    if (colon < 0) continue;
+    if (isUrlColon(doc, label, colon)) continue;
+    if (isTimestamp(doc, colon)) continue;
+    if (CONVENTIONAL_LABELS.has(labelKey(label))) continue;
+    if (inMarkdownStructure(ctx, label.span) || inMarkdownStructure(ctx, reveal.span)) continue;
+
+    // LABEL arm: the whole short label is the setup, so the finding spans it, word to word — the
+    // colon itself is inside neither unit span under readDocument, and inside the label's under
+    // makeDoc, so spanning the WORDS is the one construction both builders agree on.
+    if (label.words.length <= LABEL_MAX_WORDS && reveal.words.length >= REVEAL_MIN_WORDS) {
+      hits.push({
+        arm: "label",
+        span: spanning(label.words),
+        label: doc.text.slice(label.span.start, label.span.end).replace(/[:\s]+$/, ""),
+        reveal: doc.text.slice(reveal.span.start, reveal.span.end),
+      });
+      continue;
+    }
+
+    // APPOSITIVE arm: the setup is a whole sentence, so the finding narrows to the junction — the
+    // noun being restated, the colon, and the opener that restates it.
+    const opener = revealOpener(doc, reveal);
+    if (!opener) continue;
+    const noun = label.words[label.words.length - 1]!;
+    const openerEnd = reveal.span.start + opener.length;
+    hits.push({
+      arm: "appositive",
+      span: { start: noun.span.start, end: openerEnd },
+      label: noun.text,
+      reveal: doc.text.slice(reveal.span.start, reveal.span.end),
+    });
+  }
+  return hits;
+}
+
+const severityFor = (count: number): Severity => (count >= 2 ? "medium" : "low");
+
+export const colonRevealRule: TropeRule = {
+  id: RULE_ID,
+  name: "Colon reveal (the setup label)",
+  tier: "syntactic",
+  detect(doc: DocAnalysis): Finding[] {
+    const ctx = markdownContext(doc.text);
+    const hits = collect(doc, ctx);
+    if (hits.length === 0) return [];
+
+    const severity = severityFor(hits.length);
+    const density = hits.length >= 2 ? ` You set up ${hits.length} sentences this way in this piece.` : "";
+    return hits.map((h) => {
+      const opening = (n: number): string => h.reveal.split(/\s+/).slice(0, n).join(" ");
+      return {
+        ruleId: RULE_ID,
+        span: h.span,
+        severity,
+        message:
+          h.arm === "label"
+            ? `“${h.label}:” — a nameplate, then the sentence`
+            : `“${h.label}: ${opening(2)}…” — the noun restated as a reveal`,
+        explanation:
+          (h.arm === "label"
+            ? `“${h.label}:” announces that a point is coming instead of making it. The colon buys a beat of suspense ` +
+              `for a sentence that would land harder on its own — start with “${opening(4)}…” and let the claim carry itself.`
+            : `The colon here restates the noun you just introduced — “${h.label}” — and then spends a clause explaining it. ` +
+              `That is a definition wearing a dramatic pause. Fold it into the sentence (“a security model where teams contribute code”) ` +
+              `or make it its own sentence and drop the colon.`) + density,
+      };
+    });
+  },
+};

--- a/scripts/destink/vendor/lint/rules/contrast-tail.ts
+++ b/scripts/destink/vendor/lint/rules/contrast-tail.ts
@@ -1,0 +1,155 @@
+// CONTRAST TAIL (#34) — the terminal ", not X" dismissal. "Bake governance into the design phase,
+// not the end of the pipeline." "Ship the small fix, never the grand rewrite."
+//
+// This is the em-dash dismissal's quieter cousin and the half of negative parallelism that
+// rules/reframe.ts deliberately leaves alone. reframe.ts detects a denial answered by a replacement
+// across two CLAUSES ("It is not bold. It is backwards."), and its file header says in as many
+// words that the bare "not X, but Y" form is left alone because ordinary English uses it. That
+// judgement is right for the mid-sentence form and wrong for the terminal one: a sentence that ends
+// by naming the thing it is not is the tic, because the last thing the reader is handed is a
+// negation of something nobody proposed.
+//
+// --- the shape ---
+//
+// A unit whose LAST comma segment opens with "not" / "never" (optionally "but not" / "but never")
+// and reads as a bare phrase rather than a clause. Three tests stand in for "bare phrase", all
+// crude and all documented as crude, because this rule reads text and never the IR:
+//
+//   no verb-ish token   none of the auxiliaries/copulas in AUXILIARIES, and no word ending in
+//                       "-ed" or "-ing" anywhere in the tail. "not the end of the pipeline" passes;
+//                       "not translated Java" does not (and neither does anything with a real
+//                       predicate in it).
+//   no subordinator     "because", "since", "although", "while", "when", "if"… A tail carrying one
+//                       is a REASON, and "not because X, but because Y" already belongs to
+//                       reframe.ts's because-variant (see reframe.ts, BECAUSE-VARIANT). Two rules
+//                       reporting the same words teaches the reader nothing twice.
+//   length              MIN_TAIL_WORDS..MAX_TAIL_WORDS words. Short denials of a bare noun ("a paper
+//                       cut, not a blocker") are ordinary compression and stay clean; the tell is a
+//                       trailing phrase substantial enough to mirror the phrase it denies. Past the
+//                       upper bound the tail is a clause the verb tests happened to miss.
+//
+// --- severity, and why it stays gentle ---
+//
+// Humans write this on purpose, and it is often the right sentence: "She chose the red one, not the
+// blue one" IS the pattern and still fires, because the point of the linter is to show you the
+// shape, not to tell you it is wrong. So one instance reports at "candidate" (structurally narrowed,
+// unconfirmable without semantics — see types.ts), two at "low", three or more at "medium". The
+// density is the actual signal: a piece that ends three sentences this way has a tic.
+//
+// One more reason to stay gentle: fix/fixers/reframe.ts's `reframeContrast` PROPOSAL rewrites a
+// reframe into exactly this shape ("The problem was your head, not the code"). A fixed document can
+// therefore acquire a contrast-tail candidate that the author never wrote. That proposal is
+// human-reviewed and never run by the auto loop (the registered fixer is the pure-deletion
+// collapse), so the interaction is a note, not a cycle — see the comment in that file.
+
+import type { DocAnalysis, Finding, Severity, Span, TropeRule } from "../types.js";
+
+const RULE_ID = "claude/contrast-tail";
+
+const MIN_TAIL_WORDS = 4; // "not the blue one" — below this it is ordinary compression
+const MAX_TAIL_WORDS = 10; // above this the tail is a clause, whatever the verb tests said
+const MIN_HOST_WORDS = 2; // there has to be a sentence in front of the tail for it to dismiss
+
+const TERMINATORS = ".!?;:";
+
+const OPENER = /^(?:but\s+)?(?:not|never)\b/i;
+
+// Crude verb evidence. Deliberately not a POS tagger: this rule runs on the parser-free path, where
+// no tags exist, and every entry here is a word that can only be a verb.
+const AUXILIARIES = new Set([
+  "is", "are", "was", "were", "am", "be", "been", "being",
+  "has", "have", "had", "does", "do", "did",
+  "will", "would", "can", "could", "shall", "should", "may", "might", "must",
+]);
+
+// A tail carrying one of these is a reason, not an appositive — reframe.ts owns those. Kept to the
+// words that only ever subordinate a clause: "as", "before", "after" and "until" are prepositions
+// at least as often as they are conjunctions ("not until Friday"), and listing them would suppress
+// ordinary tails.
+const SUBORDINATORS = new Set([
+  "because", "since", "although", "though", "while", "when", "whenever", "if", "unless", "whether",
+]);
+
+// Nouns and adjectives that end in "-ed"/"-ing" and would otherwise read as verb evidence. Short
+// words are excluded by length below ("red", "king", "bed"); these are the longer ones that slip
+// through. Not exhaustive, and it does not need to be: a miss here costs one finding, not a wrong
+// one.
+const NOT_VERBS = new Set([
+  "thing", "things", "something", "anything", "everything", "nothing",
+  "morning", "evening", "ceiling", "during", "spring", "string", "sibling",
+  "indeed", "speed", "breed", "sacred", "hundred", "thousand",
+]);
+
+const wordRe = (): RegExp => /[\p{L}\p{N}]+(?:['‘’ʼ-][\p{L}\p{N}]+)*/gu;
+const wordsIn = (s: string): string[] => s.match(wordRe()) ?? [];
+
+const looksVerbal = (word: string): boolean => {
+  const w = word.toLowerCase();
+  if (AUXILIARIES.has(w) || /n['‘’ʼ]t$/.test(w)) return true;
+  return /(?:ed|ing)$/.test(w) && w.length > 4 && !NOT_VERBS.has(w);
+};
+
+// The unit's text with trailing whitespace and terminating punctuation removed, as a span. Both
+// document builders are served by this: document.ts's readDocument excludes the terminator from the
+// unit's span already, stub-doc.ts's makeDoc folds it in, and after this they agree.
+function coreSpan(text: string, span: Span): Span | null {
+  let end = span.end;
+  while (end > span.start && (/\s/.test(text[end - 1]!) || TERMINATORS.includes(text[end - 1]!))) end--;
+  return end > span.start ? { start: span.start, end } : null;
+}
+
+// The trailing ", not …" of one unit, or null. Returns the tail's span in the source.
+function contrastTail(text: string, unitSpan: Span): Span | null {
+  const core = coreSpan(text, unitSpan);
+  if (!core) return null;
+  const slice = text.slice(core.start, core.end);
+
+  const comma = slice.lastIndexOf(",");
+  if (comma < 0) return null;
+
+  let start = core.start + comma + 1;
+  while (start < core.end && /\s/.test(text[start]!)) start++;
+  const tail = text.slice(start, core.end);
+  if (!OPENER.test(tail)) return null;
+
+  const words = wordsIn(tail);
+  if (words.length < MIN_TAIL_WORDS || words.length > MAX_TAIL_WORDS) return null;
+  if (words.some((w) => SUBORDINATORS.has(w.toLowerCase()))) return null;
+  if (words.some(looksVerbal)) return null;
+  if (wordsIn(slice.slice(0, comma)).length < MIN_HOST_WORDS) return null;
+
+  return { start, end: core.end };
+}
+
+// One is a sentence a person might mean; three is a habit the reader starts hearing.
+const severityFor = (count: number): Severity => (count >= 3 ? "medium" : count === 2 ? "low" : "candidate");
+
+export const contrastTailRule: TropeRule = {
+  id: RULE_ID,
+  name: "Contrast tail (the trailing “, not X” dismissal)",
+  tier: "syntactic",
+  detect(doc: DocAnalysis): Finding[] {
+    const tails = doc.units.flatMap((u) => {
+      const span = contrastTail(doc.text, u.span);
+      return span ? [span] : [];
+    });
+    if (tails.length === 0) return [];
+
+    const severity = severityFor(tails.length);
+    const density = tails.length >= 2 ? ` You end ${tails.length} sentences this way in this piece; that is the part a reader hears.` : "";
+    return tails.map((span) => {
+      const tail = doc.text.slice(span.start, span.end);
+      return {
+        ruleId: RULE_ID,
+        span,
+        severity,
+        message: `the sentence ends on what it isn't: “${tail}”`,
+        explanation:
+          `Trailing a sentence with “${tail}” hands the reader a denial as the last thing they hold, and usually denies ` +
+          `something nobody had proposed. Say the positive version and stop — “bake governance into the design phase” ` +
+          `is the whole claim. Keep the contrast only when a reader would genuinely have assumed the other thing.` +
+          density,
+      };
+    });
+  },
+};

--- a/scripts/destink/vendor/lint/rules/corporate-jargon.ts
+++ b/scripts/destink/vendor/lint/rules/corporate-jargon.ts
@@ -1,0 +1,13 @@
+// corporate-jargon (issue #34) — wires the corporate-jargon Lexicon (lexicons/corporate-jargon.ts)
+// through the standard-tier factory (rules/standard-lexicon.ts). Every entry there is a distinctive
+// multi-word phrase with no densityThreshold, so this rides the factory's default: a single hit
+// fires at the lexicon's severity outright (no step-down applies when densityThreshold is unset).
+import { buildStandardLexiconRule } from "./standard-lexicon.js";
+import { corporateJargon } from "../lexicons/corporate-jargon.js";
+
+const EXPLANATION =
+  `"Move the needle", "low-hanging fruit", "circle back", "take this offline" are boardroom ` +
+  `stand-ins for a plain statement — say what actually changed, what's easy, when you'll follow up, ` +
+  `or that you'll answer later, instead of reaching for the meeting-room version of the sentence.`;
+
+export const corporateJargonRule = buildStandardLexiconRule(corporateJargon, EXPLANATION);

--- a/scripts/destink/vendor/lint/rules/dead-metaphor.ts
+++ b/scripts/destink/vendor/lint/rules/dead-metaphor.ts
@@ -1,0 +1,183 @@
+// Dead-metaphor candidates (discourse tier, issue #22) — a rare CONTENT lemma recurring far above
+// its expected rate: "walls and doors" repeated thirty times until the figure of speech has worn
+// through to a tic, or any image/metaphor reused as a crutch rather than developed once and left
+// alone.
+//
+// No corpus is available at runtime, so there's no real background frequency to compare a word
+// against. Two document-internal proxies stand in for it:
+//
+//   1. "content word" = not a function word. STOPWORDS below is a small, closed, hand-picked list
+//      of English function words — pronouns, articles, prepositions, conjunctions, auxiliaries,
+//      negation, degree words (~130 entries).
+//   2. "rare" = absent from COMMON_WORDS, a hand-assembled list of ~300 everyday English content
+//      words ("time", "people", "world", "make", "know", "day"...) modeled loosely on the shape
+//      of a top-1000-word frequency list but built by hand for this file, not exported from a
+//      real corpus — there is no such table available in the browser build. A word that ISN'T on
+//      this list is "rare" only in this coarse, document-internal sense: it might be a genuine
+//      technical term (fine, expected to repeat) or a word the list simply omits. The rule can't
+//      tell those apart on its own — see the tuning note below for how thresholds compensate.
+//
+// Deliberately absent from COMMON_WORDS: "wall", "door", and comparably-common but non-essential
+// nouns. They're frequent enough in general English that a genuinely exhaustive top-1000 list
+// would include them and this rule could never flag the issue's own example. Keeping the list
+// modest, by hand, is a design choice, not an oversight.
+//
+// Tuning against the must-not-fire case (a technical doc repeating "the parser" once per distinct
+// sentence): the absolute floor BASE_MIN_COUNT and the doc-relative RATE_THRESHOLD below are both
+// picked so a handful of ordinary term mentions across a short document never qualifies — see
+// dead-metaphor.test.ts for the worked numbers.
+
+import type { DocAnalysis, Finding, Severity, Span, TropeRule } from "../types.js";
+
+// --- data: function words (excluded from "content word" entirely) ---------------------------
+
+const STOPWORDS = new Set([
+  "a", "an", "the",
+  "i", "me", "my", "mine", "myself", "you", "your", "yours", "yourself", "yourselves",
+  "he", "him", "his", "himself", "she", "her", "hers", "herself", "it", "its", "itself",
+  "we", "us", "our", "ours", "ourselves", "they", "them", "their", "theirs", "themselves",
+  "this", "that", "these", "those",
+  "who", "whom", "whose", "which", "what", "whatever", "whichever", "whoever",
+  "and", "or", "but", "nor", "so", "yet", "if", "because", "although", "though", "while", "as",
+  "than", "whether", "unless", "until", "since",
+  "in", "on", "at", "by", "for", "with", "about", "against", "between", "into", "through",
+  "during", "before", "after", "above", "below", "to", "from", "up", "down", "over", "under",
+  "again", "further", "once", "of", "off", "out",
+  "be", "am", "is", "are", "was", "were", "been", "being",
+  "have", "has", "had", "having",
+  "do", "does", "did", "doing",
+  "will", "would", "shall", "should", "may", "might", "must", "can", "could",
+  "not", "no", "nor",
+  "there", "here",
+  "very", "too", "also", "just", "only", "even", "still", "then",
+  "all", "any", "some", "each", "every", "other", "another", "such", "own", "same",
+  "etc",
+]);
+
+// --- data: common English content words (excluded because they're too ordinary to be "rare") -
+// Hand-assembled for this rule, not sourced from a frequency corpus (none is available at
+// runtime). Roughly 300 entries, biased toward the everyday nouns/verbs/adjectives that dominate
+// ordinary prose, so their repetition is expected rather than a metaphor tic.
+const COMMON_WORDS = new Set([
+  "time", "people", "way", "day", "man", "woman", "thing", "life", "child", "world", "school",
+  "state", "family", "student", "group", "country", "problem", "hand", "part", "place", "case",
+  "week", "company", "system", "program", "question", "work", "government", "number", "night",
+  "point", "home", "water", "room", "mother", "area", "money", "story", "fact", "month", "lot",
+  "study", "book", "eye", "job", "word", "business", "issue", "side", "kind", "head", "house",
+  "service", "friend", "father", "power", "hour", "game", "line", "end", "member", "law", "car",
+  "city", "community", "name", "president", "team", "minute", "idea", "body", "information",
+  "back", "parent", "face", "level", "office", "health", "person", "art", "history", "party",
+  "result", "change", "morning", "reason", "research", "girl", "guy", "moment", "air", "teacher",
+  "force", "education", "foot", "boy", "age", "policy", "process", "music", "market", "sense",
+  "nation", "plan", "college", "interest", "death", "experience", "effect", "use", "class",
+  "control", "care", "field", "development", "role", "effort", "rate", "heart", "show", "leader",
+  "light", "voice", "wife", "whole", "mind", "price", "report", "decision", "son", "hope", "view",
+  "relationship", "town", "road", "arm", "election", "hair", "situation", "step", "culture",
+  "model", "writer", "offer", "chance", "order", "forward", "half", "sea", "plane", "mission",
+  "product", "standard", "project", "sound", "base", "star", "ready", "focus", "action",
+  "movement", "note", "court", "industry", "agency", "style", "evening", "matter", "choice",
+  "cause", "opinion", "top", "region", "table", "wind", "event", "army", "mouth", "tax",
+  "structure", "feeling", "unit", "food", "cell", "difference", "agreement", "front", "board",
+  "activity", "energy", "budget", "condition", "media", "network", "security", "individual",
+  "animal", "series", "million", "official", "staff", "discussion", "average", "environment",
+  "majority", "income", "phone", "blood", "sort", "wood", "image", "weight", "task", "category",
+  "quality", "statement", "technology", "worker", "benefit", "position", "sample", "exercise",
+  "factor", "letter", "master", "machine", "entire", "source", "memory", "size", "past",
+  "evidence", "tree", "entry", "patient", "generation", "thought", "capital", "video", "character",
+  "page", "resource", "wave", "band", "term", "oil", "revenue", "gene", "sky", "fish", "respect",
+  "purpose", "section", "growth", "guest", "tone", "horse", "dog", "cat", "bird", "flower",
+  "river", "mountain", "forest", "ocean", "beach", "storm", "cloud", "rain", "snow", "sun", "moon",
+  "make", "know", "think", "take", "come", "give", "look", "find", "tell", "ask", "seem", "feel",
+  "leave", "call", "need", "want", "become", "put", "mean", "keep", "let", "begin", "help", "talk",
+  "turn", "start", "show", "hear", "play", "run", "move", "live", "believe", "bring", "happen",
+  "write", "sit", "stand", "lose", "pay", "meet", "include", "continue", "set", "learn", "change",
+  "lead", "understand", "watch", "follow", "stop", "create", "speak", "read", "allow", "add",
+  "spend", "grow", "open", "walk", "win", "offer", "remember", "consider", "appear", "buy", "wait",
+  "serve", "die", "send", "expect", "build", "stay", "fall", "cut", "reach", "kill", "remain",
+  "good", "new", "first", "last", "long", "great", "little", "own", "other", "old", "right",
+  "big", "high", "different", "small", "large", "next", "early", "young", "important", "few",
+  "public", "bad", "same", "able", "human", "local", "sure", "possible", "hard", "clear", "true",
+]);
+
+const MIN_WORD_LEN = 4; // below this, even a "rare" token is too short to read as a content word
+
+// --- data: a light, document-internal lemmatizer (heuristic, not linguistic) -----------------
+// Collapses common English inflections so "wall"/"walls" and "door"/"doors" count together. It's
+// suffix-stripping, not a dictionary lemmatizer — good enough to group inflections of the SAME
+// word within one document, not meant to be linguistically exact (see the false negative on
+// "trees" vs "tree" that the tests document and accept).
+function lemmatize(lower: string): string {
+  if (lower.length <= 3) return lower;
+  if (/[^aeiou]ies$/.test(lower)) return `${lower.slice(0, -3)}y`; // parties -> party
+  if (/(sses|shes|ches|xes|zes)$/.test(lower)) return lower.slice(0, -2); // boxes -> box
+  if (/[^aeiou]s$/.test(lower)) return lower.slice(0, -1); // walls -> wall, doors -> door
+  if (/[^aeiou]ing$/.test(lower) && lower.length > 5) return lower.slice(0, -3); // walking -> walk
+  if (/[^aeiou]ed$/.test(lower) && lower.length > 4) return lower.slice(0, -2); // walked -> walk
+  return lower;
+}
+
+// --- thresholds --------------------------------------------------------------------------------
+// Below this many qualifying content words, per-lemma rate is too noisy to trust at all (a
+// five-sentence document "repeating" a word 3 times is unremarkable).
+const MIN_DOC_CONTENT_WORDS = 40;
+// Absolute floor: fewer than this many repeats of one lemma is unremarkable regardless of
+// document size — this is what keeps a short technical doc's handful of "parser" mentions clean.
+const BASE_MIN_COUNT = 10;
+// Doc-relative floor: a lemma eating more than 4% of ALL content-word tokens is disproportionate
+// even in a long document, where the absolute floor alone would be too lax.
+const RATE_THRESHOLD = 0.04;
+const TOP_K = 8; // report at most this many candidate lemmas, worst rate first
+
+type LemmaGroup = { lemma: string; count: number; surfaceForms: Set<string>; firstSpan: Span };
+
+export const deadMetaphorRule: TropeRule = {
+  id: "dead-metaphor/rare-lemma",
+  name: "Dead-metaphor candidate",
+  tier: "discourse",
+  detect(doc: DocAnalysis): Finding[] {
+    const groups = new Map<string, LemmaGroup>();
+    let contentWordCount = 0;
+
+    for (const unit of doc.units) {
+      for (const w of unit.words) {
+        const lc = w.text.toLowerCase();
+        if (lc.length < MIN_WORD_LEN || STOPWORDS.has(lc)) continue;
+        // Check the common-words list against both the surface form and its lemma: "shows"
+        // isn't itself in COMMON_WORDS, but its lemma "show" is, and an inflected common verb is
+        // exactly as ordinary as its base form.
+        const lemma = lemmatize(lc);
+        if (COMMON_WORDS.has(lc) || COMMON_WORDS.has(lemma)) continue;
+        contentWordCount++;
+        const existing = groups.get(lemma);
+        if (existing) {
+          existing.count++;
+          existing.surfaceForms.add(lc);
+        } else {
+          groups.set(lemma, { lemma, count: 1, surfaceForms: new Set([lc]), firstSpan: w.span });
+        }
+      }
+    }
+
+    if (contentWordCount < MIN_DOC_CONTENT_WORDS) return [];
+
+    const minCount = Math.max(BASE_MIN_COUNT, Math.ceil(contentWordCount * RATE_THRESHOLD));
+
+    const candidates = [...groups.values()]
+      .filter((g) => g.count >= minCount)
+      .sort((a, b) => b.count - a.count || (a.lemma < b.lemma ? -1 : 1))
+      .slice(0, TOP_K);
+
+    return candidates.map((g): Finding => {
+      const severity: Severity = g.count >= minCount * 3 ? "high" : g.count >= minCount * 1.5 ? "medium" : "low";
+      const forms = [...g.surfaceForms].sort().join("/");
+      const rate = Math.round((g.count / contentWordCount) * 100);
+      return {
+        ruleId: "dead-metaphor/rare-lemma",
+        span: g.firstSpan,
+        severity,
+        message: `“${forms}” recurs ${g.count} times (${rate}% of the document's content words)`,
+        explanation: `“${forms}” isn't a common English word, so ${g.count} occurrences — against a floor of ${minCount} for a document this size — is disproportionate for one piece of writing. That's the shape of a metaphor or image reused as a crutch rather than developed once and left alone: if it's figurative, cut most of the repeats; if it's a genuine technical term, still vary it with a pronoun or a synonym here and there.`,
+      };
+    });
+  },
+};

--- a/scripts/destink/vendor/lint/rules/demo.ts
+++ b/scripts/destink/vendor/lint/rules/demo.ts
@@ -1,0 +1,40 @@
+// DEMO RULE — the reference implementation. It is here to prove the loop end-to-end (text in,
+// located findings out, deterministic) and to be the thing a new rule gets copied from. Filler
+// intensifiers are not one of the tropes in the epic; wave 2 should delete this entry from
+// registry.ts once real rules land, and keep the tests that pin the runner's semantics.
+//
+// It demonstrates the three things every rule does:
+//   1. locate — findings carry spans into doc.text, taken from the words the analysis already
+//      mapped, so nothing re-tokenizes and every span slices back to the exact surface form.
+//   2. count first, judge second — the whole document is in hand, so severity comes from DENSITY.
+//      One "very" is a word; five is a tic. This is the thing a sentence-at-a-time judge can't do.
+//   3. teach — `message` names the pattern in a few words, `explanation` says why it reads as a
+//      tell and what to do instead, in the voice of free.ts's hints: concrete, second person,
+//      one example, no lecture.
+
+import type { DocAnalysis, Finding, TropeRule } from "../types.js";
+
+const INTENSIFIERS = new Set(["very", "really", "quite", "extremely", "incredibly", "truly"]);
+
+// Below this the word is just a word; at or above it the repetition is the tell.
+const PATTERN_AT = 3;
+
+export const demoIntensifierRule: TropeRule = {
+  id: "demo/intensifier",
+  name: "Filler intensifier (demo)",
+  tier: "lexical",
+  detect(doc: DocAnalysis): Finding[] {
+    const hits = doc.units.flatMap((u) => u.words.filter((w) => INTENSIFIERS.has(w.text.toLowerCase())));
+    if (hits.length === 0) return [];
+    const dense = hits.length >= PATTERN_AT;
+    return hits.map((w) => ({
+      ruleId: "demo/intensifier",
+      span: w.span,
+      severity: dense ? ("medium" as const) : ("low" as const),
+      message: dense ? `“${w.text}” — ${hits.length} filler intensifiers in this piece` : `“${w.text}” adds emphasis, not meaning`,
+      explanation: dense
+        ? `You lean on ${hits.length} of these (very, really, quite…). Once is a shrug; this often it reads as padding. Cut them all, then put the emphasis back with a stronger word — “very fast” becomes “blistering”.`
+        : `“${w.text}” tells the reader to feel more without giving them more. Try the sentence without it — if nothing is lost, leave it out.`,
+    }));
+  },
+};

--- a/scripts/destink/vendor/lint/rules/elegant-variation.ts
+++ b/scripts/destink/vendor/lint/rules/elegant-variation.ts
@@ -1,0 +1,183 @@
+// ELEGANT VARIATION (claude-isms tier, #34) — the inverse of repetition.ts. Where dilution flags a
+// writer saying the same thing over and over, this flags a writer refusing to say the same WORD
+// twice: one referent cycled through a thesaurus so no noun has to appear a second time.
+//
+//   "The vehicle arrived late that morning. This automobile had been repainted twice.
+//    Said car was finally towed away."
+//
+// Nothing was clarified by the second and third names; the reader now has to check whether three
+// objects are being tracked or one. Fowler named the habit a century ago and it is a strong tell in
+// generated prose, which reaches for a synonym the moment a word has been used.
+//
+// --- how it is detected without embeddings ---
+// No vector model ships to the browser build, so "these two nouns mean the same thing" comes from a
+// small, curated, hand-written table instead: CLUSTERS below, a dozen-odd groups of everyday
+// synonyms. It is deliberately data, not code — adding a cluster is one array entry, and the table
+// is meant to grow. What the rule looks for:
+//
+//   phrase   a DETERMINER immediately (or nearly) followed by a cluster member: "the vehicle",
+//            "this automobile", "that car", "said car". The determiner requirement is what makes
+//            the phrase a REFERENCE to a specific thing rather than a generic mention — "cars are
+//            expensive" is a claim about cars, not a way of avoiding the word "car". Up to
+//            MAX_GAP tokens are allowed between the two so an adjective ("the repainted vehicle")
+//            does not hide the noun.
+//   window   the phrases have to be close together: WINDOW consecutive units. Two synonyms a page
+//            apart are two mentions, not a cycle.
+//   cycling  at least MIN_DISTINCT distinct head nouns from ONE cluster, each occurring EXACTLY
+//            ONCE inside the window. The exactly-once test is the point of the rule: a writer who
+//            says "the car" three times is repeating, which is fine here (dilution owns that), and
+//            a writer who says "the car ... the vehicle ... the car" is alternating, not cycling.
+//
+// --- what it deliberately does not catch ---
+//   * two synonyms only ("the vehicle ... this automobile"). Two names for one thing is often just
+//     a sentence that needed a different word; three is a pattern.
+//   * synonyms outside the table. There is no general synonymy here and there cannot be without a
+//     model — every miss of that kind is a missing cluster, and the fix is an entry in CLUSTERS.
+//   * bare plurals and determinerless mentions ("vehicles ... automobiles ... cars"), for the
+//     reason above: no determiner, no single referent being tracked.
+//
+// Severity: "low" per cycling cluster, bumped to "medium" for every finding once two or more
+// DIFFERENT clusters cycle in the same document — one referent given three names can be a stylistic
+// slip, two referents both being cycled is the writing habit.
+
+import type { DocAnalysis, Finding, Severity, Span, TropeRule, WordSpan } from "../types.js";
+import { spanning } from "../span.js";
+
+const RULE_ID = "claude/elegant-variation";
+
+const WINDOW = 4; // consecutive units a cycle has to fit inside
+const MIN_DISTINCT = 3; // distinct synonyms before a cycle is a cycle
+const MAX_GAP = 2; // tokens allowed between the determiner and the noun ("the freshly repainted car")
+
+// Determiners that make the following noun a reference to one specific thing. "said" is the legal-
+// register variant that shows up in exactly this trope ("said car"); "such" likewise.
+const DETERMINERS = new Set(["the", "this", "that", "these", "those", "said", "such"]);
+
+// --- the synonym table --------------------------------------------------------------------------
+// Hand-curated, shipped as data, extensible: add a group and the rule covers it. Kept to everyday
+// referents a writer actually cycles; technical vocabulary is left out because a genuine term of
+// art repeating is not this trope.
+const CLUSTERS: readonly (readonly string[])[] = [
+  ["vehicle", "car", "automobile", "auto", "motorcar"],
+  ["dog", "canine", "hound", "pooch", "mutt"],
+  ["house", "home", "residence", "dwelling", "abode"],
+  ["company", "firm", "organization", "organisation", "enterprise", "corporation"],
+  ["report", "document", "paper", "dossier", "memo"],
+  ["city", "metropolis", "municipality", "township", "conurbation"],
+  ["book", "volume", "tome", "publication", "title"],
+  ["ship", "vessel", "boat", "freighter", "steamer"],
+  ["doctor", "physician", "clinician", "medic", "practitioner"],
+  ["film", "movie", "picture", "feature", "motion-picture"],
+  ["plan", "scheme", "strategy", "blueprint", "roadmap"],
+  ["teacher", "educator", "instructor", "tutor", "lecturer"],
+  ["meeting", "gathering", "session", "assembly", "convocation"],
+  ["money", "cash", "funds", "capital", "currency"],
+];
+
+// word -> index into CLUSTERS. Built once at module load; every lookup is O(1).
+const CLUSTER_OF = new Map<string, number>();
+CLUSTERS.forEach((group, i) => {
+  for (const word of group) CLUSTER_OF.set(word, i);
+});
+
+// Singular lookup for a plural surface form ("the vehicles"). Nothing fancier: the table holds
+// singulars, and stripping a trailing "s" (or "es") is enough to find them.
+function clusterIndex(surface: string): number | undefined {
+  const lc = surface.toLowerCase();
+  const direct = CLUSTER_OF.get(lc);
+  if (direct !== undefined) return direct;
+  if (lc.endsWith("es")) {
+    const stripped = CLUSTER_OF.get(lc.slice(0, -2));
+    if (stripped !== undefined) return stripped;
+  }
+  return lc.endsWith("s") ? CLUSTER_OF.get(lc.slice(0, -1)) : undefined;
+}
+
+// --- occurrences ----------------------------------------------------------------------------------
+
+type Occurrence = { cluster: number; noun: string; unitIndex: number; span: Span };
+
+const isWordToken = (w: WordSpan): boolean => /[\p{L}\p{N}]/u.test(w.text);
+
+// Every "<determiner> … <cluster noun>" phrase in the document, in order. The span runs from the
+// determiner through the noun, so a finding slices back to the phrase the writer actually wrote.
+function occurrences(doc: DocAnalysis): Occurrence[] {
+  const out: Occurrence[] = [];
+  doc.units.forEach((unit, unitIndex) => {
+    const words = unit.words.filter(isWordToken);
+    for (let i = 0; i < words.length; i++) {
+      if (!DETERMINERS.has(words[i]!.text.toLowerCase())) continue;
+      for (let j = i + 1; j <= i + 1 + MAX_GAP && j < words.length; j++) {
+        const cluster = clusterIndex(words[j]!.text);
+        if (cluster === undefined) continue;
+        const noun = words[j]!.text.toLowerCase();
+        out.push({ cluster, noun, unitIndex, span: spanning([words[i]!, words[j]!]) });
+        i = j; // the noun is consumed; don't let it pair with a second determiner
+        break;
+      }
+    }
+  });
+  return out;
+}
+
+// --- windows ---------------------------------------------------------------------------------------
+
+type Cycle = { cluster: number; nouns: string[]; span: Span };
+
+// The earliest qualifying window for one cluster, then the scan resumes past it — a run of five
+// synonyms reads as one cycle, not three overlapping ones.
+function cyclesIn(cluster: number, occs: readonly Occurrence[]): Cycle[] {
+  const out: Cycle[] = [];
+  let from = 0;
+  while (from < occs.length) {
+    const start = occs[from]!;
+    const window = occs.slice(from).filter((o) => o.unitIndex - start.unitIndex < WINDOW);
+    const counts = new Map<string, number>();
+    for (const o of window) counts.set(o.noun, (counts.get(o.noun) ?? 0) + 1);
+    const once = window.filter((o) => counts.get(o.noun) === 1);
+    if (once.length >= MIN_DISTINCT) {
+      out.push({ cluster, nouns: once.map((o) => o.noun), span: spanning(once) });
+      from += window.length;
+      continue;
+    }
+    from++;
+  }
+  return out;
+}
+
+export const elegantVariationRule: TropeRule = {
+  id: RULE_ID,
+  name: "Elegant variation (synonym-cycling for one referent)",
+  tier: "discourse",
+  detect(doc: DocAnalysis): Finding[] {
+    const byCluster = new Map<number, Occurrence[]>();
+    for (const occ of occurrences(doc)) {
+      const list = byCluster.get(occ.cluster);
+      if (list) list.push(occ);
+      else byCluster.set(occ.cluster, [occ]);
+    }
+
+    const cycles = [...byCluster.entries()]
+      .flatMap(([cluster, occs]) => cyclesIn(cluster, occs))
+      .sort((a, b) => a.span.start - b.span.start || a.span.end - b.span.end);
+
+    const distinctClusters = new Set(cycles.map((c) => c.cluster)).size;
+    const severity: Severity = distinctClusters >= 2 ? "medium" : "low";
+    const density = distinctClusters >= 2 ? ` Two different things get this treatment in one piece, which makes it a habit rather than a slip.` : "";
+
+    return cycles.map((c) => {
+      const named = c.nouns.map((n) => `“${n}”`).join(", ");
+      return {
+        ruleId: RULE_ID,
+        span: c.span,
+        severity,
+        message: `Elegant variation: ${c.nouns.length} names for one thing — ${named}`,
+        explanation:
+          `${named} all point at the same thing here, each used exactly once, within a few sentences of each other. ` +
+          `Swapping in a synonym every time avoids a repeated word at the cost of the reader's certainty that it is still the same thing — ` +
+          `they have to stop and check. Pick the plainest of the ${c.nouns.length} (“${c.nouns[0]}”), use it every time, and reach for a pronoun when the repetition gets heavy.` +
+          density,
+      };
+    });
+  },
+};

--- a/scripts/destink/vendor/lint/rules/excess-vocabulary.ts
+++ b/scripts/destink/vendor/lint/rules/excess-vocabulary.ts
@@ -1,0 +1,17 @@
+// excess-vocabulary (issue #34) — wires the excess-vocabulary Lexicon (lexicons/
+// excess-vocabulary.ts) through the standard-tier factory (rules/standard-lexicon.ts): density
+// STEPS DOWN a sparse hit, the opposite of the claude-lexicon.ts tier's escalation-only model. See
+// that lexicon file's header for the full source attribution (Kobak et al. 2025, Juzek & Ward 2025)
+// and the dedup decisions against every other lexicon in this directory.
+import { buildStandardLexiconRule } from "./standard-lexicon.js";
+import { excessVocabulary } from "../lexicons/excess-vocabulary.js";
+
+const EXPLANATION =
+  `"Delves", "showcasing", "underscores", "meticulously" and dozens of otherwise ordinary words ` +
+  `like "pivotal", "intricate" and "invaluable" measurably show up far more often in text written ` +
+  `with LLM assistance than in matched human baselines (Kobak et al. 2025, Science Advances; Juzek ` +
+  `& Ward 2025, COLING). None of these words is wrong on its own — the tell is how often the same ` +
+  `handful recur. Reach for the plainer word your own voice would use, or just say the thing ` +
+  `directly.`;
+
+export const excessVocabularyRule = buildStandardLexiconRule(excessVocabulary, EXPLANATION);

--- a/scripts/destink/vendor/lint/rules/false-range.ts
+++ b/scripts/destink/vendor/lint/rules/false-range.ts
@@ -1,0 +1,364 @@
+// FALSE RANGE — "from X to Y" where X and Y aren't on any real scale ("from innovation to
+// cultural transformation"). Issue #19.
+//
+// Judging whether X..Y is a real scale is semantic; this rule only narrows the field. Two
+// independent detectors feed one severity ladder:
+//
+//   IR path     Walks the lowered Clause looking for a from-PP whose neighborhood (the same
+//               modifier list, or recursively the from-PP's own object's modifiers) holds a
+//               matching to-PP — including a chain ("from A to B to C"). Confirmed structure, so
+//               a clean hit starts at "candidate" and gets UPGRADED to "low"/"medium" by three
+//               heuristics (see scoreHeuristics below): both ends abstract-suffixed, 3+ items
+//               strung along the range, and no shared unit/dimension between the ends.
+//
+//   Token path  A plain scan over unit.words for "from" ... "to" within a modest window, with no
+//               tree required. It catches everything the rule-based chunker mangles or refuses
+//               (run-on coordinations, fragments), but with no structure to confirm it against,
+//               its findings are ALWAYS "candidate" — never upgraded.
+//
+// Both paths apply the same downgrade: a numeric end (digit or spelled-out small number, or a CD
+// tag), a capitalized proper-noun end (place-to-place), or a known idiom (start to finish, top to
+// bottom, time to time, head to toe, 9 to 5) suppresses the finding entirely — these are literal
+// ranges, not false ones.
+//
+// Span: from the "from" token through the end of the range's last object, resolved by matching
+// word text against unit.words (which carries source offsets); when that lookup fails (the object
+// doesn't appear as a single token — e.g. a coordinated object flattened to a multi-word head by
+// lower.ts's asNominal) the span degrades to the whole unit.
+
+import type { Compound, Clause, Complement, Modifier, Nominal, Predicate, Subject, Verbal, Word } from "../../ir.js";
+import type { DocAnalysis, Finding, Severity, Span, TropeRule, UnitAnalysis, WordSpan } from "../types.js";
+import { spanning, overlaps } from "../span.js";
+
+const RULE_ID = "false-range/from-to";
+
+// --- shared word-level checks (both paths) ---
+
+const NUMBER_WORDS = new Set([
+  "zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten", "eleven", "twelve",
+]);
+const isNumericText = (text: string): boolean => /^\d+$/.test(text) || NUMBER_WORDS.has(text.toLowerCase());
+const isProperText = (text: string): boolean => /^[A-Z]/.test(text);
+
+// Small, deliberately narrow: literal ranges that would otherwise trip the structural heuristics
+// (both ends common nouns, no shared dimension) but are idiomatic, not rhetorical.
+const IDIOMS: ReadonlyArray<readonly [string, string]> = [
+  ["start", "finish"],
+  ["top", "bottom"],
+  ["time", "time"],
+  ["head", "toe"],
+  ["9", "5"],
+];
+const isIdiomPair = (a: string, b: string): boolean =>
+  IDIOMS.some(([x, y]) => x === a.toLowerCase() && y === b.toLowerCase());
+
+// --- IR path ---
+
+type RangeCandidate = { fromWord: Word; endpoints: Nominal[] }; // endpoints[0] is the from-object
+
+const bareWord = (text: string): string => {
+  const parts = text.trim().split(/\s+/);
+  return (parts[parts.length - 1] ?? "").toLowerCase();
+};
+
+// How many sibling modifiers we'll look past, from a "from"-PP, to find its matching "to"(s). Kept
+// small on purpose — this is structure-narrowing, not a free-form search of the whole clause.
+const MAX_MOD_GAP = 4;
+
+// Scans one modifiers list for from -> to (-> to ...) chains; recursion into nested lists (a PP's
+// own object, a nested clause, a participle) happens in the walk* functions below, which call this
+// at every list they visit.
+function scanModifiers(mods: Modifier[], out: RangeCandidate[]): void {
+  for (let i = 0; i < mods.length; i++) {
+    const m = mods[i]!;
+    if (m.kind !== "prep" || bareWord(m.prep.text) !== "from") continue;
+    const endpoints: Nominal[] = [m.object];
+    const limit = Math.min(mods.length, i + 1 + MAX_MOD_GAP);
+    for (let j = i + 1; j < limit; j++) {
+      const next = mods[j]!;
+      if (next.kind !== "prep") continue;
+      const w = bareWord(next.prep.text);
+      if (w === "from") break; // a new range starts — don't reach across it
+      if (w === "to") endpoints.push(next.object);
+    }
+    // The OTHER neighborhood the issue calls out: a "to" living inside the from-PP's own object's
+    // modifiers, not as a sibling of "from" itself.
+    for (const inner of m.object.modifiers) {
+      if (inner.kind === "prep" && bareWord(inner.prep.text) === "to") endpoints.push(inner.object);
+    }
+    if (endpoints.length >= 2) out.push({ fromWord: m.prep, endpoints });
+  }
+}
+
+const asItems = <T>(n: T | Compound<T>): T[] => ("items" in (n as Compound<T>) ? (n as Compound<T>).items : [n as T]);
+
+function walkNominal(n: Nominal | Compound<Nominal>, out: RangeCandidate[]): void {
+  for (const item of asItems(n)) walkModifiers(item.modifiers, out);
+}
+
+function walkModifiers(mods: Modifier[], out: RangeCandidate[]): void {
+  scanModifiers(mods, out);
+  for (const m of mods) {
+    if (m.kind === "prep") walkNominal(m.object, out);
+    else if (m.kind === "clause") walkClause(m.value, out);
+    else if (m.kind === "participle") {
+      walkModifiers(m.modifiers, out);
+      if (m.object) walkNominal(m.object, out);
+    }
+  }
+}
+
+function walkVerbal(v: Verbal, out: RangeCandidate[]): void {
+  walkModifiers(v.modifiers, out);
+  if (v.indirectObject) walkNominal(v.indirectObject, out);
+}
+
+function walkPredicate(p: Predicate, out: RangeCandidate[]): void {
+  if ("items" in p) {
+    for (const part of p.items) {
+      walkVerbal(part.verb, out);
+      if (part.complement) walkComplement(part.complement, out);
+    }
+    return;
+  }
+  walkVerbal(p, out);
+}
+
+function walkComplement(c: Complement, out: RangeCandidate[]): void {
+  switch (c.kind) {
+    case "predicateNoun":
+      walkNominal(c.value, out);
+      return;
+    case "predicateAdj":
+      return; // Word | Compound<Word> — nothing to recurse into
+    case "objectComplement":
+      walkNominal(c.object, out);
+      if (!c.ocIsAdj) walkNominal(c.oc as Nominal, out);
+      return;
+    case "directObject": {
+      const v = c.value;
+      if ("items" in v) walkNominal(v, out); // Compound<Nominal>
+      else if ("kind" in v) {
+        // Infinitive ("wanted to leave")
+        walkModifiers(v.modifiers, out);
+        if (v.object) walkNominal(v.object, out);
+      } else if ("head" in v) {
+        walkNominal(v, out); // Nominal
+      } else {
+        walkClause(v, out); // Clause (causative small clause)
+      }
+    }
+  }
+}
+
+function walkSubject(s: Subject, out: RangeCandidate[]): void {
+  if ("items" in s) {
+    for (const item of s.items) walkNominal(item, out);
+  } else if ("kind" in s) {
+    walkModifiers(s.modifiers, out); // Infinitive | Gerund
+    if (s.object) walkNominal(s.object, out);
+  } else if ("head" in s) {
+    walkNominal(s, out); // Nominal
+  } else {
+    walkClause(s, out); // a full clause used nominally ("Whoever made this...")
+  }
+}
+
+function walkClause(clause: Clause, out: RangeCandidate[]): void {
+  walkSubject(clause.subject, out);
+  walkPredicate(clause.verb, out);
+  if (clause.complement) walkComplement(clause.complement, out);
+}
+
+// --- heuristics (IR path only — see module doc) ---
+
+const ABSTRACT_SUFFIXES = ["tion", "ment", "ness", "ity", "ism", "ance", "ence"];
+const hasAbstractSuffix = (text: string): boolean => {
+  const lc = text.toLowerCase();
+  return ABSTRACT_SUFFIXES.some((suf) => lc.length > suf.length + 2 && lc.endsWith(suf));
+};
+
+// Endpoints with a recognizable shared dimension — a real scale, not a "no shared unit" false
+// range — even though neither is numeric, proper, or an idiom pair on its own.
+const DIMENSION_WORDS = new Set([
+  "top", "bottom", "start", "finish", "beginning", "end", "head", "toe",
+  "north", "south", "east", "west", "left", "right", "inside", "outside",
+  "morning", "evening", "dawn", "dusk", "sunrise", "sunset",
+  "childhood", "adulthood", "birth", "death",
+  "spring", "summer", "fall", "autumn", "winter",
+]);
+
+// A coordinated object gets flattened by lower.ts's asNominal into one head text joined by its
+// conjunction ("discovery and expression and innovation") — this recovers an item count from that.
+const coordinatedItemCount = (text: string): number => text.split(/\s+(?:and|or)\s+/i).length;
+
+function scoreHeuristics(endpoints: Nominal[]): number {
+  const first = endpoints[0]!.head.text;
+  const last = endpoints[endpoints.length - 1]!.head.text;
+  let hits = 0;
+  if (hasAbstractSuffix(first) && hasAbstractSuffix(last)) hits++;
+  const itemCount = Math.max(endpoints.length, coordinatedItemCount(first), coordinatedItemCount(last));
+  if (itemCount >= 3) hits++;
+  const known = (t: string) => DIMENSION_WORDS.has(t.toLowerCase());
+  if (!known(first) && !known(last)) hits++;
+  return hits;
+}
+
+const severityFor = (hits: number): Severity => (hits >= 2 ? "medium" : hits === 1 ? "low" : "candidate");
+
+const isSuppressedEndpoint = (w: Word): boolean =>
+  w.pos === "CD" || w.pos === "NNP" || w.pos === "NNPS" || isNumericText(w.text) || isProperText(w.text);
+
+const isSuppressedIrPair = (first: Word, last: Word): boolean =>
+  isSuppressedEndpoint(first) || isSuppressedEndpoint(last) || isIdiomPair(first.text, last.text);
+
+// --- span resolution: map the IR's Words back onto unit.words for source offsets ---
+
+function findWordSpan(words: WordSpan[], text: string, fromIndex: number): { index: number; span: Span } | null {
+  const lc = text.toLowerCase();
+  for (let i = fromIndex; i < words.length; i++) {
+    if (words[i]!.text.toLowerCase() === lc) return { index: i, span: words[i]!.span };
+  }
+  return null;
+}
+
+// Resolves from "from" (searched no earlier than `cursor`, so repeated ranges in one unit don't
+// all latch onto the first "from") through the last word of `lastHeadText` (the range's final
+// object head — for a head-final NP that's the object's own last token). Degrades to the whole
+// unit span when either lookup fails — e.g. a coordinated object whose head text is a multi-word
+// join and so never appears as a single source token.
+function resolveSpan(unit: UnitAnalysis, cursor: number, lastHeadText: string): { span: Span; next: number } {
+  const fromHit = findWordSpan(unit.words, "from", cursor);
+  if (!fromHit) return { span: unit.span, next: cursor };
+  const lastToken = lastHeadText.trim().split(/\s+/).pop() ?? lastHeadText;
+  const endHit = findWordSpan(unit.words, lastToken, fromHit.index + 1);
+  if (!endHit) return { span: unit.span, next: fromHit.index + 1 };
+  return { span: spanning([fromHit.span, endHit.span]), next: endHit.index + 1 };
+}
+
+// --- messages ---
+
+function buildFinding(span: Span, x: string, y: string, hits: number): Finding {
+  const severity = severityFor(hits);
+  if (hits === 0) {
+    return {
+      ruleId: RULE_ID,
+      span,
+      severity,
+      message: `"from ${x} to ${y}" has the shape of a range`,
+      explanation: `"From ${x} to ${y}" borrows the form of a scale — a beginning point and an end — without anything confirming ${x} and ${y} sit on one measurable line. If they don't, say what actually changed instead of implying a spectrum.`,
+    };
+  }
+  const reasons: string[] = [];
+  if (hasAbstractSuffix(x) && hasAbstractSuffix(y)) reasons.push("both ends are abstract nouns");
+  reasons.push("the two ends share no unit or dimension");
+  return {
+    ruleId: RULE_ID,
+    span,
+    severity,
+    message: `"from ${x} to ${y}" is a false range`,
+    explanation: `${x} and ${y} aren't points on the same scale (${reasons.join("; ")}). "From X to Y" reads as measurement, but this pairs two unrelated ideas — name the change directly instead.`,
+  };
+}
+
+function tokenFinding(span: Span, x: string, y: string): Finding {
+  return {
+    ruleId: RULE_ID,
+    span,
+    severity: "candidate",
+    message: `"from ${x} to ${y}" reads like a range`,
+    explanation: `Word order alone suggests a range here, but nothing confirmed the structure. Check that ${x} and ${y} are actually two points on one scale — if not, this is a false range dressed up as one.`,
+  };
+}
+
+// --- token path ---
+
+const MAX_GAP = 16; // words allowed between "from" and its "to"(s) before giving up on the pair
+const MAX_RANGE_WORDS = 10; // words captured as the range's tail object, past the last "to"
+const LEADING_DET = new Set(["a", "an", "the"]);
+
+// The representative word for Y-side suppression checks: skip a leading article so "the bottom"
+// keys off "bottom", not "the". Not a claim about where the head of the NP actually is (it isn't,
+// in general) — just enough to catch the idiom/numeric/proper cases the suppression list cares
+// about without a tree.
+function firstContentToken(tokens: WordSpan[]): WordSpan {
+  const [first, second] = tokens;
+  if (first && second && LEADING_DET.has(first.text.toLowerCase())) return second;
+  return first!;
+}
+
+function tokenPathCandidates(unit: UnitAnalysis): Finding[] {
+  const words = unit.words;
+  const findings: Finding[] = [];
+  let i = 0;
+  while (i < words.length) {
+    if (words[i]!.text.toLowerCase() !== "from") {
+      i++;
+      continue;
+    }
+    const fromIdx = i;
+    const limit = Math.min(words.length, fromIdx + 1 + MAX_GAP);
+    const toIdxs: number[] = [];
+    for (let j = fromIdx + 1; j < limit; j++) if (words[j]!.text.toLowerCase() === "to") toIdxs.push(j);
+    if (toIdxs.length === 0) {
+      i = fromIdx + 1;
+      continue;
+    }
+    const firstTo = toIdxs[0]!;
+    const lastTo = toIdxs[toIdxs.length - 1]!;
+    if (firstTo <= fromIdx + 1) {
+      i = fromIdx + 1;
+      continue;
+    }
+    const xTokens = words.slice(fromIdx + 1, firstTo);
+    const yEnd = Math.min(words.length, lastTo + 1 + MAX_RANGE_WORDS);
+    const yTokens = words.slice(lastTo + 1, yEnd);
+    if (xTokens.length === 0 || yTokens.length === 0) {
+      i = fromIdx + 1;
+      continue;
+    }
+    const xLast = xTokens[xTokens.length - 1]!;
+    const yRep = firstContentToken(yTokens);
+    const suppressed = isNumericText(xLast.text) || isNumericText(yRep.text) ||
+      isProperText(xLast.text) || isProperText(yRep.text) || isIdiomPair(xLast.text, yRep.text);
+    if (!suppressed) {
+      const yLast = yTokens[yTokens.length - 1]!;
+      findings.push(tokenFinding(spanning([words[fromIdx]!.span, yLast.span]), xLast.text, yRep.text));
+    }
+    i = lastTo + 1;
+  }
+  return findings;
+}
+
+// --- rule ---
+
+export const falseRangeRule: TropeRule = {
+  id: RULE_ID,
+  name: 'False range ("from X to Y")',
+  tier: "syntactic",
+  detect(doc: DocAnalysis): Finding[] {
+    const findings: Finding[] = [];
+    for (const unit of doc.units) {
+      const irFindings: Finding[] = [];
+      if (unit.clauses && unit.clauses.length > 0) {
+        const candidates: RangeCandidate[] = [];
+        for (const clause of unit.clauses) walkClause(clause, candidates);
+        let cursor = 0;
+        for (const cand of candidates) {
+          const first = cand.endpoints[0]!.head;
+          const last = cand.endpoints[cand.endpoints.length - 1]!.head;
+          if (isSuppressedIrPair(first, last)) continue;
+          const { span, next } = resolveSpan(unit, cursor, last.text);
+          cursor = next;
+          const hits = scoreHeuristics(cand.endpoints);
+          irFindings.push(buildFinding(span, first.text, last.text, hits));
+        }
+      }
+      const tokenFindings = tokenPathCandidates(unit).filter(
+        (tf) => !irFindings.some((irf) => overlaps(irf.span, tf.span)),
+      );
+      findings.push(...irFindings, ...tokenFindings);
+    }
+    return findings;
+  },
+};

--- a/scripts/destink/vendor/lint/rules/formatting.ts
+++ b/scripts/destink/vendor/lint/rules/formatting.ts
@@ -1,0 +1,252 @@
+// Formatting tier (epic #28, #21) — parser-free, markdown-aware. These four rules read doc.text
+// directly and lean on markdown.ts's markdownContext for structure; they do NOT read doc.units,
+// because the formatting tier cares about the document's shape (headings, lists, fences,
+// paragraphs), not its clauses. All four skip code fences entirely via inKind(ctx, span,
+// "codeFence").
+//
+// One file for the tier because the rules share one markdownContext per detect() call and the
+// shared helpers (word counting, code-fence filtering) are tiny — four files would mostly be
+// import boilerplate. Split them out if a rule outgrows this.
+
+import type { DocAnalysis, Finding, Severity, TropeRule } from "../types.js";
+import type { MarkdownContext, ListBlock, Paragraph } from "../markdown.js";
+import { markdownContext, inKind } from "../markdown.js";
+import { spanning } from "../span.js";
+
+// ---------------------------------------------------------------------------------------------
+// em-dash density
+// ---------------------------------------------------------------------------------------------
+// Counts em dashes (—) and double-hyphens used as a dash (--) outside code fences, per 1000 words
+// of the document (also outside code fences). One em dash is normal prose punctuation — the repo's
+// own comments use them — so a lone hit never fires regardless of how short the document is: we
+// require at least 2 occurrences before density even gets computed. Thresholds (per 1000 words):
+//   < 1        no finding — could be one dash in a long document, not a pattern
+//   1 to <3    low
+//   3 to <6    medium  (the CLAUDE.md guidance's ">3/1000 medium" line)
+//   >= 6       high
+// Findings are emitted one per occurrence (so the UI can highlight each dash), all sharing the
+// document-wide severity and a message that states the aggregate count and density.
+
+const WORD_RE = /[\p{L}\p{N}]+/gu;
+const DASH_RE = /—|--/g;
+
+function countWordsOutsideFences(ctx: MarkdownContext): number {
+  let count = 0;
+  for (const m of ctx.text.matchAll(WORD_RE)) {
+    const span = { start: m.index!, end: m.index! + m[0].length };
+    if (!inKind(ctx, span, "codeFence")) count++;
+  }
+  return count;
+}
+
+function dashOccurrences(ctx: MarkdownContext): { start: number; end: number }[] {
+  const hits: { start: number; end: number }[] = [];
+  for (const m of ctx.text.matchAll(DASH_RE)) {
+    const span = { start: m.index!, end: m.index! + m[0].length };
+    if (!inKind(ctx, span, "codeFence")) hits.push(span);
+  }
+  return hits;
+}
+
+export const emDashDensityRule: TropeRule = {
+  id: "formatting/em-dash-density",
+  name: "Em-dash density",
+  tier: "formatting",
+  detect(doc: DocAnalysis): Finding[] {
+    const ctx = markdownContext(doc.text);
+    const hits = dashOccurrences(ctx);
+    if (hits.length < 2) return [];
+    const words = countWordsOutsideFences(ctx);
+    const density = words === 0 ? 0 : (hits.length / words) * 1000;
+    if (density < 1) return [];
+    const severity: Severity = density >= 6 ? "high" : density >= 3 ? "medium" : "low";
+    const rounded = Math.round(density * 10) / 10;
+    const message = `em dash — ${hits.length} in ~${words} words (${rounded}/1000)`;
+    const explanation = `You use an em dash or double-hyphen ${hits.length} times across this document — about ${rounded} per 1000 words. One is a stylistic choice; this many reads as a tic AI writing leans on for every aside and pivot. Cut most of them and let sentences end, or split into two sentences instead of dashing on.`;
+    return hits.map((span) => ({ ruleId: "formatting/em-dash-density", span, severity, message, explanation }));
+  },
+};
+
+// ---------------------------------------------------------------------------------------------
+// unicode decoration
+// ---------------------------------------------------------------------------------------------
+// Three categories, outside code fences: arrows (→ ⇒ etc.), smart/curly quotation marks used AS
+// quotation marks (not the same codepoint used as an apostrophe in a contraction), and decorative
+// symbols (emoji, dingbats, misc symbols). One finding per category per document — not one per
+// character — because ten arrows in a diagram-ish list is one tell, not ten. Each finding's span
+// covers the full range from the first to the last hit in that category (spanning()), and the
+// message carries the per-character count. Any category with zero hits produces no finding.
+//
+// Smart-quote detection: “ ” (U+201C/201D) are unambiguous quotation marks — always counted. ‘
+// (U+2018) is also unambiguous — an opening single quote is never an apostrophe. ’ (U+2019) is
+// reused as BOTH a closing single quote and a typed apostrophe ("don't" autocorrected to "don't"
+// with a curly mark). We only count ’ when it is NOT sitting between two letters (that shape is a
+// contraction/possessive apostrophe, normal prose); a ’ preceded or followed by a non-letter is
+// being used as a quotation mark.
+// Arrows block (U+2190–U+21FF: →, ⇒, ⇔…), Supplemental Arrows-A (U+27F0–U+27FF), Supplemental
+// Arrows-B (U+2900–U+297F). Written as \u{} escapes, not literal glyphs, so the range boundaries
+// are auditable rather than dependent on how two arrow-ish glyphs happen to render.
+const ARROW_RE = /[\u{2190}-\u{21FF}\u{27F0}-\u{27FF}\u{2900}-\u{297F}]/gu;
+// Misc Symbols + Dingbats (U+2600–U+27BF: ☀ ✨ ✔ ➜…), Misc Symbols & Arrows (U+2B00–U+2BFF: ⬆ ★…),
+// and the emoji-ish astral ranges (U+1F300–U+1FAFF).
+const DECORATIVE_RE = /[\u{2600}-\u{27BF}\u{2B00}-\u{2BFF}\u{1F300}-\u{1FAFF}]/gu;
+const CURLY_DOUBLE_RE = /[“”]/gu;
+const CURLY_SINGLE_OPEN_RE = /‘/gu;
+const CURLY_APOSTROPHE_OR_CLOSE_RE = /’/gu;
+const LETTER = /\p{L}/u;
+
+function findAll(text: string, re: RegExp, filter?: (index: number) => boolean): { start: number; end: number }[] {
+  const hits: { start: number; end: number }[] = [];
+  for (const m of text.matchAll(re)) {
+    if (filter && !filter(m.index!)) continue;
+    hits.push({ start: m.index!, end: m.index! + m[0].length });
+  }
+  return hits;
+}
+
+function isQuotationUse(text: string, index: number): boolean {
+  const before = index > 0 ? text[index - 1]! : "";
+  const after = index + 1 < text.length ? text[index + 1]! : "";
+  return !(LETTER.test(before) && LETTER.test(after));
+}
+
+function outsideFences(ctx: MarkdownContext, hits: { start: number; end: number }[]): { start: number; end: number }[] {
+  return hits.filter((h) => !inKind(ctx, h, "codeFence"));
+}
+
+export const unicodeDecorationRule: TropeRule = {
+  id: "formatting/unicode-decoration",
+  name: "Unicode decoration",
+  tier: "formatting",
+  detect(doc: DocAnalysis): Finding[] {
+    const ctx = markdownContext(doc.text);
+    const text = doc.text;
+
+    const arrows = outsideFences(ctx, findAll(text, ARROW_RE));
+    const decorative = outsideFences(ctx, findAll(text, DECORATIVE_RE));
+    const smartQuotes = outsideFences(
+      ctx,
+      [
+        ...findAll(text, CURLY_DOUBLE_RE),
+        ...findAll(text, CURLY_SINGLE_OPEN_RE),
+        ...findAll(text, CURLY_APOSTROPHE_OR_CLOSE_RE, (i) => isQuotationUse(text, i)),
+      ].sort((a, b) => a.start - b.start),
+    );
+
+    const findings: Finding[] = [];
+    if (arrows.length > 0) {
+      findings.push({
+        ruleId: "formatting/unicode-decoration",
+        span: spanning(arrows),
+        severity: "low",
+        message: `${arrows.length} unicode arrow${arrows.length === 1 ? "" : "s"} (→, ⇒…)`,
+        explanation: `Arrows like → read as a deck slide, not prose. Real keyboards type "->" or just write the word: "leads to", "then".`,
+      });
+    }
+    if (smartQuotes.length > 0) {
+      findings.push({
+        ruleId: "formatting/unicode-decoration",
+        span: spanning(smartQuotes),
+        severity: "low",
+        message: `${smartQuotes.length} curly quotation mark${smartQuotes.length === 1 ? "" : "s"} ("smart quotes")`,
+        explanation: `Curly “quotes” and ‘quotes’ are what a word processor autocorrects to, not what someone typing in a plain editor produces. Straight quotes read as typed, not generated.`,
+      });
+    }
+    if (decorative.length > 0) {
+      findings.push({
+        ruleId: "formatting/unicode-decoration",
+        span: spanning(decorative),
+        severity: "low",
+        message: `${decorative.length} decorative symbol${decorative.length === 1 ? "" : "s"}`,
+        explanation: `Dingbats and emoji sprinkled into prose (✨, ★…) read as decoration standing in for something to say. Say the thing instead.`,
+      });
+    }
+    return findings;
+  },
+};
+
+// ---------------------------------------------------------------------------------------------
+// bold-first bullets
+// ---------------------------------------------------------------------------------------------
+// A list where most items open with a bolded lead-in ("**Security**: ..." or "**Performance**
+// improvements...") reads as generated documentation. One bolded lead-in in an otherwise varied
+// list is just emphasis; the PATTERN is what's flagged, once, for the whole list — not per item.
+// Fires when a list has >= 3 items AND >= 60% of them open with **...** (optionally followed by a
+// colon).
+const BOLD_LEAD_RE = /^\*\*[^*]+\*\*:?/;
+const MIN_LIST_ITEMS = 3;
+const BOLD_FRACTION_THRESHOLD = 0.6;
+
+function boldLeadFraction(list: ListBlock, text: string): number {
+  const bold = list.items.filter((item) => BOLD_LEAD_RE.test(text.slice(item.contentSpan.start, item.contentSpan.end))).length;
+  return bold / list.items.length;
+}
+
+export const boldFirstBulletRule: TropeRule = {
+  id: "formatting/bold-first-bullet",
+  name: "Bold-first bullets",
+  tier: "formatting",
+  detect(doc: DocAnalysis): Finding[] {
+    const ctx = markdownContext(doc.text);
+    const findings: Finding[] = [];
+    for (const list of ctx.lists) {
+      if (list.items.length < MIN_LIST_ITEMS) continue;
+      const fraction = boldLeadFraction(list, doc.text);
+      if (fraction < BOLD_FRACTION_THRESHOLD) continue;
+      const boldCount = Math.round(fraction * list.items.length);
+      findings.push({
+        ruleId: "formatting/bold-first-bullet",
+        span: list.span,
+        severity: "medium",
+        message: `bold-first bullets — ${boldCount}/${list.items.length} items open with **bold**`,
+        explanation: `Almost every item in this list starts with a bolded word or phrase, like a spec sheet. One bolded lead-in is emphasis; a whole list of them is a template. Vary the openings, or drop the bold and let the sentence do the work.`,
+      });
+    }
+    return findings;
+  },
+};
+
+// ---------------------------------------------------------------------------------------------
+// listicle in a trench coat
+// ---------------------------------------------------------------------------------------------
+// >= 3 consecutive prose paragraphs that each open with an ordinal phrase ("The first...", "The
+// second wall is...", "Next,...", "Finally..."), case-insensitive. This is a listicle wearing
+// paragraph clothes: a numbered list rewritten as prose so it doesn't look like a list. Fires once
+// per run, spanning from the first paragraph in the run to the last.
+const ORDINAL_RE = /^(the\s+)?(first|second|third|fourth|fifth|sixth|next|final|last)\b/i;
+
+function opensWithOrdinal(p: Paragraph, text: string): boolean {
+  return ORDINAL_RE.test(text.slice(p.span.start, p.span.end).trimStart());
+}
+
+export const listicleInTrenchCoatRule: TropeRule = {
+  id: "formatting/listicle-in-trench-coat",
+  name: "Listicle in a trench coat",
+  tier: "formatting",
+  detect(doc: DocAnalysis): Finding[] {
+    const ctx = markdownContext(doc.text);
+    const findings: Finding[] = [];
+    let run: Paragraph[] = [];
+
+    const flush = () => {
+      if (run.length >= 3) {
+        const severity: Severity = run.length >= 4 ? "high" : "medium";
+        findings.push({
+          ruleId: "formatting/listicle-in-trench-coat",
+          span: spanning(run),
+          severity,
+          message: `${run.length} consecutive paragraphs open with "The first/second/next..."`,
+          explanation: `This is a numbered list wearing paragraph clothes — each paragraph exists only to announce its position in a sequence. Either make it an actual list, or drop the ordinal openers and let the content carry the order.`,
+        });
+      }
+      run = [];
+    };
+
+    for (const p of ctx.paragraphs) {
+      if (opensWithOrdinal(p, doc.text)) run.push(p);
+      else flush();
+    }
+    flush();
+    return findings;
+  },
+};

--- a/scripts/destink/vendor/lint/rules/fragments.ts
+++ b/scripts/destink/vendor/lint/rules/fragments.ts
@@ -1,0 +1,276 @@
+// Fragment tier (epic #28, #15) — the fragment-preserving splitter is the whole point: a verbless
+// unit ("Not a bug.") is data, not a parse failure (see document.ts and types.ts's UnitOutcome).
+// Two rules live here because they share every helper below (short-fragment eligibility, markdown
+// suppression, the quote heuristic) and both walk doc.units in document order looking for runs.
+//
+// Tier: "discourse", not "syntactic". Both rules are fundamentally cross-sentence — punchy-fragments
+// measures a document-wide (or run-wide) density and countdown recognizes a shape across 3+ units —
+// neither says anything about a single sentence's grammar the way a syntactic rule would.
+//
+// --- what counts as a fragment here ---
+// unit.outcome === "fragment" is the ENTIRE signal: document.ts already decides "verbless" for us
+// (no-VP on the tree path, "no-verb:" on the parse-failure path — see document.ts's treeReason and
+// readUnit). We do not re-derive verblessness from unit.reason; outcome alone is document.ts's
+// considered answer, and unit.reason strings are informal (stub-doc.ts's makeDoc doesn't reproduce
+// them at all — see stub-doc.ts). outcome === "unparseable" is a DIFFERENT signal (the parser choked
+// on something that does have a predicate, e.g. a "she said" dialogue tag) and is never treated as a
+// fragment here, per the issue: "treat parser-fell-over unparseables as NOT fragments."
+//
+// One consequence, called out in the issue and pinned by document.test.ts ("chunker loses the
+// copula"): the rule-based chunker also marks a contracted-copula clause like "It's not bold." as
+// "fragment" (it can't see the 's as a verb). We don't special-case that away — instead both rules
+// key off the unit's FIRST WORD TOKEN, and "It's" is never "Not"/"No", so the reframe trope ("It's
+// not bold — it's backwards.") never satisfies either rule's negation/short-run shape regardless of
+// how its outcome got decided.
+//
+// --- suppression ---
+// Two independent filters, applied before a unit is allowed to play ANY role (short fragment,
+// negated opener, or countdown cap):
+//   markdown   the unit's span sits inside a heading/bullet/codeFence/blockquote line (whole-span
+//              containment via markdown.ts's inKind — same idiom rules/formatting.ts uses). A unit
+//              from readDocument (document.ts's splitUnits, which does NOT split on newlines) can
+//              straddle a heading line and the prose after it when the heading has no terminal
+//              punctuation; inKind is strict about whole-span containment, so a straddling unit is
+//              NOT suppressed. That's a known gap in the fragment-preserving splitter, not something
+//              this rule can fix (document.ts is out of scope for #15) — makeDoc's splitter (which
+//              does split on newlines) does not have this problem, which is why the markdown
+//              suppression tests below build their fixtures with makeDoc.
+//   quotation  dialogue and quoted speech. A "she said" / "he replied" tag on a quoted line usually
+//              already saves us for free: hasVerb(unit) sees the verb and document.ts calls the
+//              whole unit "unparseable", not "fragment" (see document.ts's readUnit). But bare
+//              quoted fragments with no attribution ("Not a bug." "Not a feature.") DO come back
+//              verbless. The heuristic: scan the document for quote characters (" " ` and the curly
+//              pair), pair them up by simple alternation (odd occurrence opens, even closes) — this
+//              is deliberately not a real quote parser, just enough to bound the common case — and
+//              suppress a unit whose span overlaps a quoted interval by at least half its own length
+//              ("dominated by a quoted span"). A unit fully inside a quoted interval trivially clears
+//              that bar, which covers "starts and ends inside quotation marks" too.
+
+import type { DocAnalysis, Finding, Severity, TropeRule, UnitAnalysis, Span, WordSpan } from "../types.js";
+import { markdownContext, inKind } from "../markdown.js";
+import { spanning } from "../span.js";
+
+// --- word-token helpers ---
+// Both makeDoc (stub-doc.ts's wordRe: letters/digits only, contractions kept whole) and the real
+// pipeline's tokenizer (offsets.ts's tokenizeWithSpans, which peels a leading quote or a contraction
+// apostrophe into its own token) can appear in `words`. Filtering to tokens that CONTAIN a letter or
+// digit, and taking the first such token, gives the same answer either way: a stray leading quote
+// character is never mistaken for the unit's first word.
+const isWordToken = (w: WordSpan): boolean => /[\p{L}\p{N}]/u.test(w.text);
+
+function wordCount(u: UnitAnalysis): number {
+  return u.words.filter(isWordToken).length;
+}
+
+function firstWord(u: UnitAnalysis): string | undefined {
+  return u.words.find(isWordToken)?.text;
+}
+
+// Short = at most this many words. Documented threshold, not derived: "Openly" (1), "In a book" (3),
+// "As a priest" (3) and "A fundamental design flaw" (4) — the tropes.fyi examples this issue names —
+// all fall inside it; a full clause rarely does.
+const SHORT_WORD_MAX = 4;
+
+// --- markdown + quote suppression ---
+
+const SUPPRESSED_MARKDOWN_KINDS = ["heading", "bullet", "codeFence", "blockquote"] as const;
+
+function suppressedByMarkdown(ctx: ReturnType<typeof markdownContext>, span: Span): boolean {
+  return SUPPRESSED_MARKDOWN_KINDS.some((k) => inKind(ctx, span, k));
+}
+
+const QUOTE_CHARS = new Set(['"', "“", "”"]); // " “ ”
+
+// Quote characters in doc.text, paired by simple alternation: 1st opens, 2nd closes, 3rd opens...
+// A trailing unmatched opener closes nothing and is dropped. Deliberately naive — see the header
+// comment for why a real quote-nesting parser is out of scope here.
+function quotedIntervals(text: string): Span[] {
+  const positions: number[] = [];
+  for (let i = 0; i < text.length; i++) if (QUOTE_CHARS.has(text[i]!)) positions.push(i);
+  const intervals: Span[] = [];
+  for (let i = 0; i + 1 < positions.length; i += 2) intervals.push({ start: positions[i]!, end: positions[i + 1]! + 1 });
+  return intervals;
+}
+
+function overlapLength(a: Span, b: Span): number {
+  return Math.max(0, Math.min(a.end, b.end) - Math.max(a.start, b.start));
+}
+
+// "Dominated by a quoted span": at least half of the unit's own span sits inside some quoted
+// interval. A unit fully bookended by quotation marks (the common case) clears this easily.
+function suppressedByQuote(intervals: readonly Span[], span: Span): boolean {
+  const len = span.end - span.start;
+  if (len <= 0) return false;
+  for (const q of intervals) {
+    if (overlapLength(q, span) * 2 >= len) return true;
+  }
+  return false;
+}
+
+// One pass of suppression state, computed once per detect() call and threaded through both rules.
+//
+// EXPORTED (not because this file needs it, but because the suppression question is shared): any
+// rule that keys off short verbless units has the same two problems these two do — a heading or a
+// bullet is not a fragment, and quoted speech is the author quoting someone else. rules/
+// quantity-hook.ts reads the same shapes and gets the same answer from here rather than growing a
+// second, subtly different copy of the markdown containment test and the quote-pairing heuristic.
+// The header above is the documentation for both; keep it that way if a third caller shows up.
+export type Context = { markdown: ReturnType<typeof markdownContext>; quotes: readonly Span[] };
+
+export function makeContext(doc: DocAnalysis): Context {
+  return { markdown: markdownContext(doc.text), quotes: quotedIntervals(doc.text) };
+}
+
+export function suppressed(ctx: Context, span: Span): boolean {
+  return suppressedByMarkdown(ctx.markdown, span) || suppressedByQuote(ctx.quotes, span);
+}
+
+// ---------------------------------------------------------------------------------------------
+// punchy fragments
+// ---------------------------------------------------------------------------------------------
+// "He published this. Openly. In a book. As a priest." — a lowered opener followed by a run of
+// short verbless fragments. Two ways to trip this rule, checked in order per document:
+//
+//   1. A RUN of >= 2 consecutive eligible short fragments (eligible = outcome "fragment", <= 4
+//      words, not suppressed) is direct evidence on its own — "runs...weigh more" from the issue —
+//      and fires regardless of how long the rest of the document is. One finding per maximal run,
+//      spanning the run; severity "medium" at exactly 2, "high" at 3+.
+//   2. Only if NO run fired anywhere in the document: a document-wide density fallback for
+//      fragments that never cluster into a run (spread one-per-paragraph, say) but are still
+//      frequent enough to be a document-wide tic. Needs >= 2 eligible short fragments total (the
+//      absolute floor that keeps one intentional fragment clean) AND a document with >= MIN_UNITS
+//      units total (so a two-sentence document can't trip this on density alone) AND density
+//      (eligible short fragments / total units) >= 0.3 for "medium", >= 0.5 for "high". One finding
+//      spanning the first eligible fragment to the last.
+//
+// MIN_UNITS only gates the density fallback, not run detection — a run of 2+ short fragments fires
+// regardless of how long the surrounding document is (see "He published this..." above, a 4-unit
+// document). One consequence: "It's not bold. It's backwards." — both units come back "fragment"
+// via the copula-losing bug documented above, both short — DOES form a qualifying run and this rule
+// fires on it. That's a legitimate reading under this rule's contract (outcome === "fragment" is
+// the signal, full stop; two three-word verbless-per-the-chunker units in a row is exactly what a
+// run is), not a bug: the issue's explicit "must not fire on this input" requirement names the
+// countdown rule only, because ONLY countdown's shape (negation + cap) is what this specific input
+// pretends to be (a reframe, not a countdown). This is documented and tested below rather than
+// silently patched around.
+
+const MIN_FRAGMENTS = 2;
+const MIN_UNITS = 4;
+const DENSITY_MEDIUM = 0.3;
+const DENSITY_HIGH = 0.5;
+
+function isShortFragment(ctx: Context, u: UnitAnalysis): boolean {
+  return u.outcome === "fragment" && wordCount(u) >= 1 && wordCount(u) <= SHORT_WORD_MAX && !suppressed(ctx, u.span);
+}
+
+function punchyRuns(ctx: Context, units: readonly UnitAnalysis[]): UnitAnalysis[][] {
+  const runs: UnitAnalysis[][] = [];
+  let run: UnitAnalysis[] = [];
+  for (const u of units) {
+    if (isShortFragment(ctx, u)) {
+      run.push(u);
+    } else {
+      if (run.length >= 2) runs.push(run);
+      run = [];
+    }
+  }
+  if (run.length >= 2) runs.push(run);
+  return runs;
+}
+
+function runFinding(run: UnitAnalysis[]): Finding {
+  const severity: Severity = run.length >= 3 ? "high" : "medium";
+  return {
+    ruleId: "discourse/punchy-fragments",
+    span: spanning(run),
+    severity,
+    message: `${run.length} short fragments in a row`,
+    explanation: `${run.length} verbless fragments back to back ("${run[0]!.unit}."...) is the choppy, staccato rhythm AI writing reaches for to manufacture emphasis. One fragment lands; a run of them reads like a drum machine. Let some of these be full sentences.`,
+  };
+}
+
+export const punchyFragmentsRule: TropeRule = {
+  id: "discourse/punchy-fragments",
+  name: "Short punchy fragments",
+  tier: "discourse",
+  detect(doc: DocAnalysis): Finding[] {
+    const ctx = makeContext(doc);
+    const units = doc.units;
+    const runs = punchyRuns(ctx, units);
+    if (runs.length > 0) return runs.map(runFinding);
+
+    const fragments = units.filter((u) => isShortFragment(ctx, u));
+    if (fragments.length < MIN_FRAGMENTS || units.length < MIN_UNITS) return [];
+    const density = fragments.length / units.length;
+    if (density < DENSITY_MEDIUM) return [];
+    const severity: Severity = density >= DENSITY_HIGH ? "high" : "medium";
+    const pct = Math.round(density * 100);
+    return [
+      {
+        ruleId: "discourse/punchy-fragments",
+        span: spanning(fragments),
+        severity,
+        message: `${fragments.length} short verbless fragments (${pct}% of sentences)`,
+        explanation: `${fragments.length} of this document's ${units.length} sentences are short verbless fragments — not clustered, just a recurring tic throughout. Reserve the fragment for the one moment it earns; write the rest as sentences.`,
+      },
+    ];
+  },
+};
+
+// ---------------------------------------------------------------------------------------------
+// countdown
+// ---------------------------------------------------------------------------------------------
+// "Not a bug. Not a feature. A fundamental design flaw." — 2+ consecutive negated fragments capped
+// by a unit that does NOT open with Not/No (a fragment or a full clause; "must fire even when the
+// capping unit is a full clause" per the issue). Negation is read off the unit's own first word
+// token, not a parse — "Not"/"No", case-insensitive, literally. That literal-token requirement is
+// what keeps "It's not bold. It's backwards." out: its first word token is "It's" (or "It", split by
+// the real tokenizer), never "Not", regardless of the unit's outcome.
+//
+// A run needs a cap to be a countdown at all — a trailing run with nothing after it (document ends
+// mid-count) is not a punchline and does not fire.
+
+const NEGATORS = new Set(["not", "no"]);
+
+function isNegatedFragment(ctx: Context, u: UnitAnalysis): boolean {
+  if (u.outcome !== "fragment" || suppressed(ctx, u.span)) return false;
+  const w = firstWord(u);
+  return w !== undefined && NEGATORS.has(w.toLowerCase());
+}
+
+function isCap(ctx: Context, u: UnitAnalysis): boolean {
+  if (suppressed(ctx, u.span)) return false;
+  const w = firstWord(u);
+  return w !== undefined && !NEGATORS.has(w.toLowerCase());
+}
+
+export const countdownRule: TropeRule = {
+  id: "discourse/countdown",
+  name: "The countdown",
+  tier: "discourse",
+  detect(doc: DocAnalysis): Finding[] {
+    const ctx = makeContext(doc);
+    const units = doc.units;
+    const findings: Finding[] = [];
+    let run: UnitAnalysis[] = [];
+
+    for (const u of units) {
+      if (isNegatedFragment(ctx, u)) {
+        run.push(u);
+        continue;
+      }
+      if (run.length >= 2 && isCap(ctx, u)) {
+        const severity: Severity = run.length >= 3 ? "high" : "medium";
+        findings.push({
+          ruleId: "discourse/countdown",
+          span: spanning([...run, u]),
+          severity,
+          message: `countdown — ${run.length} negated fragments, then the reveal`,
+          explanation: `"${run.map((r) => r.unit).join(". ")}." builds by ruling things out one at a time before landing on "${u.unit}." — a dramatic countdown to the actual point. Say the point; drop the runway of negations leading up to it.`,
+        });
+      }
+      run = [];
+    }
+    return findings;
+  },
+};

--- a/scripts/destink/vendor/lint/rules/ing-tackon.ts
+++ b/scripts/destink/vendor/lint/rules/ing-tackon.ts
@@ -1,0 +1,206 @@
+// Superficial "-ing" Tack-on (issue #18) — a dangling present-participle phrase glued onto the
+// end of a sentence to inject shallow significance ("...opened in 1994, highlighting its
+// importance."). The word list lives in src/lint/lexicons/superficial-ing-verbs.ts (imported
+// below, never redefined here). Per that lexicon's own header comment, an ordinary "-ing" verb is
+// not the tell — SYNTACTIC POSITION is: the verb must be (1) in the list, (2) sitting at/near the
+// clause's end, and (3) hanging loosely off the clause (a trailing modifier on the subject or
+// complement) rather than doing integrated work mid-sentence ("the dog barking furiously bit me"
+// — real information, right where the action is). All three are required; any one alone is common
+// and innocent.
+//
+// TWO DETECTION PATHS, because the rule-based parser doesn't reliably preserve the shape path 1
+// needs (see PARSER GAP below):
+//
+//   PATH 1 — IR-based (confirmed, scored at the lexicon's own defaultSeverity, "low"). Looks for
+//   Modifier{kind:"participle"} as the TRAILING modifier on the clause's subject or complement
+//   nominal (lower.ts attaches a comma-set-off participial phrase to the subject this way — see
+//   lower.ts's lowerClause, "Participial phrases set off from the subject"; the same shape covers
+//   a participle trailing the complement). "Near the clause's end" is checked by estimating the
+//   participle phrase's own word count (verb + object + its modifiers, recursively) and requiring
+//   that count to reach the unit's last word once counted forward from the participle verb's own
+//   position — since the Clause IR carries no offsets, this is an estimate, documented at
+//   nominalWordCount below, not a token-exact reconstruction.
+//
+//   PATH 2 — token-shape fallback (candidate severity, i.e. lower than path 1 — it can't confirm
+//   attachment or a real parse, only a surface pattern). Triggers on comma + a listed verb's -ing
+//   surface form within MAX_TAIL_WORDS words of the unit's end, with no parse involved at all.
+//   Applies only to units path 1 did NOT already confirm, so the same tack-on is never reported
+//   twice under two different rule findings for one span.
+//
+// PARSER GAP — reported per #18's ground rules and since CLOSED in the engine (issue #33). For the
+// exact example #18 asks about, `parse("The station opened in 1994, highlighting its importance.")`
+// used to return `(S (NP The station) (VP (VBD opened) (PP in 1994)))` and drop the trailing
+// phrase outright, so the lowered Clause carried no participle and only path 2 could catch it.
+// parse.ts now keeps a comma-set-off "-ing" phrase and lower.ts hangs it on the subject, so path 1
+// fires through readDocument — and path 2 stands down for that unit, as designed. Path 2 still
+// carries units whose parse doesn't reach path 1's shape. See ing-tackon.test.ts's end-to-end
+// describe block.
+
+import nlp from "compromise";
+import type { Clause, Compound, Modifier, Nominal } from "../../ir.js";
+import type { DocAnalysis, Finding, Severity, Span, TropeRule, UnitAnalysis } from "../types.js";
+import { POS_GATE_PREFIX, superficialIngVerbs } from "../lexicons/index.js";
+
+// See serves-as.ts for the long-form rationale of this exact technique; duplicated here (not
+// imported) so each rule file in this pair stays self-contained the way rules/demo.ts is.
+function lemmaOf(word: string): string {
+  const inf = nlp(`it ${word} that`).verbs().toInfinitive().text();
+  const stripped = inf.replace(/^it\s+/i, "").replace(/\s+that$/i, "");
+  return (stripped || word).toLowerCase();
+}
+
+const lastToken = (text: string): string => {
+  const parts = text.trim().split(/\s+/);
+  return (parts[parts.length - 1] ?? "").toLowerCase();
+};
+
+type Participle = Extract<Modifier, { kind: "participle" }>;
+
+// The two places a trailing participle can hang for #18's purposes: the clause's subject, and its
+// complement, when either is (or reduces to) a nominal. A gerund/infinitive/clause-shaped subject,
+// or a predicateAdj complement, has no nominal to carry a trailing modifier and is skipped.
+function hosts(clause: Clause): Array<Nominal | Compound<Nominal>> {
+  const out: Array<Nominal | Compound<Nominal>> = [];
+  const subj = clause.subject;
+  if ("head" in subj || "items" in subj) out.push(subj);
+  const c = clause.complement;
+  if (c && (c.kind === "directObject" || c.kind === "predicateNoun") && ("head" in c.value || "items" in c.value)) {
+    out.push(c.value);
+  }
+  return out;
+}
+
+// The LAST modifier on the host's (first, for a Compound) item, when it is a participle. "Last in
+// the array" is what "hangs loosely off the clause" means structurally here — see the file header.
+function trailingParticiple(host: Nominal | Compound<Nominal>): Participle | null {
+  const items = "items" in host ? host.items : [host];
+  const last = items[items.length - 1];
+  const lastMod = last?.modifiers[last.modifiers.length - 1];
+  return lastMod?.kind === "participle" ? lastMod : null;
+}
+
+// An approximate word count for a participle phrase (verb + object + its own modifiers,
+// recursively) used ONLY to estimate whether the phrase reaches the unit's last word — the Clause
+// IR carries no source offsets (src/lint/types.ts), so this is a count of Word-shaped leaves, not
+// a token-exact reconstruction. "clause" modifiers count as 1 (the connector) rather than
+// descending into an embedded clause, which would overcount for this rule's purposes.
+function nominalWordCount(n: Nominal | Compound<Nominal>): number {
+  const items = "items" in n ? n.items : [n];
+  return items.reduce((sum, it) => sum + 1 + it.modifiers.reduce((m, mod) => m + modifierWordCount(mod), 0), 0);
+}
+function modifierWordCount(m: Modifier): number {
+  switch (m.kind) {
+    case "word":
+      return 1;
+    case "prep":
+      return m.prep.text.trim().split(/\s+/).length + nominalWordCount(m.object);
+    case "clause":
+      return 1;
+    case "participle":
+      return 1 + (m.object ? nominalWordCount(m.object) : 0) + m.modifiers.reduce((s, x) => s + modifierWordCount(x), 0);
+  }
+}
+
+// The word-index tolerance for "near the end": the position estimate above is approximate (it
+// doesn't count determiners dropped by lowering, etc.), so a 1-word slop absorbs minor undercounts
+// without opening the door to genuinely mid-sentence participles like "the dog barking furiously
+// bit me" (there the shortfall is 3+ words, comfortably outside this slop — see the test file).
+const POSITION_SLOP = 1;
+
+function lastWordIndex(unit: UnitAnalysis, text: string): number {
+  const tok = lastToken(text);
+  for (let i = unit.words.length - 1; i >= 0; i--) if (unit.words[i]!.text.toLowerCase() === tok) return i;
+  return -1;
+}
+
+function nearUnitEnd(unit: UnitAnalysis, participleVerbText: string, approxLen: number): boolean {
+  const idx = lastWordIndex(unit, participleVerbText);
+  return idx >= 0 && idx + approxLen >= unit.words.length - POSITION_SLOP;
+}
+
+// Locates a Word's surface text among the unit's word spans (see serves-as.ts's `locate` for the
+// same technique and why it's needed — the Clause IR carries no offsets). Degrades to the unit's
+// own span when the text can't be found.
+function locate(unit: UnitAnalysis, text: string): Span {
+  const tok = lastToken(text);
+  const hit = unit.words.find((w) => w.text.toLowerCase() === tok);
+  return hit ? hit.span : unit.span;
+}
+
+const bareEntry = (lemma: string) => superficialIngVerbs.entries.find((e) => typeof e.match === "string" && e.match === lemma);
+
+// How many words after `unit.words[i]` remain before the unit ends — the fallback's own, cruder
+// stand-in for "near the end" (path 1's nominalWordCount isn't available here; there's no parse).
+const MAX_TAIL_WORDS = 6;
+
+function precedingNonSpaceChar(text: string, pos: number): string | undefined {
+  let i = pos - 1;
+  while (i >= 0 && /\s/.test(text[i]!)) i--;
+  return i >= 0 ? text[i] : undefined;
+}
+
+const SEVERITY_ORDER: Severity[] = ["candidate", "low", "medium", "high"];
+const shiftSeverity = (s: Severity, delta: number): Severity => {
+  const i = SEVERITY_ORDER.indexOf(s);
+  return SEVERITY_ORDER[Math.min(SEVERITY_ORDER.length - 1, Math.max(0, i + delta))]!;
+};
+
+type Hit = { span: Span; verbText: string; origin: "ir" | "fallback" };
+
+export const ingTackOnRule: TropeRule = {
+  id: "ing-tackon",
+  name: "Superficial -ing tack-on",
+  tier: "syntactic",
+  detect(doc: DocAnalysis): Finding[] {
+    const hits: Hit[] = [];
+    const irConfirmedUnits = new Set<UnitAnalysis>();
+
+    // --- path 1: IR-based ---
+    for (const unit of doc.units) {
+      if (!unit.clauses) continue;
+      for (const clause of unit.clauses) {
+        for (const host of hosts(clause)) {
+          const p = trailingParticiple(host);
+          if (!p) continue;
+          const lemma = lemmaOf(lastToken(p.verb.text));
+          const entry = bareEntry(lemma);
+          if (!entry) continue;
+          if (entry.posGate && p.verb.pos && !p.verb.pos.startsWith(POS_GATE_PREFIX[entry.posGate])) continue;
+          const approxLen = 1 + (p.object ? nominalWordCount(p.object) : 0) + p.modifiers.reduce((s, x) => s + modifierWordCount(x), 0);
+          if (!nearUnitEnd(unit, p.verb.text, approxLen)) continue;
+          hits.push({ span: locate(unit, p.verb.text), verbText: p.verb.text, origin: "ir" });
+          irConfirmedUnits.add(unit);
+        }
+      }
+    }
+
+    // --- path 2: token-shape fallback (skips units path 1 already confirmed) ---
+    for (const unit of doc.units) {
+      if (irConfirmedUnits.has(unit)) continue;
+      for (let i = 0; i < unit.words.length; i++) {
+        const word = unit.words[i]!;
+        if (!/ing$/i.test(word.text)) continue;
+        if (precedingNonSpaceChar(doc.text, word.span.start) !== ",") continue;
+        const entry = bareEntry(lemmaOf(word.text));
+        if (!entry) continue;
+        const tailWords = unit.words.length - 1 - i;
+        if (tailWords > MAX_TAIL_WORDS) continue;
+        hits.push({ span: word.span, verbText: word.text, origin: "fallback" });
+      }
+    }
+
+    // Count first, judge second (rules/demo.ts's contract): density is a whole-document call,
+    // computed once over every hit (both paths — they're the same trope) before severity is set.
+    const dense = hits.length >= (superficialIngVerbs.densityThreshold ?? 1);
+    const irSeverity = dense ? shiftSeverity(superficialIngVerbs.defaultSeverity, 1) : superficialIngVerbs.defaultSeverity;
+    const fallbackSeverity = dense ? superficialIngVerbs.defaultSeverity : shiftSeverity(superficialIngVerbs.defaultSeverity, -1);
+
+    return hits.map((h) => ({
+      ruleId: "ing-tackon",
+      span: h.span,
+      severity: h.origin === "ir" ? irSeverity : fallbackSeverity,
+      message: `“${h.verbText}” tacked on at the end`,
+      explanation: `A trailing “, ${h.verbText.toLowerCase()} ...” bolts significance onto a sentence that already ended — it reads as analysis but says nothing the sentence didn't already say. Cut it, or make the claim its own sentence and back it up.`,
+    }));
+  },
+};

--- a/scripts/destink/vendor/lint/rules/lexical.ts
+++ b/scripts/destink/vendor/lint/rules/lexical.ts
@@ -1,0 +1,269 @@
+// The lexical tier (issue #20) — one TropeRule per word-list Lexicon in ../lexicons/index.ts. Each
+// rule scans doc.units[].words for its lexicon's entries and reports a Finding per hit. This file
+// is the "wave-2" half of issue #20: the lexicon data files fix WHAT the trigger words are; this
+// file decides HOW a WordSpan[] gets checked against them and what a hit is worth.
+//
+// Two lexicons are skipped here on purpose: lex-serves-as-verbs and lex-superficial-ing-verbs feed
+// issue #18's syntactic rules (they need the copular-dodge query helpers and a trailing-VBG
+// position check respectively — a plain word-list scan over-fires on both, per their own file
+// comments). Building a lexical rule for them here would just get thrown away when #18 lands its
+// real version, so they are left out of LEXICAL_RULES and out of the registry.
+//
+// ---------------------------------------------------------------------------------------------
+// MATCHING SEMANTICS (the spec this file implements — see lexicons/types.ts's proposal comment
+// for the open questions this resolves):
+//
+//  Case            Every comparison lowercases the source WordSpan.text before comparing. Lexicon
+//                  data is already lowercase (enforced by the hygiene test), so no case-folding is
+//                  needed on that side.
+//
+//  Word boundary   A single-word `match` is compared against one whole WordSpan.text, never a
+//                  substring — "robust" cannot match inside "robustness" because the tokenizer
+//                  (stub-doc.ts's wordSpans, or the real analyzer's future equivalent) already
+//                  produced "robustness" as one token distinct from "robust".
+//
+//  Multi-word      A `match: string[]` is a contiguous run of tokens: entry.match[0] must equal
+//                  words[i], entry.match[1] must equal words[i+1], and so on with no gaps. The
+//                  found span is spanning() over that exact slice of WordSpans, so it covers only
+//                  the matched words and nothing around them.
+//
+//  Contractions    The lexicon data spells out contractions as one token — "it's", "here's" — on
+//                  the assumption that the tokenizer does the same. stub-doc.ts's wordRe keeps an
+//                  internal apostrophe attached to its neighbors ("it's" is one WordSpan, not
+//                  "it" + "'s"), which is exactly the convention the data was written against, so
+//                  multi-word entries like ["it's", "worth", "noting"] line up with zero special
+//                  casing here. Any other tokenizer feeding this rule must keep that same
+//                  convention or these entries silently stop matching.
+//
+//  lemma           A small, dependency-free suffix matcher (lemmaMatches, below) — not a stemmer
+//                  library, just the regular-inflection patterns the lemma:true entries in these
+//                  lexicons actually need: plain -s/-es, -ed/-ing with e-drop ("delve" ->
+//                  "delving"), and y -> ies/ied ("deny" -> "denies"/"denied"; not exercised by the
+//                  current data, kept for the next lexicon that needs it). It is deliberately
+//                  narrow: it does not know irregular verbs. That's fine for every lemma:true entry
+//                  in the lexicons this file actually builds rules for (all regular verbs); the one
+//                  lexicon with an irregular form in its notes (lex-serves-as-verbs' "stand" ->
+//                  "stood") is one of the two skipped above and is #18's problem. For a multi-word
+//                  entry, lemma applies to the FIRST token only (the phrase's head verb), matching
+//                  the per-file notes left on the data.
+//
+//  posGate         Checked against WordSpan.pos using POS_GATE_PREFIX: the gate passes when pos is
+//                  present and starts with the gate's 2-letter prefix (e.g. a "verb" gate accepts
+//                  any tag starting "VB": VB, VBD, VBG, VBN, VBP, VBZ). FAIL-CLOSED WHEN POS IS
+//                  ABSENT: an entry with a posGate simply does not match a word that carries no
+//                  pos at all, rather than treating "unknown" as "assume it passes". makeDoc (the
+//                  stub analyzer used everywhere real parsing hasn't run yet) never fills pos, so
+//                  every posGate'd entry is silent against stub documents until a real tagger is
+//                  wired in. That trades recall for precision on purpose — a linter that guesses at
+//                  a word's part of speech and is wrong reads as broken; one that stays quiet
+//                  without evidence reads as careful. posGate is ignored on multi-word entries
+//                  (the hygiene test already forbids the combination).
+//
+//  Figurative      A few entries (landscape, tapestry, invented-concept-label nouns, magic
+//  senses          adverbs) flag a sense no POS tag distinguishes from an entirely innocent literal
+//                  use ("the landscape of modern AI" vs. "hiked across the landscape"). This file
+//                  does not attempt a collocation or embedding heuristic for that — per the data
+//                  author's note, it's an accepted design trade this rule makes: these lexicons
+//                  keep densityThreshold set specifically so an occasional literal false positive
+//                  doesn't score high on its own, but they can still fire on a single literal use.
+//
+//  Severity        finding.severity = entry.severity ?? lexicon.defaultSeverity, then adjusted for
+//                  density (below).
+//
+//  Density         CHOSEN SEMANTICS (the data author left this open in lexicons/types.ts): when a
+//                  lexicon declares densityThreshold N, count every hit from every entry in that
+//                  lexicon across the WHOLE document. If that total is below N, every hit whose
+//                  entry did NOT specify its own `severity` (i.e. it's riding the lexicon's
+//                  defaultSeverity) is reported one severity step lower than usual, floored at
+//                  "candidate" (never negative, never dropped). At or above N, hits score at their
+//                  normal severity. An entry with an explicit `severity` override is exempt from
+//                  this downgrade in both directions — that override exists specifically to mark an
+//                  entry as a strong-enough signal on its own regardless of density (e.g. "delve",
+//                  whose note says as much). Steps run candidate < low < medium < high.
+// ---------------------------------------------------------------------------------------------
+
+import type { DocAnalysis, Finding, Severity, Span, TropeRule, WordSpan } from "../types.js";
+import { spanning, textAt } from "../span.js";
+import { LEXICONS, POS_GATE_PREFIX, type Lexicon, type LexiconEntry } from "../lexicons/index.js";
+
+// Lexicons that feed issue #18's structural rules instead of getting a plain word-list scan here.
+const STRUCTURAL_LEXICON_IDS = new Set(["lex-serves-as-verbs", "lex-superficial-ing-verbs"]);
+
+// --- lemma matching ------------------------------------------------------------------------
+
+// True when `word` is `base` or one of its regular inflections. See the file-level comment above
+// for exactly which suffix patterns this covers and why that's enough for this data.
+export function lemmaMatches(base: string, word: string): boolean {
+  const b = base.toLowerCase();
+  const w = word.toLowerCase();
+  if (w === b) return true;
+
+  if (/[^aeiou]y$/.test(b)) {
+    // deny -> denies / denied (y -> ies/ied after a consonant). -ing keeps the y (denying), which
+    // plain concatenation below already produces, so it isn't special-cased here.
+    const stem = b.slice(0, -1);
+    if (w === `${stem}ies` || w === `${stem}ied`) return true;
+  } else if (w === `${b}s` || w === `${b}es`) {
+    return true;
+  }
+
+  if (b.endsWith("e")) {
+    // delve -> delved / delving (drop the trailing e before -ing; -ed just appends d).
+    const stem = b.slice(0, -1);
+    if (w === `${b}d` || w === `${stem}ing`) return true;
+  } else if (w === `${b}ed` || w === `${b}ing`) {
+    return true;
+  }
+
+  return false;
+}
+
+// --- entry matching -------------------------------------------------------------------------
+
+function posGateFails(entry: LexiconEntry, word: WordSpan): boolean {
+  if (!entry.posGate) return false;
+  if (!word.pos) return true; // fail closed: no POS evidence, no match
+  return !word.pos.startsWith(POS_GATE_PREFIX[entry.posGate]);
+}
+
+function singleWordHits(entry: LexiconEntry, match: string, words: WordSpan[]): Span[] {
+  const hits: Span[] = [];
+  for (const w of words) {
+    const textMatches = entry.lemma ? lemmaMatches(match, w.text) : w.text.toLowerCase() === match;
+    if (!textMatches) continue;
+    if (posGateFails(entry, w)) continue;
+    hits.push(w.span);
+  }
+  return hits;
+}
+
+function phraseHits(entry: LexiconEntry, tokens: string[], words: WordSpan[]): Span[] {
+  const hits: Span[] = [];
+  for (let i = 0; i + tokens.length <= words.length; i++) {
+    let ok = true;
+    for (let j = 0; j < tokens.length; j++) {
+      const w = words[i + j]!;
+      const isHead = j === 0;
+      const wordMatches = isHead && entry.lemma ? lemmaMatches(tokens[j]!, w.text) : w.text.toLowerCase() === tokens[j];
+      if (!wordMatches) {
+        ok = false;
+        break;
+      }
+    }
+    if (ok) hits.push(spanning(words.slice(i, i + tokens.length)));
+  }
+  return hits;
+}
+
+// Exported for claude-lexicon.ts, which reuses the exact matching semantics with different
+// severity semantics (single-hit, escalation-only — see that file).
+export function entryHits(entry: LexiconEntry, words: WordSpan[]): Span[] {
+  return Array.isArray(entry.match) ? phraseHits(entry, entry.match, words) : singleWordHits(entry, entry.match, words);
+}
+
+// --- severity / density ----------------------------------------------------------------------
+
+const SEVERITY_STEPS: readonly Severity[] = ["candidate", "low", "medium", "high"];
+
+function stepDown(s: Severity): Severity {
+  const i = SEVERITY_STEPS.indexOf(s);
+  return SEVERITY_STEPS[Math.max(0, i - 1)]!;
+}
+
+// --- rule factory ----------------------------------------------------------------------------
+
+function buildLexiconRule(lexicon: Lexicon, explanation: string): TropeRule {
+  return {
+    id: lexicon.id,
+    name: lexicon.name,
+    tier: "lexical",
+    detect(doc: DocAnalysis): Finding[] {
+      const rawHits: { entry: LexiconEntry; span: Span }[] = [];
+      for (const unit of doc.units) {
+        for (const entry of lexicon.entries) {
+          for (const span of entryHits(entry, unit.words)) rawHits.push({ entry, span });
+        }
+      }
+      if (rawHits.length === 0) return [];
+
+      const total = rawHits.length;
+      const findings: Finding[] = rawHits.map(({ entry, span }) => {
+        const base = entry.severity ?? lexicon.defaultSeverity;
+        const belowDensity =
+          entry.severity === undefined && lexicon.densityThreshold !== undefined && total < lexicon.densityThreshold;
+        const severity = belowDensity ? stepDown(base) : base;
+        const matchedText = textAt(doc, span);
+        return {
+          ruleId: lexicon.id,
+          span,
+          severity,
+          message: `${lexicon.name}: “${matchedText}”`,
+          explanation,
+        };
+      });
+
+      findings.sort((a, b) => a.span.start - b.span.start || a.span.end - b.span.end);
+      return findings;
+    },
+  };
+}
+
+// --- per-lexicon explanations (free.ts hint voice: concrete, second person, one example, no
+// lecture) — one per rule, reused for every finding that rule produces. -------------------------
+
+const EXPLANATIONS: Record<string, string> = {
+  "lex-delve-family": `"Delve", "utilize", "leverage", "robust", "streamline", "harness", "certainly" ` +
+    `used to be uncommon words; AI writing wore them smooth. Swap in the plain version: delve becomes ` +
+    `look into, utilize becomes use, leverage (as a verb) becomes use or draw on.`,
+  "lex-ornate-nouns": `"Tapestry", "landscape", "paradigm", "synergy", "ecosystem" dress up an ordinary ` +
+    `noun in a costume. Say what you mean instead: the field, not the landscape; the approach, not the ` +
+    `paradigm.`,
+  "lex-filler-transitions": `"It's worth noting", "it bears mentioning", "importantly", "interestingly", ` +
+    `"notably" announce that a point is coming without connecting it to the one before. Cut the phrase ` +
+    `and open with the point itself.`,
+  "lex-false-suspense": `"Here's the kicker", "here's the thing", "here's where it gets interesting" ` +
+    `promise a reveal, then land on something ordinary. State the fact and skip the drumroll.`,
+  "lex-pedagogical-voice": `"Let's break this down", "let's unpack", "think of it as" switch into ` +
+    `teacher mode even for a reader who already knows the material. Say the thing plainly and trust the ` +
+    `reader to follow.`,
+  "lex-signposts": `"In conclusion", "to sum up", "in summary" announce that the piece is ending instead ` +
+    `of just ending it. A reader feels the last paragraph coming; you don't need to label it.`,
+  "lex-stakes-inflation": `"Fundamentally reshape", "will define the next era", "entirely new" turn an ` +
+    `ordinary claim into a world-historical one. Scale the language to match the actual claim.`,
+  "lex-vague-attribution": `"Experts argue", "observers have cited", "industry reports suggest" pin a ` +
+    `claim on nobody in particular. Name the source, or admit the claim is your own.`,
+  "lex-invented-concept-labels": `"Paradox", "trap", "creep", "divide", "vacuum", "inversion" tacked onto ` +
+    `a plain noun can dress up an ordinary observation as a named phenomenon, like "the supervision ` +
+    `paradox". If the label isn't an established term, describe the thing instead of naming it.`,
+  "lex-magic-adverbs": `"Quietly", "deeply", "fundamentally", "remarkably", "arguably" get reached for to ` +
+    `make a mundane sentence feel weighty. Try the sentence without the adverb; if it loses nothing, ` +
+    `that's the tell.`,
+};
+
+// --- the rules --------------------------------------------------------------------------------
+
+const lexiconById = new Map(LEXICONS.map((l) => [l.id, l]));
+
+function ruleFor(id: string): TropeRule {
+  const lexicon = lexiconById.get(id);
+  if (!lexicon) throw new Error(`lexical.ts: no lexicon registered with id ${id}`);
+  const explanation = EXPLANATIONS[id];
+  if (!explanation) throw new Error(`lexical.ts: no explanation written for ${id}`);
+  return buildLexiconRule(lexicon, explanation);
+}
+
+// Alphabetical by rule id, matching how registry.ts orders them.
+export const lexDelveFamilyRule = ruleFor("lex-delve-family");
+export const lexFalseSuspenseRule = ruleFor("lex-false-suspense");
+export const lexFillerTransitionsRule = ruleFor("lex-filler-transitions");
+export const lexInventedConceptLabelsRule = ruleFor("lex-invented-concept-labels");
+export const lexMagicAdverbsRule = ruleFor("lex-magic-adverbs");
+export const lexOrnateNounsRule = ruleFor("lex-ornate-nouns");
+export const lexPedagogicalVoiceRule = ruleFor("lex-pedagogical-voice");
+export const lexSignpostsRule = ruleFor("lex-signposts");
+export const lexStakesInflationRule = ruleFor("lex-stakes-inflation");
+export const lexVagueAttributionRule = ruleFor("lex-vague-attribution");
+
+export const LEXICAL_RULES: readonly TropeRule[] = LEXICONS.filter((l) => !STRUCTURAL_LEXICON_IDS.has(l.id)).map((l) =>
+  ruleFor(l.id),
+);

--- a/scripts/destink/vendor/lint/rules/mirrored-clauses.ts
+++ b/scripts/destink/vendor/lint/rules/mirrored-clauses.ts
@@ -1,0 +1,259 @@
+// MIRRORED CLAUSES (claude-isms tier, #34) — two adjacent clauses poured into the same mould with
+// the content words swapped out:
+//
+//   "Products impress people; platforms empower them."
+//   "Engineers write code. Managers write memos."
+//
+// Same skeleton on both sides, two contrasting plural nouns in the subject slot, both halves the
+// same length. Read one and you have read the other; the second clause exists for the symmetry,
+// not for anything it adds. Detected over the Clause IR rather than by string shape, because the
+// string is the least stable part of it — the semicolon, the period and the dash are all the same
+// pattern once the units are lowered.
+//
+// --- the pattern ---
+// A pair of ADJACENT clauses (consecutive clauses of one lowered unit, or the last clause of one
+// unit against the first clause of the next — unit boundaries are sentence boundaries and ";" /
+// ":", so the semicolon form and the two-sentence form are one code path) where ALL of:
+//
+//   affirmative     neither clause is negated. reframe.ts (#14) owns denied-then-replaced pairs;
+//                   requiring both sides affirmative is the seam between the two rules, and it is
+//                   what keeps "Products are not tools. Platforms are worlds." out of here.
+//   different heads the two subject heads differ. anaphora.ts owns same-subject repeats
+//                   ("Platforms empower people. Platforms create worlds."); a shared subject head
+//                   is that rule's signal, not this one's.
+//   plural, bare    BOTH subject heads are plural, non-pronominal nouns — the products/platforms
+//                   shape, two generic categories being set against each other. This is the single
+//                   biggest precision lever in the file: ordinary narrative prose ("The dog chased
+//                   the ball. A cat slept on the sill.") has singular subjects and never qualifies.
+//   same skeleton   both TRANSITIVE (a directObject complement) or both COPULAR (isCopular — a
+//                   be-form with a predicate noun/adjective). predicateNoun and predicateAdj are
+//                   one bucket on purpose: the rule-based chunker cheerfully tags "engines" in
+//                   "Products are engines" as a predicate adjective, and splitting the bucket would
+//                   make the rule's answer depend on that coin flip.
+//   swapped content the complement heads differ too. Same frame AND the same object is one sentence
+//                   restated, which is repetition.ts's territory, not a mirror.
+//   bare frame      no prepositional phrase, subordinate clause or participial phrase anywhere in
+//                   either clause, and no indirect object. A mirror is a tight subject-verb-object
+//                   (or subject-be-complement) frame; this is what keeps out the sentences the
+//                   rule-based chunker parses into the same shape by accident, e.g. "Birds gathered
+//                   near a feeder by the fence. Markets closed early ahead of the holiday weekend."
+//                   — two directObject clauses by the IR's reckoning, with the PPs folded into the
+//                   object and the indirect-object slot, and not a mirror by anyone's.
+//   same weight     clause lengths (words walked out of the IR) within LENGTH_SLACK tokens. The
+//                   trope is metrically matched; a long clause beside a short one is not a mirror
+//                   however well its parts line up.
+//
+// --- what it deliberately does not catch ---
+//   * intransitive mirrors — "Products scale linearly; platforms scale exponentially." A null
+//     complement carries no skeleton to match on, so admitting it would fire on any two adjacent
+//     plural-subject sentences of similar length ("Birds gathered near the feeder. Markets closed
+//     early ahead of the holiday.") — which is prose, not a mirror. Known false negative, taken
+//     on purpose.
+//   * singular mirrors — "The product impresses; the platform empowers." Real, and out of reach
+//     without knowing that "product" and "platform" are contrastable categories.
+//   * mirrors spanning a clause that failed to lower. Nothing lowered means nothing to compare.
+//   * the chained middle. A clause belongs to ONE mirror: three mirrored sentences in a row report
+//     as one pair plus a leftover, not as two pairs sharing the middle clause. Without that, an
+//     ordinary sentence sandwiched between two plural-subject sentences of the same shape would
+//     pull both into overlapping findings and double the density count.
+//
+// This is the most precision-risky rule in the tier, so severity starts a notch lower than the
+// others': one pair is a "candidate" (structurally narrowed, unconfirmable without semantics — the
+// same honesty false-range.ts uses), two are "low", three or more "medium". A writer who does this
+// three times in a piece is not varying sentence shape at all, which is the thing worth saying.
+
+import type { Clause, Compound, Complement, Infinitive, Gerund, Modifier, Nominal, Predicate, Word } from "../../ir.js";
+import { complementHead, isCopular, isNegated, subjectHead, subjectIsPronominal } from "../ir-query.js";
+import { spanning } from "../span.js";
+import type { DocAnalysis, Finding, Severity, Span, TropeRule } from "../types.js";
+
+const RULE_ID = "claude/mirrored-clauses";
+
+const LENGTH_SLACK = 2; // clause lengths may differ by at most this many words
+
+// --- clause length -----------------------------------------------------------------------------
+// Walked out of the IR rather than taken from the unit's word count, because an in-unit pair shares
+// one unit and there would be nothing to compare. A verb head may itself be a phrase ("has been
+// running"), so words are counted by splitting each Word's text.
+
+const wordsIn = (w: Word): number => w.text.trim().split(/\s+/).filter(Boolean).length;
+
+const sum = (ns: number[]): number => ns.reduce((a, b) => a + b, 0);
+
+function modifierWords(m: Modifier): number {
+  switch (m.kind) {
+    case "word":
+      return wordsIn(m.value);
+    case "prep":
+      return wordsIn(m.prep) + nominalWords(m.object);
+    case "clause":
+      return wordsIn(m.connector) + clauseWords(m.value);
+    case "participle":
+      return wordsIn(m.verb) + (m.object ? nominalWords(m.object) : 0) + sum(m.modifiers.map(modifierWords));
+  }
+}
+
+function nominalWords(n: Nominal): number {
+  return wordsIn(n.head) + sum(n.modifiers.map(modifierWords)) + (n.appositive ? wordsIn(n.appositive) : 0);
+}
+
+const nominalOrCompoundWords = (n: Nominal | Compound<Nominal>): number =>
+  "items" in n ? wordsIn(n.conjunction) + sum(n.items.map(nominalWords)) : nominalWords(n);
+
+const verbalWords = (v: { head: Word; modifiers: Modifier[]; indirectObject?: Nominal }): number =>
+  wordsIn(v.head) + sum(v.modifiers.map(modifierWords)) + (v.indirectObject ? nominalWords(v.indirectObject) : 0);
+
+const verbalOrInfinitiveWords = (v: Infinitive | Gerund): number =>
+  wordsIn(v.verb) + (v.object ? nominalWords(v.object) : 0) + sum(v.modifiers.map(modifierWords));
+
+function predicateWords(p: Predicate): number {
+  if (!("items" in p)) return verbalWords(p);
+  return wordsIn(p.conjunction) + sum(p.items.map((part) => verbalWords(part.verb) + (part.complement ? complementWords(part.complement) : 0)));
+}
+
+function complementWords(c: Complement): number {
+  switch (c.kind) {
+    case "predicateAdj":
+      return "items" in c.value ? wordsIn(c.value.conjunction) + sum(c.value.items.map(wordsIn)) : wordsIn(c.value);
+    case "predicateNoun":
+      return nominalOrCompoundWords(c.value);
+    case "directObject":
+      if ("head" in c.value) return nominalWords(c.value);
+      if ("items" in c.value) return nominalOrCompoundWords(c.value);
+      if ("kind" in c.value) return verbalOrInfinitiveWords(c.value);
+      return clauseWords(c.value);
+    case "objectComplement":
+      return nominalOrCompoundWords(c.object) + ("head" in c.oc ? nominalWords(c.oc) : wordsIn(c.oc));
+  }
+}
+
+function subjectWords(s: Clause["subject"]): number {
+  if ("head" in s) return nominalWords(s);
+  if ("items" in s) return nominalOrCompoundWords(s);
+  if ("kind" in s) return verbalOrInfinitiveWords(s);
+  return clauseWords(s);
+}
+
+function clauseWords(c: Clause): number {
+  return subjectWords(c.subject) + predicateWords(c.verb) + (c.complement ? complementWords(c.complement) : 0);
+}
+
+// --- subject shape -----------------------------------------------------------------------------
+
+const PLURAL_TAGS = new Set(["NNS", "NNPS"]);
+const NOUN_TAGS = new Set(["NN", "NNP", "NNS", "NNPS"]);
+
+// Plural by the tag when the parse supplies one, by surface form when the tag is a singular noun
+// tag the chunker guessed wrong (it routinely calls a capitalized sentence-initial "Products" an
+// NNP). "-ss" endings are excluded so "business" / "process" are not read as plurals; a stray
+// "-is" singular ("analysis") is a known, accepted miss of that heuristic.
+function isPluralNoun(w: Word): boolean {
+  if (w.pos && PLURAL_TAGS.has(w.pos)) return true;
+  if (w.pos && !NOUN_TAGS.has(w.pos)) return false;
+  const lc = w.text.toLowerCase();
+  return lc.length >= 4 && /[^s]s$/.test(lc);
+}
+
+const contrastableSubject = (c: Clause): Word | null => {
+  const head = subjectHead(c);
+  if (!head || subjectIsPronominal(c) || !isPluralNoun(head)) return null;
+  return head;
+};
+
+// --- skeleton ----------------------------------------------------------------------------------
+
+type Skeleton = "transitive" | "copular";
+
+function skeletonOf(c: Clause): Skeleton | null {
+  if (isCopular(c)) return "copular";
+  if (c.complement?.kind === "directObject") return "transitive";
+  return null;
+}
+
+// --- bareness ------------------------------------------------------------------------------------
+// The mirror is a tight frame: subject, verb, object, nothing hanging off any of them. Requiring
+// that is what separates "Products impress people" from the sentence the chunker parses into the
+// same SHAPE but that nobody would call mirrored — "Birds gathered near a feeder by the fence"
+// lowers to a directObject too, with the PP folded into the object's modifiers and "near" parked in
+// the indirect-object slot. Determiners and adjectives are fine; a prepositional phrase, a
+// subordinate clause or a participial phrase anywhere in the frame is not.
+const HEAVY = new Set<Modifier["kind"]>(["prep", "clause", "participle"]);
+const isLight = (ms: readonly Modifier[]): boolean => !ms.some((m) => HEAVY.has(m.kind));
+
+const bareNominal = (n: Nominal | Compound<Nominal>): boolean =>
+  "items" in n ? n.items.every(bareNominal) : isLight(n.modifiers);
+
+function bareFrame(c: Clause): boolean {
+  if ("items" in c.verb) return false; // a compound predicate is not a frame you can mirror
+  if (c.verb.indirectObject || !isLight(c.verb.modifiers)) return false;
+  if ("head" in c.subject ? !isLight(c.subject.modifiers) : !("items" in c.subject && bareNominal(c.subject))) return false;
+  const comp = c.complement;
+  if (!comp) return false;
+  if (comp.kind === "predicateAdj") return true; // a Word (or a compound of Words): nothing to hang off
+  if (comp.kind === "predicateNoun") return bareNominal(comp.value);
+  if (comp.kind !== "directObject") return false;
+  if ("head" in comp.value) return isLight(comp.value.modifiers);
+  return "items" in comp.value ? bareNominal(comp.value) : false;
+}
+
+const same = (a: Word, b: Word): boolean => a.text.toLowerCase() === b.text.toLowerCase();
+
+type Pair = { span: Span; a: Word; b: Word; skeleton: Skeleton };
+
+function mirroredPair(a: Clause, b: Clause, span: Span): Pair | null {
+  if (isNegated(a) || isNegated(b)) return null; // reframe.ts owns the negated pairs
+  const sa = contrastableSubject(a), sb = contrastableSubject(b);
+  if (!sa || !sb || same(sa, sb)) return null; // anaphora.ts owns the same-subject repeats
+  const ka = skeletonOf(a), kb = skeletonOf(b);
+  if (!ka || ka !== kb) return null;
+  if (!bareFrame(a) || !bareFrame(b)) return null;
+  const ca = complementHead(a), cb = complementHead(b);
+  if (!ca || !cb || same(ca, cb)) return null;
+  if (Math.abs(clauseWords(a) - clauseWords(b)) > LENGTH_SLACK) return null;
+  return { span, a: sa, b: sb, skeleton: ka };
+}
+
+// --- findings ----------------------------------------------------------------------------------
+
+const severityFor = (count: number): Severity => (count >= 3 ? "medium" : count === 2 ? "low" : "candidate");
+
+export const mirroredClausesRule: TropeRule = {
+  id: RULE_ID,
+  name: "Mirrored clauses (parallel frames, swapped content)",
+  tier: "syntactic",
+  detect(doc: DocAnalysis): Finding[] {
+    // Every clause of the document, flattened in order, each remembering the unit it came from.
+    // Adjacency is then a single sweep, and "consecutive clauses of one unit" and "last clause of
+    // one unit against the first of the next" stop being two code paths.
+    const flat = doc.units.flatMap((unit) => (unit.clauses ?? []).map((clause) => ({ clause, unit })));
+
+    const pairs: Pair[] = [];
+    for (let i = 0; i + 1 < flat.length; ) {
+      const [x, y] = [flat[i]!, flat[i + 1]!];
+      const span = x.unit === y.unit ? x.unit.span : spanning([x.unit, y.unit]);
+      const pair = mirroredPair(x.clause, y.clause, span);
+      if (!pair) {
+        i++;
+        continue;
+      }
+      pairs.push(pair);
+      i += 2; // a clause belongs to one mirror: a run of three mirrored sentences is one pair plus
+      // a leftover, not two overlapping pairs chained through the middle clause.
+    }
+
+    const severity = severityFor(pairs.length);
+    const density = pairs.length >= 2 ? ` You build ${pairs.length} of these in this piece — at that rate the symmetry is the only thing the reader hears.` : "";
+
+    return pairs.map((p) => ({
+      ruleId: RULE_ID,
+      span: p.span,
+      severity,
+      message: `Mirrored clauses: “${p.a.text}” and “${p.b.text}” in the same ${p.skeleton === "copular" ? "copular" : "subject-verb-object"} frame`,
+      explanation:
+        `Both halves run the same grammar with the words swapped — “${p.a.text}” does one thing, “${p.b.text}” does its opposite, ` +
+        `at matching length. The symmetry sounds like an insight, but the second half only restates the first from the other side; ` +
+        `nothing in it had to be true. Keep the claim you can back up and write it once, then spend the saved clause on why it matters.` +
+        density,
+    }));
+  },
+};

--- a/scripts/destink/vendor/lint/rules/reframe.ts
+++ b/scripts/destink/vendor/lint/rules/reframe.ts
@@ -1,0 +1,357 @@
+// NEGATIVE PARALLELISM — "It's not X. It's Y." (#14). The most-identified AI tell, detected as a
+// SHAPE in the Clause IR rather than as a string pattern, because the string is the least stable
+// part of it. "It's not bold — it's backwards", "That isn't boldness. That's backwardness", "The
+// question isn't the cost; the question is the timeline" share no substring worth matching, but
+// they share one structure:
+//
+//     clause A: subject + copula + NOT + predicate noun/adjective
+//     clause B: the same subject + copula + predicate noun/adjective, affirmative
+//     A and B adjacent
+//
+// That is the whole detector. Everything else here is locating it in the source, deciding how
+// loudly to complain, and one extra signal (lexical echo) that sharpens the message.
+//
+// Density decides severity, not the individual hit. A writer can land this once on purpose; the
+// tell is doing it over and over, and only a rule holding the whole document can see that. One
+// pair is "low", two "medium", three or more "high" — counted across the document, in one place,
+// after every pair has been found.
+//
+// --- what the parser actually gives us today ---
+//
+// The rule reads whatever DocAnalysis carries and never re-parses, so what it can catch depends on
+// what lowered. On the no-model (rule-based chunker) path, as of this writing:
+//
+//   two units, uncontracted   "That is not boldness. That is backwardness."   -> two lowered units,
+//                             one copular clause each. Caught.
+//   semicolon / colon         "The problem was not the code; it was your head." -> the splitter
+//                             (src/document.ts) treats ";" and ":" as unit boundaries, so this
+//                             arrives as two ADJACENT UNITS and is caught by the same path.
+//   contracted                "It's not bold. It's backwards."   -> NOT caught: the rule-based
+//                             tagger drops the contracted copula, so the unit comes back a
+//                             fragment with no clauses at all (engine bug #31 — not this rule's to
+//                             fix). Nothing lowered means nothing to inspect. A model parser, or
+//                             #31, makes these work with no change here.
+//   em-dash / comma splice    "That is not boldness — it is backwardness."  -> ONE unit, and the
+//                             rule-based chunker lowers it to ONE mangled clause (the second half
+//                             is folded into the first clause's complement or dropped). So the
+//                             dash variant is not caught on that path today. It is not a separate
+//                             code path though: when a parser lowers such a unit to two clauses,
+//                             the in-unit pass below catches it, which is why "adjacent" means
+//                             "consecutive clauses of one unit" as well as "consecutive units".
+//
+// The "not because X, but because Y" variant is handled separately and deliberately differently:
+// see BECAUSE-VARIANT below.
+
+import type { Clause, Word } from "../../ir.js";
+import type { DocAnalysis, Finding, Severity, Span, TropeRule, UnitAnalysis } from "../types.js";
+import { complementHead, hasAbsoluteAdverb, isCopular, isNegated, subjectHead, subjectIsPronominal } from "../ir-query.js";
+
+const RULE_ID = "reframe";
+
+// --- tokens ---
+
+// Words of a unit, lowercased, possessive stripped ("innovation's" -> "innovation"). Prefers the
+// offsets the analysis already mapped; falls back to scanning the unit's own text, because
+// UnitAnalysis.words is empty on any path that built units without a word mapping (a bare
+// readDocument DocUnit widened into a UnitAnalysis, for one). Only the echo check reads these, so
+// the fallback is about not going blind, not about offsets.
+const wordRe = /[\p{L}\p{N}]+(?:['‘’ʼ-][\p{L}\p{N}]+)*/gu;
+const normalize = (w: string): string => w.toLowerCase().replace(/['‘’ʼ]s$/, "");
+const unitTokens = (u: UnitAnalysis): string[] =>
+  (u.words.length > 0 ? u.words.map((w) => w.text) : (u.unit.match(wordRe) ?? [])).map(normalize);
+
+// Where the negation sits, for the start of the reported span. "not" as its own word, the
+// contraction fused onto the verb ("isn't", "wasn't"), or "never" (#34 — isNegated now covers it
+// too, see ir-query.ts, and it never fuses the way "n't" does, so it only ever shows up as its own
+// word here). Falls back to the start of the unit when there are no word offsets to point at — a
+// span covering the whole unit is still honest, it is just blunter than "starting at the word that
+// does the denying".
+const isNegator = (w: string): boolean => /^not$/i.test(w) || /n't$/i.test(w) || /^never$/i.test(w);
+function negationStart(u: UnitAnalysis): number {
+  const hit = u.words.find((w) => isNegator(w.text));
+  return hit ? hit.span.start : u.span.start;
+}
+
+// --- coreference ---
+
+// The two clauses have to be about the same thing, or this is just two sentences that happen to
+// both use "is". Three ways to believe they corefer, in order of how sure we are:
+//
+//   1. both subjects pronominal/demonstrative — "It … It", "This … That". The referent is thin
+//      enough in both that the reader carries it across.
+//   2. the same head noun, compared case-insensitively — "The question … The question". No
+//      lemmatization: "The questions … The question" does NOT match. Stemming English properly is
+//      a dependency this rule will not take, and the plural/singular flip is rare in this pattern
+//      (the trope repeats the noun verbatim; that repetition is half of what makes it a tell).
+//   3. a full noun phrase answered by a back-referring pronoun — "The problem was not the code; it
+//      was your head." Only third-person anaphors count here: "The report was not a summary. I was
+//      furious." is two subjects, not one.
+//
+// Direction matters for arm 3. Full-NP-then-pronoun is anaphora and common; pronoun-then-full-NP
+// ("It is not the code. The problem is your head.") is cataphora, much rarer, and much more likely
+// to be two genuinely different subjects — so it does not match.
+const ANAPHORS = new Set(["it", "this", "that", "they", "these", "those"]);
+
+function corefer(a: Clause, b: Clause): boolean {
+  const ha = subjectHead(a), hb = subjectHead(b);
+  if (!ha || !hb) return false;
+  const pa = subjectIsPronominal(a), pb = subjectIsPronominal(b);
+  if (pa && pb) return true;
+  if (ha.text.toLowerCase() === hb.text.toLowerCase()) return true;
+  return !pa && pb && ANAPHORS.has(hb.text.toLowerCase());
+}
+
+// --- the pattern ---
+
+// Denied, then replaced. isCopular carries the complement requirement for both sides: a be-verb
+// with nothing predicated of the subject ("It is not here. It is there.") fails it, and so does a
+// verb chain that only ends in a be-form by accident ("It is not running. It is walking.").
+//
+// #34's never/always variant needs no separate predicate here: isNegated now covers "never" too
+// (see ir-query.ts), so "It was never bold. It was always safe." already satisfies this — a
+// negated (via "never") copular clause followed by an affirmative copular one, same referent. The
+// only thing that variant adds on top is a severity bump when "always" is the word making clause B
+// affirmative (see strongPair below); a plain affirmative with no "always" still fires here, just
+// without the bump ("It was never bold. It was safe.").
+const isReframePair = (a: Clause, b: Clause): boolean =>
+  isCopular(a) && isNegated(a) && isCopular(b) && !isNegated(b) && corefer(a, b);
+
+// --- ABOUT-VARIANT: "It was never about X. It was always about Y." ---
+//
+// isCopular requires clause.complement to be a predicateNoun/predicateAdj, but that is not what the
+// rule-based lowerer gives a copula followed by a bare prepositional phrase: "It was never about
+// the money" lowers with complement: null and "about the money" riding as a "prep" MODIFIER on the
+// verb instead (see lower.ts — a PP after a copula with nothing else to attach to falls onto the
+// verbal, not the complement slot). isCopular correctly says false for that shape; it just isn't the
+// shape this variant is made of, so this is a second, narrower predicate for it: the same be-form
+// check as isCopular, without the complement requirement, plus a same-clause "about" prep modifier
+// to stand in for the missing complement.
+const BE_FORMS = new Set(["be", "am", "is", "are", "was", "were", "been", "being"]);
+const lastToken = (text: string): string => (text.trim().split(/\s+/).pop() ?? "").toLowerCase();
+function isBeVerb(clause: Clause): boolean {
+  if (!("head" in clause.verb)) return false; // compound predicate — no single head to check
+  const last = lastToken(clause.verb.head.text);
+  return BE_FORMS.has(last) || BE_FORMS.has(last.replace(/n't$/i, ""));
+}
+
+function aboutHead(clause: Clause): Word | null {
+  if (!("head" in clause.verb)) return null;
+  const hit = clause.verb.modifiers.find((m) => m.kind === "prep" && m.prep.text.toLowerCase() === "about");
+  return hit && hit.kind === "prep" ? hit.object.head : null;
+}
+
+const isAboutPair = (a: Clause, b: Clause): boolean =>
+  isBeVerb(a) && isNegated(a) && isBeVerb(b) && !isNegated(b) && aboutHead(a) !== null && aboutHead(b) !== null && corefer(a, b);
+
+// Either shape counts as the reframe: the ordinary predicate-noun/adjective form, or the about-PP
+// form the ordinary isCopular can't see.
+const isReframePairAny = (a: Clause, b: Clause): boolean => isReframePair(a, b) || isAboutPair(a, b);
+
+// The head naming what was denied/offered, for the message: the ordinary complement, or (when
+// isCopular's complement is null) the about-PP's object — whichever the clause actually has.
+const pairHead = (c: Clause): Word | null => complementHead(c) ?? aboutHead(c);
+
+// The never/always STRONG bonus (#34): both sides carrying their respective absolute adverb is a
+// stronger signal than a bare "never … affirmative" pair, so it earns one severity step up over the
+// document's count-scaled severity (see the bump/strong handling in reframeRule.detect below).
+const strongPair = (a: Clause, b: Clause): boolean => hasAbsoluteAdverb(a) === "never" && hasAbsoluteAdverb(b) === "always";
+
+// Lexical echo, the bonus signal: clause A's complement head coming back inside clause B — "It is
+// not innovation. It is innovation wearing old clothes." The word is denied and then handed back,
+// which is the pattern at its most circular, so the message says so.
+//
+// Counted over the source tokens rather than walked out of the IR, so it survives the words a
+// parser dropped. When both clauses live in the SAME unit, one occurrence is clause A's own
+// complement — hence the >= 2 threshold there. Short words are skipped: "It is not it" is noise,
+// not echo.
+const ECHO_MIN_LENGTH = 4;
+function echoedWord(a: Clause, unitB: UnitAnalysis, sameUnit: boolean): string | null {
+  const head = pairHead(a);
+  if (!head) return null;
+  const word = normalize(head.text);
+  if (word.length < ECHO_MIN_LENGTH) return null;
+  const hits = unitTokens(unitB).filter((t) => t === word).length;
+  return hits >= (sameUnit ? 2 : 1) ? head.text : null;
+}
+
+// --- BECAUSE-VARIANT: "not because X, but because Y" ---
+//
+// The same reframe with the contrast moved into the reasons. Detected from TOKEN SHAPE, not from
+// the IR, and that is a considered choice: the rule-based chunker lowers "He left not because he
+// was tired, but because he was bored" to one clause carrying ONE because-modifier — the second
+// because-clause is dropped in lowering, so the paired structure the pattern is made of is simply
+// not in the IR to query. Matching the token sequence (a negator, then "because", then "but", then
+// "because", in that order, inside one unit) recovers it without pretending the IR knows.
+//
+// It stays narrow on purpose. The bare "not X, but Y" form is left alone: "not a request but an
+// order" is ordinary English contrast, and firing on every "not … but" would bury the signal.
+// When the IR starts keeping both because-clauses, this can move to the modifier list and become
+// as structural as the rest of the file.
+const SEQUENCE = ["because", "but", "because"];
+function becauseVariant(u: UnitAnalysis): Span | null {
+  const tokens = unitTokens(u);
+  let i = tokens.findIndex(isNegator);
+  if (i < 0) return null;
+  for (const want of SEQUENCE) {
+    i = tokens.indexOf(want, i + 1);
+    if (i < 0) return null;
+  }
+  return { start: negationStart(u), end: u.span.end };
+}
+
+// --- COMMA-VARIANT: "It was never about the money, it was always about control." (#34) ---
+//
+// The owner's original example ("it was never X, it was always Y") is one sentence, comma-spliced —
+// document.ts's splitUnits does not treat "," as a boundary, so this is ONE unit, not two. It is
+// also not an in-unit clause PAIR: the rule-based chunker doesn't split the comma splice into two
+// clauses at all. What actually lowers ("It was never about the money, it was always about
+// control." verified against the real parser) is one clause whose complement swallows the second
+// half's SUBJECT ("it") as a bare predicateNoun and drops "always about control" on the floor
+// entirely — there is only ever one Clause here, so isReframePairAny (which needs two) has nothing
+// to pair. If a future parser change ever does lower this to two clauses, the in-unit loop in
+// pairCandidates above already catches it via the normal clause-pair path, taking priority (this
+// arm's span would be a strict subset, subsumed by the earlier structural finding).
+//
+// So this reads the shape off the unit's own text instead: "never" ... a comma ... "always", with a
+// be-verb somewhere in the unit to keep it from firing on non-copular near-misses ("It never works,
+// but it always ships" has no copula and should not read as this reframe). Being read off text
+// rather than confirmed structurally, it reports at "candidate" severity (see types.ts) — never
+// scaled up by document density and never given the never/always strength bump, both of which
+// assume the confirmed clause-level shape.
+function commaVariant(u: UnitAnalysis): Span | null {
+  const text = u.unit;
+  const never = /\bnever\b/i.exec(text);
+  if (!never) return null;
+  const comma = text.indexOf(",", never.index);
+  if (comma < 0) return null;
+  const always = /\balways\b/i.exec(text.slice(comma));
+  if (!always) return null;
+  if (!/\b(?:is|are|was|were|am|be|been|being)\b/i.test(text)) return null;
+  return { start: u.span.start + never.index, end: u.span.end };
+}
+
+// --- findings ---
+
+// Severity is a function of how many times the document does this, not of any one instance: once
+// can be deliberate, three times is a habit the reader starts hearing.
+const severityFor = (count: number): Severity => (count >= 3 ? "high" : count === 2 ? "medium" : "low");
+
+// One severity step up, capped at "high" — the never/always strong bonus. "candidate" findings
+// never pass through here: they carry their own fixed severity (see Candidate.severity below).
+const SEVERITY_STEPS: readonly Severity[] = ["low", "medium", "high"];
+const bump = (s: Severity): Severity => SEVERITY_STEPS[Math.min(SEVERITY_STEPS.indexOf(s) + 1, SEVERITY_STEPS.length - 1)]!;
+
+type Candidate = {
+  span: Span;
+  message: string;
+  explanation: string;
+  strong?: boolean; // never/always bonus: bump the count-scaled severity one step
+  severity?: Severity; // fixed severity, bypassing both the count scaling and the bump (comma-variant)
+};
+
+const quote = (s: string): string => `“${s}”`;
+
+function pairCandidate(a: Clause, b: Clause, span: Span, echo: string | null, strong: boolean): Candidate {
+  const denied = pairHead(a)?.text, offered = pairHead(b)?.text;
+  const named = denied && offered ? `${quote("not " + denied)} answered by ${quote(offered)}` : "a denial answered by its replacement";
+  return {
+    span,
+    message: `Negative parallelism: ${named}${echo ? `, echoing ${quote(echo)}` : ""}`,
+    explanation:
+      `You deny a label and hand back its replacement, with the same subject on both sides: “It is not bold. It is backwards.” ` +
+      `The reframe sounds like a discovery, but the reader never gets the reasoning — only the swap. ` +
+      (echo
+        ? `The echo of ${quote(echo)} makes it circular: the word you rejected is the word you kept. `
+        : "") +
+      `Make the positive claim once, with the detail that earns it — “The rollback undoes two years of work.”`,
+    strong,
+  };
+}
+
+const becauseCandidate = (span: Span): Candidate => ({
+  span,
+  message: `Negative parallelism: “not because …, but because …”`,
+  explanation:
+    `“Not because X, but because Y” frames the real reason as a reveal, and the wrong reason is usually one nobody had in mind. ` +
+    `Give the reason plainly — “He left because he was bored” — and keep the contrast only when a reader would genuinely have guessed the other one.`,
+});
+
+const commaCandidate = (span: Span): Candidate => ({
+  span,
+  message: `Negative parallelism: “never …, … always …” in one breath`,
+  explanation:
+    `"It was never X, it was always Y" denies one claim and hands you its replacement in the same sentence, timed as though the writer knew all along. ` +
+    `Say what it was, once, plainly — and drop the denial.`,
+  severity: "candidate",
+});
+
+// Adjacent clause pairs, in document order:
+//   in-unit    consecutive clauses of one lowered unit — what a dash variant looks like when a
+//              parser manages to lower both halves ("That isn't boldness — it's backwardness").
+//   cross-unit the last clause of one unit against the first clause of the next. Unit boundaries
+//              are sentence boundaries AND ";" / ":", so this is the two-sentence form and the
+//              semicolon form at once.
+// A unit can take part in both (its own pair, plus a pair with its neighbour); the spans differ,
+// so both are reported and both count toward density.
+function pairCandidates(doc: DocAnalysis): Candidate[] {
+  const out: Candidate[] = [];
+  const clausesOf = (u: UnitAnalysis): Clause[] => u.clauses ?? [];
+  doc.units.forEach((unit, i) => {
+    const here = clausesOf(unit);
+    for (let c = 0; c + 1 < here.length; c++) {
+      const [a, b] = [here[c]!, here[c + 1]!];
+      if (isReframePairAny(a, b)) {
+        out.push(pairCandidate(a, b, { start: negationStart(unit), end: unit.span.end }, echoedWord(a, unit, true), strongPair(a, b)));
+      }
+    }
+    const next = doc.units[i + 1];
+    if (!next) return;
+    const a = here[here.length - 1], b = clausesOf(next)[0];
+    if (a && b && isReframePairAny(a, b)) {
+      out.push(pairCandidate(a, b, { start: negationStart(unit), end: next.span.end }, echoedWord(a, next, false), strongPair(a, b)));
+    }
+  });
+  return out;
+}
+
+export const reframeRule: TropeRule = {
+  id: RULE_ID,
+  name: "Negative parallelism (the reframe)",
+  tier: "syntactic",
+  detect(doc: DocAnalysis): Finding[] {
+    const candidates = [
+      ...pairCandidates(doc),
+      ...doc.units.flatMap((u) => {
+        const span = becauseVariant(u);
+        return span ? [becauseCandidate(span)] : [];
+      }),
+      ...doc.units.flatMap((u) => {
+        const span = commaVariant(u);
+        return span ? [commaCandidate(span)] : [];
+      }),
+    ];
+
+    // One span, one finding. Two candidates can land on the same range (a dash unit whose clauses
+    // pair up AND whose neighbour pairs with it); the runner would dedupe them anyway, but doing it
+    // here keeps the density count honest.
+    const bySpan = new Map<string, Candidate>();
+    for (const c of candidates) {
+      const key = `${c.span.start}:${c.span.end}`;
+      if (!bySpan.has(key)) bySpan.set(key, c);
+    }
+    const unique = [...bySpan.values()].sort((x, y) => x.span.start - y.span.start || x.span.end - y.span.end);
+
+    // Density scales the base severity; the never/always bonus then bumps it one step further. A
+    // candidate with a fixed `severity` (the comma-variant, read off text rather than confirmed
+    // structurally) skips both — it always reports at "candidate".
+    const baseSeverity = severityFor(unique.length);
+    const density = unique.length >= 2 ? ` You do this ${unique.length} times in this piece; that rhythm is the tell.` : "";
+    return unique.map((c) => ({
+      ruleId: RULE_ID,
+      span: c.span,
+      severity: c.severity ?? (c.strong ? bump(baseSeverity) : baseSeverity),
+      message: c.message,
+      explanation: c.explanation + density,
+    }));
+  },
+};

--- a/scripts/destink/vendor/lint/rules/repetition.ts
+++ b/scripts/destink/vendor/lint/rules/repetition.ts
@@ -1,0 +1,191 @@
+// Repetition and dilution metrics (discourse tier, issue #22) — the measurable slice of
+// "discourse-level" tells that don't need embeddings or an LLM: content duplication and
+// one-point dilution. Two rules live in this file because they share the "count things across
+// the whole document" shape and the char n-gram machinery near-duplicate detection needs:
+//
+//   repetition/near-duplicate  — pairwise near-duplicate UNITS: a paragraph pasted twice, or a
+//                                 point restated almost verbatim a few sentences later.
+//   repetition/dilution        — one document-level signal: how much of the token stream is
+//                                 restated n-grams, a dependency-free proxy for a gzip-style
+//                                 compression ratio. node:zlib (or any node builtin) is off-limits
+//                                 in rule code — this ships to the browser build.
+
+import type { DocAnalysis, Finding, TropeRule } from "../types.js";
+
+// --- shared: normalized text, character n-grams, cosine ------------------------------------
+
+const normalize = (text: string): string => text.toLowerCase().replace(/\s+/g, " ").trim();
+
+const GRAM_N = 4; // 4-char grams: catches near-verbatim paraphrase without collapsing into a
+// bag-of-letters signal the way trigrams do on short units; 5 is stricter but starts missing
+// paraphrases that swap one short word ("the"/"a", "is"/"was").
+
+function charGrams(text: string, n = GRAM_N): Map<string, number> {
+  const norm = normalize(text);
+  const grams = new Map<string, number>();
+  for (let i = 0; i + n <= norm.length; i++) {
+    const g = norm.slice(i, i + n);
+    grams.set(g, (grams.get(g) ?? 0) + 1);
+  }
+  return grams;
+}
+
+function cosine(a: Map<string, number>, b: Map<string, number>): number {
+  if (a.size === 0 || b.size === 0) return 0;
+  const [small, large] = a.size <= b.size ? [a, b] : [b, a];
+  let dot = 0;
+  for (const [g, v] of small) {
+    const w = large.get(g);
+    if (w) dot += v * w;
+  }
+  if (dot === 0) return 0;
+  let normA = 0;
+  let normB = 0;
+  for (const v of a.values()) normA += v * v;
+  for (const v of b.values()) normB += v * v;
+  return dot / Math.sqrt(normA * normB);
+}
+
+const preview = (text: string, max = 60): string => {
+  const t = normalize(text);
+  return t.length > max ? `${t.slice(0, max)}…` : t;
+};
+
+// --- near-duplicate sentences ----------------------------------------------------------------
+
+// Units shorter than this (after whitespace normalization) are skipped entirely: a 3-word
+// fragment ("Not a bug.") shares most of its 4-grams with any other short sentence purely from
+// having so few distinct ones to draw from, so comparing them produces noise, not signal.
+const MIN_UNIT_LEN = 24;
+
+// Cosine similarity bands, tuned against the fixtures in repetition.test.ts: a paragraph pasted
+// twice lands at or near 1.0 and must clear the high band; a tight technical doc that repeats
+// *terms* but not *sentences* ("the parser reads the input. the parser resolves names. the
+// parser emits code.") must clear NEITHER band — sharing one 6-8 character word out of a
+// 24+ character sentence isn't enough 4-gram overlap to reach 0.65.
+const EXACT_THRESHOLD = 0.8; // near-verbatim: copy-paste, or copy-paste plus trivial edits
+const NEAR_THRESHOLD = 0.65; // paraphrase-level overlap: same content, light rewording
+
+// Comparing every pair of qualifying units is O(n^2); fine at document scale (a few hundred
+// units), not fine unbounded. Past this many qualifying units the rule stops adding new
+// comparisons and reports the cap instead of stalling the linter on a huge document.
+const MAX_COMPARED_UNITS = 500;
+
+export const nearDuplicateRule: TropeRule = {
+  id: "repetition/near-duplicate",
+  name: "Near-duplicate sentence",
+  tier: "discourse",
+  detect(doc: DocAnalysis): Finding[] {
+    const qualifying = doc.units
+      .map((u, index) => ({ u, index }))
+      .filter(({ u }) => normalize(u.unit).length >= MIN_UNIT_LEN);
+
+    const capped = qualifying.length > MAX_COMPARED_UNITS;
+    const compared = capped ? qualifying.slice(0, MAX_COMPARED_UNITS) : qualifying;
+    const profiles = compared.map(({ u }) => charGrams(u.unit));
+
+    // Only the single best earlier match survives per later unit — a sentence that echoes two
+    // earlier ones should read as one finding, not a pile-up on the same span.
+    const best = new Map<number, { earlier: number; cos: number }>();
+    for (let i = 0; i < compared.length; i++) {
+      for (let j = i + 1; j < compared.length; j++) {
+        const cos = cosine(profiles[i]!, profiles[j]!);
+        if (cos < NEAR_THRESHOLD) continue;
+        const laterIdx = compared[j]!.index;
+        const earlierIdx = compared[i]!.index;
+        const current = best.get(laterIdx);
+        if (!current || cos > current.cos) best.set(laterIdx, { earlier: earlierIdx, cos });
+      }
+    }
+
+    const findings: Finding[] = [];
+    for (const [laterIdx, { earlier, cos }] of best) {
+      const laterUnit = doc.units[laterIdx]!;
+      const earlierUnit = doc.units[earlier]!;
+      const exact = cos >= EXACT_THRESHOLD;
+      const pct = Math.round(cos * 100);
+      findings.push({
+        ruleId: "repetition/near-duplicate",
+        span: laterUnit.span,
+        severity: exact ? "high" : "medium",
+        message: exact
+          ? `near-identical to the sentence at position ${earlier + 1} (${pct}% overlap)`
+          : `close paraphrase of the sentence at position ${earlier + 1} (${pct}% overlap)`,
+        explanation: `This sentence shares ${pct}% of its character 4-grams with the one at position ${earlier + 1}: “${preview(earlierUnit.unit)}”. ${exact ? "That's copy-paste-level overlap" : "That's enough overlap to read as restating the same point"} — say it once, or make the second pass add something the first one didn't.`,
+      });
+    }
+
+    if (capped) {
+      findings.push({
+        ruleId: "repetition/near-duplicate",
+        span: { start: 0, end: doc.text.length },
+        severity: "low",
+        message: `near-duplicate check capped at ${MAX_COMPARED_UNITS} units (document has ${qualifying.length} eligible)`,
+        explanation: `Comparing every pair of units is O(n^2); past ${MAX_COMPARED_UNITS} eligible units this rule stops adding comparisons rather than stalling the linter on a large document. Units beyond the cap were not checked against each other for duplication.`,
+      });
+    }
+
+    return findings;
+  },
+};
+
+// --- document-level dilution (compression-ratio proxy) ---------------------------------------
+
+// gzip's compression ratio is the obvious repetition proxy, but node:zlib is a Node builtin and
+// this package ships to the browser — no zlib, no other node builtin, in rule code. This is the
+// dependency-free proxy the issue asks for instead: repeated n-gram MASS over the token stream,
+// the same "distinct-n" idea used to score repetitive text generation, inverted into a ratio:
+//
+//   trigrams = every (token[i], token[i+1], token[i+2]) triple across the WHOLE document's word
+//              stream, in document order, lowercased. Unit boundaries are NOT reset between
+//              units — a sentence that echoes the tail of the previous one is still restatement.
+//   dilution = 1 - (distinct trigrams / total trigrams)
+//
+// A document that never repeats a 3-word run scores 0. A document that is two copies of the same
+// paragraph approaches 1. This also gets "name the most-repeated phrases" for free: whichever
+// trigram strings have count > 1 ARE the repeated phrases.
+const MIN_TRIGRAMS = 20; // below this the ratio is noise (a ten-word document "repeats" trivially)
+const DILUTION_THRESHOLD = 0.25; // >=25% of trigram occurrences restate an earlier one
+const TOP_PHRASES = 3;
+
+function trigramsOf(doc: DocAnalysis): string[] {
+  const tokens = doc.units.flatMap((u) => u.words.map((w) => w.text.toLowerCase()));
+  const grams: string[] = [];
+  for (let i = 0; i + 2 < tokens.length; i++) grams.push(`${tokens[i]} ${tokens[i + 1]} ${tokens[i + 2]}`);
+  return grams;
+}
+
+export const dilutionRule: TropeRule = {
+  id: "repetition/dilution",
+  name: "Document-level dilution",
+  tier: "discourse",
+  detect(doc: DocAnalysis): Finding[] {
+    const grams = trigramsOf(doc);
+    if (grams.length < MIN_TRIGRAMS) return [];
+
+    const counts = new Map<string, number>();
+    for (const g of grams) counts.set(g, (counts.get(g) ?? 0) + 1);
+
+    const distinct = counts.size;
+    const ratio = 1 - distinct / grams.length;
+    if (ratio < DILUTION_THRESHOLD) return [];
+
+    const top = [...counts.entries()]
+      .filter(([, c]) => c > 1)
+      .sort((a, b) => b[1] - a[1] || (a[0] < b[0] ? -1 : 1))
+      .slice(0, TOP_PHRASES)
+      .map(([phrase, c]) => `“${phrase}” x${c}`)
+      .join(", ");
+
+    const pct = Math.round(ratio * 100);
+    return [
+      {
+        ruleId: "repetition/dilution",
+        span: { start: 0, end: doc.text.length },
+        severity: "low",
+        message: `${pct}% of this document's 3-word runs restate an earlier one`,
+        explanation: `Of ${grams.length} overlapping 3-word runs in the document, only ${distinct} are distinct (${pct}% restatement — 1 minus that ratio is what a real compressor would exploit). The most-repeated: ${top || "none over the threshold"}. That's the same idea said again rather than developed — cut the restatement or move the argument forward instead.`,
+      },
+    ];
+  },
+};

--- a/scripts/destink/vendor/lint/rules/self-posed-question.ts
+++ b/scripts/destink/vendor/lint/rules/self-posed-question.ts
@@ -1,0 +1,183 @@
+// Self-posed question (epic #28, #16) — "The result? Devastating." / "The worst part? Nobody saw
+// it coming." A unit that ends in "?" immediately followed by a short declarative (or fragment)
+// answer: the writer asks their own question so they can deliver the "reveal" themselves.
+//
+// Terminator gap. document.ts's readDocument (the real, parsed path) EXCLUDES a unit's terminating
+// punctuation from its span: "The result? Devastating." splits into two units, "The result" and
+// "Devastating", with the "?" sitting in neither span — it's in the gap between them. stub-doc.ts's
+// makeDoc does the opposite and folds the terminator INTO the unit's own trailing text. Both are
+// legitimate DocAnalysis producers, so unitEndsWith() below checks both: the unit's own trailing
+// terminator run first, then the gap up to the next unit (or end of document).
+//
+// Two forms, by how the question is shaped:
+//
+//   STRONG  "The X?" — at most STRONG_MAX_WORDS words AND the outcome is "fragment"/"unparseable"
+//           (no verb came out of it; a bare NP dressed as a question). This is the shape from the
+//           tropes list, and the strongest signal: nobody drops a subject and asks a two-word
+//           question except for the reveal-beat effect. Fires with any answer up to
+//           MAX_ANSWER_WORDS words.
+//
+//   WEAK    Anything else that still ends in "?" — a real interrogative clause (has a verb; would
+//           parse as SQ/SBARQ if a constituency parser ever labels questions that way — the
+//           rule-based chunker in nlp/parse.ts normalizes questions to declarative order before
+//           parsing and never produces that label, so this is a forward-looking check, not a live
+//           one against the current parser) or simply a longer fragment ending in "?". A real
+//           question deserves a real answer, so this only fires when the answer is a short punchy
+//           fragment (<= WEAK_ANSWER_MAX_WORDS words) — "Why does this matter? Because it always
+//           does." reads as the same beat as the strong form. A real question answered at length
+//           (FAQ prose, a tutorial) is exactly what this rule must stay quiet on.
+//
+// Either form is suppressed across a markdown heading boundary: the question itself is a heading
+// line, or a heading sits between the question and its answer. "## The result?\n\nDevastating." is
+// a section title and its body, not a self-posed question.
+//
+// Density (whole document, both forms pooled): 1 instance -> low if it's the strong form, nothing
+// at all if it's the lone weak-form hit (a single real question briefly answered is not yet a
+// pattern); 2 instances -> medium; 3+ -> high.
+
+import type { DocAnalysis, Finding, Severity, TropeRule, UnitAnalysis } from "../types.js";
+import type { MarkdownContext } from "../markdown.js";
+import { markdownContext, kindAt } from "../markdown.js";
+import { spanning } from "../span.js";
+
+const STRONG_MAX_WORDS = 4; // "The result?" / "The worst part?" / "The scary part?"
+const MAX_ANSWER_WORDS = 12; // beyond this the question was answered at length — never fires
+const WEAK_ANSWER_MAX_WORDS = 6; // the weak form only fires when the answer is this punchy
+
+const TERMINATOR_CHARS = ".!?;:";
+
+// --- terminator-gap helpers ---
+
+// The text between this unit's own span and the next unit's span (or the end of the document for
+// the last unit) — the region where a splitter that excludes terminators leaves them.
+function gapAfter(doc: DocAnalysis, i: number): string {
+  const start = doc.units[i]!.span.end;
+  const end = i + 1 < doc.units.length ? doc.units[i + 1]!.span.start : doc.text.length;
+  return doc.text.slice(start, end);
+}
+
+// The run of terminator punctuation at the very end of `text` (after trimming trailing whitespace),
+// e.g. "Wait?!" -> "?!", "Not a bug." -> ".", "Devastating" -> "".
+function trailingTerminators(text: string): string {
+  const trimmed = text.replace(/\s+$/, "");
+  let end = trimmed.length;
+  while (end > 0 && TERMINATOR_CHARS.includes(trimmed[end - 1]!)) end--;
+  return trimmed.slice(end);
+}
+
+// True when unit `i` ends with `ch`, whichever splitter convention produced `doc`: check the unit's
+// own trailing terminator run first (makeDoc folds the terminator into the unit), then the gap after
+// it (readDocument excludes the terminator from the unit and leaves it in the gap).
+function unitEndsWith(doc: DocAnalysis, i: number, ch: string): boolean {
+  const u = doc.units[i]!;
+  if (trailingTerminators(doc.text.slice(u.span.start, u.span.end)).includes(ch)) return true;
+  return gapAfter(doc, i).includes(ch);
+}
+
+// True only for the document's last unit, and only when nothing — not even a terminator — follows
+// it: the text just stops ("...and the winner is Devastating" with no closing punctuation at all).
+function endsDocumentUnterminated(doc: DocAnalysis, i: number): boolean {
+  if (i !== doc.units.length - 1) return false;
+  return !/[.!?;:]/.test(gapAfter(doc, i));
+}
+
+const isQuestionUnit = (doc: DocAnalysis, i: number): boolean => unitEndsWith(doc, i, "?");
+
+const isDeclarativeAnswer = (doc: DocAnalysis, i: number): boolean =>
+  unitEndsWith(doc, i, ".") || unitEndsWith(doc, i, "!") || endsDocumentUnterminated(doc, i);
+
+// --- shape ---
+
+// No clause came out of this unit — fragment or unparseable outcome both mean "no verb found",
+// which for a 1-4 word unit ending in "?" is the "The result?" shape, not a truncated real question.
+const looksVerbless = (u: UnitAnalysis): boolean => u.outcome !== "lowered";
+
+const isStrongQuestion = (doc: DocAnalysis, i: number): boolean =>
+  doc.units[i]!.words.length <= STRONG_MAX_WORDS && looksVerbless(doc.units[i]!);
+
+// --- markdown suppression ---
+
+// document.ts's readDocument only splits on . ! ? ; : — never on a bare newline — so a heading
+// interposed between a question and its answer with no other boundary punctuation ends up glued to
+// the FRONT of the answer unit's own span rather than sitting in the gap before it ("The result?\n##
+// Aside\nDevastating." has its answer unit start at "## Aside"). Using aSpan.end rather than
+// aSpan.start as the upper bound catches that merged case too, alongside the clean
+// question-gap-heading-answer shape a newline-splitting doc builder (makeDoc) produces.
+function crossesHeadingBoundary(
+  ctx: MarkdownContext,
+  qSpan: { start: number; end: number },
+  aSpan: { start: number; end: number },
+): boolean {
+  if (kindAt(ctx, qSpan.start) === "heading") return true; // the question IS a heading
+  return ctx.lines.some((l) => l.kind === "heading" && l.span.start >= qSpan.end && l.span.start < aSpan.end);
+}
+
+// --- collect ---
+
+type Instance = { kind: "strong" | "weak"; qIndex: number; aIndex: number };
+
+function collectInstances(doc: DocAnalysis, ctx: MarkdownContext): Instance[] {
+  const out: Instance[] = [];
+  for (let i = 0; i < doc.units.length - 1; i++) {
+    if (!isQuestionUnit(doc, i)) continue;
+    const j = i + 1;
+    if (!isDeclarativeAnswer(doc, j)) continue;
+
+    const answerWords = doc.units[j]!.words.length;
+    if (answerWords > MAX_ANSWER_WORDS) continue; // answered at length — a real FAQ, not the trope
+
+    const strong = isStrongQuestion(doc, i);
+    if (!strong && answerWords > WEAK_ANSWER_MAX_WORDS) continue; // a real question, answered properly
+
+    if (crossesHeadingBoundary(ctx, doc.units[i]!.span, doc.units[j]!.span)) continue;
+
+    out.push({ kind: strong ? "strong" : "weak", qIndex: i, aIndex: j });
+  }
+  return out;
+}
+
+function buildFinding(doc: DocAnalysis, inst: Instance, severity: Severity, total: number): Finding {
+  const q = doc.units[inst.qIndex]!;
+  const a = doc.units[inst.aIndex]!;
+  const qText = doc.text.slice(q.span.start, q.span.end);
+  const aText = doc.text.slice(a.span.start, a.span.end);
+  const countNote = total > 1 ? ` — ${total} in this piece` : "";
+
+  const message =
+    inst.kind === "strong"
+      ? `"${qText}?" answered in the next breath${countNote}`
+      : `"${qText}?" — a real question, answered in one short beat${countNote}`;
+
+  const explanation =
+    inst.kind === "strong"
+      ? `You ask "${qText}?" and immediately answer it yourself: "${aText}." That's a manufactured reveal for something you could just state — "${qText} was ${aText.toLowerCase()}." Say the thing, no question required.`
+      : `"${qText}?" reads like a real question, but you answer it in a single short beat: "${aText}." Either commit to the question and answer it properly, or drop the question mark and lead with "${aText}" directly.`;
+
+  return {
+    ruleId: "syntactic/self-posed-question",
+    span: spanning([q.span, a.span]),
+    severity,
+    message,
+    explanation,
+  };
+}
+
+export const selfPosedQuestionRule: TropeRule = {
+  id: "syntactic/self-posed-question",
+  name: "Self-posed question",
+  tier: "syntactic",
+  detect(doc: DocAnalysis): Finding[] {
+    const ctx = markdownContext(doc.text);
+    const instances = collectInstances(doc, ctx);
+    if (instances.length === 0) return [];
+
+    if (instances.length === 1) {
+      const only = instances[0]!;
+      if (only.kind === "weak") return []; // one real, briefly-answered question isn't a pattern yet
+      return [buildFinding(doc, only, "low", 1)];
+    }
+
+    const severity: Severity = instances.length >= 3 ? "high" : "medium";
+    return instances.map((inst) => buildFinding(doc, inst, severity, instances.length));
+  },
+};

--- a/scripts/destink/vendor/lint/rules/serves-as.ts
+++ b/scripts/destink/vendor/lint/rules/serves-as.ts
@@ -1,0 +1,193 @@
+// The "Serves As" Dodge (issue #18) — {serve as, stand as, mark, represent} standing in for a
+// plain "is"/"are". The word list lives in src/lint/lexicons/serves-as-verbs.ts (imported below,
+// never redefined here); this file supplies the STRUCTURE that tells a dodge from a literal use
+// of the same verb — the thing a word list alone can't do ("the sign marks the trailhead" uses
+// the exact same word as "the plaque marks a turning point").
+//
+// Two grammatically different frames share the one lexicon:
+//
+//   PHRASAL — "serve as" / "stand as". SERVE and STAND are intransitive on their own; the dodge's
+//   target sits inside an "as X" prepositional phrase hanging off the VERB
+//   (clause.verb.modifiers), not the clause's own complement — clause.complement stays null
+//   ("The building serves" has no object of its own; "as a reminder" is a PP, not a direct
+//   object). Confirming the frame means finding that "as" PP and checking its object is a PLAIN
+//   nominal: "The waiter serves as many tables as he can" fails this because the trailing
+//   "as he can" leaves its own comparative clause-modifier hanging off the object ("many tables"
+//   modified by an "as"-connected clause) — that nested modifier is the structural tell that this
+//   is the "as ... as" comparative, not "serve as NOUN", and isPlainNominal below rejects it.
+//
+//   BARE — "mark" / "represent". These ARE transitive main verbs; the target is the clause's own
+//   complement (direct object or predicate noun), read via ir-query's complementHead. Structurally
+//   "the sign marks the trailhead" and "the plaque marks a turning point" are IDENTICAL shapes —
+//   telling literal from figurative needs semantics (is the complement abstract?) that this rule
+//   deliberately does not attempt (lexicons/types.ts's own note calls this exact call a wave-2
+//   design decision, not something POS/structure can resolve). So the bare frame is scored lower
+//   than the phrasal one and only escalates with repetition — see SEVERITY TIERS below.
+//
+// SEVERITY TIERS. Both frames start from servesAsVerbs.defaultSeverity ("low") and shift by one
+// step along candidate < low < medium < high:
+//   - PHRASAL hits get defaultSeverity shifted UP one tier ("full severity", medium) unconditionally
+//     — the literal word "as" plus a plain nominal complement is confirming structural evidence a
+//     bare transitive verb doesn't have, so a single hit is already trustworthy.
+//   - BARE hits get defaultSeverity shifted DOWN one tier ("candidate" — see the Severity type's
+//     own doc comment: "structurally-narrowed suspects a rule can't confirm without semantics",
+//     which is exactly this case) UNLESS the document repeats the bare pattern at least
+//     servesAsVerbs.densityThreshold times, in which case they hold at the lexicon's own
+//     defaultSeverity ("low") — repetition is the only corroboration a structural-only check can
+//     use for mark/represent, mirroring rules/demo.ts's "count first, judge second".
+//
+// PARSER GAP — reported per #18's ground rules and since CLOSED in the engine (issue #33). The
+// rule-based chunker used to drop "as X" entirely after serve/stand:
+// parse("The building serves as a reminder of the city's heritage.") returned
+// `(S (NP (DT The) (NN building)) (VP (VBZ serves)))`, so clause.verb.modifiers was always [] and
+// the phrasal frame could only be tested against hand-built Clause fixtures. parse.ts now reads a
+// subordinator with no clause after it as a preposition, so the "as" PP reaches the IR and this
+// frame fires through readDocument — including the discriminator above, since the comparative's
+// "as he can" attaches to the object. See serves-as.test.ts's end-to-end describe block.
+// mark/represent were never affected: plain transitive objects parse fine (verified against
+// readDocument — "represents a turning point" and "marks a turning point" both lower to an
+// ordinary directObject complement, and passive voice, "is represented by ...", correctly leaves
+// clause.complement null, which the bare frame's own transitive-frame requirement already handles
+// without any special-casing).
+
+import nlp from "compromise";
+import type { Clause, Compound, Nominal, Verbal, Word } from "../../ir.js";
+import type { DocAnalysis, Finding, Severity, TropeRule, UnitAnalysis } from "../types.js";
+import { complementHead } from "../ir-query.js";
+import { POS_GATE_PREFIX, servesAsVerbs } from "../lexicons/index.js";
+import { spanning } from "../span.js";
+
+// --- lemma ---
+//
+// The "small lemma helper" #18 asks for. compromise, forced to read a BARE word as a verb,
+// mis-tags some past-participle-shaped forms as adjectives instead ("marked" alone stays
+// "marked" — compromise's own lexicon outranks the forced tag). Wrapping the word in a minimal
+// "it WORD that" frame gives it the syntactic context compromise's tagger actually listens to,
+// which resolves every inflection this lexicon lists (verified by hand: serves/served/serving/
+// serve -> serve; stands/stood -> stand; marks/marking/marked/mark -> mark; represents/
+// representing/represented/represent -> represent). ing-tackon.ts carries its own copy of this
+// same helper rather than importing it from here, so each rule file stays self-contained the way
+// rules/demo.ts is.
+function lemmaOf(word: string): string {
+  const inf = nlp(`it ${word} that`).verbs().toInfinitive().text();
+  const stripped = inf.replace(/^it\s+/i, "").replace(/\s+that$/i, "");
+  return (stripped || word).toLowerCase();
+}
+
+const lastToken = (text: string): string => {
+  const parts = text.trim().split(/\s+/);
+  return (parts[parts.length - 1] ?? "").toLowerCase();
+};
+
+// Bails on a Compound predicate, same call ir-query's isCopular makes and for the same reason:
+// a compound predicate's conjuncts each carry their own complement, so there is no single
+// clause-level verb/complement pair to test. A caller wanting per-conjunct precision can walk
+// clause.verb.items itself.
+const asVerbal = (clause: Clause): Verbal | null => ("head" in clause.verb ? clause.verb : null);
+
+// A nominal (or compound) counts as "plain" only when none of its items carries a comparative
+// "as"-clause of its own — see the PHRASAL doc comment above for why that's the discriminator
+// between "serve as NOUN" and "serve as ADJ as CLAUSE".
+function isPlainNominal(n: Nominal | Compound<Nominal>): boolean {
+  const items = "items" in n ? n.items : [n];
+  return items.every((it) => !it.modifiers.some((m) => m.kind === "clause" && m.connector.text.toLowerCase() === "as"));
+}
+
+// The phrasal frame's evidence: a prep modifier headed by "as" on the VERB, with a plain nominal
+// object. This is the only shape lowerPP/lowerPredicate can produce for "as X" hanging off a verb
+// (see the PARSER GAP note above for why today's parser never actually produces it for serve/stand).
+function asPhraseObject(verbal: Verbal): Nominal | null {
+  for (const m of verbal.modifiers) {
+    if (m.kind === "prep" && m.prep.text.toLowerCase() === "as" && isPlainNominal(m.object)) return m.object;
+  }
+  return null;
+}
+
+// The bare frame's evidence: the CLAUSE's own complement is a nominal (direct object or predicate
+// noun) — not an infinitive, not a causative small clause, and not absent (passive voice, or an
+// intransitive use, leaves this null and correctly excludes those cases with no extra code).
+function nominalComplementHead(clause: Clause): Word | null {
+  const c = clause.complement;
+  if (!c || (c.kind !== "directObject" && c.kind !== "predicateNoun")) return null;
+  if (!("head" in c.value) && !("items" in c.value)) return null; // Infinitive | Clause value — not a nominal
+  return complementHead(clause);
+}
+
+const SEVERITY_ORDER: Severity[] = ["candidate", "low", "medium", "high"];
+const shiftSeverity = (s: Severity, delta: number): Severity => {
+  const i = SEVERITY_ORDER.indexOf(s);
+  return SEVERITY_ORDER[Math.min(SEVERITY_ORDER.length - 1, Math.max(0, i + delta))]!;
+};
+
+type Frame = "phrasal" | "bare";
+type Hit = { unit: UnitAnalysis; verbText: string; frame: Frame; note: string | undefined };
+
+// Locates a Word's (possibly multi-word) surface text among the unit's word spans, so the
+// finding's span slices cleanly from doc.text — the Clause IR carries no offsets of its own (see
+// src/lint/types.ts). Degrades to the whole unit's span when the text can't be found, per #18's
+// instruction (e.g. a hand-built fixture whose `words` don't happen to mirror the Clause text).
+function locate(unit: UnitAnalysis, text: string) {
+  const tokens = text.trim().split(/\s+/).map((t) => t.toLowerCase());
+  for (let i = 0; i + tokens.length <= unit.words.length; i++) {
+    const slice = unit.words.slice(i, i + tokens.length);
+    if (slice.every((w, j) => w.text.toLowerCase() === tokens[j])) return spanning(slice);
+  }
+  return unit.span;
+}
+
+export const servesAsDodgeRule: TropeRule = {
+  id: "serves-as-dodge",
+  name: 'The "Serves As" Dodge',
+  tier: "syntactic",
+  detect(doc: DocAnalysis): Finding[] {
+    const hits: Hit[] = [];
+
+    for (const unit of doc.units) {
+      if (!unit.clauses) continue;
+      for (const clause of unit.clauses) {
+        const verbal = asVerbal(clause);
+        if (!verbal) continue;
+        const lemma = lemmaOf(lastToken(verbal.head.text));
+
+        const phrasalEntry = servesAsVerbs.entries.find((e) => Array.isArray(e.match) && e.match[0] === lemma);
+        if (phrasalEntry && asPhraseObject(verbal)) {
+          hits.push({ unit, verbText: verbal.head.text, frame: "phrasal", note: phrasalEntry.note });
+          continue;
+        }
+
+        const bareEntry = servesAsVerbs.entries.find((e) => typeof e.match === "string" && e.match === lemma);
+        if (bareEntry) {
+          if (bareEntry.posGate && verbal.head.pos && !verbal.head.pos.startsWith(POS_GATE_PREFIX[bareEntry.posGate])) continue;
+          if (nominalComplementHead(clause)) hits.push({ unit, verbText: verbal.head.text, frame: "bare", note: undefined });
+        }
+      }
+    }
+
+    // Count first, judge second (rules/demo.ts's contract): the bare frame's confidence is a
+    // document-wide density call, computed once over every bare hit before any Finding is built.
+    const bareCount = hits.filter((h) => h.frame === "bare").length;
+    const bareDense = bareCount >= (servesAsVerbs.densityThreshold ?? 1);
+    const bareSeverity = shiftSeverity(servesAsVerbs.defaultSeverity, bareDense ? 0 : -1);
+    const phrasalSeverity = shiftSeverity(servesAsVerbs.defaultSeverity, 1);
+
+    return hits.map((h) => {
+      const span = locate(h.unit, h.verbText);
+      if (h.frame === "phrasal") {
+        return {
+          ruleId: "serves-as-dodge",
+          span,
+          severity: phrasalSeverity,
+          message: `“${h.verbText} as” stands in for “is”`,
+          explanation: `“X ${h.verbText} as Y” dodges the plain copula (“X is Y”) to sound more consequential${h.note ? ` (${h.note})` : ""}. Swap in “is”/“was” and read it back — if the sentence survives, you didn't need “${h.verbText} as”.`,
+        };
+      }
+      return {
+        ruleId: "serves-as-dodge",
+        span,
+        severity: bareSeverity,
+        message: `“${h.verbText}” may be doing “is”'s job`,
+        explanation: `“mark”/“represent” sometimes just replace “is” for gravitas (compare the literal “the sign marks the trailhead” with the figurative “the plaque marks a turning point” — same verb, same shape). This rule can't tell those apart from structure alone, so treat it as a prompt: does a plain “is”/“was” fit just as well here?`,
+      };
+    });
+  },
+};

--- a/scripts/destink/vendor/lint/rules/setup-turn.ts
+++ b/scripts/destink/vendor/lint/rules/setup-turn.ts
@@ -1,0 +1,269 @@
+// THE SETUP AND THE TURN (#34) — a bare noun phrase presented as a sentence, answered by a short
+// beat that takes it away. "3 rules. And none you set." "A new framework. And nobody asked for it."
+// "Beautiful documentation. None of it true." "Six weeks of planning. Not one line shipped."
+//
+// The tell is the SETUP, not what fills it. The first beat is not a sentence — it names a thing and
+// stops, which is a stage direction rather than a claim. The second beat voids the thing before the
+// reader has been told anything about it. Two beats in there is still nothing to agree or disagree
+// with, and that is the formula working: it buys attention with a frame and pays it off with a
+// reversal, and no argument is ever made. It reads as written-for-the-feed because that is the unit
+// the feed rewards.
+//
+// This rule shipped first as "quantity-hook", keyed on a number in the setup slot ("3 rules.",
+// "Twelve engineers."). That was reading the filler for the form. A count is the most common thing
+// people put in a setup slot and it is not what makes it one — dropping the requirement took the
+// rule from 5 of 14 collected specimens to 14 of 14, and the nine it had been missing are the same
+// formula with a noun phrase instead of a number ("Endless meetings. No decisions."). The count is
+// kept only as a label in the message, because "a bare count" is worth naming when it is there.
+//
+// --- why discourse/punchy-fragments does not cover this ---
+//
+// It fires on four of the fourteen specimens, and the four are arbitrary. punchy-fragments needs a
+// run of >= 2 consecutive units with outcome === "fragment", and the turn usually has a verb in it,
+// so document.ts calls it "unparseable" and fragments.ts (correctly, per its own header) refuses to
+// treat unparseables as fragments:
+//
+//   "3 rules. And none you set."                  "And none you set" -> unparseable  (silent)
+//   "A thousand dashboards. Nobody reading them."                    -> unparseable  (silent)
+//   "Six weeks of planning. Not one line shipped."                   -> unparseable  (silent)
+//   "Endless meetings. No decisions."             both verbless      -> FIRES
+//
+// So coverage is decided by whether the turn happens to contain a verb, which has nothing to do
+// with the trope. And when it does fire it hands the reader the wrong note — "choppy staccato
+// rhythm, let some of these be full sentences" is advice about rhythm, and the problem here is a
+// frame that never becomes a claim. This rule reads the shape, so the verb in the turn stops
+// mattering.
+//
+// --- the four tests ---
+//
+//   setup is a noun phrase   2..5 words, no finite verb of its own, and not opening on a
+//                            preposition or a subordinator (those make it a stranded modifier, not
+//                            a frame) or on a voider (that is rules/fragments.ts's countdown).
+//   setup is verbless        crude lexical evidence, NOT the parse: the rule-based chunker lowers
+//                            "Twelve engineers" as a clause (reading the noun as a verb) while
+//                            calling "3 rules" a fragment, so keying on outcome would make coverage
+//                            depend on that coin-flip. See hasVerbEvidence.
+//   the turn voids           a quantificational negator near the front of the second beat. This is
+//                            the test that makes the rule safe to fire on a SINGLE instance, and it
+//                            is why the disproportion variant is out (below).
+//   both beats stay short    past these lengths a beat is a sentence, and a sentence is not a beat.
+//
+// --- what is deliberately NOT here: the disproportion variant ---
+//
+// "Four hours. One line of code." and "5 minutes. That's all it took." are the same formula with a
+// turn that diminishes instead of voiding. They are left out because nothing structural separates
+// them from an ingredient list or a spec sheet:
+//
+//   "Four hours. One line of code."     noun-phrase beat, noun-phrase beat
+//   "2 eggs. 1 cup flour."              noun-phrase beat, noun-phrase beat
+//
+// Telling those apart needs to know four hours is a lot and one line is a little, which is
+// semantics this rule cannot see. Requiring an explicit voider is the rule, not a threshold on it.
+// If the variant is ever wanted it belongs behind "candidate" severity (see types.ts).
+
+import type { DocAnalysis, Finding, Severity, TropeRule, UnitAnalysis, WordSpan } from "../types.js";
+import { makeContext, suppressed, type Context } from "./fragments.js";
+import { spanning } from "../span.js";
+
+const RULE_ID = "discourse/setup-turn";
+
+// Lengths. The setup is a noun phrase ("A whole quarter of work" is the longest specimen at 5); the
+// turn runs a word or two longer because it may carry a verb ("Nobody could answer it").
+const MAX_SETUP_WORDS = 5;
+const MAX_TURN_WORDS = 6;
+
+// --- the setup beat ---
+//
+// Cardinals and the digit test below no longer GATE anything — a setup is a noun phrase whether or
+// not it opens on a number. They survive only to label the finding, because "a bare count answered
+// by a void" is a more useful sentence to hand a reader than the generic one when the count is
+// actually there. See isQuantitySetup at the bottom.
+
+// Spelled cardinals. Ordinals are absent on purpose: "First rule. None you set." is a different
+// (and ordinary) shape — an ordinal enumerates, it does not quantify.
+const CARDINALS = new Set([
+  "zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten",
+  "eleven", "twelve", "thirteen", "fourteen", "fifteen", "sixteen", "seventeen", "eighteen",
+  "nineteen", "twenty", "thirty", "forty", "fifty", "sixty", "seventy", "eighty", "ninety",
+  "hundred", "thousand", "million", "billion", "dozen",
+]);
+
+// "a thousand dashboards", "a dozen meetings" — the article carries no quantity on its own, so it
+// only counts when the next token does. Kept to the big round ones: "a rule" is not a quantity.
+const ARTICLE_QUANTIFIABLE = new Set(["dozen", "hundred", "thousand", "million", "billion"]);
+
+const DIGIT_QUANTITY = /^\d/; // 3, 40%, 1,000 — anything opening with a digit
+
+// Crude finite-verb evidence, the same idiom and for the same reason as contrast-tail.ts's: this
+// rule runs on the parser-free path too, where no POS tags exist, and every word here can only be a
+// verb. It is what keeps "Twelve engineers are idle." out of the count beat — and it is needed
+// because the parse alone is not reliable on a bare noun phrase (the rule-based chunker lowers
+// "Twelve engineers" as a clause, reading the noun "engineers" as a verb, while calling "3 rules" a
+// fragment; keying on outcome would make coverage depend on that coin-flip).
+const FINITE_VERBS = new Set([
+  "is", "are", "was", "were", "am", "be", "been", "being",
+  "has", "have", "had", "does", "do", "did",
+  "will", "would", "can", "could", "shall", "should", "may", "might", "must",
+]);
+
+const isWordToken = (w: WordSpan): boolean => /[\p{L}\p{N}]/u.test(w.text);
+
+const wordsOf = (u: UnitAnalysis): string[] => u.words.filter(isWordToken).map((w) => w.text);
+
+const isQuantity = (w: string): boolean => DIGIT_QUANTITY.test(w) || CARDINALS.has(w.toLowerCase());
+
+// Label only — see the note above CARDINALS. True when the setup opens on a number, so the finding
+// can say "a bare count" instead of "a bare noun phrase".
+function isQuantitySetup(u: UnitAnalysis): boolean {
+  const words = wordsOf(u);
+  if (words.length === 0) return false;
+  const first = words[0]!.toLowerCase();
+  if (isQuantity(first)) return true;
+  return (first === "a" || first === "an") && words.length > 1 && ARTICLE_QUANTIFIABLE.has(words[1]!.toLowerCase());
+}
+
+const PREPOSITIONS = new Set([
+  "in", "on", "at", "of", "for", "with", "by", "from", "to", "into", "over", "under", "after",
+  "before", "during", "through", "about", "against", "between", "across", "behind", "beyond",
+]);
+
+const SUBORDINATORS = new Set([
+  "because", "since", "although", "though", "while", "when", "whenever", "if", "unless", "whether",
+  "that", "which", "who", "whom", "whose", "where", "why", "how",
+]);
+
+// Past-tense "-ed" is the other half of the crude verb evidence, and it is what keeps "He counted
+// them twice. Sixteen, not fifteen." out — the auxiliary list alone does not see "counted". The
+// exception set is the short list of "-ed" words that are adjectives or nouns; a miss here costs
+// one finding, never a wrong one. "-ing" is deliberately NOT evidence: "Six weeks of planning" is a
+// noun phrase and one of the specimens.
+const ED_NOT_VERBS = new Set([
+  "red", "bed", "fed", "led", "wed", "bred", "sled", "shed", "speed", "breed", "creed", "deed",
+  "greed", "need", "seed", "indeed", "sacred", "hundred", "thousand", "tired", "wicked", "naked",
+  "united", "limited", "advanced", "mixed", "used", "aged",
+]);
+
+// Irregular past forms, which neither the auxiliary list nor the "-ed" test can see. Kept to forms
+// that are rarely anything but a verb: "saw", "left", "lost", "read", "set", "put", "won", "met",
+// "fell" and "paid" are all common nouns or adjectives inside a short noun phrase ("the left
+// column", "a lost cause") and listing them would suppress real setups. The cost of that omission
+// is a missed finding; the cost of including them is a wrong one.
+const IRREGULAR_PASTS = new Set([
+  "went", "came", "stood", "sat", "took", "made", "ran", "gave", "found", "told", "felt", "knew",
+  "thought", "said", "held", "kept", "brought", "bought", "caught", "taught", "sent", "spent",
+  "built", "began", "wrote", "spoke", "broke", "chose", "drove", "threw", "grew", "fought",
+  "sought", "became", "got", "gotten", "flew", "fled", "shook", "swore", "tore", "wore",
+]);
+
+function hasVerbEvidence(w: string): boolean {
+  const lower = w.toLowerCase();
+  if (FINITE_VERBS.has(lower) || IRREGULAR_PASTS.has(lower)) return true;
+  return lower.length > 4 && lower.endsWith("ed") && !ED_NOT_VERBS.has(lower);
+}
+
+function isSetupBeat(ctx: Context, u: UnitAnalysis): boolean {
+  if (suppressed(ctx, u.span)) return false;
+  const words = wordsOf(u);
+  if (words.length < 2 || words.length > MAX_SETUP_WORDS) return false;
+  if (words.some((w) => hasVerbEvidence(w))) return false;
+  const first = words[0]!.toLowerCase();
+  if (PREPOSITIONS.has(first) || SUBORDINATORS.has(first)) return false;
+  if (VOIDERS.has(first)) return false;
+  return true;
+}
+
+// --- the turn ---
+
+// Words that take the count away. "not" covers "Not one line shipped"; "no" covers both "No
+// decisions" and "no one". Every entry has to VOID rather than merely modify — "few", "some" and
+// "half" are absent because "Twelve engineers. Half of them remote." is a report, not a hook.
+const VOIDERS = new Set([
+  "none", "no", "nobody", "nothing", "never", "neither", "nowhere", "not", "zero",
+]);
+
+// Auxiliaries that turn a following "not" into ordinary verb negation rather than a void.
+const AUXILIARY_BEFORE_NOT = new Set([
+  "do", "does", "did", "will", "would", "can", "could", "shall", "should", "may", "might", "must",
+  "is", "are", "was", "were", "am", "be", "been", "has", "have", "had",
+]);
+
+// A leading conjunction is part of the formula ("And none you set"), not part of the negation, so
+// it is skipped before looking for the voider rather than blocking the match.
+const LEADING_CONJUNCTIONS = new Set(["and", "but", "yet", "still", "so"]);
+
+// The void beat: short, and negating within its first couple of tokens. Position matters — a voider
+// buried at the end ("Twelve engineers, and the scheduler is not done") is a clause that happens to
+// contain a negative, not a beat that opens by taking the count away. Deliberately NOT tested for
+// verblessness: the second beat carrying a verb is exactly the case punchy-fragments misses.
+const VOIDER_SEARCH_DEPTH = 2;
+
+function isTurnBeat(ctx: Context, u: UnitAnalysis): boolean {
+  if (suppressed(ctx, u.span)) return false;
+  const words = wordsOf(u);
+  if (words.length < 1 || words.length > MAX_TURN_WORDS) return false;
+
+  let i = 0;
+  if (LEADING_CONJUNCTIONS.has(words[0]!.toLowerCase())) i = 1;
+  for (let j = i; j < Math.min(words.length, i + VOIDER_SEARCH_DEPTH); j++) {
+    const w = words[j]!.toLowerCase();
+    if (!VOIDERS.has(w)) continue;
+    // "not" is the one voider that is also ordinary verb negation. "Do not rely on it." and "The
+    // job is not finished." negate a VERB — the setup is still standing, nothing was taken away.
+    // Only quantificational "not" voids: "Not one line shipped.", "Not a single test." So when the
+    // token is "not", it counts only if nothing auxiliary precedes it.
+    if (w === "not" && j > 0 && AUXILIARY_BEFORE_NOT.has(words[j - 1]!.toLowerCase())) continue;
+    return true;
+  }
+  return false;
+}
+
+// --- the rule ---
+
+export const setupTurnRule: TropeRule = {
+  id: RULE_ID,
+  name: "The setup and the turn",
+  tier: "discourse",
+  detect(doc: DocAnalysis): Finding[] {
+    const ctx = makeContext(doc);
+    const units = doc.units;
+    const findings: Finding[] = [];
+
+    for (let i = 0; i + 1 < units.length; i++) {
+      const setup = units[i]!;
+      const turn = units[i + 1]!;
+      if (!isSetupBeat(ctx, setup) || !isTurnBeat(ctx, turn)) continue;
+
+      // Opening position is the formula in its native habitat: a hook is a hook because it is the
+      // first thing the reader meets. Mid-document the same pair is likelier to be a writer landing
+      // one deliberate beat, so it reports a step lower.
+      const opensDocument = i === 0;
+      const severity: Severity = opensDocument ? "medium" : "low";
+
+      const setupText = setup.unit.trim();
+      const turnText = turn.unit.trim();
+      const counted = isQuantitySetup(setup);
+
+      findings.push({
+        ruleId: RULE_ID,
+        span: spanning([setup, turn]),
+        severity,
+        message:
+          `${counted ? "A bare count" : "A bare noun phrase"} answered by a negation: ` +
+          `“${setupText}. ${turnText}.”`,
+        explanation:
+          `“${setupText}.” is not a sentence. It names a thing and stops, and then “${turnText}.” ` +
+          `takes the thing away before the reader has been told anything about it. Two beats in ` +
+          `there is still nothing to agree or disagree with, which is the formula working: a frame ` +
+          `bought with ${counted ? "a specific-sounding number" : "a noun phrase"} and paid off ` +
+          `with a reversal, and no argument made anywhere in it. ` +
+          `${opensDocument ? "Opening on it makes it the first thing the reader meets. " : ""}` +
+          `Put the setup inside the sentence that makes the argument: what were they, whose were ` +
+          `they, and what went wrong because of it.`,
+      });
+
+      i++; // a beat belongs to one pair; don't let a void beat also open the next
+    }
+
+    return findings;
+  },
+};

--- a/scripts/destink/vendor/lint/rules/sounds-like-claude.ts
+++ b/scripts/destink/vendor/lint/rules/sounds-like-claude.ts
@@ -1,0 +1,112 @@
+// claude/sounds-like-claude (issue #34) — the capstone. Every other claude-* rule in this
+// directory flags ONE family of Claude-isms (chat-register phrases, dev-prose idiolect, discourse
+// markers, fiction frames, fiction gestures, figurative suffixes, leaked artifacts, aphoristic
+// enders, elegant variation, mirrored clauses). A document can
+// trip any single one of those without reading as machine-written at all — a real engineer says
+// "footgun" and "north star" without ever having talked to an AI. What's actually diagnostic is
+// several DIFFERENT families showing up in the same document: that's not vocabulary, that's a
+// voice. This rule is the document-level signal for that co-occurrence.
+//
+// Tier: "discourse", not "lexical" — like repetition.ts's dilution rule, this reasons over the
+// WHOLE document's rule outputs, not over any one span of text. It has no lexicon of its own.
+//
+// WHY THE FAMILY RULES ARE IMPORTED DIRECTLY, NOT VIA registry.ts: registry.ts imports this file
+// (to add soundsLikeClaudeRule to RULES); importing registry.ts back from here to enumerate
+// "every rule whose id starts with claude" would be a straight import cycle. Importing the ten
+// concrete rule objects directly below is both cycle-free and exactly equivalent in practice — the
+// list below already covers every registered rule whose id starts "claude", including the three
+// discourse-tier structural rules whose file headers also say "claude-isms tier, #34"
+// (aphoristic-ender.ts, elegant-variation.ts, mirrored-clauses.ts) even though they don't live in
+// this file's lexical neighborhood (checked against registry.ts by hand; the hygiene test in
+// sounds-like-claude.test.ts re-checks it every run so this can't drift silently).
+//
+// WHY THE FAMILIES' OWN FINDINGS STILL APPEAR SEPARATELY (this rule is a CAPSTONE, not a
+// replacement): a reader fixing "footgun" needs to know it's specifically the dev-prose idiolect
+// that's the tell, with its own explanation and its own severity — collapsing that into one
+// document-wide note would lose the "which word, where, why" specificity every other rule in this
+// tier promises. This rule adds ONE extra signal on top — "the co-occurrence itself is the
+// pattern" — it does not suppress or replace what the family rules already reported. (The engine's
+// dedupe key is ruleId+span, so this rule's whole-document span under its own id never collides
+// with anything the family rules reported under theirs.)
+//
+// DETERMINISM: family order below is fixed (declaration order, not discovery order), the message
+// lists families in that same fixed order, and finding counts come straight from each family's own
+// detect() — same doc in, same finding out, every run.
+import type { DocAnalysis, Finding, TropeRule } from "../types.js";
+import { aiLeakageRule } from "./ai-leakage.js";
+import { aphoristicEnderRule } from "./aphoristic-ender.js";
+import { claudeAssistantVoiceRule } from "./claude-assistant-voice.js";
+import { claudeDiscourseMarkersRule } from "./claude-discourse-markers.js";
+import { claudeFictionFramesRule, claudeFictionGesturesRule } from "./claude-fiction.js";
+import { claudeFigurativeSuffixesRule } from "./claude-figurative.js";
+import { contrastTailRule } from "./contrast-tail.js";
+import { colonRevealRule } from "./colon-reveal.js";
+import { claudeStockFramesRule } from "./claude-stock-frames.js";
+import { claudeTechnicalVocabularyRule } from "./claude-lexicon.js";
+import { elegantVariationRule } from "./elegant-variation.js";
+import { mirroredClausesRule } from "./mirrored-clauses.js";
+
+const RULE_ID = "claude/sounds-like-claude";
+
+// Every registry.ts rule whose id starts "claude" — see the header note on why this is a direct
+// list rather than a registry lookup. sounds-like-claude.test.ts's hygiene check keeps this honest.
+const CLAUDE_FAMILIES: readonly TropeRule[] = [
+  aiLeakageRule,
+  aphoristicEnderRule,
+  claudeAssistantVoiceRule,
+  claudeDiscourseMarkersRule,
+  claudeFictionFramesRule,
+  claudeFictionGesturesRule,
+  claudeFigurativeSuffixesRule,
+  claudeStockFramesRule,
+  claudeTechnicalVocabularyRule,
+  colonRevealRule,
+  contrastTailRule,
+  elegantVariationRule,
+  mirroredClausesRule,
+];
+
+// A document needs findings from at least this many DISTINCT families before the co-occurrence
+// itself is worth flagging. Below this, any one (or two, or three) families firing alone is just
+// that family's own finding(s) doing their job — see the file header.
+const CO_OCCURRENCE_THRESHOLD = 4;
+
+export const soundsLikeClaudeRule: TropeRule = {
+  id: RULE_ID,
+  name: "Sounds like Claude (family co-occurrence)",
+  tier: "discourse",
+  detect(doc: DocAnalysis): Finding[] {
+    const counts: { rule: TropeRule; count: number }[] = [];
+    for (const rule of CLAUDE_FAMILIES) {
+      const n = rule.detect(doc).length;
+      if (n > 0) counts.push({ rule, count: n });
+    }
+
+    if (counts.length < CO_OCCURRENCE_THRESHOLD) return [];
+
+    const breakdown = counts.map(({ rule, count }) => `${rule.id} (x${count})`).join(", ");
+    const totalHits = counts.reduce((sum, { count }) => sum + count, 0);
+
+    return [
+      {
+        ruleId: RULE_ID,
+        span: { start: 0, end: doc.text.length },
+        severity: "high",
+        message: `${counts.length} distinct Claude-isms families co-occur in this document: ${breakdown}`,
+        explanation:
+          `Any one of these families alone is just a word choice — a real engineer says "footgun" ` +
+          `without ever prompting an AI. But ${counts.length} different families (${totalHits} hits ` +
+          `total) landing in the same document is a voice, not a vocabulary: ${breakdown}. Each ` +
+          `finding above still points at its own specific phrase and family; this one flags the ` +
+          `pattern of all of them showing up together. Read the piece for a consistent register in ` +
+          `your own voice, not just word-by-word swaps.`,
+      },
+    ];
+  },
+};
+
+// Hygiene check (issue #34's consolidation ask): CLAUDE_FAMILIES above must track "every registered
+// rule whose id starts 'claude'" exactly. Importing registry.ts here (to compare against RULES)
+// would reintroduce the cycle this file's header explains avoiding, so instead this exports the id
+// set for a test file to import ALONGSIDE registry.ts and compare from the outside.
+export const CLAUDE_FAMILY_IDS: ReadonlySet<string> = new Set(CLAUDE_FAMILIES.map((r) => r.id));

--- a/scripts/destink/vendor/lint/rules/staccato-register.ts
+++ b/scripts/destink/vendor/lint/rules/staccato-register.ts
@@ -1,0 +1,312 @@
+// STACCATO REGISTER (#34's other half) — the de-stinked document.
+//
+// The prompt loop this rule exists for is now a common one: a writer asks a model to strip the
+// semicolons, the colons and the em dashes, then asks it again to stop using commas, then again to
+// make the sentences shorter, until what comes back is a column of one-sentence paragraphs with
+// almost no punctuation inside them. The output reads clean. Nothing was fixed.
+//
+// The measurement that motivated this rule: the same 400-word argument, once as its author's
+// de-punctuated LinkedIn version and once rewritten with ordinary punctuation and paragraphs,
+// scores 29.9 and 60.3 respectively under the rest of this registry. Every rule keyed to a
+// character the loop deletes — formatting/em-dash-density, tricolon/comma-series — goes quiet, and
+// the reframe, the tricolon and the fragment run are all still sitting there in the text. The loop
+// is a straight exploit against the scorer, and it does not touch the writing.
+//
+// --- what the rule actually claims ---
+//
+// The punctuation did not disappear. It MIGRATED. Every comma that got deleted came back as a full
+// stop and every full stop came back as a blank line, so the clause boundaries left the marks and
+// moved into the whitespace. That migration is what this rule measures, and it takes both halves to
+// see it. Measured over the sample above plus this repo's own prose and two hard negatives:
+//
+//   document                  internal marks/unit    one-sentence paragraphs
+//   the de-punctuated post           0.37                     90%
+//   Hemingway, Old Man               0.36                     25%
+//   a human LinkedIn post            0.63                     67%
+//   README.md                        1.49                     14%
+//   DESIGN.md                        1.19                     58%
+//   DESTINK.md                       1.42                     15%
+//   RESEARCH.md                      1.30                     24%
+//
+// Neither column is a rule on its own, and the two failures are the whole argument for the
+// conjunction. Punctuation starvation alone flags Hemingway HARDER than it flags the post — that is
+// issue #35's human-literary false positive arriving by a new road. Paragraph layout alone flags
+// the human LinkedIn post and DESIGN.md. Hemingway is sparse but keeps his sentences inside
+// paragraphs; the LinkedIn writer breaks her lines but keeps her commas. Doing both is what a
+// punctuation ban plus "shorter" plus "shorter" produces, and very little else does.
+//
+// CAVEAT, stated because the thresholds below look more settled than they are: that table is seven
+// documents, five of them from this repo. The gap between 0.63 and 1.19 is clean but it is seven
+// points wide. Re-measure over whatever corpus #35 assembles for the Melville false positives
+// before treating INTERNAL_PER_UNIT_MAX as anything but a first cut.
+//
+// --- tier ---
+//
+// "discourse", for the reason rules/fragments.ts gives for the same choice: this is a document-wide
+// density measure over doc.units and says nothing about any one sentence's grammar. It reads
+// markdownContext for structure the way the formatting tier does, but a formatting rule does not
+// read doc.units and this one is built on them.
+//
+// --- severity ---
+//
+// Three tiers, escalating on evidence about the CAUSE, because the base conjunction is a shape
+// someone could have chosen on purpose:
+//
+//   low     the conjunction alone. A register, reported as one.
+//   medium  plus punctuation displaced into SYMBOLS. You do not reach for "!=" between two nouns
+//           unless "is not" felt forbidden, and you do not shout a whole line in capitals unless
+//           the emphasis you wanted had nowhere else to go. This is the tell that the punctuation
+//           was avoided rather than simply never needed — which is exactly what separates this
+//           document from a plain writer with short sentences.
+//   high    plus two or more structural tropes still firing. This is the finding worth reading:
+//           the scrub moved the tells, it did not remove them.
+//
+// SURVIVOR RULES ARE IMPORTED DIRECTLY, NOT VIA registry.ts — same constraint and same resolution
+// as rules/sounds-like-claude.ts's header explains: registry.ts imports this file, so importing it
+// back to enumerate rules would be a cycle. None of the seven below imports registry.ts.
+//
+// DETERMINISM: survivor order is declaration order, displacement kinds are reported in a fixed
+// order, and every count comes from a pure pass over doc.text — same document in, same finding out.
+
+import type { DocAnalysis, Finding, Severity, TropeRule, UnitAnalysis } from "../types.js";
+import { markdownContext, inKind, type MarkdownContext } from "../markdown.js";
+import { anaphoraRule } from "./anaphora.js";
+import { colonRevealRule } from "./colon-reveal.js";
+import { contrastTailRule } from "./contrast-tail.js";
+import { punchyFragmentsRule } from "./fragments.js";
+import { reframeRule } from "./reframe.js";
+import { tricolonRule } from "./tricolon.js";
+import { tricolonSeriesRule } from "./tricolon-series.js";
+
+const RULE_ID = "discourse/staccato-register";
+
+// --- gates ---
+//
+// A reader clocks this register in about five lines, and the rule should too. The floors are
+// therefore low: six sentences across four paragraphs is enough to SEE, and the first draft of this
+// rule (12 units, 10 paragraphs) stayed silent through the first eleven paragraphs of the post that
+// motivated it, which is eleven paragraphs past the point a person would have called it.
+//
+// What the low floors cost, and how it is paid: the human LinkedIn post in the table above sits at
+// 0.63 marks/unit and 67% solo paragraphs, near enough both thresholds that a size gate excluding
+// it was really excluding it on a coin-flip. So the size gate does not decide it any more. Below
+// SELF_EVIDENT_*, the conjunction alone is not enough — the document must ALSO show corroboration
+// (see CORROBORATION below), and that post shows none: no symbols, no glyph markers, nothing
+// shouted, and fewer than two structural tropes. It is now excluded on evidence rather than on
+// word count, which is the only exclusion that survives someone writing 400 words in that voice.
+const MIN_UNITS = 6;
+const MIN_PARAGRAPHS = 4;
+
+// Above BOTH of these the density is its own argument and the conjunction fires unaided: at twelve
+// sentences across ten paragraphs, "almost no internal punctuation" and "almost every paragraph is
+// one sentence" are no longer small-sample artifacts.
+const SELF_EVIDENT_UNITS = 12;
+const SELF_EVIDENT_PARAGRAPHS = 10;
+
+// Internal punctuation per unit, at or above which the document is punctuated normally. Everything
+// in the table that is ordinary prose sits at 1.19 or higher; everything starved sits at 0.63 or
+// lower.
+const INTERNAL_PER_UNIT_MAX = 0.75;
+
+// Fraction of unit-bearing prose paragraphs that hold exactly one unit, at or above which the
+// layout is one-idea-per-line. DESIGN.md's 58% is the highest ordinary-prose reading measured.
+const SOLO_PARAGRAPH_MIN = 0.7;
+
+// CORROBORATION. Below the self-evident size, the conjunction has to be joined by independent
+// evidence that the punctuation was AVOIDED rather than simply not needed: either the punctuation
+// reappearing as symbols (displacementKinds — a symbol where a copula belongs, a glyph list marker,
+// a shouted line) or two or more structural tropes still firing. Both are things a plain writer
+// with short sentences does not do, and both are things the scrub-the-punctuation loop produces on
+// its own. This is what lets the floors above be low without the rule turning into a complaint
+// about terse writing.
+
+// Structural tropes that survive a punctuation scrub with their shape intact. Two or more still
+// firing is what escalates to "high" — one could be incidental.
+const SURVIVORS: readonly TropeRule[] = [
+  anaphoraRule,
+  colonRevealRule,
+  contrastTailRule,
+  punchyFragmentsRule,
+  reframeRule,
+  tricolonRule,
+  tricolonSeriesRule,
+];
+const MIN_SURVIVORS = 2;
+
+// --- counting ---
+
+const WORD_RE = /[\p{L}\p{N}]/u;
+
+// The marks a clause boundary lives in. Em dash and the double-hyphen dash are counted here rather
+// than left to formatting/em-dash-density: this rule is measuring whether internal punctuation is
+// PRESENT, and a document full of em dashes is not starved even though that rule has its own
+// complaint about it. Counting them makes this rule strictly harder to fire, which is the right
+// direction for a document-wide claim.
+const INTERNAL_RE = /[,;:()]|—|–|--/g;
+
+const hasWord = (u: UnitAnalysis): boolean => WORD_RE.test(u.unit);
+
+function countInternalMarks(ctx: MarkdownContext): number {
+  let n = 0;
+  for (const m of ctx.text.matchAll(INTERNAL_RE)) {
+    const span = { start: m.index!, end: m.index! + m[0].length };
+    if (!inKind(ctx, span, "codeFence")) n++;
+  }
+  return n;
+}
+
+// Units are attributed to the paragraph their span STARTS in. A unit that runs past a paragraph
+// boundary (splitUnits does not split on newlines — see document.ts) belongs to where it began,
+// which is also where a reader would say the sentence is. Paragraphs holding no unit at all — a
+// bare label line with no terminal punctuation, say — are not counted in either the numerator or
+// the denominator: they are not evidence of one-sentence-per-paragraph OR against it.
+type Layout = { solo: number; withUnits: number };
+
+function paragraphLayout(ctx: MarkdownContext, units: readonly UnitAnalysis[]): Layout {
+  let solo = 0;
+  let withUnits = 0;
+  for (const p of ctx.paragraphs) {
+    let n = 0;
+    for (const u of units) if (u.span.start >= p.span.start && u.span.start < p.span.end) n++;
+    if (n === 0) continue;
+    withUnits++;
+    if (n === 1) solo++;
+  }
+  return { solo, withUnits };
+}
+
+// --- displacement: where the punctuation went ---
+//
+// Three shapes, each a way of encoding something punctuation used to carry. All three are line
+// tests over doc.text, deliberately not parse-based: the point is what the surface looks like.
+
+// A line whose whole content is "<words> <operator> <words>" with no verb in sight — "Capability
+// != Authority". The operator is standing in for a copula the writer would otherwise have had to
+// spell out. Requires words on both sides so an arithmetic line inside prose is not caught by the
+// glyph alone.
+const OPERATOR_COPULA_RE = /^\s*[\p{L}\p{N}][^\n]*?\s[≠≈≡≪≫]\s[^\n]*[\p{L}\p{N}][^\n]*$/u;
+
+// A line-initial marker glyph. markdown.ts now classifies these as bullets (see its BULLET_RE
+// note), so this test reads the raw line rather than the classification — the question here is not
+// "is this a list" but "did the writer reach for a glyph to mark it".
+const GLYPH_BULLET_RE = /^ {0,3}[•‣▪▸◦→⇒➜➤]\s+\S/u;
+
+// A whole line shouted. Emphasis with nowhere else to go once the writer has no italics, no bold
+// and no punctuation to lean on. Needs >= 3 words and >= 12 characters so an acronym line ("LLM"),
+// a heading-ish label ("API") or "OK" never qualifies, and at least one multi-letter word so a line
+// of initialisms does not either.
+const ALL_CAPS_RE = /^[^\p{Ll}\n]*\p{Lu}[^\p{Ll}\n]*$/u;
+
+function displacementKinds(ctx: MarkdownContext): string[] {
+  const kinds: string[] = [];
+  let operator = 0;
+  let glyph = 0;
+  let caps = 0;
+
+  for (const line of ctx.lines) {
+    if (line.kind === "codeFence") continue;
+    const raw = ctx.text.slice(line.span.start, line.span.end);
+    if (OPERATOR_COPULA_RE.test(raw)) operator++;
+    if (GLYPH_BULLET_RE.test(raw)) glyph++;
+    if (line.kind !== "heading") {
+      const words = raw.match(/[\p{L}]{2,}/gu) ?? [];
+      if (words.length >= 3 && raw.trim().length >= 12 && ALL_CAPS_RE.test(raw)) caps++;
+    }
+  }
+
+  // Fixed order, not discovery order — see the header's determinism note.
+  if (operator > 0) kinds.push(`${operator} line${operator === 1 ? "" : "s"} using a symbol where a verb belongs`);
+  if (glyph > 0) kinds.push(`${glyph} glyph-marked list line${glyph === 1 ? "" : "s"}`);
+  if (caps > 0) kinds.push(`${caps} line${caps === 1 ? "" : "s"} shouted in capitals`);
+  return kinds;
+}
+
+// --- the rule ---
+
+export const staccatoRegisterRule: TropeRule = {
+  id: RULE_ID,
+  name: "Staccato register (punctuation stripped, tells intact)",
+  tier: "discourse",
+  detect(doc: DocAnalysis): Finding[] {
+    const units = doc.units.filter(hasWord);
+    if (units.length < MIN_UNITS) return [];
+
+    const ctx = markdownContext(doc.text);
+    const { solo, withUnits } = paragraphLayout(ctx, units);
+    if (withUnits < MIN_PARAGRAPHS) return [];
+
+    const internal = countInternalMarks(ctx);
+    const perUnit = internal / units.length;
+    if (perUnit >= INTERNAL_PER_UNIT_MAX) return [];
+
+    const soloFraction = solo / withUnits;
+    if (soloFraction < SOLO_PARAGRAPH_MIN) return [];
+
+    const kinds = displacementKinds(ctx);
+    const survivors = SURVIVORS.filter((r) => r.detect(doc).length > 0);
+
+    // See CORROBORATION above: a small document has to show that the punctuation was avoided, not
+    // merely absent, before this rule will make a claim about its register.
+    const selfEvident = units.length >= SELF_EVIDENT_UNITS && withUnits >= SELF_EVIDENT_PARAGRAPHS;
+    if (!selfEvident && kinds.length === 0 && survivors.length < MIN_SURVIVORS) return [];
+
+    const severity: Severity =
+      survivors.length >= MIN_SURVIVORS ? "high" : kinds.length > 0 ? "medium" : "low";
+
+    const rounded = Math.round(perUnit * 100) / 100;
+    const pct = Math.round(soloFraction * 100);
+    const message =
+      `${solo} of ${withUnits} paragraphs are a single sentence (${pct}%) and the document averages ` +
+      `${rounded} internal punctuation marks per sentence`;
+
+    const parts: string[] = [
+      `${solo} of this document's ${withUnits} paragraphs hold exactly one sentence, and across ` +
+        `${units.length} sentences there are ${internal} commas, semicolons, colons, parentheses ` +
+        `and dashes in total — ${rounded} per sentence, against 1.2 to 1.5 for ordinary prose. ` +
+        `The clause boundaries did not go away; they moved out of the punctuation and into the ` +
+        `blank lines.`,
+    ];
+
+    if (kinds.length > 0) {
+      parts.push(
+        `The punctuation was avoided rather than never needed: ${kinds.join(", ")}. Nobody puts a ` +
+          `symbol between two nouns unless writing "is not" felt off-limits.`,
+      );
+    }
+
+    if (survivors.length >= MIN_SURVIVORS) {
+      parts.push(
+        `And the tells are all still here — ${survivors.map((r) => r.id).join(", ")} each still ` +
+          `fire on this text. Deleting punctuation relocated them into the line breaks; it did not ` +
+          `remove them. Fix the shapes those rules point at, then let the punctuation back in.`,
+      );
+    } else {
+      parts.push(
+        `Let some of these sentences join each other. A comma that subordinates one clause to ` +
+          `another is doing work no full stop can do, and a reader who is handed one idea per line ` +
+          `has to assemble the argument themselves.`,
+      );
+    }
+
+    return [
+      {
+        ruleId: RULE_ID,
+        span: { start: 0, end: doc.text.length },
+        severity,
+        message,
+        explanation: parts.join(" "),
+      },
+    ];
+  },
+};
+
+// Exported for the rule's own tests to assert against without re-deriving the thresholds.
+export const THRESHOLDS = {
+  MIN_UNITS,
+  MIN_PARAGRAPHS,
+  SELF_EVIDENT_UNITS,
+  SELF_EVIDENT_PARAGRAPHS,
+  INTERNAL_PER_UNIT_MAX,
+  SOLO_PARAGRAPH_MIN,
+  MIN_SURVIVORS,
+} as const;

--- a/scripts/destink/vendor/lint/rules/standard-lexicon.ts
+++ b/scripts/destink/vendor/lint/rules/standard-lexicon.ts
@@ -1,0 +1,66 @@
+// Shared factory for standalone lexicons that want the GENERIC lexical tier's severity philosophy
+// (rules/lexical.ts's buildLexiconRule: density STEPS DOWN a sparse hit) but can't go through
+// lexical.ts's own LEXICONS-driven pipeline, because that pipeline auto-builds one rule per entry
+// in lexicons/index.ts's LEXICONS array and lexical.test.ts pins that array's exact rule count.
+// Adding a lexicon there for this consolidation pass would both grow that hardcoded count (a wave-1
+// test this pass doesn't own) and mix these words into the lexical tier's blanket exports.
+//
+// This is the "standard-tier" analogue of rules/claude-lexicon.ts's buildClaudeLexiconRule: same
+// idea (one shared factory, several concrete rule files import it and supply a Lexicon + taught
+// explanation), opposite severity direction. buildLexiconRule itself isn't exported from
+// lexical.ts, so this reimplements its density step-down logic — about a dozen lines, not worth a
+// bigger refactor of lexical.ts to share one function. It DOES reuse lexical.ts's entryHits (word
+// boundaries, phrase matching, lemma, posGate — the actual matching semantics), so this file's only
+// job is severity/density scoring, not re-deriving how a word gets found.
+//
+// See rules/lexical.ts's own header for the full density model this mirrors: a lexicon declares
+// densityThreshold N; when total hits < N, every hit whose entry rides the lexicon's
+// defaultSeverity (no per-entry override) is reported one severity step down, floored at
+// "candidate"; an entry with an explicit severity is exempt in both directions.
+
+import type { DocAnalysis, Finding, Severity, Span, TropeRule } from "../types.js";
+import { textAt } from "../span.js";
+import type { Lexicon, LexiconEntry } from "../lexicons/index.js";
+import { entryHits } from "./lexical.js";
+
+const SEVERITY_STEPS: readonly Severity[] = ["candidate", "low", "medium", "high"];
+
+function stepDown(s: Severity): Severity {
+  const i = SEVERITY_STEPS.indexOf(s);
+  return SEVERITY_STEPS[Math.max(0, i - 1)]!;
+}
+
+export function buildStandardLexiconRule(lexicon: Lexicon, explanation: string): TropeRule {
+  return {
+    id: lexicon.id,
+    name: lexicon.name,
+    tier: "lexical",
+    detect(doc: DocAnalysis): Finding[] {
+      const rawHits: { entry: LexiconEntry; span: Span }[] = [];
+      for (const unit of doc.units) {
+        for (const entry of lexicon.entries) {
+          for (const span of entryHits(entry, unit.words)) rawHits.push({ entry, span });
+        }
+      }
+      if (rawHits.length === 0) return [];
+
+      const total = rawHits.length;
+      const findings: Finding[] = rawHits.map(({ entry, span }) => {
+        const base = entry.severity ?? lexicon.defaultSeverity;
+        const belowDensity =
+          entry.severity === undefined && lexicon.densityThreshold !== undefined && total < lexicon.densityThreshold;
+        const severity = belowDensity ? stepDown(base) : base;
+        return {
+          ruleId: lexicon.id,
+          span,
+          severity,
+          message: `${lexicon.name}: “${textAt(doc, span)}”`,
+          explanation,
+        };
+      });
+
+      findings.sort((a, b) => a.span.start - b.span.start || a.span.end - b.span.end);
+      return findings;
+    },
+  };
+}

--- a/scripts/destink/vendor/lint/rules/tricolon-series.ts
+++ b/scripts/destink/vendor/lint/rules/tricolon-series.ts
@@ -1,0 +1,237 @@
+// COMMA-SERIES TRICOLON (#34) — "A, B, and C" read off the raw text, with no parser involved.
+//
+// rules/tricolon.ts detects the rule-of-three STRUCTURALLY, out of the Clause IR's `Compound`
+// nodes, which is the right way to do it — when the parse produces one. On the no-model path it
+// usually doesn't: the rule-based chunker never builds an N-item Compound out of a comma list (it
+// merges the conjuncts into one head instead of splitting them), a limit tricolon.ts's own fixture
+// file already records as a negative ("She bought apples, bananas, and cherries." — no Compound).
+// The consequence is that the single most common real-world tricolon — the comma series in a
+// LinkedIn-shaped post — is invisible to the IR rule on the path most users run. This rule closes
+// that recall gap by reading the shape off the source text: commas and one coordinator, nothing
+// more.
+//
+// --- the shape ---
+//
+//   A, B(, C)*, and Z        the Oxford form: the series ends in a segment that OPENS with and/or
+//   A, B and Z               the no-Oxford form: the last comma segment carries the coordinator
+//                            internally, so the split happens on " and " / " or " inside it
+//
+// Both need >= 3 items inside ONE unit. Items are runs of words, not single words: "contribute
+// code" and "iterate alongside engineering" are items, and requiring single-word items would miss
+// every interesting case.
+//
+// Anything AFTER the coordinated segment is not part of the series and is cut off — that is what
+// makes "automate everything you safely can, keep humans in the loop only where risk demands it,
+// and bake governance into the design phase, not the end of the pipeline" a 3-item series rather
+// than a 4-item one. (The trailing ", not …" there is claude/contrast-tail's finding, not this
+// rule's.)
+//
+// --- precision guards, and what they are actually protecting against ---
+//
+//   letters      every item must contain a letter and must not be a bare numeral, so the comma in
+//                "May 1, 2024" or "1,000, 2,000, and 3,000" cannot manufacture items.
+//   length       a non-final item runs to at most ITEM_MAX_WORDS words. #34's brief suggested ~8;
+//                the post that motivated the rule has a 10-word item ("keep humans in the loop only
+//                where risk demands it"), so 8 would have made the rule blind to its own motivating
+//                sample. 12 it is. The FINAL item gets a looser cap (FINAL_ITEM_MAX_WORDS) because
+//                the last item of a series routinely absorbs a trailing adjunct belonging to the
+//                whole series — "help build the guardrails from day one rather than reviewing after
+//                the fact".
+//   phrases      a THREE-item series needs at least MIN_MULTIWORD_ITEMS items of more than one
+//                word. Three bare nouns ("apples, bananas, and cherries") is an ordinary
+//                enumeration, not the rhetorical tic; the tell at that length is the RHYTHM of
+//                parallel phrases. This is also what keeps this rule off tricolon.ts's own fixture
+//                negative. Four items and up skip the test, for the same reason tricolon.ts flags a
+//                4-item Compound on its own: at that length the list is the tell whatever the items
+//                are made of.
+//
+// The span a finding reports runs from the start of the first item to the end of the last, and the
+// first item is whatever precedes the first comma — including any sentence opening glued to it
+// ("The rollout covered logging, alerting, tracing, …" starts its first item at "The"). Finding
+// where a series really begins needs a parser; the span stays honest by covering the whole run.
+//
+// A comma splice of short clauses ("I came, I saw, I conquered") is deliberately NOT guarded
+// against: that is a tricolon, and it should fire.
+//
+// KNOWN FALSE POSITIVE, accepted: a leading adverbial followed by two coordinated clauses ("Last
+// year, the team shipped it, and everyone cheered") has exactly the same comma-and-coordinator
+// silhouette as a 3-item series and no parser-free test tells them apart. It fires at "low", the
+// gentlest severity there is, which is the honest weight for a shape this ambiguous.
+//
+// --- not double-firing with the IR rule ---
+//
+// When the parse DID produce a Compound, tricolon.ts owns the finding. Rather than guess at that
+// from here, this rule runs tricolonRule over the same document and drops any of its own findings
+// that overlap an IR finding's span. Only the per-compound "tricolon/density" findings count for
+// that: the sibling "tricolon/document-density" finding spans the WHOLE document by design, so
+// letting it into the overlap test would suppress everything, everywhere, whenever a document
+// happened to be tricolon-dense.
+
+import type { DocAnalysis, Finding, Severity, Span, TropeRule, UnitAnalysis } from "../types.js";
+import { overlaps } from "../span.js";
+import { tricolonRule } from "./tricolon.js";
+
+const RULE_ID = "tricolon/comma-series";
+
+const MIN_ITEMS = 3;
+const ITEM_MAX_WORDS = 12; // a non-final item longer than this is a clause, not a list item
+const FINAL_ITEM_MAX_WORDS = 16; // the last item carries the series' trailing adjunct
+const MIN_MULTIWORD_ITEMS = 2; // a three-item bare-noun enumeration is not the trope
+const BARE_LIST_OK_AT = 4; // ...but at four items the list is the tell whatever the items are
+
+const wordRe = (): RegExp => /[\p{L}\p{N}]+(?:['‘’ʼ-][\p{L}\p{N}]+)*/gu;
+const wordCount = (s: string): number => (s.match(wordRe()) ?? []).length;
+const hasLetter = (s: string): boolean => /\p{L}/u.test(s);
+
+// --- segmentation ---
+
+type Segment = { text: string; span: Span };
+
+// Trim whitespace off both ends of [start, end), keeping the offsets in step.
+function trimSpan(text: string, start: number, end: number): Span | null {
+  while (start < end && /\s/.test(text[start]!)) start++;
+  while (end > start && /\s/.test(text[end - 1]!)) end--;
+  return end > start ? { start, end } : null;
+}
+
+// The unit minus its trailing punctuation. document.ts's readDocument excludes the terminator from
+// a unit's span; stub-doc.ts's makeDoc folds it in. Trimming it here means the last item of a series
+// slices to the same text under either document builder.
+const TERMINATORS = ".!?;:";
+function coreSpan(text: string, span: Span): Span | null {
+  let end = span.end;
+  while (end > span.start && (/\s/.test(text[end - 1]!) || TERMINATORS.includes(text[end - 1]!))) end--;
+  return end > span.start ? { start: span.start, end } : null;
+}
+
+// The unit's text cut on every comma, each piece carrying its source offsets. Empty pieces (a
+// doubled comma, a trailing one) drop out — they are not items.
+function commaSegments(text: string, span: Span): Segment[] {
+  const segments: Segment[] = [];
+  let start = span.start;
+  for (let i = span.start; i <= span.end; i++) {
+    if (i < span.end && text[i] !== ",") continue;
+    const trimmed = trimSpan(text, start, i);
+    if (trimmed) segments.push({ text: text.slice(trimmed.start, trimmed.end), span: trimmed });
+    start = i + 1;
+  }
+  return segments;
+}
+
+// "and Z" / "or Z" -> the offset just past the coordinator, or -1 when the segment doesn't open
+// with one.
+const CONJ_OPENER = /^(?:and|or)\s+/i;
+function afterOpeningConj(seg: Segment): number {
+  const m = CONJ_OPENER.exec(seg.text);
+  return m ? seg.span.start + m[0].length : -1;
+}
+
+// The first internal " and " / " or " of a segment: the no-Oxford form's split point, returned as
+// [end of the left item, start of the right item].
+const INTERNAL_CONJ = /\s+(?:and|or)\s+/i;
+function splitInternalConj(seg: Segment): [Span, Span] | null {
+  const m = INTERNAL_CONJ.exec(seg.text);
+  if (!m) return null;
+  const left = trimSpan(seg.text, 0, m.index);
+  if (!left) return null;
+  const rightStart = m.index + m[0].length;
+  const right = trimSpan(seg.text, rightStart, seg.text.length);
+  if (!right) return null;
+  return [
+    { start: seg.span.start + left.start, end: seg.span.start + left.end },
+    { start: seg.span.start + right.start, end: seg.span.start + right.end },
+  ];
+}
+
+// --- the series ---
+
+function itemsOf(text: string, unit: UnitAnalysis): Span[] | null {
+  const core = coreSpan(text, unit.span);
+  if (!core) return null;
+  const segments = commaSegments(text, core);
+  if (segments.length < 2) return null;
+
+  // Oxford: the first segment at index >= 2 that opens with a coordinator closes the series, and
+  // everything after it (a trailing ", not X" tail, an appended clause) is not part of it.
+  const closing = segments.findIndex((s, i) => i >= 2 && afterOpeningConj(s) >= 0);
+  if (closing >= 0) {
+    const last = segments[closing]!;
+    return [...segments.slice(0, closing).map((s) => s.span), { start: afterOpeningConj(last), end: last.span.end }];
+  }
+
+  // No Oxford comma: the coordinator lives inside the final segment, which therefore holds the
+  // last TWO items. One comma is enough here ("A, B and Z" is three items).
+  const tail = segments[segments.length - 1]!;
+  if (afterOpeningConj(tail) >= 0) return null; // "A, and B" — two items, not a series
+  const split = splitInternalConj(tail);
+  if (!split) return null;
+  return [...segments.slice(0, -1).map((s) => s.span), ...split];
+}
+
+function isSeries(text: string, items: Span[]): boolean {
+  if (items.length < MIN_ITEMS) return false;
+  const texts = items.map((s) => text.slice(s.start, s.end));
+  if (!texts.every(hasLetter)) return false;
+  const counts = texts.map(wordCount);
+  if (counts.some((n) => n === 0)) return false;
+  if (counts.slice(0, -1).some((n) => n > ITEM_MAX_WORDS)) return false;
+  if (counts[counts.length - 1]! > FINAL_ITEM_MAX_WORDS) return false;
+  if (items.length >= BARE_LIST_OK_AT) return true;
+  return counts.filter((n) => n >= 2).length >= MIN_MULTIWORD_ITEMS;
+}
+
+// 3 is ordinary rhetoric read once and a tic read twice, so it is visible but gentle; 4-5 is a list
+// wearing a sentence; 6+ is an inventory. The escalation mirrors rules/tricolon.ts's own.
+const severityFor = (count: number): Severity => (count >= 6 ? "high" : count >= 4 ? "medium" : "low");
+
+// --- the rule ---
+
+type Hit = { span: Span; items: number; first: string; last: string };
+
+function collect(doc: DocAnalysis): Hit[] {
+  const hits: Hit[] = [];
+  for (const unit of doc.units) {
+    const items = itemsOf(doc.text, unit);
+    if (!items || !isSeries(doc.text, items)) continue;
+    const span: Span = { start: items[0]!.start, end: items[items.length - 1]!.end };
+    hits.push({
+      span,
+      items: items.length,
+      first: doc.text.slice(items[0]!.start, items[0]!.end),
+      last: doc.text.slice(items[items.length - 1]!.start, items[items.length - 1]!.end),
+    });
+  }
+  return hits;
+}
+
+// Spans the IR rule has already claimed. Its document-wide sibling finding is excluded on purpose —
+// see the file header.
+function irClaimedSpans(doc: DocAnalysis): Span[] {
+  return tricolonRule.detect(doc).filter((f) => f.ruleId === "tricolon/density").map((f) => f.span);
+}
+
+export const tricolonSeriesRule: TropeRule = {
+  id: RULE_ID,
+  name: "Tricolon (comma series)",
+  tier: "syntactic",
+  detect(doc: DocAnalysis): Finding[] {
+    const hits = collect(doc);
+    if (hits.length === 0) return [];
+    const claimed = irClaimedSpans(doc);
+    return hits
+      .filter((h) => !claimed.some((c) => overlaps(c, h.span)))
+      .map((h) => ({
+        ruleId: RULE_ID,
+        span: h.span,
+        severity: severityFor(h.items),
+        message: `a ${h.items}-item comma series: “${h.first}, … ${h.last}”`,
+        explanation:
+          `Three parallel phrases in a row land like a drumbeat, and once you hear it you hear it everywhere — ` +
+          `“contribute code, iterate alongside engineering, and help build the guardrails”. ` +
+          (h.items > 3
+            ? `${h.items} items is past rhetoric and into inventory: keep the ones that carry weight and cut the rest. `
+            : `Keep the item that does the work and put the others in their own sentence, or drop one and let two do the job. `) +
+          `The reader remembers what you said, not how evenly you spaced it.`,
+      }));
+  },
+};

--- a/scripts/destink/vendor/lint/rules/tricolon.ts
+++ b/scripts/destink/vendor/lint/rules/tricolon.ts
@@ -1,0 +1,186 @@
+// Tricolon abuse — rule-of-three density. `Compound<T>` (src/ir.ts) already models "X, Y, and Z"
+// structurally: items.length >= 3 is exactly a tricolon (or a longer list) sitting in a subject,
+// predicate, object, or modifier slot anywhere in the clause. This rule walks the whole Clause IR
+// of every lowered unit — a small recursive walker over subjects, predicates, complements and
+// modifiers, since none of the existing modules (ir-query.ts asks yes/no questions of ONE clause;
+// span.ts is offset arithmetic) provide one — and counts every compound of 3+ items it finds.
+//
+// Compound IR nodes carry no source offsets (a `Word` is only `{ text, pos }` — see src/ir.ts),
+// so every finding here degrades to its enclosing UNIT's span, per the issue's guidance for rules
+// that lack word-level spans.
+//
+// Two independent triggers:
+//   - A 4-or-5(+)-item compound is flagged on its own, every time, at a higher severity than a
+//     bare triple: "three things" is ordinary rhetoric and not itself a tell (see the "1 tricolon
+//     clean" acceptance case), but four or five in one series already reads as a list dressed up
+//     as a sentence, even in isolation.
+//   - Document-level density: three or more tricolons ANYWHERE in the document (triples and
+//     larger, all counted together) is the actual trope — "three back-to-back tricolons are a
+//     pattern recognition failure." That finding's span covers the WHOLE document (chosen over
+//     "the third instance" — the pattern is a document-wide property, and a whole-document span
+//     stays correct and unambiguous no matter how the three are spread across units).
+//
+// This rule emits under two ruleIds ("tricolon/density" for the per-compound findings,
+// "tricolon/document-density" for the whole-document one) — the engine's dedupe keys on a
+// finding's OWN ruleId, so one module reporting under sub-ids is an intended shape (see
+// engine.ts's dedupe comment).
+
+import type { Clause, Complement, Gerund, Infinitive, Modifier, Nominal, Predicate, Subject, Verbal } from "../../ir.js";
+import type { DocAnalysis, Finding, TropeRule } from "../types.js";
+
+const RULE_ID = "tricolon/density";
+const DOC_RULE_ID = "tricolon/document-density";
+
+const LARGE_AT = 4; // 4+ items get their own finding, independent of document density
+const DOC_DENSITY_AT = 3; // 3+ tricolons anywhere in the document trips the document-level finding
+
+type Hit = { count: number };
+
+function walkModifiers(mods: Modifier[], out: Hit[]): void {
+  for (const m of mods) {
+    if (m.kind === "prep") walkNominal(m.object, out);
+    else if (m.kind === "clause") walkClause(m.value, out);
+    else if (m.kind === "participle") {
+      if (m.object) walkNominal(m.object, out);
+      walkModifiers(m.modifiers, out);
+    }
+    // m.kind === "word": a bare Word, nothing further to walk
+  }
+}
+
+function walkNominal(n: Nominal, out: Hit[]): void {
+  walkModifiers(n.modifiers, out);
+}
+
+function walkVerbal(v: Verbal, out: Hit[]): void {
+  walkModifiers(v.modifiers, out);
+  if (v.indirectObject) walkNominal(v.indirectObject, out);
+}
+
+function walkInfinitiveOrGerund(v: Infinitive | Gerund, out: Hit[]): void {
+  walkModifiers(v.modifiers, out);
+  if (v.object) walkNominal(v.object, out);
+}
+
+function walkSubject(s: Subject, out: Hit[]): void {
+  if ("items" in s) {
+    out.push({ count: s.items.length });
+    for (const item of s.items) walkNominal(item, out);
+    return;
+  }
+  if ("head" in s) {
+    walkNominal(s, out); // Nominal
+    return;
+  }
+  if ("kind" in s) {
+    walkInfinitiveOrGerund(s, out); // Infinitive | Gerund
+    return;
+  }
+  walkClause(s, out); // a whole clause used nominally ("Whoever made this...")
+}
+
+function walkComplement(c: Complement | null, out: Hit[]): void {
+  if (!c) return;
+  switch (c.kind) {
+    case "directObject": {
+      const v = c.value;
+      if ("items" in v) {
+        out.push({ count: v.items.length });
+        for (const item of v.items) walkNominal(item, out);
+      } else if ("head" in v) {
+        walkNominal(v, out); // Nominal
+      } else if ("kind" in v) {
+        walkInfinitiveOrGerund(v, out); // Infinitive
+      } else {
+        walkClause(v, out); // a causative small clause ("made her students read four novels")
+      }
+      return;
+    }
+    case "predicateNoun": {
+      const v = c.value;
+      if ("items" in v) {
+        out.push({ count: v.items.length });
+        for (const item of v.items) walkNominal(item, out);
+      } else {
+        walkNominal(v, out);
+      }
+      return;
+    }
+    case "predicateAdj": {
+      const v = c.value;
+      if ("items" in v) out.push({ count: v.items.length }); // Compound<Word> — a Word has no further nesting
+      return;
+    }
+    case "objectComplement": {
+      const obj = c.object;
+      if ("items" in obj) {
+        out.push({ count: obj.items.length });
+        for (const item of obj.items) walkNominal(item, out);
+      } else {
+        walkNominal(obj, out);
+      }
+      if (!c.ocIsAdj) walkNominal(c.oc as Nominal, out);
+      return;
+    }
+  }
+}
+
+function walkPredicate(p: Predicate, out: Hit[]): void {
+  if ("items" in p) {
+    out.push({ count: p.items.length });
+    for (const part of p.items) {
+      walkVerbal(part.verb, out);
+      walkComplement(part.complement, out);
+    }
+    return;
+  }
+  walkVerbal(p, out);
+}
+
+function walkClause(clause: Clause, out: Hit[]): void {
+  walkSubject(clause.subject, out);
+  walkPredicate(clause.verb, out);
+  walkComplement(clause.complement, out);
+  for (const a of clause.absolutes ?? []) walkNominal(a, out);
+}
+
+function collectTricolons(clauses: Clause[]): Hit[] {
+  const out: Hit[] = [];
+  for (const c of clauses) walkClause(c, out);
+  return out.filter((h) => h.count >= 3);
+}
+
+export const tricolonRule: TropeRule = {
+  id: RULE_ID,
+  name: "Tricolon abuse (rule-of-three density)",
+  tier: "syntactic",
+  detect(doc: DocAnalysis): Finding[] {
+    const findings: Finding[] = [];
+    let total = 0;
+    for (const unit of doc.units) {
+      if (!unit.clauses || unit.clauses.length === 0) continue;
+      const hits = collectTricolons(unit.clauses);
+      total += hits.length;
+      for (const h of hits) {
+        if (h.count < LARGE_AT) continue;
+        findings.push({
+          ruleId: RULE_ID,
+          span: unit.span,
+          severity: h.count >= LARGE_AT + 1 ? "high" : "medium",
+          message: `a ${h.count}-item list — past a tricolon, into padding`,
+          explanation: `Three items reads as rhetoric; ${h.count} in one series reads like a list dressed up as a sentence. Cut it to three, or make it an actual list.`,
+        });
+      }
+    }
+    if (total >= DOC_DENSITY_AT) {
+      findings.push({
+        ruleId: DOC_RULE_ID,
+        span: { start: 0, end: doc.text.length },
+        severity: "medium",
+        message: `${total} rule-of-three constructions in this document`,
+        explanation: `A tricolon here and there is ordinary rhetoric; ${total} of them in one piece is a tic. Vary the sentence shapes — not every list needs to come in exactly three.`,
+      });
+    }
+    return findings;
+  },
+};

--- a/scripts/destink/vendor/lint/score.ts
+++ b/scripts/destink/vendor/lint/score.ts
@@ -1,0 +1,87 @@
+// The stink score: weighted findings per 1000 words. This is the number issue #13 exists to
+// produce — run any destinking skill's output through the linter and get a score, so "the oracle-
+// gated pass beat this skill" is measurable instead of argued.
+//
+// Weights (why these four numbers, not five, or 1/2/3/4):
+//   candidate  0.25  A rule that narrowed a suspect structurally but can't confirm it without
+//                     semantics (false ranges, #19 — see the Severity doc comment in types.ts).
+//                     It should nudge the score, not swing it: a quarter of the base unit.
+//   low        1     The base unit. "One confirmed tell per 1000 words" is the score's natural
+//                     scale — a `low` finding is worth exactly one of those.
+//   medium     2     A rule staked a firmer claim (usually: density crossed a threshold inside the
+//                     rule itself, per engine.ts's doc comment on why rules see the whole document).
+//   high       4     Reads as a real problem to a reader, not a rule quibble.
+// Doubling per tier (not linear 1/2/3/4) means one `high` outweighs two `medium`s or four `low`s —
+// a pile of minor tics shouldn't out-shout one glaring tell, and vice versa.
+//
+// Word count: whitespace-split tokens of the ORIGINAL source text — `text.trim().split(/\s+/)`.
+// Not the tokenizer's word count (drops punctuation-only tokens, splits contractions) and not a
+// sum of per-unit word spans (would depend on how units were split). Determinism matters more than
+// linguistic purity: one implementation, one number, forever.
+//
+// The floor: below MIN_WORDS_FOR_SCORE, "per 1000 words" amplifies noise — a single `high` finding
+// in a 20-word fragment would score 200. Dividing by max(words, floor) instead of words keeps short
+// inputs from producing scores that can't be compared against real documents.
+
+import type { Finding, Severity, TropeTier } from "./types.js";
+
+export const SEVERITY_WEIGHT: Readonly<Record<Severity, number>> = {
+  candidate: 0.25,
+  low: 1,
+  medium: 2,
+  high: 4,
+};
+
+export const MIN_WORDS_FOR_SCORE = 100;
+
+// Whitespace-split tokens of `text`. See the module doc comment for why this definition (not the
+// tokenizer's) is the one the score uses.
+export function countWords(text: string): number {
+  const trimmed = text.trim();
+  return trimmed === "" ? 0 : trimmed.split(/\s+/).length;
+}
+
+// Every tier, always present in the output (0 when a tier had no findings) so byTier has the same
+// shape regardless of input — a consumer can destructure it without an existence check.
+export const TIERS: readonly TropeTier[] = ["lexical", "syntactic", "formatting", "discourse"];
+
+export type ScoreBreakdown = {
+  total: number;
+  byTier: Readonly<Record<TropeTier, number>>;
+  byRule: Readonly<Record<string, number>>;
+};
+
+// Weighted findings per 1000 words, overall and split by tier and by rule. `ruleTier` maps a
+// finding's ruleId back to its tier — findings don't carry tier themselves (see types.ts), so the
+// caller supplies the lookup (built from whatever TropeRule[] was actually run) rather than this
+// module importing the registry, which would make score.ts untestable without it.
+export function scoreFindings(
+  findings: readonly Finding[],
+  wordCount: number,
+  ruleTier: (ruleId: string) => TropeTier | undefined,
+): ScoreBreakdown {
+  const denom = Math.max(wordCount, MIN_WORDS_FOR_SCORE);
+  const per1000 = (weight: number): number => (weight / denom) * 1000;
+
+  const byTierWeight: Partial<Record<TropeTier, number>> = {};
+  const byRuleWeight: Record<string, number> = {};
+  let totalWeight = 0;
+
+  for (const f of findings) {
+    const w = SEVERITY_WEIGHT[f.severity];
+    totalWeight += w;
+    byRuleWeight[f.ruleId] = (byRuleWeight[f.ruleId] ?? 0) + w;
+    const tier = ruleTier(f.ruleId);
+    if (tier) byTierWeight[tier] = (byTierWeight[tier] ?? 0) + w;
+  }
+
+  const byTier = {} as Record<TropeTier, number>;
+  for (const t of TIERS) byTier[t] = per1000(byTierWeight[t] ?? 0);
+
+  // Sorted by ruleId so the key order — and thus JSON.stringify output — never depends on finding
+  // order, which itself depends only on span position (engine.ts), not on rule registration order.
+  const byRule: Record<string, number> = {};
+  for (const id of Object.keys(byRuleWeight).sort()) byRule[id] = per1000(byRuleWeight[id]!);
+
+  return { total: per1000(totalWeight), byTier, byRule };
+}

--- a/scripts/destink/vendor/lint/span.ts
+++ b/scripts/destink/vendor/lint/span.ts
@@ -1,0 +1,35 @@
+// Span arithmetic for the linter. Every Finding carries a Span into the ORIGINAL source text, so
+// these helpers are what rules use to turn "words 3 through 7 of unit 2" into one highlightable
+// range. Nothing here reads the text — offsets only.
+
+import type { Span, DocAnalysis } from "./types.js";
+
+// The source surface form for a span. Rules that need to look at characters (dashes, quotes,
+// capitalization) slice through here rather than re-tokenizing.
+export const textAt = (source: DocAnalysis | string, span: Span): string =>
+  (typeof source === "string" ? source : source.text).slice(span.start, span.end);
+
+// The smallest span covering every part. Takes spans or anything carrying one (WordSpan,
+// UnitAnalysis, Finding), so `spanning(unit.words.slice(i, j))` is the common call.
+export function spanning(parts: ReadonlyArray<Span | { span: Span }>): Span {
+  if (parts.length === 0) throw new Error("spanning: no parts");
+  let start = Infinity, end = -Infinity;
+  for (const p of parts) {
+    const s = "span" in p ? p.span : p;
+    if (s.start < start) start = s.start;
+    if (s.end > end) end = s.end;
+  }
+  return { start, end };
+}
+
+export const sameSpan = (a: Span, b: Span): boolean => a.start === b.start && a.end === b.end;
+
+// Half-open overlap: [0,3) and [3,5) touch but do not overlap.
+export const overlaps = (a: Span, b: Span): boolean => a.start < b.end && b.start < a.end;
+
+export const contains = (outer: Span, inner: Span): boolean =>
+  outer.start <= inner.start && inner.end <= outer.end;
+
+// Document order: earlier start wins; on a tie the shorter span comes first, so a nested finding
+// is listed before the wider one enclosing it. A ruleId tiebreak makes this a total order.
+export const compareSpans = (a: Span, b: Span): number => a.start - b.start || a.end - b.end;

--- a/scripts/destink/vendor/lint/types.ts
+++ b/scripts/destink/vendor/lint/types.ts
@@ -1,0 +1,65 @@
+// Shared contracts for the de-stink linter (epic #28, step 0). Types only — no runtime code.
+// Wave-1 modules build against these interfaces in parallel:
+//   #7/#8  document splitter + parser-agnostic document path (produces DocUnit)
+//   #9     analyzeDocument with source char offsets (produces DocAnalysis)
+//   #10    copular/negation query helpers over the Clause IR (consumes Clause)
+//   #11    TropeRule engine + runner (consumes DocAnalysis, produces Finding)
+
+import type { Clause } from "../ir.js";
+import type { Tree } from "../ptb.js";
+
+// A half-open [start, end) character range into the ORIGINAL source text. For any span,
+// text.slice(span.start, span.end) is the exact surface form — contractions, curly quotes and all.
+export type Span = { start: number; end: number };
+
+// One split unit of the document and what happened when we tried to parse + lower it.
+// Fragments are data, not failures: verbless units ("Not a bug.") are the strongest trope signal.
+export type UnitOutcome = "lowered" | "fragment" | "unparseable";
+
+export type DocUnit = {
+  unit: string; // the unit's raw text, exactly as sliced from the source
+  span: Span; // where the unit sits in the original text
+  outcome: UnitOutcome;
+  clauses?: Clause[]; // present iff outcome === "lowered"
+  reason?: string; // why lowering failed: the lower error message, or a root label like FRAG / no-VP
+};
+
+// A word with its source offsets. `text` is the SOURCE surface form for the span; tokenization may
+// have normalized it (e.g. "won't" -> "wo" + "n't" as two entries mapping into one source word).
+export type WordSpan = { text: string; span: Span; pos?: string };
+
+// Per-unit analysis: the DocUnit outcome plus whatever the parse produced.
+export type UnitAnalysis = DocUnit & {
+  tree?: Tree; // constituency parse (fine POS tags at the leaves), when one was obtained
+  words: WordSpan[]; // the unit's words in order, each mapped to source offsets
+};
+
+// The whole document, analyzed. Rules see all units in document order so cross-sentence patterns
+// (anaphora, the reframe) and density thresholds are first-class.
+export type DocAnalysis = {
+  text: string; // the original input, untouched
+  units: UnitAnalysis[];
+};
+
+export type TropeTier = "lexical" | "syntactic" | "formatting" | "discourse";
+
+// "candidate" marks structurally-narrowed suspects a rule can't confirm without semantics
+// (e.g. false ranges, #19); the scorer weighs them below confirmed findings.
+export type Severity = "candidate" | "low" | "medium" | "high";
+
+export type Finding = {
+  ruleId: string;
+  span: Span; // the primary offending span in the original text
+  severity: Severity;
+  message: string; // names the pattern, briefly
+  explanation: string; // teaches it — why this reads as a tell, in the free.ts hint-writing voice
+};
+
+// A trope rule: a predicate over the whole document that returns located findings.
+// Same shape as the game's Condition with the polarity flipped.
+export type TropeRule = {
+  id: string;
+  name: string;
+  tier: TropeTier;
+  detect(doc: DocAnalysis): Finding[];
+};

--- a/scripts/destink/vendor/lower.ts
+++ b/scripts/destink/vendor/lower.ts
@@ -1,0 +1,514 @@
+// Lowering: constituency parse (Penn-Treebank Tree) -> Clause IR. THE BRIDGE — the piece no
+// existing tool provides (see RESEARCH.md). Grammar-directed: it reads phrase structure to
+// recover subject / predicate / complement, modifiers, PPs, coordination, and subordinate
+// clauses. Deliberately a pragmatic subset; unsupported shapes throw a clear error so callers
+// (e.g. lowerNBest) can fall back rather than silently mis-diagram.
+//
+// ENGLISH-SPECIFIC SEAM (2 of 2). Constituency-shaped and English-tuned (subject = first NP,
+// copula list, PTB labels). A future multilingual path adds a SIBLING `dependency -> IR`
+// lowering (UD arcs -> subject/object/modifiers); both produce the same Clause IR. Keeping
+// the IR the convergence point is what keeps that door open.
+
+import type { Clause, Nominal, Verbal, Modifier, Word, Compound, Complement, Sentence, Infinitive, Gerund, Subject, Predicate, PredicatePart } from "./ir.js";
+import { parseBracket, phrase, type Tree } from "./ptb.js";
+
+const w = (text: string): Word => ({ text });
+const wt = (leaf: Tree): Word => ({ text: leaf.word!, pos: leaf.label }); // a Word from a single leaf, carrying its POS tag
+
+const COPULA = new Set([
+  "be", "am", "is", "are", "was", "were", "been", "being",
+  "seem", "seems", "seemed", "become", "becomes", "became",
+  "feel", "feels", "felt", "look", "looks", "appear", "appears", "remain", "remains",
+]);
+
+// Correlative pre-markers: "both ... and", "either ... or", "neither ... nor". The leading word
+// is folded into the conjunction label rather than mis-read as a determiner on the first item.
+const CORREL = new Set(["both", "either", "neither"]);
+const isCorrelative = (t: Tree | undefined): boolean => !!t?.word && CORREL.has(t.word.toLowerCase());
+const conjLabel = (correlative: string | null, conj: string): string => (correlative ? `${correlative}...${conj}` : conj);
+
+const NOUN = new Set(["NN", "NNS", "NNP", "NNPS", "PRP"]);
+const PREMOD = new Set(["DT", "JJ", "JJR", "JJS", "PRP$", "CD", "POS", "PDT", "RB", "VBN", "VBG"]); // RB: "very"; VBN/VBG: "burned toast"
+const isVerb = (label: string) => /^(VB|MD|AUX)/.test(label);
+const isCC = (t: Tree) => t.label === "CC";
+const isPunct = (t: Tree) => /^[,:.]$/.test(t.label);
+
+// Flatten a compound to a single Nominal where the IR needs one (prep objects, etc.).
+const asNominal = (n: Nominal | Compound<Nominal>): Nominal =>
+  "items" in n ? { head: w(n.items.map((i) => i.head.text).join(` ${n.conjunction.text} `)), modifiers: [] } : n;
+
+// --- noun phrases ---
+
+function lowerNP(np: Tree): Nominal | Compound<Nominal> {
+  if (np.children.some(isCC)) return lowerCoordNP(np);
+
+  // (NP (NP ...) (PP|SBAR|VP ...)+) — a base nominal with trailing post-modifiers, where a VP is a
+  // reduced participial clause ("the girl running across the field").
+  const first = np.children[0];
+  const rest = np.children.slice(1);
+  if (first && first.label === "NP" && rest.length > 0 && rest.every((c) => c.label === "PP" || c.label === "SBAR" || (c.label === "VP" && isParticipial(c)))) {
+    const base = asNominal(lowerNP(first));
+    for (const c of rest) base.modifiers.push(c.label === "PP" ? lowerPP(c) : c.label === "SBAR" ? lowerSBAR(c) : lowerParticipleVP(c));
+    return base;
+  }
+
+  // flat NP: pre-modifiers, head noun (last noun wins; earlier nouns become noun-adjunct mods)
+  const modifiers: Modifier[] = [];
+  let headLeaf: Tree | null = null;
+  let appositive: string | undefined;
+  for (const c of np.children) {
+    if (c.word !== undefined) {
+      if (NOUN.has(c.label)) {
+        if (headLeaf !== null) modifiers.push({ kind: "word", value: wt(headLeaf) });
+        headLeaf = c;
+      } else if (PREMOD.has(c.label)) {
+        modifiers.push({ kind: "word", value: wt(c) });
+      }
+    } else if (c.label === "PP") modifiers.push(lowerPP(c));
+    else if (c.label === "SBAR") modifiers.push(lowerSBAR(c));
+    else if (c.label === "ADJP" || c.label === "QP") modifiers.push({ kind: "word", value: w(phrase(c)) }); // QP: "almost any"
+    else if (c.label === "NP" && c.children.some((k) => k.label === "POS")) {
+      // possessive noun ("Alicia's hobby"): the whole 's-phrase is a determiner-like slant modifier
+      modifiers.push({ kind: "word", value: w(phrase(c).replace(/ (['’]s?)\b/g, "$1")) });
+    } else if (c.label === "NP") appositive = phrase(c); // trailing name ("the hero Beowulf")
+  }
+  return { head: headLeaf ? wt(headLeaf) : w(phrase(np)), modifiers, ...(appositive ? { appositive: w(appositive) } : {}) };
+}
+
+function lowerCoordNP(np: Tree): Compound<Nominal> {
+  let kids = np.children;
+  let correlative: string | null = null;
+  if (isCorrelative(kids[0]) && (kids[0]!.label === "DT" || kids[0]!.label === "CC")) {
+    correlative = kids[0]!.word!.toLowerCase(); // "both Max and I" -> "both...and", not "both" on Max
+    kids = kids.slice(1);
+  }
+  const groups: Tree[][] = [[]];
+  let conjunction = "and";
+  for (const c of kids) {
+    if (isCC(c)) {
+      if (c.word) conjunction = c.word;
+      groups.push([]);
+    } else if (isPunct(c)) {
+      groups.push([]);
+    } else {
+      groups[groups.length - 1]!.push(c);
+    }
+  }
+  const items = groups
+    .filter((g) => g.length > 0)
+    .map((g) => asNominal(lowerNP(g.length === 1 && g[0]!.label === "NP" ? g[0]! : { label: "NP", children: g })));
+  return { items, conjunction: w(conjLabel(correlative, conjunction)) };
+}
+
+// --- prepositional & subordinate ---
+
+function lowerPP(pp: Tree): Modifier {
+  const prepTok = pp.children.find((c) => c.label === "IN" || c.label === "TO");
+  const objNP = pp.children.find((c) => c.label === "NP");
+  // an adverb qualifying the preposition ("especially in the winter") rides on the prep label
+  const isAdv = (c: Tree) => c.label === "ADVP" || c.label === "RB";
+  const adv = pp.children.filter(isAdv).map(phrase).join(" ");
+  let object: Nominal;
+  if (objNP) {
+    object = asNominal(lowerNP(objNP));
+  } else {
+    // object is a clause/gerund ("after leaving Portugal") — use the words AFTER the preposition,
+    // not phrase(pp), which would repeat the preposition itself.
+    const rest = pp.children.filter((c) => c !== prepTok && !isAdv(c)).map(phrase).join(" ").trim();
+    object = { head: w(rest || phrase(pp)), modifiers: [] };
+  }
+  const prepWord = prepTok?.word ?? phrase(pp).split(" ")[0] ?? "?";
+  return { kind: "prep", prep: w(adv ? `${adv} ${prepWord}` : prepWord), object };
+}
+
+function lowerSBAR(sbar: Tree): Modifier {
+  const wh = sbar.children.find((c) => ["WHNP", "WHADVP", "WHPP", "WDT", "WP", "WRB"].includes(c.label));
+  const inConn = sbar.children.find((c) => c.label === "IN");
+  const s = sbar.children.find((c) => c.label === "S" || c.label === "SINV" || c.label === "SQ");
+  const fallback: Clause = { subject: { head: w("?"), modifiers: [] }, verb: { head: w("?"), modifiers: [] }, complement: null };
+  if (!s) return { kind: "clause", connector: w(inConn ? phrase(inConn) : wh ? phrase(wh) : "that"), value: fallback };
+
+  // Relative clause: the wh-word is the gapped subject ("the dog that barked"); the dotted
+  // connector carries no separate word (the relativizer IS the clause's subject).
+  if (wh && !s.children.some((c) => c.label === "NP")) {
+    return { kind: "clause", connector: w(""), value: lowerClause(s, { head: w(phrase(wh)), modifiers: [] }) };
+  }
+  // Adverbial / complement clause ("because dogs barked"): the subordinator is the connector.
+  return { kind: "clause", connector: w(inConn ? phrase(inConn) : wh ? phrase(wh) : "that"), value: lowerClause(s) };
+}
+
+// --- predicates ---
+
+function lowerPredicate(vp: Tree): { verb: Predicate; complement: Complement | null } {
+  // compound predicate: (VP (VP ...) (CC and) (VP ...)) — each conjunct keeps its own complement.
+  const vpKids = vp.children.filter((c) => c.label === "VP");
+  if (vp.children.some((c) => isCC(c) || c.label === "CONJP") && vpKids.length >= 2) {
+    // Walk in order so a conjunctive adverb between the conjuncts ("barked loudly and [then]
+    // jumped") attaches to the conjunct it precedes, instead of being dropped.
+    let conjunction = "and";
+    const conjps = vp.children.filter((c) => c.label === "CONJP").map(phrase); // "not only", "but also"
+    const items: PredicatePart[] = [];
+    let pendingAdv: Modifier[] = [];
+    for (const c of vp.children) {
+      if (isCC(c)) { if (c.word) conjunction = c.word; continue; }
+      if (c.label === "CONJP") continue; // correlative marker(s) -> folded into the label below
+      if (c.label === "ADVP" || c.label === "RB") { pendingAdv.push({ kind: "word", value: w(phrase(c)) }); continue; }
+      if (c.label !== "VP") continue;
+      const r = lowerPredicate(c);
+      const verb = "items" in r.verb ? asVerbalFlat(r.verb) : r.verb;
+      if (pendingAdv.length) { verb.modifiers = [...pendingAdv, ...verb.modifiers]; pendingAdv = []; }
+      items.push({ verb, complement: r.complement });
+    }
+    if (pendingAdv.length && items.length) items[items.length - 1]!.verb.modifiers.push(...pendingAdv); // trailing
+    if (conjps.length) conjunction = conjps.join("..."); // correlative "not only ... but also"
+    return { verb: { items, conjunction: w(conjunction) }, complement: null };
+  }
+
+  // word-level coordinated verbs: "(VP (CC either) (VBZ complains) (CC or) (VBZ criticizes))" — no
+  // VP children, just finite verbs joined by a conjunction. Only when there is nothing else to
+  // attach (no objects/complements), so a shared-object coordination isn't mis-split.
+  const bareVerbs = vp.children.filter((c) => c.word !== undefined && isVerb(c.label));
+  if (
+    vp.children.some(isCC) && bareVerbs.length >= 2 &&
+    !vp.children.some((c) => ["VP", "NP", "ADJP", "S", "INF", "PP", "SBAR"].includes(c.label))
+  ) {
+    let conjunction = "and";
+    const correlative = isCorrelative(vp.children[0]) && isCC(vp.children[0]!) ? vp.children[0]!.word!.toLowerCase() : null;
+    for (const c of vp.children) if (isCC(c) && c.word && !CORREL.has(c.word.toLowerCase())) conjunction = c.word;
+    const items: PredicatePart[] = bareVerbs.map((v) => ({ verb: { head: wt(v), modifiers: [] }, complement: null }));
+    return { verb: { items, conjunction: w(conjLabel(correlative, conjunction)) }, complement: null };
+  }
+
+  const verbWords: string[] = [];
+  const verbLeaves: Tree[] = [];
+  const modifiers: Modifier[] = [];
+  const objNPs: Tree[] = []; // object NPs in order; two => indirect + direct object
+  let indirectObject: Nominal | undefined;
+  const ocClauses: Tree[] = []; // verbless small clauses carrying an objective complement
+  let complement: Complement | null = null;
+
+  const walk = (node: Tree): void => {
+    for (const c of node.children) {
+      if (c.word !== undefined && (isVerb(c.label) || c.label === "TO")) { verbWords.push(c.word); verbLeaves.push(c); } // incl. infinitive "to"
+      else if (c.label === "VP") walk(c); // auxiliary chain: "has been running"
+      else if (c.label === "S" && c.children.some((x) => x.label === "VP") && !c.children.some((x) => x.label === "NP")) {
+        const inner = c.children.find((x) => x.label === "VP"); // subjectless S = infinitive: "has to think about X"
+        if (inner) walk(inner);
+      }
+      else if (c.label === "S" && !c.children.some((x) => x.label === "VP")) {
+        ocClauses.push(c); // verbless small clause = objective complement ("named our daughter Alice")
+      }
+      else if (c.label === "S" && c.children.some((x) => x.label === "NP") && c.children.some((x) => x.label === "VP")) {
+        complement = { kind: "directObject", value: lowerClause(c) }; // causative small clause ("made her students read four novels")
+      }
+      else if (c.label === "ADVP" || c.label === "RB") modifiers.push({ kind: "word", value: w(phrase(c)) });
+      else if (c.label === "PRT" || c.label === "RP") modifiers.push({ kind: "word", value: w(phrase(c)) }); // phrasal-verb particle ("stood up")
+      else if (c.label === "PP") modifiers.push(lowerPP(c));
+      else if (c.label === "SBAR") modifiers.push(lowerSBAR(c));
+      else if (c.label === "NP") objNPs.push(c); // resolved after the walk (copula / IO+DO / DO)
+      else if (c.label === "INF") {
+        complement = { kind: "directObject", value: lowerInfinitive(c) }; // infinitive object on a stand
+      } else if (c.label === "ADJP" || c.label === "JJ") {
+        const jjs = c.label === "JJ" ? [c] : c.children.filter((k) => k.label === "JJ");
+        const cc = c.children.find((k) => k.label === "CC");
+        if (jjs.length > 1 && cc) {
+          complement = { kind: "predicateAdj", value: { items: jjs.map((j) => w(j.word ?? phrase(j))), conjunction: w(cc.word ?? "and") } };
+        } else {
+          complement = { kind: "predicateAdj", value: w(phrase(c)) };
+        }
+      }
+    }
+  };
+  walk(vp);
+
+  // Objective complement: a verbless small clause. It may carry both the object and the
+  // complement ("makes [me happy]"), or just the complement, with the object as the preceding
+  // sibling NP ("painted my room [red]").
+  const ocClause = ocClauses[0];
+  if (ocClause) {
+    const scNPs = ocClause.children.filter((x) => x.label === "NP");
+    const scAdj = ocClause.children.find((x) => x.label === "ADJP" || x.label === "JJ");
+    let objectTree: Tree | undefined;
+    let ocIsAdj: boolean;
+    let ocTree: Tree | undefined;
+    if (scNPs.length >= 1 && (scAdj || scNPs.length >= 2)) {
+      objectTree = scNPs[0]; // small clause holds both DO and OC
+      ocIsAdj = !!scAdj;
+      ocTree = scAdj ?? scNPs[1];
+    } else {
+      objectTree = objNPs.pop(); // OC only; DO is the preceding sibling NP
+      ocIsAdj = !!scAdj;
+      ocTree = scAdj ?? scNPs[0];
+    }
+    if (objectTree && ocTree) {
+      complement = {
+        kind: "objectComplement",
+        object: lowerNP(objectTree),
+        oc: ocIsAdj ? w(phrase(ocTree)) : asNominal(lowerNP(ocTree)),
+        ocIsAdj,
+      };
+    }
+  }
+
+  // Resolve object NPs, unless an ADJP/INF/objective-complement already claimed the complement slot.
+  if (complement === null && objNPs.length) {
+    if (isCopula(verbWords)) {
+      complement = { kind: "predicateNoun", value: lowerNP(objNPs[objNPs.length - 1]!) };
+    } else if (objNPs.length >= 2) {
+      // ditransitive "gave the children homework": first NP is the indirect object.
+      indirectObject = asNominal(lowerNP(objNPs[0]!));
+      complement = { kind: "directObject", value: lowerNP(objNPs[objNPs.length - 1]!) };
+    } else {
+      complement = { kind: "directObject", value: lowerNP(objNPs[0]!) };
+    }
+  }
+
+  const verbHead: Word = verbLeaves.length === 1 ? wt(verbLeaves[0]!) : w(verbWords.join(" ") || phrase(vp));
+  return { verb: { head: verbHead, modifiers, ...(indirectObject ? { indirectObject } : {}) }, complement };
+}
+
+function lowerInfinitive(inf: Tree): Infinitive {
+  const verb = inf.children.find((c) => c.label === "VB");
+  const obj = inf.children.find((c) => c.label === "NP");
+  const modifiers: Modifier[] = [];
+  for (const c of inf.children) {
+    if (c.label === "ADVP" || c.label === "RB") modifiers.push({ kind: "word", value: w(phrase(c)) });
+    else if (c.label === "PP") modifiers.push(lowerPP(c));
+  }
+  return { kind: "infinitive", verb: w(verb?.word ?? phrase(inf)), object: obj ? asNominal(lowerNP(obj)) : null, modifiers };
+}
+
+const asVerbalFlat = (c: Compound<PredicatePart>): Verbal => ({ head: w(c.items.map((i) => i.verb.head.text).join(` ${c.conjunction.text} `)), modifiers: [] });
+
+// A negative contraction stays FUSED in the verb head — src/nlp/tagger.ts leaves "isn't" as one
+// token on purpose (the negation is still visible in the surface word, and lint/ir-query reads it
+// back off the head), so the copula test has to look past a trailing "n't". Without this,
+// "Growth isn't a destination" made "a destination" a DIRECT OBJECT rather than a predicate noun.
+//
+// Only be-form STEMS survive the strip, which is exactly the wanted narrowness: "doesn't" -> "does"
+// and "won't" -> "wo" are not in COPULA, so a fused auxiliary or modal still takes an ordinary
+// object. "ain't" has no stem to strip and is listed outright.
+const FUSED_COPULA = new Set(["ain't"]);
+const stripContractedNegation = (word: string): string => (/n't$/i.test(word) ? word.slice(0, -3) : word);
+const isCopulaWord = (v: string): boolean => {
+  const lc = v.toLowerCase();
+  return COPULA.has(lc) || FUSED_COPULA.has(lc) || COPULA.has(stripContractedNegation(lc));
+};
+const isCopula = (verbWords: string[]) => verbWords.some(isCopulaWord);
+
+// Gather adverb/PP modifiers from a verbal phrase (shared by gerund/infinitive lowering).
+function verbalModifiers(src: Tree): Modifier[] {
+  const mods: Modifier[] = [];
+  for (const c of src.children) {
+    if (c.label === "PP") mods.push(lowerPP(c));
+    else if (c.label === "ADVP" || c.label === "RB") mods.push({ kind: "word", value: w(phrase(c)) });
+  }
+  return mods;
+}
+
+// A participial phrase modifying a noun: the VBG/VBN verb + object + adverb/PP modifiers.
+function lowerParticipleVP(vp: Tree, leading: Tree[] = []): Modifier {
+  const part = vp.children.find((c) => c.label === "VBG" || c.label === "VBN");
+  const obj = vp.children.find((c) => c.label === "NP");
+  const modifiers = [...leading.map((a) => ({ kind: "word", value: w(phrase(a)) } as Modifier)), ...verbalModifiers(vp)];
+  return { kind: "participle", verb: w(part?.word ?? phrase(vp)), object: obj ? asNominal(lowerNP(obj)) : null, modifiers };
+}
+
+// A participial phrase set off as its own S: "(S (ADVP Cheerfully) (VP (VBG whistling) ...))".
+const lowerParticipleS = (s: Tree): Modifier =>
+  lowerParticipleVP(s.children.find((c) => c.label === "VP")!, s.children.filter((c) => c.label === "ADVP" || c.label === "RB"));
+
+// A reduced clause acting as a participle ("the dog[,] barking furiously"): an S (or bare VP) with a
+// VBG/VBN-headed VP and no subject NP. Distinct from a gerund subject only by having a sibling
+// subject NP — the caller decides which reading applies.
+function isParticipial(t: Tree): boolean {
+  const vp = t.label === "VP" ? t : t.label === "S" && !t.children.some((c) => c.label === "NP") ? t.children.find((c) => c.label === "VP") : undefined;
+  const head = vp?.children[0];
+  return !!head && (head.label === "VBG" || head.label === "VBN");
+}
+
+// An absolute phrase ("Smoke alarms screaming, ...") — a noun with a participial VP, grammatically
+// independent of the clause. Lowered to a nominal carrying the participle as a modifier.
+function isAbsolute(t: Tree): boolean {
+  if (t.label !== "S" || !t.children.some((c) => c.label === "NP")) return false;
+  const head = t.children.find((c) => c.label === "VP")?.children[0];
+  return !!head && (head.label === "VBG" || head.label === "VBN");
+}
+function lowerAbsolute(s: Tree): Nominal {
+  const nominal = asNominal(lowerNP(s.children.find((c) => c.label === "NP")!));
+  nominal.modifiers.push(lowerParticipleVP(s.children.find((c) => c.label === "VP")!));
+  return nominal;
+}
+
+// A gerund subject/object: (S (VP (VBG Running) (NP marathons) (PP ...))).
+function lowerGerund(vp: Tree): Gerund {
+  const vbg = vp.children.find((c) => c.label === "VBG");
+  const obj = vp.children.find((c) => c.label === "NP");
+  return { kind: "gerund", verb: w(vbg?.word ?? phrase(vp)), object: obj ? asNominal(lowerNP(obj)) : null, modifiers: verbalModifiers(vp) };
+}
+
+// An infinitive subject: (S (VP (TO To) (VP (VB master) (NP a new skill)))).
+function lowerInfinitiveFromVP(vp: Tree): Infinitive {
+  const inner = vp.children.find((c) => c.label === "VP") ?? vp;
+  const vb = inner.children.find((c) => isVerb(c.label) && c.word);
+  const obj = inner.children.find((c) => c.label === "NP");
+  return { kind: "infinitive", verb: w(vb?.word ?? phrase(inner)), object: obj ? asNominal(lowerNP(obj)) : null, modifiers: verbalModifiers(inner) };
+}
+
+// A noun clause (SBAR) used nominally: "Whatever you want", "Whoever made this pottery",
+// "Where the sock had gone". Mirrors lowerSBARQ: the wh-word is the gapped subject, the gapped
+// object, or (WHADVP) an adverbial modifier on the verb.
+function lowerNounClause(sbar: Tree): Clause {
+  const wh = sbar.children.find((c) => ["WHNP", "WHADVP", "WHPP"].includes(c.label));
+  const s = sbar.children.find((c) => c.label === "S" || c.label === "SQ");
+  if (!s) throw new Error("lower: noun clause without a clause");
+  const whWord = wh ? phrase(wh) : "that";
+  if (wh?.label === "WHNP" && !s.children.some((c) => c.label === "NP")) {
+    return lowerClause(s, { head: w(whWord), modifiers: [] }); // wh is the gapped subject
+  }
+  const clause = lowerClause(s);
+  if (wh?.label === "WHADVP" && "modifiers" in clause.verb) {
+    clause.verb.modifiers.push({ kind: "word", value: w(whWord) }); // "Where ... gone"
+  } else if (wh?.label === "WHNP" && !clause.complement) {
+    clause.complement = { kind: "directObject", value: { head: w(whWord), modifiers: [] } }; // gapped object
+  }
+  return clause;
+}
+
+// The subject constituent may be an NP, a gerund/infinitive (S), or a noun clause (SBAR).
+function lowerSubjectConstituent(t: Tree): Subject | null {
+  if (t.label === "NP") return lowerNP(t);
+  if (t.label === "SBAR") return lowerNounClause(t);
+  if (t.label === "S") {
+    const vp = t.children.find((c) => c.label === "VP");
+    const first = vp?.children[0];
+    if (first?.label === "TO") return lowerInfinitiveFromVP(vp!);
+    if (first?.label === "VBG") return lowerGerund(vp!);
+  }
+  return null;
+}
+
+// --- clause ---
+
+function lowerClause(s: Tree, fallbackSubject?: Subject): Clause {
+  const vp = s.children.find((c) => c.label === "VP");
+  if (!vp) throw new Error(`lower: unsupported clause (no VP) in (${s.label} ...)`);
+  // The subject is the NP adjacent to the predicate; an earlier NP is a fronted adverbial ("Today
+  // Darren left ..."). Only with no NP is a gerund/infinitive S or noun-clause SBAR the subject.
+  const preVP = s.children.slice(0, s.children.indexOf(vp));
+  const nps = preVP.filter((c) => c.label === "NP");
+  const subjTree = nps[nps.length - 1] ?? preVP.find((c) => c.label === "S" || c.label === "SBAR");
+  const subject = subjTree ? lowerSubjectConstituent(subjTree) ?? fallbackSubject : fallbackSubject; // relative clauses have a gapped subject
+  if (!subject) throw new Error(`lower: unsupported clause (need NP + VP) in (${s.label} ...)`);
+  // Participial phrases set off from the subject ("The dog, barking furiously, chased ...";
+  // "Growling, the monster charged ...") modify the subject noun — attach them there.
+  const participles = s.children.filter((c) => c !== subjTree && c !== vp && c.label === "S" && isParticipial(c)).map(lowerParticipleS);
+  if (participles.length && "modifiers" in subject) subject.modifiers.push(...participles);
+  const { verb, complement } = lowerPredicate(vp);
+  // Fronted / adverbial siblings outside the VP — a temporal noun ("Today"), a fronted PP ("In old
+  // tales, ..."), a fronted adverb clause ("because the field flooded, ..."), a clause-level adverb
+  // ("your team really needs") — attach to the verb (the first conjunct if it is compound).
+  const advTarget: Verbal | null = "modifiers" in verb ? verb : verb.items[0] ? verb.items[0].verb : null;
+  if (advTarget) {
+    for (const c of s.children) {
+      if (c === subjTree || c === vp) continue;
+      if (c.label === "PP") advTarget.modifiers.push(lowerPP(c));
+      else if (c.label === "SBAR") advTarget.modifiers.push(lowerSBAR(c));
+      else if (c.label === "ADVP" || c.label === "RB" || c.label === "NP") advTarget.modifiers.push({ kind: "word", value: w(phrase(c)) });
+    }
+  }
+  // Interjections ("Man,", "Wow!") float on a detached line above the diagram, unconnected.
+  const detached = s.children.filter((c) => c.label === "INTJ").map((c) => w(phrase(c)));
+  // Absolute phrases ("Smoke alarms screaming, ...") are grammatically independent — drawn detached.
+  const absolutes = s.children.filter((c) => c !== subjTree && c !== vp && isAbsolute(c)).map(lowerAbsolute);
+  return { subject, verb, complement, ...(detached.length ? { detached } : {}), ...(absolutes.length ? { absolutes } : {}) };
+}
+
+// Yes/no question: (SQ (VBZ Is) (NP the sky) (ADJP blue)) — un-invert to subject + predicate.
+function lowerSQ(sq: Tree): Clause {
+  const kids = sq.children.filter((c) => c.label !== "." && c.label !== ",");
+  const lead: Tree[] = []; // leading auxiliary/verb before the subject
+  let i = 0;
+  while (i < kids.length && /^(VB|MD|AUX)/.test(kids[i]!.label)) lead.push(kids[i++]!);
+  const subjNP = kids[i]?.label === "NP" ? kids[i]! : undefined;
+  if (subjNP) i++;
+  const vp: Tree = { label: "VP", children: [...lead, ...kids.slice(i)] }; // synthetic declarative predicate
+  const { verb, complement } = lowerPredicate(vp);
+  return { subject: subjNP ? lowerNP(subjNP) : { head: w("?"), modifiers: [] }, verb, complement };
+}
+
+// Wh-question: (SBARQ (WHNP Who) (SQ ...)). The wh-word is the subject if the SQ has no inverted
+// aux+subject ("Who chased the cat"), otherwise the gapped object ("What did the dog eat").
+function lowerSBARQ(sbarq: Tree): Clause {
+  const wh = sbarq.children.find((c) => ["WHNP", "WHADVP", "WHPP"].includes(c.label));
+  const sq = sbarq.children.find((c) => c.label === "SQ" || c.label === "S");
+  if (!sq) {
+    // declarative-order question, often interjection-prefixed: SBARQ holds NP + VP directly
+    if (sbarq.children.some((c) => c.label === "VP")) return lowerClause(sbarq);
+    throw new Error("lower: SBARQ without a clause");
+  }
+  const whWord = wh ? phrase(wh) : "what";
+  const sqKids = sq.children.filter((c) => c.label !== "." && c.label !== ",");
+  if (sqKids[0]?.label === "VP") {
+    const { verb, complement } = lowerPredicate(sqKids[0]!); // wh is the subject
+    return { subject: { head: w(whWord), modifiers: [] }, verb, complement };
+  }
+  const clause = lowerSQ(sq); // inverted; wh is the object
+  if (!clause.complement) clause.complement = { kind: "directObject", value: { head: w(whWord), modifiers: [] } };
+  return clause;
+}
+
+// Dispatch a top-level constituent to the right lowering.
+function lowerTop(t: Tree): Clause {
+  if (t.label === "SQ") return lowerSQ(t);
+  if (t.label === "SBARQ") return lowerSBARQ(t);
+  // Imperative: a top-level clause with a VP but NO subject constituent at all -> implied "(you)".
+  // (A gerund/infinitive/noun-clause subject is an S/SBAR, so those are NOT imperatives.)
+  const SUBJECTY = new Set(["NP", "S", "SBAR", "SQ", "SBARQ"]);
+  if ((t.label === "S" || t.label === "VP") && t.children.some((c) => c.label === "VP") && !t.children.some((c) => SUBJECTY.has(c.label))) {
+    return lowerClause(t, { head: w("(you)"), modifiers: [] });
+  }
+  return lowerClause(t);
+}
+
+// --- public API ---
+
+export function lower(parse: Tree | string): Clause {
+  return lowerTop(typeof parse === "string" ? parseBracket(parse) : parse);
+}
+
+// Lower a whole sentence: a compound sentence (top-level S with several S children) becomes
+// multiple clauses; anything else is a single-clause sentence.
+export function lowerSentence(parse: Tree | string): Sentence {
+  let t = typeof parse === "string" ? parseBracket(parse) : parse;
+  // unwrap a ROOT/TOP/S1 wrapper (the neural parser returns a Tree object, not a string)
+  while (["ROOT", "TOP", "S1", ""].includes(t.label) && t.children.length === 1 && t.children[0]) t = t.children[0];
+  const sKids = t.children.filter((c) => c.label === "S" || c.label === "SINV");
+  if (t.label === "S" && sKids.length >= 2) {
+    let ccWords = t.children.filter((c) => c.label === "CC").map((c) => c.word ?? "and");
+    // fold a leading correlative ("Either ... or ...") into the first conjunction label
+    const correlative = ccWords[0] && CORREL.has(ccWords[0].toLowerCase()) ? ccWords.shift()!.toLowerCase() : null;
+    const conjunctions = ccWords.map((cw, i) => w(i === 0 ? conjLabel(correlative, cw) : cw));
+    const clauses = sKids.map((c) => lowerClause(c));
+    // A fronted PP/adverb before the first clause ("In old tales, Grendel was ...") attaches there.
+    const fronted = t.children.slice(0, t.children.indexOf(sKids[0]!)).filter((c) => c.label === "PP" || c.label === "ADVP");
+    if (fronted.length && clauses[0] && "modifiers" in clauses[0].verb) {
+      for (const f of fronted) clauses[0].verb.modifiers.push(f.label === "PP" ? lowerPP(f) : { kind: "word", value: w(phrase(f)) });
+    }
+    return { clauses, conjunctions };
+  }
+  return { clauses: [lowerTop(t)], conjunctions: [] };
+}
+
+// N-best: lower each candidate parse, dropping any that fail to lower.
+export function lowerNBest(parses: Array<Tree | string>): Clause[] {
+  const out: Clause[] = [];
+  for (const p of parses) {
+    try {
+      out.push(lower(p));
+    } catch {
+      /* skip unsupported parse */
+    }
+  }
+  return out;
+}

--- a/scripts/destink/vendor/nlp/lexicon.ts
+++ b/scripts/destink/vendor/nlp/lexicon.ts
@@ -1,0 +1,42 @@
+// Function-word lexicon for the in-browser rule-based parser. Closed-class words (determiners,
+// prepositions, pronouns, conjunctions, auxiliaries, subordinators) are finite and high-value:
+// tagging them reliably is most of what a shallow parser needs. Open-class words (nouns, verbs,
+// adjectives) are left ambiguous here and resolved by position in the chunker (parse.ts).
+
+export const DET = new Set(["the", "a", "an", "this", "that", "these", "those", "each", "every", "some", "any", "no", "all", "both"]);
+export const POSS = new Set(["my", "your", "his", "her", "its", "our", "their", "whose"]);
+export const PRON = new Set(["i", "you", "he", "she", "it", "we", "they", "me", "him", "them", "us", "who", "what"]);
+export const PREP = new Set([
+  "in", "on", "at", "by", "for", "with", "from", "of", "about", "under", "over", "into", "onto",
+  "through", "across", "behind", "beside", "between", "near", "toward", "towards", "against",
+  "around", "above", "below", "during", "without", "within", "upon",
+]);
+export const SUBORD = new Set(["because", "although", "though", "while", "when", "whenever", "if", "unless", "since", "whereas", "as", "after", "before", "until"]);
+export const REL = new Set(["that", "which", "who", "whom"]); // relative pronouns (clause introducers)
+export const CONJ = new Set(["and", "or", "but", "nor"]);
+export const MODAL = new Set(["will", "would", "can", "could", "shall", "should", "may", "might", "must"]);
+export const COPULA = new Set(["is", "are", "am", "was", "were", "be", "been", "being", "seem", "seems", "seemed", "become", "becomes", "became", "feel", "feels", "felt", "look", "looks", "appear", "appears", "remain", "remains"]);
+export const AUX = new Set(["has", "have", "had", "do", "does", "did"]);
+
+// Common adverbs that don't end in -ly (the -ly ones are caught morphologically).
+export const ADV = new Set(["not", "very", "here", "there", "now", "then", "today", "always", "never", "often", "soon", "again", "too", "also", "still", "just", "well", "fast", "almost", "quite", "so"]);
+
+// A seed verb lexicon (base + common irregular forms) so verb detection doesn't rely on
+// morphology alone. Not exhaustive — the chunker also uses -s/-ed/-ing and position.
+export const VERBS = new Set([
+  "run", "runs", "ran", "chase", "chases", "chased", "see", "sees", "saw", "seen", "eat", "eats", "ate", "eaten",
+  "sleep", "sleeps", "slept", "bark", "barks", "barked", "like", "likes", "liked", "love", "loves", "loved",
+  "go", "goes", "went", "make", "makes", "made", "take", "takes", "took", "give", "gives", "gave", "find", "finds", "found",
+  "know", "knows", "knew", "think", "thinks", "thought", "say", "says", "said", "tell", "tells", "told", "want", "wants", "wanted",
+  "play", "plays", "played", "read", "reads", "write", "writes", "wrote", "walk", "walks", "walked", "jump", "jumps", "jumped",
+  "sit", "sits", "sat", "stand", "stands", "stood", "hold", "holds", "held", "bring", "brings", "brought", "build", "builds", "built",
+  "catch", "catches", "caught", "throw", "throws", "threw", "hit", "hits", "won", "win", "wins", "drink", "drinks", "drank",
+  // common irregular past / participle forms that don't end in -ed
+  "sold", "sang", "sung", "swam", "drove", "rode", "spoke", "broke", "chose", "froze", "stole", "woke", "drew", "flew", "grew", "blew",
+  "bought", "taught", "fought", "sought", "lost", "sent", "spent", "kept", "felt", "left", "meant", "dealt", "began", "rang", "sank",
+  "became", "got", "forgot", "hung", "dug", "wore", "tore", "swore", "bore", "rose", "lit", "bit", "hid", "slid", "fell",
+  "met", "fed", "led", "paid", "laid", "understood", "arose", "awoke", "shook", "rang",
+]);
+
+export const isNumber = (w: string) => /^\d[\d,.]*$/.test(w);
+export const isCapitalized = (w: string) => /^[A-Z][a-z]/.test(w);

--- a/scripts/destink/vendor/nlp/parse.ts
+++ b/scripts/destink/vendor/nlp/parse.ts
@@ -1,0 +1,394 @@
+// Rule-based constituency chunker. Tagged tokens -> PTB Tree, which the existing (tested)
+// lower() turns into Clause IR. Deliberately a pragmatic subset for the pedagogical domain
+// (simple-to-moderate sentences); it degrades gracefully and the UI catches hard failures.
+//
+// ENGLISH-SPECIFIC SEAM (1 of 2). This chunker hard-codes English word order (subject before
+// verb, adjectives before the head noun). A future multilingual path does NOT extend this; it
+// swaps in a Universal-Dependencies parser and a dependency->IR lowering. The IR is the
+// convergence point — both paths feed the same Clause IR, layout, and renderer.
+//
+// Core idea: an NP's open-class run stops at the first verb-like word, so the boundary between
+// subject and predicate falls out of greedy NP parsing rather than needing a separate step.
+
+import type { Tree } from "../ptb.js";
+import { tag, type Tagged } from "./tagger.js";
+import { VERBS, isCapitalized, MODAL, COPULA, AUX } from "./lexicon.js";
+
+const leaf = (label: string, word: string): Tree => ({ label, word, children: [] });
+const node = (label: string, children: Tree[]): Tree => ({ label, children });
+
+// Verb-like: compromise tagged it a verb (forced), OR the seed lexicon/morphology catches one
+// compromise mis-tagged as a noun ("bark", "runs"). The lexicon can over-fire on noun uses
+// ("a big old walk"); parseBaseNP guards that with a head-noun check, not this predicate.
+const looksLikeVerb = (t: Tagged): boolean =>
+  t.forced === "V" || (t.tag === "X" && (VERBS.has(t.lc) || t.lc.endsWith("ed") || t.lc.endsWith("ing")));
+
+// Questions invert the auxiliary before the subject ("Can dogs bark?", "Why can X identify Y?").
+// Rewrite to declarative order so the SVO grammar handles them: aux subj ... -> subj aux ...,
+// routing the wh-word to its role (why/when/where/how -> adverb; who/what/which -> subject or
+// the gapped object).
+const WH_ADJUNCT = new Set(["why", "when", "where", "how"]);
+const WH_ARG = new Set(["who", "whom", "what", "which"]);
+const isAux = (t: Tagged) => t.tag === "MD" || t.tag === "AUX" || t.tag === "COP";
+
+function normalizeQuestion(ts: Tagged[]): Tagged[] {
+  if (ts.length === 0) return ts;
+  // compromise sometimes noun-tags a capitalized sentence-initial aux ("Can ...", "Is ..."); fix it.
+  const a0 = ts[0]!;
+  if (a0.tag === "X") {
+    if (MODAL.has(a0.lc)) a0.tag = "MD";
+    else if (COPULA.has(a0.lc)) a0.tag = "COP";
+    else if (AUX.has(a0.lc)) a0.tag = "AUX";
+  }
+
+  let wh: Tagged | null = null;
+  let rest = ts;
+  if (WH_ADJUNCT.has(ts[0]!.lc) || WH_ARG.has(ts[0]!.lc)) {
+    wh = ts[0]!;
+    rest = ts.slice(1);
+  }
+
+  if (rest.length > 0 && isAux(rest[0]!)) {
+    const aux = rest[0]!;
+    // minimal subject NP after the aux: determiner? + adjectives + head noun(s) — stop at the
+    // predicate (an adjective AFTER the noun, e.g. "is the sky | blue", is NOT part of the subject)
+    let k = 1;
+    while (k < rest.length && (rest[k]!.tag === "DT" || rest[k]!.tag === "PRP$")) k++;
+    if (k < rest.length && rest[k]!.tag === "PRP") k++;
+    else {
+      while (k < rest.length && (rest[k]!.tag === "JJ" || rest[k]!.tag === "RB")) k++; // pre-noun modifiers
+      while (k < rest.length && (rest[k]!.tag === "X" || rest[k]!.tag === "CD") && !looksLikeVerb(rest[k]!)) k++; // noun(s)
+    }
+    let subj = rest.slice(1, k);
+    // In a question the word right after the aux IS the subject, even if the tagger guessed a
+    // verb for it ("Can dogs bark" — compromise tags "dogs" as a verb). Force it to a noun.
+    if (subj.length === 0 && k < rest.length && (rest[k]!.tag === "X" || rest[k]!.tag === "JJ")) {
+      subj = [{ word: rest[k]!.word, lc: rest[k]!.lc, tag: "X" }];
+      k++;
+    }
+    if (subj.length > 0) {
+      let out: Tagged[] = [...subj, aux, ...rest.slice(k)]; // un-invert: subject + aux + rest
+      if (wh) out = [...out, { word: wh.word, lc: wh.lc, tag: WH_ARG.has(wh.lc) ? "X" : "RB" }]; // arg->object, adjunct->adverb
+      return out;
+    }
+  }
+  // no inversion: a wh-subject ("Who chased the cat") stays the subject
+  if (wh && WH_ARG.has(wh.lc)) return [{ word: wh.word, lc: wh.lc, tag: "X" }, ...rest];
+  return ts;
+}
+
+function finiteVerbTag(word: string): string {
+  const lc = word.toLowerCase();
+  const cop: Record<string, string> = { is: "VBZ", are: "VBP", am: "VBP", was: "VBD", were: "VBD", be: "VB", been: "VBN", being: "VBG" };
+  const aux: Record<string, string> = { has: "VBZ", have: "VBP", had: "VBD", do: "VBP", does: "VBZ", did: "VBD" };
+  return cop[lc] ?? aux[lc] ?? (lc.endsWith("ing") ? "VBG" : lc.endsWith("ed") ? "VBD" : lc.endsWith("s") ? "VBZ" : "VBP");
+}
+
+const nounTag = (word: string): string => (isCapitalized(word) ? "NNP" : word.toLowerCase().endsWith("s") ? "NNS" : "NN");
+
+type R = { tree: Tree; next: number } | null;
+
+// determiner/possessive? + (adverb|adjective)* + head noun, OR a bare pronoun.
+function parseBaseNP(ts: Tagged[], i: number, end: number): R {
+  const kids: Tree[] = [];
+  let j = i;
+  if (j < end && ts[j]!.tag === "DT") kids.push(leaf("DT", ts[j++]!.word));
+  else if (j < end && ts[j]!.tag === "PRP$") kids.push(leaf("PRP$", ts[j++]!.word));
+
+  if (j < end && ts[j]!.tag === "PRP") {
+    kids.push(leaf("PRP", ts[j++]!.word));
+    return { tree: node("NP", kids), next: j };
+  }
+
+  // open-class run: adjectives + head noun. A verb-like word ends the run ONLY once we already
+  // have a head noun (then it's the predicate: "dogs | bark"). Before that, a verb-like word is
+  // taken as the noun head, so a determiner-led NP gets its head ("a big old | walk").
+  const run: Tagged[] = [];
+  let hasNoun = false;
+  while (j < end && (ts[j]!.tag === "X" || ts[j]!.tag === "JJ" || ts[j]!.tag === "CD" || ts[j]!.tag === "RB")) {
+    if (looksLikeVerb(ts[j]!) && hasNoun) break;
+    if (ts[j]!.tag === "X" || ts[j]!.tag === "CD") hasNoun = true;
+    run.push(ts[j]!);
+    j++;
+  }
+  if (run.length === 0 && kids.length === 0) return null;
+
+  // last open-class word is the head noun; earlier ones are modifiers
+  let headIdx = -1;
+  for (let k = run.length - 1; k >= 0; k--) if (run[k]!.tag === "X" || run[k]!.tag === "CD") { headIdx = k; break; }
+  if (headIdx === -1) headIdx = run.length - 1; // no clear noun (e.g. an -ly word) -> last token is head
+  run.forEach((t, k) => {
+    if (k === headIdx) kids.push(leaf(nounTag(t.word), t.word));
+    else if (t.tag === "RB") kids.push(leaf("RB", t.word));
+    else if (t.tag === "CD") kids.push(leaf("CD", t.word));
+    else kids.push(leaf("JJ", t.word)); // pre-head open-class word -> adjective
+  });
+  if (headIdx === -1 && kids.length === 0) return null;
+  return { tree: node("NP", kids), next: j };
+}
+
+// "SUB" is accepted alongside IN/TO because several subordinators double as prepositions ("as",
+// "since", "after", "before", "until", "while"). Callers gate on the tag themselves; parseSingleVP
+// is the one that reaches here with a SUB, and only after a clause reading has already failed.
+function parsePP(ts: Tagged[], i: number, end: number): R {
+  const t = ts[i]!.tag;
+  if (t !== "IN" && t !== "TO" && t !== "SUB") return null;
+  const np = parseNP(ts, i + 1, end);
+  if (!np) return null;
+  // Correlative comparative: "as many tables AS he can". The second "as" introduces a clause that
+  // belongs to the OBJECT ("many tables"), not to the main verb — attaching it here is what keeps
+  // "serves as many tables as he can" structurally distinct from "serves as a reminder".
+  let obj = np.tree;
+  let next = np.next;
+  if (next < end && ts[next]!.tag === "SUB" && ts[next]!.lc === ts[i]!.lc) {
+    const s = parseS(ts, next + 1, end);
+    if (s) {
+      obj = node("NP", [np.tree, node("SBAR", [leaf("IN", ts[next]!.word), s.tree])]);
+      next = s.next;
+    }
+  }
+  return { tree: node("PP", [leaf("IN", ts[i]!.word), obj]), next };
+}
+
+// Infinitive phrase: "to" + verb + (object) + (adverbs/PPs). A verbal — diagrammed on a stand.
+function parseInfinitive(ts: Tagged[], i: number, end: number): R {
+  const verb = ts[i + 1];
+  if (!verb) return null;
+  const kids: Tree[] = [leaf("TO", ts[i]!.word), leaf("VB", verb.word)];
+  let j = i + 2;
+  while (j < end && ts[j]!.tag !== "CC") {
+    const t = ts[j]!;
+    if (t.tag === "RB") {
+      kids.push(node("ADVP", [leaf("RB", t.word)]));
+      j++;
+    } else if (t.tag === "IN" || t.tag === "TO") {
+      const pp = parsePP(ts, j, end);
+      if (!pp) break;
+      kids.push(pp.tree);
+      j = pp.next;
+    } else if (t.tag === "DT" || t.tag === "PRP$" || t.tag === "PRP" || t.tag === "JJ" || (t.tag === "X" && !looksLikeVerb(t)) || t.tag === "CD") {
+      const np = parseNP(ts, j, end);
+      if (!np) break;
+      kids.push(np.tree);
+      j = np.next;
+    } else break;
+  }
+  return { tree: node("INF", kids), next: j };
+}
+
+// base NP + trailing PPs + coordination (NP CC NP)
+function parseNP(ts: Tagged[], i: number, end: number): R {
+  const base = parseBaseNP(ts, i, end);
+  if (!base) return null;
+  let j = base.next;
+  const post: Tree[] = [];
+  while (j < end && ts[j]!.tag === "IN") {
+    const pp = parsePP(ts, j, end);
+    if (!pp) break;
+    post.push(pp.tree);
+    j = pp.next;
+  }
+  let tree = post.length ? node("NP", [base.tree, ...post]) : base.tree;
+
+  if (j < end && ts[j]!.tag === "CC") {
+    const rhs = parseNP(ts, j + 1, end);
+    if (rhs) {
+      tree = node("NP", [tree, leaf("CC", ts[j]!.word), rhs.tree]);
+      j = rhs.next;
+    }
+  }
+  return { tree, next: j };
+}
+
+// one predicate: verb chain + complement (object / predicate noun / adjective) + modifiers
+function parseSingleVP(ts: Tagged[], i: number, end: number): R {
+  const kids: Tree[] = [];
+  let j = i;
+  let isCop = false;
+  const isAuxOrVerb = (t: Tagged) => t.tag === "MD" || t.tag === "AUX" || t.tag === "COP" || looksLikeVerb(t);
+  while (j < end) {
+    const t = ts[j]!;
+    if (isSetOffParticiple(ts, j)) break; // "barked, wagging its tail" — not part of the verb chain
+    if (isAuxOrVerb(t)) {
+      if (t.tag === "COP") isCop = true;
+      kids.push(leaf(t.tag === "MD" ? "MD" : finiteVerbTag(t.word), t.word));
+      j++;
+    } else if (t.tag === "RB" && j + 1 < end && isAuxOrVerb(ts[j + 1]!)) {
+      kids.push(node("ADVP", [leaf("RB", t.word)])); // adverb inside the verb chain: "can not identify"
+      j++;
+    } else break;
+  }
+  if (kids.length === 0) return null;
+
+  while (j < end && ts[j]!.tag !== "CC") {
+    const t = ts[j]!;
+    if (t.tag === "RB") {
+      kids.push(node("ADVP", [leaf("RB", t.word)]));
+      j++;
+    } else if (t.tag === "TO" && j + 1 < end && looksLikeVerb(ts[j + 1]!)) {
+      const inf = parseInfinitive(ts, j, end); // "to take a walk" — an infinitive object
+      if (!inf) break;
+      kids.push(inf.tree);
+      j = inf.next;
+    } else if (t.tag === "IN" || t.tag === "TO") {
+      const pp = parsePP(ts, j, end); // "to" + noun is a preposition ("went to the store")
+      if (!pp) break;
+      kids.push(pp.tree);
+      j = pp.next;
+    } else if (t.tag === "SUB") {
+      const s = parseS(ts, j + 1, end);
+      if (s) {
+        kids.push(node("SBAR", [leaf("IN", t.word), s.tree]));
+        j = s.next;
+      } else {
+        // No clause after it, so the subordinator is being used as a PREPOSITION: "serves as a
+        // reminder", "left after the movie". Without this fallback the whole phrase was dropped
+        // on the floor (#33) — the VP ended at the verb and everything after it vanished.
+        const pp = parsePP(ts, j, end);
+        if (!pp) break;
+        kids.push(pp.tree);
+        j = pp.next;
+      }
+    } else if (isCop && (t.tag === "JJ" || t.tag === "X") && !looksLikeVerb(t)) {
+      // predicate adjective(s): copula + bare adjective(s), incl. "tiny and loud"
+      const adjLike = (x: Tagged) => (x.tag === "JJ" || x.tag === "X") && !looksLikeVerb(x);
+      const adj: Tree[] = [];
+      for (;;) {
+        if (j < end && adjLike(ts[j]!)) adj.push(leaf("JJ", ts[j++]!.word));
+        else if (j + 1 < end && ts[j]!.tag === "CC" && adjLike(ts[j + 1]!)) adj.push(leaf("CC", ts[j++]!.word));
+        else break;
+      }
+      kids.push(node("ADJP", adj));
+    } else if (t.tag === "DT" || t.tag === "PRP$" || t.tag === "PRP" || t.tag === "JJ" || (t.tag === "X" && !looksLikeVerb(t)) || t.tag === "CD") {
+      const np = parseNP(ts, j, end);
+      if (!np) break;
+      kids.push(np.tree); // lower() decides object vs predicate-nominative by copula
+      j = np.next;
+    } else break;
+  }
+  return { tree: node("VP", kids), next: j };
+}
+
+// predicate with optional coordination (VP CC VP)
+function parseVP(ts: Tagged[], i: number, end: number): R {
+  const first = parseSingleVP(ts, i, end);
+  if (!first) return null;
+  let j = first.next;
+  if (j < end && ts[j]!.tag === "CC") {
+    const rhs = parseSingleVP(ts, j + 1, end);
+    if (rhs) return { tree: node("VP", [first.tree, leaf("CC", ts[j]!.word), rhs.tree]), next: rhs.next };
+  }
+  return first;
+}
+
+// A participial phrase set off by a comma — "..., highlighting its importance". Both halves of the
+// signal matter: an -ing verb, and a comma on the word before it (Tagged.comma). Everything the
+// chunker used to do with such a phrase was drop it (#33) — parseSingleVP has no rule for a verb
+// after a complete predicate, so it broke out and the rest of the sentence vanished.
+//
+// The comma requirement is what keeps this from mis-attaching: "I saw the man running" has no
+// comma, so it keeps today's behavior rather than gaining a participle on the wrong noun.
+// Restricted to -ing too — a bare -ed/-en in the same slot is more often a mis-tagged main verb.
+const isSetOffParticiple = (ts: Tagged[], j: number): boolean => {
+  const t = ts[j]!;
+  return !!ts[j - 1]?.comma && looksLikeVerb(t) && t.lc.endsWith("ing") && t.tag !== "COP" && t.tag !== "AUX";
+};
+
+// (S (VP (VBG highlighting) (NP its importance) ...)) — wrapped in its own S because that is the
+// shape lower.ts recognizes as a participial phrase (isParticipial: an S with no subject NP whose
+// VP is VBG/VBN-headed), which it then attaches to the subject noun as a { kind: "participle" }
+// modifier — where Reed-Kellogg puts a participle.
+function parseParticipial(ts: Tagged[], i: number, end: number): R {
+  const kids: Tree[] = [leaf("VBG", ts[i]!.word)];
+  let j = i + 1;
+  while (j < end && ts[j]!.tag !== "CC") {
+    const t = ts[j]!;
+    if (t.tag === "RB") {
+      kids.push(node("ADVP", [leaf("RB", t.word)]));
+      j++;
+    } else if (t.tag === "IN" || t.tag === "TO") {
+      const pp = parsePP(ts, j, end);
+      if (!pp) break;
+      kids.push(pp.tree);
+      j = pp.next;
+    } else if (t.tag === "DT" || t.tag === "PRP$" || t.tag === "PRP" || t.tag === "JJ" || t.tag === "CD" || (t.tag === "X" && !looksLikeVerb(t))) {
+      const np = parseNP(ts, j, end);
+      if (!np) break;
+      kids.push(np.tree);
+      j = np.next;
+    } else break;
+  }
+  return { tree: node("S", [node("VP", kids)]), next: j };
+}
+
+// Consume a run of comma-set-off participial phrases starting at `j`.
+function parseParticipials(ts: Tagged[], j: number, end: number, into: Tree[]): number {
+  while (j < end && isSetOffParticiple(ts, j)) {
+    const p = parseParticipial(ts, j, end);
+    if (!p || p.next === j) break;
+    into.push(p.tree);
+    j = p.next;
+  }
+  return j;
+}
+
+function parseS(ts: Tagged[], i: number, end: number): R {
+  const subj = parseNP(ts, i, end);
+  if (!subj) return null;
+  // A participial phrase can sit between the subject and the predicate ("The dog, barking
+  // furiously, chased the cat") or trail the whole clause ("... opened in 1994, highlighting its
+  // importance"). Both end up as S siblings, which lower.ts hangs on the subject noun.
+  const parts: Tree[] = [];
+  const afterMid = parseParticipials(ts, subj.next, end, parts);
+  let vp = parseVP(ts, afterMid, end);
+  if (!vp && afterMid !== subj.next) {
+    parts.length = 0; // no predicate after the participle — fall back to reading it as the verb
+    vp = parseVP(ts, subj.next, end);
+  }
+  if (!vp) return null;
+  const j = parseParticipials(ts, vp.next, end, parts);
+  return { tree: node("S", [subj.tree, vp.tree, ...parts]), next: j };
+}
+
+// Parse into a constituency Tree. A single clause returns its S; independent clauses joined by
+// a conjunction ("Birds sing and dogs bark") return an S whose children are several S + CC
+// (a compound sentence). Throws if it can't find even one clause.
+export function parse(text: string): Tree {
+  // Punctuation tokens are dropped, but a comma's POSITION is kept on the word it follows — the
+  // tagger already records it that way (Tagged.comma), and a standalone comma token (spaced input,
+  // "a , b") has to fold into the same place so both spellings parse alike.
+  const kept: Tagged[] = [];
+  for (const t of tag(text)) {
+    if (t.tag === ".") continue;
+    if (t.tag === ",") {
+      const last = kept[kept.length - 1];
+      if (last) last.comma = true;
+      continue;
+    }
+    kept.push(t);
+  }
+  const ts = normalizeQuestion(kept);
+
+  const clauses: Tree[] = [];
+  const ccs: string[] = [];
+  let i = 0;
+  while (i < ts.length) {
+    const s = parseS(ts, i, ts.length);
+    if (!s) break;
+    clauses.push(s.tree);
+    i = s.next;
+    if (i < ts.length && ts[i]!.tag === "CC") {
+      ccs.push(ts[i]!.word);
+      i++;
+    } else break;
+  }
+  if (clauses.length === 0) throw new Error("couldn't parse: expected a subject and a verb");
+  if (clauses.length === 1) return clauses[0]!;
+
+  const kids: Tree[] = [];
+  clauses.forEach((c, k) => {
+    kids.push(c);
+    if (k < ccs.length) kids.push(leaf("CC", ccs[k]!));
+  });
+  return node("S", kids);
+}

--- a/scripts/destink/vendor/nlp/tagger.ts
+++ b/scripts/destink/vendor/nlp/tagger.ts
@@ -1,0 +1,121 @@
+// POS tagger backed by `compromise` (pure-JS, ships in the bundle — no WASM, no model
+// download). It replaced a hand-rolled lexicon+morphology tagger whose failures were all POS
+// ambiguities a rule can't resolve ("sally" noun vs -ly adverb; "sold" verb vs unknown word).
+//
+// We map compromise's rich tag set down to the coarse tags the chunker (parse.ts) consumes.
+// Open-class words stay "X" (the chunker assigns noun/adjective by position); a detected verb
+// is marked forced:"V" so the chunker treats it as the predicate reliably.
+//
+// compromise also emits ZERO-WIDTH terms for the second half of a contraction; see the
+// "contracted verbs" section below for which ones we put back and which stay dropped.
+//
+// ENGLISH-SPECIFIC: this + parse.ts + lower.ts are the English layer. A future multilingual
+// path swaps in a Universal-Dependencies parser and a dependency->IR lowering; the IR and
+// everything downstream are unchanged.
+
+import nlp from "compromise";
+import { POSS, AUX, SUBORD, REL, ADV } from "./lexicon.js";
+
+export type Tag = "DT" | "PRP$" | "PRP" | "IN" | "TO" | "SUB" | "REL" | "CC" | "MD" | "COP" | "AUX" | "RB" | "CD" | "JJ" | "X" | "," | ".";
+// `comma`: this word is followed by a comma. compromise carries punctuation in a term's trailing
+// whitespace rather than as a term of its own, so without this the chunker cannot see where a
+// phrase was set off — which is the only signal distinguishing a trailing participial phrase
+// ("opened in 1994, highlighting ...") from a verb chain ("kept highlighting ...").
+export type Tagged = { word: string; lc: string; tag: Tag; forced?: "V"; comma?: true };
+
+type Term = { text: string; tags?: string[]; post?: string };
+
+function mapTags(word: string, tags: Set<string>): { tag: Tag; forced?: "V" } {
+  const lc = word.toLowerCase();
+  if (/^[.!?;:]$/.test(word)) return { tag: "." };
+  if (word === ",") return { tag: "," };
+  if (lc === "to") return { tag: "TO" }; // infinitive marker OR preposition — disambiguated in the chunker
+  if (POSS.has(lc)) return { tag: "PRP$" };
+  if (SUBORD.has(lc)) return { tag: "SUB" };
+  if (AUX.has(lc)) return { tag: "AUX" };
+  if (REL.has(lc) && !tags.has("Determiner")) return { tag: "REL" };
+  if (tags.has("Determiner")) return { tag: "DT" };
+  if (tags.has("Modal")) return { tag: "MD" };
+  if (tags.has("Copula")) return { tag: "COP" };
+  if (tags.has("Conjunction")) return { tag: "CC" };
+  if (tags.has("Pronoun")) return { tag: "PRP" };
+  if (tags.has("Preposition")) return { tag: "IN" };
+  if (tags.has("Adverb") || tags.has("Negative") || ADV.has(lc)) return { tag: "RB" }; // incl. "not"
+  if (tags.has("Value") || tags.has("Cardinal")) return { tag: "CD" };
+  if (tags.has("Verb")) return { tag: "X", forced: "V" }; // open-class verb -> the predicate
+  if (tags.has("Adjective")) return { tag: "JJ" };
+  return { tag: "X" }; // noun / unknown -> resolved by position in the chunker
+}
+
+// --- contracted verbs ---
+//
+// compromise splits a contraction into the host word plus a ZERO-WIDTH term carrying the clitic's
+// tags: "It's not bold" arrives as ["It's" Pronoun, "" Verb+Copula, "not" Negative, "bold"
+// Adjective]. Dropping the empty term (what this file used to do) threw away the sentence's only
+// verb, so the chunker saw PRP RB JJ and readDocument called the whole thing a fragment (#31).
+//
+// We restore it by splitting the clitic off the host and expanding it to the full form the rest of
+// the pipeline already keys on — lower.ts's COPULA list and lint/ir-query's BE_FORMS both hold
+// "is"/"are"/"am", never "'s" — so "It's" tags as It/PRP is/COP. Expanding also matches how a
+// contraction is conventionally diagrammed (the verb goes on the baseline in full).
+const CLITIC = /['’](s|re|m|ve|ll|d)$/i;
+
+// Which verb the clitic stands for. compromise's own tags on the zero-width term disambiguate the
+// two ambiguous ones: "'s" is the copula ("It's bold") unless it is a bare auxiliary ("It's been
+// raining" -> has), and "'d" is "would" when tagged Modal ("She'd like tea") and "had" otherwise
+// ("She'd left already").
+function expandClitic(clitic: string, tags: Set<string>): string | null {
+  switch (clitic) {
+    case "s": return tags.has("Copula") ? "is" : tags.has("Auxiliary") ? "has" : null;
+    case "re": return "are";
+    case "m": return "am";
+    case "ve": return "have";
+    case "ll": return "will";
+    case "d": return tags.has("Modal") ? "would" : "had";
+    default: return null;
+  }
+}
+
+export function tag(text: string): Tagged[] {
+  // compromise's published types don't expose the runtime json() options shape; cast past it.
+  const sentences = (nlp(text) as { json(o: unknown): unknown }).json({ terms: true }) as Array<{ terms: Term[] }>;
+  const out: Tagged[] = [];
+  let prevTags = new Set<string>(); // tags of the term that produced out[out.length - 1]
+  const push = (word: string, tags: Set<string>): void => {
+    const m = mapTags(word, tags);
+    out.push(m.forced ? { word, lc: word.toLowerCase(), tag: m.tag, forced: m.forced } : { word, lc: word.toLowerCase(), tag: m.tag });
+  };
+  // compromise keeps a comma in the preceding term's trailing whitespace, so record it on the word
+  // it follows (see Tagged.comma).
+  const markComma = (): void => {
+    const last = out[out.length - 1];
+    if (last) last.comma = true;
+  };
+  for (const sent of sentences) {
+    for (const t of sent.terms) {
+      const tags = new Set(t.tags ?? []);
+      const word = t.text;
+      if (!word) {
+        // Only a VERB clitic is restored. A zero-width Negative ("isn't" -> "isn't" + "") stays
+        // dropped on purpose: the negation is still visible in the surface word, and downstream
+        // (lint/ir-query's stripContractedNegation) reads it off the fused verb head. A zero-width
+        // pronoun ("Let's" -> "Let" + "us") is left alone too — splitting it would turn an
+        // imperative into a subject the chunker would then have to re-analyse.
+        const prev = out[out.length - 1];
+        const m = prev && tags.has("Verb") ? CLITIC.exec(prev.word) : null;
+        const full = m && m.index > 0 ? expandClitic(m[1]!.toLowerCase(), tags) : null;
+        if (!m || !full || !prev) continue;
+        out.pop();
+        push(prev.word.slice(0, m.index), prevTags); // host word without the clitic, re-tagged
+        push(full, tags);
+        prevTags = tags;
+        if (t.post?.includes(",")) markComma();
+        continue;
+      }
+      push(word, tags);
+      prevTags = tags;
+      if (t.post?.includes(",")) markComma();
+    }
+  }
+  return out;
+}

--- a/scripts/destink/vendor/ptb.ts
+++ b/scripts/destink/vendor/ptb.ts
@@ -1,0 +1,43 @@
+// Penn-Treebank bracket parser. benepar (and most constituency parsers) emit parses as nested
+// labelled brackets, e.g. (S (NP (DT the) (NN dog)) (VP (VBD barked) (ADVP (RB loudly)))).
+// This turns that string into a Tree; src/lower.ts lowers a Tree into our Clause IR.
+
+export type Tree = {
+  label: string; // phrase/POS tag: S, NP, VP, DT, NN, VBD, ...
+  word?: string; // set only on preterminals: (DT the) -> { label:"DT", word:"the" }
+  children: Tree[];
+};
+
+export function parseBracket(input: string): Tree {
+  const toks = input.replace(/\(/g, " ( ").replace(/\)/g, " ) ").trim().split(/\s+/);
+  let i = 0;
+
+  function node(): Tree {
+    if (toks[i] !== "(") throw new Error(`PTB: expected '(' at token ${i}, got ${toks[i] ?? "EOF"}`);
+    i++; // consume '('
+    const label = toks[i++];
+    if (label === undefined) throw new Error("PTB: missing label after '('");
+    const children: Tree[] = [];
+    let word: string | undefined;
+    while (i < toks.length && toks[i] !== ")") {
+      if (toks[i] === "(") children.push(node());
+      else word = toks[i++]; // terminal word
+    }
+    if (toks[i] !== ")") throw new Error("PTB: unbalanced parentheses");
+    i++; // consume ')'
+    return word !== undefined ? { label, word, children } : { label, children };
+  }
+
+  const tree = node();
+  // unwrap a ROOT/TOP/S1 wrapper if present
+  return ["ROOT", "TOP", "S1", ""].includes(tree.label) && tree.children[0] ? tree.children[0]! : tree;
+}
+
+// All terminal words under a subtree, in order.
+export const leaves = (t: Tree): string[] => (t.word !== undefined ? [t.word] : t.children.flatMap(leaves));
+export const phrase = (t: Tree): string => leaves(t).join(" ");
+
+// All (word, POS tag) preterminals under a subtree, in order — e.g. { word:"small", tag:"JJ" }.
+// The parse keeps the fine POS the IR drops, so criteria like "two adjectives" read straight off it.
+export const posTags = (t: Tree): Array<{ word: string; tag: string }> =>
+  t.word !== undefined ? [{ word: t.word, tag: t.label }] : t.children.flatMap(posTags);

--- a/scripts/destink/vendor/scene.ts
+++ b/scripts/destink/vendor/scene.ts
@@ -1,0 +1,78 @@
+// Scene — the decoupling seam. layout() runs once and produces a Scene;
+// every renderer (Canvas now, WebGPU later) consumes the same Scene.
+//
+// Two rules that make "rich" possible:
+//   (a) a tagged scene-*graph*, not a flat list (groups carry role + stable id)
+//   (b) primitives carry *roles*, not pixels (Theme maps role -> appearance)
+
+export type Pt = { x: number; y: number };
+
+// Axis-aligned bounding box, in abstract layout units. Right/left may overhang the head.
+export type BBox = { left: number; top: number; right: number; bottom: number };
+
+// Identity back-references.
+export type NodeId = string; // stable, STRUCTURAL (derived from IR path/role) — load-bearing for morph
+export type IrId = string; // back-ref to the originating IR node
+
+// The full alphabet of marks. Everything renders to a Seg or a Lbl.
+export type Role =
+  | "baseline"
+  | "rail"
+  | "divider.full"
+  | "divider.half"
+  | "divider.lean"
+  | "slant"
+  | "word"
+  | "connector.dotted"
+  | "fork";
+
+export type Prim =
+  | { kind: "seg"; a: Pt; b: Pt; role: Role; sourceId?: IrId }
+  | { kind: "lbl"; text: string; anchor: Pt; angle: number; role: Role; pos?: string; sourceId?: IrId }; // pos: POS tag when the label is a single leaf word
+
+export type NodeRole =
+  | "sentence"
+  | "clause"
+  | "subject"
+  | "verb"
+  | "object"
+  | "complement"
+  | "modifier"
+  | "pp"
+  | "compound"
+  | "subclause";
+
+export type SceneNode = {
+  id: NodeId;
+  role: NodeRole;
+  sourceId?: IrId;
+  children: Array<SceneNode | Prim>;
+  bounds: BBox;
+};
+
+export type Scene = { root: SceneNode; bounds: BBox };
+
+// --- small helpers ---
+
+export const isNode = (c: SceneNode | Prim): c is SceneNode =>
+  (c as SceneNode).children !== undefined;
+
+export const emptyBBox = (): BBox => ({
+  left: Infinity,
+  top: Infinity,
+  right: -Infinity,
+  bottom: -Infinity,
+});
+
+// --- fit-to-canvas view transform (scene units -> screen px). Shared by the renderer and by
+// pointer hit-testing so they never drift. Only ever scales DOWN, and centres the diagram. ---
+export type View = { s: number; tx: number; ty: number };
+
+export const fitView = (b: BBox, cssW: number, cssH: number, pad = 28): View => {
+  const bw = Math.max(1, b.right - b.left);
+  const bh = Math.max(1, b.bottom - b.top);
+  const s = Math.min(1, (cssW - 2 * pad) / bw, (cssH - 2 * pad) / bh);
+  return { s, tx: (cssW - bw * s) / 2 - b.left * s, ty: (cssH - bh * s) / 2 - b.top * s };
+};
+
+export const screenToScene = (p: Pt, v: View): Pt => ({ x: (p.x - v.tx) / v.s, y: (p.y - v.ty) / v.s });

--- a/scripts/destink/vendor/theme.ts
+++ b/scripts/destink/vendor/theme.ts
@@ -1,0 +1,107 @@
+// Theme — role -> appearance. Same geometry, different looks by swapping one object.
+// Strictly separate from LayoutStyle: nothing here may change coordinates.
+
+import type { Role } from "./scene.js";
+
+export type StrokeSpec = {
+  color: string;
+  weight: number;
+  dash?: number[];
+  cap?: "butt" | "round" | "square";
+};
+
+export type FontSpec = {
+  family: string;
+  size: number; // px
+  style?: "normal" | "italic";
+  weight?: number;
+};
+
+export type Override = Partial<StrokeSpec> & { opacity?: number };
+
+export type EmphasisState = "hover" | "active" | "muted";
+
+export interface Theme {
+  stroke(role: Role): StrokeSpec;
+  font(role: Role): FontSpec;
+  emphasis(role: Role, state: EmphasisState): Override;
+}
+
+// Geometric style — feeds layout(), changes coordinates. Kept apart from Theme on purpose.
+export type LayoutStyle = {
+  em: number; // base unit driving spacing
+  slantAngle: number; // theta, radians from horizontal
+  dividerGap: number; // min horizontal gap at a divider
+  fullDividerRise: number; // how far the full vertical crosses above/below the baseline
+  halfDividerRise: number; // verb|object half-divider height (sits on baseline)
+  leanLeftAngle: number; // angle of the lean-left complement divider
+  minSlantSpacing: number; // min x-distance between two slants under one head
+  pad: number;
+};
+
+// A minimal, clean-minimal Theme — proves the role->appearance seam. Phase 4 adds variants.
+export const defaultTheme: Theme = {
+  stroke(role: Role): StrokeSpec {
+    switch (role) {
+      case "baseline":
+      case "rail":
+        return { color: "#2b2b2b", weight: 1.8, cap: "round" };
+      case "divider.full":
+      case "divider.half":
+      case "divider.lean":
+        return { color: "#2b2b2b", weight: 1.4, cap: "round" };
+      case "slant":
+        return { color: "#3a3a3a", weight: 1.2, cap: "round" };
+      case "connector.dotted":
+        return { color: "#6a6a6a", weight: 1.1, dash: [3, 3], cap: "butt" };
+      default:
+        return { color: "#2b2b2b", weight: 1.2 };
+    }
+  },
+  font(_role: Role): FontSpec {
+    return { family: "Tinos, Georgia, 'Times New Roman', serif", size: 16 }; // pinned: matches test metrics
+  },
+  emphasis(_role: Role, state: EmphasisState): Override {
+    if (state === "muted") return { opacity: 0.35 };
+    if (state === "hover") return { color: "#1769aa" };
+    return { color: "#0b3d91" };
+  },
+};
+
+// A second, visually distinct Theme over IDENTICAL geometry — proves the role->appearance
+// seam and the LayoutStyle/RenderStyle split (this changes appearance, never coordinates).
+export const blueprintTheme: Theme = {
+  stroke(role: Role): StrokeSpec {
+    switch (role) {
+      case "baseline":
+      case "rail":
+        return { color: "#cfe8ff", weight: 2, cap: "round" };
+      case "slant":
+        return { color: "#9ecbff", weight: 1.3, cap: "round" };
+      case "connector.dotted":
+        return { color: "#7fb0e8", weight: 1.1, dash: [2, 4], cap: "butt" };
+      case "fork":
+        return { color: "#9ecbff", weight: 1.3, cap: "round" };
+      default:
+        return { color: "#dbeeff", weight: 1.5, cap: "round" };
+    }
+  },
+  font(_role: Role): FontSpec {
+    return { family: "ui-monospace, 'SF Mono', Menlo, monospace", size: 15 };
+  },
+  emphasis(_role: Role, state: EmphasisState): Override {
+    if (state === "muted") return { opacity: 0.4 };
+    return { color: "#ffd36b" };
+  },
+};
+
+export const defaultLayoutStyle: LayoutStyle = {
+  em: 16,
+  slantAngle: Math.PI / 3, // 60deg
+  dividerGap: 18,
+  fullDividerRise: 14,
+  halfDividerRise: 12,
+  leanLeftAngle: Math.PI / 3,
+  minSlantSpacing: 14,
+  pad: 8,
+};


### PR DESCRIPTION
`docs/` has two prose gates today. `scripts/docs-style.py` enforces the style sheet, and `vale lint docs` enforces ASD-STE100. Neither looks for the thing an AI-written page actually sounds like, and these pages are AI-written.

This adds a third: `node scripts/destink/destink.mjs`, wired into both places a docs change reaches CI (the `checks` job for a mixed PR, the `docs` job for a docs-only one).

## Where the engine comes from

Vendored from [lex00/sentences](https://github.com/lex00/sentences) (MIT) under `scripts/destink/vendor`, pinned by SHA in `vendor/UPSTREAM`. `scripts/destink/sync.mjs` re-copies it, recomputing the import closure from four entry points rather than carrying a file list that would go stale silently. Nothing in `vendor/` is edited: the sync overwrites it wholesale, so a local fix there would be reverted without anyone noticing.

## Two things made it workable

**It lints prose, not markdown.** Pointed at raw pages the linter reported **2,721 findings**, and roughly 1,750 were markdown being mistaken for writing:

| what fired | why it was wrong |
|---|---|
| `formatting/em-dash-density`, 788 hits | the rule is `/—\|--/g`, and here `--` is `--config` or a `\|---\|` table separator |
| fragment / anaphora / near-duplicate, ~700 | the splitter breaks on `. ! ? ; :`, so table rows and link lists read as verbless sentences |
| `dead-metaphor/rare-lemma` on `guides`, `operate` | they were path segments inside a URL |

`extract-prose.mjs` blanks code fences, tables, inline code, link targets, HTML blocks and admonition directives. It **blanks rather than deletes** — every character becomes a space, newlines kept — so offsets still index the real file and every reported line number is real. That took 2,721 to 972.

Three of its rules were found by chasing a false positive to its cause rather than editing the page: fences indented inside a list item (4+ spaces, not CommonMark's top-level 3) leaked ~60 lines of TypeScript; the inlined primitives SVG, which `docs_test` pins byte-for-byte against `README.md`, offered up its arrow as a `unicode-decoration` finding; and `!!! tip "In a hurry?"` came back as a self-posed question, which is what a callout title is supposed to be.

**The rule set is opt-in.** `ENABLED` and `DISABLED` in `destink.mjs` name all 46 vendored rules with the count each produced over `docs/`, and the disabled ten carry the reason — comma series are ordinary technical lists (478 hits), `dead-metaphor` has no Technical Names list so it flags `agent` and `token` (74), `docs-style.py` already owns em dashes and colon-introduced lists.

Opt-in is the safety property: a rule added upstream between syncs arrives **off**. The gate also refuses to start if an id named here is missing from the vendored registry, which is what a rename upstream looks like from here. That guard caught eight wrong ids the first time it ran.

## Result

33 rules, 87 pages, clean, in 3.9s. `scripts/destink/allow.txt` is the backlog and is **empty**, like `scripts/docs-style-allow.txt` and `.valeignore`.

The first commit clears the 79 findings across 50 pages so each commit lands green. The largest was `## At a glance`, which had become the template heading on 26 catalog and integration pages; every one opens a table of facts, so they are all `## Summary` now. `Wire up observability` became `Configure observability`, matching its sibling `Configure email` — it is a phrasal verb STE bans, and vale never saw it because it only appeared in link text and a heading.

## Verified

- `destink`: 87 pages clean; plants an AI-ism, exits 1 with the finding located; reverts, exits 0
- allow-list entry skips a page; a stale rule id exits 2 with the reconcile message
- `sync.mjs` re-run reproduces the vendored tree byte-for-byte
- `docs-style.py` clean, `vale lint docs` exits 0, `docs_test.exs` + `docs_controller_test.exs` 52 tests 0 failures
- `npm ci` from a removed `node_modules` (one dependency, `compromise`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GJJU9aAsG13D9H4VLJBZcT