### PR TITLE
fix(schema-guard): see an extension's responses, and declare what they render (#1536)

### DIFF
--- a/apps/fountain/test/support/extension_fixtures.ex
+++ b/apps/fountain/test/support/extension_fixtures.ex
@@ -67,6 +67,22 @@ defmodule Fountain.ExtensionFixtures do
         }
       })
     end
+
+    defmodule Deep do
+      @moduledoc false
+      require OpenApiSpex
+
+      OpenApiSpex.schema(%{
+        title: "FixtureDeep",
+        type: :object,
+        properties: %{
+          path_info: %OpenApiSpex.Schema{
+            type: :array,
+            items: %OpenApiSpex.Schema{type: :string}
+          }
+        }
+      })
+    end
   end
 
   defmodule Controller do
@@ -77,10 +93,20 @@ defmodule Fountain.ExtensionFixtures do
     use Phoenix.Controller, formats: [:json]
     use OpenApiSpex.ControllerSpecs
 
+    # Both operations declare every status they can render, because the schema
+    # guard resolves through `ExtensionDispatch` since #1536 and this fixture is
+    # an installed extension in the test VM like any other. Before that it was
+    # the only kind of extension there was, and none of its responses were ever
+    # checked — `:whoami` declared no 401 and `:deep` declared nothing at all.
+    # A fixture that models the seam should model a well-formed extension too.
     operation(:whoami,
       summary: "Who the host authenticated",
       operation_id: "fixtureWhoami",
-      responses: [ok: {"Whoami", "application/json", Fountain.ExtensionFixtures.Schemas.Whoami}]
+      responses: [
+        ok: {"Whoami", "application/json", Fountain.ExtensionFixtures.Schemas.Whoami},
+        unauthorized:
+          {"Missing or invalid API key", "application/json", FountainWeb.Schemas.Error}
+      ]
     )
 
     def whoami(conn, _params) do
@@ -94,7 +120,15 @@ defmodule Fountain.ExtensionFixtures do
       })
     end
 
-    operation(:deep, summary: "A nested path", operation_id: "fixtureDeep", responses: [])
+    operation(:deep,
+      summary: "A nested path",
+      operation_id: "fixtureDeep",
+      responses: [
+        ok: {"The trimmed path", "application/json", Fountain.ExtensionFixtures.Schemas.Deep},
+        unauthorized:
+          {"Missing or invalid API key", "application/json", FountainWeb.Schemas.Error}
+      ]
+    )
 
     def deep(conn, _params), do: json(conn, %{path_info: conn.path_info})
   end

