### PR TITLE
docs: add a first-agent quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,14 +122,19 @@ Log in against your Fountain instance:
 fountain auth login
 ```
 
-Apply a manifest. [`jhgaylor/agent-specs`](https://github.com/jhgaylor/agent-specs) is a public example tree of agents, environments, and vaults:
+Before the first run, add an Anthropic credential under Settings, then
+Inference credentials. Apply the smallest example and run its agent against a
+real checkout:
 
 ```sh
-git clone https://github.com/jhgaylor/agent-specs
-fountain apply -f agent-specs
+fountain apply -f examples/quickstart/fountain.yml
+fountain run fountain-reader -p \
+  "Find the code that reclaims an idle sandbox. Explain when it runs and name the files you read."
 ```
 
 `fountain apply` walks the directory and applies every `*.yml` / `*.yaml` doc that declares both `apiVersion` and `kind`. See [`cli/README.md`](cli/README.md) for the rest of the command surface.
+If you are not in this checkout, the [quickstart](docs/quickstart.md) downloads
+the manifest first.
 
 ## Use the API directly
 

--- a/README.md
+++ b/README.md
@@ -122,9 +122,10 @@ Log in against your Fountain instance:
 fountain auth login
 ```
 
-Before the first run, add an Anthropic credential under Settings, then
-Inference credentials. Apply the smallest example and run its agent against a
-real checkout:
+Before the first run, add an Anthropic credential under Account, then
+Inference keys. From this checkout, apply the smallest example and run its
+agent against a real repository. (Not in the checkout? The
+[quickstart](docs/quickstart.md) downloads the manifest first.)
 
 ```sh
 fountain apply -f examples/quickstart/fountain.yml
@@ -133,8 +134,6 @@ fountain run fountain-reader -p \
 ```
 
 `fountain apply` walks the directory and applies every `*.yml` / `*.yaml` doc that declares both `apiVersion` and `kind`. See [`cli/README.md`](cli/README.md) for the rest of the command surface.
-If you are not in this checkout, the [quickstart](docs/quickstart.md) downloads
-the manifest first.
 
 ## Use the API directly
 

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/oss_launch.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/oss_launch.html.heex
@@ -18,10 +18,10 @@
       </p>
       <div class="mt-9 flex flex-col sm:flex-row gap-3 [&>a]:w-full sm:[&>a]:w-auto">
         <a
-          href={~p"/docs/guides/operate/deploy"}
+          href={~p"/docs/quickstart"}
           class="inline-flex items-center justify-center px-6 py-3 rounded-lg bg-[var(--color-brand)] text-[var(--color-brand-text)] font-medium hover:bg-[var(--color-brand-hover)] transition-colors text-sm shadow-sm"
         >
-          Deploy Fountain
+          Run the quickstart
         </a>
         <a
           href={repo_url()}
@@ -174,10 +174,10 @@
           </li>
         </ol>
         <a
-          href={~p"/docs/tour"}
+          href={~p"/docs/quickstart"}
           class="mt-8 inline-block text-sm font-medium text-[var(--color-accent)] underline underline-offset-4 hover:text-[var(--color-ink-text)]"
         >
-          Run the complete tour →
+          Run the minimal example →
         </a>
       </div>
 

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/oss_launch.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/oss_launch.html.heex
@@ -36,52 +36,110 @@
       </p>
     </div>
 
-    <%!-- A compact system map, not a decorative terminal. It establishes the
-          product boundary before the page expands each layer below. --%>
-    <div
-      class="rounded-2xl border border-[var(--color-ink-border)] bg-[var(--color-ink-0)] text-[var(--color-ink-text)] shadow-xl shadow-black/10 overflow-hidden"
+    <%!-- The launch path is one continuous story: a request enters Fountain,
+          Fountain assembles the complete working context, and a live agent
+          comes out. Keeping the whole bundle in one box makes the product
+          boundary legible at a glance. --%>
+    <figure
+      class="rounded-2xl border border-[var(--color-border)] bg-[var(--color-bg-1)] p-5 sm:p-7 shadow-xl shadow-black/5"
       data-role="system-map"
