### PR TITLE
fix(ops): deduplicate gauges and tag turns by provider

### DIFF
--- a/.github/workflows/alert-rules.yml
+++ b/.github/workflows/alert-rules.yml
@@ -1,0 +1,29 @@
+name: Alert rules
+
+on:
+  pull_request:
+    paths:
+      - deploy/k8s/prometheusrule.yaml
+      - scripts/test-alerts.py
+      - .github/workflows/alert-rules.yml
+  push:
+    branches: [main]
+    paths:
+      - deploy/k8s/prometheusrule.yaml
+      - scripts/test-alerts.py
+      - .github/workflows/alert-rules.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  alerts:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
+      - name: Install the rule evaluator
+        run: sudo apt-get update && sudo apt-get install -y prometheus python3-yaml
+      - name: Check rules and replica-independent thresholds
+        run: /usr/bin/python3 scripts/test-alerts.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,6 +168,9 @@ upgrade, is in
 
 ### Fixed
 
+- Deduplicate database gauges across replicas in sandbox, conversation and Oban alerts.
+- Label turn duration and first-output metrics by sandbox provider so hosted alerts can exclude self-hosted runners.
+
 - **ACP `session/new` carried the agent's unsubstituted MCP configuration**
   (#1404). Fountain resolves `${VAR}` references once at provision and writes
   the sandbox's `.mcp.json` from the result, but the turn path re-read the

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -471,7 +471,7 @@ defmodule Fountain.Conversations.ConversationServer do
       # ended in the :exit / :interrupt handlers).
       current_turn_span: nil,
       # Aggregate-metric bookkeeping for the in-flight turn (#536, #535):
-      # `%{started_mono: ms, runtime: "claude", first_output?: bool}`, set
+      # `%{started_mono: ms, runtime: "claude", provider: "sprites", first_output?: bool}`, set
       # once the turn's command is spawned and dropped on every terminal
       # path. nil whenever no turn is running. Monotonic rather than the
       # turn row's timestamps because `now/0` truncates to the second,
@@ -2514,11 +2514,12 @@ defmodule Fountain.Conversations.ConversationServer do
                   current_turn: turn,
                   runtime_session_id: runtime_session_id,
                   current_turn_span: turn_span,
-                  turn_metrics: %{
-                    started_mono: turn_started_mono,
-                    runtime: conv.runtime,
-                    first_output?: false
-                  },
+                  turn_metrics:
+                    TurnMachine.start_metrics(
+                      conv.runtime,
+                      state.handle.provider,
+                      turn_started_mono
+                    ),
                   stream_tracer: stream_tracer,
                   acp_peer: peer,
                   acp_peer_mon: peer_mon
@@ -2710,11 +2711,8 @@ defmodule Fountain.Conversations.ConversationServer do
           touch_activity(state)
           | current_turn: turn,
             current_turn_span: turn_span,
-            turn_metrics: %{
-              started_mono: started_mono,
-              runtime: conv.runtime,
-              first_output?: false
-            },
+            turn_metrics:
+              TurnMachine.start_metrics(conv.runtime, state.handle.provider, started_mono),
             stream_tracer: tracer
         }
 

--- a/apps/fountain/lib/fountain/conversations/turn_machine.ex
+++ b/apps/fountain/lib/fountain/conversations/turn_machine.ex
@@ -457,6 +457,17 @@ defmodule Fountain.Conversations.TurnMachine do
     %{turn | row: nil, span: nil, metrics: nil, tracer: nil}
   end
 
+  @doc "Start one turn's measurements with the provider of the computer it runs on."
+  @spec start_metrics(String.t(), atom(), integer()) :: map()
+  def start_metrics(runtime, provider, started_mono) do
+    %{
+      started_mono: started_mono,
+      runtime: runtime,
+      provider: to_string(provider),
+      first_output?: false
+    }
+  end
+
   # Emit the aggregate turn-duration event (#536). Called from every path
   # that ends a turn which actually ran: the :exit handler, the mid-turn
   # {:error, ...} handler (#413) and :interrupt.
