### PR TITLE
docs(connections): Node stdio MCP servers need NODE_USE_ENV_PROXY

### DIFF
--- a/docs/catalog/connections/index.md
+++ b/docs/catalog/connections/index.md
@@ -58,6 +58,18 @@ the placeholder.
               "env": { "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_ACCESS_TOKEN}" } } }
 ```
 
+A Node server needs one more variable. The built-in `fetch` in Node ignores
+`HTTP_PROXY` and `HTTPS_PROXY`. Its requests do not reach the broker, so the
+broker never replaces the placeholder. The server fails with `fetch failed`.
+Set `NODE_USE_ENV_PROXY` to `1` in the same `env` block. A Python server
+obeys the proxy variables and needs no change.
+
+```json
+{ "slack": { "command": "npx", "args": ["-y", "@modelcontextprotocol/server-slack"],
+             "env": { "SLACK_BOT_TOKEN": "${SLACK_ACCESS_TOKEN}",
+                      "NODE_USE_ENV_PROXY": "1" } } }
+```
+
 **A remote MCP server.** The entry names a URL and a connection. At spawn it
 gets a placeholder bearer, and the broker attaches the token to that host.
 


### PR DESCRIPTION
Closes #1333.

Node's built-in `fetch` (undici) ignores `HTTP_PROXY` and `HTTPS_PROXY`. A Node stdio MCP server attached to a brokered connection therefore never reaches the egress broker, the broker never substitutes the placeholder, and the server fails with `fetch failed`.

The failure reads as "the MCP server is broken" rather than as a proxy problem, which is what makes it worth a paragraph rather than a troubleshooting entry.

It goes on the "stdio server in the sandbox" shape in `docs/catalog/connections/index.md`, where someone wiring a community Node server to a connection env key is already reading. The example is the one verified live on #1333 (`@modelcontextprotocol/server-slack`, which fails without the variable and works with it). A Python server obeys the proxy variables and needs nothing, so the paragraph says so rather than leaving the reader to wonder whether it applies to them.

## Gates

Docs-only, but this page is under all four:

| Gate | Result |
|---|---|
| `python3 scripts/docs-style.py` | clean, 111 files, 0 on the backlog |
| `vale lint docs` (STE, v0.15.0, same pin as CI) | 0 errors, 0 warnings |
| `node scripts/destink/destink.mjs` | clean, 111 pages, 33 rules |
| `mix test .../docs_test.exs` | 28 tests, 0 failures |

The new lines raise three `STE.Vocabulary` suggestions (`reach`, `never`, `block`). That rule advises and does not gate, by design — its wordset was built for aircraft maintenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WDjZnydTVfeKhUBH3Qp7LD