### PR TITLE
feat(dist): the core distribution becomes a gate, and the switch covers every extension (#1510)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1064,6 +1064,194 @@ jobs:
       - name: Swift release build
         run: swift build --configuration release -Xswiftc -warnings-as-errors
 
+  # ADR 0043 decision 7 promises two distributions from one tree: the bundled
+  # release, which every existing tag has meant, and a core release that carries
+  # no extension at all. Until this job existed the core half was an assertion —
+  # `apps/fountain` running alone in the test partitions proves the TEST path,
+  # and the release path was proved only by `mix release` assembling with every
+  # `applications:` entry present.
+  #
+  # Its own job rather than a step in `checks`, for two reasons: that job is
+  # already close to its 15-minute ceiling (#1537), and a red here should say
+  # one thing — "the core distribution does not work" — rather than arrive
+  # buried in static analysis.
+  core-distribution:
+    name: Core distribution boots without the extensions
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    needs: [already-tested, changes]
+    if: ${{ !cancelled() && needs.already-tested.outputs.skip != 'true'
+         && needs.changes.outputs.docs_only != 'true' }}
+
+    permissions:
+      contents: read
+
+    env:
+      PG_IMAGE: postgres:16@sha256:287eced1f33b59ed265ed13a60d3680dd7646d70c4dc0e785f59a470ebc03eeb
+
+    steps:
+      # Backgrounded rather than a service container, for the reason the test
+      # job's copy explains: a service container's ~27s sits on the critical
+      # path before the first step runs.
+      - name: Start Postgres in the background
+        run: |
+          set -euo pipefail
+          nohup docker run -d --name postgres \
+            -p 5432:5432 \
+            -e POSTGRES_USER=postgres \
+            -e POSTGRES_PASSWORD=postgres \
+            -e POSTGRES_DB=fountain_core \
+            "${PG_IMAGE}" > "${RUNNER_TEMP}/postgres-start.log" 2>&1 &
+          echo "postgres starting; the wait step is what decides"
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
+
+      - name: Set up Elixir
+        id: beam
+        uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1.24.1
+        with:
+          elixir-version: "1.19.2"
+          otp-version: "28.3"
+
+      - name: Restore deps cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
+        with:
+          path: deps
+          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-mix-
+
+      - name: Wait for Postgres
+        run: |
+          set -euo pipefail
+          for _ in $(seq 1 120); do
+            if docker exec postgres pg_isready -U postgres -q 2>/dev/null; then
+              echo "postgres ready"
+              exit 0
+            fi
+            sleep 0.5
+          done
+          echo "::error::postgres never became ready"
+          docker logs postgres 2>&1 | tail -50 || true
+          exit 1
+
+      # BUNDLE_EXTENSIONS is read by `extension_applications/0` in mix.exs and by the
+      # Dockerfile's asset stage; one switch drives both halves so an image
+      # cannot end up with an extension application and no binaries (#1509).
+      - name: Build the core release
+        env:
+          MIX_ENV: prod
+          BUNDLE_EXTENSIONS: "false"
+        run: |
+          set -euo pipefail
+          mix deps.get --only prod
+          rm -rf _build/prod/rel
+          mix release fountain_server
+
+      # The assertion the campaign has been making since #1507. `mix release`
+      # is happy to build a release containing an application nobody asked
+      # for, so the contents are checked rather than trusted.
+      - name: The core release carries no extension
+        run: |
+          set -euo pipefail
+          apps=$(ls _build/prod/rel/fountain_server/lib | sed -E 's/-[0-9.]+$//' | sort)
+          echo "$apps" | tr '\n' ' '; echo
+          # `apps/fountain_*` is the extension naming convention. A
+          # `managoat_*` library under apps/ would be a DEPENDENCY of fountain
+          # and legitimately in both releases, so it must not be swept up here.
+          for ext in $(ls apps | grep '^fountain_'); do
+            if echo "$apps" | grep -qx "$ext"; then
+              echo "::error::the core release contains $ext" >&2
+              exit 1
+            fi
+          done
+          echo "no extension application in the core release"
+
+      # A FRESH database, migrated by the core release itself. This is the
+      # check that would have caught the crossing #1509 found by accident: a
+      # core migration altering `buzz_identities`, a table a core distribution
+      # does not have. Nothing but a core release against an empty database
+      # exercises that path.
+      - name: The core release boots, migrates and answers its health probes
+        env:
+          MIX_ENV: prod
+          PHX_SERVER: "true"
+          PORT: "4000"
+          SECRET_KEY_BASE: ci-only-not-a-secret-000000000000000000000000000000000000000000000000
+          MASTER_SECRETS_KEY: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          DATABASE_URL: postgres://postgres:postgres@localhost/fountain_core
+          DATABASE_SSL: "false"
+          PUBLIC_URL: https://ci.example.com
+          EMAIL_DELIVERY: none
+          OTEL_TRACES_EXPORTER: none
+        run: |
+          set -euo pipefail
+          rel=_build/prod/rel/fountain_server/bin/fountain_server
+
+          # Config providers run here, against a release whose :extensions list
+          # resolves to nothing. A core release that names an extension it does
+          # not carry aborts in Fountain.Extensions.validate!/0, at this line.
+          "$rel" eval 'IO.puts("config ok")'
+
+          # Migrations run on boot. An empty database plus a core-only path set
+          # is the whole point of this step.
+          "$rel" daemon
+          trap '"$rel" stop || true' EXIT
+
+          probe() {
+            for _ in $(seq 1 45); do
+              code=$(curl -s -o /dev/null -w '%{http_code}' -H 'Host: 10.42.0.1' "http://127.0.0.1:4000$1") || code=000
+              if [ "$code" = "200" ]; then
+                echo "  $1 -> 200"
+                return 0
+              fi
+              if [ "$code" != "000" ] && [ "$code" != "502" ]; then
+                echo "  $1 -> $code (expected 200)" >&2
+                return 1
+              fi
+              sleep 2
+            done
+            echo "  $1 never answered" >&2
+            return 1
+          }
+
+          probe /health
+          probe /health/ready
+
+          # The served document describes the running distribution (ADR 0043).
+          # A core release advertising an operation it cannot serve would be a
+          # lie the SDKs are generated from.
+          curl -fsS -H 'Host: 10.42.0.1' http://127.0.0.1:4000/api/openapi.json > /tmp/core-openapi.json
+          for ext in $(ls apps | grep '^fountain_' | sed 's/^fountain_//'); do
+            if jq -e --arg p "/api/$ext" '.paths | keys[] | select(startswith($p))' \
+                 /tmp/core-openapi.json > /dev/null 2>&1; then
+              echo "::error::the core spec describes /api/$ext" >&2
+              jq -r '.paths | keys[]' /tmp/core-openapi.json | grep "^/api/$ext" >&2
+              exit 1
+            fi
+          done
+          echo "no extension path in the core spec ($(jq '.paths | length' /tmp/core-openapi.json) paths)"
+
+      # The other direction, from the same compiled tree, so the job proves the
+      # switch rather than one setting of it. A release that carried nothing
+      # either way would pass every check above.
+      - name: The bundled release carries every extension
+        env:
+          MIX_ENV: prod
+          BUNDLE_EXTENSIONS: "true"
+        run: |
+          set -euo pipefail
+          rm -rf _build/prod/rel
+          mix release fountain_server
+          apps=$(ls _build/prod/rel/fountain_server/lib | sed -E 's/-[0-9.]+$//' | sort)
+          for ext in $(ls apps | grep '^fountain_'); do
+            echo "$apps" | grep -qx "$ext" || {
+              echo "::error::the bundled release is missing $ext" >&2
+              exit 1
+            }
+          done
+          echo "every extension application is in the bundled release"
+
   compose-fresh-clone:
     name: Compose fresh-clone check
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1221,7 +1221,26 @@ jobs:
           # The served document describes the running distribution (ADR 0043).
           # A core release advertising an operation it cannot serve would be a
           # lie the SDKs are generated from.
-          curl -fsS -H 'Host: 10.42.0.1' http://127.0.0.1:4000/api/openapi.json > /tmp/core-openapi.json
+          curl -fsS -H 'Host: 10.42.0.1' -H 'Accept: application/json' \
+            http://127.0.0.1:4000/api/openapi.json > /tmp/core-openapi.json
+
+          # Guard the guard. The first version of this check printed
+          # "no extension path in the core spec ( paths)" — an EMPTY count,
+          # because jq could not read the file — and passed anyway: every
+          # `jq -e ... select(...)` found nothing in nothing. A check that
+          # passes on an unreadable document is worse than no check, so the
+          # document has to be real before its contents mean anything.
+          paths=$(jq '.paths | length' /tmp/core-openapi.json) || {
+            echo "::error::/api/openapi.json did not return a readable document" >&2
+            head -c 2000 /tmp/core-openapi.json >&2 || true
+            exit 1
+          }
+          if [ -z "$paths" ] || [ "$paths" -lt 50 ]; then
+            echo "::error::the core spec has $paths paths; the API has far more" >&2
+            head -c 2000 /tmp/core-openapi.json >&2 || true
+            exit 1
+          fi
+
           for ext in $(ls apps | grep '^fountain_' | sed 's/^fountain_//'); do
             if jq -e --arg p "/api/$ext" '.paths | keys[] | select(startswith($p))' \
                  /tmp/core-openapi.json > /dev/null 2>&1; then
@@ -1230,7 +1249,7 @@ jobs:
               exit 1
             fi
           done
-          echo "no extension path in the core spec ($(jq '.paths | length' /tmp/core-openapi.json) paths)"
+          echo "no extension path in the core spec ($paths paths)"
 
       # The other direction, from the same compiled tree, so the job proves the
       # switch rather than one setting of it. A release that carried nothing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1218,38 +1218,42 @@ jobs:
           probe /health
           probe /health/ready
 
-          # The served document describes the running distribution (ADR 0043).
-          # A core release advertising an operation it cannot serve would be a
-          # lie the SDKs are generated from.
-          curl -fsS -H 'Host: 10.42.0.1' -H 'Accept: application/json' \
-            http://127.0.0.1:4000/api/openapi.json > /tmp/core-openapi.json
+          # The document describes the running distribution (ADR 0043). A core
+          # release advertising an operation it cannot serve would be a lie the
+          # SDKs are generated from.
+          #
+          # Asked of the running node with `rpc`, not fetched over HTTP. The
+          # first version curled /api/openapi.json and got a **301** — prod
+          # enforces HTTPS and only the health paths are excluded — which
+          # `curl -f` does not treat as a failure, so it wrote an empty file,
+          # `jq` exited 0 with no output, and the check passed on nothing. That
+          # is the same redirect trap the bundled boot check's own comment
+          # warns about, walked into one step later.
+          #
+          # `eval` cannot do this either: ApiSpec.spec/0 reaches the Endpoint
+          # through OpenApiSpex.Server.from_endpoint/1, which needs it started.
+          # `rpc` runs in the daemon that is already serving.
+          "$rel" rpc 'FountainWeb.ApiSpec.spec().paths |> Map.keys() |> Enum.sort() |> Enum.each(&IO.puts/1)' \
+            > /tmp/core-paths.txt
 
-          # Guard the guard. The first version of this check printed
-          # "no extension path in the core spec ( paths)" — an EMPTY count,
-          # because jq could not read the file — and passed anyway: every
-          # `jq -e ... select(...)` found nothing in nothing. A check that
-          # passes on an unreadable document is worse than no check, so the
-          # document has to be real before its contents mean anything.
-          paths=$(jq '.paths | length' /tmp/core-openapi.json) || {
-            echo "::error::/api/openapi.json did not return a readable document" >&2
-            head -c 2000 /tmp/core-openapi.json >&2 || true
-            exit 1
-          }
-          if [ -z "$paths" ] || [ "$paths" -lt 50 ]; then
-            echo "::error::the core spec has $paths paths; the API has far more" >&2
-            head -c 2000 /tmp/core-openapi.json >&2 || true
+          # Guard the guard: a spec with no paths satisfies every "describes no
+          # extension" check ever written, which is exactly how the first
+          # version of this step passed.
+          count=$(wc -l < /tmp/core-paths.txt | tr -d ' ')
+          if [ "${count:-0}" -lt 50 ]; then
+            echo "::error::the core spec has ${count:-0} paths; the API has far more" >&2
+            head -c 2000 /tmp/core-paths.txt >&2 || true
             exit 1
           fi
 
           for ext in $(ls apps | grep '^fountain_' | sed 's/^fountain_//'); do
-            if jq -e --arg p "/api/$ext" '.paths | keys[] | select(startswith($p))' \
-                 /tmp/core-openapi.json > /dev/null 2>&1; then
+            if grep -q "^/api/$ext" /tmp/core-paths.txt; then
               echo "::error::the core spec describes /api/$ext" >&2
-              jq -r '.paths | keys[]' /tmp/core-openapi.json | grep "^/api/$ext" >&2
+              grep "^/api/$ext" /tmp/core-paths.txt >&2
               exit 1
             fi
           done
-          echo "no extension path in the core spec ($paths paths)"
+          echo "no extension path in the core spec ($count paths)"
 
       # The other direction, from the same compiled tree, so the job proves the
       # switch rather than one setting of it. A release that carried nothing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ fountain/                  umbrella root
                            buzz-acp-publish workflow's inputs live in its app,
                            and FountainBuzz.Assets both finds the binaries and
                            refuses one whose version does not match the pin.
-                           `BUNDLE_BUZZ=false` builds the core distribution —
+                           `BUNDLE_EXTENSIONS=false` builds the core distribution —
                            no Buzz application in the release (mix.exs) and no
                            binaries in the image (Dockerfile), one switch for
                            both.

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 #     generation here — fail-fast at boot if it's missing rather than
 #     silently invalidate cookie sessions on every restart.
 #   - One Dockerfile, two distributions (ADR 0043 decision 7).
-#     `--build-arg BUNDLE_BUZZ=false` builds the CORE image: no Buzz
+#     `--build-arg BUNDLE_EXTENSIONS=false` builds the CORE image: no Buzz
 #     application in the release, no Buzz binaries, no Buzz smoke check.
 #     The default is the bundled image, which is what every existing tag
 #     has meant and what the hosted deployment runs.
@@ -24,7 +24,7 @@
 # Global scope, before the first FROM, because a `FROM` line can only
 # interpolate an ARG declared out here. Each stage that also *uses* the value
 # re-declares it; that is how build args work and not a duplication to tidy.
-ARG BUNDLE_BUZZ=true
+ARG BUNDLE_EXTENSIONS=true
 
 FROM hexpm/elixir:1.19.2-erlang-28.3-debian-trixie-20260610-slim AS build
 
@@ -56,7 +56,7 @@ COPY apps/fountain/mix.exs ./apps/fountain/mix.exs
 # Every extension's mix.exs is COPYd whatever the distribution: the umbrella
 # loads every child's project to resolve dependencies, so a missing one fails
 # `mix deps.get` here regardless of what the release ends up carrying. What
-# BUNDLE_BUZZ decides is whether the release *includes* the Buzz application
+# BUNDLE_EXTENSIONS decides is whether the release *includes* the Buzz application
 # and whether this image carries its binaries (ADR 0043 decision 7).
 COPY apps/fountain_buzz/mix.exs ./apps/fountain_buzz/mix.exs
 COPY apps/fountain_support/mix.exs ./apps/fountain_support/mix.exs
@@ -105,11 +105,11 @@ COPY sdk/typescript/examples ./sdk/typescript/examples
 # config/runtime.exs, which demands MASTER_SECRETS_KEY and the rest of the
 # production environment that does not exist during a build. Prepending the
 # compiled ebin paths gives the same code without the config.
-# BUNDLE_BUZZ decides which applications the release carries (ADR 0043 decision
+# BUNDLE_EXTENSIONS decides which applications the release carries (ADR 0043 decision
 # 7, and see mix.exs). Declared in this stage as well as the asset stage below
 # because a build ARG is scoped to the stage that declares it — and the two must
 # agree, or the image gets the extension without its binaries or the reverse.
-ARG BUNDLE_BUZZ=true
+ARG BUNDLE_EXTENSIONS=true
 RUN mix compile \
  && elixir -e 'Enum.each(Path.wildcard("_build/prod/lib/*/ebin"), &Code.prepend_path/1); {:ok, _} = Application.ensure_all_started(:lumis); {:ok, _} = Lumis.Languages.cache(Fountain.Docs.languages())' \
  && mix release fountain_server
@@ -131,9 +131,9 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH="${TARGETARCH:-amd64}" \
 # ---
 # The Buzz extension's native assets (ADR 0043, #1509). Everything in this
 # section belongs to `apps/fountain_buzz` and is present only in the BUNDLED
-# distribution: `--build-arg BUNDLE_BUZZ=false` selects the empty stage below
+# distribution: `--build-arg BUNDLE_EXTENSIONS=false` selects the empty stage below
 # instead, and the resulting image carries no Buzz binary, runs no Buzz smoke
-# check and, through `BUNDLE_BUZZ` in mix.exs, does not even include the
+# check and, through `BUNDLE_EXTENSIONS` in mix.exs, does not even include the
 # extension application.
 #
 # block/buzz publishes an amd64 .deb only, and our cluster is arm64 (ADR 0020,
@@ -147,7 +147,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH="${TARGETARCH:-amd64}" \
 # fork — the version is then only the release name; see that workflow. #776
 # tracks repinning to upstream once block/buzz#6088 ships.)
 
-FROM debian:trixie-slim AS buzz-assets-true
+FROM debian:trixie-slim AS native-assets-true
 ARG TARGETARCH
 ARG BUZZ_ACP_VERSION=0.5.14-fountain.4
 # buzz-acp: the hosted harness (gate 2). buzz: the CLI the server-side MCP tools
@@ -169,13 +169,13 @@ RUN apt-get update -y \
 # directory that happens to be empty is a no-op, so the runtime stage below
 # needs no conditional COPY — the only thing that varies is which of these two
 # it copies from.
-FROM debian:trixie-slim AS buzz-assets-false
+FROM debian:trixie-slim AS native-assets-false
 RUN mkdir -p /out
 
-# The one line that makes an image core or bundled. `BUNDLE_BUZZ` is declared in
+# The one line that makes an image core or bundled. `BUNDLE_EXTENSIONS` is declared in
 # the global scope at the top of this file, which is the only place a FROM can
 # read an ARG from.
-FROM buzz-assets-${BUNDLE_BUZZ} AS buzz-assets
+FROM native-assets-${BUNDLE_EXTENSIONS} AS native-assets
 
 # ---
 
@@ -213,22 +213,22 @@ COPY --from=gocli /out/fountain /usr/local/bin/fountain
 #
 # buzz-acp is the harness; buzz is the CLI the extension's MCP tools shell out
 # to for signed publishes. Both our own builds, for both arches.
-COPY --from=buzz-assets /out/ /usr/local/lib/fountain-buzz/
+COPY --from=native-assets /out/ /usr/local/lib/fountain-buzz/
 
 # Fail the build now if a baked binary will not run in this image, rather than
 # at the first request, harness start or publish. The Buzz half is checked only
 # where it was meant to be copied: absent binaries are the core distribution
 # working, and absent binaries in a BUNDLED build are a broken one.
-ARG BUNDLE_BUZZ=true
+ARG BUNDLE_EXTENSIONS=true
 RUN /usr/local/bin/fountain --version >/dev/null 2>&1 \
       || { echo "the fountain CLI will not run in this image" >&2; exit 1; }
-RUN if [ "${BUNDLE_BUZZ}" = "true" ]; then \
+RUN if [ "${BUNDLE_EXTENSIONS}" = "true" ]; then \
       /usr/local/lib/fountain-buzz/buzz-acp --help >/dev/null 2>&1 \
    && /usr/local/lib/fountain-buzz/buzz --help >/dev/null 2>&1 \
         || { echo "a baked Buzz binary will not run in this image" >&2; exit 1; } ; \
     else \
       test -z "$(ls -A /usr/local/lib/fountain-buzz 2>/dev/null)" \
-        || { echo "BUNDLE_BUZZ=false but Buzz binaries were baked in" >&2; exit 1; } ; \
+        || { echo "BUNDLE_EXTENSIONS=false but Buzz binaries were baked in" >&2; exit 1; } ; \
     fi
 
 EXPOSE 4000

--- a/apps/fountain/test/fountain/extension_guard_test.exs
+++ b/apps/fountain/test/fountain/extension_guard_test.exs
@@ -127,11 +127,27 @@ defmodule Fountain.ExtensionGuardTest do
                "apps/fountain must not depend on an extension; the release owns inclusion"
       end
 
-      test "the bundled release includes it" do
-        umbrella_mix = Path.expand("../../../../mix.exs", __DIR__) |> File.read!()
+      test "the bundled release discovers it" do
+        umbrella = Path.expand("../../../..", __DIR__)
+        umbrella_mix = umbrella |> Path.join("mix.exs") |> File.read!()
 
-        assert umbrella_mix =~ "#{@extension.app}: :permanent",
-               "the bundled release must include #{@extension.app} (ADR 0043 decision 7)"
+        # Extensions are DISCOVERED from `apps/fountain_*` rather than listed
+        # (#1510), so a new one is in the bundled release from the commit that
+        # adds it and out of the core one for free. Asserting the literal name
+        # in mix.exs would therefore assert the old mechanism; what matters is
+        # that this app is one the glob finds.
+        assert umbrella_mix =~ ~s|Path.join("apps/fountain_*")|,
+               "the release must discover extensions, not list them (ADR 0043 decision 7)"
+
+        discovered =
+          umbrella
+          |> Path.join("apps/fountain_*")
+          |> Path.wildcard()
+          |> Enum.filter(&File.dir?/1)
+          |> Enum.map(&Path.basename/1)
+
+        assert to_string(@extension.app) in discovered,
+               "#{@extension.app} is not under apps/fountain_*, so no release would carry it"
       end
     end
   end

--- a/apps/fountain_buzz/test/fountain_buzz/boundary_test.exs
+++ b/apps/fountain_buzz/test/fountain_buzz/boundary_test.exs
@@ -227,26 +227,30 @@ defmodule FountainBuzz.BoundaryTest do
 
       # The stages and the install path are the bundled distribution's layer and
       # belong here — one Dockerfile builds both distributions.
-      assert dockerfile =~ "BUNDLE_BUZZ"
-      assert dockerfile =~ "buzz-assets-false"
+      assert dockerfile =~ "BUNDLE_EXTENSIONS"
+      assert dockerfile =~ "native-assets-false"
     end
 
     test "the Dockerfile can build without the extension at all" do
       dockerfile = @root |> Path.join("Dockerfile") |> File.read!()
 
       # The empty-assets stage and the conditional smoke check are what make a
-      # core image possible; without either, `BUNDLE_BUZZ=false` would produce
+      # core image possible; without either, `BUNDLE_EXTENSIONS=false` would produce
       # an image that either fails to build or silently carries the binaries.
-      assert dockerfile =~ "FROM buzz-assets-${BUNDLE_BUZZ}"
-      assert dockerfile =~ "BUNDLE_BUZZ=false but Buzz binaries were baked in"
+      assert dockerfile =~ "FROM native-assets-${BUNDLE_EXTENSIONS}"
+      assert dockerfile =~ "BUNDLE_EXTENSIONS=false but Buzz binaries were baked in"
     end
 
-    test "the release includes this app only when BUNDLE_BUZZ says so" do
+    test "the release includes this app only when BUNDLE_EXTENSIONS says so" do
       mix = @root |> Path.join("mix.exs") |> File.read!()
 
-      assert mix =~ "bundled_applications",
-             "the release's applications must follow BUNDLE_BUZZ, or a core image " <>
+      assert mix =~ "extension_applications",
+             "the release's applications must follow BUNDLE_EXTENSIONS, or a core image " <>
                "would carry the extension without its binaries"
+
+      assert mix =~ ~s|Path.join("apps/fountain_*")|,
+             "extensions are discovered, not listed — a new one must be in the bundled " <>
+               "release from the commit that adds it"
     end
   end
 

--- a/decisions/0043-first-party-extensions.md
+++ b/decisions/0043-first-party-extensions.md
@@ -24,7 +24,7 @@ Buzz has moved: `apps/fountain_buzz` is an AGPL OTP application depending on
 enforces it), and the bundled release includes both apps.
 
 Gate 5 (#1509) is built too: the extension owns its `buzz-acp` pin, its fork
-override and the paths its binaries install to, and `BUNDLE_BUZZ=false` builds
+override and the paths its binaries install to, and `BUNDLE_EXTENSIONS=false` builds
 a core image — no extension application in the release, no binaries in the
 image, one switch for both halves. Both images were built and their contents
 checked.
@@ -434,10 +434,14 @@ each leaves bundled behaviour green, and **none is built**.
    which is what "the wire did not move" means.
 5. **#1508 — the Go split.** `buzz-backend-fountain` moves to the extension's
    ownership; `fountain buzz` stays in `cli/` (decision 6). Rescope the issue.
+   `BUNDLE_EXTENSIONS=false` is the one switch (#1510): the release carries no
+   `apps/fountain_*` application, discovered by glob rather than listed, and
+   the image copies an empty native-asset stage.
+
 6. **#1509 — the supply chain. Built.** `buzz-acp.version` and
    `buzz-acp.source` moved to `apps/fountain_buzz`, the publish and build
    workflows read them there, and the Docker stage became a pair selected by
-   `BUNDLE_BUZZ` — the bundled image downloads and checksum-verifies both
+   `BUNDLE_EXTENSIONS` — the bundled image downloads and checksum-verifies both
    binaries, the core image copies an empty directory and refuses to contain
    one. `FountainBuzz.Assets` owns where they install and refuses a binary
    whose version does not match the pin, so a partial upgrade is an inert

--- a/mix.exs
+++ b/mix.exs
@@ -125,24 +125,34 @@ defmodule Fountain.Umbrella.MixProject do
         # release's decision, made here, and dropping one is a switch rather
         # than untangling a dependency.
         #
-        # Only Buzz is switchable today, because only Buzz carries native
-        # binaries whose absence is the point of a core image. `fountain_support`
-        # (#1528) is pure Elixir and rides along; #1510 should generalise this
-        # to one list when it defines the core distribution properly.
-        applications:
-          [fountain: :permanent, fountain_support: :permanent] ++ bundled_applications()
+        # `BUNDLE_EXTENSIONS=false` builds the core release: the server and
+        # nothing else. Every `apps/fountain_*` app is an extension and is
+        # discovered rather than listed, so a new one is in the bundled release
+        # from the commit that adds it and out of the core one for free.
+        applications: [fountain: :permanent] ++ extension_applications()
       ]
     ]
   end
 
