### PR TITLE
copy(marketing): one grammar for the six cards, one job for the subhead

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -177,12 +177,29 @@
       This is also the page's only mention of a Vault, so it states the
       HashiCorp collision before the feature (standards/voice-and-style.md).
 
+      EVERY dt IS AN IMPERATIVE. Six of them read down one left edge, so the
+      grammar is part of the shape: a list that changes person between items
+      reads as six unrelated claims rather than one inventory. These ran a noun
+      phrase, an imperative, a negative noun phrase, "You never" and "You can"
+      across six cards before this rule was written down. "You can" also hedges
+      a claim the page is entitled to make outright.
+
+      No dd repeats its own dt. Two of them did: the card about the pull
+      request opened by restating the headline, and the card about the
+      Environment ended on the reuse the headline had already promised.
+
       Three elements, three jobs. The h2 names the problem and claims it, the
       grid shows the mechanisms, and the closer hands the product back. The
-      lead-in only puts the reader at the moment after the demo worked. It used
-      to end "none of them is your product", which is the closer's line 270
-      words early, and it used to count the cards, which the reader can see and
-      which is the move 6291ec55 took out of this same paragraph.
+      lead-in only puts the reader at the moment after the demo worked, and
+      that is all it does: it used to carry a second sentence saying what the
+      h2 had just said, in the register of the h2. It used to end "none of them
+      is your product", which is the closer's line 270 words early, and it used
+      to count the cards, which the reader can see and which is the move
+      6291ec55 took out of this same paragraph.
+
+      The closer names one noun per mechanism the grid just showed, so each has
+      a card behind it. It used to end "that machine, that vault and that
+      owner", and "owner" was the only appearance of the word on the page.
 
       This is the first of the two sections that set their heading against the
       left edge instead of the centre. Six items of dense reference read down a
@@ -194,7 +211,7 @@
     You did not set out to run a sandbox platform. We did.
   </h2>
   <p class="mt-3 text-[var(--color-text-secondary)] max-w-2xl text-lg">
