### PR TITLE
feat(credits): telemetry for the workers and for the ledger (#1169)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,24 @@ upgrade, is in
 
 ### Added
 
+- **The credit workers report on themselves, and money movement is measured
+  at the ledger** (#1169). Under ADR 0031 the balance is the gate, so
+  `CreditPricer`, `CreditExpirer` and `Credits.Rent` are load-bearing, and the
+  only thing watching them was `FountainObanJobsRaising` — which needs a job
+  to *raise*. A pricer that ran happily and priced nothing (a bad rate config,
+  an empty `SandboxUsage`, a query matching zero rows) tripped nothing, and
+  the failure mode is free compute with no signal. Two events answer the two
+  different questions. `[:fountain, :credits, :worker, :run]` carries a
+  wall-clock `last_run_unix` per worker, so a rule can alert on staleness and
+  on a worker that never fires at all. `[:fountain, :credits, :posted]` is
+  emitted by `Credits.post/4` at the ledger write, tagged by reason, so cents
+  burned cannot drift from the ledger and one event covers turns, inference,
+  messages, rent, expiry, grants and purchases. Stripe webhook rejections and
+  failures are counted by coarse kind, and email delivery by outcome — the
+  latter needs no call-site change, because Swoosh already spans every
+  delivery. The per-replica gauge trap applies to `last_run_unix`: it exists
+  only on the pod that ran the job, so every rule over it needs `max`.
+
 - **Fountain can sit behind LiteLLM as an OpenAI-compatible upstream.** The
   `examples/litellm-gateway` configuration maps `fountain/<agent>` to every
   agent on an account, forwards `X-Fountain-Thread`, gives long-running turns

--- a/apps/fountain/lib/fountain_web/telemetry.ex
+++ b/apps/fountain/lib/fountain_web/telemetry.ex
@@ -244,6 +244,60 @@ defmodule FountainWeb.Telemetry do
         event_name: [:fountain, :sandbox, :suspended],
         description: "Sandboxes parked by the idle bound (sprite kept, decisions/0017)"
       ),
+      # ── Credits and billing (#1169) ────────────────────────────────────
+      #
+      # ADR 0031 makes the balance the gate, so these workers are load-bearing
+      # and none of them was watched: `FountainObanJobsRaising` needs a job to
+      # *raise*, and a pricer that runs and prices nothing never does. Two
+      # separate questions, deliberately — see Fountain.Credits.Telemetry.
+      #
+      # "Did it run?" A wall-clock stamp, so a rule can alert on staleness and
+      # on a worker that never fires at all. PER-REPLICA: the stamp exists only
+      # on the pod that ran the Oban job, so every rule over it needs `max`.
+      last_value("fountain.credits.worker.run.last_run_unix",
+        event_name: [:fountain, :credits, :worker, :run],
+        measurement: :last_run_unix,
+        tags: [:worker],
+        description: "Unix time of the last completed pass, per credit worker"
+      ),
+      sum("fountain.credits.worker.run.total",
+        event_name: [:fountain, :credits, :worker, :run],
+        measurement: :total,
+        tags: [:worker],
+        description: "Ledger rows written per credit worker pass"
+      ),
+      # "Did money move?" From the ledger write itself, so it cannot drift
+      # from the ledger. `reason` is a closed vocabulary, so this is the whole
+      # answer for turns, inference, messages, rent, expiry and purchases —
+      # and a burn_turn total of zero over a day while turns complete is the
+      # signal that the pricer is broken rather than idle.
+      sum("fountain.credits.posted.cents",
+        event_name: [:fountain, :credits, :posted],
+        measurement: :cents,
+        tags: [:reason, :direction],
+        description: "Cents moved through the credit ledger, by reason"
+      ),
+      counter("fountain.stripe_webhook.failure.count",
+        event_name: [:fountain, :stripe_webhook, :failure],
+        tags: [:kind],
+        description: "Stripe webhooks rejected or failed, by coarse kind"
+      ),
+      # Swoosh already spans every delivery, so this needs no call-site change
+      # across the fourteen `Mailer.deliver/1` sites. A failed credit or
+      # verification email is a customer who never learns their balance ran
+      # out, which until now was visible in a log line and nowhere else.
+      counter("fountain.email.delivery.count",
+        event_name: [:swoosh, :deliver, :stop],
+        measurement: :duration,
+        tags: [:outcome],
+        tag_values: &email_outcome/1,
+        description: "Email deliveries attempted, by outcome"
+      ),
+      counter("fountain.email.delivery.exception",
+        event_name: [:swoosh, :deliver, :exception],
+        measurement: :duration,
+        description: "Email deliveries that raised"
+      ),
       sum("fountain.reaper.run.released",
         event_name: [:fountain, :reaper, :run],
         measurement: :released,
@@ -479,6 +533,14 @@ defmodule FountainWeb.Telemetry do
       worker: meta.job.worker,
       state: Map.get(meta, :state, "exception")
     }
+  end
+
+  # Swoosh reports a delivery failure as an `:error` key in the stop event's
+  # metadata rather than as a separate event, so the outcome has to be derived
+  # (#1169). Two label values only — the error term itself is unbounded and
+  # would be a cardinality incident as a label.
+  defp email_outcome(meta) do
+    %{outcome: if(Map.get(meta, :error), do: "error", else: "ok")}
   end
 
   def metrics do

--- a/apps/fountain/test/fountain_web/metrics_test.exs
+++ b/apps/fountain/test/fountain_web/metrics_test.exs
@@ -205,6 +205,23 @@ defmodule FountainWeb.MetricsTest do
         # Also the proxy's own (Managoat.Broker.Proxy.connect_event/4, since
         # managoat_broker 0.1.2): once per connection rather than per request
         [:managoat, :broker, :connect],
+        # Credits and billing (#1169). The two are deliberately different
+        # producers: `worker.run` is Fountain.Credits.Telemetry.emit_run/2,
+        # called from each credit worker's perform/1, and answers "did it
+        # run"; `posted` is Fountain.Credits.post/4 at the ledger write, and
+        # answers "did money move". Both are exercised by
+        # Fountain.CreditsTelemetryTest.
+        [:fountain, :credits, :worker, :run],
+        [:fountain, :credits, :posted],
+        # FountainWeb.StripeWebhookController, on every rejected or failed
+        # delivery — exercised by its controller test.
+        [:fountain, :stripe_webhook, :failure],
+        # Swoosh's own span around Mailer.deliver/1, which is why the email
+        # metrics needed no call-site change across the fourteen deliver
+        # sites. A failure is an `:error` key in the stop event's metadata,
+        # not a separate event, hence the derived `outcome` tag.
+        [:swoosh, :deliver, :stop],
+        [:swoosh, :deliver, :exception],
         # Emitted by Oban itself around every job execution
         [:oban, :job, :stop],
         [:oban, :job, :exception],

--- a/ee/lib/fountain/credits.ex
+++ b/ee/lib/fountain/credits.ex
@@ -483,11 +483,39 @@ defmodule Fountain.Credits do
     if changeset.valid? do
       changeset
       |> insert_and_move(Keyword.get(opts, :lot_id), Keyword.get(opts, :cap_to_lot, false))
+      |> emit_posted()
       |> audited(opts)
     else
       {:error, changeset}
     end
   end
+
+  # Every movement of money, measured where it actually happens (#1169).
+  #
+  # Emitting here rather than from each worker's return value is deliberate:
+  # this is the ledger write, so the measurement cannot drift from the ledger
+  # the way a separately-counted total can, and one event covers turns,
+  # inference, messages, rent, expiry, grants and purchases at once. It is
+  # outside the transaction — `insert_and_move/3` has already returned — for
+  # the reason ADR 0013 gives about audit rows: work inside a transaction that
+  # can fail takes the transaction with it.
+  #
+  # `reason` is the label because it is a closed vocabulary
+  # (`LedgerEntry.debit_reasons/0` plus the credit reasons), so it cannot blow
+  # up Prometheus cardinality. A duplicate posts nothing and measures nothing,
+  # which is what makes "the pricer priced zero cents today" a real signal
+  # rather than an artefact of the seven-day look-back re-reading old rows.
+  defp emit_posted({:ok, %LedgerEntry{} = entry} = result) do
+    :telemetry.execute(
+      [:fountain, :credits, :posted],
+      %{cents: abs(entry.amount_cents)},
+      %{reason: entry.reason, direction: if(entry.amount_cents < 0, do: "debit", else: "credit")}
+    )
+
+    result
+  end
+
+  defp emit_posted(result), do: result
 
   # The unique index is the idempotency guard, and the duplicate is detected
   # *after* attempting the insert rather than by a lookup first: two workers

--- a/ee/lib/fountain/credits/telemetry.ex
+++ b/ee/lib/fountain/credits/telemetry.ex
@@ -1,0 +1,56 @@
+defmodule Fountain.Credits.Telemetry do
+  @moduledoc """
+  What the credit workers report about themselves (#1169).
+
+  Under ADR 0031 the balance is the gate, so the workers that keep it honest
+  are load-bearing — and until this existed none of them was watched. The only
+  coverage was `FountainObanJobsRaising`, which needs a job to *raise*. A
+  pricer that runs happily and prices nothing (a bad rate config, an empty
+  `SandboxUsage`, a query that silently matches zero rows) never tripped it,
+  and the failure mode is free compute with no signal at all.
+
+  Two events, deliberately shaped for the two different questions.
+
+  ### `[:fountain, :credits, :worker, :run]`
+
+  "Did this worker run?" One event per pass, tagged `worker`
+  (`pricer` / `expirer` / `rent`), carrying `last_run_unix` and `total` (the
+  rows it wrote). `last_run_unix` is a wall-clock stamp rather than a counter
+  because the alert is a staleness one, and a gauge survives a worker that
+  never fires at all, which is exactly the case a counter cannot express.
+
+  **The per-replica gauge trap applies.** The stamp only exists on the pod
+  that ran the Oban job, so every rule over it needs `max`, not `avg` or a
+  bare selector.
+
+  ### `[:fountain, :credits, :posted]`
+
+  "Did money actually move?" Emitted by `Fountain.Credits.post/4` at the
+  ledger write, not by a worker counting its own output, so the measurement
+  cannot drift from the ledger. Tagged by `reason`, which is a closed
+  vocabulary, so one event answers turns, inference, messages, rent, expiry,
+  grants and purchases.
+
+  That split is the point. A worker can run on schedule and still be broken,
+  which is why "it ran" and "money moved" have to be separate signals.
+  """
+
+  @workers ~w(pricer expirer rent)
+
+  @doc """
+  Report that a credit worker finished a pass.
+
+  `counts` is the map the worker's own `run/1` returns; `total` is the sum of
+  its values, so a caller does not have to know which keys a given worker has.
+  """
+  @spec emit_run(String.t(), map()) :: :ok
+  def emit_run(worker, counts) when worker in @workers and is_map(counts) do
+    total = counts |> Map.values() |> Enum.filter(&is_integer/1) |> Enum.sum()
+
+    :telemetry.execute(
+      [:fountain, :credits, :worker, :run],
+      Map.merge(counts, %{last_run_unix: System.system_time(:second), total: total}),
+      %{worker: worker}
+    )
+  end
+end

--- a/ee/lib/fountain/workers/credit_expirer.ex
+++ b/ee/lib/fountain/workers/credit_expirer.ex
@@ -22,7 +22,10 @@ defmodule Fountain.Workers.CreditExpirer do
 
   @impl Oban.Worker
   def perform(_job) do
-    case run() do
+    counts = run()
+    Fountain.Credits.Telemetry.emit_run("expirer", counts)
+
+    case counts do
       %{expired: 0} -> :ok
       c -> Logger.info("credit expirer: #{c.expired} expiries")
     end

--- a/ee/lib/fountain/workers/credit_pricer.ex
+++ b/ee/lib/fountain/workers/credit_pricer.ex
@@ -59,7 +59,10 @@ defmodule Fountain.Workers.CreditPricer do
 
   @impl Oban.Worker
   def perform(_job) do
-    case run() do
+    counts = run()
+    Fountain.Credits.Telemetry.emit_run("pricer", counts)
+
+    case counts do
       %{turns: 0, inference: 0, messages: 0, expired: 0} ->
         :ok
 

--- a/ee/lib/fountain/workers/credit_rent_collector.ex
+++ b/ee/lib/fountain/workers/credit_rent_collector.ex
@@ -7,7 +7,10 @@ defmodule Fountain.Workers.CreditRentCollector do
 
   @impl Oban.Worker
   def perform(_job) do
-    case Fountain.Credits.Rent.collect() do
+    counts = Fountain.Credits.Rent.collect()
+    Fountain.Credits.Telemetry.emit_run("rent", counts)
+
+    case counts do
       %{charged: 0, reminded: 0, released: 0} ->
         :ok
 

--- a/ee/lib/fountain_web/controllers/stripe_webhook_controller.ex
+++ b/ee/lib/fountain_web/controllers/stripe_webhook_controller.ex
@@ -43,8 +43,17 @@ defmodule FountainWeb.StripeWebhookController do
           "[stripe_webhook] Rejecting webhook: STRIPE_WEBHOOK_SECRET is not configured"
         )
 
