### PR TITLE
feat(sdk): a shared cross-language behavioural conformance suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -914,6 +914,31 @@ jobs:
         working-directory: sdk/elixir
         run: mix test test/contract_test.exs
 
+      # The behavioural half (#1412). sdk/contract pins the shape of the wire;
+      # these scenarios pin what a client does with it — SSE framing, cursor
+      # resume, error mapping, terminal run states. They are one set of JSON
+      # files run by four adapters, so this step checks the files and the three
+      # after it run them.
+      #
+      # The lint is not only a format check: it validates every fixture body
+      # against the schema sdk/contract/contract.json declares for that
+      # operation, which is what stops a scenario going green against a
+      # response the real server would never send.
+      - name: SDK conformance scenarios are well formed
+        run: python3 sdk/conformance/lint.py
+
+      - name: TypeScript SDK conformance
+        working-directory: sdk/typescript
+        run: npm run conformance
+
+      - name: Python SDK conformance
+        working-directory: sdk/python
+        run: python3 -m unittest discover -s tests -p "test_conformance.py" -v
+
+      - name: Elixir SDK conformance
+        working-directory: sdk/elixir
+        run: mix test test/conformance_test.exs
+
       # Eleven browser applications are built on this API, so the SDK's default
       # entry has to bundle for a browser — no Node built-ins reachable from it.
       - name: SDK bundles for the browser
@@ -1009,6 +1034,12 @@ jobs:
       # sdk/contract/contract.json, which is why that file is committed (#1411).
       - name: Swift SDK contract
         run: swift test --configuration debug -Xswiftc -warnings-as-errors --filter ContractTests
+
+      # The behavioural half (#1412), the same scenarios the other three run.
+      # Its own step for the same reason: a divergence should say "Swift SDK
+      # conformance" in the checks list, not hide inside a suite of forty.
+      - name: Swift SDK conformance
+        run: swift test --configuration debug -Xswiftc -warnings-as-errors --filter ConformanceTests
 
       - name: Swift debug tests
         run: swift test --configuration debug -Xswiftc -warnings-as-errors

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -306,6 +306,40 @@ Two things that are not optional:
   which has no Elixir toolchain, can check against it. `dist/openapi.json` is
   the rebuilt input and stays ignored.
 
+### Changing behaviour rather than shape
+
+The contract above covers request and response *shape*. What a client does with
+that shape — SSE framing, reconnect and cursor resume, which error class a
+status becomes, terminal run states, the permission flow, pagination — is the
+shared conformance suite in `sdk/conformance/`, run by all four clients from
+one set of JSON scenarios.
+
+Change one of those behaviours and the scenario is where you start, before any
+client changes:
+
+```bash
+$EDITOR sdk/conformance/scenarios/<name>.json
+python3 sdk/conformance/lint.py
+```
+
+The lint checks the format, checks the support matrix, and checks every fixture
+body against the schema the server declares for that operation, so a scenario
+cannot go green against a response the real server would never send. Then run
+the four adapters:
+
+```bash
+cd sdk/typescript && npm run conformance
+cd sdk/python     && python3 -m unittest discover -s tests -p test_conformance.py
+cd sdk/elixir     && mix test test/conformance_test.exs
+swift test --filter ConformanceTests        # from the repository root
+```
+
+A client that cannot pass a scenario yet gets an entry in
+`sdk/conformance/matrix.json` saying what it does instead and the issue
+tracking it. `lint.py` refuses a skip with no issue number, so a gap is always
+something somebody decided and filed. `sdk/conformance/README.md` is the
+reference for the scenario format and the shared vocabularies.
+
 Do not bump an SDK's version because the contract moved. Merging a version bump
 publishes that SDK, so a version moves when its own public surface changes.
 Label a PR `sdk-no-release` where the distinction needs saying out loud.