+      aria-labelledby="system-map-caption"
     >
-      <div class="flex items-center gap-2 px-5 py-3.5 border-b border-[var(--color-ink-border)] bg-[var(--color-ink-1)]">
-        <span class="size-2 rounded-full bg-[var(--color-accent)]"></span>
-        <span class="font-mono text-[11px] uppercase tracking-[0.16em] text-[var(--color-ink-secondary)]">
-          Your Fountain instance
-        </span>
-        <span class="ml-auto font-mono text-[10px] text-[var(--color-accent)]">ready</span>
-      </div>
-      <div class="p-5 sm:p-6 space-y-3">
-        <div class="grid grid-cols-3 gap-2 text-center font-mono text-[11px] text-[var(--color-ink-secondary)]">
-          <div class="rounded-lg border border-[var(--color-ink-border)] px-2 py-3">your app</div>
-          <div class="rounded-lg border border-[var(--color-ink-border)] px-2 py-3">your IDE</div>
-          <div class="rounded-lg border border-[var(--color-ink-border)] px-2 py-3">
+      <figcaption id="system-map-caption" class="sr-only">
+        Your product, IDE or chat sends a request to Fountain. Fountain combines a repository, model, tools, secrets and sandbox into a running agent.
+      </figcaption>
+
+      <div class="grid grid-cols-3 gap-2" aria-label="Ways to start an agent">
+        <div class="rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-0)] px-2 py-3 text-center">
+          <span class="block font-mono text-[9px] uppercase tracking-[0.14em] text-[var(--color-text-muted)]">
+            API
+          </span>
+          <span class="mt-1 block text-xs font-medium text-[var(--color-text-primary)]">
+            your product
+          </span>
+        </div>
+        <div class="rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-0)] px-2 py-3 text-center">
+          <span class="block font-mono text-[9px] uppercase tracking-[0.14em] text-[var(--color-text-muted)]">
+            ACP
+          </span>
+          <span class="mt-1 block text-xs font-medium text-[var(--color-text-primary)]">
+            your IDE
+          </span>
+        </div>
+        <div class="rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-0)] px-2 py-3 text-center">
+          <span class="block font-mono text-[9px] uppercase tracking-[0.14em] text-[var(--color-text-muted)]">
+            AG-UI
+          </span>
+          <span class="mt-1 block text-xs font-medium text-[var(--color-text-primary)]">
             your chat
-          </div>
-        </div>
-        <div class="flex justify-center text-[var(--color-accent)]" aria-hidden="true">↓</div>
-        <div class="rounded-xl border border-[var(--color-accent)] bg-[var(--color-ink-1)] p-5">
-          <div class="flex items-center justify-between gap-4">
-            <strong class="text-sm">Fountain API</strong>
-            <span class="font-mono text-[10px] text-[var(--color-accent)]">
-              REST · SSE · webhooks
-            </span>
-          </div>
-          <div class="mt-4 grid grid-cols-3 gap-2 text-center text-[11px] text-[var(--color-ink-secondary)]">
-            <span class="rounded-md bg-[var(--color-ink-0)] px-2 py-2">Agent</span>
-            <span class="rounded-md bg-[var(--color-ink-0)] px-2 py-2">Environment</span>
-            <span class="rounded-md bg-[var(--color-ink-0)] px-2 py-2">Vault</span>
-          </div>
-        </div>
-        <div class="flex justify-center text-[var(--color-accent)]" aria-hidden="true">↓</div>
-        <div class="grid grid-cols-3 gap-2 text-center font-mono text-[11px] text-[var(--color-ink-secondary)]">
-          <div class="rounded-lg border border-[var(--color-ink-border)] px-2 py-3">sandbox</div>
-          <div class="rounded-lg border border-[var(--color-ink-border)] px-2 py-3">runtime</div>
-          <div class="rounded-lg border border-[var(--color-ink-border)] px-2 py-3">tools</div>
+          </span>
         </div>
       </div>
