### PR TITLE
docs(swift): install from v0.16.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,13 +96,12 @@ pip install fountain-agent-sdk
 # or add {:fountain_sdk, "~> 0.1.0"} to mix.exs
 ```
 
-Until the next Fountain release contains the root `Package.swift`, use the
-repository's `main` branch with Swift Package Manager:
+Add Fountain with Swift Package Manager:
 
 ```swift
 .package(
     url: "https://github.com/BinaryBourbon/fountain.git",
-    branch: "main"
+    from: "0.16.0"
 )
 ```
 

--- a/docs/swift-sdk.md
+++ b/docs/swift-sdk.md
@@ -23,14 +23,13 @@ enter the prompt or the event feed that the SDK reads.
 
 ## Install
 
-Until the next Fountain release contains the root `Package.swift`, use the
-repository's `main` branch:
+Add Fountain as a package dependency:
 
 ```swift
 dependencies: [
     .package(
         url: "https://github.com/BinaryBourbon/fountain.git",
-        branch: "main"
+        from: "0.16.0"
     ),
 ]
 ```

--- a/sdk/swift/README.md
+++ b/sdk/swift/README.md
@@ -26,17 +26,16 @@ print(try await next.value().text)
 
 ## Install
 
-The remotely consumable `Package.swift` is at the repository root. Until a
-new Fountain release tag containing that manifest exists, depend on `main`:
+The remotely consumable `Package.swift` is at the repository root. Depend on
+Fountain 0.16.0 or newer:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/BinaryBourbon/fountain.git", branch: "main")
+    .package(url: "https://github.com/BinaryBourbon/fountain.git", from: "0.16.0")
 ]
 ```
 
 Then add `.product(name: "Fountain", package: "fountain")` to your target.
-After the next Fountain `vX.Y.Z` tag, pin that version instead of a branch.
 
 Swift 6.1 or newer is required. The SDK supports macOS 12, iOS/tvOS 15,
 watchOS 8, and Linux FoundationNetworking, with no third-party dependencies.


### PR DESCRIPTION
## Summary

- replace the temporary main-branch dependency with the released semantic version
- document 0.16.0 as the minimum remotely consumable Swift package release

## Validation

- v0.16.0 release workflow remote-consumer job resolves, builds, imports Fountain, and verifies the SDK version
- git diff --check