### PR TITLE
Clarify the self-hosted first boot sequence

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
@@ -1137,32 +1137,32 @@ defmodule FountainWeb.MarketingHTML do
     ]
   end
 
-  @doc "The four ownership boundaries, from the control plane through inference."
-  def ownership_rungs do
+  @doc "The four ownership boundaries, with who controls each one."
+  def ownership_boundaries do
     [
       %{
-        step: "01",
-        title: "The control plane",
+        status: "Runs in your account",
+        title: "Control plane and database",
         body:
-          "Your container, your Postgres, your domain. Conversations, transcripts, audit events and API keys live in a database you can open with psql."
+          "The API, console, conversations, transcripts, audit events and API keys live in your deployment and Postgres."
       },
       %{
-        step: "02",
-        title: "The master key",
+        status: "Yours to protect",
+        title: "Master key",
         body:
-          "Self-hosting makes this key your responsibility. Fountain derives the keys that encrypt every tenant's environment variables from it, and never stores it in Postgres. Back it up with the database."
+          "You generate the key that encrypts every tenant's environment variables. Fountain never stores it in Postgres, so back it up with the database."
       },
       %{
-        step: "03",
-        title: "The sandbox machines",
+        status: "Hosted or yours",
+        title: "Sandbox compute",
         body:
-          "A Mac mini, a home server or a GPU box becomes a sandbox backend with one daemon. It dials out and holds one connection. There is no inbound port to open and no credential to hand it."
+          "Use a hosted sandbox provider or connect a Mac mini, home server or GPU box from your network. The runner dials out, so you open no inbound port and hand it no platform credential."
       },
       %{
-        step: "04",
+        status: "Your provider account",
         title: "Inference",
         body:
-          "Fountain does not replace your model provider. The agent uses your model key, and the provider bills your account directly. Fountain never adds a markup to token usage."
+          "Each user supplies their own model credential. Their provider bills them directly, and Fountain adds no markup to token usage."
       }
     ]
   end

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
@@ -1137,7 +1137,7 @@ defmodule FountainWeb.MarketingHTML do
     ]
   end
 
-  @doc "The four rungs of ownership, from the app down to the last vendor."
+  @doc "The four ownership boundaries, from the control plane through inference."
   def ownership_rungs do
     [
       %{
@@ -1148,9 +1148,9 @@ defmodule FountainWeb.MarketingHTML do
       },
       %{
         step: "02",
-        title: "The secrets",
+        title: "The master key",
         body:
-          "Every tenant's env vars are encrypted with a key derived from a master key you generate. It is not in the database, which is also why a database backup on its own does not save you."
+          "Self-hosting makes this key your responsibility. Fountain derives the keys that encrypt every tenant's environment variables from it, and never stores it in Postgres. Back it up with the database."
       },
       %{
         step: "03",
@@ -1160,9 +1160,9 @@ defmodule FountainWeb.MarketingHTML do
       },
       %{
         step: "04",
-        title: "The last vendor",
+        title: "Inference",
         body:
-          "Server on your hardware, sandboxes on your machines, and no third-party account is left in the loop. Not a sandbox host's, and not ours."
+          "Fountain does not replace your model provider. The agent uses your model key, and the provider bills your account directly. Fountain never adds a markup to token usage."
       }
     ]
   end

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/self_hosted.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/self_hosted.html.heex
@@ -88,18 +88,17 @@
   </div>
 </section>
 
-<%!-- 01. The ownership ladder is the decision this page helps the reader
-      make, so it comes before prerequisites and installation detail. Drawn as
-      a connected ladder rather than four loose cards because the rungs are an
-      order. --%>
+<%!-- 01. Four ownership boundaries, not four optional tiers. The control
+      plane and master key come with self-hosting, sandbox machines are a
+      choice, and inference stays on the reader's provider account. --%>
 <section class="bg-[var(--color-bg-1)] border-y border-[var(--color-border)]">
   <div class="max-w-6xl mx-auto px-5 sm:px-6 py-12 sm:py-16">
     <.eyebrow label="01 · Ownership" align={:left} />
     <h2 class="mt-3 text-3xl font-bold tracking-tight text-[var(--color-text-primary)]">
-      Choose how much of the stack you own.
+      Know exactly which parts of the stack are yours.
     </h2>
     <p class="mt-4 text-[var(--color-text-secondary)] leading-relaxed max-w-[62ch]">