-  # `BUNDLE_BUZZ=false mix release` builds the core distribution. Read from the
-  # environment rather than from Mix config because the Dockerfile already
-  # passes it as a build arg for the native-asset stage, and one switch for
-  # both halves is the point: an image cannot end up with the extension
-  # application but no binaries, or the reverse.
-  defp bundled_applications do
-    if System.get_env("BUNDLE_BUZZ", "true") == "true" do
-      [fountain_buzz: :permanent]
+  # `BUNDLE_EXTENSIONS=false mix release` builds the core distribution.
+  #
+  # Read from the environment rather than from Mix config because the Dockerfile
+  # passes the same switch as a build arg for the native-asset stage, and one
+  # switch for both halves is the point: an image cannot end up with an
+  # extension application but no binaries, or the reverse.
+  #
+  # Discovered from `apps/fountain_*` rather than listed. A `managoat_*` library
+  # under apps/ is a DEPENDENCY of fountain (decisions/0037) and belongs in both
+  # releases, which is why the glob is the naming convention and not "every
+  # sibling".
+  defp extension_applications do
+    if System.get_env("BUNDLE_EXTENSIONS", "true") == "true" do
+      __DIR__
+      |> Path.join("apps/fountain_*")
+      |> Path.wildcard()
+      |> Enum.filter(&File.dir?/1)
+      |> Enum.map(&{String.to_atom(Path.basename(&1)), :permanent})
+      |> Enum.sort()
     else
       []
     end


