### PR TITLE
feat(billing): platform inference keys, metered against credits (#1388)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -339,6 +339,32 @@ STRIPE_WEBHOOK_SECRET=
 # CREDIT_SMS_MESSAGE_CENTS=
 # CREDIT_PACKS_CENTS=1000,2500,10000
 
+# ── Platform inference keys (ADR 0038, amending ADR 0008) ────────────────────
+#
+# Inference keys this deployment owns. Fountain runs a tenant's agent on one
+# when the tenant has no credential of their own for the model's provider, and
+# meters the tokens against their credit balance. The tenant's own credential
+# always wins, and there is no per-agent toggle.
+#
+# Blank means off, per provider. Set none of these and the instance behaves
+# exactly as it did before: bring-your-own only. Anthropic is the one that
+# matters first — the default agent runs on the claude runtime.
+# PLATFORM_ANTHROPIC_API_KEY=
+# PLATFORM_OPENAI_API_KEY=
+# PLATFORM_GEMINI_API_KEY=
+
+# The most the keys above may cost in a UTC day, across every tenant together.
+# A log line and a 503 when it is hit, so a bad day cannot cost more than this
+# number. Measured from the credit ledger: it needs CREDITS_ENABLED=true.
+# PLATFORM_INFERENCE_DAILY_CENTS=5000
+
+# Per-model rates, overriding the compiled card. Five colon-separated fields
+# per entry — provider/model_id (or provider/* for a provider fallback), then
+# input, output, cached-read and cached-write prices in cents per million
+# tokens. Decimals allowed. The compiled card is provider list price with no
+# markup, on purpose (ADR 0038): Fountain's margin is sandbox time.
+# PLATFORM_INFERENCE_RATES=anthropic/claude-opus-5:500:2500:50:625
+
 
 # ── Database TLS and pool ────────────────────────────────────────────────────
 

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -1800,6 +1800,10 @@ defmodule Fountain.Conversations do
          {:ok, parent_id} <- resolve_parent_id(attrs["parent_conversation_id"], user_id),
          :ok <- Fountain.Accounts.check_not_suspended(user_id),
          :ok <- Fountain.Billing.check_spend(user_id),
+         # Whose inference key would run this (#1388): refused only when it
+         # would be Fountain's and the deployment has spent its day. A door
+         # with no platform key configured runs no query here.
+         :ok <- Fountain.PlatformInference.gate(user_id, agent.model),
          # A persistent launch lands on the identity's home when there is one
          # (ADR 0023 gate 6): `{:home, sandbox}` leaves the `with` and attaches
          # below. Only when there is none does a machine get provisioned, and
@@ -2306,6 +2310,10 @@ defmodule Fountain.Conversations do
          {:ok, parent_id} <- resolve_parent_id(attrs["parent_conversation_id"], user_id),
          :ok <- Fountain.Accounts.check_not_suspended(user_id),
          :ok <- Fountain.Billing.check_spend(user_id),
+         # Whose inference key would run this (#1388): refused only when it
+         # would be Fountain's and the deployment has spent its day. A door
+         # with no platform key configured runs no query here.
+         :ok <- Fountain.PlatformInference.gate(user_id, agent.model),
          %Sandbox{} = sandbox <- get_sandbox(sandbox_id, user_id) || {:error, :sandbox_not_found},
          :ok <- check_attachable(sandbox, agent, vault_id, env_id),
          :ok <- check_attach_capacity(sandbox, agent, attrs["prompt"]),
@@ -2769,6 +2777,10 @@ defmodule Fountain.Conversations do
           # backstop; this one makes the refusal synchronous at the API door.
           with :ok <- Fountain.Accounts.check_not_suspended(conv.user_id),
                :ok <- Fountain.Billing.check_spend(conv.user_id),
+               # Whose inference key would run this (#1388): refused only when it
+               # would be Fountain's and the deployment has spent its day. A door
+               # with no platform key configured runs no query here.
+               :ok <- Fountain.PlatformInference.gate(conv.user_id, agent.model),
                {:ok, _} <- wake_suspended_sandbox(conv.user_id, sandbox_id) do
             case start_conversation_server(conv, sandbox_id, runtime_module, initial_prompt) do
               {:error, {:already_started, winner_pid}} ->
@@ -3027,6 +3039,10 @@ defmodule Fountain.Conversations do
 
     with :ok <- Fountain.Accounts.check_not_suspended(conv.user_id),
          :ok <- Fountain.Billing.check_spend(conv.user_id),
+         # Whose inference key would run this (#1388): refused only when it
+         # would be Fountain's and the deployment has spent its day. A door
+         # with no platform key configured runs no query here.
+         :ok <- Fountain.PlatformInference.gate(conv.user_id, agent.model),
          # A fresh sandbox is a fresh placement decision — re-resolve from
          # the agent, so a conversation whose old sandbox died can migrate
          # providers naturally.

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -474,6 +474,9 @@ defmodule Fountain.Conversations.ConversationServer do
       # What the runtime's default_env/2 is handed (gate 3): the real
       # credentials, or placeholders when the conversation is brokered.
       env_credentials: %{},
+      # #1388; see `SpriteEnv.select_inference/2`, which decides both.
+      inference_source: nil,
+      inference_model: nil,
       broker: nil,
       current_command: nil,
       current_command_ref: nil,
@@ -686,7 +689,8 @@ defmodule Fountain.Conversations.ConversationServer do
     vault = if conv.vault_id, do: Vaults._unsafe_get_vault(conv.vault_id)
 
     case SpriteEnv.load_tenant_state(conv.user_id) do
-      {:ok, dek, inference_creds} ->
+      {:ok, dek, own_creds} ->
+        {inference_source, inference_creds} = SpriteEnv.select_inference(agent, own_creds)
         bindings = Egress.bindings(conv.user_id)
 
         {merged, bindings, connection_keys} =
@@ -709,6 +713,8 @@ defmodule Fountain.Conversations.ConversationServer do
               runtime_session_id: conv.runtime_session_id,
               tenant_key: dek,
               inference_credentials: inference_creds,
+              inference_source: inference_source,
+              inference_model: agent && agent.model,
               env_credentials: env_creds,
               brokered: brokered,
               broker_bindings: bindings,
@@ -1589,7 +1595,7 @@ defmodule Fountain.Conversations.ConversationServer do
       state = close_autonomous_turn(state, "superseded_by_prompt")
       conv = Conversations._unsafe_get_conversation!(state.conversation_id)
 
-      with :ok <- TurnMachine.gate(conv.user_id),
+      with :ok <- TurnMachine.gate(conv.user_id, state.inference_source),
            :ok <- TurnMachine.capacity_gate(state.sandbox_id, conv) do
         agent = if conv.agent_id, do: Agents._unsafe_get_agent!(conv.agent_id)
         {:reply, :ok, kick_turn(state, prompt, agent, images)}
@@ -1748,7 +1754,7 @@ defmodule Fountain.Conversations.ConversationServer do
     else
       conv = Conversations._unsafe_get_conversation!(state.conversation_id)
 
-      case TurnMachine.gate(conv.user_id) do
+      case TurnMachine.gate(conv.user_id, state.inference_source) do
         :ok ->
           state = close_autonomous_turn(state, "superseded_by_prompt")
           agent = if conv.agent_id, do: Agents._unsafe_get_agent!(conv.agent_id)
@@ -1825,7 +1831,7 @@ defmodule Fountain.Conversations.ConversationServer do
   # No `cycle_end` came. Close the autonomous turn as completed — the updates
   # it collected are real — and say why.
   def handle_info({:autonomous_quiet, turn_id}, %{current_turn: %{id: turn_id}} = state) do
-    if autonomous_turn?(state) do
+    if TurnMachine.autonomous_turn?(state) do
       {:noreply,
        finish_acp_turn(state, "completed", %{"origin" => "quiet"}, %{
          origin: "autonomous",
@@ -2674,11 +2680,7 @@ defmodule Fountain.Conversations.ConversationServer do
   # server holds goes in, the next one comes back with the effects to apply,
   # in order. `ctx` is what the machine needs that is not the turn's own.
   defp drive_turn(state, payload, extra \\ []) do
-    ctx =
-      Map.new(
-        [autonomous?: autonomous_turn?(state), runtime_module: state.runtime_module] ++ extra
-      )
-
+    ctx = TurnMachine.ctx(state, extra)
     {turn, effects} = TurnMachine.handle(TurnMachine.from_state(state), payload, ctx)
     state = TurnMachine.into_state(state, turn)
 
@@ -2732,9 +2734,6 @@ defmodule Fountain.Conversations.ConversationServer do
 
   defp user_turn_running?(%{current_turn: %{origin: "autonomous"}}), do: false
   defp user_turn_running?(%{current_turn: turn}), do: not is_nil(turn)
-
-  defp autonomous_turn?(%{current_turn: %{origin: "autonomous"}}), do: true
-  defp autonomous_turn?(_state), do: false
 
   # This turn rides the open connection: no spawn, no handshake. `Peer.prompt/3`
   # reuses the session already open, so a background task keeps running and the
@@ -2795,7 +2794,7 @@ defmodule Fountain.Conversations.ConversationServer do
 
   defp drop_connection(state, why) do
     state =
-      if autonomous_turn?(state) do
+      if TurnMachine.autonomous_turn?(state) do
         finish_acp_turn(state, "completed", %{"origin" => "connection_closed"}, %{
           origin: "autonomous",
           cycle: "connection_closed"
@@ -2881,7 +2880,7 @@ defmodule Fountain.Conversations.ConversationServer do
   end
 
   defp close_autonomous_turn(state, why) do
-    if autonomous_turn?(state) do
+    if TurnMachine.autonomous_turn?(state) do
       finish_acp_turn(state, "completed", %{"origin" => why}, %{origin: "autonomous", cycle: why})
     else
       state

--- a/apps/fountain/lib/fountain/conversations/sprite_env.ex
+++ b/apps/fountain/lib/fountain/conversations/sprite_env.ex
@@ -32,6 +32,29 @@ defmodule Fountain.Conversations.SpriteEnv do
     end
   end
 
+  @doc """
+  Whose inference key this conversation runs on, and the credentials to run
+  it with (#1388, ADR 0038 decision 3). The agent may be nil (a conversation
+  with none, or one whose agent was deleted), which needs no credential.
+
+  `InferenceCredentials.select/2` is the rule; this is where a provision
+  applies it. The platform key comes back merged into the same map a tenant's
+  own key lives in, so everything downstream — the gate 3 broker split, the
+  runtime's `default_env/2`, the redaction register — is untouched by the
+  feature existing at all.
+
+  `:no_credential` keeps the behaviour that predates platform keys: the
+  conversation provisions anyway, and the provider's own auth failure lands
+  on the transcript rather than a refusal invented here.
+  """
+  @spec select_inference(map() | nil, map()) :: {:own | :platform, map()}
+  def select_inference(agent, own_creds) do
+    case InferenceCredentials.select(agent && agent.model, own_creds) do
+      {:ok, source, creds} -> {source, creds}
+      {:error, :no_credential} -> {:own, own_creds}
+    end
+  end
+
   # Env secrets first, vault overrides last — vault wins on key collision.
   # Same merged map feeds repositories[].secret_key resolution.
   @spec merge_secrets(Environment.t() | nil, Vault.t() | nil, binary()) :: %{

--- a/apps/fountain/lib/fountain/conversations/turn_machine.ex
+++ b/apps/fountain/lib/fountain/conversations/turn_machine.ex
@@ -49,13 +49,17 @@ defmodule Fountain.Conversations.TurnMachine do
   @typedoc """
   What the machine needs that is not the turn's own: `:autonomous?` (the
   connection family's predicate, read by the server), `:runtime_module`
-  (the OAuth clause is Claude-only) and `:oauth_switched?` (the server
-  swaps the env before the call; the machine words the message).
+  (the OAuth clause is Claude-only), `:oauth_switched?` (the server
+  swaps the env before the call; the machine words the message), and the
+  pair the usage stamp needs — `:inference` (`:own` | `:platform`, whose key
+  ran this turn, #1388) and `:model` (what it ran).
   """
   @type ctx :: %{
           optional(:autonomous?) => boolean(),
           optional(:runtime_module) => module(),
-          optional(:oauth_switched?) => boolean()
+          optional(:oauth_switched?) => boolean(),
+          optional(:inference) => :own | :platform | nil,
+          optional(:model) => String.t() | nil
         }
 
   @type effect ::
@@ -112,6 +116,35 @@ defmodule Fountain.Conversations.TurnMachine do
   end
 
   # ── the machine ───────────────────────────────────────────────────────────
+
+  @doc """
+  The `ctx/0` for a report, from the server's state plus whatever the call
+  site adds (`:oauth_switched?` is the only one).
+
+  Here rather than at the call site because every key of it is the machine's
+  own vocabulary, and the server's job is to hold the state, not to know
+  which parts of it the machine reads.
+  """
+  @spec ctx(map(), keyword()) :: ctx()
+  def ctx(state, extra \\ []) do
+    Map.new(
+      [
+        autonomous?: autonomous_turn?(state),
+        runtime_module: state.runtime_module,
+        inference: state.inference_source,
+        model: state.inference_model
+      ] ++ extra
+    )
+  end
+
+  @doc """
+  Whether the running turn is a background cycle the agent narrated out of
+  turn (#817) rather than a prompt somebody sent. Over the server's state,
+  which is where the running turn lives.
+  """
+  @spec autonomous_turn?(map()) :: boolean()
+  def autonomous_turn?(%{current_turn: %{origin: "autonomous"}}), do: true
+  def autonomous_turn?(_state), do: false
 
   @doc "One peer report: the next turn and the effects the server applies."
   @spec handle(t(), payload(), ctx()) :: {t(), [effect()]}
@@ -252,9 +285,9 @@ defmodule Fountain.Conversations.TurnMachine do
   # `usage` is the turn's end-of-turn token figure (#827), recorded once here
   # — the response is the only place the runtime reports it — before the turn
   # row is closed. nil records nothing.
-  def handle(%__MODULE__{} = turn, {:done, stop_reason, usage}, _ctx) do
+  def handle(%__MODULE__{} = turn, {:done, stop_reason, usage}, ctx) do
     status = if stop_reason in ["refusal", "cancelled"], do: "failed", else: "completed"
-    record_usage(turn, usage)
+    record_usage(turn, with_inference(usage, ctx))
 
     {turn,
      [
@@ -480,6 +513,47 @@ defmodule Fountain.Conversations.TurnMachine do
   # a previous BEAM lifetime).
   def maybe_emit_first_output(%__MODULE__{} = turn), do: turn
 
+  @doc """
+  The usage figure with the turn's inference source on it (#1388).
+
+  Two keys beside the token counts: `"inference"` — `"platform"` when
+  Fountain's key ran the turn, `"own"` when the tenant's did — and, on a
+  platform turn, `"model"`, which is what `Workers.CreditPricer` prices
+  against the rate card.
+
+  **Only stamped on a deployment that holds a platform key at all.** With
+  none configured there is no question to answer, and an unstamped map is
+  byte-for-byte the map every turn has always carried, which is what keeps a
+  self-hosted install (and the tests that assert on it) unchanged.
+
+  The `"model"` key is deliberately absent on an `"own"` turn: nothing prices
+  it, so recording it would put a configuration detail in a column that
+  exists to hold token counts.
+  """
+  @spec with_inference(map() | nil, ctx()) :: map() | nil
+  def with_inference(usage, ctx) when is_map(usage) do
+    case Map.get(ctx, :inference) do
+      source when source in [:own, :platform] ->
+        if Fountain.PlatformInference.enabled?() do
+          usage
+          |> Map.put("inference", Atom.to_string(source))
+          |> put_model(source, Map.get(ctx, :model))
+        else
+          usage
+        end
+
+      _ ->
+        usage
+    end
+  end
+
+  def with_inference(usage, _ctx), do: usage
+
+  defp put_model(usage, :platform, model) when is_binary(model),
+    do: Map.put(usage, "model", model)
+
+  defp put_model(usage, _source, _model), do: usage
+
   @spec record_usage(t(), map() | nil) :: :ok
   def record_usage(%__MODULE__{row: %{} = row}, %{} = usage) do
     case Conversations._unsafe_record_turn_usage(row, usage) do
@@ -571,10 +645,19 @@ defmodule Fountain.Conversations.TurnMachine do
   # started under, and each turn resets the idle clock, so a balance spent to
   # zero otherwise bought up to the 24h max lifetime of continued service per
   # live sandbox (#313). Suspension is the same shape.
-  @spec gate(String.t()) :: :ok | {:error, term()}
-  def gate(user_id) do
-    with :ok <- Fountain.Accounts.check_not_suspended(user_id) do
-      Fountain.Billing.check_spend(user_id)
+  #
+  # `inference` is the conversation's inference source (#1388). On a turn
+  # running on a platform key the deployment's daily ceiling is the third
+  # gate: a live server outlives the ceiling it started under exactly as it
+  # outlives the balance, so the same backstop shape applies. A turn on the
+  # tenant's own key is never touched by it.
+  @spec gate(String.t(), :own | :platform | nil) :: :ok | {:error, term()}
+  def gate(user_id, inference \\ nil) do
+    with :ok <- Fountain.Accounts.check_not_suspended(user_id),
+         :ok <- Fountain.Billing.check_spend(user_id) do
+      if inference == :platform,
+        do: Fountain.PlatformInference.check_ceiling(),
+        else: :ok
     end
   end
 

--- a/apps/fountain/lib/fountain/inference_credentials.ex
+++ b/apps/fountain/lib/fountain/inference_credentials.ex
@@ -182,6 +182,74 @@ defmodule Fountain.InferenceCredentials do
   end
 
   @doc """
+  Whether the tenant has a credential of their own that would run this model.
+
+  True also when the model's provider needs none at all (a local model, a
+  gateway): there is nothing missing, which is the same answer
+  `missing_for_model/2` gives.
+  """
+  @spec has_own?(binary(), String.t() | nil) :: boolean()
+  def has_own?(user_id, model) when is_binary(user_id),
+    do: is_nil(missing_for_model(user_id, model))
+
+  @doc """
+  Which credential a conversation on `model` runs on (#1388, ADR 0038
+  decision 3). **This is the whole selection rule**, and it is one function so
+  that the two paths a credential reaches a sandbox by cannot disagree.
+
+    * `{:ok, :own, creds}` — the tenant has a credential the model's provider
+      accepts, or the provider needs none. `creds` is what came in, untouched.
+    * `{:ok, :platform, creds}` — the tenant has none and this deployment
+      holds a platform key for that provider. `creds` is what came in with the
+      platform key merged in under the provider's credential, so everything
+      downstream — the broker split, the runtime's `default_env/2`, the
+      redaction register — treats it as exactly what it is: a credential for
+      that provider.
+    * `{:error, :no_credential}` — neither. The caller keeps today's
+      behaviour, which is to provision anyway and let the runtime report the
+      provider's own auth failure on the transcript.
+
+  **The tenant's credential always wins**, and there is no per-agent toggle:
+  a tenant who has supplied a key is never quietly run on Fountain's, whatever
+  their balance says. The tenant's other credentials survive the merge, so an
+  agent with an `openai` model on an account that holds only an Anthropic key
+  still exports that key for whatever else the sandbox does with it.
+
+  `own_creds` is the decrypted map `decrypted_for_user/2` returns, so this is
+  a pure function over it: no query, no decryption, and testable without a
+  tenant.
+  """
+  @spec select(String.t() | nil, %{atom() => String.t()}) ::
+          {:ok, :own, %{atom() => String.t()}}
+          | {:ok, :platform, %{atom() => String.t()}}
+          | {:error, :no_credential}
+  def select(model, own_creds) when is_map(own_creds) do
+    provider = Managoat.Runtimes.Model.provider(model)
+    accepted = credentials_for_provider(provider)
+
+    cond do
+      accepted == [] ->
+        {:ok, :own, own_creds}
+
+      Enum.any?(accepted, &present?(own_creds, &1)) ->
+        {:ok, :own, own_creds}
+
+      true ->
+        case Fountain.PlatformInference.key_for(provider) do
+          {:ok, credential, key} -> {:ok, :platform, Map.put(own_creds, credential, key)}
+          :none -> {:error, :no_credential}
+        end
+    end
+  end
+
+  defp present?(creds, credential) do
+    case Map.get(creds, credential) do
+      value when is_binary(value) and value != "" -> true
+      _ -> false
+    end
+  end
+
+  @doc """
   Returns a map `%{provider => boolean}` of which providers the user has set.
   Cheap — does not decrypt; just checks for non-nil ciphertext.
   """

--- a/apps/fountain/lib/fountain/platform_inference.ex
+++ b/apps/fountain/lib/fountain/platform_inference.ex
@@ -1,0 +1,162 @@
+defmodule Fountain.PlatformInference do
+  @moduledoc """
+  The deployment's own inference keys, and the ceiling on what they may spend
+  in a day (#1388, ADR 0038 decision 3, amending ADR 0008).
+
+  Fountain holds a set of inference keys and runs a tenant's agent on one when
+  the tenant has none of their own. The tenant's credential always wins; a
+  deployment that configures no platform key behaves exactly as it did before
+  this module existed, which is what makes it opt-in for a self-hoster.
+
+  ## What is here
+
+    * `enabled?/0` and `key_for/1` — the keys, from
+      `PLATFORM_ANTHROPIC_API_KEY`, `PLATFORM_OPENAI_API_KEY` and
+      `PLATFORM_GEMINI_API_KEY`. Blank is off, per provider.
+    * `gate/2` — the door check: may this user's next conversation on this
+      model start? `:ok` unless it would run on a platform key and the
+      deployment has spent its day.
+    * `check_ceiling/0` — the same ceiling without the "would it even use the
+      platform key" question, for the per-turn backstop in
+      `Conversations.TurnMachine.gate/2`, which already knows the answer.
+
+  The *selection* rule lives in `Fountain.InferenceCredentials.select/2`, one
+  function, because it is a statement about credentials rather than about
+  money.
+
+  ## The ceiling is a circuit breaker, not a quota
+
+  `PLATFORM_INFERENCE_DAILY_CENTS` (default 5000, $50) bounds platform
+  inference spend for the **whole deployment**, every tenant together, over a
+  UTC day. It exists so one bad day cannot cost more than a number somebody
+  wrote down. Hitting it is a 503, like `:fleet_full` — this is Fountain's
+  limit, not the tenant's balance, and there is nothing they can buy to clear
+  it (`FountainWeb.FallbackController`).
+
+  Two properties worth knowing before trusting it:
+
+    * **It is measured from the ledger**, so it lags `Workers.CreditPricer` by
+      at most one tick. It bounds the day, not the minute.
+    * **It needs `CREDITS_ENABLED=true`**, because that is what writes the
+      ledger rows it reads. With credits off nothing is priced at all
+      (ADR 0031), so nothing is counted and the ceiling never trips. A
+      deployment that sets a platform key with credits off is paying its own
+      inference bill knowingly and has no brake here.
+  """
+
+  require Logger
+
+  @providers %{
+    "anthropic" => {:anthropic_api_key, :platform_anthropic_api_key},
+    "openai" => {:openai_api_key, :platform_openai_api_key},
+    "google" => {:gemini_api_key, :platform_gemini_api_key}
+  }
+
+  @doc "Whether this deployment holds a platform key for any provider at all."
+  @spec enabled?() :: boolean()
+  def enabled?, do: Enum.any?(@providers, fn {provider, _} -> key_for(provider) != :none end)
+
+  @doc """
+  The providers this deployment holds a key for, in `Managoat.Runtimes.Model`
+  order. For the admin surfaces and the docs test; never a gate.
+  """
+  @spec configured_providers() :: [String.t()]
+  def configured_providers do
+    Enum.filter(Managoat.Runtimes.Model.providers(), &(key_for(&1) != :none))
+  end
+
+  @doc """
+  The platform key for a provider: `{:ok, credential, key}` — the credential
+  atom `Fountain.InferenceCredentials` uses for it, so the value drops into
+  the same map a tenant's own key lives in — or `:none`.
+
+  A blank value is `:none`, not an empty key: an unset variable and a variable
+  set to `""` are the same statement, and the second is what a Helm chart
+  with no value produces.
+  """
+  @spec key_for(String.t() | nil) :: {:ok, atom(), String.t()} | :none
+  def key_for(provider) when is_binary(provider) do
+    case Map.get(@providers, provider) do
+      nil ->
+        :none
+
+      {credential, config_key} ->
+        case Application.get_env(:fountain, config_key) do
+          key when is_binary(key) and key != "" -> {:ok, credential, key}
+          _ -> :none
+        end
+    end
+  end
+
+  def key_for(_provider), do: :none
+
+  @doc """
+  The daily ceiling in cents (`PLATFORM_INFERENCE_DAILY_CENTS`, default 5000).
+  """
+  @spec daily_ceiling_cents() :: non_neg_integer()
+  def daily_ceiling_cents do
+    case Application.get_env(:fountain, :platform_inference_daily_cents) do
+      cents when is_integer(cents) and cents >= 0 -> cents
+      _ -> 5_000
+    end
+  end
+
+  @doc """
+  The door check, at every place a conversation begins: `:ok`, or
+  `{:error, :platform_inference_unavailable}`.
+
+  Three questions, cheapest first, so a deployment with no platform key runs
+  no query at all:
+
+    1. does this deployment hold a key for the model's provider?
+    2. would this user actually take it — that is, do they have none of their
+       own for that provider?
+    3. has the deployment spent its day?
+
+  Only a "yes" to all three refuses.
+  """
+  @spec gate(binary(), String.t() | nil) :: :ok | {:error, :platform_inference_unavailable}
+  def gate(user_id, model) when is_binary(user_id) do
+    provider = Managoat.Runtimes.Model.provider(model)
+
+    if key_for(provider) != :none and not Fountain.InferenceCredentials.has_own?(user_id, model) do
+      check_ceiling()
+    else
+      :ok
+    end
+  end
+
+  @doc """
+  The ceiling on its own, for a caller that already knows the turn runs on a
+  platform key.
+
+  `:ok` when credits are off (nothing is counted), when the ceiling is zero
+  (which reads as "unbounded" the way `SANDBOX_CAP_CEILING` does not — see
+  below), or when the day's spend is under it.
+  """
+  @spec check_ceiling() :: :ok | {:error, :platform_inference_unavailable}
+  def check_ceiling do
+    ceiling = daily_ceiling_cents()
+
+    # Zero is "no platform inference today", not "unbounded": the variable
+    # exists to bound spend, so the degenerate value has to bound it hardest.
+    # An operator who wants the feature off unsets the keys.
+    spent = Fountain.Billing.platform_inference_spend_today()
+
+    cond do
+      is_nil(spent) ->
+        :ok
+
+      spent < ceiling ->
+        :ok
+
+      true ->
+        Logger.warning(
+          "platform inference: daily ceiling reached (#{spent} of #{ceiling} cents); " <>
+            "refusing conversations that would run on a platform key until UTC midnight"
+        )
+
+        {:error, :platform_inference_unavailable}
+    end
+  end
+end

--- a/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
@@ -189,6 +189,24 @@ defmodule FountainWeb.FallbackController do
     })
   end
 
+  # The deployment has spent its platform inference budget for the day
+  # (#1388). 503 rather than 402, for the same reason as `:fleet_full`: this
+  # is Fountain's own ceiling, not the caller's balance, and there is nothing
+  # they can buy to clear it. Adding an inference credential does clear it —
+  # a tenant's own key never touches this ceiling — so the message says so.
+  def call(conn, {:error, :platform_inference_unavailable}) do
+    conn
+    |> put_resp_header("retry-after", "3600")
+    |> put_status(:service_unavailable)
+    |> json(%{
+      error: "platform_inference_unavailable",
+      message:
+        "Fountain's shared inference budget for today is spent. Add your own " <>
+          "inference credential to run now, or try again tomorrow.",
+      credentials_url: "/account/inference-credentials"
+    })
+  end
+
   # The ConversationServer did not answer within the call timeout — almost
   # always a server still inside handle_continue(:provision), whose blocked
   # mailbox makes every call wait the full 30s and exit (#412). 503 with

--- a/apps/fountain/test/fountain/conversations/conversation_server_platform_inference_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_platform_inference_test.exs
@@ -1,0 +1,191 @@
+defmodule Fountain.Conversations.ConversationServerPlatformInferenceTest do
+  # The platform key through a real ConversationServer (#1388): that it is
+  # selected only when the tenant has none, that it takes the *same* two
+  # routes a tenant's own key takes (ADR 0019 gate 3 when brokered, the
+  # sandbox env when not), and that the turn it ran is marked so the pricer
+  # can find it.
+  use Fountain.ConversationServerCase
+
+  alias Fountain.Conversations.TurnMachine
+
+  @session %{vault: "c-test", token: "av_sess_conv", expires_at: nil}
+  @platform_key "sk-ant-platform-key"
+
+  setup do
+    user = insert_verified_user()
+    agent = insert_agent(user_id: user.id, runtime: "claude", model: "anthropic/claude-opus-5")
+
+    previous =
+      for key <- [
+            :broker_url,
+            :broker_token,
+            :broker_proxy_url,
+            :broker_tenants,
+            :platform_anthropic_api_key
+          ],
+          do: {key, Application.get_env(:fountain, key)}
+
+    on_exit(fn ->
+      for {key, value} <- previous do
+        if is_nil(value),
+          do: Application.delete_env(:fountain, key),
+          else: Application.put_env(:fountain, key, value)
+      end
+    end)
+
+    # The deployment holds a key. The tenant holds nothing — that is
+    # `ConversationServerCase`'s own default stub of `decrypted_for_user/2`,
+    # which the two tests about a tenant's own key override.
+    Application.put_env(:fountain, :platform_anthropic_api_key, @platform_key)
+
+    {:ok, user: user, agent: agent}
+  end
+
+  describe "the non-brokered path" do
+    test "the platform key is what the runtime is handed, exactly as a tenant's own is", %{
+      user: user,
+      agent: agent
+    } do
+      conv = insert_conversation(user_id: user.id, agent: agent)
+
+      stub_happy_sprite()
+      _ref = stub_turn_boundary()
+      reject(Fountain.Broker, :prepare, 4)
+
+      {pid, _mon, :alive} = start_server(conv, initial_prompt: "hello")
+      on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+
+      # The harness runtime ignores credentials, so the assertion is on what
+      # the server hands `default_env/2` plus what the real runtime makes of
+      # it — the same two halves the broker test checks.
+      state = :sys.get_state(pid)
+      assert state.env_credentials == %{anthropic_api_key: @platform_key}
+      assert state.brokered == %{}
+
+      assert Managoat.Runtimes.Claude.default_env(nil, state.env_credentials) ==
+               [{"ANTHROPIC_API_KEY", @platform_key}]
+    end
+
+    test "a tenant with their own key never sees the platform one", %{
+      user: user,
+      agent: agent
+    } do
+      conv = insert_conversation(user_id: user.id, agent: agent)
+
+      stub_happy_sprite()
+      _ref = stub_turn_boundary()
+
+      # After `stub_happy_sprite/0`, which sets the case's own default of "no
+      # credentials at all" — a stub set before it is overwritten by it.
+      Mimic.stub(Fountain.InferenceCredentials, :decrypted_for_user, fn _u, _k ->
+        {:ok, %{anthropic_api_key: "sk-ant-tenant-key"}}
+      end)
+
+      {pid, _mon, :alive} = start_server(conv, initial_prompt: "hello")
+      on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+
+      state = :sys.get_state(pid)
+      assert state.inference_source == :own
+      assert state.env_credentials == %{anthropic_api_key: "sk-ant-tenant-key"}
+    end
+  end
+
+  describe "the brokered path (ADR 0019 gate 3)" do
+    setup %{user: user} do
+      Application.put_env(:fountain, :broker_url, "http://broker.test:14321")
+      Application.put_env(:fountain, :broker_token, "av_admin")
+      Application.put_env(:fountain, :broker_proxy_url, "http://broker.test:14322")
+      Application.put_env(:fountain, :broker_tenants, [user.id])
+      :ok
+    end
+
+    test "the platform key goes to the broker and never into the sandbox", %{
+      user: user,
+      agent: agent
+    } do
+      conv = insert_conversation(user_id: user.id, agent: agent)
+      test = self()
+
+      stub_happy_sprite()
+      _ref = stub_turn_boundary()
+      stub(Fountain.Broker, :preflight, fn -> :ok end)
+      stub(Fountain.Broker, :ca_pem, fn -> {:ok, "PEM"} end)
+
+      stub(Fountain.Broker, :prepare, fn _c, brokered, bindings, _opts ->
+        send(test, {:prepared, brokered, bindings})
+        {:ok, @session}
+      end)
+
+      {pid, _mon, :alive} = start_server(conv, initial_prompt: "hello")
+      on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+
+      # Same route as a tenant's own key: the value reaches the broker with
+      # an implicit substitute binding to the provider's host.
+      assert_receive {:prepared, brokered, bindings}, 2_000
+      assert brokered["ANTHROPIC_API_KEY"] == @platform_key
+
+      assert [%{host: "api.anthropic.com", auth_type: "substitute"}] =
+               bindings["ANTHROPIC_API_KEY"]
+
+      assert_receive {:spawned, _cmd, _args, opts}, 2_000
+      spawn_env = Keyword.fetch!(opts, :env)
+      refute Enum.any?(spawn_env, fn {_, v} -> v == @platform_key end)
+    end
+  end
+
+  describe "the mark on the turn" do
+    test "the server records which key it selected", %{user: user, agent: agent} do
+      conv = insert_conversation(user_id: user.id, agent: agent)
+
+      stub_happy_sprite()
+      _ref = stub_turn_boundary()
+
+      {pid, _mon, :alive} = start_server(conv)
+      on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+
+      state = :sys.get_state(pid)
+      assert state.inference_source == :platform
+      assert state.inference_model == "anthropic/claude-opus-5"
+      assert state.env_credentials.anthropic_api_key == @platform_key
+    end
+
+    test "usage says which key ran the turn, and names the model on a platform turn" do
+      ctx = %{inference: :platform, model: "anthropic/claude-opus-5"}
+
+      assert TurnMachine.with_inference(%{"input" => 5, "output" => 3}, ctx) ==
+               %{
+                 "input" => 5,
+                 "output" => 3,
+                 "inference" => "platform",
+                 "model" => "anthropic/claude-opus-5"
+               }
+
+      assert TurnMachine.with_inference(%{"input" => 5}, %{ctx | inference: :own}) ==
+               %{"input" => 5, "inference" => "own"}
+
+      assert TurnMachine.with_inference(nil, ctx) == nil
+    end
+
+    test "with no platform key configured the usage map is untouched" do
+      Application.delete_env(:fountain, :platform_anthropic_api_key)
+
+      ctx = %{inference: :own, model: "anthropic/claude-opus-5"}
+      assert TurnMachine.with_inference(%{"input" => 5}, ctx) == %{"input" => 5}
+    end
+  end
+
+  defp stub_turn_boundary do
+    test = self()
+    ref = make_ref()
+
+    Mimic.stub(Managoat.Sandbox.Sprites, :spawn, fn _h, cmd, args, opts ->
+      send(test, {:spawned, cmd, args, opts})
+      {:ok, %Managoat.Sandbox.Command{provider: :sprites, ref: ref}}
+    end)
+
+    Mimic.stub(Managoat.Sandbox.Sprites, :write_stdin, fn _c, _data -> :ok end)
+    Mimic.stub(Managoat.Sandbox.Sprites, :close_stdin, fn _c -> :ok end)
+    Mimic.stub(Managoat.Sandbox.Sprites, :stop_command, fn _c -> :ok end)
+    ref
+  end
+end

--- a/apps/fountain/test/fountain/conversations/conversation_server_size_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_size_test.exs
@@ -15,7 +15,7 @@ defmodule Fountain.Conversations.ConversationServerSizeTest do
   accepts is downward. Lower it when you move something out; never raise it.
   """
 
-  @pin 3049
+  @pin 3048
 
   @server "apps/fountain/lib/fountain/conversations/conversation_server.ex"
 

--- a/apps/fountain/test/fountain/platform_inference_test.exs
+++ b/apps/fountain/test/fountain/platform_inference_test.exs
@@ -1,0 +1,193 @@
+defmodule Fountain.PlatformInferenceTest do
+  @moduledoc """
+  The platform keys, the selection rule and the daily ceiling (#1388).
+
+  `async: false` throughout: platform keys and the ceiling live in the global
+  application environment, and an async module that writes it races every
+  other module that reads it (#1214).
+  """
+
+  use Fountain.DataCase, async: false
+
+  alias Fountain.Credits
+  alias Fountain.InferenceCredentials
+  alias Fountain.PlatformInference
+
+  setup do
+    original =
+      for key <- [
+            :platform_anthropic_api_key,
+            :platform_openai_api_key,
+            :platform_gemini_api_key,
+            :platform_inference_daily_cents
+          ],
+          do: {key, Application.get_env(:fountain, key)}
+
+    on_exit(fn ->
+      Enum.each(original, fn
+        {key, nil} -> Application.delete_env(:fountain, key)
+        {key, value} -> Application.put_env(:fountain, key, value)
+      end)
+    end)
+
+    :ok
+  end
+
+  defp with_platform_key(provider \\ :platform_anthropic_api_key, key \\ "sk-platform") do
+    Application.put_env(:fountain, provider, key)
+  end
+
+  describe "key_for/1 and enabled?/0" do
+    test "off with nothing configured, and a blank value is still off" do
+      refute PlatformInference.enabled?()
+      assert PlatformInference.key_for("anthropic") == :none
+
+      Application.put_env(:fountain, :platform_anthropic_api_key, "")
+      refute PlatformInference.enabled?()
+      assert PlatformInference.key_for("anthropic") == :none
+    end
+
+    test "a configured key comes back under the credential the tenant's own uses" do
+      with_platform_key()
+
+      assert PlatformInference.enabled?()
+      assert PlatformInference.key_for("anthropic") == {:ok, :anthropic_api_key, "sk-platform"}
+      assert PlatformInference.key_for("openai") == :none
+      assert PlatformInference.configured_providers() == ["anthropic"]
+    end
+
+    test "a provider Fountain cannot export a credential for is never platform-served" do
+      with_platform_key()
+      assert PlatformInference.key_for("ollama") == :none
+      assert PlatformInference.key_for(nil) == :none
+    end
+  end
+
+  describe "InferenceCredentials.select/2" do
+    test "with no platform key an account with nothing gets the refusal, not a key" do
+      assert InferenceCredentials.select("anthropic/claude-opus-5", %{}) ==
+               {:error, :no_credential}
+    end
+
+    test "the tenant's own credential wins over a configured platform key" do
+      with_platform_key()
+      own = %{anthropic_api_key: "sk-tenant"}
+
+      assert {:ok, :own, ^own} = InferenceCredentials.select("anthropic/claude-opus-5", own)
+    end
+
+    test "an OAuth token is a credential for anthropic and wins too" do
+      with_platform_key()
+      own = %{claude_code_oauth_token: "oauth"}
+
+      assert {:ok, :own, ^own} = InferenceCredentials.select("anthropic/claude-opus-5", own)
+    end
+
+    test "the platform key is merged in, leaving the tenant's other credentials alone" do
+      with_platform_key()
+      own = %{openai_api_key: "sk-tenant-openai"}
+
+      assert {:ok, :platform, creds} = InferenceCredentials.select("anthropic/claude-opus-5", own)
+      assert creds.anthropic_api_key == "sk-platform"
+      assert creds.openai_api_key == "sk-tenant-openai"
+    end
+
+    test "a provider with no platform key configured is still refused" do
+      with_platform_key()
+
+      assert InferenceCredentials.select("openai/gpt-5.5", %{}) == {:error, :no_credential}
+    end
+
+    test "a provider that needs no credential is :own, whatever is configured" do
+      with_platform_key()
+
+      assert {:ok, :own, %{}} = InferenceCredentials.select("ollama/llama3", %{})
+      assert {:ok, :own, %{}} = InferenceCredentials.select(nil, %{})
+    end
+
+    test "an empty-string credential is not a credential" do
+      with_platform_key()
+
+      assert {:ok, :platform, creds} =
+               InferenceCredentials.select("anthropic/claude-opus-5", %{anthropic_api_key: ""})
+
+      assert creds.anthropic_api_key == "sk-platform"
+    end
+  end
+
+  describe "gate/2" do
+    setup do
+      %{user: insert_verified_user()}
+    end
+
+    test "with no platform key nothing is gated", %{user: user} do
+      assert PlatformInference.gate(user.id, "anthropic/claude-opus-5") == :ok
+    end
+
+    test "under the ceiling a platform account passes", %{user: user} do
+      with_platform_key()
+      assert PlatformInference.gate(user.id, "anthropic/claude-opus-5") == :ok
+    end
+
+    test "over the ceiling a platform account is refused", %{user: user} do
+      with_platform_key()
+      Application.put_env(:fountain, :platform_inference_daily_cents, 10)
+      burn_inference(user, 10)
+
+      assert PlatformInference.gate(user.id, "anthropic/claude-opus-5") ==
+               {:error, :platform_inference_unavailable}
+    end
+
+    test "a tenant with their own key is never touched by the ceiling", %{user: user} do
+      with_platform_key()
+      Application.put_env(:fountain, :platform_inference_daily_cents, 0)
+      burn_inference(user, 500)
+
+      {:ok, dek} = Fountain.Crypto.load_tenant_key(user.id)
+      {:ok, _} = InferenceCredentials.put_credential(user.id, dek, :anthropic_api_key, "sk-mine")
+
+      assert PlatformInference.gate(user.id, "anthropic/claude-opus-5") == :ok
+      # And the same account without the key would have been refused.
+      assert PlatformInference.gate(insert_verified_user().id, "anthropic/claude-opus-5") ==
+               {:error, :platform_inference_unavailable}
+    end
+
+    test "yesterday's spend does not count against today", %{user: user} do
+      with_platform_key()
+      Application.put_env(:fountain, :platform_inference_daily_cents, 10)
+      entry = burn_inference(user, 500)
+
+      entry
+      |> Ecto.Changeset.change(
+        inserted_at: DateTime.utc_now() |> DateTime.add(-2, :day) |> DateTime.truncate(:second)
+      )
+      |> Repo.update!()
+
+      assert PlatformInference.gate(user.id, "anthropic/claude-opus-5") == :ok
+    end
+  end
+
+  describe "check_ceiling/0" do
+    test "a zero ceiling refuses rather than reading as unbounded" do
+      Application.put_env(:fountain, :platform_inference_daily_cents, 0)
+
+      assert PlatformInference.check_ceiling() ==
+               {:error, :platform_inference_unavailable}
+    end
+
+    test "the default ceiling is $50" do
+      Application.delete_env(:fountain, :platform_inference_daily_cents)
+      assert PlatformInference.daily_ceiling_cents() == 5_000
+    end
+  end
+
+  defp burn_inference(user, cents) do
+    {:ok, entry} =
+      Credits.debit(user.id, cents, "burn_inference",
+        idempotency_key: "burn_inference:test:#{System.unique_integer([:positive])}",
+        actor: "system:test"
+      )
+
+    entry
+  end
+end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -969,6 +969,93 @@ config :fountain, :credits,
   sms_message_cents: credit_cents.("CREDIT_SMS_MESSAGE_CENTS"),
   packs_cents: credit_packs
 
+# Platform inference keys (#1388, ADR 0038 decision 3, amending ADR 0008).
+#
+# Fountain runs a tenant's agent on one of these when the tenant has no
+# credential of their own for the model's provider, and meters the tokens
+# against their credit balance. The tenant's own credential always wins.
+#
+# **Blank means off, per provider.** A deployment that sets none of these
+# behaves exactly as it did before the feature existed: bring-your-own only.
+# That is what makes it opt-in for a self-hoster, who would otherwise be
+# paying a model provider for their users without having said so.
+#
+# Anthropic first: the default agent every verified account gets (#1389) runs
+# on the claude runtime, so this is the one key that makes the four-step path
+# — verify, copy, run, reply — work with nothing else configured.
+config :fountain,
+  platform_anthropic_api_key: System.get_env("PLATFORM_ANTHROPIC_API_KEY"),
+  platform_openai_api_key: System.get_env("PLATFORM_OPENAI_API_KEY"),
+  platform_gemini_api_key: System.get_env("PLATFORM_GEMINI_API_KEY")
+
+# The circuit breaker: the most this deployment's platform keys may cost in a
+# UTC day, across every tenant together. A log line and a 503 when it is hit
+# (`FountainWeb.FallbackController`), so one bad day cannot cost more than the
+# number written here. It is measured from the `burn_inference` ledger rows,
+# so it needs CREDITS_ENABLED=true and it lags the pricer's tick: it bounds
+# the day, not the minute.
+config :fountain,
+       :platform_inference_daily_cents,
+       whole_number.("PLATFORM_INFERENCE_DAILY_CENTS", 5_000)
+
+# Per-model inference rates, overriding the compiled card in
+# `Fountain.Credits.InferenceRates`. One entry per comma:
+#
+#   PLATFORM_INFERENCE_RATES="anthropic/claude-opus-5:500:2500:50:625,openai/*:500:3000:50:500"
+#
+# Five colon-separated fields: `provider/model_id` (or `provider/*` for that
+# provider's fallback), then input, output, cached-read and cached-write
+# prices **in cents per million tokens**, which is the unit every provider
+# publishes in. Decimals are allowed and are the point — OpenAI's cached
+# input for gpt-5.3-codex is 17.5 cents per million tokens.
+#
+# The compiled card is list price with **no markup, a 1.0x margin**, and that
+# is a decision (ADR 0038, noted on 0030 and 0031): Fountain's margin is
+# sandbox time (CREDIT_TURN_HOUR_CENTS), and marking inference up would make
+# the opening credit buy less of the one thing it was granted to buy. This
+# variable exists so a price change does not need a deploy, not so a
+# deployment can quietly add a margin — though a self-hoster reselling
+# inference is welcome to.
+inference_rates =
+  case System.get_env("PLATFORM_INFERENCE_RATES") do
+    value when value in [nil, ""] ->
+      %{}
+
+    value ->
+      value
+      |> String.split(",", trim: true)
+      |> Map.new(fn entry ->
+        cents_per_mtok = fn field ->
+          case Float.parse(String.trim(field)) do
+            {n, ""} when n >= 0 ->
+              # Cents per billion tokens: the unit the rate card holds, so a
+              # fraction of a cent per million tokens is still an integer.
+              round(n * 1_000)
+
+            _ ->
+              raise "PLATFORM_INFERENCE_RATES: #{inspect(field)} is not a price in cents per million tokens"
+          end
+        end
+
+        case String.split(String.trim(entry), ":") do
+          [model, input, output, cache_read, cache_write] when model != "" ->
+            {model,
+             %{
+               input: cents_per_mtok.(input),
+               output: cents_per_mtok.(output),
+               cache_read: cents_per_mtok.(cache_read),
+               cache_write: cents_per_mtok.(cache_write)
+             }}
+
+          _ ->
+            raise "PLATFORM_INFERENCE_RATES: #{inspect(entry)} is not " <>
+                    "provider/model:input:output:cache_read:cache_write"
+        end
+      end)
+  end
+
+config :fountain, :inference_rates, inference_rates
+
 # Mail delivery.
 #
 # With no adapter configured this used to silently fall back to

--- a/decisions/0008-byo-inference-credentials.md
+++ b/decisions/0008-byo-inference-credentials.md
@@ -12,7 +12,16 @@ generated: { by: human:jhgaylor, at: 2026-05-10T05:00:20-04:00 }
 
 # 0008 — BYO inference credentials per tenant
 
-**Status:** Accepted — 2026-05-10.
+**Status:** Accepted — 2026-05-10. **Amended by
+[0038](0038-onboarding-first-reply.md)** (2026-09-02, built in #1388): the
+premise "Fountain holds no platform inference keys and pays nothing for
+inference" no longer holds. Fountain holds a set of platform keys and runs a
+tenant's agent on one when that tenant has none of their own for the model's
+provider, metering the tokens against their credit balance at provider list
+price. Everything else here stands unchanged — the per-tenant DEK, the
+encrypted-at-rest columns, and the rule that **the tenant's own credential
+always wins**. A deployment that configures no platform key behaves exactly as
+this ADR describes.
 
 ## Context
 

--- a/decisions/0030-prepaid-credits.md
+++ b/decisions/0030-prepaid-credits.md
@@ -36,6 +36,12 @@ once the hosted deployment had crossed over (#1121, #1116).
 **Not built, on purpose:** auto top-up (#1086 phase 6); #1038 steps 3
 onward (sandbox size, storage, per-provider cost basis).
 
+
+**Inference is a priced cost in this ledger since #1388**
+([0038](0038-onboarding-first-reply.md)): a turn that ran on a Fountain
+platform key posts a `burn_inference` debit beside its `burn_turn`, priced
+from `turns.usage` at the provider's list price with no markup.
+
 ## Context
 
 ADR 0026 shipped capacity tiers and deliberately left the usage half open:

--- a/decisions/0031-credits-are-the-product.md
+++ b/decisions/0031-credits-are-the-product.md
@@ -23,6 +23,16 @@ machinery, plan Checkout, the portal and `verify_plans` are gone, with the
 subscription columns left unread in Postgres for one release. Stripe holds
 no subscription and no price. Persistent-home rent (decision 7) is not built.
 
+
+**Inference is a priced cost in the ledger since #1388**
+([0038](0038-onboarding-first-reply.md)): a tenant with no inference
+credential of their own runs on a Fountain platform key and burns
+`burn_inference` for the tokens, at provider list price. The gate is
+unchanged — the balance, through `Billing.check_spend/1` — and the only new
+refusal is a per-deployment daily ceiling on platform inference, which is a
+503 like `:fleet_full` rather than a 402, because it is Fountain's limit and
+not the tenant's balance.
+
 ## Context
 
 ADR 0026 sold three tiers that differed on one axis, the concurrency cap,

--- a/decisions/0038-onboarding-first-reply.md
+++ b/decisions/0038-onboarding-first-reply.md
@@ -44,6 +44,7 @@ Not built: the default agent, the verified landing, the CLI commands and the
 field cleanup. `onboarding_completed_at` is still stamped by the dashboard
 checklist (#1390 moves the stamp to the seam
 `Fountain.Activation.capture_first_reply/2` marks).
+
 Amends [0008](0008-byo-inference-credentials.md): Fountain will hold platform
 inference keys. Leans on [0031](0031-credits-are-the-product.md) (the opening
 credit and the balance gate), [0030](0030-prepaid-credits.md) (the ledger),

--- a/decisions/0038-onboarding-first-reply.md
+++ b/decisions/0038-onboarding-first-reply.md
@@ -20,14 +20,30 @@ stale_after: 2026-11-02
 and measured) and #1393 (the field cleanup), all sub-issues of #1039. Each PR
 that builds one updates this block.
 
-**Built so far:** decision 2 (#1392). `Fountain.Activation` holds the
-definition, `Fountain.Funnel` counts it and measures verification to first
-reply, and `activation.first_reply` reaches PostHog from the turn-ending write.
-Nothing else described here is built: there is no platform inference key, no
-default agent, no verified landing, and `onboarding_completed_at` is still
-stamped by the dashboard checklist (#1390 moves the stamp to the seam
-`Fountain.Activation.capture_first_reply/2` marks).
+**Built so far:** decisions 2 (#1392) and 3 (#1388).
 
+Decision 2: `Fountain.Activation` holds the definition, `Fountain.Funnel`
+counts it and measures verification to first reply, and
+`activation.first_reply` reaches PostHog from the turn-ending write.
+
+Decision 3: `PLATFORM_ANTHROPIC_API_KEY` / `_OPENAI_` / `_GEMINI_` (blank is
+off, per provider), `Fountain.InferenceCredentials.select/2` as the one
+selection rule, a `burn_inference` debit per closed platform turn from
+`Fountain.Credits.InferenceRates` posted by `Workers.CreditPricer`, and
+`PLATFORM_INFERENCE_DAILY_CENTS` (default 5000) as a deployment-wide daily
+circuit breaker answering 503.
+
+**The price is pass-through at provider list, a 1.0x margin, no markup**
+(decided with Jake on 2026-09-02). Fountain's margin is sandbox time
+(`CREDIT_TURN_HOUR_CENTS`, [0031](0031-credits-are-the-product.md)). Marking
+inference up would make the opening credit buy less of the one thing it was
+granted to buy, which is the reply this ADR is about. A future decision may
+change that; a passing thought about margin should not.
+
+Not built: the default agent, the verified landing, the CLI commands and the
+field cleanup. `onboarding_completed_at` is still stamped by the dashboard
+checklist (#1390 moves the stamp to the seam
+`Fountain.Activation.capture_first_reply/2` marks).
 Amends [0008](0008-byo-inference-credentials.md): Fountain will hold platform
 inference keys. Leans on [0031](0031-credits-are-the-product.md) (the opening
 credit and the balance gate), [0030](0030-prepaid-credits.md) (the ledger),

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -173,6 +173,67 @@ and message counts, and it shows `—` in each money column. A rate you do not
 set stays `—` and never becomes `$0`, because a cost of zero and a cost nobody
 told us about are different facts.
 
+## Platform inference
+
+Fountain can hold its own inference keys. A tenant with no credential of their
+own then runs on a Fountain key, and the tokens burn their credit balance. The
+tenant's own credential always wins. There is no per-agent switch.
+
+Every variable here is blank by default. A deployment with no platform key
+behaves as it always did, and each tenant supplies a credential of their own.
+
+| Variable | Default | Required | Effect |
+|---|---|---|---|
+| `PLATFORM_ANTHROPIC_API_KEY` | — | No. | The Anthropic key Fountain runs a tenant on when that tenant has none. This is the first key to set. The default agent uses the claude runtime. |
+| `PLATFORM_OPENAI_API_KEY` | — | No. | The same, for an agent on an `openai/` model. |
+| `PLATFORM_GEMINI_API_KEY` | — | No. | The same, for an agent on a `google/` model. |
+| `PLATFORM_INFERENCE_DAILY_CENTS` | `5000` | No. | The most the keys above may cost in one UTC day, across every tenant. A conversation beyond it gets `503 platform_inference_unavailable`. |
+| `PLATFORM_INFERENCE_RATES` | — | No. | Per-model prices, in cents per million tokens. See below. |
+
+### What a tenant pays
+
+Fountain prices these tokens at the provider's list price. There is no markup.
+The margin on a conversation is the turn time (`CREDIT_TURN_HOUR_CENTS`), not
+the tokens. A closed platform turn posts a `burn_inference` debit beside its
+`burn_turn` debit. The account credits page names both, and the
+finance panel at `/admin/finance` shows the two totals.
+
+The gate stays the balance. An account at zero cannot start the next
+conversation, and the answer is `402 insufficient_credits`. A comped account
+pays nothing, here as everywhere.
+
+### The daily ceiling
+
+`PLATFORM_INFERENCE_DAILY_CENTS` is a circuit breaker for the whole
+deployment. One bad day cannot cost more than this number. A refusal is a 503
+and not a 402, because the limit belongs to you and not to the tenant. A
+tenant with their own credential never meets this ceiling.
+
+Two limits on the ceiling. Fountain counts the day from the credit ledger, so
+`CREDITS_ENABLED` must be `true`. Fountain also writes those ledger rows on a
+timer, so the count trails the real spend by a few minutes. The ceiling bounds
+a day. It does not bound a minute.
+
+### Rate overrides
+
+Fountain ships a rate card for the models in the catalog. Each rate carries
+the date somebody read it from the provider. A provider that moves a price
+makes the card stale, and `PLATFORM_INFERENCE_RATES` corrects it without a new
+release.
+
+Give one entry per model, and separate the entries with a comma. Each entry
+has five fields with a colon between them. The fields are the model, the input
+price, the output price, the cached-read price and the cached-write price.
+Prices are cents per million tokens, and a fraction is valid.
+
+```bash
+PLATFORM_INFERENCE_RATES="anthropic/claude-opus-5:500:2500:50:625,openai/*:500:3000:50:500"
+```
+
+A `provider/*` entry is the price for every model of that provider with no
+entry of its own.
+
+
 ## Public pages
 
 The `/` page is not the same page on every deployment. The Fountain project's

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -187,7 +187,7 @@ behaves as it always did, and each tenant supplies a credential of their own.
 | `PLATFORM_ANTHROPIC_API_KEY` | — | No. | The Anthropic key Fountain runs a tenant on when that tenant has none. This is the first key to set. The default agent uses the claude runtime. |
 | `PLATFORM_OPENAI_API_KEY` | — | No. | The same, for an agent on an `openai/` model. |
 | `PLATFORM_GEMINI_API_KEY` | — | No. | The same, for an agent on a `google/` model. |
-| `PLATFORM_INFERENCE_DAILY_CENTS` | `5000` | No. | The most the keys above may cost in one UTC day, across every tenant. A conversation beyond it gets `503 platform_inference_unavailable`. |
+| `PLATFORM_INFERENCE_DAILY_CENTS` | `5000` | No. | The most the keys above may cost in one UTC day, across every tenant. A conversation beyond it gets `503 platform_inference_unavailable`. It works only with `CREDITS_ENABLED=true`. |
 | `PLATFORM_INFERENCE_RATES` | — | No. | Per-model prices, in cents per million tokens. See below. |
 
 ### What a tenant pays
@@ -209,10 +209,19 @@ deployment. One bad day cannot cost more than this number. A refusal is a 503
 and not a 402, because the limit belongs to you and not to the tenant. A
 tenant with their own credential never meets this ceiling.
 
-Two limits on the ceiling. Fountain counts the day from the credit ledger, so
-`CREDITS_ENABLED` must be `true`. Fountain also writes those ledger rows on a
-timer, so the count trails the real spend by a few minutes. The ceiling bounds
-a day. It does not bound a minute.
+The ceiling trails the real spend, because Fountain writes the ledger rows on
+a timer. The ceiling bounds a day. It does not bound a minute.
+
+#### With credits off there is no ceiling
+
+Fountain counts the day from the credit ledger. `CREDITS_ENABLED=false` prices
+nothing and writes no ledger rows, so it also counts nothing.
+
+**A deployment with credits off and a platform key set has no ceiling at all.**
+Every tenant with no credential of their own runs on your key, and no limit
+stops the spend. For a self-hoster that is the correct behaviour, because the
+key is yours and the provider bill is yours. Do not set a platform key with
+credits off unless you accept an unbounded bill.
 
 ### Rate overrides
 

--- a/ee/lib/fountain/billing.ex
+++ b/ee/lib/fountain/billing.ex
@@ -36,6 +36,33 @@ defmodule Fountain.Billing do
   def check_spend(subject), do: Fountain.Credits.gate(subject)
 
   @doc """
+  What this deployment's platform inference keys have cost today, in cents,
+  across every tenant — the number `Fountain.PlatformInference` holds against
+  `PLATFORM_INFERENCE_DAILY_CENTS` (#1388).
+
+  `nil` with credits off: nothing is priced then (ADR 0031), so there is no
+  spend to report and "zero" would be a claim rather than an answer.
+
+  A UTC day, deliberately, and not each tenant's billing window: the ceiling
+  is a property of the deployment's own bill, and a sum over windows that
+  each start on a different day is not a number to bound anything with — the
+  same reasoning `Finance.summary/1` gives for the calendar month.
+  """
+  @spec platform_inference_spend_today(DateTime.t() | nil) :: non_neg_integer() | nil
+  def platform_inference_spend_today(now \\ nil) do
+    if Fountain.Credits.enabled?() do
+      now = now || DateTime.utc_now()
+      day_start = now |> DateTime.to_date() |> DateTime.new!(~T[00:00:00], "Etc/UTC")
+
+      Repo.one(
+        from e in Fountain.Credits.LedgerEntry,
+          where: e.reason == "burn_inference" and e.inserted_at >= ^day_start,
+          select: coalesce(sum(-e.amount_cents), 0)
+      )
+    end
+  end
+
+  @doc """
   Creates a Stripe Customer for the given user and stores its id.
 
   Customer only: a customer is what Checkout attaches a credit-pack payment

--- a/ee/lib/fountain/billing/finance.ex
+++ b/ee/lib/fountain/billing/finance.ex
@@ -79,6 +79,16 @@ defmodule Fountain.Billing.Finance do
   channels are counted apart (`Team.Comms.channel_counts/0`) because the two
   providers charge differently and a contact can hold either, neither or both.
 
+  **Platform inference** is the one cost that is not priced from the rate
+  card at all: it is read straight off the `burn_inference` ledger rows
+  (#1388). Those rows *are* the bill — the rate card in
+  `Fountain.Credits.InferenceRates` is the provider's list price with no
+  markup (ADR 0038), so what a tenant was charged and what Fountain paid are
+  the same number. It is therefore never `nil`, it appears in `revenue` and
+  in `cost` both, and it nets to zero margin. That is the intended reading:
+  the panel exists to show that inference is passed through and sandbox time
+  is where the margin is.
+
   **Messages** are per-send, from the `comms_email_sent`, `comms_sms_sent` and
   `comms_sms_received` usage events (`FountainWeb.TeamCommsMcpController`,
   `Team.Comms.Inbound`). Inbound counts: AgentPhone charges to receive.
@@ -130,6 +140,7 @@ defmodule Fountain.Billing.Finance do
           sandbox_cost_cents: non_neg_integer() | nil,
           contact_cost_cents: non_neg_integer() | nil,
           message_cost_cents: non_neg_integer() | nil,
+          inference_cost_cents: non_neg_integer(),
           cost_cents: non_neg_integer() | nil,
           margin_cents: integer() | nil
         }
@@ -330,6 +341,10 @@ defmodule Fountain.Billing.Finance do
         ),
       contact_cents: sum_or_nil(tenants, & &1.contact_cost_cents),
       message_cents: sum_or_nil(tenants, & &1.message_cost_cents),
+      # What the platform inference keys cost this period (#1388). Equal to
+      # the `burn_inference` credit inside `revenue.earned_cents`, because
+      # inference is sold at cost.
+      inference_cents: tenants |> Enum.map(& &1.inference_cost_cents) |> Enum.sum(),
       inboxes: tenants |> Enum.map(& &1.inboxes) |> Enum.sum(),
       numbers: tenants |> Enum.map(& &1.numbers) |> Enum.sum(),
       emails_sent: tenants |> Enum.map(& &1.emails_sent) |> Enum.sum(),
@@ -423,7 +438,11 @@ defmodule Fountain.Billing.Finance do
     message_cost = message_cost_cents(messages, card)
     turn_seconds = billable_turn_seconds(usage)
 
-    cost = add_or_nil([sandbox_cost, contact_cost, message_cost])
+    # Never nil: the inference bill is read off the ledger rather than priced
+    # from a rate card, so unlike the three above it is always known.
+    inference_cost = ledger.inference
+
+    cost = add_or_nil([sandbox_cost, contact_cost, message_cost, inference_cost])
 
     # Earned revenue is credit burned, unless the account is comped and the
     # burn was never paid for.
@@ -449,6 +468,7 @@ defmodule Fountain.Billing.Finance do
       sandbox_cost_cents: sandbox_cost,
       contact_cost_cents: contact_cost,
       message_cost_cents: message_cost,
+      inference_cost_cents: inference_cost,
       cost_cents: cost,
       margin_cents: cost && revenue_cents - cost
     }
@@ -608,6 +628,18 @@ defmodule Fountain.Billing.Finance do
                "coalesce(sum(case when ? = 'purchase' then ? end), 0)",
                e.reason,
                e.amount_cents
+             ),
+           # Platform inference (#1388) is inside `burned` — it is credit the
+           # tenant spent — and also a bill Fountain paid, so it is pulled out
+           # again here as a cost. Priced pass-through at list (ADR 0038), so
+           # the two cancel and inference contributes nothing to margin, which
+           # is the point and is only visible because both numbers are on the
+           # row.
+           inference:
+             fragment(
+               "coalesce(sum(case when ? = 'burn_inference' then -? end), 0)",
+               e.reason,
+               e.amount_cents
              )
          }}
     )
@@ -615,7 +647,7 @@ defmodule Fountain.Billing.Finance do
     |> Map.new()
   end
 
-  defp empty_ledger, do: %{granted: 0, burned: 0, sold: 0}
+  defp empty_ledger, do: %{granted: 0, burned: 0, sold: 0, inference: 0}
 
   defp empty_usage,
     do: %{active_seconds: 0, busy_seconds: 0, idle_seconds: 0, turn_seconds: 0, by_provider: []}

--- a/ee/lib/fountain/credits/inference_rates.ex
+++ b/ee/lib/fountain/credits/inference_rates.ex
@@ -1,0 +1,259 @@
+defmodule Fountain.Credits.InferenceRates do
+  @moduledoc """
+  What a turn that ran on a **platform inference key** costs, priced from the
+  tokens the runtime reported (#1388, amending ADR 0008).
+
+  ## Pass-through, on purpose
+
+  Every rate below is the provider's list price, unchanged: a **1.0x margin,
+  no markup**. Fountain's margin is sandbox time (`CREDIT_TURN_HOUR_CENTS`,
+  ADR 0031), not inference. The platform key exists so a verified account can
+  see a first reply without opening an account with a model provider first
+  (ADR 0038), and a markup would make the opening credit buy less of the one
+  thing it was granted for. **This is a decision, not an oversight** — do not
+  "fix" it into a margin without a decision record that says so.
+
+  ## The unit
+
+  Rates are integers in **cents per billion tokens** — a published price in
+  cents per million tokens, times a thousand. A published price can be
+  fractions of a cent per million tokens (OpenAI's cached input for
+  `gpt-5.3-codex` is $0.175/MTok), and a float in a money table is how a
+  ledger stops reconciling. The turn's cost is rounded to whole cents exactly
+  once, at the end, in `cost_cents/1`.
+
+  ## Four token kinds
+
+  `Managoat.ACP.Usage` normalises a turn's end-of-turn figure into `"input"`,
+  `"output"` and, when the runtime reports them, `"cache_read"` and
+  `"cache_write"`. Cached tokens are billed separately by every provider here
+  and they are the *majority* of an agentic turn's input, so pricing only
+  `input` and `output` would under-report a claude turn by roughly an order of
+  magnitude. Where a provider publishes no cached-token price, cached tokens
+  are priced at that provider's base input rate, which over-states rather than
+  invents.
+
+  ## Staying current
+
+  Every number carries its source and the date it was read. A rate the
+  provider has moved is a stale number, not a bug that announces itself, so
+  the comment is the mechanism: read the date, re-read the page. Any entry can
+  be overridden per deployment with `PLATFORM_INFERENCE_RATES` (see
+  `config/runtime.exs` and `docs/configuration.md`), so a price change does
+  not need a deploy of this file.
+  """
+
+  alias Managoat.Runtimes.Model
+
+  # ---------------------------------------------------------------------------
+  # The card
+  # ---------------------------------------------------------------------------
+  #
+  # Cents per billion tokens. Multiply a published $/MTok figure by 100_000.
+  #
+  # `"<provider>/*"` is the provider's fallback for a model id not listed
+  # here — Fountain's model field is not an allowlist (`Agents.ModelCatalog`),
+  # so a model released after this deploy has to be priceable the day it ships.
+  # Each fallback is the provider's **flagship** rate, deliberately: an
+  # unlisted model priced too low is Fountain paying a bill it never charged
+  # for, and the platform key is a courtesy with a ceiling on it, so the
+  # failure to prefer is over-charging a grant.
+  #
+  # Anthropic: platform.claude.com/docs/en/about-claude/pricing, read
+  # 2026-09-02. Cache reads are 0.1x base input and 5-minute cache writes
+  # 1.25x, which is the multiplier claude's adapter actually uses.
+  @anthropic_opus %{input: 500_000, output: 2_500_000, cache_read: 50_000, cache_write: 625_000}
+
+  @card %{
+    # ── anthropic ──────────────────────────────────────────────────────────
+    # $5.00 / $25.00, cache read $0.50, 5m cache write $6.25.
+    "anthropic/claude-opus-5" => @anthropic_opus,
+    "anthropic/claude-opus-4-8" => @anthropic_opus,
+    "anthropic/claude-opus-4-7" => @anthropic_opus,
+    "anthropic/*" => @anthropic_opus,
+    # $2.00 / $10.00, cache read $0.20, 5m cache write $2.50. The $2/$10
+    # introductory price became the standard price on 2026-09-01; the
+    # scheduled rise to $3/$15 was cancelled.
+    "anthropic/claude-sonnet-5" => %{
+      input: 200_000,
+      output: 1_000_000,
+      cache_read: 20_000,
+      cache_write: 250_000
+    },
+    # $3.00 / $15.00, cache read $0.30, 5m cache write $3.75.
+    "anthropic/claude-sonnet-4-6" => %{
+      input: 300_000,
+      output: 1_500_000,
+      cache_read: 30_000,
+      cache_write: 375_000
+    },
+    # $1.00 / $5.00, cache read $0.10, 5m cache write $1.25.
+    "anthropic/claude-haiku-4-5" => %{
+      input: 100_000,
+      output: 500_000,
+      cache_read: 10_000,
+      cache_write: 125_000
+    },
+
+    # ── openai ─────────────────────────────────────────────────────────────
+    # developers.openai.com/api/docs/pricing, read 2026-09-02. OpenAI bills a
+    # cache *write* as an ordinary input token, so `cache_write` is the base
+    # input rate rather than a multiple of it.
+    #
+    # $5.00 / $30.00, cached input $0.50. The <=272K context tier; a longer
+    # request costs more and is priced here at the short-context rate.
+    "openai/gpt-5.5" => %{
+      input: 500_000,
+      output: 3_000_000,
+      cache_read: 50_000,
+      cache_write: 500_000
+    },
+    "openai/*" => %{
+      input: 500_000,
+      output: 3_000_000,
+      cache_read: 50_000,
+      cache_write: 500_000
+    },
+    # $1.75 / $14.00, cached input $0.175 — the fraction of a cent per million
+    # tokens this module's unit exists for.
+    "openai/gpt-5.3-codex" => %{
+      input: 175_000,
+      output: 1_400_000,
+      cache_read: 17_500,
+      cache_write: 175_000
+    },
+    # $1.25 / $10.00, cached input $0.125.
+    "openai/gpt-5" => %{
+      input: 125_000,
+      output: 1_000_000,
+      cache_read: 12_500,
+      cache_write: 125_000
+    },
+
+    # ── google ─────────────────────────────────────────────────────────────
+    # ai.google.dev/gemini-api/docs/pricing, read 2026-09-02. Google's cached
+    # pricing depends on a cache the ACP adapter does not manage, so cached
+    # tokens take the base input rate here.
+    #
+    # $2.00 / $12.00 for prompts <=200K ($4.00 / $18.00 above that; a turn
+    # over 200K is priced low here, which is the direction that costs
+    # Fountain and is bounded by the daily ceiling).
+    "google/gemini-3.1-pro-preview" => %{
+      input: 200_000,
+      output: 1_200_000,
+      cache_read: 200_000,
+      cache_write: 200_000
+    },
+    "google/*" => %{
+      input: 200_000,
+      output: 1_200_000,
+      cache_read: 200_000,
+      cache_write: 200_000
+    },
+    # $0.75 / $3.75 through 2026-12-31, then $1.50 / $7.50 — the one entry
+    # here with a known expiry date on it.
+    "google/gemini-3.7-flash" => %{
+      input: 75_000,
+      output: 375_000,
+      cache_read: 75_000,
+      cache_write: 75_000
+    },
+    "google/gemini-3.6-flash" => %{
+      input: 75_000,
+      output: 375_000,
+      cache_read: 75_000,
+      cache_write: 75_000
+    },
+    # $1.50 / $9.00.
+    "google/gemini-3.5-flash" => %{
+      input: 150_000,
+      output: 900_000,
+      cache_read: 150_000,
+      cache_write: 150_000
+    }
+  }
+
+  @zero %{input: 0, output: 0, cache_read: 0, cache_write: 0}
+
+  @doc """
+  The compiled card, before any deployment override. Every value is cents per
+  billion tokens.
+  """
+  @spec card() :: %{String.t() => map()}
+  def card, do: @card
+
+  @doc """
+  The rate card in force: `card/0` with `PLATFORM_INFERENCE_RATES` merged over
+  it, entry by entry.
+  """
+  @spec rates() :: %{String.t() => map()}
+  def rates do
+    case Application.get_env(:fountain, :inference_rates) do
+      overrides when is_map(overrides) -> Map.merge(@card, overrides)
+      _ -> @card
+    end
+  end
+
+  @doc """
+  The rate for a canonical `provider/model_id`: the model's own entry, else
+  the provider's fallback, else zero.
+
+  Zero is the right answer for a provider Fountain holds no platform key for
+  (a local model, a gateway): no platform turn can run on it, so there is
+  nothing to price, and inventing a number would put a debit on a tenant's
+  own credential.
+  """
+  @spec rate_for(String.t() | nil) :: %{
+          input: non_neg_integer(),
+          output: non_neg_integer(),
+          cache_read: non_neg_integer(),
+          cache_write: non_neg_integer()
+        }
+  def rate_for(model) do
+    table = rates()
+
+    case Model.split(model) do
+      {nil, nil} ->
+        @zero
+
+      {provider, id} ->
+        Map.get(table, "#{provider}/#{id}") || Map.get(table, "#{provider}/*") || @zero
+    end
+  end
+
+  @doc """
+  What a turn's `usage` map costs, in whole cents.
+
+  `usage` is the map on `turns.usage` — `Managoat.ACP.Usage`'s normalised
+  figure plus the `"model"` and `"inference"` keys the ConversationServer
+  stamps on a platform turn. A turn with no usage, no model, or no tokens
+  costs nothing.
+
+  Rounded to the nearest cent, once. A turn that rounds to zero writes no
+  ledger row at all, exactly as a sub-cent turn hour does.
+  """
+  @spec cost_cents(map() | nil) :: non_neg_integer()
+  def cost_cents(usage) when is_map(usage) do
+    rate = rate_for(Map.get(usage, "model"))
+
+    per_billion =
+      tokens(usage, "input") * rate.input +
+        tokens(usage, "output") * rate.output +
+        tokens(usage, "cache_read") * rate.cache_read +
+        tokens(usage, "cache_write") * rate.cache_write
+
+    div(per_billion + 500_000_000, 1_000_000_000)
+  end
+
+  def cost_cents(_usage), do: 0
+
+  # The same tolerance `Conversations._unsafe_record_turn_usage/2` applies to
+  # the counters: whatever the runtime reported that is not a non-negative
+  # integer counts as nothing, which is what an unreported figure counts as.
+  defp tokens(usage, key) do
+    case Map.get(usage, key) do
+      n when is_integer(n) and n >= 0 -> n
+      _ -> 0
+    end
+  end
+end

--- a/ee/lib/fountain/credits/ledger_entry.ex
+++ b/ee/lib/fountain/credits/ledger_entry.ex
@@ -36,7 +36,12 @@ defmodule Fountain.Credits.LedgerEntry do
   end
 
   @credit_reasons ~w(grant_opening grant_admin purchase)
-  @debit_reasons ~w(burn_turn burn_rent burn_message expire clawback_refund clawback_dispute)
+  # `burn_inference` is tokens a turn spent on a **platform** inference key
+  # (#1388), priced at the provider's list price by
+  # `Fountain.Credits.InferenceRates`. A turn on the tenant's own credential
+  # burns none of it — Fountain paid nothing — so it sits beside `burn_turn`
+  # rather than inside it.
+  @debit_reasons ~w(burn_turn burn_inference burn_rent burn_message expire clawback_refund clawback_dispute)
 
   @doc "Reasons that put money in. Every one is a positive row."
   def credit_reasons, do: @credit_reasons

--- a/ee/lib/fountain/workers/credit_pricer.ex
+++ b/ee/lib/fountain/workers/credit_pricer.ex
@@ -10,6 +10,13 @@ defmodule Fountain.Workers.CreditPricer do
       in-flight turn that crosses zero finishes and lands as debt, which is
       the soft stop of decision 6. Runner turns cost Fountain nothing and burn
       nothing (ADR 0022); a turn with no sandbox never ran.
+    * **Inference.** Every closed turn that ran on a **platform** inference
+      key (#1388) burns `Credits.InferenceRates.cost_cents/1` of its
+      `turns.usage` under the key `burn_inference:<turn_id>`. Unlike the turn
+      pass this one does **not** filter on the sandbox provider: a
+      self-hosted runner costs Fountain no sandbox time but its tokens are
+      still on Fountain's key. A turn on the tenant's own credential is not
+      marked and is never seen here.
     * **Messages.** Every `comms_email_sent`, `comms_sms_sent` and
       `comms_sms_received` usage event burns the matching price under
       `burn_message:<event_id>`. A `nil` price burns nothing (#1042).
@@ -53,13 +60,13 @@ defmodule Fountain.Workers.CreditPricer do
   @impl Oban.Worker
   def perform(_job) do
     case run() do
-      %{turns: 0, messages: 0, expired: 0} ->
+      %{turns: 0, inference: 0, messages: 0, expired: 0} ->
         :ok
 
       counts ->
         Logger.info(
-          "credit pricer: burned #{counts.turns} turns, #{counts.messages} messages, " <>
-            "expired #{counts.expired} grants"
+          "credit pricer: burned #{counts.turns} turns, #{counts.inference} platform-inference " <>
+            "turns, #{counts.messages} messages, expired #{counts.expired} grants"
         )
     end
 
@@ -67,12 +74,13 @@ defmodule Fountain.Workers.CreditPricer do
   end
 
   @doc """
-  Run both passes now. `:now` pins the clock; `:since` overrides the
-  configured floor. Returns `%{turns: n, messages: n, expired: n}` — rows
-  written, not rows seen.
+  Run every pass now. `:now` pins the clock; `:since` overrides the
+  configured floor. Returns `%{turns: n, inference: n, messages: n,
+  expired: n}` — rows written, not rows seen.
   """
   @spec run(keyword()) :: %{
           turns: non_neg_integer(),
+          inference: non_neg_integer(),
           messages: non_neg_integer(),
           expired: non_neg_integer()
         }
@@ -92,16 +100,22 @@ defmodule Fountain.Workers.CreditPricer do
 
     if Credits.enabled?(),
       do: do_run(floor, now),
-      else: %{turns: 0, messages: 0, expired: 0}
+      else: %{turns: 0, inference: 0, messages: 0, expired: 0}
   end
 
   defp do_run(floor, now) do
     {turns, touched} = price_turns(floor)
+    {inference, inference_touched} = price_inference(floor)
     messages = price_messages(floor)
-    Enum.each(touched, &Fountain.Workers.CreditsEmail.notify_after_burn/1)
+
+    touched
+    |> MapSet.new()
+    |> MapSet.union(MapSet.new(inference_touched))
+    |> Enum.each(&Fountain.Workers.CreditsEmail.notify_after_burn/1)
+
     # Burns first, so a turn consumes the grant before the grant is swept.
     %{expired: expired} = Fountain.Workers.CreditExpirer.run(now: now)
-    %{turns: turns, messages: messages, expired: expired}
+    %{turns: turns, inference: inference, messages: messages, expired: expired}
   end
 
   # ---------------------------------------------------------------------------
@@ -188,6 +202,100 @@ defmodule Fountain.Workers.CreditPricer do
 
           {:error, reason} ->
             Logger.warning("credit pricer: turn #{turn.id} not priced: #{inspect(reason)}")
+            false
+        end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Platform inference (#1388)
+  # ---------------------------------------------------------------------------
+
+  # Same shape as the turn pass: `{rows_written, user_ids_touched}`.
+  defp price_inference(floor), do: price_inference(floor, 0, MapSet.new())
+
+  defp price_inference(floor, written, touched) do
+    case unpriced_inference_turns(floor) do
+      [] ->
+        {written, MapSet.to_list(touched)}
+
+      turns ->
+        priced = Enum.filter(turns, &price_inference_turn/1)
+        n = length(priced)
+        touched = Enum.reduce(priced, touched, &MapSet.put(&2, &1.user_id))
+
+        if n == 0 or length(turns) < @batch,
+          do: {written + n, MapSet.to_list(touched)},
+          else: price_inference(floor, written + n, touched)
+    end
+  end
+
+  # No join to `sandboxes` and no provider filter, unlike `unpriced_turns/1`:
+  # the sandbox provider says who paid for the *machine*, and this pass is
+  # about who paid for the *tokens*. A turn on a tenant's own runner
+  # (ADR 0022) costs Fountain no sandbox time and still spends Fountain's
+  # inference key when the tenant has none of their own.
+  #
+  # `usage ->> 'inference' = 'platform'` is the whole selector: the
+  # ConversationServer stamps that key only on a turn whose credentials came
+  # from `Fountain.PlatformInference`, so a deployment that holds no platform
+  # key has no matching row and this query is a cheap miss.
+  defp unpriced_inference_turns(floor) do
+    from(t in Turn,
+      join: c in Conversation,
+      on: c.id == t.conversation_id,
+      left_join: l in LedgerEntry,
+      on: l.idempotency_key == fragment("'burn_inference:' || ?::text", t.id),
+      where: is_nil(l.id),
+      where: not is_nil(t.ended_at),
+      where: t.ended_at >= ^floor,
+      where: fragment("? ->> 'inference' = 'platform'", t.usage),
+      where: not is_nil(c.user_id),
+      order_by: [asc: t.ended_at],
+      limit: @batch,
+      select: %{
+        id: t.id,
+        user_id: c.user_id,
+        conversation_id: c.id,
+        usage: t.usage
+      }
+    )
+    |> Repo.all()
+  end
+
+  # True when a row was written. A turn whose tokens round to nothing writes
+  # none, and is skipped again next run — the same trade `price_turn/1` makes.
+  defp price_inference_turn(turn) do
+    case Credits.InferenceRates.cost_cents(turn.usage) do
+      0 ->
+        false
+
+      cents ->
+        case Credits.debit(turn.user_id, cents, "burn_inference",
+               idempotency_key: "burn_inference:#{turn.id}",
+               resource_type: "turn",
+               resource_id: turn.id,
+               actor: "system:credit_pricer",
+               # Tokens and a model id, not a prompt and not a reply: the
+               # ledger is not a second copy of the transcript.
+               metadata: %{
+                 "model" => turn.usage["model"],
+                 "input" => turn.usage["input"],
+                 "output" => turn.usage["output"],
+                 "conversation_id" => turn.conversation_id
+               }
+             ) do
+          {:ok, _} ->
+            true
+
+          {:ok, :duplicate, _} ->
+            false
+
+          {:error, reason} ->
+            Logger.warning(
+              "credit pricer: turn #{turn.id} inference not priced: #{inspect(reason)}"
+            )
+
             false
         end
     end

--- a/ee/lib/fountain_web/live/admin_finance_live.ex
+++ b/ee/lib/fountain_web/live/admin_finance_live.ex
@@ -349,6 +349,18 @@ defmodule FountainWeb.Live.AdminFinanceLive do
             </div>
             <div class="text-xs text-zinc-400">inbound counts — AgentPhone charges to receive</div>
           </div>
+          <div class="bg-white rounded shadow border border-zinc-200 px-4 py-3">
+            <div class="text-xs text-zinc-500">Platform inference</div>
+            <div class="text-xl font-semibold tabular-nums">
+              {money(@finance.cost.inference_cents)}
+            </div>
+            <div class="text-xs text-zinc-500">
+              tokens on Fountain's own keys, for tenants with none of their own
+            </div>
+            <div class="text-xs text-zinc-400">
+              sold at provider list price, so this is earned revenue too and nets to zero margin
+            </div>
+          </div>
         </div>
 
         <div :if={@finance.cost.by_provider != %{}} class="grid grid-cols-2 sm:grid-cols-4 gap-3">
@@ -583,7 +595,7 @@ defmodule FountainWeb.Live.AdminFinanceLive do
   defp negative?(cents), do: is_integer(cents) and cents < 0
 
   defp total_cost(%{cost: cost}) do
-    [cost.sandbox_cents, cost.contact_cents, cost.message_cents]
+    [cost.sandbox_cents, cost.contact_cents, cost.message_cents, cost.inference_cents]
     |> then(fn parts -> if Enum.any?(parts, &is_nil/1), do: nil, else: Enum.sum(parts) end)
   end
 
@@ -629,7 +641,8 @@ defmodule FountainWeb.Live.AdminFinanceLive do
   defp contacts_cell(%{inboxes: i, numbers: n}), do: "#{i}✉ #{n}☎"
 
   defp cost_breakdown(t) do
-    "sandboxes #{money(t.sandbox_cost_cents)} · contacts #{money(t.contact_cost_cents)} · messages #{money(t.message_cost_cents)}"
+    "sandboxes #{money(t.sandbox_cost_cents)} · contacts #{money(t.contact_cost_cents)} · " <>
+      "messages #{money(t.message_cost_cents)} · inference #{money(t.inference_cost_cents)}"
   end
 
   defp pluralize(1, singular, _plural), do: singular

--- a/ee/lib/fountain_web/live/credits_live.ex
+++ b/ee/lib/fountain_web/live/credits_live.ex
@@ -215,6 +215,16 @@ defmodule FountainWeb.Live.CreditsLive do
     do: "Conversation time, #{format_seconds(s)}"
 
   defp ledger_label(%{reason: "burn_turn"}), do: "Conversation time"
+
+  # A platform-inference burn (#1388). The model is on the row because it is
+  # what the price came from, and because "Fountain's key" is the answer to
+  # the question this line raises: why am I paying for tokens? A tenant who
+  # adds their own credential stops seeing these.
+  defp ledger_label(%{reason: "burn_inference", metadata: %{"model" => model}})
+       when is_binary(model),
+       do: "Inference on Fountain's key, #{model}"
+
+  defp ledger_label(%{reason: "burn_inference"}), do: "Inference on Fountain's key"
   defp ledger_label(%{reason: "burn_rent"}), do: "Number or inbox, one month"
   defp ledger_label(%{reason: "burn_message"}), do: "Message"
   defp ledger_label(%{reason: "expire"}), do: "Expired with the period"

--- a/ee/test/fountain/credits_inference_test.exs
+++ b/ee/test/fountain/credits_inference_test.exs
@@ -1,0 +1,309 @@
+defmodule Fountain.Credits.InferenceTest do
+  @moduledoc """
+  Pricing a platform-inference turn (#1388): the rate card, the pricer's
+  fourth pass, and what the finance panel makes of it.
+
+  `async: false` — the rate override and the platform keys are application
+  environment, and a module that writes it races every module that reads it
+  (#1214).
+  """
+
+  use Fountain.DataCase, async: false
+
+  alias Fountain.Billing
+  alias Fountain.Billing.Finance
+  alias Fountain.Credits
+  alias Fountain.Credits.InferenceRates
+  alias Fountain.Workers.CreditPricer
+
+  @since ~U[2026-08-01 00:00:00Z]
+  @now ~U[2026-08-03 12:00:00Z]
+
+  setup do
+    original = Application.get_env(:fountain, :inference_rates)
+
+    on_exit(fn ->
+      case original do
+        nil -> Application.delete_env(:fountain, :inference_rates)
+        value -> Application.put_env(:fountain, :inference_rates, value)
+      end
+    end)
+
+    :ok
+  end
+
+  defp platform_turn(conv, usage, opts \\ []) do
+    started = Keyword.get(opts, :started_at, ~U[2026-08-02 10:00:00Z])
+
+    insert_turn(conv, %{
+      status: "completed",
+      started_at: started,
+      ended_at: DateTime.add(started, Keyword.get(opts, :seconds, 60), :second),
+      usage: usage
+    })
+  end
+
+  defp conv_for(user, provider \\ "sprites") do
+    sandbox = insert_sandbox(user_id: user.id, provider: provider, status: "ready")
+    insert_conversation(user_id: user.id, sandbox: sandbox)
+  end
+
+  describe "InferenceRates" do
+    test "a million input tokens on opus 5 is $5 and a million output is $25" do
+      assert InferenceRates.cost_cents(%{
+               "model" => "anthropic/claude-opus-5",
+               "input" => 1_000_000,
+               "output" => 0
+             }) == 500
+
+      assert InferenceRates.cost_cents(%{
+               "model" => "anthropic/claude-opus-5",
+               "input" => 0,
+               "output" => 1_000_000
+             }) == 2_500
+    end
+
+    test "cached tokens are priced at their own published rate, not as input" do
+      # Opus 5: cache reads are 0.1x base input, 5-minute writes 1.25x.
+      assert InferenceRates.cost_cents(%{
+               "model" => "anthropic/claude-opus-5",
+               "input" => 0,
+               "output" => 0,
+               "cache_read" => 1_000_000,
+               "cache_write" => 1_000_000
+             }) == 50 + 625
+    end
+
+    test "a fraction of a cent per million tokens survives the unit" do
+      # OpenAI's cached input for gpt-5.3-codex is $0.175/MTok.
+      assert InferenceRates.cost_cents(%{
+               "model" => "openai/gpt-5.3-codex",
+               "cache_read" => 4_000_000
+             }) == 70
+    end
+
+    test "an unlisted model falls back to the provider's flagship rate" do
+      assert InferenceRates.rate_for("anthropic/claude-opus-9") ==
+               InferenceRates.rate_for("anthropic/claude-opus-5")
+    end
+
+    test "a provider Fountain holds no key for prices nothing" do
+      assert InferenceRates.cost_cents(%{"model" => "ollama/llama3", "input" => 9_999_999}) == 0
+      assert InferenceRates.cost_cents(%{"input" => 9_999_999}) == 0
+      assert InferenceRates.cost_cents(nil) == 0
+    end
+
+    test "a token count that is not a non-negative integer counts as nothing" do
+      assert InferenceRates.cost_cents(%{
+               "model" => "anthropic/claude-opus-5",
+               "input" => "lots",
+               "output" => -5
+             }) == 0
+    end
+
+    test "a config override replaces one entry and leaves the rest compiled" do
+      Application.put_env(:fountain, :inference_rates, %{
+        "anthropic/claude-opus-5" => %{
+          input: 1_000_000,
+          output: 0,
+          cache_read: 0,
+          cache_write: 0
+        }
+      })
+
+      assert InferenceRates.cost_cents(%{
+               "model" => "anthropic/claude-opus-5",
+               "input" => 1_000_000
+             }) == 1_000
+
+      assert InferenceRates.cost_cents(%{
+               "model" => "anthropic/claude-sonnet-5",
+               "input" => 1_000_000
+             }) == 200
+    end
+
+    test "rounding is to the nearest cent, once" do
+      # At $5/MTok a cent is 2,000 tokens, so 400 of them is 0.2 cents.
+      assert InferenceRates.cost_cents(%{
+               "model" => "anthropic/claude-opus-5",
+               "input" => 400
+             }) == 0
+
+      # 1,200 is 0.6 cents, and rounds the other way.
+      assert InferenceRates.cost_cents(%{
+               "model" => "anthropic/claude-opus-5",
+               "input" => 1_200
+             }) == 1
+
+      # Rounded once from the total, not per token kind: two 0.6-cent halves
+      # are 1.2 cents and one row, not two rows of one cent.
+      assert InferenceRates.cost_cents(%{
+               "model" => "anthropic/claude-opus-5",
+               "input" => 1_200,
+               "cache_write" => 960
+             }) == 1
+    end
+  end
+
+  describe "the pricer's inference pass" do
+    test "a platform turn burns its tokens, once, beside the turn-time burn" do
+      user = insert_empty_user()
+      conv = conv_for(user)
+
+      turn =
+        platform_turn(
+          conv,
+          %{
+            "inference" => "platform",
+            "model" => "anthropic/claude-sonnet-5",
+            "input" => 1_000_000,
+            "output" => 500_000
+          },
+          seconds: 3_600
+        )
+
+      assert %{turns: 1, inference: 1} = CreditPricer.run(since: @since, now: @now)
+
+      # $2 of input plus $5 of output is 700 cents of inference, and the hour
+      # of turn time is 25 more. Two rows, two reasons: Fountain's margin is
+      # the second one.
+      assert Credits.balance(user.id) == -725
+
+      [entry] = Credits.list_entries(user.id) |> Enum.filter(&(&1.reason == "burn_inference"))
+      assert entry.resource_type == "turn"
+      assert entry.resource_id == turn.id
+      assert entry.idempotency_key == "burn_inference:#{turn.id}"
+      assert entry.metadata["model"] == "anthropic/claude-sonnet-5"
+      assert entry.metadata["input"] == 1_000_000
+      assert entry.metadata["conversation_id"] == conv.id
+
+      assert %{inference: 0} = CreditPricer.run(since: @since, now: @now)
+      assert Credits.balance(user.id) == -725
+    end
+
+    test "a turn on the tenant's own key burns nothing for inference" do
+      user = insert_empty_user()
+      conv = conv_for(user)
+
+      platform_turn(conv, %{
+        "inference" => "own",
+        "input" => 1_000_000,
+        "output" => 1_000_000
+      })
+
+      assert %{inference: 0} = CreditPricer.run(since: @since, now: @now)
+      assert Credits.list_entries(user.id) == []
+    end
+
+    test "an unmarked turn — the shape every turn had before #1388 — burns nothing" do
+      user = insert_empty_user()
+      conv = conv_for(user)
+
+      platform_turn(conv, %{"input" => 1_000_000, "output" => 1_000_000})
+
+      assert %{inference: 0} = CreditPricer.run(since: @since, now: @now)
+    end
+
+    test "a runner turn costs no sandbox time and still burns its platform tokens" do
+      user = insert_empty_user()
+      conv = conv_for(user, "runner")
+
+      platform_turn(
+        conv,
+        %{
+          "inference" => "platform",
+          "model" => "anthropic/claude-opus-5",
+          "input" => 1_000_000
+        },
+        seconds: 3_600
+      )
+
+      # The turn pass skips it (ADR 0022: Fountain pays for no runner hour);
+      # the inference pass does not, because the tokens were still on
+      # Fountain's key.
+      assert %{turns: 0, inference: 1} = CreditPricer.run(since: @since, now: @now)
+      assert Credits.balance(user.id) == -500
+    end
+
+    test "a turn that rounds to nothing writes no row" do
+      user = insert_empty_user()
+      conv = conv_for(user)
+
+      platform_turn(conv, %{
+        "inference" => "platform",
+        "model" => "anthropic/claude-opus-5",
+        "input" => 100
+      })
+
+      assert %{inference: 0} = CreditPricer.run(since: @since, now: @now)
+      assert Credits.list_entries(user.id) == []
+    end
+
+    test "an open turn is not priced until it closes" do
+      user = insert_empty_user()
+      conv = conv_for(user)
+
+      insert_turn(conv, %{
+        status: "running",
+        started_at: ~U[2026-08-02 10:00:00Z],
+        usage: %{
+          "inference" => "platform",
+          "model" => "anthropic/claude-opus-5",
+          "input" => 10_000_000
+        }
+      })
+
+      assert %{inference: 0} = CreditPricer.run(since: @since, now: @now)
+    end
+  end
+
+  describe "the ceiling and the finance panel" do
+    test "spend today is the day's burn_inference rows, across every tenant" do
+      one = insert_empty_user()
+      two = insert_empty_user()
+
+      {:ok, _} =
+        Credits.debit(one.id, 120, "burn_inference",
+          idempotency_key: "burn_inference:a",
+          actor: "system:test"
+        )
+
+      {:ok, _} =
+        Credits.debit(two.id, 80, "burn_inference",
+          idempotency_key: "burn_inference:b",
+          actor: "system:test"
+        )
+
+      # A turn-time burn is not inference spend.
+      {:ok, _} =
+        Credits.debit(one.id, 500, "burn_turn",
+          idempotency_key: "burn_turn:x",
+          actor: "system:test"
+        )
+
+      assert Billing.platform_inference_spend_today() == 200
+    end
+
+    test "the finance panel counts inference as both earned and paid, netting to zero" do
+      user = insert_empty_user()
+      now = DateTime.utc_now()
+      {start, _} = Billing.current_month_range()
+
+      {:ok, _} =
+        Credits.debit(user.id, 300, "burn_inference",
+          idempotency_key: "burn_inference:finance",
+          actor: "system:test"
+        )
+
+      summary = Finance.summary(period: {start, DateTime.add(now, 1, :day)}, now: now)
+      row = Enum.find(summary.tenants, &(&1.user_id == user.id))
+
+      assert row.inference_cost_cents == 300
+      assert row.revenue_cents == 300
+      assert row.credit_burned_cents == 300
+      assert summary.cost.inference_cents == 300
+      # Pass-through: the tenant paid exactly what the tokens cost.
+      assert row.margin_cents == 0
+    end
+  end
+end


### PR DESCRIPTION
Closes #1388. Builds decision 3 of ADR 0038 and amends ADR 0008.

Fountain can hold its own inference keys and run a tenant's agent on one when
that tenant has no credential for the model's provider. The tokens burn their
credit balance. **Blank means off, per provider** — a deployment that
configures no platform key behaves exactly as it did before, which is what
makes this opt-in for a self-hoster.

## The pricing decision

Pass-through at provider list price, **1.0x margin, no markup** (decided with
Jake, 2026-09-02). Fountain's margin is sandbox time
(`CREDIT_TURN_HOUR_CENTS`); a markup would make the opening credit buy less of
the one thing it was granted to buy. The reasoning is written into the config
comment, the `InferenceRates` moduledoc and ADR 0038 so nobody "fixes" it later.

`PLATFORM_INFERENCE_DAILY_CENTS` defaults to 5000 ($50/day across all tenants).

## The rate table

Cents per **billion** tokens — the published cents-per-million price times a
thousand — because a published price can be a fraction of a cent per million
tokens (OpenAI's cached input for `gpt-5.3-codex` is $0.175/MTok) and a float
in a money table is how a ledger stops reconciling. Four token kinds per model
(input, output, cached read, cached write): cached tokens are the majority of
an agentic claude turn's input, so pricing only input+output would under-report
by roughly an order of magnitude.

Every value below is $/MTok, read from the provider on **2026-09-02**.
Anthropic: `platform.claude.com/docs/en/about-claude/pricing`. OpenAI:
`developers.openai.com/api/docs/pricing`. Google:
`ai.google.dev/gemini-api/docs/pricing`.

| Model | Input | Output | Cache read | Cache write |
|---|---|---|---|---|
| `anthropic/claude-opus-5`, `-4-8`, `-4-7`, and the `anthropic/*` fallback | 5.00 | 25.00 | 0.50 | 6.25 |
| `anthropic/claude-sonnet-5` | 2.00 | 10.00 | 0.20 | 2.50 |
| `anthropic/claude-sonnet-4-6` | 3.00 | 15.00 | 0.30 | 3.75 |
| `anthropic/claude-haiku-4-5` | 1.00 | 5.00 | 0.10 | 1.25 |
| `openai/gpt-5.5` and the `openai/*` fallback | 5.00 | 30.00 | 0.50 | 5.00 |
| `openai/gpt-5.3-codex` | 1.75 | 14.00 | 0.175 | 1.75 |
| `openai/gpt-5` | 1.25 | 10.00 | 0.125 | 1.25 |
| `google/gemini-3.1-pro-preview` and the `google/*` fallback | 2.00 | 12.00 | 2.00 | 2.00 |
| `google/gemini-3.7-flash`, `-3.6-flash` | 0.75 | 3.75 | 0.75 | 0.75 |
| `google/gemini-3.5-flash` | 1.50 | 9.00 | 1.50 | 1.50 |

Anthropic cache rates are the published 0.1x read / 1.25x five-minute write.
OpenAI bills a cache write as an ordinary input token, so its cache-write
column is the base input rate. Google's cached pricing depends on a cache the
ACP adapter does not manage, so cached tokens take the base input rate there.
A `provider/*` fallback prices a model with no entry of its own, and each is
the provider's flagship rate on purpose — an unlisted model priced too low is
Fountain paying a bill it never charged for.

Every rate is overridable with `PLATFORM_INFERENCE_RATES`, so a provider price
change does not need a release.

> **The Anthropic rows are independently verified; the OpenAI and Google rows
> are not.** A second reader checked every Anthropic number and cache
> multiplier against the pricing reference and found them exact. The OpenAI and
> Google rows come from one read of the provider pages on 2026-09-02 and have
> had no second pair of eyes — and they are the rows a reader is least likely
> to question. Re-check them before the platform OpenAI or Gemini key is set on
> a deployment that meters real money. The Anthropic key is the one #1388 is
> actually about; the other two providers price nothing until someone
> configures a key for them.

## What changed

- **Selection.** `InferenceCredentials.select/2` is the whole rule, one pure
  function over the decrypted credentials map. `SpriteEnv.select_inference/2`
  applies it once per provision. No per-agent toggle; the tenant's credential
  always wins. `{:error, :no_credential}` keeps today's behaviour — provision
  anyway, and let the provider's own auth failure land on the transcript.
- **Metering.** `burn_inference` joins `@debit_reasons`. `CreditPricer` gains a
  fourth pass posting `burn_inference:<turn_id>` beside `burn_turn`, idempotent
  per turn, from `turns.usage`. It deliberately does **not** filter on sandbox
  provider: a self-hosted runner costs Fountain no sandbox time and still spends
  Fountain's inference key.
- **Circuit breaker.** `PlatformInference.gate/2` runs at the four conversation
  doors and `TurnMachine.gate/2` is the per-turn backstop. Refusal is
  `503 platform_inference_unavailable` with `retry-after`, like `:fleet_full`
  and unlike a 402 — this is Fountain's limit, not the tenant's balance.
- **Visibility.** A platform turn's `usage` carries `inference` and `model`.
  `CreditsLive` gets a `ledger_label` clause; `/admin/finance` gains a
  "Platform inference" tile and a per-tenant column, read off the ledger rather
  than a rate card, so it lands in revenue and cost both and nets to zero
  margin. That is the point of showing it.
- **ADRs.** 0008's body now carries the amendment; 0030 and 0031 each get the
  one-line note; 0038's status block records what shipped and why the price is
  pass-through. `okf validate decisions` is clean and the index is unchanged
  (no frontmatter moved).
- **Docs.** A `## Platform inference` section in `docs/configuration.md`, plus
  `.env.example`.

## Egress (item 7), confirmed both ways

The platform key is merged into the same `%{credential => value}` map a
tenant's own key occupies, *before* `Egress.split_inference/4`. So:

- **Brokered:** `Broker.split_inference/2` keys purely off the credential atom,
  so the platform key becomes a placeholder in the sandbox and the real value
  goes to the broker with an implicit `substitute` binding to
  `api.anthropic.com`. Asserted end to end in
  `conversation_server_platform_inference_test.exs` — the brokered map holds
  the key, the binding is right, and the value appears nowhere in the spawn env.
- **Non-brokered:** it reaches `runtime_module.default_env/2` unchanged.
  Asserted on the server's `env_credentials` plus
  `Managoat.Runtimes.Claude.default_env/2` turning it into `ANTHROPIC_API_KEY`
  (the harness runtime ignores credentials, which is the same shape the
  existing broker test uses).

## Deliberately left out

- **The ceiling is inert with `CREDITS_ENABLED=false`**, because it is measured
  from the `burn_inference` ledger rows and nothing is priced with credits off
  (ADR 0031's own rule). This is intended: with credits off the key is the
  self-hoster's own and so is the provider bill, so there is no Fountain money
  to protect. It does mean such a deployment has **no ceiling at all** on
  platform inference, which `docs/configuration.md` now says under its own
  heading rather than only implying through the `CREDITS_ENABLED` prerequisite.
  On the hosted deployment credits are on, which is where the ceiling matters.
- **The ceiling lags the pricer's tick** by up to one interval. It bounds a
  day, not a minute. Also documented.
- **A turn whose runtime reported no usage is not priced and not marked.** No
  tokens reported means nothing to price; recording a zero would be a claim.
- **`google/gemini-3.1-pro-preview` over 200K input** is priced at the
  short-context rate ($2/$12, not $4/$18). Over-charging every short turn by 2x
  is the worse error, and the daily ceiling bounds the other direction.
- **No admin surface for the platform keys.** They are deployment config, like
  every other secret in `runtime.exs`.

## Surprises

- **The size ratchet.** `ConversationServer` has a line-count pin (#1369) and my
  additions went 34 over it. I moved `TurnMachine.ctx/2`,
  `TurnMachine.autonomous_turn?/1` and the inference selection out rather than
  raising it; the pin drops 3049 -> 3048.
- **`stub_happy_sprite/0` re-stubs `InferenceCredentials.decrypted_for_user/2`**,
  so a Mimic stub set before it is silently overwritten. Cost me a confusing
  failure; there is now a comment at the call site.
- **ADR 0008's frontmatter already said "Amended by 0038"** before this PR. Only
  the body needed the status line.

## Verification

`mix precommit` from the umbrella root: compile with warnings-as-errors clean,
`deps.unlock --unused` clean, `format --check-formatted` clean, `credo --strict`
"found no issues", dialyzer "Total errors: 0", sobelow "done (passed
successfully)", **6 doctests, 4022 tests, 0 failures**.

Docs gates: `python3 scripts/docs-style.py` clean, `vale lint docs` exit 0,
`node scripts/destink/destink.mjs` clean, `mix test .../docs_test.exs` 28/0.

One flake seen on an earlier run and not on the final one:
`sse_stream_test.exs` "heartbeats hold the connection open past the idle
timeout" — a wall-clock assertion that fails under full-suite load and passes in
isolation on two seeds. Unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BXYa9CQNG8oFNq5YhAxva