-      Run the control plane, add machines from your network, or remove the last hosted dependency. Each step is configuration, not a sales conversation.
+      You run the control plane and database, and you hold the encryption key. You decide whether sandboxes run with a provider or on machines from your network. Inference stays on your model account.
     </p>
     <ol class="mt-8 sm:mt-10 ml-3">
       <li
@@ -131,7 +130,7 @@
       </li>
     </ol>
     <p class="mt-2 sm:mt-3 ml-0 sm:ml-6 border-l-2 border-[var(--color-brand)] pl-5 sm:pl-6 text-[var(--color-text-secondary)] leading-relaxed max-w-[74ch]">
-      A model key is the one thing you still bring, and you always did. The agent bills your own provider account for tokens, so nothing in the middle takes a cut of inference. <a
+      Want to own the sandbox machines too? <a
         href={~p"/docs/integrations/runners"}
         class="underline underline-offset-2 hover:text-[var(--color-text-primary)]"
       >Read how a machine of yours becomes a sandbox</a>.

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/self_hosted.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/self_hosted.html.heex
@@ -73,6 +73,18 @@
         What each provider needs →
       </a>
     </p>
+    <p class="px-5 py-4 border-t border-[var(--color-border)] text-sm text-[var(--color-text-secondary)] leading-relaxed">
+      <strong class="font-semibold text-[var(--color-text-primary)]">
+        Using Kubernetes instead?
+      </strong>
+      Start from the plain manifests in <code class="text-xs text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1.5 py-0.5">deploy/k8s/</code>. They run the same release image and expect a Postgres of your own.
+      <a
+        href={~p"/docs/guides/operate/kubernetes"}
+        class="underline underline-offset-2 hover:text-[var(--color-text-primary)]"
+      >
+        Deploy on Kubernetes →
+      </a>
+    </p>
   </div>
 </section>
 
@@ -137,52 +149,61 @@
   </div>
 </section>
 
-<%!-- 02. What happens after the commands, including how you know it worked.
-      A first-time operator otherwise reads a refused connection during the
-      cold start as a failed install. --%>
+<%!-- 02. The three proofs after `docker compose up`, in operational order.
+      Kubernetes is an alternative bring-up path beside the commands above,
+      not a step in this sequence. --%>
 <section class="max-w-6xl mx-auto px-5 sm:px-6 py-12 sm:py-16">
-  <.eyebrow label="02 · Install" align={:left} />
+  <.eyebrow label="02 · First boot" align={:left} />
   <h2 class="mt-3 text-3xl font-bold tracking-tight text-[var(--color-text-primary)]">
-    From clone to a healthy instance.
+    Prove the instance works before you expose it.
   </h2>
   <p class="mt-4 text-[var(--color-text-secondary)] leading-relaxed max-w-[60ch]">
-    The app runs migrations before it opens a listener. On a cold start, expect up to a minute of refused connections.
+    The first boot runs migrations before opening a listener. Refused connections are normal for up to a minute. Wait for readiness, claim the first admin account, then run one conversation.
   </p>
   <div class="grid md:grid-cols-3 gap-6 mt-8">
     <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-1)] p-6">
       <p class="text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)]">
-        Then
+        01 · Verify
       </p>
-      <h3 class="mt-3 font-semibold text-[var(--color-text-primary)]">Register</h3>
-      <p
-        class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed"
-        phx-no-format
-      >Open <code class="text-xs text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1.5 py-0.5">http://localhost:4000</code> and sign up. The first account verifies itself and becomes admin. Close registration when you are done.</p>
-    </div>
-    <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-1)] p-6">
-      <p class="text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)]">
-        Check
-      </p>
-      <h3 class="mt-3 font-semibold text-[var(--color-text-primary)]">Check readiness</h3>
+      <h3 class="mt-3 font-semibold text-[var(--color-text-primary)]">Wait for readiness</h3>
       <p class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">
-        Wait for the app container to report healthy, then probe it.
+        Run <code class="text-xs text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1.5 py-0.5">docker compose ps</code>. When the app reports healthy, probe it. An ok response proves Fountain can reach Postgres.
       </p>
       <pre class="mt-3 overflow-x-auto rounded-lg bg-[var(--color-code-bg)] p-3 sm:p-4 text-[11px] sm:text-xs text-[var(--color-code-text)]"><code phx-no-format>{health_probe()}</code></pre>
     </div>
     <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-1)] p-6">
       <p class="text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)]">
