### PR TITLE
Tighten homepage apps section

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
@@ -771,9 +771,10 @@ defmodule FountainWeb.MarketingHTML do
   #
   # The first group is the three this project builds itself, and they lead
   # every page that shows the roster. An app in it carries a `:flagship` key
-  # holding the two lines the featured cards add: what it is like, and who it
-  # is for. That key is what `flagship_apps/0` selects on, so the tier is a
-  # property of the entry rather than a second list to keep in step.
+  # holding the lines its featured cards add: a short homepage description,
+  # what it is like, and who it is for. That key is what `flagship_apps/0`
+  # selects on, so the tier is a property of the entry rather than a second
+  # list to keep in step.
 
   @doc "The applications built on the API, in the order and grouping the page shows."
   def built_apps do
@@ -795,6 +796,7 @@ defmodule FountainWeb.MarketingHTML do
               "Start a run, watch the agent work turn by turn, and drive it. Chat, timeline and raw views of the same conversation, plus the machine it shares with its siblings.",
             shows: "the event stream as blocks, and one sandbox behind many conversations",
             flagship: %{
+              homepage: "Run an agent and watch every step.",
               like:
                 "ChatGPT, except the model has a checkout and a shell, and you can watch it work.",
               who: "Open this one first. It is the whole platform with a face on it."
@@ -811,6 +813,7 @@ defmodule FountainWeb.MarketingHTML do
               "Your agents as teammates in a messaging app. Roster on the left, thread on the right, routines on a schedule, images and search. Enter to send.",
             shows: "the team API, SSE streaming, schedules, usage",
             flagship: %{
+              homepage: "Message your agents like teammates.",
               like:
                 "A group chat whose contacts are bots you made, one click each, faces and all.",
               who: "For anyone who would rather text a teammate than fill in a form."
@@ -827,6 +830,7 @@ defmodule FountainWeb.MarketingHTML do
               "A dev workstation the team shares. A project is an environment and a vault, work items live in it, and putting a teammate on one is a first prompt rather than four steps of setup.",
             shows: "projects over environments and vaults, agents as staff",
             flagship: %{
+              homepage: "Assign work across shared projects.",
               like:
                 "Multiplayer engineering: one board of work items, and staff you put on them by typing.",
               who:
@@ -984,9 +988,6 @@ defmodule FountainWeb.MarketingHTML do
 
   @doc "The rest of the roster, which /built-with lists under the featured three."
   def other_app_groups, do: Enum.reject(built_apps(), &(&1.id == "flagship"))
-
-  @doc "The rest of the roster, flattened, for the homepage's chip row."
-  def other_apps_flat, do: Enum.flat_map(other_app_groups(), & &1.apps)
 
   ## /self-hosted
 

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -535,24 +535,27 @@
   </p>
 </section>
 
-<%!-- The apps, in one section. The flagship three as cards, the rest of the
-      roster as chips under them. These used to be two adjacent sections with
-      two intros and two buttons saying the same thing. Cards come from
-      built_apps/0, so the homepage cannot name an app /built-with has renamed
-      or retired. --%>
+<%!-- The apps, as the other side of the fork the protocols open above: use a
+      working frontend or build one on the same API. The homepage names three
+      shapes and leaves the catalog to /built-with. Showing the rest as chips
+      repeated that apps exist without helping a reader choose one, and made
+      this proof section compete with the product argument above it.
+
+      Cards come from built_apps/0, so the homepage cannot name an app
+      /built-with has renamed or retired. --%>
 <section class="max-w-5xl mx-auto px-6 pb-16">
   <div class="border-t border-[var(--color-border)] pt-16">
     <.eyebrow label="Apps" />
     <h2 class="mt-4 text-2xl sm:text-3xl font-semibold tracking-tight text-[var(--color-text-primary)] text-center">
-      Start from an app that already works.
+      Use an app. Or build your own on the same API.
     </h2>
     <p class="mt-3 text-center text-[var(--color-text-secondary)] max-w-2xl mx-auto text-lg">
-      Each app is a static frontend over the same public API. Read its source, borrow what you need, or point it at your own instance.
+      {built_app_count()} open-source apps already run on the public API. Use one, fork its source, or point it at your own instance.
     </p>
     <div class="mt-10 grid md:grid-cols-3 gap-6">
       <article
         :for={app <- flagship_apps()}
-        class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-1)] p-6 flex flex-col"
+        class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-1)] p-5 flex flex-col"
         data-role="flagship"
       >
         <%!-- The glyph is an emoji out of built_apps/0, shared with
