### PR TITLE
Improve case study copy and proof flow

### DIFF
--- a/.agents/product-marketing.md
+++ b/.agents/product-marketing.md
@@ -1,6 +1,6 @@
 # Product Marketing Context
 
-**Document version:** v4
+**Document version:** v5
 **Last updated:** 2026-08-29
 
 This file is the positioning, the ICP and the vocabulary that marketing work in
@@ -273,8 +273,8 @@ fail the gate in a manual, and that is by design.
 **Metrics:** The only sourced numbers are the case study's, counted on one
 production cluster over a stated window (11 to 25 August 2026) and held as
 literals in `marketing_html.ex` so they cannot quietly widen their own window.
-78 incidents handled by an agent; 4m 27s from alert to open pull request on the
-worked incident; 7.5 minute median incident to verdict; 0 cluster credentials
+78 alerts investigated by an agent; 4m 27s from alert to open pull request on
+the worked incident; 7.5 minute median alert to verdict; 0 cluster credentials
 the agent holds. Twelve fix pull requests opened, eight merged, four of those a
 rehearsal fault raised on purpose.
 
@@ -307,7 +307,7 @@ pull-request text, not a person's.
 | The machine is not your problem | Built, warmed, metered, reclaimed; parks and wakes with work intact |
 | The credential is separable from the machine | Vault wins on collision; egress broker placeholders |
 | A run is addressable | Id, status, transcript, event stream; the case study's webhook |
-| Guardrails are mechanisms, not promises | "Each refusal is somebody else's 405" |
+| Guardrails are mechanisms, not promises | Every limit in the case study is enforced outside the model |
 | You pay for machine time, never tokens | Live price card; bring your own model key |
 
 ## Goals
@@ -325,6 +325,7 @@ reader into someone who has seen the primitives compose.
 
 ## Changelog
 *Newest first. One line per revision: what changed and why.*
+- v5 (2026-08-29) — Case-study clarity pass: report alerts rather than incidents, show the full pull-request funnel, and describe the outcome as alert to pull request rather than self-healing.
 - v4 (2026-08-29) — Self-hosted clarity pass: lead with ownership, put the ownership decision before installation detail, and frame open-source apps as examples rather than customer proof.
 - v3 (2026-08-29) — Homepage clarity pass: lead with coding agents and the work-only meter, put production proof before implementation detail, and remove customer-shaped proof language.
 - v1 (2026-08-27) — Initial context, drafted from the repo while working the case study headline. Competitive landscape, customer language, customers, testimonials and current WAU left as explicit GAPs rather than invented.

--- a/apps/fountain/lib/fountain_web/controllers/marketing_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_controller.ex
@@ -185,12 +185,10 @@ defmodule FountainWeb.MarketingController do
     if Fountain.Marketing.site?() do
       render(conn, :case_study_self_healing,
         layout: {FountainWeb.Layouts, :marketing},
-        page_title: "Self-healing infrastructure · #{Fountain.Brand.name()}",
+        page_title: "Kubernetes alert to pull request in 4m 27s · #{Fountain.Brand.name()}",
         meta_description:
-          "A Kubernetes cluster that answers its own alerts. Prometheus fires, " <>
-            "#{Fountain.Brand.name()} starts an agent, the agent finds the commit that " <>
-            "broke the cluster and opens one pull request. The on-call engineer decides " <>
-            "whether to merge it."
+          "A real Kubernetes incident from alert to pull request in 4m 27s. The agent " <>
+            "held no cluster credentials, and a human kept the only approval."
       )
     else
       redirect(conn, to: ~p"/docs/tour")

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
@@ -1483,27 +1483,27 @@ defmodule FountainWeb.MarketingHTML do
     [
       %{
         value: "78",
-        label: "incidents handled by an agent",
-        home_label: "incidents investigated",
+        label: "alerts investigated by an agent",
+        home_label: "alerts investigated",
         note: "Fifteen days, one cluster, one runbook."
       },
       %{
-        value: "4m 27s",
-        label: "from alert to open pull request",
-        home_label: "alert to open pull request in the incident below",
-        note: "The incident below. The second took 4m 08s."
+        value: "12",
+        label: "fix pull requests opened",
+        home_label: "fix pull requests opened",
+        note: "Four came from the same planned rehearsal fault."
+      },
+      %{
+        value: "8",
+        label: "fix pull requests merged",
+        home_label: "fix pull requests merged",
+        note: "The agent could neither approve nor merge."
       },
       %{
         value: "7.5 min",
-        label: "median incident, start to verdict",
-        home_label: "median investigation time",
-        note: "The longest ran 50 minutes."
-      },
-      %{
-        value: "0",
-        label: "cluster credentials the agent holds",
-        home_label: "cluster credentials held by the agent",
-        note: "No kubectl, no kubeconfig, no write path of its own."
+        label: "median alert-to-verdict time",
+        home_label: "median alert-to-verdict time",
+        note: "The longest investigation ran 50 minutes."
       }
     ]
   end
