### PR TITLE
Sharpen the homepage argument

### DIFF
--- a/.agents/product-marketing.md
+++ b/.agents/product-marketing.md
@@ -1,7 +1,7 @@
 # Product Marketing Context
 
-**Document version:** v2
-**Last updated:** 2026-08-27
+**Document version:** v3
+**Last updated:** 2026-08-29
 
 This file is the positioning, the ICP and the vocabulary that marketing work in
 this repo starts from. It is drafted from the repo itself: `README.md`,
@@ -16,8 +16,7 @@ and bump the version.
 
 ## Product Overview
 
-**One-liner:** A conversational API to a computer, metered only while an agent
-is working.
+**One-liner:** Run coding agents on ready machines. Pay only while they work.
 
 **Lead with the meter.** Both halves of that line are the pitch, and the second
 half is the part nobody else offers. A prompt goes over HTTP, a machine wakes
@@ -207,10 +206,11 @@ template, run, transcript, credit, primitive, estate, gate, guardrail.
 
 **"Computer" is a marketing word only.** `standards/voice-and-style.md` bans it
 from `docs/` because reference prose needs one name for the machine, and that
-name is "sandbox". The homepage hero and `README.md` use it on purpose: it is
-the word the reader already has for the thing they do not want to run, and it
-is how the one-liner lands before "sandbox" means anything. Use it once to open,
-then say "sandbox" or "machine" for the rest of the page, and never in `docs/`.
+name is "sandbox". `README.md` uses it on purpose because it is the word the
+reader already has for the thing they do not want to run. The homepage instead
+names coding agents and the work-only meter in its first line. When another
+marketing surface uses "computer", use it once to open, then say "sandbox" or
+"machine" for the rest of the page. Never use it in `docs/`.
 
 **Words to avoid:** "simply", "just", "easy", "obviously", "coming soon" (the docs style
 gate fails on these); "plans", "tiers", "seats", "subscription" (there are none);
@@ -319,4 +319,5 @@ reader into someone who has seen the primitives compose.
 
 ## Changelog
 *Newest first. One line per revision: what changed and why.*
+- v3 (2026-08-29) — Homepage clarity pass: lead with coding agents and the work-only meter, put production proof before implementation detail, and remove customer-shaped proof language.
 - v1 (2026-08-27) — Initial context, drafted from the repo while working the case study headline. Competitive landscape, customer language, customers, testimonials and current WAU left as explicit GAPs rather than invented.

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
@@ -795,7 +795,8 @@ defmodule FountainWeb.MarketingHTML do
               "Start a run, watch the agent work turn by turn, and drive it. Chat, timeline and raw views of the same conversation, plus the machine it shares with its siblings.",
             shows: "the event stream as blocks, and one sandbox behind many conversations",
             flagship: %{
-              like: "ChatGPT, except the model has a real computer and you can watch it use one.",
+              like:
+                "ChatGPT, except the model has a checkout and a shell, and you can watch it work.",
               who: "Open this one first. It is the whole platform with a face on it."
             }
           },

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -49,22 +49,11 @@
         be `text-5xl`, one step off the section headings, so the page opened at
         roughly the volume it kept for the next eight thousand pixels. --%>
   <h1 class="text-[2.75rem] leading-[1.05] sm:text-6xl font-bold tracking-[-0.03em] text-[var(--color-text-primary)] mb-6">
-    A conversational API to a computer.
+    Run coding agents on ready machines.<span :if={pricing?()}> Pay only while they work.</span>
   </h1>
   <p class="text-lg sm:text-xl leading-relaxed text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-10">
     The machine arrives with your repositories cloned, your packages installed and credentials the model never sees.
-    <%!-- The meter is the differentiator, so it gets its own sentence rather
-          than the trailing clause of a fourth one. The h1 already says the
-          API and the answer coming back, so the subhead no longer narrates
-          them a second time. It is also a claim only a billing deployment
-          can make, and the same `pricing?()` guard the price card uses keeps
-          a free install from making it. --%>
-    <span :if={pricing?()}>
-      The meter runs while an agent works and stops while the machine waits.
-    </span>
-    <span :if={!pricing?()}>
-      It parks between messages and wakes with its work intact.
-    </span>
+    It parks between prompts and wakes with its work intact.
   </p>
   <div class="flex flex-col sm:flex-row gap-3 justify-center mb-5">
     <a
@@ -88,9 +77,57 @@
   </p>
 </section>
 
