### PR TITLE
Clarify the Built With page's proof and conversion path

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/marketing_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_controller.ex
@@ -114,10 +114,9 @@ defmodule FountainWeb.MarketingController do
         page_title: "Built with #{Fountain.Brand.name()} · #{Fountain.Brand.name()}",
         meta_description:
           "#{length(FountainWeb.MarketingHTML.built_apps_flat())} open-source " <>
-            "applications built on the #{Fountain.Brand.name()} API: research briefs, " <>
-            "CSV analysis, repository Q&A, agent fleets, DNS and infrastructure " <>
-            "patrols, model bake-offs and the team clients. Most have no backend " <>
-            "of their own."
+            "applications built on the #{Fountain.Brand.name()} API. Explore chat, " <>
+            "research, data analysis, code work, infrastructure operations and " <>
+            "multi-agent workflows."
       )
     else
       redirect(conn, to: ~p"/docs/build")

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
@@ -760,27 +760,27 @@ defmodule FountainWeb.MarketingHTML do
 
   ## /built-with
   #
-  # The apps built on the API, grouped by who they are for. Every one is a
-  # real deployment against the hosted instance, and every one is open source,
-  # so a card carries two links and the page carries no claim that cannot be
-  # clicked. The controller test asserts both are absolute and that no app is
-  # listed twice.
+  # The example apps this project built on the API, grouped by product shape.
+  # Every one is a real deployment against the hosted instance, and every one
+  # is open source, so a card carries two links and the page carries no claim
+  # that cannot be clicked. The controller test asserts both are absolute and
+  # that no app is listed twice.
   #
