### PR TITLE
feat(marketing): add Fountain OSS launch page

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/marketing_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_controller.ex
@@ -1,12 +1,12 @@
 defmodule FountainWeb.MarketingController do
   @moduledoc """
-  The public pages: `/`, `/launch`, `/integrations`, `/built-with`,
+  The public pages: `/`, `/launch`, `/oss-launch`, `/integrations`, `/built-with`,
   `/self-hosted`, `/faq`, `/code-review-bot`, `/case-studies/*`, `/terms`
   and `/privacy`.
 
   None of them is the same page on every deployment. `/` serves the
   product pitch on the marketing site and a plain front door everywhere else
-  (`Fountain.Marketing`); `/launch`, `/integrations`, `/built-with`,
+  (`Fountain.Marketing`); `/launch`, `/oss-launch`, `/integrations`, `/built-with`,
   `/self-hosted`, `/faq`, `/code-review-bot` and the case studies are the
   pitch's other pages and redirect into the manual on any other instance;
   the legal pages render the operator's identity, or nothing at all
@@ -82,6 +82,26 @@ defmodule FountainWeb.MarketingController do
       )
     else
       redirect(conn, to: ~p"/docs/tour")
+    end
+  end
+
+  # The Fountain project launch page. Managoat's `/launch` sells the hosted
+  # instance; this page makes the parallel case for the open-source engine:
+  # deploy it, define one agent, connect existing systems and choose what
+  # observability leaves the instance. It is a campaign destination rather
+  # than a second homepage, so it stays out of the permanent navigation.
+  def oss_launch(conn, _params) do
+    if Fountain.Marketing.site?() do
+      render(conn, :oss_launch,
+        layout: {FountainWeb.Layouts, :marketing},
+        page_title: "Open-source infrastructure for coding agents · #{Fountain.Brand.engine()}",
+        meta_description:
+          "Deploy #{Fountain.Brand.engine()} with Docker, Render, Fly.io or Kubernetes. " <>
+            "Define a coding agent once, connect it to the systems you already use, and " <>
+            "keep telemetry under your control."
+      )
+    else
+      redirect(conn, to: ~p"/docs/open-source")
     end
   end
 

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
@@ -1076,6 +1076,80 @@ defmodule FountainWeb.MarketingHTML do
   @doc "The project's repository. The self-hosted page links it from four places."
   def repo_url, do: @repo_url
 
+  @doc "Deployment paths featured by the Fountain open-source launch page."
+  def oss_deploy_targets do
+    [
+      %{
+        name: "Docker Compose",
+        label: "Fastest start",
+        body:
+          "One app container, Postgres and the same published release image used everywhere else.",
+        href: "/docs/guides/operate/deploy",
+        command: "docker compose up -d"
+      },
+      %{
+        name: "Render",
+        label: "Blueprint",
+        body: "Fork the repo and let render.yaml create the web service and managed Postgres.",
+        href: "/docs/guides/operate/render",
+        command: "render.yaml"
+      },
+      %{
+        name: "Fly.io",
+        label: "Machine",
+        body:
+          "Deploy the published image from fly.toml and bring the Postgres database you choose.",
+        href: "/docs/guides/operate/fly",
+        command: "fly deploy"
+      },
+      %{
+        name: "Kubernetes",
+        label: "Portable baseline",
+        body:
+          "Plain manifests, no operator or CRDs, with clustering and probes already described.",
+        href: "/docs/guides/operate/kubernetes",
+        command: "kubectl apply -k deploy/k8s"
+      },
+      %{
+        name: "Coolify",
+        label: "Your server",
+        body: "Point Coolify at the repository and use the same Compose stack behind its proxy.",
+        href: "/docs/guides/operate/coolify",
+        command: "docker-compose.yml"
+      }
+    ]
+  end
+
+  @doc "The three observability signals an operator controls on /oss-launch."
+  def oss_telemetry do
+    [
+      %{
+        signal: "Metrics",
+        destination: "Prometheus → Grafana",
+        body:
+          "Scrape routes, database timings, provisioning, turn latency and sandbox state from the private metrics listener. The repo includes dashboards and alerts.",
+        config: "METRICS_PORT=9568",
+        state: "Local by default"
+      },
+      %{
+        signal: "Traces",
+        destination: "OpenTelemetry → your OTLP backend",
+        body:
+          "Export request, provisioning and turn spans over OTLP. Point the standard exporter variables at Honeycomb, Grafana Tempo or another compatible collector.",
+        config: "OTEL_EXPORTER_OTLP_ENDPOINT=…",
+        state: "Off until configured"
+      },
+      %{
+        signal: "Errors",
+        destination: "Sentry API → Sentry or GlitchTip",
+        body:
+          "Send grouped crashes without cookies, IP addresses or request bodies. Unset the DSN and the SDK stays inert; nothing is buffered for later.",
+        config: "SENTRY_DSN=…",
+        state: "Off until configured"
+      }
+    ]
+  end
+
   # The four apps /self-hosted shows, chosen for four different shapes of
   # front door: a commission that comes back as a document, an analyst behind a
   # file upload, an unattended repair loop, and a fan-out. Selected from

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/oss_launch.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/oss_launch.html.heex
@@ -1,0 +1,401 @@
+<%!-- Fountain's open-source launch page. Unlike /launch, this page names the
+      engine rather than the hosted brand and makes deployment, connection and
+      observability part of the first-screen promise. --%>
+
+<section class="relative overflow-hidden border-b border-[var(--color-border)]">
+  <div class="absolute inset-x-0 top-0 h-px bg-[var(--color-accent)]" aria-hidden="true"></div>
+  <div class="max-w-6xl mx-auto px-5 sm:px-6 py-16 sm:py-24 grid lg:grid-cols-[1.05fr_0.95fr] gap-12 lg:gap-16 items-center">
+    <div>
+      <p class="inline-flex items-center gap-2 rounded-full border border-[var(--color-border-strong)] bg-[var(--color-bg-1)] px-3.5 py-1.5 text-xs font-medium uppercase tracking-[0.16em] text-[var(--color-text-secondary)]">
+        <span class="size-1.5 rounded-full bg-[var(--color-accent)]" aria-hidden="true"></span>
+        Fountain · AGPL-3.0
+      </p>
+      <h1 class="mt-6 text-[2.75rem] leading-[1.02] sm:text-6xl font-bold tracking-[-0.035em] text-[var(--color-text-primary)]">
+        The open-source control plane for coding agents.
+      </h1>
+      <p class="mt-6 text-lg sm:text-xl leading-relaxed text-[var(--color-text-secondary)] max-w-[39rem]">
+        Deploy Fountain in your cloud. Define an agent with its machine, tools and credentials. Start it from any product that can make an API call.
+      </p>
+      <div class="mt-9 flex flex-col sm:flex-row gap-3 [&>a]:w-full sm:[&>a]:w-auto">
+        <a
+          href={~p"/docs/guides/operate/deploy"}
+          class="inline-flex items-center justify-center px-6 py-3 rounded-lg bg-[var(--color-brand)] text-[var(--color-brand-text)] font-medium hover:bg-[var(--color-brand-hover)] transition-colors text-sm shadow-sm"
+        >
+          Deploy Fountain
+        </a>
+        <a
+          href={repo_url()}
+          rel="noopener"
+          class="inline-flex items-center justify-center px-6 py-3 rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-bg-1)] text-[var(--color-text-primary)] font-medium hover:bg-[var(--color-bg-2)] transition-colors text-sm"
+        >
+          View on GitHub
+        </a>
+      </div>
+      <p class="mt-5 text-xs text-[var(--color-text-muted)]">
+        No license key · no seat count · no token markup · same release image as hosted
+      </p>
+    </div>
+
+    <%!-- A compact system map, not a decorative terminal. It establishes the
+          product boundary before the page expands each layer below. --%>
+    <div
+      class="rounded-2xl border border-[var(--color-ink-border)] bg-[var(--color-ink-0)] text-[var(--color-ink-text)] shadow-xl shadow-black/10 overflow-hidden"
+      data-role="system-map"
+    >
+      <div class="flex items-center gap-2 px-5 py-3.5 border-b border-[var(--color-ink-border)] bg-[var(--color-ink-1)]">
+        <span class="size-2 rounded-full bg-[var(--color-accent)]"></span>
+        <span class="font-mono text-[11px] uppercase tracking-[0.16em] text-[var(--color-ink-secondary)]">
+          Your Fountain instance
+        </span>
+        <span class="ml-auto font-mono text-[10px] text-[var(--color-accent)]">ready</span>
+      </div>
+      <div class="p-5 sm:p-6 space-y-3">
+        <div class="grid grid-cols-3 gap-2 text-center font-mono text-[11px] text-[var(--color-ink-secondary)]">
+          <div class="rounded-lg border border-[var(--color-ink-border)] px-2 py-3">your app</div>
+          <div class="rounded-lg border border-[var(--color-ink-border)] px-2 py-3">your IDE</div>
+          <div class="rounded-lg border border-[var(--color-ink-border)] px-2 py-3">
+            your chat
+          </div>
+        </div>
+        <div class="flex justify-center text-[var(--color-accent)]" aria-hidden="true">↓</div>
+        <div class="rounded-xl border border-[var(--color-accent)] bg-[var(--color-ink-1)] p-5">
+          <div class="flex items-center justify-between gap-4">
+            <strong class="text-sm">Fountain API</strong>
+            <span class="font-mono text-[10px] text-[var(--color-accent)]">
+              REST · SSE · webhooks
+            </span>
+          </div>
+          <div class="mt-4 grid grid-cols-3 gap-2 text-center text-[11px] text-[var(--color-ink-secondary)]">
+            <span class="rounded-md bg-[var(--color-ink-0)] px-2 py-2">Agent</span>
+            <span class="rounded-md bg-[var(--color-ink-0)] px-2 py-2">Environment</span>
+            <span class="rounded-md bg-[var(--color-ink-0)] px-2 py-2">Vault</span>
+          </div>
+        </div>
+        <div class="flex justify-center text-[var(--color-accent)]" aria-hidden="true">↓</div>
+        <div class="grid grid-cols-3 gap-2 text-center font-mono text-[11px] text-[var(--color-ink-secondary)]">
+          <div class="rounded-lg border border-[var(--color-ink-border)] px-2 py-3">sandbox</div>
+          <div class="rounded-lg border border-[var(--color-ink-border)] px-2 py-3">runtime</div>
+          <div class="rounded-lg border border-[var(--color-ink-border)] px-2 py-3">tools</div>
+        </div>
+      </div>
+      <p class="border-t border-[var(--color-ink-border)] px-5 py-4 font-mono text-[11px] text-[var(--color-ink-secondary)]">
+        state → Postgres&nbsp;&nbsp; logs → stdout&nbsp;&nbsp; metrics → :9568
+      </p>
+    </div>
+  </div>
+</section>
+
+<section class="max-w-6xl mx-auto px-5 sm:px-6 py-14 sm:py-20" data-role="deployments">
+  <.eyebrow label="Deploy anywhere" align={:left} />
+  <div class="mt-4 grid lg:grid-cols-[1fr_0.72fr] gap-5 lg:items-end">
+    <h2 class="text-3xl sm:text-4xl font-bold tracking-tight text-[var(--color-text-primary)]">
+      One container image. Five documented paths to production.
+    </h2>
+    <p class="text-[var(--color-text-secondary)] leading-relaxed">
+      Start on one machine, or run a clustered control plane against your Postgres. The deployment shape changes; the API does not.
+    </p>
+  </div>
+  <div class="mt-10 grid sm:grid-cols-2 lg:grid-cols-5 border-y border-l border-[var(--color-border)]">
+    <a
+      :for={target <- oss_deploy_targets()}
+      href={target.href}
+      class="group min-w-0 border-r border-b sm:[&:nth-last-child(-n+1)]:border-b-0 lg:border-b-0 border-[var(--color-border)] bg-[var(--color-bg-1)] p-5 hover:bg-[var(--color-bg-2)] transition-colors"
+      data-role="deployment-target"
+    >
+      <p class="font-mono text-[10px] uppercase tracking-[0.14em] text-[var(--color-accent-ink)]">
+        {target.label}
+      </p>
+      <h3 class="mt-3 font-semibold text-[var(--color-text-primary)] group-hover:text-[var(--color-brand)]">
+        {target.name}
+      </h3>
+      <p class="mt-2 min-h-20 text-sm leading-relaxed text-[var(--color-text-secondary)]">
+        {target.body}
+      </p>
+      <code class="mt-4 block overflow-hidden text-ellipsis whitespace-nowrap text-[10px] text-[var(--color-code-text)]">
+        {target.command}
+      </code>
+    </a>
+  </div>
+  <p class="mt-6 text-sm text-[var(--color-text-secondary)]">
+    Or run the OCI image anywhere that can keep a Phoenix process and Postgres alive.
+    <a
+      href={~p"/docs/self-hosting"}
+      class="font-medium text-[var(--color-text-primary)] underline underline-offset-2 hover:text-[var(--color-brand)]"
+    >
+      Compare deployment requirements →
+    </a>
+  </p>
+</section>
+
+<section class="bg-[var(--color-ink-0)] text-[var(--color-ink-text)]">
+  <div class="max-w-6xl mx-auto px-5 sm:px-6 py-16 sm:py-20">
+    <.eyebrow label="Your first agent" tone={:ink} align={:left} />
+    <div class="mt-4 grid lg:grid-cols-[0.78fr_1.22fr] gap-10 lg:gap-14 items-start">
+      <div>
+        <h2 class="text-3xl sm:text-4xl font-bold tracking-tight">
+          Describe it once. After that, send prompts.
+        </h2>
+        <p class="mt-5 text-[var(--color-ink-secondary)] leading-relaxed">
+          An Environment describes the machine. A Vault provides per-run credentials. An Agent chooses the runtime, model and tools. Keep all three in one manifest and apply it like infrastructure.
+        </p>
+        <ol class="mt-8 space-y-5">
+          <li class="grid grid-cols-[2rem_1fr] gap-3">
+            <span class="flex size-8 items-center justify-center rounded-full border border-[var(--color-accent)] font-mono text-xs text-[var(--color-accent)]">
+              1
+            </span>
+            <div>
+              <h3 class="font-semibold">Apply the manifest</h3>
+              <p class="mt-1 text-sm text-[var(--color-ink-secondary)]">
+                Fountain creates what is new and updates what changed.
+              </p>
+            </div>
+          </li>
+          <li class="grid grid-cols-[2rem_1fr] gap-3">
+            <span class="flex size-8 items-center justify-center rounded-full border border-[var(--color-accent)] font-mono text-xs text-[var(--color-accent)]">
+              2
+            </span>
+            <div>
+              <h3 class="font-semibold">Call the agent by name</h3>
+              <p class="mt-1 text-sm text-[var(--color-ink-secondary)]">
+                The API provisions the sandbox, clones repositories and starts the runtime.
+              </p>
+            </div>
+          </li>
+          <li class="grid grid-cols-[2rem_1fr] gap-3">
+            <span class="flex size-8 items-center justify-center rounded-full border border-[var(--color-accent)] font-mono text-xs text-[var(--color-accent)]">
+              3
+            </span>
+            <div>
+              <h3 class="font-semibold">Resume with the conversation ID</h3>
+              <p class="mt-1 text-sm text-[var(--color-ink-secondary)]">
+                The checkout, installed packages and runtime session are still there.
+              </p>
+            </div>
+          </li>
+        </ol>
+        <a
+          href={~p"/docs/tour"}
+          class="mt-8 inline-block text-sm font-medium text-[var(--color-accent)] underline underline-offset-4 hover:text-[var(--color-ink-text)]"
+        >
+          Run the complete tour →
+        </a>
+      </div>
+
+      <div class="min-w-0 space-y-4">
+        <div class="overflow-hidden rounded-xl border border-[var(--color-ink-border)] bg-[var(--color-ink-1)]">
+          <div class="flex items-center justify-between gap-4 border-b border-[var(--color-ink-border)] px-4 py-3">
+            <span class="font-mono text-[11px] text-[var(--color-ink-secondary)]">
+              fountain.yml
+            </span>
+            <span class="font-mono text-[10px] uppercase tracking-wider text-[var(--color-accent)]">
+              environment · vault · agent
+            </span>
+          </div>
+          <pre
+            class="max-h-[28rem] overflow-auto p-4 text-xs leading-relaxed text-[var(--color-code-text)]"
+            phx-no-format
+          ><code>{apply_example()}</code></pre>
+          <p class="border-t border-[var(--color-ink-border)] px-4 py-3 font-mono text-xs text-[var(--color-accent)]">
+            $ fountain apply -f fountain.yml
+          </p>
+        </div>
+        <div class="overflow-hidden rounded-xl border border-[var(--color-ink-border)] bg-[var(--color-ink-1)]">
+          <div class="border-b border-[var(--color-ink-border)] px-4 py-3 font-mono text-[11px] text-[var(--color-ink-secondary)]">
+            run.ts
+          </div>
+          <pre
+            class="overflow-x-auto p-4 text-xs leading-relaxed text-[var(--color-code-text)]"
+            phx-no-format
+          ><code>{sdk_example()}</code></pre>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="max-w-6xl mx-auto px-5 sm:px-6 py-16 sm:py-20" data-role="integrations">
+  <.eyebrow label="Fits your stack" align={:left} />
+  <h2 class="mt-4 text-3xl sm:text-4xl font-bold tracking-tight text-[var(--color-text-primary)] max-w-3xl">
+    One agent, every place your team already works.
+  </h2>
+  <p class="mt-4 max-w-2xl text-[var(--color-text-secondary)] leading-relaxed">
+    Put Fountain behind your product, editor, chat app or agent framework. Every interface reaches the same roster, persistent workspace and event stream.
+  </p>
+
+  <div class="mt-10 grid lg:grid-cols-[1.15fr_0.85fr] gap-6">
+    <div class="rounded-2xl border border-[var(--color-border)] bg-[var(--color-bg-1)] p-6 sm:p-8">
+      <p class="font-mono text-[10px] uppercase tracking-[0.16em] text-[var(--color-accent-ink)]">
+        Start and follow an agent
+      </p>
+      <div class="mt-5 grid sm:grid-cols-2 gap-px overflow-hidden rounded-xl border border-[var(--color-border)] bg-[var(--color-border)]">
+        <a
+          :for={protocol <- client_protocols()}
+          href={protocol.docs}
+          class="bg-[var(--color-bg-0)] p-5 hover:bg-[var(--color-bg-2)] transition-colors"
+        >
+          <h3 class="font-semibold text-[var(--color-text-primary)]">{protocol.name}</h3>
+          <p class="mt-2 text-sm leading-relaxed text-[var(--color-text-secondary)]">
+            {protocol.direction}
+          </p>
+        </a>
+      </div>
+    </div>
+
+    <div class="rounded-2xl border border-[var(--color-accent-line)] bg-[var(--color-accent-soft)] p-6 sm:p-8">
+      <p class="font-mono text-[10px] uppercase tracking-[0.16em] text-[var(--color-accent-ink)]">
+        What runs behind it
+      </p>
+      <div class="mt-5 space-y-6">
+        <div :for={group <- inside()}>
+          <h3 class="text-sm font-semibold text-[var(--color-text-primary)]">{group.title}</h3>
+          <div class="mt-2 flex flex-wrap gap-2">
+            <span
+              :for={item <- group.items}
+              class="rounded-full border border-[var(--color-accent-line)] bg-[var(--color-bg-1)] px-3 py-1 text-xs text-[var(--color-text-secondary)]"
+            >
+              {item.name}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="mt-6 rounded-2xl border border-[var(--color-border)] bg-[var(--color-bg-1)] p-6 sm:p-8">
+    <div class="grid lg:grid-cols-[0.7fr_1.3fr] gap-6 lg:items-center">
+      <div>
+        <p class="font-mono text-[10px] uppercase tracking-[0.16em] text-[var(--color-accent-ink)]">
+          Tools and systems
+        </p>
+        <h3 class="mt-3 text-xl font-semibold text-[var(--color-text-primary)]">
+          MCP inside. Webhooks outside.
+        </h3>
+        <p class="mt-3 text-sm leading-relaxed text-[var(--color-text-secondary)]">
+          Attach any stdio or HTTP MCP server. Use credential bindings for services Fountain knows, so the real token can stay outside the sandbox.
+        </p>
+      </div>
+      <div class="flex flex-wrap gap-2">
+        <span
+          :for={service <- brokered_services()}
+          class="rounded-md border border-[var(--color-border)] bg-[var(--color-bg-0)] px-3 py-2 text-xs font-medium text-[var(--color-text-secondary)]"
+        >
+          {service.name}
+        </span>
+        <span class="rounded-md border border-dashed border-[var(--color-border-strong)] px-3 py-2 text-xs font-medium text-[var(--color-text-muted)]">
+          + any MCP server
+        </span>
+      </div>
+    </div>
+  </div>
+  <a
+    href={~p"/integrations"}
+    class="mt-7 inline-block text-sm font-medium text-[var(--color-text-primary)] underline underline-offset-4 hover:text-[var(--color-brand)]"
+  >
+    Browse every protocol and integration →
+  </a>
+</section>
+
+<section
+  class="bg-[var(--color-band)] border-y border-[var(--color-border)]"
+  data-role="telemetry"
+>
+  <div class="max-w-6xl mx-auto px-5 sm:px-6 py-16 sm:py-20">
+    <.eyebrow label="Observable by design" align={:left} />
+    <div class="mt-4 grid lg:grid-cols-[1fr_0.78fr] gap-5 lg:items-end">
+      <h2 class="text-3xl sm:text-4xl font-bold tracking-tight text-[var(--color-text-primary)]">
+        Telemetry goes where you point it—and nowhere by surprise.
+      </h2>
+      <p class="text-[var(--color-text-secondary)] leading-relaxed">
+        Logs stay on stdout. Metrics stay on a private listener. Trace and error export only turn on when you configure a destination.
+      </p>
+    </div>
+
+    <div class="mt-10 grid lg:grid-cols-3 gap-6">
+      <article
+        :for={item <- oss_telemetry()}
+        class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-1)] p-6"
+        data-role="telemetry-signal"
+      >
+        <div class="flex items-center justify-between gap-3">
+          <p class="font-mono text-[10px] uppercase tracking-[0.16em] text-[var(--color-accent-ink)]">
+            {item.signal}
+          </p>
+          <span class="rounded-full border border-[var(--color-border)] px-2.5 py-1 text-[10px] text-[var(--color-text-muted)]">
+            {item.state}
+          </span>
+        </div>
+        <h3 class="mt-4 font-semibold text-[var(--color-text-primary)]">{item.destination}</h3>
+        <p class="mt-3 text-sm leading-relaxed text-[var(--color-text-secondary)]">{item.body}</p>
+        <code class="mt-5 block overflow-x-auto rounded-md bg-[var(--color-code-bg)] px-3 py-2 text-[11px] text-[var(--color-code-text)]">
+          {item.config}
+        </code>
+      </article>
+    </div>
+
+    <div class="mt-6 grid md:grid-cols-3 overflow-hidden rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-1)]">
+      <div class="p-5 border-b md:border-b-0 md:border-r border-[var(--color-border)]">
+        <p class="text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)]">
+          Agent activity
+        </p>
+        <p class="mt-2 text-sm text-[var(--color-text-secondary)]">
+          Stage events stream to clients over SSE and persist with the conversation.
+        </p>
+      </div>
+      <div class="p-5 border-b md:border-b-0 md:border-r border-[var(--color-border)]">
+        <p class="text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)]">
+          Operator activity
+        </p>
+        <p class="mt-2 text-sm text-[var(--color-text-secondary)]">
+          Resource and administrative changes land in the audit trail in your database.
+        </p>
+      </div>
+      <div class="p-5">
+        <p class="text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)]">
+          Health
+        </p>
+        <p class="mt-2 text-sm text-[var(--color-text-secondary)]">
+          <code class="text-xs">/health</code>
+          restarts; <code class="text-xs">/health/ready</code>
+          controls load-balancer readiness.
+        </p>
+      </div>
+    </div>
+    <a
+      href={~p"/docs/guides/operate/observability"}
+      class="mt-7 inline-block text-sm font-medium text-[var(--color-text-primary)] underline underline-offset-4 hover:text-[var(--color-brand)]"
+    >
+      Import the included dashboards and alert pack →
+    </a>
+  </div>
+</section>
+
+<section class="max-w-6xl mx-auto px-5 sm:px-6 py-16 sm:py-20">
+  <div class="rounded-2xl border border-[var(--color-accent-line)] bg-[var(--color-accent-soft)] p-8 sm:p-12 grid lg:grid-cols-[1fr_auto] gap-8 lg:items-center">
+    <div>
+      <p class="font-mono text-[10px] uppercase tracking-[0.16em] text-[var(--color-accent-ink)]">
+        Own the whole loop
+      </p>
+      <h2 class="mt-4 text-3xl sm:text-4xl font-bold tracking-tight text-[var(--color-text-primary)]">
+        Your database. Your keys. Your agents.
+      </h2>
+      <p class="mt-4 max-w-2xl text-[var(--color-text-secondary)] leading-relaxed">
+        Fountain stores conversations and configuration in your Postgres, encrypts tenant secrets with the master key you hold, and runs sandboxes through Sprites, E2B, Daytona or machines on your own network.
+      </p>
+    </div>
+    <div class="flex flex-col sm:flex-row lg:flex-col gap-3 lg:min-w-52">
+      <a
+        href={~p"/docs/guides/operate/deploy"}
+        class="inline-flex items-center justify-center rounded-lg bg-[var(--color-brand)] px-6 py-3 text-sm font-medium text-[var(--color-brand-text)] hover:bg-[var(--color-brand-hover)] transition-colors"
+      >
+        Deploy Fountain
+      </a>
+      <a
+        href={repo_url()}
+        rel="noopener"
+        class="inline-flex items-center justify-center rounded-lg border border-[var(--color-accent-line)] bg-[var(--color-bg-1)] px-6 py-3 text-sm font-medium text-[var(--color-text-primary)] hover:bg-[var(--color-bg-2)] transition-colors"
+      >
+        Read the source
+      </a>
+    </div>
+  </div>
+</section>

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -156,6 +156,7 @@ defmodule FountainWeb.Router do
     pipe_through [:browser, :browser_optional_auth, :public_analytics]
     get "/", MarketingController, :home
     get "/launch", MarketingController, :launch
+    get "/oss-launch", MarketingController, :oss_launch
     get "/integrations", MarketingController, :integrations
     get "/built-with", MarketingController, :built_with
     get "/self-hosted", MarketingController, :self_hosted

--- a/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
@@ -114,6 +114,74 @@ defmodule FountainWeb.MarketingControllerTest do
     end
   end
 
+  describe "GET /oss-launch" do
+    test "launches the Fountain project from deploy through telemetry", %{conn: conn} do
+      body = conn |> get(~p"/oss-launch") |> html_response(200)
+
+      assert body =~ "Fountain · AGPL-3.0"
+      assert body =~ "The open-source control plane for coding agents."
+      assert body =~ "Deploy Fountain"
+      assert body =~ FountainWeb.MarketingHTML.repo_url()
+
+      for target <- FountainWeb.MarketingHTML.oss_deploy_targets() do
+        assert body =~ target.name, "missing deployment target #{target.name}"
+        assert body =~ target.href, "missing guide for #{target.name}"
+      end
+
+      assert body =~ "Describe it once. After that, send prompts."
+      assert body =~ "kind: Environment"
+      assert body =~ "kind: Vault"
+      assert body =~ "kind: Agent"
+      assert body =~ "fountain apply -f fountain.yml"
+      assert body =~ "@agentshit/fountain-sdk"
+
+      assert body =~ "One agent, every place your team already works."
+
+      for name <- ~w(AG-UI ACP OpenAI-compatible) do
+        assert body =~ name, "missing client protocol #{name}"
+      end
+
+      for name <- ["Claude Code", "Codex", "Gemini CLI", "OpenCode", "Sprites", "E2B"] do
+        assert body =~ name, "missing runtime or sandbox #{name}"
+      end
+
+      assert body =~ "Telemetry goes where you point it—and nowhere by surprise."
+      assert body =~ "Prometheus → Grafana"
+      assert body =~ "OpenTelemetry → your OTLP backend"
+      assert body =~ "Sentry API → Sentry or GlitchTip"
+      assert body =~ "Off until configured"
+      assert body =~ "/docs/guides/operate/observability"
+    end
+
+    test "carries a Fountain-specific card and stays out of permanent navigation", %{conn: conn} do
+      body = conn |> get(~p"/oss-launch") |> html_response(200)
+
+      assert body =~
+               ~s(<meta property="og:title" content="Open-source infrastructure for coding agents · Fountain")
+
+      assert body =~ ~s(<meta property="og:url" content="http://localhost:4000/oss-launch")
+      assert body =~ ~s(<meta name="description" content="Deploy Fountain with Docker)
+
+      refute conn |> get(~p"/") |> html_response(200) =~ ~s(href="/oss-launch")
+    end
+
+    test "every link into the manual resolves", %{conn: conn} do
+      body = conn |> get(~p"/oss-launch") |> html_response(200)
+
+      slugs =
+        ~r/href="\/docs\/([^"#]+)/
+        |> Regex.scan(body)
+        |> Enum.map(fn [_, slug] -> slug end)
+        |> Enum.uniq()
+
+      assert slugs != []
+
+      for slug <- slugs do
+        assert match?({:ok, _}, Fountain.Docs.get(slug)), "/docs/#{slug} is not a page"
+      end
+    end
+  end
+
   describe "GET /terms" do
     test "renders the terms of service with the configured identity", %{conn: conn} do
       body = conn |> get(~p"/terms") |> html_response(200)

--- a/apps/fountain/test/fountain_web/controllers/marketing_instance_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_instance_test.exs
@@ -116,6 +116,15 @@ defmodule FountainWeb.MarketingInstanceTest do
     end
   end
 
+  describe "GET /oss-launch where the deployment is not the marketing site" do
+    test "sends the visitor to the open-source manual", %{conn: conn} do
+      Application.put_env(:fountain, :marketing_site, false)
+
+      conn = get(conn, ~p"/oss-launch")
+      assert redirected_to(conn) == ~p"/docs/open-source"
+    end
+  end
+
   describe "GET /built-with where the deployment is not the marketing site" do
     test "sends the visitor to the build guide rather than somebody else's apps", %{conn: conn} do
       Application.put_env(:fountain, :marketing_site, false)


### PR DESCRIPTION
## Summary

- add an unlisted `/oss-launch` campaign page for the open-source Fountain engine
- cover Docker Compose, Render, Fly.io, Kubernetes, and Coolify deployment paths
- show the Environment/Vault/Agent manifest and first SDK run
- map supported client protocols, runtimes, sandboxes, MCP tools, and credential-bound systems
- explain Prometheus, OpenTelemetry, Sentry-compatible errors, health endpoints, and audit/event telemetry defaults
- redirect non-marketing deployments to the open-source manual

## Test plan

- `mix test apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs apps/fountain/test/fountain_web/controllers/marketing_instance_test.exs`
- `mix format --check-formatted ...`
- `git diff --check`

88 focused tests pass.
