### PR TITLE
refactor(conversations): pending permissions and parked caller tools out (Pending)

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -86,6 +86,9 @@
                # the turn state machine (#1374): the server's own code, called
                # only from its callbacks, under the ownership init established
                "lib/fountain/conversations/turn_machine.ex",
+               # what a turn waits on (#1375): the same, writing the same turn
+               # row the server owns, called only from its callbacks
+               "lib/fountain/conversations/pending.ex",
                # system-level sweeps, run with no user in scope
                "lib/fountain/conversations/rehydrator.ex",
                "lib/fountain/workers/",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -260,6 +260,15 @@ upgrade, is in
   spawn, the peer and the connection. Twenty-four functions and twelve
   report handlers moved; no stage, log line, telemetry event, timer or
   audit event changed. The pin drops from 3,991 to 3,322.
+- **What a turn waits on has left `ConversationServer`** (#1375, tracker
+  #1369). `Fountain.Conversations.Pending` is the parked caller-tool calls
+  with their deadlines and the permission request's timeout, as one value,
+  with the functions that add, answer, deny, expire and drain it and return
+  the reply, the turn row and the next value. The server's five
+  `handle_call` clauses, the two timeout handlers and the ask are each a
+  call into it; the GenServer messages, the stage events and the audit of a
+  denial are unchanged, and `Fountain.CallerTools` still owns the wire
+  shapes. The pin drops from 3,322 to 3,192.
 
 ### Added
 

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -28,6 +28,7 @@ defmodule Fountain.Conversations.ConversationServer do
     HomeCheckpoint,
     Lifecycle,
     McpServers,
+    Pending,
     Provisioning,
     SpriteEnv,
     TurnMachine
@@ -1615,92 +1616,60 @@ defmodule Fountain.Conversations.ConversationServer do
     {:reply, :ok, interrupt_turn(state)}
   end
 
-  # First answer wins. The web apps and an editor (#708) are peer clients of
-  # this door, not fallbacks for one another, so a second answer to the same
-  # request is "too late" rather than an error in the caller.
+  # First answer wins (`Pending.answer_permission/6`): the web apps and an
+  # editor (#708) are peer clients of this door, not fallbacks for one
+  # another, so a second answer to the same request is "too late" rather
+  # than an error in the caller.
   def handle_call({:answer_permission, request_id, option_id}, _from, state) do
-    case state.acp_peer do
-      nil ->
-        {:reply, {:error, :no_pending_permission}, state}
+    {reply, turn, pending} =
+      Pending.answer_permission(
+        Pending.from_state(state),
+        state.conversation_id,
+        state.current_turn,
+        state.acp_peer,
+        request_id,
+        option_id
+      )
 
-      peer ->
-        case Managoat.ACP.Peer.answer_permission(peer, request_id, option_id) do
-          :ok ->
-            {:reply, :ok, resolve_permission(state, request_id, "answered", option_id)}
-
-          {:error, reason} ->
-            {:reply, {:error, reason}, state}
-        end
-    end
+    {:reply, reply, %{Pending.into_state(state, pending) | current_turn: turn}}
   end
 
+  # A call needs a turn to belong to, and the client following that turn is
+  # the only party that can answer.
   def handle_call({:park_caller_tool, name, arguments, waiter}, _from, state) do
     case state.current_turn do
       nil ->
         {:reply, {:error, :no_turn}, state}
 
       turn ->
-        call_id = "call_" <> (Ecto.UUID.generate() |> String.replace("-", ""))
-
-        publish_stage(state.conversation_id, "caller_tool", "started", %{
-          call_id: call_id,
-          turn_id: turn.id,
-          name: name,
-          arguments: arguments,
-          timeout_ms: Fountain.Conversations.Lifecycle.ask_timeout_ms()
-        })
-
-        timer =
-          Process.send_after(
-            self(),
-            {:caller_tool_timeout, call_id},
-            Fountain.Conversations.Lifecycle.ask_timeout_ms()
+        {call_id, pending} =
+          Pending.park(
+            Pending.from_state(state),
+            state.conversation_id,
+            turn,
+            name,
+            arguments,
+            waiter
           )
 
-        entry = %{
-          id: call_id,
-          name: name,
-          arguments: arguments,
-          turn_id: turn.id,
-          waiter: waiter,
-          timer: timer,
-          result: nil,
-          parked_at: System.monotonic_time(:millisecond)
-        }
-
-        {:reply, {:ok, call_id}, put_in(state.caller_calls[call_id], entry)}
+        {:reply, {:ok, call_id}, Pending.into_state(state, pending)}
     end
   end
 
   def handle_call({:await_caller_tool, call_id, waiter}, _from, state) do
-    case state.caller_calls[call_id] do
-      nil -> {:reply, {:error, :unknown_call}, state}
-      %{result: nil} -> {:reply, :pending, put_in(state.caller_calls[call_id].waiter, waiter)}
-      %{result: result} -> {:reply, {:ok, result}, state}
-    end
+    {reply, pending} = Pending.await(Pending.from_state(state), call_id, waiter)
+    {:reply, reply, Pending.into_state(state, pending)}
   end
 
   def handle_call(:pending_caller_calls, _from, state) do
-    {:reply, pending_caller_calls_of(state), state}
+    {:reply, Pending.calls(Pending.from_state(state)), state}
   end
 
   def handle_call({:answer_caller_tools, answers}, _from, state) do
-    matched =
-      state.caller_calls
-      |> Map.values()
-      |> Enum.filter(&(is_nil(&1.result) and Map.has_key?(answers, &1.id)))
+    {reply, pending} =
+      Pending.answer_calls(Pending.from_state(state), state.conversation_id, answers)
 
-    if matched == [] do
-      {:reply, {:error, :no_pending_calls}, state}
-    else
-      state =
-        Enum.reduce(matched, state, fn call, state ->
-          resolve_caller_tool(state, call.id, "answered", {:ok, Map.fetch!(answers, call.id)})
-        end)
-
-      turn_id = matched |> List.first() |> Map.fetch!(:turn_id)
-      {:reply, {:ok, %{turn_id: turn_id, remaining: pending_caller_calls_of(state)}}, state}
-    end
+    {:reply, reply, Pending.into_state(state, pending)}
   end
 
   def handle_call(:terminate_conv, _from, state) do
@@ -1880,13 +1849,16 @@ defmodule Fountain.Conversations.ConversationServer do
   # The caller never answered a parked tool call (#1202). The agent gets an
   # error result and carries on; the stream records the outcome.
   def handle_info({:caller_tool_timeout, call_id}, state) do
-    {:noreply,
-     resolve_caller_tool(
-       state,
-       call_id,
-       "timeout",
-       {:error, "the caller did not answer within the deadline"}
-     )}
+    pending =
+      Pending.resolve_call(
+        Pending.from_state(state),
+        state.conversation_id,
+        call_id,
+        "timeout",
+        {:error, "the caller did not answer within the deadline"}
+      )
+
+    {:noreply, Pending.into_state(state, pending)}
   end
 
   # #655: the org has refused this account's Claude OAuth token. The machine
@@ -2133,110 +2105,41 @@ defmodule Fountain.Conversations.ConversationServer do
 
   def handle_info(_msg, state), do: {:noreply, state}
 
-  # The one place a held request stops being held, whoever ended it: an answer,
-  # the timeout, or the turn ending. Cancels the timer, clears the turn's
-  # `pending_permission`, and publishes the resolution so a card can close.
-  #
-  # `state: "done"` for every outcome, including a deny and a timeout. The stage
-  # and its status are the Prometheus counter's only tags and there is an alert
-  # on them — a timeout emitting `failed` would page someone for a policy doing
-  # exactly what it was told.
+  # The permission request's end, whichever way (`Pending.resolve_permission/7`):
+  # the turn row and the timer are the server's to hold.
   defp resolve_permission(state, request_id, outcome, option_id) do
-    if state.permission_timer, do: Process.cancel_timer(state.permission_timer)
+    {turn, pending} =
+      Pending.resolve_permission(
+        Pending.from_state(state),
+        state.conversation_id,
+        state.current_turn,
+        state.acp_peer,
+        request_id,
+        outcome,
+        option_id
+      )
 
-    # Read before the clear below wipes it.
-    tool = pending_tool(state)
-
-    if outcome != "answered" and state.acp_peer do
-      Managoat.ACP.Peer.deny_permission(state.acp_peer, request_id)
-    end
-
-    state =
-      case state.current_turn do
-        nil ->
-          state
-
-        turn ->
-          {:ok, turn} = Conversations._unsafe_update_turn(turn, %{pending_permission: nil})
-          %{state | current_turn: turn}
-      end
-
-    publish_stage(state.conversation_id, "request", "done", %{
-      request_id: request_id,
-      outcome: outcome,
-      option_id: option_id
-    })
-
-    if outcome != "answered" do
-      Conversations.record_permission_denied(state.conversation_id, tool, outcome)
-    end
-
-    %{state | permission_timer: nil}
+    %{Pending.into_state(state, pending) | current_turn: turn}
   end
 
-  defp pending_tool(%{current_turn: %{pending_permission: %{"tool" => tool}}}), do: tool
-  defp pending_tool(_state), do: nil
-
-  # Resolve whatever is held, if anything. The turn row is the source of truth
-  # rather than the timer, so this is also correct for a request raised by a
-  # previous BEAM lifetime and reattached to.
+  # Resolve whatever is held, if anything, as the turn ends.
   defp resolve_pending_permission(state, outcome) do
-    case state.current_turn do
-      %{pending_permission: %{"request_id" => request_id}} ->
-        resolve_permission(state, request_id, outcome, nil)
+    {turn, pending} =
+      Pending.resolve_pending_permission(
+        Pending.from_state(state),
+        state.conversation_id,
+        state.current_turn,
+        state.acp_peer,
+        outcome
+      )
 
-      _ ->
-        state
-    end
+    %{Pending.into_state(state, pending) | current_turn: turn}
   end
 
-  # The one place a parked caller-tool call stops being parked (#1202): an
-  # answer, the deadline, or the turn ending. Cancels the timer, hands the
-  # result to whoever is waiting, keeps it for a waiter that asks later, and
-  # says so on the stream. `done` for every outcome, as `request` does.
-  defp resolve_caller_tool(state, call_id, outcome, result) do
-    case state.caller_calls[call_id] do
-      %{result: nil} = call ->
-        if call.timer, do: Process.cancel_timer(call.timer)
-        if is_pid(call.waiter), do: send(call.waiter, {:caller_tool_result, call_id, result})
-
-        publish_stage(state.conversation_id, "caller_tool", "done", %{
-          call_id: call_id,
-          turn_id: call.turn_id,
-          name: call.name,
-          outcome: outcome
-        })
-
-        put_in(state.caller_calls[call_id], %{call | result: result, timer: nil, waiter: nil})
-
-      _ ->
-        state
-    end
-  end
-
-  # Everything still parked when the turn ends: the agent gave up waiting, or
-  # the turn was cut. Resolved as errors, then the whole registry is dropped —
-  # a kept result belongs to a turn that is over.
+  # Everything still parked when the turn ends (`Pending.drop_calls/3`).
   defp drop_caller_tools(state, outcome) do
-    state =
-      Enum.reduce(pending_caller_calls_of(state), state, fn call, state ->
-        resolve_caller_tool(
-          state,
-          call.id,
-          outcome,
-          {:error, "the turn ended before the caller answered"}
-        )
-      end)
-
-    %{state | caller_calls: %{}}
-  end
-
-  defp pending_caller_calls_of(state) do
-    state.caller_calls
-    |> Map.values()
-    |> Enum.filter(&is_nil(&1.result))
-    |> Enum.sort_by(& &1.parked_at)
-    |> Enum.map(&Map.take(&1, [:id, :name, :arguments, :turn_id]))
+    pending = Pending.drop_calls(Pending.from_state(state), state.conversation_id, outcome)
+    Pending.into_state(state, pending)
   end
 
   # The absolute lifetime ceiling measures a continuous run, not calendar age:
@@ -2947,54 +2850,21 @@ defmodule Fountain.Conversations.ConversationServer do
 
   defp apply_effect(state, {:drop_connection, why}), do: drop_connection(state, why)
 
-  # `ask`: the agent is blocked and a human has to answer (#940).
-  #
-  # Three things happen, and the order matters. The pending request is persisted
-  # on the turn first, so a deploy landing a millisecond later can still be
-  # answered; then the stage event goes out; then the timeout is armed.
-  #
-  # The timeout is not optional and it is not a tidiness measure.
-  # `Lifecycle.check/4` suppresses only the *idle* verdict while a turn is in
-  # flight, so an unanswered request would sail past the idle bound and be
-  # resolved by the max-lifetime ceiling — and per 0017 the idle bound suspends
-  # while the ceiling destroys. Left alone, a prompt nobody answers does not
-  # hang forever; it burns the whole lifetime and then takes the agent's memory
-  # with it (#649).
+  # `ask`: the agent is blocked and a human has to answer (#940). The request
+  # goes on the turn row first, then the stage, then the timeout
+  # (`Pending.ask/6`); the server holds the row and the timer.
   defp ask_permission(state, request_id, tool, options) do
-    pending = %{
-      "request_id" => request_id,
-      "tool" => tool,
-      "options" => options,
-      "asked_at" => DateTime.utc_now() |> DateTime.to_iso8601()
-    }
-
-    state =
-      case state.current_turn do
-        nil ->
-          state
-
-        turn ->
-          {:ok, turn} = Conversations._unsafe_update_turn(turn, %{pending_permission: pending})
-          %{state | current_turn: turn}
-      end
-
-    publish_stage(state.conversation_id, "request", "started", %{
-      request_id: request_id,
-      tool: tool,
-      # The agent's own list, verbatim. A client must never offer an option
-      # that is not on it.
-      options: options,
-      timeout_ms: Fountain.Conversations.Lifecycle.ask_timeout_ms()
-    })
-
-    timer =
-      Process.send_after(
-        self(),
-        {:permission_timeout, request_id},
-        Fountain.Conversations.Lifecycle.ask_timeout_ms()
+    {turn, pending} =
+      Pending.ask(
+        Pending.from_state(state),
+        state.conversation_id,
+        state.current_turn,
+        request_id,
+        tool,
+        options
       )
 
-    %{state | permission_timer: timer}
+    %{Pending.into_state(state, pending) | current_turn: turn}
   end
 
   # ── the connection (#817) ─────────────────────────────────────────────────

--- a/apps/fountain/lib/fountain/conversations/pending.ex
+++ b/apps/fountain/lib/fountain/conversations/pending.ex
@@ -1,0 +1,394 @@
+defmodule Fountain.Conversations.Pending do
+  @moduledoc """
+  What a turn waits on a human or a client for (#1375): a permission
+  request the peer asked (#940), and a caller-defined tool call the tool
+  bridge parked (#1202).
+
+  A value and the functions that add, answer, deny, expire and drain it.
+  The value is the parked calls with their timers and the permission
+  timeout; the permission request itself lives on the turn row, which is
+  why a request raised before a deploy is still answerable after one.
+  `from_state/1` reads the two server fields into a `%Pending{}` and
+  `into_state/2` writes them back; the server's state does not change shape.
+
+  Every function takes what it reads (the conversation id, the turn row,
+  the peer) and returns what changed: the reply to hand back, the turn row
+  and the next value. Timers are armed in the calling process, which is the
+  server; the answers reach the peer (`Managoat.ACP.Peer`) and the parked
+  caller from here, and the stage events say what happened on the stream.
+  `Fountain.CallerTools` owns the wire shapes and stays where it is.
+  """
+
+  alias Fountain.Conversations
+  alias Fountain.Conversations.Lifecycle
+
+  @type call :: %{
+          id: String.t(),
+          name: String.t(),
+          arguments: map(),
+          turn_id: String.t(),
+          waiter: pid() | nil,
+          timer: reference() | nil,
+          result: {:ok, String.t()} | {:error, String.t()} | nil,
+          parked_at: integer()
+        }
+
+  @type t :: %__MODULE__{
+          calls: %{String.t() => call()},
+          permission_timer: reference() | nil
+        }
+
+  defstruct calls: %{}, permission_timer: nil
+
+  # ── the server boundary ───────────────────────────────────────────────────
+
+  @doc "What the server holds, as one value."
+  @spec from_state(map()) :: t()
+  def from_state(state),
+    do: %__MODULE__{calls: state.caller_calls, permission_timer: state.permission_timer}
+
+  @doc "The value written back into the server's fields."
+  @spec into_state(map(), t()) :: map()
+  def into_state(state, %__MODULE__{} = pending),
+    do: %{state | caller_calls: pending.calls, permission_timer: pending.permission_timer}
+
+  # ── permission requests (#940) ────────────────────────────────────────────
+
+  @doc """
+  `ask`: the agent is blocked and a human has to answer (#940).
+
+  Three things happen, and the order matters. The pending request is persisted
+  on the turn first, so a deploy landing a millisecond later can still be
+  answered; then the stage event goes out; then the timeout is armed.
+
+  The timeout is not optional and it is not a tidiness measure.
+  `Lifecycle.check/4` suppresses only the *idle* verdict while a turn is in
+  flight, so an unanswered request would sail past the idle bound and be
+  resolved by the max-lifetime ceiling — and per 0017 the idle bound suspends
+  while the ceiling destroys. Left alone, a prompt nobody answers does not
+  hang forever; it burns the whole lifetime and then takes the agent's memory
+  with it (#649).
+
+  Returns the turn row with the request on it (unchanged when there is no
+  turn) and the value with the timer armed.
+  """
+  @spec ask(t(), String.t(), Conversations.Turn.t() | nil, term(), String.t(), list()) ::
+          {Conversations.Turn.t() | nil, t()}
+  def ask(%__MODULE__{} = pending, conversation_id, turn, request_id, tool, options) do
+    request = %{
+      "request_id" => request_id,
+      "tool" => tool,
+      "options" => options,
+      "asked_at" => DateTime.utc_now() |> DateTime.to_iso8601()
+    }
+
+    turn =
+      case turn do
+        nil ->
+          nil
+
+        turn ->
+          {:ok, turn} = Conversations._unsafe_update_turn(turn, %{pending_permission: request})
+          turn
+      end
+
+    publish_stage(conversation_id, "request", "started", %{
+      request_id: request_id,
+      tool: tool,
+      # The agent's own list, verbatim. A client must never offer an option
+      # that is not on it.
+      options: options,
+      timeout_ms: Lifecycle.ask_timeout_ms()
+    })
+
+    timer =
+      Process.send_after(
+        self(),
+        {:permission_timeout, request_id},
+        Lifecycle.ask_timeout_ms()
+      )
+
+    {turn, %{pending | permission_timer: timer}}
+  end
+
+  @doc """
+  A human answered. First answer wins: the web apps and an editor (#708) are
+  peer clients of this door, not fallbacks for one another, so a second
+  answer to the same request is "too late" rather than an error in the
+  caller. The peer takes the option; the request is then resolved as
+  `answered`.
+  """
+  @spec answer_permission(
+          t(),
+          String.t(),
+          Conversations.Turn.t() | nil,
+          pid() | nil,
+          term(),
+          String.t()
+        ) ::
+          {:ok | {:error, term()}, Conversations.Turn.t() | nil, t()}
+  def answer_permission(
+        %__MODULE__{} = pending,
+        conversation_id,
+        turn,
+        peer,
+        request_id,
+        option_id
+      ) do
+    case peer do
+      nil ->
+        {{:error, :no_pending_permission}, turn, pending}
+
+      peer ->
+        case Managoat.ACP.Peer.answer_permission(peer, request_id, option_id) do
+          :ok ->
+            {turn, pending} =
+              resolve_permission(
+                pending,
+                conversation_id,
+                turn,
+                peer,
+                request_id,
+                "answered",
+                option_id
+              )
+
+            {:ok, turn, pending}
+
+          {:error, reason} ->
+            {{:error, reason}, turn, pending}
+        end
+    end
+  end
+
+  # `state: "done"` for every outcome, including a deny and a timeout. The stage
+  # and its status are the Prometheus counter's only tags and there is an alert
+  # on them — a timeout emitting `failed` would page someone for a policy doing
+  # exactly what it was told.
+  @spec resolve_permission(
+          t(),
+          String.t(),
+          Conversations.Turn.t() | nil,
+          pid() | nil,
+          term(),
+          String.t(),
+          String.t() | nil
+        ) :: {Conversations.Turn.t() | nil, t()}
+  def resolve_permission(
+        %__MODULE__{} = pending,
+        conversation_id,
+        turn,
+        peer,
+        request_id,
+        outcome,
+        option_id
+      ) do
+    if pending.permission_timer, do: Process.cancel_timer(pending.permission_timer)
+
+    # Read before the clear below wipes it.
+    tool = pending_tool(turn)
+
+    if outcome != "answered" and peer do
+      Managoat.ACP.Peer.deny_permission(peer, request_id)
+    end
+
+    turn =
+      case turn do
+        nil ->
+          nil
+
+        turn ->
+          {:ok, turn} = Conversations._unsafe_update_turn(turn, %{pending_permission: nil})
+          turn
+      end
+
+    publish_stage(conversation_id, "request", "done", %{
+      request_id: request_id,
+      outcome: outcome,
+      option_id: option_id
+    })
+
+    if outcome != "answered" do
+      Conversations.record_permission_denied(conversation_id, tool, outcome)
+    end
+
+    {turn, %{pending | permission_timer: nil}}
+  end
+
+  @doc "The tool the turn is blocked on, or nil."
+  @spec pending_tool(Conversations.Turn.t() | nil) :: String.t() | nil
+  def pending_tool(%{pending_permission: %{"tool" => tool}}), do: tool
+  def pending_tool(_turn), do: nil
+
+  # Resolve whatever is held, if anything. The turn row is the source of truth
+  # rather than the timer, so this is also correct for a request raised by a
+  # previous BEAM lifetime and reattached to.
+  @spec resolve_pending_permission(
+          t(),
+          String.t(),
+          Conversations.Turn.t() | nil,
+          pid() | nil,
+          String.t()
+        ) ::
+          {Conversations.Turn.t() | nil, t()}
+  def resolve_pending_permission(%__MODULE__{} = pending, conversation_id, turn, peer, outcome) do
+    case turn do
+      %{pending_permission: %{"request_id" => request_id}} ->
+        resolve_permission(pending, conversation_id, turn, peer, request_id, outcome, nil)
+
+      _ ->
+        {turn, pending}
+    end
+  end
+
+  # ── parked caller-tool calls (#1202) ──────────────────────────────────────
+
+  @doc """
+  Park a caller-tool call the agent just made. The call gets an id, a
+  `caller_tool`/`started` stage event goes out (which is what closes the
+  client's completion with `tool_calls`), and a deadline is armed. `waiter`
+  receives `{:caller_tool_result, id, result}` when the call resolves.
+  """
+  @spec park(t(), String.t(), Conversations.Turn.t(), String.t(), map(), pid()) ::
+          {String.t(), t()}
+  def park(%__MODULE__{} = pending, conversation_id, turn, name, arguments, waiter) do
+    call_id = "call_" <> (Ecto.UUID.generate() |> String.replace("-", ""))
+
+    publish_stage(conversation_id, "caller_tool", "started", %{
+      call_id: call_id,
+      turn_id: turn.id,
+      name: name,
+      arguments: arguments,
+      timeout_ms: Lifecycle.ask_timeout_ms()
+    })
+
+    timer =
+      Process.send_after(
+        self(),
+        {:caller_tool_timeout, call_id},
+        Lifecycle.ask_timeout_ms()
+      )
+
+    entry = %{
+      id: call_id,
+      name: name,
+      arguments: arguments,
+      turn_id: turn.id,
+      waiter: waiter,
+      timer: timer,
+      result: nil,
+      parked_at: System.monotonic_time(:millisecond)
+    }
+
+    {call_id, put_in(pending.calls[call_id], entry)}
+  end
+
+  @doc """
+  Re-attach `waiter` to a parked call (the MCP handler's in-request wait ran
+  out and the agent is asking again). `{:ok, result}` at once if it resolved
+  meanwhile — a result is kept until the turn ends, so an answer that landed
+  between two waits is not lost.
+  """
+  @spec await(t(), String.t(), pid()) ::
+          {:pending | {:ok, term()} | {:error, :unknown_call}, t()}
+  def await(%__MODULE__{} = pending, call_id, waiter) do
+    case pending.calls[call_id] do
+      nil -> {{:error, :unknown_call}, pending}
+      %{result: nil} -> {:pending, put_in(pending.calls[call_id].waiter, waiter)}
+      %{result: result} -> {{:ok, result}, pending}
+    end
+  end
+
+  @doc "The calls parked and unanswered, oldest first: `%{id, name, arguments, turn_id}`."
+  @spec calls(t()) :: [map()]
+  def calls(%__MODULE__{} = pending) do
+    pending.calls
+    |> Map.values()
+    |> Enum.filter(&is_nil(&1.result))
+    |> Enum.sort_by(& &1.parked_at)
+    |> Enum.map(&Map.take(&1, [:id, :name, :arguments, :turn_id]))
+  end
+
+  @doc """
+  Resolve parked calls with the client's answers, `%{call_id => content}`.
+  Ids that match nothing are ignored; if none match, `{:error, :no_pending_calls}`
+  and nothing changes. Returns the turn the calls belong to and whatever is
+  still parked, so the controller can emit the remainder at once instead of
+  waiting for a stage event that is already behind its cursor.
+  """
+  @spec answer_calls(t(), String.t(), %{String.t() => String.t()}) ::
+          {{:ok, %{turn_id: String.t(), remaining: [map()]}} | {:error, :no_pending_calls}, t()}
+  def answer_calls(%__MODULE__{} = pending, conversation_id, answers) do
+    matched =
+      pending.calls
+      |> Map.values()
+      |> Enum.filter(&(is_nil(&1.result) and Map.has_key?(answers, &1.id)))
+
+    if matched == [] do
+      {{:error, :no_pending_calls}, pending}
+    else
+      pending =
+        Enum.reduce(matched, pending, fn call, pending ->
+          resolve_call(
+            pending,
+            conversation_id,
+            call.id,
+            "answered",
+            {:ok, Map.fetch!(answers, call.id)}
+          )
+        end)
+
+      turn_id = matched |> List.first() |> Map.fetch!(:turn_id)
+      {{:ok, %{turn_id: turn_id, remaining: calls(pending)}}, pending}
+    end
+  end
+
+  # The one place a parked caller-tool call stops being parked (#1202): an
+  # answer, the deadline, or the turn ending. Cancels the timer, hands the
+  # result to whoever is waiting, keeps it for a waiter that asks later, and
+  # says so on the stream. `done` for every outcome, as `request` does.
+  @spec resolve_call(t(), String.t(), String.t(), String.t(), {:ok, term()} | {:error, term()}) ::
+          t()
+  def resolve_call(%__MODULE__{} = pending, conversation_id, call_id, outcome, result) do
+    case pending.calls[call_id] do
+      %{result: nil} = call ->
+        if call.timer, do: Process.cancel_timer(call.timer)
+        if is_pid(call.waiter), do: send(call.waiter, {:caller_tool_result, call_id, result})
+
+        publish_stage(conversation_id, "caller_tool", "done", %{
+          call_id: call_id,
+          turn_id: call.turn_id,
+          name: call.name,
+          outcome: outcome
+        })
+
+        put_in(pending.calls[call_id], %{call | result: result, timer: nil, waiter: nil})
+
+      _ ->
+        pending
+    end
+  end
+
+  # Everything still parked when the turn ends: the agent gave up waiting, or
+  # the turn was cut. Resolved as errors, then the whole registry is dropped —
+  # a kept result belongs to a turn that is over.
+  @spec drop_calls(t(), String.t(), String.t()) :: t()
+  def drop_calls(%__MODULE__{} = pending, conversation_id, outcome) do
+    pending =
+      Enum.reduce(calls(pending), pending, fn call, pending ->
+        resolve_call(
+          pending,
+          conversation_id,
+          call.id,
+          outcome,
+          {:error, "the turn ended before the caller answered"}
+        )
+      end)
+
+    %{pending | calls: %{}}
+  end
+
+  defp publish_stage(conv_id, stage, status, meta) do
+    Conversations.publish_stage(conv_id, stage, status, meta)
+  end
+end

--- a/apps/fountain/test/fountain/conversations/conversation_server_size_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_size_test.exs
@@ -15,7 +15,7 @@ defmodule Fountain.Conversations.ConversationServerSizeTest do
   accepts is downward. Lower it when you move something out; never raise it.
   """
 
-  @pin 3322
+  @pin 3192
 
   @server "apps/fountain/lib/fountain/conversations/conversation_server.ex"
 

--- a/apps/fountain/test/fountain/conversations/pending_test.exs
+++ b/apps/fountain/test/fountain/conversations/pending_test.exs
@@ -1,0 +1,311 @@
+defmodule Fountain.Conversations.PendingTest do
+  @moduledoc """
+  What a turn waits on (#1375), driven without a server: a permission request
+  answered, denied by timeout and drained at the turn's end; a parked
+  caller-tool call answered, expired and dropped. The peer is this process,
+  so what would reach it is asserted as messages; the timers land here too.
+  """
+  use Fountain.DataCase, async: true
+
+  alias Fountain.Conversations
+  alias Fountain.Conversations.Pending
+
+  setup do
+    user = insert_verified_user()
+    conv = insert_conversation(user_id: user.id)
+    turn = insert_turn(conv, status: "running", started_at: DateTime.utc_now())
+    {:ok, conv: conv, turn: turn, pending: %Pending{}}
+  end
+
+  defp stages(conv_id, stage) do
+    Fountain.Repo.all(
+      from(e in Conversations.LogEvent,
+        where: e.conversation_id == ^conv_id and e.kind == "stage" and e.stage == ^stage,
+        order_by: e.id
+      )
+    )
+    |> Enum.map(&{&1.state, Jason.decode!(&1.data)})
+  end
+
+  defp denials(conv_id) do
+    Fountain.Repo.all(
+      from(a in Fountain.Audit.Event,
+        where: a.resource_id == ^conv_id and a.action == "conversation.permission_denied"
+      )
+    )
+    |> Enum.map(& &1.metadata)
+  end
+
+  # A stand-in peer: a process that records the deny cast it receives.
+  defp fake_peer do
+    test = self()
+
+    spawn_link(fn ->
+      receive do
+        {:"$gen_cast", {:deny_permission, id}} -> send(test, {:denied, id})
+      end
+    end)
+  end
+
+  describe "from_state/1 and into_state/2" do
+    test "round-trip the two server fields" do
+      state = %{caller_calls: %{"c" => %{}}, permission_timer: :t, other: 1}
+      assert %Pending{calls: %{"c" => %{}}, permission_timer: :t} = p = Pending.from_state(state)
+
+      assert Pending.into_state(state, %{p | permission_timer: nil}) == %{
+               state
+               | permission_timer: nil
+             }
+    end
+  end
+
+  describe "a permission request" do
+    test "ask/6 puts it on the row, announces it and arms the timeout", %{
+      conv: conv,
+      turn: turn,
+      pending: pending
+    } do
+      {turn, pending} = Pending.ask(pending, conv.id, turn, 7, "bash", ["yes", "no"])
+
+      assert %{"request_id" => 7, "tool" => "bash", "options" => ["yes", "no"], "asked_at" => _} =
+               turn.pending_permission
+
+      assert Fountain.Repo.get!(Conversations.Turn, turn.id).pending_permission["tool"] == "bash"
+
+      assert [{"started", %{"request_id" => 7, "tool" => "bash", "timeout_ms" => ms}}] =
+               stages(conv.id, "request")
+
+      assert is_integer(ms) and ms > 0
+      assert is_reference(pending.permission_timer)
+      assert Process.read_timer(pending.permission_timer) > 0
+      Process.cancel_timer(pending.permission_timer)
+    end
+
+    test "ask/6 with no turn announces and arms, with nothing to persist on", %{
+      conv: conv,
+      pending: pending
+    } do
+      {nil, pending} = Pending.ask(pending, conv.id, nil, 7, "bash", [])
+      assert [{"started", _}] = stages(conv.id, "request")
+      Process.cancel_timer(pending.permission_timer)
+    end
+
+    test "pending_tool/1 reads the row" do
+      assert Pending.pending_tool(%{pending_permission: %{"tool" => "bash"}}) == "bash"
+      assert Pending.pending_tool(%{pending_permission: nil}) == nil
+      assert Pending.pending_tool(nil) == nil
+    end
+
+    test "an answer clears the row, cancels the timer, says done and audits nothing", %{
+      conv: conv,
+      turn: turn,
+      pending: pending
+    } do
+      {turn, pending} = Pending.ask(pending, conv.id, turn, 7, "bash", ["yes"])
+      timer = pending.permission_timer
+      peer = fake_peer()
+
+      {turn, pending} =
+        Pending.resolve_permission(pending, conv.id, turn, peer, 7, "answered", "yes")
+
+      assert turn.pending_permission == nil
+      assert pending.permission_timer == nil
+      assert Process.read_timer(timer) == false
+
+      assert [{"started", _}, {"done", %{"outcome" => "answered", "option_id" => "yes"}}] =
+               stages(conv.id, "request")
+
+      assert denials(conv.id) == []
+      refute_receive {:denied, _}, 50
+    end
+
+    test "a timeout denies at the peer, says done (never failed) and audits the tool", %{
+      conv: conv,
+      turn: turn,
+      pending: pending
+    } do
+      {turn, pending} = Pending.ask(pending, conv.id, turn, 7, "bash", ["yes"])
+      peer = fake_peer()
+
+      {turn, _pending} =
+        Pending.resolve_permission(pending, conv.id, turn, peer, 7, "timeout", nil)
+
+      assert turn.pending_permission == nil
+      assert_receive {:denied, 7}
+
+      assert [{"started", _}, {"done", %{"outcome" => "timeout", "option_id" => nil}}] =
+               stages(conv.id, "request")
+
+      assert [%{"tool" => "bash", "verdict" => "timeout"}] = denials(conv.id)
+    end
+
+    test "resolve_pending_permission/5 drains whatever the row holds, and nothing otherwise", %{
+      conv: conv,
+      turn: turn,
+      pending: pending
+    } do
+      assert {^turn, ^pending} =
+               Pending.resolve_pending_permission(pending, conv.id, turn, nil, "turn_ended")
+
+      assert {nil, ^pending} =
+               Pending.resolve_pending_permission(pending, conv.id, nil, nil, "turn_ended")
+
+      {turn, pending} = Pending.ask(pending, conv.id, turn, 9, "rm", [])
+
+      {turn, pending} =
+        Pending.resolve_pending_permission(pending, conv.id, turn, nil, "turn_ended")
+
+      assert turn.pending_permission == nil
+      assert pending.permission_timer == nil
+      assert [%{"tool" => "rm", "verdict" => "turn_ended"}] = denials(conv.id)
+    end
+
+    test "answer_permission/6 hands the option to the peer first, and is an error with no peer",
+         %{
+           conv: conv,
+           turn: turn,
+           pending: pending
+         } do
+      assert {{:error, :no_pending_permission}, ^turn, ^pending} =
+               Pending.answer_permission(pending, conv.id, turn, nil, 7, "yes")
+
+      test = self()
+
+      peer =
+        spawn_link(fn ->
+          receive do
+            {:"$gen_call", from, {:answer_permission, 7, "yes"}} ->
+              send(test, :peer_took_it)
+              GenServer.reply(from, :ok)
+          end
+        end)
+
+      {turn, pending} = Pending.ask(pending, conv.id, turn, 7, "bash", ["yes"])
+
+      assert {:ok, turn, pending} =
+               Pending.answer_permission(pending, conv.id, turn, peer, 7, "yes")
+
+      assert_receive :peer_took_it
+      assert turn.pending_permission == nil
+      assert pending.permission_timer == nil
+
+      refusing =
+        spawn_link(fn ->
+          receive do
+            {:"$gen_call", from, _} -> GenServer.reply(from, {:error, :unknown_option})
+          end
+        end)
+
+      assert {{:error, :unknown_option}, ^turn, ^pending} =
+               Pending.answer_permission(pending, conv.id, turn, refusing, 7, "made-up")
+    end
+  end
+
+  describe "a parked caller-tool call" do
+    test "park/6 announces it, arms a deadline and lists it oldest first", %{
+      conv: conv,
+      turn: turn,
+      pending: pending
+    } do
+      {id1, pending} = Pending.park(pending, conv.id, turn, "lookup", %{"a" => 1}, self())
+      # Oldest first is by the monotonic millisecond a call was parked at, so
+      # two parks in the same millisecond have no order to assert.
+      Process.sleep(2)
+      {id2, pending} = Pending.park(pending, conv.id, turn, "other", %{}, nil)
+
+      assert String.starts_with?(id1, "call_")
+
+      assert [%{id: ^id1, name: "lookup", arguments: %{"a" => 1}}, %{id: ^id2, name: "other"}] =
+               Pending.calls(pending)
+
+      assert [
+               {"started", %{"call_id" => ^id1, "name" => "lookup", "arguments" => %{"a" => 1}}},
+               {"started", _}
+             ] =
+               stages(conv.id, "caller_tool")
+
+      for call <- Map.values(pending.calls), do: Process.cancel_timer(call.timer)
+    end
+
+    test "await/3 is pending until resolved, then the kept result; unknown ids are refused", %{
+      conv: conv,
+      turn: turn,
+      pending: pending
+    } do
+      {id, pending} = Pending.park(pending, conv.id, turn, "lookup", %{}, nil)
+
+      assert {:pending, pending} = Pending.await(pending, id, self())
+      assert pending.calls[id].waiter == self()
+      assert {{:error, :unknown_call}, ^pending} = Pending.await(pending, "call_nope", self())
+
+      pending = Pending.resolve_call(pending, conv.id, id, "answered", {:ok, "shipped"})
+      assert_receive {:caller_tool_result, ^id, {:ok, "shipped"}}
+      assert {{:ok, {:ok, "shipped"}}, ^pending} = Pending.await(pending, id, self())
+    end
+
+    test "answer_calls/3 resolves the matched ids, ignores strays and reports the rest", %{
+      conv: conv,
+      turn: turn,
+      pending: pending
+    } do
+      {a, pending} = Pending.park(pending, conv.id, turn, "a", %{}, self())
+      {b, pending} = Pending.park(pending, conv.id, turn, "b", %{}, nil)
+
+      assert {{:ok, %{turn_id: turn_id, remaining: [%{id: ^b}]}}, pending} =
+               Pending.answer_calls(pending, conv.id, %{a => "one", "stray" => "x"})
+
+      assert turn_id == turn.id
+      assert_receive {:caller_tool_result, ^a, {:ok, "one"}}
+      assert Pending.calls(pending) |> Enum.map(& &1.id) == [b]
+
+      assert [_, _, {"done", %{"call_id" => ^a, "outcome" => "answered"}}] =
+               stages(conv.id, "caller_tool")
+
+      assert {{:error, :no_pending_calls}, ^pending} =
+               Pending.answer_calls(pending, conv.id, %{a => "again"})
+
+      Process.cancel_timer(pending.calls[b].timer)
+    end
+
+    test "resolve_call/5 cancels the deadline and resolves once", %{
+      conv: conv,
+      turn: turn,
+      pending: pending
+    } do
+      {id, pending} = Pending.park(pending, conv.id, turn, "a", %{}, nil)
+      timer = pending.calls[id].timer
+
+      pending = Pending.resolve_call(pending, conv.id, id, "timeout", {:error, "late"})
+      assert Process.read_timer(timer) == false
+      assert %{result: {:error, "late"}, timer: nil, waiter: nil} = pending.calls[id]
+
+      assert ^pending = Pending.resolve_call(pending, conv.id, id, "answered", {:ok, "x"})
+      assert [_, {"done", %{"outcome" => "timeout"}}] = stages(conv.id, "caller_tool")
+    end
+
+    test "drop_calls/3 errors what is still parked and empties the registry", %{
+      conv: conv,
+      turn: turn,
+      pending: pending
+    } do
+      {a, pending} = Pending.park(pending, conv.id, turn, "a", %{}, self())
+      {b, pending} = Pending.park(pending, conv.id, turn, "b", %{}, self())
+      pending = Pending.resolve_call(pending, conv.id, a, "answered", {:ok, "done"})
+
+      pending = Pending.drop_calls(pending, conv.id, "turn_ended")
+
+      assert pending.calls == %{}
+
+      assert_receive {:caller_tool_result, ^b,
+                      {:error, "the turn ended before the caller answered"}}
+
+      assert [
+               _,
+               _,
+               {"done", %{"call_id" => ^a}},
+               {"done", %{"call_id" => ^b, "outcome" => "turn_ended"}}
+             ] =
+               stages(conv.id, "caller_tool")
+    end
+  end
+end

--- a/apps/fountain/test/fountain/webhooks/events_test.exs
+++ b/apps/fountain/test/fountain/webhooks/events_test.exs
@@ -23,7 +23,8 @@ defmodule Fountain.Webhooks.EventsTest do
     "lib/fountain/conversations/conversation_server.ex",
     "lib/fountain/conversations/provisioning.ex",
     "lib/fountain/conversations/egress.ex",
-    "lib/fountain/conversations/turn_machine.ex"
+    "lib/fountain/conversations/turn_machine.ex",
+    "lib/fountain/conversations/pending.ex"
   ]
 
   # publish_stage(<anything>, "<stage>", "<status>"


### PR DESCRIPTION
Part of #1369, sixth of eight. What waits on a human or a client leaves the server for `Fountain.Conversations.Pending`: a value (the parked caller-tool calls with their deadlines, and the permission request's timeout) and the functions that add, answer, deny, expire and drain it, each returning the reply, the turn row and the next value.

## Functions moved

All eleven named functions and the five `handle_call` clauses are accounted for; two corrections to the issue:

- `park_caller_tool/4`, `await_caller_tool/3`, `pending_caller_calls/1`, `answer_caller_tools/2` and `answer_permission/3` are the tool bridge's and the permission door's **client** API (`whereis` plus `call_server`). `Fountain.CallerTools`, the OpenAI and AG-UI controllers and `Conversations.answer_permission_request/5` call them on the server, and the server tests drive the same doors as `GenServer.call` messages, so the message shapes and replies are pinned. The client functions stay on the server as they are; what moved is what the clauses did.
- The issue's "deny-on-terminate rule (`conversation_server_shutdown_revoke_test.exs`)" is not in the code: `terminate/2` revokes the callback key and denies nothing, and that test has no permission case. A held request is denied when the turn ends (`finish_acp_turn/4` resolves it as `turn_ended`), which is what `resolve_pending_permission` pins in `conversation_server_acp_test.exs`. Nothing was invented to match.

| was (`ConversationServer`) | now (`Pending`) |
|---|---|
| `handle_call({:answer_permission, …})` body | `answer_permission/6` (the peer call, then the resolve) |
| `handle_call({:park_caller_tool, …})` body | `park/6` (the `no_turn` refusal stays in the clause) |
| `handle_call({:await_caller_tool, …})` body | `await/3` |
| `handle_call(:pending_caller_calls, …)` body, `pending_caller_calls_of/1` | `calls/1` |
| `handle_call({:answer_caller_tools, …})` body | `answer_calls/3` |
| `ask_permission/4` body (the apply of #1374's `ask_permission` effect) | `ask/6` |
| `resolve_permission/4` | `resolve_permission/7` |
| `pending_tool/1` (over state) | `pending_tool/1` (over the turn row) |
| `resolve_pending_permission/2` | `resolve_pending_permission/5` |
| `resolve_caller_tool/4` | `resolve_call/5` |
| `drop_caller_tools/2` | `drop_calls/3` |

Every function takes what it reads (the conversation id, the turn row, the peer) and returns `{reply, turn, pending}` or `{turn, pending}` or `pending`. Timers are armed with `Process.send_after(self(), …)` as before, in the calling process, which is the server; the peer gets `Managoat.ACP.Peer.answer_permission/3` and `deny_permission/2` from here, the parked caller its `{:caller_tool_result, id, result}`; the `request` and `caller_tool` stage events and the `conversation.permission_denied` audit are the same calls in the same order.

## What the server keeps

`from_state/1` and `into_state/2` convert the two fields (`caller_calls`, `permission_timer`); the state does not change shape. The five clauses, the two timeout handlers and `ask_permission/4` are each one call into `Pending` and one write-back. `resolve_permission/4`, `resolve_pending_permission/2` and `drop_caller_tools/2` remain as three-line wrappers for the call sites in `finish_acp_turn/4` and the timeout handler.

`pending.ex` joined `turn_machine.ex` in the ownership check's exemptions (`.credo.exs`) for the same reason, with its own line: it writes the turn row the server already owns, and is called only from the server's callbacks. `webhooks/events_test.exs` lists it as a `publish_stage` source.

## Unit tests, no process

`pending_test.exs` (13 tests, `async: true`): the round trip; `ask/6` on a turn (row, `request/started` with the timeout, the armed timer) and without one; `pending_tool/1`; an answer (row cleared, timer cancelled, `request/done`, no audit, no deny); a timeout (the deny cast reaches the peer, `done` not `failed`, the audit carries the tool and verdict); draining at turn end with and without a held request; `answer_permission/6` with no peer, with a peer that takes the option, and with one that refuses it; `park/6` (stage, deadline, oldest first); `await/3` before and after a result and for an unknown id; `answer_calls/3` with strays and the remainder; `resolve_call/5` once only; `drop_calls/3`. The peer is a plain process that records what it is sent; no server, no sandbox, no `Peer`.

One test sleeps 2ms between two parks: oldest-first sorts on `System.monotonic_time(:millisecond)`, so two parks inside one millisecond have no defined order. That is the behaviour as it was, not a bug fixed here.

## Pin

| | lines |
|---|---|
| before | 3322 |
| after | 3192 |

## Gates

| gate | result |
|---|---|
| `MIX_ENV=test mix compile --warnings-as-errors` | clean |
| `mix format --check-formatted` (mise Elixir 1.19.2, from `apps/fountain`) | exit 0 |
| `mix credo --strict` | 5790 mods/funs, no issues |
| `MIX_ENV=dev mix dialyzer` | passed, `Total errors: 0` |
| the fourteen `conversation_server*_test.exs` + `pending_test` + `turn_machine_test` + `audit_guardrail`, `caller_tools`, `provisioning`, `provisioning_steps`, `docs`, `webhooks/events`, `metrics` | 379 tests, 0 failures |
| `gitleaks git --log-opts="origin/main..HEAD"` | no leaks found |
| full root suite | posted as a comment when it finishes |

`git diff --stat origin/main` over the thirteen server test files is empty; the only test file this PR edits under that glob is the ratchet.

**Proof:** with `origin/main`'s server file put back beside the new module, the size test fails — `apps/fountain/lib/fountain/conversations/conversation_server.ex is 3322 lines, over the pin of 3192`. Restored; the committed file is 3,192.

## CHANGELOG

One entry under `[Unreleased] → ### Changed`.

Closes #1375. Part of #1369.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mx2sij38JHM6gQu6PxiGG
