### PR TITLE
feat(deploy): Fly, Coolify, and a name for the hosts that do not work

### DIFF
--- a/.github/workflows/release-bump.yml
+++ b/.github/workflows/release-bump.yml
@@ -128,7 +128,7 @@ jobs:
           # (#478). Bump them in the release commit so the tag's own tree
           # pins the tag. ReleasePinTest keeps this list and the files in
           # lockstep between releases.
-          pins='docker-compose.yml .env.compose.example render.yaml deploy/k8s/kustomization.yaml deploy/k8s/deployment.yaml'
+          pins='docker-compose.yml .env.compose.example render.yaml fly.toml deploy/k8s/kustomization.yaml deploy/k8s/deployment.yaml'
           for f in ${pins}; do
             sed -i "s/${current}/${next}/g" "$f"
             # sed exits 0 whether or not it matched; a pin that no longer
@@ -149,7 +149,7 @@ jobs:
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add mix.exs apps/fountain/mix.exs \
-            docker-compose.yml .env.compose.example render.yaml \
+            docker-compose.yml .env.compose.example render.yaml fly.toml \
             deploy/k8s/kustomization.yaml deploy/k8s/deployment.yaml
           # [skip ci] keeps this commit from re-triggering CI on main.
           # release.yml is dispatched explicitly in the next step.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,42 @@ upgrade, is in
 
 ### Added
 
+- **A Fly blueprint, and a name for the hosts that do not work.** `fly.toml`
+  declares one machine on the published image, defaulted the way compose and
+  `render.yaml` are, and the guide at `/docs/guides/operate/fly` attaches a
+  managed Postgres in a second command. What the file mostly does is hold off
+  two Fly defaults that are right for a web app and wrong for this one:
+  `auto_stop_machines` parks an idle machine, and every scheduler runs inside
+  the app process, so a parked instance quietly stops reaping sandboxes and
+  stops pricing turns; `canary` and `bluegreen` bring a second machine up
+  before retiring the first, and two machines are two schedulers racing over
+  the same sandboxes. `auto_stop_machines`, `auto_start_machines`,
+  `min_machines_running` and `strategy = "rolling"` are each pinned by a guard
+  test for that reason. `PUBLIC_URL` is absent here too, for a different
+  reason than on Render: the hostname is knowable, but the file ships with an
+  app name `fly launch` replaces, so `config/runtime.exs` derives
+  `https://$FLY_APP_NAME.fly.dev` behind an operator's own `PUBLIC_URL`.
+  `FLY_APP_NAME` was already read for an OTel attribute and sat on
+  `config_reference_test`'s exemption list; it builds an operator-visible URL
+  now, so it has a row in the configuration reference and that exemption list
+  is empty and gone.
+
+- **Coolify and Dokploy, on the compose file that already exists.** No new
+  file. `/docs/guides/operate/coolify` names the five values to set in the
+  interface and the two compose defaults a public server must not keep, which
+  are the published Postgres port with its default password and a `PUBLIC_URL`
+  that stays at `http://localhost:4000` and quietly puts localhost in every
+  verification email.
+
+- **What a host must give you, and which popular ones do not.**
+  `/docs/self-hosting` now states the three properties a host needs (one
+  instance and only one, a process that never parks, long-lived connections)
+  and names Cloud Run, App Runner, Lambda, Vercel, Netlify and Cloudflare
+  Workers as hosts that fail one of them. They fail quietly: an instance that
+  scales to zero looks healthy while it stops reaping sandboxes and pricing
+  turns. The README says the same thing in three lines, and now points at
+  `render.yaml` and `fly.toml`, which it never mentioned.
+
 - **A Render blueprint, for an instance that is not ours.** `render.yaml`
   declares one web service on the published image and one managed Postgres,
   so somebody who wants Fountain on Render applies a blueprint instead of

