### PR TITLE
feat(connections): registry of remote MCP servers verified with discovery

### DIFF
--- a/.github/workflows/mcp-catalog-probe.yml
+++ b/.github/workflows/mcp-catalog-probe.yml
@@ -1,0 +1,62 @@
+name: MCP catalog probe
+
+# Re-verifies Fountain.Connections.McpServerCatalog (#1322): the MCP
+# authorization chain must still complete against every listed URL. Runs
+# scripts/mcp-catalog-probe.exs, which drives the production discovery code
+# (Fountain.Connections.McpDiscovery) read-only — no client is registered.
+#
+# Deliberately NOT part of PR CI: these are network calls to nine third
+# parties, and an entry going stale is drift against the catalog's dated
+# claim, not a defect in anyone's PR. A red run here means "re-probe and
+# update the entry's verified_on (or its dcr flag)", never "delete the
+# entry" — see the comment in mcp_server_catalog.ex.
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Monthly, on the 1st. The catalog's claim is dated, so the cadence only
+    # bounds how stale a date can silently get.
+    - cron: "17 6 1 * *"
+
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    name: probe the catalog
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
+        with:
+          persist-credentials: false
+
+      - name: Set up Elixir
+        id: beam
+        uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1.24.1
+        with:
+          elixir-version: "1.19.2"
+          otp-version: "28.3"
+
+      # Read-only restores of the dev-tree caches the `checks` job saves; a
+      # scheduled run must not save archives that PR jobs would then restore.
+      - name: Restore deps cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
+        with:
+          path: deps
+          key: ${{ runner.os }}-mix-checks-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-mix-checks-
+
+      - name: Restore build cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
+        with:
+          path: _build
+          key: ${{ runner.os }}-build-checks-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-build-checks-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-
+
+      - name: Probe
+        run: |
+          mix deps.get
+          mix run --no-start scripts/mcp-catalog-probe.exs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,18 @@ upgrade, is in
 
 ### Added
 
+- **A verified registry of remote MCP servers** (#1322). Fountain now ships
+  a list of ten remote MCP servers (Linear, Sentry, Notion, Asana,
+  Cloudflare, PayPal, Square, Webflow, Stripe, GitHub) whose MCP
+  authorization chain is verified to complete, each entry carrying the date
+  it was last checked. The list feeds preset chips on the console's
+  *Connect a remote MCP server* box, an `mcp_servers` key on
+  `GET /api/catalog`, and per-server pages under the docs catalog.
+  `scripts/mcp-catalog-probe.exs` re-verifies every entry through the
+  production discovery code, on demand and on a monthly schedule; a failed
+  probe means the entry keeps its stale date, so the claim stays honest.
+  Suggestions, not an allowlist: any URL still discovers.
+
 - **Two more platform connection providers: Microsoft and Slack** (#1299).
   The Connections page and `GET /api/connections/providers` now list three
   platform providers. One Microsoft sign-in covers Outlook mail, calendar and

--- a/apps/fountain/lib/fountain/connections/mcp_server_catalog.ex
+++ b/apps/fountain/lib/fountain/connections/mcp_server_catalog.ex
@@ -1,0 +1,140 @@
+defmodule Fountain.Connections.McpServerCatalog do
+  @moduledoc """
+  Remote MCP servers verified to work with connection discovery (#1322).
+
+  An entry is a checkable claim, not an endorsement: *the MCP authorization
+  chain (RFC 9728 resource metadata → RFC 8414 authorization-server
+  metadata → RFC 7591 registration where `dcr: true`) completed against
+  `url` on `verified_on`*. No human judgement is in the claim —
+  `scripts/mcp-catalog-probe.exs` re-runs the chain through
+  `Fountain.Connections.McpDiscovery.discover/1` itself and reports drift.
+  That definition is what unblocked #932: "supported" as an opinion is an
+  assertion nobody can verify, which CLAUDE.md forbids in docs.
+
+  Suggestions, not an allowlist — the `Fountain.Runtimes.Model` philosophy.
+  Nothing gates on membership: any URL a tenant pastes into the console or
+  `POST /api/connection-providers` is discovered the same way. The list
+  feeds the preset chips on the console's *Connect a remote MCP server*
+  box, the `mcp_servers` key of `GET /api/catalog`, and the entries under
+  `docs/catalog/mcp-servers/`.
+  """
+
+  # Every entry below was probed on 2026-09-01 with read-only metadata
+  # fetches (no client was registered, except where noted). `dcr: true`
+  # means the authorization-server metadata carried a
+  # `registration_endpoint`, so connecting is paste-the-URL with zero
+  # credentials typed; `dcr: false` means discovery fills the endpoints and
+  # the tenant pastes a client id from their own app registration — the
+  # console's existing fallback.
+  #
+  # A probe failure on a listed entry is drift, not deletion: the entry
+  # keeps its last good `verified_on`, and the stale date is the honest
+  # statement (#932's "known to work, dated"). Update the date only from a
+  # probe run, never by hand.
+  #
+  # Probed on 2026-09-01 and NOT qualifying — recheck with
+  # `mix run --no-start scripts/mcp-catalog-probe.exs <url>` before adding:
+  #   * Atlassian (https://mcp.atlassian.com/v1/sse) — no resource metadata
+  #     (404 at the well-known path).
+  #   * Intercom (https://mcp.intercom.com/mcp) — same.
+  # Stripe sat on this list in #1322's seed data ("AS metadata has no
+  # authorize endpoint") and turned out to qualify: the seed was a curl
+  # probe of one metadata path, while `McpDiscovery` tries the four RFC
+  # 8414/OIDC candidates and finds Stripe's at the issuer-path form. Which
+  # is why the probe drives the production discovery code and not curl.
+  @entries [
+    # Linear is the one entry verified past metadata: a provider was
+    # created end-to-end in prod via `POST /api/connection-providers`
+    # and came back `client_source: "dcr"`.
+    %{
+      slug: "linear",
+      name: "Linear",
+      url: "https://mcp.linear.app/mcp",
+      dcr: true,
+      verified_on: ~D[2026-09-01]
+    },
+    %{
+      slug: "sentry",
+      name: "Sentry",
+      url: "https://mcp.sentry.dev/mcp",
+      dcr: true,
+      verified_on: ~D[2026-09-01]
+    },
+    %{
+      slug: "notion",
+      name: "Notion",
+      url: "https://mcp.notion.com/mcp",
+      dcr: true,
+      verified_on: ~D[2026-09-01]
+    },
+    %{
+      slug: "asana",
+      name: "Asana",
+      url: "https://mcp.asana.com/sse",
+      dcr: true,
+      verified_on: ~D[2026-09-01]
+    },
+    %{
+      slug: "cloudflare",
+      name: "Cloudflare",
+      url: "https://mcp.cloudflare.com/mcp",
+      dcr: true,
+      verified_on: ~D[2026-09-01]
+    },
+    %{
+      slug: "paypal",
+      name: "PayPal",
+      url: "https://mcp.paypal.com/mcp",
+      dcr: true,
+      verified_on: ~D[2026-09-01]
+    },
+    %{
+      slug: "square",
+      name: "Square",
+      url: "https://mcp.squareup.com/sse",
+      dcr: true,
+      verified_on: ~D[2026-09-01]
+    },
+    %{
+      slug: "webflow",
+      name: "Webflow",
+      url: "https://mcp.webflow.com/sse",
+      dcr: true,
+      verified_on: ~D[2026-09-01]
+    },
+    # Issuer https://access.stripe.com/mcp; its RFC 8414 document lives at
+    # the issuer-path candidate, which is the one a naive probe misses.
+    %{
+      slug: "stripe",
+      name: "Stripe",
+      url: "https://mcp.stripe.com/mcp",
+      dcr: true,
+      verified_on: ~D[2026-09-01]
+    },
+    # GitHub's AS (github.com/login/oauth) publishes its metadata but
+    # offers no registration endpoint.
+    %{
+      slug: "github",
+      name: "GitHub",
+      url: "https://api.githubcopilot.com/mcp",
+      dcr: false,
+      verified_on: ~D[2026-09-01]
+    }
+  ]
+
+  @type entry :: %{
+          slug: String.t(),
+          name: String.t(),
+          url: String.t(),
+          dcr: boolean(),
+          verified_on: Date.t()
+        }
+
+  @doc "Every verified entry, in display order."
+  @spec entries() :: [entry()]
+  def entries, do: @entries
+
+  @doc "The entry for a slug, or nil."
+  @spec get(String.t()) :: entry() | nil
+  def get(slug), do: Enum.find(@entries, &(&1.slug == slug))
+end

--- a/apps/fountain/lib/fountain_web/controllers/catalog_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/catalog_controller.ex
@@ -4,7 +4,8 @@ defmodule FountainWeb.CatalogController do
   agent and environment forms — runtimes and their model suggestions,
   the sandbox providers usable here and the default, the package managers
   an environment accepts, the avatar generator's bases and moods (#815),
-  and where this instance's browser apps live (#866).
+  where this instance's browser apps live (#866), and the remote MCP
+  servers verified to complete connection discovery (#1322).
 
   Everything here is already public through the forms; this is the same
   lists over the API so a client on another origin does not hard-code them
@@ -27,8 +28,11 @@ defmodule FountainWeb.CatalogController do
       "Runtimes with model suggestions per runtime (suggestions, not an allowlist — " <>
         "any `provider/model` under a known provider is accepted), sandbox providers " <>
         "usable on this instance and the default, package managers an environment " <>
-        "accepts, the avatar generator's bases and moods, and the URLs of the " <>
-        "browser apps this instance sends people to for conversations and the team.",
+        "accepts, the avatar generator's bases and moods, the URLs of the " <>
+        "browser apps this instance sends people to for conversations and the team, " <>
+        "and remote MCP servers verified to complete connection discovery " <>
+        "(again suggestions — any URL can be discovered), each with the date " <>
+        "it was last verified.",
     responses: [ok: {"Catalog", "application/json", Schemas.CatalogResponse}]
   )
 
@@ -54,7 +58,11 @@ defmodule FountainWeb.CatalogController do
         apps: %{
           conversations: Fountain.Apps.conversations(),
           team: Fountain.Apps.team()
-        }
+        },
+        # Remote MCP servers whose authorization chain is known to complete
+        # (dated, re-checked by scripts/mcp-catalog-probe.exs) — so a client
+        # can render "Connect Sentry"-style rows without hard-coding URLs.
+        mcp_servers: Fountain.Connections.McpServerCatalog.entries()
       }
     })
   end

