### PR TITLE
docs(libraries): record the no-Fountain consumer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ upgrade, is in
 
 ## [Unreleased]
 
+### Added
+
+- **Standalone consumers for the Managoat libraries** (#1365). The
+  [`managoat_examples`](https://github.com/managoat/managoat_examples)
+  repository has three plain Mix projects with Hex dependencies and no
+  Fountain dependency: a local ACP adapter over an Erlang `Port`, an ACP
+  session inside `Managoat.Sandbox` with a credential-free Fake path and an
+  opt-in Sprites path, and MCP authorization discovery with dynamic client
+  registration. Its CI compiles all three with warnings as errors and runs
+  the Fake sandbox turn.
+
 ### Fixed
 
 - **opencode on a `google/` model could never authenticate** (#1460).

--- a/decisions/0037-component-libraries.md
+++ b/decisions/0037-component-libraries.md
@@ -83,6 +83,20 @@ holds no library app, and `umbrella_layout_test.exs` and
 `scripts/test-libraries.sh` guard the next one. The tracker is #1334. Each PR
 that extracts or graduates a library updates this block.
 
+**Second consumer:**
+[`managoat/managoat_examples`](https://github.com/managoat/managoat_examples)
+(#1365, 2026-09-03) is three standalone Mix projects that depend only on the
+Hex releases. `acp_stdio` runs an adapter as an Erlang `Port` and gives its
+bytes to `Managoat.ACP.Peer` through the writer callback. `sandbox_agent`
+runs the same peer behind `Managoat.Sandbox.write_stdin/2`; its default
+`Managoat.Sandbox.Fake` script needs no credentials, and its opt-in Sprites
+path provisions a real adapter through `Managoat.Runtimes`. `mcp_discovery`
+starts with one verified server URL and uses `Managoat.McpAuth` through
+dynamic client registration. CI compiles every example from exact Hex pins
+and runs the Fake turn. The consumer needed no new library surface: the
+writer callback, the Fake command vocabulary and `${VAR}` substitution were
+enough outside Fountain.
+
 Extends [0010](0010-ee-directory-boundary.md) (the licence boundary inside
 one repo) and [0027](0027-agpl-relicensing.md) (the server's licence). Names
 the seams that [0018](0018-sandbox-provider-abstraction.md),
@@ -233,6 +247,10 @@ credit rules that `CLAUDE.md` lists as easy to get wrong.
 - **The credits ledger is the exception that proves the licence rule.** It
   is listed so the boundary is written down, not because extraction is
   assumed.
+- **A second consumer now exercises the seams without Fountain.** The
+  examples in `managoat/managoat_examples` compile only against Hex packages.
+  The local-Port and sandbox transports share the same peer, and the Fake
+  sandbox completes a scripted ACP turn in CI without provider credentials.
 
 ## Alternatives considered
 


### PR DESCRIPTION
Closes #1365. Part of #1334.

Creates https://github.com/managoat/managoat_examples at commit 01e46cd36be3530f711b58c7a95241bae2919d2c: three independent Mix projects with exact Hex pins and no Fountain dependency.

- acp_stdio runs a local adapter as an Erlang Port, supplies Port.command/2 as the Managoat.ACP.Peer writer, feeds Port output to Peer.stdout/2, applies the requested ask/read policy, accepts a terminal permission answer, and prints Managoat.ACP.Blocks.
- sandbox_agent uses Managoat.Sandbox.write_stdin/2 as the writer. Its default Managoat.Sandbox.Fake command scripts a complete ACP turn without credentials; --provider sprites provisions and runs a real adapter through Managoat.Runtimes. Managoat.Substitution resolves the MCP config first.
- mcp_discovery discovers endpoints from the verified Linear URL and registers a client through register/3.
- repository CI compiles all three with warnings as errors and actually runs the Fake sandbox path.

This Fountain PR records that second consumer in ADR 0037 and the changelog.

Verified:
- New repository CI: https://github.com/managoat/managoat_examples/actions/runs/33721905496
- All three projects: mix compile --warnings-as-errors
- sandbox_agent Fake turn: completed with normalized text, tool-use and tool-result blocks plus usage
- acp_stdio: deterministic shell-backed adapter completed the Port handshake and interactive permission path
- Linear discovery: live read-only metadata chain returned authorization, token and registration endpoints; registration itself was not invoked as a test side effect
- python3 scripts/docs-style.py: clean
- okf validate decisions: valid (three pre-existing actor-convention warnings)