### PR TITLE
refactor(conversations): MCP server list and callback key out (McpServers, CallbackKey)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,16 @@ upgrade, is in
   the pin in the PR that moves a function family out. The section headers
   now say what sits under them (`sprite environment and egress`, `turns`,
   `permissions, reclaim and redaction`). No code moved.
+- **The MCP server list and the callback key have left `ConversationServer`**
+  (#1371, tracker #1369). `Fountain.Conversations.McpServers` assembles the
+  list a runtime receives (the agent's own after `${VAR}` substitution, then
+  the Fountain-served buzz, team, team-comms and caller-tool entries) and
+  `Fountain.Conversations.CallbackKey` mints, rotates and expires the
+  sprite's callback key and builds its env pair. Functions over rows and
+  values; the server passes in what it holds. No behaviour, timer, audit
+  event or option changed, and `ConversationServer.callback_api_key_opts/0`
+  still answers for the tests that pin it. The pin drops from 4,498 to
+  4,348.
 
 ### Added
 

--- a/apps/fountain/lib/fountain/conversations/callback_key.ex
+++ b/apps/fountain/lib/fountain/conversations/callback_key.ex
@@ -1,0 +1,144 @@
+defmodule Fountain.Conversations.CallbackKey do
+  @moduledoc """
+  The per-conversation API key that authenticates the sandbox back to
+  Fountain: how long it lives, the options it is minted with, the env pair
+  that carries it into the sprite, and the rotation on every fresh provision
+  and reattach.
+
+  The plaintext lives only in `ConversationServer` state (`callback_token`)
+  and in the sandbox's process env (`Fountain.Conversations.Identity`); the
+  durable record is a hash in `api_keys`. `rotate/2` returns the new
+  plaintext and row id for the server to hold, with the conversation row
+  updated to point at the key. Minting and revoking go through
+  `Fountain.Accounts`, which records the audit events (ADR 0013); nothing
+  here writes the trail itself.
+
+  Functions over rows and values, not over server state (#1369).
+  """
+
+  require Logger
+
+  alias Fountain.{Accounts, Conversations}
+  alias Fountain.Conversations.Conversation
+
+  # How long a sprite's callback key stays valid.
+  #
+  # This is a backstop, not the primary control: the key is revoked at
+  # terminate/2 and rotated on every provision and reattach, so under normal
+  # operation it is replaced long before expiry. It exists for the hard-crash
+  # case, where the row is orphaned and would otherwise be valid forever.
+  #
+  # The default is deliberately generous. The token is only rotated on provision
+  # and reattach, so a TTL shorter than the longest continuously-running
+  # conversation would expire a token mid-flight and break the agent's callbacks
+  # — a worse failure than a long-lived orphan. Lower it if conversations in your
+  # deployment are short.
+  @default_ttl_seconds 30 * 24 * 60 * 60
+
+  @spec ttl_seconds() :: non_neg_integer()
+  def ttl_seconds do
+    Application.get_env(:fountain, :callback_key_ttl_seconds, @default_ttl_seconds)
+  end
+
+  # The `x != ""` guards here defend against operator configuration, not against
+  # types. Dialyzer proves them always-true from today's success typings —
+  # `PublicUrl.base/0` cannot currently return `""` — and flags both the
+  # comparison (`exact_compare`) and the `if`'s consequently-dead else branch
+  # (`pattern_match`). The guards stay: a future config path that yields an
+  # empty base or token must produce no callback env, not a sprite told to call
+  # back to `""`.
+  #
+  # Suppressed here rather than in `.dialyzer_ignore.exs` because that file
+  # pins by `{line, column}`, and this function sat near the bottom of a
+  # 1400-line module before #1371: the pin moved three times during #540
+  # alone, each time failing the build with a misleading "Unnecessary Skips:
+  # 1" that reads like a stale suppression rather than "you added lines
+  # above". A function-scoped attribute travels with the code it describes
+  # and is narrower than the file-wide alternative.
+  @dialyzer {:nowarn_function, env: 1}
+  @spec env(String.t() | nil) :: [{String.t(), String.t()}]
+  def env(token) do
+    base = Fountain.PublicUrl.base()
+
+    if is_binary(base) and base != "" and is_binary(token) and token != "" do
+      [{"FOUNTAIN_BASE_URL", base}, {"FOUNTAIN_TOKEN", token}]
+    else
+      []
+    end
+  end
+
+  @doc """
+  Options used when minting a sprite's callback key.
+
+  `"sprite"` scope, not full: the sandbox can stream, prompt and spawn
+  sub-agents, but cannot mint a key that would survive the revoke at teardown.
+  The expiry is a backstop for the orphan case — if the BEAM dies hard the row
+  is never revoked, and without it the key stays valid forever.
+
+  Public so the scope and expiry can be asserted directly (#192): an unscoped
+  callback token is the privilege-escalation path the scoping exists to close.
+  `ConversationServer.callback_api_key_opts/0` re-exports it for the tests
+  that pin it there.
+  """
+  @spec api_key_opts() :: keyword()
+  def api_key_opts do
+    [
+      scopes: ["sprite"],
+      expires_at:
+        DateTime.utc_now()
+        |> DateTime.add(ttl_seconds(), :second)
+        |> DateTime.truncate(:second),
+      # Minting a sprite credential is exactly the event the trail is for, and
+      # this is the one mint the account owner did not ask for by hand. Low
+      # volume by construction: rotation happens on fresh provision and on
+      # wake, not per turn.
+      actor: "system:conversation_server"
+    ]
+  end
+
+  @doc """
+  Issue a fresh per-conversation API key scoped to the conversation owner,
+  revoking `previous_key_id` — the one THIS server previously minted (a
+  re-provision or reattach within one server life) — when there is one.
+
+  Returns `{:ok, plaintext, key_id, conv}` with the row now pointing at the
+  key, or `{:error, conv}` when the mint failed; the caller holds the
+  plaintext, since the durable record is a hash in `api_keys` which cannot
+  be reversed. That is why the key is rotated on every fresh provision /
+  reattach instead of trying to recover the old plaintext.
+
+  Deliberately NOT revoking `conv.callback_api_key_id` when it isn't
+  ours: with duplicate servers (registry lag, #367), the row's id can be
+  the live credential of the other server's sprite — revoking it 401s
+  every callback and sub-agent spawn there, surfaced nowhere. A
+  predecessor's un-revoked key goes inert at its `expires_at` and its
+  row is pruned by RetentionPruner.
+  """
+  @spec rotate(Conversation.t(), String.t() | nil) ::
+          {:ok, String.t(), String.t(), Conversation.t()} | {:error, Conversation.t()}
+  def rotate(%Conversation{} = conv, previous_key_id) do
+    if previous_key_id do
+      _ =
+        Accounts.revoke_api_key(conv.user_id, previous_key_id,
+          actor: "system:conversation_server"
+        )
+    end
+
+    case Accounts.create_api_key(
+           conv.user_id,
+           "sprite:#{String.slice(conv.id, 0, 8)}",
+           api_key_opts()
+         ) do
+      {:ok, {%Accounts.ApiKey{id: key_id}, raw}} ->
+        {:ok, conv} = Conversations.update_conversation(conv, %{callback_api_key_id: key_id})
+        {:ok, raw, key_id, conv}
+
+      {:error, cs} ->
+        Logger.warning(
+          "could not issue callback api key for conv #{conv.id}: #{inspect(cs.errors)}"
+        )
+
+        {:error, conv}
+    end
+  end
+end

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -23,8 +23,7 @@ defmodule Fountain.Conversations.ConversationServer do
     Vaults
   }
 
