### PR TITLE
feat(funnel): activation is the first conversation with a reply

### DIFF
--- a/apps/fountain/lib/fountain/activation.ex
+++ b/apps/fountain/lib/fountain/activation.ex
@@ -1,0 +1,202 @@
+defmodule Fountain.Activation do
+  @moduledoc """
+  Activation is **the first conversation with a reply** (ADR 0038).
+
+  One definition, in one module, for the two readers that ask about it:
+
+    * `Fountain.Funnel`, which counts accounts and measures verification to
+      first reply, and
+    * PostHog, which gets `activation.first_reply` the moment it happens so a
+      funnel can put the landing page's own events either side of it.
+
+  A reply is a `turns` row whose `reply_text` is a non-empty string.
+  `Conversations._unsafe_update_turn/2` materialises that column from the
+  turn's events when the turn ends, through the same parse the transcript
+  uses (`Conversations.Blocks.assistant_text/2`, which trims and returns `""`
+  when the agent said nothing), so "the agent answered" needs no second
+  definition here. A conversation that provisioned a sandbox, ran, and
+  produced no assistant text is not an activation.
+
+  ## The seam
+
+  `turn_replied/1` is called from `Conversations._unsafe_update_turn/2` —
+  every turn ending in the system goes through there, from the
+  ConversationServer's six endings to the orphan sweep, so a new way for a
+  turn to end is instrumented by construction rather than by remembering.
+  It is the *account's first* reply that this module cares about, so the
+  function is a no-op for every later turn.
+
+  **#1390 stamps `users.onboarding_completed_at` here**, at the first reply,
+  instead of the dashboard checklist stamping it when three things exist.
+  The call site is marked in `capture_first_reply/2`; the field is untouched
+  by this module today.
+
+  ## What it costs
+
+  Two queries per turn that ends with a reply — the conversation's owner, and
+  whether an earlier reply already exists for that owner — and a third (the
+  user row, for the time since verification) only on the one turn per account
+  that is the first. It is best-effort: a raise here would take a turn ending
+  with it, so everything is rescued, exactly as
+  `Conversations.publish_stage/4` treats its own analytics mirror.
+  """
+
+  import Ecto.Query
+
+  require Logger
+
+  alias Fountain.Accounts.User
+  alias Fountain.Conversations.{Conversation, Turn}
+  alias Fountain.Repo
+
+  @event "activation.first_reply"
+
+  @doc """
+  The moment each account first got a reply: `%{user_id => DateTime.t()}`.
+
+  The turn's `ended_at`, which is when the reply landed; a turn that ended
+  without one stamped falls back to when its row was written, so a missing
+  timestamp cannot silently drop an activated account out of the funnel.
+  No tenant scope — the caller is the admin funnel.
+  """
+  @spec first_reply_by_user() :: %{String.t() => DateTime.t()}
+  def first_reply_by_user do
+    # The reply predicate, repeated in the two queries below it: non-null and
+    # non-empty. `assistant_text/2` trims and yields "" for "the agent said
+    # nothing", which `_unsafe_turn_reply_text/1` turns into nil — the
+    # empty-string arm is belt and braces for rows written any other way,
+    # including the #826 backfill.
+    Repo.all(
+      from t in Turn,
+        join: c in Conversation,
+        on: c.id == t.conversation_id,
+        where: not is_nil(t.reply_text) and t.reply_text != "",
+        group_by: c.user_id,
+        select: {c.user_id, type(min(coalesce(t.ended_at, t.inserted_at)), :utc_datetime)}
+    )
+    |> Map.new()
+  end
+
+  @doc """
+  When `user_id` first got a reply, or `nil` if it never has.
+  """
+  @spec first_reply_at(String.t()) :: DateTime.t() | nil
+  def first_reply_at(user_id) when is_binary(user_id) do
+    Repo.one(
+      from t in Turn,
+        join: c in Conversation,
+        on: c.id == t.conversation_id,
+        where: c.user_id == ^user_id,
+        where: not is_nil(t.reply_text) and t.reply_text != "",
+        select: type(min(coalesce(t.ended_at, t.inserted_at)), :utc_datetime)
+    )
+  end
+
+  @doc """
+  A turn has ended carrying a reply: if it is the account's first, this is
+  activation.
+
+  Returns `:ok` in every case, including when the turn has no reply, when the
+  account activated long ago, and when anything at all goes wrong. Callers
+  are on the turn-ending path and must never branch on it.
+  """
+  @spec turn_replied(Turn.t()) :: :ok
+  def turn_replied(%Turn{reply_text: text} = turn) when is_binary(text) and text != "" do
+    with user_id when is_binary(user_id) <- owner_of(turn),
+         true <- first_reply?(user_id, turn) do
+      capture_first_reply(user_id, turn)
+    else
+      _ -> :ok
+    end
+  rescue
+    e ->
+      Logger.warning("activation: first-reply check failed: #{inspect(e)}")
+      :ok
+  end
+
+  def turn_replied(_turn), do: :ok
+
+  @doc """
+  The PostHog event name this module emits, and the names the verified
+  landing (#1390) emits either side of it.
+
+  The funnel ADR 0038 asks for is `auth.email.verified` →
+  `onboarding.landing_viewed` → `onboarding.request_sent` →
+  `activation.first_reply`. The first arrives already, from the audit trail's
+  own choke point (`Accounts.verify_email/2` records `auth.email.verified`);
+  the last is emitted here; the middle two are the landing page's, and are
+  named here so the funnel definition and the page that fills it cannot drift
+  apart. `onboarding.key_copied` is the fourth moment #1390 captures and is
+  not a funnel step: copying is not doing.
+  """
+  @spec funnel_events() :: [String.t()]
+  def funnel_events do
+    [
+      "auth.email.verified",
+      "onboarding.landing_viewed",
+      "onboarding.request_sent",
+      @event
+    ]
+  end
+
+  defp owner_of(%Turn{} = turn) do
+    Repo.one(
+      from c in Conversation,
+        join: t in Turn,
+        on: t.conversation_id == c.id,
+        where: t.id == ^turn.id,
+        select: c.user_id
+    )
+  end
+
+  # Is `turn` the earliest replied turn this account has? Ordered by the same
+  # timestamp `first_reply_by_user/0` reports, with the id as the tie-break so
+  # two turns that ended in the same second still name one winner.
+  defp first_reply?(user_id, %Turn{} = turn) do
+    earliest =
+      Repo.one(
+        from t in Turn,
+          join: c in Conversation,
+          on: c.id == t.conversation_id,
+          where: c.user_id == ^user_id,
+          where: not is_nil(t.reply_text) and t.reply_text != "",
+          order_by: [asc: coalesce(t.ended_at, t.inserted_at), asc: t.id],
+          limit: 1,
+          select: t.id
+      )
+
+    earliest == turn.id
+  end
+
+  defp capture_first_reply(user_id, %Turn{} = turn) do
+    # #1390: stamp `users.onboarding_completed_at` here, on this branch —
+    # it runs exactly once per account, at the first reply, whatever door the
+    # request came through. Nothing writes it from this module today.
+    user = Repo.get(User, user_id)
+    at = turn.ended_at || turn.inserted_at
+
+    Fountain.Analytics.capture(
+      @event,
+      user_id,
+      %{
+        "conversation_id" => turn.conversation_id,
+        "turn_id" => turn.id,
+        "turn_number" => turn.turn_number,
+        "origin" => turn.origin,
+        "hours_since_verified" => hours_since_verified(user, at),
+        "source" => "activation"
+      },
+      timestamp: at,
+      set_once: %{"first_reply_at" => iso(at)}
+    )
+  end
+
+  defp hours_since_verified(%User{email_verified_at: %DateTime{} = verified_at}, %DateTime{} = at) do
+    Float.round(DateTime.diff(at, verified_at, :second) / 3600, 3)
+  end
+
+  defp hours_since_verified(_user, _at), do: nil
+
+  defp iso(%DateTime{} = dt), do: DateTime.to_iso8601(dt)
+  defp iso(_), do: nil
+end

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -1217,13 +1217,29 @@ defmodule Fountain.Conversations do
   to the orphan sweep, so search coverage is by construction rather than
   by each ending remembering. A turn that already carries a `reply_text`
   keeps it.
