### PR TITLE
feat(cli): device flow is the default interactive login

### DIFF
--- a/cli/internal/cmd/auth.go
+++ b/cli/internal/cmd/auth.go
@@ -32,23 +32,29 @@ func init() {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			withAPIKey, _ := cmd.Flags().GetBool("api-key")
 			withDevice, _ := cmd.Flags().GetBool("device")
-			switch {
-			case withAPIKey && withDevice:
-				Fatal("--api-key and --device are two different login flows; pick one")
-				return nil
-			case withAPIKey:
+			withPassword, _ := cmd.Flags().GetBool("password")
+
+			mode, err := loginMode(withAPIKey, withDevice, withPassword,
+				term.IsTerminal(int(os.Stdin.Fd())))
+			if err != nil {
+				Fatal(err.Error())
+			}
+			switch mode {
+			case loginModeAPIKey:
 				return authLoginAPIKey()
-			case withDevice:
+			case loginModeDevice:
 				return authLoginDevice()
 			default:
 				return authLogin()
 			}
 		},
 	}
-	loginCmd.Flags().Bool("api-key", false,
-		"paste an API key instead of email + password (for accounts that sign in with GitHub)")
 	loginCmd.Flags().Bool("device", false,
-		"sign in by approving this device in your browser (works for accounts that sign in with GitHub)")
+		"sign in by approving this device in your browser (the default on a terminal)")
+	loginCmd.Flags().Bool("password", false,
+		"sign in with email + password (the default when stdin is piped)")
+	loginCmd.Flags().Bool("api-key", false,
+		"paste an API key you created in the console")
 	authCmd.AddCommand(
 		loginCmd,
 		&cobra.Command{
@@ -63,6 +69,48 @@ func init() {
 		},
 	)
 	rootCmd.AddCommand(authCmd)
+}
+
+// deviceFallbackAccepted reads the [Y/n] answer to the post-401 offer:
+// enter and anything starting with y mean yes.
+func deviceFallbackAccepted(answer string) bool {
+	answer = strings.ToLower(strings.TrimSpace(answer))
+	return answer == "" || strings.HasPrefix(answer, "y")
+}
+
+const (
+	loginModeAPIKey   = "api-key"
+	loginModeDevice   = "device"
+	loginModePassword = "password"
+)
+
+// loginMode picks the flow for `auth login`. At most one flag may force one;
+// with none, a terminal gets the device flow — it works for every account,
+// including "Sign up with GitHub" ones that have no password to type (#1305),
+// so there is nothing to detect and no wrong default. Piped stdin keeps the
+// email + password read, so a script that feeds credentials is unchanged.
+func loginMode(apiKey, device, password, stdinTTY bool) (string, error) {
+	forced := 0
+	for _, f := range []bool{apiKey, device, password} {
+		if f {
+			forced++
+		}
+	}
+	if forced > 1 {
+		return "", fmt.Errorf("--device, --password and --api-key are different login flows; pick one")
+	}
+	switch {
+	case apiKey:
+		return loginModeAPIKey, nil
+	case device:
+		return loginModeDevice, nil
+	case password:
+		return loginModePassword, nil
+	case stdinTTY:
+		return loginModeDevice, nil
+	default:
+		return loginModePassword, nil
+	}
 }
 
 func authLogin() error {
@@ -101,16 +149,21 @@ func authLogin() error {
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		// The server answers every bad credential with the same 401 on
 		// purpose (anti-enumeration, #324) — an account created with "Sign
-		// up with GitHub" has no password and lands here too, so the hint
-		// has to live on this side.
+		// up with GitHub" has no password and lands here too, and the CLI
+		// cannot tell the two apart. It does not need to: the device flow
+		// works for both, so on a terminal offer it instead of erroring.
 		if resp.StatusCode == http.StatusUnauthorized {
-			Fatalf("login failed (HTTP %d): %s\n\n"+
-				"If you signed up with GitHub, your account has no password.\n"+
-				"Sign in through your browser instead:\n\n"+
-				"  fountain auth login --device\n\n"+
-				"Or create an API key in the console (%s/api-keys) and run\n"+
-				"`fountain auth login --api-key`.",
-				resp.StatusCode, respBody, base)
+			fmt.Fprintf(os.Stderr, "fountain: login failed (HTTP %d): %s\n\n", resp.StatusCode, respBody)
+			fmt.Fprintln(os.Stderr, "If you signed up with GitHub, your account has no password.")
+			if term.IsTerminal(int(os.Stdin.Fd())) {
+				answer, perr := promptLine("Sign in through your browser instead? [Y/n] ")
+				if perr == nil && deviceFallbackAccepted(answer) {
+					return authLoginDevice()
+				}
+			}
+			Fatalf("run `fountain auth login --device` to sign in through your browser,\n"+
+				"or create an API key in the console (%s/api-keys) and run\n"+
+				"`fountain auth login --api-key`.", base)
 		}
 		Fatalf("login failed (HTTP %d): %s", resp.StatusCode, respBody)
 	}

--- a/cli/internal/cmd/auth_test.go
+++ b/cli/internal/cmd/auth_test.go
@@ -185,6 +185,53 @@ func TestPollDeviceGrantStopsOnDenial(t *testing.T) {
 	}
 }
 
