### PR TITLE
feat(libraries): managoat_broker, the egress credential proxy from #1148 as a library

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -22,4 +22,11 @@
 # location term exactly as dialyzer reports it: a bare line number when there
 # is no column, a {line, column} tuple when there is. A stale entry shows up as
 # an "unnecessary skip" in `mix dialyzer --list-unused-filters`.
-[]
+[
+  # x509 0.9.2 (the broker CA, apps/managoat_broker, ADR 0019) references two
+  # types dialyzer does not know: its own X509.ASN1.record/1 macro-type and
+  # :public_key's unexported ec_private_key/0. Both are inside the dependency,
+  # not ours.
+  {"lib/x509/certificate.ex", :unknown_type, {20, 23}},
+  {"lib/x509/private_key.ex", :unknown_type, {33, 57}}
+]

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,7 @@ COPY apps/fountain/mix.exs ./apps/fountain/mix.exs
 # One line per umbrella library app (decisions/0037): the umbrella loads every
 # child's mix.exs to resolve deps, so a missing one fails `mix deps.get` here.
 # umbrella_layout_test.exs checks that every apps/managoat_* has its line.
+COPY apps/managoat_broker/mix.exs ./apps/managoat_broker/mix.exs
 COPY apps/managoat_docs/mix.exs ./apps/managoat_docs/mix.exs
 COPY apps/managoat_mcp_auth/mix.exs ./apps/managoat_mcp_auth/mix.exs
 COPY apps/managoat_oauth/mix.exs ./apps/managoat_oauth/mix.exs

--- a/apps/fountain/mix.exs
+++ b/apps/fountain/mix.exs
@@ -51,6 +51,7 @@ defmodule Fountain.MixProject do
       # repository once its surface stops moving; the line then becomes a hex
       # requirement. umbrella_layout_test.exs checks every apps/managoat_*
       # directory is listed here.
+      {:managoat_broker, in_umbrella: true},
       {:managoat_docs, in_umbrella: true},
       {:managoat_mcp_auth, in_umbrella: true},
       {:managoat_oauth, in_umbrella: true},

--- a/apps/managoat_broker/.formatter.exs
+++ b/apps/managoat_broker/.formatter.exs
@@ -1,0 +1,3 @@
+[
+  inputs: ["*.{ex,exs}", "{lib,test}/**/*.{ex,exs}"]
+]

