### PR TITLE
Clarify the integrations page by direction

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/marketing_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_controller.ex
@@ -72,12 +72,11 @@ defmodule FountainWeb.MarketingController do
     if Fountain.Marketing.site?() do
       render(conn, :integrations,
         layout: {FountainWeb.Layouts, :marketing},
-        page_title: "Integrations · #{Fountain.Brand.name()}",
+        page_title: "Coding agent integrations · #{Fountain.Brand.name()}",
         meta_description:
-          "#{Fountain.Brand.name()} speaks AG-UI, the Agent Client Protocol, " <>
-            "OpenAI chat completions, MCP and its own REST API, so the editor, " <>
-            "chat app, gateway or framework you already use can start an agent " <>
-            "on a sandbox."
+          "Start a coding agent from your editor, chat app, gateway, framework " <>
+            "or code. #{Fountain.Brand.name()} connects over ACP, AG-UI, OpenAI-compatible " <>
+            "chat completions, MCP and its REST API."
       )
     else
       redirect(conn, to: ~p"/docs/integrations/clients")

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
@@ -367,21 +367,87 @@ defmodule FountainWeb.MarketingHTML do
   # page of the manual, and the controller test checks every such link
   # resolves, so a renamed docs page fails here rather than on the site.
 
-  @doc "The protocols Fountain answers, in the order the page shows them."
+  attr :protocol, :map, required: true
+  attr :works_label, :string, default: "Works with"
+
+  def protocol_card(assigns) do
+    ~H"""
+    <article
+      id={@protocol.id}
+      class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6 sm:p-8 scroll-mt-6"
+      data-role="protocol"
+    >
+      <div class="grid md:grid-cols-5 gap-8">
+        <div class="md:col-span-3">
+          <div class="flex flex-wrap items-baseline gap-x-3 gap-y-1 mb-1">
+            <h3 class="text-xl font-semibold text-[var(--color-text-primary)]">
+              {@protocol.name}
+            </h3>
+            <span class="text-sm text-[var(--color-text-muted)]">{@protocol.long}</span>
+            <span
+              :if={@protocol[:status]}
+              class="inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide bg-[var(--color-bg-2)] text-[var(--color-text-muted)]"
+            >
+              {@protocol.status}
+            </span>
+          </div>
+          <code
+            class="inline-block mt-1 mb-4 text-xs text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1.5 py-0.5"
+            phx-no-format
+          >{@protocol.surface}</code>
+          <p class="text-sm text-[var(--color-text-secondary)] leading-relaxed">
+            {@protocol.pitch}
+          </p>
+          <p class="mt-3 text-xs text-[var(--color-text-muted)]">
+            {@protocol.direction}
+          </p>
+          <a
+            href={@protocol.docs}
+            class="inline-block mt-4 text-sm font-medium text-[var(--color-text-primary)] underline underline-offset-2 hover:text-[var(--color-brand)]"
+          >
+            {@protocol.docs_label} →
+          </a>
+        </div>
+        <div class="md:col-span-2">
+          <p class="text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)] mb-3">
+            {@works_label}
+          </p>
+          <ul class="space-y-2">
+            <li
+              :for={item <- @protocol.works_with}
+              class="flex items-start gap-2.5 text-sm"
+              data-role="works-with"
+            >
+              <span class="mt-0.5 flex-shrink-0 text-[var(--color-text-primary)]">
+                <.mark name={item.name} slug={item.slug} class="size-4" />
+              </span>
+              <span>
+                <span class="font-medium text-[var(--color-text-primary)]">{item.name}</span>
+                <span class="text-[var(--color-text-muted)]">· {item.note}</span>
+              </span>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </article>
+    """
+  end
+
+  @doc "The protocol integrations this page describes."
   def protocols do
     [
       %{
         id: "agui",
+        kind: :client,
         name: "AG-UI",
         long: "Agent-User Interaction Protocol",
         surface: "POST /api/agui/:agent_id",
-        direction: "An AG-UI host drives a Fountain agent.",
+        direction: "An AG-UI host starts and follows a Fountain agent.",
         pitch:
-          "The open protocol between an agent and a front end, from CopilotKit. " <>
-            "Fountain answers a RunAgentInput with the standard event stream, so a " <>
-            "Fountain agent takes a seat next to a LangGraph or CrewAI one with no " <>
-            "adapter. Pass the host's tools and a call comes back as TOOL_CALL events. " <>
-            "One thread binds to one conversation, and the sandbox is the memory.",
+          "Put a Fountain agent in an AG-UI front end without writing an adapter. " <>
+            "Fountain turns RunAgentInput into the standard event stream and returns " <>
+            "host tools as TOOL_CALL events. Each thread maps to one Conversation, so " <>
+            "its sandbox keeps the files and context from one message to the next.",
         docs: "/docs/integrations/openbot",
         docs_label: "OpenBot and AG-UI",
         works_with: [
@@ -405,15 +471,16 @@ defmodule FountainWeb.MarketingHTML do
       },
       %{
         id: "acp",
+        kind: :client,
         name: "ACP",
         long: "Agent Client Protocol",
         surface: "fountain acp --agent <name>",
-        direction: "An editor or chat harness spawns the CLI and drives a conversation.",
+        direction: "An editor or chat app launches the local CLI; the work runs remotely.",
         pitch:
-          "Zed's editor protocol for coding agents. Fountain is an ACP client of the " <>
-            "agents it runs in sandboxes and an ACP agent for the editor in front of you, " <>
-            "so the same block vocabulary flows through untranslated. Close the laptop " <>
-            "mid-turn; the turn continues on the sandbox and replays when you reopen.",
+          "Run a Fountain agent from an ACP-capable editor or chat app. The CLI " <>
+            "connects the client to a remote sandbox, so you can close your laptop " <>
+            "mid-turn and pick up the result when you return. The protocol's block " <>
+            "vocabulary passes through without another adapter.",
         docs: "/docs/integrations/editors",
         docs_label: "Editors over ACP",
         works_with: [
@@ -443,16 +510,17 @@ defmodule FountainWeb.MarketingHTML do
       },
       %{
         id: "openai",
+        kind: :client,
         name: "OpenAI-compatible",
+        status: "Alpha",
         long: "Chat completions, where the model is an agent",
         surface: "POST /v1/chat/completions",
         direction: "Any client or gateway with a base-URL field drives a Fountain agent.",
         pitch:
-          "The request shape every gateway and every chat client already speaks. Point " <>
-            "one at your instance with an API key, and GET /v1/models fills its picker with " <>
-            "your agents. Your tools come back as tool_calls, so a Fountain agent sits " <>
-            "inside a LangChain loop or a Deep Agents plan as a subagent. A thread key " <>
-            "binds each chat to one sandbox. Alpha, behind a flag; ask and it is on.",
+          "Point an OpenAI-compatible client or gateway at Fountain and your agents " <>
+            "appear in its model picker. A thread key binds each chat to one sandbox, " <>
+            "and tools come back as tool_calls for existing LangChain and Deep Agents " <>
+            "loops. Available on request while the response shape is in alpha.",
         docs: "/docs/integrations/openai-compatible",
         docs_label: "The OpenAI-compatible API",
         works_with: [
@@ -484,16 +552,17 @@ defmodule FountainWeb.MarketingHTML do
       },
       %{
         id: "mcp",
+        kind: :tool,
         name: "MCP",
         long: "Model Context Protocol, both ways",
         surface: "Any MCP server, on any agent",
         direction: "Agents call the servers you name; Fountain hosts four of its own.",
         pitch:
-          "An agent's config lists the MCP servers it may call, and Fountain passes " <>
-            "the declaration through and curates nothing. A Gmail Connection holds the " <>
-            "OAuth grant on the server, so an inbox arrives as tools with no token in " <>
-            "the prompt. Fountain also serves MCP to its own sandboxes: a teammate to " <>
-            "message, an email address and a phone number, a Buzz channel, a mailbox.",
+          "Give each Fountain agent the stdio or HTTP MCP servers it needs. Fountain " <>
+            "passes their declarations to the runtime without curating them. With a " <>
+            "brokered Gmail Connection, the sandbox gets inbox tools without receiving " <>
+            "the OAuth token. Fountain also serves MCP tools for teammate messaging, " <>
+            "email, phone and Buzz.",
         docs: "/docs/catalog/mcp-servers",
         docs_label: "The MCP servers Fountain hosts",
         works_with: [
@@ -514,17 +583,16 @@ defmodule FountainWeb.MarketingHTML do
       },
       %{
         id: "api",
+        kind: :client,
         name: "REST, SSE and webhooks",
         long: "Fountain's own API",
         surface: "/api, with a TypeScript SDK and a CLI",
         direction: "Your code drives everything the console can, and more.",
         pitch:
-          "Everything above is a translation of this. Create a conversation, send a " <>
-            "prompt, stream the turn as blocks the server has already parsed, or take a " <>
-            "signed webhook when it ends. Sign in with Fountain gives a browser app of " <>
-            "your own an OAuth flow whose tokens are ordinary API keys. The three apps " <>
-            "this project ships are built on exactly this and nothing private: static " <>
-            "files, the SDK, your key.",
+          "Start and follow agents from your own code. Create a Conversation, send a " <>
+            "prompt, stream the parsed blocks or receive a signed webhook when the turn " <>
+            "ends. Sign in with Fountain gives browser apps an OAuth flow. The apps this " <>
+            "project ships use the same public API and TypeScript SDK.",
         docs: "/docs/api",
         docs_label: "The API reference",
         works_with: [
@@ -555,15 +623,15 @@ defmodule FountainWeb.MarketingHTML do
       },
       %{
         id: "nostr",
+        kind: :outbound,
         name: "Nostr",
         long: "Buzz, the other direction",
         surface: "POST /api/buzz/agents",
         direction: "Outbound. Fountain hosts the agent and shows up on the relay.",
         pitch:
-          "Buzz is an agent workspace on Nostr, and on the desktop an agent's body runs " <>
-            "on your laptop. Bind its identity to a Fountain agent instead and the body " <>
-            "runs here: it holds presence on the relay, answers a mention from a sandbox, " <>
-            "and its key stays in a vault Fountain signs with.",
+          "Run a Buzz identity on Fountain instead of your laptop. It holds presence on " <>
+            "the relay, answers a mention from its sandbox and keeps its signing key on " <>
+            "the server.",
         docs: "/docs/integrations/buzz",
         docs_label: "Buzz on Fountain",
         works_with: [
@@ -574,13 +642,22 @@ defmodule FountainWeb.MarketingHTML do
     ]
   end
 
-  @doc "What runs inside a conversation, grouped for the page's second section."
+  @doc "The interfaces a client uses to start and follow an agent."
+  def client_protocols, do: Enum.filter(protocols(), &(&1.kind == :client))
+
+  @doc "The protocol an agent uses to reach its tools."
+  def tool_protocol, do: Enum.find(protocols(), &(&1.kind == :tool))
+
+  @doc "The integration where Fountain brings the agent to another network."
+  def outbound_protocol, do: Enum.find(protocols(), &(&1.kind == :outbound))
+
+  @doc "What runs behind an integration, split into choices the developer makes."
   def inside do
     [
       %{
         title: "Runtimes",
         blurb:
-          "The coding agent the sandbox runs. All four speak ACP to Fountain, so every surface above sees one shape.",
+          "Choose the coding agent the sandbox runs. Every client-facing interface sees the same shape.",
         items: [
           %{name: "Claude Code", slug: "claudecode"},
           %{name: "Codex", slug: "openai"},
@@ -589,9 +666,9 @@ defmodule FountainWeb.MarketingHTML do
         ]
       },
       %{
-        title: "Models",
+        title: "Model access",
         blurb:
-          "Bring your own key. Inference bills your account; Fountain never marks up a token.",
+          "Bring your own credentials. Your model provider bills you directly; Fountain never marks up tokens.",
         items: [
           %{name: "Anthropic", slug: "anthropic"},
           %{name: "OpenAI", slug: "openai"},
@@ -608,17 +685,6 @@ defmodule FountainWeb.MarketingHTML do
           %{name: "E2B", slug: nil},
           %{name: "Daytona", slug: nil},
           %{name: "Your own machine", slug: nil}
-        ]
-      },
-      %{
-        title: "Chat surfaces",
-        blurb:
-          "Where a person talks to the agent, through OpenClaw or Hermes on one side or a Buzz channel on the other.",
-        items: [
-          %{name: "Telegram", slug: "telegram"},
-          %{name: "Discord", slug: "discord"},
-          %{name: "Slack", slug: "slack"},
-          %{name: "Signal", slug: "signal"}
         ]
       }
     ]
@@ -664,7 +730,8 @@ defmodule FountainWeb.MarketingHTML do
         id: "react",
         have: "A React app",
         want: "An agent in the product, with a sandbox of its own behind the chat.",
-        how: "Point CopilotKit's AG-UI client at the agent's endpoint. No adapter, no proxy.",
+        how:
+          "Point CopilotKit's AG-UI client at the agent's endpoint with a user-scoped OAuth token. No server-side adapter.",
         lang: "ts",
         docs: "/docs/integrations/openbot",
         code: """
@@ -672,7 +739,7 @@ defmodule FountainWeb.MarketingHTML do
 
         const reviewer = new HttpAgent({
           url: "https://managoat.com/api/agui/<agent_id>",
-          headers: { Authorization: "Bearer ftn_..." },
+          headers: { Authorization: `Bearer ${userToken}` }, // from Sign in with Fountain
         });
         """
       },

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/integrations.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/integrations.html.heex
@@ -2,10 +2,10 @@
 <section class="max-w-5xl mx-auto px-6 py-20 text-center">
   <.eyebrow label="Integrations" class="mb-5" />
   <h1 class="text-4xl sm:text-5xl font-bold tracking-tight text-[var(--color-text-primary)] mb-5 leading-tight">
-    It speaks what your stack already speaks.
+    Start a coding agent from the tools you already use.
   </h1>
   <p class="text-lg sm:text-xl text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-10">
-    {Fountain.Brand.name()} answers AG-UI, the Agent Client Protocol, OpenAI chat completions and MCP, on top of its own REST API. So the editor, the chat app, the gateway or the framework you use today can start an agent on a sandbox with a URL and a key, and nothing to install on our side.
+    Connect your editor, chat app, gateway, framework or your own code to a coding agent on a ready sandbox. Use ACP, AG-UI, OpenAI-compatible chat completions or {Fountain.Brand.name()}'s REST API. The sandbox keeps its work between messages and costs nothing while parked.
   </p>
   <div class="flex flex-wrap gap-2 justify-center" data-role="protocol-chips">
     <a
@@ -19,148 +19,78 @@
   </div>
 </section>
 
-<%!-- Protocols --%>
-<section class="bg-[var(--color-bg-1)] border-y border-[var(--color-border)]">
-  <div class="max-w-5xl mx-auto px-6 py-16">
-    <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-3 text-center">
-      Six ways in, one agent behind them.
-    </h2>
-    <p class="text-center text-[var(--color-text-secondary)] max-w-xl mx-auto mb-12">
-      Each protocol is a translation of the same conversation. Whichever door a prompt comes through, the agent runs on a sandbox that parks between messages and wakes with its work intact.
-    </p>
-    <div class="space-y-6">
-      <article
-        :for={protocol <- protocols()}
-        id={protocol.id}
-        class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6 sm:p-8 scroll-mt-6"
-        data-role="protocol"
-      >
-        <div class="grid md:grid-cols-5 gap-8">
-          <div class="md:col-span-3">
-            <div class="flex flex-wrap items-baseline gap-x-3 gap-y-1 mb-1">
-              <h3 class="text-xl font-semibold text-[var(--color-text-primary)]">
-                {protocol.name}
-              </h3>
-              <span class="text-sm text-[var(--color-text-muted)]">{protocol.long}</span>
-            </div>
-            <code
-              class="inline-block mt-1 mb-4 text-xs text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1.5 py-0.5"
-              phx-no-format
-            >{protocol.surface}</code>
-            <p class="text-sm text-[var(--color-text-secondary)] leading-relaxed">
-              {protocol.pitch}
-            </p>
-            <p class="mt-3 text-xs text-[var(--color-text-muted)]">
-              {protocol.direction}
-            </p>
-            <a
-              href={protocol.docs}
-              class="inline-block mt-4 text-sm font-medium text-[var(--color-text-primary)] underline underline-offset-2 hover:text-[var(--color-brand)]"
-            >
-              {protocol.docs_label} →
-            </a>
-          </div>
-          <div class="md:col-span-2">
-            <p class="text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)] mb-3">
-              Speaks it
-            </p>
-            <ul class="space-y-2">
-              <li
-                :for={item <- protocol.works_with}
-                class="flex items-start gap-2.5 text-sm"
-                data-role="works-with"
-              >
-                <span class="mt-0.5 flex-shrink-0 text-[var(--color-text-primary)]">
-                  <.mark name={item.name} slug={item.slug} class="size-4" />
-                </span>
-                <span>
-                  <span class="font-medium text-[var(--color-text-primary)]">{item.name}</span>
-                  <span class="text-[var(--color-text-muted)]">· {item.note}</span>
-                </span>
-              </li>
-            </ul>
-          </div>
-        </div>
-      </article>
-    </div>
-  </div>
-</section>
-
 <%!-- Scenarios --%>
-<section class="max-w-5xl mx-auto px-6 py-16">
-  <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-3 text-center">
-    Start from what you have.
-  </h2>
-  <p class="text-center text-[var(--color-text-secondary)] max-w-xl mx-auto mb-12">
-    Six shapes of builder, and the few lines each one needs. Every snippet runs against the hosted instance or your own.
-  </p>
-  <div class="grid md:grid-cols-2 gap-6">
-    <div
-      :for={scenario <- scenarios()}
-      class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6 flex flex-col"
-      data-role="scenario"
-    >
-      <p class="text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)]">
-        You have
-      </p>
-      <h3 class="mt-1 font-semibold text-[var(--color-text-primary)]">{scenario.have}</h3>
-      <p class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">
-        <span class="font-medium text-[var(--color-text-primary)]">You want</span> {scenario.want}
-      </p>
-      <p class="mt-1 text-sm text-[var(--color-text-secondary)] leading-relaxed">
-        <span class="font-medium text-[var(--color-text-primary)]">How</span> {scenario.how}
-      </p>
-      <pre
-        class="mt-4 flex-1 rounded-lg border border-[var(--color-border)] bg-[var(--color-code-bg)] text-[var(--color-code-text)] p-4 text-xs leading-relaxed overflow-x-auto"
-        phx-no-format
-      ><code>{scenario.code}</code></pre>
-      <a
-        href={scenario.docs}
-        class="mt-4 text-sm font-medium text-[var(--color-text-primary)] underline underline-offset-2 hover:text-[var(--color-brand)]"
-      >
-        Read the guide →
-      </a>
-    </div>
-  </div>
-</section>
-
-<%!-- Inside --%>
 <section class="bg-[var(--color-bg-1)] border-y border-[var(--color-border)]">
   <div class="max-w-5xl mx-auto px-6 py-16">
     <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-3 text-center">
-      What runs behind the door.
+      Start from what you have.
     </h2>
     <p class="text-center text-[var(--color-text-secondary)] max-w-xl mx-auto mb-12">
-      The agent, its model, its machine, and the people it talks to. Pick each one; none of them changes the protocols above.
+      Choose the starting point that matches your stack. Each example works with the hosted service or an instance you run yourself.
     </p>
-    <div class="grid sm:grid-cols-2 lg:grid-cols-4 gap-6">
+    <div class="grid md:grid-cols-2 gap-6">
       <div
-        :for={group <- inside()}
-        class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6"
-        data-role="inside"
+        :for={scenario <- scenarios()}
+        class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6 flex flex-col"
+        data-role="scenario"
       >
-        <h3 class="font-semibold text-[var(--color-text-primary)]">{group.title}</h3>
-        <p class="mt-2 text-xs text-[var(--color-text-muted)] leading-relaxed">{group.blurb}</p>
-        <ul class="mt-4 space-y-2">
-          <li
-            :for={item <- group.items}
-            class="flex items-center gap-2.5 text-sm text-[var(--color-text-primary)]"
-          >
-            <.mark name={item.name} slug={item.slug} class="size-4" />
-            <span>{item.name}</span>
-          </li>
-        </ul>
+        <p class="text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)]">
+          You have
+        </p>
+        <h3 class="mt-1 font-semibold text-[var(--color-text-primary)]">{scenario.have}</h3>
+        <p class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">
+          <span class="font-medium text-[var(--color-text-primary)]">You want</span> {scenario.want}
+        </p>
+        <p class="mt-1 text-sm text-[var(--color-text-secondary)] leading-relaxed">
+          <span class="font-medium text-[var(--color-text-primary)]">How</span> {scenario.how}
+        </p>
+        <pre
+          class="mt-4 flex-1 rounded-lg border border-[var(--color-border)] bg-[var(--color-code-bg)] text-[var(--color-code-text)] p-4 text-xs leading-relaxed overflow-x-auto"
+          phx-no-format
+        ><code>{scenario.code}</code></pre>
+        <a
+          href={scenario.docs}
+          class="mt-4 text-sm font-medium text-[var(--color-text-primary)] underline underline-offset-2 hover:text-[var(--color-brand)]"
+        >
+          Read the guide →
+        </a>
       </div>
     </div>
+  </div>
+</section>
+
+<%!-- Client protocols --%>
+<section class="max-w-5xl mx-auto px-6 py-16">
+  <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-3 text-center">
+    Connect to the same agent four ways.
+  </h2>
+  <p class="text-center text-[var(--color-text-secondary)] max-w-xl mx-auto mb-12">
+    Whether a prompt starts in an editor, a chat app or your code, {Fountain.Brand.name()} runs the agent in its sandbox. The machine parks between messages and wakes with its files and work intact.
+  </p>
+  <div class="space-y-6">
+    <.protocol_card :for={protocol <- client_protocols()} protocol={protocol} />
+  </div>
+</section>
+
+<%!-- Tools --%>
+<section class="bg-[var(--color-bg-1)] border-y border-[var(--color-border)]">
+  <div class="max-w-5xl mx-auto px-6 py-16">
+    <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-3 text-center">
+      Give the agent the tools it needs.
+    </h2>
+    <p class="text-center text-[var(--color-text-secondary)] max-w-xl mx-auto mb-12">
+      MCP servers and service credentials stay separate from the client that started the run.
+    </p>
+    <.protocol_card protocol={tool_protocol()} works_label="Connects to" />
 
     <%!-- The broker presets: names read from the catalog the console offers,
           so the page never claims a service the broker cannot bind. --%>
     <div class="mt-12 max-w-3xl mx-auto text-center" data-role="brokered">
       <h3 class="text-lg font-semibold text-[var(--color-text-primary)]">
-        Credentials the agent uses and never holds.
+        Keep service credentials out of the sandbox.
       </h3>
       <p class="mt-2 text-sm text-[var(--color-text-secondary)]">
-        The egress broker attaches a real credential to a request on its way out, so the sandbox, the prompt and the transcript see a placeholder. A preset for each of these, and a custom binding for anything else.
+        On hosted accounts with the egress broker enabled, {Fountain.Brand.name()} replaces each bound credential with a placeholder inside the sandbox and attaches the real value only to matching outbound requests. Use a preset below or add a custom binding.
       </p>
       <ul class="mt-6 flex flex-wrap justify-center gap-2">
         <li
@@ -175,13 +105,55 @@
   </div>
 </section>
 
+<%!-- Inside --%>
+<section class="max-w-5xl mx-auto px-6 py-16">
+  <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-3 text-center">
+    Choose what runs behind the integration.
+  </h2>
+  <p class="text-center text-[var(--color-text-secondary)] max-w-xl mx-auto mb-12">
+    Pick the coding agent, model access and sandbox separately. The client-facing interfaces stay the same.
+  </p>
+  <div class="grid sm:grid-cols-3 gap-6">
+    <div
+      :for={group <- inside()}
+      class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6"
+      data-role="inside"
+    >
+      <h3 class="font-semibold text-[var(--color-text-primary)]">{group.title}</h3>
+      <p class="mt-2 text-xs text-[var(--color-text-muted)] leading-relaxed">{group.blurb}</p>
+      <ul class="mt-4 space-y-2">
+        <li
+          :for={item <- group.items}
+          class="flex items-center gap-2.5 text-sm text-[var(--color-text-primary)]"
+        >
+          <.mark name={item.name} slug={item.slug} class="size-4" />
+          <span>{item.name}</span>
+        </li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<%!-- Outbound --%>
+<section class="bg-[var(--color-bg-1)] border-y border-[var(--color-border)]">
+  <div class="max-w-5xl mx-auto px-6 py-16">
+    <h2 class="text-2xl font-semibold text-[var(--color-text-primary)] mb-3 text-center">
+      Put the agent on a Nostr relay.
+    </h2>
+    <p class="text-center text-[var(--color-text-secondary)] max-w-xl mx-auto mb-12">
+      Buzz runs in the other direction. {Fountain.Brand.name()} hosts the agent and brings its identity to the relay.
+    </p>
+    <.protocol_card protocol={outbound_protocol()} works_label="Shows up in" />
+  </div>
+</section>
+
 <%!-- Footer CTA --%>
 <section class="max-w-5xl mx-auto px-6 py-20 text-center">
   <h2 class="text-2xl sm:text-3xl font-bold text-[var(--color-text-primary)] mb-4">
-    Something of yours not on the list?
+    Haven't found your tool?
   </h2>
   <p class="text-[var(--color-text-secondary)] mb-8 max-w-lg mx-auto">
-    If it takes a base URL, spawns a command, or renders AG-UI, it already works. If it does neither, the REST API is the whole product and the SDK is one import away.
+    If it accepts an OpenAI-compatible base URL, launches an ACP agent or hosts AG-UI, it can connect directly. Otherwise, build against {Fountain.Brand.name()}'s REST API or TypeScript SDK.
   </p>
   <div class="flex flex-col sm:flex-row gap-3 justify-center">
     <a
@@ -194,10 +166,10 @@
       href={~p"/docs/integrations/clients"}
       class="inline-flex items-center justify-center px-6 py-3 rounded-lg border border-[var(--color-border)] text-[var(--color-text-primary)] font-medium hover:bg-[var(--color-bg-2)] transition-colors text-sm"
     >
-      Every client, in the manual
+      Browse integration guides
     </a>
   </div>
   <p class="mt-8 text-xs text-[var(--color-text-muted)] max-w-xl mx-auto">
-    Product names and marks belong to their owners and name what the protocol reaches; none of them endorses {Fountain.Brand.name()}. Marked "verified" where we ran it end to end; the rest speak the protocol by their own documentation.
+    Names and marks belong to their owners. "Verified" means we tested the integration end to end; other compatibility is based on each project's protocol documentation.
   </p>
 </section>

--- a/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
@@ -66,10 +66,20 @@ defmodule FountainWeb.MarketingControllerTest do
   end
 
   describe "GET /integrations" do
-    test "renders every protocol and what speaks it", %{conn: conn} do
+    test "renders every integration around the reader's starting point", %{conn: conn} do
       body = conn |> get(~p"/integrations") |> html_response(200)
 
-      assert body =~ "It speaks what your stack already speaks."
+      assert body =~ "Start a coding agent from the tools you already use."
+      assert body =~ "Start from what you have."
+      assert body =~ "Connect to the same agent four ways."
+      assert body =~ "Give the agent the tools it needs."
+      assert body =~ "Put the agent on a Nostr relay."
+
+      assert Enum.map(FountainWeb.MarketingHTML.client_protocols(), & &1.id) ==
+               ~w(agui acp openai api)
+
+      assert FountainWeb.MarketingHTML.tool_protocol().id == "mcp"
+      assert FountainWeb.MarketingHTML.outbound_protocol().id == "nostr"
 
       for name <- ~w(AG-UI ACP OpenAI-compatible MCP Nostr) do
         assert body =~ name, "missing protocol #{name}"
@@ -88,8 +98,8 @@ defmodule FountainWeb.MarketingControllerTest do
 
     test "carries its own card", %{conn: conn} do
       body = conn |> get(~p"/integrations") |> html_response(200)
-      assert body =~ ~s(<meta property="og:title" content="Integrations · Fountain")
-      assert body =~ ~s(<meta name="description" content="Fountain speaks AG-UI)
+      assert body =~ ~s(<meta property="og:title" content="Coding agent integrations · Fountain")
+      assert body =~ ~s(<meta name="description" content="Start a coding agent from your editor)
       assert body =~ ~s(<meta property="og:url" content="http://localhost:4000/integrations")
     end
 


### PR DESCRIPTION
## Summary
- lead with the reader starting point and move scenario cards above the protocol catalog
- separate client interfaces, agent tools, runtime choices, and the outbound Nostr integration
- tighten protocol, credential, CTA, and metadata copy while making the OpenAI-compatible alpha state visible
- use a user-scoped OAuth token in the React example

## Tests
- mix format --check-formatted
- mix test apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs apps/fountain/test/fountain_web/controllers/marketing_instance_test.exs apps/fountain/test/fountain_web/paper_skin_test.exs