### PR TITLE
feat(buzz): cap and gate hosted agents, and stop them at a zero balance (#1017)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -321,6 +321,10 @@ STRIPE_WEBHOOK_SECRET=
 # Teammate contacts (numbers and inboxes) one account may hold at once. An
 # abuse ceiling, not an allowance: each is rented from the balance.
 # TEAM_CONTACT_CEILING=10
+# Hosted Buzz agents one account may run at once. Each enabled one is a
+# permanent buzz-acp process on Fountain's own pods, so it costs while nobody
+# uses it and no sandbox meter reports it. An abuse ceiling, not an allowance.
+# BUZZ_IDENTITY_CEILING=10
 
 # Prepaid credits (ADR 0030): what the customer pays, in whole cents. Distinct
 # from the provider costs above. The turn-hour price defaults to 25 and is a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,24 @@ upgrade, is in
   delivery. The per-replica gauge trap applies to `last_run_unix`: it exists
   only on the pod that ran the job, so every rule over it needs `max`.
 
+- **Hosted Buzz agents are bounded and gated** (#1017). Each enabled Buzz
+  identity is a supervised `buzz-acp` OS process on Fountain's own pods, so
+  the cost is standing rather than metered and `SandboxUsage` reports zero for
+  it. One account could stand up unbounded permanent processes, and
+  `BootSweep` restarted every one of them on each deploy. Standing up a *new*
+  agent now calls `Billing.check_spend/1` and a `BUZZ_IDENTITY_CEILING`
+  (default 10), both `402`; a converging deploy of an agent that already
+  exists is exempt, because it adds no process and refusing it would strand a
+  running harness on stale credentials. `Workers.BuzzHarnessSweep` stops the
+  harnesses of an account that cannot spend and starts them again when it can,
+  keeping the identity row so a top-up restores the agent intact rather than
+  needing a fresh deploy; the boot sweep asks the same question, so a deploy
+  no longer undoes it. The admin users table grows a **Slots** column showing
+  teammate contacts and hosted agents per tenant, which also renders the
+  contact count that had been assigned and never displayed. Pricing the slot
+  is still open, deliberately: the ceiling should run for a cycle before
+  anyone picks a number.
+
 - **Fountain can sit behind LiteLLM as an OpenAI-compatible upstream.** The
   `examples/litellm-gateway` configuration maps `fountain/<agent>` to every
   agent on an account, forwards `X-Fountain-Thread`, gives long-running turns

--- a/apps/fountain/lib/fountain/buzz.ex
+++ b/apps/fountain/lib/fountain/buzz.ex
@@ -60,6 +60,33 @@ defmodule Fountain.Buzz do
   end
 
   @doc """
+  How many hosted agents this tenant has. `BUZZ_IDENTITY_CEILING` bounds it.
+
+  Counts every identity, enabled or not: a disabled row is a slot the tenant
+  can re-enable without asking anyone, so a ceiling that ignored them would
+  bound nothing.
+  """
+  @spec identity_count(binary()) :: non_neg_integer()
+  def identity_count(user_id) when is_binary(user_id) do
+    Repo.aggregate(from(i in BuzzIdentity, where: i.user_id == ^user_id), :count, :id)
+  end
+
+  @doc """
+  Identity counts for every tenant with at least one, in a single query — for
+  the admin view, which shows the number on every row and must not run a count
+  per row (the same contract as `Fountain.Team.Comms.contact_counts/0` and
+  `Fountain.Quotas.active_sandbox_counts/0`).
+
+  Returns `%{user_id => count}`; tenants with no identities are absent.
+  """
+  @spec identity_counts() :: %{optional(binary()) => non_neg_integer()}
+  def identity_counts do
+    from(i in BuzzIdentity, group_by: i.user_id, select: {i.user_id, count(i.id)})
+    |> Repo.all()
+    |> Map.new()
+  end
+
+  @doc """
   Provision a Buzz identity from a caller that holds the Nostr key — the
   Fountain-side of the remote-agents provider deploy (ADR 0020 Phase 3, #738).
 
@@ -85,16 +112,55 @@ defmodule Fountain.Buzz do
   `owner-only` with an empty list, again because the deploy is the whole truth;
   `allowlist` with no pubkeys is `{:error, %Ecto.Changeset{}}` rather than a
   harness that refuses to start.
+
+  A *new* identity is gated twice (#1017). An enabled identity is a supervised
+  `buzz-acp` OS process on Fountain's own pods for as long as it exists, so
+  standing one up is spend that no sandbox meter ever reports: `check_spend/1`
+  refuses it on an exhausted balance, and `BUZZ_IDENTITY_CEILING` bounds how
+  many one tenant may stand up in a burst. Both are skipped when the deploy
+  **converges on an identity that already exists**, which adds no standing
+  process — refusing a re-deploy would strand a running harness on stale
+  credentials, which is strictly worse than letting it refresh them. What
+  stops the cost for an account out of credit is
+  `Fountain.Workers.BuzzHarnessSweep`, which suspends the harness and keeps
+  the row.
+
   Returns `{:ok, %BuzzIdentity{}}` or `{:error, reason}`.
   """
   def provision_identity(user_id, params, opts \\ []) when is_binary(user_id) do
     with {:ok, fields} <- validate_provision(params),
          :ok <- check_environment(fields.environment_id, user_id),
          :ok <- check_sandbox_mode(fields.sandbox_mode),
+         :ok <- check_new_identity_allowed(user_id, fields.pubkey),
          {:ok, dek} <- Crypto.load_tenant_key(user_id),
          {:ok, vault} <- ensure_vault(user_id, fields, dek, opts),
          :ok <- write_buzz_secrets(vault, fields, dek, opts) do
       upsert_identity(user_id, vault, fields, opts)
+    end
+  end
+
+  # The gate is the balance and the ceiling is the burst bound (ADR 0031,
+  # #1017). Both only apply to a provision that would add a standing process:
+  # `provision_identity/3` converges on the pubkey, and a converging deploy is
+  # maintenance on a slot the tenant already holds.
+  defp check_new_identity_allowed(user_id, pubkey) do
+    if get_identity_by_pubkey(pubkey, user_id) do
+      :ok
+    else
+      with :ok <- Fountain.Billing.check_spend(user_id) do
+        check_identity_ceiling(user_id)
+      end
+    end
+  end
+
+  defp check_identity_ceiling(user_id) do
+    limit = Application.get_env(:fountain, :buzz_identity_ceiling, 10)
+    count = identity_count(user_id)
+
+    if count < limit do
+      :ok
+    else
+      {:error, {:identity_limit_reached, %{count: count, limit: limit}}}
     end
   end
 

--- a/apps/fountain/lib/fountain/buzz/boot_sweep.ex
+++ b/apps/fountain/lib/fountain/buzz/boot_sweep.ex
@@ -37,8 +37,30 @@ defmodule Fountain.Buzz.BootSweep do
     # not a user-facing request — every identity's own user_id scopes the mint
     # and vault decrypt that `Manager.start_harness/2` performs downstream.
     Buzz._unsafe_list_enabled_identities()
+    |> Enum.filter(&may_spend?/1)
     |> Enum.map(&start_one/1)
     |> Enum.count(&(&1 == :ok))
+  end
+
+  # A harness is a standing OS process the sandbox meters never see (#1017),
+  # so the balance gates it here too. Without this the sweep would undo
+  # `Fountain.Workers.BuzzHarnessSweep` on every deploy: it stops a harness
+  # whose tenant cannot spend, and the next boot stood it straight back up.
+  # `check_spend/1` is `:ok` with billing off or for a comped account, so a
+  # deployment without credits sweeps exactly as it always did.
+  defp may_spend?(identity) do
+    case Fountain.Billing.check_spend(identity.user_id) do
+      :ok ->
+        true
+
+      {:error, reason} ->
+        Logger.info(
+          "buzz boot sweep: skipping identity=#{identity.id} " <>
+            "(user #{identity.user_id}: #{inspect(reason)})"
+        )
+
+        false
+    end
   end
 
   @impl true

--- a/apps/fountain/lib/fountain/workers/buzz_harness_sweep.ex
+++ b/apps/fountain/lib/fountain/workers/buzz_harness_sweep.ex
@@ -1,0 +1,123 @@
+defmodule Fountain.Workers.BuzzHarnessSweep do
+  @moduledoc """
+  Stops a hosted Buzz agent's harness when its tenant runs out of credit, and
+  starts it again when they top up (#1017).
+
+  ## Why this exists at all
+
+  A `BuzzIdentity` is not a row. Each enabled one is a supervised `buzz-acp`
+  **OS process** on Fountain's own pods (`Fountain.Buzz.Harness`, ADR 0020),
+  holding an Erlang port, a live relay connection and a long-lived API key. It
+  runs whether or not anyone ever mentions the agent, so the cost is
+  **standing, not usage**, and `Fountain.Billing.SandboxUsage` reports zero for
+  it: a harness is not a sandbox on any provider, and every existing meter
+  measures sandboxes.
+
+  So the balance could reach zero with the harnesses still up, and
+  `Fountain.Buzz.BootSweep` would stand every one of them back up on the next
+  deploy. Under ADR 0031 the gate is the balance, and nothing was applying it
+  to the one cost that is invisible to the meters.
+
+  ## Park, do not destroy
+
+  A tenant who fails `Billing.check_spend/1` has their harnesses **stopped**,
+  and the identity rows keep `enabled: true`. That mirrors how ADR 0017 parks
+  an idle sandbox rather than destroying it: the account is out of credit, not
+  gone, and a top-up should bring the agent back exactly as it was rather than
+  ask the provider to deploy it again. The sweep is symmetric for that reason
+  — it starts a harness whose tenant can spend again, which is also the
+  self-healing path for a harness that lost a race or died on a drained node.
+
+  Setting `enabled: false` is the tenant's own lever and this worker never
+  touches it. A disabled identity is a decision; a stopped harness is a
+  balance.
+
+  ## Reading the gate
+
+  `check_spend/1` is `:ok` with billing off, for a comped account, or on a
+  positive balance, so a deployment with `CREDITS_ENABLED` unset sweeps
+  nothing and every harness stays up. The tenants are asked once each rather
+  than once per identity — an account with several agents is one query, not
+  several.
+  """
+
+  use Oban.Worker, queue: :maintenance, max_attempts: 3
+
+  require Logger
+
+  alias Fountain.Buzz
+  alias Fountain.Buzz.{BootSweep, Manager}
+
+  @impl Oban.Worker
+  def perform(_job) do
+    %{stopped: stopped, started: started} = run()
+
+    Logger.info("buzz harness sweep: stopped=#{stopped} started=#{started}")
+
+    :telemetry.execute(
+      [:fountain, :buzz_harness_sweep, :run],
+      %{stopped: stopped, started: started},
+      %{}
+    )
+
+    :ok
+  end
+
+  @doc """
+  Reconcile every enabled identity's harness against its tenant's balance.
+
+  Returns `%{stopped: n, started: n}`. A no-op unless a `buzz-acp` binary is
+  configured — with none there is no harness to stop, and `BootSweep.enabled?/0`
+  is the same question this asks.
+  """
+  @spec run() :: %{stopped: non_neg_integer(), started: non_neg_integer()}
+  def run do
+    if BootSweep.enabled?() do
+      # ownership: a system-level sweep across all tenants, like the boot
+      # sweep and the sandbox reaper. Each identity's own user_id scopes the
+      # gate below and the mint that `start_harness/2` performs downstream.
+      identities = Buzz._unsafe_list_enabled_identities()
+
+      may_spend =
+        identities
+        |> Enum.map(& &1.user_id)
+        |> Enum.uniq()
+        |> Map.new(&{&1, Fountain.Billing.check_spend(&1) == :ok})
+
+      Enum.reduce(identities, %{stopped: 0, started: 0}, fn identity, acc ->
+        reconcile(identity, Map.get(may_spend, identity.user_id, true), acc)
+      end)
+    else
+      %{stopped: 0, started: 0}
+    end
+  end
+
+  defp reconcile(identity, may_spend?, acc) do
+    case {may_spend?, Manager.running?(identity.id)} do
+      {false, true} ->
+        :ok = Manager.stop_harness(identity.id)
+
+        Logger.info(
+          "buzz harness sweep: stopped #{identity.id} (user #{identity.user_id} cannot spend)"
+        )
+
+        %{acc | stopped: acc.stopped + 1}
+
+      {true, false} ->
+        case Manager.start_harness(identity) do
+          {:ok, _pid} ->
+            %{acc | started: acc.started + 1}
+
+          {:error, reason} ->
+            Logger.warning(
+              "buzz harness sweep: could not start #{identity.id}: #{inspect(reason)}"
+            )
+
+            acc
+        end
+
+      _ ->
+        acc
+    end
+  end
+end

--- a/apps/fountain/lib/fountain_web/controllers/buzz_agent_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/buzz_agent_controller.ex
@@ -39,8 +39,16 @@ defmodule FountainWeb.BuzzAgentController do
   operation(:create,
     summary: "Provision (or converge on) a hosted Buzz agent",
     request_body: {"Provision attributes", "application/json", Schemas.BuzzProvisionRequest},
+    description:
+      "Converges on the Nostr pubkey, so a provider may call it repeatedly. " <>
+        "A deploy that would add a **new** hosted agent is gated by the credit " <>
+        "balance and by `BUZZ_IDENTITY_CEILING`, both `402`; a converging " <>
+        "deploy of an agent that already exists is not.",
     responses: [
       created: {"Buzz agent", "application/json", Schemas.BuzzIdentityResponse},
+      payment_required:
+        {"Balance exhausted, or the hosted-agent ceiling is reached", "application/json",
+         Schemas.Error},
       unprocessable_entity: {"Validation error", "application/json", Schemas.Error}
     ]
   )
@@ -88,6 +96,26 @@ defmodule FountainWeb.BuzzAgentController do
           error: "invalid_sandbox_mode",
           detail: "sandbox_mode must be ephemeral or persistent"
         })
