### PR TITLE
The demo suite moved to *.demo.managoat.com

### DIFF
--- a/apps/fountain/lib/fountain/apps.ex
+++ b/apps/fountain/lib/fountain/apps.ex
@@ -9,12 +9,12 @@ defmodule Fountain.Apps do
   one place that knows their URLs, so the console's links, an email's
   "open it" and a forwarded support report all agree.
 
-  Both default to the apps hosted at jakegaylor.com. They are ordinary static
+  Both default to the apps hosted on demo.managoat.com. They are ordinary static
   builds with **no server of their own**: the reader types their Fountain's
   URL in, so the hosted build works against a self-hosted Fountain as soon as
   that server admits the origin:
 
-      API_CORS_ORIGINS=https://jakegaylor.com
+      API_CORS_ORIGINS=https://fountain-conversations.demo.managoat.com
 
   A deployment that would rather host its own copy points `CONVERSATIONS_APP_URL`
   and `TEAM_APP_URL` at it (and admits *that* origin instead). Setting either
@@ -23,8 +23,8 @@ defmodule Fountain.Apps do
   rather than off-site.
   """
 
-  @conversations "https://jakegaylor.com/fountain-conversations/"
-  @team "https://jakegaylor.com/fountain-team/"
+  @conversations "https://fountain-conversations.demo.managoat.com/"
+  @team "https://fountain-team.demo.managoat.com/"
 
   @doc "The conversations app's base URL, or nil where the deployment has none."
   @spec conversations() :: String.t() | nil
@@ -41,7 +41,7 @@ defmodule Fountain.Apps do
   log `#/c/<id>/logs`.
 
       iex> Fountain.Apps.conversation_url("abc")
-      "https://jakegaylor.com/fountain-conversations/#/c/abc"
+      "https://fountain-conversations.demo.managoat.com/#/c/abc"
   """
   @spec conversation_url(String.t(), keyword()) :: String.t() | nil
   def conversation_url(id, opts \\ []) when is_binary(id) do

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
@@ -643,9 +643,9 @@ defmodule FountainWeb.MarketingHTML do
             id: "fountain-conversations",
             glyph: "\u{1F9F5}",
             name: "Conversations",
-            host: "jakegaylor.com/fountain-conversations",
-            url: "https://jakegaylor.com/fountain-conversations/",
-            source: "https://github.com/jhgaylor/fountain-conversations",
+            host: "fountain-conversations.demo.managoat.com",
+            url: "https://fountain-conversations.demo.managoat.com/",
+            source: "https://github.com/managoat/fountain-conversations",
             blurb:
               "Start a run, watch the agent work turn by turn, and drive it. Chat, timeline and raw views of the same conversation, plus the machine it shares with its siblings.",
             shows: "the event stream as blocks, and one sandbox behind many conversations",
@@ -658,9 +658,9 @@ defmodule FountainWeb.MarketingHTML do
             id: "fountain-team",
             glyph: "\u{1F465}",
             name: "Team",
-            host: "jakegaylor.com/fountain-team",
-            url: "https://jakegaylor.com/fountain-team/",
-            source: "https://github.com/jhgaylor/fountain-team",
+            host: "fountain-team.demo.managoat.com",
+            url: "https://fountain-team.demo.managoat.com/",
+            source: "https://github.com/managoat/fountain-team",
             blurb:
               "Your agents as teammates in a messaging app. Roster on the left, thread on the right, routines on a schedule, images and search. Enter to send.",
             shows: "the team API, SSE streaming, schedules, usage",
@@ -674,9 +674,9 @@ defmodule FountainWeb.MarketingHTML do
             id: "fountain-workbench",
             glyph: "\u{1F9F0}",
             name: "Workbench",
-            host: "workbench.inevitable.fyi",
-            url: "https://workbench.inevitable.fyi",
-            source: "https://github.com/jhgaylor/fountain-workbench",
+            host: "fountain-workbench.demo.managoat.com",
+            url: "https://fountain-workbench.demo.managoat.com",
+            source: "https://github.com/managoat/fountain-workbench",
             blurb:
               "A dev workstation the team shares. A project is an environment and a vault, work items live in it, and putting a teammate on one is a first prompt rather than four steps of setup.",
             shows: "projects over environments and vaults, agents as staff",
@@ -699,9 +699,9 @@ defmodule FountainWeb.MarketingHTML do
             id: "briefing-room",
             glyph: "\u{1F4F0}",
             name: "Briefing Room",
-            host: "briefs.inevitable.fyi",
-            url: "https://briefs.inevitable.fyi",
-            source: "https://github.com/jhgaylor/briefing-room",
+            host: "briefing-room.demo.managoat.com",
+            url: "https://briefing-room.demo.managoat.com",
+            source: "https://github.com/managoat/briefing-room",
             blurb:
               "Say what you need to understand and why. A researcher with its own computer reads real sources and hands back a clean, cited brief. A document, not a chat.",
             shows: "web research behind a UI with none of the AI-chat furniture"
