### PR TITLE
feat(release): publish the core image beside the bundled one (#1510)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,7 +177,7 @@ jobs:
     # the arm64 Erlang compile. build.yml migrated off it and this job was
     # left behind, so the only slow build left in the repo was the one that
     # runs least often and blocks the release.
-    name: Build versioned server image (${{ matrix.arch }})
+    name: Build versioned server image (${{ matrix.distribution }}, ${{ matrix.arch }})
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 20
     permissions:
@@ -186,6 +186,16 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
+        # Two distributions from one tree (ADR 0043 decision 7), each built
+        # natively on both arches. The bundled one is what every existing tag
+        # has meant and what the hosted deployment runs; the core one carries
+        # no extension application and none of their native binaries, and is
+        # the supported base for someone writing an extension of their own.
+        #
+        # Four builds rather than two, but four runners rather than two as
+        # well: the release's wall clock is one native build, not the sum.
+        distribution: [bundled, core]
+        arch: [amd64, arm64]
         include:
           - arch: amd64
             platform: linux/amd64
@@ -194,6 +204,14 @@ jobs:
             platform: linux/arm64
             # Free for public repos; the cluster's own architecture.
             runner: ubuntu-24.04-arm
+          - distribution: bundled
+            bundle_extensions: "true"
+            # The bundled image keeps the bare tags. A core image that had to
+            # be asked for by name is the whole point of the default.
+            suffix: ""
+          - distribution: core
+            bundle_extensions: "false"
+            suffix: "-core"
 
     steps:
       - name: Resolve tag
@@ -255,6 +273,7 @@ jobs:
           build-args: |
             BUILD_SHA=${{ steps.sha.outputs.sha }}
             BUZZ_ACP_VERSION=${{ steps.buzzver.outputs.version }}
+            BUNDLE_EXTENSIONS=${{ matrix.bundle_extensions }}
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ steps.sha.outputs.sha }}
@@ -276,13 +295,14 @@ jobs:
         run: |
           mkdir -p "${RUNNER_TEMP}/digests"
           digest="${{ steps.build.outputs.digest }}"
