### PR TITLE
fix(test): pin the clock the dashboard turn-hours tile is read against (#1586)

### DIFF
--- a/apps/fountain/test/fountain_web/live/dashboard_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/dashboard_live_test.exs
@@ -13,6 +13,15 @@ defmodule FountainWeb.DashboardLiveTest do
 
   defp max_dt(a, b), do: if(DateTime.compare(a, b) == :gt, do: a, else: b)
 
+  # This module is `async: false`, so the pin is not visible to another test
+  # running beside it; restored either way.
+  defp pin_usage_clock(%DateTime{} = at) do
+    key = Fountain.Billing.SandboxUsage
+    original = Application.get_env(:fountain, key, [])
+    Application.put_env(:fountain, key, Keyword.put(original, :now, at))
+    on_exit(fn -> Application.put_env(:fountain, key, original) end)
+  end
+
   setup %{conn: conn} do
     user = insert_verified_user()
 
@@ -123,6 +132,19 @@ defmodule FountainWeb.DashboardLiveTest do
   end
 
   describe "turn hours" do
+    # Every usage window is clipped at *now* (`SandboxUsage.attribution/3`), so
+    # ten hours seeded at the month's start have not happened yet during the
+    # month's first ten hours, and the tile reads less than the two this test
+    # asserts. The finance panel escaped that by reading the closed previous
+    # month (#1317); the dashboard has no month picker, so the clock is what
+    # moves instead (#1586). Pinned an hour past the seeded data, which is what
+    # every other hour of the month already looks like.
+    setup do
+      {period_start, _} = Fountain.Billing.current_month_range()
+      pin_usage_clock(DateTime.add(period_start, 11 * 3600, :second))
+      :ok
+    end
+
     test "the tile reports turn time, not the wall-clock the sandbox was awake", %{
       conn: conn,
       user: user

--- a/ee/lib/fountain/billing/sandbox_usage.ex
+++ b/ee/lib/fountain/billing/sandbox_usage.ex
@@ -142,7 +142,9 @@ defmodule Fountain.Billing.SandboxUsage do
   Active seconds per `{user_id, provider}` over `[period_start, period_end)`.
 
   Pass `user_id: id` to scope to a single tenant — the same computation, one
-  tenant's rows. `:now` pins the clock (tests).
+  tenant's rows. `:now` pins the clock (tests); a test driving a surface end to
+  end, with nowhere to pass an option, pins the same clock with
+  `Application.put_env(:fountain, Fountain.Billing.SandboxUsage, now: dt)`.
 
   A still-running sandbox accrues only up to *now*, never to a `period_end`
   that has not happened yet: asked about the current month, this reports what
@@ -154,7 +156,7 @@ defmodule Fountain.Billing.SandboxUsage do
   @spec attribution(DateTime.t(), DateTime.t(), keyword()) :: [row()]
   def attribution(%DateTime{} = period_start, %DateTime{} = period_end, opts \\ []) do
     sandboxes = overlapping_sandboxes(period_start, period_end, opts)
-    ceiling = earliest(period_end, Keyword.get(opts, :now) || DateTime.utc_now())
+    ceiling = earliest(period_end, Keyword.get(opts, :now) || now())
 
     overlapping =
       sandboxes
@@ -379,6 +381,20 @@ defmodule Fountain.Billing.SandboxUsage do
     stop = earliest(to, ceiling)
 
     stop |> DateTime.diff(start, :second) |> max(0)
+  end
+
+  # The clock every window is clipped against. `:now` on the call is the way to
+  # pin it; this is for a test that drives a surface end to end and has nowhere
+  # to pass one. The dashboard's turn-hours tile is that case: the console has
+  # no month picker, so the tile can only be read against the running month,
+  # and a two-hour turn seeded at the month's start does not exist yet during
+  # the month's first two hours (#1586). Unset outside tests, so this is one
+  # application-env read per attribution pass.
+  defp now do
+    case Application.get_env(:fountain, __MODULE__, [])[:now] do
+      %DateTime{} = pinned -> pinned
+      nil -> DateTime.utc_now()
+    end
   end
 
   defp earliest(a, b), do: if(DateTime.compare(a, b) == :gt, do: b, else: a)


### PR DESCRIPTION
Closes #1586.

`FountainWeb.DashboardLiveTest`'s turn-hours test seeds ten hours of sandbox time and a two-hour turn forward from the month's start, then asserts the tile reads `2.0`. `SandboxUsage.attribution/3` clips every window at *now*, so during the month's first two hours that turn has not happened yet and the tile reads less. It took partition 1 red at 00:32 UTC on 2026-09-01 and was green on a re-run an hour later.

The finance panel escaped the same clip by seeding the closed previous month and opening the page with `?months_ago=1` (#1317). The console has no month picker, so the dashboard tile can only be read against the running month — the clock is what has to move instead.

## The change

- `attribution/3` already documents `:now` as the way to pin its clock. Its default now reads `Application.get_env(:fountain, Fountain.Billing.SandboxUsage)[:now]` before falling back to `DateTime.utc_now()`, which is a seam a test driving a LiveView end to end can reach. Unset outside tests, so it is one application-env read per attribution pass.
- The `turn hours` describe pins it eleven hours past the seeded data and restores it in `on_exit`. The module is already `async: false`.

## Verification

Moving the pin proves the test still guards what it claims:

| pin | result |
|---|---|
| month start + 30 min (what CI hit) | `assert html =~ "2.0"` fails |
| month start + 11 h | 13 tests, 0 failures |

`dashboard_live_test.exs` plus `billing_test.exs`, `billing_turn_hours_test.exs`, `billing_sandbox_usage_test.exs` and `usage_metering_test.exs`: 104 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DBK3uwQuJozQHKmEuBrvrP