### PR TITLE
chore(mix): stop using the deprecated --app in mix cmd (#1526)

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -101,7 +101,7 @@ defmodule Fountain.Umbrella.MixProject do
 
     args = if "--migrations-path" in args, do: args, else: args ++ migration_path_args()
 
-    Mix.Task.run("cmd", ["--app", "fountain", "mix", task] ++ args)
+    Mix.Task.run("do", ["--app", "fountain", "cmd", "mix", task] ++ args)
   end
 
   defp migration_path_args do
@@ -166,12 +166,21 @@ defmodule Fountain.Umbrella.MixProject do
       # a database with no extension tables (ADR 0043). Same bug CI caught on
       # the plain `ecto.migrate` path, on the two entrances CI does not run.
       setup: ["deps.get", "ecto.setup"],
+      # `cmd` under `do --app`, rather than `do --app <task>` directly (#1526,
+      # replacing the deprecated `cmd --app`): `mix do --app` narrows only a
+      # task that is `@recursive`, and none of ecto.create, ecto.drop,
+      # ecto.migrate, ecto.rollback or run is one. Handed the task directly,
+      # `do --app fountain ecto.create` drops the narrowing and runs at the
+      # umbrella root, and `do --app fountain run priv/repo/seeds.exs` fails
+      # outright ("No such file"), because the relative path resolves against
+      # the root. `mix cmd` IS recursive, so the --app narrows *it* and the
+      # command runs inside apps/fountain, which is what `cmd --app` did.
       "ecto.setup": [
-        "cmd --app fountain mix ecto.create",
+        "do --app fountain cmd mix ecto.create",
         "ecto.migrate",
-        "cmd --app fountain mix run priv/repo/seeds.exs"
+        "do --app fountain cmd mix run priv/repo/seeds.exs"
       ],
-      "ecto.reset": ["cmd --app fountain mix ecto.drop", "ecto.setup"],
+      "ecto.reset": ["do --app fountain cmd mix ecto.drop", "ecto.setup"],
       # Migrating from the umbrella root has to go through apps/fountain, or the
       # extension migration paths are silently dropped (ADR 0043, #1506).
       #


### PR DESCRIPTION
Closes #1526. Part of #1539.

Every umbrella-root alias that shells into `apps/fountain` printed

```
warning: the --app in mix cmd is deprecated. Use mix do --app instead.
```

with six lines of stack trace under it, **five times per `mix ecto.setup`** — so on every CI database step and every workstation bootstrap.

## Not the literal replacement the warning suggests

The issue proposed `cmd --app fountain mix X` → `do --app fountain mix X`. That does not hold, and the reason is worth writing down: **`mix do --app` narrows a task only when that task is `@recursive`**, and none of `ecto.create`, `ecto.drop`, `ecto.migrate`, `ecto.rollback` or `run` is one. `Mix.Task.run_task/5` takes its `apps && not recursive` branch and runs the task at the umbrella root with the narrowing silently dropped.

Measured, not assumed:

| Form | What happens |
|---|---|
| `do --app fountain ecto.create` | Runs at the umbrella root. Happens to work — `config/config.exs` names `ecto_repos`, and the root alias already appends every `--migrations-path`. |
| `do --app fountain run priv/repo/seeds.exs` | `** (Mix) No such file: priv/repo/seeds.exs`. The relative path resolves against the root, and `mix ecto.setup` exits 1. |

`mix cmd` **is** `@recursive true`, so `do --app fountain cmd mix X` narrows the recursion to that one app and runs the command inside `apps/fountain` — exactly what `cmd --app fountain mix X` did. Where a task runs does not change; only the spelling of the flag. That matters here because the comments above these aliases turn on the child's `ecto.migrate` alias firing (ADR 0043, #1506), and the root-level form would have quietly taken that away.

The trap is now a comment in `mix.exs`, so the next reader does not "simplify" it back.

## Verified against a database built from nothing

A scratch database, `mix ecto.reset` on each side:

```
before: 5 deprecation warnings, 101 migrations, 44 tables
after:  0 deprecation warnings, 101 migrations, 44 tables
```

`buzz_identities` and `extension_fixture_rows` are both present afterwards, so the extension migration paths still reach the migrator.

Every entrance exercised: `mix setup`, `mix ecto.setup`, `mix ecto.reset`, `mix ecto.migrate` twice (the second reports "Migrations already up"), and `mix ecto.rollback --step 2` — which took 101 → 99, with `mix ecto.migrate` restoring 101. Trailing arguments pass through the new form unchanged, which is what the issue asked to confirm before switching.

`apps/fountain/test/fountain/extension_composition_test.exs`: 24 tests, 0 failures, run **against that freshly-built database** rather than a workstation one that was already migrated — the strong form of its assertion. `mix format --check-formatted` and `mix credo --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DBK3uwQuJozQHKmEuBrvrP