### PR TITLE
docs(ops): distinguish portable and hosted alert coverage

### DIFF
--- a/apps/fountain/test/fountain/docs_test.exs
+++ b/apps/fountain/test/fountain/docs_test.exs
@@ -42,6 +42,21 @@ defmodule Fountain.DocsTest do
 
   @repo_root Path.expand("../../../..", __DIR__)
 
+  test "the portable alert table matches the shipped rule names" do
+    rules = File.read!(Path.join(@repo_root, "deploy/k8s/prometheusrule.yaml"))
+    page = File.read!(Path.join(@repo_root, "docs/guides/operate/observability.md"))
+    [_, table] = Regex.run(~r/### Portable baseline\n(.*?)### Added by the hosted overlay/s, page)
+
+    shipped =
+      Regex.scan(~r/^\s*- alert: (\w+)/m, rules, capture: :all_but_first) |> List.flatten()
+
+    documented =
+      Regex.scan(~r/\| `(Fountain\w+)` \|/, table, capture: :all_but_first) |> List.flatten()
+
+    assert shipped != []
+    assert Enum.sort(documented) == Enum.sort(shipped)
+  end
+
   describe "nav ← docs/nav.yml" do
     test "parses the real docs/nav.yml into pages and one-level sections" do
       nav = Docs.nav_source()

--- a/docs/guides/operate/back-up-and-restore.md
+++ b/docs/guides/operate/back-up-and-restore.md
@@ -104,6 +104,10 @@ The Kubernetes CronJob has the
 [Sentry Crons check-in](../../integrations/sentry.md#crons-an-alert-when-a-scheduled-job-stops)
 built in. Set `SENTRY_DSN`, then arm the monitor's schedule.
 
+The portable alerts cover the dump CronJob. If you use CNPG for point-in-time
+recovery, add the separate base-backup and WAL alerts described in
+[Which alerts you get](observability.md#which-alerts-you-get).
+
 On compose, read the dates on the service's log lines.
 
 ```bash

--- a/docs/guides/operate/observability.md
+++ b/docs/guides/operate/observability.md
@@ -33,6 +33,84 @@ each provider holds right now, by status. See
 [See what sandboxes cost](sandbox-spend.md) for the per-account view that goes
 with it.
 
+## Which alerts you get
+
+The portable rules are in
+[`deploy/k8s/prometheusrule.yaml`](https://github.com/BinaryBourbon/fountain/blob/main/deploy/k8s/prometheusrule.yaml).
+They are optional: enable the file in your Kustomization and install the
+PrometheusRule CRD and the scrapes its expressions need. A rule file alone
+does not collect metrics.
+
+The hosted instance adds rules in the
+[home-cloud overlay](https://github.com/jhgaylor/home-cloud/blob/main/platform/fountain-site/prometheusrule.yaml).
+Those rules are specific to that deployment. They do not arrive with the
+portable manifest artifact. Shared rule names can also have different
+thresholds or selectors in the overlay.
+
+### Portable baseline
+
+| Rule | What it watches |
+|---|---|
+| `FountainBackupStale` | The optional dump CronJob has not succeeded in 36 hours. |
+| `FountainBackupNeverSucceeded` | The dump CronJob has no successful run. |
+| `FountainBackupJobFailing` | A dump Job failed. |
+| `FountainBackupSuspended` | The dump CronJob has `suspend: true`. |
+| `FountainMetricsTargetDown` | Prometheus cannot scrape Fountain. |
+| `FountainHighServerErrorRate` | More than 5% of HTTP responses are server errors. |
+| `FountainUnhandledExceptions` | Request handlers raise exceptions. |
+| `FountainDatabasePoolSaturated` | Requests wait for database connections. |
+| `FountainProvisionFailures` | Sandbox provision attempts fail. |
+| `FountainProvisionDeadlineExceeded` | A provision attempt reaches its watchdog deadline. |
+| `FountainSandboxBudgetExceeded` | Sandbox concurrency exceeds the configured budget. |
+| `FountainConversationsAboveBudget` | Live conversations exceed the configured budget. |
+| `FountainUntrackedSprites` | Sprites exist without a sandbox row. |
+| `FountainReaperSilent` | The sandbox reaper has not completed a run. |
+| `FountainObanJobsRaising` | Background jobs raise exceptions. |
+| `FountainObanJobsDiscarded` | Background jobs exhaust their retries. |
+| `FountainObanQueueBacklog` | A background queue has a sustained backlog. |
+
+### Added by the hosted overlay
+
+| Rule | What it watches |
+|---|---|
+| `FountainPitrBaseBackupStale` | The CNPG base backup is older than 26 hours. |
+| `FountainPitrBaseBackupNeverSucceeded` | CNPG has never completed a base backup. |
+| `FountainPitrBackupFailed` | The latest CNPG base backup failed. |
+| `FountainPitrWalArchivingFailing` | The write-ahead log (WAL) archive queue falls behind. |
+| `FountainPitrMetricsAbsent` | CNPG base-backup metrics are absent from Prometheus. |
+| `FountainPitrWalMetricsAbsent` | CNPG WAL archive metrics are absent from Prometheus. |
+| `FountainStageFailures` | Conversation stages fail. |
+| `FountainSiteUnreachable` | An external probe cannot reach the public site. |
+| `FountainCreditPricerSilent` | The turn pricer has no successful pass. |
+| `FountainCreditWorkerSilent` | A credit worker stops. |
+| `FountainCreditPricerPricedNothing` | Paid-provider turns complete without ledger debits. |
+| `FountainStripeWebhookFailures` | Stripe webhooks fail. |
+| `FountainEmailDeliveryFailures` | Transactional email fails to send. |
+| `FountainBrokerListenerDown` | The broker listener refuses connections. |
+| `FountainBrokerUnreachable` | A probe cannot reach the broker through its Service. |
+| `FountainBrokerDenialSpike` | The broker denies most requests. |
+| `FountainBrokerUpstreamFailures` | The broker cannot reach upstream origins. |
+| `FountainBrokerSessionsUnresolvable` | Sandbox broker tokens do not resolve. |
+| `FountainBrokerLogDropping` | The broker drops request-log rows. |
+| `FountainBrokerCaExpiring` | The broker root CA expires within 14 days. |
+
+### If you run CNPG
+
+The four portable backup rules watch the dump CronJob. They do **not** cover
+CNPG point-in-time recovery (PITR), its base backups or WAL archives.
+
+Add the six `FountainPitr*` rules from the overlay to your own Prometheus
+configuration. Enable the scrape for your CNPG cluster and check that the
+metrics named in those rules appear in Prometheus. Adapt the namespace,
+cluster name, scrape labels and backup cadence: the hosted selectors name
+`fountain` and `fountain-pg`, and the staleness threshold assumes daily base
+backups.
+
+Keep both missing-metrics rules. Without them, an exporter that stops can make a failed backup look quiet. Validate the rules with
+`promtool`, exercise an absent scrape, and run a
+[restore drill](back-up-and-restore.md#run-the-restore-drill). An alert that
+stays quiet does not prove a backup can restore your data.
+
 ## Logs
 
 Logs go to stdout.


### PR DESCRIPTION
The portable backup alerts cover the optional dump CronJob; they do not cover CNPG point-in-time recovery. Document the 17 portable rules separately from the 20 additional hosted rules, link their sources, and explain the six PITR rules and scrape configuration a CNPG self-hoster needs.

Closes #1171.

The backup guide links to this coverage distinction. A regression test compares the portable table's rule names with the shipped YAML so an alert addition or removal cannot silently stale the inventory.

Validation: `mix precommit apps/fountain/test/fountain/docs_test.exs` passed all static/release gates and 29 docs tests. Docs style, Vale (zero errors/warnings), and destink passed across 112 pages. The hosted list was checked against home-cloud's current alert file.
