### PR TITLE
fix(test): the rate-limit window test no longer races its own window (#1575)

### DIFF
--- a/apps/fountain/test/fountain_web/plugs/rate_limit_test.exs
+++ b/apps/fountain/test/fountain_web/plugs/rate_limit_test.exs
@@ -74,16 +74,26 @@ defmodule FountainWeb.Plugs.RateLimitTest do
     end
 
     test "resets the window after the window_ms has elapsed" do
-      # Use a very short window (1 ms) so we can expire it immediately.
-      opts = %{bucket: unique_bucket(), max: 1, window_ms: 1}
+      # A full-length window, and the row is aged rather than slept through.
+      #
+      # This used to run a 1 ms window so a 5 ms sleep could expire it, which
+      # made that millisecond do two contradictory jobs: outlast the two bumps
+      # below, and be short enough to sleep past. On a loaded run the scheduler
+      # put a millisecond between the bumps, the second one opened a *new*
+      # window and answered `:ok`, and the test failed on its own setup line
+      # having never reached the reset it is about (#1575).
+      opts = %{bucket: unique_bucket(), max: 1, window_ms: 60_000}
       key = {opts.bucket, self()}
 
-      RateLimit.bump(key, opts)
+      assert :ok = RateLimit.bump(key, opts)
       # Exhaust the single slot
       assert {:limited, _} = RateLimit.bump(key, opts)
 
-      # Wait long enough for the window to expire
-      Process.sleep(5)
+      # Age the window past the cutoff. The table is public and the row shape
+      # is the one `evict_expired/1` selects on, so this drives the same
+      # `started_at < cutoff` branch a wall-clock wait would, with no clock.
+      [{^key, started_at, count}] = :ets.lookup(RateLimit.table(), key)
+      :ets.insert(RateLimit.table(), {key, started_at - opts.window_ms - 1, count})
 
       # New window — should be :ok again
       assert :ok = RateLimit.bump(key, opts)


### PR DESCRIPTION
Closes #1575.

Found on a full local run while burning down #1524/#1568. The test failed on its own setup line, not on what it tests:

```
3) test bump/2 resets the window after the window_ms has elapsed
   code:  assert {:limited, _} = RateLimit.bump(key, opts)
   left:  {:limited, _}
   right: :ok
```

## One millisecond, two contradictory jobs

`window_ms: 1` was picked so a 5 ms sleep could expire the window. That same millisecond also had to outlast the two `bump/2` calls above the sleep — and `bump/2` reads `System.system_time(:millisecond)` itself. When the scheduler put a millisecond between them, the second bump opened a *new* window, returned `:ok`, and the test failed having never reached the reset. Nothing about the limiter was wrong; the window really had reset.

`Process.sleep(2)` between the two bumps reproduces it every time, with exactly that left/right.

## The change

The window length now does one job. A 60 s window makes exhausting the single slot unraceable, and the row is aged past the cutoff instead of slept through:

```elixir
[{^key, started_at, count}] = :ets.lookup(RateLimit.table(), key)
:ets.insert(RateLimit.table(), {key, started_at - opts.window_ms - 1, count})
```

Same `started_at < cutoff` branch, no clock in the test, no `Process.sleep/1`. The table is public and this is the `{key, started_at, count}` shape `evict_expired/1` already selects on.

## Verification

16 tests, 0 failures. Neutering the aging step makes the final assertion read `{:limited, 60}`, so the new step is what the test stands on rather than an incidental pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DBK3uwQuJozQHKmEuBrvrP