### PR TITLE
feat(marketing): add Buzz launch page at /buzz-launch

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/marketing_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_controller.ex
@@ -105,6 +105,27 @@ defmodule FountainWeb.MarketingController do
     end
   end
 
+  # The Buzz campaign page: hosted Buzz agents, for readers arriving from a
+  # launch announcement in that community. Like the other campaign pages it
+  # makes one argument (the agent should outlive the laptop) and asks for one
+  # action, and stays out of the permanent navigation. Another deployment gets
+  # the integration manual, which is the page that tells an operator the same
+  # story without selling the hosted product.
+  def buzz_launch(conn, _params) do
+    if Fountain.Marketing.site?() do
+      render(conn, :buzz_launch,
+        layout: {FountainWeb.Layouts, :marketing},
+        page_title: "Hosted Buzz agents · #{Fountain.Brand.name()}",
+        meta_description:
+          "Host a Buzz agent on #{Fountain.Brand.name()} instead of a laptop. It keeps " <>
+            "presence on the relay, answers mentions from a sandbox, and its Nostr key " <>
+            "never leaves the server."
+      )
+    else
+      redirect(conn, to: ~p"/docs/integrations/buzz")
+    end
+  end
+
   # The protocols Fountain speaks and what already speaks them. Sales copy,
   # so it follows `/`: a self-hosted instance gets the manual's version of
   # the same list rather than a page selling the hosted product.

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
@@ -289,6 +289,109 @@ defmodule FountainWeb.MarketingHTML do
     """
   end
 
+  ## The Buzz campaign page
+  #
+  # Every claim on /buzz-launch is the marketing register of a sentence in
+  # docs/integrations/buzz.md, which was written against the code (ADR 0020).
+  # The page must not outrun the manual: a claim that is not on that page does
+  # not belong here either.
+
+  @doc """
+  One turn of a hosted Buzz agent, from mention to signed reply.
+
+  The asymmetry between steps 3 and 4 is the integration's defining fact: the
+  harness never publishes the agent's own text, so the MCP tool is the whole
+  outbound path and the key never leaves the server.
+  docs/integrations/buzz.md carries the same sequence as a diagram.
+  """
+  def buzz_turn_steps do
+    [
+      %{
+        n: 1,
+        title: "A mention arrives.",
+        body:
+          "Somebody @-mentions the agent in a channel. The harness holding its " <>
+            "presence picks the mention up on the gateway, not on anybody's laptop."
+      },
+      %{
+        n: 2,
+        title: "A sandbox wakes.",
+        body:
+          "Fountain drives the turn over ACP on a machine built from the bound " <>
+            "agent's Environment: its repositories, packages, tools and credentials."
+      },
+      %{
+        n: 3,
+        title: "The agent asks to publish.",
+        body:
+          "To reply, it calls buzz_send_message, a Fountain-hosted MCP tool. The " <>
+            "sandbox holds no relay connection and no key, so the tool is the only " <>
+            "way anything reaches the channel."
+      },
+      %{
+        n: 4,
+        title: "Fountain signs and sends.",
+        body:
+          "The reply is signed with the key in the vault and published as the " <>
+            "agent. The owner watches the whole turn from the Buzz desktop, over " <>
+            "encrypted telemetry."
+      }
+    ]
+  end
+
+  @doc """
+  Provisioning an identity over the API, for the reader who skips the desktop.
+
+  The shape is docs/integrations/buzz.md's worked example, trimmed to the
+  required fields. The nsec goes in and never comes back: the response carries
+  the identity's public fields alone, which is the fact the section around
+  this snippet is making. Kept out of the template so its braces are not HEEx.
+  """
+  def buzz_provision_example do
+    """
+    curl -X POST $FOUNTAIN_BASE_URL/api/buzz/agents \\
+      -H "Authorization: Bearer $FOUNTAIN_API_KEY" \\
+      -H "Content-Type: application/json" \\
+      -d '{
+        "name": "night-owl",
+        "agent_id": "<fountain agent uuid>",
+        "relay_url": "wss://relay.example.com",
+        "pubkey": "<64-hex nostr pubkey>",
+        "private_key_nsec": "nsec1…",
+        "auth_tag": "<owner attestation>"
+      }'\
+    """
+  end
+
+  @doc """
+  The three in-channel owner commands a hosted identity answers.
+
+  Only the attested owner can send them, verified through the NIP-OA
+  attestation rather than the display name. `!shutdown` is a restart rather
+  than a stop because the supervisor restarts an enabled identity; the page
+  says so instead of promising an off switch a mention does not have.
+  """
+  def buzz_owner_commands do
+    [
+      %{
+        command: "@Agent !rotate",
+        effect:
+          "Ends the channel's current conversation and opens a fresh one on the " <>
+            "next mention. A clean slate without a redeploy."
+      },
+      %{
+        command: "@Agent !cancel",
+        effect: "Interrupts the turn in flight."
+      },
+      %{
+        command: "@Agent !shutdown",
+        effect:
+          "Exits the harness. Fountain restarts it while the identity stays " <>
+            "enabled, so stopping for good is the API's delete, not a mention."
+      }
+    ]
+  end
+
   ## The security review
   #
   # What a builder's security reviewer asks, answered on the page. Every answer

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/buzz_launch.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/buzz_launch.html.heex
@@ -1,0 +1,284 @@
+<%!-- The Buzz campaign page. One reader (someone already running Buzz agents
+      on a desktop), one argument (the agent should outlive the laptop), one
+      action (host it here). Unlisted, like the other campaign pages: the
+      homepage stays the canonical product page. Every claim is the marketing
+      register of a sentence in docs/integrations/buzz.md; if the manual does
+      not say it, this page must not either. --%>
+
+<%!-- Hero --%>
+<section class="max-w-5xl mx-auto px-6 py-20 text-center" data-role="hero">
+  <p class="mb-5 inline-flex items-center gap-2 rounded-full border border-[var(--color-border)] bg-[var(--color-bg-1)] px-3.5 py-1.5 text-xs text-[var(--color-text-secondary)]">
+    <span class="size-1.5 rounded-full bg-[var(--color-accent)]" aria-hidden="true"></span>
+    Buzz on {Fountain.Brand.name()} · hosted agents on Nostr
+  </p>
+  <h1 class="text-[2.75rem] leading-[1.05] sm:text-6xl font-bold tracking-[-0.03em] text-[var(--color-text-primary)]">
+    Close your laptop. Your Buzz agent keeps answering.
+  </h1>
+  <p class="mt-6 text-lg sm:text-xl leading-relaxed text-[var(--color-text-secondary)] max-w-2xl mx-auto">
+    A Buzz agent is a Nostr identity, and on the desktop the coding agent behind it runs on your laptop and stops when the laptop does. {Fountain.Brand.name()} hosts that half instead: the identity holds its presence on the relay and answers every mention from a sandbox, whether or not a laptop is open.
+  </p>
+  <div class="mt-10 flex flex-col sm:flex-row gap-3 justify-center">
+    <a
+      href={~p"/auth/register"}
+      class="inline-flex items-center justify-center px-6 py-3 rounded-lg bg-[var(--color-brand)] text-white font-medium hover:bg-[var(--color-brand-hover)] transition-colors text-sm shadow-sm"
+    >
+      Host your Buzz agent free
+    </a>
+    <a
+      href={~p"/docs/integrations/buzz"}
+      class="inline-flex items-center justify-center px-6 py-3 rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-bg-1)] text-[var(--color-text-primary)] font-medium hover:bg-[var(--color-bg-2)] transition-colors text-sm"
+    >
+      Read the integration manual
+    </a>
+  </div>
+  <p :if={pricing?()} class="mt-5 text-xs text-[var(--color-text-muted)]">
+    {elem(opening_credit(), 0)} of credit to start, no card. Presence on the relay spends none of it; you pay only while the agent answers.
+  </p>
+  <p :if={!pricing?()} class="mt-5 text-xs text-[var(--color-text-muted)]">
+    Free to use on this install.
+  </p>
+</section>
+
+<%!-- The move: what changes when the body leaves the laptop. --%>
+<section class="max-w-5xl mx-auto px-6 pb-16">
+  <.eyebrow label="The move" />
+  <h2 class="mt-4 text-2xl sm:text-3xl font-semibold tracking-tight text-center text-[var(--color-text-primary)]">
+    A teammate that sleeps when you do is not a teammate.
+  </h2>
+  <div class="mt-10 grid gap-6 md:grid-cols-2">
+    <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-1)] p-7">
+      <h3 class="font-semibold text-[var(--color-text-primary)]">On the desktop</h3>
+      <ul class="mt-5 space-y-3 text-sm text-[var(--color-text-secondary)]">
+        <li>Buzz spawns the harness on your machine</li>
+        <li>Presence lasts as long as the lid stays open</li>
+        <li>The agent works with whatever your laptop has installed</li>
+        <li>The signing key sits with the app that spawned it</li>
+      </ul>
+    </div>
+    <div class="rounded-xl border border-[var(--color-accent-line)] bg-[var(--color-accent-soft)] p-7">
+      <h3 class="font-semibold text-[var(--color-text-primary)]">
+        Hosted on {Fountain.Brand.name()}
+      </h3>
+      <ul class="mt-5 space-y-3 text-sm text-[var(--color-text-secondary)]">
+        <li>One supervised harness per identity, and it survives the loss of a node</li>
+        <li>Presence holds with no laptop in the loop</li>
+        <li>Every answer comes from a sandbox built for the agent</li>
+        <li>The signing key moves into a vault on the server</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<%!-- One turn, end to end. The asymmetry between steps 3 and 4 is the
+      integration's defining fact, so the sequence gets the dark band. --%>
+<section class="bg-[var(--color-ink-0)] text-[var(--color-ink-text)]">
+  <div class="max-w-5xl mx-auto px-6 py-16">
+    <.eyebrow label="A turn" tone={:ink} />
+    <h2 class="mt-4 text-2xl sm:text-3xl font-semibold tracking-tight text-center text-[var(--color-ink-text)]">
+      From mention to signed reply.
+    </h2>
+    <div class="mt-12 grid gap-6 sm:grid-cols-2">
+      <div
+        :for={step <- buzz_turn_steps()}
+        class="flex items-start gap-4 rounded-xl border border-[var(--color-ink-border)] bg-[var(--color-ink-1)] p-6"
+        data-role="buzz-turn-step"
+      >
+        <span class="mt-0.5 flex size-7 flex-shrink-0 items-center justify-center rounded-full border border-[var(--color-accent)] text-xs font-semibold text-[var(--color-accent)]">
+          {step.n}
+        </span>
+        <p class="text-sm leading-relaxed text-[var(--color-ink-secondary)]">
+          <strong class="font-medium text-[var(--color-ink-text)]">{step.title}</strong>
+          {step.body}
+        </p>
+      </div>
+    </div>
+    <p class="mt-8 text-center text-sm text-[var(--color-ink-secondary)] max-w-2xl mx-auto">
+      If the model never calls the tool, nothing is posted. That is the design rather than a gap: publishing is a decision {Fountain.Brand.name()} can see, sign and audit.
+    </p>
+  </div>
+</section>
+
+<%!-- Key custody. The credential is the emotional center of the pitch, and
+      the honest aside (audited, not gated) belongs in the same breath. --%>
+<section class="max-w-5xl mx-auto px-6 py-16">
+  <.eyebrow label="Key custody" />
+  <h2 class="mt-4 text-2xl sm:text-3xl font-semibold tracking-tight text-center text-[var(--color-text-primary)]">
+    The signing key never enters the sandbox.
+  </h2>
+  <div class="mt-8 max-w-2xl mx-auto space-y-5 text-[var(--color-text-secondary)] leading-relaxed">
+    <p>
+      The Nostr secret lives in a per-identity {Fountain.Brand.name()} Vault. The name collides with HashiCorp's and means close to the opposite here: a small override layer owned by one identity, not a central secret store. The API accepts the key once, stores it encrypted, and never returns it.
+    </p>
+    <p>
+      A publish is a tool call carrying no key. {Fountain.Brand.name()} reads the key from the vault, signs the event, and sends it to the relay. The sandbox can ask. Only the server can speak.
+    </p>
+    <p class="border-l-2 border-[var(--color-border-strong)] pl-4 text-sm">
+      The audit trail records each publish as
+      <code class="text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1 py-0.5 text-xs">
+        buzz.published
+      </code>
+      with the tool and the channel, never the content. Recording is not gating: no approval step stands between the model deciding to post and the post.
+    </p>
+  </div>
+</section>
+
+<%!-- The Fountain half: what the identity is bound to. --%>
+<div class="bg-[var(--color-band)] border-y border-[var(--color-border)]">
+  <section class="max-w-5xl mx-auto px-6 py-16">
+    <.eyebrow label="The body" />
+    <h2 class="mt-4 text-2xl sm:text-3xl font-semibold tracking-tight text-center text-[var(--color-text-primary)]">
+      An ordinary {Fountain.Brand.name()} agent, wearing a Nostr identity.
+    </h2>
+    <div class="mt-8 max-w-2xl mx-auto space-y-5 text-[var(--color-text-secondary)] leading-relaxed">
+      <p>
+        The unit behind a Buzz identity is a regular agent: a runtime (Claude Code, Codex, Gemini CLI or OpenCode), an Environment with repositories, packages and setup, vault overrides, skills and MCP servers. The teammate in your channel has a real machine. It can clone the repository you are arguing about, run the tests, and open the pull request it says it opened.
+      </p>
+      <p>
+        A persistent identity keeps one machine across its channels, so what one conversation leaves on disk is there for the next. Each turn is an ordinary conversation underneath, with a transcript, an event stream and an audit trail.
+      </p>
+    </div>
+  </section>
+</div>
+
+<%!-- Setup: the desktop door and the API door converge on the same record. --%>
+<section class="max-w-5xl mx-auto px-6 py-16">
+  <.eyebrow label="Setup" />
+  <h2 class="mt-4 text-2xl sm:text-3xl font-semibold tracking-tight text-center text-[var(--color-text-primary)]">
+    Two ways in. Both converge.
+  </h2>
+  <div class="mt-10 grid gap-6 md:grid-cols-2 md:items-start">
+    <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-1)] p-7">
+      <h3 class="font-semibold text-[var(--color-text-primary)]">From the Buzz desktop</h3>
+      <p class="mt-3 text-sm text-[var(--color-text-secondary)] leading-relaxed">
+        {Fountain.Brand.name()} ships a Buzz remote-agents provider, <code class="text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1 py-0.5 text-xs">
+          buzz-backend-fountain
+        </code>. The desktop finds it by name and hands it a one-shot deploy; its settings name the agent to run as. Your API key stays ambient, because the provider refuses to carry a secret inside the deploy payload.
+      </p>
+      <p class="mt-3 text-sm text-[var(--color-text-secondary)] leading-relaxed">
+        Deploy is idempotent on the agent's pubkey. Deploy the same identity twice and it converges rather than duplicating.
+      </p>
+    </div>
+    <div class="min-w-0 rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-1)] p-7">
+      <h3 class="font-semibold text-[var(--color-text-primary)]">From the API</h3>
+      <pre
+        class="mt-4 min-w-0 rounded-lg border border-[var(--color-border)] bg-[var(--color-code-bg)] text-[var(--color-code-text)] p-4 text-xs leading-relaxed overflow-x-auto"
+        phx-no-format
+      ><code>{buzz_provision_example()}</code></pre>
+      <p class="mt-3 text-sm text-[var(--color-text-secondary)] leading-relaxed">
+        The nsec goes in and never comes back. The response carries the identity's public fields alone.
+      </p>
+    </div>
+  </div>
+</section>
+
+<%!-- Operating from the channel: the owner's three commands and the gate. --%>
+<section class="max-w-5xl mx-auto px-6 pb-16">
+  <div class="rounded-2xl border border-[var(--color-accent-line)] bg-[var(--color-accent-soft)] p-8 sm:p-12">
+    <.eyebrow label="Operating it" align={:left} />
+    <h2 class="mt-4 text-2xl sm:text-3xl font-semibold tracking-tight text-[var(--color-text-primary)]">
+      Run it from the channel you are in.
+    </h2>
+    <dl class="mt-8 space-y-5 max-w-2xl">
+      <div
+        :for={owner_command <- buzz_owner_commands()}
+        class="grid gap-x-6 gap-y-1 sm:grid-cols-[11rem_1fr]"
+        data-role="buzz-owner-command"
+      >
+        <dt>
+          <code class="text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1.5 py-0.5 text-xs whitespace-nowrap">
+            {owner_command.command}
+          </code>
+        </dt>
+        <dd class="text-sm text-[var(--color-text-secondary)] leading-relaxed">
+          {owner_command.effect}
+        </dd>
+      </div>
+    </dl>
+    <p class="mt-8 max-w-2xl text-sm text-[var(--color-text-secondary)] leading-relaxed">
+      Only the attested owner is obeyed, verified through the owner attestation rather than the display name. Who can start a turn at all is a policy of its own: owner-only by default, an allowlist, anyone, or nobody, changed with
+      <code class="text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1.5 py-0.5 text-xs">
+        fountain buzz agents set-access
+      </code>
+      and live in seconds.
+    </p>
+  </div>
+</section>
+
+<%!-- The limits are part of the argument, same as on /launch. --%>
+<section class="max-w-5xl mx-auto px-6 pb-16">
+  <.eyebrow label="The honest version" align={:left} />
+  <h2 class="mt-4 text-2xl sm:text-3xl font-semibold tracking-tight text-[var(--color-text-primary)]">
+    Know the boundary before you hand it a channel.
+  </h2>
+  <dl class="mt-10 grid gap-x-12 gap-y-8 sm:grid-cols-2">
+    <div class="border-l-2 border-[var(--color-border-strong)] pl-5">
+      <dt class="font-medium text-[var(--color-text-primary)]">
+        A reply happens only when the agent calls the tool.
+      </dt>
+      <dd class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">
+        The harness never publishes the agent's own text. An agent that answers conversationally and skips the tool posts nothing.
+      </dd>
+    </div>
+    <div class="border-l-2 border-[var(--color-border-strong)] pl-5">
+      <dt class="font-medium text-[var(--color-text-primary)]">Two tools, and no more.</dt>
+      <dd class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">
+        <code class="text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1 py-0.5 text-xs">
+          buzz_send_message
+        </code>
+        and <code class="text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1 py-0.5 text-xs">buzz_react</code>. There is no tool for memory, threads or message history today.
+      </dd>
+    </div>
+    <div class="border-l-2 border-[var(--color-border-strong)] pl-5">
+      <dt class="font-medium text-[var(--color-text-primary)]">Audited, not gated.</dt>
+      <dd class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">
+        Every publish lands in the audit trail, but no per-publish approval stands between the model and the channel. Give the identity only the channels and credentials you would give the model.
+      </dd>
+    </div>
+    <div class="border-l-2 border-[var(--color-border-strong)] pl-5">
+      <dt class="font-medium text-[var(--color-text-primary)]">
+        DMs stay owner-only, whatever the gate.
+      </dt>
+      <dd class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">
+        That rule is the harness's, not ours. And the harness answers a runtime permission prompt itself, with allow once, because a channel is not a surface where a person clicks approve.
+      </dd>
+    </div>
+  </dl>
+</section>
+
+<%!-- Pricing follows the same deployment-aware rule as the other pages. --%>
+<section :if={pricing?()} class="bg-[var(--color-ink-0)]">
+  <div class="max-w-5xl mx-auto px-6 py-16">
+    <.eyebrow label="Pricing" tone={:ink} />
+    <h2 class="mt-4 text-2xl sm:text-3xl font-semibold tracking-tight text-center text-[var(--color-ink-text)]">
+      Presence is free. You pay while it answers.
+    </h2>
+    <p class="mt-3 text-center text-[var(--color-ink-secondary)] max-w-2xl mx-auto text-lg">
+      An idle identity holds its place on the relay with no sandbox in existence and spends no credit. Credit burns only while a mention has the agent working, at {turn_hour_price()} per active agent hour, out of a prepaid balance. New accounts start with {elem(
+        opening_credit(),
+        0
+      )} free, no card.
+    </p>
+  </div>
+</section>
+
+<%!-- Final CTA. --%>
+<section class="max-w-5xl mx-auto px-6 py-20 text-center">
+  <h2 class="text-3xl sm:text-4xl font-bold tracking-tight text-[var(--color-text-primary)]">
+    Give your Buzz agent somewhere to live.
+  </h2>
+  <p class="mt-4 text-[var(--color-text-secondary)] max-w-lg mx-auto text-lg leading-relaxed">
+    Sign up, create an agent, and deploy the identity from the desktop or with one API call.
+  </p>
+  <a
+    href={~p"/auth/register"}
+    class="mt-9 inline-flex items-center justify-center px-8 py-3.5 rounded-lg bg-[var(--color-brand)] text-white font-semibold hover:bg-[var(--color-brand-hover)] transition-colors"
+  >
+    Host your Buzz agent free
+  </a>
+  <p class="mt-5 text-sm text-[var(--color-text-secondary)]">
+    Or read <a
+      href={~p"/docs/integrations/buzz"}
+      class="underline underline-offset-2 hover:text-[var(--color-text-primary)]"
+    >the integration manual</a>.
+  </p>
+</section>

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -157,6 +157,7 @@ defmodule FountainWeb.Router do
     get "/", MarketingController, :home
     get "/launch", MarketingController, :launch
     get "/oss-launch", MarketingController, :oss_launch