@@ -567,11 +570,8 @@
           {app.glyph}
         </div>
         <h3 class="mt-4 text-lg font-semibold text-[var(--color-text-primary)]">{app.name}</h3>
-        <p class="mt-1 text-sm font-medium text-[var(--color-text-primary)]">
-          {app.flagship.like}
-        </p>
-        <p class="mt-3 text-sm text-[var(--color-text-secondary)] leading-relaxed flex-1">
-          {app.blurb}
+        <p class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed flex-1">
+          {app.flagship.homepage}
         </p>
         <div class="mt-5 flex flex-wrap items-center gap-4">
           <a
@@ -579,7 +579,7 @@
             rel="noopener"
             class="inline-flex items-center px-4 py-2 rounded-lg bg-[var(--color-brand)] text-white font-medium hover:bg-[var(--color-brand-hover)] transition-colors text-sm"
           >
-            Open it
+            Open app
           </a>
           <a
             href={app.source}
@@ -591,28 +591,12 @@
         </div>
       </article>
     </div>
-
-    <p class="mt-12 text-center text-[var(--color-text-secondary)]">
-      <span class="font-medium text-[var(--color-text-primary)]">
-        {length(built_apps_flat())} open-source apps are running on it now.
-      </span>
-      In several, nothing on screen says the word agent.
-    </p>
-    <ul class="mt-6 flex flex-wrap justify-center gap-2">
-      <li
-        :for={app <- other_apps_flat()}
-        class="inline-flex items-center gap-1.5 rounded-full border border-[var(--color-border)] bg-[var(--color-bg-1)] px-3 py-1 text-sm text-[var(--color-text-secondary)]"
-      >
-        <span aria-hidden="true" data-role="glyph">{app.glyph}</span>
-        {app.name}
-      </li>
-    </ul>
     <p class="mt-8 text-center">
       <a
         href={~p"/built-with"}
         class="inline-flex items-center justify-center px-5 py-2.5 rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-bg-1)] text-[var(--color-text-primary)] text-sm font-medium hover:bg-[var(--color-bg-2)] transition-colors"
       >
-        See what people built
+        Browse all {built_app_count()} apps
       </a>
     </p>
   </div>

--- a/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
@@ -196,7 +196,7 @@ defmodule FountainWeb.MarketingControllerTest do
     test "the marketing nav and the homepage link to it", %{conn: conn} do
       body = conn |> get(~p"/") |> html_response(200)
       assert body =~ ~p"/built-with"
-      assert body =~ "open-source apps are running on it now."
+      assert body =~ "open-source apps already run on the public API."
     end
   end
 
@@ -728,6 +728,7 @@ defmodule FountainWeb.MarketingControllerTest do
                ~w(fountain-conversations fountain-team fountain-workbench)
 
       for app <- flagship do
+        assert app.flagship.homepage != ""
         assert app.flagship.like != ""
         assert app.flagship.who != ""
         assert app in FountainWeb.MarketingHTML.built_apps_flat(), "#{app.name} left the roster"
@@ -749,13 +750,15 @@ defmodule FountainWeb.MarketingControllerTest do
     test "the homepage opens each one and links its source", %{conn: conn} do
       body = conn |> get(~p"/") |> html_response(200)
 
-      assert body =~ "Start from an app that already works."
+      assert body =~ "Use an app. Or build your own on the same API."
+      assert body =~ "Browse all #{FountainWeb.MarketingHTML.built_app_count()} apps"
 
       for app <- FountainWeb.MarketingHTML.flagship_apps() do
         assert body =~ app.name, "the homepage does not name #{app.name}"
         assert body =~ app.url, "the homepage does not open #{app.name}"
         assert body =~ app.source, "the homepage does not link #{app.name}'s source"
-        assert body =~ app.flagship.like, "the homepage drops #{app.name}'s framing"
+        assert body =~ app.flagship.homepage, "the homepage drops #{app.name}'s short description"
+        refute body =~ app.blurb, "the homepage expands #{app.name} into a catalog card"
       end
     end
 


### PR DESCRIPTION
## Summary

- frame the section as a clear choice between using an existing app and building on the public API
- replace catalog-length flagship copy with one-line descriptions
- remove the duplicate app roster and direct readers to the full gallery
- avoid implying the gallery is third-party customer proof

## Verification

- mix format --check-formatted on changed files
- mix test apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs (61 tests, 0 failures)