### PR TITLE
copy(marketing): sharpen Buzz launch page

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/marketing_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_controller.ex
@@ -117,9 +117,9 @@ defmodule FountainWeb.MarketingController do
         layout: {FountainWeb.Layouts, :marketing},
         page_title: "Hosted Buzz agents · #{Fountain.Brand.name()}",
         meta_description:
-          "Host a Buzz agent on #{Fountain.Brand.name()} instead of a laptop. It keeps " <>
-            "presence on the relay, answers mentions from a sandbox, and its Nostr key " <>
-            "never leaves the server."
+          "Keep your Buzz agent on the relay without keeping your laptop open. " <>
+            "#{Fountain.Brand.name()} wakes a sandbox for accepted mentions and keeps " <>
+            "the Nostr key on the server."
       )
     else
       redirect(conn, to: ~p"/docs/integrations/buzz")

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
@@ -308,25 +308,25 @@ defmodule FountainWeb.MarketingHTML do
     [
       %{
         n: 1,
-        title: "A mention arrives.",
+        title: "A mention reaches Fountain.",
         body:
-          "Somebody @-mentions the agent in a channel. The harness holding its " <>
-            "presence picks the mention up on the gateway, not on anybody's laptop."
+          "An allowed sender @-mentions the agent in a channel. The hosted harness " <>
+            "picks it up from the relay with no laptop in the path."
       },
       %{
         n: 2,
-        title: "A sandbox wakes.",
+        title: "Fountain wakes the agent.",
         body:
-          "Fountain drives the turn over ACP on a machine built from the bound " <>
-            "agent's Environment: its repositories, packages, tools and credentials."
+          "Fountain starts or resumes a sandbox built from the bound agent's " <>
+            "Environment, then drives the turn over ACP."
       },
       %{
         n: 3,
-        title: "The agent asks to publish.",
+        title: "The agent chooses to reply.",
         body:
-          "To reply, it calls buzz_send_message, a Fountain-hosted MCP tool. The " <>
-            "sandbox holds no relay connection and no key, so the tool is the only " <>
-            "way anything reaches the channel."
+          "It calls buzz_send_message, a Fountain-hosted MCP tool. The sandbox has " <>
+            "no relay connection or signing key, so the call is the only path to " <>
+            "the channel."
       },
       %{
         n: 4,
@@ -376,8 +376,8 @@ defmodule FountainWeb.MarketingHTML do
       %{
         command: "@Agent !rotate",
         effect:
-          "Ends the channel's current conversation and opens a fresh one on the " <>
-            "next mention. A clean slate without a redeploy."
+          "Ends the channel's current conversation. The next mention starts clean, " <>
+            "with no redeploy."
       },
       %{
         command: "@Agent !cancel",
@@ -386,8 +386,8 @@ defmodule FountainWeb.MarketingHTML do
       %{
         command: "@Agent !shutdown",
         effect:
-          "Exits the harness. Fountain restarts it while the identity stays " <>
-            "enabled, so stopping for good is the API's delete, not a mention."
+          "Exits the harness. Fountain restarts it while the identity remains " <>
+            "enabled. Delete the identity through the API to stop it permanently."
       }
     ]
   end

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/buzz_launch.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/buzz_launch.html.heex
@@ -15,7 +15,7 @@
     Close your laptop. Your Buzz agent keeps answering.
   </h1>
   <p class="mt-6 text-lg sm:text-xl leading-relaxed text-[var(--color-text-secondary)] max-w-2xl mx-auto">
-    A Buzz agent is a Nostr identity, and on the desktop the coding agent behind it runs on your laptop and stops when the laptop does. {Fountain.Brand.name()} hosts that half instead: the identity holds its presence on the relay and answers every mention from a sandbox, whether or not a laptop is open.
+    On Buzz Desktop, the coding agent behind each identity runs on your laptop. Host it on {Fountain.Brand.name()} and it stays connected to the relay, wakes a ready sandbox for each accepted mention, and keeps its signing key out of the sandbox.
   </p>
   <div class="mt-10 flex flex-col sm:flex-row gap-3 justify-center">
     <a
@@ -32,7 +32,7 @@
     </a>
   </div>
   <p :if={pricing?()} class="mt-5 text-xs text-[var(--color-text-muted)]">
-    {elem(opening_credit(), 0)} of credit to start, no card. Presence on the relay spends none of it; you pay only while the agent answers.
+    {elem(opening_credit(), 0)} of credit to start, no card. Presence on the relay uses no credit. You pay only while the agent handles a mention.
   </p>
   <p :if={!pricing?()} class="mt-5 text-xs text-[var(--color-text-muted)]">
     Free to use on this install.
@@ -43,16 +43,16 @@
 <section class="max-w-5xl mx-auto px-6 pb-16">
   <.eyebrow label="The move" />
   <h2 class="mt-4 text-2xl sm:text-3xl font-semibold tracking-tight text-center text-[var(--color-text-primary)]">
-    A teammate that sleeps when you do is not a teammate.
+    Take your laptop out of the loop.
   </h2>
   <div class="mt-10 grid gap-6 md:grid-cols-2">
     <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-1)] p-7">
