### PR TITLE
feat(libraries): the graduation template, script and recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ upgrade, is in
 
 ## [Unreleased]
 
+### Added
+
+- **The graduation recipe for umbrella libraries** (#1345, ADR 0037):
+  `templates/managoat-library/` (CI, a release gate, a publish workflow that
+  makes a version bump on `main` the release, mirroring the SDK's) and
+  `scripts/graduate-library.sh`, which moves an `apps/managoat_<name>` app to
+  `managoat/managoat_<name>` with its history. CONTRIBUTING.md has the
+  recipe, the ordering rule and the cost.
+
 ### Changed
 
 - **`managoat_substitution` comes from hex** (#1345, ADR 0037). The first

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,6 +134,127 @@ and their coverage export joins the merged gate, so a library with no tests
 fails the run rather than passing unmeasured. Add a `[Unreleased]` entry
 and update the "Built so far" block in decisions/0037.
 
+## Graduating a library
+
+The reverse of the section above: an `apps/managoat_<name>` app leaves this
+umbrella for a repository of its own, `managoat/managoat_<name>` (the same
+string as the hex package), from which CI publishes it to hex, and
+`apps/fountain` pins the hex release. The recipe is `scripts/graduate-library.sh`
+plus `templates/managoat-library/`; #1345 wrote both and proved them on
+`managoat_substitution`, then ran them for the other seven.
+
+**When.** A library graduates when it has stopped moving: its public surface
+has not changed since extraction, or its last change was a release of its own
+rather than a fix that a Fountain PR needed the same day. There is no open
+issue that needs a change on both sides of the seam. Until then the umbrella
+gives the compile-time boundary at no release cost; after, every cross-seam
+change costs two PRs (below).
+
+**Prerequisite, org admin only.** The publish workflow authenticates with
+`HEX_API_KEY`, an organization-level secret on `managoat` visible to every
+repository, holding a write key from the hex.pm user account that owns every
+`managoat_*` package. There is no hex organization and hex has no trusted
+publishing; that key, used only by CI, is the mechanism. Listing org secrets
+needs a scope your `gh` token may not have, so the check is to use it: the
+first publish run of a new repository either works or fails with 401. On a
+401, stop and ask; never create a key, and never put one in a repository
+secret or a file.
+
+**The script.** From the umbrella root, on a clean and up-to-date `main`:
+
+```bash
+scripts/graduate-library.sh --prepare-only <name>   # nothing on GitHub yet
+scripts/graduate-library.sh <name>
+```
+
+`--prepare-only` runs the preflight and builds the stand-alone tree in a
+scratch clone with the local gates, and stops. Do that first: a hex package
+name is claimed by its first publish and can never be released, and the name
+in `mix.exs` is permanent from the moment `main` exists. The full run then:
+
+1. refuses unless the tree is clean, `main` matches `origin/main`, and
+   `mix hex.build` succeeds for the app (a git dependency fails it; hex takes
+   hex packages only, which is why `managoat_sandbox` waited for the Sprites
+   client's hex release, pinned exactly to `0.2.0` for the reason in its
+   `mix.exs`);
+2. `git subtree split -P apps/managoat_<name>` puts the app's history on
+   `graduate/<name>` (one commit per app today, the extraction PR; an
+   `--unshallow` fetch first if the clone is shallow);
+3. creates the repository (public, no wiki, topic `managoat-library`) and
+   pushes the split as `main`;
+4. in a fresh clone, copies the template in, takes the three umbrella path
+   lines out of `mix.exs`, points `@source_url` at the new repository, adds
+   `ex_doc` (so `mix hex.publish` publishes hexdocs too), credo and dialyzer,
+   writes the repository's own `mix.lock`, runs compile, credo, the tests and
+   `mix hex.build` locally, and pushes `chore: stand alone (...)`. That push
+   is what runs CI and the first publish;
+5. creates the `no-release` label and protects `main` behind the two checks,
+   `ci` and `release gate`, with no review requirement, since a library
+   repository's `main` is what publishes and the gate is what keeps it honest.
+
+It is idempotent after a failure in 4 or 5: rerun it and it skips what exists.
+The template it copies mirrors the SDK's release automation
+(`.github/workflows/sdk-publish.yml`, `sdk-release-gate.yml`,
+`scripts/sdk-release.mjs`): `scripts/release.exs state` reads `@version` from
+`mix.exs` and asks hex whether it exists; `guard <base>` fails a PR that
+changes `lib/`, `priv/` or the consumer-facing part of `mix.exs` without a
+bump, a bump whose version hex already has, or a bump without a
+`## [<version>]` heading in `CHANGELOG.md`. Merging a bump publishes and tags
+`v<version>` as a record; a docs-only merge finds nothing to do. The template
+carries a Postgres service block that only `managoat_oauth` keeps (the script
+strips it for the others) and action pins copied from `ci.yml`; Dependabot
+maintains them from there, and the checkout-pin trap from this repository
+applies: a Dependabot bump can move the SHA and leave the version comment
+behind, so trust the SHA.
+
+**What the script does not do: the Fountain-side PR.** One per library, opened
+only after the hex release exists and only after the previous library's PR has
+merged (two open at once conflict on `apps/fountain/mix.exs`, the Dockerfile
+and `CLAUDE.md`):
+
+- delete `apps/managoat_<name>`;
+- `{:managoat_<name>, in_umbrella: true}` becomes
+  `{:managoat_<name>, "~> 0.1.0"}` in `apps/fountain/mix.exs`;
+- drop its `COPY apps/managoat_<name>/mix.exs` line from the Dockerfile;
+- `mix deps.get`, then `mix deps.unlock --unused`;
+- the layout block in `CLAUDE.md`, the "Built so far" block in
+  decisions/0037 (then `scripts/decisions-index.sh` and
+  `okf validate decisions`), and a `[Unreleased]` line here in `CHANGELOG.md`;
+- the gates: `mix compile --warnings-as-errors`, `mix format --check-formatted`,
+  `mix credo --strict`, `MIX_ENV=dev mix dialyzer`, the full root suite with
+  every remaining library's banner at `0 failures`,
+  `umbrella_layout_test.exs`, `scripts/test-libraries.sh`, and
+  **`docker build --target build .`**. The last one matters most: the
+  Dockerfile's deps layer is the only consumer of the hex release that CI does
+  not exercise, since CI never builds the image. After the merge, watch
+  `build.yml` on `main` go green.
+
+`umbrella_layout_test.exs` and `scripts/test-libraries.sh` walk whatever
+`apps/managoat_*` directories remain, so they need no edit per library; the
+last library out relaxes the "at least one library" assertion and makes the
+script exit 0 with a message on zero apps. The `config :managoat_*` lines in
+`config/*.exs` stay: a hex dependency reads its otp_app configuration the same
+way an umbrella app did.
+
+**Ordering: a library that depends on another graduates after it.** Hex
+refuses `in_umbrella` dependencies, so the dependency must be on hex first.
+`managoat_runner` depends on `managoat_sandbox` and is the worked example:
+sandbox graduates and its Fountain-side PR merges; a one-line Fountain PR
+changes `apps/managoat_runner/mix.exs` from
+`{:managoat_sandbox, in_umbrella: true}` to `{:managoat_sandbox, "~> 0.1.0"}`
+(the umbrella resolves it from hex like Fountain does, and `mix hex.build`
+for runner now succeeds inside the umbrella); then runner graduates.
+
+**The cost that starts on graduation day.** A change across the seam is two
+PRs: a bump in the library (its gate insists), then a pin in Fountain. The
+version pins here are `~> 0.1.0`, patch-level while every library is 0.x, so
+a library's `0.2.0` reaches Fountain only when someone bumps the pin, on
+purpose. Under this repository's ruleset a solo merge is
+`gh pr merge --admin`, and a merged-PR branch push runs no CI here, so the pin
+PR is the only place the new version is exercised against Fountain; do not
+skip its gates. Merges into a library repository are yours once its CI is
+green, because its `main` is what publishes.
+
 ## Pull requests
 
 Every change goes through a PR and the CI gate must pass. Do not push directly

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -239,11 +239,15 @@ way an umbrella app did.
 **Ordering: a library that depends on another graduates after it.** Hex
 refuses `in_umbrella` dependencies, so the dependency must be on hex first.
 `managoat_runner` depends on `managoat_sandbox` and is the worked example:
-sandbox graduates and its Fountain-side PR merges; a one-line Fountain PR
-changes `apps/managoat_runner/mix.exs` from
-`{:managoat_sandbox, in_umbrella: true}` to `{:managoat_sandbox, "~> 0.1.0"}`
-(the umbrella resolves it from hex like Fountain does, and `mix hex.build`
-for runner now succeeds inside the umbrella); then runner graduates.
+sandbox graduates to hex; sandbox's Fountain-side PR deletes
+`apps/managoat_sandbox` **and, in the same PR**, changes
+`apps/managoat_runner/mix.exs` from `{:managoat_sandbox, in_umbrella: true}`
+to `{:managoat_sandbox, "~> 0.1.0"}`, because an `in_umbrella` dependency on
+an app that no longer exists cannot resolve, so the switch cannot be a PR of
+its own after the deletion. The umbrella then resolves it from hex like
+Fountain does, `mix hex.build` for runner succeeds inside the umbrella (that
+PR's gate), the runner conformance suite still passes; then runner
+graduates.
 
 **The cost that starts on graduation day.** A change across the seam is two
 PRs: a bump in the library (its gate insists), then a pin in Fountain. The

--- a/scripts/graduate-library.sh
+++ b/scripts/graduate-library.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+#
+# Graduate an umbrella library app (apps/managoat_<name>) to its own
+# repository, managoat/managoat_<name>, from which CI publishes it to hex.
+# The recipe is written down in CONTRIBUTING.md ("Graduating a library");
+# this is the executable half of it. It does not touch Fountain's tree: the
+# Fountain-side PR (delete the app, pin the hex release) is a separate step.
+#
+#   scripts/graduate-library.sh <name>              the whole thing
+#   scripts/graduate-library.sh --prepare-only <name>
+#       steps 1, 2 and the stand-alone conversion into a scratch clone of the
+#       split branch, with the local gates, and nothing on GitHub. Run this
+#       first: a package name is claimed by its first publish and never
+#       released, so the tree has to be right before main exists.
+#
+# Run from the umbrella root, on a clean, up-to-date main. Steps:
+#
+#   1. Refuse unless the tree is clean, main is checked out and matches
+#      origin/main, apps/managoat_<name>/mix.exs exists and `mix hex.build`
+#      succeeds for it.
+#   2. `git subtree split` the app's history onto graduate/<name>.
+#   3. Create managoat/managoat_<name> (public, no wiki, topic
+#      managoat-library) and push the split branch as main.
+#   4. In a fresh clone: copy templates/managoat-library in, edit mix.exs for
+#      life outside the umbrella, `mix deps.get` for the repo's own mix.lock,
+#      `mix format`, run the local gates, commit "chore: stand alone (...)"
+#      and push. That push is what triggers CI and the first publish.
+#   5. Create the `no-release` label and protect main behind the two checks
+#      (no review requirement). Print the repo URL and the next step.
+#
+# Idempotent after a failure in 4 or 5: an existing repo is not recreated, a
+# main that already carries the stand-alone commit is not pushed again, the
+# label and the protection are upserted.
+#
+# Prerequisite that only the org admin can meet: HEX_API_KEY as an
+# organization secret on managoat, visible to all repositories. The script
+# cannot check it (listing org secrets needs a scope `gh` may not have); the
+# first publish run is the check.
+#
+# Environment: GRADUATE_WORKDIR (scratch parent; default $TMPDIR),
+# GRADUATE_SKIP_LOCAL_GATES=1 to skip compile/credo/test in step 4 (CI still
+# runs them, and the publish workflow runs the tests before publishing).
+
+set -euo pipefail
+
+die() { echo "graduate-library: $*" >&2; exit 1; }
+
+mode=full
+if [ "${1:-}" = "--prepare-only" ]; then mode=prepare; shift; fi
+name="${1:-}"
+[ -n "$name" ] || die "usage: scripts/graduate-library.sh [--prepare-only] <name>   (name as in apps/managoat_<name>)"
+case "$name" in managoat_*) die "give the short name: '${name#managoat_}', not '$name'";; esac
+
+app="managoat_${name}"
+repo="managoat/${app}"
+repo_url="https://github.com/${repo}"
+push_url="git@github.com:${repo}.git"
+app_dir="apps/${app}"
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+template="${script_dir}/../templates/managoat-library"
+root="$PWD"
+workdir="${GRADUATE_WORKDIR:-${TMPDIR:-/tmp}}/graduate-${app}"
+
+[ -d "$template" ] || die "template missing at $template"
+command -v gh >/dev/null || die "gh is required"
+command -v mix >/dev/null || die "mix is required"
+command -v perl >/dev/null || die "perl is required"
+
+# ---- 1. preflight ----------------------------------------------------------
+
+[ -f mix.exs ] && grep -q 'apps_path' mix.exs || die "run from the umbrella root (no mix.exs with apps_path here)"
+[ -f "$app_dir/mix.exs" ] || die "$app_dir/mix.exs does not exist"
+[ -z "$(git status --porcelain)" ] || die "working tree is not clean"
+branch="$(git rev-parse --abbrev-ref HEAD)"
+[ "$branch" = "main" ] || die "main must be checked out (on $branch)"
+git fetch -q origin main
+head_sha="$(git rev-parse HEAD)"
+[ "$head_sha" = "$(git rev-parse origin/main)" ] || die "main is not up to date with origin/main"
+if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+  echo "== shallow clone: fetching full history for subtree split"
+  git fetch --unshallow
+fi
+
+echo "== 1. $app_dir builds a hex package"
+tarball="$(mktemp -d)/${app}.tar"
+(cd "$app_dir" && mix hex.build --output "$tarball" >/dev/null) || die "mix hex.build fails for $app_dir; fix that first"
+rm -f "$tarball"
+
+description="$(cd "$app_dir" && mix eval --no-deps-check --no-compile 'IO.puts(Mix.Project.config()[:description])' | tail -1)"
+[ -n "$description" ] || die "no :description in $app_dir/mix.exs"
+module="$(perl -ne 'print $1 and exit if /^defmodule\s+([\w.]+)\.MixProject/' "$app_dir/mix.exs")"
+[ -n "$module" ] || die "could not read the module name from $app_dir/mix.exs"
+
+# ---- 2. split --------------------------------------------------------------
+
+echo "== 2. git subtree split -P $app_dir"
+split_sha="$(git subtree split -P "$app_dir" 2>/dev/null)"
+[ -n "$split_sha" ] || die "git subtree split produced nothing"
+git branch -f "graduate/${name}" "$split_sha" >/dev/null
+subject="$(git log -1 --format=%s "$split_sha")"
+extraction_pr="$(printf '%s' "$subject" | perl -ne 'print $1 if /\(#(\d+)\)\s*$/')"
+[ -n "$extraction_pr" ] || die "the split's tip commit does not name its PR: $subject"
+echo "   graduate/${name} = ${split_sha:0:12} ($subject)"
+
+# ---- the stand-alone conversion (shared by both modes) ---------------------
+
+# $1: a checkout of the split branch, on main. Leaves it committed.
+stand_alone() {
+  local dir="$1"
+  cd "$dir"
+  local today
+  today="$(date +%Y-%m-%d)"
+
+  echo "== 4. stand alone in $dir"
+  # The template, dotfiles included. .formatter.exs is patched rather than
+  # copied: the library's own may carry import_deps (managoat_oauth's does).
+  (cd "$template" && find . -type f ! -name .formatter.exs -print0) |
+    while IFS= read -r -d '' f; do
+      mkdir -p "$(dirname "$f")"
+      cp "$template/$f" "$f"
+    done
+  if [ -f .formatter.exs ]; then
+    perl -pi -e 's|"\{lib,test\}/\*\*/\*\.\{ex,exs\}"|"{lib,test,scripts}/**/*.{ex,exs}"|' .formatter.exs
+  else
+    cp "$template/.formatter.exs" .formatter.exs
+  fi
+
+  # Placeholders in NOTICE and CHANGELOG.md.
+  perl -pi -e "s/__NAME__/${app}/g; s/__MODULE__/${module}/g; s/__DATE__/${today}/g; s/__EXTRACTION_PR__/${extraction_pr}/g" NOTICE CHANGELOG.md
+
+  # The Postgres service is managoat_oauth's alone.
+  if [ "$name" != "oauth" ]; then
+    for wf in .github/workflows/ci.yml .github/workflows/publish.yml; do
+      perl -ni -e 'if (/^\s*# ---- oauth only/) { $skip = 1 } if (!$skip && !/# oauth only\s*$/) { print } if (/^\s*# ---- end oauth only/) { $skip = 0 }' "$wf"
+    done
+  fi
+
+  # mix.exs: out of the umbrella.
+  #  - the umbrella-first comment block and the three path lines go;
+  #  - @source_url becomes this repository, links gain the changelog;
+  #  - the package ships CHANGELOG.md and NOTICE too;
+  #  - docs (ex_doc, so hex.publish publishes hexdocs), dialyzer config and
+  #    the tool deps CI needs.
+  perl -0pi -e '
+    s/[ \t]*# Umbrella-first \(decisions\/0037\).*?lockfile: "\.\.\/\.\.\/mix\.lock",\n//s
+      or die "mix.exs: umbrella block not found\n";
+    s|\@source_url "https://github\.com/BinaryBourbon/fountain/tree/main/apps/'"$app"'"|\@source_url "https://github.com/managoat/'"$app"'"|
+      or die "mix.exs: \@source_url not found\n";
+    s|links: %\{"GitHub" => \@source_url\}|links: %{"GitHub" => \@source_url, "Changelog" => "#{\@source_url}/blob/main/CHANGELOG.md"}|
+      or die "mix.exs: links not found\n";
+    s|files: ~w\(lib mix\.exs README\.md LICENSE\)|files: ~w(lib mix.exs README.md CHANGELOG.md LICENSE NOTICE)|
+      or die "mix.exs: files not found\n";
+    s|(\n[ \t]*package: package\(\),\n)|$1      source_url: \@source_url,\n      docs: docs(),\n      dialyzer: dialyzer(),\n|
+      or die "mix.exs: package: line not found\n";
+    s|(\n[ \t]*defp deps do\n[ \t]*\[\n)|$1      # Tooling for the repository, not the package: docs for hexdocs.pm (built\n      # by `mix hex.publish`), credo and dialyzer for CI. dialyxir is pinned to\n      # the commit that added OTP 28 support; 1.4.7 crashes on OTP 28 warnings.\n      {:ex_doc, "~> 0.34", only: :dev, runtime: false},\n      {:credo, "~> 1.7", only: [:dev, :test], runtime: false},\n      {:dialyxir,\n       github: "jeremyjh/dialyxir",\n       ref: "3553678f4d69281ac6db61034bcf35bcb30cfd78",\n       only: [:dev, :test],\n       runtime: false},\n|
+      or die "mix.exs: defp deps not found\n";
+    s|\nend\s*$|\n\n  defp docs do\n    [\n      main: "readme",\n      extras: ["README.md", "CHANGELOG.md"],\n      source_ref: "v#{\@version}",\n      source_url: \@source_url\n    ]\n  end\n\n  defp dialyzer do\n    [\n      ignore_warnings: ".dialyzer_ignore.exs",\n      # A fixed path so CI can cache the PLT across runs.\n      plt_file: {:no_warn, "priv/plts/dialyzer.plt"}\n    ]\n  end\nend\n|
+      or die "mix.exs: final end not found\n";
+  ' mix.exs
+
+  echo "   mix deps.get (the repository's own mix.lock)"
+  mix deps.get >/dev/null
+  mix format
+
+  if [ "${GRADUATE_SKIP_LOCAL_GATES:-0}" != "1" ]; then
+    echo "   local gates: compile, credo, test, hex.build"
+    mix compile --warnings-as-errors >/dev/null
+    env MIX_ENV=test mix compile --warnings-as-errors >/dev/null
+    mix credo --strict
+    mix test
+    mix hex.build --output "$(mktemp -d)/${app}.tar" >/dev/null
+    mix format --check-formatted
+    elixir scripts/release.exs state
+  fi
+
+  git add -A
+  git commit -q -m "chore: stand alone (from BinaryBourbon/fountain apps/${app} at ${head_sha:0:12})" \
+    -m "The graduation of ${app} out of the Fountain umbrella (BinaryBourbon/fountain#1345, decisions/0037): the managoat-library template (CI, the release gate, the publish workflow, scripts/release.exs, NOTICE, CHANGELOG), mix.exs without its umbrella paths, and a mix.lock of its own. Merging a version bump to main publishes to hex."
+  echo "   committed $(git rev-parse --short HEAD)"
+  cd "$root"
+}
+
+# ---- prepare-only ends here -------------------------------------------------
+
+if [ "$mode" = "prepare" ]; then
+  rm -rf "$workdir"
+  git clone -q --branch "graduate/${name}" "$root" "$workdir"
+  (cd "$workdir" && git checkout -q -b main)
+  stand_alone "$workdir"
+  echo
+  echo "Prepared, nothing pushed. Inspect $workdir, then run: scripts/graduate-library.sh $name"
+  exit 0
+fi
+
+# ---- 3. the repository -------------------------------------------------------
+
+echo "== 3. $repo"
+if gh repo view "$repo" >/dev/null 2>&1; then
+  echo "   exists, not recreated"
+else
+  gh repo create "$repo" --public --description "$description" --disable-wiki >/dev/null
+  echo "   created"
+fi
+gh repo edit "$repo" --add-topic managoat-library --delete-branch-on-merge --enable-projects=false >/dev/null
+
+if [ -z "$(git ls-remote --heads "$push_url" main)" ]; then
+  git push -q "$push_url" "${split_sha}:refs/heads/main"
+  echo "   pushed graduate/${name} as main"
+else
+  echo "   main already exists on the remote, not pushed"
+fi
+
+# ---- 4. stand alone -----------------------------------------------------------
+
+rm -rf "$workdir"
+git clone -q "$push_url" "$workdir"
+if (cd "$workdir" && git cat-file -e "origin/main:.github/workflows/publish.yml" 2>/dev/null); then
+  echo "== 4. main already carries the stand-alone commit, skipped"
+else
+  stand_alone "$workdir"
+  (cd "$workdir" && git push -q origin main)
+  echo "   pushed: CI and the first publish are running"
+fi
+
+# ---- 5. label, protection ----------------------------------------------------
+
+echo "== 5. label and branch protection"
+gh label create no-release --repo "$repo" --force --color d4c5f9 \
+  --description "This PR changes the published surface without cutting a release; the release gate is skipped." >/dev/null
+echo "   label no-release"
+
+protection="$(mktemp)"
+cat > "$protection" <<'JSON'
+{
+  "required_status_checks": { "strict": false, "contexts": ["ci", "release gate"] },
+  "enforce_admins": false,
+  "required_pull_request_reviews": null,
+  "restrictions": null,
+  "allow_force_pushes": false,
+  "allow_deletions": false
+}
+JSON
+gh api -X PUT "repos/${repo}/branches/main/protection" --input "$protection" >/dev/null
+rm -f "$protection"
+echo "   main requires the checks: ci, release gate (no review requirement)"
+
+cat <<MSG
+
+Done: ${repo_url}
+
+Next:
+  1. Watch ${repo_url}/actions: CI on the stand-alone commit, then Publish,
+     which publishes ${app} to hex and tags v<version>. A 401 from hex means
+     HEX_API_KEY is not visible to the repository; stop and ask.
+  2. Confirm https://hex.pm/packages/${app} and https://hexdocs.pm/${app}.
+  3. The Fountain-side PR (CONTRIBUTING.md, "Graduating a library"): delete
+     ${app_dir}, pin {:${app}, "~> <version>"} in apps/fountain/mix.exs, drop
+     the Dockerfile COPY line, and build the image locally before opening it.
+MSG

--- a/templates/managoat-library/.credo.exs
+++ b/templates/managoat-library/.credo.exs
@@ -1,0 +1,226 @@
+# Credo configuration for a managoat_* library, copied from
+# BinaryBourbon/fountain's .credo.exs with the `included` paths trimmed to this
+# repository's lib/ and test/ and Fountain's own check dropped. Run with
+# `mix credo --strict`, which is what CI does.
+#
+# If you find anything wrong or unclear in this file, please report an
+# issue on GitHub: https://github.com/rrrene/credo/issues
+#
+%{
+  #
+  # You can have as many configs as you like in the `configs:` field.
+  configs: [
+    %{
+      #
+      # Run any config using `mix credo -C <name>`. If no config name is given
+      # "default" is used.
+      #
+      name: "default",
+      #
+      # These are the files included in the analysis:
+      files: %{
+        #
+        # You can give explicit globs or simply directories.
+        # In the latter case `**/*.{ex,exs}` will be used.
+        #
+        included: ["lib/", "test/"],
+        excluded: [~r"/_build/", ~r"/deps/", ~r"/node_modules/"]
+      },
+      #
+      # Load and configure plugins here:
+      #
+      plugins: [],
+      #
+      # If you create your own checks, you must specify the source files for
+      # them here, so they can be loaded by Credo before running the analysis.
+      #
+      requires: [],
+      #
+      # If you want to enforce a style guide and need a more traditional linting
+      # experience, you can change `strict` to `true` below:
+      #
+      strict: false,
+      #
+      # To modify the timeout for parsing files, change this value:
+      #
+      parse_timeout: 5000,
+      #
+      # If you want to use uncolored output by default, you can change `color`
+      # to `false` below:
+      #
+      color: true,
+      #
+      # You can customize the parameters of any check by adding a second element
+      # to the tuple.
+      #
+      # To disable a check put `false` as second element:
+      #
+      #     {Credo.Check.Design.DuplicatedCode, false}
+      #
+      checks: %{
+        enabled: [
+          #
+          ## Project checks
+          #
+          # Replaces the manual `_unsafe_` call-site sweeps (#328/#383):
+          # every remote `Mod._unsafe_*` call needs a nearby `# ownership:`
+          # comment. Exemptions are the caller shapes from CLAUDE.md's
+          # tenant isolation section where ownership is structural, plus
+          # tests (which create their own data).
+          {Credo.Check.Consistency.ExceptionNames, []},
+          {Credo.Check.Consistency.LineEndings, []},
+          {Credo.Check.Consistency.ParameterPatternMatching, []},
+          {Credo.Check.Consistency.SpaceAroundOperators, []},
+          {Credo.Check.Consistency.SpaceInParentheses, []},
+          {Credo.Check.Consistency.TabsOrSpaces, []},
+
+          #
+          ## Design Checks
+          #
+          {Credo.Check.Design.TagFIXME, []},
+          # You can also customize the exit_status of each check.
+          # If you don't want TODO comments to cause `mix credo` to fail, just
+          # set this value to 0 (zero).
+          #
+          {Credo.Check.Design.TagTODO, [exit_status: 2]},
+
+          #
+          ## Readability Checks
+          #
+          {Credo.Check.Readability.FunctionNames, []},
+          {Credo.Check.Readability.LargeNumbers, []},
+          {Credo.Check.Readability.ModuleAttributeNames, []},
+          {Credo.Check.Readability.ModuleDoc, []},
+          {Credo.Check.Readability.ModuleNames, []},
+          {Credo.Check.Readability.ParenthesesInCondition, []},
+          {Credo.Check.Readability.PipeIntoAnonymousFunctions, []},
+          {Credo.Check.Readability.PredicateFunctionNames, []},
+          {Credo.Check.Readability.RedundantBlankLines, []},
+          {Credo.Check.Readability.Semicolons, []},
+          {Credo.Check.Readability.SpaceAfterCommas, []},
+          {Credo.Check.Readability.StringSigils, []},
+          {Credo.Check.Readability.TrailingBlankLine, []},
+          {Credo.Check.Readability.TrailingWhiteSpace, []},
+          {Credo.Check.Readability.UnnecessaryAliasExpansion, []},
+          {Credo.Check.Readability.VariableNames, []},
+
+          #
+          ## Refactoring Opportunities
+          #
+          {Credo.Check.Refactor.FilterCount, []},
+          {Credo.Check.Refactor.FilterFilter, []},
+          {Credo.Check.Refactor.FunctionArity, []},
+          {Credo.Check.Refactor.LongQuoteBlocks, []},
+          {Credo.Check.Refactor.MapJoin, []},
+          {Credo.Check.Refactor.MatchInCondition, []},
+          {Credo.Check.Refactor.NegatedConditionsInUnless, []},
+          {Credo.Check.Refactor.NegatedConditionsWithElse, []},
+          {Credo.Check.Refactor.RedundantWithClauseResult, []},
+          {Credo.Check.Refactor.RejectReject, []},
+          {Credo.Check.Refactor.UnlessWithElse, []},
+          {Credo.Check.Refactor.WithClauses, []},
+
+          #
+          ## Warnings
+          #
+          {Credo.Check.Warning.ApplicationConfigInModuleAttribute, []},
+          {Credo.Check.Warning.BoolOperationOnSameValues, []},
+          {Credo.Check.Warning.Dbg, []},
+          {Credo.Check.Warning.ExpensiveEmptyEnumCheck, []},
+          {Credo.Check.Warning.IExPry, []},
+          {Credo.Check.Warning.IoInspect, []},
+          {Credo.Check.Warning.MissedMetadataKeyInLoggerConfig, []},
+          {Credo.Check.Warning.OperationOnSameValues, []},
+          {Credo.Check.Warning.OperationWithConstantResult, []},
+          {Credo.Check.Warning.RaiseInsideRescue, []},
+          {Credo.Check.Warning.SpecWithStruct, []},
+          {Credo.Check.Warning.StructFieldAmount, []},
+          {Credo.Check.Warning.UnsafeExec, []},
+          {Credo.Check.Warning.UnusedEnumOperation, []},
+          {Credo.Check.Warning.UnusedFileOperation, []},
+          {Credo.Check.Warning.UnusedKeywordOperation, []},
+          {Credo.Check.Warning.UnusedListOperation, []},
+          {Credo.Check.Warning.UnusedMapOperation, []},
+          {Credo.Check.Warning.UnusedPathOperation, []},
+          {Credo.Check.Warning.UnusedRegexOperation, []},
+          {Credo.Check.Warning.UnusedStringOperation, []},
+          {Credo.Check.Warning.UnusedTupleOperation, []},
+          {Credo.Check.Warning.WrongTestFilename, []}
+        ],
+        disabled: [
+          #
+          # ── Tech debt: pre-existing violations ────────────────────────────────────────────────────────────────────────────────────
+          # These checks found issues in the initial codebase. Disabled here so CI is
+          # a clean gate for new issues. Re-enable each check as its violations are
+          # fixed.
+          #
+          # Design: alias usage suggestions (advisory, not bugs)
+          {Credo.Check.Design.AliasUsage,
+           [priority: :low, if_nested_deeper_than: 2, if_called_more_often_than: 0]},
+          # Readability: alias ordering violations in accounts.ex, factory.ex, api_spec.ex
+          {Credo.Check.Readability.AliasOrder, []},
+          # Readability: lines > 120 chars in conversation_server.ex
+          {Credo.Check.Readability.MaxLineLength, [priority: :low, max_length: 120]},
+          # Readability: zero-arity function with parens in application.ex:82
+          {Credo.Check.Readability.ParenthesesOnZeroArityDefs, []},
+          # Readability: explicit try in conversation_server.ex:242
+          {Credo.Check.Readability.PreferImplicitTry, []},
+          # Readability: single-clause with/else in accounts.ex:190
+          {Credo.Check.Readability.WithSingleClause, []},
+          # Refactor: apply/2 with known args in application.ex (intentional dynamic dispatch)
+          {Credo.Check.Refactor.Apply, []},
+          # Refactor: cond with one condition in conversation_server.ex, sse_loop, inference_live
+          {Credo.Check.Refactor.CondStatements, []},
+          # Refactor: cyclomatic complexity in kick_turn, upsert_oauth_user, agent.ex
+          {Credo.Check.Refactor.CyclomaticComplexity, []},
+          # Refactor: function body nesting in conversation_server, accounts, wizard, show, provisioning
+          {Credo.Check.Refactor.Nesting, []},
+
+          #
+          # ── Checks scheduled for next update (opt-in for now) ───────────────────────────────────────────
+          {Credo.Check.Refactor.UtcNowTruncate, []},
+
+          #
+          # ── Controversial and experimental checks ────────────────────────────────────────────
+          # (opt-in, move to :enabled and use `mix credo --strict` to see)
+          #
+          {Credo.Check.Consistency.MultiAliasImportRequireUse, []},
+          {Credo.Check.Consistency.UnusedVariableNames, []},
+          {Credo.Check.Design.DuplicatedCode, []},
+          {Credo.Check.Design.SkipTestWithoutComment, []},
+          {Credo.Check.Readability.AliasAs, []},
+          {Credo.Check.Readability.BlockPipe, []},
+          {Credo.Check.Readability.ImplTrue, []},
+          {Credo.Check.Readability.MultiAlias, []},
+          {Credo.Check.Readability.NestedFunctionCalls, []},
+          {Credo.Check.Readability.OneArityFunctionInPipe, []},
+          {Credo.Check.Readability.OnePipePerLine, []},
+          {Credo.Check.Readability.SeparateAliasRequire, []},
+          {Credo.Check.Readability.SingleFunctionToBlockPipe, []},
+          {Credo.Check.Readability.SinglePipe, []},
+          {Credo.Check.Readability.Specs, []},
+          {Credo.Check.Readability.StrictModuleLayout, []},
+          {Credo.Check.Readability.WithCustomTaggedTuple, []},
+          {Credo.Check.Refactor.ABCSize, []},
+          {Credo.Check.Refactor.AppendSingleItem, []},
+          {Credo.Check.Refactor.CondInsteadOfIfElse, []},
+          {Credo.Check.Refactor.DoubleBooleanNegation, []},
+          {Credo.Check.Refactor.FilterReject, []},
+          {Credo.Check.Refactor.IoPuts, []},
+          {Credo.Check.Refactor.MapMap, []},
+          {Credo.Check.Refactor.ModuleDependencies, []},
+          {Credo.Check.Refactor.NegatedIsNil, []},
+          {Credo.Check.Refactor.PassAsyncInTestCases, []},
+          {Credo.Check.Refactor.PipeChainStart, []},
+          {Credo.Check.Refactor.RejectFilter, []},
+          {Credo.Check.Refactor.VariableRebinding, []},
+          {Credo.Check.Warning.LazyLogging, []},
+          {Credo.Check.Warning.LeakyEnvironment, []},
+          {Credo.Check.Warning.MapGetUnsafePass, []},
+          {Credo.Check.Warning.MixEnv, []},
+          {Credo.Check.Warning.UnsafeToAtom, []}
+        ]
+      }
+    }
+  ]
+}

--- a/templates/managoat-library/.dialyzer_ignore.exs
+++ b/templates/managoat-library/.dialyzer_ignore.exs
@@ -1,0 +1,9 @@
+# Dialyzer warnings that are understood and deliberately kept, each with its
+# reason. Entries are {file, warning_type, location}.
+#
+# Prefer `@dialyzer {:nowarn_function, name: arity}` beside the function: a
+# location pin here is only stable while nothing above it in the file moves.
+# Reach for this file when the warning has no single owning function, or when
+# the code is inside a dependency. A stale entry shows up in
+# `mix dialyzer --list-unused-filters`.
+[]

--- a/templates/managoat-library/.formatter.exs
+++ b/templates/managoat-library/.formatter.exs
@@ -1,0 +1,3 @@
+[
+  inputs: ["*.{ex,exs}", "{lib,test,scripts}/**/*.{ex,exs}"]
+]

--- a/templates/managoat-library/.github/dependabot.yml
+++ b/templates/managoat-library/.github/dependabot.yml
@@ -1,0 +1,22 @@
+# SHA-pinned actions never move on their own; dependabot is the only thing
+# that will ever propose bumping them. A mix bump that touches a runtime
+# dependency in mix.exs is a release (the release gate says so); a dev-only
+# bump is not. Same shape as BinaryBourbon/fountain's.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns: ["*"]
+
+  - package-ecosystem: mix
+    directory: /
+    schedule:
+      interval: weekly
+    # Security + patch/minor noise control: one PR per week at most per group.
+    groups:
+      hex-deps:
+        update-types: [minor, patch]

--- a/templates/managoat-library/.github/workflows/ci.yml
+++ b/templates/managoat-library/.github/workflows/ci.yml
@@ -1,0 +1,122 @@
+name: CI
+
+# The gate on every PR and on main, for a managoat_* library that graduated
+# from the Fountain umbrella (BinaryBourbon/fountain, decisions/0037). Same
+# checks the umbrella ran over it, in the same order, on the same Elixir and
+# OTP the umbrella pins. The publish workflow runs the tests again before it
+# publishes; this is the check a PR has to pass to reach main at all.
+#
+# Actions are pinned by SHA with the version in a comment. Dependabot bumps
+# the SHA and is supposed to update the comment; it has not always, so trust
+# the SHA over the comment.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+env:
+  MIX_ENV: test
+
+jobs:
+  ci:
+    name: ci
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    # ---- oauth only --------------------------------------------------------
+    # managoat_oauth runs its suite against a Postgres database of its own
+    # (test/test_helper.exs drops, creates and migrates it on every run).
+    # Every other library deletes this block, and the MANAGOAT_OAUTH_* line
+    # under `Test` below; scripts/graduate-library.sh does that for them.
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    # ---- end oauth only ----------------------------------------------------
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
+        with:
+          persist-credentials: false
+
+      - name: Set up Elixir
+        id: beam
+        uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1.24.1
+        with:
+          elixir-version: "1.19.2"
+          otp-version: "28.3"
+
+      - name: Restore deps cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
+        with:
+          path: deps
+          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-mix-
+
+      - name: Restore build cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
+        with:
+          path: _build
+          key: ${{ runner.os }}-build-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-${{ hashFiles('**/mix.lock') }}
+          # No bare "-build-" fallback: bytecode from another OTP or Elixir is
+          # rebuilt anyway, and a cross-version restore has produced subtle
+          # staleness in the umbrella.
+          restore-keys: |
+            ${{ runner.os }}-build-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-
+
+      - name: Install dependencies
+        run: mix deps.get
+
+      - name: Check for unused dependencies
+        run: mix deps.unlock --unused && git diff --exit-code mix.lock
+
+      - name: Check formatting
+        run: mix format --check-formatted
+
+      - name: Compile (warnings as errors)
+        run: mix compile --warnings-as-errors
+
+      - name: Run Credo
+        run: mix credo --strict
+
+      # The PLT encodes OTP + deps; rebuilding it cold takes minutes, so it is
+      # cached on the exact beam versions + lockfile. mix.exs pins its path to
+      # priv/plts for this cache. restore-keys deliberately omitted: a PLT from
+      # different versions would be rebuilt anyway.
+      - name: Restore dialyzer PLT cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
+        with:
+          path: priv/plts
+          key: ${{ runner.os }}-plt-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-${{ hashFiles('**/mix.lock') }}
+
+      # MIX_ENV=dev on purpose (the job env is test): dialyzer analyzes the
+      # shipped code; the test env would drag test/support and test-only deps
+      # into the analysis and the PLT.
+      - name: Dialyzer
+        run: MIX_ENV=dev mix dialyzer --format github
+
+      # --cover: the library's own threshold in mix.exs gates.
+      - name: Test
+        env: # oauth only
+          MANAGOAT_OAUTH_TEST_DATABASE_URL: postgres://postgres:postgres@localhost:5432/managoat_oauth_test # oauth only
+        run: mix test --cover
+
+      # What hex.publish will build. A dependency hex refuses (a git dep, a
+      # path dep) fails here, on the PR, instead of on main.
+      - name: Package builds
+        run: MIX_ENV=dev mix hex.build

--- a/templates/managoat-library/.github/workflows/publish.yml
+++ b/templates/managoat-library/.github/workflows/publish.yml
@@ -1,0 +1,175 @@
+name: Publish
+
+# Publishes this package to hex.pm. **CI is the only publisher**; nothing is
+# ever released from a laptop.
+#
+# The trigger is the version itself: merge a PR that bumps `@version` in
+# mix.exs and that version goes out. There is no tag to push and no button to
+# remember, because a release step a human performs is a release step a human
+# forgets. The `Release gate` workflow is the other half: it fails a PR that
+# changes what the package ships without bumping, so the bump happens during
+# review rather than after.
+#
+# Idempotent by construction: the run starts by asking hex whether this
+# version already exists and stops if it does. So a PR touching only the
+# tests or the changelog runs this workflow, finds nothing to do, and says so.
+#
+# Authentication is HEX_API_KEY, an organization-level secret on managoat
+# owned by the hex.pm user account that owns every managoat_* package. Hex
+# has no trusted publishing; the key is the mechanism and this workflow is
+# the only place it is used. `mix hex.publish` also builds and publishes the
+# docs (hexdocs.pm), which is why ex_doc is a dev dependency.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Two merges in quick succession must not race to publish the same version.
+concurrency:
+  group: publish
+  cancel-in-progress: false
+
+env:
+  MIX_ENV: test
+
+jobs:
+  publish:
+    name: Publish to hex
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    permissions:
+      # `contents: write` only to push the `v*` tag *after* a successful
+      # publish, as a record of which commit produced which version. The tag
+      # is an output of a release, never the input that causes one.
+      contents: write
+
+    # ---- oauth only --------------------------------------------------------
+    # The tests below need managoat_oauth's Postgres, as in ci.yml. Every
+    # other library deletes this block and the MANAGOAT_OAUTH_* line under
+    # `Test`; scripts/graduate-library.sh does that for them.
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    # ---- end oauth only ----------------------------------------------------
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
+
+      - name: Set up Elixir
+        id: beam
+        uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1.24.1
+        with:
+          elixir-version: "1.19.2"
+          otp-version: "28.3"
+
+      - name: Is there anything to publish?
+        id: release
+        run: |
+          elixir scripts/release.exs state > state.json
+          cat state.json
+          name=$(jq -r .name state.json)
+          version=$(jq -r .version state.json)
+          tag=$(jq -r .tag state.json)
+          published=$(jq -r .published state.json)
+          if [ "$published" = "true" ]; then needed=no; else needed=yes; fi
+          {
+            echo "name=$name"
+            echo "version=$version"
+            echo "tag=$tag"
+            echo "needed=$needed"
+          } >> "$GITHUB_OUTPUT"
+          echo "$name $version already on hex: $published (publish: $needed)"
+
+      - name: Restore deps cache
+        if: steps.release.outputs.needed == 'yes'
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
+        with:
+          path: deps
+          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-mix-
+
+      - name: Install dependencies
+        if: steps.release.outputs.needed == 'yes'
+        run: mix deps.get
+
+      # CI ran these on the PR. They are here again so a publish never happens
+      # on a tree that does not pass them, and so a failure names the gate
+      # that failed instead of surfacing as a publish that died inside hex.
+      - name: Compile (warnings as errors)
+        if: steps.release.outputs.needed == 'yes'
+        run: mix compile --warnings-as-errors
+
+      - name: Test
+        if: steps.release.outputs.needed == 'yes'
+        env: # oauth only
+          MANAGOAT_OAUTH_TEST_DATABASE_URL: postgres://postgres:postgres@localhost:5432/managoat_oauth_test # oauth only
+        run: mix test
+
+      # Package and docs, in one call. hex names are claimed on first publish
+      # and never released, so the name in mix.exs is permanent from here.
+      - name: Publish
+        if: steps.release.outputs.needed == 'yes'
+        env:
+          HEX_API_KEY: ${{ secrets.HEX_API_KEY }}
+          MIX_ENV: dev
+        run: |
+          if [ -z "$HEX_API_KEY" ]; then
+            echo "::error::HEX_API_KEY is empty: the managoat organization secret is not visible to this repository." >&2
+            exit 1
+          fi
+          mix hex.publish --yes
+
+      # After the fact, and only on success: which commit produced which
+      # version. A failed publish leaves no tag to clean up.
+      - name: Record the release as a tag
+        if: steps.release.outputs.needed == 'yes'
+        env:
+          NAME: ${{ steps.release.outputs.name }}
+          TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "$NAME ${TAG#v}" "$GITHUB_SHA"
+          git push origin "$TAG"
+
+      - name: Say what happened
+        env:
+          NAME: ${{ steps.release.outputs.name }}
+          VERSION: ${{ steps.release.outputs.version }}
+          NEEDED: ${{ steps.release.outputs.needed }}
+        run: |
+          if [ "$NEEDED" = "yes" ]; then
+            {
+              echo "### Published \`$NAME $VERSION\`"
+              echo
+              echo "https://hex.pm/packages/$NAME/$VERSION"
+              echo "https://hexdocs.pm/$NAME/$VERSION"
+              echo
+              echo "Tagged \`v$VERSION\` at \`$GITHUB_SHA\`."
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            {
+              echo "### Nothing to publish"
+              echo
+              echo "\`$NAME $VERSION\` is already on hex. This push changed the"
+              echo "repository without changing its version, which is fine for"
+              echo "tests, CI and the changelog."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/templates/managoat-library/.github/workflows/release-gate.yml
+++ b/templates/managoat-library/.github/workflows/release-gate.yml
@@ -1,0 +1,45 @@
+name: Release gate
+
+# Makes "does this need a release?" part of review rather than something
+# remembered afterwards.
+#
+# The publish workflow ships whatever version lands on main, so a PR that
+# changes what the package ships and leaves the version alone produces a
+# change that sits on main unreleased, invisible until somebody wonders why
+# the fix they merged is not on hex. This says so on the PR instead.
+#
+# It also front-loads everything that would make the publish fail on main,
+# where failing is cheap and a person is already looking: a version already
+# on hex (which can never be republished) and a missing changelog heading.
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  gate:
+    name: release gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # The deliberate exception: changing the published surface without cutting
+    # a release. Rare, and it should take a label and a sentence in the PR.
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-release') }}
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
+        with:
+          persist-credentials: false
+          # The guard diffs against the merge base, so it needs history.
+          fetch-depth: 0
+
+      - name: Set up Elixir
+        uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1.24.1
+        with:
+          elixir-version: "1.19.2"
+          otp-version: "28.3"
+
+      # No deps.get: scripts/release.exs is plain Elixir over OTP's httpc.
+      - name: Does this PR need a version bump?
+        run: elixir scripts/release.exs guard "origin/${{ github.base_ref }}"

--- a/templates/managoat-library/.gitignore
+++ b/templates/managoat-library/.gitignore
@@ -1,0 +1,10 @@
+/_build/
+/deps/
+/cover/
+/doc/
+/priv/plts/
+/.fetch
+/.elixir_ls/
+erl_crash.dump
+*.ez
+*.tar

--- a/templates/managoat-library/.tool-versions
+++ b/templates/managoat-library/.tool-versions
@@ -1,0 +1,2 @@
+erlang 28.3
+elixir 1.19.2-otp-28

--- a/templates/managoat-library/CHANGELOG.md
+++ b/templates/managoat-library/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to `__NAME__` are documented here. Format:
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
+[SemVer](https://semver.org/). Pre-1.0, a minor bump (`0.x` to `0.y`) may
+include breaking changes and says so; patch releases are always safe to take.
+
+Merging a version bump to `main` publishes it to hex; a PR that changes what
+the package ships without a bump fails the release gate.
+
+## [Unreleased]
+
+## [0.1.0] - __DATE__
+
+### Added
+
+- Extracted from Fountain (BinaryBourbon/fountain#__EXTRACTION_PR__).

--- a/templates/managoat-library/NOTICE
+++ b/templates/managoat-library/NOTICE
@@ -1,0 +1,11 @@
+__MODULE__ (__NAME__)
+Copyright (c) 2026 Jake Gaylor
+
+Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+This library was extracted from Fountain, https://github.com/BinaryBourbon/fountain,
+where it began as the umbrella app
+  apps/__NAME__
+under decisions/0037 (component libraries, extracted umbrella-first under the
+Managoat namespace), and graduated to this repository in
+BinaryBourbon/fountain#1345.

--- a/templates/managoat-library/scripts/release.exs
+++ b/templates/managoat-library/scripts/release.exs
@@ -1,0 +1,165 @@
+# The facts about a release of this package, in one place, so the PR gate and
+# the publish workflow cannot disagree about them. A port of Fountain's
+# scripts/sdk-release.mjs to the hex shape.
+#
+#   elixir scripts/release.exs state          -> JSON on stdout
+#   elixir scripts/release.exs guard <base>   -> the PR gate; exits 1 on a problem
+#
+# No dependencies: this runs before `mix deps.get` in both callers. The version
+# is read from the `@version` attribute in mix.exs rather than by loading the
+# project, so it needs no compiled deps either.
+defmodule Release do
+  @mix "mix.exs"
+  @changelog "CHANGELOG.md"
+
+  # Files whose contents reach a consumer. Changing one needs a release. The
+  # changelog is not here on purpose: requiring a version bump to write the
+  # changelog entry for that very version is a loop with no entrance. Neither
+  # are the tests, CI, or the README (hexdocs rebuilds it on the next release;
+  # it never needs one of its own).
+  @shipped_dirs ["lib/", "priv/"]
+  @shipped_files ["mix.exs"]
+
+  def main(["state"]) do
+    {name, version} = manifest(nil)
+
+    %{
+      "name" => name,
+      "version" => version,
+      "published" => published?(name, version),
+      "tag" => "v#{version}"
+    }
+    |> JSON.encode!()
+    |> IO.puts()
+  end
+
+  def main(["guard", base]) do
+    changed = git(["diff", "--name-only", "#{base}...HEAD"]) |> String.split("\n", trim: true)
+    {name, head_version} = manifest(nil)
+    {_, base_version} = manifest(base)
+    bumped = head_version != base_version
+
+    needs_release =
+      Enum.filter(changed, fn path ->
+        cond do
+          # mix.exs ships, but a dev-only dependency or a comment does not
+          # reach a consumer; compare the projection that does.
+          path == @mix -> consumer_facing(read(nil)) != consumer_facing(read(base))
+          path in @shipped_files -> true
+          true -> Enum.any?(@shipped_dirs, &String.starts_with?(path, &1))
+        end
+      end)
+
+    IO.puts("package:  #{name}")
+    IO.puts("base:     #{base_version}")
+    IO.puts("head:     #{head_version}#{if bumped, do: "  (bumped)", else: "  (unchanged)"}")
+    IO.puts("touched:  #{length(changed)} file(s)")
+    if needs_release != [], do: IO.puts("shipped:  #{Enum.join(needs_release, ", ")}")
+
+    cond do
+      needs_release != [] and not bumped ->
+        fail(
+          "This PR changes what #{name} ships (#{Enum.join(needs_release, ", ")}) but leaves " <>
+            "@version at #{head_version}. Nothing publishes without a bump, so the change " <>
+            "would sit on main unreleased. Bump @version in mix.exs, add a " <>
+            "\"## [<version>]\" heading to CHANGELOG.md, and commit. To change the " <>
+            "published surface without releasing, add the \"no-release\" label."
+        )
+
+      not bumped ->
+        IO.puts("\nNo release needed for this PR.")
+
+      true ->
+        # From here on the PR claims a release, so everything that would make
+        # the publish fail on main is checked here instead, where it is cheap.
+        problems =
+          [
+            published?(name, head_version) &&
+              "#{name} #{head_version} is already on hex, and hex never allows a version " <>
+                "to be republished. Bump to something new.",
+            not (File.read!(@changelog) =~ "## [#{head_version}]") &&
+              "#{@changelog} has no \"## [#{head_version}]\" heading. A release says what changed."
+          ]
+          |> Enum.filter(&is_binary/1)
+
+        case problems do
+          [] -> IO.puts("\nRelease looks well-formed. Merging this publishes #{head_version}.")
+          _ -> Enum.each(problems, &fail/1)
+        end
+    end
+
+    if Process.get(:failed), do: System.halt(1)
+  end
+
+  def main(_) do
+    IO.puts(:stderr, "usage: elixir scripts/release.exs state | guard <base-ref>")
+    System.halt(2)
+  end
+
+  # {app name, version} from mix.exs at HEAD (nil) or at a git ref.
+  defp manifest(ref) do
+    source = read(ref)
+
+    with [_, name] <- Regex.run(~r/^\s*app:\s*:(\w+)/m, source),
+         [_, version] <- Regex.run(~r/^\s*@version\s+"([^"]+)"/m, source) do
+      {name, version}
+    else
+      _ -> raise "could not read app: and @version from #{@mix}#{if ref, do: " at #{ref}"}"
+    end
+  end
+
+  defp read(nil), do: File.read!(@mix)
+  defp read(ref), do: git(["show", "#{ref}:#{@mix}"])
+
+  # mix.exs without what never reaches a consumer: comments, blank lines, and
+  # dependencies confined to :dev or :test (`only:` on one line, the shape the
+  # formatter writes). Everything else in the file (deps, package metadata,
+  # elixir requirement, the application spec) is the package.
+  defp consumer_facing(source) do
+    source
+    |> String.split("\n")
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == "" or String.starts_with?(&1, "#")))
+    |> Enum.reject(&(&1 =~ ~r/only:\s*(:dev|:test|\[\s*:(dev|test)\s*,\s*:(dev|test)\s*\])/))
+  end
+
+  # Whether hex already has this exact version. 200 yes, 404 no (a package
+  # that does not exist at all also answers 404); anything else is a fault.
+  defp published?(name, version) do
+    {:ok, _} = Application.ensure_all_started(:inets)
+    {:ok, _} = Application.ensure_all_started(:ssl)
+    url = ~c"https://hex.pm/api/packages/#{name}/releases/#{version}"
+
+    headers = [
+      {~c"accept", ~c"application/json"},
+      {~c"user-agent", ~c"managoat-release-script (#{name})"}
+    ]
+
+    ssl = [
+      verify: :verify_peer,
+      cacerts: :public_key.cacerts_get(),
+      customize_hostname_check: [match_fun: :public_key.pkix_verify_hostname_match_fun(:https)]
+    ]
+
+    case :httpc.request(:get, {url, headers}, [ssl: ssl, timeout: 15_000], body_format: :binary) do
+      {:ok, {{_, 200, _}, _, _}} -> true
+      {:ok, {{_, 404, _}, _, _}} -> false
+      {:ok, {{_, status, _}, _, _}} -> raise "hex.pm answered #{status} for #{name} #{version}"
+      {:error, reason} -> raise "hex.pm request failed: #{inspect(reason)}"
+    end
+  end
+
+  defp git(args) do
+    case System.cmd("git", args, stderr_to_stdout: true) do
+      {out, 0} -> out
+      {out, status} -> raise "git #{Enum.join(args, " ")} exited #{status}: #{out}"
+    end
+  end
+
+  defp fail(message) do
+    IO.puts(:stderr, "::error::#{message}")
+    Process.put(:failed, true)
+  end
+end
+
+Release.main(System.argv())


### PR DESCRIPTION
Part of #1345 and #1334. The recipe for moving an umbrella library app to `managoat/managoat_<name>`, publishing it to hex from CI, and pinning Fountain back onto the release. Written once here; proved on `managoat_substitution` and then run for the other seven in the Fountain-side PRs that follow this one.

## What is in it

- **`templates/managoat-library/`**, copied into every new repository:
  - `.github/workflows/ci.yml`: push to `main` and PRs; `erlef/setup-beam` at the SHA and versions `ci.yml` pins (Elixir 1.19.2, OTP 28.3); deps, `_build` and PLT caches keyed like Fountain's; `deps.get`, unused-deps check, format, compile `--warnings-as-errors`, `credo --strict`, `MIX_ENV=dev mix dialyzer`, `mix test --cover` (the library's own threshold gates), `mix hex.build`. A Postgres service block that only `managoat_oauth` keeps; the script strips it for the others.
  - `.github/workflows/publish.yml`: on push to `main`, `contents: write`; `scripts/release.exs state`, and if the version is not on hex: `deps.get`, compile, `mix test`, `mix hex.publish --yes` with `HEX_API_KEY`, then the `v<version>` tag. Idempotent: a docs-only merge finds nothing to do. Fails loudly when the secret is empty.
  - `.github/workflows/release-gate.yml`: on PRs, `scripts/release.exs guard origin/<base>`; skipped under the `no-release` label.
  - `scripts/release.exs`: the port of `sdk-release.mjs`. Plain Elixir over `:httpc` (no deps, so both workflows run it before `deps.get`); reads `@version` from `mix.exs` by regex rather than loading the project. `guard` treats `lib/`, `priv/` and the consumer-facing part of `mix.exs` as shipped (comments and `only: :dev/:test` deps are not, so a Dependabot bump of credo is not a release), and checks bump, already-published, and the changelog heading.
  - `.credo.exs` (Fountain's, trimmed to `lib/` and `test/`), `.dialyzer_ignore.exs`, `.formatter.exs`, `.gitignore`, `.tool-versions`, `dependabot.yml`, `NOTICE`, `CHANGELOG.md`.
- **`scripts/graduate-library.sh <name>`**: preflight (clean tree, `main` at `origin/main`, `mix hex.build` succeeds), `git subtree split`, `gh repo create` + topic + push as `main`, the stand-alone conversion in a fresh clone (template in, umbrella paths out of `mix.exs`, `ex_doc`/credo/dialyxir in, own `mix.lock`, local gates, commit, push), `no-release` label, branch protection requiring `ci` and `release gate` with no review. Idempotent after a failure in the last two steps. `--prepare-only` does everything up to and including the conversion in a scratch clone and touches nothing on GitHub.
- **CONTRIBUTING.md, "Graduating a library"**: the stability test, the secret, the script, the Fountain-side PR it does not do, the ordering rule (runner after sandbox), the pin policy and the cost.

## Verified

- `--prepare-only substitution` from a clean `main` worktree: split, conversion, `deps.get`, `format`, compile (dev and test), `credo --strict`, 22 tests green, `hex.build`, `release.exs state` -> `{"published":false, ...}`; then `MIX_ENV=dev mix dialyzer` and `mix docs` on the prepared tree, both clean.
- `release.exs guard` exercised on the prepared tree: no change (ok), `lib/` change without bump (fails), bump without changelog heading (fails), bump with heading (ok), dev-only dep change (ok), runtime dep change without bump (fails), already-published version (fails, using `dialyxir 1.4.7` as the stand-in), changelog-only change (ok).
- `actionlint` and `shellcheck` clean; root `mix format --check-formatted` and `docs_test.exs` green.

## What the template needed that the SDK pattern did not

- A dev-only `dialyxir` pinned to the same git ref the umbrella uses (1.4.7 crashes on OTP 28); `mix hex.build` accepts a git dependency that is `only: [:dev, :test]`, confirmed.
- `ex_doc` plus a `docs:` entry, because `mix hex.publish` publishes hexdocs in the same call.
- A `concurrency` group on publish, so two quick merges cannot race for the same version.
- An oauth-only Postgres service in **both** workflows, since publish runs the tests too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019jvYzhde9vkLhKmeBd5p3W
