### PR TITLE
fix(cli): stop a cached pass hiding a red examples test (#1542)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -688,9 +688,19 @@ jobs:
 
       # The CLI had tests since launch that no workflow ever ran, so they gated
       # neither a merge nor a release.
+      #
+      # `-count=1` disables Go's test cache, and it is load-bearing rather than
+      # belt-and-braces (#1542). `TestExamplesParse` reads its inputs from
+      # `examples/`, outside its own package, so Go has no reliable way to know
+      # those inputs moved — and `setup-go`'s cache is keyed on `cli/go.sum`,
+      # which does not move when an example changes. Go caches only successes,
+      # so the stale entry it kept serving was a pass from before the example
+      # that broke it existed: CI reported `ok (cached)` for a day while a
+      # fresh run failed. The suite takes about two seconds; a cache that can
+      # report green for a red tree is not worth that.
       - name: CLI tests
         working-directory: cli
-        run: go test ./...
+        run: go test -count=1 ./...
 
       - name: CLI vet
         working-directory: cli

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,9 +57,11 @@ jobs:
       # A release used to cross-compile without ever running the suite, so a
       # binary could ship with failing tests. Run once on the host platform —
       # cross-compiled test binaries cannot be executed here anyway.
+      # `-count=1` for the same reason as ci.yml: a cached pass can outlive the
+      # tree that earned it (#1542), and a release must not ship on one.
       - name: Test
         working-directory: cli
-        run: go test ./...
+        run: go test -count=1 ./...
 
       - name: Build
         env:

--- a/cli/internal/manifest/examples_test.go
+++ b/cli/internal/manifest/examples_test.go
@@ -27,7 +27,12 @@ func TestExamplesParse(t *testing.T) {
 
 	knownKinds := map[string]bool{"Environment": true, "Vault": true, "Agent": true}
 	total := 0
+	checked := 0
 	for _, f := range files {
+		if notOurs[filepath.ToSlash(f)] {
+			continue
+		}
+		checked++
 		docs, err := readFile(f)
 		if err != nil {
 			t.Errorf("%s: %v", f, err)
@@ -64,4 +69,29 @@ func TestExamplesParse(t *testing.T) {
 	if total == 0 {
 		t.Fatal("no resource documents under examples/")
 	}
+	// A skip-list entry naming a file that is no longer there is the same hazard
+	// in miniature: it reads as "checked and excused" when nothing was excused,
+	// and it is how the list grows to cover files that do not exist while a real
+	// manifest quietly goes unchecked. The list may only name files the walk
+	// actually found.
+	if matched := len(files) - checked; matched < len(notOurs) {
+		t.Errorf("the skip list names %d files but only %d of them are under examples/; delete the %d stale entr%s", len(notOurs), matched, len(notOurs)-matched, map[bool]string{true: "y", false: "ies"}[len(notOurs)-matched == 1])
+	}
+}
+
+// notOurs are files under examples/ that are YAML but are not Fountain
+// manifests, so `fountain apply` never reads them and the assertions above do
+// not apply. They are third-party configuration that an example needs in order
+// to be runnable at all.
+//
+// An explicit list rather than a filename convention (`*fountain.yml`), and
+// deliberately so: a convention would silently stop checking a real manifest
+// somebody named differently, which is the same shape of hole as the one that
+// hid this test's failure for a day (#1542). Anything new under examples/ is
+// checked until a person adds it here with a reason.
+var notOurs = map[string]bool{
+	// LiteLLM's own proxy config, read by the litellm container (#1479).
+	"../../../examples/litellm-gateway/config.yaml": true,
+	// Compose file that stands the example's two containers up (#1479).
+	"../../../examples/litellm-gateway/docker-compose.yml": true,
 }


### PR DESCRIPTION
Closes #1542. `go test ./...` in `cli/` has been failing on `main` since #1479 landed on 2026-09-03, and every CI run since has reported it passing.

## The failure

`TestExamplesParse` (added 2026-08-23, #1044) walks **every** YAML file under `examples/` and requires each document to be a Fountain resource. `examples/litellm-gateway/` (added 2026-09-03, #1479) carries two files that are correctly not Fountain manifests — LiteLLM's own `config.yaml` and a `docker-compose.yml`.

The example is fine. The test's assumption that everything under `examples/` is a manifest is what broke.

## Why CI said otherwise

From `main`'s own run for `7349a821`:

```
CLI tests  ok  github.com/BinaryBourbon/fountain/cli/internal/manifest  (cached)
```

Go caches only **successful** test results, so that `ok` was earned by a run from before the example existed and has been served ever since. `setup-go`'s cache is keyed on `cli/go.sum`, which does not move when an example changes, and this test reads its inputs from outside its own package, so Go has no reliable way to know they moved.

That is the real defect, and it is bigger than two files: any future example, or any edit to an existing one, was equally invisible.

## Both halves, because either alone leaves the hole

- **`-count=1`** on the CLI test step in `ci.yml` and `release.yml`. The suite takes about two seconds. A cache that can report green for a red tree is not worth that, and a release must not ship on one.
- **An explicit skip list** naming the two third-party files, each with the issue that introduced it.

Deliberately a list and not a filename convention (`*fountain.yml`): a convention would silently stop checking a real manifest somebody named differently — the same shape of hole as the one that hid this. Anything new under `examples/` is checked until a person adds it to the list with a reason.

The skip list has its own guard: an entry naming a file that is no longer there fails the test, because "checked and excused" must not outlive the thing it excused.

## Verified by breaking it

| What I broke | What happened |
|---|---|
| Dropped the `config.yaml` skip entry | Original failure returns: `config.yaml doc 0: missing apiVersion or kind` |
| Added a bogus skip entry | `the skip list names 3 files but only 2 of them are under examples/; delete the 1 stale entry` |

The first draft of that second guard had inverted logic and could never fire. It is checked here rather than assumed — which is the whole lesson of the bug it guards.

`cli` suite green with the cache off; `gofmt` and `go vet` clean.

## How it was found

Working #1508 in a worktree, a local `go test ./...` failed on a change touching neither `examples/` nor `internal/manifest`. Confirmed against a pristine `git worktree add --detach origin/main` to rule out the working tree, then against the CI log, which named the cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015unQSjdFCfcmt4XJHPHtAY