### PR TITLE
copy(marketing): clarify OSS agent setup

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
@@ -60,10 +60,10 @@ defmodule FountainWeb.MarketingHTML do
   The Agent is named `reviewer` because that is the agent `sdk_example/0`
   starts in the last beat. Renaming it here means renaming it there.
 
-  The Vault beat argues rate of change rather than the HashiCorp collision.
-  The collision is stated once on this page, in the "Whose token does it push
-  with?" card below, which is where a reader meets the word with an
-  explanation attached.
+  The Vault beat says what the record is, when to attach it, and that it is
+  optional. The collision with HashiCorp is stated once on this page, in the
+  "Whose token does it push with?" card below, where the longer distinction
+  belongs.
   """
   def build_steps do
     [
@@ -89,10 +89,10 @@ defmodule FountainWeb.MarketingHTML do
       },
       %{
         n: 2,
-        title: "Keep the credentials apart.",
+        title: "Add credentials only when a run needs them.",
         body:
-          "They are their own document, so rotating a token is not an edit to " <>
-            "the machine, and one machine can run as you or as a bot.",
+          "A Vault is an optional set of environment-variable overrides. " <>
+            "Attach one in the API call; leave it off when a run needs no credentials.",
         code: """
         apiVersion: fountain.dev/v1
         kind: Vault
