### PR TITLE
fix(buzz): make harness teardown deterministic

### DIFF
--- a/apps/fountain/lib/fountain/buzz/harness.ex
+++ b/apps/fountain/lib/fountain/buzz/harness.ex
@@ -31,6 +31,8 @@ defmodule Fountain.Buzz.Harness do
   require Logger
 
   @default_backoff_ms 1_000
+  @launcher_shutdown_timeout_ms 6_000
+  @launcher_shutdown_poll_ms 10
   # Line-frame buzz-acp's output at the port so a single log line is bounded and
   # a chatty process cannot deliver one unbounded binary.
   @max_line 4_096
@@ -143,7 +145,7 @@ defmodule Fountain.Buzz.Harness do
 
   @impl true
   def terminate(_reason, state) do
-    close(state.port)
+    close(state.port, state.launcher)
     run_on_stop(state.on_stop)
     :ok
   end
@@ -179,18 +181,70 @@ defmodule Fountain.Buzz.Harness do
   defp spawn_argv(%{launcher: launcher, shell: shell} = state),
     do: {shell, [launcher, state.command | state.args]}
 
-  defp close(nil), do: :ok
+  defp close(nil, _launcher), do: :ok
+
+  defp close(port, nil) do
+    close_port(port)
+  end
 
   # Closing the port EOFs the launcher's held pipe, which TERMs buzz-acp (and,
   # if it will not go, KILLs it) and reaps its `fountain acp` child — see
-  # priv/buzz-acp-launch.sh. Without the launcher this only closes the pipe and
-  # a bare buzz-acp would be orphaned.
-  defp close(port) do
-    Port.close(port)
+  # priv/buzz-acp-launch.sh. Port.close/1 returns before the launcher OS process
+  # necessarily exits, so wait for that process too: callers rely on a completed
+  # Harness shutdown meaning its executable and other launch resources are no
+  # longer in use (#1469). Without the launcher this only closes the pipe and a
+  # bare buzz-acp would be orphaned.
+  defp close(port, _launcher) do
+    launcher_pid = port_os_pid(port)
+    close_port(port)
+    await_launcher_exit(launcher_pid)
     :ok
+  end
+
+  defp close_port(port) do
+    Port.close(port)
   rescue
     # Port already closed between the exit frame and here.
     ArgumentError -> :ok
+  end
+
+  defp port_os_pid(port) do
+    case Port.info(port, :os_pid) do
+      {:os_pid, os_pid} -> os_pid
+      nil -> nil
+    end
+  rescue
+    ArgumentError -> nil
+  end
+
+  defp await_launcher_exit(nil), do: :ok
+
+  defp await_launcher_exit(os_pid) do
+    deadline = System.monotonic_time(:millisecond) + @launcher_shutdown_timeout_ms
+    do_await_launcher_exit(os_pid, deadline)
+  end
+
+  defp do_await_launcher_exit(os_pid, deadline) do
+    cond do
+      not os_process_alive?(os_pid) ->
+        :ok
+
+      System.monotonic_time(:millisecond) >= deadline ->
+        Logger.warning("buzz-acp launcher did not exit after shutdown: os_pid=#{os_pid}")
+
+      true ->
+        Process.sleep(@launcher_shutdown_poll_ms)
+        do_await_launcher_exit(os_pid, deadline)
+    end
+  end
+
+  defp os_process_alive?(os_pid) do
+    match?(
+      {_, 0},
+      System.cmd("kill", ["-0", Integer.to_string(os_pid)], stderr_to_stdout: true)
+    )
+  rescue
+    ErlangError -> false
   end
 
   defp run_on_stop(nil), do: :ok

--- a/apps/fountain/lib/fountain/buzz/harness.ex
+++ b/apps/fountain/lib/fountain/buzz/harness.ex
@@ -262,7 +262,13 @@ defmodule Fountain.Buzz.Harness do
   # `:enoent` there. The rescue below would read that as "already exited" and
   # skip the wait entirely, in prod only: macOS and the CI runner both have the
   # binary, so every test would still pass. priv/buzz-acp-launch.sh checks the
