### PR TITLE
Restructure /self-hosted around the bring-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,19 @@ upgrade, is in
   rather than to one runner. See ADR 0036.
 
 ### Changed
+- **`/self-hosted` reads on a phone, and the site spells license the American
+  way.** The page was built at desktop widths: fixed `px-6` gutters, `py-16`
+  section rhythm and `p-6` cards at every size, two code blocks that wrapped
+  mid-token rather than scrolling, and a numbered ladder whose left margin
+  pushed its own text off a narrow screen. Every one of those is a breakpoint
+  now, the code blocks scroll in their own box, and the two call-to-action
+  rows go full width before they go side by side. No copy moved. Separately,
+  the site mixed British and American forms; `licence` and `enrol` are the
+  British ones, and the visible text now uses `license` and `enroll`
+  throughout. `licence_parts/0`, the `:licence` key and `data-role="licence"`
+  keep their spelling, because they are identifiers and one is a test
+  selector, and the license names (`AGPL-3.0-or-later`, `Elastic 2.0`,
+  `Apache-2.0`) were never in question.
 
 - **The homepage sells infrastructure to builders, not an agent to a
   consumer.** The pitch read as a coworker product ("hire an agent by role",

--- a/apps/fountain/lib/fountain_web/controllers/marketing_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_controller.ex
@@ -116,7 +116,7 @@ defmodule FountainWeb.MarketingController do
           "Define an agent once and every app you build can hire it over one API. " <>
             "#{Fountain.Brand.engine()} is open source and the whole platform is in " <>
             "the repo. Bring an instance up with Docker Compose or plain Kubernetes " <>
-            "manifests, on your hardware, under your own keys, with no licence key " <>
+            "manifests, on your hardware, under your own keys, with no license key " <>
             "and no seat count."
       )
     else

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
@@ -797,7 +797,7 @@ defmodule FountainWeb.MarketingHTML do
             url: "https://rounds.demo.managoat.com",
             source: "https://github.com/managoat/rounds",
             blurb:
-              "Dependabot for infrastructure config. Enrol a repository and it gets audited on a schedule; an agent fixes what it can verify and opens the pull request. Never twice for the same finding, never again for one you closed.",
+              "Dependabot for infrastructure config. Enroll a repository and it gets audited on a schedule; an agent fixes what it can verify and opens the pull request. Never twice for the same finding, never again for one you closed.",
             shows: "an unattended product, and an agent that knows when to do nothing"
           }
         ]
@@ -957,14 +957,14 @@ defmodule FountainWeb.MarketingHTML do
         name: "Brokered credentials",
         blurb:
           "The real token never enters the sandbox. The broker attaches it on the way out, and the transcript keeps a placeholder.",
-        hosted: "Limited access. We enrol an account by hand.",
+        hosted: "Limited access. We enroll an account by hand.",
         yours: "Set BROKER_URL and BROKER_TOKEN, and list the tenants in BROKER_TENANTS.",
         docs: "/docs/concepts/secrets"
       }
     ]
   end
 
