### PR TITLE
Clarify human control in case study copy

### DIFF
--- a/.agents/product-marketing.md
+++ b/.agents/product-marketing.md
@@ -208,7 +208,7 @@ transcripts, reviews or quotes in this repo to mine. Until there are, copy draws
 on the repo's own problem statement rather than pretending to quote a user.
 
 **Words to use:** Agent, Environment, Vault, Conversation, sandbox, runtime,
-template, run, transcript, credit, primitive, estate, gate, guardrail.
+template, run, transcript, credit, primitive, cluster, gate, guardrail.
 
 **"Computer" is a marketing word only.** `standards/voice-and-style.md` bans it
 from `docs/` because reference prose needs one name for the machine, and that
@@ -271,14 +271,14 @@ fail the gate in a manual, and that is by design.
 ## Proof Points
 
 **Metrics:** The only sourced numbers are the case study's, counted on one
-production estate over a stated window (11 to 25 August 2026) and held as
+production cluster over a stated window (11 to 25 August 2026) and held as
 literals in `marketing_html.ex` so they cannot quietly widen their own window.
 78 incidents handled by an agent; 4m 27s from alert to open pull request on the
 worked incident; 7.5 minute median incident to verdict; 0 cluster credentials
 the agent holds. Twelve fix pull requests opened, eight merged, four of those a
 rehearsal fault raised on purpose.
 
-The estate is a Kubernetes cluster carrying live production workloads. Numbers
+The system is a Kubernetes cluster carrying live production workloads. Numbers
 reported by the cluster administrator (us). **Say both whenever the numbers
 appear, and keep the "(us)".** Without it the role noun reads as a neutral
 third party, on a page where the administrator and the seller are the same
@@ -286,7 +286,7 @@ party. That conflict is the disclosure, so hiding it behind a job title is
 worse than saying nothing.
 
 The disclosure is provenance, not size. Every number is self-reported from a
-single estate rather than audited or drawn from a customer, and that is what a
+single cluster rather than audited or drawn from a customer, and that is what a
 reader is owed. It is not a hobby cluster and copy must not imply one: "a
 private cluster run by one person" conceded smallness, which is neither true
 nor the thing being disclosed. "The numbers are its own" then failed the other

--- a/apps/fountain/lib/fountain_web/controllers/marketing_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_controller.ex
@@ -178,7 +178,7 @@ defmodule FountainWeb.MarketingController do
     end
   end
 
-  # An estate that pages an agent instead of a person, and what stops the
+  # A cluster that pages an agent as well as a person, and what stops the
   # agent from merging its own work. Sales copy, so it follows `/`: another
   # deployment gets the manual's tour of the same shape.
   def case_study(conn, _params) do
@@ -187,10 +187,10 @@ defmodule FountainWeb.MarketingController do
         layout: {FountainWeb.Layouts, :marketing},
         page_title: "Self-healing infrastructure · #{Fountain.Brand.name()}",
         meta_description:
-          "A Kubernetes estate that answers its own alerts. Prometheus fires, " <>
+          "A Kubernetes cluster that answers its own alerts. Prometheus fires, " <>
             "#{Fountain.Brand.name()} starts an agent, the agent finds the commit that " <>
-            "broke the cluster and opens one pull request. A human still approves every " <>
-            "merge, because the agent is built so that it cannot."
+            "broke the cluster and opens one pull request. The on-call engineer decides " <>
+            "whether to merge it."
       )
     else
       redirect(conn, to: ~p"/docs/tour")

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
@@ -1473,7 +1473,7 @@ defmodule FountainWeb.MarketingHTML do
   # The case study is data first, like /integrations above. Every number here
   # was counted once, by hand, over the window `case_window/0` names: the
   # dispatch counts and turn durations from this deployment's own database,
-  # the pull requests and their timestamps from the estate's repository. They
+  # the pull requests and their timestamps from the cluster's repository. They
   # are literals on purpose. A figure that recomputed at request time would
   # quietly widen its own window and end up claiming something nobody checked.
 