-  # same way for the same reason. `os_pid` is an integer from `Port.info/2`.
+  # same way for the same reason.
+  #
+  # sobelow_skip ["CI.System"] — nothing here is reachable by a tenant. `shell`
+  # is the harness's own `:shell` option, which no caller sets and which
+  # defaults to "/bin/sh"; `os_pid` is an integer from `Port.info/2`, so the
+  # interpolation cannot carry a shell metacharacter. The `-c` string is a
+  # literal otherwise.
   defp os_process_alive?(os_pid, shell) do
     match?({_, 0}, System.cmd(shell, ["-c", "kill -0 #{os_pid} 2>/dev/null"]))
   rescue

--- a/apps/fountain/lib/fountain/buzz/harness.ex
+++ b/apps/fountain/lib/fountain/buzz/harness.ex
@@ -31,8 +31,17 @@ defmodule Fountain.Buzz.Harness do
   require Logger
 
   @default_backoff_ms 1_000
+  # priv/buzz-acp-launch.sh TERMs buzz-acp and gives it five seconds before
+  # SIGKILL, so six is one second past the worst case the launcher can produce.
+  # It has to stay well under the supervisor's `shutdown: 10_000` (manager.ex),
+  # which is why `terminate/2` revokes the key before it spends any of this.
   @launcher_shutdown_timeout_ms 6_000
-  @launcher_shutdown_poll_ms 10
+  # Back the poll off rather than firing every 10ms: each check forks a shell,
+  # and a node draining its harnesses on a rolling deploy would otherwise spend
+  # hundreds of spawns per hung launcher at the worst possible moment. The
+  # common case — a launcher already gone — is caught before the first sleep.
+  @launcher_poll_start_ms 1
+  @launcher_poll_max_ms 50
   # Line-frame buzz-acp's output at the port so a single log line is bounded and
   # a chatty process cannot deliver one unbounded binary.
   @max_line 4_096
@@ -143,10 +152,16 @@ defmodule Fountain.Buzz.Harness do
 
   def handle_info(_msg, state), do: {:noreply, state}
 
+  # Revoke first, close second. `close/3` can wait seconds on a launcher that is
+  # slow to go, and all of this runs under the supervisor's `shutdown: 10_000`:
+  # with the wait first, a hung launcher plus a slow database would leave the
+  # revoke unfinished at `:brutal_kill` and leak this launch's API key — the one
+  # thing `on_stop` exists to prevent. Nothing in `on_stop` needs the OS process
+  # to be gone, so the order costs nothing.
   @impl true
   def terminate(_reason, state) do
-    close(state.port, state.launcher)
     run_on_stop(state.on_stop)
+    close(state.port, state.launcher, state.shell)
     :ok
   end
 
@@ -181,9 +196,9 @@ defmodule Fountain.Buzz.Harness do
   defp spawn_argv(%{launcher: launcher, shell: shell} = state),
     do: {shell, [launcher, state.command | state.args]}
 
-  defp close(nil, _launcher), do: :ok
+  defp close(nil, _launcher, _shell), do: :ok
 
-  defp close(port, nil) do
+  defp close(port, nil, _shell) do
     close_port(port)
   end
 
@@ -194,10 +209,10 @@ defmodule Fountain.Buzz.Harness do
   # Harness shutdown meaning its executable and other launch resources are no
   # longer in use (#1469). Without the launcher this only closes the pipe and a
   # bare buzz-acp would be orphaned.
-  defp close(port, _launcher) do
+  defp close(port, _launcher, shell) do
     launcher_pid = port_os_pid(port)
     close_port(port)
-    await_launcher_exit(launcher_pid)
+    await_launcher_exit(launcher_pid, shell)
     :ok
   end
 
