### PR TITLE
fix(sdk): make the Swift package release-ready

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -349,10 +349,14 @@ jobs:
             echo "expected 2 digests (amd64 + arm64), found ${#digests[@]}: ${digests[*]}" >&2
             exit 1
           fi
+          refs=()
+          for digest in "${digests[@]}"; do
+            refs+=("${IMAGE}@sha256:${digest}")
+          done
           docker buildx imagetools create \
             --tag "${IMAGE}:${TAG}" \
             --tag "${IMAGE}:${MINOR}" \
-            $(printf "${IMAGE}@sha256:%s " *)
+            "${refs[@]}"
           docker buildx imagetools inspect "${IMAGE}:${TAG}"
 
   compose-boot:
@@ -403,6 +407,67 @@ jobs:
         if: failure()
         run: docker compose logs --timestamps
 
+  swift-package:
+    name: Resolve the released Swift package remotely
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    steps:
+      - name: Set up Swift
+        uses: swift-actions/setup-swift@7ca6abe6b3b0e8b5421b88be48feee39cbf52c6a # v2.4.0
+        with:
+          swift-version: "6.1"
+
+      - name: Resolve and build a clean consumer
+        env:
+          RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref_name }}
+        run: |
+          set -euo pipefail
+          if ! echo "${RELEASE_TAG}" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "'${RELEASE_TAG}' is not a vX.Y.Z tag" >&2
+            exit 1
+          fi
+          version="${RELEASE_TAG#v}"
+          consumer="${RUNNER_TEMP}/fountain-swift-consumer"
+          mkdir -p "${consumer}/Sources/FountainReleaseSmoke"
+          cat > "${consumer}/Package.swift" <<EOF
+          // swift-tools-version: 6.1
+          import PackageDescription
+
+          let package = Package(
+            name: "FountainReleaseSmoke",
+            dependencies: [
+              .package(
+                url: "https://github.com/BinaryBourbon/fountain.git",
+                exact: "${version}"
+              )
+            ],
+            targets: [
+              .executableTarget(
+                name: "FountainReleaseSmoke",
+                dependencies: [
+                  .product(name: "Fountain", package: "fountain")
+                ]
+              )
+            ]
+          )
+          EOF
+          cat > "${consumer}/Sources/FountainReleaseSmoke/main.swift" <<'EOF'
+          import Fountain
+
+          print(fountainSDKVersion)
+          EOF
+          cd "${consumer}"
+          swift package resolve
+          swift build
+          resolved_version="$(swift run FountainReleaseSmoke)"
+          if [ "${resolved_version}" != "${version}" ]; then
+            echo "remote package reports ${resolved_version}, expected ${version}" >&2
+            exit 1
+          fi
+
   release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
@@ -413,7 +478,7 @@ jobs:
     # pushed digests with no manifest list on the tag is not a published image.
     # compose-boot goes one further: the image also has to boot through the
     # quick start the release page points at.
-    needs: [build, openapi, image-manifest, compose-boot]
+    needs: [build, openapi, image-manifest, compose-boot, swift-package]
     permissions:
       contents: write
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ upgrade, is in
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-09-03
+
+### Upgrade notes
+
+- None.
+
 ### Removed
 
 - **`users.onboarding_state`** (#1393, ADR 0038, settling NC-6 from ADR 0007).
@@ -53,6 +59,10 @@ upgrade, is in
 
 ### Changed
 
+- **The Swift SDK becomes a versioned SwiftPM package in `v0.16.0`.** The
+  manifest now declares Swift tools 6.1, its SSE iterator passes Swift 6 strict
+  concurrency checks, and the release pipeline resolves and builds the tag from
+  a clean remote consumer before it creates the GitHub Release.
 - **`managoat_runtimes` comes from hex** (#1368, #1345, ADR 0037), the
   ninth library to graduate and the last in the umbrella:
   `apps/managoat_runtimes` is gone, the pin is

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.1
 import PackageDescription
 
 let package = Package(

--- a/README.md
+++ b/README.md
@@ -96,12 +96,13 @@ pip install fountain-agent-sdk
 # or add {:fountain_sdk, "~> 0.1.0"} to mix.exs
 ```
 
-For Swift Package Manager, use the versioned repository package:
+Until the next Fountain release contains the root `Package.swift`, use the
+repository's `main` branch with Swift Package Manager:
 
 ```swift
 .package(
     url: "https://github.com/BinaryBourbon/fountain.git",
-    from: "0.15.0"
+    branch: "main"
 )
 ```
 

--- a/docs/swift-sdk.md
+++ b/docs/swift-sdk.md
@@ -23,13 +23,14 @@ enter the prompt or the event feed that the SDK reads.
 
 ## Install
 
-Add Fountain as a Swift Package Manager dependency:
+Until the next Fountain release contains the root `Package.swift`, use the
+repository's `main` branch:
 
 ```swift
 dependencies: [
     .package(
         url: "https://github.com/BinaryBourbon/fountain.git",
-        from: "0.15.0"
+        branch: "main"
     ),
 ]
 ```
@@ -45,7 +46,7 @@ Add the library product to your target:
 )
 ```
 
-The Swift package follows Fountain's `vX.Y.Z` release tags.
+After that release, replace the branch requirement with its version.
 
 ## Credentials
 

--- a/sdk/swift/CHANGELOG.md
+++ b/sdk/swift/CHANGELOG.md
@@ -5,6 +5,8 @@ Notable changes to the Fountain Swift SDK follow
 
 ## Unreleased
 
+## [0.16.0] - 2026-09-03
+
 ### Added
 
 - Initial dependency-free Swift SDK with async run streaming, resumable
@@ -18,3 +20,10 @@ Notable changes to the Fountain Swift SDK follow
   instead of falling back to the hosted deployment and sending the API key to
   a host the caller never named.
 - Credentials-file reads only when an argument and the environment both miss.
+
+### Changed
+
+- Swift 6.1 is now both the declared package tools version and the minimum
+  compiler version. The SSE iterator is safe under Swift 6 strict concurrency.
+- The Fountain release pipeline resolves and builds the tagged package from a
+  clean consumer before it creates the GitHub Release.

--- a/sdk/swift/Sources/Fountain/SSE.swift
+++ b/sdk/swift/Sources/Fountain/SSE.swift
@@ -68,11 +68,11 @@ func streamPath(
 }
 
 /// Holds the connection the first `next()` opens. An `AsyncIterator` has a
-/// single consumer by contract, which is what makes the actor's read-await-write
-/// of `iterator` safe here.
+/// single consumer by contract, which is what makes access to the boxed
+/// iterator safe here.
 private actor LazyStream {
   private let open: @Sendable () -> AsyncThrowingStream<JSONObject, Error>
-  private var iterator: AsyncThrowingStream<JSONObject, Error>.AsyncIterator?
+  private var iterator: StreamIterator?
   private var opened = false
 
   init(open: @escaping @Sendable () -> AsyncThrowingStream<JSONObject, Error>) {
@@ -82,11 +82,24 @@ private actor LazyStream {
   func next() async throws -> JSONObject? {
     if !opened {
       opened = true
-      iterator = open().makeAsyncIterator()
+      iterator = StreamIterator(open().makeAsyncIterator())
     }
-    guard var current = iterator else { return nil }
-    defer { iterator = current }
-    return try await current.next()
+    return try await iterator?.next()
+  }
+}
+
+/// `AsyncThrowingStream.Iterator` is a single-consumer value but does not
+/// declare `Sendable`. The actor above owns this box, and the sequence contract
+/// prevents overlapping calls to `next()`.
+private final class StreamIterator: @unchecked Sendable {
+  private var iterator: AsyncThrowingStream<JSONObject, Error>.AsyncIterator
+
+  init(_ iterator: AsyncThrowingStream<JSONObject, Error>.AsyncIterator) {
+    self.iterator = iterator
+  }
+
+  func next() async throws -> JSONObject? {
+    try await iterator.next()
   }
 }
 


### PR DESCRIPTION
Corrects the invalid v0.15.0 installation guidance and prepares the first valid tagged Swift package.

- restores branch: main until v0.16.0 exists
- declares Swift tools 6.1 to match README and CI
- fixes the strict-concurrency iterator error exposed by Swift 6 mode
- adds a clean remote-consumer package resolution/build gate to release.yml
- prepares the v0.16.0 changelogs

Checks:
- Swift 6.1 format lint
- 23 Swift tests
- real-socket streaming test
- actionlint
- Vale: zero errors and warnings