+
+  The same write is where activation is decided (ADR 0038): a turn that ends
+  carrying a reply is handed to `Fountain.Activation.turn_replied/1`, which
+  does nothing unless it is the account's *first*. Same choke-point argument,
+  same best-effort contract — it cannot fail this update.
   """
   def _unsafe_update_turn(%Turn{} = turn, attrs) do
-    changeset = Turn.changeset(turn, attrs)
+    changeset =
+      turn
+      |> Turn.changeset(attrs)
+      |> maybe_put_reply_text(turn)
 
-    changeset
-    |> maybe_put_reply_text(turn)
-    |> Repo.update()
+    result = Repo.update(changeset)
+
+    # The write that *materialises* the reply, not every later update to a
+    # turn that already has one — a turn is written again after it ends, and
+    # activation happens once.
+    with {:ok, updated} <- result,
+         text when is_binary(text) <- Ecto.Changeset.get_change(changeset, :reply_text) do
+      Fountain.Activation.turn_replied(updated)
+    end
+
+    result
   end
 
   @doc """

--- a/apps/fountain/lib/fountain/funnel.ex
+++ b/apps/fountain/lib/fountain/funnel.ex
@@ -3,14 +3,18 @@ defmodule Fountain.Funnel do
   Lifecycle funnel: registered → verified → onboarded → activated → funded.
 
   Admin-only aggregates (no tenant scoping — callers are the admin panel and
-  the metrics poller). Answers two operator questions:
+  the metrics poller). Answers three operator questions:
 
   - `summary_admin/0` — how many users reach each stage, the conversion from
     the previous stage, and the median time between stages.
-  - included stall breakdown — of the users who verified but never started a
-    conversation, how far did they get? This is the "38 verified, zero
-    conversations" question: did they finish onboarding, build an agent,
-    create an environment, or bounce straight off?
+  - **time to first reply** — verification to the first reply, median and p90,
+    plus the share of accounts that get there inside a day. This is the number
+    ADR 0038 says the onboarding redesign is judged on.
+  - included stall breakdown — of the users who verified but never got a
+    reply, how far did they get? This is the "40 verified, nothing created"
+    question: did they finish onboarding, build an agent, create an
+    environment, start a conversation that never answered, or bounce straight
+    off?
 
   Stage definitions:
 
@@ -18,22 +22,27 @@ defmodule Fountain.Funnel do
   - **verified** — `email_verified_at` set
   - **onboarded** — `onboarding_completed_at` set. Since #867 that means the
     account has an inference credential and an agent (the console stamps it),
-    rather than "clicked through the wizard". `by_onboarding_state` in the
-    stall breakdown is the vestige of that wizard — it now only distinguishes
-    `step_1` from `completed`; `built_agent` / `built_environment` /
-    `built_nothing` are the live signal.
-  - **activated** — first conversation: the earliest of a `conversations` row
-    or a `sandbox_provisioned` usage event. The union matters: conversations
-    can be deleted, usage events predate nothing after metering (#213) — either
-    alone under-counts.
+    rather than "clicked through the wizard"; ADR 0038 moves the stamp to the
+    first reply, which is `Fountain.Activation`'s seam. `by_onboarding_state`
+    in the stall breakdown is the vestige of that wizard — it now only
+    distinguishes `step_1` from `completed`; `built_agent` /
+    `built_environment` / `built_nothing` are the live signal.
+  - **activated** — **the first conversation with a reply** (ADR 0038): the
+    earliest `turns` row for the account carrying a non-empty `reply_text`.
+    A conversation that never answered does not count, and neither does a
+    sandbox that was provisioned for one. Until #1392 this stage was the
+    union of a `conversations` row and a `sandbox_provisioned` usage event,
+    which counted an attempt as an outcome; the union survives one stage
+    down, in `stalled.started`, where "started something and got nothing" is
+    exactly what it witnesses.
   - **funded** — holds a positive credit balance (ADR 0031). Comped accounts
     are operator-granted, not conversions, and are excluded; an account that
     spent its balance to zero drops out of this stage (a churn view is #286's
     job).
 
-  Everything is computed from one pass over `users` plus two grouped min
-  queries — O(users) in memory, which is fine well past 10k users; push the
-  math into SQL if that stops being true.
+  Everything is computed from one pass over `users` plus a handful of grouped
+  min queries — O(users) in memory, which is fine well past 10k users; push
+  the math into SQL if that stops being true.
   """
 
   import Ecto.Query
@@ -41,9 +50,13 @@ defmodule Fountain.Funnel do
   require Logger
 
   alias Fountain.Accounts.User
+  alias Fountain.Activation
   alias Fountain.Billing.UsageEvent
   alias Fountain.Conversations.Conversation
   alias Fountain.Repo
+
+  # A day, in hours: the window ADR 0038 judges the landing by.
+  @day_hours 24
 
   @type stage :: %{
           key: atom(),
@@ -52,18 +65,28 @@ defmodule Fountain.Funnel do
           median_hours: float() | nil
         }
 
-  @doc """
-  The funnel: five stages plus the stalled-at-activation breakdown.
+  @type timing :: %{
+          count: non_neg_integer(),
+          median_hours: float() | nil,
+          p90_hours: float() | nil,
+          within_day: non_neg_integer(),
+          within_day_of: non_neg_integer(),
+          within_day_share: float() | nil
+        }
 
-  Returns `%{stages: [stage], stalled: %{count: n, by_onboarding_state: map,
-  built_agent: n, built_environment: n, built_nothing: n}}`.
+  @doc """
+  The funnel: five stages, time to first reply, and the stalled breakdown.
+
+  Returns `%{stages: [stage], time_to_first_reply: timing, stalled: %{count: n,
+  by_onboarding_state: map, started: n, built_agent: n, built_environment: n,
+  built_nothing: n}}`.
 
   `conversion` is the fraction of the *previous* stage (nil for registered);
   `median_hours` is the median time from the previous stage's timestamp, for
   users that have both (nil for registered and funded — there is no
   funded-at timestamp to measure against).
   """
-  @spec summary_admin() :: %{stages: [stage()], stalled: map()}
+  @spec summary_admin() :: %{stages: [stage()], time_to_first_reply: timing(), stalled: map()}
   def summary_admin do
     users =
       Repo.all(
@@ -78,12 +101,12 @@ defmodule Fountain.Funnel do
           }
       )
 