@@ -1530,8 +1530,8 @@ defmodule FountainWeb.MarketingHTML do
         title: "A webhook starts an agent",
         mono: "POST /api/conversations",
         body:
-          "Two hundred lines of Node, posting an agent id, a vault id and the " <>
-            "alert text. It needs no cluster access."
+          "The production handler is two hundred lines of Node. Its handoff to " <>
+            "Fountain posts an agent id, an identity id and the alert text."
       },
       %{
         step: "4",
@@ -1546,8 +1546,8 @@ defmodule FountainWeb.MarketingHTML do
         title: "It finds the wrong fact in git",
         mono: "gh api · git log -S",
         body:
-          "A bad cluster is a bad commit. The agent reads the history and " <>
-            "names the one at fault before editing."
+          "When the repository can fix an alert, the agent reads the history and " <>
+            "names the commit at fault before editing."
       },
       %{
         step: "6",
@@ -1694,8 +1694,8 @@ defmodule FountainWeb.MarketingHTML do
       %{
         title: "Agent",
         body:
-          "Runtime, model, runbook and tools, written once as a file in a " <>
-            "public repository. The runbook is the product: diagnose, fix by " <>
+          "Runtime, model, runbook and tools, defined once in a file in a " <>
+            "public repository. That reviewed file defines the job: diagnose, fix by " <>
             "pull request, wait for the human, verify, report."
       },
       %{
@@ -1706,18 +1706,17 @@ defmodule FountainWeb.MarketingHTML do
             "per incident, never patched by hand."
       },
       %{
-        title: "Vault",
+        title: "Fountain Vault",
         body:
-          "The bot identity, kept apart from the environment. Swap it and the " <>
-            "agent acts as a different GitHub account. The token is an environment " <>
-            "variable, never in the prompt, the context or the transcript."
+          "Not a central secret store, a Fountain Vault is a small override layer. " <>
+            "Here it supplied the bot identity separately from the environment. " <>
+            "The token never entered the prompt, context or transcript."
       },
       %{
         title: "Conversation",
         body:
           "One incident, one sandbox, one transcript, addressed by its alert. " <>
-            "It survives an hour-long diagnosis, and a human opens it at 08:50 " <>
-            "to see 07:02."
+            "The run and transcript stayed available while the human was away."
       }
     ]
   end

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/case_study_self_healing.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/case_study_self_healing.html.heex
@@ -1,15 +1,15 @@
 <%!-- Hero --%>
 <section class="max-w-5xl mx-auto px-6 py-20 text-center">
-  <.eyebrow label="Case study · Self-healing infrastructure" class="mb-5" />
+  <.eyebrow label="Case study · Alert to pull request" class="mb-5" />
   <%!-- The two clock times are the incident below, 06:58:15 and 07:02:42, which
