### PR TITLE
feat: device-authorization login for the CLI (fountain auth login --device)

### DIFF
--- a/apps/fountain/lib/fountain/oauth.ex
+++ b/apps/fountain/lib/fountain/oauth.ex
@@ -33,10 +33,18 @@ defmodule Fountain.OAuth do
   import Ecto.Query, warn: false
 
   alias Fountain.{Accounts, Audit, Repo}
-  alias Fountain.OAuth.AuthorizationCode
+  alias Fountain.OAuth.{AuthorizationCode, DeviceGrant}
 
   @code_ttl_seconds 300
   @token_ttl_seconds 30 * 24 * 3600
+
+  @device_ttl_seconds 900
+  @device_interval_seconds 5
+  # RFC 8628's suggested consonant alphabet: no vowels (no words, no
+  # accidental profanity), no ambiguous glyphs. 20^8 codes for a
+  # fifteen-minute, rate-limited window.
+  @user_code_alphabet ~c"BCDFGHJKLMNPQRSTVWXZ"
+  @user_code_length 8
 
   @type client :: %{id: String.t(), name: String.t(), redirect_uris: [String.t()]}
 
@@ -211,14 +219,241 @@ defmodule Fountain.OAuth do
     Accounts.revoke_api_key(key.user_id, key.id, opts)
   end
 
-  @doc "Delete codes past their expiry (a sweep; codes are tiny, this is hygiene)."
+  ## ─── Device authorization (RFC 8628 shape, for the CLI — #1305) ───────────
+  #
+  # `fountain auth login --device` cannot exchange a password: an account
+  # created with "Sign up with GitHub" has none. Instead the CLI starts a
+  # grant, shows the human a short code and the console's `/device` page,
+  # and polls with its own high-entropy device code until the signed-in
+  # browser session approves. The mint mirrors `POST /api/auth/token`:
+  # a full-scope API key with no expiry, because it replaces that endpoint
+  # for these accounts.
+
+  @doc """
+  Start a device grant. Returns `{:ok, %{device_code, user_code, expires_in,
+  interval}}` — `device_code` is raw (only its hash is stored) and stays on
+  the polling machine; `user_code` is formatted `XXXX-XXXX` for a human to
+  type. Unauthenticated and deliberately unaudited: nothing has happened to
+  any account yet, and the poll's mint audits `api_key.created` as usual.
+  """
+  def start_device_grant do
+    raw = Base.url_encode64(:crypto.strong_rand_bytes(32), padding: false)
+    insert_device_grant(raw, _attempts_left = 3)
+  end
+
+  defp insert_device_grant(_raw, 0), do: {:error, :server_error}
+
+  defp insert_device_grant(raw, attempts_left) do
+    user_code = generate_user_code()
+
+    %DeviceGrant{}
+    |> DeviceGrant.changeset(%{
+      device_code_hash: hash(raw),
+      user_code: user_code,
+      expires_at:
+        DateTime.utc_now()
+        |> DateTime.add(@device_ttl_seconds, :second)
+        |> DateTime.truncate(:second)
+    })
+    |> Repo.insert()
+    |> case do
+      {:ok, _grant} ->
+        {:ok,
+         %{
+           device_code: raw,
+           user_code: format_user_code(user_code),
+           expires_in: @device_ttl_seconds,
+           interval: @device_interval_seconds
+         }}
+
+      # A user_code collision (20^8 space, so effectively never) — roll again.
+      {:error, %Ecto.Changeset{errors: errors}} ->
+        if Keyword.has_key?(errors, :user_code),
+          do: insert_device_grant(raw, attempts_left - 1),
+          else: {:error, :server_error}
+    end
+  end
+
+  defp generate_user_code do
+    for _ <- 1..@user_code_length, into: "" do
+      <<Enum.random(@user_code_alphabet)>>
+    end
+  end
+
+  @doc ~S(Format a stored user code for humans: "BCDFGHJK" → "BCDF-GHJK".)
+  def format_user_code(<<a::binary-size(4), b::binary-size(4)>>), do: a <> "-" <> b
+  def format_user_code(code), do: code
+
+  @doc """
+  Normalize what a human typed: case, the display dash, stray spaces.
+  """
+  def normalize_user_code(input) when is_binary(input) do
+    input |> String.upcase() |> String.replace(~r/[^A-Z]/, "")
+  end
+
+  @doc """
+  The pending, unexpired grant for a typed user code — what the `/device`
+  approval page shows before the user decides. `{:ok, grant}` or
+  `{:error, :not_found}` (one answer for unknown, expired and decided alike).
+  """
+  def get_device_grant_for_approval(input) when is_binary(input) do
+    now = DateTime.utc_now()
+    code = normalize_user_code(input)
+
+    Repo.one(
+      from g in DeviceGrant,
+        where:
+          g.user_code == ^code and is_nil(g.approved_at) and is_nil(g.denied_at) and
+            is_nil(g.used_at) and g.expires_at > ^now
+    )
+    |> case do
+      %DeviceGrant{} = grant -> {:ok, grant}
+      nil -> {:error, :not_found}
+    end
+  end
+
+  @doc """
+  The signed-in user approves the grant behind a typed user code: binds their
+  account to it so the next poll mints them a key. Conditional on the grant
+  still being pending and unexpired, so approve/deny/expiry cannot race.
+  Records `oauth.device_approved`.
+  """
+  def approve_device_grant(input, user_id, opts \\ []) when is_binary(user_id) do
+    decide_device_grant(input, user_id, [approved_at: now_s()], "oauth.device_approved", opts)
+  end
+
+  @doc """
+  The signed-in user denies the grant: the polling CLI gets `access_denied`.
+  Records `oauth.device_denied`.
+  """
+  def deny_device_grant(input, user_id, opts \\ []) when is_binary(user_id) do
+    decide_device_grant(input, user_id, [denied_at: now_s()], "oauth.device_denied", opts)
+  end
+
+  defp decide_device_grant(input, user_id, set, action, opts) do
+    with {:ok, grant} <- get_device_grant_for_approval(input) do
+      from(g in DeviceGrant,
+        where:
+          g.id == ^grant.id and is_nil(g.approved_at) and is_nil(g.denied_at) and
+            is_nil(g.used_at)
+      )
+      |> Repo.update_all(set: [{:user_id, user_id} | set])
+      |> case do
+        {1, _} ->
+          Audit.record(%{
+            user_id: user_id,
+            action: action,
+            resource_type: "oauth_device_grant",
+            resource_id: grant.id,
+            actor: Keyword.get(opts, :actor, "ui"),
+            request_ip: Keyword.get(opts, :request_ip)
+          })
+
+          :ok
+
+        {0, _} ->
+          {:error, :not_found}
+      end
+    end
+  end
+
+  @doc """
+  The CLI polls with its device code. One of:
+
+  - `{:ok, %{access_token, api_key}}` — approved; the grant is consumed and a
+    full-scope API key minted (once: the conditional update that marks the
+    grant used means two concurrent polls cannot both win)
+  - `{:error, :authorization_pending}` — nobody has decided yet
+  - `{:error, :slow_down}` — polled faster than the advertised interval
+  - `{:error, :access_denied}` — denied in the console, or the approving
+    account cannot hold a key (suspended, unverified)
+  - `{:error, :expired_token}` — the grant timed out
+  - `{:error, :invalid_grant}` — unknown or already-consumed code
+  """
+  def poll_device_grant(device_code, opts \\ []) when is_binary(device_code) do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    case Repo.get_by(DeviceGrant, device_code_hash: hash(device_code)) do
+      nil ->
+        {:error, :invalid_grant}
+
+      %DeviceGrant{used_at: %DateTime{}} ->
+        {:error, :invalid_grant}
+
+      %DeviceGrant{denied_at: %DateTime{}} ->
+        {:error, :access_denied}
+
+      %DeviceGrant{} = grant ->
+        if DateTime.compare(grant.expires_at, now) == :gt,
+          do: poll_live_grant(grant, now, opts),
+          else: {:error, :expired_token}
+    end
+  end
+
+  defp poll_live_grant(%DeviceGrant{approved_at: nil} = grant, now, _opts) do
+    threshold = DateTime.add(now, -(@device_interval_seconds - 1), :second)
+
+    from(g in DeviceGrant,
+      where: g.id == ^grant.id and (is_nil(g.last_polled_at) or g.last_polled_at <= ^threshold)
+    )
+    |> Repo.update_all(set: [last_polled_at: now])
+    |> case do
+      {1, _} -> {:error, :authorization_pending}
+      {0, _} -> {:error, :slow_down}
+    end
+  end
+
+  defp poll_live_grant(%DeviceGrant{} = grant, now, opts) do
+    # user_id was established by the approval above; the grant is the proof.
+    user = Repo.preload(grant, :user).user
+
+    cond do
+      is_nil(user) ->
+        {:error, :invalid_grant}
+
+      # The console page sits behind `require_authenticated_user`, which
+      # turns away unverified and suspended sessions — so these are
+      # belt-and-braces for state that changed between approval and poll.
+      Accounts.suspended?(user) or is_nil(user.email_verified_at) ->
+        {:error, :access_denied}
+
+      true ->
+        mint_device_key(grant, user, now, opts)
+    end
+  end
+
+  defp mint_device_key(grant, user, now, opts) do
+    from(g in DeviceGrant, where: g.id == ^grant.id and is_nil(g.used_at))
+    |> Repo.update_all(set: [used_at: now])
+    |> case do
+      {0, _} ->
+        {:error, :invalid_grant}
+
+      {1, _} ->
+        name = "CLI login — #{DateTime.to_date(now)}"
+
+        case Accounts.create_api_key(user.id, name,
+               actor: Keyword.get(opts, :actor, "api"),
+               request_ip: Keyword.get(opts, :request_ip)
+             ) do
+          {:ok, {api_key, raw_key}} -> {:ok, %{access_token: raw_key, api_key: api_key}}
+          {:error, _} -> {:error, :server_error}
+        end
+    end
+  end
+
+  defp now_s, do: DateTime.utc_now() |> DateTime.truncate(:second)
+
+  @doc "Delete codes and device grants past their expiry (a sweep; hygiene)."
   def prune_expired do
     now = DateTime.utc_now()
-    {n, _} = Repo.delete_all(from(c in AuthorizationCode, where: c.expires_at < ^now))
-    n
+    {codes, _} = Repo.delete_all(from(c in AuthorizationCode, where: c.expires_at < ^now))
+    {grants, _} = Repo.delete_all(from(g in DeviceGrant, where: g.expires_at < ^now))
+    codes + grants
   end
 
   def token_ttl_seconds, do: @token_ttl_seconds
+  def device_interval_seconds, do: @device_interval_seconds
 
   defp hash(raw), do: Base.encode16(:crypto.hash(:sha256, raw), case: :lower)
 end

--- a/apps/fountain/lib/fountain/oauth/device_grant.ex
+++ b/apps/fountain/lib/fountain/oauth/device_grant.ex
@@ -1,0 +1,36 @@
+defmodule Fountain.OAuth.DeviceGrant do
+  @moduledoc """
+  A device-authorization grant (RFC 8628 shape) for the CLI (#1305).
+
+  Two codes, two audiences: the high-entropy `device_code` (stored hashed)
+  stays on the machine that started the flow and is what the CLI polls with;
+  the short `user_code` is what a human types into the console at `/device`.
+  `user_id` is null until a signed-in user approves or denies. Single use
+  (`used_at`), fifteen minutes to live.
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+
+  schema "oauth_device_grants" do
+    field :device_code_hash, :string
+    field :user_code, :string
+    field :approved_at, :utc_datetime
+    field :denied_at, :utc_datetime
+    field :used_at, :utc_datetime
+    field :last_polled_at, :utc_datetime
+    field :expires_at, :utc_datetime
+    belongs_to :user, Fountain.Accounts.User
+    timestamps(type: :utc_datetime)
+  end
+
+  def changeset(grant, attrs) do
+    grant
+    |> cast(attrs, [:device_code_hash, :user_code, :expires_at])
+    |> validate_required([:device_code_hash, :user_code, :expires_at])
+    |> unique_constraint(:device_code_hash)
+    |> unique_constraint(:user_code)
+  end
+end

--- a/apps/fountain/lib/fountain_web/controllers/device_auth_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/device_auth_controller.ex
@@ -1,0 +1,114 @@
+defmodule FountainWeb.DeviceAuthController do
+  @moduledoc """
+  Device authorization for the CLI (#1305, RFC 8628 shape).
+
+  `POST /api/auth/device` starts a grant; the human approves it at `/device`
+  in a signed-in browser; `POST /api/auth/device/token` is what the CLI polls
+  until the approval mints a key. This is the login path for accounts that
+  signed up with GitHub and therefore cannot use `POST /api/auth/token` —
+  they have no password to exchange.
+
+  Both endpoints are unauthenticated by design (the whole point is that the
+  caller has no credential yet) and rate-limited: the start like the other
+  auth front doors, the poll generously enough for one grant's lifetime of
+  five-second polls.
+  """
+
+  use FountainWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Fountain.OAuth
+  alias FountainWeb.Audited
+  alias FountainWeb.Schemas
+
+  plug FountainWeb.Plugs.RateLimit,
+       [bucket: "device_auth", max: 10, window_ms: 3_600_000]
+       when action in [:create]
+
+  plug FountainWeb.Plugs.RateLimit,
+       [bucket: "device_token", max: 600, window_ms: 3_600_000]
+       when action in [:token]
+
+  tags(["Auth"])
+
+  operation(:create,
+    summary: "Start a device-authorization grant",
+    description:
+      "The CLI login path for accounts without a password (\"Sign up with " <>
+        "GitHub\"). Show the user `user_code` and send them to " <>
+        "`verification_uri` (or open `verification_uri_complete`), then poll " <>
+        "`POST /api/auth/device/token` with `device_code` every `interval` " <>
+        "seconds until they approve. The grant expires after `expires_in` " <>
+        "seconds. Rate-limited to 10 grants per IP per hour.",
+    security: [],
+    responses: [
+      created: {"A new device grant", "application/json", Schemas.DeviceAuthResponse}
+    ]
+  )
+
+  def create(conn, _params) do
+    case OAuth.start_device_grant() do
+      {:ok, grant} ->
+        conn
+        |> put_status(:created)
+        |> put_resp_header("cache-control", "no-store")
+        |> json(%{
+          device_code: grant.device_code,
+          user_code: grant.user_code,
+          verification_uri: url(~p"/device"),
+          verification_uri_complete: url(~p"/device?#{[code: grant.user_code]}"),
+          expires_in: grant.expires_in,
+          interval: grant.interval
+        })
+
+      {:error, _} ->
+        conn |> put_status(:internal_server_error) |> json(%{error: "server_error"})
+    end
+  end
+
+  operation(:token,
+    summary: "Poll a device grant for the API key",
+    description:
+      "Polled by the CLI with the `device_code` from `POST /api/auth/device`. " <>
+        "Until the user decides, 400 `authorization_pending` (or `slow_down` " <>
+        "when polled faster than `interval`). A denial is 400 `access_denied`; " <>
+        "a timed-out grant is 400 `expired_token`; an unknown or already-used " <>
+        "code is 400 `invalid_grant`. On approval, 201 with a full-scope API " <>
+        "key — the same shape `POST /api/auth/token` returns — and the grant " <>
+        "is consumed.",
+    security: [],
+    request_body:
+      {"Device token request", "application/json", Schemas.DeviceTokenRequest, required: true},
+    responses: [
+      created: {"A new API key", "application/json", Schemas.AuthTokenResponse},
+      bad_request:
+        {"authorization_pending / slow_down / access_denied / expired_token / invalid_grant",
+         "application/json", Schemas.Error}
+    ]
+  )
+
+  def token(conn, %{"device_code" => device_code}) when is_binary(device_code) do
+    # No session, so derivation would call the mint "system"; it is the CLI
+    # collecting the key a browser approval promised it.
+    case OAuth.poll_device_grant(device_code,
+           actor: "api",
+           request_ip: Audited.attribution(conn)[:request_ip]
+         ) do
+      {:ok, %{access_token: raw_key, api_key: api_key}} ->
+        conn
+        |> put_status(:created)
+        |> put_resp_header("cache-control", "no-store")
+        |> json(%{api_key: raw_key, key_id: api_key.id, prefix: api_key.key_prefix})
+
+      {:error, :server_error} ->
+        conn |> put_status(:internal_server_error) |> json(%{error: "server_error"})
+
+      {:error, reason} ->
+        conn |> put_status(:bad_request) |> json(%{error: to_string(reason)})
+    end
+  end
+
+  def token(conn, _params) do
+    conn |> put_status(:bad_request) |> json(%{error: "invalid_grant"})
+  end
+end

--- a/apps/fountain/lib/fountain_web/live/device_live.ex
+++ b/apps/fountain/lib/fountain_web/live/device_live.ex
@@ -1,0 +1,161 @@
+defmodule FountainWeb.DeviceLive do
+  @moduledoc """
+  The human half of device authorization (#1305): `fountain auth login
+  --device` prints a short code and this page's URL; the signed-in user types
+  (or arrives with) the code, sees what approving means, and decides. The
+  polling CLI then collects an API key minted for this account.
+  """
+  use FountainWeb, :live_view
+
+  alias Fountain.OAuth
+
+  @impl true
+  def mount(params, _session, socket) do
+    socket =
+      socket
+      |> assign(:page_title, "Device login")
+      |> assign(:stage, :enter)
+      |> assign(:grant, nil)
+      |> assign(:code_value, params["code"] || "")
+
+    # A ?code= arrival (verification_uri_complete) skips the typing but not
+    # the decision: look it up now so the user lands on approve/deny.
+    socket =
+      case params["code"] do
+        code when is_binary(code) and code != "" -> lookup(socket, code)
+        _ -> socket
+      end
+
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_event("lookup", %{"code" => code}, socket) do
+    {:noreply, lookup(assign(socket, :code_value, code), code)}
+  end
+
+  def handle_event("approve", _params, socket) do
+    case socket.assigns.grant do
+      nil ->
+        {:noreply, assign(socket, :stage, :enter)}
+
+      grant ->
+        case OAuth.approve_device_grant(
+               grant.user_code,
+               socket.assigns.current_user.id,
+               FountainWeb.Audited.attribution(socket)
+             ) do
+          :ok ->
+            {:noreply, socket |> assign(:stage, :approved) |> assign(:grant, nil)}
+
+          {:error, :not_found} ->
+            {:noreply,
+             socket
+             |> assign(:stage, :enter)
+             |> assign(:grant, nil)
+             |> put_flash(:error, "That code is no longer waiting for approval.")}
+        end
+    end
+  end
+
+  def handle_event("deny", _params, socket) do
+    case socket.assigns.grant do
+      nil ->
+        {:noreply, assign(socket, :stage, :enter)}
+
+      grant ->
+        _ =
+          OAuth.deny_device_grant(
+            grant.user_code,
+            socket.assigns.current_user.id,
+            FountainWeb.Audited.attribution(socket)
+          )
+
+        {:noreply, socket |> assign(:stage, :denied) |> assign(:grant, nil)}
+    end
+  end
+
+  defp lookup(socket, code) do
+    case OAuth.get_device_grant_for_approval(code) do
+      {:ok, grant} ->
+        socket |> assign(:stage, :confirm) |> assign(:grant, grant)
+
+      {:error, :not_found} ->
+        socket
+        |> assign(:stage, :enter)
+        |> assign(:grant, nil)
+        |> put_flash(:error, "Code not found, expired, or already used. Check it and try again.")
+    end
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="max-w-md mx-auto space-y-6">
+      <div>
+        <h1 class="text-2xl font-semibold">Device login</h1>
+        <p class="text-sm text-[var(--color-text-secondary)] mt-1">
+          Approve a <code>fountain auth login --device</code> request from your terminal.
+        </p>
+      </div>
+
+      <form :if={@stage == :enter} phx-submit="lookup" class="space-y-3">
+        <.form_field
+          id="code"
+          label="Code shown in your terminal"
+          name="code"
+          type="text"
+          placeholder="BCDF-GHJK"
+          value={@code_value}
+          errors={[]}
+          required
+        />
+        <.button type="submit">Continue</.button>
+      </form>
+
+      <div
+        :if={@stage == :confirm && @grant}
+        class="rounded border border-[var(--color-border)] bg-[var(--color-bg-1)] p-6 space-y-4"
+      >
+        <p class="text-sm">
+          A device holding the code below is asking for an API key for <span class="font-medium">{@current_user.email}</span>.
+        </p>
+        <code class="block text-center text-2xl font-mono tracking-widest py-2">
+          {OAuth.format_user_code(@grant.user_code)}
+        </code>
+        <p class="text-sm text-[var(--color-text-secondary)]">
+          Only approve if you just ran <code>fountain auth login --device</code>
+          on a machine you control and this code matches your terminal.
+          The key has full access to your account.
+        </p>
+        <div class="flex gap-2">
+          <.button phx-click="approve">Approve</.button>
+          <.button phx-click="deny" variant="secondary">Deny</.button>
+        </div>
+      </div>
+
+      <div
+        :if={@stage == :approved}
+        class="rounded border border-[var(--color-border)] bg-[var(--color-bg-1)] p-6"
+      >
+        <p class="text-sm font-medium">Approved.</p>
+        <p class="text-sm text-[var(--color-text-secondary)] mt-1">
+          Return to your terminal — the CLI picks the key up on its next poll.
+          It lists under <.link navigate={~p"/api-keys"} class="underline">API keys</.link>,
+          where you can revoke it any time.
+        </p>
+      </div>
+
+      <div
+        :if={@stage == :denied}
+        class="rounded border border-[var(--color-border)] bg-[var(--color-bg-1)] p-6"
+      >
+        <p class="text-sm font-medium">Denied.</p>
+        <p class="text-sm text-[var(--color-text-secondary)] mt-1">
+          The device gets <code>access_denied</code> and no key was created.
+        </p>
+      </div>
+    </div>
+    """
+  end
+end

--- a/apps/fountain/lib/fountain_web/plugs/tenant_session_auth.ex
+++ b/apps/fountain/lib/fountain_web/plugs/tenant_session_auth.ex
@@ -43,8 +43,20 @@ defmodule FountainWeb.Plugs.TenantSessionAuth do
     else
       _ ->
         conn
+        |> maybe_stash_return_to()
         |> redirect(to: ~p"/auth/login")
         |> halt()
     end
   end
+
+  # A GET that needed a session comes back to the same path + query after
+  # login — the pattern ReturnTo established for the OAuth consent page
+  # (#818), needed here for /device?code=… (#1305): the CLI keeps polling
+  # while the human signs in, so losing the destination strands both. POSTs
+  # are not stashed: the post-login redirect is a GET, and replaying a POST
+  # path as one lands nowhere.
+  defp maybe_stash_return_to(%Plug.Conn{method: "GET"} = conn),
+    do: FountainWeb.ReturnTo.stash(conn)
+
+  defp maybe_stash_return_to(conn), do: conn
 end

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -246,6 +246,14 @@ defmodule FountainWeb.Router do
     pipe_through :api_public
 
     post "/token", AuthTokenController, :create
+
+    # Device authorization (#1305): the CLI login path for accounts that have
+    # no password ("Sign up with GitHub"). Unauthenticated by design — the
+    # approval happens in a signed-in browser at /device; rate-limited in the
+    # controller.
+    post "/device", DeviceAuthController, :create
+    post "/device/token", DeviceAuthController, :token
+
     post "/register", RegistrationController, :api_create
     post "/resend-verification", RegistrationController, :api_resend
     post "/forgot", PasswordResetController, :api_forgot
@@ -679,6 +687,10 @@ defmodule FountainWeb.Router do
       live "/vaults/:id/edit", VaultsLive.Form, :edit
       live "/audit", AuditLive.Index, :index
       live "/api-keys", ApiKeysLive.Index, :index
+      # Device-authorization approval (#1305): where `fountain auth login
+      # --device` sends the human. Authenticated so the key lands on the
+      # signed-in account.
+      live "/device", DeviceLive, :index
       live "/help", HelpLive.Show, :index
       live "/help/:topic", HelpLive.Show, :show
 

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -2822,6 +2822,69 @@ defmodule FountainWeb.Schemas do
     })
   end
 
