### PR TITLE
ci(sdk): publish the Elixir package from Actions

### DIFF
--- a/.github/workflows/elixir-sdk-publish.yml
+++ b/.github/workflows/elixir-sdk-publish.yml
@@ -1,0 +1,129 @@
+name: Publish Elixir SDK
+
+# Hex publishing happens only here. A push to main that changes the Elixir SDK
+# asks Hex whether the version already exists, validates a new package, then
+# publishes it with the repository's HEX_API_KEY secret. The release gate makes
+# shipped changes bump the version before they can merge.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "sdk/elixir/**"
+      - "scripts/elixir-sdk-release.exs"
+      - ".github/workflows/elixir-sdk-publish.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish to Hex
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      # Write access is used only to record a successful publication as an
+      # elixir-sdk-v* tag. Hex receives the dedicated key below.
+      contents: write
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
+
+      - name: Set up Elixir
+        uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1.24.1
+        with:
+          elixir-version: "1.19.2"
+          otp-version: "28.3"
+
+      - name: Read release state
+        id: release
+        run: |
+          set -euo pipefail
+          elixir scripts/elixir-sdk-release.exs state > state.json
+          cat state.json
+          version=$(jq -r .version state.json)
+          tag=$(jq -r .tag state.json)
+          published=$(jq -r .published state.json)
+          if [ "$published" = "true" ]; then needed=no; else needed=yes; fi
+          {
+            echo "version=$version"
+            echo "tag=$tag"
+            echo "needed=$needed"
+          } >> "$GITHUB_OUTPUT"
+          echo "fountain_sdk $version already on Hex: $published"
+
+      - name: Install dependencies
+        if: steps.release.outputs.needed == 'yes'
+        working-directory: sdk/elixir
+        env:
+          MIX_ENV: dev
+        run: mix deps.get
+
+      - name: Format
+        if: steps.release.outputs.needed == 'yes'
+        working-directory: sdk/elixir
+        run: mix format --check-formatted
+
+      - name: Compile
+        if: steps.release.outputs.needed == 'yes'
+        working-directory: sdk/elixir
+        run: mix compile --warnings-as-errors
+
+      - name: Test
+        if: steps.release.outputs.needed == 'yes'
+        working-directory: sdk/elixir
+        run: mix test
+
+      - name: Build documentation
+        if: steps.release.outputs.needed == 'yes'
+        working-directory: sdk/elixir
+        env:
+          MIX_ENV: dev
+        run: mix docs --warnings-as-errors
+
+      - name: Build package
+        if: steps.release.outputs.needed == 'yes'
+        working-directory: sdk/elixir
+        env:
+          MIX_ENV: dev
+        run: mix hex.build
+
+      - name: Publish
+        if: steps.release.outputs.needed == 'yes'
+        working-directory: sdk/elixir
+        env:
+          HEX_API_KEY: ${{ secrets.HEX_API_KEY }}
+          MIX_ENV: dev
+        run: mix hex.publish --yes
+
+      - name: Record the release as a tag
+        if: steps.release.outputs.needed == 'yes'
+        env:
+          TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "fountain_sdk ${TAG#elixir-sdk-v}" "$GITHUB_SHA"
+          git push origin "$TAG"
+
+      - name: Say what happened
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+          NEEDED: ${{ steps.release.outputs.needed }}
+        run: |
+          if [ "$NEEDED" = yes ]; then
+            {
+              echo "### Published \`fountain_sdk $VERSION\`"
+              echo
+              echo "https://hex.pm/packages/fountain_sdk/$VERSION"
+              echo
+              echo "Tagged \`elixir-sdk-v$VERSION\` at \`$GITHUB_SHA\`."
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            {
+              echo "### Nothing to publish"
+              echo
+              echo "\`fountain_sdk $VERSION\` is already on Hex."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/README.md
+++ b/README.md
@@ -93,16 +93,15 @@ The CLI and the SDKs are convenience wrappers over the REST API. Everything they
 npm install @agentshit/fountain-sdk
 # or
 pip install fountain-agent-sdk
-# After its first Hex release, add {:fountain_sdk, "~> 0.1.0"} to mix.exs
+# or add {:fountain_sdk, "~> 0.1.0"} to mix.exs
 ```
 
-For Swift Package Manager, add the repository's `main` branch until the next
-Fountain release supplies the first versioned Swift package:
+For Swift Package Manager, use the versioned repository package:
 
 ```swift
 .package(
     url: "https://github.com/BinaryBourbon/fountain.git",
-    branch: "main"
+    from: "0.15.0"
 )
 ```
 

--- a/docs/elixir-sdk.md
+++ b/docs/elixir-sdk.md
@@ -200,14 +200,11 @@ checks the files and metadata that Hex will receive. A change to shipped code
 must bump `@version` in `sdk/elixir/mix.exs` and add the related
 `## [<version>]` heading to `sdk/elixir/CHANGELOG.md`.
 
-To publish to Hex, use an API key with `api:write` permission. The Hex account
-that owns the key must also own `fountain_sdk`. A maintainer stores the key
-outside the repository and passes it only for the publish command.
+CI is the only publisher. The `HEX_API_KEY` Actions secret stores the Hex key.
+The key does not expire. It has API write and repository access, but does not
+enter the checkout. When a shipped change reaches `main`, CI publishes
+its new version and records the commit as `elixir-sdk-v<version>`. The workflow
+first checks Hex, so a repeat run is safe when that version exists.
 
-```sh
-cd sdk/elixir
-HEX_API_KEY=... MIX_ENV=dev mix hex.publish --yes
-```
-
-The first publisher claims the package name for its Hex account. Do not commit
-the key or put it in a checked-in environment file.
+The first successful run claims the package name for the Hex account that owns
+the key. Do not publish from a checkout or put the key in a file.

--- a/docs/open-source.md
+++ b/docs/open-source.md
@@ -45,7 +45,7 @@ holds the third-party attribution.
 | The CLI | `brew install BinaryBourbon/tap/fountain`, or the [CLI reference](cli.md). |
 | The TypeScript SDK | `@agentshit/fountain-sdk` on npm, or the [TypeScript reference](sdk.md). |
 | The Python SDK | `fountain-agent-sdk` on PyPI, or the [Python reference](python-sdk.md). |
-| The Elixir SDK | The [`sdk/elixir`](https://github.com/BinaryBourbon/fountain/tree/main/sdk/elixir) source, or the [Elixir reference](elixir-sdk.md). When published, its Hex name is `fountain_sdk`. |
+| The Elixir SDK | [`fountain_sdk`](https://hex.pm/packages/fountain_sdk) on Hex, the [`sdk/elixir`](https://github.com/BinaryBourbon/fountain/tree/main/sdk/elixir) source, or the [Elixir reference](elixir-sdk.md). |
 | The Swift SDK | The [`sdk/swift`](https://github.com/BinaryBourbon/fountain/tree/main/sdk/swift) source, or the [Swift reference](swift-sdk.md). SwiftPM reads the `Package.swift` at the repository root. |
 
 There is no separate project website. The manual you read now is the project

--- a/docs/swift-sdk.md
+++ b/docs/swift-sdk.md
@@ -23,14 +23,13 @@ enter the prompt or the event feed that the SDK reads.
 
 ## Install
 
-Add Fountain as a Swift Package Manager dependency. Until the next Fountain
-release includes the root `Package.swift`, depend on `main`:
+Add Fountain as a Swift Package Manager dependency:
 
 ```swift
 dependencies: [
     .package(
         url: "https://github.com/BinaryBourbon/fountain.git",
-        branch: "main"
+        from: "0.15.0"
     ),
 ]
 ```
@@ -46,9 +45,7 @@ Add the library product to your target:
 )
 ```
 
-The next Fountain `vX.Y.Z` release that contains `Package.swift` will also be
-the first versioned Swift package release. You can then replace the branch
-requirement with `from: "X.Y.Z"`.
+The Swift package follows Fountain's `vX.Y.Z` release tags.
 
 ## Credentials
 


### PR DESCRIPTION
Publishes the Elixir SDK from GitHub Actions using the repository HEX_API_KEY secret. The workflow is idempotent, validates the package before publishing, and records successful releases with elixir-sdk-v* tags.

Also updates the installation docs now that Python and Swift are already released and Hex publication is automated.

Checks:
- 52 Elixir SDK tests pass
- docs build with warnings as errors
- mix hex.build succeeds
- actionlint passes