@@ -466,7 +477,7 @@ defmodule Fountain.Conversations.TurnMachine do
   # dashboard/alert signal.
   #
   # Tags are `runtime` (four values, gated by Runtimes.for_runtime/1 on the
-  # only path that starts a server) and the terminal `status`
+  # only path that starts a server), the sandbox `provider`, and terminal `status`
   # (completed/failed/interrupted). conv_id rides along as metadata — it is
   # what makes the JSON log line actionable, and as a tag it would mint a
   # time series per conversation.
@@ -476,7 +487,12 @@ defmodule Fountain.Conversations.TurnMachine do
   def emit_completed(%__MODULE__{metrics: metrics} = turn, status) do
     Fountain.Telemetry.event(
       [:turn, :completed],
-      %{runtime: metrics.runtime, status: status, conv_id: turn.conversation_id},
+      %{
+        runtime: metrics.runtime,
+        provider: metrics.provider,
+        status: status,
+        conv_id: turn.conversation_id
+      },
       %{duration_ms: System.monotonic_time(:millisecond) - metrics.started_mono}
     )
   end
@@ -500,7 +516,7 @@ defmodule Fountain.Conversations.TurnMachine do
   def maybe_emit_first_output(%__MODULE__{metrics: %{first_output?: false} = metrics} = turn) do
     Fountain.Telemetry.event(
       [:turn, :first_output],
-      %{runtime: metrics.runtime, conv_id: turn.conversation_id},
+      %{runtime: metrics.runtime, provider: metrics.provider, conv_id: turn.conversation_id},
       %{elapsed_ms: System.monotonic_time(:millisecond) - metrics.started_mono}
     )
 

--- a/apps/fountain/lib/fountain_web/telemetry.ex
+++ b/apps/fountain/lib/fountain_web/telemetry.ex
@@ -153,11 +153,11 @@ defmodule FountainWeb.Telemetry do
       distribution("fountain.turn.completed.duration_ms",
         event_name: [:fountain, :turn, :completed],
         measurement: :duration_ms,
-        tags: [:runtime, :status],
+        tags: [:runtime, :status, :provider],
         reporter_options: [
           buckets: [1000, 5000, 15_000, 30_000, 60_000, 120_000, 300_000, 600_000, 1_800_000]
         ],
-        description: "Turn duration by runtime and terminal status"
+        description: "Turn duration by runtime, provider and terminal status"
       ),
       # Time to first token (#535) — the latency between hitting enter and
       # seeing the agent do something, which is the one a user actually
@@ -174,7 +174,7 @@ defmodule FountainWeb.Telemetry do
       distribution("fountain.turn.first_output.elapsed_ms",
         event_name: [:fountain, :turn, :first_output],
         measurement: :elapsed_ms,
-        tags: [:runtime],
+        tags: [:runtime, :provider],
         reporter_options: [buckets: [250, 500, 1000, 2500, 5000, 10_000, 30_000, 60_000]],
         description: "Time from turn start to the sandbox's first output byte"
       ),