--- a/apps/fountain/test/support/extension_schema_guard_case.ex
+++ b/apps/fountain/test/support/extension_schema_guard_case.ex
@@ -1,0 +1,123 @@
+defmodule FountainWeb.ExtensionSchemaGuardCase do
+  @moduledoc """
+  The schema guard's own coverage check, for one extension (ADR 0043, #1536).
+
+  `FountainWeb.SchemaGuard` validates every response the suite renders against
+  the schema its operation declares — and for the first two extensions it
+  validated none of them, silently, for as long as they existed. The core
+  router ends `/api` with `forward "/", ExtensionDispatch`, and a forward is
+  opaque to `Phoenix.Router.route_info/4`: it reports the forward's own route,
+  `/api`, which matches no documented path, so every extension response was
+  skipped as `:undocumented`.
+
+  Nothing failed, because a guard that checks nothing looks exactly like a
+  guard that finds nothing. That is the failure this file exists to make
+  impossible a second time: it asserts the guard can *resolve* every operation
+  the extension documents, which is the step that was missing. It says nothing
+  about whether those responses are correct — the guard itself does that, on
+  every request the extension's own tests make.
+
+  Use it from the extension's suite, naming the extension module:
+
+      defmodule FountainBuzz.SchemaGuardTest do
+        use FountainWeb.ExtensionSchemaGuardCase, extension: FountainBuzz.Extension
+      end
+
+  It lives in core's `test/support` rather than in each extension because both
+  extensions need the identical checks and neither may depend on the other. It
+  names no extension: the module under test arrives as an option, and
+  everything else is read from `Fountain.Extensions`, which is the host's own
+  registry.
+  """
+
+  @doc false
+  defmacro __using__(opts) do
+    extension = Keyword.fetch!(opts, :extension)
+
+    quote bind_quoted: [extension: extension] do
+      use ExUnit.Case, async: true
+
+      alias FountainWeb.{SchemaGuard, SchemaGuardAllowlist}
+
+      @extension extension
+
+      test "the extension is installed in this run" do
+        # Everything below is vacuous otherwise, and "vacuously true" is the
+        # exact shape of the defect this file is about. An extension's own
+        # suite always installs it (config/runtime.exs asks
+        # `Code.ensure_loaded?/1`, and here the answer is yes).
+        assert @extension in Fountain.Extensions.installed(),
+               "#{inspect(@extension)} is not installed, so this file would check nothing."
+      end
+
+      test "the schema guard resolves every operation this extension documents" do
+        unresolved =
+          for {path, item} <- @extension.openapi_paths(),
+              {method, operation} <- Map.from_struct(item),
+              match?(%OpenApiSpex.Operation{}, operation),
+              verb = method |> to_string() |> String.upcase(),
+              name = SchemaGuard.name(conn_for(verb, path)),
+              name != "#{verb} #{path}",
+              do: "#{verb} #{path} resolved to #{inspect(name)}"
+
+        assert unresolved == [], """
+        The schema guard could not resolve these operations back to the paths
+        the extension publishes:
+
+        #{Enum.map_join(unresolved, "\n", &"  #{&1}")}
+
+        `SchemaGuard.name/1` goes through the core router, which sees only the
+        `forward "/", ExtensionDispatch` that mounts this extension. When that
+        resolution breaks, nothing fails — every response is skipped as
+        `:undocumented` and the guard reports a clean run while checking
+        nothing at all (#1536). Fix `template/1` in
+        apps/fountain/test/support/schema_guard.ex.
+        """
+      end
+
+      test "no operation of this extension is on the core allowlist" do
+        mine =
+          for {path, item} <- @extension.openapi_paths(),
+              {method, operation} <- Map.from_struct(item),
+              match?(%OpenApiSpex.Operation{}, operation),
+              do: "#{method |> to_string() |> String.upcase()} #{path}"
+
+        listed =
+          for {{name, status}, _family} <- SchemaGuardAllowlist.entries(),
+              name in mine,
+              do: "#{name} -> #{status}"
+
+        assert listed == [], """
+        These entries on FountainWeb.SchemaGuardAllowlist name operations that
+        #{inspect(@extension)} serves:
+
+        #{Enum.map_join(listed, "\n", &"  #{&1}")}
+
+        An extension's operations declare their statuses; they do not go on the
+        core allowlist. The core ratchet cannot evaluate them: `apps/fountain`
+        runs with no extension installed, so
+        `FountainWeb.SchemaGuardrailTest`'s staleness check sees no such
+        operation and reports the entry as stale. That is not hypothetical —
+        it is how `{"POST /api/support/reports", 401}` was deleted in #1528 as
+        a fix nobody made (#1536).
+
+        Declare the status on the operation instead. There are #{length(mine)}
+        of them here, against the 66 core operations #1432 still owes.
+        """
+      end
+
+      # A conn shaped like the one the guard receives: `route_info/4` reads the
+      # method, the request path and the host, and nothing else. Path templates
+      # are spelled `{id}`, and a real request carries a value there — any
+      # value routes the same way, so a literal segment stands in for one.
+      defp conn_for(method, path) do
+        request_path = Regex.replace(~r/\{[^}]+\}/, path, "x")
+
+        :get
+        |> Plug.Test.conn(request_path)
+        |> Map.put(:method, method)
+        |> Map.put(:host, "www.example.com")
+      end
+    end
+  end
+end

