### PR TITLE
chore(release): v0.16.0

### DIFF
--- a/.env.compose.example
+++ b/.env.compose.example
@@ -51,7 +51,7 @@ SPRITES_TOKEN=
 # it moves under you on every merge). Releases publish vX.Y.Z (immutable)
 # and vX.Y (newest patch in the line) tags:
 # https://managoat.com/docs/guides/operate/upgrade#how-versions-work
-FOUNTAIN_IMAGE_TAG=v0.15.0
+FOUNTAIN_IMAGE_TAG=v0.16.0
 
 # Mail. The default (EMAIL_DELIVERY=none) sends nothing; accounts self-verify
 # at registration instead (ADR 0011), so signup works without a mail provider.

--- a/apps/fountain/mix.exs
+++ b/apps/fountain/mix.exs
@@ -4,7 +4,7 @@ defmodule Fountain.MixProject do
   def project do
     [
       app: :fountain,
-      version: "0.15.0",
+      version: "0.16.0",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -40,7 +40,7 @@ spec:
         - name: fountain
           # Retagged by kustomization.yaml's images: block — edit the pin
           # there, not here.
-          image: ghcr.io/binarybourbon/fountain:v0.15.0
+          image: ghcr.io/binarybourbon/fountain:v0.16.0
           imagePullPolicy: IfNotPresent
           lifecycle:
             # Endpoints propagation is asynchronous: without this pause the

--- a/deploy/k8s/kustomization.yaml
+++ b/deploy/k8s/kustomization.yaml
@@ -27,4 +27,4 @@ images:
   # Released tags: vX.Y.Z (immutable) and vX.Y (newest patch in the line).
   # https://managoat.com/docs/guides/operate/upgrade#how-versions-work
   - name: ghcr.io/binarybourbon/fountain
-    newTag: v0.15.0
+    newTag: v0.16.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
     # migrations applied at boot and downgrade unsupported — the exact
     # combination the versioning guide tells you never to run. Upgrade by
     # setting FOUNTAIN_IMAGE_TAG in .env (see .env.compose.example).
-    image: ghcr.io/binarybourbon/fountain:${FOUNTAIN_IMAGE_TAG:-v0.15.0}
+    image: ghcr.io/binarybourbon/fountain:${FOUNTAIN_IMAGE_TAG:-v0.16.0}
     # To run your own build instead of the published image, comment the line
     # above and uncomment this:
     #   build: .

--- a/fly.toml
+++ b/fly.toml
@@ -34,7 +34,7 @@ primary_region = "iad"
   # `image` line and let Fly build the Dockerfile in this checkout. The build
   # compiles the umbrella, the Go CLI and fetches the pinned Buzz binaries, so
   # prefer the image unless you have changes to run.
-  image = "ghcr.io/binarybourbon/fountain:v0.15.0"
+  image = "ghcr.io/binarybourbon/fountain:v0.16.0"
 
 # Migrations run at boot, inside the app's own start sequence, and the
 # endpoint does not listen until they finish. There is deliberately no

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Fountain.Umbrella.MixProject do
       apps_path: "apps",
       # Kept in lockstep with the newest v* git tag — release-bump.yml
       # computes the next tag from this value.
-      version: "0.15.0",
+      version: "0.16.0",
       deps: deps(),
       releases: releases(),
       aliases: aliases(),

--- a/render.yaml
+++ b/render.yaml
@@ -38,7 +38,7 @@ services:
     # umbrella, the Go CLI and fetches the pinned Buzz binaries — so prefer the
     # image unless you have changes to run.
     image:
-      url: ghcr.io/binarybourbon/fountain:v0.15.0
+      url: ghcr.io/binarybourbon/fountain:v0.16.0
 
     region: oregon
     plan: starter

--- a/sdk/swift/Sources/Fountain/Fountain.swift
+++ b/sdk/swift/Sources/Fountain/Fountain.swift
@@ -5,7 +5,7 @@ import Foundation
 #endif
 
 /// The Fountain server release this SDK shipped with.
-public let fountainSDKVersion = "0.15.0"
+public let fountainSDKVersion = "0.16.0"
 
 public final class Fountain: @unchecked Sendable {
   public let configuration: FountainConfiguration


### PR DESCRIPTION
Version bump for v0.16.0: both `mix.exs` files, the Swift SDK version source, and the six self-host image pins.

Merging this PR tags the squash commit `v0.16.0` and dispatches `release.yml`, which builds the CLI binaries, publishes `ghcr.io/binarybourbon/fountain:v0.16.0`, boots it through the documented quick start and creates the GitHub Release.

"Compose boots the pinned image" skips on this PR because the pinned image does not exist until the release runs; the same check runs on the tag instead.
