### PR TITLE
docs(quickstart): give Linux the release binary, not only brew

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ upgrade, is in
 
 ## [Unreleased]
 
+### Fixed
+
+- **The quickstart installs on Linux.** The page offered only `brew install`,
+  and Homebrew on Linux refuses to install any formula, even one that only
+  downloads a prebuilt binary, until a C compiler is present. Walked on a
+  fresh Ubuntu 24.04 host, the first command failed with "No developer tools
+  installed". The page now gives the release binary for Linux and names the
+  compiler requirement for anyone who prefers Homebrew there.
+
 ## [0.15.0] — 2026-09-01
 
 ### Upgrade notes

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -45,9 +45,23 @@ server supplies the control plane and sandbox provider.
 
 ## Install and authenticate the CLI
 
+On macOS, install the CLI with Homebrew.
+
 ```sh
 brew install BinaryBourbon/tap/fountain
 ```
+
+On Linux, Homebrew needs a C compiler before it installs a formula,
+`build-essential` on Debian and Ubuntu. The release binary has no such need.
+
+```sh
+curl -fsSLo fountain \
+  https://github.com/BinaryBourbon/fountain/releases/latest/download/fountain-linux-amd64
+chmod +x fountain
+sudo mv fountain /usr/local/bin/
+```
+
+Use `fountain-linux-arm64` on an ARM machine.
 
 Point the CLI at the server you chose.
 


### PR DESCRIPTION
Walked `/docs/quickstart` on a fresh Ubuntu 24.04 host (fireball) against the hosted server with the tap's 0.15.0. Everything after install works: device login, `fountain apply`, `fountain run`, the follow-up prompt on the same sandbox. The install step does not: Homebrew on Linux refuses to install any formula until a C compiler is present, so the page's only install command fails with `No developer tools installed`.

The page now offers the release binary for Linux (`releases/latest/download/fountain-linux-amd64`, with the arm64 name beside it) and names the compiler requirement for anyone who prefers Homebrew there.

Gates: vale (0 errors, 0 warnings), docs-style clean, destink clean, `docs_test.exs` 43/43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017cvrzdzX6ni4BsbUjMPVXn