### PR TITLE
Refine self-hosted marketing copy

### DIFF
--- a/.agents/product-marketing.md
+++ b/.agents/product-marketing.md
@@ -1,6 +1,6 @@
 # Product Marketing Context
 
-**Document version:** v3
+**Document version:** v4
 **Last updated:** 2026-08-29
 
 This file is the positioning, the ICP and the vocabulary that marketing work in
@@ -48,6 +48,12 @@ every page.
 
 **Product type:** Multi-tenant hosted API plus a self-hostable server. Web UI is
 an operator console, not an application.
+
+**Self-hosted positioning:** Ownership is the decision, and the bring-up is its
+proof. Lead with the same API, SDK and CLI running under the reader's keys and
+infrastructure. Put the ownership choices before prerequisites and installation
+detail. The open-source applications demonstrate product shapes, not customer
+adoption, and copy must not present them as third-party proof.
 
 **Business model:** Prepaid credit. No plans, no seats, no subscription
 (ADR 0031). Agent time bills out of a balance at the rate on the price card
@@ -319,5 +325,6 @@ reader into someone who has seen the primitives compose.
 
 ## Changelog
 *Newest first. One line per revision: what changed and why.*
+- v4 (2026-08-29) — Self-hosted clarity pass: lead with ownership, put the ownership decision before installation detail, and frame open-source apps as examples rather than customer proof.
 - v3 (2026-08-29) — Homepage clarity pass: lead with coding agents and the work-only meter, put production proof before implementation detail, and remove customer-shaped proof language.
 - v1 (2026-08-27) — Initial context, drafted from the repo while working the case study headline. Competitive landscape, customer language, customers, testimonials and current WAU left as explicit GAPs rather than invented.

--- a/apps/fountain/lib/fountain_web/controllers/marketing_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_controller.ex
@@ -159,11 +159,9 @@ defmodule FountainWeb.MarketingController do
         layout: {FountainWeb.Layouts, :marketing},
         page_title: "Self-host #{Fountain.Brand.engine()} · #{Fountain.Brand.name()}",
         meta_description:
-          "Define an agent once and every app you build can start it over one API. " <>
-            "#{Fountain.Brand.engine()} is open source and the whole platform is in " <>
-            "the repo. Bring an instance up with Docker Compose or plain Kubernetes " <>
-            "manifests, on your hardware, under your own keys, with no license key " <>
-            "and no seat count."
+          "Run #{Fountain.Brand.engine()} on your infrastructure with the same API, " <>
+            "SDK and CLI. Own the database, keys and sandboxes. Start with Docker " <>
+            "Compose or Kubernetes, with no license key or seat count."
       )
     else
       redirect(conn, to: ~p"/docs/self-hosting")

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
@@ -995,21 +995,21 @@ defmodule FountainWeb.MarketingHTML do
   @doc "The project's repository. The self-hosted page links it from four places."
   def repo_url, do: @repo_url
 
-  # The four apps /self-hosted leads with, chosen for four different shapes of
+  # The four apps /self-hosted shows, chosen for four different shapes of
   # front door: a commission that comes back as a document, an analyst behind a
   # file upload, an unattended repair loop, and a fan-out. Selected from
   # `built_apps/0` by id rather than restated, so a card here cannot drift from
   # /built-with, and an app that is renamed or retired there raises at render
   # instead of linking nowhere — which is exactly what dropping Reflex from the
   # roster did to this list, and why briefing-room now holds the first slot.
-  # The flagship three are deliberately not here: the same page shows them
-  # below the bring-up, as the front ends the reader gets rather than as
-  # evidence that other people build on this.
+  # The flagship three are deliberately not here because the same page shows
+  # them above as the front ends an instance gets. The showcase adds four
+  # different product shapes without repeating those cards.
   @showcase_ids ~w(briefing-room table-talk rounds mission-control)
 
   @doc """
-  The applications /self-hosted shows above the bring-up. The page's claim is
-  that an agent defined once gets started by anything, and these are the anything.
+  Four applications /self-hosted shows as different frontends over the same
+  API and roster.
   """
   def self_host_showcase do
     by_id = Map.new(built_apps_flat(), &{&1.id, &1})
