### PR TITLE
feat(onboarding): a default agent in every account at verification

### DIFF
--- a/apps/fountain/lib/fountain/accounts.ex
+++ b/apps/fountain/lib/fountain/accounts.ex
@@ -178,10 +178,19 @@ defmodule Fountain.Accounts do
   verification route — the emailed link, `Fountain.Release.verify_email/1`,
   and the `EMAIL_DELIVERY=none` auto-verify — behaves the same.
 
+  It is also where an account gets the two things it is meant to have before
+  it has built anything: the opening credit (ADR 0031) and the starter agent
+  (ADR 0038, `Fountain.Agents.Starter`). Both are best-effort and neither can
+  fail a verification.
+
   Returns `{:ok, user}` or `{:error, changeset}`.
   """
   @spec verify_email(User.t(), keyword()) :: {:ok, User.t()} | {:error, Ecto.Changeset.t()}
   def verify_email(%User{} = user, opts \\ []) do
+    # The before-state, read before the update overwrites it: the starter
+    # agent lands on the transition, not on every call of this function.
+    first_verification? = is_nil(user.email_verified_at)
+
     result =
       user
       |> Ecto.Changeset.change(
@@ -193,6 +202,7 @@ defmodule Fountain.Accounts do
 
     with {:ok, verified} <- result do
       verified = maybe_bootstrap_first_admin(verified)
+      plant_starter_agent(verified, first_verification?)
       broadcast_verification(verified)
       {:ok, verified}
     end
@@ -210,6 +220,27 @@ defmodule Fountain.Accounts do
   end
 
   defp grant_opening_credit(_), do: :ok
+
+  # The default agent (ADR 0038 decision 4) is planted beside the opening
+  # credit, for the same reason and on the same transition: a verified account
+  # must have something to send a first request to without building anything.
+  #
+  # Guarded on the *transition* rather than on the agent's existence, so that
+  # re-running a verification route on an already-verified account — the
+  # release task, a second click on the emailed link — cannot resurrect an
+  # agent the tenant deleted. `Starter.create_for/2` is idempotent by name on
+  # top of that, which covers two doors finishing the same verification at once.
+  #
+  # Best-effort by rescuing, exactly like the credit: no failure to make an
+  # agent is worth refusing someone their account.
+  defp plant_starter_agent(%User{} = user, true) do
+    Fountain.Agents.Starter.create_for(user.id)
+    :ok
+  rescue
+    e -> Logger.warning("starter agent for #{user.id} failed: #{inspect(e)}")
+  end
+
+  defp plant_starter_agent(_user, _first_verification?), do: :ok
 
   @doc """
   PubSub topic carrying a user's verification transition.

--- a/apps/fountain/lib/fountain/agents/starter.ex
+++ b/apps/fountain/lib/fountain/agents/starter.ex
@@ -1,0 +1,105 @@
+defmodule Fountain.Agents.Starter do
+  @moduledoc """
+  The one agent every account is verified into owning (ADR 0038 decision 4).
+
+  It exists so that a freshly verified account has something to send a first
+  request to. Before it, the first screen asked for an inference credential, an
+  agent and a conversation before anything could run.
+
+  What it is *not* is a special kind of agent. There is no flag on the row, no
+  branch that reads its name, and nothing that recreates it: it is listed,
+  edited, launched and deleted exactly like an agent the developer wrote. This
+  module holds the definition and the one call site that plants it, and that is
+  the whole of its existence in the codebase.
+
+  Its inference runs on the platform key while the account has no credential of
+  its own (#1388); the selection rule lives there, not here. On a deployment
+  with no platform key the first run fails with the existing "no credential"
+  error, which is where the account was starting from anyway.
+
+  The canned manifests under `examples/agents/` were the other candidate source
+  for this definition (#1010). The only one is `fountain-contributor`, which
+  needs an environment, a repository and a GitHub token — the three costs this
+  agent exists to remove — so the definition below is its own.
+  """
+
+  alias Fountain.Agents
+
+  @name "starter"
+  @runtime "claude"
+  @model "anthropic/claude-sonnet-5"
+
+  @description "The agent this account started with. Runs on Fountain's " <>
+                 "inference key until you add your own. Edit it or delete it freely."
+
+  @system """
+  You are `starter`, the agent Fountain put in this account when it was
+  verified. You exist so that there is something to send a first request to.
+
+  While this account has no inference credential of its own, your model runs on
+  Fountain's platform key and each turn is billed against the account's credit
+  balance. Adding a credential on the credentials page moves you onto that key.
+  Nothing here changes when it does.
+
+  You are an ordinary agent. Change the model, this prompt, the environment and
+  the skills, or delete this agent and write your own with `fountain apply`.
+
+  No environment is attached, so you run in a plain sandbox: no repository, no
+  extra packages and no MCP servers. Answer what you are asked. When a request
+  needs a repository or a tool you do not have, say what is missing and where it
+  is configured rather than guessing at it.
+  """
+
+  @doc "The agent's name. `starter`, and the tenant may rename it the next minute."
+  @spec name() :: String.t()
+  def name, do: @name
+
+  @doc """
+  The attrs the starter agent is created from, for `user_id`.
+
+  String-keyed, so it reads the way every other `create_agent/2` call site and
+  the factories do.
+  """
+  @spec attrs(binary()) :: map()
+  def attrs(user_id) when is_binary(user_id) do
+    %{
+      "user_id" => user_id,
+      "name" => @name,
+      "runtime" => @runtime,
+      "model" => @model,
+      "description" => @description,
+      "system" => @system
+    }
+  end
+
+  @doc """
+  Create the starter agent for `user_id`.
+
+  Idempotent per account by name: an account that already has an agent called
+  `starter` gets nothing, which is what makes a re-run of a verification route
+  harmless. It is *not* a resurrection — the call site fires on the
+  unverified-to-verified transition only, so deleting the agent afterwards
+  leaves it deleted.
+
+  Returns `{:ok, agent}`, `{:ok, :exists}`, or the changeset error. Callers on
+  the verification path treat every outcome as non-fatal; see
+  `Fountain.Accounts.verify_email/2`.
+  """
+  @spec create_for(binary(), keyword()) ::
+          {:ok, Agents.Agent.t()} | {:ok, :exists} | {:error, Ecto.Changeset.t()}
+  def create_for(user_id, opts \\ []) when is_binary(user_id) do
+    case Agents.get_agent_by_name(@name, user_id) do
+      nil -> Agents.create_agent(attrs(user_id), Keyword.put_new(opts, :actor, actor()))
+      _agent -> {:ok, :exists}
+    end
+  end
+
+  @doc """
+  The audit actor for the planting, `system:onboarding` (ADR 0013).
+
+  Not `self`: nobody asked for this agent, and a trail that said the account
+  created it would be describing an account action that never happened.
+  """
+  @spec actor() :: String.t()
+  def actor, do: "system:onboarding"
+end

