### PR TITLE
feat(deploy): a Render blueprint, for an instance that is not ours

### DIFF
--- a/.github/workflows/release-bump.yml
+++ b/.github/workflows/release-bump.yml
@@ -128,7 +128,7 @@ jobs:
           # (#478). Bump them in the release commit so the tag's own tree
           # pins the tag. ReleasePinTest keeps this list and the files in
           # lockstep between releases.
-          pins='docker-compose.yml .env.compose.example deploy/k8s/kustomization.yaml deploy/k8s/deployment.yaml'
+          pins='docker-compose.yml .env.compose.example render.yaml deploy/k8s/kustomization.yaml deploy/k8s/deployment.yaml'
           for f in ${pins}; do
             sed -i "s/${current}/${next}/g" "$f"
             # sed exits 0 whether or not it matched; a pin that no longer
@@ -149,7 +149,7 @@ jobs:
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add mix.exs apps/fountain/mix.exs \
-            docker-compose.yml .env.compose.example \
+            docker-compose.yml .env.compose.example render.yaml \
             deploy/k8s/kustomization.yaml deploy/k8s/deployment.yaml
           # [skip ci] keeps this commit from re-triggering CI on main.
           # release.yml is dispatched explicitly in the next step.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,25 @@ upgrade, is in
 
 ### Added
 
+- **A Render blueprint, for an instance that is not ours.** `render.yaml`
+  declares one web service on the published image and one managed Postgres,
+  so somebody who wants Fountain on Render applies a blueprint instead of
+  reverse-engineering the compose file. It asks for three values
+  (`SECRET_KEY_BASE`, `MASTER_SECRETS_KEY`, `SPRITES_TOKEN`) and defaults the
+  rest the way compose does: credits off, no mail, registration open for the
+  first account, one instance. `PUBLIC_URL` is deliberately not among the
+  three. It is required in prod and the hostname does not exist until the
+  first deploy has happened, so a blueprint that asked for it up front could
+  never complete its own first deploy; `config/runtime.exs` now falls back to
+  Render's injected `RENDER_EXTERNAL_URL`, behind an operator's own
+  `PUBLIC_URL`. That fallback is a list rather than an `||` chain, because
+  `""` is truthy in Elixir and a blank `PUBLIC_URL` — what every `${VAR:-}`
+  and every blank dashboard field delivers — would otherwise win it and raise.
+  Three guards hold the new surface to the old one: every key the blueprint
+  sets must be a variable the app reads, every variable a prod boot raises
+  without must be present, and the image pin joins the four `release-bump.yml`
+  already moves. The guide is at `/docs/guides/operate/render`.
+
 - **A code review bot, whole, at `/code-review-bot`.** The shortest useful
   program anybody writes on this API, shown unabridged rather than described:
   a GitHub webhook handler that upserts the reviewer for the repository it