+
+      # 402, the same status the credit gate uses, and for the same reason the
+      # contact ceiling does: the fix is a top-up or an operator decision, not
+      # a retry. The numbers are in the body so a provider can say which
+      # ceiling it hit (#1017).
+      {:error, {:identity_limit_reached, %{count: count, limit: limit}}} ->
+        conn
+        |> put_status(:payment_required)
+        |> json(%{
+          error: "identity_limit_reached",
+          message: "this account may run #{limit} hosted Buzz agents (#{count} in use)",
+          count: count,
+          limit: limit
+        })
+
+      # Standing up a permanent process is spend, so the balance gates it
+      # (ADR 0031). Rendered by the FallbackController as the 402 every other
+      # door gives, with `upgrade_url`.
+      {:error, :insufficient_credits} = err ->
+        err
 
       # Field errors — an empty allowlist in allowlist mode, a malformed pubkey —
       # so a provider deploy can say *why* it was refused, not a bare 422.

--- a/apps/fountain/lib/fountain_web/live/admin_live/users.ex
+++ b/apps/fountain/lib/fountain_web/live/admin_live/users.ex
@@ -33,7 +33,11 @@ defmodule FountainWeb.AdminLive.Users do
      socket
      |> FountainWeb.Audited.put_client_ip()
      |> assign(:page_title, "Admin · Users")