--- a/apps/fountain/test/fountain/agents/starter_test.exs
+++ b/apps/fountain/test/fountain/agents/starter_test.exs
@@ -1,0 +1,137 @@
+defmodule Fountain.Agents.StarterTest do
+  @moduledoc """
+  The default agent every account is verified into owning (ADR 0038, #1389).
+
+  The behaviour worth pinning is in two halves. One is that it is *there*: a
+  freshly verified account has exactly one agent, from every door that finishes
+  a verification, and the trail says the system made it rather than the account.
+  The other is that it is *ordinary*: nothing recreates it, nothing protects it,
+  and no code path reads its name. The second half is the one a later change is
+  likely to break, which is why deleting it is asserted here rather than assumed.
+  """
+
+  use Fountain.DataCase, async: true
+
+  alias Fountain.{Accounts, Agents, Audit}
+  alias Fountain.Agents.Starter
+
+  defp agents(user), do: Agents.list_agents(user.id, [])
+
+  defp agent_created_events(user) do
+    user.id
+    |> Audit.list_recent_for_user(200)
+    |> Enum.filter(&(&1.action == "agent.created"))
+  end
+
+  describe "verification plants it" do
+    test "a freshly verified account has exactly one agent" do
+      user = insert_verified_user()
+
+      assert [agent] = agents(user)
+      assert agent.name == "starter"
+      assert agent.runtime == "claude"
+      assert agent.user_id == user.id
+    end
+
+    test "it is configured to need nothing: no environment, no MCP, no skills" do
+      # The three things the first screen used to ask for. An agent that needed
+      # any of them would not be an agent a blank account can run.
+      assert [agent] = agents(insert_verified_user())
+
+      assert agent.environment_id == nil
+      assert agent.mcp_servers == %{}
+      assert agent.skills == []
+    end
+
+    test "its prompt says what it is and whose inference key it runs on" do
+      assert [agent] = agents(insert_verified_user())
+
+      assert agent.system =~ "starter"
+      assert agent.system =~ "platform key"
+      assert agent.system =~ "credential"
+      assert agent.description != ""
+    end
+
+    test "an unverified account has no agent" do
+      # Nothing is created for an account until it verifies (ADR 0038).
+      user = insert_user()
+
+      assert agents(user) == []
+    end
+  end
+
+  describe "the audit trail" do
+    test "records agent.created with actor system:onboarding" do
+      user = insert_verified_user()
+
+      assert [event] = agent_created_events(user)
+      assert event.actor == "system:onboarding"
+      assert event.resource_type == "agent"
+      assert event.metadata["name"] == "starter"
+    end
+
+    test "the actor is not `self` — the account did not ask for this" do
+      user = insert_verified_user()
+
+      refute Enum.any?(agent_created_events(user), &(&1.actor == "self"))
+    end
+  end
+
+  describe "it is an ordinary agent" do
+    test "it can be renamed, re-pointed and re-prompted like any other" do
+      user = insert_verified_user()
+      [agent] = agents(user)
+
+      assert {:ok, updated} =
+               Agents.update_agent(agent, %{
+                 "name" => "mine",
+                 "model" => "anthropic/claude-opus-5",
+                 "system" => "Do as I say."
+               })
+
+      assert updated.name == "mine"
+      assert updated.model == "anthropic/claude-opus-5"
+    end
+
+    test "deleting it leaves the account with no agents, and nothing brings it back" do
+      user = insert_verified_user()
+      [agent] = agents(user)
+
+      assert {:ok, _} = Agents.delete_agent(agent)
+      assert agents(user) == []
+
+      # Re-running a verification route on an already-verified account is the
+      # way this would resurrect. It must not: the account deleted it.
+      {:ok, _} = Accounts.verify_email(Fountain.Repo.reload!(user))
+
+      assert agents(user) == []
+    end
+  end
+
+  describe "create_for/2" do
+    test "is idempotent per account" do
+      user = insert_verified_user()
+
+      assert {:ok, :exists} = Starter.create_for(user.id)
+      assert length(agents(user)) == 1
+    end
+
+    test "plants one for an account that has none" do
+      user = insert_user_without_agents()
+
+      assert {:ok, agent} = Starter.create_for(user.id)
+      assert agent.name == "starter"
+      assert [_] = agents(user)
+    end
+
+    test "the model is a canonical provider/model_id under the claude runtime" do
+      # `Agent.changeset/2` rejects a mismatched prefix, so a wrong default here
+      # would fail every verification's planting silently (best-effort) and
+      # leave new accounts empty. Asserted rather than trusted to the insert.
+      attrs = Starter.attrs(Ecto.UUID.generate())
+
+      assert attrs["runtime"] == "claude"
+      assert attrs["model"] =~ ~r"^anthropic/"
+    end
+  end
+end

