### PR TITLE
docs(adr-0038): record the production walk, verification to reply in 35s

### DIFF
--- a/decisions/0038-onboarding-first-reply.md
+++ b/decisions/0038-onboarding-first-reply.md
@@ -23,6 +23,24 @@ that builds one updates this block.
 **Built:** every decision. 2 (#1392), 3 (#1388), 4 (#1389), 5 (#1426),
 6 (#1443) and 7 (#1393).
 
+**Walked on production, 2026-09-03**, by the first account ever to run on a
+platform key. Verified at 04:35:03Z, request sent at 04:35:19Z, the turn
+started at 04:35:33Z once the sandbox was up, and the reply was on screen at
+04:35:38Z: **verification to first reply, 35 seconds** — 14 of them the
+sandbox, 5 the model, and 16 a human copying the request. The account held no
+credential of its own, so decision 3's selection rule served it from
+`PLATFORM_ANTHROPIC_API_KEY`, and the `Workers.CreditPricer` tick at 04:40:00Z
+posted a 3-cent `burn_inference` debit against the $5 opening grant. That is
+the metering half of decision 3 exercised outside a test for the first time.
+Sandbox time added no `burn_turn` row, because five seconds at
+`CREDIT_TURN_HOUR_CENTS` rounds to nothing, which is what the pricer says it
+does.
+
+Setting a platform key is a deployment step and not a code one, so a
+deployment that has never set `PLATFORM_ANTHROPIC_API_KEY` still puts every
+new account in front of the wall this ADR removes. Production itself ran that
+way from #1388 merging until the walk above.
+
 Decision 2: `Fountain.Activation` holds the definition, `Fountain.Funnel`
 counts it and measures verification to first reply, and
 `activation.first_reply` reaches PostHog from the turn-ending write.


### PR DESCRIPTION
ADR 0038 has read "built" since 2026-09-02 with nobody having watched the path run, because dev has neither `SPRITES_TOKEN` nor a platform key. It ran on production tonight.

## The walk

| moment | time (UTC) |
|---|---|
| verified | 04:35:03 |
| request sent | 04:35:19 |
| turn started (sandbox up) | 04:35:33 |
| reply on screen | 04:35:38 |

**Verification to first reply: 35 seconds** — 14 the sandbox, 5 the model, and 16 a human copying the request out of the landing page. The account (`starter` agent, no credential of its own) was served from `PLATFORM_ANTHROPIC_API_KEY` by decision 3's selection rule, and the `Workers.CreditPricer` tick at 04:40:00Z posted a 3-cent `burn_inference` debit against the $5 opening grant, leaving 497. That is the metering half of decision 3 running outside a test for the first time. No `burn_turn` row: five seconds at `CREDIT_TURN_HOUR_CENTS` rounds to nothing, as the pricer documents.

Every number above is read from the production database, not from a stopwatch — the same `email_verified_at` and first-reply-turn columns `Funnel.time_to_first_reply` reports, so the acceptance number and the dashboard number are the same number by construction.

## What the walk turned up

Production had **no `PLATFORM_ANTHROPIC_API_KEY` set** until this walk — the code shipped with #1388 on 2026-09-02, the key is a deployment step, and nobody had taken it. So every account verified between then and now still hit the wall this ADR exists to remove. The ADR now says that a platform key is a deployment step rather than a code one, since a self-hoster reading "built" would otherwise conclude the path works out of the box.

`okf validate decisions` passes (0 errors; the 3 warnings are pre-existing on 0006, 0030 and 0033). The index is unchanged — no frontmatter changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BXYa9CQNG8oFNq5YhAxva