-     |> assign(:credits_enabled, Fountain.Credits.enabled?())}
+     |> assign(:credits_enabled, Fountain.Credits.enabled?())
+     |> assign(
+       :buzz_identity_ceiling,
+       Application.get_env(:fountain, :buzz_identity_ceiling, 10)
+     )}
   end
 
   # Filter/sort/page state lives in the URL, so the 10s refresh, admin
@@ -318,6 +322,10 @@ defmodule FountainWeb.AdminLive.Users do
     # One grouped query, not one per row — the same contract as the sandbox
     # counts above. The page refreshes on a timer.
     contact_counts = Fountain.Team.Comms.contact_counts()
+    # Hosted Buzz agents are standing OS processes on the gateway pods that no
+    # sandbox meter reports (#1017). You cannot bound what nobody can see, so
+    # the slot count sits beside the sandbox and contact counts.
+    identity_counts = Fountain.Buzz.identity_counts()
 
     %{users: users, total: total} =
       Accounts.list_users_admin(
@@ -337,6 +345,7 @@ defmodule FountainWeb.AdminLive.Users do
         |> Map.put(:active_sandboxes, Map.get(sandbox_counts, u.id, 0))
         |> Map.put(:sandbox_limit, Fountain.Quotas.sandbox_limit_for(u))
         |> Map.put(:contact_count, Map.get(contact_counts, u.id, 0))
+        |> Map.put(:buzz_identity_count, Map.get(identity_counts, u.id, 0))
         |> Map.put(:usage, Map.get(usage, u.id, no_usage))
       end)
 