--- a/apps/fountain/test/support/schema_guard.ex
+++ b/apps/fountain/test/support/schema_guard.ex
@@ -32,9 +32,16 @@ defmodule FountainWeb.SchemaGuard do
   @doc """
   Watch every response the suite renders.
 
-  Attached once from `test_helper.exs`. `Plug.Telemetry` is already in the
+  Attached from `test_helper.exs`. `Plug.Telemetry` is already in the
   endpoint, so this costs nothing per test and sees every response any
   controller test produces — 146 operations, from tests that already exist.
+
+  **Every app with a helper attaches it, and calling it again is a no-op.**
+  Each umbrella app's helper runs in the same VM under a root `mix test`, and
+  each extension attaches for its own standalone run (#1536). Naively that
+  spawned a second keeper, which died on `:ets.new` against a table the first
+  one already owns — harmless, but a crash report in every run. So a second
+  call finds the table and returns.
 
   **It records rather than raises, and that is not a style choice.**
   `:telemetry` wraps a handler in a try/catch: a handler that raises is logged
@@ -46,22 +53,29 @@ defmodule FountainWeb.SchemaGuard do
   """
   @spec attach() :: :ok
   def attach do
-    keeper =
-      spawn(fn ->
-        :ets.new(@table, [:public, :named_table, :duplicate_bag])
-        Process.sleep(:infinity)
-      end)
+    if :ets.whereis(@table) == :undefined do
+      keeper =
+        spawn(fn ->
+          :ets.new(@table, [:public, :named_table, :duplicate_bag])
+          Process.sleep(:infinity)
+        end)
 
-    # The table dies with its owner, so wait for the keeper to create it before
-    # any request can look for it.
-    wait_for_table(keeper, 200)
+      # The table dies with its owner, so wait for the keeper to create it
+      # before any request can look for it.
+      wait_for_table(keeper, 200)
+    end
 
-    :telemetry.attach(
-      "schema-guard",
-      [:phoenix, :endpoint, :stop],
-      &__MODULE__.handle/4,
-      nil
-    )
+    # `:already_exists` is the second helper attaching the same handler, which
+    # is the intended outcome rather than a failure.
+    case :telemetry.attach(
+           "schema-guard",
+           [:phoenix, :endpoint, :stop],
+           &__MODULE__.handle/4,
+           nil
+         ) do
+      :ok -> :ok
+      {:error, :already_exists} -> :ok
+    end
   end
 
   defp wait_for_table(_keeper, 0), do: raise("schema guard: the violations table never appeared")
@@ -201,13 +215,38 @@ defmodule FountainWeb.SchemaGuard do
       :error ->
         {:skip, :no_route}
 
+      # An extension's routes sit behind `forward "/", ExtensionDispatch`, and a
+      # forward is opaque to `route_info/4`: the core router reports the
+      # forward's own route, `/api`, which matches no documented path. So every
+      # extension response was skipped as `:undocumented` and the guard has
+      # never seen one (ADR 0043, #1536). Re-resolve through the mount.
+      %{plug: FountainWeb.Plugs.ExtensionDispatch} ->
+        extension_template(conn)
+
       %{route: route} ->
-        {:ok, Regex.replace(~r/:([a-zA-Z_][a-zA-Z0-9_]*)/, route, "{\\1}")}
+        {:ok, spell(route)}
 
       _ ->
         {:skip, :no_route}
     end
   end
+
+  # `Fountain.Extensions` is the host's own registry, so this reads no
+  # extension module and crosses no ADR 0043 boundary.
+  defp extension_template(%Plug.Conn{} = conn) do
+    segments = conn.request_path |> String.split("/", trim: true) |> Enum.drop(1)
+
+    with {_ext, mount, plug} when is_atom(plug) <- Fountain.Extensions.find_mount(segments),
+         under = segments |> Enum.drop(length(mount)) |> Enum.join("/"),
+         %{route: route} <-
+           Phoenix.Router.route_info(plug, conn.method, "/" <> under, conn.host) do
+      {:ok, spell("/api/" <> Enum.join(mount, "/") <> route)}
+    else
+      _ -> {:skip, :no_route}
+    end
+  end
+
+  defp spell(route), do: Regex.replace(~r/:([a-zA-Z_][a-zA-Z0-9_]*)/, route, "{\\1}")
 
   defp operation(conn, template) do
     spec = spec()

--- a/apps/fountain/test/support/schema_guard_allowlist.ex
+++ b/apps/fountain/test/support/schema_guard_allowlist.ex
@@ -14,6 +14,26 @@ defmodule FountainWeb.SchemaGuardAllowlist do
   fails if the list grows past `@ceiling`, so growing it is a deliberate edit a
   reviewer sees.
 