--- a/apps/fountain/test/fountain/conversations/conversation_server_size_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_size_test.exs
@@ -15,7 +15,7 @@ defmodule Fountain.Conversations.ConversationServerSizeTest do
   accepts is downward. Lower it when you move something out; never raise it.
   """
 
-  @pin 2815
+  @pin 2813
 
   @server "apps/fountain/lib/fountain/conversations/conversation_server.ex"
 

--- a/apps/fountain/test/fountain/conversations/conversation_server_turn_metrics_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_turn_metrics_test.exs
@@ -78,6 +78,7 @@ defmodule Fountain.Conversations.ConversationServerTurnMetricsTest do
 
       assert_received {:turn_completed, measurements, metadata}
       assert metadata.runtime == "gemini"
+      assert metadata.provider == "sprites"
       assert metadata.status == "completed"
 
       # Metadata, never a tag: it's what makes the JSON log line point at a
@@ -177,6 +178,7 @@ defmodule Fountain.Conversations.ConversationServerTurnMetricsTest do
 
       assert_received {:first_output, measurements, metadata}
       assert metadata.runtime == "gemini"
+      assert metadata.provider == "sprites"
       assert metadata.conv_id == conv.id
       assert is_integer(measurements.elapsed_ms)
       assert measurements.elapsed_ms >= 0

--- a/apps/fountain/test/fountain/conversations/turn_machine_test.exs
+++ b/apps/fountain/test/fountain/conversations/turn_machine_test.exs
@@ -19,11 +19,7 @@ defmodule Fountain.Conversations.TurnMachineTest do
     machine = %TurnMachine{
       conversation_id: conv.id,
       row: row,
-      metrics: %{
-        started_mono: System.monotonic_time(:millisecond),
-        runtime: "claude",
-        first_output?: false
-      }
+      metrics: TurnMachine.start_metrics("claude", :runner, System.monotonic_time(:millisecond))
     }
 
     {:ok, user: user, agent: agent, conv: conv, row: row, machine: machine}
@@ -291,7 +287,12 @@ defmodule Fountain.Conversations.TurnMachineTest do
       assert Conversations._unsafe_get_conversation!(conv.id).status == "idle"
 
       assert_receive {:telemetry, [:fountain, :turn, :completed], %{duration_ms: _},
-                      %{runtime: "claude", status: "completed", conv_id: conv_id}}
+                      %{
+                        runtime: "claude",
+                        provider: "runner",
+                        status: "completed",
+                        conv_id: conv_id
+                      }}
 
       assert conv_id == conv.id
     end
@@ -336,7 +337,7 @@ defmodule Fountain.Conversations.TurnMachineTest do
       assert once.metrics.first_output?
 
       assert_receive {:telemetry, [:fountain, :turn, :first_output], %{elapsed_ms: _},
-                      %{runtime: "claude"}}
+                      %{runtime: "claude", provider: "runner"}}
 
       assert TurnMachine.maybe_emit_first_output(once) == once
       refute_receive {:telemetry, [:fountain, :turn, :first_output], _, _}, 50

--- a/apps/fountain/test/fountain_web/metrics_test.exs
+++ b/apps/fountain/test/fountain_web/metrics_test.exs
@@ -496,7 +496,12 @@ defmodule FountainWeb.MetricsTest do
       # nothing else, so the bucket counts below are this test's alone.
       Fountain.Telemetry.event(
         [:turn, :completed],
-        %{runtime: "opencode", status: "completed", conv_id: Ecto.UUID.generate()},
+        %{
+          runtime: "opencode",
+          status: "completed",
+          provider: "runner",
+          conv_id: Ecto.UUID.generate()
+        },
         %{duration_ms: 42_000}
       )
 
@@ -504,7 +509,7 @@ defmodule FountainWeb.MetricsTest do
       {200, body} = scrape()
 
       series =
-        ~s(fountain_turn_completed_duration_ms_bucket{runtime="opencode",status="completed")
+        ~s(fountain_turn_completed_duration_ms_bucket{provider="runner",runtime="opencode",status="completed")
 
       # 42s lands above the 30s boundary and below 60s. A duration handed over
       # in seconds or in native units lands in a different bucket entirely.
@@ -523,14 +528,15 @@ defmodule FountainWeb.MetricsTest do
       # can ever be named keeps the exact-count assertions meaningful.
       Fountain.Telemetry.event(
         [:turn, :first_output],
-        %{runtime: "probe-runtime", conv_id: Ecto.UUID.generate()},
+        %{runtime: "probe-runtime", provider: "runner", conv_id: Ecto.UUID.generate()},
         %{elapsed_ms: 1_500}
       )
 
       Process.sleep(50)
       {200, body} = scrape()
 
-      series = ~s(fountain_turn_first_output_elapsed_ms_bucket{runtime="probe-runtime")
+      series =
+        ~s(fountain_turn_first_output_elapsed_ms_bucket{provider="runner",runtime="probe-runtime")
 
       # 1.5s is above the 1s boundary and below 2.5s.
       assert body =~ ~s(#{series},le="2500"} 1)

--- a/deploy/k8s/prometheusrule.yaml
+++ b/deploy/k8s/prometheusrule.yaml
@@ -208,6 +208,8 @@ spec:
               run, and grep the app logs for "provisioning exceeded".
 
         - alert: FountainSandboxBudgetExceeded
+          # OpsGauges polls the same database on each replica. Deduplicate
+          # each status before adding them; event counters still need sum.
           # Instance-wide concurrency ceiling (#405). Every sprite bills to
           # your single SPRITES_TOKEN and the only enforced cap is per-tenant
           # (default 5), so total concurrent spend is otherwise
@@ -215,7 +217,7 @@ spec:
           # operator knob, not a law: size it to what you are willing to pay
           # for.
           expr: |
-            sum(fountain_sandboxes_count{namespace="fountain", status=~"pending|starting|ready"}) > 50
+            sum(max by (namespace, status) (fountain_sandboxes_count{namespace="fountain", status=~"pending|starting|ready"})) > 50
           for: 10m
           labels:
             severity: warning
@@ -236,7 +238,7 @@ spec:
           # sandbox rows are wrong — the drift SandboxReaper measures — and
           # shares the same 50 knob.
           expr: |
-            sum(fountain_conversations_count{namespace="fountain", status=~"pending|running"}) > 50
+            sum(max by (namespace, status) (fountain_conversations_count{namespace="fountain", status=~"pending|running"})) > 50
           for: 10m
           labels:
             severity: warning
@@ -330,7 +332,7 @@ spec:
           # for 7 days until Oban's pruner removes them, and an alert that
           # stays red for a week trains people to ignore it.
           expr: |
-            delta(fountain_oban_queue_depth{namespace="fountain", state="discarded"}[2h]) > 0
+            delta((max by (namespace, queue, state) (fountain_oban_queue_depth{namespace="fountain", state="discarded"}))[2h:1m]) > 0
           labels:
             severity: critical
           annotations:
@@ -346,7 +348,7 @@ spec:
           # available = runnable now but not picked up. A sustained backlog
           # means concurrency is saturated or a worker is wedged.
           expr: |
-            fountain_oban_queue_depth{namespace="fountain", state="available"} > 25
+            max by (namespace, queue, state) (fountain_oban_queue_depth{namespace="fountain", state="available"}) > 25
           for: 30m
           labels:
             severity: warning

--- a/scripts/test-alerts.py
+++ b/scripts/test-alerts.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Evaluate the shipped alert expressions with promtool (requires PyYAML)."""
+from pathlib import Path
+import subprocess
+import tempfile
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def main():
+    spec = yaml.safe_load((ROOT / "deploy/k8s/prometheusrule.yaml").read_text())["spec"]
+    rules = {r["alert"]: r for g in spec["groups"] for r in g["rules"]}
+    cases = []
+    for replicas in (1, 2, 3):
+        for alert, metric, statuses in (
+            ("FountainSandboxBudgetExceeded", "fountain_sandboxes_count", ("pending", "ready")),
+            ("FountainConversationsAboveBudget", "fountain_conversations_count", ("pending", "running")),
+        ):
+            for counts in ((10, 20), (20, 40)):
+                series = [
+                    {"series": f'{metric}{{namespace="fountain",status="{status}",pod="pod-{pod}"}}',
+                     "values": f"{count}+0x120"}
+                    for pod in range(replicas)
+                    for status, count in zip(statuses, counts)
+                ]
+                total = sum(counts)
+                cases.append({
+                    "name": f"{alert}: {replicas} replicas, {total} rows",
+                    "interval": "1m", "input_series": series,
+                    "promql_expr_test": [{"expr": rules[alert]["expr"], "eval_time": "120m",
+                                          "exp_samples": [{"labels": "{}", "value": total}] if total > 50 else []}],
+                })
+
+        for alert, state in (("FountainObanQueueBacklog", "available"),
+                             ("FountainObanJobsDiscarded", "discarded")):
+            for fires in (False, True):
+                values = ("30+0x120" if fires else "20+0x120") if state == "available" else (
+                    "0+0x59 1+0x60" if fires else "1+0x120")
+                # delta extrapolates the 119 observed intervals across the 120-minute window.
+                value = 30 if state == "available" else 120 / 119
+                series = [
+                    {"series": f'fountain_oban_queue_depth{{namespace="fountain",queue="default",state="{state}",pod="pod-{pod}"}}',
+                     "values": values}
+                    for pod in range(replicas)
+                ]
+                # A second quiet queue must neither add to the first nor page.
+                series.append({"series": f'fountain_oban_queue_depth{{namespace="fountain",queue="quiet",state="{state}",pod="pod-0"}}',
+                               "values": "0+0x120"})
+                cases.append({
+                    "name": f"{alert}: {replicas} replicas, fires={fires}",
+                    "interval": "1m", "input_series": series,
+                    "promql_expr_test": [{"expr": rules[alert]["expr"], "eval_time": "120m",
+                                          "exp_samples": [{"labels": f'{{namespace="fountain",queue="default",state="{state}"}}',
+                                                           "value": value}] if fires else []}],
+                })
+
+    with tempfile.TemporaryDirectory(prefix="fountain-alert-tests-") as directory:
+        rule_file = Path(directory) / "rules.yml"
+        rule_file.write_text(yaml.safe_dump(spec))
+        test_file = Path(directory) / "tests.yml"
+        test_file.write_text(yaml.safe_dump({"rule_files": [str(rule_file)], "evaluation_interval": "1m", "tests": cases}))
+        subprocess.run(["promtool", "check", "rules", str(rule_file)], check=True)
+        subprocess.run(["promtool", "test", "rules", str(test_file)], check=True)
+    print(f"Passed {len(cases)} alert expression cases")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test-alerts.py
+++ b/scripts/test-alerts.py
@@ -39,8 +39,12 @@ def main():
             for fires in (False, True):
                 values = ("30+0x120" if fires else "20+0x120") if state == "available" else (
                     "0+0x59 1+0x60" if fires else "1+0x120")
