### PR TITLE
copy: rework the problem lead-in, cut the teammate contact section

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -663,34 +663,6 @@
   </div>
 </section>
 
-<%!-- The teammate contact. Deep on the page on purpose. It is the most
-      quotable thing here and the only one gated on asking us, so down here it
-      reads as a bonus rather than a barrier on the way in. --%>
-<section class="max-w-5xl mx-auto px-6 py-16">
-  <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-6 text-center">
-    Give one a phone number.
-    <span class="ml-1 align-middle inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide bg-[var(--color-bg-2)] text-[var(--color-text-muted)]">
-      Alpha
-    </span>
-  </h2>
-  <div class="max-w-2xl mx-auto space-y-4 text-center text-[var(--color-text-secondary)]">
-    <p>
-      An agent can hold an email address and a number of its own. A message to either arrives as a prompt in its thread, on the same machine it has been working on all week, and the reply goes back the same way. Your product gets an inbound channel, and you do not run an inbox.
-    </p>
-    <p>
-      {Fountain.Brand.name()} holds the keys to that inbox and that number. The sandbox is handed tools, and never a credential.
-    </p>
-    <p :if={pricing?() and rent_line()} class="text-sm text-[var(--color-text-muted)]">
-      A contact rents from your balance. {String.capitalize(rent_line())}, a month up front.
-    </p>
-    <p class="text-xs text-[var(--color-text-muted)]">
-      Ask us and we turn it on for your account. On your own instance, set the AgentMail and AgentPhone keys. Then add
-      <code class="text-xs px-1 py-0.5 rounded bg-[var(--color-bg-2)]">team_comms</code>
-      to <code class="text-xs px-1 py-0.5 rounded bg-[var(--color-bg-2)]">FEATURE_FLAGS_ON</code>.
-    </p>
-  </div>
-</section>
-
 <%!-- Lane three's section on the homepage. One question sorts the reader, and
       the runner concession sits beside the runner claim rather than a page
       away, because the hero promises a boundary and a runner has none. --%>

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -58,7 +58,7 @@
       You did not set out to run a sandbox platform.
     </h2>
     <p class="text-center text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-10">
-      Harnesses are not the scarce part. There are dozens, and {Fountain.Brand.name()} runs four of them behind one API. The scarce part is everything under the harness, and it arrives as six questions between a demo on your laptop and a feature in front of your users.
+      The agent was the easy part. Under it sits a machine to build, a credential that must never reach the prompt, and a lifecycle somebody has to own. Six questions stand between a demo on your laptop and a feature in front of your users, and not one of them is what your users came for.
     </p>
     <div class="grid sm:grid-cols-2 gap-6">
       <div class="p-5 rounded-lg bg-[var(--color-bg)] border border-[var(--color-border)]">


### PR DESCRIPTION
## What

The paragraph that leads into the six-question grid on the homepage read:

> Harnesses are not the scarce part. There are dozens, and Managoat runs four of them behind one API. The scarce part is everything under the harness, and it arrives as six questions between a demo on your laptop and a feature in front of your users.

It now reads:

> The agent was the easy part. Under it sits a machine to build, a credential that must never reach the prompt, and a lifecycle somebody has to own. Six questions stand between a demo on your laptop and a feature in front of your users, and not one of them is what your users came for.

## Why

- **"Dozens, and we run four" reads as a shortfall.** The sentence was trying to say the harness is commodity, but the arithmetic on the page says we cover a third of it.
- **It argued about harnesses in a section that is not about harnesses.** The H2 above it is "You did not set out to run a sandbox platform" and the six cards below it are the machine, the credential, the egress, the reply shape, the lifecycle and the trigger. The lead-in now previews three of those instead of relitigating the runtime.
- **It ends on the reader.** "Not one of them is what your users came for" is the argument the section is making.

Nothing is lost by dropping the count. The four-runtimes-behind-one-API claim is still made further down the same page, in the "one seam over the runtimes and the sandbox providers" section, where it is the point rather than an aside.

## Test

Copy-only, one line in one template. The two tests that assert on this section pin the H2 (`brand_chrome_test.exs`, `marketing_instance_test.exs`), which is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176oj6fYqofyFL5nVZvk7q9

---

## Second commit: cut the teammate contact section

`Give one a phone number.` came off the homepage whole. It was the most quotable block on the page and the least available: alpha, behind `team_comms`, and turned on only by asking us. Placing it deep was meant to read as a bonus, but it still asks a first-time reader to hold a feature they cannot switch on.

- The price card's contact line stays, guarded by `rent_line()` exactly as before. `CREDIT_NUMBER_CENTS` and `CREDIT_INBOX_CENTS` have no default, so nothing about contacts renders on a stock install.
- `rent_line/0` keeps its other caller in the price card, so no helper goes unused and the compile stays clean under `--warnings-as-errors`.
- The badge legend in the protocols section stays: OpenAI chat completions is now the page's only Alpha.

`marketing_pricing_test.exs`, `marketing_instance_test.exs` and `brand_chrome_test.exs` pass (28 tests, 0 failures).