-        is the same 4m 27s the stats quote. The headline concedes the pager on
+        is the same 4m 27s the headline quotes. The headline concedes the pager on
         purpose: the loop forks the page rather than swallowing it, so a
         headline that retired the pager would contradict step 2 and 08:50. --%>
   <h1 class="text-4xl sm:text-5xl font-bold tracking-tight text-[var(--color-text-primary)] mb-5 leading-tight">
-    The pager still goes off at 06:58. The pull request is open by 07:02.
+    The pager went off at 06:58. The pull request was open 4 minutes 27 seconds later.
   </h1>
   <p class="text-lg sm:text-xl text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-10">
-    A Kubernetes cluster pages an on-call engineer when a workload breaks. This one also starts an agent. It reads the cluster, finds the commit at fault, and opens one small pull request. That engineer decides whether to merge it.
+    Alertmanager paged the on-call engineer and started an agent at the same time. The agent read the cluster through a GET-only service, traced the failure through git, and opened one focused pull request. A human still had to approve it.
   </p>
   <div class="flex flex-col sm:flex-row gap-3 justify-center">
     <a
@@ -40,55 +40,112 @@
       </div>
     </div>
     <p class="mt-8 text-center text-xs text-[var(--color-text-muted)]">
-      Counted in one production cluster over {case_window()}.
+      Counted in one Kubernetes cluster carrying live production workloads over {case_window()}. Numbers reported by the cluster administrator (us).
     </p>
   </div>
 </section>
 
-<%!-- The failure class --%>
+<%!-- One real incident. It immediately pays off the minute-by-minute promise
+      that brings readers here from the homepage. --%>
 <section class="max-w-5xl mx-auto px-6 py-16">
   <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-3 text-center">
-    Some breakage reconciliation cannot fix.
+    One morning, minute by minute.
   </h2>
-  <p class="text-center text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-12">
-    GitOps makes the cluster match the repository, and keeps doing it when the repository is wrong.
+  <p class="text-center text-[var(--color-text-secondary)] max-w-xl mx-auto mb-12">
+    25 August 2026, UTC. The first pull request was ready before the on-call engineer opened the page.
   </p>
-  <div class="grid md:grid-cols-2 gap-6 max-w-3xl mx-auto">
-    <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6">
-      <p class="text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)] mb-2">
-        Drift
-      </p>
-      <p class="text-lg font-semibold text-[var(--color-text-primary)]">Green</p>
-      <p class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">
-        The cluster is exactly what the repository says. Reconciliation has nothing left to do, and reports success.
-      </p>
+  <ol class="max-w-3xl mx-auto">
+    <li
+      :for={event <- case_timeline()}
+      class="grid sm:grid-cols-[6.5rem_1fr] gap-x-6 gap-y-1 border-l border-[var(--color-border)] pl-6 pb-8 relative"
+      data-role="timeline-event"
+    >
+      <span
+        class="absolute -left-[5px] top-1.5 size-2.5 rounded-full bg-[var(--color-brand)]"
+        aria-hidden="true"
+      >
+      </span>
+      <span
+        class="text-sm font-medium text-[var(--color-text-muted)] tabular-nums"
+        phx-no-format
+      >{event.time}</span>
+      <div>
+        <h3 class="font-semibold text-[var(--color-text-primary)]">{event.title}</h3>
+        <p class="mt-1.5 text-sm text-[var(--color-text-secondary)] leading-relaxed">
+          {event.body}
+        </p>
+      </div>
+    </li>
+  </ol>
+
+  <%!-- The agent's own words. Quoted verbatim from the pull request body,
+        so the reader judges the diagnosis rather than our summary of it. --%>
+  <figure class="max-w-3xl mx-auto mt-4" data-role="case-quote">
+    <blockquote class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6 text-sm text-[var(--color-text-secondary)] leading-relaxed">
+      <span :for={part <- case_quote()}>
+        <%= case part do %>
+          <% {:code, text} -> %>
+            <code
+              class="text-xs text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1 py-0.5"
+              phx-no-format
+            >{text}</code>
+          <% {:text, text} -> %>
+            {text}
+        <% end %>
+      </span>
+    </blockquote>
+    <figcaption class="mt-3 text-xs text-[var(--color-text-muted)]">
+      The agent's root-cause paragraph, quoted from the pull request it opened at 07:02. The gap had sat there for months unalerted, because no commit had moved a lockfile until that week.
+    </figcaption>
+  </figure>
+</section>
+
+<%!-- The failure class --%>
+<section class="bg-[var(--color-bg-1)] border-y border-[var(--color-border)]">
+  <div class="max-w-5xl mx-auto px-6 py-16">
+    <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-3 text-center">
+      GitOps can reconcile the wrong state perfectly.
+    </h2>
+    <p class="text-center text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-12">
+      It makes the cluster match the repository. It keeps doing so when the repository is wrong.
+    </p>
+    <div class="grid md:grid-cols-2 gap-6 max-w-3xl mx-auto">
+      <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6">
+        <p class="text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)] mb-2">
+          Drift
+        </p>
+        <p class="text-lg font-semibold text-[var(--color-text-primary)]">Green</p>
+        <p class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">
+          The cluster is exactly what the repository says. Reconciliation has nothing left to do, and reports success.
+        </p>
+      </div>
+      <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6">
+        <p class="text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)] mb-2">
+          Health
+        </p>
+        <p class="text-lg font-semibold text-[var(--color-text-primary)]">Red</p>
+        <p class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">
+          The workload crashes anyway, because what the repository says is false: a dropped variable, a lost secret reference, a bad image pin. No apply fixes that. Somebody has to read the evidence and change the source.
+        </p>
+      </div>
     </div>
