### PR TITLE
Strengthen the homepage closing copy

### DIFF
--- a/apps/fountain/lib/fountain_web/components/layouts/marketing.html.heex
+++ b/apps/fountain/lib/fountain_web/components/layouts/marketing.html.heex
@@ -157,14 +157,11 @@
             </span>
           </a>
           <p class="mt-3 max-w-xs text-[var(--color-text-muted)]">
-            <%!-- Uncontracted, like every other line on the site: "who'd" was the
-                  only contraction on any marketing page. It also said "for teams",
-                  which the homepage's own limits contradict ("An account is one
-                  person. No organizations, no seats, no single sign-on"), and this
-                  footer runs on every marketing page. No meter claim here either,
-                  so it stays true on a deployment that prices nothing. --%>
+            <%!-- This line divides the work instead of making a generic promise
+                  about less management. It avoids a meter claim, so it stays true
+                  on a deployment that prices nothing. --%>
             <span :if={Fountain.Marketing.site?()}>
-              Run coding agents on machines you do not have to manage.
+              Your coding agents do the work. We run the machines.
             </span>
             <span :if={!Fountain.Marketing.site?()}>Powered by Fountain.</span>
           </p>
@@ -277,14 +274,14 @@
         </div>
       </div>
 
-      <%!-- The hosted site's copyright line names the brand, and credits the
-        engine, which is open source. Somebody else's deployment gets an
-        attribution. --%>
+      <%!-- The hosted site's copyright line names the brand, and turns the
+        engine credit into the ownership promise behind open source. Somebody
+        else's deployment gets an attribution. --%>
       <div class="mt-10 pt-6 border-t border-[var(--color-border)] flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3 text-[var(--color-text-muted)]">
         <span>
           © 2026 {Fountain.Brand.name()}.
           <span :if={Fountain.Brand.hosted?()}>
-            It runs {Fountain.Brand.engine()}, which is open source.
+            Built on {Fountain.Brand.engine()}. Open source and yours to run.
           </span>
         </span>
         <div :if={Fountain.Legal.published?()} class="flex items-center gap-6">

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
@@ -1046,24 +1046,24 @@ defmodule FountainWeb.MarketingHTML do
   def prerequisites do
     [
       %{
-        label: "You need",
-        body: "Docker Engine with Compose v2, and openssl for the two key lines."
-      },
-      %{
-        label: "No database",
-        body: "The compose file runs Postgres 16 for you. You install no database."
-      },
-      %{
-        label: "Network",
+        label: "Compose tools",
         body:
-          "Your machine reaches ghcr.io, the registry that holds the image. " <>
-            "Blocked? Compose builds it from the checkout instead."
+          "For the six-command path, bring Docker Engine with Compose v2 and openssl for the two key lines."
       },
       %{
-        label: "One address",
+        label: "Postgres 16+",
         body:
-          "Reaching it by anything but localhost? Set PUBLIC_URL too. It builds " <>
-            "the links in verification emails, and every sandbox reads it."
+          "Fountain requires it. Compose runs one for you, or point Fountain at a Postgres you operate."
+      },
+      %{
+        label: "Image access",
+        body:
+          "Pull the release image from ghcr.io. If your network blocks it, Compose can build from the checkout."
+      },
+      %{
+        label: "Public URL",
+        body:
+          "Set PUBLIC_URL when users or sandboxes reach Fountain anywhere but localhost. It also builds verification links."
       }
     ]
   end

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -898,11 +898,11 @@
       machine you did not build is also the page's third telling of that idea
       by this point.
 
-      The deck is one sentence and three steps. It was three sentences: the
+      The deck is one sentence and four steps. It was three sentences: the
       steps, then a list of things that do not happen (no machine to provision,
       no card, nothing that renews), then the payoff. The middle sentence is
       the hero's own fine print and the price card's. The new line gives the
-      three steps a concrete finish instead.
+      four steps a concrete finish instead.
 
       It says "model key", the phrase the other five marketing mentions use,
       and it names no surface. The protocols section a screen above ends
@@ -922,7 +922,7 @@
       Give your product a coding agent.
     </h2>
     <p class="text-[var(--color-ink-secondary)] mb-9 max-w-lg mx-auto text-lg leading-relaxed">
-      Sign up, paste a model key, and start one with a single API call.
+      Sign up, paste a model key, configure your agent, and start each run with one API call.
     </p>
     <a
       href={~p"/auth/register"}

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -631,8 +631,9 @@
       question with two answers, so they share a surface.
 
       Questions is last before the ask, because a limit is the final thing
-      between a convinced reader and the button, and `/faq#security` is the URL
-      they forward to whoever has to approve it.
+      between a convinced reader and the button. The single link opens the full
+      set of answers rather than making the reader choose between two routes to
+      the same page.
 
       Four sections sharing one surface rather than one section, because a
       deployment that prices nothing renders no pricing and the rest has to
