### PR TITLE
refactor(conversations): sandbox reclaim actions into Lifecycle

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -89,6 +89,9 @@
                # what a turn waits on (#1375): the same, writing the same turn
                # row the server owns, called only from its callbacks
                "lib/fountain/conversations/pending.ex",
+               # the reclaim actions (#1376): the sandbox and rows of the
+               # conversation whose server called them, ownership as above
+               "lib/fountain/conversations/lifecycle.ex",
                # system-level sweeps, run with no user in scope
                "lib/fountain/conversations/rehydrator.ex",
                "lib/fountain/workers/",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -269,6 +269,16 @@ upgrade, is in
   call into it; the GenServer messages, the stage events and the audit of a
   denial are unchanged, and `Fountain.CallerTools` still owns the wire
   shapes. The pin drops from 3,322 to 3,192.
+- **The sandbox reclaim actions have joined the policy that decides them**
+  (#1376, tracker #1369). `Fountain.Conversations.Lifecycle` already held
+  the bounds (`check/4`, `idle_action/1`, `explain/1,2`); it now also holds
+  the consequence — the sandbox clock, the lifecycle tick, the two verdicts
+  with their suspend call, the park, the destroy and the cast that tells the
+  co-tenants on the machine. A reader of `idle_action/1` can see what
+  `:destroy` costs without opening another file. The server keeps the log
+  line, the connection drop and the `{:stop, :normal, …}` around each. No
+  stage, log line, telemetry event, timer or audit event changed. The pin
+  drops from 3,192 to 3,049.
 
 ### Added
 

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -25,7 +25,6 @@ defmodule Fountain.Conversations.ConversationServer do
     CallbackKey,
     Conversation,
     Egress,
-    HomeCheckpoint,
     Lifecycle,
     McpServers,
     Pending,
@@ -33,11 +32,6 @@ defmodule Fountain.Conversations.ConversationServer do
     SpriteEnv,
     TurnMachine
   }
-
-  # How often the sandbox lifetime bounds are evaluated. A minute is far finer
-  # than the bounds themselves (an hour, a day), so the cost of the tick is
-  # irrelevant and the overshoot is bounded by it.
-  @lifecycle_check_ms :timer.minutes(1)
 
   # Absolute ceiling on provisioning (#329). Generous against the summed
   # per-step timeouts (packages 300s + clone 600s + setup 120s + slack), so
@@ -555,7 +549,7 @@ defmodule Fountain.Conversations.ConversationServer do
       output_capped: false
     }
 
-    schedule_lifecycle_check()
+    Lifecycle.schedule_check()
     start_provision_watchdog(state.conversation_id, state.sandbox_id)
     {:ok, state, {:continue, :provision}}
   end
@@ -924,7 +918,7 @@ defmodule Fountain.Conversations.ConversationServer do
             state
             | handle: handle,
               sprite_env: sprite_env,
-              sandbox_started_at: sandbox_clock_start(sandbox)
+              sandbox_started_at: Lifecycle.clock_start(sandbox)
           }
 
           # Any prompt this conversation was started for arrives as a cast,
@@ -1187,7 +1181,7 @@ defmodule Fountain.Conversations.ConversationServer do
         state
         | handle: handle,
           sprite_env: sprite_env,
-          sandbox_started_at: sandbox_clock_start(sandbox)
+          sandbox_started_at: Lifecycle.clock_start(sandbox)
       }
 
       new_state = reattach_running_turn(new_state)
@@ -1689,7 +1683,11 @@ defmodule Fountain.Conversations.ConversationServer do
 
       publish_stage(state.conversation_id, "terminate", "done", %{
         sandbox: "kept",
-        reason: if(home?(state), do: "persistent_home", else: "held_by_another_conversation")
+        reason:
+          if(Lifecycle.home?(state.sandbox_id),
+            do: "persistent_home",
+            else: "held_by_another_conversation"
+          )
       })
 
       {:stop, :normal, :ok, %{state | handle: nil}}
@@ -2074,7 +2072,7 @@ defmodule Fountain.Conversations.ConversationServer do
   # ── permissions, reclaim and redaction ────────────────────────────────────
 
   def handle_info(:lifecycle_check, state) do
-    schedule_lifecycle_check()
+    Lifecycle.schedule_check()
 
     started_at = state.sandbox_started_at
 
@@ -2142,104 +2140,37 @@ defmodule Fountain.Conversations.ConversationServer do
     Pending.into_state(state, pending)
   end
 
-  # The absolute lifetime ceiling measures a continuous run, not calendar age:
-  # a wake from `suspended` stamps `last_resumed_at` and restarts the clock,
-  # while a deploy reattach of a `ready` row stamps nothing and keeps it.
-  # SandboxReaper.expired?/2 must agree with this — change both together.
-  # The provider tag for telemetry: read off the live handle, which was
-  # built from the sandbox row's provider column.
-  defp provider(%{handle: %Managoat.Sandbox.Handle{provider: provider}}), do: provider
-  defp provider(_state), do: :sprites
-
-  defp sandbox_clock_start(sandbox), do: sandbox.last_resumed_at || sandbox.inserted_at
-
-  defp schedule_lifecycle_check do
-    # Interval overridable in tests so the timer wiring itself is testable —
-    # dropping schedule_lifecycle_check() from init/1 used to pass the whole
-    # suite (#337) while silently disabling idle/max-lifetime reclamation.
-    interval = Application.get_env(:fountain, :lifecycle_check_ms, @lifecycle_check_ms)
-    Process.send_after(self(), :lifecycle_check, interval)
-  end
-
+  # The server's own clock stamp: the input `Lifecycle.check/4` reads. Nothing
+  # but this process writes it.
   defp touch_activity(state), do: %{state | last_activity_at: DateTime.utc_now()}
 
-  # Idle: park where the provider can preserve the disk (the :suspend
-  # capability — implicit scale-to-zero for Sprites, an explicit pause/stop
-  # for providers that need one), destroy where it cannot. The disk holds the
-  # runtime session — the agent's memory, which #649 proved cannot be rebuilt
-  # on a fresh sandbox — so parking is always preferred; but an idle sandbox
-  # that cannot park keeps billing, and a park *call* that fails leaves it
-  # billing too, so both of those degrade to the destroy arm. The decision
-  # lives in Lifecycle.idle_action/1.
+  # Idle: the machine's verdict, not this conversation's (ADR 0023 step 5).
   defp reclaim_sandbox(state, :idle) do
