### PR TITLE
Clarify the homepage case study proof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,12 @@ upgrade, is in
   rather than to one runner. See ADR 0036.
 
 ### Changed
+- **The homepage case study distinguishes investigation from resolution.** The
+  pager still reaches an on-call engineer while an agent investigates in
+  parallel, and the copy now says that a pull request follows only when the
+  agent finds a repository fix. Its headline, stat labels and incident link
+  make that human gate and the scope of the measured proof explicit.
+
 - **The homepage makes session state and the two scaling modes explicit.** A
   caller binds a conversation to an id it already owns and sends the same
   Agent, Environment and Vault to resume it, without keeping a lookup table of

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
@@ -1484,21 +1484,25 @@ defmodule FountainWeb.MarketingHTML do
       %{
         value: "78",
         label: "incidents handled by an agent",
+        home_label: "incidents investigated",
         note: "Fifteen days, one cluster, one runbook."
       },
       %{
         value: "4m 27s",
         label: "from alert to open pull request",
+        home_label: "alert to open pull request in the incident below",
         note: "The incident below. The second took 4m 08s."
       },
       %{
         value: "7.5 min",
         label: "median incident, start to verdict",
+        home_label: "median investigation time",
         note: "The longest ran 50 minutes."
       },
       %{
         value: "0",
         label: "cluster credentials the agent holds",
+        home_label: "cluster credentials held by the agent",
         note: "No kubectl, no kubeconfig, no write path of its own."
       }
     ]

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -92,10 +92,10 @@
   >
     <.eyebrow label="Case study" align={:left} />
     <h2 class="mt-4 text-2xl sm:text-3xl font-semibold tracking-tight text-[var(--color-text-primary)]">
-      A cluster that answers its own alerts.
+      The pager still rings. An agent starts working too.
     </h2>
     <p class="mt-4 text-[var(--color-text-secondary)] max-w-2xl leading-relaxed">
-      A Kubernetes cluster used to page a person when a workload broke. Now it also starts an agent, which finds the commit that broke it and opens one small pull request. The agent never holds a credential for the cluster it is fixing, and a person still merges the request.
+      When a workload breaks, this Kubernetes cluster pages an on-call engineer and starts an agent at the same time. The agent investigates the alert and, when it finds a repository fix, opens one focused pull request. It never holds cluster credentials. A person decides whether to merge.
     </p>
     <dl class="mt-10 grid grid-cols-2 gap-x-8 gap-y-8 sm:grid-cols-4 sm:gap-x-6">
       <div :for={stat <- case_stats()}>
@@ -105,18 +105,20 @@
         >
           {stat.value}
         </dt>
-        <dd class="mt-1.5 text-xs leading-snug text-[var(--color-accent-ink)]">{stat.label}</dd>
+        <dd class="mt-1.5 text-xs leading-snug text-[var(--color-accent-ink)]">
+          {stat.home_label}
+        </dd>
       </div>
     </dl>
     <p class="mt-8 max-w-2xl text-xs text-[var(--color-text-secondary)]">
-      Counted over {case_window()} on one Kubernetes cluster carrying live production workloads. Numbers reported by the cluster administrator (us).
+      Measured from {case_window()} on one Kubernetes cluster running live production workloads. Numbers reported by the cluster administrator (us).
     </p>
     <div class="mt-8">
       <a
         href={~p"/case-studies/self-healing-infrastructure"}
         class="inline-flex items-center justify-center px-5 py-2.5 rounded-lg border border-[var(--color-accent-line)] bg-[var(--color-bg-1)] text-[var(--color-text-primary)] text-sm font-medium hover:bg-[var(--color-bg-2)] transition-colors"
       >
-        Follow the whole incident
+        Follow the incident, minute by minute
       </a>
     </div>
   </div>

--- a/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
@@ -631,7 +631,15 @@ defmodule FountainWeb.MarketingControllerTest do
     test "the homepage and the marketing footer link to it", %{conn: conn} do
       body = conn |> get(~p"/") |> html_response(200)
       assert body =~ ~p"/case-studies/self-healing-infrastructure"
-      assert body =~ "A cluster that answers its own alerts."
+      assert body =~ "The pager still rings. An agent starts working too."
+      assert body =~ "pages an on-call engineer and starts an agent at the same time"
+      assert body =~ "when it finds a repository fix"
+      assert body =~ "A person decides whether to merge."
+      refute body =~ "used to page a person"
+
+      for stat <- FountainWeb.MarketingHTML.case_stats() do
+        assert body =~ stat.home_label, "missing homepage label for #{stat.value}"
+      end
 
       {proof_at, _} = :binary.match(body, ~s(data-role="case-study-callout"))
       {setup_at, _} = :binary.match(body, "You write this once.")


### PR DESCRIPTION
## Summary

- say explicitly that the on-call page and agent investigation start in parallel
- distinguish incidents investigated from pull requests opened, with homepage-specific stat labels
- retain the self-reported production provenance and make the incident CTA more specific

## Testing

- `mix test apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs` (64 tests, 0 failures)
- `mix precommit` (4,166 tests, 0 failures)