@@ -844,10 +845,8 @@
 
       What stays is the signpost, and it is not decoration. A page that sells
       hard and mentions no limit anywhere is the shape the voice standard
-      argues against, and the pinned `/faq#security` link (a test asserts it on
-      this page) is the one URL a reader forwards to somebody who has to
-      approve this. Both survive here without the homepage carrying a list that
-      goes stale as the tickets close.
+      argues against. The full FAQ carries both the limits and the security
+      answers without making the homepage offer two links to the same page.
 
       The h2 is what the reader gets, in the second person, like the rest of
       the page. It read "What it cannot do is written down", which is about the
@@ -859,8 +858,8 @@
       style.md is built on conceding the failure case and on answers that name
       mechanisms, and the server is open source, so "you do not have to take
       our word for it" is a statement about this repository rather than a
-      posture. The deck carries the mechanism-not-intention line underneath,
-      which is the proof of the heading rather than a restatement of it.
+      posture. The deck says what the answers give the reader: the enforced
+      boundary and the point where it ends.
 
       Left-aligned, which is what it was when it sat under the protocol list.
       It keeps that here for a different reason: it is the one section of the
@@ -875,22 +874,14 @@
       </h2>
       <div class="mt-10 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <p class="text-sm text-[var(--color-ink-secondary)] max-w-lg">
-          Read every limit and review the security model yourself. Each answer names a mechanism you can check, not an intention you have to trust.
+          Read every limit and review the security model yourself. The answers tell you what the software enforces and where it stops.
         </p>
-        <div class="flex flex-col sm:flex-row gap-3 sm:shrink-0">
-          <a
-            href={~p"/faq"}
-            class="inline-flex items-center justify-center px-5 py-2.5 rounded-lg border border-[var(--color-ink-border)] bg-[var(--color-ink-1)] text-[var(--color-ink-text)] text-sm font-medium hover:bg-[var(--color-ink-2)] transition-colors"
-          >
-            Get the answers
-          </a>
-          <a
-            href={~p"/faq#security"}
-            class="inline-flex items-center justify-center px-5 py-2.5 rounded-lg border border-[var(--color-ink-border)] bg-[var(--color-ink-1)] text-[var(--color-ink-text)] text-sm font-medium hover:bg-[var(--color-ink-2)] transition-colors"
-          >
-            The security answers
-          </a>
-        </div>
+        <a
+          href={~p"/faq"}
+          class="inline-flex items-center justify-center px-5 py-2.5 rounded-lg border border-[var(--color-ink-border)] bg-[var(--color-ink-1)] text-[var(--color-ink-text)] text-sm font-medium hover:bg-[var(--color-ink-2)] transition-colors sm:shrink-0"
+        >
+          Get the answers
+        </a>
       </div>
     </div>
   </div>
@@ -898,11 +889,9 @@
 
 <%!-- Footer CTA. The last thing on the page, which is what a closer is.
 
-      The h2 is the page's own argument turned into an instruction. "You did
-      not set out to run a sandbox platform" opens the middle of the page; this
-      is the other end of it. The "What you get" grid used to close on "You
-      keep the product", which was a recap sitting under the six cards that had
-      just said it; here it is the ask, which is where it belongs.
+      The h2 names the job the reader came to do. The "What you get" grid used
+      to close on "You keep the product", which was a recap sitting under the
+      six cards that had just said it. Here the outcome becomes the ask.
 
       It used to read "A key, a call, and a machine you did not build", three
       nouns in a row that named the ingredients rather than the payoff. The
@@ -912,8 +901,8 @@
       The deck is one sentence and three steps. It was three sentences: the
       steps, then a list of things that do not happen (no machine to provision,
       no card, nothing that renews), then the payoff. The middle sentence is
-      the hero's own fine print and the price card's, and the payoff is now the
-      heading above it.
+      the hero's own fine print and the price card's. The new line gives the
+      three steps a concrete finish instead.
 
       It says "model key", the phrase the other five marketing mentions use,
       and it names no surface. The protocols section a screen above ends
@@ -930,10 +919,10 @@
 ]}>
   <div class="max-w-5xl mx-auto px-6 py-20 text-center">
     <h2 class="text-3xl sm:text-4xl font-bold tracking-tight text-[var(--color-ink-text)] mb-4">
-      Go build the part that is yours.
+      Give your product a coding agent.
     </h2>
     <p class="text-[var(--color-ink-secondary)] mb-9 max-w-lg mx-auto text-lg leading-relaxed">
-      Sign up, paste a model key, and wire it into your product.
+      Sign up, paste a model key, and start one with a single API call.
     </p>
     <a
       href={~p"/auth/register"}