-    <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6">
-      <p class="text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)] mb-2">
-        Health
-      </p>
-      <p class="text-lg font-semibold text-[var(--color-text-primary)]">Red</p>
-      <p class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">
-        The workload crashes anyway, because what the repository says is false: a dropped variable, a lost secret reference, a bad image pin. No apply fixes that. Somebody has to read the evidence and change the source.
-      </p>
-    </div>
+    <p class="text-center text-[var(--color-text-secondary)] max-w-2xl mx-auto mt-12">
+      That gap is where the pager lives. Reading the evidence and writing a small diff is exactly what a coding agent is good at. The agent still needs a machine, a checkout, a push credential, and a human with the only approval.
+    </p>
   </div>
-  <p class="text-center text-[var(--color-text-secondary)] max-w-2xl mx-auto mt-12">
-    That gap is where the pager lives, and reading evidence to write a small diff is exactly what a coding agent is good at. What was missing was never the diagnosis. It was a machine, a checkout, a push credential, and a human still allowed to say no.
-  </p>
 </section>
 
 <%!-- The loop --%>
 <section
   id="loop"
-  class="bg-[var(--color-bg-1)] border-y border-[var(--color-border)] scroll-mt-6"
+  class="scroll-mt-6"
 >
   <div class="max-w-5xl mx-auto px-6 py-16">
     <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-3 text-center">
       Nine steps, one of them a person.
     </h2>
     <p class="text-center text-[var(--color-text-secondary)] max-w-xl mx-auto mb-12">
-      The alerting stack was already there. Adding the agent took one webhook and one API call.
+      The existing alert path gained one webhook. That webhook starts the agent with one API call.
     </p>
     <ol class="max-w-3xl mx-auto space-y-4">
       <li
@@ -123,98 +180,44 @@
 </section>
 
 <%!-- The guardrails --%>
