### PR TITLE
copy(marketing): the setup h2 says what you get for writing it

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -98,6 +98,22 @@
       database table. They are templates here and in
       .agents/product-marketing.md. "Row" is not a marketing word.
 
+      The h2 makes two claims and needs both. "Once" is what a reader scanning
+      five code blocks is actually asking, and "everything after it is a
+      prompt" is what the section is for. It used to be "This is everything you
+      write", which made the volume claim by pointing at the blocks and left
+      the payoff to be inferred from step 4.
+
+      It does not say "describe", though every step below is declarative and
+      card 1 of "What you get" opens with the word. Step 1's title is "Describe
+      the machine once." and it sits directly under this heading, so an h2
+      taking the same verb and the same "once" reads as a stutter.
+
+      It also does not say "your agents". Three documents are on this page and
+      the Agent is one of them. The split between the machine, the credentials
+      and the agent config is the thing the section exists to show, and a
+      heading that collapses it into "agents" argues against its own steps.
+
       It is on ink, and it is the reason the ink tokens exist. The code is the
       substance of the section and there are five blocks of it, so a light
       ground made five black rectangles float on a white page. On ink they are
@@ -108,7 +124,7 @@
   <div class="max-w-5xl mx-auto px-6 py-16">
     <.eyebrow label="Setup" tone={:ink} />
     <h2 class="mt-4 text-2xl sm:text-3xl font-semibold tracking-tight text-[var(--color-ink-text)] text-center">
-      This is everything you write.
+      You write this once. Everything after it is a prompt.
     </h2>
     <%!-- One beat per document, each annotation on the row of the code it
           describes. `items-start` rather than `items-center`: the prose is two

--- a/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
@@ -817,7 +817,7 @@ defmodule FountainWeb.OpenGraphTest do
     test "the homepage renders it, and the command that applies it", %{conn: conn} do
       body = conn |> get(~p"/") |> html_response(200)
 
-      assert body =~ "This is everything you write."
+      assert body =~ "You write this once."
       assert body =~ "fountain apply -f fountain.yml"
       assert body =~ "kind: Environment"
     end


### PR DESCRIPTION
> ~~This is everything you write.~~
> **You write this once. Everything after it is a prompt.**

The old heading made its claim by pointing at the code blocks below it. That claim is true and it is the one a reader scanning five blocks wants — but it was the whole heading, and the payoff got left to be inferred from step 4 at the bottom of the section.

The new one keeps the volume claim, adds **once** (the second question a reader has, right after "is that all?"), and states the thing the section exists to prove.

### Two words it avoids on purpose

**"Describe."** Every step here is declarative, and card 1 of *What you get* opens with the word. But step 1's title is `Describe the machine once.` and it sits directly under this heading — an h2 taking the same verb *and* the same adverb reads as a stutter.

**"Agents."** Three documents are on this page (`Environment`, `Vault`, `Agent`) and the Agent is one of them. The split between the machine, the credentials and the agent config is exactly what the section is showing, and a heading that collapses it into "your agents" argues against its own steps. `.agents/product-marketing.md` calls that division "the product."

Reasoning is recorded in the comment above the section.

### Checks

`marketing_controller_test.exs:820` pinned the old string and is updated. 87 marketing/brand tests pass locally, plus `mix format` and `mix compile --warnings-as-errors`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176oj6fYqofyFL5nVZvk7q9