--- a/README.md
+++ b/README.md
@@ -40,8 +40,19 @@ cp .env.compose.example .env   # then fill in the generated keys
 docker compose up -d
 ```
 
-Prefer Kubernetes? A portable baseline — plain manifests, `kubectl apply -k`,
-no operators assumed — lives in [`deploy/k8s/`](deploy/k8s/).
+Prefer a platform? [`render.yaml`](render.yaml) declares one service and a
+managed Postgres; [`fly.toml`](fly.toml) declares one machine, and you attach
+a database in a second command. Both pin a release image and one instance —
+Fountain clusters over Erlang distribution, so a second replica is two
+schedulers racing over the same sandboxes. Coolify and Dokploy run the compose
+file above straight from this repo. Prefer Kubernetes? A portable baseline —
+plain manifests, `kubectl apply -k`, no operators assumed — lives in
+[`deploy/k8s/`](deploy/k8s/).
+
+Scale-to-zero hosts (Cloud Run, App Runner, Vercel) do not work: the sandbox
+reaper and the credit pricer run inside the app process, so a parked instance
+quietly stops both. [docs/self-hosting.md](docs/self-hosting.md) has the three
+properties a host must have.
 
 ## The apps
 

--- a/apps/fountain/lib/fountain_web/markdown.ex
+++ b/apps/fountain/lib/fountain_web/markdown.ex
@@ -53,8 +53,10 @@ defmodule FountainWeb.Markdown do
   # `python` and `javascript` joined the list with the webhooks reference
   # (#700), which carries a signature verifier in each. A receiver author
   # reading an unhighlighted wall of HMAC code is the case this guard exists
-  # for.
-  @languages ~w(bash typescript javascript python json json5 yaml elixir ini)
+  # for. `toml` joined with the Fly guide, which is the first page here to
+  # quote a `fly.toml`; `ini` is a near miss for it and highlights the wrong
+  # things, so the fence names the real language and this list grew instead.
+  @languages ~w(bash typescript javascript python json json5 yaml toml elixir ini)
 
   @doc """
   The languages whose parsers are baked into the image — see `@languages`.

--- a/apps/fountain/test/fountain/config_reference_test.exs
+++ b/apps/fountain/test/fountain/config_reference_test.exs
@@ -407,7 +407,8 @@ defmodule Fountain.ConfigReferenceTest do
 
     for {pattern, why} <- [
           {~r/^\s*auto_stop_machines = "off"$/m, "a parked machine stops reaping and pricing"},
-          {~r/^\s*auto_start_machines = false$/m, "a machine Fly starts on demand is a parked one"},
+          {~r/^\s*auto_start_machines = false$/m,
+           "a machine Fly starts on demand is a parked one"},
           {~r/^\s*min_machines_running = 1$/m, "the instance has to stay up between requests"},
           {~r/^\s*strategy = "rolling"$/m, "canary and bluegreen run two machines at once"}
         ] do

--- a/apps/fountain/test/fountain/config_reference_test.exs
+++ b/apps/fountain/test/fountain/config_reference_test.exs
@@ -8,10 +8,6 @@ defmodule Fountain.ConfigReferenceTest do
 
   @repo_root Path.expand("../../../..", __DIR__)
 
-  # Injected by the platform or release tooling rather than set by an
-  # operator; not part of the operator-facing reference.
-  @platform_injected ~w(FLY_APP_NAME)
-
   test "every env var read in config/runtime.exs is documented in docs/configuration.md" do
     source = File.read!(Path.join(@repo_root, "config/runtime.exs"))
     doc = File.read!(Path.join(@repo_root, "docs/configuration.md"))
@@ -45,7 +41,7 @@ defmodule Fountain.ConfigReferenceTest do
 
     undocumented =
       Enum.reject(vars, fn var ->
-        var in @platform_injected or String.contains?(doc, "`#{var}`")
+        String.contains?(doc, "`#{var}`")
       end)
 
     assert undocumented == [],
@@ -54,8 +50,11 @@ defmodule Fountain.ConfigReferenceTest do
 
              #{Enum.join(undocumented, ", ")}
 
-           Add a row for each (in backticks), or — only for vars the platform
-           injects rather than an operator sets — add them to @platform_injected.
+           Add a row for each, in backticks. A variable the platform injects
+           rather than an operator sets still gets a row: RENDER_EXTERNAL_URL
+           and FLY_APP_NAME are both read here, both invisible from a
+           dashboard, and both worth a line that says who sets them. The
+           exemption list they used to sit on is gone.
            """
   end
 
@@ -330,6 +329,116 @@ defmodule Fountain.ConfigReferenceTest do
            fallback in config/runtime.exs out of reach — or guesses. Leave it
            to the fallback and to the dashboard.
            """