-          touch "${RUNNER_TEMP}/digests/${digest#sha256:}"
+          mkdir -p "${RUNNER_TEMP}/digests/${{ matrix.distribution }}"
+          touch "${RUNNER_TEMP}/digests/${{ matrix.distribution }}/${digest#sha256:}"
 
       - name: Upload digest
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: image-digest-${{ matrix.arch }}
-          path: ${{ runner.temp }}/digests/*
+          name: image-digest-${{ matrix.distribution }}-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/${{ matrix.distribution }}/*
           if-no-files-found: error
           retention-days: 1
 
@@ -316,12 +336,17 @@ jobs:
             echo "minor=${tag%.*}"
           } >> "$GITHUB_OUTPUT"
 
+      # Deliberately NOT merge-multiple: each artifact lands in its own
+      # directory named for the artifact, which is how the two distributions'
+      # digests stay apart. Merged, four digests would arrive in one directory
+      # and a manifest built from them would mix a core image into the bundled
+      # tag — the failure this job's digest count exists to catch, arriving in
+      # a form the count could not see.
       - name: Download digests
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: ${{ runner.temp }}/digests
           pattern: image-digest-*
-          merge-multiple: true
 
       - name: Set up Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
@@ -333,7 +358,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Create and push the manifest list
+      - name: Create and push the manifest lists
         working-directory: ${{ runner.temp }}/digests
         env:
           IMAGE: ghcr.io/binarybourbon/fountain
@@ -341,23 +366,81 @@ jobs:
           MINOR: ${{ steps.tag.outputs.minor }}
         run: |
           set -euo pipefail
-          # One digest file per arch. Anything else means a build job pushed
-          # something unexpected, and a manifest built from it would publish
-          # a release image nobody checked.
-          digests=(*)
-          if [ "${#digests[@]}" -ne 2 ]; then
-            echo "expected 2 digests (amd64 + arm64), found ${#digests[@]}: ${digests[*]}" >&2
+
+          # One manifest list per distribution (ADR 0043 decision 7). The
+          # bundled one keeps the bare tags, because that is what every
+          # existing tag has meant and what every existing puller expects; the
+          # core one is the same version with a `-core` suffix, so nobody has
+          # to decide which product they are running.
+          publish() {
+            distribution="$1"
+            suffix="$2"
+
+            # One digest per arch, in per-arch directories. Anything else means
+            # a build job pushed something unexpected, and a manifest built
+            # from it would publish a release image nobody checked.
+            refs=()
+            for arch in amd64 arm64; do
+              dir="image-digest-${distribution}-${arch}"
+              if [ ! -d "$dir" ]; then
+                echo "no digest artifact for ${distribution}/${arch}" >&2
+                exit 1
+              fi
+              digests=("$dir"/*)
+              if [ "${#digests[@]}" -ne 1 ]; then
+                echo "expected 1 digest in ${dir}, found ${#digests[@]}" >&2
+                exit 1
+              fi
+              refs+=("${IMAGE}@sha256:$(basename "${digests[0]}")")
+            done
+
+            docker buildx imagetools create \
+              --tag "${IMAGE}:${TAG}${suffix}" \
+              --tag "${IMAGE}:${MINOR}${suffix}" \
+              "${refs[@]}"
+            docker buildx imagetools inspect "${IMAGE}:${TAG}${suffix}"
+          }
+
+          publish bundled ""
+          publish core "-core"
+
+      # The published core image, opened. Every claim the campaign makes about
+      # it is checked somewhere earlier — CI's core-distribution job builds the
+      # release, and the Dockerfile refuses to bake a Buzz binary under
+      # BUNDLE_EXTENSIONS=false — but nothing had looked inside the artifact a
+      # person actually pulls. A build arg that stopped being passed would
+      # publish a bundled image under the core tag and every one of those
+      # earlier checks would still be green.
+      - name: The published core image carries no extension
+        env:
+          IMAGE: ghcr.io/binarybourbon/fountain
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          core="${IMAGE}:${TAG}-core"
+
+          apps=$(docker run --rm --entrypoint sh "$core" -c 'ls /app/lib')
+          echo "$apps" | tr '\n' ' '; echo
+          if echo "$apps" | grep -qE '^fountain_'; then
+            echo "::error::${core} contains an extension application" >&2
+            echo "$apps" | grep -E '^fountain_' >&2
             exit 1
           fi
-          refs=()
-          for digest in "${digests[@]}"; do
-            refs+=("${IMAGE}@sha256:${digest}")
-          done
-          docker buildx imagetools create \
-            --tag "${IMAGE}:${TAG}" \
-            --tag "${IMAGE}:${MINOR}" \
-            "${refs[@]}"
-          docker buildx imagetools inspect "${IMAGE}:${TAG}"
+
+          binaries=$(docker run --rm --entrypoint sh "$core" \
+            -c 'ls -A /usr/local/lib/fountain-buzz 2>/dev/null || true')
+          if [ -n "$binaries" ]; then
+            echo "::error::${core} carries native extension assets: ${binaries}" >&2
+            exit 1
+          fi
+
+          # Guard the guard: an image whose /app/lib is empty would satisfy
+          # both checks above. The server itself has to be in there.
+          echo "$apps" | grep -qE '^fountain-[0-9]' || {
+            echo "::error::${core} does not contain the fountain application" >&2
+            exit 1
+          }
+          echo "${core}: no extension application, no native assets"
 
   compose-boot:
     # ci.yml's "Compose boots the pinned image" skips on the bump PR and on

--- a/decisions/0043-first-party-extensions.md
+++ b/decisions/0043-first-party-extensions.md
@@ -29,10 +29,14 @@ a core image — no extension application in the release, no binaries in the
 image, one switch for both halves. Both images were built and their contents
 checked.
 
-**Not built:** a core-image *boot* check (gate 7 / #1510 — the image builds and
-its contents are asserted, but nothing has yet started one against a database),
-the docs move, and the graduation to `BinaryBourbon/fountain_buzz`. The Go CLI
-split is #1508.
+Gate 7's distribution half is built too: CI builds and boots a core release
+against an empty database on every PR, and each release publishes
+`vX.Y.Z-core` and `vX.Y-core` beside the bare tags, with the published core
+image opened and checked for extension applications and native assets.
+
+**Not built:** the docs move (which wants either an extension-contributed
+manual seam or a documented build-time assembly step) and the graduation to
+`BinaryBourbon/fountain_buzz`. The Go CLI split is #1508.
 
 ADR [0020](0020-buzz-as-a-client-of-the-acp-gateway.md)'s hosted harness and
 brokered signer ship in the image today and keep working unchanged throughout.
@@ -302,7 +306,7 @@ reading:
 
 ### 7. Two images from one repository; uninstall is a config change, not a migration
 
-**Distribution.** `ghcr.io/binarybourbon/fountain:vX.Y.Z` stays the **bundled**
+**Distribution.** Built. `ghcr.io/binarybourbon/fountain:vX.Y.Z` stays the **bundled**
 image — extension compiled in, `buzz-acp` and `buzz` binaries present — because
 that is what runs in production and what every existing tag has meant.
 `…:vX.Y.Z-core` is the same tree built without `apps/fountain_buzz` and without
@@ -446,9 +450,13 @@ each leaves bundled behaviour green, and **none is built**.
    one. `FountainBuzz.Assets` owns where they install and refuses a binary
    whose version does not match the pin, so a partial upgrade is an inert
    extension and a log line rather than a harness crash-loop per identity.
-7. **#1510 — graduation and distributions.** The `-core` image and its boot
-   check, the docs move, and — only once `Fountain.Extension` has stopped
-   moving — `BinaryBourbon/fountain_buzz`.
+7. **#1510 — graduation and distributions. Distributions built.** CI's
+   `core-distribution` job builds a core release, boots it against an empty
+   database and checks the spec it serves; `release.yml` publishes
+   `vX.Y.Z-core` and `vX.Y-core` from the same tree and opens the published
+   image to check it. Still open: the docs move, and
+   `BinaryBourbon/fountain_buzz` — whose precondition (a second extension
+   exercising the seam) `apps/fountain_support` met in #1528.
 
 Outside the gate list, because it is not a Buzz gate:
 [#1528](https://github.com/BinaryBourbon/fountain/issues/1528) moved the

--- a/docs/guides/operate/upgrade.md
+++ b/docs/guides/operate/upgrade.md
@@ -28,6 +28,29 @@ under two tags, next to the tags that track development.
 | `latest` | On each merge to `main`. | Nothing you keep in production, because it moves under you. |
 | `sha-<commit>` | Never. | To reproduce exactly what one commit built. |
 
+## Two distributions
+
+Each tag above names the **bundled** image: the server plus the first-party
+extensions, which is what this project has always published. Each release also
+publishes the same version with a `-core` suffix.
+
+| Tag | Contains |
+|---|---|
+| `vX.Y.Z` and `vX.Y` | The server, the Buzz extension and the support extension, plus the `buzz-acp` and `buzz` executables the Buzz extension runs. |
+| `vX.Y.Z-core` and `vX.Y-core` | The server. No extension, no extension route, no extension migration and no extension executable. |
+
+Use the bundled image unless you know you want the other one. The hosted
+deployment runs it, and we triage a bug report against it.
+
+The core image is smaller and has less surface to attack. It is also what to
+build an extension of your own against. The cost: hosted Buzz agents
+(`/api/buzz/agents` and the Nostr harness) and the problem-report endpoint
+answer `404`, because the code that serves them is not installed.
+
+To move between them, pull the other tag and restart. Extension tables stay in
+the database. A core image does not create them. It also does not drop the ones
+a bundled image made, so a move back finds your rows where you left them.
+
 Releases v0.2.1 and earlier are older than the image tags. They exist as
 `sha-` tags alone.
 


### PR DESCRIPTION
Part of #1510, under ADR 0043 decision 7. #1541 made the core release a CI gate; this publishes it.

`release.yml`'s image job gains a `distribution` dimension, so each tag builds four images — bundled and core, each natively on amd64 and arm64, on four runners rather than two. The release's wall clock is one native build, not the sum.

| Tag | Contains |
|---|---|
| `vX.Y.Z`, `vX.Y` | The server, every extension, and the `buzz-acp`/`buzz` executables |
| `vX.Y.Z-core`, `vX.Y-core` | The server |

The bundled image keeps the bare tags. A core image that has to be asked for by name is the whole point of the default, and every existing puller keeps getting what it has always got.

## Keeping the two apart

Digests upload per distribution and download **without** `merge-multiple`, so each artifact lands in its own directory. Merged, four digests would arrive in one directory and a manifest built from them could mix a core image into the bundled tag — the exact failure the old `-ne 2` digest count existed to catch, arriving in a form that count could not see. It is now one digest per arch per distribution, named.

## The published image is opened

Every claim about the core image is checked earlier: CI builds the release, and the Dockerfile refuses to bake a Buzz binary under `BUNDLE_EXTENSIONS=false`. Nothing had looked inside the artifact a person actually pulls. **A build arg that stopped being passed would publish a bundled image under the core tag with every earlier check still green** — so the manifest job now runs the published core image and asserts no extension application in `/app/lib` and nothing in `/usr/local/lib/fountain-buzz`, plus a guard-the-guard that the `fountain` application *is* there (an empty image would satisfy both).

## Verified

Built both images from this tree and ran the assertion against each: it passes on the core image and **rejects the bundled one**. The manifest grouping was dry-run against a fabricated digest layout including both failure modes — a missing arch, and two digests where there should be one.

A caution worth recording: my first attempt at this verification was invalid. The shell's working directory had been reset to the primary checkout, so both "images" were built from an older tree and came out identical. The result looked like a bug in the build arg; it was a bug in where I was standing. Re-run from the worktree, the two images differ exactly as they should.

## Not in this change

`build.yml` is untouched — main pushes stay bundled-only. The `-core` promise is per release, and doubling every main build to publish a moving core tag nobody pins would cost more than it buys.

The docs move and the repository split are what remain on #1510. `docs/guides/operate/upgrade.md` gains a "Two distributions" section now: which tag contains what, which one to take, what the core one costs, and that extension tables survive a move in either direction.

## Local gate

`mix precommit` green — 4,206 core + 120 buzz + 33 support tests, 0 failures; credo, dialyzer, sobelow, prod release assembles. All three prose gates clean on the new docs section, with no new vale errors or warnings against the baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DBK3uwQuJozQHKmEuBrvrP