### PR TITLE
fix(sdk): keep npm latest on the newest stable release

### DIFF
--- a/.github/workflows/sdk-publish.yml
+++ b/.github/workflows/sdk-publish.yml
@@ -27,6 +27,13 @@ on:
       - "sdk/typescript/**"
   workflow_dispatch:
 
+# Hold the registry read and publish in one critical section. Keep pending
+# releases: the default one-slot queue cancels an intermediate version.
+concurrency:
+  group: npm-fountain-sdk-publish
+  queue: max
+  cancel-in-progress: false
+
 permissions:
   contents: read
 
@@ -129,7 +136,9 @@ jobs:
         working-directory: sdk/typescript
         env:
           FOUNTAIN_CI_PUBLISH: "1"
-        run: npm publish
+        run: |
+          tag="$(node ../../scripts/sdk-publish-tag.mjs)"
+          npm publish --tag "$tag"
 
       # After the fact, and only on success: which commit produced which
       # version. A failed publish leaves no tag to clean up.

--- a/.github/workflows/sdk-release-gate.yml
+++ b/.github/workflows/sdk-release-gate.yml
@@ -25,6 +25,8 @@ on:
     paths:
       - "sdk/typescript/**"
       - "scripts/sdk-release.mjs"
+      - "scripts/sdk-publish-tag*.mjs"
+      - ".github/workflows/sdk-publish.yml"
       - ".github/workflows/sdk-release-gate.yml"
 
 permissions:
@@ -48,6 +50,9 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
+
+      - name: Publish tag regression tests
+        run: node --test scripts/sdk-publish-tag.test.mjs
 
       - name: Does this PR need a version bump?
         run: node scripts/sdk-release.mjs guard "origin/${{ github.base_ref }}"