-    if Conversations._unsafe_sandbox_busy_elsewhere?(
-         state.sandbox_id,
-         state.conversation_id,
-         Lifecycle.idle_timeout_seconds()
-       ) do
+    if Lifecycle.busy_elsewhere?(state.sandbox_id, state.conversation_id) do
       # This conversation is idle; the machine is not. Another conversation
       # on it is mid-turn or was active more recently than the bound, so the
       # verdict is the machine's to reach, over all of them (ADR 0023 step 5).
       # Checked again on the next tick.
       {:noreply, state}
     else
-      reclaim_idle_machine(state)
+      case Lifecycle.idle_machine_action(state.conversation_id, state.handle) do
+        :park -> park_sandbox(state)
+        :destroy -> destroy_sandbox(state, :idle)
+      end
     end
   end
 
-  # Max lifetime: tear down and stop, whatever the provider. This bound exists
-  # for the conversation that never stops being busy; the conversation stays
-  # `idle` and resumable — setting it `terminated` here would make a cost
-  # control into data loss. See Fountain.Conversations.Lifecycle.
-  #
-  # A home is parked instead, where the provider can park: its disk is the
-  # agent's memory across every conversation, and destroying it at a busy
-  # ceiling would defeat the mode (ADR 0023 step 5). The ceiling itself is
-  # slated to go; until then this is the interim it names. A home on a
-  # provider that cannot park, or whose park call fails, is destroyed as an
-  # ephemeral one would be — an unparked machine keeps billing.
+  # Max lifetime: `Lifecycle.max_lifetime_action/2` decides, and has already
+  # made the suspend call by the time it answers `:park`.
   defp reclaim_sandbox(state, :max_lifetime) do
-    with true <- home?(state),
-         :suspend <- Lifecycle.idle_action(provider(state)),
-         :ok <- suspend_sandbox(state) do
-      park_sandbox(state, :max_lifetime)
-    else
-      _ -> destroy_sandbox(state, :max_lifetime)
+    case Lifecycle.max_lifetime_action(state.sandbox_id, state.handle) do
+      :park -> park_sandbox(state, :max_lifetime)
+      :destroy -> destroy_sandbox(state, :max_lifetime)
     end
   end
 
