### PR TITLE
Copy: compress the case-study human handoff

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
@@ -1506,77 +1506,43 @@ defmodule FountainWeb.MarketingHTML do
     ]
   end
 
-  @doc "The loop, in the order it runs."
-  def case_loop do
+  @doc "The two observed intervals around the case study's human handoff."
+  def case_handoff_metrics do
     [
       %{
-        step: "1",
-        title: "Prometheus notices",
-        mono: "KubePodCrashLooping · PodOOMKilled · CPUThrottlingHigh · PodRestartChurn",
-        body: "The cluster's existing alert rules. Prometheus knows nothing about the agent."
+        id: "alert-to-pr",
+        value: "4m 27s",
+        prose_value: "4 minutes 27 seconds",
+        seconds: 267,
+        label: "Alert to proposed fix"
       },
       %{
-        step: "2",
-        title: "Alertmanager forks the page",
-        mono: "continue: true",
-        body:
-          "One copy goes to the on-call engineer's phone, as before. One goes to a webhook. " <>
-            "The agent joins the response; it does not replace the engineer."
+        id: "pr-to-review",
+        value: "1h 47m 45s",
+        prose_value: "1 hour 47 minutes 45 seconds",
+        seconds: 6_465,
+        label: "Proposed fix to human review"
+      }
+    ]
+  end
+
+  @doc "The loop compressed into automatic work around its one human decision."
+  def case_workflow do
+    [
+      %{
+        owner: "Automatic",
+        human?: false,
+        body: "Detect → page and start agent → read cluster → trace git → open pull request"
       },
       %{
-        step: "3",
-        title: "A webhook starts an agent",
-        mono: "POST /api/conversations",
-        body:
-          "The production handler is two hundred lines of Node. Its handoff to " <>
-            "Fountain posts an agent id, an identity id and the alert text."
+        owner: "Human",
+        human?: true,
+        body: "Decide whether to approve and merge"
       },
       %{
-        step: "4",
-        title: "The agent reads the cluster",
-        mono: "Authorization: Bearer … (GET only)",
-        body:
-          "A read-only service answers with node health, drift from " <>
-            "source, and controller conditions. Every other method returns 405."
-      },
-      %{
-        step: "5",
-        title: "It finds the wrong fact in git",
-        mono: "gh api · git log -S",
-        body:
-          "When the repository can fix an alert, the agent reads the history and " <>
-            "names the commit at fault before editing."
-      },
-      %{
-        step: "6",
-        title: "It opens one minimal pull request",
-        mono: "symptom · root cause · why this diff is the whole fix",
-        body:
-          "Source and regenerated manifests in one commit, from an identity " <>
-            "with push rights and nothing else. If no change to the repository " <>
-            "can fix the alert, it opens nothing."
-      },
-      %{
-        step: "7",
-        title: "The on-call engineer decides",
-        mono: "422 on self-approval · 405 on self-merge",
-        body:
-          "The one gate. GitHub blocks self-approval, and the branch needs a " <>
-            "review from another account."
-      },
-      %{
-        step: "8",
-        title: "Flux applies the merge",
-        mono: "reconcile on webhook",
-        body: "Git was always the apply path. There is no apply button to trust it with."
-      },
-      %{
-        step: "9",
-        title: "The agent verifies and reports",
-        mono: "poll until healthy",
-        body:
-          "It watches the node come back, checks nothing else regressed, " <>
-            "posts the summary, and stops."
+        owner: "Automatic",
+        human?: false,
+        body: "Flux applies the merge → agent verifies health"
       }
     ]
   end

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/case_study_self_healing.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/case_study_self_healing.html.heex
@@ -135,47 +135,80 @@
   </div>
 </section>
 
-<%!-- The loop --%>
+<%!-- The handoff. The timeline above supplies the chronology; this section
+      turns those timestamps into the operating-model change. It does not
+      claim time saved against a counterfactual incident that never ran. --%>
 <section
   id="loop"
   class="scroll-mt-6"
 >
+  <% handoff_metrics = case_handoff_metrics() %>
+  <% [alert_to_pr, pr_to_review] = handoff_metrics %>
   <div class="max-w-5xl mx-auto px-6 py-16">
+    <.eyebrow label="Nine steps · one human decision" class="mb-4" />
     <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-3 text-center">
-      Nine steps, one of them a person.
+      The pull request waited for the engineer.
     </h2>
-    <p class="text-center text-[var(--color-text-secondary)] max-w-xl mx-auto mb-12">
-      The existing alert path gained one webhook. That webhook starts the agent with one API call.
+    <p class="text-center text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-10">
+      The agent opened a proposed fix {alert_to_pr.prose_value} after the page. The on-call engineer reviewed it {pr_to_review.prose_value} later.
     </p>
-    <ol class="max-w-3xl mx-auto space-y-4">
-      <li
-        :for={step <- case_loop()}
-        class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-5 sm:p-6 flex items-start gap-4"
-        data-role="loop-step"
+    <div class="grid sm:grid-cols-2 gap-px max-w-3xl mx-auto overflow-hidden rounded-xl border border-[var(--color-border)] bg-[var(--color-border)]">
+      <div
+        :for={metric <- handoff_metrics}
+        class="bg-[var(--color-bg-0)] p-6 text-center"
+        data-role="handoff-metric"
+        data-metric={metric.id}
       >
