### PR TITLE
feat(cli): auth register waits for verification; quickstart runs the request

### DIFF
--- a/apps/fountain/lib/fountain/onboarding.ex
+++ b/apps/fountain/lib/fountain/onboarding.ex
@@ -106,6 +106,20 @@ defmodule Fountain.Onboarding do
     ~w($FOUNTAIN_BASE_URL $FOUNTAIN_API_KEY $FOUNTAIN_AGENT_ID $FOUNTAIN_AGENT_NAME)
   end
 
+  @doc """
+  The placeholders still present in `text`, in `placeholders/0` order.
+
+  `GET /api/catalog` answers with this rather than the whole list: the server
+  fills the base URL in before it hands the snippet over, so a client told to
+  substitute `$FOUNTAIN_BASE_URL` would be looking for a token that is not
+  there. What is left is exactly what the caller has and the server does not
+  — its own raw key, and the agent it picked.
+  """
+  @spec remaining_placeholders(String.t()) :: [String.t()]
+  def remaining_placeholders(text) when is_binary(text) do
+    Enum.filter(placeholders(), &String.contains?(text, &1))
+  end
+
   defp replace(text, _token, nil), do: text
   defp replace(text, token, value), do: String.replace(text, token, to_string(value))
 

--- a/apps/fountain/lib/fountain_web/controllers/catalog_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/catalog_controller.ex
@@ -5,17 +5,23 @@ defmodule FountainWeb.CatalogController do
   the sandbox providers usable here and the default, the package managers
   an environment accepts, the avatar generator's bases and moods (#815),
   where this instance's browser apps live (#866), and the remote MCP