--- a/apps/fountain/lib/fountain_web/live/connections_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/connections_live/index.ex
@@ -80,6 +80,11 @@ defmodule FountainWeb.ConnectionsLive.Index do
 
   def presets, do: @presets
 
+  # The chips on the MCP box come from the verified registry (#1322), not a
+  # second list here: same menu-not-a-gate rule as @presets above, but these
+  # entries carry a machine-checked claim, so they live beside the checker.
+  def mcp_catalog, do: Fountain.Connections.McpServerCatalog.entries()
+
   @impl true
   def mount(_params, _session, socket) do
     user = socket.assigns.current_user
@@ -257,6 +262,13 @@ defmodule FountainWeb.ConnectionsLive.Index do
   end
 
   # ── remote MCP servers ────────────────────────────────────────────────────
+
+  def handle_event("mcp_preset", %{"slug" => slug}, socket) do
+    case Fountain.Connections.McpServerCatalog.get(slug) do
+      nil -> {:noreply, socket}
+      entry -> {:noreply, assign(socket, :mcp_url, entry.url)}
+    end
+  end
 
   def handle_event("validate_mcp", params, socket) do
     {:noreply,
@@ -724,6 +736,19 @@ defmodule FountainWeb.ConnectionsLive.Index do
             client with the authorization server where it offers one, so there is no client id to
             type. Paste one below only for a server without registration.
           </p>
+          <div class="flex gap-1 flex-wrap">
+            <span class="text-xs text-[var(--color-text-secondary)] self-center">Verified:</span>
+            <button
+              :for={entry <- mcp_catalog()}
+              type="button"
+              phx-click="mcp_preset"
+              phx-value-slug={entry.slug}
+              title={entry.url}
+              class="rounded-md border border-[var(--color-border)] px-2 py-0.5 text-xs"
+            >
+              {entry.name}
+            </button>
+          </div>
           <div class="flex gap-2">
             <input
               type="url"

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -2721,6 +2721,30 @@ defmodule FountainWeb.Schemas do
                 team: %Schema{type: :string, nullable: true}
               },
               required: [:conversations, :team]