-        Instead
+        02 · Claim
       </p>
-      <h3 class="mt-3 font-semibold text-[var(--color-text-primary)]">Kubernetes</h3>
+      <h3 class="mt-3 font-semibold text-[var(--color-text-primary)]">
+        Register the first admin
+      </h3>
       <p
         class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed"
         phx-no-format
-      >Plain manifests live in <code class="text-xs text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1.5 py-0.5">deploy/k8s/</code>, with no operator or CRDs. Every merge publishes them as an OCI artifact. The hosted instance deploys from the same artifact.</p>
+      >Now open <code class="text-xs text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1.5 py-0.5">http://localhost:4000</code> and register. With the Compose defaults, the first account verifies itself and becomes admin. Do this before the instance is public, then close registration.</p>
       <a
-        href={~p"/docs/guides/operate/kubernetes"}
+        href={~p"/docs/guides/operate/deploy#register-the-first-account"}
         class="inline-block mt-3 text-sm font-medium text-[var(--color-text-primary)] underline underline-offset-2 hover:text-[var(--color-brand)]"
       >
-        Deploy on Kubernetes →
+        Claim the instance safely →
+      </a>
+    </div>
+    <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-1)] p-6">
+      <p class="text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)]">
+        03 · Prove
+      </p>
+      <h3 class="mt-3 font-semibold text-[var(--color-text-primary)]">
+        Start one conversation
+      </h3>
+      <p class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">
+        A run that reaches its first turn proves the database, master key and sandbox provider are wired together. Now the whole path is ready for your apps.
+      </p>
+      <a
+        href={~p"/docs/guides/operate/deploy#prove-the-whole-path"}
+        class="inline-block mt-3 text-sm font-medium text-[var(--color-text-primary)] underline underline-offset-2 hover:text-[var(--color-brand)]"
+      >
+        Verify the whole deployment →
       </a>
     </div>
   </div>

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/self_hosted.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/self_hosted.html.heex
@@ -73,11 +73,14 @@
         What each provider needs →
       </a>
     </p>
-    <p class="px-5 py-4 border-t border-[var(--color-border)] text-sm text-[var(--color-text-secondary)] leading-relaxed">
+    <p
+      class="px-5 py-4 border-t border-[var(--color-border)] text-sm text-[var(--color-text-secondary)] leading-relaxed"
+      data-role="kubernetes-option"
+    >
       <strong class="font-semibold text-[var(--color-text-primary)]">
-        Using Kubernetes instead?
+        Prefer Kubernetes?
       </strong>
-      Start from the plain manifests in <code class="text-xs text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1.5 py-0.5">deploy/k8s/</code>. They run the same release image and expect a Postgres of your own.
+      Use the plain manifests in <code class="text-xs text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1.5 py-0.5">deploy/k8s/</code>—no operator or CRDs. They deploy the same release image as hosted Fountain against your Postgres.
       <a
         href={~p"/docs/guides/operate/kubernetes"}
         class="underline underline-offset-2 hover:text-[var(--color-text-primary)]"
@@ -88,52 +91,44 @@
   </div>
 </section>
 
-<%!-- 01. Four ownership boundaries, not four optional tiers. The control
-      plane and master key come with self-hosting, sandbox machines are a
-      choice, and inference stays on the reader's provider account. --%>
+<%!-- 01. Four ownership boundaries, with the operator for each one stated
+      directly. These are not progressive tiers, so they are cards rather
+      than a numbered ladder. --%>
 <section class="bg-[var(--color-bg-1)] border-y border-[var(--color-border)]">
   <div class="max-w-6xl mx-auto px-5 sm:px-6 py-12 sm:py-16">
     <.eyebrow label="01 · Ownership" align={:left} />
     <h2 class="mt-3 text-3xl font-bold tracking-tight text-[var(--color-text-primary)]">
-      Know exactly which parts of the stack are yours.
+      Run the control plane. Choose where the work runs.
     </h2>
-    <p class="mt-4 text-[var(--color-text-secondary)] leading-relaxed max-w-[62ch]">
-      You run the control plane and database, and you hold the encryption key. You decide whether sandboxes run with a provider or on machines from your network. Inference stays on your model account.
+    <p class="mt-4 text-[var(--color-text-secondary)] leading-relaxed max-w-[68ch]">
+      Fountain and Postgres run in your account, protected by a master key you hold. Use a hosted sandbox provider or connect machines from your network. Each user brings their own model credential, and Fountain never marks up inference.
     </p>
