### PR TITLE
copy(marketing): the case study card ends on the credential, and stops underselling the estate

### DIFF
--- a/.agents/product-marketing.md
+++ b/.agents/product-marketing.md
@@ -272,8 +272,10 @@ worked incident; 7.5 minute median incident to verdict; 0 cluster credentials
 the agent holds. Twelve fix pull requests opened, eight merged, four of those a
 rehearsal fault raised on purpose.
 
-The estate is a private Kubernetes cluster run by one person and the numbers are
-its own. **Say that whenever the numbers appear.** The agent's definition is
+The estate is a Kubernetes cluster carrying live production workloads and the
+numbers are its own. **Say that whenever the numbers appear.** It is not a
+hobby cluster and copy must not imply one; the disclosure is that the numbers
+are self-reported from a single estate, not that the estate is small. The agent's definition is
 public at `jhgaylor/agent-specs`.
 
 **Customers:** GAP. No named customers or logos.

--- a/.agents/product-marketing.md
+++ b/.agents/product-marketing.md
@@ -272,10 +272,16 @@ worked incident; 7.5 minute median incident to verdict; 0 cluster credentials
 the agent holds. Twelve fix pull requests opened, eight merged, four of those a
 rehearsal fault raised on purpose.
 
-The estate is a Kubernetes cluster carrying live production workloads and the
-numbers are its own. **Say that whenever the numbers appear.** It is not a
-hobby cluster and copy must not imply one; the disclosure is that the numbers
-are self-reported from a single estate, not that the estate is small. The agent's definition is
+The estate is a Kubernetes cluster carrying live production workloads. We run
+it and we took the measurements. **Say both whenever the numbers appear.**
+
+The disclosure is provenance, not size. Every number is self-reported from a
+single estate rather than audited or drawn from a customer, and that is what a
+reader is owed. It is not a hobby cluster and copy must not imply one: "a
+private cluster run by one person" conceded smallness, which is neither true
+nor the thing being disclosed. "The numbers are its own" then failed the other
+way, because a possessive asserts nothing about who measured. Name the two
+facts plainly, that we run it and that we counted. The agent's definition is
 public at `jhgaylor/agent-specs`.
 
 **Customers:** GAP. No named customers or logos.

--- a/.agents/product-marketing.md
+++ b/.agents/product-marketing.md
@@ -272,16 +272,20 @@ worked incident; 7.5 minute median incident to verdict; 0 cluster credentials
 the agent holds. Twelve fix pull requests opened, eight merged, four of those a
 rehearsal fault raised on purpose.
 
-The estate is a Kubernetes cluster carrying live production workloads. We run
-it and we took the measurements. **Say both whenever the numbers appear.**
+The estate is a Kubernetes cluster carrying live production workloads. Numbers
+reported by the cluster administrator (us). **Say both whenever the numbers
+appear, and keep the "(us)".** Without it the role noun reads as a neutral
+third party, on a page where the administrator and the seller are the same
+party. That conflict is the disclosure, so hiding it behind a job title is
+worse than saying nothing.
 
 The disclosure is provenance, not size. Every number is self-reported from a
 single estate rather than audited or drawn from a customer, and that is what a
 reader is owed. It is not a hobby cluster and copy must not imply one: "a
 private cluster run by one person" conceded smallness, which is neither true
 nor the thing being disclosed. "The numbers are its own" then failed the other
-way, because a possessive asserts nothing about who measured. Name the two
-facts plainly, that we run it and that we counted. The agent's definition is
+way, because a possessive asserts nothing about who measured. Name the source
+and admit it is us. The agent's definition is
 public at `jhgaylor/agent-specs`.
 
 **Customers:** GAP. No named customers or logos.

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/case_study_self_healing.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/case_study_self_healing.html.heex
@@ -306,7 +306,7 @@
     </a>
   </div>
   <p class="mt-10 text-xs text-[var(--color-text-muted)] max-w-2xl mx-auto leading-relaxed">
-    The estate is a private Kubernetes cluster run by one person, and the numbers are its own. Twelve fix pull requests opened in the window and eight merged, four of them the same rehearsal fault raised on purpose. Most incidents end with no pull request, because the agent decides the repository cannot fix them. The agent's definition is public at <a
+    The estate is a Kubernetes cluster carrying live production workloads, and the numbers are its own. Twelve fix pull requests opened in the window and eight merged, four of them the same rehearsal fault raised on purpose. Most incidents end with no pull request, because the agent decides the repository cannot fix them. The agent's definition is public at <a
       href="https://github.com/jhgaylor/agent-specs/blob/main/src/agents/specialists/engineering/estate-medic.ts"
       class="underline underline-offset-2 hover:text-[var(--color-text-secondary)]"
     >jhgaylor/agent-specs</a>.

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/case_study_self_healing.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/case_study_self_healing.html.heex
@@ -306,7 +306,7 @@
     </a>
   </div>
   <p class="mt-10 text-xs text-[var(--color-text-muted)] max-w-2xl mx-auto leading-relaxed">