-  alias Fountain.Conversations.{Conversation, HomeCheckpoint, Lifecycle}
-  alias Managoat.Substitution
+  alias Fountain.Conversations.{CallbackKey, Conversation, HomeCheckpoint, Lifecycle, McpServers}
 
   # How often the sandbox lifetime bounds are evaluated. A minute is far finer
   # than the bounds themselves (an hour, a day), so the cost of the tick is
@@ -738,7 +737,7 @@ defmodule Fountain.Conversations.ConversationServer do
   end
 
   defp dispatch_provision(state, conv, sandbox, agent, env, _vault, secrets) do
-    case substitute_agent_mcp(agent, env, secrets) do
+    case McpServers.substitute_agent(agent, env, secrets) do
       {:ok, agent} ->
         case sandbox.status do
           s when s in ["ready", "suspended"] ->
@@ -773,30 +772,6 @@ defmodule Fountain.Conversations.ConversationServer do
         Conversations.update_conversation(conv, %{status: "failed"})
         {:stop, :normal, state}
     end
-  end
-
-  # Resolve `${VAR}` references in the agent's MCP server config against
-  # env_vars + env_secrets + vault_secrets (vault wins). Env vars values
-  # are coerced to strings; non-string values further down the tree pass
-  # through untouched.
-  defp substitute_agent_mcp(nil, _env, _secrets), do: {:ok, nil}
-
-  defp substitute_agent_mcp(agent, env, secrets) do
-    vars = substitution_vars(env, secrets)
-
-    case Substitution.apply(agent.mcp_servers || %{}, vars) do
-      {:ok, mcp} -> {:ok, %{agent | mcp_servers: mcp}}
-      {:error, _} = err -> err
-    end
-  end
-
-  defp substitution_vars(env, secrets) do
-    env_vars =
-      if env,
-        do: Map.new(env.env_vars || %{}, fn {k, v} -> {to_string(k), to_string(v)} end),
-        else: %{}
-
-    Map.merge(env_vars, secrets)
   end
 
   defp fresh_provision(state, conv, sandbox, agent, env, secrets) do