--- a/apps/fountain/test/fountain/agents_test.exs
+++ b/apps/fountain/test/fountain/agents_test.exs
@@ -83,8 +83,8 @@ defmodule Fountain.AgentsTest do
 
   describe "list_agents/2" do
     test "returns only agents for the given user" do
-      user_a = insert_verified_user()
-      user_b = insert_verified_user()
+      user_a = insert_user_without_agents()
+      user_b = insert_user_without_agents()
       agent_a = insert_agent(user_id: user_a.id)
       _agent_b = insert_agent(user_id: user_b.id)
 
@@ -94,7 +94,7 @@ defmodule Fountain.AgentsTest do
     end
 
     test "returns empty list when user has no agents" do
-      user = insert_verified_user()
+      user = insert_user_without_agents()
       assert Agents.list_agents(user.id, []) == []
     end
 
@@ -117,7 +117,7 @@ defmodule Fountain.AgentsTest do
     end
 
     test "runtimes filter returns only matching agents" do
-      user = insert_verified_user()
+      user = insert_user_without_agents()
       insert_agent(user_id: user.id, runtime: "claude")
       insert_agent(user_id: user.id, runtime: "claude")
 
@@ -325,7 +325,7 @@ defmodule Fountain.AgentsTest do
     end
 
     test "env_ids: [\"none\", env.id] returns agents with no env OR that env" do
-      user = insert_verified_user()
+      user = insert_user_without_agents()
       env_a = insert_env(user_id: user.id)
       env_b = insert_env(user_id: user.id)
       agent_no_env = insert_agent(user_id: user.id)
@@ -410,7 +410,7 @@ defmodule Fountain.AgentsTest do
 
   describe "list_agents_with_counts/2" do
     test "returns conversation_count 0 for agent with no conversations" do
-      user = insert_verified_user()
+      user = insert_user_without_agents()
       _agent = insert_agent(user_id: user.id)
 
       results = Agents.list_agents_with_counts(user.id, [])
@@ -419,8 +419,8 @@ defmodule Fountain.AgentsTest do
     end
 
     test "does not return agents belonging to another user" do
-      user_a = insert_verified_user()
-      user_b = insert_verified_user()
+      user_a = insert_user_without_agents()
+      user_b = insert_user_without_agents()
       agent_a = insert_agent(user_id: user_a.id)
       _agent_b = insert_agent(user_id: user_b.id)
 
@@ -430,7 +430,7 @@ defmodule Fountain.AgentsTest do
     end
 
     test "returns correct conversation_count for agent with conversations" do
-      user = insert_verified_user()
+      user = insert_user_without_agents()
       agent = insert_agent(user_id: user.id)
       insert_conversation(user_id: user.id, agent_id: agent.id)
       insert_conversation(user_id: user.id, agent_id: agent.id)
