### PR TITLE
fix(marketing): sync diagram with header mark

### DIFF
--- a/apps/fountain/lib/fountain_web/components/layouts/marketing.html.heex
+++ b/apps/fountain/lib/fountain_web/components/layouts/marketing.html.heex
@@ -3,7 +3,12 @@
   <header class="border-b border-[var(--color-border)] bg-[var(--color-bg-0)]">
     <div class="max-w-5xl mx-auto px-6 py-4 flex items-center justify-between">
       <a href="/" class="flex items-center gap-2">
-        <img src={Fountain.Brand.asset("app-icon.png")} alt="" class="size-7 rounded-md" />
+        <img
+          src={Fountain.Brand.asset("app-icon.png")}
+          alt=""
+          class="size-7 rounded-md"
+          data-role="brand-mark"
+        />
         <span class="font-semibold text-sm text-[var(--color-text-primary)]">
           {Fountain.Brand.name()}
         </span>
@@ -165,7 +170,12 @@
       <div class="grid grid-cols-2 gap-x-8 gap-y-10 md:grid-cols-4">
         <div class="col-span-2 md:col-span-1">
           <a href="/" class="flex items-center gap-2">
-            <img src={Fountain.Brand.asset("app-icon.png")} alt="" class="size-6 rounded-md" />
+            <img
+              src={Fountain.Brand.asset("app-icon.png")}
+              alt=""
+              class="size-6 rounded-md"
+              data-role="brand-mark"
+            />
             <span class="font-semibold text-[var(--color-text-primary)]">
               {Fountain.Brand.name()}
             </span>

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/oss_launch.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/oss_launch.html.heex
@@ -3,7 +3,6 @@
       observability part of the first-screen promise. --%>
 
 <section class="relative overflow-hidden border-b border-[var(--color-border)]">
-  <div class="absolute inset-x-0 top-0 h-px bg-[var(--color-accent)]" aria-hidden="true"></div>
   <div class="max-w-6xl mx-auto px-5 sm:px-6 py-16 sm:py-24 grid lg:grid-cols-[1.05fr_0.95fr] gap-12 lg:gap-16 items-center">
     <div>
       <p class="inline-flex items-center gap-2 rounded-full border border-[var(--color-border-strong)] bg-[var(--color-bg-1)] px-3.5 py-1.5 text-xs font-medium uppercase tracking-[0.16em] text-[var(--color-text-secondary)]">

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/oss_launch.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/oss_launch.html.heex
@@ -93,7 +93,8 @@
           <img
             src={Fountain.Brand.asset("app-icon.png")}
             alt=""
-            class="size-8 rounded-lg ring-1 ring-white/15"
+            class="size-8 rounded-lg"
+            data-role="brand-mark"
           />
           <strong class="text-sm font-semibold uppercase tracking-[0.08em]">
             Fountain

--- a/apps/fountain/priv/static/assets/paper.css
+++ b/apps/fountain/priv/static/assets/paper.css
@@ -233,13 +233,14 @@
   opacity: 0.07;
 }
 
-/* The mark. The chrome's app icon is a colour tile, and a page with one ink
-   cannot hold a second palette in the corner, so `content` swaps in the
-   brand's mono drawing without the layout having to know which skin is on.
-   `width: auto` keeps the drawing's proportions inside the square box the
-   utility class gives it. */
-[data-skin="paper"] header img[alt=""],
-[data-skin="paper"] footer img[alt=""] {
+/* The mark. The default app icon is a colour tile, and a page with one ink
+   cannot hold a second palette, so `content` swaps in the brand's mono
+   drawing without the layout or a diagram having to know which skin is on.
+   Every displayed brand mark carries the same hook: the chrome and product
+   diagrams therefore cannot quietly choose different marks. `width: auto`
+   keeps the drawing's proportions inside the square box the utility class
+   gives it. */
+[data-skin="paper"] img[data-role="brand-mark"] {
   content: var(--paper-mark);
   width: auto;
   filter: var(--paper-mark-filter);

--- a/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
@@ -131,6 +131,7 @@ defmodule FountainWeb.MarketingControllerTest do
 
       assert body =~ "Running agent"
       assert body =~ "fixing test_user_login.py"
+      refute body =~ ~s(absolute inset-x-0 top-0 h-px)
 
       for target <- FountainWeb.MarketingHTML.oss_deploy_targets() do
         assert body =~ target.name, "missing deployment target #{target.name}"

--- a/apps/fountain/test/fountain_web/paper_skin_test.exs
+++ b/apps/fountain/test/fountain_web/paper_skin_test.exs
@@ -146,6 +146,13 @@ defmodule FountainWeb.PaperSkinTest do
 
       assert html =~ ~s(data-skin="paper")
     end
+
+    test "the OSS diagram uses the same displayed brand mark as the chrome", %{conn: conn} do
+      html = conn |> get(~p"/oss-launch") |> html_response(200)
+
+      assert length(Regex.scan(~r/data-role="brand-mark"/, html)) == 3
+      assert File.read!(@paper) =~ ~s(img[data-role="brand-mark"])
+    end
   end
 
   describe "everything that is not a marketing page" do


### PR DESCRIPTION
## Summary

- give the marketing header, footer, and OSS launch diagram one shared brand-mark hook
- keep the configured color app icon in the classic skin
- apply the paper skin's configured monochrome mark and dark-mode inversion to the diagram exactly as the header does
- remove the diagram-only icon ring and add regression coverage for the shared hook
- remove the OSS hero's accent rule so the shared gray navbar divider matches the rest of the site

## Test plan

- `mix format --check-formatted apps/fountain/lib/fountain_web/components/layouts/marketing.html.heex apps/fountain/lib/fountain_web/controllers/marketing_html/oss_launch.html.heex apps/fountain/test/fountain_web/paper_skin_test.exs`
- `mix test apps/fountain/test/fountain_web/paper_skin_test.exs apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs apps/fountain/test/fountain_web/brand_chrome_test.exs` (95 tests, 0 failures)