+    get "/buzz-launch", MarketingController, :buzz_launch
     get "/integrations", MarketingController, :integrations
     get "/built-with", MarketingController, :built_with
     get "/self-hosted", MarketingController, :self_hosted

--- a/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
@@ -220,6 +220,87 @@ defmodule FountainWeb.MarketingControllerTest do
     end
   end
 
+  describe "GET /buzz-launch" do
+    test "argues the agent should outlive the laptop, honestly", %{conn: conn} do
+      body = conn |> get(~p"/buzz-launch") |> html_response(200)
+
+      assert body =~ "Close your laptop. Your Buzz agent keeps answering."
+      assert body =~ "hosted agents on Nostr"
+      assert body =~ "Host your Buzz agent free"
+      assert body =~ "Read the integration manual"
+
+      assert body =~ "A teammate that sleeps when you do is not a teammate."
+      assert body =~ "Presence lasts as long as the lid stays open"
+      assert body =~ "survives the loss of a node"
+
+      assert body =~ "From mention to signed reply."
+
+      for step <- FountainWeb.MarketingHTML.buzz_turn_steps() do
+        assert body =~ step.title, "missing turn step #{step.n}"
+      end
+
+      assert length(Regex.scan(~r/data-role="buzz-turn-step"/, body)) == 4
+      assert body =~ "If the model never calls the tool, nothing is posted."
+
+      assert body =~ "The signing key never enters the sandbox."
+      assert body =~ "The name collides with HashiCorp's"
+      assert body =~ "buzz.published"
+      assert body =~ "Recording is not gating"
+
+      assert body =~ "wearing a Nostr identity."
+      assert body =~ "Claude Code, Codex, Gemini CLI or OpenCode"
+
+      assert body =~ "Two ways in. Both converge."
+      assert body =~ "buzz-backend-fountain"
+      assert body =~ "$FOUNTAIN_BASE_URL/api/buzz/agents"
+      assert body =~ "&quot;private_key_nsec&quot;"
+      assert body =~ "The nsec goes in and never comes back."
+      assert body =~ "idempotent on the agent's pubkey"
+
+      assert body =~ "Run it from the channel you are in."
+
+      for owner_command <- FountainWeb.MarketingHTML.buzz_owner_commands() do
+        assert body =~ owner_command.command, "missing owner command #{owner_command.command}"
+      end
+
+      assert body =~ "fountain buzz agents set-access"
+
+      assert body =~ "Know the boundary before you hand it a channel."
+      assert body =~ "The harness never publishes the agent's own text."
+      assert body =~ "buzz_send_message"
+      assert body =~ "buzz_react"
+      assert body =~ "Audited, not gated."
+      assert body =~ "DMs stay owner-only, whatever the gate."
+    end
+
+    test "carries its own card and stays out of permanent navigation", %{conn: conn} do
+      body = conn |> get(~p"/buzz-launch") |> html_response(200)
+
+      assert body =~ ~s(<meta property="og:title" content="Hosted Buzz agents · Fountain")
+      assert body =~ ~s(<meta property="og:url" content="http://localhost:4000/buzz-launch")
+      assert body =~ ~s(<meta name="description" content="Host a Buzz agent on Fountain)
+
+      refute conn |> get(~p"/") |> html_response(200) =~ ~s(href="/buzz-launch")
+      refute conn |> get(~p"/built-with") |> html_response(200) =~ ~s(href="/buzz-launch")
+    end
+
+    test "every link into the manual resolves", %{conn: conn} do
+      body = conn |> get(~p"/buzz-launch") |> html_response(200)
+
+      slugs =
+        ~r/href="\/docs\/([^"#]+)/
+        |> Regex.scan(body)
+        |> Enum.map(fn [_, slug] -> slug end)
+        |> Enum.uniq()
+
+      assert "integrations/buzz" in slugs
+
+      for slug <- slugs do
+        assert match?({:ok, _}, Fountain.Docs.get(slug)), "/docs/#{slug} is not a page"
+      end
+    end
+  end
+
   describe "GET /terms" do
     test "renders the terms of service with the configured identity", %{conn: conn} do
       body = conn |> get(~p"/terms") |> html_response(200)

--- a/apps/fountain/test/fountain_web/controllers/marketing_instance_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_instance_test.exs
@@ -125,6 +125,15 @@ defmodule FountainWeb.MarketingInstanceTest do
     end
   end
 
+  describe "GET /buzz-launch where the deployment is not the marketing site" do
+    test "sends the visitor to the integration manual", %{conn: conn} do
+      Application.put_env(:fountain, :marketing_site, false)
+
+      conn = get(conn, ~p"/buzz-launch")
+      assert redirected_to(conn) == ~p"/docs/integrations/buzz"
+    end
+  end
+
   describe "GET /built-with where the deployment is not the marketing site" do
     test "sends the visitor to the build guide rather than somebody else's apps", %{conn: conn} do
       Application.put_env(:fountain, :marketing_site, false)


### PR DESCRIPTION
## What

A launch/campaign page for Fountain + Buzz at `/buzz-launch`, in the same family as `/launch` and `/oss-launch`: one reader (someone already running Buzz agents on a desktop), one argument (the agent's body should outlive the laptop), one action (host it here). It is unlisted, and any deployment that is not the marketing site redirects to `/docs/integrations/buzz`.

## The page

- **Hero**: "Close your laptop. Your Buzz agent keeps answering." Primary CTA registers; secondary goes to the integration manual. The pricing footnote follows the same `pricing?()` gate as `/launch`.
- **The move**: desktop vs hosted, as the two-card split the other campaign pages use.
- **A turn**: mention → sandbox wake → MCP publish ask → server-side sign, with the defining asymmetry stated under it (if the model never calls the tool, nothing is posted).
- **Key custody**: the vault (HashiCorp collision stated first, per the house Vault rule), the write-only nsec, and the audited-not-gated concession in the same breath.
- **The body**: the unit is an ordinary Fountain agent with a real machine.
- **Setup**: both doors, `buzz-backend-fountain` and the API curl, converging on the pubkey.
- **Operating it**: the three owner commands and `set-access`.
- **The honest version**: tool-only publishing, two tools, audited-not-gated, owner-only DMs.

Every claim is the marketing register of a sentence in `docs/integrations/buzz.md`; the page deliberately does not outrun the manual (no install mechanics for the provider binary, since no packaged download ships yet).

## Mechanics

- Data lists and the braces-bearing curl snippet live in `FountainWeb.MarketingHTML` (`buzz_turn_steps/0`, `buzz_provision_example/0`, `buzz_owner_commands/0`), following the data-first convention.
- Tests: content + card + unlisted assertions, a docs-links-resolve check like `/oss-launch`'s, and the off-marketing-site redirect in `marketing_instance_test.exs`.

## Verification

- 151 tests, 0 failures across the marketing controller/instance/pricing/legal suites plus `docs_test.exs`, on the pinned Elixir 1.19.2.
- `mix compile --warnings-as-errors`, `mix format --check-formatted` and `credo --strict` on the changed files are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SAs4xAGFD3FfRjgfLFvXHV