-                # delta extrapolates the 119 observed intervals across the 120-minute window.
-                value = 30 if state == "available" else 120 / 119
+                # Assert alert membership rather than delta's fractional
+                # extrapolation, which differs between Prometheus 2 and 3.
+                expression = rules[alert]["expr"]
+                if state == "discarded":
+                    expression = f"({expression.strip()}) > bool 0"
+                value = 30 if state == "available" else 1
                 series = [
                     {"series": f'fountain_oban_queue_depth{{namespace="fountain",queue="default",state="{state}",pod="pod-{pod}"}}',
                      "values": values}
@@ -52,7 +56,7 @@ def main():
                 cases.append({
                     "name": f"{alert}: {replicas} replicas, fires={fires}",
                     "interval": "1m", "input_series": series,
-                    "promql_expr_test": [{"expr": rules[alert]["expr"], "eval_time": "120m",
+                    "promql_expr_test": [{"expr": expression, "eval_time": "120m",
                                           "exp_samples": [{"labels": f'{{namespace="fountain",queue="default",state="{state}"}}',
                                                            "value": value}] if fires else []}],
                 })


### PR DESCRIPTION
Database gauges are exported identically by every replica, so summing them makes budget alerts fire early. Deduplicate by status or queue before aggregating, and add the sandbox provider to turn-duration and first-output telemetry so paid and self-hosted traffic can be distinguished.

Closes #1167. Closes #1522.

The hosted billing-alert consumer is in jhgaylor/home-cloud#173 and should merge after this is deployed. Both fresh turns and reused ACP connections obtain their metric state through TurnMachine; ConversationServer shrinks and its size guard moves down.

Validation: `mix precommit` passed compilation, formatting, Credo, Dialyzer, Sobelow, production release assembly, 4,272 core tests plus six doctests, 144 Buzz tests and 33 Support tests (seven existing exclusions). `python3 scripts/test-alerts.py` checked all 17 rules and passed 24 PromQL cases across one, two and three replicas. The rule tests also run in a dedicated PR workflow.