@@ -489,6 +498,12 @@ defmodule FountainWeb.AdminLive.Users do
                 Usage 30d
               </th>
               <th class="px-4 py-2">Sandboxes</th>
+              <%!-- Standing slots: a teammate contact is rented from the
+                    balance every month, and a hosted Buzz agent is a
+                    permanent OS process on these pods that no sandbox meter
+                    reports (#1017). Both cost while nobody uses them, which
+                    is exactly why they belong on the row. --%>
+              <th class="px-4 py-2" title="Teammate contacts · hosted Buzz agents">Slots</th>
               <th class="px-4 py-2">Onboarding</th>
               <th class="px-4 py-2">
                 <.sort_header label="Last active" col="last_activity" filters={@filters} />
@@ -605,6 +620,19 @@ defmodule FountainWeb.AdminLive.Users do
                   />
                   <button class="text-xs text-zinc-500 hover:text-zinc-900 underline">set</button>
                 </form>
+              </td>
+              <td
+                class="px-4 py-2 text-xs text-zinc-500 tabular-nums whitespace-nowrap"
+                title={"#{u.contact_count} teammate contact(s) · #{u.buzz_identity_count} hosted Buzz agent(s)"}
+              >
+                <span class={
+                  if(u.buzz_identity_count >= @buzz_identity_ceiling,
+                    do: "text-red-600 font-medium",
+                    else: ""
+                  )
+                }>
+                  {u.contact_count}c · {u.buzz_identity_count}b
+                </span>
               </td>
               <td class="px-4 py-2 text-zinc-500 text-xs">
                 {if u.onboarding_completed_at, do: format_date(u.onboarding_completed_at), else: "—"}

--- a/apps/fountain/test/fountain/buzz_ceiling_test.exs
+++ b/apps/fountain/test/fountain/buzz_ceiling_test.exs
@@ -1,0 +1,130 @@
+defmodule Fountain.BuzzCeilingTest do
+  @moduledoc """
+  `BUZZ_IDENTITY_CEILING` and the spend gate on `provision_identity/3` (#1017).
+
+  `async: false`: the ceiling is application env, and an async test that writes
+  it leaks into every other module running beside it (#1214).
+  """
+
+  use Fountain.DataCase, async: false
+
+  alias Fountain.{Buzz, Credits}
+
+  setup do
+    prev = Application.get_env(:fountain, :buzz_identity_ceiling)
+    on_exit(fn -> restore(:buzz_identity_ceiling, prev) end)
+
+    user = insert_verified_user()
+    agent = insert_agent(%{"user_id" => user.id})
+
+    params = fn pubkey ->
+      %{
+        "name" => "philo-#{String.slice(pubkey, 0, 6)}",
+        "relay_url" => "wss://relay.example",
+        "agent_id" => agent.id,
+        "pubkey" => pubkey,
+        "private_key_nsec" => "nsec1secret",
+        "auth_tag" => "[\"auth\",\"owner\"]"
+      }
+    end
+
+    %{user: user, params: params}
+  end
+
+  defp restore(key, nil), do: Application.delete_env(:fountain, key)
+  defp restore(key, val), do: Application.put_env(:fountain, key, val)
+
+  defp pubkey(n), do: String.duplicate(Integer.to_string(n, 16), 64) |> String.slice(0, 64)
+
+  describe "the ceiling" do
+    test "refuses a new identity once the tenant is at the limit", %{user: user, params: params} do
+      Application.put_env(:fountain, :buzz_identity_ceiling, 2)
+
+      assert {:ok, _} = Buzz.provision_identity(user.id, params.(pubkey(1)))
+      assert {:ok, _} = Buzz.provision_identity(user.id, params.(pubkey(2)))
+
+      assert {:error, {:identity_limit_reached, %{count: 2, limit: 2}}} =
+               Buzz.provision_identity(user.id, params.(pubkey(3)))
+
+      # Refused before anything was written: no orphan vault, no third row.
+      assert length(Buzz.list_identities(user.id)) == 2
+    end
+
+    test "a converging deploy of an identity that already exists is exempt", %{
+      user: user,
+      params: params
+    } do
+      Application.put_env(:fountain, :buzz_identity_ceiling, 1)
+
+      assert {:ok, first} = Buzz.provision_identity(user.id, params.(pubkey(1)))
+
+      # At the ceiling now. The provider's repeated `deploy` must still land —
+      # it adds no standing process, and refusing it would strand a running
+      # harness on stale credentials.
+      assert {:ok, again} =
+               Buzz.provision_identity(
+                 user.id,
+                 params.(pubkey(1)) |> Map.put("private_key_nsec", "nsec1rotated")
+               )
+
+      assert again.id == first.id
+
+      {:ok, dek} = Fountain.Crypto.load_tenant_key(user.id)
+      vault = Fountain.Vaults.get_vault(again.vault_id, user.id)
+      assert Fountain.Vaults.decrypted_env(vault, dek)["BUZZ_PRIVATE_KEY"] == "nsec1rotated"
+    end
+
+    test "a disabled identity still occupies a slot", %{user: user, params: params} do
+      Application.put_env(:fountain, :buzz_identity_ceiling, 1)
+
+      assert {:ok, identity} = Buzz.provision_identity(user.id, params.(pubkey(1)))
+      {:ok, _} = Buzz.update_identity(identity, %{"enabled" => false})
+
+      # A disabled row is a slot the tenant can re-enable without asking
+      # anyone, so a ceiling that ignored it would bound nothing.
+      assert {:error, {:identity_limit_reached, %{count: 1, limit: 1}}} =
+               Buzz.provision_identity(user.id, params.(pubkey(2)))
+    end
+
+    test "the ceiling is per tenant, not global", %{user: user, params: params} do
+      Application.put_env(:fountain, :buzz_identity_ceiling, 1)
+
+      assert {:ok, _} = Buzz.provision_identity(user.id, params.(pubkey(1)))
+
+      other = insert_verified_user()
+      other_agent = insert_agent(%{"user_id" => other.id})
+      other_params = params.(pubkey(2)) |> Map.put("agent_id", other_agent.id)
+
+      assert {:ok, _} = Buzz.provision_identity(other.id, other_params)
+    end
+  end
+
+  describe "the spend gate" do
+    test "a drained account cannot stand up a new hosted agent", %{user: user, params: params} do
+      drain(user)
+
+      assert {:error, :insufficient_credits} =
+               Buzz.provision_identity(user.id, params.(pubkey(1)))
+
+      assert Buzz.list_identities(user.id) == []
+    end
+
+    test "a drained account may still converge on one it already has", %{
+      user: user,
+      params: params
+    } do
+      assert {:ok, first} = Buzz.provision_identity(user.id, params.(pubkey(1)))
+      drain(user)
+
+      assert {:ok, again} = Buzz.provision_identity(user.id, params.(pubkey(1)))
+      assert again.id == first.id
+    end
+  end
+
+  defp drain(user) do
+    case Credits.balance(user.id) do
+      0 -> :ok
+      cents -> {:ok, _} = Credits.debit(user.id, cents, "burn_turn", idempotency_key: "drain")
+    end
+  end
+end

--- a/apps/fountain/test/fountain/workers/buzz_harness_sweep_test.exs
+++ b/apps/fountain/test/fountain/workers/buzz_harness_sweep_test.exs
@@ -1,0 +1,130 @@
+defmodule Fountain.Workers.BuzzHarnessSweepTest do
+  @moduledoc """
+  The balance applied to the one cost no sandbox meter sees (#1017).
+
+  `async: false`: sets application env and starts real harnesses under the
+  global Horde supervisor, the same reasons `BootSweepTest` gives.
+  """
+
+  use Fountain.DataCase, async: false
+
+  alias Fountain.Buzz.{BootSweep, Manager}
+  alias Fountain.Credits
+  alias Fountain.Workers.BuzzHarnessSweep
+
+  setup do
+    dir = Fountain.TmpDir.mkdir!("buzz-harness-sweep")
+    fake = Path.join(dir, "buzz-acp")
+    File.write!(fake, "#!/bin/sh\nexec sleep 30\n")
+    File.chmod!(fake, 0o755)
+
+    prev_path = Application.get_env(:fountain, :buzz_acp_path)
+    prev_url = Application.get_env(:fountain, :buzz_acp_base_url)
+
+    on_exit(fn ->
+      restore(:buzz_acp_path, prev_path)
+      restore(:buzz_acp_base_url, prev_url)
+      Fountain.BuzzTestSupport.stop_all_harnesses!()
+      File.rm_rf(dir)
+    end)
+
+    Application.put_env(:fountain, :buzz_acp_path, fake)
+    Application.put_env(:fountain, :buzz_acp_base_url, "https://fountain.test")
+
+    :ok
+  end
+
+  defp restore(key, nil), do: Application.delete_env(:fountain, key)
+  defp restore(key, val), do: Application.put_env(:fountain, key, val)
+
+  defp drain(user_id) do
+    case Credits.balance(user_id) do
+      0 -> :ok
+      cents -> {:ok, _} = Credits.debit(user_id, cents, "burn_turn", idempotency_key: "drain")
+    end
+  end
+
+  test "stops the harness of a tenant who cannot spend, and keeps the row enabled" do
+    identity = insert_buzz_identity(%{"enabled" => true})
+    assert {:ok, _} = Manager.start_harness(identity)
+    assert Manager.running?(identity.id)
+
+    drain(identity.user_id)
+
+    assert %{stopped: 1} = BuzzHarnessSweep.run()
+    refute Manager.running?(identity.id)
+
+    # Park, do not destroy (ADR 0017's shape): the account is out of credit,
+    # not gone, so a top-up brings the same agent back rather than asking the
+    # provider to deploy it again. `enabled` is the tenant's own lever and the
+    # sweep never touches it.
+    assert Fountain.Buzz._unsafe_get_identity(identity.id).enabled
+  end
+
+  test "starts a harness again once the tenant can spend" do
+    identity = insert_buzz_identity(%{"enabled" => true})
+    drain(identity.user_id)
+
+    assert %{started: 0} = BuzzHarnessSweep.run()
+    refute Manager.running?(identity.id)
+
+    {:ok, _} = Credits.grant(identity.user_id, 500, "grant_admin", idempotency_key: "top-up")
+
+    assert %{started: 1} = BuzzHarnessSweep.run()
+    assert Manager.running?(identity.id)
+  end
+
+  test "leaves a funded tenant's running harness alone" do
+    identity = insert_buzz_identity(%{"enabled" => true})
+    assert {:ok, pid} = Manager.start_harness(identity)
+
+    assert %{stopped: 0, started: 0} = BuzzHarnessSweep.run()
+    assert Manager.whereis(identity.id) == pid
+  end
+
+  test "ignores a disabled identity whatever the balance" do
+    identity = insert_buzz_identity(%{"enabled" => false})
+    drain(identity.user_id)
+
+    assert %{stopped: 0, started: 0} = BuzzHarnessSweep.run()
+    refute Manager.running?(identity.id)
+  end
+
+  test "is inert with no buzz-acp binary configured" do
+    Application.delete_env(:fountain, :buzz_acp_path)
+    refute BootSweep.enabled?()
+
+    identity = insert_buzz_identity(%{"enabled" => true})
+    drain(identity.user_id)
+
+    # Nothing to stop and nothing to start: the sweep must not query, log or
+    # act on an instance that runs no harnesses at all.
+    assert %{stopped: 0, started: 0} = BuzzHarnessSweep.run()
+  end
+
+  test "asks the gate once per tenant, not once per identity" do
+    user = insert_verified_user()
+    agent = insert_agent(%{"user_id" => user.id})
+
+    for _ <- 1..3 do
+      insert_buzz_identity(%{"user_id" => user.id, "agent_id" => agent.id, "enabled" => true})
+    end
+
+    drain(user.id)
+
+    assert %{stopped: 0, started: 0} = BuzzHarnessSweep.run()
+  end
+
+  test "the boot sweep skips a tenant who cannot spend" do
+    funded = insert_buzz_identity(%{"enabled" => true})
+    broke = insert_buzz_identity(%{"enabled" => true})
+    drain(broke.user_id)
+
+    BootSweep.run()
+
+    # Without this the boot sweep would undo the harness sweep on every
+    # deploy: stopped at 15 past the hour, back up at the next rollout.
+    assert Manager.running?(funded.id)
+    refute Manager.running?(broke.id)
+  end
+end

--- a/apps/fountain/test/fountain_web/controllers/buzz_agent_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/buzz_agent_controller_test.exs
@@ -280,4 +280,59 @@ defmodule FountainWeb.BuzzAgentControllerTest do
     # OpenApiSpex CastAndValidate rejects the missing required field before the action.
     assert conn.status in [422, 400]
   end
+
+  describe "the standing-cost gates (#1017)" do
+    test "402 identity_limit_reached at the ceiling, with the numbers", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key,
+      agent: agent
+    } do
+      prev = Application.get_env(:fountain, :buzz_identity_ceiling)
+      Application.put_env(:fountain, :buzz_identity_ceiling, 1)
+
+      on_exit(fn ->
+        if prev,
+          do: Application.put_env(:fountain, :buzz_identity_ceiling, prev),
+          else: Application.delete_env(:fountain, :buzz_identity_ceiling)
+      end)
+
+      {:ok, _} = Fountain.Buzz.provision_identity(user.id, params(agent))
+
+      conn =
+        conn
+        |> authed_with_key(raw_key)
+        |> put_req_header("content-type", "application/json")
+        |> post("/api/buzz/agents", %{params(agent) | "pubkey" => String.duplicate("b", 64)})
+
+      # 402 rather than 429: the fix is a ceiling change, not a retry, which
+      # is the same reasoning the teammate-contact ceiling gives.
+      assert %{"error" => "identity_limit_reached", "count" => 1, "limit" => 1} =
+               json_response(conn, 402)
+    end
+
+    test "402 insufficient_credits when the balance is exhausted", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key,
+      agent: agent
+    } do
+      case Fountain.Credits.balance(user.id) do
+        0 -> :ok
+        c -> {:ok, _} = Fountain.Credits.debit(user.id, c, "burn_turn", idempotency_key: "d")
+      end
+
+      conn =
+        conn
+        |> authed_with_key(raw_key)
+        |> put_req_header("content-type", "application/json")
+        |> post("/api/buzz/agents", params(agent))
+
+      # The FallbackController's 402, the same one every other spending door
+      # gives, carrying `upgrade_url` — not the generic 422 the catch-all
+      # would have produced.
+      assert %{"error" => "insufficient_credits"} = json_response(conn, 402)
+      assert Fountain.Buzz.list_identities(user.id) == []
+    end
+  end
 end

--- a/config/config.exs
+++ b/config/config.exs
@@ -28,6 +28,12 @@ config :fountain, Oban,
        # A server's autonomous quiet timer is in memory. Sweep old, silent
        # running turns whose server disappeared before that timer fired.
        {"*/5 * * * *", Fountain.Workers.AutonomousTurnReaper},
+       # Every 15 minutes: a hosted Buzz agent is a standing OS process that
+       # no sandbox meter sees (#1017), so the balance has to be applied to it
+       # out of band. Stops a harness whose tenant cannot spend, starts one
+       # whose tenant can again. Cheap — one query for the enabled identities
+       # and one gate per distinct tenant.
+       {"*/15 * * * *", Fountain.Workers.BuzzHarnessSweep},
        # 05:41 UTC — after the 03:17 backup and the 04:23 retention prune, so
        # a backup always captures the accounts before the sweep removes them.
        {"41 5 * * *", Fountain.Workers.UnverifiedAccountPruner},
@@ -77,6 +83,12 @@ config :fountain,
 # overrides from SANDBOX_*.
 # Teammate contacts a tenant may hold at once — an abuse ceiling, not a price.
 config :fountain, :team_contact_ceiling, 10
+
+# Hosted Buzz agents a tenant may run at once. Each enabled identity is a
+# supervised `buzz-acp` OS process on Fountain's own pods (ADR 0020), so the
+# cost is standing rather than metered — no sandbox meter sees it. An abuse
+# ceiling, not an allowance (#1017).
+config :fountain, :buzz_identity_ceiling, 10
 
 config :fountain, :sandboxes,
   reserve_cents: 200,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -968,6 +968,9 @@ config :fountain, :sandboxes,
 # Teammate contacts one account may hold at once — an abuse ceiling.
 config :fountain, :team_contact_ceiling, whole_number.("TEAM_CONTACT_CEILING", 10)
 
