### PR TITLE
fix(billing): price comms messages from a row that cannot be dropped (#1143)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,26 @@ upgrade, is in
   The wake-on-miss decision moved to `Conversations.wake_for_interrupt/1`,
   taking the server's pin from 2,835 down to 2,815.
 
+- **A dropped metering event was a free message** (#1143). Comms messages were
+  priced from `usage_events`, whose writer `Billing.record_usage/5` rescues and
+  logs rather than failing the action that produced it — the right contract for
+  a count on a dashboard, and the wrong one for a row the ledger keys on. A
+  `comms_*` event that failed to write was a message the customer was never
+  charged for, and nothing reconciled it afterwards, because the pricer's
+  seven-day look-back only re-reads rows that exist. Messages now have a
+  durable row of their own, `comms_messages`, written on the send and receive
+  paths through `Team.Comms.record_message/1`, which does **not** rescue: a
+  failure is logged as an unbilled message rather than silently discarded. The
+  row is keyed on the provider's own message id, so a send retried after a
+  timeout that in fact reached the provider bills once, and so a reconciliation
+  against a provider invoice has something to join on. `CreditPricer` and the
+  `/admin/finance` cost side both read it — leaving one of them on
+  `usage_events` would have put a discrepancy inside the view built to find
+  discrepancies. `usage_events` keeps the `comms_*` types for the PostHog
+  product mirror and no longer prices anything; its docs say so. **Messages
+  whose event was dropped before this are not charged retroactively**: there is
+  no record of them to price.
+
 - **Platform inference on the gemini runtime was unbilled** (#1459). gemini
   leaves ACP's `PromptResponse.usage` empty and reports the turn's tokens
   under a vendor extension at `_meta.quota.token_count`, so

--- a/apps/fountain/lib/fountain/team/comms.ex
+++ b/apps/fountain/lib/fountain/team/comms.ex
@@ -28,7 +28,7 @@ defmodule Fountain.Team.Comms do
 
   alias Fountain.{Audit, Conversations, FeatureFlags, Repo, Team}
   alias Fountain.Team.Comms.{AgentMail, AgentPhone}
-  alias Fountain.Team.Contact
+  alias Fountain.Team.{CommsMessage, Contact}
 
   @flag :team_comms
   @mcp_name "fountain-comms"
@@ -53,6 +53,68 @@ defmodule Fountain.Team.Comms do
 
   @doc "The MCP server name the teammate sees the tools under."
   def mcp_name, do: @mcp_name
+
+  ## messages
+
+  @doc """
+  Record a message a provider charged for. **This is the row the credit
+  ledger prices from** (#1143), so unlike `Billing.record_usage/5` it does
+  not rescue: a write that fails must be visible, not logged and forgotten.
+
+  Idempotent on the provider's own message id, so a send retried after a
+  timeout that in fact reached the provider converges on one row rather than
+  billing twice. That makes `{:ok, :duplicate}` a success from every caller's
+  point of view.
+
+  `attrs` (atom-keyed): `:user_id`, `:channel` (`email`/`sms`), `:direction`
+  (`outbound`/`inbound`), `:provider_message_id`, and optionally
+  `:contact_id`, `:agent_id` and `:metadata`.
+  """
+  @spec record_message(map()) ::
+          {:ok, CommsMessage.t()} | {:ok, :duplicate} | {:error, Ecto.Changeset.t()}
+  def record_message(attrs) when is_map(attrs) do
+    attrs = Map.put_new(attrs, :inserted_at, DateTime.utc_now() |> DateTime.truncate(:second))
+
+    %CommsMessage{}
+    |> CommsMessage.changeset(attrs)
+    |> Repo.insert()
+    |> case do
+      {:ok, %CommsMessage{}} = ok ->
+        ok
+
+      # The unique index did its job. The provider already told us about this
+      # message once, and it is already priced or waiting to be.
+      {:error, %Ecto.Changeset{errors: errors} = cs} ->
+        if Keyword.has_key?(errors, :user_id) or has_provider_id_error?(errors),
+          do: {:ok, :duplicate},
+          else: {:error, cs}
+    end
+  end
+
+  defp has_provider_id_error?(errors) do
+    Enum.any?(errors, fn
+      {:provider_message_id, {_, opts}} -> opts[:constraint] == :unique
+      {_, {_, opts}} -> opts[:constraint] == :unique
+    end)
+  end
+
+  @doc """
+  Messages this tenant was charged for in a period, for the finance view.
+  Counts both directions: AgentPhone charges for a received SMS as well as a
+  sent one.
+  """
+  @spec message_counts(binary(), DateTime.t(), DateTime.t()) :: %{
+          optional(String.t()) => non_neg_integer()
+        }
+  def message_counts(user_id, from, to) when is_binary(user_id) do
+    from(m in CommsMessage,
+      where: m.user_id == ^user_id and m.inserted_at >= ^from and m.inserted_at < ^to,
+      group_by: m.channel,
+      select: {m.channel, count(m.id)}
+    )
+    |> Repo.all()
+    |> Map.new()
+  end
 
   ## contacts
 

--- a/apps/fountain/lib/fountain/team/comms/inbound.ex
+++ b/apps/fountain/lib/fountain/team/comms/inbound.ex
@@ -87,7 +87,7 @@ defmodule Fountain.Team.Comms.Inbound do
              source: "sms"
            ) do
         {:ok, conv} ->
-          record(contact, text, conv)
+          record(contact, text, conv, data["id"] || delivery_id)
           {:ok, conv.id}
 
         {:error, reason} ->
@@ -241,7 +241,7 @@ defmodule Fountain.Team.Comms.Inbound do
       "texted back.]\n\n#{text}#{media}"
   end
 
-  defp record(%Contact{} = contact, text, conv) do
+  defp record(%Contact{} = contact, text, conv, provider_message_id) do
     Audit.record(%{
       user_id: contact.user_id,
       action: "team.contact.prompted",
@@ -258,8 +258,42 @@ defmodule Fountain.Team.Comms.Inbound do
 
     # AgentPhone charges for an inbound message as well as an outbound one, so
     # it is metered on the same footing as a send
-    # (`FountainWeb.TeamCommsMcpController`). Best-effort, after the prompt is
-    # already away.
+    # (`FountainWeb.TeamCommsMcpController`).
+    #
+    # Two writes, for the two contracts (#1143). The `comms_messages` row is
+    # what the ledger prices, so it does not rescue and a failure is loud; the
+    # `usage_events` row keeps `record_usage/5`'s swallow-and-log contract and
+    # feeds the product mirror only. Both run after the prompt is away, which
+    # is deliberate: a billing problem must not cost the customer the message
+    # they were charged for.
+    case provider_message_id do
+      id when is_binary(id) and id != "" ->
+        case Comms.record_message(%{
+               user_id: contact.user_id,
+               contact_id: contact.id,
+               agent_id: contact.agent_id,
+               channel: "sms",
+               direction: "inbound",
+               provider_message_id: id,
+               metadata: %{"conversation_id" => conv.id}
+             }) do
+          {:ok, _} ->
+            :ok
+
+          {:error, reason} ->
+            Logger.error(
+              "team comms inbound: sms #{id} for user #{contact.user_id} was received but " <>
+                "not recorded, so it will not be billed: #{inspect(reason)}"
+            )
+        end
+
+      _ ->
+        Logger.error(
+          "team comms inbound: sms for user #{contact.user_id} carried no provider message " <>
+            "id or delivery id; it will not be billed"
+        )
+    end
+
     Fountain.Billing.record_usage(
       contact.user_id,
       "comms_sms_received",

--- a/apps/fountain/lib/fountain/team/comms/mcp.ex
+++ b/apps/fountain/lib/fountain/team/comms/mcp.ex
@@ -231,7 +231,7 @@ defmodule Fountain.Team.Comms.Mcp do
 
       case mail(ctx).send_message(c.email_inbox_id, body) do
         {:ok, %{"message_id" => mid} = resp} ->
-          audit(ctx, "email_send", %{"recipients" => length(to)})
+          audit(ctx, "email_send", %{"recipients" => length(to), "provider_message_id" => mid})
           ok(id, %{message_id: mid, thread_id: resp["thread_id"]})
 
         {:ok, other} ->
@@ -256,7 +256,11 @@ defmodule Fountain.Team.Comms.Mcp do
 
       case mail(ctx).reply_to_message(c.email_inbox_id, message_id, body) do
         {:ok, %{"message_id" => mid} = resp} ->
-          audit(ctx, "email_reply", %{"reply_all" => args["reply_all"] == true})
+          audit(ctx, "email_reply", %{
+            "reply_all" => args["reply_all"] == true,
+            "provider_message_id" => mid
+          })
+
           ok(id, %{message_id: mid, thread_id: resp["thread_id"]})
 
         {:ok, other} ->
@@ -317,7 +321,7 @@ defmodule Fountain.Team.Comms.Mcp do
 
       case phone(ctx).send_message(payload) do
         {:ok, %{"id" => mid} = resp} ->
-          audit(ctx, "sms_send", %{})
+          audit(ctx, "sms_send", %{"provider_message_id" => mid})
           ok(id, %{message_id: mid, status: resp["status"], channel: resp["channel"]})
 
         {:ok, other} ->

--- a/apps/fountain/lib/fountain/team/comms_message.ex
+++ b/apps/fountain/lib/fountain/team/comms_message.ex
@@ -1,0 +1,77 @@
+defmodule Fountain.Team.CommsMessage do
+  @moduledoc """
+  One teammate message that a provider charged for, and the row the credit
+  ledger prices from (#1143).
+
+  ## Why this exists rather than a `usage_events` row
+
+  Comms messages used to be priced from `usage_events`. Those rows are written
+  by `Fountain.Billing.record_usage/5`, which **rescues and logs** rather than
+  failing the action that produced them — a metering outage must never fail a
+  conversation. That contract is right for a count on a dashboard and wrong for
+  a row the ledger keys on: a dropped `comms_*` event was a message the
+  customer was never charged for, and nothing reconciled it afterwards, because
+  the pricer's seven-day look-back only re-reads rows that already exist.
+
+  So the money moved to a row of its own, written on the send path where a
+  failure is visible. `usage_events` keeps the `comms_*` types for the product
+  mirror, and is no longer what anything prices from.
+
+  ## The idempotency key is the provider's
+
+  `provider_message_id` is the id AgentMail or AgentPhone returned for this
+  message, unique with `user_id` and `channel`. A send retried after a
+  timeout that in fact reached the provider converges on one row instead of
+  billing twice, and it is also the id to compare against when reconciling
+  with a provider invoice — which is the comparison anybody auditing a bill
+  would want to make anyway.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+
+  @channels ~w(email sms)
+  @directions ~w(inbound outbound)
+
+  @type t :: %__MODULE__{}
+
+  schema "comms_messages" do
+    field :user_id, :binary_id
+    field :contact_id, :binary_id
+    field :agent_id, :binary_id
+    field :channel, :string
+    field :direction, :string
+    field :provider_message_id, :string
+    field :metadata, :map, default: %{}
+    field :inserted_at, :utc_datetime
+  end
+
+  @doc "Both channels, for a caller that wants the vocabulary."
+  def channels, do: @channels
+
+  @doc "Both directions. Inbound counts: AgentPhone charges for a received SMS."
+  def directions, do: @directions
+
+  def changeset(message, attrs) do
+    message
+    |> cast(attrs, [
+      :user_id,
+      :contact_id,
+      :agent_id,
+      :channel,
+      :direction,
+      :provider_message_id,
+      :metadata,
+      :inserted_at
+    ])
+    |> validate_required([:user_id, :channel, :direction, :provider_message_id, :inserted_at])
+    |> validate_inclusion(:channel, @channels)
+    |> validate_inclusion(:direction, @directions)
+    |> unique_constraint([:user_id, :channel, :provider_message_id],
+      name: :comms_messages_provider_id_index
+    )
+  end
+end

--- a/apps/fountain/lib/fountain_web/controllers/team_comms_mcp_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/team_comms_mcp_controller.ex
@@ -14,6 +14,8 @@ defmodule FountainWeb.TeamCommsMcpController do
   """
   use FountainWeb, :controller
 
+  require Logger
+
   alias Fountain.{Audit, Conversations}
   alias Fountain.Team.Comms
   alias Fountain.Team.Comms.Mcp
@@ -76,19 +78,63 @@ defmodule FountainWeb.TeamCommsMcpController do
   # for those alone today, so the fallback clause is a guard against a future
   # tool joining the audit path without joining the rate card.
   defp meter(tool, contact, user, summary) when tool in ~w(email_send email_reply) do
-    record_message(user, contact, "comms_email_sent", %{
+    record_message(user, contact, "email", "comms_email_sent", summary, %{
       "tool" => tool,
       "recipients" => Map.get(summary, "recipients", 1)
     })
   end
 
-  defp meter("sms_send", contact, user, _summary) do
-    record_message(user, contact, "comms_sms_sent", %{"tool" => "sms_send"})
+  defp meter("sms_send", contact, user, summary) do
+    record_message(user, contact, "sms", "comms_sms_sent", summary, %{"tool" => "sms_send"})
   end
 
   defp meter(_tool, _contact, _user, _summary), do: :ok
 
-  defp record_message(user, contact, event_type, metadata) do
+  # Two writes, deliberately, because they answer to different contracts
+  # (#1143).
+  #
+  # The `comms_messages` row is **money**: it is what `CreditPricer` prices,
+  # so it is written through `Team.Comms.record_message/1`, which does not
+  # rescue. A failure is logged loudly here rather than swallowed, and it is
+  # idempotent on the provider's own message id, so a retried send converges.
+  #
+  # The `usage_events` row is the **product** signal, and keeps
+  # `record_usage/5`'s swallow-and-log contract: it drives the PostHog mirror
+  # and a dashboard count, and a metering outage must never fail a send. It
+  # is no longer what anything prices from, which is the whole point — that
+  # conflation is what made a dropped event a free message.
+  defp record_message(user, contact, channel, event_type, summary, metadata) do
+    case summary["provider_message_id"] do
+      id when is_binary(id) and id != "" ->
+        case Fountain.Team.Comms.record_message(%{
+               user_id: user.id,
+               contact_id: contact.id,
+               agent_id: contact.agent_id,
+               channel: channel,
+               direction: "outbound",
+               provider_message_id: id,
+               metadata: metadata
+             }) do
+          {:ok, _} ->
+            :ok
+
+          {:error, reason} ->
+            Logger.error(
+              "[team_comms] #{channel} message #{id} for user #{user.id} was sent but not " <>
+                "recorded, so it will not be billed: #{inspect(reason)}"
+            )
+        end
+
+      _ ->
+        # The provider answered without an id, so there is nothing to key on
+        # and nothing to reconcile against. Say so rather than billing a
+        # message we cannot identify.
+        Logger.error(
+          "[team_comms] #{channel} send for user #{user.id} returned no provider message id; " <>
+            "it will not be billed"
+        )
+    end
+
     Fountain.Billing.record_usage(
       user.id,
       event_type,

--- a/apps/fountain/priv/repo/migrations/20260903211500_create_comms_messages.exs
+++ b/apps/fountain/priv/repo/migrations/20260903211500_create_comms_messages.exs
@@ -1,0 +1,52 @@
+defmodule Fountain.Repo.Migrations.CreateCommsMessages do
+  use Ecto.Migration
+
+  @moduledoc """
+  A durable row per teammate message, which is what the credit ledger prices
+  from (#1143).
+
+  Comms messages used to be priced from `usage_events`, whose writer
+  (`Billing.record_usage/5`) rescues and logs by contract — a metering outage
+  must never fail a conversation. That contract is right for a count on a
+  dashboard and wrong for a row the ledger keys on: a dropped `comms_*` event
+  was a message the customer was never charged for, and nothing reconciled it
+  afterwards, because the seven-day look-back only re-reads rows that exist.
+  """
+
+  def change do
+    create table(:comms_messages, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+
+      # Not `on_delete: :delete_all`. Deleting an account must not silently
+      # erase what it owed; the ledger rows that priced these outlive the user
+      # the same way (ADR 0013's deletion semantics).
+      add :user_id, references(:users, type: :binary_id, on_delete: :nilify_all)
+      add :contact_id, references(:team_contacts, type: :binary_id, on_delete: :nilify_all)
+      add :agent_id, :binary_id
+
+      add :channel, :string, null: false
+      add :direction, :string, null: false
+
+      # The provider's own id for the message, and the idempotency key. A
+      # retried send that reaches the provider twice converges on one row
+      # rather than billing twice.
+      add :provider_message_id, :string, null: false
+
+      add :metadata, :map, null: false, default: %{}
+      add :inserted_at, :utc_datetime, null: false
+    end
+
+    # What makes a double-charge impossible. Scoped by user as well as
+    # channel: provider message ids are only unique within a provider, and
+    # two tenants on the same provider could in principle collide.
+    create unique_index(:comms_messages, [:user_id, :channel, :provider_message_id],
+             name: :comms_messages_provider_id_index
+           )
+
+    # The pricer sweeps by time, oldest first, within its look-back window.
+    create index(:comms_messages, [:inserted_at])
+
+    # `Fountain.Billing.Finance` reports per tenant per period.
+    create index(:comms_messages, [:user_id, :inserted_at])
+  end
+end

--- a/apps/fountain/test/fountain/team/comms/inbound_test.exs
+++ b/apps/fountain/test/fountain/team/comms/inbound_test.exs
@@ -74,6 +74,33 @@ defmodule Fountain.Team.Comms.InboundTest do
     |> Map.merge(Map.delete(overrides, "data"))
   end
 
+  # #1143: the row the ledger prices. AgentPhone charges for a received SMS as
+  # well as a sent one, so an inbound message is metered on the same footing.
+  test "an inbound text records a durable comms message", %{user: user, contact: contact} do
+    assert {:ok, _} = Inbound.handle(payload(), "del_durable")
+
+    assert [message] = Fountain.Repo.all(Fountain.Team.CommsMessage)
+    assert message.user_id == user.id
+    assert message.contact_id == contact.id
+    assert message.channel == "sms"
+    assert message.direction == "inbound"
+
+    # No provider message id on the payload, so the webhook's own delivery id
+    # is the key — still stable per message, and still what a redelivery
+    # would collide on.
+    assert message.provider_message_id == "del_durable"
+  end
+
+  test "the provider's own message id is preferred over the delivery id", %{user: user} do
+    payload = payload(%{"data" => %{"id" => "msg_provider_1"}})
+
+    assert {:ok, _} = Inbound.handle(payload, "del_2")
+
+    assert [message] = Fountain.Repo.all(Fountain.Team.CommsMessage)
+    assert message.provider_message_id == "msg_provider_1"
+    assert message.user_id == user.id
+  end
+
   test "a text from the allow-listed number becomes a prompt in the teammate's conversation", %{
     conv: conv,
     user: user,

--- a/apps/fountain/test/fountain/team/comms/mcp_test.exs
+++ b/apps/fountain/test/fountain/team/comms/mcp_test.exs
@@ -198,7 +198,8 @@ defmodule Fountain.Team.Comms.McpTest do
                          "cc" => ["c@y.com"]
                        }}
 
-      assert_received {:audit, "email_send", %{"recipients" => 2}}
+      assert_received {:audit, "email_send",
+                       %{"recipients" => 2, "provider_message_id" => "msg_1"}}
     end
 
     test "email_send accepts a single comma-separated string for `to`" do
@@ -286,7 +287,10 @@ defmodule Fountain.Team.Comms.McpTest do
       assert_received {:sms_send,
                        %{"number_id" => "num_1", "to_number" => "+15550001111", "body" => "hey"}}
 
-      assert_received {:audit, "sms_send", %{}}
+      # The provider's id rides the audit summary so the controller can key
+      # the durable billing row on it (#1143). Without it a send is logged as
+      # unbillable rather than billed against something unidentifiable.
+      assert_received {:audit, "sms_send", %{"provider_message_id" => "sms_1"}}
     end
 
     test "sms_list shapes the messages" do

--- a/apps/fountain/test/fountain/team/comms_test.exs
+++ b/apps/fountain/test/fountain/team/comms_test.exs
@@ -458,4 +458,75 @@ defmodule Fountain.Team.CommsTest do
       assert [] = Comms.conversation_mcp_servers("not-a-uuid", "tok")
     end
   end
+
+  describe "record_message/1 — the row the ledger prices (#1143)" do
+    setup do
+      %{user: insert_verified_user()}
+    end
+
+    defp attrs(user, overrides \\ %{}) do
+      Map.merge(
+        %{
+          user_id: user.id,
+          channel: "sms",
+          direction: "outbound",
+          provider_message_id: "prov-#{System.unique_integer([:positive])}"
+        },
+        overrides
+      )
+    end
+
+    test "writes a row and stamps it", %{user: user} do
+      assert {:ok, message} = Comms.record_message(attrs(user))
+      assert message.user_id == user.id
+      assert message.inserted_at
+    end
+
+    # The contract that makes this different from `Billing.record_usage/5`,
+    # and the whole reason the table exists. `record_usage/5` rescues by
+    # design, so a dropped comms row was a message nobody was charged for.
+    # This one must hand the failure back, not log it and return :ok.
+    test "an invalid row is an error, not a swallowed log line", %{user: user} do
+      assert {:error, %Ecto.Changeset{} = cs} =
+               Comms.record_message(attrs(user, %{channel: "carrier-pigeon"}))
+
+      assert %{channel: _} = errors_on(cs)
+
+      assert {:error, %Ecto.Changeset{}} =
+               Comms.record_message(attrs(user, %{provider_message_id: nil}))
+
+      assert {:error, %Ecto.Changeset{}} =
+               Comms.record_message(attrs(user, %{direction: "sideways"}))
+    end
+
+    test "the provider's id makes a repeat a no-op, not a second charge", %{user: user} do
+      a = attrs(user, %{provider_message_id: "prov-fixed"})
+
+      assert {:ok, _} = Comms.record_message(a)
+      assert {:ok, :duplicate} = Comms.record_message(a)
+
+      assert Fountain.Repo.aggregate(Fountain.Team.CommsMessage, :count, :id) == 1
+    end
+
+    # Scoped by user as well as channel: provider message ids are unique
+    # within a provider, so two tenants could in principle collide, and one
+    # tenant's send must never be swallowed as another's duplicate.
+    test "two tenants may hold the same provider id", %{user: user} do
+      other = insert_verified_user()
+
+      assert {:ok, _} = Comms.record_message(attrs(user, %{provider_message_id: "shared"}))
+      assert {:ok, _} = Comms.record_message(attrs(other, %{provider_message_id: "shared"}))
+
+      assert Fountain.Repo.aggregate(Fountain.Team.CommsMessage, :count, :id) == 2
+    end
+
+    test "the same id on different channels is two messages", %{user: user} do
+      assert {:ok, _} = Comms.record_message(attrs(user, %{provider_message_id: "x"}))
+
+      assert {:ok, _} =
+               Comms.record_message(attrs(user, %{provider_message_id: "x", channel: "email"}))
+
+      assert Fountain.Repo.aggregate(Fountain.Team.CommsMessage, :count, :id) == 2
+    end
+  end
 end

--- a/ee/lib/fountain/billing/finance.ex
+++ b/ee/lib/fountain/billing/finance.ex
@@ -89,9 +89,12 @@ defmodule Fountain.Billing.Finance do
   the panel exists to show that inference is passed through and sandbox time
   is where the margin is.
 
-  **Messages** are per-send, from the `comms_email_sent`, `comms_sms_sent` and
-  `comms_sms_received` usage events (`FountainWeb.TeamCommsMcpController`,
-  `Team.Comms.Inbound`). Inbound counts: AgentPhone charges to receive.
+  **Messages** are per-send, from the `comms_messages` rows the ledger also
+  prices (`FountainWeb.TeamCommsMcpController`, `Team.Comms.Inbound`). Inbound
+  counts: AgentPhone charges to receive. They moved off `usage_events` with
+  the pricer in #1143 — counting cost from a table whose writer can drop a row
+  while revenue reads one that cannot would put a discrepancy inside the view
+  built to find them.
 
   ## Cost, ownership and the tenants that are not there
 
@@ -113,11 +116,8 @@ defmodule Fountain.Billing.Finance do
   alias Fountain.Accounts.User
   alias Fountain.Billing
   alias Fountain.Billing.SandboxUsage
-  alias Fountain.Billing.UsageEvent
   alias Fountain.Repo
-  alias Fountain.Team.Comms
-
-  @message_events ~w(comms_email_sent comms_sms_sent comms_sms_received)
+  alias Fountain.Team.{Comms, CommsMessage}
 
   @typedoc "One tenant's money for a period. Every `*_cents` may be `nil` when the rate card is silent."
   @type tenant_row :: %{
@@ -576,28 +576,38 @@ defmodule Fountain.Billing.Finance do
     )
   end
 
-  # Message counts per tenant for the period, one grouped query over the same
-  # `usage_events` table the sandbox counts come from.
+  # Message counts per tenant for the period, one grouped query over
+  # `comms_messages` — the same rows the ledger prices (#1143).
+  #
+  # This used to read `usage_events`, and had to move with the pricer. The
+  # panel exists to hold revenue against cost, so counting the cost side from
+  # a table whose writer can silently drop a row while the revenue side reads
+  # a table whose writer cannot would put a discrepancy inside the one view
+  # built to find discrepancies.
   defp message_counts(period_start, period_end) do
-    from(e in UsageEvent,
+    from(m in CommsMessage,
       where:
-        e.inserted_at >= ^period_start and e.inserted_at < ^period_end and
-          e.event_type in @message_events and not is_nil(e.user_id),
-      group_by: [e.user_id, e.event_type],
-      select: {e.user_id, e.event_type, count(e.id)}
+        m.inserted_at >= ^period_start and m.inserted_at < ^period_end and
+          not is_nil(m.user_id),
+      group_by: [m.user_id, m.channel, m.direction],
+      select: {m.user_id, m.channel, m.direction, count(m.id)}
     )
     |> Repo.all()
-    |> Enum.reduce(%{}, fn {user_id, type, count}, acc ->
+    |> Enum.reduce(%{}, fn {user_id, channel, direction, count}, acc ->
       counts = Map.get(acc, user_id, empty_messages())
 
-      Map.put(acc, user_id, %{
-        counts
-        | emails_sent: counts.emails_sent + if(type == "comms_email_sent", do: count, else: 0),
-          sms_sent: counts.sms_sent + if(type == "comms_sms_sent", do: count, else: 0),
-          sms_received: counts.sms_received + if(type == "comms_sms_received", do: count, else: 0)
-      })
+      Map.put(acc, user_id, add_message_count(counts, channel, direction, count))
     end)
   end
+
+  defp add_message_count(counts, "email", _direction, n),
+    do: %{counts | emails_sent: counts.emails_sent + n}
+
+  defp add_message_count(counts, "sms", "inbound", n),
+    do: %{counts | sms_received: counts.sms_received + n}
+
+  defp add_message_count(counts, "sms", _outbound, n),
+    do: %{counts | sms_sent: counts.sms_sent + n}
 
   defp empty_messages, do: %{emails_sent: 0, sms_sent: 0, sms_received: 0}
 

--- a/ee/lib/fountain/billing/usage_event.ex
+++ b/ee/lib/fountain/billing/usage_event.ex
@@ -2,9 +2,21 @@ defmodule Fountain.Billing.UsageEvent do
   @moduledoc """
   Schema for the `usage_events` table.
 
-  Tracks platform usage for billing aggregation and post-hoc analytics.
-  Written synchronously from `ConversationServer` at key lifecycle points;
-  never updated after insertion (no `updated_at`).
+  **Nothing here is money any more** (#1143). These rows are the product
+  signal: a count on a dashboard and the PostHog mirror that
+  `Billing.record_usage/5` writes from the same choke point. That writer
+  rescues and logs rather than failing the action that produced it, because a
+  metering outage must never fail a conversation — the right contract for a
+  count and the wrong one for a row the ledger keys on.
+
+  Comms messages used to be priced from the `comms_*` rows here, so a dropped
+  event was a message the customer was never charged for. They are priced from
+  `Fountain.Team.CommsMessage` now, whose writer does not rescue and whose key
+  is the provider's own message id. The `comms_*` types stay in the
+  vocabulary, and stay product-only.
+
+  Written from `ConversationServer` at key lifecycle points and from the comms
+  paths; never updated after insertion (no `updated_at`).
   """
 
   use Ecto.Schema
@@ -26,12 +38,14 @@ defmodule Fountain.Billing.UsageEvent do
     field :inserted_at, :utc_datetime
   end
 
-  # The closed vocabulary of things Fountain pays for. Sandbox lifecycle, and
-  # the teammate messages that carry a per-message provider charge on top of
-  # the monthly cost of an inbox or a number (`Fountain.Billing.Finance`).
-  # `sandbox_terminated` is forensic only: nothing prices or aggregates it
-  # (`SandboxUsage` reads the sandbox rows), but its `duration_ms` and
-  # `final_status` are the record of what a sandbox did when it died.
+  # The closed vocabulary. Sandbox lifecycle, and the teammate messages that
+  # carry a per-message provider charge (`Fountain.Billing.Finance`).
+  #
+  # None of it is priced from here. `sandbox_terminated` never was — it is
+  # forensic only, and `SandboxUsage` reads the sandbox rows — and since #1143
+  # the `comms_*` types are not either: `CreditPricer` prices comms messages
+  # from `comms_messages`, whose writer cannot silently drop one. Keep these
+  # for the product mirror; do not add a type expecting it to bill.
   @valid_event_types ~w(sandbox_provisioned sandbox_provision_failed turn_started sandbox_terminated
                          sandbox_suspended sandbox_resumed
                          comms_email_sent comms_sms_sent comms_sms_received)

--- a/ee/lib/fountain/workers/credit_pricer.ex
+++ b/ee/lib/fountain/workers/credit_pricer.ex
@@ -17,9 +17,13 @@ defmodule Fountain.Workers.CreditPricer do
       self-hosted runner costs Fountain no sandbox time but its tokens are
       still on Fountain's key. A turn on the tenant's own credential is not
       marked and is never seen here.
-    * **Messages.** Every `comms_email_sent`, `comms_sms_sent` and
-      `comms_sms_received` usage event burns the matching price under
-      `burn_message:<event_id>`. A `nil` price burns nothing (#1042).
+    * **Messages.** Every `comms_messages` row burns its channel's price
+      under `burn_message:<message_id>`. A `nil` price burns nothing (#1042).
+      Inbound counts, because AgentPhone charges to receive an SMS as well as
+      to send one. These were priced from `usage_events` until #1143, where a
+      dropped row meant a free message: that table's writer rescues by
+      contract, so a metering outage never fails a conversation, which is the
+      wrong contract for a row the ledger keys on.
 
   Rows are written for every tenant, comped included: the ledger is also how
   `Finance` sees what a comp cost. Refusing spend is `Credits.gate/1`'s job,
@@ -43,19 +47,18 @@ defmodule Fountain.Workers.CreditPricer do
   import Ecto.Query
 
   alias Fountain.Billing.SandboxUsage
-  alias Fountain.Billing.UsageEvent
   alias Fountain.Conversations.Conversation
   alias Fountain.Conversations.Sandbox
   alias Fountain.Conversations.Turn
   alias Fountain.Credits
   alias Fountain.Credits.LedgerEntry
   alias Fountain.Repo
+  alias Fountain.Team.CommsMessage
 
   require Logger
 
   @lookback_days 7
   @batch 500
-  @message_events ~w(comms_email_sent comms_sms_sent comms_sms_received)
 
   @impl Oban.Worker
   def perform(_job) do
@@ -309,52 +312,67 @@ defmodule Fountain.Workers.CreditPricer do
   # Messages
   # ---------------------------------------------------------------------------
 
+  # Prices from `comms_messages`, not `usage_events` (#1143).
+  #
+  # `usage_events` rows are written by `Billing.record_usage/5`, which rescues
+  # and logs by contract, so a dropped row was a message nobody was ever
+  # charged for — and nothing reconciled it, because the look-back below only
+  # re-reads rows that exist. `Team.Comms.record_message/1` does not rescue,
+  # and its row is keyed on the provider's own message id, which is also what
+  # a reconciliation against a provider invoice would compare.
+  #
+  # The rate card is still per channel rather than per direction: AgentPhone
+  # charges for a received SMS as well as a sent one, which is why inbound
+  # rows are priced at all.
   defp price_messages(floor) do
     card = Credits.price_card()
 
-    prices = %{
-      "comms_email_sent" => card.email_message,
-      "comms_sms_sent" => card.sms_message,
-      "comms_sms_received" => card.sms_message
-    }
+    prices = %{"email" => card.email_message, "sms" => card.sms_message}
+    priced_channels = for {channel, cents} <- prices, is_integer(cents) and cents > 0, do: channel
 
-    priced_types = for {type, cents} <- prices, is_integer(cents) and cents > 0, do: type
-
-    if priced_types == [] do
+    if priced_channels == [] do
       0
     else
       floor
-      |> unpriced_messages(priced_types)
-      |> Enum.count(&price_message(&1, Map.fetch!(prices, &1.event_type)))
+      |> unpriced_messages(priced_channels)
+      |> Enum.count(&price_message(&1, Map.fetch!(prices, &1.channel)))
     end
   end
 
-  defp unpriced_messages(floor, types) do
-    from(e in UsageEvent,
+  defp unpriced_messages(floor, channels) do
+    from(m in CommsMessage,
       left_join: l in LedgerEntry,
-      on: l.idempotency_key == fragment("'burn_message:' || ?::text", e.id),
+      on: l.idempotency_key == fragment("'burn_message:' || ?::text", m.id),
       where: is_nil(l.id),
-      where: e.event_type in ^types and e.event_type in ^@message_events,
-      where: e.inserted_at >= ^floor,
-      order_by: [asc: e.inserted_at],
+      where: m.channel in ^channels,
+      where: m.inserted_at >= ^floor,
+      # A deleted account's rows are nilified rather than removed, and there is
+      # nobody left to charge.
+      where: not is_nil(m.user_id),
+      order_by: [asc: m.inserted_at],
       limit: @batch,
       select: %{
-        id: e.id,
-        user_id: e.user_id,
-        event_type: e.event_type,
-        resource_id: e.resource_id
+        id: m.id,
+        user_id: m.user_id,
+        channel: m.channel,
+        direction: m.direction,
+        contact_id: m.contact_id
       }
     )
     |> Repo.all()
   end
 
-  defp price_message(event, cents) do
-    case Credits.debit(event.user_id, cents, "burn_message",
-           idempotency_key: "burn_message:#{event.id}",
-           resource_type: "usage_event",
-           resource_id: Integer.to_string(event.id),
+  defp price_message(message, cents) do
+    case Credits.debit(message.user_id, cents, "burn_message",
+           idempotency_key: "burn_message:#{message.id}",
+           resource_type: "comms_message",
+           resource_id: message.id,
            actor: "system:credit_pricer",
-           metadata: %{"event_type" => event.event_type, "contact_id" => event.resource_id}
+           metadata: %{
+             "channel" => message.channel,
+             "direction" => message.direction,
+             "contact_id" => message.contact_id
+           }
          ) do
       {:ok, _} ->
         true
@@ -363,7 +381,7 @@ defmodule Fountain.Workers.CreditPricer do
         false
 
       {:error, reason} ->
-        Logger.warning("credit pricer: message #{event.id} not priced: #{inspect(reason)}")
+        Logger.warning("credit pricer: message #{message.id} not priced: #{inspect(reason)}")
         false
     end
   end

--- a/ee/test/fountain/billing_finance_test.exs
+++ b/ee/test/fountain/billing_finance_test.exs
@@ -588,13 +588,25 @@ defmodule Fountain.Billing.FinanceTest do
     |> Repo.insert!()
   end
 
+  # The cost side counts the same `comms_messages` rows the ledger prices
+  # (#1143). The old event-type names are kept as this helper's vocabulary
+  # because the assertions read better in them; they map to the row's
+  # channel/direction pair.
   defp message(user, event_type, count, at \\ ~U[2026-05-10 00:00:00Z]) do
+    {channel, direction} =
+      case event_type do
+        "comms_email_sent" -> {"email", "outbound"}
+        "comms_sms_sent" -> {"sms", "outbound"}
+        "comms_sms_received" -> {"sms", "inbound"}
+      end
+
     for _ <- 1..count do
-      %Fountain.Billing.UsageEvent{}
-      |> Fountain.Billing.UsageEvent.changeset(%{
+      %Fountain.Team.CommsMessage{}
+      |> Fountain.Team.CommsMessage.changeset(%{
         user_id: user.id,
-        event_type: event_type,
-        resource_type: "team_contact",
+        channel: channel,
+        direction: direction,
+        provider_message_id: "prov-#{System.unique_integer([:positive])}",
         inserted_at: at
       })
       |> Repo.insert!()

--- a/ee/test/fountain/workers/credit_pricer_test.exs
+++ b/ee/test/fountain/workers/credit_pricer_test.exs
@@ -133,21 +133,32 @@ defmodule Fountain.Workers.CreditPricerTest do
       assert %{messages: 0} = CreditPricer.run(since: @since, now: @now)
     end
 
-    test "a priced message burns once, inbound SMS included" do
-      user = insert_empty_user()
-      cfg = Application.get_env(:fountain, :credits)
-
+    defp priced_card(cfg) do
       Application.put_env(
         :fountain,
         :credits,
         Keyword.merge(cfg, email_message_cents: 1, sms_message_cents: 2)
       )
+    end
 
-      {:ok, _} = Billing.record_usage(user.id, "comms_email_sent", nil, "contact", %{})
-      {:ok, _} = Billing.record_usage(user.id, "comms_sms_sent", nil, "contact", %{})
-      {:ok, _} = Billing.record_usage(user.id, "comms_sms_received", nil, "contact", %{})
-      # Not a message.
-      {:ok, _} = Billing.record_usage(user.id, "turn_started", nil, "conversation", %{})
+    defp comms_message(user, channel, direction) do
+      {:ok, _} =
+        Fountain.Team.Comms.record_message(%{
+          user_id: user.id,
+          channel: channel,
+          direction: direction,
+          provider_message_id: "prov-#{System.unique_integer([:positive])}"
+        })
+    end
+
+    test "a priced message burns once, inbound SMS included" do
+      user = insert_empty_user()
+      priced_card(Application.get_env(:fountain, :credits))
+
+      comms_message(user, "email", "outbound")
+      comms_message(user, "sms", "outbound")
+      # AgentPhone charges for a received SMS too, so inbound is priced.
+      comms_message(user, "sms", "inbound")
 
       assert %{messages: 3} = CreditPricer.run(since: @since, now: DateTime.utc_now())
       assert Credits.balance(user.id) == -5
@@ -155,6 +166,56 @@ defmodule Fountain.Workers.CreditPricerTest do
 
       reasons = Credits.list_entries(user.id) |> Enum.map(& &1.reason) |> Enum.uniq()
       assert reasons == ["burn_message"]
+    end
+
+    # The whole point of #1143. `usage_events` rows come from a writer that
+    # rescues and logs, so a dropped one was a free message; they are the
+    # product signal now and the ledger must not read them. If this ever
+    # starts billing again, a comms message would be charged twice — once from
+    # each table.
+    test "a usage_events row is not priced" do
+      user = insert_empty_user()
+      priced_card(Application.get_env(:fountain, :credits))
+
+      {:ok, _} = Billing.record_usage(user.id, "comms_email_sent", nil, "contact", %{})
+      {:ok, _} = Billing.record_usage(user.id, "comms_sms_sent", nil, "contact", %{})
+      {:ok, _} = Billing.record_usage(user.id, "comms_sms_received", nil, "contact", %{})
+
+      assert %{messages: 0} = CreditPricer.run(since: @since, now: DateTime.utc_now())
+      assert Credits.balance(user.id) == 0
+    end
+
+    # The provider's id is the idempotency key, so a send retried after a
+    # timeout that in fact reached the provider bills once.
+    test "the same provider message id is one row and one charge" do
+      user = insert_empty_user()
+      priced_card(Application.get_env(:fountain, :credits))
+
+      attrs = %{
+        user_id: user.id,
+        channel: "sms",
+        direction: "outbound",
+        provider_message_id: "prov-retried"
+      }
+
+      assert {:ok, _} = Fountain.Team.Comms.record_message(attrs)
+      assert {:ok, :duplicate} = Fountain.Team.Comms.record_message(attrs)
+
+      assert %{messages: 1} = CreditPricer.run(since: @since, now: DateTime.utc_now())
+      assert Credits.balance(user.id) == -2
+    end
+
+    # A deleted account's rows are nilified rather than removed, and there is
+    # nobody left to charge. Without the guard the pricer would raise on a
+    # nil user_id every pass, taking the turn and inference passes with it.
+    test "a message whose account was deleted is skipped" do
+      user = insert_empty_user()
+      priced_card(Application.get_env(:fountain, :credits))
+
+      comms_message(user, "sms", "outbound")
+      Fountain.Repo.update_all(Fountain.Team.CommsMessage, set: [user_id: nil])
+
+      assert %{messages: 0} = CreditPricer.run(since: @since, now: DateTime.utc_now())
     end
   end
 


### PR DESCRIPTION
Closes #1143.

## The bug

Since ADR 0031 the ledger prices from the real tables — turns from `turns`, sandbox minutes from `sandboxes`. Comms messages were the exception: they were priced from `usage_events`, and those rows are written by `Billing.record_usage/5`, which **rescues and logs** rather than failing the action that produced them, because a metering outage must never fail a conversation.

That contract is right for a count on a dashboard and wrong for a row the ledger keys on. **A dropped `comms_*` event was a message the customer was never charged for**, and nothing reconciled it afterwards: the pricer's seven-day look-back only re-reads rows that already exist. Verified on main — neither call site (`team/comms/inbound.ex`, `team_comms_mcp_controller.ex`) checks the return value, and neither could have done anything useful with it.

## The durable row

`comms_messages`, written on both the send and receive paths through `Team.Comms.record_message/1`, which does **not** rescue — a failure is logged as an unbilled message rather than silently discarded.

**The key is the provider's own message id**, unique per `(user_id, channel)`. That buys three things:

- a send retried after a timeout that in fact reached the provider bills **once**;
- a reconciliation against a provider invoice has something to join on, which is the comparison anyone auditing a bill would want anyway;
- two tenants on one provider cannot collide, since provider ids are only unique within a provider.

`Comms.Mcp` already had that id in hand at every send (`%{"message_id" => mid}` / `%{"id" => mid}`); it now rides the audit summary so the controller can key on it. Inbound uses the payload's own id, falling back to the webhook delivery id.

## Both sides moved, deliberately

`CreditPricer` prices from it **and** `Finance`'s cost column counts from it. Leaving the cost side on `usage_events` would have put a discrepancy inside the one view built to find discrepancies.

## `usage_events` is no longer money at all

The `comms_*` types stay for the PostHog product mirror — which is what `record_usage/5`'s choke point exists for, and which the issue explicitly asked to keep. Both the moduledoc and the vocabulary comment now say nothing there is priced, so the next reader does not repeat this.

## Edge cases, each with a test

- A send or receive whose provider returned **no id** is logged as unbillable rather than billed against something unidentifiable.
- Rows are **nilified, not deleted** with an account (ADR 0013's deletion semantics — deleting an account must not erase what it owed), and the pricer skips a nil user. Without that guard it would raise every pass and take the turn and inference passes down with it.
- The same id on two channels is two messages; the same id for two tenants is two messages.

## No backfill, by decision

A message whose usage event was dropped before this **is not charged retroactively** — there is no record of it to price, the same position #1459 reached for gemini's unbilled turns. Stated plainly in the CHANGELOG so nobody expects otherwise.

## Testing

- `mix precommit` — **6 doctests, 4172 tests, 0 failures**, exit 0.
- New: the `record_message/1` contract (5 tests), the inbound durable row (2), the pricer over the new table (4, including **a `usage_events` row is not priced** — the regression guard that would catch a future double-charge from both tables).
- The no-swallow contract verified by reverting: making `record_message/1` return `{:ok, :duplicate}` for any changeset error fails exactly the test that asserts an invalid row is an error.
- The existing finance and pricer tests were rewritten onto the new table rather than deleted, so the same assertions still hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bcpj4FrtXSmLrsWphGMVus