@@ -1486,7 +1486,7 @@ defmodule FountainWeb.MarketingHTML do
       %{
         value: "78",
         label: "incidents handled by an agent",
-        note: "Fifteen days, one estate, one runbook, no rota."
+        note: "Fifteen days, one cluster, one runbook."
       },
       %{
         value: "4m 27s",
@@ -1513,15 +1513,15 @@ defmodule FountainWeb.MarketingHTML do
         step: "1",
         title: "Prometheus notices",
         mono: "KubePodCrashLooping · PodOOMKilled · CPUThrottlingHigh · PodRestartChurn",
-        body: "The estate's existing alert rules. Prometheus knows nothing about the agent."
+        body: "The cluster's existing alert rules. Prometheus knows nothing about the agent."
       },
       %{
         step: "2",
         title: "Alertmanager forks the page",
         mono: "continue: true",
         body:
-          "One copy to the operator's phone, as before. One to a webhook. " <>
-            "The human is added to, not replaced."
+          "One copy goes to the on-call engineer's phone, as before. One goes to a webhook. " <>
+            "The agent joins the response; it does not replace the engineer."
       },
       %{
         step: "3",
@@ -1533,10 +1533,10 @@ defmodule FountainWeb.MarketingHTML do
       },
       %{
         step: "4",
-        title: "The agent reads the estate",
+        title: "The agent reads the cluster",
         mono: "Authorization: Bearer … (GET only)",
         body:
-          "A read-only estate service answers with node health, drift from " <>
+          "A read-only service answers with node health, drift from " <>
             "source, and controller conditions. Every other method returns 405."
       },
       %{
@@ -1558,7 +1558,7 @@ defmodule FountainWeb.MarketingHTML do
       },
       %{
         step: "7",
-        title: "A human approves",
+        title: "The on-call engineer decides",
         mono: "422 on self-approval · 405 on self-merge",
         body:
           "The one gate. GitHub blocks self-approval, and the branch needs a " <>
@@ -1585,7 +1585,7 @@ defmodule FountainWeb.MarketingHTML do
   def case_guardrails do
     [
       %{
-        can: "Read the whole estate graph, including controller conditions.",
+        can: "Read cluster state, including controller conditions.",
         cannot: "Change anything. The token is refused on any method but GET."
       },
       %{
@@ -1645,7 +1645,7 @@ defmodule FountainWeb.MarketingHTML do
       },
       %{
         time: "08:50:27",
-        title: "A human wakes up and reads two pull requests",
+        title: "The on-call engineer wakes up and reads two pull requests",
         body:
           "The throttling fix is merged. Flux reconciles on the webhook, and " <>
             "the agent watches the container come back."
@@ -1700,7 +1700,7 @@ defmodule FountainWeb.MarketingHTML do
         title: "Environment",
         body:
           "The machine the agent wakes up on, with the repository, the CLI and " <>
-            "the read-only estate service's address. Described once, rebuilt " <>
+            "a read-only service for cluster state. Described once, rebuilt " <>
             "per incident, never patched by hand."
       },
       %{
@@ -1735,7 +1735,7 @@ defmodule FountainWeb.MarketingHTML do
         agent_id: agentId,  // estate-medic
         vault_id: vaultId,  // the identity it acts as
         prompt: [
-          `The estate is alerting.`,
+          `The cluster is alerting.`,
           alertLines,
           `Diagnose it. If a change to the repo can`,
           `fix it, open one minimal PR, wait for the`,

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/case_study_self_healing.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/case_study_self_healing.html.heex
@@ -9,7 +9,7 @@
     The pager still goes off at 06:58. The pull request is open by 07:02.
   </h1>
   <p class="text-lg sm:text-xl text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-10">
-    A Kubernetes estate pages a person when a workload breaks. This one also starts an agent. It reads the cluster, finds the commit at fault, and opens one small pull request it is unable to merge.
+    A Kubernetes cluster pages an on-call engineer when a workload breaks. This one also starts an agent. It reads the cluster, finds the commit at fault, and opens one small pull request. That engineer decides whether to merge it.
   </p>
   <div class="flex flex-col sm:flex-row gap-3 justify-center">
     <a
@@ -40,7 +40,7 @@
       </div>
     </div>
     <p class="mt-8 text-center text-xs text-[var(--color-text-muted)]">
-      Counted on one production estate over {case_window()}.
+      Counted in one production cluster over {case_window()}.
     </p>
   </div>
 </section>
@@ -88,7 +88,7 @@
       Nine steps, one of them a person.
     </h2>
     <p class="text-center text-[var(--color-text-secondary)] max-w-xl mx-auto mb-12">
-      Everything but the agent was already in the estate. One webhook, one API call.
+      The alerting stack was already there. Adding the agent took one webhook and one API call.
     </p>
     <ol class="max-w-3xl mx-auto space-y-4">
       <li
@@ -306,7 +306,7 @@
     </a>
   </div>
   <p class="mt-10 text-xs text-[var(--color-text-muted)] max-w-2xl mx-auto leading-relaxed">
-    The estate is a Kubernetes cluster carrying live production workloads. Numbers reported by the cluster administrator (us). Twelve fix pull requests opened in the window and eight merged, four of them the same rehearsal fault raised on purpose. Most incidents end with no pull request, because the agent decides the repository cannot fix them. The agent's definition is public at <a
+    This is a Kubernetes cluster carrying live production workloads. Numbers reported by the cluster administrator (us). Twelve fix pull requests opened in the window and eight merged, four of them the same rehearsal fault raised on purpose. Most incidents end with no pull request, because the agent decides the repository cannot fix them. The agent's definition is public at <a
       href="https://github.com/jhgaylor/agent-specs/blob/main/src/agents/specialists/engineering/estate-medic.ts"
       class="underline underline-offset-2 hover:text-[var(--color-text-secondary)]"
     >jhgaylor/agent-specs</a>.

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -84,10 +84,7 @@
       The agent never holds a cluster credential. It cannot merge for a
       different reason: GitHub refuses a self-approval from the account that
       clones, pushes a branch and opens the request. Keep those mechanisms
-      separate in the copy.
-
-      "Cluster" stays in the heading because it is familiar on a homepage.
-      "Estate" is accurate in the disclosure after the paragraph defines it. --%>
+      separate in the copy. --%>
 <section class="max-w-5xl mx-auto px-6 pt-8 pb-16">
   <div
     class="rounded-2xl border border-[var(--color-accent-line)] bg-[var(--color-accent-soft)] p-8 sm:p-12"
@@ -112,7 +109,7 @@
       </div>
     </dl>
     <p class="mt-8 max-w-2xl text-xs text-[var(--color-text-secondary)]">
-      Counted over {case_window()} on one production estate, a Kubernetes cluster carrying live production workloads. Numbers reported by the cluster administrator (us).
+      Counted over {case_window()} on one Kubernetes cluster carrying live production workloads. Numbers reported by the cluster administrator (us).
     </p>
     <div class="mt-8">
       <a

--- a/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
@@ -525,6 +525,9 @@ defmodule FountainWeb.MarketingControllerTest do
       body = conn |> get(~p"/case-studies/self-healing-infrastructure") |> html_response(200)
 
       assert body =~ "The pager still goes off at 06:58."
+      assert body =~ "That engineer decides whether to merge it."
+      refute body =~ "Kubernetes estate"
+      refute body =~ "production estate"
 
       # The headline quotes the incident's own clock. Assert it against the
       # timeline so editing one cannot leave the other behind: the hero would


### PR DESCRIPTION
## Summary

- frame merge approval as a decision retained by the on-call engineer
- replace British infrastructure terms such as estate and rota with natural American wording
- align the case study, homepage teaser, metadata, and product-marketing vocabulary
- add regression assertions for the new hero language

## Testing

- mix format --check-formatted on the changed Elixir and HEEx files
- mix test apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs (61 tests, 0 failures)