-  @doc "What each licence lets you do, in the order that matters to somebody deciding."
+  @doc "What each license lets you do, in the order that matters to somebody deciding."
   def licence_parts do
     [
       %{
@@ -1074,7 +1074,7 @@ defmodule FountainWeb.MarketingHTML do
       %{
         q: "What do I pay for the software?",
         a:
-          "Nothing. There is no licence key and no seat count, and nobody has to talk to us first. Leave credits off and the instance prices nothing and shows nobody a bill. Turn credits on and it bills your users rather than you."
+          "Nothing. There is no license key and no seat count, and nobody has to talk to us first. Leave credits off and the instance prices nothing and shows nobody a bill. Turn credits on and it bills your users rather than you."
       },
       %{
         q: "Do I still bring a model key?",

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/self_hosted.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/self_hosted.html.heex
@@ -6,7 +6,7 @@
       the rendered body: "Define your agents once. Let every app you build
       hire them." (now the deck under the h1) and "Six commands and a token."
       (now the label over the terminal). --%>
-<section class="max-w-6xl mx-auto px-6 pt-12 pb-20 grid lg:grid-cols-2 gap-14 items-start">
+<section class="max-w-6xl mx-auto px-5 sm:px-6 pt-8 pb-14 sm:pt-12 sm:pb-20 grid lg:grid-cols-2 gap-10 lg:gap-14 items-start">
   <div>
     <p class="inline-flex items-center gap-2 rounded-full border border-[var(--color-border-strong)] px-3 py-1.5 text-xs font-medium uppercase tracking-widest text-[var(--color-text-secondary)]">
       <span class="h-1.5 w-1.5 rounded-full bg-[var(--color-brand)]" aria-hidden="true"></span>
@@ -21,7 +21,7 @@
     <p class="mt-5 text-lg text-[var(--color-text-secondary)] leading-relaxed max-w-[54ch]">
       Run it yourself and the whole platform is yours. Your machines, your keys, nothing rationed.
     </p>
-    <div class="mt-8 flex flex-col sm:flex-row gap-3">
+    <div class="mt-8 flex flex-col sm:flex-row gap-3 [&>a]:w-full sm:[&>a]:w-auto">
       <a
         href={~p"/docs/guides/operate/deploy"}
         class="inline-flex items-center justify-center px-6 py-3 rounded-lg bg-[var(--color-brand)] text-[var(--color-brand-text)] font-medium hover:bg-[var(--color-brand-hover)] transition-colors text-sm"
@@ -38,7 +38,7 @@
     <p class="mt-6 flex flex-wrap gap-x-3 gap-y-1 font-mono text-xs text-[var(--color-text-secondary)]">
       <span>AGPL-3.0-or-later</span>
       <span aria-hidden="true">·</span>
-      <span>no licence key</span>
+      <span>no license key</span>
       <span aria-hidden="true">·</span>
       <span>no seat count</span>
       <span aria-hidden="true">·</span>
@@ -63,7 +63,7 @@
       </button>
     </div>
     <pre
-      class="bg-[var(--color-code-bg)] text-[var(--color-code-text)] p-5 text-xs leading-relaxed whitespace-pre-wrap break-words"
+      class="bg-[var(--color-code-bg)] text-[var(--color-code-text)] p-4 sm:p-5 text-xs sm:text-sm leading-relaxed overflow-x-auto"
       phx-no-format
     ><code>{compose_example()}</code></pre>
     <p class="px-5 py-4 border-t border-[var(--color-border)] text-sm text-[var(--color-text-secondary)] leading-relaxed">
@@ -83,7 +83,7 @@
       line is the deploy guide's "Before you start", so the page cannot
       promise a bring-up the manual contradicts. --%>
 <section class="bg-[var(--color-bg-1)] border-y border-[var(--color-border)]">
-  <div class="max-w-6xl mx-auto px-6 py-8">
+  <div class="max-w-6xl mx-auto px-5 sm:px-6 py-7 sm:py-8">
     <p class="font-mono text-[11px] uppercase tracking-widest text-[var(--color-text-secondary)]">
       Before you start
     </p>
@@ -101,7 +101,7 @@
 <%!-- 01. What happens after the commands, including how you know it worked.
       A first-time operator otherwise reads a refused connection during the
       cold start as a failed install. --%>
-<section class="max-w-6xl mx-auto px-6 py-16">
+<section class="max-w-6xl mx-auto px-5 sm:px-6 py-12 sm:py-16">
   <p class="font-mono text-[11px] uppercase tracking-widest text-[var(--color-brand)]">
     01 · Install
   </p>
@@ -130,7 +130,7 @@
       <p class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">
         Wait for the app container to report healthy, then probe it.
       </p>
-      <pre class="mt-3 rounded-lg bg-[var(--color-code-bg)] p-4 text-xs text-[var(--color-code-text)] whitespace-pre-wrap break-all"><code phx-no-format>{health_probe()}</code></pre>
+      <pre class="mt-3 overflow-x-auto rounded-lg bg-[var(--color-code-bg)] p-3 sm:p-4 text-[11px] sm:text-xs text-[var(--color-code-text)]"><code phx-no-format>{health_probe()}</code></pre>
     </div>
     <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-1)] p-6">
       <p class="font-mono text-[11px] uppercase tracking-widest text-[var(--color-text-secondary)]">
@@ -154,7 +154,7 @@
 <%!-- 02. The front ends the instance gets. Cards come from built_apps/0 via
       flagship_apps/0, so this cannot name a retired app. --%>
 <section class="bg-[var(--color-bg-1)] border-y border-[var(--color-border)]">
-  <div class="max-w-6xl mx-auto px-6 py-16">
+  <div class="max-w-6xl mx-auto px-5 sm:px-6 py-12 sm:py-16">
     <p class="font-mono text-[11px] uppercase tracking-widest text-[var(--color-brand)]">
       02 · What you open
     </p>
@@ -167,7 +167,7 @@
     <div class="grid md:grid-cols-3 gap-6 mt-8">
       <article
         :for={app <- flagship_apps()}
-        class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6 flex flex-col"
+        class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-5 sm:p-6 flex flex-col"
         data-role="flagship"
       >
         <div class="text-2xl leading-none" aria-hidden="true">{app.glyph}</div>
@@ -200,7 +200,7 @@
       <p class="text-sm text-[var(--color-text-secondary)] leading-relaxed">
         A browser app on another origin calling your API is a CORS request, so name the origin it is served from:
       </p>
-      <pre class="mt-3 overflow-x-auto rounded-lg bg-[var(--color-code-bg)] p-4 text-xs text-[var(--color-code-text)]"><code phx-no-format>API_CORS_ORIGINS=https://fountain-conversations.demo.managoat.com</code></pre>
+      <pre class="mt-3 overflow-x-auto rounded-lg bg-[var(--color-code-bg)] p-3 sm:p-4 text-[11px] sm:text-xs text-[var(--color-code-text)]"><code phx-no-format>API_CORS_ORIGINS=https://fountain-conversations.demo.managoat.com</code></pre>
       <p class="mt-3 text-sm text-[var(--color-text-secondary)] leading-relaxed">
         Conversations and Team are also what the console's own links point at, so <code
           class="text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1 py-0.5 text-xs"
@@ -219,7 +219,7 @@
 
 <%!-- 03. Evidence that other people build on this. Selected from
       built_apps/0 by id, so a card cannot drift from /built-with. --%>
-<section class="max-w-6xl mx-auto px-6 py-16">
+<section class="max-w-6xl mx-auto px-5 sm:px-6 py-12 sm:py-16">
   <p class="font-mono text-[11px] uppercase tracking-widest text-[var(--color-brand)]">
     03 · Built on it
   </p>
@@ -258,11 +258,11 @@
 </section>
 
 <%!-- 04. The ownership ladder, ahead of the rationed features and the
-      licences. For somebody deciding hosted against self-hosted this is the
+      licenses. For somebody deciding hosted against self-hosted this is the
       argument, and it used to arrive seventh. Drawn as a connected ladder
       rather than four loose cards, because the rungs are an order. --%>
 <section class="bg-[var(--color-bg-1)] border-y border-[var(--color-border)]">
-  <div class="max-w-6xl mx-auto px-6 py-16">
+  <div class="max-w-6xl mx-auto px-5 sm:px-6 py-12 sm:py-16">
     <p class="font-mono text-[11px] uppercase tracking-widest text-[var(--color-brand)]">
       04 · Ownership
     </p>
@@ -272,10 +272,10 @@
     <p class="mt-4 text-[var(--color-text-secondary)] leading-relaxed max-w-[62ch]">
       Most people stop at the first rung and are happy there. The point is that the next three exist, and that none of them is a sales conversation.
     </p>
-    <ol class="mt-10 ml-3 border-l-2 border-[var(--color-border-strong)]">
+    <ol class="mt-8 sm:mt-10 ml-3 border-l-2 border-[var(--color-border-strong)]">
       <li
         :for={rung <- ownership_rungs()}
-        class="grid grid-cols-[auto_1fr] gap-6 pb-8"
+        class="grid grid-cols-[auto_1fr] gap-4 sm:gap-6 pb-6 sm:pb-8"
         data-role="rung"
       >
         <div class="-ml-[13px] flex items-start gap-3">
@@ -294,7 +294,7 @@
         </div>
       </li>
     </ol>
-    <p class="ml-6 border-l-2 border-[var(--color-brand)] pl-6 text-[var(--color-text-secondary)] leading-relaxed max-w-[74ch]">
+    <p class="ml-0 sm:ml-6 border-l-2 border-[var(--color-brand)] pl-5 sm:pl-6 text-[var(--color-text-secondary)] leading-relaxed max-w-[74ch]">
       A model key is the one thing you still bring, and you always did. The agent bills your own provider account for tokens, so nothing in the middle takes a cut of inference. <a
         href={~p"/docs/integrations/runners"}
         class="underline underline-offset-2 hover:text-[var(--color-text-primary)]"
@@ -306,7 +306,7 @@
 <%!-- 05. The inversion, as a table rather than three stacked panels: the
       config column is the page's point, so it gets a column of its own and a
       tint. The rows track docs/reference/feature-status.md. --%>
-<section class="max-w-6xl mx-auto px-6 py-16">
+<section class="max-w-6xl mx-auto px-5 sm:px-6 py-12 sm:py-16">
   <p class="font-mono text-[11px] uppercase tracking-widest text-[var(--color-brand)]">
     05 · Feature flags
   </p>
@@ -371,14 +371,14 @@
   </p>
 </section>
 
-<%!-- 06. Licences --%>
+<%!-- 06. Licenses --%>
 <section class="bg-[var(--color-bg-1)] border-y border-[var(--color-border)]">
-  <div class="max-w-6xl mx-auto px-6 py-16">
+  <div class="max-w-6xl mx-auto px-5 sm:px-6 py-12 sm:py-16">
     <p class="font-mono text-[11px] uppercase tracking-widest text-[var(--color-brand)]">
-      06 · Licences
+      06 · Licenses
     </p>
     <h2 class="mt-3 text-3xl font-bold tracking-tight text-[var(--color-text-primary)]">
-      Three licences, and what each one asks of you.
+      Three licenses, and what each one asks of you.
     </h2>
     <p class="mt-4 text-[var(--color-text-secondary)] leading-relaxed max-w-[62ch]">
       The parts your code touches are permissive on purpose. A connection to {Fountain.Brand.engine()} must never put an obligation on your application.
@@ -386,7 +386,7 @@
     <div class="grid md:grid-cols-3 gap-6 mt-8">
       <div
         :for={part <- licence_parts()}
-        class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6 flex flex-col"
+        class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-5 sm:p-6 flex flex-col"
         data-role="licence"
       >
         <div class="flex items-center justify-between gap-3">
@@ -416,7 +416,7 @@
 </section>
 
 <%!-- 07. The bill, said out loud. --%>
-<section class="max-w-6xl mx-auto px-6 py-16">
+<section class="max-w-6xl mx-auto px-5 sm:px-6 py-12 sm:py-16">
   <p class="font-mono text-[11px] uppercase tracking-widest text-[var(--color-brand)]">
     07 · Trade-offs
   </p>
@@ -429,7 +429,7 @@
   <div class="grid md:grid-cols-2 gap-6 mt-8">
     <div
       :for={cost <- self_host_costs()}
-      class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-1)] p-6 flex flex-col"
+      class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-1)] p-5 sm:p-6 flex flex-col"
       data-role="cost"
     >
       <h3 class="font-semibold text-[var(--color-text-primary)]">{cost.title}</h3>
