### PR TITLE
chore(precommit): assemble the prod release (#1477)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,21 @@ upgrade, is in
 
 ### Changed
 
+- **`mix precommit` now assembles the production release** (#1477). It was the
+  documented pre-push gate and it could not see a whole class of breakage:
+  anything that exists only in `MIX_ENV=prod`. `apps/fountain` scopes the
+  OpenTelemetry family `only: :prod`, so `chatterbox` — reached through
+  grpcbox under `opentelemetry_exporter` — is in no dev or test dependency
+  graph, and when the hackney 4 bump pulled in `h2` with the same four module
+  names, `mix release` refused to assemble while compile, format, credo,
+  sobelow, dialyzer and all 4,117 tests stayed green (#1472). The new step is
+  the assemble alone, not CI's boot check: duplicate modules and the
+  application-mode validation are decided at assemble time, and assembling
+  needs no secrets, because `mix release` copies `config/runtime.exs` in as a
+  config provider rather than evaluating it. It costs ~9s in a warm tree; a
+  fresh checkout pays one prod compile (~2 min) and then caches it under
+  `_build/prod`.
+
 - **The connection and the transcript have left `ConversationServer`, and the
   server is what is left** (#1377, tracker #1369, last). The ACP connection
   that outlives the turn (#817) is `Fountain.Conversations.Connection`: the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -397,7 +397,21 @@ produce the identical total (85.46% on the same six exports). Run
 and re-verify the two agree when bumping Elixir, since the script depends on
 `:cover` semantics the pin currently freezes.
 
-Run `mix precommit` locally before pushing — it covers the core gate (compile with warnings-as-errors, unused deps, format, `credo --strict`, sobelow, dialyzer, tests). CI additionally runs hex.audit, the Go CLI checks, the release boot check, and OpenAPI validation.
+Run `mix precommit` locally before pushing — it covers the core gate (compile
+with warnings-as-errors, unused deps, format, `credo --strict`, sobelow,
+dialyzer, a prod release **assemble**, tests). CI additionally runs hex.audit,
+the Go CLI checks, the release **boot** check, and OpenAPI validation.
+
+The release assemble is the only step that builds `MIX_ENV=prod`, and it is
+there because everything else is blind to a prod-only dependency graph: the
+OpenTelemetry family is `only: :prod`, so `chatterbox` exists in no dev or test
+build, and the hackney 4 bump that collided with it left every other gate green
+on a tree whose release would not assemble (#1472, #1477). It costs ~9s warm;
+the first run in a fresh checkout pays a full prod compile (~2 min) and then
+caches it under `_build/prod`. It needs no secrets — assembling copies
+`config/runtime.exs` in as a config provider rather than evaluating it, which
+is why CI keeps the booting half where `SECRET_KEY_BASE` and a database are
+required.
 
 ## Test patterns
 

--- a/mix.exs
+++ b/mix.exs
@@ -83,6 +83,7 @@ defmodule Fountain.Umbrella.MixProject do
         "credo --strict",
         &dialyzer_in_dev/1,
         &sobelow_in_app/1,
+        &release_assembles_in_prod/1,
         "test"
       ]
     ]
@@ -117,6 +118,50 @@ defmodule Fountain.Umbrella.MixProject do
     case Mix.shell().cmd("mix dialyzer", env: [{"MIX_ENV", "dev"}]) do
       0 -> :ok
       status -> Mix.raise("mix dialyzer failed with exit status #{status}")
+    end
+  end
+
+  # The only step here that builds :prod, and so the only one that can see a
+  # dependency graph the dev and test builds do not have. apps/fountain scopes
+  # the OpenTelemetry family `only: :prod`, which puts `chatterbox` (reached
+  # through grpcbox under opentelemetry_exporter) in no dev or test build. When
+  # the hackney 4 bump pulled in `h2`, whose modules collide with chatterbox's,
+  # every other gate above stayed green while `mix release` refused to
+  # assemble (#1472, #1477):
+  #
+  #   ** (Mix) Duplicated modules:
+  #     h2_settings specified in chatterbox and h2
+  #
+  # Assemble only, not CI's boot check. Duplicate modules and the
+  # application-mode validation are decided at assemble time, and assembling
+  # needs no secrets: `mix release` reads config/runtime.exs to copy it in as a
+  # config provider rather than to evaluate it. Booting is the half that needs
+  # SECRET_KEY_BASE and a database, and CI keeps it.
+  #
+  # ~9s in a warm tree. A cold one also pays the first prod compile (~2 min),
+  # once, and then caches it under _build/prod like any other env.
+  #
+  # `deps.get`, not CI's `deps.get --only prod`. `--only` *prunes* deps/ down
+  # to that env, so running it here would delete credo, dialyxir, sobelow,
+  # mimic and stream_data and leave the `test` step below dying on "Unchecked
+  # dependencies for environment test". CI gets away with it because its job
+  # ends at the release. Plain `deps.get` is env-agnostic and fetches nothing
+  # when the tree is current, but it has to run: the steps above only check
+  # :test and :dev deps, so the lockfile bump this gate exists for would
+  # otherwise fail on "lock mismatch" instead of assembling.
+  defp release_assembles_in_prod(_args) do
+    env = [{"MIX_ENV", "prod"}]
+
+    with 0 <- Mix.shell().cmd("mix deps.get", env: env),
+         0 <- Mix.shell().cmd("mix release fountain_server --overwrite", env: env) do
+      :ok
+    else
+      status ->
+        Mix.raise(
+          "the prod release failed to assemble (exit status #{status}). " <>
+            "CI fails this in \"Static analysis and release checks\". A duplicate-module " <>
+            "clash between a new dependency and a prod-only one is the usual cause."
+        )
     end
   end
 


### PR DESCRIPTION
Closes #1477.

`mix precommit` is the documented pre-push gate in CLAUDE.md, and it could not
see a whole class of breakage: anything that exists only in `MIX_ENV=prod`.

#1472 is the worked example. `apps/fountain` scopes the OpenTelemetry family
`only: :prod`, so `chatterbox` — reached through grpcbox under
`opentelemetry_exporter` — is in no dev or test dependency graph. When the
hackney 4 bump pulled in `h2`, whose four module names are the ones chatterbox
has used for years, `mix release` refused to assemble while
`compile --warnings-as-errors`, `format --check-formatted`, `credo --strict`,
`sobelow`, `dialyzer` and all 4,117 tests stayed green. Only CI could report
it, as "Static analysis and release checks: fail" — which reads as unrelated
to a lockfile bump until you open the log.

## What this adds

One step, `&release_assembles_in_prod/1`, between sobelow and the suite,
following the existing `dialyzer_in_dev/1` and `sobelow_in_app/1` helpers.

It is the **assemble** alone, not CI's boot check. Duplicate modules and the
application-mode validation are both decided at assemble time, and assembling
needs no secrets: `mix release` reads `config/runtime.exs` to copy it in as a
config provider rather than to evaluate it. Booting is the half that wants
`SECRET_KEY_BASE` and a database, and CI keeps it.

## `deps.get`, not `deps.get --only prod`

CI's release step opens with `mix deps.get --only prod`. Copying that here is
a trap, and running it is how it was found: `--only` **prunes** `deps/` down to
that env, deleting credo, dialyxir, sobelow, mimic, lazy_html and stream_data,
so the `test` step below dies on `Unchecked dependencies for environment test`.
CI gets away with it because its job ends at the release.

The fetch still has to run, though. Every step above it checks only `:dev` and
`:test` deps, so the lockfile bump this gate exists for would otherwise fail on
`lock mismatch: the dependency is out of date` instead of assembling. Plain
`mix deps.get` is env-agnostic and prunes nothing — verified: 112 packages in
`deps/` before and after, every dev/test package still present.

## Verification

Both directions, on this tree:

- **Passes.** `MIX_ENV=prod mix release fountain_server --overwrite` assembles
  with no environment set at all — no `SECRET_KEY_BASE`, no `DATABASE_URL`.
  **9.2s** warm, against the 8.5s the issue measured. A full `mix precommit` is
  green end to end: 6 doctests, **4,169 tests, 0 failures**.
- **Fails when it should.** Pinning `{:grpcbox, "== 0.17.1", override: true}`
  drags ts_chatterbox back to 0.15.1 and restores the collision. `mix release`
  then prints the original error verbatim and exits 1:

  ```
  ** (Mix) Duplicated modules:
      h2_settings specified in chatterbox and h2
      h2_frame specified in chatterbox and h2
      h2_connection specified in chatterbox and h2
      h2_client specified in chatterbox and h2
  ```

  and `mix precommit` raises rather than reaching the suite:

  ```
  ** (Mix) the prod release failed to assemble (exit status 1). CI fails this
  in "Static analysis and release checks". A duplicate-module clash between a
  new dependency and a prod-only one is the usual cause.
  ```

## Cost

~9s in a warm tree. A fresh checkout pays one prod compile (~2 min), once, and
then caches it under `_build/prod` like any other env.

CLAUDE.md and the changelog are updated to say precommit assembles and CI
boots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hk3QL6c6MGvxGBY68uXb87
