### PR TITLE
fix(api): LogEvent renders state and stage as null, not ""

### DIFF
--- a/apps/fountain/lib/fountain/conversations/log_event.ex
+++ b/apps/fountain/lib/fountain/conversations/log_event.ex
@@ -34,6 +34,38 @@ defmodule Fountain.Conversations.LogEvent do
   def streams, do: @streams
   def states, do: @states
 
+  @doc """
+  `state` as the API renders it: `nil` for an event that has no state.
+
+  The column is `NOT NULL DEFAULT ''`, so "no state" is stored as `""` on every
+  row this table has ever held. The published schema says the field is one of
+  `#{Enum.join(@states, " ")}` or `null` — `""` is neither, and a generated
+  client with a strict enum decoder is entitled to reject an ordinary output
+  event on the busiest read in the API (#1430).
+
+  Converting here rather than on the way in keeps one representation on disk
+  and one on the wire, with a single named conversion between them. Storing
+  `nil` instead would mean dropping a `NOT NULL` on `log_events`, the
+  highest-volume table in the system, and would still need this function for
+  every row written before that migration.
+  """
+  @spec rendered_state(t()) :: String.t() | nil
+  def rendered_state(%__MODULE__{state: state}), do: blank_to_nil(state)
+
+  @doc """
+  `stage` as the API renders it: `nil` for an event that has no stage.
+
+  Follows `rendered_state/1`. `stage` has no enum to violate, so this is not a
+  contract fix but a consistency one: an output event that answered `null` for
+  its state and `""` for its stage would be describing the same absence two
+  ways.
+  """
+  @spec rendered_stage(t()) :: String.t() | nil
+  def rendered_stage(%__MODULE__{stage: stage}), do: blank_to_nil(stage)
+
+  defp blank_to_nil(""), do: nil
+  defp blank_to_nil(value), do: value
+
   def changeset(event, attrs) do
     event
     |> cast(attrs, [

--- a/apps/fountain/lib/fountain/exports.ex
+++ b/apps/fountain/lib/fountain/exports.ex
@@ -470,8 +470,8 @@ defmodule Fountain.Exports do
       "kind" => le.kind,
       "stream" => le.stream,
       "data" => le.data,
-      "stage" => le.stage,
-      "state" => le.state,
+      "stage" => LogEvent.rendered_stage(le),
+      "state" => LogEvent.rendered_state(le),
       "duration_ms" => le.duration_ms,
       "turn_id" => le.turn_id,
       "at" => le.inserted_at

--- a/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
@@ -939,8 +939,8 @@ defmodule FountainWeb.ConversationController do
         kind: ev.kind,
         stream: ev.stream,
         data: ev.data,
-        stage: ev.stage,
-        state: ev.state,
+        stage: LogEvent.rendered_stage(ev),
+        state: LogEvent.rendered_state(ev),
         turn_id: ev.turn_id,
         ts: ev.inserted_at
       }

--- a/apps/fountain/lib/fountain_web/controllers/conversation_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_json.ex
@@ -142,8 +142,8 @@ defmodule FountainWeb.ConversationJSON do
       kind: e.kind,
       stream: e.stream,
       data: e.data,
-      stage: e.stage,
-      state: e.state,
+      stage: LogEvent.rendered_stage(e),
+      state: LogEvent.rendered_state(e),
       duration_ms: e.duration_ms,
       turn_id: e.turn_id,
       ts: e.inserted_at

--- a/apps/fountain/lib/fountain_web/controllers/events_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/events_controller.ex
@@ -206,8 +206,8 @@ defmodule FountainWeb.EventsController do
         kind: ev.kind,
         stream: ev.stream,
         data: ev.data,
-        stage: ev.stage,
-        state: ev.state,
+        stage: LogEvent.rendered_stage(ev),
+        state: LogEvent.rendered_state(ev),
         duration_ms: ev.duration_ms,
         turn_id: ev.turn_id,
         ts: ev.inserted_at

--- a/apps/fountain/lib/fountain_web/controllers/team_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/team_controller.ex
@@ -610,8 +610,8 @@ defmodule FountainWeb.TeamController do
         kind: ev.kind,
         stream: ev.stream,
         data: ev.data,
-        stage: ev.stage,
-        state: ev.state,
+        stage: LogEvent.rendered_stage(ev),
+        state: LogEvent.rendered_state(ev),
         turn_id: ev.turn_id,
         ts: ev.inserted_at
       }

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -1610,8 +1610,17 @@ defmodule FountainWeb.Schemas do
           type: :string,
           description: "Output text, or JSON-encoded metadata for stage events."
         },