+  defmodule DeviceAuthResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "DeviceAuthResponse",
+      description:
+        "A fresh device-authorization grant (#1305). `device_code` stays on the " <>
+          "polling machine and never gets typed; `user_code` is what the human " <>
+          "enters at `verification_uri`.",
+      type: :object,
+      properties: %{
+        device_code: %Schema{
+          type: :string,
+          description: "High-entropy code the CLI polls the token endpoint with. Shown once."
+        },
+        user_code: %Schema{
+          type: :string,
+          example: "BCDF-GHJK",
+          description: "Short code for the human to type into the console."
+        },
+        verification_uri: %Schema{
+          type: :string,
+          description: "The console page where the user approves the grant."
+        },
+        verification_uri_complete: %Schema{
+          type: :string,
+          description: "`verification_uri` with the user code prefilled."
+        },
+        expires_in: %Schema{type: :integer, description: "Seconds until the grant expires."},
+        interval: %Schema{
+          type: :integer,
+          description: "Minimum seconds between polls; faster gets `slow_down`."
+        }
+      },
+      required: [
+        :device_code,
+        :user_code,
+        :verification_uri,
+        :verification_uri_complete,
+        :expires_in,
+        :interval
+      ]
+    })
+  end
+
+  defmodule DeviceTokenRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "DeviceTokenRequest",
+      type: :object,
+      properties: %{
+        device_code: %Schema{
+          type: :string,
+          description: "The `device_code` from `POST /api/auth/device`."
+        }
+      },
+      required: [:device_code]
+    })
+  end
+
   defmodule WebhookEndpoint do
     @moduledoc false
     require OpenApiSpex