+        emit_failure("no_secret")
         send_resp(conn, 400, "Webhook secret not configured")
     end
+  end
+
+  # A rejected signature or a failed event is money that did not land, and it
+  # was visible only inside the global 5xx rate (#1169). The label is a coarse
+  # kind rather than the reason itself: an exception message is unbounded, and
+  # a Prometheus label built from one is a cardinality incident.
+  defp emit_failure(kind) do
+    :telemetry.execute([:fountain, :stripe_webhook, :failure], %{count: 1}, %{kind: kind})
   end
 
   defp verify_and_process(conn, secret) do
@@ -66,6 +75,7 @@ defmodule FountainWeb.StripeWebhookController do
 
       {:error, reason} ->
         Logger.warning("[stripe_webhook] Signature verification failed: #{inspect(reason)}")
+        emit_failure("bad_signature")
         send_resp(conn, 400, "Bad signature")
     end
   end
@@ -88,17 +98,20 @@ defmodule FountainWeb.StripeWebhookController do
       {:error, :user_not_found} ->
         Logger.error("[stripe_webhook] No user for event #{event.id} (#{event.type})")
         Billing.record_webhook_failure(event, :user_not_found)
+        emit_failure("user_not_found")
         :ok
 
       {:error, reason} ->
         Logger.error("[stripe_webhook] Event processing error: #{inspect(reason)}")
         Billing.record_webhook_failure(event, reason)
