### PR TITLE
fix(buzz): wait for the registry before asserting on it (#1544)

### DIFF
--- a/apps/fountain_buzz/lib/fountain_buzz/manager.ex
+++ b/apps/fountain_buzz/lib/fountain_buzz/manager.ex
@@ -143,19 +143,40 @@ defmodule FountainBuzz.Manager do
   @spec restart_harness(Identity.t(), keyword()) :: {:ok, pid()} | {:error, term()}
   def restart_harness(%Identity{} = identity, opts \\ []) do
     :ok = stop_harness(identity.id)
-    await_unregistered(identity.id, 50)
+    await_stopped(identity.id)
     start_harness(identity, opts)
   end
 
-  # `terminate_child` is synchronous, but the registry learns of the exit by
-  # monitor; give it a moment so `start_harness`'s `whereis` does not hand back
-  # the dead pid.
-  defp await_unregistered(_identity_id, 0), do: :ok
+  @doc """
+  Wait for the registry to drop `identity_id` after a stop.
 
-  defp await_unregistered(identity_id, tries) do
+  `stop_harness/1`'s `terminate_child` returns once the process is down, but
+  the registry learns of the exit **by monitor**, so for a moment afterwards
+  `running?/1` still says yes, `whereis/1` still hands back the dead pid, and
+  `running_count/0` still counts it.
+
+  Every caller that stops a harness and then reads the registry has to wait for
+  that, which is why this is public rather than a private step of
+  `restart_harness/2`: a test asserting on the count after a stop needs the same
+  wait, and two implementations of "the registry has caught up" would be one
+  too many. That gap is exactly what made
+  `ManagerTest "running_count counts registered harnesses cluster-wide"` flaky
+  (#1544) — it read the count on the line after the stop and periodically saw
+  the harness still there.
+
+  Returns `:ok` whether or not the entry went, deliberately. The caller's own
+  assertion is the real check and gives the better failure message; a raise
+  from in here would report the helper instead of the thing under test.
+  """
+  @spec await_stopped(String.t(), non_neg_integer()) :: :ok
+  def await_stopped(identity_id, tries \\ 50)
+
+  def await_stopped(_identity_id, 0), do: :ok
+
+  def await_stopped(identity_id, tries) do
     if running?(identity_id) do
       Process.sleep(20)
-      await_unregistered(identity_id, tries - 1)
+      await_stopped(identity_id, tries - 1)
     else
       :ok
     end

--- a/apps/fountain_buzz/test/fountain_buzz/manager_test.exs
+++ b/apps/fountain_buzz/test/fountain_buzz/manager_test.exs
@@ -65,7 +65,12 @@ defmodule FountainBuzz.ManagerTest do
     assert {:ok, _pid} = Manager.start_harness(second, launch_opts(fake))
     assert Manager.running_count() == baseline + 2
 
+    # `stop_harness/1` returns once the process is down, but the registry drops
+    # the entry by monitor a moment later, so the count here raced it and
+    # periodically read 2 (#1544). `await_stopped/2` is the same wait
+    # `restart_harness/2` uses for the same reason.
     Manager.stop_harness(first.id)
+    Manager.await_stopped(first.id)
     assert Manager.running_count() == baseline + 1
     Manager.stop_harness(second.id)
   end
@@ -88,9 +93,12 @@ defmodule FountainBuzz.ManagerTest do
     assert active_key_count(identity.user_id) == 1
 
     :ok = Manager.stop_harness(identity.id)
+    Manager.await_stopped(identity.id)
 
     refute Manager.running?(identity.id)
-    # terminate_child is synchronous, so the harness's on_stop (key revoke) has run.
+    # terminate_child is synchronous, so the harness's on_stop (key revoke) has
+    # already run by the time it returns — that part needs no wait. It is the
+    # registry that lags, which is what the line above waits for (#1544).
     assert active_key_count(identity.user_id) == 0
   end
 


### PR DESCRIPTION
Closes #1544. `FountainBuzz.ManagerTest` "running_count counts registered harnesses cluster-wide" fails intermittently in CI — most recently on #1543, whose diff is two workflow YAMLs and one Go test and touches no Elixir at all.

```
code:  assert Manager.running_count() == baseline + 1
left:  2
right: 1
```

## Why it is the registry, established by elimination

`stop_harness/1` calls `Horde.DynamicSupervisor.terminate_child/2`, which returns once the process is down. The registry learns of the exit **by monitor**, so for a moment afterwards `running?/1` still says yes, `whereis/1` still hands back the dead pid, and `running_count/0` still counts it. `manager.ex` says exactly this in a comment, and `restart_harness/2` waits for it. The test read the count on the line after the stop and did not.

The obvious first reading is a stray harness from another module — the supervisor and registry are global. **The failure shape rules that out**, because it would have broken the earlier assertion too:

```elixir
assert Manager.running_count() == baseline + 2    # passed
Manager.stop_harness(first.id)
assert Manager.running_count() == baseline + 1    # failed, saw 2
```

The count was exactly right before the stop and unchanged after it. Nothing arrived; something failed to leave.

## The fix

`await_unregistered/2` becomes public `await_stopped/2`, so there is one notion of "the registry has caught up" instead of a private one for `restart_harness/2` and a missing one everywhere else.

Both racy assertions now use it — the count one, and `refute Manager.running?(...)` in "stop_harness terminates the harness and revokes its launch key", which had the same race and carried a comment asserting the very misconception `manager.ex` corrects. The key-revoke assertion beside it genuinely needs no wait (that runs in `terminate`, before `terminate_child` returns); the comment now says which half is synchronous.

A fixed `Process.sleep` would have traded a flake for a slow test that still races on a loaded runner.

## What I could not do

**I did not reproduce it locally**, and the commit says so.

| Attempt | Result |
|---|---|
| Probe: registry read immediately after 30 stops | already settled 30/30 |
| Original test, 12 runs under 6× CPU load | 0 failures |
| Whole `apps/fountain_buzz` suite, 8 runs under load | 0 failures |

The window is small on this hardware; the CI runner is slower. So the mechanism above is argued from the failure shape and from the production code's own acknowledgement of the lag, not from a local repro. The change cannot make the test weaker either way — it waits for a condition the assertion already depends on.

If you would rather see a reproduction before merging, say so and I will try widening the window artificially (a slowed registry, or many more iterations in CI's shape).

## Gate

`apps/fountain_buzz`: 120 tests, 0 failures. `mix credo --strict` clean. `mix format --check-formatted` clean.

Worth landing before #1510 rather than after: this app is about to graduate to its own repository with its own CI, and a flaky test travels with it into a repo with less traffic to notice it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015unQSjdFCfcmt4XJHPHtAY