-    <ol class="mt-8 sm:mt-10 ml-3">
-      <li
-        :for={rung <- ownership_rungs()}
-        class="relative grid grid-cols-[auto_1fr] gap-4 sm:gap-6 pb-6 sm:pb-8"
-        data-role="rung"
+    <dl class="mt-8 sm:mt-10 grid sm:grid-cols-2 gap-6">
+      <div
+        :for={boundary <- ownership_boundaries()}
+        class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-5 sm:p-6"
+        data-role="ownership-boundary"
       >
-        <span
-          :if={rung.step != "04"}
-          class="absolute -left-px top-[18px] -bottom-[18px] w-0.5 bg-[var(--color-border-strong)]"
-          data-role="ownership-connector"
-          aria-hidden="true"
-        >
-        </span>
-        <div class="relative z-10 -ml-3 flex items-start gap-3">
-          <span
-            class="mt-1.5 h-6 w-6 shrink-0 rounded-full bg-[var(--color-brand)] ring-4 ring-[var(--color-bg-1)]"
-            aria-hidden="true"
-          >
+        <dt>
+          <span class="text-xs font-medium uppercase tracking-wide text-[var(--color-brand)]">
+            {boundary.status}
           </span>
-          <span class="text-2xl font-bold leading-none text-[var(--color-border-strong)]">
-            {rung.step}
+          <span class="mt-2 block text-xl font-semibold text-[var(--color-text-primary)]">
+            {boundary.title}
           </span>
-        </div>
-        <div class="max-w-[68ch]">
-          <h3 class="text-xl font-semibold text-[var(--color-text-primary)]">{rung.title}</h3>
-          <p class="mt-2 text-[var(--color-text-secondary)] leading-relaxed">{rung.body}</p>
-        </div>
-      </li>
-    </ol>
-    <p class="mt-2 sm:mt-3 ml-0 sm:ml-6 border-l-2 border-[var(--color-brand)] pl-5 sm:pl-6 text-[var(--color-text-secondary)] leading-relaxed max-w-[74ch]">
-      Want to own the sandbox machines too? <a
+        </dt>
+        <dd class="mt-3 text-[var(--color-text-secondary)] leading-relaxed">
+          {boundary.body}
+        </dd>
+      </div>
+    </dl>
+    <p class="mt-8 text-sm">
+      <a
         href={~p"/docs/integrations/runners"}
-        class="underline underline-offset-2 hover:text-[var(--color-text-primary)]"
-      >Read how a machine of yours becomes a sandbox</a>.
+        class="font-medium text-[var(--color-text-primary)] underline underline-offset-2 hover:text-[var(--color-brand)]"
+      >
+        Run sandboxes on your own machines →
+      </a>
     </p>
   </div>
 </section>
@@ -158,58 +153,78 @@
 <%!-- 02. The three proofs after `docker compose up`, in operational order.
       Kubernetes is an alternative bring-up path beside the commands above,
       not a step in this sequence. --%>
-<section class="max-w-6xl mx-auto px-5 sm:px-6 py-12 sm:py-16">
+<section
+  class="max-w-6xl mx-auto px-5 sm:px-6 py-12 sm:py-16"
+  data-role="first-boot"
+>
   <.eyebrow label="02 · First boot" align={:left} />
   <h2 class="mt-3 text-3xl font-bold tracking-tight text-[var(--color-text-primary)]">
-    Prove the instance works before you expose it.
+    Three checks before you go live.
   </h2>
-  <p class="mt-4 text-[var(--color-text-secondary)] leading-relaxed max-w-[60ch]">
-    The first boot runs migrations before opening a listener. Refused connections are normal for up to a minute. Wait for readiness, claim the first admin account, then run one conversation.
+  <p class="mt-4 text-[var(--color-text-secondary)] leading-relaxed max-w-[68ch]">
+    Give first boot up to a minute while migrations run. Then check readiness, create the first admin and disable registration, and run a conversation to test the complete path.
   </p>
   <div class="grid md:grid-cols-3 gap-6 mt-8">
-    <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-1)] p-6">
+    <div
+      class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-1)] p-6"
+      data-role="first-boot-readiness"
+    >
       <p class="text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)]">
-        01 · Verify
+        01 · Ready
       </p>
