### PR TITLE
copy: say what Fountain is before saying what it saves you

### DIFF
--- a/.agents/product-marketing.md
+++ b/.agents/product-marketing.md
@@ -1,6 +1,6 @@
 # Product Marketing Context
 
-**Document version:** v1
+**Document version:** v2
 **Last updated:** 2026-08-27
 
 This file is the positioning, the ICP and the vocabulary that marketing work in
@@ -16,7 +16,23 @@ and bump the version.
 
 ## Product Overview
 
-**One-liner:** A multi-tenant API and UI for running sandboxed coding agents.
+**One-liner:** A conversational API to a computer, metered only while an agent
+is working.
+
+**Lead with the meter.** Both halves of that line are the pitch, and the second
+half is the part nobody else offers. A prompt goes over HTTP, a machine wakes
+up with the repositories, packages and credentials already on it, an agent
+works, the answer comes back, and the machine parks. A parked machine costs
+nothing, holds its disk and takes none of the account's concurrency. Copy that
+describes the machine without the meter has described a sandbox provider.
+
+**The harness is not the product.** There is a glut of agent harnesses and
+Fountain runs four of them (`claude`, `codex`, `gemini`, `opencode`) behind one
+API. Nothing in the pitch should imply the runtime is the scarce part. The
+scarce part is everything under it: the machine lifecycle, the installs, the
+configuration, the networking, and a credential that reaches the machine
+without reaching the prompt. That list is the reader's own to-do list, and
+naming it is what makes the page land.
 
 **What it does:** Agent, Environment and Vault are templates you write once. A
 Conversation runs one of them on a machine Fountain builds, warms, meters and
@@ -84,9 +100,15 @@ Do not write multi-stakeholder copy until org features exist.
 
 ## Problems & Pain Points
 
-**Core problem:** Running Claude instances with worktrees locally, and shuffling
-MCP configurations and skill setups by hand, is painful. That sentence is
-`README.md`'s own, and it is the most load-bearing problem statement in the repo.
+**Core problem:** Builders do not want to run computers. They want software that
+holds a conversation, and the software needs a computer to hold it on. So they
+end up owning a machine lifecycle, a package install, a config, a network and a
+credential problem, none of which is the product they set out to ship. That is
+`README.md`'s own framing and the most load-bearing problem statement in the
+repo. The older version of the sentence, "running Claude instances with
+worktrees locally and shuffling MCP configs by hand is painful", is the same
+problem told from the laptop rather than from the product, and it still works
+for a reader who has not shipped yet.
 
 **Why alternatives fall short:**
 - A raw sandbox provider gives you a machine, not a template that outlives the
@@ -127,6 +149,10 @@ without telling us.
 ## Differentiation
 
 **Key differentiators:**
+- **The meter runs only while an agent works.** A parked machine, an idle one
+  and one on the customer's own runner all cost nothing. A sandbox provider
+  rents a box by the hour whether or not anybody is talking to it. This is the
+  differentiator to lead with, and the one that pays for the whole pitch.
 - **Four primitives, split by rate of change.** What the machine holds changes
   rarely; which credentials a run uses changes constantly; how the agent behaves
   changes sometimes; what it does now changes continuously. Fountain gives each
@@ -179,8 +205,14 @@ on the repo's own problem statement rather than pretending to quote a user.
 **Words to use:** Agent, Environment, Vault, Conversation, sandbox, runtime,
 template, run, transcript, credit, primitive, estate, gate, guardrail.
 