@@ -105,10 +105,10 @@ defmodule FountainWeb.MarketingHTML do
       },
       %{
         n: 3,
-        title: "Name the agent.",
+        title: "Name the agent and its tools.",
         body:
-          "Pick the runtime and model, add skills and MCP servers, attach the " <>
-            "Environment. Or start from a ready-made one.",
+          "Pick the runtime and model, add skills and MCP tools, and attach the " <>
+            "Environment. The public DeepWiki server needs no credential.",
         code: """
         apiVersion: fountain.dev/v1
         kind: Agent
@@ -117,7 +117,14 @@ defmodule FountainWeb.MarketingHTML do
         spec:
           runtime: claude
           model: anthropic/claude-sonnet-5
-          environment: app\
+          environment: app
+          skills:
+            - source: obra/superpowers
+              ref: v2.1.0
+          mcp_servers:
+            deepwiki:
+              type: http
+              url: https://mcp.deepwiki.com/mcp\
         """
       },
       %{
@@ -166,7 +173,7 @@ defmodule FountainWeb.MarketingHTML do
 
     const run = await fountain.run(
       "Fix the failing test and open a PR",
-      { agent: "reviewer", channelId: ticket.id }
+      { agent: "reviewer", vault: "ci-bot", channelId: ticket.id }
     );
 
     console.log(run.text);\

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -185,7 +185,7 @@
       You write this once. Everything after it is a prompt.
     </h2>
     <%!-- The three resources are one file, so they are one code block. On wide
-          screens its annotations occupy proportional rows beside it: 43/27/30
+          screens its annotations occupy proportional rows beside it: 34/23/43
           follows the documents' rendered line counts (including each `---`),
           keeping every annotation level with the document it names. On narrow
           screens the numbered annotations become a compact preface to the
@@ -196,7 +196,7 @@
           YAML is a defect and a wrapped line of prose is not. --%>
     <div class="mt-12">
       <div class="grid md:grid-cols-[minmax(0,0.85fr)_minmax(0,1.15fr)] gap-x-10 gap-y-5 items-stretch">
-        <div class="grid md:grid-rows-[43%_27%_30%]">
+        <div class="grid md:grid-rows-[34%_23%_43%]">
           <div
             :for={step <- Enum.take(build_steps(), 3)}
             class="flex items-start gap-4 py-4 first:pt-0 last:pb-0 md:py-0 md:pr-4"

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/oss_launch.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/oss_launch.html.heex
@@ -13,7 +13,7 @@
         Run coding agents on infrastructure you control.
       </h1>
       <p class="mt-6 text-lg sm:text-xl leading-relaxed text-[var(--color-text-secondary)] max-w-[39rem]">
-        Define the repo, tools, credentials, runtime and model an agent needs, and give it a name. Then call it from your product, editor, chat app or CI job. Fountain handles the machine underneath.
+        Connect your repo, tools, credentials, and model. Specify a runtime and give the agent a name. Then call it from your product, editor, chat app or CI job. Fountain handles the machine underneath.
       </p>
       <div class="mt-9 flex flex-col sm:flex-row gap-3 [&>a]:w-full sm:[&>a]:w-auto">
         <a

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/oss_launch.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/oss_launch.html.heex
@@ -179,7 +179,7 @@
           Define an agent once. Then send prompts.
         </h2>
         <p class="mt-5 text-[var(--color-ink-secondary)] leading-relaxed">
-          An Environment describes the machine. A Vault provides per-run credentials. An Agent chooses the runtime, model and tools. Keep all three in one manifest and apply it like infrastructure.
+          An Environment supplies the machine and checkout. An Agent adds the runtime, model, skills and MCP tools. When a run needs credentials, attach a Vault in the API call. Keep the configuration in one manifest and apply it like infrastructure.
         </p>
         <ol class="mt-8 space-y-5">
           <li class="grid grid-cols-[2rem_1fr] gap-3">
@@ -200,7 +200,9 @@
             <div>
               <h3 class="font-semibold">Call the agent by name</h3>
               <p class="mt-1 text-sm text-[var(--color-ink-secondary)]">
-                The API provisions the sandbox, clones repositories and starts the runtime.
+                Attach the
+                <code class="font-mono text-xs text-[var(--color-ink-text)]">ci-bot</code>
+                Vault for a run that needs its GitHub token; leave it off otherwise.
               </p>
             </div>
           </li>
@@ -235,7 +237,7 @@
             </span>
           </div>
           <pre
-            class="max-h-[28rem] overflow-auto p-4 text-xs leading-relaxed text-[var(--color-code-text)]"
+            class="overflow-x-auto p-4 text-xs leading-relaxed text-[var(--color-code-text)]"
             phx-no-format
           ><code>{apply_example()}</code></pre>
           <p class="border-t border-[var(--color-ink-border)] px-4 py-3 font-mono text-xs text-[var(--color-accent)]">

--- a/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
@@ -120,6 +120,8 @@ defmodule FountainWeb.MarketingControllerTest do
 
       assert body =~ "Fountain · AGPL-3.0-or-later"
       assert body =~ "Run coding agents on infrastructure you control."
+      assert body =~ "Connect your repo, tools, credentials, and model."
+      assert body =~ "Specify a runtime and give the agent a name."
 
       assert body =~ "An agent should not need a laptop."
 

--- a/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
@@ -158,6 +158,9 @@ defmodule FountainWeb.MarketingControllerTest do
       assert body =~ "kind: Environment"
       assert body =~ "kind: Vault"
       assert body =~ "kind: Agent"
+      assert body =~ "source: obra/superpowers"
+      assert body =~ "url: https://mcp.deepwiki.com/mcp"
+      assert body =~ "vault: &quot;ci-bot&quot;"
       assert body =~ "fountain apply -f fountain.yml"
       assert body =~ "@agentshit/fountain-sdk"
 
@@ -1176,6 +1179,23 @@ defmodule FountainWeb.OpenGraphTest do
 
       assert MarketingHTML.sdk_example() =~ ~s(agent: "#{name}"),
              "the manifest defines agent #{name} and the call beside it starts a different one"
+    end
+
+    test "defines the vault the SDK call attaches" do
+      [_, name] =
+        Regex.run(~r/kind: Vault\nmetadata:\n  name: (\S+)/, MarketingHTML.apply_example())
+
+      assert MarketingHTML.sdk_example() =~ ~s(vault: "#{name}"),
+             "the manifest defines vault #{name} but the call beside it never attaches it"
+    end
+
+    test "shows a skill and a credential-free MCP server on the agent" do
+      manifest = MarketingHTML.apply_example()
+
+      assert manifest =~ "skills:\n"
+      assert manifest =~ "source: obra/superpowers"
+      assert manifest =~ "mcp_servers:\n"
+      assert manifest =~ "url: https://mcp.deepwiki.com/mcp"
     end
 
     test "carries no plaintext secret onto the page" do


### PR DESCRIPTION
## Summary

- replace the abstract "Define the repo" setup language with concrete connection steps
- clarify that the agent, rather than the runtime, receives a name
- explain that a Vault is an optional per-run environment override and attach the example Vault in the SDK call
- add a GitHub-sourced skill and the credential-free DeepWiki MCP server to the example Agent
- show the full manifest without an internal scrollbar and keep the shared homepage annotations aligned
- cover the revised copy and manifest relationships in the marketing controller test

## Test plan

- `mix format --check-formatted apps/fountain/lib/fountain_web/controllers/marketing_html.ex apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex apps/fountain/lib/fountain_web/controllers/marketing_html/oss_launch.html.heex apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs`
- `mix test apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs`
