### PR TITLE
fix(funnel): re-decompose the stalled breakdown around the starter agent (#1421)

### DIFF
--- a/apps/fountain/lib/fountain/funnel.ex
+++ b/apps/fountain/lib/fountain/funnel.ex
@@ -12,8 +12,8 @@ defmodule Fountain.Funnel do
     ADR 0038 says the onboarding redesign is judged on.
   - included stall breakdown — of the users who verified but never got a
     reply, how far did they get? This is the "40 verified, nothing created"
-    question: did they finish onboarding, build an agent, create an
-    environment, start a conversation that never answered, or bounce straight
+    question: did they add a credential, create an environment, write an agent
+    of their own, start a conversation that never answered, or bounce straight
     off?
 
   Stage definitions:
@@ -25,8 +25,8 @@ defmodule Fountain.Funnel do
     wizard's position; the wizard went in #867, after which the column only
     distinguished `step_1` from `completed`, so it is dropped.
     `Fountain.Activation` stamps the date at the first reply (ADR 0038).
-    `built_agent` / `built_environment` / `built_nothing` are the stall
-    breakdown's live signal.
+    `added_credential` / `built_environment` / `built_own_agent` are the
+    stall breakdown's live signal.
   - **activated** — **the first conversation with a reply** (ADR 0038): the
     earliest `turns` row for the account carrying a non-empty `reply_text`.
     A conversation that never answered does not count, and neither does a
@@ -51,8 +51,11 @@ defmodule Fountain.Funnel do
 
   alias Fountain.Accounts.User
   alias Fountain.Activation
+  alias Fountain.Agents.Agent
   alias Fountain.Billing.UsageEvent
   alias Fountain.Conversations.Conversation
+  alias Fountain.Environments.Environment
+  alias Fountain.InferenceCredentials
   alias Fountain.Repo
 
   # A day, in hours: the window ADR 0038 judges the landing by.
@@ -78,7 +81,8 @@ defmodule Fountain.Funnel do
   The funnel: five stages, time to first reply, and the stalled breakdown.
 
   Returns `%{stages: [stage], time_to_first_reply: timing, stalled: %{count: n,
-  started: n, built_agent: n, built_environment: n, built_nothing: n}}`.
+  started: n, added_credential: n, built_environment: n, built_own_agent:
+  n}}`.
 
   `conversion` is the fraction of the *previous* stage (nil for registered);
   `median_hours` is the median time from the previous stage's timestamp, for
@@ -214,25 +218,38 @@ defmodule Fountain.Funnel do
   end
 
   # Of the verified users who never got a reply: how far did each get?
+  #
+  # The decomposition changed in #1421. `built_agent` and `built_nothing` were
+  # the useful halves of this answer until #1389 planted a `starter` agent in
+  # every account at verification; after it they are constants
+  # (`built_agent == count`, `built_nothing == 0`) and tell an operator
+  # nothing. What replaces them are the two things owning an agent no longer
+  # implies: paying the cost of a credential, and writing an agent of one's
+  # own. `started` and `built_environment` carry the signal they always did
+  # and are unchanged.
+  #
+  # "Arrived at the landing and never sent the request" is the other split
+  # worth having, and it is deliberately not here.
+  # `onboarding.landing_viewed` is a PostHog event (`FountainWeb.StartLive`)
+  # and this function is SQL over `users`; a page view is the product sink's
+  # question rather than the audit trail's or the invoice's, so it is asked
+  # of PostHog (ADR 0028, `Fountain.Analytics`).
   defp stalled_breakdown(verified, first_reply) do
     stalled = Enum.reject(verified, &Map.has_key?(first_reply, &1.id))
     stalled_ids = MapSet.new(stalled, & &1.id)
 
-    agent_owners = owners_in(Fountain.Agents.Agent, stalled_ids)
-    env_owners = owners_in(Fountain.Environments.Environment, stalled_ids)
-    starters = started_ids(stalled_ids)
-
-    built_nothing =
-      Enum.count(stalled, fn u ->
-        not MapSet.member?(agent_owners, u.id) and not MapSet.member?(env_owners, u.id)
-      end)
-
+    # ownership: an admin-only aggregate over every account, like the rest of
+    # this module — the ids handed over are the stalled cohort computed above,
+    # and no tenant is being served.
     %{
       count: length(stalled),
-      started: MapSet.size(starters),
-      built_agent: MapSet.size(agent_owners),
-      built_environment: MapSet.size(env_owners),
-      built_nothing: built_nothing
+      started: MapSet.size(started_ids(stalled_ids)),
+      added_credential:
+        MapSet.size(
+          InferenceCredentials._unsafe_user_ids_with_credential(MapSet.to_list(stalled_ids))
+        ),
+      built_environment: MapSet.size(owners_in(Environment, stalled_ids)),
+      built_own_agent: MapSet.size(own_agent_owners(stalled_ids))
     }
   end
 
@@ -240,6 +257,30 @@ defmodule Fountain.Funnel do
     ids = MapSet.to_list(stalled_ids)
 
     from(r in schema, where: r.user_id in ^ids, distinct: true, select: r.user_id)
+    |> Repo.all()
+    |> MapSet.new()
+  end
+
+  # The accounts that own an agent they wrote, rather than the one they were
+  # given. Every verified account owns a `starter` (#1389), so the question is
+  # what they did to it: kept a second agent, or edited this one.
+  #
+  # Neither half reads the agent's name. `Fountain.Agents.Starter` says the
+  # starter is an ordinary row with no flag on it and that the tenant may
+  # rename it the next minute, so a name match would answer a different
+  # question every time somebody did. Nothing but a tenant edit moves
+  # `updated_at` — agents carry no `last_used_at` and no worker stamps them —
+  # though the column is second-granular, so an agent created and edited
+  # inside one second reads as untouched.
+  defp own_agent_owners(stalled_ids) do
+    ids = MapSet.to_list(stalled_ids)
+
+    from(a in Agent,
+      where: a.user_id in ^ids,
+      group_by: a.user_id,
+      having: count(a.id) > 1 or fragment("bool_or(? > ?)", a.updated_at, a.inserted_at),
+      select: a.user_id
+    )
     |> Repo.all()
     |> MapSet.new()
   end

--- a/apps/fountain/lib/fountain/inference_credentials.ex
+++ b/apps/fountain/lib/fountain/inference_credentials.ex
@@ -146,6 +146,35 @@ defmodule Fountain.InferenceCredentials do
   end
 
   @doc """
+  Of `user_ids`, the ones holding at least one provider credential.
+
+  The set form of `has_any_credential?/1`, for the admin funnel's stalled
+  breakdown (#1421). A row whose every ciphertext is `nil` belongs to an
+  account that cleared its last key (`put_credential/5` clears to `nil`), so
+  the row existing is not the signal and this asks the same question
+  `has_any_credential?/1` asks, one query instead of one account at a time.
+
+  `_unsafe_` because it crosses tenants: it answers for whatever ids it is
+  handed. The legitimate caller is a system-level aggregate — today
+  `Fountain.Funnel`, which is admin-only and unscoped by construction.
+  """
+  @spec _unsafe_user_ids_with_credential([binary()]) :: MapSet.t(binary())
+  def _unsafe_user_ids_with_credential(user_ids) when is_list(user_ids) do
+    held =
+      @providers
+      |> Enum.map(&ciphertext_field/1)
+      |> Enum.reduce(nil, fn ct, acc ->
+        clause = dynamic([c], not is_nil(field(c, ^ct)))
+        if acc, do: dynamic(^acc or ^clause), else: clause
+      end)
+
+    from(c in Credential, where: c.user_id in ^user_ids, distinct: true, select: c.user_id)
+    |> where(^held)
+    |> Repo.all()
+    |> MapSet.new()
+  end
+
+  @doc """
   The credentials that let a model's provider run: a model `provider/id`
   names a provider; any one of these credentials serves it. Unknown
   providers (a local model, a gateway) need none — Fountain cannot know.

--- a/apps/fountain/lib/fountain_web/live/admin_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/admin_live/index.ex
@@ -148,7 +148,7 @@ defmodule FountainWeb.AdminLive.Index do
             started a conversation and got nothing back: {@funnel.stalled.started}
           </div>
           <div class="text-xs">
-            built an agent: {@funnel.stalled.built_agent} · created an environment: {@funnel.stalled.built_environment} · built nothing: {@funnel.stalled.built_nothing}
+            added a credential: {@funnel.stalled.added_credential} · created an environment: {@funnel.stalled.built_environment} · built their own agent: {@funnel.stalled.built_own_agent}
           </div>
         </div>
       </section>

--- a/apps/fountain/test/fountain/funnel_test.exs
+++ b/apps/fountain/test/fountain/funnel_test.exs
@@ -36,6 +36,31 @@ defmodule Fountain.FunnelTest do
     })
   end
 
+  # An inference credential the tenant supplied. `nil` clears it, which is
+  # what an account that set a key and removed it leaves behind.
+  defp put_credential!(user, value \\ "sk-ant-test") do
+    {:ok, dek} = Fountain.Crypto.load_tenant_key(user.id)
+
+    {:ok, _} =
+      Fountain.InferenceCredentials.put_credential(user.id, dek, :anthropic_api_key, value)
+
+    :ok
+  end
+
+  # Edit the agent the account was given. The write goes through
+  # `update_agent/3` so the changeset stamps `updated_at` the way production
+  # does, and the row is aged backwards first: `updated_at` is second-granular,
+  # so an agent inserted and edited inside one test would otherwise read as
+  # untouched.
+  defp edit_agent!(user) do
+    [agent] = Fountain.Agents.list_agents(user.id, [])
+
+    agent
+    |> Ecto.Changeset.change(inserted_at: at(1), updated_at: at(1))
+    |> Repo.update!()
+    |> Fountain.Agents.update_agent(%{"description" => "mine now"})
+  end
+
   describe "summary_admin/0 — stage counts" do
     test "empty database: zero counts, nil conversions and medians" do
       summary = Funnel.summary_admin()
@@ -235,17 +260,29 @@ defmodule Fountain.FunnelTest do
   end
 
   describe "summary_admin/0 — stalled breakdown" do
-    test "verified users with no conversation, by how far they got" do
-      _nothing = insert_verified_user()
+    test "verified users with no reply, by how far they got" do
+      # Took the starter agent and stopped. The floor every verified account
+      # stands on since #1389, and the case the old decomposition could not
+      # tell apart from any other.
+      _floor = insert_verified_user()
 
-      agent_builder = insert_verified_user()
-      insert_agent(user_id: agent_builder.id)
+      credentialled = insert_verified_user()
+      put_credential!(credentialled)
 
       env_builder = insert_verified_user()
       insert_env(user_id: env_builder.id)
 
+      # Two ways to own an agent of your own: keep a second one...
+      second_agent = insert_verified_user()
+      insert_agent(user_id: second_agent.id)
+
+      # ...or edit the one you were given.
+      editor = insert_verified_user()
+      edit_agent!(editor)
+
       # An account that got a reply is not stalled, whatever else is true.
       activated = insert_verified_user()
+      put_credential!(activated)
       reply!(activated)
 
       # Unverified users are not in the stalled cohort.
@@ -253,12 +290,38 @@ defmodule Fountain.FunnelTest do
 
       %{stalled: stalled} = Funnel.summary_admin()
 
-      assert stalled.count == 3
-      # All three, and none: every verified account owns a starter agent
-      # (ADR 0038). #1421 replaces this decomposition.
-      assert stalled.built_agent == 3
+      assert stalled.count == 5
+      assert stalled.added_credential == 1
       assert stalled.built_environment == 1
-      assert stalled.built_nothing == 0
+      assert stalled.built_own_agent == 2
+    end
+
+    test "a cleared credential is not an added one" do
+      user = insert_verified_user()
+      put_credential!(user)
+      assert Funnel.summary_admin().stalled.added_credential == 1
+
+      # Clearing the last key leaves the row behind, so the row's existence
+      # cannot be the signal.
+      put_credential!(user, nil)
+
+      assert Repo.get_by(Fountain.InferenceCredentials.Credential, user_id: user.id)
+      assert Funnel.summary_admin().stalled.added_credential == 0
+    end
+
+    test "the starter agent alone is not an agent of your own" do
+      user = insert_verified_user()
+
+      assert [%{name: "starter"}] = Fountain.Agents.list_agents(user.id, [])
+      assert Funnel.summary_admin().stalled.built_own_agent == 0
+    end
+
+    test "an account with no agents at all is not counted as owning one" do
+      # The starter deleted rather than kept or edited.
+      _bare = insert_user_without_agents()
+
+      assert Funnel.summary_admin().stalled.count == 1
+      assert Funnel.summary_admin().stalled.built_own_agent == 0
     end
 
     test "started: the stalled accounts that ran something and got nothing back" do

--- a/apps/fountain/test/fountain_web/live/admin_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/admin_live_test.exs
@@ -63,8 +63,10 @@ defmodule FountainWeb.AdminLiveTest do
       # conversation that never answered is a start, not an activation.
       assert html =~ "2 verified users have never had a reply"
       assert html =~ "started a conversation and got nothing back: 1"
-      # Both, because a verified account owns a starter agent (ADR 0038).
-      assert html =~ "built an agent: 2"
+      # One: `stalled` kept a second agent beside the starter every verified
+      # account owns (ADR 0038); the admin has only the starter (#1421).
+      assert html =~ "built their own agent: 1"
+      assert html =~ "added a credential: 0"
     end
 
     test "shows time to first reply", %{conn: conn} do


### PR DESCRIPTION
Closes #1421.

Since #1389 planted a `starter` agent in every account at verification, two of the three buckets in `Funnel.stalled_breakdown/2` were constants — `built_agent == count`, `built_nothing == 0`. #1389 pinned the degenerate values in tests on purpose rather than fix them blind, and #1421 waited for #1390 and #1393 so the replacement would be chosen against the funnel's final shape. Both are in.

## What changes

`started` and `built_environment` carry the signal they always did and are untouched. The other two are replaced by the two things owning an agent no longer implies:

| was | is |
|---|---|
| `built_agent` | `added_credential` — the account supplied an inference key |
| `built_nothing` | `built_own_agent` — kept a second agent, or edited the one it was given |

**`added_credential`** is the issue's own strongest candidate: ADR 0038's platform key stopped a credential being a gate, so it is now a signal of intent. `InferenceCredentials._unsafe_user_ids_with_credential/1` is the set form of `has_any_credential?/1` and asks the same question — a row whose every ciphertext is `nil` belongs to an account that cleared its last key, so the row existing is not the signal.

**`built_own_agent`** deliberately does not read the agent's name. `Agents.Starter` says the starter is an ordinary row with no flag on it, and that the tenant may rename it the next minute, so a name match would answer a different question every time somebody did. Instead: more than one agent, or `updated_at > inserted_at` on one. Nothing but a tenant edit moves `updated_at` — agents carry no `last_used_at` and no worker stamps them — though the column is second-granular, so an agent created and edited inside one second reads as untouched (the test ages the row rather than asserting on that).

The admin one-liner now reads:

> started a conversation and got nothing back: N
> added a credential: N · created an environment: N · built their own agent: N

## What is deliberately not here

The issue also floats "did they view the verified landing", to split "never came back after verifying" from "arrived, read it, did not send the request". That is a good question and it stays in PostHog. `onboarding.landing_viewed` is an `Analytics.capture/3` from `StartLive` with no Postgres row, and `Fountain.Funnel` is SQL over `users`; persisting it would mean picking a sink, and by `Fountain.Analytics`'s own moduledoc a page view is the product sink's question rather than the audit trail's ("who changed what, kept forever") or the invoice's ("a closed set of event types"). #1390 already emits both halves of that funnel, so PostHog can answer it today. The reasoning is a comment on `stalled_breakdown/2` so the next reader does not re-litigate it.

## Verification

`mix precommit` green: 6 doctests, 4112 tests, 0 failures.

Each new assertion was checked by breaking the thing it guards and confirming it fails:

- dropped the `count(a.id) > 1` half → the second-agent case fails
- dropped the `bool_or(updated_at > inserted_at)` half → the edited-starter case fails
- dropped the held-credential filter, leaving row existence → "a cleared credential is not an added one" fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BXYa9CQNG8oFNq5YhAxva
