### PR TITLE
refactor(conversations): the size ratchet and honest section headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,14 @@ upgrade, is in
   merged into the gate, a Dockerfile `COPY` per library, and a test that
   refuses a library which reaches back into Fountain).
 
+- **`ConversationServer` only shrinks** (#1370, tracker #1369). The first
+  step of refactoring the server by subtraction, the "not a rewrite" ADR
+  0037 promised: `conversation_server_size_test.exs` pins the file at its
+  current 4,498 lines and fails if it grows, and each later sub-issue lowers
+  the pin in the PR that moves a function family out. The section headers
+  now say what sits under them (`sprite environment and egress`, `turns`,
+  `permissions, reclaim and redaction`). No code moved.
+
 ### Added
 
 - **A native egress credential broker, selected by `BROKER_LISTEN_PORT`**

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -1512,7 +1512,7 @@ defmodule Fountain.Conversations.ConversationServer do
       broker_env(state)
   end
 
-  # ── Egress credential brokerage (ADR 0019 gate 1a) ─────────────────────────
+  # ── sprite environment and egress (ADR 0019 gate 1a) ──────────────────────
 
   defp brokered?(state), do: Fountain.Broker.enabled_for?(state.user_id)
 
@@ -2753,7 +2753,7 @@ defmodule Fountain.Conversations.ConversationServer do
     {:noreply, %{state | replay_dedup: MapSet.new()}}
   end
 
-  # ── sandbox lifetime ──────────────────────────────────────────────────────
+  # ── permissions, reclaim and redaction ────────────────────────────────────
 
   def handle_info(:lifecycle_check, state) do
     schedule_lifecycle_check()
@@ -3172,7 +3172,7 @@ defmodule Fountain.Conversations.ConversationServer do
   defp redact(nil), do: nil
   defp redact(_present), do: "[REDACTED]"
 
-  # ── helpers ───────────────────────────────────────────────────────────────
+  # ── turns ─────────────────────────────────────────────────────────────────
 
   # A runtime session lives in the sandbox filesystem, so it cannot follow the
   # conversation onto a freshly provisioned one. Until #778 a wake that took

--- a/apps/fountain/test/fountain/conversations/conversation_server_size_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_size_test.exs
@@ -1,0 +1,34 @@
+defmodule Fountain.Conversations.ConversationServerSizeTest do
+  use ExUnit.Case, async: true
+
+  @moduledoc """
+  `ConversationServer` only shrinks.
+
+  Tracker #1369 refactors the server by subtraction: each sub-issue moves a
+  function family into a module under `Fountain.Conversations.*` and lowers
+  `@pin` to the file's new length in the same PR. The pin is the file's line
+  count on `main` at the last move, so a change that makes the file longer
+  fails here and has to say why.
+
+  The shape is the docs-style allowlist that only shrinks (#911): the number
+  is not a target, it is a record of where the file is, and the only edit it
+  accepts is downward. Lower it when you move something out; never raise it.
+  """
+
+  @pin 4498
+
+  @server "apps/fountain/lib/fountain/conversations/conversation_server.ex"
+
+  test "the server is no longer than the pin" do
+    root = Path.expand("../../../../..", __DIR__)
+    lines = root |> Path.join(@server) |> File.read!() |> String.split("\n")
+    # `String.split/2` yields one more element than there are newlines, so
+    # this is `wc -l` for a file that ends in a newline.
+    count = length(lines) - 1
+
+    assert count <= @pin,
+           "#{@server} is #{count} lines, over the pin of #{@pin}. " <>
+             "The server only shrinks (#1369): move the new code into a " <>
+             "Fountain.Conversations.* module rather than raising the pin."
+  end
+end


### PR DESCRIPTION
Part of #1369, first of eight. Comment-only on the server plus one new test file; nothing moves.

## What changed

**Functions moved:** none. #1370 names no functions and this PR moves no line of code. `git diff --stat main -- apps/fountain/test/fountain/conversations/conversation_server_*_test.exs` is empty (the size test is new, not a change to an existing file).

**New test:** `apps/fountain/test/fountain/conversations/conversation_server_size_test.exs`, `@pin 4498`. Reads the server source, asserts `wc -l` is at or under the pin, and the failure message names #1369 and says the file only shrinks. Each later sub-issue lowers the pin in the same PR as its move.

**Section headers renamed**, each keeping its 78-column width:

| line | before | after |
|---|---|---|
| 1515 | `Egress credential brokerage (ADR 0019 gate 1a)` | `sprite environment and egress (ADR 0019 gate 1a)` |
| 2756 | `sandbox lifetime` | `permissions, reclaim and redaction` |
| 3175 | `helpers` | `turns` |

The names were checked against what is under them: the first section holds `broker_*` and the whole `*_env` / `merge_secrets` / `write_runtime_config` / `prepare_*_sprite` family; the second holds `lifecycle_check`, `resolve_permission` and the caller-tool answers, `reclaim_sandbox` through `destroy_sandbox`, `terminate`, and `format_status` / `redact_*`; the third is the turn machinery from `interrupt_turn` to `finish_acp_turn` (with `forget_runtime_session`, `create_sandbox_handle`, the `*_mcp_servers` list and the callback key at its head; the last two are #1371's).

**CHANGELOG:** one entry under `[Unreleased] → ### Changed`.

## Pin

| | lines |
|---|---|
| before | 4498 |
| after | 4498 |

## Gates

| gate | result |
|---|---|
| `MIX_ENV=test mix compile --warnings-as-errors` | clean |
| `mix format --check-formatted` (mise Elixir 1.19.2) | exit 0 |
| `mix credo --strict` | 6215 mods/funs, no issues |
| `MIX_ENV=dev mix dialyzer` | passed (2 errors, 2 skipped, 0 unnecessary skips) |
| `conversation_server_*_test.exs` (12 server files + size test) | 117 tests, 0 failures |
| `audit_guardrail_test`, `caller_tools_test`, `provisioning_test`, `docs_test` | 135 tests, 0 failures |
| full root suite | posted as a comment when it finishes |

**Proof the ratchet bites:** appended one comment line to the server (4499 lines), ran the size test alone: `1 test, 1 failure`, message `... is 4499 lines, over the pin of 4498. The server only shrinks (#1369) ...`. Removed the line; the file is back at 4498 with the same three-line diff.

## Notes for the tracker

- The tracker counts thirteen server test files at 4,756 lines; `main` at 369dd609 has **twelve** at 3,488 lines (the ACP extraction, #1339, took the rest). The rule is unchanged: those twelve do not change in any sub-issue.
- `CHANGELOG.md` is excluded from vale and the docs-style gate by design; `docs_test` still covers it as a snippet and is green.

Closes #1370. Part of #1369.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mx2sij38JHM6gQu6PxiGG
