### PR TITLE
test(api): guard the schema against its own controller

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -306,6 +306,32 @@ Two things that are not optional:
   which has no Elixir toolchain, can check against it. `dist/openapi.json` is
   the rebuilt input and stays ignored.
 
+### The schema has to match its own controller
+
+`sdk/contract` and `sdk/conformance` both compare a schema with another schema,
+so neither notices when the document is wrong about what the action actually
+renders. Three defects of that shape landed in a day (#1417, #1418, #1427), so
+the suite now checks it directly and you will meet it without doing anything:
+
+- **Every response any controller test renders** is validated against the
+  schema its operation declares. The check is attached in `test_helper.exs` and
+  costs nothing per test; 146 operations are covered by tests that already
+  exist. A failure names the operation, the mismatch and the body.
+- **`apps/fountain/test/fountain_web/schema_guardrail_test.exs`** adds what a
+  rendered response cannot show: that no `required` list names a property its
+  schema lacks, that no response is declared as an object with no properties,
+  and — for the operations on its short list — that the action renders *every*
+  property the schema declares, which an optional field never sent would
+  otherwise hide.
+
+If you hit it, the schema in `apps/fountain/lib/fountain_web/schemas.ex` is
+usually the thing that is wrong, not the action. When it genuinely cannot be
+fixed in that PR, add the `{operation, status}` pair to
+`FountainWeb.SchemaGuardAllowlist` with a reason and an issue, and raise
+`@ceiling` in the guardrail test in the same diff — that number moving is the
+signal to a reviewer. The list may shrink freely; deleting a line is how a fix
+finishes.
+
 ### Changing behaviour rather than shape
 
 The contract above covers request and response *shape*. What a client does with

--- a/apps/fountain/test/fountain_web/schema_guardrail_test.exs
+++ b/apps/fountain/test/fountain_web/schema_guardrail_test.exs
@@ -1,0 +1,229 @@
+defmodule FountainWeb.SchemaGuardrailTest do
+  @moduledoc """
+  Does the OpenAPI document tell the truth about its own controllers (#1427)?
+
+  Three defects of one class surfaced in a day, and nothing in the repository
+  could catch any of them, because every existing check compares a schema with
+  another schema:
+
+    1. `AuthMeResponse.required` named `name`, `prefix` and `created_at`,
+       properties the schema does not have, copied from `ApiKey` (#1417).
+       `openapi-typescript` drops a required name with no property, so the
+       published client had every field on that response optional.
+    2. `AuthMeResponse` declares `expires_at`, which `show/2` never renders
+       (#1418). The spec promises a field the endpoint does not return.
+    3. Reported as a bare `{"type": "object"}` 402 on `POST /api/conversations`
+       carrying an undeclared `upgrade_url`. Building this guard showed that
+       one was not a server defect at all: the operation declares `error` and
+       `upgrade_url` perfectly well, and `scripts/sdk-contract/build.py` was
+       dropping the properties of an inline schema when it projected them.
+       Fixed there. The check below still exists, because a response declared
+       as a propertyless object is a real hazard even though nothing is in that
+       state today.
+
+  Each needs a different question asked, so this file asks three.
+
+  **The rendered half** is not here at all — it is a telemetry handler attached
+  in `test_helper.exs`, validating every response any controller test produces
+  against the schema its operation declares. That is where defect 1 is caught,
+  and it covers 146 operations for free because the tests already exist.
+  `FountainWeb.SchemaGuardAllowlist` holds what is already wrong.
+
+  **The static half** is `every declared response says something` below: a
+  declared JSON response with no properties, no `$ref` and no type promises
+  nothing, so no guard anywhere can disagree with it. It passes today and its
+  job is to keep it that way.
+
+  **The exhaustive half** is `renders every property it declares`, which catches
+  defect 2. The rendered half cannot: an optional property that is never sent
+  still validates. This one drives a real request and compares the keys that
+  came back against the properties the schema declares, for a short list of
+  operations where that is worth pinning.
+  """
+
+  use FountainWeb.ConnCase, async: true
+
+  alias FountainWeb.{SchemaGuard, SchemaGuardAllowlist}
+  alias OpenApiSpex.{Reference, Schema}
+
+  # The allowlist may shrink freely. Growing it means editing this number in
+  # the same diff, which is the whole ratchet: a reviewer sees the number move.
+  @ceiling 98
+
+  describe "the ratchet" do
+    test "the allowlist has not grown" do
+      count = map_size(SchemaGuardAllowlist.entries())
+
+      assert count <= @ceiling, """
+      The schema guard allowlist has #{count} entries, and the ceiling is #{@ceiling}.
+
+      A new entry means a new place where the document disagrees with its
+      controller. If that is deliberate, raise @ceiling here in the same diff so
+      the growth is visible in review. If it is not, fix the schema instead.
+      """
+    end
+
+    test "every entry names a family that has a reason" do
+      families = SchemaGuardAllowlist.reasons()
+
+      for {{operation, status}, family} <- SchemaGuardAllowlist.entries() do
+        assert Map.has_key?(families, family),
+               "#{operation} -> #{status} is allowlisted as #{inspect(family)}, " <>
+                 "which has no reason. Every entry has to say why."
+      end
+    end
+
+    test "every entry names an operation the API still serves" do
+      served = SchemaGuard.operations() |> Enum.map(&elem(&1, 0)) |> MapSet.new()
+
+      stale =
+        for {{operation, status}, _} <- SchemaGuardAllowlist.entries(),
+            not MapSet.member?(served, operation),
+            do: "#{operation} -> #{status}"
+
+      assert stale == [], """
+      These allowlist entries name operations the API no longer serves:
+
+      #{Enum.map_join(stale, "\n", &"  #{&1}")}
+
+      Delete them. A stale allowlist entry is a fix nobody noticed landing.
+      """
+    end
+  end
+
+  describe "the schema itself" do
+    test "no `required` names a property the schema does not have" do
+      # Defect 1's shape, caught statically as well as at render time, because
+      # `openapi-typescript` drops such a name silently and the published client
+      # then has every field optional. scripts/sdk-contract/build.py refuses to
+      # project one too; this fails first and in the language it was written in.
+      offenders =
+        for {title, schema} <- schemas(),
+            required = schema.required || [],
+            properties = schema.properties || %{},
+            missing = Enum.reject(required, &Map.has_key?(properties, &1)),
+            missing != [],
+            do: "#{title}: requires #{inspect(missing)}, which it does not declare"
+
+      assert offenders == [], """
+      A schema requires properties it does not have:
+
+      #{Enum.map_join(offenders, "\n", &"  #{&1}")}
+
+      This is #1417 exactly. Either add the properties or fix the `required:` list.
+      """
+    end
+
+    test "every declared JSON response says something" do
+      # A response declared as a bare object with no properties, no ref and no
+      # additionalProperties accepts literally anything, so no guard anywhere —
+      # this file, the SDK projection, a generated client — can ever disagree
+      # with it. It is a hole in the contract shaped like a schema. Nothing is
+      # in that state today; this is here so nothing gets there.
+      offenders =
+        for {name, operation} <- documented_operations(),
+            {status, response} <- operation.responses || %{},
+            schema = json_schema(response),
+            schema != nil,
+            empty_object?(schema),
+            do: "#{name} -> #{status}"
+
+      assert offenders == [], """
+      These responses are declared as an object with no properties:
+
+      #{Enum.map_join(offenders, "\n", &"  #{&1}")}
+
+      A schema that promises nothing cannot be wrong, and cannot be useful to a
+      generated client either. Give it properties, or point it at a schema that
+      has them.
+      """
+    end
+  end
+
+  describe "the controller renders what the schema declares" do
+    # Defect 2. The rendered half cannot catch a declared property that is never
+    # sent, because an absent optional property validates fine. So for the
+    # operations where the schema should be exhaustive, drive a real request and
+    # compare the keys.
+    #
+    # Adding to this list is how a response gets held to its whole schema, not
+    # just to the parts it happens to send.
+    @unrendered %{
+      # #1418: `expires_at` is declared and `AuthMeController.show/2` never
+      # renders it. Which way it goes is an API decision rather than a test
+      # one — a client that wants to warn before a key lapses would need the
+      # field rendered, and a client that does not wants it dropped from the
+      # schema. Recorded here with the pointer rather than decided here.
+      {"GET /api/auth/me", "expires_at"} => 1418
+    }
+
+    test "GET /api/auth/me renders every property AuthMeResponse declares" do
+      user = insert_verified_user()
+      {_record, raw_key} = insert_api_key(user)
+
+      body =
+        build_conn()
+        |> authed_with_key(raw_key)
+        |> get(~p"/api/auth/me")
+        |> json_response(200)
+
+      assert_renders_every_property("GET /api/auth/me", "AuthMeResponse", body)
+    end
+
+    defp assert_renders_every_property(operation, title, body) do
+      declared = schemas() |> Map.new() |> Map.fetch!(title) |> Map.get(:properties, %{})
+
+      missing =
+        declared
+        |> Map.keys()
+        |> Enum.map(&to_string/1)
+        |> Enum.reject(fn property ->
+          Map.has_key?(body, property) or Map.has_key?(@unrendered, {operation, property})
+        end)
+        |> Enum.sort()
+
+      assert missing == [], """
+      #{operation} declares #{inspect(missing)} on #{title} and did not render #{if length(missing) == 1, do: "it", else: "them"}.
+
+      The spec promises a field the endpoint does not return, and every SDK
+      generated from it carries the field. Either render it in the action or
+      drop it from the schema. If the answer is a real API decision, add it to
+      @unrendered with the issue number.
+      """
+    end
+  end
+
+  # ── reading the document ────────────────────────────────────────────────────
+
+  defp spec, do: OpenApiSpex.resolve_schema_modules(FountainWeb.ApiSpec.spec())
+
+  defp schemas do
+    for {title, %Schema{} = schema} <- spec().components.schemas, do: {title, schema}
+  end
+
+  defp documented_operations do
+    for {path, item} <- spec().paths,
+        {method, %OpenApiSpex.Operation{} = operation} <- Map.from_struct(item),
+        do: {"#{method |> to_string() |> String.upcase()} #{path}", operation}
+  end
+
+  defp json_schema(%Reference{}), do: nil
+
+  defp json_schema(response) do
+    # A response with no `content` at all is a 204 or a redirect, and there is
+    # nothing there to be wrong about.
+    case Map.get(response, :content) do
+      nil -> nil
+      content -> content |> Map.get("application/json", %{}) |> Map.get(:schema)
+    end
+  end
+
+  defp empty_object?(%Schema{} = schema) do
+    schema.type == :object and
+      (schema.properties == nil or schema.properties == %{}) and
+      schema.additionalProperties in [nil, false] and
+      schema.oneOf == nil and schema.anyOf == nil and schema.allOf == nil
+  end
+
+  defp empty_object?(_), do: false
+end

--- a/apps/fountain/test/support/conn_case.ex
+++ b/apps/fountain/test/support/conn_case.ex
@@ -34,6 +34,23 @@ defmodule FountainWeb.ConnCase do
 
   setup tags do
     Fountain.DataCase.setup_sandbox(tags)
+
+    # The schema guard (#1427) validates every response this test renders
+    # against the schema its operation declares, and files anything that
+    # disagrees under this process. Collect it here rather than raising in the
+    # telemetry handler, which `:telemetry` would catch and then detach.
+    test_pid = self()
+
+    ExUnit.Callbacks.on_exit(fn ->
+      case FountainWeb.SchemaGuard.take(test_pid) do
+        [] ->
+          :ok
+
+        violations ->
+          raise "Schema guard: " <> Enum.join(violations, "\n")
+      end
+    end)
+
     {:ok, conn: Phoenix.ConnTest.build_conn()}
   end
 

--- a/apps/fountain/test/support/schema_guard.ex
+++ b/apps/fountain/test/support/schema_guard.ex
@@ -1,0 +1,329 @@
+defmodule FountainWeb.SchemaGuard do
+  @moduledoc """
+  Does the response a controller rendered match the schema it declares?
+
+  Every other check in this repository compares a schema with another schema.
+  `sdk/contract` projects the OpenAPI document and pins four SDKs to it,
+  `sdk/conformance` pins what those clients do with it, and both pass happily
+  when the document itself is a lie about its own controller. Three defects of
+  exactly that shape surfaced in one day (#1427): a `required` list naming
+  properties the schema did not have (#1417), a declared field the action never
+  renders (#1418), and a declared response body with no properties at all while
+  the real one carries `upgrade_url`.
+
+  This module is the missing side of the comparison. It takes a `%Plug.Conn{}`
+  that has already been sent, finds the operation the router routed it to, and
+  validates the rendered body against that operation's declared response schema
+  for that status.
+
+  It reports rather than raises. `FountainWeb.SchemaGuardrailTest` decides what
+  is a failure and what is on the ratchet; a helper that flunked on its own
+  could not be used to measure the ground truth first.
+  """
+
+  alias OpenApiSpex.{Cast, Reference, Schema}
+
+  @router FountainWeb.Router
+  @spec_module FountainWeb.ApiSpec
+  @table :schema_guard_violations
+
+  # ── wiring ──────────────────────────────────────────────────────────────────
+
+  @doc """
+  Watch every response the suite renders.
+
+  Attached once from `test_helper.exs`. `Plug.Telemetry` is already in the
+  endpoint, so this costs nothing per test and sees every response any
+  controller test produces — 146 operations, from tests that already exist.
+
+  **It records rather than raises, and that is not a style choice.**
+  `:telemetry` wraps a handler in a try/catch: a handler that raises is logged
+  and then *detached*, so the raise fails nothing and every later response goes
+  unchecked. Wired that way this guard reported a reintroduced #1417 and the
+  suite still finished `7 tests, 0 failures`. Instead the violation is filed
+  under the process that made the request, and `FountainWeb.ConnCase` fails
+  that test on the way out.
+  """
+  @spec attach() :: :ok
+  def attach do
+    keeper =
+      spawn(fn ->
+        :ets.new(@table, [:public, :named_table, :duplicate_bag])
+        Process.sleep(:infinity)
+      end)
+
+    # The table dies with its owner, so wait for the keeper to create it before
+    # any request can look for it.
+    wait_for_table(keeper, 200)
+
+    :telemetry.attach(
+      "schema-guard",
+      [:phoenix, :endpoint, :stop],
+      &__MODULE__.handle/4,
+      nil
+    )
+  end
+
+  defp wait_for_table(_keeper, 0), do: raise("schema guard: the violations table never appeared")
+
+  defp wait_for_table(keeper, attempts) do
+    if :ets.whereis(@table) == :undefined do
+      Process.sleep(5)
+      wait_for_table(keeper, attempts - 1)
+    else
+      :ok
+    end
+  end
+
+  @doc false
+  def handle(_event, _measurements, %{conn: conn}, _config) do
+    with {:violation, detail} <- check(conn),
+         name = name(conn) || detail.operation,
+         false <- FountainWeb.SchemaGuardAllowlist.allowed?(name, detail.status) do
+      :ets.insert(@table, {self(), report(name, detail, conn)})
+    end
+
+    :ok
+  catch
+    # A guard that breaks the suite it guards is worse than no guard. Anything
+    # unexpected here is recorded as itself rather than allowed to detach the
+    # handler and silently stop checking.
+    kind, error ->
+      :ets.insert(
+        @table,
+        {self(), "schema guard raised #{inspect(kind)}: #{Exception.format(kind, error)}"}
+      )
+
+      :ok
+  end
+
+  @doc """
+  Take everything recorded against a process. Called by `ConnCase` on the way
+  out of each test, which is what turns a recorded violation into a failure.
+  """
+  @spec take(pid()) :: [String.t()]
+  def take(pid) do
+    case :ets.whereis(@table) do
+      :undefined -> []
+      _ -> @table |> :ets.take(pid) |> Enum.map(&elem(&1, 1))
+    end
+  end
+
+  defp report(name, detail, conn) do
+    """
+    #{name} rendered a #{detail.status} that does not match its declared schema.
+
+        #{detail.message}
+
+    The response body was:
+
+        #{String.slice(to_string(conn.resp_body), 0, 800)}
+
+    The OpenAPI document is the wire contract for four SDKs (#1411), so a schema
+    that disagrees with its controller propagates into all of them. Fix whichever
+    is wrong — usually the schema in apps/fountain/lib/fountain_web/schemas.ex,
+    sometimes the action.
+
+    If it genuinely cannot be fixed now, add {"#{name}", #{detail.status}} to
+    FountainWeb.SchemaGuardAllowlist with a reason and an issue, and raise the
+    ceiling in FountainWeb.SchemaGuardrailTest in the same diff.
+    """
+  end
+
+  @typedoc """
+  What one response was worth.
+
+  `:skip` is not a pass — it is "there was nothing here to check", and the
+  reason says which kind of nothing, so a guard can tell an undocumented route
+  from a 204 with no body.
+  """
+  @type result ::
+          {:ok, operation_id :: String.t()}
+          | {:skip, reason :: atom()}
+          | {:violation, %{operation: String.t(), status: integer(), message: String.t()}}
+
+  @doc """
+  Check one sent connection.
+
+  Returns `{:ok, operation_id}`, `{:skip, reason}` or `{:violation, detail}`.
+  """
+  # `:set` is the state a response is in at `register_before_send`, which is
+  # where the telemetry the guardrail listens on fires. Status and body are both
+  # populated by then; waiting for `:sent` would see nothing at all.
+  @spec check(Plug.Conn.t()) :: result()
+  def check(%Plug.Conn{state: state}) when state not in [:set, :sent, :chunked],
+    do: {:skip, :not_sent}
+
+  def check(%Plug.Conn{status: 204}), do: {:skip, :no_content}
+
+  def check(%Plug.Conn{} = conn) do
+    with {:ok, template} <- template(conn),
+         {:ok, operation} <- operation(conn, template),
+         {:ok, schema} <- response_schema(operation, conn) do
+      validate(conn, operation, schema)
+    end
+  end
+
+  @doc """
+  Every documented operation, as `"METHOD /path/{template}"`.
+
+  The same spelling `sdk/contract/contract.json` uses, so a name is the same
+  string in both halves of the guard and in an allowlist a person reads.
+  """
+  @spec operations() :: [String.t()]
+  def operations do
+    spec = spec()
+
+    for {path, item} <- spec.paths,
+        {method, operation} <- Map.from_struct(item),
+        match?(%OpenApiSpex.Operation{}, operation),
+        do: {"#{method |> to_string() |> String.upcase()} #{path}", operation.operationId}
+  end
+
+  @doc "The `METHOD /template` name for a conn, or nil when it routed nowhere documented."
+  @spec name(Plug.Conn.t()) :: String.t() | nil
+  def name(%Plug.Conn{} = conn) do
+    case template(conn) do
+      {:ok, template} -> "#{conn.method} #{template}"
+      _ -> nil
+    end
+  end
+
+  # ── resolution ──────────────────────────────────────────────────────────────
+
+  # Phoenix spells a path parameter `:id`; OpenAPI spells it `{id}`. Going
+  # through the router rather than pattern-matching the request path is what
+  # makes this exact: two operations can share a controller action (the PUT
+  # aliases of the PATCH routes all report `AgentController.update`), so the
+  # action alone cannot say which operation answered.
+  defp template(%Plug.Conn{} = conn) do
+    case Phoenix.Router.route_info(@router, conn.method, conn.request_path, conn.host) do
+      :error ->
+        {:skip, :no_route}
+
+      %{route: route} ->
+        {:ok, Regex.replace(~r/:([a-zA-Z_][a-zA-Z0-9_]*)/, route, "{\\1}")}
+
+      _ ->
+        {:skip, :no_route}
+    end
+  end
+
+  defp operation(conn, template) do
+    spec = spec()
+
+    with %OpenApiSpex.PathItem{} = item <- Map.get(spec.paths, template, :none),
+         %OpenApiSpex.Operation{} = operation <-
+           Map.get(Map.from_struct(item), method_key(conn.method), :none) do
+      {:ok, operation}
+    else
+      _ -> {:skip, :undocumented}
+    end
+  end
+
+  defp method_key(method), do: method |> String.downcase() |> String.to_existing_atom()
+
+  # A response the operation does not declare at all is a finding for the
+  # guardrail to weigh, not something to pass over: an endpoint that answers
+  # 404 while documenting only 200 is the same class of lie as a wrong field.
+  defp response_schema(operation, conn) do
+    responses = operation.responses || %{}
+
+    case Map.get(responses, conn.status) || Map.get(responses, "#{conn.status}") do
+      nil ->
+        {:violation,
+         %{
+           operation: operation.operationId,
+           status: conn.status,
+           message:
+             "the operation declares no #{conn.status} response. It declares: " <>
+               (responses |> Map.keys() |> Enum.map_join(", ", &to_string/1))
+         }}
+
+      response ->
+        schema =
+          response
+          |> resolve_response()
+          |> Map.get(:content, %{})
+          |> Map.get(content_type(conn), %{})
+          |> Map.get(:schema)
+
+        if schema, do: {:ok, schema}, else: {:skip, :no_json_schema}
+    end
+  end
+
+  defp resolve_response(%Reference{} = ref),
+    do: Reference.resolve_response(ref, spec().components.responses)
+
+  defp resolve_response(response), do: response
+
+  defp content_type(conn) do
+    conn
+    |> Plug.Conn.get_resp_header("content-type")
+    |> List.first()
+    |> to_string()
+    |> String.split(";")
+    |> List.first()
+    |> String.trim()
+  end
+
+  # ── validation ──────────────────────────────────────────────────────────────
+
+  defp validate(conn, operation, schema) do
+    with {:ok, body} <- decode(conn) do
+      spec = spec()
+      resolved = resolve_schema(schema, spec)
+
+      context = %Cast{
+        value: body,
+        schema: resolved,
+        schemas: spec.components.schemas,
+        # A response is read side: a `writeOnly` property being absent is
+        # correct, not missing.
+        read_write_scope: :read
+      }
+
+      case Cast.cast(context) do
+        {:ok, _} ->
+          {:ok, operation.operationId}
+
+        {:error, errors} ->
+          {:violation,
+           %{
+             operation: operation.operationId,
+             status: conn.status,
+             message: Enum.map_join(errors, "; ", &Cast.Error.message_with_path/1)
+           }}
+      end
+    end
+  end
+
+  defp resolve_schema(%Reference{} = ref, spec),
+    do: Reference.resolve_schema(ref, spec.components.schemas)
+
+  defp resolve_schema(%Schema{} = schema, _spec), do: schema
+  defp resolve_schema(other, _spec), do: other
+
+  defp decode(conn) do
+    if String.contains?(content_type(conn), "json") do
+      case Jason.decode(conn.resp_body) do
+        {:ok, body} -> {:ok, body}
+        {:error, _} -> {:skip, :body_not_json}
+      end
+    else
+      {:skip, :not_json}
+    end
+  end
+
+  defp spec do
+    case :persistent_term.get({__MODULE__, :spec}, nil) do
+      nil ->
+        spec = OpenApiSpex.resolve_schema_modules(@spec_module.spec())
+        :persistent_term.put({__MODULE__, :spec}, spec)
+        spec
+
+      spec ->
+        spec
+    end
+  end
+end

--- a/apps/fountain/test/support/schema_guard_allowlist.ex
+++ b/apps/fountain/test/support/schema_guard_allowlist.ex
@@ -1,0 +1,191 @@
+defmodule FountainWeb.SchemaGuardAllowlist do
+  @moduledoc """
+  What the schema guard is allowed to find today, and why.
+
+  The ratchet this repository already uses for the docs prose gates
+  (`scripts/docs-style-allow.txt`) and for the omissions list in
+  `sdk/contract`: write down what is wrong now, forbid anything new, and let
+  the list only shrink. Every entry is one `{operation, status}` pair — never a
+  pattern — so a second operation with the same defect fails until somebody
+  decides about it too. That is the whole point: the families below are
+  systemic, and a wildcard would let the next instance in unnoticed.
+
+  Cleaning one up means deleting its line. `FountainWeb.SchemaGuardrailTest`
+  fails if the list grows past `@ceiling`, so growing it is a deliberate edit a
+  reviewer sees.
+
+  ## The families
+
+  `:plug_status` — the operation does not declare a status something in the
+  pipeline can return on any route. `Plugs.TenantAPIAuth` answers 401,
+  `require_admin` 403, `Plugs.RateLimit` 429, an unready sandbox 503,
+  `plug :accepts` 406. The document describes controllers; these come from
+  plugs, which is why 68 of them appear at once. Declaring each per operation
+  is a large, mechanical documentation change (#1432).
+
+  `:cast_and_validate_422` — `OpenApiSpex.Plug.CastAndValidate` renders its own
+  422 body, `%{"errors" => [%{message, title, source}]}`, while these
+  operations declare `Error` (`%{error}`) or `ChangesetError`
+  (`%{errors: %{field => [message]}}`). So the spec describes the changeset's
+  422 and the wire sometimes carries the validator's. One root cause, 27
+  operations (#1431).
+
+  `:log_event_empty_state` — `Fountain.Conversations.LogEvent` validates
+  `state` against `["" | @states]` and stores `""` for an event that has no
+  state, but the schema's enum is `started done failed interrupted` and does
+  not include it. A generated client with a strict enum decoder rejects a real
+  event, and all four SDKs decode this field (#1430).
+
+  `:test_fixture_vocabulary` — not a defect in the API. The fixture inserts a
+  value on purpose that the domain no longer accepts (a conversation whose
+  runtime is `retired-runtime`, exercising the retired-runtime path), so the
+  rendered enum is out of vocabulary because the test asked for that.
+
+  `:openai_error_shape` — the OpenAI-compatible gateway renders `error` as a
+  string on a 409 while `OpenAIError.error` declares an object. Narrow, and its
+  clients are OpenAI SDKs rather than ours (#1433).
+  """
+
+  @reasons %{
+    plug_status: "a status a pipeline plug returns that the operation does not declare (#1432)",
+    cast_and_validate_422:
+      "CastAndValidate renders its own 422 body, not the declared error schema (#1431)",
+    log_event_empty_state: "LogEvent stores state \"\", which the schema's enum omits (#1430)",
+    test_fixture_vocabulary: "the fixture inserts an out-of-vocabulary value on purpose",
+    openai_error_shape: "the OpenAI gateway renders `error` as a string, not an object (#1433)"
+  }
+
+  # The list may shrink, never grow, without a deliberate edit here and in the
+  # guardrail's own ceiling.
+  @entries %{
+    # ── plug_status (68) ─────────────────────────────
+    {"DELETE /api/account", 401} => :plug_status,
+    {"DELETE /api/agents/{id}", 401} => :plug_status,
+    {"DELETE /api/conversations/{id}", 401} => :plug_status,
+    {"DELETE /api/environments/{id}", 401} => :plug_status,
+    {"DELETE /api/vaults/{id}", 401} => :plug_status,
+    {"GET /api/account/billing", 401} => :plug_status,
+    {"GET /api/account/inference-credentials", 401} => :plug_status,
+    {"GET /api/admin/users", 401} => :plug_status,
+    {"GET /api/admin/users", 422} => :plug_status,
+    {"GET /api/agents", 401} => :plug_status,
+    {"GET /api/agents", 429} => :plug_status,
+    {"GET /api/agents/{id}", 401} => :plug_status,
+    {"GET /api/agents/{id}/avatar", 401} => :plug_status,
+    {"GET /api/agents/{id}/versions", 401} => :plug_status,
+    {"GET /api/agents/{id}/versions/{version}", 422} => :plug_status,
+    {"GET /api/audit", 401} => :plug_status,
+    {"GET /api/catalog", 401} => :plug_status,
+    {"GET /api/connection-providers", 403} => :plug_status,
+    {"GET /api/connections", 403} => :plug_status,
+    {"GET /api/conversations", 401} => :plug_status,
+    {"GET /api/conversations", 406} => :plug_status,
+    {"GET /api/conversations/{conversation_id}/events", 401} => :plug_status,
+    {"GET /api/conversations/{conversation_id}/events", 422} => :plug_status,
+    {"GET /api/conversations/{conversation_id}/stream", 401} => :plug_status,
+    {"GET /api/conversations/{conversation_id}/tree", 401} => :plug_status,
+    {"GET /api/conversations/{conversation_id}/turns/{turn_id}/images/{position}", 401} =>
+      :plug_status,
+    {"GET /api/conversations/{id}", 401} => :plug_status,
+    {"GET /api/environments", 401} => :plug_status,
+    {"GET /api/environments/{environment_id}/secrets", 401} => :plug_status,
+    {"GET /api/environments/{id}", 401} => :plug_status,
+    {"GET /api/sandboxes/{sandbox_id}/file", 403} => :plug_status,
+    {"GET /api/sandboxes/{sandbox_id}/files", 403} => :plug_status,
+    {"GET /api/search", 401} => :plug_status,
+    {"GET /api/team", 401} => :plug_status,
+    {"GET /api/team/schedules", 401} => :plug_status,
+    {"GET /api/vaults", 401} => :plug_status,
+    {"GET /api/vaults/{id}", 401} => :plug_status,
+    {"GET /api/webhooks", 403} => :plug_status,
+    {"GET /v1/models", 404} => :plug_status,
+    {"POST /api/account/onboarding/complete", 401} => :plug_status,
+    {"POST /api/agents", 401} => :plug_status,
+    {"POST /api/agui/{agent_id}", 401} => :plug_status,
+    {"POST /api/agui/{agent_id}", 409} => :plug_status,
+    {"POST /api/apply", 401} => :plug_status,
+    {"POST /api/auth/token", 429} => :plug_status,
+    {"POST /api/avatars/generate", 400} => :plug_status,
+    {"POST /api/buzz/agents", 404} => :plug_status,
+    {"POST /api/conversations", 400} => :plug_status,
+    {"POST /api/conversations", 409} => :plug_status,
+    {"POST /api/conversations", 429} => :plug_status,
+    {"POST /api/conversations", 503} => :plug_status,
+    {"POST /api/conversations/{conversation_id}/interrupt", 503} => :plug_status,
+    {"POST /api/conversations/{conversation_id}/prompts", 402} => :plug_status,
+    {"POST /api/conversations/{conversation_id}/prompts", 410} => :plug_status,
+    {"POST /api/conversations/{conversation_id}/prompts", 422} => :plug_status,
+    {"POST /api/conversations/{conversation_id}/prompts", 429} => :plug_status,
+    {"POST /api/conversations/{conversation_id}/prompts", 503} => :plug_status,
+    {"POST /api/conversations/{conversation_id}/terminate", 503} => :plug_status,
+    {"POST /api/environments", 401} => :plug_status,
+    {"POST /api/support/reports", 401} => :plug_status,
+    {"POST /api/team/{agent_id}/contact", 424} => :plug_status,
+    {"POST /api/vaults", 401} => :plug_status,
+    {"POST /api/webhooks", 403} => :plug_status,
+    {"POST /v1/chat/completions", 401} => :plug_status,
+    {"POST /v1/chat/completions", 500} => :plug_status,
+    {"PUT /api/agents/{id}", 401} => :plug_status,
+    {"PUT /api/environments/{id}", 401} => :plug_status,
+    {"PUT /api/vaults/{id}", 401} => :plug_status,
+
+    # ── cast_and_validate_422 (27) ─────────────────────────────
+    {"DELETE /api/account", 422} => :cast_and_validate_422,
+    {"GET /api/sandboxes/{sandbox_id}/file", 422} => :cast_and_validate_422,
+    {"GET /api/search", 422} => :cast_and_validate_422,
+    {"PATCH /api/buzz/agents/{id}", 422} => :cast_and_validate_422,
+    {"PATCH /api/connection-providers/{id}", 422} => :cast_and_validate_422,
+    {"PATCH /api/team/{agent_id}", 422} => :cast_and_validate_422,
+    {"PATCH /api/team/{agent_id}/contact", 422} => :cast_and_validate_422,
+    {"PATCH /api/team/{agent_id}/schedules/{id}", 422} => :cast_and_validate_422,
+    {"POST /api/admin/users/{id}/credits", 422} => :cast_and_validate_422,
+    {"POST /api/admin/users/{id}/sandbox-limit", 422} => :cast_and_validate_422,
+    {"POST /api/agents", 422} => :cast_and_validate_422,
+    {"POST /api/apply", 422} => :cast_and_validate_422,
+    {"POST /api/auth/api-keys", 422} => :cast_and_validate_422,
+    {"POST /api/auth/password", 422} => :cast_and_validate_422,
+    {"POST /api/auth/register", 422} => :cast_and_validate_422,
+    {"POST /api/auth/reset", 422} => :cast_and_validate_422,
+    {"POST /api/buzz/agents", 422} => :cast_and_validate_422,
+    {"POST /api/conversations", 422} => :cast_and_validate_422,
+    {"POST /api/secret-bindings", 422} => :cast_and_validate_422,
+    {"POST /api/support/reports", 422} => :cast_and_validate_422,
+    {"POST /api/team/{agent_id}/contact", 422} => :cast_and_validate_422,
+    {"POST /api/team/{agent_id}/schedules", 422} => :cast_and_validate_422,
+    {"POST /api/vaults", 422} => :cast_and_validate_422,
+    {"POST /api/webhooks", 422} => :cast_and_validate_422,
+    {"PUT /api/account/inference-credentials/{provider}", 422} => :cast_and_validate_422,
+    {"PUT /api/environments/{id}", 422} => :cast_and_validate_422,
+    {"PUT /api/vaults/{id}", 422} => :cast_and_validate_422,
+
+    # ── log_event_empty_state (1) ─────────────────────────────
+    {"GET /api/conversations/{conversation_id}/events", 200} => :log_event_empty_state,
+
+    # ── test_fixture_vocabulary (1) ─────────────────────────────
+    {"GET /api/conversations/{id}", 200} => :test_fixture_vocabulary,
+
+    # ── openai_error_shape (1) ─────────────────────────────
+    {"POST /v1/chat/completions", 409} => :openai_error_shape
+  }
+
+  @doc "Is this `{operation, status}` a known, recorded disagreement?"
+  @spec allowed?(String.t(), integer()) :: boolean()
+  def allowed?(operation, status), do: Map.has_key?(@entries, {operation, status})
+
+  @doc "The reason family for one entry, or nil."
+  @spec reason(String.t(), integer()) :: String.t() | nil
+  def reason(operation, status) do
+    case Map.get(@entries, {operation, status}) do
+      nil -> nil
+      family -> Map.fetch!(@reasons, family)
+    end
+  end
+
+  @doc "Every entry, for the guardrail's hygiene checks."
+  @spec entries() :: %{{String.t(), integer()} => atom()}
+  def entries, do: @entries
+
+  @doc "The families and their prose."
+  @spec reasons() :: %{atom() => String.t()}
+  def reasons, do: @reasons
+end

--- a/apps/fountain/test/test_helper.exs
+++ b/apps/fountain/test/test_helper.exs
@@ -54,3 +54,18 @@ Mimic.copy(Fountain.Health)
 Mimic.copy(FountainWeb.OAuth)
 Mimic.copy(Fountain.Mailer)
 Mimic.copy(Fountain.InferenceCredentials)
+
+# ─── The schema guard (#1427) ────────────────────────────────────────────────
+#
+# Every other check in this repository compares a schema with another schema.
+# `sdk/contract` projects the OpenAPI document and pins four SDKs to it,
+# `sdk/conformance` pins what those clients do with it, and both pass happily
+# when the document is a lie about its own controller. Three defects of that
+# shape surfaced in one day (#1417, #1418, #1427).
+#
+# This is the missing side of the comparison and it costs nothing per test:
+# `Plug.Telemetry` is already in the endpoint, so every response any controller
+# test produces is validated against the schema its operation declares. It
+# records; `FountainWeb.ConnCase` fails the test that caused it. See the
+# `attach/0` docstring for why it must not raise here.
+FountainWeb.SchemaGuard.attach()

--- a/scripts/sdk-contract/build.py
+++ b/scripts/sdk-contract/build.py
@@ -119,6 +119,25 @@ def project_type(node: Any) -> Dict[str, Any]:
     if isinstance(node.get("items"), dict):
         out["items"] = project_type(node["items"])
 
+    # An inline object — a response body declared in the `operation` macro
+    # rather than as a named schema — carries its properties here, and dropping
+    # them left the projection saying `{"type": "object"}`: a shape nothing can
+    # disagree with. That is how the 402 on POST /api/conversations looked like
+    # an undeclared body when the server declares `error` and `upgrade_url`
+    # perfectly well (#1427). Requiredness is read the same way as in
+    # `project_schema`: from the sibling `required` list, never from a default.
+    properties = node.get("properties")
+    if isinstance(properties, dict):
+        required = set(node.get("required") or [])
+        projected = {}
+        for prop, sub in properties.items():
+            entry = project_type(sub)
+            entry["required"] = prop in required
+            if isinstance(sub, dict) and "default" in sub:
+                entry["has_default"] = True
+            projected[prop] = entry
+        out["properties"] = projected
+
     for keyword in ("oneOf", "anyOf", "allOf"):
         if isinstance(node.get(keyword), list):
             out[keyword] = [project_type(member) for member in node[keyword]]

--- a/sdk/conformance/scenarios/history-drains-the-feed-across-pages.json
+++ b/sdk/conformance/scenarios/history-drains-the-feed-across-pages.json
@@ -44,7 +44,8 @@
           ],
           "meta": {
             "next_cursor": 2,
-            "has_more": true
+            "has_more": true,
+            "limit": 1000
           }
         }
       }
