### PR TITLE
fix(test): the -core marketing assertions run only in a -core VM (#1574)

### DIFF
--- a/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
@@ -228,9 +228,16 @@ defmodule FountainWeb.MarketingControllerTest do
 
   describe "marketing that needs an extension (#1525)" do
     # `Fountain.Marketing.available?/1` reads `config :fountain, :extensions`,
-    # and this file runs from apps/fountain, which depends on no extension.
-    # So these assertions describe a `-core` image, and the bundled shape is
+    # so these assertions describe a `-core` image, and the bundled shape is
     # asserted in apps/fountain_buzz/test/fountain_buzz/marketing_test.exs.
+    #
+    # Which of the two this VM is depends on the invocation rather than on the
+    # code: from apps/fountain, which is what CI's partition script runs, no
+    # extension is on the code path; from the umbrella root, `:fountain_buzz`
+    # is, and these correctly-written assertions describe a distribution this
+    # VM is not (#1574). The tag is what keeps them out of that run —
+    # test_helper.exs excludes it when the extension is really installed.
+    @describetag :core_distribution
 
     test "the catalogue still holds cards that need one" do
       # Guard the guard. Every assertion below is a filter removing something,
@@ -286,11 +293,12 @@ defmodule FountainWeb.MarketingControllerTest do
   end
 
   describe "GET /buzz-launch, on a distribution without the extension" do
-    # This file runs from apps/fountain, which depends on no extension, so
-    # `Fountain.Extensions.installed?(:buzz)` is false here exactly as it is in
-    # a `-core` image. The page's own content tests moved to
-    # apps/fountain_buzz/test/fountain_buzz/marketing_test.exs, which is the
-    # suite that has the extension installed (#1525).
+    # Run from apps/fountain, `Fountain.Extensions.installed?(:buzz)` is false
+    # exactly as it is in a `-core` image; run from the umbrella root it is
+    # true, so this is tagged and excluded there (#1574). The page's own
+    # content tests moved to apps/fountain_buzz/test/fountain_buzz/marketing_test.exs,
+    # which is the suite that has the extension installed (#1525).
+    @describetag :core_distribution
 
     test "the page is not served", %{conn: conn} do
       # A plain 404, not a raised NoRouteError reaching the test: the endpoint

--- a/apps/fountain/test/fountain_web/controllers/marketing_instance_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_instance_test.exs
@@ -126,16 +126,19 @@ defmodule FountainWeb.MarketingInstanceTest do
   end
 
   describe "GET /buzz-launch where the deployment is not the marketing site" do
-    # And has no Buzz extension, which is this suite's distribution: it runs
-    # from apps/fountain, where nothing installs one. The route gate comes
-    # before the marketing-site branch (#1525), so the answer is 404 either
-    # way and the redirect below never runs.
+    # And has no Buzz extension, which is this suite's distribution when it is
+    # run the way CI runs it: from apps/fountain, where nothing installs one.
+    # From the umbrella root one is installed, hence the tag (#1574). The route
+    # gate comes before the marketing-site branch (#1525), so the answer is 404
+    # either way and the redirect below never runs.
     #
     # The redirect's own target is why the gate has to come first. It points
     # at /docs/integrations/buzz, a page that moved to the extension in #1510
     # — a link guard that scrapes `href=` out of a rendered body cannot see a
     # redirect, so this was a dead end nothing caught. The bundled behaviour
     # is asserted in apps/fountain_buzz/test/fountain_buzz/marketing_test.exs.
+    @describetag :core_distribution
+
     test "is not served at all, whatever kind of deployment it is", %{conn: conn} do
       Application.put_env(:fountain, :marketing_site, false)
       assert conn |> get(~p"/buzz-launch") |> response(404)

--- a/apps/fountain/test/test_helper.exs
+++ b/apps/fountain/test/test_helper.exs
@@ -1,5 +1,25 @@
 ExUnit.start()
 
+# ─── The `-core` distribution's own assertions (#1574) ───────────────────────
+#
+# A handful of tests assert what an image *without* an extension serves: no
+# /buzz-launch, no Nostr card, no fountain-buzz row. Whether this VM is that
+# image is decided by the invocation, not by the code. `config/runtime.exs`
+# names each extension only where it loads, so `mix test` from apps/fountain —
+# what scripts/test-partition.sh runs, and what CI is therefore green on —
+# installs none, while `mix test` at the umbrella root, which CLAUDE.md's Quick
+# start gives, has :fountain_buzz on the code path and installs it. Those five
+# tests then described a distribution this VM is not, and the documented local
+# command was red on a green `main`.
+#
+# Excluded rather than duplicated: the bundled side is asserted in
+# apps/fountain_buzz/test/fountain_buzz/marketing_test.exs, which is the suite
+# that has the extension. Appended to whatever is already excluded so a
+# `--exclude` on the command line survives.
+if Fountain.Extensions.installed?(:buzz) do
+  ExUnit.configure(exclude: ExUnit.configuration()[:exclude] ++ [:core_distribution])
+end
+
 # The managoat_runner library has no config of its own and no default host on
 # purpose; its own test helper names Managoat.Runner.Host.Local. While it was
 # an umbrella app, `mix test` at the root ran its suite in this VM first and


### PR DESCRIPTION
Closes #1574.

`mix test` at the umbrella root — the command CLAUDE.md's Quick start gives — is red on `main` at `8e208e1c`, five failures, and has been since #1525's tests landed. CI never sees it: `scripts/test-partition.sh` runs from `apps/fountain`.

## Why it fails there and not in CI

The five tests assert what a `-core` image serves, and they are right about it. Which distribution the VM *is* depends on the invocation:

| Invocation | `installed?(:buzz)` | Result |
|---|---|---|
| `mix test` in `apps/fountain` (CI) | false | assertions hold |
| `mix test` at the umbrella root | **true** | `/buzz-launch` is served, the Nostr card renders, five reds |

`config/runtime.exs` names each extension only where it loads — deliberately, so a partition run does not fail `Fountain.Extensions.validate!/0`.

## The change

The three describes carry `@describetag :core_distribution`, and `apps/fountain/test/test_helper.exs` excludes that tag when the extension is really installed — asking the VM rather than the working directory. The bundled side is already asserted in `apps/fountain_buzz/test/fountain_buzz/marketing_test.exs`, so this excludes rather than duplicates. The exclusion appends to the existing `:exclude` list so a `--exclude` on the command line survives.

## Verification

```
from apps/fountain (what CI runs):  97 tests, 0 failures
from the umbrella root:             90 tests, 0 failures (7 excluded)
```

Full umbrella-root suite on this branch: `4,267 tests, 3 failures (7 excluded)`, and the three are unrelated pre-existing flakes, all reproduced and accounted for — two are the sandbox-connection drops fixed in #1573 (this branch does not carry that fix), and the third is #1575, filed from this run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DBK3uwQuJozQHKmEuBrvrP