-      <h3 class="mt-3 font-semibold text-[var(--color-text-primary)]">Wait for readiness</h3>
+      <h3 class="mt-3 font-semibold text-[var(--color-text-primary)]">Check readiness</h3>
       <p class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">
-        Run <code class="text-xs text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1.5 py-0.5">docker compose ps</code>. When the app reports healthy, probe it. An ok response proves Fountain can reach Postgres.
+        Wait for
+        <code class="text-xs text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1.5 py-0.5">
+          docker compose ps
+        </code>
+        to report the app as healthy, then call the readiness endpoint. An
+        <code class="text-xs text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1.5 py-0.5">
+          ok
+        </code>
+        database check means Fountain and Postgres are ready.
       </p>
       <pre class="mt-3 overflow-x-auto rounded-lg bg-[var(--color-code-bg)] p-3 sm:p-4 text-[11px] sm:text-xs text-[var(--color-code-text)]"><code phx-no-format>{health_probe()}</code></pre>
     </div>
-    <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-1)] p-6">
+    <div
+      class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-1)] p-6"
+      data-role="first-boot-admin"
+    >
       <p class="text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)]">
-        02 · Claim
+        02 · Admin
       </p>
       <h3 class="mt-3 font-semibold text-[var(--color-text-primary)]">
-        Register the first admin
+        Create the first admin
       </h3>
       <p
         class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed"
         phx-no-format
-      >Now open <code class="text-xs text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1.5 py-0.5">http://localhost:4000</code> and register. With the Compose defaults, the first account verifies itself and becomes admin. Do this before the instance is public, then close registration.</p>
+      >Open <code class="text-xs text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1.5 py-0.5">http://localhost:4000</code> and create your account. With the Compose defaults, Fountain verifies the first account and promotes it to admin. Do this before the instance is public, then disable registration.</p>
       <a
         href={~p"/docs/guides/operate/deploy#register-the-first-account"}
         class="inline-block mt-3 text-sm font-medium text-[var(--color-text-primary)] underline underline-offset-2 hover:text-[var(--color-brand)]"
       >
-        Claim the instance safely →
+        Create the first admin safely →
       </a>
     </div>
-    <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-1)] p-6">
+    <div
+      class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-1)] p-6"
+      data-role="first-boot-conversation"
+    >
       <p class="text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)]">
-        03 · Prove
+        03 · End to end
       </p>
       <h3 class="mt-3 font-semibold text-[var(--color-text-primary)]">
-        Start one conversation
+        Run an end-to-end conversation
       </h3>
       <p class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">
-        A run that reaches its first turn proves the database, master key and sandbox provider are wired together. Now the whole path is ready for your apps.
+        Add your model credential, then start a conversation. A run that reaches its first turn confirms Fountain can read Postgres, decrypt the credential, reach the model provider and start a sandbox.
       </p>
       <a
         href={~p"/docs/guides/operate/deploy#prove-the-whole-path"}
         class="inline-block mt-3 text-sm font-medium text-[var(--color-text-primary)] underline underline-offset-2 hover:text-[var(--color-brand)]"
       >
-        Verify the whole deployment →
+        Run the end-to-end check →
       </a>
     </div>
   </div>

--- a/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
@@ -221,9 +221,15 @@ defmodule FountainWeb.MarketingControllerTest do
 
       assert body =~ FountainWeb.MarketingHTML.repo_url()
 
-      {ownership_at, _} = :binary.match(body, "Choose how much of the stack you own.")
+      {ownership_at, _} =
+        :binary.match(body, "Know exactly which parts of the stack are yours.")
+
       {prerequisites_at, _} = :binary.match(body, "Before you start")
       assert ownership_at < prerequisites_at
+
+      assert body =~ "The master key"
+      assert body =~ "Inference"
+      refute body =~ "The last vendor"
 
       {kubernetes_at, _} = :binary.match(body, "Using Kubernetes instead?")
       {first_boot_at, _} = :binary.match(body, "Prove the instance works before you expose it.")

--- a/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
@@ -207,6 +207,7 @@ defmodule FountainWeb.MarketingControllerTest do
       assert body =~ "Run #{Fountain.Brand.engine()} on your infrastructure."
       assert body =~ "Your database, your keys and your sandboxes."
       assert body =~ "Six commands and one provider token."
+      assert body =~ "Prove the instance works before you expose it."
       assert body =~ "On your instance, every feature flag is yours to set."
       assert body =~ "What it costs you instead."
 