-  # The first group is the three this project builds itself, and they lead
-  # every page that shows the roster. An app in it carries a `:flagship` key
-  # holding the lines its featured cards add: a short homepage description,
-  # what it is like, and who it is for. That key is what `flagship_apps/0`
-  # selects on, so the tier is a property of the entry rather than a second
-  # list to keep in step.
+  # The first group holds the three flagship apps, and they lead every page
+  # that shows the roster. An app in it carries a `:flagship` key holding the
+  # lines its featured cards add: a short homepage description, what it is
+  # like, and who it is for. That key is what `flagship_apps/0` selects on, so
+  # the tier is a property of the entry rather than a second list to keep in
+  # step.
 
   @doc "The applications built on the API, in the order and grouping the page shows."
   def built_apps do
     [
       %{
         id: "flagship",
-        title: "The three we build ourselves",
+        title: "Three ways to work with your agents",
         blurb:
-          "Fountain's own UI is a console: accounts, keys, agents, environments, audit. The apps you actually work in are these, on their own origins, built on the same public API as everything below. Open one, point it at your instance, sign in.",
+          "Fountain's web UI is the operator console for accounts, keys, agents, environments and audit. These three apps are working surfaces built on the same public API available to your product.",
         apps: [
           %{
             id: "fountain-conversations",
@@ -790,13 +790,13 @@ defmodule FountainWeb.MarketingHTML do
             url: "https://fountain-conversations.demo.managoat.com/",
             source: "https://github.com/managoat/fountain-conversations",
             blurb:
-              "Start a run, watch the agent work turn by turn, and drive it. Chat, timeline and raw views of the same conversation, plus the machine it shares with its siblings.",
-            shows: "the event stream as blocks, and one sandbox behind many conversations",
+              "Start a run and watch the agent work turn by turn. Switch among chat, timeline and raw views of the same conversation, including the sandbox it shares with related runs.",
+            shows:
+              "event streams rendered as blocks and one sandbox shared by several conversations",
             flagship: %{
               homepage: "Run an agent and watch every step.",
-              like:
-                "ChatGPT, except the model has a checkout and a shell, and you can watch it work.",
-              who: "Open this one first. It is the whole platform with a face on it."
+              like: "A coding-agent chat with its checkout, shell and event stream visible.",
+              who: "Start here to see one run from first prompt to final response."
             }
           },
           %{
@@ -807,13 +807,12 @@ defmodule FountainWeb.MarketingHTML do
             url: "https://fountain-team.demo.managoat.com/",
             source: "https://github.com/managoat/fountain-team",
             blurb:
-              "Your agents as teammates in a messaging app. Roster on the left, thread on the right, routines on a schedule, images and search. Enter to send.",
-            shows: "the team API, SSE streaming, schedules, usage",
+              "Message your agents as teammates. Keep a roster beside the thread, schedule recurring routines, attach images and search the conversation history.",
+            shows: "the team API, SSE streaming, schedules and usage",
             flagship: %{
               homepage: "Message your agents like teammates.",
-              like:
-                "A group chat whose contacts are bots you made, one click each, faces and all.",
-              who: "For anyone who would rather text a teammate than fill in a form."
+              like: "A team messenger whose contacts are agents you configured.",
+              who: "Use it when a thread is the natural place to hand off work."
             }
           },
           %{
@@ -824,23 +823,22 @@ defmodule FountainWeb.MarketingHTML do
             url: "https://fountain-workbench.demo.managoat.com",
             source: "https://github.com/managoat/fountain-workbench",
             blurb:
-              "A dev workstation the team shares. A project is an environment and a vault, work items live in it, and putting a teammate on one is a first prompt rather than four steps of setup.",
-            shows: "projects over environments and vaults, agents as staff",
+              "A shared engineering workbench. Each project bundles a reusable environment and credentials with its work items, so assigning an agent takes one prompt.",
+            shows:
+              "projects composed from reusable environments and credentials, with agents as staff",
             flagship: %{
               homepage: "Assign work across shared projects.",
-              like:
-                "Multiplayer engineering: one board of work items, and staff you put on them by typing.",
-              who:
-                "For a team that wants the same projects, the same agents and one place to watch."
+              like: "One board for shared projects, work items and the agents assigned to them.",
+              who: "Use it when several people need the same agents and project setup."
             }
           }
         ]
       },
       %{
         id: "everyone",
-        title: "For everyone",
+        title: "Research and data",
         blurb:
-          "No agent, no sandbox and no prompt box on screen. The product is the document or the chart.",
+          "The output is a document or a chart. The agent and its sandbox stay behind the interface.",
         apps: [
           %{
             id: "briefing-room",
@@ -850,8 +848,8 @@ defmodule FountainWeb.MarketingHTML do
             url: "https://briefing-room.demo.managoat.com",
             source: "https://github.com/managoat/briefing-room",
             blurb:
-              "Say what you need to understand and why. A researcher with its own computer reads real sources and hands back a clean, cited brief. A document, not a chat.",
-            shows: "web research behind a UI with none of the AI-chat furniture"
+              "Describe what you need to understand and why. A research agent reads sources on the web and returns a cited brief instead of a chat transcript.",
+            shows: "web research that returns a document instead of a chat interface"
           },
           %{
             id: "table-talk",
@@ -861,16 +859,16 @@ defmodule FountainWeb.MarketingHTML do
             url: "https://table-talk.demo.managoat.com",
             source: "https://github.com/managoat/table-talk",
             blurb:
-              "Drop a CSV in. An analyst runs Python on its sandbox and comes back with charts and plain-English findings. Then keep asking questions of your data.",
-            shows: "a real computer as the engine under a zero-jargon UI"
+              "Drop in a CSV. An analyst runs Python in its sandbox and returns charts with plain-language findings. Keep asking questions of the same data.",
+            shows: "sandboxed Python analysis behind a file-upload interface"
           }
         ]
       },
       %{
         id: "engineers",
-        title: "For engineers",
+        title: "Software engineering",
         blurb:
-          "The sandbox is the point. Each of these hands an agent a checkout, a shell and a task list, then shows you the work.",
+          "Each app gives an agent a checkout, a shell and a bounded task, then makes the work visible.",
         apps: [
           %{
             id: "repo-sage",
@@ -880,8 +878,8 @@ defmodule FountainWeb.MarketingHTML do
             url: "https://repo-sage.demo.managoat.com",
             source: "https://github.com/managoat/repo-sage",
             blurb:
-              "Name any public GitHub repository. An agent clones it on its own machine and answers with file-and-line citations that link back to the source.",
-            shows: "the sandbox as a workstation: clone, grep, read, cite"
+              "Name any public GitHub repository. An agent clones it in a sandbox and answers with file-and-line citations that link back to the source.",
+            shows: "repository checkout, search and file-and-line citations"
           },
           %{
             id: "mission-control",
@@ -891,8 +889,8 @@ defmodule FountainWeb.MarketingHTML do
             url: "https://mission-control.demo.managoat.com",
             source: "https://github.com/managoat/mission-control",
             blurb:
-              "Describe a mission. A coordinator plans it, you approve the plan, and the app starts one sandboxed agent per task. Watch the fleet work and take one report.",
-            shows: "plan, approve, fan out, multiplex the streams, synthesize"
+              "Describe a goal. A coordinator drafts a plan for your approval, then starts one sandboxed agent per task. Watch them work and receive one combined report.",
+            shows: "approval gates, parallel runs, combined event streams and a final report"
           },
           %{
             id: "dns-desk",
@@ -903,15 +901,15 @@ defmodule FountainWeb.MarketingHTML do
             source: "https://github.com/managoat/dns-desk",
             blurb:
               "A DNS operator for your Cloudflare zones. Ask in plain words, read the plan as a diff, approve. The zone tables stay on screen while the agent does the work.",
-            shows: "plan, approve, apply on a live system, with a vault as the blast radius"
+            shows: "a reviewable plan and explicit approval before changing a live system"
           }
         ]
       },
       %{
         id: "infrastructure",
-        title: "For infrastructure",
+        title: "Infrastructure operations",
         blurb:
-          "Nobody is watching these. A schedule wakes the agent, it decides whether anything needs doing, and most of the time the answer is no.",
+          "These apps monitor and repair systems with tools scoped to the job. A scheduled run can decide that nothing needs doing.",
         apps: [
           %{
             id: "watchtower",
@@ -921,8 +919,9 @@ defmodule FountainWeb.MarketingHTML do
             url: "https://watchtower.demo.managoat.com",
             source: "https://github.com/managoat/watchtower",
             blurb:
-              "An SRE teammate on a cron: uptime, latency, TLS expiry and DNS for every site you name. When a tile turns red, ask it to investigate. It has real tools.",
-            shows: "schedules as a product heartbeat, the conversation as the store"
+              "A scheduled SRE agent monitors uptime, latency, TLS expiry and DNS for every site you name. When a tile turns red, ask it to investigate with its tools.",
+            shows:
+              "scheduled runs, tool-backed investigation and conversations as durable history"
           },
           %{
             id: "mend",
@@ -932,9 +931,8 @@ defmodule FountainWeb.MarketingHTML do
             url: "https://mend.demo.managoat.com",
             source: "https://github.com/managoat/mend",
             blurb:
-              "What an audit finds across a repository's CI, manifests, Dockerfiles and cloud templates, and what an agent does once you hand it that tool. Mechanical fixes applied, judgement calls argued, one patch back.",
-            shows:
-              "a real CLI in the sandbox, and the restraint to leave the ambiguous ones alone"
+              "Mend audits CI, manifests, Dockerfiles and cloud templates. It applies mechanical fixes, explains judgment calls and returns one patch.",
+            shows: "a real CLI in the sandbox and ambiguous findings left for review"
           },
           %{
             id: "rounds",
@@ -944,15 +942,15 @@ defmodule FountainWeb.MarketingHTML do
             url: "https://rounds.demo.managoat.com",
             source: "https://github.com/managoat/rounds",
             blurb:
-              "Dependabot for infrastructure config. Enroll a repository and it gets audited on a schedule; an agent fixes what it can verify and opens the pull request. Never twice for the same finding, never again for one you closed.",
-            shows: "an unattended product, and an agent that knows when to do nothing"
+              "Dependabot for infrastructure config. Rounds audits an enrolled repository on a schedule, fixes what it can verify and opens a pull request without repeating closed findings.",
+            shows: "an unattended workflow and an agent that knows when to do nothing"
           }
         ]
       },
       %{
         id: "ai-engineers",
-        title: "For AI engineers",
-        blurb: "Several agents at once, side by side, with the numbers underneath.",
+        title: "Agent evaluation",
+        blurb: "Run the same prompt across several agents, then compare their outputs and usage.",
         apps: [
           %{
             id: "arena",
@@ -962,8 +960,8 @@ defmodule FountainWeb.MarketingHTML do
             url: "https://arena.demo.managoat.com",
             source: "https://github.com/managoat/arena",
             blurb:
-              "One prompt, several brains, side by side. Blind columns, live streams, latency and token counts, and your vote on the scoreboard.",
-            shows: "parallel conversations, the model catalog, per-turn usage"
+              "Send one prompt to several agents in blind columns. Compare their live responses, latency and token counts, then vote on the result.",
+            shows: "parallel conversations, model selection and per-turn usage"
           }
         ]
       }
@@ -974,9 +972,9 @@ defmodule FountainWeb.MarketingHTML do
   def built_apps_flat, do: Enum.flat_map(built_apps(), & &1.apps)
 
   @doc """
-  The three applications this project builds itself, in the order every page
-  shows them. Selected out of `built_apps/0` rather than restated, so a
-  flagship card cannot drift from its roster entry.
+  The three flagship applications, in the order every page shows them.
+  Selected out of `built_apps/0` rather than restated, so a flagship card
+  cannot drift from its roster entry.
   """
   def flagship_apps, do: Enum.filter(built_apps_flat(), &Map.has_key?(&1, :flagship))
 

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/built_with.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/built_with.html.heex
@@ -2,12 +2,30 @@
 <section class="max-w-5xl mx-auto px-6 py-20 text-center">
   <.eyebrow label={"Built with #{Fountain.Brand.name()}"} class="mb-5" />
   <h1 class="text-4xl sm:text-5xl font-bold tracking-tight text-[var(--color-text-primary)] mb-5 leading-tight">
-    {length(built_apps_flat())} products. One API behind all of them.
+    {length(built_apps_flat())} open-source apps. One API for the agents behind them.
   </h1>
-  <p class="text-lg sm:text-xl text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-10">
-    Three of them we build ourselves: a chat app, a team messenger and a shared engineering workbench. The rest were built the same way, on the same public API. Most have no backend of their own at all: static files in a browser, the API, and an agent with a real computer. That is the whole stack. All of them are open source, and all of them are running right now.
+  <p class="text-lg sm:text-xl text-[var(--color-text-secondary)] max-w-2xl mx-auto">
+    We built these apps to show what {Fountain.Brand.name()} can power: chat, research, data analysis, code work, infrastructure operations and multi-agent workflows. Open any app, inspect its source or connect it to your own {Fountain.Brand.name()} server.
   </p>
-  <div class="flex flex-wrap gap-2 justify-center" data-role="group-chips">
+  <p class="mt-4 text-sm text-[var(--color-text-muted)] max-w-2xl mx-auto">
+    Most have no backend of their own. {Fountain.Brand.name()} keeps the agent machines ready, holds credentials and transcripts, and meters only the time an agent is working.
+  </p>
+  <div class="mt-8 flex flex-col sm:flex-row gap-3 justify-center">
+    <a
+      href={(flagship_apps() |> hd()).url}
+      rel="noopener"
+      class="inline-flex items-center justify-center px-6 py-3 rounded-lg bg-[var(--color-brand)] text-white font-medium hover:bg-[var(--color-brand-hover)] transition-colors text-sm"
+    >
+      Open Conversations
+    </a>
+    <a
+      href={~p"/docs/build"}
+      class="inline-flex items-center justify-center px-6 py-3 rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-bg-1)] text-[var(--color-text-primary)] font-medium hover:bg-[var(--color-bg-2)] transition-colors text-sm"
+    >
+      Build a chat app
+    </a>
+  </div>
+  <div class="mt-8 flex flex-wrap gap-2 justify-center" data-role="group-chips">
     <a
       :for={group <- built_apps()}
       href={"##{group.id}"}
@@ -80,57 +98,14 @@
   </div>
 </section>
 
-<%!-- How they all connect --%>
-<section class="border-y border-[var(--color-border)]">
-  <div class="max-w-5xl mx-auto px-6 py-16">
-    <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-3 text-center">
-      They all connect the same way.
-    </h2>
-    <p class="text-center text-[var(--color-text-secondary)] max-w-xl mx-auto mb-12">
-      Open one, give it the address of a {Fountain.Brand.name()} server, then sign in with your account or paste an API key. The app runs in your browser against your own agents, your own sandboxes and your own credit. Nothing of yours reaches whoever wrote it.
-    </p>
-    <div class="grid sm:grid-cols-3 gap-6">
-      <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-1)] p-6">
-        <p class="text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)]">
-          Step one
-        </p>
-        <h3 class="mt-1 font-semibold text-[var(--color-text-primary)]">Point it at a server</h3>
-        <p class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">
-          The hosted instance, or the one you self-host. The app asks for the URL on first load.
-        </p>
-      </div>
-      <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-1)] p-6">
-        <p class="text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)]">
-          Step two
-        </p>
-        <h3 class="mt-1 font-semibold text-[var(--color-text-primary)]">
-          Sign in with {Fountain.Brand.name()}
-        </h3>
-        <p class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">
-          OAuth with PKCE. The token it gets is an ordinary API key, so it lists and revokes under Account.
-        </p>
-      </div>
-      <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-1)] p-6">
-        <p class="text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)]">
-          Step three
-        </p>
-        <h3 class="mt-1 font-semibold text-[var(--color-text-primary)]">Your agents show up</h3>
-        <p class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">
-          Whatever the app launches runs on a sandbox on your account, and every run is a conversation you already own.
-        </p>
-      </div>
-    </div>
-  </div>
-</section>
-
 <%!-- The rest of the roster --%>
 <section class="max-w-5xl mx-auto px-6 py-16 space-y-16">
   <div class="text-center">
     <h2 class="text-2xl font-semibold text-[var(--color-text-primary)]">
