### PR TITLE
Speak to builders on the open-source launch page

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/marketing_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_controller.ex
@@ -86,19 +86,19 @@ defmodule FountainWeb.MarketingController do
   end
 
   # The Fountain project launch page. Managoat's `/launch` sells the hosted
-  # instance; this page makes the parallel case for the open-source engine:
-  # deploy it, define one agent, connect existing systems and choose what
-  # observability leaves the instance. It is a campaign destination rather
-  # than a second homepage, so it stays out of the permanent navigation.
+  # instance; this page shows builders what they can make with the open-source
+  # engine, then proves they can own and reshape the whole stack. It is a
+  # campaign destination rather than a second homepage, so it stays out of the
+  # permanent navigation.
   def oss_launch(conn, _params) do
     if Fountain.Marketing.site?() do
       render(conn, :oss_launch,
         layout: {FountainWeb.Layouts, :marketing},
-        page_title: "Open-source infrastructure for coding agents · #{Fountain.Brand.engine()}",
+        page_title: "A conversational API to a computer · #{Fountain.Brand.engine()}",
         meta_description:
-          "Deploy #{Fountain.Brand.engine()} with Docker, Render, Fly.io or Kubernetes. " <>
-            "Define a coding agent once, connect it to the systems you already use, and " <>
-            "keep telemetry under your control."
+          "Give your app a computer it can talk to. Build on #{Fountain.Brand.engine()}, " <>
+            "run the open-source stack yourself, and keep your data, keys and agents " <>
+            "under your control."
       )
     else
       redirect(conn, to: ~p"/docs/open-source")

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/oss_launch.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/oss_launch.html.heex
@@ -1,37 +1,40 @@
-<%!-- Fountain's open-source launch page. Unlike /launch, this page names the
-      engine rather than the hosted brand and makes deployment, connection and
-      observability part of the first-screen promise. --%>
+<%!-- Fountain's open-source launch page. Unlike /launch, this page speaks to
+      builders first: the engine is a new application primitive, while
+      deployment and ownership are the reasons they can make it their own. --%>
 
 <section class="relative overflow-hidden border-b border-[var(--color-border)]">
   <div class="max-w-6xl mx-auto px-5 sm:px-6 py-16 sm:py-24 grid lg:grid-cols-[1.05fr_0.95fr] gap-12 lg:gap-16 items-center">
     <div>
       <p class="inline-flex items-center gap-2 rounded-full border border-[var(--color-border-strong)] bg-[var(--color-bg-1)] px-3.5 py-1.5 text-xs font-medium uppercase tracking-[0.16em] text-[var(--color-text-secondary)]">
         <span class="size-1.5 rounded-full bg-[var(--color-accent)]" aria-hidden="true"></span>
-        Fountain · AGPL-3.0-or-later
+        Open source · self-hosted · AGPL-3.0-or-later
       </p>
       <h1 class="mt-6 text-[2.75rem] leading-[1.02] sm:text-6xl font-bold tracking-[-0.035em] text-[var(--color-text-primary)]">
-        Run coding agents on infrastructure you control.
+        Give your app a computer it can talk to.
       </h1>
       <p class="mt-6 text-lg sm:text-xl leading-relaxed text-[var(--color-text-secondary)] max-w-[39rem]">
-        Connect your repo, tools, credentials, and model. Specify a runtime and give the agent a name. Then call it from your product, editor, chat app or CI job. Fountain handles the machine underneath.
+        Send a prompt. A sandbox wakes up with the repos, tools and credentials it needs, an agent gets to work, and the answer streams back. Build an engineering workbench around it, hide it behind your product, or make something we have not imagined yet.
+      </p>
+      <p class="mt-4 text-base leading-relaxed text-[var(--color-text-muted)] max-w-[39rem]">
+        Fountain is the open-source conversational API underneath. Run it on your infrastructure, keep the data in your database, hold the keys, and change anything.
       </p>
       <div class="mt-9 flex flex-col sm:flex-row gap-3 [&>a]:w-full sm:[&>a]:w-auto">
         <a
           href={~p"/docs/quickstart"}
           class="inline-flex items-center justify-center px-6 py-3 rounded-lg bg-[var(--color-brand)] text-[var(--color-brand-text)] font-medium hover:bg-[var(--color-brand-hover)] transition-colors text-sm shadow-sm"
         >
-          Run the quickstart
+          Build with Fountain
         </a>
         <a
           href={repo_url()}
           rel="noopener"
           class="inline-flex items-center justify-center px-6 py-3 rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-bg-1)] text-[var(--color-text-primary)] font-medium hover:bg-[var(--color-bg-2)] transition-colors text-sm"
         >
-          View on GitHub
+          Read the source
         </a>
       </div>
       <p class="mt-5 text-xs text-[var(--color-text-muted)]">
-        No license key · no seat count · no token markup · same release image as hosted
+        Your server · your database · your keys · your agents
       </p>
     </div>
 
@@ -45,32 +48,32 @@
       aria-labelledby="system-map-caption"
     >
       <figcaption id="system-map-caption" class="sr-only">
-        Your product, IDE or chat sends a request to Fountain. Fountain assembles the Agent, Environment and Vault, then provisions a sandbox containing the repository, tools, configuration, credentials and running agent.
+        A product, workbench or automation sends a prompt to Fountain. Fountain assembles the reusable configuration, then wakes a sandbox containing the repository, tools, credentials and running agent.
       </figcaption>
 
-      <div class="grid grid-cols-3 gap-2" aria-label="Ways to start an agent">
+      <div class="grid grid-cols-3 gap-2" aria-label="Things you can build">
         <div class="rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-0)] px-2 py-3 text-center">
           <span class="block font-mono text-[9px] uppercase tracking-[0.14em] text-[var(--color-text-muted)]">
-            API
+            Product
           </span>
           <span class="mt-1 block text-xs font-medium text-[var(--color-text-primary)]">
-            your product
+            agent hidden
           </span>
         </div>
         <div class="rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-0)] px-2 py-3 text-center">
           <span class="block font-mono text-[9px] uppercase tracking-[0.14em] text-[var(--color-text-muted)]">
-            ACP
+            Workbench
           </span>
           <span class="mt-1 block text-xs font-medium text-[var(--color-text-primary)]">
-            your IDE
+            agent visible
           </span>
         </div>
         <div class="rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-0)] px-2 py-3 text-center">
           <span class="block font-mono text-[9px] uppercase tracking-[0.14em] text-[var(--color-text-muted)]">
-            AG-UI
+            Automation
           </span>
           <span class="mt-1 block text-xs font-medium text-[var(--color-text-primary)]">
-            your chat
+            no screen
           </span>
         </div>
       </div>
@@ -100,7 +103,7 @@
           </strong>
         </div>
         <p class="mt-4 text-center font-mono text-[10px] sm:text-[11px] text-[var(--color-ink-secondary)]">
-          assembles Agent + Environment + Vault
+          one conversational API
         </p>
       </div>
 
@@ -148,19 +151,66 @@
   </div>
 </section>
 
-<%!-- The problem before the product. The reader meets Environment, Vault,
-      Agent and Conversation here, framed by what an agent needs beyond a
-      model, before any protocol or deployment name asks them to care. --%>
+<%!-- Show the range before explaining the machinery. The reader should see
+      their own product shape here, including products whose customers never
+      know an agent is underneath. --%>
 <section class="max-w-6xl mx-auto px-5 sm:px-6 py-14 sm:py-20" data-role="primitives">
   <h2 class="text-3xl sm:text-5xl font-bold tracking-tight text-[var(--color-text-primary)] max-w-3xl">
-    An agent should not need a laptop.
+    Put the agent wherever the idea needs it.
   </h2>
   <div class="mt-6 max-w-3xl space-y-4 text-lg text-[var(--color-text-secondary)] leading-relaxed">
     <p>
-      A coding agent needs more than a model. It needs a repository. Packages. Tools. Credentials. A machine to run on. Somewhere to keep its work between prompts. And an API that lets the rest of your software reach it.
+      Keep it on the screen while engineers steer every move. Put it behind a file upload, a button or an API and return only the result. Let a webhook wake it up when nobody is watching.
     </p>
     <p>
-      Without that layer, every new agent becomes another pile of shell scripts, environment variables and special cases. Fountain turns those pieces into infrastructure you define once and reuse.
+      These look like different products to the customer. Underneath, they all need the same thing: a machine that can pick up a conversation and keep working after you close your laptop.
+    </p>
+  </div>
+  <div class="mt-10 grid md:grid-cols-3 gap-px overflow-hidden rounded-xl border border-[var(--color-border)] bg-[var(--color-border)]">
+    <article class="bg-[var(--color-bg-1)] p-6">
+      <p class="font-mono text-[10px] uppercase tracking-[0.14em] text-[var(--color-accent-ink)]">
+        Agent on the glass
+      </p>
+      <h3 class="mt-3 text-lg font-semibold text-[var(--color-text-primary)]">
+        Build the engineering workbench.
+      </h3>
+      <p class="mt-2 text-sm leading-relaxed text-[var(--color-text-secondary)]">
+        Show the thread, shell, diff and event stream. Let people steer the work while it happens.
+      </p>
+    </article>
+    <article class="bg-[var(--color-bg-1)] p-6">
+      <p class="font-mono text-[10px] uppercase tracking-[0.14em] text-[var(--color-accent-ink)]">
+        Agent behind the interface
+      </p>
+      <h3 class="mt-3 text-lg font-semibold text-[var(--color-text-primary)]">
+        Ship the outcome, not the agent.
+      </h3>
+      <p class="mt-2 text-sm leading-relaxed text-[var(--color-text-secondary)]">
+        Your customer asks for a brief, a chart or a change. Your product returns it. The agent stays plumbing.
+      </p>
+    </article>
+    <article class="bg-[var(--color-bg-1)] p-6">
+      <p class="font-mono text-[10px] uppercase tracking-[0.14em] text-[var(--color-accent-ink)]">
+        Agent off on its own
+      </p>
+      <h3 class="mt-3 text-lg font-semibold text-[var(--color-text-primary)]">
+        Start work from anything.
+      </h3>
+      <p class="mt-2 text-sm leading-relaxed text-[var(--color-text-secondary)]">
+        A webhook, cron job, CI run or another agent can start a conversation and follow it to the result.
+      </p>
+    </article>
+  </div>
+
+  <div class="mt-14 max-w-3xl">
+    <p class="font-mono text-[10px] uppercase tracking-[0.16em] text-[var(--color-accent-ink)]">
+      The reusable pieces
+    </p>
+    <h3 class="mt-3 text-2xl sm:text-3xl font-bold tracking-tight text-[var(--color-text-primary)]">
+      Set up the machine once. Start it with a prompt.
+    </h3>
+    <p class="mt-4 text-[var(--color-text-secondary)] leading-relaxed">
+      Fountain keeps the machine, credentials, agent configuration and live work separate. Change one without rebuilding the rest, then reuse the same setup anywhere your product needs it.
     </p>
   </div>
   <div class="mt-10 grid sm:grid-cols-2 lg:grid-cols-4 gap-px overflow-hidden rounded-xl border border-[var(--color-border)] bg-[var(--color-border)]">
@@ -179,7 +229,7 @@
   <div class="max-w-5xl mx-auto px-5 sm:px-6 py-16 sm:py-20">
     <.eyebrow label="Your first agent" tone={:ink} />
     <h2 class="mt-4 text-3xl sm:text-4xl font-bold tracking-tight text-center">
-      You write this once. Everything after it is a prompt.
+      Define the setup once. Your product sends the prompts.
     </h2>
 
     <%!-- Keep the four beats in one sequence, but let each example be a card
@@ -230,10 +280,10 @@
 <section class="max-w-6xl mx-auto px-5 sm:px-6 py-16 sm:py-20" data-role="integrations">
   <.eyebrow label="Interfaces" align={:left} />
   <h2 class="mt-4 text-3xl sm:text-4xl font-bold tracking-tight text-[var(--color-text-primary)] max-w-3xl">
-    Use the same agents from your product, editor or chat app.
+    Talk to it from whatever you are building.
   </h2>
   <p class="mt-4 max-w-2xl text-[var(--color-text-secondary)] leading-relaxed">
-    Connect through Fountain’s own API, an OpenAI-compatible endpoint, ACP or AG-UI. Different doors, same agents: every interface reaches the same roster and the same conversation and event APIs.
+    Use Fountain’s API and SDK in your product. Speak OpenAI-compatible chat from existing tools. Plug into editors over ACP or build a live interface over AG-UI. Every door reaches the same agents, conversations and event stream.
   </p>
 
   <div class="mt-10 grid sm:grid-cols-2 lg:grid-cols-4 gap-px overflow-hidden rounded-xl border border-[var(--color-border)] bg-[var(--color-border)]">
@@ -307,7 +357,7 @@
 </section>
 
 <%!-- The operator's pair, side by side: what leaves the instance and where it
-      runs. Both come after the reader knows what the product is — deployment
+      runs. Both come after the reader knows what the product is. Deployment
       is proof, not pitch. Folding the two bands into one keeps the page's
       back half from sprawling; the audit-trail and SSE facts from the old
       activity strip live in the telemetry card's intro line. --%>
@@ -318,13 +368,13 @@
   <div class="max-w-6xl mx-auto px-5 sm:px-6 py-16 sm:py-20 grid lg:grid-cols-2 gap-6 items-start">
     <article class="rounded-2xl border border-[var(--color-border)] bg-[var(--color-bg-1)] p-6 sm:p-8">
       <p class="font-mono text-[10px] uppercase tracking-[0.16em] text-[var(--color-accent-ink)]">
-        Telemetry
+        Own the data
       </p>
       <h2 class="mt-3 text-2xl sm:text-3xl font-bold tracking-tight text-[var(--color-text-primary)]">
-        Nothing phones home unless you tell it to.
+        The conversation stays on your server.
       </h2>
       <p class="mt-3 text-sm leading-relaxed text-[var(--color-text-secondary)]">
-        Logs stay on stdout. Metrics stay on a private listener. Trace and error export only turn on when you configure a destination. Conversation events and the audit trail land in your Postgres, not anyone else's.
+        Prompts, events, configuration and the audit trail land in your Postgres. Logs stay on stdout. Metrics stay on a private listener. Trace and error export turn on only when you configure a destination.
       </p>
       <div class="mt-7 space-y-5">
         <div
@@ -374,7 +424,7 @@
       data-role="deployments"
     >
       <p class="font-mono text-[10px] uppercase tracking-[0.16em] text-[var(--color-accent-ink)]">
-        Deploy anywhere
+        Own the stack
       </p>
       <h2 class="mt-3 text-2xl sm:text-3xl font-bold tracking-tight text-[var(--color-text-primary)]">
         Start with one machine. Grow when you need to.
@@ -417,13 +467,13 @@
   <div class="rounded-2xl border border-[var(--color-accent-line)] bg-[var(--color-accent-soft)] p-8 sm:p-12 grid lg:grid-cols-[1fr_auto] gap-8 lg:items-center">
     <div>
       <p class="font-mono text-[10px] uppercase tracking-[0.16em] text-[var(--color-accent-ink)]">
-        Run it yourself
+        Make it yours
       </p>
       <h2 class="mt-4 text-3xl sm:text-4xl font-bold tracking-tight text-[var(--color-text-primary)]">
-        Your database. Your keys. Your agents.
+        Fork it. Extend it. Build the thing only you would build.
       </h2>
       <p class="mt-4 max-w-2xl text-[var(--color-text-secondary)] leading-relaxed">
-        Fountain stores conversations and configuration in your Postgres, encrypts tenant secrets with the master key you hold, and runs sandboxes through Sprites, E2B, Daytona or machines on your own network.
+        Host the apps and API yourself. Keep conversations and configuration in your Postgres. Hold the encryption keys. Run sandboxes through Sprites, E2B, Daytona or machines on your own network. The engine and apps are open for you to take apart and reshape.
       </p>
     </div>
     <div class="flex flex-col sm:flex-row lg:flex-col gap-3 lg:min-w-52">
@@ -431,7 +481,7 @@
         href={~p"/docs/guides/operate/deploy"}
         class="inline-flex items-center justify-center rounded-lg bg-[var(--color-brand)] px-6 py-3 text-sm font-medium text-[var(--color-brand-text)] hover:bg-[var(--color-brand-hover)] transition-colors"
       >
-        Deploy Fountain
+        Start building
       </a>
       <a
         href={repo_url()}

--- a/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
@@ -118,27 +118,31 @@ defmodule FountainWeb.MarketingControllerTest do
     test "launches the Fountain project from definition through deploy", %{conn: conn} do
       body = conn |> get(~p"/oss-launch") |> html_response(200)
 