@@ -441,7 +441,7 @@ defmodule Fountain.AgentsTest do
     end
 
     test "does not count conversations belonging to other agents" do
-      user = insert_verified_user()
+      user = insert_user_without_agents()
       agent_a = insert_agent(user_id: user.id)
       agent_b = insert_agent(user_id: user.id)
       insert_conversation(user_id: user.id, agent_id: agent_b.id)
@@ -452,7 +452,7 @@ defmodule Fountain.AgentsTest do
     end
 
     test "accepts the same filters as list_agents/2" do
-      user = insert_verified_user()
+      user = insert_user_without_agents()
       insert_agent(user_id: user.id, name: "alpha", runtime: "claude")
       insert_agent(user_id: user.id, name: "beta", runtime: "gemini")
 
@@ -462,8 +462,8 @@ defmodule Fountain.AgentsTest do
     end
 
     test "does not count conversations belonging to another user" do
-      user_a = insert_verified_user()
-      user_b = insert_verified_user()
+      user_a = insert_user_without_agents()
+      user_b = insert_user_without_agents()
       agent = insert_agent(user_id: user_a.id)
       insert_conversation(user_id: user_b.id, agent_id: agent.id)
 
@@ -473,7 +473,7 @@ defmodule Fountain.AgentsTest do
     end
 
     test "preloads the environment association" do
-      user = insert_verified_user()
+      user = insert_user_without_agents()
       env = insert_env(user_id: user.id)
       _agent = insert_agent(user_id: user.id, environment_id: env.id)
 

--- a/apps/fountain/test/fountain/audit_test.exs
+++ b/apps/fountain/test/fountain/audit_test.exs
@@ -80,11 +80,12 @@ defmodule Fountain.AuditTest do
       b_ids = user_b.id |> Audit.list_recent_for_user() |> Enum.map(& &1.id)
 
       refute event.id in b_ids
-      # Registration, the verification that `insert_verified_user` performs and
-      # the opening credit that verification posts (ADR 0031) are all audited
-      # in the context, so a fresh verified account opens with three events.
+      # Registration, the verification that `insert_verified_user` performs, the
+      # opening credit that verification posts (ADR 0031) and the starter agent
+      # it plants (ADR 0038) are all audited in the context, so a fresh
+      # verified account opens with four events.
       assert Audit.list_recent_for_user(user_b.id) |> Enum.map(& &1.action) ==
-               ["auth.email.verified", "credit.granted", "account.registered"]
+               ["agent.created", "auth.email.verified", "credit.granted", "account.registered"]
     end
 
     test "respects limit" do

--- a/apps/fountain/test/fountain/exports_test.exs
+++ b/apps/fountain/test/fountain/exports_test.exs
@@ -92,7 +92,9 @@ defmodule Fountain.ExportsTest do
   # Seed one account with every kind of owned data, including a real encrypted
   # secret, and a second account whose data must never bleed in.
   defp seed_account do
-    user = insert_verified_user()
+    # No starter agent (ADR 0038): every assertion below names the rows this
+    # function seeded, and an agent verification handed out is not one of them.
+    user = insert_user_without_agents()
 
     env = insert_env(user_id: user.id, name: "export-env")
     insert_secret(env, %{"key" => "EXPORT_TOKEN", "value" => @secret_value})

--- a/apps/fountain/test/fountain/funnel_test.exs
+++ b/apps/fountain/test/fountain/funnel_test.exs
@@ -258,9 +258,11 @@ defmodule Fountain.FunnelTest do
 
       assert stalled.count == 3
       assert stalled.by_onboarding_state == %{"step_1" => 1, "step_3" => 2}
-      assert stalled.built_agent == 1
+      # All three, and none: every verified account owns a starter agent
+      # (ADR 0038). #1421 replaces this decomposition.
+      assert stalled.built_agent == 3
       assert stalled.built_environment == 1
-      assert stalled.built_nothing == 1
+      assert stalled.built_nothing == 0
     end
 
     test "started: the stalled accounts that ran something and got nothing back" do

--- a/apps/fountain/test/fountain/manifest_test.exs
+++ b/apps/fountain/test/fountain/manifest_test.exs
@@ -4,7 +4,9 @@ defmodule Fountain.ManifestTest do
   alias Fountain.{Agents, Crypto, Environments, Manifest, Vaults}
 
   setup do
-    %{user: insert_verified_user()}
+    # No starter agent (ADR 0038): every assertion here counts what the
+    # manifest reconciled, and an agent the account was given is not that.
+    %{user: insert_user_without_agents()}
   end
 
   defp env_resource(name, spec \\ %{}) do

--- a/apps/fountain/test/fountain/team_test.exs
+++ b/apps/fountain/test/fountain/team_test.exs
@@ -570,7 +570,9 @@ defmodule Fountain.TeamTest do
 
   describe "list_addable_agents/1" do
     test "the user's agents not yet on the team" do