-      And what the API carries beyond them.
+      More products built on the same API.
     </h2>
     <p class="mt-3 text-[var(--color-text-secondary)] max-w-2xl mx-auto">
-      Same API, same sign-in, no backend of their own. Each one was written to prove a different thing an agent with a computer can do.
+      Each app isolates a different pattern: document generation, data analysis, code work, live operations, scheduled maintenance or parallel agents.
     </p>
   </div>
   <div
@@ -166,7 +141,8 @@
           {app.blurb}
         </p>
         <p class="mt-4 text-xs text-[var(--color-text-muted)]">
-          <span class="font-medium text-[var(--color-text-secondary)]">Shows</span> {app.shows}
+          <span class="font-medium text-[var(--color-text-secondary)]">Under the hood</span>
+          {app.shows}
         </p>
         <div class="mt-5 flex flex-wrap gap-3">
           <a
@@ -189,6 +165,50 @@
   </div>
 </section>
 
+<%!-- How they all connect. This follows the roster so setup does not interrupt
+      the product proof a reader came to see. --%>
+<section class="border-y border-[var(--color-border)]">
+  <div class="max-w-5xl mx-auto px-6 py-16">
+    <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-3 text-center">
+      One connection for every app.
+    </h2>
+    <p class="text-center text-[var(--color-text-secondary)] max-w-xl mx-auto mb-12">
+      Each app calls {Fountain.Brand.name()} directly from your browser. Point it at the hosted service or your own server, then authenticate with OAuth or an API key.
+    </p>
+    <div class="grid sm:grid-cols-3 gap-6">
+      <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-1)] p-6">
+        <p class="text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)]">
+          Server
+        </p>
+        <h3 class="mt-1 font-semibold text-[var(--color-text-primary)]">Choose where it runs</h3>
+        <p class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">
+          Use the hosted service or a {Fountain.Brand.name()} server under your own keys and infrastructure.
+        </p>
+      </div>
+      <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-1)] p-6">
+        <p class="text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)]">
+          Authentication
+        </p>
+        <h3 class="mt-1 font-semibold text-[var(--color-text-primary)]">
+          Sign in with {Fountain.Brand.name()}
+        </h3>
+        <p class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">
+          OAuth with PKCE creates an API key without giving the app your password. See and revoke the key under Account.
+        </p>
+      </div>
+      <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-1)] p-6">
+        <p class="text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)]">
+          Runs
+        </p>
+        <h3 class="mt-1 font-semibold text-[var(--color-text-primary)]">Work on your account</h3>
+        <p class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">
+          The app sees the agents and conversations your key can access. Each new run happens in a sandbox on that account.
+        </p>
+      </div>
+    </div>
+  </div>
+</section>
+
 <%!-- Footer CTA --%>
 <section class="bg-[var(--color-bg-1)] border-t border-[var(--color-border)]">
   <div class="max-w-5xl mx-auto px-6 py-20 text-center">
