### PR TITLE
docs(contributing): the one-VM trap for library test helpers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,6 +117,13 @@ to a `managoat/<name>` repository once its surface stops moving.
   `Application.get_env(:fountain, …)`, and no `[:fountain, …]` telemetry
   anywhere under its `lib/` or `test/`. The library takes what it needs as
   arguments or reads its own otp_app.
+- If the library's `test/test_helper.exs` writes its own config (a test
+  host, a stub name), Fountain's `apps/fountain/test/test_helper.exs` must
+  set the value Fountain needs for that same key, with a comment. `mix test`
+  at the umbrella root runs every app in one VM, so a library helper's
+  `put_env` is still in effect when Fountain's suite starts (#1352 lost ten
+  runner tests to this). CI never sees it, since the partitions and
+  `scripts/test-libraries.sh` are separate VMs; `mix precommit` does.
 
 `apps/fountain/test/fountain/umbrella_layout_test.exs` checks every one of
 those and fails the suite on a miss. The root gates already reach the new


### PR DESCRIPTION
One bullet in "Adding an umbrella library app". #1352 found that a root `mix test` runs every umbrella app in one VM, so a library test helper that writes its own config (`host: Host.Local`) is still in effect when Fountain's suite starts; ten runner-presence tests failed until Fountain's helper re-set the host. The fix and its comment are in `apps/fountain/test/test_helper.exs`; the rule was not yet in the checklist later libraries copy. Docs and OAuth (#1342, #1343) are next and both will have test-helper config.

CI never sees the trap (partitions and `scripts/test-libraries.sh` are separate VMs); `mix precommit` does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rKjC1mfpREc5pKrNbqu8G