--- a/apps/managoat_broker/LICENSE
+++ b/apps/managoat_broker/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Jake Gaylor
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/apps/managoat_broker/README.md
+++ b/apps/managoat_broker/README.md
@@ -1,0 +1,198 @@
+# Managoat.Broker
+
+An egress credential proxy for sandboxed agents. The sandbox holds a
+**placeholder** where a credential used to be, plus a proxy address with a
+session token in it. Every outbound HTTP request goes through this proxy,
+which looks the token up in a session store the host implements, gets back
+the rules the host prepared for that session, and attaches the real
+credential to each request that matches one. The agent process never holds
+the credential; the proxy is the only host it may reach, so a placeholder
+is worthless off the box.
+
+```elixir
+# The host's supervision tree:
+children = [
+  {Managoat.Broker,
+   port: 14322,
+   store: MyApp.BrokerSessions,        # a Managoat.Broker.Store
+   ca_seed: MyApp.broker_ca_seed(),    # 32 bytes, the same on every replica
+   allow_private_upstreams: false}
+]
+
+# The sandbox's environment, prepared by the host:
+#   HTTPS_PROXY=http://<token>:<label>@broker.example.com:14322
+#   GITHUB_TOKEN=__github_token__
+# and the root from Managoat.Broker.ca_pem/0 in its trust store.
+```
+
+## What the proxy does
+
+One plaintext HTTP listener (TLS toward the sandbox, if any, is the
+ingress's job) speaking the two things a forward proxy speaks:
+
+- **`CONNECT host:443`** for HTTPS. The proxy opens the upstream TLS
+  connection first (an unreachable or untrusted origin is a `502` before any
+  tunnel exists), answers `200`, then completes a TLS handshake with the
+  *sandbox* using a leaf certificate for that host signed by the listener's
+  own CA. Inside the tunnel it reads each request head, rewrites the headers
+  per the session's rules, and forwards head and body to the origin. Bytes
+  coming back are relayed untouched and unparsed, so a streaming model reply
+  streams. Keep-alive works; every request on the tunnel is rewritten. A
+  WebSocket upgrade is injected like any other request, after which the
+  tunnel is a byte pipe.
+- **Absolute-form requests** (`GET http://host/path`) for plain HTTP, one
+  request per connection.
+
+The client authenticates with `Proxy-Authorization: Basic
+base64(token:label)`, which is what an HTTP client sends for a proxy URL
+with userinfo. The token is looked up once per client connection (the unit
+a sandbox's HTTP client pools on); `proxy-authorization` never reaches the
+origin. A missing, unknown or expired token is `407`.
+
+Two guards protect the operator's network and the tenant's intent:
+
+- **SSRF.** An origin that resolves to a private, loopback, link-local
+  (including the cloud metadata address), CGNAT or unspecified IPv4 address
+  is refused with `403` before any connection, and the dial goes to the
+  vetted address rather than the name, so a rebinding DNS answer between
+  check and dial changes nothing. `allow_private_upstreams: true` turns the
+  guard off for a test rig whose origins are on localhost.
+- **`deny`.** A session whose `unmatched_host_policy` is `:deny` refuses a
+  host no rule names at `CONNECT`, before a tunnel or handshake exists, and
+  refuses a request no rule matches inside a tunnel with `403`. That is how
+  an allowlist is enforced: one `:passthrough` rule per allowed host.
+
+## The `Store` behaviour
+
+```elixir
+@callback lookup(token :: binary()) :: {:ok, Managoat.Broker.Session.t()} | :error
+```
+
+That is all the proxy needs at request time: the raw token in, a session
+with its rules (credentials already resolved) out. Creating, releasing and
+sweeping sessions are the host's business; they touch its tables and its
+key hierarchy, and the proxy never needs any of it. Hashing the token
+before storing it is the host's choice inside `lookup/1`; the library
+passes the raw token from the header.
+
+A store with several instances (one per listener in a test) implements
+`lookup/2` instead and is configured as `store: {Module, instance}`.
+`Managoat.Broker.Store.Memory` is the reference store, an `Agent` holding a
+map, for the library's tests and for a consumer without a database.
+
+A `Managoat.Broker.Session` has `rules`, `unmatched_host_policy`
+(`:passthrough` or `:deny`), `expires_at` and an opaque `meta` map the host
+fills for its own logging. A `Managoat.Broker.Rule` has a `pattern`
+(`host[:port][/path]`, wildcards allowed), a `scheme` and the fields the
+scheme needs:
+
+| `scheme` | fields | effect on a matched request |
+|---|---|---|
+| `:bearer` | `credential` | `Authorization: Bearer <credential>` replaces any `Authorization` |
+| `:basic` | `credential` as `{username, password}` | `Authorization: Basic base64(username:password)` |
+| `:api_key` | `header` (default `Authorization`), `prefix`, `credential` | `<header>: <prefix><credential>` |
+| `:custom` | `template` (`%{header => "text {{ KEY }}"}`), `credential` (`%{"KEY" => value}`) | each header rendered from its template |
+| `:substitute` | `placeholder`, `credential` | every header value has the placeholder replaced by the credential |
+| `:passthrough` | none | forwarded untouched; under `deny`, how a host is allowed |
+
+The first matched rule that sets a header does; every matched `:substitute`
+rule applies to the header values.
+
+## The child spec
+
+`{Managoat.Broker, port: 14322, store: Module, ca_seed: <32 bytes>,
+allow_private_upstreams: false}`. Every option but the last is required,
+and a missing one raises at start naming the option. Optional:
+`upstream_ssl_options` (merged over the `:ssl` options the proxy dials
+origins with; a test origin's `cacerts`) and `name` (default
+`Managoat.Broker`, for several listeners in one VM). There is no
+configuration module reading an otp_app: the listener is started by the
+host with values the host computed at boot, and a library that is not
+started serves nothing.
+
+Once up: `Managoat.Broker.port/1`, `running?/1` and `ca_pem/1`.
+
+## The CA
+
+A brokered sandbox trusts one root, and the proxy presents a leaf for each
+host the sandbox `CONNECT`s to, signed by that root. Every replica of the
+host must present leaves the sandbox trusts, whichever one the ingress
+hands a connection to, and a sandbox that survived a restart must still
+trust what a fresh replica signs. So the root is not generated and stored:
+it is **derived** from the 32-byte `ca_seed` with HKDF-SHA256, reduced into
+P-256's scalar field, and the certificate's subject, serial and validity
+are fixed, so every replica computes the same key, subject and serial from
+the same seed. Rotating the seed rotates the CA; nothing else does.
+
+The root's self-signature bytes vary per derivation, because ECDSA signing
+is randomised, so two replicas' PEMs differ byte for byte. That is
+harmless: a client matches a trust anchor by subject and public key and
+never verifies a root's own signature. `ca_test.exs` proves a leaf signed
+after a re-derivation chains to the first root.
+
+The seed is the host's to derive, and it must not be a key the host uses
+for anything else: derive it from a master key with a fixed info string,
+so the CA key is never the storage key. Leaves live thirty days, are cached
+per host in an ETS table the listener owns, and are re-signed after
+twenty-nine.
+
+## Telemetry
+
+Every request the proxy decides about emits `[:managoat, :broker,
+:request]` with `%{count: 1}` and the metadata `method`, `host`, `path`,
+`outcome` (`:injected`, `:passthrough` or `:denied`), `rule` (the matched
+rule's name, or nil) and `meta` (the session's, unchanged). Never a header,
+never a body. The host attaches a handler and writes its log line with
+whatever `meta` carries; the library logs only refusals, which have no
+session to attribute.
+
+## Deviations from Agent Vault
+
+This proxy replaced Infisical's Agent Vault behind the same interface. The
+parity suite (`test/managoat/broker/agent_vault_parity_test.exs`) replays
+the upstream tests it stands in for and lists what was not ported. In
+short:
+
+- **Absolute-form (plain HTTP) is one request per connection.** The proxy
+  adds `Connection: close` upstream and closes after the response. HTTPS
+  tunnels keep-alive normally. Plain HTTP through the proxy is apt and
+  little else.
+- **No path, query or body substitution.** The `:substitute` rule reaches
+  header values only, which covers an inference key a runtime sends as a
+  bearer or an `x-api-key` in a placeholder it was handed. A credential a
+  client puts in a URL is not brokered.
+- **No WebSocket frame rewriting.** The upgrade request is injected; the
+  frames after it are piped as bytes.
+- **No auth-failure rate limiting** on the proxy port.
+- **No body-size caps** (Agent Vault's response cap was unlimited by
+  default too).
+- **No IPv6 upstreams.** The proxy resolves IPv4 only.
+- **The label half of the proxy credential is not checked.** Agent Vault
+  refused a valid token presented with another vault's name. Here the
+  random per-session token is the whole binding; the label exists because
+  some clients (git) refuse a proxy URL with a user and no password.
+
+## Two operational traps a host must handle
+
+Both were found in production with the previous broker and are about the
+sandbox and the ingress, not the proxy, so this library cannot fix them.
+
+- **`sudo` strips the proxy environment.** A sandbox that runs `sudo
+  apt-get` loses `HTTPS_PROXY` and the rest, and the install fails against
+  a closed network with an error naming apt, not the proxy. Provisioning
+  has to keep the proxy variables across `sudo` (`Defaults env_keep` in a
+  sudoers drop-in).
+- **An unknown CA leaf, and a shared-NAT peer.** A sandbox that does not
+  trust the root sees every brokered host fail TLS with an "unknown
+  issuer" error the tool attributes to the origin. The root has to reach
+  the operating system trust store (`update-ca-certificates`) and the
+  toolchains that carry their own roots (`NODE_EXTRA_CA_CERTS` for Node,
+  `SSL_CERT_FILE`/`REQUESTS_CA_BUNDLE`/`CARGO_HTTP_CAINFO` pointed at the
+  full system bundle, `UV_NATIVE_TLS`) before anything else runs. The same
+  incident's other half was a per-IP auth rate limiter at the vendor's
+  proxy port tripping on many sandboxes behind one NAT address; this proxy
+  has none, so nothing in front of it needs to allow for that.
+
+## Licence
+
+Apache-2.0. See `LICENSE`.

--- a/apps/managoat_broker/lib/managoat/broker.ex
+++ b/apps/managoat_broker/lib/managoat/broker.ex
@@ -1,0 +1,141 @@
+defmodule Managoat.Broker do
+  @moduledoc """
+  An egress credential proxy for sandboxed agents.
+
+  The sandbox holds a **placeholder** where a credential used to be, plus a
+  proxy address with a session token in it. Outbound HTTP goes through this
+  proxy, which looks the token up in the host's `Managoat.Broker.Store`,
+  gets back the `Managoat.Broker.Session` of rules the host prepared, and
+  attaches the real credential to each request that matches one. The
+  sandbox's only permitted egress is the proxy, so a placeholder is
+  worthless off the box. The pieces:
+
+  | Module | Role |
+  |---|---|
+  | `Managoat.Broker` | this: the listener's child spec and supervisor |
+  | `Managoat.Broker.Proxy` | one client connection: `CONNECT` tunnels with TLS terminated on both ends, absolute-form plain HTTP, the SSRF guard, the byte pump |
+  | `Managoat.Broker.Injector` | the header rewrite for one request |
+  | `Managoat.Broker.Rule`, `Managoat.Broker.Session` | what a token resolves to |
+  | `Managoat.Broker.Store` | the behaviour the host implements: token in, session out |
+  | `Managoat.Broker.Store.Memory` | the reference store, in memory |
+  | `Managoat.Broker.CA`, `Managoat.Broker.Certs` | the root derived from the seed, and the cached per-host leaves |
+  | `Managoat.Broker.HTTP` | request heads and body framing |
+
+  ## Starting it
+
+      children = [
+        {Managoat.Broker,
+         port: 14322,
+         store: MyApp.BrokerSessions,
+         ca_seed: MyApp.broker_ca_seed(),
+         allow_private_upstreams: false}
+      ]
+
+  Every option but the last is required, and a missing one raises at start
+  naming it. There is no configuration module reading an otp_app: the
+  host computed these values at boot, and a library that is not started
+  serves nothing.
+
+  | Option | |
+  |---|---|
+  | `port` | the plaintext listener port (`0` for an ephemeral one; see `port/1`) |
+  | `store` | a `Managoat.Broker.Store` module, or `{module, instance}` |
+  | `ca_seed` | 32 bytes the root CA is derived from; the same seed on every replica |
+  | `allow_private_upstreams` | default `false`. `true` lets the proxy dial private, loopback and link-local origins, for a test rig only |
+  | `upstream_ssl_options` | default `[]`. Merged over the `:ssl` options the proxy dials origins with (a test origin's `cacerts`) |
+  | `name` | default `Managoat.Broker`. The supervisor's name; `port/1`, `running?/1` and `ca_pem/1` take it |
+
+  The root certificate the sandbox must trust is `ca_pem/1` once the
+  listener is up, or `Managoat.Broker.CA.pem/1` from the seed at any time.
+  """
+
+  use Supervisor
+
+  alias Managoat.Broker.{CA, Certs, Proxy}
+
+  @required [:port, :store, :ca_seed]
+  @idle_timeout 300_000
+
+  @doc false
+  def child_spec(opts) do
+    %{
+      id: Keyword.get(opts, :name, __MODULE__),
+      start: {__MODULE__, :start_link, [opts]},
+      type: :supervisor
+    }
+  end
+
+  @doc "Start the listener and its certificate cache under `name`."
+  @spec start_link(keyword()) :: Supervisor.on_start()
+  def start_link(opts) when is_list(opts) do
+    for key <- @required, not Keyword.has_key?(opts, key) do
+      raise ArgumentError,
+            "Managoat.Broker needs the #{inspect(key)} option; " <>
+              "required: #{inspect(@required)}"
+    end
+
+    unless match?(<<_::binary-32>>, Keyword.fetch!(opts, :ca_seed)) do
+      raise ArgumentError, "Managoat.Broker's :ca_seed must be 32 bytes"
+    end
+
+    Supervisor.start_link(__MODULE__, opts, name: Keyword.get(opts, :name, __MODULE__))
+  end
+
+  @impl Supervisor
+  def init(opts) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    certs = Certs.new(Keyword.fetch!(opts, :ca_seed))
+    :persistent_term.put({__MODULE__, name, :certs}, certs)
+
+    listener = %{
+      id: :listener,
+      start:
+        {ThousandIsland, :start_link,
+         [
+           [
+             port: Keyword.fetch!(opts, :port),
+             handler_module: Proxy,
+             handler_options: [
+               store: Keyword.fetch!(opts, :store),
+               certs: certs,
+               allow_private_upstreams: Keyword.get(opts, :allow_private_upstreams, false),
+               upstream_ssl_options: Keyword.get(opts, :upstream_ssl_options, [])
+             ],
+             read_timeout: @idle_timeout,
+             supervisor_options: [name: listener_name(name)]
+           ]
+         ]},
+      type: :supervisor
+    }
+
+    Supervisor.init([listener], strategy: :one_for_one)
+  end
+
+  @doc "True when the listener under `name` is up on this node."
+  @spec running?(atom()) :: boolean()
+  def running?(name \\ __MODULE__) do
+    case Process.whereis(listener_name(name)) do
+      pid when is_pid(pid) -> Process.alive?(pid)
+      _ -> false
+    end
+  end
+
+  @doc "The port the listener under `name` is bound to."
+  @spec port(atom()) :: :inet.port_number()
+  def port(name \\ __MODULE__) do
+    {:ok, {_ip, port}} = ThousandIsland.listener_info(listener_name(name))
+    port
+  end
+
+  @doc "The root certificate the listener under `name` signs with, as PEM."
+  @spec ca_pem(atom()) :: String.t()
+  def ca_pem(name \\ __MODULE__) do
+    {__MODULE__, name, :certs} |> :persistent_term.get() |> Certs.ca_pem()
+  end
+
+  @doc "The root certificate a listener started with `seed` signs with, as PEM. Pure."
+  @spec ca_pem_for_seed(binary()) :: String.t()
+  def ca_pem_for_seed(seed), do: CA.pem(seed)
+
+  defp listener_name(name), do: Module.concat(name, Listener)
+end

--- a/apps/managoat_broker/lib/managoat/broker/ca.ex
+++ b/apps/managoat_broker/lib/managoat/broker/ca.ex
@@ -1,0 +1,125 @@
+defmodule Managoat.Broker.CA do
+  @moduledoc """
+  The certificate authority the egress proxy signs with.
+
+  A brokered sandbox trusts one root, and the proxy presents a leaf for each
+  host the sandbox `CONNECT`s to, signed by that root. Every replica of the
+  host application must present leaves the sandbox trusts, whichever one
+  the ingress hands the connection to, and a sandbox that survived a
+  restart must still trust what a fresh replica signs. So the root is not
+  generated and stored: it is **derived** from a 32-byte `seed` the host
+  passes at start (HKDF-SHA256, reduced into P-256's scalar field), and the
+  certificate's subject, serial and validity are fixed, so every replica
+  computes the same key, subject and serial from the same seed. Rotating
+  the seed rotates the CA; nothing else does.
+
+  The self-signature bytes differ per derivation, because ECDSA signing is
+  randomised. That is harmless: a client matches a trust anchor by subject
+  and public key and never checks a root's own signature, and `ca_test.exs`
+  proves a leaf signed after a re-derivation chains to the first root.
+
+  The seed is the host's to derive. It must not be a key the host uses for
+  anything else: derive one from a master key with a fixed info string, so
+  the CA key is never the storage key. Every function here is pure; the
+  listener caches the root and the leaves in `Managoat.Broker.Certs`.
+  """
+
+  @curve :secp256r1
+  @salt "managoat.broker.salt"
+  @info "managoat.broker.ca"
+  # Fixed so that every replica derives the same certificate from the same
+  # seed. A validity window that starts at a constant and runs twenty years
+  # is a constant, not a clock read.
+  @not_before ~U[2026-05-01 00:00:00Z]
+  @not_after ~U[2046-05-01 00:00:00Z]
+  @leaf_days 30
+
+  @typedoc "The root certificate and its private key."
+  @type root :: {X509.Certificate.t(), X509.PrivateKey.t()}
+
+  @doc "The root certificate as PEM, for a sandbox trust store."
+  @spec pem(binary()) :: String.t()
+  def pem(seed), do: seed |> root() |> elem(0) |> X509.Certificate.to_pem()
+
+  @doc "The root certificate as DER, for a `cacerts` option."
+  @spec der(binary()) :: binary()
+  def der(seed), do: seed |> root() |> elem(0) |> X509.Certificate.to_der()
+
+  @doc """
+  Derive the root from a 32-byte seed. Deterministic in key, subject and
+  serial; see the moduledoc for the signature.
+  """
+  @spec root(binary()) :: root()
+  def root(<<_::binary-32>> = seed) do
+    key = derive_key(seed)
+    validity = X509.Certificate.Validity.new(@not_before, @not_after)
+
+    cert =
+      X509.Certificate.self_signed(key, "/CN=Managoat Broker CA/O=Managoat",
+        template: :root_ca,
+        validity: validity,
+        serial: serial(key)
+      )
+
+    {cert, key}
+  end
+
+  def root(other) when is_binary(other) do
+    raise ArgumentError, "the broker CA seed must be 32 bytes, got #{byte_size(other)}"
+  end
+
+  @doc """
+  A leaf certificate and key for `host`, signed by `root`, as the
+  `[cert: der, key: {:ECPrivateKey, der}]` pair `:ssl` takes.
+  """
+  @spec leaf(String.t(), root()) :: [cert: binary(), key: {:ECPrivateKey, binary()}]
+  def leaf(host, {ca_cert, ca_key}) when is_binary(host) do
+    key = X509.PrivateKey.new_ec(@curve)
+    now = DateTime.utc_now()
+
+    validity =
+      X509.Certificate.Validity.new(
+        DateTime.add(now, -300, :second),
+        DateTime.add(now, @leaf_days * 86_400, :second)
+      )
+
+    cert =
+      key
+      |> X509.PublicKey.derive()
+      |> X509.Certificate.new("/CN=#{host}", ca_cert, ca_key,
+        template: :server,
+        validity: validity,
+        extensions: [subject_alt_name: X509.Certificate.Extension.subject_alt_name([host])]
+      )
+
+    [cert: X509.Certificate.to_der(cert), key: {:ECPrivateKey, X509.PrivateKey.to_der(key)}]
+  end
+
+  # HKDF-SHA256 over the seed, reduced into the curve's scalar field. The
+  # reduction bias on a 256-bit output against P-256's order is under 2^-32;
+  # the key is not a signature-oracle target at that precision.
+  defp derive_key(seed) do
+    prk = :crypto.mac(:hmac, :sha256, @salt, seed)
+    okm = :crypto.mac(:hmac, :sha256, prk, @info <> <<1>>)
+    n = curve_order()
+    scalar = rem(:binary.decode_unsigned(okm), n - 1) + 1
+    priv = <<scalar::unsigned-big-integer-size(256)>>
+    {pub, ^priv} = :crypto.generate_key(:ecdh, @curve, priv)
+
+    {:ECPrivateKey, 1, priv, {:namedCurve, :pubkey_cert_records.namedCurves(@curve)}, pub,
+     :asn1_NOVALUE}
+  end
+
+  # P-256's group order, from the curve parameters OTP ships.
+  defp curve_order do
+    {_field, _curve, _base, order, _cofactor} = :crypto.ec_curve(@curve)
+    :binary.decode_unsigned(order)
+  end
+
+  # A serial from the public key, so it is as stable as the key itself.
+  defp serial(key) do
+    {:ECPrivateKey, _, _, _, pub, _} = key
+    <<n::unsigned-big-integer-size(64), _::binary>> = :crypto.hash(:sha256, pub)
+    Bitwise.bsr(n, 1) + 1
+  end
+end

--- a/apps/managoat_broker/lib/managoat/broker/certs.ex
+++ b/apps/managoat_broker/lib/managoat/broker/certs.ex
@@ -1,0 +1,60 @@
+defmodule Managoat.Broker.Certs do
+  @moduledoc """
+  One listener's certificates: the derived root, and the per-host leaves
+  the proxy presents, cached in an ETS table.
+
+  Signing a leaf is a few milliseconds of ECDSA; a sandbox opens a new
+  tunnel per connection, so the same host comes back many times. Leaves
+  live thirty days and are re-signed after twenty-nine.
+
+  The table is created by the listener's supervisor (`Managoat.Broker`), so
+  it lives exactly as long as the listener, and handed to every connection
+  handler as an option. Public, so the handlers read and insert without a
+  round trip through a process.
+  """
+
+  alias Managoat.Broker.CA
+
+  @refresh_after_seconds 29 * 86_400
+
+  @opaque t :: :ets.table()
+
+  @doc "A table holding the root derived from `seed`. Owned by the caller."
+  @spec new(binary()) :: t()
+  def new(seed) do
+    table = :ets.new(__MODULE__, [:public, :set, read_concurrency: true])
+    :ets.insert(table, {:root, CA.root(seed)})
+    table
+  end
+
+  @doc "The root certificate and key."
+  @spec root(t()) :: CA.root()
+  def root(table) do
+    [{:root, pair}] = :ets.lookup(table, :root)
+    pair
+  end
+
+  @doc "The root certificate as PEM."
+  @spec ca_pem(t()) :: String.t()
+  def ca_pem(table), do: table |> root() |> elem(0) |> X509.Certificate.to_pem()
+
+  @doc "The root certificate as DER."
+  @spec ca_der(t()) :: binary()
+  def ca_der(table), do: table |> root() |> elem(0) |> X509.Certificate.to_der()
+
+  @doc "The `:ssl` `cert`/`key` options for `host`, signed by the root."
+  @spec for_host(t(), String.t()) :: keyword()
+  def for_host(table, host) do
+    now = System.system_time(:second)
+
+    case :ets.lookup(table, {:leaf, host}) do
+      [{{:leaf, ^host}, opts, signed_at}] when now - signed_at < @refresh_after_seconds ->
+        opts
+
+      _ ->
+        opts = CA.leaf(host, root(table))
+        :ets.insert(table, {{:leaf, host}, opts, now})
+        opts
+    end
+  end
+end

--- a/apps/managoat_broker/lib/managoat/broker/http.ex
+++ b/apps/managoat_broker/lib/managoat/broker/http.ex
@@ -1,0 +1,241 @@
+defmodule Managoat.Broker.HTTP do
+  @moduledoc """
+  The slice of HTTP/1.1 the proxy has to understand: a request head, and
+  how long the body after it is. Responses are never parsed; they flow back
+  to the sandbox as bytes, which is what keeps a streaming model reply a
+  stream.
+  """
+
+  @type head :: %{
+          method: String.t(),
+          target: String.t(),
+          version: {integer(), integer()},
+          headers: [{String.t(), String.t()}]
+        }
+
+  @typedoc "How the body after a head is delimited."
+  @type framing :: :none | {:length, non_neg_integer()} | :chunked
+
+  @doc """
+  Parse a request head off the front of `buffer`. `{:more, buffer}` when the
+  head is not complete yet, `{:ok, head, rest}` with the bytes after the
+  blank line, `{:error, reason}` on garbage.
+  """
+  @spec parse_request(binary()) :: {:ok, head(), binary()} | {:more, binary()} | {:error, term()}
+  def parse_request(buffer) do
+    case :erlang.decode_packet(:http_bin, buffer, []) do
+      {:ok, {:http_request, method, target, version}, rest} ->
+        parse_headers(rest, %{
+          method: method_string(method),
+          target: target_string(target),
+          version: version,
+          headers: []
+        })
+
+      {:ok, {:http_error, line}, _} ->
+        {:error, {:bad_request_line, line}}
+
+      {:ok, other, _} ->
+        {:error, {:unexpected, other}}
+
+      {:more, _} ->
+        {:more, buffer}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp parse_headers(buffer, head) do
+    case :erlang.decode_packet(:httph_bin, buffer, []) do
+      {:ok, {:http_header, _, name, _, value}, rest} ->
+        parse_headers(rest, %{head | headers: [{header_string(name), value} | head.headers]})
+
+      {:ok, :http_eoh, rest} ->
+        {:ok, %{head | headers: Enum.reverse(head.headers)}, rest}
+
+      {:ok, {:http_error, line}, _} ->
+        {:error, {:bad_header, line}}
+
+      {:more, _} ->
+        # The whole head has to be re-parsed from the request line; the
+        # caller keeps the original buffer and calls again with more bytes.
+        :more
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+    |> case do
+      :more -> {:more, :incomplete}
+      other -> other
+    end
+  end
+
+  @doc "How the request body after `head` is delimited (RFC 9112 §6)."
+  @spec body_framing(head()) :: framing()
+  def body_framing(%{headers: headers}) do
+    te = header(headers, "transfer-encoding")
+    cl = header(headers, "content-length")
+
+    cond do
+      is_binary(te) and String.contains?(String.downcase(te), "chunked") -> :chunked
+      is_binary(cl) -> {:length, cl |> String.trim() |> String.to_integer()}
+      true -> :none
+    end
+  end
+
+  @doc "The first value of header `name` (case-insensitive), or nil."
+  @spec header([{String.t(), String.t()}], String.t()) :: String.t() | nil
+  def header(headers, name) do
+    down = String.downcase(name)
+
+    Enum.find_value(headers, fn {k, v} ->
+      if String.downcase(k) == down, do: v
+    end)
+  end
+
+  @doc "Serialise a head back to bytes, with `target` as the request-target."
+  @spec encode_request(head(), String.t()) :: iodata()
+  def encode_request(%{method: method, version: {maj, min}, headers: headers}, target) do
+    [
+      method,
+      " ",
+      target,
+      " HTTP/#{maj}.#{min}\r\n",
+      Enum.map(headers, fn {k, v} -> [k, ": ", v, "\r\n"] end),
+      "\r\n"
+    ]
+  end
+
+  @doc """
+  The host and port a request-target names, and the origin-form target to
+  forward. Absolute-form (`http://host/path`) is what a client sends a
+  forward proxy for plain HTTP; an authority (`host:port`) is a `CONNECT`.
+  """
+  @spec destination(head()) ::
+          {:ok, {String.t(), :inet.port_number()}, String.t()} | {:error, :bad_target}
+  def destination(%{method: "CONNECT", target: target}) do
+    case String.split(target, ":") do
+      [host, port] ->
+        case Integer.parse(port) do
+          {p, ""} when p in 1..65_535 -> {:ok, {host, p}, target}
+          _ -> {:error, :bad_target}
+        end
+
+      _ ->
+        {:error, :bad_target}
+    end
+  end
+
+  def destination(%{target: "http://" <> _ = target}) do
+    case URI.parse(target) do
+      %URI{host: host, port: port} = uri when is_binary(host) ->
+        path = if uri.path in [nil, ""], do: "/", else: uri.path
+        query = if uri.query, do: "?" <> uri.query, else: ""
+        {:ok, {host, port || 80}, path <> query}
+
+      _ ->
+        {:error, :bad_target}
+    end
+  end
+
+  def destination(_), do: {:error, :bad_target}
+
+  @doc """
+  Split `buffer` per `framing`: `{:done, consumed, rest}` once the whole
+  body is in hand, `{:partial, consumed, state}` when more is needed and
+  `consumed` (the whole buffer) may be forwarded. Chunked bodies are
+  forwarded verbatim, framing included; the state remembers where in the
+  chunk stream the buffer ended.
+  """
+  @spec take_body(framing() | {:chunked, term()}, binary()) ::
+          {:done, binary(), binary()} | {:partial, binary(), framing() | {:chunked, term()}}
+  def take_body(:none, buffer), do: {:done, "", buffer}
+
+  def take_body({:length, n}, buffer) when byte_size(buffer) >= n do
+    <<body::binary-size(n), rest::binary>> = buffer
+    {:done, body, rest}
+  end
+
+  def take_body({:length, n}, buffer), do: {:partial, buffer, {:length, n - byte_size(buffer)}}
+
+  def take_body(:chunked, buffer), do: take_body({:chunked, {:size, ""}}, buffer)
+
+  def take_body({:chunked, state}, buffer) do
+    case chunks(buffer, state) do
+      {:done, rest} ->
+        {:done, binary_part(buffer, 0, byte_size(buffer) - byte_size(rest)), rest}
+
+      {:partial, state} ->
+        {:partial, buffer, {:chunked, state}}
+    end
+  end
+
+  # The chunk stream: `{:size, acc}` reading a size line, `{:data, n}` inside
+  # a chunk with n bytes left (its trailing CRLF included), `{:trailers, acc}`
+  # after the zero chunk until the blank line.
+  defp chunks(buffer, {:size, acc}) do
+    case take_line(buffer) do
+      {line, rest} ->
+        case chunk_size(acc <> line) do
+          0 -> chunks(rest, {:trailers, ""})
+          size -> chunks(rest, {:data, size + 2})
+        end
+
+      :nomatch ->
+        {:partial, {:size, acc <> buffer}}
+    end
+  end
+
+  defp chunks(buffer, {:data, n}) when byte_size(buffer) >= n do
+    chunks(binary_part(buffer, n, byte_size(buffer) - n), {:size, ""})
+  end
+
+  defp chunks(buffer, {:data, n}), do: {:partial, {:data, n - byte_size(buffer)}}
+
+  defp chunks(buffer, {:trailers, acc}) do
+    case take_line(buffer) do
+      {line, rest} ->
+        if String.trim(acc <> line) == "", do: {:done, rest}, else: chunks(rest, {:trailers, ""})
+
+      :nomatch ->
+        {:partial, {:trailers, acc <> buffer}}
+    end
+  end
+
+  defp take_line(buffer) do
+    case :binary.match(buffer, "\n") do
+      {pos, 1} ->
+        {binary_part(buffer, 0, pos + 1),
+         binary_part(buffer, pos + 1, byte_size(buffer) - pos - 1)}
+
+      :nomatch ->
+        :nomatch
+    end
+  end
+
+  defp chunk_size(line) do
+    line
+    |> String.trim()
+    |> String.split(";", parts: 2)
+    |> hd()
+    |> String.trim()
+    |> String.to_integer(16)
+  end
+
+  defp method_string(m) when is_atom(m), do: Atom.to_string(m)
+  defp method_string(m) when is_binary(m), do: m
+
+  defp target_string({:abs_path, p}), do: p
+
+  defp target_string({:absoluteURI, scheme, host, port, path}) do
+    "#{scheme}://#{host}#{if port == :undefined, do: "", else: ":#{port}"}#{path}"
+  end
+
+  defp target_string({:scheme, host, port}), do: "#{host}:#{port}"
+  defp target_string(:*), do: "*"
+  defp target_string(other) when is_binary(other), do: other
+
+  defp header_string(h) when is_atom(h), do: Atom.to_string(h)
+  defp header_string(h) when is_binary(h), do: h
+end

--- a/apps/managoat_broker/lib/managoat/broker/injector.ex
+++ b/apps/managoat_broker/lib/managoat/broker/injector.ex
@@ -1,0 +1,140 @@
+defmodule Managoat.Broker.Injector do
+  @moduledoc """
+  The header rewrite the proxy applies to one request.
+
+  A `Managoat.Broker.Rule` binds a host pattern to an auth shape and a
+  credential. When a request matches a rule that sets a header, the
+  request's own copy of that header is dropped whatever it carried (the
+  placeholder, usually) and the real one is written in its place.
+  `proxy-authorization`, which carried the session token from the sandbox,
+  never reaches the origin. When no rule matches, the session's
+  `unmatched_host_policy` decides: `:passthrough` sends the request
+  untouched, `:deny` refuses it.
+
+  Several rules may match. The first matched rule that sets a header is the
+  one that does (a host's rules are in the order the host declared them);
+  every matched `:substitute` rule applies to the header values.
+  """
+
+  alias Managoat.Broker.{Rule, Session}
+
+  @hop_by_hop ~w(proxy-authorization proxy-connection)
+  @template_re ~r/\{\{\s*([A-Z][A-Z0-9_]*)\s*\}\}/
+
+  @type header :: {String.t(), String.t()}
+
+  @doc """
+  Rewrite `headers` for a request to `host`:`port` at `path`. Returns
+  `{:ok, headers, rule_name}` with the name of the first matched rule
+  (`nil` for passthrough), or `{:error, :denied}`.
+  """
+  @spec inject([header()], String.t(), :inet.port_number(), String.t(), Session.t()) ::
+          {:ok, [header()], String.t() | nil} | {:error, :denied}
+  def inject(headers, host, port, path, %Session{} = session) do
+    headers = Enum.reject(headers, fn {k, _} -> String.downcase(k) in @hop_by_hop end)
+
+    case Enum.filter(session.rules, &matches?(&1.pattern, host, port, path)) do
+      [] ->
+        if session.unmatched_host_policy == :deny,
+          do: {:error, :denied},
+          else: {:ok, headers, nil}
+
+      [first | _] = matched ->
+        headers =
+          matched
+          |> Enum.filter(&(&1.scheme == :substitute))
+          |> Enum.reduce(headers, &substitute/2)
+
+        headers =
+          case Enum.find(matched, &(&1.scheme not in [:substitute, :passthrough])) do
+            nil -> headers
+            rule -> put_auth(headers, rule)
+          end
+
+        {:ok, headers, first.name}
+    end
+  end
+
+  @doc "Does the host part of a rule `pattern` match this host and port, whatever the path?"
+  @spec host_matches?(String.t(), String.t(), :inet.port_number()) :: boolean()
+  def host_matches?(pattern, host, port) when is_binary(pattern) do
+    host_only = pattern |> String.split("/", parts: 2) |> hd()
+    matches?(host_only, host, port, "/")
+  end
+
+  @doc "Does a rule `pattern` (`host[:port][/path]`) match this request?"
+  @spec matches?(String.t(), String.t(), :inet.port_number(), String.t()) :: boolean()
+  def matches?(pattern, host, port, path) when is_binary(pattern) do
+    {host_part, path_part} =
+      case String.split(pattern, "/", parts: 2) do
+        [h] -> {h, nil}
+        [h, p] -> {h, "/" <> p}
+      end
+
+    {host_pattern, port_pattern} =
+      case String.split(host_part, ":", parts: 2) do
+        [h] -> {h, nil}
+        [h, p] -> {h, p}
+      end
+
+    host_pattern_matches?(String.downcase(host_pattern), String.downcase(host)) and
+      port_matches?(port_pattern, port) and path_matches?(path_part, path)
+  end
+
+  defp host_pattern_matches?("*." <> suffix, host), do: String.ends_with?(host, "." <> suffix)
+  defp host_pattern_matches?(pattern, host), do: pattern == host
+
+  defp port_matches?(nil, _port), do: true
+  defp port_matches?(pattern, port), do: pattern == Integer.to_string(port)
+
+  defp path_matches?(nil, _path), do: true
+
+  defp path_matches?(pattern, path) do
+    path = path |> String.split("?", parts: 2) |> hd()
+
+    if String.ends_with?(pattern, "*"),
+      do: String.starts_with?(path, String.trim_trailing(pattern, "*")),
+      else: path == pattern or String.starts_with?(path, pattern <> "/")
+  end
+
+  defp put_auth(headers, %Rule{scheme: :bearer, credential: token}) when is_binary(token) do
+    replace(headers, "authorization", "Bearer " <> token)
+  end
+
+  defp put_auth(headers, %Rule{scheme: :basic, credential: {user, pass}})
+       when is_binary(user) and is_binary(pass) do
+    replace(headers, "authorization", "Basic " <> Base.encode64(user <> ":" <> pass))
+  end
+
+  defp put_auth(headers, %Rule{scheme: :api_key, credential: value} = rule)
+       when is_binary(value) do
+    replace(headers, rule.header || "Authorization", (rule.prefix || "") <> value)
+  end
+
+  defp put_auth(headers, %Rule{scheme: :custom, template: templates, credential: creds})
+       when is_map(templates) and is_map(creds) do
+    Enum.reduce(templates, headers, fn {name, template}, acc ->
+      replace(acc, name, render(template, creds))
+    end)
+  end
+
+  # Every `{{ KEY }}` the rule holds a value for; one it does not is left
+  # as written, which the origin then refuses, rather than sent empty.
+  defp render(template, creds) do
+    Regex.replace(@template_re, template, fn whole, key ->
+      Map.get(creds, key, whole)
+    end)
+  end
+
+  defp substitute(%Rule{placeholder: placeholder, credential: value}, headers)
+       when is_binary(placeholder) and placeholder != "" and is_binary(value) do
+    Enum.map(headers, fn {k, v} -> {k, String.replace(v, placeholder, value)} end)
+  end
+
+  defp substitute(_rule, headers), do: headers
+
+  defp replace(headers, name, value) do
+    down = String.downcase(name)
+    [{name, value} | Enum.reject(headers, fn {k, _} -> String.downcase(k) == down end)]
+  end
+end

--- a/apps/managoat_broker/lib/managoat/broker/proxy.ex
+++ b/apps/managoat_broker/lib/managoat/broker/proxy.ex
@@ -1,0 +1,467 @@
+defmodule Managoat.Broker.Proxy do
+  @moduledoc """
+  The egress proxy a brokered sandbox dials: one client connection.
+
+  The listener (`Managoat.Broker`) is plaintext HTTP; TLS toward the
+  sandbox, if any, is the ingress's job. It speaks the two things a forward
+  proxy speaks: `CONNECT host:443` for HTTPS, and absolute-form requests
+  (`GET http://host/path`) for plain HTTP. The client authenticates with
+  the session token in its proxy URL, which arrives as
+  `Proxy-Authorization: Basic base64(token:label)`; the token is looked up
+  in the `Managoat.Broker.Store` once per connection.
+
+  On `CONNECT` the proxy opens the upstream TLS connection first (a host it
+  cannot reach is a `502` before the tunnel exists), answers `200`, then
+  completes a TLS handshake with the *sandbox* using a leaf for that host
+  signed by the listener's `Managoat.Broker.CA`, which the sandbox trusts
+  because the host installed the root. Inside the tunnel it reads each
+  request head, lets `Managoat.Broker.Injector` rewrite the headers, and
+  forwards the head and body to the origin. Bytes coming back are relayed
+  untouched and unparsed, so a streaming model reply streams.
+
+  Every request the proxy decides about emits `[:managoat, :broker,
+  :request]` with `%{count: 1}` and the metadata `method`, `host`, `path`,
+  `outcome` (`:injected`, `:passthrough` or `:denied`), `rule` (the matched
+  rule's name or nil) and `meta` (the session's, unchanged). Never a header,
+  never a body. The host attaches a handler and writes its log line.
+
+  This module is a `ThousandIsland.Handler`; ThousandIsland calls its
+  `child_spec/1` for every accepted connection, which is why the listener's
+  own child spec lives on `Managoat.Broker` and not here.
+  """
+
+  use ThousandIsland.Handler
+
+  require Logger
+
+  alias Managoat.Broker.{Certs, HTTP, Injector, Session, Store}
+  alias ThousandIsland.Socket
+
+  @head_timeout 30_000
+  @idle_timeout 300_000
+  @connect_timeout 10_000
+
+  # ---------------------------------------------------------------------------
+  # One client connection
+
+  @impl ThousandIsland.Handler
+  def handle_connection(socket, opts) do
+    state = %{
+      store: Keyword.fetch!(opts, :store),
+      certs: Keyword.fetch!(opts, :certs),
+      allow_private_upstreams: Keyword.get(opts, :allow_private_upstreams, false),
+      upstream_ssl_options: Keyword.get(opts, :upstream_ssl_options, [])
+    }
+
+    with {:ok, head, rest} <- read_head(socket, "", @head_timeout),
+         {:ok, session} <- authenticate(socket, head, state),
+         {:ok, {host, port}, target} <- destination(socket, head) do
+      case head.method do
+        "CONNECT" ->
+          if reachable?(session, host, port) do
+            tunnel(socket, host, port, session, state)
+          else
+            log_request(session, head, host, {:error, :denied})
+            reply(socket, 403, "Forbidden")
+            {:close, state}
+          end
+
+        _ ->
+          forward_plain(socket, head, rest, host, port, target, session, state)
+      end
+    else
+      {:error, _} -> {:close, state}
+    end
+  end
+
+  # Under `deny`, a host no rule could match is refused at CONNECT, before
+  # a tunnel exists; paths are only known per request, so a host that
+  # matches some rule still gets its per-request check inside the tunnel.
+  defp reachable?(%Session{unmatched_host_policy: :deny, rules: rules}, host, port) do
+    Enum.any?(rules, &Injector.host_matches?(&1.pattern, host, port))
+  end
+
+  defp reachable?(_session, _host, _port), do: true
+
+  defp read_head(socket, buffer, timeout) do
+    case HTTP.parse_request(buffer) do
+      {:ok, head, rest} ->
+        {:ok, head, rest}
+
+      {:error, reason} ->
+        reply(socket, 400, "Bad Request")
+        {:error, reason}
+
+      {:more, _} ->
+        case Socket.recv(socket, 0, timeout) do
+          {:ok, data} -> read_head(socket, buffer <> data, timeout)
+          {:error, reason} -> {:error, reason}
+        end
+    end
+  end
+
+  defp authenticate(socket, head, state) do
+    with {:ok, token} <- proxy_token(head.headers),
+         {:ok, %Session{} = session} <- lookup(state.store, token),
+         false <- Session.expired?(session, DateTime.utc_now()) do
+      {:ok, session}
+    else
+      reason ->
+        Logger.info("broker: refused connection: #{inspect(refusal(reason))}")
+
+        reply(socket, 407, "Proxy Authentication Required", [
+          {"proxy-authenticate", ~s(Basic realm="managoat-broker")}
+        ])
+
+        {:error, :unauthenticated}
+    end
+  end
+
+  defp refusal({:error, reason}), do: reason
+  defp refusal(:error), do: :unknown_token
+  defp refusal(true), do: :expired
+
+  defp lookup(store, token) do
+    case Store.lookup(store, token) do
+      {:ok, %Session{}} = ok -> ok
+      _ -> :error
+    end
+  end
+
+  defp proxy_token(headers) do
+    with "Basic " <> encoded <- HTTP.header(headers, "proxy-authorization") || "",
+         {:ok, pair} <- Base.decode64(String.trim(encoded)),
+         [token, _label] <- String.split(pair, ":", parts: 2) do
+      {:ok, token}
+    else
+      _ -> {:error, :no_credentials}
+    end
+  end
+
+  defp destination(socket, head) do
+    case HTTP.destination(head) do
+      {:ok, _, _} = ok ->
+        ok
+
+      {:error, :bad_target} ->
+        reply(socket, 400, "Bad Request")
+        {:error, :bad_target}
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # CONNECT: a TLS tunnel the proxy terminates on both ends
+
+  defp tunnel(socket, host, port, session, state) do
+    with {:ok, address} <- resolve(socket, host, port, state),
+         {:ok, upstream} <- connect_tls(socket, address, host, port, state) do
+      Socket.send(socket, "HTTP/1.1 200 Connection established\r\n\r\n")
+
+      # The handshake runs on the raw socket: the handler is synchronous
+      # from here to the end of the tunnel, so the transport switch stays
+      # ours. (`Socket.upgrade` does not compose with a synchronous handler.)
+      # Closing the TLS socket closes the TCP one under it, and the
+      # handler's own close afterwards is a no-op on a closed port.
+      case :ssl.handshake(socket.socket, client_ssl_options(state.certs, host), @head_timeout) do
+        {:ok, client} ->
+          relay = spawn_link(fn -> pump(upstream, client) end)
+          result = serve(client, upstream, host, port, session, "")
+          :ssl.close(upstream)
+          Process.exit(relay, :kill)
+          :ssl.close(client)
+          {result, state}
+
+        {:error, reason} ->
+          Logger.info("broker: sandbox TLS handshake for #{host} failed: #{inspect(reason)}")
+          :ssl.close(upstream)
+          {:close, state}
+      end
+    else
+      {:error, _} -> {:close, state}
+    end
+  end
+
+  # The origin's address, vetted. A sandbox may name any host, and the proxy
+  # sits on the operator's network, so a name that resolves into a private,
+  # loopback or link-local range is refused before any connection exists:
+  # otherwise the broker is a door from a third-party sandbox into the
+  # operator's network. The connection is then made to the vetted address,
+  # not the name, so a rebinding DNS answer between check and dial changes
+  # nothing. Off only for a test rig (`allow_private_upstreams: true`),
+  # whose origins are on localhost.
+  defp resolve(socket, host, port, state) do
+    case :inet.getaddrs(String.to_charlist(host), :inet) do
+      {:ok, [address | _]} ->
+        if private?(address) and not state.allow_private_upstreams do
+          Logger.info("broker: refused #{host}:#{port}: resolves to #{:inet.ntoa(address)}")
+          reply(socket, 403, "Forbidden")
+          {:error, :private_upstream}
+        else
+          {:ok, address}
+        end
+
+      {:error, reason} ->
+        Logger.info("broker: upstream #{host}:#{port} did not resolve: #{inspect(reason)}")
+        reply(socket, 502, "Bad Gateway")
+        {:error, reason}
+    end
+  end
+
+  @doc """
+  Is this an address the proxy must not dial on a sandbox's behalf? RFC
+  1918, loopback, link-local (including the cloud metadata address), CGNAT,
+  and the unspecified address.
+  """
+  @spec private?(:inet.ip4_address()) :: boolean()
+  def private?({10, _, _, _}), do: true
+  def private?({127, _, _, _}), do: true
+  def private?({169, 254, _, _}), do: true
+  def private?({172, b, _, _}) when b in 16..31, do: true
+  def private?({192, 168, _, _}), do: true
+  def private?({100, b, _, _}) when b in 64..127, do: true
+  def private?({0, _, _, _}), do: true
+  def private?(_), do: false
+
+  defp connect_tls(socket, address, host, port, state) do
+    case :ssl.connect(address, port, upstream_ssl_options(host, state), @connect_timeout) do
+      {:ok, _} = ok ->
+        ok
+
+      {:error, reason} ->
+        Logger.info("broker: upstream #{host}:#{port} unreachable: #{inspect(reason)}")
+        reply(socket, 502, "Bad Gateway")
+        {:error, reason}
+    end
+  end
+
+  # Upstream → sandbox, byte for byte. When the origin closes, the sandbox's
+  # side is closed too, which ends `serve/6`.
+  defp pump(upstream, client) do
+    case :ssl.recv(upstream, 0) do
+      {:ok, data} ->
+        case :ssl.send(client, data) do
+          :ok -> pump(upstream, client)
+          {:error, _} -> :ok
+        end
+
+      {:error, _} ->
+        :ssl.close(client)
+        :ok
+    end
+  end
+
+  # Sandbox → upstream, one request at a time: head rewritten, body copied.
+  defp serve(client, upstream, host, port, session, buffer) do
+    case HTTP.parse_request(buffer) do
+      {:ok, head, rest} ->
+        case Injector.inject(head.headers, host, port, head.target, session) do
+          {:ok, headers, rule} ->
+            log_request(session, head, host, {:ok, rule})
+            request = HTTP.encode_request(%{head | headers: headers}, head.target)
+
+            with :ok <- :ssl.send(upstream, request),
+                 {:ok, rest} <- copy_body(client, upstream, HTTP.body_framing(head), rest) do
+              if upgrade?(head),
+                do: pipe(client, upstream, rest),
+                else: serve(client, upstream, host, port, session, rest)
+            else
+              {:error, _} -> :close
+            end
+
+          {:error, :denied} ->
+            log_request(session, head, host, {:error, :denied})
+            reply(client, 403, "Forbidden", [{"connection", "close"}])
+            :close
+        end
+
+      {:more, _} ->
+        case :ssl.recv(client, 0, @idle_timeout) do
+          {:ok, data} -> serve(client, upstream, host, port, session, buffer <> data)
+          {:error, _} -> :close
+        end
+
+      {:error, _} ->
+        reply(client, 400, "Bad Request", [{"connection", "close"}])
+        :close
+    end
+  end
+
+  defp copy_body(client, upstream, framing, buffer) do
+    case HTTP.take_body(framing, buffer) do
+      {:done, bytes, rest} ->
+        send_upstream(upstream, bytes)
+        {:ok, rest}
+
+      {:partial, bytes, framing} ->
+        send_upstream(upstream, bytes)
+
+        case :ssl.recv(client, 0, @idle_timeout) do
+          {:ok, data} -> copy_body(client, upstream, framing, data)
+          {:error, reason} -> {:error, reason}
+        end
+    end
+  end
+
+  # A request that upgrades the connection (WebSocket) is the last HTTP on
+  # it: what follows is frames, so the client side becomes a byte pipe like
+  # the upstream side already is. The upgrade request itself was injected
+  # like any other; frames are never rewritten.
+  defp upgrade?(%{headers: headers}) do
+    case HTTP.header(headers, "upgrade") do
+      nil -> false
+      _ -> true
+    end
+  end
+
+  defp pipe(client, upstream, buffered) do
+    with :ok <- send_upstream(upstream, buffered),
+         {:ok, data} <- :ssl.recv(client, 0, @idle_timeout) do
+      pipe(client, upstream, data)
+    else
+      _ -> :close
+    end
+  end
+
+  defp send_upstream(_upstream, ""), do: :ok
+  defp send_upstream(upstream, bytes), do: :ssl.send(upstream, bytes)
+
+  # ---------------------------------------------------------------------------
+  # Absolute-form: one plain-HTTP request, its response, then close
+
+  defp forward_plain(socket, head, rest, host, port, target, session, state) do
+    with {:ok, headers, rule} <- inject_or_deny(socket, head, host, port, target, session),
+         {:ok, address} <- resolve(socket, host, port, state),
+         {:ok, upstream} <- connect_plain(socket, address, host, port) do
+      log_request(session, head, host, {:ok, rule})
+
+      headers = [
+        {"connection", "close"}
+        | Enum.reject(headers, &(String.downcase(elem(&1, 0)) == "connection"))
+      ]
+
+      :ok = :gen_tcp.send(upstream, HTTP.encode_request(%{head | headers: headers}, target))
+
+      case copy_body_plain(socket, upstream, HTTP.body_framing(head), rest) do
+        :ok -> pump_plain(upstream, socket)
+        {:error, _} -> :ok
+      end
+
+      :gen_tcp.close(upstream)
+      {:close, state}
+    else
+      {:error, _} -> {:close, state}
+    end
+  end
+
+  defp inject_or_deny(socket, head, host, port, target, session) do
+    case Injector.inject(head.headers, host, port, target, session) do
+      {:ok, _, _} = ok ->
+        ok
+
+      {:error, :denied} ->
+        log_request(session, head, host, {:error, :denied})
+        reply(socket, 403, "Forbidden")
+        {:error, :denied}
+    end
+  end
+
+  defp connect_plain(socket, address, host, port) do
+    case :gen_tcp.connect(address, port, [:binary, active: false], @connect_timeout) do
+      {:ok, _} = ok ->
+        ok
+
+      {:error, reason} ->
+        Logger.info("broker: upstream #{host}:#{port} unreachable: #{inspect(reason)}")
+        reply(socket, 502, "Bad Gateway")
+        {:error, reason}
+    end
+  end
+
+  defp copy_body_plain(client, upstream, framing, buffer) do
+    case HTTP.take_body(framing, buffer) do
+      {:done, bytes, _rest} ->
+        if bytes != "", do: :gen_tcp.send(upstream, bytes)
+        :ok
+
+      {:partial, bytes, framing} ->
+        if bytes != "", do: :gen_tcp.send(upstream, bytes)
+
+        case Socket.recv(client, 0, @idle_timeout) do
+          {:ok, data} -> copy_body_plain(client, upstream, framing, data)
+          {:error, reason} -> {:error, reason}
+        end
+    end
+  end
+
+  defp pump_plain(upstream, client) do
+    case :gen_tcp.recv(upstream, 0, @idle_timeout) do
+      {:ok, data} ->
+        case Socket.send(client, data) do
+          :ok -> pump_plain(upstream, client)
+          {:error, _} -> :ok
+        end
+
+      {:error, _} ->
+        :ok
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+
+  # A pure keyword list, so `Keyword.merge` with the host's options works.
+  defp upstream_ssl_options(host, state) do
+    [
+      mode: :binary,
+      active: false,
+      verify: :verify_peer,
+      cacerts: :public_key.cacerts_get(),
+      server_name_indication: String.to_charlist(host),
+      customize_hostname_check: [match_fun: :public_key.pkix_verify_hostname_match_fun(:https)],
+      alpn_advertised_protocols: ["http/1.1"],
+      depth: 5
+    ]
+    |> Keyword.merge(state.upstream_ssl_options)
+  end
+
+  defp client_ssl_options(certs, host) do
+    Certs.for_host(certs, host) ++
+      [
+        alpn_preferred_protocols: ["http/1.1"],
+        reuse_sessions: false,
+        handshake_timeout: @head_timeout
+      ]
+  end
+
+  defp reply(socket, status, reason, headers \\ []) do
+    lines = Enum.map(headers ++ [{"content-length", "0"}], fn {k, v} -> [k, ": ", v, "\r\n"] end)
+    data = ["HTTP/1.1 ", Integer.to_string(status), " ", reason, "\r\n", lines, "\r\n"]
+
+    case socket do
+      %Socket{} -> Socket.send(socket, data)
+      ssl -> :ssl.send(ssl, data)
+    end
+  end
+
+  # The request log: who sent what where, and what the proxy did about it.
+  # Never the headers, never a body. The host's handler writes the line.
+  defp log_request(%Session{meta: meta}, head, host, decision) do
+    {outcome, rule} =
+      case decision do
+        {:ok, nil} -> {:passthrough, nil}
+        {:ok, rule} -> {:injected, rule}
+        {:error, :denied} -> {:denied, nil}
+      end
+
+    :telemetry.execute([:managoat, :broker, :request], %{count: 1}, %{
+      method: head.method,
+      host: host,
+      path: path_only(head.target),
+      outcome: outcome,
+      rule: rule,
+      meta: meta
+    })
+  end
+
+  defp path_only("http://" <> _ = target), do: URI.parse(target).path || "/"
+  defp path_only(target), do: target
+end

--- a/apps/managoat_broker/lib/managoat/broker/rule.ex
+++ b/apps/managoat_broker/lib/managoat/broker/rule.ex
@@ -1,0 +1,64 @@
+defmodule Managoat.Broker.Rule do
+  @moduledoc """
+  One rule of a session: requests to hosts matching `pattern` get this
+  credential, in this shape.
+
+  The host defines what a rule is *for* (a tenant's binding, a catalog
+  default, an allowed host under `deny`) and maps it to one of these at
+  session creation. The proxy sees only the struct, with the credential
+  already resolved to its value: nothing here names a key in some other
+  store.
+
+  ## Patterns
+
+  `host[:port][/path]`. The host may be a `*.example.com` wildcard (matching
+  subdomains, not the apex) and the path a prefix, with a trailing `*`
+  matching the rest. A port pins the request's port; without one any port
+  matches. Matching is case-insensitive on the host and ignores the query.
+
+  ## Schemes
+
+  | `scheme` | fields | effect on a matched request |
+  |---|---|---|
+  | `:bearer` | `credential` (binary) | `Authorization: Bearer <credential>` replaces any `Authorization` header |
+  | `:basic` | `credential` (`{username, password}`) | `Authorization: Basic base64(username:password)` |
+  | `:api_key` | `header` (default `Authorization`), `prefix` (default `""`), `credential` (binary) | `<header>: <prefix><credential>` replaces that header |
+  | `:custom` | `template` (`%{header => "text {{ KEY }}"}`), `credential` (`%{"KEY" => value}`) | each header rendered from its template; a `{{ KEY }}` with no value is left as written |
+  | `:substitute` | `placeholder`, `credential` (binary) | every header *value* has each occurrence of `placeholder` replaced by `credential`; sets no header itself |
+  | `:passthrough` | none | the request is forwarded untouched; under `deny` this is how a host is allowed |
+
+  `:substitute` is the shape for a credential the agent addresses itself
+  (an inference key the runtime sends as `x-api-key`, or as a bearer, in
+  a placeholder it was handed): the proxy does not need to know the header,
+  only the placeholder. It reaches headers only, never the path, query or
+  body, which is one of the deviations from Agent Vault the README lists.
+
+  Several rules may match one request. The first matched rule that sets a
+  header is the one that does; every matched `:substitute` rule applies.
+  """
+
+  @type scheme :: :bearer | :basic | :api_key | :custom | :substitute | :passthrough
+
+  @type t :: %__MODULE__{
+          name: String.t() | nil,
+          pattern: String.t(),
+          scheme: scheme(),
+          credential: term(),
+          header: String.t() | nil,
+          prefix: String.t(),
+          template: %{String.t() => String.t()},
+          placeholder: String.t() | nil
+        }
+
+  @enforce_keys [:pattern, :scheme]
+  defstruct [
+    :name,
+    :pattern,
+    :scheme,
+    :credential,
+    :header,
+    :placeholder,
+    prefix: "",
+    template: %{}
+  ]
+end

--- a/apps/managoat_broker/lib/managoat/broker/session.ex
+++ b/apps/managoat_broker/lib/managoat/broker/session.ex
@@ -1,0 +1,38 @@
+defmodule Managoat.Broker.Session do
+  @moduledoc """
+  What a proxy token resolves to: the rules the proxy may apply, what to do
+  with a host no rule names, when the token stops working, and an opaque
+  `meta` the host fills for its own logging.
+
+  A `Managoat.Broker.Store` returns one of these from `lookup/1` with the
+  credentials inside `rules` already decrypted. How it is stored, hashed,
+  encrypted or swept is the store's business; the proxy looks a token up
+  once per client connection, which is the unit a sandbox's HTTP client
+  pools on.
+
+  `meta` travels unchanged into every `[:managoat, :broker, :request]`
+  telemetry event for a request served under the session, so a host that
+  puts a conversation id and a user id there gets them back on each log
+  line without the library knowing what either is.
+  """
+
+  alias Managoat.Broker.Rule
+
+  @type policy :: :passthrough | :deny
+
+  @type t :: %__MODULE__{
+          rules: [Rule.t()],
+          unmatched_host_policy: policy(),
+          expires_at: DateTime.t() | nil,
+          meta: map()
+        }
+
+  defstruct rules: [], unmatched_host_policy: :passthrough, expires_at: nil, meta: %{}
+
+  @doc "True when `expires_at` is set and in the past."
+  @spec expired?(t(), DateTime.t()) :: boolean()
+  def expired?(%__MODULE__{expires_at: nil}, _now), do: false
+
+  def expired?(%__MODULE__{expires_at: %DateTime{} = at}, now),
+    do: DateTime.compare(at, now) == :lt
+end

--- a/apps/managoat_broker/lib/managoat/broker/store.ex
+++ b/apps/managoat_broker/lib/managoat/broker/store.ex
@@ -1,0 +1,47 @@
+defmodule Managoat.Broker.Store do
+  @moduledoc """
+  The one thing the proxy needs from the host at request time: a session
+  for a token.
+
+  A sandbox dials the proxy with `Proxy-Authorization: Basic
+  base64(token:label)`. The proxy hands the raw `token` to the store and
+  serves the connection under the `Managoat.Broker.Session` it gets back,
+  or refuses it with 407. Everything else about sessions (creating one,
+  hashing the token before storing it, encrypting the rules, releasing a
+  conversation's sessions, sweeping expired rows) is the host's business:
+  it touches the host's tables and its key hierarchy, and the proxy never
+  needs any of it.
+
+  The `label` half of the credential is not passed on. It exists because
+  some clients (git) refuse a proxy URL with a user and no password; with a
+  random per-session token the token alone is the binding.
+
+  ## Configuring the store
+
+  The listener's `store:` option is either a module implementing this
+  behaviour, called as `module.lookup(token)`, or a `{module, instance}`
+  pair, called as `module.lookup(instance, token)` for a store that has
+  several instances (the in-memory store in a test, one per listener).
+
+  `Managoat.Broker.Store.Memory` is the reference store: an in-memory map,
+  for tests and for a consumer without a database.
+  """
+
+  alias Managoat.Broker.Session
+
+  @doc "The session for a raw token, or `:error` for a token the store does not know."
+  @callback lookup(token :: binary()) :: {:ok, Session.t()} | :error
+
+  @doc "The same, for a store with several instances (see the moduledoc)."
+  @callback lookup(instance :: term(), token :: binary()) :: {:ok, Session.t()} | :error
+
+  @optional_callbacks lookup: 1, lookup: 2
+
+  @typedoc "What the listener's `store:` option accepts."
+  @type ref :: module() | {module(), term()}
+
+  @doc false
+  @spec lookup(ref(), binary()) :: {:ok, Session.t()} | :error
+  def lookup(module, token) when is_atom(module), do: module.lookup(token)
+  def lookup({module, instance}, token) when is_atom(module), do: module.lookup(instance, token)
+end

--- a/apps/managoat_broker/lib/managoat/broker/store/memory.ex
+++ b/apps/managoat_broker/lib/managoat/broker/store/memory.ex
@@ -1,0 +1,58 @@
+defmodule Managoat.Broker.Store.Memory do
+  @moduledoc """
+  The reference `Managoat.Broker.Store`: sessions in an `Agent`, keyed by
+  token.
+
+  For the library's own tests and for a consumer without a database. Start
+  one per listener (`{Managoat.Broker.Store.Memory, name: MyStore}`) and
+  point the listener at it with `store: {Managoat.Broker.Store.Memory,
+  MyStore}`; or start it under its default name and use the bare module.
+
+  Tokens are stored as given. A store that persists them should hash first
+  (`Managoat.Broker.Store` says why that is the host's choice).
+  """
+
+  @behaviour Managoat.Broker.Store
+
+  use Agent
+
+  alias Managoat.Broker.Session
+
+  @doc "Start a store. `name:` defaults to this module."
+  @spec start_link(keyword()) :: Agent.on_start()
+  def start_link(opts \\ []) do
+    Agent.start_link(fn -> %{} end, name: Keyword.get(opts, :name, __MODULE__))
+  end
+
+  @doc "Bind `token` to `session`. Replaces an existing binding."
+  @spec put(Agent.agent(), binary(), Session.t()) :: :ok
+  def put(store \\ __MODULE__, token, %Session{} = session) when is_binary(token) do
+    Agent.update(store, &Map.put(&1, token, session))
+  end
+
+  @doc "Forget `token`."
+  @spec delete(Agent.agent(), binary()) :: :ok
+  def delete(store \\ __MODULE__, token) when is_binary(token) do
+    Agent.update(store, &Map.delete(&1, token))
+  end
+
+  @doc "Every token the store holds."
+  @spec tokens(Agent.agent()) :: [binary()]
+  def tokens(store \\ __MODULE__), do: Agent.get(store, &Map.keys/1)
+
+  @doc "Mint a random token (`mb_` + 43 url-safe base64 characters)."
+  @spec generate_token() :: binary()
+  def generate_token,
+    do: "mb_" <> Base.url_encode64(:crypto.strong_rand_bytes(32), padding: false)
+
+  @impl Managoat.Broker.Store
+  def lookup(token), do: lookup(__MODULE__, token)
+
+  @impl Managoat.Broker.Store
+  def lookup(store, token) when is_binary(token) do
+    case Agent.get(store, &Map.fetch(&1, token)) do
+      {:ok, %Session{} = session} -> {:ok, session}
+      :error -> :error
+    end
+  end
+end

--- a/apps/managoat_broker/mix.exs
+++ b/apps/managoat_broker/mix.exs
@@ -1,0 +1,76 @@
+defmodule Managoat.Broker.MixProject do
+  use Mix.Project
+
+  @version "0.1.0"
+  @source_url "https://github.com/BinaryBourbon/fountain/tree/main/apps/managoat_broker"
+
+  def project do
+    [
+      app: :managoat_broker,
+      version: @version,
+      # Umbrella-first (decisions/0037): this app builds into the umbrella's
+      # _build and deps and shares its lockfile while it lives here. The three
+      # path lines go when it graduates to a managoat/<name> repository.
+      #
+      # Deliberately no `config_path` pointing at the umbrella's config: that
+      # config is Fountain's (config/runtime.exs calls Fountain modules), and
+      # this library reads no configuration at all. Everything the listener
+      # needs (the port, the session store, the CA seed) is a start argument,
+      # because the host computed those values at boot and a library that is
+      # not started serves nothing. Run from this directory the app boots
+      # with no config, which is what a consumer of the hex package gets too.
+      build_path: "../../_build",
+      deps_path: "../../deps",
+      lockfile: "../../mix.lock",
+      elixir: "~> 1.18",
+      elixirc_paths: elixirc_paths(Mix.env()),
+      start_permanent: Mix.env() == :prod,
+      deps: deps(),
+      description:
+        "An egress credential proxy for sandboxed agents: CONNECT and absolute-form forward proxy that attaches the real credential where the sandbox sent a placeholder, behind a session-store behaviour.",
+      package: package(),
+      test_coverage: [
+        # What this suite measures on its own: the proxy end to end against a
+        # real Bandit HTTPS origin, the CA, the injector, the HTTP slice and
+        # the in-memory store. Raise it as the library's own tests grow;
+        # never lower it.
+        summary: [threshold: 85]
+      ]
+    ]
+  end
+
+  def application do
+    [extra_applications: [:logger, :ssl, :public_key, :crypto]]
+  end
+
+  # The end-to-end rig (a Bandit origin, the sandbox-shaped client) is test
+  # support, not part of the package.
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
+
+  defp deps do
+    [
+      # The listener. Bandit sits on the same library, so a Phoenix host
+      # already has it; it is named here because the proxy handler is written
+      # against it directly.
+      {:thousand_island, "~> 1.5"},
+      # Certificate building for the derived root and the per-host leaves.
+      # Pure Elixir over :public_key.
+      {:x509, "~> 0.9"},
+      {:telemetry, "~> 1.0"},
+      # Test only: a real HTTPS origin behind the proxy, a WebSocket echo on
+      # it, and JSON for what the origin echoes back.
+      {:bandit, "~> 1.5", only: :test},
+      {:websock_adapter, "~> 0.5", only: :test},
+      {:jason, "~> 1.2", only: :test}
+    ]
+  end
+
+  defp package do
+    [
+      licenses: ["Apache-2.0"],
+      links: %{"GitHub" => @source_url},
+      files: ~w(lib mix.exs README.md LICENSE)
+    ]
+  end
+end

--- a/apps/managoat_broker/test/managoat/broker/agent_vault_parity_test.exs
+++ b/apps/managoat_broker/test/managoat/broker/agent_vault_parity_test.exs
@@ -1,0 +1,201 @@
+defmodule Managoat.Broker.AgentVaultParityTest do
+  # The behaviours Fountain relied on from Agent Vault 0.39.1, replayed
+  # against this proxy. Each test names the upstream test it stands in for
+  # (internal/mitm/proxy_test.go and forward_test.go in
+  # Infisical/agent-vault), so a gap between the two is a missing test here,
+  # not a guess. What is deliberately NOT ported is listed at the bottom.
+  use Managoat.Broker.ProxyCase, async: true
+
+  setup do
+    ctx = start_rig()
+
+    session = %Session{
+      rules: [
+        %Rule{name: "origin", pattern: "localhost", scheme: :bearer, credential: "real-secret"}
+      ],
+      unmatched_host_policy: :passthrough,
+      expires_at: DateTime.add(DateTime.utc_now(), 600, :second),
+      meta: %{conversation_id: "conv-parity"}
+    }
+
+    Map.merge(ctx, %{token: put_session(ctx, session), session: session})
+  end
+
+  defp read_json(tls, acc \\ "") do
+    {:ok, data} = :ssl.recv(tls, 0, 5_000)
+    acc = acc <> data
+
+    with [head, body] <- String.split(acc, "\r\n\r\n", parts: 2),
+         [_, len] <- Regex.run(~r/content-length: (\d+)/i, head),
+         true <- byte_size(body) >= String.to_integer(len) do
+      Jason.decode!(binary_part(body, 0, String.to_integer(len)))
+    else
+      _ -> read_json(tls, acc)
+    end
+  end
+
+  # TestMITMInjectsCredentials
+  test "the credential is attached where the client sent a placeholder", ctx do
+    tls = tunnel(ctx, ctx.token)
+
+    :ok =
+      :ssl.send(
+        tls,
+        "GET /a HTTP/1.1\r\nHost: localhost\r\nAuthorization: Bearer __key__\r\n\r\n"
+      )
+
+    assert %{"headers" => %{"authorization" => "Bearer real-secret"}} = read_json(tls)
+  end
+
+  # TestMITMForwardStripsHopByHopHeaders / TestMITMBearerForwardsArbitraryClientHeaders
+  test "proxy headers are stripped; every other client header is forwarded", ctx do
+    tls = tunnel(ctx, ctx.token)
+
+    :ok =
+      :ssl.send(
+        tls,
+        "GET /h HTTP/1.1\r\nHost: localhost\r\nProxy-Authorization: Basic leak\r\n" <>
+          "Proxy-Connection: keep-alive\r\nX-Custom: yes\r\nUser-Agent: sandbox/1\r\n\r\n"
+      )
+
+    %{"headers" => headers} = read_json(tls)
+    refute Map.has_key?(headers, "proxy-authorization")
+    refute Map.has_key?(headers, "proxy-connection")
+    assert headers["x-custom"] == "yes"
+    assert headers["user-agent"] == "sandbox/1"
+  end
+
+  # TestMITMForwardKeepalivePersistsAcrossRequests
+  test "keep-alive: the injection happens on every request of a tunnel", ctx do
+    tls = tunnel(ctx, ctx.token)
+
+    for n <- 1..3 do
+      :ok = :ssl.send(tls, "GET /#{n} HTTP/1.1\r\nHost: localhost\r\n\r\n")
+      path = "/#{n}"
+
+      assert %{"path" => ^path, "headers" => %{"authorization" => "Bearer real-secret"}} =
+               read_json(tls)
+    end
+  end
+
+  # TestMITMForwardStreamsChunksPromptly
+  test "a streaming response is relayed chunk by chunk, not buffered to the end", ctx do
+    tls = tunnel(ctx, ctx.token)
+    stream = "parity_stream_#{System.unique_integer([:positive])}"
+
+    :ok =
+      :ssl.send(
+        tls,
+        "GET /stream HTTP/1.1\r\nHost: localhost\r\nX-Stream-Name: #{stream}\r\n\r\n"
+      )
+
+    first = recv_until(tls, "data: first")
+    refute first =~ "data: second"
+
+    # Release the origin's second chunk and see it arrive.
+    send(String.to_atom(stream), :continue)
+
+    assert recv_until(tls, "data: second") =~ "data: second"
+  end
+
+  # TestMITMUpstreamCertUntrusted
+  test "an origin whose certificate is not trusted is a 502, and no tunnel opens", ctx do
+    {_tcp, reply} = connect(ctx, "localhost:#{ctx.untrusted_port}", proxy_auth(ctx.token))
+    assert reply =~ "HTTP/1.1 502"
+  end
+
+  # TestMITMPassthroughForwardsClientAuthorization
+  test "an unmatched host keeps the client's own authorization header", ctx do
+    Memory.put(ctx.store, ctx.token, %{ctx.session | rules: []})
+    tls = tunnel(ctx, ctx.token)
+
+    :ok =
+      :ssl.send(tls, "GET /p HTTP/1.1\r\nHost: localhost\r\nAuthorization: Bearer mine\r\n\r\n")
+
+    assert %{"headers" => %{"authorization" => "Bearer mine"}} = read_json(tls)
+  end
+
+  # TestMITMUnknownHostInTunnel (deny mode)
+  test "deny: an unmatched host is 403 inside the tunnel", ctx do
+    # A rule for one path of the host lets the tunnel open; the request
+    # below is to another path, so it is unmatched inside the tunnel.
+    Memory.put(ctx.store, ctx.token, %{
+      ctx.session
+      | rules: [%Rule{name: "narrow", pattern: "localhost/allowed/*", scheme: :passthrough}],
+        unmatched_host_policy: :deny
+    })
+
+    tls = tunnel(ctx, ctx.token)
+    :ok = :ssl.send(tls, "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")
+    {:ok, reply} = :ssl.recv(tls, 0, 5_000)
+    assert reply =~ "HTTP/1.1 403"
+  end
+
+  # Beyond Agent Vault, for a `limited` network policy: under deny a host no
+  # rule names is refused at CONNECT, so no tunnel and no TLS handshake
+  # happen for it.
+  test "deny: a host no rule names is 403 at CONNECT", ctx do
+    Memory.put(ctx.store, ctx.token, %{
+      ctx.session
+      | rules: [%Rule{name: "x", pattern: "api.example.com", scheme: :passthrough}],
+        unmatched_host_policy: :deny
+    })
+
+    {_tcp, reply} = connect(ctx, "localhost:#{ctx.https_port}", proxy_auth(ctx.token))
+    assert reply =~ "HTTP/1.1 403"
+  end
+
+  # TestMITMMissingProxyAuth / TestMITMInvalidSession
+  test "no token and a bad token are refused with 407", ctx do
+    for auth <- [nil, proxy_auth("mb_bad")] do
+      {_tcp, reply} = connect(ctx, "localhost:#{ctx.https_port}", auth)
+      assert reply =~ "HTTP/1.1 407"
+    end
+  end
+
+  # TestMITMWebSocketInjectsCredentialsAndPipesFrames (the header half: the
+  # upgrade request is injected like any other; frames are piped as bytes,
+  # never rewritten, see the list at the bottom)
+  test "a WebSocket upgrade through the tunnel carries the injected header, and frames flow",
+       ctx do
+    tls = tunnel(ctx, ctx.token)
+    key = Base.encode64(:crypto.strong_rand_bytes(16))
+
+    :ok =
+      :ssl.send(
+        tls,
+        "GET /ws HTTP/1.1\r\nHost: localhost\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n" <>
+          "Sec-WebSocket-Key: #{key}\r\nSec-WebSocket-Version: 13\r\nAuthorization: Bearer __key__\r\n\r\n"
+      )
+
+    {:ok, reply} = :ssl.recv(tls, 0, 5_000)
+    assert reply =~ "HTTP/1.1 101"
+
+    # One masked text frame: "hi".
+    mask = <<1, 2, 3, 4>>
+    payload = :crypto.exor("hi", binary_part(mask, 0, 2))
+    :ok = :ssl.send(tls, <<0x81, 0x82>> <> mask <> payload)
+
+    {:ok, frame} = :ssl.recv(tls, 0, 5_000)
+    <<0x81, len, text::binary-size(len)>> = frame
+    assert text == "Bearer real-secret|hi"
+  end
+
+  # Not ported, on purpose:
+  # - TestMITMSubstitution* (placeholder rewriting in path, query, body and
+  #   arbitrary headers): the `:substitute` rule reaches header values only,
+  #   which covers an inference key a runtime sends as a bearer or an
+  #   `x-api-key`; a credential a client puts in the URL is not brokered.
+  # - TestCopyWSFrames* (credential substitution inside WebSocket frames).
+  # - TestMITM*RateLimit* (auth-failure rate limiting on the proxy port).
+  # - TestResponseLimit* / TestRequestBodyCap* (body size caps; Agent Vault's
+  #   response cap was unlimited by default too).
+  # - TestMITMForwardIPv6PreservesHostHeader: the proxy resolves IPv4 only.
+  # - TestMITMPortBasedRouting, TestMITMAmbiguousAgentVault: Agent Vault's
+  #   multi-vault selection, which a per-conversation token makes moot.
+  # - TestMITMVaultHintMismatch: Agent Vault refused a valid token presented
+  #   with another vault's name. Here the token is the whole binding and the
+  #   label half of the proxy credential is not consulted (the store's
+  #   moduledoc says why it exists at all), so there is no mismatch to test;
+  #   proxy_test.exs asserts the label is ignored.
+end

--- a/apps/managoat_broker/test/managoat/broker/broker_test.exs
+++ b/apps/managoat_broker/test/managoat/broker/broker_test.exs
@@ -1,0 +1,59 @@
+defmodule Managoat.BrokerTest do
+  # The listener's child spec: what it requires, and what it exposes once up.
+  use ExUnit.Case, async: true
+
+  alias Managoat.Broker
+  alias Managoat.Broker.CA
+  alias Managoat.Broker.Store.Memory
+
+  @seed :crypto.hash(:sha256, "broker test seed")
+
+  test "every required option is named when missing" do
+    for {missing, opts} <- [
+          {:port, [store: Memory, ca_seed: @seed]},
+          {:store, [port: 0, ca_seed: @seed]},
+          {:ca_seed, [port: 0, store: Memory]}
+        ] do
+      assert_raise ArgumentError, ~r/#{inspect(missing)}/, fn -> Broker.start_link(opts) end
+    end
+  end
+
+  test "a seed that is not 32 bytes is refused before anything listens" do
+    assert_raise ArgumentError, ~r/32 bytes/, fn ->
+      Broker.start_link(port: 0, store: Memory, ca_seed: "short")
+    end
+  end
+
+  test "up, it reports its port, that it runs, and the root it signs with" do
+    name = :"broker_#{System.unique_integer([:positive])}"
+    refute Broker.running?(name)
+
+    start_supervised!({Broker, name: name, port: 0, store: Memory, ca_seed: @seed})
+
+    assert Broker.running?(name)
+    assert Broker.port(name) > 0
+    assert Broker.ca_pem_for_seed(@seed) =~ "BEGIN CERTIFICATE"
+
+    # The PEM bytes vary per derivation (randomised self-signature); the
+    # anchor does not.
+    assert anchor(Broker.ca_pem(name)) == anchor(CA.pem(@seed))
+  end
+
+  test "the child spec is keyed by name, so two listeners coexist in one tree" do
+    a = :"broker_#{System.unique_integer([:positive])}"
+    b = :"broker_#{System.unique_integer([:positive])}"
+
+    assert %{id: ^a, type: :supervisor} = Broker.child_spec(name: a, port: 0)
+    assert %{id: Managoat.Broker} = Broker.child_spec(port: 0)
+
+    start_supervised!({Broker, name: a, port: 0, store: Memory, ca_seed: @seed})
+    start_supervised!({Broker, name: b, port: 0, store: Memory, ca_seed: @seed})
+    refute Broker.port(a) == Broker.port(b)
+  end
+
+  defp anchor(pem) do
+    [{:Certificate, der, :not_encrypted}] = :public_key.pem_decode(pem)
+    cert = X509.Certificate.from_der!(der)
+    {X509.Certificate.subject(cert), X509.Certificate.public_key(cert)}
+  end
+end

--- a/apps/managoat_broker/test/managoat/broker/ca_test.exs
+++ b/apps/managoat_broker/test/managoat/broker/ca_test.exs
@@ -1,0 +1,68 @@
+defmodule Managoat.Broker.CATest do
+  use ExUnit.Case, async: true
+
+  alias Managoat.Broker.{CA, Certs}
+
+  @seed :crypto.hash(:sha256, "a fixed seed for the CA tests")
+
+  # What a trust anchor is matched on. The self-signature is not in here:
+  # ECDSA signing is randomised, so it differs per derivation, and no client
+  # consults it.
+  defp anchor(der) do
+    cert = X509.Certificate.from_der!(der)
+
+    {X509.Certificate.subject(cert), X509.Certificate.public_key(cert),
+     X509.Certificate.serial(cert)}
+  end
+
+  test "the root is derived from the seed: same seed, same anchor" do
+    assert anchor(CA.der(@seed)) == anchor(CA.der(@seed))
+  end
+
+  test "a leaf signed by a re-derivation still chains to the first root" do
+    root = CA.der(@seed)
+    [cert: leaf, key: _] = CA.leaf("github.com", CA.root(@seed))
+    assert {:ok, _} = :public_key.pkix_path_validation(root, [leaf], [])
+  end
+
+  test "a different seed is a different CA" do
+    refute anchor(CA.der(@seed)) == anchor(CA.der(:crypto.strong_rand_bytes(32)))
+  end
+
+  test "the root is a CA and a leaf for a host chains to it" do
+    root = CA.der(@seed)
+    [cert: leaf, key: {:ECPrivateKey, _}] = CA.leaf("api.github.com", CA.root(@seed))
+
+    assert {:ok, _} = :public_key.pkix_path_validation(root, [leaf], [])
+
+    otp = X509.Certificate.from_der!(leaf)
+    assert X509.Certificate.subject(otp) |> X509.RDNSequence.to_string() =~ "api.github.com"
+
+    {:Extension, _, _, names} = X509.Certificate.extension(otp, :subject_alt_name)
+    assert {:dNSName, ~c"api.github.com"} in names
+  end
+
+  test "the PEM is one certificate" do
+    assert [{:Certificate, _, :not_encrypted}] = :public_key.pem_decode(CA.pem(@seed))
+  end
+
+  test "a seed that is not 32 bytes is refused by name" do
+    assert_raise ArgumentError, ~r/32 bytes/, fn -> CA.root("short") end
+  end
+
+  describe "Certs" do
+    test "caches a leaf per host and hands the root back" do
+      table = Certs.new(@seed)
+
+      assert anchor(Certs.ca_der(table)) == anchor(CA.der(@seed))
+      assert Certs.ca_pem(table) =~ "BEGIN CERTIFICATE"
+
+      first = Certs.for_host(table, "api.github.com")
+      assert first == Certs.for_host(table, "api.github.com")
+      refute first == Certs.for_host(table, "github.com")
+
+      assert {:ok, _} =
+               :public_key.pkix_path_validation(Certs.ca_der(table), [first[:cert]], [])
+    end
+  end
+end

--- a/apps/managoat_broker/test/managoat/broker/http_test.exs
+++ b/apps/managoat_broker/test/managoat/broker/http_test.exs
@@ -1,0 +1,105 @@
+defmodule Managoat.Broker.HTTPTest do
+  use ExUnit.Case, async: true
+
+  alias Managoat.Broker.HTTP
+
+  describe "parse_request/1" do
+    test "a CONNECT head" do
+      raw =
+        "CONNECT api.github.com:443 HTTP/1.1\r\nHost: api.github.com:443\r\nProxy-Authorization: Basic x\r\n\r\ntail"
+
+      assert {:ok, head, "tail"} = HTTP.parse_request(raw)
+      assert head.method == "CONNECT"
+      assert head.target == "api.github.com:443"
+      assert head.version == {1, 1}
+      assert head.headers == [{"Host", "api.github.com:443"}, {"Proxy-Authorization", "Basic x"}]
+      assert {:ok, {"api.github.com", 443}, "api.github.com:443"} = HTTP.destination(head)
+    end
+
+    test "an absolute-form GET, and its origin-form target" do
+      raw =
+        "GET http://deb.debian.org/debian/dists/x?y=1 HTTP/1.1\r\nHost: deb.debian.org\r\n\r\n"
+
+      assert {:ok, head, ""} = HTTP.parse_request(raw)
+      assert head.method == "GET"
+      assert {:ok, {"deb.debian.org", 80}, "/debian/dists/x?y=1"} = HTTP.destination(head)
+    end
+
+    test "an absolute-form target with no path is the root" do
+      {:ok, head, ""} =
+        HTTP.parse_request("GET http://h.example HTTP/1.1\r\nHost: h.example\r\n\r\n")
+
+      assert {:ok, {"h.example", 80}, "/"} = HTTP.destination(head)
+    end
+
+    test "an origin-form request inside a tunnel" do
+      raw = "POST /repos HTTP/1.1\r\nHost: api.github.com\r\nContent-Length: 2\r\n\r\n{}"
+
+      assert {:ok, head, "{}"} = HTTP.parse_request(raw)
+      assert head.target == "/repos"
+      assert HTTP.body_framing(head) == {:length, 2}
+      assert {:error, :bad_target} = HTTP.destination(head)
+    end
+
+    test "an incomplete head asks for more, keeping the buffer" do
+      assert {:more, _} = HTTP.parse_request("GET /x HTTP/1.1\r\nHost: a")
+      assert {:more, _} = HTTP.parse_request("GET /x HT")
+    end
+
+    test "garbage is an error" do
+      assert {:error, _} = HTTP.parse_request("\x16\x03\x01 not http\r\n\r\n")
+    end
+
+    test "a bad CONNECT authority" do
+      {:ok, head, _} = HTTP.parse_request("CONNECT nope HTTP/1.1\r\n\r\n")
+      assert {:error, :bad_target} = HTTP.destination(head)
+
+      {:ok, head, _} = HTTP.parse_request("CONNECT h:99999 HTTP/1.1\r\n\r\n")
+      assert {:error, :bad_target} = HTTP.destination(head)
+    end
+  end
+
+  test "encode_request round-trips a head with the target substituted" do
+    {:ok, head, _} = HTTP.parse_request("GET http://h/p HTTP/1.1\r\nHost: h\r\nX: y\r\n\r\n")
+
+    assert IO.iodata_to_binary(HTTP.encode_request(head, "/p")) ==
+             "GET /p HTTP/1.1\r\nHost: h\r\nX: y\r\n\r\n"
+  end
+
+  test "body_framing reads chunked before content-length, and none when neither" do
+    {:ok, chunked, _} =
+      HTTP.parse_request("POST / HTTP/1.1\r\nTransfer-Encoding: gzip, chunked\r\n\r\n")
+
+    assert HTTP.body_framing(chunked) == :chunked
+
+    {:ok, none, _} = HTTP.parse_request("GET / HTTP/1.1\r\nHost: h\r\n\r\n")
+    assert HTTP.body_framing(none) == :none
+  end
+
+  describe "take_body/2" do
+    test "no body" do
+      assert {:done, "", "next"} = HTTP.take_body(:none, "next")
+    end
+
+    test "content-length, whole and in pieces" do
+      assert {:done, "abc", "d"} = HTTP.take_body({:length, 3}, "abcd")
+      assert {:partial, "ab", {:length, 1}} = HTTP.take_body({:length, 3}, "ab")
+      assert {:done, "c", ""} = HTTP.take_body({:length, 1}, "c")
+    end
+
+    test "chunked, forwarded verbatim through to the trailers" do
+      body = "3\r\nabc\r\n2;ext=1\r\nde\r\n0\r\n\r\n"
+      assert {:done, ^body, "NEXT"} = HTTP.take_body(:chunked, body <> "NEXT")
+    end
+
+    test "chunked, split at every awkward point" do
+      body = "3\r\nabc\r\n2\r\nde\r\n0\r\nTrailer: t\r\n\r\n"
+
+      for cut <- 1..(byte_size(body) - 1) do
+        <<a::binary-size(cut), b::binary>> = body
+        assert {:partial, ^a, state} = HTTP.take_body(:chunked, a)
+        assert {:done, ^b, "X"} = HTTP.take_body(state, b <> "X")
+      end
+    end
+  end
+end

--- a/apps/managoat_broker/test/managoat/broker/injector_test.exs
+++ b/apps/managoat_broker/test/managoat/broker/injector_test.exs
@@ -1,0 +1,200 @@
+defmodule Managoat.Broker.InjectorTest do
+  use ExUnit.Case, async: true
+
+  alias Managoat.Broker.{Injector, Rule, Session}
+
+  @session %Session{
+    rules: [
+      %Rule{
+        name: "github-api",
+        pattern: "api.github.com",
+        scheme: :bearer,
+        credential: "ghp_real"
+      },
+      %Rule{
+        name: "github-git",
+        pattern: "github.com",
+        scheme: :basic,
+        credential: {"x-access-token", "ghp_real"}
+      },
+      %Rule{
+        name: "anthropic",
+        pattern: "api.anthropic.com",
+        scheme: :api_key,
+        header: "x-api-key",
+        credential: "sk-ant-real"
+      },
+      %Rule{
+        name: "discord",
+        pattern: "discord.com/api/*",
+        scheme: :api_key,
+        prefix: "Bot ",
+        credential: "disc"
+      },
+      %Rule{
+        name: "pagerduty",
+        pattern: "api.pagerduty.com",
+        scheme: :custom,
+        template: %{
+          "Authorization" => "Token token={{ PAGERDUTY_TOKEN }}",
+          "X-Missing" => "{{ NOT_A_KEY }}"
+        },
+        credential: %{"PAGERDUTY_TOKEN" => "pd"}
+      },
+      %Rule{
+        name: "openai-sub",
+        pattern: "api.openai.com",
+        scheme: :substitute,
+        placeholder: "sk-__openai_api_key__",
+        credential: "sk-real-openai"
+      },
+      %Rule{
+        name: "allowed",
+        pattern: "registry.npmjs.org",
+        scheme: :passthrough
+      }
+    ],
+    unmatched_host_policy: :passthrough
+  }
+
+  @headers [
+    {"Host", "api.github.com"},
+    {"Proxy-Authorization", "Basic abc"},
+    {"Authorization", "Bearer __github_token__"},
+    {"Accept", "application/json"}
+  ]
+
+  defp inject(headers, host, path \\ "/", session \\ @session),
+    do: Injector.inject(headers, host, 443, path, session)
+
+  test "a bearer rule replaces the authorization header wholesale" do
+    assert {:ok, headers, "github-api"} = inject(@headers, "api.github.com")
+
+    assert {"authorization", "Bearer ghp_real"} in headers
+    refute Enum.any?(headers, fn {k, _} -> String.downcase(k) == "proxy-authorization" end)
+    assert Enum.count(headers, fn {k, _} -> String.downcase(k) == "authorization" end) == 1
+    assert {"Accept", "application/json"} in headers
+  end
+
+  test "a basic rule encodes username and password" do
+    {:ok, headers, "github-git"} = inject(@headers, "github.com")
+    assert {"authorization", "Basic " <> Base.encode64("x-access-token:ghp_real")} in headers
+  end
+
+  test "an api-key rule writes its own header, and leaves authorization alone" do
+    headers = [{"x-api-key", "__anthropic_api_key__"}, {"Authorization", "Bearer keep"}]
+    {:ok, out, "anthropic"} = inject(headers, "api.anthropic.com")
+
+    assert {"x-api-key", "sk-ant-real"} in out
+    assert {"Authorization", "Bearer keep"} in out
+    refute {"x-api-key", "__anthropic_api_key__"} in out
+  end
+
+  test "an api-key rule with a prefix and no header writes Authorization with the prefix" do
+    {:ok, out, "discord"} = inject(@headers, "discord.com", "/api/v10/users/@me")
+    assert {"Authorization", "Bot disc"} in out
+    refute {"Authorization", "Bearer __github_token__"} in out
+  end
+
+  test "a custom rule renders every {{ KEY }} it holds and leaves one it does not" do
+    {:ok, out, "pagerduty"} = inject(@headers, "api.pagerduty.com")
+    assert {"Authorization", "Token token=pd"} in out
+    assert {"X-Missing", "{{ NOT_A_KEY }}"} in out
+  end
+
+  test "a substitute rule replaces the placeholder wherever a header value carries it" do
+    headers = [
+      {"Host", "api.openai.com"},
+      {"Authorization", "Bearer sk-__openai_api_key__"},
+      {"X-Also", "prefix sk-__openai_api_key__ suffix"},
+      {"X-Other", "untouched"}
+    ]
+
+    {:ok, out, "openai-sub"} = inject(headers, "api.openai.com")
+    assert {"Authorization", "Bearer sk-real-openai"} in out
+    assert {"X-Also", "prefix sk-real-openai suffix"} in out
+    assert {"X-Other", "untouched"} in out
+  end
+
+  test "a substitute rule and a header rule on one host both apply; the first names the outcome" do
+    session = %Session{
+      rules: [
+        %Rule{
+          name: "sub",
+          pattern: "api.anthropic.com",
+          scheme: :substitute,
+          placeholder: "__oauth__",
+          credential: "oauth-real"
+        },
+        %Rule{
+          name: "key",
+          pattern: "api.anthropic.com",
+          scheme: :api_key,
+          header: "x-api-key",
+          credential: "sk-real"
+        }
+      ]
+    }
+
+    headers = [{"Authorization", "Bearer __oauth__"}, {"x-api-key", "__key__"}]
+    {:ok, out, "sub"} = inject(headers, "api.anthropic.com", "/v1/messages", session)
+    assert {"Authorization", "Bearer oauth-real"} in out
+    assert {"x-api-key", "sk-real"} in out
+  end
+
+  test "a passthrough rule forwards the request untouched but for the hop-by-hop headers" do
+    {:ok, out, "allowed"} = inject(@headers, "registry.npmjs.org")
+    assert {"Authorization", "Bearer __github_token__"} in out
+    refute Enum.any?(out, fn {k, _} -> k == "Proxy-Authorization" end)
+  end
+
+  test "an unmatched host passes through with only the hop-by-hop headers dropped" do
+    {:ok, headers, nil} = inject(@headers, "example.com")
+
+    assert {"Authorization", "Bearer __github_token__"} in headers
+    refute Enum.any?(headers, fn {k, _} -> k == "Proxy-Authorization" end)
+  end
+
+  test "deny refuses an unmatched host and lets a passthrough rule allow one" do
+    session = %{@session | unmatched_host_policy: :deny}
+    assert {:error, :denied} = inject(@headers, "example.com", "/", session)
+    assert {:ok, _, "github-api"} = inject(@headers, "api.github.com", "/", session)
+    assert {:ok, _, "allowed"} = inject(@headers, "registry.npmjs.org", "/", session)
+  end
+
+  test "the match is on the exact host: api.github.com is not github.com" do
+    {:ok, _, "github-git"} = inject(@headers, "github.com")
+    {:ok, _, nil} = inject(@headers, "gist.github.com")
+  end
+
+  describe "matches?/4" do
+    test "host, case-insensitively, any port" do
+      assert Injector.matches?("api.stripe.com", "API.Stripe.com", 443, "/v1")
+      refute Injector.matches?("api.stripe.com", "stripe.com", 443, "/")
+    end
+
+    test "a wildcard host matches subdomains only" do
+      assert Injector.matches?("*.atlassian.net", "acme.atlassian.net", 443, "/")
+      refute Injector.matches?("*.atlassian.net", "atlassian.net", 443, "/")
+    end
+
+    test "a port pins the port" do
+      assert Injector.matches?("db.example.com:8443", "db.example.com", 8443, "/")
+      refute Injector.matches?("db.example.com:8443", "db.example.com", 443, "/")
+    end
+
+    test "a path is a prefix; a trailing * matches the rest; the query is ignored" do
+      assert Injector.matches?("discord.com/api/*", "discord.com", 443, "/api/v10/x?y=1")
+      refute Injector.matches?("discord.com/api/*", "discord.com", 443, "/oauth2")
+      assert Injector.matches?("h.example/v1", "h.example", 443, "/v1")
+      assert Injector.matches?("h.example/v1", "h.example", 443, "/v1/users")
+      refute Injector.matches?("h.example/v1", "h.example", 443, "/v10")
+    end
+  end
+
+  test "host_matches?/3 ignores the path part of the pattern" do
+    assert Injector.host_matches?("discord.com/api/*", "discord.com", 443)
+    refute Injector.host_matches?("discord.com:8443/api/*", "discord.com", 443)
+    refute Injector.host_matches?("api.example.com", "example.com", 443)
+  end
+end

--- a/apps/managoat_broker/test/managoat/broker/proxy_test.exs
+++ b/apps/managoat_broker/test/managoat/broker/proxy_test.exs
@@ -1,0 +1,272 @@
+defmodule Managoat.Broker.ProxyTest do
+  # The proxy end to end: a sandbox-shaped client dials the listener with a
+  # session token, tunnels TLS to an origin, and the origin sees the real
+  # credential where the client sent a placeholder.
+  use Managoat.Broker.ProxyCase, async: true
+
+  alias Managoat.Broker.Proxy
+
+  setup do
+    ctx = start_rig()
+
+    session = %Session{
+      rules: [
+        %Rule{name: "origin", pattern: "localhost", scheme: :bearer, credential: "ghp_real"}
+      ],
+      unmatched_host_policy: :passthrough,
+      expires_at: DateTime.add(DateTime.utc_now(), 600, :second),
+      meta: %{conversation_id: "conv-1", user_id: "user-1"}
+    }
+
+    Map.merge(ctx, %{token: put_session(ctx, session), session: session})
+  end
+
+  test "the origin sees the real credential where the sandbox sent a placeholder", ctx do
+    tls = tunnel(ctx, ctx.token)
+
+    {head, echoed} =
+      request(
+        tls,
+        "GET /repos HTTP/1.1\r\nHost: localhost\r\nAuthorization: Bearer __github_token__\r\n\r\n"
+      )
+
+    assert head =~ "HTTP/1.1 200"
+    assert echoed["path"] == "/repos"
+    assert echoed["headers"]["authorization"] == "Bearer ghp_real"
+    refute Map.has_key?(echoed["headers"], "proxy-authorization")
+  end
+
+  test "several requests ride one tunnel, bodies included", ctx do
+    tls = tunnel(ctx, ctx.token)
+
+    {_, first} = request(tls, "GET /a HTTP/1.1\r\nHost: localhost\r\n\r\n")
+    assert first["path"] == "/a"
+    assert first["headers"]["authorization"] == "Bearer ghp_real"
+
+    {_, second} =
+      request(
+        tls,
+        "POST /b HTTP/1.1\r\nHost: localhost\r\nContent-Type: text/plain\r\nContent-Length: 5\r\n\r\nhello"
+      )
+
+    assert second["method"] == "POST"
+    assert second["body"] == "hello"
+
+    {_, third} =
+      request(
+        tls,
+        "POST /c HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: chunked\r\n\r\n3\r\nabc\r\n2\r\nde\r\n0\r\n\r\n"
+      )
+
+    assert third["body"] == "abcde"
+  end
+
+  test "a request body that arrives in pieces is copied whole", ctx do
+    tls = tunnel(ctx, ctx.token)
+    :ok = :ssl.send(tls, "POST /p HTTP/1.1\r\nHost: localhost\r\nContent-Length: 10\r\n\r\n0123")
+    Process.sleep(50)
+    :ok = :ssl.send(tls, "456789")
+    {_, echoed} = read_response(tls, "")
+    assert echoed["body"] == "0123456789"
+  end
+
+  test "a request head that arrives in pieces is parsed whole", ctx do
+    tls = tunnel(ctx, ctx.token)
+    :ok = :ssl.send(tls, "GET /split HTTP/1.1\r\nHost: loc")
+    Process.sleep(50)
+    :ok = :ssl.send(tls, "alhost\r\n\r\n")
+    {_, echoed} = read_response(tls, "")
+    assert echoed["path"] == "/split"
+  end
+
+  test "a wrong token, an expired session, garbage and no token are all 407", ctx do
+    expired = %{ctx.session | expires_at: DateTime.add(DateTime.utc_now(), -1, :second)}
+    expired_token = put_session(ctx, expired)
+
+    for auth <- [
+          proxy_auth("mb_nope"),
+          proxy_auth(expired_token),
+          "Basic " <> Base.encode64("garbage"),
+          "Basic not-base64!",
+          "Bearer #{ctx.token}",
+          nil
+        ] do
+      {_tcp, reply} = connect(ctx, "localhost:#{ctx.https_port}", auth)
+      assert reply =~ "HTTP/1.1 407", "#{inspect(auth)} was not refused"
+      assert reply =~ ~r/proxy-authenticate: Basic/i
+    end
+  end
+
+  test "the label half of the proxy credential is not checked: the token is the binding", ctx do
+    {_tcp, reply} = connect(ctx, "localhost:#{ctx.https_port}", proxy_auth(ctx.token, "other"))
+    assert reply =~ "HTTP/1.1 200"
+  end
+
+  test "an origin the proxy cannot reach is a 502 before any tunnel exists", ctx do
+    {_tcp, reply} = connect(ctx, "localhost:1", proxy_auth(ctx.token))
+    assert reply =~ "HTTP/1.1 502"
+  end
+
+  test "a host that does not resolve is a 502", ctx do
+    {_tcp, reply} = connect(ctx, "no-such-host.invalid:443", proxy_auth(ctx.token))
+    assert reply =~ "HTTP/1.1 502"
+  end
+
+  test "a bad request line and a bad CONNECT authority are 400", ctx do
+    {:ok, tcp} = :gen_tcp.connect(~c"127.0.0.1", ctx.proxy_port, [:binary, active: false])
+    :ok = :gen_tcp.send(tcp, "\x16\x03\x01 not http\r\n\r\n")
+    {:ok, reply} = :gen_tcp.recv(tcp, 0, 5_000)
+    assert reply =~ "HTTP/1.1 400"
+
+    {_tcp, reply} = connect(ctx, "nope", proxy_auth(ctx.token))
+    assert reply =~ "HTTP/1.1 400"
+  end
+
+  test "an origin on a private or loopback address is refused before any connection" do
+    ctx = start_rig(allow_private_upstreams: false)
+    token = put_session(ctx, bearer_session("x"))
+
+    {_tcp, reply} = connect(ctx, "localhost:#{ctx.https_port}", proxy_auth(token))
+    assert reply =~ "HTTP/1.1 403"
+
+    for ip <- [
+          {10, 1, 2, 3},
+          {172, 16, 0, 1},
+          {192, 168, 1, 1},
+          {169, 254, 169, 254},
+          {100, 64, 0, 1},
+          {127, 0, 0, 1},
+          {0, 0, 0, 0}
+        ],
+        do: assert(Proxy.private?(ip))
+
+    for ip <- [{140, 82, 112, 3}, {172, 32, 0, 1}, {100, 128, 0, 1}, {8, 8, 8, 8}],
+        do: refute(Proxy.private?(ip))
+  end
+
+  test "a passthrough host is forwarded untouched", ctx do
+    # A session whose rules name another host: nothing matches localhost.
+    Memory.put(ctx.store, ctx.token, %{ctx.session | rules: []})
+    tls = tunnel(ctx, ctx.token)
+
+    {_, echoed} =
+      request(
+        tls,
+        "GET /x HTTP/1.1\r\nHost: localhost\r\nAuthorization: Bearer __github_token__\r\n\r\n"
+      )
+
+    assert echoed["headers"]["authorization"] == "Bearer __github_token__"
+  end
+
+  test "a denied host is 403 inside the tunnel", ctx do
+    # A rule for one path of the host lets the tunnel open; the request
+    # below is to another path, so it is unmatched inside the tunnel.
+    Memory.put(ctx.store, ctx.token, %{
+      ctx.session
+      | rules: [%Rule{name: "narrow", pattern: "localhost/allowed/*", scheme: :passthrough}],
+        unmatched_host_policy: :deny
+    })
+
+    tls = tunnel(ctx, ctx.token)
+    :ok = :ssl.send(tls, "GET /x HTTP/1.1\r\nHost: localhost\r\n\r\n")
+    {:ok, reply} = :ssl.recv(tls, 0, 5_000)
+    assert reply =~ "HTTP/1.1 403"
+  end
+
+  test "plain HTTP in absolute form is forwarded with the credential attached", ctx do
+    {:ok, tcp} = :gen_tcp.connect(~c"127.0.0.1", ctx.proxy_port, [:binary, active: false])
+
+    :ok =
+      :gen_tcp.send(
+        tcp,
+        "GET http://localhost:#{ctx.http_port}/plain?q=1 HTTP/1.1\r\nHost: localhost\r\n" <>
+          "Proxy-Authorization: #{proxy_auth(ctx.token)}\r\n" <>
+          "Authorization: Bearer __github_token__\r\n\r\n"
+      )
+
+    reply = read_until_closed(tcp)
+    assert reply =~ "HTTP/1.1 200"
+    [_, body] = String.split(reply, "\r\n\r\n", parts: 2)
+    echoed = Jason.decode!(body)
+    assert echoed["path"] == "/plain"
+    assert echoed["headers"]["authorization"] == "Bearer ghp_real"
+    refute Map.has_key?(echoed["headers"], "proxy-authorization")
+  end
+
+  test "plain HTTP with a body is forwarded whole", ctx do
+    {:ok, tcp} = :gen_tcp.connect(~c"127.0.0.1", ctx.proxy_port, [:binary, active: false])
+
+    :ok =
+      :gen_tcp.send(
+        tcp,
+        "POST http://localhost:#{ctx.http_port}/body HTTP/1.1\r\nHost: localhost\r\n" <>
+          "Proxy-Authorization: #{proxy_auth(ctx.token)}\r\nContent-Length: 5\r\n\r\nhel"
+      )
+
+    Process.sleep(50)
+    :ok = :gen_tcp.send(tcp, "lo")
+
+    reply = read_until_closed(tcp)
+    [_, body] = String.split(reply, "\r\n\r\n", parts: 2)
+    assert Jason.decode!(body)["body"] == "hello"
+  end
+
+  test "plain HTTP under deny to an unmatched host is 403", ctx do
+    Memory.put(ctx.store, ctx.token, %{ctx.session | rules: [], unmatched_host_policy: :deny})
+    {:ok, tcp} = :gen_tcp.connect(~c"127.0.0.1", ctx.proxy_port, [:binary, active: false])
+
+    :ok =
+      :gen_tcp.send(
+        tcp,
+        "GET http://localhost:#{ctx.http_port}/ HTTP/1.1\r\nHost: localhost\r\n" <>
+          "Proxy-Authorization: #{proxy_auth(ctx.token)}\r\n\r\n"
+      )
+
+    assert read_until_closed(tcp) =~ "HTTP/1.1 403"
+  end
+
+  test "the request log names the session's meta and the rule, never a header", ctx do
+    handler = "proxy-test-#{System.unique_integer([:positive])}"
+
+    :telemetry.attach(
+      handler,
+      [:managoat, :broker, :request],
+      fn _e, measurements, meta, pid -> send(pid, {:request, measurements, meta}) end,
+      self()
+    )
+
+    on_exit(fn -> :telemetry.detach(handler) end)
+
+    tls = tunnel(ctx, ctx.token)
+    request(tls, "GET /logged HTTP/1.1\r\nHost: localhost\r\nAuthorization: Bearer x\r\n\r\n")
+
+    assert_receive {:request, %{count: 1},
+                    %{
+                      method: "GET",
+                      host: "localhost",
+                      path: "/logged",
+                      outcome: :injected,
+                      rule: "origin",
+                      meta: %{conversation_id: "conv-1", user_id: "user-1"}
+                    } = meta}
+
+    refute Map.has_key?(meta, :headers)
+
+    # Passthrough and denied outcomes, on the same event.
+    Memory.put(ctx.store, ctx.token, %{ctx.session | rules: []})
+    tls = tunnel(ctx, ctx.token)
+    request(tls, "GET /through HTTP/1.1\r\nHost: localhost\r\n\r\n")
+    assert_receive {:request, _, %{path: "/through", outcome: :passthrough, rule: nil}}
+
+    Memory.put(ctx.store, ctx.token, %{
+      ctx.session
+      | rules: [%Rule{name: "n", pattern: "localhost/ok", scheme: :passthrough}],
+        unmatched_host_policy: :deny
+    })
+
+    tls = tunnel(ctx, ctx.token)
+    :ok = :ssl.send(tls, "GET /no HTTP/1.1\r\nHost: localhost\r\n\r\n")
+    {:ok, _} = :ssl.recv(tls, 0, 5_000)
+    assert_receive {:request, _, %{path: "/no", outcome: :denied, rule: nil}}
+  end
+end

--- a/apps/managoat_broker/test/managoat/broker/store_memory_test.exs
+++ b/apps/managoat_broker/test/managoat/broker/store_memory_test.exs
@@ -1,0 +1,54 @@
+defmodule Managoat.Broker.Store.MemoryTest do
+  use ExUnit.Case, async: true
+
+  alias Managoat.Broker.{Session, Store}
+  alias Managoat.Broker.Store.Memory
+
+  setup do
+    name = :"memory_#{System.unique_integer([:positive])}"
+    start_supervised!(Supervisor.child_spec({Memory, name: name}, id: name))
+    %{store: name}
+  end
+
+  test "put, lookup, delete", %{store: store} do
+    token = Memory.generate_token()
+    assert String.starts_with?(token, "mb_")
+    session = %Session{meta: %{conversation_id: "c1"}}
+
+    assert :error = Memory.lookup(store, token)
+    :ok = Memory.put(store, token, session)
+    assert {:ok, ^session} = Memory.lookup(store, token)
+    assert Memory.tokens(store) == [token]
+
+    :ok = Memory.delete(store, token)
+    assert :error = Memory.lookup(store, token)
+    assert Memory.tokens(store) == []
+  end
+
+  test "the store behaviour dispatches both shapes", %{store: store} do
+    token = Memory.generate_token()
+    :ok = Memory.put(store, token, %Session{})
+
+    assert {:ok, %Session{}} = Store.lookup({Memory, store}, token)
+    assert :error = Store.lookup({Memory, store}, "mb_other")
+  end
+
+  test "the default instance answers the one-argument callback" do
+    start_supervised!(Memory)
+    token = Memory.generate_token()
+    :ok = Memory.put(token, %Session{})
+
+    assert {:ok, %Session{}} = Memory.lookup(token)
+    assert {:ok, %Session{}} = Store.lookup(Memory, token)
+    :ok = Memory.delete(token)
+    assert :error = Memory.lookup(token)
+    assert Memory.tokens() == []
+  end
+
+  test "Session.expired?/2" do
+    now = DateTime.utc_now()
+    refute Session.expired?(%Session{expires_at: nil}, now)
+    refute Session.expired?(%Session{expires_at: DateTime.add(now, 60, :second)}, now)
+    assert Session.expired?(%Session{expires_at: DateTime.add(now, -60, :second)}, now)
+  end
+end

--- a/apps/managoat_broker/test/support/proxy_case.ex
+++ b/apps/managoat_broker/test/support/proxy_case.ex
@@ -1,0 +1,287 @@
+defmodule Managoat.Broker.ProxyCase do
+  @moduledoc """
+  The rig the end-to-end proxy tests share: a real Bandit HTTPS origin under
+  its own CA (which only the proxy is told to trust), a listener on port 0
+  with an in-memory store, and a sandbox-shaped client that `CONNECT`s,
+  trusts the broker CA and speaks HTTP/1.1 by hand inside the tunnel.
+
+  Everything is per test: distinct listener name, own store, own origins,
+  so the modules that use this run `async: true`.
+  """
+
+  use ExUnit.CaseTemplate
+
+  alias Managoat.Broker.{CA, Rule, Session}
+  alias Managoat.Broker.Store.Memory
+
+  using do
+    quote do
+      import Managoat.Broker.ProxyCase
+      alias Managoat.Broker.{Rule, Session}
+      alias Managoat.Broker.Store.Memory
+    end
+  end
+
+  defmodule Origin do
+    @moduledoc false
+    # Echoes the request it saw, so a test can look at the headers the proxy
+    # forwarded. `/stream` answers in two chunks, the second on demand;
+    # `/ws` upgrades to a WebSocket that echoes the upgrade's auth header.
+    import Plug.Conn
+
+    def init(opts), do: opts
+
+    def call(%{request_path: "/stream"} = conn, _opts) do
+      [name] = get_req_header(conn, "x-stream-name")
+      Process.register(self(), String.to_atom(name))
+      conn = conn |> put_resp_content_type("text/event-stream") |> send_chunked(200)
+      {:ok, conn} = chunk(conn, "data: first\n\n")
+
+      receive do
+        :continue -> :ok
+      after
+        5_000 -> :ok
+      end
+
+      {:ok, conn} = chunk(conn, "data: second\n\n")
+      conn
+    end
+
+    def call(%{request_path: "/ws"} = conn, _opts) do
+      conn
+      |> WebSockAdapter.upgrade(Managoat.Broker.ProxyCase.Echo, conn.req_headers, timeout: 5_000)
+      |> halt()
+    end
+
+    def call(conn, _opts) do
+      {:ok, body, conn} = read_body(conn)
+
+      conn
+      |> put_resp_content_type("application/json")
+      |> send_resp(
+        200,
+        Jason.encode!(%{
+          method: conn.method,
+          path: conn.request_path,
+          headers: Map.new(conn.req_headers),
+          body: body
+        })
+      )
+    end
+  end
+
+  defmodule Echo do
+    @moduledoc false
+    # A WebSocket that answers every text frame with the authorization header
+    # the upgrade request carried, then the frame.
+    @behaviour WebSock
+
+    def init(headers), do: {:ok, Map.new(headers)}
+
+    def handle_in({text, [opcode: :text]}, headers) do
+      {:reply, :ok, {:text, (headers["authorization"] || "none") <> "|" <> text}, headers}
+    end
+
+    def handle_info(_, state), do: {:ok, state}
+    def terminate(_, _), do: :ok
+  end
+
+  @doc "A fresh 32-byte CA seed."
+  def seed, do: :crypto.strong_rand_bytes(32)
+
+  @doc "A CA and a leaf for `localhost` signed by it, as Bandit's `transport_options`."
+  def origin_tls do
+    ca_key = X509.PrivateKey.new_ec(:secp256r1)
+    ca = X509.Certificate.self_signed(ca_key, "/CN=Origin CA", template: :root_ca)
+    key = X509.PrivateKey.new_ec(:secp256r1)
+
+    cert =
+      key
+      |> X509.PublicKey.derive()
+      |> X509.Certificate.new("/CN=localhost", ca, ca_key,
+        extensions: [subject_alt_name: X509.Certificate.Extension.subject_alt_name(["localhost"])]
+      )
+
+    {ca, [cert: X509.Certificate.to_der(cert), key: {:ECPrivateKey, X509.PrivateKey.to_der(key)}]}
+  end
+
+  @doc "Start an HTTPS origin on 127.0.0.1:0 with `tls`; returns its port."
+  def start_https_origin(tls) do
+    pid =
+      ExUnit.Callbacks.start_supervised!(
+        {Bandit,
+         plug: Origin,
+         scheme: :https,
+         port: 0,
+         ip: {127, 0, 0, 1},
+         thousand_island_options: [transport_options: tls]},
+        id: make_ref()
+      )
+
+    {:ok, {_, port}} = ThousandIsland.listener_info(pid)
+    port
+  end
+
+  @doc "Start a plain HTTP origin on 127.0.0.1:0; returns its port."
+  def start_http_origin do
+    pid =
+      ExUnit.Callbacks.start_supervised!(
+        {Bandit, plug: Origin, scheme: :http, port: 0, ip: {127, 0, 0, 1}},
+        id: make_ref()
+      )
+
+    {:ok, {_, port}} = ThousandIsland.listener_info(pid)
+    port
+  end
+
+  @doc """
+  The whole rig: an HTTPS origin, a second one under a CA the proxy does not
+  trust, a plain HTTP origin, a store, and a listener on port 0 that trusts
+  the first origin's CA and may dial localhost. Returns the context the
+  tests read.
+  """
+  def start_rig(opts \\ []) do
+    {origin_ca, tls} = origin_tls()
+    {_untrusted_ca, untrusted_tls} = origin_tls()
+
+    https_port = start_https_origin(tls)
+    untrusted_port = start_https_origin(untrusted_tls)
+    http_port = start_http_origin()
+
+    store = :"store_#{System.unique_integer([:positive])}"
+    name = :"broker_#{System.unique_integer([:positive])}"
+    seed = seed()
+
+    # An explicit id: `use Agent`'s child spec is keyed by the module, and a
+    # test that starts a second rig would collide on it.
+    ExUnit.Callbacks.start_supervised!(Supervisor.child_spec({Memory, name: store}, id: store))
+
+    ExUnit.Callbacks.start_supervised!(
+      {Managoat.Broker,
+       [
+         name: name,
+         port: 0,
+         store: {Memory, store},
+         ca_seed: seed,
+         allow_private_upstreams: Keyword.get(opts, :allow_private_upstreams, true),
+         upstream_ssl_options: [cacerts: [X509.Certificate.to_der(origin_ca)]]
+       ]}
+    )
+
+    %{
+      name: name,
+      store: store,
+      seed: seed,
+      ca_der: CA.der(seed),
+      proxy_port: Managoat.Broker.port(name),
+      https_port: https_port,
+      untrusted_port: untrusted_port,
+      http_port: http_port
+    }
+  end
+
+  @doc "Put a session in the rig's store under a fresh token; returns the token."
+  def put_session(ctx, %Session{} = session) do
+    token = Memory.generate_token()
+    Memory.put(ctx.store, token, session)
+    token
+  end
+
+  @doc "A session with one bearer rule for `localhost`, carrying `credential`."
+  def bearer_session(credential, meta \\ %{}) do
+    %Session{
+      rules: [
+        %Rule{name: "origin", pattern: "localhost", scheme: :bearer, credential: credential}
+      ],
+      unmatched_host_policy: :passthrough,
+      expires_at: DateTime.add(DateTime.utc_now(), 600, :second),
+      meta: meta
+    }
+  end
+
+  @doc "The `Proxy-Authorization` value for a token and a label."
+  def proxy_auth(token, label \\ "c-test"), do: "Basic " <> Base.encode64(token <> ":" <> label)
+
+  @doc "CONNECT `host_port` through the proxy with `auth`; returns the raw socket and the reply."
+  def connect(ctx, host_port, auth) do
+    {:ok, tcp} = :gen_tcp.connect(~c"127.0.0.1", ctx.proxy_port, [:binary, active: false], 5_000)
+
+    line = if auth, do: "Proxy-Authorization: #{auth}\r\n", else: ""
+
+    :ok =
+      :gen_tcp.send(tcp, "CONNECT #{host_port} HTTP/1.1\r\nHost: #{host_port}\r\n#{line}\r\n")
+
+    {:ok, reply} = :gen_tcp.recv(tcp, 0, 5_000)
+    {tcp, reply}
+  end
+
+  @doc "A tunnel as the sandbox sees it: CONNECT to the HTTPS origin, then TLS trusting the broker CA."
+  def tunnel(ctx, token, host_port \\ nil) do
+    host_port = host_port || "localhost:#{ctx.https_port}"
+    {tcp, reply} = connect(ctx, host_port, proxy_auth(token))
+
+    unless reply =~ "HTTP/1.1 200" do
+      raise "CONNECT #{host_port} answered #{inspect(reply)}"
+    end
+
+    {:ok, tls} =
+      :ssl.connect(
+        tcp,
+        [
+          verify: :verify_peer,
+          cacerts: [ctx.ca_der],
+          server_name_indication: ~c"localhost",
+          customize_hostname_check: [
+            match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
+          ],
+          active: false
+        ],
+        5_000
+      )
+
+    tls
+  end
+
+  @doc "Send `raw` down the tunnel and read one JSON response: `{head, decoded_body}`."
+  def request(tls, raw) do
+    :ok = :ssl.send(tls, raw)
+    read_response(tls, "")
+  end
+
+  @doc "Read one `Content-Length` framed response off the tunnel."
+  def read_response(tls, acc) do
+    {:ok, data} = :ssl.recv(tls, 0, 5_000)
+    acc = acc <> data
+
+    case String.split(acc, "\r\n\r\n", parts: 2) do
+      [head, body] ->
+        [_, len] = Regex.run(~r/content-length: (\d+)/i, head)
+        len = String.to_integer(len)
+
+        if byte_size(body) >= len,
+          do: {head, Jason.decode!(binary_part(body, 0, len))},
+          else: read_response(tls, acc)
+
+      _ ->
+        read_response(tls, acc)
+    end
+  end
+
+  @doc "Read until `needle` has arrived."
+  def recv_until(tls, needle, acc \\ "") do
+    if String.contains?(acc, needle) do
+      acc
+    else
+      {:ok, data} = :ssl.recv(tls, 0, 5_000)
+      recv_until(tls, needle, acc <> data)
+    end
+  end
+
+  @doc "Read a plain socket until the peer closes it."
+  def read_until_closed(tcp, acc \\ "") do
+    case :gen_tcp.recv(tcp, 0, 5_000) do
+      {:ok, data} -> read_until_closed(tcp, acc <> data)
+      {:error, :closed} -> acc
+    end
+  end
+end

--- a/apps/managoat_broker/test/test_helper.exs
+++ b/apps/managoat_broker/test/test_helper.exs
@@ -1,0 +1,5 @@
+# Run from this directory the library has no config at all (mix.exs sets no
+# config_path on purpose) and needs none: every proxy test starts its own
+# listener on port 0, its own in-memory store and its own Bandit origin, so
+# nothing here is global and the modules run async.
+ExUnit.start()

--- a/mix.lock
+++ b/mix.lock
@@ -100,4 +100,5 @@
   "uri_query": {:hex, :uri_query, "0.2.0", "0f5e0f7ea6d9e6a7fb4929a81df9ecd756e3c71bdee5c9bc14e57d90069a82f7", [:mix], [], "hexpm", "e99f50a6af7c6643dff948db152a6a420bfe446aaec7f0924cfcdb710c175e63"},
   "websock": {:hex, :websock, "0.5.3", "2f69a6ebe810328555b6fe5c831a851f485e303a7c8ce6c5f675abeb20ebdadc", [:mix], [], "hexpm", "6105453d7fac22c712ad66fab1d45abdf049868f253cf719b625151460b8b453"},
   "websock_adapter": {:hex, :websock_adapter, "0.6.0", "73db5ab8aaefd1a876a97ce3e6afc96562625de69ef17a4e04426e034849d0b8", [:mix], [{:bandit, ">= 0.6.0", [hex: :bandit, repo: "hexpm", optional: true]}, {:plug, "~> 1.14", [hex: :plug, repo: "hexpm", optional: false]}, {:plug_cowboy, "~> 2.6", [hex: :plug_cowboy, repo: "hexpm", optional: true]}, {:websock, "~> 0.5", [hex: :websock, repo: "hexpm", optional: false]}], "hexpm", "50021a85bce8f203b086705d9e0c5415e2c7eb05d319111b0428fe71f9934617"},
+  "x509": {:hex, :x509, "0.9.2", "a75aa605348abd905990f3d2dc1b155fcde4e030fa2f90c4a91534405dce0f6e", [:mix], [], "hexpm", "4c5ede75697e565d4b0f5be04c3b71bb1fd3a090ea243af4bd7dae144e48cfc7"},
 }


### PR DESCRIPTION
## Summary

The native egress credential broker that #1148 built inside `apps/fountain` (closed 2026-08-25 to wait for the component-libraries plan, now 151 commits behind and conflicting), **ported** onto current `main` as the Apache-2.0 umbrella library `apps/managoat_broker` (`Managoat.Broker`). #1148's diff was the specification and its tests the acceptance suite; this is not a rebase of that branch. Decision and reasoning: #1340 (comment dated 2026-09-02), tracker #1334, ADR 0037.

**Inert for Fountain.** Nothing in `apps/fountain` calls the library. The only Fountain-side changes are the `in_umbrella` dep line, the Dockerfile `COPY` for the deps layer, `mix.lock` (x509) and two `.dialyzer_ignore.exs` entries. PR B wires it in beside the Agent Vault client, selected by `BROKER_LISTEN_PORT`.

## What was ported, and what changed on the way

| #1148 module | Lines | Now | Change on the way |
|---|---|---|---|
| `Broker.Proxy` (ThousandIsland handler: `CONNECT` + absolute-form, TLS toward the sandbox with a per-host leaf, raw byte pump, SSRF guard `private?/1`, dial the vetted address, `deny` at `CONNECT`, WebSocket upgrade → byte pipe) | 489 → 467 | `Managoat.Broker.Proxy` | reads `store`, `certs`, `allow_private_upstreams` and `upstream_ssl_options` from the handler options the listener passes, not `:fountain` config. Looks the token up through `Managoat.Broker.Store`; refuses an expired session itself. Emits `[:managoat, :broker, :request]` with `outcome` (`:injected`/`:passthrough`/`:denied`), `rule` and the session's `meta`; no per-request `Logger` line (the host writes it). |
| `Broker.CA` (HKDF → P-256 root from a seed, fixed subject/serial/validity; leaves per host) | 140 → 125 | `Managoat.Broker.CA` | **pure functions over a 32-byte `seed` argument**, never `MASTER_SECRETS_KEY`; no `persistent_term`. Subject is `/CN=Managoat Broker CA/O=Managoat`. Refuses a seed that is not 32 bytes by name. |
| `Broker.Certs` (ETS leaf cache) | 39 → 60 | `Managoat.Broker.Certs` | an ETS table per listener (created by the listener's supervisor, handed to every handler) holding the root and the leaves, instead of a named GenServer. |
| `Broker.Injector` (header rewrite) | 125 → 140 | `Managoat.Broker.Injector` | takes `%Managoat.Broker.Rule{}` structs with the credential already resolved, not Agent Vault service maps naming keys in a credentials map. Schemes: `:bearer`, `:basic`, `:api_key`, `:custom`, `:passthrough`, and **`:substitute`** (new: placeholder replaced in header values, so gate 3's inference keys work natively; see below). Several rules may match: the first that sets a header does, every `:substitute` applies. `host_matches?/3` exposed for the `CONNECT`-time `deny` check. |
| `Broker.HTTP` | 241 | `Managoat.Broker.HTTP` | none |
| `Broker.Session` (Ecto schema) | 50 | `Managoat.Broker.Session` (plain struct) + `Managoat.Broker.Rule` | fields `rules`, `unmatched_host_policy` (`:passthrough`/`:deny`), `expires_at`, `meta` (opaque). The Ecto row is the host's (PR B). |
| `Broker.Sessions` (Repo + tenant-DEK ciphertext) | 132 | **not ported here**; `Managoat.Broker.Store` behaviour + `Store.Memory` | the store is the host's. PR B adds `Fountain.Broker.Native.Sessions` implementing `lookup/1`. |
| `Broker.Supervisor` + `application.ex` wiring | 20 | `Managoat.Broker` (child spec + supervisor) | one supervisor per listener, `name:` option so several coexist; `port/1`, `running?/1`, `ca_pem/1`, `ca_pem_for_seed/1`. |
| `[:fountain, :broker, :request]` | | `[:managoat, :broker, :request]` | measurements `%{count: 1}`; metadata `method`, `host`, `path`, `outcome`, `rule`, `meta`. |
| `agent_vault_parity_test`, `ca_test`, `http_test`, `injector_test`, `proxy_test` (1,033 lines) | | the library's `test/` (959 lines + 287 in `test/support/proxy_case.ex`) | against `Store.Memory`; `bandit`, `websock_adapter` and `jason` as test deps. Every module is `async: true`: each test starts its own listener on port 0, its own store and its own Bandit origins. New tests: the `:substitute` rule, `host_matches?/3`, the `Store` behaviour's two shapes, the child spec's required-option errors, an expired session and the ignored label. |
| `.dialyzer_ignore.exs` | | root, unchanged in kind | the same two x509 0.9.2 `unknown_type` entries. |

**Not ported beyond #1148's own list:** `Sessions.lookup/2`'s vault-mismatch refusal. The library's store callback is `lookup(token)`; the label half of `Proxy-Authorization` (Agent Vault's vault name) is parsed and dropped. The token is a random per-session secret and is the whole binding, so the check added nothing; the label survives only because git refuses a proxy URL with a user and no password. The parity suite records this under its not-ported list, and `proxy_test.exs` asserts the label is ignored.

**Added beyond #1148:** the `:substitute` rule scheme. `main`'s `Fountain.Broker` (gate 3, built 2026-08-25 against Agent Vault) brokers inference credentials with `auth_type: "substitute"` bindings, which #1148 mapped to `passthrough` (it predates gate 3 landing). Without a header-level substitution the native flip would send `sk-ant-oat01-__claude_code_oauth_token__` upstream unreplaced, the 401 the ADR's gate 3 notes describe. Header values only; path/query/body substitution stays on the deviations list.

## The `Store` behaviour

```elixir
@callback lookup(token :: binary()) :: {:ok, Managoat.Broker.Session.t()} | :error
```

That is all the proxy needs at request time. A store with several instances (one per listener in a test) implements `lookup/2` and is configured as `{Module, instance}`. Token hashing is the host's choice inside `lookup/1`; the library passes the raw token from the header.

## The child spec

```elixir
{Managoat.Broker,
 port: 14322,
 store: Fountain.Broker.Native.Sessions,
 ca_seed: <<32 bytes>>,
 allow_private_upstreams: false}
```

Every option but the last is required; a missing one raises at start naming it. Optional: `upstream_ssl_options`, `name`. No `Config` module.

## Deviations from Agent Vault (unchanged from #1148, plus one)

- Absolute-form (plain HTTP) is one request per connection.
- No path, query or body substitution (`:substitute` reaches header values only).
- No WebSocket frame rewriting.
- No auth-failure rate limiting on the proxy port.
- No body-size caps.
- No IPv6 upstreams.
- The label half of the proxy credential is not checked (above).

The README carries all of this, the CA derivation and why the root's self-signature bytes vary per derivation, and the two operational traps a host must handle (#1158 `sudo` strips the proxy env; #1206 unknown-CA leaf on a shared-NAT peer).

## Gates

Local results are posted as a comment once the full suite finishes.

Part of #1340 and #1334.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016FzoNG8MR2yW5aAnnxKHmF