+// TestLoginModeDefaults pins the dispatch that makes #1305's "auto detect"
+// unnecessary: the server's 401 is deliberately uniform (anti-enumeration),
+// so instead of detecting a passwordless account the default flow is one
+// that works for every account — device on a terminal — while piped stdin
+// keeps the email + password read so existing scripts are unchanged.
+func TestLoginModeDefaults(t *testing.T) {
+	cases := []struct {
+		name                     string
+		apiKey, device, password bool
+		tty                      bool
+		want                     string
+		wantErr                  bool
+	}{
+		{name: "terminal defaults to device", tty: true, want: loginModeDevice},
+		{name: "piped stdin keeps password", tty: false, want: loginModePassword},
+		{name: "--password wins on a terminal", password: true, tty: true, want: loginModePassword},
+		{name: "--device works piped", device: true, tty: false, want: loginModeDevice},
+		{name: "--api-key works piped", apiKey: true, tty: false, want: loginModeAPIKey},
+		{name: "two flags is an error", device: true, password: true, tty: true, wantErr: true},
+	}
+	for _, tc := range cases {
+		got, err := loginMode(tc.apiKey, tc.device, tc.password, tc.tty)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("%s: want an error, got mode %q", tc.name, got)
+			}
+			continue
+		}
+		if err != nil || got != tc.want {
+			t.Errorf("%s: got (%q, %v), want %q", tc.name, got, err, tc.want)
+		}
+	}
+}
+
+func TestDeviceFallbackAccepted(t *testing.T) {
+	for _, yes := range []string{"", "y", "Y", "yes", " Yes "} {
+		if !deviceFallbackAccepted(yes) {
+			t.Errorf("%q should accept the fallback", yes)
+		}
+	}
+	for _, no := range []string{"n", "N", "no", "q", "later"} {
+		if deviceFallbackAccepted(no) {
+			t.Errorf("%q should decline the fallback", no)
+		}
+	}
+}
+
 // stdinFrom replaces os.Stdin with a pipe holding `input` and returns the
 // restore func. promptPassword falls back to a plain line read on a non-TTY,
 // which is what a pipe is.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -23,20 +23,25 @@ Or take a release binary from the
 ## Authentication
 
 ```bash
-fountain auth login            # prompts for email + password, saves an API key
-fountain auth login --device   # approve this device in your browser instead
+fountain auth login            # browser approval on a terminal; email + password when piped
+fountain auth login --device   # force the browser approval flow
+fountain auth login --password # force the email + password prompt
 fountain auth login --api-key  # prompts for a pasted API key instead
 fountain auth whoami           # print the current user
 fountain auth logout           # remove saved credentials
 ```
 
-An account made with the "Sign up with GitHub" button has no password. For
-that account, use `--device` or `--api-key`.
+On a terminal, `fountain auth login` signs you in through your browser. The
+CLI shows a short one-time code and a console URL, and opens the URL for
+you. Enter the code in the console and approve the device. The CLI waits,
+collects a fresh API key, and saves it. This flow works for every account.
+An account made with the "Sign up with GitHub" button has no password, so
+the other flows cannot serve it.
 
-`--device` is the easy path. The CLI shows a short one-time code and a
-console URL, and opens the URL in your browser when it runs on a terminal.
-Enter the code in the console and approve the device. The CLI waits,
-collects a fresh API key, and saves it.
+When stdin is a pipe, the command reads an email and a password instead.
+A script that feeds credentials keeps its behavior. `--password` forces that
+prompt on a terminal. If the password login fails there, the CLI offers the
+browser flow.
 
 `--api-key` takes a key you created yourself. Create an API key in the
 console, on the **API keys** page. Then run `fountain auth login --api-key`

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -120,8 +120,9 @@ fountain auth login [flags]
 Options:
 
 ```
-      --api-key   paste an API key instead of email + password (for accounts that sign in with GitHub)
-      --device    sign in by approving this device in your browser (works for accounts that sign in with GitHub)
+      --api-key    paste an API key you created in the console
+      --device     sign in by approving this device in your browser (the default on a terminal)
+      --password   sign in with email + password (the default when stdin is piped)
 ```
 
 ## `fountain auth logout`


### PR DESCRIPTION
Follow-up to #1309 (this commit was pushed to that branch minutes after it merged, so it gets its own PR — same content, cherry-picked onto `main`).

## What (#1305's last concern)

A GitHub-signup user should not have to discover by trial that their account has no password. True auto-detection is off the table by design: `/api/auth/token` answers every bad credential with one uniform 401 (anti-enumeration, #324), and any distinguishable response would be an account-existence/auth-method oracle. So the default becomes a flow with nothing to detect:

- **On a terminal, `fountain auth login` now runs the device flow** (the `gh auth login` model) — it works identically for password and GitHub accounts.
- **Piped stdin keeps the email + password read unchanged**, so scripts that feed credentials are unaffected. `--password` forces the prompt interactively; `--device` / `--api-key` force their flows; two mode flags together is an error.
- **A password 401 on a terminal now recovers instead of erroring**: it explains the no-password case and asks "Sign in through your browser instead? [Y/n]" — Enter rolls straight into the device flow, which is the right rescue for a passwordless account and a typo'd password alike. Non-interactive keeps the fatal hint.

## Testing

- `loginMode` dispatch and the [Y/n] parsing are unit-tested (terminal→device, pipe→password, forced flags, flag conflicts).
- Full Go suite + `go vet` green; `docs/cli.md` rewritten (docs-style, vale STE, destink all clean); `docs/cli/commands.md` regenerated; `docs_test.exs` 43/43.
- No server or SDK changes — CLI and docs only.

Refs #1305

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dex5a9SZHXpST6KyueR3Bc