-        stage: %Schema{type: :string, description: "Lifecycle stage name (stage events)."},
-        state: %Schema{type: :string, enum: ~w(started done failed interrupted), nullable: true},
+        stage: %Schema{
+          type: :string,
+          nullable: true,
+          description: "Lifecycle stage name. null on an event that has no stage."
+        },
+        state: %Schema{
+          type: :string,
+          enum: ~w(started done failed interrupted),
+          nullable: true,
+          description: "Lifecycle state of the stage. null on an event that has no state."
+        },
         duration_ms: %Schema{type: :integer, nullable: true},
         turn_id: %Schema{type: :string, format: :uuid, nullable: true},
         ts: %Schema{type: :string, format: :"date-time"},

--- a/apps/fountain/test/fountain/conversations/log_event_test.exs
+++ b/apps/fountain/test/fountain/conversations/log_event_test.exs
@@ -103,6 +103,34 @@ defmodule Fountain.Conversations.LogEventTest do
     end
   end
 
+  describe "rendered_state/1 and rendered_stage/1 (#1430)" do
+    # The column is NOT NULL DEFAULT '', so "no state" is `""` on disk while
+    # the published schema says the field is one of the four states or null.
+    # These two functions are the whole of the conversion, and every render
+    # path goes through them.
+    test "an event with no state or stage renders both as nil" do
+      event = %LogEvent{}
+
+      assert LogEvent.rendered_state(event) == nil
+      assert LogEvent.rendered_stage(event) == nil
+    end
+
+    test "a real state and stage pass through untouched" do
+      event = %LogEvent{kind: "stage", stage: "provision", state: "done"}
+
+      assert LogEvent.rendered_state(event) == "done"
+      assert LogEvent.rendered_stage(event) == "provision"
+    end
+
+    test "every state the changeset accepts survives the conversion" do
+      # Only `""` becomes nil. A conversion that swallowed a real state would
+      # be invisible on the wire, since the field is nullable either way.
+      for state <- LogEvent.states() do
+        assert LogEvent.rendered_state(%LogEvent{state: state}) == state
+      end
+    end
+  end
+
   describe "changeset/2 state inclusion" do
     for state <- ["started", "done", "failed", "interrupted", ""] do
       test "accepts state #{inspect(state)}" do

--- a/apps/fountain/test/fountain_web/controllers/conversation_events_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/conversation_events_controller_test.exs
@@ -20,6 +20,10 @@ defmodule FountainWeb.ConversationEventsControllerTest do
     conn |> authed_with_key(key) |> get("/api/conversations/#{conv.id}/events" <> query)
   end
 
+  defp body_of(conn, key, conv) do
+    conn |> get_events(key, conv) |> json_response(200) |> Map.fetch!("data")
+  end
+
   describe "GET /api/conversations/:id/events" do
     test "returns the feed oldest-first with the SSE payload's fields", %{
       conn: conn,
@@ -44,6 +48,32 @@ defmodule FountainWeb.ConversationEventsControllerTest do
                "turn_id" => _,
                "ts" => _
              } = hd(body["data"])
+    end
+
+    test "an event with no state or stage renders them null, not \"\" (#1430)", %{
+      conn: conn,
+      key: key,
+      conv: conv
+    } do
+      # The schema declares `state` as one of four values or null, and the
+      # server used to answer `""` — neither. This is the busiest read in the
+      # API and all four SDKs decode the field, so a strict enum decoder was
+      # entitled to reject an ordinary output line.
+      insert_log_event(conv, kind: "output", stream: "stdout", data: "hello")
+
+      assert %{"state" => nil, "stage" => nil} = hd(body_of(conn, key, conv))
+    end
+
+    test "a stage event still renders its real stage and state", %{
+      conn: conn,
+      key: key,
+      conv: conv
+    } do
+      # Guard the guard: a conversion that nilled everything would satisfy the
+      # test above and lose the field's entire meaning.
+      insert_log_event(conv, kind: "stage", stream: "", stage: "provision", state: "done")
+
+      assert %{"stage" => "provision", "state" => "done"} = hd(body_of(conn, key, conv))
     end
 
     test "an empty feed is an empty page, not an error", %{conn: conn, key: key, conv: conv} do