-  servers verified to complete connection discovery (#1322).
+  servers verified to complete connection discovery (#1322), and the first
+  request (ADR 0038).
 
   Everything here is already public through the forms; this is the same
   lists over the API so a client on another origin does not hard-code them
-  and drift from the server.
+  and drift from the server. `first_request` is that argument applied to the
+  onboarding snippet: the verified landing prints it, `docs/quickstart.md`
+  prints it, and `fountain auth register` prints it, so the text has to come
+  from one place or the three will disagree. `Fountain.Onboarding` is that
+  place; this is how a client that is not the server reaches it.
   """
   use FountainWeb, :controller
   use OpenApiSpex.ControllerSpecs
 
   alias Fountain.Agents.Agent
   alias Fountain.Agents.ModelCatalog
+  alias Fountain.Onboarding
   alias Managoat.Runtimes.Model
   alias FountainWeb.Schemas
 
@@ -33,12 +39,15 @@ defmodule FountainWeb.CatalogController do
         "browser apps this instance sends people to for conversations and the team, " <>
         "and remote MCP servers verified to complete connection discovery " <>
         "(again suggestions — any URL can be discovered), each with the date " <>
-        "it was last verified.",
+        "it was last verified. Also `first_request`, the one onboarding " <>
+        "snippet this deployment hands out, with its base URL already in it " <>
+        "and the caller's own key and agent left as placeholders.",
     responses: [ok: {"Catalog", "application/json", Schemas.CatalogResponse}]
   )
 
   def show(conn, _params) do
     runtimes = Agent.runtimes()
+    base_url = Fountain.PublicUrl.base()
 
     json(conn, %{
       data: %{
@@ -63,8 +72,36 @@ defmodule FountainWeb.CatalogController do
         # Remote MCP servers whose authorization chain is known to complete
         # (dated, re-checked by scripts/mcp-catalog-probe.exs) — so a client
         # can render "Connect Sentry"-style rows without hard-coding URLs.
-        mcp_servers: Fountain.Connections.McpServerCatalog.entries()
+        mcp_servers: Fountain.Connections.McpServerCatalog.entries(),
+        # The first request, from the one source the landing and the manual
+        # share (ADR 0038). Rendered with this deployment's base URL, which
+        # the server knows; the key and the agent stay placeholders, because
+        # the server holds only a *hash* of the caller's key and cannot fill
+        # one in. A client substitutes the key it already has and an agent it
+        # resolves from `GET /api/agents`, and `placeholders` names the exact
+        # tokens so it does not have to guess at them.
+        first_request: first_request(base_url)
       }
     })
+  end
+
+  defp first_request(base_url) do
+    curl = Onboarding.curl(base_url: base_url)
+
+    # The TypeScript keeps its bare `new Fountain()`, and that is not an
+    # oversight. The SDK resolves the key and the base URL exactly as the CLI
+    # does — option, then environment, then `~/.fountain/credentials` — so a
+    # constructor filled in here would be worse than the one the manual
+    # prints: it would carry a base URL and no key, which reads as a complete
+    # snippet and is not one. `curl` gets the base URL because `curl`
+    # resolves nothing.
+    typescript = Onboarding.typescript()
+
+    %{
+      curl: curl,
+      typescript: typescript,
+      prompt: Onboarding.prompt(),
+      placeholders: Onboarding.remaining_placeholders(curl <> typescript)
+    }
   end
 end

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -2845,6 +2845,32 @@ defmodule FountainWeb.Schemas do
                 },
                 required: [:slug, :name, :url, :dcr, :verified_on]
               }
+            },
+            first_request: %Schema{
+              type: :object,
+              description:
+                "The one onboarding request this deployment hands out (ADR 0038), " <>
+                  "the same text the verified landing and the manual print. The base " <>
+                  "URL is already in it. The caller's key and agent are not: the " <>
+                  "server stores only a hash of a key, so a client substitutes the " <>
+                  "key it holds and an agent from `GET /api/agents`.",
+              properties: %{
+                curl: %Schema{type: :string, description: "The `curl`, with placeholders."},
+                typescript: %Schema{
+                  type: :string,
+                  description: "The TypeScript SDK equivalent, with placeholders."
+                },
+                prompt: %Schema{
+                  type: :string,
+                  description: "The prompt both snippets send, for a client that runs it."
+                },
+                placeholders: %Schema{
+                  type: :array,
+                  items: %Schema{type: :string},
+                  description: "Every token a client must substitute before it runs the request."
+                }
+              },
+              required: [:curl, :typescript, :prompt, :placeholders]
             }
           },
           required: [
@@ -2853,7 +2879,8 @@ defmodule FountainWeb.Schemas do
             :sandbox_providers,
             :package_managers,
             :avatar,
-            :apps
+            :apps,
+            :first_request
           ]
         }
       },

--- a/apps/fountain/test/fountain_web/controllers/catalog_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/catalog_controller_test.exs
@@ -34,6 +34,43 @@ defmodule FountainWeb.CatalogControllerTest do
     assert {:ok, _} = Date.from_iso8601(linear["verified_on"])
   end
 
+  # ADR 0038: the landing, the manual and `fountain auth register` print the
+  # same request, so it has one source. This is how a client that is not the
+  # server reaches it.
+  test "GET /api/catalog carries the first request", %{conn: conn, raw_key: key} do
+    body = conn |> authed_with_key(key) |> get("/api/catalog") |> json_response(200)
+    first = body["data"]["first_request"]
+
+    assert first["curl"] == Fountain.Onboarding.curl(base_url: Fountain.PublicUrl.base())
+
+    # The SDK resolves its own key and base URL, so its snippet keeps the bare
+    # constructor the manual prints; a base URL with no key beside it would
+    # look finished and would not be.
+    assert first["typescript"] == Fountain.Onboarding.typescript()
+    assert first["typescript"] =~ "new Fountain()"
+
+    assert first["prompt"] == Fountain.Onboarding.prompt()
+    # Only what a client must still substitute: the base URL is already in.
+    assert first["placeholders"] ==
+             Fountain.Onboarding.remaining_placeholders(first["curl"] <> first["typescript"])
+
+    refute "$FOUNTAIN_BASE_URL" in first["placeholders"]
+
+    # The base URL is filled in, because the server knows it.
+    assert first["curl"] =~ Fountain.PublicUrl.base()
+    refute first["curl"] =~ "$FOUNTAIN_BASE_URL"
+
+    # The key is not, and cannot be: only a hash of it is stored.
+    assert first["curl"] =~ "$FOUNTAIN_API_KEY"
+    refute first["curl"] =~ key
+
+    # Every token a client must still substitute is named, so it does not
+    # have to scrape them out of the text.
+    for token <- first["placeholders"] do
+      assert String.contains?(first["curl"] <> first["typescript"], token)
+    end
+  end
+
   test "401 without a key", %{conn: conn} do
     assert conn |> get("/api/catalog") |> json_response(401)
   end

--- a/cli/internal/cmd/auth.go
+++ b/cli/internal/cmd/auth.go
@@ -55,8 +55,24 @@ func init() {
 		"sign in with email + password (the default when stdin is piped)")
 	loginCmd.Flags().Bool("api-key", false,
 		"paste an API key you created in the console")
+	registerCmd := &cobra.Command{
+		Use:   "register",
+		Short: "Create an account, wait for the emailed link, and save the key",
+		Long: "The terminal half of ADR 0038's path. Creates the account, waits " +
+			"while you click the link in your email, saves the API key, and prints " +
+			"the same first request the start page shows.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			email, _ := cmd.Flags().GetString("email")
+			password, _ := cmd.Flags().GetString("password")
+			return authRegister(email, password)
+		},
+	}
+	registerCmd.Flags().String("email", "", "email address (prompted for when omitted)")
+	registerCmd.Flags().String("password", "", "password (prompted for when omitted, which keeps it out of shell history)")
+
 	authCmd.AddCommand(
 		loginCmd,
+		registerCmd,
 		&cobra.Command{
 			Use:   "logout",
 			Short: "Remove saved credentials",

--- a/cli/internal/cmd/quickstart.go
+++ b/cli/internal/cmd/quickstart.go
@@ -1,0 +1,240 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/BinaryBourbon/fountain/cli/internal/config"
+	"github.com/BinaryBourbon/fountain/cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+// ── the first request, from the server ──────────────────────────────────
+//
+// ADR 0038 says the landing, the manual and this CLI print the same request.
+// That is only true if there is one copy of the text, and there is: the two
+// files under docs/snippets/, read at compile time by `Fountain.Onboarding`.
+// The CLI is Go and cannot read them — `go:embed` cannot reach outside
+// cli/'s own module, and a build-time copy would be a second file to keep in
+// step, which is the failure this is trying to avoid.
+//
+// So the text arrives over the wire, from `GET /api/catalog`, whose whole
+// purpose is already "the same lists over the API so a client does not
+// hard-code them and drift from the server". The server fills in the base
+// URL because it knows it; the CLI fills in the key, because the server
+// stores only a hash of it and genuinely cannot.
+
+const (
+	apiKeyPlaceholder    = "$FOUNTAIN_API_KEY"
+	agentIDPlaceholder   = "$FOUNTAIN_AGENT_ID"
+	agentNamePlaceholder = "$FOUNTAIN_AGENT_NAME"
+	starterAgentName     = "starter"
+)
+
+type firstRequest struct {
+	Curl         string   `json:"curl"`
+	TypeScript   string   `json:"typescript"`
+	Prompt       string   `json:"prompt"`
+	Placeholders []string `json:"placeholders"`
+}
+
+type namedAgent struct {
+	ID   string
+	Name string
+}
+
+// fetchFirstRequest reads the snippet out of the catalog with an explicit
+// key, so it works in `auth register` before the credentials file has been
+// re-read.
+func fetchFirstRequest(base, key string) (firstRequest, error) {
+	var out struct {
+		Data struct {
+			FirstRequest firstRequest `json:"first_request"`
+		} `json:"data"`
+	}
+
+	raw, err := getJSON(base, key, "/api/catalog")
+	if err != nil {
+		return firstRequest{}, err
+	}
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return firstRequest{}, err
+	}
+	return out.Data.FirstRequest, nil
+}
+
+// fetchDefaultAgent picks the agent the first request runs against: the
+// `starter` planted at verification, or failing that whatever the account
+// has. Same rule as the verified landing, for the same reason — the starter
+// is an ordinary agent and may be renamed or deleted.
+func fetchDefaultAgent(base, key string) (namedAgent, error) {
+	var out struct {
+		Data []map[string]any `json:"data"`
+	}
+
+	raw, err := getJSON(base, key, "/api/agents")
+	if err != nil {
+		return namedAgent{}, err
+	}
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return namedAgent{}, err
+	}
+	if len(out.Data) == 0 {
+		return namedAgent{}, fmt.Errorf("this account has no agent yet")
+	}
+
+	agents := make([]namedAgent, 0, len(out.Data))
+	for _, a := range out.Data {
+		agents = append(agents, namedAgent{
+			ID:   output.ToString(a["id"]),
+			Name: output.ToString(a["name"]),
+		})
+	}
+	for _, a := range agents {
+		if a.Name == starterAgentName {
+			return a, nil
+		}
+	}
+	return agents[0], nil
+}
+
+// render substitutes what the server could not: the caller's own key, and the
+// agent it just resolved.
+func (f firstRequest) render(key string, agent namedAgent) (curl, ts string) {
+	rep := strings.NewReplacer(
+		apiKeyPlaceholder, key,
+		agentIDPlaceholder, agent.ID,
+		agentNamePlaceholder, agent.Name,
+	)
+	return rep.Replace(f.Curl), rep.Replace(f.TypeScript)
+}
+
+// printFirstRequest is what `auth register` ends with: the same three things
+// the verified landing shows, in the order that page shows them.
+func printFirstRequest(w io.Writer, base, key string) {
+	req, err := fetchFirstRequest(base, key)
+	if err != nil {
+		fmt.Fprintf(w, "\nYour key is saved. Open %s/start for your first request.\n", base)
+		return
+	}
+
+	agent, aerr := fetchDefaultAgent(base, key)
+	if aerr != nil {
+		fmt.Fprintf(w, "\n%s. Create one with `fountain apply`, then run `fountain quickstart`.\n", aerr)
+		return
+	}
+
+	curl, ts := req.render(key, agent)
+
+	fmt.Fprintf(w, "\nOne request against your %s agent:\n\n%s\n", agent.Name, curl)
+	fmt.Fprintf(w, "\nOr from the TypeScript SDK:\n\n%s\n", ts)
+	fmt.Fprintf(w, "\nOr let this CLI run it for you:\n\n  fountain quickstart\n")
+}
+
+// ── fountain quickstart ─────────────────────────────────────────────────
+
+func init() {
+	rootCmd.AddCommand(&cobra.Command{
+		Use:   "quickstart",
+		Short: "Run the first request against your default agent and stream the reply",
+		Long: "Sends the same prompt the start page and the manual show, to the agent " +
+			"this account already has, and streams the reply. It is `fountain run` " +
+			"with the agent and the prompt filled in.",
+		RunE: func(cmd *cobra.Command, args []string) error { return quickstart() },
+	})
+}
+
+func quickstart() error {
+	opts := activeOpts()
+	base := config.BaseURL(opts)
+	key, err := config.APIKey(opts)
+	if err != nil || key == "" {
+		Fatal("no saved credentials. Run `fountain auth register` or `fountain auth login` first.")
+	}
+
+	req, err := fetchFirstRequest(base, key)
+	if err != nil {
+		Fatalf("could not read the first request from %s: %v", base, err)
+	}
+	agent, err := fetchDefaultAgent(base, key)
+	if err != nil {
+		Fatalf("%v. Create one with `fountain apply`, then try again", err)
+	}
+
+	fmt.Fprintf(os.Stderr, "▸ %s: %s\n", agent.Name, req.Prompt)
+
+	c := activeClient()
+	var resp struct {
+		Data map[string]any `json:"data"`
+	}
+	if err := c.Post("/conversations", map[string]any{
+		"agent_id": agent.ID,
+		"prompt":   req.Prompt,
+	}, &resp); err != nil {
+		Fatal(err.Error())
+	}
+
+	convID := output.ToString(resp.Data["id"])
+	fmt.Fprintf(os.Stderr, "▸ conversation %s\n", convID)
+
+	if err := followUntilIdle(convID, ""); err != nil {
+		printWhyItMightNotHaveAnswered(os.Stderr, base)
+		return err
+	}
+
+	printDoors(os.Stdout, base)
+	return nil
+}
+
+// printWhyItMightNotHaveAnswered runs when the first run a person ever starts
+// does not answer. It names the two things that stop one on a fresh account
+// and where to look, and it does NOT try to diagnose which: the server's own
+// error is above this, and guessing over it would be worse than pointing.
+//
+// The no-credential case is one of the two, and it is deliberately not
+// special-cased here — `InferenceCredentials.select/2` decides whether this
+// deployment covers an account that has none (#1388), and a client that
+// second-guessed that rule would go stale the moment a platform key appeared.
+func printWhyItMightNotHaveAnswered(w io.Writer, base string) {
+	fmt.Fprintf(w, "\nThe two usual reasons a first run does not answer:\n")
+	fmt.Fprintf(w, "  no model key for this account   %s/account/inference-credentials\n", base)
+	fmt.Fprintf(w, "  no sandbox provider configured  %s/docs/self-hosting\n", base)
+	fmt.Fprintf(w, "Your start page shows which of the two applies: %s/start\n", base)
+}
+
+// printDoors is the three doors the verified landing shows below the fold,
+// for the developer who never opened it.
+func printDoors(w io.Writer, base string) {
+	fmt.Fprintf(w, "\nThat reply came from your agent, in a sandbox Fountain started for it.\n\n")
+	fmt.Fprintf(w, "  Your own inference key   %s/account/inference-credentials\n", base)
+	fmt.Fprintf(w, "  Your own agents          fountain apply -f fountain.yml\n")
+	fmt.Fprintf(w, "  The SDK, for real code   %s/docs/sdk\n", base)
+}
+
+// getJSON is a bare authenticated GET. `api.Client` reads its key from the
+// config, and both callers here have one in hand that may not be on disk yet.
+func getJSON(base, key, path string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, base+path, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+key)
+
+	resp, err := (&http.Client{Timeout: 30 * time.Second}).Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	raw, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("GET %s: HTTP %d: %s", path, resp.StatusCode, strings.TrimSpace(string(raw)))
+	}
+	return raw, nil
+}

--- a/cli/internal/cmd/register.go
+++ b/cli/internal/cmd/register.go
@@ -1,0 +1,280 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/BinaryBourbon/fountain/cli/internal/config"
+	"github.com/BinaryBourbon/fountain/cli/internal/credentials"
+)
+
+// ── fountain auth register ──────────────────────────────────────────────
+//
+// The second door of ADR 0038: the same path as the verified landing, for a
+// developer who lives in a terminal. It creates the account, waits for the
+// verification the emailed link performs, saves the key, and prints the same
+// first request the landing shows.
+//
+// It does the steps rather than describing them. What it deliberately does
+// NOT do is anything the server already does: anti-enumeration and rate
+// limiting live on /api/auth/register and /api/auth/token and this adds
+// nothing to either.
+
+// pollSchedule is the wait between verification checks, and it is shaped by
+// the server's budget rather than by taste.
+//
+// POST /api/auth/token is rate-limited to **10 per hour per IP**
+// (AuthTokenController). A poll loop is an unusual client for that endpoint —
+// it is sized for a human typing a password wrong — so a naive "every five
+// seconds for ten minutes" would exhaust the hour's budget in under a minute
+// and then sit through a 429 telling it to come back in fifty-nine.
+//
+// So: nine attempts, front-loaded, adding up to ten minutes, leaving one
+// request in the budget for whatever the developer does next. The first is
+// immediate and costs one attempt on a deployment that mails a link — nobody
+// clicks that fast — but it is what makes an auto-verifying deployment
+// (EMAIL_DELIVERY=none, ADR 0011) succeed without sleeping at all.
+var pollSchedule = []time.Duration{
+	10 * time.Second,
+	20 * time.Second,
+	40 * time.Second,
+	60 * time.Second,
+	90 * time.Second,
+	120 * time.Second,
+	130 * time.Second,
+	130 * time.Second,
+}
+
+// registerDeps is what the flow reaches outside itself for, so a test can run
+// the whole loop against a stub server in microseconds instead of ten
+// minutes. Production wiring is registerLive().
+type registerDeps struct {
+	baseURL string
+	client  *http.Client
+	// sleep is the wait between attempts. A test passes one that records the
+	// durations and returns immediately.
+	sleep func(time.Duration)
+	// out and errOut are where the human-facing text goes.
+	out    io.Writer
+	errOut io.Writer
+	// schedule may be shortened by a test; nil means pollSchedule.
+	schedule []time.Duration
+}
+
+func registerLive() registerDeps {
+	return registerDeps{
+		baseURL:  config.BaseURL(activeOpts()),
+		client:   &http.Client{Timeout: 30 * time.Second},
+		sleep:    time.Sleep,
+		out:      os.Stdout,
+		errOut:   os.Stderr,
+		schedule: pollSchedule,
+	}
+}
+
+func (d registerDeps) steps() []time.Duration {
+	if d.schedule == nil {
+		return pollSchedule
+	}
+	return d.schedule
+}
+
+// authRegister is `fountain auth register`.
+func authRegister(email, password string) error {
+	d := registerLive()
+
+	var err error
+	if email == "" {
+		if email, err = promptLine("Email: "); err != nil {
+			return err
+		}
+	}
+	if password == "" {
+		if password, err = promptPassword("Password: "); err != nil {
+			return err
+		}
+	}
+	email, password = strings.TrimSpace(email), strings.TrimSpace(password)
+	if email == "" || password == "" {
+		Fatal("email and password are both required")
+	}
+
+	if err := d.createAccount(email, password); err != nil {
+		return err
+	}
+
+	key, err := d.waitForVerification(email, password)
+	if err != nil {
+		return err
+	}
+
+	profile := credentials.ProfileName(activeOpts())
+	if err := credentials.WriteProfile(profile, map[string]string{
+		"api_key":  key,
+		"base_url": d.baseURL,
+	}); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(d.out, "\nVerified. Logged in as %s (profile: %s).\n", email, profile)
+	printFirstRequest(d.out, d.baseURL, key)
+	return nil
+}
+
+// createAccount posts to /api/auth/register and reports what the server said.
+// A 403 here is a policy refusal — registration closed, a domain that is not
+// allowed — and its message is the server's to write, not the CLI's to guess.
+func (d registerDeps) createAccount(email, password string) error {
+	body, err := json.Marshal(map[string]string{"email": email, "password": password})
+	if err != nil {
+		return err
+	}
+
+	resp, raw, err := d.post("/api/auth/register", body)
+	if err != nil {
+		Fatalf("could not reach %s: %v", d.baseURL, err)
+	}
+
+	switch {
+	case resp.StatusCode == http.StatusCreated:
+		var out struct {
+			Message string `json:"message"`
+		}
+		_ = json.Unmarshal(raw, &out)
+		if out.Message != "" {
+			fmt.Fprintln(d.errOut, out.Message)
+		}
+		return nil
+
+	case resp.StatusCode == http.StatusUnprocessableEntity:
+		Fatalf("the server rejected those details: %s", strings.TrimSpace(string(raw)))
+	case resp.StatusCode == http.StatusTooManyRequests:
+		Fatalf("too many attempts from this address. %s", retryHint(resp))
+	default:
+		Fatalf("registration failed (HTTP %d): %s", resp.StatusCode, strings.TrimSpace(string(raw)))
+	}
+	return nil
+}
+
+// waitForVerification polls the token endpoint until the account stops being
+// unverified. The emailed link keeps working exactly as it always did; this
+// only notices the result.
+func (d registerDeps) waitForVerification(email, password string) (string, error) {
+	body, err := json.Marshal(map[string]string{"email": email, "password": password})
+	if err != nil {
+		return "", err
+	}
+
+	steps := d.steps()
+	for attempt := 0; ; attempt++ {
+		resp, raw, err := d.post("/api/auth/token", body)
+		if err != nil {
+			return "", fmt.Errorf("could not reach %s: %w", d.baseURL, err)
+		}
+
+		switch resp.StatusCode {
+		case http.StatusCreated, http.StatusOK:
+			key := extractAPIKey(raw)
+			if key == "" {
+				return "", fmt.Errorf("unexpected token response: %s", raw)
+			}
+			return key, nil
+
+		case http.StatusForbidden:
+			if !unverified(raw) {
+				return "", fmt.Errorf("the server refused the sign-in: %s", strings.TrimSpace(string(raw)))
+			}
+			if attempt == 0 {
+				fmt.Fprintf(d.errOut,
+					"\nWaiting for you to click the link in that email.\n"+
+						"This gives up after about ten minutes; Ctrl-C is safe, and\n"+
+						"`fountain auth login` finishes the job whenever you are ready.\n")
+			}
+
+		case http.StatusTooManyRequests:
+			// The one rule the CLI owes the limiter: never come back sooner
+			// than it asked. If it wants longer than the whole remaining
+			// schedule, stop rather than pretend to wait.
+			wait := retryAfter(resp)
+			if wait > 0 && wait <= 10*time.Minute {
+				d.sleep(wait)
+				continue
+			}
+			return "", fmt.Errorf("rate limited by the server. %s", retryHint(resp))
+
+		case http.StatusUnauthorized:
+			// The account was just created with these credentials, so this is
+			// not a typo — it is a different account with the same address,
+			// or a password change between the two calls.
+			return "", fmt.Errorf(
+				"the server did not accept that password for %s.\n"+
+					"If the address already had an account, run `fountain auth login`", email)
+
+		default:
+			return "", fmt.Errorf("sign-in failed (HTTP %d): %s",
+				resp.StatusCode, strings.TrimSpace(string(raw)))
+		}
+
+		if attempt >= len(steps) {
+			return "", fmt.Errorf(
+				"gave up after about ten minutes.\n" +
+					"The account exists and the link in your email still works.\n" +
+					"Run `fountain auth login` once you have clicked it")
+		}
+		d.sleep(steps[attempt])
+	}
+}
+
+func (d registerDeps) post(path string, body []byte) (*http.Response, []byte, error) {
+	req, err := http.NewRequestWithContext(
+		context.Background(), http.MethodPost, d.baseURL+path, bytes.NewReader(body))
+	if err != nil {
+		return nil, nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := d.client.Do(req)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer resp.Body.Close()
+
+	raw, _ := io.ReadAll(resp.Body)
+	return resp, raw, nil
+}
+
+// unverified reports whether a 403 is "click the link in your email" rather
+// than a refusal to serve this account at all. The server names the reason
+// (`email_unverified`, #533) precisely so a client need not read the prose.
+func unverified(raw []byte) bool {
+	var out struct {
+		Reason string `json:"reason"`
+	}
+	_ = json.Unmarshal(raw, &out)
+	return out.Reason == "email_unverified"
+}
+
+// retryAfter reads the header the rate limiter sets. Seconds only: that is
+// what FountainWeb.Plugs.RateLimit sends.
+func retryAfter(resp *http.Response) time.Duration {
+	secs, err := strconv.Atoi(strings.TrimSpace(resp.Header.Get("Retry-After")))
+	if err != nil || secs < 0 {
+		return 0
+	}
+	return time.Duration(secs) * time.Second
+}
+
+func retryHint(resp *http.Response) string {
+	if wait := retryAfter(resp); wait > 0 {
+		return fmt.Sprintf("Try again in %s.", wait.Round(time.Second))
+	}
+	return "Try again later."
+}

--- a/cli/internal/cmd/register_test.go
+++ b/cli/internal/cmd/register_test.go
@@ -1,0 +1,312 @@
+package cmd
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The verification wait, against the exact JSON the server sends and a clock
+// that does not tick. Every sleep is recorded instead of taken, so the whole
+// ten-minute schedule runs in microseconds — and the durations themselves are
+// asserted, because the schedule is the part that has to respect the server's
+// rate limit rather than the part that has to look nice.
+
+type fakeClock struct{ slept []time.Duration }
+
+func (f *fakeClock) sleep(d time.Duration) { f.slept = append(f.slept, d) }
+
+func (f *fakeClock) total() time.Duration {
+	var t time.Duration
+	for _, d := range f.slept {
+		t += d
+	}
+	return t
+}
+
+// unverifiedThenKey answers 403 email_unverified for the first `refusals`
+// calls to /api/auth/token, then 201 with a key — the shape of a human
+// clicking the link partway through the wait.
+func unverifiedThenKey(t *testing.T, refusals int, key string) (*httptest.Server, *int) {
+	t.Helper()
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/auth/token" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if calls < refusals {
+			calls++
+			w.WriteHeader(http.StatusForbidden)
+			// Byte-for-byte AuthTokenController's refusal (#533).
+			_, _ = w.Write([]byte(`{"error":"Verify your email address before requesting an API key","reason":"email_unverified"}`))
+			return
+		}
+		calls++
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"api_key":"` + key + `","key_id":"k1","prefix":"ftn_test"}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &calls
+}
+
+func depsFor(srv *httptest.Server, clock *fakeClock) registerDeps {
+	return registerDeps{
+		baseURL:  srv.URL,
+		client:   srv.Client(),
+		sleep:    clock.sleep,
+		out:      io.Discard,
+		errOut:   io.Discard,
+		schedule: pollSchedule,
+	}
+}
+
+func TestWaitForVerificationReturnsTheKeyOnce(t *testing.T) {
+	srv, calls := unverifiedThenKey(t, 3, "ftn_verified")
+	clock := &fakeClock{}
+
+	key, err := depsFor(srv, clock).waitForVerification("a@example.com", "pw")
+	if err != nil {
+		t.Fatalf("waitForVerification: %v", err)
+	}
+	if key != "ftn_verified" {
+		t.Fatalf("key = %q", key)
+	}
+	if *calls != 4 {
+		t.Fatalf("token attempts = %d, want 4 (three refusals then the key)", *calls)
+	}
+	if len(clock.slept) != 3 {
+		t.Fatalf("slept %d times, want 3 (once after each refusal)", len(clock.slept))
+	}
+}
+
+// An auto-verifying deployment (EMAIL_DELIVERY=none, ADR 0011) verifies at
+// registration, so the very first attempt succeeds and the CLI must not sit
+// through an interval first.
+func TestWaitForVerificationDoesNotSleepWhenAlreadyVerified(t *testing.T) {
+	srv, calls := unverifiedThenKey(t, 0, "ftn_auto")
+	clock := &fakeClock{}
+
+	key, err := depsFor(srv, clock).waitForVerification("a@example.com", "pw")
+	if err != nil {
+		t.Fatalf("waitForVerification: %v", err)
+	}
+	if key != "ftn_auto" {
+		t.Fatalf("key = %q", key)
+	}
+	if *calls != 1 {
+		t.Fatalf("token attempts = %d, want 1", *calls)
+	}
+	if len(clock.slept) != 0 {
+		t.Fatalf("slept %v, want no sleep at all", clock.slept)
+	}
+}
+
+// The schedule exists to fit POST /api/auth/token's budget of 10 per hour per
+// IP. If someone lowers the intervals to make the wait feel snappier, this is
+// what tells them what they just broke.
+func TestPollScheduleFitsTheServersRateLimit(t *testing.T) {
+	const budget = 10
+
+	attempts := len(pollSchedule) + 1
+	if attempts > budget {
+		t.Fatalf("the wait makes %d calls to /api/auth/token; the limit is %d per hour", attempts, budget)
+	}
+	if attempts == budget {
+		t.Fatalf("the wait uses the entire %d-per-hour budget, leaving nothing for the next command", budget)
+	}
+
+	var total time.Duration
+	for _, d := range pollSchedule {
+		total += d
+	}
+	if total < 8*time.Minute || total > 12*time.Minute {
+		t.Fatalf("the wait covers %s; the documented window is about ten minutes", total)
+	}
+}
+
+func TestWaitForVerificationGivesUpAfterTheSchedule(t *testing.T) {
+	srv, calls := unverifiedThenKey(t, 1000, "never")
+	clock := &fakeClock{}
+
+	_, err := depsFor(srv, clock).waitForVerification("a@example.com", "pw")
+	if err == nil {
+		t.Fatal("expected the wait to give up")
+	}
+	if !strings.Contains(err.Error(), "fountain auth login") {
+		t.Fatalf("the message should say how to finish later, got: %v", err)
+	}
+	if *calls != len(pollSchedule)+1 {
+		t.Fatalf("token attempts = %d, want %d", *calls, len(pollSchedule)+1)
+	}
+	if clock.total() < 8*time.Minute {
+		t.Fatalf("gave up after only %s of waiting", clock.total())
+	}
+}
+
+// The one rule the CLI owes the limiter: never come back sooner than it asked.
+func TestWaitForVerificationHonoursRetryAfter(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		calls++
+		if calls == 1 {
+			w.Header().Set("Retry-After", "45")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"error":"rate_limited","retry_after_seconds":45}`))
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"api_key":"ftn_after_wait"}`))
+	}))
+	defer srv.Close()
+
+	clock := &fakeClock{}
+	key, err := depsFor(srv, clock).waitForVerification("a@example.com", "pw")
+	if err != nil {
+		t.Fatalf("waitForVerification: %v", err)
+	}
+	if key != "ftn_after_wait" {
+		t.Fatalf("key = %q", key)
+	}
+	if len(clock.slept) != 1 || clock.slept[0] != 45*time.Second {
+		t.Fatalf("slept %v, want exactly the 45s the server asked for", clock.slept)
+	}
+}
+
+// A 403 that is not `email_unverified` is a refusal to serve this account, not
+// something waiting will fix.
+func TestWaitForVerificationStopsOnANonVerificationRefusal(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":"suspended","reason":"account_suspended"}`))
+	}))
+	defer srv.Close()
+
+	clock := &fakeClock{}
+	_, err := depsFor(srv, clock).waitForVerification("a@example.com", "pw")
+	if err == nil {
+		t.Fatal("expected the wait to stop")
+	}
+	if len(clock.slept) != 0 {
+		t.Fatalf("slept %v; a refusal that is not about verification must not be waited out", clock.slept)
+	}
+}
+
+// ── the printed request ────────────────────────────────────────────────
+
+// The CLI substitutes exactly what the server could not: the raw key it holds
+// and the agent it resolved. Everything else in the text is the server's.
+func TestFirstRequestRenderSubstitutesKeyAndAgent(t *testing.T) {
+	req := firstRequest{
+		Curl:       `curl -H "Authorization: Bearer $FOUNTAIN_API_KEY" -d '{"agent_id": "$FOUNTAIN_AGENT_ID"}'`,
+		TypeScript: `run("hi", { agent: "$FOUNTAIN_AGENT_NAME" })`,
+	}
+
+	curl, ts := req.render("ftn_secret", namedAgent{ID: "agent-uuid", Name: "starter"})
+
+	if !strings.Contains(curl, "Bearer ftn_secret") || !strings.Contains(curl, `"agent-uuid"`) {
+		t.Fatalf("curl not substituted: %s", curl)
+	}
+	if !strings.Contains(ts, `agent: "starter"`) {
+		t.Fatalf("typescript not substituted: %s", ts)
+	}
+	for _, token := range []string{apiKeyPlaceholder, agentIDPlaceholder, agentNamePlaceholder} {
+		if strings.Contains(curl+ts, token) {
+			t.Fatalf("%s survived into what the developer pastes", token)
+		}
+	}
+}
+
+// The catalog is the one source for the text (ADR 0038). This pins the shape
+// the CLI reads out of it against what CatalogController renders.
+func TestFetchFirstRequestReadsTheCatalogShape(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/catalog" {
+			http.NotFound(w, r)
+			return
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer ftn_k" {
+			t.Errorf("Authorization = %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"first_request":{
+			"curl":"curl -X POST https://x.test/api/conversations",
+			"typescript":"import { Fountain }",
+			"prompt":"Which operating system are you on?",
+			"placeholders":["$FOUNTAIN_API_KEY","$FOUNTAIN_AGENT_ID"]}}}`))
+	}))
+	defer srv.Close()
+
+	req, err := fetchFirstRequest(srv.URL, "ftn_k")
+	if err != nil {
+		t.Fatalf("fetchFirstRequest: %v", err)
+	}
+	if !strings.Contains(req.Curl, "/api/conversations") {
+		t.Fatalf("curl = %q", req.Curl)
+	}
+	if req.Prompt != "Which operating system are you on?" {
+		t.Fatalf("prompt = %q", req.Prompt)
+	}
+	if len(req.Placeholders) != 2 {
+		t.Fatalf("placeholders = %v", req.Placeholders)
+	}
+}
+
+// Same rule as the verified landing: prefer the starter planted at
+// verification, but work for an account that renamed or deleted it.
+func TestFetchDefaultAgentPrefersTheStarter(t *testing.T) {
+	agentsJSON := func(names ...string) string {
+		type a struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		}
+		list := make([]a, 0, len(names))
+		for i, n := range names {
+			list = append(list, a{ID: string(rune('a'+i)) + "-id", Name: n})
+		}
+		body, _ := json.Marshal(map[string]any{"data": list})
+		return string(body)
+	}
+
+	for _, tc := range []struct {
+		names []string
+		want  string
+	}{
+		{[]string{"aardvark", "starter", "zebra"}, "starter"},
+		{[]string{"aardvark", "zebra"}, "aardvark"},
+	} {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(agentsJSON(tc.names...)))
+		}))
+
+		agent, err := fetchDefaultAgent(srv.URL, "ftn_k")
+		srv.Close()
+		if err != nil {
+			t.Fatalf("fetchDefaultAgent(%v): %v", tc.names, err)
+		}
+		if agent.Name != tc.want {
+			t.Fatalf("fetchDefaultAgent(%v) = %q, want %q", tc.names, agent.Name, tc.want)
+		}
+	}
+}
+
+func TestFetchDefaultAgentSaysSoWhenThereIsNone(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	}))
+	defer srv.Close()
+
+	if _, err := fetchDefaultAgent(srv.URL, "ftn_k"); err == nil {
+		t.Fatal("expected an error naming the missing agent")
+	}
+}

--- a/decisions/0038-onboarding-first-reply.md
+++ b/decisions/0038-onboarding-first-reply.md
@@ -20,8 +20,8 @@ stale_after: 2026-11-02
 and measured) and #1393 (the field cleanup), all sub-issues of #1039. Each PR
 that builds one updates this block.
 
-**Built so far:** decisions 2 (#1392), 3 (#1388), 4 (#1389), 5 (#1426) and
-7 (#1393).
+**Built:** every decision. 2 (#1392), 3 (#1388), 4 (#1389), 5 (#1426),
+6 (#1443) and 7 (#1393).
 
 Decision 2: `Fountain.Activation` holds the definition, `Fountain.Funnel`
 counts it and measures verification to first reply, and
@@ -51,6 +51,16 @@ agent from the single source `Fountain.Onboarding` shares with
 `docs/quickstart.md`, and shows the reply inline. Both signup routes land
 there. The dashboard checklist is gone.
 
+Decision 6: `fountain auth register` creates the account, waits while the
+person clicks the link in their email, saves the key and prints the same
+first request the landing shows; `fountain quickstart` sends it. The request
+text has one source — `docs/snippets/first-request.*`, which
+`Fountain.Onboarding` reads at compile time — and the CLI reaches it over the
+wire through `GET /api/catalog`, because Go cannot read those files and a
+build-time copy would be the second copy this is meant to prevent. The wait
+is nine attempts over ten minutes, shaped by the ten-per-hour limit on
+`POST /api/auth/token` rather than by taste.
+
 Decision 7, both halves. `Fountain.Activation` stamps
 `onboarding_completed_at` at the first reply rather than a console page
 (#1426), and `users.onboarding_state` is dropped (#1393) along with
@@ -61,8 +71,6 @@ onboarding endpoints still work: only the vestigial field went, because
 whether `POST /onboarding/complete` has a purpose left now that the stamp
 moved is a question about the landing, not about this cleanup. This settles
 NC-6 from [0007](0007-g3-launch-go.md).
-
-Not built: the CLI commands (#1391).
 
 Amends [0008](0008-byo-inference-credentials.md): Fountain will hold platform
 inference keys. Leans on [0031](0031-credits-are-the-product.md) (the opening

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -20,6 +20,27 @@ brew install BinaryBourbon/tap/fountain
 Or take a release binary from the
 [GitHub Releases](https://github.com/BinaryBourbon/fountain/releases) page.
 
+On Linux, Homebrew compiles a formula and needs a C compiler first,
+`build-essential` on Debian and Ubuntu. A release binary needs no compiler,
+and the [quickstart](../quickstart.md) has the three commands that install
+one.
+
+## Start from nothing
+
+```bash
+fountain auth register    # create an account, wait for the emailed link, save the key
+fountain quickstart       # run the first request and stream the reply
+```
+
+`auth register` asks for an email address and a password, creates the
+account, then waits while you click the link in your email. It saves the API
+key and prints the same first request your start page shows. The wait ends
+after about ten minutes. The account and the emailed link both survive that,
+so `fountain auth login` finishes the job later.
+
+`quickstart` sends that request. It runs the prompt against the agent your
+account already has, streams the reply, and prints where to go next.
+
 ## Authentication
 
 ```bash

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -133,6 +133,23 @@ Remove saved credentials
 fountain auth logout
 ```
 
+## `fountain auth register`
+
+Create an account, wait for the emailed link, and save the key
+
+The terminal half of ADR 0038's path. Creates the account, waits while you click the link in your email, saves the API key, and prints the same first request the start page shows.
+
+```
+fountain auth register [flags]
+```
+
+Options:
+
+```
+      --email string      email address (prompted for when omitted)
+      --password string   password (prompted for when omitted, which keeps it out of shell history)
+```
+
 ## `fountain auth whoami`
 
 Print current user info
@@ -298,6 +315,16 @@ Revoke an API key
 
 ```
 fountain keys revoke <id>
+```
+
+## `fountain quickstart`
+
+Run the first request against your default agent and stream the reply
+
+Sends the same prompt the start page and the manual show, to the agent this account already has, and streams the reply. It is `fountain run` with the agent and the prompt filled in.
+
+```
+fountain quickstart
 ```
 
 ## `fountain run`

--- a/sdk/contract/contract.json
+++ b/sdk/contract/contract.json
@@ -5995,6 +5995,31 @@
               "required": true,
               "type": "object"
             },
+            "first_request": {
+              "properties": {
+                "curl": {
+                  "required": true,
+                  "type": "string"
+                },
+                "placeholders": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "required": true,
+                  "type": "array"
+                },
+                "prompt": {
+                  "required": true,
+                  "type": "string"
+                },
+                "typescript": {
+                  "required": true,
+                  "type": "string"
+                }
+              },
+              "required": true,
+              "type": "object"
+            },
             "mcp_servers": {
               "items": {
                 "properties": {

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -10,6 +10,17 @@ server releases.
 
 ---
 
+## [1.18.0] — 2026-09-03
+
+### Added
+
+- `GET /api/catalog` now carries `first_request`: the one onboarding request
+  this deployment hands out (ADR 0038), as `curl` and as the TypeScript
+  equivalent, with the prompt and the placeholders a client must still
+  substitute. It is the same text the verified landing and the manual print,
+  so a client that shows a first request no longer keeps its own copy to
+  drift from. `fountain auth register` reads it from here (#1391).
+
 ## [1.17.0] — 2026-09-02
 
 ### Removed

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentshit/fountain-sdk",
-      "version": "1.17.0",
+      "version": "1.18.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "description": "Run a coding agent on a real computer, with your repos and your credentials, in one call.",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -938,7 +938,7 @@ export interface paths {
         };
         /**
          * The instance's form vocabulary
-         * @description Runtimes with model suggestions per runtime (suggestions, not an allowlist — any `provider/model` under a known provider is accepted), sandbox providers usable on this instance and the default, package managers an environment accepts, the avatar generator's bases and moods, the URLs of the browser apps this instance sends people to for conversations and the team, and remote MCP servers verified to complete connection discovery (again suggestions — any URL can be discovered), each with the date it was last verified.
+         * @description Runtimes with model suggestions per runtime (suggestions, not an allowlist — any `provider/model` under a known provider is accepted), sandbox providers usable on this instance and the default, package managers an environment accepts, the avatar generator's bases and moods, the URLs of the browser apps this instance sends people to for conversations and the team, and remote MCP servers verified to complete connection discovery (again suggestions — any URL can be discovered), each with the date it was last verified. Also `first_request`, the one onboarding snippet this deployment hands out, with its base URL already in it and the caller's own key and agent left as placeholders.
          */
         get: operations["FountainWeb.CatalogController.show"];
         put?: never;
@@ -3039,6 +3039,17 @@ export interface components {
                 avatar: {
                     bases: string[];
                     moods: string[];
+                };
+                /** @description The one onboarding request this deployment hands out (ADR 0038), the same text the verified landing and the manual print. The base URL is already in it. The caller's key and agent are not: the server stores only a hash of a key, so a client substitutes the key it holds and an agent from `GET /api/agents`. */
+                first_request: {
+                    /** @description The `curl`, with placeholders. */
+                    curl: string;
+                    /** @description Every token a client must substitute before it runs the request. */
+                    placeholders: string[];
+                    /** @description The prompt both snippets send, for a client that runs it. */
+                    prompt: string;
+                    /** @description The TypeScript SDK equivalent, with placeholders. */
+                    typescript: string;
                 };
                 /** @description Remote MCP servers verified to complete the MCP authorization discovery chain, each with the date it was last verified. Suggestions, not an allowlist — any URL can be discovered. */
                 mcp_servers?: {

--- a/sdk/typescript/src/http.ts
+++ b/sdk/typescript/src/http.ts
@@ -19,7 +19,7 @@ export interface RequestOptions {
  * this string is already what Fountain's request logs are keyed on. The
  * version half is asserted against `package.json` by a test.
  */
-export const USER_AGENT = "fountain-sdk-js/1.17.0";
+export const USER_AGENT = "fountain-sdk-js/1.18.0";
 
 /**
  * The thin layer everything else is built on: one bearer token, JSON in and


### PR DESCRIPTION
Closes #1391. ADR 0038 decision 6 — the second door.

## The seam, which is the substance

The landing, the manual and this CLI print the same request, so there must be
one copy of the text. There is: `docs/snippets/first-request.{sh,ts}`, read at
compile time by `Fountain.Onboarding`.

**Go cannot read those files.** `go:embed` will not reach outside `cli/`'s own
module, and a build-time copy into `cli/` is exactly the second file this is
supposed to prevent. So **the text comes over the wire**, from
`GET /api/catalog` — the endpoint whose stated purpose is already "the same
lists over the API so a client on another origin does not hard-code them and
drift from the server". Adding the snippet there is that argument applied to
the snippet.

The split of who fills in what is not arbitrary:

| Filled by | What | Why |
|---|---|---|
| Server | the base URL | it knows it |
| CLI | the API key | the server stores only a **hash** and genuinely cannot |
| CLI | the agent id and name | it resolves one from `GET /api/agents` |

`first_request.placeholders` names the tokens that are still in the text, so a
client does not scrape them out — and it reports only what *remains*, since
the base URL is already substituted (`Onboarding.remaining_placeholders/1`).

## The poll schedule is the rate limit, not taste

`POST /api/auth/token` is limited to **ten per hour per IP**. It is sized for a
human mistyping a password, and a poll loop is an unusual client for it: "every
five seconds for ten minutes" would exhaust the hour's budget in under a minute
and then sit through a 429 telling it to come back in fifty-nine.

So the wait makes **nine attempts on a widening interval totalling ten
minutes**, leaving one request in the budget for whatever comes next.
`TestPollScheduleFitsTheServersRateLimit` fails with that arithmetic spelled
out if anyone tightens the intervals to make it feel snappier.

The first attempt is immediate. On a deployment that mails a link that costs
one attempt — nobody clicks that fast — and it is precisely what makes an
**auto-verifying deployment** (`EMAIL_DELIVERY=none`, ADR 0011) return with no
sleep at all, which is the behaviour the issue asks for, obtained without
sniffing the registration message.

A 429 is obeyed **to the second** from `Retry-After`. Nothing is added to the
server's anti-enumeration or rate limiting.

## What I measured, and what I could not

`auth register` was run end to end against a real dev server with a real
Postgres: registered, waited, noticed the verification, saved the key, printed
the substituted request.

| Segment | Measured |
|---|---|
| `auth register` → printed request (verification clicked at ~22s) | **31s wall clock** |
| `quickstart` → conversation created, stream attached | **~1s**, real |
| `quickstart` → a sandbox starts and a model answers | **not measured** |

**Proven by running it:** registration, the wait, the token exchange, the
credentials write, the catalog read, the agent resolution, the substituted
`curl` and TypeScript, and `quickstart` creating a conversation and attaching
to its stream.

**Proven by test against a stub server and a fake clock:** the whole poll loop
— key on success, no sleep when already verified, giving up after the schedule,
obeying `Retry-After` exactly, and refusing to wait out a 403 that is not
`email_unverified`.

**Unmeasured:** real verification email delivery (this environment has no mail
provider, so I clicked the link out of band by calling `verify_email/2`), and a
real sandbox and model — `quickstart` reaches "provisioning failed — the
sandbox never started" because there is no `SPRITES_TOKEN` here. **The
blank-machine recording the issue asks for needs a deployment with real mail
and a sandbox provider.** That is the same owed acceptance step as #1426's
timed run, and I would rather say so than stage something.

## Two things the run found

- **The printed TypeScript had a `baseUrl` and no key.** The catalog was
  rendering the SDK snippet with the base URL filled in, which collapsed the
  bare `new Fountain()` into a constructor that *looks* complete and is not.
  The SDK resolves the key and the base URL exactly as the CLI does, so the
  snippet keeps the manual's bare constructor. `curl` still gets the base URL,
  because `curl` resolves nothing.
- **`docs/cli.md` cannot carry the Linux install commands.** `docs_test.go`
  reads every `bash` fence and treats a line containing `fountain ` as a
  command, so `curl -fsSLo fountain \` and `sudo mv fountain /usr/local/bin/`
  both failed as "a command that does not exist". The #1327 trap is therefore
  **named in prose** in the install section, with the commands left where they
  already live in the quickstart. The CLI cannot report an install failure it
  is not installed for.

## The no-credential case

Not special-cased, as instructed. `InferenceCredentials.select/2` decides
whether this deployment covers an account with no key (#1388), and a client
second-guessing that rule would go stale the moment a platform key appeared.
What `quickstart` does instead, when a first run fails, is print where to look
— the two things that stop one on a fresh account, and the start page that says
which applies. Verified in the real run.

## Docs, contract, and the release

`docs/cli.md` gains a "Start from nothing" section with both commands in a
`bash` fence, and `docs/cli/commands.md` is regenerated from the command tree
(`-update-cli-docs`).

**The wire contract did move, and the first version of this PR said it had
not.** That was a false negative, not a judgement call: `first_request` is an
*inline* schema nested in the catalog response, and the `build.py` on my base
commit dropped an inline schema's properties when projecting it — the bug
#1442 fixed. Rebased onto `cf3b30e1`, `--check` fails as it should, and the
regenerated `sdk/contract/contract.json` carries `curl`, `typescript`,
`prompt` and `placeholders` with their types and required flags.

All four SDK verifiers pass **unchanged** — TypeScript, Python, Elixir and
Swift — because none of them claims the catalog operation. The addition is
additive and no manifest moves.

**Merging this publishes `@agentshit/fountain-sdk` 1.18.0.** The TypeScript
client ships the regenerated types, so it releases: version, lockfile,
`USER_AGENT` in `src/http.ts` and the changelog heading — `npm version`
moves the first two, and the gate checks the last two because it does not.

**1.18.0 rather than 1.17.0**, because #1393 has claimed 1.17.0. Distinct
versions are necessary — two PRs on one version means whichever lands second
carries a version already on npm and fails its own gate — but they are **not
sufficient**.

**These must also merge in ascending version order.**
`.github/workflows/sdk-publish.yml:128` is a bare `npm publish` with no
`--tag`, and npm moves the `latest` dist-tag to whatever it just published
**regardless of semver ordering**. Publishing 1.18.0 before 1.17.0 would
therefore drag `latest` backwards, and `npm install @agentshit/fountain-sdk`
would start handing people an older SDK than the one before it. Nothing is
broken today (`latest` is 1.16.0); the order is what keeps it that way.

So: 1.17.0 (#1393), then this one, then 1.19.0 (#1445). This PR is held on
that ordering alone. `node scripts/sdk-release.mjs guard` reports the release
well-formed.

## Gate

On the rebased branch: compile with warnings-as-errors, format, `credo
--strict` (no issues), sobelow, dialyzer 0 errors, **4102 Elixir tests**;
`go test ./...`, `go vet ./...` and `gofmt` clean; TypeScript SDK 101 tests
and its contract verifier clean; Python and Elixir SDK verifiers clean; all
three prose gates, `docs_test` and the contract check green.

#1442's schema guard now validates the catalog response against the schema
this PR declares, and passes — which is the proof that the controller renders
all four required properties. It cannot render fewer: the map literal is
unconditional, and an empty snippet file would yield `""` rather than a
missing key.

One failure in the full run, `Fountain.Buzz.HarnessTest` "reaps the child OS
process on shutdown", which passes in isolation — the concurrent-suite class
of #1423. Worth noting it is a *different* test in that file from the one
#1428 fixed, so that file may still have a load-sensitive case in it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BXYa9CQNG8oFNq5YhAxva



