### PR TITLE
perf(ci): stop npm ci waiting on the advisories endpoint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,3 +32,24 @@ updates:
     directory: /
     schedule:
       interval: weekly
+
+  # The two npm lockfiles. Added when `npm ci` in CI lost its implicit
+  # `npm audit` call: that call printed advisories and could not fail a build,
+  # while costing 88s to 302s per run waiting on an endpoint that stalls from a
+  # runner. Removing it left these packages watched by nothing at all, so the
+  # signal moves here, where it arrives as a PR someone can merge.
+  - package-ecosystem: npm
+    directory: /sdk/typescript
+    schedule:
+      interval: weekly
+    groups:
+      sdk-typescript:
+        update-types: [minor, patch]
+
+  - package-ecosystem: npm
+    directory: /scripts/destink
+    schedule:
+      interval: weekly
+    groups:
+      destink:
+        update-types: [minor, patch]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -748,9 +748,26 @@ jobs:
           cache: npm
           cache-dependency-path: sdk/typescript/package-lock.json
 
+      # `--no-audit` is the whole reason this step is not the longest in CI.
+      # `npm ci` runs a vulnerability audit by default, which is one POST to
+      # registry.npmjs.org/-/npm/v1/security/advisories/bulk — and that request
+      # stalls from Actions runners rather than failing fast. Measured on this
+      # lockfile: 35 packages, every tarball fetched in 325ms from a warm
+      # cache, and then `reify:audit Completed in 300202ms`. The step was
+      # taking 88s to 302s depending on how far into npm's 5-minute timeout the
+      # request got, on every PR, and it made this job 426s against 171s for
+      # the slowest test partition. With the flag it is under 5s.
+      #
+      # Nothing is lost, because nothing was gated: `npm ci` does not fail on
+      # advisories, so this could only ever print "found 0 vulnerabilities"
+      # into a log. What DOES watch these packages is dependabot, which was
+      # given its two npm ecosystems in the same change that added this flag --
+      # before that the audit line was the only npm advisory signal in the
+      # repository, and it was one nobody could act on. `--no-fund` suppresses
+      # the funding notice for the same reason: it is output, not a check.
       - name: SDK install
         working-directory: sdk/typescript
-        run: npm ci
+        run: npm ci --no-audit --no-fund
 
       - name: SDK typecheck
         working-directory: sdk/typescript
@@ -1027,10 +1044,15 @@ jobs:
       # job already installed Node 24 for the SDK steps above, unconditionally.
       # A second setup-node would re-point the npm cache at a different
       # lockfile for the rest of the job.
+      #
+      # `--no-audit --no-fund` for the reason spelled out on the SDK install
+      # step above: five packages, 5.2MB, every tarball fetched in 325ms, and
+      # then five minutes waiting on the advisories endpoint. This step was
+      # measured at 61s and 278s on consecutive runs from that alone.
       - name: Docs de-stink
         if: ${{ needs.changes.outputs.docs_touched == 'true' }}
         run: |
-          npm ci --prefix scripts/destink
+          npm ci --prefix scripts/destink --no-audit --no-fund
           node scripts/destink/destink.mjs
 
   swift-sdk:
@@ -1568,9 +1590,11 @@ jobs:
           cache: npm
           cache-dependency-path: scripts/destink/package-lock.json
 
+      # `--no-audit --no-fund`: see the SDK install step in `checks`. The audit
+      # request stalls for minutes from a runner and can only ever print.
       - name: Docs de-stink
         run: |
-          npm ci --prefix scripts/destink
+          npm ci --prefix scripts/destink --no-audit --no-fund
           node scripts/destink/destink.mjs
 
       - name: Set up Go

--- a/.github/workflows/sdk-publish.yml
+++ b/.github/workflows/sdk-publish.yml
@@ -88,10 +88,14 @@ jobs:
           } >> "$GITHUB_OUTPUT"
           echo "version $version already on npm: $published (publish: $needed)"
 
+      # `--no-audit --no-fund`: see the SDK install step in ci.yml's `checks`
+      # job. The audit endpoint stalls for minutes from a runner and `npm ci`
+      # never fails on what it returns. This is the publish path, so the delay
+      # sat between a merged version bump and the package being on npm.
       - name: Install
         if: steps.release.outputs.needed == 'yes'
         working-directory: sdk/typescript
-        run: npm ci
+        run: npm ci --no-audit --no-fund
 
       # `prepublishOnly` runs these again. They are here as their own steps so a
       # failure names the gate that failed, instead of surfacing as a publish


### PR DESCRIPTION
`Static analysis and release checks` has been the last job to finish on every PR — 426s against 171s for the slowest test partition. Almost none of that is analysis.

## What it actually is

`npm ci` runs a vulnerability audit by default: one POST to `registry.npmjs.org/-/npm/v1/security/advisories/bulk`. That request stalls from an Actions runner rather than failing fast. Reproduced locally with `--timing`, on a run where every cache in the job hit:

```
all 35 tarballs fetched        325 ms
reify:audit Completed in    300202 ms
```

Step timings across five recent PR runs:

| Step | Observed |
|---|---|
| **SDK install** (`npm ci`, 35 pkgs) | **88 / 150 / 185 / 302 / 302 s** |
| **Docs de-stink** (`npm ci`, 5 pkgs, 5.2MB) | **61 / 278 s** |
| Dialyzer | 29–32 s |
| Release boot | 19–22 s |
| Credo | 14 s |

The spread is how far into npm's five-minute timeout the request got. With `--no-audit --no-fund` both steps are under 5s.

## Nothing was gated by it

`npm ci` does not fail on advisories — the audit could only ever print `found 0 vulnerabilities` into a log nobody reads.

It was still the only npm advisory signal in the repository, though: `dependabot.yml` had `github-actions`, `mix`, `gomod` and `docker`, but no `npm` ecosystem. So both lockfiles get one here, where the signal arrives as a PR someone can merge.

## Scope

The flag goes on all four `npm ci` call sites — two in `checks`, one in `docs`, and one in `sdk-publish.yml`. That last one is on the publish path, where the stall sat between a merged version bump and the package reaching npm.

Expected: `checks` drops to roughly 195s, below the test partitions. Whether the job is then worth splitting by toolchain is a separate question — this PR does not touch its structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GXM8homHJBHZT1KLUxP71e