-      user = insert_verified_user()
+      # No starter agent (ADR 0038): the subject is which of the two agents
+      # below is addable, not how many agents the account happens to own.
+      user = insert_user_without_agents()
       ada = insert_agent(user_id: user.id, name: "Ada")
       linus = insert_agent(user_id: user.id, name: "Linus")
       insert_teammate_conv(user, ada)

--- a/apps/fountain/test/fountain_web/audit_resource_crud_test.exs
+++ b/apps/fountain/test/fountain_web/audit_resource_crud_test.exs
@@ -88,9 +88,17 @@ defmodule FountainWeb.AuditResourceCrudTest do
 
     test "a rejected changeset records nothing", %{user: user} do
       # The mutation did not happen, so the trail must not claim it did.
+      #
+      # Counted rather than refuted: the account already owns one
+      # `agent.created`, for the starter agent verification planted (ADR 0038),
+      # so what "records nothing" means here is that the number did not move.
+      # The assertion on the baseline keeps the guard from passing over nothing.
+      before = Enum.count(actions_for(user.id), &(&1 == "agent.created"))
+      assert before == 1
+
       {:error, _} = Agents.create_agent(agent_attrs(%{"user_id" => user.id, "name" => ""}))
 
-      refute "agent.created" in actions_for(user.id)
+      assert Enum.count(actions_for(user.id), &(&1 == "agent.created")) == before
     end
 
     test "an update records which fields moved, never their values", %{user: user} do

--- a/apps/fountain/test/fountain_web/controllers/account_data_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/account_data_controller_test.exs
@@ -17,7 +17,9 @@ defmodule FountainWeb.AccountDataControllerTest do
   alias Fountain.Workers.AccountExport
 
   setup do
-    user = insert_verified_user()
+    # No starter agent (ADR 0038), so an export's `agents` list holds exactly
+    # what a test seeded into it.
+    user = insert_user_without_agents()
     {_rec, key} = insert_api_key(user)
     {:ok, user: user, key: key}
   end

--- a/apps/fountain/test/fountain_web/controllers/agent_filter_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/agent_filter_test.exs
@@ -11,7 +11,10 @@ defmodule FountainWeb.AgentFilterTest do
   use FountainWeb.ConnCase, async: true
 
   setup do
-    user = insert_verified_user()
+    # No starter agent (ADR 0038): every count below is of the two agents this
+    # setup creates, and a third one nobody asked for would only obscure which
+    # filter matched what.
+    user = insert_user_without_agents()
     {_key, raw_key} = insert_api_key(user)
     env = insert_env(user_id: user.id)
 

--- a/apps/fountain/test/fountain_web/controllers/audit_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/audit_controller_test.exs
@@ -121,8 +121,10 @@ defmodule FountainWeb.AuditControllerTest do
     test "resource_type is an exact match", %{conn: conn, key: key} do
       body = list(conn, key, "?resource_type=agent")
 
-      assert length(body["data"]) == 1
-      assert hd(body["data"])["resource_type"] == "agent"
+      # Exact: the two `vault_secret` rows are out. What is in is every `agent`
+      # row the account has — the one this setup recorded, and the starter
+      # agent verification planted (ADR 0038).
+      assert Enum.map(body["data"], & &1["resource_type"]) == ["agent", "agent"]
     end
 
     test "since and until bound the window", %{conn: conn, user: user, key: key} do

--- a/apps/fountain/test/fountain_web/controllers/export_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/export_controller_test.exs
@@ -25,7 +25,9 @@ defmodule FountainWeb.ExportControllerTest do
   end
 
   test "the owner downloads a plain JSON file", %{conn: conn} do
-    user = insert_verified_user()
+    # No starter agent (ADR 0038), so the one agent in the payload is the one
+    # this test put there.
+    user = insert_user_without_agents()
     insert_agent(user_id: user.id, name: "download-agent")
     export = completed_export(user)
 

--- a/apps/fountain/test/fountain_web/controllers/list_counts_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/list_counts_test.exs
@@ -11,7 +11,10 @@ defmodule FountainWeb.ListCountsTest do
   use FountainWeb.ConnCase, async: true
 
   setup do
-    user = insert_verified_user()
+    # No starter agent (ADR 0038). `first/2` below takes the head of the list,
+    # and two agents inserted in the same second are ordered by a random id —
+    # so the agent under test has to be the only one.
+    user = insert_user_without_agents()
     {_rec, key} = insert_api_key(user)
     {:ok, user: user, key: key}
   end

--- a/apps/fountain/test/fountain_web/controllers/openai_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/openai_controller_test.exs
@@ -17,7 +17,9 @@ defmodule FountainWeb.OpenAIControllerTest do
   alias FountainWeb.OpenAIController
 
   setup do