--- a/apps/fountain/test/fountain_web/controllers/sse_stream_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/sse_stream_test.exs
@@ -104,6 +104,24 @@ defmodule FountainWeb.SseStreamTest do
       assert conn.resp_body =~ "id: #{ev.id}"
     end
 
+    test "an output event streams state and stage as null, not \"\" (#1430)", %{
+      raw_key: key,
+      conv: conv
+    } do
+      # The stream builds its own payload rather than sharing the JSON view's,
+      # so it is a second place the conversion has to happen. A reader of the
+      # SSE feed and a reader of `/events` must not disagree about what "no
+      # state" looks like.
+      insert_log_event(conv, %{kind: "output", stream: "stdout", data: "x"})
+
+      conn = stream(key, "/api/conversations/#{conv.id}/stream?wait=false")
+
+      assert conn.resp_body =~ ~s("state":null)
+      assert conn.resp_body =~ ~s("stage":null)
+      refute conn.resp_body =~ ~s("state":"")
+      refute conn.resp_body =~ ~s("stage":"")
+    end
+
     test "a garbage Last-Event-ID replays everything rather than nothing", %{
       raw_key: key,
       conv: conv

--- a/apps/fountain/test/fountain_web/schema_guardrail_test.exs
+++ b/apps/fountain/test/fountain_web/schema_guardrail_test.exs
@@ -48,7 +48,7 @@ defmodule FountainWeb.SchemaGuardrailTest do
 
   # The allowlist may shrink freely. Growing it means editing this number in
   # the same diff, which is the whole ratchet: a reviewer sees the number move.
-  @ceiling 98
+  @ceiling 97
 
   describe "the ratchet" do
     test "the allowlist has not grown" do

--- a/apps/fountain/test/support/schema_guard_allowlist.ex
+++ b/apps/fountain/test/support/schema_guard_allowlist.ex
@@ -30,12 +30,6 @@ defmodule FountainWeb.SchemaGuardAllowlist do
   422 and the wire sometimes carries the validator's. One root cause, 27
   operations (#1431).
 
-  `:log_event_empty_state` — `Fountain.Conversations.LogEvent` validates
-  `state` against `["" | @states]` and stores `""` for an event that has no
-  state, but the schema's enum is `started done failed interrupted` and does
-  not include it. A generated client with a strict enum decoder rejects a real
-  event, and all four SDKs decode this field (#1430).
-
   `:test_fixture_vocabulary` — not a defect in the API. The fixture inserts a
   value on purpose that the domain no longer accepts (a conversation whose
   runtime is `retired-runtime`, exercising the retired-runtime path), so the
@@ -50,7 +44,6 @@ defmodule FountainWeb.SchemaGuardAllowlist do
     plug_status: "a status a pipeline plug returns that the operation does not declare (#1432)",
     cast_and_validate_422:
       "CastAndValidate renders its own 422 body, not the declared error schema (#1431)",
-    log_event_empty_state: "LogEvent stores state \"\", which the schema's enum omits (#1430)",
     test_fixture_vocabulary: "the fixture inserts an out-of-vocabulary value on purpose",
     openai_error_shape: "the OpenAI gateway renders `error` as a string, not an object (#1433)"
   }
@@ -157,9 +150,6 @@ defmodule FountainWeb.SchemaGuardAllowlist do
     {"PUT /api/account/inference-credentials/{provider}", 422} => :cast_and_validate_422,
     {"PUT /api/environments/{id}", 422} => :cast_and_validate_422,
     {"PUT /api/vaults/{id}", 422} => :cast_and_validate_422,
-
-    # ── log_event_empty_state (1) ─────────────────────────────
-    {"GET /api/conversations/{conversation_id}/events", 200} => :log_event_empty_state,
 
     # ── test_fixture_vocabulary (1) ─────────────────────────────
     {"GET /api/conversations/{id}", 200} => :test_fixture_vocabulary,

--- a/sdk/contract/contract.json
+++ b/sdk/contract/contract.json
@@ -7480,6 +7480,7 @@
           "type": "string"
         },
         "stage": {
+          "nullable": true,
           "required": false,
           "type": "string"
         },

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -10,6 +10,26 @@ server releases.
 
 ---
 
+## [1.19.0] — 2026-09-03
+
+### Changed
+
+- `LogEvent.stage` is typed `string | null` rather than `string`. The server
+  used to answer `""` for an event with no stage and no state, while its own
+  schema declared `state` as one of `started done failed interrupted` or
+  `null` — so `""` was a value the published contract did not allow, on the
+  busiest read in the API. The server now renders `null` for both fields
+  (#1430), which is what the schema always said for `state`; `stage` is typed
+  nullable here to match. `LogEvent.state`'s type is unchanged, because the
+  document already described it correctly and only the server was wrong.
+
+  Code that reads `event.stage` on an event that has no stage now sees `null`
+  where it saw `""`. This client's own readers were already null-safe. A
+  falsy check (`if (event.stage)`) behaves the same either way; `event.stage
+  .length` does not.
+
+---
+
 ## [1.18.0] — 2026-09-03
 
 ### Added

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentshit/fountain-sdk",
-      "version": "1.18.0",
+      "version": "1.19.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "description": "Run a coding agent on a real computer, with your repos and your credentials, in one call.",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -3681,9 +3681,12 @@ export interface components {
             id: number;
             /** @enum {string} */
             kind: "output" | "stage";
-            /** @description Lifecycle stage name (stage events). */
-            stage?: string;
-            /** @enum {string|null} */
+            /** @description Lifecycle stage name. null on an event that has no stage. */
+            stage?: string | null;
+            /**
+             * @description Lifecycle state of the stage. null on an event that has no state.
+             * @enum {string|null}
+             */
             state?: "started" | "done" | "failed" | "interrupted" | null;
             /** @description `stdout` / `stderr` for output events; empty for stage events. */
             stream?: string;

--- a/sdk/typescript/src/http.ts
+++ b/sdk/typescript/src/http.ts
@@ -19,7 +19,7 @@ export interface RequestOptions {
  * this string is already what Fountain's request logs are keyed on. The
  * version half is asserted against `package.json` by a test.
  */
-export const USER_AGENT = "fountain-sdk-js/1.18.0";
+export const USER_AGENT = "fountain-sdk-js/1.19.0";
 
 /**
  * The thin layer everything else is built on: one bearer token, JSON in and


### PR DESCRIPTION
Closes #1430. Found by the schema guard (#1427).

## The decision, and why it is not an API change

The schema declares `state` as one of `started done failed interrupted` or
`null`. The server answered `""` on every ordinary output event — neither of
those — on the busiest read in the API.

So `null` is the **documented contract today** and `""` is the undocumented
thing the server emits. Rendering `null` makes the server conform to what it
already publishes. The contract projection proves it: `state` was
`nullable: true` before this PR and after it, and the diff on
`sdk/contract/contract.json` is **one line, for `stage`**. Nothing about
`state` moved, because the document was already right and only the server was
wrong.

The other two options cost more than they save. Adding `""` to the enum
enshrines an empty-string enum member in four generated clients. Dropping the
enum discards a guarantee `sdk/conformance` currently pins across all four.

## Where the conversion lives, and why not the changeset

The issue left this open, so: **read path, no migration.** The reason is in the
column definition —

```
stage  | NO (not null) | ''::character varying
state  | NO (not null) | ''::character varying
```

Storing `nil` would need a migration dropping `NOT NULL` on `log_events`, the
highest-volume table in the system, **and would still need a read-path
conversion** for every row written before it — a backfill of that table is a
full rewrite, which is a lot to pay for a rendering concern. Since the read
path is required either way, the write-path change buys nothing for the
contract and only splits storage into two representations no consumer can tell
apart.

Converting on the way out keeps **one representation on disk, one on the wire**,
with `LogEvent.rendered_state/1` and `rendered_stage/1` as the single named
conversion between them — on the schema module, next to the field, where the
next person to add a render path will find it.

## Four render paths, not one

The issue named `/events`. There are four, plus the export, and each builds its
own payload:

| Path | File |
|---|---|
| `GET /api/conversations/:id/events` | `conversation_json.ex` |
| `GET /api/conversations/:id/stream` | `conversation_controller.ex` |
| `GET /api/events` (multi-conversation) | `events_controller.ex` |
| `GET /api/team/stream` | `team_controller.ex` |
| account data export | `exports.ex` |

The per-conversation stream was found by a test written for the JSON view
failing against it — exactly the drift its own "field-for-field the SSE
payload" comment was warning about.

## `stage` follows, and that part does move the contract

`stage` has no enum to violate, so this half is consistency rather than
conformance: an event answering `null` for its state and `""` for its stage
would be describing the same absence two ways. It gains `nullable: true`, so
`LogEvent.stage` becomes `string | null` in the generated TypeScript.

**That is a published surface change, so the SDK goes to 1.19.0.** Not 1.17.0:
main is at 1.16.0 and two other PRs are in flight ahead of this one (#1393 takes
1.17.0, #1443 takes 1.18.0).

**These three must merge in ascending order, and that is not a preference.**
`.github/workflows/sdk-publish.yml:128` runs a bare `npm publish` with no
`--tag`. npm defaults that to `latest` and moves the `latest` dist-tag to
whatever it just published, *regardless of semver ordering*. So publishing
1.19.0 before 1.17.0 would leave `latest` pointing at 1.17.0 once that one
lands, and every `npm install @agentshit/fountain-sdk` would get an older SDK
than the release before it. `npm view @agentshit/fountain-sdk dist-tags` reads
`latest: 1.16.0` today, so nothing is wrong yet.

The release guard checks only that a version is bumped and unpublished — it
does not compare against the versions other open PRs are claiming, so it will
happily let these merge in the wrong order. The ordering is held outside the
gate.

**The order is now satisfied.** #1447 merged 1.17.0 (`ddab88f9`, published) and
#1443 merged 1.18.0 (`3353fd73`). Main's `package.json` reads 1.18.0, this PR
is rebased onto `3353fd73`, and `scripts/sdk-release.mjs guard` reports
`base: 1.18.0 → head: 1.19.0`. This is the last of the three, so merging it
moves `latest` forward rather than back.

Four places, moved with `npm version 1.19.0 --no-git-tag-version` rather than by
hand: `package.json` and `package-lock.json` (both, which is what `npm version`
gets right and a hand-edit misses), plus `USER_AGENT` in `src/http.ts` and the
`## [1.19.0]` CHANGELOG heading, which it does not touch — which is exactly what
the gate checks. `node scripts/sdk-release.mjs guard` says "Release looks
well-formed. Merging this publishes 1.19.0." No `sdk-no-release`.
`LogEvent.state`'s type is unchanged.

## Verification

- **All four SDK contract verifiers pass unchanged** — TypeScript, Python,
  Elixir and Swift. No manifest needed editing: `stage` is declared as a plain
  read field by all four, and the `LogEvent.state` enum is untouched.
- **All four conformance suites pass unchanged** (24 scenarios each). No
  scenario models an output event's `state` — the fixtures were written against
  the documented contract, not the server's actual output, which is its own
  small piece of evidence for this direction.
- **No client behaviour changes.** None of the four decodes these fields
  strictly: Swift reads `event["stage"]?.stringValue`, Python `event.get(...)`,
  TypeScript a falsy check, Elixir a plain map.
- **Neither downstream app is affected.** Every read of these two fields in
  `fountain-conversations` and `fountain-team` is a truthiness or equality test
  (`ev.stage && ev.stage !== "turn"`, `ev.state === "started"`), and `""` and
  `null` are alike under both. `RawView` interpolates them into JSX, where both
  render as nothing. Neither repo is touched by this PR.
- **The guard now proves the fix.** The allowlist entry, its prose and its
  reason are deleted and `@ceiling` drops 98 → 97. Reverting the JSON view's
  conversion makes the events test fail with
  `#/data/0/state: Invalid value for enum`.

## Gate

`mix precommit` on `fountain_test_p1389`: compile (warnings-as-errors),
`deps.unlock` check, `format --check-formatted`, `credo --strict` (5956
mods/funs, no issues), dialyzer (`Total errors: 0`), sobelow, and
**6 doctests, 4107 tests, 0 failures**, exit 0. Plus the TypeScript build and
its 101 tests, and the four contract and four conformance suites above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BXYa9CQNG8oFNq5YhAxva