@@ -450,7 +450,7 @@
       `self_host_faq/0`, so the objection list is written once and this page
       links to its section by anchor. --%>
 <section class="bg-[var(--color-bg-1)] border-y border-[var(--color-border)]">
-  <div class="max-w-6xl mx-auto px-6 py-16">
+  <div class="max-w-6xl mx-auto px-5 sm:px-6 py-12 sm:py-16">
     <p class="font-mono text-[11px] uppercase tracking-widest text-[var(--color-brand)]">
       08 · Before the clone
     </p>
@@ -471,14 +471,14 @@
 
 <%!-- Footer CTA --%>
 <section class="bg-[var(--color-bg-2)] border-t border-[var(--color-border)]">
-  <div class="max-w-6xl mx-auto px-6 py-20">
+  <div class="max-w-6xl mx-auto px-5 sm:px-6 py-14 sm:py-20">
     <h2 class="text-3xl sm:text-4xl font-bold tracking-tight text-[var(--color-text-primary)]">
       Clone it tonight.
     </h2>
     <p class="mt-4 text-[var(--color-text-secondary)] leading-relaxed max-w-[58ch]">
       A container, a Postgres and a sandbox token. The manual has the whole path, the repo has the issues, and neither of them has a sales form in it.
     </p>
-    <div class="mt-8 flex flex-col sm:flex-row gap-3">
+    <div class="mt-8 flex flex-col sm:flex-row gap-3 [&>a]:w-full sm:[&>a]:w-auto">
       <a
         href={~p"/docs/guides/operate/deploy"}
         class="inline-flex items-center justify-center px-8 py-3 rounded-lg bg-[var(--color-brand)] text-[var(--color-brand-text)] font-medium hover:bg-[var(--color-brand-hover)] transition-colors"


