### PR TITLE
design(marketing): lead with alert verdict time

### DIFF
--- a/.agents/product-marketing.md
+++ b/.agents/product-marketing.md
@@ -273,6 +273,8 @@ fail the gate in a manual, and that is by design.
 **Metrics:** The only sourced numbers are the case study's, counted on one
 production cluster over a stated window (11 to 25 August 2026) and held as
 literals in `marketing_html.ex` so they cannot quietly widen their own window.
+Lead the aggregate proof with the 7.5 minute median alert-to-verdict time. The
+alert and pull-request counts support that result rather than compete with it.
 78 alerts investigated by an agent; 4m 27s from alert to open pull request on
 the worked incident; 7.5 minute median alert to verdict; 0 cluster credentials
 the agent holds. Twelve fix pull requests opened, eight merged, four of those a
@@ -325,6 +327,7 @@ reader into someone who has seen the primitives compose.
 
 ## Changelog
 *Newest first. One line per revision: what changed and why.*
+- v6 (2026-08-29) — Proof hierarchy pass: lead the aggregate case with median alert-to-verdict time and make the alert and pull-request counts supporting evidence.
 - v5 (2026-08-29) — Case-study clarity pass: report alerts rather than incidents, show the full pull-request funnel, and describe the outcome as alert to pull request rather than self-healing.
 - v4 (2026-08-29) — Self-hosted clarity pass: lead with ownership, put the ownership decision before installation detail, and frame open-source apps as examples rather than customer proof.
 - v3 (2026-08-29) — Homepage clarity pass: lead with coding agents and the work-only meter, put production proof before implementation detail, and remove customer-shaped proof language.

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
@@ -1543,35 +1543,45 @@ defmodule FountainWeb.MarketingHTML do
   @doc "The window every number on the case study covers."
   def case_window, do: "11 to 25 August 2026"
 
-  @doc "The four headline numbers, counted over `case_window/0`."
+  @doc "The lead result and its three supporting numbers, counted over `case_window/0`."
   def case_stats do
     [
+      %{
+        value: "7.5 min",
+        label: "median alert-to-verdict time",
+        home_label: "median alert-to-verdict time",
+        note: "The longest investigation ran 50 minutes.",
+        emphasis: :lead
+      },
       %{
         value: "78",
         label: "alerts investigated by an agent",
         home_label: "alerts investigated",
-        note: "Fifteen days, one cluster, one runbook."
+        note: "Fifteen days, one cluster, one runbook.",
+        emphasis: :supporting
       },
       %{
         value: "12",
         label: "fix pull requests opened",
         home_label: "fix pull requests opened",
-        note: "Four came from the same planned rehearsal fault."
+        note: "Four came from the same planned rehearsal fault.",
+        emphasis: :supporting
       },
       %{
         value: "8",
         label: "fix pull requests merged",
         home_label: "fix pull requests merged",
-        note: "The agent could neither approve nor merge."
-      },
-      %{
-        value: "7.5 min",
-        label: "median alert-to-verdict time",
-        home_label: "median alert-to-verdict time",
-        note: "The longest investigation ran 50 minutes."
+        note: "The agent could neither approve nor merge.",
+        emphasis: :supporting
       }
     ]
   end
+
+  @doc "The result the case study leads with."
+  def case_lead_stat, do: Enum.find(case_stats(), &(&1.emphasis == :lead))
+
+  @doc "The counts that support the lead result."
+  def case_supporting_stats, do: Enum.filter(case_stats(), &(&1.emphasis == :supporting))
 
   @doc "The two observed intervals around the case study's human handoff."
   def case_handoff_metrics do

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/case_study_self_healing.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/case_study_self_healing.html.heex
@@ -30,13 +30,37 @@
 <%!-- The numbers, counted once over a stated window (see case_window/0). --%>
 <section class="bg-[var(--color-bg-1)] border-y border-[var(--color-border)]">
   <div class="max-w-5xl mx-auto px-6 py-16">
-    <div class="grid sm:grid-cols-2 lg:grid-cols-4 gap-6">
-      <div :for={stat <- case_stats()} data-role="case-stat">
-        <p class="text-3xl font-semibold text-[var(--color-text-primary)]" data-role="figure">
-          {stat.value}
+    <div class="grid gap-10 md:grid-cols-[minmax(0,1.15fr)_minmax(0,1fr)] md:items-center md:gap-14">
+      <% lead_stat = case_lead_stat() %>
+      <div data-role="case-stat" data-emphasis="lead">
+        <p
+          class="text-5xl sm:text-6xl font-semibold tracking-tight text-[var(--color-text-primary)]"
+          data-role="figure"
+        >
+          {lead_stat.value}
         </p>
