### PR TITLE
feat(admin): show running Buzz runtimes

### DIFF
--- a/apps/fountain/lib/fountain/buzz/manager.ex
+++ b/apps/fountain/lib/fountain/buzz/manager.ex
@@ -57,6 +57,15 @@ defmodule Fountain.Buzz.Manager do
   @doc "Whether a harness is running for `identity_id` (anywhere in the cluster)."
   def running?(identity_id), do: whereis(identity_id) != nil
 
+  @doc "Number of Buzz harnesses running across the cluster."
+  @spec running_count() :: non_neg_integer()
+  def running_count do
+    case Horde.Registry.count(@registry) do
+      :undefined -> 0
+      count -> count
+    end
+  end
+
   @doc """
   Ensure a harness is running for `identity`. Idempotent: if one already runs,
   returns it without minting a credential. Otherwise starts the supervised

--- a/apps/fountain/lib/fountain_web/live/admin_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/admin_live/index.ex
@@ -20,6 +20,7 @@ defmodule FountainWeb.AdminLive.Index do
 
   alias Fountain.{Billing, Conversations}
   alias Fountain.Billing.SandboxUsage
+  alias Fountain.Buzz.Manager, as: BuzzManager
 
   @impl true
   def mount(_params, _session, socket) do
@@ -43,6 +44,7 @@ defmodule FountainWeb.AdminLive.Index do
     |> assign(:funnel, Fountain.Funnel.summary_admin())
     |> assign(:provider_spend, Billing.provider_spend())
     |> assign(:sandbox_count, Conversations._unsafe_count_sandboxes_admin())
+    |> assign(:buzz_runtime_count, BuzzManager.running_count())
     |> assign_billing_overview()
   end
 
@@ -155,7 +157,7 @@ defmodule FountainWeb.AdminLive.Index do
 
       <section class="space-y-3">
         <h2 class="text-lg font-medium">At a glance</h2>
-        <div class="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <div class="grid grid-cols-2 sm:grid-cols-5 gap-3">
           <.link
             :if={@credits_enabled}
             navigate={~p"/admin/finance"}
@@ -189,6 +191,15 @@ defmodule FountainWeb.AdminLive.Index do
             <div class="text-xs text-zinc-500">Active sandboxes</div>
             <div class="text-2xl font-semibold tabular-nums">{@sandbox_count}</div>
             <div class="text-xs text-zinc-500">running now ↗</div>
+          </.link>
+
+          <.link
+            navigate={~p"/admin/users"}
+            class="bg-white rounded shadow border border-zinc-200 px-4 py-3 hover:border-zinc-400"
+          >
+            <div class="text-xs text-zinc-500">Buzz runtimes</div>
+            <div class="text-2xl font-semibold tabular-nums">{@buzz_runtime_count}</div>
+            <div class="text-xs text-zinc-500">running now · owners ↗</div>
           </.link>
 
           <%!-- Hours, not money: minutes on different providers cost

--- a/apps/fountain/test/fountain/buzz/manager_test.exs
+++ b/apps/fountain/test/fountain/buzz/manager_test.exs
@@ -56,6 +56,20 @@ defmodule Fountain.Buzz.ManagerTest do
     Manager.stop_harness(identity.id)
   end
 
+  test "running_count counts registered harnesses cluster-wide", %{fake: fake} do
+    baseline = Manager.running_count()
+    first = insert_buzz_identity()
+    second = insert_buzz_identity()
+
+    assert {:ok, _pid} = Manager.start_harness(first, launch_opts(fake))
+    assert {:ok, _pid} = Manager.start_harness(second, launch_opts(fake))
+    assert Manager.running_count() == baseline + 2
+
+    Manager.stop_harness(first.id)
+    assert Manager.running_count() == baseline + 1
+    Manager.stop_harness(second.id)
+  end
+
   test "start_harness is idempotent and mints no second credential", %{fake: fake} do
     identity = insert_buzz_identity()
 

--- a/apps/fountain/test/fountain_web/live/admin_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/admin_live_test.exs
@@ -18,6 +18,8 @@ defmodule FountainWeb.AdminLiveTest do
       {:ok, _lv, html} = live(conn, ~p"/admin")
       assert html =~ "Admin"
       assert html =~ "Users"
+      assert html =~ "Buzz runtimes"
+      assert html =~ "running now · owners"
     end
 
     test "regular user is redirected away from /admin", %{conn: conn} do


### PR DESCRIPTION
## Summary

- count live Buzz harnesses from the cluster-wide registry
- surface the count on the admin overview with the existing 10-second refresh
- link the metric to the users page, where Buzz ownership is shown
- cover both harness lifecycle counting and admin rendering

## Testing

- mix compile --warnings-as-errors
- mix test apps/fountain/test/fountain/buzz/manager_test.exs apps/fountain/test/fountain_web/live/admin_live_test.exs (17 tests, 0 failures)