-        <span class={[
-          "flex-shrink-0 size-7 rounded-full text-sm font-semibold flex items-center justify-center",
-          if(step.step == "7",
-            do: "bg-[var(--color-text-primary)] text-[var(--color-bg-0)]",
-            else: "bg-[var(--color-brand)] text-white"
+        <p class="text-3xl font-semibold text-[var(--color-text-primary)] tabular-nums">
+          {metric.value}
+        </p>
+        <p class="mt-2 text-sm text-[var(--color-text-secondary)]">{metric.label}</p>
+      </div>
+    </div>
+
+    <p
+      class="text-center text-[var(--color-text-secondary)] max-w-2xl mx-auto mt-10"
+      data-role="handoff-contrast"
+    >
+      By review time, the starting point was no longer an alert. It was a root-cause explanation, the commit that exposed the fault, and a 13-line diff.
+    </p>
+
+    <ol class="grid md:grid-cols-[1.4fr_0.7fr_1fr] gap-4 max-w-4xl mx-auto mt-10">
+      <li
+        :for={stage <- case_workflow()}
+        class={[
+          "rounded-xl border p-5",
+          if(stage.human?,
+            do: "border-[var(--color-text-primary)] bg-[var(--color-text-primary)]",
+            else: "border-[var(--color-border)] bg-[var(--color-bg-0)]"
+          )
+        ]}
+        data-role="workflow-stage"
+      >
+        <p class={[
+          "text-xs font-medium uppercase tracking-wide",
+          if(stage.human?,
+            do: "text-[var(--color-bg-0)]",
+            else: "text-[var(--color-text-muted)]"
           )
         ]}>
-          {step.step}
-        </span>
-        <div class="min-w-0">
-          <h3 class="font-semibold text-[var(--color-text-primary)]">{step.title}</h3>
-          <p class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">
-            {step.body}
-          </p>
-          <div class="mt-3 overflow-x-auto">
-            <code
-              class="inline-block whitespace-nowrap text-xs text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1.5 py-0.5"
-              phx-no-format
-            >{step.mono}</code>
-          </div>
-        </div>
+          {stage.owner}
+        </p>
+        <p class={[
+          "mt-2 text-sm leading-relaxed",
+          if(stage.human?,
+            do: "text-[var(--color-bg-0)]",
+            else: "text-[var(--color-text-secondary)]"
+          )
+        ]}>
+          {stage.body}
+        </p>
       </li>
     </ol>
+
+    <p class="text-center text-[var(--color-text-secondary)] max-w-2xl mx-auto mt-10">
+      The person still owned the consequential step. The agent could propose a change; it could not approve or merge one.
+    </p>
   </div>
 </section>
 

--- a/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
@@ -553,7 +553,7 @@ defmodule FountainWeb.MarketingControllerTest do
   end
 
   describe "GET /case-studies/self-healing-infrastructure" do
-    test "renders the loop, the guardrails and the incident", %{conn: conn} do
+    test "renders the handoff, the guardrails and the incident", %{conn: conn} do
       body = conn |> get(~p"/case-studies/self-healing-infrastructure") |> html_response(200)
 
       assert body =~ "The pager went off at 06:58."
@@ -576,12 +576,35 @@ defmodule FountainWeb.MarketingControllerTest do
       assert body =~
                "#{div(elapsed, 60)} minutes #{rem(elapsed, 60)} seconds later"
 
-      # Every step of the loop, and the human gate among them.
-      for step <- FountainWeb.MarketingHTML.case_loop() do
-        assert body =~ step.title, "missing loop step #{step.title}"
+      # The handoff uses the incident's measured intervals, not a claimed
+      # comparison against a counterfactual incident that never ran.
+      review = Enum.find(timeline, &String.contains?(&1.title, "reviews both pull requests"))
+
+      metrics =
+        FountainWeb.MarketingHTML.case_handoff_metrics()
+        |> Map.new(&{&1.id, &1})
+
+      {:ok, review_at} = Time.from_iso8601(review.time)
+
+      assert metrics["alert-to-pr"].seconds == elapsed
+      assert metrics["pr-to-review"].seconds == Time.diff(review_at, first_pr_at)
+
+      for {_id, metric} <- metrics do
+        assert body =~ metric.value, "missing handoff metric #{metric.label}"
+        assert body =~ metric.prose_value, "missing handoff prose #{metric.label}"
+        assert body =~ metric.label, "missing handoff label #{metric.label}"
       end
 
-      assert body =~ "422 on self-approval"
+      # The full loop is compressed into ownership stages, with the human gate
+      # still explicit rather than buried among nine equal cards.
+      for stage <- FountainWeb.MarketingHTML.case_workflow() do
+        assert body =~ stage.body, "missing workflow stage #{stage.owner}"
+      end
+
+      assert body =~ "The pull request waited for the engineer."
+      assert body =~ "The person still owned the consequential step."
+      refute body =~ ~s(data-role="loop-step")
+      assert body =~ "GitHub blocks self-approval"
       assert body =~ "The sandbox has no kubectl and no kubeconfig."
       assert body =~ "install_members()"
 
@@ -591,8 +614,8 @@ defmodule FountainWeb.MarketingControllerTest do
       end
 
       {timeline_at, _} = :binary.match(body, ~s(data-role="timeline-event"))
-      {loop_at, _} = :binary.match(body, ~s(data-role="loop-step"))
-      assert timeline_at < loop_at
+      {handoff_at, _} = :binary.match(body, ~s(data-role="handoff-metric"))
+      assert timeline_at < handoff_at
 
       # The snippet is kept out of the template so its braces are not HEEx.
       assert body =~ "POST"


### PR DESCRIPTION
## Summary

- replace the nine full-width process cards with two observed handoff intervals
- show the loop as automatic work around one explicit human approve-or-merge decision
- tie both displayed intervals back to the incident timestamps in the controller test

## Verification

- mix format --check-formatted
- mix test apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs (64 tests, 0 failures)

## Visual QA

A connected browser was unavailable in this session, so this PR has rendered-page test coverage but no screenshot pass.