-    first_activity = first_activity_by_user()
+    first_reply = Activation.first_reply_by_user()
 
     registered = users
     verified = Enum.filter(users, & &1.verified_at)
     onboarded = Enum.filter(users, & &1.onboarded_at)
-    activated = Enum.filter(users, &Map.has_key?(first_activity, &1.id))
+    activated = Enum.filter(users, &Map.has_key?(first_reply, &1.id))
 
     # Funded: a positive credit balance (ADR 0031). With billing disabled
     # nothing is granted or sold, so the stage stays in the list at 0 to keep
@@ -111,7 +134,7 @@ defmodule Fountain.Funnel do
         key: :activated,
         count: length(activated),
         conversion: ratio(length(activated), length(onboarded)),
-        median_hours: median_hours(activated, & &1.onboarded_at, &Map.get(first_activity, &1.id))
+        median_hours: median_hours(activated, & &1.onboarded_at, &Map.get(first_reply, &1.id))
       },
       %{
         key: :funded,
@@ -121,13 +144,21 @@ defmodule Fountain.Funnel do
       }
     ]
 
-    %{stages: stages, stalled: stalled_breakdown(verified, first_activity)}
+    %{
+      stages: stages,
+      time_to_first_reply: time_to_first_reply(verified, first_reply),
+      stalled: stalled_breakdown(verified, first_reply)
+    }
   end
 
   @doc """
   Poller hook for `FountainWeb.Telemetry.periodic_measurements/0`: emits stage
   counts as a `[:fountain, :funnel]` telemetry event so Prometheus/Grafana can
-  trend them. Counts only — no medians (a median makes a poor gauge).
+  trend them. Counts only — no medians (a median makes a poor gauge, and time
+  to first reply is a PostHog question because it wants an account attached).
+
+  Every replica polls the same database and reports the same number, so a
+  Grafana panel over these aggregates with `max`, never `sum`.
   """
   @spec emit_telemetry() :: :ok
   def emit_telemetry do
@@ -145,13 +176,53 @@ defmodule Fountain.Funnel do
     end)
   end
 
-  # Of the verified users with no conversation ever: how far did each get?
-  defp stalled_breakdown(verified, first_activity) do
-    stalled = Enum.reject(verified, &Map.has_key?(first_activity, &1.id))
+  # Verification to the first reply, over the accounts that have both.
+  #
+  # `within_day_share` deliberately does not divide by every verified account.
+  # An account verified an hour ago has not failed to reply within a day; it
+  # has not had a day. The denominator is the accounts a full day has passed
+  # for, which is a number that can only be read one way and can never exceed
+  # its numerator.
+  defp time_to_first_reply(verified, first_reply) do
+    now = DateTime.utc_now()
+
+    hours =
+      for u <- verified,
+          reply_at = Map.get(first_reply, u.id),
+          not is_nil(reply_at) do
+        {u, DateTime.diff(reply_at, u.verified_at, :second) / 3600}
+      end
+
+    judged =
+      Enum.filter(verified, fn u ->
+        DateTime.diff(now, u.verified_at, :second) / 3600 >= @day_hours
+      end)
+
+    judged_ids = MapSet.new(judged, & &1.id)
+
+    within_day =
+      Enum.count(hours, fn {u, h} -> h <= @day_hours and MapSet.member?(judged_ids, u.id) end)
+
+    values = Enum.map(hours, &elem(&1, 1))
+
+    %{
+      count: length(values),
+      median_hours: median(values),
+      p90_hours: percentile(values, 0.9),
+      within_day: within_day,
+      within_day_of: length(judged),
+      within_day_share: ratio(within_day, length(judged))
+    }
+  end
+
+  # Of the verified users who never got a reply: how far did each get?
+  defp stalled_breakdown(verified, first_reply) do
+    stalled = Enum.reject(verified, &Map.has_key?(first_reply, &1.id))
     stalled_ids = MapSet.new(stalled, & &1.id)
 
     agent_owners = owners_in(Fountain.Agents.Agent, stalled_ids)
     env_owners = owners_in(Fountain.Environments.Environment, stalled_ids)
