### PR TITLE
fix(acp): stop session metadata opening phantom autonomous turns (#1300)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -425,6 +425,25 @@ upgrade, is in
   leaks nothing by sitting there, but a live-looking secrets artifact in the
   repo root implies a workflow that does not exist.
 
+### Fixed
+
+- **The session title no longer opens a phantom "(background task follow-up)"
+  turn after every claude turn** (#1300). The claude adapter generates the
+  session title asynchronously and writes its `session_info_update` about a
+  second after the prompt response — out of turn — and the server read any
+  out-of-turn protocol line as a background task narrating a follow-up (#817).
+  So nearly every claude turn was followed by a synthetic autonomous turn
+  holding the conversation `running` for the full ten-minute quiet window:
+  a phantom user bubble in the transcript, idle park deferred, and the window
+  billed as turn time. On the hosted instance, 167 of the 190 autonomous turns
+  in the fourteen days before the fix held exactly one such line and nothing
+  else. Session metadata (`session_info_update`, `available_commands_update`,
+  `current_mode_update`) is now classified as describing the session rather
+  than the agent talking: it opens no autonomous turn, does not extend one
+  already open, and still lands on the transcript when a real turn is in
+  flight. Real background follow-ups — updates that carry agent output or
+  tool calls — behave exactly as before.
+
 ## [0.14.0] — 2026-08-25
 
 ### Upgrade notes

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -2211,12 +2211,28 @@ defmodule Fountain.Conversations.ConversationServer do
   # follow-up. That opens an autonomous turn — a real row, so the log budget,
   # redaction and the stage events apply unchanged — and every further line
   # re-arms the quiet timer that closes it if no `cycle_end` ever does.
+  #
+  # Session *metadata* is the exception (#1300). The claude adapter writes its
+  # `session_info_update` (the generated title) about a second after every
+  # prompt response — out of turn — and reading that as a background follow-up
+  # opened a phantom autonomous turn after nearly every turn, held open for
+  # the full quiet window: `running` status, deferred idle park, billed turn
+  # time. Metadata is nothing the agent did, so it opens no turn and re-arms
+  # no quiet timer; with a turn in flight it still lands on the transcript.
   def handle_info({:acp, ref, {:lines, stream, data}}, %{current_command_ref: ref} = state) do
     cond do
       stream == "acp" and MapSet.member?(state.replay_dedup, data) ->
         # A replayed line we already hold (ACP reattach). Each persisted line
         # suppresses at most one arrival, so a legitimate later repeat survives.
         {:noreply, %{state | replay_dedup: MapSet.delete(state.replay_dedup, data)}}
+
+      stream == "acp" and Fountain.Runtimes.ACP.Protocol.session_metadata?(data) ->
+        if is_nil(state.current_turn) do
+          # No turn to attach it to, and not worth opening one: dropped.
+          {:noreply, state}
+        else
+          {:noreply, persist_acp_lines(state, stream, data)}
+        end
 
       stream == "acp" and is_nil(state.current_turn) ->
         state = open_autonomous_turn(state)

--- a/apps/fountain/lib/fountain/runtimes/acp/protocol.ex
+++ b/apps/fountain/lib/fountain/runtimes/acp/protocol.ex
@@ -67,6 +67,33 @@ defmodule Fountain.Runtimes.ACP.Protocol do
     end
   end
 
+  # `sessionUpdate` kinds that describe the *session* rather than anything the
+  # agent did: the generated title, the slash-command list, the current mode.
+  @metadata_updates ~w(session_info_update available_commands_update current_mode_update)
+
+  @doc """
+  Whether this line is a `session/update` carrying session metadata rather
+  than agent activity.
+
+  The claude adapter generates the session title asynchronously and writes the
+  `session_info_update` about a second *after* the prompt response — out of
+  turn. Metadata is nothing the agent said or ran, so it must not be read as
+  "the agent is talking out of turn": it opens no autonomous turn and holds
+  none open (#1300). Exposed for `ConversationServer`, which classifies the
+  peer's reported lines.
+  """
+  @spec session_metadata?(String.t()) :: boolean()
+  def session_metadata?(line) when is_binary(line) do
+    case classify_line(line) do
+      {:notification, "session/update", params} ->
+        update = Map.get(params, "update") || %{}
+        Map.get(update, "sessionUpdate") in @metadata_updates
+
+      _ ->
+        false
+    end
+  end
+
   @doc "Classify a decoded JSON-RPC object."
   @spec classify(map()) :: message()
   def classify(%{"id" => id, "result" => result}), do: {:response, id, result}

--- a/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
@@ -374,6 +374,74 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
       assert Enum.any?(turns, &(&1.origin == "autonomous" and &1.status == "completed"))
     end
 
+    test "an out-of-turn session_info_update opens no autonomous turn (#1300)", %{
+      conv: conv,
+      pid: pid,
+      ref: ref
+    } do
+      prompt_id = drive_to_prompt(pid, ref)
+      reply(pid, ref, prompt_id, %{"stopReason" => "end_turn"})
+      assert is_nil(:sys.get_state(pid).current_turn)
+
+      # The claude adapter writes the generated session title about a second
+      # after every prompt response — session metadata, not the agent talking.
+      notify(pid, ref, %{
+        "sessionUpdate" => "session_info_update",
+        "title" => "Research Xfinity internet promotion pricing",
+        "updatedAt" => "2026-08-25T12:05:48.620Z"
+      })
+
+      assert is_nil(:sys.get_state(pid).current_turn)
+      assert Conversations._unsafe_get_conversation!(conv.id).status == "idle"
+      assert [%{origin: "user"}] = Conversations._unsafe_list_turns(conv.id)
+
+      # With no turn to attach it to, the line is dropped, not persisted.
+      refute Enum.any?(
+               Conversations._unsafe_list_log_events(conv.id),
+               &(&1.data =~ "session_info_update")
+             )
+    end
+
+    test "session metadata mid-turn still lands on the transcript (#1300)", %{
+      conv: conv,
+      pid: pid,
+      ref: ref
+    } do
+      prompt_id = drive_to_prompt(pid, ref)
+
+      notify(pid, ref, %{"sessionUpdate" => "session_info_update", "title" => "Early title"})
+
+      assert Enum.any?(
+               Conversations._unsafe_list_log_events(conv.id),
+               &(&1.stream == "acp" and &1.data =~ "session_info_update")
+             )
+
+      reply(pid, ref, prompt_id, %{"stopReason" => "end_turn"})
+      assert [%{origin: "user", status: "completed"}] = Conversations._unsafe_list_turns(conv.id)
+    end
+
+    test "metadata does not re-arm the quiet timer holding an autonomous turn open (#1300)", %{
+      pid: pid,
+      ref: ref
+    } do
+      prompt_id = drive_to_prompt(pid, ref)
+      reply(pid, ref, prompt_id, %{"stopReason" => "end_turn"})
+
+      # A real background narration opens the turn and arms the quiet timer.
+      notify(pid, ref, %{"sessionUpdate" => "agent_message_chunk", "text" => "CI passed"})
+      %{current_turn: %{origin: "autonomous"}, autonomous_quiet: timer} = :sys.get_state(pid)
+      assert is_reference(timer)
+
+      # A title update mid-cycle persists into the open turn but must not
+      # extend its life: the same timer is still the one running.
+      notify(pid, ref, %{"sessionUpdate" => "session_info_update", "title" => "t"})
+      assert :sys.get_state(pid).autonomous_quiet == timer
+
+      # A further narration line does re-arm.
+      notify(pid, ref, %{"sessionUpdate" => "agent_message_chunk", "text" => "and deployed"})
+      refute :sys.get_state(pid).autonomous_quiet == timer
+    end
+
     test "terminating the conversation closes the connection (#817)", %{
       conv: conv,
       pid: pid,

--- a/apps/fountain/test/fountain/runtimes/acp/protocol_test.exs
+++ b/apps/fountain/test/fountain/runtimes/acp/protocol_test.exs
@@ -101,6 +101,58 @@ defmodule Fountain.Runtimes.ACP.ProtocolTest do
     end
   end
 
+  defp update_line(update) do
+    Jason.encode!(%{
+      "jsonrpc" => "2.0",
+      "method" => "session/update",
+      "params" => %{"sessionId" => "s1", "update" => update}
+    })
+  end
+
+  describe "session_metadata?/1" do
+    test "true for every metadata update kind" do
+      for kind <- ~w(session_info_update available_commands_update current_mode_update) do
+        assert Protocol.session_metadata?(update_line(%{"sessionUpdate" => kind})),
+               "expected #{kind} to be metadata"
+      end
+    end
+
+    test "the claude adapter's post-turn title line is metadata (#1300)" do
+      assert Protocol.session_metadata?(
+               update_line(%{
+                 "sessionUpdate" => "session_info_update",
+                 "title" => "Research Xfinity internet promotion pricing",
+                 "updatedAt" => "2026-08-25T12:05:48.620Z"
+               })
+             )
+    end
+
+    test "false for agent activity" do
+      for kind <- ~w(agent_message_chunk agent_thought_chunk tool_call tool_call_update plan
+                     usage_update user_message_chunk) do
+        refute Protocol.session_metadata?(update_line(%{"sessionUpdate" => kind})),
+               "expected #{kind} not to be metadata"
+      end
+    end
+
+    test "false for other notifications, requests, responses and junk" do
+      refute Protocol.session_metadata?(
+               Jason.encode!(%{"jsonrpc" => "2.0", "method" => "session/cancel", "params" => %{}})
+             )
+
+      refute Protocol.session_metadata?(
+               Jason.encode!(%{"jsonrpc" => "2.0", "id" => 1, "result" => %{}})
+             )
+
+      refute Protocol.session_metadata?("npm warn deprecated foo@1.0.0")
+
+      # A session/update with no update object at all is not metadata either.
+      refute Protocol.session_metadata?(
+               Jason.encode!(%{"jsonrpc" => "2.0", "method" => "session/update"})
+             )
+    end
+  end
+
   describe "encoding" do
     test "every encoded frame ends in exactly one newline" do
       for frame <- [


### PR DESCRIPTION
Closes #1300.

## What

The claude adapter generates the session title asynchronously and writes its `session_info_update` about a second **after** the prompt response — out of turn. The server read any out-of-turn protocol line as a background task narrating a follow-up (#817) and opened a synthetic `(background task follow-up)` turn, held open for the full ten-minute quiet window because a metadata line never carries the `usage_update` origin that ends a cycle.

The cost, measured on the hosted instance over the fourteen days before the fix: 167 of 190 autonomous turns held exactly one `session_info_update` and nothing else — a phantom user bubble in the transcript after nearly every claude turn, the conversation `running` for ten minutes (which defers idle park, since an in-flight turn suppresses the idle verdict), and the window billed as turn time (`turn_seconds` has no origin filter). It is also what created the stuck turn in #1179.

## How

- **`Protocol.session_metadata?/1`** classifies a stored line as a `session/update` whose kind describes the *session* rather than anything the agent did: `session_info_update`, `available_commands_update`, `current_mode_update`. It reuses `classify_line/1`, the same decoder the tracer reads lines with.
- **`ConversationServer`'s `{:lines, "acp", …}` handler** gets a metadata branch between the replay-dedup check and the turn-opening heuristic: a metadata line opens no autonomous turn and re-arms no quiet timer. With a turn in flight (user or autonomous) it still persists onto the transcript exactly as before; with none there is nothing to attach it to and it is dropped.

Real background follow-ups — updates carrying agent output or tool calls — behave exactly as before: they open the autonomous turn, re-arm the quiet timer, and close on `cycle_end` or quiet.

## Relation to #1197 / #1252

Independent halves of the same incident family. #1252 makes a stuck autonomous turn close when its server dies; this PR stops 88% of autonomous turns from existing at all, which also shrinks the population #1252's reaper has to sweep. No overlap in code touched.

## Testing

- `mix test test/fountain/runtimes/acp/protocol_test.exs test/fountain/conversations/conversation_server_acp_test.exs` — 71 tests, 0 failures on the pinned 1.19.2 toolchain.
- Verified the new tests bite by reverting the two lib files: 6 failures, restored, green again.
- New coverage: the exact post-turn title line from #1179 opens no turn and is dropped; metadata mid-turn still lands on the transcript; metadata during an open autonomous turn does not re-arm the quiet timer (asserted on the timer reference) while a narration line still does.
- `mix format --check-formatted` and the docs suite (CHANGELOG is a docs page) both green on 1.19.2.
- `mix precommit` green on 1.19.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Npkq4utPYxR6NdwetyzCzr