@@ -710,9 +710,9 @@ defmodule FountainWeb.MarketingHTML do
             id: "table-talk",
             glyph: "\u{1F4CA}",
             name: "Table Talk",
-            host: "tables.inevitable.fyi",
-            url: "https://tables.inevitable.fyi",
-            source: "https://github.com/jhgaylor/table-talk",
+            host: "table-talk.demo.managoat.com",
+            url: "https://table-talk.demo.managoat.com",
+            source: "https://github.com/managoat/table-talk",
             blurb:
               "Drop a CSV in. An analyst runs Python on its sandbox and comes back with charts and plain-English findings. Then keep asking questions of your data.",
             shows: "a real computer as the engine under a zero-jargon UI"
@@ -740,9 +740,9 @@ defmodule FountainWeb.MarketingHTML do
             id: "repo-sage",
             glyph: "\u{1F33F}",
             name: "Repo Sage",
-            host: "reposage.inevitable.fyi",
-            url: "https://reposage.inevitable.fyi",
-            source: "https://github.com/jhgaylor/repo-sage",
+            host: "repo-sage.demo.managoat.com",
+            url: "https://repo-sage.demo.managoat.com",
+            source: "https://github.com/managoat/repo-sage",
             blurb:
               "Name any public GitHub repository. An agent clones it on its own machine and answers with file-and-line citations that link back to the source.",
             shows: "the sandbox as a workstation: clone, grep, read, cite"
@@ -751,9 +751,9 @@ defmodule FountainWeb.MarketingHTML do
             id: "mission-control",
             glyph: "\u{1F680}",
             name: "Mission Control",
-            host: "mission.inevitable.fyi",
-            url: "https://mission.inevitable.fyi",
-            source: "https://github.com/jhgaylor/mission-control",
+            host: "mission-control.demo.managoat.com",
+            url: "https://mission-control.demo.managoat.com",
+            source: "https://github.com/managoat/mission-control",
             blurb:
               "Describe a mission. A coordinator plans it, you approve the plan, and the app starts one sandboxed agent per task. Watch the fleet work and take one report.",
             shows: "plan, approve, fan out, multiplex the streams, synthesize"
@@ -762,9 +762,9 @@ defmodule FountainWeb.MarketingHTML do
             id: "dns-desk",
             glyph: "\u{1F5C2}\u{FE0F}",
             name: "DNS Desk",
-            host: "jakegaylor.com/dns-desk",
-            url: "https://jakegaylor.com/dns-desk/",
-            source: "https://github.com/jhgaylor/dns-desk",
+            host: "dns-desk.demo.managoat.com",
+            url: "https://dns-desk.demo.managoat.com/",
+            source: "https://github.com/managoat/dns-desk",
             blurb:
               "A DNS operator for your Cloudflare zones. Ask in plain words, read the plan as a diff, approve. The zone tables stay on screen while the agent does the work.",
             shows: "plan, approve, apply on a live system, with a vault as the blast radius"
@@ -781,9 +781,9 @@ defmodule FountainWeb.MarketingHTML do
             id: "watchtower",
             glyph: "\u{1F5FC}",
             name: "Watchtower",
-            host: "watchtower.inevitable.fyi",
-            url: "https://watchtower.inevitable.fyi",
-            source: "https://github.com/jhgaylor/watchtower",
+            host: "watchtower.demo.managoat.com",
+            url: "https://watchtower.demo.managoat.com",
+            source: "https://github.com/managoat/watchtower",
             blurb:
               "An SRE teammate on a cron: uptime, latency, TLS expiry and DNS for every site you name. When a tile turns red, ask it to investigate. It has real tools.",
             shows: "schedules as a product heartbeat, the conversation as the store"
@@ -792,9 +792,9 @@ defmodule FountainWeb.MarketingHTML do
             id: "mend",
             glyph: "\u{1F526}",
             name: "Mend",
-            host: "mend.inevitable.fyi",
-            url: "https://mend.inevitable.fyi",
-            source: "https://github.com/jhgaylor/mend",
+            host: "mend.demo.managoat.com",
+            url: "https://mend.demo.managoat.com",
+            source: "https://github.com/managoat/mend",
             blurb:
               "What an audit finds across a repository's CI, manifests, Dockerfiles and cloud templates, and what an agent does once you hand it that tool. Mechanical fixes applied, judgement calls argued, one patch back.",
             shows:
@@ -804,9 +804,9 @@ defmodule FountainWeb.MarketingHTML do
             id: "rounds",
             glyph: "\u{1F501}",
             name: "Rounds",
-            host: "rounds.inevitable.fyi",
-            url: "https://rounds.inevitable.fyi",
-            source: "https://github.com/jhgaylor/rounds",
+            host: "rounds.demo.managoat.com",
+            url: "https://rounds.demo.managoat.com",
+            source: "https://github.com/managoat/rounds",
             blurb:
               "Dependabot for infrastructure config. Enrol a repository and it gets audited on a schedule; an agent fixes what it can verify and opens the pull request. Never twice for the same finding, never again for one you closed.",
             shows: "an unattended product, and an agent that knows when to do nothing"
@@ -822,9 +822,9 @@ defmodule FountainWeb.MarketingHTML do
             id: "arena",
             glyph: "\u{1F94A}",
             name: "Arena",
-            host: "arena.inevitable.fyi",
-            url: "https://arena.inevitable.fyi",
-            source: "https://github.com/jhgaylor/arena",
+            host: "arena.demo.managoat.com",
+            url: "https://arena.demo.managoat.com",
+            source: "https://github.com/managoat/arena",
             blurb:
               "One prompt, several brains, side by side. Blind columns, live streams, latency and token counts, and your vote on the scoreboard.",
             shows: "parallel conversations, the model catalog, per-turn usage"

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/self_hosted.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/self_hosted.html.heex
@@ -200,7 +200,7 @@
       <p class="text-sm text-[var(--color-text-secondary)] leading-relaxed">
         A browser app on another origin calling your API is a CORS request, so name the origin it is served from:
       </p>
-      <pre class="mt-3 overflow-x-auto rounded-lg bg-[var(--color-code-bg)] p-4 text-xs text-[var(--color-code-text)]"><code phx-no-format>API_CORS_ORIGINS=https://jakegaylor.com</code></pre>
+      <pre class="mt-3 overflow-x-auto rounded-lg bg-[var(--color-code-bg)] p-4 text-xs text-[var(--color-code-text)]"><code phx-no-format>API_CORS_ORIGINS=https://fountain-conversations.demo.managoat.com</code></pre>
       <p class="mt-3 text-sm text-[var(--color-text-secondary)] leading-relaxed">
         Conversations and Team are also what the console's own links point at, so <code
           class="text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1 py-0.5 text-xs"

--- a/apps/fountain/test/fountain/apps_test.exs
+++ b/apps/fountain/test/fountain/apps_test.exs
@@ -36,8 +36,8 @@ defmodule Fountain.AppsTest do
     Application.delete_env(:fountain, :conversations_app_url)
     Application.delete_env(:fountain, :team_app_url)
 
-    assert Apps.conversations() == "https://jakegaylor.com/fountain-conversations/"
-    assert Apps.team() == "https://jakegaylor.com/fountain-team/"
+    assert Apps.conversations() == "https://fountain-conversations.demo.managoat.com/"
+    assert Apps.team() == "https://fountain-team.demo.managoat.com/"
   end
 
   test "a configured URL wins, with exactly one trailing slash either way" do

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1270,7 +1270,7 @@ config :fountain,
 #
 # Fountain's own UI is a console; conversations and the team roster are
 # separate single-page apps (Fountain.Apps). Both default to the builds
-# hosted at jakegaylor.com, which work against any Fountain the reader types
+# hosted on demo.managoat.com, which work against any Fountain the reader types
 # in — provided this server admits that origin in API_CORS_ORIGINS. Point
 # these at your own deployment instead, or set one to "" to say this
 # deployment has no such app.
@@ -1285,7 +1285,7 @@ end
 #
 # The public browser apps allowed to sign in with Fountain (#818), as JSON:
 #   OAUTH_CLIENTS='[{"id":"fountain-conversations","name":"Fountain Conversations",
-#                    "redirect_uris":["https://jakegaylor.com/fountain-conversations/"]}]'
+#                    "redirect_uris":["https://fountain-conversations.demo.managoat.com/"]}]'
 # Unset (or invalid) means no clients — /oauth/authorize refuses everything —
 # except in dev and test, whose config files register the local apps.
 case System.get_env("OAUTH_CLIENTS") do


### PR DESCRIPTION
Every app on `/built-with` changed address. The repos moved from the `jhgaylor` user account into the new `managoat` org, and the hosting went with them: the ten that were on `*.inevitable.fyi` and the three published to GitHub Pages under `jakegaylor.com/<repo>/` are now one shape, at `<repo>.demo.managoat.com`, served by the same cluster.

Host label = repo name = OAuth client id, so four changed subdomain on the way:

| was | now |
|---|---|
| `briefs.inevitable.fyi` | `briefing-room.demo.managoat.com` |
| `tables.inevitable.fyi` | `table-talk.demo.managoat.com` |
| `reposage.inevitable.fyi` | `repo-sage.demo.managoat.com` |
| `mission.inevitable.fyi` | `mission-control.demo.managoat.com` |
| `workbench.inevitable.fyi` | `fountain-workbench.demo.managoat.com` |
| `jakegaylor.com/{fountain-team,fountain-conversations,dns-desk}/` | `{…}.demo.managoat.com` |

`built_apps/0` carried the old `host`, `url` and `source` for all thirteen, so every "Open it" and "Source" link on that page was pointing somewhere dead. `Fountain.Apps` carried the same two stale defaults, so a console link and an email's "open it" were too.

Reflex keeps `reflex.inevitable.fyi` and stays in `jhgaylor` — built on the API, but not one of the demos.

The CORS origins and OAuth redirect URIs for the new hosts are already deployed from home-cloud's `platform/fountain-site`. `config/dev.exs` needs nothing: its clients are localhost-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0192ByGypvhatVt294GfM4mn