@@ -77,7 +78,8 @@
           ],
           "meta": {
             "next_cursor": 3,
-            "has_more": false
+            "has_more": false,
+            "limit": 1000
           }
         }
       }

--- a/sdk/conformance/scenarios/history-empty-feed-is-an-empty-list.json
+++ b/sdk/conformance/scenarios/history-empty-feed-is-an-empty-list.json
@@ -21,7 +21,8 @@
           "data": [],
           "meta": {
             "next_cursor": 0,
-            "has_more": false
+            "has_more": false,
+            "limit": 1000
           }
         }
       }

--- a/sdk/contract/contract.json
+++ b/sdk/contract/contract.json
@@ -1922,6 +1922,62 @@
       "responses": {
         "200": {
           "application/json": {
+            "properties": {
+              "data": {
+                "items": {
+                  "properties": {
+                    "created": {
+                      "required": false,
+                      "type": "integer"
+                    },
+                    "fountain": {
+                      "properties": {
+                        "agent_id": {
+                          "required": false,
+                          "type": "string"
+                        },
+                        "model": {
+                          "nullable": true,
+                          "required": false,
+                          "type": "string"
+                        },
+                        "runtime": {
+                          "required": false,
+                          "type": "string"
+                        }
+                      },
+                      "required": false,
+                      "type": "object"
+                    },
+                    "id": {
+                      "required": false,
+                      "type": "string"
+                    },
+                    "object": {
+                      "enum": [
+                        "model"
+                      ],
+                      "required": false,
+                      "type": "string"
+                    },
+                    "owned_by": {
+                      "required": false,
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "required": false,
+                "type": "array"
+              },
+              "object": {
+                "enum": [
+                  "list"
+                ],
+                "required": false,
+                "type": "string"
+              }
+            },
             "type": "object"
           }
         }
@@ -1935,11 +1991,77 @@
       "responses": {
         "200": {
           "application/json": {
+            "properties": {
+              "created": {
+                "required": false,
+                "type": "integer"
+              },
+              "fountain": {
+                "properties": {
+                  "agent_id": {
+                    "required": false,
+                    "type": "string"
+                  },
+                  "model": {
+                    "nullable": true,
+                    "required": false,
+                    "type": "string"
+                  },
+                  "runtime": {
+                    "required": false,
+                    "type": "string"
+                  }
+                },
+                "required": false,
+                "type": "object"
+              },
+              "id": {
+                "required": false,
+                "type": "string"
+              },
+              "object": {
+                "enum": [
+                  "model"
+                ],
+                "required": false,
+                "type": "string"
+              },
+              "owned_by": {
+                "required": false,
+                "type": "string"
+              }
+            },
             "type": "object"
           }
         },
         "404": {
           "application/json": {
+            "properties": {
+              "error": {
+                "properties": {
+                  "code": {
+                    "nullable": true,
+                    "required": false,
+                    "type": "string"
+                  },
+                  "message": {
+                    "required": false,
+                    "type": "string"
+                  },
+                  "param": {
+                    "nullable": true,
+                    "required": false,
+                    "type": "string"
+                  },
+                  "type": {
+                    "required": false,
+                    "type": "string"
+                  }
+                },
+                "required": false,
+                "type": "object"
+              }
+            },
             "type": "object"
           }
         }
@@ -2593,6 +2715,45 @@
       "request_body": {
         "content": {
           "application/json": {
+            "properties": {
+              "context": {
+                "items": {
+                  "type": "object"
+                },
+                "required": false,
+                "type": "array"
+              },
+              "forwardedProps": {
+                "required": false,
+                "type": "object"
+              },
+              "messages": {
+                "items": {
+                  "type": "object"
+                },
+                "required": true,
+                "type": "array"
+              },
+              "runId": {
+                "required": true,
+                "type": "string"
+              },
+              "state": {
+                "required": false,
+                "type": "object"
+              },
+              "threadId": {
+                "required": true,
+                "type": "string"
+              },
+              "tools": {
+                "items": {
+                  "type": "object"
+                },
+                "required": false,
+                "type": "array"
+              }
+            },
             "type": "object"
           }
         },
@@ -3089,6 +3250,16 @@
         },
         "402": {
           "application/json": {
+            "properties": {
+              "error": {
+                "required": false,
+                "type": "string"
+              },
+              "upgrade_url": {
+                "required": false,
+                "type": "string"
+              }
+            },
             "type": "object"
           }
         },
@@ -3723,6 +3894,39 @@
       "request_body": {
         "content": {
           "application/json": {
+            "properties": {
+              "messages": {
+                "items": {
+                  "type": "object"
+                },
+                "required": true,
+                "type": "array"
+              },
+              "model": {
+                "required": true,
+                "type": "string"
+              },
+              "stream": {
+                "has_default": true,
+                "required": false,
+                "type": "boolean"
+              },
+              "tool_choice": {
+                "required": false,
+                "type": "string"
+              },
+              "tools": {
+                "items": {
+                  "type": "object"
+                },
+                "required": false,
+                "type": "array"
+              },
+              "user": {
+                "required": false,
+                "type": "string"
+              }
+            },
             "type": "object"
           }
         },
@@ -3731,21 +3935,206 @@
       "responses": {
         "200": {
           "application/json": {
+            "properties": {
+              "choices": {
+                "items": {
+                  "properties": {
+                    "finish_reason": {
+                      "enum": [
+                        "stop",
+                        "tool_calls"
+                      ],
+                      "required": false,
+                      "type": "string"
+                    },
+                    "index": {
+                      "required": false,
+                      "type": "integer"
+                    },
+                    "message": {
+                      "properties": {
+                        "content": {
+                          "required": false,
+                          "type": "string"
+                        },
+                        "reasoning_content": {
+                          "required": false,
+                          "type": "string"
+                        },
+                        "role": {
+                          "enum": [
+                            "assistant"
+                          ],
+                          "required": false,
+                          "type": "string"
+                        },
+                        "tool_calls": {
+                          "items": {
+                            "type": "object"
+                          },
+                          "required": false,
+                          "type": "array"
+                        }
+                      },
+                      "required": false,
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "required": false,
+                "type": "array"
+              },
+              "created": {
+                "required": false,
+                "type": "integer"
+              },
+              "fountain": {
+                "properties": {
+                  "conversation_id": {
+                    "required": false,
+                    "type": "string"
+                  },
+                  "thread": {
+                    "required": false,
+                    "type": "string"
+                  },
+                  "turn_id": {
+                    "nullable": true,
+                    "required": false,
+                    "type": "string"
+                  }
+                },
+                "required": false,
+                "type": "object"
+              },
+              "id": {
+                "required": false,
+                "type": "string"
+              },
+              "model": {
+                "required": false,
+                "type": "string"
+              },
+              "object": {
+                "enum": [
+                  "chat.completion"
+                ],
+                "required": false,
+                "type": "string"
+              },
+              "usage": {
+                "properties": {
+                  "completion_tokens": {
+                    "required": false,
+                    "type": "integer"
+                  },
+                  "prompt_tokens": {
+                    "required": false,
+                    "type": "integer"
+                  },
+                  "total_tokens": {
+                    "required": false,
+                    "type": "integer"
+                  }
+                },
+                "required": false,
+                "type": "object"
+              }
+            },
             "type": "object"
           }
         },
         "400": {
           "application/json": {
+            "properties": {
+              "error": {
+                "properties": {
+                  "code": {
+                    "nullable": true,
+                    "required": false,
+                    "type": "string"
+                  },
+                  "message": {
+                    "required": false,
+                    "type": "string"
+                  },
+                  "param": {
+                    "nullable": true,
+                    "required": false,
+                    "type": "string"
+                  },
+                  "type": {
+                    "required": false,
+                    "type": "string"
+                  }
+                },
+                "required": false,
+                "type": "object"
+              }
+            },
             "type": "object"
           }
         },
         "404": {
           "application/json": {
+            "properties": {
+              "error": {
+                "properties": {
+                  "code": {
+                    "nullable": true,
+                    "required": false,
+                    "type": "string"
+                  },
+                  "message": {
+                    "required": false,
+                    "type": "string"
+                  },
+                  "param": {
+                    "nullable": true,
+                    "required": false,
+                    "type": "string"
+                  },
+                  "type": {
+                    "required": false,
+                    "type": "string"
+                  }
+                },
+                "required": false,
+                "type": "object"
+              }
+            },
             "type": "object"
           }
         },
         "409": {
           "application/json": {
+            "properties": {
+              "error": {
+                "properties": {
+                  "code": {
+                    "nullable": true,
+                    "required": false,
+                    "type": "string"
+                  },
+                  "message": {
+                    "required": false,
+                    "type": "string"
+                  },
+                  "param": {
+                    "nullable": true,
+                    "required": false,
+                    "type": "string"
+                  },
+                  "type": {
+                    "required": false,
+                    "type": "string"
+                  }
+                },
+                "required": false,
+                "type": "object"
+              }
+            },
             "type": "object"
           }
         }
@@ -4030,6 +4419,38 @@
       "properties": {
         "data": {
           "items": {
+            "properties": {
+              "actor_user_id": {
+                "format": "uuid",
+                "nullable": true,
+                "required": false,
+                "type": "string"
+              },
+              "event_type": {
+                "required": true,
+                "type": "string"
+              },
+              "id": {
+                "required": false,
+                "type": "integer"
+              },
+              "inserted_at": {
+                "format": "date-time",
+                "required": false,
+                "type": "string"
+              },
+              "metadata": {
+                "additionalProperties": true,
+                "required": false,
+                "type": "object"
+              },
+              "target_user_id": {
+                "format": "uuid",
+                "nullable": true,
+                "required": false,
+                "type": "string"
+              }
+            },
             "type": "object"
           },
           "required": true,
@@ -4041,6 +4462,22 @@
     "AdminReapResponse": {
       "properties": {
         "data": {
+          "properties": {
+            "outcome": {
+              "enum": [
+                "already_terminal",
+                "released",
+                "terminated"
+              ],
+              "required": true,
+              "type": "string"
+            },
+            "sandbox_id": {
+              "format": "uuid",
+              "required": false,
+              "type": "string"
+            }
+          },
           "required": true,
           "type": "object"
         }
@@ -4233,6 +4670,20 @@
           "type": "array"
         },
         "meta": {
+          "properties": {
+            "page": {
+              "required": true,
+              "type": "integer"
+            },
+            "per_page": {
+              "required": true,
+              "type": "integer"
+            },
+            "total": {
+              "required": true,
+              "type": "integer"
+            }
+          },
           "required": true,
           "type": "object"
         }
@@ -4369,6 +4820,24 @@
         },
         "skills": {
           "items": {
+            "properties": {
+              "content": {
+                "required": false,
+                "type": "string"
+              },
+              "name": {
+                "required": false,
+                "type": "string"
+              },
+              "ref": {
+                "required": false,
+                "type": "string"
+              },
+              "source": {
+                "required": false,
+                "type": "string"
+              }
+            },
             "type": "object"
           },
           "required": false,
@@ -4490,6 +4959,24 @@
         },
         "skills": {
           "items": {
+            "properties": {
+              "content": {
+                "required": false,
+                "type": "string"
+              },
+              "name": {
+                "required": false,
+                "type": "string"
+              },
+              "ref": {
+                "required": false,
+                "type": "string"
+              },
+              "source": {
+                "required": false,
+                "type": "string"
+              }
+            },
             "type": "object"
           },
           "required": false,
@@ -4603,6 +5090,24 @@
         },
         "skills": {
           "items": {
+            "properties": {
+              "content": {
+                "required": false,
+                "type": "string"
+              },
+              "name": {
+                "required": false,
+                "type": "string"
+              },
+              "ref": {
+                "required": false,
+                "type": "string"
+              },
+              "source": {
+                "required": false,
+                "type": "string"
+              }
+            },
             "type": "object"
           },
           "required": false,
@@ -4770,6 +5275,15 @@
     "ApplyResponse": {
       "properties": {
         "data": {
+          "properties": {
+            "results": {
+              "items": {
+                "ref": "ApplyResult"
+              },
+              "required": true,
+              "type": "array"
+            }
+          },
           "required": true,
           "type": "object"
         }
@@ -4887,6 +5401,21 @@
           "type": "array"
         },
         "meta": {
+          "properties": {
+            "has_more": {
+              "required": true,
+              "type": "boolean"
+            },
+            "limit": {
+              "required": true,
+              "type": "integer"
+            },
+            "next_cursor": {
+              "nullable": true,
+              "required": false,
+              "type": "integer"
+            }
+          },
           "required": true,
           "type": "object"
         }
@@ -5006,6 +5535,16 @@
     "AvatarGenerateResponse": {
       "properties": {
         "data": {
+          "properties": {
+            "data": {
+              "required": true,
+              "type": "string"
+            },
+            "media_type": {
+              "required": true,
+              "type": "string"
+            }
+          },
           "required": true,
           "type": "object"
         }
@@ -5034,6 +5573,102 @@
     "BillingResponse": {
       "properties": {
         "data": {
+          "properties": {
+            "credits": {
+              "nullable": true,
+              "properties": {
+                "balance_cents": {
+                  "required": false,
+                  "type": "integer"
+                },
+                "expires_at": {
+                  "format": "date-time",
+                  "nullable": true,
+                  "required": false,
+                  "type": "string"
+                },
+                "expiring_cents": {
+                  "required": false,
+                  "type": "integer"
+                },
+                "packs_cents": {
+                  "items": {
+                    "type": "integer"
+                  },
+                  "required": false,
+                  "type": "array"
+                },
+                "purchased_cents": {
+                  "required": false,
+                  "type": "integer"
+                },
+                "turn_hour_cents": {
+                  "required": false,
+                  "type": "integer"
+                }
+              },
+              "required": false,
+              "type": "object"
+            },
+            "has_stripe_customer": {
+              "required": false,
+              "type": "boolean"
+            },
+            "period": {
+              "properties": {
+                "end": {
+                  "format": "date-time",
+                  "required": false,
+                  "type": "string"
+                },
+                "start": {
+                  "format": "date-time",
+                  "required": false,
+                  "type": "string"
+                }
+              },
+              "required": false,
+              "type": "object"
+            },
+            "sandbox_cap": {
+              "required": false,
+              "type": "integer"
+            },
+            "usage": {
+              "properties": {
+                "conversations": {
+                  "required": false,
+                  "type": "integer"
+                },
+                "credit_burned_cents": {
+                  "nullable": true,
+                  "required": false,
+                  "type": "integer"
+                },
+                "sandbox_minutes": {
+                  "required": false,
+                  "type": "number"
+                },
+                "sandbox_minutes_by_provider": {
+                  "additionalProperties": {
+                    "type": "number"
+                  },
+                  "required": false,
+                  "type": "object"
+                },
+                "turn_hours": {
+                  "required": false,
+                  "type": "number"
+                },
+                "turns": {
+                  "required": false,
+                  "type": "integer"
+                }
+              },
+              "required": true,
+              "type": "object"
+            }
+          },
           "required": true,
           "type": "object"
         }
@@ -5328,6 +5963,122 @@
     "CatalogResponse": {
       "properties": {
         "data": {
+          "properties": {
+            "apps": {
+              "properties": {
+                "conversations": {
+                  "nullable": true,
+                  "required": true,
+                  "type": "string"
+                },
+                "team": {
+                  "nullable": true,
+                  "required": true,
+                  "type": "string"
+                }
+              },
+              "required": true,
+              "type": "object"
+            },
+            "avatar": {
+              "properties": {
+                "bases": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "required": true,
+                  "type": "array"
+                },
+                "moods": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "required": true,
+                  "type": "array"
+                }
+              },
+              "required": true,
+              "type": "object"
+            },
+            "mcp_servers": {
+              "items": {
+                "properties": {
+                  "dcr": {
+                    "required": true,
+                    "type": "boolean"
+                  },
+                  "name": {
+                    "required": true,
+                    "type": "string"
+                  },
+                  "slug": {
+                    "required": true,
+                    "type": "string"
+                  },
+                  "url": {
+                    "required": true,
+                    "type": "string"
+                  },
+                  "verified_on": {
+                    "format": "date",
+                    "required": true,
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "required": false,
+              "type": "array"
+            },
+            "model_providers": {
+              "items": {
+                "type": "string"
+              },
+              "required": false,
+              "type": "array"
+            },
+            "models": {
+              "additionalProperties": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "required": true,
+              "type": "object"
+            },
+            "package_managers": {
+              "items": {
+                "type": "string"
+              },
+              "required": true,
+              "type": "array"
+            },
+            "runtimes": {
+              "items": {
+                "type": "string"
+              },
+              "required": true,
+              "type": "array"
+            },
+            "sandbox_providers": {
+              "properties": {
+                "default": {
+                  "required": true,
+                  "type": "string"
+                },
+                "enabled": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "required": true,
+                  "type": "array"
+                }
+              },
+              "required": true,
+              "type": "object"
+            }
+          },
           "required": true,
           "type": "object"
         }
@@ -5353,6 +6104,48 @@
       "properties": {
         "choices": {
           "items": {
+            "properties": {
+              "finish_reason": {
+                "enum": [
+                  "stop",
+                  "tool_calls"
+                ],
+                "required": false,
+                "type": "string"
+              },
+              "index": {
+                "required": false,
+                "type": "integer"
+              },
+              "message": {
+                "properties": {
+                  "content": {
+                    "required": false,
+                    "type": "string"
+                  },
+                  "reasoning_content": {
+                    "required": false,
+                    "type": "string"
+                  },
+                  "role": {
+                    "enum": [
+                      "assistant"
+                    ],
+                    "required": false,
+                    "type": "string"
+                  },
+                  "tool_calls": {
+                    "items": {
+                      "type": "object"
+                    },
+                    "required": false,
+                    "type": "array"
+                  }
+                },
+                "required": false,
+                "type": "object"
+              }
+            },
             "type": "object"
           },
           "required": false,
@@ -5363,6 +6156,21 @@
           "type": "integer"
         },
         "fountain": {
+          "properties": {
+            "conversation_id": {
+              "required": false,
+              "type": "string"
+            },
+            "thread": {
+              "required": false,
+              "type": "string"
+            },
+            "turn_id": {
+              "nullable": true,
+              "required": false,
+              "type": "string"
+            }
+          },
           "required": false,
           "type": "object"
         },
@@ -5382,6 +6190,20 @@
           "type": "string"
         },
         "usage": {
+          "properties": {
+            "completion_tokens": {
+              "required": false,
+              "type": "integer"
+            },
+            "prompt_tokens": {
+              "required": false,
+              "type": "integer"
+            },
+            "total_tokens": {
+              "required": false,
+              "type": "integer"
+            }
+          },
           "required": false,
           "type": "object"
         }
@@ -6259,6 +7081,15 @@
         },
         "networking_config": {
           "additionalProperties": true,
+          "properties": {
+            "allowed_hosts": {
+              "items": {
+                "type": "string"
+              },
+              "required": false,
+              "type": "array"
+            }
+          },
           "required": false,
           "type": "object"
         },
@@ -6330,6 +7161,15 @@
         },
         "networking_config": {
           "additionalProperties": true,
+          "properties": {
+            "allowed_hosts": {
+              "items": {
+                "type": "string"
+              },
+              "required": false,
+              "type": "array"
+            }
+          },
           "required": false,
           "type": "object"
         },
@@ -6389,6 +7229,15 @@
         },
         "networking_config": {
           "additionalProperties": true,
+          "properties": {
+            "allowed_hosts": {
+              "items": {
+                "type": "string"
+              },
+              "required": false,
+              "type": "array"
+            }
+          },
           "required": false,
           "type": "object"
         },
@@ -6653,6 +7502,21 @@
           "type": "array"
         },
         "meta": {
+          "properties": {
+            "has_more": {
+              "required": true,
+              "type": "boolean"
+            },
+            "limit": {
+              "required": true,
+              "type": "integer"
+            },
+            "next_cursor": {
+              "nullable": true,
+              "required": false,
+              "type": "integer"
+            }
+          },
           "required": true,
           "type": "object"
         }
@@ -6698,6 +7562,21 @@
           "type": "integer"
         },
         "fountain": {
+          "properties": {
+            "agent_id": {
+              "required": false,
+              "type": "string"
+            },
+            "model": {
+              "nullable": true,
+              "required": false,
+              "type": "string"
+            },
+            "runtime": {
+              "required": false,
+              "type": "string"
+            }
+          },
           "required": false,
           "type": "object"
         },
@@ -6764,6 +7643,30 @@
     "OnboardingResponse": {
       "properties": {
         "data": {
+          "properties": {
+            "completed": {
+              "required": true,
+              "type": "boolean"
+            },
+            "completed_at": {
+              "format": "date-time",
+              "nullable": true,
+              "required": false,
+              "type": "string"
+            },
+            "state": {
+              "enum": [
+                "completed",
+                "step_1",
+                "step_2",
+                "step_3",
+                "step_4"
+              ],
+              "nullable": true,
+              "required": false,
+              "type": "string"
+            }
+          },
           "required": true,
           "type": "object"
         }
@@ -6773,6 +7676,26 @@
     "OpenAIError": {
       "properties": {
         "error": {
+          "properties": {
+            "code": {
+              "nullable": true,
+              "required": false,
+              "type": "string"
+            },
+            "message": {
+              "required": false,
+              "type": "string"
+            },
+            "param": {
+              "nullable": true,
+              "required": false,
+              "type": "string"
+            },
+            "type": {
+              "required": false,
+              "type": "string"
+            }
+          },
           "required": false,
           "type": "object"
         }
@@ -7068,6 +7991,18 @@
         },
         "checkpoint": {
           "nullable": true,
+          "properties": {
+            "at": {
+              "format": "date-time",
+              "nullable": true,
+              "required": false,
+              "type": "string"
+            },
+            "id": {
+              "required": false,
+              "type": "string"
+            }
+          },
           "required": false,
           "type": "object"
         },
@@ -7102,6 +8037,33 @@
         },
         "runner": {
           "nullable": true,
+          "properties": {
+            "hostname": {
+              "nullable": true,
+              "required": false,
+              "type": "string"
+            },
+            "id": {
+              "format": "uuid",
+              "nullable": true,
+              "required": false,
+              "type": "string"
+            },
+            "name": {
+              "nullable": true,
+              "required": false,
+              "type": "string"
+            },
+            "online": {
+              "required": true,
+              "type": "boolean"
+            },
+            "path": {
+              "nullable": true,
+              "required": false,
+              "type": "string"
+            }
+          },
           "required": false,
           "type": "object"
         },
@@ -7190,6 +8152,18 @@
         },
         "checkpoint": {
           "nullable": true,
+          "properties": {
+            "at": {
+              "format": "date-time",
+              "nullable": true,
+              "required": false,
+              "type": "string"
+            },
+            "id": {
+              "required": false,
+              "type": "string"
+            }
+          },
           "required": false,
           "type": "object"
         },
@@ -7242,6 +8216,33 @@
         },
         "runner": {
           "nullable": true,
+          "properties": {
+            "hostname": {
+              "nullable": true,
+              "required": false,
+              "type": "string"
+            },
+            "id": {
+              "format": "uuid",
+              "nullable": true,
+              "required": false,
+              "type": "string"
+            },
+            "name": {
+              "nullable": true,
+              "required": false,
+              "type": "string"
+            },
+            "online": {
+              "required": true,
+              "type": "boolean"
+            },
+            "path": {
+              "nullable": true,
+              "required": false,
+              "type": "string"
+            }
+          },
           "required": false,
           "type": "object"
         },
@@ -7481,6 +8482,20 @@
           "type": "array"
         },
         "meta": {
+          "properties": {
+            "has_more": {
+              "required": true,
+              "type": "boolean"
+            },
+            "limit": {
+              "required": true,
+              "type": "integer"
+            },
+            "offset": {
+              "required": true,
+              "type": "integer"
+            }
+          },
           "required": true,
           "type": "object"
         }
@@ -7744,6 +8759,13 @@
     "StripeUrlResponse": {
       "properties": {
         "data": {
+          "properties": {
+            "url": {
+              "format": "uri",
+              "required": true,
+              "type": "string"
+            }
+          },
           "required": true,
           "type": "object"
         }
@@ -7854,6 +8876,22 @@
         },
         "screenshot": {
           "nullable": true,
+          "properties": {
+            "data": {
+              "required": true,
+              "type": "string"
+            },
+            "media_type": {
+              "enum": [
+                "image/gif",
+                "image/jpeg",
+                "image/png",
+                "image/webp"
+              ],
+              "required": true,
+              "type": "string"
+            }
+          },
           "required": false,
           "type": "object"
         }
@@ -8150,6 +9188,39 @@
         },
         "last_turn": {
           "nullable": true,
+          "properties": {
+            "id": {
+              "format": "uuid",
+              "required": false,
+              "type": "string"
+            },
+            "inserted_at": {
+              "format": "date-time",
+              "required": false,
+              "type": "string"
+            },
+            "prompt": {
+              "required": false,
+              "type": "string"
+            },
+            "status": {
+              "required": false,
+              "type": "string"
+            },
+            "turn_number": {
+              "required": false,
+              "type": "integer"
+            },
+            "usage": {
+              "nullable": true,
+              "oneOf": [
+                {
+                  "ref": "TurnUsage"
+                }
+              ],
+              "required": false
+            }
+          },
           "required": false,
           "type": "object"
         },
@@ -8158,11 +9229,47 @@
           "type": "string"
         },
         "presence": {
+          "properties": {
+            "label": {
+              "required": true,
+              "type": "string"
+            },
+            "state": {
+              "enum": [
+                "asleep",
+                "away",
+                "failed",
+                "machine_offline",
+                "offline",
+                "online",
+                "starting",
+                "working"
+              ],
+              "required": true,
+              "type": "string"
+            }
+          },
           "required": true,
           "type": "object"
         },
         "preview": {
           "nullable": true,
+          "properties": {
+            "kind": {
+              "enum": [
+                "them",
+                "typing",
+                "you"
+              ],
+              "required": false,
+              "type": "string"
+            },
+            "text": {
+              "nullable": true,
+              "required": false,
+              "type": "string"
+            }
+          },
           "required": false,
           "type": "object"
         },
@@ -8218,6 +9325,12 @@
           "ref": "Conversation"
         },
         {
+          "properties": {
+            "current": {
+              "required": true,
+              "type": "boolean"
+            }
+          },
           "type": "object"
         }
       ]


### PR DESCRIPTION
Closes #1427

Every other check in this repository compares a schema with another schema.
`sdk/contract` (#1411) projects the OpenAPI document and pins four SDKs to it,
`sdk/conformance` (#1412) pins what those clients do with it, and both pass
happily when the document is a lie about the action that renders it.

## Which shape, and why

**Both, and the split is measured rather than chosen.**

I wired the validator to the endpoint telemetry `Plug.Telemetry` already emits
and ran the controller suite. The existing tests exercise **146 distinct
operations**, producing 687 validated responses. A guardrail test would have to
hand-drive 158 requests with fixtures to get near that, so the hook is where the
coverage comes from and it costs nothing per test.

But the hook cannot see two of the three defects the issue names. An optional
property that is never rendered still validates, and a `required` list naming a
property the schema does not have is worth catching before a request is made at
all. So the guardrail test asks the questions a rendered response cannot answer,
and lands green.

| | Catches | Lands |
|---|---|---|
| Hook (`test_helper.exs` + `ConnCase`) | rendered body vs declared schema, 146 operations | green, with the allowlist |
| `schema_guardrail_test.exs` static | `required` naming an absent property; a response declared as a propertyless object | green |
| `schema_guardrail_test.exs` exhaustive | a declared property the action never renders | green, `expires_at` exempted → #1418 |

## The one non-obvious thing

**The hook must not raise.** `:telemetry` wraps a handler in a try/catch: a
handler that raises is logged and then *detached*, so the raise fails nothing
and every response after it goes unchecked. Wired that way, this guard reported
a deliberately reintroduced #1417 and the suite still finished
`7 tests, 0 failures`.

It records the violation against the process that made the request, and
`ConnCase` fails that test on the way out. `SchemaGuard.attach/0`'s docstring
says so, at the place someone would otherwise "simplify" it.

## Verified by reintroducing the defects, not by a green run

| Reintroduced | Result |
|---|---|
| `AuthMeResponse.required` naming `name`/`prefix`/`created_at` (#1417) | static check fails **and** every controller test hitting the endpoint fails, naming the missing fields and the body |
| Removing the `expires_at` exemption (#1418) | exhaustive check fails: `declares ["expires_at"] … and did not render it` |
| Making the 402 a propertyless object | static check fails, naming `POST /api/conversations -> 402` |

Full suite with the guard live: **4058 tests, 0 failures**, zero violations.

## Defect 3 in the issue was mine, not the server's

`POST /api/conversations` declares its 402 as `{error, upgrade_url}` and always
has. `scripts/sdk-contract/build.py` was dropping the properties of an **inline**
schema when projecting one, so `contract.json` said `{"type": "object"}` — and I
reported that as an undeclared body while writing the #1412 linter. Fixed here.

That fix immediately made `sdk/conformance`'s fixture check stronger: it caught
two scenarios omitting `meta.limit`, which the real server always sends. Both
fixtures corrected.

The static "every declared response says something" check stays, because a
propertyless response is a real hazard even with nothing in that state today.

## What the guard found

All filed, all allowlisted rather than fixed here, one `{operation, status}`
entry each so a second instance of any of them still fails:

| Issue | Family | Operations |
|---|---|---|
| #1432 | operations do not declare the statuses their pipeline plugs return (401 auth, 403 admin, 429 rate limit, 503 not-ready …) | 68 |
| #1431 | declare `Error`/`ChangesetError` for 422, but `CastAndValidate` renders its own `{"errors":[…]}` | 27 |
| #1430 | `LogEvent` renders `state` and `stage` as `""`, which the enum omits — and all four SDKs decode that field | 1 |
| #1433 | the OpenAI gateway's 409 renders `error` as a string while `OpenAIError` declares an object | 1 |
| — | a fixture inserting `runtime: "retired-runtime"` on purpose; not an API defect | 1 |

**#1430 is the one worth reading.** `LogEvent`'s changeset validates against
`["" | @states]` and stores `""`, while the schema's enum is
`started done failed interrupted`. `sdk/conformance` pins that enum across four
clients, so a strict enum decoder would reject a real event on the busiest read
in the API. Which way it goes (render `null`, add `""`, or drop the enum) is an
API decision, so it is filed rather than decided.

**#1418 stays exempted with its pointer**, per your instruction: whether
`expires_at` should be rendered or dropped is a real API decision.

## The ratchet

`FountainWeb.SchemaGuardAllowlist` holds 98 pairs with five reason families.
`@ceiling 98` in the guardrail test means growing the list requires editing a
number in the same diff, so growth is visible in review; shrinking is just
deleting a line. Two hygiene tests keep it honest: every entry names a family
that has a reason, and every entry names an operation the API still serves — so
a fix that lands elsewhere cannot leave a stale exemption behind.

## Verification

- `mix precommit`: **6 doctests, 4058 tests, 0 failures**; compile with
  warnings-as-errors, unused deps, format, `credo --strict` (found no issues),
  dialyzer `Total errors: 0`, sobelow all passed. No pool-checkout flakes this
  run — see the note below.
- All four SDK contract checks and all four conformance adapters re-run after
  the `contract.json` change: green.
- No CI change needed: the guardrail test runs in the normal partitions and the
  hook runs wherever a controller test does.

## Note on the Postgres ceiling

Your `max_connections` raise landed — it reads 400 with 6 in use. The
`DBConnection` checkout failures I saw earlier were **not** the server ceiling:
they were in-VM contention between `pool_size: 20` and `max_cases: 20` when
`Fountain.CreditsTest`'s concurrent-post test spawns tasks under full-suite
load. It passed 24/24 alone every time and did not recur in either full run
here. Reporting rather than working around it, as you asked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BXYa9CQNG8oFNq5YhAxva
