### PR TITLE
fix(api): one shape for every 422

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/account_data_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/account_data_controller.ex
@@ -24,7 +24,9 @@ defmodule FountainWeb.AccountDataController do
 
   action_fallback FountainWeb.FallbackController
 
-  plug OpenApiSpex.Plug.CastAndValidate, replace_params: false
+  plug OpenApiSpex.Plug.CastAndValidate,
+    replace_params: false,
+    render_error: FountainWeb.Plugs.CastRenderError
 
   tags(["Account"])
 

--- a/apps/fountain/lib/fountain_web/controllers/admin_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/admin_controller.ex
@@ -30,7 +30,9 @@ defmodule FountainWeb.AdminController do
 
   action_fallback FountainWeb.FallbackController
 
-  plug OpenApiSpex.Plug.CastAndValidate, replace_params: false
+  plug OpenApiSpex.Plug.CastAndValidate,
+    replace_params: false,
+    render_error: FountainWeb.Plugs.CastRenderError
 
   @default_per_page 25
   @max_per_page 100

--- a/apps/fountain/lib/fountain_web/controllers/agent_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/agent_controller.ex
@@ -10,7 +10,9 @@ defmodule FountainWeb.AgentController do
 
   action_fallback FountainWeb.FallbackController
 
-  plug OpenApiSpex.Plug.CastAndValidate, replace_params: false
+  plug OpenApiSpex.Plug.CastAndValidate,
+    replace_params: false,
+    render_error: FountainWeb.Plugs.CastRenderError
 
   tags(["Agents"])
 

--- a/apps/fountain/lib/fountain_web/controllers/agent_version_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/agent_version_controller.ex
@@ -8,7 +8,9 @@ defmodule FountainWeb.AgentVersionController do
 
   action_fallback FountainWeb.FallbackController
 
-  plug OpenApiSpex.Plug.CastAndValidate, replace_params: false
+  plug OpenApiSpex.Plug.CastAndValidate,
+    replace_params: false,
+    render_error: FountainWeb.Plugs.CastRenderError
 
   tags(["Agents"])
 

--- a/apps/fountain/lib/fountain_web/controllers/apply_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/apply_controller.ex
@@ -8,7 +8,9 @@ defmodule FountainWeb.ApplyController do
 
   action_fallback FountainWeb.FallbackController
 
-  plug OpenApiSpex.Plug.CastAndValidate, replace_params: false
+  plug OpenApiSpex.Plug.CastAndValidate,
+    replace_params: false,
+    render_error: FountainWeb.Plugs.CastRenderError
 
   tags(["Apply"])
 

--- a/apps/fountain/lib/fountain_web/controllers/audit_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/audit_controller.ex
@@ -19,7 +19,9 @@ defmodule FountainWeb.AuditController do
 
   action_fallback FountainWeb.FallbackController
 
-  plug OpenApiSpex.Plug.CastAndValidate, replace_params: false
+  plug OpenApiSpex.Plug.CastAndValidate,
+    replace_params: false,
+    render_error: FountainWeb.Plugs.CastRenderError
 
   @default_limit 100
   @max_limit 500

--- a/apps/fountain/lib/fountain_web/controllers/avatar_generate_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/avatar_generate_controller.ex
@@ -15,7 +15,9 @@ defmodule FountainWeb.AvatarGenerateController do
 
   action_fallback FountainWeb.FallbackController
 
-  plug OpenApiSpex.Plug.CastAndValidate, replace_params: false
+  plug OpenApiSpex.Plug.CastAndValidate,
+    replace_params: false,
+    render_error: FountainWeb.Plugs.CastRenderError
 
   tags(["Agents"])
 

--- a/apps/fountain/lib/fountain_web/controllers/buzz_agent_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/buzz_agent_controller.ex
@@ -20,7 +20,9 @@ defmodule FountainWeb.BuzzAgentController do
 
   action_fallback FountainWeb.FallbackController
 
-  plug OpenApiSpex.Plug.CastAndValidate, replace_params: false
+  plug OpenApiSpex.Plug.CastAndValidate,
+    replace_params: false,
+    render_error: FountainWeb.Plugs.CastRenderError
 
   tags(["Buzz"])
 

--- a/apps/fountain/lib/fountain_web/controllers/changeset_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/changeset_json.ex
@@ -1,7 +1,34 @@
 defmodule FountainWeb.ChangesetJSON do
-  @moduledoc false
+  @moduledoc """
+  A failed changeset, as the API renders it.
+
+  Two keys, and both are load-bearing (#1431):
+
+      {"error": "validation_failed",
+       "errors": {"name": ["can't be blank"]}}
+
+  `errors` is the field detail, keyed by field, which is the only useful thing
+  about a validation failure and what `ValidationError.fieldErrors` reads in
+  every SDK.
+
+  `error` is the code every other Fountain error carries. A 422 is not always a
+  validation failure — `FountainWeb.FallbackController` renders sixteen coded
+  refusals with that status, `%{error: "vault_not_allowed", message: ...}` and
+  the like — so before this, one status meant two incompatible shapes and an
+  operation's declared 422 schema could only ever describe one of them. With a
+  code here as well, every 422 in the API carries `error`, a client never has
+  to branch on which kind it got, and `Error`, `AuthError` and `ChangesetError`
+  are all satisfied by a validation body.
+
+  `FountainWeb.Plugs.CastRenderError` renders the same two keys for a request
+  the OpenAPI cast rejects, so the shape does not depend on which layer caught
+  the problem either.
+  """
+
+  @code "validation_failed"
+
   def error(%{changeset: changeset}) do
-    %{errors: translate(changeset)}
+    %{error: @code, errors: translate(changeset)}
   end
 
   defp translate(changeset) do

--- a/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
@@ -13,7 +13,9 @@ defmodule FountainWeb.ConversationController do
 
   action_fallback FountainWeb.FallbackController
 
-  plug OpenApiSpex.Plug.CastAndValidate, replace_params: false
+  plug OpenApiSpex.Plug.CastAndValidate,
+    replace_params: false,
+    render_error: FountainWeb.Plugs.CastRenderError
 
   tags(["Conversations"])
 

--- a/apps/fountain/lib/fountain_web/controllers/environment_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/environment_controller.ex
@@ -10,7 +10,9 @@ defmodule FountainWeb.EnvironmentController do
 
   action_fallback FountainWeb.FallbackController
 
-  plug OpenApiSpex.Plug.CastAndValidate, replace_params: false
+  plug OpenApiSpex.Plug.CastAndValidate,
+    replace_params: false,
+    render_error: FountainWeb.Plugs.CastRenderError
 
   tags(["Environments"])
 

--- a/apps/fountain/lib/fountain_web/controllers/events_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/events_controller.ex
@@ -19,7 +19,9 @@ defmodule FountainWeb.EventsController do
 
   action_fallback FountainWeb.FallbackController
 
-  plug OpenApiSpex.Plug.CastAndValidate, replace_params: false
+  plug OpenApiSpex.Plug.CastAndValidate,
+    replace_params: false,
+    render_error: FountainWeb.Plugs.CastRenderError
 
   tags(["Conversations"])
 

--- a/apps/fountain/lib/fountain_web/controllers/health_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/health_controller.ex
@@ -19,7 +19,9 @@ defmodule FountainWeb.HealthController do
 
   alias FountainWeb.Schemas
 
-  plug OpenApiSpex.Plug.CastAndValidate, replace_params: false
+  plug OpenApiSpex.Plug.CastAndValidate,
+    replace_params: false,
+    render_error: FountainWeb.Plugs.CastRenderError
 
   tags(["Health"])
   security([])

--- a/apps/fountain/lib/fountain_web/controllers/inference_credential_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/inference_credential_controller.ex
@@ -20,7 +20,9 @@ defmodule FountainWeb.InferenceCredentialController do
 
   action_fallback FountainWeb.FallbackController
 
-  plug OpenApiSpex.Plug.CastAndValidate, replace_params: false
+  plug OpenApiSpex.Plug.CastAndValidate,
+    replace_params: false,
+    render_error: FountainWeb.Plugs.CastRenderError
 
   @providers Credential.providers()
   @provider_strings Enum.map(@providers, &Atom.to_string/1)

--- a/apps/fountain/lib/fountain_web/controllers/oauth_token_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/oauth_token_controller.ex
@@ -15,7 +15,9 @@ defmodule FountainWeb.OAuthTokenController do
 
   action_fallback FountainWeb.FallbackController
 
-  plug OpenApiSpex.Plug.CastAndValidate, replace_params: false
+  plug OpenApiSpex.Plug.CastAndValidate,
+    replace_params: false,
+    render_error: FountainWeb.Plugs.CastRenderError
 
   plug FountainWeb.Plugs.RateLimit,
        [bucket: "oauth_token", max: 30, window_ms: 3_600_000]

--- a/apps/fountain/lib/fountain_web/controllers/onboarding_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/onboarding_controller.ex
@@ -20,7 +20,9 @@ defmodule FountainWeb.OnboardingController do
 
   action_fallback FountainWeb.FallbackController
 
-  plug OpenApiSpex.Plug.CastAndValidate, replace_params: false
+  plug OpenApiSpex.Plug.CastAndValidate,
+    replace_params: false,
+    render_error: FountainWeb.Plugs.CastRenderError
 
   tags(["Account"])
 

--- a/apps/fountain/lib/fountain_web/controllers/sandbox_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/sandbox_controller.ex
@@ -17,7 +17,9 @@ defmodule FountainWeb.SandboxController do
 
   action_fallback FountainWeb.FallbackController
 
-  plug OpenApiSpex.Plug.CastAndValidate, replace_params: false
+  plug OpenApiSpex.Plug.CastAndValidate,
+    replace_params: false,
+    render_error: FountainWeb.Plugs.CastRenderError
 
   tags(["Sandboxes"])
 

--- a/apps/fountain/lib/fountain_web/controllers/sandbox_files_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/sandbox_files_controller.ex
@@ -17,7 +17,9 @@ defmodule FountainWeb.SandboxFilesController do
 
   action_fallback FountainWeb.FallbackController
 
-  plug OpenApiSpex.Plug.CastAndValidate, replace_params: false
+  plug OpenApiSpex.Plug.CastAndValidate,
+    replace_params: false,
+    render_error: FountainWeb.Plugs.CastRenderError
 
   tags(["Sandboxes"])
 

--- a/apps/fountain/lib/fountain_web/controllers/search_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/search_controller.ex
@@ -13,7 +13,9 @@ defmodule FountainWeb.SearchController do
 
   action_fallback FountainWeb.FallbackController
 
-  plug OpenApiSpex.Plug.CastAndValidate, replace_params: false
+  plug OpenApiSpex.Plug.CastAndValidate,
+    replace_params: false,
+    render_error: FountainWeb.Plugs.CastRenderError
 
   tags(["Search"])
 

--- a/apps/fountain/lib/fountain_web/controllers/secret_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/secret_controller.ex
@@ -8,7 +8,9 @@ defmodule FountainWeb.SecretController do
 
   action_fallback FountainWeb.FallbackController
 
-  plug OpenApiSpex.Plug.CastAndValidate, replace_params: false
+  plug OpenApiSpex.Plug.CastAndValidate,
+    replace_params: false,
+    render_error: FountainWeb.Plugs.CastRenderError
 
   tags(["Secrets"])
 

--- a/apps/fountain/lib/fountain_web/controllers/support_report_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/support_report_controller.ex
@@ -12,7 +12,9 @@ defmodule FountainWeb.SupportReportController do
 
   action_fallback FountainWeb.FallbackController
 
-  plug OpenApiSpex.Plug.CastAndValidate, replace_params: false
+  plug OpenApiSpex.Plug.CastAndValidate,
+    replace_params: false,
+    render_error: FountainWeb.Plugs.CastRenderError
 
   tags(["Support"])
 

--- a/apps/fountain/lib/fountain_web/controllers/team_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/team_controller.ex
@@ -19,7 +19,9 @@ defmodule FountainWeb.TeamController do
 
   action_fallback FountainWeb.FallbackController
 
-  plug OpenApiSpex.Plug.CastAndValidate, replace_params: false
+  plug OpenApiSpex.Plug.CastAndValidate,
+    replace_params: false,
+    render_error: FountainWeb.Plugs.CastRenderError
 
   tags(["Team"])
 

--- a/apps/fountain/lib/fountain_web/controllers/team_schedule_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/team_schedule_controller.ex
@@ -17,7 +17,9 @@ defmodule FountainWeb.TeamScheduleController do
 
   action_fallback FountainWeb.FallbackController
 
-  plug OpenApiSpex.Plug.CastAndValidate, replace_params: false
+  plug OpenApiSpex.Plug.CastAndValidate,
+    replace_params: false,
+    render_error: FountainWeb.Plugs.CastRenderError
 
   tags(["Team"])
 

--- a/apps/fountain/lib/fountain_web/controllers/vault_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/vault_controller.ex
@@ -10,7 +10,9 @@ defmodule FountainWeb.VaultController do
 
   action_fallback FountainWeb.FallbackController
 
-  plug OpenApiSpex.Plug.CastAndValidate, replace_params: false
+  plug OpenApiSpex.Plug.CastAndValidate,
+    replace_params: false,
+    render_error: FountainWeb.Plugs.CastRenderError
 
   tags(["Vaults"])
 

--- a/apps/fountain/lib/fountain_web/controllers/vault_secret_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/vault_secret_controller.ex
@@ -8,7 +8,9 @@ defmodule FountainWeb.VaultSecretController do
 
   action_fallback FountainWeb.FallbackController
 
-  plug OpenApiSpex.Plug.CastAndValidate, replace_params: false
+  plug OpenApiSpex.Plug.CastAndValidate,
+    replace_params: false,
+    render_error: FountainWeb.Plugs.CastRenderError
 
   tags(["Vault Secrets"])
 

--- a/apps/fountain/lib/fountain_web/plugs/cast_render_error.ex
+++ b/apps/fountain/lib/fountain_web/plugs/cast_render_error.ex
@@ -1,0 +1,90 @@
+defmodule FountainWeb.Plugs.CastRenderError do
+  @moduledoc """
+  How a request rejected by `OpenApiSpex.Plug.CastAndValidate` is rendered.
+
+  Without this, the validator renders its own quasi-JSON:API shape:
+
+      {"errors": [{"title": "Invalid value", "source": {"pointer": "/limit"},
+                   "detail": "Invalid integer. Got: string"}]}
+
+  An **array**, keyed by pointer. Fountain's own validation failures are
+  `ChangesetError` — an object keyed by field:
+
+      {"errors": {"limit": ["Invalid integer. Got: string"]}}
+
+  So one status meant two shapes depending on whether the request died at the
+  validator or in a changeset, and 27 operations declared one while sometimes
+  sending the other (#1431). The visible cost was in the clients: the
+  TypeScript SDK's `ValidationError.fieldErrors` reads `body.errors` as an
+  object of field to messages, so against a validator 422 it returned `{}` —
+  the caller was told the request was invalid and not which field, on exactly
+  the failures where the field is the only useful information.
+
+  ## Why the body carries both keys
+
+  The 27 operations do not all declare the same thing: 18 declare `Error`
+  (`{error}`), 7 declare `ChangesetError` (`{errors}`) and 2 declare
+  `AuthError` (`{error, message}`). Rendering only `ChangesetError` would fix
+  the 7 and leave the other 20 still disagreeing with their own document, and
+  re-declaring those 20 as `ChangesetError` would then be wrong for their
+  *other* 422s — the fallback controller renders sixteen coded
+  `%{error: ..., message: ...}` unprocessable-entity responses that have
+  nothing to do with schema validation.
+
+  So this renders both:
+
+      {"error": "validation_failed",
+       "errors": {"limit": ["Invalid integer. Got: string"]}}
+
+  which satisfies `Error`, `AuthError` and `ChangesetError` at once, because
+  none of them forbids the other's key. A client reading `body.error` for a
+  code gets one, a client reading `body.errors` for fields gets those, and
+  nothing has to branch on which kind of 422 it received. That is the property
+  worth having: the alternative shapes clients apart, and four SDKs would each
+  need to learn the difference.
+
+  `FountainWeb.SchemaGuardrailTest` and the guard in `test_helper.exs` (#1427)
+  are what keep this true — every one of those 27 operations validates its real
+  rendered 422 against its declared schema on every run.
+  """
+
+  @behaviour Plug
+
+  alias OpenApiSpex.OpenApi
+  alias Plug.Conn
+
+  @code "validation_failed"
+
+  @impl Plug
+  def init(errors), do: errors
+
+  @impl Plug
+  def call(conn, errors) when is_list(errors) do
+    body = %{error: @code, errors: field_errors(errors)}
+
+    conn
+    |> Conn.put_resp_content_type("application/json")
+    |> Conn.send_resp(422, OpenApi.json_encoder().encode!(body))
+  end
+
+  def call(conn, error), do: call(conn, [error])
+
+  # `{field => [message]}`, in the order the validator reported them.
+  #
+  # A `Cast.Error` carries the path it failed at, so `[:limit]` is `"limit"` and
+  # a nested `[:repos, 0, :url]` is `"repos/0/url"` — flattened because
+  # `ChangesetError` declares its values as arrays of strings, not as a tree.
+  # An error with no path at all is about the body as a whole; `"body"` is the
+  # only key left to give it, and it is the one Ecto would not produce, so it
+  # cannot collide with a real field.
+  defp field_errors(errors) do
+    errors
+    |> Enum.map(&{key(&1), to_string(&1)})
+    |> Enum.group_by(&elem(&1, 0), &elem(&1, 1))
+  end
+
+  defp key(%{path: path}) when is_list(path) and path != [],
+    do: Enum.map_join(path, "/", &to_string/1)
+
+  defp key(_error), do: "body"
+end

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -3344,13 +3344,21 @@ defmodule FountainWeb.Schemas do
 
     OpenApiSpex.schema(%{
       title: "ChangesetError",
-      description: "Validation errors keyed by field, with each value an array of messages.",
+      description:
+        "Validation errors keyed by field, with each value an array of messages, " <>
+          "beside the code every Fountain error carries.",
       type: :object,
       properties: %{
         errors: %Schema{
           type: :object,
           additionalProperties: %Schema{type: :array, items: %Schema{type: :string}}
-        }
+        },
+        # Always `validation_failed` on this body, and always present since
+        # #1431 — a 422 is not always a validation failure (the fallback
+        # controller renders coded refusals with the same status), so a client
+        # that branches on the code needs one here too. Optional rather than
+        # required because widening that is the open question in #1444.
+        error: %Schema{type: :string, description: "`validation_failed`."}
       },
       required: [:errors]
     })

--- a/apps/fountain/test/fountain_web/controllers/changeset_json_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/changeset_json_test.exs
@@ -20,9 +20,13 @@ defmodule FountainWeb.ChangesetJSONTest do
   # ---------------------------------------------------------------------------
 
   describe "error/1" do
-    test "returns empty errors map when changeset has no errors" do
+    test "returns a code and an empty errors map when the changeset has no errors" do
       cs = build_changeset(%{name: :string}, %{name: "Alice"})
-      assert ChangesetJSON.error(%{changeset: cs}) == %{errors: %{}}
+
+      # `error` is here so a 422 has one shape whether it came from a
+      # changeset, from the OpenAPI cast or from a coded refusal (#1431).
+      assert ChangesetJSON.error(%{changeset: cs}) ==
+               %{error: "validation_failed", errors: %{}}
     end
 
     test "includes field key with message for a required-field error" do

--- a/apps/fountain/test/fountain_web/controllers/sandbox_files_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/sandbox_files_controller_test.exs
@@ -178,7 +178,9 @@ defmodule FountainWeb.SandboxFilesControllerTest do
     test "path is required — the operation says so, and the cast plug enforces it", ctx do
       reject(&Managoat.Sandbox.exec/4)
 
-      assert %{"errors" => [%{"source" => %{"pointer" => "/path"}}]} =
+      # The cast plug renders ChangesetError like every other validation
+      # failure now (#1431), so the field is a key rather than a pointer.
+      assert %{"error" => "validation_failed", "errors" => %{"path" => [_ | _]}} =
                ctx.conn
                |> authed_with_key(ctx.raw_key)
                |> get("/api/sandboxes/#{ctx.sandbox.id}/file")

--- a/apps/fountain/test/fountain_web/controllers/support_report_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/support_report_controller_test.exs
@@ -42,14 +42,15 @@ defmodule FountainWeb.SupportReportControllerTest do
     end
 
     test "rejects a bad category or an empty message", %{conn: conn, raw_key: key} do
-      # the OpenAPI cast rejects the enum before the context sees it
-      assert %{"errors" => [%{"source" => %{"pointer" => "/category"}}]} =
+      # the OpenAPI cast rejects the enum before the context sees it, and
+      # renders it as ChangesetError like every other 422 (#1431)
+      assert %{"error" => "validation_failed", "errors" => %{"category" => [_ | _]}} =
                conn
                |> authed_with_key(key)
                |> post_json("/api/support/reports", %{"category" => "rant", "message" => "x"})
                |> json_response(422)
 
-      assert %{"errors" => [%{"source" => %{"pointer" => "/message"}}]} =
+      assert %{"error" => "validation_failed", "errors" => %{"message" => [_ | _]}} =
                conn
                |> authed_with_key(key)
                |> post_json("/api/support/reports", %{"category" => "bug", "message" => ""})

--- a/apps/fountain/test/fountain_web/plugs/cast_render_error_test.exs
+++ b/apps/fountain/test/fountain_web/plugs/cast_render_error_test.exs
@@ -1,0 +1,101 @@
+defmodule FountainWeb.Plugs.CastRenderErrorTest do
+  @moduledoc """
+  The 422 body a request rejected by the OpenAPI cast comes back with (#1431).
+
+  Two halves, and both matter. The unit tests pin the field mapping, which is
+  the part a client reads. The request test pins that a real rejection actually
+  goes through this renderer — the plug is wired into 25 controllers, and a
+  correct renderer nobody installed would be invisible.
+  """
+
+  use FountainWeb.ConnCase, async: true
+
+  alias FountainWeb.Plugs.CastRenderError
+  alias OpenApiSpex.Cast.Error
+
+  describe "the body" do
+    test "carries the code and the field errors" do
+      body = render([error(:invalid_type, [:limit], type: :integer, value: "not a number")])
+
+      assert %{"error" => "validation_failed", "errors" => %{"limit" => [message]}} = body
+      assert message =~ "Invalid integer"
+    end
+
+    test "carries both keys so it satisfies Error, AuthError and ChangesetError alike" do
+      # The reason this renderer emits two keys rather than one: the 27
+      # operations it answers for do not all declare the same 422 schema, and
+      # none of those schemas forbids the other's key.
+      body = render([error(:invalid_type, [:name], type: :string, value: 1)])
+
+      assert Map.has_key?(body, "error"), "Error and AuthError require `error`"
+      assert Map.has_key?(body, "errors"), "ChangesetError requires `errors`"
+    end
+
+    test "groups several failures on one field into one list, in order" do
+      body =
+        render([
+          error(:invalid_type, [:cron], type: :string, value: 1),
+          error(:invalid_format, [:cron], format: :cron, value: "nope")
+        ])
+
+      assert %{"errors" => %{"cron" => [_first, _second]}} = body
+    end
+
+    test "flattens a nested path, because the schema declares arrays of strings" do
+      body = render([error(:invalid_type, [:repos, 0, :url], type: :string, value: 1)])
+
+      assert %{"errors" => %{"repos/0/url" => [_]}} = body
+    end
+
+    test "files an error with no path under `body`" do
+      body = render([error(:missing_field, [], name: :prompt)])
+
+      assert %{"errors" => %{"body" => [_]}} = body
+    end
+
+    test "accepts a bare error as well as a list" do
+      conn =
+        Phoenix.ConnTest.build_conn()
+        |> CastRenderError.call(error(:invalid_type, [:limit], type: :integer, value: "x"))
+
+      assert conn.status == 422
+      assert %{"errors" => %{"limit" => [_]}} = Jason.decode!(conn.resp_body)
+    end
+  end
+
+  describe "through a real request" do
+    setup do
+      user = insert_verified_user()
+      {_record, raw_key} = insert_api_key(user)
+      %{user: user, raw_key: raw_key}
+    end
+
+    test "a value the operation refuses is rendered by this plug, not by the default", ctx do
+      # `category` is an enum in the spec, so CastAndValidate rejects this
+      # before SupportReportController ever runs. Before #1431 the body was
+      # `{"errors": [{"title": …, "source": {"pointer": "/category"}}]}` — an
+      # array keyed by pointer, which no declared schema described and which
+      # every SDK's `fieldErrors` read as empty.
+      body =
+        build_conn()
+        |> authed_with_key(ctx.raw_key)
+        |> post_json("/api/support/reports", %{"category" => "rant", "message" => "x"})
+        |> json_response(422)
+
+      assert %{"error" => "validation_failed", "errors" => %{"category" => [message]}} = body
+      assert is_binary(message)
+    end
+  end
+
+  defp render(errors) do
+    Phoenix.ConnTest.build_conn()
+    |> CastRenderError.call(errors)
+    |> Map.fetch!(:resp_body)
+    |> Jason.decode!()
+  end
+
+  defp error(reason, path, attrs) do
+    %Error{reason: reason, path: path}
+    |> struct(attrs)
+  end
+end

--- a/apps/fountain/test/fountain_web/schema_guardrail_test.exs
+++ b/apps/fountain/test/fountain_web/schema_guardrail_test.exs
@@ -48,7 +48,7 @@ defmodule FountainWeb.SchemaGuardrailTest do
 
   # The allowlist may shrink freely. Growing it means editing this number in
   # the same diff, which is the whole ratchet: a reviewer sees the number move.
-  @ceiling 97
+  @ceiling 72
 
   describe "the ratchet" do
     test "the allowlist has not grown" do

--- a/apps/fountain/test/support/schema_guard_allowlist.ex
+++ b/apps/fountain/test/support/schema_guard_allowlist.ex
@@ -23,12 +23,11 @@ defmodule FountainWeb.SchemaGuardAllowlist do
   plugs, which is why 68 of them appear at once. Declaring each per operation
   is a large, mechanical documentation change (#1432).
 
-  `:cast_and_validate_422` — `OpenApiSpex.Plug.CastAndValidate` renders its own
-  422 body, `%{"errors" => [%{message, title, source}]}`, while these
-  operations declare `Error` (`%{error}`) or `ChangesetError`
-  (`%{errors: %{field => [message]}}`). So the spec describes the changeset's
-  422 and the wire sometimes carries the validator's. One root cause, 27
-  operations (#1431).
+  `:mixed_422_shapes` — the operation declares `ChangesetError` for 422, which
+  requires `errors`, and can also refuse with a coded
+  `%{error: ..., message: ...}` that has none. Since #1431 both bodies carry
+  `error`, so the question left is what such an operation should declare;
+  #1444 has the three answers and why it is an API decision rather than a fix.
 
   `:test_fixture_vocabulary` — not a defect in the API. The fixture inserts a
   value on purpose that the domain no longer accepts (a conversation whose
@@ -42,8 +41,7 @@ defmodule FountainWeb.SchemaGuardAllowlist do
 
   @reasons %{
     plug_status: "a status a pipeline plug returns that the operation does not declare (#1432)",
-    cast_and_validate_422:
-      "CastAndValidate renders its own 422 body, not the declared error schema (#1431)",
+    mixed_422_shapes: "declares ChangesetError for 422 but can also refuse with a code (#1444)",
     test_fixture_vocabulary: "the fixture inserts an out-of-vocabulary value on purpose",
     openai_error_shape: "the OpenAI gateway renders `error` as a string, not an object (#1433)"
   }
@@ -122,34 +120,9 @@ defmodule FountainWeb.SchemaGuardAllowlist do
     {"PUT /api/environments/{id}", 401} => :plug_status,
     {"PUT /api/vaults/{id}", 401} => :plug_status,
 
-    # ── cast_and_validate_422 (27) ─────────────────────────────
-    {"DELETE /api/account", 422} => :cast_and_validate_422,
-    {"GET /api/sandboxes/{sandbox_id}/file", 422} => :cast_and_validate_422,
-    {"GET /api/search", 422} => :cast_and_validate_422,
-    {"PATCH /api/buzz/agents/{id}", 422} => :cast_and_validate_422,
-    {"PATCH /api/connection-providers/{id}", 422} => :cast_and_validate_422,
-    {"PATCH /api/team/{agent_id}", 422} => :cast_and_validate_422,
-    {"PATCH /api/team/{agent_id}/contact", 422} => :cast_and_validate_422,
-    {"PATCH /api/team/{agent_id}/schedules/{id}", 422} => :cast_and_validate_422,
-    {"POST /api/admin/users/{id}/credits", 422} => :cast_and_validate_422,
-    {"POST /api/admin/users/{id}/sandbox-limit", 422} => :cast_and_validate_422,
-    {"POST /api/agents", 422} => :cast_and_validate_422,
-    {"POST /api/apply", 422} => :cast_and_validate_422,
-    {"POST /api/auth/api-keys", 422} => :cast_and_validate_422,
-    {"POST /api/auth/password", 422} => :cast_and_validate_422,
-    {"POST /api/auth/register", 422} => :cast_and_validate_422,
-    {"POST /api/auth/reset", 422} => :cast_and_validate_422,
-    {"POST /api/buzz/agents", 422} => :cast_and_validate_422,
-    {"POST /api/conversations", 422} => :cast_and_validate_422,
-    {"POST /api/secret-bindings", 422} => :cast_and_validate_422,
-    {"POST /api/support/reports", 422} => :cast_and_validate_422,
-    {"POST /api/team/{agent_id}/contact", 422} => :cast_and_validate_422,
-    {"POST /api/team/{agent_id}/schedules", 422} => :cast_and_validate_422,
-    {"POST /api/vaults", 422} => :cast_and_validate_422,
-    {"POST /api/webhooks", 422} => :cast_and_validate_422,
-    {"PUT /api/account/inference-credentials/{provider}", 422} => :cast_and_validate_422,
-    {"PUT /api/environments/{id}", 422} => :cast_and_validate_422,
-    {"PUT /api/vaults/{id}", 422} => :cast_and_validate_422,
+    # ── mixed_422_shapes (2) ─────────────────────────────
+    {"POST /api/auth/register", 422} => :mixed_422_shapes,
+    {"POST /api/conversations", 422} => :mixed_422_shapes,
 
     # ── test_fixture_vocabulary (1) ─────────────────────────────
     {"GET /api/conversations/{id}", 200} => :test_fixture_vocabulary,

--- a/ee/lib/fountain_web/controllers/credits_api_controller.ex
+++ b/ee/lib/fountain_web/controllers/credits_api_controller.ex
@@ -22,7 +22,9 @@ defmodule FountainWeb.CreditsApiController do
 
   action_fallback FountainWeb.FallbackController
 
-  plug OpenApiSpex.Plug.CastAndValidate, replace_params: false
+  plug OpenApiSpex.Plug.CastAndValidate,
+    replace_params: false,
+    render_error: FountainWeb.Plugs.CastRenderError
 
   tags(["Billing"])
 

--- a/ee/test/fountain/credits_enforcement_test.exs
+++ b/ee/test/fountain/credits_enforcement_test.exs
@@ -172,8 +172,10 @@ defmodule Fountain.CreditsEnforcementTest do
         |> post("/api/admin/users/#{user.id}/credits", %{"cents" => -5})
         |> json_response(422)
 
-      # The spec's `minimum: 1` refuses it before the action does.
-      assert body["error"] == "invalid_request" or is_list(body["errors"])
+      # The spec's `minimum: 1` refuses it before the action does, and the cast
+      # plug renders that like every other validation failure (#1431).
+      assert body["error"] == "validation_failed"
+      assert is_map(body["errors"])
     end
   end
 

--- a/sdk/conformance/scenarios/error-422-carries-field-errors.json
+++ b/sdk/conformance/scenarios/error-422-carries-field-errors.json
@@ -1,8 +1,8 @@
 {
   "name": "error-422-carries-field-errors",
-  "title": "A 422 becomes a validation error that still carries the server's per-field messages",
+  "title": "A 422 becomes a validation error carrying both the code and the server's per-field messages",
   "contract": "errors",
-  "why": "`errors: {field: [message]}` is the only thing that tells a caller which field to fix.",
+  "why": "`errors` keyed by field is the only thing that tells a caller which field to fix, and since #1431 every 422 carries a code beside it whether it came from a changeset, from the OpenAPI cast or from a coded refusal.",
   "client": {
     "api_key": "conformance-key"
   },
@@ -15,6 +15,7 @@
       "respond": {
         "status": 422,
         "json": {
+          "error": "validation_failed",
           "errors": {
             "name": [
               "can't be blank"
@@ -36,6 +37,7 @@
     "error": {
       "kind": "validation",
       "status": 422,
+      "code": "validation_failed",
       "field_errors": {
         "name": [
           "can't be blank"

--- a/sdk/contract/contract.json
+++ b/sdk/contract/contract.json
@@ -6107,6 +6107,10 @@
     },
     "ChangesetError": {
       "properties": {
+        "error": {
+          "required": false,
+          "type": "string"
+        },
         "errors": {
           "additionalProperties": {
             "items": {

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -10,6 +10,23 @@ server releases.
 
 ---
 
+## [1.20.0] — 2026-09-03
+
+### Changed
+
+- `error.fieldErrors` now populates on a request the server rejected against
+  its OpenAPI schema, not only on one a changeset rejected. Those two
+  failures used to come back in different shapes — the schema validator sent
+  an array keyed by JSON pointer, which this client read as `{}` — so a
+  caller was told the request was invalid and not which field, on exactly the
+  failures where the field is the only useful information. The server now
+  sends one shape for every 422 (#1431). No API change here; the client got
+  better because the wire did.
+- `ChangesetError` gains an optional `error`, the code every Fountain error
+  carries. On a validation body it is always `validation_failed`.
+
+---
+
 ## [1.19.0] — 2026-09-03
 
 ### Changed

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentshit/fountain-sdk",
-      "version": "1.19.0",
+      "version": "1.20.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "Run a coding agent on a real computer, with your repos and your credentials, in one call.",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -3077,9 +3077,11 @@ export interface components {
         };
         /**
          * ChangesetError
-         * @description Validation errors keyed by field, with each value an array of messages.
+         * @description Validation errors keyed by field, with each value an array of messages, beside the code every Fountain error carries.
          */
         ChangesetError: {
+            /** @description `validation_failed`. */
+            error?: string;
             errors: {
                 [key: string]: string[];
             };

--- a/sdk/typescript/src/http.ts
+++ b/sdk/typescript/src/http.ts
@@ -19,7 +19,7 @@ export interface RequestOptions {
  * this string is already what Fountain's request logs are keyed on. The
  * version half is asserted against `package.json` by a test.
  */
-export const USER_AGENT = "fountain-sdk-js/1.19.0";
+export const USER_AGENT = "fountain-sdk-js/1.20.0";
 
 /**
  * The thin layer everything else is built on: one bearer token, JSON in and


### PR DESCRIPTION
Closes #1431

`OpenApiSpex.Plug.CastAndValidate` rendered its own quasi-JSON:API body for a
request it rejected:

```json
{"errors": [{"title": "Invalid value", "source": {"pointer": "/limit"},
             "detail": "Invalid integer. Got: string"}]}
```

An array keyed by pointer, which no operation declares. Every SDK's
`ValidationError.fieldErrors` reads `body.errors` as an object of field to
messages, so against one of these it returned `{}` — the caller was told the
request was invalid and **not which field**, on exactly the failures where the
field is the only useful information.

`FountainWeb.Plugs.CastRenderError` renders `ChangesetError` instead, wired into
all 25 controllers that install the plug.

## Why the body carries two keys

This is the part worth reviewing. The 27 operations do not declare the same 422:

| Declared | Count |
|---|---|
| `Error` (`{error}`) | 18 |
| `ChangesetError` (`{errors}`) | 7 |
| `AuthError` (`{error, message}`) | 2 |

Rendering only `ChangesetError` fixes the 7 and leaves 20 still disagreeing with
their own document. Re-declaring those 20 as `ChangesetError` would then be wrong
for their **other** 422s: `FallbackController` renders sixteen coded
`%{error: ..., message: ...}` refusals with that status, which have nothing to do
with schema validation. So the body is:

```json
{"error": "validation_failed", "errors": {"limit": ["Invalid integer. Got: string"]}}
```

which satisfies `Error`, `AuthError` and `ChangesetError` at once, because none of
them forbids the other's key. A client reading `body.error` for a code gets one, a
client reading `body.errors` for fields gets those, and **nothing branches on which
kind of 422 it received** — which is the property you said you wanted and the one
the naive version does not deliver.

`ChangesetJSON` renders the same two keys, so a changeset failure and a cast
failure are one shape rather than two.

## My classification in #1427 was too coarse, and this proved it

Removing the 27 `:cast_and_validate_422` entries and running the suite left **16
failures, none of them from the validator**:

| | Fixed by | Count |
|---|---|---|
| genuinely `CastAndValidate` | the new renderer | 11 |
| changeset body on an `Error`-declaring operation | `ChangesetJSON` carrying the code | 14 |
| coded refusal on a `ChangesetError`-declaring operation | **not fixed** → #1444 | 2 |

The last two are `POST /api/conversations` and `POST /api/auth/register`. What a
422 that can be *either* a validation failure or a coded refusal should declare is
a real API decision with three defensible answers, so it is filed rather than
decided, and re-allowlisted under `:mixed_422_shapes` — a family name that says
what they actually are.

**Allowlist 97 → 72, ceiling with it.** (97, not the 98 this branch started
against: #1445 fixed #1430 on main and dropped that entry, so the count here is
97 − 27 `cast_and_validate_422` + 2 `mixed_422_shapes`.) The ratchet caught my own arithmetic on
the way: I counted 72 by grep and the real map had 73, because `mix format` had
wrapped an entry across lines. The guard told me before CI did.

## Your three follow-ups

- **Allowlist entries removed and ceiling lowered** — yes, 25 of the 27, with the
  2 above re-recorded under an accurate family and a new issue.
- **Should a conformance scenario pin the 422 shape?** The error group already had
  `error-422-carries-field-errors`, so no new scenario — but it pinned only
  `{errors: …}`. It now pins the **real bytes**, code included, and asserts both
  `code: "validation_failed"` and `field_errors`. Same count, more truth.
- **Does `fieldErrors` populate against a real `CastAndValidate` failure?** Yes,
  and the chain is proven at both ends rather than assumed:
  `cast_render_error_test.exs` drives a real request at `POST /api/support/reports`
  (whose `category` is an enum, so the plug rejects it before the controller runs)
  and asserts the exact bytes; the conformance scenario feeds those same bytes to
  all four clients and asserts `field_errors` comes out populated.

## Also here

`ChangesetError` documents the `error` it now always carries — **optional**, so
the contract only widens and `errors` stays required. That surfaced through the
tooling rather than by inspection: `sdk/conformance/lint.py` refused the updated
fixture until the schema declared the key.

Four tests that pinned the old array shape are updated, and the new plug has its
own test file: field mapping (nested paths flatten to `repos/0/url`, a pathless
error files under `body`, repeated failures on one field group into one list) plus
the end-to-end request above.

## Verification

- `mix precommit`: **6 doctests, 4108 tests, 0 failures**; compile with
  warnings-as-errors, unused deps, format, `credo --strict` (found no issues),
  dialyzer `Total errors: 0`, sobelow all passed. **Zero schema-guard violations**
  with 25 fewer allowlist entries, which is the real proof the fix landed.
- All four SDK contract checks and all four conformance adapters, after the
  `contract.json` change: green.
- No `DBConnection` flake in either full run.

## Release

Four PRs bumped this package on the same night, so this branch was rebased
repeatedly and renumbered each time: #1393 took 1.17.0, #1443 1.18.0 and #1445
1.19.0. npm never lets a version be republished, and the release gate compares
one PR against main, so it cannot see a number another *open* PR has claimed —
which is what #1446 is filed to fix. **1.20.0 was assigned rather than derived
from main.**

Set with `npm version 1.20.0 --no-git-tag-version`, which moves `package.json`
and both `package-lock.json` fields together. Hand-editing moves neither
lockfile field, and nothing in CI checks them: `test/config.test.ts` catches a
`USER_AGENT` that disagrees with `package.json`, the lockfile nothing at all.

After every rebase I rebuilt `dist/openapi.json` and regenerated the TypeScript
types rather than trusting a merge of generated files. No drift in any of them.

`ChangesetError` gaining an optional field moves the generated types, so
**sdk/typescript is bumped to 1.20.0 — merging this publishes it.** The changelog
entry is about the behaviour rather than the type: the client did not change, but
`fieldErrors` now populates on a schema-validation 422 because the server stopped
sending a second shape. No other SDK is bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BXYa9CQNG8oFNq5YhAxva
