### PR TITLE
copy(marketing): the homepage titles itself

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/marketing_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_controller.ex
@@ -37,9 +37,32 @@ defmodule FountainWeb.MarketingController do
     end
   end
 
+  # The one page on the site that set no `:page_title`, so `<title>` and both
+  # card titles were the bare brand name — the only word a reader who has
+  # never heard it learns nothing from. Every other page here carries
+  # "<what it is> · <brand>" and the homepage now does too.
+  #
+  # It is the slot a category label is for. The h1 makes a claim ("A
+  # conversational API to a computer"), which is the right job for a headline
+  # and the wrong one for a tab, a bookmark and a search result, where a
+  # reader is deciding whether this is even the kind of thing they want.
+  # standards/voice-and-style.md is explicit that the audience has no prior
+  # model for the category, and they arrive searching for how to run a coding
+  # agent on a server, not for a phrase from the hero.
+  #
+  # Only on the marketing site. An instance keeps the bare brand: it is a
+  # front door, not the project, and a title selling a category would be this
+  # module's whole objection (#517) in the `<head>`.
+  @site_title "Serverless sandboxes for coding agents"
+
   def home(conn, _params) do
-    page = if Fountain.Marketing.site?(), do: :home, else: :instance
-    render(conn, page, layout: {FountainWeb.Layouts, :marketing})
+    if Fountain.Marketing.site?() do
+      conn
+      |> assign(:page_title, "#{@site_title} · #{Fountain.Brand.name()}")
+      |> render(:home, layout: {FountainWeb.Layouts, :marketing})
+    else
+      render(conn, :instance, layout: {FountainWeb.Layouts, :marketing})
+    end
   end
 
   # The protocols Fountain speaks and what already speaks them. Sales copy,

--- a/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
@@ -5,6 +5,26 @@ defmodule FountainWeb.MarketingControllerTest do
   # the unpublished and placeholder paths live in MarketingLegalUnpublishedTest
   # (async: false — they mutate global app env).
 
+  describe "GET / titling" do
+    test "names the category in the title and both card titles", %{conn: conn} do
+      body = conn |> get(~p"/") |> html_response(200)
+      expected = "Serverless sandboxes for coding agents · #{Fountain.Brand.name()}"
+
+      assert body =~ "<title>#{expected}</title>"
+      assert body =~ ~s(<meta property="og:title" content="#{expected}")
+      assert body =~ ~s(<meta name="twitter:title" content="#{expected}")
+    end
+
+    test "the title is not the bare brand name", %{conn: conn} do
+      # The whole defect: `OpenGraph.title/1` falls back to the brand when a
+      # page sets no `:page_title`, so this page announced only a word a new
+      # reader cannot decode, in the tab, the bookmark and every unfurl.
+      body = conn |> get(~p"/") |> html_response(200)
+
+      refute body =~ "<title>#{Fountain.Brand.name()}</title>"
+    end
+  end
+
   describe "GET /terms" do
     test "renders the terms of service with the configured identity", %{conn: conn} do
       body = conn |> get(~p"/terms") |> html_response(200)
@@ -759,7 +779,14 @@ defmodule FountainWeb.OpenGraphTest do
 
   test "every public page carries an Open Graph card", %{conn: conn} do
     body = conn |> get(~p"/") |> html_response(200)
-    assert body =~ ~s(<meta property="og:title" content="Fountain")
+
+    # This asserted `content="Fountain"` and so was pinning `OpenGraph.title/1`'s
+    # brand-name fallback, which is what a page with no `:page_title` gets. The
+    # homepage has one now. What belongs here is that the card carries a title
+    # ending in the brand; the phrase itself is owned by "GET / titling".
+    assert body =~ ~s(<meta property="og:title" content=")
+    assert body =~ ~s(· #{Fountain.Brand.name()}")
+
     assert body =~ ~s(<meta property="og:url" content="http://localhost:4000/")
 
     assert body =~

--- a/apps/fountain/test/fountain_web/controllers/marketing_instance_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_instance_test.exs
@@ -38,6 +38,11 @@ defmodule FountainWeb.MarketingInstanceTest do
                ~s(<meta property="og:description" content="Fountain runs agents on sandboxes)
 
       assert body =~ ~s(<meta property="og:image:alt" content="Fountain")
+
+      # The title too. The marketing site names the category here; an instance
+      # is a front door and not the project, so it keeps the bare brand.
+      assert body =~ "<title>#{Fountain.Brand.name()}</title>"
+      refute body =~ "Serverless sandboxes for coding agents"
     end
 
     # The footer groups its links now. A deployment that is not the marketing


### PR DESCRIPTION
The homepage set no `:page_title`, so `OpenGraph.title/1` fell through to its brand-name fallback. `<title>`, `og:title` and `twitter:title` were all the single word **Managoat** — the one thing a reader who has never heard of us cannot decode, and the tab, the bookmark, the search result and every Slack unfurl were made of nothing else. Every other page this controller serves already carries `"<what it is> · <brand>"`.

```
<title>Serverless sandboxes for coding agents · Managoat</title>
```

### Why a category label, and why here rather than the h1

The h1 makes a claim — *"A conversational API to a computer"* — which is the right job for a headline and the wrong one for a search result, where the reader is still deciding whether this is even the kind of thing they want. `standards/voice-and-style.md` is explicit that this audience has **no prior model for the category**, and `.agents/product-marketing.md` says they arrive from "how do I run Claude Code / Codex on a server", not from a phrase in the hero.

So the claim keeps the h1 and the category goes in the `<head>`, where it does SEO and unfurl work without costing the headline.

### The instance front door keeps the bare brand

`Fountain.Marketing.site?()` already splits `/` into the pitch and a plain front door. A self-hosted deployment is not the project, and a `<title>` selling a category there would be exactly this module's objection (#517) restated in the `<head>`. `MarketingInstanceTest` now asserts that, next to the card assertions it already makes for the same rule.

### One pre-existing test was pinning the bug

`OpenGraphTest` asserted `og:title content="Fountain"` on the homepage — the fallback, not an intent. It now asserts the card carries a title ending in the brand, and the phrase itself is owned by the new `GET / titling` tests. That keeps one place to change if the label changes.

### Checks

96 marketing/brand/OG tests pass locally, plus `mix format` and `mix compile --warnings-as-errors`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176oj6fYqofyFL5nVZvk7q9