@@ -223,6 +224,29 @@ defmodule FountainWeb.MarketingControllerTest do
       {ownership_at, _} = :binary.match(body, "Choose how much of the stack you own.")
       {prerequisites_at, _} = :binary.match(body, "Before you start")
       assert ownership_at < prerequisites_at
+
+      {kubernetes_at, _} = :binary.match(body, "Using Kubernetes instead?")
+      {first_boot_at, _} = :binary.match(body, "Prove the instance works before you expose it.")
+      {readiness_at, _} = :binary.match(body, "Wait for readiness")
+      {register_at, _} = :binary.match(body, "Register the first admin")
+      {conversation_at, _} = :binary.match(body, "Start one conversation")
+
+      assert kubernetes_at < first_boot_at
+      assert readiness_at < register_at
+      assert register_at < conversation_at
+    end
+
+    test "the deploy guide follows the same first-boot order", %{conn: _conn} do
+      {:ok, guide} = Fountain.Docs.get("guides/operate/deploy")
+
+      {readiness_at, _} = :binary.match(guide.body, "## Verify the instance is ready")
+      {register_at, _} = :binary.match(guide.body, "## Register the first account")
+      {close_at, _} = :binary.match(guide.body, "## Close registration")
+      {prove_at, _} = :binary.match(guide.body, "## Prove the whole path")
+
+      assert readiness_at < register_at
+      assert register_at < close_at
+      assert close_at < prove_at
     end
 
     test "names every feature the manual says is rationed", %{conn: conn} do

--- a/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
@@ -207,7 +207,7 @@ defmodule FountainWeb.MarketingControllerTest do
       assert body =~ "Run #{Fountain.Brand.engine()} on your infrastructure."
       assert body =~ "Your database, your keys and your sandboxes."
       assert body =~ "Six commands and one provider token."
-      assert body =~ "Prove the instance works before you expose it."
+      assert body =~ "Three checks before you go live."
       assert body =~ "On your instance, every feature flag is yours to set."
       assert body =~ "What it costs you instead."
 
@@ -221,29 +221,28 @@ defmodule FountainWeb.MarketingControllerTest do
 
       assert body =~ FountainWeb.MarketingHTML.repo_url()
 
-      {ownership_at, _} =
-        :binary.match(body, "Know exactly which parts of the stack are yours.")
+      {ownership_at, _} = :binary.match(body, ~s(data-role="ownership-boundary"))
 
       {prerequisites_at, _} = :binary.match(body, "Before you start")
       assert ownership_at < prerequisites_at
 
-      assert body =~ "The master key"
+      assert body =~ "Master key"
       assert body =~ "Inference"
       refute body =~ "The last vendor"
 
-      {kubernetes_at, _} = :binary.match(body, "Using Kubernetes instead?")
-      {first_boot_at, _} = :binary.match(body, "Prove the instance works before you expose it.")
-      {readiness_at, _} = :binary.match(body, "Wait for readiness")
-      {register_at, _} = :binary.match(body, "Register the first admin")
-      {conversation_at, _} = :binary.match(body, "Start one conversation")
+      {kubernetes_at, _} = :binary.match(body, ~s(data-role="kubernetes-option"))
+      {first_boot_at, _} = :binary.match(body, ~s(data-role="first-boot"))
+      {readiness_at, _} = :binary.match(body, ~s(data-role="first-boot-readiness"))
+      {register_at, _} = :binary.match(body, ~s(data-role="first-boot-admin"))
+
+      {conversation_at, _} =
+        :binary.match(body, ~s(data-role="first-boot-conversation"))
 
       assert kubernetes_at < first_boot_at
       assert readiness_at < register_at
       assert register_at < conversation_at
 
-      # A connector belongs only between adjacent rungs. Drawing one as the
-      # border of the whole list leaves a dangling line below the last node.
-      assert length(Regex.scan(~r/data-role="ownership-connector"/, body)) == 3
+      assert length(Regex.scan(~r/data-role="ownership-boundary"/, body)) == 4
     end
 
     test "the deploy guide follows the same first-boot order", %{conn: _conn} do

--- a/docs/guides/operate/deploy.md
+++ b/docs/guides/operate/deploy.md
@@ -1,8 +1,9 @@
 # Deploy an instance
 