@@ -1498,7 +1473,7 @@ defmodule Fountain.Conversations.ConversationServer do
 
   defp do_build_sprite_env(state, agent, env, secrets, sandbox_url) do
     (state.runtime_module.default_env(agent, state.env_credentials) || []) ++
-      fountain_callback_env(state.callback_token) ++
+      CallbackKey.env(state.callback_token) ++
       conversation_env(state.conversation_id) ++
       sandbox_id_env(state.sandbox_id) ++
       sandbox_url_env(sandbox_url) ++
@@ -3113,7 +3088,7 @@ defmodule Fountain.Conversations.ConversationServer do
   # already dead or inert.
   #
   # If the BEAM crashes hard (SIGKILL — untrappable) the row in `api_keys`
-  # is left behind, but it is not dangerous: `callback_api_key_opts/0`
+  # is left behind, but it is not dangerous: `CallbackKey.api_key_opts/0`
   # sets an `expires_at`, so an un-revoked key stops authenticating on its
   # own, and RetentionPruner deletes long-expired rows. See SandboxReaper
   # for the sprite half, which does not self-heal.
@@ -3242,146 +3217,24 @@ defmodule Fountain.Conversations.ConversationServer do
     )
   end
 
-  # The `x != ""` guards here defend against operator configuration, not against
-  # types. Dialyzer proves them always-true from today's success typings —
-  # `PublicUrl.base/0` cannot currently return `""` — and flags both the
-  # comparison (`exact_compare`) and the `if`'s consequently-dead else branch
-  # (`pattern_match`). The guards stay: a future config path that yields an
-  # empty base or token must produce no callback env, not a sprite told to call
-  # back to `""`.
-  #
-  # Suppressed here rather than in `.dialyzer_ignore.exs` because that file
-  # pins by `{line, column}`, and this function sits near the bottom of a
-  # 1400-line module: the pin moved three times during #540 alone, each time
-  # failing the build with a misleading "Unnecessary Skips: 1" that reads like
-  # a stale suppression rather than "you added lines above". A function-scoped
-  # attribute travels with the code it describes and is narrower than the
-  # file-wide alternative.
-  @dialyzer {:nowarn_function, fountain_callback_env: 1}
-  defp fountain_callback_env(token) do
-    base = Fountain.PublicUrl.base()
-
-    if is_binary(base) and base != "" and is_binary(token) and token != "" do
-      [{"FOUNTAIN_BASE_URL", base}, {"FOUNTAIN_TOKEN", token}]
-    else
-      []
-    end
-  end
-
-  # The Buzz reply tools (#737), injected into `session/new` only for a
-  # Buzz-driven conversation and only once a callback token has been minted —
-  # `Fountain.Buzz` decides both. `[]` for every other conversation.
-  defp buzz_mcp_servers(%{callback_token: token, conversation_id: conv_id})
-       when is_binary(token) and is_binary(conv_id) do
-    Fountain.Buzz.conversation_mcp_servers(conv_id, token)
-  end
-
-  defp buzz_mcp_servers(_state), do: []
-
-  # The team tools (#851), for conversations on the team channel.
-  defp team_mcp_servers(%{callback_token: token, conversation_id: conv_id})
-       when is_binary(token) and is_binary(conv_id),
-       do: Fountain.Team.conversation_mcp_servers(conv_id, token)
-
-  defp team_mcp_servers(_state), do: []
-
-  # A teammate's email + phone tools (flag `team_comms`), injected the same
-  # way: only for a team conversation whose teammate has a contact, and only
-  # once a callback token exists — `Fountain.Team.Comms` decides. Computed
-  # at every turn kick, so a contact given mid-session is there next turn.
-  defp team_comms_mcp_servers(%{callback_token: token, conversation_id: conv_id})
-       when is_binary(token) and is_binary(conv_id) do
-    Fountain.Team.Comms.conversation_mcp_servers(conv_id, token)
-  end
-
-  defp team_comms_mcp_servers(_state), do: []
-
-  # The caller-tool bridge (#1202): the tools a chat-completions or AG-UI
-  # client defined, served back to the sandbox as one more MCP server. Read
-  # off the conversation row at every turn kick, so a list registered by the
-  # request that opened this turn is on it.
-  defp caller_mcp_servers(%{callback_token: token}, conv) when is_binary(token),
-    do: Fountain.CallerTools.conversation_mcp_servers(conv, token)
-
-  defp caller_mcp_servers(_state, _conv), do: []
-
-  # How long a sprite's callback key stays valid.
-  #
-  # This is a backstop, not the primary control: the key is revoked at
-  # terminate/2 and rotated on every provision and reattach, so under normal
-  # operation it is replaced long before expiry. It exists for the hard-crash
-  # case, where the row is orphaned and would otherwise be valid forever.
-  #
-  # The default is deliberately generous. The token is only rotated on provision
-  # and reattach, so a TTL shorter than the longest continuously-running
-  # conversation would expire a token mid-flight and break the agent's callbacks
-  # — a worse failure than a long-lived orphan. Lower it if conversations in your
-  # deployment are short.
-  @default_callback_key_ttl_seconds 30 * 24 * 60 * 60
-
-  defp callback_key_ttl_seconds do
-    Application.get_env(:fountain, :callback_key_ttl_seconds, @default_callback_key_ttl_seconds)
-  end
-
   @doc """
-  Options used when minting a sprite's callback key.
+  The options a sprite's callback key is minted with: `CallbackKey.api_key_opts/0`.
 
-  `"sprite"` scope, not full: the sandbox can stream, prompt and spawn
-  sub-agents, but cannot mint a key that would survive the revoke at teardown.
-  The expiry is a backstop for the orphan case — if the BEAM dies hard the row
-  is never revoked, and without it the key stays valid forever.
-
-  Public so the scope and expiry can be asserted directly: this module has no
-  test coverage of its own (#192), and an unscoped callback token is the
-  privilege-escalation path the scoping exists to close.
+  Re-exported here because `conversation_server_shutdown_revoke_test`,
+  `api_key_scope_test` and `audit_coverage_test` pin the scope and expiry
+  through this module, and the server tests do not change (#1369).
   """