-    The estate is a Kubernetes cluster carrying live production workloads. We run it and we took the measurements. Twelve fix pull requests opened in the window and eight merged, four of them the same rehearsal fault raised on purpose. Most incidents end with no pull request, because the agent decides the repository cannot fix them. The agent's definition is public at <a
+    The estate is a Kubernetes cluster carrying live production workloads. Numbers reported by the cluster administrator (us). Twelve fix pull requests opened in the window and eight merged, four of them the same rehearsal fault raised on purpose. Most incidents end with no pull request, because the agent decides the repository cannot fix them. The agent's definition is public at <a
       href="https://github.com/jhgaylor/agent-specs/blob/main/src/agents/specialists/engineering/estate-medic.ts"
       class="underline underline-offset-2 hover:text-[var(--color-text-secondary)]"
     >jhgaylor/agent-specs</a>.

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/case_study_self_healing.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/case_study_self_healing.html.heex
@@ -306,7 +306,7 @@
     </a>
   </div>
   <p class="mt-10 text-xs text-[var(--color-text-muted)] max-w-2xl mx-auto leading-relaxed">
-    The estate is a Kubernetes cluster carrying live production workloads, and the numbers are its own. Twelve fix pull requests opened in the window and eight merged, four of them the same rehearsal fault raised on purpose. Most incidents end with no pull request, because the agent decides the repository cannot fix them. The agent's definition is public at <a
+    The estate is a Kubernetes cluster carrying live production workloads. We run it and we took the measurements. Twelve fix pull requests opened in the window and eight merged, four of them the same rehearsal fault raised on purpose. Most incidents end with no pull request, because the agent decides the repository cannot fix them. The agent's definition is public at <a
       href="https://github.com/jhgaylor/agent-specs/blob/main/src/agents/specialists/engineering/estate-medic.ts"
       class="underline underline-offset-2 hover:text-[var(--color-text-secondary)]"
     >jhgaylor/agent-specs</a>.

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -355,6 +355,28 @@
       deserve and the one they did not have when they matched the body text
       around them.
 
+      THE LAST SENTENCE IS THE CREDENTIAL, NOT THE MERGE. Two mechanisms hold
+      this agent and they are not the same one. It never holds a cluster
+      credential, which is the `0` stat directly below and the thing it is
+      unable to do. It cannot merge, which is GitHub refusing a self-approval
+      from an account that does hold a token: it clones, pushes a branch and
+      opens the request. Copy that says the keys are kept away from the agent
+      and then points at the merge has fused the two, and the merge half is
+      false.
+
+      The paragraph leads on the credential because that is the reader's
+      actual fear (.agents/product-marketing.md calls handing a real
+      credential to a model "the product's best material"), and because the
+      stat under it counts exactly that. It sets the number up rather than
+      restating its note, which already reads "No kubectl, no kubeconfig, no
+      write path of its own".
+
+      It used to end "the mechanism stopping it is not a system prompt". True,
+      and it only lands for a reader who already knows a system prompt is the
+      usual way an agent gets constrained, which is a lot to assume in the
+      last clause of a card. A credential the agent was never given is the
+      same argument without the prerequisite.
+
       The h2 says "cluster" and the rest of the case study says "estate". That
       is on purpose and it is the only place the two differ. "Estate" is the
       right word for what the story is about, which is a whole footprint and
@@ -381,7 +403,7 @@
       A cluster that answers its own alerts.
     </h2>
     <p class="mt-4 text-[var(--color-text-secondary)] max-w-2xl leading-relaxed">
-      A Kubernetes cluster used to page a person when a workload broke. Now it also starts an agent, which finds the commit that broke it and opens one small pull request. It cannot merge that request, and the mechanism stopping it is not a system prompt.
+      A Kubernetes cluster used to page a person when a workload broke. Now it also starts an agent, which finds the commit that broke it and opens one small pull request. The agent never holds a credential for the cluster it is fixing, and a person still merges the request.
     </p>
     <dl class="mt-10 grid grid-cols-2 gap-x-8 gap-y-8 sm:grid-cols-4 sm:gap-x-6">
       <div :for={stat <- case_stats()}>

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -417,7 +417,7 @@
       </div>
     </dl>
     <p class="mt-8 max-w-2xl text-xs text-[var(--color-text-secondary)]">
