### PR TITLE
feat(onboarding): the verified landing is a key, one request, the reply

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,11 @@ COPY ee ./ee
 # A missing one is not a broken link, it is a failed image build —
 # `docs_test.exs` checks this list against the module's @external_resource
 # attributes so the failure lands in CI instead.
+#
+# `Fountain.Onboarding` reads docs/snippets/ at compile time as well — the one
+# copy of the first request, which the landing page renders and the manual
+# includes. It is under docs/ for exactly this reason, so the line below
+# already carries it; `onboarding_test.exs` pins that.
 COPY docs ./docs
 COPY CHANGELOG.md ./
 COPY sdk/typescript/examples ./sdk/typescript/examples

--- a/apps/fountain/lib/fountain/activation.ex
+++ b/apps/fountain/lib/fountain/activation.ex
@@ -26,19 +26,29 @@ defmodule Fountain.Activation do
   It is the *account's first* reply that this module cares about, so the
   function is a no-op for every later turn.
 
-  **#1390 stamps `users.onboarding_completed_at` here**, at the first reply,
-  instead of the dashboard checklist stamping it when three things exist.
-  The call site is marked in `capture_first_reply/2`; the field is untouched
-  by this module today.
+  **`users.onboarding_completed_at` is stamped here** (#1390), at the first
+  reply, rather than by the dashboard checklist when three things existed. It
+  is the same moment the funnel calls activated, so the two can no longer
+  disagree, and it lands whatever door the request came through.
+
+  `conversation_created/1` is the second seam, on
+  `Conversations.create_conversation/1`, which both create paths go through.
+  It emits `onboarding.request_sent` on the account's *first* conversation.
+  That event is a step in the PostHog funnel and is deliberately **not** the
+  landing page's to send: a developer who copies the request, closes the tab
+  and runs it an hour later still sent it, and an ordered funnel whose third
+  step only fires while a browser is open would drop exactly the people who
+  did the thing.
 
   ## What it costs
 
   Two queries per turn that ends with a reply — the conversation's owner, and
   whether an earlier reply already exists for that owner — and a third (the
   user row, for the time since verification) only on the one turn per account
-  that is the first. It is best-effort: a raise here would take a turn ending
-  with it, so everything is rescued, exactly as
-  `Conversations.publish_stage/4` treats its own analytics mirror.
+  that is the first. One `EXISTS` per conversation created. It is best-effort:
+  a raise here would take a turn ending or a conversation create with it, so
+  everything is rescued, exactly as `Conversations.publish_stage/4` treats its
+  own analytics mirror.
   """
 
   import Ecto.Query
@@ -50,6 +60,7 @@ defmodule Fountain.Activation do
   alias Fountain.Repo
 
   @event "activation.first_reply"
+  @request_sent "onboarding.request_sent"
 
   @doc """
   The moment each account first got a reply: `%{user_id => DateTime.t()}`.
@@ -93,6 +104,33 @@ defmodule Fountain.Activation do
   end
 
   @doc """
+  The account's first reply itself — when it landed, which conversation it
+  came from, and what the agent said — or `nil` if it never got one.
+
+  This is what the verified landing renders (#1390), so the words on that
+  screen are the same row the funnel counted rather than a second guess at
+  which reply was first. No tenant scope: `user_id` is the scope.
+  """
+  @spec first_reply(String.t()) ::
+          %{at: DateTime.t(), conversation_id: String.t(), text: String.t()} | nil
+  def first_reply(user_id) when is_binary(user_id) do
+    Repo.one(
+      from t in Turn,
+        join: c in Conversation,
+        on: c.id == t.conversation_id,
+        where: c.user_id == ^user_id,
+        where: not is_nil(t.reply_text) and t.reply_text != "",
+        order_by: [asc: coalesce(t.ended_at, t.inserted_at), asc: t.id],
+        limit: 1,
+        select: %{
+          at: type(coalesce(t.ended_at, t.inserted_at), :utc_datetime),
+          conversation_id: c.id,
+          text: t.reply_text
+        }
+    )
+  end
+
+  @doc """
   A turn has ended carrying a reply: if it is the account's first, this is
   activation.
 
@@ -117,24 +155,66 @@ defmodule Fountain.Activation do
   def turn_replied(_turn), do: :ok
 
   @doc """
+  A conversation row was just written: if it is the account's first, the
+  developer has sent the request the landing handed them.
+
+  Emits `onboarding.request_sent`, the funnel's third step. Called from
+  `Conversations.create_conversation/1`, which is the one write both create
+  paths share, so a new door onto conversation creation is instrumented by
+  construction. Returns `:ok` in every case.
+  """
+  @spec conversation_created(Conversation.t()) :: :ok
+  def conversation_created(%Conversation{user_id: user_id, id: id} = conv)
+      when is_binary(user_id) do
+    if Fountain.Analytics.enabled?() and first_conversation?(user_id, id) do
+      Fountain.Analytics.capture(
+        @request_sent,
+        user_id,
+        %{
+          "conversation_id" => id,
+          "agent_id" => conv.agent_id,
+          "conversation_source" => conv.source,
+          "source" => "activation"
+        },
+        timestamp: conv.inserted_at
+      )
+    end
+
+    :ok
+  rescue
+    e ->
+      Logger.warning("activation: first-conversation check failed: #{inspect(e)}")
+      :ok
+  end
+
+  def conversation_created(_conv), do: :ok
+
+  @doc """
   The PostHog event name this module emits, and the names the verified
   landing (#1390) emits either side of it.
 
   The funnel ADR 0038 asks for is `auth.email.verified` →
   `onboarding.landing_viewed` → `onboarding.request_sent` →
   `activation.first_reply`. The first arrives already, from the audit trail's
-  own choke point (`Accounts.verify_email/2` records `auth.email.verified`);
-  the last is emitted here; the middle two are the landing page's, and are
-  named here so the funnel definition and the page that fills it cannot drift
-  apart. `onboarding.key_copied` is the fourth moment #1390 captures and is
-  not a funnel step: copying is not doing.
+  own choke point (`Accounts.verify_email/2` records `auth.email.verified`).
+  The last two are emitted here — `onboarding.request_sent` from
+  `conversation_created/1` and `activation.first_reply` from
+  `turn_replied/1` — so neither depends on a browser being open.
+  `onboarding.landing_viewed` is `FountainWeb.StartLive`'s, and is named here
+  so the funnel definition and the page that fills it cannot drift apart.
+
+  Two more events the landing sends are deliberately not steps.
+  `onboarding.key_copied` is not doing, it is intending to.
+  `onboarding.reply_shown` says the reply arrived while the developer was
+  still watching, which is a fact about the page rather than about the
+  account, and `activation.first_reply` already counts the account.
   """
   @spec funnel_events() :: [String.t()]
   def funnel_events do
     [
       "auth.email.verified",
       "onboarding.landing_viewed",
-      "onboarding.request_sent",
+      @request_sent,
       @event
     ]
   end
@@ -168,12 +248,23 @@ defmodule Fountain.Activation do
     earliest == turn.id
   end
 
+  # Is this the account's first conversation? The row is already written when
+  # this runs, so "no other row" is the test. One indexed EXISTS.
+  defp first_conversation?(user_id, conversation_id) do
+    not Repo.exists?(
+      from c in Conversation, where: c.user_id == ^user_id and c.id != ^conversation_id
+    )
+  end
+
   defp capture_first_reply(user_id, %Turn{} = turn) do
-    # #1390: stamp `users.onboarding_completed_at` here, on this branch —
-    # it runs exactly once per account, at the first reply, whatever door the
-    # request came through. Nothing writes it from this module today.
     user = Repo.get(User, user_id)
     at = turn.ended_at || turn.inserted_at
+
+    # ADR 0038 decision 7: onboarding is done at the first reply, not when
+    # three things exist. This branch runs exactly once per account, whatever
+    # door the request came through, which is why the stamp belongs here and
+    # not on a console page the developer may never open.
+    stamp_onboarding(user)
 
     Fountain.Analytics.capture(
       @event,
@@ -190,6 +281,13 @@ defmodule Fountain.Activation do
       set_once: %{"first_reply_at" => iso(at)}
     )
   end
+
+  defp stamp_onboarding(%User{onboarding_completed_at: nil} = user) do
+    Fountain.Accounts.complete_onboarding(user)
+    :ok
+  end
+
+  defp stamp_onboarding(_user), do: :ok
 
   defp hours_since_verified(%User{email_verified_at: %DateTime{} = verified_at}, %DateTime{} = at) do
     Float.round(DateTime.diff(at, verified_at, :second) / 3600, 3)

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -836,6 +836,14 @@ defmodule Fountain.Conversations do
     %Conversation{}
     |> Conversation.changeset(attrs)
     |> Repo.insert()
+    |> tap(fn
+      # The account's first conversation is the request the verified landing
+      # handed over (ADR 0038). Both create paths go through this write, so
+      # the funnel's third step cannot be missed by a new door — and it does
+      # not depend on the landing page still being open.
+      {:ok, conv} -> Fountain.Activation.conversation_created(conv)
+      _ -> :ok
+    end)
   end
 
   @doc """

--- a/apps/fountain/lib/fountain/onboarding.ex
+++ b/apps/fountain/lib/fountain/onboarding.ex
@@ -1,0 +1,122 @@
+defmodule Fountain.Onboarding do
+  @moduledoc """
+  The first request, in one place (ADR 0038 decision 5).
+
+  Onboarding is a key and one request. The request the verified landing hands
+  over (`FountainWeb.StartLive`) and the request `docs/quickstart.md` prints
+  have to be the same text, or the developer who reads both learns that one of
+  them is wrong. So there is one source for it, and it is a pair of files:
+
+    * `docs/snippets/first-request.sh` — the `curl`
+    * `docs/snippets/first-request.ts` — the TypeScript SDK equivalent
+
+  The docs include those files verbatim (`--8<--`, the same mechanism
+  `docs/changelog.md` and `docs/tour.md` use) with their placeholders intact,
+  because a reader of the manual has no key yet. This module reads the same
+  two files at compile time and substitutes the placeholders, because a reader
+  of the landing page does.
+
+  They live under `docs/` deliberately. Anything `Fountain.Docs` reads at
+  compile time must be `COPY`d into the Docker build stage or `mix release`
+  dies and the deploy silently never happens (#884), and `COPY docs ./docs` is
+  already in the Dockerfile. A snippet under `examples/` would have needed a
+  second `COPY` line and a second thing to remember.
+
+  ## Placeholders
+
+  | Token | Becomes |
+  |---|---|
+  | `$FOUNTAIN_BASE_URL` | this instance's public URL |
+  | `$FOUNTAIN_API_KEY` | the key the landing just minted |
+  | `$FOUNTAIN_AGENT_ID` | the agent the request runs against |
+  | `$FOUNTAIN_AGENT_NAME` | that agent's name, which is what the SDK takes |
+  | `new Fountain()` | `new Fountain({apiKey, baseUrl})`, since a copied snippet has no environment |
+
+  The shell snippet keeps environment variables rather than inlining anything,
+  so what the manual prints and what the page prints differ only in the values
+  a reader could not have known.
+  """
+
+  @root Path.expand("../../../..", __DIR__)
+  @sh_path Path.join(@root, "docs/snippets/first-request.sh")
+  @ts_path Path.join(@root, "docs/snippets/first-request.ts")
+
+  @external_resource @sh_path
+  @external_resource @ts_path
+
+  @curl @sh_path |> File.read!() |> String.trim_trailing()
+  @typescript @ts_path |> File.read!() |> String.trim_trailing()
+
+  # The one prompt. It asks for something every sandbox can answer with no
+  # repository, no token and no setup script, which is the whole point: the
+  # shortest documented path used to need a GitHub token, and an account that
+  # has to fetch one before anything replies is an account that leaves.
+  @prompt "Which operating system and working directory are you in? Answer in one sentence."
+
+  @doc "The prompt both snippets send."
+  @spec prompt() :: String.t()
+  def prompt, do: @prompt
+
+  @doc "The `curl`, with its placeholders left in — what the manual prints."
+  @spec curl_template() :: String.t()
+  def curl_template, do: @curl
+
+  @doc "The TypeScript, with its placeholders left in — what the manual prints."
+  @spec typescript_template() :: String.t()
+  def typescript_template, do: @typescript
+
+  @doc """
+  The `curl` for a real key and a real agent.
+
+  Options: `:base_url`, `:api_key`, `:agent_id`. Anything not given keeps its
+  placeholder, so a page with no agent yet still renders something honest.
+  """
+  @spec curl(keyword()) :: String.t()
+  def curl(opts \\ []) do
+    @curl
+    |> replace("$FOUNTAIN_BASE_URL", opts[:base_url])
+    |> replace("$FOUNTAIN_API_KEY", opts[:api_key])
+    |> replace("$FOUNTAIN_AGENT_ID", opts[:agent_id])
+  end
+
+  @doc """
+  The TypeScript for a real key and a real agent.
+
+  Options: `:base_url`, `:api_key`, `:agent`. A copied snippet runs in a
+  terminal that has never heard of this account, so the bare `new Fountain()`
+  the manual shows — which reads `FOUNTAIN_API_KEY` from the environment, as
+  the CLI does — becomes an explicit constructor here.
+  """
+  @spec typescript(keyword()) :: String.t()
+  def typescript(opts \\ []) do
+    @typescript
+    |> replace("$FOUNTAIN_AGENT_NAME", opts[:agent])
+    |> constructor(opts[:api_key], opts[:base_url])
+  end
+
+  @doc """
+  Every placeholder token these snippets carry.
+
+  `onboarding_test.exs` asserts that a fully-substituted render contains none
+  of them: a token that survives is a token the developer pastes into their
+  terminal.
+  """
+  @spec placeholders() :: [String.t()]
+  def placeholders do
+    ~w($FOUNTAIN_BASE_URL $FOUNTAIN_API_KEY $FOUNTAIN_AGENT_ID $FOUNTAIN_AGENT_NAME)
+  end
+
+  defp replace(text, _token, nil), do: text
+  defp replace(text, token, value), do: String.replace(text, token, to_string(value))
+
+  defp constructor(text, nil, nil), do: text
+
+  defp constructor(text, api_key, base_url) do
+    args =
+      [{"apiKey", api_key}, {"baseUrl", base_url}]
+      |> Enum.reject(&is_nil(elem(&1, 1)))
+      |> Enum.map_join(", ", fn {k, v} -> ~s(#{k}: "#{v}") end)
+
+    String.replace(text, "new Fountain()", "new Fountain({ #{args} })")
+  end
+end

--- a/apps/fountain/lib/fountain_web/controllers/email_verification_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/email_verification_controller.ex
@@ -62,9 +62,12 @@ defmodule FountainWeb.EmailVerificationController do
                 # the welcome fires on the verification transition (#449).
                 Fountain.Workers.WelcomeEmail.enqueue(verified_user)
 
+                # The verified landing, not the dashboard (ADR 0038): the
+                # first screen after verification hands over a key and one
+                # request rather than a list of things to go and set up.
                 conn
                 |> log_in_user(verified_user)
-                |> redirect(to: ~p"/dashboard")
+                |> redirect(to: ~p"/start")
 
               {:error, _changeset} ->
                 conn

--- a/apps/fountain/lib/fountain_web/controllers/ueberauth_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/ueberauth_controller.ex
@@ -86,11 +86,15 @@ defmodule FountainWeb.UeberauthController do
         # created verified, so this is its verification transition.
         Fountain.Workers.WelcomeEmail.enqueue(user)
 
+        # And the same landing (ADR 0038). An OAuth signup is created verified,
+        # so this *is* its first screen after verification; sending it to the
+        # dashboard instead would give one of the two signup doors a different
+        # first hour.
         conn
         |> configure_session(renew: true)
         |> put_session(:user_id, user.id)
         |> put_session(:session_version, user.session_version)
-        |> redirect(to: ~p"/dashboard")
+        |> redirect(to: ~p"/start")
 
       {:ok, user, :existing} ->
         if Fountain.Accounts.suspended?(user) do

--- a/apps/fountain/lib/fountain_web/live/dashboard_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/dashboard_live/index.ex
@@ -1,17 +1,20 @@
 defmodule FountainWeb.DashboardLive.Index do
   @moduledoc """
-  The console's home, and what greets a new account (#867).
+  The console's home: the account's own numbers, and the way in to its
+  primitives.
 
-  It replaced the onboarding wizard, which was four pages an account could
-  not leave until it finished. The same three things have to be true before
-  an agent can run — an inference credential, an agent, and somewhere to
-  watch it — so they are listed here, ticked as they are done, and the
-  account is free to do them in any order or not at all.
+  It is no longer what greets a new account. It used to carry a three-item
+  checklist — an inference credential, an agent, a conversation — which
+  replaced the four-page onboarding wizard and then defined onboarding as
+  "three things exist" (#867). ADR 0038 replaced that with the verified
+  landing (`FountainWeb.StartLive`), where a key and one request produce a
+  reply, and `users.onboarding_completed_at` is stamped at that reply by
+  `Fountain.Activation` rather than by this mount. The dashboard is what an
+  account gets *after* the first reply, which is what a dashboard is for.
   """
   use FountainWeb, :live_view
 
   alias Fountain.{
-    Accounts,
     Agents,
     Apps,
     Conversations,
@@ -28,13 +31,6 @@ defmodule FountainWeb.DashboardLive.Index do
     counts = Conversations.conversation_counts(user.id)
     has_credential? = InferenceCredentials.has_any_credential?(user.id)
 
-    # `onboarding_completed_at` used to be stamped by the wizard's last step.
-    # Nothing else ever set it, so with the wizard gone the lifecycle funnel's
-    # "onboarded" stage would have flatlined (Fountain.Funnel). Stamp it here
-    # instead, off what the checklist actually asks for — a truer definition
-    # than "clicked through four pages", and idempotent.
-    maybe_complete_onboarding(user, has_credential?, agents)
-
     {:ok,
      socket
      |> assign(:page_title, "Dashboard")
@@ -42,6 +38,7 @@ defmodule FountainWeb.DashboardLive.Index do
      |> assign(:environment_count, length(Environments.list_environments(user.id)))
      |> assign(:vault_count, length(Vaults.list_vaults(user.id)))
      |> assign(:has_credential?, has_credential?)
+     |> assign(:replied?, Fountain.Activation.first_reply_at(user.id) != nil)
      |> assign(:active_count, counts.active)
      |> assign(:conversation_count, counts.total)
      |> assign(:recent_conversations, Conversations.list_conversations(user.id, limit: 5))
@@ -80,39 +77,18 @@ defmodule FountainWeb.DashboardLive.Index do
         </a>
       </div>
 
-      <%!-- Setup, when something is still missing. Ticks disappear once
-            everything is in place rather than nagging forever. --%>
-      <section :if={not ready?(assigns)} class="rounded-lg border border-[var(--color-border)] p-5">
-        <h2 class="text-sm font-semibold">Before an agent can run</h2>
+      <%!-- One line, not a checklist: an account that has never had a reply
+            has somewhere better to be, and it is not this page. --%>
+      <.link
+        :if={not @replied?}
+        navigate={~p"/start"}
+        class="block rounded-lg border border-[var(--color-border)] p-4 hover:border-[var(--color-border-strong)]"
+      >
+        <p class="text-sm font-medium">Nothing has answered on this account yet</p>
         <p class="mt-1 text-sm text-[var(--color-text-secondary)]">
-          Three things, in any order.
+          Your key and one request are on the start page, and the reply comes back there.
         </p>
-        <ul class="mt-4 space-y-3">
-          <.setup_step
-            done={@has_credential?}
-            label="An inference credential"
-            hint="Your own Anthropic, OpenAI or Google key — Fountain never bills you for tokens."
-            href={~p"/account/inference-credentials"}
-            cta="Add a key"
-          />
-          <.setup_step
-            done={@agent_count > 0}
-            label="An agent"
-            hint="A name, a runtime and a model — the thing that runs."
-            href={~p"/agents/new"}
-            cta="Create an agent"
-          />
-          <.setup_step
-            :if={@conversations_app}
-            done={@conversation_count > 0}
-            label="A conversation"
-            hint="Runs in an isolated sandbox and streams back live, in the conversations app."
-            href={@conversations_app <> "#/new"}
-            cta="Start one"
-            external
-          />
-        </ul>
-      </section>
+      </.link>
 
       <%!-- The apps. External on purpose: their own origins, their own
             tokens, and a deployment may have neither. --%>
@@ -226,12 +202,6 @@ defmodule FountainWeb.DashboardLive.Index do
     """
   end
 
-  defp maybe_complete_onboarding(%{onboarding_completed_at: nil} = user, true, [_ | _]) do
-    Accounts.complete_onboarding(user)
-  end
-
-  defp maybe_complete_onboarding(_user, _has_credential?, _agents), do: :ok
-
   defp nothing_this_month?(assigns) do
     assigns.usage.conversations == 0 and assigns.usage.turns == 0 and
       assigns.usage.sandbox_minutes == 0 and Conversations.total_input(assigns.tokens) == 0 and
@@ -278,57 +248,6 @@ defmodule FountainWeb.DashboardLive.Index do
   end
 
   defp format_hours(_), do: "—"
-
-  defp ready?(assigns) do
-    assigns.has_credential? and assigns.agent_count > 0 and
-      (is_nil(assigns.conversations_app) or assigns.conversation_count > 0)
-  end
-
-  attr :done, :boolean, required: true
-  attr :label, :string, required: true
-  attr :hint, :string, required: true
-  attr :href, :string, required: true
-  attr :cta, :string, required: true
-  attr :external, :boolean, default: false
-
-  defp setup_step(assigns) do
-    ~H"""
-    <li class="flex items-start gap-3">
-      <span class={[
-        "mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full border text-xs",
-        if(@done,
-          do: "border-green-500 bg-green-500/15 text-green-600",
-          else: "border-[var(--color-border)] text-[var(--color-text-muted)]"
-        )
-      ]}>
-        {if @done, do: "✓", else: "•"}
-      </span>
-      <div class="min-w-0 flex-1">
-        <p class={[
-          "text-sm font-medium",
-          @done && "text-[var(--color-text-muted)] line-through"
-        ]}>
-          {@label}
-        </p>
-        <p :if={not @done} class="text-xs text-[var(--color-text-secondary)]">{@hint}</p>
-      </div>
-      <a
-        :if={not @done and @external}
-        href={@href}
-        class="shrink-0 text-sm text-[var(--color-brand)] hover:underline"
-      >
-        {@cta} ↗
-      </a>
-      <.link
-        :if={not @done and not @external}
-        navigate={@href}
-        class="shrink-0 text-sm text-[var(--color-brand)] hover:underline"
-      >
-        {@cta}
-      </.link>
-    </li>
-    """
-  end
 
   attr :label, :string, required: true
   attr :value, :string, required: true

--- a/apps/fountain/lib/fountain_web/live/start_live.ex
+++ b/apps/fountain/lib/fountain_web/live/start_live.ex
@@ -118,10 +118,12 @@ defmodule FountainWeb.StartLive do
     end
   end
 
-  # The agent the first request runs against. #1389 gives every verified
-  # account a canned `starter`; until that ships — and afterwards, for an
-  # account that renamed or deleted it — any agent will do, oldest first, so
-  # this page works either way and never creates one of its own.
+  # The agent the first request runs against. `Fountain.Agents.Starter` plants
+  # a `starter` at verification (#1389), so an account has one from the moment
+  # it exists. The fallback is not dead code: the starter is an ordinary agent
+  # and may be renamed or deleted, and every account verified before #1389
+  # never had one. Any agent will do, oldest first. This page never creates
+  # one of its own.
   defp default_agent(user_id) do
     agents = Agents.list_agents(user_id, [])
 

--- a/apps/fountain/lib/fountain_web/live/start_live.ex
+++ b/apps/fountain/lib/fountain_web/live/start_live.ex
@@ -60,7 +60,7 @@ defmodule FountainWeb.StartLive do
       |> assign(:has_key?, Accounts.list_api_keys(user.id) != [])
       |> assign(:reply, Activation.first_reply(user.id))
       |> assign(:sent?, false)
-      |> assign(:needs_credential?, needs_credential?(user.id))
+      |> assign(:needs_credential?, needs_credential?(user.id, agent))
 
     {:ok, if(connected?(socket), do: on_connect(socket, user), else: socket)}
   end
@@ -91,15 +91,32 @@ defmodule FountainWeb.StartLive do
     end
   end
 
-  # Today the request only answers for an account that holds an inference
-  # credential of its own (ADR 0008), so the page says so rather than letting
-  # a copied `curl` fail with a refusal the developer has to go and decode.
+  # Will this request reach a model at all?
   #
-  # **#1388 is what removes this.** When this deployment holds a platform
-  # inference key, an account with no credential runs on it, and this becomes
-  # `not (has_own_credential? or platform_key_available?)`. One condition, in
-  # one place, deliberately not coupled to a thing that does not exist yet.
-  defp needs_credential?(user_id), do: not InferenceCredentials.has_any_credential?(user_id)
+  # `InferenceCredentials.select/2` is the one selection rule (#1388): the
+  # tenant's own key wins, this deployment's platform key covers an account
+  # that has none, and `{:error, :no_credential}` is the case where the
+  # sandbox starts and the agent has nothing to call. The page says so rather
+  # than letting a copied `curl` fail with a provider's auth error the
+  # developer has to go and decode.
+  #
+  # Asked here rather than reimplemented, so a deployment that turns a
+  # platform key on stops showing the banner with no change to this file. It
+  # is also the reason the banner is per-*agent*: `select/2` keys off the
+  # model's provider, and an account holding an Anthropic key still has
+  # nothing for an agent on a `gemini` model.
+  defp needs_credential?(_user_id, nil), do: false
+
+  defp needs_credential?(user_id, agent) do
+    with {:ok, dek} <- Fountain.Crypto.load_tenant_key(user_id),
+         {:ok, own} <- InferenceCredentials.decrypted_for_user(user_id, dek) do
+      match?({:error, :no_credential}, InferenceCredentials.select(agent.model, own))
+    else
+      # A tenant key that will not load is a bigger problem than this banner,
+      # and it is not this page's to report.
+      _ -> false
+    end
+  end
 
   # The agent the first request runs against. #1389 gives every verified
   # account a canned `starter`; until that ships — and afterwards, for an
@@ -192,9 +209,9 @@ defmodule FountainWeb.StartLive do
       >
         <p class="text-sm font-medium">This account has no inference credential yet</p>
         <p class="mt-1 text-sm">
-          The request below reaches a sandbox, and the agent in it has no model to call.
-          Add an Anthropic, OpenAI or Google key first. It takes a minute, and Fountain
-          never bills you for those tokens.
+          This deployment holds no model key for your agent's provider either, so the
+          request below reaches a sandbox and the agent in it has nothing to call. Add
+          an Anthropic, OpenAI or Google key first. It takes a minute.
         </p>
       </.link>
 

--- a/apps/fountain/lib/fountain_web/live/start_live.ex
+++ b/apps/fountain/lib/fountain_web/live/start_live.ex
@@ -1,0 +1,365 @@
+defmodule FountainWeb.StartLive do
+  @moduledoc """
+  `/start` — the verified landing (ADR 0038 decision 5, #1390).
+
+  The first screen after verification. It hands over a key and one request,
+  shows the reply on the same screen when it arrives, and then points at three
+  doors. It does not onboard; it hands off.
+
+  It replaced a three-item checklist on the dashboard — a credential, an
+  agent, a conversation — which defined done as "three things exist", sent
+  the third item to a different origin to click a button, and asked for an
+  inference key before the product had done anything.
+
+  ## Why the key is minted here
+
+  A raw API key exists for exactly one render: `Accounts.create_api_key/3`
+  stores a hash. So the mint has to happen on the screen that shows it, and
+  only when the socket is connected, or the dead render would burn one key and
+  the live render another. An account that already has a key is not given a
+  second one silently — it gets the same "keys are shown once" sentence the
+  API keys page uses, and a button.
+
+  ## Why the reply arrives without polling the agent
+
+  `Conversations` broadcasts `sidebar:<user_id>` on every log event and every
+  conversation change — the same topic the console's sidebar counts on. The
+  page subscribes to it and, while it has no reply yet, asks
+  `Fountain.Activation.first_reply/1` on each nudge. So the reply that appears
+  here is the row the funnel counted, not a second opinion about which reply
+  was first.
+
+  ## The events
+
+  `onboarding.landing_viewed` and `onboarding.reply_shown` are this page's,
+  and `onboarding.key_copied` rides on the copy button's `phx-click`. The
+  funnel's third step, `onboarding.request_sent`, is deliberately **not**
+  here: it is emitted server-side by `Fountain.Activation` when the account's
+  first conversation is written, so a developer who copies the request and
+  runs it after closing the tab still counts. `Activation.funnel_events/0`
+  holds the four names.
+  """
+  use FountainWeb, :live_view
+
+  alias Fountain.{Accounts, Activation, Agents, Analytics, Apps, InferenceCredentials, Onboarding}
+
+  @key_label "quickstart"
+
+  @impl true
+  def mount(_params, _session, socket) do
+    user = socket.assigns.current_user
+    agent = default_agent(user.id)
+
+    socket =
+      socket
+      |> assign(:page_title, "Start")
+      |> assign(:agent, agent)
+      |> assign(:base_url, Fountain.PublicUrl.base())
+      |> assign(:conversations_app, Apps.conversations())
+      |> assign(:raw_key, nil)
+      |> assign(:has_key?, Accounts.list_api_keys(user.id) != [])
+      |> assign(:reply, Activation.first_reply(user.id))
+      |> assign(:sent?, false)
+      |> assign(:needs_credential?, needs_credential?(user.id))
+
+    {:ok, if(connected?(socket), do: on_connect(socket, user), else: socket)}
+  end
+
+  defp on_connect(socket, user) do
+    Phoenix.PubSub.subscribe(Fountain.PubSub, "sidebar:#{user.id}")
+
+    Analytics.capture("onboarding.landing_viewed", user, %{
+      "has_agent" => socket.assigns.agent != nil,
+      "already_replied" => socket.assigns.reply != nil,
+      "source" => "console"
+    })
+
+    socket
+    |> assign(:sent?, Fountain.Conversations.conversation_counts(user.id).total > 0)
+    |> mint_first_key(user)
+  end
+
+  # Only when the account has none. A developer who lands here twice is not
+  # given a second key behind their back; the page says so and offers one.
+  defp mint_first_key(%{assigns: %{has_key?: true}} = socket, _user), do: socket
+  defp mint_first_key(socket, user), do: mint(socket, user)
+
+  defp mint(socket, user) do
+    case Accounts.create_api_key(user.id, @key_label, FountainWeb.Audited.attribution(socket)) do
+      {:ok, {_key, raw}} -> socket |> assign(:raw_key, raw) |> assign(:has_key?, true)
+      {:error, _} -> put_flash(socket, :error, "Could not create an API key.")
+    end
+  end
+
+  # Today the request only answers for an account that holds an inference
+  # credential of its own (ADR 0008), so the page says so rather than letting
+  # a copied `curl` fail with a refusal the developer has to go and decode.
+  #
+  # **#1388 is what removes this.** When this deployment holds a platform
+  # inference key, an account with no credential runs on it, and this becomes
+  # `not (has_own_credential? or platform_key_available?)`. One condition, in
+  # one place, deliberately not coupled to a thing that does not exist yet.
+  defp needs_credential?(user_id), do: not InferenceCredentials.has_any_credential?(user_id)
+
+  # The agent the first request runs against. #1389 gives every verified
+  # account a canned `starter`; until that ships — and afterwards, for an
+  # account that renamed or deleted it — any agent will do, oldest first, so
+  # this page works either way and never creates one of its own.
+  defp default_agent(user_id) do
+    agents = Agents.list_agents(user_id, [])
+
+    Enum.find(agents, &(&1.name == "starter")) ||
+      Enum.min_by(agents, & &1.inserted_at, DateTime, fn -> nil end)
+  end
+
+  @impl true
+  def handle_event("key_copied", _params, socket) do
+    Analytics.capture("onboarding.key_copied", socket.assigns.current_user, %{
+      "source" => "console"
+    })
+
+    {:noreply, socket}
+  end
+
+  def handle_event("new_key", _params, socket) do
+    {:noreply, mint(socket, socket.assigns.current_user)}
+  end
+
+  @impl true
+  def handle_info({:sidebar_update, _user_id}, socket) do
+    {:noreply, refresh_reply(socket)}
+  end
+
+  def handle_info(_message, socket), do: {:noreply, socket}
+
+  # Cheap while it matters: once the reply is on screen the page stops asking,
+  # and a chatty run broadcasts on every log event.
+  defp refresh_reply(%{assigns: %{reply: reply}} = socket) when not is_nil(reply), do: socket
+
+  defp refresh_reply(socket) do
+    user = socket.assigns.current_user
+
+    case Activation.first_reply(user.id) do
+      nil ->
+        assign(socket, :sent?, Fountain.Conversations.conversation_counts(user.id).total > 0)
+
+      reply ->
+        Analytics.capture("onboarding.reply_shown", user, %{
+          "conversation_id" => reply.conversation_id,
+          "source" => "console"
+        })
+
+        socket |> assign(:reply, reply) |> assign(:sent?, true)
+    end
+  end
+
+  defp curl(assigns) do
+    Onboarding.curl(
+      base_url: assigns.base_url,
+      api_key: assigns.raw_key,
+      agent_id: assigns.agent && assigns.agent.id
+    )
+  end
+
+  defp typescript(assigns) do
+    Onboarding.typescript(
+      base_url: assigns.base_url,
+      api_key: assigns.raw_key,
+      agent: assigns.agent && assigns.agent.name
+    )
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="space-y-8 max-w-3xl">
+      <div>
+        <h1 class="text-2xl font-semibold">Your key, one request, the reply</h1>
+        <%!-- Not "you need nothing else": while BYO inference is the rule
+              (#1388), the banner under this line asks for one thing, and a
+              headline that contradicts the next paragraph reads as a lie. --%>
+        <p class="mt-1 text-sm text-[var(--color-text-secondary)]">
+          Everything below is ready to paste. No repository, no GitHub token, and nothing
+          to install.
+        </p>
+      </div>
+
+      <%!-- The one wall left on this path, and it is honest about itself. --%>
+      <.link
+        :if={@needs_credential?}
+        navigate={~p"/account/inference-credentials"}
+        class="block rounded-lg border border-amber-300 bg-amber-50 p-4 text-amber-900 hover:border-amber-500"
+      >
+        <p class="text-sm font-medium">This account has no inference credential yet</p>
+        <p class="mt-1 text-sm">
+          The request below reaches a sandbox, and the agent in it has no model to call.
+          Add an Anthropic, OpenAI or Google key first. It takes a minute, and Fountain
+          never bills you for those tokens.
+        </p>
+      </.link>
+
+      <%!-- 1. The key. Shown once, because only a hash is stored. --%>
+      <section class="rounded-lg border border-[var(--color-border)] p-5 space-y-3">
+        <h2 class="text-sm font-semibold">1. Your API key</h2>
+
+        <div :if={@raw_key} class="space-y-2">
+          <div class="flex items-center gap-2">
+            <code
+              id="start-api-key"
+              class="flex-1 bg-[var(--color-bg-2)] rounded border border-[var(--color-border)] px-3 py-2 text-sm font-mono break-all"
+            >{@raw_key}</code>
+            <.button
+              id="copy-start-api-key"
+              phx-hook="CopyToClipboard"
+              phx-click="key_copied"
+              data-target="start-api-key"
+              variant="secondary"
+            >
+              Copy
+            </.button>
+          </div>
+          <p class="text-xs text-[var(--color-text-muted)]">
+            Shown once. It is already in the request below, so you can skip straight to
+            step 2 and come back for it later from <.link navigate={~p"/api-keys"} class="underline">API keys</.link>.
+          </p>
+        </div>
+
+        <div :if={!@raw_key and @has_key?} class="space-y-2">
+          <p class="text-sm text-[var(--color-text-secondary)]">
+            This account already has a key, and a key is shown once. Create another to fill
+            in the request below.
+          </p>
+          <.button phx-click="new_key" variant="secondary">Create another key</.button>
+        </div>
+
+        <%!-- Neither a raw key nor a stored one. The mint happens on the
+              connected mount, so this is the dead render, a browser with no
+              JavaScript, or a mint that failed — and in none of those is it
+              true that the account already has a key. --%>
+        <div :if={!@raw_key and !@has_key?} class="space-y-2">
+          <p class="text-sm text-[var(--color-text-secondary)]">
+            This account has no API key yet.
+          </p>
+          <.button phx-click="new_key" variant="secondary">Create a key</.button>
+        </div>
+      </section>
+
+      <%!-- 2. The request. The same text docs/quickstart.md prints. --%>
+      <section class="rounded-lg border border-[var(--color-border)] p-5 space-y-4">
+        <div>
+          <h2 class="text-sm font-semibold">2. Send one request</h2>
+          <p :if={@agent} class="mt-1 text-sm text-[var(--color-text-secondary)]">
+            Against your <strong>{@agent.name}</strong>
+            agent. It starts a sandbox, runs the agent in it, and answers.
+          </p>
+          <p :if={!@agent} class="mt-1 text-sm text-[var(--color-text-secondary)]">
+            You have no agent yet, so the request below still has a placeholder in it.
+            <.link navigate={~p"/agents/new"} class="underline">Create one</.link>
+            and this page fills it in.
+          </p>
+        </div>
+
+        <div class="space-y-2">
+          <div class="flex items-center justify-between">
+            <span class="text-xs font-medium text-[var(--color-text-muted)]">curl</span>
+            <.button
+              id="copy-start-curl"
+              phx-hook="CopyToClipboard"
+              data-target="start-curl"
+              variant="ghost"
+            >
+              Copy
+            </.button>
+          </div>
+          <pre class="bg-[var(--color-bg-2)] rounded border border-[var(--color-border)] px-3 py-2 text-xs font-mono overflow-x-auto"><code id="start-curl">{curl(assigns)}</code></pre>
+        </div>
+
+        <div class="space-y-2">
+          <div class="flex items-center justify-between">
+            <span class="text-xs font-medium text-[var(--color-text-muted)]">
+              TypeScript SDK
+            </span>
+            <.button
+              id="copy-start-ts"
+              phx-hook="CopyToClipboard"
+              data-target="start-ts"
+              variant="ghost"
+            >
+              Copy
+            </.button>
+          </div>
+          <pre class="bg-[var(--color-bg-2)] rounded border border-[var(--color-border)] px-3 py-2 text-xs font-mono overflow-x-auto"><code id="start-ts">{typescript(assigns)}</code></pre>
+          <p class="text-xs text-[var(--color-text-muted)]">
+            <code class="font-mono">npm install @agentshit/fountain-sdk</code>
+          </p>
+        </div>
+      </section>
+
+      <%!-- 3. The reply, on this screen. --%>
+      <section class="rounded-lg border border-[var(--color-border)] p-5 space-y-3">
+        <h2 class="text-sm font-semibold">3. The reply</h2>
+
+        <div :if={@reply} class="space-y-3" id="start-reply">
+          <blockquote class="bg-[var(--color-bg-2)] rounded border border-[var(--color-border)] px-4 py-3 text-sm whitespace-pre-wrap">
+            {@reply.text}
+          </blockquote>
+          <p class="text-sm">
+            <strong>That reply came from your agent</strong>, running in a sandbox Fountain
+            started for it. That is the whole product.
+          </p>
+          <p :if={@conversations_app} class="text-sm">
+            <a href={Apps.conversation_url(@reply.conversation_id)} class="underline">
+              Watch the rest of it in the conversations app ↗
+            </a>
+          </p>
+        </div>
+
+        <p :if={!@reply and @sent?} class="text-sm text-[var(--color-text-secondary)]">
+          Your request is running. The first sandbox takes a few seconds to start. The
+          reply appears here.
+        </p>
+
+        <p :if={!@reply and !@sent?} class="text-sm text-[var(--color-text-secondary)]">
+          Nothing has run on this account yet. Send the request above and the reply
+          appears here.
+        </p>
+      </section>
+
+      <%!-- 4. The doors, below the fold. --%>
+      <section class="space-y-3">
+        <h2 class="text-lg font-medium">Where to go next</h2>
+        <div class="grid gap-4 sm:grid-cols-3">
+          <.link
+            navigate={~p"/account/inference-credentials"}
+            class="rounded-lg border border-[var(--color-border)] p-4 hover:border-[var(--color-border-strong)]"
+          >
+            <div class="text-sm font-medium">Add your own inference key</div>
+            <p class="mt-1 text-xs text-[var(--color-text-secondary)]">
+              Anthropic, OpenAI or Google. Yours wins over anything this instance supplies.
+            </p>
+          </.link>
+          <a
+            href="/docs/cli"
+            class="rounded-lg border border-[var(--color-border)] p-4 hover:border-[var(--color-border-strong)]"
+          >
+            <div class="text-sm font-medium">Your own agents, from a file</div>
+            <p class="mt-1 text-xs text-[var(--color-text-secondary)]">
+              <code class="font-mono">fountain apply</code>
+              takes a manifest of agents, environments and vaults.
+            </p>
+          </a>
+          <a
+            href="/docs/sdk"
+            class="rounded-lg border border-[var(--color-border)] p-4 hover:border-[var(--color-border-strong)]"
+          >
+            <div class="text-sm font-medium">The SDK, for real code</div>
+            <p class="mt-1 text-xs text-[var(--color-text-secondary)]">
+              TypeScript, Python, Elixir and Swift over the same API.
+            </p>
+          </a>
+        </div>
+      </section>
+    </div>
+    """
+  end
+end

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -701,6 +701,10 @@ defmodule FountainWeb.Router do
     # protects spend is in the context (ADR 0031), not here.
     live_session :authenticated,
       on_mount: [{FountainWeb.Live.Hooks, :require_authenticated_user}] do
+      # The verified landing (ADR 0038): a key, one request, the reply. Where
+      # `GET /users/confirm/:token` sends a person, and where the welcome
+      # email points. The dashboard is what they get afterwards.
+      live "/start", StartLive, :index
       live "/dashboard", DashboardLive.Index, :index
       live "/agents", AgentsLive.Index, :index
       live "/agents/new", AgentsLive.Form, :new

--- a/apps/fountain/test/fountain/activation_test.exs
+++ b/apps/fountain/test/fountain/activation_test.exs
@@ -133,6 +133,59 @@ defmodule Fountain.ActivationTest do
     end
   end
 
+  describe "onboarding_completed_at" do
+    test "is stamped at the first reply, not before it" do
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id)
+      turn = insert_turn(conv, %{status: "running"})
+
+      refute Repo.reload!(user).onboarding_completed_at
+
+      insert_log_event(conv, %{turn_id: turn.id, stream: "acp", data: acp_text("hello")})
+      {:ok, _} = Conversations._unsafe_update_turn(turn, %{status: "completed", ended_at: at(0)})
+
+      assert Repo.reload!(user).onboarding_completed_at
+    end
+
+    test "is not stamped by a turn that said nothing" do
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id)
+      turn = insert_turn(conv, %{status: "running"})
+
+      {:ok, _} = Conversations._unsafe_update_turn(turn, %{status: "completed", ended_at: at(0)})
+
+      refute Repo.reload!(user).onboarding_completed_at
+    end
+
+    test "an account that was already onboarded keeps its original timestamp" do
+      user = insert_verified_user()
+      earlier = at(48)
+      Repo.update!(Ecto.Changeset.change(user, onboarding_completed_at: earlier))
+
+      conv = insert_conversation(user_id: user.id)
+      turn = insert_turn(conv, %{status: "running"})
+      insert_log_event(conv, %{turn_id: turn.id, stream: "acp", data: acp_text("hello")})
+      {:ok, _} = Conversations._unsafe_update_turn(turn, %{status: "completed", ended_at: at(0)})
+
+      assert DateTime.compare(Repo.reload!(user).onboarding_completed_at, earlier) == :eq
+    end
+  end
+
+  describe "conversation_created/1" do
+    test "is safe for the first conversation and for every one after it" do
+      user = insert_verified_user()
+      first = insert_conversation(user_id: user.id)
+      second = insert_conversation(user_id: user.id)
+
+      assert Activation.conversation_created(first) == :ok
+      assert Activation.conversation_created(second) == :ok
+    end
+
+    test "does not raise for a conversation with no owner" do
+      assert Activation.conversation_created(%Fountain.Conversations.Conversation{}) == :ok
+    end
+  end
+
   describe "funnel_events/0" do
     test "names the four steps of the PostHog funnel, in order" do
       assert Activation.funnel_events() == [

--- a/apps/fountain/test/fountain/analytics_bridges_test.exs
+++ b/apps/fountain/test/fountain/analytics_bridges_test.exs
@@ -357,6 +357,92 @@ defmodule Fountain.AnalyticsBridgesTest do
     end
   end
 
+  # ADR 0038's funnel: verified, saw the landing, sent the request, got a
+  # reply. Two of its four steps leave from `Fountain.Activation`, and
+  # deliberately not from the landing page — a developer who copies the
+  # request and runs it after closing the tab still did the thing.
+  describe "activation" do
+    # `create_conversation/1` is the write both create paths share, which is
+    # why the seam is on it rather than on either path. The factory inserts
+    # directly, so these go through the real function.
+    defp create_conversation!(user) do
+      agent = insert_agent(user_id: user.id)
+      sandbox = insert_sandbox(user_id: user.id)
+
+      {:ok, conv} =
+        Conversations.create_conversation(%{
+          user_id: user.id,
+          agent_id: agent.id,
+          sandbox_id: sandbox.id,
+          runtime: agent.runtime,
+          status: "pending",
+          source: "api"
+        })
+
+      {conv, agent}
+    end
+
+    test "the account's first conversation is the request being sent" do
+      user = insert_verified_user()
+      forget_setup()
+
+      {conv, agent} = create_conversation!(user)
+
+      assert event = event_named("onboarding.request_sent")
+      assert event["distinct_id"] == user.id
+      assert event["properties"]["conversation_id"] == conv.id
+      assert event["properties"]["agent_id"] == agent.id
+    end
+
+    test "the account's second conversation is not" do
+      user = insert_verified_user()
+      create_conversation!(user)
+      forget_setup()
+
+      create_conversation!(user)
+
+      refute event_named("onboarding.request_sent")
+    end
+
+    test "a turn that ends with a reply is the activation" do
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id)
+      turn = insert_turn(conv, %{status: "running"})
+
+      insert_log_event(conv, %{
+        turn_id: turn.id,
+        stream: "acp",
+        data:
+          Jason.encode!(%{
+            "jsonrpc" => "2.0",
+            "method" => "session/update",
+            "params" => %{
+              "sessionId" => "s",
+              "update" => %{
+                "sessionUpdate" => "agent_message_chunk",
+                "content" => %{"type" => "text", "text" => "Linux, /work."}
+              }
+            }
+          })
+      })
+
+      forget_setup()
+
+      {:ok, _} =
+        Conversations._unsafe_update_turn(turn, %{
+          status: "completed",
+          ended_at: DateTime.utc_now() |> DateTime.truncate(:second)
+        })
+
+      assert event = event_named("activation.first_reply")
+      assert event["distinct_id"] == user.id
+      assert event["properties"]["conversation_id"] == conv.id
+      assert is_number(event["properties"]["hours_since_verified"])
+      # The reply itself is agent output, and agent output never leaves.
+      refute inspect(event) =~ "Linux, /work."
+    end
+  end
+
   describe "with capture off" do
     setup do
       Application.put_env(:fountain, :analytics_enabled, false)

--- a/apps/fountain/test/fountain/onboarding_test.exs
+++ b/apps/fountain/test/fountain/onboarding_test.exs
@@ -1,0 +1,110 @@
+defmodule Fountain.OnboardingTest do
+  @moduledoc """
+  The first request has one source (ADR 0038 decision 5). These tests are what
+  stops the landing page and `docs/quickstart.md` from drifting apart, which
+  is the failure the shared file exists to prevent.
+  """
+  use ExUnit.Case, async: true
+
+  alias Fountain.Onboarding
+
+  @repo_root Path.expand("../../../..", __DIR__)
+
+  describe "the templates" do
+    test "are the files the manual includes, verbatim" do
+      for {render, path} <- [
+            {Onboarding.curl_template(), "docs/snippets/first-request.sh"},
+            {Onboarding.typescript_template(), "docs/snippets/first-request.ts"}
+          ] do
+        on_disk = @repo_root |> Path.join(path) |> File.read!() |> String.trim_trailing()
+        assert render == on_disk, "#{path} is not what Fountain.Onboarding serves"
+      end
+    end
+
+    test "both send the same prompt" do
+      assert Onboarding.curl_template() =~ Onboarding.prompt()
+      assert Onboarding.typescript_template() =~ Onboarding.prompt()
+    end
+
+    test "the curl posts a conversation and the TypeScript runs the SDK" do
+      assert Onboarding.curl_template() =~ "/api/conversations"
+      assert Onboarding.curl_template() =~ "Authorization: Bearer"
+      assert Onboarding.typescript_template() =~ "@agentshit/fountain-sdk"
+      assert Onboarding.typescript_template() =~ "fountain.run("
+    end
+
+    test "carry every placeholder between them, so the manual reads as instructions" do
+      both = Onboarding.curl_template() <> Onboarding.typescript_template()
+
+      for token <- Onboarding.placeholders() do
+        assert String.contains?(both, token), "#{token} is in placeholders/0 but in no snippet"
+      end
+    end
+  end
+
+  describe "curl/1" do
+    test "substitutes the key, the agent and the instance" do
+      rendered =
+        Onboarding.curl(
+          base_url: "https://fountain.example",
+          api_key: "ftn_abc123",
+          agent_id: "agent-uuid"
+        )
+
+      assert rendered =~ "https://fountain.example/api/conversations"
+      assert rendered =~ "Bearer ftn_abc123"
+      assert rendered =~ ~s(\\"agent-uuid\\")
+    end
+
+    test "leaves what it was not given alone" do
+      rendered = Onboarding.curl(base_url: "https://fountain.example")
+
+      assert rendered =~ "$FOUNTAIN_API_KEY"
+      assert rendered =~ "$FOUNTAIN_AGENT_ID"
+      refute rendered =~ "$FOUNTAIN_BASE_URL"
+    end
+  end
+
+  describe "typescript/1" do
+    test "names the agent and fills the constructor a copied snippet needs" do
+      rendered =
+        Onboarding.typescript(
+          base_url: "https://fountain.example",
+          api_key: "ftn_abc123",
+          agent: "starter"
+        )
+
+      assert rendered =~ ~S|{ agent: "starter" }|
+
+      assert rendered =~
+               ~S|new Fountain({ apiKey: "ftn_abc123", baseUrl: "https://fountain.example" })|
+
+      refute rendered =~ "new Fountain()"
+    end
+
+    test "keeps the bare constructor when there is nothing to put in it" do
+      assert Onboarding.typescript(agent: "starter") =~ "new Fountain()"
+    end
+  end
+
+  # The #884 failure: a compile-time read of a file the Docker build stage does
+  # not COPY kills `mix release`, no image is built, CI stays green and the
+  # deploy silently never happens. The snippets live under docs/ so that the
+  # existing line covers them; this is what says so out loud.
+  test "the Docker build stage copies what this module reads at compile time" do
+    dockerfile = @repo_root |> Path.join("Dockerfile") |> File.read!()
+
+    assert dockerfile =~ ~r/^COPY docs \.\/docs$/m,
+           "Fountain.Onboarding reads docs/snippets/ at compile time"
+  end
+
+  test "a fully substituted render carries no placeholder into anyone's terminal" do
+    rendered =
+      Onboarding.curl(base_url: "https://x.test", api_key: "ftn_k", agent_id: "a") <>
+        Onboarding.typescript(base_url: "https://x.test", api_key: "ftn_k", agent: "starter")
+
+    for token <- Onboarding.placeholders() do
+      refute String.contains?(rendered, token), "#{token} survived substitution"
+    end
+  end
+end

--- a/apps/fountain/test/fountain_web/controllers/docs_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/docs_controller_test.exs
@@ -26,14 +26,23 @@ defmodule FountainWeb.DocsControllerTest do
       assert body =~ ~s(href="/docs/integrations/sprites-contract")
     end
 
-    test "renders the admonition as a blockquote, not its raw source syntax", %{conn: conn} do
+    test "the home page has no raw admonition source in it", %{conn: conn} do
       body = conn |> get(~p"/docs") |> html_response(200)
-      assert body =~ "In a hurry?"
       refute body =~ "!!!"
     end
   end
 
   describe "GET /docs/:page" do
+    # The home page carried the admonition this used to read until #1390 made
+    # its "in a hurry" box a snippet include — an admonition indents its body,
+    # and an indented `--8<--` is left unexpanded. The quickstart carries one
+    # now, so the rendering is still pinned to a real page.
+    test "renders an admonition as a blockquote, not its raw source syntax", %{conn: conn} do
+      body = conn |> get(~p"/docs/quickstart") |> html_response(200)
+      assert body =~ "Whose model key"
+      refute body =~ "!!!"
+    end
+
     test "serves a top-level page", %{conn: conn} do
       body = conn |> get(~p"/docs/setup") |> html_response(200)
       assert body =~ "Setup"

--- a/apps/fountain/test/fountain_web/controllers/email_verification_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/email_verification_controller_test.exs
@@ -8,7 +8,7 @@ defmodule FountainWeb.EmailVerificationControllerTest do
   alias Fountain.Workers.WelcomeEmail
 
   describe "GET /users/confirm/:token" do
-    test "verifies email, sets session, and redirects to the dashboard for a new user", %{
+    test "verifies email, sets session, and redirects to the verified landing", %{
       conn: conn
     } do
       user = insert_user()
@@ -17,7 +17,9 @@ defmodule FountainWeb.EmailVerificationControllerTest do
       token = Phoenix.Token.sign(FountainWeb.Endpoint, "email_verification", user.id)
       conn = get(conn, ~p"/users/confirm/#{token}")
 
-      assert redirected_to(conn) == ~p"/dashboard"
+      # ADR 0038: the first screen after verification is the landing that
+      # hands over a key and one request, not the dashboard.
+      assert redirected_to(conn) == ~p"/start"
       assert get_session(conn, :user_id) == user.id
 
       # User should be verified in DB

--- a/apps/fountain/test/fountain_web/controllers/oauth_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/oauth_controller_test.exs
@@ -54,7 +54,9 @@ defmodule FountainWeb.UeberauthControllerTest do
   end
 
   describe "callback/2 — success (new user)" do
-    test "creates user, sets session, redirects to the dashboard", %{conn: conn} do
+    # An OAuth signup is created verified, so this is its first screen after
+    # verification too (ADR 0038): the landing, not the dashboard.
+    test "creates user, sets session, redirects to the verified landing", %{conn: conn} do
       email = "github_new_#{System.unique_integer()}@example.com"
       auth = github_auth(email)
 
@@ -64,7 +66,7 @@ defmodule FountainWeb.UeberauthControllerTest do
         |> assign_auth(auth)
         |> get(~p"/auth/oauth/github/callback")
 
-      assert redirected_to(conn) == ~p"/dashboard"
+      assert redirected_to(conn) == ~p"/start"
       user_id = get_session(conn, :user_id)
       assert user_id
 

--- a/apps/fountain/test/fountain_web/live/dashboard_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/dashboard_live_test.exs
@@ -30,34 +30,19 @@ defmodule FountainWeb.DashboardLiveTest do
     {:ok, conn: login_user(conn, user), user: user}
   end
 
-  test "a brand-new account is told what is missing, and where to do it", %{conn: conn} do
+  # The three-item checklist went with ADR 0038. What is left is one line
+  # pointing at the landing, and it is about a reply rather than about things
+  # existing.
+  test "an account that has never had a reply is pointed at the landing", %{conn: conn} do
     {:ok, _lv, html} = live(conn, ~p"/dashboard")
 
-    assert html =~ "Before an agent can run"
-    assert html =~ "An inference credential"
-    assert html =~ "/account/inference-credentials"
-    assert html =~ "https://apps.test/convs/#/new"
-
-    # The agent step arrives ticked: verification plants the starter agent
-    # (ADR 0038), so the item this list used to send a new account away to
-    # build is the one it now already has. #1390 replaces the checklist.
-    assert html =~ "An agent"
-    refute html =~ "/agents/new"
+    assert html =~ "Nothing has answered on this account yet"
+    assert html =~ "/start"
+    refute html =~ "Before an agent can run"
   end
 
-  test "a step that is done is ticked and loses its call to action", %{conn: conn, user: user} do
+  test "owning an agent and a credential is not what clears it", %{conn: conn, user: user} do
     insert_agent(user_id: user.id)
-
-    {:ok, _lv, html} = live(conn, ~p"/dashboard")
-
-    assert html =~ "Before an agent can run"
-    refute html =~ "/agents/new"
-  end
-
-  test "the checklist disappears once there is nothing left in it", %{conn: conn, user: user} do
-    insert_agent(user_id: user.id)
-    insert_conversation(user_id: user.id)
-
     {:ok, dek} = Fountain.Crypto.load_tenant_key(user.id)
 
     {:ok, _} =
@@ -71,12 +56,26 @@ defmodule FountainWeb.DashboardLiveTest do
 
     {:ok, _lv, html} = live(conn, ~p"/dashboard")
 
-    refute html =~ "Before an agent can run"
+    assert html =~ "Nothing has answered on this account yet"
   end
 
-  # The wizard's last step used to stamp this; the funnel's "onboarded" stage
-  # reads it, so the console has to keep it true (#867).
-  test "an account with a credential and an agent is marked onboarded", %{conn: conn, user: user} do
+  test "a reply clears it", %{conn: conn, user: user} do
+    conv = insert_conversation(user_id: user.id)
+
+    insert_turn(conv, %{
+      status: "completed",
+      reply_text: "the agent answered",
+      ended_at: DateTime.utc_now() |> DateTime.truncate(:second)
+    })
+
+    {:ok, _lv, html} = live(conn, ~p"/dashboard")
+
+    refute html =~ "Nothing has answered on this account yet"
+  end
+
+  # ADR 0038 decision 7: `onboarding_completed_at` is stamped at the first
+  # reply by `Fountain.Activation`, not by this mount when three things exist.
+  test "the dashboard no longer stamps onboarding", %{conn: conn, user: user} do
     refute user.onboarding_completed_at
 
     insert_agent(user_id: user.id)
@@ -90,14 +89,6 @@ defmodule FountainWeb.DashboardLiveTest do
         "sk-ant-test-key-000000000000",
         actor: "ui"
       )
-
-    {:ok, _lv, _html} = live(conn, ~p"/dashboard")
-
-    assert Fountain.Accounts.get_user(user.id).onboarding_completed_at
-  end
-
-  test "an account still missing a piece is not", %{conn: conn, user: user} do
-    insert_agent(user_id: user.id)
 
     {:ok, _lv, _html} = live(conn, ~p"/dashboard")
 

--- a/apps/fountain/test/fountain_web/live/start_live_platform_test.exs
+++ b/apps/fountain/test/fountain_web/live/start_live_platform_test.exs
@@ -1,0 +1,52 @@
+defmodule FountainWeb.StartLivePlatformTest do
+  @moduledoc """
+  The verified landing against platform inference (#1388 + #1390).
+
+  This is the premise ADR 0038 rests on: an account that has supplied nothing
+  but an email address can send the request on the landing and get a reply.
+  The page asks `InferenceCredentials.select/2` rather than "does this tenant
+  hold a key", so a deployment that turns a platform key on stops warning
+  about a wall that is no longer there.
+
+  `async: false`, and in its own module for that reason: platform keys live in
+  the global application environment, and an async module that writes it races
+  every module that reads it (#1214).
+  """
+  use FountainWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  setup %{conn: conn} do
+    original =
+      for key <- [:platform_anthropic_api_key, :platform_openai_api_key],
+          do: {key, Application.get_env(:fountain, key)}
+
+    on_exit(fn ->
+      Enum.each(original, fn
+        {key, nil} -> Application.delete_env(:fountain, key)
+        {key, value} -> Application.put_env(:fountain, key, value)
+      end)
+    end)
+
+    user = insert_verified_user()
+    {:ok, conn: login_user(conn, user), user: user}
+  end
+
+  test "with a platform key for the agent's provider, the page warns about nothing",
+       %{conn: conn} do
+    Application.put_env(:fountain, :platform_anthropic_api_key, "sk-platform")
+
+    {:ok, _lv, html} = live(conn, ~p"/start")
+
+    refute html =~ "no inference credential yet"
+  end
+
+  test "a platform key for another provider does not cover a claude agent", %{conn: conn} do
+    Application.delete_env(:fountain, :platform_anthropic_api_key)
+    Application.put_env(:fountain, :platform_openai_api_key, "sk-platform")
+
+    {:ok, _lv, html} = live(conn, ~p"/start")
+
+    assert html =~ "no inference credential yet"
+  end
+end

--- a/apps/fountain/test/fountain_web/live/start_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/start_live_test.exs
@@ -1,0 +1,188 @@
+defmodule FountainWeb.StartLiveTest do
+  @moduledoc """
+  `/start`, the verified landing (ADR 0038, #1390): a key, one request, the
+  reply on the same screen.
+  """
+  use FountainWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias Fountain.{Accounts, Onboarding}
+
+  setup %{conn: conn} do
+    user = insert_verified_user()
+    {:ok, conn: login_user(conn, user), user: user}
+  end
+
+  defp reply!(user, text \\ "I am on Linux, in /work.") do
+    conv = insert_conversation(user_id: user.id)
+
+    turn =
+      insert_turn(conv, %{
+        status: "completed",
+        reply_text: text,
+        ended_at: DateTime.utc_now() |> DateTime.truncate(:second)
+      })
+
+    {conv, turn}
+  end
+
+  describe "the key" do
+    test "is minted on the first view and shown once", %{conn: conn, user: user} do
+      assert Accounts.list_api_keys(user.id) == []
+
+      {:ok, _lv, html} = live(conn, ~p"/start")
+
+      assert [key] = Accounts.list_api_keys(user.id)
+      assert html =~ key.key_prefix
+      assert html =~ "Shown once"
+    end
+
+    test "is not silently minted a second time on a later view", %{conn: conn, user: user} do
+      {:ok, _lv, _html} = live(conn, ~p"/start")
+      assert length(Accounts.list_api_keys(user.id)) == 1
+
+      {:ok, lv, html} = live(conn, ~p"/start")
+
+      assert length(Accounts.list_api_keys(user.id)) == 1
+      assert html =~ "a key is shown once"
+
+      # ...but the page can hand out another when asked.
+      html = lv |> element("button", "Create another key") |> render_click()
+      assert length(Accounts.list_api_keys(user.id)) == 2
+      assert html =~ "Shown once"
+    end
+
+    # Found by walking the real path: the mint happens on the connected mount,
+    # so the dead render has no raw key — and it used to tell an account with
+    # no key at all that it already had one.
+    test "the dead render does not claim a key that does not exist", %{conn: conn} do
+      html = conn |> Phoenix.ConnTest.get(~p"/start") |> Phoenix.ConnTest.html_response(200)
+
+      assert html =~ "This account has no API key yet"
+      refute html =~ "already has a key"
+    end
+
+    test "the mint is attributed to the console, not to the system", %{conn: conn, user: user} do
+      {:ok, _lv, _html} = live(conn, ~p"/start")
+
+      events = Fountain.Audit.list_recent_for_user(user.id)
+      mint = Enum.find(events, &(&1.action == "api_key.created"))
+
+      assert mint.actor == "ui"
+    end
+  end
+
+  # BYO inference (ADR 0008) is still the one wall on this path. #1388 is what
+  # removes it; until then the page says so rather than letting a pasted
+  # request fail with a refusal the reader has to decode.
+  describe "the inference credential" do
+    test "an account with none is told before it pastes anything", %{conn: conn} do
+      {:ok, _lv, html} = live(conn, ~p"/start")
+
+      assert html =~ "no inference credential yet"
+      assert html =~ "/account/inference-credentials"
+    end
+
+    test "an account with one is not", %{conn: conn, user: user} do
+      {:ok, dek} = Fountain.Crypto.load_tenant_key(user.id)
+
+      {:ok, _} =
+        Fountain.InferenceCredentials.put_credential(
+          user.id,
+          dek,
+          :anthropic_api_key,
+          "sk-ant-test-key-000000000000",
+          actor: "ui"
+        )
+
+      {:ok, _lv, html} = live(conn, ~p"/start")
+
+      refute html =~ "no inference credential yet"
+    end
+  end
+
+  describe "the request" do
+    test "carries the real key and the account's agent", %{conn: conn, user: user} do
+      agent = insert_agent(user_id: user.id, name: "starter")
+
+      {:ok, _lv, html} = live(conn, ~p"/start")
+
+      assert html =~ agent.id
+      assert html =~ "/api/conversations"
+      assert html =~ "starter"
+
+      for token <- Onboarding.placeholders() do
+        refute html =~ token
+      end
+    end
+
+    test "says so plainly when there is no agent to run against", %{conn: conn} do
+      {:ok, _lv, html} = live(conn, ~p"/start")
+
+      assert html =~ "You have no agent yet"
+      assert html =~ "/agents/new"
+    end
+
+    test "prefers a starter agent over the account's other agents", %{conn: conn, user: user} do
+      _other = insert_agent(user_id: user.id, name: "aardvark")
+      starter = insert_agent(user_id: user.id, name: "starter")
+
+      {:ok, _lv, html} = live(conn, ~p"/start")
+
+      assert html =~ starter.id
+    end
+  end
+
+  describe "the reply" do
+    test "says nothing has run before anything has", %{conn: conn} do
+      {:ok, _lv, html} = live(conn, ~p"/start")
+
+      assert html =~ "Nothing has run on this account yet"
+    end
+
+    test "says the request is running once a conversation exists", %{conn: conn, user: user} do
+      insert_conversation(user_id: user.id)
+
+      {:ok, _lv, html} = live(conn, ~p"/start")
+
+      assert html =~ "Your request is running"
+    end
+
+    test "shows the account's first reply on the page", %{conn: conn, user: user} do
+      {conv, _turn} = reply!(user)
+
+      {:ok, _lv, html} = live(conn, ~p"/start")
+
+      assert html =~ "I am on Linux, in /work."
+      assert html =~ "That reply came from your agent"
+      assert html =~ conv.id
+    end
+
+    test "arrives without a reload when the account is nudged", %{conn: conn, user: user} do
+      {:ok, lv, html} = live(conn, ~p"/start")
+      refute html =~ "That reply came from your agent"
+
+      reply!(user, "Ubuntu, /work/app.")
+      send(lv.pid, {:sidebar_update, user.id})
+
+      html = render(lv)
+      assert html =~ "Ubuntu, /work/app."
+      assert html =~ "That reply came from your agent"
+    end
+  end
+
+  test "the three doors are below the fold", %{conn: conn} do
+    {:ok, _lv, html} = live(conn, ~p"/start")
+
+    assert html =~ "/account/inference-credentials"
+    assert html =~ "/docs/cli"
+    assert html =~ "/docs/sdk"
+  end
+
+  test "an unauthenticated visitor is sent to login", %{conn: _conn} do
+    conn = Phoenix.ConnTest.build_conn()
+    assert {:error, {:redirect, %{to: path}}} = live(conn, ~p"/start")
+    assert path =~ "/auth/login"
+  end
+end

--- a/apps/fountain/test/fountain_web/live/start_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/start_live_test.exs
@@ -5,6 +5,7 @@ defmodule FountainWeb.StartLiveTest do
   """
   use FountainWeb.ConnCase, async: true
 
+  import Ecto.Query
   import Phoenix.LiveViewTest
 
   alias Fountain.{Accounts, Onboarding}
@@ -103,8 +104,12 @@ defmodule FountainWeb.StartLiveTest do
   end
 
   describe "the request" do
+    # #1389 plants a `starter` agent at verification, so `insert_verified_user/0`
+    # already owns one and this page has something to point at from the moment
+    # an account exists.
     test "carries the real key and the account's agent", %{conn: conn, user: user} do
-      agent = insert_agent(user_id: user.id, name: "starter")
+      agent = Fountain.Agents.get_agent_by_name("starter", user.id)
+      assert agent, "verification should have planted a starter agent"
 
       {:ok, _lv, html} = live(conn, ~p"/start")
 
@@ -117,16 +122,21 @@ defmodule FountainWeb.StartLiveTest do
       end
     end
 
-    test "says so plainly when there is no agent to run against", %{conn: conn} do
+    # An account can still reach this page with nothing: the starter is an
+    # ordinary agent and may be deleted, and an account verified before #1389
+    # never had one.
+    test "says so plainly when there is no agent to run against", %{conn: conn, user: user} do
+      Fountain.Repo.delete_all(from a in Fountain.Agents.Agent, where: a.user_id == ^user.id)
+
       {:ok, _lv, html} = live(conn, ~p"/start")
 
       assert html =~ "You have no agent yet"
       assert html =~ "/agents/new"
     end
 
-    test "prefers a starter agent over the account's other agents", %{conn: conn, user: user} do
+    test "prefers the starter agent over the account's other agents", %{conn: conn, user: user} do
       _other = insert_agent(user_id: user.id, name: "aardvark")
-      starter = insert_agent(user_id: user.id, name: "starter")
+      starter = Fountain.Agents.get_agent_by_name("starter", user.id)
 
       {:ok, _lv, html} = live(conn, ~p"/start")
 

--- a/decisions/0038-onboarding-first-reply.md
+++ b/decisions/0038-onboarding-first-reply.md
@@ -44,10 +44,17 @@ inference up would make the opening credit buy less of the one thing it was
 granted to buy, which is the reply this ADR is about. A future decision may
 change that; a passing thought about margin should not.
 
-Not built: the verified landing, the CLI commands and the field cleanup.
-`onboarding_completed_at` is still stamped by the dashboard checklist (#1390
-moves the stamp to the seam `Fountain.Activation.capture_first_reply/2`
-marks).`Fountain.Activation.capture_first_reply/2` marks).
+Decision 5: `FountainWeb.StartLive` is the verified landing at `/start`. It
+mints an API key and shows it once, prints one request against the account's
+agent from the single source `Fountain.Onboarding` shares with
+`docs/quickstart.md`, and shows the reply inline. Both signup routes land
+there. The dashboard checklist is gone.
+
+The first half of decision 7: `onboarding_completed_at` is stamped by
+`Fountain.Activation` at the first reply, not by a console page.
+
+Not built: the CLI commands (#1391) and the second half of decision 7,
+dropping `onboarding_state` (#1393).
 
 Amends [0008](0008-byo-inference-credentials.md): Fountain will hold platform
 inference keys. Leans on [0031](0031-credits-are-the-product.md) (the opening

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,16 +8,19 @@ It is an API first. Your app reaches it over a protocol you already speak, or
 through an SDK. The person who uses your app need never learn that an agent
 is there.
 
-!!! tip "In a hurry?"
-    Install the CLI and log in. For your own instance, set `FOUNTAIN_BASE_URL`
-    first, because the CLI defaults to the hosted one.
-    ```sh
-    brew install BinaryBourbon/tap/fountain
-    fountain auth login
-    fountain auth whoami
-    ```
-    The CLI now works, and you have no agent to run yet. The
-    [quickstart](quickstart.md) starts the first one.
+The whole product fits in one request. It gets a reply from an agent in its
+own sandbox. Your API key and your agent's id are on your start page, and that
+page puts both into this request for you.
+
+```sh
+--8<-- "docs/snippets/first-request.sh"
+```
+
+The reply arrives on that same page. The [quickstart](quickstart.md) is those
+three steps in full.
+
+<!-- The snippet include above must start a line: an admonition indents its
+     body, and an indented include is left unexpanded. -->
 
 ## The problem
 
@@ -69,9 +72,9 @@ in full.
 
 ## Start here
 
-- **[Run your first agent](quickstart.md)** applies a small manifest and
-  starts an agent against a public repository. It needs no GitHub token or
-  setup script. Start here if Fountain is new to you.
+- **[Run your first agent](quickstart.md)** is a key and one request. It
+  needs no repository, no GitHub token and no install. Start here if Fountain
+  is new to you.
 - **[The guided tour](tour.md)** builds an agent that clones a repo, changes it
   and opens a pull request. A second turn then lands a revision on the same PR.
   The tour is about forty lines. It is the step after the quickstart.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,18 +1,75 @@
 # Run your first agent
 
-This is the shortest path that demonstrates Fountain's whole job. An agent
-starts in a sandbox with a real repository, inspects the checkout, and streams
-its answer to your terminal.
+One request gets a reply from an agent in its own sandbox. You need an
+account, an inference credential, and nothing else. No repository, no GitHub
+token, and no install.
 
-The example uses Fountain's public repository. It needs no GitHub token, setup
-script, package install, or Vault.
+## 1. Your key and your agent
 
-## Choose where Fountain runs
+Your start page holds an API key and the id of your agent. The page adds both
+to the request below, and it shows a key once. Copy the key there.
 
-Run the server yourself, or use the hosted server. The manifest and the agent
-run are the same on both.
+```sh
+export FOUNTAIN_BASE_URL="https://managoat.com"
+export FOUNTAIN_API_KEY="the key from your start page"
+export FOUNTAIN_AGENT_ID="the agent id from your start page"
+```
 
-### Run your own server
+For your own server, use that server's address as `FOUNTAIN_BASE_URL`.
+
+!!! note "One credential first"
+
+    An agent calls a model, and today the model key is yours. Add an
+    Anthropic, OpenAI or Google key under Account, then Inference keys. Your
+    start page says so too, and the request answers as soon as a key exists.
+
+## 2. Send the request
+
+```sh
+--8<-- "docs/snippets/first-request.sh"
+```
+
+Fountain starts a sandbox, starts the agent in it, and answers. The response
+holds the conversation `id`.
+
+## 3. Read the reply
+
+The reply arrives on your start page. For a terminal, read the conversation
+stream with the id from step 2.
+
+```sh
+curl -N -H "Authorization: Bearer $FOUNTAIN_API_KEY" \
+  "$FOUNTAIN_BASE_URL/api/conversations/CONVERSATION_ID/stream?blocks=true"
+```
+
+That reply came from your agent, on a machine that Fountain operates for you.
+Fountain counts that moment as activation. It is the whole product, in one
+request.
+
+## The same request from the SDK
+
+```bash
+npm install @agentshit/fountain-sdk
+```
+
+```ts
+--8<-- "docs/snippets/first-request.ts"
+```
+
+`new Fountain()` reads `FOUNTAIN_API_KEY` and `FOUNTAIN_BASE_URL` from the
+environment, exactly as the CLI does. There are
+[Python](python-sdk.md), [Elixir](elixir-sdk.md) and [Swift](swift-sdk.md)
+clients over the same API.
+
+## Where to go next
+
+The [guided tour](tour.md) is the second page. It builds an agent that clones
+your repository, changes it, and opens a pull request.
+
+The rest of this page is the same first run from the CLI, and the way to run
+the server yourself.
+
+## Run your own server
 
 You need Docker, OpenSSL, and a sandbox provider token. The Compose file runs
 Postgres. The example below uses Sprites as the sandbox provider.
@@ -36,12 +93,6 @@ The Compose defaults self-verify the first account and make it the admin.
 Create that account before you expose the server to another network. The
 [deployment guide](guides/operate/deploy.md) shows how to verify readiness,
 close registration, and configure the other sandbox providers.
-
-### Use the hosted server
-
-Create an account on [managoat.com](https://managoat.com), then add an
-Anthropic credential under Account, then Inference keys. The hosted
-server supplies the control plane and sandbox provider.
 
 ## Install and authenticate the CLI
 
@@ -77,9 +128,11 @@ fountain auth login
 your browser. Approve the device there. The CLI saves the server URL and an
 API key, so the commands below need no server flag.
 
-## Apply and run
+## Apply and run your own agent
 
-Download the small manifest, apply it, and call the agent by name.
+The request above runs the agent your account already has. A manifest
+describes agents of your own, with the machine each one gets. Download the
+small manifest, apply it, and call the agent by name.
 
 ```sh
 curl -fsSLo fountain.yml \

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,8 +1,7 @@
 # Run your first agent
 
 One request gets a reply from an agent in its own sandbox. You need an
-account, an inference credential, and nothing else. No repository, no GitHub
-token, and no install.
+account and nothing else. No repository, no GitHub token, and no install.
 
 ## 1. Your key and your agent
 
@@ -17,11 +16,12 @@ export FOUNTAIN_AGENT_ID="the agent id from your start page"
 
 For your own server, use that server's address as `FOUNTAIN_BASE_URL`.
 
-!!! note "One credential first"
+!!! note "Whose model key"
 
-    An agent calls a model, and today the model key is yours. Add an
-    Anthropic, OpenAI or Google key under Account, then Inference keys. Your
-    start page says so too, and the request answers as soon as a key exists.
+    An agent calls a model. Fountain runs your agent on this deployment's own
+    model key while your account has none. Your key always wins when you add
+    one, under Account, then Inference keys. A server with no key of its own
+    needs yours first, and your start page says which case you are in.
 
 ## 2. Send the request
 

--- a/docs/snippets/first-request.sh
+++ b/docs/snippets/first-request.sh
@@ -1,0 +1,4 @@
+curl -sS -X POST "$FOUNTAIN_BASE_URL/api/conversations" \
+  -H "Authorization: Bearer $FOUNTAIN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d "{\"agent_id\": \"$FOUNTAIN_AGENT_ID\", \"prompt\": \"Which operating system and working directory are you in? Answer in one sentence.\"}"

--- a/docs/snippets/first-request.ts
+++ b/docs/snippets/first-request.ts
@@ -1,0 +1,9 @@
+import { Fountain } from "@agentshit/fountain-sdk";
+
+const fountain = new Fountain();
+const run = await fountain.run(
+  "Which operating system and working directory are you in? Answer in one sentence.",
+  { agent: "$FOUNTAIN_AGENT_NAME" },
+);
+
+console.log(run.text);

--- a/docs/tour.md
+++ b/docs/tour.md
@@ -8,6 +8,10 @@ runs.
 The tour is about forty lines. Each number and each output below came from a
 real run.
 
+This is the second page. The [quickstart](quickstart.md) is the first one: a
+key and one request, with no repository and no token. Read it first if nothing
+has answered on your account yet.
+
 ## What you must have
 
 - A Fountain API key (Account, then API keys, or `fountain auth login`).

--- a/ee/lib/fountain/emails/credits_emails.ex
+++ b/ee/lib/fountain/emails/credits_emails.ex
@@ -37,18 +37,23 @@ defmodule Fountain.Emails.CreditsEmails do
   def deliver_welcome_email(%User{} = user) do
     base_url = Fountain.PublicUrl.base()
 
-    # The console's dashboard, whatever the account has set up: it is the
-    # thing that says what is still missing (#867).
-    start_url = "#{base_url}/dashboard"
+    # The verified landing (ADR 0038): a key, one request, the reply. Not the
+    # dashboard, which used to greet a new account with a checklist of things
+    # to go and set up before anything could answer.
+    start_url = "#{base_url}/start"
 
     opening_text = welcome_opening_phrase(user)
+    # The same request the landing shows and the manual prints, with its
+    # placeholders left in. The key is never in an email; the email says
+    # where the key is.
+    request = Fountain.Onboarding.curl(base_url: base_url)
 
     new()
     |> from(UserEmails.from_address())
     |> to({user.email, user.email})
     |> subject("Welcome to #{brand()}")
-    |> html_body(welcome_html(start_url, opening_text))
-    |> text_body(welcome_text(start_url, opening_text))
+    |> html_body(welcome_html(start_url, opening_text, request))
+    |> text_body(welcome_text(start_url, opening_text, request))
     |> Mailer.deliver()
   end
 
@@ -65,21 +70,26 @@ defmodule Fountain.Emails.CreditsEmails do
     end
   end
 
-  defp welcome_html(start_url, opening_text) do
+  defp welcome_html(start_url, opening_text, request) do
     """
     <!DOCTYPE html>
     <html>
     <body style="font-family: sans-serif; max-width: 600px; margin: 0 auto; padding: 24px;">
       <h2>Welcome to #{brand()}</h2>
       <p>
-        Your account is verified and ready. Set up an agent, give it an
-        environment, and start a conversation — it runs in an isolated sandbox
-        and streams back live.
+        Your account is verified. One request gets you a reply from an agent
+        running in its own sandbox — no repository, no token, no install.
+      </p>
+      <pre style="background: #f4f4f5; border-radius: 6px; padding: 12px; font-size: 12px; overflow-x: auto;"><code>#{Phoenix.HTML.html_escape(request) |> Phoenix.HTML.safe_to_string()}</code></pre>
+      <p>
+        Your API key and your agent's id are on your start page, already
+        filled into that request. Keys are shown once, so open it when you are
+        ready to paste.
       </p>
       <p style="margin: 32px 0;">
         <a href="#{start_url}"
            style="background: #18181b; color: #fff; padding: 12px 24px; border-radius: 6px; text-decoration: none; font-size: 14px;">
-          Get started
+          Get your key
         </a>
       </p>
       #{if opening_text, do: "<p>#{opening_text}</p>", else: ""}
@@ -92,13 +102,18 @@ defmodule Fountain.Emails.CreditsEmails do
     """
   end
 
-  defp welcome_text(start_url, opening_text) do
+  defp welcome_text(start_url, opening_text, request) do
     """
     Welcome to #{brand()}
 
-    Your account is verified and ready. Set up an agent, give it an
-    environment, and start a conversation — it runs in an isolated sandbox
-    and streams back live:
+    Your account is verified. One request gets you a reply from an agent
+    running in its own sandbox — no repository, no token, no install.
+
+    #{request}
+
+    Your API key and your agent's id are on your start page, already filled
+    into that request. Keys are shown once, so open it when you are ready to
+    paste:
 
     #{start_url}
     #{if opening_text, do: "\n#{opening_text}\n", else: ""}

--- a/ee/test/fountain/emails/credits_emails_test.exs
+++ b/ee/test/fountain/emails/credits_emails_test.exs
@@ -6,7 +6,9 @@ defmodule Fountain.Emails.CreditsEmailsTest do
   alias Fountain.Emails.CreditsEmails
 
   describe "deliver_welcome_email/1" do
-    test "welcomes the user and points at the console" do
+    # ADR 0038: the welcome points at the verified landing, and carries the
+    # same request that page shows. The key is never in an email.
+    test "welcomes the user and points at the landing" do
       user = insert_verified_user()
 
       assert {:ok, _email} = CreditsEmails.deliver_welcome_email(user)
@@ -14,12 +16,25 @@ defmodule Fountain.Emails.CreditsEmailsTest do
       assert_email_sent(fn email ->
         assert email.subject == "Welcome to Fountain"
         assert email.to == [{user.email, user.email}]
-        assert email.html_body =~ "/dashboard"
-        assert email.text_body =~ "/dashboard"
+        assert email.html_body =~ "/start"
+        assert email.text_body =~ "/start"
       end)
     end
 
-    test "links to the dashboard instead once onboarding is complete" do
+    test "carries the first request, with the key still a placeholder" do
+      user = insert_verified_user()
+
+      assert {:ok, _email} = CreditsEmails.deliver_welcome_email(user)
+
+      assert_email_sent(fn email ->
+        assert email.text_body =~ "/api/conversations"
+        assert email.text_body =~ Fountain.Onboarding.prompt()
+        assert email.text_body =~ "$FOUNTAIN_API_KEY"
+        assert email.text_body =~ "on your start page"
+      end)
+    end
+
+    test "names no dead onboarding route" do
       user = insert_verified_user()
       now = DateTime.utc_now() |> DateTime.truncate(:second)
 

--- a/ee/test/fountain/workers/welcome_email_test.exs
+++ b/ee/test/fountain/workers/welcome_email_test.exs
@@ -6,7 +6,7 @@ defmodule Fountain.Workers.WelcomeEmailTest do
   alias Fountain.Workers.WelcomeEmail
 
   describe "perform/1" do
-    test "welcomes a verified user and points at the console" do
+    test "welcomes a verified user and points at the landing" do
       user = insert_verified_user()
       assert is_nil(user.onboarding_completed_at)
 
@@ -15,7 +15,7 @@ defmodule Fountain.Workers.WelcomeEmailTest do
       assert_email_sent(fn email ->
         assert email.subject == "Welcome to Fountain"
         assert email.to == [{user.email, user.email}]
-        assert email.text_body =~ "/dashboard"
+        assert email.text_body =~ "/start"
       end)
     end
 


### PR DESCRIPTION
Closes #1390. ADR 0038 decision 5, and the first half of decision 7.

Rebased onto main at `c0d72e93`, so this sits on top of #1388 (platform
inference), #1389 (the starter agent) and #1411/#1425 (the SDK contract).

## What replaced what

The first screen after verification was the dashboard and its three-item
checklist. `/start` (`FountainWeb.StartLive`) is now that screen:

1. **The key**, minted on the first connected view and shown once, with the
   copy affordance the API keys page uses.
2. **One request** against the account's agent, as `curl` and as the
   TypeScript SDK, with the key and the agent already substituted in.
3. **The reply**, inline on the same screen, with a link into the
   conversations app for the rest.
4. **Three doors** below the fold: your own inference key, `fountain apply`,
   the SDK.

Both signup routes land there — the emailed verification link, and an OAuth
signup, which is created verified and so has the same first screen.

## One source for the request

`docs/snippets/first-request.sh` and `.ts` are the text. The manual includes
them verbatim with placeholders intact; `Fountain.Onboarding` reads the same
two files at compile time and substitutes. `onboarding_test.exs` asserts the
module serves exactly what is on disk, that both snippets carry the same
prompt, and that a fully substituted render leaks no placeholder.

They live under `docs/` on purpose: the Dockerfile's existing
`COPY docs ./docs` already carries them. A compile-time read the build stage
does not copy kills `mix release`, no image is built, CI stays green and the
deploy silently never happens (#884). There is a test pinning that COPY line.

## The stamp moved

`users.onboarding_completed_at` is stamped by `Fountain.Activation` at the
first reply — the same moment the funnel calls activated, so the two can no
longer disagree, and it lands whatever door the request came through. The
dashboard's `maybe_complete_onboarding` went with the checklist; what is left
there is one line pointing at `/start` when nothing has answered yet.

## The events, and one deliberate departure

`onboarding.landing_viewed`, `onboarding.key_copied` and
`onboarding.reply_shown` come from the page, as the issue asks.

**`onboarding.request_sent` does not, and that is deliberate — not an
oversight.** It is emitted server-side from
`Conversations.create_conversation/1` — the one write both create paths share
— on the account's first conversation. A developer who copies the request,
closes the tab and runs it an hour later still sent it, and an ordered PostHog
funnel whose third step only fires while a browser is open would drop exactly
the people who did the thing. The funnel I built in #1416 needs step three to
be true of the account, not of the tab. `Activation.funnel_events/0` still
holds the four names, so the definition and the page cannot drift.

`key_copied` and `reply_shown` are captured but are not funnel steps —
copying is intending, and "the reply arrived while they were watching" is a
fact about the page, not the account.

## What the rebase changed

**The credential banner now asks #1388's rule.** It no longer asks "does this
tenant hold a key"; it asks `InferenceCredentials.select/2`, so a deployment
holding a platform key stops warning about a wall that is not there, and the
banner is per-*agent* — `select/2` keys off the model's provider, and an
Anthropic key does not cover a `gemini` agent. `start_live_platform_test.exs`
pins both directions, `async: false` in its own module because platform keys
live in global application env (#1214).

**#1389 plants a `starter` agent at verification**, so the landing has
something to point at from the moment an account exists. I kept the generic
resolution as asked (prefer `starter`, else the oldest, else say so) — the
starter is an ordinary agent and may be deleted, and accounts verified before
#1389 never had one.

**No API surface changed**, so the SDK contract needs no regeneration:
`scripts/sdk-contract/build.sh --check` reports "ok (158 operations, 179
schemas)". The only router change is a browser LiveView route in the console
scope.

## The timed run, and what I could not measure

Walked locally against a dev server on a private database, with a fresh
account and nothing but an email address.

| Segment | Measured |
|---|---|
| Register, verify, land on `/start` with a key and a filled-in request | **2s** server time |
| Read the page, copy the request | not timed; the page is three short sections |
| Sandbox start, model call, reply on screen | **not measured** |

**Proven by test:** the key mint (connected and disconnected), the substituted
request, the agent resolution, the credential banner in both directions
against a platform key, the reply arriving on a `sidebar:` nudge with no
reload, the stamp landing at the first reply, and both PostHog events at their
choke points.

**Unmeasured:** a real sandbox starting and a real model answering, end to
end, on a wall clock.

**I could not measure the last segment honestly.** This environment has no
`SPRITES_TOKEN` and no platform inference key, so no real sandbox starts and
no model answers. The reply half is proven by the LiveView test (the reply
arrives on a `sidebar:` nudge with no reload) and by a browser check against a
seeded reply, not by a real run.

With #1388 merged the "nothing but an email address" path is now real in
principle — that was the missing premise when I first wrote this — but I still
cannot time it here. Point me at a deployment with both secrets and I will
re-run the walk and post the real five minutes.

## Two things the walk found

- The **dead render told an account with no key that it already had one**.
  The mint only happens on the connected mount, so the first HTML a browser
  gets has no raw key — and the "you already have a key" branch was the
  fallback. Now three-way, and pinned by a test that asserts on the dead
  render specifically.
- The headline said "you need nothing else" directly above a banner asking
  for an inference credential. Reworded.

## Docs

`docs/quickstart.md` opens with the three steps and the shared snippet; the
Compose bootstrap and the CLI/manifest walk-through stay on the page below,
under headings that say what they are. **I did not delete them** — the ADR
says the quickstart is the same request, not that the manual loses the only
place a reader can find `docker compose up` or `fountain apply`. Say the word
and I will move them to `self-hosting.md` and `cli.md` instead.

**Docs trap, no error message:** an admonition indents its body, and **an
indented `--8<--` snippet include is silently left unexpanded**. So a snippet
include cannot live inside an admonition. `docs/index.md`'s "in a hurry" box
is the same snippet by include and is therefore no longer a `!!! tip` —
`docs_test`'s "no unexpanded snippet include" check is what caught it, and it
names no page, so the search is manual. That moved the
docs-controller test's admonition fixture to the quickstart, which carries one
now. `docs/tour.md` says at the top that it is the second page.

## Gate

On the rebased branch: compile with warnings-as-errors, format, `credo
--strict` (no issues), sobelow, dialyzer 0 errors, **4088 tests, 0 failures**.
All three prose gates clean (`docs-style.py`, `vale lint docs`, `destink`),
`docs_test` green including snippet-include resolution, and the SDK contract
check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BXYa9CQNG8oFNq5YhAxva