-      <h3 class="font-semibold text-[var(--color-text-primary)]">On the desktop</h3>
+      <h3 class="font-semibold text-[var(--color-text-primary)]">Running on your desktop</h3>
       <ul class="mt-5 space-y-3 text-sm text-[var(--color-text-secondary)]">
-        <li>Buzz spawns the harness on your machine</li>
-        <li>Presence lasts as long as the lid stays open</li>
-        <li>The agent works with whatever your laptop has installed</li>
-        <li>The signing key sits with the app that spawned it</li>
+        <li>Your laptop runs the agent harness</li>
+        <li>Closing the laptop takes the agent offline</li>
+        <li>Each turn uses your local checkout, packages and tools</li>
+        <li>Buzz Desktop holds the identity's signing key</li>
       </ul>
     </div>
     <div class="rounded-xl border border-[var(--color-accent-line)] bg-[var(--color-accent-soft)] p-7">
@@ -60,10 +60,10 @@
         Hosted on {Fountain.Brand.name()}
       </h3>
       <ul class="mt-5 space-y-3 text-sm text-[var(--color-text-secondary)]">
-        <li>One supervised harness per identity, and it survives the loss of a node</li>
-        <li>Presence holds with no laptop in the loop</li>
-        <li>Every answer comes from a sandbox built for the agent</li>
-        <li>The signing key moves into a vault on the server</li>
+        <li>{Fountain.Brand.name()} supervises the harness and restarts it after a node loss</li>
+        <li>Your laptop is not part of the runtime</li>
+        <li>Each turn runs in a sandbox built from its Environment</li>
+        <li>{Fountain.Brand.name()} signs replies; the key never enters the sandbox</li>
       </ul>
     </div>
   </div>
@@ -93,7 +93,7 @@
       </div>
     </div>
     <p class="mt-8 text-center text-sm text-[var(--color-ink-secondary)] max-w-2xl mx-auto">
-      If the model never calls the tool, nothing is posted. That is the design rather than a gap: publishing is a decision {Fountain.Brand.name()} can see, sign and audit.
+      The agent must make an explicit tool call to publish. {Fountain.Brand.name()} signs the event and records when and where it was sent.
     </p>
   </div>
 </section>
@@ -107,10 +107,10 @@
   </h2>
   <div class="mt-8 max-w-2xl mx-auto space-y-5 text-[var(--color-text-secondary)] leading-relaxed">
     <p>
-      The Nostr secret lives in a per-identity {Fountain.Brand.name()} Vault. The name collides with HashiCorp's and means close to the opposite here: a small override layer owned by one identity, not a central secret store. The API accepts the key once, stores it encrypted, and never returns it.
+      The name collides with HashiCorp's, but a {Fountain.Brand.name()} Vault is a small set of per-agent overrides rather than a central secret store. {Fountain.Brand.name()} gives each Buzz identity its own Vault for the Nostr secret. The API accepts the key once, stores it encrypted, and never returns it.
     </p>
     <p>
