### PR TITLE
fix(swift): stop status reads after run cancellation

### DIFF
--- a/sdk/conformance/matrix.json
+++ b/sdk/conformance/matrix.json
@@ -123,10 +123,7 @@
     "run-timeout-raises-and-keeps-partial-text": {
       "typescript": "yes",
       "python": "yes",
-      "swift": {
-        "skip": "On timeout, Swift cancels the stream but then sends GET /api/conversations/:id before raising its timeout error.",
-        "issue": 1424
-      },
+      "swift": "yes",
       "swift-kit": "yes",
       "elixir": "yes"
     },

--- a/sdk/swift/CHANGELOG.md
+++ b/sdk/swift/CHANGELOG.md
@@ -20,6 +20,8 @@ Notable changes to the Fountain Swift SDK follow
 
 ### Fixed
 
+- A timed-out or cancelled `Fountain.Run` stops before the final conversation status request. The shared timeout scenario now passes for both Swift products.
+
 - `swift test` no longer traps at teardown on Linux with
   "Trying to access a behaviour for a task that in not in the registry"
   (#1410). Cancelling a `URLSessionTask` is unsafe in FoundationNetworking

--- a/sdk/swift/Sources/Fountain/Run.swift
+++ b/sdk/swift/Sources/Fountain/Run.swift
@@ -124,6 +124,7 @@ public final class Run: @unchecked Sendable {
       await progress.update(cursor: event["id"]?.intValue ?? 0, text: follower.text)
       if follower.finished { break }
       if mayEndConversation(event) {
+        try Task.checkCancellation()
         let fresh = try? await http.data("GET", "/api/conversations/\(id)")
         let status = fresh?["status"]?.stringValue ?? conversation["status"]?.stringValue
         if status == "failed" || status == "terminated" {
@@ -132,6 +133,9 @@ public final class Run: @unchecked Sendable {
         }
       }
     }
+    // Cancellation can end stream iteration normally. Do not start another
+    // request after the deadline has won the race.
+    try Task.checkCancellation()
     let fresh = try? await http.data("GET", "/api/conversations/\(id)")
     let status = fresh?["status"]?.stringValue ?? conversation["status"]?.stringValue
     let state = follower.state ?? (failureReason == nil ? .timeout : .failed)


### PR DESCRIPTION
A timed-out `Fountain.Run` cancels its stream, but stream iteration can end normally and send one more conversation-status GET before the timeout reaches the caller. Check cancellation before that request and before the terminal-stage status probe.

Closes #1424.

Enable the existing `run-timeout-raises-and-keeps-partial-text` conformance scenario for `swift`; keep its exact request expectations. It failed before the fix on the extra GET and passes afterward, preserving the timeout error and partial text. `FountainKit` already passed this scenario.

Validation: all 76 Swift tests passed, Swift formatting passed, and the release build passed. `mix precommit apps/fountain/test/fountain/docs_test.exs` passed all static/release gates and 28 docs tests; no Elixir code changed.