@@ -1051,7 +1051,7 @@ defmodule FountainWeb.MarketingHTML do
       },
       %{
         label: "No database",
-        body: "The compose file runs Postgres 16 for you. You install nothing."
+        body: "The compose file runs Postgres 16 for you. You install no database."
       },
       %{
         label: "Network",
@@ -1142,7 +1142,7 @@ defmodule FountainWeb.MarketingHTML do
     [
       %{
         step: "01",
-        title: "The app",
+        title: "The control plane",
         body:
           "Your container, your Postgres, your domain. Conversations, transcripts, audit events and API keys live in a database you can open with psql."
       },
@@ -1154,7 +1154,7 @@ defmodule FountainWeb.MarketingHTML do
       },
       %{
         step: "03",
-        title: "The machines",
+        title: "The sandbox machines",
         body:
           "A Mac mini, a home server or a GPU box becomes a sandbox backend with one daemon. It dials out and holds one connection. There is no inbound port to open and no credential to hand it."
       },
@@ -1174,28 +1174,28 @@ defmodule FountainWeb.MarketingHTML do
   def self_host_costs do
     [
       %{
-        title: "A sandbox backend is somebody's service, unless you bring machines",
+        title: "Bring machines or choose a sandbox provider",
         body:
           "Sprites, E2B and Daytona are all hosted. Daytona you can run yourself, and your own runners need no vendor at all. Pick one before your first conversation, because without one every conversation fails.",
         docs: "/docs/integrations/runners",
         docs_label: "Runners on your own hardware"
       },
       %{
-        title: "Email is a decision, not an optional extra",
+        title: "Configure email before inviting anyone",
         body:
           "Verification and password resets go through Resend, or an SMTP server of yours. So does anything a teammate sends. The compose defaults skip delivery so the first account can register, and that default is for day one only.",
         docs: "/docs/guides/operate/email",
         docs_label: "Configure email"
       },
       %{
-        title: "The master key is yours to lose",
+        title: "Back up the master key with the database",
         body:
           "Back it up before you have data. Lose it and every encrypted secret in the instance is gone, and no database restore brings them back.",
         docs: "/docs/guides/operate/back-up-and-restore",
         docs_label: "Back up and restore"
       },
       %{
-        title: "Upgrades are yours to run",
+        title: "Own every upgrade",
         body:
           "Pull the tag, run the migrations, read the note. There is no window where somebody else does it for you, and no window where somebody else does it to you.",
         docs: "/docs/guides/operate/upgrade",

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/self_hosted.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/self_hosted.html.heex
@@ -2,10 +2,9 @@
       bring-up on the right, so the commands are on the first screen rather
       than three sections down.
 
-      Two strings here are pinned by MarketingControllerTest and must stay in
-      the rendered body: "Define your agents once. Let every app you build
-      run them." (now the deck under the h1) and "Six commands and a token."
-      (now the label over the terminal). --%>
+      The h1 names the decision before the page shows the implementation. The
+      terminal stays on the first screen because a high-intent reader should
+      be able to verify the bring-up without scrolling through the pitch. --%>
 <section class="max-w-6xl mx-auto px-5 sm:px-6 pt-12 pb-14 sm:pt-20 sm:pb-20 grid lg:grid-cols-2 gap-10 lg:gap-14 items-start">
   <div>
     <p class="inline-flex items-center gap-2 rounded-full border border-[var(--color-border-strong)] px-3.5 py-1.5 text-xs font-medium uppercase tracking-[0.18em] text-[var(--color-text-secondary)]">
@@ -13,20 +12,20 @@
       Self-hosted
     </p>
     <h1 class="mt-6 text-4xl sm:text-5xl font-bold tracking-tight leading-[1.05] text-[var(--color-text-primary)]">
-      There are no tiers to buy.
+      Run {Fountain.Brand.engine()} on your infrastructure.
     </h1>
     <p class="mt-5 text-xl sm:text-2xl font-medium leading-snug text-[var(--color-text-primary)] max-w-[34ch]">
-      Define your agents once. Let every app you build run them.
+      The same API, SDK and CLI. Your database, your keys and your sandboxes.
     </p>
     <p class="mt-5 text-lg text-[var(--color-text-secondary)] leading-relaxed max-w-[54ch]">
-      Run it yourself and the whole platform is yours. Your machines, your keys, nothing rationed.
+      No license key, no seat count and nobody to ask first. Start with Docker Compose, then own more of the stack when you want to.
     </p>
     <div class="mt-8 flex flex-col sm:flex-row gap-3 [&>a]:w-full sm:[&>a]:w-auto">
       <a
         href={~p"/docs/guides/operate/deploy"}
         class="inline-flex items-center justify-center px-6 py-3 rounded-lg bg-[var(--color-brand)] text-[var(--color-brand-text)] font-medium hover:bg-[var(--color-brand-hover)] transition-colors text-sm"
       >
-        Bring up an instance
+        Bring up your instance
       </a>
       <a
         href={repo_url()}
@@ -38,11 +37,9 @@
     <p class="mt-6 flex flex-wrap gap-x-3 gap-y-1 font-mono text-xs text-[var(--color-text-secondary)]">
       <span>AGPL-3.0-or-later</span>
       <span aria-hidden="true">·</span>
-      <span>no license key</span>
+      <span>same release image</span>
       <span aria-hidden="true">·</span>
-      <span>no seat count</span>
-      <span aria-hidden="true">·</span>
-      <span>no call with us</span>
+      <span>no sales call</span>
     </p>
   </div>
 
@@ -52,7 +49,7 @@
   >
     <div class="flex items-center gap-3 px-5 py-3 border-b border-[var(--color-border)] bg-[var(--color-bg-2)]">
       <h2 class="text-sm font-semibold text-[var(--color-text-primary)]">
-        Six commands and a token.
+        Six commands and one provider token.
       </h2>
       <button
         type="button"
@@ -70,11 +67,55 @@
       The compose file brings its own Postgres. Back the master key up before you have data, because it is not in the database.
     </p>
     <p class="px-5 py-4 border-t border-[var(--color-border)] bg-[var(--color-info-bg)] text-sm text-[var(--color-info-text)] leading-relaxed">
-      <strong class="font-semibold">First:</strong>
-      pick a sandbox provider before you run any of this. Without a token every conversation fails.
+      <strong class="font-semibold">Before you run them:</strong>
+      add a sandbox provider token. The app starts without one, but every conversation fails.
       <a href={~p"/docs/self-hosting"} class="underline underline-offset-2">
         What each provider needs →
       </a>
+    </p>
+  </div>
+</section>
+
+<%!-- 01. The ownership ladder is the decision this page helps the reader
+      make, so it comes before prerequisites and installation detail. Drawn as
+      a connected ladder rather than four loose cards because the rungs are an
+      order. --%>
+<section class="bg-[var(--color-bg-1)] border-y border-[var(--color-border)]">
+  <div class="max-w-6xl mx-auto px-5 sm:px-6 py-12 sm:py-16">
+    <.eyebrow label="01 · Ownership" align={:left} />
+    <h2 class="mt-3 text-3xl font-bold tracking-tight text-[var(--color-text-primary)]">
+      Choose how much of the stack you own.
+    </h2>
+    <p class="mt-4 text-[var(--color-text-secondary)] leading-relaxed max-w-[62ch]">
+      Run the control plane, add machines from your network, or remove the last hosted dependency. Each step is configuration, not a sales conversation.
+    </p>
+    <ol class="mt-8 sm:mt-10 ml-3 border-l-2 border-[var(--color-border-strong)]">
+      <li
+        :for={rung <- ownership_rungs()}
+        class="grid grid-cols-[auto_1fr] gap-4 sm:gap-6 pb-6 sm:pb-8"
+        data-role="rung"
+      >
+        <div class="-ml-[13px] flex items-start gap-3">
+          <span
+            class="mt-1.5 h-6 w-6 shrink-0 rounded-full bg-[var(--color-brand)] ring-4 ring-[var(--color-bg-1)]"
+            aria-hidden="true"
+          >
+          </span>
+          <span class="text-2xl font-bold leading-none text-[var(--color-border-strong)]">
+            {rung.step}
+          </span>
+        </div>
+        <div class="max-w-[68ch]">
+          <h3 class="text-xl font-semibold text-[var(--color-text-primary)]">{rung.title}</h3>
+          <p class="mt-2 text-[var(--color-text-secondary)] leading-relaxed">{rung.body}</p>
+        </div>
+      </li>
+    </ol>
+    <p class="ml-0 sm:ml-6 border-l-2 border-[var(--color-brand)] pl-5 sm:pl-6 text-[var(--color-text-secondary)] leading-relaxed max-w-[74ch]">
+      A model key is the one thing you still bring, and you always did. The agent bills your own provider account for tokens, so nothing in the middle takes a cut of inference. <a
+        href={~p"/docs/integrations/runners"}
+        class="underline underline-offset-2 hover:text-[var(--color-text-primary)]"
+      >Read how a machine of yours becomes a sandbox</a>.
     </p>
   </div>
 </section>
@@ -96,16 +137,16 @@
   </div>
 </section>
 
-<%!-- 01. What happens after the commands, including how you know it worked.
+<%!-- 02. What happens after the commands, including how you know it worked.
       A first-time operator otherwise reads a refused connection during the
       cold start as a failed install. --%>
 <section class="max-w-6xl mx-auto px-5 sm:px-6 py-12 sm:py-16">
-  <.eyebrow label="01 · Install" align={:left} />
+  <.eyebrow label="02 · Install" align={:left} />
   <h2 class="mt-3 text-3xl font-bold tracking-tight text-[var(--color-text-primary)]">
-    After the six commands.
+    From clone to a healthy instance.
   </h2>
   <p class="mt-4 text-[var(--color-text-secondary)] leading-relaxed max-w-[60ch]">
-    Migrations run before the app opens a listener, so a cold start takes up to a minute. A refused connection in that window is normal.
+    The app runs migrations before it opens a listener. On a cold start, expect up to a minute of refused connections.
   </p>
   <div class="grid md:grid-cols-3 gap-6 mt-8">
     <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-1)] p-6">
@@ -116,13 +157,13 @@
       <p
         class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed"
         phx-no-format
-      >Open <code class="text-xs text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1.5 py-0.5">http://localhost:4000</code> and sign up. The first account verifies itself and takes the admin role, so there is no bootstrap ritual and no console of ours in the path. Close registration behind you when you are done.</p>
+      >Open <code class="text-xs text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1.5 py-0.5">http://localhost:4000</code> and sign up. The first account verifies itself and becomes admin. Close registration when you are done.</p>
     </div>
     <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-1)] p-6">
       <p class="text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)]">
         Check
       </p>