+        emit_failure("processing")
         :retry
     end
   rescue
     e ->
       Logger.error("[stripe_webhook] Unhandled error: #{Exception.message(e)}")
       Billing.record_webhook_failure(event, e)
+      emit_failure("exception")
       :retry
   end
 

--- a/ee/test/fountain/credits_telemetry_test.exs
+++ b/ee/test/fountain/credits_telemetry_test.exs
@@ -1,0 +1,114 @@
+defmodule Fountain.CreditsTelemetryTest do
+  @moduledoc """
+  What the credit machinery reports about itself (#1169).
+
+  Two questions, and the whole point is that they are separate: a worker can
+  run on schedule and still move no money, which is the failure the old
+  coverage (`FountainObanJobsRaising`, which needs a *raise*) could not see.
+
+  `async: false`, and it genuinely needs to be: a `:telemetry` handler is
+  **global**, so an async module receives the events of every other module
+  running beside it. `[:fountain, :credits, :posted]` fires on any ledger
+  write anywhere — including the $5 opening grant that `insert_verified_user/0`
+  posts — so `refute_receive` here caught another module's grant and failed
+  under the full suite while passing when run alone.
+  """
+
+  use Fountain.DataCase, async: false
+
+  alias Fountain.Credits
+  alias Fountain.Credits.Telemetry
+
+  defp attach(event) do
+    test = self()
+    handler = "t-#{System.unique_integer([:positive])}"
+
+    :telemetry.attach(
+      handler,
+      event,
+      fn _e, measurements, meta, _cfg -> send(test, {:telemetry, measurements, meta}) end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler) end)
+  end
+
+  describe "[:fountain, :credits, :posted]" do
+    # The users are made BEFORE the handler attaches. Verification posts the
+    # $5 opening grant, which is itself a ledger write and so reports too —
+    # true to the design, and noise for a test that asserts nothing else
+    # arrives.
+    setup do
+      user = insert_verified_user()
+      empty = insert_empty_user()
+      attach([:fountain, :credits, :posted])
+      %{user: user, empty: empty}
+    end
+
+    test "a debit reports its cents and reason", %{user: user} do
+      {:ok, _} = Credits.debit(user.id, 137, "burn_turn", idempotency_key: "t1")
+
+      assert_receive {:telemetry, %{cents: 137}, %{reason: "burn_turn", direction: "debit"}}
+    end
+
+    test "a grant reports as a credit", %{empty: empty} do
+      {:ok, _} = Credits.grant(empty.id, 500, "grant_admin", idempotency_key: "g1")
+
+      assert_receive {:telemetry, %{cents: 500}, %{reason: "grant_admin", direction: "credit"}}
+    end
+
+    # The seven-day look-back re-reads rows that already exist, so a pricer
+    # pass over old turns writes nothing. If a duplicate measured anyway,
+    # "cents burned today" would read healthy while the pricer priced nothing
+    # new — exactly the signal this exists to give.
+    test "a duplicate post measures nothing", %{user: user} do
+      {:ok, _} = Credits.debit(user.id, 10, "burn_turn", idempotency_key: "dup")
+      assert_receive {:telemetry, %{cents: 10}, _}
+
+      Credits.debit(user.id, 10, "burn_turn", idempotency_key: "dup")
+      refute_receive {:telemetry, %{cents: 10}, %{reason: "burn_turn"}}, 100
+    end
+
+    test "a rejected post measures nothing", %{user: user} do
+      # Zero is not a valid ledger row, so the changeset never reaches the
+      # database and nothing should be reported as moved.
+      Credits.post(user.id, 0, "burn_turn", idempotency_key: "zero")
+
+      refute_receive {:telemetry, _, %{reason: "burn_turn"}}, 100
+    end
+  end
+
+  describe "[:fountain, :credits, :worker, :run]" do
+    setup do
+      attach([:fountain, :credits, :worker, :run])
+      :ok
+    end
+
+    test "reports a wall-clock stamp and the rows written" do
+      before = System.system_time(:second)
+
+      Telemetry.emit_run("pricer", %{turns: 3, inference: 1, messages: 0, expired: 2})
+
+      assert_receive {:telemetry, measurements, %{worker: "pricer"}}
+      assert measurements.total == 6
+      assert measurements.turns == 3
+      assert measurements.last_run_unix >= before
+    end
+
+    # The staleness alert is the reason this is a stamp rather than a counter:
+    # a pass that did nothing must still say it happened, or "the pricer has
+    # not run" and "the pricer found no work" look identical.
+    test "a pass that wrote nothing still reports that it ran" do
+      Telemetry.emit_run("expirer", %{expired: 0})
+
+      assert_receive {:telemetry, %{total: 0, last_run_unix: stamp}, %{worker: "expirer"}}
+      assert is_integer(stamp)
+    end
+
+    test "each worker is its own series" do
+      Telemetry.emit_run("rent", %{charged: 1, reminded: 0, released: 0})
+
+      assert_receive {:telemetry, %{total: 1}, %{worker: "rent"}}
+    end
+  end
+end