+    starters = started_ids(stalled_ids)
 
     built_nothing =
       Enum.count(stalled, fn u ->
@@ -161,6 +232,7 @@ defmodule Fountain.Funnel do
     %{
       count: length(stalled),
       by_onboarding_state: Enum.frequencies_by(stalled, & &1.onboarding_state),
+      started: MapSet.size(starters),
       built_agent: MapSet.size(agent_owners),
       built_environment: MapSet.size(env_owners),
       built_nothing: built_nothing
@@ -175,27 +247,28 @@ defmodule Fountain.Funnel do
     |> MapSet.new()
   end
 
-  # %{user_id => first-ever conversation timestamp}, from the union of the
-  # conversations table and sandbox_provisioned usage events.
-  defp first_activity_by_user do
+  # The accounts that started something and got nothing back: a conversation
+  # row, or a `sandbox_provisioned` usage event for one whose conversation has
+  # since been deleted (turns cascade with it, so the metering row is the only
+  # surviving witness). This union used to *be* the activated stage; it is
+  # honest here, one stage below the reply it never produced.
+  defp started_ids(stalled_ids) do
+    ids = MapSet.to_list(stalled_ids)
+
     conversations =
       Repo.all(
-        from c in Conversation,
-          group_by: c.user_id,
-          select: {c.user_id, min(c.inserted_at)}
+        from c in Conversation, where: c.user_id in ^ids, distinct: true, select: c.user_id
       )
 
     usage =
       Repo.all(
         from e in UsageEvent,
-          where: e.event_type == "sandbox_provisioned",
-          group_by: e.user_id,
-          select: {e.user_id, min(e.inserted_at)}
+          where: e.user_id in ^ids and e.event_type == "sandbox_provisioned",
+          distinct: true,
+          select: e.user_id
       )
 
-    Map.merge(Map.new(conversations), Map.new(usage), fn _id, a, b ->
-      if DateTime.compare(a, b) == :lt, do: a, else: b
-    end)
+    MapSet.new(conversations ++ usage)
   end
 
   defp ratio(_num, 0), do: nil
@@ -224,5 +297,16 @@ defmodule Fountain.Funnel do
     else
       (Enum.at(sorted, mid - 1) + Enum.at(sorted, mid)) / 2
     end
+  end
+
+  # Nearest-rank percentile: the smallest value at or above which `p` of the
+  # sample sits. No interpolation — with a handful of accounts an interpolated
+  # p90 is a number nobody in the sample experienced.
+  defp percentile([], _p), do: nil
+
+  defp percentile(values, p) do
+    sorted = Enum.sort(values)
+    rank = max(1, ceil(p * length(sorted)))
+    Enum.at(sorted, rank - 1)
   end
 end

--- a/apps/fountain/lib/fountain_web/live/admin_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/admin_live/index.ex
@@ -99,6 +99,42 @@ defmodule FountainWeb.AdminLive.Index do
             </div>
           </div>
         </div>
+        <%!-- The number ADR 0038 judges onboarding on. Verification to the
+              first reply, not to the first conversation: an attempt that
+              never answered is not an activation. --%>
+        <div class="bg-white rounded shadow border border-zinc-200 px-4 py-3 text-sm space-y-1">
+          <div class="font-medium">Time to first reply</div>
+          <div :if={@funnel.time_to_first_reply.count > 0} class="text-zinc-700 space-x-2">
+            <span>
+              median
+              <span class="font-semibold tabular-nums">
+                {format_hours(@funnel.time_to_first_reply.median_hours)}
+              </span>
+            </span>
+            <span>
+              · p90
+              <span class="font-semibold tabular-nums">
+                {format_hours(@funnel.time_to_first_reply.p90_hours)}
+              </span>
+            </span>
+            <span class="text-zinc-500">
+              · over {@funnel.time_to_first_reply.count} activated {if @funnel.time_to_first_reply.count ==
+                                                                         1,
+                                                                       do: "account",
+                                                                       else: "accounts"}
+            </span>
+          </div>
+          <div :if={@funnel.time_to_first_reply.count == 0} class="text-zinc-500">
+            No account has had a reply yet.
+          </div>
+          <div :if={@funnel.time_to_first_reply.within_day_of > 0} class="text-xs text-zinc-500">
+            within a day of verifying: {@funnel.time_to_first_reply.within_day} of {@funnel.time_to_first_reply.within_day_of}
+            <span :if={@funnel.time_to_first_reply.within_day_share}>
+              ({format_pct(@funnel.time_to_first_reply.within_day_share)})
+            </span>
+            — accounts verified less than a day ago are counted in neither.
+          </div>
+        </div>
         <div
           :if={@funnel.stalled.count > 0}
           class="bg-amber-50 border border-amber-200 rounded px-4 py-3 text-sm text-amber-900 space-y-1"
@@ -106,7 +142,10 @@ defmodule FountainWeb.AdminLive.Index do
           <div class="font-medium">
             {@funnel.stalled.count} verified {if @funnel.stalled.count == 1,
               do: "user has",
-              else: "users have"} never started a conversation
+              else: "users have"} never had a reply
+          </div>
+          <div class="text-xs">
+            started a conversation and got nothing back: {@funnel.stalled.started}
           </div>
           <div class="text-xs">
             onboarding:

--- a/apps/fountain/test/fountain/activation_test.exs
+++ b/apps/fountain/test/fountain/activation_test.exs
@@ -1,0 +1,146 @@
+defmodule Fountain.ActivationTest do
+  use Fountain.DataCase, async: true
+
+  alias Fountain.Activation
+  alias Fountain.Conversations
+
+  # One ACP `agent_message_chunk`: the shape a runtime writes assistant text
+  # in, and what `Blocks.assistant_text/2` parses `reply_text` out of.
+  defp acp_text(text) do
+    Jason.encode!(%{
+      "jsonrpc" => "2.0",
+      "method" => "session/update",
+      "params" => %{
+        "sessionId" => "s",
+        "update" => %{
+          "sessionUpdate" => "agent_message_chunk",
+          "content" => %{"type" => "text", "text" => text}
+        }
+      }
+    })
+  end
+
+  defp at(hours_ago) do
+    DateTime.utc_now()
+    |> DateTime.add(-round(hours_ago * 3600), :second)
+    |> DateTime.truncate(:second)
+  end
+
+  describe "first_reply_by_user/0" do
+    test "empty when nobody has replied" do
+      user = insert_verified_user()
+      insert_conversation(user_id: user.id)
+
+      assert Activation.first_reply_by_user() == %{}
+      assert Activation.first_reply_at(user.id) == nil
+    end
+
+    test "the earliest replied turn, across conversations" do
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id)
+      other = insert_conversation(user_id: user.id)
+
+      insert_turn(other, %{status: "completed", reply_text: "later", ended_at: at(1)})
+      insert_turn(conv, %{status: "completed", reply_text: "first", ended_at: at(4)})
+
+      first = Activation.first_reply_at(user.id)
+
+      assert DateTime.compare(first, at(4)) == :eq
+      assert Activation.first_reply_by_user() == %{user.id => first}
+    end
+
+    test "a turn with no assistant text is not a reply" do
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id)
+
+      insert_turn(conv, %{status: "completed", ended_at: at(1)})
+      insert_turn(conv, %{status: "failed", reply_text: "", ended_at: at(1)})
+
+      assert Activation.first_reply_by_user() == %{}
+    end
+
+    test "accounts are separate" do
+      one = insert_verified_user()
+      two = insert_verified_user()
+
+      insert_turn(insert_conversation(user_id: one.id), %{
+        status: "completed",
+        reply_text: "hi",
+        ended_at: at(2)
+      })
+
+      assert Map.keys(Activation.first_reply_by_user()) == [one.id]
+      assert Activation.first_reply_at(two.id) == nil
+    end
+  end
+
+  describe "turn_replied/1" do
+    test "is a no-op for a turn with no reply" do
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id)
+      turn = insert_turn(conv, %{status: "running"})
+
+      assert Activation.turn_replied(turn) == :ok
+    end
+
+    test "does not raise when the turn's conversation is gone" do
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id)
+      turn = insert_turn(conv, %{status: "completed", reply_text: "hi", ended_at: at(1)})
+
+      Repo.delete!(conv)
+
+      assert Activation.turn_replied(turn) == :ok
+    end
+
+    test "answers :ok for the first reply and for every one after it" do
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id)
+
+      first = insert_turn(conv, %{status: "completed", reply_text: "one", ended_at: at(3)})
+      second = insert_turn(conv, %{status: "completed", reply_text: "two", ended_at: at(2)})
+
+      assert Activation.turn_replied(first) == :ok
+      assert Activation.turn_replied(second) == :ok
+    end
+  end
+
+  describe "the seam in Conversations._unsafe_update_turn/2" do
+    test "ending a turn with assistant text activates the account" do
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id)
+      turn = insert_turn(conv, %{status: "running"})
+
+      insert_log_event(conv, %{turn_id: turn.id, stream: "acp", data: acp_text("hello")})
+
+      {:ok, ended} =
+        Conversations._unsafe_update_turn(turn, %{status: "completed", ended_at: at(0)})
+
+      assert ended.reply_text =~ "hello"
+      assert Activation.first_reply_at(user.id) != nil
+    end
+
+    test "ending a turn that said nothing does not activate the account" do
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id)
+      turn = insert_turn(conv, %{status: "running"})
+
+      {:ok, ended} =
+        Conversations._unsafe_update_turn(turn, %{status: "completed", ended_at: at(0)})
+
+      assert ended.reply_text == nil
+      assert Activation.first_reply_at(user.id) == nil
+    end
+  end
+
+  describe "funnel_events/0" do
+    test "names the four steps of the PostHog funnel, in order" do
+      assert Activation.funnel_events() == [
+               "auth.email.verified",
+               "onboarding.landing_viewed",
+               "onboarding.request_sent",
+               "activation.first_reply"
+             ]
+    end
+  end
+end