-      <h3 class="mt-3 font-semibold text-[var(--color-text-primary)]">Know it worked</h3>
+      <h3 class="mt-3 font-semibold text-[var(--color-text-primary)]">Check readiness</h3>
       <p class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">
         Wait for the app container to report healthy, then probe it.
       </p>
@@ -136,7 +177,7 @@
       <p
         class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed"
         phx-no-format
-      >Plain manifests in <code class="text-xs text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1.5 py-0.5">deploy/k8s/</code>, with no operators and no CRDs. Every merge publishes them as an OCI artifact, and the hosted instance deploys from it. Same manifests, one pin apart: the artifact carries a sha tag, and the committed release pin is the one you apply.</p>
+      >Plain manifests live in <code class="text-xs text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1.5 py-0.5">deploy/k8s/</code>, with no operator or CRDs. Every merge publishes them as an OCI artifact. The hosted instance deploys from the same artifact.</p>
       <a
         href={~p"/docs/guides/operate/kubernetes"}
         class="inline-block mt-3 text-sm font-medium text-[var(--color-text-primary)] underline underline-offset-2 hover:text-[var(--color-brand)]"
@@ -147,16 +188,16 @@
   </div>
 </section>
 
-<%!-- 02. The front ends the instance gets. Cards come from built_apps/0 via
+<%!-- 03. The front ends the instance gets. Cards come from built_apps/0 via
       flagship_apps/0, so this cannot name a retired app. --%>
 <section class="bg-[var(--color-bg-1)] border-y border-[var(--color-border)]">
   <div class="max-w-6xl mx-auto px-5 sm:px-6 py-12 sm:py-16">
