### PR TITLE
chore(scripts): graduate-library keeps a library's extra package files

### DIFF
--- a/scripts/graduate-library.sh
+++ b/scripts/graduate-library.sh
@@ -148,7 +148,10 @@ stand_alone() {
       or die "mix.exs: \@source_url not found\n";
     s|links: %\{"GitHub" => \@source_url\}|links: %{"GitHub" => \@source_url, "Changelog" => "#{\@source_url}/blob/main/CHANGELOG.md"}|
       or die "mix.exs: links not found\n";
-    s|files: ~w\(lib mix\.exs README\.md LICENSE\)|files: ~w(lib mix.exs README.md CHANGELOG.md LICENSE NOTICE)|
+    # A library may package more than lib/ (managoat_runtimes carries priv/,
+    # which Gemini.SessionStore embeds at compile time): keep whatever sits
+    # between lib and mix.exs, and add the files the template brings.
+    s|files: ~w\(lib (.*?)mix\.exs README\.md LICENSE\)|files: ~w(lib $1mix.exs README.md CHANGELOG.md LICENSE NOTICE)|
       or die "mix.exs: files not found\n";
     s|(\n[ \t]*package: package\(\),\n)|$1      source_url: \@source_url,\n      docs: docs(),\n      dialyzer: dialyzer(),\n|
       or die "mix.exs: package: line not found\n";


### PR DESCRIPTION
`scripts/graduate-library.sh` step 4 rewrites the package `files:` line and matched it only as the literal `~w(lib mix.exs README.md LICENSE)` the first eight libraries had. `managoat_runtimes` (#1387) packages `priv/` too, because `Gemini.SessionStore` embeds the consolidation script from it at compile time, so `--prepare-only runtimes` died with `mix.exs: files not found`. The rewrite now keeps whatever sits between `lib` and `mix.exs` and adds the template's `CHANGELOG.md` and `NOTICE` as before. Verified against `apps/managoat_runtimes/mix.exs`: `~w(lib priv mix.exs README.md CHANGELOG.md LICENSE NOTICE)`.

Unblocks the runtimes graduation, which runs right after this merges. Part of #1334.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012uqJ38S6wE2e3ZukxSnbe1