-    user = insert_verified_user()
+    # No starter agent (ADR 0038): `/v1/models` lists every agent the tenant
+    # owns, and the model list here is meant to be the agents these tests name.
+    user = insert_user_without_agents()
     {_key, raw_key} = insert_api_key(user)
     agent = insert_agent(user_id: user.id, name: "pr-reviewer")
 

--- a/apps/fountain/test/fountain_web/live/admin_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/admin_live_test.exs
@@ -63,7 +63,8 @@ defmodule FountainWeb.AdminLiveTest do
       # conversation that never answered is a start, not an activation.
       assert html =~ "2 verified users have never had a reply"
       assert html =~ "started a conversation and got nothing back: 1"
-      assert html =~ "built an agent: 1"
+      # Both, because a verified account owns a starter agent (ADR 0038).
+      assert html =~ "built an agent: 2"
     end
 
     test "shows time to first reply", %{conn: conn} do

--- a/apps/fountain/test/fountain_web/live/agents_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/agents_live_test.exs
@@ -19,7 +19,9 @@ defmodule FountainWeb.AgentsLive.IndexTest do
     end
 
     test "renders empty state when user has no agents", %{conn: conn} do
-      user = insert_verified_user()
+      # Verification plants the starter agent (ADR 0038), so an account with no
+      # agents is now one that deleted it — still a state the page has to draw.
+      user = insert_user_without_agents()
       conn = login_user(conn, user)
 
       {:ok, _view, html} = live(conn, ~p"/agents")

--- a/apps/fountain/test/fountain_web/live/dashboard_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/dashboard_live_test.exs
@@ -36,9 +36,13 @@ defmodule FountainWeb.DashboardLiveTest do
     assert html =~ "Before an agent can run"
     assert html =~ "An inference credential"
     assert html =~ "/account/inference-credentials"
-    assert html =~ "An agent"
-    assert html =~ "/agents/new"
     assert html =~ "https://apps.test/convs/#/new"
+
+    # The agent step arrives ticked: verification plants the starter agent
+    # (ADR 0038), so the item this list used to send a new account away to
+    # build is the one it now already has. #1390 replaces the checklist.
+    assert html =~ "An agent"
+    refute html =~ "/agents/new"
   end
 
   test "a step that is done is ticked and loses its call to action", %{conn: conn, user: user} do

--- a/apps/fountain/test/fountain_web/self_host_bootstrap_test.exs
+++ b/apps/fountain/test/fountain_web/self_host_bootstrap_test.exs
@@ -53,6 +53,12 @@ defmodule FountainWeb.SelfHostBootstrapTest do
       user = Accounts.get_user_by_email("hoster@example.com")
       assert %DateTime{} = user.email_verified_at
       refute_enqueued(worker: VerificationEmail)
+
+      # The self-verifying door is verification like any other, so it plants
+      # the starter agent too (ADR 0038). It is also the only door that runs
+      # inside the registration transaction, which is where a planting that
+      # rolled back would take the whole account with it.
+      assert [%{name: "starter"}] = Fountain.Agents.list_agents(user.id, [])
     end
 
     test "API signup self-verifies and says so", %{conn: conn} do

--- a/apps/fountain/test/support/factory.ex
+++ b/apps/fountain/test/support/factory.ex
@@ -29,6 +29,13 @@ defmodule Fountain.Factory do
     user
   end
 
+  @doc """
+  A verified user, with everything verification gives an account: the $5
+  opening credit (ADR 0031) and the `starter` agent (ADR 0038). Both are real
+  rows, because both are what a verified account really has — see
+  `insert_empty_user/1` and `insert_user_without_agents/1` for the tests that
+  need one of them gone.
+  """
   def insert_verified_user(overrides \\ %{}) do
     user = insert_user(overrides)
     {:ok, verified} = Fountain.Accounts.verify_email(user)