--- a/apps/fountain/test/fountain/funnel_test.exs
+++ b/apps/fountain/test/fountain/funnel_test.exs
@@ -23,6 +23,19 @@ defmodule Fountain.FunnelTest do
 
   defp stage(summary, key), do: Enum.find(summary.stages, &(&1.key == key))
 
+  # An account that got a reply: a conversation, and a turn that ended
+  # carrying assistant text. `insert_turn/2` writes the row directly, so the
+  # funnel reads exactly what production's turn-ending write would have left.
+  defp reply!(user, opts \\ []) do
+    conv = Keyword.get_lazy(opts, :conversation, fn -> insert_conversation(user_id: user.id) end)
+
+    insert_turn(conv, %{
+      status: "completed",
+      reply_text: Keyword.get(opts, :text, "the agent answered"),
+      ended_at: Keyword.get(opts, :at, at(0))
+    })
+  end
+
   describe "summary_admin/0 — stage counts" do
     test "empty database: zero counts, nil conversions and medians" do
       summary = Funnel.summary_admin()
@@ -45,13 +58,13 @@ defmodule Fountain.FunnelTest do
 
       activated = insert_verified_user()
       set!(activated, onboarding_completed_at: at(2))
-      insert_conversation(user_id: activated.id)
+      reply!(activated)
 
       # Every verified account holds the opening credit, so "funded" is the
       # ones that still have some: drain the others.
       funded = insert_verified_user()
       set!(funded, onboarding_completed_at: at(3))
-      insert_conversation(user_id: funded.id)
+      reply!(funded)
       for u <- [verified_only, onboarded, activated], do: drain!(u)
 
       summary = Funnel.summary_admin()
@@ -76,26 +89,51 @@ defmodule Fountain.FunnelTest do
     end
   end
 
-  describe "summary_admin/0 — activation sources" do
-    test "a usage event alone counts as activated (conversation may be deleted)" do
-      user = insert_verified_user()
-      {:ok, _} = Fountain.Billing.record_usage(user.id, "sandbox_provisioned", nil, nil)
+  # ADR 0038: activation is the first conversation *with a reply*. Everything
+  # short of that — a conversation row, a provisioned sandbox, a turn that ran
+  # and said nothing — is an attempt, and an attempt is not an outcome.
+  describe "summary_admin/0 — activation is the first reply" do
+    test "a turn carrying assistant text counts as activated" do
+      reply!(insert_verified_user())
 
       assert stage(Funnel.summary_admin(), :activated).count == 1
     end
 
-    test "a conversation row alone counts as activated" do
+    test "a conversation with no reply does not count" do
       user = insert_verified_user()
       insert_conversation(user_id: user.id)
 
-      assert stage(Funnel.summary_admin(), :activated).count == 1
+      assert stage(Funnel.summary_admin(), :activated).count == 0
     end
 
-    test "non-provisioning usage events do not count as activation" do
+    test "a turn that ran and produced no text does not count" do
       user = insert_verified_user()
-      {:ok, _} = Fountain.Billing.record_usage(user.id, "turn_started", nil, nil)
+      conv = insert_conversation(user_id: user.id)
+      insert_turn(conv, %{status: "completed", ended_at: at(0)})
+      insert_turn(conv, %{status: "failed", reply_text: "", ended_at: at(0)})
 
       assert stage(Funnel.summary_admin(), :activated).count == 0