-  # Whether this server's machine is a persistent home (ADR 0023).
-  defp home?(%{sandbox_id: sandbox_id}) when is_binary(sandbox_id) do
-    match?(%{mode: "persistent"}, Conversations._unsafe_get_sandbox(sandbox_id))
-  end
-
-  defp home?(_state), do: false
-
-  defp reclaim_idle_machine(state) do
-    with :suspend <- Lifecycle.idle_action(provider(state)),
-         :ok <- suspend_sandbox(state) do
-      park_sandbox(state)
-    else
-      :destroy ->
-        destroy_sandbox(state, :idle)
-
-      {:error, reason} ->
-        Logger.warning(
-          "suspend call failed for conv #{state.conversation_id} " <>
-            "(#{inspect(reason)}); destroying instead — an unparked sandbox keeps billing"
-        )
-
-        destroy_sandbox(state, :idle)
-    end
-  end
-
-  # Explicitly park the sandbox before the row flips: for Sprites this is a
-  # no-op (scale-to-zero), for pause/stop providers it is the call that stops
-  # the meter. Ordering matters — a row marked suspended with the backend
-  # still running would be invisible to every reclaim pass.
-  defp suspend_sandbox(%{handle: nil}), do: :ok
-  defp suspend_sandbox(state), do: Managoat.Sandbox.suspend(state.handle)
-
+  # The log line and the connection are the process's; the rest of a park is
+  # `Lifecycle.park/4`.
   defp park_sandbox(state, reason \\ :idle) do
     Logger.info(
       "suspending sandbox for conv #{state.conversation_id}: #{reason} " <>
@@ -2248,59 +2179,13 @@ defmodule Fountain.Conversations.ConversationServer do
 
     # A parked sprite never keeps a live adapter (#817).
     state = drop_connection(state, "suspended")
-
-    if state.sandbox_id do
-      sandbox = Conversations._unsafe_get_sandbox!(state.sandbox_id)
-
-      if sandbox.status not in ["terminated", "failed"] do
-        # A home's disk is kept at its quietest moment, where the provider
-        # can (ADR 0023, #1073). Best-effort: the park goes ahead either way.
-        HomeCheckpoint.on_park(sandbox)
-        {:ok, _} = Conversations.update_sandbox(sandbox, %{status: "suspended"})
-      end
-    end
+    Lifecycle.park(state.conversation_id, state.sandbox_id, state.handle, reason)
 
     # The conversation stays idle and resumable; the sprite stays parked.
-    conv = Conversations._unsafe_get_conversation!(state.conversation_id)
-    if conv.status == "running", do: Conversations.update_conversation(conv, %{status: "idle"})
-
-    # Same stage/state as the reclaim below (LogEvent's state set is closed and
-    # clients already key on the "sandbox" stage); `event` is the discriminator.
-    publish_stage(state.conversation_id, "sandbox", "done", %{
-      event: "suspended",
-      reason: to_string(reason),
-      message: Lifecycle.explain(reason, :suspend)
-    })
-
-    :telemetry.execute([:fountain, :sandbox, :suspended], %{count: 1}, %{
-      provider: provider(state)
-    })
-
-    stop_cotenants(state, "suspended", to_string(reason), Lifecycle.explain(reason, :suspend))
-
     {:stop, :normal, %{state | handle: nil}}
   end
 
-  # A park or a destroy is a machine operation: every other conversation on
-  # the sandbox loses its handle with it. Tell their servers, so each records
-  # what happened on its own transcript and stops — the next prompt then takes
-  # the wake path, the only path that brings the machine back. A cast: a
-  # co-tenant whose server is already gone is not an error here.
-  defp stop_cotenants(state, event, reason, message) do
-    state.sandbox_id
-    |> Conversations._unsafe_list_cotenant_ids(state.conversation_id)
-    |> Enum.each(fn conv_id ->
-      case whereis(conv_id) do
-        nil -> :ok
-        pid -> GenServer.cast(pid, {:machine_gone, event, reason, message})
-      end
-    end)
-  end
-
-  # Tear down the sandbox and stop; the conversation stays `idle` and
-  # resumable (setting it `terminated` here would make a cost control into
-  # data loss). Serves both the max-lifetime ceiling and the idle bound on a
-  # provider that cannot park. See Fountain.Conversations.Lifecycle.
+  # The same shape for a destroy (`Lifecycle.destroy/5`).
   defp destroy_sandbox(state, reason) do
     Logger.info(
       "reclaiming sandbox for conv #{state.conversation_id}: #{reason} " <>
@@ -2309,44 +2194,16 @@ defmodule Fountain.Conversations.ConversationServer do
 
     state = drop_connection(state, "reclaimed")
 
-    if state.handle, do: _ = Managoat.Sandbox.destroy(state.handle)
-    Egress.release(state.user_id, state.conversation_id)
-
-    if state.sandbox_id do
-      sandbox = Conversations._unsafe_get_sandbox!(state.sandbox_id)
-
-      if sandbox.status not in ["terminated", "failed"] do
-        {:ok, _} =
-          Conversations.update_sandbox(sandbox, %{status: "terminated", terminated_at: now()})
-      end
-    end
-
-    conv = Conversations._unsafe_get_conversation!(state.conversation_id)
-    if conv.status == "running", do: Conversations.update_conversation(conv, %{status: "idle"})
-
-    # `state` is a stage-lifecycle vocabulary — LogEvent allows only
-    # started/done/failed/interrupted, and both the CLI and the LiveView switch
-    # on it. A reclaimed sandbox is a stage that reached its end, so "done" is
-    # accurate and needs no client to learn a new word; the `reason` and
-    # `message` fields carry what actually happened.
-    publish_stage(state.conversation_id, "sandbox", "done", %{
-      event: "reclaimed",
-      reason: to_string(reason),
-      message: reclaim_message(reason)
-    })
-
-    :telemetry.execute([:fountain, :sandbox, :reclaimed], %{count: 1}, %{
-      reason: reason,
-      provider: provider(state)
-    })
-
-    stop_cotenants(state, "reclaimed", to_string(reason), reclaim_message(reason))
+    Lifecycle.destroy(
+      state.conversation_id,
+      state.sandbox_id,
+      state.user_id,
+      state.handle,
+      reason
+    )
 
     {:stop, :normal, %{state | handle: nil}}
   end
-
-  defp reclaim_message(:max_lifetime), do: Lifecycle.explain(:max_lifetime)
-  defp reclaim_message(:idle), do: Lifecycle.explain(:idle, :destroy)
 
   # Best-effort revoke of the per-conversation API key when this server
   # exits — clean termination (`:terminate_conv`), crash paths that hit

--- a/apps/fountain/lib/fountain/conversations/lifecycle.ex
+++ b/apps/fountain/lib/fountain/conversations/lifecycle.ex
@@ -44,10 +44,36 @@ defmodule Fountain.Conversations.Lifecycle do
   Setting the conversation itself to `terminated` on either bound would *not*
   be safe — it would make the conversation permanently unresumable, turning a
   cost control into data loss.
+
+  ## Policy, then the actions
+
+  The first half of this module is policy: `check/4`, `idle_action/1`,
+  `explain/1,2` and the two bounds they read. Pure, and safe to ask from
+  anywhere — the `ConversationServer` and `Workers.SandboxReaper` both do.
+
+  The second half (#1376) is the consequence: the sandbox clock, the calls
+  that park or destroy the machine, and what the co-tenants on it are told.
+  They talk to the provider, the rows, the stream and the other servers, and
+  they run inside a `ConversationServer` whose ownership of the conversation
+  was established at `init/1`. The decision and its consequence sit in one
+  file so a reader of `idle_action/1` can see what `:destroy` costs.
   """
+
+  require Logger
+
+  alias Fountain.Conversations
+  alias Fountain.Conversations.ConversationServer
+  alias Fountain.Conversations.Egress
+  alias Fountain.Conversations.HomeCheckpoint
+  alias Managoat.Sandbox.Handle
 
   @default_idle_minutes 60
   @default_max_lifetime_hours 0
+
+  # How often the sandbox lifetime bounds are evaluated. A minute is far finer
+  # than the bounds themselves (an hour, a day), so the cost of the tick is
+  # irrelevant and the overshoot is bounded by it.
+  @check_ms :timer.minutes(1)
 
   @doc "Idle timeout in seconds, or `nil` when disabled."
   @spec idle_timeout_seconds() :: pos_integer() | nil
@@ -191,6 +217,262 @@ defmodule Fountain.Conversations.Lifecycle do
       "Send another prompt to continue — the transcript above is kept, but this sandbox " <>
       "provider cannot park an idle sandbox, so the agent starts a fresh session and " <>
       "will not remember the earlier turns."
+  end
+
+  @doc """
+  The copy for a destroy, by the bound that reached it. `explain/2`'s
+  destroy arms, named once so the two `publish_stage` fields agree.
+  """
+  @spec reclaim_message(:idle | :max_lifetime) :: String.t()
+  def reclaim_message(:max_lifetime), do: explain(:max_lifetime)
+  def reclaim_message(:idle), do: explain(:idle, :destroy)
+
+  # ── the actions ───────────────────────────────────────────────────────────
+
+  @doc """
+  The provider tag for telemetry: read off the live handle, which was built
+  from the sandbox row's provider column.
+  """
+  @spec provider(Handle.t() | nil) :: atom()
+  def provider(%Handle{provider: provider}), do: provider
+  def provider(_handle), do: :sprites
+
+  @doc """
+  When the sandbox's continuous run started.
+
+  The absolute lifetime ceiling measures a continuous run, not calendar age:
+  a wake from `suspended` stamps `last_resumed_at` and restarts the clock,
+  while a deploy reattach of a `ready` row stamps nothing and keeps it.
+  `SandboxReaper.expired?/2` must agree with this — change both together.
+  """
+  @spec clock_start(map()) :: DateTime.t() | NaiveDateTime.t()
+  def clock_start(sandbox), do: sandbox.last_resumed_at || sandbox.inserted_at
+
+  @doc """
+  Arm the next lifecycle tick, in the calling process — the server.
+
+  Interval overridable in tests so the timer wiring itself is testable —
+  dropping this call from `ConversationServer.init/1` used to pass the whole
+  suite (#337) while silently disabling idle/max-lifetime reclamation.
+  """
+  @spec schedule_check() :: reference()
+  def schedule_check do
+    interval = Application.get_env(:fountain, :lifecycle_check_ms, @check_ms)
+    Process.send_after(self(), :lifecycle_check, interval)
+  end
+
+  @doc "Whether this machine is a persistent home (ADR 0023)."
+  @spec home?(String.t() | nil) :: boolean()
+  def home?(sandbox_id) when is_binary(sandbox_id) do
+    # Ownership: the caller is the server for a conversation on this sandbox,
+    # established at its init/1.
+    match?(%{mode: "persistent"}, Conversations._unsafe_get_sandbox(sandbox_id))
+  end
+
+  def home?(_sandbox_id), do: false
+
+  @doc """
+  Whether a conversation other than this one holds the machine busy: mid-turn,
+  or active more recently than the idle bound. One conversation going quiet is
+  not the machine's verdict; that is reached over all of them (ADR 0023 step
+  5).
+  """
+  @spec busy_elsewhere?(String.t() | nil, String.t()) :: boolean()
+  def busy_elsewhere?(sandbox_id, conversation_id) do
+    # Ownership: as home?/1 above.
+    Conversations._unsafe_sandbox_busy_elsewhere?(
+      sandbox_id,
+      conversation_id,
+      idle_timeout_seconds()
+    )
+  end
+
+  @doc """
+  Explicitly park the sandbox before the row flips: for Sprites this is a
+  no-op (scale-to-zero), for pause/stop providers it is the call that stops
+  the meter. Ordering matters — a row marked suspended with the backend still
+  running would be invisible to every reclaim pass.
+  """
+  @spec suspend(Handle.t() | nil) :: :ok | {:error, term()}
+  def suspend(nil), do: :ok
+  def suspend(handle), do: Managoat.Sandbox.suspend(handle)
+
+  @doc """
+  What the idle bound does to this machine, the suspend call included.
+
+  Park where the provider can preserve the disk (the `:suspend` capability —
+  implicit scale-to-zero for Sprites, an explicit pause/stop for providers
+  that need one), destroy where it cannot. The disk holds the runtime session
+  — the agent's memory, which #649 proved cannot be rebuilt on a fresh
+  sandbox — so parking is always preferred; but an idle sandbox that cannot
+  park keeps billing, and a park *call* that fails leaves it billing too, so
+  both of those degrade to the destroy arm. `idle_action/1` is the
+  capability half of the decision.
+  """
+  @spec idle_machine_action(String.t(), Handle.t() | nil) :: :park | :destroy
+  def idle_machine_action(conversation_id, handle) do
+    with :suspend <- idle_action(provider(handle)),
+         :ok <- suspend(handle) do
+      :park
+    else
+      :destroy ->
+        :destroy
+
+      {:error, reason} ->
+        Logger.warning(
+          "suspend call failed for conv #{conversation_id} " <>
+            "(#{inspect(reason)}); destroying instead — an unparked sandbox keeps billing"
+        )
+
+        :destroy
+    end
+  end
+
+  @doc """
+  What the max-lifetime ceiling does to this machine, the suspend call
+  included.
+
+  Tear down, whatever the provider. This bound exists for the conversation
+  that never stops being busy; the conversation stays `idle` and resumable —
+  setting it `terminated` would make a cost control into data loss.
+
+  A home is parked instead, where the provider can park: its disk is the
+  agent's memory across every conversation, and destroying it at a busy
+  ceiling would defeat the mode (ADR 0023 step 5). The ceiling itself is
+  slated to go; until then this is the interim it names. A home on a provider
+  that cannot park, or whose park call fails, is destroyed as an ephemeral one
+  would be — an unparked machine keeps billing.
+  """
+  @spec max_lifetime_action(String.t() | nil, Handle.t() | nil) :: :park | :destroy
+  def max_lifetime_action(sandbox_id, handle) do
+    with true <- home?(sandbox_id),
+         :suspend <- idle_action(provider(handle)),
+         :ok <- suspend(handle) do
+      :park
+    else
+      _ -> :destroy
+    end
+  end
+
+  @doc """
+  Park the machine: the sandbox row to `suspended`, the conversation back to
+  `idle`, the stage event, the telemetry and the co-tenants. The suspend call
+  itself has already been made by whichever action decided on `:park`.
+  """
+  @spec park(String.t(), String.t() | nil, Handle.t() | nil, :idle | :max_lifetime) :: :ok
+  def park(conversation_id, sandbox_id, handle, reason) do
+    if sandbox_id do
+      # Ownership: as home?/1 above.
+      sandbox = Conversations._unsafe_get_sandbox!(sandbox_id)
+
+      if sandbox.status not in ["terminated", "failed"] do
+        # A home's disk is kept at its quietest moment, where the provider
+        # can (ADR 0023, #1073). Best-effort: the park goes ahead either way.
+        HomeCheckpoint.on_park(sandbox)
+        {:ok, _} = Conversations.update_sandbox(sandbox, %{status: "suspended"})
+      end
+    end
+
+    # The conversation stays idle and resumable; the sprite stays parked.
+    conv = Conversations._unsafe_get_conversation!(conversation_id)
+    if conv.status == "running", do: Conversations.update_conversation(conv, %{status: "idle"})
+
+    # Same stage/state as the reclaim below (LogEvent's state set is closed and
+    # clients already key on the "sandbox" stage); `event` is the discriminator.
+    Conversations.publish_stage(conversation_id, "sandbox", "done", %{
+      event: "suspended",
+      reason: to_string(reason),
+      message: explain(reason, :suspend)
+    })
+
+    :telemetry.execute([:fountain, :sandbox, :suspended], %{count: 1}, %{
+      provider: provider(handle)
+    })
+
+    stop_cotenants(
+      sandbox_id,
+      conversation_id,
+      "suspended",
+      to_string(reason),
+      explain(reason, :suspend)
+    )
+  end
+
+  @doc """
+  Tear down the sandbox; the conversation stays `idle` and resumable (setting
+  it `terminated` here would make a cost control into data loss). Serves both
+  the max-lifetime ceiling and the idle bound on a provider that cannot park.
+  """
+  @spec destroy(
+          String.t(),
+          String.t() | nil,
+          String.t(),
+          Handle.t() | nil,
+          :idle | :max_lifetime
+        ) :: :ok
+  def destroy(conversation_id, sandbox_id, user_id, handle, reason) do
+    if handle, do: _ = Managoat.Sandbox.destroy(handle)
+    Egress.release(user_id, conversation_id)
+
+    if sandbox_id do
+      # Ownership: as home?/1 above.
+      sandbox = Conversations._unsafe_get_sandbox!(sandbox_id)
+
+      if sandbox.status not in ["terminated", "failed"] do
+        {:ok, _} =
+          Conversations.update_sandbox(sandbox, %{
+            status: "terminated",
+            terminated_at: DateTime.utc_now() |> DateTime.truncate(:second)
+          })
+      end
+    end
+
+    conv = Conversations._unsafe_get_conversation!(conversation_id)
+    if conv.status == "running", do: Conversations.update_conversation(conv, %{status: "idle"})
+
+    # `state` is a stage-lifecycle vocabulary — LogEvent allows only
+    # started/done/failed/interrupted, and both the CLI and the LiveView switch
+    # on it. A reclaimed sandbox is a stage that reached its end, so "done" is
+    # accurate and needs no client to learn a new word; the `reason` and
+    # `message` fields carry what actually happened.
+    Conversations.publish_stage(conversation_id, "sandbox", "done", %{
+      event: "reclaimed",
+      reason: to_string(reason),
+      message: reclaim_message(reason)
+    })
+
+    :telemetry.execute([:fountain, :sandbox, :reclaimed], %{count: 1}, %{
+      reason: reason,
+      provider: provider(handle)
+    })
+
+    stop_cotenants(
+      sandbox_id,
+      conversation_id,
+      "reclaimed",
+      to_string(reason),
+      reclaim_message(reason)
+    )
+  end
+
+  @doc """
+  A park or a destroy is a machine operation: every other conversation on the
+  sandbox loses its handle with it. Tell their servers, so each records what
+  happened on its own transcript and stops — the next prompt then takes the
+  wake path, the only path that brings the machine back. A cast: a co-tenant
+  whose server is already gone is not an error here.
+  """
+  @spec stop_cotenants(String.t() | nil, String.t(), String.t(), String.t(), String.t()) :: :ok
+  def stop_cotenants(sandbox_id, conversation_id, event, reason, message) do
+    # Ownership: as home?/1 above.
+    sandbox_id
+    |> Conversations._unsafe_list_cotenant_ids(conversation_id)
+    |> Enum.each(fn conv_id ->
+      case ConversationServer.whereis(conv_id) do
+        nil -> :ok
+        pid -> GenServer.cast(pid, {:machine_gone, event, reason, message})
+      end
+    end)
   end
 
   defp minutes(nil), do: "?"

--- a/apps/fountain/test/fountain/conversations/conversation_server_size_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_size_test.exs
@@ -15,7 +15,7 @@ defmodule Fountain.Conversations.ConversationServerSizeTest do
   accepts is downward. Lower it when you move something out; never raise it.
   """
 
-  @pin 3192
+  @pin 3049
 
   @server "apps/fountain/lib/fountain/conversations/conversation_server.ex"
 

--- a/apps/fountain/test/fountain/conversations/lifecycle_actions_test.exs
+++ b/apps/fountain/test/fountain/conversations/lifecycle_actions_test.exs
@@ -1,0 +1,302 @@
+defmodule Fountain.Conversations.LifecycleActionsTest do
+  @moduledoc """
+  The reclaim actions that moved out of `ConversationServer` in #1376: the
+  sandbox clock, what each bound does to the machine, the park and the
+  destroy, and what the co-tenants on it are told. Driven with the
+  `Managoat.Sandbox` facade stubbed and no server — a co-tenant is a plain
+  process registered under its conversation id, which is all `whereis/1`
+  looks for.
+
+  The policy half of `Lifecycle` is pinned by `lifecycle_test.exs`; this file
+  only asserts the consequences.
+  """
+  use Fountain.DataCase, async: true
+  use Mimic
+
+  alias Fountain.Conversations
+  alias Fountain.Conversations.Lifecycle
+  alias Managoat.Sandbox.Handle
+
+  defp handle(name \\ "s"), do: %Handle{provider: :sprites, name: name}
+
+  setup do
+    user = insert_verified_user()
+    sandbox = insert_sandbox(user_id: user.id, status: "ready")
+    conv = insert_conversation(user_id: user.id, sandbox_id: sandbox.id, status: "running")
+    {:ok, user: user, sandbox: sandbox, conv: conv}
+  end
+
+  # The stage events of one stage as `{state, meta}` pairs, in order.
+  defp stages(conv_id, stage) do
+    Fountain.Repo.all(
+      from(e in Conversations.LogEvent,
+        where: e.conversation_id == ^conv_id and e.kind == "stage" and e.stage == ^stage,
+        order_by: e.id
+      )
+    )
+    |> Enum.map(&{&1.state, Jason.decode!(&1.data)})
+  end
+
+  # Collect one telemetry event into this process's mailbox.
+  defp listen(event) do
+    ref = make_ref()
+    test = self()
+    id = "lifecycle-actions-#{inspect(ref)}"
+
+    :telemetry.attach(
+      id,
+      event,
+      fn _e, measurements, meta, _ -> send(test, {ref, measurements, meta}) end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(id) end)
+    ref
+  end
+
+  describe "provider/1 and clock_start/1" do
+    test "the provider tag comes off the live handle, and defaults to sprites" do
+      assert Lifecycle.provider(%Handle{provider: :daytona, name: "d"}) == :daytona
+      assert Lifecycle.provider(nil) == :sprites
+    end
+
+    test "the clock starts at the last wake, else at creation" do
+      created = ~U[2026-01-01 00:00:00Z]
+      woke = ~U[2026-01-02 00:00:00Z]
+
+      assert Lifecycle.clock_start(%{last_resumed_at: nil, inserted_at: created}) == created
+      assert Lifecycle.clock_start(%{last_resumed_at: woke, inserted_at: created}) == woke
+    end
+  end
+
+  describe "schedule_check/0" do
+    test "arms :lifecycle_check in the calling process" do
+      ref = Lifecycle.schedule_check()
+      assert is_reference(ref)
+      # The default is a minute; the point is that a timer exists and carries
+      # the message the server's handle_info matches on.
+      assert Process.read_timer(ref) > 0
+      assert Process.cancel_timer(ref) > 0
+    end
+  end
+
+  describe "home?/1" do
+    test "a persistent sandbox is a home; an ephemeral one and nil are not", ctx do
+      {:ok, home} = Conversations.update_sandbox(ctx.sandbox, %{mode: "persistent"})
+
+      assert Lifecycle.home?(home.id)
+      refute Lifecycle.home?(insert_sandbox(user_id: ctx.user.id).id)
+      refute Lifecycle.home?(nil)
+    end
+  end
+
+  describe "busy_elsewhere?/2" do
+    test "false when this conversation is alone on the machine", ctx do
+      refute Lifecycle.busy_elsewhere?(ctx.sandbox.id, ctx.conv.id)
+    end
+
+    test "true when a co-tenant is mid-turn", ctx do
+      other =
+        insert_conversation(user_id: ctx.user.id, sandbox_id: ctx.sandbox.id, status: "running")
+
+      insert_turn(other, status: "running", started_at: DateTime.utc_now())
+
+      assert Lifecycle.busy_elsewhere?(ctx.sandbox.id, ctx.conv.id)
+    end
+
+    test "a terminated co-tenant does not hold the machine", ctx do
+      other =
+        insert_conversation(user_id: ctx.user.id, sandbox_id: ctx.sandbox.id, status: "running")
+
+      insert_turn(other, status: "running", started_at: DateTime.utc_now())
+      {:ok, _} = Conversations.update_conversation(other, %{status: "terminated"})
+
+      refute Lifecycle.busy_elsewhere?(ctx.sandbox.id, ctx.conv.id)
+    end
+  end
+
+  describe "suspend/1" do
+    test "no handle is nothing to park" do
+      assert Lifecycle.suspend(nil) == :ok
+    end
+
+    test "a handle goes to the provider" do
+      expect(Managoat.Sandbox, :suspend, fn %Handle{name: "s"} -> :ok end)
+      assert Lifecycle.suspend(handle()) == :ok
+    end
+  end
+
+  describe "idle_machine_action/2" do
+    test "parks when the provider can and the call succeeds", ctx do
+      expect(Managoat.Sandbox, :suspend, fn _ -> :ok end)
+      assert Lifecycle.idle_machine_action(ctx.conv.id, handle()) == :park
+    end
+
+    test "destroys where the provider cannot park", ctx do
+      stub(Managoat.Sandbox, :supports?, fn :sprites, :suspend -> false end)
+      # No suspend call at all: there is nothing to park onto.
+      reject(&Managoat.Sandbox.suspend/1)
+
+      assert Lifecycle.idle_machine_action(ctx.conv.id, handle()) == :destroy
+    end
+
+    test "destroys when the park call fails — an unparked sandbox keeps billing", ctx do
+      expect(Managoat.Sandbox, :suspend, fn _ -> {:error, {:unavailable, :timeout}} end)
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert Lifecycle.idle_machine_action(ctx.conv.id, handle()) == :destroy
+        end)
+
+      assert log =~ "suspend call failed for conv #{ctx.conv.id}"
+      assert log =~ "an unparked sandbox keeps billing"
+    end
+  end
+
+  describe "max_lifetime_action/2" do
+    test "an ephemeral sandbox is destroyed at the ceiling", ctx do
+      reject(&Managoat.Sandbox.suspend/1)
+      assert Lifecycle.max_lifetime_action(ctx.sandbox.id, handle()) == :destroy
+    end
+
+    test "a home is parked at the ceiling instead (ADR 0023)", ctx do
+      {:ok, home} = Conversations.update_sandbox(ctx.sandbox, %{mode: "persistent"})
+      expect(Managoat.Sandbox, :suspend, fn _ -> :ok end)
+
+      assert Lifecycle.max_lifetime_action(home.id, handle()) == :park
+    end
+
+    test "a home whose park call fails is destroyed as an ephemeral one would be", ctx do
+      {:ok, home} = Conversations.update_sandbox(ctx.sandbox, %{mode: "persistent"})
+      expect(Managoat.Sandbox, :suspend, fn _ -> {:error, :nope} end)
+
+      assert Lifecycle.max_lifetime_action(home.id, handle()) == :destroy
+    end
+  end
+
+  describe "park/4" do
+    test "parks the row, idles the conversation, and says so on the stream", ctx do
+      ref = listen([:fountain, :sandbox, :suspended])
+
+      assert Lifecycle.park(ctx.conv.id, ctx.sandbox.id, handle(), :idle) == :ok
+
+      assert Repo.reload(ctx.sandbox).status == "suspended"
+      assert Repo.reload(ctx.conv).status == "idle"
+
+      assert [{"done", meta}] = stages(ctx.conv.id, "sandbox")
+      assert meta["event"] == "suspended"
+      assert meta["reason"] == "idle"
+      assert meta["message"] == Lifecycle.explain(:idle, :suspend)
+
+      assert_received {^ref, %{count: 1}, %{provider: :sprites}}
+    end
+
+    test "the ceiling's park says which bound it was", ctx do
+      assert Lifecycle.park(ctx.conv.id, ctx.sandbox.id, handle(), :max_lifetime) == :ok
+
+      assert [{"done", meta}] = stages(ctx.conv.id, "sandbox")
+      assert meta["reason"] == "max_lifetime"
+      assert meta["message"] == Lifecycle.explain(:max_lifetime, :suspend)
+    end
+
+    test "a row already terminated or failed is left alone", ctx do
+      {:ok, sandbox} = Conversations.update_sandbox(ctx.sandbox, %{status: "failed"})
+
+      assert Lifecycle.park(ctx.conv.id, sandbox.id, handle(), :idle) == :ok
+      assert Repo.reload(sandbox).status == "failed"
+      # The conversation and the stream still get the news.
+      assert Repo.reload(ctx.conv).status == "idle"
+      assert [{"done", _}] = stages(ctx.conv.id, "sandbox")
+    end
+
+    test "a conversation that is not running keeps its status", ctx do
+      {:ok, conv} = Conversations.update_conversation(ctx.conv, %{status: "terminated"})
+
+      assert Lifecycle.park(conv.id, ctx.sandbox.id, handle(), :idle) == :ok
+      assert Repo.reload(conv).status == "terminated"
+    end
+  end
+
+  describe "destroy/5" do
+    test "tears the sandbox down, terminates the row and idles the conversation", ctx do
+      ref = listen([:fountain, :sandbox, :reclaimed])
+      test = self()
+
+      expect(Managoat.Sandbox, :destroy, fn %Handle{name: "s"} ->
+        send(test, :destroyed) && :ok
+      end)
+
+      assert Lifecycle.destroy(ctx.conv.id, ctx.sandbox.id, ctx.user.id, handle(), :max_lifetime) ==
+               :ok
+
+      assert_received :destroyed
+
+      reloaded = Repo.reload(ctx.sandbox)
+      assert reloaded.status == "terminated"
+      assert reloaded.terminated_at
+      assert Repo.reload(ctx.conv).status == "idle"
+
+      assert [{"done", meta}] = stages(ctx.conv.id, "sandbox")
+      assert meta["event"] == "reclaimed"
+      assert meta["reason"] == "max_lifetime"
+      assert meta["message"] == Lifecycle.reclaim_message(:max_lifetime)
+
+      assert_received {^ref, %{count: 1}, %{reason: :max_lifetime, provider: :sprites}}
+    end
+
+    test "no handle is nothing to tear down, and the rows still move", ctx do
+      reject(&Managoat.Sandbox.destroy/1)
+
+      assert Lifecycle.destroy(ctx.conv.id, ctx.sandbox.id, ctx.user.id, nil, :idle) == :ok
+
+      assert Repo.reload(ctx.sandbox).status == "terminated"
+      assert [{"done", meta}] = stages(ctx.conv.id, "sandbox")
+      assert meta["message"] == Lifecycle.reclaim_message(:idle)
+      # The provider tag falls back with the handle.
+      assert meta["reason"] == "idle"
+    end
+  end
+
+  describe "stop_cotenants/5" do
+    test "casts :machine_gone to every other live server on the machine", ctx do
+      other =
+        insert_conversation(user_id: ctx.user.id, sandbox_id: ctx.sandbox.id, status: "running")
+
+      test = self()
+
+      # A plain process standing in for the co-tenant's server: `whereis/1`
+      # only asks the registry, and a cast is a message.
+      {:ok, stand_in} =
+        Task.start_link(fn ->
+          {:ok, _} = Horde.Registry.register(Fountain.ConversationRegistry, other.id, nil)
+          send(test, :registered)
+
+          receive do
+            msg -> send(test, {:cotenant, msg})
+          end
+        end)
+
+      assert_receive :registered
+
+      assert Lifecycle.stop_cotenants(ctx.sandbox.id, ctx.conv.id, "suspended", "idle", "why") ==
+               :ok
+
+      assert_receive {:cotenant, {:"$gen_cast", {:machine_gone, "suspended", "idle", "why"}}}
+      assert is_pid(stand_in)
+    end
+
+    test "a co-tenant with no live server is not an error", ctx do
+      insert_conversation(user_id: ctx.user.id, sandbox_id: ctx.sandbox.id, status: "running")
+
+      assert Lifecycle.stop_cotenants(ctx.sandbox.id, ctx.conv.id, "reclaimed", "idle", "why") ==
+               :ok
+    end
+  end
+
+  describe "reclaim_message/1" do
+    test "names the bound that destroyed the sandbox" do
+      assert Lifecycle.reclaim_message(:max_lifetime) == Lifecycle.explain(:max_lifetime)
+      assert Lifecycle.reclaim_message(:idle) == Lifecycle.explain(:idle, :destroy)
+    end
+  end
+end

--- a/apps/fountain/test/fountain/webhooks/events_test.exs
+++ b/apps/fountain/test/fountain/webhooks/events_test.exs
@@ -24,7 +24,8 @@ defmodule Fountain.Webhooks.EventsTest do
     "lib/fountain/conversations/provisioning.ex",
     "lib/fountain/conversations/egress.ex",
     "lib/fountain/conversations/turn_machine.ex",
-    "lib/fountain/conversations/pending.ex"
+    "lib/fountain/conversations/pending.ex",
+    "lib/fountain/conversations/lifecycle.ex"
   ]
 
   # publish_stage(<anything>, "<stage>", "<status>"


### PR DESCRIPTION
Part of #1369, seventh of eight. `Fountain.Conversations.Lifecycle` already held the policy — `check/4`, `idle_action/1`, `explain/1,2` and the two bounds they read — and none of the consequence. It now holds both, in a clearly separated second half, so a reader of `idle_action/1` can see what `:destroy` costs without opening another file. The policy functions are untouched and still pure.

## Functions moved

Two corrections to the issue:

- **`terminate/2` has no sandbox half.** It deletes the conversation's redaction registry and best-effort revokes the callback API key it minted (#322, and the long comment about a dying Horde duplicate revoking the survivor's credential). It touches no sandbox and no row. Nothing moved from it, and nothing was invented to match.
- **`touch_activity/1` stays on the server.** It writes one field of the server's own state (`last_activity_at`), which is the input `check/4` reads; moving it would be a function over `state`, which this refactor is specifically not making. It keeps a one-line comment saying what it is.