+  end
+
+  # Keys fly.toml sets that Fly consumes rather than the release: the port it
+  # asks the machine to bind is read by the app too, so this stays empty until
+  # something is genuinely Fly-only.
+  @fly_only ~w()
+
+  test "every env var fly.toml sets is one the app reads" do
+    # Third self-host deploy surface, same rot as the first two: a key set
+    # here that the app never reads is a knob wired to nothing, and an
+    # operator has no way to tell from the outside.
+    source = File.read!(Path.join(@repo_root, "config/runtime.exs"))
+    fly = File.read!(Path.join(@repo_root, "fly.toml"))
+
+    keys =
+      fly
+      |> env_block()
+      |> then(&Regex.scan(~r/^\s*([A-Z][A-Z0-9_]*) = /m, &1, capture: :all_but_first))
+      |> List.flatten()
+      |> Enum.uniq()
+
+    assert length(keys) > 5,
+           "extracted only #{length(keys)} keys from fly.toml [env] — its layout changed"
+
+    unread =
+      Enum.reject(keys, fn var ->
+        String.contains?(source, ~s("#{var}")) or var in @fly_only or
+          Map.has_key?(@read_elsewhere, var)
+      end)
+
+    assert unread == [],
+           """
+           fly.toml sets env vars that the app never reads:
+
+             #{Enum.join(unread, ", ")}
+
+           Remove the key, or add it to @fly_only/@read_elsewhere with a reason.
+           """
+  end
+
+  test "fly.toml keeps the secrets out of the repository" do
+    # The Render blueprint asks for these three in a dashboard (`sync: false`).
+    # Fly has no such marker: a value written in [env] is a value committed to
+    # a git repository, and `fly secrets set` is the only right home for them.
+    # The guide says so; this makes the file itself say so.
+    fly = env_block(File.read!(Path.join(@repo_root, "fly.toml")))
+
+    committed =
+      Enum.filter(~w(SECRET_KEY_BASE MASTER_SECRETS_KEY SPRITES_TOKEN DATABASE_URL), fn var ->
+        Regex.match?(~r/^\s*#{var} = /m, fly)
+      end)
+
+    assert committed == [],
+           """
+           fly.toml writes secrets into [env], which commits them:
+
+             #{Enum.join(committed, ", ")}
+
+           These belong in `fly secrets set`, and DATABASE_URL comes from
+           `fly mpg attach`.
+           """
+  end
+
+  test "fly.toml pins one machine that never parks" do
+    # These four lines are the entire reason this file exists rather than a
+    # paragraph in a guide, so they get a guard rather than a comment.
+    #
+    # Fly's defaults stop an idle machine and start it again on a request, and
+    # a parked machine is an instance that quietly stops reaping sandboxes and
+    # stops pricing turns — every scheduler runs inside this process. A second
+    # machine is worse: Fountain clusters over Erlang distribution and nothing
+    # on Fly discovers peers, so two machines are two schedulers racing over
+    # the same sandboxes. `canary` and `bluegreen` both create that second
+    # machine for the length of a deploy.
+    fly = File.read!(Path.join(@repo_root, "fly.toml"))
+
+    for {pattern, why} <- [
+          {~r/^\s*auto_stop_machines = "off"$/m, "a parked machine stops reaping and pricing"},
+          {~r/^\s*auto_start_machines = false$/m, "a machine Fly starts on demand is a parked one"},
+          {~r/^\s*min_machines_running = 1$/m, "the instance has to stay up between requests"},
+          {~r/^\s*strategy = "rolling"$/m, "canary and bluegreen run two machines at once"}
+        ] do
+      assert Regex.match?(pattern, fly),
+             "fly.toml no longer matches #{inspect(pattern)} — #{why}"
+    end
+
+    assert Regex.match?(~r/^\s*path = "\/health\/ready"$/m, fly),
+           """
+           fly.toml no longer health-checks /health/ready. /health is static
+           and passes with an unreachable database, so Fly would send traffic
+           to a machine that cannot serve it.
+           """
+
+    refute Regex.match?(~r/^\s*PUBLIC_URL = /m, env_block(fly)),
+           """
+           fly.toml sets PUBLIC_URL. This file ships with an app name that
+           `fly launch` replaces, so a committed base URL names the wrong app
+           — and a set-but-wrong value takes the FLY_APP_NAME fallback in
+           config/runtime.exs out of reach. Leave it to the fallback, and set
+           it with `fly secrets set` when you add a custom domain.
+           """
+  end
+
+  # The [env] table of fly.toml: everything between the `[env]` header and the
+  # next top-level table. Scanning the whole file instead would read the
+  # commented examples and the prose in the header comment.
+  defp env_block(fly) do
+    [_, rest] = String.split(fly, ~r/^\[env\]\n/m, parts: 2)
+    [block | _] = String.split(rest, ~r/^\[/m, parts: 2)
+    block
   end
 
   # Two legitimate pass-through forms in the app service's environment block:

--- a/apps/fountain/test/fountain/release_pin_test.exs
+++ b/apps/fountain/test/fountain/release_pin_test.exs
@@ -1,5 +1,5 @@
 defmodule Fountain.ReleasePinTest do
-  # The self-host quick start pins a release image in five places. Those pins
+  # The self-host quick start pins a release image in six places. Those pins
   # sat at v0.3.0 through two releases, handing newcomers an image from before
   # the in-app first-login flow (#478), where EMAIL_DELIVERY=none dead-ends
   # signup. release-bump.yml now bumps the pins inside the release commit;
@@ -13,6 +13,7 @@ defmodule Fountain.ReleasePinTest do
     {"docker-compose.yml", ~r/fountain:\$\{FOUNTAIN_IMAGE_TAG:-(v[\d.]+)\}/},
     {".env.compose.example", ~r/^FOUNTAIN_IMAGE_TAG=(v[\d.]+)$/m},
     {"render.yaml", ~r/url: ghcr\.io\/binarybourbon\/fountain:(v[\d.]+)/},
+    {"fly.toml", ~r/image = "ghcr\.io\/binarybourbon\/fountain:(v[\d.]+)"/},
     {"deploy/k8s/kustomization.yaml", ~r/newTag: (v[\d.]+)/},
     {"deploy/k8s/deployment.yaml", ~r/image: ghcr\.io\/binarybourbon\/fountain:(v[\d.]+)/}
   ]

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -297,27 +297,43 @@ config :fountain, :sandbox_default_provider, sandbox_default_provider
 # deployments keep booting and get correct links without an env change.
 default_scheme = if env == :prod, do: "https", else: "http"
 
-# RENDER_EXTERNAL_URL is last, and is the only entry here nobody sets by hand:
-# Render injects it into every web service as the absolute URL that service is
-# reachable at. Without it, render.yaml has a chicken-and-egg problem — the
-# hostname does not exist until the first deploy, and the raise below means
-# that first deploy is the one that cannot come up. An operator's own
-# PUBLIC_URL still wins, which is what a custom domain sets.
+# RENDER_EXTERNAL_URL and FLY_APP_NAME are the two entries nobody sets by
+# hand. Render injects the former into every web service as the absolute URL
+# that service is reachable at. Without it, render.yaml has a chicken-and-egg
+# problem — the hostname does not exist until the first deploy, and the raise
+# below means that first deploy is the one that cannot come up. An operator's
+# own PUBLIC_URL still wins, which is what a custom domain sets.
 #
 # Each candidate is trimmed and tested on its own rather than chained with
 # `||`: "" is truthy in Elixir, so a present-but-empty PUBLIC_URL — the shape
 # every `${VAR:-}` and every dashboard field left blank delivers — would win
 # the chain and take the fallbacks out of reach.
 #
-# Spelled as three separate quoted literals because `config_reference_test`
-# extracts the variables this file reads by scanning for exactly that shape.
-# Folded into a `~w` sigil they become invisible to it, and PUBLIC_URL reads
-# as documentation for a variable nothing consumes.
+# Spelled as separate quoted literals because `config_reference_test` extracts
+# the variables this file reads by scanning for exactly that shape. Folded
+# into a `~w` sigil they become invisible to it, and PUBLIC_URL reads as
+# documentation for a variable nothing consumes.
+#
+# FLY_APP_NAME is the same problem in a different shape, and it is last
+# because it is the only candidate that is derived rather than read: Fly
+# injects the app's name, and `<app>.fly.dev` is the hostname its proxy
+# answers on. fly.toml therefore ships with no PUBLIC_URL. It carries an app
+# name that `fly launch` is about to replace, and a base URL still naming the
+# old one is silently wrong rather than broken — it builds the links in
+# verification emails and every sandbox reads it as FOUNTAIN_BASE_URL. An
+# operator's own PUBLIC_URL wins here too, which is what a custom domain sets.
+fly_public_url =
+  case System.get_env("FLY_APP_NAME") do
+    blank when blank in [nil, ""] -> nil
+    app -> "https://#{app}.fly.dev"
+  end
+
 public_url_env =
   [
     System.get_env("PUBLIC_URL"),
     System.get_env("FOUNTAIN_DOMAIN"),
-    System.get_env("RENDER_EXTERNAL_URL")
+    System.get_env("RENDER_EXTERNAL_URL"),
+    fly_public_url
   ]
   |> Enum.map(&String.trim(&1 || ""))
   |> Enum.find(&(&1 != ""))

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,6 +27,7 @@ message.
 | `PHX_HOST` | The host of `PUBLIC_URL`. | — | The bare host for the endpoint URL and for the LiveView origin check. Set it only when it differs from the host in `PUBLIC_URL`. |
 | `FOUNTAIN_DOMAIN` | — | deprecated | The old combined variable. Fountain still honours it as a fallback for both of the two above. Prefer `PUBLIC_URL` and `PHX_HOST`. |
 | `RENDER_EXTERNAL_URL` | — | — | Render sets this on each web service. Fountain reads it as the last fallback for `PUBLIC_URL`, after the deprecated `FOUNTAIN_DOMAIN`. The first deploy from `render.yaml` needs it, because the hostname does not exist before that deploy. An explicit `PUBLIC_URL` has precedence. Set `PUBLIC_URL` when you add a custom domain. |
+| `FLY_APP_NAME` | — | — | Fly sets this on each machine. Fountain builds `https://<app>.fly.dev` from it, and reads that as the last fallback for `PUBLIC_URL`. A deploy from `fly.toml` needs it, because that file ships with an app name that `fly launch` replaces. An explicit `PUBLIC_URL` has precedence. Set `PUBLIC_URL` when you add a custom domain. |
 | `PHX_SERVER` | `true` in the shipped image. | — | A `1`, `true` or `yes` starts the web listener. A release task runs with `PHX_SERVER=false … eval '…'`. That boots the app, and binds no port. |
 | `PORT` | `4000` | — | The HTTP port to listen on. |
 

--- a/docs/guides/operate/coolify.md
+++ b/docs/guides/operate/coolify.md
@@ -1,0 +1,133 @@
+# Deploy on Coolify
+
+[Coolify](https://coolify.io) runs on a server you own, and it deploys a
+Docker Compose file from a git repository. Fountain ships one, so Coolify
+needs no file of its own here. This guide shows you which five values to set
+in the Coolify interface. It then shows you the two compose defaults that a
+public server must not keep.
+
+[Dokploy](https://dokploy.com) works the same way. The values below apply
+there too.
+
+For a plain Docker host with no interface in front of it, read
+[Deploy an instance](deploy.md). Coolify runs the same
+[`docker-compose.yml`](https://github.com/BinaryBourbon/fountain/blob/main/docker-compose.yml),
+so the two paths differ in the interface and not in the result.
+
+## Before you start
+
+You need a Coolify server, and a domain that points at it.
+
+Generate the two keys now. You paste them in a later step.
+
+```bash
+openssl rand -base64 48 | tr -d '\n'                    # SECRET_KEY_BASE
+openssl rand 32 | base64 | tr '+/' '-_' | tr -d '=\n'   # MASTER_SECRETS_KEY
+```
+
+Back `MASTER_SECRETS_KEY` up before you have data. It is not in the database.
+A database backup alone does not protect you. Read
+[Back up and restore](back-up-and-restore.md).
+
+You also need a sandbox provider token. Read
+[Self-host Fountain](../../self-hosting.md) for what each provider needs.
+
+## Create the resource
+
+In Coolify, select **New**, then **Docker Compose**. Point it at
+`https://github.com/BinaryBourbon/fountain`, on the `main` branch, with
+`docker-compose.yml` as the compose file.
+
+Coolify reads the file and lists the environment variables in it. Every
+variable has a default that works, except the ones below.
+
+## Set the five values
+
+| | |
+|---|---|
+| `SECRET_KEY_BASE` | The first key above. |
+| `MASTER_SECRETS_KEY` | The second key above. |
+| `SPRITES_TOKEN` | Your sandbox provider token. The app starts without one, and every conversation then fails. |
+| `POSTGRES_PASSWORD` | A long random string. The default is `postgres`, and the next section says why that matters. |
+| `PUBLIC_URL` | The address you gave the app service, with the scheme. |
+
+`PUBLIC_URL` is the one that catches people. Its compose default is
+`http://localhost:4000`, and that default is a value, not an absence. The app
+starts, and every verification email and every sandbox then holds a localhost
+address. Set it to the domain in the app service's **Domains** field, and
+include `https://`.
+
+The compose file does not use Coolify's `SERVICE_FQDN_` variables, which fill
+a domain in for you. Docker Compose on its own resolves an unset variable to
+an empty string, and an empty `PUBLIC_URL` is a value that a production boot
+refuses. One file serves both paths, so you type the domain twice.
+
+## Close the two ports
+
+The compose file publishes two ports on the host. That suits a laptop. It
+does not suit a server on the internet.
+
+```yaml
+ports:
+  - "${POSTGRES_HOST_PORT:-5432}:5432"   # postgres
+  - "${PORT:-4000}:4000"                 # app
+```
+
+Postgres is the one that matters. A server with an open firewall offers
+Postgres to the internet on 5432, and the compose default password is
+`postgres`. Set `POSTGRES_PASSWORD`, and block 5432 at the firewall. Coolify
+does not manage the host firewall for you.
+
+The app port needs no host publication either. Coolify's proxy reaches the
+container over the compose network, and the **Domains** field is what routes
+traffic to it.
+
+## Trust the proxy
+
+Coolify puts a proxy in front of the app, so the app sees the proxy and not
+the caller. Left unset, Fountain falls back to cluster ranges that match
+nothing here. Every per-IP rate-limit bucket then collapses into one, and
+every audit row records the proxy's address.
+
+```
+TRUSTED_PROXIES=172.16.0.0/12
+```
+
+That range covers the Docker bridge networks Coolify creates. Narrow it when
+you confirm the address that the proxy forwards from.
+
+## Deploy
+
+Select **Deploy**. The first deploy takes a few minutes, because the app
+applies the database migrations before it opens a listener.
+
+The app service carries a health check, so Coolify reports the container as
+healthy only after the migrations finish.
+
+## Register the first account
+
+Open your domain and register. The compose defaults are `EMAIL_DELIVERY=none`
+and `FIRST_USER_ADMIN=true`, so your account self-verifies and becomes the
+admin.
+
+Register **before** you give the URL to anybody. While no admin exists, the
+first verified account takes the role.
+
+Then set `REGISTRATION_ENABLED=false` and deploy again.
+
+## What Coolify does not do for you
+
+- **It runs one instance.** Fountain clusters over Erlang distribution, and
+  the compose file describes a single container. A second replica is not a
+  second node, and two schedulers then race over the same sandboxes. Read
+  [Architecture](../../architecture.md#clustering).
+- **It takes no database backup.** The compose file has a `backup` profile
+  that dumps Postgres nightly, and Coolify does not start a profile. Use
+  Coolify's own scheduled backups for the Postgres service instead. Read
+  [Back up and restore](back-up-and-restore.md) for what a restore needs, and
+  remember that a dump alone cannot decrypt itself.
+- **It does not pin the version for you.** The compose file pins a release
+  tag, and a redeploy from `main` picks up whatever tag the branch holds.
+  Fork the repository, or set `FOUNTAIN_IMAGE_TAG`, and read
+  [Upgrade an instance](upgrade.md) before you move it. Migrations run at
+  boot, and Fountain does not support a downgrade.

--- a/docs/guides/operate/fly.md
+++ b/docs/guides/operate/fly.md
@@ -1,0 +1,179 @@
+# Deploy on Fly.io
+
+This guide shows you how to bring up an instance on [Fly](https://fly.io) from
+the `fly.toml` in this repository. It then shows you what to set after the
+first deploy.
+
+For a machine you control, read [Deploy an instance](deploy.md). That guide
+uses Docker Compose, and it is the shorter path.
+
+## What the file gives you
+
+[`fly.toml`](https://github.com/BinaryBourbon/fountain/blob/main/fly.toml)
+declares one machine on the published image. The machine runs the published
+image, not a build of your checkout. The file gives you an instance that runs.
+It does not describe how the hosted service runs, which is Kubernetes.
+
+Fly gives you no database. You create one in a separate step below.
+
+## Before you start
+
+Install [flyctl](https://fly.io/docs/flyctl/install/) and sign in. Then clone
+this repository. Fly reads `fly.toml` from the directory you deploy from, so a
+fork is optional here.
+
+Generate the two keys now. You paste them in a later step.
+
+```bash
+openssl rand -base64 48 | tr -d '\n'                    # SECRET_KEY_BASE
+openssl rand 32 | base64 | tr '+/' '-_' | tr -d '=\n'   # MASTER_SECRETS_KEY
+```
+
+Back `MASTER_SECRETS_KEY` up before you have data. It is not in the database.
+A database backup alone does not protect you. Read
+[Back up and restore](back-up-and-restore.md).
+
+You also need a sandbox provider token. Read
+[Self-host Fountain](../../self-hosting.md) for what each provider needs.
+
+## Create the app
+
+```bash
+fly launch --no-deploy --copy-config
+```
+
+`--copy-config` keeps the settings in `fly.toml`, and `--no-deploy` stops Fly
+before it starts a machine with no database and no keys. Answer the prompts
+with a name of your own. Fly writes that name back into `fly.toml`.
+
+## Create the database
+
+```bash
+fly mpg create
+fly mpg attach <cluster-name>
+```
+
+The attach step sets `DATABASE_URL` as a secret on the app. Managed Postgres
+serves TLS, which the app expects.
+
+The older `fly pg create` command makes an unmanaged Postgres app instead, and
+that one serves no TLS. Against one of those, set `DATABASE_SSL = "false"` in
+`fly.toml`. The file carries the line as a comment.
+
+## Set the three secrets
+
+```bash
+fly secrets set \
+  SECRET_KEY_BASE=... \
+  MASTER_SECRETS_KEY=... \
+  SPRITES_TOKEN=...
+```
+
+Fly stages a secret on an app that has no machine yet, and the first deploy
+picks all three up.
+
+| | |
+|---|---|
+| `SECRET_KEY_BASE` | The first key above. Phoenix signs the session cookie with it. |
+| `MASTER_SECRETS_KEY` | The second key above. It wraps every tenant's data encryption key. |
+| `SPRITES_TOKEN` | Your sandbox provider token. The app starts without one, and every conversation then fails. |
+
+Keep all three out of `fly.toml`. That file is in a git repository, and a
+guard test fails the build when one of these keys appears in it.
+
+## Deploy
+
+```bash
+fly deploy
+```
+
+The first deploy takes a few minutes, because the app applies the database
+migrations before it opens a listener. The health check waits 60 seconds for
+that reason.
+
+`PUBLIC_URL` is absent from `fly.toml` on purpose. The file ships with an app
+name that `fly launch` replaces, so a base URL in it names the wrong app.
+Fountain builds `https://<app>.fly.dev` from Fly's own `FLY_APP_NAME` instead,
+so the first deploy has a correct base URL.
+
+## Register the first account
+
+```bash
+fly open
+```
+
+Register on the page that opens. `fly.toml` sets `EMAIL_DELIVERY=none` and
+`FIRST_USER_ADMIN=true`, so your account self-verifies and becomes the admin.
+
+Register **before** you give the URL to anybody. While no admin exists, the
+first verified account takes the role.
+
+Then close registration.
+
+```bash
+fly secrets set REGISTRATION_ENABLED=false
+```
+
+A secret change restarts the machine on its own, so this needs no second
+`fly deploy`.
+
+## Add a custom domain
+
+```bash
+fly certs add fountain.example.com
+fly secrets set PUBLIC_URL=https://fountain.example.com
+```
+
+Set the second one. The `FLY_APP_NAME` fallback still resolves to the
+`fly.dev` address, and Fountain keeps that address in every verification email
+and in every sandbox until you replace it.
+
+## Run your own build
+
+`fly.toml` runs the published image, which is the same image the compose quick
+start runs. To run a fork with your own changes, delete the `image` line under
+`[build]`. Fly then builds the `Dockerfile` in your checkout.
+
+The build takes 15 to 25 minutes on Fly's builders. It compiles the umbrella,
+it builds the Go CLI, and it fetches the pinned Buzz binaries.
+
+## What the file does not do
+
+- **It runs one machine.** Fountain clusters over Erlang distribution, and
+  nothing on Fly discovers peers. A second machine is not a second node, and
+  two schedulers then race over the same sandboxes. Read
+  [Architecture](../../architecture.md#clustering). Scale the VM in `[[vm]]`
+  instead of the machine count, and avoid `fly scale count`.
+- **It never lets the machine park.** `auto_stop_machines` and
+  `auto_start_machines` are off, and `min_machines_running` is 1. Fly's
+  defaults park an idle machine and start it again on the next request, which
+  suits a web app. It does not suit this one. The sandbox reaper, the credit
+  pricer and every scheduled teammate run inside this process, so a parked
+  machine is an instance that quietly stops the reaper and stops the pricer.
+- **It deploys with the `rolling` strategy.** `canary` and `bluegreen` both
+  start a second machine before they retire the first, which is the split
+  brain above for the length of a deploy. `rolling` replaces the machine in
+  place, and the instance is unreachable for a few seconds.
+- **It sends no mail.** Accounts self-verify at registration in this mode
+  (ADR 0011). Read [Configure email](email.md) for a real provider.
+- **It trusts a wide proxy range.** Fly terminates TLS at its edge, so the app
+  sees the proxy and not the caller. The file sets `TRUSTED_PROXIES` to the
+  6PN range and a private IPv4 range. Only Fly's proxy reaches the machine, so
+  this is safe. Narrow it when you confirm the address that Fly forwards from.
+- **It does not back the database up.** Managed Postgres takes its own
+  snapshots. Read [Back up and restore](back-up-and-restore.md) for what a
+  restore needs, and remember that a dump alone cannot decrypt itself.
+
+## Upgrade
+
+The file pins a release tag. A push to your fork does not move the pin.
+
+Edit the tag in `fly.toml`, then deploy again.
+
+```toml
+[build]
+  image = "ghcr.io/binarybourbon/fountain:vX.Y.Z"
+```
+
+Read [Upgrade an instance](upgrade.md) first. Migrations run at boot, and
+Fountain does not support a downgrade.

--- a/docs/nav.yml
+++ b/docs/nav.yml
@@ -43,6 +43,8 @@ nav:
       - Put it on the internet: guides/operate/put-it-on-the-internet.md
       - Connect a database: guides/operate/database.md
       - Deploy on Render: guides/operate/render.md
+      - Deploy on Fly.io: guides/operate/fly.md
+      - Deploy on Coolify: guides/operate/coolify.md
       - Deploy on Kubernetes: guides/operate/kubernetes.md
       - Configure email: guides/operate/email.md
       - Change sandbox lifetimes: guides/operate/sandbox-lifetime.md

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -31,6 +31,28 @@ provider. A sandbox that already exists always stays where Fountain made it.
 [Architecture](architecture.md) says what each piece of the system does, and
 what breaks when a dependency is down.
 
+## What a host must give you
+
+Fountain is one long-lived Erlang process with a database beside it. Three
+properties decide whether a host suits it.
+
+| | |
+|---|---|
+| **One instance, and only one** | Fountain clusters over Erlang distribution, and most platforms give a service no way to discover its own peers. A second replica is not a second node. Two schedulers then race over the same sandboxes. |
+| **A process that never parks** | The sandbox reaper, the credit pricer and every scheduled teammate run inside the app process. A host that stops an idle instance stops all three, and nothing reports the loss. |
+| **Long-lived connections** | The event streams are Server-Sent Events, and one turn runs for minutes. A host with a short request limit cuts them. |
+
+Some popular hosts fail one of these, and they fail it quietly.
+
+- **Cloud Run, AWS App Runner and Lambda.** Each one scales to zero between
+  requests, and each one adds instances under load. Both behaviours break the
+  table above. An instance looks healthy and stops its own background work.
+- **Vercel, Netlify and Cloudflare Workers.** Each one runs a function per
+  request. Fountain needs a process that outlives the request.
+
+Any host that runs one container, keeps it awake and offers a Postgres works.
+Five have a guide below.
+
 ## The guides
 
 **How to stand it up.**
@@ -39,6 +61,8 @@ what breaks when a dependency is down.
 - [Put it on the internet](guides/operate/put-it-on-the-internet.md)
 - [Connect a database](guides/operate/database.md)
 - [Deploy on Render](guides/operate/render.md)
+- [Deploy on Fly.io](guides/operate/fly.md)
+- [Deploy on Coolify](guides/operate/coolify.md)
 - [Deploy on Kubernetes](guides/operate/kubernetes.md)
 
 **The decisions it forces.**

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,128 @@
+# Fountain on Fly.io — https://fly.io/docs/reference/configuration/
+#
+# This file is for somebody who wants an instance of their own on Fly. It is
+# not how the hosted service runs (that is Kubernetes, ADR 0032), so treat it
+# the way you would treat docker-compose.yml: a starting point that comes up,
+# not a description of production.
+#
+#   fly launch --no-deploy --copy-config    # keeps this file, names the app
+#   fly mpg create                          # managed Postgres
+#   fly mpg attach <cluster>                # sets DATABASE_URL
+#   fly secrets set SECRET_KEY_BASE=... MASTER_SECRETS_KEY=... SPRITES_TOKEN=...
+#   fly deploy
+#
+# Generate the two keys before you start:
+#
+#   openssl rand -base64 48 | tr -d '\n'                    # SECRET_KEY_BASE
+#   openssl rand 32 | base64 | tr '+/' '-_' | tr -d '=\n'   # MASTER_SECRETS_KEY
+#
+# The full list of what you can set afterwards is docs/configuration.md, and
+# docs/guides/operate/fly.md is the guide this file belongs to.
+
+# `fly launch` replaces this with the name you give it. Nothing else in this
+# file names the app, and Fountain reads FLY_APP_NAME for its own base URL.
+app = "fountain"
+primary_region = "iad"
+
+[build]
+  # A pinned release, deliberately not `latest`: `latest` moves on every merge
+  # to main, across breaking minors, with migrations applied at boot and
+  # downgrade unsupported. Upgrade by editing this tag. Releases publish
+  # vX.Y.Z (immutable) and vX.Y (newest patch in the line).
+  #
+  # To run your own build of a fork instead of the published image, delete the
+  # `image` line and let Fly build the Dockerfile in this checkout. The build
+  # compiles the umbrella, the Go CLI and fetches the pinned Buzz binaries, so
+  # prefer the image unless you have changes to run.
+  image = "ghcr.io/binarybourbon/fountain:v0.14.0"
+
+# Migrations run at boot, inside the app's own start sequence, and the
+# endpoint does not listen until they finish. There is deliberately no
+# `[deploy] release_command`: a release machine would run the same migrations
+# a few seconds earlier, against the same database, for no gain.
+[deploy]
+  # Rolling, and not the two strategies that read as safer. `canary` and
+  # `bluegreen` both bring a second machine up before taking the first one
+  # down, and for those seconds two schedulers hold the same sandboxes (see
+  # the machine count below). Rolling stops a machine, replaces it, and waits
+  # for the health check, so one instance stays one instance across a deploy.
+  strategy = "rolling"
+
+[env]
+  PHX_SERVER = "true"
+
+  # Fly's proxy sends to whatever `internal_port` says. The image defaults to
+  # 4000, so this has to be explicit rather than inherited.
+  PORT = "8080"
+
+  # Fly terminates TLS at its edge and forwards over the private network, so
+  # the app sees the proxy rather than the caller. Left unset, the built-in
+  # defaults are cluster CIDRs that match nothing here, every per-IP
+  # rate-limit bucket collapses into one, and every audit row records the
+  # proxy's address. fdaa::/16 is the 6PN range Fly gives an organization;
+  # the IPv4 range covers a proxy that reaches the machine over the host.
+  TRUSTED_PROXIES = "fdaa::/16,172.16.0.0/12"
+
+  # Credits (ADR 0031) price the hosted service. On your own instance they are
+  # a lock with no key.
+  CREDITS_ENABLED = "false"
+
+  # No mail, so a first deploy needs nothing external. Accounts self-verify at
+  # registration in this mode (ADR 0011). For real mail set RESEND_API_KEY or
+  # SMTP_HOST, and EMAIL_FROM, with `fly secrets set`.
+  EMAIL_DELIVERY = "none"
+
+  # Open so the first account can be created, and the first verified account
+  # becomes admin. Register before you hand the URL to anybody, then set this
+  # to false and deploy again.
+  REGISTRATION_ENABLED = "true"
+  FIRST_USER_ADMIN = "true"
+
+  # There is no OTLP collector in a default Fly setup, and without this the
+  # exporter retries per span and floods the logs.
+  OTEL_TRACES_EXPORTER = "none"
+
+  # PUBLIC_URL is deliberately absent, and unlike Render this is not a
+  # chicken-and-egg problem — `<app>.fly.dev` is known the moment you pick the
+  # name. It is absent because this file ships with a name you are about to
+  # change, and a stale base URL is silently wrong rather than broken: it
+  # builds the links in verification emails and every sandbox reads it as
+  # FOUNTAIN_BASE_URL. config/runtime.exs derives https://$FLY_APP_NAME.fly.dev
+  # instead. Set PUBLIC_URL here when you add a custom domain, and it wins.
+
+  # Fly's managed Postgres serves TLS, which the app expects by default. The
+  # older unmanaged `fly pg create` app does not serve TLS at all, and against
+  # one of those the app cannot connect until you uncomment this:
+  #   DATABASE_SSL = "false"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+
+  # One machine, on purpose. Fountain clusters over Erlang distribution and
+  # nothing here discovers peers, so a second machine is not a second node —
+  # it is a split brain, with two schedulers racing over the same sandboxes.
+  # Scale the VM below, not the count, and do not run `fly scale count`.
+  #
+  # These two lines are the whole reason this file exists. Fly's defaults stop
+  # an idle machine and start it again on a request, which is right for a web
+  # app and wrong here: the sandbox reaper, the credit pricer and every
+  # scheduled teammate run inside this process, so a parked machine is an
+  # instance that quietly stops reaping and stops pricing.
+  auto_stop_machines = "off"
+  auto_start_machines = false
+  min_machines_running = 1
+
+  [[http_service.checks]]
+    # Fly gates traffic on this, which is a readiness question. /health is
+    # static and would pass with an unreachable database.
+    path = "/health/ready"
+    interval = "15s"
+    timeout = "5s"
+    # Boot runs migrations before the endpoint listens. Do not count failures
+    # against the machine while that is still happening.
+    grace_period = "60s"
+
+[[vm]]
+  size = "shared-cpu-2x"
+  memory = "2gb"


### PR DESCRIPTION
Render got a blueprint in #1244. This is the rest of the shortlist: the two platforms worth the same affordance, and the one thing that is worth more than a fourth config file.

## `fly.toml`

The largest audience overlap Fountain has, since Fly is the default answer for "where do I put a Phoenix app". The file is not a translation of `render.yaml` though, because **Fly's defaults are the two things that break this app**:

- `auto_stop_machines` parks an idle machine. Every scheduler runs inside the app process, so a parked instance quietly stops reaping sandboxes and stops pricing turns. Nothing reports it.
- `canary` and `bluegreen` bring a second machine up before retiring the first, and two machines are two schedulers racing over the same sandboxes.

So `auto_stop_machines`, `auto_start_machines`, `min_machines_running` and `strategy = "rolling"` are pinned, with the reason next to each, and a guard test holds all four. That test is most of the value here.

`PUBLIC_URL` is absent for a different reason than on Render. The hostname is knowable on Fly, but this file ships with an app name `fly launch` replaces, so a committed base URL names the wrong app — silently wrong, not broken, since it builds verification links and every sandbox's `FOUNTAIN_BASE_URL`. `runtime.exs` derives `https://$FLY_APP_NAME.fly.dev` behind an operator's own `PUBLIC_URL`, joining the same list `RENDER_EXTERNAL_URL` sits in.

`FLY_APP_NAME` was already read for an OTel resource attribute and sat on `config_reference_test`'s exemption list. It builds an operator-visible URL now, so it gets a row in the reference like `RENDER_EXTERNAL_URL` has — and that exemption list is now empty and deleted.

## Coolify and Dokploy: no new file

Both deploy a compose file from a git repository, and this repo has one. The guide is the five values to set in the interface and the two compose defaults a public server must not keep: the published Postgres port with its default password, and a `PUBLIC_URL` left at `http://localhost:4000`, which is a value rather than an absence.

## What a host must give you

The part that was never written down: one instance and only one, a process that never parks, long-lived connections. Cloud Run, App Runner, Lambda, Vercel, Netlify and Cloudflare Workers each fail one of those and fail it quietly — an instance that scales to zero looks healthy while it stops its own housekeeping. Naming them costs four sentences and prevents the worst first impression the project can make.

The README never mentioned `render.yaml` at all. It does now, with `fly.toml` and the scale-to-zero warning.

## Guards, checked by breaking each one

| Guard | Breaks when |
|---|---|
| every `[env]` key is a var the app reads | a knob wired to nothing |
| no secret in `[env]` | `SPRITES_TOKEN` committed to git |
| the four single-instance lines | a parked or duplicated machine |
| `/health/ready` health check | traffic to a machine with no database |
| no `PUBLIC_URL` in `[env]` | the `FLY_APP_NAME` fallback goes out of reach |
| `fly.toml` in `release_pin_test` + `release-bump.yml` | a pin left two releases behind |

`toml` also joins the baked highlighter parsers. The Fly guide is the first page to quote a `fly.toml`, `markdown_test` caught the fence, and Lumis has a real parser, so the list grew rather than the fence lying about its language.

## Deliberately left out

- **A "Deploy to Render" button.** `render.md` says the blueprint needs a fork, and I could not verify the public-repo button flow against that. A button that lands on an error is worse than none. Worth 60 seconds from somebody with a Render account.
- **DigitalOcean App Platform.** The closest structural twin to Render (`.do/app.yaml` declares the service and its database, and its deploy button needs no fork), but the marginal one of the three by audience. Say the word and it is a small follow-up.
- **Railway.** Big audience, but its affordance is a dashboard-defined template, not a repo file — so the thing that rots would live outside CI's reach, which is the opposite of the property that makes `render.yaml` safe.
- **Heroku, a Helm chart.** Shrinking audience; a second Kubernetes surface duplicating `deploy/k8s`.

## Verification

- `mix test` 4,125 tests, 0 failures (full suite, twice — before and after the `toml` fix).
- `mix credo --strict` no issues; `mix format --check-formatted` clean.
- Three prose gates clean: `docs-style.py`, `vale lint docs` (0 errors, 0 warnings), `destink`.
- Each new guard verified by breaking it and watching the right test fail.
- **Not verified against live platforms.** I have no Fly or Coolify account here. The Fly file is checked against Fly's config reference and the app's own requirements; the command sequence in both guides is unrun. Worth one real deploy each before anybody relies on them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RuL8Uq7dMkG6dyq6Ag2LRV