+    end
+
+    test "a provisioned sandbox does not count on its own" do
+      user = insert_verified_user()
+      {:ok, _} = Fountain.Billing.record_usage(user.id, "sandbox_provisioned", nil, nil)
+
+      assert stage(Funnel.summary_admin(), :activated).count == 0
+    end
+
+    test "a turn still running does not count until it ends with a reply" do
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id)
+      turn = insert_turn(conv, %{status: "running"})
+
+      assert stage(Funnel.summary_admin(), :activated).count == 0
+
+      Repo.update!(
+        Ecto.Changeset.change(turn, status: "completed", reply_text: "done", ended_at: at(0))
+      )
+
+      assert stage(Funnel.summary_admin(), :activated).count == 1
     end
   end
 
@@ -112,20 +150,87 @@ defmodule Fountain.FunnelTest do
       assert_in_delta stage(summary, :verified).median_hours, 3.0, 0.01
     end
 
-    test "activation timing uses the earliest of conversation and usage event" do
+    test "activation timing uses the earliest replied turn" do
       user = insert_verified_user()
       set!(user, inserted_at: at(10), email_verified_at: at(9), onboarding_completed_at: at(8))
 
-      # Conversation at -2h, usage event at -5h: the event is earlier and wins.
-      conv = insert_conversation(user_id: user.id)
-      Repo.update!(Ecto.Changeset.change(conv, inserted_at: at(2)))
-
-      {:ok, event} = Fountain.Billing.record_usage(user.id, "sandbox_provisioned", nil, nil)
-      Repo.update!(Ecto.Changeset.change(event, inserted_at: at(5)))
+      # Two replies, at -5h and -2h across two conversations: the earlier wins.
+      reply!(user, at: at(5))
+      reply!(user, at: at(2))
 
       summary = Funnel.summary_admin()
-      # onboarded at -8h, first activity at -5h → 3h
+      # onboarded at -8h, first reply at -5h → 3h
       assert_in_delta stage(summary, :activated).median_hours, 3.0, 0.01
+    end
+
+    test "a replied turn with no ended_at falls back to when its row was written" do
+      user = insert_verified_user()
+      set!(user, inserted_at: at(10), email_verified_at: at(9), onboarding_completed_at: at(8))
+
+      turn = reply!(user, at: nil)
+      Repo.update!(Ecto.Changeset.change(turn, inserted_at: at(4)))
+
+      assert_in_delta stage(Funnel.summary_admin(), :activated).median_hours, 4.0, 0.01
+    end
+  end
+
+  describe "summary_admin/0 — time to first reply" do
+    test "nothing measured on an instance where nobody has replied" do
+      insert_verified_user()
+
+      ttfr = Funnel.summary_admin().time_to_first_reply
+
+      assert ttfr.count == 0
+      assert ttfr.median_hours == nil
+      assert ttfr.p90_hours == nil
+      assert ttfr.within_day_share == nil
+    end
+
+    test "median and p90 run from verification, not from onboarding" do
+      # Five accounts verified 10 days ago, replying 1, 2, 3, 4 and 30 hours
+      # later. Median is the third; nearest-rank p90 of five values is the
+      # fifth, which is the point of a p90: the slow one is visible.
+      for h <- [1, 2, 3, 4, 30] do
+        user = insert_verified_user()
+        set!(user, email_verified_at: at(240), onboarding_completed_at: at(240))
+        reply!(user, at: at(240 - h))
+      end
+
+      ttfr = Funnel.summary_admin().time_to_first_reply
+
+      assert ttfr.count == 5
+      assert_in_delta ttfr.median_hours, 3.0, 0.01
+      assert_in_delta ttfr.p90_hours, 30.0, 0.01
+    end
+
+    test "the within-a-day share counts only accounts a day has passed for" do
+      # Verified 10 days ago, replied in an hour: in both halves.
+      quick = insert_verified_user()
+      set!(quick, email_verified_at: at(240))
+      reply!(quick, at: at(239))
+
+      # Verified 10 days ago, replied after two days: in the denominator only.
+      slow = insert_verified_user()
+      set!(slow, email_verified_at: at(240))
+      reply!(slow, at: at(192))
+
+      # Verified 10 days ago, never replied: in the denominator only.
+      stalled = insert_verified_user()
+      set!(stalled, email_verified_at: at(240))
+
+      # Verified an hour ago and already replied: it has not had a day, so it
+      # is in neither half. Counting it in the numerator alone would let the
+      # share exceed 1.
+      fresh = insert_verified_user()
+      set!(fresh, email_verified_at: at(1))
+      reply!(fresh, at: at(0.5))
+
+      ttfr = Funnel.summary_admin().time_to_first_reply
+
+      assert ttfr.count == 3
+      assert ttfr.within_day == 1
+      assert ttfr.within_day_of == 3
+      assert_in_delta ttfr.within_day_share, 1 / 3, 0.001
     end
   end
 
@@ -142,9 +247,9 @@ defmodule Fountain.FunnelTest do
       set!(env_builder, onboarding_state: "step_3")
       insert_env(user_id: env_builder.id)
 
-      # Activated user is not stalled, whatever else is true.
+      # An account that got a reply is not stalled, whatever else is true.
       activated = insert_verified_user()
-      insert_conversation(user_id: activated.id)
+      reply!(activated)
 
       # Unverified users are not in the stalled cohort.
       _unverified = insert_user()
@@ -156,6 +261,34 @@ defmodule Fountain.FunnelTest do
       assert stalled.built_agent == 1
       assert stalled.built_environment == 1
       assert stalled.built_nothing == 1
+    end
+
+    test "started: the stalled accounts that ran something and got nothing back" do
+      # A conversation that never answered. This is the account the old
+      # activation definition counted as activated.
+      tried = insert_verified_user()
+      insert_conversation(user_id: tried.id)
+
+      # A conversation since deleted: its turns went with it, so the metering
+      # row is the only surviving witness that anything ran. This is what the
+      # usage-event union is still worth, one stage below activation.
+      deleted = insert_verified_user()
+      {:ok, _} = Fountain.Billing.record_usage(deleted.id, "sandbox_provisioned", nil, nil)
+
+      # Built an agent, never ran it.
+      _never = insert_verified_user() |> tap(&insert_agent(user_id: &1.id))
+
+      %{stalled: stalled} = Funnel.summary_admin()
+
+      assert stalled.count == 3
+      assert stalled.started == 2
+    end
+
+    test "a non-provisioning usage event is not a start" do
+      user = insert_verified_user()
+      {:ok, _} = Fountain.Billing.record_usage(user.id, "turn_started", nil, nil)
+
+      assert Funnel.summary_admin().stalled.started == 0
     end
   end
 

