### PR TITLE
fix(conversations): recover orphaned running turns

### DIFF
--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -1251,6 +1251,92 @@ defmodule Fountain.Conversations do
   end
 
   @doc """
+  Reconciles a turn left `running` after its server or runtime disappeared.
+
+  The turn transition and the conversation's `running` to `idle` transition
+  are conditional writes. If another process already ended the turn, this is
+  a no-op rather than overwriting its result. `orphaned_at` records that the
+  true end of work is unknown, which keeps the interval out of billing and
+  usage attribution.
+
+  This function is unscoped because it is called by a conversation's own
+  server and by the system reaper. Callers may supply audit attribution.
+  """
+  def _unsafe_orphan_turn(%Turn{} = turn, why, opts \\ []) do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+    reply_text = turn.reply_text || _unsafe_turn_reply_text(turn)
+
+    updates =
+      [status: "interrupted", ended_at: now, orphaned_at: now]
+      |> maybe_set_reply_text(reply_text)
+
+    result =
+      Repo.transaction(fn ->
+        {count, _} =
+          from(t in Turn, where: t.id == ^turn.id and t.status == "running")
+          |> Repo.update_all(set: updates)
+
+        if count == 0 do
+          :noop
+        else
+          {conversation_count, _} =
+            from(c in Conversation,
+              where: c.id == ^turn.conversation_id and c.status == "running"
+            )
+            |> Repo.update_all(set: [status: "idle", updated_at: now])
+
+          {
+            Repo.get!(Turn, turn.id),
+            Repo.get!(Conversation, turn.conversation_id),
+            conversation_count == 1
+          }
+        end
+      end)
+
+    case result do
+      {:ok, :noop} ->
+        :noop
+
+      {:ok, {updated_turn, conv, conversation_changed?}} ->
+        if is_nil(turn.reply_text) and is_binary(updated_turn.reply_text) do
+          Fountain.Activation.turn_replied(updated_turn)
+        end
+
+        if conversation_changed?, do: broadcast_sidebar_update(conv.user_id)
+
+        publish_stage(turn.conversation_id, "reattach", "interrupted", %{
+          outcome: "turn_orphaned",
+          turn_id: turn.id,
+          turn_number: turn.turn_number,
+          reason: why
+        })
+
+        Audit.record(%{
+          user_id: conv.user_id,
+          action: "conversation.turn.orphaned",
+          resource_type: "turn",
+          resource_id: turn.id,
+          actor: Keyword.get(opts, :actor, "system:conversation_server"),
+          metadata: %{
+            "conversation_id" => turn.conversation_id,
+            "turn_number" => turn.turn_number,
+            "reason" => why
+          }
+        })
+
+        {:ok, updated_turn, conv}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp maybe_set_reply_text(updates, nil), do: updates
+
+  defp maybe_set_reply_text(updates, reply_text),
+    do: Keyword.put(updates, :reply_text, reply_text)
+
+  @doc """
   Record a turn's end-of-turn token usage (#827): stamp `usage` on the turn
   and add its `input` / `output` to the conversation's running sums, in one
   transaction. `usage` is the normalised map `Managoat.ACP.Usage`

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -1461,26 +1461,8 @@ defmodule Fountain.Conversations.ConversationServer do
     }
   end
 
-  defp mark_orphan(state, running_turn, why) do
-    {:ok, _} =
-      Conversations._unsafe_update_turn(running_turn, %{
-        status: "interrupted",
-        ended_at: DateTime.utc_now() |> DateTime.truncate(:second)
-      })
-
-    # The orphaned turn was the only thing keeping the conversation in
-    # `running`. Flip it back to `idle` so the UI accurately reflects
-    # state and the user can prompt without going through wake.
-    conv = Conversations._unsafe_get_conversation!(state.conversation_id)
-    {:ok, _} = Conversations.update_conversation(conv, %{status: "idle"})
-
-    Output.publish_stage(state.conversation_id, "reattach", "interrupted", %{
-      outcome: "turn_orphaned",
-      turn_id: running_turn.id,
-      turn_number: running_turn.turn_number,
-      reason: why
-    })
-  end
+  defp mark_orphan(_state, running_turn, why),
+    do: Conversations._unsafe_orphan_turn(running_turn, why)
 
   defp find_running_turn(conv_id) do
     import Ecto.Query
@@ -2238,7 +2220,7 @@ defmodule Fountain.Conversations.ConversationServer do
   # own, and RetentionPruner deletes long-expired rows. See SandboxReaper
   # for the sprite half, which does not self-heal.
   @impl true
-  def terminate(_reason, state) do
+  def terminate(reason, state) do
     Fountain.Conversations.Redaction.delete(state.conversation_id)
 
     if state.conversation_id && state.callback_api_key_id do
@@ -2252,6 +2234,22 @@ defmodule Fountain.Conversations.ConversationServer do
 
         _ ->
           :ok
+      end
+    end
+
+    # A normal stop is not restarted, and its quiet timer dies with it. Leave
+    # supervisor shutdowns and crashes running for reattach. This stays last
+    # and best-effort so it cannot skip callback-key revocation.
+    if reason == :normal and state.current_turn do
+      try do
+        _ =
+          Conversations._unsafe_orphan_turn(state.current_turn, "server_terminated_normally")
+      rescue
+        error ->
+          Logger.error(
+            "terminate/2: orphaning turn for conv #{inspect(state.conversation_id)} raised: " <>
+              Exception.format(:error, error, __STACKTRACE__)
+          )
       end
     end
 

--- a/apps/fountain/lib/fountain/conversations/turn.ex
+++ b/apps/fountain/lib/fountain/conversations/turn.ex
@@ -22,6 +22,10 @@ defmodule Fountain.Conversations.Turn do
     field :exit_code, :integer
     field :started_at, :utc_datetime
     field :ended_at, :utc_datetime
+    # Set when Fountain, rather than the runtime or the user, reconciles a
+    # running turn that no longer has anything driving it. Billing and usage
+    # exclude these intervals because the true end of work is unknowable.
+    field :orphaned_at, :utc_datetime
     # JSON-RPC id of the ACP `session/prompt` in flight; nil on the legacy
     # path and until the peer has written the prompt. See the migration.
     field :acp_prompt_id, :integer
@@ -59,6 +63,7 @@ defmodule Fountain.Conversations.Turn do
       :exit_code,
       :started_at,
       :ended_at,
+      :orphaned_at,
       :acp_prompt_id,
       :pending_permission,
       :usage,

--- a/apps/fountain/lib/fountain/workers/autonomous_turn_reaper.ex
+++ b/apps/fountain/lib/fountain/workers/autonomous_turn_reaper.ex
@@ -1,0 +1,92 @@
+defmodule Fountain.Workers.AutonomousTurnReaper do
+  @moduledoc """
+  Reconciles turns left `running` without a live `ConversationServer`.
+
+  The in-process autonomous quiet timer disappears with its server. This
+  worker is the durable backstop for hard crashes and departed nodes. It only
+  considers old turns that are not waiting on a permission and have produced
+  no recent output. Output is the partition-safe liveness signal because all
+  nodes write it to the shared database even when Horde's registry cannot see
+  across a cluster partition.
+
+  A conversation that reached its durable output budget can appear quiet even
+  while its runtime is active. The server liveness check remains a second
+  guard for that case. The oldest candidates are capped per run so a historical
+  backlog cannot fan out an unbounded burst of events and webhooks.
+  """
+
+  use Oban.Worker, queue: :maintenance, max_attempts: 3
+
+  import Ecto.Query
+
+  require Logger
+
+  alias Fountain.Conversations
+  alias Fountain.Conversations.{ConversationServer, LogEvent, Turn}
+  alias Fountain.Repo
+
+  @stuck_after_minutes 30
+  @quiet_grace_minutes 15
+  @reap_limit 25
+
+  @impl Oban.Worker
+  def perform(_job) do
+    reaped = sweep_stuck_turns()
+
+    Logger.info("autonomous_turn_reaper: reaped=#{reaped}")
+    :telemetry.execute([:fountain, :autonomous_turn_reaper, :run], %{reaped: reaped}, %{})
+
+    :ok
+  end
+
+  @doc false
+  def sweep_stuck_turns do
+    now = DateTime.utc_now()
+    started_cutoff = DateTime.add(now, -@stuck_after_minutes * 60, :second)
+    quiet_cutoff = DateTime.add(now, -@quiet_grace_minutes * 60, :second)
+
+    last_output =
+      from(l in LogEvent,
+        where: l.turn_id == parent_as(:turn).id and l.kind == "output",
+        select: max(l.inserted_at)
+      )
+
+    Turn
+    |> from(as: :turn)
+    |> where([t], t.status == "running" and t.started_at < ^started_cutoff)
+    |> where([t], is_nil(t.pending_permission))
+    |> where([t], coalesce(subquery(last_output), t.started_at) < ^quiet_cutoff)
+    |> order_by([t], asc: t.started_at)
+    |> limit(^@reap_limit)
+    |> Repo.all()
+    |> Enum.count(&reap_if_unowned/1)
+  end
+
+  defp reap_if_unowned(%Turn{} = turn) do
+    if ConversationServer.whereis(turn.conversation_id) do
+      false
+    else
+      case Conversations._unsafe_orphan_turn(turn, "stuck_running_no_server",
+             actor: "system:autonomous_turn_reaper"
+           ) do
+        {:ok, _, _} ->
+          Logger.info(
+            "autonomous_turn_reaper: reaped turn #{turn.id} " <>
+              "(conversation #{turn.conversation_id}) started #{turn.started_at}"
+          )
+
+          true
+
+        :noop ->
+          false
+
+        {:error, reason} ->
+          Logger.warning(
+            "autonomous_turn_reaper: could not reap turn #{turn.id}: #{inspect(reason)}"
+          )
+
+          false
+      end
+    end
+  end
+end

--- a/apps/fountain/priv/repo/migrations/20260903010000_add_orphaned_at_to_turns.exs
+++ b/apps/fountain/priv/repo/migrations/20260903010000_add_orphaned_at_to_turns.exs
@@ -1,0 +1,9 @@
+defmodule Fountain.Repo.Migrations.AddOrphanedAtToTurns do
+  use Ecto.Migration
+
+  def change do
+    alter table(:turns) do
+      add :orphaned_at, :utc_datetime
+    end
+  end
+end

--- a/apps/fountain/priv/repo/migrations/20260903020000_index_running_turns_by_started_at.exs
+++ b/apps/fountain/priv/repo/migrations/20260903020000_index_running_turns_by_started_at.exs
@@ -1,0 +1,17 @@
+defmodule Fountain.Repo.Migrations.IndexRunningTurnsByStartedAt do
+  use Ecto.Migration
+
+  # Supports AutonomousTurnReaper's oldest-first candidate query. A partial
+  # index keeps the structure small because only currently running turns that
+  # are not waiting on a person can be candidates.
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def change do
+    create index(:turns, [:started_at],
+             name: :turns_running_started_at_index,
+             where: "status = 'running' AND pending_permission IS NULL",
+             concurrently: true
+           )
+  end
+end

--- a/apps/fountain/test/fountain/webhooks/events_test.exs
+++ b/apps/fountain/test/fountain/webhooks/events_test.exs
@@ -20,6 +20,7 @@ defmodule Fountain.Webhooks.EventsTest do
 
   # Where publish_stage/4 is called from. A new file calling it belongs here.
   @sources [
+    "lib/fountain/conversations.ex",
     "lib/fountain/conversations/conversation_server.ex",
     "lib/fountain/conversations/provisioning.ex",
     "lib/fountain/conversations/egress.ex",

--- a/apps/fountain/test/fountain/workers/autonomous_turn_reaper_test.exs
+++ b/apps/fountain/test/fountain/workers/autonomous_turn_reaper_test.exs
@@ -1,0 +1,203 @@
+defmodule Fountain.Workers.AutonomousTurnReaperTest do
+  use Fountain.DataCase, async: false
+  use Mimic
+
+  import ExUnit.CaptureLog
+
+  alias Fountain.Audit
+  alias Fountain.Conversations
+  alias Fountain.Conversations.ConversationServer
+  alias Fountain.Repo
+  alias Fountain.Workers.AutonomousTurnReaper
+
+  setup :set_mimic_global
+
+  defp minutes_ago(minutes) do
+    DateTime.utc_now()
+    |> DateTime.add(-minutes * 60, :second)
+    |> DateTime.truncate(:second)
+  end
+
+  defp running_turn(minutes \\ 45, overrides \\ %{}) do
+    user = insert_verified_user()
+    sandbox = insert_sandbox(user_id: user.id, status: "ready")
+    conv = insert_conversation(user_id: user.id, sandbox: sandbox, status: "running")
+
+    turn =
+      insert_turn(
+        conv,
+        Map.merge(
+          %{status: "running", origin: "autonomous", started_at: minutes_ago(minutes)},
+          overrides
+        )
+      )
+
+    {user, conv, turn}
+  end
+
+  defp no_live_servers do
+    stub(Fountain.Conversations.ConversationServer, :whereis, fn _ -> nil end)
+  end
+
+  test "reaps an old silent turn with no live server" do
+    {user, conv, turn} = running_turn()
+    no_live_servers()
+
+    Phoenix.PubSub.subscribe(Fountain.PubSub, "conv:#{conv.id}")
+
+    capture_log(fn -> assert 1 = AutonomousTurnReaper.sweep_stuck_turns() end)
+
+    reloaded = Repo.reload(turn)
+    assert reloaded.status == "interrupted"
+    assert %DateTime{} = reloaded.ended_at
+    assert %DateTime{} = reloaded.orphaned_at
+    assert Repo.reload(conv).status == "idle"
+
+    assert_receive {:log_event, %{stage: "reattach", state: "interrupted"} = event}
+    assert Jason.decode!(event.data)["reason"] == "stuck_running_no_server"
+
+    assert Enum.any?(Audit.list_recent_for_user(user.id), fn event ->
+             event.action == "conversation.turn.orphaned" and
+               event.actor == "system:autonomous_turn_reaper" and
+               event.resource_id == turn.id
+           end)
+  end
+
+  test "leaves a turn with a live server alone" do
+    {_user, conv, turn} = running_turn(120)
+
+    stub(Fountain.Conversations.ConversationServer, :whereis, fn id ->
+      if id == conv.id, do: self()
+    end)
+
+    assert 0 = AutonomousTurnReaper.sweep_stuck_turns()
+    assert Repo.reload(turn).status == "running"
+  end
+
+  test "leaves recent and recently-active turns alone" do
+    {_user, recent_conv, recent_turn} = running_turn(5)
+    {_user, active_conv, active_turn} = running_turn(60)
+
+    insert_log_event(active_conv, %{turn_id: active_turn.id, inserted_at: minutes_ago(5)})
+    no_live_servers()
+
+    assert 0 = AutonomousTurnReaper.sweep_stuck_turns()
+    assert Repo.reload(recent_turn).status == "running"
+    assert Repo.reload(active_turn).status == "running"
+    assert Repo.reload(recent_conv).status == "running"
+  end
+
+  test "leaves a turn waiting on a person's permission alone" do
+    {_user, _conv, turn} =
+      running_turn(120, %{
+        pending_permission: %{"request_id" => 42, "tool" => "shell", "options" => []}
+      })
+
+    no_live_servers()
+
+    assert 0 = AutonomousTurnReaper.sweep_stuck_turns()
+    assert Repo.reload(turn).status == "running"
+  end
+
+  test "does not resurrect a terminated conversation" do
+    {_user, conv, turn} = running_turn()
+    {:ok, _} = Conversations.update_conversation(conv, %{status: "terminated"})
+    no_live_servers()
+
+    assert 1 = AutonomousTurnReaper.sweep_stuck_turns()
+    assert Repo.reload(turn).status == "interrupted"
+    assert Repo.reload(conv).status == "terminated"
+  end
+
+  test "a concurrent turn ending wins over orphan reconciliation" do
+    {user, conv, stale_turn} = running_turn()
+
+    {:ok, completed} =
+      Conversations._unsafe_update_turn(stale_turn, %{
+        status: "completed",
+        ended_at: minutes_ago(1)
+      })
+
+    assert :noop = Conversations._unsafe_orphan_turn(stale_turn, "stale_candidate")
+    assert Repo.reload(completed).status == "completed"
+    assert Repo.reload(completed).orphaned_at == nil
+    assert Repo.reload(conv).status == "running"
+
+    refute Enum.any?(Audit.list_recent_for_user(user.id), fn event ->
+             event.action == "conversation.turn.orphaned"
+           end)
+  end
+
+  describe "ConversationServer.terminate/2" do
+    test "a normal stop reconciles the turn its in-memory timer can no longer close" do
+      {_user, conv, turn} = running_turn()
+
+      assert :ok =
+               ConversationServer.terminate(:normal, %{
+                 conversation_id: conv.id,
+                 callback_api_key_id: nil,
+                 current_turn: turn
+               })
+
+      assert Repo.reload(turn).status == "interrupted"
+      assert Repo.reload(turn).orphaned_at
+      assert Repo.reload(conv).status == "idle"
+    end
+
+    test "a supervisor shutdown leaves the turn available for reattach" do
+      {_user, conv, turn} = running_turn()
+
+      assert :ok =
+               ConversationServer.terminate(:shutdown, %{
+                 conversation_id: conv.id,
+                 callback_api_key_id: nil,
+                 current_turn: turn
+               })
+
+      assert Repo.reload(turn).status == "running"
+      assert Repo.reload(turn).orphaned_at == nil
+      assert Repo.reload(conv).status == "running"
+    end
+  end
+
+  test "caps each sweep at 25 and takes the oldest candidates first" do
+    user = insert_verified_user()
+    sandbox = insert_sandbox(user_id: user.id, status: "ready")
+    conv = insert_conversation(user_id: user.id, sandbox: sandbox, status: "running")
+
+    turns =
+      for n <- 1..30 do
+        insert_turn(conv, %{
+          status: "running",
+          origin: "autonomous",
+          turn_number: n,
+          started_at: minutes_ago(45 + n)
+        })
+      end
+
+    expected = turns |> Enum.sort_by(& &1.started_at) |> Enum.take(25) |> MapSet.new(& &1.id)
+    no_live_servers()
+
+    capture_log(fn -> assert 25 = AutonomousTurnReaper.sweep_stuck_turns() end)
+
+    reaped =
+      turns
+      |> Enum.map(&Repo.reload/1)
+      |> Enum.filter(&(&1.status == "interrupted"))
+      |> MapSet.new(& &1.id)
+
+    assert reaped == expected
+  end
+
+  test "is scheduled every five minutes" do
+    crontab =
+      Application.fetch_env!(:fountain, Oban)
+      |> Keyword.fetch!(:plugins)
+      |> Enum.find_value(fn
+        {Oban.Plugins.Cron, opts} -> Keyword.fetch!(opts, :crontab)
+        _ -> nil
+      end)
+
+    assert {"*/5 * * * *", AutonomousTurnReaper} in crontab
+  end
+end

--- a/config/config.exs
+++ b/config/config.exs
@@ -25,6 +25,9 @@ config :fountain, Oban,
        # matters. Each run is one paginated list plus at most a handful of
        # deletes.
        {"7 * * * *", Fountain.Workers.SandboxReaper},
+       # A server's autonomous quiet timer is in memory. Sweep old, silent
+       # running turns whose server disappeared before that timer fired.
+       {"*/5 * * * *", Fountain.Workers.AutonomousTurnReaper},
        # 05:41 UTC — after the 03:17 backup and the 04:23 retention prune, so
        # a backup always captures the accounts before the sweep removes them.
        {"41 5 * * *", Fountain.Workers.UnverifiedAccountPruner},

--- a/ee/lib/fountain/billing/sandbox_usage.ex
+++ b/ee/lib/fountain/billing/sandbox_usage.ex
@@ -424,6 +424,7 @@ defmodule Fountain.Billing.SandboxUsage do
         on: c.id == t.conversation_id,
         where: c.sandbox_id in ^ids,
         where: not is_nil(t.started_at),
+        where: is_nil(t.orphaned_at),
         where: t.started_at < ^ceiling,
         where: is_nil(t.ended_at) or t.ended_at >= ^period_start,
         select: %{sandbox_id: c.sandbox_id, started_at: t.started_at, ended_at: t.ended_at}

--- a/ee/lib/fountain/workers/credit_pricer.ex
+++ b/ee/lib/fountain/workers/credit_pricer.ex
@@ -155,6 +155,7 @@ defmodule Fountain.Workers.CreditPricer do
       on: l.idempotency_key == fragment("'burn_turn:' || ?::text", t.id),
       where: is_nil(l.id),
       where: not is_nil(t.started_at) and not is_nil(t.ended_at),
+      where: is_nil(t.orphaned_at),
       where: t.ended_at >= ^floor,
       where: s.provider in ^providers,
       where: not is_nil(c.user_id),

--- a/ee/test/fountain/billing_sandbox_usage_test.exs
+++ b/ee/test/fountain/billing_sandbox_usage_test.exs
@@ -280,21 +280,26 @@ defmodule Fountain.Billing.SandboxUsageTest do
     # A sandbox nobody is prompting still costs full price, so it stays in
     # active. Reporting it separately is what says whether the bill is
     # avoidable.
-    defp turn(sandbox, user, started_at, ended_at) do
+    defp turn(sandbox, user, started_at, ended_at, overrides \\ %{}) do
       agent = insert_agent(user_id: user.id)
 
       conversation =
         insert_conversation(user_id: user.id, agent_id: agent.id, sandbox: sandbox)
 
-      {:ok, _} =
-        Conversations._unsafe_create_turn(%{
-          conversation_id: conversation.id,
-          turn_number: System.unique_integer([:positive]),
-          prompt: "hello",
-          status: "completed",
-          started_at: started_at,
-          ended_at: ended_at
-        })
+      attrs =
+        Map.merge(
+          %{
+            conversation_id: conversation.id,
+            turn_number: System.unique_integer([:positive]),
+            prompt: "hello",
+            status: "completed",
+            started_at: started_at,
+            ended_at: ended_at
+          },
+          overrides
+        )
+
+      {:ok, _} = Conversations._unsafe_create_turn(attrs)
     end
 
     test "an hour with a ten-minute turn is fifty minutes idle" do
@@ -309,6 +314,26 @@ defmodule Fountain.Billing.SandboxUsageTest do
       assert row.active_seconds == 3600
       assert row.busy_seconds == 600
       assert row.idle_seconds == 3000
+    end
+
+    test "orphaned turns are excluded from busy and turn time" do
+      user = insert_verified_user()
+
+      sandbox =
+        terminated_sandbox(user, "sprites", ~U[2026-05-10 12:00:00Z], ~U[2026-05-10 13:00:00Z])
+
+      turn(
+        sandbox,
+        user,
+        ~U[2026-05-10 12:00:00Z],
+        ~U[2026-05-10 13:00:00Z],
+        %{status: "interrupted", orphaned_at: ~U[2026-05-10 13:00:00Z]}
+      )
+
+      assert [row] = attribution()
+      assert row.busy_seconds == 0
+      assert row.turn_seconds == 0
+      assert row.idle_seconds == row.active_seconds
     end
 
     test "a sandbox that never took a turn is entirely idle" do

--- a/ee/test/fountain/workers/credit_pricer_test.exs
+++ b/ee/test/fountain/workers/credit_pricer_test.exs
@@ -62,6 +62,21 @@ defmodule Fountain.Workers.CreditPricerTest do
     assert Credits.balance(user.id) == 0
   end
 
+  test "an orphaned turn is not priced" do
+    user = insert_empty_user()
+    conv = setup_conv(user)
+
+    insert_turn(conv, %{
+      status: "interrupted",
+      started_at: ~U[2026-08-02 10:00:00Z],
+      ended_at: ~U[2026-08-02 14:00:00Z],
+      orphaned_at: ~U[2026-08-02 14:00:00Z]
+    })
+
+    assert %{turns: 0} = CreditPricer.run(since: @since, now: @now)
+    assert Credits.list_entries(user.id) == []
+  end
+
   test "a turn that rounds to zero cents writes nothing and is not an error" do
     user = insert_empty_user()
     conv = setup_conv(user)


### PR DESCRIPTION
## Summary

- reconcile a still-running turn when its ConversationServer stops normally, while preserving supervisor shutdown and crash reattachment
- add a durable Oban sweep for old, quiet turns with no live server, skipping recent activity and pending permissions
- make orphan reconciliation compare-and-set safe, preserve terminal conversation state, emit lifecycle and audit events, and cap each sweep at 25
- record orphaned intervals explicitly and exclude them from credit pricing and sandbox usage attribution
- add concurrent indexing and coverage for liveness, races, termination semantics, scheduling, billing, and usage

## Credit and replacement for #1252

The original diagnosis and implementation were by @geekyNads in #1252. This is a rewrite rather than a rebase because the conversation/runtime lifecycle and billing paths underwent a major refactor after that branch diverged. It retains the core terminate-hook and durable-reaper design from #1252 while incorporating the review feedback around shutdown recovery, durable liveness, pending permissions, compare-and-set writes, billing, auditability, bounded sweeps, and concurrent migrations.

The largest observed source of orphaned turns has also since been fixed in #1300: out-of-turn title updates accounted for 88% of sampled autonomous turns. This PR is the durable backstop for genuine server-loss cases that remain possible.

Supersedes #1252.
Closes #1197.

## Validation

- mix precommit
- 6 doctests and 4,169 tests, 0 failures
- formatting, compilation with warnings as errors, Credo, Dialyzer, and Sobelow all pass