### PR TITLE
refactor(onboarding): drop users.onboarding_state (#1393)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,21 @@ upgrade, is in
 
 ## [Unreleased]
 
+### Removed
+
+- **`users.onboarding_state`** (#1393, ADR 0038, settling NC-6 from ADR 0007).
+  It was the browser wizard's position. The wizard went in #867, after which
+  the column only ever held `step_1` or `completed` — which is exactly what
+  `onboarding_completed_at` being null or set already says. Gone with it:
+  `Accounts.advance_onboarding/2`, the funnel's `by_onboarding_state`
+  breakdown and its line on `/admin`, the field on the admin user views, and
+  the `onboarding_state` property on `GET /api/auth/me` plus `state` on
+  `GET /api/account/onboarding`. **Both onboarding endpoints still work and
+  are unchanged otherwise**; `completed` and `completed_at` come from the one
+  stamp that is left. The migration's `down/0` restores the column and
+  backfills `completed`, but cannot restore which step an unfinished account
+  had reached, because nothing has recorded that since #867.
+
 ### Added
 
 - **The graduation recipe for umbrella libraries** (#1345, ADR 0037):

--- a/apps/fountain/lib/fountain/accounts.ex
+++ b/apps/fountain/lib/fountain/accounts.ex
@@ -26,13 +26,6 @@ defmodule Fountain.Accounts do
   alias Fountain.Audit
   alias Fountain.Crypto
 
-  # The onboarding wizard's states, in order. An attribute rather than an
-  # inline literal so `advance_onboarding/2` can guard on it and the OpenAPI
-  # schema can be checked against it — see the enum guardrail test.
-  @onboarding_states ~w(step_1 step_2 step_3 step_4 completed)
-
-  def onboarding_states, do: @onboarding_states
-
   ## Users
 
   @doc "Look up a user by (downcased) email. Returns `nil` if not found."
@@ -535,40 +528,18 @@ defmodule Fountain.Accounts do
 
   @doc """
   Mark onboarding as completed by setting `onboarding_completed_at` to now.
+
+  `onboarding_completed_at` is the whole of it since #1393. The wizard's
+  `onboarding_state` column is gone, and so is `advance_onboarding/2`, which
+  existed only to walk that state machine: a stamp is either set or it is not,
+  and there are no steps left to be part-way through.
   """
   @spec complete_onboarding(User.t()) :: {:ok, User.t()} | {:error, Ecto.Changeset.t()}
   def complete_onboarding(%User{} = user) do
     now = DateTime.utc_now() |> DateTime.truncate(:second)
 
     user
-    |> Ecto.Changeset.change(
-      onboarding_completed_at: now,
-      onboarding_state: "completed"
-    )
-    |> Repo.update()
-  end
-
-  @doc """
-  Advance the onboarding wizard to the given state.
-  Valid states: "step_1", "step_2", "step_3", "step_4", "completed"
-
-  When state is "completed", also sets `onboarding_completed_at`.
-  """
-  @spec advance_onboarding(User.t(), String.t()) ::
-          {:ok, User.t()} | {:error, Ecto.Changeset.t()}
-  def advance_onboarding(%User{} = user, state)
-      when state in @onboarding_states do
-    now = DateTime.utc_now() |> DateTime.truncate(:second)
-
-    changes =
-      if state == "completed" do
-        %{onboarding_state: state, onboarding_completed_at: now}
-      else
-        %{onboarding_state: state}
-      end
-
-    user
-    |> Ecto.Changeset.change(changes)
+    |> Ecto.Changeset.change(onboarding_completed_at: now)
     |> Repo.update()
   end
 

--- a/apps/fountain/lib/fountain/accounts/user.ex
+++ b/apps/fountain/lib/fountain/accounts/user.ex
@@ -17,7 +17,6 @@ defmodule Fountain.Accounts.User do
     field :password, :string, virtual: true, redact: true
     field :email_verified_at, :utc_datetime
     field :onboarding_completed_at, :utc_datetime
-    field :onboarding_state, :string, default: "step_1"
     # Per-user override of the balance-funded concurrent-sandbox cap
     # (`Fountain.Quotas.sandbox_limit/1`); null means the balance rule. The
     # Postgres column is still `max_concurrent_sandboxes` — renaming it would

--- a/apps/fountain/lib/fountain/analytics.ex
+++ b/apps/fountain/lib/fountain/analytics.ex
@@ -409,7 +409,6 @@ defmodule Fountain.Analytics do
       "credit_balance_cents" => user.credit_balance_cents,
       "email_verified" => not is_nil(user.email_verified_at),
       "onboarded" => not is_nil(user.onboarding_completed_at),
-      "onboarding_state" => user.onboarding_state,
       "suspended" => not is_nil(user.suspended_at),
       "max_concurrent_sandboxes" => Fountain.Quotas.sandbox_limit_for(user),
       "sandbox_limit_override" => user.sandbox_limit_override,

--- a/apps/fountain/lib/fountain/funnel.ex
+++ b/apps/fountain/lib/fountain/funnel.ex
@@ -21,13 +21,12 @@ defmodule Fountain.Funnel do
   - **registered** — a `users` row exists
   - **verified** — `email_verified_at` set
   - **onboarded** — `onboarding_completed_at` set, and since #1393 that stamp
-    is the whole of it: the `onboarding_state` column it used to sit beside
-    was the wizard's, distinguished nothing once the wizard went (#867), and
-    is dropped. Since #867 the stamp means the account has an inference
-    credential and an agent (the console stamps it) rather than "clicked
-    through the wizard"; ADR 0038 moves it to the first reply, which is
-    `Fountain.Activation`'s seam. `built_agent` / `built_environment` /
-    `built_nothing` are the stall breakdown's live signal.
+    is the whole of it. The `onboarding_state` column beside it was the
+    wizard's position; the wizard went in #867, after which the column only
+    distinguished `step_1` from `completed`, so it is dropped.
+    `Fountain.Activation` stamps the date at the first reply (ADR 0038).
+    `built_agent` / `built_environment` / `built_nothing` are the stall
+    breakdown's live signal.
   - **activated** — **the first conversation with a reply** (ADR 0038): the
     earliest `turns` row for the account carrying a non-empty `reply_text`.
     A conversation that never answered does not count, and neither does a

--- a/apps/fountain/lib/fountain/funnel.ex
+++ b/apps/fountain/lib/fountain/funnel.ex
@@ -20,13 +20,14 @@ defmodule Fountain.Funnel do
 
   - **registered** — a `users` row exists
   - **verified** — `email_verified_at` set
-  - **onboarded** — `onboarding_completed_at` set. Since #867 that means the
-    account has an inference credential and an agent (the console stamps it),
-    rather than "clicked through the wizard"; ADR 0038 moves the stamp to the
-    first reply, which is `Fountain.Activation`'s seam. `by_onboarding_state`
-    in the stall breakdown is the vestige of that wizard — it now only
-    distinguishes `step_1` from `completed`; `built_agent` /
-    `built_environment` / `built_nothing` are the live signal.
+  - **onboarded** — `onboarding_completed_at` set, and since #1393 that stamp
+    is the whole of it: the `onboarding_state` column it used to sit beside
+    was the wizard's, distinguished nothing once the wizard went (#867), and
+    is dropped. Since #867 the stamp means the account has an inference
+    credential and an agent (the console stamps it) rather than "clicked
+    through the wizard"; ADR 0038 moves it to the first reply, which is
+    `Fountain.Activation`'s seam. `built_agent` / `built_environment` /
+    `built_nothing` are the stall breakdown's live signal.
   - **activated** — **the first conversation with a reply** (ADR 0038): the
     earliest `turns` row for the account carrying a non-empty `reply_text`.
     A conversation that never answered does not count, and neither does a
@@ -78,8 +79,7 @@ defmodule Fountain.Funnel do
   The funnel: five stages, time to first reply, and the stalled breakdown.
 
   Returns `%{stages: [stage], time_to_first_reply: timing, stalled: %{count: n,
-  by_onboarding_state: map, started: n, built_agent: n, built_environment: n,
-  built_nothing: n}}`.
+  started: n, built_agent: n, built_environment: n, built_nothing: n}}`.
 
   `conversion` is the fraction of the *previous* stage (nil for registered);
   `median_hours` is the median time from the previous stage's timestamp, for
@@ -96,7 +96,6 @@ defmodule Fountain.Funnel do
             registered_at: u.inserted_at,
             verified_at: u.email_verified_at,
             onboarded_at: u.onboarding_completed_at,
-            onboarding_state: u.onboarding_state,
             credit_balance_cents: u.credit_balance_cents
           }
       )
@@ -231,7 +230,6 @@ defmodule Fountain.Funnel do
 
     %{
       count: length(stalled),
-      by_onboarding_state: Enum.frequencies_by(stalled, & &1.onboarding_state),
       started: MapSet.size(starters),
       built_agent: MapSet.size(agent_owners),
       built_environment: MapSet.size(env_owners),

--- a/apps/fountain/lib/fountain_web/controllers/auth_me_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/auth_me_controller.ex
@@ -34,7 +34,6 @@ defmodule FountainWeb.AuthMeController do
       email_verified: not is_nil(user.email_verified_at),
       # Read side of #525: a client that just bootstrapped an account can see
       # whether the browser will drop this user into the wizard.
-      onboarding_state: user.onboarding_state,
       onboarding_completed: not is_nil(user.onboarding_completed_at),
       # Null on a billing-disabled instance, even for an account that was
       # comped before billing was turned off — there is no balance for the

--- a/apps/fountain/lib/fountain_web/controllers/onboarding_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/onboarding_controller.ex
@@ -2,9 +2,8 @@ defmodule FountainWeb.OnboardingController do
   @moduledoc """
   Onboarding state over the API (#525).
 
-  `complete_onboarding/1` and `advance_onboarding/2` were called only from the
-  wizard LiveView, so an account driven entirely through the API stayed
-  permanently un-onboarded: `onboarding_state` never reached `"completed"`.
+  `complete_onboarding/1` was called only from the wizard LiveView, so an
+  account driven entirely through the API stayed permanently un-onboarded.
 
   The wizard is gone (#867). The console's dashboard stamps the flag when the
   account actually has what it needs — an inference credential and an agent —

--- a/apps/fountain/lib/fountain_web/controllers/onboarding_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/onboarding_json.ex
@@ -1,10 +1,12 @@
 defmodule FountainWeb.OnboardingJSON do
   @moduledoc false
 
+  # `completed` and `completed_at` both come from `onboarding_completed_at`,
+  # which is the one source of truth since #1393. The `state` field went with
+  # the column: it distinguished nothing that `completed` does not.
   def show(%{user: user}) do
     %{
       data: %{
-        state: user.onboarding_state,
         completed: not is_nil(user.onboarding_completed_at),
         completed_at: user.onboarding_completed_at
       }

--- a/apps/fountain/lib/fountain_web/live/admin_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/admin_live/index.ex
@@ -148,12 +148,6 @@ defmodule FountainWeb.AdminLive.Index do
             started a conversation and got nothing back: {@funnel.stalled.started}
           </div>
           <div class="text-xs">
-            onboarding:
-            <span :for={{state, n} <- Enum.sort(@funnel.stalled.by_onboarding_state)} class="mr-2">
-              {state} ×{n}
-            </span>
-          </div>
-          <div class="text-xs">
             built an agent: {@funnel.stalled.built_agent} · created an environment: {@funnel.stalled.built_environment} · built nothing: {@funnel.stalled.built_nothing}
           </div>
         </div>

--- a/apps/fountain/lib/fountain_web/live/admin_live/user_detail.ex
+++ b/apps/fountain/lib/fountain_web/live/admin_live/user_detail.ex
@@ -142,11 +142,13 @@ defmodule FountainWeb.AdminLive.UserDetail do
           class="bg-white rounded shadow border border-zinc-200 px-4 py-3"
         >
           <div class="text-xs text-zinc-500">Onboarding</div>
-          <div class="text-sm font-medium">{@user.onboarding_state}</div>
+          <div class="text-sm font-medium">
+            {if @user.onboarding_completed_at, do: "completed", else: "not completed"}
+          </div>
           <div class="text-xs text-zinc-500">
             {if @user.onboarding_completed_at,
-              do: "completed #{format_date(@user.onboarding_completed_at)}",
-              else: "not completed"}
+              do: format_date(@user.onboarding_completed_at),
+              else: "—"}
           </div>
         </div>
         <div class="bg-white rounded shadow border border-zinc-200 px-4 py-3">

--- a/apps/fountain/lib/fountain_web/live/admin_live/users.ex
+++ b/apps/fountain/lib/fountain_web/live/admin_live/users.ex
@@ -607,10 +607,7 @@ defmodule FountainWeb.AdminLive.Users do
                 </form>
               </td>
               <td class="px-4 py-2 text-zinc-500 text-xs">
-                {u.onboarding_state}
-                <span :if={u.onboarding_completed_at} class="text-zinc-400">
-                  · {format_date(u.onboarding_completed_at)}
-                </span>
+                {if u.onboarding_completed_at, do: format_date(u.onboarding_completed_at), else: "—"}
               </td>
               <td class="px-4 py-2 text-zinc-500 text-xs">
                 {if u.last_activity_at, do: format_date(u.last_activity_at), else: "—"}

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -2148,12 +2148,6 @@ defmodule FountainWeb.Schemas do
         data: %Schema{
           type: :object,
           properties: %{
-            state: %Schema{
-              type: :string,
-              nullable: true,
-              enum: ~w(step_1 step_2 step_3 step_4 completed),
-              description: "Wizard position. Only `completed` means anything to an API client."
-            },
             completed: %Schema{type: :boolean},
             completed_at: %Schema{type: :string, format: :"date-time", nullable: true}
           },
@@ -3414,11 +3408,6 @@ defmodule FountainWeb.Schemas do
         email: %Schema{type: :string, format: :email},
         role: %Schema{type: :string, enum: ~w(user admin)},
         email_verified: %Schema{type: :boolean},
-        onboarding_state: %Schema{
-          type: :string,
-          nullable: true,
-          description: "Wizard position. Only `completed` means anything to an API client."
-        },
         onboarding_completed: %Schema{type: :boolean},
         comped: %Schema{type: :boolean, nullable: true, description: "Null when billing is off."},
         brokered: %Schema{

--- a/apps/fountain/priv/repo/migrations/20260902120000_drop_onboarding_state_from_users.exs
+++ b/apps/fountain/priv/repo/migrations/20260902120000_drop_onboarding_state_from_users.exs
@@ -1,0 +1,34 @@
+defmodule Fountain.Repo.Migrations.DropOnboardingStateFromUsers do
+  @moduledoc """
+  Drop `users.onboarding_state` (#1393, NC-6 from ADR 0007).
+
+  It was the wizard's position. The wizard went in #867, after which the
+  column only ever held `step_1` or `completed` — which is exactly what
+  `onboarding_completed_at` being null or set already says. ADR 0038 makes
+  that stamp the one source of truth.
+
+  `down/0` restores the column with its original default and NOT NULL, and
+  backfills `completed` for the accounts whose stamp is set. It cannot restore
+  which *step* an account had reached, because that information stopped being
+  recorded when the wizard went; a rollback puts every unfinished account back
+  at `step_1`, which is what the column would say about them today anyway.
+  """
+
+  use Ecto.Migration
+
+  def up do
+    alter table(:users) do
+      remove :onboarding_state
+    end
+  end
+
+  def down do
+    alter table(:users) do
+      add :onboarding_state, :string, default: "step_1", null: false
+    end
+
+    execute(
+      "UPDATE users SET onboarding_state = 'completed' WHERE onboarding_completed_at IS NOT NULL"
+    )
+  end
+end

--- a/apps/fountain/test/fountain/accounts_additional_test.exs
+++ b/apps/fountain/test/fountain/accounts_additional_test.exs
@@ -311,37 +311,11 @@ defmodule Fountain.AccountsAdditionalTest do
   # ── complete_onboarding/1 ───────────────────────────────────────────────────
 
   describe "complete_onboarding/1" do
-    test "sets onboarding_state to 'completed' and onboarding_completed_at to a datetime" do
+    test "sets onboarding_completed_at, which is the whole of onboarding since #1393" do
       user = insert_verified_user()
       assert is_nil(user.onboarding_completed_at)
 
       assert {:ok, updated} = Accounts.complete_onboarding(user)
-      assert updated.onboarding_state == "completed"
-      assert %DateTime{} = updated.onboarding_completed_at
-    end
-  end
-
-  # ── advance_onboarding/2 ────────────────────────────────────────────────────
-
-  describe "advance_onboarding/2" do
-    test "advances to step_1 and only sets onboarding_state" do
-      user = insert_verified_user()
-      assert {:ok, updated} = Accounts.advance_onboarding(user, "step_1")
-      assert updated.onboarding_state == "step_1"
-      assert is_nil(updated.onboarding_completed_at)
-    end
-
-    test "advances to step_3 and only sets onboarding_state" do
-      user = insert_verified_user()
-      assert {:ok, updated} = Accounts.advance_onboarding(user, "step_3")
-      assert updated.onboarding_state == "step_3"
-      assert is_nil(updated.onboarding_completed_at)
-    end
-
-    test "advancing to 'completed' also sets onboarding_completed_at" do
-      user = insert_verified_user()
-      assert {:ok, updated} = Accounts.advance_onboarding(user, "completed")
-      assert updated.onboarding_state == "completed"
       assert %DateTime{} = updated.onboarding_completed_at
     end
   end

--- a/apps/fountain/test/fountain/accounts_test.exs
+++ b/apps/fountain/test/fountain/accounts_test.exs
@@ -5,7 +5,6 @@ defmodule Fountain.AccountsTest do
   alias Fountain.Accounts.User
 
   # Pure unit tests do not touch the DB.
-  # DB-backed tests for advance_onboarding/2 are below.
 
   describe "User.registration_changeset/2" do
     test "valid attrs produce a valid changeset" do
@@ -115,32 +114,6 @@ defmodule Fountain.AccountsTest do
       cs = Fountain.Accounts.User.theme_changeset(user, %{theme_preference: "invalid"})
       refute cs.valid?
       assert cs.errors[:theme_preference] != nil
-    end
-  end
-
-  describe "Accounts.advance_onboarding/2" do
-    setup do
-      {:ok, user: insert_verified_user()}
-    end
-
-    test "step_2 sets onboarding_state to 'step_2' and leaves onboarding_completed_at nil",
-         %{user: user} do
-      assert {:ok, updated} = Accounts.advance_onboarding(user, "step_2")
-      assert updated.onboarding_state == "step_2"
-      assert updated.onboarding_completed_at == nil
-    end
-
-    test "step_4 sets onboarding_state to 'step_4' and leaves onboarding_completed_at nil",
-         %{user: user} do
-      assert {:ok, updated} = Accounts.advance_onboarding(user, "step_4")
-      assert updated.onboarding_state == "step_4"
-      assert updated.onboarding_completed_at == nil
-    end
-
-    test "invalid state raises FunctionClauseError", %{user: user} do
-      assert_raise FunctionClauseError, fn ->
-        Accounts.advance_onboarding(user, "invalid_step")
-      end
     end
   end
 

--- a/apps/fountain/test/fountain/analytics_test.exs
+++ b/apps/fountain/test/fountain/analytics_test.exs
@@ -51,7 +51,6 @@ defmodule Fountain.AnalyticsTest do
         role: "user",
         comped: false,
         credit_balance_cents: 0,
-        onboarding_state: "step_1",
         sandbox_limit_override: nil,
         inserted_at: ~U[2026-01-01 00:00:00Z]
       },

--- a/apps/fountain/test/fountain/funnel_test.exs
+++ b/apps/fountain/test/fountain/funnel_test.exs
@@ -236,15 +236,12 @@ defmodule Fountain.FunnelTest do
 
   describe "summary_admin/0 — stalled breakdown" do
     test "verified users with no conversation, by how far they got" do
-      nothing = insert_verified_user()
-      set!(nothing, onboarding_state: "step_1")
+      _nothing = insert_verified_user()
 
       agent_builder = insert_verified_user()
-      set!(agent_builder, onboarding_state: "step_3")
       insert_agent(user_id: agent_builder.id)
 
       env_builder = insert_verified_user()
-      set!(env_builder, onboarding_state: "step_3")
       insert_env(user_id: env_builder.id)
 
       # An account that got a reply is not stalled, whatever else is true.
@@ -257,7 +254,6 @@ defmodule Fountain.FunnelTest do
       %{stalled: stalled} = Funnel.summary_admin()
 
       assert stalled.count == 3
-      assert stalled.by_onboarding_state == %{"step_1" => 1, "step_3" => 2}
       # All three, and none: every verified account owns a starter agent
       # (ADR 0038). #1421 replaces this decomposition.
       assert stalled.built_agent == 3

--- a/apps/fountain/test/fountain_web/controllers/onboarding_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/onboarding_controller_test.exs
@@ -39,11 +39,12 @@ defmodule FountainWeb.OnboardingControllerTest do
         |> json_response(200)
 
       assert body["data"]["completed"] == true
-      assert body["data"]["state"] == "completed"
+      # The wizard's `state` went with the column (#1393); `completed` and
+      # `completed_at` both derive from the one stamp that is left.
+      refute Map.has_key?(body["data"], "state")
 
       reloaded = Accounts.get_user(user.id)
       assert reloaded.onboarding_completed_at
-      assert reloaded.onboarding_state == "completed"
     end
 
     test "is idempotent and does not move the original timestamp", %{
@@ -101,7 +102,7 @@ defmodule FountainWeb.OnboardingControllerTest do
         build_conn() |> authed_with_key(key) |> get("/api/auth/me") |> json_response(200)
 
       assert after_body["onboarding_completed"] == true
-      assert after_body["onboarding_state"] == "completed"
+      refute Map.has_key?(after_body, "onboarding_state")
     end
   end
 end

--- a/apps/fountain/test/fountain_web/live/admin_users_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/admin_users_live_test.exs
@@ -22,12 +22,20 @@ defmodule FountainWeb.AdminUsersLiveTest do
       assert html =~ other.email
     end
 
-    test "shows onboarding state for each user", %{conn: conn} do
+    # The column was the wizard's `onboarding_state` until #1393. What is left
+    # is the one stamp: a date when the account is onboarded, an em dash when
+    # it is not.
+    test "shows whether each user is onboarded", %{conn: conn} do
       admin = insert_admin()
       conn = login_user(conn, admin)
       {:ok, _lv, html} = live(conn, ~p"/admin/users")
 
-      assert html =~ "step_1"
+      refute html =~ "step_1"
+      assert html =~ "Onboarding"
+
+      {:ok, _} = Accounts.complete_onboarding(admin)
+      {:ok, _lv, onboarded} = live(login_user(build_conn(), admin), ~p"/admin/users")
+      assert onboarded =~ Calendar.strftime(DateTime.utc_now(), "%Y-%m-%d")
     end
   end
 

--- a/apps/fountain/test/fountain_web/schema_enum_guardrail_test.exs
+++ b/apps/fountain/test/fountain_web/schema_enum_guardrail_test.exs
@@ -35,7 +35,7 @@ defmodule FountainWeb.SchemaEnumGuardrailTest do
   alias Fountain.Environments.Environment
   alias Fountain.Exports.Export
   alias Fountain.InferenceCredentials.Credential
-  alias Fountain.{Accounts, Images, Manifest}
+  alias Fountain.{Images, Manifest}
   alias OpenApiSpex.Schema
 
   # {schema module, dotted property path} => {owning module, function}
@@ -111,7 +111,6 @@ defmodule FountainWeb.SchemaEnumGuardrailTest do
     {FountainWeb.Schemas.LogEvent, "kind"} => {LogEvent, :kinds},
     {FountainWeb.Schemas.LogEvent, "state"} => {LogEvent, :states},
     {FountainWeb.Schemas.ManifestResource, "kind"} => {Manifest, :kinds},
-    {FountainWeb.Schemas.OnboardingResponse, "data.state"} => {Accounts, :onboarding_states},
     {FountainWeb.Schemas.Sandbox, "status"} => {Sandbox, :statuses},
     # The sandbox mode (ADR 0023 gate 6): on the agent as a default, on a
     # launch as the choice, on the sandbox row as what it is.

--- a/decisions/0007-g3-launch-go.md
+++ b/decisions/0007-g3-launch-go.md
@@ -45,7 +45,7 @@ Validation report: `plan/phase-3-release-validation/validation-report.md`.
 - NC-1: Dark mode implementation
 - NC-4: `Billing.sync_subscription/1` unit tests
 - NC-5: `BillingLive` LiveView tests
-- NC-6: Standardise `onboarding_completed_at` vs `onboarding_state`
+- NC-6: Standardise `onboarding_completed_at` vs `onboarding_state` — **done** (#1393, [0038](0038-onboarding-first-reply.md)): `onboarding_state` is dropped and the stamp is the one field.
 - NC-9: `usage_events` user-deletion handling
 - NC-2, NC-3, NC-7, NC-8, NC-10: cleanup and coverage gaps
 

--- a/decisions/0038-onboarding-first-reply.md
+++ b/decisions/0038-onboarding-first-reply.md
@@ -20,7 +20,7 @@ stale_after: 2026-11-02
 and measured) and #1393 (the field cleanup), all sub-issues of #1039. Each PR
 that builds one updates this block.
 
-**Built so far:** decisions 2 (#1392), 3 (#1388) and 4 (#1389).
+**Built so far:** decisions 2 (#1392), 3 (#1388), 4 (#1389) and 7 (#1393).
 
 Decision 2: `Fountain.Activation` holds the definition, `Fountain.Funnel`
 counts it and measures verification to first reply, and
@@ -36,6 +36,15 @@ circuit breaker answering 503.
 Decision 4: `Fountain.Agents.Starter` is planted by `Accounts.verify_email/2`,
 so an account verified from now on owns one agent from the moment it is
 verified.
+
+Decision 7: `users.onboarding_state` is dropped, and with it
+`Accounts.advance_onboarding/2`, the funnel's `by_onboarding_state`
+breakdown and the field on `GET /api/auth/me` and
+`GET /api/account/onboarding`. `onboarding_completed_at` is the whole of
+onboarding. Both onboarding endpoints still work; only the vestigial field
+went, because #1390 owns the larger question of whether
+`POST /onboarding/complete` still has a purpose once the stamp moves to the
+first reply. This settles NC-6 from [0007](0007-g3-launch-go.md).
 
 **The price is pass-through at provider list, a 1.0x margin, no markup**
 (decided with Jake on 2026-09-02). Fountain's margin is sandbox time

--- a/decisions/0038-onboarding-first-reply.md
+++ b/decisions/0038-onboarding-first-reply.md
@@ -20,7 +20,8 @@ stale_after: 2026-11-02
 and measured) and #1393 (the field cleanup), all sub-issues of #1039. Each PR
 that builds one updates this block.
 
-**Built so far:** decisions 2 (#1392), 3 (#1388), 4 (#1389) and 7 (#1393).
+**Built so far:** decisions 2 (#1392), 3 (#1388), 4 (#1389), 5 (#1426) and
+7 (#1393).
 
 Decision 2: `Fountain.Activation` holds the definition, `Fountain.Funnel`
 counts it and measures verification to first reply, and
@@ -33,19 +34,6 @@ selection rule, a `burn_inference` debit per closed platform turn from
 `PLATFORM_INFERENCE_DAILY_CENTS` (default 5000) as a deployment-wide daily
 circuit breaker answering 503.
 
-Decision 4: `Fountain.Agents.Starter` is planted by `Accounts.verify_email/2`,
-so an account verified from now on owns one agent from the moment it is
-verified.
-
-Decision 7: `users.onboarding_state` is dropped, and with it
-`Accounts.advance_onboarding/2`, the funnel's `by_onboarding_state`
-breakdown and the field on `GET /api/auth/me` and
-`GET /api/account/onboarding`. `onboarding_completed_at` is the whole of
-onboarding. Both onboarding endpoints still work; only the vestigial field
-went, because #1390 owns the larger question of whether
-`POST /onboarding/complete` still has a purpose once the stamp moves to the
-first reply. This settles NC-6 from [0007](0007-g3-launch-go.md).
-
 **The price is pass-through at provider list, a 1.0x margin, no markup**
 (decided with Jake on 2026-09-02). Fountain's margin is sandbox time
 (`CREDIT_TURN_HOUR_CENTS`, [0031](0031-credits-are-the-product.md)). Marking
@@ -53,17 +41,28 @@ inference up would make the opening credit buy less of the one thing it was
 granted to buy, which is the reply this ADR is about. A future decision may
 change that; a passing thought about margin should not.
 
+Decision 4: `Fountain.Agents.Starter` is planted by `Accounts.verify_email/2`,
+so an account verified from now on owns one agent from the moment it is
+verified.
+
 Decision 5: `FountainWeb.StartLive` is the verified landing at `/start`. It
 mints an API key and shows it once, prints one request against the account's
 agent from the single source `Fountain.Onboarding` shares with
 `docs/quickstart.md`, and shows the reply inline. Both signup routes land
 there. The dashboard checklist is gone.
 
-The first half of decision 7: `onboarding_completed_at` is stamped by
-`Fountain.Activation` at the first reply, not by a console page.
+Decision 7, both halves. `Fountain.Activation` stamps
+`onboarding_completed_at` at the first reply rather than a console page
+(#1426), and `users.onboarding_state` is dropped (#1393) along with
+`Accounts.advance_onboarding/2`, the funnel's `by_onboarding_state`
+breakdown, and the field on `GET /api/auth/me` and
+`GET /api/account/onboarding`. The stamp is the whole of onboarding. Both
+onboarding endpoints still work: only the vestigial field went, because
+whether `POST /onboarding/complete` has a purpose left now that the stamp
+moved is a question about the landing, not about this cleanup. This settles
+NC-6 from [0007](0007-g3-launch-go.md).
 
-Not built: the CLI commands (#1391) and the second half of decision 7,
-dropping `onboarding_state` (#1393).
+Not built: the CLI commands (#1391).
 
 Amends [0008](0008-byo-inference-credentials.md): Fountain will hold platform
 inference keys. Leans on [0031](0031-credits-are-the-product.md) (the opening

--- a/docs/api.md
+++ b/docs/api.md
@@ -129,7 +129,7 @@ expires in 30 days, and it lists under Account, then API keys, as
 ## Account state
 
 ```
-GET    /api/account/onboarding           # {state, completed, completed_at}
+GET    /api/account/onboarding           # {completed, completed_at}
 POST   /api/account/onboarding/complete  # idempotent
 ```
 
@@ -137,8 +137,7 @@ An account that somebody configured through the API alone never passes through
 the browser wizard. So nothing marks it onboarded, and a later browser visit
 re-enters that wizard. Complete it over the API and the loop closes.
 
-`GET /api/auth/me` also carries `email_verified`, `onboarding_state` and
-`onboarding_completed`.
+`GET /api/auth/me` also carries `email_verified` and `onboarding_completed`.
 
 ### Billing
 

--- a/sdk/contract/contract.json
+++ b/sdk/contract/contract.json
@@ -7648,18 +7648,6 @@
               "nullable": true,
               "required": false,
               "type": "string"
-            },
-            "state": {
-              "enum": [
-                "completed",
-                "step_1",
-                "step_2",
-                "step_3",
-                "step_4"
-              ],
-              "nullable": true,
-              "required": false,
-              "type": "string"
             }
           },
           "required": true,

--- a/sdk/contract/contract.json
+++ b/sdk/contract/contract.json
@@ -5470,11 +5470,6 @@
           "required": false,
           "type": "boolean"
         },
-        "onboarding_state": {
-          "nullable": true,
-          "required": false,
-          "type": "string"
-        },
         "role": {
           "enum": [
             "admin",

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -10,6 +10,25 @@ server releases.
 
 ---
 
+## [1.17.0] — 2026-09-02
+
+### Removed
+
+- `onboarding_state` is gone from `AuthMe`, and `state` is gone from the
+  onboarding response. Both were the browser wizard's position. The wizard
+  went in #867, after which the field only ever said `step_1` or `completed`
+  — which is what `onboarding_completed` and `completed_at` already say. The
+  server dropped the column in #1393 (ADR 0038 makes `onboarding_completed_at`
+  the one source of truth), so these types now match what the API sends.
+
+  Nothing in the hand-written layer read either field, so this is a generated
+  types change only. Code that read `me.onboarding_state` should read
+  `me.onboarding_completed`; there is no replacement for a part-way step,
+  because the server no longer records one.
+
+- `GET /api/account/onboarding` and `POST /api/account/onboarding/complete`
+  are unchanged and still work. Only the vestigial field went.
+
 ## [1.16.0] — 2026-09-02
 
 ### Changed

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentshit/fountain-sdk",
-      "version": "1.16.0",
+      "version": "1.17.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "description": "Run a coding agent on a real computer, with your repos and your credentials, in one call.",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -2804,8 +2804,6 @@ export interface components {
             /** Format: uuid */
             id: string;
             onboarding_completed?: boolean;
-            /** @description Wizard position. Only `completed` means anything to an API client. */
-            onboarding_state?: string | null;
             /** @enum {string} */
             role: "user" | "admin";
         };
@@ -3750,11 +3748,6 @@ export interface components {
                 completed: boolean;
                 /** Format: date-time */
                 completed_at?: string | null;
-                /**
-                 * @description Wizard position. Only `completed` means anything to an API client.
-                 * @enum {string|null}
-                 */
-                state?: "step_1" | "step_2" | "step_3" | "step_4" | "completed" | null;
             };
         };
         /** OpenAIError */

--- a/sdk/typescript/src/http.ts
+++ b/sdk/typescript/src/http.ts
@@ -19,7 +19,7 @@ export interface RequestOptions {
  * this string is already what Fountain's request logs are keyed on. The
  * version half is asserted against `package.json` by a test.
  */
-export const USER_AGENT = "fountain-sdk-js/1.16.0";
+export const USER_AGENT = "fountain-sdk-js/1.17.0";
 
 /**
  * The thin layer everything else is built on: one bearer token, JSON in and


### PR DESCRIPTION
Closes #1393. Builds decision 7 of ADR 0038 and settles NC-6 from ADR 0007.

> **Merging this publishes `@agentshit/fountain-sdk@1.17.0` to npm.**
> `sdk-publish.yml` runs a bare `npm publish` with no `--tag`, so npm moves the
> `latest` dist-tag to whatever it publishes regardless of semver. This PR must
> publish before #1443 (1.18.0) and #1445 (1.19.0), or `latest` goes backwards
> and a fresh `npm install` gets an older client. `npm view` says `latest:
> 1.16.0` today. See #1446.

## What went

`onboarding_state` was the browser wizard's position. The wizard went in #867,
after which the column only ever held `step_1` or `completed` — which is
exactly what `onboarding_completed_at` being null or set already says.

Dropped: the column (with a migration), `Accounts.advance_onboarding/2` and
`@onboarding_states` (they existed only to walk that state machine), the
funnel's `by_onboarding_state` breakdown and its line on `/admin`, the field
on both admin user views, `Analytics`' `onboarding_state` property, and the
`onboarding_state` property on `GET /api/auth/me` plus `state` on
`GET /api/account/onboarding`.

`Analytics` drops the property rather than sending a constant: a field that
always says the same thing is worse than no field.

## What stayed, and why

**Both onboarding endpoints still work.** `completed` and `completed_at`
derive from the one stamp that is left, so the endpoints' purpose survives the
column; only the field that no longer distinguishes anything went. Deleting a
live endpoint is an API-compatibility decision of a different size than
"drop a vestigial field", and #1390 is reshaping this surface and may make
`POST /onboarding/complete` vestigial in its own right now that the stamp
moved to the first reply. That is its call with the full picture, not this
cleanup's to pre-empt. A consequence worth noting: `omissions.json` keeps its
account self-service entry unchanged, so `build.py --check` stays happy.

## The migration

`down/0` restores the column and backfills `completed` from the stamp. It
cannot restore which *step* an unfinished account had reached, because nothing
has recorded that since #867; a rollback puts them back at `step_1`, which is
what the column would say about them today anyway. Verified down and up
against the test database.

## The schema guard (#1442)

**No allowlist entry deleted and no `@ceiling` change, and I checked rather
than assumed.** The only onboarding entry is
`{"POST /api/account/onboarding/complete", 401} => :plug_status`, which is
about a status a pipeline plug returns and not about this field; there is no
entry for `GET /api/auth/me`. The change removes the field from the rendered
body *and* the declared schema together, so the two still agree.
`schema_guardrail_test`, `schema_enum_guardrail_test`,
`onboarding_controller_test` and `auth_me_controller_test` are green, and the
allowlist stays at 98 entries against `@ceiling 98`.

`schema_enum_guardrail_test.exs`'s `OnboardingResponse "data.state"` ->
`{Accounts, :onboarding_states}` mapping went with the field.

## One lesson worth carrying

`admin_users_live_test.exs` asserted `html =~ "step_1"` — on the *value*, not
the field name — so a grep for `onboarding_state` missed it entirely and it
failed in the suite rather than in review. **The next person removing a field
will grep exactly the same way.** Grep for the values too. The test now
asserts the stamp and refutes `step_1`.

## The rebase hid a semantic conflict

Rebasing onto `cf3b30e1` applied with **zero conflicts**, which was the
problem. #1426 and this branch both rewrote ADR 0038's status block for
different reasons, so Git kept one line from each side: this branch's
`**Built so far:**` line won and silently dropped #1426's decision 5, while
#1426's `Not built: ... dropping onboarding_state (#1393)` survived into the
very commit that drops it. Repaired in a second commit — decisions in numeric
order 2, 3, 4, 5, 7, the two halves of decision 7 merged into one paragraph
crediting #1426 for the stamp move and #1393 for the column, `Not built:`
reduced to the CLI commands. `okf validate decisions` is `"valid": true`.

`sdk/contract/contract.json` was rebuilt rather than merged, for the same
reason. The projection on current main renders nested properties where the
old one did not, so the `OnboardingResponse.state` removal now appears there
beside the `AuthMe` one. `build.sh --check` is clean; the generated
TypeScript types needed no further change.

## Verification

`mix precommit` from the umbrella root, output read rather than trusted:
compile with warnings-as-errors clean, `deps.unlock --unused` clean,
`format --check-formatted` clean, `credo --strict` "found no issues",
dialyzer "Total errors: 0", sobelow "done (passed successfully)", **6
doctests, 4095 tests, 1 failure**.

That one failure is `Fountain.CreditsTest` "concurrent posts of one key move
the balance once", a `DBConnection` checkout timeout. It passes in isolation
(24 tests, 0 failures) and is the known in-VM pool-contention family from
running four suites on one machine — not this change, and it cannot happen in
CI, where each partition gets its own machine.

Docs gates: `scripts/docs-style.py` clean, `vale lint docs` exit 0,
`scripts/destink/destink.mjs` clean, `docs_test.exs` 28/0. SDK: typecheck
clean, 101/101 tests, release guard "Release looks well-formed."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BXYa9CQNG8oFNq5YhAxva