-**Words to avoid:** "computer" for a sandbox (banned in docs, and defined
-nowhere); "simply", "just", "easy", "obviously", "coming soon" (the docs style
+**"Computer" is a marketing word only.** `standards/voice-and-style.md` bans it
+from `docs/` because reference prose needs one name for the machine, and that
+name is "sandbox". The homepage hero and `README.md` use it on purpose: it is
+the word the reader already has for the thing they do not want to run, and it
+is how the one-liner lands before "sandbox" means anything. Use it once to open,
+then say "sandbox" or "machine" for the rest of the page, and never in `docs/`.
+
+**Words to avoid:** "simply", "just", "easy", "obviously", "coming soon" (the docs style
 gate fails on these); "plans", "tiers", "seats", "subscription" (there are none);
 em dashes anywhere in `docs/`.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,24 @@
 # Fountain
 
-A multi-tenant API and UI for managing agents, repos, secrets, and conversations. It's for people who want to create sandboxed coding agent instances with preconfigured sets of env vars, MCP servers, skills, repos, and packages. Users treat Fountain as a building block for their own workflows, but also use the UI to get started and to debug. It exists because running Claude instances with worktrees locally — and shuffling MCP configurations and skill setups by hand — is painful.
+**A conversational API to a computer. The meter runs while an agent works and
+stops while the machine waits, so a conversation nobody is talking to costs
+nothing.**
+
+Send a prompt to an HTTP endpoint. On the other end a machine wakes up with
+your repositories cloned, your packages installed and your credentials already
+in the environment, a coding agent runs on it, and the answer comes back.
+Between messages the machine parks. A parked machine holds its disk, costs
+nothing and takes none of your concurrency, so the next prompt lands on the
+same files instead of on a fresh box that has to be told everything again.
+
+Coding agents are not the scarce thing. There are dozens of them and Fountain
+runs Claude Code, Codex, Gemini CLI and opencode behind one API. The scarce
+thing is the computer underneath: building it, installing on it, configuring
+it, getting the networking right, getting a credential onto it that the model
+never reads, and turning it off before the bill notices. Nobody sets out to
+build that, and everybody shipping an agent ends up building it.
+
+Fountain is that half. You write the conversation.
 
 ## In one picture
 

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -12,10 +12,20 @@
     {Fountain.Brand.name()} is the hosted {Fountain.Brand.engine()}. The engine is open source and you can run it yourself.
   </p>
   <h1 class="text-4xl sm:text-5xl font-bold tracking-tight text-[var(--color-text-primary)] mb-5 leading-tight">
-    You did not set out to run a sandbox platform.
+    A conversational API to a computer.
   </h1>
   <p class="text-lg sm:text-xl text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-10">
-    But an agent in front of your users needs one, and then you maintain it. {Fountain.Brand.name()} is that half. One call gets a sandbox with a checkout, credentials the model never sees, a lifecycle that parks and wakes itself, and the answer back instead of the transcript.
+    Send a prompt over HTTP. A machine wakes up with your repositories cloned, your packages installed and credentials the model never sees, a coding agent does the work, and the answer comes back.
+    <%!-- The meter is the differentiator, so it belongs in the hero. It is
+          also a claim only a billing deployment can make, and the same
+          `pricing?()` guard the price card uses keeps a free install from
+          making it. --%>
+    <span :if={pricing?()}>
+      It parks between messages, and you pay for the minutes it works rather than for the machine sitting there.
+    </span>
+    <span :if={!pricing?()}>
+      It parks between messages and wakes on the next one with its files intact, so nothing is running while nobody is talking.
+    </span>
   </p>
   <div class="flex flex-col sm:flex-row gap-3 justify-center mb-4">
     <a
@@ -45,10 +55,10 @@
 <section class="bg-[var(--color-bg-1)] border-y border-[var(--color-border)]">
   <div class="max-w-5xl mx-auto px-6 py-16">
     <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-3 text-center">
-      Six questions between a demo and a product.
+      You did not set out to run a sandbox platform.
     </h2>
     <p class="text-center text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-10">
-      The agent works on your laptop. Putting it in front of your users means answering all of these first, and not one of them is the thing you set out to build.
+      Harnesses are not the scarce part. There are dozens, and {Fountain.Brand.name()} runs four of them behind one API. The scarce part is everything under the harness, and it arrives as six questions between a demo on your laptop and a feature in front of your users.
     </p>
     <div class="grid sm:grid-cols-2 gap-6">
       <div class="p-5 rounded-lg bg-[var(--color-bg)] border border-[var(--color-border)]">

--- a/apps/fountain/lib/fountain_web/open_graph.ex
+++ b/apps/fountain/lib/fountain_web/open_graph.ex
@@ -33,8 +33,9 @@ defmodule FountainWeb.OpenGraph do
   @spec default_description() :: String.t()
   def default_description do
     if Fountain.Marketing.site?() do
-      "#{Fountain.Brand.name()} runs a coding agent on a cloud sandbox and hands " <>
-        "your app a conversation with it. Send a prompt, read the reply."
+      "#{Fountain.Brand.name()} is a conversational API to a computer. Send a " <>
+        "prompt, a sandbox with your repositories and credentials does the work, " <>
+        "and you pay for the minutes it works."
     else
       "#{Fountain.Brand.name()} runs agents on sandboxes and serves their " <>
         "conversations over an API."

--- a/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
@@ -681,7 +681,7 @@ defmodule FountainWeb.OpenGraphTest do
 
     assert body =~ ~s(<meta property="og:image:width" content="1200")
     assert body =~ ~s(<meta name="twitter:card" content="summary_large_image")
-    assert body =~ ~s(<meta name="description" content="Fountain runs a coding agent)
+    assert body =~ ~s(<meta name="description" content="Fountain is a conversational API)
   end
 
   test "a docs page describes itself and names its own URL", %{conn: conn} do


### PR DESCRIPTION
The README opened with an inventory ("a multi-tenant API and UI for managing
agents, repos, secrets, and conversations") and the homepage opened with the
problem ("You did not set out to run a sandbox platform"). Neither told a
first-time reader what the thing **is**, and neither said the part nobody else
offers: the meter runs while an agent works and stops while the machine waits.

Both now lead with it.

## README

> **A conversational API to a computer. The meter runs while an agent works and
> stops while the machine waits, so a conversation nobody is talking to costs
> nothing.**
>
> Send a prompt to an HTTP endpoint. On the other end a machine wakes up with
> your repositories cloned, your packages installed and your credentials already
> in the environment, a coding agent runs on it, and the answer comes back.
> Between messages the machine parks. […]
>
> Coding agents are not the scarce thing. There are dozens of them and Fountain
> runs Claude Code, Codex, Gemini CLI and opencode behind one API. The scarce
> thing is the computer underneath: building it, installing on it, configuring
> it, getting the networking right, getting a credential onto it that the model
> never reads, and turning it off before the bill notices. Nobody sets out to
> build that, and everybody shipping an agent ends up building it.
>
> Fountain is that half. You write the conversation.

Four short paragraphs replace the old one. Everything below `## In one picture`
is untouched.

## Homepage

- `h1` is now "A conversational API to a computer.", with a subhead carrying the
  prompt to machine to answer loop and the meter.
- "You did not set out to run a sandbox platform." is not thrown away. It moves
  down to head the six-questions section, where it reads as the argument rather
  than as the introduction, and that section's intro now names the harness glut
  out loud: harnesses are not the scarce part, everything under them is.
- The hero's billing clause sits behind the same `pricing?()` guard the price
  card uses, so an install that prices nothing does not claim a meter. It gets a
  parks-and-wakes sentence instead.

## The rest

- `open_graph.ex`: the default card description follows the new one-liner, so a
  link unfurling in Slack says the same thing the page does.
- `.agents/product-marketing.md`: one-liner, core problem and differentiators
  re-pointed at this message, so the next copy pass starts here rather than from
  the old inventory. Version bumped to v2.

## The "computer" carve-out

`standards/voice-and-style.md` bans "computer" outright, but scopes that to
`docs/` and says to keep it "in the UI if it earns its place there". It is used
deliberately in the hero and the README, because it is the word the reader
already has for the thing they do not want to run, and it is how the one-liner
lands before "sandbox" means anything. The carve-out is written down in
`.agents/product-marketing.md` so the two documents do not read as contradicting
each other: once to open, then "sandbox" for the rest of the page, and never in
`docs/`. Happy to drop it if you would rather the ban be absolute.

## Verification

- 76 tests green across `marketing_controller_test`, `marketing_instance_test`,
  `brand_chrome_test`, `marketing_pricing_test`.
- `docs_test` green (it pins the README's diagram alt text).
- `mix credo --strict` clean.
- One assertion changed: the OG description sentinel in
  `marketing_controller_test.exs`. The three "You did not set out to run a
  sandbox platform." sentinels still pass unchanged, because the line is still on
  the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VcbwyVHwqu7SLYiRuAqbF2