-      <p class="border-t border-[var(--color-ink-border)] px-5 py-4 font-mono text-[11px] text-[var(--color-ink-secondary)]">
-        state → Postgres&nbsp;&nbsp; logs → stdout&nbsp;&nbsp; metrics → :9568
+
+      <div class="flex h-9 justify-center text-[var(--color-text-muted)]" aria-hidden="true">
+        <svg class="h-9 w-4" viewBox="0 0 16 36" fill="none">
+          <path
+            d="M8 1v27m0 0-5-5m5 5 5-5"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
+      </div>
+
+      <div class="rounded-xl border border-[var(--color-ink-border)] bg-[var(--color-ink-0)] px-4 py-5 sm:px-6 sm:py-6 text-[var(--color-ink-text)] shadow-lg shadow-black/10">
+        <div class="flex items-center justify-center gap-2.5">
+          <img
+            src={Fountain.Brand.asset("app-icon.png")}
+            alt=""
+            class="size-8 rounded-lg ring-1 ring-white/15"
+          />
+          <strong class="text-sm font-semibold uppercase tracking-[0.08em]">
+            Fountain
+          </strong>
+        </div>
+        <div class="mt-5 flex flex-wrap items-center justify-center gap-x-2.5 gap-y-2 font-mono text-[10px] sm:text-[11px] text-[var(--color-ink-secondary)]">
+          <span>repo</span>
+          <span class="text-[var(--color-accent)]" aria-hidden="true">+</span>
+          <span>model</span>
+          <span class="text-[var(--color-accent)]" aria-hidden="true">+</span>
+          <span>tools</span>
+          <span class="text-[var(--color-accent)]" aria-hidden="true">+</span>
+          <span>secrets</span>
+          <span class="text-[var(--color-accent)]" aria-hidden="true">+</span>
+          <span>sandbox</span>
+        </div>
+      </div>
+
+      <div class="flex h-9 justify-center text-[var(--color-text-muted)]" aria-hidden="true">
+        <svg class="h-9 w-4" viewBox="0 0 16 36" fill="none">
+          <path
+            d="M8 1v27m0 0-5-5m5 5 5-5"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
+      </div>
+
+      <p class="text-center font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--color-text-secondary)]">
+        Running agent
       </p>
-    </div>
+      <div class="mt-3 flex min-w-0 items-center gap-3 rounded-lg border border-[var(--color-accent-line)] bg-[var(--color-accent-soft)] px-3.5 py-3 text-[var(--color-text-primary)]">
+        <span class="shrink-0 font-mono text-xs text-[var(--color-accent-ink)]" aria-hidden="true">
+          $
+        </span>
+        <code class="min-w-0 flex-1 truncate bg-transparent p-0 text-[11px] sm:text-xs text-[var(--color-text-secondary)]">
+          fixing test_user_login.py …
+        </code>
+        <span class="inline-flex shrink-0 items-center gap-1.5 rounded-full bg-[var(--color-accent)] px-2.5 py-1 font-mono text-[9px] font-semibold uppercase tracking-wider text-[var(--color-ink-0)]">
+          <span class="size-1.5 rounded-full bg-current opacity-75" aria-hidden="true"></span>
+          live
+        </span>
+      </div>
+    </figure>
   </div>
 </section>
 
@@ -174,10 +232,10 @@
           </li>
         </ol>
         <a
-          href={~p"/docs/quickstart"}
+          href={~p"/docs/tour"}
           class="mt-8 inline-block text-sm font-medium text-[var(--color-accent)] underline underline-offset-4 hover:text-[var(--color-ink-text)]"
         >
-          Run the minimal example →
+          Run the complete tour →
         </a>
       </div>
 

