### PR TITLE
feat(marketing): one page for the questions, at /faq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,22 @@ upgrade, is in
 
 ### Added
 
+- **One page for the questions, at `/faq`.** Three marketing pages carried a
+  question-shaped block at the bottom, and a reader with a question had to
+  guess which page it sat on. They are one page now, grouped into building on
+  it, what it costs, security and data, and running it yourself, linked from
+  the footer. The homepage keeps its six-question grid, which is the problem
+  statement rather than an FAQ, and its two other blocks moved whole: the
+  security answers (`security_answers/0`, with every limit still stated beside
+  the answer it limits, and the "what we do not have" list still with them)
+  and the objections, now `build_faq/0`. `/self-hosted` section 08 moved the
+  same way, still `self_host_faq/0`. Both pages link back to their section by
+  anchor rather than repeating the copy, and the suite asserts those anchors
+  exist. On a deployment that bills, a billing section reads the same price
+  card the ledger burns at, so the page cannot quote a rate the meter does not
+  charge. Off the marketing site `/faq` redirects into the manual, like the
+  other sales pages.
+
 - **A Fly blueprint, and a name for the hosts that do not work.** `fly.toml`
   declares one machine on the published image, defaulted the way compose and
   `render.yaml` are, and the guide at `/docs/guides/operate/fly` attaches a

--- a/apps/fountain/lib/fountain_web/components/layouts/marketing.html.heex
+++ b/apps/fountain/lib/fountain_web/components/layouts/marketing.html.heex
@@ -130,6 +130,16 @@
                 Docs
               </a>
             </li>
+            <%!-- The FAQ redirects into the manual off the marketing site, so
+                  the link is gated the same way its neighbours are. --%>
+            <li :if={Fountain.Marketing.site?()}>
+              <a
+                href={~p"/faq"}
+                class="hover:text-[var(--color-text-primary)] transition-colors"
+              >
+                Questions
+              </a>
+            </li>
             <li :if={Fountain.Marketing.site?()}>
               <a
                 href={~p"/self-hosted"}