-  def callback_api_key_opts do
-    [
-      scopes: ["sprite"],
-      expires_at:
-        DateTime.utc_now()
-        |> DateTime.add(callback_key_ttl_seconds(), :second)
-        |> DateTime.truncate(:second),
-      # Minting a sprite credential is exactly the event the trail is for, and
-      # this is the one mint the account owner did not ask for by hand. Low
-      # volume by construction: rotation happens on fresh provision and on
-      # wake, not per turn.
-      actor: "system:conversation_server"
-    ]
-  end
+  def callback_api_key_opts, do: CallbackKey.api_key_opts()
 
-  # Issue a fresh per-conversation API key scoped to the conversation
-  # owner, revoking the one THIS server previously minted (a re-provision
-  # or reattach within one server life). The plaintext is only kept in
-  # `state.callback_token` — the durable record is a hash in `api_keys`,
-  # which we can't reverse, so we rotate on every fresh provision /
-  # reattach instead of trying to recover the old plaintext.
-  #
-  # Deliberately NOT revoking `conv.callback_api_key_id` when it isn't
-  # ours: with duplicate servers (registry lag, #367), the row's id can be
-  # the live credential of the other server's sprite — revoking it 401s
-  # every callback and sub-agent spawn there, surfaced nowhere. A
-  # predecessor's un-revoked key goes inert at its `expires_at` and its
-  # row is pruned by RetentionPruner.
+  # Rotate the sandbox's callback key (`CallbackKey.rotate/2`) and hold the
+  # result: the plaintext and the row id on success. On failure only the
+  # token is cleared; `callback_api_key_id` is left as it was.
   defp rotate_callback_api_key(state, %Conversation{} = conv) do
-    if id = state.callback_api_key_id do
-      _ = Accounts.revoke_api_key(conv.user_id, id, actor: "system:conversation_server")
-    end
-
-    case Accounts.create_api_key(
-           conv.user_id,
-           "sprite:#{String.slice(conv.id, 0, 8)}",
-           callback_api_key_opts()
-         ) do
-      {:ok, {%Accounts.ApiKey{id: key_id}, raw}} ->
-        {:ok, conv} = Conversations.update_conversation(conv, %{callback_api_key_id: key_id})
+    case CallbackKey.rotate(conv, state.callback_api_key_id) do
+      {:ok, raw, key_id, conv} ->
         {%{state | callback_token: raw, callback_api_key_id: key_id}, conv}
 
-      {:error, cs} ->
-        Logger.warning(
-          "could not issue callback api key for conv #{conv.id}: #{inspect(cs.errors)}"
-        )
-
+      {:error, conv} ->
         {%{state | callback_token: nil}, conv}
     end
   end
@@ -3705,10 +3558,7 @@ defmodule Fountain.Conversations.ConversationServer do
                     images: images,
                     mcp_servers:
                       Fountain.Runtimes.ACP.mcp_servers(with_connection_servers(agent, state)) ++