| was (`ConversationServer`) | now (`Lifecycle`) |
|---|---|
| `provider/1` (over state) | `provider/1` (over the handle) |
| `sandbox_clock_start/1` | `clock_start/1` |
| `schedule_lifecycle_check/0`, `@lifecycle_check_ms` | `schedule_check/0`, `@check_ms` |
| `home?/1` (over state) | `home?/1` (over the sandbox id) |
| the `_unsafe_sandbox_busy_elsewhere?` read in `reclaim_sandbox/2` | `busy_elsewhere?/2` |
| `suspend_sandbox/1` | `suspend/1` |
| `reclaim_idle_machine/1`'s `with` | `idle_machine_action/2` |
| `reclaim_sandbox(state, :max_lifetime)`'s `with` | `max_lifetime_action/2` |
| `park_sandbox/2`'s body | `park/4` |
| `destroy_sandbox/2`'s body | `destroy/5` |
| `stop_cotenants/4` | `stop_cotenants/5` |
| `reclaim_message/1` | `reclaim_message/1` |

The two `*_action` functions answer `:park` or `:destroy`, and make the suspend call themselves, because in the original the call *was* part of the decision (`with :suspend <- idle_action(...), :ok <- suspend_sandbox(...)`), and the error arm is where the "an unparked sandbox keeps billing" warning lives. Splitting the call out of the `with` would have changed which failures degrade to destroy.

