### PR TITLE
ci: gate Hex advisories without blocking retirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -605,12 +605,10 @@ jobs:
         run: mix credo --strict
 
       - name: Audit dependencies
-        # Deliberately non-blocking. A package can be retired upstream at any
-        # moment by someone else, and that would break every build here for a
-        # reason unrelated to the change under test. It stays visible in the
-        # log. Currently flags earmark 1.4.48 (deprecated, unmaintained).
-        continue-on-error: true
-        run: mix hex.audit
+        # Security advisories block the build unless explicitly acknowledged in
+        # mix.exs. Retirements stay visible without breaking unrelated work: an
+        # upstream maintainer can retire a package at any moment.
+        run: elixir scripts/hex-audit-gate.exs
 
       # The Elixir SDK is a standalone Mix project. Keep its dependency graph
       # and build artifacts separate from this umbrella's -- which also puts

--- a/apps/fountain/test/fountain/hex_audit_gate_test.exs
+++ b/apps/fountain/test/fountain/hex_audit_gate_test.exs
@@ -1,0 +1,75 @@
+defmodule Fountain.HexAuditGateTest do
+  use ExUnit.Case, async: true
+
+  @advisory_failure "Found packages with security advisories"
+  @retirement_failure "Found retired packages"
+
+  test "an advisory fails the gate" do
+    {output, status} = run_gate("Advisories:\nfoo 1.0.0\n#{@advisory_failure}\n", 1)
+
+    assert status == 1
+    assert output =~ @advisory_failure
+  end
+
+  test "a retirement remains visible but does not fail the gate" do
+    {output, status} = run_gate("Retired:\nearmark 1.4.48\n#{@retirement_failure}\n", 1)
+
+    assert status == 0
+    assert output =~ @retirement_failure
+    assert output =~ "Retired dependencies are reported above but do not block CI."
+  end
+
+  test "an advisory still fails when a retirement is also present" do
+    output =
+      "\e[1m#{@retirement_failure}\e[0m\n" <>
+        "\e[31m#{@advisory_failure}\e[0m\n"
+
+    {_output, status} = run_gate(output, 1)
+
+    assert status == 1
+  end
+
+  test "a clean or fully acknowledged audit passes" do
+    {_output, status} = run_gate("Ignored advisories:\nEEF-CVE-2026-43969\n", 0)
+
+    assert status == 0
+  end
+
+  test "an inconclusive audit error fails closed" do
+    {output, status} = run_gate("registry request failed\n", 2)
+
+    assert status == 2
+    assert output =~ "hex.audit failed without a finding summary; failing closed."
+  end
+
+  defp run_gate(output, exit_status) do
+    root = Path.expand("../../../..", __DIR__)
+    script = Path.join(root, "scripts/hex-audit-gate.exs")
+
+    fake_bin =
+      Path.join(System.tmp_dir!(), "hex-audit-gate-#{System.unique_integer([:positive])}")
+
+    fake_mix = Path.join(fake_bin, "mix")
+
+    File.mkdir_p!(fake_bin)
+
+    File.write!(fake_mix, """
+    #!/bin/sh
+    printf '%s' "$HEX_AUDIT_FIXTURE"
+    exit "$HEX_AUDIT_FIXTURE_STATUS"
+    """)
+
+    File.chmod!(fake_mix, 0o755)
+
+    on_exit(fn -> File.rm_rf!(fake_bin) end)
+
+    System.cmd("elixir", [script],
+      env: [
+        {"PATH", fake_bin <> ":" <> System.fetch_env!("PATH")},
+        {"HEX_AUDIT_FIXTURE", output},
+        {"HEX_AUDIT_FIXTURE_STATUS", Integer.to_string(exit_status)}
+      ],
+      stderr_to_stdout: true
+    )
+  end
+end

--- a/apps/fountain/test/fountain/hex_audit_gate_test.exs
+++ b/apps/fountain/test/fountain/hex_audit_gate_test.exs
@@ -46,12 +46,8 @@ defmodule Fountain.HexAuditGateTest do
     root = Path.expand("../../../..", __DIR__)
     script = Path.join(root, "scripts/hex-audit-gate.exs")
 
