### PR TITLE
test(activation): bind the fixture timestamp once (#1471)

### DIFF
--- a/apps/fountain/test/fountain/activation_test.exs
+++ b/apps/fountain/test/fountain/activation_test.exs
@@ -40,12 +40,15 @@ defmodule Fountain.ActivationTest do
       conv = insert_conversation(user_id: user.id)
       other = insert_conversation(user_id: user.id)
 
+      # Bound once: `at/1` reads the clock, so a second call either side of a
+      # second boundary would compare against a timestamp the row never held.
+      earliest = at(4)
       insert_turn(other, %{status: "completed", reply_text: "later", ended_at: at(1)})
-      insert_turn(conv, %{status: "completed", reply_text: "first", ended_at: at(4)})
+      insert_turn(conv, %{status: "completed", reply_text: "first", ended_at: earliest})
 
       first = Activation.first_reply_at(user.id)
 
-      assert DateTime.compare(first, at(4)) == :eq
+      assert DateTime.compare(first, earliest) == :eq
       assert Activation.first_reply_by_user() == %{user.id => first}
     end
 


### PR DESCRIPTION
`at/1` in `activation_test.exs` reads the clock. The test "the earliest replied turn, across conversations" called it twice for the same value — once for the turn row's `ended_at`, once in the assertion:

```elixir
insert_turn(conv, %{status: "completed", reply_text: "first", ended_at: at(4)})
first = Activation.first_reply_at(user.id)
assert DateTime.compare(first, at(4)) == :eq
```

Truncation to the second usually hides the gap between the two calls. When they straddle a second boundary — likelier under a loaded full-suite run than alone — the assertion compares against a timestamp the row never held and `DateTime.compare/2` answers `:lt`. That is the failure in #1471 (seed 880189). Nothing about `Fountain.Activation` is wrong; the fixture moved.

This binds the value once and uses it in both places.

## Verification

Verified by reverting. A temporary probe held both shapes, each sleeping to just past the next whole second before asserting, so the boundary crossing is forced rather than waited for:

```
1) test OLD SHAPE: at/1 evaluated twice (Fountain.ActivationFlakeProbeTest)
   code:  assert DateTime.compare(first, at(4)) == :eq
   left:  :lt
   right: :eq

2 tests, 1 failure
```

The old shape reproduces the reported `left: :lt` exactly; the new shape passes across the same boundary. The probe was deleted; it is not part of this PR.

`mix test test/fountain/activation_test.exs test/fountain/funnel_test.exs` — 37 tests, 0 failures. `mix format --check-formatted` clean.

## The other call sites

The issue asked for a look at the rest. The other `at/1` call sites in this file are single-use or already bind the value (`earlier = at(48)`). Across the suite only two other test files define a clock-reading helper: `funnel_test.exs` never asserts against a re-read clock value, and `lifecycle_test.exs`'s `ago/1` values are inputs to a threshold check sitting hours away from their bounds. No other instance of the shape.

Closes #1471

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DtNAVJ7qYiYofbRCjj2xbe