--- a/apps/fountain/priv/repo/migrations/20260831000000_create_oauth_device_grants.exs
+++ b/apps/fountain/priv/repo/migrations/20260831000000_create_oauth_device_grants.exs
@@ -1,0 +1,23 @@
+defmodule Fountain.Repo.Migrations.CreateOauthDeviceGrants do
+  use Ecto.Migration
+
+  def change do
+    create table(:oauth_device_grants, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :device_code_hash, :string, null: false
+      add :user_code, :string, null: false
+      # Null until a signed-in user approves or denies in the console.
+      add :user_id, references(:users, type: :binary_id, on_delete: :delete_all)
+      add :approved_at, :utc_datetime
+      add :denied_at, :utc_datetime
+      add :used_at, :utc_datetime
+      add :last_polled_at, :utc_datetime
+      add :expires_at, :utc_datetime, null: false
+      timestamps(type: :utc_datetime)
+    end
+
+    create unique_index(:oauth_device_grants, [:device_code_hash])
+    create unique_index(:oauth_device_grants, [:user_code])
+    create index(:oauth_device_grants, [:expires_at])
+  end
+end

--- a/apps/fountain/test/fountain/oauth_test.exs
+++ b/apps/fountain/test/fountain/oauth_test.exs
@@ -136,6 +136,102 @@ defmodule Fountain.OAuthTest do
     end
   end
 
+  describe "device authorization (#1305)" do
+    alias Fountain.OAuth.DeviceGrant
+
+    test "the happy path: start → approve in the console → poll mints a key, once" do
+      user = insert_verified_user()
+
+      assert {:ok, %{device_code: device_code, user_code: user_code} = grant} =
+               OAuth.start_device_grant()
+
+      assert grant.expires_in == 900
+      assert grant.interval == OAuth.device_interval_seconds()
+      # The display shape a human types back in, dash and all.
+      assert user_code =~ ~r/^[BCDFGHJKLMNPQRSTVWXZ]{4}-[BCDFGHJKLMNPQRSTVWXZ]{4}$/
+
+      # Nobody has decided yet.
+      assert {:error, :authorization_pending} = OAuth.poll_device_grant(device_code)
+
+      # The approval page finds it however the human typed it.
+      assert {:ok, _} = OAuth.get_device_grant_for_approval(String.downcase(user_code))
+      assert :ok = OAuth.approve_device_grant(user_code, user.id, actor: "ui")
+
+      assert {:ok, %{access_token: token, api_key: key}} =
+               OAuth.poll_device_grant(device_code, actor: "api")
+
+      assert key.name =~ "CLI login"
+      assert key.scopes == ["full"]
+      assert is_nil(key.expires_at)
+      assert {:ok, %{id: uid}, _} = Accounts.authenticate_api_key(token)
+      assert uid == user.id
+
+      # Single use: the grant is consumed with the mint.
+      assert {:error, :invalid_grant} = OAuth.poll_device_grant(device_code)
+
+      actions = user.id |> Audit.list_recent_for_user(20) |> Enum.map(& &1.action)
+      assert "oauth.device_approved" in actions
+      assert "api_key.created" in actions
+    end
+
+    test "polling faster than the interval gets slow_down" do
+      {:ok, %{device_code: device_code}} = OAuth.start_device_grant()
+
+      assert {:error, :authorization_pending} = OAuth.poll_device_grant(device_code)
+      assert {:error, :slow_down} = OAuth.poll_device_grant(device_code)
+    end
+
+    test "a denial reaches the polling CLI as access_denied and audits" do
+      user = insert_verified_user()
+      {:ok, %{device_code: device_code, user_code: user_code}} = OAuth.start_device_grant()
+
+      assert :ok = OAuth.deny_device_grant(user_code, user.id, actor: "ui")
+      assert {:error, :access_denied} = OAuth.poll_device_grant(device_code)
+
+      # Decided is decided: no second opinion, in either direction.
+      assert {:error, :not_found} = OAuth.approve_device_grant(user_code, user.id)
+      assert {:error, :not_found} = OAuth.get_device_grant_for_approval(user_code)
+
+      actions = user.id |> Audit.list_recent_for_user(20) |> Enum.map(& &1.action)
+      assert "oauth.device_denied" in actions
+    end
+
+    test "an expired grant is expired_token to the poll, invisible to approval, and pruned" do
+      user = insert_verified_user()
+      {:ok, %{device_code: device_code, user_code: user_code}} = OAuth.start_device_grant()
+
+      Repo.update_all(DeviceGrant,
+        set: [
+          expires_at: DateTime.add(DateTime.utc_now(), -1, :second) |> DateTime.truncate(:second)
+        ]
+      )
+
+      assert {:error, :expired_token} = OAuth.poll_device_grant(device_code)
+      assert {:error, :not_found} = OAuth.get_device_grant_for_approval(user_code)
+      assert {:error, :not_found} = OAuth.approve_device_grant(user_code, user.id)
+      assert OAuth.prune_expired() >= 1
+    end
+
+    test "an unknown device code is invalid_grant" do
+      assert {:error, :invalid_grant} = OAuth.poll_device_grant("not-a-code")
+    end
+
+    test "a suspended approver cannot collect a key" do
+      user = insert_verified_user()
+      {:ok, %{device_code: device_code, user_code: user_code}} = OAuth.start_device_grant()
+      assert :ok = OAuth.approve_device_grant(user_code, user.id)
+
+      {:ok, _, _} = Accounts.suspend_user(user, actor: "admin")
+
+      assert {:error, :access_denied} = OAuth.poll_device_grant(device_code)
+    end
+
+    test "normalize_user_code strips the display shape" do
+      assert OAuth.normalize_user_code(" bcdf-ghjk ") == "BCDFGHJK"
+      assert OAuth.format_user_code("BCDFGHJK") == "BCDF-GHJK"
+    end
+  end
+
   test "pkce_verify is S256 and constant-shape" do
     {v, c} = pkce()
     assert OAuth.pkce_verify(v, c)

--- a/apps/fountain/test/fountain_web/controllers/device_auth_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/device_auth_controller_test.exs
@@ -1,0 +1,81 @@
+defmodule FountainWeb.DeviceAuthControllerTest do
+  # async: true is safe alongside the rate-limited routes because
+  # :rate_limit_test_isolation keys the buckets by test pid.
+  use FountainWeb.ConnCase, async: true
+
+  alias Fountain.OAuth
+
+  describe "POST /api/auth/device" do
+    test "starts a grant the whole flow can run on", %{conn: conn} do
+      conn = post_json(conn, "/api/auth/device", %{})
+
+      assert %{
+               "device_code" => device_code,
+               "user_code" => user_code,
+               "verification_uri" => uri,
+               "verification_uri_complete" => uri_complete,
+               "expires_in" => expires_in,
+               "interval" => interval
+             } = json_response(conn, 201)
+
+      assert String.ends_with?(uri, "/device")
+      assert uri_complete =~ "/device?code="
+      assert expires_in > 0
+      assert interval > 0
+      # The pieces really belong to one live grant.
+      assert {:ok, _} = OAuth.get_device_grant_for_approval(user_code)
+      assert {:error, :authorization_pending} = OAuth.poll_device_grant(device_code)
+      assert get_resp_header(conn, "cache-control") == ["no-store"]
+    end
+  end
+
+  describe "POST /api/auth/device/token" do
+    setup %{conn: conn} do
+      started = post_json(conn, "/api/auth/device", %{})
+
+      %{"device_code" => device_code, "user_code" => user_code} =
+        json_response(started, 201)
+
+      %{device_code: device_code, user_code: user_code}
+    end
+
+    test "pending until approved, then the AuthTokenResponse shape, once",
+         %{conn: conn, device_code: device_code, user_code: user_code} do
+      pending = post_json(conn, "/api/auth/device/token", %{device_code: device_code})
+      assert %{"error" => "authorization_pending"} = json_response(pending, 400)
+
+      user = insert_verified_user()
+      assert :ok = OAuth.approve_device_grant(user_code, user.id)
+
+      minted = post_json(conn, "/api/auth/device/token", %{device_code: device_code})
+      assert %{"api_key" => key, "key_id" => _, "prefix" => prefix} = json_response(minted, 201)
+      assert String.starts_with?(key, "ftn_")
+      assert String.starts_with?(prefix, "ftn_")
+      assert get_resp_header(minted, "cache-control") == ["no-store"]
+
+      # Consumed: the same device code never mints twice.
+      again = post_json(conn, "/api/auth/device/token", %{device_code: device_code})
+      assert %{"error" => "invalid_grant"} = json_response(again, 400)
+    end
+
+    test "a denial is access_denied", %{
+      conn: conn,
+      device_code: device_code,
+      user_code: user_code
+    } do
+      user = insert_verified_user()
+      assert :ok = OAuth.deny_device_grant(user_code, user.id)
+
+      conn = post_json(conn, "/api/auth/device/token", %{device_code: device_code})
+      assert %{"error" => "access_denied"} = json_response(conn, 400)
+    end
+
+    test "an unknown code is invalid_grant, and so is a missing one", %{conn: conn} do
+      unknown = post_json(conn, "/api/auth/device/token", %{device_code: "nope"})
+      assert %{"error" => "invalid_grant"} = json_response(unknown, 400)
+
+      missing = post_json(conn, "/api/auth/device/token", %{})
+      assert %{"error" => "invalid_grant"} = json_response(missing, 400)
+    end
+  end
+end

--- a/apps/fountain/test/fountain_web/live/device_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/device_live_test.exs
@@ -10,6 +10,39 @@ defmodule FountainWeb.DeviceLiveTest do
       assert {:error, {:redirect, %{to: "/auth/login" <> _}}} = live(conn, ~p"/device")
     end
 
+    test "signed out with ?code=: login round-trips back to the confirmation screen", %{
+      conn: conn
+    } do
+      # The normal case for the flow's primary audience: `fountain auth login
+      # --device` opened this URL, but the browser has no console session yet.
+      # The login must come back here — the CLI is polling and the code is
+      # fifteen minutes from expiry — not land on the dashboard.
+      {:ok, %{device_code: device_code, user_code: user_code}} = OAuth.start_device_grant()
+      user = insert_verified_user(password: "correct horse battery")
+      path = "/device?" <> URI.encode_query(code: user_code)
+
+      conn = get(conn, path)
+      assert redirected_to(conn) == "/auth/login"
+      assert get_session(conn, :return_to) == path
+
+      conn =
+        conn
+        |> recycle()
+        |> Plug.Test.init_test_session(%{return_to: path})
+        |> post("/auth/login", %{"email" => user.email, "password" => "correct horse battery"})
+
+      assert redirected_to(conn) == path
+
+      # Follow the redirect: the confirmation screen, code prefilled.
+      {:ok, lv, html} = conn |> recycle() |> live(path)
+      assert html =~ "Approve"
+      assert html =~ user_code
+
+      lv |> element("button", "Approve") |> render_click()
+      assert {:ok, %{api_key: key}} = OAuth.poll_device_grant(device_code)
+      assert key.user_id == user.id
+    end
+
     test "typing the code leads to confirm, approve feeds the waiting poll", %{conn: conn} do
       {:ok, %{device_code: device_code, user_code: user_code}} = OAuth.start_device_grant()
       user = insert_verified_user()

--- a/apps/fountain/test/fountain_web/live/device_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/device_live_test.exs
@@ -1,0 +1,56 @@
+defmodule FountainWeb.DeviceLiveTest do
+  use FountainWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias Fountain.OAuth
+
+  describe "/device — the approval half of fountain auth login --device (#1305)" do
+    test "unauthenticated user is redirected to login", %{conn: conn} do
+      assert {:error, {:redirect, %{to: "/auth/login" <> _}}} = live(conn, ~p"/device")
+    end
+
+    test "typing the code leads to confirm, approve feeds the waiting poll", %{conn: conn} do
+      {:ok, %{device_code: device_code, user_code: user_code}} = OAuth.start_device_grant()
+      user = insert_verified_user()
+
+      conn = login_user(conn, user)
+      {:ok, lv, html} = live(conn, ~p"/device")
+      assert html =~ "Code shown in your terminal"
+
+      html = lv |> element("form") |> render_submit(%{"code" => user_code})
+      assert html =~ user_code
+      assert html =~ user.email
+
+      html = lv |> element("button", "Approve") |> render_click()
+      assert html =~ "Return to your terminal"
+
+      assert {:ok, %{api_key: key}} = OAuth.poll_device_grant(device_code)
+      assert key.user_id == user.id
+    end
+
+    test "arriving with ?code= skips the typing but not the decision", %{conn: conn} do
+      {:ok, %{device_code: device_code, user_code: user_code}} = OAuth.start_device_grant()
+      user = insert_verified_user()
+
+      conn = login_user(conn, user)
+      {:ok, lv, html} = live(conn, ~p"/device?#{[code: user_code]}")
+
+      assert html =~ "Approve"
+      assert {:error, :authorization_pending} = OAuth.poll_device_grant(device_code)
+
+      lv |> element("button", "Deny") |> render_click()
+      assert {:error, :access_denied} = OAuth.poll_device_grant(device_code)
+    end
+
+    test "a wrong code stays on the form with a flash", %{conn: conn} do
+      user = insert_verified_user()
+      conn = login_user(conn, user)
+      {:ok, lv, _html} = live(conn, ~p"/device")
+
+      html = lv |> element("form") |> render_submit(%{"code" => "WRNG-CODE"})
+      assert html =~ "Code not found"
+      assert html =~ "Code shown in your terminal"
+    end
+  end
+end

--- a/cli/internal/cmd/auth.go
+++ b/cli/internal/cmd/auth.go
@@ -9,6 +9,8 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"os/exec"
+	"runtime"
 	"strings"
 	"time"
 
@@ -29,14 +31,24 @@ func init() {
 		Short: "Authenticate and save credentials",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			withAPIKey, _ := cmd.Flags().GetBool("api-key")
-			if withAPIKey {
+			withDevice, _ := cmd.Flags().GetBool("device")
+			switch {
+			case withAPIKey && withDevice:
+				Fatal("--api-key and --device are two different login flows; pick one")
+				return nil
+			case withAPIKey:
 				return authLoginAPIKey()
+			case withDevice:
+				return authLoginDevice()
+			default:
+				return authLogin()
 			}
-			return authLogin()
 		},
 	}
 	loginCmd.Flags().Bool("api-key", false,
 		"paste an API key instead of email + password (for accounts that sign in with GitHub)")
+	loginCmd.Flags().Bool("device", false,
+		"sign in by approving this device in your browser (works for accounts that sign in with GitHub)")
 	authCmd.AddCommand(
 		loginCmd,
 		&cobra.Command{
@@ -94,8 +106,10 @@ func authLogin() error {
 		if resp.StatusCode == http.StatusUnauthorized {
 			Fatalf("login failed (HTTP %d): %s\n\n"+
 				"If you signed up with GitHub, your account has no password.\n"+
-				"Create an API key in the console (%s/api-keys), then run:\n\n"+
-				"  fountain auth login --api-key",
+				"Sign in through your browser instead:\n\n"+
+				"  fountain auth login --device\n\n"+
+				"Or create an API key in the console (%s/api-keys) and run\n"+
+				"`fountain auth login --api-key`.",
 				resp.StatusCode, respBody, base)
 		}
 		Fatalf("login failed (HTTP %d): %s", resp.StatusCode, respBody)
@@ -153,6 +167,169 @@ func authLoginAPIKey() error {
 
 	fmt.Printf("Logged in as %s. Credentials written to ~/.fountain/credentials (profile: %s).\n", me.Email, profile)
 	return nil
+}
+
+// authLoginDevice is `auth login --device`: the RFC-8628-shaped flow (#1305).
+// Works for every account, and is the only interactive option for one created
+// with "Sign up with GitHub" — no password exists to exchange. The CLI starts
+// a grant, sends the human to the console's /device page with a short code,
+// and polls until they approve; the server then mints an API key that is
+// written to ~/.fountain/credentials like any other login.
+func authLoginDevice() error {
+	opts := activeOpts()
+	profile := credentials.ProfileName(opts)
+	base := config.BaseURL(opts)
+
+	grant, err := startDeviceGrant(base)
+	if err != nil {
+		Fatalf("could not start a device login against %s: %v", base, err)
+	}
+
+	fmt.Printf("First, note your one-time code: %s\n\n", grant.UserCode)
+	fmt.Printf("Then approve this device at: %s\n", grant.VerificationURI)
+	// Only reach for a browser on a real terminal; scripts and tests get the
+	// printed URL and nothing else.
+	if term.IsTerminal(int(os.Stdout.Fd())) && openBrowser(grant.VerificationURIComplete) {
+		fmt.Println("(opened in your browser)")
+	}
+	fmt.Println("\nWaiting for approval...")
+
+	key, err := pollDeviceGrant(base, grant)
+	if err != nil {
+		Fatal(err.Error())
+	}
+
+	// The email is cosmetic; the key is already proven by the mint itself.
+	email := "you"
+	if me, err := fetchAuthMe(base, key); err == nil && me.Email != "" {
+		email = me.Email
+	}
+
+	if err := credentials.WriteProfile(profile, map[string]string{
+		"api_key":  key,
+		"base_url": base,
+	}); err != nil {
+		return err
+	}
+
+	fmt.Printf("Logged in as %s. Credentials written to ~/.fountain/credentials (profile: %s).\n", email, profile)
+	return nil
+}
+
+// deviceGrant mirrors FountainWeb.DeviceAuthController.create/2.
+type deviceGrant struct {
+	DeviceCode              string `json:"device_code"`
+	UserCode                string `json:"user_code"`
+	VerificationURI         string `json:"verification_uri"`
+	VerificationURIComplete string `json:"verification_uri_complete"`
+	ExpiresIn               int    `json:"expires_in"`
+	Interval                int    `json:"interval"`
+}
+
+func startDeviceGrant(base string) (*deviceGrant, error) {
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, base+"/api/auth/device", strings.NewReader("{}"))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		if resp.StatusCode == http.StatusNotFound {
+			return nil, fmt.Errorf("HTTP 404 — this server does not support device login yet; use `fountain auth login --api-key` instead")
+		}
+		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, respBody)
+	}
+
+	var grant deviceGrant
+	if err := json.Unmarshal(respBody, &grant); err != nil || grant.DeviceCode == "" || grant.UserCode == "" {
+		return nil, fmt.Errorf("unexpected response: %s", respBody)
+	}
+	return &grant, nil
+}
+
+// deviceSleep is swapped out by tests so the poll loop's pacing is
+// observable without waiting it out.
+var deviceSleep = time.Sleep
+
+// pollDeviceGrant polls until the grant is decided or times out, returning
+// the minted API key. The pacing is the server's: `interval` seconds between
+// polls, plus five more whenever it answers slow_down (RFC 8628 §3.5).
+func pollDeviceGrant(base string, grant *deviceGrant) (string, error) {
+	interval := grant.Interval
+	expiresIn := grant.ExpiresIn
+	if expiresIn <= 0 {
+		expiresIn = 900
+	}
+	deadline := time.Now().Add(time.Duration(expiresIn) * time.Second)
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	body, _ := json.Marshal(map[string]string{"device_code": grant.DeviceCode})
+
+	for time.Now().Before(deadline) {
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, base+"/api/auth/device/token", bytes.NewReader(body))
+		if err != nil {
+			return "", err
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := client.Do(req)
+		if err != nil {
+			return "", err
+		}
+		respBody, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+
+		if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+			if key := extractAPIKey(respBody); key != "" {
+				return key, nil
+			}
+			return "", fmt.Errorf("unexpected token response: %s", respBody)
+		}
+
+		var errResp struct {
+			Error string `json:"error"`
+		}
+		_ = json.Unmarshal(respBody, &errResp)
+
+		switch errResp.Error {
+		case "authorization_pending":
+			// keep waiting
+		case "slow_down":
+			interval += 5
+		case "access_denied":
+			return "", fmt.Errorf("the request was denied in the console; no key was created")
+		case "expired_token":
+			return "", fmt.Errorf("the code expired before it was approved — run `fountain auth login --device` again")
+		default:
+			return "", fmt.Errorf("device login failed (HTTP %d): %s", resp.StatusCode, respBody)
+		}
+
+		deviceSleep(time.Duration(interval) * time.Second)
+	}
+	return "", fmt.Errorf("timed out waiting for approval — run `fountain auth login --device` again")
+}
+
+// openBrowser best-effort opens url in the user's browser; false means the
+// user follows the printed URL by hand.
+func openBrowser(url string) bool {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", url)
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
+	default:
+		cmd = exec.Command("xdg-open", url)
+	}
+	return cmd.Start() == nil
 }
 
 // fetchAuthMe checks a raw key against GET /api/auth/me. It cannot go through