-                        buzz_mcp_servers(state) ++
-                        team_mcp_servers(state) ++
-                        team_comms_mcp_servers(state) ++
-                        caller_mcp_servers(state, conv),
+                        McpServers.fountain_served(conv, state.callback_token),
                     model:
                       agent &&
                         Fountain.Runtimes.Model.acp_model(

--- a/apps/fountain/lib/fountain/conversations/mcp_servers.ex
+++ b/apps/fountain/lib/fountain/conversations/mcp_servers.ex
@@ -1,0 +1,104 @@
+defmodule Fountain.Conversations.McpServers do
+  @moduledoc """
+  The MCP server list a runtime receives at `session/new`.
+
+  Two halves. The agent-declared servers, with their `${VAR}` references
+  resolved against the environment and the secrets (`substitute_agent/3`),
+  and the ones Fountain serves back to the sandbox itself, authenticated with
+  the conversation's callback token (`Fountain.Conversations.CallbackKey`):
+  the Buzz reply tools, the team tools, a teammate's comms tools and the
+  caller-tool bridge. Each of those decides for itself whether this
+  conversation gets it; `fountain_served/2` only asks, in the order the
+  server has always appended them.
+
+  Functions over rows and values, not over server state: `ConversationServer`
+  unpacks what it holds and passes it in (#1369). Nothing here touches the
+  database directly; the Fountain-served lists read the conversation row
+  through the context that owns each tool set.
+  """
+
+  alias Fountain.Agents.Agent
+  alias Fountain.Environments.Environment
+  alias Managoat.Substitution
+
+  # Resolve `${VAR}` references in the agent's MCP server config against
+  # env_vars + env_secrets + vault_secrets (vault wins). Env vars values
+  # are coerced to strings; non-string values further down the tree pass
+  # through untouched.
+  @spec substitute_agent(Agent.t() | nil, Environment.t() | nil, map()) ::
+          {:ok, Agent.t() | nil} | {:error, term()}
+  def substitute_agent(nil, _env, _secrets), do: {:ok, nil}
+
+  def substitute_agent(agent, env, secrets) do
+    vars = substitution_vars(env, secrets)
+
+    case Substitution.apply(agent.mcp_servers || %{}, vars) do
+      {:ok, mcp} -> {:ok, %{agent | mcp_servers: mcp}}
+      {:error, _} = err -> err
+    end
+  end
+
+  @doc """
+  The variables `${VAR}` resolves against: the environment's `env_vars` with
+  keys and values as strings, overridden by the decrypted `secrets`.
+  """
+  @spec substitution_vars(Environment.t() | nil, map()) :: map()
+  def substitution_vars(env, secrets) do
+    env_vars =
+      if env,
+        do: Map.new(env.env_vars || %{}, fn {k, v} -> {to_string(k), to_string(v)} end),
+        else: %{}
+
+    Map.merge(env_vars, secrets)
+  end
+
+  @doc """
+  The Fountain-served servers for a turn, in the order the server has always
+  appended them after the agent's own: buzz, team, team comms, caller.
+  """
+  @spec fountain_served(map(), String.t() | nil) :: [map()]
+  def fountain_served(%{id: conv_id} = conv, token) do
+    buzz(conv_id, token) ++
+      team(conv_id, token) ++
+      team_comms(conv_id, token) ++
+      caller(conv, token)
+  end
+
+  # The Buzz reply tools (#737), injected into `session/new` only for a
+  # Buzz-driven conversation and only once a callback token has been minted —
+  # `Fountain.Buzz` decides both. `[]` for every other conversation.
+  @spec buzz(String.t() | nil, String.t() | nil) :: [map()]
+  def buzz(conv_id, token) when is_binary(token) and is_binary(conv_id) do
+    Fountain.Buzz.conversation_mcp_servers(conv_id, token)
+  end
+
+  def buzz(_conv_id, _token), do: []
+
+  # The team tools (#851), for conversations on the team channel.
+  @spec team(String.t() | nil, String.t() | nil) :: [map()]
+  def team(conv_id, token) when is_binary(token) and is_binary(conv_id),
+    do: Fountain.Team.conversation_mcp_servers(conv_id, token)
+
+  def team(_conv_id, _token), do: []
+
+  # A teammate's email + phone tools (flag `team_comms`), injected the same
+  # way: only for a team conversation whose teammate has a contact, and only
+  # once a callback token exists — `Fountain.Team.Comms` decides. Computed
+  # at every turn kick, so a contact given mid-session is there next turn.
+  @spec team_comms(String.t() | nil, String.t() | nil) :: [map()]
+  def team_comms(conv_id, token) when is_binary(token) and is_binary(conv_id) do
+    Fountain.Team.Comms.conversation_mcp_servers(conv_id, token)
+  end
+
+  def team_comms(_conv_id, _token), do: []
+
+  # The caller-tool bridge (#1202): the tools a chat-completions or AG-UI
+  # client defined, served back to the sandbox as one more MCP server. Read
+  # off the conversation row at every turn kick, so a list registered by the
+  # request that opened this turn is on it.
+  @spec caller(map(), String.t() | nil) :: [map()]
+  def caller(conv, token) when is_binary(token),
+    do: Fountain.CallerTools.conversation_mcp_servers(conv, token)
+
+  def caller(_conv, _token), do: []
+end

--- a/apps/fountain/test/fountain/conversations/callback_key_test.exs
+++ b/apps/fountain/test/fountain/conversations/callback_key_test.exs
@@ -1,0 +1,79 @@
+defmodule Fountain.Conversations.CallbackKeyTest do
+  use Fountain.DataCase, async: true
+
+  alias Fountain.Accounts
+  alias Fountain.Conversations
+  alias Fountain.Conversations.CallbackKey
+
+  describe "ttl_seconds/0" do
+    test "defaults to thirty days" do
+      # The TTL config override is covered by api_key_scope_test in a sync
+      # module; this async one must not write application env.
+      assert CallbackKey.ttl_seconds() == 30 * 24 * 60 * 60
+    end
+  end
+
+  describe "env/1" do
+    test "is the base URL and the token" do
+      assert [{"FOUNTAIN_BASE_URL", base}, {"FOUNTAIN_TOKEN", "tok"}] = CallbackKey.env("tok")
+      assert base == Fountain.PublicUrl.base()
+    end
+
+    test "is empty without a token" do
+      assert CallbackKey.env(nil) == []
+      assert CallbackKey.env("") == []
+    end
+  end
+
+  describe "api_key_opts/0" do
+    test "scopes the key to the sprite, expires it after the TTL, names the actor" do
+      opts = CallbackKey.api_key_opts()
+
+      assert Keyword.fetch!(opts, :scopes) == ["sprite"]
+      assert Keyword.fetch!(opts, :actor) == "system:conversation_server"
+
+      expires_at = Keyword.fetch!(opts, :expires_at)
+      expected = DateTime.add(DateTime.utc_now(), CallbackKey.ttl_seconds(), :second)
+      assert_in_delta DateTime.diff(expires_at, expected, :second), 0, 2
+      assert expires_at.microsecond == {0, 0}
+    end
+  end
+
+  describe "rotate/2" do
+    test "mints a sprite-scoped key named for the conversation and points the row at it" do
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id)
+
+      assert {:ok, "ftn_" <> _ = raw, key_id, conv} = CallbackKey.rotate(conv, nil)
+      assert conv.callback_api_key_id == key_id
+      assert Conversations.get_conversation(conv.id, user.id).callback_api_key_id == key_id
+
+      assert [%Accounts.ApiKey{id: ^key_id, name: name, scopes: ["sprite"], revoked_at: nil}] =
+               Accounts.list_api_keys(user.id)
+
+      assert name == "sprite:" <> String.slice(conv.id, 0, 8)
+
+      assert {:ok, %{id: user_id}, %Accounts.ApiKey{id: ^key_id}} =
+               Accounts.authenticate_api_key(raw)
+
+      assert user_id == user.id
+    end
+
+    test "revokes the key this server minted before, and only that one" do
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id)
+      {:ok, {other, _raw}} = Accounts.create_api_key(user.id, "not-ours")
+
+      {:ok, _raw1, first_id, conv} = CallbackKey.rotate(conv, nil)
+      {:ok, _raw2, second_id, conv} = CallbackKey.rotate(conv, first_id)
+
+      assert second_id != first_id
+      assert conv.callback_api_key_id == second_id
+
+      # `list_api_keys/1` hides revoked rows, so read them directly.
+      assert Repo.get!(Accounts.ApiKey, first_id).revoked_at
+      refute Repo.get!(Accounts.ApiKey, second_id).revoked_at
+      refute Repo.get!(Accounts.ApiKey, other.id).revoked_at
+    end
+  end
+end

