### PR TITLE
test: scratch paths two concurrent suites cannot collide on

### DIFF
--- a/apps/fountain/test/fountain/buzz/boot_sweep_test.exs
+++ b/apps/fountain/test/fountain/buzz/boot_sweep_test.exs
@@ -6,8 +6,7 @@ defmodule Fountain.Buzz.BootSweepTest do
   alias Fountain.Buzz.{BootSweep, Manager}
 
   setup do
-    dir = Path.join(System.tmp_dir!(), "buzz-sweep-#{System.unique_integer([:positive])}")
-    File.mkdir_p!(dir)
+    dir = Fountain.TmpDir.mkdir!("buzz-sweep")
     fake = Path.join(dir, "buzz-acp")
     File.write!(fake, "#!/bin/sh\nsleep 30\n")
     File.chmod!(fake, 0o755)
@@ -58,7 +57,7 @@ defmodule Fountain.Buzz.BootSweepTest do
   end
 
   test "run is idempotent — a second sweep does not double-start" do
-    fake = Path.join(System.tmp_dir!(), "buzz-acp-#{System.unique_integer([:positive])}")
+    fake = Fountain.TmpDir.path("buzz-acp")
     File.write!(fake, "#!/bin/sh\nsleep 30\n")
     File.chmod!(fake, 0o755)
     on_exit(fn -> File.rm(fake) end)

--- a/apps/fountain/test/fountain/buzz/harness_test.exs
+++ b/apps/fountain/test/fountain/buzz/harness_test.exs
@@ -27,10 +27,7 @@ defmodule Fountain.Buzz.HarnessTest do
 
   setup do
     assert File.exists?(@launcher), "launcher missing at #{@launcher}"
-    dir = Path.join(System.tmp_dir!(), "buzz-harness-#{System.unique_integer([:positive])}")
-    File.mkdir_p!(dir)
-    on_exit(fn -> File.rm_rf(dir) end)
-    %{dir: dir}
+    %{dir: Fountain.TmpDir.mkdir!("buzz-harness")}
   end
 
   defp start(opts) do

--- a/apps/fountain/test/fountain/buzz/manager_test.exs
+++ b/apps/fountain/test/fountain/buzz/manager_test.exs
@@ -11,8 +11,7 @@ defmodule Fountain.Buzz.ManagerTest do
   alias Fountain.Repo
 
   setup do
-    dir = Path.join(System.tmp_dir!(), "buzz-mgr-#{System.unique_integer([:positive])}")
-    File.mkdir_p!(dir)
+    dir = Fountain.TmpDir.mkdir!("buzz-mgr")
     fake = Path.join(dir, "buzz-acp")
     File.write!(fake, "#!/bin/sh\nsleep 30\n")
     File.chmod!(fake, 0o755)

--- a/apps/fountain/test/fountain/conversations/provisioning_test.exs
+++ b/apps/fountain/test/fountain/conversations/provisioning_test.exs
@@ -289,7 +289,7 @@ defmodule Fountain.Conversations.ProvisioningTest do
   # across lines.
   defp sourced_value(value) do
     body = Provisioning.render_env_file(%{"SECRET" => value})
-    dir = Path.join(System.tmp_dir!(), "envq-#{System.unique_integer([:positive])}")
+    dir = Fountain.TmpDir.path("envq")
     File.mkdir_p!(dir)
     file = Path.join(dir, ".env")
     File.write!(file, body)