--- a/cli/internal/cmd/auth_test.go
+++ b/cli/internal/cmd/auth_test.go
@@ -1,12 +1,14 @@
 package cmd
 
 import (
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/BinaryBourbon/fountain/cli/internal/credentials"
 )
@@ -83,6 +85,103 @@ func TestAuthLoginAPIKeyRejectsBadKey(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "401") {
 		t.Errorf("error %q does not name the 401", err)
+	}
+}
+
+// TestAuthLoginDeviceWritesCredentials drives the whole RFC-8628-shaped flow
+// (#1305) against the exact JSON FountainWeb.DeviceAuthController renders:
+// start a grant, poll through authorization_pending and slow_down, collect
+// the key once "the browser approved", and write the credentials file.
+func TestAuthLoginDeviceWritesCredentials(t *testing.T) {
+	const key = "ftn_test_2222222222222222"
+
+	var polls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/auth/device":
+			// interval 0 keeps the test's poll loop fast.
+			_, _ = w.Write([]byte(`{
+				"device_code": "dev-code-1",
+				"user_code": "BCDF-GHJK",
+				"verification_uri": "` + "http://console.test/device" + `",
+				"verification_uri_complete": "http://console.test/device?code=BCDF-GHJK",
+				"expires_in": 900,
+				"interval": 0
+			}`))
+		case "/api/auth/device/token":
+			body, _ := io.ReadAll(r.Body)
+			if !strings.Contains(string(body), "dev-code-1") {
+				t.Errorf("poll body %q does not carry the device code", body)
+			}
+			polls++
+			switch polls {
+			case 1:
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`{"error":"authorization_pending"}`))
+			case 2:
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`{"error":"slow_down"}`))
+			default:
+				w.WriteHeader(http.StatusCreated)
+				_, _ = w.Write([]byte(`{"api_key":"` + key + `","key_id":"k1","prefix":"ftn_test"}`))
+			}
+		case "/api/auth/me":
+			_, _ = w.Write([]byte(`{"id":"u1","email":"goat@example.com","role":"user"}`))
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	t.Setenv("FOUNTAIN_BASE_URL", srv.URL)
+	t.Setenv("FOUNTAIN_PROFILE", "")
+
+	credsPath := filepath.Join(t.TempDir(), "credentials")
+	credentials.SetPathOverride(credsPath)
+	t.Cleanup(func() { credentials.SetPathOverride("") })
+
+	var sleeps []time.Duration
+	deviceSleep = func(d time.Duration) { sleeps = append(sleeps, d) }
+	t.Cleanup(func() { deviceSleep = time.Sleep })
+
+	if err := authLoginDevice(); err != nil {
+		t.Fatalf("authLoginDevice: %v", err)
+	}
+	if polls < 3 {
+		t.Errorf("expected the loop to ride out pending and slow_down, got %d polls", polls)
+	}
+	// slow_down (poll 2) must have added five seconds to the pacing.
+	if len(sleeps) < 2 || sleeps[1] != 5*time.Second {
+		t.Errorf("slow_down did not back the interval off: sleeps = %v", sleeps)
+	}
+
+	content, err := os.ReadFile(credsPath)
+	if err != nil {
+		t.Fatalf("credentials file was not written: %v", err)
+	}
+	attrs := credentials.ParseAll(string(content))["default"]
+	if attrs["api_key"] != key {
+		t.Errorf("saved api_key = %q, want %q", attrs["api_key"], key)
+	}
+	if attrs["base_url"] != srv.URL {
+		t.Errorf("saved base_url = %q, want %q", attrs["base_url"], srv.URL)
+	}
+}
+
+// A denial must stop the loop with a clear error, not run out the clock.
+func TestPollDeviceGrantStopsOnDenial(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"access_denied"}`))
+	}))
+	defer srv.Close()
+
+	_, err := pollDeviceGrant(srv.URL, &deviceGrant{DeviceCode: "dev", ExpiresIn: 900, Interval: 0})
+	if err == nil || !strings.Contains(err.Error(), "denied") {
+		t.Fatalf("want a denial error, got %v", err)
 	}
 }
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -40,10 +40,17 @@ curl -H "Authorization: Bearer $FOUNTAIN_API_KEY" \
 
 ```
 POST   /api/auth/token             # email + password -> a fresh API key
