### PR TITLE
fix(buzz): await_stopped waits on the row the count reads (#1590)

### DIFF
--- a/apps/fountain_buzz/lib/fountain_buzz/manager.ex
+++ b/apps/fountain_buzz/lib/fountain_buzz/manager.ex
@@ -167,6 +167,22 @@ defmodule FountainBuzz.Manager do
   Returns `:ok` whether or not the entry went, deliberately. The caller's own
   assertion is the real check and gives the better failure message; a raise
   from in here would report the helper instead of the thing under test.
+
+  Waits on the registry *row*, not on `running?/1`. The two are different
+  clocks: `Horde.Registry.lookup/2` checks the pid is alive before handing a
+  row back, so `whereis/1` and `running?/1` report a harness gone the moment
+  its process dies, while `running_count/0` is `:ets.info(size)` over the same
+  table and keeps counting the row until Horde's monitor reaps it. Waiting on
+  the first and then reading the second is a wait that is over before the
+  number it waits for can move — which is why #1544's fix left
+  `ManagerTest "running_count counts registered harnesses cluster-wide"`
+  failing on CI three more times. The lag is a microsecond on an idle
+  laptop and as long as the registry takes to be scheduled on a loaded one.
+
+  `running_count/0` deliberately keeps counting the unreaped row: it is what
+  teardown drains against (`stop_all_harnesses!/1`), and a count that dropped
+  with the pid would let a module hand its successor a baseline still about to
+  move (#1533).
   """
   @spec await_stopped(String.t(), non_neg_integer()) :: :ok
   def await_stopped(identity_id, tries \\ 50)
@@ -174,12 +190,20 @@ defmodule FountainBuzz.Manager do
   def await_stopped(_identity_id, 0), do: :ok
 
   def await_stopped(identity_id, tries) do
-    if running?(identity_id) do
+    if registered?(identity_id) do
       Process.sleep(20)
       await_stopped(identity_id, tries - 1)
     else
       :ok
     end
+  end
+
+  # Whether the registry still holds a row for this key, alive or not — the
+  # view `running_count/0` counts, as opposed to the liveness-filtered one
+  # `whereis/1` reads.
+  defp registered?(identity_id) do
+    Horde.Registry.select(@registry, [{{:"$1", :_, :_}, [{:==, :"$1", identity_id}], [true]}]) !=
+      []
   end
 
   defp start_child(%Identity{} = identity, opts) do

--- a/apps/fountain_buzz/test/fountain_buzz/manager_test.exs
+++ b/apps/fountain_buzz/test/fountain_buzz/manager_test.exs
@@ -88,6 +88,41 @@ defmodule FountainBuzz.ManagerTest do
     Manager.stop_harness(second.id)
   end
 
+  # The wait #1544 needed and did not have. `Horde.Registry.lookup/2` checks
+  # the pid is alive before handing a row back, so `whereis/1` and `running?/1`
+  # report a harness gone the moment its process dies; `running_count/0` is
+  # `:ets.info(size)` over the same table and keeps counting the row until
+  # Horde's monitor reaps it. #1544 waited on the first and asserted on the
+  # second, so the wait was over before the number could move — a microsecond
+  # of daylight here, and three more red CI partitions in the week after the
+  # fix.
+  #
+  # Suspending the registry holds the two views apart for as long as this test
+  # needs: the pid is gone, the row cannot be reaped, so a wait on the row
+  # spends its tries and a wait on the pid returns at once. Reverting
+  # `await_stopped/2` to `running?/1` makes this 0 ms.
+  test "await_stopped waits for the row the count reads, not for the pid", %{fake: fake} do
+    identity = insert_buzz_identity()
+    {:ok, pid} = Manager.start_harness(identity, launch_opts(fake))
+
+    :sys.suspend(FountainBuzz.Registry)
+
+    try do
+      ref = Process.monitor(pid)
+      :ok = Manager.stop_harness(identity.id)
+      assert_receive {:DOWN, ^ref, :process, ^pid, _}, 5_000
+
+      # The two clocks, held apart.
+      assert Manager.whereis(identity.id) == nil
+      assert Manager.running_count() == 1
+
+      {elapsed_us, :ok} = :timer.tc(fn -> Manager.await_stopped(identity.id, 10) end)
+      assert elapsed_us >= 100_000
+    after
+      :sys.resume(FountainBuzz.Registry)
+    end
+  end
+
   # The contract #1533 needed and did not have: when the drain returns, the
   # registry is empty too. Asserted without `await_stopped/2`, on purpose —
   # the point is that the *drain* did the waiting, so the next module's


### PR DESCRIPTION
Closes #1590.

`FountainBuzz.ManagerTest "running_count counts registered harnesses cluster-wide"` was still failing after #1544 and #1567 — CI partitions 1 and 5, three times this week, green on every re-run, and once in ten full local suite runs on `main` at 2a12b433.

## The two clocks

`Horde.Registry` keeps two views of one ETS table:

| read | what it does | when a stopped harness disappears from it |
|---|---|---|
| `lookup/2` → `Manager.whereis/1`, `running?/1` | reads the row, then checks `process_alive?(pid)` | the moment the process dies |
| `count/1` → `Manager.running_count/0` | `:ets.info(table, :size)` | when Horde's monitor reaps the row |

`await_stopped/2` waited on the first. Every caller that stops a harness then reads the second. So the wait was over before the number it exists to wait for could move — 0–89 µs of daylight on an idle laptop (median 1 µs, measured over 30 stops), and however long the registry takes to be scheduled on a loaded one.

`stop_all_harnesses!/1` already waits on `running_count/0`, which is why #1567 closed the cross-module half (#1533) and this half survived.

`running_count/0` is deliberately unchanged: teardown drains against it, and a count that dropped with the pid would hand the next module a baseline still about to move — #1533 again.

## The test is a fixed observation, not a rate

Suspending the registry holds the two views apart for as long as the test needs: the pid is gone, the row cannot be reaped.

| `await_stopped(id, 10)` | elapsed |
|---|---|
| waiting on `running?/1` (before) | 0 ms |
| waiting on the row (after) | 210 ms |

So reverting the one-line change fails the new test outright, rather than failing it one run in ten. Verified both ways.

`apps/fountain_buzz`: 144 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DBK3uwQuJozQHKmEuBrvrP