-    <.eyebrow label="02 · What you open" align={:left} />
+    <.eyebrow label="03 · What you open" align={:left} />
     <h2 class="mt-3 text-3xl font-bold tracking-tight text-[var(--color-text-primary)]">
-      The apps come with it.
+      Use the apps or host your own.
     </h2>
     <p class="mt-4 text-[var(--color-text-secondary)] leading-relaxed max-w-[68ch]">
-      What you just brought up serves a console: accounts, keys, agents, environments, audit. The apps your team works in are these three, and each is static files that take a server URL as input. Admit the origin once and all three answer to your instance, with your agents, your sandboxes and your keys. Host your own copies instead if you would rather; they are open source too.
+      Your instance serves an operator console for accounts, keys, agents, environments and audit. Conversations, Team and Workbench are static frontends over the same public API. Point them at your instance or host your own copies.
     </p>
     <div class="grid md:grid-cols-3 gap-6 mt-8">
       <article
@@ -192,7 +233,7 @@
     </div>
     <div class="mt-8 rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6">
       <p class="text-sm text-[var(--color-text-secondary)] leading-relaxed">
-        A browser app on another origin calling your API is a CORS request, so name the origin it is served from:
+        A browser app on another origin needs one CORS entry. Name the origin it is served from.
       </p>
       <pre class="mt-3 overflow-x-auto rounded-lg bg-[var(--color-code-bg)] p-3 sm:p-4 text-[11px] sm:text-xs text-[var(--color-code-text)]"><code phx-no-format>API_CORS_ORIGINS=https://fountain-conversations.demo.managoat.com</code></pre>
       <p class="mt-3 text-sm text-[var(--color-text-secondary)] leading-relaxed">