+  ## An extension's operations do not belong here
+
+  This list is core's, and only core's. `apps/fountain` installs no extension
+  (ADR 0043, and `config/runtime.exs` asks `Code.ensure_loaded?/1`), so the
+  staleness check in `SchemaGuardrailTest` — "every entry names an operation
+  the API still serves" — cannot see an extension operation and reports any
+  entry naming one as stale.
+
+  That is not a hypothetical. `{"POST /api/support/reports", 401}` sat here
+  until #1528 deleted it as stale, and it was not stale: the operation had
+  simply moved into `apps/fountain_support`, where nothing checked it either,
+  because the schema guard could not resolve through `ExtensionDispatch` at all
+  until #1536. A ratchet cannot count what it cannot see, and the entry looked
+  like a fix landing.
+
+  So an extension declares the statuses on its own operations instead — there
+  were 8 of them across both extensions, against the 66 core operations #1432
+  still owes. `FountainWeb.ExtensionSchemaGuardCase` enforces it from each
+  extension's suite, which is the only run that can.
+
   ## The families
 
   `:plug_status` — the operation does not declare a status something in the

--- a/apps/fountain_buzz/lib/fountain_buzz/agent_controller.ex
+++ b/apps/fountain_buzz/lib/fountain_buzz/agent_controller.ex
@@ -35,7 +35,15 @@ defmodule FountainBuzz.AgentController do
     operation_id: "FountainWeb.BuzzAgentController.index",
     summary: "List hosted Buzz agents",
     responses: [
-      ok: {"Buzz agents", "application/json", FountainBuzz.Schemas.BuzzIdentityListResponse}
+      ok: {"Buzz agents", "application/json", FountainBuzz.Schemas.BuzzIdentityListResponse},
+      # Declared on every operation here rather than allowlisted, which is what
+      # #1536 asked for: the schema guard could not see an extension's responses
+      # at all until it learned to resolve through `ExtensionDispatch`, and the
+      # core allowlist is the wrong home for an entry a core-only run cannot
+      # evaluate. `TenantAPIAuth` runs in the host's `:api` pipeline before the
+      # forward, so every operation below can answer 401. Core's own operations
+      # are still on the allowlist under #1432; there are 66 of those and 8 here.
+      unauthorized: {"Missing or invalid API key", "application/json", Schemas.Error}
     ]
   )
 
@@ -64,7 +72,12 @@ defmodule FountainBuzz.AgentController do
       payment_required:
         {"Balance exhausted, or the hosted-agent ceiling is reached", "application/json",
          Schemas.Error},
-      unprocessable_entity: {"Validation error", "application/json", Schemas.Error}
+      unprocessable_entity: {"Validation error", "application/json", Schemas.Error},
+      # `environment_id` naming an environment that does not exist, or belongs
+      # to somebody else. Undeclared until #1536 taught the schema guard to see
+      # this extension at all, and then found it on the first run.
+      not_found: {"The named environment does not exist", "application/json", Schemas.Error},
+      unauthorized: {"Missing or invalid API key", "application/json", Schemas.Error}
     ]
   )
 
@@ -161,7 +174,8 @@ defmodule FountainBuzz.AgentController do
     responses: [
       ok: {"Buzz agent", "application/json", FountainBuzz.Schemas.BuzzIdentityResponse},
       not_found: {"Not found", "application/json", Schemas.Error},
-      unprocessable_entity: {"Validation error", "application/json", Schemas.Error}
+      unprocessable_entity: {"Validation error", "application/json", Schemas.Error},
+      unauthorized: {"Missing or invalid API key", "application/json", Schemas.Error}
     ]
   )
 
@@ -211,7 +225,8 @@ defmodule FountainBuzz.AgentController do
     parameters: [id: [in: :path, type: :string, description: "Buzz agent id"]],
     responses: [
       no_content: "Deleted",
-      not_found: {"Not found", "application/json", Schemas.Error}
+      not_found: {"Not found", "application/json", Schemas.Error},
+      unauthorized: {"Missing or invalid API key", "application/json", Schemas.Error}
     ]
   )
 

