### PR TITLE
fix(cli): print why a turn failed, with the inference-key fix when that is why

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -446,6 +446,13 @@ upgrade, is in
 
 ### Fixed
 
+- **`fountain run` says why a turn failed.** A `turn`/`failed` event carries
+  the runtime's reason, and the CLI printed only `turn failed`. It prints the
+  reason now, and when the reason is the runtime's "Authentication required"
+  (what a sandbox reports when the account has no inference credential, the
+  quickstart step most easily skipped) it names the fix: add one under
+  Account, then Inference keys. The exit code is unchanged.
+
 - **The session title no longer opens a phantom "(background task follow-up)"
   turn after every claude turn** (#1300). The claude adapter generates the
   session title asynchronously and writes its `session_info_update` about a

--- a/cli/internal/cmd/conv.go
+++ b/cli/internal/cmd/conv.go
@@ -427,7 +427,18 @@ func handleStageEvent(data map[string]any) (bool, error) {
 	// stream would reconnect and wait out the idle timeout for a turn that
 	// is never coming.
 	case stage == "turn" && state == "failed":
-		fmt.Fprintf(os.Stderr, "▸ turn failed\n")
+		// The server puts why in the payload (conversation_server.ex
+		// publish_stage of "turn"/"failed"); a bare "turn failed" left a
+		// first-time user whose only mistake was skipping the inference
+		// key with nothing to act on.
+		if reason := innerDataString(data, "reason"); reason != "" {
+			fmt.Fprintf(os.Stderr, "▸ turn failed: %s\n", reason)
+			if hint := turnFailureHint(reason); hint != "" {
+				fmt.Fprintf(os.Stderr, "  %s\n", hint)
+			}
+		} else {
+			fmt.Fprintf(os.Stderr, "▸ turn failed\n")
+		}
 		return true, errTurnFailed
 
 	case stage == "provision" && state == "failed":
@@ -488,6 +499,18 @@ func exitCodeFromStageDone(data map[string]any) string {
 // innerDataString digs `data.data.<key>` out of a stage event. The Elixir
 // code JSON-encodes the stage metadata into the inner `data`, so we accept
 // either a nested map or a JSON string.
+// turnFailureHint turns a failure reason the runtime reported into the one
+// step that fixes it, where there is such a step. The ACP runtimes answer a
+// prompt with "Authentication required" when they were started with no
+// provider credential at all, which is what a run looks like when the
+// inference-key step of the quickstart was skipped.
+func turnFailureHint(reason string) string {
+	if strings.Contains(reason, "Authentication required") {
+		return "The runtime has no inference credential. Add one in the console under Account, then Inference keys, and prompt again."
+	}
+	return ""
+}
+
 func innerDataString(data map[string]any, key string) string {
 	inner := data["data"]
 	if s, ok := inner.(string); ok {

--- a/cli/internal/cmd/conv_test.go
+++ b/cli/internal/cmd/conv_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"errors"
+	"strings"
 	"testing"
 )
 
@@ -45,6 +46,15 @@ func TestHandleStageEvent(t *testing.T) {
 		{
 			name:     "turn failed",
 			data:     map[string]any{"stage": "turn", "state": "failed", "data": "{}"},
+			terminal: true,
+			wantErr:  errTurnFailed,
+		},
+		{
+			name: "turn failed with a reason is still errTurnFailed",
+			data: map[string]any{
+				"stage": "turn", "state": "failed",
+				"data": `{"reason":"acp: {:acp_error, :prompt, %{\"code\" => -32000, \"message\" => \"Authentication required\"}}"}`,
+			},
 			terminal: true,
 			wantErr:  errTurnFailed,
 		},
@@ -204,5 +214,18 @@ func TestLastEventIDIn(t *testing.T) {
 	// Heartbeat comments carry no id and must not confuse the head.
 	if got := lastEventIDIn(": heartbeat\n\n"); got != "" {
 		t.Errorf("heartbeat-only drain should have no head, got %q", got)
+	}
+}
+
+// A turn that fails because the runtime was started with no provider
+// credential reports "Authentication required"; the CLI names the fix rather
+// than leaving a bare "turn failed" (the quickstart's inference-key step).
+func TestTurnFailureHint(t *testing.T) {
+	reason := `acp: {:acp_error, :prompt, %{"code" => -32000, "message" => "Authentication required"}}`
+	if hint := turnFailureHint(reason); !strings.Contains(hint, "Inference keys") {
+		t.Fatalf("expected an inference-key hint, got %q", hint)
+	}
+	if hint := turnFailureHint("acp: peer closed"); hint != "" {
+		t.Fatalf("expected no hint for an unrelated reason, got %q", hint)
 	}
 }


### PR DESCRIPTION
## Why

Walked `/docs/quickstart` end to end with the CLI a new user gets. A run without an inference credential (the step most easily skipped) provisions the sandbox, clones the repository, then prints only:

```
▸ turn failed
fountain: turn failed
```

The server's `turn`/`failed` event carries the reason (`acp_error -32000 Authentication required`); the CLI dropped it.

## What

- `handleStageEvent` prints the payload's `reason` on `turn`/`failed`, the same way it already does for `reattach`/`failed`.
- When the reason is the runtime's "Authentication required", it adds one line naming the fix: add a credential under Account, then Inference keys.
- Exit code and `errTurnFailed` are unchanged, so `fountain run` in CI behaves as before.
- Tests: the table case with a reason, and `TestTurnFailureHint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017cvrzdzX6ni4BsbUjMPVXn