### PR TITLE
fix(acp): send the substituted MCP configuration on session/new (#1404)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,26 @@ upgrade, is in
 
 ### Fixed
 
+- **ACP `session/new` carried the agent's unsubstituted MCP configuration**
+  (#1404). Fountain resolves `${VAR}` references once at provision and writes
+  the sandbox's `.mcp.json` from the result, but the turn path re-read the
+  agent row on every prompt and sent *that* — the stored document, escapes
+  and all — as `session/new.mcpServers`. The session copy wins in Claude
+  Code, so a conversation-authenticated HTTP MCP server declared
+  `Bearer $${FOUNTAIN_TOKEN}` received `Bearer $ftn_…`: the runtime expanded
+  the inner reference and left the escape behind, and Salon had to strip the
+  stray `$` at its end. There is one substitution pass and one effective
+  configuration now — the resolved document is carried on the conversation
+  and is what both the project file and the session get. Resolved values
+  still exist only on the live conversation path; the stored agent, API
+  responses, logs and audit records are unchanged. `${FOUNTAIN_TOKEN}` and
+  `${FOUNTAIN_CONVERSATION_ID}` remain the runtime's to expand from the
+  sandbox process environment, which is what keeps a reattached or resumed
+  turn on the current credential rather than one frozen into a document.
+  Assembling the `session/new` list moved to
+  `Conversations.McpServers.for_session/3`, so the server's pin holds at
+  2,835 rather than growing.
+
 - **Platform inference on the gemini runtime was unbilled** (#1459). gemini
   leaves ACP's `PromptResponse.usage` empty and reports the turn's tokens
   under a vendor extension at `_meta.quota.token_count`, so

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -471,6 +471,9 @@ defmodule Fountain.Conversations.ConversationServer do
       # conversation (#1178): their access tokens rotate hourly, so each turn
       # kick re-reads them and re-prepares the vault when one has changed.
       connection_keys: [],
+      # This conversation's one resolved MCP configuration (#1404). See
+      # `McpServers.resolve_for_session/2`.
+      resolved_mcp_servers: nil,
       # The environment's networking shape, enforced at the broker (gate 2).
       broker_network: :unrestricted,
       # What the runtime's default_env/2 is handed (gate 3): the real
@@ -746,6 +749,8 @@ defmodule Fountain.Conversations.ConversationServer do
   defp dispatch_provision(state, conv, sandbox, agent, env, _vault, secrets) do
     case McpServers.substitute_agent(agent, env, secrets) do
       {:ok, agent} ->
+        state = %{state | resolved_mcp_servers: agent && agent.mcp_servers}
+
         case sandbox.status do
           s when s in ["ready", "suspended"] ->
             # The sprite already exists at sprites.dev and was fully provisioned
@@ -2504,15 +2509,12 @@ defmodule Fountain.Conversations.ConversationServer do
                     cwd: cwd,
                     images: images,
                     mcp_servers:
-                      Managoat.Runtimes.ACP.mcp_servers(
-                        Egress.with_connection_servers(
-                          agent,
-                          state.user_id,
-                          state.conversation_id,
-                          state.callback_token
-                        )
-                      ) ++
-                        McpServers.fountain_served(conv, state.callback_token),
+                      McpServers.for_session(agent, conv,
+                        user_id: state.user_id,
+                        conversation_id: state.conversation_id,
+                        callback_token: state.callback_token,
+                        resolved: state.resolved_mcp_servers
+                      ),
                     model:
                       agent &&
                         Managoat.Runtimes.Model.acp_model(

--- a/apps/fountain/lib/fountain/conversations/mcp_servers.ex
+++ b/apps/fountain/lib/fountain/conversations/mcp_servers.ex
@@ -39,6 +39,62 @@ defmodule Fountain.Conversations.McpServers do
   end
 
   @doc """
+  The whole `session/new` MCP list for a turn: the agent's own servers, with
+  `${VAR}` already resolved and the tenant's brokered connections folded in,
+  followed by the ones Fountain serves back to the sandbox.
+
+  `opts` is what `ConversationServer` unpacks from its state — `:user_id`,
+  `:conversation_id`, `:callback_token` and `:resolved`, the conversation's
+  resolved MCP configuration (see `resolve_for_session/2`).
+  """
+  @spec for_session(Agent.t() | nil, map(), keyword()) :: [map()]
+  def for_session(agent, conv, opts) do
+    token = Keyword.get(opts, :callback_token)
+
+    agent
+    |> resolve_for_session(Keyword.get(opts, :resolved))
+    |> Fountain.Conversations.Egress.with_connection_servers(
+      Keyword.fetch!(opts, :user_id),
+      Keyword.fetch!(opts, :conversation_id),
+      token
+    )
+    |> Managoat.Runtimes.ACP.mcp_servers()
+    |> Kernel.++(fountain_served(conv, token))
+  end
+
+  @doc """
+  Put the conversation's already-resolved MCP configuration back onto a
+  freshly-fetched agent, for the turn that is about to open a session.
+
+  The turn path re-reads the agent row on every prompt, which is right — an
+  edit between turns should take effect — but that row holds the *stored*
+  document, with its `${VAR}` references and `$$` escapes unresolved. Sending
+  that to ACP `session/new` was #1404: the session copy wins in Claude Code,
+  so a header written `Bearer $${FOUNTAIN_TOKEN}` reached the server as
+  `Bearer $ftn_…`, the runtime having expanded the inner reference and left
+  the escape behind. The sandbox's own `.mcp.json` never had the bug, because
+  that copy is written from the substituted document — which is exactly the
+  point: there must be **one** substitution pass and one effective config,
+  not a resolved copy on disk and a raw one on the wire.
+
+  `resolved` is `nil` for an agentless conversation, and for one whose server
+  has not provisioned yet; the agent is returned untouched in both cases
+  rather than having its configuration blanked.
+
+  Resolution happens once per provision (`substitute_agent/3`), so a reattach
+  or a wake re-resolves against the environment and secrets as they are then.
+  Values Fountain does not own are deliberately still the runtime's to expand:
+  `${FOUNTAIN_TOKEN}` and `${FOUNTAIN_CONVERSATION_ID}` are process
+  environment inside the sandbox, never entries in `vars`, so a resumed turn
+  reads the current callback credential rather than one frozen into a
+  document.
+  """
+  @spec resolve_for_session(Agent.t() | nil, map() | nil) :: Agent.t() | nil
+  def resolve_for_session(nil, _resolved), do: nil
+  def resolve_for_session(agent, nil), do: agent
+  def resolve_for_session(agent, resolved), do: %{agent | mcp_servers: resolved}
+
+  @doc """
   The variables `${VAR}` resolves against: the environment's `env_vars` with
   keys and values as strings, overridden by the decrypted `secrets`.
   """

--- a/apps/fountain/test/fountain/conversations/conversation_server_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_test.exs
@@ -146,6 +146,92 @@ defmodule Fountain.Conversations.ConversationServerTest do
     end
   end
 
+  describe "the resolved MCP configuration (#1404)" do
+    # The server's half of the fix. Resolution happens once, at provision, and
+    # the resolved document is carried on state — so the turn path, which
+    # re-reads the agent row on every prompt, has the resolved copy to send to
+    # `session/new` instead of the raw one. `McpServersTest` covers what that
+    # copy then becomes on the wire.
+    test "provision resolves the agent's MCP config onto the server state", %{
+      user: user,
+      env: env,
+      sandbox: sandbox
+    } do
+      {:ok, env} =
+        Environments.update_environment(env, %{"env_vars" => %{"SALON_HOST" => "salon.example"}})
+
+      agent =
+        insert_agent(
+          user_id: user.id,
+          environment_id: env.id,
+          runtime: "claude",
+          mcp_servers: %{
+            "salon" => %{
+              "type" => "http",
+              "url" => "https://${SALON_HOST}/mcp",
+              "headers" => %{"Authorization" => "Bearer $${FOUNTAIN_TOKEN}"}
+            }
+          }
+        )
+
+      conv =
+        insert_conversation(
+          user_id: user.id,
+          agent: agent,
+          runtime: @legacy_runtime,
+          sandbox_id: sandbox.id,
+          status: "pending"
+        )
+
+      stub_happy_sprite()
+
+      {pid, _ref, :alive} = start_server(conv)
+
+      resolved = :sys.get_state(pid).resolved_mcp_servers
+
+      # The environment reference is resolved by Fountain, and the escaped one
+      # is left as a single-`$` reference for the runtime to expand from the
+      # sandbox's own process env — where the credential is always current,
+      # which is why a reattached or resumed turn cannot send a stale token.
+      assert resolved == %{
+               "salon" => %{
+                 "type" => "http",
+                 "url" => "https://salon.example/mcp",
+                 "headers" => %{"Authorization" => "Bearer ${FOUNTAIN_TOKEN}"}
+               }
+             }
+
+      # The stored agent still holds the unresolved document: the resolved
+      # values live only on the live conversation path.
+      assert Fountain.Agents._unsafe_get_agent!(agent.id).mcp_servers["salon"]["url"] ==
+               "https://${SALON_HOST}/mcp"
+
+      GenServer.stop(pid)
+    end
+
+    test "an agentless conversation carries no resolved config", %{
+      user: user,
+      sandbox: sandbox
+    } do
+      conv =
+        insert_conversation(
+          user_id: user.id,
+          agent_id: nil,
+          runtime: @legacy_runtime,
+          sandbox_id: sandbox.id,
+          status: "pending"
+        )
+
+      stub_happy_sprite()
+
+      {pid, _ref, :alive} = start_server(conv)
+
+      assert :sys.get_state(pid).resolved_mcp_servers == nil
+
+      GenServer.stop(pid)
+    end
+  end
+
   describe "provisioning — per-launch environment override (#783)" do
     # The observable difference between two environments at provision is which
     # checkpoint is restored, so that is what the assertion reads.

--- a/apps/fountain/test/fountain/conversations/mcp_servers_test.exs
+++ b/apps/fountain/test/fountain/conversations/mcp_servers_test.exs
@@ -33,6 +33,103 @@ defmodule Fountain.Conversations.McpServersTest do
     end
   end
 
+  describe "resolve_for_session/2 and for_session/3 (#1404)" do
+    # The escape is the whole bug. `$${FOUNTAIN_TOKEN}` means "leave a literal
+    # `${FOUNTAIN_TOKEN}` for the runtime to expand from the sandbox's process
+    # env". Fountain's pass turns `$$` into `$`; the runtime then expands the
+    # single-`$` reference. Send the *raw* document to `session/new` instead
+    # and the runtime expands the inner reference and leaves the escape, so
+    # the server receives `Bearer $ftn_…`.
+    test "the escaped form survives exactly one pass" do
+      agent = %Agent{
+        mcp_servers: %{
+          "salon" => %{"headers" => %{"Authorization" => "Bearer $${FOUNTAIN_TOKEN}"}}
+        }
+      }
+
+      assert {:ok, %Agent{mcp_servers: resolved}} =
+               McpServers.substitute_agent(agent, nil, %{})
+
+      assert resolved == %{
+               "salon" => %{"headers" => %{"Authorization" => "Bearer ${FOUNTAIN_TOKEN}"}}
+             }
+
+      # And that resolved form is what a turn puts on the wire, not the row.
+      assert %Agent{mcp_servers: ^resolved} = McpServers.resolve_for_session(agent, resolved)
+    end
+
+    test "an ordinary reference resolves once, and is not expanded twice" do
+      # `${A}` resolving to a string that itself looks like a reference must
+      # not be re-scanned: one pass, or a secret whose value contains `${...}`
+      # would reach for a variable the tenant never wrote.
+      agent = %Agent{mcp_servers: %{"svc" => %{"url" => "${A}"}}}
+
+      assert {:ok, %Agent{mcp_servers: mcp}} =
+               McpServers.substitute_agent(agent, nil, %{"A" => "${B}", "B" => "leaked"})
+
+      assert mcp == %{"svc" => %{"url" => "${B}"}}
+    end
+
+    test "the stored agent is never mutated by resolution" do
+      raw = %{"svc" => %{"token" => "${SECRET}"}}
+      agent = %Agent{mcp_servers: raw}
+
+      {:ok, %Agent{mcp_servers: resolved}} =
+        McpServers.substitute_agent(agent, nil, %{"SECRET" => "s3cret"})
+
+      # The resolved value exists only on the copy the session is built from.
+      assert resolved == %{"svc" => %{"token" => "s3cret"}}
+      assert agent.mcp_servers == raw
+    end
+
+    test "no resolved config leaves the freshly-fetched agent alone" do
+      # An agentless conversation, and one whose server has not provisioned
+      # yet: return the agent untouched rather than blanking its config.
+      agent = %Agent{mcp_servers: %{"svc" => %{"url" => "${A}"}}}
+
+      assert McpServers.resolve_for_session(agent, nil) == agent
+      assert McpServers.resolve_for_session(nil, %{"svc" => %{}}) == nil
+    end
+
+    # The reported case, end to end: Salon's conversation-authenticated HTTP
+    # MCP server. The row holds `Bearer $${FOUNTAIN_TOKEN}`; what reaches
+    # `session/new` must be the single-`$` form the runtime can expand, so the
+    # server sees `Bearer ftn_…` and not `Bearer $ftn_…`.
+    test "for_session sends the resolved document, not the agent row" do
+      user = insert_verified_user()
+
+      raw = %{
+        "salon" => %{
+          "type" => "http",
+          "url" => "https://salon.example/mcp",
+          "headers" => %{"Authorization" => "Bearer $${FOUNTAIN_TOKEN}"}
+        }
+      }
+
+      agent = insert_agent(user_id: user.id, mcp_servers: raw)
+      conv = insert_conversation(user_id: user.id, agent: agent)
+
+      {:ok, %Agent{mcp_servers: resolved}} = McpServers.substitute_agent(agent, nil, %{})
+
+      servers =
+        McpServers.for_session(agent, conv,
+          user_id: user.id,
+          conversation_id: conv.id,
+          callback_token: nil,
+          resolved: resolved
+        )
+
+      assert %{name: "salon", headers: headers} =
+               Enum.find(servers, &(&1[:name] == "salon"))
+
+      assert headers == [%{name: "Authorization", value: "Bearer ${FOUNTAIN_TOKEN}"}]
+
+      # The bug: the raw row would have put the escape on the wire, and the
+      # runtime would have expanded the inner reference and left the `$`.
+      refute inspect(servers) =~ "$${FOUNTAIN_TOKEN}"
+    end
+  end
+
   describe "substitution_vars/2" do
     test "no environment is just the secrets" do
       assert McpServers.substitution_vars(nil, %{"K" => "v"}) == %{"K" => "v"}

--- a/docs/concepts/agent.md
+++ b/docs/concepts/agent.md
@@ -111,6 +111,19 @@ spec:
 `${GITHUB_PAT}` resolves from the merged environment and vault secrets. Read
 [substitution](../api.md).
 
+Substitution applies to the whole entry, and not to `env` alone. A header, a
+URL or an argument takes a reference too.
+
+Write `$$` for a literal `$`. Use it when the value must reach the runtime
+unresolved. Fountain turns `"Bearer $${FOUNTAIN_TOKEN}"` into
+`"Bearer ${FOUNTAIN_TOKEN}"`, and the runtime then reads `FOUNTAIN_TOKEN` from
+the sandbox environment. Fountain resolves each reference one time, and does
+not scan the result again.
+
+The runtime receives one configuration. Fountain resolves it at spawn time,
+and the project file in the sandbox and the agent session both carry the same
+document.
+
 ## What an agent is not
 
 **Not a process that runs.** An Agent that nobody has run has no sandbox, no


### PR DESCRIPTION
Closes #1404.

## The bug

Fountain resolves `${VAR}` in an agent's MCP configuration **once**, at provision, and writes the sandbox's `.mcp.json` from the result. The turn path did not use it.

`handle_call({:send_prompt, …})` and the initial-prompt cast each re-read the agent row with `_unsafe_get_agent!/1` — right in itself, an edit between turns should take effect — and passed that raw document straight through to `session/new.mcpServers`.

The session copy wins in Claude Code, so the sandbox had the **resolved** configuration on disk and the runtime used the **unresolved** one on the wire. A conversation-authenticated HTTP server declared as:

```json
{ "headers": { "Authorization": "Bearer $${FOUNTAIN_TOKEN}" } }
```

therefore received `Bearer $ftn_…` — the runtime expanded the inner reference and left the escape prefix behind. `managoat/salon` strips the stray `$` in `server/sandbox.ts#unescaped` to cope.

## The fix

One pass, one effective configuration. The resolved document is carried on the conversation as `state.resolved_mcp_servers`, set by the same `dispatch_provision` call the project file is written from — so the two cannot disagree by construction. `McpServers.resolve_for_session/2` puts it back onto the freshly-read agent for the session, and returns the agent untouched when there is none (an agentless conversation, or one that has not provisioned).

## Against the acceptance criteria

- [x] `session/new.mcpServers` is built from the same substituted configuration used for the conversation.
- [x] The exact `Bearer ftn_…` value, no leading `$` — asserted on the reported Salon shape.
- [x] `$${…}` escaping and ordinary `${…}` both covered, including a test that a resolved value containing `${…}` is **not** expanded a second time.
- [x] Resolved headers never appear in stored agent JSON, logs, audit metadata or API responses — resolution produces a copy; a test asserts the stored row still holds the references.
- [x] Reattach and resumed turns resolve against the current credential. `${FOUNTAIN_TOKEN}` and `${FOUNTAIN_CONVERSATION_ID}` are sandbox *process environment*, never substitution variables, so they stay the runtime's to expand and cannot be frozen into a document. A wake re-runs `dispatch_provision` and re-resolves against the environment and secrets as they are then.
- [ ] The `managoat/salon` workaround can be deleted — true once this deploys, but it is a change in that repo and not this PR.

## The size ratchet

The state field would have pushed `conversation_server.ex` past its 2,835-line pin. Assembling the `session/new` list — the agent's servers, the brokered connections, then the Fountain-served ones — moved into `McpServers.for_session/3`, which is what that module's own moduledoc already said it owned. That extraction is what pays for the field: **the server holds at 2,835 rather than growing.**

## Testing

- `mix precommit` — **6 doctests, 4169 tests, 0 failures**, exit 0.
- Both halves verified by reverting: dropping the `dispatch_provision` assignment fails the server-state test, and dropping the `resolve_for_session` step in `for_session/3` fails the wire test. Neither passes on the old code.
- All three prose gates clean. `docs/concepts/agent.md` gained the `$$` escape rule and the "substitution applies to the whole entry, not just `env`" correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bcpj4FrtXSmLrsWphGMVus