-<section class="max-w-5xl mx-auto px-6 py-16">
-  <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-3 text-center">
-    The gate is a mechanism, not a promise.
-  </h2>
-  <p class="text-center text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-12">
-    An agent that opens infrastructure pull requests is only as safe as the least it can do. Nothing rests on a good choice, a prompt holding, or a model behaving. Each refusal below is somebody else's 405.
-  </p>
-  <div class="max-w-3xl mx-auto space-y-4">
-    <div
-      :for={rule <- case_guardrails()}
-      class="grid sm:grid-cols-2 gap-4 sm:gap-6 rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-5"
-      data-role="guardrail"
-    >
-      <div>
-        <p class="text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)] mb-1.5">
-          It can
-        </p>
-        <p class="text-sm text-[var(--color-text-primary)] leading-relaxed">{rule.can}</p>
-      </div>
-      <div class="sm:border-l sm:border-[var(--color-border)] sm:pl-6">
-        <p class="text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)] mb-1.5">
-          It cannot
-        </p>
-        <p class="text-sm text-[var(--color-text-secondary)] leading-relaxed">{rule.cannot}</p>
-      </div>
-    </div>
-  </div>
-</section>
-
-<%!-- One real incident --%>
 <section class="bg-[var(--color-bg-1)] border-y border-[var(--color-border)]">
   <div class="max-w-5xl mx-auto px-6 py-16">
     <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-3 text-center">
-      One morning, end to end.
+      The gate is a mechanism, not a promise.
     </h2>
-    <p class="text-center text-[var(--color-text-secondary)] max-w-xl mx-auto mb-12">
-      25 August 2026, UTC. Nobody was awake for the first half.
+    <p class="text-center text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-12">
+      The agent held zero cluster credentials and could not approve or merge. Nothing rested on a good choice, a prompt holding, or a model behaving. Every limit below was enforced outside the model.
     </p>
-    <ol class="max-w-3xl mx-auto">
-      <li
-        :for={event <- case_timeline()}
-        class="grid sm:grid-cols-[6.5rem_1fr] gap-x-6 gap-y-1 border-l border-[var(--color-border)] pl-6 pb-8 relative"
-        data-role="timeline-event"
+    <div class="max-w-3xl mx-auto space-y-4">
+      <div
+        :for={rule <- case_guardrails()}
+        class="grid sm:grid-cols-2 gap-4 sm:gap-6 rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-5"
+        data-role="guardrail"
       >
-        <span
-          class="absolute -left-[5px] top-1.5 size-2.5 rounded-full bg-[var(--color-brand)]"
-          aria-hidden="true"
-        >
-        </span>
-        <span
-          class="text-sm font-medium text-[var(--color-text-muted)] tabular-nums"
-          phx-no-format
-        >{event.time}</span>
         <div>
-          <h3 class="font-semibold text-[var(--color-text-primary)]">{event.title}</h3>
-          <p class="mt-1.5 text-sm text-[var(--color-text-secondary)] leading-relaxed">
-            {event.body}
+          <p class="text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)] mb-1.5">
+            It can
           </p>
+          <p class="text-sm text-[var(--color-text-primary)] leading-relaxed">{rule.can}</p>
         </div>
-      </li>
-    </ol>
-
-    <%!-- The agent's own words. Quoted verbatim from the pull request body,
-          so the reader judges the diagnosis rather than our summary of it. --%>
-    <figure class="max-w-3xl mx-auto mt-4" data-role="case-quote">
-      <blockquote class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6 text-sm text-[var(--color-text-secondary)] leading-relaxed">
-        <span :for={part <- case_quote()}>
-          <%= case part do %>
-            <% {:code, text} -> %>
-              <code
-                class="text-xs text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1 py-0.5"
-                phx-no-format
-              >{text}</code>
-            <% {:text, text} -> %>
-              {text}
-          <% end %>
-        </span>
-      </blockquote>
-      <figcaption class="mt-3 text-xs text-[var(--color-text-muted)]">
-        The agent's root-cause paragraph, quoted from the pull request it opened at 07:02. The gap had sat there for months unalerted, because no commit had moved a lockfile until that week.
-      </figcaption>
-    </figure>
+        <div class="sm:border-l sm:border-[var(--color-border)] sm:pl-6">
+          <p class="text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)] mb-1.5">
+            It cannot
+          </p>
+          <p class="text-sm text-[var(--color-text-secondary)] leading-relaxed">{rule.cannot}</p>
+        </div>
+      </div>
+    </div>
   </div>
 </section>
 
 <%!-- What Fountain supplied --%>
 <section class="max-w-5xl mx-auto px-6 py-16">
   <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-3 text-center">
