### PR TITLE
copy(marketing): clarify launch backend boundaries

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/launch.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/launch.html.heex
@@ -303,15 +303,15 @@
         Persistence depends on the backend.
       </dt>
       <dd class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">
-        A provider without suspend support destroys an idle sandbox. The transcript survives, but the runtime starts fresh.
+        All four built-in backends support it: Sprites, E2B and Daytona park the sandbox, and a self-hosted runner keeps its workspace. A third-party backend without suspend support destroys an idle sandbox; the transcript survives, but the runtime starts fresh.
       </dd>
     </div>
     <div class="border-l-2 border-[var(--color-border-strong)] pl-5">
       <dt class="font-medium text-[var(--color-text-primary)]">
-        A trusted runner is not a sandbox.
+        Runner trusted mode has no isolation.
       </dt>
       <dd class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">
-        The default self-hosted runner executes as you, with your network and tools. Use the Firecracker backend on Linux with KVM when you need a microVM boundary.
+        The default self-hosted runner gives each conversation its own home directory, but its processes run as you, with the host's network and tools. There is no VM, container or egress policy. Use it on a machine where you would hand the agent a shell, or run the Firecracker backend on Linux with KVM to put each sandbox in a microVM.
       </dd>
     </div>
   </dl>

--- a/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
@@ -70,7 +70,10 @@ defmodule FountainWeb.MarketingControllerTest do
 
       assert body =~ "Know the boundary before you build on it."
       assert body =~ "The server is pre-1.0."
-      assert body =~ "A trusted runner is not a sandbox."
+      assert body =~ "All four built-in backends support it"
+      assert body =~ "Sprites, E2B and Daytona park the sandbox"
+      assert body =~ "Runner trusted mode has no isolation."
+      assert body =~ "There is no VM, container or egress policy."
     end
 
     test "uses the case-study figures with their provenance", %{conn: conn} do


### PR DESCRIPTION
## Summary

- name the four built-in backends that preserve workspace state
- explain that runner trusted mode has no VM, container, or egress isolation
- point readers to Firecracker when they need a microVM boundary

## Test plan

- mix format --check-formatted apps/fountain/lib/fountain_web/controllers/marketing_html/launch.html.heex apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
- mix test apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs (69 tests, 0 failures)