-<%!-- How it works, directly under the hero. The reader has no prior model for
+<%!-- Proof comes before the implementation detail. A reader sees one measured
+      production use before the page asks them to parse the primitives and five
+      code blocks.
+
+      The agent never holds a cluster credential. It cannot merge for a
+      different reason: GitHub refuses a self-approval from the account that
+      clones, pushes a branch and opens the request. Keep those mechanisms
+      separate in the copy.
+
+      "Cluster" stays in the heading because it is familiar on a homepage.
+      "Estate" is accurate in the disclosure after the paragraph defines it. --%>
+<section class="max-w-5xl mx-auto px-6 pt-8 pb-16">
+  <div
+    class="rounded-2xl border border-[var(--color-accent-line)] bg-[var(--color-accent-soft)] p-8 sm:p-12"
+    data-role="case-study-callout"
+  >
+    <.eyebrow label="Case study" align={:left} />
+    <h2 class="mt-4 text-2xl sm:text-3xl font-semibold tracking-tight text-[var(--color-text-primary)]">
+      A cluster that answers its own alerts.
+    </h2>
+    <p class="mt-4 text-[var(--color-text-secondary)] max-w-2xl leading-relaxed">
+      A Kubernetes cluster used to page a person when a workload broke. Now it also starts an agent, which finds the commit that broke it and opens one small pull request. The agent never holds a credential for the cluster it is fixing, and a person still merges the request.
+    </p>
+    <dl class="mt-10 grid grid-cols-2 gap-x-8 gap-y-8 sm:grid-cols-4 sm:gap-x-6">
+      <div :for={stat <- case_stats()}>
+        <dt
+          class="text-3xl sm:text-4xl font-semibold tracking-tight text-[var(--color-text-primary)]"
+          data-role="figure"
+        >
+          {stat.value}
+        </dt>
+        <dd class="mt-1.5 text-xs leading-snug text-[var(--color-accent-ink)]">{stat.label}</dd>
+      </div>
+    </dl>
+    <p class="mt-8 max-w-2xl text-xs text-[var(--color-text-secondary)]">
+      Counted over {case_window()} on one production estate, a Kubernetes cluster carrying live production workloads. Numbers reported by the cluster administrator (us).
+    </p>
+    <div class="mt-8">
+      <a
+        href={~p"/case-studies/self-healing-infrastructure"}
+        class="inline-flex items-center justify-center px-5 py-2.5 rounded-lg border border-[var(--color-accent-line)] bg-[var(--color-bg-1)] text-[var(--color-text-primary)] text-sm font-medium hover:bg-[var(--color-bg-2)] transition-colors"
+      >
+        Follow the whole incident
+      </a>
+    </div>
+  </div>
+</section>
+
+<%!-- How it works, directly after the proof. The reader has no prior model for
       the category, so the shape comes before the argument and the SDK call is
-      the second thing on the page rather than the fourth.
+      near the top of the page rather than buried under the feature inventory.
 
       This used to follow the six-question grid and open with "Everything above
       is three rows and one call". That pointed backwards at a section the
@@ -345,106 +382,6 @@
   </dl>
 </section>
 
