### PR TITLE
fix(api): report the authenticated key expiry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,6 +168,8 @@ upgrade, is in
 
 ### Fixed
 
+- `/api/auth/me` now returns the presented API key's `expires_at`, or null for a key without an expiry, as its schema declares.
+
 - Deduplicate database gauges across replicas in sandbox, conversation and Oban alerts.
 - Label turn duration and first-output metrics by sandbox provider so hosted alerts can exclude self-hosted runners.
 

--- a/apps/fountain/lib/fountain_web/controllers/auth_me_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/auth_me_controller.ex
@@ -30,6 +30,7 @@ defmodule FountainWeb.AuthMeController do
     json(conn, %{
       id: user.id,
       email: user.email,
+      expires_at: conn.assigns.current_api_key.expires_at,
       role: user.role,
       email_verified: not is_nil(user.email_verified_at),
       # Read side of #525: a client that just bootstrapped an account can see

--- a/apps/fountain/test/fountain_web/controllers/auth_me_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/auth_me_controller_test.exs
@@ -27,6 +27,7 @@ defmodule FountainWeb.AuthMeControllerTest do
                "id" => id,
                "email" => email,
                "role" => role,
+               "expires_at" => nil,
                "comped" => comped
              } = json_response(conn, 200)
 
@@ -34,6 +35,24 @@ defmodule FountainWeb.AuthMeControllerTest do
       assert email == user.email
       assert role == user.role
       assert comped == false
+    end
+
+    test "reports the presented key's expiry, not another key on the account", %{conn: conn} do
+      user = insert_verified_user()
+      expires_at = DateTime.utc_now() |> DateTime.add(3600) |> DateTime.truncate(:second)
+      {_permanent, permanent_key} = insert_api_key(user)
+      {expiring, raw_key} = insert_api_key(user, nil, expires_at: expires_at)
+
+      body = conn |> authed_with_key(raw_key) |> get("/api/auth/me") |> json_response(200)
+      assert body["expires_at"] == DateTime.to_iso8601(expiring.expires_at)
+
+      permanent =
+        build_conn()
+        |> authed_with_key(permanent_key)
+        |> get("/api/auth/me")
+        |> json_response(200)
+
+      assert Map.fetch!(permanent, "expires_at") == nil
     end
 
     test "carries brokered, false off the broker ratchet and true on it", %{conn: conn} do

--- a/apps/fountain/test/fountain_web/schema_guardrail_test.exs
+++ b/apps/fountain/test/fountain_web/schema_guardrail_test.exs
@@ -148,14 +148,7 @@ defmodule FountainWeb.SchemaGuardrailTest do
     #
     # Adding to this list is how a response gets held to its whole schema, not
     # just to the parts it happens to send.
-    @unrendered %{
-      # #1418: `expires_at` is declared and `AuthMeController.show/2` never
-      # renders it. Which way it goes is an API decision rather than a test
-      # one — a client that wants to warn before a key lapses would need the
-      # field rendered, and a client that does not wants it dropped from the
-      # schema. Recorded here with the pointer rather than decided here.
-      {"GET /api/auth/me", "expires_at"} => 1418
-    }
+    @unrendered %{}
 
     test "GET /api/auth/me renders every property AuthMeResponse declares" do
       user = insert_verified_user()


### PR DESCRIPTION
`/api/auth/me` declares `expires_at` but never sends it. Return the presented API key's expiry, including an explicit null for a permanent key, so clients can use the documented field.

Closes #1418.

Removed the schema guard's missing-field exception. Regression coverage authenticates with expiring and permanent keys on the same account to prove the response describes the presented credential.

Validation: 14 focused controller/schema tests passed. Full `mix precommit` passed, including 4,280 core tests and 6 doctests, 144 Buzz tests and 33 Support tests (7 excluded).