+            },
+            mcp_servers: %Schema{
+              type: :array,
+              description:
+                "Remote MCP servers verified to complete the MCP authorization " <>
+                  "discovery chain, each with the date it was last verified. " <>
+                  "Suggestions, not an allowlist — any URL can be discovered.",
+              items: %Schema{
+                type: :object,
+                properties: %{
+                  slug: %Schema{type: :string},
+                  name: %Schema{type: :string},
+                  url: %Schema{type: :string},
+                  dcr: %Schema{
+                    type: :boolean,
+                    description:
+                      "Whether the authorization server offers dynamic client " <>
+                        "registration (RFC 7591). False means the tenant pastes a " <>
+                        "client id from their own app registration."
+                  },
+                  verified_on: %Schema{type: :string, format: :date}
+                },
+                required: [:slug, :name, :url, :dcr, :verified_on]
+              }
             }
           },
           required: [

--- a/apps/fountain/test/fountain/connections/mcp_server_catalog_test.exs
+++ b/apps/fountain/test/fountain/connections/mcp_server_catalog_test.exs
@@ -1,0 +1,29 @@
+defmodule Fountain.Connections.McpServerCatalogTest do
+  use ExUnit.Case, async: true
+
+  alias Fountain.Connections.{McpServerCatalog, UrlGuard}
+
+  test "every entry is well-formed" do
+    for entry <- McpServerCatalog.entries() do
+      assert is_binary(entry.slug) and entry.slug != ""
+      assert entry.slug == String.downcase(entry.slug)
+      assert is_binary(entry.name) and entry.name != ""
+      assert is_boolean(entry.dcr)
+      assert %Date{} = entry.verified_on
+      # The same rule discovery applies to a pasted URL: a listed URL that
+      # UrlGuard would refuse could never have been verified.
+      assert UrlGuard.check(entry.url) == :ok, "#{entry.slug}: #{entry.url}"
+    end
+  end
+
+  test "slugs and urls are unique" do
+    entries = McpServerCatalog.entries()
+    assert entries |> Enum.map(& &1.slug) |> Enum.uniq() |> length() == length(entries)
+    assert entries |> Enum.map(& &1.url) |> Enum.uniq() |> length() == length(entries)
+  end
+
+  test "get/1 finds by slug" do
+    assert %{name: "Linear", dcr: true} = McpServerCatalog.get("linear")
+    assert McpServerCatalog.get("nope") == nil
+  end
+end

--- a/apps/fountain/test/fountain_web/controllers/catalog_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/catalog_controller_test.exs
@@ -23,6 +23,15 @@ defmodule FountainWeb.CatalogControllerTest do
              "bases" => ~w(robot human alien),
              "moods" => ~w(serious casual goofy)
            }
+
+    assert length(data["mcp_servers"]) ==
+             length(Fountain.Connections.McpServerCatalog.entries())
+
+    linear = Enum.find(data["mcp_servers"], &(&1["slug"] == "linear"))
+    assert linear["name"] == "Linear"
+    assert linear["url"] == "https://mcp.linear.app/mcp"
+    assert linear["dcr"] == true
+    assert {:ok, _} = Date.from_iso8601(linear["verified_on"])
   end
 
   test "401 without a key", %{conn: conn} do

--- a/apps/fountain/test/fountain_web/live/connections_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/connections_live_test.exs
@@ -169,6 +169,10 @@ defmodule FountainWeb.ConnectionsLiveTest do
 
     {:ok, lv, _html} = conn |> login_user(user) |> live(~p"/account/connections")
 
+    # A chip from the verified registry (#1322) prefills the URL.
+    html = lv |> element("#mcp-discover-form button", "Linear") |> render_click()
+    assert html =~ ~s(value="https://mcp.linear.app/mcp")
+
     html =
       lv
       |> form("#mcp-discover-form", %{"mcp_url" => "https://mcp.example/mcp"})

--- a/docs/catalog/index.md
+++ b/docs/catalog/index.md
@@ -11,7 +11,7 @@ Each entry has the same shape. Read one and you can skim the rest.
 |---|---|---|
 | [Runtimes](runtimes/index.md) | One coding-agent CLI that a sandbox can run. | 4 |
 | [Skills](skills/index.md) | One `SKILL.md` that Fountain writes into the sandbox. | 2 bundled, and any repo on GitHub. |
-| [MCP servers](mcp-servers/index.md) | One server that gives the runtime tools. | 3 hosted, and any server you declare. |
+| [MCP servers](mcp-servers/index.md) | One server that gives the runtime tools. | 3 hosted, 10 verified remote, and any server you declare. |
 
 ## Start from a whole agent
 
@@ -35,12 +35,13 @@ configures. Mail, GitHub OAuth, Stripe, Sentry.
 **[Plug into Fountain](../integrations/clients.md).** What drives Fountain
 from outside. Editors, chat surfaces, plugin hosts, relays, and your own code.
 
