### PR TITLE
docs: name the three prose gates on the contribute page

### DIFF
--- a/docs/open-source.md
+++ b/docs/open-source.md
@@ -63,3 +63,18 @@ and
 [CLAUDE.md](https://github.com/BinaryBourbon/fountain/blob/main/CLAUDE.md)
 in the repo. The second file is the contributor guide, and coding agents read
 it too.
+
+Three prose checks run on every change to a page under `docs/`. Read
+[the style sheet](https://github.com/BinaryBourbon/fountain/blob/main/standards/voice-and-style.md)
+and
+[the English standard](https://github.com/BinaryBourbon/fountain/blob/main/standards/simplified-technical-english.md)
+before you write a page.
+
+| Check | What it holds you to |
+|---|---|
+| `scripts/docs-style.py` | The house style sheet. |
+| `vale lint docs` | ASD-STE100 Simplified Technical English. |
+| `scripts/destink/destink.mjs` | The tells that make a page read as machine written. |
+
+Each check has a backlog file, and each backlog file is empty. A new page
+gets all three checks from its first commit.


### PR DESCRIPTION
A genuine small docs change, chosen because it is also the first **docs-only** PR since the de-stink gate landed. That path has never executed: #1239 predated the gate and #1240/#1242 touch `scripts/` and `.github/`, so both take the `checks` job. This one takes the `docs` job, which is the second of the two wiring sites.

> Depends on #1242. Until that merges, the `docs` job here has no de-stink step and this PR only proves the other two gates. Merge #1242 first, then re-run this.

## The change

`docs/open-source.md`'s "To contribute" section pointed at `CONTRIBUTING.md` and `CLAUDE.md` and stopped. A contributor writing their first page had no way to learn that three checks read it, or that `standards/voice-and-style.md` and `standards/simplified-technical-english.md` exist, until CI told them.

It now names the three, links both standards, and states the part that is easy to get wrong: every backlog file is empty, so a new page is inside all three checks from its first commit rather than being added to a list later.

Twelve lines. `CONTRIBUTING.md` gets the same third gate in #1242, where it belongs — that PR is what makes the list of two wrong.

## What this measures

The point is the timing of the `Docs` job with a third gate in it. For reference, on the combined branch the de-stink step ran in the `checks` job in **~8s wall clock**, of which `npm ci` was 0.5s (4 packages) and the gate itself 3.9s over 87 pages. The `docs` job should look the same. Numbers get posted here once it runs.

## Checks run locally

All four, against this branch, with the gate borrowed from #1242's branch since it is not on `main` yet:

- `scripts/docs-style.py` clean
- `vale lint docs` exit 0 — it caught a passive "is covered" in my first draft, now "a new page gets all three checks"
- `destink.mjs` 87 pages clean, exit 0
- `docs_test.exs` 43 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GJJU9aAsG13D9H4VLJBZcT