--- a/ee/test/fountain_web/controllers/stripe_webhook_controller_test.exs
+++ b/ee/test/fountain_web/controllers/stripe_webhook_controller_test.exs
@@ -315,4 +315,74 @@ defmodule FountainWeb.StripeWebhookControllerTest do
       assert conn.status == 400
     end
   end
+
+  describe "POST /api/stripe/webhook — failure telemetry (#1169)" do
+    setup do
+      test = self()
+      handler = "stripe-fail-#{System.unique_integer([:positive])}"
+
+      :telemetry.attach(
+        handler,
+        [:fountain, :stripe_webhook, :failure],
+        fn _e, m, meta, _cfg -> send(test, {:webhook_failure, m, meta}) end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler) end)
+    end
+
+    @tag capture_log: true
+    test "a bad signature is measured", %{conn: conn} do
+      stub(Stripe.Webhook, :construct_event, fn _b, _s, _sec -> {:error, "no match"} end)
+
+      conn =
+        conn
+        |> Plug.Conn.put_req_header("content-type", "application/json")
+        |> Plug.Conn.put_req_header("stripe-signature", "t=1,v1=forged")
+        |> Phoenix.ConnTest.dispatch(
+          FountainWeb.Endpoint,
+          :post,
+          "/api/stripe/webhook",
+          @raw_body
+        )
+
+      assert conn.status == 400
+
+      # Until now a rejected signature was visible only inside the global 5xx
+      # rate — and a 400 is not even in that.
+      assert_receive {:webhook_failure, %{count: 1}, %{kind: "bad_signature"}}
+    end
+
+    @tag capture_log: true
+    test "a processing failure is measured, and a success is not", %{conn: conn} do
+      event = %Stripe.Event{
+        id: "evt_telemetry_#{System.unique_integer([:positive])}",
+        type: "charge.refunded",
+        data: %{object: %{status: "active", customer: "cus_x", trial_end: nil}}
+      }
+
+      stub(Stripe.Webhook, :construct_event, fn _b, _s, _sec -> {:ok, event} end)
+      stub(Fountain.Billing, :handle_event, fn _e -> {:error, :database_unavailable} end)
+
+      post = fn ->
+        conn
+        |> Plug.Conn.put_req_header("content-type", "application/json")
+        |> Plug.Conn.put_req_header("stripe-signature", "t=1,v1=validhash")
+        |> Phoenix.ConnTest.dispatch(
+          FountainWeb.Endpoint,
+          :post,
+          "/api/stripe/webhook",
+          @raw_body
+        )
+      end
+
+      assert post.().status == 500
+      assert_receive {:webhook_failure, %{count: 1}, %{kind: "processing"}}
+
+      stub(Fountain.Billing, :handle_event, fn _e -> {:ok, :done} end)
+
+      assert post.().status == 200
+      refute_receive {:webhook_failure, _, _}, 100
+    end
+  end
 end