@@ -211,15 +252,15 @@
   </div>
 </section>
 
-<%!-- 03. Evidence that other people build on this. Selected from
-      built_apps/0 by id, so a card cannot drift from /built-with. --%>
+<%!-- 04. Four shapes of product on the same API. Selected from built_apps/0
+      by id, so a card cannot drift from /built-with. --%>
 <section class="max-w-6xl mx-auto px-5 sm:px-6 py-12 sm:py-16">
-  <.eyebrow label="03 · Built on it" align={:left} />
+  <.eyebrow label="04 · Built on it" align={:left} />
   <h2 class="mt-3 text-3xl font-bold tracking-tight text-[var(--color-text-primary)]">
-    {built_app_count()} applications already share one roster.
+    {built_app_count()} open-source apps already run on the API.
   </h2>
   <p class="mt-4 text-[var(--color-text-secondary)] leading-relaxed max-w-[68ch]">
-    Here are four of them, and they are four different front doors onto the same idea. Nobody wrote an agent into any of these apps. The teammate was defined once and the app is the part somebody built on top of it. All of them are open source, and each one points at whichever instance you configure.
+    These four put different frontends on the same agent roster. Each source tree is public, and each app points at whichever instance you configure. The app is the part you build; the Agent stays reusable behind the API.
   </p>
   <div class="grid sm:grid-cols-2 lg:grid-cols-4 gap-6 mt-8">
     <a