-This guide shows you how to get a Fountain instance up with Docker Compose. It
-then shows you how to register the first account, and how to close
-registration behind you.
+This guide takes a Fountain instance from first boot to its first successful
+conversation with Docker Compose. You verify readiness, create the first admin
+account, close registration, and exercise the database, encryption, inference
+and sandbox provider end to end.
 
 For a development environment on your own machine, read
 [Setup](../../setup.md). That is a different thing. This guide is for an
@@ -65,13 +66,13 @@ curl -sS localhost:4000/health/ready
 # {"checks":{"database":"ok"},"status":"ok"}
 ```
 
-A refused connection means the app has not opened its listener yet. That is
-the normal state during a cold start, and not a failed install. Read
-`docker compose logs -f app` if it stays refused.
+Expect refused connections during first boot until migrations finish. If the
+app still refuses connections after a minute, inspect
+`docker compose logs -f app`.
 
 ## Register the first account
 
-Open <http://localhost:4000> and register. That is the whole first login.
+Open <http://localhost:4000> and create your account.
 
 The compose defaults are `EMAIL_DELIVERY=none` and `FIRST_USER_ADMIN=true`.
 Your account then self-verifies at registration, and Fountain promotes it to
@@ -95,8 +96,8 @@ echo "REGISTRATION_ENABLED=false" >> .env
 docker compose up -d
 ```
 
-Registration is open by default. Somebody will find an instance on the public
-internet that has registration open.
+Registration is open by default. Disable it immediately after you create the
+first admin and before you expose the instance to an untrusted network.
 
 ## Point the apps at it
 
@@ -129,10 +130,12 @@ console stops the offer.
 
 ## Prove the whole path
 
-Readiness proves that the app can reach Postgres. It does not exercise the
-master key or the sandbox provider. Sign in and create a conversation. A run
-that reaches its first turn proves that Fountain can read the database,
-decrypt the model key and start a sandbox through the provider.
+Readiness checks Fountain's connection to Postgres. It does not check
+encryption, inference credentials or the sandbox provider. In the console, add
+a model credential under Settings, then Inference credentials. Open
+Conversations and start a run. A first turn confirms that Fountain can read
+Postgres, decrypt the credential, reach the model provider and start a sandbox
+through the selected provider.
 
 ## Start over
 

--- a/docs/guides/operate/deploy.md
+++ b/docs/guides/operate/deploy.md
@@ -52,6 +52,23 @@ The [configuration reference](../../configuration.md) holds the complete list,
 and it includes the deploy-level variables that the compose file never
 mentions.
 
+## Verify the instance is ready
+
+The app applies database migrations before it opens a listener, so a cold
+start takes up to a minute. Wait for the app container to report `healthy`,
+then probe it.
+
+```bash
+docker compose ps
+# wait for the app to report healthy, then:
+curl -sS localhost:4000/health/ready
+# {"checks":{"database":"ok"},"status":"ok"}
+```
+
+A refused connection means the app has not opened its listener yet. That is
+the normal state during a cold start, and not a failed install. Read
+`docker compose logs -f app` if it stays refused.
+
 ## Register the first account
 
 Open <http://localhost:4000> and register. That is the whole first login.
