### PR TITLE
Lead with apps and refresh runtime and provider docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,24 @@
 # Fountain
 
+Use Claude Code, Codex and Gemini CLI from a chat app, with a real computer
+behind each conversation. Watch the agent work, steer it, and come back to
+the same files.
+
+[Open Conversations](https://fountain-conversations.demo.managoat.com/) ·
+[Build with the API](docs/quickstart.md) · [Self-host](docs/self-hosting.md)
+
+## The apps
+
+Choose a chat, a team of agents, or a workbench for a shared project.
+
+| App | What it is | |
+|---|---|---|
+| [**Conversations**](https://github.com/managoat/fountain-conversations) | ChatGPT, except the model has a real computer and you can watch it use one: start a run, follow it turn by turn, steer it, read the raw log. | [Open it](https://fountain-conversations.demo.managoat.com/) |
+| [**Team**](https://github.com/managoat/fountain-team) | A group chat whose contacts are agents you made, one click each: roster on the left, thread on the right, routines on a schedule. | [Open it](https://fountain-team.demo.managoat.com/) |
+| [**Workbench**](https://github.com/managoat/fountain-workbench) | Multiplayer engineering: projects over an environment and a vault, work items in them, and teammates you put on a work item by typing. | [Open it](https://fountain-workbench.demo.managoat.com) |
+
+## What runs underneath
+
 **A conversational API to a computer. The meter runs while an agent works and
 stops while the machine waits, so a conversation nobody is talking to costs
 nothing.**
@@ -33,28 +52,8 @@ four.
 
 ## Self-hosting
 
-Run your own instance: [docs/self-hosting.md](docs/self-hosting.md).
-
-```sh
-cp .env.compose.example .env   # then fill in the generated keys
-docker compose up -d
-```
-
-Prefer a platform? [`render.yaml`](render.yaml) declares one service and a
-managed Postgres; [`fly.toml`](fly.toml) declares one machine, and you attach
-a database in a second command. Both pin a release image and one instance —
-Fountain clusters over Erlang distribution, so a second replica is two
-schedulers racing over the same sandboxes. Coolify and Dokploy run the compose
-file above straight from this repo. Prefer Kubernetes? A portable baseline —
-plain manifests, `kubectl apply -k`, no operators assumed — lives in
-[`deploy/k8s/`](deploy/k8s/).
-
-Scale-to-zero hosts (Cloud Run, App Runner, Vercel) do not work: the sandbox
-reaper and the credit pricer run inside the app process, so a parked instance
-quietly stops both. [docs/self-hosting.md](docs/self-hosting.md) has the three
-properties a host must have.
-
-## The apps
+[Run your own Fountain instance](docs/self-hosting.md) with the same apps,
+API, CLI and SDKs under your own keys and infrastructure.
 
 Fountain's own UI is an operator console. You configure things in it; you do
 not watch an agent work in it. The three apps we build for that are separate
@@ -62,12 +61,6 @@ single-page apps on their own origins, talking to `/api` with a key you paste
 in or an OAuth sign-in. Each is static files, so a hosted build works against
 your instance as soon as it admits the origin
 (`API_CORS_ORIGINS=https://fountain-conversations.demo.managoat.com`).
-
-| App | What it is | |
-|---|---|---|
-| [**Conversations**](https://github.com/managoat/fountain-conversations) | ChatGPT, except the model has a real computer and you can watch it use one: start a run, follow it turn by turn, steer it, read the raw log. | [Open it](https://fountain-conversations.demo.managoat.com/) |
-| [**Team**](https://github.com/managoat/fountain-team) | A group chat whose contacts are agents you made, one click each: roster on the left, thread on the right, routines on a schedule. | [Open it](https://fountain-team.demo.managoat.com/) |
-| [**Workbench**](https://github.com/managoat/fountain-workbench) | Multiplayer engineering: projects over an environment and a vault, work items in them, and teammates you put on a work item by typing. | [Open it](https://fountain-workbench.demo.managoat.com) |
 
 `CONVERSATIONS_APP_URL` and `TEAM_APP_URL` point the console's own links at
 copies you host. [The console, the apps, and the API](docs/concepts/surfaces.md)

--- a/apps/fountain/lib/fountain_web/controllers/marketing_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_controller.ex
@@ -38,23 +38,9 @@ defmodule FountainWeb.MarketingController do
     end
   end
 
-  # The one page on the site that set no `:page_title`, so `<title>` and both
-  # card titles were the bare brand name — the only word a reader who has
-  # never heard it learns nothing from. Every other page here carries
-  # "<what it is> · <brand>" and the homepage now does too.
-  #
-  # It is the slot a category label is for. The h1 makes a claim ("A
-  # conversational API to a computer"), which is the right job for a headline
-  # and the wrong one for a tab, a bookmark and a search result, where a
-  # reader is deciding whether this is even the kind of thing they want.
-  # standards/voice-and-style.md is explicit that the audience has no prior
-  # model for the category, and they arrive searching for how to run a coding
-  # agent on a server, not for a phrase from the hero.
-  #
-  # Only on the marketing site. An instance keeps the bare brand: it is a
-  # front door, not the project, and a title selling a category would be this
-  # module's whole objection (#517) in the `<head>`.
-  @site_title "Serverless sandboxes for coding agents"
+  # Search results name the runtimes and the API. The visible homepage leads
+  # with the apps; an ordinary self-hosted instance keeps its own front door.
+  @site_title "Claude Code, Codex and Gemini CLI behind one API"
 
   def home(conn, _params) do
     if Fountain.Marketing.site?() do

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html/home.html.heex
@@ -49,24 +49,24 @@
         be `text-5xl`, one step off the section headings, so the page opened at
         roughly the volume it kept for the next eight thousand pixels. --%>
   <h1 class="text-[2.75rem] leading-[1.05] sm:text-6xl font-bold tracking-[-0.03em] text-[var(--color-text-primary)] mb-6">
-    Run coding agents on ready machines.<span :if={pricing?()}> Pay only while they work.</span>
+    Chat with Claude Code, Codex or Gemini CLI. Watch it work.
   </h1>
   <p class="text-lg sm:text-xl leading-relaxed text-[var(--color-text-secondary)] max-w-2xl mx-auto mb-10">
-    The machine arrives with your repositories cloned, your packages installed and credentials the model never sees.
-    It parks between prompts and wakes with its work intact.
+    Open Conversations to give an agent a task, follow its tools and changes, and send a follow-up.
+    Each conversation has a real computer that keeps its files between prompts.
   </p>
   <div class="flex flex-col sm:flex-row gap-3 justify-center mb-5">
     <a
-      href={~p"/auth/register"}
+      href="https://fountain-conversations.demo.managoat.com/"
       class="inline-flex items-center justify-center px-6 py-3 rounded-lg bg-[var(--color-brand)] text-white font-medium hover:bg-[var(--color-brand-hover)] transition-colors text-sm shadow-sm"
     >
-      Run your first agent free
+      Open Conversations
     </a>
     <a
       href={~p"/docs/tour"}
       class="inline-flex items-center justify-center px-6 py-3 rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-bg-1)] text-[var(--color-text-primary)] font-medium hover:bg-[var(--color-bg-2)] transition-colors text-sm"
     >
-      See it work in 40 lines
+      Build with the API
     </a>
   </div>
   <p :if={pricing?()} class="text-xs text-[var(--color-text-muted)]">
@@ -74,6 +74,79 @@
   </p>
   <p :if={!pricing?()} class="text-xs text-[var(--color-text-muted)]">
     Free to use on this install.
+  </p>
+</section>
+
+<%!-- The apps lead the page. The catalog owns their names, destinations and
+      descriptions; the machine and API explanations follow the choices. --%>
+<section class="max-w-5xl mx-auto px-6 pb-16">
+  <div class="border-t border-[var(--color-border)] pt-16">
+    <.eyebrow label="Apps" />
+    <h2 class="mt-4 text-2xl sm:text-3xl font-semibold tracking-tight text-[var(--color-text-primary)] text-center">
+      Use an app. Or build your own on the same API.
+    </h2>
+    <p class="mt-3 text-center text-[var(--color-text-secondary)] max-w-2xl mx-auto text-lg">
+      {built_app_count()} open-source apps already run on the public API. Use one, fork its source, or point it at your own instance.
+    </p>
+    <div class="mt-10 grid md:grid-cols-3 gap-6">
+      <article
+        :for={app <- flagship_apps()}
+        class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-1)] p-5 flex flex-col"
+        data-role="flagship"
+      >
+        <%!-- The glyph is an emoji out of built_apps/0, shared with
+              /built-with. Set loose at `text-3xl` it read as a stray character
+              above the title; in a bordered tile it reads as the app's mark,
+              which is the job it is doing. --%>
+        <div
+          class="size-11 rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-2)] flex items-center justify-center text-xl leading-none"
+          aria-hidden="true"
+          data-role="glyph"
+        >
+          {app.glyph}
+        </div>
+        <h3 class="mt-4 text-lg font-semibold text-[var(--color-text-primary)]">{app.name}</h3>
+        <p class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed flex-1">
+          {app.flagship.homepage}
+        </p>
+        <div class="mt-5 flex flex-wrap items-center gap-4">
+          <a
+            href={app.url}
+            rel="noopener"
+            class="inline-flex items-center px-4 py-2 rounded-lg bg-[var(--color-brand)] text-white font-medium hover:bg-[var(--color-brand-hover)] transition-colors text-sm"
+          >
+            Open app
+          </a>
+          <a
+            href={app.source}
+            rel="noopener"
+            class="text-sm text-[var(--color-text-secondary)] underline underline-offset-2 hover:text-[var(--color-text-primary)]"
+          >
+            Source
+          </a>
+        </div>
+      </article>
+    </div>
+    <p class="mt-8 text-center">
+      <a
+        href={~p"/built-with"}
+        class="inline-flex items-center justify-center px-5 py-2.5 rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-bg-1)] text-[var(--color-text-primary)] text-sm font-medium hover:bg-[var(--color-bg-2)] transition-colors"
+      >
+        Browse all {built_app_count()} apps
+      </a>
+    </p>
+  </div>
+</section>
+
+<section class="max-w-5xl mx-auto px-6 pb-16 text-center" data-role="machine-story">
+  <h2 class="text-2xl sm:text-3xl font-semibold text-[var(--color-text-primary)]">
+    Run coding agents on ready machines.<span :if={pricing?()}> Pay only while they work.</span>
+  </h2>
+  <p class="mt-4 text-lg text-[var(--color-text-secondary)] max-w-2xl mx-auto">
+    Your repositories, packages and credentials arrive with the machine.
+    It parks between prompts and wakes with its work intact.
+    <a href={~p"/self-hosted"} class="underline underline-offset-2">Run your own instance</a>
+    or use the hosted service.
   </p>
 </section>
 
@@ -588,73 +661,6 @@
       See what connects today
     </a>
   </p>
-</section>
-
-<%!-- The apps, as the other side of the fork the protocols open above: use a
-      working frontend or build one on the same API. The homepage names three
-      shapes and leaves the catalog to /built-with. Showing the rest as chips
-      repeated that apps exist without helping a reader choose one, and made
-      this proof section compete with the product argument above it.
-
-      Cards come from built_apps/0, so the homepage cannot name an app
-      /built-with has renamed or retired. --%>
-<section class="max-w-5xl mx-auto px-6 pb-16">
-  <div class="border-t border-[var(--color-border)] pt-16">
-    <.eyebrow label="Apps" />
-    <h2 class="mt-4 text-2xl sm:text-3xl font-semibold tracking-tight text-[var(--color-text-primary)] text-center">
-      Use an app. Or build your own on the same API.
-    </h2>
-    <p class="mt-3 text-center text-[var(--color-text-secondary)] max-w-2xl mx-auto text-lg">
-      {built_app_count()} open-source apps already run on the public API. Use one, fork its source, or point it at your own instance.
-    </p>
-    <div class="mt-10 grid md:grid-cols-3 gap-6">
-      <article
-        :for={app <- flagship_apps()}
-        class="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-1)] p-5 flex flex-col"
-        data-role="flagship"
-      >
-        <%!-- The glyph is an emoji out of built_apps/0, shared with
-              /built-with. Set loose at `text-3xl` it read as a stray character
-              above the title; in a bordered tile it reads as the app's mark,
-              which is the job it is doing. --%>
-        <div
-          class="size-11 rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-2)] flex items-center justify-center text-xl leading-none"
-          aria-hidden="true"
-          data-role="glyph"
-        >
-          {app.glyph}
-        </div>
-        <h3 class="mt-4 text-lg font-semibold text-[var(--color-text-primary)]">{app.name}</h3>
-        <p class="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed flex-1">
-          {app.flagship.homepage}
-        </p>
-        <div class="mt-5 flex flex-wrap items-center gap-4">
-          <a
-            href={app.url}
-            rel="noopener"
-            class="inline-flex items-center px-4 py-2 rounded-lg bg-[var(--color-brand)] text-white font-medium hover:bg-[var(--color-brand-hover)] transition-colors text-sm"
-          >
-            Open app
-          </a>
-          <a
-            href={app.source}
-            rel="noopener"
-            class="text-sm text-[var(--color-text-secondary)] underline underline-offset-2 hover:text-[var(--color-text-primary)]"
-          >
-            Source
-          </a>
-        </div>
-      </article>
-    </div>
-    <p class="mt-8 text-center">
-      <a
-        href={~p"/built-with"}
-        class="inline-flex items-center justify-center px-5 py-2.5 rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-bg-1)] text-[var(--color-text-primary)] text-sm font-medium hover:bg-[var(--color-bg-2)] transition-colors"
-      >
-        Browse all {built_app_count()} apps
-      </a>
-    </p>
-  </div>
 </section>
 
 <%!-- FORK TWO, and the finale, on ink: what it costs, how to owe us nothing,

--- a/apps/fountain/test/fountain_web/controllers/docs_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/docs_controller_test.exs
@@ -72,6 +72,32 @@ defmodule FountainWeb.DocsControllerTest do
     end
   end
 
+  describe "runtime landing pages" do
+    for {slug, name} <- [
+          {"claude", "Claude Code"},
+          {"codex", "Codex"},
+          {"gemini", "Gemini CLI"},
+          {"opencode", "OpenCode"}
+        ] do
+      @slug slug
+      @name name
+      test "#{name} has a titled page with an executable request", %{conn: conn} do
+        body = conn |> get("/docs/catalog/runtimes/#{@slug}") |> html_response(200)
+        assert body =~ "<title>Docs · Run #{@name} as an API</title>"
+
+        code =
+          Regex.scan(~r{<pre\b[^>]*>(.*?)</pre>}s, body, capture: :all_but_first)
+          |> List.flatten()
+          |> Enum.join("\n")
+
+        assert code =~ "FOUNTAIN_AGENT_ID"
+        assert code =~ "agent_id"
+        refute code =~ "--8<--"
+        assert body =~ "https://fountain-conversations.demo.managoat.com/"
+      end
+    end
+  end
+
   # The search index (#1009) is served as a `<script type="application/json">`
   # block the page's own JS reads with `JSON.parse`. HEEx treats a `<script>`
   # body as raw text and does not interpolate `{...}` inside one, so the

--- a/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
@@ -8,7 +8,7 @@ defmodule FountainWeb.MarketingControllerTest do
   describe "GET / titling" do
     test "names the category in the title and both card titles", %{conn: conn} do
       body = conn |> get(~p"/") |> html_response(200)
-      expected = "Serverless sandboxes for coding agents · #{Fountain.Brand.name()}"
+      expected = "Claude Code, Codex and Gemini CLI behind one API · #{Fountain.Brand.name()}"
 
       assert body =~ "<title>#{expected}</title>"
       assert body =~ ~s(<meta property="og:title" content="#{expected}")
@@ -22,6 +22,21 @@ defmodule FountainWeb.MarketingControllerTest do
       body = conn |> get(~p"/") |> html_response(200)
 
       refute body =~ "<title>#{Fountain.Brand.name()}</title>"
+    end
+  end
+
+  describe "GET / app-first entry" do
+    test "offers a working app before the machine and API explanations", %{conn: conn} do
+      body = conn |> get(~p"/") |> html_response(200)
+      [_, hero] = Regex.run(~r{<section[^>]*data-role="hero"[^>]*>(.*?)</section>}s, body)
+      assert hero =~ "Open Conversations"
+      assert hero =~ ~s(href="https://fountain-conversations.demo.managoat.com/")
+
+      {apps, _} = :binary.match(body, ~s(data-role="flagship"))
+      {machine, _} = :binary.match(body, ~s(data-role="machine-story"))
+      {api, _} = :binary.match(body, ~s(data-role="setup-manifest"))
+      assert apps < machine
+      assert machine < api
     end
   end
 

--- a/apps/fountain/test/fountain_web/controllers/marketing_instance_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_instance_test.exs
@@ -42,7 +42,7 @@ defmodule FountainWeb.MarketingInstanceTest do
       # The title too. The marketing site names the category here; an instance
       # is a front door and not the project, so it keeps the bare brand.
       assert body =~ "<title>#{Fountain.Brand.name()}</title>"
-      refute body =~ "Serverless sandboxes for coding agents"
+      refute body =~ "Claude Code, Codex and Gemini CLI behind one API"
     end
 
     # The footer groups its links now. A deployment that is not the marketing

--- a/docs/catalog/runtimes/claude.md
+++ b/docs/catalog/runtimes/claude.md
@@ -1,6 +1,14 @@
-# claude
+# Run Claude Code as an API
 
 > Anthropic's Claude Code CLI, headless in the sandbox.
+
+Run Claude Code on a sandbox with your repositories, packages and credentials.
+Send a prompt over HTTP, follow the transcript, and send the next prompt to
+the same conversation. Fountain manages the machine between turns.
+
+To use a chat interface, [open Conversations](https://fountain-conversations.demo.managoat.com/).
+To call it from your own code, follow the [quickstart](../../quickstart.md),
+then use the agent definition below.
 
 ## Summary
 
@@ -79,6 +87,19 @@ fix both sit in the transcript, and not only in a log nobody reads.
 conversation tries the OAuth token again. So an organization policy that
 somebody later reverts heals on its own. It does not stay pinned to the
 fallback.
+
+## Call it over HTTP
+
+After you apply the agent definition, set `FOUNTAIN_AGENT_ID` to the returned
+agent id, `FOUNTAIN_BASE_URL` to your instance URL, and `FOUNTAIN_API_KEY` to
+your Fountain account key. The account key is separate from the model credential.
+
+```sh
+--8<-- "docs/snippets/first-request.sh"
+```
+
+Use the returned conversation id to [follow events and send another prompt](../../api.md).
+A self-hosted instance uses the same request at its own base URL.
 
 ## Verify
 

--- a/docs/catalog/runtimes/codex.md
+++ b/docs/catalog/runtimes/codex.md
@@ -1,6 +1,14 @@
-# codex
+# Run Codex as an API
 
 > OpenAI's Codex CLI, headless in the sandbox.
+
+Run Codex on a sandbox with your repositories, packages and credentials.
+Send a prompt over HTTP, follow the transcript, and send the next prompt to
+the same conversation. Fountain manages the machine between turns.
+
+To use a chat interface, [open Conversations](https://fountain-conversations.demo.managoat.com/).
+To call it from your own code, follow the [quickstart](../../quickstart.md),
+then use the agent definition below.
 
 ## Summary
 
@@ -34,6 +42,19 @@ spec:
 The model must carry the `openai/` prefix.
 
 Add your OpenAI key at `/account/inference-credentials` in the app.
+
+## Call it over HTTP
+
+After you apply the agent definition, set `FOUNTAIN_AGENT_ID` to the returned
+agent id, `FOUNTAIN_BASE_URL` to your instance URL, and `FOUNTAIN_API_KEY` to
+your Fountain account key. The account key is separate from the model credential.
+
+```sh
+--8<-- "docs/snippets/first-request.sh"
+```
+
+Use the returned conversation id to [follow events and send another prompt](../../api.md).
+A self-hosted instance uses the same request at its own base URL.
 
 ## Verify
 

--- a/docs/catalog/runtimes/gemini.md
+++ b/docs/catalog/runtimes/gemini.md
@@ -1,7 +1,15 @@
-# gemini
+# Run Gemini CLI as an API
 
 > Google's Gemini CLI. The last runtime to reach ACP, and it reached it on
 > 2026-08-22.
+
+Run Gemini CLI on a sandbox with your repositories, packages and credentials.
+Send a prompt over HTTP, follow the transcript, and send the next prompt to
+the same conversation. Fountain manages the machine between turns.
+
+To use a chat interface, [open Conversations](https://fountain-conversations.demo.managoat.com/).
+To call it from your own code, follow the [quickstart](../../quickstart.md),
+then use the agent definition below.
 
 ## Summary
 
@@ -36,6 +44,19 @@ spec:
 ```
 
 Add your Gemini key at `/account/inference-credentials`.
+
+## Call it over HTTP
+
+After you apply the agent definition, set `FOUNTAIN_AGENT_ID` to the returned
+agent id, `FOUNTAIN_BASE_URL` to your instance URL, and `FOUNTAIN_API_KEY` to
+your Fountain account key. The account key is separate from the model credential.
+
+```sh
+--8<-- "docs/snippets/first-request.sh"
+```
+
+Use the returned conversation id to [follow events and send another prompt](../../api.md).
+A self-hosted instance uses the same request at its own base URL.
 
 ## Verify
 

--- a/docs/catalog/runtimes/opencode.md
+++ b/docs/catalog/runtimes/opencode.md
@@ -1,6 +1,14 @@
-# opencode
+# Run OpenCode as an API
 
 > The opencode CLI. The only runtime that can reach more than one provider.
+
+Run OpenCode on a sandbox with your repositories, packages and credentials.
+Send a prompt over HTTP, follow the transcript, and send the next prompt to
+the same conversation. Fountain manages the machine between turns.
+
+To use a chat interface, [open Conversations](https://fountain-conversations.demo.managoat.com/).
+To call it from your own code, follow the [quickstart](../../quickstart.md),
+then use the agent definition below.
 
 ## Summary
 
@@ -36,6 +44,19 @@ spec:
 
 Add a key for whichever provider you name, at
 `/account/inference-credentials`.
+
+## Call it over HTTP
+
+After you apply the agent definition, set `FOUNTAIN_AGENT_ID` to the returned
+agent id, `FOUNTAIN_BASE_URL` to your instance URL, and `FOUNTAIN_API_KEY` to
+your Fountain account key. The account key is separate from the model credential.
+
+```sh
+--8<-- "docs/snippets/first-request.sh"
+```
+
+Use the returned conversation id to [follow events and send another prompt](../../api.md).
+A self-hosted instance uses the same request at its own base URL.
 
 ## Verify
 

--- a/docs/integrations/adding-a-sandbox-provider.md
+++ b/docs/integrations/adding-a-sandbox-provider.md
@@ -4,9 +4,11 @@ Fountain runs a conversation on a pluggable sandbox backend, behind the
 `Managoat.Sandbox` behaviour. Today those are Sprites, E2B, Daytona and the
 self-hosted runner. This page is the practical checklist for another one.
 The behaviour and the three hosted adapters are the `managoat_sandbox`
-library, in `apps/managoat_sandbox`. The runner adapter lives in Fountain and
-implements the behaviour from outside the library, which is the shape a new
-adapter can take too.
+library, published on [Hex](https://hex.pm/packages/managoat_sandbox) with
+source in [managoat/managoat_sandbox](https://github.com/managoat/managoat_sandbox).
+Fountain pins it in `apps/fountain/mix.exs`. The runner adapter is a separate
+[managoat_runner library](https://github.com/managoat/managoat_runner) that
+implements the same behaviour.
 
 Three places hold the contract itself.
 [ADR 0018](https://github.com/BinaryBourbon/fountain/blob/main/decisions/0018-sandbox-provider-abstraction.md)
@@ -72,15 +74,23 @@ gRPC dependency.
 
 ## The code checklist
 
-Registration centers on `apps/fountain/lib/fountain/sandbox.ex`. The changeset
+A provider change crosses two repositories. Open the adapter and conformance
+PR in the library, publish its Hex release, then bump Fountain's dependency
+pin and register the provider here. Follow the
+[component library contribution recipes](https://github.com/BinaryBourbon/fountain/blob/main/CONTRIBUTING.md#graduating-a-library)
+for the library gates, release and consumer PR. A local path override can test
+the two changes together before release; the committed pin must name a
+published version.
+
+Registration centers on `apps/fountain/lib/fountain/sandbox_providers.ex`. The changeset
 validations and the schema-enum guardrail derive from `known_providers/0`.
 Three lists are still literals, and the guardrail is what catches the drift.
 Those are the `sandbox_provider` enums in `fountain_web/schemas.ex`, on Agent,
 AgentCreate and AgentUpdate, and the `SANDBOX_PROVIDER` boot check in
 `config/runtime.exs`. Budget for those edits.
 
-1. **Adapter modules**, under
-   `apps/managoat_sandbox/lib/managoat/sandbox/<provider>/`. You need the
+1. **Adapter modules**, in the `managoat/managoat_sandbox` repository, under
+   `lib/managoat/sandbox/<provider>/`. You need the
    adapter, with `@behaviour Managoat.Sandbox`, an API client, and whatever stream or
    command-server processes the provider needs. Keep the provider's secrets
    out of an inspection of `Handle.private`. The struct already excludes

--- a/docs/nav.yml
+++ b/docs/nav.yml
@@ -77,10 +77,10 @@ nav:
   - Catalog:
       - Overview: catalog/index.md
       - Runtimes: catalog/runtimes/index.md
-      - claude: catalog/runtimes/claude.md
-      - codex: catalog/runtimes/codex.md
-      - opencode: catalog/runtimes/opencode.md
-      - gemini: catalog/runtimes/gemini.md
+      - Run Claude Code as an API: catalog/runtimes/claude.md
+      - Run Codex as an API: catalog/runtimes/codex.md
+      - Run OpenCode as an API: catalog/runtimes/opencode.md
+      - Run Gemini CLI as an API: catalog/runtimes/gemini.md
       - Skills: catalog/skills/index.md
       - fountain (skill): catalog/skills/fountain.md
       - create-team (skill): catalog/skills/create-team.md


### PR DESCRIPTION
Readers currently encounter the metering and infrastructure explanation before they see an app they can use. Move Conversations, Team and Workbench ahead of that explanation in the README and marketing homepage, with an Open Conversations primary action and links for API development and self-hosting.

Give each existing runtime page a query-shaped title and an expanded, shared curl request. Name Claude Code, Codex and Gemini CLI in the marketing page title and social titles. Runtime URL slugs stay stable. The repository description, topics and homepage URL were also corrected to the values requested in #1583.

The sandbox-provider contribution guide now points to the published `managoat_sandbox` library and its repository, distinguishes `managoat_runner`, and explains the library release followed by the Fountain dependency bump. Its registration path now names the existing `sandbox_providers.ex`.

Closes #1440. Closes #1583. Refs #1578 and #1580.

The app-first text and ordering are implemented here. Product screenshots and the OG image remain pending: an isolated instance and three local apps are ready, but automatic approval review requires explicit approval before transmitting the disposable local API key to their sign-in forms. No login-page or fabricated product screenshots are included. #1578 remains open for its above-the-fold picture requirement alongside #1580.

Validation:
- 140 focused docs and marketing tests passed, including runtime title/snippet expansion and app-before-infrastructure ordering.
- Docs style, Vale (zero errors/warnings), and destink passed across 112 pages.
- The homepage was inspected in the browser at desktop and 390px mobile width; the primary action is visible without horizontal page overflow.
- Full `mix precommit`: compilation, unused dependencies, formatting, Credo, Dialyzer, Sobelow and production assembly passed. The umbrella suite ran 4,277 core tests and 6 doctests, 144 Buzz tests and 33 Support tests, with one docs-anchor timeout during Markdown rendering. All 28 docs tests passed on the focused rerun (2.6 seconds). The same timeout also appeared on the independent SDK workflow branch.
- All 18 GitHub checks passed, including all six test partitions and the coverage gate.