-    fake_bin =
-      Path.join(System.tmp_dir!(), "hex-audit-gate-#{System.unique_integer([:positive])}")
-
+    fake_bin = Fountain.TmpDir.mkdir!("hex-audit-gate")
     fake_mix = Path.join(fake_bin, "mix")
-
-    File.mkdir_p!(fake_bin)
 
     File.write!(fake_mix, """
     #!/bin/sh
@@ -60,8 +56,6 @@ defmodule Fountain.HexAuditGateTest do
     """)
 
     File.chmod!(fake_mix, 0o755)
-
-    on_exit(fn -> File.rm_rf!(fake_bin) end)
 
     System.cmd("elixir", [script],
       env: [

--- a/mix.exs
+++ b/mix.exs
@@ -7,6 +7,22 @@ defmodule Fountain.Umbrella.MixProject do
       # Kept in lockstep with the newest v* git tag — release-bump.yml
       # computes the next tag from this value.
       version: "0.16.0",
+      hex: [
+        ignore_advisories: [
+          # cowlib 2.19.0 is already the newest Hex release, OSV lists no fixed
+          # Hex version, and Fountain serves HTTP with Bandit rather than Cowboy.
+          "EEF-CVE-2026-43969",
+          # cowlib 2.19.0 is already the newest Hex release, OSV lists no fixed
+          # Hex version, and Fountain serves HTTP with Bandit rather than Cowboy.
+          "EEF-CVE-2026-43971",
+          # cowlib 2.19.0 is already the newest Hex release, OSV lists no fixed
+          # Hex version, and Fountain serves HTTP with Bandit rather than Cowboy.
+          "EEF-CVE-2026-43966",
+          # gun 2.5.0 is already the newest Hex release, OSV lists no fixed Hex
+          # version, and Fountain serves HTTP with Bandit rather than Cowboy.
+          "GHSA-w4f7-4cxr-rv3c"
+        ]
+      ],
       deps: deps(),
       releases: releases(),
       aliases: aliases(),

--- a/scripts/hex-audit-gate.exs
+++ b/scripts/hex-audit-gate.exs
@@ -1,0 +1,36 @@
+# `mix hex.audit` uses one non-zero exit code for two findings with different
+# CI policies: security advisories must block a build, while a package that an
+# upstream maintainer retires must remain visible without breaking unrelated
+# work. Hex applies the reviewable advisory acknowledgements from mix.exs; this
+# wrapper only separates the resulting exit status.
+
+defmodule HexAuditGate do
+  @advisory_failure "Found packages with security advisories"
+  @retirement_failure "Found retired packages"
+  @ansi_escape ~r/\e\[[0-9;]*m/
+
+  def run do
+    {output, status} = System.cmd("mix", ["hex.audit"], stderr_to_stdout: true)
+    IO.write(output)
+
+    plain_output = Regex.replace(@ansi_escape, output, "")
+
+    cond do
+      status == 0 ->
+        0
+
+      String.contains?(plain_output, @advisory_failure) ->
+        status
+
+      String.contains?(plain_output, @retirement_failure) ->
+        IO.puts("\nRetired dependencies are reported above but do not block CI.")
+        0
+
+      true ->
+        IO.puts(:stderr, "\nhex.audit failed without a finding summary; failing closed.")
+        status
+    end
+  end
+end
+
+System.halt(HexAuditGate.run())


### PR DESCRIPTION
## Summary

- replace the non-blocking Hex audit step with an advisory-aware, fail-closed gate
- keep upstream package retirements visible without failing unrelated builds
- document the four current advisory acknowledgements in mix.exs
- cover advisory, retirement, combined, clean, and inconclusive outcomes

## Verification

- mix test apps/fountain/test/fountain/hex_audit_gate_test.exs (5 tests, 0 failures)
- mix format --check-formatted
- mix compile --warnings-as-errors
- live Hex 2.5.1 audit passes with the acknowledged findings
- live audit exits 1 with a non-matching acknowledgement override

Closes #1476