@@ -217,32 +232,39 @@ defmodule Fountain.Buzz.Harness do
     ArgumentError -> nil
   end
 
-  defp await_launcher_exit(nil), do: :ok
+  defp await_launcher_exit(nil, _shell), do: :ok
 
-  defp await_launcher_exit(os_pid) do
+  defp await_launcher_exit(os_pid, shell) do
     deadline = System.monotonic_time(:millisecond) + @launcher_shutdown_timeout_ms
-    do_await_launcher_exit(os_pid, deadline)
+    do_await_launcher_exit(os_pid, shell, deadline, @launcher_poll_start_ms)
   end
 
-  defp do_await_launcher_exit(os_pid, deadline) do
+  defp do_await_launcher_exit(os_pid, shell, deadline, poll_ms) do
     cond do
-      not os_process_alive?(os_pid) ->
+      not os_process_alive?(os_pid, shell) ->
         :ok
 
       System.monotonic_time(:millisecond) >= deadline ->
         Logger.warning("buzz-acp launcher did not exit after shutdown: os_pid=#{os_pid}")
 
       true ->
-        Process.sleep(@launcher_shutdown_poll_ms)
-        do_await_launcher_exit(os_pid, deadline)
+        Process.sleep(poll_ms)
+        next = min(poll_ms * 2, @launcher_poll_max_ms)
+        do_await_launcher_exit(os_pid, shell, deadline, next)
     end
   end
 
-  defp os_process_alive?(os_pid) do
-    match?(
-      {_, 0},
-      System.cmd("kill", ["-0", Integer.to_string(os_pid)], stderr_to_stdout: true)
-    )
+  # `kill -0` through the shell, because it has to be the shell's builtin.
+  # `System.cmd/3` resolves an executable with `:os.find_executable/1` and never
+  # goes through a shell, and the runtime image — debian:trixie-slim plus
+  # libstdc++6, openssl, libncurses6, locales, ca-certificates and tini, see the
+  # Dockerfile — ships no /bin/kill, so spawning "kill" directly raises
+  # `:enoent` there. The rescue below would read that as "already exited" and
+  # skip the wait entirely, in prod only: macOS and the CI runner both have the
+  # binary, so every test would still pass. priv/buzz-acp-launch.sh checks the
+  # same way for the same reason. `os_pid` is an integer from `Port.info/2`.
+  defp os_process_alive?(os_pid, shell) do
+    match?({_, 0}, System.cmd(shell, ["-c", "kill -0 #{os_pid} 2>/dev/null"]))
   rescue
     ErlangError -> false
   end

--- a/apps/fountain/lib/fountain/buzz/manager.ex
+++ b/apps/fountain/lib/fountain/buzz/manager.ex
@@ -109,6 +109,12 @@ defmodule Fountain.Buzz.Manager do
   @doc """
   Stop the harness for `identity_id` if one is running. The harness's own
   `terminate` revokes its launch key. Returns `:ok` whether or not one was found.
+
+  Synchronous, and it waits for the launcher OS process to exit so a completed
+  stop means the launch's executable and pipes are free (#1469). A buzz-acp that
+  handles SIGTERM goes in milliseconds; one that ignores it costs the launcher's
+  five-second grace, capped at `Harness`'s six. Callers on a request path — the
+  buzz-agent create, update and delete endpoints — pay that tail.
   """
   def stop_harness(identity_id) do
     case whereis(identity_id) do

--- a/apps/fountain/test/fountain/buzz/boot_sweep_test.exs
+++ b/apps/fountain/test/fountain/buzz/boot_sweep_test.exs
@@ -8,7 +8,7 @@ defmodule Fountain.Buzz.BootSweepTest do
   setup do
     dir = Fountain.TmpDir.mkdir!("buzz-sweep")
     fake = Path.join(dir, "buzz-acp")
-    File.write!(fake, "#!/bin/sh\nsleep 30\n")
+    File.write!(fake, "#!/bin/sh\nexec sleep 30\n")
     File.chmod!(fake, 0o755)
 
     prev_path = Application.get_env(:fountain, :buzz_acp_path)
@@ -18,10 +18,7 @@ defmodule Fountain.Buzz.BootSweepTest do
       restore(:buzz_acp_path, prev_path)
       restore(:buzz_acp_base_url, prev_url)
 
-      for {_, pid, _, _} <- Horde.DynamicSupervisor.which_children(Fountain.BuzzSupervisor),
-          is_pid(pid) do
-        Horde.DynamicSupervisor.terminate_child(Fountain.BuzzSupervisor, pid)
-      end
+      Fountain.BuzzTestSupport.stop_all_harnesses!()
 
       File.rm_rf(dir)
     end)
@@ -56,12 +53,7 @@ defmodule Fountain.Buzz.BootSweepTest do
     refute Manager.running?(disabled.id)
   end
 
-  test "run is idempotent — a second sweep does not double-start" do
-    fake = Fountain.TmpDir.path("buzz-acp")
-    File.write!(fake, "#!/bin/sh\nsleep 30\n")
-    File.chmod!(fake, 0o755)
-    on_exit(fn -> File.rm(fake) end)
-
+  test "run is idempotent — a second sweep does not double-start", %{fake: fake} do
     Application.put_env(:fountain, :buzz_acp_path, fake)
     Application.put_env(:fountain, :buzz_acp_base_url, "https://fountain.test")
 

--- a/apps/fountain/test/fountain/buzz/harness_test.exs
+++ b/apps/fountain/test/fountain/buzz/harness_test.exs
@@ -36,7 +36,9 @@ defmodule Fountain.Buzz.HarnessTest do
 
   test "opens the port with the given env and stays running", %{dir: dir} do
     marker = Path.join(dir, "marker")
-    cmd = write_fake(dir, "buzz-acp", "printf '%s' \"$BUZZ_RELAY_URL\" > #{marker}\nsleep 30\n")
+
+    cmd =
+      write_fake(dir, "buzz-acp", "printf '%s' \"$BUZZ_RELAY_URL\" > #{marker}\nexec sleep 30\n")
 
     pid = start(command: cmd, env: [{"BUZZ_RELAY_URL", "wss://relay.example"}], label: "t")
 
@@ -64,7 +66,7 @@ defmodule Fountain.Buzz.HarnessTest do
   # still-live process. Through the launcher the port stays open, so no restart.
   test "does NOT restart when the child merely closes its stdio", %{dir: dir} do
     # Close stdin/stdout/stderr toward the port, then keep running.
-    cmd = write_fake(dir, "buzz-acp", "exec 0<&- 1>&- 2>&-\nsleep 30\n")
+    cmd = write_fake(dir, "buzz-acp", "exec 0<&- 1>&- 2>&-\nexec sleep 30\n")
 
     pid = start(command: cmd, restart_backoff_ms: 20, label: "t")
 
@@ -98,10 +100,30 @@ defmodule Fountain.Buzz.HarnessTest do
     assert reaped, "child OS process #{child} survived shutdown (leaked)"
   end
 
+  test "shutdown waits for the launcher OS process to exit", %{dir: dir} do
+    launcher =
+      write_fake(dir, "slow-launcher", "exec 3<&0\ncat <&3 >/dev/null\nexec sleep 0.2\n")
+
+    cmd = write_fake(dir, "buzz-acp", "exit 0\n")
+    pid = start(command: cmd, launcher: launcher, label: "t")
+    {:os_pid, launcher_pid} = pid |> :sys.get_state() |> Map.fetch!(:port) |> Port.info(:os_pid)
+
+    :ok = stop_supervised(Harness)
+
+    refute alive?(launcher_pid), "launcher OS process #{launcher_pid} survived shutdown"
+  end
+
   test "surfaces buzz-acp output on the Logger, tagged with the label", %{dir: dir} do
     import ExUnit.CaptureLog
 
-    cmd = write_fake(dir, "buzz-acp", "echo 'connected to relay'\nsleep 30\n")
+    marker = Path.join(dir, "logged")
+
+    cmd =
+      write_fake(
+        dir,
+        "buzz-acp",
+        "echo 'connected to relay'\necho ready > #{marker}\nexec sleep 30\n"
+      )
 
     # Test config filters :info at the primary level; prod logs at :info. Lower
     # the level for this test so the info line is dispatched to the capture.
@@ -111,8 +133,10 @@ defmodule Fountain.Buzz.HarnessTest do
 
     log =
       capture_log(fn ->
-        start(command: cmd, label: "philo-xyz")
-        Process.sleep(400)
+        pid = start(command: cmd, label: "philo-xyz")
+        wait_until(fn -> File.exists?(marker) end)
+        _ = :sys.get_state(pid)
+        Logger.flush()
       end)
 
     assert log =~ "[buzz-acp philo-xyz]"
@@ -148,7 +172,7 @@ defmodule Fountain.Buzz.HarnessTest do
   end
 
   test "a :normal linked exit is ignored — the harness keeps running", %{dir: dir} do
-    cmd = write_fake(dir, "buzz-acp", "sleep 30\n")
+    cmd = write_fake(dir, "buzz-acp", "exec sleep 30\n")
     pid = start(command: cmd, label: "t")
     # What a linked helper that exits normally would deliver to a trapping process.
     send(pid, {:EXIT, self(), :normal})
@@ -157,7 +181,7 @@ defmodule Fountain.Buzz.HarnessTest do
   end
 
   test "runs the on_stop callback on shutdown", %{dir: dir} do
-    cmd = write_fake(dir, "buzz-acp", "sleep 30\n")
+    cmd = write_fake(dir, "buzz-acp", "exec sleep 30\n")
     test_pid = self()
 
     start(command: cmd, label: "t", on_stop: fn -> send(test_pid, :stopped) end)
@@ -165,7 +189,7 @@ defmodule Fountain.Buzz.HarnessTest do
     assert_receive :stopped, 2_000
   end
 
-  defp wait_until(fun, tries \\ 200)
+  defp wait_until(fun, tries \\ 1_000)
   defp wait_until(_fun, 0), do: flunk("condition not met in time")
 
   defp wait_until(fun, tries) do

--- a/apps/fountain/test/fountain/buzz/harness_test.exs
+++ b/apps/fountain/test/fountain/buzz/harness_test.exs
@@ -1,3 +1,22 @@
+defmodule Fountain.Buzz.HarnessTest.LogSink do
+  @moduledoc false
+  # A :logger handler that forwards every event to a test process. :logger calls
+  # `log/2` in the process that logged, so receiving the message is proof the
+  # harness reached the Logger — the ordering a marker file cannot give.
+
+  def log(%{msg: msg}, %{config: %{pid: pid}}) do
+    send(pid, {:log_line, flatten(msg)})
+    :ok
+  end
+
+  defp flatten({:string, chardata}), do: IO.chardata_to_string(chardata)
+  defp flatten({:report, report}), do: inspect(report)
+
+  defp flatten({format, args}) do
+    format |> :io_lib.format(args) |> IO.chardata_to_string()
+  end
+end
+
 defmodule Fountain.Buzz.HarnessTest do
   # async: false — writes fake executables and spawns OS processes.
   use ExUnit.Case, async: false
@@ -100,7 +119,27 @@ defmodule Fountain.Buzz.HarnessTest do
     assert reaped, "child OS process #{child} survived shutdown (leaked)"
   end
 