### PR DESCRIPTION
The server half of #1169. The alert rules and dashboard panels are a companion PR in `home-cloud`; this cannot close the issue on its own.

## The gap

ADR 0031 makes the balance the gate, so `CreditPricer`, `CreditExpirer` and `Credits.Rent` are load-bearing — and none of them was watched. The only coverage was `FountainObanJobsRaising`, which needs a job to **raise**. A pricer that runs on schedule, reports success and prices nothing (a bad rate config, an empty `SandboxUsage` join, a query matching zero rows) tripped nothing at all, and that failure hands out free compute with no signal.

## Two events, because there are two questions

A worker can answer the first healthily while failing the second, which is exactly the case the old coverage could not express.

**"Did it run?"** — `[:fountain, :credits, :worker, :run]`, one per pass, tagged `worker` (pricer / expirer / rent), carrying `last_run_unix` and the rows written. A wall-clock stamp rather than a counter: the alert is a staleness one, and a gauge also expresses "never fired at all", which a counter cannot. **The per-replica trap applies** — the stamp exists only on the pod that ran the Oban job, so a rule over it needs `max`. That is said in the moduledoc and again in the metric's comment.

**"Did money move?"** — `[:fountain, :credits, :posted]`, emitted by `Credits.post/4` **at the ledger write**. Instrumenting the write rather than each worker's return value means the measurement cannot drift from the ledger, and one event covers turns, inference, messages, rent, expiry, grants and purchases at once. It is outside the transaction, for the reason ADR 0013 gives about audit rows. A duplicate post measures nothing — which is what stops the seven-day look-back from making a broken pricer look busy, and there is a test for it. `reason` is the label because it is a closed vocabulary.