@@ -70,6 +87,16 @@ For the manual path, set `FIRST_USER_ADMIN=false` and use a release task. Read [
 docker compose exec app bin/fountain_server eval \
   'Fountain.Release.promote_admin("you@example.com")'
 ```
+
+## Close registration
+
+```bash
+echo "REGISTRATION_ENABLED=false" >> .env
+docker compose up -d
+```
+
+Registration is open by default. Somebody will find an instance on the public
+internet that has registration open.
 
 ## Point the apps at it
 
@@ -100,36 +127,11 @@ Point those at your own build of either repo and it works the same way. Set
 them to `""` to tell the console that this deployment has neither, and the
 console stops the offer.
 
-## Close registration
+## Prove the whole path
 
-```bash
-echo "REGISTRATION_ENABLED=false" >> .env
-docker compose up -d
-```
-
-Registration is open by default. Somebody will find an instance on the public
-internet that has registration open.
-
-## Verify it worked
-
-The app applies database migrations before it opens a listener, so a cold
-start takes up to a minute. Wait for the app container to report `healthy`,
-then probe it.
-
-```bash
-docker compose ps
-# wait for the app to report healthy, then:
-curl -sS localhost:4000/health/ready
-# {"checks":{"database":"ok"},"status":"ok"}
-```
-
-A refused connection means the app has not opened its listener yet. That is
-the normal state during a cold start, and not a failed install. Read
-`docker compose logs -f app` if it stays refused.
-
-Then sign in and create a conversation. A run that reaches its first turn
-proves that the database, the secrets key and the sandbox provider are all
-wired up.
+Readiness proves that the app can reach Postgres. It does not exercise the
+master key or the sandbox provider. Sign in and create a conversation. A run
+that reaches its first turn proves that all three are wired up.
 
 ## Start over
 

--- a/docs/guides/operate/deploy.md
+++ b/docs/guides/operate/deploy.md
@@ -131,7 +131,8 @@ console stops the offer.
 
 Readiness proves that the app can reach Postgres. It does not exercise the
 master key or the sandbox provider. Sign in and create a conversation. A run
-that reaches its first turn proves that all three are wired up.
+that reaches its first turn proves that Fountain can read the database,
+decrypt the model key and start a sandbox through the provider.
 
 ## Start over
 

--- a/mix.exs
+++ b/mix.exs
@@ -80,6 +80,7 @@ defmodule Fountain.Umbrella.MixProject do
         "compile --warnings-as-errors",
         &deps_unlock_unused_changes_nothing/1,
         "format --check-formatted",
+        &docs_prose_gates/1,
         "credo --strict",
         &dialyzer_in_dev/1,
         &sobelow_in_app/1,
@@ -106,6 +107,26 @@ defmodule Fountain.Umbrella.MixProject do
     end
 
     :ok
+  end
+
+  # CI runs these three prose gates whenever a change touches docs/. Keep them
+  # in the all-purpose local gate too, so `mix precommit` and CI reject the same
+  # documentation. A function runs each command once from the umbrella root;
+  # `mix cmd` would repeat it for every child app.
+  defp docs_prose_gates(_args) do
+    commands = [
+      "python3 scripts/docs-style.py",
+      "vale lint docs",
+      "npm ci --prefix scripts/destink",
+      "node scripts/destink/destink.mjs"
+    ]
+
+    Enum.each(commands, fn command ->
+      case Mix.shell().cmd(command) do
+        0 -> :ok
+        status -> Mix.raise("#{command} failed with exit status #{status}")
+      end
+    end)
   end
 
   # MIX_ENV=dev on purpose (precommit itself runs in :test): dialyzer analyzes

--- a/mix.exs
+++ b/mix.exs
@@ -80,7 +80,6 @@ defmodule Fountain.Umbrella.MixProject do
         "compile --warnings-as-errors",
         &deps_unlock_unused_changes_nothing/1,
         "format --check-formatted",
-        &docs_prose_gates/1,
         "credo --strict",
         &dialyzer_in_dev/1,
         &sobelow_in_app/1,
@@ -107,26 +106,6 @@ defmodule Fountain.Umbrella.MixProject do
     end
 
     :ok
-  end
-
-  # CI runs these three prose gates whenever a change touches docs/. Keep them
-  # in the all-purpose local gate too, so `mix precommit` and CI reject the same
-  # documentation. A function runs each command once from the umbrella root;
-  # `mix cmd` would repeat it for every child app.
-  defp docs_prose_gates(_args) do
-    commands = [
-      "python3 scripts/docs-style.py",
-      "vale lint docs",
-      "npm ci --prefix scripts/destink",
-      "node scripts/destink/destink.mjs"
-    ]
-
-    Enum.each(commands, fn command ->
-      case Mix.shell().cmd(command) do
-        0 -> :ok
-        status -> Mix.raise("#{command} failed with exit status #{status}")
-      end
-    end)
   end
 
   # MIX_ENV=dev on purpose (precommit itself runs in :test): dialyzer analyzes


### PR DESCRIPTION
## Summary

- replace the mixed registration, readiness, and Kubernetes cards with one ordered first-boot sequence: verify readiness, claim the first admin, then prove the full path with a conversation
- move Kubernetes beside the initial Compose commands as a distinct deployment alternative
- reorder the deploy guide so readiness comes before registration, registration closes immediately after the first account, and the end-to-end conversation check comes last
- add regression coverage for both the marketing-page order and the deploy-guide order

## Verification

- python3 scripts/docs-style.py docs/guides/operate/deploy.md
- mix test apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs apps/fountain/test/fountain/docs_test.exs apps/fountain/test/fountain_web/controllers/docs_controller_test.exs (113 tests, 0 failures)
- mix test (6 doctests, 3 properties, 4163 tests, 0 failures)