### PR TITLE
marketing: the limits move to the FAQ, and the homepage becomes two forks

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
@@ -1298,6 +1298,25 @@ defmodule FountainWeb.MarketingHTML do
         docs_label: "Build a chat app"
       },
       %{
+        q: "Can two people share one conversation?",
+        a:
+          "Not as a shared inbox. One conversation is one thread on one machine, so " <>
+            "two users pointed at the same one see each other's work and each other's " <>
+            "files. Give each person a conversation id of their own. Your account holds " <>
+            "the agents, and the ids are yours to assign.",
+        docs: "concepts/conversation",
+        docs_label: "About conversations"
+      },
+      %{
+        q: "Can an agent start another agent, and how deep does that go?",
+        a:
+          "It can, and the agent it starts can do the same from inside its own " <>
+            "sandbox. Nothing caps the depth on our side, so the balance is the " <>
+            "backstop rather than a limit #{Fountain.Brand.name()} enforces. Treat a " <>
+            "spawning agent the way you would treat a recursive job anywhere else, and " <>
+            "watch the balance while you do."
+      },
+      %{
         q: "Is this only good for writing code?",
         a:
           "The runtimes are coding agents, which is to say a shell, a filesystem and a " <>

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -588,71 +588,32 @@
   </p>
 </section>
 
-<%!-- The limits, stated before the price rather than discovered after it. Every
-      number here reads from the same settings the quota enforces. This is the
-      only place the concurrency rule is explained outside the price card.
+<%!-- Questions, where the limits used to be.
 
-      The h2 does not name the section, because `eyebrow` already did. It used
-      to read "The limits, before you build on them", whose first two words
-      repeated the label directly above them and whose remaining five told the
-      reader when to read rather than what any of it meant. A heading that
-      announces its own section spends the largest type in the section saying
-      nothing.
+      This was a three-item list of things the product cannot do: no depth cap
+      on recursion, no shared conversations, no organizations or seats. Those
+      are now answers on /faq, and the two that were missing from it were
+      written when this came out (the third, orgs and seats, has been in
+      `security_absent/0` verbatim the whole time).
 
-      What the section is actually doing is volunteering bad news. Nobody asked
-      whether recursion has a depth cap, whether two people can share a
-      conversation, or whether there are organizations. The three answers are
-      no, no and no, and they arrive unprompted and above the price rather than
-      in a support thread afterwards. That is the claim, and the sentence in
-      this comment made it better than the heading did.
+      What stays is the signpost, and it is not decoration. A page that sells
+      hard and mentions no limit anywhere is the shape the voice standard
+      argues against, and the pinned `/faq#security` link (a test asserts it on
+      this page) is the one URL a reader forwards to somebody who has to
+      approve this. Both survive here without the homepage carrying a list that
+      goes stale as the tickets close.
 
-      So the heading is the concession itself. It carries no noun from the
-      section because it does not need one: three items sit directly under it,
-      and a reader who has met the eyebrow knows what "these" are. --%>
-The second of the two left-aligned sections, and for the same reason as
-the first: it is reference, read down a margin. Setting it left also
-separates it from the protocol list directly above, which is centred and
-is otherwise the same shape of thing. --%>
+      Left-aligned, and it keeps the rule above it: it is still reference, and
+      it still separates the centred protocol list from the band below. --%>
 <section class="max-w-5xl mx-auto px-6 pb-16">
   <div class="border-t border-[var(--color-border)] pt-16">
-    <.eyebrow label="Limits" align={:left} />
+    <.eyebrow label="Questions" align={:left} />
     <h2 class="mt-4 text-2xl sm:text-3xl font-semibold tracking-tight text-[var(--color-text-primary)]">
-      Better to hear these from us.
+      What it cannot do is written down.
     </h2>
-
-    <dl class="mt-10 grid gap-x-12 gap-y-8 sm:grid-cols-3">
-      <div class="border-l-2 border-[var(--color-border-strong)] pl-5">
-        <dt class="font-medium text-[var(--color-text-primary)]">Recursion is yours to bound</dt>
-        <dd class="mt-1.5 text-sm text-[var(--color-text-secondary)] leading-relaxed">
-          An agent that starts agents can do it again from inside the one it started. Nothing caps the depth on our side; your balance is the backstop.
-        </dd>
-      </div>
-
-      <div class="border-l-2 border-[var(--color-border-strong)] pl-5">
-        <dt class="font-medium text-[var(--color-text-primary)]">
-          A conversation is not a shared inbox
-        </dt>
-        <dd class="mt-1.5 text-sm text-[var(--color-text-secondary)] leading-relaxed">
-          One conversation is one thread on one machine. Two users pointed at the same one see each other's work. Give each an id of their own.
-        </dd>
-      </div>
-
-      <div class="border-l-2 border-[var(--color-border-strong)] pl-5">
-        <dt class="font-medium text-[var(--color-text-primary)]">An account is one person</dt>
-        <dd class="mt-1.5 text-sm text-[var(--color-text-secondary)] leading-relaxed">
-          No organizations, no seats, no single sign-on. A team shares an account, or runs its own instance.
-        </dd>
-      </div>
-    </dl>
-    <%!-- The questions used to be a section of their own here, 48 words and a
-          tinted band whose only job was two links the footer already carries.
-          Limits and questions are the same beat for the same reader, so the
-          links close this section instead. Keep the `/faq#security` one: a
-          reader forwarding an answer wants one URL to forward, and a test
-          pins it. --%>
     <div class="mt-10 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
       <p class="text-sm text-[var(--color-text-secondary)] max-w-lg">
-        More of them are on the questions page, beside what a security reviewer asks, each answer a mechanism rather than an intention.
+        The limits are on the questions page, beside what a security reviewer asks, each answer a mechanism rather than an intention.
       </p>
       <div class="flex flex-col sm:flex-row gap-3 sm:shrink-0">
         <a

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -522,6 +522,19 @@
   </section>
 </div>
 
+<%!-- FORK ONE: drive it with the stack you have, or start from something that
+      already works. Two sections on one surface with a rule between them,
+      which is the shape State and Scale use above for the same reason.
+
+      On the page ground rather than a tint, because the band above is tinted
+      and two tinted regions with nothing between them read as one long tint.
+      The rule does the pairing instead.
+
+      Apps used to be banded with Self-host, on the argument that both are the
+      reader looking at somebody else's copy of the product. True, and the
+      wrong cut. An app you start from is the alternative to writing against
+      the protocols; running it yourself is the alternative to paying us. Each
+      fork now sits beside the thing it forks. --%>
 <%!-- Bring your own stack. Four protocols, one of which is behind a flag, so
       this is where the badge legend lives: it is the first badge a reader
       meets, and everything above it is generally available. How to turn the
@@ -588,61 +601,13 @@
   </p>
 </section>
 
-<%!-- Questions, where the limits used to be.
-
-      This was a three-item list of things the product cannot do: no depth cap
-      on recursion, no shared conversations, no organizations or seats. Those
-      are now answers on /faq, and the two that were missing from it were
-      written when this came out (the third, orgs and seats, has been in
-      `security_absent/0` verbatim the whole time).
-
-      What stays is the signpost, and it is not decoration. A page that sells
-      hard and mentions no limit anywhere is the shape the voice standard
-      argues against, and the pinned `/faq#security` link (a test asserts it on
-      this page) is the one URL a reader forwards to somebody who has to
-      approve this. Both survive here without the homepage carrying a list that
-      goes stale as the tickets close.
-
-      Left-aligned, and it keeps the rule above it: it is still reference, and
-      it still separates the centred protocol list from the band below. --%>
+<%!-- The apps, in one section. The flagship three as cards, the rest of the
+      roster as chips under them. These used to be two adjacent sections with
+      two intros and two buttons saying the same thing. Cards come from
+      built_apps/0, so the homepage cannot name an app /built-with has renamed
+      or retired. --%>
 <section class="max-w-5xl mx-auto px-6 pb-16">
   <div class="border-t border-[var(--color-border)] pt-16">
-    <.eyebrow label="Questions" align={:left} />
-    <h2 class="mt-4 text-2xl sm:text-3xl font-semibold tracking-tight text-[var(--color-text-primary)]">
-      What it cannot do is written down.
-    </h2>
-    <div class="mt-10 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-      <p class="text-sm text-[var(--color-text-secondary)] max-w-lg">
-        The limits are on the questions page, beside what a security reviewer asks, each answer a mechanism rather than an intention.
-      </p>
-      <div class="flex flex-col sm:flex-row gap-3 sm:shrink-0">
-        <a
-          href={~p"/faq"}
-          class="inline-flex items-center justify-center px-5 py-2.5 rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-bg-1)] text-[var(--color-text-primary)] text-sm font-medium hover:bg-[var(--color-bg-2)] transition-colors"
-        >
-          Get the answers
-        </a>
-        <a
-          href={~p"/faq#security"}
-          class="inline-flex items-center justify-center px-5 py-2.5 rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-bg-1)] text-[var(--color-text-primary)] text-sm font-medium hover:bg-[var(--color-bg-2)] transition-colors"
-        >
-          The security answers
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
-
-<%!-- The second band: what other people have already built on this, and what
-      it takes to run it yourself. Both are the reader looking at somebody
-      else's copy of the product. --%>
-<div class="bg-[var(--color-band)] border-y border-[var(--color-border)]">
-  <%!-- The apps, in one section. The flagship three as cards, the rest of the
-        roster as chips under them. These used to be two adjacent sections with
-        two intros and two buttons saying the same thing. Cards come from
-        built_apps/0, so the homepage cannot name an app /built-with has renamed
-        or retired. --%>
-  <section class="max-w-5xl mx-auto px-6 py-16">
     <.eyebrow label="Apps" />
     <h2 class="mt-4 text-2xl sm:text-3xl font-semibold tracking-tight text-[var(--color-text-primary)] text-center">
       Start from an app that already works.
@@ -716,52 +681,31 @@
         See what people built
       </a>
     </p>
-  </section>
+  </div>
+</section>
 
-  <%!-- Lane three's section on the homepage. The runner concession sits beside
-        the runner claim rather than a page away, because the hero promises a
-        boundary and a runner has none. --%>
-  <section class="max-w-5xl mx-auto px-6 pb-16">
-    <div class="border-t border-[var(--color-border)] pt-16">
-      <.eyebrow label="Self-host" />
-      <h2 class="mt-4 text-2xl sm:text-3xl font-semibold tracking-tight text-[var(--color-text-primary)] text-center">
-        Or run the whole thing yourself.
-      </h2>
-      <p class="mt-3 text-center text-[var(--color-text-secondary)] max-w-xl mx-auto text-lg">
-        Two reasons to go: your customers' code cannot leave your infrastructure, or you need more machines than the ceiling allows.
-      </p>
-
-      <div class="mt-10 max-w-2xl mx-auto space-y-4 text-[var(--color-text-secondary)] leading-relaxed">
-        <p>
-          {Fountain.Brand.engine()} is open source and nothing is held back from the copy you run; a compose file brings an instance up. Or keep this platform and serve only the sandboxes: a runner dials out, needs no inbound port and burns no credit.
-        </p>
-        <p class="border-l-2 border-[var(--color-accent-line)] pl-4 text-sm text-[var(--color-text-muted)]">
-          A runner runs in trusted mode: the agent's processes run as you, with your network and tools and no container between. Run one where you would hand a colleague a shell.
-        </p>
-      </div>
-
-      <p class="mt-10 text-center">
-        <a
-          href={~p"/self-hosted"}
-          class="inline-flex items-center justify-center px-5 py-2.5 rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-bg-1)] text-[var(--color-text-primary)] text-sm font-medium hover:bg-[var(--color-bg-2)] transition-colors"
-        >
-          What it takes to run it yourself
-        </a>
-      </p>
-    </div>
-  </section>
-</div>
-
-<%!-- The finale, on ink: the price, then the ask.
+<%!-- FORK TWO, and the finale, on ink: what it costs, how to owe us nothing,
+      what it cannot do, then the ask.
 
       Pricing used to sit *after* the closing call to action, so the page said
       goodbye and then kept talking about money. It now answers the last
-      question a convinced reader has and hands them the button underneath it.
+      questions a convinced reader has and hands them the button underneath
+      them.
 
-      The two are separate sections sharing one surface rather than one
-      section, because a deployment that prices nothing renders no pricing and
-      the closer has to stand on its own. It does: same ink, same ask, no seam
-      where the price would have been. --%>
+      Self-host is the other half of the price. "What does this cost" and "what
+      if I would rather it cost nothing and run on my own hardware" are one
+      question with two answers, so they share a surface.
+
+      Questions is last before the ask, because a limit is the final thing
+      between a convinced reader and the button, and `/faq#security` is the URL
+      they forward to whoever has to approve it.
+
+      Four sections sharing one surface rather than one section, because a
+      deployment that prices nothing renders no pricing and the rest has to
+      stand without it. It does: same ink, same ask, no seam where the price
+      would have been. That is also why the self-host heading no longer opens
+      with "Or". With `pricing?()` false there is nothing above it for the "Or"
+      to answer. --%>
 
 <%!-- Pricing (ADR 0031): credits are the product. Rendered only where the
       deployment bills, so a self-hosted instance shows nothing. The three
@@ -867,6 +811,90 @@
           A new conversation or prompt is refused until the balance is positive again.
           Anything already running finishes, even below zero.
         </p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<%!-- Lane three's section on the homepage. The runner concession sits beside
+      the runner claim rather than a page away, because the hero promises a
+      boundary and a runner has none. --%>
+<section class="bg-[var(--color-ink-0)]">
+  <div class="max-w-5xl mx-auto px-6 pb-16">
+    <div class="border-t border-[var(--color-ink-border)] pt-16">
+      <.eyebrow label="Self-host" tone={:ink} />
+      <h2 class="mt-4 text-2xl sm:text-3xl font-semibold tracking-tight text-[var(--color-ink-text)] text-center">
+        Run the whole thing yourself.
+      </h2>
+      <p class="mt-3 text-center text-[var(--color-ink-secondary)] max-w-xl mx-auto text-lg">
+        Two reasons to go: your customers' code cannot leave your infrastructure, or you need more machines than the ceiling allows.
+      </p>
+
+      <div class="mt-10 max-w-2xl mx-auto space-y-4 text-[var(--color-ink-secondary)] leading-relaxed">
+        <p>
+          {Fountain.Brand.engine()} is open source and nothing is held back from the copy you run; a compose file brings an instance up. Or keep this platform and serve only the sandboxes: a runner dials out, needs no inbound port and burns no credit.
+        </p>
+        <p class="border-l-2 border-[var(--color-ink-border)] pl-4 text-sm text-[var(--color-ink-secondary)]">
+          A runner runs in trusted mode: the agent's processes run as you, with your network and tools and no container between. Run one where you would hand a colleague a shell.
+        </p>
+      </div>
+
+      <p class="mt-10 text-center">
+        <a
+          href={~p"/self-hosted"}
+          class="inline-flex items-center justify-center px-5 py-2.5 rounded-lg border border-[var(--color-ink-border)] bg-[var(--color-ink-1)] text-[var(--color-ink-text)] text-sm font-medium hover:bg-[var(--color-ink-2)] transition-colors"
+        >
+          What it takes to run it yourself
+        </a>
+      </p>
+    </div>
+  </div>
+</section>
+
+<%!-- Questions, where the limits used to be.
+
+      This was a three-item list of things the product cannot do: no depth cap
+      on recursion, no shared conversations, no organizations or seats. Those
+      are now answers on /faq, and the two that were missing from it were
+      written when this came out (the third, orgs and seats, has been in
+      `security_absent/0` verbatim the whole time).
+
+      What stays is the signpost, and it is not decoration. A page that sells
+      hard and mentions no limit anywhere is the shape the voice standard
+      argues against, and the pinned `/faq#security` link (a test asserts it on
+      this page) is the one URL a reader forwards to somebody who has to
+      approve this. Both survive here without the homepage carrying a list that
+      goes stale as the tickets close.
+
+      Left-aligned, which is what it was when it sat under the protocol list.
+      It keeps that here for a different reason: it is the one section of the
+      ink finale that is reference rather than pitch, and the margin says so
+      against the two centred sections above it. --%>
+<section class="bg-[var(--color-ink-0)]">
+  <div class="max-w-5xl mx-auto px-6 pb-16">
+    <div class="border-t border-[var(--color-ink-border)] pt-16">
+      <.eyebrow label="Questions" align={:left} tone={:ink} />
+      <h2 class="mt-4 text-2xl sm:text-3xl font-semibold tracking-tight text-[var(--color-ink-text)]">
+        What it cannot do is written down.
+      </h2>
+      <div class="mt-10 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <p class="text-sm text-[var(--color-ink-secondary)] max-w-lg">
+          The limits are on the questions page, beside what a security reviewer asks, each answer a mechanism rather than an intention.
+        </p>
+        <div class="flex flex-col sm:flex-row gap-3 sm:shrink-0">
+          <a
+            href={~p"/faq"}
+            class="inline-flex items-center justify-center px-5 py-2.5 rounded-lg border border-[var(--color-ink-border)] bg-[var(--color-ink-1)] text-[var(--color-ink-text)] text-sm font-medium hover:bg-[var(--color-ink-2)] transition-colors"
+          >
+            Get the answers
+          </a>
+          <a
+            href={~p"/faq#security"}
+            class="inline-flex items-center justify-center px-5 py-2.5 rounded-lg border border-[var(--color-ink-border)] bg-[var(--color-ink-1)] text-[var(--color-ink-text)] text-sm font-medium hover:bg-[var(--color-ink-2)] transition-colors"
+          >
+            The security answers
+          </a>
+        </div>
       </div>
     </div>
   </div>

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -592,15 +592,32 @@
       number here reads from the same settings the quota enforces. This is the
       only place the concurrency rule is explained outside the price card.
 
-      The second of the two left-aligned sections, and for the same reason as
-      the first: it is reference, read down a margin. Setting it left also
-      separates it from the protocol list directly above, which is centred and
-      is otherwise the same shape of thing. --%>
+      The h2 does not name the section, because `eyebrow` already did. It used
+      to read "The limits, before you build on them", whose first two words
+      repeated the label directly above them and whose remaining five told the
+      reader when to read rather than what any of it meant. A heading that
+      announces its own section spends the largest type in the section saying
+      nothing.
+
+      What the section is actually doing is volunteering bad news. Nobody asked
+      whether recursion has a depth cap, whether two people can share a
+      conversation, or whether there are organizations. The three answers are
+      no, no and no, and they arrive unprompted and above the price rather than
+      in a support thread afterwards. That is the claim, and the sentence in
+      this comment made it better than the heading did.
+
+      So the heading is the concession itself. It carries no noun from the
+      section because it does not need one: three items sit directly under it,
+      and a reader who has met the eyebrow knows what "these" are. --%>
+The second of the two left-aligned sections, and for the same reason as
+the first: it is reference, read down a margin. Setting it left also
+separates it from the protocol list directly above, which is centred and
+is otherwise the same shape of thing. --%>
 <section class="max-w-5xl mx-auto px-6 pb-16">
   <div class="border-t border-[var(--color-border)] pt-16">
     <.eyebrow label="Limits" align={:left} />
     <h2 class="mt-4 text-2xl sm:text-3xl font-semibold tracking-tight text-[var(--color-text-primary)]">
-      The limits, before you build on them.
+      Better to hear these from us.
     </h2>
 
     <dl class="mt-10 grid gap-x-12 gap-y-8 sm:grid-cols-3">

--- a/apps/fountain/priv/static/assets/paper.css
+++ b/apps/fountain/priv/static/assets/paper.css
@@ -12,12 +12,18 @@
  * templates keep their classes and the classic look is one attribute away:
  * `/?skin=classic`.
  *
- * The three sections built on `--color-ink-*` (setup, pricing, the closer) are
- * dark in the classic skin. On paper they are not: the ink scale is redefined
- * here as the deeper sheet the page is printed on, and the closer alone takes
- * the ink back by redeclaring those same custom properties *on its own
- * element*, which every Tailwind `var(--color-ink-…)` class inside it then
- * reads. One inverted block at the end, like the back of a card.
+ * The sections built on `--color-ink-*` are dark in the classic skin. On paper
+ * they are not: the ink scale is redefined here as the deeper sheet the page is
+ * printed on, so an ink section is a tinted band rather than a black slab.
+ *
+ * There are five of them on the homepage now: setup near the top, then pricing,
+ * self-host, questions and the closer, which run together as one band at the
+ * end. Nothing here needs to know the count, because the skin redefines the
+ * tokens rather than naming sections, but the number is worth knowing before
+ * you decide the page has too much of one surface on it.
+ *
+ * The closer used to redeclare these properties on its own element to take the
+ * ink back. It no longer does; see "No inverted block" below.
  *
  * ONE FILE, unlike `tokens.css`. That one is split into a commented source and
  * a stripped served copy with nothing generating the second, which is a drift


### PR DESCRIPTION
Two changes to the homepage: the limits section becomes a signpost, and the page's four loose middle sections become two forks.

## 1. The limits move to the questions page

| Limit | FAQ | Issue |
|---|---|---|
| Recursion has no depth cap | **new answer** | [#1269](https://github.com/BinaryBourbon/fountain/issues/1269) |
| A conversation is not a shared inbox | **new answer** | [#1270](https://github.com/BinaryBourbon/fountain/issues/1270) |
| An account is one person | already in `security_absent/0`, verbatim | **none, deliberately** |

**No issue for organizations and seats.** That is a gate, not a gap — `CLAUDE.md` holds org and team features out of scope until 100 weekly active users, so a ticket to add them would argue against the roadmap. It is already disclosed, in a list whose docstring forbids softening a row into "coming soon".

The section stays as a four-line signpost rather than being deleted, for one hard reason: `marketing_controller_test.exs:348` pins `/faq#security` to the homepage, and the footer carries `/faq` without the anchor. Deleting outright breaks the test and drops the only deep link into the security answers — the URL a reader forwards to whoever approves this. Nothing on the homepage now goes stale as #1269 and #1270 close.

## 2. The page is two forks

Protocols, Apps, Pricing and Self-host were arranged by what they are. They are now arranged by the choice each offers.

```
tint    State · Scale
ground  FORK ONE   Protocols ── rule ── Apps
band    FORK TWO   Pricing ── Self-host ── Questions ── Closer
```

**Fork one** — drive it with the stack you have, or start from an app that already works. On the page ground rather than a tint, because the band above is tinted and two tinted regions with nothing between read as one long tint. A rule pairs them, the shape State and Scale already use.

**Fork two** — what it costs, how to owe us nothing, what it cannot do, then the ask.

Apps used to be banded with Self-host, on the argument that both are the reader looking at somebody else's copy of the product. True, and the wrong cut: **an app you start from is the alternative to writing against the protocols; running it yourself is the alternative to paying us.** Each fork now sits beside the thing it forks.

### The self-host heading loses its "Or"

It read *"Or run the whole thing yourself"*, which answered Apps above it. Under the price it would answer the price — except `pricing?()` is false on a deployment that bills nothing, and then the "Or" answers nothing at all. The finale comment already carried that rule for the closer.

### paper.css

Self-host and Questions take the ink tokens. That made the skin's header comment stale: it said three sections are built on the ink scale (now five), and it still described the closer inverting itself, which the same file reverses two hundred lines further down.

## Verified in the browser

Rendered at 1280 wide with the paper skin (`MARKETING_SITE=true CREDITS_ENABLED=true PRODUCT_NAME=Managoat`). Section order confirmed in the DOM, and the surfaces alternate tint → ground → band with the four finale sections reading as one.

## Checks

**112 tests** across the marketing, brand, paper-skin and design-token files, plus `mix format` and `mix compile --warnings-as-errors`. The new FAQ answer links `concepts/conversation`, which resolves — the test that walks every `/docs` link would catch it otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176oj6fYqofyFL5nVZvk7q9