-      Counted on one production estate over {case_window()}. It is a Kubernetes cluster carrying live production workloads, and the numbers are its own.
+      Counted over {case_window()} on one production estate, a Kubernetes cluster carrying live production workloads. We run it and we took the measurements.
     </p>
     <div class="mt-8 flex flex-col sm:flex-row gap-3">
       <a

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -417,7 +417,7 @@
       </div>
     </dl>
     <p class="mt-8 max-w-2xl text-xs text-[var(--color-text-secondary)]">
-      Counted over {case_window()} on one production estate, a Kubernetes cluster carrying live production workloads. We run it and we took the measurements.
+      Counted over {case_window()} on one production estate, a Kubernetes cluster carrying live production workloads. Numbers reported by the cluster administrator (us).
     </p>
     <div class="mt-8 flex flex-col sm:flex-row gap-3">
       <a

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -387,7 +387,7 @@
       prior for the word is real estate.
 
       A reader deep in the case study has been given the gloss ("The estate is
-      a private Kubernetes cluster run by one person") and can afford the
+      a Kubernetes cluster carrying live production workloads") and can afford the
       word. A reader scanning the homepage has not, and this heading is where
       they decide whether the section is for them. It also used to disagree
       with its own paragraph, which opens "A Kubernetes cluster used to page a
@@ -417,7 +417,7 @@
       </div>
     </dl>
     <p class="mt-8 max-w-2xl text-xs text-[var(--color-text-secondary)]">
-      Counted on one production estate over {case_window()}. It is a private Kubernetes cluster run by one person, and the numbers are its own.
+      Counted on one production estate over {case_window()}. It is a Kubernetes cluster carrying live production workloads, and the numbers are its own.
     </p>
     <div class="mt-8 flex flex-col sm:flex-row gap-3">
       <a


### PR DESCRIPTION
Two changes to the homepage case study callout, plus the attribution footnote it shares with the case study page.

## 1. The card ends on the credential

> ~~It cannot merge that request, and the mechanism stopping it is not a system prompt.~~
> **The agent never holds a credential for the cluster it is fixing, and a person still merges the request.**

The old ending is true, but only lands for a reader who already knows a system prompt is the usual way an agent gets constrained. That is a lot to assume in the last clause of a card. A credential the agent was never given makes the same argument with no prerequisite.

**The trap here: two mechanisms hold this agent and they are not the same one.**

| | Mechanism | Evidence |
|---|---|---|
| The cluster | it was never given a way in | `0 cluster credentials the agent holds` |
| The merge | GitHub refuses a self-approval | step 7 · `422 on self-approval · 405 on self-merge` |

The agent **does** hold a GitHub token — it clones, pushes a branch, opens the request and answers review comments (`case_guardrails`, `can:` "Open a pull request…"). So copy saying the keys are kept away from the agent and then pointing at *the merge* would fuse the two, and the merge half would be false. They are separate clauses here for that reason.

Leading on the credential also **sets up the `0` stat directly below** instead of restating its caption, and it is the reader's actual fear — `.agents/product-marketing.md` calls handing a real credential to a model "the product's best material."

## 2. The attribution footnote stops underselling the estate

Three attempts, each failing in a different direction. All three are recorded in `.agents/product-marketing.md`, which mandates this sentence ("Say that whenever the numbers appear") and so carries a third copy of it.

| Version | Why it failed |
|---|---|
| ~~A private Kubernetes cluster run by one person, and the numbers are its own~~ | conceded **smallness**, which is untrue and is not what a reader is owed |
| ~~…and the numbers are its own~~ | a possessive asserts nothing about **who measured** |
| **The estate is a Kubernetes cluster carrying live production workloads. Numbers reported by the cluster administrator (us).** | names the source and admits it is us |

The `(us)` is load-bearing. "The cluster administrator" alone is third person, and on a vendor's own page that implies a neutral party supplied the figures. The administrator and the seller are the same party, and **that conflict is the disclosure** — hiding it behind a job title is worse than saying nothing. The doc now says to keep it, since it is the kind of thing a later editor trims as redundant.

**No new figures.** The estate carries live production workloads; the workload count and anything about how the cluster is built are unsourced here, and `.agents/product-marketing.md` is explicit that an invented metric costs more than a blank line.

## Scope

The "system prompt" phrase appeared nowhere else. The attribution sentence appears in three places (case study footnote, homepage callout footnote, and the doc that mandates it) and all three are updated. The case study page's own subhead is worded differently and is untouched.

Reasoning for both is recorded in the comment above the homepage section, including which mechanism is which — the two are easy to fuse and only one direction of that mistake is visible on the page.

## Checks

No test pinned any of these strings. 83 marketing/brand tests pass locally, plus `mix format`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176oj6fYqofyFL5nVZvk7q9