--- a/apps/fountain_buzz/test/fountain_buzz/schema_guard_test.exs
+++ b/apps/fountain_buzz/test/fountain_buzz/schema_guard_test.exs
@@ -1,0 +1,10 @@
+defmodule FountainBuzz.SchemaGuardTest do
+  @moduledoc """
+  The schema guard can see this extension (#1536).
+
+  Every check is in `FountainWeb.ExtensionSchemaGuardCase`; the responses
+  themselves are validated by the guard on every request the rest of this
+  suite makes.
+  """
+  use FountainWeb.ExtensionSchemaGuardCase, extension: FountainBuzz.Extension
+end

--- a/apps/fountain_buzz/test/test_helper.exs
+++ b/apps/fountain_buzz/test/test_helper.exs
@@ -7,3 +7,13 @@ ExUnit.start()
 if Process.whereis(Fountain.Repo) do
   Ecto.Adapters.SQL.Sandbox.mode(Fountain.Repo, :manual)
 end
+
+# The schema guard (#1427) validates every rendered response against the schema
+# its operation declares. It is attached from `apps/fountain`'s helper for a
+# root `mix test`, and again here because `scripts/test-libraries.sh` runs this
+# suite from this directory, where that helper never runs. `attach/0` is
+# idempotent: `:telemetry.attach/4` with the same id replaces the handler, and
+# the second ETS keeper finds the table already there. Without it this app's
+# own suite would be the one place an extension's responses go unchecked
+# (#1536).
+FountainWeb.SchemaGuard.attach()

--- a/apps/fountain_support/lib/fountain_support/report_controller.ex
+++ b/apps/fountain_support/lib/fountain_support/report_controller.ex
@@ -43,7 +43,15 @@ defmodule FountainSupport.ReportController do
     request_body: {"Report", "application/json", Schemas.SupportReportCreateRequest},
     responses: [
       created: {"Report", "application/json", Schemas.SupportReportResponse},
-      unprocessable_entity: {"Validation errors", "application/json", FountainWeb.Schemas.Error}
+      unprocessable_entity: {"Validation errors", "application/json", FountainWeb.Schemas.Error},
+      # Declared on every operation here rather than allowlisted, which is what
+      # #1536 asked for. `{"POST /api/support/reports", 401}` was on the core
+      # allowlist until #1528 deleted it as stale — and it was not stale, it was
+      # merely unobservable, because the staleness check reads the operations
+      # `apps/fountain` serves and that run installs no extension. `TenantAPIAuth`
+      # runs in the host's `:api` pipeline before the forward, so all three
+      # operations here can answer 401.
+      unauthorized: {"Missing or invalid API key", "application/json", FountainWeb.Schemas.Error}
     ]
   )
 
@@ -62,7 +70,10 @@ defmodule FountainSupport.ReportController do
     operation_id: "FountainWeb.SupportReportController.index",
     summary: "List the caller's reports",
     description: "Newest first, with forwarding status and the issue URL when one was created.",
-    responses: [ok: {"Reports", "application/json", Schemas.SupportReportListResponse}]
+    responses: [
+      ok: {"Reports", "application/json", Schemas.SupportReportListResponse},
+      unauthorized: {"Missing or invalid API key", "application/json", FountainWeb.Schemas.Error}
+    ]
   )
 
   def index(conn, _params) do
@@ -76,7 +87,8 @@ defmodule FountainSupport.ReportController do
     parameters: [id: [in: :path, type: :string, required: true]],
     responses: [
       ok: {"Report", "application/json", Schemas.SupportReportResponse},
-      not_found: {"Not found", "application/json", FountainWeb.Schemas.Error}
+      not_found: {"Not found", "application/json", FountainWeb.Schemas.Error},
+      unauthorized: {"Missing or invalid API key", "application/json", FountainWeb.Schemas.Error}
     ]
   )
 

--- a/apps/fountain_support/test/fountain_support/schema_guard_test.exs
+++ b/apps/fountain_support/test/fountain_support/schema_guard_test.exs
@@ -1,0 +1,10 @@
+defmodule FountainSupport.SchemaGuardTest do
+  @moduledoc """
+  The schema guard can see this extension (#1536).
+
+  Every check is in `FountainWeb.ExtensionSchemaGuardCase`; the responses
+  themselves are validated by the guard on every request the rest of this
+  suite makes.
+  """
+  use FountainWeb.ExtensionSchemaGuardCase, extension: FountainSupport.Extension
+end