-    What {Fountain.Brand.name()} was for.
+    What {Fountain.Brand.name()} supplied.
   </h2>
   <p class="text-center text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-12">
-    The alerting, the repository and the reconciler were already there. What was missing was somewhere for an agent to live between alerts.
+    The alerting, repository and reconciler already existed. {Fountain.Brand.name()} supplied a ready machine for each run, reusable agent and credential configuration, and an addressable run the webhook could start and the engineer could reopen.
   </p>
   <div class="grid sm:grid-cols-2 gap-6 max-w-3xl mx-auto">
     <div
@@ -227,7 +230,7 @@
     </div>
   </div>
   <p class="text-center text-[var(--color-text-secondary)] max-w-2xl mx-auto mt-12">
-    Nobody provisions a machine for an incident, or pays for one between them. A sandbox lasts as long as the incident. <a
+    {Fountain.Brand.name()} builds the sandbox for the run and parks it between prompts without discarding the checkout. Parked machines cost nothing. <a
       href={~p"/docs/primitives"}
       class="underline underline-offset-2 hover:text-[var(--color-text-primary)]"
     >Read about the four primitives</a>.
@@ -244,7 +247,7 @@
       Point your own alerts at an agent.
     </h2>
     <p class="text-center text-[var(--color-text-secondary)] max-w-xl mx-auto mb-12">
-      Whatever pages you today can post a webhook. That is the whole handoff.
+      Send the same alert to a webhook. That is the whole handoff.
     </p>
     <div class="grid md:grid-cols-2 gap-8 items-start max-w-4xl mx-auto">
       <pre
@@ -254,19 +257,19 @@
       <div class="space-y-5 text-sm text-[var(--color-text-secondary)]">
         <p>
           <span class="font-medium text-[var(--color-text-primary)]">
-            Write the agent down first.
+            Define the agent in a file.
           </span>
           Runbook, tools and model belong in a file you review, not a webhook handler. Apply it once and the dispatcher needs only its id.
         </p>
         <p>
           <span class="font-medium text-[var(--color-text-primary)]">
-            Put the identity in a Vault.
+            Put the identity in a Fountain Vault.
           </span>
           The token that pushes should be its own account with the least rights that work, so changing identity is a field, not a redeploy.
         </p>
         <p>
           <span class="font-medium text-[var(--color-text-primary)]">
-            Make the last step refuse you.
+            Put the last gate outside the agent.
           </span>
           Let the agent stop where a human already signs off. A gate it is unable to pass beats one it is asked not to.
         </p>
@@ -275,7 +278,7 @@
             href={~p"/docs/tour"}
             class="font-medium text-[var(--color-text-primary)] underline underline-offset-2 hover:text-[var(--color-brand)]"
           >
-            Read the tour, an agent that opens a pull request →
+            Build an agent that opens a pull request →
           </a>
         </p>
       </div>
@@ -286,10 +289,10 @@
 <%!-- Footer CTA --%>
 <section class="max-w-5xl mx-auto px-6 py-20 text-center">
   <h2 class="text-2xl sm:text-3xl font-bold text-[var(--color-text-primary)] mb-4">
-    Your on-call has a queue of small, obvious fixes.
+    Some alerts end in a small repository change.
   </h2>
   <p class="text-[var(--color-text-secondary)] mb-8 max-w-lg mx-auto">
-    Each starts with reading the evidence and ends with a diff somebody approves. Start an agent for the middle.
+    The work starts with reading the evidence and ends with a diff somebody approves. Start an agent for the middle.
   </p>
   <div class="flex flex-col sm:flex-row gap-3 justify-center">
     <a
@@ -306,7 +309,7 @@
     </a>
   </div>
   <p class="mt-10 text-xs text-[var(--color-text-muted)] max-w-2xl mx-auto leading-relaxed">