-      A publish is a tool call carrying no key. {Fountain.Brand.name()} reads the key from the vault, signs the event, and sends it to the relay. The sandbox can ask. Only the server can speak.
+      To publish, the sandbox sends {Fountain.Brand.name()} a tool call containing no key. {Fountain.Brand.name()} reads the key, signs the event, and sends it to the relay.
     </p>
     <p class="border-l-2 border-[var(--color-border-strong)] pl-4 text-sm">
       The audit trail records each publish as
@@ -125,16 +125,16 @@
 <%!-- The Fountain half: what the identity is bound to. --%>
 <div class="bg-[var(--color-band)] border-y border-[var(--color-border)]">
   <section class="max-w-5xl mx-auto px-6 py-16">
-    <.eyebrow label="The body" />
+    <.eyebrow label="The coding agent" />
     <h2 class="mt-4 text-2xl sm:text-3xl font-semibold tracking-tight text-center text-[var(--color-text-primary)]">
-      An ordinary {Fountain.Brand.name()} agent, wearing a Nostr identity.
+      Give the identity a repository and the tools to use it.
     </h2>
     <div class="mt-8 max-w-2xl mx-auto space-y-5 text-[var(--color-text-secondary)] leading-relaxed">
       <p>
-        The unit behind a Buzz identity is a regular agent: a runtime (Claude Code, Codex, Gemini CLI or OpenCode), an Environment with repositories, packages and setup, vault overrides, skills and MCP servers. The teammate in your channel has a real machine. It can clone the repository you are arguing about, run the tests, and open the pull request it says it opened.
+        Behind the identity is a regular {Fountain.Brand.name()} agent. Choose Claude Code, Codex, Gemini CLI or OpenCode, then give it an Environment with the repositories, packages and setup it needs. Add vault overrides, skills and MCP servers as needed. The agent can inspect the repository, run its tests, and open the pull request it says it opened.
       </p>
       <p>
-        A persistent identity keeps one machine across its channels, so what one conversation leaves on disk is there for the next. Each turn is an ordinary conversation underneath, with a transcript, an event stream and an audit trail.
+        In persistent sandbox mode, the identity keeps one sandbox across its channels. What one conversation leaves on disk is there for the next. Every turn remains an ordinary {Fountain.Brand.name()} Conversation with a transcript, an event stream and an audit trail.
       </p>
     </div>
   </section>
@@ -144,18 +144,22 @@
 <section class="max-w-5xl mx-auto px-6 py-16">
   <.eyebrow label="Setup" />
   <h2 class="mt-4 text-2xl sm:text-3xl font-semibold tracking-tight text-center text-[var(--color-text-primary)]">
-    Two ways in. Both converge.
+    Deploy from Buzz Desktop or the API.
   </h2>
   <div class="mt-10 grid gap-6 md:grid-cols-2 md:items-start">
     <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-1)] p-7">
-      <h3 class="font-semibold text-[var(--color-text-primary)]">From the Buzz desktop</h3>
+      <h3 class="font-semibold text-[var(--color-text-primary)]">From Buzz Desktop</h3>
       <p class="mt-3 text-sm text-[var(--color-text-secondary)] leading-relaxed">
-        {Fountain.Brand.name()} ships a Buzz remote-agents provider, <code class="text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1 py-0.5 text-xs">
+        {Fountain.Brand.name()} ships a Buzz remote-agents provider named <code class="text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1 py-0.5 text-xs">
           buzz-backend-fountain
-        </code>. The desktop finds it by name and hands it a one-shot deploy; its settings name the agent to run as. Your API key stays ambient, because the provider refuses to carry a secret inside the deploy payload.
+        </code>. Buzz Desktop discovers it and uses it to deploy the identity. In its settings, choose the {Fountain.Brand.name()} agent and optional Environment that should run behind the identity.
       </p>
       <p class="mt-3 text-sm text-[var(--color-text-secondary)] leading-relaxed">
