### PR TITLE
docs: credit the sentences package in the prose-check table

### DIFF
--- a/docs/open-source.md
+++ b/docs/open-source.md
@@ -74,7 +74,7 @@ before you write a page.
 |---|---|
 | `scripts/docs-style.py` | The house style sheet. |
 | `vale lint docs` | ASD-STE100 Simplified Technical English. |
-| `scripts/destink/destink.mjs` | The tells that make a page read as machine written. |
+| `scripts/destink/destink.mjs` | The tells that make a page read as machine written, via the [`sentences`](https://github.com/lex00/sentences) package (MIT). |
 
 Each check has a backlog file, and each backlog file is empty. A new page
 gets all three checks from its first commit.


### PR DESCRIPTION
Small follow-up to #1254 (merged), which switched scripts/destink from a vendored copy of lex00/sentences to depending on the published package directly.

That PR's own CI run never actually exercised the migrated destink gate: `changes.outputs.docs_touched` only flips true on a change under `docs/`, and #1254 touched only `scripts/destink/**`, `CLAUDE.md`, `CONTRIBUTING.md`, and `.github/workflows/ci.yml` — no docs page. So both the `checks` job's "Docs de-stink" step and the separate `docs` job were skipped, and the merge to main reused that same non-verifying run via the `already-tested` short-circuit. Verification of the actual migration was local only (documented in #1254).

This PR touches `docs/open-source.md` (crediting the `sentences` package in the existing prose-check table, matching what CLAUDE.md and CONTRIBUTING.md already say) specifically so `docs_touched` is true here and CI runs the real, now-merged `destink.mjs` against `docs/` for the first time.

## Verified locally
- `node scripts/destink/destink.mjs docs/open-source.md` → `1 page(s) clean, 33 rules.`
- `python3 scripts/docs-style.py` → clean, 90 files