--- a/apps/fountain/test/fountain/tmp_dir_test.exs
+++ b/apps/fountain/test/fountain/tmp_dir_test.exs
@@ -1,0 +1,115 @@
+defmodule Fountain.TmpDirTest do
+  @moduledoc """
+  The scratch-path helper, and the guardrail that keeps the defect it fixes
+  from coming back (#1423).
+
+  The bug this replaces was not a wrong assertion anywhere. It was a path built
+  from `System.unique_integer/1` alone, which is unique per BEAM node while
+  `$TMPDIR` is shared by the whole host — so two concurrent `mix test` runs
+  built the same path and deleted each other's files. It cost a session two
+  false diagnoses, because the failure lands on whichever test was running and
+  reads as a regression in that branch.
+
+  CI cannot catch it: the six partitions each get their own machine. The
+  guardrail below is what catches it instead, at review time, by refusing the
+  spelling rather than the symptom.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Fountain.TmpDir
+
+  describe "path/1" do
+    test "is scoped to this OS process, not just this node" do
+      # The whole bug: a sibling `mix test` is a different OS process with its
+      # own low unique integers, so the pid is the part that separates them.
+      path = TmpDir.path("thing")
+
+      assert Path.basename(path) =~ ~r/^thing-#{System.pid()}-\d+$/
+      assert Path.dirname(path) == Path.dirname(TmpDir.path("other"))
+    end
+
+    test "two calls never agree" do
+      assert TmpDir.path("thing") != TmpDir.path("thing")
+    end
+
+    test "creates nothing" do
+      refute File.exists?(TmpDir.path("thing"))
+    end
+  end
+
+  describe "mkdir!/1" do
+    test "creates the directory and hands back the path" do
+      dir = TmpDir.mkdir!("thing")
+
+      assert File.dir?(dir)
+      assert Path.basename(dir) =~ ~r/^thing-#{System.pid()}-\d+$/
+    end
+
+    test "removes it when the test ends, contents and all" do
+      key = {__MODULE__, :cleanup_dir}
+
+      # `on_exit` callbacks run last-registered-first, so this one — registered
+      # *before* `mkdir!/1` registers its removal — is the one that runs after
+      # it. The path travels through `:persistent_term` because the callback
+      # runs in ExUnit's handler process, not this one, and the key is scoped
+      # to this module so an async sibling cannot see it.
+      on_exit(fn ->
+        dir = :persistent_term.get(key)
+        :persistent_term.erase(key)
+
+        refute File.exists?(dir)
+      end)
+
+      dir = TmpDir.mkdir!("thing")
+      :persistent_term.put(key, dir)
+      File.write!(Path.join(dir, "f"), "x")
+
+      assert File.exists?(Path.join(dir, "f"))
+    end
+  end
+
+  describe "the guardrail" do
+    # Every test file, from both test roots. `test_paths` is ["test",
+    # "../../ee/test"] and this file lives in apps/fountain/test/fountain.
+    # This file names the forbidden call in its own scan and in the assertion
+    # above, so it is the one file the scan skips. Nothing else is exempt.
+    @self Path.expand(__ENV__.file)
+
+    defp test_files do
+      root = Path.expand("../..", __DIR__)
+
+      [Path.join(root, "test/**/*.exs"), Path.expand("../../../../ee/test/**/*.exs", __DIR__)]
+      |> Enum.flat_map(&Path.wildcard/1)
+      |> Enum.reject(&(Path.expand(&1) == @self))
+    end
+
+    test "no test builds its own $TMPDIR path" do
+      offenders =
+        for file <- test_files(),
+            line <- String.split(File.read!(file), "\n"),
+            String.contains?(line, "System.tmp_dir"),
+            do: "#{Path.relative_to_cwd(file)}: #{String.trim(line)}"
+
+      assert offenders == [],
+             """
+             These build a scratch path under the shared $TMPDIR themselves.
+             Two concurrent `mix test` runs will collide on it — see
+             `Fountain.TmpDir`. Use `Fountain.TmpDir.mkdir!/1` for a directory,
+             or `Fountain.TmpDir.path/1` when you want the path alone:
+
+             #{Enum.join(offenders, "\n")}
+             """
+    end
+
+    test "the guardrail is looking at the files it thinks it is" do
+      # Guard the guard (#406): an empty or mis-rooted glob would make the test
+      # above pass over nothing. Both roots must be represented.
+      files = test_files()
+
+      assert length(files) > 100
+      assert Enum.any?(files, &String.contains?(&1, "/ee/test/"))
+      assert Enum.any?(files, &String.contains?(&1, "/buzz/harness_test.exs"))
+    end
+  end
+end

--- a/apps/fountain/test/fountain_web/controllers/buzz_mcp_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/buzz_mcp_controller_test.exs
@@ -57,8 +57,7 @@ defmodule FountainWeb.BuzzMcpControllerTest do
   } do
     # Point the controller at a fake `buzz` that echoes JSON, so the full path
     # (controller → Mcp → System.cmd) runs without the real binary.
-    dir = Path.join(System.tmp_dir!(), "buzzbin-#{System.unique_integer([:positive])}")
-    File.mkdir_p!(dir)
+    dir = Fountain.TmpDir.mkdir!("buzzbin")
     fake = Path.join(dir, "buzz")
     File.write!(fake, "#!/bin/sh\necho '{\"accepted\":true,\"event_id\":\"e1\"}'\n")
     File.chmod!(fake, 0o755)

--- a/apps/fountain/test/support/tmp_dir.ex
+++ b/apps/fountain/test/support/tmp_dir.ex
@@ -1,0 +1,69 @@
+defmodule Fountain.TmpDir do
+  @moduledoc """
+  Scratch paths under `$TMPDIR` that two concurrent suites cannot collide on
+  (#1423).
+
+  The obvious spelling is wrong in a way that only shows up on a developer's
+  machine:
+
+      Path.join(System.tmp_dir!(), "thing-\#{System.unique_integer([:positive])}")
+
+  `System.unique_integer/1` is unique **per BEAM node**, not per machine, while
+  `$TMPDIR` is shared by every process on the host. Two `mix test` runs are two
+  nodes, so both counters start low and hand out the same small integers, and
+  both runs then build the same path. Whichever finishes first deletes the
+  directory the other is still working in.
+
+  It is invisible in CI, where the six partitions each get a machine to
+  themselves, and it appears exactly when several worktrees or agents build in
+  parallel — where it reads as a regression in whichever branch happened to be
+  running. `Fountain.Buzz.HarnessTest` is the one that was seen failing,
+  because it launches a real OS process out of the directory and so has the
+  widest window between `mkdir_p!` and use; the other five call sites had the
+  same defect with a narrower window.
+
+  Adding `System.pid/0` — the BEAM's OS pid — makes the path unique per *run*,
+  which is the scope that was missing. The unique integer stays for uniqueness
+  within a run.
+
+  ## Use
+
+      # a directory, made and cleaned up for you
+      dir = Fountain.TmpDir.mkdir!("buzz-harness")
+
+      # just the path, when the caller owns creation and cleanup
+      file = Fountain.TmpDir.path("buzz-acp")
+  """
+
+  @doc """
+  A collision-free path under `$TMPDIR` beginning with `prefix`.
+
+  Creates nothing. For a caller that wants the path itself — a file rather
+  than a directory, or cleanup on its own schedule.
+  """
+  @spec path(String.t()) :: String.t()
+  def path(prefix) when is_binary(prefix) do
+    Path.join(
+      System.tmp_dir!(),
+      "#{prefix}-#{System.pid()}-#{System.unique_integer([:positive])}"
+    )
+  end
+
+  @doc """
+  `path/1`, created, and removed again when the test ends.
+
+  The `on_exit` is registered here so that the cleanup and the path can never
+  drift apart. It stacks with any other `on_exit` the caller registers, so a
+  test that also restores application env keeps doing that.
+
+  Callable from `setup` or from a test body — anywhere `ExUnit.Callbacks.on_exit/1`
+  is.
+  """
+  @spec mkdir!(String.t()) :: String.t()
+  def mkdir!(prefix) when is_binary(prefix) do
+    dir = path(prefix)
+    File.mkdir_p!(dir)
+    ExUnit.Callbacks.on_exit(fn -> File.rm_rf(dir) end)
+    dir
+  end
+end


### PR DESCRIPTION
Closes #1423.

## The defect

Six tests built a scratch path this way:

```elixir
Path.join(System.tmp_dir!(), "thing-#{System.unique_integer([:positive])}")
```

`System.unique_integer/1` is unique **per BEAM node**. `$TMPDIR` is shared by
the whole host. Two `mix test` runs are two nodes, so both counters start low
and hand out the same small integers, and both runs build the same path.
Whichever finishes first deletes the directory the other is still working in.

Two separate BEAMs, old spelling then new:

```
$ for i in 1 2; do elixir -e '... unique_integer ...'; done
buzz-harness-1346
buzz-harness-1346          # identical, every time

$ for i in 1 2; do elixir -e '... pid + unique_integer ...'; done
buzz-harness-48204-261
buzz-harness-48227-1383
```

## The fix

`Fountain.TmpDir` in `test/support` adds `System.pid/0` — the scope that was
missing — and gives the next test that wants a scratch directory the right
thing to reach for:

- `mkdir!/1` makes the directory and registers its own `on_exit`, so a path and
  its cleanup cannot drift apart. Five call sites; three of them lose an
  explicit `mkdir_p!`/`on_exit` pair. It stacks with a caller's own `on_exit`,
  so the sites that also restore application env keep doing that.
- `path/1` returns the path alone, for the two callers that own creation and
  cleanup: `boot_sweep_test.exs:61` wants a *file* in `$TMPDIR`, and
  `provisioning_test.exs`'s `sourced_value/1` cleans up per call with
  `try/after` because it runs several times per test.

All six sites converted. `System.tmp_dir!` now appears in exactly one place.

| File | Prefix | Helper |
|---|---|---|
| `buzz/harness_test.exs` | `buzz-harness` | `mkdir!/1` |
| `buzz/boot_sweep_test.exs` | `buzz-sweep` | `mkdir!/1` |
| `buzz/boot_sweep_test.exs` | `buzz-acp` | `path/1` |
| `buzz/manager_test.exs` | `buzz-mgr` | `mkdir!/1` |
| `buzz_mcp_controller_test.exs` | `buzzbin` | `mkdir!/1` |
| `conversations/provisioning_test.exs` | `envq` | `path/1` |

## Evidence

**Reproduced and fixed.** Three buzz suites, two BEAMs, two databases, twelve
rounds each way:

| | Concurrent runs failed |
|---|---|
| before (main's six call sites) | **1 of 12** |
| after | **0 of 24** |

The one reproduced failure was `HarnessTest`, on a *different* example than the
one first reported (`surfaces buzz-acp output on the Logger` rather than `opens
the port with the given env`) — which is what a timing window looks like from
the outside, and is why this kept reading as a regression in whatever branch
was running.

**The guardrail was checked by breaking it.** `tmp_dir_test.exs` scans both
test roots (`test/` and `../../ee/test`) and refuses the spelling rather than
the symptom, because the symptom is invisible in CI — the six partitions each
get a machine to themselves. Reintroducing the old line in `manager_test.exs`
made it fail and name the file and line. It also guards itself: a second test
asserts the glob actually resolves both roots, so it cannot pass over nothing.
This file is the only one the scan exempts, since it necessarily names the call
it forbids.

## Gate

`mix precommit` on `fountain_test_p1389`: compile (warnings-as-errors),
`deps.unlock` check, `format --check-formatted`, `credo --strict` (5876
mods/funs, no issues), dialyzer (`Total errors: 0`), sobelow, and
**6 doctests, 4059 tests, 0 failures**, exit 0 — run while two other worktrees
were mid-suite, which is the condition this PR is about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BXYa9CQNG8oFNq5YhAxva
