### PR TITLE
chore: add Fountain project gardener skill

### DIFF
--- a/.agents/skills/fountain-project-gardener/SKILL.md
+++ b/.agents/skills/fountain-project-gardener/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: fountain-project-gardener
+description: Audit, triage, prune, and refresh the BinaryBourbon/fountain GitHub Project, its issues, labels, iterations, views, workflows, and access. Use when someone asks what work remains, what is stale, how to prioritize the backlog, or to organize or clean up Project #1.
+---
+
+# Fountain Project Gardener
+
+Keep the Fountain GitHub Project trustworthy enough that a contributor can tell what matters now, what comes next, and why work is blocked.
+
+This skill may inspect, recommend, or apply changes. Infer the requested mode from the caller's words. An audit or question is read-only. A request to clean, organize, prune, refresh, or update authorizes ordinary in-scope project maintenance, but not irreversible cleanup or changes to product priorities that the caller has not supplied.
+
+## Establish ground truth
+
+Read [references/project-policy.md](references/project-policy.md) before acting.
+
+Prefer `gh` and GitHub APIs for semantic operations. Use a signed-in browser only for Project settings that the CLI/API cannot safely handle. Before any mutation, verify both the active GitHub identity and the target owner; a browser session and `gh` may be signed into different accounts.
+
+Inspect the live repository and Project before relying on the reference baseline. At minimum, examine:
+
+- open issues and pull requests, including linked and soon-to-merge PRs;
+- Project item counts by Status, Horizon, Iteration, Workstream, Size, and repository state;
+- items in Triage, Blocked, Now, and the current/next iteration;
+- closed items not marked Done and old completed items not archived;
+- priority and area label usage, empty or overlapping labels, and labels used only on closed work;
+- iteration coverage, views, automation workflows, and collaborator access.
+
+Report query failures and incomplete visibility. Do not treat missing API fields or a partial page of results as zero.
+
+## Interrogate for judgment, not facts GitHub can answer
+
+Inspect first, then ask concise questions in batches of at most three. Skip questions already answered by the caller or repository state. Continue asking only while an answer would materially change prioritization or cleanup.
+
+The highest-value questions are:
+
+1. What outcome or release must not slip, and is there a real date?
+2. Who has capacity in the next one to four weeks, and what work is already effectively committed or under review?
+3. How aggressive should pruning be: organize only, archive superseded work, or propose closing obsolete work and deleting redundant labels?
+
+When relevant, ask which dependency or decision can unblock an item, whether a tracker still represents an active program, or whether contributor-friendly issues should be preserved even when they are not near-term.
+
+State useful defaults instead of blocking on optional answers:
+
+- Preserve existing Now/Next choices if no new objective is supplied.
+- Do not promote work when capacity is unknown.
+- Use conservative cleanup when pruning posture is unspecified.
+- Treat pending reviewed PRs as near-complete work and avoid reshuffling their linked issues.
+
+## Produce a decision-ready gardening pass
+
+Separate findings into:
+
+- **One-time cleanup:** imported or historical drift that should be reconciled once.
+- **Recurring maintenance:** small actions required weekly or monthly.
+- **Priority decisions:** choices that need product or maintainer judgment.
+- **Automation gaps:** repetitive state transitions GitHub can own.
+
+For each proposed change, give the reason and the exact affected items or labels. Order work by risk and leverage:
+
+1. Production, security, data-loss, and release-blocking work.
+2. Active work and reviewed PRs that can be completed or unblocked cheaply.
+3. Decisions or external dependencies blocking multiple downstream issues.
+4. Near-term reliability and committed roadmap work.
+5. Backlog hygiene, documentation, and opportunistic improvements.
+
+Prefer closing loops over increasing work in progress. Trackers describe programs; executable child issues carry iteration, size, and day-to-day status.
+
+## Apply changes safely
+
+Ordinary reversible organization includes assigning Project fields, adding appropriate existing labels, moving unblocked work between Triage/Ready/In progress/In review/Blocked, adding future iterations, and correcting clear automation drift.
+
+Require the caller to confirm an exact proposed set before any of these actions:
+
+- close or delete issues;
+- delete or rename labels, fields, views, workflows, iterations, or projects;
+- remove collaborators or reduce access;
+- change P0/P1 priority, Horizon Now, ownership, or a committed target date based on inference;
+- archive a large batch whose contents the caller has not reviewed.
+
+Never delete a label merely because it is old or unused. First verify that it has no unique policy meaning, migrate every open use to the intended replacement, check automation and documentation references, and show the deletion list. Never remove an issue from the Project merely to make counts look clean.
+
+After mutations, query the live state again. Summarize what changed, what remains intentionally untouched, any questions still requiring a maintainer, and the next date or condition that should trigger another gardening pass.