-        Deploy is idempotent on the agent's pubkey. Deploy the same identity twice and it converges rather than duplicating.
+        The provider reads your API key from the environment or the
+        <code class="text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1 py-0.5 text-xs">
+          fountain
+        </code>
+        CLI credentials file. It refuses to put the key in the Buzz deploy payload. Deploying the same pubkey again updates the existing identity instead of creating a duplicate.
       </p>
     </div>
     <div class="min-w-0 rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-1)] p-7">
@@ -165,7 +169,7 @@
         phx-no-format
       ><code>{buzz_provision_example()}</code></pre>
       <p class="mt-3 text-sm text-[var(--color-text-secondary)] leading-relaxed">
-        The nsec goes in and never comes back. The response carries the identity's public fields alone.
+        {Fountain.Brand.name()} stores the nsec from this request and never returns it. The response contains only the identity's public fields.
       </p>
     </div>
   </div>
@@ -176,7 +180,7 @@
   <div class="rounded-2xl border border-[var(--color-accent-line)] bg-[var(--color-accent-soft)] p-8 sm:p-12">
     <.eyebrow label="Operating it" align={:left} />
     <h2 class="mt-4 text-2xl sm:text-3xl font-semibold tracking-tight text-[var(--color-text-primary)]">
-      Run it from the channel you are in.
+      Control it from the Buzz channel.
     </h2>
     <dl class="mt-8 space-y-5 max-w-2xl">
       <div
@@ -195,51 +199,74 @@
       </div>
     </dl>
     <p class="mt-8 max-w-2xl text-sm text-[var(--color-text-secondary)] leading-relaxed">
-      Only the attested owner is obeyed, verified through the owner attestation rather than the display name. Who can start a turn at all is a policy of its own: owner-only by default, an allowlist, anyone, or nobody, changed with
+      Only the attested owner can issue these commands. {Fountain.Brand.name()} verifies the owner attestation rather than trusting the display name.
+    </p>
+    <p class="mt-4 max-w-2xl text-sm text-[var(--color-text-secondary)] leading-relaxed">
+      A separate harness policy decides whose mentions may start a turn. Choose owner-only (the default), an allowlist, anyone or nobody. Change it with
       <code class="text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1.5 py-0.5 text-xs">
         fountain buzz agents set-access
       </code>
-      and live in seconds.
+      and the harness applies the new policy within seconds.
     </p>
   </div>
 </section>
 
 <%!-- The limits are part of the argument, same as on /launch. --%>
 <section class="max-w-5xl mx-auto px-6 pb-16">
-  <.eyebrow label="The honest version" align={:left} />
+  <.eyebrow label="Current limits" align={:left} />
   <h2 class="mt-4 text-2xl sm:text-3xl font-semibold tracking-tight text-[var(--color-text-primary)]">
-    Know the boundary before you hand it a channel.
+    What the integration does, and what it does not.
   </h2>
   <dl class="mt-10 grid gap-x-12 gap-y-8 sm:grid-cols-2">
     <div class="border-l-2 border-[var(--color-border-strong)] pl-5">
       <dt class="font-medium text-[var(--color-text-primary)]">
-        A reply happens only when the agent calls the tool.
+        A reply requires an explicit tool call.
       </dt>
       <dd class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">
-        The harness never publishes the agent's own text. An agent that answers conversationally and skips the tool posts nothing.
-      </dd>
-    </div>
-    <div class="border-l-2 border-[var(--color-border-strong)] pl-5">
-      <dt class="font-medium text-[var(--color-text-primary)]">Two tools, and no more.</dt>
-      <dd class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">
-        <code class="text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1 py-0.5 text-xs">
-          buzz_send_message
-        </code>
-        and <code class="text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1 py-0.5 text-xs">buzz_react</code>. There is no tool for memory, threads or message history today.
-      </dd>
-    </div>
-    <div class="border-l-2 border-[var(--color-border-strong)] pl-5">
-      <dt class="font-medium text-[var(--color-text-primary)]">Audited, not gated.</dt>
-      <dd class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">
-        Every publish lands in the audit trail, but no per-publish approval stands between the model and the channel. Give the identity only the channels and credentials you would give the model.
+        The harness does not publish the agent's normal response. If the agent does not call a publishing tool, nothing reaches the channel.
       </dd>
     </div>
     <div class="border-l-2 border-[var(--color-border-strong)] pl-5">
       <dt class="font-medium text-[var(--color-text-primary)]">
