### PR TITLE
fix(swift): stop cancelling URLSessionTasks that have already finished (#1410)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1082,17 +1082,11 @@ jobs:
       - name: Swift SDK conformance
         run: swift test --configuration debug -Xswiftc -warnings-as-errors --filter ConformanceTests
 
+      # Includes the loopback streaming test, which used to need a process of
+      # its own while the SDK still cancelled finished URLSessionTasks and
+      # tripped FoundationNetworking's task registry at teardown (#1410).
       - name: Swift debug tests
         run: swift test --configuration debug -Xswiftc -warnings-as-errors
-
-      # Its own process: a real URLSession and the suite's mocked ones share
-      # FoundationNetworking's global task registry, which traps at teardown.
-      - name: Swift streaming test over a real socket
-        env:
-          FOUNTAIN_REAL_NETWORK_TESTS: "1"
-        run: |
-          swift test --configuration debug -Xswiftc -warnings-as-errors \
-            --filter aRealSocketStreamsEventsThroughURLSession
 
       - name: Swift release build
         run: swift build --configuration release -Xswiftc -warnings-as-errors

--- a/sdk/swift/CHANGELOG.md
+++ b/sdk/swift/CHANGELOG.md
@@ -18,6 +18,28 @@ Notable changes to the Fountain Swift SDK follow
   green on all 24 scenarios — including the timeout scenario `swift` skips
   (#1424), because it raises before re-reading the conversation.
 
+### Fixed
+
+- `swift test` no longer traps at teardown on Linux with
+  "Trying to access a behaviour for a task that in not in the registry"
+  (#1410). Cancelling a `URLSessionTask` is unsafe in FoundationNetworking
+  whenever the session carries a `URLCache`: the cache is read on a background
+  queue before the task's `URLProtocol` exists, so a cancel that lands in that
+  window reports its failure after the task has left the task registry, and
+  `URLSession.behaviour(for:)` traps the process. Both clients now build the
+  sessions they cancel tasks on, without a cache; the `session` a caller passes
+  supplies the configuration rather than being used directly. Fountain sends no
+  cache headers and an event stream must not be replayed from a cache, so
+  nothing is cacheable in the first place.
+- SSE connections share one `URLSession` per client instead of building one
+  each. No session is invalidated from inside a delegate callback, and
+  `invalidateAndCancel()`, which walks the task registry off the session's work
+  queue, is gone.
+- `URLSession.data(for:)` is no longer used. It holds the task in its
+  cancellation handler for the whole call and never releases it on completion,
+  so a Swift task cancelled just after a response arrived cancelled a
+  `URLSessionTask` that had already finished.
+
 ## [0.16.0] - 2026-09-03
 
 ### Added

--- a/sdk/swift/Sources/Fountain/Fountain.swift
+++ b/sdk/swift/Sources/Fountain/Fountain.swift
@@ -21,6 +21,12 @@ public final class Fountain: @unchecked Sendable {
   /// Throws when a base URL supplied by an argument, the environment or the CLI
   /// credentials file is not a valid http(s) URL. It is never replaced with a
   /// different host.
+  ///
+  /// `session` supplies the configuration this client transports on — protocol
+  /// classes, headers, cookie and credential storage, proxies, timeouts — not
+  /// the session itself. The client builds its own, because it cancels the
+  /// tasks it starts and on Linux that is only safe on a session it made
+  /// (`FountainHTTPClient.transportConfiguration(from:)`).
   public init(
     apiKey: String? = nil,
     baseURL: String? = nil,

--- a/sdk/swift/Sources/Fountain/HTTPClient.swift
+++ b/sdk/swift/Sources/Fountain/HTTPClient.swift
@@ -14,14 +14,57 @@ let fountainStreamTimeout: TimeInterval = 24 * 60 * 60
 public final class FountainHTTPClient: @unchecked Sendable {
   public let configuration: FountainConfiguration
   public let timeout: TimeInterval
-  private let session: URLSession
+  /// The caller's `session` is read for its configuration, not used directly.
+  /// See `transportConfiguration(from:)`.
+  private let transport: URLSessionConfiguration
+  private let lock = NSLock()
+  private var openRequests: URLSession?
+  private var openStreamer: SSEStreamer?
 
   public init(
     configuration: FountainConfiguration, timeout: TimeInterval = 30, session: URLSession = .shared
   ) {
     self.configuration = configuration
     self.timeout = timeout
-    self.session = session
+    self.transport = Self.transportConfiguration(from: session)
+  }
+
+  deinit { openRequests?.finishTasksAndInvalidate() }
+
+  /// The configuration both of this client's sessions are built from: the one
+  /// the caller supplied, minus its `URLCache`.
+  ///
+  /// The SDK cancels the tasks it starts, and on Linux that is only safe on a
+  /// cacheless session. FoundationNetworking looks a cached response up on a
+  /// background queue before it creates the task's `URLProtocol`, so a cancel
+  /// that lands in that window reports its failure once the task has already
+  /// left the task registry, and `URLSession.behaviour(for:)` traps the whole
+  /// process rather than returning nil. Over 40,000 cancel-after-resume rounds
+  /// in `swift:6.1`, every batch with a cache trapped and no batch without one
+  /// did (#1410). `URLSession.shared`, the default here, carries
+  /// `URLCache.shared`.
+  ///
+  /// Nothing is lost by dropping it. Fountain answers every request under an
+  /// `Authorization` header and sends no cache headers, and an event stream
+  /// must never be replayed out of a cache.
+  private static func transportConfiguration(from session: URLSession) -> URLSessionConfiguration {
+    let configuration = session.configuration
+    let copy = (configuration.copy() as? URLSessionConfiguration) ?? configuration
+    copy.urlCache = nil
+    copy.requestCachePolicy = .reloadIgnoringLocalCacheData
+    return copy
+  }
+
+  /// One session for plain requests, built on the first one. Streams get their
+  /// own (`streamer`): a handful of tailing connections would otherwise fill
+  /// `httpMaximumConnectionsPerHost` and queue every API call behind them.
+  private var requests: URLSession {
+    lock.lock()
+    defer { lock.unlock() }
+    if let openRequests { return openRequests }
+    let created = URLSession(configuration: transport)
+    openRequests = created
+    return created
   }
 
   public func url(path: String, query: [String: String?] = [:]) -> URL {
@@ -79,7 +122,7 @@ public final class FountainHTTPClient: @unchecked Sendable {
   ) async throws -> JSONValue {
     let request = try makeRequest(method, path, query: query, body: body)
     do {
-      let (data, response) = try await session.data(for: request)
+      let (data, response) = try await perform(request)
       guard let http = response as? HTTPURLResponse else {
         throw FountainError(
           .connection,
@@ -127,5 +170,89 @@ public final class FountainHTTPClient: @unchecked Sendable {
     return request
   }
 
-  var sessionConfiguration: URLSessionConfiguration { session.configuration }
+  /// One request, awaited. See `RequestCancellation` for why
+  /// `URLSession.data(for:)` is not used.
+  private func perform(_ request: URLRequest) async throws -> (Data, URLResponse) {
+    let cancellation = RequestCancellation()
+    return try await withTaskCancellationHandler {
+      try await withCheckedThrowingContinuation {
+        (continuation: CheckedContinuation<(Data, URLResponse), Error>) in
+        let task = requests.dataTask(with: request) { data, response, error in
+          cancellation.clear()
+          if let error {
+            continuation.resume(throwing: error)
+          } else if let response {
+            continuation.resume(returning: (data ?? Data(), response))
+          } else {
+            continuation.resume(throwing: URLError(.badServerResponse))
+          }
+        }
+        task.resume()
+        cancellation.activate(task)
+      }
+    } onCancel: {
+      cancellation.cancel()
+    }
+  }
+
+  /// One streaming session for the life of the client, built on the first
+  /// stream. Like `requests` it carries the caller's configuration, so a test
+  /// that installs a `URLProtocol` reaches the stream too.
+  var streamer: SSEStreamer {
+    lock.lock()
+    defer { lock.unlock() }
+    if let openStreamer { return openStreamer }
+    let created = SSEStreamer(configuration: transport)
+    openStreamer = created
+    return created
+  }
+}
+
+/// Holds the `URLSessionTask` a request is running on, and lets go of it the
+/// moment the response lands.
+///
+/// This is why `URLSession.data(for:)` is not used. Its own version of this
+/// never lets go: it keeps the task for the whole call, so a Swift task
+/// cancelled just after the response arrived still cancels the
+/// `URLSessionTask`. Letting go on completion means the common case cancels
+/// nothing at all; `transportConfiguration(from:)` is what makes the cancels
+/// that do happen safe.
+private final class RequestCancellation: @unchecked Sendable {
+  private enum State {
+    case pending
+    case completed
+    case cancelled
+  }
+
+  private let lock = NSLock()
+  private var state = State.pending
+  private var task: URLSessionTask?
+
+  /// Called from the completion handler. A request that answered is not
+  /// cancelled, whatever happens to the Swift task afterwards.
+  func clear() {
+    lock.lock()
+    state = .completed
+    task = nil
+    lock.unlock()
+  }
+
+  /// Called after `resume()`, so it has to cope with a request that answered,
+  /// or was cancelled, before it got here.
+  func activate(_ task: URLSessionTask) {
+    lock.lock()
+    let state = self.state
+    if state == .pending { self.task = task }
+    lock.unlock()
+    if state == .cancelled { task.cancel() }
+  }
+
+  func cancel() {
+    lock.lock()
+    let task = self.task
+    if state == .pending { state = .cancelled }
+    self.task = nil
+    lock.unlock()
+    task?.cancel()
+  }
 }

--- a/sdk/swift/Sources/Fountain/SSE.swift
+++ b/sdk/swift/Sources/Fountain/SSE.swift
@@ -118,9 +118,7 @@ private func openStream(
             query: [
               "streams": streams, "wait": wait ? nil : "false", "blocks": blocks ? "true" : nil,
             ], lastEventID: lastID)
-          for try await item in SSEConnection.stream(
-            request: request, configuration: http.sessionConfiguration)
-          {
+          for try await item in http.streamer.stream(request: request) {
             switch item {
             case .opened:
               attempt = 0
@@ -162,52 +160,127 @@ func streamEvents(
 
 /// URLSessionDataDelegate is used instead of URLSession.AsyncBytes because the
 /// latter is unavailable in FoundationNetworking on Linux.
-private enum SSEItem: Sendable {
+enum SSEItem: Sendable {
   case opened
   case event(JSONObject)
 }
 
-private final class SSEConnection: NSObject, URLSessionDataDelegate, @unchecked Sendable {
-  private let continuation: AsyncThrowingStream<SSEItem, Error>.Continuation
+/// One `URLSession` for every SSE connection a client opens, and one delegate
+/// that fans its callbacks back out by `URLSessionTask.taskIdentifier`.
+///
+/// A delegate that holds per-connection state needs a session of its own, which
+/// is why this used to build one per connection. Releasing that delegate meant
+/// invalidating that session, from inside its own `didCompleteWithError`, with
+/// `invalidateAndCancel()` — which reads the task registry off the session's
+/// work queue and cancels every task on it whatever state it is in. So: one
+/// session, invalidated once with `finishTasksAndInvalidate()` when the client
+/// that owns it is released, and never from inside a callback (#1410).
+final class SSEStreamer: @unchecked Sendable {
+  private let configuration: URLSessionConfiguration
+  /// A separate object rather than `self`, because the session holds its
+  /// delegate until it is invalidated. Were `self` the delegate, `deinit` would
+  /// wait on the invalidation it is meant to perform.
+  private let delegate = SSEDelegate()
   private let lock = NSLock()
-  private var response: HTTPURLResponse?
-  private var buffer = Data()
-  private var errorBody = Data()
   private var session: URLSession?
-  private var task: URLSessionDataTask?
-  private var finished = false
 
-  static func stream(request: URLRequest, configuration: URLSessionConfiguration)
-    -> AsyncThrowingStream<SSEItem, Error>
-  {
+  init(configuration: URLSessionConfiguration) {
+    self.configuration = configuration
+  }
+
+  deinit { session?.finishTasksAndInvalidate() }
+
+  func stream(request: URLRequest) -> AsyncThrowingStream<SSEItem, Error> {
     AsyncThrowingStream { continuation in
-      let connection = SSEConnection(continuation: continuation)
-      let session = URLSession(
-        configuration: configuration, delegate: connection, delegateQueue: nil)
-      connection.session = session
-      let task = session.dataTask(with: request)
-      connection.task = task
+      let task = openSession().dataTask(with: request)
+      let connection = SSEConnection(continuation: continuation, task: task)
+      // Registered before `resume()`, so no callback can arrive before the
+      // delegate can route it.
+      delegate.register(connection, for: task)
       continuation.onTermination = { _ in connection.cancel() }
       task.resume()
     }
   }
 
-  init(continuation: AsyncThrowingStream<SSEItem, Error>.Continuation) {
-    self.continuation = continuation
+  /// Built on the first stream, so a client that never streams never makes one.
+  private func openSession() -> URLSession {
+    lock.lock()
+    defer { lock.unlock() }
+    if let session { return session }
+    let created = URLSession(configuration: configuration, delegate: delegate, delegateQueue: nil)
+    session = created
+    return created
+  }
+}
+
+/// Task identifiers are unique for the life of a session, so a finished task
+/// never hands its slot to a later one.
+private final class SSEDelegate: NSObject, URLSessionDataDelegate, @unchecked Sendable {
+  private let lock = NSLock()
+  private var connections: [Int: SSEConnection] = [:]
+
+  func register(_ connection: SSEConnection, for task: URLSessionDataTask) {
+    lock.lock()
+    defer { lock.unlock() }
+    connections[task.taskIdentifier] = connection
+  }
+
+  private func connection(for task: URLSessionTask) -> SSEConnection? {
+    lock.lock()
+    defer { lock.unlock() }
+    return connections[task.taskIdentifier]
+  }
+
+  private func take(_ task: URLSessionTask) -> SSEConnection? {
+    lock.lock()
+    defer { lock.unlock() }
+    return connections.removeValue(forKey: task.taskIdentifier)
   }
 
   func urlSession(
     _ session: URLSession, dataTask: URLSessionDataTask, didReceive response: URLResponse,
     completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
   ) {
-    self.response = response as? HTTPURLResponse
-    if let response = self.response, (200..<300).contains(response.statusCode) {
-      continuation.yield(.opened)
-    }
+    connection(for: dataTask)?.receive(response)
     completionHandler(.allow)
   }
 
   func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+    connection(for: dataTask)?.receive(data)
+  }
+
+  func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+    take(task)?.complete(error)
+  }
+}
+
+/// The per-connection half: the parse buffer, the status, and the continuation
+/// the events go to. It owns no session, and invalidates none.
+private final class SSEConnection: @unchecked Sendable {
+  private let continuation: AsyncThrowingStream<SSEItem, Error>.Continuation
+  private let task: URLSessionDataTask
+  private let lock = NSLock()
+  private var response: HTTPURLResponse?
+  private var buffer = Data()
+  private var errorBody = Data()
+  private var finished = false
+
+  init(
+    continuation: AsyncThrowingStream<SSEItem, Error>.Continuation, task: URLSessionDataTask
+  ) {
+    self.continuation = continuation
+    self.task = task
+  }
+
+  func receive(_ response: URLResponse) {
+    let http = response as? HTTPURLResponse
+    lock.lock()
+    self.response = http
+    lock.unlock()
+    if let http, (200..<300).contains(http.statusCode) { continuation.yield(.opened) }
+  }
+
+  func receive(_ data: Data) {
     lock.lock()
     defer { lock.unlock() }
     guard !finished else { return }
@@ -219,7 +292,7 @@ private final class SSEConnection: NSObject, URLSessionDataDelegate, @unchecked 
     drainCompleteMessages()
   }
 
-  func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+  func complete(_ error: Error?) {
     lock.lock()
     guard !finished else {
       lock.unlock()
@@ -233,7 +306,6 @@ private final class SSEConnection: NSObject, URLSessionDataDelegate, @unchecked 
     let response = self.response
     let body = errorBody
     lock.unlock()
-    defer { session.finishTasksAndInvalidate() }
     if let error {
       continuation.finish(throwing: error)
       return
@@ -276,15 +348,17 @@ private final class SSEConnection: NSObject, URLSessionDataDelegate, @unchecked 
     }
   }
 
-  private func cancel() {
+  /// A consumer that walks away from a live stream has to cancel the task, or
+  /// a tail would hold the connection open forever. A consumer that read to the
+  /// end has nothing to cancel. This is safe to call whatever the task is doing
+  /// only because the session carries no `URLCache` — see
+  /// `FountainHTTPClient.transportConfiguration(from:)`.
+  func cancel() {
     lock.lock()
     let alreadyFinished = finished
     finished = true
     lock.unlock()
-    if !alreadyFinished {
-      task?.cancel()
-      session?.invalidateAndCancel()
-    }
+    if !alreadyFinished { task.cancel() }
   }
 }
 

--- a/sdk/swift/Sources/FountainKit/Transport/HTTPTransport.swift
+++ b/sdk/swift/Sources/FountainKit/Transport/HTTPTransport.swift
@@ -18,15 +18,68 @@ public protocol HTTPTransport: Sendable {
 }
 
 /// Production transport backed by URLSession.
+///
+/// The `session` a caller supplies is read for its configuration, not used
+/// directly: this transport owns the two sessions it cancels tasks on, and
+/// builds both without a `URLCache`. See `transportConfiguration(from:)`.
 public struct URLSessionTransport: HTTPTransport {
-  private let session: URLSession
+  private let requests: RequestSession
+  private let streamer: StreamingSession
 
   public init(session: URLSession = .shared) {
-    self.session = session
+    let transport = URLSessionTransport.transportConfiguration(from: session)
+    self.requests = RequestSession(configuration: transport)
+    self.streamer = StreamingSession(configuration: transport)
   }
 
+  /// The configuration both sessions are built from: the caller's, minus its
+  /// `URLCache`.
+  ///
+  /// This transport cancels the tasks it starts, and on Linux that is only safe
+  /// on a cacheless session. FoundationNetworking looks a cached response up on
+  /// a background queue before it creates the task's `URLProtocol`, so a cancel
+  /// that lands in that window reports its failure once the task has already
+  /// left the task registry, and `URLSession.behaviour(for:)` traps the whole
+  /// process rather than returning nil. Over 40,000 cancel-after-resume rounds
+  /// in `swift:6.1`, every batch with a cache trapped and no batch without one
+  /// did (#1410). `URLSession.shared`, the default here, carries
+  /// `URLCache.shared`.
+  ///
+  /// Nothing is lost by dropping it. Fountain answers every request under an
+  /// `Authorization` header and sends no cache headers, and an event stream
+  /// must never be replayed out of a cache.
+  private static func transportConfiguration(from session: URLSession)
+    -> URLSessionConfiguration
+  {
+    let configuration = session.configuration
+    let copy = (configuration.copy() as? URLSessionConfiguration) ?? configuration
+    copy.urlCache = nil
+    copy.requestCachePolicy = .reloadIgnoringLocalCacheData
+    return copy
+  }
+
+  /// Not `session.data(for:)`. See `RequestCancellation` for why.
   public func data(for request: URLRequest) async throws -> (Data, HTTPURLResponse) {
-    let (data, response) = try await session.data(for: request)
+    let cancellation = RequestCancellation()
+    let (data, response): (Data, URLResponse) = try await withTaskCancellationHandler {
+      try await withCheckedThrowingContinuation {
+        (continuation: CheckedContinuation<(Data, URLResponse), Error>) in
+        let task = requests.session.dataTask(with: request) { data, response, error in
+          cancellation.clear()
+          if let error {
+            continuation.resume(throwing: error)
+          } else if let response {
+            continuation.resume(returning: (data ?? Data(), response))
+          } else {
+            continuation.resume(throwing: URLError(.badServerResponse))
+          }
+        }
+        task.resume()
+        cancellation.activate(task)
+      }
+    } onCancel: {
+      cancellation.cancel()
+    }
     guard let http = response as? HTTPURLResponse else {
       throw FountainError.transport(URLError(.badServerResponse))
     }
@@ -39,55 +92,150 @@ public struct URLSessionTransport: HTTPTransport {
     // Not `session.bytes(for:)`: `URLSession.AsyncBytes` does not exist in
     // FoundationNetworking, so on Linux the only way to read a body as it
     // arrives is the data-task delegate.
-    try await StreamingConnection.open(request: request, configuration: session.configuration)
+    try await streamer.open(request: request)
   }
 }
 
-/// One streaming response, delivered chunk by chunk. The headers resolve
-/// first — a caller needs the status before it decides whether the body is
-/// a stream or an error — and the body follows on the returned stream.
-private final class StreamingConnection: NSObject, URLSessionDataDelegate, @unchecked Sendable {
-  private let lock = NSLock()
-  private var opened: CheckedContinuation<HTTPURLResponse, any Error>?
-  private var chunks: AsyncThrowingStream<Data, Error>.Continuation?
-  private var session: URLSession?
-  private var task: URLSessionDataTask?
-  private var response: HTTPURLResponse?
-  private var finished = false
+/// The session plain requests run on, held so that it is invalidated once, when
+/// the transport that owns it is released.
+private final class RequestSession: @unchecked Sendable {
+  let session: URLSession
 
-  static func open(request: URLRequest, configuration: URLSessionConfiguration) async throws -> (
-    HTTPURLResponse, AsyncThrowingStream<Data, Error>
-  ) {
-    let connection = StreamingConnection()
+  init(configuration: URLSessionConfiguration) {
+    session = URLSession(configuration: configuration)
+  }
+
+  deinit { session.finishTasksAndInvalidate() }
+}
+
+/// One `URLSession` for every streaming request a transport opens, and one
+/// delegate that fans its callbacks back out by `URLSessionTask.taskIdentifier`.
+///
+/// A delegate that holds per-connection state needs a session of its own, which
+/// is why this used to build one per request. FoundationNetworking cannot take
+/// that: releasing the delegate means invalidating the session, and doing it
+/// from inside `didCompleteWithError` runs while that task's completion is
+/// still in flight (#1410). So: one session, invalidated once when the
+/// transport that owns this is released, and never from inside a callback.
+private final class StreamingSession: @unchecked Sendable {
+  private let configuration: URLSessionConfiguration
+  /// A separate object rather than `self`, because the session holds its
+  /// delegate until it is invalidated. Were `self` the delegate, `deinit` would
+  /// wait on the invalidation it is meant to perform.
+  private let delegate = StreamingDelegate()
+  private let lock = NSLock()
+  private var session: URLSession?
+
+  init(configuration: URLSessionConfiguration) {
+    self.configuration = configuration
+  }
+
+  deinit { session?.finishTasksAndInvalidate() }
+
+  /// The headers resolve first — a caller needs the status before it decides
+  /// whether the body is a stream or an error — and the body follows on the
+  /// returned stream.
+  func open(request: URLRequest) async throws -> (HTTPURLResponse, AsyncThrowingStream<Data, Error>)
+  {
+    let task = openSession().dataTask(with: request)
+    let connection = StreamingConnection(task: task)
     // Built before the task starts, so bytes that arrive before the caller
     // iterates are buffered by the stream rather than dropped.
     let stream = AsyncThrowingStream<Data, Error> { continuation in
       connection.chunks = continuation
       continuation.onTermination = { _ in connection.cancel() }
     }
-    let session = URLSession(configuration: configuration, delegate: connection, delegateQueue: nil)
-    connection.session = session
-    let task = session.dataTask(with: request)
-    connection.task = task
+    // Registered before `resume()`, so no callback can arrive before the
+    // delegate can route it.
+    delegate.register(connection, for: task)
 
     let response = try await withCheckedThrowingContinuation {
       (continuation: CheckedContinuation<HTTPURLResponse, any Error>) in
-      connection.lock.lock()
-      connection.opened = continuation
-      connection.lock.unlock()
+      connection.settleOnOpen(continuation)
       task.resume()
     }
     return (response, stream)
   }
 
-  private func cancel() {
+  /// Built on the first stream, so a transport that never streams never makes
+  /// one.
+  private func openSession() -> URLSession {
     lock.lock()
-    let task = self.task
-    let session = self.session
-    self.task = nil
+    defer { lock.unlock() }
+    if let session { return session }
+    let created = URLSession(configuration: configuration, delegate: delegate, delegateQueue: nil)
+    session = created
+    return created
+  }
+}
+
+/// Task identifiers are unique for the life of a session, so a finished task
+/// never hands its slot to a later one.
+private final class StreamingDelegate: NSObject, URLSessionDataDelegate, @unchecked Sendable {
+  private let lock = NSLock()
+  private var connections: [Int: StreamingConnection] = [:]
+
+  func register(_ connection: StreamingConnection, for task: URLSessionDataTask) {
+    lock.lock()
+    defer { lock.unlock() }
+    connections[task.taskIdentifier] = connection
+  }
+
+  private func connection(for task: URLSessionTask) -> StreamingConnection? {
+    lock.lock()
+    defer { lock.unlock() }
+    return connections[task.taskIdentifier]
+  }
+
+  private func take(_ task: URLSessionTask) -> StreamingConnection? {
+    lock.lock()
+    defer { lock.unlock() }
+    return connections.removeValue(forKey: task.taskIdentifier)
+  }
+
+  func urlSession(
+    _ session: URLSession,
+    dataTask: URLSessionDataTask,
+    didReceive response: URLResponse,
+    completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
+  ) {
+    guard let connection = connection(for: dataTask) else {
+      completionHandler(.cancel)
+      return
+    }
+    completionHandler(connection.receive(response) ? .allow : .cancel)
+  }
+
+  func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+    connection(for: dataTask)?.receive(data)
+  }
+
+  func urlSession(
+    _ session: URLSession, task: URLSessionTask, didCompleteWithError error: (any Error)?
+  ) {
+    take(task)?.complete(error)
+  }
+}
+
+/// The per-connection half: the headers continuation, the chunk continuation
+/// and the status. It owns no session, and invalidates none.
+private final class StreamingConnection: @unchecked Sendable {
+  private let task: URLSessionDataTask
+  private let lock = NSLock()
+  private var opened: CheckedContinuation<HTTPURLResponse, any Error>?
+  private var response: HTTPURLResponse?
+  private var finished = false
+  /// Set once, inside the stream's build closure, before the task resumes.
+  var chunks: AsyncThrowingStream<Data, Error>.Continuation?
+
+  init(task: URLSessionDataTask) {
+    self.task = task
+  }
+
+  func settleOnOpen(_ continuation: CheckedContinuation<HTTPURLResponse, any Error>) {
+    lock.lock()
+    opened = continuation
     lock.unlock()
-    task?.cancel()
-    session?.finishTasksAndInvalidate()
   }
 
   /// Resolve the headers exactly once, whether they arrived or the request
@@ -100,34 +248,27 @@ private final class StreamingConnection: NSObject, URLSessionDataDelegate, @unch
     continuation?.resume(with: result)
   }
 
-  func urlSession(
-    _ session: URLSession,
-    dataTask: URLSessionDataTask,
-    didReceive response: URLResponse,
-    completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
-  ) {
+  /// Returns whether the body should be allowed through.
+  func receive(_ response: URLResponse) -> Bool {
     guard let http = response as? HTTPURLResponse else {
       settleOpen(.failure(FountainError.transport(URLError(.badServerResponse))))
-      completionHandler(.cancel)
-      return
+      return false
     }
     lock.lock()
     self.response = http
     lock.unlock()
     settleOpen(.success(http))
-    completionHandler(.allow)
+    return true
   }
 
-  func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+  func receive(_ data: Data) {
     lock.lock()
     let continuation = finished ? nil : chunks
     lock.unlock()
     continuation?.yield(data)
   }
 
-  func urlSession(
-    _ session: URLSession, task: URLSessionTask, didCompleteWithError error: (any Error)?
-  ) {
+  func complete(_ error: (any Error)?) {
     lock.lock()
     if finished {
       lock.unlock()
@@ -138,7 +279,6 @@ private final class StreamingConnection: NSObject, URLSessionDataDelegate, @unch
     let hadResponse = response != nil
     lock.unlock()
 
-    defer { session.finishTasksAndInvalidate() }
     // A failure before any headers has nobody on the stream to tell yet.
     if let error, !hadResponse {
       settleOpen(.failure(FountainError.transport(error)))
@@ -149,5 +289,67 @@ private final class StreamingConnection: NSObject, URLSessionDataDelegate, @unch
       settleOpen(.failure(FountainError.transport(URLError(.badServerResponse))))
     }
     continuation?.finish(throwing: error)
+  }
+
+  /// A caller that walks away from a live body has to cancel the task, or the
+  /// connection stays open. A caller that read to the end has nothing to
+  /// cancel. This is safe to call whatever the task is doing only because the
+  /// session carries no `URLCache` — see
+  /// `URLSessionTransport.transportConfiguration(from:)`.
+  func cancel() {
+    lock.lock()
+    let alreadyFinished = finished
+    finished = true
+    lock.unlock()
+    if !alreadyFinished { task.cancel() }
+  }
+}
+
+/// Holds the `URLSessionTask` a request is running on, and lets go of it the
+/// moment the response lands.
+///
+/// This is why `URLSession.data(for:)` is not used. Its own version of this
+/// never lets go: it keeps the task for the whole call, so a Swift task
+/// cancelled just after the response arrived still cancels the
+/// `URLSessionTask`. Letting go on completion means the common case cancels
+/// nothing at all; `transportConfiguration(from:)` is what makes the cancels
+/// that do happen safe.
+private final class RequestCancellation: @unchecked Sendable {
+  private enum State {
+    case pending
+    case completed
+    case cancelled
+  }
+
+  private let lock = NSLock()
+  private var state = State.pending
+  private var task: URLSessionTask?
+
+  /// Called from the completion handler. A request that answered is not
+  /// cancelled, whatever happens to the Swift task afterwards.
+  func clear() {
+    lock.lock()
+    state = .completed
+    task = nil
+    lock.unlock()
+  }
+
+  /// Called after `resume()`, so it has to cope with a request that answered,
+  /// or was cancelled, before it got here.
+  func activate(_ task: URLSessionTask) {
+    lock.lock()
+    let state = self.state
+    if state == .pending { self.task = task }
+    lock.unlock()
+    if state == .cancelled { task.cancel() }
+  }
+
+  func cancel() {
+    lock.lock()
+    let task = self.task
+    if state == .pending { state = .cancelled }
+    self.task = nil
+    lock.unlock()
+    task?.cancel()
   }
 }

--- a/sdk/swift/Tests/FountainTests/LoopbackTests.swift
+++ b/sdk/swift/Tests/FountainTests/LoopbackTests.swift
@@ -134,27 +134,16 @@ private enum LoopbackError: Error {
   case failed(String)
 }
 
-/// Opt-in, and run in a process of its own.
+/// This used to be opt-in behind `FOUNTAIN_REAL_NETWORK_TESTS=1`, running in a
+/// process of its own: a real `URLSession` sharing a process with the mocked
+/// ones tripped FoundationNetworking's task registry at teardown in about a
+/// third of runs. The cause was the SDK cancelling `URLSessionTask`s that had
+/// already completed, which #1410 fixed, so it runs in the default suite.
 ///
-/// FoundationNetworking keeps one global task registry, and it traps at process
-/// teardown ("Trying to access a behaviour for a task that in not in the
-/// registry") in roughly a fifth of runs when a real `URLSession` shares a
-/// process with the mocked ones the rest of the suite installs. That is upstream
-/// of this package and reproduces without any SDK code in the path, so the test
-/// runs on its own instead: CI gives it a step, and `swift test` for everyone
-/// else stays deterministic. Alone it is stable.
-///
-///     FOUNTAIN_REAL_NETWORK_TESTS=1 swift test \
-///       --filter aRealSocketStreamsEventsThroughURLSession
-///
-/// It belongs to `TransportTests` so that setting the variable and running
-/// everything at least serializes it against the mocked tests.
+/// It belongs to `TransportTests` so that it serializes against the mocked
+/// tests, which share one `URLProtocol` handler.
 extension TransportTests {
-  @Test(
-    .enabled(
-      if: ProcessInfo.processInfo.environment["FOUNTAIN_REAL_NETWORK_TESTS"] == "1",
-      "Set FOUNTAIN_REAL_NETWORK_TESTS=1 to run this in a process of its own"))
-  func aRealSocketStreamsEventsThroughURLSession() async throws {
+  @Test func aRealSocketStreamsEventsThroughURLSession() async throws {
     let server = try LoopbackSSEServer(
       response: """
         HTTP/1.1 200 OK\r
@@ -175,16 +164,14 @@ extension TransportTests {
     server.start()
     defer { server.stop() }
 
-    // The SSE path builds its own session from this one's configuration, so this
-    // session stays unused. FoundationNetworking's task registry crashes at
-    // process teardown over a session that was never invalidated, so dispose it.
+    // The streaming session is built from this one's configuration, so this one
+    // carries only the protocol classes and stays otherwise unused.
     let session = URLSession(configuration: .ephemeral)
     defer { session.finishTasksAndInvalidate() }
     let fountain = try Fountain(
       apiKey: "loopback-secret", baseURL: "http://127.0.0.1:\(server.port)", session: session)
-    // Read to the end of the stream rather than breaking out of it. Cancelling a
-    // live task is what trips FoundationNetworking's task registry on Linux, and
-    // the server closes the connection once it has sent both events.
+    // Read to the end of the stream rather than breaking out of it: the server
+    // closes the connection once it has sent both events.
     var ids: [Int] = []
     for try await event in fountain.events(after: 10, wait: false, maxRetries: 0) {
       ids.append(event["id"]?.intValue ?? 0)

--- a/sdk/swift/Tests/FountainTests/TransportTests.swift
+++ b/sdk/swift/Tests/FountainTests/TransportTests.swift
@@ -189,8 +189,18 @@ private func json(_ value: JSONValue) -> Data { try! JSONEncoder().encode(value)
   }
 
   @Test func successfulEmptySSEConnectionsResetRetryBudget() async throws {
+    // Counted by path, not by call, for the reason
+    // `anEventStreamOpensNothingUntilItIsIterated` counts by cursor: a stream
+    // an earlier test left retrying reaches this handler too, and an extra
+    // connection it made would move the run that carries the event. Only this
+    // test asks for this path.
+    let path = "/api/events/retry-budget"
     let counter = LockedCounter()
-    MockURLProtocol.handler = { _, protocolInstance in
+    MockURLProtocol.handler = { request, protocolInstance in
+      guard request.url?.path == path else {
+        protocolInstance.respond(headers: ["Content-Type": "text/event-stream"])
+        return
+      }
       let count = counter.increment()
       let body = count == 7 ? "id: 7\nevent: output\ndata: {\"kind\":\"output\"}\n\n" : ""
       protocolInstance.respond(
@@ -200,9 +210,7 @@ private func json(_ value: JSONValue) -> Data { try! JSONEncoder().encode(value)
       baseURL: URL(string: "https://api.example.test")!, apiKey: "secret", appURL: nil)
     let http = FountainHTTPClient(configuration: config, session: mockSession())
     var ids: [Int] = []
-    for try await event in streamPath(
-      http: http, path: "/api/events/stream", maxRetries: 5, retryDelay: 0)
-    {
+    for try await event in streamPath(http: http, path: path, maxRetries: 5, retryDelay: 0) {
       ids.append(event["id"]?.intValue ?? 0)
       break
     }

--- a/sdk/swift/Tests/FountainTests/TransportTests.swift
+++ b/sdk/swift/Tests/FountainTests/TransportTests.swift
@@ -29,12 +29,10 @@ private final class MockURLProtocol: URLProtocol, @unchecked Sendable {
   }
 }
 
-/// One session for every mocked test, not one per test. FoundationNetworking
-/// keeps a single global task registry, and a process that churns through
-/// sessions trips it at teardown ("Trying to access a behaviour for a task that
-/// in not in the registry"), which failed about one Ubuntu run in six. Sharing
-/// is safe here because `MockURLProtocol.handler` is global too, and the suite
-/// is serialized.
+/// One session for every mocked test, not one per test: `MockURLProtocol.handler`
+/// is global and the suite is serialized, so a session each would buy nothing.
+/// The client copies this configuration rather than using the session, which is
+/// how `MockURLProtocol` reaches the streams as well as the plain requests.
 private let sharedMockSession: URLSession = {
   let configuration = URLSessionConfiguration.ephemeral
   configuration.protocolClasses = [MockURLProtocol.self]
@@ -217,8 +215,8 @@ private func json(_ value: JSONValue) -> Data { try! JSONEncoder().encode(value)
     // `.greatestFiniteMagnitude` is out of Int range, so converting it traps.
     let config = FountainConfiguration(
       baseURL: URL(string: "https://api.example.test")!, apiKey: "secret", appURL: nil)
-    // No session: the request never goes out, and a URLSession left unused
-    // trips FoundationNetworking's task registry when the process exits.
+    // No session: this only builds a request, and a client that neither
+    // requests nor streams opens no session at all.
     let http = FountainHTTPClient(configuration: config)
     let request = try http.streamRequest("/api/events/stream", query: [:], lastEventID: 0)
     #expect(request.timeoutInterval.isFinite)


### PR DESCRIPTION
Closes #1410.

## The issue's diagnosis was wrong

The issue blamed `URLSession` churn and proposed one shared streaming session. That change alone moves the failure rate from 6/20 to 5/20. Every backtrace says something else:

```
URLSession.behaviour(for:)                                  <- fatalError
_ProtocolClient.urlProtocol(task:didFailWithError:)
closure #1 in closure #2 in closure #1 in URLSessionTask.cancel()
```

The trap is **cancelling a `URLSessionTask` that has already left the registry**, and the thing that makes it possible is the session's `URLCache`. `URLSessionTask._getProtocol` hands the cache lookup to `DispatchQueue.global(qos: .background)` before the task's `URLProtocol` exists, so a cancel landing in that window enqueues its `didFailWithError` from that background queue, completely unordered against the registry removal.

A 60-line standalone reproducer settles it. Cancel immediately after `resume()`, 2,000 rounds per batch, `swift:6.1` aarch64:

| Variant | Batches trapped |
|---|---|
| cancel, session has a `URLCache` | **5 / 5** |
| cancel, no `URLCache` | **0 / 20** (40,000 rounds) |
| cancel on the delegate queue, `URLCache` | 3 / 12 |
| no cancel at all | 0 / 12 |

Serializing the cancel onto the delegate queue halves it and does not fix it. The cache is the gate.

## What this changes

**Both clients now build the sessions they cancel tasks on, without a cache.** `session:` supplies the configuration (protocol classes, cookie and credential storage, proxies, timeouts) rather than being used directly. Nothing was cacheable anyway: Fountain answers every request under an `Authorization` header and sends no cache headers, and an event stream must never be replayed from a cache.

**`URLSession.data(for:)` is gone.** Its cancellation handler keeps the task for the whole call and never releases it on completion, so a Swift task cancelled just after a response arrived cancels a finished task. Its default session here is `URLSession.shared`, which carries `URLCache.shared` — so **this was reachable by any SDK user on Linux, not just CI**. It is replaced by a completion-handler task that releases the task the moment the response lands.

**SSE connections share one session per client**, which the issue asked for and which stands on its own: no session is invalidated from inside a delegate callback any more, and `invalidateAndCancel()` is gone — it read the task registry off the session's work queue and cancelled every task on it whatever state it was in.

`FountainKit` had the identical defect in `URLSessionTransport` and gets the same treatment. Its tests drive a fake transport, so it was not contributing to the flake, but shipping the fix in one client and not its sibling seemed worse than the extra diff.

The second commit fixes a **separate, latent** test weakness that this change surfaced. `successfulEmptySSEConnectionsResetRetryBudget` counted every call on the global mock handler, so a stream an earlier test left retrying moved which connection carried the event. Sharing a warm session makes those leaked retries faster, so it started landing inside the window. `anEventStreamOpensNothingUntilItIsIterated` already documents this hazard and counts by cursor; this one now counts by a path no other test uses.

## Measurements

50 runs of `swift test --configuration debug -Xswiftc -warnings-as-errors` in `swift:6.1`:

| Tree | Failed | What |
|---|---|---|
| `main`, real-socket test still gated off | **11 / 50** | every one the task-registry trap |
| this branch, real-socket test in-process | **0 / 50** | |

The branch is measured under the harder condition: the loopback test now runs in the default suite rather than a process of its own.

## Acceptance criteria

- [x] `SSEConnection` no longer builds a `URLSession` per connection
- [x] No `URLSession` invalidated from inside a delegate callback
- [x] 50 consecutive `swift test` runs exit 0, real-socket test in the same process
- [x] `aRealSocketStreamsEventsThroughURLSession` loses its `FOUNTAIN_REAL_NETWORK_TESTS` gate
- [x] The separate `Swift streaming test over a real socket` CI step is deleted

## Reviewer note

The behavioural change worth a second opinion is that `session:` becomes a configuration source rather than the transport. The alternative was to leave plain requests on the caller's session and drop cancellation for them, which would leave a cancelled `await` hanging until the 30s timeout. I took the safe-cancel route; say the word if you would rather keep the literal parameter semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W4AvmuN8Uqki6wkZ6hdz5a