### PR TITLE
fix(api): render OpenAI envelopes for sandbox conflicts

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/openai_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/openai_controller.ex
@@ -687,6 +687,29 @@ defmodule FountainWeb.OpenAIController do
     )
   end
 
+  defp respond_error(conn, {:error, :no_runner_online}) do
+    openai_error(
+      conn,
+      409,
+      "this agent runs on a self-hosted runner and none of yours is connected — " <>
+        "start `fountain runner` on the machine and try again",
+      "conflict_error",
+      "no_runner_online"
+    )
+  end
+
+  defp respond_error(conn, {:error, :sandbox_at_capacity}) do
+    conn
+    |> put_resp_header("retry-after", "5")
+    |> openai_error(
+      409,
+      "another conversation is running a turn on this sandbox; " <>
+        "wait for it to finish or interrupt it, then send again",
+      "conflict_error",
+      "sandbox_at_capacity"
+    )
+  end
+
   # The thread owes tool results (#1202). Same shape as busy: the client
   # knows what to send, and it is not a prompt.
   defp respond_error(conn, {:error, {:tool_calls_pending, ids}}) do

--- a/apps/fountain/test/fountain_web/controllers/openai_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/openai_controller_test.exs
@@ -536,7 +536,50 @@ defmodule FountainWeb.OpenAIControllerTest do
 
       conn = chat(conn, raw_key, request("offline", "hello"), [{"x-fountain-thread", "t2"}])
 
-      assert json_response(conn, 409)["error"] == "no_runner_online"
+      assert %{
+               "error" => %{
+                 "code" => "no_runner_online",
+                 "type" => "conflict_error",
+                 "message" => message,
+                 "param" => nil
+               }
+             } =
+               json_response(conn, 409)
+
+      assert message =~ "start `fountain runner`"
+    end
+
+    for stream <- [false, true] do
+      @stream stream
+      test "sandbox capacity refusal has an OpenAI envelope with stream=#{stream}", %{
+        conn: conn,
+        user: user,
+        agent: agent,
+        raw_key: raw_key
+      } do
+        _conv = bound_conversation(user, agent, "capacity")
+
+        expect(ConversationServer, :send_prompt, fn _id, _prompt, [], _opts ->
+          {:error, :sandbox_at_capacity}
+        end)
+
+        conn =
+          chat(conn, raw_key, request("pr-reviewer", "hello", %{"stream" => @stream}), [
+            {"x-fountain-thread", "capacity"}
+          ])
+
+        assert %{
+                 "error" => %{
+                   "code" => "sandbox_at_capacity",
+                   "type" => "conflict_error",
+                   "message" => message,
+                   "param" => nil
+                 }
+               } = json_response(conn, 409)
+
+        assert message =~ "another conversation"
+        assert get_resp_header(conn, "retry-after") == ["5"]
+      end
     end
 
     test "a busy thread is 409 with Retry-After, not a queue", %{

--- a/apps/fountain/test/fountain_web/schema_guardrail_test.exs
+++ b/apps/fountain/test/fountain_web/schema_guardrail_test.exs
@@ -48,7 +48,7 @@ defmodule FountainWeb.SchemaGuardrailTest do
 
   # The allowlist may shrink freely. Growing it means editing this number in
   # the same diff, which is the whole ratchet: a reviewer sees the number move.
-  @ceiling 70
+  @ceiling 69
 
   describe "the ratchet" do
     test "the allowlist has not grown" do

--- a/apps/fountain/test/support/schema_guard_allowlist.ex
+++ b/apps/fountain/test/support/schema_guard_allowlist.ex
@@ -53,17 +53,12 @@ defmodule FountainWeb.SchemaGuardAllowlist do
   value on purpose that the domain no longer accepts (a conversation whose
   runtime is `retired-runtime`, exercising the retired-runtime path), so the
   rendered enum is out of vocabulary because the test asked for that.
-
-  `:openai_error_shape` — the OpenAI-compatible gateway renders `error` as a
-  string on a 409 while `OpenAIError.error` declares an object. Narrow, and its
-  clients are OpenAI SDKs rather than ours (#1433).
   """
 
   @reasons %{
     plug_status: "a status a pipeline plug returns that the operation does not declare (#1432)",
     mixed_422_shapes: "declares ChangesetError for 422 but can also refuse with a code (#1444)",
-    test_fixture_vocabulary: "the fixture inserts an out-of-vocabulary value on purpose",
-    openai_error_shape: "the OpenAI gateway renders `error` as a string, not an object (#1433)"
+    test_fixture_vocabulary: "the fixture inserts an out-of-vocabulary value on purpose"
   }
 
   # The list may shrink, never grow, without a deliberate edit here and in the
@@ -143,10 +138,7 @@ defmodule FountainWeb.SchemaGuardAllowlist do
     {"POST /api/conversations", 422} => :mixed_422_shapes,
 
     # ── test_fixture_vocabulary (1) ─────────────────────────────
-    {"GET /api/conversations/{id}", 200} => :test_fixture_vocabulary,
-
-    # ── openai_error_shape (1) ─────────────────────────────
-    {"POST /v1/chat/completions", 409} => :openai_error_shape
+    {"GET /api/conversations/{id}", 200} => :test_fixture_vocabulary
   }
 
   @doc "Is this `{operation, status}` a known, recorded disagreement?"


### PR DESCRIPTION
An offline self-hosted runner or a sandbox at capacity returns HTTP 409 from the OpenAI-compatible gateway, but its fallback body puts a string in `error`. Render these refusals with the declared OpenAI envelope (`error.message`, `type`, `param`, and `code`); capacity refusals also carry Retry-After.

Closes #1433.

Removed the 409 schema-guard exception and lowered its ceiling. Regression coverage exercises the real offline-runner path and sandbox-capacity refusals with both streaming and non-streaming requests. Existing busy-thread and pending-tool behavior stays covered.

Validation: `mix precommit` passed all static checks, production release assembly, 4,274 core tests plus six doctests, 144 Buzz tests and 33 Support tests (seven existing exclusions).