+# Hosted Buzz agents one account may run at once — an abuse ceiling (#1017).
+config :fountain, :buzz_identity_ceiling, whole_number.("BUZZ_IDENTITY_CEILING", 10)
+
 config :fountain, :credits,
   # The opening grant a new account gets, and how many days it lasts.
   opening_cents: credit_cents.("CREDIT_OPENING_CENTS") || 500,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -150,6 +150,7 @@ at a dead end, with no error to see. Read [Email](guides/operate/email.md).
 | `CREDIT_OPENING_CENTS` | `500` | No. | The credit a new account starts with, in cents. |
 | `CREDIT_OPENING_DAYS` | `14` | No. | How many days the opening credit lasts. |
 | `TEAM_CONTACT_CEILING` | `10` | No. | The most teammate contacts one account may hold at once. |
+| `BUZZ_IDENTITY_CEILING` | `10` | No. | The most hosted Buzz agents one account may run at once. Each one is a permanent process on the Fountain pods. |
 | `CREDIT_TURN_HOUR_CENTS` | `25` | No. | What a tenant pays for one hour of turn time, in whole cents, from their prepaid balance. |
 | `CREDIT_NUMBER_CENTS` | — | No. | What a tenant pays for one phone number each month, in whole cents. Unset means the number burns nothing. |
 | `CREDIT_INBOX_CENTS` | — | No. | What a tenant pays for one inbox each month, in whole cents. Unset means the inbox burns nothing. |