--- a/apps/fountain/test/fountain_web/live/admin_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/admin_live_test.exs
@@ -54,13 +54,49 @@ defmodule FountainWeb.AdminLiveTest do
       admin = insert_admin()
       stalled = insert_active_user()
       insert_agent(user_id: stalled.id)
+      insert_conversation(user_id: stalled.id)
       conn = login_user(conn, admin)
 
       {:ok, _lv, html} = live(conn, ~p"/admin")
 
-      # admin + stalled are both verified with no conversations
-      assert html =~ "2 verified users have never started a conversation"
+      # admin + stalled are both verified and neither has had a reply; the
+      # conversation that never answered is a start, not an activation.
+      assert html =~ "2 verified users have never had a reply"
+      assert html =~ "started a conversation and got nothing back: 1"
       assert html =~ "built an agent: 1"
+    end
+
+    test "shows time to first reply", %{conn: conn} do
+      admin = insert_admin()
+      conn = login_user(conn, admin)
+
+      {:ok, _lv, html} = live(conn, ~p"/admin")
+
+      assert html =~ "Time to first reply"
+      assert html =~ "No account has had a reply yet."
+
+      user = insert_active_user()
+
+      Fountain.Repo.update!(
+        Ecto.Changeset.change(user,
+          email_verified_at:
+            DateTime.utc_now() |> DateTime.add(-48, :hour) |> DateTime.truncate(:second)
+        )
+      )
+
+      insert_turn(insert_conversation(user_id: user.id), %{
+        status: "completed",
+        reply_text: "the agent answered",
+        ended_at: DateTime.utc_now() |> DateTime.add(-46, :hour) |> DateTime.truncate(:second)
+      })
+
+      {:ok, _lv, html} = live(conn, ~p"/admin")
+
+      assert html =~ "Time to first reply"
+      assert html =~ "median"
+      assert html =~ "p90"
+      assert html =~ "2h"
+      assert html =~ "within a day of verifying: 1 of"
     end
   end
 end

--- a/decisions/0038-onboarding-first-reply.md
+++ b/decisions/0038-onboarding-first-reply.md
@@ -14,11 +14,19 @@ stale_after: 2026-11-02
 
 # 0038 — Onboarding is the path from verified to first reply, carried by the API
 