@@ -196,7 +216,7 @@
       Build the next one.
     </h2>
     <p class="text-[var(--color-text-secondary)] mb-8 max-w-lg mx-auto">
-      A static page, the TypeScript SDK and Sign in with {Fountain.Brand.name()} is the whole recipe. The manual walks a team chat end to end, and the apps above are the working copies to read.
+      A static front end can start with the TypeScript SDK and Sign in with {Fountain.Brand.name()}. The build guide walks through a team chat end to end, and every app above is an implementation you can read.
     </p>
     <div class="flex flex-col sm:flex-row gap-3 justify-center">
       <a
@@ -206,14 +226,14 @@
         Build a chat app
       </a>
       <a
-        href={~p"/integrations"}
+        href={~p"/docs/api"}
         class="inline-flex items-center justify-center px-6 py-3 rounded-lg border border-[var(--color-border)] text-[var(--color-text-primary)] font-medium hover:bg-[var(--color-bg-2)] transition-colors text-sm"
       >
-        Or plug in what you already run
+        Explore the API
       </a>
     </div>
     <p class="mt-8 text-xs text-[var(--color-text-muted)] max-w-xl mx-auto">
-      Each app is MIT licensed and hosted by its author, not by {Fountain.Brand.name()}. Signing in hands it a key scoped to your account, which you can revoke at any time under Account and API keys.
+      Each app is MIT licensed and runs on its own origin. Inspect or self-host the source before connecting an account. You can revoke its {Fountain.Brand.name()} API key at any time under Account.
     </p>
   </div>
 </section>