@@ -41,6 +48,46 @@ defmodule Fountain.Factory do
   "an account that may spend" keep reading.
   """
   def insert_active_user(overrides \\ %{}), do: insert_verified_user(overrides)
+
+  @doc """
+  Delete the starter agent verification plants (ADR 0038, #1389).
+
+  Every verified account owns one, so `insert_verified_user/1` no longer
+  produces an account with no agents. Tests whose subject is a *controlled* set
+  of agents — a filter's arithmetic, the empty state, an export's contents —
+  call this first and then insert exactly what they mean to count. Tests whose
+  subject is a real surface should show the starter rather than delete it: an
+  account listing its agents genuinely has this one.
+
+  Deletes the row directly rather than through `Agents.delete_agent/2`, so a
+  test asserting on the audit trail sees no `agent.deleted` it did not cause.
+  Raises when there is no starter to delete, so this cannot quietly become a
+  no-op if the planting moves.
+  """
+  def delete_starter_agent(%{id: user_id}), do: delete_starter_agent(user_id)
+
+  def delete_starter_agent(user_id) when is_binary(user_id) do
+    name = Fountain.Agents.Starter.name()
+
+    {1, _} =
+      Repo.delete_all(
+        Ecto.Query.from(a in Fountain.Agents.Agent,
+          where: a.user_id == ^user_id and a.name == ^name
+        )
+      )
+
+    :ok
+  end
+
+  @doc """
+  A verified user with no agents: `insert_verified_user/1` with the starter
+  agent removed. See `delete_starter_agent/1`.
+  """
+  def insert_user_without_agents(overrides \\ %{}) do
+    user = insert_verified_user(overrides)
+    :ok = delete_starter_agent(user)
+    user
+  end
 
   @doc """
   A verified user with an empty ledger: the opening credit every verified

--- a/decisions/0013-audit-trail.md
+++ b/decisions/0013-audit-trail.md
@@ -95,12 +95,21 @@ for the sandbox privilege-escalation fix make them distinguishable.
 `system:<worker>` names are snake_case and match the module doing the work:
 `conversation_server`, `sandbox_reaper`, `retention_pruner`, `release_task`,
 `provisioning`, `account_export`, `unverified_pruner`, `verify_lifecycle`,
-`team_scheduler`, `webhook_delivery`, and
+`team_scheduler`, `webhook_delivery`, `onboarding`, and
 in `ee/` the billing sources `webhook`, `stripe`, `local`, `trial_sweeper`.
 
 `webhook_delivery` was added by [0024](0024-outbound-webhooks.md): the delivery
 worker disables an endpoint after sustained failure, which is a mutation of
 tenant state with no human behind it.
+
+`onboarding` was added by [0038](0038-onboarding-first-reply.md) and #1389:
+verification plants a starter agent in the account, which is an `agent.created`
+in a tenant's trail that the tenant did not ask for. It is the one member of
+the vocabulary named after a moment rather than a worker module, because the
+work is done inline on the verification transition rather than by a background
+worker of its own. `self` would have been the wrong answer for the same reason
+`system` is wrong on the unauthenticated routes: it names a principal that did
+not act.
 
 Two rules keep the list from fraying:
 

--- a/decisions/0038-onboarding-first-reply.md
+++ b/decisions/0038-onboarding-first-reply.md
@@ -20,7 +20,7 @@ stale_after: 2026-11-02
 and measured) and #1393 (the field cleanup), all sub-issues of #1039. Each PR
 that builds one updates this block.
 
