### PR TITLE
feat(cli): add auth login --api-key for GitHub-OAuth accounts

### DIFF
--- a/cli/internal/cmd/auth.go
+++ b/cli/internal/cmd/auth.go
@@ -24,12 +24,21 @@ func init() {
 		Use:   "auth",
 		Short: "Authenticate against the Fountain API",
 	}
-	authCmd.AddCommand(
-		&cobra.Command{
-			Use:   "login",
-			Short: "Authenticate and save credentials",
-			RunE:  func(cmd *cobra.Command, args []string) error { return authLogin() },
+	loginCmd := &cobra.Command{
+		Use:   "login",
+		Short: "Authenticate and save credentials",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			withAPIKey, _ := cmd.Flags().GetBool("api-key")
+			if withAPIKey {
+				return authLoginAPIKey()
+			}
+			return authLogin()
 		},
+	}
+	loginCmd.Flags().Bool("api-key", false,
+		"paste an API key instead of email + password (for accounts that sign in with GitHub)")
+	authCmd.AddCommand(
+		loginCmd,
 		&cobra.Command{
 			Use:   "logout",
 			Short: "Remove saved credentials",
@@ -78,6 +87,17 @@ func authLogin() error {
 
 	respBody, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		// The server answers every bad credential with the same 401 on
+		// purpose (anti-enumeration, #324) — an account created with "Sign
+		// up with GitHub" has no password and lands here too, so the hint
+		// has to live on this side.
+		if resp.StatusCode == http.StatusUnauthorized {
+			Fatalf("login failed (HTTP %d): %s\n\n"+
+				"If you signed up with GitHub, your account has no password.\n"+
+				"Create an API key in the console (%s/api-keys), then run:\n\n"+
+				"  fountain auth login --api-key",
+				resp.StatusCode, respBody, base)
+		}
 		Fatalf("login failed (HTTP %d): %s", resp.StatusCode, respBody)
 	}
 
@@ -95,6 +115,76 @@ func authLogin() error {
 
 	fmt.Printf("Logged in as %s. Credentials written to ~/.fountain/credentials (profile: %s).\n", email, profile)
 	return nil
+}
+
+// authLoginAPIKey is `auth login --api-key`: the login path for accounts that
+// sign in with GitHub and therefore have no password to exchange at
+// /api/auth/token (#1305). The key is prompted for, never taken as a flag
+// value, so it stays out of shell history; the prompt is hidden on a TTY and
+// falls back to a plain stdin read so `echo $KEY | fountain auth login
+// --api-key` works in scripts.
+func authLoginAPIKey() error {
+	opts := activeOpts()
+	profile := credentials.ProfileName(opts)
+	base := config.BaseURL(opts)
+
+	key, err := promptPassword("API key: ")
+	if err != nil {
+		return err
+	}
+	key = strings.TrimSpace(key)
+	if key == "" {
+		Fatal("no API key given. Create one in the console at " + base + "/api-keys.")
+	}
+
+	// Validate before writing, so a mispasted key fails here rather than on
+	// the next command.
+	me, err := fetchAuthMe(base, key)
+	if err != nil {
+		Fatalf("could not verify the API key against %s: %v", base, err)
+	}
+
+	if err := credentials.WriteProfile(profile, map[string]string{
+		"api_key":  key,
+		"base_url": base,
+	}); err != nil {
+		return err
+	}
+
+	fmt.Printf("Logged in as %s. Credentials written to ~/.fountain/credentials (profile: %s).\n", me.Email, profile)
+	return nil
+}
+
+// fetchAuthMe checks a raw key against GET /api/auth/me. It cannot go through
+// api.Client, which resolves its key from the environment and the credentials
+// file — exactly what this key has not been written to yet.
+func fetchAuthMe(base, key string) (*authMe, error) {
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, base+"/api/auth/me", nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+key)
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, fmt.Errorf("the server rejected the key (HTTP 401)")
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, respBody)
+	}
+
+	var me authMe
+	if err := json.Unmarshal(respBody, &me); err != nil {
+		return nil, fmt.Errorf("unexpected response: %s", respBody)
+	}
+	return &me, nil
 }
 
 // extractAPIKey accepts any of the four shapes the server has returned:

--- a/cli/internal/cmd/auth_test.go
+++ b/cli/internal/cmd/auth_test.go
@@ -1,0 +1,108 @@
+package cmd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/BinaryBourbon/fountain/cli/internal/credentials"
+)
+
+// TestAuthLoginAPIKeyWritesCredentials is the fix for #1305: an account
+// created with "Sign up with GitHub" has no password, so `auth login`'s
+// email + password exchange can never work for it. `auth login --api-key`
+// reads a pasted key from stdin, verifies it against GET /api/auth/me and
+// writes it to the credentials file.
+func TestAuthLoginAPIKeyWritesCredentials(t *testing.T) {
+	const key = "ftn_test_1111111111111111"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/api/auth/me" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer "+key {
+			t.Errorf("Authorization = %q, want the pasted key", got)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		// Byte-for-byte the shape of FountainWeb.AuthMeController.show/2:
+		// a flat object, no `data` envelope.
+		_, _ = w.Write([]byte(`{
+			"id": "0198c9a2-1111-7222-8333-444455556666",
+			"email": "goat@example.com",
+			"role": "user"
+		}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("FOUNTAIN_BASE_URL", srv.URL)
+	t.Setenv("FOUNTAIN_PROFILE", "")
+
+	credsPath := filepath.Join(t.TempDir(), "credentials")
+	credentials.SetPathOverride(credsPath)
+	t.Cleanup(func() { credentials.SetPathOverride("") })
+
+	restore := stdinFrom(t, key+"\n")
+	defer restore()
+
+	if err := authLoginAPIKey(); err != nil {
+		t.Fatalf("authLoginAPIKey: %v", err)
+	}
+
+	content, err := os.ReadFile(credsPath)
+	if err != nil {
+		t.Fatalf("credentials file was not written: %v", err)
+	}
+	attrs := credentials.ParseAll(string(content))["default"]
+	if attrs["api_key"] != key {
+		t.Errorf("saved api_key = %q, want %q", attrs["api_key"], key)
+	}
+	if attrs["base_url"] != srv.URL {
+		t.Errorf("saved base_url = %q, want %q", attrs["base_url"], srv.URL)
+	}
+}
+
+// A mispasted key must fail at login time, not on the next command — and it
+// must not be written to the credentials file.
+func TestAuthLoginAPIKeyRejectsBadKey(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"Invalid API key"}`))
+	}))
+	defer srv.Close()
+
+	_, err := fetchAuthMe(srv.URL, "ftn_wrong")
+	if err == nil {
+		t.Fatal("fetchAuthMe accepted a key the server rejected")
+	}
+	if !strings.Contains(err.Error(), "401") {
+		t.Errorf("error %q does not name the 401", err)
+	}
+}
+
+// stdinFrom replaces os.Stdin with a pipe holding `input` and returns the
+// restore func. promptPassword falls back to a plain line read on a non-TTY,
+// which is what a pipe is.
+func stdinFrom(t *testing.T, input string) func() {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	if _, err := w.WriteString(input); err != nil {
+		t.Fatalf("write to pipe: %v", err)
+	}
+	w.Close()
+	orig := os.Stdin
+	os.Stdin = r
+	return func() {
+		os.Stdin = orig
+		r.Close()
+	}
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -23,10 +23,17 @@ Or take a release binary from the
 ## Authentication
 
 ```bash
-fountain auth login     # prompts for email + password, saves an API key
-fountain auth whoami    # print the current user
-fountain auth logout    # remove saved credentials
+fountain auth login            # prompts for email + password, saves an API key
+fountain auth login --api-key  # prompts for a pasted API key instead
+fountain auth whoami           # print the current user
+fountain auth logout           # remove saved credentials
 ```
+
+An account made with the "Sign up with GitHub" button has no password. For
+that account, use `--api-key`. Create an API key in the console, on the
+**API keys** page. Then run `fountain auth login --api-key` and paste the key
+at the prompt. The CLI checks the key against the server and saves it. The
+prompt also reads a piped line, so a script can supply the key on stdin.
 
 `auth login` has no `--endpoint` flag. Point the CLI at a different instance
 with `FOUNTAIN_BASE_URL`. `auth login` then records that URL in the saved

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -114,7 +114,13 @@ Options:
 Authenticate and save credentials
 
 ```
-fountain auth login
+fountain auth login [flags]
+```
+
+Options:
+
+```
+      --api-key   paste an API key instead of email + password (for accounts that sign in with GitHub)
 ```
 
 ## `fountain auth logout`


### PR DESCRIPTION
## Problem (#1305)

`fountain auth login` only exchanges email + password at `/api/auth/token`. An account created with **Sign up with GitHub** has no password, so the exchange can never succeed and the CLI died with an unexplained 401. That is the default hosted-path experience for launch traffic.

## What this does

- **`fountain auth login --api-key`** — prompts for a pasted API key (hidden input on a TTY; a plain stdin read when piped, so `echo $KEY | fountain auth login --api-key` works in scripts). The key is verified against `GET /api/auth/me` before anything is written, then saved to `~/.fountain/credentials` with the base URL. Unlike the exported-`FOUNTAIN_API_KEY` workaround from #1304, it survives new shells and profiles work.
- The key is prompted for, never accepted as a flag value, so it stays out of shell history.
- The password path's 401 now explains the GitHub-account case and points at the console's `/api-keys` page and the new flag, instead of failing silently.
- `docs/cli.md` documents the flow; `docs/cli/commands.md` regenerated.

## What this deliberately does not do

The issue's server-side option (a distinguishable error for passwordless accounts) is not taken: `Accounts.authenticate_user/2` answers every bad credential identically on purpose so login cannot become an account-existence or auth-method oracle (#324, see the comment in `apps/fountain/lib/fountain/accounts.ex`). The device-authorization flow remains open as a future UX improvement.

## Testing

- `go test ./...` and `go vet ./...` in `cli/` — green (new `auth_test.go` covers the happy path against the real `/api/auth/me` shape, and bad-key rejection).
- `mix test apps/fountain/test/fountain/docs_test.exs` — 43 tests, 0 failures.
- All three prose gates clean (`docs-style.py`, vale STE 0 errors, destink).

Closes #1305

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dex5a9SZHXpST6KyueR3Bc