--- a/scripts/sdk-publish-tag.mjs
+++ b/scripts/sdk-publish-tag.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+/** Choose the dist-tag inside the publish workflow's serialized concurrency group. */
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+// Only stable releases may move latest. Compare numeric components, not strings;
+// build metadata has no precedence and prereleases remain on next.
+function stable(version) {
+  const match = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:\+[\da-zA-Z.-]+)?$/.exec(version);
+  return match ? match.slice(1, 4).map(BigInt) : null;
+}
+
+function greater(left, right) {
+  for (let i = 0; i < 3; i++) {
+    if (left[i] !== right[i]) return left[i] > right[i];
+  }
+  return false;
+}
+
+export function publishTag(version, registry) {
+  if (!registry || typeof registry.versions !== "object" || registry.versions === null || Array.isArray(registry.versions)) {
+    throw new Error("Registry response has no versions map; refusing to choose a publish tag");
+  }
+  const candidate = stable(version);
+  if (!candidate) return "next";
+  const published = [...Object.keys(registry.versions), registry["dist-tags"]?.latest].filter(Boolean);
+  return published.some((version) => {
+    const tuple = stable(version);
+    return tuple && !greater(candidate, tuple);
+  }) ? "backport" : "latest";
+}
+
+export async function registryState(name, fetchRegistry = fetch) {
+  const response = await fetchRegistry(`https://registry.npmjs.org/${encodeURIComponent(name)}`, {
+    headers: { accept: "application/json", "cache-control": "no-cache" },
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (response.status === 404) return { versions: {} };
+  if (!response.ok) throw new Error(`Registry answered ${response.status}; refusing to publish`);
+  return response.json();
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const pkg = JSON.parse(readFileSync(new URL("../sdk/typescript/package.json", import.meta.url), "utf8"));
+  console.log(publishTag(pkg.version, await registryState(pkg.name)));
+}

--- a/scripts/sdk-publish-tag.test.mjs
+++ b/scripts/sdk-publish-tag.test.mjs
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { publishTag, registryState } from "./sdk-publish-tag.mjs";
+
+const registry = (...versions) => ({ versions: Object.fromEntries(versions.map((v) => [v, {}])) });
+
+test("numeric version order, prereleases and backports", () => {
+  assert.equal(publishTag("1.10.0", registry("1.9.9")), "latest");
+  assert.equal(publishTag("2.0.0", registry("1.99.99")), "latest");
+  assert.equal(publishTag("1.18.0", registry("1.19.0")), "backport");
+  assert.equal(publishTag("1.19.0", registry("1.19.0")), "backport");
+  assert.equal(publishTag("1.19.0+build.2", registry("1.19.0+build.1")), "backport");
+  assert.equal(publishTag("2.0.0-rc.1", registry("1.19.0")), "next");
+  assert.equal(publishTag("1.20.0", registry("2.0.0-rc.1", "1.19.0")), "latest");
+  assert.equal(publishTag("0.1.0", registry()), "latest");
+});
+
+test("all six release orders leave latest on the highest stable version", () => {
+  const versions = ["1.17.0", "1.18.0", "1.19.0"];
+  for (const first of versions) {
+    for (const second of versions.filter((v) => v !== first)) {
+      const third = versions.find((v) => v !== first && v !== second);
+      const state = { ...registry("1.16.0"), "dist-tags": { latest: "1.16.0" } };
+      for (const version of [first, second, third]) {
+        const tag = publishTag(version, state);
+        state.versions[version] = {};
+        state["dist-tags"][tag] = version;
+      }
+      assert.equal(state["dist-tags"].latest, "1.19.0");
+      assert.equal(Object.keys(state.versions).length, 4);
+    }
+  }
+});
+
+test("a newer latest tag protects against an incomplete versions listing", () => {
+  assert.equal(publishTag("1.18.0", { ...registry("1.17.0"), "dist-tags": { latest: "1.19.0" } }), "backport");
+});
+
+test("registry errors and malformed data fail closed", async () => {
+  for (const body of [null, {}, { versions: null }, { versions: [] }]) {
+    assert.throws(() => publishTag("1.18.0", body), /versions map/);
+  }
+  await assert.rejects(registryState("@agentshit/fountain-sdk", async () => new Response("unavailable", { status: 503 })), /503/);
+  await assert.rejects(registryState("@agentshit/fountain-sdk", async () => new Response("not JSON")), SyntaxError);
+  assert.deepEqual(await registryState("@agentshit/fountain-sdk", async (url) => {
+    assert.equal(url, "https://registry.npmjs.org/%40agentshit%2Ffountain-sdk");
+    return new Response("missing", { status: 404 });
+  }), { versions: {} });
+});


### PR DESCRIPTION
Merging an older SDK version after a newer one currently moves npm's `latest` tag backward. Choose an explicit tag from the registry immediately before publishing: a new highest stable version gets `latest`, an older stable version gets `backport`, and a prerelease gets `next`.

Closes #1446.

The entire publish workflow shares one concurrency group with `queue: max`, so the registry read and publish cannot overlap and pending releases are preserved. Registry failures and malformed responses fail closed. Publishing continues to use OIDC; there is no new npm token or separate dist-tag mutation.

Validation: Node regression tests cover all six orders of three releases, numeric version ordering, prereleases, build metadata, registry errors and malformed data. The selector also ran against the read-only npm registry. The tests run in the SDK release gate whenever their scripts or the publishing workflow change.

The full local `mix precommit` reached the umbrella suite with one existing docs-anchor test timing out in syntax highlighting (4,272 core tests, 144 Buzz tests and 33 Support tests). A focused rerun of all 28 docs tests passed. All 18 GitHub checks passed.

References: [GitHub's queued concurrency](https://docs.github.com/en/actions/concepts/workflows-and-actions/concurrency), [npm trusted publishing](https://docs.npmjs.com/trusted-publishers/). The latest actionlint release (1.7.12) does not yet recognize GitHub's documented `queue` property; its local syntax warning is recorded here rather than removing the queue that prevents dropped releases.
