### PR TITLE
Orient the root-cause quote before it begins

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/case_study_self_healing.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/case_study_self_healing.html.heex
@@ -105,6 +105,9 @@
   <%!-- The agent's own words. Quoted verbatim from the pull request body,
         so the reader judges the diagnosis rather than our summary of it. --%>
   <figure class="max-w-3xl mx-auto mt-4" data-role="case-quote">
+    <figcaption class="mb-3 text-xs text-[var(--color-text-muted)]">
+      The agent's root-cause paragraph, quoted from the pull request it opened at 07:02. The gap had sat there for months unalerted, because no commit had moved a lockfile until that week.
+    </figcaption>
     <blockquote class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-0)] p-6 text-sm text-[var(--color-text-secondary)] leading-relaxed">
       <span :for={part <- case_quote()}>
         <%= case part do %>
@@ -118,9 +121,6 @@
         <% end %>
       </span>
     </blockquote>
-    <figcaption class="mt-3 text-xs text-[var(--color-text-muted)]">
-      The agent's root-cause paragraph, quoted from the pull request it opened at 07:02. The gap had sat there for months unalerted, because no commit had moved a lockfile until that week.
-    </figcaption>
   </figure>
 </section>
 

--- a/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
@@ -694,6 +694,11 @@ defmodule FountainWeb.MarketingControllerTest do
       assert body =~ "The sandbox has no kubectl and no kubeconfig."
       assert body =~ "install_members()"
 
+      # Orient the reader before presenting the agent's verbatim diagnosis.
+      {quote_context_at, _} = :binary.match(body, "The agent's root-cause paragraph")
+      {root_cause_at, _} = :binary.match(body, "Both modes call")
+      assert quote_context_at < root_cause_at
+
       # The incident is told with its own timestamps, not rounded prose.
       for event <- FountainWeb.MarketingHTML.case_timeline() do
         assert body =~ event.time, "missing timeline entry #{event.time}"


### PR DESCRIPTION
## Summary
- move the root-cause explanation above the quoted diagnosis
- preserve the existing copy and visual treatment
- assert that the explanation renders before the diagnosis

## Testing
- mix format --check-formatted apps/fountain/lib/fountain_web/controllers/marketing_html/case_study_self_healing.html.heex apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
- mix test apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs