### PR TITLE
ci(release): open the bump as a PR and tag on merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -909,48 +909,42 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
 
-      # The exact commands the quick start documents (cp, the two openssl
-      # lines, up) rather than a synthetic env — the job exists to run what
-      # a fresh user runs, so any divergence here would defeat it. The two
-      # appended keys are now the only definition of each: the example file
-      # ships them commented out, so a followed quick start no longer leaves
-      # two copies of every secret in .env, shadowing each other and relying
-      # on last-value-wins to pick the real one (#1215).
-      - name: Run the documented quick start
+      # A release bump pins the tag it is about to create, so on the bump PR
+      # (and on main until release.yml has published the image) the pin
+      # names an image that does not exist yet. That is the one legitimate
+      # reason for the pull to fail, and it failed twice at v0.15.0: once on
+      # the PR by construction, and once on main, where the red CI run kept
+      # build.yml from building the bump commit and prod's footer stayed on
+      # the previous version (#1329). When the pin matches the version in
+      # mix.exs and the registry has no image for it, this tree is that
+      # bump: skip here, and release.yml runs the same script on the tag once
+      # the image is up. Any other missing image is a broken quick start.
+      - name: Resolve the pinned image
+        id: pin
         run: |
           set -euo pipefail
-          cp .env.compose.example .env
-          echo "SECRET_KEY_BASE=$(openssl rand -base64 48 | tr -d '\n')" >> .env
-          echo "MASTER_SECRETS_KEY=$(openssl rand 32 | base64 | tr '+/' '-_' | tr -d '=\n')" >> .env
-          docker compose up -d
+          pin="$(sed -nE 's/^FOUNTAIN_IMAGE_TAG=(v[0-9]+\.[0-9]+\.[0-9]+)$/\1/p' .env.compose.example)"
+          version="$(grep -oE 'version: "[0-9]+\.[0-9]+\.[0-9]+"' mix.exs | head -1 \
+            | sed -E 's/version: "([0-9.]+)"/\1/')"
+          echo "pinned ${pin}; mix.exs is ${version}"
+          if docker manifest inspect "ghcr.io/binarybourbon/fountain:${pin}" > /dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "${pin}" = "v${version}" ]; then
+            echo "::notice::${pin} has no image yet (release bump); release.yml boots it on the tag"
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "the quick start pins ${pin}, which has no image in the registry" >&2
+          exit 1
 
-      - name: Probe /health and /health/ready
-        run: |
-          set -euo pipefail
-          probe() {
-            # Boot runs migrations before the endpoint listens, so tolerate
-            # refused connections while waiting — but a non-200 answer is a
-            # verdict, not a retry.
-            for _ in $(seq 1 60); do
-              code=$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:4000$1") || code=000
-              if [ "$code" = "200" ]; then
-                echo "  $1 -> 200"
-                return 0
-              fi
-              if [ "$code" != "000" ]; then
-                echo "  $1 -> $code (expected 200)" >&2
-                return 1
-              fi
-              sleep 2
-            done
-            echo "  $1 never answered" >&2
-            return 1
-          }
-          probe /health
-          probe /health/ready
+      - name: Run the documented quick start and probe the app
+        if: ${{ steps.pin.outputs.exists == 'true' }}
+        run: scripts/compose-boot-check.sh
 
       - name: Dump container logs
-        if: failure()
+        if: ${{ failure() && steps.pin.outputs.exists == 'true' }}
         run: docker compose logs --timestamps
 
   # What a docs-only PR runs instead of the three test partitions, the

--- a/.github/workflows/release-bump.yml
+++ b/.github/workflows/release-bump.yml
@@ -1,11 +1,29 @@
 name: Release bump
 
-# Manually-triggered workflow that bumps the version in both mix.exs
-# files (umbrella + fountain app), commits, tags, and pushes.
-# The tag push then dispatches release.yml which builds Go CLI binaries.
+# Cuts a release in two halves, because main only takes pull requests.
 #
-# Run from Actions tab → "Release bump" → "Run workflow".
-# Defaults to `patch`; minor / major are also available.
+# 1. "Run workflow" (Actions tab → "Release bump"; defaults to `patch`)
+#    bumps the version in both mix.exs files and the six self-host image
+#    pins on a `release/vX.Y.Z` branch and opens the PR. CI runs on it like
+#    any other PR; the compose boot check knows the pinned image does not
+#    exist yet and skips.
+# 2. Merging that PR (`gh pr merge --squash --admin`, like every PR here)
+#    triggers the `tag` job below, which tags the squash commit and
+#    dispatches release.yml to build the CLI binaries, publish the
+#    versioned image, boot it, and create the GitHub Release.
+#
+# This used to be one job that committed straight to main, tagged and
+# pushed. The Main Protection ruleset (pull requests only, no bypass actors,
+# and a user account cannot grant the Actions app one) rejects that push,
+# which is how two dispatches at v0.15.0 failed before the tag step (#1329).
+#
+# The PR is opened with RELEASE_BUMP_TOKEN, a fine-grained personal access
+# token for this repository with Contents and Pull requests set to
+# read/write, and not with GITHUB_TOKEN: a branch pushed and a PR opened by
+# GITHUB_TOKEN trigger no workflows, so the bump PR would arrive with no
+# checks at all. The tag half needs no such token; a tag pushed by
+# GITHUB_TOKEN is fine, and release.yml is dispatched explicitly because the
+# same rule suppresses its `push: tags:` trigger.
 
 on:
   workflow_dispatch:
@@ -19,31 +37,41 @@ on:
           - patch
           - minor
           - major
+  pull_request:
+    types: [closed]
+    branches: [main]
 
 permissions:
   contents: read
 
 jobs:
-  bump:
-    name: Bump version, commit, tag, push
+  open-pr:
+    name: Bump version and open the release PR
+    if: ${{ github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
     permissions:
-      # Push commit + tag back to main.
-      contents: write
-      # Dispatch release.yml after the tag push (the tag push itself
-      # doesn't trigger release.yml because tags pushed by GITHUB_TOKEN
-      # don't fire downstream workflows — GitHub anti-recursion safeguard).
-      actions: write
+      contents: read
 
     steps:
+      - name: Require RELEASE_BUMP_TOKEN
+        env:
+          TOKEN: ${{ secrets.RELEASE_BUMP_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${TOKEN}" ]; then
+            echo "RELEASE_BUMP_TOKEN is not set." >&2
+            echo "Add a fine-grained PAT scoped to this repository with Contents: read/write and Pull requests: read/write as that secret." >&2
+            echo "GITHUB_TOKEN cannot open this PR: a PR it opens gets no CI run." >&2
+            exit 1
+          fi
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
         with:
-          # Full history so git tag sees existing tags and push back
-          # to main isn't rejected as a shallow-clone.
+          # Full history so the tag and branch checks below see what exists.
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_BUMP_TOKEN }}
 
       - name: Compute next version
         id: ver
@@ -62,11 +90,20 @@ jobs:
           esac
           next="${major}.${minor}.${patch}"
           tag="v${next}"
-          echo "next=$next"    >> "$GITHUB_OUTPUT"
-          echo "tag=$tag"      >> "$GITHUB_OUTPUT"
-          echo "current=$current" >> "$GITHUB_OUTPUT"
+          branch="release/${tag}"
+          echo "next=$next"
+          {
+            echo "next=$next"
+            echo "tag=$tag"
+            echo "branch=$branch"
+            echo "current=$current"
+          } >> "$GITHUB_OUTPUT"
           if git rev-parse "refs/tags/${tag}" >/dev/null 2>&1; then
             echo "tag ${tag} already exists" >&2
+            exit 1
+          fi
+          if git rev-parse "refs/remotes/origin/${branch}" >/dev/null 2>&1; then
+            echo "branch ${branch} already exists; merge or delete the open release PR first" >&2
             exit 1
           fi
 
@@ -76,8 +113,8 @@ jobs:
         run: |
           set -euo pipefail
           # v0.3.0 shipped with its upgrade notes stranded under
-          # [Unreleased] (#318). Refuse to tag until CHANGELOG.md has a
-          # heading for the version being released.
+          # [Unreleased] (#318). Refuse to open the PR until CHANGELOG.md
+          # has a heading for the version being released.
           if ! grep -qF "## [${NEXT}]" CHANGELOG.md; then
             echo "CHANGELOG.md has no \"## [${NEXT}]\" section." >&2
             echo "Roll the [Unreleased] entries into a dated [${NEXT}] section before running the release bump." >&2
@@ -140,23 +177,109 @@ jobs:
           done
           git diff --stat
 
-      - name: Commit, tag, push
+      - name: Commit, push the branch, open the PR
         env:
+          GH_TOKEN: ${{ secrets.RELEASE_BUMP_TOKEN }}
           TAG: ${{ steps.ver.outputs.tag }}
-          NEXT: ${{ steps.ver.outputs.next }}
+          BRANCH: ${{ steps.ver.outputs.branch }}
         run: |
           set -euo pipefail
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "${BRANCH}"
           git add mix.exs apps/fountain/mix.exs \
             docker-compose.yml .env.compose.example render.yaml fly.toml \
             deploy/k8s/kustomization.yaml deploy/k8s/deployment.yaml
-          # [skip ci] keeps this commit from re-triggering CI on main.
-          # release.yml is dispatched explicitly in the next step.
-          git commit -m "chore(release): ${TAG} [skip ci]"
-          git tag -a "${TAG}" -m "Release ${TAG}"
-          git push origin HEAD:main
-          git push origin "${TAG}"
+          # No [skip ci]: the PR is meant to run CI, and a main push whose
+          # tree a PR run already tested is skipped by ci.yml on its own.
+          git commit -m "chore(release): ${TAG}"
+          git push origin "${BRANCH}"
+          cat > "${RUNNER_TEMP}/body.md" <<EOF
+          Version bump for ${TAG}: both \`mix.exs\` files and the six self-host image pins.
+
+          Merging this PR tags the squash commit \`${TAG}\` and dispatches \`release.yml\`, which builds the CLI binaries, publishes \`ghcr.io/binarybourbon/fountain:${TAG}\`, boots it through the documented quick start and creates the GitHub Release.
+
+          "Compose boots the pinned image" skips on this PR because the pinned image does not exist until the release runs; the same check runs on the tag instead.
+          EOF
+          gh pr create \
+            --base main \
+            --head "${BRANCH}" \
+            --title "chore(release): ${TAG}" \
+            --body-file "${RUNNER_TEMP}/body.md"
+
+  tag:
+    name: Tag the merged release PR and dispatch release.yml
+    if: >-
+      ${{ github.event_name == 'pull_request'
+          && github.event.pull_request.merged == true
+          && github.event.pull_request.head.repo.full_name == github.repository
+          && startsWith(github.event.pull_request.head.ref, 'release/v') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    permissions:
+      # Push the tag.
+      contents: write
+      # Dispatch release.yml: a tag pushed by GITHUB_TOKEN does not fire its
+      # `push: tags:` trigger (GitHub's anti-recursion rule).
+      actions: write
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+        with:
+          # The squash commit on main, not the PR's merge ref (which is gone
+          # once the PR closes). Full history so existing tags are visible.
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve the tag from the merged tree
+        id: ver
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          set -euo pipefail
+          # The version the merged tree carries is the truth; the branch name
+          # is a cross-check. A hand-opened bump PR (v0.15.0 was one) takes
+          # this path too, as long as its branch is release/vX.Y.Z.
+          version=$(grep -oE 'version: "[0-9]+\.[0-9]+\.[0-9]+"' mix.exs \
+            | head -1 \
+            | sed -E 's/version: "([0-9]+\.[0-9]+\.[0-9]+)"/\1/')
+          tag="v${version}"
+          git fetch --quiet origin main
+          if [ "${HEAD_REF}" != "release/${tag}" ]; then
+            echo "merged tree is at ${tag} but the PR branch is ${HEAD_REF}; not tagging" >&2
+            exit 1
+          fi
+          if ! git merge-base --is-ancestor "${MERGE_SHA}" origin/main; then
+            echo "${MERGE_SHA} is not on main; not tagging" >&2
+            exit 1
+          fi
+          if existing="$(git rev-parse -q --verify "refs/tags/${tag}^{commit}")"; then
+            if [ "${existing}" = "${MERGE_SHA}" ]; then
+              echo "${tag} already points at ${MERGE_SHA}; nothing to push"
+              echo "push=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "${tag} already exists at ${existing}, not at the merge commit ${MERGE_SHA}" >&2
+              exit 1
+            fi
+          else
+            echo "push=true" >> "$GITHUB_OUTPUT"
+          fi
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Tag and push
+        if: ${{ steps.ver.outputs.push == 'true' }}
+        env:
+          TAG: ${{ steps.ver.outputs.tag }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          set -euo pipefail
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "${TAG}" -m "Release ${TAG}" "${MERGE_SHA}"
+          git push origin "refs/tags/${TAG}"
 
       - name: Dispatch release.yml
         env:
@@ -164,7 +287,14 @@ jobs:
           TAG: ${{ steps.ver.outputs.tag }}
         run: |
           set -euo pipefail
-          # Tag push above ran under GITHUB_TOKEN, so release.yml's
-          # `on: push: tags:` trigger is suppressed. Dispatch explicitly.
+          # If the tag was pushed by hand with a personal token, release.yml
+          # already fired on the push; a second run for the same tag would
+          # publish the same image and fail at the release page. Only
+          # dispatch when nothing is running or done for it.
+          runs="$(gh run list --workflow release.yml --branch "${TAG}" --json databaseId --jq 'length')"
+          if [ "${runs}" != "0" ]; then
+            echo "release.yml already has ${runs} run(s) for ${TAG}; not dispatching again"
+            exit 0
+          fi
           gh workflow run release.yml --ref "${TAG}" -f tag="${TAG}"
           echo "Dispatched release.yml for ${TAG}"

--- a/.github/workflows/release-bump.yml
+++ b/.github/workflows/release-bump.yml
@@ -17,9 +17,10 @@ name: Release bump
 # and a user account cannot grant the Actions app one) rejects that push,
 # which is how two dispatches at v0.15.0 failed before the tag step (#1329).
 #
-# The PR is opened with RELEASE_BUMP_TOKEN, a fine-grained personal access
-# token for this repository with Contents and Pull requests set to
-# read/write, and not with GITHUB_TOKEN: a branch pushed and a PR opened by
+# The PR is opened with RELEASE_BUMP_TOKEN, a personal access token with
+# write access to this repository's contents and pull requests (a classic
+# PAT with `repo`, or a fine-grained one with Contents and Pull requests
+# read/write), and not with GITHUB_TOKEN: a branch pushed and a PR opened by
 # GITHUB_TOKEN trigger no workflows, so the bump PR would arrive with no
 # checks at all. The tag half needs no such token; a tag pushed by
 # GITHUB_TOKEN is fine, and release.yml is dispatched explicitly because the
@@ -62,7 +63,7 @@ jobs:
           set -euo pipefail
           if [ -z "${TOKEN}" ]; then
             echo "RELEASE_BUMP_TOKEN is not set." >&2
-            echo "Add a fine-grained PAT scoped to this repository with Contents: read/write and Pull requests: read/write as that secret." >&2
+            echo "Add a PAT with write access to this repository's contents and pull requests as that secret." >&2
             echo "GITHUB_TOKEN cannot open this PR: a PR it opens gets no CI run." >&2
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,10 +162,10 @@ jobs:
 
   image:
     # The server image is built fresh from the tag's tree rather than
-    # re-tagging the sha- image build.yml already pushed, for two reasons:
-    # the tag points at release-bump's version commit, which build.yml never
-    # built ([skip ci] + GITHUB_TOKEN suppression), and the mix.exs version
-    # baked into the image is surfaced in-app — it must match the tag.
+    # re-tagging the sha- image build.yml pushes for the same commit. The
+    # bump lands on main through a PR (#1329), so build.yml does build it,
+    # but that build runs concurrently with this one and this workflow must
+    # not wait on it or race it: the tag's tree, built here, is the release.
     #
     # Each architecture builds NATIVELY and pushes by digest; image-manifest
     # below stitches the digests into one multi-arch manifest and owns the
@@ -262,11 +262,10 @@ jobs:
           outputs: type=image,name=ghcr.io/binarybourbon/fountain,push-by-digest=true,name-canonical=true,push=true
           provenance: false
           # Read build.yml's cache, write nothing back. The layers above
-          # `COPY mix.exs` hit; the deps.compile layer below it cannot,
-          # because release-bump's commit exists precisely to change the
-          # version in mix.exs. Writing mode=max back would replace main's
-          # cache with the version-bump variant, so the next build.yml run
-          # would miss the same layer — a release must not degrade the cache
+          # `COPY mix.exs` hit; the deps.compile layer below it may not,
+          # because the bump commit exists precisely to change the version
+          # in mix.exs. build.yml owns that cache and is building the same
+          # commit beside this run; a release must not overwrite the cache
           # every subsequent main build depends on.
           cache-from: type=registry,ref=ghcr.io/binarybourbon/fountain:buildcache-${{ matrix.arch }}
 
@@ -353,6 +352,54 @@ jobs:
             $(printf "${IMAGE}@sha256:%s " *)
           docker buildx imagetools inspect "${IMAGE}:${TAG}"
 
+  compose-boot:
+    # ci.yml's "Compose boots the pinned image" skips on the bump PR and on
+    # the merged bump commit, because the pin names this image before it
+    # exists (#1329). This is where that check runs instead: the tag's tree
+    # pins the tag, the manifest job just published it, and the release
+    # below waits for the answer. A tag whose image will not boot through
+    # the documented quick start gets no release page telling self-hosters
+    # to pin it.
+    name: Compose boots the released image
+    needs: image-manifest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    steps:
+      - name: Resolve tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "tag=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+        with:
+          ref: refs/tags/${{ steps.tag.outputs.tag }}
+          persist-credentials: false
+
+      - name: The tree pins the tag
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          pin="$(sed -nE 's/^FOUNTAIN_IMAGE_TAG=(v[0-9]+\.[0-9]+\.[0-9]+)$/\1/p' .env.compose.example)"
+          if [ "${pin}" != "${TAG}" ]; then
+            echo ".env.compose.example pins ${pin}, but this is ${TAG}; the bump did not reach this tree" >&2
+            exit 1
+          fi
+
+      - name: Run the documented quick start and probe the app
+        run: scripts/compose-boot-check.sh
+
+      - name: Dump container logs
+        if: failure()
+        run: docker compose logs --timestamps
+
   release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
@@ -361,7 +408,9 @@ jobs:
     # image — the release page is what tells a self-hoster the tag exists to
     # pin. Depending on the manifest job rather than the per-arch builds: two
     # pushed digests with no manifest list on the tag is not a published image.
-    needs: [build, openapi, image-manifest]
+    # compose-boot goes one further: the image also has to boot through the
+    # quick start the release page points at.
+    needs: [build, openapi, image-manifest, compose-boot]
     permissions:
       contents: write
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ upgrade, is in
 
 ### Fixed
 
+- **Releases are cut through a pull request.** The release bump used to
+  commit straight to `main`, which the branch ruleset rejects, so the two
+  v0.15.0 attempts failed before the tag step (#1329). "Release bump" now
+  opens a `release/vX.Y.Z` PR; merging it tags the squash commit and starts
+  the release. The "Compose boots the pinned image" check skips on that PR
+  and on the merged commit, where the pinned image cannot exist yet, and
+  runs on the tag after the image is published instead. That red check on
+  `main` is also why the deployed footer stayed on v0.14.0 after 0.15.0
+  merged: the failed CI run kept the image from being built.
 - **The quickstart installs on Linux.** The page offered only `brew install`,
   and Homebrew on Linux refuses to install any formula, even one that only
   downloads a prebuilt binary, until a C compiler is present. Walked on a

--- a/apps/fountain/test/fountain/release_pin_test.exs
+++ b/apps/fountain/test/fountain/release_pin_test.exs
@@ -2,9 +2,10 @@ defmodule Fountain.ReleasePinTest do
   # The self-host quick start pins a release image in six places. Those pins
   # sat at v0.3.0 through two releases, handing newcomers an image from before
   # the in-app first-login flow (#478), where EMAIL_DELIVERY=none dead-ends
-  # signup. release-bump.yml now bumps the pins inside the release commit;
-  # since that commit is [skip ci], this test is the net that catches a pin
-  # the workflow missed — on the next PR, not two releases later.
+  # signup. release-bump.yml bumps the pins in the release PR, and this test
+  # runs on that PR, so a pin the workflow missed fails the bump itself
+  # rather than surfacing two releases later. ci.yml's compose boot check
+  # also reads the pin against mix.exs to know a bump tree from a broken one.
   use ExUnit.Case, async: true
 
   @root Path.expand("../../../..", __DIR__)

--- a/scripts/compose-boot-check.sh
+++ b/scripts/compose-boot-check.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Runs the documented self-host quick start verbatim against the image the
+# tree pins, then asks the app what the walkthrough asks. Two workflows run
+# it, and it is one script so they cannot drift:
+#
+#   ci.yml       "Compose boots the pinned image" on every PR and main push,
+#                skipped when the pinned tag has no image yet (a release
+#                bump PR, and main right after it merges).
+#   release.yml  the same check on the tag, after image-manifest has
+#                published the image the bump pins, before the GitHub
+#                Release is created.
+#
+# The exact commands the quick start documents (cp, the two openssl lines,
+# up) rather than a synthetic env: the check exists to run what a fresh user
+# runs, so any divergence here would defeat it. The two appended keys are
+# the only definition of each: the example file ships them commented out, so
+# a followed quick start no longer leaves two copies of every secret in .env,
+# shadowing each other and relying on last-value-wins (#1215).
+set -euo pipefail
+
+cp .env.compose.example .env
+echo "SECRET_KEY_BASE=$(openssl rand -base64 48 | tr -d '\n')" >> .env
+echo "MASTER_SECRETS_KEY=$(openssl rand 32 | base64 | tr '+/' '-_' | tr -d '=\n')" >> .env
+docker compose up -d
+
+probe() {
+  # Boot runs migrations before the endpoint listens, so tolerate refused
+  # connections while waiting. A non-200 answer is a verdict, not a retry.
+  for _ in $(seq 1 60); do
+    code=$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:4000$1") || code=000
+    if [ "$code" = "200" ]; then
+      echo "  $1 -> 200"
+      return 0
+    fi
+    if [ "$code" != "000" ]; then
+      echo "  $1 -> $code (expected 200)" >&2
+      return 1
+    fi
+    sleep 2
+  done
+  echo "  $1 never answered" >&2
+  return 1
+}
+
+probe /health
+probe /health/ready


### PR DESCRIPTION
Closes #1329.

## What broke

`release-bump.yml` committed the bump straight to `main`, which the **Main Protection** ruleset rejects. Two dispatches at v0.15.0 failed before the tag step, so v0.15.0 was cut by hand (PR #1326 + a hand-pushed tag).

While chasing the two side effects the issue lists, the second one turned out to have a different cause than stated: build.yml did not skip the bump commit because of its ignore list (`mix.exs` is not on it). CI on `main` for a9c27c52 **failed** at "Compose boots the pinned image" (`manifest unknown`, because `v0.15.0` had no image yet), and build.yml only builds commits whose CI succeeded. Same check, same reason, two places.

## What changes

- **`release-bump.yml`** is two jobs. `open-pr` (workflow_dispatch) keeps every pre-flight, bumps on `release/vX.Y.Z` and opens the PR with `RELEASE_BUMP_TOKEN`. `tag` runs on the merged PR (`pull_request: closed`, head branch `release/v*`), reads the version from the merged tree, cross-checks the branch name, tags `merge_commit_sha`, and dispatches `release.yml` unless a run for that tag already exists (the hand-pushed-tag path). A hand-opened bump PR like #1326 takes the tag path too.
- **`ci.yml`** "Compose boots the pinned image" resolves the pin first. Image exists: boot it. Image missing and pin == mix.exs version: notice + skip (this is a bump tree). Image missing otherwise: fail, the quick start is broken.
- **`release.yml`** gains `compose-boot` after `image-manifest`: checks the tag's tree pins the tag, runs the same script, and `release` now needs it. A tag whose image will not boot through the quick start gets no release page.
- **`scripts/compose-boot-check.sh`** holds the quick start + probe both workflows run.
- Comments in `release.yml` and `ReleasePinTest` no longer describe the `[skip ci]` commit.

## The one secret it needs is set

`RELEASE_BUMP_TOKEN` is populated (2026-09-01) with a classic PAT that has `repo` + `workflow` scope and push access here. A branch and PR created by `GITHUB_TOKEN` trigger no workflows, so the bump PR would arrive with no checks. The workflow fails on its first step with that instruction if the secret is ever absent. The tag job needs nothing extra.

## Verified locally

- `actionlint` on `release-bump.yml` (clean; the two shellcheck notes it raises on `ci.yml`/`release.yml` are pre-existing and unchanged).
- `shellcheck scripts/compose-boot-check.sh`, `python3 scripts/docs-style.py`.
- `mix test` on `release_pin_test.exs` + `docs_test.exs`: 44 tests, 0 failures. `mix format --check-formatted` clean.

Not exercised end to end: the workflow itself. The first real run is the next release bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017cvrzdzX6ni4BsbUjMPVXn