@@ -244,53 +285,9 @@
       href={~p"/built-with"}
       class="font-medium text-[var(--color-text-primary)] underline underline-offset-2 hover:text-[var(--color-brand)]"
     >
-      All {built_app_count()} of them, and what each one proves →
+      See all {built_app_count()} apps and their source →
     </a>
   </p>
-</section>
-
-<%!-- 04. The ownership ladder, ahead of the rationed features and the
-      licenses. For somebody deciding hosted against self-hosted this is the
-      argument, and it used to arrive seventh. Drawn as a connected ladder
-      rather than four loose cards, because the rungs are an order. --%>
-<section class="bg-[var(--color-bg-1)] border-y border-[var(--color-border)]">
-  <div class="max-w-6xl mx-auto px-5 sm:px-6 py-12 sm:py-16">
-    <.eyebrow label="04 · Ownership" align={:left} />
-    <h2 class="mt-3 text-3xl font-bold tracking-tight text-[var(--color-text-primary)]">
-      How far down do you want to own it?
-    </h2>
-    <p class="mt-4 text-[var(--color-text-secondary)] leading-relaxed max-w-[62ch]">
-      Most people stop at the first rung and are happy there. The point is that the next three exist, and that none of them is a sales conversation.
-    </p>
-    <ol class="mt-8 sm:mt-10 ml-3 border-l-2 border-[var(--color-border-strong)]">
-      <li
-        :for={rung <- ownership_rungs()}
-        class="grid grid-cols-[auto_1fr] gap-4 sm:gap-6 pb-6 sm:pb-8"
-        data-role="rung"
-      >
-        <div class="-ml-[13px] flex items-start gap-3">
-          <span
-            class="mt-1.5 h-6 w-6 shrink-0 rounded-full bg-[var(--color-brand)] ring-4 ring-[var(--color-bg-1)]"
-            aria-hidden="true"
-          >
-          </span>
-          <span class="text-2xl font-bold leading-none text-[var(--color-border-strong)]">
-            {rung.step}
-          </span>
-        </div>
-        <div class="max-w-[68ch]">
-          <h3 class="text-xl font-semibold text-[var(--color-text-primary)]">{rung.title}</h3>
-          <p class="mt-2 text-[var(--color-text-secondary)] leading-relaxed">{rung.body}</p>
-        </div>
-      </li>
-    </ol>
-    <p class="ml-0 sm:ml-6 border-l-2 border-[var(--color-brand)] pl-5 sm:pl-6 text-[var(--color-text-secondary)] leading-relaxed max-w-[74ch]">
-      A model key is the one thing you still bring, and you always did. The agent bills your own provider account for tokens, so nothing in the middle takes a cut of inference. <a
-        href={~p"/docs/integrations/runners"}
-        class="underline underline-offset-2 hover:text-[var(--color-text-primary)]"
-      >Read how a machine of yours becomes a sandbox</a>.
-    </p>
-  </div>
 </section>
 
 <%!-- 05. The inversion, as a table rather than three stacked panels: the
@@ -299,10 +296,10 @@
 <section class="max-w-6xl mx-auto px-5 sm:px-6 py-12 sm:py-16">
   <.eyebrow label="05 · Feature flags" align={:left} />
   <h2 class="mt-3 text-3xl font-bold tracking-tight text-[var(--color-text-primary)]">
-    The features we ration, you switch on.
+    On your instance, every feature flag is yours to set.
   </h2>
   <p class="mt-4 text-[var(--color-text-secondary)] leading-relaxed max-w-[64ch]">