--- a/.agents/skills/fountain-project-gardener/references/project-policy.md
+++ b/.agents/skills/fountain-project-gardener/references/project-policy.md
@@ -1,0 +1,106 @@
+# Fountain Project Policy
+
+## Scope and identity
+
+- Repository: `BinaryBourbon/fountain`
+- Account-owned Project: `BinaryBourbon` Project `1`
+- Project URL: `https://github.com/users/BinaryBourbon/projects/1`
+- The Project is private. Repository collaborators should normally have Write access unless the caller specifies a narrower policy.
+- The browser may be signed in as `jhgaylor` while `gh` is signed in as `BinaryBourbon`. Verify identity at the point of mutation.
+
+Treat this as an expected configuration, not proof of current state. Query GitHub every time.
+
+## Field semantics
+
+### Status
+
+- **Triage:** captured but not yet made execution-ready.
+- **Ready:** sufficiently defined and unblocked; someone could start it.
+- **In progress:** actively being worked, with an assignee.
+- **In review:** implementation is awaiting review or merge.
+- **Blocked:** cannot advance until a named decision, dependency, or external event occurs.
+- **Done:** closed or merged.
+
+Do not use Status as a statement of strategic importance.
+
+### Horizon
+
+- **Now:** a current commitment. Keep this deliberately small.
+- **Next:** a credible candidate for the next few weeks, subject to capacity.
+- **Later:** useful but not scheduled.
+- **Parked:** deliberately not being pursued; retain only when the record still has value.
+
+Do not use Horizon as a workflow state. A blocked issue can still be Now; a Ready issue can still be Later.
+
+### Priority labels
+
+- **P0:** production emergency, active security exposure, data loss, or an immediate existential release blocker.
+- **P1:** critical reliability or committed release work with near-term impact.
+- **P2:** important planned work.
+- **P3:** opportunistic, low urgency, or contributor-friendly work.
+
+Priority is relative impact and urgency, not implementation order by itself. Do not infer P0/P1 from age, comment volume, or a maintainer's enthusiasm.
+
+### Other fields
+
+- **Workstream:** use one primary owning domain: Broker, Production safety, Conversation reliability, Render, API/SDK, Billing, Architecture, or Distribution.
+- **Iteration:** assign executable Now/Next work when capacity makes the plan credible. Keep at least four future weekly iterations available.
+- **Size:** estimate Now/Next executable issues as S/M/L/XL. Do not estimate the entire Later/Parked backlog.
+- **Target date:** reserve for genuine external or release commitments, not aspirational scheduling.
+
+## Labels
+
+Prefer labels for durable issue meaning and cross-repository search; prefer Project fields for execution state.
+
+Retain these label families unless the caller deliberately changes the taxonomy:
+
+- priorities: `P0`, `P1`, `P2`, `P3`;
+- durable ownership: `area:*`;
+- issue nature: `bug`, `enhancement`, `question`, `dependencies`, language/ecosystem labels;
+- contribution: `good first issue`, `help wanted`;
+- coordination: `tracker`, `needs:decision`, `needs:external`;
+- terminal GitHub semantics: `duplicate`, `invalid`, `wontfix`.
+
+Campaign labels such as `*-2026-09` may be useful while a bounded program is active. Retire them only after the campaign is complete, all open uses have a durable replacement, and no automation depends on them.
+
+Avoid labels duplicating Status, Horizon, Size, or Iteration.
+
+## Expected views and automation
+
+Expected views include Backlog, Now, Next, Programs, Risks, Inbox, and Roadmap. Their exact filters may evolve, but each should answer a distinct maintainer question.
+
+Expected automations include:
+
+- add matching open repository issues;
+- set newly added items to Triage;
+- mark closed items Done;
+- return reopened items to Triage;
+- move issues with linked pull requests to In review;
+- archive sufficiently old completed items.
+
+Automation is support, not evidence. Test or inspect it after configuration changes and reconcile items created before a workflow was enabled.
+
+## Freshness checks
+
+Use these signals to guide the conversation, not as blind mutation rules:
+
+- Inbox/Triage contains items older than the team's chosen response window.
+- Now exceeds actual contributor capacity or contains unowned work.
+- In progress has no assignee, recent activity, or credible next action.
+- In review has no open linked PR, or the PR merged without the issue closing.
+- Blocked lacks a named dependency/decision or has not been revisited for two weeks.
+- Next has no plausible iteration or more work than the next few weeks can absorb.
+- Current/next iterations are missing or contain unfinished work that rolled silently.
+- P0/P1 issues lack owners or a next action.
+- Closed items are not Done, or old Done items remain unarchived.
+- Campaign labels outlive their programs; redundant labels reappear.
+- Project access drifts from repository collaborator access.
+
+## Sustainable cadence
+
+- **Twice weekly, about 10 minutes:** empty or explain Triage; update active, blocked, and review states.
+- **Weekly, about 20 minutes:** reconcile current iteration, protect a small Now set, promote only to available capacity, and close completed tracker loops.
+- **Monthly, about 30 minutes:** revisit Later/Parked, extend iterations, inspect label entropy and workflow health, review old blockers, and verify access.
+- **After a release or program completes:** close or re-horizon the tracker and children, then propose retiring any temporary campaign labels.
+
+The goal is not a perfectly classified backlog. The goal is a Project whose top few decisions and next actions are true.


### PR DESCRIPTION
## Summary

- add a repository-local skill for auditing, triaging, pruning, and refreshing Project #1
- make the workflow question-driven for product judgment, capacity, and cleanup posture
- document Fountain-specific field semantics, label policy, freshness signals, automation expectations, and maintenance cadence
- require exact confirmation before destructive cleanup or inferred priority changes

## Validation

- `quick_validate.py .agents/skills/fountain-project-gardener`
- `git diff --check`