-        DMs stay owner-only, whatever the gate.
+        There are two publishing tools.
       </dt>
       <dd class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">
-        That rule is the harness's, not ours. And the harness answers a runtime permission prompt itself, with allow once, because a channel is not a surface where a person clicks approve.
+        <code class="text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1 py-0.5 text-xs">
+          buzz_send_message
+        </code>
+        and <code class="text-[var(--color-code-text)] bg-[var(--color-code-bg)] rounded px-1 py-0.5 text-xs">buzz_react</code>. There is currently no tool for memory, threads or message history.
+      </dd>
+    </div>
+    <div class="border-l-2 border-[var(--color-border-strong)] pl-5">
+      <dt class="font-medium text-[var(--color-text-primary)]">
+        Publishing is audited, not approved.
+      </dt>
+      <dd class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">
+        Every publish appears in the audit trail. There is no per-publish approval between the model and the channel, so give the identity only the channels and credentials you would give the model.
+      </dd>
+    </div>
+    <div class="border-l-2 border-[var(--color-border-strong)] pl-5">
+      <dt class="font-medium text-[var(--color-text-primary)]">
+        Direct messages remain owner-only.
+      </dt>
+      <dd class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">
+        The harness admits only the owner and other agents with the same owner in direct messages, regardless of the access policy.
+      </dd>
+    </div>
+    <div class="border-l-2 border-[var(--color-border-strong)] pl-5">
+      <dt class="font-medium text-[var(--color-text-primary)]">
+        Runtime permission prompts are automatic.
+      </dt>
+      <dd class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">
+        A Buzz channel has no approval button, so the harness answers runtime permission requests with allow once. Scope the agent's Environment and credentials accordingly.
+      </dd>
+    </div>
+    <div class="border-l-2 border-[var(--color-border-strong)] pl-5">
+      <dt class="font-medium text-[var(--color-text-primary)]">
+        Access does not make the agent discoverable.
+      </dt>
+      <dd class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">
+        The access policy controls which mentions the harness accepts. Buzz Desktop separately controls whether other people can find the identity in the composer.
       </dd>
     </div>
   </dl>
@@ -253,7 +280,7 @@
       Presence is free. You pay while it answers.
     </h2>
     <p class="mt-3 text-center text-[var(--color-ink-secondary)] max-w-2xl mx-auto text-lg">