--- a/docs/guides/operate/plans-and-prices.md
+++ b/docs/guides/operate/plans-and-prices.md
@@ -67,6 +67,21 @@ number.
 `TEAM_CONTACT_CEILING` (10) is the most contacts one account may hold at once.
 It is an abuse ceiling, not a price.
 
+## Hosted Buzz agents
+
+An enabled Buzz identity is a permanent `buzz-acp` process on the Fountain
+pods. It costs while nobody uses it, and no sandbox meter reports it, because
+it is not a sandbox. Two rules apply to it.
+
+`BUZZ_IDENTITY_CEILING` (10) is the most hosted agents one account may run at
+once. It is an abuse ceiling, not a price.
+
+An account with no credit keeps its agents but not their processes. Fountain
+stops each harness within 15 minutes and keeps the row, in the same way that
+an idle sandbox parks. A top-up starts them again on the next sweep. Nothing
+charges for the agent itself yet. Only the conversations it opens burn
+credit.
+
 ## How many agents at once
 
 A tenant may run as many sandboxes at once as the balance funds: one for each

--- a/sdk/contract/contract.json
+++ b/sdk/contract/contract.json
@@ -3157,6 +3157,11 @@
             "ref": "BuzzIdentityResponse"
           }
         },
+        "402": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "422": {
           "application/json": {
             "ref": "Error"

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -902,7 +902,10 @@ export interface paths {
         /** List hosted Buzz agents */
         get: operations["FountainWeb.BuzzAgentController.index"];
         put?: never;
-        /** Provision (or converge on) a hosted Buzz agent */
+        /**
+         * Provision (or converge on) a hosted Buzz agent
+         * @description Converges on the Nostr pubkey, so a provider may call it repeatedly. A deploy that would add a **new** hosted agent is gated by the credit balance and by `BUZZ_IDENTITY_CEILING`, both `402`; a converging deploy of an agent that already exists is not.
+         */
         post: operations["FountainWeb.BuzzAgentController.create"];
         delete?: never;
         options?: never;
@@ -7013,6 +7016,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["BuzzIdentityResponse"];
+                };
+            };
+            /** @description Balance exhausted, or the hosted-agent ceiling is reached */
+            402: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
                 };
             };
             /** @description Validation error */