-        <p class="mt-1 text-sm font-medium text-[var(--color-text-primary)]">{stat.label}</p>
-        <p class="mt-2 text-xs text-[var(--color-text-muted)] leading-relaxed">{stat.note}</p>
+        <p class="mt-2 text-base font-medium text-[var(--color-text-primary)]">
+          {lead_stat.label}
+        </p>
+        <p class="mt-3 text-sm text-[var(--color-text-muted)] leading-relaxed">
+          {lead_stat.note}
+        </p>
+      </div>
+      <div class="border-t border-[var(--color-border)] md:border-l md:border-t-0 md:pl-10">
+        <div
+          :for={stat <- case_supporting_stats()}
+          class="grid grid-cols-[4rem_1fr] gap-5 border-b border-[var(--color-border)] py-4 last:border-b-0 first:pt-0 md:first:pt-4"
+          data-role="case-stat"
+          data-emphasis="supporting"
+        >
+          <p class="text-2xl font-semibold text-[var(--color-text-primary)]" data-role="figure">
+            {stat.value}
+          </p>
+          <div>
+            <p class="text-sm font-medium text-[var(--color-text-primary)]">{stat.label}</p>
+            <p class="mt-1 text-xs text-[var(--color-text-muted)] leading-relaxed">{stat.note}</p>
+          </div>
+        </div>
       </div>
     </div>
     <p class="mt-8 text-center text-xs text-[var(--color-text-muted)]">

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -97,19 +97,41 @@
     <p class="mt-4 text-[var(--color-text-secondary)] max-w-2xl leading-relaxed">
       When a workload breaks, this Kubernetes cluster pages an on-call engineer and starts an agent at the same time. The agent investigates the alert and, when it finds a repository fix, opens one focused pull request. It never holds cluster credentials. A person decides whether to merge.
     </p>
-    <dl class="mt-10 grid grid-cols-2 gap-x-8 gap-y-8 sm:grid-cols-4 sm:gap-x-6">
-      <div :for={stat <- case_stats()}>
+    <div class="mt-10 grid gap-8 sm:grid-cols-[minmax(0,1.15fr)_minmax(0,1fr)] sm:items-center sm:gap-10">
+      <% lead_stat = case_lead_stat() %>
+      <dl data-role="case-stat" data-emphasis="lead">
         <dt
-          class="text-3xl sm:text-4xl font-semibold tracking-tight text-[var(--color-text-primary)]"
+          class="text-5xl sm:text-6xl font-semibold tracking-tight text-[var(--color-text-primary)]"
           data-role="figure"
         >
-          {stat.value}
+          {lead_stat.value}
         </dt>
-        <dd class="mt-1.5 text-xs leading-snug text-[var(--color-accent-ink)]">
-          {stat.home_label}
+        <dd class="mt-2 text-sm font-medium leading-snug text-[var(--color-text-primary)]">
+          {lead_stat.home_label}
         </dd>
-      </div>
-    </dl>
+        <dd class="mt-2 text-xs leading-relaxed text-[var(--color-accent-ink)]">
+          {lead_stat.note}
+        </dd>
+      </dl>
+      <dl class="border-t border-[var(--color-accent-line)] sm:border-l sm:border-t-0 sm:pl-8">
+        <div
+          :for={stat <- case_supporting_stats()}
+          class="grid grid-cols-[3.5rem_1fr] gap-4 border-b border-[var(--color-accent-line)] py-4 last:border-b-0 first:pt-0 sm:first:pt-4"
+          data-role="case-stat"
+          data-emphasis="supporting"
+        >
+          <dt
+            class="text-2xl font-semibold tracking-tight text-[var(--color-text-primary)]"
+            data-role="figure"
+          >
+            {stat.value}
+          </dt>
+          <dd class="self-center text-xs leading-snug text-[var(--color-accent-ink)]">
+            {stat.home_label}
+          </dd>
+        </div>
+      </dl>
+    </div>
     <p class="mt-8 max-w-2xl text-xs text-[var(--color-text-secondary)]">
       Measured from {case_window()} on one Kubernetes cluster running live production workloads. Numbers reported by the cluster administrator (us).
     </p>

--- a/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
@@ -642,6 +642,26 @@ defmodule FountainWeb.MarketingControllerTest do
       assert body =~ FountainWeb.MarketingHTML.case_window()
     end
 
+    test "the median is the lead figure and the counts support it", %{conn: conn} do
+      lead = FountainWeb.MarketingHTML.case_lead_stat()
+      supporting = FountainWeb.MarketingHTML.case_supporting_stats()
+
+      assert lead.value == "7.5 min"
+      assert length(supporting) == 3
+      assert Enum.all?(supporting, &(&1.emphasis == :supporting))
+
+      for path <- [~p"/", ~p"/case-studies/self-healing-infrastructure"] do
+        body = conn |> get(path) |> html_response(200)
+
+        assert length(Regex.scan(~r/data-emphasis="lead"/, body)) == 1
+        assert length(Regex.scan(~r/data-emphasis="supporting"/, body)) == 3
+
+        {lead_at, _} = :binary.match(body, ~s(data-emphasis="lead"))
+        {supporting_at, _} = :binary.match(body, ~s(data-emphasis="supporting"))
+        assert lead_at < supporting_at
+      end
+    end
+
     test "carries its own card", %{conn: conn} do
       body = conn |> get(~p"/case-studies/self-healing-infrastructure") |> html_response(200)
 


### PR DESCRIPTION
## Summary

- make the 7.5 minute median alert-to-verdict result the lead case-study metric
- render alert and pull-request counts as supporting evidence on the case study and homepage card
- encode and test the shared metric hierarchy, and document it in the marketing guidance

## Validation

- mix test apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
- 65 tests, 0 failures
- mix format --check-formatted on changed Elixir and HEEx files
- git diff --check