### PR TITLE
copy(marketing): the case study callout says cluster

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -353,7 +353,24 @@
       The four numbers are the peak of the light half of the page: they are
       set larger than any heading below the hero, which is the ranking they
       deserve and the one they did not have when they matched the body text
-      around them. --%>
+      around them.
+
+      The h2 says "cluster" and the rest of the case study says "estate". That
+      is on purpose and it is the only place the two differ. "Estate" is the
+      right word for what the story is about, which is a whole footprint and
+      not one cluster: alerts, Prometheus, node health, controller drift and
+      the repositories behind them. It is also enterprise IT vocabulary, more
+      at home in the UK than here, and .agents/product-marketing.md names the
+      enterprise buyer as the anti-persona. In American English the first
+      prior for the word is real estate.
+
+      A reader deep in the case study has been given the gloss ("The estate is
+      a private Kubernetes cluster run by one person") and can afford the
+      word. A reader scanning the homepage has not, and this heading is where
+      they decide whether the section is for them. It also used to disagree
+      with its own paragraph, which opens "A Kubernetes cluster used to page a
+      person": the unfamiliar word in the heading, the familiar one for the
+      same thing a line later. --%>
 <section class="max-w-5xl mx-auto px-6 pt-8 pb-16">
   <div
     class="rounded-2xl border border-[var(--color-accent-line)] bg-[var(--color-accent-soft)] p-8 sm:p-12"
@@ -361,7 +378,7 @@
   >
     <.eyebrow label="Case study" align={:left} />
     <h2 class="mt-4 text-2xl sm:text-3xl font-semibold tracking-tight text-[var(--color-text-primary)]">
-      An estate that answers its own alerts.
+      A cluster that answers its own alerts.
     </h2>
     <p class="mt-4 text-[var(--color-text-secondary)] max-w-2xl leading-relaxed">
       A Kubernetes cluster used to page a person when a workload broke. Now it also hires an agent, which finds the commit that broke it and opens one small pull request. It cannot merge that request, and the mechanism stopping it is not a system prompt.

--- a/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
@@ -561,7 +561,7 @@ defmodule FountainWeb.MarketingControllerTest do
     test "the homepage and the marketing footer link to it", %{conn: conn} do
       body = conn |> get(~p"/") |> html_response(200)
       assert body =~ ~p"/case-studies/self-healing-infrastructure"
-      assert body =~ "An estate that answers its own alerts."
+      assert body =~ "A cluster that answers its own alerts."
     end
   end
 


### PR DESCRIPTION
> ~~An estate that answers its own alerts.~~
> **A cluster that answers its own alerts.**

### The heading disagreed with its own paragraph

```
An estate that answers its own alerts.
A Kubernetes cluster used to page a person when a workload broke…
```

The unfamiliar word in the heading, the familiar one for the same thing a line later. If "cluster" is good enough for the body, the heading does not need "estate".

### Why the word is wrong *here* and right elsewhere

"Estate" is enterprise IT vocabulary — standard in the UK and EU (*server estate*, *IT estate*, *application estate*), uncommon in US startup and SRE register, where the words are *fleet*, *infra*, *footprint*, *cluster*. `.agents/product-marketing.md` names the enterprise buyer as the **anti-persona** and the reader as a solo builder or small team, so this is the anti-persona's register. In American English the first prior for the word is real estate.

It stays everywhere else. In the case study proper the word is doing real work — the story is a whole footprint, not one cluster: alerts, Prometheus, node health, controller drift, the repos behind them. And that page glosses it: *"The estate is a private Kubernetes cluster run by one person."* A reader that deep has the gloss and can afford the word. A reader scanning the homepage has not, and this heading is where they decide whether the section is for them.

### Deliberately narrow

Not a sweep. `estate` is on the approved-words list in `.agents/product-marketing.md`, carries ~15 sentences of the case study, and the agent is named `estate-medic` in the public `jhgaylor/agent-specs` repo. Ripping it out would be a much larger change and I do not think it is the right one.

Reasoning recorded in the comment above the section, including why the two now differ on purpose.

### Checks

`marketing_controller_test.exs:564` pinned the old string and is updated. 89 marketing/brand tests pass locally, plus `mix format` and `mix compile --warnings-as-errors`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176oj6fYqofyFL5nVZvk7q9