### PR TITLE
test(finance): seed the closed previous month, not the running one

### DIFF
--- a/ee/test/fountain/billing_reconciliation_test.exs
+++ b/ee/test/fountain/billing_reconciliation_test.exs
@@ -37,10 +37,15 @@ defmodule Fountain.Billing.ReconciliationTest do
     admin
   end
 
-  defp month_start do
-    now = DateTime.utc_now()
-    %DateTime{now | day: 1, hour: 0, minute: 0, second: 0, microsecond: {0, 0}}
-  end
+  # The previous, closed month: the page and Finance.summary clip every
+  # interval to `now`, so hours seeded forward from the running month's start
+  # only report in full once the month is that many hours old — these tests
+  # failed on the first CI runs of 2026-09-01, the same way
+  # admin_finance_live_test.exs did. A closed month has a fixed ceiling, so
+  # the numbers are exact whenever the suite runs. Tests that seed through
+  # `ran/2` compute over `month_range(1)` and open the page with
+  # ?months_ago=1.
+  defp month_start, do: Billing.month_range(1).start
 
   defp ran(user, hours) do
     started = month_start()
@@ -87,7 +92,7 @@ defmodule Fountain.Billing.ReconciliationTest do
     user = insert_verified_user()
     ran(user, 10)
 
-    {ps, pe} = Billing.current_month_range()
+    %{start: ps, end: pe} = Billing.month_range(1)
     summary = Finance.summary(period: {ps, pe}, basis: :active)
 
     {:ok, _} =
@@ -118,7 +123,7 @@ defmodule Fountain.Billing.ReconciliationTest do
     admin = insert_admin()
     ran(insert_verified_user(), 10)
 
-    {:ok, lv, html} = live(login_user(conn, admin), ~p"/admin/finance")
+    {:ok, lv, html} = live(login_user(conn, admin), ~p"/admin/finance?months_ago=1")
     assert html =~ "Provider invoices"
     assert html =~ "$10.00"
     refute html =~ "dropped on this node"

--- a/ee/test/fountain_web/admin_finance_live_test.exs
+++ b/ee/test/fountain_web/admin_finance_live_test.exs
@@ -45,12 +45,17 @@ defmodule FountainWeb.AdminFinanceLiveTest do
 
   defp subscriber(_plan), do: insert_empty_user()
 
-  # A sandbox in the current month, awake for `hours` with a prompt in flight
-  # for `busy_hours`. Anchored to the start of this month so the page's default
-  # window contains it whatever day the suite runs.
+  # A sandbox in the previous, closed month, awake for `hours` with a prompt
+  # in flight for `busy_hours`. The previous month rather than the running one
+  # because the page clips every interval to `now` (SandboxUsage's ceiling is
+  # `earliest(period_end, now)`): anchored to the start of the running month,
+  # a 100-hour sandbox reports 100 hours only once the month is 100 hours
+  # old, so these tests failed for the first days of every month. A closed
+  # month has a fixed ceiling, so the numbers are exact whenever the suite
+  # runs. Every test that seeds through here opens the page with
+  # ?months_ago=1.
   defp ran(user, hours, busy_hours) do
-    now = DateTime.utc_now()
-    started = %DateTime{now | day: 1, hour: 0, minute: 0, second: 0, microsecond: {0, 0}}
+    %{start: started} = Fountain.Billing.month_range(1)
     ended = DateTime.add(started, hours * 3600, :second)
 
     sandbox =
@@ -98,7 +103,7 @@ defmodule FountainWeb.AdminFinanceLiveTest do
       user = subscriber("solo")
       ran(user, 10, 4)
 
-      {:ok, _lv, html} = live(login_user(conn, admin), ~p"/admin/finance")
+      {:ok, _lv, html} = live(login_user(conn, admin), ~p"/admin/finance?months_ago=1")
 
       assert html =~ "No rate card is configured"
       assert html =~ "PROVIDER_HOURLY_CENTS"
@@ -118,7 +123,7 @@ defmodule FountainWeb.AdminFinanceLiveTest do
       user = subscriber("solo")
       ran(user, 10, 4)
 
-      {:ok, _lv, html} = live(login_user(conn, admin), ~p"/admin/finance")
+      {:ok, _lv, html} = live(login_user(conn, admin), ~p"/admin/finance?months_ago=1")
 
       refute html =~ "No rate card is configured"
       # Ten active hours at $1 — active, not the four turn hours: the provider