One comment was mis-attached in the original and is now attached correctly: the four lines about the ceiling measuring a continuous run sat above `provider/1` but describe `sandbox_clock_start/1`, which was below it. No words changed.

## What the server keeps

Each reclaim is still a server callback returning a GenServer tuple, so the wrapper around each action stays: the `Logger.info`, then `drop_connection/2`, then the `Lifecycle` call, then `{:stop, :normal, %{state | handle: nil}}`.

The log line and `drop_connection/2` stay on the server on purpose, and in their original position. `drop_connection/2` is #1377's, and it can finish an autonomous turn — which persists rows and publishes stage events — so its order relative to the sandbox row update is observable. Keeping it where it was is the only way to leave that ordering alone. `destroy_sandbox/2` has the same shape.

`handle_info(:lifecycle_check, ...)` still owns the tick and the `Lifecycle.check/4` call; only `schedule_lifecycle_check()` became `Lifecycle.schedule_check()`, which arms the timer in the calling process exactly as before.

`lifecycle.ex` joined `turn_machine.ex` and `pending.ex` in the ownership check's exemptions (`.credo.exs`), with its own line: the sandbox and rows it reads belong to the conversation whose server called it, ownership established at that server's `init/1`. Each `_unsafe_` call site carries the comment saying so. `webhooks/events_test.exs` lists it as a `publish_stage` source.