--- a/apps/fountain/test/fountain/docs_test.exs
+++ b/apps/fountain/test/fountain/docs_test.exs
@@ -134,20 +134,29 @@ defmodule Fountain.DocsTest do
 
     test "keeps docs/nav.yml's order" do
       titles = Enum.map(Docs.nav_source(), &elem(&1, 0))
-      assert Enum.take(titles, 3) == ["Home", "Guided tour, a pull request", "Concepts"]
+
+      assert Enum.take(titles, 4) == [
+               "Home",
+               "Quickstart, first agent",
+               "Guided tour, a pull request",
+               "Concepts"
+             ]
+
       assert List.last(titles) == "Changelog"
     end
 
-    # The tutorial sits second and the concepts tree third, ahead of every
-    # reference page. It was position 15 of 34 and unlinked from the home page,
-    # so a newcomer met three reference pages before the lesson.
-    test "the tutorial and the concepts tree come before reference" do
+    # The quickstart and tutorial sit before the concepts tree, and all three
+    # sit ahead of every reference page. A newcomer gets an executable path
+    # before the data model and the command catalog.
+    test "the quickstart, tutorial, and concepts tree come before reference" do
       titles = Enum.map(Docs.nav_source(), &elem(&1, 0))
 
+      quickstart = Enum.find_index(titles, &(&1 == "Quickstart, first agent"))
       tour = Enum.find_index(titles, &(&1 == "Guided tour, a pull request"))
       concepts = Enum.find_index(titles, &(&1 == "Concepts"))
       reference = Enum.find_index(titles, &(&1 == "Reference"))
 
+      assert quickstart < tour
       assert tour < concepts
       assert concepts < reference
     end

--- a/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
@@ -122,8 +122,19 @@ defmodule FountainWeb.MarketingControllerTest do
       assert body =~ "The open-source control plane for coding agents."
       assert body =~ ~s(href="/docs/quickstart")
       assert body =~ "Run the quickstart"
+      assert body =~ ~s(href="/docs/tour")
+      assert body =~ "Run the complete tour"
       assert body =~ "Deploy Fountain"
       assert body =~ FountainWeb.MarketingHTML.repo_url()
+
+      assert body =~ ~s(data-role="system-map")
+
+      for part <- ~w(repo model tools secrets sandbox) do
+        assert body =~ ">#{part}</span>", "missing #{part} from the agent bundle"
+      end
+
+      assert body =~ "Running agent"
+      assert body =~ "fixing test_user_login.py"
 
       for target <- FountainWeb.MarketingHTML.oss_deploy_targets() do
         assert body =~ target.name, "missing deployment target #{target.name}"

--- a/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
@@ -120,6 +120,8 @@ defmodule FountainWeb.MarketingControllerTest do
 
       assert body =~ "Fountain · AGPL-3.0-or-later"
       assert body =~ "The open-source control plane for coding agents."
+      assert body =~ ~s(href="/docs/quickstart")
+      assert body =~ "Run the quickstart"
       assert body =~ "Deploy Fountain"
       assert body =~ FountainWeb.MarketingHTML.repo_url()
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -68,6 +68,9 @@ in full.
 
 ## Start here
 