--- a/apps/fountain/test/fountain_web/brand_chrome_test.exs
+++ b/apps/fountain/test/fountain_web/brand_chrome_test.exs
@@ -48,7 +48,7 @@ defmodule FountainWeb.BrandChromeTest do
     assert home =~ "© 2026 Managoat."
     assert home =~ ~s(data-role="hosted-brand")
     assert home =~ "Managoat is the hosted Fountain. The engine is open source"
-    assert home =~ "It runs Fountain, which is open source."
+    assert home =~ "Built on Fountain. Open source and yours to run."
 
     for path <- [~p"/terms", ~p"/privacy"] do
       html = conn |> get(path) |> html_response(200)
@@ -63,7 +63,7 @@ defmodule FountainWeb.BrandChromeTest do
     Application.delete_env(:fountain, :product_name)
     home = conn |> get(~p"/") |> html_response(200)
     assert home =~ "© 2026 Fountain."
-    refute home =~ "It runs Fountain, which is open source."
+    refute home =~ "Built on Fountain. Open source and yours to run."
   end
 
   test "without the brand the docs show no note", %{conn: conn} do

--- a/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
@@ -225,6 +225,9 @@ defmodule FountainWeb.MarketingControllerTest do
 
       {prerequisites_at, _} = :binary.match(body, "Before you start")
       assert ownership_at < prerequisites_at
+      assert body =~ "Postgres 16+"
+      assert body =~ "Fountain requires it."
+      refute body =~ "No database"
 
       assert body =~ "Master key"
       assert body =~ "Inference"

--- a/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
@@ -369,20 +369,15 @@ defmodule FountainWeb.MarketingControllerTest do
       end
     end
 
-    # The three pages that gave up their questions link back by anchor. A
-    # renamed section id would leave those links pointing at nothing, and
-    # nothing else in the suite would notice.
+    # The self-hosted page gave up its questions and links back by anchor. A
+    # renamed section id would leave that link pointing at nothing, and nothing
+    # else in the suite would notice.
     test "the anchors the other pages link at all exist", %{conn: conn} do
       body = conn |> get(~p"/faq") |> html_response(200)
       ids = Enum.map(FountainWeb.MarketingHTML.faq_sections(), & &1.id)
 
-      for anchor <- ~w(security self-hosting) do
-        assert anchor in ids, "/faq has no ##{anchor} section to link at"
-        assert body =~ ~s(id="#{anchor}")
-      end
-
-      home = conn |> get(~p"/") |> html_response(200)
-      assert home =~ "/faq#security"
+      assert "self-hosting" in ids, "/faq has no #self-hosting section to link at"
+      assert body =~ ~s(id="self-hosting")
 
       self_hosted = conn |> get(~p"/self-hosted") |> html_response(200)
       assert self_hosted =~ "/faq#self-hosting"

--- a/apps/fountain/test/fountain_web/controllers/marketing_instance_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_instance_test.exs
@@ -31,7 +31,7 @@ defmodule FountainWeb.MarketingInstanceTest do
       refute body =~ "You did not set out to run a sandbox platform."
       refute body =~ "A hundred tickets is a hundred calls, not an architecture."
       refute body =~ "14-day trial"
-      refute body =~ "machines you do not have to manage"
+      refute body =~ "Give your product a coding agent."
 
       # The Open Graph card follows the same rule: no pitch, only what it is.
       assert body =~
@@ -177,7 +177,7 @@ defmodule FountainWeb.MarketingInstanceTest do
 
       body = conn |> get(~p"/") |> html_response(200)
       assert body =~ "You did not set out to run a sandbox platform."
-      assert body =~ "machines you do not have to manage"
+      assert body =~ "Give your product a coding agent."
       refute body =~ "This instance runs agents on sandboxes"
     end
   end

--- a/docs/guides/operate/deploy.md
+++ b/docs/guides/operate/deploy.md
@@ -12,8 +12,8 @@ instance that stays up.
 ## Before you start
 
 You must have Docker Engine with Compose v2, and `openssl` for the two key
-lines below. The compose file runs Postgres 16 for you, so you do not install
-a database yourself.
+lines below. Fountain requires Postgres 16 or newer. The compose file runs one
+for you, or you can point Fountain at a Postgres you operate.
 
 Your machine must also reach `ghcr.io`, the registry that holds the published
 image. Does your network block it? Then comment the `image:` line in


### PR DESCRIPTION
## Summary

- sharpen the marketing footer around the division of work and open-source ownership
- replace the abstract homepage closer and security proof copy with concrete outcomes
- remove the redundant security-answers button and its obsolete deep-link assertion

## Verification

- mix format --check-formatted on the four changed files
- mix test apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs apps/fountain/test/fountain_web/brand_chrome_test.exs (71 tests, 0 failures)