### PR TITLE
fix(broker): BROKER_TOKEN only warns, it does not stop boot

### DIFF
--- a/apps/fountain/test/fountain/runtime_config_test.exs
+++ b/apps/fountain/test/fountain/runtime_config_test.exs
@@ -250,20 +250,32 @@ defmodule Fountain.RuntimeConfigTest do
       end
     end
 
-    test "a retired Agent Vault variable is a boot error, not a silent no-op", %{base: base} do
-      # These used to select a whole backend (#1487). A deployment that still
-      # carries one would otherwise broker nothing at all and say nothing.
-      for retired <- ~w(BROKER_URL BROKER_TOKEN) do
-        # read_prod_config/1 puts the map into the real environment, so the
-        # previous iteration's variable has to go or it raises first.
-        for k <- @broker_vars, do: System.delete_env(k)
+    test "BROKER_URL is a boot error, not a silent no-op", %{base: base} do
+      # It used to select a whole backend (#1487), so a deployment still
+      # carrying it would otherwise broker nothing at all and say nothing.
+      assert_raise RuntimeError,
+                   ~r/BROKER_URL is set, but the Agent Vault backend was removed/,
+                   fn ->
+                     read_prod_config(Map.put(base, "BROKER_URL", "http://agent-vault:14321"))
+                   end
+    end
 
-        assert_raise RuntimeError,
-                     ~r/#{retired} is set, but the Agent Vault backend was removed/,
-                     fn ->
-                       read_prod_config(Map.put(base, retired, "x"))
-                     end
-      end
+    test "BROKER_TOKEN only warns, because refusing to boot over it broke a real rollout",
+         %{base: base} do
+      # It never turned anything on by itself, and it outlives a deployment
+      # change by sitting in a secret store: dropped from the Deployment, it
+      # still arrived through `envFrom` and crash-looped the rollout that
+      # removed the backend. A warning is the proportionate answer.
+      cfg =
+        read_prod_config(
+          Map.merge(base, %{
+            "BROKER_TOKEN" => "av_sess_owner",
+            "BROKER_LISTEN_PORT" => "14322",
+            "BROKER_PROXY_URL" => "http://broker.example:14322"
+          })
+        )
+
+      assert cfg[:broker_listen_port] == 14_322
     end
 
     test "blank means off, including for the retired variables", %{base: base} do

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -205,13 +205,25 @@ broker_listen_port =
       end
   end
 
-# A deployment still carrying the retired vendor variables is told, rather
-# than quietly brokering nothing: they used to select a whole backend.
-for retired <- ~w(BROKER_URL BROKER_TOKEN) do
-  if blank_to_nil.(System.get_env(retired)) do
-    raise "#{retired} is set, but the Agent Vault backend was removed in #1487. " <>
-            "Set BROKER_LISTEN_PORT and BROKER_PROXY_URL instead; see docs/configuration.md."
-  end
+# BROKER_URL selected a whole backend, so a deployment still carrying it is
+# told rather than left to broker nothing in silence.
+if blank_to_nil.(System.get_env("BROKER_URL")) do
+  raise "BROKER_URL is set, but the Agent Vault backend was removed in #1487. " <>
+          "Set BROKER_LISTEN_PORT and BROKER_PROXY_URL instead; see docs/configuration.md."
+end
+
+# BROKER_TOKEN is only a warning, and the difference matters. It never turned
+# anything on by itself: it was the credential BROKER_URL used. Refusing to
+# boot over a leftover one punishes an upgrade for a variable that was doing
+# nothing, and it is the kind of value that outlives a deployment change by
+# sitting in a secret store rather than in a manifest. That is exactly how it
+# crash-looped this deployment's own rollout: the variable had been dropped
+# from the Deployment, and arrived anyway through `envFrom`.
+if blank_to_nil.(System.get_env("BROKER_TOKEN")) do
+  IO.warn(
+    "BROKER_TOKEN is set and is ignored: the Agent Vault backend was removed in #1487. " <>
+      "Remove it from your secret store; it is a credential for a service that no longer exists."
+  )
 end
 
 if broker_listen_port && is_nil(broker_proxy_url) do

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -56,6 +56,8 @@ message.
 | `BROKER_SESSION_TTL_SECONDS` | `21600` | — | How long a proxy session token lives. Fountain mints a new one on each provision and each reattach, and again before a turn when the current one is near its end. Both backends accept 300 to 604800. |
 | `BROKER_LOG_RETENTION_HOURS` | `168` | — | How long the egress request log keeps a row. `GET /api/conversations/:id/egress` reads it. A daily job deletes older rows. |
 | `BROKER_ALLOW_UNENFORCED` | `false` | — | A `true` lets a brokered conversation run on a provider that has no network policy, for example a self-hosted runner. The sandbox then holds placeholders and a proxy address, but nothing stops a process from a direct connection that avoids the proxy. For development only. |
+| `BROKER_URL` | — | — | **Retired.** It selected the Agent Vault backend. Fountain now runs the proxy itself, so this backend no longer exists. Boot refuses it, because a deployment that still sets it would otherwise broker nothing and say nothing. Remove it, and set `BROKER_LISTEN_PORT`. |
+| `BROKER_TOKEN` | — | — | **Retired.** It was the credential `BROKER_URL` used. Boot warns and ignores it. Remove it from your secret store: it is a credential for a service that no longer exists. |
 | `E2B_API_KEY` | — | For the `e2b` provider. | The [E2B](https://e2b.dev) API key. Its presence turns the provider on. |
 | `E2B_BASE_URL` | `https://api.e2b.app` | — | Repoints the E2B control plane. |
 | `E2B_TEMPLATE` | `base` | — | The template that Fountain creates a new E2B sandbox from. The stock `base` template has no agent CLI, so build one from `images/e2b/` for real use. |


### PR DESCRIPTION
**Unblocks a stalled production rollout that #1494 caused.** Production is up — the old replicas kept serving and the broker kept answering — but the new pods crash-loop and the Deployment is stuck.

```
** (RuntimeError) BROKER_TOKEN is set, but the Agent Vault backend was removed in #1487.
    /app/releases/0.16.0/runtime.exs:212
```

## What I got wrong

#1494 made **either** retired variable a boot error. That is right for `BROKER_URL`, which selected a whole backend: a deployment still carrying it and silently brokering nothing is the worst outcome available, so it should be told.

It is wrong for `BROKER_TOKEN`, which never turned anything on by itself — it was the credential `BROKER_URL` used. Refusing to boot over a leftover one punishes an upgrade for a variable that was doing nothing.

## How it reached the pods at all

The flip ([home-cloud#153](https://github.com/jhgaylor/home-cloud/pull/153)) dropped both variables from the Deployment. `BROKER_TOKEN` also lives in the Infisical-managed `fountain-secrets`, which the Deployment pulls in wholesale with `envFrom`, so it arrived anyway.

That is the part worth keeping: **a variable dropped from a manifest can still arrive from a secret store**, so a boot check reads as stricter than it looks when you are only looking at the manifest. I checked the Deployment for leftovers and not the Secret.

## The fix

`BROKER_URL` keeps the raise. `BROKER_TOKEN` warns, and says to remove it from the secret store because it is a credential for a service that no longer exists.

The follow-up is deleting the key from the Infisical project, which is the actual end state — this only stops it being fatal.

## Tests

The two cases are now separate, each naming the failure it guards. The `BROKER_TOKEN` one records why it is a warning, so nobody tightens it back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WDjZnydTVfeKhUBH3Qp7LD