### PR TITLE
The docs stop sounding like an assistant wrote them

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -29,7 +29,7 @@ that somebody remembered to document.
 
 **An API key. Use this for a script and for CI.**
 
-Create a key under Account → API Keys. Or exchange your credentials at
+Create a key under Account, then API Keys. Or exchange your credentials at
 `POST /api/auth/token`, which is what `fountain auth login` does. Then pass
 the key as a Bearer token.
 
@@ -115,7 +115,7 @@ URIs. A client or a redirect that nobody registered renders an error page, and
 Fountain redirects nowhere.
 
 A code lives five minutes, and it works once. The key is full-scope, it
-expires in 30 days, and it lists under Account → API keys as
+expires in 30 days, and it lists under Account, then API keys, as
 `oauth:<client_id>`.
 
 ## Account state
@@ -278,7 +278,7 @@ somewhere else can read it, and hard-code nothing.
 A model list is a set of suggestions, and not an allowlist. Fountain accepts
 any `provider/model` under a provider it knows.
 
-`package_managers` names what Fountain truly installs from an environment's
+`package_managers` names what Fountain installs from an environment's
 `packages`, which is `apt` and `npm`. It stores another key and ignores it.
 
 To draw an avatar, Fountain uses the tenant's own OpenAI credential. Without

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -144,7 +144,7 @@ a state of `started`, `done`, `failed` or `interrupted`.
 
     Then one of two things happens. **`checkpoint_restore`** is a warm start
     from an environment checkpoint, and it skips the rest. Or the cold
-    pipeline runs, which is **`packages` → `network` → `clone` → `setup`**.
+    pipeline runs, which is **`packages`, then `network`, then `clone`, then `setup`**.
     The sandbox is then `ready`. A step that fails destroys the sprite, and
     marks the sandbox and the conversation `failed`.
 3. **`turn`.** Fountain spawns the runtime, which is claude, codex, gemini or