-    Three things are not on for everyone here. Two are alpha and one changes what a sandbox can reach, so on the hosted platform each of them means an email to us and a wait. On an instance of your own they are a line in a config file, and nobody has to approve you.
+    Teammate contacts, the OpenAI-compatible API and brokered credentials require approval on the hosted platform. On your instance, each is configuration you control.
   </p>
   <div class="mt-8 overflow-hidden rounded-xl border border-[var(--color-border)]">
     <div class="hidden md:grid md:grid-cols-[1.5fr_1fr_1.25fr] bg-[var(--color-bg-2)] border-b border-[var(--color-border)] text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)]">
@@ -408,7 +405,7 @@
     What it costs you instead.
   </h2>
   <p class="mt-4 text-[var(--color-text-secondary)] leading-relaxed max-w-[62ch]">
-    Self-hosting is not free, it is paid in a different currency. Better you know the four line items now than in week three.
+    Self-hosting is not free. You pay in infrastructure and operations instead of credit. Better you know the four line items now than in week three.
   </p>
   <div class="grid md:grid-cols-2 gap-6 mt-8">
     <div
@@ -437,16 +434,16 @@
   <div class="max-w-6xl mx-auto px-5 sm:px-6 py-12 sm:py-16">
     <.eyebrow label="08 · Before the clone" align={:left} />
     <h2 class="mt-3 text-3xl font-bold tracking-tight text-[var(--color-text-primary)]">
-      Things you would ask before the clone.
+      Read the questions before you clone.
     </h2>
     <p class="mt-4 max-w-[58ch] text-[var(--color-text-secondary)] leading-relaxed">
-      Whether it is really the same code, whether the AGPL reaches your application, what the software costs, and how you get rid of it again. Those are answered with the rest of the questions people ask about this platform.
+      Check whether it is the same code, whether the AGPL reaches your application, what the software costs and how to remove it again.
     </p>
     <a
       href={~p"/faq#self-hosting"}
       class="mt-8 inline-flex items-center justify-center px-5 py-2.5 rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-0)] text-[var(--color-text-primary)] text-sm font-medium hover:bg-[var(--color-bg-2)] transition-colors"
     >
-      Read the questions
+      Read the self-hosting answers
     </a>
   </div>
 </section>
@@ -455,17 +452,17 @@
 <section class="bg-[var(--color-bg-2)] border-t border-[var(--color-border)]">
   <div class="max-w-6xl mx-auto px-5 sm:px-6 py-14 sm:py-20">
     <h2 class="text-3xl sm:text-4xl font-bold tracking-tight text-[var(--color-text-primary)]">
-      Clone it tonight.
+      Run your own instance tonight.
     </h2>
     <p class="mt-4 text-[var(--color-text-secondary)] leading-relaxed max-w-[58ch]">
-      A container, a Postgres and a sandbox token. The manual has the whole path, the repo has the issues, and neither of them has a sales form in it.
+      Docker Compose, Postgres and one sandbox provider token. The deploy guide has the whole path, and the repository has every open issue.
     </p>
     <div class="mt-8 flex flex-col sm:flex-row gap-3 [&>a]:w-full sm:[&>a]:w-auto">
       <a
         href={~p"/docs/guides/operate/deploy"}
         class="inline-flex items-center justify-center px-8 py-3 rounded-lg bg-[var(--color-brand)] text-[var(--color-brand-text)] font-medium hover:bg-[var(--color-brand-hover)] transition-colors"
       >
-        Bring up an instance
+        Bring up your instance
       </a>
       <a
         href={~p"/docs/self-hosting"}

--- a/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
@@ -204,9 +204,10 @@ defmodule FountainWeb.MarketingControllerTest do
     test "makes the case and shows the whole bring-up", %{conn: conn} do
       body = conn |> get(~p"/self-hosted") |> html_response(200)
 