-**Built so far:** decisions 2 (#1392) and 3 (#1388).
+**Built so far:** decisions 2 (#1392), 3 (#1388) and 4 (#1389).
 
 Decision 2: `Fountain.Activation` holds the definition, `Fountain.Funnel`
 counts it and measures verification to first reply, and
@@ -33,6 +33,10 @@ selection rule, a `burn_inference` debit per closed platform turn from
 `PLATFORM_INFERENCE_DAILY_CENTS` (default 5000) as a deployment-wide daily
 circuit breaker answering 503.
 
+Decision 4: `Fountain.Agents.Starter` is planted by `Accounts.verify_email/2`,
+so an account verified from now on owns one agent from the moment it is
+verified.
+
 **The price is pass-through at provider list, a 1.0x margin, no markup**
 (decided with Jake on 2026-09-02). Fountain's margin is sandbox time
 (`CREDIT_TURN_HOUR_CENTS`, [0031](0031-credits-are-the-product.md)). Marking
@@ -40,10 +44,10 @@ inference up would make the opening credit buy less of the one thing it was
 granted to buy, which is the reply this ADR is about. A future decision may
 change that; a passing thought about margin should not.
 
-Not built: the default agent, the verified landing, the CLI commands and the
-field cleanup. `onboarding_completed_at` is still stamped by the dashboard
-checklist (#1390 moves the stamp to the seam
-`Fountain.Activation.capture_first_reply/2` marks).
+Not built: the verified landing, the CLI commands and the field cleanup.
+`onboarding_completed_at` is still stamped by the dashboard checklist (#1390
+moves the stamp to the seam `Fountain.Activation.capture_first_reply/2`
+marks).`Fountain.Activation.capture_first_reply/2` marks).
 
 Amends [0008](0008-byo-inference-credentials.md): Fountain will hold platform
 inference keys. Leans on [0031](0031-credits-are-the-product.md) (the opening
@@ -108,7 +112,9 @@ them nothing; inference is the second cost on the same first run.
 4. **Every account has a default agent from the moment it is verified**, a
    canned agent on the claude runtime created beside the opening credit,
    ordinary in every way (listed, editable, deletable, never recreated). It
-   exists so there is something to send the first request to. (#1389)
+   exists so there is something to send the first request to. (#1389, built:
+   `Fountain.Agents.Starter`, planted by `Accounts.verify_email/2` and audited
+   as `system:onboarding` per [0013](0013-audit-trail.md).)
 
 5. **The path is a key and one request, and the API carries it.** The first
    screen after verification hands the developer their API key and one
@@ -148,9 +154,17 @@ developer takes because they want to, not because nothing works without it.
   that have not supplied a key. The per-tenant DEK, the BYO path and "the
   tenant's credential wins" are unchanged; what changes is the default when
   there is none.
-- **Two tests that count a new account's agents change**, and
-  `insert_verified_user/1` creates an agent. Every test that assumed an
-  empty verified account is touched once.
+- **Twenty-odd tests that count a new account's agents change**, and
+  `insert_verified_user/1` creates an agent. Every test that assumed an empty
+  verified account is touched once; the ones whose subject is a controlled set
+  of agents take the new `insert_user_without_agents/1` instead. Two of them
+  are not arithmetic: the funnel's stalled breakdown now reports "built an
+  agent" for every stalled account and "built nothing" for none, and the
+  dashboard checklist's agent step arrives ticked. #1421 and #1390 own those
+  two surfaces respectively; #1389 left both computing what they always did,
+  and the tests assert the degenerate numbers rather than hiding them. #1421
+  waits for #1390 so that the replacement decomposition is chosen against the
+  funnel's final shape.
 - **Activation counted through turns instead of conversations** will report
   fewer activated accounts than today's funnel, since conversations that
   never answered stop counting. That is the point; the PR that changes it


### PR DESCRIPTION
Closes #1389. ADR 0038 decision 4.

## What changed

Verification plants one agent, beside the opening credit and on the same
transition: `starter`, claude runtime, `anthropic/claude-sonnet-5`, no
environment, no MCP servers, no skills, and a short system prompt that says
what it is and that its inference runs on Fountain's key until the account
adds its own credential.

`Fountain.Agents.Starter` is the whole of it — the definition, and
`create_for/2`. `Accounts.verify_email/2` calls it beside
`grant_opening_credit/1`. Nothing else in the codebase reads its name.

**It is an ordinary agent.** It lists, edits, launches and deletes like one
the developer wrote, and nothing recreates it: the planting is guarded on the
`nil -> verified` transition, so re-running a verification route (the release
task, a second click on the emailed link) on an account that deleted its
starter does not bring it back. `create_for/2` is idempotent by name on top of
that, for two doors finishing the same verification at once. Best-effort by
rescuing, like the credit grant.

Inference selection (#1388) is untouched and unstubbed. On a deployment with
no platform key the first run fails with the existing "no credential" error.

### Not from the canned set

The issue asks to reuse a canned manifest from #1010. The only entry under
`examples/agents/` is `fountain-contributor`, which needs an environment, a
repository and a GitHub token — the three costs this agent exists to remove —
so the definition is its own, in code, as the single source.

### Audit

`agent.created` with actor `system:onboarding`, a new member of ADR 0013's
closed actor vocabulary. Amended in `decisions/0013-audit-trail.md` with the
reasoning: `self` would name a principal that did not act, for the same reason
a bare `system` is a defect on the unauthenticated routes. `okf validate
decisions` is `"valid": true` (3 pre-existing WARNs on other ADRs); the index
needed no regeneration since no status block moved.

## The test fallout

`insert_verified_user/1` now produces an account with one agent. Twenty tests
across sixteen files assumed otherwise.

- **Controlled-fixture tests** (list/filter arithmetic, exports, `/v1/models`,
  the empty state) take a new `insert_user_without_agents/1` factory, so every
  assertion is preserved verbatim and counts exactly what the test inserted.
- **Real-surface tests** show the starter instead of deleting it: the audit
  trail's opening events are now four, and `?resource_type=agent` returns both
  `agent` rows.
- `audit_resource_crud_test`'s "a rejected changeset records nothing" is now
  a delta on the `agent.created` count, with the baseline asserted so the
  guard cannot pass over nothing.

## Two things I deliberately did not fix

Both are surfaces another issue in this batch owns, and changing their
semantics here would invent a second definition for that issue to reconcile.
Both are recorded in code and asserted in tests rather than papered over.

1. **`Funnel.stalled_breakdown/2` degraded.** Every stalled verified account
   now owns an agent, so `built_agent` equals `count` and `built_nothing` is
   always zero — including on the admin page's one-line breakdown. The numbers
   are still true, they just no longer distinguish anyone. **#1392** redefines
   activation and the breakdown together. There is a comment on the function
   and the funnel test asserts the degenerate values on purpose.
2. **The dashboard checklist's agent step arrives ticked.** A brand-new
   account is no longer offered `/agents/new`. **#1390** replaces the checklist
   with the verified landing.

## Gate

`mix precommit` on `fountain_test_p1389`: compile (warnings-as-errors),
`deps.unlock` check, `format --check-formatted`, `credo --strict` (5811
mods/funs, no issues), dialyzer (Total errors: 0), sobelow, and
**6 doctests, 3994 tests, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BXYa9CQNG8oFNq5YhAxva