--- a/docs/build/index.md
+++ b/docs/build/index.md
@@ -112,7 +112,7 @@ appears in both threads. Read [Team](../api.md#team).
 [Nostr](../integrations/buzz.md). Where the instance allows it, the teammate
 also answers from its own email address and phone number.
 
-Each of those surfaces binds its own durable thread, through the mechanism
+Each of those surfaces binds its own durable thread, by the mechanism
 your app uses. Your UI is one door onto something that exists whether or not
 the tab is open.
 

--- a/docs/build/pieces.md
+++ b/docs/build/pieces.md
@@ -74,7 +74,7 @@ thread.
 
 **The 202 is not the answer.** `POST /messages` queues a turn and returns the
 conversation id. Everything after that arrives on the stream. So an app that
-awaits a reply really awaits stream events. The SDK's `Run` handle does that
+awaits a reply must await stream events. The SDK's `Run` handle does that
 wait for you.
 
 **Secrets arrive at spawn, and not at the prompt.** Fountain merges the

--- a/docs/build/team-chat.md
+++ b/docs/build/team-chat.md
@@ -392,7 +392,7 @@ instance.
 
 [Sign in with Fountain](../api.md#sign-in-with-fountain-oauth-20-for-browser-apps)
 is OAuth 2.0 authorization code with PKCE. The token it returns *is* an API
-key. It lists and revokes under Account → API keys, and a sign-out revokes it.
+key. It lists and revokes under Account, then API keys, and a sign-out revokes it.
 For an app with no backend, that is the whole authentication story.
 
 ## The whole thing, runnable

--- a/docs/catalog/agents/fountain-contributor.md
+++ b/docs/catalog/agents/fountain-contributor.md
@@ -3,7 +3,7 @@
 > An agent that contributes to Fountain itself, configured to work the way a
 > maintainer's laptop session does.
 
-## At a glance
+## Summary
 
 | | |
 |---|---|
@@ -55,7 +55,7 @@ test, so the suite runs without it.
       -p "Read issue #NNN and fix it"
     ```
 
-The `--vault` flag is not optional in practice. The repo clone, `gh`, and the
+The `--vault` flag is not optional. The repo clone, `gh`, and the
 DCO identity all come from the vault.
 
 ## Verify

--- a/docs/catalog/mcp-servers/fountain-buzz.md
+++ b/docs/catalog/mcp-servers/fountain-buzz.md
@@ -2,7 +2,7 @@
 
 > Lets a hosted Buzz agent publish its reply to a Nostr channel.
 
-## At a glance
+## Summary
 
 | | |
 |---|---|

--- a/docs/catalog/mcp-servers/fountain-comms.md
+++ b/docs/catalog/mcp-servers/fountain-comms.md
@@ -3,7 +3,7 @@
 > Gives a teammate its own email address and phone number, and gives it no
 > keys.
 
-## At a glance
+## Summary
 
 | | |
 |---|---|

--- a/docs/catalog/mcp-servers/fountain-gmail.md
+++ b/docs/catalog/mcp-servers/fountain-gmail.md
@@ -3,7 +3,7 @@
 > Gives an agent a Gmail mailbox that the account owner connected once, and
 > gives it no Google token.
 
-## At a glance
+## Summary
 
 | | |
 |---|---|

--- a/docs/catalog/mcp-servers/fountain-team.md
+++ b/docs/catalog/mcp-servers/fountain-team.md
@@ -2,7 +2,7 @@
 
 > Lets a teammate see who else is on the team, and message them.
 
-## At a glance
+## Summary
 
 | | |
 |---|---|

--- a/docs/catalog/runtimes/claude.md
+++ b/docs/catalog/runtimes/claude.md
@@ -2,7 +2,7 @@
 
 > Anthropic's Claude Code CLI, headless in the sandbox.
 
-## At a glance
+## Summary
 
 | | |
 |---|---|

--- a/docs/catalog/runtimes/codex.md
+++ b/docs/catalog/runtimes/codex.md
@@ -2,7 +2,7 @@
 
 > OpenAI's Codex CLI, headless in the sandbox.
 
-## At a glance
+## Summary
 
 | | |
 |---|---|

--- a/docs/catalog/runtimes/gemini.md
+++ b/docs/catalog/runtimes/gemini.md
@@ -3,7 +3,7 @@
 > Google's Gemini CLI. The last runtime to reach ACP, and it reached it on
 > 2026-08-22.
 
-## At a glance
+## Summary
 
 | | |
 |---|---|

--- a/docs/catalog/runtimes/opencode.md
+++ b/docs/catalog/runtimes/opencode.md
@@ -2,7 +2,7 @@
 
 > The opencode CLI. The only runtime that can reach more than one provider.
 
-## At a glance
+## Summary
 
 | | |
 |---|---|

--- a/docs/catalog/skills/create-team.md
+++ b/docs/catalog/skills/create-team.md
@@ -3,7 +3,7 @@
 > A five-question conversation that proposes a roster of teammates, creates
 > them, and hands them over.
 
-## At a glance
+## Summary
 
 | | |
 |---|---|
@@ -19,14 +19,14 @@ Say `/create-team` to any teammate. Or ask it what the team must look like.
 **It asks at most five questions**, one at a time. It offers a default with
 each one, so "yes" is a complete answer.
 
-1. What must the team get done?
-2. Which repos or services are in scope, and which need a token?
-3. How many teammates, roughly? Two to five is usual. Past three, a lead
-   earns its place.
-4. Any brain preference? It reads `GET /api/catalog` for the models, and your
+1. The work the team must get done.
+2. The repos or services in scope, and which of them need a token.
+3. How many teammates. Two to five is usual. Past three, a lead earns its
+   place.
+4. Any brain preference. It reads `GET /api/catalog` for the models, and your
    inference credentials for the providers you hold a key for. It proposes
    nothing you cannot run.
-5. What names? Role names such as `repo-maintainer`, or a themed set.
+5. The names. Role names such as `repo-maintainer`, or a themed set.
 
 **Then it proposes.** You get a table of name, brain, a one-line role, and the
 first thing it would send each teammate.

--- a/docs/catalog/skills/fountain.md
+++ b/docs/catalog/skills/fountain.md
@@ -3,7 +3,7 @@
 > Lets an agent start more Fountain conversations from inside its own sandbox,
 > and stream them.
 
-## At a glance
+## Summary
 
 | | |
 |---|---|

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -162,8 +162,8 @@ wins on a collision. `--environment` provisions from that environment, and not
 from the agent's own.
 
 The `--sandbox` flag attaches the conversation to a sandbox you already have,
-by id. Two conversations then share one disk. A conversation's `sandbox_id`
-names its sandbox.
+by id. Two conversations then share one disk. The `sandbox_id` field names
+that disk.
 
 The `--sandbox-mode` flag is `ephemeral` or `persistent`. It replaces the
 agent's default for this conversation. A persistent conversation lands on the

--- a/docs/concepts/sandboxes.md
+++ b/docs/concepts/sandboxes.md
@@ -97,7 +97,7 @@ deny-all.
 
 ## Capabilities are honest, and that has consequences
 
-An adapter advertises what it can truly do, from `:suspend`,
+An adapter advertises only what it can do, from `:suspend`,
 `:network_policy`, `:attach`, `:tty`, `:checkpoint` and `:public_url`. The
 lifecycle then degrades to match, and it pretends nothing.
 

--- a/docs/concepts/secrets.md
+++ b/docs/concepts/secrets.md
@@ -127,7 +127,7 @@ value. It cannot audit the read, because that read happens in the sandbox.
 everything in the merged map. That is why the value is there at all. Scope the
 credential. Do not scope the agent.
 
-## Hop 5, which is really a hop back: Fountain scrubs the output
+## Hop 5, a hop back: Fountain scrubs the output
 
 Fountain writes everything a sandbox sends to stdout or stderr into
 `log_events`, word for word, and streams it over SSE. That table has none of

--- a/docs/concepts/surfaces.md
+++ b/docs/concepts/surfaces.md
@@ -104,6 +104,6 @@ that it can move and break no link.
 
 - [Plug into Fountain](../integrations/clients.md), for editors, chat
   surfaces, plugins and SDKs.
-- [Build a chat app](../build/index.md), the case for the API below it.
+- [Build a chat app](../build/index.md), and why the API below it exists.
 - [API reference](../api.md).
 - [Agents as teammates](teammates.md), which is what the Team app renders.

--- a/docs/guides/operate/dashboards.md
+++ b/docs/guides/operate/dashboards.md
@@ -210,7 +210,7 @@ above, so the repo stays the description of record.
 
 ## Related
 
-- [Wire up observability](observability.md), for the scrape, the alerts and the
+- [Configure observability](observability.md), for the scrape, the alerts and the
   health endpoints.
 - [See what sandboxes cost](sandbox-spend.md), for the per-account view.
 - [Operations overview](../../operations.md).

--- a/docs/guides/operate/deploy.md
+++ b/docs/guides/operate/deploy.md
@@ -64,8 +64,7 @@ any other role change (ADR 0011).
 Register **before** you expose the instance to a network you do not trust.
 While no admin exists, the first verified account takes the role.
 
-Do you want the manual path instead? Set `FIRST_USER_ADMIN=false` and use a
-release task. Read [Run a release task](run-a-release-task.md).
+For the manual path, set `FIRST_USER_ADMIN=false` and use a release task. Read [Run a release task](run-a-release-task.md).
 
 ```bash
 docker compose exec app bin/fountain_server eval \
@@ -148,7 +147,7 @@ value then becomes unreadable.
 Does the app serve while a sandbox fails to start? The sandbox provider is the
 usual cause. Read [Sandbox errors](../../troubleshooting/sandbox-errors.md).
 
-Does the container never open a listener? Migrations cannot reach the
+If the container never opens a listener, migrations cannot reach the
 database. Read
 [Pods restart or never go ready](../../troubleshooting/pods-restarting.md).
 

--- a/docs/guides/operate/kubernetes.md
+++ b/docs/guides/operate/kubernetes.md
@@ -86,6 +86,6 @@ work.
 
 ## Related
 
-- [Wire up observability](observability.md), for the PrometheusRule.
+- [Configure observability](observability.md), for the PrometheusRule.
 - [Back up and restore](back-up-and-restore.md).
 - [Architecture](../../architecture.md), for the cluster picture.

--- a/docs/guides/operate/observability.md
+++ b/docs/guides/operate/observability.md
@@ -1,4 +1,4 @@
-# Wire up observability
+# Configure observability
 
 This guide shows you how to scrape metrics. It also shows you how to import
 the dashboard and alerts that ship with the repo, and where to point your
@@ -19,7 +19,7 @@ observability pack, built from a real run of the hosted instance.
   says what it means and what to do. It needs the PrometheusRule CRD, and it
   sits commented out of the kustomization until you turn it on.
 - **A starter dashboard**, in `deploy/grafana/fountain-dashboard.json`. It is
-  built from metrics the app truly exports, and from nothing else. Import it
+  built from metrics the app exports, and from nothing else. Import it
   into Grafana, then choose your Prometheus datasource. On compose, point any
   Prometheus at the metrics port and import the same file.
 - **Three team dashboards**, in `deploy/grafana/`, one each for ops, product

--- a/docs/guides/operate/sandbox-spend.md
+++ b/docs/guides/operate/sandbox-spend.md
@@ -97,7 +97,7 @@ account tag, because one time series per account would grow without a bound.
 Per-account numbers belong in the admin panel and the API, where they are a
 column.
 
-See [Wire up observability](observability.md) for how to scrape the endpoint.
+See [Configure observability](observability.md) for how to scrape the endpoint.
 
 ## When to distrust the parked figures
 
@@ -125,4 +125,4 @@ credentials and never reaches a Fountain invoice.
 - [Start billing](billing.md), to charge for what you measure here. <!-- vale disable-line STE.IngForms -->
 - [Change sandbox lifetimes](sandbox-lifetime.md), the main lever on the total.
 - [About sandboxes](../../concepts/sandboxes.md), for what a sandbox is.
-- [Wire up observability](observability.md), for the metrics endpoint.
+- [Configure observability](observability.md), for the metrics endpoint.

--- a/docs/index.md
+++ b/docs/index.md
@@ -90,8 +90,8 @@ in full.
   an agent somewhere else
 - [Architecture](architecture.md), what runs, what it talks to, and what breaks
   when a dependency is down
-- [Why a bot needs more than a chat UI](build/index.md), the case for the API
-  below it
+- [Why a bot needs more than a chat UI](build/index.md), and why the API below
+  it exists
 
 ## Build with it
 

--- a/docs/integrations/buzz.md
+++ b/docs/integrations/buzz.md
@@ -59,7 +59,7 @@ stays inside Fountain, which signs with it. The sandbox never holds it.
 <figcaption><b>Four parties, and Fountain in the middle.</b> The owner provisions once; then Fountain speaks Nostr to the relay <em>as the agent</em>, drives the coding agent in a sandbox over ACP, and the sandbox asks Fountain to publish through an MCP tool, so it never touches the relay or the key itself.</figcaption>
 </figure>
 
-## At a glance
+## Summary
 
 | | |
 |---|---|
@@ -379,7 +379,7 @@ different parties**, govern those two things.
 | kind **30177** | The **owner**, from Buzz Desktop at deploy. | The policy that Desktop builds its own agent directory from. |
 
 The harness publishes its 10100 at startup, and at each change of channel
-membership. It builds the event from the channels it truly subscribes to, and
+membership. It builds the event from the channels it subscribes to, and
 from its real `respond_to`. That entry is accurate about the harness.
 
 **Buzz Desktop 0.5.17 and newer ignores it when a 30177 exists.** It builds

--- a/docs/integrations/daytona.md
+++ b/docs/integrations/daytona.md
@@ -15,7 +15,7 @@ DAYTONA_SNAPSHOT=fountain          # a snapshot built from images/daytona/ (unse
 # SANDBOX_PROVIDER=daytona
 ```
 
-## At a glance
+## Summary
 
 | | |
 |---|---|

--- a/docs/integrations/e2b.md
+++ b/docs/integrations/e2b.md
@@ -13,7 +13,7 @@ E2B_TEMPLATE=fountain        # a template built from images/e2b/ (see below)
 # SANDBOX_PROVIDER=e2b       # make it the instance default
 ```
 
-## At a glance
+## Summary
 
 | | |
 |---|---|

--- a/docs/integrations/editors.md
+++ b/docs/integrations/editors.md
@@ -13,7 +13,7 @@ the pipe. That process talks HTTP and SSE to your Fountain instance.
    (ACP over stdio)                                                  (the agent)
 ```
 
-## At a glance
+## Summary
 
 | | |
 |---|---|

--- a/docs/integrations/github-oauth.md
+++ b/docs/integrations/github-oauth.md
@@ -3,7 +3,7 @@
 **Optional.** It adds "Continue with GitHub" to the login and registration
 pages. Email and password auth works without it.
 
-## At a glance
+## Summary
 
 | | |
 |---|---|

--- a/docs/integrations/hermes.md
+++ b/docs/integrations/hermes.md
@@ -35,7 +35,7 @@ Four reasons to reach for it.
   conversation is open in the Fountain conversations app while it runs.
 - **Fan-out is a loop of tool calls**, and not orchestration code.
 
-## At a glance
+## Summary
 
 | | |
 |---|---|

--- a/docs/integrations/langchain.md
+++ b/docs/integrations/langchain.md
@@ -18,7 +18,7 @@ alpha, behind the `openai_compat` flag. There is no package to install from
 us. One file, `fountain_langchain.py`, is the whole integration, and the
 example ships it.
 
-## At a glance
+## Summary
 
 | | |
 |---|---|

--- a/docs/integrations/mail.md
+++ b/docs/integrations/mail.md
@@ -5,7 +5,7 @@ verification email that Fountain throws away leaves signup at a dead end, with
 no error to see. There are exactly three options, and Fountain checks them in
 the order below.
 
-## At a glance
+## Summary
 
 | | |
 |---|---|

--- a/docs/integrations/openai-compatible.md
+++ b/docs/integrations/openai-compatible.md
@@ -18,7 +18,7 @@ needs to in a sandbox of its own.
 There is no plugin and no code on the client. The base URL, a key, and one
 header are the whole integration.
 
-## At a glance
+## Summary
 
 | | |
 |---|---|

--- a/docs/integrations/openbot.md
+++ b/docs/integrations/openbot.md
@@ -2,8 +2,7 @@
 
 [OpenBot](https://copilotkit.ai/openbot) is CopilotKit's self-hosted agent
 platform. It has channels, a coworker roster, an audit trail, and a browser
-computer for each bot. A "Bot" there is not a framework and not an SDK. It is
-**any HTTP endpoint that speaks
+computer for each bot. A "Bot" there is **any HTTP endpoint that speaks
 [AG-UI](https://github.com/ag-ui-protocol/ag-ui)**, the open protocol for
 interaction between an agent and a user.
 
@@ -23,7 +22,7 @@ agent the same way, whether it is a hand-written client or another product
 built on the protocol. OpenBot is the host we built it against and verified it
 against, and nothing more.
 
-## At a glance
+## Summary
 
 | | |
 |---|---|

--- a/docs/integrations/openclaw.md
+++ b/docs/integrations/openclaw.md
@@ -19,7 +19,7 @@ speaks ACP over stdio. So the integration is a config block, and not code.
    (a chat channel)   (ACP over stdio)                                        (the agent)
 ```
 
-## At a glance
+## Summary
 
 | | |
 |---|---|
@@ -264,7 +264,7 @@ level at the harness on the way. That is the case that used to abort the turn
 [#760](https://github.com/BinaryBourbon/fountain/issues/760)).
 
 When you test through `openclaw agent`, or with a prompt that must delegate,
-check that the harness truly ran. OpenClaw's own model will happily answer a
+check that the harness ran. OpenClaw's own model will happily answer a
 "reply with X" prompt itself, and report success. The tell is a
 `sessions_spawn` call in the tool summary, and a new conversation on the
 Fountain agent. From the Fountain side, `fountain conv list` shows it, with

--- a/docs/integrations/platform-requirements.md
+++ b/docs/integrations/platform-requirements.md
@@ -255,7 +255,7 @@ desirable.
 
 !!! note "Advertise or refuse, never pretend"
 
-    An orchestrator can degrade gracefully around a capability that is absent.
+    An orchestrator can degrade around a capability that is absent.
     It cannot degrade around a capability that you claim and that then quietly
     does nothing.
 
@@ -286,14 +286,14 @@ list.
   platforms can differ. Three honest platforms with three shapes beat three
   identical ones.
 
-## Where this list leans
+## The bias in this list
 
 One consumer with one workload wrote it, and it shows.
 
 We over-specify sessions and streams, because an agent turn is a long
 conversation with a process. We under-specify scheduling, burst behaviour,
 cold-start latency, and everything else that a hundred-thousand-short-jobs
-workload cares about. A truly neutral contract needs another kind of customer
+workload cares about. A neutral contract needs another kind of customer
 in the room.
 
 The capability vocabulary also does more work than it should. `:suspend` today

--- a/docs/integrations/runners.md
+++ b/docs/integrations/runners.md
@@ -27,7 +27,7 @@ Three reasons to want one.
 [ADR 0022](https://github.com/BinaryBourbon/fountain/blob/main/decisions/0022-self-hosted-runner-provider.md)
 holds the design.
 
-## At a glance
+## Summary
 
 | | |
 |---|---|
@@ -70,14 +70,14 @@ processes belong to the daemon. It reconnects with backoff on any drop. It
 gives up only when Fountain refuses the key, rejects the name, or has runners
 switched off.
 
-Then pin an agent to it. Use **Agents → edit → Sandbox provider → runner**,
+Then pin an agent to it. Use **Agents**, then **edit**, then **Sandbox provider**, then **runner**,
 or send `sandbox_provider: "runner"` to `POST /api/agents`.
 
 Fountain places a new conversation for that agent on your **most recently
 connected online runner**. Start one while no runner is online and it fails
 plainly, with `no_runner_online` and HTTP 409. It does not queue.
 
-Account → Runners, or `GET /api/runners`, lists each machine that has
+Account, then Runners, or `GET /api/runners`, lists each machine that has
 connected, with live online status. `DELETE /api/runners/:id` forgets one. A
 daemon that you left up reconnects and registers itself again.
 

--- a/docs/integrations/sandbox-contract.md
+++ b/docs/integrations/sandbox-contract.md
@@ -48,7 +48,7 @@ conversation fails at provision time.
 
 ## What the contract guarantees
 
-- **Capabilities are honest.** An adapter advertises what it can truly do,
+- **Capabilities are honest.** An adapter advertises only what it can do,
   from `:suspend`, `:network_policy`, `:attach`, `:tty`, `:checkpoint` and
   `:public_url`. The lifecycle then degrades to match. A provider without
   `:suspend` destroys on idle, and does not fake a park. The agent's memory

--- a/docs/integrations/sentry.md
+++ b/docs/integrations/sentry.md
@@ -3,7 +3,7 @@
 **Optional, and inert until you opt in.** With no DSN set, the SDK sits there
 and does nothing. No account, no events, and nothing leaves your instance.
 
-## At a glance
+## Summary
 
 | | |
 |---|---|
@@ -69,7 +69,7 @@ report carries less context than a stock Sentry integration would.
 
 ## Related
 
-- [Wire up observability](../guides/operate/observability.md), and the alert
+- [Configure observability](../guides/operate/observability.md), and the alert
   pack.
 - [Back up and restore](../guides/operate/back-up-and-restore.md), which uses
   the Crons pattern above.

--- a/docs/integrations/sprites-contract.md
+++ b/docs/integrations/sprites-contract.md
@@ -2,14 +2,14 @@
 
 This page documents the **Sprites adapter's** transport contract. It covers
 each endpoint that `Fountain.Sandbox.Sprites` calls, the semantics it depends
-on, and the operational assumptions baked into it.
+on, and the operational assumptions it makes.
 
 [The sandbox contract](sandbox-contract.md) is the provider-neutral contract
 that each backend must meet. That is the `Fountain.Sandbox` behaviour and its
 conformance suite, `Fountain.SandboxConformanceCase`, which the
 [E2B](e2b.md) and [Daytona](daytona.md) adapters also satisfy. To evaluate a
 new backend, start there. This page is the reference for what the first
-backend truly provides.
+backend provides.
 
 The [Sprites integration guide](sprites.md) holds the setup and the cost
 model.
@@ -155,7 +155,7 @@ One that ignores a deny rule fails the whole `limited` feature open.
   unique for each token, as `fountain-<tenant-prefix>-<8 hex>`. A 409 on
   create means the sprite already exists. Fountain then adopts it, and raises
   no error. Destroy tolerates a 404. The hourly reaper converges
-  whatever the happy path leaked. A replacement needs stable name-keyed create
+  whatever the successful path leaked. A replacement needs stable name-keyed create
   and destroy semantics, and no more.
 - **Errors.** Any non-2xx surfaces as a status plus the decoded body. A
   rate-limit response carries a structured body, with
@@ -185,7 +185,7 @@ Here is the checklist. It needs the twelve operations above and bearer auth.
 It needs name-keyed idempotent create and destroy, with a 409 on a duplicate
 and a delete that tolerates a 404. It needs the stream-id frame protocol with
 a real exit frame, and detachable sessions that replay from the start. It
-needs NDJSON checkpoints that truly restore filesystem state, a network policy
+needs NDJSON checkpoints that restore filesystem state, a network policy
 that can deny, and `has_more` and `next_continuation_token` pagination.
 
 Get those semantics right, and the four subtle ones above with them.

--- a/docs/integrations/sprites.md
+++ b/docs/integrations/sprites.md
@@ -10,7 +10,7 @@ conversation fails at provision time.
 API surface Fountain consumes. It also says what a compatible replacement
 behind `SPRITES_BASE_URL` would have to provide.
 
-## At a glance
+## Summary
 
 | | |
 |---|---|

--- a/docs/integrations/stripe.md
+++ b/docs/integrations/stripe.md
@@ -11,7 +11,7 @@ tells Fountain about refunds and disputes. Nothing else. Billing is off by
 default (`CREDITS_ENABLED=false`), and that is the right setting for most
 self-hosted instances. Set this up only if you run Fountain commercially.
 
-## At a glance
+## Summary
 
 | | |
 |---|---|
@@ -23,7 +23,7 @@ self-hosted instances. Set this up only if you run Fountain commercially.
 
 ## The provider side
 
-1. **An API key**, from Developers → API keys, as `STRIPE_SECRET_KEY`.
+1. **An API key**, from Developers, then API keys, as `STRIPE_SECRET_KEY`.
 2. **A webhook endpoint** pointed at `<PUBLIC_URL>/api/stripe/webhook`,
    subscribed to these three events.
     - `checkout.session.completed`, which adds the credit a pack paid for.

--- a/docs/nav.yml
+++ b/docs/nav.yml
@@ -50,7 +50,7 @@ nav:
       - Prices: guides/operate/plans-and-prices.md
       - Back up and restore: guides/operate/back-up-and-restore.md
       - Upgrade an instance: guides/operate/upgrade.md
-      - Wire up observability: guides/operate/observability.md
+      - Configure observability: guides/operate/observability.md
       - Read the dashboards: guides/operate/dashboards.md
       - Run a release task: guides/operate/run-a-release-task.md
       - Operations overview: operations.md

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -25,7 +25,7 @@ Start from the symptom in [Troubleshoot a problem](troubleshooting/index.md).
   restore drill
 - [Upgrade an instance](guides/operate/upgrade.md), and what to do when one
   goes wrong
-- [Wire up observability](guides/operate/observability.md), which covers
+- [Configure observability](guides/operate/observability.md), which covers
   metrics, alerts, logs and the health endpoints
 
 ## How to stand one up

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -50,7 +50,7 @@ what breaks when a dependency is down.
 
 - [Back up and restore](guides/operate/back-up-and-restore.md)
 - [Upgrade an instance](guides/operate/upgrade.md)
-- [Wire up observability](guides/operate/observability.md)
+- [Configure observability](guides/operate/observability.md)
 - [Run a release task](guides/operate/run-a-release-task.md)
 
 When something is wrong, start from

--- a/docs/tour.md
+++ b/docs/tour.md
@@ -10,7 +10,7 @@ real run.
 
 ## What you must have
 
-- A Fountain API key (Account → API keys, or `fountain auth login`).
+- A Fountain API key (Account, then API keys, or `fountain auth login`).
 - A repository that you let an agent push a branch to.
 - A GitHub token that can push to it. Use a
   [fine-grained token](https://github.com/settings/personal-access-tokens)

--- a/docs/troubleshooting/pods-restarting.md
+++ b/docs/troubleshooting/pods-restarting.md
@@ -43,7 +43,7 @@ against a database problem that is older than the deploy. Read
 
 ## Related
 
-- [Wire up observability](../guides/operate/observability.md), for what each
+- [Configure observability](../guides/operate/observability.md), for what each
   health endpoint is for.
 - [Deploy on Kubernetes](../guides/operate/kubernetes.md).
 - [Architecture](../architecture.md), for which component owns which symptom.

--- a/docs/troubleshooting/sandbox-errors.md
+++ b/docs/troubleshooting/sandbox-errors.md
@@ -28,8 +28,8 @@ Fountain does **not** retry these, and that is deliberate.
 
 ## During a provider outage
 
-A new conversation fails, and so does a wake. A fresh provision marks the
-conversation `failed`. A wake leaves it resumable for later.
+A new conversation fails, and so does a wake. A fresh provision sets the
+conversation to `failed`. A wake leaves it resumable for later.
 
 Sign-in, dashboards, configuration and past logs all still work.
 
@@ -56,5 +56,5 @@ with `POST /api/admin/users/:id/sandbox-limit`. Read
 - [A conversation is stuck or failed](conversation-stuck-or-failed.md).
 - [The sandbox contract](../integrations/sandbox-contract.md), for the shared
   error taxonomy.
-- [Wire up observability](../guides/operate/observability.md), for the alert
+- [Configure observability](../guides/operate/observability.md), for the alert
   on a failure to provision.


### PR DESCRIPTION
Fifty pages of copy. No mechanism, no CI change — this stands on its own, and the gate that found these lands separately in the PR stacked on top.

## The big one

`## At a glance` had become the template heading on **26** catalog and integration pages. Every one of them opens a table of facts, so they are all `## Summary` now. Nothing linked to the old anchor.

## The rest

- **`Wire up observability` becomes `Configure observability`**, in `nav.yml`, the page's own H1 and the nine pages that link to it. It reads as assistant dev-prose, it is a phrasal verb ASD-STE100 bans, and `vale` never saw it because it only ever appeared in link text and a heading. The new title matches its sibling `Configure email`.
- **Eleven filler intensifiers** (`truly`, `really`) deleted. Two needed a rewrite rather than a deletion, where the word carried a real contrast.
- **Fifteen unicode arrows** in prose become `then`. Arrows inside code fences and inside the primitives SVG are untouched.
- **Three rhetorical questions** become statements. The five questions the `create-team` skill asks become the five things it asks about — the lead-in already says it asks them.
- `the case for` x2, `baked into`, `happy path`, `gracefully`, `in practice`, `leans`, `thread, through` — each swapped for the plainer word.

## Two that are just better sentences

These would stand without any of the above:

- `A conversation's sandbox_id names its sandbox` → `The sandbox_id field names that disk`, which stops repeating the noun.
- `A fresh provision marks the conversation failed` → `sets the conversation to failed`, which is what the code does.

## Checks

`scripts/docs-style.py` clean, `vale lint docs` exits 0, and `docs_test.exs` + `docs_controller_test.exs` pass 52 tests — including the nav parser, every internal `/docs` link and every anchor, which is what the heading renames needed to clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GJJU9aAsG13D9H4VLJBZcT