--- a/apps/fountain_support/test/test_helper.exs
+++ b/apps/fountain_support/test/test_helper.exs
@@ -7,3 +7,13 @@ ExUnit.start()
 if Process.whereis(Fountain.Repo) do
   Ecto.Adapters.SQL.Sandbox.mode(Fountain.Repo, :manual)
 end
+
+# The schema guard (#1427) validates every rendered response against the schema
+# its operation declares. It is attached from `apps/fountain`'s helper for a
+# root `mix test`, and again here because `scripts/test-libraries.sh` runs this
+# suite from this directory, where that helper never runs. `attach/0` is
+# idempotent: `:telemetry.attach/4` with the same id replaces the handler, and
+# the second ETS keeper finds the table already there. Without it this app's
+# own suite would be the one place an extension's responses go unchecked
+# (#1536).
+FountainWeb.SchemaGuard.attach()

--- a/sdk/contract/contract.json
+++ b/sdk/contract/contract.json
@@ -147,6 +147,11 @@
       ],
       "responses": {
         "204": {},
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
           "application/json": {
             "ref": "Error"
@@ -857,6 +862,11 @@
         "200": {
           "application/json": {
             "ref": "BuzzIdentityListResponse"
+          }
+        },
+        "401": {
+          "application/json": {
+            "ref": "Error"
           }
         }
       }
@@ -1625,6 +1635,11 @@
           "application/json": {
             "ref": "SupportReportListResponse"
           }
+        },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
         }
       }
     },
@@ -1637,6 +1652,11 @@
         "200": {
           "application/json": {
             "ref": "SupportReportResponse"
+          }
+        },
+        "401": {
+          "application/json": {
+            "ref": "Error"
           }
         },
         "404": {
@@ -2120,6 +2140,11 @@
         "200": {
           "application/json": {
             "ref": "BuzzIdentityResponse"
+          }
+        },
+        "401": {
+          "application/json": {
+            "ref": "Error"
           }
         },
         "404": {
@@ -3157,7 +3182,17 @@
             "ref": "BuzzIdentityResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "402": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "404": {
           "application/json": {
             "ref": "Error"
           }
@@ -3530,6 +3565,11 @@
         "201": {
           "application/json": {
             "ref": "SupportReportResponse"
+          }
+        },
+        "401": {
+          "application/json": {
+            "ref": "Error"
           }
         },
         "422": {
@@ -4284,6 +4324,11 @@
         "200": {
           "application/json": {
             "ref": "BuzzIdentityResponse"
+          }
+        },
+        "401": {
+          "application/json": {
+            "ref": "Error"
           }
         },
         "404": {

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -6996,6 +6996,15 @@ export interface operations {
                     "application/json": components["schemas"]["BuzzIdentityListResponse"];
                 };
             };
+            /** @description Missing or invalid API key */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
         };
     };
     "FountainWeb.BuzzAgentController.create": {
@@ -7021,8 +7030,26 @@ export interface operations {
                     "application/json": components["schemas"]["BuzzIdentityResponse"];
                 };
             };
+            /** @description Missing or invalid API key */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Balance exhausted, or the hosted-agent ceiling is reached */
             402: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description The named environment does not exist */
+            404: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -7067,6 +7094,15 @@ export interface operations {
                     "application/json": components["schemas"]["BuzzIdentityResponse"];
                 };
             };
+            /** @description Missing or invalid API key */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not found */
             404: {
                 headers: {
@@ -7106,6 +7142,15 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Missing or invalid API key */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not found */
             404: {
                 headers: {
@@ -7141,6 +7186,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["BuzzIdentityResponse"];
+                };
+            };
+            /** @description Missing or invalid API key */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
                 };
             };
             /** @description Not found */
@@ -9346,6 +9400,15 @@ export interface operations {
                     "application/json": components["schemas"]["SupportReportListResponse"];
                 };
             };
+            /** @description Missing or invalid API key */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
         };
     };
     "FountainWeb.SupportReportController.create": {
@@ -9369,6 +9432,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["SupportReportResponse"];
+                };
+            };
+            /** @description Missing or invalid API key */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
                 };
             };
             /** @description Validation errors */
@@ -9400,6 +9472,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["SupportReportResponse"];
+                };
+            };
+            /** @description Missing or invalid API key */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
                 };
             };
             /** @description Not found */