## The reaper

`Workers.SandboxReaper.park/2` now duplicates `Lifecycle.idle_machine_action/2` almost exactly — the same `with`, the same degrade-to-expire on a failed call, differing only in its log prefix and in building the handle from `sandbox.sprite_name` rather than holding one. It could call `Lifecycle` directly after this move. **Not changed here**, per the tracker: the reaper is outside this PR's scope and its tests are a pin, not a target.

## Unit tests, no process

`lifecycle_actions_test.exs` (24 tests, `async: true`, `Fountain.DataCase` plus Mimic over the `Managoat.Sandbox` facade, the same shape as `provisioning_steps_test.exs` from #1372): `provider/1` and `clock_start/1`; `schedule_check/0` arming a live timer in the caller; `home?/1` for persistent, ephemeral and nil; `busy_elsewhere?/2` alone, with a co-tenant mid-turn, and with a terminated one; `suspend/1` with and without a handle; `idle_machine_action/2` parking, degrading where the provider cannot park (asserting no suspend call is made at all) and degrading on a failed call (asserting the warning); `max_lifetime_action/2` for an ephemeral sandbox, a home, and a home whose park call fails; `park/4` (row, conversation, stage, telemetry; the ceiling's copy; a `failed` row left alone; a non-running conversation left alone); `destroy/5` (the provider call, the terminated row with its stamp, the stage, the telemetry, and the no-handle case); `stop_cotenants/5` reaching a plain process registered under a co-tenant's id, and shrugging at a co-tenant with no server; `reclaim_message/1`. No `ConversationServerCase`, no `Sprites` stub, no `Peer`.

`lifecycle_test.exs` is unchanged — it pins the policy half, which this PR does not touch.

## Pin

| | lines |
|---|---|
| before | 3192 |
| after | 3049 |

## Gates

| gate | result |
|---|---|
| `MIX_ENV=test mix compile --warnings-as-errors` | clean |
| `mix format --check-formatted` (mise Elixir 1.19.2, from `apps/fountain`) | exit 0 |
| `mix credo --strict` | 5798 mods/funs, no issues |
| `MIX_ENV=dev mix dialyzer` | passed, `Total errors: 0` |
| the fourteen `conversation_server*_test.exs` plus `lifecycle_test`, `lifecycle_actions_test`, `sandbox_reaper_test`, `home_checkpoint_test`, `pending_test`, `turn_machine_test`, `audit_guardrail`, `caller_tools`, `provisioning`, `provisioning_steps`, `docs`, `webhooks/events`, `metrics` | 450 tests, 0 failures |
| `gitleaks git --log-opts="origin/main..HEAD"` | no leaks found |
| full root suite | posted as a comment when it finishes |

`git diff --stat origin/main` over the thirteen server test files is empty; the only test file this PR edits under that glob is the ratchet.

**Proof:** with `origin/main`'s server file put back beside the new `Lifecycle`, the size test fails — `apps/fountain/lib/fountain/conversations/conversation_server.ex is 3192 lines, over the pin of 3049`. Restored; the committed file is 3,049.

## CHANGELOG

One entry under `[Unreleased]`, `### Changed`.

Closes #1376. Part of #1369.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mx2sij38JHM6gQu6PxiGG