-      assert body =~ "Define your agents once. Let every app you build run them."
-      assert body =~ "Six commands and a token."
-      assert body =~ "The features we ration, you switch on."
+      assert body =~ "Run #{Fountain.Brand.engine()} on your infrastructure."
+      assert body =~ "Your database, your keys and your sandboxes."
+      assert body =~ "Six commands and one provider token."
+      assert body =~ "On your instance, every feature flag is yours to set."
       assert body =~ "What it costs you instead."
 
       # The bring-up is kept out of the template so its $(...) is not HEEx.
@@ -218,6 +219,10 @@ defmodule FountainWeb.MarketingControllerTest do
       end
 
       assert body =~ FountainWeb.MarketingHTML.repo_url()
+
+      {ownership_at, _} = :binary.match(body, "Choose how much of the stack you own.")
+      {prerequisites_at, _} = :binary.match(body, "Before you start")
+      assert ownership_at < prerequisites_at
     end
 
     test "names every feature the manual says is rationed", %{conn: conn} do
@@ -237,12 +242,11 @@ defmodule FountainWeb.MarketingControllerTest do
       end
     end
 
-    test "shows apps that already share the roster, and links every one", %{conn: conn} do
+    test "shows four app shapes over the same roster, and links every one", %{conn: conn} do
       body = conn |> get(~p"/self-hosted") |> html_response(200)
 
-      # The hero's claim is that an agent defined once gets started by anything.
-      # The cards are the evidence, so each has to be a working pair of links
-      # into the same roster /built-with renders.
+      # The cards show four shapes over the same API and roster, so each has to
+      # be a working link into the same roster /built-with renders.
       showcase = FountainWeb.MarketingHTML.self_host_showcase()
       assert length(showcase) == 4
 
@@ -253,7 +257,7 @@ defmodule FountainWeb.MarketingControllerTest do
       end
 
       count = to_string(FountainWeb.MarketingHTML.built_app_count())
-      assert body =~ "#{count} applications already share one roster."
+      assert body =~ "#{count} open-source apps already run on the API."
       assert body =~ ~p"/built-with"
     end
 
@@ -262,7 +266,7 @@ defmodule FountainWeb.MarketingControllerTest do
       assert body =~ ~s(<meta property="og:title" content="Self-host Fountain · Fountain")
 
       assert body =~
-               ~s(<meta name="description" content="Define an agent once and every app)
+               ~s(<meta name="description" content="Run #{Fountain.Brand.engine()} on your infrastructure)
 
       assert body =~ ~s(<meta property="og:url" content="http://localhost:4000/self-hosted")
     end
@@ -745,7 +749,7 @@ defmodule FountainWeb.MarketingControllerTest do
     test "/self-hosted shows them as the front ends an instance gets", %{conn: conn} do
       body = conn |> get(~p"/self-hosted") |> html_response(200)
 
-      assert body =~ "The apps come with it."
+      assert body =~ "Use the apps or host your own."
       assert body =~ "API_CORS_ORIGINS"
       assert body =~ "CONVERSATIONS_APP_URL"
       assert body =~ "TEAM_APP_URL"
@@ -755,8 +759,8 @@ defmodule FountainWeb.MarketingControllerTest do
         assert body =~ app.source, "self-hosted does not link #{app.name}'s source"
       end
 
-      # The showcase above the bring-up argues that other people build on this,
-      # so it must not spend one of its four cards on an app of ours.
+      # The showcase complements the three frontends above it, so it must not
+      # repeat one of those cards.
       showcase = FountainWeb.MarketingHTML.self_host_showcase()
       assert showcase -- FountainWeb.MarketingHTML.flagship_apps() == showcase
     end


### PR DESCRIPTION
## Summary

- lead with infrastructure ownership and parity with the hosted API, SDK, and CLI
- move deployment choices ahead of installation details and sharpen prerequisites, tradeoffs, and CTAs
- frame the open-source apps as product examples rather than implied customer adoption
- record the self-hosted positioning guidance in the product marketing context

## Verification

- mix test apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs apps/fountain/test/fountain/config_reference_test.exs
- mix test (6 doctests, 3 properties, 4162 tests, 0 failures)