-  test "shutdown waits for the launcher OS process to exit", %{dir: dir} do
+  # Under a PATH with no `kill` on it, which is what the runtime image is: it is
+  # debian:trixie-slim plus six packages (Dockerfile), and none of them ship
+  # /bin/kill — `kill` there is only the shell's builtin. `System.cmd/3`
+  # resolves an executable with `:os.find_executable/1` and never through a
+  # shell, so a liveness probe that spawns "kill" raises :enoent in production,
+  # gets read as "the launcher already exited", and skips this wait — while
+  # passing on macOS and the CI runner, which both have the binary. Restricting
+  # PATH is how that image is reachable from here. `cat` and `sleep` are on it
+  # because the fake launcher below needs them, and `sh` because `alive?/1`
+  # does; `kill` is left off deliberately.
+  test "shutdown waits for the launcher OS process to exit, with no `kill` on PATH",
+       %{dir: dir} do
+    bin = Path.join(dir, "bin")
+    File.mkdir_p!(bin)
+
+    for tool <- ~w(sh cat sleep) do
+      File.ln_s!(System.find_executable(tool), Path.join(bin, tool))
+    end
+
+    refute File.exists?(Path.join(bin, "kill")), "the point of this test is that kill is absent"
+
     launcher =
       write_fake(dir, "slow-launcher", "exec 3<&0\ncat <&3 >/dev/null\nexec sleep 0.2\n")
 
@@ -108,7 +147,15 @@ defmodule Fountain.Buzz.HarnessTest do
     pid = start(command: cmd, launcher: launcher, label: "t")
     {:os_pid, launcher_pid} = pid |> :sys.get_state() |> Map.fetch!(:port) |> Port.info(:os_pid)
 
-    :ok = stop_supervised(Harness)
+    prev_path = System.get_env("PATH")
+    on_exit(fn -> System.put_env("PATH", prev_path) end)
+    System.put_env("PATH", bin)
+
+    try do
+      :ok = stop_supervised(Harness)
+    after
+      System.put_env("PATH", prev_path)
+    end
 
     refute alive?(launcher_pid), "launcher OS process #{launcher_pid} survived shutdown"
   end
@@ -116,31 +163,55 @@ defmodule Fountain.Buzz.HarnessTest do
   test "surfaces buzz-acp output on the Logger, tagged with the label", %{dir: dir} do
     import ExUnit.CaptureLog
 
-    marker = Path.join(dir, "logged")
-
-    cmd =
-      write_fake(
-        dir,
-        "buzz-acp",
-        "echo 'connected to relay'\necho ready > #{marker}\nexec sleep 30\n"
-      )
+    cmd = write_fake(dir, "buzz-acp", "echo 'connected to relay'\nexec sleep 30\n")
 
     # Test config filters :info at the primary level; prod logs at :info. Lower
-    # the level for this test so the info line is dispatched to the capture.
+    # the level for this test so the info line is dispatched at all.
     prev = Logger.level()
     Logger.configure(level: :info)
-    on_exit(fn -> Logger.configure(level: prev) end)
 
-    log =
-      capture_log(fn ->
-        pid = start(command: cmd, label: "philo-xyz")
-        wait_until(fn -> File.exists?(marker) end)
-        _ = :sys.get_state(pid)
-        Logger.flush()
-      end)
+    # Wait on the log event itself, not on a side effect of the fake. The fake's
+    # `echo` returning only proves its write(2) into the pipe returned; the
+    # emulator's port reader then delivers {:data, {:eol, _}} to the harness
+    # asynchronously, and nothing orders that against this process. A marker
+    # file races exactly the same way the 400ms sleep this replaced did, only
+    # faster, and `:sys.get_state/1` flushes a mailbox the line may not have
+    # reached yet (#1469).
+    handler = :"harness_log_#{System.unique_integer([:positive])}"
+    sink = Fountain.Buzz.HarnessTest.LogSink
+    :ok = :logger.add_handler(handler, sink, %{level: :info, config: %{pid: self()}})
 
