### PR TITLE
Soften the OSS setup walkthrough

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
@@ -181,21 +181,24 @@ defmodule FountainWeb.MarketingHTML do
   end
 
   @doc """
-  The SDK definitions on the open-source launch page, one resource per beat.
+  The SDK walkthrough on the open-source launch page, one action per beat.
 
-  The page keeps the three definitions separate so the explanation beside each
-  one stays attached to the code it describes. Together they are one setup
-  script: the Environment and Vault ids returned by Fountain are passed to the
-  Agent, and the Agent and Vault names match `sdk_example/0` underneath.
+  The page keeps the three definitions and first prompt separate so the
+  explanation beside each stays attached to the code it describes. The first
+  three are one setup script: the Environment and Vault ids returned by
+  Fountain are passed to the Agent. The last beat changes to `run.ts`, where
+  the Agent and Vault names match the definitions above it.
 
   The secret write is deliberately separate from `vaults.create/1`. Secret
   values are write-only in the SDK, and showing that call keeps the Vault from
   reading like an empty marker record.
   """
-  def oss_sdk_setup_steps do
+  def oss_sdk_steps do
     [
       %{
         n: 1,
+        file: "setup.ts",
+        label: "environment",
         title: "Describe the machine once.",
         body:
           "Repositories, packages, env vars and setup scripts. The Environment is reusable across agents and runs.",
@@ -216,6 +219,8 @@ defmodule FountainWeb.MarketingHTML do
       },
       %{
         n: 2,
+        file: "setup.ts",
+        label: "vault",
         title: "Add credentials only when a run needs them.",
         body:
           "A Vault is an optional set of environment-variable overrides. Write its values separately, then attach it only to runs that need them.",
@@ -231,6 +236,8 @@ defmodule FountainWeb.MarketingHTML do
       },
       %{
         n: 3,
+        file: "setup.ts",
+        label: "agent",
         title: "Name the agent and its tools.",
         body:
           "Pick the runtime and model, add skills and MCP tools, attach the Environment, and allow the Vault callers may opt into.",
@@ -250,6 +257,16 @@ defmodule FountainWeb.MarketingHTML do
           },
         });\
         """
+      },
+      %{
+        n: 4,
+        file: "run.ts",
+        label: "prompt",
+        title: "Send a prompt.",
+        body:
+          "Attach the Vault when this run needs its GitHub token; leave it off otherwise. " <>
+            "Fountain streams the work as it happens and keeps the conversation ready for the next prompt.",
+        code: sdk_example()
       }
     ]
   end

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/oss_launch.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/oss_launch.html.heex
@@ -182,22 +182,15 @@
       You write this once. Everything after it is a prompt.
     </h2>
 
-    <div class="mt-12 overflow-hidden rounded-xl border border-[var(--color-ink-border)]">
-      <div class="flex items-center justify-between gap-4 border-b border-[var(--color-ink-border)] bg-[var(--color-ink-1)] px-4 py-3 sm:px-5">
-        <span class="font-mono text-[11px] text-[var(--color-ink-secondary)]">
-          setup.ts
-        </span>
-        <span class="font-mono text-[10px] uppercase tracking-wider text-[var(--color-accent)]">
-          environment · vault · agent
-        </span>
-      </div>
-
+    <%!-- Keep the four beats in one sequence, but let each example be a card
+          instead of turning the walkthrough into one large table. --%>
+    <div class="mt-12">
       <div
-        :for={step <- oss_sdk_setup_steps()}
-        class="grid md:grid-cols-[minmax(0,0.85fr)_minmax(0,1.15fr)] border-b border-[var(--color-ink-border)] last:border-b-0"
-        data-role="sdk-setup-step"
+        :for={step <- oss_sdk_steps()}
+        class="grid items-start gap-x-10 gap-y-5 border-t border-[var(--color-ink-border)] py-8 first:border-t-0 first:pt-0 last:pb-0 md:grid-cols-[minmax(0,0.85fr)_minmax(0,1.15fr)]"
+        data-role="sdk-walkthrough-step"
       >
-        <div class="flex items-start gap-4 bg-[var(--color-ink-0)] p-5 sm:p-6 md:py-7 md:pr-8">
+        <div class="flex items-start gap-4 md:pr-4">
           <span class="mt-0.5 flex size-7 flex-shrink-0 items-center justify-center rounded-full border border-[var(--color-accent)] text-xs font-semibold text-[var(--color-accent)]">
             {step.n}
           </span>
@@ -206,31 +199,20 @@
             {step.body}
           </p>
         </div>
-        <pre
-          class="min-w-0 overflow-x-auto border-t border-[var(--color-ink-border)] bg-[var(--color-ink-1)] p-5 text-xs leading-relaxed text-[var(--color-code-text)] md:border-l md:border-t-0"
-          phx-no-format
-        ><code>{step.code}</code></pre>
-      </div>
-    </div>
-
-    <div class="mt-8 grid items-start gap-x-10 gap-y-5 border-t border-[var(--color-ink-border)] pt-8 md:grid-cols-[minmax(0,0.85fr)_minmax(0,1.15fr)]">
-      <div class="flex items-start gap-4 md:pr-4">
-        <span class="mt-0.5 flex size-7 flex-shrink-0 items-center justify-center rounded-full border border-[var(--color-accent)] text-xs font-semibold text-[var(--color-accent)]">
-          4
-        </span>
-        <p class="leading-relaxed text-[var(--color-ink-secondary)]">
-          <strong class="font-medium text-[var(--color-ink-text)]">Send a prompt.</strong>
-          Attach the Vault when this run needs its GitHub token; leave it off otherwise. Fountain streams the work as it happens and keeps the conversation ready for the next prompt.
-        </p>
-      </div>
-      <div class="min-w-0 overflow-hidden rounded-xl border border-[var(--color-ink-border)] bg-[var(--color-ink-1)]">
-        <div class="border-b border-[var(--color-ink-border)] px-4 py-3 font-mono text-[11px] text-[var(--color-ink-secondary)]">
-          run.ts
+        <div class="min-w-0 overflow-hidden rounded-xl border border-[var(--color-ink-border)] bg-[var(--color-ink-1)]">
+          <div class="flex items-center justify-between gap-4 border-b border-[var(--color-ink-border)] px-4 py-3 sm:px-5">
+            <span class="font-mono text-[11px] text-[var(--color-ink-secondary)]">
+              {step.file}
+            </span>
+            <span class="font-mono text-[10px] uppercase tracking-wider text-[var(--color-accent)]">
+              {step.label}
+            </span>
+          </div>
+          <pre
+            class="overflow-x-auto p-5 text-xs leading-relaxed text-[var(--color-code-text)]"
+            phx-no-format
+          ><code>{step.code}</code></pre>
         </div>
-        <pre
-          class="overflow-x-auto p-5 text-xs leading-relaxed text-[var(--color-code-text)]"
-          phx-no-format
-        ><code>{sdk_example()}</code></pre>
       </div>
     </div>
 

--- a/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
@@ -165,6 +165,7 @@ defmodule FountainWeb.MarketingControllerTest do
       assert body =~ "https://mcp.deepwiki.com/mcp"
       assert body =~ "vault: &quot;ci-bot&quot;"
       assert body =~ "@agentshit/fountain-sdk"
+      assert length(Regex.scan(~r/data-role="sdk-walkthrough-step"/, body)) == 4
       refute body =~ "kind: Environment"
       refute body =~ "fountain apply -f fountain.yml"
 


### PR DESCRIPTION
## Summary
- remove the enclosing table treatment from the first-agent walkthrough
- give each SDK beat its own rounded code card with lighter separators
- bring the run.ts prompt into the same four-step sequence

## Test plan
- mix test apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs (75 tests, 0 failures)