+- **[Run your first agent](quickstart.md)** applies a small manifest and
+  starts an agent against a public repository. It needs no GitHub token or
+  setup script.
 - **[The guided tour](tour.md)** builds an agent that clones a repo, changes it
   and opens a pull request. A second turn then lands a revision on the same PR.
   The tour is about forty lines. Start here if Fountain is new to you.

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ is there.
     fountain auth whoami
     ```
     The CLI now works, and you have no agent to run yet. The
-    [guided tour](tour.md) builds the first one.
+    [quickstart](quickstart.md) starts the first one.
 
 ## The problem
 
@@ -70,10 +70,10 @@ in full.
 
 - **[Run your first agent](quickstart.md)** applies a small manifest and
   starts an agent against a public repository. It needs no GitHub token or
-  setup script.
+  setup script. Start here if Fountain is new to you.
 - **[The guided tour](tour.md)** builds an agent that clones a repo, changes it
   and opens a pull request. A second turn then lands a revision on the same PR.
-  The tour is about forty lines. Start here if Fountain is new to you.
+  The tour is about forty lines. It is the step after the quickstart.
 - **[The four primitives](primitives.md)** explains the data model, and why
   Fountain divides it four ways.
 

--- a/docs/nav.yml
+++ b/docs/nav.yml
@@ -22,6 +22,7 @@
 # Paths are relative to `docs/`.
 nav:
   - Home: index.md
+  - Quickstart, first agent: quickstart.md
   - Guided tour, a pull request: tour.md
   - Concepts:
       - The four primitives: primitives.md

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,81 @@
+# Run your first agent
+
+This is the shortest path that demonstrates Fountain's whole job. An agent
+starts in a sandbox with a real repository, inspects the checkout, and streams
+its answer to your terminal.
+
+The example uses Fountain's public repository. It needs no GitHub token, setup
+script, package install, or Vault.
+
+## Before you run it
+
+You need a Fountain account with an Anthropic credential under Settings, then
+Inference credentials. You also need the `fountain` CLI.
+
+```sh
+brew install BinaryBourbon/tap/fountain
+fountain auth login
+```
+
+The CLI defaults to the hosted instance. For an instance of your own, set
+`FOUNTAIN_BASE_URL` before `fountain auth login`.
+
+## Apply and run
+
+Download the small manifest, apply it, and call the agent by name.
+
+```sh
+curl -fsSLo fountain.yml \
+  https://raw.githubusercontent.com/BinaryBourbon/fountain/main/examples/quickstart/fountain.yml
+
+fountain apply -f fountain.yml
+fountain run fountain-reader -p \
+  "Find the code that reclaims an idle sandbox. Explain when it runs and name the files you read."
+```
+
+`apply` creates two reusable rows. The Environment says which repository the
+sandbox receives. The Agent says which runtime and model work in it.
+
+`run` creates the Conversation. Fountain starts the sandbox, clones the
+repository, starts Claude, and streams the work and final answer. The command
+prints the conversation id first. Use it for a follow-up.
+
+```sh
+fountain conv prompt <conversation-id> -p \
+  "Now trace the call one level deeper. What stops two reclaimers from racing?"
+```
+
+The follow-up lands on the same sandbox. The checkout and the agent session
+are still there.
+
+## What the example leaves out
+
+The example has no Vault because it reads a public repository. Add a Vault
+when a run needs a credential that changes independently from the machine or
+the Agent. The [guided tour](tour.md) adds a GitHub token, changes a repository,
+and opens a pull request.
+
+The example uses Claude because it is Fountain's most exercised runtime. To
+use Codex, Gemini CLI, or OpenCode, change `runtime` and `model` in the
+manifest and add that provider's inference credential. The
+[runtime catalog](catalog/runtimes/index.md) lists the accepted shapes.
+
+## Run the server yourself
+
+The hosted path above removes the control plane setup from the product demo.
+Self-hosting has real inputs that a three-command example must not hide. A
+Fountain server needs two encryption keys, Postgres, and a sandbox provider.
+After the first boot, you create an account, add a model credential, and point
+the CLI at the instance.
+
+```sh
+git clone https://github.com/BinaryBourbon/fountain
+cd fountain
+cp .env.compose.example .env
+# Generate the two keys and add a sandbox provider token to .env.
+docker compose up -d
+```
+
+[Deploy an instance](guides/operate/deploy.md) gives the commands and checks
+for that path. Once `fountain auth login` targets the instance, the same
+`apply` and `run` commands above work unchanged.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -30,7 +30,7 @@ docker compose up -d
 ```
 
 Open <http://localhost:4000>. Create the first operator account, then add an
-Anthropic credential under Settings, then Inference credentials.
+Anthropic credential under Account, then Inference keys.
 
 The Compose defaults self-verify the first account and make it the admin.
 Create that account before you expose the server to another network. The