### PR DESCRIPTION
# /self-hosted — restructure, prerequisites, and spelling

**Four commits, and the first three are independent.** Commit 1 is a copy fix
worth taking on its own. Commit 2 is the data the new template reads. Commit 3
is the template. Commit 4 is the CHANGELOG line.

**Commit 2 lands before commit 3 on purpose** — the template calls
`prerequisites()` and `health_probe()` and will not compile without them.

---

## Commit 1 — `fix(marketing): American spelling for license and enroll`

The site mixes British and American forms. `enrol` and `licence` are the
British ones.

| File | From | To |
|---|---|---|
| `marketing_controller.ex` | `with no licence key` | `with no license key` |
| `marketing_html.ex` | `Enrol a repository` | `Enroll a repository` |
| `marketing_html.ex` | `We enrol an account by hand.` | `We enroll an account by hand.` |
| `marketing_html.ex` | `What each licence lets you do` (doc string) | `What each license lets you do` |
| `marketing_html.ex` | `There is no licence key` | `There is no license key` |

**Not renamed**, because they are identifiers rather than prose, and one is a
test selector: `licence_parts/0`, the `:licence` map key, `part.licence`, and
`data-role="licence"`. The license *names* (`AGPL-3.0-or-later`, `Elastic 2.0`,
`Apache-2.0`) are unaffected.

---

## Commit 2 — `feat(marketing): prerequisites and a teardown answer for /self-hosted`

Two additions to `apps/fountain/lib/fountain_web/controllers/marketing_html.ex`,
in the `## /self-hosted` section. Every line is the deploy guide's, so the page
cannot promise a bring-up the manual contradicts.

- **`prerequisites/0`** — new, after `compose_example/0`. The deploy guide's
  "Before you start": Docker Engine with Compose v2 and `openssl`, the Postgres
  16 the compose file brings, the reach to `ghcr.io`, and `PUBLIC_URL` when the
  instance is reached by anything but `localhost`.
- **`health_probe/0`** — new, beside it. Kept out of the template for the same
  reason `compose_example/0` is: HEEx would read the braces in the JSON
  response.
- **`self_host_faq/0`** — one entry added, before "How much of an instance is
  one person?". "How do I get rid of it?" is a real pre-clone question, and
  answering it (`docker compose down -v`, and the `MASTER_SECRETS_KEY` warning
  if you keep the volume) lowers the cost of trying.

---

## Commit 3 — `feat(marketing): restructure /self-hosted around the bring-up`

Replaces `apps/fountain/lib/fountain_web/controllers/marketing_html/self_hosted.html.heex`.

### What changes

1. **The bring-up is on the first screen.** Hero becomes a two-column layout,
   argument left, the whole compose block right, with a copy button. It was
   the third section.
2. **The headline sells the action.** `h1` is now "There are no tiers to buy."
   The old headline stays as the deck line directly under it, so it still
   reads as the platform claim and the h1 answers "why would I run this".
3. **`prerequisites/0` renders as a "Before you start" band** between the hero
   and the install, so the four preconditions arrive before the commands and
   after the pitch.
4. **A "Know it worked" card** carrying `health_probe/0`, and the section
   states that a refused connection during the up-to-a-minute cold start is
   normal. This was the most likely place for a first-timer to conclude the
   install failed.
5. **The instance URL is stated.** The register card opens with
   `http://localhost:4000` rather than "open the instance".
6. **The ownership ladder moves from seventh to fourth**, ahead of the
   rationed features and the licenses, and is drawn as a connected ladder
   rather than four loose cards. For somebody deciding hosted against
   self-hosted this is the argument.
7. **The rationed features become a three-column table** with the config
   column tinted, instead of three stacked panels. The inversion is the
   page's point, so it gets a column.
8. **The FAQ collapses into `<details>`**, now that it holds seven answers.
9. **Sections are numbered 01–08** in the eyebrows, and the page is
   left-aligned throughout instead of centred.
10. **Everything is on your tokens.** No hard-coded colours: surfaces, borders,
    text, brand and code colours all read `var(--color-*)`, so light and dark
    both work. This PR does **not** touch `tokens.css` and does not depend on
    the brand-blue change landing.
11. **It is built mobile-first.** Every layout is a single column by default
    and widens at `sm:`/`md:`/`lg:`, rather than a desktop grid that collapses
    at one breakpoint. On a phone: section padding drops to `py-12 px-5`, the
    terminal goes to `text-xs` and scrolls horizontally instead of wrapping the
    two long `openssl` lines into fragments, CTAs are full-width stacked
    targets, the ladder gutter tightens to `gap-4`, the FAQ answers lose the
    `pr-12` that ate a sixth of the width, and the flag table drops its header
    row and left borders for stacked rows with top rules.

### No test changes required

`MarketingControllerTest` pins two literal strings that a naive restructure
would drop. Both are still rendered, deliberately:

- `"Define your agents once. Let every app you build hire them."` — now the
  deck line under the h1.
- `"Six commands and a token."` — now the heading on the terminal card.

Also verified against the suite: `"The features we ration, you switch on."`,
`"What it costs you instead."`, `"The apps come with it."`,
`"{count} applications already hire from one roster."`, `docker compose up -d`,
`MASTER_SECRETS_KEY`, `API_CORS_ORIGINS`, `CONVERSATIONS_APP_URL`,
`TEAM_APP_URL`, all three licence names, `repo_url/0`, every
`rationed_features/0` name, and every flagship and showcase `app.url` plus
`app.source`. `data-role` attributes are preserved (`rationed`, `licence`,
`rung`, `cost`, `faq`, `flagship`, `showcase`) and two are added
(`prerequisite`, `bringup`). Every `href="/docs/..."` on the page resolves to
an existing manual page; the one new link is `/docs/self-hosting`, which the
deploy guide already references.

`mix test apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs`
— **43 tests, 0 failures.** `mix format --check-formatted` and
`mix compile --warnings-as-errors` are clean.

---

## Commit 4 — `docs(changelog): note the /self-hosted restructure`

One entry under `## [Unreleased]` → `### Changed`.

---

## Flag for review

- **The `h1` swap** is positioning, not layout. It is isolated to commit 3, so
  it can be reverted without touching anything else.
- **The copy button** is the only client-side JS on the page — an inline
  `onclick`, no LiveView hook. If marketing pages should stay script-free,
  delete the `<button>` element; nothing else depends on it.
- **The terminal scroll fade** from the design was deliberately left out. It
  needs a per-instance background token and several `!important` overrides to
  beat inline backgrounds, which is not worth it in a Tailwind template. If
  wanted, the clean version is an `after:` pseudo-element on the `<pre>` fading
  `var(--color-code-bg)` to transparent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
