### PR TITLE
docs(broker): correct the substitution scope, measured against gemini-cli

### DIFF
--- a/apps/fountain/lib/fountain/broker.ex
+++ b/apps/fountain/lib/fountain/broker.ex
@@ -212,9 +212,27 @@ defmodule Fountain.Broker do
   end
 
   # Inference credentials (gate 3): the env var each runtime reads, the host
-  # it talks to, and the prefix its vendor's tokens carry. Substitution covers
-  # every shape at once — Anthropic's `x-api-key`, the OAuth bearer, OpenAI's
-  # bearer and Gemini's `?key=` query parameter alike.
+  # it talks to, and the prefix its vendor's tokens carry. Substitution
+  # rewrites the placeholder wherever it appears in a **header value**, which
+  # is every shape these runtimes actually send — Anthropic's `x-api-key`, the
+  # OAuth bearer, OpenAI's bearer, Gemini's `x-goog-api-key`.
+  #
+  # This comment used to claim substitution also covered "Gemini's `?key=`
+  # query parameter". It does not, on either backend that matters:
+  # `Fountain.Broker.Native` substitutes in header values only, where Agent
+  # Vault also rewrote path, query and body (#1359 row 1). Measured 2026-09-03
+  # against gemini-cli 0.58.0 — the sandbox images pin no version, so this is
+  # what a sandbox runs — by hooking `fetch` under the sandbox's own env
+  # (`GEMINI_API_KEY` set, no base-URL override, so `getAuthTypeFromEnv`
+  # resolves `gemini-api-key`): every call to generativelanguage.googleapis.com
+  # carries the key in `x-goog-api-key` and nothing in the query string. The
+  # `?key=` form is real but belongs to the Live API's audio and music
+  # WebSockets, which an ACP turn never opens. Header substitution is therefore
+  # sufficient for Gemini and query substitution is not needed for the flip.
+  #
+  # Note `GOOGLE_GEMINI_BASE_URL` outranks `GEMINI_API_KEY` in that
+  # resolution, so pointing the CLI at a local capture changes the auth type
+  # out from under the measurement. Hook the client, do not redirect it.
   @inference %{
     "CLAUDE_CODE_OAUTH_TOKEN" => %{cred: :claude_code_oauth_token, hosts: ["api.anthropic.com"]},
     "ANTHROPIC_API_KEY" => %{cred: :anthropic_api_key, hosts: ["api.anthropic.com"]},


### PR DESCRIPTION
## Summary

The comment over `@inference` in `Fountain.Broker` claimed substitution covered "Gemini's `?key=` query parameter". True of Agent Vault, which rewrote path, query and body. **False of `Fountain.Broker.Native`, which substitutes in header values only** (#1359 row 1).

Left standing it reads as a guarantee the native backend does not make — the class of defect the "must not describe unbuilt behavior as existing" rule in CLAUDE.md exists for, and directly load-bearing for the flip decision.

Comment only. No behaviour change.

## What was measured

Row 1 of #1359 asked for this and had been sitting on speculation. Answered against **gemini-cli 0.58.0** (`images/e2b/e2b.Dockerfile` and `images/daytona/Dockerfile` pin no version, so this is what a sandbox runs).

The trap first: `getAuthTypeFromEnv()` checks `GOOGLE_GEMINI_BASE_URL` **before** `GEMINI_API_KEY`, so pointing the CLI at a local capture server flips the auth type to `gateway` and measures the wrong path. Hooked `fetch` instead, leaving the sandbox's own env intact (`GEMINI_API_KEY` set, no base-URL override → `gemini-api-key`), with the real placeholder `AIza__gemini_api_key__`.

Captured:

```
URL: https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-lite:generateContent
    x-goog-api-key = AIza__gemini_api_key__
URL: https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-pro-preview:streamGenerateContent?alt=sse
    x-goog-api-key = AIza__gemini_api_key__
```

Requests carrying the key in a query string: **0**. The only query parameter anywhere is `alt=sse`.

This matches the source: `@google/genai`'s `NodeAuth.addAuthHeaders` → `addKeyHeader` → `headers.append("x-goog-api-key", apiKey)`, with `GEMINI_API_KEY_AUTH_MECHANISM` defaulting to `x-goog-api-key`. The `?key=` form is real but belongs to the Live API's `BidiGenerateMusic` and `BidiGenerateContent` **WebSockets**, which an ACP turn never opens.

## Consequence

**#1359 row 1 does not block the flip.** Header substitution is sufficient for Gemini; query substitution need not be built. Row 2 (the stored egress log) remains the open one.

Worth noting the failure mode is safe either way: the placeholder goes upstream verbatim and Google rejects it, so a missed substitution is a broken call, never a leaked credential.

Two side observations for the pre-flip smoke, not addressed here:

- a Gemini turn also contacts `play.googleapis.com` (telemetry). A `limited` environment would deny it; harmless, but it will show in the egress log.
- the CLI sends a stable `x-gemini-api-privileged-user-id` UUID.

## Verification

`mix compile --warnings-as-errors`, `mix credo --strict` (no issues) and `mix format --check-formatted` all pass in a clean worktree off `origin/main`.

Closes nothing on its own; unblocks the row 1 decision on #1359.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WDjZnydTVfeKhUBH3Qp7LD