-    The agent was the easy part. Under it is everything you would have built next.
+    The agent was the easy part.
   </p>
   <%!-- A definition list, which is what the page uses for a claim and the
         mechanism behind it (the protocols, the limits and the case study all
@@ -208,10 +225,10 @@
   <dl class="mt-12 grid sm:grid-cols-2 gap-x-12 gap-y-9">
     <div class="border-l-2 border-[var(--color-border-strong)] pl-5">
       <dt class="font-medium text-[var(--color-text-primary)]">
-        One setup, every agent you run.
+        Set it up once, then point every agent at it.
       </dt>
       <dd class="mt-1.5 text-sm text-[var(--color-text-secondary)] leading-relaxed">
-        An Environment names the filesystem, the packages, the checkout and the network. You list it, diff it and launch from it, and the next agent points at the same one.
+        An Environment names the filesystem, the packages, the checkout and the network. You list it, diff it and launch from it, and it outlives every run that uses it.
       </dd>
     </div>
     <div class="border-l-2 border-[var(--color-border-strong)] pl-5">
@@ -224,15 +241,15 @@
     </div>
     <div class="border-l-2 border-[var(--color-border-strong)] pl-5">
       <dt class="font-medium text-[var(--color-text-primary)]">
-        Nothing to build to get the work out.
+        Let the agent open the pull request itself.
       </dt>
       <dd class="mt-1.5 text-sm text-[var(--color-text-secondary)] leading-relaxed">
-        The agent holds the checkout and the credential, so it opens the pull request itself. Nothing has to carry a diff back out of the sandbox.
+        It already holds the checkout and the credential, so nothing has to carry a diff back out of the sandbox.
       </dd>
     </div>
     <div class="border-l-2 border-[var(--color-border-strong)] pl-5">
       <dt class="font-medium text-[var(--color-text-primary)]">
-        You never parse a runtime's output.
+        Never parse a runtime's output.
       </dt>
       <dd class="mt-1.5 text-sm text-[var(--color-text-secondary)] leading-relaxed">
         Await the run and read one field. Or stream with <code
@@ -246,12 +263,12 @@
         Pick up where the agent left off.
       </dt>
       <dd class="mt-1.5 text-sm text-[var(--color-text-secondary)] leading-relaxed">
-        A parked sandbox holds the checkout and the work in progress, and wakes on the next message with the files where the agent left them. Nobody has to remember to turn it off.
+        A parked sandbox holds the checkout and the work in progress, and wakes on the next message with the files where the agent left them. It takes none of your concurrency while it waits.
       </dd>
     </div>
     <div class="border-l-2 border-[var(--color-border-strong)] pl-5">
       <dt class="font-medium text-[var(--color-text-primary)]">
-        You can say what changed, and who changed it.
+        Say what changed, and who changed it.
       </dt>
       <dd class="mt-1.5 text-sm text-[var(--color-text-secondary)] leading-relaxed">
         Every change is recorded where it happens, not where the request arrived. An update names the fields that moved and never their values. Agents are versioned, and each conversation records the version it ran under.
@@ -259,7 +276,7 @@
     </div>
   </dl>
   <p class="mt-12 text-lg text-[var(--color-text-primary)] max-w-2xl">
-    {Fountain.Brand.name()} is that machine, that vault and that owner. You keep the product.
+    {Fountain.Brand.name()} runs the machine, holds the credential and keeps the record. You keep the product.
   </p>
 </section>
 

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -188,6 +188,18 @@
       request opened by restating the headline, and the card about the
       Environment ended on the reuse the headline had already promised.
 
+      A DENIED CHORE HAS TO HURT. Naming an ops chore only to take it away is
+      the register this section wants, and two cards do it: "without a
+      redeploy", and the credential that never enters the sandbox. It works
+      because a redeploy is expensive and memorable. It did not work for
+      "Never parse a runtime's output", where the denied chore is one jq
+      filter, and selling the absence of a small chore cost the card the four
+      larger things `Blocks` actually does: one renderer across four dialect
+      parsers (claude, codex, gemini, opencode in `legacy_blocks.ex`, plus
+      ACP), tool calls and approval requests as first-class kinds rather than
+      scraped text, and stored transcripts that survive a runtime change
+      because each event keeps the parser that produced it (0014, #642).
+
       NO dt MAY NAME AN OPS CHORE. The h2 two lines above says the reader did
       not set out to run a sandbox platform, so a card that opens "Set the
       machine up" hands back the job the section just took away, six words
@@ -265,13 +277,13 @@
     </div>
     <div class="border-l-2 border-[var(--color-border-strong)] pl-5">
       <dt class="font-medium text-[var(--color-text-primary)]">
-        Never parse a runtime's output.
+        Render one shape, whatever runtime produced it.
       </dt>
       <dd class="mt-1.5 text-sm text-[var(--color-text-secondary)] leading-relaxed">
-        Await the run and read one field. Or stream with <code
+        Text, thinking, tool calls and their results, and approval requests arrive as the same blocks from every runtime. Ask for them with <code
           class="text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1 py-0.5 text-xs"
           phx-no-format
-        >?blocks=true</code> and the server parses each runtime's dialect, so you render one shape.
+        >?blocks=true</code>, and transcripts you stored before you changed runtime keep rendering, because every event keeps the parser that produced it.
       </dd>
     </div>
     <div class="border-l-2 border-[var(--color-border-strong)] pl-5">

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -242,9 +242,15 @@
       to count the cards, which the reader can see and which is the move
       6291ec55 took out of this same paragraph.
 
-      The closer names one noun per mechanism the grid just showed, so each has
-      a card behind it. It used to end "that machine, that vault and that
-      owner", and "owner" was the only appearance of the word on the page.
+      The closer is one sentence, and it is the turn: after six mechanisms the
+      reader is handed back the only thing they came to build. Everything
+      before the turn is a recap by construction, because the grid two
+      centimetres above just said it in detail, and a recap set on its own
+      line in an empty field reads as a stub rather than a punctuation mark.
+      Two versions have now failed that way: "that machine, that vault and
+      that owner", where "owner" was the only appearance of the word on the
+      page, and the triad that replaced it, which fixed the dangling noun by
+      listing the grid back at the reader and wrapped to two lines to do it.
 
       This is the first of the two sections that set their heading against the
       left edge instead of the centre. Six items of dense reference read down a
@@ -321,7 +327,7 @@
     </div>
   </dl>
   <p class="mt-12 text-lg text-[var(--color-text-primary)] max-w-2xl">
-    {Fountain.Brand.name()} runs the machine, holds the credential and keeps the record. You keep the product.
+    You keep the product.
   </p>
 </section>
 

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -188,6 +188,14 @@
       request opened by restating the headline, and the card about the
       Environment ended on the reuse the headline had already promised.
 
+      NO dt MAY NAME AN OPS CHORE. The h2 two lines above says the reader did
+      not set out to run a sandbox platform, so a card that opens "Set the
+      machine up" hands back the job the section just took away, six words
+      after taking it. The reader's verb is declarative: they describe a
+      machine, they do not build or configure one, and an Environment names a
+      filesystem rather than installing one. The same trap is open to "install",
+      "provision", "configure" and "wire up".
+
       A reuse claim counts runs, not Agents. `environment_id` sits on both
       `agents` and `conversations`, so "point every agent at it" was true and
       still the wrong axis: an account has a handful of Agents and an unbounded
@@ -233,7 +241,7 @@
   <dl class="mt-12 grid sm:grid-cols-2 gap-x-12 gap-y-9">
     <div class="border-l-2 border-[var(--color-border-strong)] pl-5">
       <dt class="font-medium text-[var(--color-text-primary)]">
-        Set the machine up once, then launch every run from it.
+        Describe the machine once, then launch every run from it.
       </dt>
       <dd class="mt-1.5 text-sm text-[var(--color-text-secondary)] leading-relaxed">
         An Environment names the filesystem, the packages, the checkout and the network. You list it and diff it like any other object you keep under version control.

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -203,12 +203,19 @@
       redeploy", and the credential that never enters the sandbox. It works
       because a redeploy is expensive and memorable. It did not work for
       "Never parse a runtime's output", where the denied chore is one jq
-      filter, and selling the absence of a small chore cost the card the four
+      filter, and selling the absence of a small chore cost the card the two
       larger things `Blocks` actually does: one renderer across four dialect
       parsers (claude, codex, gemini, opencode in `legacy_blocks.ex`, plus
-      ACP), tool calls and approval requests as first-class kinds rather than
-      scraped text, and stored transcripts that survive a runtime change
-      because each event keeps the parser that produced it (0014, #642).
+      ACP), and tool calls and approval requests as first-class kinds rather
+      than scraped text.
+
+      A third property is deliberately not on the card. Stored transcripts
+      survive a runtime change, because each event keeps the parser that
+      produced it (0014, #642). It is the most valuable thing here to a reader
+      who has already been bitten by it and the least legible to everyone
+      else, and it needed a subordinate clause about a hypothetical past to
+      say at all, on the card that was already the longest of the six. It
+      belongs in `docs/`, where a reader has the context to want it.
 
       NO dt MAY NAME AN OPS CHORE. The h2 two lines above says the reader did
       not set out to run a sandbox platform, so a card that opens "Set the
@@ -293,7 +300,7 @@
         Text, thinking, tool calls and their results, and approval requests arrive as the same blocks from every runtime. Ask for them with <code
           class="text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1 py-0.5 text-xs"
           phx-no-format
-        >?blocks=true</code>, and transcripts you stored before you changed runtime keep rendering, because every event keeps the parser that produced it.
+        >?blocks=true</code>.
       </dd>
     </div>
     <div class="border-l-2 border-[var(--color-border-strong)] pl-5">

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -157,8 +157,8 @@
 </section>
 
 <%!-- The problem and the answer, in one pass. The h2 concedes the reader's
-      complaint and claims it; each card states one thing they get for that,
-      and the closer hands the product back.
+      complaint and claims it, and each card states one thing they get for
+      that. The section ends on the grid.
 
       The cards were questions until they stopped needing to be. A question
       grid asks a reader who already holds the problem to re-derive it, and
@@ -233,24 +233,25 @@
       already introduces one primitive and the page is not owed a second one in
       the same four lines.
 
-      Three elements, three jobs. The h2 names the problem and claims it, the
-      grid shows the mechanisms, and the closer hands the product back. The
-      lead-in only puts the reader at the moment after the demo worked, and
-      that is all it does: it used to carry a second sentence saying what the
-      h2 had just said, in the register of the h2. It used to end "none of them
-      is your product", which is the closer's line 270 words early, and it used
-      to count the cards, which the reader can see and which is the move
-      6291ec55 took out of this same paragraph.
+      Two elements, two jobs. The h2 names the problem and claims it, and the
+      grid shows the mechanisms. The lead-in only puts the reader at the moment
+      after the demo worked, and that is all it does: it used to carry a second
+      sentence saying what the h2 had just said, in the register of the h2. It
+      used to end "none of them is your product" and it used to count the
+      cards, which the reader can see and which is the move 6291ec55 took out
+      of this same paragraph.
 
-      The closer is one sentence, and it is the turn: after six mechanisms the
-      reader is handed back the only thing they came to build. Everything
-      before the turn is a recap by construction, because the grid two
-      centimetres above just said it in detail, and a recap set on its own
-      line in an empty field reads as a stub rather than a punctuation mark.
-      Two versions have now failed that way: "that machine, that vault and
-      that owner", where "owner" was the only appearance of the word on the
-      page, and the triad that replaced it, which fixed the dangling noun by
-      listing the grid back at the reader and wrapped to two lines to do it.
+      THERE IS NO CLOSER, AND THAT IS THE DECISION. The section used to end on
+      a line handing the product back, and three versions of it failed the same
+      way. "That machine, that vault and that owner" dangled a noun that
+      appeared nowhere else on the page. The triad that replaced it fixed the
+      noun by listing the grid back at the reader. "You keep the product" alone
+      was the only part of that pair doing any work, and on the page it was one
+      short line stranded in the section's bottom padding with the case study
+      panel below it, which reads as something unfinished rather than as a last
+      beat. The grid is the argument and it ends on its own. Anything added
+      here has to be a claim the six cards do not already make, and the two
+      that were tried were both a summary of them.
 
       This is the first of the two sections that set their heading against the
       left edge instead of the centre. Six items of dense reference read down a
@@ -326,9 +327,6 @@
       </dd>
     </div>
   </dl>
-  <p class="mt-12 text-lg text-[var(--color-text-primary)] max-w-2xl">
-    You keep the product.
-  </p>
 </section>
 
 <%!-- Proof. One deployment, in production, with its own numbers.

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -188,6 +188,14 @@
       request opened by restating the headline, and the card about the
       Environment ended on the reuse the headline had already promised.
 
+      A reuse claim counts runs, not Agents. `environment_id` sits on both
+      `agents` and `conversations`, so "point every agent at it" was true and
+      still the wrong axis: an account has a handful of Agents and an unbounded
+      number of runs, and only the second number makes writing the Environment
+      down once worth anything. "Run" over "Conversation" here because the card
+      already introduces one primitive and the page is not owed a second one in
+      the same four lines.
+
       Three elements, three jobs. The h2 names the problem and claims it, the
       grid shows the mechanisms, and the closer hands the product back. The
       lead-in only puts the reader at the moment after the demo worked, and
@@ -225,10 +233,10 @@
   <dl class="mt-12 grid sm:grid-cols-2 gap-x-12 gap-y-9">
     <div class="border-l-2 border-[var(--color-border-strong)] pl-5">
       <dt class="font-medium text-[var(--color-text-primary)]">
-        Set it up once, then point every agent at it.
+        Set the machine up once, then launch every run from it.
       </dt>
       <dd class="mt-1.5 text-sm text-[var(--color-text-secondary)] leading-relaxed">
-        An Environment names the filesystem, the packages, the checkout and the network. You list it, diff it and launch from it, and it outlives every run that uses it.
+        An Environment names the filesystem, the packages, the checkout and the network. You list it and diff it like any other object you keep under version control.
       </dd>
     </div>
     <div class="border-l-2 border-[var(--color-border-strong)] pl-5">

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -188,6 +188,16 @@
       request opened by restating the headline, and the card about the
       Environment ended on the reuse the headline had already promised.
 
+      The imperative fits five of these cleanly, because five are things the
+      reader does with the product. The audit card is a capability they have
+      afterwards without acting, so the mood has to be earned rather than
+      applied: "Say what changed" made the reader the speaker when the system
+      is the one that recorded, and read as an instruction to confess. The verb
+      has to name something they really do against the trail. If a future card
+      is a property rather than an action and no honest verb presents itself,
+      the rule is wrong for that card and it is better to break it in one place
+      than to force a sentence nobody would write.
+
       A DENIED CHORE HAS TO HURT. Naming an ops chore only to take it away is
       the register this section wants, and two cards do it: "without a
       redeploy", and the credential that never enters the sandbox. It works
@@ -296,7 +306,7 @@
     </div>
     <div class="border-l-2 border-[var(--color-border-strong)] pl-5">
       <dt class="font-medium text-[var(--color-text-primary)]">
-        Say what changed, and who changed it.
+        Trace what changed, and who changed it.
       </dt>
       <dd class="mt-1.5 text-sm text-[var(--color-text-secondary)] leading-relaxed">
         Every change is recorded where it happens, not where the request arrived. An update names the fields that moved and never their values. Agents are versioned, and each conversation records the version it ran under.


### PR DESCRIPTION
Tightens the prose in the homepage's **What you get** section. Copy only, no markup, token or layout changes.

### The subhead repeated the h2

> **You did not set out to run a sandbox platform. We did.**
> The agent was the easy part. ~~Under it is everything you would have built next.~~

Both sentences made the same claim in the same register, 20 words apart. The lead-in's stated job is to put the reader at the moment after the demo worked, and the first sentence does that alone.

### The six `dt` lines ran five grammatical shapes

| | Before | After |
|---|---|---|
| 1 | One setup, every agent you run. | Describe the machine once, then launch every run from it. |
| 2 | Change a credential without a redeploy. | *unchanged* |
| 3 | Nothing to build to get the work out. | Let the agent open the pull request itself. |
| 4 | You never parse a runtime's output. | Render one shape, whatever runtime produced it. |
| 5 | Pick up where the agent left off. | *unchanged* |
| 6 | You can say what changed, and who changed it. | Trace what changed, and who changed it. |

Six items down one left edge read either as one inventory or as six unrelated claims, and the grammar decides which. All imperatives now.

Three rules came out of the pass and are recorded in the comment above the section, because each one reads fine in isolation and only breaks against its neighbours:

- **No `dt` names an ops chore.** The h2 says the reader did not set out to run a sandbox platform; "Set the machine up once" handed that job straight back, six words later. Their verb is declarative. Same trap is open to *install*, *provision*, *configure*, *wire up*.
- **A denied chore has to hurt.** Naming a chore to take it away is the right register and cards 2 and 4 use it, but it works in proportion to what the chore costs. A redeploy is expensive; parsing stream-json is one jq filter.
- **No `dd` repeats its own `dt`.** Two did once the headlines got sharper.

### Card 1 counted the wrong thing

`environment_id` sits on **both** `agents` and `conversations`, so "point every agent at it" was true and still the wrong axis: an account has a handful of Agents and an unbounded number of runs, and only the second number makes writing the Environment down once worth anything.

### Card 4 was selling the smallest of three values

"Never parse a runtime's output" is the least of what `Fountain.Conversations.Blocks` does. It now leads with one renderer across four dialect parsers (`legacy_blocks.ex`, plus the ACP path) and names tool calls and approval requests as first-class kinds rather than scraped text. The third property — stored transcripts surviving a runtime change, because each event keeps the parser that produced it (0014, #642) — is deliberately left for `docs/`: it is the most valuable thing here to a reader already bitten by it and the least legible to everyone else.

### The closer is gone

Three versions failed the same way. `that machine, that vault and that owner` dangled a noun appearing nowhere else on the page; the triad that replaced it fixed the noun by summarising the six cards just read; and `You keep the product` alone was one short line stranded in the section's bottom padding above the case study panel, reading as unfinished rather than as a last beat. The grid is the argument and it ends on its own. The comment says so, and says anything added back has to be a claim the six cards do not already make.

### Not changed

The h2 itself. `"sandbox platform"` is arguably company language for a reader who arrives from "how do I run Claude Code on a server", but three tests pin that string and it deserves its own decision.

### Checks

`mix compile --warnings-as-errors`, `mix format --check-formatted`, and the four marketing test files plus `brand_chrome_test.exs` (87 tests) pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176oj6fYqofyFL5nVZvk7q9