### PR TITLE
fix(test): the sandbox connection is a queue, so let it queue (#1524, #1568)

### DIFF
--- a/apps/fountain/test/fountain/sandbox_queue_config_test.exs
+++ b/apps/fountain/test/fountain/sandbox_queue_config_test.exs
@@ -1,0 +1,44 @@
+defmodule Fountain.SandboxQueueConfigTest do
+  @moduledoc """
+  The queue settings that keep the sandbox's one connection from dropping
+  waiters (#1524, #1568).
+
+  Under `Ecto.Adapters.SQL.Sandbox` a test has a single connection, shared by
+  every process it fans work out to — including Ecto's own parallel preloader,
+  which nobody wrote and which is in the stack of most of these failures. Those
+  processes queue rather than run in parallel, and at DBConnection's defaults a
+  loaded run drops them with a `ConnectionError` that names the test's own
+  connection. Neither the pool size nor the code under test has anything to do
+  with it, which is why both issues cost an investigation before they cost a
+  fix.
+
+  Asserted here rather than left as a comment in `config/test.exs` because the
+  cost of losing these two lines is not a failing test: it is the same
+  intermittent red, rediscovered from scratch.
+  """
+
+  use ExUnit.Case, async: true
+
+  @config Application.compile_env(:fountain, Fountain.Repo)
+
+  # The real failures waited 121-263 ms. A waiter is dropped only once it has
+  # waited past `queue_target` and the queue has been slow for a whole
+  # `queue_interval`, so these leave roughly an order of magnitude over what
+  # was observed.
+  #
+  # `is_integer/1` first, and not for tidiness: a missing key reads as `nil`,
+  # and `nil >= 200` is `true` under Elixir's term ordering, so the obvious
+  # form of this assertion passes on exactly the config it exists to reject.
+  test "the sandbox connection tolerates a queue" do
+    assert is_integer(@config[:queue_target]) and @config[:queue_target] >= 200
+    assert is_integer(@config[:queue_interval]) and @config[:queue_interval] >= 5_000
+  end
+
+  # CLAUDE.md's rule, and the reason it is not in tension with the two above:
+  # the pool is what concurrent *tests* draw from, the queue settings are about
+  # contention inside one test on one connection.
+  test "the pool still holds 20" do
+    assert @config[:pool_size] == 20
+    assert @config[:pool] == Ecto.Adapters.SQL.Sandbox
+  end
+end

--- a/config/test.exs
+++ b/config/test.exs
@@ -4,7 +4,28 @@ config :fountain, Fountain.Repo,
   url:
     System.get_env("DATABASE_URL", "postgres://postgres:postgres@localhost:5432/fountain_test"),
   pool: Ecto.Adapters.SQL.Sandbox,
-  pool_size: 20
+  pool_size: 20,
+  # The sandbox gives a test *one* connection, which every process the test
+  # fans work out to shares: `Task.async_stream` in a test body, a supervised
+  # task under `Fountain.TaskSupervisor`, and Ecto's own parallel preloader,
+  # which fans out over `Task.async_stream` whenever two or more associations
+  # are still to fetch. Those are not parallel under the sandbox — they are a
+  # queue on one connection, and four 200 ms transactions measured 814 ms.
+  #
+  # DBConnection then drops a waiter once the queue has been slow for a whole
+  # `queue_interval`, and the 50 ms / 1 s defaults are sized for a pool with
+  # spare connections rather than for a queue that is a queue by construction.
+  # On a loaded workstation that dropped real tests: #1524 (Ecto's preloader,
+  # waits of 121-160 ms) and #1568 (the credit ledger's concurrent-post test,
+  # 263 ms), neither of them a defect in the code under test.
+  #
+  # 200 ms / 5 s tolerates about 5 s of continuous backlog on one connection,
+  # against the ~250 ms the real failures waited. A genuinely stuck connection
+  # still surfaces — as the test's own timeout, with the stack of whatever is
+  # holding it, which says more than a dropped checkout does. Measured with a
+  # 40-task probe: 30 of 40 dropped at the defaults, 0 of 40 here.
+  queue_target: 200,
+  queue_interval: 5_000
 
 config :fountain, FountainWeb.Endpoint,
   http: [ip: {127, 0, 0, 1}, port: 4002],

--- a/ee/test/fountain/credits_test.exs
+++ b/ee/test/fountain/credits_test.exs
@@ -124,22 +124,34 @@ defmodule Fountain.CreditsTest do
       assert entry.resource_id == "2026-08"
     end
 
-    test "concurrent posts of one key move the balance once" do
+    # Two posters, not the eight this used to fan out to. The eight were not
+    # racing: under the SQL sandbox every task borrows the *test's* one
+    # connection, so eight `insert_and_move/3` transactions run one after
+    # another on a single Postgres backend (measured: one backend pid, and
+    # four 200 ms transactions taking 814 ms). What eight bought was eight
+    # serialized transactions queued on that connection, which is what DBConnection
+    # dropped on a loaded full-suite run (#1568) — a failure with no bearing
+    # on the property below.
+    #
+    # So this asserts the *contract* — one key posts one row, the rest report
+    # `:duplicate`, and the balance moves once — and cannot assert the
+    # simultaneity. The unique index is what makes that safe in production,
+    # and `insert_and_move/3` detects the duplicate after attempting the
+    # insert rather than by a lookup first precisely because two posters can
+    # be simultaneous there.
+    test "posting one key from several processes moves the balance once" do
       user = insert_empty_user()
 
       results =
-        1..8
+        1..2
         |> Task.async_stream(
-          fn _ ->
-            Ecto.Adapters.SQL.Sandbox.allow(Repo, self(), self())
-            Credits.grant(user.id, 100, "purchase", idempotency_key: "race")
-          end,
-          max_concurrency: 8
+          fn _ -> Credits.grant(user.id, 100, "purchase", idempotency_key: "race") end,
+          max_concurrency: 2
         )
         |> Enum.map(fn {:ok, r} -> r end)
 
       assert Enum.count(results, &match?({:ok, %LedgerEntry{}}, &1)) == 1
-      assert Enum.count(results, &match?({:ok, :duplicate, _}, &1)) == 7
+      assert Enum.count(results, &match?({:ok, :duplicate, _}, &1)) == 1
       assert Credits.balance(reload(user)) == 100
     end
   end


### PR DESCRIPTION
Closes #1524. Closes #1568.

Two flakes, one mechanism, and it is neither the pool nor the code under test.

## What is actually happening

`Ecto.Adapters.SQL.Sandbox` gives a test **one** connection, and every process the test fans work out to borrows it — `Task.async_stream` in a test body, a supervised task under `Fountain.TaskSupervisor`, and (in the stack of most of these failures, though nobody wrote it) Ecto's own preloader, which fans out whenever two or more associations are still to fetch. Those processes do not run in parallel. They queue on one connection.

Measured on #1568's own shape:

| Probe | Result |
|---|---|
| eight fanned-out tasks, `SELECT pg_backend_pid()` | one backend pid |
| four "concurrent" 200 ms transactions | 814 ms |

DBConnection drops a waiter once the queue has been slow for a whole `queue_interval`, and the 50 ms / 1 s defaults assume a pool with spare connections rather than a queue that is a queue by construction. A 40-task probe reproduces both issues' exact error text on demand:

| `queue_target` / `queue_interval` | dropped |
|---|---|
| 50 ms / 1 s (defaults) | **30 of 40** |
| 200 ms / 5 s (this PR) | **0 of 40** |

The real failures waited 121-263 ms, so 200 ms / 5 s leaves about an order of magnitude of headroom. A connection that is genuinely stuck still surfaces — as the test's own timeout, carrying the stack of whatever holds it, which says more than a dropped checkout does.

## Two corrections to what the issues assumed

- **#1568's stated cause was wrong.** It read the failure as eight connections holding 40% of a 20-connection pool while seven waited on one `SELECT ... FOR UPDATE`. There is one connection and no row-lock contention — the transactions are serial, so each takes the lock uncontended. `pool_size` is not the lever here, and CLAUDE.md's floor of 20 is not in tension with this.
- **That test's concurrency was theatre.** Serialized posts cannot exercise the race `insert_and_move/3` exists to survive (a lookup-first implementation would pass it too). The test now says what it asserts — one key posts one row, the rest report `:duplicate`, the balance moves once — and fans out to two rather than eight, since the other six bought nothing but queue. The simultaneity is guarded by the unique index, in production, where the posters really are simultaneous.

## Verification

- The probe numbers above, and `is_integer/1` in the new guard: a missing key reads as `nil`, and `nil >= 200` is `true` under term ordering, so the first version of that assertion passed on exactly the config it exists to reject. Stripping the two settings now fails it.
- Full local suite on this branch: **4,276 tests, 5 failures**, plus `fountain_buzz` 143/0 and `fountain_support` 33/0. All five failures are `FountainWeb.Marketing*Test` and reproduce unchanged with `main`'s `config/test.exs`: they assert `-core` behaviour and only pass when run from `apps/fountain`, which is what CI's partition script does and what the umbrella-root `mix test` in CLAUDE.md's Quick start does not. Pre-existing, unrelated, filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DBK3uwQuJozQHKmEuBrvrP