+POST   /api/auth/device            # start a device login: user_code + verification URL
+POST   /api/auth/device/token      # poll with device_code -> the key, once approved
 GET    /api/auth/me                # identity of the authenticated user
 POST   /api/auth/api-keys          # create a key (plaintext returned once)
 DELETE /api/auth/api-keys/:id      # revoke a key
 ```
+
+The two device endpoints serve accounts without a password, such as one from
+the "Sign up with GitHub" button. `fountain auth login --device` drives them.
+You approve the code in the console at `/device`. The poll then returns a
+fresh key.
 
 **Registration and account recovery.** These need no auth. The token in the
 email authenticates the last step.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -24,16 +24,25 @@ Or take a release binary from the
 
 ```bash
 fountain auth login            # prompts for email + password, saves an API key
+fountain auth login --device   # approve this device in your browser instead
 fountain auth login --api-key  # prompts for a pasted API key instead
 fountain auth whoami           # print the current user
 fountain auth logout           # remove saved credentials
 ```
 
 An account made with the "Sign up with GitHub" button has no password. For
-that account, use `--api-key`. Create an API key in the console, on the
-**API keys** page. Then run `fountain auth login --api-key` and paste the key
-at the prompt. The CLI checks the key against the server and saves it. The
-prompt also reads a piped line, so a script can supply the key on stdin.
+that account, use `--device` or `--api-key`.
+
+`--device` is the easy path. The CLI shows a short one-time code and a
+console URL, and opens the URL in your browser when it runs on a terminal.
+Enter the code in the console and approve the device. The CLI waits,
+collects a fresh API key, and saves it.
+
+`--api-key` takes a key you created yourself. Create an API key in the
+console, on the **API keys** page. Then run `fountain auth login --api-key`
+and paste the key at the prompt. The CLI checks the key against the server
+and saves it. The prompt also reads a piped line, so a script can supply the
+key on stdin.
 
 `auth login` has no `--endpoint` flag. Point the CLI at a different instance
 with `FOUNTAIN_BASE_URL`. `auth login` then records that URL in the saved

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -121,6 +121,7 @@ Options:
 
 ```
       --api-key   paste an API key instead of email + password (for accounts that sign in with GitHub)