-    This is a Kubernetes cluster carrying live production workloads. Numbers reported by the cluster administrator (us). Twelve fix pull requests opened in the window and eight merged, four of them the same rehearsal fault raised on purpose. Most incidents end with no pull request, because the agent decides the repository cannot fix them. The agent's definition is public at <a
+    Four of the twelve fix pull requests came from the same planned rehearsal fault. Most alerts end with no pull request, because the agent decides the repository cannot fix them. The agent's definition is public at <a
       href="https://github.com/jhgaylor/agent-specs/blob/main/src/agents/specialists/engineering/estate-medic.ts"
       class="underline underline-offset-2 hover:text-[var(--color-text-secondary)]"
     >jhgaylor/agent-specs</a>.

--- a/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
@@ -554,8 +554,8 @@ defmodule FountainWeb.MarketingControllerTest do
     test "renders the loop, the guardrails and the incident", %{conn: conn} do
       body = conn |> get(~p"/case-studies/self-healing-infrastructure") |> html_response(200)
 
-      assert body =~ "The pager still goes off at 06:58."
-      assert body =~ "That engineer decides whether to merge it."
+      assert body =~ "The pager went off at 06:58."
+      assert body =~ "A human still had to approve it."
       refute body =~ "Kubernetes estate"
       refute body =~ "production estate"
 
@@ -565,8 +565,14 @@ defmodule FountainWeb.MarketingControllerTest do
       [alert | _] = timeline = FountainWeb.MarketingHTML.case_timeline()
       first_pr = Enum.find(timeline, &(&1.title == "The first pull request opens"))
 
-      assert body =~ "goes off at #{String.slice(alert.time, 0, 5)}"
-      assert body =~ "open by #{String.slice(first_pr.time, 0, 5)}"
+      {:ok, alert_at} = Time.from_iso8601(alert.time)
+      {:ok, first_pr_at} = Time.from_iso8601(first_pr.time)
+      elapsed = Time.diff(first_pr_at, alert_at)
+
+      assert body =~ "went off at #{String.slice(alert.time, 0, 5)}"
+
+      assert body =~
+               "#{div(elapsed, 60)} minutes #{rem(elapsed, 60)} seconds later"
 
       # Every step of the loop, and the human gate among them.
       for step <- FountainWeb.MarketingHTML.case_loop() do
@@ -581,6 +587,10 @@ defmodule FountainWeb.MarketingControllerTest do
       for event <- FountainWeb.MarketingHTML.case_timeline() do
         assert body =~ event.time, "missing timeline entry #{event.time}"
       end
+
+      {timeline_at, _} = :binary.match(body, ~s(data-role="timeline-event"))
+      {loop_at, _} = :binary.match(body, ~s(data-role="loop-step"))
+      assert timeline_at < loop_at
 
       # The snippet is kept out of the template so its braces are not HEEx.
       assert body =~ "POST"
@@ -601,7 +611,7 @@ defmodule FountainWeb.MarketingControllerTest do
       body = conn |> get(~p"/case-studies/self-healing-infrastructure") |> html_response(200)
 
       assert body =~
-               ~s(<meta property="og:title" content="Self-healing infrastructure · Fountain")
+               ~s(<meta property="og:title" content="Kubernetes alert to pull request in 4m 27s · Fountain")
 
       assert body =~
                ~s(<meta property="og:url" content="http://localhost:4000/case-studies/self-healing-infrastructure")


### PR DESCRIPTION
## Summary
- lead with the measured 4m 27s incident and move its timeline ahead of the architecture
- report the full 78 alerts to 12 pull requests to 8 merges funnel without implying every alert was resolved
- replace self-healing language with alert-to-pull-request framing and make the external guardrails explicit
- clarify what Fountain supplies, including reusable configuration and free parked machines
- update product-marketing context and regression coverage

## Tests
- mix format --check-formatted on all changed Elixir and HEEx files
- mix test apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs apps/fountain/test/fountain_web/paper_skin_test.exs (75 tests, 0 failures)