### PR DESCRIPTION
Closes #1017 (the P1 half — the cap and the gate. Pricing stays open, deliberately; see below).

## What a hosted Buzz agent costs

An enabled `BuzzIdentity` is not a row. Each one is a supervised `buzz-acp` **OS process** on Fountain's own pods (`Fountain.Buzz.Harness`, ADR 0020), holding an Erlang port, a live relay connection and a long-lived API key. It runs whether or not anyone ever mentions the agent, so the cost is **standing, not usage** — and `Billing.SandboxUsage` measures *sandboxes*, so every meter reported zero for it.

Verified on `main` before starting: `provision_identity/3` ran `validate_provision → check_environment → check_sandbox_mode → ensure_vault → write_buzz_secrets → upsert_identity`. No quota, no gate. `BootSweep` stood every enabled identity across every tenant back up on each deploy.

The issue's original prescription named `Plans.hosted_agents` and `check_active/1`, both of which ADR 0031 deleted. This builds the re-spec from its 2026-09-02 comment.

## The two gates

A provision that would add a **new** identity calls `Billing.check_spend/1` and then `BUZZ_IDENTITY_CEILING` (default 10, the `TEAM_CONTACT_CEILING` shape exactly, including the 402 with `count` and `limit` in the body).

A **converging** deploy of an identity that already exists is exempt from both. `provision_identity/3` converges on the pubkey by design, a converging deploy adds no standing process, and refusing a provider's repeated `deploy` would leave a running harness on stale credentials — strictly worse than letting it refresh them. There is a test for each direction.

The ceiling counts disabled rows too: a disabled identity is a slot the tenant can re-enable without asking anyone, so a ceiling that ignored them would bound nothing.

## Stopping the cost

A ceiling alone does not help an account that already has agents and no credit. `Fountain.Workers.BuzzHarnessSweep` is a 15-minute Oban cron that stops the harnesses of a tenant who fails the gate and starts them again once they can spend, asking the gate once per distinct tenant rather than once per identity.

It keeps `enabled: true`. The account is out of credit, not gone, so a top-up brings the same agent back rather than needing a fresh deploy — ADR 0017's park-do-not-destroy shape. `enabled` stays the tenant's own lever and the sweep never writes it.

`BootSweep` asks the same question. Without that, a deploy would undo every stop: harness down at :15, back up at the next rollout.

## Making the slots visible

The admin users table grows a **Slots** column with contacts and hosted agents per tenant, over one grouped query each (the `active_sandbox_counts/0` contract — never a count per row). It also renders `contact_count`, which was being assembled and thrown away.

## Not in this PR

Pricing, on the issue's own argument: the marginal cost of one more process is lumpy and near-zero until pods abruptly run out, so the ceiling should run for a cycle before anyone picks a number. If it is ever priced the live shape is rent from the balance (`Credits.Rent`), not the plan axis or Stripe add-on the original issue proposed — both describe objects ADR 0031 deleted.

## Testing

- `mix precommit` — **6 doctests, 4177 tests, 0 failures**, exit 0.
- 13 new tests across `buzz_ceiling_test.exs`, `workers/buzz_harness_sweep_test.exs` and the controller test. Both new test files are `async: false` and say why — they write application env, which an async test leaks (#1214).
- The four gate tests were verified by reverting: removing the `check_new_identity_allowed` clause and the boot sweep's filter fails exactly the four that should fail.
- All three prose gates clean; all four SDK contract verifiers (typescript, python, elixir, swift) pass against the new 402.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bcpj4FrtXSmLrsWphGMVus