### PR TITLE
refactor(conversations): egress brokerage and connection secrets out (Egress)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -218,6 +218,17 @@ upgrade, is in
   Sixteen functions, same bodies, no behaviour change; the brokered
   placeholders reach the env through one argument, which is the seam the
   egress move (#1373) uses next. The pin drops from 4,348 to 4,168.
+- **Egress brokerage and the connection secrets have left
+  `ConversationServer`** (#1373, tracker #1369). `Fountain.Conversations.Egress`
+  holds everything ADR 0019 wired into a conversation: the split rules
+  (bindings, connection tokens, catalog keys, inference credentials), the
+  proxy session's mint, re-prepare and release, the CA install and the
+  network floor. It calls the `Fountain.Broker` facade and
+  `Fountain.Connections`; the server keeps the session and its placeholders
+  in state and three short wrappers that apply what comes back. Seventeen
+  functions, same bodies, no behaviour, stage or log change. The Agent Vault
+  client's deletion now touches one file beside the facade. The pin drops
+  from 4,168 to 3,991.
 
 ### Added
 

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -24,6 +24,7 @@ defmodule Fountain.Conversations.ConversationServer do
   alias Fountain.Conversations.{
     CallbackKey,
     Conversation,
+    Egress,
     HomeCheckpoint,
     Lifecycle,
     McpServers,
@@ -690,20 +691,20 @@ defmodule Fountain.Conversations.ConversationServer do
 
     case SpriteEnv.load_tenant_state(conv.user_id) do
       {:ok, dek, inference_creds} ->
-        bindings = broker_bindings(conv.user_id)
+        bindings = Egress.bindings(conv.user_id)
 
         {merged, bindings, connection_keys} =
-          add_connection_secrets(
+          Egress.add_connection_secrets(
             conv.user_id,
             SpriteEnv.merge_secrets(env, vault, dek),
             bindings,
             agent
           )
 
-        {secrets, brokered} = split_brokered(conv.user_id, merged, bindings)
+        {secrets, brokered} = Egress.split_brokered(conv.user_id, merged, bindings)
 
         {env_creds, brokered, bindings} =
-          split_inference(conv.user_id, inference_creds, brokered, bindings)
+          Egress.split_inference(conv.user_id, inference_creds, brokered, bindings)
 
         state =
           %{
@@ -837,7 +838,7 @@ defmodule Fountain.Conversations.ConversationServer do
              ),
            :ok <-
              Fountain.Conversations.Provisioning.check_broker_support(
-               brokered?(state),
+               Egress.brokered?(state.user_id),
                provider,
                env,
                state.conversation_id
@@ -872,7 +873,12 @@ defmodule Fountain.Conversations.ConversationServer do
                Provisioning.write_runtime_config(
                  handle,
                  state.runtime_module,
-                 with_connection_servers(agent, state)
+                 Egress.with_connection_servers(
+                   agent,
+                   state.user_id,
+                   state.conversation_id,
+                   state.callback_token
+                 )
                ),
              _ = Provisioning.write_instructions(handle, runtime, agent),
              # The file is the machine's; the conversation's identity travels as
@@ -882,7 +888,7 @@ defmodule Fountain.Conversations.ConversationServer do
                  handle,
                  Fountain.Conversations.Identity.disk_env(sprite_env)
                ),
-             :ok <- broker_install_ca(state, handle),
+             :ok <- Egress.install_ca(state.broker, handle, state.conversation_id),
              :ok <-
                run_provisioning_pipeline(
                  handle,
@@ -890,7 +896,7 @@ defmodule Fountain.Conversations.ConversationServer do
                  sprite_env,
                  secrets,
                  state.conversation_id,
-                 brokered?(state)
+                 Egress.brokered?(state.user_id)
                ),
              :ok <-
                Provisioning.prepare_runtime_sprite(
@@ -927,7 +933,7 @@ defmodule Fountain.Conversations.ConversationServer do
           {:error, reason} ->
             Logger.error("provision step failed: #{inspect(reason)}")
             _ = Managoat.Sandbox.destroy(handle)
-            broker_release(state)
+            Egress.release(state.user_id, state.conversation_id)
             {:ok, _} = Conversations.update_sandbox(sandbox, %{status: "failed"})
 
             publish_stage(state.conversation_id, "provision", "failed", %{
@@ -962,7 +968,7 @@ defmodule Fountain.Conversations.ConversationServer do
   defp run_provisioning_pipeline(handle, env, sprite_env, secrets, conv_id, brokered?) do
     case attempt_warm_start(handle, env, conv_id) do
       :warm_started ->
-        apply_egress_policy(handle, env, conv_id, brokered?)
+        Egress.apply_policy(handle, env, conv_id, brokered?)
 
       :cold ->
         with :ok <-
@@ -972,7 +978,7 @@ defmodule Fountain.Conversations.ConversationServer do
                  sprite_env,
                  conv_id
                ),
-             :ok <- apply_egress_policy(handle, env, conv_id, brokered?),
+             :ok <- Egress.apply_policy(handle, env, conv_id, brokered?),
              :ok <-
                Fountain.Conversations.Provisioning.clone_repositories(
                  handle,
@@ -1122,7 +1128,12 @@ defmodule Fountain.Conversations.ConversationServer do
       case Provisioning.write_runtime_config(
              handle,
              state.runtime_module,
-             with_connection_servers(agent, state)
+             Egress.with_connection_servers(
+               agent,
+               state.user_id,
+               state.conversation_id,
+               state.callback_token
+             )
            ) do
         :ok -> :ok
         {:error, reason} -> Logger.warning("runtime config write on wake: #{inspect(reason)}")
@@ -1131,7 +1142,7 @@ defmodule Fountain.Conversations.ConversationServer do
       # A machine provisioned before its tenant was brokered has no CA yet;
       # on one that has it this is an idempotent rewrite. Best effort here:
       # the turn's own failure says more than a refused wake would.
-      case broker_install_ca(state, handle) do
+      case Egress.install_ca(state.broker, handle, state.conversation_id) do
         :ok -> :ok
         {:error, reason} -> Logger.warning("broker CA install on wake: #{inspect(reason)}")
       end
@@ -1471,6 +1482,8 @@ defmodule Fountain.Conversations.ConversationServer do
     )
   end
 
+  # ── sprite environment and egress (ADR 0019 gate 1a) ──────────────────────
+
   # The server's half of `SpriteEnv.build/4`: unpack what the state holds and
   # hand it over. The name stays because the tests and the comments that say
   # "build_sprite_env registers the secrets" still mean this call.
@@ -1482,178 +1495,21 @@ defmodule Fountain.Conversations.ConversationServer do
       conversation_id: state.conversation_id,
       sandbox_id: state.sandbox_id,
       sandbox_url: sandbox_url,
-      brokered: broker_env(state)
+      brokered: Egress.sandbox_env(state.broker)
     )
   end
 
-  # ── sprite environment and egress (ADR 0019 gate 1a) ──────────────────────
-
-  defp brokered?(state), do: Fountain.Broker.enabled_for?(state.user_id)
-
-  # On a brokered conversation the catalog keys leave the secrets map here,
-  # before the MCP substitution and the env are built from it, so both see
-  # the placeholder and neither sees the value.
-  defp split_brokered(user_id, secrets, bindings) do
-    if Fountain.Broker.enabled_for?(user_id),
-      do: Fountain.Broker.split(secrets, bindings),
-      else: {secrets, %{}}
-  end
-
-  # A tenant's connections (#1178) contribute their access tokens as
-  # synthetic secrets, brokered like inference keys: the sandbox gets a
-  # placeholder, the broker gets the value with an implicit bearer binding
-  # to the provider's hosts. A tenant's own secret of the same name wins,
-  # as does their own binding on it (which is how the token reaches an MCP
-  # server they run). Only for brokered tenants — without the broker the
-  # token would have to enter the sandbox in the clear, which is the thing
-  # connections exist to avoid.
-  defp add_connection_secrets(user_id, merged, bindings, agent) do
-    if Fountain.Broker.enabled_for?(user_id) do
-      connections = active_connections_by_id(user_id)
-      synthetic = Fountain.Connections.synthetic_secrets(user_id)
-      remote_hosts = remote_connection_hosts(agent, connections)
-
-      {merged, bindings, keys} =
-        Enum.reduce(synthetic, {merged, bindings, []}, fn {key, token}, {m, b, keys} ->
-          if Map.has_key?(m, key) do
-            {m, b, keys}
-          else
-            b =
-              if Map.has_key?(b, key),
-                do: b,
-                else: Map.put(b, key, connection_bindings(user_id, key, remote_hosts))
-
-            {Map.put(m, key, token), b, [key | keys]}
-          end
-        end)
-
-      {merged, bindings, Enum.sort(keys)}
-    else
-      {merged, bindings, []}
-    end
-  end
-
-  # The provider's own hosts, plus the host of every remote MCP server the
-  # agent attaches with this connection (#1186): the broker attaches the
-  # bearer to exactly those and nothing else.
-  defp connection_bindings(user_id, key, remote_hosts) do
-    (Fountain.Connections.implicit_hosts(user_id, key) ++ Map.get(remote_hosts, key, []))
-    |> Enum.uniq()
-    |> Enum.map(fn host ->
-      %Fountain.SecretBindings.Binding{
-        key: key,
-        host: host,
-        auth_type: "bearer",
-        headers: %{},
-        enabled: true
-      }
-    end)
-  end
-
-  defp active_connections_by_id(user_id) do
-    user_id
-    |> Fountain.Connections.active_connections()
-    |> Map.new(&{&1.id, &1})
-  end
-
-  defp remote_connection_hosts(%{mcp_servers: servers}, connections) when is_map(servers),
-    do: Fountain.Connections.McpServers.remote_hosts(servers, connections)
-
-  defp remote_connection_hosts(_agent, _connections), do: %{}
-
-  # Re-read the brokered connection tokens; a rotated one is swapped into
-  # `brokered` and the caller re-prepares the vault. A refresh that fails
-  # leaves the old token in place: the turn runs on it and, if it has
-  # expired, fails at the provider with a reason rather than silently here.
-  defp refresh_connection_secrets(%{connection_keys: []} = state), do: {state, false}
-
-  defp refresh_connection_secrets(%{connection_keys: keys, user_id: user_id} = state) do
-    fresh = user_id |> Fountain.Connections.synthetic_secrets() |> Map.take(keys)
-
-    rotated =
-      Enum.filter(fresh, fn {k, v} -> Map.get(state.brokered, k) != v end)
-
-    if rotated == [] do
-      {state, false}
-    else
-      {%{state | brokered: Map.merge(state.brokered, Map.new(rotated))}, true}
-    end
-  end
-
-  # An agent whose `mcp_servers` names a connection gets the entry rewritten
-  # into the Fountain-served server (#1178), authenticated by the
-  # conversation's callback token. Not for an unbrokered tenant: the entry
-  # is dropped and the agent runs without it.
-  defp with_connection_servers(nil, _state), do: nil
-
-  defp with_connection_servers(%{mcp_servers: servers} = agent, state) when is_map(servers) do
-    brokered = Fountain.Broker.enabled_for?(state.user_id)
-    token = if brokered, do: state.callback_token
-    connections = if brokered, do: active_connections_by_id(state.user_id), else: %{}
-
-    %{
-      agent
-      | mcp_servers:
-          Fountain.Connections.McpServers.resolve(
-            servers,
-            state.conversation_id,
-            token,
-            connections
-          )
-    }
-  end
-
-  defp with_connection_servers(agent, _state), do: agent
-
-  # Only read for a brokered tenant: for everyone else the table is rows
-  # nobody consults, and this path stays free of a query.
-  defp broker_bindings(user_id) do
-    if Fountain.Broker.enabled_for?(user_id),
-      do: Fountain.SecretBindings.enabled_by_key(user_id),
-      else: %{}
-  end
-
-  # Gate 3: the runtime is handed placeholders for its inference credentials
-  # and the broker gets the values, with an implicit binding to the provider's
-  # host. A tenant's own secret of the same name (already split above) wins
-  # over the inference credential, as it wins in the environment.
-  defp split_inference(user_id, inference_creds, brokered, bindings) do
-    if Fountain.Broker.enabled_for?(user_id) do
-      {env_creds, inference_brokered, implicit} =
-        Fountain.Broker.split_inference(inference_creds, bindings)
-
-      {env_creds, Map.merge(inference_brokered, brokered), Map.merge(implicit, bindings)}
-    else
-      {inference_creds, brokered, bindings}
-    end
-  end
-
-  defp broker_env(%{broker: nil}), do: []
-  defp broker_env(%{broker: session}), do: Fountain.Broker.sandbox_env(session)
-
-  # Mint (or re-mint) the conversation's proxy session. A no-op that returns
-  # the state untouched when the conversation is not brokered.
+  # Mint (or re-mint) the conversation's proxy session (`Egress.prepare/4`)
+  # and hold it. A no-op that returns the state untouched when the
+  # conversation is not brokered.
   defp broker_prepare(state) do
-    if brokered?(state) do
-      publish_stage(state.conversation_id, "broker", "started", %{
-        keys: state.brokered |> Map.keys() |> Enum.sort()
-      })
-
-      case Fountain.Broker.prepare(state.conversation_id, state.brokered, state.broker_bindings,
+    if Egress.brokered?(state.user_id) do
+      case Egress.prepare(state.conversation_id, state.brokered, state.broker_bindings,
              network: state.broker_network,
              user_id: state.user_id
            ) do
-        {:ok, session} ->
-          publish_stage(state.conversation_id, "broker", "done", %{
-            vault: session.vault,
-            expires_at: session.expires_at
-          })
-
-          {:ok, %{state | broker: session}}
-
-        {:error, reason} ->
-          publish_stage(state.conversation_id, "broker", "failed", %{reason: inspect(reason)})
-          {:error, reason}
+        {:ok, session} -> {:ok, %{state | broker: session}}
+        {:error, _} = error -> error
       end
     else
       {:ok, state}
@@ -1667,29 +1523,17 @@ defmodule Fountain.Conversations.ConversationServer do
   defp broker_switch_to_api_key(%{broker: nil} = state), do: state
 
   defp broker_switch_to_api_key(state) do
-    creds = Map.delete(state.inference_credentials, :claude_code_oauth_token)
-
-    {env_creds, inference_brokered, implicit} =
-      Fountain.Broker.split_inference(creds, state.broker_bindings)
-
-    brokered =
-      state.brokered
-      |> Map.delete("CLAUDE_CODE_OAUTH_TOKEN")
-      |> Map.merge(inference_brokered)
-
-    bindings =
-      state.broker_bindings |> Map.delete("CLAUDE_CODE_OAUTH_TOKEN") |> Map.merge(implicit)
+    {env_creds, brokered, bindings} =
+      Egress.drop_oauth_token(state.inference_credentials, state.brokered, state.broker_bindings)
 
     state = %{state | brokered: brokered, broker_bindings: bindings, env_credentials: env_creds}
 
-    case Fountain.Broker.prepare(state.conversation_id, brokered, bindings,
+    case Egress.reprepare(state.conversation_id, brokered, bindings, state.sprite_env,
            network: state.broker_network,
            user_id: state.user_id
          ) do
-      {:ok, session} ->
-        keys = Fountain.Broker.env_keys()
-        kept = Enum.reject(state.sprite_env, fn {k, _} -> to_string(k) in keys end)
-        %{state | broker: session, sprite_env: kept ++ Fountain.Broker.sandbox_env(session)}
+      {:ok, session, sprite_env} ->
+        %{state | broker: session, sprite_env: sprite_env}
 
       {:error, reason} ->
         Logger.warning(
@@ -1700,27 +1544,27 @@ defmodule Fountain.Conversations.ConversationServer do
     end
   end
 
-  defp broker_install_ca(%{broker: nil}, _handle), do: :ok
-
-  defp broker_install_ca(state, handle),
-    do: Fountain.Conversations.Provisioning.install_broker_ca(handle, state.conversation_id)
-
   # A session near its end is replaced before the turn that would outlive it.
   # The env is rebuilt with the new token; everything else in it is unchanged.
   defp broker_refresh(%{broker: nil} = state), do: state
 
   defp broker_refresh(%{broker: session} = state) do
-    {state, rotated?} = refresh_connection_secrets(state)
+    {brokered, rotated?} =
+      Egress.refresh_connection_secrets(state.connection_keys, state.user_id, state.brokered)
+
+    state = %{state | brokered: brokered}
 
     if rotated? or Fountain.Broker.expiring?(session) do
-      case Fountain.Broker.prepare(state.conversation_id, state.brokered, state.broker_bindings,
+      case Egress.reprepare(
+             state.conversation_id,
+             state.brokered,
+             state.broker_bindings,
+             state.sprite_env,
              network: state.broker_network,
              user_id: state.user_id
            ) do
-        {:ok, fresh} ->
-          keys = Fountain.Broker.env_keys()
-          kept = Enum.reject(state.sprite_env, fn {k, _} -> to_string(k) in keys end)
-          %{state | broker: fresh, sprite_env: kept ++ Fountain.Broker.sandbox_env(fresh)}
+        {:ok, fresh, sprite_env} ->
+          %{state | broker: fresh, sprite_env: sprite_env}
 
         {:error, reason} ->
           # The turn runs on the old token, and fails at the proxy if it has
@@ -1735,34 +1579,6 @@ defmodule Fountain.Conversations.ConversationServer do
       state
     end
   end
-
-  # The vault and every session in it go when the conversation's sandbox
-  # does. Best effort and off the caller's path: a broker that is down at
-  # teardown must not keep a sandbox alive, and the vault is idempotently
-  # recreated on the next provision anyway.
-  defp broker_release(state) do
-    if brokered?(state) do
-      conv_id = state.conversation_id
-
-      Task.Supervisor.start_child(Fountain.TaskSupervisor, fn ->
-        case Fountain.Broker.release(conv_id) do
-          :ok ->
-            :ok
-
-          {:error, reason} ->
-            Logger.warning("broker release for conv #{conv_id}: #{inspect(reason)}")
-        end
-      end)
-    end
-
-    :ok
-  end
-
-  defp apply_egress_policy(handle, env, conv_id, false),
-    do: Fountain.Conversations.Provisioning.apply_network_policy(handle, env, conv_id)
-
-  defp apply_egress_policy(handle, _env, conv_id, true),
-    do: Fountain.Conversations.Provisioning.apply_broker_floor(handle, conv_id)
 
   @impl true
   def handle_call({:send_prompt, prompt, images}, _from, state) do
@@ -1909,7 +1725,7 @@ defmodule Fountain.Conversations.ConversationServer do
     else
       state = drop_connection(state, "terminated")
       if state.handle, do: _ = Managoat.Sandbox.destroy(state.handle)
-      broker_release(state)
+      Egress.release(state.user_id, state.conversation_id)
       sandbox = Conversations._unsafe_get_sandbox!(state.sandbox_id)
 
       {:ok, _} =
@@ -2863,7 +2679,7 @@ defmodule Fountain.Conversations.ConversationServer do
     state = drop_connection(state, "reclaimed")
 
     if state.handle, do: _ = Managoat.Sandbox.destroy(state.handle)
-    broker_release(state)
+    Egress.release(state.user_id, state.conversation_id)
 
     if state.sandbox_id do
       sandbox = Conversations._unsafe_get_sandbox!(state.sandbox_id)
@@ -3377,7 +3193,14 @@ defmodule Fountain.Conversations.ConversationServer do
                     cwd: cwd,
                     images: images,
                     mcp_servers:
-                      Managoat.Runtimes.ACP.mcp_servers(with_connection_servers(agent, state)) ++
+                      Managoat.Runtimes.ACP.mcp_servers(
+                        Egress.with_connection_servers(
+                          agent,
+                          state.user_id,
+                          state.conversation_id,
+                          state.callback_token
+                        )
+                      ) ++
                         McpServers.fountain_served(conv, state.callback_token),
                     model:
                       agent &&

--- a/apps/fountain/lib/fountain/conversations/egress.ex
+++ b/apps/fountain/lib/fountain/conversations/egress.ex
@@ -1,0 +1,301 @@
+defmodule Fountain.Conversations.Egress do
+  @moduledoc """
+  Everything ADR 0019 wired into a conversation: which secrets are brokered,
+  the connections that contribute tokens, the proxy session's life, and the
+  network floor.
+
+  Talks to `Fountain.Broker` (the facade over its backends since #1357,
+  never a backend) and `Fountain.Connections`. Functions over rows and
+  values, not over server state (#1369): `ConversationServer` keeps the
+  fields the session, its placeholders and its bindings live in, unpacks
+  them for each call and applies what comes back. The three places that
+  change more than one field at once (mint, the OAuth switch, the refresh
+  before a turn) are the server's short wrappers over `prepare/4`,
+  `drop_oauth_token/3` and `reprepare/5`.
+
+  The split rules, in order, as the server applies them at provision:
+  `bindings/1`, `add_connection_secrets/4`, `split_brokered/3`,
+  `split_inference/4`. Each is a no-op for an unbrokered tenant.
+  """
+
+  require Logger
+
+  alias Fountain.Broker
+  alias Fountain.Conversations.Provisioning
+
+  @typedoc "A proxy session as `Fountain.Broker.prepare/4` returns it, or nil when the conversation has none."
+  @type session :: map() | nil
+
+  @doc "Whether this tenant's conversations are brokered: `Fountain.Broker.enabled_for?/1`."
+  @spec brokered?(String.t() | nil) :: boolean()
+  def brokered?(user_id), do: Broker.enabled_for?(user_id)
+
+  # On a brokered conversation the catalog keys leave the secrets map here,
+  # before the MCP substitution and the env are built from it, so both see
+  # the placeholder and neither sees the value.
+  @spec split_brokered(String.t(), map(), Broker.bindings()) :: {map(), map()}
+  def split_brokered(user_id, secrets, bindings) do
+    if Broker.enabled_for?(user_id),
+      do: Broker.split(secrets, bindings),
+      else: {secrets, %{}}
+  end
+
+  # A tenant's connections (#1178) contribute their access tokens as
+  # synthetic secrets, brokered like inference keys: the sandbox gets a
+  # placeholder, the broker gets the value with an implicit bearer binding
+  # to the provider's hosts. A tenant's own secret of the same name wins,
+  # as does their own binding on it (which is how the token reaches an MCP
+  # server they run). Only for brokered tenants — without the broker the
+  # token would have to enter the sandbox in the clear, which is the thing
+  # connections exist to avoid.
+  @spec add_connection_secrets(String.t(), map(), Broker.bindings(), map() | nil) ::
+          {map(), Broker.bindings(), [String.t()]}
+  def add_connection_secrets(user_id, merged, bindings, agent) do
+    if Broker.enabled_for?(user_id) do
+      connections = active_connections_by_id(user_id)
+      synthetic = Fountain.Connections.synthetic_secrets(user_id)
+      remote_hosts = remote_connection_hosts(agent, connections)
+
+      {merged, bindings, keys} =
+        Enum.reduce(synthetic, {merged, bindings, []}, fn {key, token}, {m, b, keys} ->
+          if Map.has_key?(m, key) do
+            {m, b, keys}
+          else
+            b =
+              if Map.has_key?(b, key),
+                do: b,
+                else: Map.put(b, key, connection_bindings(user_id, key, remote_hosts))
+
+            {Map.put(m, key, token), b, [key | keys]}
+          end
+        end)
+
+      {merged, bindings, Enum.sort(keys)}
+    else
+      {merged, bindings, []}
+    end
+  end
+
+  # The provider's own hosts, plus the host of every remote MCP server the
+  # agent attaches with this connection (#1186): the broker attaches the
+  # bearer to exactly those and nothing else.
+  @spec connection_bindings(String.t(), String.t(), %{String.t() => [String.t()]}) ::
+          [Fountain.SecretBindings.Binding.t()]
+  def connection_bindings(user_id, key, remote_hosts) do
+    (Fountain.Connections.implicit_hosts(user_id, key) ++ Map.get(remote_hosts, key, []))
+    |> Enum.uniq()
+    |> Enum.map(fn host ->
+      %Fountain.SecretBindings.Binding{
+        key: key,
+        host: host,
+        auth_type: "bearer",
+        headers: %{},
+        enabled: true
+      }
+    end)
+  end
+
+  defp active_connections_by_id(user_id) do
+    user_id
+    |> Fountain.Connections.active_connections()
+    |> Map.new(&{&1.id, &1})
+  end
+
+  defp remote_connection_hosts(%{mcp_servers: servers}, connections) when is_map(servers),
+    do: Fountain.Connections.McpServers.remote_hosts(servers, connections)
+
+  defp remote_connection_hosts(_agent, _connections), do: %{}
+
+  # Re-read the brokered connection tokens; a rotated one is swapped into
+  # `brokered` and the caller re-prepares the vault. A refresh that fails
+  # leaves the old token in place: the turn runs on it and, if it has
+  # expired, fails at the provider with a reason rather than silently here.
+  @spec refresh_connection_secrets([String.t()], String.t(), map()) :: {map(), boolean()}
+  def refresh_connection_secrets([], _user_id, brokered), do: {brokered, false}
+
+  def refresh_connection_secrets(keys, user_id, brokered) do
+    fresh = user_id |> Fountain.Connections.synthetic_secrets() |> Map.take(keys)
+
+    rotated =
+      Enum.filter(fresh, fn {k, v} -> Map.get(brokered, k) != v end)
+
+    if rotated == [] do
+      {brokered, false}
+    else
+      {Map.merge(brokered, Map.new(rotated)), true}
+    end
+  end
+
+  # An agent whose `mcp_servers` names a connection gets the entry rewritten
+  # into the Fountain-served server (#1178), authenticated by the
+  # conversation's callback token. Not for an unbrokered tenant: the entry
+  # is dropped and the agent runs without it.
+  @spec with_connection_servers(map() | nil, String.t(), String.t(), String.t() | nil) ::
+          map() | nil
+  def with_connection_servers(agent, user_id, conversation_id, callback_token)
+
+  def with_connection_servers(nil, _user_id, _conversation_id, _callback_token), do: nil
+
+  def with_connection_servers(%{mcp_servers: servers} = agent, user_id, conversation_id, token)
+      when is_map(servers) do
+    brokered = Broker.enabled_for?(user_id)
+    token = if brokered, do: token
+    connections = if brokered, do: active_connections_by_id(user_id), else: %{}
+
+    %{
+      agent
+      | mcp_servers:
+          Fountain.Connections.McpServers.resolve(
+            servers,
+            conversation_id,
+            token,
+            connections
+          )
+    }
+  end
+
+  def with_connection_servers(agent, _user_id, _conversation_id, _callback_token), do: agent
+
+  # Only read for a brokered tenant: for everyone else the table is rows
+  # nobody consults, and this path stays free of a query.
+  @spec bindings(String.t()) :: Broker.bindings()
+  def bindings(user_id) do
+    if Broker.enabled_for?(user_id),
+      do: Fountain.SecretBindings.enabled_by_key(user_id),
+      else: %{}
+  end
+
+  # Gate 3: the runtime is handed placeholders for its inference credentials
+  # and the broker gets the values, with an implicit binding to the provider's
+  # host. A tenant's own secret of the same name (already split above) wins
+  # over the inference credential, as it wins in the environment.
+  @spec split_inference(String.t(), map(), map(), Broker.bindings()) ::
+          {map(), map(), Broker.bindings()}
+  def split_inference(user_id, inference_creds, brokered, bindings) do
+    if Broker.enabled_for?(user_id) do
+      {env_creds, inference_brokered, implicit} =
+        Broker.split_inference(inference_creds, bindings)
+
+      {env_creds, Map.merge(inference_brokered, brokered), Map.merge(implicit, bindings)}
+    else
+      {inference_creds, brokered, bindings}
+    end
+  end
+
+  @doc "The proxy variables a session puts in the sandbox's env; none without a session."
+  @spec sandbox_env(session()) :: [{String.t(), String.t()}]
+  def sandbox_env(nil), do: []
+  def sandbox_env(session), do: Broker.sandbox_env(session)
+
+  @doc """
+  Mint (or re-mint) the conversation's proxy session, publishing the
+  `broker` stage around it. The caller decides whether the conversation is
+  brokered at all (`brokered?/1`) and holds the session that comes back.
+  """
+  @spec prepare(String.t(), map(), Broker.bindings(), keyword()) ::
+          {:ok, map()} | {:error, term()}
+  def prepare(conversation_id, brokered, bindings, opts) do
+    publish_stage(conversation_id, "broker", "started", %{
+      keys: brokered |> Map.keys() |> Enum.sort()
+    })
+
+    case Broker.prepare(conversation_id, brokered, bindings, opts) do
+      {:ok, session} ->
+        publish_stage(conversation_id, "broker", "done", %{
+          vault: session.vault,
+          expires_at: session.expires_at
+        })
+
+        {:ok, session}
+
+      {:error, reason} ->
+        publish_stage(conversation_id, "broker", "failed", %{reason: inspect(reason)})
+        {:error, reason}
+    end
+  end
+
+  @doc """
+  The OAuth token was refused: forget it on both sides, so the API key is
+  what the substitution carries. Returns the runtime's credentials, the
+  brokered map and the bindings without it; the caller then `reprepare/5`s.
+  """
+  @spec drop_oauth_token(map(), map(), Broker.bindings()) :: {map(), map(), Broker.bindings()}
+  def drop_oauth_token(inference_credentials, brokered, bindings) do
+    creds = Map.delete(inference_credentials, :claude_code_oauth_token)
+
+    {env_creds, inference_brokered, implicit} =
+      Broker.split_inference(creds, bindings)
+
+    brokered =
+      brokered
+      |> Map.delete("CLAUDE_CODE_OAUTH_TOKEN")
+      |> Map.merge(inference_brokered)
+
+    bindings =
+      bindings |> Map.delete("CLAUDE_CODE_OAUTH_TOKEN") |> Map.merge(implicit)
+
+    {env_creds, brokered, bindings}
+  end
+
+  @doc """
+  Replace the session and rebuild the env with the new token; everything
+  else in the env is unchanged. No stage is published: this is the refresh
+  before a turn and the re-prepare after an OAuth refusal, not provisioning.
+  """
+  @spec reprepare(String.t(), map(), Broker.bindings(), [{String.t(), String.t()}], keyword()) ::
+          {:ok, map(), [{String.t(), String.t()}]} | {:error, term()}
+  def reprepare(conversation_id, brokered, bindings, sprite_env, opts) do
+    case Broker.prepare(conversation_id, brokered, bindings, opts) do
+      {:ok, session} ->
+        keys = Broker.env_keys()
+        kept = Enum.reject(sprite_env, fn {k, _} -> to_string(k) in keys end)
+        {:ok, session, kept ++ Broker.sandbox_env(session)}
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  @doc "Install the broker's CA into the sandbox; nothing to install without a session."
+  @spec install_ca(session(), Managoat.Sandbox.Handle.t(), String.t()) :: :ok | {:error, term()}
+  def install_ca(nil, _handle, _conversation_id), do: :ok
+
+  def install_ca(_session, handle, conversation_id),
+    do: Provisioning.install_broker_ca(handle, conversation_id)
+
+  # The vault and every session in it go when the conversation's sandbox
+  # does. Best effort and off the caller's path: a broker that is down at
+  # teardown must not keep a sandbox alive, and the vault is idempotently
+  # recreated on the next provision anyway.
+  @spec release(String.t() | nil, String.t()) :: :ok
+  def release(user_id, conversation_id) do
+    if Broker.enabled_for?(user_id) do
+      conv_id = conversation_id
+
+      Task.Supervisor.start_child(Fountain.TaskSupervisor, fn ->
+        case Broker.release(conv_id) do
+          :ok ->
+            :ok
+
+          {:error, reason} ->
+            Logger.warning("broker release for conv #{conv_id}: #{inspect(reason)}")
+        end
+      end)
+    end
+
+    :ok
+  end
+
+  @doc "The network floor: the environment's policy, or the broker's when brokered."
+  @spec apply_policy(Managoat.Sandbox.Handle.t(), map() | nil, String.t(), boolean()) ::
+          :ok | {:error, term()}
+  def apply_policy(handle, env, conv_id, false),
+    do: Provisioning.apply_network_policy(handle, env, conv_id)
+
+  def apply_policy(handle, _env, conv_id, true),
+    do: Provisioning.apply_broker_floor(handle, conv_id)
+
+  defp publish_stage(conv_id, stage, status, meta) do
+    Fountain.Conversations.publish_stage(conv_id, stage, status, meta)
+  end
+end

--- a/apps/fountain/test/fountain/conversations/conversation_server_size_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_size_test.exs
@@ -15,7 +15,7 @@ defmodule Fountain.Conversations.ConversationServerSizeTest do
   accepts is downward. Lower it when you move something out; never raise it.
   """
 
-  @pin 4168
+  @pin 3991
 
   @server "apps/fountain/lib/fountain/conversations/conversation_server.ex"
 

--- a/apps/fountain/test/fountain/conversations/egress_test.exs
+++ b/apps/fountain/test/fountain/conversations/egress_test.exs
@@ -1,0 +1,337 @@
+defmodule Fountain.Conversations.EgressTest do
+  @moduledoc """
+  The egress family that left `ConversationServer` in #1373, driven without
+  a server: the split rules on real rows, the session's life against a
+  stubbed `Fountain.Broker`, and the floor against a stubbed `Provisioning`.
+
+  Brokering is switched on per tenant through application env, so this
+  module is `async: false` like the other broker tests.
+  """
+  use Fountain.DataCase, async: false
+  use Mimic
+
+  alias Fountain.Broker
+  alias Fountain.Conversations
+  alias Fountain.Conversations.Egress
+  alias Fountain.SecretBindings.Binding
+  alias Managoat.Sandbox.Handle
+
+  @session %{vault: "c-test", token: "av_sess_conv", expires_at: nil}
+
+  setup do
+    previous =
+      for key <- [:broker_url, :broker_token, :broker_proxy_url, :broker_tenants],
+          do: {key, Application.get_env(:fountain, key)}
+
+    on_exit(fn ->
+      for {key, value} <- previous do
+        if is_nil(value),
+          do: Application.delete_env(:fountain, key),
+          else: Application.put_env(:fountain, key, value)
+      end
+    end)
+
+    user = insert_verified_user()
+    {:ok, user: user}
+  end
+
+  defp broker_on(tenants) do
+    Application.put_env(:fountain, :broker_url, "http://broker.test:14321")
+    Application.put_env(:fountain, :broker_token, "av_sess_owner")
+    Application.put_env(:fountain, :broker_proxy_url, "http://broker.test:14322")
+    Application.put_env(:fountain, :broker_tenants, tenants)
+  end
+
+  defp broker_off do
+    Application.delete_env(:fountain, :broker_url)
+    Application.put_env(:fountain, :broker_tenants, [])
+  end
+
+  defp host_triples(bindings), do: Enum.map(bindings, &{&1.key, &1.host, &1.auth_type})
+
+  describe "the split rules for an unbrokered tenant" do
+    test "are all no-ops, and read no bindings", %{user: user} do
+      broker_off()
+      {:ok, _} = Fountain.SecretBindings.create_binding(user.id, binding_attrs("DATABASE_URL"))
+      _conn = insert_connection(user)
+
+      refute Egress.brokered?(user.id)
+      assert Egress.bindings(user.id) == %{}
+
+      secrets = %{"GITHUB_TOKEN" => "ghp_real", "DATABASE_URL" => "postgres://x"}
+      assert Egress.split_brokered(user.id, secrets, %{}) == {secrets, %{}}
+      assert Egress.add_connection_secrets(user.id, secrets, %{}, nil) == {secrets, %{}, []}
+
+      creds = %{anthropic_api_key: "sk-ant-api03-x"}
+      assert Egress.split_inference(user.id, creds, %{}, %{}) == {creds, %{}, %{}}
+    end
+  end
+
+  describe "split_brokered/3" do
+    test "catalog keys and bound keys become placeholders; the rest stay", %{user: user} do
+      broker_on([user.id])
+      {:ok, _} = Fountain.SecretBindings.create_binding(user.id, binding_attrs("DATABASE_URL"))
+      bindings = Egress.bindings(user.id)
+
+      assert [%Binding{key: "DATABASE_URL", host: "api.example.com"}] = bindings["DATABASE_URL"]
+
+      secrets = %{"GITHUB_TOKEN" => "ghp_real", "DATABASE_URL" => "postgres://x", "PLAIN" => "p"}
+
+      assert {sandbox, brokered} = Egress.split_brokered(user.id, secrets, bindings)
+
+      assert sandbox == %{
+               "GITHUB_TOKEN" => "__github_token__",
+               "DATABASE_URL" => "__database_url__",
+               "PLAIN" => "p"
+             }
+
+      assert brokered == %{"GITHUB_TOKEN" => "ghp_real", "DATABASE_URL" => "postgres://x"}
+    end
+  end
+
+  describe "split_inference/4" do
+    test "placeholders for the runtime, values for the broker, the tenant's own wins",
+         %{user: user} do
+      broker_on([user.id])
+      creds = %{anthropic_api_key: "sk-ant-api03-real", openai_api_key: "sk-real"}
+      own = %{"ANTHROPIC_API_KEY" => "tenant-secret"}
+      own_bindings = %{"OPENAI_API_KEY" => [:tenant_binding]}
+
+      {env_creds, brokered, bindings} = Egress.split_inference(user.id, creds, own, own_bindings)
+
+      assert env_creds == %{
+               anthropic_api_key: "sk-ant-api03-__anthropic_api_key__",
+               openai_api_key: "sk-__openai_api_key__"
+             }
+
+      # The secret split before this wins over the credential of the same name.
+      assert brokered == %{"ANTHROPIC_API_KEY" => "tenant-secret", "OPENAI_API_KEY" => "sk-real"}
+
+      # An implicit binding only where the tenant has none of their own.
+      assert bindings["OPENAI_API_KEY"] == [:tenant_binding]
+
+      assert host_triples(bindings["ANTHROPIC_API_KEY"]) == [
+               {"ANTHROPIC_API_KEY", "api.anthropic.com", "substitute"}
+             ]
+    end
+  end
+
+  describe "connections" do
+    test "add_connection_secrets/4 brokers a connection's token with bearer bindings to its hosts",
+         %{user: user} do
+      broker_on([user.id])
+      conn = insert_connection(user)
+
+      {merged, bindings, keys} =
+        Egress.add_connection_secrets(user.id, %{"OWN" => "o"}, %{}, nil)
+
+      assert keys == [conn.env_key]
+      assert merged["OWN"] == "o"
+      assert merged[conn.env_key] == conn.access_token
+
+      assert host_triples(bindings[conn.env_key]) ==
+               Enum.map(Fountain.Connections.Google.token_hosts(), &{conn.env_key, &1, "bearer"})
+    end
+
+    test "a tenant's own secret and own binding of the same name win", %{user: user} do
+      broker_on([user.id])
+      conn = insert_connection(user)
+      own = %{conn.env_key => "mine"}
+      own_bindings = %{conn.env_key => [:mine]}
+
+      assert Egress.add_connection_secrets(user.id, own, own_bindings, nil) ==
+               {own, own_bindings, []}
+    end
+
+    test "connection_bindings/3 adds the agent's remote MCP hosts to the provider's",
+         %{user: user} do
+      broker_on([user.id])
+      conn = insert_connection(user)
+      remote = %{conn.env_key => ["mcp.example", hd(Fountain.Connections.Google.token_hosts())]}
+
+      hosts =
+        Egress.connection_bindings(user.id, conn.env_key, remote) |> Enum.map(& &1.host)
+
+      assert hosts == Enum.uniq(Fountain.Connections.Google.token_hosts() ++ ["mcp.example"])
+    end
+
+    test "refresh_connection_secrets/3 swaps in a rotated token and says so", %{user: user} do
+      broker_on([user.id])
+      conn = insert_connection(user)
+      current = %{conn.env_key => conn.access_token, "OTHER" => "x"}
+
+      assert Egress.refresh_connection_secrets([], user.id, current) == {current, false}
+
+      assert Egress.refresh_connection_secrets([conn.env_key], user.id, current) ==
+               {current, false}
+
+      stale = %{conn.env_key => "old", "OTHER" => "x"}
+
+      assert Egress.refresh_connection_secrets([conn.env_key], user.id, stale) ==
+               {current, true}
+    end
+
+    test "with_connection_servers/4 resolves a remote entry only for a brokered tenant",
+         %{user: user} do
+      conn = insert_connection(user)
+
+      # Three kinds of entry: one served by Fountain for the connection, one
+      # remote server the connection's token is attached to, and a plain one.
+      agent = %{
+        mcp_servers: %{
+          "served" => %{"connection" => conn.id},
+          "remote" => %{"connection" => conn.id, "url" => "https://mcp.example/sse"},
+          "plain" => %{"url" => "https://plain.example"}
+        }
+      }
+
+      # Unbrokered: no token and no connections, so both connection entries
+      # are dropped and the agent runs on the plain one.
+      broker_off()
+
+      assert %{mcp_servers: %{"plain" => _} = off} =
+               Egress.with_connection_servers(agent, user.id, "conv-1", "tok")
+
+      assert Map.keys(off) == ["plain"]
+
+      broker_on([user.id])
+
+      assert %{mcp_servers: %{"served" => %{"url" => url}, "remote" => remote, "plain" => _}} =
+               Egress.with_connection_servers(agent, user.id, "conv-1", "tok")
+
+      assert url =~ "conv-1"
+      assert remote["url"] == "https://mcp.example/sse"
+
+      assert Egress.with_connection_servers(nil, user.id, "conv-1", "tok") == nil
+
+      assert Egress.with_connection_servers(%{mcp_servers: nil}, user.id, "conv-1", "tok") == %{
+               mcp_servers: nil
+             }
+    end
+  end
+
+  describe "the session" do
+    test "prepare/4 publishes the broker stage around the mint", %{user: user} do
+      broker_on([user.id])
+      conv = insert_conversation(user_id: user.id)
+
+      stub(Broker, :prepare, fn id, brokered, bindings, opts ->
+        assert id == conv.id
+        assert brokered == %{"GITHUB_TOKEN" => "ghp"}
+        assert bindings == %{}
+        assert opts == [network: :unrestricted, user_id: user.id]
+        {:ok, @session}
+      end)
+
+      assert {:ok, @session} =
+               Egress.prepare(conv.id, %{"GITHUB_TOKEN" => "ghp"}, %{},
+                 network: :unrestricted,
+                 user_id: user.id
+               )
+
+      assert [{"started", %{"keys" => ["GITHUB_TOKEN"]}}, {"done", %{"vault" => "c-test"}}] =
+               stages(conv.id, "broker")
+    end
+
+    test "prepare/4 reports the failure as the stage's", %{user: user} do
+      conv = insert_conversation(user_id: user.id)
+      stub(Broker, :prepare, fn _id, _b, _bi, _o -> {:error, :down} end)
+
+      assert {:error, :down} =
+               Egress.prepare(conv.id, %{}, %{}, network: :unrestricted, user_id: user.id)
+
+      assert [{"started", _}, {"failed", %{"reason" => ":down"}}] = stages(conv.id, "broker")
+    end
+
+    test "reprepare/5 replaces the proxy variables and nothing else", %{user: user} do
+      broker_on([user.id])
+      stub(Broker, :prepare, fn _id, _b, _bi, _o -> {:ok, @session} end)
+
+      old = %{@session | token: "av_sess_old"}
+      env = [{"KEEP", "1"}] ++ Broker.sandbox_env(old) ++ [{"ALSO", "2"}]
+
+      assert {:ok, @session, rebuilt} =
+               Egress.reprepare("c", %{}, %{}, env, network: :unrestricted, user_id: user.id)
+
+      assert rebuilt == [{"KEEP", "1"}, {"ALSO", "2"}] ++ Broker.sandbox_env(@session)
+
+      stub(Broker, :prepare, fn _id, _b, _bi, _o -> {:error, :down} end)
+
+      assert {:error, :down} =
+               Egress.reprepare("c", %{}, %{}, env, network: :unrestricted, user_id: user.id)
+    end
+
+    test "drop_oauth_token/3 forgets the token on both sides and re-splits the API key" do
+      creds = %{claude_code_oauth_token: "sk-ant-oat01-x", anthropic_api_key: "sk-ant-api03-k"}
+      brokered = %{"CLAUDE_CODE_OAUTH_TOKEN" => "sk-ant-oat01-x", "GITHUB_TOKEN" => "ghp"}
+      bindings = %{"CLAUDE_CODE_OAUTH_TOKEN" => [:implicit], "GITHUB_TOKEN" => [:own]}
+
+      {env_creds, brokered, bindings} = Egress.drop_oauth_token(creds, brokered, bindings)
+
+      assert env_creds == %{anthropic_api_key: "sk-ant-api03-__anthropic_api_key__"}
+      assert brokered == %{"ANTHROPIC_API_KEY" => "sk-ant-api03-k", "GITHUB_TOKEN" => "ghp"}
+      assert Map.keys(bindings) |> Enum.sort() == ["ANTHROPIC_API_KEY", "GITHUB_TOKEN"]
+      assert bindings["GITHUB_TOKEN"] == [:own]
+    end
+
+    test "sandbox_env/1 is the session's proxy variables, or nothing", %{user: user} do
+      broker_on([user.id])
+      assert Egress.sandbox_env(nil) == []
+      assert Egress.sandbox_env(@session) == Broker.sandbox_env(@session)
+    end
+
+    test "install_ca/3 installs only when there is a session" do
+      handle = %Handle{provider: :sprites, name: "s"}
+      assert :ok = Egress.install_ca(nil, handle, "c")
+
+      stub(Fountain.Conversations.Provisioning, :install_broker_ca, fn ^handle, "c" -> :ok end)
+      assert :ok = Egress.install_ca(@session, handle, "c")
+    end
+  end
+
+  describe "release/2" do
+    setup :set_mimic_global
+
+    test "releases the vault off the caller's path, for a brokered tenant only", %{user: user} do
+      test_pid = self()
+      stub(Broker, :release, fn conv_id -> send(test_pid, {:released, conv_id}) && :ok end)
+
+      broker_off()
+      assert :ok = Egress.release(user.id, "c-off")
+      refute_receive {:released, "c-off"}, 100
+
+      broker_on([user.id])
+      assert :ok = Egress.release(user.id, "c-on")
+      assert_receive {:released, "c-on"}, 1_000
+    end
+  end
+
+  describe "apply_policy/4" do
+    test "is the environment's network policy, or the broker floor when brokered" do
+      handle = %Handle{provider: :sprites, name: "s"}
+      env = %{networking_type: "limited"}
+
+      stub(Fountain.Conversations.Provisioning, :apply_network_policy, fn ^handle, ^env, "c" ->
+        :policy
+      end)
+
+      stub(Fountain.Conversations.Provisioning, :apply_broker_floor, fn ^handle, "c" -> :floor end)
+
+      assert :policy = Egress.apply_policy(handle, env, "c", false)
+      assert :floor = Egress.apply_policy(handle, env, "c", true)
+    end
+  end
+
+  defp binding_attrs(key),
+    do: %{"key" => key, "host" => "api.example.com", "auth_type" => "bearer"}
+
+  defp stages(conv_id, stage) do
+    Fountain.Repo.all(
+      from(e in Conversations.LogEvent,
+        where: e.conversation_id == ^conv_id and e.kind == "stage" and e.stage == ^stage,
+        order_by: e.id
+      )
+    )
+    |> Enum.map(&{&1.state, Jason.decode!(&1.data)})
+  end
+end

--- a/apps/fountain/test/fountain/webhooks/events_test.exs
+++ b/apps/fountain/test/fountain/webhooks/events_test.exs
@@ -21,7 +21,8 @@ defmodule Fountain.Webhooks.EventsTest do
   # Where publish_stage/4 is called from. A new file calling it belongs here.
   @sources [
     "lib/fountain/conversations/conversation_server.ex",
-    "lib/fountain/conversations/provisioning.ex"
+    "lib/fountain/conversations/provisioning.ex",
+    "lib/fountain/conversations/egress.ex"
   ]
 
   # publish_stage(<anything>, "<stage>", "<status>"


### PR DESCRIPTION
Part of #1369, fourth of eight. Everything ADR 0019 wired into the server leaves for `Fountain.Conversations.Egress`, as functions over rows and values; the server keeps the session and its placeholders in state and three short wrappers that apply what comes back.

## Functions moved

All seventeen named functions exist and all seventeen moved. **One correction to the issue:** it also lists "the three `handle_info` clauses in that section (the refresh timer, the release on terminate, the CA install result)". There are none. The section has no `handle_info` clause and the server has no broker timer: the refresh runs at the turn kick (`broker_refresh/1` from `run_fresh_turn`), the release is called from `terminate_conversation`, the reclaim path and the provision failure path, and the CA install is a synchronous step of provision and reattach. Nothing to move there, and no timer was invented.

| was (`ConversationServer`, all private) | now (`Egress`) |
|---|---|
| `brokered?/1` (over state) | `brokered?/1` (user id) |
| `split_brokered/3`, `split_inference/4`, `add_connection_secrets/4`, `connection_bindings/3` | same names, public |
| `active_connections_by_id/1`, `remote_connection_hosts/2` | same names, private |
| `refresh_connection_secrets/1` (over state) | `refresh_connection_secrets/3` (keys, user id, brokered map), returns `{brokered, rotated?}` |
| `with_connection_servers/2` (agent, state) | `with_connection_servers/4` (agent, user id, conversation id, callback token) |
| `broker_bindings/1` | `bindings/1` |
| `broker_env/1` (over state) | `sandbox_env/1` (session or nil) |
| `broker_prepare/1` | `prepare/4` (the stage-publishing mint); the `if brokered?` and the state update stay in the server wrapper |
| `broker_switch_to_api_key/1` | `drop_oauth_token/3` (pure) + `reprepare/5` (mint and rebuild the env) |
| `broker_refresh/1` | `refresh_connection_secrets/3` + `reprepare/5`; the "rotated or expiring" decision stays in the wrapper |
| `broker_install_ca/2` | `install_ca/3` (session, handle, conversation id) |
| `broker_release/1` | `release/2` (user id, conversation id) |
| `apply_egress_policy/4` | `apply_policy/4` |

`reprepare/5` is one function where the server had two copies of the same six lines (the OAuth switch and the refresh both re-mint and swap the proxy variables in the env); the bodies were identical, so this is a dedupe of moved code, not a change. `Egress.prepare/4` publishes the `broker` stage exactly as before; `reprepare/5` publishes none, as neither caller did.

## What the server keeps

Under the `sprite environment and egress` header, now placed above them: the `build_sprite_env/5` wrapper from #1372 and three wrappers, each of which unpacks state, calls `Egress`, and applies the result:

- `broker_prepare/1`: `if Egress.brokered?(user_id)`, then `Egress.prepare/4` and `broker: session`; else the state untouched.
- `broker_switch_to_api_key/1`: `drop_oauth_token/3` into the three fields, then `reprepare/5` into `broker` and `sprite_env`; the same warning on failure, the same state kept.
- `broker_refresh/1`: `refresh_connection_secrets/3` into `brokered`, then `reprepare/5` only if rotated or the session is expiring (`Fountain.Broker.expiring?/1`), the same warning and comment on failure.

Every other call site is a direct `Egress.` call with the fields spelled out: the four split rules at provision, `brokered?` twice, `with_connection_servers` three times, `install_ca` twice, `release` three times, `apply_policy` twice, `sandbox_env` once (the `brokered:` argument to `SpriteEnv.build/4`, the seam #1372 left).

The facade only: `Egress` calls `Fountain.Broker` and never a backend. It also has no `Repo` call; `audit_guardrail_test` is green.

`webhooks/events_test.exs` keeps a list of the files that may call `publish_stage/4` (its comment says a new file calling it belongs there); `egress.ex` is added, since the `broker` stage now publishes from there. That is the one test outside the new module that changed, and it is a list entry, not an assertion.

## Unit tests, no process

`egress_test.exs` (17 tests, `async: false` because brokering is switched on per tenant through application env, like `broker_test`):

- every split rule is a no-op for an unbrokered tenant, and reads no bindings;
- `split_brokered/3`: a catalog key and a key with the tenant's own binding become placeholders, a plain one stays;
- `split_inference/4`: placeholders for the runtime, values for the broker, the tenant's own secret of the same name wins, an implicit binding only where the tenant has none;
- connections: a connection's token brokered with bearer bindings to the provider's hosts; the tenant's own secret and binding win; `connection_bindings/3` adds the agent's remote MCP hosts, deduplicated; `refresh_connection_secrets/3` swaps in a rotated token and says so; `with_connection_servers/4` drops both connection entries for an unbrokered tenant and resolves the served one (URL carries the conversation id) while keeping the remote one for a brokered tenant;
- the session: `prepare/4` publishes `broker/started` (keys) and `broker/done` (vault) around the facade call, and `broker/failed` with the reason; `reprepare/5` replaces the proxy variables and nothing else; `drop_oauth_token/3` forgets the token on both sides; `sandbox_env/1`; `install_ca/3` only with a session;
- `release/2` calls the facade off the caller's path for a brokered tenant only (Mimic global, since it runs in a supervised task);
- `apply_policy/4` picks the environment's policy or the broker floor.

`Fountain.Broker` and `Provisioning` are stubbed through Mimic where the test would otherwise reach the network; no `ConversationServer`, no sandbox stub, no peer.

## Pin

| | lines |
|---|---|
| before | 4168 |
| after | 3991 |

## Gates

| gate | result |
|---|---|
| `MIX_ENV=test mix compile --warnings-as-errors` | clean |
| `mix format --check-formatted` (mise Elixir 1.19.2) | exit 0 |
| `mix credo --strict` | 5816 mods/funs, no issues |
| `MIX_ENV=dev mix dialyzer` | passed, 0 errors |
| thirteen `conversation_server*_test.exs` + size test + `broker_test`, `broker_native_test`, `conversation_egress_test`, `audit_guardrail`, `caller_tools`, `provisioning_test`, `docs`, `connections` | 387 tests, 0 failures |
| `egress_test` + size test | 17 tests, 0 failures |
| gitleaks over the new module and tests | no leaks |
| full root suite | posted as a comment when it finishes |

`git diff --stat origin/main` over the thirteen server test files and the three pins named by the issue is empty.

**Proof:** with `origin/main`'s server file put back beside the new module, the size test fails: `... is 4168 lines, over the pin of 3991`. Restored; the committed file is 3,991.

## CHANGELOG

One entry under `[Unreleased] → ### Changed`.

Closes #1373. Part of #1369.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mx2sij38JHM6gQu6PxiGG
