### PR TITLE
fix(buzz): drain the registry, not only the supervisor, at teardown (#1533)

### DIFF
--- a/apps/fountain_buzz/test/fountain_buzz/manager_test.exs
+++ b/apps/fountain_buzz/test/fountain_buzz/manager_test.exs
@@ -12,6 +12,13 @@ defmodule FountainBuzz.ManagerTest do
   alias Fountain.Repo
 
   setup do
+    # This module asserts on a count taken across the whole cluster, so it
+    # drains before it measures rather than trusting that the previous module's
+    # teardown did (#1533). `stop_all_harnesses!/1` settles the registry as
+    # well as the supervisor, which is what makes the baseline below a fixed 0
+    # instead of a number that can still move.
+    FountainBuzz.TestSupport.stop_all_harnesses!()
+
     dir = Fountain.TmpDir.mkdir!("buzz-mgr")
     fake = Path.join(dir, "buzz-acp")
     FountainBuzz.TestSupport.write_fake_acp!(fake)
@@ -57,7 +64,13 @@ defmodule FountainBuzz.ManagerTest do
   end
 
   test "running_count counts registered harnesses cluster-wide", %{fake: fake} do
+    # Asserted, not merely taken: the drain in `setup` leaves the registry
+    # empty, so a non-zero baseline here means a neighbouring module leaked a
+    # harness. Compensating for it silently is what let #1533 read as a flake
+    # in this file rather than as a fault in the module that leaked.
     baseline = Manager.running_count()
+    assert baseline == 0
+
     first = insert_buzz_identity()
     second = insert_buzz_identity()
 
@@ -73,6 +86,21 @@ defmodule FountainBuzz.ManagerTest do
     Manager.await_stopped(first.id)
     assert Manager.running_count() == baseline + 1
     Manager.stop_harness(second.id)
+  end
+
+  # The contract #1533 needed and did not have: when the drain returns, the
+  # registry is empty too. Asserted without `await_stopped/2`, on purpose —
+  # the point is that the *drain* did the waiting, so the next module's
+  # baseline is trustworthy the instant teardown returns.
+  test "stop_all_harnesses! drains the registry, not only the supervisor", %{fake: fake} do
+    identity = insert_buzz_identity()
+    {:ok, _pid} = Manager.start_harness(identity, launch_opts(fake))
+    assert Manager.running_count() == 1
+
+    FountainBuzz.TestSupport.stop_all_harnesses!()
+
+    assert Manager.running_count() == 0
+    assert Horde.DynamicSupervisor.which_children(FountainBuzz.Supervisor) == []
   end
 
   test "start_harness is idempotent and mints no second credential", %{fake: fake} do

--- a/apps/fountain_buzz/test/support/buzz_test_support.ex
+++ b/apps/fountain_buzz/test/support/buzz_test_support.ex
@@ -21,6 +21,8 @@ defmodule FountainBuzz.TestSupport do
     path
   end
 
+  alias FountainBuzz.Manager
+
   @supervisor FountainBuzz.Supervisor
   @drain_tries 500
 
@@ -60,11 +62,42 @@ defmodule FountainBuzz.TestSupport do
 
     case Horde.DynamicSupervisor.which_children(@supervisor) do
       [] ->
-        :ok
+        await_registry_drained!(tries)
 
       _children ->
         Process.sleep(10)
         stop_all_harnesses!(tries - 1)
+    end
+  end
+
+  # An empty supervisor is not the whole drain. The registry learns of an exit
+  # **by monitor**, so it keeps counting a harness for a moment after
+  # `terminate_child/2` has returned — `Manager.await_stopped/2` documents the
+  # same lag, and #1544 is what it looks like inside one test.
+  #
+  # Across modules it looks like #1533 instead: teardown returns, the next
+  # module reads `running_count/0` as its baseline, and the entry this drain
+  # already killed disappears afterwards, moving the count under a test that
+  # took the number as fixed. So teardown means "nothing is registered", not
+  # "nothing is supervised".
+  defp await_registry_drained!(0) do
+    raise """
+    BuzzRegistry still counts #{Manager.running_count()} harness(es) after \
+    BuzzSupervisor drained.
+
+    The supervisor is empty, so these are registry entries for processes that \
+    are already down, and something is stopping Horde from reaping them. \
+    Leaving them would hand the next module a `running_count/0` baseline that \
+    changes under it (#1533).
+    """
+  end
+
+  defp await_registry_drained!(tries) do
+    if Manager.running_count() == 0 do
+      :ok
+    else
+      Process.sleep(10)
+      await_registry_drained!(tries - 1)
     end
   end
 end


### PR DESCRIPTION
Closes #1533. Part of #1539.

`FountainBuzz.ManagerTest "running_count counts registered harnesses cluster-wide"` compensates for a cluster-wide supervisor by reading a baseline first. #1544 fixed one race *inside* the test. The baseline itself was still not safe, one level further out.

## The fault is in teardown, not in the assertion

`TestSupport.stop_all_harnesses!/1` drained the **supervisor**: terminate every child, wait for `which_children/1` to come back empty. `running_count/0` reads the **registry**, which learns of an exit by monitor and keeps counting a harness after `terminate_child/2` has returned — the lag `Manager.await_stopped/2` already documents.

So teardown could return with the registry still holding entries for dead processes. The next module read `running_count/0` as its baseline, those entries were reaped a moment later, and the count moved underneath a test that had taken the number as fixed. That is this issue — and it is why it presents as *"another module's harness"* without any other module doing anything wrong.

- The drain now waits for both, so teardown means "nothing is registered", not "nothing is supervised". If it never settles it raises with the registry count, rather than leaving the next module to discover it.
- `ManagerTest` takes its own drain in `setup` instead of trusting its predecessor's, and asserts `baseline == 0` instead of compensating for whatever it finds. A genuine leak from a neighbour now fails by name, rather than as arithmetic that happens not to add up.

## Reproduced, which #1544 could not do

The new test asserts that once `stop_all_harnesses!/1` returns the registry is empty — deliberately with no `await_stopped/2`, because the drain is what should have waited. Run 25 times against each drain:

| Drain | Failures |
|---|---|
| old (registry wait removed) | **2 / 25** |
| new | **0 / 25** |

`apps/fountain_buzz`: 143 tests, 0 failures over five consecutive runs. `mix format --check-formatted` and `mix credo --strict` clean.

## One thing this is not

One of those runs failed on something else: a `DBConnection.ConnectionError` pool checkout in `AgentControllerTest` — that is #1524, the last open item on #1539. Replaying its seed (328003) found it on neither side of this change, so it is timing rather than ordering. Notable for that issue: it reproduced against `apps/fountain_buzz` alone (143 tests), not only under the full ~4,200-test suite its hypothesis assumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DBK3uwQuJozQHKmEuBrvrP