--- a/apps/fountain/lib/fountain_web/controllers/marketing_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_controller.ex
@@ -1,13 +1,13 @@
 defmodule FountainWeb.MarketingController do
   @moduledoc """
   The public pages: `/`, `/integrations`, `/built-with`, `/self-hosted`,
-  `/code-review-bot`, `/case-studies/*`, `/terms` and `/privacy`.
+  `/faq`, `/code-review-bot`, `/case-studies/*`, `/terms` and `/privacy`.
 
   None of them is the same page on every deployment. `/` serves the
   product pitch on the marketing site and a plain front door everywhere else
   (`Fountain.Marketing`); `/integrations`, `/built-with`, `/self-hosted`,
-  `/code-review-bot` and the case studies are the pitch's other pages and
-  redirect into the manual on any other instance;
+  `/faq`, `/code-review-bot` and the case studies are the pitch's other pages
+  and redirect into the manual on any other instance;
   the legal pages render the operator's identity, or nothing at all
   (`Fountain.Legal`). A deployment is not the Fountain project, and these
   pages are the ones that would claim otherwise.
@@ -35,6 +35,26 @@ defmodule FountainWeb.MarketingController do
       )
     else
       redirect(conn, to: ~p"/docs/integrations/clients")
+    end
+  end
+
+  # Every question-shaped block on the site, in one place. The homepage keeps
+  # its six-question grid, which is the problem statement rather than an FAQ;
+  # the security answers and the self-hosting objections moved here whole and
+  # those pages link in by anchor. Sales copy, so it follows `/`.
+  def faq(conn, _params) do
+    if Fountain.Marketing.site?() do
+      render(conn, :faq,
+        layout: {FountainWeb.Layouts, :marketing},
+        page_title: "Questions · #{Fountain.Brand.name()}",
+        meta_description:
+          "What a developer, a buyer and a security reviewer ask before building " <>
+            "on #{Fountain.Brand.name()}: model keys, what a sandbox does between " <>
+            "messages, tenant isolation, what it costs, what we do not have, and " <>
+            "what it takes to run the whole thing yourself."
+      )
+    else
+      redirect(conn, to: ~p"/docs")
     end
   end
 

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
@@ -1102,6 +1102,207 @@ defmodule FountainWeb.MarketingHTML do
     ]
   end
 
+  ## ─── /faq ─────────────────────────────────────────────────────────────────
+  #
+  # One page for the questions that used to sit at the bottom of three others.
+  # The homepage kept its six-question grid, because that grid is the problem
+  # statement rather than an FAQ, and every other question-shaped block on the
+  # site now lives here.
+  #
+  # The sections are data so the page cannot drift from the blocks it
+  # replaced: `security_answers/0` and `self_host_faq/0` are the same
+  # functions those pages rendered, and `build_faq/0` is the homepage's
+  # objection list moved rather than rewritten. Edit an answer once and both
+  # the page and the tests that assert on it follow.
+
+  @doc """
+  The questions a builder asks before committing, moved off the homepage.
+
+  Was `<dl>` markup inline in `home.html.heex` under "Things you would ask
+  before building on it". It is data now because two pages want it and
+  because the test suite can walk it.
+  """
+  def build_faq do
+    [
+      %{
+        q: "Do I need a model key?",
+        a:
+          "Yes. Bring an Anthropic, OpenAI or Google key and the agent bills your own " <>
+            "account for tokens. #{Fountain.Brand.name()} charges for the sandbox hours, " <>
+            "never for inference, so there is no markup on the model.",
+        docs: "concepts/vault",
+        docs_label: "Where a key lives"
+      },
+      %{
+        q: "I have no API key. I pay for Claude.",
+        a:
+          "That is a credential #{Fountain.Brand.name()} accepts. A Claude Pro or Team " <>
+            "subscription works in place of a metered API key, and when you hold both, " <>
+            "the subscription is the one your agents spend. It is usually the one you " <>
+            "want spent."
+      },
+      %{
+        q: "My product has users. Do they each need an account here?",
+        a:
+          "Usually not. Your account holds the agents and the key, and each of your " <>
+            "users gets their own conversation on their own machine, keyed by an id you " <>
+            "already have for them. When you would rather they held their own account " <>
+            "and their own model key, Sign in with #{Fountain.Brand.name()} is OAuth " <>
+            "with PKCE and the token it hands back is an ordinary API key.",
+        docs: "build",
+        docs_label: "Build a chat app"
+      },
+      %{
+        q: "Is this only good for writing code?",
+        a:
+          "The runtimes are coding agents, which is to say a shell, a filesystem and a " <>
+            "network. One of the applications we built on it runs Python over a CSV you " <>
+            "drop in. Another reads real sources and hands back a cited brief. If you " <>
+            "would do the job at a terminal, it fits here."
+      },
+      %{
+        q: "What happens to the sandbox between messages?",
+        a:
+          "It parks. The filesystem, the checkout and the agent's memory survive, a " <>
+            "parked sandbox costs nothing, and it takes none of your concurrency. The " <>
+            "next message wakes it in seconds instead of minutes.",
+        docs: "concepts/sandboxes",
+        docs_label: "About sandboxes"
+      },
+      %{
+        q: "Is my work separate from everyone else's?",
+        a:
+          "Every query is scoped to your account, every sandbox belongs to one " <>
+            "conversation unless you put another on it, and your secrets are encrypted " <>
+            "with a key derived for your tenant alone.",
+        docs: "architecture",
+        docs_label: "Architecture"
+      },
+      %{
+        q: "Can I run it myself?",
+        a: run_it_yourself_answer(),
+        docs: "self-hosting",
+        docs_label: "Self-host it"
+      }
+    ]
+  end
+
+  # The one answer that changes with the deployment. A branded hosted site
+  # says which of the two things it is; an unbranded install just says the
+  # engine is open source.
+  defp run_it_yourself_answer do
+    lead =
+      if Fountain.Brand.hosted?() do
+        "#{Fountain.Brand.name()} is the hosted edition of #{Fountain.Brand.engine()}, " <>
+          "an open-source server"
+      else
+        "#{Fountain.Brand.engine()} is open source"
+      end
+
+    "Yes. #{lead}, and you can run it on your own hardware, with your own sandboxes. " <>
+      "Nothing is held back for the people who pay."
+  end
+
+  @doc """
+  The billing questions, on a deployment that bills.
+
+  Every number comes from the price card the ledger burns at, so the page
+  cannot quote a rate the meter does not charge (ADR 0030).
+  """
+  def billing_faq do
+    {opening, days} = opening_credit()
+
+    [
+      %{
+        q: "What am I actually charged for?",
+        a:
+          "Agent time, at #{turn_hour_price()} an hour. An hour means an hour with a " <>
+            "prompt in flight, so a parked agent, an idle one and one running on your " <>
+            "own machine cost nothing. Two agents working for an hour on the same " <>
+            "machine are two hours."
+      },
+      %{
+        q: "Is there a plan, a seat or a subscription?",
+        a:
+          "None of the three. You hold a balance, work spends it, and you buy more " <>
+            "when you want more. New accounts start with #{opening} that expires in " <>
+            "#{days} days; credit you buy never expires."
+      },
+      %{
+        q: "What happens when the balance runs out?",
+        a:
+          "New work pauses and nothing dies. A new conversation or a new prompt is " <>
+            "refused until there is credit again, a turn already in flight finishes, " <>
+            "and your agents, environments and vaults are all still there.",
+        docs: "guides/operate/billing",
+        docs_label: "How billing works"
+      },
+      %{
+        q: "Do you take a cut of what the model costs?",
+        a:
+          "No. The key is yours and the model bills you directly. #{Fountain.Brand.name()} " <>
+            "never sees that invoice and never adds to it."
+      }
+    ]
+  end
+
+  @doc """
+  The FAQ page, grouped into sections.
+
+  Sections carry an `:id` because the pages that used to hold these blocks now
+  link to them by anchor. Renaming one breaks an inbound link, so the suite
+  asserts the anchors the other pages point at.
+  """
+  def faq_sections do
+    building = [
+      %{
+        id: "building",
+        title: "Building on it",
+        blurb: "What a developer asks between reading the tour and writing the first call.",
+        items: build_faq()
+      }
+    ]
+
+    billing =
+      if pricing?() do
+        [
+          %{
+            id: "billing",
+            title: "What it costs",
+            blurb: "Read from the same price card the ledger burns at.",
+            items: billing_faq()
+          }
+        ]
+      else
+        []
+      end
+
+    security = [
+      %{
+        id: "security",
+        title: "Security and data",
+        blurb:
+          "Each answer names a mechanism rather than an intention, and each limit is " <>
+            "stated beside the thing it limits.",
+        items:
+          Enum.map(security_answers(), fn item ->
+            %{q: item.question, a: item.answer, note: item.limit}
+          end)
+      }
+    ]
+
+    self_hosting = [
+      %{
+        id: "self-hosting",
+        title: "Running it yourself",
+        blurb: "The questions somebody asks between reading the page and running the clone.",
+        items: self_host_faq()
+      }
+    ]
+
+    building ++ billing ++ security ++ self_hosting
+  end
+
   ## /case-studies/self-healing-infrastructure
 
   # The case study is data first, like /integrations above. Every number here

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/faq.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/faq.html.heex
@@ -1,0 +1,122 @@
+<%!-- Hero. Chips are the table of contents, because a reader arrives here
+      from a link on another page that already told them which section they
+      want. --%>
+<section class="max-w-5xl mx-auto px-6 py-20 text-center">
+  <p class="mb-4 text-sm font-medium uppercase tracking-wide text-[var(--color-text-muted)]">
+    Questions
+  </p>
+  <h1 class="text-4xl sm:text-5xl font-bold tracking-tight text-[var(--color-text-primary)] mb-5 leading-tight">
+    Answers, with the limits attached.
+  </h1>
+  <p class="text-lg sm:text-xl text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-10">
+    Everything a developer, a buyer and a security reviewer ask before building on {Fountain.Brand.name()}, in one place. Where an answer has a limit, the limit is on the page beside it rather than in a questionnaire three weeks later.
+  </p>
+  <div class="flex flex-wrap gap-2 justify-center" data-role="faq-chips">
+    <a
+      :for={section <- faq_sections()}
+      href={"##{section.id}"}
+      class="inline-flex items-center gap-1.5 rounded-full border border-[var(--color-border)] px-3 py-1 text-sm text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-2)] transition-colors"
+    >
+      <span class="size-1.5 rounded-full bg-[var(--color-brand)]"></span>
+      {section.title}
+    </a>
+  </div>
+</section>
+
+<%!-- The sections. Every answer is open rather than collapsed: this page is
+      the one a reader forwards to somebody else, and a colleague who opens
+      the link should see the answers rather than seven closed rows. --%>
+<section
+  :for={{section, index} <- Enum.with_index(faq_sections())}
+  id={section.id}
+  class={[
+    "scroll-mt-6",
+    rem(index, 2) == 0 && "bg-[var(--color-bg-1)] border-y border-[var(--color-border)]"
+  ]}
+  data-role="faq-section"
+>
+  <div class="max-w-5xl mx-auto px-6 py-16">
+    <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-3">
+      {section.title}
+    </h2>
+    <p class="text-[var(--color-text-secondary)] max-w-2xl mb-10">
+      {section.blurb}
+    </p>
+    <dl class="max-w-3xl space-y-8">
+      <div :for={item <- section.items} data-role="faq-item">
+        <dt class="font-medium text-[var(--color-text-primary)]">{item.q}</dt>
+        <dd class="mt-1 text-sm text-[var(--color-text-secondary)] leading-relaxed">
+          {item.a}
+        </dd>
+        <%!-- The stated limit, on the answers that have one. A reviewer who
+              finds an unstated limit stops believing the answers above it. --%>
+        <dd
+          :if={item[:note]}
+          class="mt-1 text-sm text-[var(--color-text-muted)] leading-relaxed"
+        >
+          {item[:note]}
+        </dd>
+        <%!-- A plain string for the href, not `~p`: a verified route escapes
+              the slash in a multi-segment slug and the link 404s. --%>
+        <dd :if={item[:docs]} class="mt-2 text-sm">
+          <a
+            href={"/docs/#{item[:docs]}"}
+            class="text-[var(--color-brand)] hover:underline"
+          >
+            {item[:docs_label]}
+          </a>
+        </dd>
+      </div>
+    </dl>
+
+    <%!-- What we do not have, kept inside the security section it belongs to
+          and never softened into "coming soon". Every row was verified absent
+          from the repo. --%>
+    <div
+      :if={section.id == "security"}
+      class="max-w-3xl mt-10 rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6"
+      data-role="security-absent"
+    >
+      <h3 class="font-semibold text-[var(--color-text-primary)] mb-2">
+        What we do not have.
+      </h3>
+      <p class="text-sm text-[var(--color-text-secondary)] leading-relaxed mb-4">
+        Here rather than in week three of your review.
+      </p>
+      <ul class="space-y-3 text-sm text-[var(--color-text-secondary)]">
+        <li :for={item <- security_absent()} class="flex items-start gap-3">
+          <span class="mt-1.5 size-1.5 rounded-full bg-[var(--color-text-muted)] flex-shrink-0">
+          </span>
+          <span>{item}</span>
+        </li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<%!-- Footer CTA. The manual is the deeper answer to most of the above, so it
+      gets equal billing with the sign-up. --%>
+<section class="bg-[var(--color-bg-2)] border-t border-[var(--color-border)]">
+  <div class="max-w-5xl mx-auto px-6 py-20 text-center">
+    <h2 class="text-3xl font-bold tracking-tight text-[var(--color-text-primary)] mb-4">
+      Still holding a question?
+    </h2>
+    <p class="text-[var(--color-text-secondary)] max-w-xl mx-auto mb-8">
+      The manual answers in more depth than a page like this can, and the server it describes is open source, so the last word is always the code.
+    </p>
+    <div class="flex flex-col sm:flex-row gap-3 justify-center">
+      <a
+        href={~p"/auth/register"}
+        class="inline-flex items-center justify-center px-6 py-3 rounded-lg bg-[var(--color-brand)] text-white font-medium hover:bg-[var(--color-brand-hover)] transition-colors text-sm"
+      >
+        Run your first agent free
+      </a>
+      <a
+        href={~p"/docs"}
+        class="inline-flex items-center justify-center px-6 py-3 rounded-lg border border-[var(--color-border)] text-[var(--color-text-primary)] font-medium hover:bg-[var(--color-bg-2)] transition-colors text-sm"
+      >
+        Read the manual
+      </a>
+    </div>
+  </div>
+</section>

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -524,70 +524,24 @@
   </div>
 </section>
 
-<%!-- The security review, answered on the page rather than in a questionnaire.
-      A builder cannot ship an agent without somebody asking where the customer
-      data went, and the material for that answer was scattered across three
-      feature bullets before this section existed.
-
-      Two rules hold this section together. Every answer names the mechanism
-      rather than the intention, which is the case study's "the mechanism that
-      stops it is not a system prompt" applied to the platform. And every
-      answer that has a limit states it in the same breath, because a security
-      reader who finds the limit themselves stops believing the rest.
-
-      `security_answers/0` and `security_absent/0` carry the copy. The second
-      is the list of things this platform does not have, and it is on the page
-      on purpose: a reviewer asks for a SOC 2 report in week one, and finding
-      out then is cheaper for both sides than finding out in a questionnaire.
-      Do not soften it into "coming soon", and do not add a row to it that is
-      not verified absent. --%>
+<%!-- The security review moved to /faq whole. What stays here is the promise
+      and the link, because a reader who is going to forward an answer wants
+      one URL to forward rather than a homepage anchor. `security_answers/0`
+      and `security_absent/0` render there now. --%>
 <section class="bg-[var(--color-bg-1)] border-y border-[var(--color-border)]">
-  <div class="max-w-5xl mx-auto px-6 py-16">
-    <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-3 text-center">
+  <div class="max-w-5xl mx-auto px-6 py-16 text-center">
+    <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-3">
       The part you forward to your security reviewer.
     </h2>
-    <p class="text-center text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-10">
-      Putting an agent in front of your users means somebody asks where the credentials sit, what the model can see and what lands in the logs. Here are the answers, each one a mechanism rather than an intention, and each limit stated beside the thing it limits.
+    <p class="text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-8">
+      Putting an agent in front of your users means somebody asks where the credentials sit, what the model can see and what lands in the logs. Those answers are written down, each one a mechanism rather than an intention, each limit stated beside the thing it limits, and the things this platform does not have listed with them.
     </p>
-    <dl class="max-w-3xl mx-auto space-y-6" data-role="security-answers">
-      <div :for={item <- security_answers()}>
-        <dt class="font-medium text-[var(--color-text-primary)]">{item.question}</dt>
-        <dd class="mt-1 text-sm text-[var(--color-text-secondary)] leading-relaxed">
-          {item.answer}
-        </dd>
-        <dd :if={item.limit} class="mt-1 text-sm text-[var(--color-text-muted)] leading-relaxed">
-          {item.limit}
-        </dd>
-      </div>
-    </dl>
-    <div class="max-w-3xl mx-auto mt-10 rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6">
-      <h3 class="font-semibold text-[var(--color-text-primary)] mb-2">
-        What we do not have.
-      </h3>
-      <p class="text-sm text-[var(--color-text-secondary)] leading-relaxed mb-4">
-        Here rather than in week three of your review.
-      </p>
-      <ul class="space-y-3 text-sm text-[var(--color-text-secondary)]">
-        <li :for={item <- security_absent()} class="flex items-start gap-3">
-          <span class="mt-1.5 size-1.5 rounded-full bg-[var(--color-text-muted)] flex-shrink-0">
-          </span>
-          <span>{item}</span>
-        </li>
-      </ul>
-    </div>
-    <p class="text-center text-sm text-[var(--color-text-muted)] mt-8">
-      The manual goes further on
-      <a
-        href={~p"/docs/concepts/secrets"}
-        class="underline underline-offset-2 hover:text-[var(--color-text-primary)]"
-      >
-        where a secret comes from
-      </a>
-      and on <a
-        href={~p"/docs/concepts/permissions"}
-        class="underline underline-offset-2 hover:text-[var(--color-text-primary)]"
-      >what happens before a tool runs</a>.
-    </p>
+    <a
+      href={~p"/faq#security"}
+      class="inline-flex items-center justify-center px-5 py-2.5 rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-0)] text-[var(--color-text-primary)] text-sm font-medium hover:bg-[var(--color-bg-2)] transition-colors"
+    >
+      Read the security answers
+    </a>
   </div>
 </section>
 
@@ -698,77 +652,23 @@
   </div>
 </section>
 
-<%!-- Objections --%>
-<section class="max-w-5xl mx-auto px-6 py-16">
-  <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-10 text-center">
+<%!-- The objections moved to /faq as `build_faq/0`. A single link replaces
+      the list, so the page runs from the pitch to the call to action without
+      a seven-row detour, and the answers live where the buying and security
+      questions are. --%>
+<section class="max-w-5xl mx-auto px-6 py-16 text-center">
+  <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-3">
     Things you would ask before building on it.
   </h2>
-  <dl class="max-w-2xl mx-auto space-y-6 text-[var(--color-text-secondary)]">
-    <div>
-      <dt class="font-medium text-[var(--color-text-primary)]">Do I need a model key?</dt>
-      <dd class="mt-1 text-sm leading-relaxed">
-        Yes. Bring an Anthropic, OpenAI or Google key and the agent bills your own account for tokens. {Fountain.Brand.name()} charges for the sandbox hours, never for inference, so there is no markup on the model.
-      </dd>
-    </div>
-
-    <div>
-      <dt class="font-medium text-[var(--color-text-primary)]">
-        I have no API key. I pay for Claude.
-      </dt>
-      <dd class="mt-1 text-sm leading-relaxed">
-        That is a credential {Fountain.Brand.name()} accepts. A Claude Pro or Team subscription works in place of a metered API key, and when you hold both, the subscription is the one your agents spend. It is usually the one you want spent.
-      </dd>
-    </div>
-    <%!-- The one a builder asks first and the page owes an honest answer to.
-          There are no organisations and no seats (see the limits section), so
-          say plainly which of the two shapes they get rather than implying a
-          multi-tenant model that does not exist. --%>
-    <div>
-      <dt class="font-medium text-[var(--color-text-primary)]">
-        My product has users. Do they each need an account here?
-      </dt>
-      <dd class="mt-1 text-sm leading-relaxed">
-        Usually not. Your account holds the agents and the key, and each of your users gets their own conversation on their own machine, keyed by an id you already have for them. When you would rather they held their own account and their own model key, Sign in with {Fountain.Brand.name()} is OAuth with PKCE and the token it hands back is an ordinary API key.
-      </dd>
-    </div>
-    <div>
-      <dt class="font-medium text-[var(--color-text-primary)]">
-        Is this only good for writing code?
-      </dt>
-      <dd class="mt-1 text-sm leading-relaxed">
-        The runtimes are coding agents, which is to say a shell, a filesystem and a network. One of the apps above runs Python over a CSV you drop in. Another reads real sources and hands back a cited brief. If you would do the job at a terminal, it fits here.
-      </dd>
-    </div>
-    <div>
-      <dt class="font-medium text-[var(--color-text-primary)]">
-        What happens to the sandbox between messages?
-      </dt>
-      <dd class="mt-1 text-sm leading-relaxed">
-        It parks. The filesystem, the checkout and the agent's memory survive, a parked sandbox costs nothing, and it takes none of your concurrency. The next message wakes it in seconds instead of minutes.
-      </dd>
-    </div>
-    <div>
-      <dt class="font-medium text-[var(--color-text-primary)]">
-        Is my work separate from everyone else's?
-      </dt>
-      <dd class="mt-1 text-sm leading-relaxed">
-        Every query is scoped to your account, every sandbox belongs to one conversation unless you put another on it, and your secrets are encrypted with a key derived for your tenant alone.
-      </dd>
-    </div>
-    <div>
-      <dt class="font-medium text-[var(--color-text-primary)]">Can I run it myself?</dt>
-      <dd class="mt-1 text-sm leading-relaxed">
-        Yes.
-        <span :if={Fountain.Brand.hosted?()}>
-          {Fountain.Brand.name()} is the hosted edition of {Fountain.Brand.engine()}, an open-source server
-        </span>
-        <span :if={!Fountain.Brand.hosted?()}>{Fountain.Brand.engine()} is open source</span>, and you can run it on your own hardware, with your own sandboxes. Nothing is held back for the people who pay. <a
-          href={~p"/self-hosted"}
-          class="underline underline-offset-2 hover:text-[var(--color-text-primary)]"
-        >See the case for running it yourself</a>.
-      </dd>
-    </div>
-  </dl>
+  <p class="text-[var(--color-text-secondary)] max-w-xl mx-auto mb-8">
+    Whether you need a model key, whether your own users need accounts here, what happens to a machine between messages, and what it costs. Answered in one place.
+  </p>
+  <a
+    href={~p"/faq"}
+    class="inline-flex items-center justify-center px-5 py-2.5 rounded-lg border border-[var(--color-border)] text-[var(--color-text-primary)] text-sm font-medium hover:bg-[var(--color-bg-2)] transition-colors"
+  >
+    Read the questions
+  </a>
 </section>
 
 <%!-- Footer CTA --%>

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/self_hosted.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/self_hosted.html.heex
@@ -446,8 +446,9 @@
   </div>
 </section>
 
-<%!-- 08. Objections. Collapsed, because seven answers as open prose is a
-      wall nobody reads, and the questions themselves are scannable. --%>
+<%!-- 08. Before the clone. The seven answers moved to /faq as
+      `self_host_faq/0`, so the objection list is written once and this page
+      links to its section by anchor. --%>
 <section class="bg-[var(--color-bg-1)] border-y border-[var(--color-border)]">
   <div class="max-w-6xl mx-auto px-6 py-16">
     <p class="font-mono text-[11px] uppercase tracking-widest text-[var(--color-brand)]">
@@ -456,28 +457,15 @@
     <h2 class="mt-3 text-3xl font-bold tracking-tight text-[var(--color-text-primary)]">
       Things you would ask before the clone.
     </h2>
-    <div class="mt-8 max-w-3xl border-t border-[var(--color-border)]">
-      <details
-        :for={item <- self_host_faq()}
-        class="group border-b border-[var(--color-border)]"
-        data-role="faq"
-      >
-        <summary class="flex cursor-pointer items-center gap-4 py-5 list-none marker:content-none">
-          <h3 class="flex-1 font-semibold text-[var(--color-text-primary)] group-open:text-[var(--color-brand)] transition-colors">
-            {item.q}
-          </h3>
-          <span
-            class="text-lg leading-none text-[var(--color-text-muted)] transition-transform group-open:rotate-45"
-            aria-hidden="true"
-          >
-            +
-          </span>
-        </summary>
-        <p class="pb-6 pr-12 text-[var(--color-text-secondary)] leading-relaxed max-w-[76ch]">
-          {item.a}
-        </p>
-      </details>
-    </div>
+    <p class="mt-4 max-w-[58ch] text-[var(--color-text-secondary)] leading-relaxed">
+      Whether it is really the same code, whether the AGPL reaches your application, what the software costs, and how you get rid of it again. Those are answered with the rest of the questions people ask about this platform.
+    </p>
+    <a
+      href={~p"/faq#self-hosting"}
+      class="mt-8 inline-flex items-center justify-center px-5 py-2.5 rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-0)] text-[var(--color-text-primary)] text-sm font-medium hover:bg-[var(--color-bg-2)] transition-colors"
+    >
+      Read the questions
+    </a>
   </div>
 </section>
 

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -158,6 +158,7 @@ defmodule FountainWeb.Router do
     get "/integrations", MarketingController, :integrations
     get "/built-with", MarketingController, :built_with
     get "/self-hosted", MarketingController, :self_hosted
+    get "/faq", MarketingController, :faq
     get "/code-review-bot", MarketingController, :code_review_bot
     # One study today, so the bare path redirects to it rather than 404ing on
     # the segment a reader will inevitably chop off the URL.

--- a/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
@@ -269,6 +269,86 @@ defmodule FountainWeb.MarketingControllerTest do
     end
   end
 
+  # One page for every question-shaped block the site used to scatter across
+  # three. The point of the page is that it does not drift from the data the
+  # old blocks rendered, so the tests walk `faq_sections/0` rather than
+  # asserting sentences by hand.
+  describe "GET /faq" do
+    test "renders every section and every question in it", %{conn: conn} do
+      body = conn |> get(~p"/faq") |> html_response(200)
+
+      assert body =~ "Answers, with the limits attached."
+
+      # No emptiness assertion: faq_sections/0 is a literal list, so Elixir's
+      # type checker reads `!= []` as always true and warns.
+      for section <- FountainWeb.MarketingHTML.faq_sections() do
+        assert body =~ ~s(id="#{section.id}"), "the page drops section #{section.id}"
+        assert body =~ escape(section.title)
+
+        for item <- section.items do
+          assert body =~ escape(item.q), "the page drops #{inspect(item.q)}"
+          assert body =~ escape(item.a), "the page drops the answer to #{inspect(item.q)}"
+        end
+      end
+    end
+
+    test "carries the blocks it took off the other pages", %{conn: conn} do
+      body = conn |> get(~p"/faq") |> html_response(200)
+
+      # The homepage objections, now build_faq/0.
+      for item <- FountainWeb.MarketingHTML.build_faq() do
+        assert body =~ escape(item.q), "the page drops #{inspect(item.q)}"
+      end
+
+      # /self-hosted section 08, unchanged as a function.
+      for item <- FountainWeb.MarketingHTML.self_host_faq() do
+        assert body =~ escape(item.q), "the page drops #{inspect(item.q)}"
+      end
+
+      # The security block, questions and limits both.
+      for item <- FountainWeb.MarketingHTML.security_answers() do
+        assert body =~ escape(item.question)
+        if item.limit, do: assert(body =~ escape(item.limit), "the page drops its limit")
+      end
+    end
+
+    # The three pages that gave up their questions link back by anchor. A
+    # renamed section id would leave those links pointing at nothing, and
+    # nothing else in the suite would notice.
+    test "the anchors the other pages link at all exist", %{conn: conn} do
+      body = conn |> get(~p"/faq") |> html_response(200)
+      ids = Enum.map(FountainWeb.MarketingHTML.faq_sections(), & &1.id)
+
+      for anchor <- ~w(security self-hosting) do
+        assert anchor in ids, "/faq has no ##{anchor} section to link at"
+        assert body =~ ~s(id="#{anchor}")
+      end
+
+      home = conn |> get(~p"/") |> html_response(200)
+      assert home =~ "/faq#security"
+
+      self_hosted = conn |> get(~p"/self-hosted") |> html_response(200)
+      assert self_hosted =~ "/faq#self-hosting"
+    end
+
+    test "carries its own card", %{conn: conn} do
+      body = conn |> get(~p"/faq") |> html_response(200)
+      assert body =~ ~s(<meta property="og:title" content="Questions · Fountain")
+
+      assert body =~
+               ~s(<meta name="description" content="What a developer, a buyer and a security reviewer ask)
+
+      assert body =~ ~s(<meta property="og:url" content="http://localhost:4000/faq")
+    end
+
+    test "the footer and both pages that shed questions link to it", %{conn: conn} do
+      for path <- [~p"/", ~p"/self-hosted"] do
+        body = conn |> get(path) |> html_response(200)
+        assert body =~ ~p"/faq", "#{path} does not link to the FAQ"
+      end
+    end
+  end
+
   describe "GET /code-review-bot" do
     test "shows the whole program and every line it annotates", %{conn: conn} do
       body = conn |> get(~p"/code-review-bot") |> html_response(200)
@@ -495,6 +575,7 @@ defmodule FountainWeb.MarketingControllerTest do
             ~p"/built-with",
             ~p"/case-studies/self-healing-infrastructure",
             ~p"/self-hosted",
+            ~p"/faq",
             "/docs",
             "/docs/open-source",
             ~p"/terms",
@@ -509,12 +590,12 @@ defmodule FountainWeb.MarketingControllerTest do
   # The three apps this project builds itself lead every page that shows the
   # roster (#1219). Each is one entry in built_apps/0 carrying a :flagship
   # key, so these tests are what stops a page naming them by hand and drifting.
-  describe "the security section on /" do
+  describe "the security answers on /faq" do
     test "renders every answer and every limit", %{conn: conn} do
-      body = conn |> get(~p"/") |> html_response(200)
+      body = conn |> get(~p"/faq") |> html_response(200)
 
-      assert body =~ "The part you forward to your security reviewer."
-      assert body =~ ~s(data-role="security-answers")
+      assert body =~ "Security and data"
+      assert body =~ ~s(id="security")
 
       for item <- FountainWeb.MarketingHTML.security_answers() do
         assert body =~ escape(item.question), "the page drops #{inspect(item.question)}"
@@ -526,7 +607,7 @@ defmodule FountainWeb.MarketingControllerTest do
     end
 
     test "says out loud what the platform does not have", %{conn: conn} do
-      body = conn |> get(~p"/") |> html_response(200)
+      body = conn |> get(~p"/faq") |> html_response(200)
 
       assert body =~ "What we do not have."
 
@@ -544,7 +625,7 @@ defmodule FountainWeb.MarketingControllerTest do
     end
 
     test "claims nothing for the egress broker, which runs for one account", %{conn: conn} do
-      body = conn |> get(~p"/") |> html_response(200)
+      body = conn |> get(~p"/faq") |> html_response(200)
 
       # ADR 0019 is Proposed and live for the maintainer alone. The page may
       # only name it among the things you cannot turn on.
@@ -553,18 +634,20 @@ defmodule FountainWeb.MarketingControllerTest do
     end
 
     test "every link into the manual resolves to a page", %{conn: conn} do
-      body = conn |> get(~p"/") |> html_response(200)
+      for path <- [~p"/", ~p"/faq"] do
+        body = conn |> get(path) |> html_response(200)
 
-      links =
-        ~r/href="\/docs\/([^"#]+)/
-        |> Regex.scan(body)
-        |> Enum.map(fn [_, slug] -> slug end)
-        |> Enum.uniq()
+        links =
+          ~r/href="\/docs\/([^"#]+)/
+          |> Regex.scan(body)
+          |> Enum.map(fn [_, slug] -> slug end)
+          |> Enum.uniq()
 
-      assert links != []
+        assert links != [], "#{path} links into the manual nowhere"
 
-      for slug <- links do
-        assert match?({:ok, _}, Fountain.Docs.get(slug)), "/docs/#{slug} is not a page"
+        for slug <- links do
+          assert match?({:ok, _}, Fountain.Docs.get(slug)), "/docs/#{slug} is not a page"
+        end
       end
     end
   end

--- a/apps/fountain/test/fountain_web/controllers/marketing_instance_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_instance_test.exs
@@ -114,6 +114,18 @@ defmodule FountainWeb.MarketingInstanceTest do
     end
   end
 
+  describe "GET /faq where the deployment is not the marketing site" do
+    test "sends the visitor to the manual rather than the pitch's answers", %{conn: conn} do
+      Application.put_env(:fountain, :marketing_site, false)
+
+      conn = get(conn, ~p"/faq")
+      assert redirected_to(conn) == "/docs"
+
+      # The layout drops the link too: a nav entry to a redirect is a dead end.
+      refute conn |> get(~p"/") |> html_response(200) =~ ~p"/faq"
+    end
+  end
+
   describe "GET /self-hosted where the deployment is not the marketing site" do
     test "sends the visitor to the operator's manual rather than the pitch", %{conn: conn} do
       Application.put_env(:fountain, :marketing_site, false)


### PR DESCRIPTION
## What

A new marketing page at `/faq`, linked from the footer's **Learn** group, collecting every question-shaped block the site used to scatter across three pages. Four sections, each with its own anchor:

| Section | Anchor | Source |
|---|---|---|
| Building on it | `#building` | the homepage objections, now `build_faq/0` |
| What it costs | `#billing` | new, and only where the deployment bills |
| Security and data | `#security` | `security_answers/0` + `security_absent/0`, moved whole |
| Running it yourself | `#self-hosting` | `self_host_faq/0`, unchanged |

## Why

A reader holding a question had to guess which page the answer was at the bottom of. And the two blocks on the homepage were doing the page harm: seven objection rows sat between the pitch and the call to action, and the security wall is the thing a reader most wants to *forward*, which wants one URL rather than a homepage anchor.

## What did not move

**The six-question grid stays on the homepage.** It is the problem statement the whole page is built on ("You did not set out to run a sandbox platform"), not an FAQ, and it stays where it argues.

## Nothing was rewritten

The blocks moved as data, so the page cannot drift from what the old ones rendered:

- The homepage objections were inline `<dl>` markup and are now `build_faq/0`. The one answer that varies by deployment (*Can I run it myself?*) is `run_it_yourself_answer/0` instead of two conditional spans in a template.
- `security_answers/0` and `security_absent/0` are untouched functions rendering on the new page. Every `:limit` is still stated beside the answer it limits, and *What we do not have* still sits with them.
- `self_host_faq/0` is untouched.

Both source pages keep the heading and the promise and link to their section by anchor, so `/` and `/self-hosted` still make the argument, just without the wall.

## The one piece of new copy

The billing section. It quotes nothing it does not read from the price card `Credits` burns at (ADR 0030) — `turn_hour_price/0` and `opening_credit/0` — so the page cannot name a rate the meter does not charge, and the whole section is behind `pricing?()`.

## Deployment behaviour

Off the marketing site `/faq` redirects to `/docs`, like every other sales page, and the footer `<li>` is gated on `Fountain.Marketing.site?()` the same way its neighbours are — a nav entry pointing at a redirect is a dead end.

## Test

- New `GET /faq` block that walks `faq_sections/0` rather than asserting sentences by hand: every section id, every question, every answer.
- A test that the blocks the other pages shed all landed.
- **An anchor test.** `/` links `/faq#security` and `/self-hosted` links `/faq#self-hosting`; renaming a section id would leave those pointing at nothing and nothing else in the suite would notice.
- The three security tests retargeted from `/` to `/faq`.
- `carries its own card` (OG title, description, url), the footer group list extended with `/faq`, and the non-marketing redirect in `marketing_instance_test.exs`.
- The docs-link guardrail now walks both `/` and `/faq`.

One trap worth naming for the next person: the per-item docs link uses a plain interpolated string, not `~p`, because a verified route escapes the slash in a multi-segment slug (`concepts/vault` → `concepts%2Fvault`) and the link 404s. The guardrail caught it.

`apps/fountain/test/fountain_web`: 1,443 tests, 0 failures. `credo --strict` clean. `docs-style.py` and `destink.mjs` clean (the CHANGELOG entry is a docs page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176oj6fYqofyFL5nVZvk7q9