-    assert log =~ "[buzz-acp philo-xyz]"
-    assert log =~ "connected to relay"
+    on_exit(fn ->
+      _ = :logger.remove_handler(handler)
+      Logger.configure(level: prev)
+    end)
+
+    # capture_log only to keep the line out of the test output; the assertion is
+    # on what the handler delivered.
+    capture_log(fn ->
+      start(command: cmd, label: "philo-xyz")
+      assert await_log_line("[buzz-acp philo-xyz]") =~ "connected to relay"
+    end)
+  end
+
+  # The harness logs its own lines too, so take the first *match* rather than the
+  # first message. On a deadline, so a stream of non-matching lines cannot keep
+  # extending the wait.
+  defp await_log_line(substring, timeout \\ 5_000) do
+    do_await_log_line(substring, System.monotonic_time(:millisecond) + timeout)
+  end
+
+  defp do_await_log_line(substring, deadline) do
+    left = deadline - System.monotonic_time(:millisecond)
+
+    receive do
+      {:log_line, line} ->
+        if String.contains?(line, substring),
+          do: line,
+          else: do_await_log_line(substring, deadline)
+    after
+      max(left, 0) -> flunk("no log line containing #{inspect(substring)}")
+    end
   end
 
   # 2026-08-17: two pods ran the boot sweep before the cluster formed, both

--- a/apps/fountain/test/fountain/buzz/manager_test.exs
+++ b/apps/fountain/test/fountain/buzz/manager_test.exs
@@ -13,16 +13,13 @@ defmodule Fountain.Buzz.ManagerTest do
   setup do
     dir = Fountain.TmpDir.mkdir!("buzz-mgr")
     fake = Path.join(dir, "buzz-acp")
-    File.write!(fake, "#!/bin/sh\nsleep 30\n")
+    File.write!(fake, "#!/bin/sh\nexec sleep 30\n")
     File.chmod!(fake, 0o755)
 
     on_exit(fn ->
       # Tear down every harness this test left running (no prod harnesses exist
       # under this supervisor in the test node) before the tmp dir goes away.
-      for {_, pid, _, _} <- Horde.DynamicSupervisor.which_children(Fountain.BuzzSupervisor),
-          is_pid(pid) do
-        Horde.DynamicSupervisor.terminate_child(Fountain.BuzzSupervisor, pid)
-      end
+      Fountain.BuzzTestSupport.stop_all_harnesses!()
 
       File.rm_rf(dir)
     end)
@@ -166,7 +163,12 @@ defmodule Fountain.Buzz.ManagerTest do
       dir = Path.dirname(fake)
       old = Path.join(dir, "old-launch.sh")
       new = Path.join(dir, "new-launch.sh")
-      for l <- [old, new], do: File.write!(l, "#!/bin/sh\nexec \"$@\"\n") && File.chmod!(l, 0o755)
+      real_launcher = Application.app_dir(:fountain, "priv/buzz-acp-launch.sh")
+
+      for launcher <- [old, new] do
+        File.write!(launcher, "#!/bin/sh\nexec \"#{real_launcher}\" \"$@\"\n")
+        File.chmod!(launcher, 0o755)
+      end
 
       Application.put_env(:fountain, :buzz_acp_launcher, old)
       on_exit(fn -> Application.delete_env(:fountain, :buzz_acp_launcher) end)

--- a/apps/fountain/test/fountain_web/controllers/buzz_agent_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/buzz_agent_controller_test.exs
@@ -1,5 +1,7 @@
 defmodule FountainWeb.BuzzAgentControllerTest do
-  use FountainWeb.ConnCase, async: true
+  # Every provision request calls Manager.start_harness/1 under the global
+  # Horde supervisor, even when start_harness_link/2 later rejects the launch.
+  use FountainWeb.ConnCase, async: false
 
   alias Fountain.{Crypto, Vaults}
 