-      An idle identity holds its place on the relay with no sandbox in existence and spends no credit. Credit burns only while a mention has the agent working, at {turn_hour_price()} per active agent hour, out of a prepaid balance. New accounts start with {elem(
+      While idle, the identity stays connected to the relay without running a sandbox or using credit. Credit is charged only while the agent handles a mention, at {turn_hour_price()} per active agent hour, out of a prepaid balance. New accounts start with {elem(
         opening_credit(),
         0
       )} free, no card.
@@ -264,10 +291,10 @@
 <%!-- Final CTA. --%>
 <section class="max-w-5xl mx-auto px-6 py-20 text-center">
   <h2 class="text-3xl sm:text-4xl font-bold tracking-tight text-[var(--color-text-primary)]">
-    Give your Buzz agent somewhere to live.
+    Keep your Buzz agent online.
   </h2>
   <p class="mt-4 text-[var(--color-text-secondary)] max-w-lg mx-auto text-lg leading-relaxed">
-    Sign up, create an agent, and deploy the identity from the desktop or with one API call.
+    Create a {Fountain.Brand.name()} agent, then deploy the Buzz identity from the desktop or with one API call.
   </p>
   <a
     href={~p"/auth/register"}

--- a/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
@@ -229,9 +229,9 @@ defmodule FountainWeb.MarketingControllerTest do
       assert body =~ "Host your Buzz agent free"
       assert body =~ "Read the integration manual"
 
-      assert body =~ "A teammate that sleeps when you do is not a teammate."
-      assert body =~ "Presence lasts as long as the lid stays open"
-      assert body =~ "survives the loss of a node"
+      assert body =~ "Take your laptop out of the loop."
+      assert body =~ "Closing the laptop takes the agent offline"
+      assert body =~ "restarts it after a node loss"
 
       assert body =~ "From mention to signed reply."
 
@@ -240,24 +240,24 @@ defmodule FountainWeb.MarketingControllerTest do
       end
 
       assert length(Regex.scan(~r/data-role="buzz-turn-step"/, body)) == 4
-      assert body =~ "If the model never calls the tool, nothing is posted."
+      assert body =~ "The agent must make an explicit tool call to publish."
 
       assert body =~ "The signing key never enters the sandbox."
       assert body =~ "The name collides with HashiCorp's"
       assert body =~ "buzz.published"
       assert body =~ "Recording is not gating"
 
-      assert body =~ "wearing a Nostr identity."
+      assert body =~ "Give the identity a repository and the tools to use it."
       assert body =~ "Claude Code, Codex, Gemini CLI or OpenCode"
 
-      assert body =~ "Two ways in. Both converge."
+      assert body =~ "Deploy from Buzz Desktop or the API."
       assert body =~ "buzz-backend-fountain"
       assert body =~ "$FOUNTAIN_BASE_URL/api/buzz/agents"
       assert body =~ "&quot;private_key_nsec&quot;"
-      assert body =~ "The nsec goes in and never comes back."
-      assert body =~ "idempotent on the agent's pubkey"
+      assert body =~ "stores the nsec from this request and never returns it"
+      assert body =~ "updates the existing identity instead of creating a duplicate"
 
-      assert body =~ "Run it from the channel you are in."
+      assert body =~ "Control it from the Buzz channel."
 
       for owner_command <- FountainWeb.MarketingHTML.buzz_owner_commands() do
         assert body =~ owner_command.command, "missing owner command #{owner_command.command}"
@@ -265,12 +265,14 @@ defmodule FountainWeb.MarketingControllerTest do
 
       assert body =~ "fountain buzz agents set-access"
 
-      assert body =~ "Know the boundary before you hand it a channel."
-      assert body =~ "The harness never publishes the agent's own text."
+      assert body =~ "What the integration does, and what it does not."
+      assert body =~ "The harness does not publish the agent's normal response."
       assert body =~ "buzz_send_message"
       assert body =~ "buzz_react"
-      assert body =~ "Audited, not gated."
-      assert body =~ "DMs stay owner-only, whatever the gate."
+      assert body =~ "Publishing is audited, not approved."
+      assert body =~ "Direct messages remain owner-only."
+      assert body =~ "Runtime permission prompts are automatic."
+      assert body =~ "Access does not make the agent discoverable."
     end
 
     test "carries its own card and stays out of permanent navigation", %{conn: conn} do
@@ -278,7 +280,7 @@ defmodule FountainWeb.MarketingControllerTest do
 
       assert body =~ ~s(<meta property="og:title" content="Hosted Buzz agents · Fountain")
       assert body =~ ~s(<meta property="og:url" content="http://localhost:4000/buzz-launch")
-      assert body =~ ~s(<meta name="description" content="Host a Buzz agent on Fountain)
+      assert body =~ ~s(<meta name="description" content="Keep your Buzz agent on the relay)
 
       refute conn |> get(~p"/") |> html_response(200) =~ ~s(href="/buzz-launch")
       refute conn |> get(~p"/built-with") |> html_response(200) =~ ~s(href="/buzz-launch")


### PR DESCRIPTION
## Summary
- replace the teammate-that-sleeps line with a direct laptop-free outcome
- rewrite the page around the hosted runtime, key custody, setup, controls, limits, pricing, and CTA
- clarify that harness access and Buzz Desktop discoverability are separate behaviors
- update the page metadata and copy assertions

## Test
- focused marketing controller suite: 78 tests, 0 failures
- formatter check passes
- git diff check passes