@@ -40,7 +40,7 @@ close registration, and configure the other sandbox providers.
 ### Use the hosted server
 
 Create an account on [managoat.com](https://managoat.com), then add an
-Anthropic credential under Settings, then Inference credentials. The hosted
+Anthropic credential under Account, then Inference keys. The hosted
 server supplies the control plane and sandbox provider.
 
 ## Install and authenticate the CLI
@@ -59,8 +59,17 @@ FOUNTAIN_BASE_URL=http://localhost:4000 fountain auth login
 fountain auth login
 ```
 
-`auth login` saves the server URL and an API key. The commands below need no
-server flag after that.
+`auth login` asks for an email and a password. It saves the server URL and an
+API key. The commands below need no server flag after that.
+
+**Did you create your account with GitHub?** That account has no password, so
+`auth login` cannot sign you in. Create an API key in the console under
+Account, then API keys. Export it, and the CLI uses it before the saved
+credentials.
+
+```sh
+export FOUNTAIN_API_KEY=ftn_...
+```
 
 ## Apply and run
 
@@ -74,6 +83,11 @@ fountain apply -f fountain.yml
 fountain run fountain-reader -p \
   "Find the code that reclaims an idle sandbox. Explain when it runs and name the files you read."
 ```
+
+**Did you clone the repository for your own server?** The checkout already
+contains the manifest. Skip the download and apply
+`examples/quickstart/fountain.yml` from the repository root, so the manifest
+matches the code you deployed.
 
 `apply` creates two reusable rows. The Environment says which repository the
 sandbox receives. The Agent says which runtime and model work in it.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -62,14 +62,10 @@ fountain auth login
 `auth login` asks for an email and a password. It saves the server URL and an
 API key. The commands below need no server flag after that.
 
-**Did you create your account with GitHub?** That account has no password, so
-`auth login` cannot sign you in. Create an API key in the console under
-Account, then API keys. Export it, and the CLI uses it before the saved
-credentials.
-
-```sh
-export FOUNTAIN_API_KEY=ftn_...
-```
+**A GitHub account has no password.** If you created your account with the
+GitHub button, add `--device` to the command above. The CLI shows a one-time
+code and opens the console's approval page. Approve the device there, and the
+CLI saves the key for you.
 
 ## Apply and run
 
@@ -84,10 +80,9 @@ fountain run fountain-reader -p \
   "Find the code that reclaims an idle sandbox. Explain when it runs and name the files you read."
 ```
 
-**Did you clone the repository for your own server?** The checkout already
-contains the manifest. Skip the download and apply
-`examples/quickstart/fountain.yml` from the repository root, so the manifest
-matches the code you deployed.
+**The clone already contains the manifest.** If you run your own server from
+the checkout, skip the download. Apply `examples/quickstart/fountain.yml`
+from the repository root, so the manifest matches the code you deployed.
 
 `apply` creates two reusable rows. The Environment says which repository the
 sandbox receives. The Agent says which runtime and model work in it.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -34,8 +34,8 @@ Anthropic credential under Settings, then Inference credentials.
 
 The Compose defaults self-verify the first account and make it the admin.
 Create that account before you expose the server to another network. The
-[deployment guide](guides/operate/deploy.md) covers readiness, closing
-registration, and the other sandbox providers.
+[deployment guide](guides/operate/deploy.md) shows how to verify readiness,
+close registration, and configure the other sandbox providers.
 
 ### Use the hosted server
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -59,13 +59,9 @@ FOUNTAIN_BASE_URL=http://localhost:4000 fountain auth login
 fountain auth login
 ```
 
-`auth login` asks for an email and a password. It saves the server URL and an
-API key. The commands below need no server flag after that.
-
-**A GitHub account has no password.** If you created your account with the
-GitHub button, add `--device` to the command above. The CLI shows a one-time
-code and opens the console's approval page. Approve the device there, and the
-CLI saves the key for you.
+`auth login` shows a one-time code and opens the console's approval page in
+your browser. Approve the device there. The CLI saves the server URL and an
+API key, so the commands below need no server flag.
 
 ## Apply and run
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -7,18 +7,60 @@ its answer to your terminal.
 The example uses Fountain's public repository. It needs no GitHub token, setup
 script, package install, or Vault.
 
-## Before you run it
+## Choose where Fountain runs
 
-You need a Fountain account with an Anthropic credential under Settings, then
-Inference credentials. You also need the `fountain` CLI.
+Run the server yourself, or use the hosted server. The manifest and the agent
+run are the same on both.
+
+### Run your own server
+
+You need Docker, OpenSSL, and a sandbox provider token. The Compose file runs
+Postgres. The example below uses Sprites as the sandbox provider.
+
+```sh
+git clone https://github.com/BinaryBourbon/fountain
+cd fountain
+cp .env.compose.example .env
+
+echo "SECRET_KEY_BASE=$(openssl rand -base64 48 | tr -d '\n')" >> .env
+echo "MASTER_SECRETS_KEY=$(openssl rand 32 | base64 | tr '+/' '-_' | tr -d '=\n')" >> .env
+
+# Add your SPRITES_TOKEN to .env, then start Fountain.
+docker compose up -d
+```
+
+Open <http://localhost:4000>. Create the first operator account, then add an
+Anthropic credential under Settings, then Inference credentials.
+
+The Compose defaults self-verify the first account and make it the admin.
+Create that account before you expose the server to another network. The
+[deployment guide](guides/operate/deploy.md) covers readiness, closing
+registration, and the other sandbox providers.
+
+### Use the hosted server
+
+Create an account on [managoat.com](https://managoat.com), then add an
+Anthropic credential under Settings, then Inference credentials. The hosted
+server supplies the control plane and sandbox provider.
+
+## Install and authenticate the CLI
 
 ```sh
 brew install BinaryBourbon/tap/fountain
+```
+
+Point the CLI at the server you chose.
+
+```sh
+# Your own server
+FOUNTAIN_BASE_URL=http://localhost:4000 fountain auth login
+
+# Hosted server
 fountain auth login
 ```
 
-The CLI defaults to the hosted instance. For an instance of your own, set
-`FOUNTAIN_BASE_URL` before `fountain auth login`.
+`auth login` saves the server URL and an API key. The commands below need no
+server flag after that.
 
 ## Apply and run
 
@@ -59,23 +101,3 @@ The example uses Claude because it is Fountain's most exercised runtime. To
 use Codex, Gemini CLI, or OpenCode, change `runtime` and `model` in the
 manifest and add that provider's inference credential. The
 [runtime catalog](catalog/runtimes/index.md) lists the accepted shapes.
-
-## Run the server yourself
-
-The hosted path above removes the control plane setup from the product demo.
-Self-hosting has real inputs that a three-command example must not hide. A
-Fountain server needs two encryption keys, Postgres, and a sandbox provider.
-After the first boot, you create an account, add a model credential, and point
-the CLI at the instance.
-
-```sh
-git clone https://github.com/BinaryBourbon/fountain
-cd fountain
-cp .env.compose.example .env
-# Generate the two keys and add a sandbox provider token to .env.
-docker compose up -d
-```
-
-[Deploy an instance](guides/operate/deploy.md) gives the commands and checks
-for that path. Once `fountain auth login` targets the instance, the same
-`apply` and `run` commands above work unchanged.

--- a/examples/quickstart/README.md
+++ b/examples/quickstart/README.md
@@ -4,8 +4,9 @@ This is the smallest Fountain manifest that demonstrates a real sandbox. It
 clones Fountain's public repository and gives a Claude agent the checkout. It
 has no setup script, packages, Vault, or repository credential.
 
-You need an authenticated `fountain` CLI and an Anthropic credential on your
-Fountain account. Then run these two commands from the repository root.
+Once a Fountain server is running, authenticate the `fountain` CLI against
+that server and add an Anthropic credential to your operator account. Then run
+these two commands from the repository root.
 
 ```sh
 fountain apply -f examples/quickstart/fountain.yml
@@ -17,5 +18,5 @@ The first command creates one Environment and one Agent. The second starts a
 sandbox, clones the repository, runs the agent, and streams the answer back to
 the terminal.
 
-Read the [quickstart](../../docs/quickstart.md) for CLI installation, account
-setup, and the self-hosted path.
+Read the [quickstart](../../docs/quickstart.md) to run the server yourself or
+use the hosted one, then install and authenticate the CLI.

--- a/examples/quickstart/README.md
+++ b/examples/quickstart/README.md
@@ -1,0 +1,21 @@
+# Fountain quickstart
+
+This is the smallest Fountain manifest that demonstrates a real sandbox. It
+clones Fountain's public repository and gives a Claude agent the checkout. It
+has no setup script, packages, Vault, or repository credential.
+
+You need an authenticated `fountain` CLI and an Anthropic credential on your
+Fountain account. Then run these two commands from the repository root.
+
+```sh
+fountain apply -f examples/quickstart/fountain.yml
+fountain run fountain-reader -p \
+  "Find the code that reclaims an idle sandbox. Explain when it runs and name the files you read."
+```
+
+The first command creates one Environment and one Agent. The second starts a
+sandbox, clones the repository, runs the agent, and streams the answer back to
+the terminal.
+
+Read the [quickstart](../../docs/quickstart.md) for CLI installation, account
+setup, and the self-hosted path.

--- a/examples/quickstart/fountain.yml
+++ b/examples/quickstart/fountain.yml
@@ -5,7 +5,6 @@ kind: Environment
 metadata:
   name: fountain-quickstart
 spec:
-  networking_type: unrestricted
   repositories:
     - url: https://github.com/BinaryBourbon/fountain
       mount_path: /workspace/fountain
@@ -23,5 +22,3 @@ spec:
     Work in /workspace/fountain. Inspect the repository before you answer.
     Do not edit files. Keep the answer short and name the source files that
     support it.
-  permission_policy:
-    default: auto_allow

--- a/examples/quickstart/fountain.yml
+++ b/examples/quickstart/fountain.yml
@@ -1,0 +1,27 @@
+# The smallest Fountain setup that proves an agent received a real checkout.
+# It needs no repository credential because the Fountain repository is public.
+apiVersion: fountain.dev/v1
+kind: Environment
+metadata:
+  name: fountain-quickstart
+spec:
+  networking_type: unrestricted
+  repositories:
+    - url: https://github.com/BinaryBourbon/fountain
+      mount_path: /workspace/fountain
+---
+apiVersion: fountain.dev/v1
+kind: Agent
+metadata:
+  name: fountain-reader
+spec:
+  runtime: claude
+  model: anthropic/claude-sonnet-5
+  environment: fountain-quickstart
+  description: Reads a real repository in a Fountain sandbox
+  system: |
+    Work in /workspace/fountain. Inspect the repository before you answer.
+    Do not edit files. Keep the answer short and name the source files that
+    support it.
+  permission_policy:
+    default: auto_allow


### PR DESCRIPTION
## Summary

- add a minimal first-agent quickstart using a public Fountain checkout
- add an in-repo Environment and Agent manifest with no Vault or repository credentials
- make the OSS launch page point to the runnable quickstart
- move the quickstart near the top of the docs and README

## Why

The existing self-hosting path has real encryption, sandbox-provider, account, and model-credential prerequisites. This gives launch readers a short hosted-first proof without hiding those requirements, while keeping the full self-hosted path linked.

## Testing

- python3 scripts/docs-style.py
- go test ./...
- mix format --check-formatted
- mix test apps/fountain/test/fountain/docs_test.exs
- mix test apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs