### PR TITLE
refactor(conversations): the connection and output persistence out, and what the process keeps

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -92,6 +92,10 @@
                # the reclaim actions (#1376): the sandbox and rows of the
                # conversation whose server called them, ownership as above
                "lib/fountain/conversations/lifecycle.ex",
+               # the connection and the transcript (#1377): the same, reading
+               # and writing the conversation the server holds open
+               "lib/fountain/conversations/connection.ex",
+               "lib/fountain/conversations/output.ex",
                # system-level sweeps, run with no user in scope
                "lib/fountain/conversations/rehydrator.ex",
                "lib/fountain/workers/",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,21 @@ upgrade, is in
   registration. Its CI compiles all three with warnings as errors and runs
   the Fake sandbox turn.
 
+### Changed
+
+- **The connection and the transcript have left `ConversationServer`, and the
+  server is what is left** (#1377, tracker #1369, last). The ACP connection
+  that outlives the turn (#817) is `Fountain.Conversations.Connection`: the
+  peer, its monitor, the command underneath it and the quiet timer that closes
+  a background cycle (#1301), with the functions that reuse the connection,
+  close it, lose it and open an autonomous turn. What the sandbox says on its
+  way to the transcript is `Fountain.Conversations.Output`: the durable log
+  budget (#331), the truncation marker, the reattach replay skip and the stage
+  events. The server keeps the process — `init/1`, the provisioning watchdog,
+  the reattach orchestration, the callbacks, and the terminal paths that end a
+  turn. No stage, log line, telemetry event, timer or audit event changed. The
+  pin drops from 3,048 to 2,835, and the tracker closes.
+
 ### Fixed
 
 - **Platform inference on the gemini runtime was unbilled** (#1459). gemini

--- a/apps/fountain/lib/fountain/conversations/connection.ex
+++ b/apps/fountain/lib/fountain/conversations/connection.ex
@@ -1,0 +1,292 @@
+defmodule Fountain.Conversations.Connection do
+  @moduledoc """
+  The ACP connection, which outlives the turn (#817).
+
+  A value — the peer, its monitor, the sandbox command underneath it, and the
+  quiet timer that closes a background cycle — and the functions that reuse
+  it, close it, lose it, and open the autonomous turn an out-of-turn protocol
+  line starts.
+
+  The distinction the module exists for: a turn ends when the agent answers,
+  the connection ends when the sandbox stops being this server's. Between the
+  two, an idle adapter sits on the machine and the next prompt rides it — no
+  spawn, no handshake, no `session/resume`, no model pin — so a background
+  task it left running keeps running and the runtime's per-session grants
+  survive. `Fountain.Conversations.TurnMachine` owns the turn itself and
+  answers `autonomous_turn?/1`; what a turn ends with is the server's, because
+  ending one resolves what is pending and stamps the row.
+
+  `from_state/1` reads the five server fields into a `%Connection{}` and
+  `into_state/2` writes them back; the server's state does not change shape.
+  Timers are armed in the calling process, which is the server.
+  """
+
+  require Logger
+  require OpenTelemetry.Tracer
+
+  alias Fountain.Conversations
+  alias Fountain.Conversations.{Output, TurnMachine}
+
+  @type t :: %__MODULE__{
+          peer: pid() | nil,
+          peer_mon: reference() | nil,
+          command: term() | nil,
+          command_ref: term() | nil,
+          quiet_timer: reference() | nil
+        }
+
+  defstruct peer: nil, peer_mon: nil, command: nil, command_ref: nil, quiet_timer: nil
+
+  # An autonomous turn with no `cycle_end` closes after this long a silence.
+  @autonomous_quiet_ms :timer.minutes(10)
+
+  # ── the server boundary ───────────────────────────────────────────────────
+
+  @doc "What the server holds, as one value."
+  @spec from_state(map()) :: t()
+  def from_state(state) do
+    %__MODULE__{
+      peer: state.acp_peer,
+      peer_mon: state.acp_peer_mon,
+      command: state.current_command,
+      command_ref: state.current_command_ref,
+      quiet_timer: state.autonomous_quiet
+    }
+  end
+
+  @doc "The value written back into the server's fields."
+  @spec into_state(map(), t()) :: map()
+  def into_state(state, %__MODULE__{} = conn) do
+    %{
+      state
+      | acp_peer: conn.peer,
+        acp_peer_mon: conn.peer_mon,
+        current_command: conn.command,
+        current_command_ref: conn.command_ref,
+        autonomous_quiet: conn.quiet_timer
+    }
+  end
+
+  # ── what is open, and what is busy ────────────────────────────────────────
+
+  @doc "Whether an idle peer from an earlier turn is still driving this machine."
+  @spec alive?(t()) :: boolean()
+  def alive?(%__MODULE__{peer: peer}) when is_pid(peer), do: Process.alive?(peer)
+  def alive?(%__MODULE__{}), do: false
+
+  @doc """
+  Busy means a turn, not a connection (#817).
+
+  An autonomous turn does not make the conversation busy: a human prompt
+  supersedes the background cycle rather than queueing behind it.
+  """
+  @spec user_turn_running?(map() | nil) :: boolean()
+  def user_turn_running?(%{origin: "autonomous"}), do: false
+  def user_turn_running?(turn), do: not is_nil(turn)
+
+  # ── riding the open connection ────────────────────────────────────────────
+
+  @doc """
+  This turn rides the open connection: no spawn, no handshake.
+
+  `Peer.prompt/3` reuses the session already open, so a background task keeps
+  running and the runtime's per-session grants survive (#817). Returns the
+  turn span, the tracer over it and the monotonic stamp the turn's metrics
+  start from; `{:error, reason}` when the idle peer would not take the prompt
+  (it died between the check and the call, or is wedged), with the span
+  already closed — the caller drops the connection and spawns fresh.
+  """
+  @spec resume(
+          t(),
+          String.t(),
+          String.t(),
+          Conversations.Conversation.t(),
+          map(),
+          String.t(),
+          list()
+        ) ::
+          {:ok, term(), term(), integer()} | {:error, term()}
+  def resume(%__MODULE__{} = conn, conversation_id, user_id, conv, turn, prompt, images) do
+    turn_span = TurnMachine.open_span(user_id, conv, turn, :continue, TurnMachine.agent_for(conv))
+
+    previous_span = OpenTelemetry.Tracer.set_current_span(turn_span)
+
+    Output.publish_stage(conversation_id, "turn", "started", %{
+      turn_id: turn.id,
+      turn_number: turn.turn_number,
+      mode: "continue",
+      connection: "reused"
+    })
+
+    started_mono = System.monotonic_time(:millisecond)
+
+    case Managoat.ACP.Peer.prompt(conn.peer, prompt, images) do
+      :ok ->
+        OpenTelemetry.Tracer.set_current_span(previous_span)
+        {:ok, turn_span, Managoat.ACP.Tracer.new(turn_span, prefix: "fountain"), started_mono}
+
+      {:error, reason} ->
+        Logger.warning(
+          "conv #{conversation_id}: idle peer refused prompt (#{inspect(reason)}); respawning"
+        )
+
+        OpenTelemetry.Tracer.set_current_span(previous_span)
+        TurnMachine.end_span(turn_span, :error, %{"error" => "peer_refused_reuse"})
+        {:error, reason}
+    end
+  end
+
+  # ── letting it go ─────────────────────────────────────────────────────────
+
+  @doc """
+  Close the ACP connection.
+
+  EOF the adapter so it exits — a detachable session outlives its client, so
+  closing the socket alone leaves it and any background task running —
+  consolidate gemini's store before the next `session/load` can collide with
+  it, stop the peer, and clear the connection fields. Safe on a value with no
+  peer and no command; an autonomous turn still open is the caller's to
+  finish first, because ending a turn is the server's.
+  """
+  @spec close(t(), String.t(), term()) :: t()
+  def close(%__MODULE__{} = conn, conversation_id, handle) do
+    conn = cancel_quiet(conn)
+    if conn.command, do: Managoat.Sandbox.close_stdin(conn.command)
+    consolidate_gemini_session(handle, conversation_id)
+    stop_peer(conn)
+    if conn.command, do: Managoat.Sandbox.stop_command(conn.command)
+
+    cleared(conn)
+  end
+
+  @doc """
+  The adapter went away between turns with no turn to fail (#817). Record it
+  on the transcript and clear the connection; the next prompt spawns fresh.
+  """
+  @spec lost(t(), String.t(), term(), String.t(), map()) :: t()
+  def lost(%__MODULE__{} = conn, conversation_id, handle, reason, meta) do
+    Output.publish_stage(
+      conversation_id,
+      "sandbox",
+      "done",
+      Map.merge(%{event: "connection_lost", reason: reason}, meta)
+    )
+
+    conn = cancel_quiet(conn)
+    consolidate_gemini_session(handle, conversation_id)
+
+    cleared(conn)
+  end
+
+  @doc """
+  Stop the peer, if there is one.
+
+  Demonitor before stopping so the peer's own exit does not arrive as a
+  `:DOWN` that fails the turn we just finished.
+  """
+  @spec stop_peer(t()) :: :ok
+  def stop_peer(%__MODULE__{peer: nil}), do: :ok
+
+  def stop_peer(%__MODULE__{peer: peer, peer_mon: mon}) do
+    if mon, do: Process.demonitor(mon, [:flush])
+    if Process.alive?(peer), do: GenServer.stop(peer, :normal, 1_000)
+    :ok
+  catch
+    :exit, _ -> :ok
+  end
+
+  defp cleared(%__MODULE__{} = conn),
+    do: %{conn | peer: nil, peer_mon: nil, command: nil, command_ref: nil}
+
+  # gemini erases a session in the act of loading it (#659), so its store is
+  # consolidated at the end of every turn — before the next turn's
+  # `session/load` can collide with it. Best-effort and gemini-only; delete
+  # with the workaround when gemini-cli#28775 lands.
+  defp consolidate_gemini_session(handle, conversation_id) when not is_nil(handle) do
+    # ownership: a server's own conversation, established at init.
+    conv = Conversations._unsafe_get_conversation!(conversation_id)
+
+    if conv.runtime == "gemini" do
+      Managoat.Runtimes.Gemini.SessionStore.consolidate(handle, conv.runtime_session_id)
+    end
+
+    :ok
+  end
+
+  defp consolidate_gemini_session(_handle, _conversation_id), do: :ok
+
+  # ── the autonomous turn (#817, #1301) ─────────────────────────────────────
+
+  @doc """
+  An out-of-turn protocol line opened a background cycle (#817).
+
+  A real turn row, so the log budget, redaction and stage events all apply;
+  `origin: "autonomous"` and a marker prompt tell it from a user turn.
+  Returns the row, the span opened over it and the tracer reading it; the
+  caller holds them and arms the quiet timer.
+  """
+  @spec open_autonomous_turn(String.t(), String.t()) :: {map(), term(), term()}
+  def open_autonomous_turn(conversation_id, user_id) do
+    # ownership: a server's own conversation, established at init.
+    conv = Conversations._unsafe_get_conversation!(conversation_id)
+    turn_number = Conversations._unsafe_next_turn_number(conversation_id)
+
+    {:ok, turn} =
+      Conversations._unsafe_create_turn(%{
+        conversation_id: conv.id,
+        turn_number: turn_number,
+        prompt: "(background task follow-up)",
+        origin: "autonomous",
+        status: "running",
+        started_at: now()
+      })
+
+    turn_span =
+      TurnMachine.open_span(user_id, conv, turn, :autonomous, TurnMachine.agent_for(conv))
+
+    Output.publish_stage(conversation_id, "turn", "started", %{
+      turn_id: turn.id,
+      turn_number: turn_number,
+      origin: "autonomous"
+    })
+
+    {:ok, _} = Conversations.update_conversation(conv, %{status: "running"})
+
+    {turn, turn_span, Managoat.ACP.Tracer.new(turn_span, prefix: "fountain")}
+  end
+
+  @doc """
+  Arm the timer that closes an autonomous turn gone quiet without a
+  `cycle_end` (#1301): an adapter too old to mark its origin must not hold a
+  turn open forever. No turn, no timer.
+  """
+  @spec arm_quiet(t(), map() | nil) :: t()
+  def arm_quiet(%__MODULE__{} = conn, turn) do
+    conn = cancel_quiet(conn)
+    turn_id = turn && turn.id
+
+    timer =
+      if turn_id do
+        Process.send_after(self(), {:autonomous_quiet, turn_id}, quiet_ms())
+      end
+
+    %{conn | quiet_timer: timer}
+  end
+
+  @doc "Disarm the quiet timer."
+  @spec cancel_quiet(t()) :: t()
+  def cancel_quiet(%__MODULE__{quiet_timer: nil} = conn), do: conn
+
+  def cancel_quiet(%__MODULE__{quiet_timer: timer} = conn) do
+    Process.cancel_timer(timer)
+    %{conn | quiet_timer: nil}
+  end
+
+  @doc "How long a silence closes an autonomous turn."
+  @spec quiet_ms() :: non_neg_integer()
+  def quiet_ms do
+    Application.get_env(:fountain, :autonomous_turn_quiet_ms, @autonomous_quiet_ms)
+  end
+
+  defp now, do: DateTime.utc_now() |> DateTime.truncate(:second)
+end

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -23,10 +23,12 @@ defmodule Fountain.Conversations.ConversationServer do
 
   alias Fountain.Conversations.{
     CallbackKey,
+    Connection,
     Conversation,
     Egress,
     Lifecycle,
     McpServers,
+    Output,
     Pending,
     Provisioning,
     SpriteEnv,
@@ -604,7 +606,9 @@ defmodule Fountain.Conversations.ConversationServer do
                 :ok
             end
 
-            publish_stage(conv_id, "provision", "failed", %{reason: "provision deadline exceeded"})
+            Output.publish_stage(conv_id, "provision", "failed", %{
+              reason: "provision deadline exceeded"
+            })
 
             # Prefer supervisor termination over Process.exit: it removes the
             # child, so no restart happens at all, and it bounds the wait —
@@ -729,7 +733,7 @@ defmodule Fountain.Conversations.ConversationServer do
           "ConversationServer could not load tenant credentials for conv #{conv.id} (user #{conv.user_id}): #{inspect(reason)}"
         )
 
-        publish_stage(state.conversation_id, "provision", "failed", %{
+        Output.publish_stage(state.conversation_id, "provision", "failed", %{
           reason: "tenant_credential_load_failed: #{inspect(reason)}"
         })
 
@@ -770,7 +774,7 @@ defmodule Fountain.Conversations.ConversationServer do
       {:error, {:missing_vars, names}} ->
         reason = "missing env/vault keys referenced in mcp_servers: #{Enum.join(names, ", ")}"
         Logger.error("provision failed for conv #{conv.id}: #{reason}")
-        publish_stage(state.conversation_id, "provision", "failed", %{reason: reason})
+        Output.publish_stage(state.conversation_id, "provision", "failed", %{reason: reason})
         {:ok, _} = Conversations.update_sandbox(sandbox, %{status: "failed"})
         Conversations.update_conversation(conv, %{status: "failed"})
         {:stop, :normal, state}
@@ -794,7 +798,7 @@ defmodule Fountain.Conversations.ConversationServer do
         msg = Exception.format(:error, exception, stack)
         Logger.error("provision raised an unhandled exception:\n#{msg}")
 
-        publish_stage(state.conversation_id, "provision", "failed", %{
+        Output.publish_stage(state.conversation_id, "provision", "failed", %{
           reason: Exception.message(exception),
           stack: Exception.format_stacktrace(stack) |> String.slice(0, 2000)
         })
@@ -814,7 +818,7 @@ defmodule Fountain.Conversations.ConversationServer do
 
     {:ok, _} = Conversations.update_sandbox(sandbox, %{status: "starting"})
 
-    publish_stage(
+    Output.publish_stage(
       state.conversation_id,
       "provision",
       "started",
@@ -909,7 +913,7 @@ defmodule Fountain.Conversations.ConversationServer do
                  sprite_env
                ) do
           {:ok, _} = Conversations.update_sandbox(sandbox, %{status: "ready"})
-          publish_stage(state.conversation_id, "provision", "done")
+          Output.publish_stage(state.conversation_id, "provision", "done")
 
           # Best-effort: snapshot the fully-provisioned state so subsequent
           # conversations on this env can warm-start from it. Async so it
@@ -938,7 +942,7 @@ defmodule Fountain.Conversations.ConversationServer do
             Egress.release(state.user_id, state.conversation_id)
             {:ok, _} = Conversations.update_sandbox(sandbox, %{status: "failed"})
 
-            publish_stage(state.conversation_id, "provision", "failed", %{
+            Output.publish_stage(state.conversation_id, "provision", "failed", %{
               reason: inspect(reason)
             })
 
@@ -949,7 +953,11 @@ defmodule Fountain.Conversations.ConversationServer do
       {:error, reason} ->
         Logger.error("provision could not start: #{inspect(reason)}")
         {:ok, _} = Conversations.update_sandbox(sandbox, %{status: "failed"})
-        publish_stage(state.conversation_id, "provision", "failed", %{reason: inspect(reason)})
+
+        Output.publish_stage(state.conversation_id, "provision", "failed", %{
+          reason: inspect(reason)
+        })
+
         Conversations.update_conversation(conv, %{status: "failed"})
         {:stop, :normal, state}
     end
@@ -999,7 +1007,7 @@ defmodule Fountain.Conversations.ConversationServer do
   defp attempt_warm_start(_handle, %{checkpoint_id: ""}, _conv_id), do: :cold
 
   defp attempt_warm_start(handle, %{checkpoint_id: id} = env, conv_id) do
-    publish_stage(conv_id, "checkpoint_restore", "started", %{checkpoint_id: id})
+    Output.publish_stage(conv_id, "checkpoint_restore", "started", %{checkpoint_id: id})
 
     # `restore_checkpoint/2` returns a bare `:ok` — `Fountain.Telemetry.span/3`
     # unwraps the `{result, metadata}` pair it is given, so the `{:ok, _}` this
@@ -1008,7 +1016,7 @@ defmodule Fountain.Conversations.ConversationServer do
     # this branch was unreachable.
     case Fountain.Conversations.Provisioning.restore_checkpoint(handle, id) do
       ok when ok == :ok or (is_tuple(ok) and elem(ok, 0) == :ok) ->
-        publish_stage(conv_id, "checkpoint_restore", "done", %{checkpoint_id: id})
+        Output.publish_stage(conv_id, "checkpoint_restore", "done", %{checkpoint_id: id})
         :warm_started
 
       {:error, reason} ->
@@ -1016,7 +1024,7 @@ defmodule Fountain.Conversations.ConversationServer do
           "checkpoint #{id} on env #{env.name} restore failed (#{inspect(reason)}); clearing + cold provisioning"
         )
 
-        publish_stage(conv_id, "checkpoint_restore", "failed", %{
+        Output.publish_stage(conv_id, "checkpoint_restore", "failed", %{
           checkpoint_id: id,
           reason: inspect(reason)
         })
@@ -1114,7 +1122,7 @@ defmodule Fountain.Conversations.ConversationServer do
              label: "sprite lookup on wake"
            ),
          {:ok, state} <- broker_prepare(state) do
-      publish_stage(state.conversation_id, "reattach", "started", %{
+      Output.publish_stage(state.conversation_id, "reattach", "started", %{
         sprite_name: sandbox.sprite_name,
         node: to_string(node())
       })
@@ -1202,7 +1210,7 @@ defmodule Fountain.Conversations.ConversationServer do
           "reattach failed for sprite #{sandbox.sprite_name}: not found — marking sandbox failed"
         )
 
-        publish_stage(state.conversation_id, "reattach", "failed", %{
+        Output.publish_stage(state.conversation_id, "reattach", "failed", %{
           reason: "not_found",
           retryable: false,
           node: to_string(node())
@@ -1237,7 +1245,7 @@ defmodule Fountain.Conversations.ConversationServer do
             "transient; sandbox row left untouched"
         )
 
-        publish_stage(state.conversation_id, "reattach", "failed", %{
+        Output.publish_stage(state.conversation_id, "reattach", "failed", %{
           reason: inspect(reason),
           retryable: true,
           node: to_string(node())
@@ -1318,7 +1326,7 @@ defmodule Fountain.Conversations.ConversationServer do
 
         outcome = if mine == [], do: "no_running_turn", else: "orphan_session_reaped"
 
-        publish_stage(state.conversation_id, "reattach", "done", %{
+        Output.publish_stage(state.conversation_id, "reattach", "done", %{
           outcome: outcome,
           reaped: length(mine)
         })
@@ -1326,7 +1334,10 @@ defmodule Fountain.Conversations.ConversationServer do
         state
 
       {:error, _reason} ->
-        publish_stage(state.conversation_id, "reattach", "done", %{outcome: "no_running_turn"})
+        Output.publish_stage(state.conversation_id, "reattach", "done", %{
+          outcome: "no_running_turn"
+        })
+
         state
     end
   end
@@ -1362,7 +1373,7 @@ defmodule Fountain.Conversations.ConversationServer do
                 running_turn.id
               )
 
-        publish_stage(state.conversation_id, "reattach", "done", %{
+        Output.publish_stage(state.conversation_id, "reattach", "done", %{
           outcome: "session_attached",
           matched_by: matched_by,
           session_id: session.id,
@@ -1397,9 +1408,6 @@ defmodule Fountain.Conversations.ConversationServer do
   end
 
   @replay_dedup_ttl_ms 10_000
-
-  # An autonomous turn with no `cycle_end` closes after this long a silence.
-  @autonomous_quiet_ms :timer.minutes(10)
 
   # An ACP turn is only alive while something answers the agent: a
   # `session/request_permission` left unanswered blocks it forever, and the
@@ -1466,7 +1474,7 @@ defmodule Fountain.Conversations.ConversationServer do
     conv = Conversations._unsafe_get_conversation!(state.conversation_id)
     {:ok, _} = Conversations.update_conversation(conv, %{status: "idle"})
 
-    publish_stage(state.conversation_id, "reattach", "interrupted", %{
+    Output.publish_stage(state.conversation_id, "reattach", "interrupted", %{
       outcome: "turn_orphaned",
       turn_id: running_turn.id,
       turn_number: running_turn.turn_number,
@@ -1585,7 +1593,7 @@ defmodule Fountain.Conversations.ConversationServer do
 
   @impl true
   def handle_call({:send_prompt, prompt, images}, _from, state) do
-    if user_turn_running?(state) do
+    if Connection.user_turn_running?(state.current_turn) do
       {:reply, {:error, :busy}, state}
     else
       # A background cycle the agent was still narrating is closed by the
@@ -1687,7 +1695,7 @@ defmodule Fountain.Conversations.ConversationServer do
       conv = Conversations._unsafe_get_conversation!(state.conversation_id)
       {:ok, _} = Conversations.update_conversation(conv, %{status: "terminated"})
 
-      publish_stage(state.conversation_id, "terminate", "done", %{
+      Output.publish_stage(state.conversation_id, "terminate", "done", %{
         sandbox: "kept",
         reason:
           if(Lifecycle.home?(state.sandbox_id),
@@ -1708,7 +1716,7 @@ defmodule Fountain.Conversations.ConversationServer do
 
       conv = Conversations._unsafe_get_conversation!(state.conversation_id)
       {:ok, _} = Conversations.update_conversation(conv, %{status: "terminated"})
-      publish_stage(state.conversation_id, "terminate", "done")
+      Output.publish_stage(state.conversation_id, "terminate", "done")
       {:stop, :normal, :ok, state}
     end
   end
@@ -1727,7 +1735,7 @@ defmodule Fountain.Conversations.ConversationServer do
     state = drop_connection(state, "released")
     conv = Conversations._unsafe_get_conversation!(state.conversation_id)
     {:ok, _} = Conversations.update_conversation(conv, %{status: "terminated"})
-    publish_stage(state.conversation_id, "terminate", "done", %{event: "released"})
+    Output.publish_stage(state.conversation_id, "terminate", "done", %{event: "released"})
     {:stop, :normal, :ok, %{state | handle: nil}}
   end
 
@@ -1745,7 +1753,7 @@ defmodule Fountain.Conversations.ConversationServer do
   # happen, and re-running is the failure this whole mechanism exists to avoid.
   @impl true
   def handle_cast({:initial_prompt, prompt, images}, state) do
-    if user_turn_running?(state) do
+    if Connection.user_turn_running?(state.current_turn) do
       Logger.warning(
         "conv #{state.conversation_id}: initial prompt arrived while a turn was running; dropping it"
       )
@@ -1783,7 +1791,7 @@ defmodule Fountain.Conversations.ConversationServer do
     conv = Conversations._unsafe_get_conversation!(state.conversation_id)
     if conv.status == "running", do: Conversations.update_conversation(conv, %{status: "idle"})
 
-    publish_stage(state.conversation_id, "sandbox", "done", %{
+    Output.publish_stage(state.conversation_id, "sandbox", "done", %{
       event: event,
       reason: reason,
       by: "another_conversation",
@@ -1963,7 +1971,7 @@ defmodule Fountain.Conversations.ConversationServer do
         ended_at: now()
       })
 
-    publish_stage(state.conversation_id, "turn", "done", %{
+    Output.publish_stage(state.conversation_id, "turn", "done", %{
       turn_id: turn.id,
       turn_number: turn.turn_number,
       exit_code: code
@@ -2030,7 +2038,7 @@ defmodule Fountain.Conversations.ConversationServer do
         ended_at: now()
       })
 
-    publish_stage(state.conversation_id, "turn", "failed", %{
+    Output.publish_stage(state.conversation_id, "turn", "failed", %{
       turn_id: turn.id,
       turn_number: turn.turn_number,
       reason: "sprite connection lost: #{inspect(reason)}"
@@ -2374,7 +2382,7 @@ defmodule Fountain.Conversations.ConversationServer do
     # is still idle on this machine, this turn rides it — no spawn, no
     # handshake, no `session/resume`, no model pin — so a background task it
     # left running keeps running and codex's session grant survives.
-    if acp? and connection_alive?(state) do
+    if acp? and Connection.alive?(Connection.from_state(state)) do
       resume_acp_connection(state, conv, turn, prompt, images)
     else
       run_fresh_turn(state, conv, turn, prompt, agent, images, acp?)
@@ -2394,7 +2402,8 @@ defmodule Fountain.Conversations.ConversationServer do
     # Write image temp files to sprite. Only on the legacy path: ACP carries
     # images as content blocks inside `session/prompt`, so writing them into
     # the sandbox first would be a round trip whose product nothing reads.
-    image_paths = if acp?, do: [], else: write_image_temp_files(state.handle, turn.id, images)
+    image_paths =
+      if acp?, do: [], else: Output.write_image_temp_files(state.handle, turn.id, images)
 
     {:ok, _} = Conversations.update_conversation(conv, %{status: "running"})
 
@@ -2425,7 +2434,7 @@ defmodule Fountain.Conversations.ConversationServer do
     # return a prompt_suffix with image references to append to stdin.
     prompt_suffix = Keyword.get(build_opts, :prompt_suffix, "")
 
-    publish_stage(state.conversation_id, "turn", "started", %{
+    Output.publish_stage(state.conversation_id, "turn", "started", %{
       turn_id: turn.id,
       turn_number: turn_number,
       mode: Atom.to_string(mode)
@@ -2607,16 +2616,6 @@ defmodule Fountain.Conversations.ConversationServer do
   defp emit_turn_completed(state, status),
     do: TurnMachine.emit_completed(TurnMachine.from_state(state), status)
 
-  # Persist + broadcast one chunk of sandbox output, subject to the
-  # per-conversation byte budget (#331). log_events is unbounded per row
-  # count and lives on the same Postgres volume the app depends on, so a
-  # `while true; do base64 /dev/urandom; done` sandbox was an availability
-  # risk, not just a storage bill — retention (#217) bounds age, not rate.
-  # Once the budget is exceeded, one truncation marker is persisted and
-  # every later chunk is dropped. Dropped rather than broadcast-only:
-  # consumers key ordering off the DB-assigned event id, and an unbounded
-  # broadcast stream would still let a hostile sandbox saturate PubSub.
-
   # Persistence for peer-relayed lines: the log budget, redaction and the
   # legacy replay skip all live on this path; the tracer reads protocol lines
   # from the peer's reports, never raw chunks.
@@ -2636,22 +2635,6 @@ defmodule Fountain.Conversations.ConversationServer do
 
     %{new_state | stream_tracer: tracer}
   end
-
-  # gemini erases a session in the act of loading it (#659), so its store is
-  # consolidated at the end of every turn — before the next turn's
-  # `session/load` can collide with it. Best-effort and gemini-only; delete
-  # with the workaround when gemini-cli#28775 lands.
-  defp consolidate_gemini_session(%{handle: handle} = state) when not is_nil(handle) do
-    conv = Conversations._unsafe_get_conversation!(state.conversation_id)
-
-    if conv.runtime == "gemini" do
-      Managoat.Runtimes.Gemini.SessionStore.consolidate(handle, conv.runtime_session_id)
-    end
-
-    :ok
-  end
-
-  defp consolidate_gemini_session(_state), do: :ok
 
   # Terminal path for an ACP turn. The order matters: stdin closes first so the
   # adapter starts exiting while we do the bookkeeping, and `current_command_ref`
@@ -2728,35 +2711,21 @@ defmodule Fountain.Conversations.ConversationServer do
 
   # ── the connection (#817) ─────────────────────────────────────────────────
 
-  # Whether an idle peer from an earlier turn is still driving this machine.
-  defp connection_alive?(%{acp_peer: peer}) when is_pid(peer), do: Process.alive?(peer)
-  defp connection_alive?(_state), do: false
-
-  defp user_turn_running?(%{current_turn: %{origin: "autonomous"}}), do: false
-  defp user_turn_running?(%{current_turn: turn}), do: not is_nil(turn)
-
-  # This turn rides the open connection: no spawn, no handshake. `Peer.prompt/3`
-  # reuses the session already open, so a background task keeps running and the
-  # runtime's per-session grants survive (#817).
+  # This turn rides the open connection (`Connection.resume/7`): the span, the
+  # stage event and the peer's answer are the connection's; the turn fields
+  # they land in are the server's. A peer that refuses the prompt is dropped
+  # and the turn runs on a fresh spawn against the row that already exists.
   defp resume_acp_connection(state, conv, turn, prompt, images) do
-    turn_span =
-      TurnMachine.open_span(state.user_id, conv, turn, :continue, TurnMachine.agent_for(conv))
-
-    previous_span = OpenTelemetry.Tracer.set_current_span(turn_span)
-
-    publish_stage(state.conversation_id, "turn", "started", %{
-      turn_id: turn.id,
-      turn_number: turn.turn_number,
-      mode: "continue",
-      connection: "reused"
-    })
-
-    started_mono = System.monotonic_time(:millisecond)
-
-    case Managoat.ACP.Peer.prompt(state.acp_peer, prompt, images) do
-      :ok ->
-        OpenTelemetry.Tracer.set_current_span(previous_span)
-
+    case Connection.resume(
+           Connection.from_state(state),
+           state.conversation_id,
+           state.user_id,
+           conv,
+           turn,
+           prompt,
+           images
+         ) do
+      {:ok, turn_span, tracer, started_mono} ->
         %{
           touch_activity(state)
           | current_turn: turn,
@@ -2766,116 +2735,60 @@ defmodule Fountain.Conversations.ConversationServer do
               runtime: conv.runtime,
               first_output?: false
             },
-            stream_tracer: Managoat.ACP.Tracer.new(turn_span, prefix: "fountain")
+            stream_tracer: tracer
         }
 
-      {:error, reason} ->
-        # The idle peer would not take the prompt (it died between the check
-        # and the call, or is wedged). Drop it and spawn fresh — the turn row
-        # already exists, so run the fresh path against it.
-        Logger.warning(
-          "conv #{state.conversation_id}: idle peer refused prompt (#{inspect(reason)}); respawning"
-        )
-
-        OpenTelemetry.Tracer.set_current_span(previous_span)
-        TurnMachine.end_span(turn_span, :error, %{"error" => "peer_refused_reuse"})
+      {:error, _reason} ->
         state = drop_connection(state, "peer_refused_reuse")
         run_fresh_turn(state, conv, turn, prompt, TurnMachine.agent_for(conv), images, true)
     end
   end
 
-  # Close the ACP connection: EOF the adapter so it exits (a detachable
-  # session outlives its client, so closing the socket alone leaves it and any
-  # background task running), consolidate gemini's store before the next
-  # `session/load` can collide, stop the peer, and clear the connection
-  # fields. An autonomous turn still open is completed first — its updates are
-  # real. Safe on a server with no connection.
+  # Close the connection (`Connection.close/3`). An autonomous turn still open
+  # is completed first: its updates are real, and ending a turn resolves what
+  # the turn holds pending and stamps its row, which is the server's work. The
+  # first clause is why a server with no connection skips that finish too.
   defp drop_connection(%{acp_peer: nil, current_command: nil} = state, _why), do: state
 
   defp drop_connection(state, why) do
-    state =
-      if TurnMachine.autonomous_turn?(state) do
-        finish_acp_turn(state, "completed", %{"origin" => "connection_closed"}, %{
-          origin: "autonomous",
-          cycle: "connection_closed"
-        })
-      else
-        state
-      end
-
-    state = cancel_autonomous_quiet(state)
-    if state.current_command, do: Managoat.Sandbox.close_stdin(state.current_command)
-    consolidate_gemini_session(state)
-    stop_acp_peer(state)
-    if state.current_command, do: Managoat.Sandbox.stop_command(state.current_command)
+    state = close_autonomous_turn(state, "connection_closed")
 
     _ = why
 
-    %{
-      state
-      | current_command: nil,
-        current_command_ref: nil,
-        acp_peer: nil,
-        acp_peer_mon: nil
-    }
-  end
-
-  # The adapter went away between turns with no turn to fail (#817). Record it
-  # on the transcript and clear the connection; the next prompt spawns fresh.
-  defp connection_lost(state, reason, meta) do
-    publish_stage(
-      state.conversation_id,
-      "sandbox",
-      "done",
-      Map.merge(%{event: "connection_lost", reason: reason}, meta)
+    Connection.into_state(
+      state,
+      Connection.close(Connection.from_state(state), state.conversation_id, state.handle)
     )
-
-    state = cancel_autonomous_quiet(state)
-    consolidate_gemini_session(state)
-
-    %{
-      state
-      | current_command: nil,
-        current_command_ref: nil,
-        acp_peer: nil,
-        acp_peer_mon: nil
-    }
   end
 
-  # An out-of-turn protocol line opened a background cycle (#817). A real turn
-  # row so the log budget, redaction and stage events all apply; `origin:
-  # "autonomous"` and a marker prompt tell it from a user turn.
+  # The adapter went away between turns with no turn to fail
+  # (`Connection.lost/5`).
+  defp connection_lost(state, reason, meta) do
+    Connection.into_state(
+      state,
+      Connection.lost(
+        Connection.from_state(state),
+        state.conversation_id,
+        state.handle,
+        reason,
+        meta
+      )
+    )
+  end
+
+  # An out-of-turn protocol line opened a background cycle
+  # (`Connection.open_autonomous_turn/2`). The row, its span and its tracer are
+  # the server's to hold; the quiet timer is armed in this process.
   defp open_autonomous_turn(state) do
-    conv = Conversations._unsafe_get_conversation!(state.conversation_id)
-    turn_number = Conversations._unsafe_next_turn_number(state.conversation_id)
-
-    {:ok, turn} =
-      Conversations._unsafe_create_turn(%{
-        conversation_id: conv.id,
-        turn_number: turn_number,
-        prompt: "(background task follow-up)",
-        origin: "autonomous",
-        status: "running",
-        started_at: now()
-      })
-
-    turn_span =
-      TurnMachine.open_span(state.user_id, conv, turn, :autonomous, TurnMachine.agent_for(conv))
-
-    publish_stage(state.conversation_id, "turn", "started", %{
-      turn_id: turn.id,
-      turn_number: turn_number,
-      origin: "autonomous"
-    })
-
-    {:ok, _} = Conversations.update_conversation(conv, %{status: "running"})
+    {turn, turn_span, tracer} =
+      Connection.open_autonomous_turn(state.conversation_id, state.user_id)
 
     arm_autonomous_quiet(%{
       touch_activity(state)
       | current_turn: turn,
         current_turn_span: turn_span,
         turn_metrics: nil,
-        stream_tracer: Managoat.ACP.Tracer.new(turn_span, prefix: "fountain")
+        stream_tracer: tracer
     })
   end
 
@@ -2888,161 +2801,35 @@ defmodule Fountain.Conversations.ConversationServer do
   end
 
   defp arm_autonomous_quiet(state) do
-    state = cancel_autonomous_quiet(state)
-    turn_id = state.current_turn && state.current_turn.id
-
-    timer =
-      if turn_id do
-        Process.send_after(self(), {:autonomous_quiet, turn_id}, autonomous_quiet_ms())
-      end
-
-    %{state | autonomous_quiet: timer}
-  end
-
-  defp cancel_autonomous_quiet(%{autonomous_quiet: nil} = state), do: state
-
-  defp cancel_autonomous_quiet(%{autonomous_quiet: timer} = state) do
-    Process.cancel_timer(timer)
-    %{state | autonomous_quiet: nil}
-  end
-
-  defp autonomous_quiet_ms do
-    Application.get_env(:fountain, :autonomous_turn_quiet_ms, @autonomous_quiet_ms)
-  end
-
-  # Demonitor before stopping so the peer's own exit does not arrive as a
-  # `:DOWN` that fails the turn we just finished.
-  defp stop_acp_peer(%{acp_peer: nil}), do: :ok
-
-  defp stop_acp_peer(%{acp_peer: peer, acp_peer_mon: mon}) do
-    if mon, do: Process.demonitor(mon, [:flush])
-    if Process.alive?(peer), do: GenServer.stop(peer, :normal, 1_000)
-    :ok
-  catch
-    :exit, _ -> :ok
-  end
-
-  defp log_output(state, stream, data) do
-    state = ensure_output_bytes(state)
-    budget = output_byte_budget()
-
-    cond do
-      state.output_capped ->
-        state
-
-      budget > 0 and state.output_bytes + byte_size(data) > budget ->
-        Logger.warning(
-          "conv #{state.conversation_id}: durable output budget " <>
-            "(#{budget} bytes) reached; dropping further sandbox output"
-        )
-
-        :telemetry.execute([:fountain, :log_output, :capped], %{count: 1}, %{
-          conversation_id: state.conversation_id
-        })
-
-        persist_output(state, "stderr", cap_marker(budget))
-        %{state | output_capped: true}
-
-      true ->
-        persist_output(state, stream, data)
-        %{state | output_bytes: state.output_bytes + byte_size(data)}
-    end
-  end
-
-  defp cap_marker(budget) do
-    "\n[fountain] This conversation reached its durable log budget of " <>
-      "#{div(budget, 1_000_000)} MB. Further sandbox output is discarded — " <>
-      "the turn keeps running, and stage events still appear.\n"
-  end
-
-  defp ensure_output_bytes(%{output_bytes: nil} = state) do
-    %{state | output_bytes: Conversations._unsafe_output_byte_total(state.conversation_id)}
-  end
-
-  defp ensure_output_bytes(state), do: state
-
-  # 0 disables the cap.
-  defp output_byte_budget do
-    Application.get_env(:fountain, :log_output_byte_budget, 50_000_000)
-  end
-
-  defp persist_output(state, stream, data) do
-    # Tag this output with the stage that's active right now. The
-    # runtime CLI is always spawned inside a `turn` so all stdout /
-    # stderr from it gets `stage: "turn"`. Any operator on the
-    # presentation side (LiveView grouping, SSE consumers) can group
-    # output by stage without inferring it from event interleaving.
-    event =
-      Conversations.log!(%{
-        conversation_id: state.conversation_id,
-        turn_id: state.current_turn && state.current_turn.id,
-        kind: "output",
-        stream: stream,
-        stage: "turn",
-        data: data
-      })
-
-    Phoenix.PubSub.broadcast(
-      Fountain.PubSub,
-      "conv:#{state.conversation_id}",
-      {:log_event, event}
+    Connection.into_state(
+      state,
+      Connection.arm_quiet(Connection.from_state(state), state.current_turn)
     )
+  end
 
-    if state.user_id do
-      Phoenix.PubSub.broadcast(
-        Fountain.PubSub,
-        "sidebar:#{state.user_id}",
-        {:sidebar_update, state.user_id}
+  defp cancel_autonomous_quiet(state),
+    do: Connection.into_state(state, Connection.cancel_quiet(Connection.from_state(state)))
+
+  defp stop_acp_peer(state), do: Connection.stop_peer(Connection.from_state(state))
+
+  # ── output (#331) ─────────────────────────────────────────────────────────
+
+  # One chunk of sandbox output onto the transcript, against the durable
+  # budget: `Output.log/4`.
+  defp log_output(state, stream, data),
+    do:
+      Output.into_state(
+        state,
+        Output.log(Output.from_state(state), Output.ctx(state), stream, data)
       )
-    end
-  end
 
-  # Drop replayed bytes before persisting. After reattach, sprites replays
-  # the session's buffered output up to where it left off, then live-tails.
-  # We pre-loaded the byte count we'd already persisted for the in-flight
-  # turn into `state.replay_skip[stream]`; consume that many bytes off the
-  # front of incoming data, then start logging the remainder normally.
+  # The same, minus the bytes a reattach is replaying: `Output.log_with_replay_skip/4`.
   defp log_with_replay_skip(state, stream, data) do
-    skip = Map.get(state.replay_skip, stream, 0)
-    size = byte_size(data)
-
-    cond do
-      skip == 0 ->
-        log_output(state, stream, data)
-
-      skip >= size ->
-        put_in(state.replay_skip[stream], skip - size)
-
-      true ->
-        state = log_output(state, stream, binary_part(data, skip, size - skip))
-        put_in(state.replay_skip[stream], 0)
-    end
-  end
-
-  defp publish_stage(conv_id, stage, status, meta \\ %{}) do
-    Conversations.publish_stage(conv_id, stage, status, meta)
+    Output.into_state(
+      state,
+      Output.log_with_replay_skip(Output.from_state(state), Output.ctx(state), stream, data)
+    )
   end
 
   defp now, do: DateTime.utc_now() |> DateTime.truncate(:second)
-
-  # Write each image to a temp path in the sprite filesystem and return
-  # a list of {path, media_type} tuples for passing to the runtime.
-  defp write_image_temp_files(_handle, _turn_id, []), do: []
-
-  defp write_image_temp_files(handle, turn_id, images) do
-    images
-    |> Enum.with_index()
-    |> Enum.map(fn {%{media_type: mt, data: data}, idx} ->
-      ext = media_type_to_ext(mt)
-      path = "/tmp/aod_turn_#{turn_id}_#{idx}.#{ext}"
-      Managoat.Sandbox.write_file(handle, path, data)
-      {path, mt}
-    end)
-  end
-
-  defp media_type_to_ext("image/png"), do: "png"
-  defp media_type_to_ext("image/jpeg"), do: "jpeg"
-  defp media_type_to_ext("image/gif"), do: "gif"
-  defp media_type_to_ext("image/webp"), do: "webp"
-  defp media_type_to_ext(_), do: "bin"
 end

--- a/apps/fountain/lib/fountain/conversations/output.ex
+++ b/apps/fountain/lib/fountain/conversations/output.ex
@@ -1,0 +1,247 @@
+defmodule Fountain.Conversations.Output do
+  @moduledoc """
+  What the sandbox says, on its way to the transcript (#1377).
+
+  Three rules live here: the durable log budget (#331) and the truncation
+  marker that says it is spent, the replay skip a reattach needs, and the
+  stage events that mark the same stream. `Redaction` is the guard on the
+  single writer (`Conversations.log!/1`) and stays where it is; this module
+  decides what is written at all, not what a written row may say.
+
+  `from_state/1` reads the three server fields into an `%Output{}` and
+  `into_state/2` writes them back; the server's state does not change shape.
+  Every function takes what it reads — the conversation, the turn the output
+  belongs to and the owner whose sidebar moves, gathered by `ctx/1` — and
+  returns the next value. Nothing here holds a process or a timer.
+  """
+
+  require Logger
+
+  alias Fountain.Conversations
+
+  @type t :: %__MODULE__{
+          bytes: non_neg_integer() | nil,
+          capped: boolean(),
+          replay_skip: %{String.t() => non_neg_integer()}
+        }
+
+  @type ctx :: %{
+          conversation_id: String.t(),
+          turn_id: String.t() | nil,
+          user_id: String.t() | nil
+        }
+
+  defstruct bytes: nil, capped: false, replay_skip: %{}
+
+  # ── the server boundary ───────────────────────────────────────────────────
+
+  @doc "What the server holds, as one value."
+  @spec from_state(map()) :: t()
+  def from_state(state) do
+    %__MODULE__{
+      bytes: state.output_bytes,
+      capped: state.output_capped,
+      replay_skip: state.replay_skip
+    }
+  end
+
+  @doc "The value written back into the server's fields."
+  @spec into_state(map(), t()) :: map()
+  def into_state(state, %__MODULE__{} = output) do
+    %{
+      state
+      | output_bytes: output.bytes,
+        output_capped: output.capped,
+        replay_skip: output.replay_skip
+    }
+  end
+
+  @doc """
+  What a row needs beside the bytes: the conversation, the turn the output
+  belongs to, and the owner whose sidebar the broadcast moves.
+  """
+  @spec ctx(map()) :: ctx()
+  def ctx(state) do
+    %{
+      conversation_id: state.conversation_id,
+      turn_id: state.current_turn && state.current_turn.id,
+      user_id: state.user_id
+    }
+  end
+
+  # ── the durable budget (#331) ─────────────────────────────────────────────
+
+  @doc """
+  Persist + broadcast one chunk of sandbox output, subject to the
+  per-conversation byte budget (#331).
+
+  `log_events` is unbounded per row count and lives on the same Postgres
+  volume the app depends on, so a `while true; do base64 /dev/urandom; done`
+  sandbox was an availability risk, not just a storage bill — retention
+  (#217) bounds age, not rate. Once the budget is exceeded, one truncation
+  marker is persisted and every later chunk is dropped. Dropped rather than
+  broadcast-only: consumers key ordering off the DB-assigned event id, and an
+  unbounded broadcast stream would still let a hostile sandbox saturate
+  PubSub.
+  """
+  @spec log(t(), ctx(), String.t(), binary()) :: t()
+  def log(%__MODULE__{} = output, ctx, stream, data) do
+    output = ensure_bytes(output, ctx.conversation_id)
+    budget = byte_budget()
+
+    cond do
+      output.capped ->
+        output
+
+      budget > 0 and output.bytes + byte_size(data) > budget ->
+        Logger.warning(
+          "conv #{ctx.conversation_id}: durable output budget " <>
+            "(#{budget} bytes) reached; dropping further sandbox output"
+        )
+
+        :telemetry.execute([:fountain, :log_output, :capped], %{count: 1}, %{
+          conversation_id: ctx.conversation_id
+        })
+
+        persist(ctx, "stderr", cap_marker(budget))
+        %{output | capped: true}
+
+      true ->
+        persist(ctx, stream, data)
+        %{output | bytes: output.bytes + byte_size(data)}
+    end
+  end
+
+  @doc "The one row that says the budget is spent."
+  @spec cap_marker(non_neg_integer()) :: String.t()
+  def cap_marker(budget) do
+    "\n[fountain] This conversation reached its durable log budget of " <>
+      "#{div(budget, 1_000_000)} MB. Further sandbox output is discarded — " <>
+      "the turn keeps running, and stage events still appear.\n"
+  end
+
+  @doc """
+  Load the conversation's byte total on the first output of a server's
+  lifetime, so the budget is cumulative across wakes rather than per BEAM
+  lifetime.
+  """
+  @spec ensure_bytes(t(), String.t()) :: t()
+  def ensure_bytes(%__MODULE__{bytes: nil} = output, conversation_id) do
+    # ownership: a server's own conversation, established at init.
+    %{output | bytes: Conversations._unsafe_output_byte_total(conversation_id)}
+  end
+
+  def ensure_bytes(%__MODULE__{} = output, _conversation_id), do: output
+
+  @doc "The budget in bytes. 0 disables the cap."
+  @spec byte_budget() :: non_neg_integer()
+  def byte_budget do
+    Application.get_env(:fountain, :log_output_byte_budget, 50_000_000)
+  end
+
+  @doc """
+  Write one chunk to the transcript and broadcast it, with no budget
+  arithmetic: what `log/4` does once it has decided the chunk is affordable.
+  """
+  @spec persist(ctx(), String.t(), binary()) :: :ok
+  def persist(ctx, stream, data) do
+    # Tag this output with the stage that's active right now. The
+    # runtime CLI is always spawned inside a `turn` so all stdout /
+    # stderr from it gets `stage: "turn"`. Any operator on the
+    # presentation side (LiveView grouping, SSE consumers) can group
+    # output by stage without inferring it from event interleaving.
+    event =
+      Conversations.log!(%{
+        conversation_id: ctx.conversation_id,
+        turn_id: ctx.turn_id,
+        kind: "output",
+        stream: stream,
+        stage: "turn",
+        data: data
+      })
+
+    Phoenix.PubSub.broadcast(
+      Fountain.PubSub,
+      "conv:#{ctx.conversation_id}",
+      {:log_event, event}
+    )
+
+    if ctx.user_id do
+      Phoenix.PubSub.broadcast(
+        Fountain.PubSub,
+        "sidebar:#{ctx.user_id}",
+        {:sidebar_update, ctx.user_id}
+      )
+    end
+
+    :ok
+  end
+
+  # ── the reattach replay skip ──────────────────────────────────────────────
+
+  @doc """
+  Drop replayed bytes before persisting.
+
+  After reattach, sprites replays the session's buffered output up to where
+  it left off, then live-tails. We pre-loaded the byte count we'd already
+  persisted for the in-flight turn into `replay_skip[stream]`; consume that
+  many bytes off the front of incoming data, then start logging the remainder
+  normally.
+  """
+  @spec log_with_replay_skip(t(), ctx(), String.t(), binary()) :: t()
+  def log_with_replay_skip(%__MODULE__{} = output, ctx, stream, data) do
+    skip = Map.get(output.replay_skip, stream, 0)
+    size = byte_size(data)
+
+    cond do
+      skip == 0 ->
+        log(output, ctx, stream, data)
+
+      skip >= size ->
+        put_in(output.replay_skip[stream], skip - size)
+
+      true ->
+        output = log(output, ctx, stream, binary_part(data, skip, size - skip))
+        put_in(output.replay_skip[stream], 0)
+    end
+  end
+
+  # ── stage events ──────────────────────────────────────────────────────────
+
+  @doc """
+  The transcript's other half: a lifecycle marker on the same stream the
+  chunks go to. Unbudgeted — a stage event is one row per transition, and
+  losing them is how a client stops being able to tell a stuck agent from a
+  finished one.
+  """
+  @spec publish_stage(String.t(), String.t(), String.t(), map()) :: Conversations.LogEvent.t()
+  def publish_stage(conv_id, stage, status, meta \\ %{}) do
+    Conversations.publish_stage(conv_id, stage, status, meta)
+  end
+
+  # ── images into the sandbox ───────────────────────────────────────────────
+
+  @doc """
+  Write each image to a temp path in the sprite filesystem and return a list
+  of `{path, media_type}` tuples for passing to the runtime.
+  """
+  @spec write_image_temp_files(term(), String.t(), list()) :: [{String.t(), String.t()}]
+  def write_image_temp_files(_handle, _turn_id, []), do: []
+
+  def write_image_temp_files(handle, turn_id, images) do
+    images
+    |> Enum.with_index()
+    |> Enum.map(fn {%{media_type: mt, data: data}, idx} ->
+      ext = media_type_to_ext(mt)
+      path = "/tmp/aod_turn_#{turn_id}_#{idx}.#{ext}"
+      Managoat.Sandbox.write_file(handle, path, data)
+      {path, mt}
+    end)
+  end
+
+  defp media_type_to_ext("image/png"), do: "png"
+  defp media_type_to_ext("image/jpeg"), do: "jpeg"
+  defp media_type_to_ext("image/gif"), do: "gif"
+  defp media_type_to_ext("image/webp"), do: "webp"
+  defp media_type_to_ext(_), do: "bin"
+end

--- a/apps/fountain/test/fountain/conversations/connection_test.exs
+++ b/apps/fountain/test/fountain/conversations/connection_test.exs
@@ -1,0 +1,275 @@
+defmodule Fountain.Conversations.ConnectionTest do
+  @moduledoc """
+  The connection that outlives the turn (#817), driven without a server: what
+  counts as open, what counts as busy, riding an idle peer, letting one go,
+  and the autonomous turn an out-of-turn line opens (#1301).
+
+  The peer is a stand-in process answering the one call `Peer.prompt/3`
+  makes; the sandbox is the `Managoat.Sandbox` facade, stubbed.
+  """
+  use Fountain.DataCase, async: true
+  use Mimic
+
+  import ExUnit.CaptureLog
+
+  alias Fountain.Conversations
+  alias Fountain.Conversations.Connection
+  alias Managoat.Sandbox.Command
+  alias Managoat.Sandbox.Handle
+
+  setup do
+    user = insert_verified_user()
+    conv = insert_conversation(user_id: user.id, status: "idle")
+    {:ok, user: user, conv: conv}
+  end
+
+  defp handle, do: %Handle{provider: :sprites, name: "s"}
+  defp command, do: %Command{provider: :sprites, ref: make_ref()}
+
+  # A stand-in peer: answers `Peer.prompt/3`'s call with `reply` and stays
+  # alive, the way an idle adapter does between turns.
+  defp fake_peer(reply) do
+    test = self()
+
+    spawn_link(fn ->
+      receive do
+        {:"$gen_call", from, {:prompt, prompt, images}} ->
+          send(test, {:prompted, prompt, images})
+          GenServer.reply(from, reply)
+          Process.sleep(:infinity)
+      end
+    end)
+  end
+
+  defp stages(conv_id, stage) do
+    Fountain.Repo.all(
+      from(e in Conversations.LogEvent,
+        where: e.conversation_id == ^conv_id and e.kind == "stage" and e.stage == ^stage,
+        order_by: e.id
+      )
+    )
+    |> Enum.map(&{&1.state, Jason.decode!(&1.data)})
+  end
+
+  describe "the server boundary" do
+    test "from_state/1 and into_state/2 round-trip the five fields" do
+      cmd = command()
+
+      state = %{
+        acp_peer: self(),
+        acp_peer_mon: :mon,
+        current_command: cmd,
+        current_command_ref: cmd.ref,
+        autonomous_quiet: :timer,
+        other: 1
+      }
+
+      assert %Connection{peer: peer, peer_mon: :mon, command: ^cmd, quiet_timer: :timer} =
+               conn = Connection.from_state(state)
+
+      assert peer == self()
+      assert conn.command_ref == cmd.ref
+      assert Connection.into_state(state, conn) == state
+    end
+  end
+
+  describe "alive?/1" do
+    test "an idle peer still on the machine is alive" do
+      assert Connection.alive?(%Connection{peer: self()})
+    end
+
+    test "no peer, and a peer that has gone, are both not alive" do
+      dead = spawn(fn -> :ok end)
+      ref = Process.monitor(dead)
+      assert_receive {:DOWN, ^ref, :process, ^dead, _}
+
+      refute Connection.alive?(%Connection{})
+      refute Connection.alive?(%Connection{peer: dead})
+    end
+  end
+
+  describe "user_turn_running?/1" do
+    test "no turn is not busy" do
+      refute Connection.user_turn_running?(nil)
+    end
+
+    test "an autonomous turn is not busy: a prompt supersedes it" do
+      refute Connection.user_turn_running?(%{origin: "autonomous"})
+    end
+
+    test "a user turn is busy" do
+      assert Connection.user_turn_running?(%{origin: "user"})
+    end
+  end
+
+  describe "resume/7" do
+    setup %{conv: conv} do
+      {:ok, turn: insert_turn(conv, status: "running")}
+    end
+
+    test "rides the open peer and hands back the span, tracer and stamp", %{
+      conv: conv,
+      user: user,
+      turn: turn
+    } do
+      conn = %Connection{peer: fake_peer(:ok)}
+
+      assert {:ok, _span, tracer, started_mono} =
+               Connection.resume(conn, conv.id, user.id, conv, turn, "go on", [])
+
+      assert is_integer(started_mono)
+      refute is_nil(tracer)
+      assert_receive {:prompted, "go on", []}
+
+      assert [{"started", meta}] = stages(conv.id, "turn")
+      assert meta["mode"] == "continue"
+      assert meta["connection"] == "reused"
+      assert meta["turn_id"] == turn.id
+    end
+
+    test "a peer that refuses the prompt is an error the caller respawns from", %{
+      conv: conv,
+      user: user,
+      turn: turn
+    } do
+      conn = %Connection{peer: fake_peer({:error, :wedged})}
+
+      log =
+        capture_log(fn ->
+          assert {:error, :wedged} =
+                   Connection.resume(conn, conv.id, user.id, conv, turn, "go on", [])
+        end)
+
+      assert log =~ "idle peer refused prompt"
+      # The stage event is published before the peer answers, so it stands
+      # either way; the turn row is the caller's to run afresh.
+      assert [{"started", _}] = stages(conv.id, "turn")
+    end
+  end
+
+  describe "close/3" do
+    test "EOFs the adapter, stops it, and clears the connection", %{conv: conv} do
+      test = self()
+      cmd = command()
+
+      Mimic.stub(Managoat.Sandbox, :close_stdin, fn c -> send(test, {:closed_stdin, c.ref}) end)
+      Mimic.stub(Managoat.Sandbox, :stop_command, fn c -> send(test, {:stopped, c.ref}) end)
+
+      conn = %Connection{command: cmd, command_ref: cmd.ref, quiet_timer: arm_a_timer()}
+
+      assert %Connection{peer: nil, peer_mon: nil, command: nil, command_ref: nil} =
+               closed = Connection.close(conn, conv.id, handle())
+
+      assert closed.quiet_timer == nil
+      assert_receive {:closed_stdin, ref}
+      assert ref == cmd.ref
+      assert_receive {:stopped, ^ref}
+    end
+
+    test "is safe on a connection that has nothing open", %{conv: conv} do
+      assert Connection.close(%Connection{}, conv.id, nil) == %Connection{}
+    end
+  end
+
+  describe "lost/5" do
+    test "records the loss on the transcript and clears the connection", %{conv: conv} do
+      cmd = command()
+      conn = %Connection{peer: self(), peer_mon: :mon, command: cmd, command_ref: cmd.ref}
+
+      assert %Connection{peer: nil, peer_mon: nil, command: nil, command_ref: nil} =
+               Connection.lost(conn, conv.id, nil, "adapter_exited", %{exit_code: 3})
+
+      assert [{"done", meta}] = stages(conv.id, "sandbox")
+      assert meta["event"] == "connection_lost"
+      assert meta["reason"] == "adapter_exited"
+      assert meta["exit_code"] == 3
+    end
+  end
+
+  describe "stop_peer/1" do
+    test "no peer is nothing to stop" do
+      assert Connection.stop_peer(%Connection{}) == :ok
+    end
+
+    test "stops the peer and flushes the monitor it was watched by" do
+      {:ok, peer} = Agent.start(fn -> :ok end)
+      mon = Process.monitor(peer)
+
+      assert Connection.stop_peer(%Connection{peer: peer, peer_mon: mon}) == :ok
+      refute Process.alive?(peer)
+      # Demonitored with :flush, so the peer's own exit does not arrive as a
+      # :DOWN that would fail the turn we just finished.
+      refute_receive {:DOWN, ^mon, :process, ^peer, _}
+    end
+
+    test "a peer that has already gone is not an error" do
+      dead = spawn(fn -> :ok end)
+      ref = Process.monitor(dead)
+      assert_receive {:DOWN, ^ref, :process, ^dead, _}
+
+      assert Connection.stop_peer(%Connection{peer: dead}) == :ok
+    end
+  end
+
+  describe "the quiet timer (#1301)" do
+    test "quiet_ms/0 is ten minutes of silence" do
+      assert Connection.quiet_ms() == :timer.minutes(10)
+    end
+
+    test "arm_quiet/2 arms against the turn it will close" do
+      turn = %{id: "t-1"}
+      assert %Connection{quiet_timer: timer} = Connection.arm_quiet(%Connection{}, turn)
+      assert is_reference(timer)
+      assert Process.read_timer(timer) > 0
+    end
+
+    test "arming again replaces the timer rather than leaving two" do
+      first = Connection.arm_quiet(%Connection{}, %{id: "t-1"})
+      second = Connection.arm_quiet(first, %{id: "t-2"})
+
+      refute second.quiet_timer == first.quiet_timer
+      assert Process.read_timer(first.quiet_timer) == false
+    end
+
+    test "no turn, no timer" do
+      assert %Connection{quiet_timer: nil} = Connection.arm_quiet(%Connection{}, nil)
+    end
+
+    test "cancel_quiet/1 disarms, and is safe when nothing is armed" do
+      armed = Connection.arm_quiet(%Connection{}, %{id: "t-1"})
+      assert %Connection{quiet_timer: nil} = Connection.cancel_quiet(armed)
+      assert Process.read_timer(armed.quiet_timer) == false
+      assert Connection.cancel_quiet(%Connection{}) == %Connection{}
+    end
+  end
+
+  describe "open_autonomous_turn/2" do
+    test "opens a real turn row so the budget and the stage events apply", %{
+      conv: conv,
+      user: user
+    } do
+      assert {turn, _span, tracer} = Connection.open_autonomous_turn(conv.id, user.id)
+
+      assert turn.origin == "autonomous"
+      assert turn.status == "running"
+      assert turn.prompt == "(background task follow-up)"
+      assert turn.conversation_id == conv.id
+      refute is_nil(tracer)
+
+      assert [{"started", meta}] = stages(conv.id, "turn")
+      assert meta["origin"] == "autonomous"
+      assert meta["turn_id"] == turn.id
+
+      assert Conversations._unsafe_get_conversation!(conv.id).status == "running"
+    end
+
+    test "takes the next turn number", %{conv: conv, user: user} do
+      insert_turn(conv, status: "completed")
+
+      assert {turn, _span, _tracer} = Connection.open_autonomous_turn(conv.id, user.id)
+      assert turn.turn_number == 2
+    end
+  end
+
+  defp arm_a_timer, do: Process.send_after(self(), :never, :timer.minutes(10))
+end

--- a/apps/fountain/test/fountain/conversations/conversation_server_size_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_size_test.exs
@@ -15,7 +15,7 @@ defmodule Fountain.Conversations.ConversationServerSizeTest do
   accepts is downward. Lower it when you move something out; never raise it.
   """
 
-  @pin 3048
+  @pin 2835
 
   @server "apps/fountain/lib/fountain/conversations/conversation_server.ex"
 

--- a/apps/fountain/test/fountain/conversations/output_test.exs
+++ b/apps/fountain/test/fountain/conversations/output_test.exs
@@ -1,0 +1,213 @@
+defmodule Fountain.Conversations.OutputTest do
+  @moduledoc """
+  What the sandbox says on its way to the transcript (#1377), driven without
+  a server: the durable budget (#331) and its one marker, the reattach replay
+  skip, the two broadcasts and the stage door.
+
+  The budget is exercised against the real default rather than by writing
+  `:log_output_byte_budget`: the value is global, this file is async, and a
+  value already loaded into an `%Output{}` reaches the same branch.
+  """
+  use Fountain.DataCase, async: true
+  use Mimic
+
+  alias Fountain.Conversations
+  alias Fountain.Conversations.Output
+  alias Managoat.Sandbox.Handle
+
+  @budget 50_000_000
+
+  setup do
+    user = insert_verified_user()
+    conv = insert_conversation(user_id: user.id)
+    turn = insert_turn(conv, status: "running")
+
+    ctx = %{conversation_id: conv.id, turn_id: turn.id, user_id: user.id}
+    {:ok, user: user, conv: conv, turn: turn, ctx: ctx}
+  end
+
+  defp outputs(conv_id) do
+    Fountain.Repo.all(
+      from(e in Conversations.LogEvent,
+        where: e.conversation_id == ^conv_id and e.kind == "output",
+        order_by: e.id
+      )
+    )
+    |> Enum.map(&{&1.stream, &1.data, &1.stage, &1.turn_id})
+  end
+
+  describe "the server boundary" do
+    test "from_state/1 and into_state/2 round-trip the three fields" do
+      state = %{output_bytes: 7, output_capped: false, replay_skip: %{"stdout" => 3}, other: 1}
+
+      assert %Output{bytes: 7, capped: false, replay_skip: %{"stdout" => 3}} =
+               out = Output.from_state(state)
+
+      assert Output.into_state(state, %{out | capped: true}) == %{state | output_capped: true}
+    end
+
+    test "ctx/1 reads the conversation, the turn in flight and the owner", %{
+      conv: conv,
+      turn: turn,
+      user: user
+    } do
+      state = %{conversation_id: conv.id, current_turn: turn, user_id: user.id}
+      assert Output.ctx(state) == %{conversation_id: conv.id, turn_id: turn.id, user_id: user.id}
+    end
+
+    test "ctx/1 has no turn id between turns", %{conv: conv, user: user} do
+      state = %{conversation_id: conv.id, current_turn: nil, user_id: user.id}
+      assert %{turn_id: nil} = Output.ctx(state)
+    end
+  end
+
+  describe "log/4" do
+    test "persists the chunk against the turn and counts its bytes", %{ctx: ctx, turn: turn} do
+      assert %Output{bytes: 5, capped: false} =
+               Output.log(%Output{bytes: 0}, ctx, "stdout", "hello")
+
+      assert [{"stdout", "hello", "turn", turn_id}] = outputs(ctx.conversation_id)
+      assert turn_id == turn.id
+    end
+
+    test "broadcasts the event and moves the owner's sidebar", %{ctx: ctx, user: user} do
+      Phoenix.PubSub.subscribe(Fountain.PubSub, "conv:#{ctx.conversation_id}")
+      Phoenix.PubSub.subscribe(Fountain.PubSub, "sidebar:#{user.id}")
+
+      Output.log(%Output{bytes: 0}, ctx, "stdout", "hi")
+
+      assert_receive {:log_event, %Conversations.LogEvent{data: "hi"}}
+      assert_receive {:sidebar_update, sidebar_user}
+      assert sidebar_user == user.id
+    end
+
+    test "loads the conversation's byte total on the first chunk", %{ctx: ctx} do
+      Output.persist(ctx, "stdout", "already persisted")
+
+      # `bytes: nil` is a server that has just woken: the budget is cumulative
+      # per conversation across wakes, not per BEAM lifetime.
+      assert %Output{bytes: bytes} = Output.log(%Output{}, ctx, "stdout", "ab")
+      assert bytes == byte_size("already persisted") + 2
+    end
+
+    test "caps once at the budget and drops every later chunk", %{ctx: ctx} do
+      over = %Output{bytes: @budget}
+
+      assert %Output{capped: true} = capped = Output.log(over, ctx, "stdout", "one more byte")
+
+      assert [{"stderr", marker, _, _}] = outputs(ctx.conversation_id)
+      assert marker == Output.cap_marker(@budget)
+
+      assert ^capped = Output.log(capped, ctx, "stdout", "and another")
+      assert length(outputs(ctx.conversation_id)) == 1
+    end
+
+    test "the cap emits the telemetry the operator watches", %{ctx: ctx} do
+      :telemetry.attach(
+        "output-test-cap",
+        [:fountain, :log_output, :capped],
+        fn _event, measurements, meta, pid -> send(pid, {:capped, measurements, meta}) end,
+        self()
+      )
+
+      on_exit(fn -> :telemetry.detach("output-test-cap") end)
+
+      Output.log(%Output{bytes: @budget}, ctx, "stdout", "over")
+
+      assert_receive {:capped, %{count: 1}, %{conversation_id: conv_id}}
+      assert conv_id == ctx.conversation_id
+    end
+  end
+
+  describe "cap_marker/1 and byte_budget/0" do
+    test "the marker names the budget in megabytes" do
+      assert Output.cap_marker(@budget) =~ "durable log budget of 50 MB"
+    end
+
+    test "the default budget is 50 MB" do
+      assert Output.byte_budget() == @budget
+    end
+  end
+
+  describe "log_with_replay_skip/4" do
+    test "logs everything when nothing is being replayed", %{ctx: ctx} do
+      assert %Output{bytes: 2, replay_skip: %{}} =
+               Output.log_with_replay_skip(%Output{bytes: 0}, ctx, "stdout", "ab")
+
+      assert [{"stdout", "ab", _, _}] = outputs(ctx.conversation_id)
+    end
+
+    test "drops a chunk wholly inside the replayed tail", %{ctx: ctx} do
+      out = %Output{bytes: 0, replay_skip: %{"stdout" => 5}}
+
+      assert %Output{bytes: 0, replay_skip: %{"stdout" => 2}} =
+               Output.log_with_replay_skip(out, ctx, "stdout", "abc")
+
+      assert outputs(ctx.conversation_id) == []
+    end
+
+    test "logs the remainder of the chunk the replay ends inside", %{ctx: ctx} do
+      out = %Output{bytes: 0, replay_skip: %{"stdout" => 2}}
+
+      assert %Output{bytes: 3, replay_skip: %{"stdout" => 0}} =
+               Output.log_with_replay_skip(out, ctx, "stdout", "abcde")
+
+      assert [{"stdout", "cde", _, _}] = outputs(ctx.conversation_id)
+    end
+
+    test "the skip is per stream", %{ctx: ctx} do
+      out = %Output{bytes: 0, replay_skip: %{"stdout" => 5}}
+
+      assert %Output{bytes: 2} = Output.log_with_replay_skip(out, ctx, "stderr", "ab")
+      assert [{"stderr", "ab", _, _}] = outputs(ctx.conversation_id)
+    end
+  end
+
+  describe "publish_stage/4" do
+    test "puts a stage row on the same transcript", %{conv: conv} do
+      Output.publish_stage(conv.id, "turn", "started", %{turn_number: 1})
+
+      assert [event] =
+               Fountain.Repo.all(
+                 from(e in Conversations.LogEvent,
+                   where: e.conversation_id == ^conv.id and e.kind == "stage"
+                 )
+               )
+
+      assert event.stage == "turn"
+      assert event.state == "started"
+      assert Jason.decode!(event.data) == %{"turn_number" => 1}
+    end
+  end
+
+  describe "write_image_temp_files/3" do
+    test "writes nothing for no images" do
+      assert Output.write_image_temp_files(%Handle{provider: :sprites, name: "s"}, "t1", []) == []
+    end
+
+    test "writes each image and returns its path and media type" do
+      test = self()
+
+      Mimic.stub(Managoat.Sandbox, :write_file, fn _handle, path, data ->
+        send(test, {:wrote, path, data})
+        :ok
+      end)
+
+      images = [
+        %{media_type: "image/png", data: "one"},
+        %{media_type: "image/tiff", data: "two"}
+      ]
+
+      assert [{png, "image/png"}, {bin, "image/tiff"}] =
+               Output.write_image_temp_files(%Handle{provider: :sprites, name: "s"}, "t1", images)
+
+      # The extension comes from the media type, and an unknown one is `.bin`
+      # rather than a guess the runtime would refuse to open.
+      assert png == "/tmp/aod_turn_t1_0.png"
+      assert bin == "/tmp/aod_turn_t1_1.bin"
+
+      assert_receive {:wrote, "/tmp/aod_turn_t1_0.png", "one"}
+      assert_receive {:wrote, "/tmp/aod_turn_t1_1.bin", "two"}
+    end
+  end
+end

--- a/apps/fountain/test/fountain/webhooks/events_test.exs
+++ b/apps/fountain/test/fountain/webhooks/events_test.exs
@@ -25,7 +25,9 @@ defmodule Fountain.Webhooks.EventsTest do
     "lib/fountain/conversations/egress.ex",
     "lib/fountain/conversations/turn_machine.ex",
     "lib/fountain/conversations/pending.ex",
-    "lib/fountain/conversations/lifecycle.ex"
+    "lib/fountain/conversations/lifecycle.ex",
+    "lib/fountain/conversations/connection.ex",
+    "lib/fountain/conversations/output.ex"
   ]
 
   # publish_stage(<anything>, "<stage>", "<status>"


### PR DESCRIPTION
Part of #1369, last of eight. Two families leave `ConversationServer`: the ACP connection that outlives the turn (#817), and everything the sandbox says on its way to the transcript (#331). What is left is the process.

## Functions moved

### The connection (#817) → `Fountain.Conversations.Connection`

| was (`ConversationServer`) | now (`Connection`) |
|---|---|
| `connection_alive?/1` | `alive?/1` |
| `user_turn_running?/1` | `user_turn_running?/1` (over the turn, not the state) |
| `resume_acp_connection/5` body | `resume/7` → `{:ok, span, tracer, started_mono}` \| `{:error, reason}` |
| `drop_connection/2` body | `close/3` |
| `connection_lost/3` body | `lost/5` |
| `open_autonomous_turn/1` body | `open_autonomous_turn/2` → `{turn, span, tracer}` |
| `arm_autonomous_quiet/1` | `arm_quiet/2` |
| `cancel_autonomous_quiet/1` | `cancel_quiet/1` |
| `autonomous_quiet_ms/0` + `@autonomous_quiet_ms` | `quiet_ms/0` |
| `stop_acp_peer/1` | `stop_peer/1` |
| `consolidate_gemini_session/1` | private, called by `close/3` and `lost/5` |

`%Connection{peer, peer_mon, command, command_ref, quiet_timer}` with `from_state/1` and `into_state/2`; the server's state does not change shape. #1301's phantom-turn fix moved whole, with its comments.

### Output persistence → `Fountain.Conversations.Output`

| was (`ConversationServer`) | now (`Output`) |
|---|---|
| `log_output/3` | `log/4` |
| `cap_marker/1` | `cap_marker/1` |
| `ensure_output_bytes/1` | `ensure_bytes/2` |
| `output_byte_budget/0` | `byte_budget/0` |
| `persist_output/3` | `persist/3` |
| `log_with_replay_skip/3` | `log_with_replay_skip/4` |
| `publish_stage/4` | `publish_stage/4` |
| `write_image_temp_files/3`, `media_type_to_ext/1` | `write_image_temp_files/3` (the ext table is private) |

`%Output{bytes, capped, replay_skip}` with `from_state/1`, `into_state/2` and `ctx/1` — the conversation, the turn the output belongs to and the owner whose sidebar the broadcast moves.

## Four corrections to the issue's list

- **`autonomous_turn?/1` is already gone.** It moved to `TurnMachine` in #1374 and answers over the turn the machine holds. Moving it a second time would churn that module and its tests for nothing, so it stayed; `Connection`'s moduledoc points at it.
- **`consolidate_gemini_session/1` is not on the list but had to come.** Its only two callers are `drop_connection` and `connection_lost`, both of which moved. Leaving it behind would have meant passing it in as a callback.
- **`now/0` is not on the list and stayed.** The handoff notes grouped it with `Output`; its four call sites stamp a sandbox row and two turn rows, none of which are output. `Connection` has its own, as `TurnMachine` and `Lifecycle` already do.
- **`persist_acp_lines/3` stayed**, as a wrapper. It is `log_with_replay_skip` plus the stream tracer, and the tracer belongs to the turn; `conversation_server_log_budget_test.exs` names it in a comment as the path the budget is reached through, and that is still true.

## What stayed in the server, and why

Nine wrappers, each because the thing it does next is the process's: `resume_acp_connection/5` (holds the turn fields and respawns on refusal), `drop_connection/2` (its first clause skips the autonomous finish, and finishing a turn resolves what is pending and stamps the row), `connection_lost/3`, `open_autonomous_turn/1` (arms the timer in this process), `arm_autonomous_quiet/1`, `cancel_autonomous_quiet/1`, `stop_acp_peer/1`, `log_output/3` and `log_with_replay_skip/3`. `close_autonomous_turn/2` stayed whole: it is a branch over `finish_acp_turn/4`.

One dedup fell out: `drop_connection/2`'s autonomous-finish branch was character-for-character `close_autonomous_turn(state, "connection_closed")`, and now calls it.

## Behaviour

No stage, log line, telemetry event (`[:fountain, :log_output, :capped]` included), timer, message shape, error atom or audit event changed. The order inside `close/3` is the order `drop_connection/2` had: cancel the quiet timer, EOF stdin, consolidate gemini's store, stop the peer, stop the command.

## Pin

**3,048 → 2,835.** Proof: with `origin/main`'s server file put back beside the two new modules, `conversation_server_size_test.exs` fails — *"is 3048 lines, over the pin of 2835"* — and passes again on restore.

## Gates

| gate | result |
|---|---|
| `MIX_ENV=test mix compile --warnings-as-errors` | clean |
| `mix format --check-formatted` | clean |
| `mix credo --strict` | 5996 mods/funs, no issues |
| `MIX_ENV=dev mix dialyzer` | Total errors: 0 |
| the 15 `conversation_server*_test.exs` files | 176 tests, 0 failures |
| `pending`, `turn_machine`, `lifecycle`, `lifecycle_actions`, `provisioning`, `provisioning_steps`, `egress`, `mcp_servers`, `callback_key`, `redaction`, `caller_tools`, `audit_guardrail`, `docs`, `webhooks/events` + the two new files | 333 tests, 0 failures |
| `connection_test.exs` + `output_test.exs` alone | 38 tests, 0 failures |
| `gitleaks detect` over both new source directories | no leaks found |
| full root suite | posted as a comment |

Only the pin changed in `conversation_server*_test.exs`. `.credo.exs` gains the two files to the ownership check's `exempt_paths` (the server's own code, under the ownership `init/1` established), and `webhooks/events_test.exs` gains them to `@sources` because `publish_stage/4` now lives in `Output`.

## New tests

`connection_test.exs` (21) and `output_test.exs` (17) drive both modules as values, with no server: the peer is a stand-in process answering `Peer.prompt/3`'s one call, the sandbox is the `Managoat.Sandbox` facade stubbed. The budget is exercised against the real 50 MB default rather than by writing `:log_output_byte_budget`, so both files stay `async: true`.

Closes #1377. Part of #1369.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YP77RRzXpV32aSQbvwfsMT