### PR DESCRIPTION
Closes #1536. The first gate of tracker #1538, and the correctness gate the tracker puts before repository graduation.

`FountainWeb.SchemaGuard` (#1427) validates every response the suite renders against the schema its operation declares. It had never validated one of an extension's, and nothing failed — because a guard that checks nothing looks exactly like a guard that finds nothing.

## Why it saw nothing

`template/1` resolves through `Phoenix.Router.route_info(FountainWeb.Router, ...)`, and the `/api` scope ends with `forward "/", ExtensionDispatch`. A forward is opaque to `route_info/4`: the router reports the forward's own route, `/api`, which matches no documented path, so `operation/2` returned `{:skip, :undocumented}` for every extension response.

This is the same opacity that made `openapi_paths/0` necessary (ADR 0043 decision 3). The described-vs-served half was compensated for; the rendered-vs-declared half was not.

`template/1` now re-resolves through the mount, reading `Fountain.Extensions` — the host's own registry, so this crosses no ADR 0043 boundary and `Fountain.ExtensionGuardTest` stays green. Each extension's `test_helper.exs` attaches the guard too, because `scripts/test-libraries.sh` runs those suites from their own directories where `apps/fountain`'s helper never runs. `attach/0` is idempotent now: a root `mix test` calls it three times, and the second keeper used to die on `:ets.new` against a table the first already owns.

## What it found on the first run

Measured, not inferred. Every documented extension operation resolved, and two rendered a status nothing declared:

| | | |
|---|---|---|
| `POST /api/support/reports` | 401 | `TenantAPIAuth`, undeclared |
| `POST /api/buzz/agents` | 404 | `environment_not_found`, undeclared |

The 401 was `{"POST /api/support/reports", 401}` on `SchemaGuardAllowlist` until #1528 deleted it as stale — and it was not stale. `SchemaGuardrailTest`'s staleness check reads the operations `apps/fountain` serves, and that run installs no extension, so the entry named an operation the run could not see. The defect simply stopped being observable, and the deletion read as a fix landing. The allowlist's own moduledoc calls out the inverse ("a stale allowlist entry is a fix nobody noticed landing"); this was that failure mode running the other way.

The 404 is a real disagreement between `AgentController.create/2` and its schema, added with the `environment_id` support and catchable by nothing until now.

## What it does about them

Both extensions **declare** the statuses rather than going on the allowlist: 401 on all eight operations, plus the 404. That is nine declarations, against the 66 core operations #1432 still owes.

The ratchet therefore stays at 70 and gains no entry it could not evaluate. That rule is written down in `SchemaGuardAllowlist`'s moduledoc and enforced by `FountainWeb.ExtensionSchemaGuardCase`, from each extension's own suite — the only run that can see an extension's operations at all.

The published document moves, so `sdk/contract/contract.json` and `sdk/typescript/src/generated/openapi.ts` are rebuilt here. That is exactly why this could not ride along with #1528, whose gate was a byte-identical spec. All four SDK contract verifiers pass.

The fixture extension is an installed extension in the test VM like any other, and the guard sees it too: `:whoami` declared no 401 and `:deep` declared nothing at all. Both declare their responses now. The fixture describes OpenAPI paths only while the suite runs, so the published artifact is unchanged by that half — verified with `build.sh --check`.

## Verified by reverting

A guard that stopped guarding looks exactly like one finding nothing, so both halves were broken on purpose:

- Removing the `ExtensionDispatch` clause from `template/1` fails the new coverage test, naming all three support operations resolving to `GET /api`.
- `required: [..., :never_rendered]` planted on `SupportReportResponse` fails 2 tests across 3 operations; the same on `BuzzIdentityResponse` fails 8. Before this change both suites were `0 failures` with the schema broken.

## Gate

`mix precommit` green: 4,206 + 114 + 33 tests, 0 failures; credo clean; dialyzer 0 errors; sobelow clean; prod release assembles. Formatting checked with the pinned 1.19.2.

## Left for the tracker

`POST /api/mcp/buzz/{conversation_id}` stays `:undocumented` — `McpController` declares no `operation`, the same as core's own `/api/mcp/team/...` transports. It is a sandbox transport rather than public API, so this is the correct outcome, not a gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015unQSjdFCfcmt4XJHPHtAY