### PR DESCRIPTION
Part of #1510, under ADR 0043. Not the whole issue — see "What this leaves" below.

Two PRs now assert that a core release carries no extension. Nothing had ever built one. This makes it a check.

## A job that builds both distributions

`core-distribution` builds `BUNDLE_EXTENSIONS=false`, asserts the release contains no `apps/fountain_*` application, boots it against an **empty** database, probes `/health` and `/health/ready`, and asserts the served OpenAPI describes no extension path. Then it builds the bundled shape from the same tree and asserts every extension *is* there — a release carrying nothing either way would otherwise pass every check above it.

The empty database is the point. `apps/fountain` running alone in the test partitions proves the *test* path; only a core release migrating from scratch exercises the *migration* path — which is exactly where #1509 found a core migration altering `buzz_identities`, a table a core distribution does not have.

Its own job rather than a step in `checks`: that job is already close to its 15-minute ceiling (#1537), and a red here should say "the core distribution does not work" rather than arrive buried in static analysis.

## The job found what it was written to find, immediately

The core release still contained `fountain_support`.

`BUNDLE_BUZZ` only ever gated Buzz, and #1528's extension rode along unconditionally — so **"a core release carries no extension" was false the day after it was written down.** I left a `#1510 should generalise this` note during the #1509 rebase; this is that, and it turned out not to be cosmetic.

`BUNDLE_BUZZ` → `BUNDLE_EXTENSIONS`, and the applications are **discovered** from `apps/fountain_*` rather than listed:

```elixir
applications: [fountain: :permanent] ++ extension_applications()
```

A new extension is in the bundled release from the commit that adds it and out of the core one for free, with no third place to forget. A `managoat_*` library under `apps/` is a *dependency* of fountain (decisions/0037) and stays in both, which is why the glob is the naming convention rather than "every sibling".

The Dockerfile's stages follow: `buzz-assets-*` → `native-assets-*`, since what varies is whether an image carries any extension's native assets. Both stages rebuilt and contents checked.

`Fountain.ExtensionGuardTest` asserted each extension by literal name in mix.exs, which would now assert the *old* mechanism. It asserts the property instead: mix.exs discovers by glob, and this app is one the glob finds.

## Verified locally

| `BUNDLE_EXTENSIONS` | Release applications | Native assets stage |
|---|---|---|
| `false` | `fountain` | empty |
| `true` | `fountain`, `fountain_buzz`, `fountain_support` | `buzz-acp`, `buzz` |

`mix precommit` green: 4,206 core + 117 buzz + 30 support tests, 0 failures; credo, dialyzer, sobelow, prod release assembles.

## What this leaves

- **The `-core` image tag** in `release.yml`. Only verifiable by cutting a release, so it wants its own change rather than riding along blind.
- **The docs move and the repository split.** #1536 — the schema guard has never seen an extension's response — is in flight in another worktree, and the maintainer's note on #1510 asks for it before the split. Deliberately untouched here; I stopped when I found that branch rather than duplicating it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DBK3uwQuJozQHKmEuBrvrP