@@ -7,6 +9,9 @@ defmodule FountainWeb.BuzzAgentControllerTest do
     user = insert_verified_user()
     {_rec, raw_key} = insert_api_key(user)
     agent = insert_agent(user_id: user.id)
+
+    on_exit(fn -> Fountain.BuzzTestSupport.stop_all_harnesses!() end)
+
     %{user: user, raw_key: raw_key, agent: agent}
   end
 

--- a/apps/fountain/test/support/buzz_test_support.ex
+++ b/apps/fountain/test/support/buzz_test_support.ex
@@ -11,7 +11,14 @@ defmodule Fountain.BuzzTestSupport do
   def stop_all_harnesses!(tries \\ @drain_tries)
 
   def stop_all_harnesses!(0) do
-    raise "BuzzSupervisor still has children after test teardown"
+    raise """
+    BuzzSupervisor still has children after test teardown: \
+    #{inspect(Horde.DynamicSupervisor.which_children(@supervisor))}
+
+    This supervisor is global, so the children are not necessarily this test's.
+    Every module that starts one is async: false today, which is what makes the
+    check safe to fail on; if that changes, scope the drain before relaxing it.
+    """
   end
 
   def stop_all_harnesses!(tries) do
@@ -22,6 +29,12 @@ defmodule Fountain.BuzzTestSupport do
         _ = Horde.DynamicSupervisor.terminate_child(@supervisor, pid)
 
       {_, :restarting, _, _} ->
+        :ok
+
+      # Horde is free to grow the child tuple. A FunctionClauseError raised here
+      # would come out of on_exit and fail an unrelated test with the wrong
+      # story, so take the next loop rather than the exception.
+      _other ->
         :ok
     end)
 

--- a/apps/fountain/test/support/buzz_test_support.ex
+++ b/apps/fountain/test/support/buzz_test_support.ex
@@ -1,0 +1,37 @@
+defmodule Fountain.BuzzTestSupport do
+  @moduledoc false
+
+  @supervisor Fountain.BuzzSupervisor
+  @drain_tries 500
+
+  # Horde reports a child as :restarting between the old PID going down and
+  # start_harness_link/2 returning its replacement. A one-shot PID snapshot
+  # skips that entry and lets its next database query outlive the test's SQL
+  # sandbox owner (#1351). Keep draining while the owner is still alive.
+  def stop_all_harnesses!(tries \\ @drain_tries)
+
+  def stop_all_harnesses!(0) do
+    raise "BuzzSupervisor still has children after test teardown"
+  end
+
+  def stop_all_harnesses!(tries) do
+    @supervisor
+    |> Horde.DynamicSupervisor.which_children()
+    |> Enum.each(fn
+      {_, pid, _, _} when is_pid(pid) ->
+        _ = Horde.DynamicSupervisor.terminate_child(@supervisor, pid)
+
+      {_, :restarting, _, _} ->
+        :ok
+    end)
+
+    case Horde.DynamicSupervisor.which_children(@supervisor) do
+      [] ->
+        :ok
+
+      _children ->
+        Process.sleep(10)
+        stop_all_harnesses!(tries - 1)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- wait for the launcher OS process to exit before Harness shutdown completes
- drain all Buzz supervisor children during test teardown, including children in the restarting state
- serialize controller tests that touch the global Buzz supervisor
- replace timing sleeps with deterministic synchronization and align fake processes with the real launcher contract

## Verification

- reported Harness seeds 310031 and 228607 pass
- relevant 34-test cross-module suite passes
- Harness suite passes 50 consecutive repetitions
- compile with warnings as errors passes
- formatting and Credo strict checks pass
- full suite completed 4,156 tests with no Buzz ownership or missing-executable failures; one unrelated Credits database checkout timeout occurred, and the Credits test file then passed 10 consecutive runs

Closes #1351
Closes #1469