@@ -134,7 +139,7 @@ defmodule FountainWeb.AdminFinanceLiveTest do
       user = subscriber("solo")
       ran(user, 100, 100)
 
-      {:ok, _lv, html} = live(login_user(conn, admin), ~p"/admin/finance")
+      {:ok, _lv, html} = live(login_user(conn, admin), ~p"/admin/finance?months_ago=1")
 
       # 100 hours at $5 with nothing burned this period: the whole cost is the loss.
       assert html =~ "text-red-700"
@@ -161,7 +166,7 @@ defmodule FountainWeb.AdminFinanceLiveTest do
       user = subscriber("solo")
       ran(user, 10, 4)
 
-      {:ok, _lv, html} = live(login_user(conn, admin), ~p"/admin/finance")
+      {:ok, _lv, html} = live(login_user(conn, admin), ~p"/admin/finance?months_ago=1")
 
       # A rate is shown in cents keeping its fraction — rounded to whole cents
       # 10.76 and 5.45 would both collapse and stop being comparable.
@@ -176,7 +181,7 @@ defmodule FountainWeb.AdminFinanceLiveTest do
       user = subscriber("solo")
       ran(user, 5, 5)
 
-      {:ok, _lv, html} = live(login_user(conn, admin), ~p"/admin/finance")
+      {:ok, _lv, html} = live(login_user(conn, admin), ~p"/admin/finance?months_ago=1")
 
       assert html =~ "12c/hour"
       refute html =~ "12.0c/hour"
@@ -193,14 +198,14 @@ defmodule FountainWeb.AdminFinanceLiveTest do
 
       conn = login_user(conn, admin)
 
-      {:ok, lv, html} = live(conn, ~p"/admin/finance")
+      {:ok, lv, html} = live(conn, ~p"/admin/finance?months_ago=1")
       assert html =~ "active hours"
       # Ten awake hours at $1.
       assert html =~ "$10.00"
 
       html =
         lv
-        |> element(~s{a[href="/admin/finance?months_ago=0&basis=turn"]})
+        |> element(~s{a[href="/admin/finance?months_ago=1&basis=turn"]})
         |> render_click()
 
       # The same two turn hours, now the thing being charged for.
@@ -217,7 +222,7 @@ defmodule FountainWeb.AdminFinanceLiveTest do
       user = subscriber("solo")
       ran(user, 10, 2)
 
-      {:ok, _lv, html} = live(login_user(conn, admin), ~p"/admin/finance")
+      {:ok, _lv, html} = live(login_user(conn, admin), ~p"/admin/finance?months_ago=1")
 
       assert html =~ "$2.00"
     end


### PR DESCRIPTION
## The flake

`/admin/finance` clips every usage interval to now — `SandboxUsage`'s ceiling is `earliest(period_end, now)` — but this file's `ran/3` anchored its sandbox and turn at the start of the *running* month and extended forward. A 100-hour sandbox therefore reports its full 100 hours only once the month is 100 hours old, so five of these tests fail for roughly the first four days of every UTC month. The 2026-09-01 00:16 UTC CI runs (e.g. PR #1316's) are the first month boundary since the finance panel shipped, and they went red on exactly these tests.

## The fix

Seed through `ran/3` into the **previous, closed month** and open the page with `?months_ago=1` (the month picker the page already has). A closed month has a fixed ceiling, so the numbers are exact whenever the suite runs. The basis-toggle selector follows (`months_ago=1&basis=turn` — the link carries the socket's month). The window-navigation test keeps opening the default month; it seeds nothing.

## Verification, against the live flake condition

Run at ~00:45 UTC on Sept 1, inside the flake window:

- Before the change: 13 tests, **5 failures** (the same five CI reported).
- After the change: 13 tests, **0 failures**.

## Known residual

`DashboardLiveTest`'s turn-hours test has the same shape with a 2-hour span, so it stays red for the first two UTC hours of each month (self-heals at 02:00 UTC). The dashboard has no month picker to lean on, so making it deterministic needs a clock seam through `Billing.usage_summary/3`; left out of this PR deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SAs4xAGFD3FfRjgfLFvXHV