--- a/sdk/conformance/README.md
+++ b/sdk/conformance/README.md
@@ -1,0 +1,224 @@
+# The SDK conformance suite
+
+`sdk/contract/` pins the *shape* of the wire. This pins the *behaviour*: what a
+client does with an SSE frame split across two TCP writes, which error class a
+402 becomes, whether a dropped stream resumes from the right cursor, and what
+`run` returns when the turn fails. None of that is in an OpenAPI document, and
+all of it is something Fountain promises in four languages at once.
+
+Each scenario is a JSON file describing bytes in and observations out. Each SDK
+supplies a thin adapter that serves those bytes to its own public client and
+reports what it saw. The scenarios contain no language-specific expectation,
+and the adapters contain no expectation at all.
+
+## Layout
+
+```
+sdk/conformance/
+  README.md            this file: the format, the vocabulary, how to add one
+  scenarios/*.json     the canonical scenarios
+  matrix.json          which SDK runs which scenario, and why not
+  lint.py             validates the scenarios, the matrix and the fixtures
+```
+
+## Running it
+
+| SDK | Command | Run from |
+|---|---|---|
+| TypeScript | `npm run conformance` | `sdk/typescript` |
+| Python | `python3 -m unittest tests.test_conformance` | `sdk/python` |
+| Swift | `swift test --filter ConformanceTests` | repository root |
+| Elixir | `mix test test/conformance_test.exs` | `sdk/elixir` |
+
+Each also runs inside that SDK's normal test command, so a contributor who runs
+the suite gets it without knowing it is there. `python3 sdk/conformance/lint.py`
+checks the scenarios themselves.
+
+## A scenario
+
+```jsonc
+{
+  "name": "sse-multiline-data",
+  "title": "A data field split over several lines joins with newlines",
+  "contract": "sse-framing",
+  "why": "One sentence on what would break in a client that got this wrong.",
+
+  "client": { "api_key": "conformance-key" },
+
+  "http": [
+    {
+      "match": { "method": "POST", "path": "/api/conversations" },
+      "respond": { "status": 201, "json": { "data": { "id": "c1", "status": "running" } } }
+    },
+    {
+      "match": { "method": "GET", "path": "/api/conversations/c1/stream" },
+      "respond": {
+        "status": 200,
+        "headers": { "content-type": "text/event-stream" },
+        "sse": ["id: 1\nevent: output\ndata: {\"id\":1,...}\n\n"],
+        "close": "end"
+      }
+    }
+  ],
+
+  "steps": [{ "op": "run", "agent": "…", "prompt": "hello" }],
+
+  "expect": {
+    "requests": [
+      { "method": "POST", "path": "/api/conversations", "headers": { "authorization": "Bearer conformance-key" } },
+      { "method": "GET", "path": "/api/conversations/c1/stream" }
+    ],
+    "events": [{ "type": "text", "text": "line one\nline two" }],
+    "result": { "state": "done", "text": "line one\nline two" }
+  }
+}
+```
+
+### `http`: the bytes going out
+
+An ordered list of exchanges. For each incoming request the adapter takes the
+**first not-yet-consumed** entry whose `match` fits, and consumes it. Order
+matters only between entries that match the same request, which is how a
+reconnect scenario says "this stream dies, the next one resumes".
+
+A request matching no remaining entry is a failure, reported as an unmatched
+request rather than answered — a client asking for something the scenario did
+not anticipate is a finding, not a 404 to be swallowed.
+
+`match` takes `method`, `path`, and optionally `query` (a subset: every named
+parameter must be present with that value) and `headers` (a subset, names
+lower-cased). `path` is exact; no patterns, because a scenario that cannot say
+which conversation it means is not pinning much.
+
+`respond` is one of two shapes.
+
+**A whole response.** `status`, optional `headers`, and a body as either `json`
+(encoded by the adapter) or `body` (a string sent verbatim, for the malformed
+cases). No body key means no body.
+
+**A stream.** `status`, `headers`, and `sse`: a list of strings written in
+order, each one flushed before the next. A string is one TCP write, so
+splitting a frame across two list entries is how a scenario says "this frame
+arrives fragmented". An entry may be `{"text": "…", "delay_ms": 50}` where the
+timing matters. `close` is `end` for a clean end of stream or `abort` for a
+connection that dies without one, which is what a deploy or a proxy timeout
+looks like to a client that has been reading happily for hours.
+
+**How the bytes reach the client is the adapter's business.** A real loopback
+socket and a transport-level mock are both fine, as long as the client parses
+the same bytes. Swift uses its `MockURLProtocol` rather than a real socket on
+purpose: the `FoundationNetworking` teardown bug is tracked separately and is
+explicitly not this suite's problem.
+
+### `steps`: what the client is asked to do
+
+The vocabulary is small on purpose. Every op is something all four clients
+expose publicly; nothing here reaches into a private class.
+
+| `op` | Fields | What the adapter calls |
+|---|---|---|
+| `me` | | the "who am I" call |
+| `list` | `resource` (`agents`\|`vaults`\|`environments`) | that collection's list |
+| `create_agent` | `attrs` | create an agent from a flat attribute map |
+| `get_conversation` | `conversation_id` | read one conversation |
+| `run` | `agent`, `prompt`, `timeout_ms?`, `answer_permissions?` | start a run and consume it to completion |
+| `send` | `conversation_id`, `prompt` | send a follow-up prompt to an existing conversation |
+| `history` | `conversation_id` | drain the event feed to its end |
+
+`run` consumes the run to completion and records both the events it yielded and
+the result. `answer_permissions` maps a permission request id (or `"*"`) to the
+option id the adapter should answer with, which is how the permission flow is
+driven without the scenario knowing anything about callbacks or futures.
+
+`client` sets up the client: `api_key`, and optionally `base_url_suffix` (append
+to the server's base URL, for the normalisation scenarios) and `timeout_ms`.
+The adapter supplies the base URL; a scenario never knows the port.
+
+### `expect`: what must be observed
+
+Every key is optional, and an absent key asserts nothing.
+
+- **`requests`** — an ordered list. Each entry is a *subset* match against the
+  request the server saw: `method` and `path` exactly, `query`, `headers`
+  (lower-cased names) and `body` as subsets. Four clients do not agree on every
+  header they send, and this suite is not the place to make them.
+  `header_prefixes` asserts a header starts with a string, for the ones whose
+  tail is a version; `headers_absent` asserts a header was not sent at all.
+  `"requests_exactly": true` alongside it also asserts the count.
+- **`value`** — a subset match against what a non-run op returned, for the
+  reads. A list op compares element by element.
+- **`event_ids`** — the `id` of every event a `history` drain returned, in
+  order. Exact, not a subset: the whole point is that none went missing.
+- **`events`** — the ordered run events, each a subset match. The event
+  vocabulary is the one all four clients already emit: `conversation`,
+  `turn-start`, `text`, `thinking`, `tool`, `permission`, `block`, `event`,
+  `turn-end`. Adapters report `type` in that spelling whatever their language
+  calls it.
+- **`result`** — a subset match against the finished run: `state`, `text`,
+  `tools_used`, `turn_number`, `exit_code`, `reason`, `conversation_id`.
+- **`error`** — the failure the client raised, subset-matched. `kind` comes
+  from the shared vocabulary below, because `QuotaExceededError` and
+  `Fountain.Error` with `:quota_exceeded` are the same promise in two
+  languages. The other keys are `status`, `code` (the server's `error` string),
+  `retryable`, `retry_after` (seconds, from `Retry-After`), `field_errors` (the
+  422 map) and `partial_text` (what a timed-out run had collected).
+- **`no_error`: true** — the step must not raise. Implied when `result` or
+  `events` is present.
+
+### The error vocabulary
+
+| `kind` | Raised for |
+|---|---|
+| `auth` | 401, and a client constructed with no key |
+| `not_found` | 404 |
+| `validation` | 422 |
+| `rate_limited` | 429 |
+| `busy` | `conversation_busy` |
+| `quota` | `sandbox_quota_exceeded` — the concurrency cap; terminate a conversation and carry on |
+| `subscription` | `subscription_required`, `insufficient_credits`, and a bare 402 — a billing wall, which is a different thing to do about it |
+| `not_ready` | `provisioning`, `sprite_probe_failed`, `fleet_full`, 503 |
+| `timeout` | the client's own deadline elapsed |
+| `connection` | the transport failed before a status arrived |
+| `resolution` | a name the account has no match for |
+| `server` | any other non-2xx |
+
+An SDK whose class names differ maps them here in its adapter. The mapping is
+the adapter's only judgement call, and it is the thing the suite is asserting,
+so keep it honest: map the class the client actually raises, never the class
+the scenario wants.
+
+## The support matrix
+
+`matrix.json` says which SDK runs which scenario. Every scenario needs an entry
+for all four, and the only values are `"yes"` or an object
+`{"skip": "why", "issue": 1234}`. `lint.py` fails on a scenario missing from the
+matrix, on an SDK missing from a scenario, on a skip with no issue, and on a
+matrix entry naming a scenario that no longer exists. A gap is therefore a
+decision somebody wrote down and filed, never an absence.
+
+## Adding a behaviour
+
+One place, in this order:
+
+1. Write the scenario JSON here. This is the definition of the behaviour, and
+   it lands before any implementation changes.
+2. Run `python3 sdk/conformance/lint.py`. It checks the format, and it checks
+   every `json` response body in the scenario against the schema the server
+   declares for that operation in `sdk/contract/contract.json` — so a fixture
+   cannot quietly encode a response the real server would never send.
+3. Add it to `matrix.json`, `"yes"` for the SDKs that pass and a skip with an
+   issue number for the ones that do not yet.
+4. Fix the clients.
+
+## What this is not
+
+It does not replace each SDK's own tests. Those cover idiom, ergonomics and
+implementation detail — how `for await` behaves, whether a Swift `AsyncSequence`
+cancels cleanly, what an Elixir `Stream` does on demand. This suite owns only
+the behaviour Fountain promises identically in every language, and its scenarios
+should stay boring enough that a reader can tell which is which.
+
+It also does not drive a real Fountain. Every scenario is scripted bytes, which
+is what makes byte-level framing and connection death testable at all. The
+complementary check — that a *real* rendered response matches its declared
+schema — is a server-side concern and lives with the server.

--- a/sdk/conformance/README.md
+++ b/sdk/conformance/README.md
@@ -26,7 +26,7 @@ sdk/conformance/
 | SDK | Command | Run from |
 |---|---|---|
 | TypeScript | `npm run conformance` | `sdk/typescript` |
-| Python | `python3 -m unittest tests.test_conformance` | `sdk/python` |
+| Python | `python3 -m unittest discover -s tests -p test_conformance.py` | `sdk/python` |
 | Swift | `swift test --filter ConformanceTests` | repository root |
 | Elixir | `mix test test/conformance_test.exs` | `sdk/elixir` |
 

--- a/sdk/conformance/lint.py
+++ b/sdk/conformance/lint.py
@@ -1,0 +1,482 @@
+#!/usr/bin/env python3
+"""Check the conformance scenarios before any SDK runs them.
+
+Three jobs, in order of how much they save:
+
+1. **The fixtures must be responses the real server could send.** Every `json`
+   body in a scenario is validated against the schema the server declares for
+   that operation in `sdk/contract/contract.json` (#1411). A fixture is a
+   promise about the wire, and a fixture nobody checked is how a suite goes
+   green against an API that does not exist. This is the join between the two
+   halves: the contract says what the shapes are, the scenarios say what a
+   client does with them, and neither is allowed to drift from the other.
+
+2. **The format must be the one the adapters implement.** Four adapters read
+   these files, and a typo in a key name is otherwise four silent no-ops rather
+   than one failure.
+
+3. **The support matrix must be complete.** Every scenario needs a verdict for
+   every SDK, and a skip needs an issue number. That is what keeps a gap a
+   decision somebody made rather than a scenario quietly running nowhere.
+
+Usage:
+    python3 sdk/conformance/lint.py
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parents[1]
+SCENARIOS = HERE / "scenarios"
+MATRIX = HERE / "matrix.json"
+CONTRACT = ROOT / "sdk" / "contract" / "contract.json"
+
+SDKS = ("typescript", "python", "swift", "elixir")
+
+OPS = {
+    "me": set(),
+    "list": {"resource"},
+    "create_agent": {"attrs"},
+    "get_conversation": {"conversation_id"},
+    "run": {"agent", "prompt"},
+    "send": {"conversation_id", "prompt"},
+    "history": {"conversation_id"},
+}
+OP_OPTIONAL = {
+    "run": {"timeout_ms", "answer_permissions"},
+    "list": set(),
+}
+
+EVENT_TYPES = {
+    "conversation",
+    "turn-start",
+    "text",
+    "thinking",
+    "tool",
+    "permission",
+    "block",
+    "event",
+    "turn-end",
+}
+
+ERROR_KINDS = {
+    "auth",
+    "not_found",
+    "validation",
+    "rate_limited",
+    "busy",
+    "quota",
+    "subscription",
+    "not_ready",
+    "timeout",
+    "connection",
+    "resolution",
+    "server",
+}
+
+CONTRACTS = {
+    "auth",
+    "errors",
+    "sse-framing",
+    "reconnect",
+    "run-states",
+    "permissions",
+    "pagination",
+}
+
+SCENARIO_KEYS = {"name", "title", "contract", "why", "client", "http", "steps", "expect"}
+EXPECT_KEYS = {
+    "requests",
+    "requests_exactly",
+    "events",
+    "result",
+    "error",
+    "no_error",
+    "value",
+    "event_ids",
+}
+RESULT_KEYS = {
+    "state",
+    "text",
+    "tools_used",
+    "turn_number",
+    "exit_code",
+    "reason",
+    "conversation_id",
+    "status",
+}
+ERROR_KEYS = {
+    "kind",
+    "status",
+    "code",
+    "retryable",
+    "retry_after",
+    "field_errors",
+    "partial_text",
+}
+
+NAME = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+
+
+class Problems:
+    def __init__(self) -> None:
+        self.items: List[str] = []
+
+    def add(self, where: str, message: str) -> None:
+        self.items.append("  %s\n      %s" % (where, message))
+
+    def __bool__(self) -> bool:
+        return bool(self.items)
+
+
+# ── validating a fixture body against the declared schema ────────────────────
+
+
+def path_to_template(path: str) -> Optional[str]:
+    """Map a concrete request path back to the OpenAPI template it came from.
+
+    `/api/conversations/<uuid>/stream` is `/api/conversations/{conversation_id}/stream`.
+    Matching is by segment count and by literal segments, so a template whose
+    variable sits where the scenario has a literal still matches, which is the
+    only way this works without a router.
+    """
+    parts = [p for p in path.split("/") if p]
+    for template in TEMPLATES:
+        segments = [p for p in template.split("/") if p]
+        if len(segments) != len(parts):
+            continue
+        if all(
+            segment.startswith("{") or segment == part
+            for segment, part in zip(segments, parts)
+        ):
+            return template
+    return None
+
+
+def resolve_ref(node: Any, schemas: Dict[str, Any], seen: Optional[set] = None) -> Any:
+    seen = seen or set()
+    while isinstance(node, dict) and node.get("ref"):
+        name = node["ref"]
+        if name in seen:
+            return {}
+        seen.add(name)
+        node = schemas.get(name, {})
+    return node
+
+
+def check_body(
+    body: Any, schema: Any, schemas: Dict[str, Any], where: str, problems: Problems
+) -> None:
+    """A structural check, not a full JSON Schema implementation.
+
+    It answers the two questions a fixture gets wrong: does it use a property
+    the schema does not declare, and does it omit one the schema requires. Type
+    checking stops at the primitive families, because the aim is to catch an
+    invented field, not to reimplement a validator.
+    """
+    schema = resolve_ref(schema, schemas)
+    if not isinstance(schema, dict) or not schema:
+        return
+
+    for keyword in ("oneOf", "anyOf"):
+        if keyword in schema:
+            # A union is satisfied if any member is; report nothing rather than
+            # guess which member the fixture meant.
+            return
+
+    kind = schema.get("type")
+
+    if kind == "array":
+        if not isinstance(body, list):
+            problems.add(where, "the schema says array, the fixture has %s" % type(body).__name__)
+            return
+        for index, item in enumerate(body):
+            check_body(item, schema.get("items") or {}, schemas, "%s[%d]" % (where, index), problems)
+        return
+
+    if kind == "object" or "properties" in schema:
+        if not isinstance(body, dict):
+            problems.add(where, "the schema says object, the fixture has %s" % type(body).__name__)
+            return
+        properties = schema.get("properties") or {}
+        if properties:
+            for key in sorted(body):
+                if key not in properties:
+                    if schema.get("additionalProperties"):
+                        continue
+                    problems.add(
+                        "%s.%s" % (where, key),
+                        "no such property in the declared schema. It has: %s"
+                        % ", ".join(sorted(properties)),
+                    )
+            for key, prop in sorted(properties.items()):
+                if prop.get("required") and key not in body:
+                    problems.add(
+                        "%s.%s" % (where, key),
+                        "the schema requires this property and the fixture omits it",
+                    )
+                if key in body:
+                    check_body(body[key], prop, schemas, "%s.%s" % (where, key), problems)
+        return
+
+    if body is None:
+        return  # nullable is common enough that a null is never the interesting failure
+    families = {
+        "string": str,
+        "integer": int,
+        "number": (int, float),
+        "boolean": bool,
+    }
+    expected = families.get(kind or "")
+    if expected and not isinstance(body, expected):
+        if kind == "integer" and isinstance(body, bool):
+            pass  # bool is an int in Python; fall through to the report
+        elif isinstance(body, expected):
+            return
+        problems.add(where, "the schema says %s, the fixture has %s" % (kind, type(body).__name__))
+
+
+# Statuses a plug can produce on any route, which the OpenAPI document
+# therefore does not enumerate per operation. `Plugs.RateLimit` sits in the
+# pipeline and answers 429 anywhere; `Billing.check_spend/1` answers 402 in the
+# context (ADR 0031); the auth plug answers 401 on every authenticated route
+# even though only 34 of 158 operations declare it. A fixture for one of these
+# is still checked, against the error envelope rather than against nothing.
+PLUG_STATUSES = {401, 402, 403, 429, 500, 502, 503}
+
+
+def response_schema(
+    contract: Dict[str, Any], method: str, path: str, status: int, body: Any
+) -> Optional[Any]:
+    template = path_to_template(path)
+    if template is None:
+        return None
+    operation = contract["operations"].get("%s %s" % (method.upper(), template))
+    if not operation:
+        return None
+    media = (operation.get("responses") or {}).get(str(status)) or {}
+    declared = media.get("application/json")
+    if declared is not None:
+        return declared
+    if status in PLUG_STATUSES:
+        envelope = "ChangesetError" if isinstance(body, dict) and "errors" in body else "Error"
+        return {"ref": envelope}
+    return None
+
+
+# ── the scenario checks ──────────────────────────────────────────────────────
+
+
+def check_scenario(scenario: Dict[str, Any], path: Path, contract: Dict[str, Any], problems: Problems) -> None:
+    where = path.name
+    schemas = contract["schemas"]
+
+    unknown = sorted(set(scenario) - SCENARIO_KEYS)
+    if unknown:
+        problems.add(where, "unknown top-level keys: %s" % ", ".join(unknown))
+    for required in ("name", "title", "contract", "why", "client", "http", "steps", "expect"):
+        if required not in scenario:
+            problems.add(where, "missing `%s`" % required)
+            return
+
+    name = scenario["name"]
+    if name != path.stem:
+        problems.add(where, "`name` is %r but the file is %r" % (name, path.stem))
+    if not NAME.match(name):
+        problems.add(where, "`name` must be lower-case-with-hyphens")
+    if scenario["contract"] not in CONTRACTS:
+        problems.add(
+            where,
+            "`contract` %r is not one of %s" % (scenario["contract"], ", ".join(sorted(CONTRACTS))),
+        )
+    if not scenario["why"].endswith("."):
+        problems.add(where, "`why` should be a sentence: it is what a reviewer reads first")
+
+    # steps
+    if not scenario["steps"]:
+        problems.add(where, "`steps` is empty; a scenario that asks the client to do nothing proves nothing")
+    for index, step in enumerate(scenario["steps"]):
+        op = step.get("op")
+        if op not in OPS:
+            problems.add(
+                "%s steps[%d]" % (where, index),
+                "unknown op %r. The vocabulary is: %s" % (op, ", ".join(sorted(OPS))),
+            )
+            continue
+        allowed = OPS[op] | OP_OPTIONAL.get(op, set()) | {"op"}
+        missing = sorted(OPS[op] - set(step))
+        if missing:
+            problems.add("%s steps[%d]" % (where, index), "op %r needs %s" % (op, ", ".join(missing)))
+        extra = sorted(set(step) - allowed)
+        if extra:
+            problems.add("%s steps[%d]" % (where, index), "op %r has no field %s" % (op, ", ".join(extra)))
+
+    # http
+    for index, exchange in enumerate(scenario["http"]):
+        spot = "%s http[%d]" % (where, index)
+        match, respond = exchange.get("match"), exchange.get("respond")
+        if not isinstance(match, dict) or not isinstance(respond, dict):
+            problems.add(spot, "each exchange needs a `match` and a `respond` object")
+            continue
+        if "method" not in match or "path" not in match:
+            problems.add(spot, "`match` needs a `method` and a `path`")
+            continue
+        for header in (match.get("headers") or {}):
+            if header != header.lower():
+                problems.add(spot, "header names in `match` must be lower-case: %r" % header)
+        if "status" not in respond:
+            problems.add(spot, "`respond` needs a `status`")
+            continue
+        if "json" in respond and "body" in respond:
+            problems.add(spot, "`respond` takes `json` or `body`, not both")
+        if "sse" in respond:
+            if respond.get("close") not in ("end", "abort"):
+                problems.add(spot, "a streaming `respond` needs `close`: \"end\" or \"abort\"")
+            for chunk in respond["sse"]:
+                if isinstance(chunk, dict) and set(chunk) - {"text", "delay_ms"}:
+                    problems.add(spot, "an sse chunk object takes only `text` and `delay_ms`")
+                elif not isinstance(chunk, (str, dict)):
+                    problems.add(spot, "an sse chunk is a string or a {text, delay_ms} object")
+
+        # The join with sdk/contract: is this a body the server could send?
+        if "json" in respond:
+            schema = response_schema(
+                contract, match["method"], match["path"], respond["status"], respond["json"]
+            )
+            if schema is None:
+                problems.add(
+                    spot,
+                    "no operation in sdk/contract/contract.json serves `%s %s` with a %s. "
+                    "Either the fixture is wrong or the scenario is testing an endpoint "
+                    "the server does not have."
+                    % (match["method"], match["path"], respond["status"]),
+                )
+            else:
+                check_body(respond["json"], schema, schemas, "%s http[%d].json" % (where, index), problems)
+
+    # expect
+    expect = scenario["expect"]
+    unknown = sorted(set(expect) - EXPECT_KEYS)
+    if unknown:
+        problems.add(where, "unknown `expect` keys: %s" % ", ".join(unknown))
+    if not expect:
+        problems.add(where, "`expect` is empty; a scenario that asserts nothing is not a scenario")
+    if "error" in expect and expect.get("no_error"):
+        problems.add(where, "`expect` cannot ask for both an error and no error")
+    for index, event in enumerate(expect.get("events") or []):
+        if event.get("type") not in EVENT_TYPES:
+            problems.add(
+                "%s expect.events[%d]" % (where, index),
+                "unknown event type %r. The vocabulary is: %s"
+                % (event.get("type"), ", ".join(sorted(EVENT_TYPES))),
+            )
+    error = expect.get("error")
+    if error is not None:
+        unknown = sorted(set(error) - ERROR_KEYS)
+        if unknown:
+            problems.add(where, "unknown `expect.error` keys: %s" % ", ".join(unknown))
+        if error.get("kind") not in ERROR_KINDS:
+            problems.add(
+                where,
+                "`expect.error.kind` %r is not in the shared vocabulary: %s"
+                % (error.get("kind"), ", ".join(sorted(ERROR_KINDS))),
+            )
+    result = expect.get("result")
+    if result is not None:
+        unknown = sorted(set(result) - RESULT_KEYS)
+        if unknown:
+            problems.add(where, "unknown `expect.result` keys: %s" % ", ".join(unknown))
+
+
+def check_matrix(names: List[str], problems: Problems) -> None:
+    if not MATRIX.exists():
+        problems.add("matrix.json", "missing. Every scenario needs a verdict for every SDK.")
+        return
+    matrix = json.loads(MATRIX.read_text())
+    entries = matrix.get("scenarios") or {}
+
+    for name in names:
+        entry = entries.get(name)
+        if entry is None:
+            problems.add(
+                "matrix.json",
+                "%s has no entry. Add one per SDK: \"yes\", or {\"skip\": …, \"issue\": N}." % name,
+            )
+            continue
+        for sdk in SDKS:
+            verdict = entry.get(sdk)
+            if verdict is None:
+                problems.add("matrix.json", "%s has no verdict for %s" % (name, sdk))
+            elif verdict == "yes":
+                continue
+            elif isinstance(verdict, dict):
+                if not verdict.get("skip"):
+                    problems.add("matrix.json", "%s/%s must say why it is skipped" % (name, sdk))
+                if not isinstance(verdict.get("issue"), int):
+                    problems.add(
+                        "matrix.json",
+                        "%s/%s is skipped with no issue number. A gap that nobody filed is a gap "
+                        "nobody closes." % (name, sdk),
+                    )
+            else:
+                problems.add(
+                    "matrix.json",
+                    "%s/%s is %r; the only values are \"yes\" or {\"skip\", \"issue\"}"
+                    % (name, sdk, verdict),
+                )
+
+    for name in sorted(set(entries) - set(names)):
+        problems.add("matrix.json", "%s names no scenario in scenarios/" % name)
+
+
+def main() -> int:
+    if not CONTRACT.exists():
+        sys.stderr.write(
+            "error: %s is missing. Build it with scripts/sdk-contract/build.sh\n"
+            % CONTRACT.relative_to(ROOT)
+        )
+        return 1
+    contract = json.loads(CONTRACT.read_text())
+
+    global TEMPLATES
+    TEMPLATES = sorted(
+        {operation.split(" ", 1)[1] for operation in contract["operations"]},
+        key=lambda template: (template.count("{"), -len(template)),
+    )
+
+    problems = Problems()
+    names = []
+    for path in sorted(SCENARIOS.glob("*.json")):
+        names.append(path.stem)
+        try:
+            scenario = json.loads(path.read_text())
+        except json.JSONDecodeError as error:
+            problems.add(path.name, "is not valid JSON: %s" % error)
+            continue
+        check_scenario(scenario, path, contract, problems)
+
+    if not names:
+        problems.add("scenarios/", "is empty")
+    check_matrix(names, problems)
+
+    if problems:
+        sys.stderr.write(
+            "conformance scenarios: FAILED (%d problems)\n\n" % len(problems.items)
+        )
+        sys.stderr.write("\n\n".join(problems.items) + "\n")
+        return 1
+
+    print("conformance scenarios: ok (%d scenarios)" % len(names))
+    return 0
+
+
+TEMPLATES: List[str] = []
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sdk/conformance/matrix.json
+++ b/sdk/conformance/matrix.json
@@ -106,7 +106,10 @@
     "run-timeout-raises-and-keeps-partial-text": {
       "typescript": "yes",
       "python": "yes",
-      "swift": "yes",
+      "swift": {
+        "skip": "On timeout, Swift cancels the stream but then sends GET /api/conversations/:id before raising its timeout error.",
+        "issue": 1424
+      },
       "elixir": "yes"
     },
     "sse-comments-and-blank-lines-are-ignored": {

--- a/sdk/conformance/matrix.json
+++ b/sdk/conformance/matrix.json
@@ -1,0 +1,155 @@
+{
+  "$comment": "Which SDK runs which shared scenario. \"yes\" or {\"skip\": why, \"issue\": N}; sdk/conformance/lint.py refuses anything else, refuses a skip with no issue, and refuses a scenario with no verdict. See sdk/conformance/README.md.",
+  "sdks": [
+    "typescript",
+    "python",
+    "swift",
+    "elixir"
+  ],
+  "scenarios": {
+    "auth-bearer-and-user-agent": {
+      "typescript": "yes",
+      "python": "yes",
+      "swift": "yes",
+      "elixir": "yes"
+    },
+    "auth-me-is-not-enveloped": {
+      "typescript": "yes",
+      "python": "yes",
+      "swift": "yes",
+      "elixir": "yes"
+    },
+    "auth-missing-key-fails-before-any-request": {
+      "typescript": "yes",
+      "python": "yes",
+      "swift": "yes",
+      "elixir": "yes"
+    },
+    "base-url-trailing-slash-is-normalised": {
+      "typescript": "yes",
+      "python": "yes",
+      "swift": "yes",
+      "elixir": "yes"
+    },
+    "error-401-maps-to-auth": {
+      "typescript": "yes",
+      "python": "yes",
+      "swift": "yes",
+      "elixir": "yes"
+    },
+    "error-404-maps-to-not-found": {
+      "typescript": "yes",
+      "python": "yes",
+      "swift": "yes",
+      "elixir": "yes"
+    },
+    "error-422-carries-field-errors": {
+      "typescript": "yes",
+      "python": "yes",
+      "swift": "yes",
+      "elixir": "yes"
+    },
+    "error-429-carries-retry-after": {
+      "typescript": "yes",
+      "python": "yes",
+      "swift": "yes",
+      "elixir": "yes"
+    },
+    "error-code-outranks-status-conversation-busy": {
+      "typescript": "yes",
+      "python": "yes",
+      "swift": "yes",
+      "elixir": "yes"
+    },
+    "error-code-outranks-status-insufficient-credits": {
+      "typescript": "yes",
+      "python": "yes",
+      "swift": "yes",
+      "elixir": "yes"
+    },
+    "history-drains-the-feed-across-pages": {
+      "typescript": "yes",
+      "python": "yes",
+      "swift": "yes",
+      "elixir": "yes"
+    },
+    "history-empty-feed-is-an-empty-list": {
+      "typescript": "yes",
+      "python": "yes",
+      "swift": "yes",
+      "elixir": "yes"
+    },
+    "list-empty-collection-is-an-empty-list": {
+      "typescript": "yes",
+      "python": "yes",
+      "swift": "yes",
+      "elixir": "yes"
+    },
+    "permission-request-is-surfaced-and-answered": {
+      "typescript": "yes",
+      "python": "yes",
+      "swift": "yes",
+      "elixir": "yes"
+    },
+    "run-completes-with-text-and-tools": {
+      "typescript": "yes",
+      "python": "yes",
+      "swift": "yes",
+      "elixir": "yes"
+    },
+    "run-failed-turn-reports-failed": {
+      "typescript": "yes",
+      "python": "yes",
+      "swift": "yes",
+      "elixir": "yes"
+    },
+    "run-timeout-raises-and-keeps-partial-text": {
+      "typescript": "yes",
+      "python": "yes",
+      "swift": "yes",
+      "elixir": "yes"
+    },
+    "sse-comments-and-blank-lines-are-ignored": {
+      "typescript": "yes",
+      "python": "yes",
+      "swift": "yes",
+      "elixir": "yes"
+    },
+    "sse-crlf-frame-boundary": {
+      "typescript": "yes",
+      "python": "yes",
+      "swift": "yes",
+      "elixir": "yes"
+    },
+    "sse-fragmented-frame-is-reassembled": {
+      "typescript": "yes",
+      "python": "yes",
+      "swift": "yes",
+      "elixir": "yes"
+    },
+    "sse-malformed-frame-is-skipped": {
+      "typescript": "yes",
+      "python": "yes",
+      "swift": "yes",
+      "elixir": "yes"
+    },
+    "sse-multiline-data-joins-with-newlines": {
+      "typescript": "yes",
+      "python": "yes",
+      "swift": "yes",
+      "elixir": "yes"
+    },
+    "sse-no-cursor-header-on-the-first-connection": {
+      "typescript": "yes",
+      "python": "yes",
+      "swift": "yes",
+      "elixir": "yes"
+    },
+    "sse-reconnect-resumes-from-last-event-id": {
+      "typescript": "yes",
+      "python": "yes",
+      "swift": "yes",
+      "elixir": "yes"
+    }
+  }
+}

--- a/sdk/conformance/scenarios/auth-bearer-and-user-agent.json
+++ b/sdk/conformance/scenarios/auth-bearer-and-user-agent.json
@@ -1,0 +1,47 @@
+{
+  "name": "auth-bearer-and-user-agent",
+  "title": "Every request carries the key as a bearer token and an identifying User-Agent",
+  "contract": "auth",
+  "why": "Fountain's request logs are keyed on the product token, and an unauthenticated call is a 401 the caller cannot diagnose.",
+  "client": {
+    "api_key": "conformance-key"
+  },
+  "http": [
+    {
+      "match": {
+        "method": "GET",
+        "path": "/api/auth/me"
+      },
+      "respond": {
+        "status": 200,
+        "json": {
+          "id": "00000000-0000-0000-0000-000000000001",
+          "email": "conformance@example.test",
+          "role": "user",
+          "email_verified": true
+        }
+      }
+    }
+  ],
+  "steps": [
+    {
+      "op": "me"
+    }
+  ],
+  "expect": {
+    "requests": [
+      {
+        "method": "GET",
+        "path": "/api/auth/me",
+        "headers": {
+          "authorization": "Bearer conformance-key"
+        },
+        "header_prefixes": {
+          "user-agent": "fountain-sdk-"
+        }
+      }
+    ],
+    "requests_exactly": true,
+    "no_error": true
+  }
+}

--- a/sdk/conformance/scenarios/auth-me-is-not-enveloped.json
+++ b/sdk/conformance/scenarios/auth-me-is-not-enveloped.json
@@ -1,0 +1,38 @@
+{
+  "name": "auth-me-is-not-enveloped",
+  "title": "GET /api/auth/me answers the identity directly, not under `data`",
+  "contract": "auth",
+  "why": "The one response in the SDK surface with no envelope. A client that unwraps it returns null, which shipped once.",
+  "client": {
+    "api_key": "conformance-key"
+  },
+  "http": [
+    {
+      "match": {
+        "method": "GET",
+        "path": "/api/auth/me"
+      },
+      "respond": {
+        "status": 200,
+        "json": {
+          "id": "00000000-0000-0000-0000-000000000001",
+          "email": "conformance@example.test",
+          "role": "user",
+          "email_verified": true
+        }
+      }
+    }
+  ],
+  "steps": [
+    {
+      "op": "me"
+    }
+  ],
+  "expect": {
+    "value": {
+      "id": "00000000-0000-0000-0000-000000000001",
+      "email": "conformance@example.test"
+    },
+    "no_error": true
+  }
+}

--- a/sdk/conformance/scenarios/auth-missing-key-fails-before-any-request.json
+++ b/sdk/conformance/scenarios/auth-missing-key-fails-before-any-request.json
@@ -1,0 +1,22 @@
+{
+  "name": "auth-missing-key-fails-before-any-request",
+  "title": "A client with no API key raises rather than sending an unauthenticated request",
+  "contract": "auth",
+  "why": "Sending the request first turns a local configuration mistake into a server 401, and burns a round trip to say so.",
+  "client": {
+    "api_key": null
+  },
+  "http": [],
+  "steps": [
+    {
+      "op": "me"
+    }
+  ],
+  "expect": {
+    "requests": [],
+    "requests_exactly": true,
+    "error": {
+      "kind": "auth"
+    }
+  }
+}

--- a/sdk/conformance/scenarios/base-url-trailing-slash-is-normalised.json
+++ b/sdk/conformance/scenarios/base-url-trailing-slash-is-normalised.json
@@ -1,0 +1,41 @@
+{
+  "name": "base-url-trailing-slash-is-normalised",
+  "title": "A base URL with a trailing slash does not produce a doubled slash",
+  "contract": "auth",
+  "why": "`https://host/` plus `/api/auth/me` is `//api/auth/me` on a naive join, which Fountain answers with a 404.",
+  "client": {
+    "api_key": "conformance-key",
+    "base_url_suffix": "/"
+  },
+  "http": [
+    {
+      "match": {
+        "method": "GET",
+        "path": "/api/auth/me"
+      },
+      "respond": {
+        "status": 200,
+        "json": {
+          "id": "00000000-0000-0000-0000-000000000001",
+          "email": "conformance@example.test",
+          "role": "user",
+          "email_verified": true
+        }
+      }
+    }
+  ],
+  "steps": [
+    {
+      "op": "me"
+    }
+  ],
+  "expect": {
+    "requests": [
+      {
+        "method": "GET",
+        "path": "/api/auth/me"
+      }
+    ],
+    "no_error": true
+  }
+}

--- a/sdk/conformance/scenarios/error-401-maps-to-auth.json
+++ b/sdk/conformance/scenarios/error-401-maps-to-auth.json
@@ -1,0 +1,35 @@
+{
+  "name": "error-401-maps-to-auth",
+  "title": "A 401 becomes the client's authentication error",
+  "contract": "errors",
+  "why": "The caller's fix is a different key, and no amount of retrying finds one.",
+  "client": {
+    "api_key": "conformance-key"
+  },
+  "http": [
+    {
+      "match": {
+        "method": "GET",
+        "path": "/api/auth/me"
+      },
+      "respond": {
+        "status": 401,
+        "json": {
+          "error": "unauthorized"
+        }
+      }
+    }
+  ],
+  "steps": [
+    {
+      "op": "me"
+    }
+  ],
+  "expect": {
+    "error": {
+      "kind": "auth",
+      "status": 401,
+      "code": "unauthorized"
+    }
+  }
+}

--- a/sdk/conformance/scenarios/error-404-maps-to-not-found.json
+++ b/sdk/conformance/scenarios/error-404-maps-to-not-found.json
@@ -1,0 +1,35 @@
+{
+  "name": "error-404-maps-to-not-found",
+  "title": "A 404 becomes the client's not-found error",
+  "contract": "errors",
+  "why": "Distinguishing a missing conversation from a broken connection is the difference between retrying and not.",
+  "client": {
+    "api_key": "conformance-key"
+  },
+  "http": [
+    {
+      "match": {
+        "method": "GET",
+        "path": "/api/conversations/11111111-2222-3333-4444-555555555555"
+      },
+      "respond": {
+        "status": 404,
+        "json": {
+          "error": "not_found"
+        }
+      }
+    }
+  ],
+  "steps": [
+    {
+      "op": "get_conversation",
+      "conversation_id": "11111111-2222-3333-4444-555555555555"
+    }
+  ],
+  "expect": {
+    "error": {
+      "kind": "not_found",
+      "status": 404
+    }
+  }
+}

--- a/sdk/conformance/scenarios/error-422-carries-field-errors.json
+++ b/sdk/conformance/scenarios/error-422-carries-field-errors.json
@@ -1,0 +1,46 @@
+{
+  "name": "error-422-carries-field-errors",
+  "title": "A 422 becomes a validation error that still carries the server's per-field messages",
+  "contract": "errors",
+  "why": "`errors: {field: [message]}` is the only thing that tells a caller which field to fix.",
+  "client": {
+    "api_key": "conformance-key"
+  },
+  "http": [
+    {
+      "match": {
+        "method": "POST",
+        "path": "/api/agents"
+      },
+      "respond": {
+        "status": 422,
+        "json": {
+          "errors": {
+            "name": [
+              "can't be blank"
+            ]
+          }
+        }
+      }
+    }
+  ],
+  "steps": [
+    {
+      "op": "create_agent",
+      "attrs": {
+        "name": ""
+      }
+    }
+  ],
+  "expect": {
+    "error": {
+      "kind": "validation",
+      "status": 422,
+      "field_errors": {
+        "name": [
+          "can't be blank"
+        ]
+      }
+    }
+  }
+}

--- a/sdk/conformance/scenarios/error-429-carries-retry-after.json
+++ b/sdk/conformance/scenarios/error-429-carries-retry-after.json
@@ -1,0 +1,39 @@
+{
+  "name": "error-429-carries-retry-after",
+  "title": "A 429 becomes a rate-limit error carrying the server's Retry-After",
+  "contract": "errors",
+  "why": "The server said how long to wait. A client that drops it either hammers or sleeps arbitrarily.",
+  "client": {
+    "api_key": "conformance-key"
+  },
+  "http": [
+    {
+      "match": {
+        "method": "GET",
+        "path": "/api/auth/me"
+      },
+      "respond": {
+        "status": 429,
+        "headers": {
+          "retry-after": "7"
+        },
+        "json": {
+          "error": "rate_limited"
+        }
+      }
+    }
+  ],
+  "steps": [
+    {
+      "op": "me"
+    }
+  ],
+  "expect": {
+    "error": {
+      "kind": "rate_limited",
+      "status": 429,
+      "retry_after": 7,
+      "retryable": true
+    }
+  }
+}

--- a/sdk/conformance/scenarios/error-code-outranks-status-conversation-busy.json
+++ b/sdk/conformance/scenarios/error-code-outranks-status-conversation-busy.json
@@ -1,0 +1,67 @@
+{
+  "name": "error-code-outranks-status-conversation-busy",
+  "title": "`conversation_busy` is a 400, and the code decides the class, not the status",
+  "contract": "errors",
+  "why": "What a caller does about a busy conversation has nothing to do with the number 400. Fountain keys these on the code.",
+  "client": {
+    "api_key": "conformance-key"
+  },
+  "http": [
+    {
+      "match": {
+        "method": "GET",
+        "path": "/api/conversations/11111111-2222-3333-4444-555555555555/stream",
+        "query": {
+          "streams": "stage",
+          "wait": "false"
+        }
+      },
+      "respond": {
+        "status": 200,
+        "headers": {
+          "content-type": "text/event-stream"
+        },
+        "sse": [],
+        "close": "end"
+      }
+    },
+    {
+      "match": {
+        "method": "GET",
+        "path": "/api/conversations/11111111-2222-3333-4444-555555555555/turns"
+      },
+      "respond": {
+        "status": 200,
+        "json": {
+          "data": []
+        }
+      }
+    },
+    {
+      "match": {
+        "method": "POST",
+        "path": "/api/conversations/11111111-2222-3333-4444-555555555555/prompts"
+      },
+      "respond": {
+        "status": 400,
+        "json": {
+          "error": "conversation_busy"
+        }
+      }
+    }
+  ],
+  "steps": [
+    {
+      "op": "send",
+      "conversation_id": "11111111-2222-3333-4444-555555555555",
+      "prompt": "again"
+    }
+  ],
+  "expect": {
+    "error": {
+      "kind": "busy",
+      "status": 400,
+      "code": "conversation_busy"
+    }
+  }
+}

--- a/sdk/conformance/scenarios/error-code-outranks-status-insufficient-credits.json
+++ b/sdk/conformance/scenarios/error-code-outranks-status-insufficient-credits.json
@@ -1,0 +1,38 @@
+{
+  "name": "error-code-outranks-status-insufficient-credits",
+  "title": "`insufficient_credits` is a 402 and maps to the quota class",
+  "contract": "errors",
+  "why": "A caller topping up credit and a caller waiting for a sandbox slot need to tell these apart from a generic failure.",
+  "client": {
+    "api_key": "conformance-key"
+  },
+  "http": [
+    {
+      "match": {
+        "method": "POST",
+        "path": "/api/conversations"
+      },
+      "respond": {
+        "status": 402,
+        "json": {
+          "error": "insufficient_credits",
+          "upgrade_url": "https://managoat.com/account/billing"
+        }
+      }
+    }
+  ],
+  "steps": [
+    {
+      "op": "run",
+      "agent": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+      "prompt": "hello"
+    }
+  ],
+  "expect": {
+    "error": {
+      "kind": "subscription",
+      "status": 402,
+      "code": "insufficient_credits"
+    }
+  }
+}

--- a/sdk/conformance/scenarios/history-drains-the-feed-across-pages.json
+++ b/sdk/conformance/scenarios/history-drains-the-feed-across-pages.json
@@ -1,0 +1,117 @@
+{
+  "name": "history-drains-the-feed-across-pages",
+  "title": "Draining a conversation's history follows the cursor until the feed is exhausted",
+  "contract": "pagination",
+  "why": "A turn with more events than one page is ordinary. A client that reads one page reports a truncated conversation as complete.",
+  "client": {
+    "api_key": "conformance-key"
+  },
+  "http": [
+    {
+      "match": {
+        "method": "GET",
+        "path": "/api/conversations/11111111-2222-3333-4444-555555555555/events",
+        "query": {
+          "after": "0"
+        }
+      },
+      "respond": {
+        "status": 200,
+        "json": {
+          "data": [
+            {
+              "id": 1,
+              "kind": "stage",
+              "stage": "turn",
+              "state": "started",
+              "stream": "stage",
+              "ts": "2026-09-02T00:00:00Z",
+              "data": "{\"turn_number\": 1, \"turn_id\": \"t1\"}"
+            },
+            {
+              "id": 2,
+              "kind": "output",
+              "stream": "acp",
+              "turn_id": "t1",
+              "ts": "2026-09-02T00:00:00Z",
+              "blocks": [
+                {
+                  "kind": "text",
+                  "body": "one"
+                }
+              ]
+            }
+          ],
+          "meta": {
+            "next_cursor": 2,
+            "has_more": true
+          }
+        }
+      }
+    },
+    {
+      "match": {
+        "method": "GET",
+        "path": "/api/conversations/11111111-2222-3333-4444-555555555555/events",
+        "query": {
+          "after": "2"
+        }
+      },
+      "respond": {
+        "status": 200,
+        "json": {
+          "data": [
+            {
+              "id": 3,
+              "kind": "output",
+              "stream": "acp",
+              "turn_id": "t1",
+              "ts": "2026-09-02T00:00:00Z",
+              "blocks": [
+                {
+                  "kind": "text",
+                  "body": "two"
+                }
+              ]
+            }
+          ],
+          "meta": {
+            "next_cursor": 3,
+            "has_more": false
+          }
+        }
+      }
+    }
+  ],
+  "steps": [
+    {
+      "op": "history",
+      "conversation_id": "11111111-2222-3333-4444-555555555555"
+    }
+  ],
+  "expect": {
+    "event_ids": [
+      1,
+      2,
+      3
+    ],
+    "requests": [
+      {
+        "method": "GET",
+        "path": "/api/conversations/11111111-2222-3333-4444-555555555555/events",
+        "query": {
+          "after": "0"
+        }
+      },
+      {
+        "method": "GET",
+        "path": "/api/conversations/11111111-2222-3333-4444-555555555555/events",
+        "query": {
+          "after": "2"
+        }
+      }
+    ],
+    "requests_exactly": true,
+    "no_error": true
+  }
+}

--- a/sdk/conformance/scenarios/history-empty-feed-is-an-empty-list.json
+++ b/sdk/conformance/scenarios/history-empty-feed-is-an-empty-list.json
@@ -1,0 +1,47 @@
+{
+  "name": "history-empty-feed-is-an-empty-list",
+  "title": "A conversation with no events yields nothing and asks once",
+  "contract": "pagination",
+  "why": "An empty first page must terminate the drain rather than looping on the same cursor.",
+  "client": {
+    "api_key": "conformance-key"
+  },
+  "http": [
+    {
+      "match": {
+        "method": "GET",
+        "path": "/api/conversations/11111111-2222-3333-4444-555555555555/events",
+        "query": {
+          "after": "0"
+        }
+      },
+      "respond": {
+        "status": 200,
+        "json": {
+          "data": [],
+          "meta": {
+            "next_cursor": 0,
+            "has_more": false
+          }
+        }
+      }
+    }
+  ],
+  "steps": [
+    {
+      "op": "history",
+      "conversation_id": "11111111-2222-3333-4444-555555555555"
+    }
+  ],
+  "expect": {
+    "event_ids": [],
+    "requests_exactly": true,
+    "requests": [
+      {
+        "method": "GET",
+        "path": "/api/conversations/11111111-2222-3333-4444-555555555555/events"
+      }
+    ],
+    "no_error": true
+  }
+}

--- a/sdk/conformance/scenarios/list-empty-collection-is-an-empty-list.json
+++ b/sdk/conformance/scenarios/list-empty-collection-is-an-empty-list.json
@@ -1,0 +1,33 @@
+{
+  "name": "list-empty-collection-is-an-empty-list",
+  "title": "An empty collection is an empty list, never null",
+  "contract": "pagination",
+  "why": "A caller iterating the result of `list` must not have to null-check it, in any of the four languages.",
+  "client": {
+    "api_key": "conformance-key"
+  },
+  "http": [
+    {
+      "match": {
+        "method": "GET",
+        "path": "/api/agents"
+      },
+      "respond": {
+        "status": 200,
+        "json": {
+          "data": []
+        }
+      }
+    }
+  ],
+  "steps": [
+    {
+      "op": "list",
+      "resource": "agents"
+    }
+  ],
+  "expect": {
+    "value": [],
+    "no_error": true
+  }
+}

--- a/sdk/conformance/scenarios/permission-request-is-surfaced-and-answered.json
+++ b/sdk/conformance/scenarios/permission-request-is-surfaced-and-answered.json
@@ -1,0 +1,125 @@
+{
+  "name": "permission-request-is-surfaced-and-answered",
+  "title": "A held tool call reaches the caller as a permission event, and the answer posts the chosen option",
+  "contract": "permissions",
+  "why": "An agent with an `ask` policy blocks until the answer arrives. A client that cannot surface the request cannot use those agents at all.",
+  "client": {
+    "api_key": "conformance-key"
+  },
+  "http": [
+    {
+      "match": {
+        "method": "POST",
+        "path": "/api/conversations"
+      },
+      "respond": {
+        "status": 201,
+        "json": {
+          "data": {
+            "id": "11111111-2222-3333-4444-555555555555",
+            "status": "running",
+            "runtime": "claude"
+          }
+        }
+      }
+    },
+    {
+      "match": {
+        "method": "GET",
+        "path": "/api/conversations/11111111-2222-3333-4444-555555555555/stream"
+      },
+      "respond": {
+        "status": 200,
+        "headers": {
+          "content-type": "text/event-stream"
+        },
+        "sse": [
+          "id: 1\nevent: stage\ndata: {\"id\":1,\"kind\":\"stage\",\"stage\":\"turn\",\"state\":\"started\",\"stream\":\"stage\",\"ts\":\"2026-09-02T00:00:00Z\",\"data\":\"{\\\"turn_number\\\": 1, \\\"turn_id\\\": \\\"t1\\\"}\"}\n\n",
+          "id: 2\nevent: output\ndata: {\"id\":2,\"kind\":\"output\",\"stream\":\"acp\",\"turn_id\":\"t1\",\"ts\":\"2026-09-02T00:00:00Z\",\"blocks\":[{\"kind\":\"permission_request\",\"request_id\":\"req-1\",\"summary\":\"Run `rm -rf build`\",\"name\":\"bash\",\"options\":[{\"optionId\":\"allow-once\",\"kind\":\"allow_once\",\"name\":\"Allow once\"},{\"optionId\":\"reject\",\"kind\":\"reject_once\",\"name\":\"Reject\"}]}]}\n\n",
+          {
+            "text": "",
+            "delay_ms": 150
+          },
+          "id: 3\nevent: output\ndata: {\"id\":3,\"kind\":\"output\",\"stream\":\"acp\",\"turn_id\":\"t1\",\"ts\":\"2026-09-02T00:00:00Z\",\"blocks\":[{\"kind\":\"text\",\"body\":\"Done.\"}]}\n\n",
+          "id: 4\nevent: stage\ndata: {\"id\":4,\"kind\":\"stage\",\"stage\":\"turn\",\"state\":\"done\",\"stream\":\"stage\",\"ts\":\"2026-09-02T00:00:00Z\",\"data\":\"{\\\"turn_number\\\": 1, \\\"turn_id\\\": \\\"t1\\\", \\\"stop_reason\\\": \\\"end_turn\\\"}\"}\n\n"
+        ],
+        "close": "end"
+      }
+    },
+    {
+      "match": {
+        "method": "POST",
+        "path": "/api/conversations/11111111-2222-3333-4444-555555555555/requests/req-1"
+      },
+      "respond": {
+        "status": 200,
+        "json": {
+          "ok": true
+        }
+      }
+    },
+    {
+      "match": {
+        "method": "GET",
+        "path": "/api/conversations/11111111-2222-3333-4444-555555555555"
+      },
+      "respond": {
+        "status": 200,
+        "json": {
+          "data": {
+            "id": "11111111-2222-3333-4444-555555555555",
+            "status": "idle",
+            "runtime": "claude"
+          }
+        }
+      }
+    }
+  ],
+  "steps": [
+    {
+      "op": "run",
+      "agent": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+      "prompt": "hello",
+      "answer_permissions": {
+        "*": "allow-once"
+      }
+    }
+  ],
+  "expect": {
+    "events": [
+      {
+        "type": "permission",
+        "request_id": "req-1"
+      },
+      {
+        "type": "text",
+        "text": "Done."
+      },
+      {
+        "type": "turn-end",
+        "state": "done"
+      }
+    ],
+    "requests": [
+      {
+        "method": "POST",
+        "path": "/api/conversations"
+      },
+      {
+        "method": "GET",
+        "path": "/api/conversations/11111111-2222-3333-4444-555555555555/stream"
+      },
+      {
+        "method": "POST",
+        "path": "/api/conversations/11111111-2222-3333-4444-555555555555/requests/req-1",
+        "body": {
+          "option_id": "allow-once"
+        }
+      }
+    ],
+    "result": {
+      "state": "done",
+      "text": "Done."
+    }
+  }
+}

--- a/sdk/conformance/scenarios/run-completes-with-text-and-tools.json
+++ b/sdk/conformance/scenarios/run-completes-with-text-and-tools.json
@@ -1,0 +1,83 @@
+{
+  "name": "run-completes-with-text-and-tools",
+  "title": "A finished turn reports its text, the tools it used and the done state",
+  "contract": "run-states",
+  "why": "This is the whole product in one call: tool noise must not reach `text`, the order tools were first used is the order reported, and a tool call between two text chunks separates them with a paragraph break rather than running them together.",
+  "client": {
+    "api_key": "conformance-key"
+  },
+  "http": [
+    {
+      "match": {
+        "method": "POST",
+        "path": "/api/conversations"
+      },
+      "respond": {
+        "status": 201,
+        "json": {
+          "data": {
+            "id": "11111111-2222-3333-4444-555555555555",
+            "status": "running",
+            "runtime": "claude"
+          }
+        }
+      }
+    },
+    {
+      "match": {
+        "method": "GET",
+        "path": "/api/conversations/11111111-2222-3333-4444-555555555555/stream"
+      },
+      "respond": {
+        "status": 200,
+        "headers": {
+          "content-type": "text/event-stream"
+        },
+        "sse": [
+          "id: 1\nevent: stage\ndata: {\"id\":1,\"kind\":\"stage\",\"stage\":\"turn\",\"state\":\"started\",\"stream\":\"stage\",\"ts\":\"2026-09-02T00:00:00Z\",\"data\":\"{\\\"turn_number\\\": 1, \\\"turn_id\\\": \\\"t1\\\"}\"}\n\n",
+          "id: 2\nevent: output\ndata: {\"id\":2,\"kind\":\"output\",\"stream\":\"acp\",\"turn_id\":\"t1\",\"ts\":\"2026-09-02T00:00:00Z\",\"blocks\":[{\"kind\":\"tool_use\",\"name\":\"grep\"}]}\n\n",
+          "id: 3\nevent: output\ndata: {\"id\":3,\"kind\":\"output\",\"stream\":\"acp\",\"turn_id\":\"t1\",\"ts\":\"2026-09-02T00:00:00Z\",\"blocks\":[{\"kind\":\"text\",\"body\":\"Found \"}]}\n\n",
+          "id: 4\nevent: output\ndata: {\"id\":4,\"kind\":\"output\",\"stream\":\"acp\",\"turn_id\":\"t1\",\"ts\":\"2026-09-02T00:00:00Z\",\"blocks\":[{\"kind\":\"tool_use\",\"name\":\"read\"}]}\n\n",
+          "id: 5\nevent: output\ndata: {\"id\":5,\"kind\":\"output\",\"stream\":\"acp\",\"turn_id\":\"t1\",\"ts\":\"2026-09-02T00:00:00Z\",\"blocks\":[{\"kind\":\"text\",\"body\":\"it.\"}]}\n\n",
+          "id: 6\nevent: stage\ndata: {\"id\":6,\"kind\":\"stage\",\"stage\":\"turn\",\"state\":\"done\",\"stream\":\"stage\",\"ts\":\"2026-09-02T00:00:00Z\",\"data\":\"{\\\"turn_number\\\": 1, \\\"turn_id\\\": \\\"t1\\\", \\\"stop_reason\\\": \\\"end_turn\\\"}\"}\n\n"
+        ],
+        "close": "end"
+      }
+    },
+    {
+      "match": {
+        "method": "GET",
+        "path": "/api/conversations/11111111-2222-3333-4444-555555555555"
+      },
+      "respond": {
+        "status": 200,
+        "json": {
+          "data": {
+            "id": "11111111-2222-3333-4444-555555555555",
+            "status": "idle",
+            "runtime": "claude"
+          }
+        }
+      }
+    }
+  ],
+  "steps": [
+    {
+      "op": "run",
+      "agent": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+      "prompt": "hello"
+    }
+  ],
+  "expect": {
+    "result": {
+      "state": "done",
+      "text": "Found \n\nit.",
+      "tools_used": [
+        "grep",
+        "read"
+      ],
+      "turn_number": 1,
+      "conversation_id": "11111111-2222-3333-4444-555555555555"
+    }
+  }
+}

--- a/sdk/conformance/scenarios/run-failed-turn-reports-failed.json
+++ b/sdk/conformance/scenarios/run-failed-turn-reports-failed.json
@@ -1,0 +1,75 @@
+{
+  "name": "run-failed-turn-reports-failed",
+  "title": "A turn the runtime failed reports the failed state and its exit code",
+  "contract": "run-states",
+  "why": "A failed turn that reads as an empty success is the worst possible answer: the caller ships nothing and is told nothing.",
+  "client": {
+    "api_key": "conformance-key"
+  },
+  "http": [
+    {
+      "match": {
+        "method": "POST",
+        "path": "/api/conversations"
+      },
+      "respond": {
+        "status": 201,
+        "json": {
+          "data": {
+            "id": "11111111-2222-3333-4444-555555555555",
+            "status": "running",
+            "runtime": "claude"
+          }
+        }
+      }
+    },
+    {
+      "match": {
+        "method": "GET",
+        "path": "/api/conversations/11111111-2222-3333-4444-555555555555/stream"
+      },
+      "respond": {
+        "status": 200,
+        "headers": {
+          "content-type": "text/event-stream"
+        },
+        "sse": [
+          "id: 1\nevent: stage\ndata: {\"id\":1,\"kind\":\"stage\",\"stage\":\"turn\",\"state\":\"started\",\"stream\":\"stage\",\"ts\":\"2026-09-02T00:00:00Z\",\"data\":\"{\\\"turn_number\\\": 1, \\\"turn_id\\\": \\\"t1\\\"}\"}\n\n",
+          "id: 2\nevent: output\ndata: {\"id\":2,\"kind\":\"output\",\"stream\":\"acp\",\"turn_id\":\"t1\",\"ts\":\"2026-09-02T00:00:00Z\",\"blocks\":[{\"kind\":\"text\",\"body\":\"Trying.\"}]}\n\n",
+          "id: 3\nevent: stage\ndata: {\"id\":3,\"kind\":\"stage\",\"stage\":\"turn\",\"state\":\"failed\",\"stream\":\"stage\",\"ts\":\"2026-09-02T00:00:00Z\",\"data\":\"{\\\"turn_number\\\": 1, \\\"turn_id\\\": \\\"t1\\\", \\\"exit_code\\\": 1, \\\"reason\\\": \\\"runtime exited 1\\\"}\"}\n\n"
+        ],
+        "close": "end"
+      }
+    },
+    {
+      "match": {
+        "method": "GET",
+        "path": "/api/conversations/11111111-2222-3333-4444-555555555555"
+      },
+      "respond": {
+        "status": 200,
+        "json": {
+          "data": {
+            "id": "11111111-2222-3333-4444-555555555555",
+            "status": "failed",
+            "runtime": "claude"
+          }
+        }
+      }
+    }
+  ],
+  "steps": [
+    {
+      "op": "run",
+      "agent": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+      "prompt": "hello"
+    }
+  ],
+  "expect": {
+    "result": {
+      "state": "failed",
+      "text": "Trying.",
+      "exit_code": 1
+    }
+  }
+}

--- a/sdk/conformance/scenarios/run-timeout-raises-and-keeps-partial-text.json
+++ b/sdk/conformance/scenarios/run-timeout-raises-and-keeps-partial-text.json
@@ -1,0 +1,62 @@
+{
+  "name": "run-timeout-raises-and-keeps-partial-text",
+  "title": "A run that outlives its timeout raises, and the error carries what the agent said so far",
+  "contract": "run-states",
+  "why": "The turn is still running in the sandbox. Throwing away the partial answer loses work the caller already paid for.",
+  "client": {
+    "api_key": "conformance-key"
+  },
+  "http": [
+    {
+      "match": {
+        "method": "POST",
+        "path": "/api/conversations"
+      },
+      "respond": {
+        "status": 201,
+        "json": {
+          "data": {
+            "id": "11111111-2222-3333-4444-555555555555",
+            "status": "running",
+            "runtime": "claude"
+          }
+        }
+      }
+    },
+    {
+      "match": {
+        "method": "GET",
+        "path": "/api/conversations/11111111-2222-3333-4444-555555555555/stream"
+      },
+      "respond": {
+        "status": 200,
+        "headers": {
+          "content-type": "text/event-stream"
+        },
+        "sse": [
+          "id: 1\nevent: stage\ndata: {\"id\":1,\"kind\":\"stage\",\"stage\":\"turn\",\"state\":\"started\",\"stream\":\"stage\",\"ts\":\"2026-09-02T00:00:00Z\",\"data\":\"{\\\"turn_number\\\": 1, \\\"turn_id\\\": \\\"t1\\\"}\"}\n\n",
+          "id: 2\nevent: output\ndata: {\"id\":2,\"kind\":\"output\",\"stream\":\"acp\",\"turn_id\":\"t1\",\"ts\":\"2026-09-02T00:00:00Z\",\"blocks\":[{\"kind\":\"text\",\"body\":\"Half an answer\"}]}\n\n",
+          {
+            "text": "",
+            "delay_ms": 1000
+          }
+        ],
+        "close": "end"
+      }
+    }
+  ],
+  "steps": [
+    {
+      "op": "run",
+      "agent": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+      "prompt": "hello",
+      "timeout_ms": 300
+    }
+  ],
+  "expect": {
+    "error": {
+      "kind": "timeout",
+      "partial_text": "Half an answer"
+    }
+  }
+}

--- a/sdk/conformance/scenarios/sse-comments-and-blank-lines-are-ignored.json
+++ b/sdk/conformance/scenarios/sse-comments-and-blank-lines-are-ignored.json
@@ -1,0 +1,95 @@
+{
+  "name": "sse-comments-and-blank-lines-are-ignored",
+  "title": "Heartbeat comments and stray blank lines do not become events",
+  "contract": "sse-framing",
+  "why": "Fountain sends `: heartbeat` to hold an idle connection open. A parser that yields it emits a null event mid-turn.",
+  "client": {
+    "api_key": "conformance-key"
+  },
+  "http": [
+    {
+      "match": {
+        "method": "POST",
+        "path": "/api/conversations"
+      },
+      "respond": {
+        "status": 201,
+        "json": {
+          "data": {
+            "id": "11111111-2222-3333-4444-555555555555",
+            "status": "running",
+            "runtime": "claude"
+          }
+        }
+      }
+    },
+    {
+      "match": {
+        "method": "GET",
+        "path": "/api/conversations/11111111-2222-3333-4444-555555555555/stream"
+      },
+      "respond": {
+        "status": 200,
+        "headers": {
+          "content-type": "text/event-stream"
+        },
+        "sse": [
+          ": heartbeat\n\n",
+          "id: 1\nevent: stage\ndata: {\"id\":1,\"kind\":\"stage\",\"stage\":\"turn\",\"state\":\"started\",\"stream\":\"stage\",\"ts\":\"2026-09-02T00:00:00Z\",\"data\":\"{\\\"turn_number\\\": 1, \\\"turn_id\\\": \\\"t1\\\"}\"}\n\n",
+          ": another\n\n",
+          "\n",
+          "id: 2\nevent: output\ndata: {\"id\":2,\"kind\":\"output\",\"stream\":\"acp\",\"turn_id\":\"t1\",\"ts\":\"2026-09-02T00:00:00Z\",\"blocks\":[{\"kind\":\"text\",\"body\":\"Found it.\"}]}\n\n",
+          "id: 3\nevent: stage\ndata: {\"id\":3,\"kind\":\"stage\",\"stage\":\"turn\",\"state\":\"done\",\"stream\":\"stage\",\"ts\":\"2026-09-02T00:00:00Z\",\"data\":\"{\\\"turn_number\\\": 1, \\\"turn_id\\\": \\\"t1\\\", \\\"stop_reason\\\": \\\"end_turn\\\"}\"}\n\n"
+        ],
+        "close": "end"
+      }
+    },
+    {
+      "match": {
+        "method": "GET",
+        "path": "/api/conversations/11111111-2222-3333-4444-555555555555"
+      },
+      "respond": {
+        "status": 200,
+        "json": {
+          "data": {
+            "id": "11111111-2222-3333-4444-555555555555",
+            "status": "idle",
+            "runtime": "claude"
+          }
+        }
+      }
+    }
+  ],
+  "steps": [
+    {
+      "op": "run",
+      "agent": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+      "prompt": "hello"
+    }
+  ],
+  "expect": {
+    "events": [
+      {
+        "type": "conversation"
+      },
+      {
+        "type": "turn-start",
+        "turn_number": 1
+      },
+      {
+        "type": "text",
+        "text": "Found it."
+      },
+      {
+        "type": "turn-end",
+        "state": "done"
+      }
+    ],
+    "result": {
+      "state": "done",
+      "text": "Found it.",
+      "turn_number": 1
+    }
+  }
+}

--- a/sdk/conformance/scenarios/sse-crlf-frame-boundary.json
+++ b/sdk/conformance/scenarios/sse-crlf-frame-boundary.json
@@ -1,0 +1,80 @@
+{
+  "name": "sse-crlf-frame-boundary",
+  "title": "A stream framed with CRLF parses the same as one framed with LF",
+  "contract": "sse-framing",
+  "why": "A proxy in front of Fountain may rewrite line endings, and the SSE spec allows both.",
+  "client": {
+    "api_key": "conformance-key"
+  },
+  "http": [
+    {
+      "match": {
+        "method": "POST",
+        "path": "/api/conversations"
+      },
+      "respond": {
+        "status": 201,
+        "json": {
+          "data": {
+            "id": "11111111-2222-3333-4444-555555555555",
+            "status": "running",
+            "runtime": "claude"
+          }
+        }
+      }
+    },
+    {
+      "match": {
+        "method": "GET",
+        "path": "/api/conversations/11111111-2222-3333-4444-555555555555/stream"
+      },
+      "respond": {
+        "status": 200,
+        "headers": {
+          "content-type": "text/event-stream"
+        },
+        "sse": [
+          "id: 1\r\nevent: stage\r\ndata: {\"id\":1,\"kind\":\"stage\",\"stage\":\"turn\",\"state\":\"started\",\"stream\":\"stage\",\"ts\":\"2026-09-02T00:00:00Z\",\"data\":\"{\\\"turn_number\\\": 1, \\\"turn_id\\\": \\\"t1\\\"}\"}\r\n\r\n",
+          "id: 2\r\nevent: output\r\ndata: {\"id\":2,\"kind\":\"output\",\"stream\":\"acp\",\"turn_id\":\"t1\",\"ts\":\"2026-09-02T00:00:00Z\",\"blocks\":[{\"kind\":\"text\",\"body\":\"Found it.\"}]}\r\n\r\n",
+          "id: 3\r\nevent: stage\r\ndata: {\"id\":3,\"kind\":\"stage\",\"stage\":\"turn\",\"state\":\"done\",\"stream\":\"stage\",\"ts\":\"2026-09-02T00:00:00Z\",\"data\":\"{\\\"turn_number\\\": 1, \\\"turn_id\\\": \\\"t1\\\", \\\"stop_reason\\\": \\\"end_turn\\\"}\"}\r\n\r\n"
+        ],
+        "close": "end"
+      }
+    },
+    {
+      "match": {
+        "method": "GET",
+        "path": "/api/conversations/11111111-2222-3333-4444-555555555555"
+      },
+      "respond": {
+        "status": 200,
+        "json": {
+          "data": {
+            "id": "11111111-2222-3333-4444-555555555555",
+            "status": "idle",
+            "runtime": "claude"
+          }
+        }
+      }
+    }
+  ],
+  "steps": [
+    {
+      "op": "run",
+      "agent": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+      "prompt": "hello"
+    }
+  ],
+  "expect": {
+    "events": [
+      {
+        "type": "text",
+        "text": "Found it."
+      }
+    ],
+    "result": {
+      "state": "done",
+      "text": "Found it."
+    }
+  }
+}

--- a/sdk/conformance/scenarios/sse-fragmented-frame-is-reassembled.json
+++ b/sdk/conformance/scenarios/sse-fragmented-frame-is-reassembled.json
@@ -1,0 +1,90 @@
+{
+  "name": "sse-fragmented-frame-is-reassembled",
+  "title": "A frame split across three writes is one event, not three",
+  "contract": "sse-framing",
+  "why": "TCP does not respect frame boundaries. A parser that treats each read as a message drops most of a busy turn.",
+  "client": {
+    "api_key": "conformance-key"
+  },
+  "http": [
+    {
+      "match": {
+        "method": "POST",
+        "path": "/api/conversations"
+      },
+      "respond": {
+        "status": 201,
+        "json": {
+          "data": {
+            "id": "11111111-2222-3333-4444-555555555555",
+            "status": "running",
+            "runtime": "claude"
+          }
+        }
+      }
+    },
+    {
+      "match": {
+        "method": "GET",
+        "path": "/api/conversations/11111111-2222-3333-4444-555555555555/stream"
+      },
+      "respond": {
+        "status": 200,
+        "headers": {
+          "content-type": "text/event-stream"
+        },
+        "sse": [
+          "id: 1\nevent: stage\ndata: {\"id\":1,\"kind\":\"stage\",\"stage\":\"turn\",\"state\":\"started\",\"stream\":\"stage\",\"ts\":\"2026-09-02T00:00:00Z\",\"data\":\"{\\\"turn_number\\\": 1, \\\"turn_id\\\": \\\"t1\\\"}\"}\n\n",
+          "id: 2\nevent: output\n",
+          "data: {\"id\":2,\"kind\":\"out",
+          "put\",\"stream\":\"acp\",\"turn_id\":\"t1\",\"ts\":\"2026-09-02T00:00:00Z\",\"blocks\":[{\"kind\":\"text\",\"body\":\"Found it.\"}]}\n\n",
+          "id: 3\nevent: stage\ndata: {\"id\":3,\"kind\":\"stage\",\"stage\":\"turn\",\"state\":\"done\",\"stream\":\"stage\",\"ts\":\"2026-09-02T00:00:00Z\",\"data\":\"{\\\"turn_number\\\": 1, \\\"turn_id\\\": \\\"t1\\\", \\\"stop_reason\\\": \\\"end_turn\\\"}\"}\n\n"
+        ],
+        "close": "end"
+      }
+    },
+    {
+      "match": {
+        "method": "GET",
+        "path": "/api/conversations/11111111-2222-3333-4444-555555555555"
+      },
+      "respond": {
+        "status": 200,
+        "json": {
+          "data": {
+            "id": "11111111-2222-3333-4444-555555555555",
+            "status": "idle",
+            "runtime": "claude"
+          }
+        }
+      }
+    }
+  ],
+  "steps": [
+    {
+      "op": "run",
+      "agent": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+      "prompt": "hello"
+    }
+  ],
+  "expect": {
+    "events": [
+      {
+        "type": "turn-start",
+        "turn_number": 1
+      },
+      {
+        "type": "text",
+        "text": "Found it."
+      },
+      {
+        "type": "turn-end",
+        "state": "done"
+      }
+    ],
+    "result": {
+      "state": "done",
+      "text": "Found it."
+    }
+  }
+}

--- a/sdk/conformance/scenarios/sse-malformed-frame-is-skipped.json
+++ b/sdk/conformance/scenarios/sse-malformed-frame-is-skipped.json
@@ -1,0 +1,89 @@
+{
+  "name": "sse-malformed-frame-is-skipped",
+  "title": "A frame whose data is not JSON is dropped and the stream carries on",
+  "contract": "sse-framing",
+  "why": "One bad frame must not end a turn that is otherwise fine, and must not be reported as content.",
+  "client": {
+    "api_key": "conformance-key"
+  },
+  "http": [
+    {
+      "match": {
+        "method": "POST",
+        "path": "/api/conversations"
+      },
+      "respond": {
+        "status": 201,
+        "json": {
+          "data": {
+            "id": "11111111-2222-3333-4444-555555555555",
+            "status": "running",
+            "runtime": "claude"
+          }
+        }
+      }
+    },
+    {
+      "match": {
+        "method": "GET",
+        "path": "/api/conversations/11111111-2222-3333-4444-555555555555/stream"
+      },
+      "respond": {
+        "status": 200,
+        "headers": {
+          "content-type": "text/event-stream"
+        },
+        "sse": [
+          "id: 1\nevent: stage\ndata: {\"id\":1,\"kind\":\"stage\",\"stage\":\"turn\",\"state\":\"started\",\"stream\":\"stage\",\"ts\":\"2026-09-02T00:00:00Z\",\"data\":\"{\\\"turn_number\\\": 1, \\\"turn_id\\\": \\\"t1\\\"}\"}\n\n",
+          "id: 99\nevent: output\ndata: {not json at all\n\n",
+          "id: 2\nevent: output\ndata: {\"id\":2,\"kind\":\"output\",\"stream\":\"acp\",\"turn_id\":\"t1\",\"ts\":\"2026-09-02T00:00:00Z\",\"blocks\":[{\"kind\":\"text\",\"body\":\"Found it.\"}]}\n\n",
+          "id: 3\nevent: stage\ndata: {\"id\":3,\"kind\":\"stage\",\"stage\":\"turn\",\"state\":\"done\",\"stream\":\"stage\",\"ts\":\"2026-09-02T00:00:00Z\",\"data\":\"{\\\"turn_number\\\": 1, \\\"turn_id\\\": \\\"t1\\\", \\\"stop_reason\\\": \\\"end_turn\\\"}\"}\n\n"
+        ],
+        "close": "end"
+      }
+    },
+    {
+      "match": {
+        "method": "GET",
+        "path": "/api/conversations/11111111-2222-3333-4444-555555555555"
+      },
+      "respond": {
+        "status": 200,
+        "json": {
+          "data": {
+            "id": "11111111-2222-3333-4444-555555555555",
+            "status": "idle",
+            "runtime": "claude"
+          }
+        }
+      }
+    }
+  ],
+  "steps": [
+    {
+      "op": "run",
+      "agent": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+      "prompt": "hello"
+    }
+  ],
+  "expect": {
+    "events": [
+      {
+        "type": "turn-start",
+        "turn_number": 1
+      },
+      {
+        "type": "text",
+        "text": "Found it."
+      },
+      {
+        "type": "turn-end",
+        "state": "done"
+      }
+    ],
+    "result": {
+      "state": "done",
+      "text": "Found it."
+    }
+  }
+}

--- a/sdk/conformance/scenarios/sse-multiline-data-joins-with-newlines.json
+++ b/sdk/conformance/scenarios/sse-multiline-data-joins-with-newlines.json
@@ -1,0 +1,80 @@
+{
+  "name": "sse-multiline-data-joins-with-newlines",
+  "title": "Several `data:` lines in one frame join with a newline between them",
+  "contract": "sse-framing",
+  "why": "A JSON payload containing a newline is split across data lines by the spec. Joining with anything else corrupts it.",
+  "client": {
+    "api_key": "conformance-key"
+  },
+  "http": [
+    {
+      "match": {
+        "method": "POST",
+        "path": "/api/conversations"
+      },
+      "respond": {
+        "status": 201,
+        "json": {
+          "data": {
+            "id": "11111111-2222-3333-4444-555555555555",
+            "status": "running",
+            "runtime": "claude"
+          }
+        }
+      }
+    },
+    {
+      "match": {
+        "method": "GET",
+        "path": "/api/conversations/11111111-2222-3333-4444-555555555555/stream"
+      },
+      "respond": {
+        "status": 200,
+        "headers": {
+          "content-type": "text/event-stream"
+        },
+        "sse": [
+          "id: 1\nevent: stage\ndata: {\"id\":1,\"kind\":\"stage\",\"stage\":\"turn\",\"state\":\"started\",\"stream\":\"stage\",\"ts\":\"2026-09-02T00:00:00Z\",\"data\":\"{\\\"turn_number\\\": 1, \\\"turn_id\\\": \\\"t1\\\"}\"}\n\n",
+          "id: 2\nevent: output\ndata: {\ndata:  \"id\": 2,\ndata:  \"kind\": \"output\",\ndata:  \"stream\": \"acp\",\ndata:  \"turn_id\": \"t1\",\ndata:  \"ts\": \"2026-09-02T00:00:00Z\",\ndata:  \"blocks\": [\ndata:   {\ndata:    \"kind\": \"text\",\ndata:    \"body\": \"line one\\nline two\"\ndata:   }\ndata:  ]\ndata: }\n\n",
+          "id: 3\nevent: stage\ndata: {\"id\":3,\"kind\":\"stage\",\"stage\":\"turn\",\"state\":\"done\",\"stream\":\"stage\",\"ts\":\"2026-09-02T00:00:00Z\",\"data\":\"{\\\"turn_number\\\": 1, \\\"turn_id\\\": \\\"t1\\\", \\\"stop_reason\\\": \\\"end_turn\\\"}\"}\n\n"
+        ],
+        "close": "end"
+      }
+    },
+    {
+      "match": {
+        "method": "GET",
+        "path": "/api/conversations/11111111-2222-3333-4444-555555555555"
+      },
+      "respond": {
+        "status": 200,
+        "json": {
+          "data": {
+            "id": "11111111-2222-3333-4444-555555555555",
+            "status": "idle",
+            "runtime": "claude"
+          }
+        }
+      }
+    }
+  ],
+  "steps": [
+    {
+      "op": "run",
+      "agent": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+      "prompt": "hello"
+    }
+  ],
+  "expect": {
+    "events": [
+      {
+        "type": "text",
+        "text": "line one\nline two"
+      }
+    ],
+    "result": {
+      "state": "done",
+      "text": "line one\nline two"
+    }
+  }
+}

--- a/sdk/conformance/scenarios/sse-no-cursor-header-on-the-first-connection.json
+++ b/sdk/conformance/scenarios/sse-no-cursor-header-on-the-first-connection.json
@@ -1,0 +1,86 @@
+{
+  "name": "sse-no-cursor-header-on-the-first-connection",
+  "title": "The first connection sends no Last-Event-ID",
+  "contract": "reconnect",
+  "why": "Sending `Last-Event-ID: 0` asks the server to replay after event zero, which is not the same request.",
+  "client": {
+    "api_key": "conformance-key"
+  },
+  "http": [
+    {
+      "match": {
+        "method": "POST",
+        "path": "/api/conversations"
+      },
+      "respond": {
+        "status": 201,
+        "json": {
+          "data": {
+            "id": "11111111-2222-3333-4444-555555555555",
+            "status": "running",
+            "runtime": "claude"
+          }
+        }
+      }
+    },
+    {
+      "match": {
+        "method": "GET",
+        "path": "/api/conversations/11111111-2222-3333-4444-555555555555/stream"
+      },
+      "respond": {
+        "status": 200,
+        "headers": {
+          "content-type": "text/event-stream"
+        },
+        "sse": [
+          "id: 1\nevent: stage\ndata: {\"id\":1,\"kind\":\"stage\",\"stage\":\"turn\",\"state\":\"started\",\"stream\":\"stage\",\"ts\":\"2026-09-02T00:00:00Z\",\"data\":\"{\\\"turn_number\\\": 1, \\\"turn_id\\\": \\\"t1\\\"}\"}\n\n",
+          "id: 2\nevent: output\ndata: {\"id\":2,\"kind\":\"output\",\"stream\":\"acp\",\"turn_id\":\"t1\",\"ts\":\"2026-09-02T00:00:00Z\",\"blocks\":[{\"kind\":\"text\",\"body\":\"Found it.\"}]}\n\n",
+          "id: 3\nevent: stage\ndata: {\"id\":3,\"kind\":\"stage\",\"stage\":\"turn\",\"state\":\"done\",\"stream\":\"stage\",\"ts\":\"2026-09-02T00:00:00Z\",\"data\":\"{\\\"turn_number\\\": 1, \\\"turn_id\\\": \\\"t1\\\", \\\"stop_reason\\\": \\\"end_turn\\\"}\"}\n\n"
+        ],
+        "close": "end"
+      }
+    },
+    {
+      "match": {
+        "method": "GET",
+        "path": "/api/conversations/11111111-2222-3333-4444-555555555555"
+      },
+      "respond": {
+        "status": 200,
+        "json": {
+          "data": {
+            "id": "11111111-2222-3333-4444-555555555555",
+            "status": "idle",
+            "runtime": "claude"
+          }
+        }
+      }
+    }
+  ],
+  "steps": [
+    {
+      "op": "run",
+      "agent": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+      "prompt": "hello"
+    }
+  ],
+  "expect": {
+    "requests": [
+      {
+        "method": "POST",
+        "path": "/api/conversations"
+      },
+      {
+        "method": "GET",
+        "path": "/api/conversations/11111111-2222-3333-4444-555555555555/stream",
+        "headers_absent": [
+          "last-event-id"
+        ]
+      }
+    ],
+    "result": {
+      "state": "done"
+    }
+  }
+}

--- a/sdk/conformance/scenarios/sse-reconnect-resumes-from-last-event-id.json
+++ b/sdk/conformance/scenarios/sse-reconnect-resumes-from-last-event-id.json
@@ -1,0 +1,123 @@
+{
+  "name": "sse-reconnect-resumes-from-last-event-id",
+  "title": "A stream that dies mid-turn reconnects and asks to resume after the last id it saw",
+  "contract": "reconnect",
+  "why": "Without the cursor the second connection replays what the caller already read, or misses the gap. Both were shipped bugs.",
+  "client": {
+    "api_key": "conformance-key"
+  },
+  "http": [
+    {
+      "match": {
+        "method": "POST",
+        "path": "/api/conversations"
+      },
+      "respond": {
+        "status": 201,
+        "json": {
+          "data": {
+            "id": "11111111-2222-3333-4444-555555555555",
+            "status": "running",
+            "runtime": "claude"
+          }
+        }
+      }
+    },
+    {
+      "match": {
+        "method": "GET",
+        "path": "/api/conversations/11111111-2222-3333-4444-555555555555/stream"
+      },
+      "respond": {
+        "status": 200,
+        "headers": {
+          "content-type": "text/event-stream"
+        },
+        "sse": [
+          "id: 1\nevent: stage\ndata: {\"id\":1,\"kind\":\"stage\",\"stage\":\"turn\",\"state\":\"started\",\"stream\":\"stage\",\"ts\":\"2026-09-02T00:00:00Z\",\"data\":\"{\\\"turn_number\\\": 1, \\\"turn_id\\\": \\\"t1\\\"}\"}\n\n"
+        ],
+        "close": "abort"
+      }
+    },
+    {
+      "match": {
+        "method": "GET",
+        "path": "/api/conversations/11111111-2222-3333-4444-555555555555/stream",
+        "headers": {
+          "last-event-id": "1"
+        }
+      },
+      "respond": {
+        "status": 200,
+        "headers": {
+          "content-type": "text/event-stream"
+        },
+        "sse": [
+          "id: 2\nevent: output\ndata: {\"id\":2,\"kind\":\"output\",\"stream\":\"acp\",\"turn_id\":\"t1\",\"ts\":\"2026-09-02T00:00:00Z\",\"blocks\":[{\"kind\":\"text\",\"body\":\"Found it.\"}]}\n\n",
+          "id: 3\nevent: stage\ndata: {\"id\":3,\"kind\":\"stage\",\"stage\":\"turn\",\"state\":\"done\",\"stream\":\"stage\",\"ts\":\"2026-09-02T00:00:00Z\",\"data\":\"{\\\"turn_number\\\": 1, \\\"turn_id\\\": \\\"t1\\\", \\\"stop_reason\\\": \\\"end_turn\\\"}\"}\n\n"
+        ],
+        "close": "end"
+      }
+    },
+    {
+      "match": {
+        "method": "GET",
+        "path": "/api/conversations/11111111-2222-3333-4444-555555555555"
+      },
+      "respond": {
+        "status": 200,
+        "json": {
+          "data": {
+            "id": "11111111-2222-3333-4444-555555555555",
+            "status": "idle",
+            "runtime": "claude"
+          }
+        }
+      }
+    }
+  ],
+  "steps": [
+    {
+      "op": "run",
+      "agent": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+      "prompt": "hello"
+    }
+  ],
+  "expect": {
+    "requests": [
+      {
+        "method": "POST",
+        "path": "/api/conversations"
+      },
+      {
+        "method": "GET",
+        "path": "/api/conversations/11111111-2222-3333-4444-555555555555/stream"
+      },
+      {
+        "method": "GET",
+        "path": "/api/conversations/11111111-2222-3333-4444-555555555555/stream",
+        "headers": {
+          "last-event-id": "1"
+        }
+      }
+    ],
+    "events": [
+      {
+        "type": "turn-start",
+        "turn_number": 1
+      },
+      {
+        "type": "text",
+        "text": "Found it."
+      },
+      {
+        "type": "turn-end",
+        "state": "done"
+      }
+    ],
+    "result": {
+      "state": "done",
+      "text": "Found it."
+    }
+  }
+}

--- a/sdk/elixir/test/conformance_test.exs
+++ b/sdk/elixir/test/conformance_test.exs
@@ -1,0 +1,731 @@
+defmodule Fountain.ConformanceTest do
+  use ExUnit.Case
+
+  alias Fountain.{Agents, Conversation, Environments, Error, Run, Vaults}
+
+  @sdk "elixir"
+  @conformance Path.expand("../../conformance", __DIR__)
+  @matrix @conformance |> Path.join("matrix.json") |> File.read!() |> Jason.decode!()
+  @scenarios @conformance
+             |> Path.join("scenarios/*.json")
+             |> Path.wildcard()
+             |> Enum.sort()
+             |> Enum.map(fn path -> path |> File.read!() |> Jason.decode!() end)
+
+  defmodule ScriptedServer do
+    @moduledoc false
+
+    def start(exchanges) do
+      {:ok, state} =
+        Agent.start_link(fn ->
+          %{exchanges: exchanges, consumed: MapSet.new(), requests: [], unmatched: []}
+        end)
+
+      {:ok, listener} =
+        :gen_tcp.listen(0, [:binary, packet: :raw, active: false, reuseaddr: true])
+
+      {:ok, {_address, port}} = :inet.sockname(listener)
+      acceptor = spawn(fn -> accept(listener, state) end)
+
+      %{
+        listener: listener,
+        acceptor: acceptor,
+        state: state,
+        url: "http://127.0.0.1:#{port}"
+      }
+    end
+
+    def observations(server) do
+      Agent.get(server.state, fn state ->
+        %{
+          requests: Enum.reverse(state.requests),
+          unmatched: Enum.reverse(state.unmatched)
+        }
+      end)
+    end
+
+    def stop(server) do
+      :gen_tcp.close(server.listener)
+
+      if Process.alive?(server.acceptor), do: Process.exit(server.acceptor, :kill)
+      if Process.alive?(server.state), do: Agent.stop(server.state)
+
+      :ok
+    end
+
+    defp accept(listener, state) do
+      case :gen_tcp.accept(listener) do
+        {:ok, socket} ->
+          spawn(fn -> serve(socket, state) end)
+          accept(listener, state)
+
+        _error ->
+          :ok
+      end
+    end
+
+    defp serve(socket, state) do
+      with {:ok, request} <- read_request(socket) do
+        case pick_exchange(state, request) do
+          nil ->
+            payload = Jason.encode!(%{"error" => "conformance_unmatched_request"})
+
+            send_response(
+              socket,
+              599,
+              [{"content-type", "application/json"}, {"content-length", byte_size(payload)}],
+              payload
+            )
+
+          respond ->
+            respond(socket, respond)
+        end
+      end
+
+      :gen_tcp.close(socket)
+    end
+
+    defp pick_exchange(state, request) do
+      Agent.get_and_update(state, fn current ->
+        found =
+          current.exchanges
+          |> Enum.with_index()
+          |> Enum.find(fn {exchange, index} ->
+            not MapSet.member?(current.consumed, index) and
+              matches?(exchange["match"], request)
+          end)
+
+        requests = [request | current.requests]
+
+        case found do
+          {exchange, index} ->
+            {exchange["respond"],
+             %{
+               current
+               | consumed: MapSet.put(current.consumed, index),
+                 requests: requests
+             }}
+
+          nil ->
+            {nil, %{current | requests: requests, unmatched: [request | current.unmatched]}}
+        end
+      end)
+    end
+
+    defp matches?(match, request) do
+      String.upcase(match["method"]) == request.method and
+        match["path"] == request.path and
+        subset?(match["query"] || %{}, request.query) and
+        subset?(downcase_keys(match["headers"] || %{}), request.headers)
+    end
+
+    defp subset?(expected, actual) do
+      Enum.all?(expected, fn {key, value} -> Map.get(actual, key) == value end)
+    end
+
+    defp respond(socket, %{"sse" => chunks} = response) do
+      headers =
+        response
+        |> Map.get("headers", %{})
+        |> Map.put_new("cache-control", "no-cache")
+        |> Map.to_list()
+
+      send_head(socket, response["status"], [{"transfer-encoding", "chunked"} | headers])
+
+      Enum.each(chunks, fn chunk ->
+        {delay, text} =
+          if is_binary(chunk),
+            do: {0, chunk},
+            else: {chunk["delay_ms"] || 0, chunk["text"]}
+
+        if delay > 0, do: Process.sleep(delay)
+
+        if text != "" do
+          :gen_tcp.send(socket, [Integer.to_string(byte_size(text), 16), "\r\n", text, "\r\n"])
+        end
+      end)
+
+      if response["close"] != "abort", do: :gen_tcp.send(socket, "0\r\n\r\n")
+    end
+
+    defp respond(socket, response) do
+      headers = response["headers"] || %{}
+
+      {payload, headers} =
+        cond do
+          Map.has_key?(response, "json") ->
+            payload = Jason.encode!(response["json"])
+            {payload, Map.put_new(headers, "content-type", "application/json")}
+
+          Map.has_key?(response, "body") ->
+            {response["body"], headers}
+
+          true ->
+            {"", headers}
+        end
+
+      headers = Map.put(headers, "content-length", byte_size(payload))
+      send_response(socket, response["status"], Map.to_list(headers), payload)
+    end
+
+    defp read_request(socket), do: read_headers(socket, "")
+
+    defp read_headers(socket, buffer) do
+      case :binary.match(buffer, "\r\n\r\n") do
+        {index, 4} ->
+          <<head::binary-size(index), _separator::binary-size(4), rest::binary>> = buffer
+          [request_line | header_lines] = String.split(head, "\r\n")
+          [method, target, _version] = String.split(request_line, " ", parts: 3)
+
+          headers =
+            Map.new(header_lines, fn line ->
+              [key, value] = String.split(line, ":", parts: 2)
+              {String.downcase(key), String.trim(value)}
+            end)
+
+          content_length = headers |> Map.get("content-length", "0") |> String.to_integer()
+
+          with {:ok, body} <- read_body(socket, rest, content_length) do
+            uri = URI.parse(target)
+
+            {:ok,
+             %{
+               method: String.upcase(method),
+               path: uri.path,
+               query: URI.decode_query(uri.query || ""),
+               headers: headers,
+               body: safe_json(body)
+             }}
+          end
+
+        :nomatch ->
+          case :gen_tcp.recv(socket, 0, 2_000) do
+            {:ok, data} -> read_headers(socket, buffer <> data)
+            error -> error
+          end
+      end
+    end
+
+    defp read_body(_socket, body, length) when byte_size(body) >= length,
+      do: {:ok, binary_part(body, 0, length)}
+
+    defp read_body(socket, body, length) do
+      with {:ok, data} <- :gen_tcp.recv(socket, length - byte_size(body), 2_000),
+           do: read_body(socket, body <> data, length)
+    end
+
+    defp safe_json(""), do: nil
+
+    defp safe_json(text) do
+      case Jason.decode(text) do
+        {:ok, value} -> value
+        _error -> text
+      end
+    end
+
+    defp send_response(socket, status, headers, body) do
+      send_head(socket, status, headers)
+      :gen_tcp.send(socket, body)
+    end
+
+    defp send_head(socket, status, headers) do
+      reason =
+        %{
+          200 => "OK",
+          201 => "Created",
+          204 => "No Content",
+          400 => "Bad Request",
+          401 => "Unauthorized",
+          402 => "Payment Required",
+          404 => "Not Found",
+          422 => "Unprocessable Entity",
+          429 => "Too Many Requests",
+          503 => "Service Unavailable",
+          599 => "Conformance Unmatched Request"
+        }[status] || "Error"
+
+      values = [{"connection", "close"} | headers]
+
+      head = [
+        "HTTP/1.1 #{status} #{reason}\r\n",
+        Enum.map(values, fn {key, value} -> "#{key}: #{value}\r\n" end),
+        "\r\n"
+      ]
+
+      :gen_tcp.send(socket, head)
+    end
+
+    defp downcase_keys(map),
+      do: Map.new(map, fn {key, value} -> {String.downcase(key), value} end)
+  end
+
+  for scenario <- @scenarios do
+    verdict = get_in(@matrix, ["scenarios", scenario["name"], @sdk])
+
+    if verdict != "yes" do
+      @tag skip: "##{verdict["issue"]}: #{verdict["skip"]}"
+    end
+
+    test "conformance/#{scenario["name"]}" do
+      scenario = unquote(Macro.escape(scenario))
+      server = ScriptedServer.start(scenario["http"])
+
+      observed = %{
+        requests: [],
+        unmatched: [],
+        events: [],
+        result: nil,
+        error: nil,
+        value: nil,
+        event_ids: nil
+      }
+
+      observed =
+        try do
+          Map.merge(observed, drive(scenario, server.url))
+        rescue
+          error -> %{observed | error: normalise_error(error)}
+        catch
+          kind, reason ->
+            %{observed | error: normalise_error({kind, reason})}
+        after
+          :ok
+        end
+
+      server_observations = ScriptedServer.observations(server)
+      ScriptedServer.stop(server)
+      observed = Map.merge(observed, server_observations)
+      problems = check(scenario, observed)
+
+      if problems != [] do
+        flunk(
+          "conformance FAILED for elixir / #{scenario["name"]}\n" <>
+            "  #{scenario["title"]}\n\n" <>
+            Enum.map_join(problems, "\n\n", fn problem ->
+              "  " <> String.replace(problem, "\n", "\n  ")
+            end)
+        )
+      end
+    end
+  end
+
+  defp drive(scenario, base_url) do
+    client_config = scenario["client"]
+
+    client =
+      Fountain.new(
+        api_key: client_config["api_key"],
+        base_url: base_url <> (client_config["base_url_suffix"] || ""),
+        timeout: client_config["timeout_ms"] || 5_000,
+        env: fn _name -> nil end,
+        credentials_file: "/conformance/no-credentials"
+      )
+
+    Enum.reduce(scenario["steps"], %{}, fn step, observed ->
+      drive_step(client, step, observed)
+    end)
+  end
+
+  defp drive_step(client, %{"op" => "me"}, observed),
+    do: Map.put(observed, :value, client |> Fountain.me() |> unwrap!())
+
+  defp drive_step(client, %{"op" => "list", "resource" => resource}, observed) do
+    value =
+      case resource do
+        "agents" -> Agents.list(client.agents)
+        "vaults" -> Vaults.list(client.vaults)
+        "environments" -> Environments.list(client.environments)
+      end
+
+    Map.put(observed, :value, unwrap!(value))
+  end
+
+  defp drive_step(client, %{"op" => "create_agent", "attrs" => attrs}, observed),
+    do: Map.put(observed, :value, client.agents |> Agents.create(attrs) |> unwrap!())
+
+  defp drive_step(
+         client,
+         %{"op" => "get_conversation", "conversation_id" => conversation_id},
+         observed
+       ) do
+    value = client |> Fountain.resume(conversation_id) |> Conversation.get() |> unwrap!()
+    Map.put(observed, :value, value)
+  end
+
+  defp drive_step(client, %{"op" => "history", "conversation_id" => conversation_id}, observed) do
+    event_ids =
+      client
+      |> Fountain.resume(conversation_id)
+      |> Conversation.history()
+      |> unwrap!()
+      |> Enum.map(& &1["id"])
+
+    Map.put(observed, :event_ids, event_ids)
+  end
+
+  defp drive_step(
+         client,
+         %{"op" => "send", "conversation_id" => conversation_id, "prompt" => prompt},
+         observed
+       ) do
+    run = client |> Fountain.resume(conversation_id) |> Conversation.send(prompt)
+    result = run |> Run.await() |> unwrap!() |> normalise_result()
+    Map.put(observed, :result, result)
+  end
+
+  defp drive_step(client, %{"op" => "run"} = step, observed) do
+    options =
+      [agent: step["agent"]]
+      |> put_option(:timeout, step["timeout_ms"])
+
+    run = Fountain.run(client, step["prompt"], options)
+    consumer = Task.async(fn -> consume_run(run, step["answer_permissions"] || %{}) end)
+    completion = Run.await(run)
+    {events, _stream_error} = Task.await(consumer, :infinity)
+    observed = Map.put(observed, :events, events)
+
+    case completion do
+      {:ok, result} -> Map.put(observed, :result, normalise_result(result))
+      {:error, error} -> raise error
+    end
+  end
+
+  defp drive_step(_client, %{"op" => operation}, _observed),
+    do: raise("conformance: this adapter has no op #{operation}")
+
+  defp consume_run(run, answers) do
+    try do
+      events =
+        Enum.reduce(Run.stream(run), [], fn event, events ->
+          if event.type == :permission do
+            request_id = event.request.request_id
+
+            case answers[request_id] || answers["*"] do
+              nil -> :ok
+              option_id -> run |> Run.answer(request_id, option_id) |> unwrap_answer!()
+            end
+          end
+
+          [normalise_event(event) | events]
+        end)
+
+      {Enum.reverse(events), nil}
+    rescue
+      error -> {[], error}
+    catch
+      kind, reason -> {[], {kind, reason}}
+    end
+  end
+
+  defp unwrap!({:ok, value}), do: value
+  defp unwrap!({:error, error}), do: raise(error)
+  defp unwrap!(value), do: value
+
+  defp unwrap_answer!(:ok), do: :ok
+  defp unwrap_answer!({:ok, _value}), do: :ok
+  defp unwrap_answer!({:error, error}), do: raise(error)
+
+  defp put_option(options, _key, nil), do: options
+  defp put_option(options, key, value), do: Keyword.put(options, key, value)
+
+  defp normalise_event(%{type: :conversation} = event),
+    do: %{"type" => "conversation", "conversation_id" => event.conversation_id}
+
+  defp normalise_event(%{type: :turn_start} = event),
+    do: %{
+      "type" => "turn-start",
+      "turn_number" => event.turn_number,
+      "turn_id" => event.turn_id
+    }
+
+  defp normalise_event(%{type: type, text: text}) when type in [:text, :thinking],
+    do: %{"type" => Atom.to_string(type), "text" => text}
+
+  defp normalise_event(%{type: :tool} = event),
+    do: %{"type" => "tool", "name" => event.name}
+
+  defp normalise_event(%{type: :permission} = event),
+    do: %{
+      "type" => "permission",
+      "request_id" => event.request.request_id,
+      "options" => Enum.map(event.request.options, & &1.option_id)
+    }
+
+  defp normalise_event(%{type: :block}), do: %{"type" => "block"}
+  defp normalise_event(%{type: :event}), do: %{"type" => "event"}
+
+  defp normalise_event(%{type: :turn_end} = event),
+    do: %{
+      "type" => "turn-end",
+      "state" => atom_string(event.state),
+      "exit_code" => event.exit_code,
+      "reason" => event.reason
+    }
+
+  defp normalise_event(%{type: type}), do: %{"type" => type |> atom_string() |> dash()}
+
+  defp normalise_result(result),
+    do: %{
+      "state" => atom_string(result.state),
+      "text" => result.text,
+      "tools_used" => result.tools_used,
+      "turn_number" => result.turn_number,
+      "exit_code" => result.exit_code,
+      "reason" => result.reason,
+      "conversation_id" => result.conversation_id,
+      "status" => result.status
+    }
+
+  defp normalise_error(%Error{} = error) do
+    %{
+      "kind" => error_kind(error.kind),
+      "status" => error.status,
+      "code" => error.code,
+      "retryable" => Error.retryable?(error),
+      "retry_after" => error.retry_after,
+      "field_errors" => Error.field_errors(error),
+      "partial_text" => error.partial_text
+    }
+  end
+
+  defp normalise_error(error) do
+    %{
+      "kind" => "unknown",
+      "message" =>
+        case error do
+          {kind, reason} -> Exception.format(kind, reason)
+          value -> Exception.message(value)
+        end
+    }
+  end
+
+  defp error_kind(:auth), do: "auth"
+  defp error_kind(:not_found), do: "not_found"
+  defp error_kind(:validation), do: "validation"
+  defp error_kind(:rate_limit), do: "rate_limited"
+  defp error_kind(:conversation_busy), do: "busy"
+  defp error_kind(:quota_exceeded), do: "quota"
+  defp error_kind(:subscription_required), do: "subscription"
+  defp error_kind(:not_ready), do: "not_ready"
+  defp error_kind(:timeout), do: "timeout"
+  defp error_kind(:connection), do: "connection"
+  defp error_kind(:resolution), do: "resolution"
+  defp error_kind(:api), do: "server"
+  defp error_kind(kind), do: atom_string(kind)
+
+  defp atom_string(nil), do: nil
+  defp atom_string(value) when is_atom(value), do: Atom.to_string(value)
+  defp atom_string(value), do: value
+  defp dash(nil), do: nil
+  defp dash(value), do: String.replace(value, "_", "-")
+
+  defp check(scenario, observed) do
+    expect = scenario["expect"]
+
+    []
+    |> check_unmatched(observed.unmatched)
+    |> check_error(expect, observed)
+    |> check_requests(expect, observed)
+    |> check_events(expect, observed)
+    |> check_result(expect, observed)
+    |> check_value(expect, observed)
+    |> check_event_ids(expect, observed)
+    |> Enum.reverse()
+  end
+
+  defp check_unmatched(problems, unmatched) do
+    Enum.reduce(unmatched, problems, fn request, acc ->
+      [
+        "unmatched request\n" <>
+          "    the client sent #{request.method} #{request.path}, which no exchange in the " <>
+          "scenario anticipated. Either the client should not have sent it, or the scenario " <>
+          "needs it."
+        | acc
+      ]
+    end)
+  end
+
+  defp check_error(problems, %{"error" => wanted}, %{error: nil}),
+    do: ["error\n    expected #{show(wanted)} but the call succeeded" | problems]
+
+  defp check_error(problems, %{"error" => wanted}, %{error: got}) do
+    if subset?(wanted, got),
+      do: problems,
+      else: ["error\n    expected #{show(wanted)}\n    got #{show(got)}" | problems]
+  end
+
+  defp check_error(problems, _expect, %{error: nil}), do: problems
+
+  defp check_error(problems, _expect, %{error: error}),
+    do: ["error\n    the call was not supposed to fail, and raised #{show(error)}" | problems]
+
+  defp check_requests(problems, %{"requests" => wanted} = expect, observed) do
+    problems =
+      if expect["requests_exactly"] == true and length(observed.requests) != length(wanted) do
+        seen = Enum.map_join(observed.requests, ", ", &"#{&1.method} #{&1.path}")
+
+        [
+          "requests\n    expected exactly #{length(wanted)} request(s), " <>
+            "saw #{length(observed.requests)}: #{seen}"
+          | problems
+        ]
+      else
+        problems
+      end
+
+    wanted
+    |> Enum.with_index()
+    |> Enum.reduce(problems, fn {request, index}, acc ->
+      check_request(acc, request, Enum.at(observed.requests, index), index)
+    end)
+  end
+
+  defp check_requests(problems, _expect, _observed), do: problems
+
+  defp check_request(problems, wanted, nil, index),
+    do: [
+      "requests[#{index}]\n    expected #{wanted["method"]} #{wanted["path"]}, saw nothing"
+      | problems
+    ]
+
+  defp check_request(problems, wanted, got, index) do
+    if wanted["method"] != got.method or wanted["path"] != got.path do
+      [
+        "requests[#{index}]\n    expected #{wanted["method"]} #{wanted["path"]}, " <>
+          "saw #{got.method} #{got.path}"
+        | problems
+      ]
+    else
+      problems
+      |> check_request_subset("query", wanted["query"], got.query, index)
+      |> check_request_subset("headers", wanted["headers"], got.headers, index)
+      |> check_header_prefixes(wanted["header_prefixes"] || %{}, got.headers, index)
+      |> check_headers_absent(wanted["headers_absent"] || [], got.headers, index)
+      |> check_request_body(wanted["body"], got.body, index)
+    end
+  end
+
+  defp check_request_subset(problems, _field, nil, _got, _index), do: problems
+
+  defp check_request_subset(problems, field, wanted, got, index) do
+    if subset?(wanted, got),
+      do: problems,
+      else: [
+        "requests[#{index}].#{field}\n    expected #{show(wanted)}\n    got #{show(got)}"
+        | problems
+      ]
+  end
+
+  defp check_header_prefixes(problems, prefixes, headers, index) do
+    Enum.reduce(prefixes, problems, fn {header, prefix}, acc ->
+      value = headers[header] || ""
+
+      if String.starts_with?(value, prefix) do
+        acc
+      else
+        [
+          "requests[#{index}].headers.#{header}\n" <>
+            "    expected it to start with #{inspect(prefix)}, got #{inspect(value)}"
+          | acc
+        ]
+      end
+    end)
+  end
+
+  defp check_headers_absent(problems, absent, headers, index) do
+    Enum.reduce(absent, problems, fn header, acc ->
+      if Map.has_key?(headers, header) do
+        [
+          "requests[#{index}].headers.#{header}\n" <>
+            "    expected no such header, got #{inspect(headers[header])}"
+          | acc
+        ]
+      else
+        acc
+      end
+    end)
+  end
+
+  defp check_request_body(problems, nil, _got, _index), do: problems
+
+  defp check_request_body(problems, wanted, got, index) do
+    if deep_subset?(wanted, got),
+      do: problems,
+      else: [
+        "requests[#{index}].body\n    expected #{show(wanted)}\n    got #{show(got)}" | problems
+      ]
+  end
+
+  defp check_events(problems, %{"events" => wanted}, observed) do
+    case match_event_subsequence(wanted, observed.events, 0) do
+      :ok ->
+        problems
+
+      {:error, event, cursor} ->
+        [
+          "events\n    expected #{show(event)} after index #{cursor}, and the run emitted:\n" <>
+            "    #{show(observed.events)}"
+          | problems
+        ]
+    end
+  end
+
+  defp check_events(problems, _expect, _observed), do: problems
+
+  defp match_event_subsequence([], _actual, _cursor), do: :ok
+
+  defp match_event_subsequence([wanted | rest], actual, cursor) do
+    case actual
+         |> Enum.with_index()
+         |> Enum.find(fn {got, index} -> index >= cursor and subset?(wanted, got) end) do
+      nil -> {:error, wanted, cursor}
+      {_event, index} -> match_event_subsequence(rest, actual, index + 1)
+    end
+  end
+
+  defp check_result(problems, %{"result" => wanted}, %{result: nil}),
+    do: ["result\n    expected #{show(wanted)} but there was no result" | problems]
+
+  defp check_result(problems, %{"result" => wanted}, %{result: got}) do
+    if subset?(wanted, got),
+      do: problems,
+      else: ["result\n    expected #{show(wanted)}\n    got #{show(got)}" | problems]
+  end
+
+  defp check_result(problems, _expect, _observed), do: problems
+
+  defp check_value(problems, expect, observed) do
+    if Map.has_key?(expect, "value") and not deep_subset?(expect["value"], observed.value),
+      do: [
+        "value\n    expected #{show(expect["value"])}\n    got #{show(observed.value)}" | problems
+      ],
+      else: problems
+  end
+
+  defp check_event_ids(problems, expect, observed) do
+    if Map.has_key?(expect, "event_ids") and
+         not deep_subset?(expect["event_ids"], observed.event_ids),
+       do: [
+         "event_ids\n    expected #{show(expect["event_ids"])}\n    got #{show(observed.event_ids)}"
+         | problems
+       ],
+       else: problems
+  end
+
+  defp subset?(expected, actual) when is_map(expected) and is_map(actual),
+    do: Enum.all?(expected, fn {key, value} -> deep_subset?(value, Map.get(actual, key)) end)
+
+  defp subset?(_expected, _actual), do: false
+
+  defp deep_subset?(expected, actual) when is_list(expected) do
+    is_list(actual) and length(expected) == length(actual) and
+      Enum.zip(expected, actual) |> Enum.all?(fn {left, right} -> deep_subset?(left, right) end)
+  end
+
+  defp deep_subset?(expected, actual) when is_map(expected) and is_map(actual),
+    do: subset?(expected, actual)
+
+  defp deep_subset?(expected, actual), do: expected == actual
+
+  defp show(value), do: inspect(value, pretty: true, width: 90, limit: :infinity)
+end

--- a/sdk/python/tests/test_conformance.py
+++ b/sdk/python/tests/test_conformance.py
@@ -1,0 +1,601 @@
+"""The shared conformance suite, run against this client."""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import sys
+import threading
+import time
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional
+from unittest.mock import patch
+from urllib.parse import parse_qsl, urlparse
+
+sys.path.insert(0, str(Path(__file__).parents[1] / "src"))
+
+from fountain import (  # noqa: E402
+    AuthError,
+    ConnectionError,
+    ConversationBusyError,
+    Fountain,
+    FountainError,
+    NotFoundError,
+    NotReadyError,
+    QuotaExceededError,
+    RateLimitError,
+    ResolutionError,
+    SubscriptionRequiredError,
+    TimeoutError,
+    ValidationError,
+)
+
+
+SDK = "python"
+CONFORMANCE = Path(__file__).resolve().parents[2] / "conformance"
+
+
+def _deep_subset(expected: Any, actual: Any) -> bool:
+    if isinstance(expected, list):
+        return (
+            isinstance(actual, list)
+            and len(expected) == len(actual)
+            and all(
+                _deep_subset(item, actual[index])
+                for index, item in enumerate(expected)
+            )
+        )
+    if isinstance(expected, dict):
+        return isinstance(actual, dict) and all(
+            key in actual and _deep_subset(value, actual[key])
+            for key, value in expected.items()
+        )
+    return expected == actual
+
+
+def _subset(expected: Mapping[str, Any], actual: Mapping[str, Any]) -> bool:
+    return all(
+        key in actual and _deep_subset(value, actual[key])
+        for key, value in expected.items()
+    )
+
+
+def _safe_json(raw: str) -> Any:
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return raw
+
+
+class _ScenarioServer(ThreadingHTTPServer):
+    daemon_threads = True
+
+
+class ScriptedServer:
+    """Serve one scenario's exchanges over a real loopback socket."""
+
+    def __init__(self, exchanges: List[Dict[str, Any]]) -> None:
+        self.exchanges = exchanges
+        self.consumed = [False for _ in exchanges]
+        self.requests: List[Dict[str, Any]] = []
+        self.unmatched: List[Dict[str, Any]] = []
+        self._lock = threading.Lock()
+        self._server: Optional[_ScenarioServer] = None
+        self._thread: Optional[threading.Thread] = None
+
+    def start(self) -> str:
+        owner = self
+
+        class Handler(BaseHTTPRequestHandler):
+            protocol_version = "HTTP/1.1"
+
+            def log_message(self, *args: Any) -> None:
+                pass
+
+            def do_GET(self) -> None:
+                owner._handle(self)
+
+            def do_POST(self) -> None:
+                owner._handle(self)
+
+            def do_PATCH(self) -> None:
+                owner._handle(self)
+
+            def do_DELETE(self) -> None:
+                owner._handle(self)
+
+        self._server = _ScenarioServer(("127.0.0.1", 0), Handler)
+        self._thread = threading.Thread(
+            target=self._server.serve_forever,
+            kwargs={"poll_interval": 0.01},
+            name="fountain-conformance-server",
+            daemon=True,
+        )
+        self._thread.start()
+        host, port = self._server.server_address[:2]
+        return "http://%s:%s" % (host, port)
+
+    def stop(self) -> None:
+        if self._server is None:
+            return
+        self._server.shutdown()
+        self._server.server_close()
+        if self._thread is not None:
+            self._thread.join()
+        self._server = None
+        self._thread = None
+
+    def _pick(self, recorded: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        for index, exchange in enumerate(self.exchanges):
+            if self.consumed[index]:
+                continue
+            match = exchange["match"]
+            if match["method"].upper() != recorded["method"]:
+                continue
+            if match["path"] != recorded["path"]:
+                continue
+            if not _subset(match.get("query", {}), recorded["query"]):
+                continue
+            if not _subset(match.get("headers", {}), recorded["headers"]):
+                continue
+            self.consumed[index] = True
+            return exchange
+        return None
+
+    def _handle(self, handler: BaseHTTPRequestHandler) -> None:
+        parsed = urlparse(handler.path)
+        length = int(handler.headers.get("Content-Length", "0"))
+        raw = handler.rfile.read(length).decode("utf-8", errors="replace")
+        headers = {
+            name.lower(): ",".join(handler.headers.get_all(name, []))
+            for name in handler.headers.keys()
+        }
+        recorded = {
+            "method": handler.command.upper(),
+            "path": parsed.path,
+            "query": dict(parse_qsl(parsed.query, keep_blank_values=True)),
+            "headers": headers,
+            "body": None if raw == "" else _safe_json(raw),
+        }
+        with self._lock:
+            self.requests.append(recorded)
+            exchange = self._pick(recorded)
+            if exchange is None:
+                self.unmatched.append(recorded)
+
+        if exchange is None:
+            self._whole(
+                handler,
+                {
+                    "status": 599,
+                    "json": {"error": "conformance_unmatched_request"},
+                },
+            )
+            return
+
+        response = exchange["respond"]
+        if "sse" in response:
+            self._stream(handler, response)
+        else:
+            self._whole(handler, response)
+
+    @staticmethod
+    def _whole(handler: BaseHTTPRequestHandler, response: Dict[str, Any]) -> None:
+        headers = dict(response.get("headers", {}))
+        payload: Optional[bytes] = None
+        if "json" in response:
+            payload = json.dumps(
+                response["json"], separators=(",", ":")
+            ).encode("utf-8")
+            if not any(name.lower() == "content-type" for name in headers):
+                headers["content-type"] = "application/json"
+        elif "body" in response:
+            payload = response["body"].encode("utf-8")
+
+        handler.send_response(response["status"])
+        for name, value in headers.items():
+            handler.send_header(name, str(value))
+        if not any(name.lower() == "content-length" for name in headers):
+            handler.send_header("Content-Length", str(len(payload or b"")))
+        handler.end_headers()
+        if payload:
+            try:
+                handler.wfile.write(payload)
+                handler.wfile.flush()
+            except (BrokenPipeError, ConnectionResetError):
+                pass
+
+    @staticmethod
+    def _stream(handler: BaseHTTPRequestHandler, response: Dict[str, Any]) -> None:
+        chunks = response.get("sse", [])
+        abort = response.get("close") == "abort"
+        headers = {
+            "cache-control": "no-cache",
+            "connection": "keep-alive",
+            **response.get("headers", {}),
+        }
+        content_length = sum(
+            len((chunk if isinstance(chunk, str) else chunk["text"]).encode("utf-8"))
+            for chunk in chunks
+        ) + (1 if abort else 0)
+        handler.send_response(response["status"])
+        for name, value in headers.items():
+            handler.send_header(name, str(value))
+        if not any(name.lower() == "content-length" for name in headers):
+            handler.send_header("Content-Length", str(content_length))
+        handler.end_headers()
+
+        try:
+            for chunk in chunks:
+                delay_ms = 0 if isinstance(chunk, str) else chunk.get("delay_ms", 0)
+                if delay_ms:
+                    time.sleep(delay_ms / 1000.0)
+                raw = (chunk if isinstance(chunk, str) else chunk["text"]).encode(
+                    "utf-8"
+                )
+                handler.wfile.write(raw)
+                handler.wfile.flush()
+        except (BrokenPipeError, ConnectionResetError):
+            return
+
+        if abort:
+            handler.close_connection = True
+            try:
+                handler.connection.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
+            handler.connection.close()
+
+
+ERROR_KINDS = [
+    (ConversationBusyError, "busy"),
+    (SubscriptionRequiredError, "subscription"),
+    (QuotaExceededError, "quota"),
+    (NotReadyError, "not_ready"),
+    (RateLimitError, "rate_limited"),
+    (ValidationError, "validation"),
+    (NotFoundError, "not_found"),
+    (AuthError, "auth"),
+    (TimeoutError, "timeout"),
+    (ConnectionError, "connection"),
+    (ResolutionError, "resolution"),
+    (FountainError, "server"),
+]
+
+
+def _normalise_error(error: BaseException) -> Dict[str, Any]:
+    kind = next(
+        (label for error_type, label in ERROR_KINDS if isinstance(error, error_type)),
+        "unknown",
+    )
+    output: Dict[str, Any] = {"kind": kind}
+    if isinstance(error, FountainError):
+        output.update(
+            {
+                "status": error.status,
+                "code": error.code,
+                "retryable": error.retryable,
+                "retry_after": error.retry_after,
+                "field_errors": error.field_errors,
+            }
+        )
+    if isinstance(error, TimeoutError):
+        output["partial_text"] = error.partial_text
+    if kind == "unknown":
+        output["message"] = str(error)
+    return output
+
+
+def _normalise_event(event: Dict[str, Any]) -> Dict[str, Any]:
+    event_type = event.get("type")
+    if event_type == "conversation":
+        return {
+            "type": "conversation",
+            "conversation_id": event.get("conversation_id"),
+        }
+    if event_type == "turn-start":
+        return {
+            "type": "turn-start",
+            "turn_number": event.get("turn_number"),
+            "turn_id": event.get("turn_id"),
+        }
+    if event_type in ("text", "thinking"):
+        return {"type": event_type, "text": event.get("text")}
+    if event_type == "tool":
+        return {"type": "tool", "name": event.get("name")}
+    if event_type == "permission":
+        request = event.get("request", {})
+        return {
+            "type": "permission",
+            "request_id": request.get("request_id"),
+            "options": [
+                option.get("option_id")
+                for option in request.get("options", [])
+                if isinstance(option, dict)
+            ],
+        }
+    if event_type == "turn-end":
+        return {
+            "type": "turn-end",
+            "state": event.get("state"),
+            "exit_code": event.get("exit_code"),
+            "reason": event.get("reason"),
+        }
+    return {"type": event_type}
+
+
+def _normalise_result(result: Any) -> Dict[str, Any]:
+    return {
+        "state": result.state,
+        "text": result.text,
+        "tools_used": result.tools_used,
+        "turn_number": result.turn_number,
+        "exit_code": result.exit_code,
+        "reason": result.reason,
+        "conversation_id": result.conversation_id,
+        "status": result.status,
+    }
+
+
+def _drive(scenario: Dict[str, Any], base_url: str) -> Dict[str, Any]:
+    config = scenario["client"]
+    environment = {
+        "FOUNTAIN_API_KEY": "",
+        "FOUNTAIN_TOKEN": "",
+        "FOUNTAIN_CREDENTIALS_FILE": os.devnull,
+    }
+    with patch.dict(os.environ, environment):
+        client = Fountain(
+            api_key=config.get("api_key"),
+            base_url=base_url + config.get("base_url_suffix", ""),
+            timeout=config.get("timeout_ms", 5000) / 1000.0,
+        )
+
+    output: Dict[str, Any] = {}
+    for step in scenario["steps"]:
+        operation = step["op"]
+        if operation == "me":
+            output["value"] = client.me()
+        elif operation == "list":
+            output["value"] = getattr(client, step["resource"]).list()
+        elif operation == "create_agent":
+            output["value"] = client.agents.create(step["attrs"])
+        elif operation == "get_conversation":
+            output["value"] = client.resume(step["conversation_id"]).get()
+        elif operation == "history":
+            output["event_ids"] = [
+                int(event["id"])
+                for event in client.resume(step["conversation_id"]).history()
+            ]
+        elif operation == "send":
+            run = client.resume(step["conversation_id"]).send(step["prompt"])
+            output["result"] = _normalise_result(run.result())
+        elif operation == "run":
+            options: Dict[str, Any] = {"agent": step["agent"]}
+            if step.get("timeout_ms") is not None:
+                options["timeout"] = step["timeout_ms"] / 1000.0
+            run = client.run(step["prompt"], **options)
+            events: List[Dict[str, Any]] = []
+            output["events"] = events
+            answers = step.get("answer_permissions", {})
+            for event in run:
+                events.append(_normalise_event(event))
+                if event.get("type") == "permission":
+                    request_id = event["request"]["request_id"]
+                    option_id = answers.get(request_id, answers.get("*"))
+                    if option_id:
+                        run.answer(request_id, option_id)
+            output["result"] = _normalise_result(run.result())
+        else:
+            raise RuntimeError("conformance: this adapter has no op %s" % operation)
+    return output
+
+
+def _show(value: Any) -> str:
+    return json.dumps(value, indent=2, sort_keys=True)
+
+
+def _check(scenario: Dict[str, Any], observed: Dict[str, Any]) -> List[str]:
+    problems: List[str] = []
+    expect = scenario["expect"]
+
+    def fail(what: str, detail: str) -> None:
+        problems.append("%s\n      %s" % (what, detail))
+
+    for request in observed["unmatched"]:
+        fail(
+            "unmatched request",
+            "the client sent %s %s, which no exchange in the scenario anticipated. "
+            "Either the client should not have sent it, or the scenario needs it."
+            % (request["method"], request["path"]),
+        )
+
+    if "error" in expect:
+        if observed["error"] is None:
+            fail("error", "expected %s but the call succeeded" % _show(expect["error"]))
+        elif not _subset(expect["error"], observed["error"]):
+            fail(
+                "error",
+                "expected %s\n      got %s"
+                % (_show(expect["error"]), _show(observed["error"])),
+            )
+    elif observed["error"] is not None:
+        fail(
+            "error",
+            "the call was not supposed to fail, and raised %s"
+            % _show(observed["error"]),
+        )
+
+    if "requests" in expect:
+        wanted = expect["requests"]
+        if expect.get("requests_exactly") and len(observed["requests"]) != len(wanted):
+            fail(
+                "requests",
+                "expected exactly %s request(s), saw %s: %s"
+                % (
+                    len(wanted),
+                    len(observed["requests"]),
+                    ", ".join(
+                        "%s %s" % (request["method"], request["path"])
+                        for request in observed["requests"]
+                    ),
+                ),
+            )
+        for index, want in enumerate(wanted):
+            if index >= len(observed["requests"]):
+                fail(
+                    "requests[%s]" % index,
+                    "expected %s %s, saw nothing" % (want["method"], want["path"]),
+                )
+                continue
+            got = observed["requests"][index]
+            if want["method"] != got["method"] or want["path"] != got["path"]:
+                fail(
+                    "requests[%s]" % index,
+                    "expected %s %s, saw %s %s"
+                    % (want["method"], want["path"], got["method"], got["path"]),
+                )
+                continue
+            if "query" in want and not _subset(want["query"], got["query"]):
+                fail(
+                    "requests[%s].query" % index,
+                    "expected %s\n      got %s"
+                    % (_show(want["query"]), _show(got["query"])),
+                )
+            if "headers" in want and not _subset(want["headers"], got["headers"]):
+                fail(
+                    "requests[%s].headers" % index,
+                    "expected %s\n      got %s"
+                    % (_show(want["headers"]), _show(got["headers"])),
+                )
+            for header, prefix in want.get("header_prefixes", {}).items():
+                value = got["headers"].get(header, "")
+                if not value.startswith(str(prefix)):
+                    fail(
+                        "requests[%s].headers.%s" % (index, header),
+                        "expected it to start with %s, got %s"
+                        % (_show(prefix), _show(value)),
+                    )
+            for header in want.get("headers_absent", []):
+                if header in got["headers"]:
+                    fail(
+                        "requests[%s].headers.%s" % (index, header),
+                        "expected no such header, got %s"
+                        % _show(got["headers"][header]),
+                    )
+            if want.get("body") and not _deep_subset(want["body"], got["body"]):
+                fail(
+                    "requests[%s].body" % index,
+                    "expected %s\n      got %s"
+                    % (_show(want["body"]), _show(got["body"])),
+                )
+
+    if "events" in expect:
+        cursor = 0
+        for want in expect["events"]:
+            found = next(
+                (
+                    index
+                    for index in range(cursor, len(observed["events"]))
+                    if _subset(want, observed["events"][index])
+                ),
+                None,
+            )
+            if found is None:
+                fail(
+                    "events",
+                    "expected %s after index %s, and the run emitted:\n      %s"
+                    % (_show(want), cursor, _show(observed["events"])),
+                )
+                break
+            cursor = found + 1
+
+    if "result" in expect:
+        if observed["result"] is None:
+            fail("result", "expected %s but there was no result" % _show(expect["result"]))
+        elif not _subset(expect["result"], observed["result"]):
+            fail(
+                "result",
+                "expected %s\n      got %s"
+                % (_show(expect["result"]), _show(observed["result"])),
+            )
+
+    if "value" in expect and not _deep_subset(expect["value"], observed["value"]):
+        fail(
+            "value",
+            "expected %s\n      got %s"
+            % (_show(expect["value"]), _show(observed["value"])),
+        )
+
+    if "event_ids" in expect and not _deep_subset(
+        expect["event_ids"], observed["event_ids"]
+    ):
+        fail(
+            "event_ids",
+            "expected %s\n      got %s"
+            % (_show(expect["event_ids"]), _show(observed["event_ids"])),
+        )
+
+    return problems
+
+
+class ConformanceTests(unittest.TestCase):
+    """Run every shared scenario against the public Python client."""
+
+
+def _run_scenario(test_case: unittest.TestCase, scenario: Dict[str, Any]) -> None:
+    server = ScriptedServer(scenario["http"])
+    base_url = server.start()
+    observed = {
+        "requests": server.requests,
+        "unmatched": server.unmatched,
+        "events": [],
+        "result": None,
+        "error": None,
+        "value": None,
+        "event_ids": None,
+    }
+    try:
+        observed.update(_drive(scenario, base_url))
+    except BaseException as error:
+        observed["error"] = _normalise_error(error)
+    finally:
+        server.stop()
+
+    problems = _check(scenario, observed)
+    if problems:
+        message = (
+            "conformance FAILED for %s / %s\n  %s\n\n%s"
+            % (
+                SDK,
+                scenario["name"],
+                scenario["title"],
+                "\n\n".join("  " + problem for problem in problems),
+            )
+        )
+        test_case.fail(message)
+
+
+with (CONFORMANCE / "matrix.json").open(encoding="utf-8") as matrix_file:
+    MATRIX = json.load(matrix_file)["scenarios"]
+
+for scenario_file in sorted((CONFORMANCE / "scenarios").glob("*.json")):
+    with scenario_file.open(encoding="utf-8") as source:
+        scenario = json.load(source)
+
+    def test(self: unittest.TestCase, item: Dict[str, Any] = scenario) -> None:
+        _run_scenario(self, item)
+
+    test.__name__ = "test_%s" % scenario["name"].replace("-", "_")
+    test.__doc__ = scenario["title"]
+    verdict = MATRIX[scenario["name"]][SDK]
+    if verdict != "yes":
+        test = unittest.skip("#%s: %s" % (verdict["issue"], verdict["skip"]))(test)
+    setattr(ConformanceTests, test.__name__, test)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sdk/swift/Tests/FountainTests/ConformanceTests.swift
+++ b/sdk/swift/Tests/FountainTests/ConformanceTests.swift
@@ -1,0 +1,804 @@
+import Foundation
+import Testing
+
+@testable import Fountain
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+private typealias JSONDictionary = [String: Any]
+
+private struct ConformanceScenario {
+  let name: String
+  let title: String
+  let client: JSONDictionary
+  let exchanges: [JSONDictionary]
+  let steps: [JSONDictionary]
+  let expectation: JSONDictionary
+}
+
+private struct SkippedConformanceScenario: Sendable, CustomTestStringConvertible {
+  let name: String
+  let reason: String
+  let issue: Int
+
+  var testDescription: String { name }
+}
+
+private struct ConformanceCatalog: Sendable {
+  let scenarioDirectory: URL
+  let runnableNames: [String]
+  let skipped: [SkippedConformanceScenario]
+
+  var skipSummary: String {
+    skipped.map { "\($0.name): #\($0.issue): \($0.reason)" }.joined(separator: "\n")
+  }
+}
+
+private struct RecordedRequest: @unchecked Sendable {
+  let method: String
+  let path: String
+  let query: [String: String]
+  let headers: [String: String]
+  let body: Any
+}
+
+private final class Observations: @unchecked Sendable {
+  var events: [JSONDictionary] = []
+  var result: JSONDictionary?
+  var error: JSONDictionary?
+  var value: Any = NSNull()
+  var eventIDs: [Int]?
+}
+
+private final class ConformanceURLProtocol: URLProtocol, @unchecked Sendable {
+  nonisolated(unsafe) static var handler: (@Sendable (URLRequest, ConformanceURLProtocol) -> Void)?
+
+  private let taskLock = NSLock()
+  private var deliveryTask: Task<Void, Never>?
+
+  override class func canInit(with request: URLRequest) -> Bool { true }
+  override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+  override func startLoading() {
+    Self.handler?(request, self)
+  }
+
+  override func stopLoading() {
+    taskLock.lock()
+    let task = deliveryTask
+    deliveryTask = nil
+    taskLock.unlock()
+    task?.cancel()
+  }
+
+  func respond(status: Int, headers: [String: String], data: Data, finish: Bool = true) {
+    guard
+      let response = HTTPURLResponse(
+        url: request.url!, statusCode: status, httpVersion: "HTTP/1.1", headerFields: headers)
+    else {
+      client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+      return
+    }
+    client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+    if !data.isEmpty { client?.urlProtocol(self, didLoad: data) }
+    if finish { client?.urlProtocolDidFinishLoading(self) }
+  }
+
+  func deliver(chunks: [(text: String, delayMilliseconds: Int)], abort: Bool) {
+    let task = Task { [weak self] in
+      guard let self else { return }
+      do {
+        for chunk in chunks {
+          if chunk.delayMilliseconds > 0 {
+            try await Task.sleep(
+              nanoseconds: UInt64(chunk.delayMilliseconds) * 1_000_000)
+          }
+          try Task.checkCancellation()
+          if !chunk.text.isEmpty {
+            client?.urlProtocol(self, didLoad: Data(chunk.text.utf8))
+          }
+        }
+        try Task.checkCancellation()
+        if abort {
+          // Give URLSession's delegate queue time to process the final didLoad
+          // before it observes the broken connection.
+          try await Task.sleep(nanoseconds: 10_000_000)
+          client?.urlProtocol(self, didFailWithError: URLError(.networkConnectionLost))
+        } else {
+          client?.urlProtocolDidFinishLoading(self)
+        }
+      } catch is CancellationError {
+        return
+      } catch {
+        client?.urlProtocol(self, didFailWithError: error)
+      }
+    }
+    taskLock.lock()
+    deliveryTask = task
+    taskLock.unlock()
+  }
+}
+
+private let conformanceMockSession: URLSession = {
+  let configuration = URLSessionConfiguration.ephemeral
+  configuration.protocolClasses = [ConformanceURLProtocol.self]
+  return URLSession(configuration: configuration)
+}()
+
+private final class ScriptedTransport: @unchecked Sendable {
+  private let lock = NSLock()
+  private let exchanges: [JSONDictionary]
+  private var consumed: [Bool]
+  private var recordedRequests: [RecordedRequest] = []
+  private var unmatchedRequests: [RecordedRequest] = []
+
+  init(exchanges: [JSONDictionary]) {
+    self.exchanges = exchanges
+    self.consumed = exchanges.map { _ in false }
+  }
+
+  var requests: [RecordedRequest] {
+    lock.withLock { recordedRequests }
+  }
+
+  var unmatched: [RecordedRequest] {
+    lock.withLock { unmatchedRequests }
+  }
+
+  func handle(_ request: URLRequest, _ protocolInstance: ConformanceURLProtocol) {
+    let recorded = record(request)
+    let response: JSONDictionary? = lock.withLock {
+      recordedRequests.append(recorded)
+      guard let index = firstMatch(for: recorded) else {
+        unmatchedRequests.append(recorded)
+        return nil
+      }
+      consumed[index] = true
+      return exchanges[index]["respond"] as? JSONDictionary
+    }
+
+    guard let response else {
+      let body = try! JSONSerialization.data(
+        withJSONObject: ["error": "conformance_unmatched_request"])
+      protocolInstance.respond(
+        status: 599, headers: ["content-type": "application/json"], data: body)
+      return
+    }
+    serve(response, through: protocolInstance)
+  }
+
+  private func firstMatch(for request: RecordedRequest) -> Int? {
+    for index in exchanges.indices where !consumed[index] {
+      guard let match = exchanges[index]["match"] as? JSONDictionary else { continue }
+      guard (match["method"] as? String)?.uppercased() == request.method else { continue }
+      guard match["path"] as? String == request.path else { continue }
+      guard stringSubset(match["query"], request.query) else { continue }
+      guard stringSubset(match["headers"], request.headers, lowercaseKeys: true) else { continue }
+      return index
+    }
+    return nil
+  }
+
+  private func serve(_ response: JSONDictionary, through protocolInstance: ConformanceURLProtocol) {
+    let status = response["status"] as? Int ?? 200
+    var headers = normalizedStringDictionary(response["headers"], lowercaseKeys: true)
+    if let rawChunks = response["sse"] as? [Any] {
+      let chunks = rawChunks.compactMap { raw -> (String, Int)? in
+        if let text = raw as? String { return (text, 0) }
+        guard let object = raw as? JSONDictionary, let text = object["text"] as? String else {
+          return nil
+        }
+        return (text, object["delay_ms"] as? Int ?? 0)
+      }
+      protocolInstance.respond(status: status, headers: headers, data: Data(), finish: false)
+      protocolInstance.deliver(chunks: chunks, abort: response["close"] as? String == "abort")
+      return
+    }
+
+    let body: Data
+    if let json = response["json"] {
+      body = try! JSONSerialization.data(withJSONObject: json)
+      if headers["content-type"] == nil { headers["content-type"] = "application/json" }
+    } else if let text = response["body"] as? String {
+      body = Data(text.utf8)
+    } else {
+      body = Data()
+    }
+    if !body.isEmpty { headers["content-length"] = String(body.count) }
+    protocolInstance.respond(status: status, headers: headers, data: body)
+  }
+
+  private func record(_ request: URLRequest) -> RecordedRequest {
+    let components = request.url.flatMap {
+      URLComponents(url: $0, resolvingAgainstBaseURL: false)
+    }
+    let query = Dictionary(
+      (components?.queryItems ?? []).map { ($0.name, $0.value ?? "") },
+      uniquingKeysWith: { _, last in last })
+    let headers = Dictionary(
+      (request.allHTTPHeaderFields ?? [:]).map { ($0.key.lowercased(), $0.value) },
+      uniquingKeysWith: { _, last in last })
+    let body: Any
+    if let data = requestBodyData(request), !data.isEmpty {
+      body =
+        (try? JSONSerialization.jsonObject(with: data)) ?? String(decoding: data, as: UTF8.self)
+    } else {
+      body = NSNull()
+    }
+    return RecordedRequest(
+      method: request.httpMethod?.uppercased() ?? "GET",
+      path: components?.path ?? request.url?.path ?? "/",
+      query: query,
+      headers: headers,
+      body: body)
+  }
+}
+
+private let conformanceCatalog: ConformanceCatalog = {
+  do {
+    let scenarioDirectory = try locateConformanceFile(
+      "sdk/conformance/scenarios", from: #filePath, directory: true)
+    let matrixURL = try locateConformanceFile(
+      "sdk/conformance/matrix.json", from: #filePath)
+    let matrix = try readJSONDictionary(matrixURL)
+    let verdicts = matrix["scenarios"] as? JSONDictionary ?? [:]
+    let names = try FileManager.default.contentsOfDirectory(
+      at: scenarioDirectory, includingPropertiesForKeys: nil
+    )
+    .filter { $0.pathExtension == "json" }
+    .map { $0.deletingPathExtension().lastPathComponent }
+    .sorted()
+    var runnable: [String] = []
+    var skipped: [SkippedConformanceScenario] = []
+    for name in names {
+      let row = verdicts[name] as? JSONDictionary
+      if row?["swift"] as? String == "yes" {
+        runnable.append(name)
+      } else if let skip = row?["swift"] as? JSONDictionary {
+        skipped.append(
+          SkippedConformanceScenario(
+            name: name,
+            reason: skip["skip"] as? String ?? "matrix entry has no reason",
+            issue: skip["issue"] as? Int ?? 0))
+      } else {
+        fatalError("No Swift conformance verdict for \(name)")
+      }
+    }
+    return ConformanceCatalog(
+      scenarioDirectory: scenarioDirectory, runnableNames: runnable, skipped: skipped)
+  } catch {
+    fatalError("Could not load the Swift conformance catalog: \(error)")
+  }
+}()
+
+@Suite("ConformanceTests", .serialized)
+struct ConformanceTests {
+  @Test("conformance", arguments: conformanceCatalog.runnableNames)
+  func conformance(_ name: String) async {
+    let scenario: ConformanceScenario
+    do {
+      scenario = try loadScenario(named: name)
+    } catch {
+      Issue.record(
+        Comment(
+          rawValue:
+            "conformance FAILED for swift / \(name)\n  Could not load scenario\n\n  harness\n      \(error)"
+        ))
+      return
+    }
+
+    let transport = ScriptedTransport(exchanges: scenario.exchanges)
+    let observations = Observations()
+    let host = "\(scenario.name).conformance.invalid"
+    ConformanceURLProtocol.handler = { request, protocolInstance in
+      if request.url?.host == host {
+        transport.handle(request, protocolInstance)
+      } else {
+        protocolInstance.respond(
+          status: 599, headers: ["content-type": "application/json"], data: Data())
+      }
+    }
+    defer { ConformanceURLProtocol.handler = nil }
+
+    do {
+      try await drive(
+        scenario, baseURL: "https://\(host)", observations: observations)
+    } catch {
+      observations.error = normalizeError(error)
+    }
+
+    let problems = check(
+      scenario, observations: observations, requests: transport.requests,
+      unmatched: transport.unmatched)
+    if !problems.isEmpty {
+      let message =
+        "conformance FAILED for swift / \(scenario.name)\n"
+        + "  \(scenario.title)\n\n"
+        + problems.map { "  \($0)" }.joined(separator: "\n\n")
+        + "\n"
+      Issue.record(Comment(rawValue: message))
+    }
+  }
+
+  @Test(
+    "matrix skip",
+    .disabled(Comment(rawValue: conformanceCatalog.skipSummary)),
+    arguments: conformanceCatalog.skipped)
+  fileprivate func matrixSkip(_ scenario: SkippedConformanceScenario) {
+    _ = scenario
+  }
+}
+
+private func loadScenario(named name: String) throws -> ConformanceScenario {
+  let url = conformanceCatalog.scenarioDirectory.appendingPathComponent("\(name).json")
+  let object = try readJSONDictionary(url)
+  guard let loadedName = object["name"] as? String,
+    let title = object["title"] as? String,
+    let client = object["client"] as? JSONDictionary,
+    let exchanges = object["http"] as? [JSONDictionary],
+    let steps = object["steps"] as? [JSONDictionary],
+    let expectation = object["expect"] as? JSONDictionary
+  else {
+    throw harnessError("Malformed scenario at \(url.path)")
+  }
+  return ConformanceScenario(
+    name: loadedName, title: title, client: client, exchanges: exchanges, steps: steps,
+    expectation: expectation)
+}
+
+private func drive(
+  _ scenario: ConformanceScenario, baseURL: String, observations: Observations
+) async throws {
+  let apiKey = scenario.client["api_key"] as? String
+  let suffix = scenario.client["base_url_suffix"] as? String ?? ""
+  let clientTimeout = TimeInterval(scenario.client["timeout_ms"] as? Int ?? 5_000) / 1_000
+  let fountain = try Fountain(
+    apiKey: apiKey,
+    baseURL: "\(baseURL)\(suffix)",
+    profile: apiKey == nil ? "__fountain_conformance_missing_key__" : nil,
+    timeout: clientTimeout,
+    session: conformanceMockSession)
+
+  for step in scenario.steps {
+    guard let operation = step["op"] as? String else {
+      throw harnessError("A scenario step has no op")
+    }
+    switch operation {
+    case "me":
+      observations.value = jsonObject(try await fountain.me())
+    case "list":
+      let values: [JSONObject]
+      switch step["resource"] as? String {
+      case "agents": values = try await fountain.agents.list()
+      case "vaults": values = try await fountain.vaults.list()
+      case "environments": values = try await fountain.environments.list()
+      default:
+        throw harnessError("Unsupported list resource \(String(describing: step["resource"]))")
+      }
+      observations.value = values.map(jsonObject)
+    case "create_agent":
+      guard let attributes = step["attrs"] as? JSONDictionary else {
+        throw harnessError("create_agent has no attrs")
+      }
+      observations.value = jsonObject(
+        try await fountain.agents.create(try fountainJSON(attributes)))
+    case "get_conversation":
+      guard let id = step["conversation_id"] as? String else {
+        throw harnessError("get_conversation has no conversation_id")
+      }
+      observations.value = jsonObject(try await fountain.resume(id).get())
+    case "history":
+      guard let id = step["conversation_id"] as? String else {
+        throw harnessError("history has no conversation_id")
+      }
+      observations.eventIDs = try await fountain.resume(id).history().compactMap {
+        $0["id"]?.intValue
+      }
+    case "send":
+      guard let id = step["conversation_id"] as? String,
+        let prompt = step["prompt"] as? String
+      else {
+        throw harnessError("send has no conversation_id or prompt")
+      }
+      observations.result = normalizeResult(
+        try await fountain.resume(id).send(prompt).value())
+    case "run":
+      try await driveRun(step, fountain: fountain, observations: observations)
+    default:
+      throw harnessError("This adapter has no op \(operation)")
+    }
+  }
+}
+
+private func driveRun(
+  _ step: JSONDictionary, fountain: Fountain, observations: Observations
+) async throws {
+  guard let agent = step["agent"] as? String, let prompt = step["prompt"] as? String else {
+    throw harnessError("run has no agent or prompt")
+  }
+  let timeout = (step["timeout_ms"] as? Int).map { TimeInterval($0) / 1_000 }
+  let answers = step["answer_permissions"] as? [String: String] ?? [:]
+  let run = fountain.run(prompt, agent: agent, timeout: timeout)
+  for try await event in run.events {
+    observations.events.append(normalizeEvent(event))
+    if case .permission(let request, _) = event,
+      let option = answers[request.requestID] ?? answers["*"]
+    {
+      try await run.answer(requestID: request.requestID, optionID: option)
+    }
+  }
+  observations.result = normalizeResult(try await run.value())
+}
+
+private func normalizeError(_ error: Error) -> JSONDictionary {
+  guard let error = error as? FountainError else {
+    return ["kind": "unknown", "message": String(describing: error)]
+  }
+  let kinds: [FountainError.Kind: String] = [
+    .api: "server",
+    .authentication: "auth",
+    .subscriptionRequired: "subscription",
+    .notFound: "not_found",
+    .validation: "validation",
+    .rateLimit: "rate_limited",
+    .conversationBusy: "busy",
+    .notReady: "not_ready",
+    .quotaExceeded: "quota",
+    .connection: "connection",
+    .resolution: "resolution",
+    .timeout: "timeout",
+  ]
+  var output: JSONDictionary = [
+    "kind": kinds[error.kind] ?? "unknown",
+    "status": error.status,
+    "code": error.code ?? NSNull(),
+    "retryable": error.retryable,
+    "retry_after": error.retryAfter ?? NSNull(),
+    "field_errors": error.fieldErrors,
+  ]
+  if error.kind == .timeout { output["partial_text"] = error.partialText ?? NSNull() }
+  return output
+}
+
+private func normalizeEvent(_ event: RunEvent) -> JSONDictionary {
+  switch event {
+  case .conversation(let id, _, _):
+    return ["type": "conversation", "conversation_id": id]
+  case .turnStart(let turnNumber, let turnID):
+    return [
+      "type": "turn-start", "turn_number": turnNumber, "turn_id": turnID ?? NSNull(),
+    ]
+  case .text(let text):
+    return ["type": "text", "text": text]
+  case .thinking(let text):
+    return ["type": "thinking", "text": text]
+  case .tool(let name, _):
+    return ["type": "tool", "name": name]
+  case .permission(let request, _):
+    return [
+      "type": "permission",
+      "request_id": request.requestID,
+      "options": request.options.map(\.optionID),
+    ]
+  case .block:
+    return ["type": "block"]
+  case .event:
+    return ["type": "event"]
+  case .turnEnd(let state, let exitCode, let reason):
+    return [
+      "type": "turn-end",
+      "state": state.rawValue,
+      "exit_code": exitCode ?? NSNull(),
+      "reason": reason ?? NSNull(),
+    ]
+  }
+}
+
+private func normalizeResult(_ result: RunResult) -> JSONDictionary {
+  [
+    "state": result.state.rawValue,
+    "text": result.text,
+    "tools_used": result.toolsUsed,
+    "turn_number": result.turnNumber,
+    "exit_code": result.exitCode ?? NSNull(),
+    "reason": result.reason ?? NSNull(),
+    "conversation_id": result.conversationID,
+    "status": result.status ?? NSNull(),
+  ]
+}
+
+private func check(
+  _ scenario: ConformanceScenario,
+  observations: Observations,
+  requests: [RecordedRequest],
+  unmatched: [RecordedRequest]
+) -> [String] {
+  var problems: [String] = []
+  let expectation = scenario.expectation
+
+  func fail(_ subject: String, _ detail: String) {
+    problems.append("\(subject)\n      \(detail)")
+  }
+
+  for request in unmatched {
+    fail(
+      "unmatched request",
+      "the client sent \(request.method) \(request.path), which no exchange in the scenario "
+        + "anticipated. Either the client should not have sent it, or the scenario needs it.")
+  }
+
+  if let expectedError = expectation["error"] as? JSONDictionary {
+    guard let actualError = observations.error else {
+      fail("error", "expected \(show(expectedError)) but the call succeeded")
+      return problems
+    }
+    if !dictionarySubset(expectedError, actualError) {
+      fail("error", "expected \(show(expectedError))\n      got \(show(actualError))")
+    }
+  } else if let actualError = observations.error {
+    fail("error", "the call was not supposed to fail, and raised \(show(actualError))")
+  }
+
+  if let wanted = expectation["requests"] as? [JSONDictionary] {
+    if expectation["requests_exactly"] as? Bool == true, requests.count != wanted.count {
+      fail(
+        "requests",
+        "expected exactly \(wanted.count) request(s), saw \(requests.count): "
+          + requests.map { "\($0.method) \($0.path)" }.joined(separator: ", "))
+    }
+    for (index, expected) in wanted.enumerated() {
+      guard requests.indices.contains(index) else {
+        fail(
+          "requests[\(index)]",
+          "expected \(expected["method"] ?? "?") \(expected["path"] ?? "?"), saw nothing")
+        continue
+      }
+      checkRequest(expected, actual: requests[index], index: index, fail: fail)
+    }
+  }
+
+  if let expectedEvents = expectation["events"] as? [JSONDictionary] {
+    var cursor = 0
+    for expectedEvent in expectedEvents {
+      guard
+        let index = observations.events.indices.first(where: {
+          $0 >= cursor && dictionarySubset(expectedEvent, observations.events[$0])
+        })
+      else {
+        fail(
+          "events",
+          "expected \(show(expectedEvent)) after index \(cursor), and the run emitted:\n      "
+            + show(observations.events))
+        break
+      }
+      cursor = index + 1
+    }
+  }
+
+  if let expectedResult = expectation["result"] as? JSONDictionary {
+    if let actualResult = observations.result {
+      if !dictionarySubset(expectedResult, actualResult) {
+        fail("result", "expected \(show(expectedResult))\n      got \(show(actualResult))")
+      }
+    } else {
+      fail("result", "expected \(show(expectedResult)) but there was no result")
+    }
+  }
+
+  if let expectedValue = expectation["value"], !deepSubset(expectedValue, observations.value) {
+    fail("value", "expected \(show(expectedValue))\n      got \(show(observations.value))")
+  }
+
+  if let expectedIDs = expectation["event_ids"],
+    !deepSubset(expectedIDs, observations.eventIDs as Any)
+  {
+    fail(
+      "event_ids", "expected \(show(expectedIDs))\n      got \(show(observations.eventIDs as Any))")
+  }
+
+  return problems
+}
+
+private func checkRequest(
+  _ expected: JSONDictionary,
+  actual: RecordedRequest,
+  index: Int,
+  fail: (_ subject: String, _ detail: String) -> Void
+) {
+  let expectedMethod = expected["method"] as? String
+  let expectedPath = expected["path"] as? String
+  guard expectedMethod == actual.method, expectedPath == actual.path else {
+    fail(
+      "requests[\(index)]",
+      "expected \(expectedMethod ?? "?") \(expectedPath ?? "?"), saw \(actual.method) \(actual.path)"
+    )
+    return
+  }
+  if let query = expected["query"] as? JSONDictionary,
+    !dictionarySubset(query, actual.query)
+  {
+    fail("requests[\(index)].query", "expected \(show(query))\n      got \(show(actual.query))")
+  }
+  if let headers = expected["headers"] as? JSONDictionary,
+    !dictionarySubset(headers, actual.headers)
+  {
+    fail(
+      "requests[\(index)].headers",
+      "expected \(show(headers))\n      got \(show(actual.headers))")
+  }
+  for (header, prefix) in expected["header_prefixes"] as? [String: String] ?? [:] {
+    let value = actual.headers[header] ?? ""
+    if !value.hasPrefix(prefix) {
+      fail(
+        "requests[\(index)].headers.\(header)",
+        "expected it to start with \(show(prefix)), got \(show(value))")
+    }
+  }
+  for header in expected["headers_absent"] as? [String] ?? [] where actual.headers[header] != nil {
+    fail(
+      "requests[\(index)].headers.\(header)",
+      "expected no such header, got \(show(actual.headers[header] as Any))")
+  }
+  if let body = expected["body"], !deepSubset(body, actual.body) {
+    fail("requests[\(index)].body", "expected \(show(body))\n      got \(show(actual.body))")
+  }
+}
+
+private func dictionarySubset(_ expected: JSONDictionary, _ actual: Any) -> Bool {
+  guard let actual = actual as? JSONDictionary else { return false }
+  return expected.allSatisfy { key, value in
+    guard let actualValue = actual[key] else { return false }
+    return deepSubset(value, actualValue)
+  }
+}
+
+private func deepSubset(_ expected: Any, _ actual: Any) -> Bool {
+  if let expected = expected as? OptionalProtocol {
+    guard let wrapped = expected.wrapped else { return actual is NSNull }
+    return deepSubset(wrapped, actual)
+  }
+  if let actual = actual as? OptionalProtocol {
+    guard let wrapped = actual.wrapped else { return expected is NSNull }
+    return deepSubset(expected, wrapped)
+  }
+  if expected is NSNull { return actual is NSNull }
+  if let expected = expected as? JSONDictionary {
+    return dictionarySubset(expected, actual)
+  }
+  if let expected = expected as? [Any] {
+    guard let actual = actual as? [Any], expected.count == actual.count else { return false }
+    return zip(expected, actual).allSatisfy(deepSubset)
+  }
+  if let expected = expected as? String { return expected == actual as? String }
+  if let expected = expected as? NSNumber, let actual = actual as? NSNumber {
+    return expected.compare(actual) == .orderedSame
+  }
+  if let expected = expected as? Bool { return expected == actual as? Bool }
+  return String(describing: expected) == String(describing: actual)
+}
+
+private func stringSubset(
+  _ rawExpected: Any?, _ actual: [String: String], lowercaseKeys: Bool = false
+) -> Bool {
+  let expected = normalizedStringDictionary(rawExpected, lowercaseKeys: lowercaseKeys)
+  return expected.allSatisfy { actual[$0.key] == $0.value }
+}
+
+private func normalizedStringDictionary(
+  _ value: Any?, lowercaseKeys: Bool
+) -> [String: String] {
+  guard let dictionary = value as? JSONDictionary else { return [:] }
+  return Dictionary(
+    uniqueKeysWithValues: dictionary.compactMap { key, value in
+      guard let value = value as? String else { return nil }
+      return (lowercaseKeys ? key.lowercased() : key, value)
+    })
+}
+
+private func jsonObject(_ object: JSONObject) -> JSONDictionary {
+  object.mapValues(jsonValue)
+}
+
+private func jsonValue(_ value: JSONValue) -> Any {
+  switch value {
+  case .null: return NSNull()
+  case .bool(let value): return value
+  case .number(let value): return NSDecimalNumber(decimal: value)
+  case .string(let value): return value
+  case .array(let value): return value.map(jsonValue)
+  case .object(let value): return value.mapValues(jsonValue)
+  }
+}
+
+private func fountainJSON(_ value: Any) throws -> JSONObject {
+  let data = try JSONSerialization.data(withJSONObject: value)
+  guard let object = try JSONDecoder().decode(JSONValue.self, from: data).objectValue else {
+    throw harnessError("Expected a JSON object")
+  }
+  return object
+}
+
+private func requestBodyData(_ request: URLRequest) -> Data? {
+  if let body = request.httpBody { return body }
+  guard let stream = request.httpBodyStream else { return nil }
+  stream.open()
+  defer { stream.close() }
+  var output = Data()
+  var buffer = [UInt8](repeating: 0, count: 4_096)
+  while stream.hasBytesAvailable {
+    let count = stream.read(&buffer, maxLength: buffer.count)
+    if count <= 0 { break }
+    output.append(buffer, count: count)
+  }
+  return output
+}
+
+private func show(_ value: Any) -> String {
+  let unwrapped: Any
+  if let optional = value as? OptionalProtocol {
+    unwrapped = optional.wrapped ?? NSNull()
+  } else {
+    unwrapped = value
+  }
+  guard JSONSerialization.isValidJSONObject(unwrapped),
+    let data = try? JSONSerialization.data(
+      withJSONObject: unwrapped, options: [.prettyPrinted, .sortedKeys])
+  else {
+    return String(describing: unwrapped)
+  }
+  return String(decoding: data, as: UTF8.self)
+}
+
+private protocol OptionalProtocol {
+  var wrapped: Any? { get }
+}
+
+extension Optional: OptionalProtocol {
+  fileprivate var wrapped: Any? { self }
+}
+
+private func locateConformanceFile(
+  _ relativePath: String, from sourceFile: String, directory: Bool = false
+) throws -> URL {
+  var current = URL(fileURLWithPath: sourceFile).deletingLastPathComponent()
+  while true {
+    let candidate = relativePath.split(separator: "/").reduce(current) {
+      $0.appendingPathComponent(String($1))
+    }
+    var isDirectory: ObjCBool = false
+    if FileManager.default.fileExists(atPath: candidate.path, isDirectory: &isDirectory),
+      !directory || isDirectory.boolValue
+    {
+      return candidate
+    }
+    let parent = current.deletingLastPathComponent()
+    if parent.path == current.path {
+      throw harnessError("Could not locate \(relativePath) from \(sourceFile)")
+    }
+    current = parent
+  }
+}
+
+private func readJSONDictionary(_ url: URL) throws -> JSONDictionary {
+  let value = try JSONSerialization.jsonObject(with: Data(contentsOf: url))
+  guard let object = value as? JSONDictionary else {
+    throw harnessError("Expected a JSON object in \(url.path)")
+  }
+  return object
+}
+
+private func harnessError(_ message: String) -> NSError {
+  NSError(
+    domain: "FountainConformanceTests", code: 1,
+    userInfo: [NSLocalizedDescriptionKey: message])
+}
+
+extension NSLock {
+  fileprivate func withLock<Value>(_ body: () -> Value) -> Value {
+    lock()
+    defer { unlock() }
+    return body()
+  }
+}

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -45,6 +45,7 @@
     "build": "tsc -p tsconfig.build.json",
     "generate": "openapi-typescript ${FOUNTAIN_OPENAPI:-../../dist/openapi.json} -o src/generated/openapi.ts",
     "verify-contract": "node scripts/verify-contract.mjs",
+    "conformance": "node --test test/conformance.test.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "node --test test/*.test.ts",
     "prepublishOnly": "node scripts/ci-publishes.mjs && npm run typecheck && npm test && npm run build"

--- a/sdk/typescript/test/conformance.test.ts
+++ b/sdk/typescript/test/conformance.test.ts
@@ -1,0 +1,551 @@
+/**
+ * The shared conformance suite, run against this client.
+ *
+ * The scenarios live in `sdk/conformance/scenarios` and are the same files
+ * Python, Swift and Elixir run. Nothing language-specific belongs in them, and
+ * nothing here decides what passes: this file serves the scripted bytes, drives
+ * the public client, normalises what it saw into the shared vocabulary, and
+ * compares that against the scenario's own `expect`.
+ *
+ * `sdk/conformance/README.md` is the format. Read it before changing anything
+ * here, because three other adapters implement the same thing.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { Fountain } from "../src/client.ts";
+import {
+  AuthError,
+  ConnectionError,
+  ConversationBusyError,
+  FountainError,
+  NotFoundError,
+  NotReadyError,
+  QuotaExceededError,
+  RateLimitError,
+  ResolutionError,
+  SubscriptionRequiredError,
+  TimeoutError,
+  ValidationError,
+} from "../src/errors.ts";
+import type { RunEvent } from "../src/types.ts";
+
+const SDK = "typescript";
+const HERE = dirname(fileURLToPath(import.meta.url));
+const CONFORMANCE = join(HERE, "..", "..", "conformance");
+
+// ── the scenario format, as this adapter reads it ────────────────────────────
+
+interface Match {
+  method: string;
+  path: string;
+  query?: Record<string, string>;
+  headers?: Record<string, string>;
+}
+type SseChunk = string | { text: string; delay_ms?: number };
+interface Respond {
+  status: number;
+  headers?: Record<string, string>;
+  json?: unknown;
+  body?: string;
+  sse?: SseChunk[];
+  close?: "end" | "abort";
+}
+interface Scenario {
+  name: string;
+  title: string;
+  contract: string;
+  client: { api_key: string | null; base_url_suffix?: string; timeout_ms?: number };
+  http: { match: Match; respond: Respond }[];
+  steps: Record<string, any>[];
+  expect: Record<string, any>;
+}
+
+interface Recorded {
+  method: string;
+  path: string;
+  query: Record<string, string>;
+  headers: Record<string, string>;
+  body: unknown;
+}
+
+// ── the scripted server ──────────────────────────────────────────────────────
+
+/**
+ * Serves one scenario's exchanges over a real socket.
+ *
+ * A real socket rather than a fetch stub on purpose: half of these scenarios
+ * are about what happens between TCP writes, and a stub that hands over a whole
+ * response body cannot express a frame arriving in three pieces or a connection
+ * that dies without an end.
+ */
+class ScriptedServer {
+  readonly requests: Recorded[] = [];
+  readonly unmatched: Recorded[] = [];
+  private readonly consumed: boolean[];
+  private server: Server | null = null;
+  private readonly open = new Set<ServerResponse>();
+
+  private readonly exchanges: Scenario["http"];
+
+  constructor(exchanges: Scenario["http"]) {
+    this.exchanges = exchanges;
+    this.consumed = exchanges.map(() => false);
+  }
+
+  async start(): Promise<string> {
+    this.server = createServer((req, res) => void this.handle(req, res));
+    await new Promise<void>((resolve) => this.server!.listen(0, "127.0.0.1", resolve));
+    const { port } = this.server!.address() as AddressInfo;
+    return `http://127.0.0.1:${port}`;
+  }
+
+  async stop(): Promise<void> {
+    for (const res of this.open) res.destroy();
+    this.open.clear();
+    await new Promise<void>((resolve) => this.server?.close(() => resolve()));
+    this.server = null;
+  }
+
+  private pick(recorded: Recorded): number {
+    for (let index = 0; index < this.exchanges.length; index++) {
+      if (this.consumed[index]) continue;
+      const { match } = this.exchanges[index]!;
+      if (match.method.toUpperCase() !== recorded.method) continue;
+      if (match.path !== recorded.path) continue;
+      if (!subset(match.query ?? {}, recorded.query)) continue;
+      if (!subset(match.headers ?? {}, recorded.headers)) continue;
+      this.consumed[index] = true;
+      return index;
+    }
+    return -1;
+  }
+
+  private async handle(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const url = new URL(req.url ?? "/", "http://127.0.0.1");
+    const raw = await readBody(req);
+    const recorded: Recorded = {
+      method: (req.method ?? "GET").toUpperCase(),
+      path: url.pathname,
+      query: Object.fromEntries(url.searchParams),
+      headers: Object.fromEntries(
+        Object.entries(req.headers).map(([key, value]) => [
+          key.toLowerCase(),
+          Array.isArray(value) ? value.join(",") : String(value ?? ""),
+        ]),
+      ),
+      body: raw === "" ? null : safeJson(raw),
+    };
+    this.requests.push(recorded);
+
+    const index = this.pick(recorded);
+    if (index === -1) {
+      // Not a 404: an unanticipated request is a finding, and answering it
+      // plausibly would let a client's extra round trip pass unnoticed.
+      this.unmatched.push(recorded);
+      res.writeHead(599, { "content-type": "application/json" });
+      res.end(JSON.stringify({ error: "conformance_unmatched_request" }));
+      return;
+    }
+
+    const respond = this.exchanges[index]!.respond;
+    if (respond.sse) return this.stream(res, respond);
+
+    const headers: Record<string, string> = { ...(respond.headers ?? {}) };
+    let payload: string | null = null;
+    if (respond.json !== undefined) {
+      payload = JSON.stringify(respond.json);
+      headers["content-type"] ??= "application/json";
+    } else if (respond.body !== undefined) {
+      payload = respond.body;
+    }
+    if (payload !== null) headers["content-length"] = String(Buffer.byteLength(payload));
+    res.writeHead(respond.status, headers);
+    res.end(payload ?? undefined);
+  }
+
+  private stream(res: ServerResponse, respond: Respond): void {
+    res.writeHead(respond.status, {
+      "cache-control": "no-cache",
+      connection: "keep-alive",
+      ...(respond.headers ?? {}),
+    });
+    this.open.add(res);
+    res.on("close", () => this.open.delete(res));
+
+    void (async () => {
+      for (const chunk of respond.sse ?? []) {
+        const text = typeof chunk === "string" ? chunk : chunk.text;
+        const delay = typeof chunk === "string" ? 0 : (chunk.delay_ms ?? 0);
+        if (delay > 0) await sleep(delay);
+        if (res.destroyed) return;
+        if (text) res.write(text);
+      }
+      if (res.destroyed) return;
+      if (respond.close === "abort") {
+        // A deploy, a proxy timeout, a sandbox wake. The bytes already written
+        // reach the client; the terminating chunk never does.
+        setImmediate(() => res.destroy());
+      } else {
+        res.end();
+      }
+    })();
+  }
+}
+
+// ── driving the public client ────────────────────────────────────────────────
+
+interface Observations {
+  requests: Recorded[];
+  unmatched: Recorded[];
+  events: Record<string, unknown>[];
+  result: Record<string, unknown> | null;
+  error: Record<string, unknown> | null;
+  value: unknown;
+  eventIds: number[] | null;
+}
+
+const ERROR_KINDS: [new (...args: any[]) => Error, string][] = [
+  // Most specific first: every one of these extends FountainError.
+  [ConversationBusyError, "busy"],
+  [SubscriptionRequiredError, "subscription"],
+  [QuotaExceededError, "quota"],
+  [NotReadyError, "not_ready"],
+  [RateLimitError, "rate_limited"],
+  [ValidationError, "validation"],
+  [NotFoundError, "not_found"],
+  [AuthError, "auth"],
+  [TimeoutError, "timeout"],
+  [ConnectionError, "connection"],
+  [ResolutionError, "resolution"],
+  [FountainError, "server"],
+];
+
+function normaliseError(error: unknown): Record<string, unknown> {
+  const kind = ERROR_KINDS.find(([type]) => error instanceof type)?.[1] ?? "unknown";
+  const out: Record<string, unknown> = { kind };
+  if (error instanceof FountainError) {
+    out.status = error.status;
+    out.code = error.code ?? null;
+    out.retryable = error.retryable;
+    out.retry_after = error.retryAfter;
+    out.field_errors = error.fieldErrors;
+  }
+  if (error instanceof TimeoutError) out.partial_text = error.partialText;
+  if (out.kind === "unknown") out.message = String((error as Error)?.message ?? error);
+  return out;
+}
+
+function normaliseEvent(event: RunEvent): Record<string, unknown> {
+  switch (event.type) {
+    case "conversation":
+      return { type: "conversation", conversation_id: event.conversationId };
+    case "turn-start":
+      return { type: "turn-start", turn_number: event.turnNumber, turn_id: event.turnId };
+    case "text":
+    case "thinking":
+      return { type: event.type, text: event.text };
+    case "tool":
+      return { type: "tool", name: event.name };
+    case "permission":
+      return {
+        type: "permission",
+        request_id: event.request.requestId,
+        options: event.request.options.map((option) => option.optionId),
+      };
+    case "turn-end":
+      return {
+        type: "turn-end",
+        state: event.state,
+        exit_code: event.exitCode,
+        reason: event.reason,
+      };
+    default:
+      return { type: event.type };
+  }
+}
+
+async function drive(scenario: Scenario, baseUrl: string): Promise<Partial<Observations>> {
+  const client = new Fountain({
+    apiKey: scenario.client.api_key ?? undefined,
+    baseUrl: baseUrl + (scenario.client.base_url_suffix ?? ""),
+    // Nothing here should ever wait on a real network.
+    timeoutMs: scenario.client.timeout_ms ?? 5_000,
+  });
+
+  const out: Partial<Observations> = {};
+
+  for (const step of scenario.steps) {
+    switch (step.op) {
+      case "me":
+        out.value = await client.me();
+        break;
+      case "list":
+        out.value = await (client as any)[step.resource].list();
+        break;
+      case "create_agent":
+        out.value = await client.agents.create(step.attrs);
+        break;
+      case "get_conversation":
+        out.value = await client.resume(step.conversation_id).get();
+        break;
+      case "history":
+        out.eventIds = (await client.resume(step.conversation_id).history()).map((event) =>
+          Number(event.id),
+        );
+        break;
+      case "send": {
+        const run = client.resume(step.conversation_id).send(step.prompt);
+        out.result = normaliseResult(await run);
+        break;
+      }
+      case "run": {
+        const run = client.run(step.prompt, {
+          agent: step.agent,
+          ...(step.timeout_ms ? { timeoutMs: step.timeout_ms } : {}),
+        });
+        const events: Record<string, unknown>[] = [];
+        const answers: Record<string, string> = step.answer_permissions ?? {};
+        const consume = (async () => {
+          for await (const event of run) {
+            events.push(normaliseEvent(event));
+            if (event.type === "permission") {
+              const option = answers[event.request.requestId] ?? answers["*"];
+              if (option) await run.answer(event.request.requestId, option);
+            }
+          }
+        })();
+        try {
+          out.result = normaliseResult(await run);
+        } finally {
+          out.events = events;
+          await consume.catch(() => {});
+        }
+        break;
+      }
+      default:
+        throw new Error(`conformance: this adapter has no op ${step.op}`);
+    }
+  }
+  return out;
+}
+
+function normaliseResult(result: any): Record<string, unknown> {
+  return {
+    state: result.state,
+    text: result.text,
+    tools_used: result.toolsUsed,
+    turn_number: result.turnNumber,
+    exit_code: result.exitCode,
+    reason: result.reason,
+    conversation_id: result.conversationId,
+    status: result.status,
+  };
+}
+
+// ── comparing against `expect` ───────────────────────────────────────────────
+
+function subset(expected: Record<string, unknown>, actual: Record<string, unknown>): boolean {
+  return Object.entries(expected).every(([key, value]) => deepSubset(value, actual[key]));
+}
+
+function deepSubset(expected: unknown, actual: unknown): boolean {
+  if (expected === null || typeof expected !== "object") return expected === actual;
+  if (Array.isArray(expected)) {
+    if (!Array.isArray(actual) || actual.length !== expected.length) return false;
+    return expected.every((item, index) => deepSubset(item, actual[index]));
+  }
+  if (actual === null || typeof actual !== "object") return false;
+  return Object.entries(expected as Record<string, unknown>).every(([key, value]) =>
+    deepSubset(value, (actual as Record<string, unknown>)[key]),
+  );
+}
+
+function show(value: unknown): string {
+  return JSON.stringify(value, null, 2) ?? String(value);
+}
+
+function check(scenario: Scenario, observed: Observations): string[] {
+  const problems: string[] = [];
+  const expect = scenario.expect;
+  const fail = (what: string, detail: string) => problems.push(`${what}\n      ${detail}`);
+
+  for (const request of observed.unmatched) {
+    fail(
+      "unmatched request",
+      `the client sent ${request.method} ${request.path}, which no exchange in the scenario ` +
+        `anticipated. Either the client should not have sent it, or the scenario needs it.`,
+    );
+  }
+
+  if (expect.error) {
+    if (!observed.error) {
+      fail("error", `expected ${show(expect.error)} but the call succeeded`);
+    } else if (!subset(expect.error, observed.error)) {
+      fail("error", `expected ${show(expect.error)}\n      got ${show(observed.error)}`);
+    }
+  } else if (observed.error) {
+    fail("error", `the call was not supposed to fail, and raised ${show(observed.error)}`);
+  }
+
+  if (expect.requests) {
+    const wanted = expect.requests as Record<string, any>[];
+    if (expect.requests_exactly && observed.requests.length !== wanted.length) {
+      fail(
+        "requests",
+        `expected exactly ${wanted.length} request(s), saw ${observed.requests.length}: ` +
+          observed.requests.map((r) => `${r.method} ${r.path}`).join(", "),
+      );
+    }
+    wanted.forEach((want, index) => {
+      const got = observed.requests[index];
+      if (!got) return fail(`requests[${index}]`, `expected ${want.method} ${want.path}, saw nothing`);
+      if (want.method !== got.method || want.path !== got.path) {
+        fail(
+          `requests[${index}]`,
+          `expected ${want.method} ${want.path}, saw ${got.method} ${got.path}`,
+        );
+        return;
+      }
+      if (want.query && !subset(want.query, got.query)) {
+        fail(`requests[${index}].query`, `expected ${show(want.query)}\n      got ${show(got.query)}`);
+      }
+      if (want.headers && !subset(want.headers, got.headers)) {
+        fail(
+          `requests[${index}].headers`,
+          `expected ${show(want.headers)}\n      got ${show(got.headers)}`,
+        );
+      }
+      for (const [header, prefix] of Object.entries(want.header_prefixes ?? {})) {
+        const value = got.headers[header] ?? "";
+        if (!value.startsWith(String(prefix))) {
+          fail(
+            `requests[${index}].headers.${header}`,
+            `expected it to start with ${JSON.stringify(prefix)}, got ${JSON.stringify(value)}`,
+          );
+        }
+      }
+      for (const header of want.headers_absent ?? []) {
+        if (header in got.headers) {
+          fail(
+            `requests[${index}].headers.${header}`,
+            `expected no such header, got ${JSON.stringify(got.headers[header])}`,
+          );
+        }
+      }
+      if (want.body && !deepSubset(want.body, got.body)) {
+        fail(`requests[${index}].body`, `expected ${show(want.body)}\n      got ${show(got.body)}`);
+      }
+    });
+  }
+
+  if (expect.events) {
+    // A subsequence, not an equality: `expect.events` names the events that
+    // must appear in this order, and a client emitting extra `event` rows
+    // alongside them is not a divergence.
+    let cursor = 0;
+    for (const want of expect.events as Record<string, unknown>[]) {
+      const at = observed.events.findIndex((got, index) => index >= cursor && subset(want, got));
+      if (at === -1) {
+        fail(
+          "events",
+          `expected ${show(want)} after index ${cursor}, and the run emitted:\n      ` +
+            show(observed.events),
+        );
+        break;
+      }
+      cursor = at + 1;
+    }
+  }
+
+  if (expect.result) {
+    if (!observed.result) fail("result", `expected ${show(expect.result)} but there was no result`);
+    else if (!subset(expect.result, observed.result)) {
+      fail("result", `expected ${show(expect.result)}\n      got ${show(observed.result)}`);
+    }
+  }
+
+  if ("value" in expect && !deepSubset(expect.value, observed.value)) {
+    fail("value", `expected ${show(expect.value)}\n      got ${show(observed.value)}`);
+  }
+
+  if (expect.event_ids && !deepSubset(expect.event_ids, observed.eventIds)) {
+    fail("event_ids", `expected ${show(expect.event_ids)}\n      got ${show(observed.eventIds)}`);
+  }
+
+  return problems;
+}
+
+// ── the driver ───────────────────────────────────────────────────────────────
+
+const skips: Record<string, unknown> = (() => {
+  const matrix = JSON.parse(readFileSync(join(CONFORMANCE, "matrix.json"), "utf8"));
+  const out: Record<string, unknown> = {};
+  for (const [name, verdicts] of Object.entries(matrix.scenarios ?? {})) {
+    const verdict = (verdicts as Record<string, unknown>)[SDK];
+    if (verdict !== "yes") out[name] = verdict;
+  }
+  return out;
+})();
+
+const scenarios: Scenario[] = readdirSync(join(CONFORMANCE, "scenarios"))
+  .filter((file) => file.endsWith(".json"))
+  .sort()
+  .map((file) => JSON.parse(readFileSync(join(CONFORMANCE, "scenarios", file), "utf8")));
+
+for (const scenario of scenarios) {
+  const skip = skips[scenario.name] as { skip?: string; issue?: number } | undefined;
+  test(`conformance/${scenario.name}`, { skip: skip ? `#${skip.issue}: ${skip.skip}` : false }, async () => {
+    const server = new ScriptedServer(scenario.http);
+    const baseUrl = await server.start();
+    const observed: Observations = {
+      requests: server.requests,
+      unmatched: server.unmatched,
+      events: [],
+      result: null,
+      error: null,
+      value: undefined,
+      eventIds: null,
+    };
+    try {
+      Object.assign(observed, await drive(scenario, baseUrl));
+    } catch (error) {
+      observed.error = normaliseError(error);
+    } finally {
+      await server.stop();
+    }
+
+    const problems = check(scenario, observed);
+    assert.equal(
+      problems.length,
+      0,
+      `\nconformance FAILED for ${SDK} / ${scenario.name}\n` +
+        `  ${scenario.title}\n\n` +
+        problems.map((problem) => `  ${problem}`).join("\n\n") +
+        "\n",
+    );
+  });
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function safeJson(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+async function readBody(req: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) chunks.push(chunk as Buffer);
+  return Buffer.concat(chunks).toString("utf8");
+}


### PR DESCRIPTION
Closes #1412

`sdk/contract/` (#1411) pins the *shape* of the wire. This pins the *behaviour*:
what a client does with an SSE frame split across two TCP writes, which error
class a 402 becomes, whether a dropped stream resumes from the right cursor,
what `run` returns when the turn fails. None of that is in an OpenAPI document
and all of it is promised in four languages at once.

## The shape of it

```
sdk/conformance/
  README.md            the format, the vocabularies, how to add a behaviour
  scenarios/*.json     24 canonical scenarios, no language-specific expectations
  matrix.json          which SDK runs which, and why not
  lint.py              validates the scenarios, the matrix and the fixtures
```

Each scenario is an ordered table of scripted HTTP exchanges, a few steps from
a seven-verb vocabulary every client exposes publicly, and expectations written
in an event and error vocabulary the four clients already share. Each SDK has a
thin adapter that serves the bytes, drives its public client, normalises what it
saw and compares. **The scenarios hold every expectation; the adapters hold
none.**

| SDK | Command | Result |
|---|---|---|
| TypeScript | `npm run conformance` | 24/24 |
| Python | `python3 -m unittest discover -s tests -p test_conformance.py` | 24/24 |
| Elixir | `mix test test/conformance_test.exs` | 24/24 |
| Swift | `swift test --filter ConformanceTests` | 23/24, one skip → #1424 |

All four also run inside that SDK's normal test command, and each has its own CI
step so a divergence names the client in the checks list.

## Coverage

The eight groups the issue asks for: auth headers and base-URL normalisation
(4), error-envelope mapping (6), SSE comments / multiline / fragmented /
malformed / CRLF framing (5), reconnect budget and `Last-Event-ID` resume (2),
terminal run states including cancellation and timeout (3), the permission
request/reply flow (1), pagination and empty pages (3).

Delivery differs by language and that is allowed. Python and Elixir serve over
a real loopback socket, so an aborted stream really is a socket that dies. Swift
goes through its `MockURLProtocol` seam, one chunk per `didLoad` so the parser
sees the same read boundaries, staying clear of the `FoundationNetworking`
teardown bug this issue explicitly does not own.

## What it found

**#1424, on the first run.** On the timeout path Swift issues a
`GET /api/conversations/:id` that the other three do not: `Run.follow` reads the
status unconditionally after its event loop and the racing timeout task does not
stop it in time. Filed, and the matrix skip points at the issue rather than
hiding it.

**Three of my own scenarios were wrong about the clients**, which is the
argument for writing an adapter before finalising a format:

- `insufficient_credits` raises `SubscriptionRequiredError`, not the quota
  class. The shared vocabulary now says `quota` is the concurrency cap you fix
  by ending a conversation and `subscription` is the billing wall.
- A cold `resume().send()` discovers its cursor and its turn number before it
  posts a prompt, so that scenario scripts all three exchanges.
- A tool call between two text chunks inserts a paragraph break. Every client
  does it; the scenario pins it now instead of the run-together text I assumed.

**That the four agree at all is the other finding.** Error taxonomy, event
vocabulary, cursor resume and framing already lined up across four
independently written clients, on the first run. This locks that in.

## `lint.py` is the join with #1411

Besides the format and the matrix, it validates every `json` fixture body
against the schema `sdk/contract/contract.json` declares for that operation. A
scenario cannot go green against a response the real server would never send.
Statuses a plug produces on any route (401, 402, 429, 503 …) are checked against
the error envelope instead, because the document describes controllers and the
rate limiter is a plug.

The matrix has teeth in both directions: a scenario with no verdict for an SDK
fails, and so does a skip with no issue number. A gap is always something
somebody decided and filed.

## On the guard you asked me to consider

**It does not fit here, and I recommend filing it separately.** #1418 and the
`AuthMeResponse` bug are both a mismatch between a schema and its *controller*,
so catching them needs a really rendered response. Every scenario in this suite
is scripted bytes with no server in the process — that is exactly what makes
byte-level framing and connection death testable, and a non-goal of the issue.

The good news is it is nearly free where it does belong. `open_api_spex` is
already a dependency and ships `OpenApiSpex.TestAssertions.assert_operation_response/1`,
which takes a `conn` and validates the rendered body against the operation's
declared response schema. A hook in `ConnCase` — or one guardrail test walking
the API controller tests — would cover the whole class from inside the Elixir
suite. Happy to build it if you file it.

**While writing the lint I found a second instance of that class**: the 402 body
carries `upgrade_url` (per ADR 0031 and `Billing.check_spend/1`), and the
declared response for `POST /api/conversations` is a bare `{"type": "object"}`
with no properties at all. Not fixed here; it belongs with #1418.

## Verification

- All four adapters, plus `python3 sdk/conformance/lint.py`.
- **Verified by mutation, not by a green run**: I broke two scenarios (a wrong
  expected text, a wrong expected `Last-Event-ID`) and confirmed all four
  adapters fail on them, then restored. That is also what caught a mistake in my
  own CI step — `python3 -m unittest tests.test_conformance` cannot import a
  package with no `__init__.py`, so it reported one passing import error instead
  of running anything. The discover form is what is wired.
- TypeScript: typecheck, 101 tests, conformance 24/24.
- Python: 41 tests, `compileall`.
- Elixir SDK: format, warnings-as-errors compile, 52 tests.
- Swift: strict format lint, full suite under warnings-as-errors, release build.
- `mix precommit`: 6 doctests, 4002 tests, 2 failures — both `DBConnection`
  pool-checkout timeouts under parallel agents sharing one Postgres. Those two
  files alone: 60 tests, 0 failures. **This branch touches no file under
  `apps/`, `ee/` or `config/`**, so it cannot have caused them. Compile with
  warnings-as-errors, unused deps, format, `credo --strict`, dialyzer
  (`Total errors: 0`) and sobelow all passed.
- Both SDK release guards: no release needed. No SDK version is bumped.

## Notes for review

- `sdk/conformance/README.md` is the reference, including a "what this is not"
  section: it does not replace each SDK's own tests, and it does not drive a
  real Fountain.
- `CONTRIBUTING.md` gains a "Changing behaviour rather than shape" section next
  to the contract one from #1411.
- The three ports were written by codex from the TypeScript reference, one run
  per language, under instructions to report a divergence rather than bend
  anything. Every file was read here, every error mapping was checked against
  that client's own error module, and every check re-run — including the
  mutation test above, which is the part that proves the adapters assert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BXYa9CQNG8oFNq5YhAxva