-## What is not here yet
-
-**A list of third-party MCP servers.** Fountain hosts three of its own and
-documents those. No curated list says which external servers work.
-[#908](https://github.com/BinaryBourbon/fountain/issues/908) tracks it. Before
-such a list could be honest, somebody must decide what "supported" would mean.
+## Request an entry
 
 If you want an entry that does not exist, open an issue. The entry template is
 `standards/catalog-template.md` in the repository.
+
+For a remote MCP server, run
+`mix run --no-start scripts/mcp-catalog-probe.exs <url>` first. A green
+probe is the whole bar for the
+[verified list](mcp-servers/index.md#what-verified-means). "Supported" as
+an opinion was the reason no such list existed for a year.

--- a/docs/catalog/mcp-servers/asana.md
+++ b/docs/catalog/mcp-servers/asana.md
@@ -1,0 +1,50 @@
+# asana (MCP server)
+
+> Asana's remote MCP server. It gives an agent tools for the tasks
+> and projects in an Asana workspace.
+
+## Summary
+
+| | |
+|---|---|
+| URL | `https://mcp.asana.com/sse` |
+| Authorization server | Asana runs its own. |
+| Client registration | Automatic (RFC 7591). You type no client id. |
+| Verified | 2026-09-01. Read [what verified means](index.md#what-verified-means). |
+| Status | Beta. Only for accounts the egress broker is on for. Read [Feature status](../../reference/feature-status.md). |
+
+## What you will need
+
+A Asana account. The consent screen asks for the rest.
+
+## Set it up
+
+1. Open **Account, then Connections** in the console.
+2. Under **Connect a remote MCP server**, click **Asana**. The URL above
+   appears in the field.
+3. Click **Discover**. Fountain finds the authorization server and
+   registers a client there.
+4. Click **Connect** and approve on the consent screen.
+5. Attach the server to an agent. Read
+   [Connect a remote MCP server](../../guides/connect/remote-mcp-server.md).
+
+## Verify
+
+```bash
+mix run --no-start scripts/mcp-catalog-probe.exs https://mcp.asana.com/sse
+```
+
+The probe walks the discovery chain and prints one `ok` line.
+
+## Limits
+
+Fountain verifies the authorization chain, and not the tools. The tools
+are for Asana to change, and this page does not list them. The verified
+date says when the chain last completed, and nothing more.
+
+## Related
+
+- [MCP servers](index.md), the catalog hub, with
+  [what verified means](index.md#what-verified-means).
+- [Connect a remote MCP server](../../guides/connect/remote-mcp-server.md),
+  the full guide.

--- a/docs/catalog/mcp-servers/cloudflare.md
+++ b/docs/catalog/mcp-servers/cloudflare.md
@@ -1,0 +1,50 @@
+# cloudflare (MCP server)
+
+> Cloudflare's remote MCP server. It gives an agent tools for the
+> resources in a Cloudflare account.
+
+## Summary
+
+| | |
+|---|---|
+| URL | `https://mcp.cloudflare.com/mcp` |
+| Authorization server | Cloudflare runs its own. |
+| Client registration | Automatic (RFC 7591). You type no client id. |
+| Verified | 2026-09-01. Read [what verified means](index.md#what-verified-means). |
+| Status | Beta. Only for accounts the egress broker is on for. Read [Feature status](../../reference/feature-status.md). |
+
+## What you will need
+
+A Cloudflare account. The consent screen asks for the rest.
+
+## Set it up
+
+1. Open **Account, then Connections** in the console.
+2. Under **Connect a remote MCP server**, click **Cloudflare**. The URL above
+   appears in the field.
+3. Click **Discover**. Fountain finds the authorization server and
+   registers a client there.
+4. Click **Connect** and approve on the consent screen.
+5. Attach the server to an agent. Read
+   [Connect a remote MCP server](../../guides/connect/remote-mcp-server.md).
+
+## Verify
+
+```bash
+mix run --no-start scripts/mcp-catalog-probe.exs https://mcp.cloudflare.com/mcp
+```
+
+The probe walks the discovery chain and prints one `ok` line.
+
+## Limits
+
+Fountain verifies the authorization chain, and not the tools. The tools
+are for Cloudflare to change, and this page does not list them. The verified
+date says when the chain last completed, and nothing more.
+
+## Related
+
+- [MCP servers](index.md), the catalog hub, with
+  [what verified means](index.md#what-verified-means).
+- [Connect a remote MCP server](../../guides/connect/remote-mcp-server.md),
+  the full guide.

--- a/docs/catalog/mcp-servers/github.md
+++ b/docs/catalog/mcp-servers/github.md
@@ -1,0 +1,54 @@
+# github (MCP server)
+
+> GitHub's remote MCP server. It gives an agent tools for the
+> repositories, issues, and pull requests an account can reach.
+
+## Summary
+
+| | |
+|---|---|
+| URL | `https://api.githubcopilot.com/mcp` |
+| Authorization server | `github.com/login/oauth`. |
+| Client registration | Manual. Discovery fills the endpoints, and you paste a client id from your own GitHub app. |
+| Verified | 2026-09-01. Read [what verified means](index.md#what-verified-means). |
+| Status | Beta. Only for accounts the egress broker is on for. Read [Feature status](../../reference/feature-status.md). |
+
+## What you will need
+
+A GitHub account, and an OAuth app of your own. Create one under
+**Developer settings** on GitHub, with the redirect URI the provider
+shows after discovery.
+
+## Set it up
+
+1. Open **Account, then Connections** in the console.
+2. Under **Connect a remote MCP server**, click **GitHub**. The URL above
+   appears in the field.
+3. Click **Discover**. Fountain finds the endpoints. GitHub offers no
+   client registration, and the page says so.
+4. Edit the provider. Paste the client id and secret from your app.
+5. Click **Connect** and approve on the consent screen.
+6. Attach the server to an agent. Read
+   [Connect a remote MCP server](../../guides/connect/remote-mcp-server.md).
+
+## Verify
+
+```bash
+mix run --no-start scripts/mcp-catalog-probe.exs https://api.githubcopilot.com/mcp
+```
+
+The probe walks the discovery chain and prints one `ok` line.
+
+## Limits
+
+GitHub publishes its authorization metadata and offers no RFC 7591
+registration. Each tenant supplies an app of their own. Fountain verifies
+the authorization chain, and not the tools. The verified date says when
+the chain last completed, and nothing more.
+
+## Related
+
+- [MCP servers](index.md), the catalog hub, with
+  [what verified means](index.md#what-verified-means).
+- [Connect a remote MCP server](../../guides/connect/remote-mcp-server.md),
+  the full guide.

--- a/docs/catalog/mcp-servers/index.md
+++ b/docs/catalog/mcp-servers/index.md
@@ -8,8 +8,9 @@ and no operator configures them. Fountain injects them into a conversation
 when that conversation qualifies.
 
 **Servers you declare.** Everything else, through the `mcp_servers` field on
-an [Agent](../../concepts/agent.md). Fountain passes the declaration through
-and curates no list.
+an [Agent](../../concepts/agent.md). Fountain passes the declaration through.
+For remote servers with OAuth discovery, it keeps the dated list below. The
+authorization chain completed against each entry on the date shown.
 
 ## The three Fountain hosts
 
@@ -72,12 +73,52 @@ servers, and it does not pass them for each session. The effect is the same.
 The mechanism matters only when you debug why a raw ACP probe behaves one way
 and Fountain behaves another. Read [claude](../runtimes/claude.md).
 
-## No catalog of third-party servers
+## Remote servers verified with discovery
 
-Fountain keeps no list of which MCP servers work, and this page is not one.
+Paste one of these URLs into **Connect a remote MCP server** on the
+Connections page, or click its chip there, and the connection flow
+completes. Read
+[Connect a remote MCP server](../../guides/connect/remote-mcp-server.md)
+for the flow itself.
 
-Any server the runtime can launch will run. Whether it is a good idea is
-between you and its author.
+| Server | URL | Client registration | Verified |
+|---|---|---|---|
+| [asana](asana.md) | `https://mcp.asana.com/sse` | Automatic. | 2026-09-01. |
+| [cloudflare](cloudflare.md) | `https://mcp.cloudflare.com/mcp` | Automatic. | 2026-09-01. |
+| [github](github.md) | `https://api.githubcopilot.com/mcp` | Your own app. | 2026-09-01. |
+| [linear](linear.md) | `https://mcp.linear.app/mcp` | Automatic. | 2026-09-01. |
+| [notion](notion.md) | `https://mcp.notion.com/mcp` | Automatic. | 2026-09-01. |
+| [paypal](paypal.md) | `https://mcp.paypal.com/mcp` | Automatic. | 2026-09-01. |
+| [sentry](sentry.md) | `https://mcp.sentry.dev/mcp` | Automatic. | 2026-09-01. |
+| [square](square.md) | `https://mcp.squareup.com/sse` | Automatic. | 2026-09-01. |
+| [stripe](stripe.md) | `https://mcp.stripe.com/mcp` | Automatic. | 2026-09-01. |
+| [webflow](webflow.md) | `https://mcp.webflow.com/sse` | Automatic. | 2026-09-01. |
+
+The same list reaches clients through the `mcp_servers` key of
+`GET /api/catalog`, so an app on another origin renders it without
+hard-coded URLs. Read [Catalog](../../api.md) in the API reference.
+
+## What verified means
+
+One checkable claim, and no more. The MCP authorization chain, which is
+RFC 9728, then RFC 8414, then RFC 7591, completed against the URL on the
+date shown. A script makes the claim, not a person. The probe script,
+`scripts/mcp-catalog-probe.exs` in the repository, walks the chain with
+the same code the console uses. A green run is what re-dates an entry.
+
+The list is a menu, not a gate. Paste any URL and Fountain runs the same
+discovery. An entry here saves you the guess, and nothing more.
+
+The claim stops at authorization. Fountain does not verify the tools a
+server offers, and it does not endorse the server. **Automatic** in the
+table means the server's authorization server registers a client for
+Fountain, so you type no credentials. **Your own app** means you paste a
+client id from an app registration of your own.
+
+## Every other server
+
+Any server the runtime can launch will run, listed here or not. Whether it
+is a good idea is between you and its author.
 
 ## Related
 

--- a/docs/catalog/mcp-servers/linear.md
+++ b/docs/catalog/mcp-servers/linear.md
@@ -1,0 +1,50 @@
+# linear (MCP server)
+
+> Linear's remote MCP server. It gives an agent tools for the issues
+> and projects in a Linear workspace.
+
+## Summary
+
+| | |
+|---|---|
+| URL | `https://mcp.linear.app/mcp` |
+| Authorization server | Linear runs its own. |
+| Client registration | Automatic (RFC 7591). You type no client id. |
+| Verified | 2026-09-01. Read [what verified means](index.md#what-verified-means). |
+| Status | Beta. Only for accounts the egress broker is on for. Read [Feature status](../../reference/feature-status.md). |
+
+## What you will need
+
+A Linear account. The consent screen asks for the rest.
+
+## Set it up
+
+1. Open **Account, then Connections** in the console.
+2. Under **Connect a remote MCP server**, click **Linear**. The URL above
+   appears in the field.
+3. Click **Discover**. Fountain finds the authorization server and
+   registers a client there.
+4. Click **Connect** and approve on the consent screen.
+5. Attach the server to an agent. Read
+   [Connect a remote MCP server](../../guides/connect/remote-mcp-server.md).
+
+## Verify
+
+```bash
+mix run --no-start scripts/mcp-catalog-probe.exs https://mcp.linear.app/mcp
+```
+
+The probe walks the discovery chain and prints one `ok` line.
+
+## Limits
+
+Fountain verifies the authorization chain, and not the tools. The tools
+are for Linear to change, and this page does not list them. The verified
+date says when the chain last completed, and nothing more.
+
+## Related
+
+- [MCP servers](index.md), the catalog hub, with
+  [what verified means](index.md#what-verified-means).
+- [Connect a remote MCP server](../../guides/connect/remote-mcp-server.md),
+  the full guide.

--- a/docs/catalog/mcp-servers/notion.md
+++ b/docs/catalog/mcp-servers/notion.md
@@ -1,0 +1,50 @@
+# notion (MCP server)
+
+> Notion's remote MCP server. It gives an agent tools for the pages
+> and databases in a Notion workspace.
+
+## Summary
+
+| | |
+|---|---|
+| URL | `https://mcp.notion.com/mcp` |
+| Authorization server | Notion runs its own. |
+| Client registration | Automatic (RFC 7591). You type no client id. |
+| Verified | 2026-09-01. Read [what verified means](index.md#what-verified-means). |
+| Status | Beta. Only for accounts the egress broker is on for. Read [Feature status](../../reference/feature-status.md). |
+
+## What you will need
+
+A Notion account. The consent screen asks for the rest.
+
+## Set it up
+
+1. Open **Account, then Connections** in the console.
+2. Under **Connect a remote MCP server**, click **Notion**. The URL above
+   appears in the field.
+3. Click **Discover**. Fountain finds the authorization server and
+   registers a client there.
+4. Click **Connect** and approve on the consent screen.
+5. Attach the server to an agent. Read
+   [Connect a remote MCP server](../../guides/connect/remote-mcp-server.md).
+
+## Verify
+
+```bash
+mix run --no-start scripts/mcp-catalog-probe.exs https://mcp.notion.com/mcp
+```
+
+The probe walks the discovery chain and prints one `ok` line.
+
+## Limits
+
+Fountain verifies the authorization chain, and not the tools. The tools
+are for Notion to change, and this page does not list them. The verified
+date says when the chain last completed, and nothing more.
+
+## Related
+
+- [MCP servers](index.md), the catalog hub, with
+  [what verified means](index.md#what-verified-means).
+- [Connect a remote MCP server](../../guides/connect/remote-mcp-server.md),
+  the full guide.

--- a/docs/catalog/mcp-servers/paypal.md
+++ b/docs/catalog/mcp-servers/paypal.md
@@ -1,0 +1,50 @@
+# paypal (MCP server)
+
+> PayPal's remote MCP server. It gives an agent tools for the invoices
+> and payments in a PayPal account.
+
+## Summary
+
+| | |
+|---|---|
+| URL | `https://mcp.paypal.com/mcp` |
+| Authorization server | PayPal runs its own. |
+| Client registration | Automatic (RFC 7591). You type no client id. |
+| Verified | 2026-09-01. Read [what verified means](index.md#what-verified-means). |
+| Status | Beta. Only for accounts the egress broker is on for. Read [Feature status](../../reference/feature-status.md). |
+
+## What you will need
+
+A PayPal account. The consent screen asks for the rest.
+
+## Set it up
+
+1. Open **Account, then Connections** in the console.
+2. Under **Connect a remote MCP server**, click **PayPal**. The URL above
+   appears in the field.
+3. Click **Discover**. Fountain finds the authorization server and
+   registers a client there.
+4. Click **Connect** and approve on the consent screen.
+5. Attach the server to an agent. Read
+   [Connect a remote MCP server](../../guides/connect/remote-mcp-server.md).
+
+## Verify
+
+```bash
+mix run --no-start scripts/mcp-catalog-probe.exs https://mcp.paypal.com/mcp
+```
+
+The probe walks the discovery chain and prints one `ok` line.
+
+## Limits
+
+Fountain verifies the authorization chain, and not the tools. The tools
+are for PayPal to change, and this page does not list them. The verified
+date says when the chain last completed, and nothing more.
+
+## Related
+
+- [MCP servers](index.md), the catalog hub, with
+  [what verified means](index.md#what-verified-means).
+- [Connect a remote MCP server](../../guides/connect/remote-mcp-server.md),
+  the full guide.

--- a/docs/catalog/mcp-servers/sentry.md
+++ b/docs/catalog/mcp-servers/sentry.md
@@ -1,0 +1,50 @@
+# sentry (MCP server)
+
+> Sentry's remote MCP server. It gives an agent tools for the issues
+> and errors in a Sentry organization.
+
+## Summary
+
+| | |
+|---|---|
+| URL | `https://mcp.sentry.dev/mcp` |
+| Authorization server | Sentry runs its own. |
+| Client registration | Automatic (RFC 7591). You type no client id. |
+| Verified | 2026-09-01. Read [what verified means](index.md#what-verified-means). |
+| Status | Beta. Only for accounts the egress broker is on for. Read [Feature status](../../reference/feature-status.md). |
+
+## What you will need
+
+A Sentry account. The consent screen asks for the rest.
+
+## Set it up
+
+1. Open **Account, then Connections** in the console.
+2. Under **Connect a remote MCP server**, click **Sentry**. The URL above
+   appears in the field.
+3. Click **Discover**. Fountain finds the authorization server and
+   registers a client there.
+4. Click **Connect** and approve on the consent screen.
+5. Attach the server to an agent. Read
+   [Connect a remote MCP server](../../guides/connect/remote-mcp-server.md).
+
+## Verify
+
+```bash
+mix run --no-start scripts/mcp-catalog-probe.exs https://mcp.sentry.dev/mcp
+```
+
+The probe walks the discovery chain and prints one `ok` line.
+
+## Limits
+
+Fountain verifies the authorization chain, and not the tools. The tools
+are for Sentry to change, and this page does not list them. The verified
+date says when the chain last completed, and nothing more.
+
+## Related
+
+- [MCP servers](index.md), the catalog hub, with
+  [what verified means](index.md#what-verified-means).
+- [Connect a remote MCP server](../../guides/connect/remote-mcp-server.md),
+  the full guide.

--- a/docs/catalog/mcp-servers/square.md
+++ b/docs/catalog/mcp-servers/square.md
@@ -1,0 +1,50 @@
+# square (MCP server)
+
+> Square's remote MCP server. It gives an agent tools for the payments
+> and catalog in a Square account.
+
+## Summary
+
+| | |
+|---|---|
+| URL | `https://mcp.squareup.com/sse` |
+| Authorization server | Square runs its own. |
+| Client registration | Automatic (RFC 7591). You type no client id. |
+| Verified | 2026-09-01. Read [what verified means](index.md#what-verified-means). |
+| Status | Beta. Only for accounts the egress broker is on for. Read [Feature status](../../reference/feature-status.md). |
+
+## What you will need
+
+A Square account. The consent screen asks for the rest.
+
+## Set it up
+
+1. Open **Account, then Connections** in the console.
+2. Under **Connect a remote MCP server**, click **Square**. The URL above
+   appears in the field.
+3. Click **Discover**. Fountain finds the authorization server and
+   registers a client there.
+4. Click **Connect** and approve on the consent screen.
+5. Attach the server to an agent. Read
+   [Connect a remote MCP server](../../guides/connect/remote-mcp-server.md).
+
+## Verify
+
+```bash
+mix run --no-start scripts/mcp-catalog-probe.exs https://mcp.squareup.com/sse
+```
+
+The probe walks the discovery chain and prints one `ok` line.
+
+## Limits
+
+Fountain verifies the authorization chain, and not the tools. The tools
+are for Square to change, and this page does not list them. The verified
+date says when the chain last completed, and nothing more.
+
+## Related
+
+- [MCP servers](index.md), the catalog hub, with
+  [what verified means](index.md#what-verified-means).
+- [Connect a remote MCP server](../../guides/connect/remote-mcp-server.md),
+  the full guide.

--- a/docs/catalog/mcp-servers/stripe.md
+++ b/docs/catalog/mcp-servers/stripe.md
@@ -1,0 +1,50 @@
+# stripe (MCP server)
+
+> Stripe's remote MCP server. It gives an agent tools for the customers
+> and payments in a Stripe account.
+
+## Summary
+
+| | |
+|---|---|
+| URL | `https://mcp.stripe.com/mcp` |
+| Authorization server | Stripe runs its own. |
+| Client registration | Automatic (RFC 7591). You type no client id. |
+| Verified | 2026-09-01. Read [what verified means](index.md#what-verified-means). |
+| Status | Beta. Only for accounts the egress broker is on for. Read [Feature status](../../reference/feature-status.md). |
+
+## What you will need
+
+A Stripe account. The consent screen asks for the rest.
+
+## Set it up
+
+1. Open **Account, then Connections** in the console.
+2. Under **Connect a remote MCP server**, click **Stripe**. The URL above
+   appears in the field.
+3. Click **Discover**. Fountain finds the authorization server and
+   registers a client there.
+4. Click **Connect** and approve on the consent screen.
+5. Attach the server to an agent. Read
+   [Connect a remote MCP server](../../guides/connect/remote-mcp-server.md).
+
+## Verify
+
+```bash
+mix run --no-start scripts/mcp-catalog-probe.exs https://mcp.stripe.com/mcp
+```
+
+The probe walks the discovery chain and prints one `ok` line.
+
+## Limits
+
+Fountain verifies the authorization chain, and not the tools. The tools
+are for Stripe to change, and this page does not list them. The verified
+date says when the chain last completed, and nothing more.
+
+## Related
+
+- [MCP servers](index.md), the catalog hub, with
+  [what verified means](index.md#what-verified-means).
+- [Connect a remote MCP server](../../guides/connect/remote-mcp-server.md),
+  the full guide.

--- a/docs/catalog/mcp-servers/webflow.md
+++ b/docs/catalog/mcp-servers/webflow.md
@@ -1,0 +1,50 @@
+# webflow (MCP server)
+
+> Webflow's remote MCP server. It gives an agent tools for the sites
+> and collections in a Webflow workspace.
+
+## Summary
+
+| | |
+|---|---|
+| URL | `https://mcp.webflow.com/sse` |
+| Authorization server | Webflow runs its own. |
+| Client registration | Automatic (RFC 7591). You type no client id. |
+| Verified | 2026-09-01. Read [what verified means](index.md#what-verified-means). |
+| Status | Beta. Only for accounts the egress broker is on for. Read [Feature status](../../reference/feature-status.md). |
+
+## What you will need
+
+A Webflow account. The consent screen asks for the rest.
+
+## Set it up
+
+1. Open **Account, then Connections** in the console.
+2. Under **Connect a remote MCP server**, click **Webflow**. The URL above
+   appears in the field.
+3. Click **Discover**. Fountain finds the authorization server and
+   registers a client there.
+4. Click **Connect** and approve on the consent screen.
+5. Attach the server to an agent. Read
+   [Connect a remote MCP server](../../guides/connect/remote-mcp-server.md).
+
+## Verify
+
+```bash
+mix run --no-start scripts/mcp-catalog-probe.exs https://mcp.webflow.com/sse
+```
+
+The probe walks the discovery chain and prints one `ok` line.
+
+## Limits
+
+Fountain verifies the authorization chain, and not the tools. The tools
+are for Webflow to change, and this page does not list them. The verified
+date says when the chain last completed, and nothing more.
+
+## Related
+
+- [MCP servers](index.md), the catalog hub, with
+  [what verified means](index.md#what-verified-means).
+- [Connect a remote MCP server](../../guides/connect/remote-mcp-server.md),
+  the full guide.

--- a/docs/guides/connect/remote-mcp-server.md
+++ b/docs/guides/connect/remote-mcp-server.md
@@ -18,7 +18,9 @@ For a service with a classic OAuth app, read
 
 1. Open **Account, then Connections** in the console.
 2. Under **Connect a remote MCP server**, paste the server URL, for example
-   `https://mcp.linear.app/mcp`.
+   `https://mcp.linear.app/mcp`. Or click one of the **Verified** chips,
+   and the URL appears. The chips come from the
+   [verified list](../../catalog/mcp-servers/index.md#what-verified-means).
 3. Click **Discover**.
 
 The page reports the authorization server it found. With client
@@ -165,4 +167,4 @@ other host with it.
 - [Connect a service with your own OAuth app](own-oauth-app.md).
 - [Connections](../../catalog/connections/index.md), the catalog hub.
 - [MCP servers](../../catalog/mcp-servers/index.md), for the servers
-  Fountain hosts.
+  Fountain hosts and the verified remote servers.

--- a/docs/nav.yml
+++ b/docs/nav.yml
@@ -83,6 +83,16 @@ nav:
       - fountain-buzz: catalog/mcp-servers/fountain-buzz.md
       - fountain-comms: catalog/mcp-servers/fountain-comms.md
       - fountain-gmail: catalog/mcp-servers/fountain-gmail.md
+      - asana (MCP server): catalog/mcp-servers/asana.md
+      - cloudflare (MCP server): catalog/mcp-servers/cloudflare.md
+      - github (MCP server): catalog/mcp-servers/github.md
+      - linear (MCP server): catalog/mcp-servers/linear.md
+      - notion (MCP server): catalog/mcp-servers/notion.md
+      - paypal (MCP server): catalog/mcp-servers/paypal.md
+      - sentry (MCP server): catalog/mcp-servers/sentry.md
+      - square (MCP server): catalog/mcp-servers/square.md
+      - stripe (MCP server): catalog/mcp-servers/stripe.md
+      - webflow (MCP server): catalog/mcp-servers/webflow.md
       - Connections: catalog/connections/index.md
       - google (connection): catalog/connections/google.md
       - microsoft (connection): catalog/connections/microsoft.md

--- a/scripts/mcp-catalog-probe.exs
+++ b/scripts/mcp-catalog-probe.exs
@@ -1,0 +1,84 @@
+# Re-verifies Fountain.Connections.McpServerCatalog (#1322): for every entry,
+# the MCP authorization chain (RFC 9728 resource metadata → RFC 8414 AS
+# metadata → RFC 7591 registration endpoint where the entry claims DCR) must
+# still complete against the listed URL. Read-only — it never registers a
+# client, so running it leaves nothing behind on anyone's authorization
+# server.
+#
+#   mix run --no-start scripts/mcp-catalog-probe.exs            # the catalog
+#   mix run --no-start scripts/mcp-catalog-probe.exs <url>...   # candidates
+#
+# The second form probes arbitrary URLs — for rechecking the
+# probed-not-qualifying set noted in the catalog module (Stripe, Atlassian,
+# Intercom), or vetting a new entry before adding it.
+#
+# Why this is Elixir driving `McpDiscovery.discover/1` rather than the ~30
+# lines of curl+jq the seed data was gathered with: the catalog's claim is
+# "discovery completes against this URL", and discovery is
+# `Fountain.Connections.McpDiscovery` — a parallel curl implementation would
+# drift from it (the 401-challenge parse, the four AS metadata candidates,
+# the UrlGuard on every hop) and end up verifying a different claim.
+#
+# Where it runs: on demand, and on a schedule in
+# `.github/workflows/mcp-catalog-probe.yml`. Deliberately NOT in PR CI —
+# third-party network calls do not belong in the merge gate, and an entry
+# going stale is drift to report (re-date it), not a defect in the PR under
+# test.
+
+alias Fountain.Connections.{McpDiscovery, McpServerCatalog}
+
+{:ok, _} = Application.ensure_all_started(:req)
+
+defmodule McpCatalogProbe do
+  def probe(%{url: url} = entry) do
+    case McpDiscovery.discover(url) do
+      {:ok, md} -> check_registration(entry, md)
+      {:error, reason} -> {:drift, FountainWeb.ConnectionProviderJSON.describe(reason)}
+    end
+  end
+
+  # A dcr entry whose AS dropped its registration endpoint still "discovers",
+  # but the paste-the-URL-and-nothing-else claim no longer holds.
+  defp check_registration(%{dcr: true}, %{"registration_endpoint" => ep}) when is_binary(ep),
+    do: {:ok, "dcr"}
+
+  defp check_registration(%{dcr: true}, _md),
+    do: {:drift, "chain completes, but the registration endpoint is gone"}
+
+  defp check_registration(%{dcr: false}, %{"registration_endpoint" => ep}) when is_binary(ep),
+    do: {:ok, "now offers dcr — consider flipping the entry"}
+
+  defp check_registration(%{dcr: false}, _md), do: {:ok, "no dcr, as listed"}
+
+  def report({entry, {:ok, note}}) do
+    IO.puts("ok     #{String.pad_trailing(entry.slug, 12)} #{entry.url} (#{note})")
+    false
+  end
+
+  def report({entry, {:drift, reason}}) do
+    IO.puts("drift  #{String.pad_trailing(entry.slug, 12)} #{entry.url} — #{reason}")
+    true
+  end
+end
+
+entries =
+  case System.argv() do
+    [] -> McpServerCatalog.entries()
+    urls -> Enum.map(urls, &%{slug: URI.parse(&1).host || &1, url: &1, dcr: false})
+  end
+
+drifted =
+  entries
+  |> Task.async_stream(&{&1, McpCatalogProbe.probe(&1)}, timeout: 60_000, ordered: true)
+  |> Enum.map(fn {:ok, result} -> McpCatalogProbe.report(result) end)
+  |> Enum.count(& &1)
+
+# The trailing marker exists so a caller that swallows exit codes still
+# cannot read a partial log as success (same convention as
+# scripts/sandbox-image/smoke.sh).
+if drifted == 0 do
+  IO.puts("MCP_CATALOG_PROBE_RESULT: ok (#{length(entries)} probed)")
+else
+  IO.puts("MCP_CATALOG_PROBE_RESULT: drift (#{drifted} of #{length(entries)})")
+  System.halt(1)
+end

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -10,6 +10,18 @@ server releases.
 
 ---
 
+## [1.14.0] — 2026-09-01
+
+### Added
+
+- `client.catalog()` now returns `mcp_servers` (#1322): remote MCP servers
+  verified to complete the MCP authorization discovery chain, each with
+  `slug`, `name`, `url`, `dcr` (whether the server registers a client for
+  Fountain, RFC 7591) and `verified_on`, the date the chain last completed.
+  Suggestions, not an allowlist — any URL can still be discovered through
+  `client.connections.providers.create({ kind: "mcp", mcp_url })`. The
+  field is absent on servers older than this release.
+
 ## [1.13.0] — 2026-09-01
 
 ### Added

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentshit/fountain-sdk",
-      "version": "1.13.0",
+      "version": "1.14.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "Run a coding agent on a real computer, with your repos and your credentials, in one call.",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -13,7 +13,7 @@ export interface paths {
         };
         /**
          * The instance's form vocabulary
-         * @description Runtimes with model suggestions per runtime (suggestions, not an allowlist — any `provider/model` under a known provider is accepted), sandbox providers usable on this instance and the default, package managers an environment accepts, the avatar generator's bases and moods, and the URLs of the browser apps this instance sends people to for conversations and the team.
+         * @description Runtimes with model suggestions per runtime (suggestions, not an allowlist — any `provider/model` under a known provider is accepted), sandbox providers usable on this instance and the default, package managers an environment accepts, the avatar generator's bases and moods, the URLs of the browser apps this instance sends people to for conversations and the team, and remote MCP servers verified to complete connection discovery (again suggestions — any URL can be discovered), each with the date it was last verified.
          */
         get: operations["FountainWeb.CatalogController.show"];
         put?: never;
@@ -2932,6 +2932,16 @@ export interface components {
                     bases: string[];
                     moods: string[];
                 };
+                /** @description Remote MCP servers verified to complete the MCP authorization discovery chain, each with the date it was last verified. Suggestions, not an allowlist — any URL can be discovered. */
+                mcp_servers?: {
+                    /** @description Whether the authorization server offers dynamic client registration (RFC 7591). False means the tenant pastes a client id from their own app registration. */
+                    dcr: boolean;
+                    name: string;
+                    slug: string;
+                    url: string;
+                    /** Format: date */
+                    verified_on: string;
+                }[];
                 model_providers?: string[];
                 /** @description Suggested `provider/model` ids per runtime. Suggestions, not an allowlist. */
                 models: {

--- a/sdk/typescript/src/http.ts
+++ b/sdk/typescript/src/http.ts
@@ -19,7 +19,7 @@ export interface RequestOptions {
  * this string is already what Fountain's request logs are keyed on. The
  * version half is asserted against `package.json` by a test.
  */
-export const USER_AGENT = "fountain-sdk-js/1.13.0";
+export const USER_AGENT = "fountain-sdk-js/1.14.0";
 
 /**
  * The thin layer everything else is built on: one bearer token, JSON in and


### PR DESCRIPTION
Closes #1322. Unblocks #932 by giving "supported" a machine-checkable definition: *the MCP authorization chain (RFC 9728 resource metadata → RFC 8414 AS metadata → RFC 7591 DCR) completes against this URL on date X.* No human judgement in the claim; a script re-verifies it.

## What's here

- **`Fountain.Connections.McpServerCatalog`** — ten entries `{slug, name, url, dcr, verified_on}`, suggestions in code, not an allowlist (the `Fountain.Runtimes.Model` philosophy, comment discipline included). Nothing gates on membership.
- **Console** — a row of *Verified* preset chips on the *Connect a remote MCP server* box, mirroring the OAuth-app form's prefill chips. Click Linear → URL fills → Discover.
- **`GET /api/catalog`** — new `mcp_servers` key (optional in the schema, matching the `model_providers` precedent; SDK generated types regenerated), so downstream apps can render "Connect Sentry"-style rows.
- **Docs** — one `docs/catalog/mcp-servers/` entry per server with the verified-on date shown, a verified-servers table plus a *What verified means* section on the hub, and the two "no such list exists" paragraphs retired (`catalog/index.md`, `catalog/mcp-servers/index.md`). All four docs gates green (docs_test, docs-style, vale STE, destink).
- **`scripts/mcp-catalog-probe.exs`** — re-verifies every entry through `McpDiscovery.discover/1` itself, read-only (never registers a client). Runs on demand and monthly via `.github/workflows/mcp-catalog-probe.yml`; deliberately **not** in PR CI. Drift keeps the entry and stales its date, per the issue.

## One deviation from the seed data: Stripe qualifies

The issue listed Stripe as "probed, not qualifying (AS metadata has no authorize endpoint)". Probing through the production discovery code says otherwise: Stripe's RFC 8414 document lives at the **issuer-path** candidate (`issuer https://access.stripe.com/mcp`), one of the four forms `McpDiscovery` tries and a single-path curl probe misses. It has authorize, token, **and registration** endpoints, so it's in as tier 1 — which is itself the argument for the probe driving the real discovery code rather than a parallel curl implementation. Atlassian and Intercom re-probed today and still fail (404 at the well-known resource path).

## Verification

- `mix precommit` green (4272 tests, 0 failures).
- Live probe run today, all ten entries: chain completes, registration endpoint present where claimed (`MCP_CATALOG_PROBE_RESULT: ok (10 probed)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B7rooVmbjrUPETijsVKe5m