--- a/apps/fountain/test/fountain/config_reference_test.exs
+++ b/apps/fountain/test/fountain/config_reference_test.exs
@@ -257,6 +257,81 @@ defmodule Fountain.ConfigReferenceTest do
            """
   end
 
+  # Keys render.yaml sets that Render consumes rather than the release: the
+  # port it asks the service to bind is read by the app too, so this stays
+  # empty until something is genuinely Render-only.
+  @render_only ~w()
+
+  test "every env var render.yaml sets is one the app reads" do
+    # render.yaml is the second self-host deploy surface, and it drifts the
+    # same way compose did: a key set here that the app never reads is a knob
+    # wired to nothing, and an operator has no way to tell from the outside.
+    source = File.read!(Path.join(@repo_root, "config/runtime.exs"))
+    blueprint = File.read!(Path.join(@repo_root, "render.yaml"))
+
+    keys =
+      Regex.scan(~r/^\s*- key: ([A-Z][A-Z0-9_]*)\s*$/m, blueprint, capture: :all_but_first)
+      |> List.flatten()
+      |> Enum.uniq()
+
+    assert length(keys) > 5,
+           "extracted only #{length(keys)} keys from render.yaml — its layout changed"
+
+    unread =
+      Enum.reject(keys, fn var ->
+        String.contains?(source, ~s("#{var}")) or var in @render_only or
+          Map.has_key?(@read_elsewhere, var)
+      end)
+
+    assert unread == [],
+           """
+           render.yaml sets env vars that the app never reads:
+
+             #{Enum.join(unread, ", ")}
+
+           Remove the key, or add it to @render_only/@read_elsewhere with a reason.
+           """
+  end
+
+  test "render.yaml supplies everything a prod boot refuses to start without" do
+    # The compose guards all run "declared, therefore real". None of them runs
+    # the other direction — that a deploy surface actually carries the values
+    # runtime.exs raises over. Compose gets away with it because a reader
+    # follows a guide that says which lines to append; a blueprint is applied
+    # whole, in a dashboard, and a missing key is a crash loop on a service
+    # somebody has no shell on.
+    #
+    # PUBLIC_URL is the one exception, and it is the reason RENDER_EXTERNAL_URL
+    # is in the fallback chain: the hostname does not exist until the first
+    # deploy has happened.
+    blueprint = File.read!(Path.join(@repo_root, "render.yaml"))
+
+    required = ~w(SECRET_KEY_BASE MASTER_SECRETS_KEY DATABASE_URL)
+
+    missing =
+      Enum.reject(required, fn var ->
+        Regex.match?(~r/^\s*- key: #{var}\s*$/m, blueprint)
+      end)
+
+    assert missing == [],
+           """
+           render.yaml does not set variables config/runtime.exs raises without:
+
+             #{Enum.join(missing, ", ")}
+
+           A blueprint missing one of these deploys a service that crash-loops.
+           """
+
+    refute Regex.match?(~r/^\s*- key: PUBLIC_URL\s*$/m, blueprint),
+           """
+           render.yaml sets PUBLIC_URL. It cannot know the hostname before the
+           first deploy, so an operator either leaves it blank — and a blank
+           value is set, not absent, which takes the RENDER_EXTERNAL_URL
+           fallback in config/runtime.exs out of reach — or guesses. Leave it
+           to the fallback and to the dashboard.
+           """
+  end
+
   # Two legitimate pass-through forms in the app service's environment block:
   # `VAR: ${VAR...}` with any default, and a bare `VAR:` with no value at all.
   # The second one forwards the variable only when .env sets it, which is the

--- a/apps/fountain/test/fountain/release_pin_test.exs
+++ b/apps/fountain/test/fountain/release_pin_test.exs
@@ -1,5 +1,5 @@
 defmodule Fountain.ReleasePinTest do
-  # The self-host quick start pins a release image in four places. Those pins
+  # The self-host quick start pins a release image in five places. Those pins
   # sat at v0.3.0 through two releases, handing newcomers an image from before
   # the in-app first-login flow (#478), where EMAIL_DELIVERY=none dead-ends
   # signup. release-bump.yml now bumps the pins inside the release commit;
@@ -12,6 +12,7 @@ defmodule Fountain.ReleasePinTest do
   @pins [
     {"docker-compose.yml", ~r/fountain:\$\{FOUNTAIN_IMAGE_TAG:-(v[\d.]+)\}/},
     {".env.compose.example", ~r/^FOUNTAIN_IMAGE_TAG=(v[\d.]+)$/m},
+    {"render.yaml", ~r/url: ghcr\.io\/binarybourbon\/fountain:(v[\d.]+)/},
     {"deploy/k8s/kustomization.yaml", ~r/newTag: (v[\d.]+)/},
     {"deploy/k8s/deployment.yaml", ~r/image: ghcr\.io\/binarybourbon\/fountain:(v[\d.]+)/}
   ]

--- a/apps/fountain/test/fountain/runtime_config_test.exs
+++ b/apps/fountain/test/fountain/runtime_config_test.exs
@@ -32,7 +32,8 @@ defmodule Fountain.RuntimeConfigTest do
     on_exit(fn ->
       System.put_env(previous)
 
-      for k <- ~w(PUBLIC_URL PHX_HOST FOUNTAIN_DOMAIN RESEND_API_KEY SMTP_HOST EMAIL_DELIVERY),
+      for k <-
+            ~w(PUBLIC_URL PHX_HOST FOUNTAIN_DOMAIN RENDER_EXTERNAL_URL RESEND_API_KEY SMTP_HOST EMAIL_DELIVERY),
           not Map.has_key?(previous, k),
           do: System.delete_env(k)
     end)
@@ -41,7 +42,7 @@ defmodule Fountain.RuntimeConfigTest do
   end
 
   defp read_prod_config(env) do
-    for k <- ~w(PUBLIC_URL PHX_HOST FOUNTAIN_DOMAIN SMTP_HOST EMAIL_DELIVERY),
+    for k <- ~w(PUBLIC_URL PHX_HOST FOUNTAIN_DOMAIN RENDER_EXTERNAL_URL SMTP_HOST EMAIL_DELIVERY),
         do: System.delete_env(k)
 
     System.put_env(env)
@@ -82,6 +83,64 @@ defmodule Fountain.RuntimeConfigTest do
     assert cfg[:public_url] == "https://new.example.com"
   end
 
+  describe "RENDER_EXTERNAL_URL" do
+    # Render injects it into every web service. It is in the fallback chain so
+    # that render.yaml has something to boot on: PUBLIC_URL is required in
+    # prod, and on Render the hostname does not exist until the first deploy
+    # has already happened, so a blueprint that asked for it up front could
+    # never complete its own first deploy.
+    test "stands in for an unset PUBLIC_URL", %{base: base} do
+      cfg =
+        read_prod_config(
+          Map.put(base, "RENDER_EXTERNAL_URL", "https://fountain-ab12.onrender.com")
+        )
+
+      assert cfg[:public_url] == "https://fountain-ab12.onrender.com"
+      assert cfg[:phx_host] == "fountain-ab12.onrender.com"
+    end
+
+    test "loses to an operator's own PUBLIC_URL", %{base: base} do
+      # What adding a custom domain looks like. The injected value does not go
+      # away when the operator sets one, so the order is the whole feature.
+      cfg =
+        base
+        |> Map.merge(%{
+          "PUBLIC_URL" => "https://fountain.example.com",
+          "RENDER_EXTERNAL_URL" => "https://fountain-ab12.onrender.com"
+        })
+        |> read_prod_config()
+
+      assert cfg[:public_url] == "https://fountain.example.com"
+    end
+
+    test "a blank PUBLIC_URL falls through to it rather than winning", %{base: base} do
+      # "" is truthy in Elixir, so the `||` chain this replaced would have
+      # taken the empty string and raised. Every `${VAR:-}` and every
+      # dashboard field left blank delivers exactly this shape.
+      cfg =
+        base
+        |> Map.merge(%{
+          "PUBLIC_URL" => "",
+          "RENDER_EXTERNAL_URL" => "https://fountain-ab12.onrender.com"
+        })
+        |> read_prod_config()
+
+      assert cfg[:public_url] == "https://fountain-ab12.onrender.com"
+    end
+
+    test "a blank one still raises rather than passing the check", %{base: base} do
+      for k <-
+            ~w(PUBLIC_URL PHX_HOST FOUNTAIN_DOMAIN RENDER_EXTERNAL_URL SMTP_HOST EMAIL_DELIVERY),
+          do: System.delete_env(k)
+
+      System.put_env(Map.put(base, "RENDER_EXTERNAL_URL", ""))
+
+      assert_raise RuntimeError, ~r/PUBLIC_URL/, fn ->
+        Config.Reader.read!(@runtime_exs, env: :prod)
+      end
+    end
+  end
+
   test "endpoint scheme and port follow PUBLIC_URL for plain-HTTP self-hosts", %{base: base} do
     cfg = read_prod_config(Map.put(base, "PUBLIC_URL", "http://fountain.internal:4000"))
 
@@ -110,7 +169,8 @@ defmodule Fountain.RuntimeConfigTest do
     # secret, nothing crashed: the instance ran and silently put localhost
     # links in every verification email and every sprite's FOUNTAIN_BASE_URL.
     test "prod refuses to boot with neither PUBLIC_URL nor FOUNTAIN_DOMAIN", %{base: base} do
-      for k <- ~w(PUBLIC_URL PHX_HOST FOUNTAIN_DOMAIN SMTP_HOST EMAIL_DELIVERY),
+      for k <-
+            ~w(PUBLIC_URL PHX_HOST FOUNTAIN_DOMAIN RENDER_EXTERNAL_URL SMTP_HOST EMAIL_DELIVERY),
           do: System.delete_env(k)
 
       System.put_env(base)
@@ -128,7 +188,8 @@ defmodule Fountain.RuntimeConfigTest do
 
     test "a blank PUBLIC_URL counts as unset", %{base: base} do
       # Compose-style `${VAR:-}` interpolation delivers "", not absence.
-      for k <- ~w(PUBLIC_URL PHX_HOST FOUNTAIN_DOMAIN SMTP_HOST EMAIL_DELIVERY),
+      for k <-
+            ~w(PUBLIC_URL PHX_HOST FOUNTAIN_DOMAIN RENDER_EXTERNAL_URL SMTP_HOST EMAIL_DELIVERY),
           do: System.delete_env(k)
 
       System.put_env(Map.put(base, "PUBLIC_URL", ""))
@@ -139,7 +200,8 @@ defmodule Fountain.RuntimeConfigTest do
     end
 
     test "dev keeps the localhost default", %{base: base} do
-      for k <- ~w(PUBLIC_URL PHX_HOST FOUNTAIN_DOMAIN SMTP_HOST EMAIL_DELIVERY),
+      for k <-
+            ~w(PUBLIC_URL PHX_HOST FOUNTAIN_DOMAIN RENDER_EXTERNAL_URL SMTP_HOST EMAIL_DELIVERY),
           do: System.delete_env(k)
 
       System.put_env(base)

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -297,11 +297,30 @@ config :fountain, :sandbox_default_provider, sandbox_default_provider
 # deployments keep booting and get correct links without an env change.
 default_scheme = if env == :prod, do: "https", else: "http"
 
+# RENDER_EXTERNAL_URL is last, and is the only entry here nobody sets by hand:
+# Render injects it into every web service as the absolute URL that service is
+# reachable at. Without it, render.yaml has a chicken-and-egg problem — the
+# hostname does not exist until the first deploy, and the raise below means
+# that first deploy is the one that cannot come up. An operator's own
+# PUBLIC_URL still wins, which is what a custom domain sets.
+#
+# Each candidate is trimmed and tested on its own rather than chained with
+# `||`: "" is truthy in Elixir, so a present-but-empty PUBLIC_URL — the shape
+# every `${VAR:-}` and every dashboard field left blank delivers — would win
+# the chain and take the fallbacks out of reach.
+#
+# Spelled as three separate quoted literals because `config_reference_test`
+# extracts the variables this file reads by scanning for exactly that shape.
+# Folded into a `~w` sigil they become invisible to it, and PUBLIC_URL reads
+# as documentation for a variable nothing consumes.
 public_url_env =
-  case String.trim(System.get_env("PUBLIC_URL") || System.get_env("FOUNTAIN_DOMAIN") || "") do
-    "" -> nil
-    value -> value
-  end
+  [
+    System.get_env("PUBLIC_URL"),
+    System.get_env("FOUNTAIN_DOMAIN"),
+    System.get_env("RENDER_EXTERNAL_URL")
+  ]
+  |> Enum.map(&String.trim(&1 || ""))
+  |> Enum.find(&(&1 != ""))
 
 # In prod the fallback would be http://localhost:4000 — and unlike a missing
 # secret, nothing crashes: the instance runs, and every verification/reset

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,6 +26,7 @@ message.
 | `PUBLIC_URL` | — | prod | The base URL that the outside world sees, with the scheme. A prod instance refuses to boot without it, or without the deprecated `FOUNTAIN_DOMAIN`. The old `http://localhost:4000` fallback quietly put localhost links in each verification email. This variable builds each link that leaves the app, which is the verification and reset emails and `llms.txt`. Fountain passes it to each sandbox as `FOUNTAIN_BASE_URL`. An `https://` value also starts the HTTPS redirect, HSTS and the secure cookie flag, and Fountain derives all three from the scheme. |
 | `PHX_HOST` | The host of `PUBLIC_URL`. | — | The bare host for the endpoint URL and for the LiveView origin check. Set it only when it differs from the host in `PUBLIC_URL`. |
 | `FOUNTAIN_DOMAIN` | — | deprecated | The old combined variable. Fountain still honours it as a fallback for both of the two above. Prefer `PUBLIC_URL` and `PHX_HOST`. |
+| `RENDER_EXTERNAL_URL` | — | — | Render sets this on each web service. Fountain reads it as the last fallback for `PUBLIC_URL`, after the deprecated `FOUNTAIN_DOMAIN`. The first deploy from `render.yaml` needs it, because the hostname does not exist before that deploy. An explicit `PUBLIC_URL` has precedence. Set `PUBLIC_URL` when you add a custom domain. |
 | `PHX_SERVER` | `true` in the shipped image. | — | A `1`, `true` or `yes` starts the web listener. A release task runs with `PHX_SERVER=false … eval '…'`. That boots the app, and binds no port. |
 | `PORT` | `4000` | — | The HTTP port to listen on. |
 

--- a/docs/guides/operate/render.md
+++ b/docs/guides/operate/render.md
@@ -1,0 +1,127 @@
+# Deploy on Render
+
+This guide shows you how to bring up an instance on [Render](https://render.com)
+from the blueprint in this repository. It then shows you what to set after the
+first deploy.
+
+For a machine you control, read [Deploy an instance](deploy.md). That guide
+uses Docker Compose, and it is the shorter path.
+
+## What the blueprint gives you
+
+[`render.yaml`](https://github.com/BinaryBourbon/fountain/blob/main/render.yaml)
+declares one web service and one managed Postgres. The web service runs the
+published image, not a build of your checkout. The blueprint gives you an
+instance that runs. It does not describe how the hosted service runs, which
+is Kubernetes.
+
+## Before you start
+
+Fork this repository. Render reads the blueprint from a repository you own.
+
+Generate the two keys now. You paste them during the next step.
+
+```bash
+openssl rand -base64 48 | tr -d '\n'                    # SECRET_KEY_BASE
+openssl rand 32 | base64 | tr '+/' '-_' | tr -d '=\n'   # MASTER_SECRETS_KEY
+```
+
+Back `MASTER_SECRETS_KEY` up before you have data. It is not in the database.
+A database backup alone does not protect you. Read
+[Back up and restore](back-up-and-restore.md).
+
+You also need a sandbox provider token. Read
+[Self-host Fountain](../../self-hosting.md) for what each provider needs.
+
+## Apply it
+
+In the Render dashboard, select **New**, then **Blueprint**, then your fork.
+Render reads `render.yaml` and asks for three values.
+
+| | |
+|---|---|
+| `SECRET_KEY_BASE` | The first key above. Render's own value generator makes a value that is too short for the cookie session store. |
+| `MASTER_SECRETS_KEY` | The second key above. Render's generator cannot make this shape either. |
+| `SPRITES_TOKEN` | Your sandbox provider token. |
+
+Select **Apply**. The first deploy takes a few minutes, because the app
+applies the database migrations before it opens a listener.
+
+`PUBLIC_URL` is absent from the blueprint on purpose. A prod instance refuses
+to boot without it, and the hostname does not exist before this first deploy.
+Fountain reads Render's own `RENDER_EXTERNAL_URL` instead, so the first deploy
+has a correct base URL.
+
+## Register the first account
+
+Open the service URL and register. The blueprint sets `EMAIL_DELIVERY=none`
+and `FIRST_USER_ADMIN=true`, so your account self-verifies and becomes the
+admin.
+
+Register **before** you give the URL to anybody. While no admin exists, the
+first verified account takes the role.
+
+Then close registration in the Render dashboard, under **Environment**.
+
+```
+REGISTRATION_ENABLED=false
+```
+
+## Add a custom domain
+
+Add the domain to the web service in the dashboard. Then set `PUBLIC_URL` to
+the new address, with the scheme.
+
+```
+PUBLIC_URL=https://fountain.example.com
+```
+
+Set it. `RENDER_EXTERNAL_URL` still holds the `onrender.com` address, and
+Fountain keeps that address in every verification email and in every sandbox
+until you replace it.
+
+## Run your own build
+
+The blueprint runs the published image, which is the same image the compose
+quick start runs. To run a fork with your own changes, replace the `runtime`
+and `image` keys with these two lines.
+
+```yaml
+runtime: docker
+dockerfilePath: ./Dockerfile
+```
+
+The build takes 15 to 25 minutes on Render's builders. It compiles the
+umbrella, it builds the Go CLI, and it fetches the pinned Buzz binaries.
+
+## What the blueprint does not do
+
+- **It runs one instance.** Fountain clusters over Erlang distribution, and a
+  Render service cannot discover its own peers. A second instance is not a
+  second node, and two schedulers then race over the same sandboxes. Read
+  [Architecture](../../architecture.md#clustering). Scale the plan instead of
+  the instance count.
+- **It sends no mail.** Accounts self-verify at registration in this mode
+  (ADR 0011). Read [Configure email](email.md) for a real provider.
+- **It trusts a wide proxy range.** Render terminates TLS at its edge, so the
+  app sees the proxy and not the caller. The blueprint sets `TRUSTED_PROXIES`
+  to the private ranges. Only Render's proxy reaches the container, so this is
+  safe. Narrow it when you confirm the address that Render forwards from.
+- **It does not back the database up.** Render takes its own snapshots on a
+  paid plan. Read [Back up and restore](back-up-and-restore.md) for what a
+  restore needs, and remember that a dump alone cannot decrypt itself.
+
+## Upgrade
+
+The blueprint pins a release tag, and `autoDeploy` is off. A push to your fork
+does not move the pin.
+
+Edit the tag in `render.yaml`, then apply the blueprint again.
+
+```yaml
+image:
+  url: ghcr.io/binarybourbon/fountain:vX.Y.Z
+```
+
+Read [Upgrade an instance](upgrade.md) first. Migrations run at boot, and
+Fountain does not support a downgrade.

--- a/docs/nav.yml
+++ b/docs/nav.yml
@@ -42,6 +42,7 @@ nav:
       - Deploy an instance: guides/operate/deploy.md
       - Put it on the internet: guides/operate/put-it-on-the-internet.md
       - Connect a database: guides/operate/database.md
+      - Deploy on Render: guides/operate/render.md
       - Deploy on Kubernetes: guides/operate/kubernetes.md
       - Configure email: guides/operate/email.md
       - Change sandbox lifetimes: guides/operate/sandbox-lifetime.md

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -38,6 +38,7 @@ what breaks when a dependency is down.
 - [Deploy an instance](guides/operate/deploy.md)
 - [Put it on the internet](guides/operate/put-it-on-the-internet.md)
 - [Connect a database](guides/operate/database.md)
+- [Deploy on Render](guides/operate/render.md)
 - [Deploy on Kubernetes](guides/operate/kubernetes.md)
 
 **The decisions it forces.**

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,153 @@
+# Fountain on Render — https://render.com/docs/blueprint-spec
+#
+# This file is for somebody who wants an instance of their own on Render. It
+# is not how the hosted service runs (that is Kubernetes, ADR 0032), so treat
+# it the way you would treat docker-compose.yml: a starting point that comes
+# up, not a description of production.
+#
+# Point Render at a fork of this repository:
+#
+#   Dashboard → New → Blueprint → pick the repo → Apply
+#
+# Render then asks for the three values marked `sync: false` below. Generate
+# the first two before you start:
+#
+#   openssl rand -base64 48 | tr -d '\n'                    # SECRET_KEY_BASE
+#   openssl rand 32 | base64 | tr '+/' '-_' | tr -d '=\n'   # MASTER_SECRETS_KEY
+#
+# Everything else has a default that works. The full list of what you can set
+# afterwards, in the dashboard, is docs/configuration.md.
+
+services:
+  - type: web
+    name: fountain
+    runtime: image
+
+    # A pinned release, deliberately not `latest`: `latest` moves on every
+    # merge to main, across breaking minors, with migrations applied at boot
+    # and downgrade unsupported. Upgrade by editing this tag. Releases publish
+    # vX.Y.Z (immutable) and vX.Y (newest patch in the line).
+    #
+    # To run your own build of a fork instead of the published image, drop the
+    # `runtime`/`image` pair above and use these two lines:
+    #
+    #   runtime: docker
+    #   dockerfilePath: ./Dockerfile
+    #
+    # The build takes 15-25 minutes on Render's builders — it compiles the
+    # umbrella, the Go CLI and fetches the pinned Buzz binaries — so prefer the
+    # image unless you have changes to run.
+    image:
+      url: ghcr.io/binarybourbon/fountain:v0.14.0
+
+    region: oregon
+    plan: starter
+
+    # One instance, on purpose. Fountain clusters over Erlang distribution and
+    # Render gives a service no way to discover its own peers, so a second
+    # instance is not a second node — it is a split brain, with two schedulers
+    # racing over the same sandboxes. Scale the plan, not the count.
+    numInstances: 1
+
+    # Render gates traffic on this, which is a readiness question. /health is
+    # static and would pass with an unreachable database.
+    healthCheckPath: /health/ready
+
+    # Upgrades stay deliberate: a push to the fork does not move a pinned image
+    # tag, and an unattended jump across a minor is the one thing the upgrade
+    # guide tells you never to do.
+    autoDeploy: false
+
+    envVars:
+      - key: PHX_SERVER
+        value: "true"
+
+      # Render injects PORT and expects the service to bind it. The image
+      # defaults to 4000, so this has to be explicit rather than inherited.
+      - key: PORT
+        value: "10000"
+
+      - key: DATABASE_URL
+        fromDatabase:
+          name: fountain-db
+          property: connectionString
+
+      # ── The three you supply ──────────────────────────────────────────────
+
+      # Phoenix session and cookie signing. Render's `generateValue: true` is
+      # not usable here: it produces a value shorter than the 64 bytes the
+      # cookie session store requires. Paste one from the openssl line at the
+      # top of this file.
+      - key: SECRET_KEY_BASE
+        sync: false
+
+      # Wraps every tenant's data encryption key. 32 bytes, url-safe base64,
+      # no padding — `generateValue` cannot produce that shape either.
+      #
+      # BACK THIS UP, AND DO NOT CHANGE IT. Every encrypted environment and
+      # vault value in the database is unreadable without it, and a database
+      # backup alone cannot decrypt itself.
+      - key: MASTER_SECRETS_KEY
+        sync: false
+
+      # Required to run conversations. The app starts without a token and
+      # every conversation then fails. E2B, Daytona and self-hosted runners
+      # are the alternatives; see docs/self-hosting.md.
+      - key: SPRITES_TOKEN
+        sync: false
+
+      # ── Defaults that make a first deploy come up ─────────────────────────
+
+      # PUBLIC_URL is deliberately absent. It is required in prod, and the
+      # hostname does not exist until this service has deployed once, so
+      # asking for it up front makes the first deploy the one that cannot come
+      # up. config/runtime.exs falls back to RENDER_EXTERNAL_URL, which Render
+      # injects. Set PUBLIC_URL in the dashboard when you add a custom domain:
+      # it builds the links in verification emails and every sandbox reads it
+      # as FOUNTAIN_BASE_URL, so a stale value is silently wrong rather than
+      # broken.
+
+      # Render terminates TLS at its edge and forwards, so the app sees the
+      # proxy rather than the caller. Left unset, the built-in defaults are
+      # cluster CIDRs that match nothing here, every per-IP rate-limit bucket
+      # collapses into one, and every audit row records the proxy's address.
+      # Only Render's proxy can reach this container, so trusting the private
+      # ranges is safe. Narrow it if you confirm the address it forwards from.
+      - key: TRUSTED_PROXIES
+        value: 10.0.0.0/8,172.16.0.0/12
+
+      # Credits (ADR 0031) price the hosted service. On your own instance they
+      # are a lock with no key.
+      - key: CREDITS_ENABLED
+        value: "false"
+
+      # No mail, so a first deploy needs nothing external. Accounts
+      # self-verify at registration in this mode (ADR 0011). For real mail set
+      # RESEND_API_KEY or SMTP_HOST, and EMAIL_FROM, in the dashboard.
+      - key: EMAIL_DELIVERY
+        value: none
+
+      # Open so the first account can be created, and the first verified
+      # account becomes admin. Register before you hand the URL to anybody,
+      # then set this to false in the dashboard.
+      - key: REGISTRATION_ENABLED
+        value: "true"
+      - key: FIRST_USER_ADMIN
+        value: "true"
+
+      # There is no OTLP collector in a default Render setup, and without this
+      # the exporter retries per span and floods the logs.
+      - key: OTEL_TRACES_EXPORTER
+        value: none
+
+databases:
+  - name: fountain-db
+    databaseName: fountain
+    user: fountain
+    region: oregon
+
+    # Render's free database is deleted after 30 days. This is the smallest
+    # paid plan; Fountain stores conversation turns and log events, so watch
+    # the disk and size up rather than out.
+    plan: basic-256mb
+    postgresMajorVersion: "16"


### PR DESCRIPTION
Somebody who wants Fountain on Render has had to reverse-engineer
`docker-compose.yml`. This adds `render.yaml`: one web service on the published
image, one managed Postgres, defaulted the way compose is (credits off, no
mail, registration open for the first account, one instance). It asks for three
values — `SECRET_KEY_BASE`, `MASTER_SECRETS_KEY`, `SPRITES_TOKEN` — and
everything else has a default that comes up.

We do not use it. Production is Kubernetes (ADR 0032) and stays there.

## The one app change

`PUBLIC_URL` is required in prod, and on Render the hostname does not exist
until the first deploy has already happened — so a blueprint that asked for it
up front could never complete its own first deploy. `config/runtime.exs` now
falls back to Render's injected `RENDER_EXTERNAL_URL`, behind an operator's own
`PUBLIC_URL` (which is what a custom domain sets).

Two details in that three-line change are load-bearing:

- The candidates are a **list, not an `||` chain**. `""` is truthy in Elixir,
  so a present-but-empty `PUBLIC_URL` — the shape every `${VAR:-}` and every
  blank dashboard field delivers — would have won the chain and raised. There
  is a test for exactly that, and reverting to the `||` form fails it.
- They stay **three quoted literals**. `config_reference_test` finds the
  variables this file reads by scanning for that shape; folded into a `~w`
  sigil, `PUBLIC_URL` and `FOUNTAIN_DOMAIN` become invisible to it and read as
  documentation for a variable nothing consumes.

## Guards

A second deploy surface drifts the way compose did, so it gets the same
treatment:

| Guard | Catches |
|---|---|
| every key `render.yaml` sets is one the app reads | a knob wired to nothing |
| every var a prod boot raises without is present | a blueprint that crash-loops on a service nobody has a shell on |
| no `PUBLIC_URL` key | re-introducing the blank-value trap above |
| the image pin, in `ReleasePinTest` + `release-bump.yml` | a pin left at an old release, the way four of them sat at v0.3.0 |

Each one was verified by breaking the thing it guards and watching it fail.

## Notes for review

- **One instance, on purpose.** Fountain clusters over Erlang distribution and
  a Render service cannot discover its own peers, so a second instance is two
  schedulers racing over the same sandboxes, not a second node.
- **`TRUSTED_PROXIES` is a wide private range.** Render terminates TLS at its
  edge, and the built-in defaults are k3s CIDRs that match nothing there — left
  alone, every per-IP rate-limit bucket collapses into one and every audit row
  records the proxy. Only Render's proxy reaches the container, so trusting the
  private ranges is safe, but I could not confirm the exact address Render
  forwards from without deploying. The guide says to narrow it.
- **Untested against a live Render account.** The YAML parses and every key is
  from the blueprint spec, but nobody has applied it. `DATABASE_SSL` is left at
  its default (on, unverified), which should suit Render's managed Postgres.

Full suite green: 4122 tests, 0 failures. All three prose gates clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V6FYp9KTQ2kLbPzLXnd547