-**Status:** Accepted, 2026-09-02. **Nothing described here is built.** The
-implementation issues are #1388 (platform inference), #1389 (the default
-agent), #1390 (the verified landing), #1391 (the CLI's `auth register` and
-`quickstart`), #1392 (activation redefined and measured) and #1393 (the field
-cleanup), all sub-issues of #1039. Each PR that builds one updates this block.
+**Status:** Accepted, 2026-09-02. The implementation issues are #1388
+(platform inference), #1389 (the default agent), #1390 (the verified landing),
+#1391 (the CLI's `auth register` and `quickstart`), #1392 (activation redefined
+and measured) and #1393 (the field cleanup), all sub-issues of #1039. Each PR
+that builds one updates this block.
+
+**Built so far:** decision 2 (#1392). `Fountain.Activation` holds the
+definition, `Fountain.Funnel` counts it and measures verification to first
+reply, and `activation.first_reply` reaches PostHog from the turn-ending write.
+Nothing else described here is built: there is no platform inference key, no
+default agent, no verified landing, and `onboarding_completed_at` is still
+stamped by the dashboard checklist (#1390 moves the stamp to the seam
+`Fountain.Activation.capture_first_reply/2` marks).
 
 Amends [0008](0008-byo-inference-credentials.md): Fountain will hold platform
 inference keys. Leans on [0031](0031-credits-are-the-product.md) (the opening

--- a/deploy/grafana/fountain-product.json
+++ b/deploy/grafana/fountain-product.json
@@ -64,7 +64,7 @@
     {
       "type": "bargauge",
       "title": "Users by lifecycle stage",
-      "description": "All-time totals, polled from Fountain.Funnel. Onboarded means the account holds an inference credential and an agent (#867), not that somebody clicked through the old wizard. Activated means a first conversation, counted as the union of a conversations row and a sandbox_provisioned usage event, because either one alone under-counts. Every replica polls the same database and reports the same number, so these use `max`; `sum` would multiply the funnel by the replica count.",
+      "description": "All-time totals, polled from Fountain.Funnel. Onboarded means the account holds an inference credential and an agent (#867), not that somebody clicked through the old wizard. Activated means the first conversation with a reply (ADR 0038), counted as the earliest turn carrying assistant text. A conversation that never answered does not count, and neither does the sandbox provisioned for one. Every replica polls the same database and reports the same number, so these use `max`; `sum` would multiply the funnel by the replica count.",
       "gridPos": {
         "h": 9,
         "w": 12,
@@ -229,7 +229,7 @@
     {
       "type": "stat",
       "title": "Activated / verified",
-      "description": "The conversion that matters most: a verified account that ever started a conversation.",
+      "description": "The conversion that matters most: a verified account that ever got a reply from an agent.",
       "gridPos": {
         "h": 4,
         "w": 3,
@@ -321,7 +321,7 @@
     {
       "type": "stat",
       "title": "Stalled after verifying",
-      "description": "Verified accounts that never started a conversation. The admin funnel page breaks the same number down further, into built an agent, built an environment, or built nothing.",
+      "description": "Verified accounts that never got a reply. The admin funnel page breaks the same number down further, into started a conversation and got nothing back, built an agent, built an environment, or built nothing. Time to first reply, the number ADR 0038 judges onboarding on, is on that page and in PostHog rather than here \u2014 a median makes a poor gauge.",
       "gridPos": {
         "h": 5,
         "w": 6,

--- a/docs/guides/operate/dashboards.md
+++ b/docs/guides/operate/dashboards.md
@@ -80,7 +80,8 @@ Read this one for volume and speed.
 
 - **Lifecycle funnel**. Registered, verified, onboarded, activated, funded,
   and the conversion between each pair. The counts are all time, so read the
-  slope rather than the level.
+  slope rather than the level. Activated means the first conversation with a
+  reply. A conversation that never answered is not an activation.
 - **What agents actually do**. Turn outcomes per hour, the failure share, and
   the two latency panels.
 - **Time to first output** is the latency a person feels. Turn duration is how
@@ -121,6 +122,32 @@ Every tile carries a description that states what it measures and why.
 | `What ends an attempt before any output`. | Setup and model failures, per account. |
 | `What people build`. | Agents, conversations and scheduled runs. |
 | `How much each active account runs`. | Depth against breadth. |
+| `Verified to first reply`. | Where does a new account stop before its first reply. |
+| `Time to first reply`. | How long an account waits from verification to the first reply. |
+
+### The activation funnel
+
+Activation is the first conversation with a reply. ADR 0038 sets that rule, and
+`Fountain.Activation` holds the one definition. The admin page and PostHog both
+read it.
+
+The funnel has four steps.
+
+| Step | Event | Source |
+|---|---|---|
+| Verified. | `auth.email.verified`. | `Fountain.Audit.record/1`. |
+| First page seen. | `onboarding.landing_viewed`. | The page after verification. |
+| Request sent. | `onboarding.request_sent`. | The page after verification. |
+| First reply. | `activation.first_reply`. | `Fountain.Activation.turn_replied/1`. |
+
+The two middle events come from the page after verification. Both of those
+steps are optional in the funnel. The conversion from the first step to the
+last step is therefore correct before that page exists.
+
+`activation.first_reply` carries an `hours_since_verified` property. A trend on
+that property reports the median and the p90 for any window. The admin funnel
+page at `/admin` reports the same two numbers from Postgres. It also reports the
+share of accounts that reach a reply inside a day.
 
 ### Fountain / Finance
 
@@ -141,6 +168,7 @@ point that the action already had to pass through.
 | `Fountain.Audit.record/1`. | Each audited mutation, under its own action name. |
 | `Fountain.Billing.record_usage/5`. | The nine `usage.` events. |
 | `Conversations.publish_stage/4`. | `conversation.turn.done` and the other outcome stages. |
+| `Fountain.Activation.turn_replied/1`. | `activation.first_reply`, once per account. |
 | `FountainWeb.Live.Hooks`. | `$pageview` for the console. |
 
 A new audited action is therefore a new product event, and the two can never


### PR DESCRIPTION
Closes #1392. ADR 0038 decision 2.

## The definition

**Activated is the first conversation with a reply**: the earliest `turns`
row for the account with a non-empty `reply_text`. That column is
materialised by `Conversations._unsafe_update_turn/2` at every turn ending,
through the same `Blocks.assistant_text/2` parse the transcript uses, so a
turn that ran and said nothing carries `nil` and does not count.

`Fountain.Activation` is the one place that definition lives. `Fountain.Funnel`
reads it; PostHog gets `activation.first_reply` from it.

## The usage-event union: dropped from activation, kept one stage down

A `sandbox_provisioned` usage event cannot witness a reply — it witnesses an
attempt, which is the old definition wearing a different hat. So it no longer
counts as activation.

It still adds one thing, so it survives in `stalled.started`. Turns cascade
with their conversation, so when a user deletes a conversation the metering
row is the only surviving evidence that anything ran at all. `stalled.started`
is "verified, never got a reply, but did start something", and the union is
the honest way to count that.

## Time to first reply

Verification to that turn's `ended_at`, as a **median** and a **p90**
(nearest-rank, no interpolation — with a handful of accounts an interpolated
p90 is a number nobody experienced), plus the share that get there **within a
day**.

That share divides only by accounts a full day has passed for. An account
verified an hour ago has not failed to reply within a day, it has not had a
day; counting it in the numerator alone would let the share exceed 1.

The finance panel has no onboarding row (`AdminFinanceLive` is revenue, cost,
provider invoices, per-tenant), so there was nothing to add it to. It is on
`/admin` beside the funnel tiles.

## PostHog

Created in project 570897 and added to **Fountain / Product**:

- [Verified to first reply](https://us.posthog.com/project/570897/insights/CfSpUaR8) — the funnel, `auth.email.verified` → `onboarding.landing_viewed` → `onboarding.request_sent` → `activation.first_reply`, 30-day conversion window, ordered.
- [Time to first reply](https://us.posthog.com/project/570897/insights/wFYhoN8e) — median and p90 of `hours_since_verified` on `activation.first_reply`, weekly.

Step 1 already arrives from the audit choke point. Step 4 is new here. **Steps
2 and 3 belong to #1390 and do not exist yet**, so they are marked
`optionalInFunnel` — the verified-to-first-reply conversion reads correctly
today and the two middle steps fill in when the landing ships. Their names are
fixed in `Activation.funnel_events/0` and in the docs so the two issues cannot
drift. `onboarding.key_copied` is #1390's fourth moment and is deliberately not
a funnel step: copying is not doing.

`docs/guides/operate/dashboards.md` records both tiles, the four steps, and
where each event comes from. The Grafana product dashboard's panel
descriptions are corrected to the new definition (they still aggregate with
`max`, never `sum`).

## The baseline, so this can be judged later

Prod on 2026-09-02: **49 registered** (all verified; the unverified were
pruned), **9 have ever started a conversation**, **40 created nothing**. Of the
9, **3 are internal** and the rest are friends. **Time to first reply has never
been measured.**

Counting through replies instead of conversations will report *fewer* activated
accounts than the old funnel did, which is the point. The numbers that matter
are the median time to first reply and the within-a-day share, from the day the
landing ships.

## Not in scope

- `users.onboarding_state` and `stalled.by_onboarding_state` are untouched (#1393).
- `onboarding_completed_at` is still stamped by the dashboard checklist. The
  seam for #1390 is marked in `Activation.capture_first_reply/2`: it runs
  exactly once per account, at the first reply, whatever door the request came
  through.

## Tests

`funnel_test.exs` covers the new definition, **including a conversation with no
reply not counting**, a turn that produced no text, a provisioned sandbox
alone, a running turn before and after it ends, the median/p90, and the
within-a-day denominator. `activation_test.exs` covers the module and the seam
end to end (a real ACP log event through `_unsafe_update_turn/2`).

Verified by reverting: with the reply predicate removed, 2 of the new tests
fail; with the old conversation union restored, 8 fail, including the
acceptance case.

Full gate green (`mix precommit`): compile with warnings-as-errors, format,
`credo --strict`, sobelow, dialyzer 0 errors, **4002 tests**. One unrelated
flake in `Fountain.Buzz.HarnessTest` (a temp-path `buzz-acp` race under
four concurrent suites on one machine); it passes in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BXYa9CQNG8oFNq5YhAxva