+      --device    sign in by approving this device in your browser (works for accounts that sign in with GitHub)
 ```
 
 ## `fountain auth logout`

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -10,6 +10,19 @@ server releases.
 
 ---
 
+## [1.12.0] — 2026-08-31
+
+### Added
+
+- Generated types for device-authorization login (fountain #1305):
+  `POST /api/auth/device` starts a grant (`DeviceAuthResponse` — the
+  `user_code` a human types at the console's `/device` page, the
+  `device_code` the machine polls with) and `POST /api/auth/device/token`
+  polls it (`DeviceTokenRequest`), answering the RFC 8628 error vocabulary
+  until approval mints the same `AuthTokenResponse` as
+  `POST /api/auth/token`. This is the login path for accounts created with
+  "Sign up with GitHub", which have no password to exchange.
+
 ## [1.11.1] — 2026-08-28
 
 ### Changed

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentshit/fountain-sdk",
-      "version": "1.11.1",
+      "version": "1.12.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "description": "Run a coding agent on a real computer, with your repos and your credentials, in one call.",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -1905,6 +1905,46 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/auth/device/token": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Poll a device grant for the API key
+         * @description Polled by the CLI with the `device_code` from `POST /api/auth/device`. Until the user decides, 400 `authorization_pending` (or `slow_down` when polled faster than `interval`). A denial is 400 `access_denied`; a timed-out grant is 400 `expired_token`; an unknown or already-used code is 400 `invalid_grant`. On approval, 201 with a full-scope API key — the same shape `POST /api/auth/token` returns — and the grant is consumed.
+         */
+        post: operations["FountainWeb.DeviceAuthController.token"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/auth/device": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Start a device-authorization grant
+         * @description The CLI login path for accounts without a password ("Sign up with GitHub"). Show the user `user_code` and send them to `verification_uri` (or open `verification_uri_complete`), then poll `POST /api/auth/device/token` with `device_code` every `interval` seconds until they approve. The grant expires after `expires_in` seconds. Rate-limited to 10 grants per IP per hour.
+         */
+        post: operations["FountainWeb.DeviceAuthController.create"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/admin/users/{id}": {
         parameters: {
             query?: never;
@@ -3299,6 +3339,11 @@ export interface components {
         ApiKeyListResponse: {
             data: components["schemas"]["ApiKey"][];
         };
+        /** DeviceTokenRequest */
+        DeviceTokenRequest: {
+            /** @description The `device_code` from `POST /api/auth/device`. */
+            device_code: string;
+        };
         /**
          * Runner
          * @description A self-hosted runner: a machine of yours running `fountain runner`, serving sandboxes for the `runner` provider (ADR 0022). `online` is live — whether the daemon holds a connection right now.
@@ -3747,6 +3792,27 @@ export interface components {
         /** TeamScheduleResponse */
         TeamScheduleResponse: {
             data: components["schemas"]["TeamSchedule"];
+        };
+        /**
+         * DeviceAuthResponse
+         * @description A fresh device-authorization grant (#1305). `device_code` stays on the polling machine and never gets typed; `user_code` is what the human enters at `verification_uri`.
+         */
+        DeviceAuthResponse: {
+            /** @description High-entropy code the CLI polls the token endpoint with. Shown once. */
+            device_code: string;
+            /** @description Seconds until the grant expires. */
+            expires_in: number;
+            /** @description Minimum seconds between polls; faster gets `slow_down`. */
+            interval: number;
+            /**
+             * @description Short code for the human to type into the console.
+             * @example BCDF-GHJK
+             */
+            user_code: string;
+            /** @description The console page where the user approves the grant. */
+            verification_uri: string;
+            /** @description `verification_uri` with the user code prefilled. */
+            verification_uri_complete: string;
         };
         /** EmailRequest */
         EmailRequest: {
@@ -9339,6 +9405,60 @@ export interface operations {
                 };
                 content: {
                     "text/event-stream": string;
+                };
+            };
+        };
+    };
+    "FountainWeb.DeviceAuthController.token": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Device token request */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["DeviceTokenRequest"];
+            };
+        };
+        responses: {
+            /** @description A new API key */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthTokenResponse"];
+                };
+            };
+            /** @description authorization_pending / slow_down / access_denied / expired_token / invalid_grant */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    "FountainWeb.DeviceAuthController.create": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description A new device grant */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DeviceAuthResponse"];
                 };
             };
         };

--- a/sdk/typescript/src/http.ts
+++ b/sdk/typescript/src/http.ts
@@ -19,7 +19,7 @@ export interface RequestOptions {
  * this string is already what Fountain's request logs are keyed on. The
  * version half is asserted against `package.json` by a test.
  */
-export const USER_AGENT = "fountain-sdk-js/1.11.1";
+export const USER_AGENT = "fountain-sdk-js/1.12.0";
 
 /**
  * The thin layer everything else is built on: one bearer token, JSON in and


### PR DESCRIPTION
~~Stacked on #1307~~ — #1307 merged; this now targets `main` directly (rebased, so the diff is the device flow alone). Merging also publishes SDK **1.12.0** (minor: the new endpoint types), per the release guard.

## What (#1305, the "best UX" option)

An account created with **Sign up with GitHub** has no password, so `fountain auth login` can never exchange one. This adds the device-authorization flow (RFC 8628 shape): the CLI shows a short code and a console URL, the user approves in a signed-in browser, and the CLI collects a full-scope API key.

```
$ fountain auth login --device
First, note your one-time code: BCDF-GHJK

