### PR TITLE
fix(web): version the tokens.css URL, so a deploy cannot land on a cached one

### DIFF
--- a/apps/fountain/lib/fountain_web/components/layouts/root.html.heex
+++ b/apps/fountain/lib/fountain_web/components/layouts/root.html.heex
@@ -111,7 +111,7 @@
       });
     </script>
     <%!-- Design tokens — must load before Tailwind CDN so CSS vars are defined --%>
-    <link rel="stylesheet" href="/assets/tokens.css" />
+    <link rel="stylesheet" href={FountainWeb.StaticVersion.tokens_css()} />
     <%!-- Tailwind CDN config: register token-backed colour utilities --%>
     <script>
       window.tailwind = window.tailwind || {};

--- a/apps/fountain/lib/fountain_web/static_version.ex
+++ b/apps/fountain/lib/fountain_web/static_version.ex
@@ -1,0 +1,45 @@
+defmodule FountainWeb.StaticVersion do
+  @moduledoc """
+  A content hash for the static files the layout links by a fixed path.
+
+  This site has no asset build. Tailwind is the play CDN and `tokens.css` is a
+  hand-maintained file served straight out of `priv/static`, so there is no
+  digest step and nothing rewrites the URL in the layout. `Plug.Static` sends
+  it with a four-hour `max-age`, and the CDN in front of production caches on
+  the URL.
+
+  That combination means a deploy can ship new markup against a stale
+  stylesheet, and it did: #1258 rendered on production with the ink and accent
+  tokens undefined, so a section designed dark had a transparent ground and its
+  code blocks were light grey text on a light grey page. Every workflow was
+  green and the HTML was correct. The stylesheet the HTML asked for was four
+  hours old, because it was the same URL it had always been.
+
+  So the URL carries the file's hash. New file, new URL, guaranteed miss on
+  every cache between here and the reader; unchanged file, unchanged URL, and
+  the long `max-age` keeps doing its job.
+
+  The hash is taken at compile time and `@external_resource` puts the file in
+  the recompile set, so editing `tokens.css` changes this module too.
+  """
+
+  @tokens_path Path.expand("../../priv/static/assets/tokens.css", __DIR__)
+  @external_resource @tokens_path
+
+  @tokens_version :sha256
+                  |> :crypto.hash(File.read!(@tokens_path))
+                  |> Base.encode16(case: :lower)
+                  |> binary_part(0, 8)
+
+  @doc """
+  The versioned path for `tokens.css`, for the `href` in the root layout.
+
+  Never link the bare path. `design_tokens_test.exs` fails if the layout does.
+  """
+  @spec tokens_css() :: String.t()
+  def tokens_css, do: "/assets/tokens.css?v=" <> @tokens_version
+
+  @doc "The hash alone, so a test can compare it against the file on disk."
+  @spec tokens_version() :: String.t()
+  def tokens_version, do: @tokens_version
+end

--- a/apps/fountain/test/fountain_web/design_tokens_test.exs
+++ b/apps/fountain/test/fountain_web/design_tokens_test.exs
@@ -83,6 +83,46 @@ defmodule FountainWeb.DesignTokensTest do
     end
   end
 
+  describe "the URL the layout links" do
+    @layout Path.expand(
+              "../../lib/fountain_web/components/layouts/root.html.heex",
+              __DIR__
+            )
+
+    test "carries the file's hash, so a deploy cannot land on a cached stylesheet" do
+      # #1258 shipped correct markup to production against a four-hour-old
+      # tokens.css, because the layout asked for the same URL it always had and
+      # the CDN answered from cache. The ink and accent tokens were undefined
+      # for every reader: a section designed dark had a transparent ground.
+      layout = File.read!(@layout)
+
+      refute layout =~ ~s(href="/assets/tokens.css"),
+             "the layout links the bare path, so a token change cannot reach a cached reader"
+
+      assert layout =~ "FountainWeb.StaticVersion.tokens_css()",
+             "the layout should link the versioned path"
+    end
+
+    test "the version is the hash of the file actually served" do
+      expected =
+        :sha256
+        |> :crypto.hash(File.read!(@served))
+        |> Base.encode16(case: :lower)
+        |> binary_part(0, 8)
+
+      assert FountainWeb.StaticVersion.tokens_version() == expected,
+             "the compiled hash is stale against priv/static/assets/tokens.css"
+
+      assert FountainWeb.StaticVersion.tokens_css() == "/assets/tokens.css?v=" <> expected
+    end
+
+    test "the served file is reachable at the path the layout asks for" do
+      "/" <> path = FountainWeb.StaticVersion.tokens_css() |> String.split("?") |> hd()
+      assert Path.basename(path) == Path.basename(@served)
+      assert "assets/tokens.css" == path
+    end
+  end
+
   describe "the marketing scales" do
     setup do
       %{tokens: Map.new(declarations(File.read!(@source)))}


### PR DESCRIPTION
## What broke

#1258 shipped correct markup to production against a **four-hour-old stylesheet**. Every workflow was green, the HTML was right, and the homepage was broken for every reader: the ink and accent tokens were undefined, so the section designed dark had a transparent ground and its code blocks rendered as light grey text on a light grey page.

```
$ curl -sI https://managoat.com/assets/tokens.css
cache-control: public, max-age=14400
age: 287
cf-cache-status: HIT

$ curl -s https://managoat.com/ | grep -o 'href="/assets/tokens.css[^"]*"'
href="/assets/tokens.css"          ← the same URL it has always been
```

## Why

There is no asset build on this site. Tailwind is the play CDN and `tokens.css` is hand-maintained in `priv/static`, so nothing digests the path or rewrites it per release. `Plug.Static` sends it with a four-hour `max-age`, and the CDN caches on the URL. A deploy can therefore ship new markup that asks for a stylesheet the reader already has an old copy of, and nothing in CI can see it.

**The bug is older than #1258.** Any token edit would have done this. That PR is just the first to add a scale the page could not render without, which turned something dormant into a front page.

## The fix

The URL carries the file's content hash, taken at compile time with `@external_resource` so editing `tokens.css` recompiles the module that names the version:

```
/assets/tokens.css?v=1cd05f3a
```

New file → new URL → guaranteed miss on every cache between the server and the reader. Unchanged file → unchanged URL, and the long `max-age` keeps doing its job.

It also recovers production **faster than purging the CDN**, and needs no credentials: the new URL does not address the cached object at all.

## Guardrail

`design_tokens_test.exs` gains three tests: the layout must not link the bare path, the compiled hash must match the file actually served, and the versioned path must still resolve to that file. Confirmed by reverting the fix — the first one goes red.

## Verification

- Local: `/` emits `href="/assets/tokens.css?v=1cd05f3a"`, that URL 200s and carries `--color-ink-0`.
- `mix format --check-formatted`, `mix credo --strict`, and 1,460 `fountain_web` tests, checking `mix test`'s own exit code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176oj6fYqofyFL5nVZvk7q9