--- a/apps/fountain/test/fountain/conversations/conversation_server_size_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_size_test.exs
@@ -15,7 +15,7 @@ defmodule Fountain.Conversations.ConversationServerSizeTest do
   accepts is downward. Lower it when you move something out; never raise it.
   """
 
-  @pin 4498
+  @pin 4348
 
   @server "apps/fountain/lib/fountain/conversations/conversation_server.ex"
 

--- a/apps/fountain/test/fountain/conversations/mcp_servers_test.exs
+++ b/apps/fountain/test/fountain/conversations/mcp_servers_test.exs
@@ -1,0 +1,112 @@
+defmodule Fountain.Conversations.McpServersTest do
+  use Fountain.DataCase, async: true
+
+  alias Fountain.Agents.Agent
+  alias Fountain.Conversations.McpServers
+  alias Fountain.Environments.Environment
+
+  describe "substitute_agent/3" do
+    test "no agent is no agent" do
+      assert {:ok, nil} = McpServers.substitute_agent(nil, nil, %{})
+    end
+
+    test "resolves ${VAR} against env vars, with secrets winning on collision" do
+      agent = %Agent{mcp_servers: %{"svc" => %{"url" => "${HOST}/${TOKEN}", "port" => 1}}}
+      env = %Environment{env_vars: %{"TOKEN" => "from-env", HOST: "h"}}
+
+      assert {:ok, %Agent{mcp_servers: mcp}} =
+               McpServers.substitute_agent(agent, env, %{"TOKEN" => "from-vault"})
+
+      assert mcp == %{"svc" => %{"url" => "h/from-vault", "port" => 1}}
+    end
+
+    test "an agent with no servers passes through" do
+      assert {:ok, %Agent{mcp_servers: %{}}} =
+               McpServers.substitute_agent(%Agent{mcp_servers: nil}, nil, %{})
+    end
+
+    test "names every missing variable" do
+      agent = %Agent{mcp_servers: %{"a" => "${B}", "c" => "${A}"}}
+
+      assert {:error, {:missing_vars, ["A", "B"]}} =
+               McpServers.substitute_agent(agent, nil, %{})
+    end
+  end
+
+  describe "substitution_vars/2" do
+    test "no environment is just the secrets" do
+      assert McpServers.substitution_vars(nil, %{"K" => "v"}) == %{"K" => "v"}
+    end
+
+    test "env keys and values become strings; secrets override" do
+      env = %Environment{env_vars: %{"K" => "env", PORT: 8080}}
+
+      assert McpServers.substitution_vars(env, %{"K" => "secret"}) ==
+               %{"PORT" => "8080", "K" => "secret"}
+    end
+
+    test "nil env_vars is an empty map" do
+      assert McpServers.substitution_vars(%Environment{env_vars: nil}, %{}) == %{}
+    end
+  end
+
+  describe "the Fountain-served lists without a callback token" do
+    test "are empty, whatever the conversation" do
+      conv = insert_conversation(channel_id: Fountain.Team.channel())
+      conv = %{conv | caller_tools: [%{"name" => "x"}]}
+
+      assert McpServers.buzz(conv.id, nil) == []
+      assert McpServers.team(conv.id, nil) == []
+      assert McpServers.team_comms(conv.id, nil) == []
+      assert McpServers.caller(conv, nil) == []
+      assert McpServers.fountain_served(conv, nil) == []
+    end
+  end
+
+  describe "team/2" do
+    test "serves the team tools to a conversation on the team channel only" do
+      team = insert_conversation(channel_id: Fountain.Team.channel())
+      other = insert_conversation()
+
+      assert [%{name: name, type: "http", url: url, headers: [header]}] =
+               McpServers.team(team.id, "tok")
+
+      assert name == Fountain.Team.Mcp.mcp_name()
+      assert String.ends_with?(url, "/api/mcp/team/" <> team.id)
+      assert header == %{name: "Authorization", value: "Bearer tok"}
+
+      assert McpServers.team(other.id, "tok") == []
+    end
+  end
+
+  describe "caller/2" do
+    test "serves the caller bridge when the row has tools registered" do
+      conv = %{id: "c1", caller_tools: [%{"name" => "x"}]}
+
+      assert [%{name: "fountain-caller", type: "http", url: url}] =
+               McpServers.caller(conv, "tok")
+
+      assert String.ends_with?(url, "/api/mcp/caller/c1")
+      assert McpServers.caller(%{id: "c1", caller_tools: []}, "tok") == []
+    end
+  end
+
+  describe "fountain_served/2" do
+    test "is buzz, team, team comms, caller, in that order" do
+      # No Buzz identity and no teammate contact on this row, so the first
+      # and third lists are empty; the order of the two that remain is the
+      # order the server appended them before #1371.
+      conv = insert_conversation(channel_id: Fountain.Team.channel())
+      conv = %{conv | caller_tools: [%{"name" => "x"}]}
+
+      assert [%{name: team_name}, %{name: "fountain-caller"}] =
+               McpServers.fountain_served(conv, "tok")
+
+      assert team_name == Fountain.Team.Mcp.mcp_name()
+    end
+
+    test "is empty for an ordinary conversation" do
+      assert McpServers.fountain_served(insert_conversation(), "tok") == []
+    end
+  end
+end


### PR DESCRIPTION
Part of #1369, second of eight. The first real move: ten functions leave the server for two modules, as functions over rows and values rather than over server state.

## Functions moved

As listed in #1371, all ten exist and all ten moved; no correction to the list.

| was (`ConversationServer`) | now |
|---|---|
| `substitute_agent_mcp/3` | `McpServers.substitute_agent/3` |
| `substitution_vars/2` | `McpServers.substitution_vars/2` |
| `buzz_mcp_servers/1` | `McpServers.buzz/2` (conversation id, token) |
| `team_mcp_servers/1` | `McpServers.team/2` |
| `team_comms_mcp_servers/1` | `McpServers.team_comms/2` |
| `caller_mcp_servers/2` | `McpServers.caller/2` (conversation row, token) |
| `fountain_callback_env/1` | `CallbackKey.env/1` |
| `callback_key_ttl_seconds/0` | `CallbackKey.ttl_seconds/0` |
| `callback_api_key_opts/0` (public) | `CallbackKey.api_key_opts/0`, re-exported (below) |
| `rotate_callback_api_key/2` | `CallbackKey.rotate/2` (conversation row, previous key id) |

The four `*_mcp_servers` functions used to pattern-match `callback_token` and `conversation_id` out of state; they now take those as arguments with the same guards. `McpServers.fountain_served/2` is the one call the server makes at the turn kick, and it appends the four lists in the order the server always did (buzz, team, team comms, caller).

## What the server keeps

- `callback_api_key_opts/0`, one line delegating to `CallbackKey.api_key_opts/0`. `conversation_server_shutdown_revoke_test`, `api_key_scope_test` and `audit_coverage_test` call it on the server, and the server tests do not change.
- `rotate_callback_api_key/2`, four lines: calls `CallbackKey.rotate(conv, state.callback_api_key_id)` and applies the result. On success the state gets the plaintext and the new row id; on failure only `callback_token` is cleared and `callback_api_key_id` is left as it was, exactly as before.
- The two call sites of `rotate_callback_api_key/2` (fresh provision, reattach) and the `substitute_agent`/`CallbackKey.env` call sites are one-line renames.

## New modules' public functions

**`Fountain.Conversations.McpServers`**: `substitute_agent/3`, `substitution_vars/2`, `fountain_served/2`, `buzz/2`, `team/2`, `team_comms/2`, `caller/2`. `Fountain.CallerTools` stays where it is and is called, not moved.

**`Fountain.Conversations.CallbackKey`**: `ttl_seconds/0`, `env/1`, `api_key_opts/0`, `rotate/2`. `rotate/2` returns `{:ok, plaintext, key_id, conv}` or `{:error, conv}`. It mints through `Accounts.create_api_key/3` with the same `actor: "system:conversation_server"` attribution and revokes the previous key through `Accounts.revoke_api_key/3`, so the audit events are recorded where they were (ADR 0013); the module itself has no `Repo` call and the audit guardrail is green.

The `@dialyzer {:nowarn_function, ...}` on the env function travels with it, with its comment (one tense fix: the function "sat" near the bottom of the server).

## Unit tests, no process

- `mcp_servers_test.exs` (13 tests): substitution, vault-wins, missing-var collection, key/value coercion, every list empty without a token, the team list on and off the team channel, the caller bridge, and `fountain_served/2` ordering (team before caller on a team conversation with caller tools).
- `callback_key_test.exs` (6 tests): default TTL, the env pair, the minting options (scope, actor, truncated expiry), and rotation: a sprite-scoped key named `sprite:<8>` that authenticates, the row pointing at it, and a second rotation revoking the first key and only that one.

Neither starts a `ConversationServer`, a sandbox stub or a peer.

## Pin

| | lines |
|---|---|
| before | 4498 |
| after | 4348 |

## Gates

| gate | result |
|---|---|
| `MIX_ENV=test mix compile --warnings-as-errors` | clean |
| `mix format --check-formatted` (mise Elixir 1.19.2) | exit 0 |
| `mix credo --strict` | 5783 mods/funs, no issues |
| `MIX_ENV=dev mix dialyzer` | passed |
| thirteen `conversation_server*_test.exs` + size test + `audit_guardrail`, `caller_tools`, `provisioning`, `docs`, `api_key_scope`, `audit_coverage` | 350 tests, 0 failures |
| `mcp_servers_test`, `callback_key_test`, size test | 19 tests, 0 failures |
| full root suite | posted as a comment when it finishes |

`git diff --stat origin/main` over the thirteen server test files is empty.

**Proof:** with `origin/main`'s server file put back beside the new modules, the size test fails: `... is 4498 lines, over the pin of 4348`. Restored; the committed file is 4,348.

## CHANGELOG

One entry under `[Unreleased] → ### Changed`.

Closes #1371. Part of #1369.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mx2sij38JHM6gQu6PxiGG