-      assert body =~ "Fountain · AGPL-3.0-or-later"
-      assert body =~ "Run coding agents on infrastructure you control."
-      assert body =~ "Connect your repo, tools, credentials, and model."
-      assert body =~ "Specify a runtime and give the agent a name."
+      assert body =~ "Open source · self-hosted · AGPL-3.0-or-later"
+      assert body =~ "Give your app a computer it can talk to."
+      assert body =~ "Build an engineering workbench around it"
+      assert body =~ "hide it behind your product"
+      assert body =~ "Your server · your database · your keys · your agents"
 
-      assert body =~ "An agent should not need a laptop."
+      assert body =~ "Put the agent wherever the idea needs it."
+      assert body =~ "Build the engineering workbench."
+      assert body =~ "Ship the outcome, not the agent."
+      assert body =~ "Start work from anything."
 
       for primitive <- FountainWeb.MarketingHTML.oss_primitives() do
         assert body =~ primitive.name, "missing primitive #{primitive.name}"
       end
 
       assert body =~ ~s(href="/docs/quickstart")
-      assert body =~ "Run the quickstart"
+      assert body =~ "Build with Fountain"
       assert body =~ ~s(href="/docs/tour")
       assert body =~ "Run the complete tour"
-      assert body =~ "Deploy Fountain"
+      assert body =~ "Start building"
       assert body =~ FountainWeb.MarketingHTML.repo_url()
 
       assert body =~ ~s(data-role="system-map")
 
-      assert body =~ "assembles Agent + Environment + Vault"
+      assert body =~ "one conversational API"
       assert body =~ "repo · tools · config · credentials"
       assert body =~ "Sandbox"
 
@@ -154,7 +158,7 @@ defmodule FountainWeb.MarketingControllerTest do
         assert FountainWeb.MarketingIcons.has?(target.slug), "no mark for #{target.name}"
       end
 
-      assert body =~ "You write this once. Everything after it is a prompt."
+      assert body =~ "Define the setup once. Your product sends the prompts."
       assert body =~ "fountain.environments.create"
       assert body =~ "fountain.vaults.create"
       assert body =~ "fountain.vaults.secrets.set"
@@ -169,7 +173,7 @@ defmodule FountainWeb.MarketingControllerTest do
       refute body =~ "kind: Environment"
       refute body =~ "fountain apply -f fountain.yml"
 
-      assert body =~ "Use the same agents from your product, editor or chat app."
+      assert body =~ "Talk to it from whatever you are building."
 
       for name <- ~w(AG-UI ACP OpenAI-compatible) do
         assert body =~ name, "missing client protocol #{name}"
@@ -183,7 +187,7 @@ defmodule FountainWeb.MarketingControllerTest do
         assert body =~ group.pitch, "missing group pitch #{group.pitch}"
       end
 
-      assert body =~ "Nothing phones home unless you tell it to."
+      assert body =~ "The conversation stays on your server."
       assert body =~ "Prometheus → Grafana"
       assert body =~ "OpenTelemetry → your OTLP backend"
       assert body =~ "Sentry API → Sentry or GlitchTip"
@@ -195,10 +199,12 @@ defmodule FountainWeb.MarketingControllerTest do
       body = conn |> get(~p"/oss-launch") |> html_response(200)
 
       assert body =~
-               ~s(<meta property="og:title" content="Open-source infrastructure for coding agents · Fountain")
+               ~s(<meta property="og:title" content="A conversational API to a computer · Fountain")
 
       assert body =~ ~s(<meta property="og:url" content="http://localhost:4000/oss-launch")
-      assert body =~ ~s(<meta name="description" content="Deploy Fountain with Docker)
+
+      assert body =~
+               ~s(<meta name="description" content="Give your app a computer it can talk to.)
 
       refute conn |> get(~p"/") |> html_response(200) =~ ~s(href="/oss-launch")
     end


### PR DESCRIPTION
## What changed

- replace the infrastructure-first headline with a builder-facing promise
- show three product shapes: visible workbenches, hidden agents, and unattended automation
- frame Fountain as an open-source conversational API before introducing its primitives
- recast self-hosting around ownership, extension, and control of data and keys
- update page metadata and coverage for the new argument

## Verification

- `mix test apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs` (78 tests)
- `mix test apps/fountain/test/fountain_web/paper_skin_test.exs` (12 tests)