-<%!-- Proof. One deployment, in production, with its own numbers.
-
-      This is the one place the accent is spent on a whole panel rather than a
-      six-pixel rule, because it is the only section on the page carrying
-      measurements from a real estate rather than a claim about the product.
-      The four numbers are the peak of the light half of the page: they are
-      set larger than any heading below the hero, which is the ranking they
-      deserve and the one they did not have when they matched the body text
-      around them.
-
-      THE LAST SENTENCE IS THE CREDENTIAL, NOT THE MERGE. Two mechanisms hold
-      this agent and they are not the same one. It never holds a cluster
-      credential, which is the `0` stat directly below and the thing it is
-      unable to do. It cannot merge, which is GitHub refusing a self-approval
-      from an account that does hold a token: it clones, pushes a branch and
-      opens the request. Copy that says the keys are kept away from the agent
-      and then points at the merge has fused the two, and the merge half is
-      false.
-
-      The paragraph leads on the credential because that is the reader's
-      actual fear (.agents/product-marketing.md calls handing a real
-      credential to a model "the product's best material"), and because the
-      stat under it counts exactly that. It sets the number up rather than
-      restating its note, which already reads "No kubectl, no kubeconfig, no
-      write path of its own".
-
-      It used to end "the mechanism stopping it is not a system prompt". True,
-      and it only lands for a reader who already knows a system prompt is the
-      usual way an agent gets constrained, which is a lot to assume in the
-      last clause of a card. A credential the agent was never given is the
-      same argument without the prerequisite.
-
-      The h2 says "cluster" and the rest of the case study says "estate". That
-      is on purpose and it is the only place the two differ. "Estate" is the
-      right word for what the story is about, which is a whole footprint and
-      not one cluster: alerts, Prometheus, node health, controller drift and
-      the repositories behind them. It is also enterprise IT vocabulary, more
-      at home in the UK than here, and .agents/product-marketing.md names the
-      enterprise buyer as the anti-persona. In American English the first
-      prior for the word is real estate.
-
-      A reader deep in the case study has been given the gloss ("The estate is
-      a Kubernetes cluster carrying live production workloads") and can afford the
-      word. A reader scanning the homepage has not, and this heading is where
-      they decide whether the section is for them. It also used to disagree
-      with its own paragraph, which opens "A Kubernetes cluster used to page a
-      person": the unfamiliar word in the heading, the familiar one for the
-      same thing a line later. --%>
-<section class="max-w-5xl mx-auto px-6 pt-8 pb-16">
-  <div
-    class="rounded-2xl border border-[var(--color-accent-line)] bg-[var(--color-accent-soft)] p-8 sm:p-12"
-    data-role="case-study-callout"
-  >
-    <.eyebrow label="Case study" align={:left} />
-    <h2 class="mt-4 text-2xl sm:text-3xl font-semibold tracking-tight text-[var(--color-text-primary)]">
-      A cluster that answers its own alerts.
-    </h2>
-    <p class="mt-4 text-[var(--color-text-secondary)] max-w-2xl leading-relaxed">
-      A Kubernetes cluster used to page a person when a workload broke. Now it also starts an agent, which finds the commit that broke it and opens one small pull request. The agent never holds a credential for the cluster it is fixing, and a person still merges the request.
-    </p>
-    <dl class="mt-10 grid grid-cols-2 gap-x-8 gap-y-8 sm:grid-cols-4 sm:gap-x-6">
-      <div :for={stat <- case_stats()}>
-        <dt
-          class="text-3xl sm:text-4xl font-semibold tracking-tight text-[var(--color-text-primary)]"
-          data-role="figure"
-        >
-          {stat.value}
-        </dt>
-        <dd class="mt-1.5 text-xs leading-snug text-[var(--color-accent-ink)]">{stat.label}</dd>
-      </div>
-    </dl>
-    <p class="mt-8 max-w-2xl text-xs text-[var(--color-text-secondary)]">
-      Counted over {case_window()} on one production estate, a Kubernetes cluster carrying live production workloads. Numbers reported by the cluster administrator (us).
-    </p>
-    <div class="mt-8 flex flex-col sm:flex-row gap-3">
-      <a
-        href={~p"/case-studies/self-healing-infrastructure"}
-        class="inline-flex items-center justify-center px-5 py-2.5 rounded-lg border border-[var(--color-accent-line)] bg-[var(--color-bg-1)] text-[var(--color-text-primary)] text-sm font-medium hover:bg-[var(--color-bg-2)] transition-colors"
-      >
-        Follow the whole incident
-      </a>
-      <%!-- The page's second ask. The first is the hero and the next one was
-            1,300 words further down, so a reader convinced by the six claims
-            above had nowhere to act without scrolling back. cd2745fa had two
-            mid-page asks and 5cf40e2c dropped both; this is that pattern
-            restored. It sits beside the proof rather than alone under it,
-            where it read as a stray button on an empty band, and it stays in
-            the secondary style so it does not compete with the hero and the
-            closer. The label matches them on purpose. One primary action,
-            worded once. --%>
-      <a
-        href={~p"/auth/register"}
-        class="inline-flex items-center justify-center px-5 py-2.5 rounded-lg text-sm font-medium text-[var(--color-accent-ink)] hover:underline underline-offset-4"
-      >
-        Run your first agent free
-      </a>
-    </div>
-  </div>
-</section>
-
 <%!-- The band. Two sections about how a run behaves over time, on one tint
       with a rule between them rather than two tinted bands with a page
       between, because they answer the same question. --%>
@@ -462,7 +399,7 @@
     </h2>
     <div class="mt-10 max-w-2xl mx-auto space-y-5 text-[var(--color-text-secondary)] leading-relaxed">
       <p>
-        A conversation binds to an id you already have, a customer, a ticket or a Slack channel. The next prompt for that id and that agent continues it, so there is no lookup table to keep.
+        A conversation binds to an id you already have, such as a customer id, ticket id or Slack channel. The next prompt for that id and that agent continues it, so there is no lookup table to keep.
       </p>
       <p>
         It parks when nobody is typing and wakes with its files intact. Put one on a schedule and it runs with nobody there at all.
@@ -613,7 +550,7 @@
       Start from an app that already works.
     </h2>
     <p class="mt-3 text-center text-[var(--color-text-secondary)] max-w-2xl mx-auto text-lg">
-      Each is static files in a browser on the same public API your key opens, with no backend of its own. Read the source, take what you need, or point it at your own instance.
+      Each app is a static frontend over the same public API. Read its source, borrow what you need, or point it at your own instance.
     </p>
     <div class="mt-10 grid md:grid-cols-3 gap-6">
       <article
@@ -660,9 +597,9 @@
 
     <p class="mt-12 text-center text-[var(--color-text-secondary)]">
       <span class="font-medium text-[var(--color-text-primary)]">
-        People build whole products on it.
+        {length(built_apps_flat())} open-source apps are running on it now.
       </span>
-      {length(built_apps_flat())} are open source and running now, and in several nothing on screen says the word agent.
+      In several, nothing on screen says the word agent.
     </p>
     <ul class="mt-6 flex flex-wrap justify-center gap-2">
       <li
@@ -799,7 +736,7 @@
       <div class="mt-6 space-y-4 text-sm text-[var(--color-ink-secondary)] leading-relaxed">
         <p>
           <span class="font-medium text-[var(--color-ink-text)]">
-            Credit is the whole product.
+            Credit is the whole pricing model.
           </span>
           The opening grant expires; credit you buy never expires and is spent after
           it, in packs of {credit_packs()}.
@@ -873,7 +810,7 @@
         Run the whole thing yourself.
       </h2>
       <p class="mt-3 text-center text-[var(--color-ink-secondary)] max-w-xl mx-auto text-lg">
-        You are not locked in. The same API, SDK and CLI run on your own hardware, with no license key and nobody to ask first.
+        The same API, SDK and CLI run on your own hardware. There is no license key and nobody to ask first.
       </p>
 
       <div class="mt-10 max-w-2xl mx-auto space-y-4 text-[var(--color-ink-secondary)] leading-relaxed">
@@ -941,7 +878,7 @@
       </h2>
       <div class="mt-10 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <p class="text-sm text-[var(--color-ink-secondary)] max-w-lg">
-          Every limit is written down on the questions page, beside what a security reviewer asks, and every answer names a mechanism you can check rather than an intention we state.
+          Read every limit and review the security model yourself. Each answer names a mechanism you can check, not an intention you have to trust.
         </p>
         <div class="flex flex-col sm:flex-row gap-3 sm:shrink-0">
           <a

--- a/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
@@ -196,7 +196,7 @@ defmodule FountainWeb.MarketingControllerTest do
     test "the marketing nav and the homepage link to it", %{conn: conn} do
       body = conn |> get(~p"/") |> html_response(200)
       assert body =~ ~p"/built-with"
-      assert body =~ "People build whole products on it."
+      assert body =~ "open-source apps are running on it now."
     end
   end
 
@@ -562,6 +562,10 @@ defmodule FountainWeb.MarketingControllerTest do
       body = conn |> get(~p"/") |> html_response(200)
       assert body =~ ~p"/case-studies/self-healing-infrastructure"
       assert body =~ "A cluster that answers its own alerts."
+
+      {proof_at, _} = :binary.match(body, ~s(data-role="case-study-callout"))
+      {setup_at, _} = :binary.match(body, "You write this once.")
+      assert proof_at < setup_at
     end
   end
 

--- a/apps/fountain/test/fountain_web/controllers/marketing_pricing_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_pricing_test.exs
@@ -51,7 +51,7 @@ defmodule FountainWeb.MarketingPricingTest do
     body = conn |> get(~p"/") |> html_response(200)
 
     assert body =~ "How billing works"
-    assert body =~ "Credit is the whole product"
+    assert body =~ "Credit is the whole pricing model"
     assert body =~ "Agent time costs $0.25 an hour"
     assert body =~ "in packs of $10.00, $25.00, $100.00"
     assert body =~ "At zero, new work pauses; nothing dies"
@@ -69,6 +69,8 @@ defmodule FountainWeb.MarketingPricingTest do
 
   test "the hero quotes the opening credit", %{conn: conn} do
     body = conn |> get(~p"/") |> html_response(200)
+    assert body =~ "Run coding agents on ready machines."
+    assert body =~ "Pay only while they work."
     assert body =~ "$5.00 of credit to start"
   end
 
@@ -76,6 +78,8 @@ defmodule FountainWeb.MarketingPricingTest do
     Application.put_env(:fountain, :credits_enabled, false)
 
     body = conn |> get(~p"/") |> html_response(200)
+    assert body =~ "Run coding agents on ready machines."
+    refute body =~ "Pay only while they work."
     refute body =~ "You pay only while an agent is working."
     refute body =~ "per agent hour"
     refute body =~ "of credit to start"


### PR DESCRIPTION
## Summary

- lead the hero with coding agents and the work-only meter
- move measured production proof ahead of the code-heavy setup
- tighten state, apps, pricing, self-hosting, and security copy
- remove customer-shaped proof language and keep the positioning context aligned
- cover the hosted-only hero claim and proof ordering in controller tests

## Verification

- mix test apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs apps/fountain/test/fountain_web/controllers/marketing_pricing_test.exs (66 tests, 0 failures)
- mix test (6 doctests, 3 properties, 4,162 tests, 0 failures)