### PR TITLE
fix(libraries): two things the stand-alone gates found before graduation

### DIFF
--- a/apps/managoat_broker/mix.exs
+++ b/apps/managoat_broker/mix.exs
@@ -59,10 +59,12 @@ defmodule Managoat.Broker.MixProject do
       {:x509, "~> 0.9"},
       {:telemetry, "~> 1.0"},
       # Test only: a real HTTPS origin behind the proxy, a WebSocket echo on
-      # it, and JSON for what the origin echoes back.
+      # it, and JSON for what the origin echoes back. jason is :dev as well
+      # because credo depends on it in :dev; with only :test here, Mix
+      # refuses the divergence once the library stands alone.
       {:bandit, "~> 1.5", only: :test},
       {:websock_adapter, "~> 0.5", only: :test},
-      {:jason, "~> 1.2", only: :test}
+      {:jason, "~> 1.2", only: [:dev, :test]}
     ]
   end
 

--- a/apps/managoat_docs/test/managoat/docs/checks_test.exs
+++ b/apps/managoat_docs/test/managoat/docs/checks_test.exs
@@ -24,9 +24,19 @@ defmodule Managoat.Docs.ChecksTest do
 
   # Writes `files` under <tmp>/docs, the Dockerfile at <tmp>/Dockerfile, and
   # defines a docs module over them. Options pass through to the `use` line.
+  #
+  # The directory name is random, not `System.unique_integer/1`: that integer
+  # is unique per VM, and two runs of this suite on one machine (a second
+  # worktree, or a run after one that was interrupted) reuse the same small
+  # numbers, so a "sound" manual landed in a directory a previous run had
+  # written `orphans/lost.md` into and failed the orphan check. It is also
+  # removed when the test ends, which the old shape never did (238 leftovers
+  # were in one developer's tmp dir when this was found).
   defp manual(files, opts \\ []) do
-    root = Path.join(System.tmp_dir!(), "managoat_docs_#{System.unique_integer([:positive])}")
+    suffix = 8 |> :crypto.strong_rand_bytes() |> Base.url_encode64(padding: false)
+    root = Path.join(System.tmp_dir!(), "managoat_docs_#{suffix}")
     File.mkdir_p!(Path.join(root, "docs"))
+    on_exit(fn -> File.rm_rf!(root) end)
 
     for {name, body} <- files do
       path = Path.join([root, "docs", name])


### PR DESCRIPTION
Part of #1345 and #1334. The `--prepare-only` pass of `scripts/graduate-library.sh` (#1362) over the remaining libraries found two faults the umbrella hides. Both have to be on `main` before `managoat_docs` and `managoat_broker` are split out, so they are their own PR; no conflict with #1362 or #1366.

- **`managoat_docs`**: `checks_test.exs` built each fixture manual in `<tmp>/managoat_docs_<System.unique_integer>`, unique per VM and never removed. Two runs on one machine reuse the same small integers, so a "sound" manual landed in a directory an earlier run had written `orphans/lost.md` into, and the orphan check failed (238 leftover directories in one tmp dir). Random name, `on_exit` cleanup. Verified: the stand-alone suite failed deterministically before, and passes twice in a row after, with the leftovers still present.
- **`managoat_broker`**: `jason` was `only: :test`; credo (which the stand-alone repo adds in `:dev`) depends on jason in `:dev`, and Mix refuses the divergence at `deps.get`. `only: [:dev, :test]` now. Verified: `deps.get`, compile, credo, 70 tests, `hex.build` all green stand-alone.

Umbrella gates: `mix deps.get` leaves `mix.lock` unchanged, `mix format --check-formatted`, `mix credo --strict` (no issues), `managoat_docs` 110 tests and `managoat_broker` 70 tests at 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019jvYzhde9vkLhKmeBd5p3W