Then approve this device at: https://managoat.com/device
(opened in your browser)

Waiting for approval...
Logged in as you@example.com. Credentials written to ~/.fountain/credentials (profile: default).
```

## Server

- **`Fountain.OAuth` extension**, following ADR 0021's model (tokens are ordinary API keys): a new `oauth_device_grants` table holds a hashed high-entropy `device_code` (never typed, stays on the polling machine) and a short `XXXX-XXXX` `user_code` from RFC 8628's consonant alphabet (20^8 space, 15-minute expiry, single use).
- **`POST /api/auth/device`** starts a grant (public, rate-limited 10/hr/IP). **`POST /api/auth/device/token`** is the poll: RFC 8628 error vocabulary (`authorization_pending`, `slow_down` with per-grant pacing, `access_denied`, `expired_token`, `invalid_grant`), and on approval it mints the same key `POST /api/auth/token` would — same name pattern, same response shape, full scope, no expiry.
- **`/device`** (LiveView, behind `require_authenticated_user`): enter or arrive with the code (`verification_uri_complete` prefills it), see exactly which account gets the key and a phishing warning, approve or deny. Audits `oauth.device_approved` / `oauth.device_denied` (actor `ui`); the mint audits `api_key.created` (actor `api`) as always.
- Suspended/unverified accounts cannot collect a key even after approval (belt-and-braces; the console hooks already turn them away). OpenAPI operations and schemas included; `OAuth.prune_expired` sweeps expired grants.

## CLI

- `fountain auth login --device`, plus browser open on a real TTY only (scripts and tests just get the printed URL). Polling honors the server's `interval` and backs off 5s on `slow_down`. The password path's 401 hint now leads with `--device`.
- Docs: `docs/cli.md` authentication section, `docs/api.md` endpoint list, regenerated `docs/cli/commands.md`.

## Testing

- `mix test` full suite: **4,200 tests, 0 failures** (new coverage: context happy path/single-use/slow_down/deny/expiry/suspension, controller flow, LiveView approve/deny/wrong-code).
- `mix compile --warnings-as-errors`, `mix format --check-formatted`, `credo --strict`, dialyzer, sobelow, OpenAPI spec generation + `jq empty` — all green.
- `go test ./...` + `go vet` in `cli/` — green, including a full-flow test against the exact controller JSON (pending → slow_down → key) with the sleep instrumented.
- All three prose gates clean (docs-style, vale STE, destink); `docs_test.exs` 43/43.

Closes #1305

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dex5a9SZHXpST6KyueR3Bc


---

**Update (d27d6f44): the device flow is now the default interactive login.** True auto-detection of a passwordless account is impossible by design (the uniform 401 is #324's anti-enumeration guard), so the default became a flow with nothing to detect: on a terminal, `fountain auth login` runs the device flow, which works for every account. `--password` forces the email+password prompt; **piped stdin keeps the password read unchanged**, so scripts that feed credentials are unaffected. A password 401 on a terminal now offers "Sign in through your browser instead? [Y/n]" and rolls into the device flow instead of dying with a hint.
