### PR TITLE
Lead integrations with managed machines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,14 @@ upgrade, is in
   rather than to one runner. See ADR 0036.
 
 ### Changed
+- **The integrations page leads with the managed machine and the work-only
+  meter.** Its hero now treats editors, chat apps, gateways, frameworks and
+  code as ways into Fountain rather than the product itself. The machine is
+  provisioned, preserves its work and parks between turns, so the reader sees
+  the two differences in the first screen: there is no machine to manage and
+  no idle time to pay for. Registration and integration-guide actions now sit
+  beside that promise instead of appearing only at the bottom of the page.
+
 - **The homepage case study distinguishes investigation from resolution.** The
   pager still reaches an on-call engineer while an agent investigates in
   parallel, and the copy now says that a pull request follows only when the

--- a/apps/fountain/lib/fountain_web/controllers/marketing_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_controller.ex
@@ -74,9 +74,8 @@ defmodule FountainWeb.MarketingController do
         layout: {FountainWeb.Layouts, :marketing},
         page_title: "Coding agent integrations · #{Fountain.Brand.name()}",
         meta_description:
-          "Start a coding agent from your editor, chat app, gateway, framework " <>
-            "or code. #{Fountain.Brand.name()} connects over ACP, AG-UI, OpenAI-compatible " <>
-            "chat completions, MCP and its REST API."
+          "Run coding agents from your editor, chat app, framework, gateway or code. " <>
+            "#{Fountain.Brand.name()} manages ready sandboxes and charges only while agents work."
       )
     else
       redirect(conn, to: ~p"/docs/integrations/clients")

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/integrations.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/integrations.html.heex
@@ -2,11 +2,25 @@
 <section class="max-w-5xl mx-auto px-6 py-20 text-center">
   <.eyebrow label="Integrations" class="mb-5" />
   <h1 class="text-4xl sm:text-5xl font-bold tracking-tight text-[var(--color-text-primary)] mb-5 leading-tight">
-    Start a coding agent from the tools you already use.
+    Your tools start the agent. {Fountain.Brand.name()} runs the machine.
   </h1>
   <p class="text-lg sm:text-xl text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-10">
-    Connect your editor, chat app, gateway, framework or your own code to a coding agent on a ready sandbox. Use ACP, AG-UI, OpenAI-compatible chat completions or {Fountain.Brand.name()}'s REST API. The sandbox keeps its work between messages and costs nothing while parked.
+    Connect your editor, chat app, gateway, framework or code to a coding agent on a ready sandbox. {Fountain.Brand.name()} provisions the machine, preserves its work between messages and parks it when the agent stops. No machine to manage. No idle time to pay for.
   </p>
+  <div class="flex flex-col sm:flex-row gap-3 justify-center mb-8">
+    <a
+      href={~p"/auth/register"}
+      class="inline-flex items-center justify-center px-6 py-3 rounded-lg bg-[var(--color-brand)] text-white font-medium hover:bg-[var(--color-brand-hover)] transition-colors text-sm shadow-sm"
+    >
+      Run your first agent free
+    </a>
+    <a
+      href={~p"/docs/integrations/clients"}
+      class="inline-flex items-center justify-center px-6 py-3 rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-bg-1)] text-[var(--color-text-primary)] font-medium hover:bg-[var(--color-bg-2)] transition-colors text-sm"
+    >
+      Browse integration guides
+    </a>
+  </div>
   <div class="flex flex-wrap gap-2 justify-center" data-role="protocol-chips">
     <a
       :for={protocol <- protocols()}

--- a/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
@@ -69,7 +69,10 @@ defmodule FountainWeb.MarketingControllerTest do
     test "renders every integration around the reader's starting point", %{conn: conn} do
       body = conn |> get(~p"/integrations") |> html_response(200)
 
-      assert body =~ "Start a coding agent from the tools you already use."
+      assert body =~ "Your tools start the agent. Fountain runs the machine."
+      assert body =~ "No machine to manage. No idle time to pay for."
+      assert body =~ "Run your first agent free"
+      assert body =~ "Browse integration guides"
       assert body =~ "Start from what you have."
       assert body =~ "Connect to the same agent four ways."
       assert body =~ "Give the agent the tools it needs."
@@ -99,7 +102,7 @@ defmodule FountainWeb.MarketingControllerTest do
     test "carries its own card", %{conn: conn} do
       body = conn |> get(~p"/integrations") |> html_response(200)
       assert body =~ ~s(<meta property="og:title" content="Coding agent integrations · Fountain")
-      assert body =~ ~s(<meta name="description" content="Start a coding agent from your editor)
+      assert body =~ ~s(<meta name="description" content="Run coding agents from your editor)
       assert body =~ ~s(<meta property="og:url" content="http://localhost:4000/integrations")
     end
 


### PR DESCRIPTION
## Summary

- reposition the integrations hero around Fountain managing the machine beneath the agent
- make zero idle-time cost explicit and add signup/docs actions above the protocol navigation
- align page metadata, regression assertions, and the changelog with the new promise

## Test plan

- mix format --check-formatted apps/fountain/lib/fountain_web/controllers/marketing_controller.ex apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs apps/fountain/lib/fountain_web/controllers/marketing_html/integrations.html.heex
- mix test apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs (64 tests, 0 failures)