### PR TITLE
fix(broker): brokered clones, by not waiting for the proxy's 407

### DIFF
--- a/apps/fountain/lib/fountain/conversations/provisioning.ex
+++ b/apps/fountain/lib/fountain/conversations/provisioning.ex
@@ -410,6 +410,20 @@ defmodule Fountain.Conversations.Provisioning do
   exception and reads `NODE_EXTRA_CA_CERTS`, which `Fountain.Broker.sandbox_env/1`
   points at the same file.
 
+  It also pins git's `http.proxyAuthMethod` to `basic`. git defaults to
+  `anyauth`, which by definition cannot send a credential until it has seen a
+  `407` naming the scheme: it sends CONNECT bare, reads the challenge, and
+  retries on the same connection. The native broker closes the connection
+  after a `407`, so the retry lands on a dead socket and git reports
+  `Proxy CONNECT aborted` — which is every brokered clone, on an environment
+  with a repository, failing to provision. Agent Vault kept the connection
+  open and answered the retry, which is why this only appeared at the flip
+  (#1485). `basic` makes libcurl send the credential preemptively, the way
+  the curl binary already did, so the first CONNECT carries it and no retry
+  is needed. The broker's own keep-alive gap is worth closing too, but this
+  is the half that does not need a library release, and it is the half that
+  makes the client stop depending on the server's 407 behaviour at all.
+
   The sudoers drop-in is what lets a setup script's `sudo apt-get install`
   reach a mirror at all: sudo's `env_reset` strips `http_proxy` and friends,
   apt then resolves the mirror directly, and the broker floor (only the
@@ -429,7 +443,10 @@ defmodule Fountain.Conversations.Provisioning do
     # trust directory the way `install_packages/4` reaches apt: through sudo.
     install =
       "sudo install -D -m 644 #{shell_quote(staging)} #{shell_quote(path)} && " <>
-        "sudo update-ca-certificates && " <> sudo_env_keep_command()
+        "sudo update-ca-certificates && " <>
+        sudo_env_keep_command() <>
+        " && " <>
+        git_proxy_auth_command()
 
     with {:ok, pem} <- Fountain.Broker.ca_pem(),
          :ok <-
@@ -458,6 +475,12 @@ defmodule Fountain.Conversations.Provisioning do
         err
     end
   end
+
+  # Global, so it covers the agent's own `git push`/`fetch` inside the sandbox
+  # and not only the clone provisioning runs. Written to the sprite user's
+  # ~/.gitconfig, which git reads whatever XDG_CONFIG_HOME says.
+  defp git_proxy_auth_command,
+    do: "git config --global http.proxyAuthMethod basic"
 
   @sudoers_staging "/tmp/fountain-broker-proxy.sudoers"
   @sudoers_path "/etc/sudoers.d/fountain-broker-proxy"
@@ -583,6 +606,12 @@ defmodule Fountain.Conversations.Provisioning do
   # `env:` is passed for the same reason every other step passes it: a
   # brokered clone reaches GitHub only through `HTTPS_PROXY`, and git reads
   # that from its environment. It was the one step that ran bare.
+  #
+  # `-c http.proxyAuthMethod=basic` repeats what `install_broker_ca/2` writes
+  # globally, on purpose: the clone must not depend on that step having run,
+  # and it is inert when the conversation is not brokered (there is no proxy
+  # to authenticate to). The moduledoc there explains what git's `anyauth`
+  # default does to a proxy that closes the connection after a 407.
   defp clone_https(
          handle,
          %{"url" => url, "mount_path" => mount} = repo,
@@ -595,7 +624,8 @@ defmodule Fountain.Conversations.Provisioning do
     cmd =
       git_env_prefix() <>
         "mkdir -p #{shell_quote(Path.dirname(mount))} && " <>
-        "git clone --depth 50 #{branch_arg(repo)}#{shell_quote(auth_url)} #{shell_quote(mount)}"
+        "git -c http.proxyAuthMethod=basic clone --depth 50 " <>
+        "#{branch_arg(repo)}#{shell_quote(auth_url)} #{shell_quote(mount)}"
 
     # Not retried: a clone into a half-written directory is not idempotent.
     case Sandbox.exec(handle, "bash", ["-lc", cmd],

--- a/apps/fountain/test/fountain/conversations/provisioning_test.exs
+++ b/apps/fountain/test/fountain/conversations/provisioning_test.exs
@@ -157,6 +157,38 @@ defmodule Fountain.Conversations.ProvisioningTest do
     end
   end
 
+  describe "clone_repositories/5" do
+    test "clones with basic proxy auth, so the CONNECT carries the credential first time" do
+      # The other half of the #1485 fix. This one must hold even if
+      # install_broker_ca/2 never ran: the clone is what fails visibly, as
+      # "Proxy CONNECT aborted", when git is left on its `anyauth` default
+      # against a proxy that closes the connection after a 407.
+      conv = insert_conversation()
+      test = self()
+
+      env = %Fountain.Environments.Environment{
+        repositories: [%{"url" => "https://github.com/o/r", "mount_path" => "/workspace/r"}]
+      }
+
+      Mimic.stub(Managoat.Sandbox.Sprites, :exec, fn _h, _cmd, [_, script], _opts ->
+        send(test, {:script, script})
+        {:ok, "", 0}
+      end)
+
+      assert :ok =
+               Provisioning.clone_repositories(
+                 sandbox_handle(),
+                 env,
+                 %{},
+                 [{"HTTPS_PROXY", "https://t:v@broker.example:443"}],
+                 conv.id
+               )
+
+      assert_received {:script, script}
+      assert script =~ "git -c http.proxyAuthMethod=basic clone --depth 50"
+    end
+  end
+
   describe "install_broker_ca/2" do
     test "writes the CA where update-ca-certificates reads it, then runs it" do
       conv = insert_conversation()
@@ -186,7 +218,30 @@ defmodule Fountain.Conversations.ProvisioningTest do
                  "NO_PROXY NODE_EXTRA_CA_CERTS SSL_CERT_FILE REQUESTS_CA_BUNDLE CARGO_HTTP_CAINFO " <>
                  "UV_NATIVE_TLS\"' > '/tmp/fountain-broker-proxy.sudoers' && " <>
                  "sudo visudo -cf '/tmp/fountain-broker-proxy.sudoers' && " <>
-                 "sudo install -m 440 '/tmp/fountain-broker-proxy.sudoers' '/etc/sudoers.d/fountain-broker-proxy'"
+                 "sudo install -m 440 '/tmp/fountain-broker-proxy.sudoers' '/etc/sudoers.d/fountain-broker-proxy' && " <>
+                 "git config --global http.proxyAuthMethod basic"
+    end
+
+    test "pins git's proxy auth to basic, so a brokered clone never waits for a 407" do
+      # git's `anyauth` default sends CONNECT bare, reads the 407 naming the
+      # scheme, and retries on the same connection. The native broker closes
+      # after a 407, so the retry hits a dead socket and git says
+      # "Proxy CONNECT aborted" — every brokered clone failing to provision
+      # (#1485). Basic sends the credential on the first CONNECT instead.
+      conv = insert_conversation()
+      test = self()
+
+      stub(Fountain.Broker, :ca_pem, fn -> {:ok, "PEM"} end)
+      Mimic.stub(Managoat.Sandbox.Sprites, :write_file, fn _h, _p, _d, _o -> :ok end)
+
+      Mimic.stub(Managoat.Sandbox.Sprites, :exec, fn _h, _cmd, [_, script], _opts ->
+        send(test, {:script, script})
+        {:ok, "", 0}
+      end)
+
+      assert :ok = Provisioning.install_broker_ca(sandbox_handle(), conv.id)
+      assert_received {:script, script}
+      assert script =~ "git config --global http.proxyAuthMethod basic"
     end
 
     test "sudo keeps every proxy variable the broker sets, so `sudo apt-get` reaches a mirror" do


### PR DESCRIPTION
**Production regression from the native-broker flip (#1485), found by the pre-flip smoke on its first run.** Every brokered `git clone` fails, so an environment with a repository cannot provision:

```
fatal: unable to access 'https://github.com/...': Proxy CONNECT aborted
```

## Why

git leaves libcurl on its `anyauth` default, which by definition cannot send a credential before it has seen a `407` naming the scheme. It sends CONNECT bare, reads the challenge, and retries **on the same connection**. `Managoat.Broker` closes the connection after a 407, so the retry lands on a dead socket.

Agent Vault held the connection open and answered the retry on it. That is why this appeared at the flip and not in any earlier test. Both verified against production:

| Proxy | First CONNECT (no credential) | Retry on the same connection |
|---|---|---|
| `Managoat.Broker` | `407` | connection closed |
| Agent Vault | `407` | `407`, answered |

Nothing else noticed because every other client sends the credential preemptively. The `curl` binary does, and so does Node's proxy agent — which is why the ACP adapter's `npm install` and all 221 logged inference calls tunnelled fine while clones did not. Reproduced exactly, against the live broker:

```
curl --proxy-anyauth  -> curl: (56) Proxy CONNECT aborted      # git's behaviour
curl --proxy-basic    -> curl: (56) CONNECT tunnel failed, response 407
```

The second is the healthy shape: a clean 407 that a valid token turns into a tunnel.

## The fix

Pin git's `http.proxyAuthMethod` to `basic`, so the first CONNECT carries the credential and no retry is needed. Two places on purpose:

- **globally**, in `install_broker_ca/2` — covers the agent's own `git push` and `fetch` inside the sandbox, which would hit the same wall
- **as `-c` on the clone** — so provisioning does not depend on that step having run

Inert when the conversation is not brokered: with no proxy there is nothing to authenticate to.

## Verification

Confirmed on the production sandbox **before** writing the fix — the same clone that failed succeeds under `git -c http.proxyAuthMethod=basic`:

```
$ git -c http.proxyAuthMethod=basic clone --depth 1 https://github.com/BinaryBourbon/fountain /tmp/t2
Cloning into '/tmp/t2'...
$ ls /tmp/t2
CHANGELOG.md  CLAUDE.md  CONTRIBUTING.md  Dockerfile  LICENSE
```

Two tests, one per call site, each stating the failure mode they guard. 674 tests green across `test/fountain/conversations/` and the broker suite.

## Follow-up, not in here

The broker should hold the connection open across a 407 rather than closing — a client should not have to know. That needs a `managoat_broker` release, so it is filed separately along with two other things one release should carry. This PR is the half that stops the client depending on the server's 407 behaviour at all, and it is the half that unblocks production now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WDjZnydTVfeKhUBH3Qp7LD