### PR TITLE
fix(cli): render published code changes and system notices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,6 +168,8 @@ upgrade, is in
 
 ### Fixed
 
+- The CLI displays published code changes with their URL, and renders unknown system notices as a dim line.
+
 - Deduplicate database gauges across replicas in sandbox, conversation and Oban alerts.
 - Label turn duration and first-output metrics by sandbox provider so hosted alerts can exclude self-hosted runners.
 

--- a/cli/internal/cmd/conv.go
+++ b/cli/internal/cmd/conv.go
@@ -646,6 +646,9 @@ func formatStreamJSONLine(line string) string {
 	}
 	t, _ := msg["type"].(string)
 	switch t {
+	case "system":
+		return formatSystemEvent(msg)
+
 	case "assistant":
 		message, _ := msg["message"].(map[string]any)
 		content, _ := message["content"].([]any)
@@ -691,4 +694,39 @@ func formatStreamJSONLine(line string) string {
 		}
 	}
 	return ""
+}
+
+// System notices are useful progress, not turn failures. Unknown subtypes
+// stay visible without dumping their payload into the terminal.
+func formatSystemEvent(msg map[string]any) string {
+	field := func(key string) string {
+		value, _ := msg[key].(string)
+		return strings.Join(strings.Fields(value), " ")
+	}
+	subtype := field("subtype")
+	if subtype != "code_change_published" {
+		if subtype == "" {
+			subtype = "notice"
+		}
+		return "\n\x1b[2m▸ system: " + subtype + "\x1b[0m\n"
+	}
+	label := "published"
+	if provider := field("provider"); provider != "" {
+		label += ": " + provider
+		if provider == "github" {
+			label += " pull request"
+		}
+	}
+	reference := field("repo")
+	if identifier := field("identifier"); identifier != "" {
+		reference += "#" + identifier
+	}
+	if reference != "" {
+		label += " " + reference
+	}
+	result := "\n▸ " + label + "\n"
+	if url := field("url"); url != "" {
+		result += "  " + url + "\n"
+	}
+	return result
 }

--- a/cli/internal/cmd/conv_test.go
+++ b/cli/internal/cmd/conv_test.go
@@ -229,3 +229,21 @@ func TestTurnFailureHint(t *testing.T) {
 		t.Fatalf("expected no hint for an unrelated reason, got %q", hint)
 	}
 }
+
+func TestSystemNoticesInTurnOutput(t *testing.T) {
+	tests := []struct{ name, raw, want string }{
+		{"published pull request", `{"type":"system","subtype":"code_change_published","provider":"github","url":"https://github.com/acme/app/pull/42","repo":"acme/app","identifier":"42"}`, "\n▸ published: github pull request acme/app#42\n  https://github.com/acme/app/pull/42\n"},
+		{"missing optional fields", `{"type":"system","subtype":"code_change_published"}`, "\n▸ published\n"},
+		{"unknown subtype", `{"type":"system","subtype":"future_notice","secret":"do not dump"}`, "\n\x1b[2m▸ system: future_notice\x1b[0m\n"},
+		{"unknown fields stay on one line", `{"type":"system","subtype":"future\nnotice"}`, "\n\x1b[2m▸ system: future notice\x1b[0m\n"},
+		{"malformed subtype", `{"type":"system","subtype":42}`, "\n\x1b[2m▸ system: notice\x1b[0m\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatOutput(map[string]any{"stream": "stdout", "stage": "turn", "data": tt.raw})
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The Go CLI drops `system` events from turn output, including the URL when an agent publishes a code change. Render `code_change_published` as a readable publication notice with its URL. Unknown system subtypes produce a dim one-line notice without dumping their payload.

Closes #1047. The issue's original red `Unexpected case` output predates the Go renderer; the missing useful result remained.

Validation: the full Go test suite and `go vet ./...` passed. Regression cases exercise publication, missing fields, unknown subtypes, multiline subtypes and malformed subtype values through the stream-output renderer. `mix precommit apps/fountain/test/fountain/docs_test.exs` passed all static/release gates and 28 docs tests; no Elixir code changed.