## Stripe and email

Webhook rejections and failures are counted by coarse **kind** (`bad_signature`, `user_not_found`, `processing`, `exception`, `no_secret`) — not by the reason itself, since an exception message is unbounded and a label built from one is a cardinality incident. Worth noting a forged signature answers **400**, so it was not even inside the 5xx rate it would otherwise have hidden in.

Email needed **no call-site change** across the fourteen `Mailer.deliver/1` sites: Swoosh already spans every delivery and reports a failure as an `:error` key in the stop event's metadata, so the metric derives an `outcome` tag from the existing event.

## What the suite caught

Both worth recording, because both are the kind of thing that would have shipped a dead metric:

- **`metrics_test.exs` holds a curated producer allowlist** (from #310 — metrics subscribed to names nothing emits pass every name-list assertion while the scrape stays empty forever). All five new event names are added there, each pinned to the code that fires it.
- **A `:telemetry` handler is process-global**, so the new test module is `async: false` and says why: `refute_receive` in an async module caught *another* module's `insert_verified_user/0` posting its $5 opening grant, and failed only under the full suite.

## Testing

- `mix precommit` — **6 doctests, 4171 tests, 0 failures**, exit 0.
- All five guards verified by reverting: dropping `emit_posted/1` and the two `emit_failure/1` calls fails exactly the five tests that should fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bcpj4FrtXSmLrsWphGMVus