### PR TITLE
chore: drop .sops.public-key, missed when SOPS left

### DIFF
--- a/.sops.public-key
+++ b/.sops.public-key
@@ -1,1 +1,0 @@
-age1gqdqq7uagezyew5uvhylgcasuntmltqx3mdxmwa6es5k393hg3ns4fsyrt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -262,6 +262,17 @@ upgrade, is in
   nothing changes. Changing a brand's pixels no longer means rebuilding the
   engine.
 
+### Removed
+
+- **`.sops.public-key`.** ADR 0032 deleted `.sops.yaml` because the only
+  SOPS-encrypted file in the repo had stopped existing; the age public key it
+  paired with was missed in that sweep. SOPS itself was retired across the
+  operator's cluster in 2026-07 for two-tier Infisical, whose bootstrap
+  credential its manifests describe as the replacement for the SOPS age key.
+  Nothing in this repo or in home-cloud read the file or the key. A public key
+  leaks nothing by sitting there, but a live-looking secrets artifact in the
+  repo root implies a workflow that does not exist.
+
 ## [0.14.0] — 2026-08-25
 
 ### Upgrade notes


### PR DESCRIPTION
`.sops.public-key` is dead config. Three confirmations:

- **Its companion is already gone.** The key arrived in `7b7b1d35` ("add k8s
  manifests for home-cloud deployment") alongside `.sops.yaml`. ADR 0032
  deleted `.sops.yaml` because *"the file it existed for … stopped existing …
  and nothing else in the repo is SOPS-encrypted."* The public key was missed
  in that sweep.
- **SOPS is retired on the operator's side too.** home-cloud moved to two-tier
  Infisical in 2026-07, age decryption stripped from all 26 Kustomizations. Its
  manifests describe the Infisical bootstrap credential as "the cluster's
  secret zero, replacing the SOPS age key".
- **Nothing reads it.** No workflow, script, doc, ADR, or Dockerfile `COPY`
  references the filename or the key value, in this repo or in home-cloud.

No security angle: an age *public* key is safe to publish, and this is not a
rotation. The cost of keeping it is that a live-looking secrets artifact in the
repo root implies a workflow that does not exist — the same thing ADR 0032 was
cleaning up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V6FYp9KTQ2kLbPzLXnd547