--- a/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
@@ -148,7 +148,9 @@ defmodule FountainWeb.MarketingControllerTest do
     test "renders every app, grouped", %{conn: conn} do
       body = conn |> get(~p"/built-with") |> html_response(200)
 
-      assert body =~ "One API behind all of them."
+      assert body =~ "One API for the agents behind them."
+      assert body =~ "We built these apps to show what #{Fountain.Brand.name()} can power"
+      refute body =~ "Nothing of yours reaches whoever wrote it"
 
       for group <- FountainWeb.MarketingHTML.built_apps() do
         assert body =~ group.title, "missing group #{group.title}"


### PR DESCRIPTION
## Summary

- identify the gallery as Fountain-built open-source examples instead of implying customer adoption
- explain Fountain's role and work-only meter above the fold, with direct demo and build-guide actions
- reorganize and tighten the app catalog around product patterns, move setup below the proof, and replace the absolute security claim with precise connection guidance
- shorten the metadata and update the rendered-copy assertion

## Test plan

- mix format --check-formatted apps/fountain/lib/fountain_web/controllers/marketing_controller.ex apps/fountain/lib/fountain_web/controllers/marketing_html.ex apps/fountain/lib/fountain_web/controllers/marketing_html/built_with.html.heex apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
- mix test apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs (64 tests, 0 failures)