### PR TITLE
fix(manifest): reject unknown spec keys before applying resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ upgrade, is in
 
 ### Changed
 
+- Manifest apply rejects unknown `spec` keys before writing that resource or its secrets. Previously, Ecto silently discarded them, including misspelled network restrictions. Correct these keys before upgrading. Bulk apply keeps its HTTP 200 response with per-resource errors; other valid resources still apply. Ownership keys remain ignored.
+
 - **Credential brokerage is on for every account on the hosted platform**
   (ADR 0019 §9, home-cloud#163). It was limited access, enrolled by hand, and
   named one tenant from 2026-08-25. The docs said so on six pages; they now

--- a/apps/fountain/lib/fountain/agents/agent.ex
+++ b/apps/fountain/lib/fountain/agents/agent.ex
@@ -63,9 +63,9 @@ defmodule Fountain.Agents.Agent do
   @doc "The sandbox modes a launch may choose (ADR 0023)."
   def sandbox_modes, do: @sandbox_modes
 
-  def changeset(agent, attrs) do
-    agent
-    |> cast(attrs, [
+  @doc false
+  def cast_fields,
+    do: [
       :name,
       :description,
       :system,
@@ -81,7 +81,11 @@ defmodule Fountain.Agents.Agent do
       :permission_policy,
       :user_id,
       :environment_id
-    ])
+    ]
+
+  def changeset(agent, attrs) do
+    agent
+    |> cast(attrs, cast_fields())
     |> validate_required([:name, :model, :runtime])
     |> validate_inclusion(:runtime, @runtimes)
     |> validate_inclusion(:sandbox_mode, @sandbox_modes)

--- a/apps/fountain/lib/fountain/environments/environment.ex
+++ b/apps/fountain/lib/fountain/environments/environment.ex
@@ -49,9 +49,9 @@ defmodule Fountain.Environments.Environment do
   def warm_start_fields, do: @warm_start_fields
   def networking, do: @networking
 
-  def changeset(env, attrs) do
-    env
-    |> cast(attrs, [
+  @doc false
+  def cast_fields,
+    do: [
       :name,
       :packages,
       :env_vars,
@@ -62,7 +62,11 @@ defmodule Fountain.Environments.Environment do
       :checkpoint_id,
       :metadata,
       :user_id
-    ])
+    ]
+
+  def changeset(env, attrs) do
+    env
+    |> cast(attrs, cast_fields())
     |> validate_required([:name])
     |> validate_inclusion(:networking_type, @networking)
     |> validate_length(:name, min: 1, max: 200)

--- a/apps/fountain/lib/fountain/manifest.ex
+++ b/apps/fountain/lib/fountain/manifest.ex
@@ -74,88 +74,100 @@ defmodule Fountain.Manifest do
   # ── per-kind reconciliation ───────────────────────────────────────────────
 
   defp apply_environment(user_id, %{"name" => name} = res, dek, opts) do
-    {attrs, secrets} = split_spec(res, name)
+    with :ok <- validate_spec(res, Environments.Environment, ~w(secrets)) do
+      {attrs, secrets} = split_spec(res, name)
 
-    outcome =
-      case Environments.get_environment_by_name(name, user_id) do
-        nil ->
-          {:created, Environments.create_environment(Map.put(attrs, "user_id", user_id), opts)}
+      outcome =
+        case Environments.get_environment_by_name(name, user_id) do
+          nil ->
+            {:created, Environments.create_environment(Map.put(attrs, "user_id", user_id), opts)}
 
-        env ->
-          {:updated, Environments.update_environment(env, attrs, opts)}
+          env ->
+            {:updated, Environments.update_environment(env, attrs, opts)}
+        end
+
+      case outcome do
+        {action, {:ok, env}} ->
+          secret_results =
+            upsert_secrets(secrets, &Environments.upsert_secret(env, &1, dek, secret_opts(opts)))
+
+          {result("Environment", name, action, nil, secret_results, env.id), env}
+
+        {_action, {:error, changeset}} ->
+          {result("Environment", name, :error, changeset_errors(changeset), []), nil}
       end
-
-    case outcome do
-      {action, {:ok, env}} ->
-        secret_results =
-          upsert_secrets(secrets, &Environments.upsert_secret(env, &1, dek, secret_opts(opts)))
-
-        {result("Environment", name, action, nil, secret_results, env.id), env}
-
-      {_action, {:error, changeset}} ->
-        {result("Environment", name, :error, changeset_errors(changeset), []), nil}
+    else
+      {:error, errors} -> {result("Environment", name, :error, errors, []), nil}
     end
   end
 
   defp apply_vault(user_id, %{"name" => name} = res, dek, opts) do
-    {attrs, secrets} = split_spec(res, name)
+    with :ok <- validate_spec(res, Vaults.Vault, ~w(secrets)) do
+      {attrs, secrets} = split_spec(res, name)
 
-    outcome =
-      case Vaults.get_vault_by_name(name, user_id) do
-        nil -> {:created, Vaults.create_vault(Map.put(attrs, "user_id", user_id), opts)}
-        vault -> {:updated, Vaults.update_vault(vault, attrs, opts)}
+      outcome =
+        case Vaults.get_vault_by_name(name, user_id) do
+          nil -> {:created, Vaults.create_vault(Map.put(attrs, "user_id", user_id), opts)}
+          vault -> {:updated, Vaults.update_vault(vault, attrs, opts)}
+        end
+
+      case outcome do
+        {action, {:ok, vault}} ->
+          secret_results =
+            upsert_secrets(secrets, &Vaults.upsert_secret(vault, &1, dek, secret_opts(opts)))
+
+          result("Vault", name, action, nil, secret_results, vault.id)
+
+        {_action, {:error, changeset}} ->
+          result("Vault", name, :error, changeset_errors(changeset), [])
       end
-
-    case outcome do
-      {action, {:ok, vault}} ->
-        secret_results =
-          upsert_secrets(secrets, &Vaults.upsert_secret(vault, &1, dek, secret_opts(opts)))
-
-        result("Vault", name, action, nil, secret_results, vault.id)
-
-      {_action, {:error, changeset}} ->
-        result("Vault", name, :error, changeset_errors(changeset), [])
+    else
+      {:error, errors} -> result("Vault", name, :error, errors, [])
     end
   end
 
   defp apply_agent(user_id, %{"name" => name} = res, env_id_by_name, opts) do
-    {attrs, _secrets} = split_spec(res, name)
-    {env_ref, attrs} = Map.pop(attrs, "environment")
+    with :ok <- validate_spec(res, Agents.Agent, ~w(environment)) do
+      {attrs, _secrets} = split_spec(res, name)
+      {env_ref, attrs} = Map.pop(attrs, "environment")
 
-    case resolve_environment_ref(user_id, env_ref, env_id_by_name) do
-      {:ok, env_attrs} ->
-        attrs = Map.merge(attrs, env_attrs)
+      case resolve_environment_ref(user_id, env_ref, env_id_by_name) do
+        {:ok, env_attrs} ->
+          attrs = Map.merge(attrs, env_attrs)
 
-        outcome =
-          case Agents.get_agent_by_name(name, user_id) do
-            nil -> {:created, Agents.create_agent(Map.put(attrs, "user_id", user_id), opts)}
-            agent -> {:updated, Agents.update_agent(agent, attrs, opts)}
+          outcome =
+            case Agents.get_agent_by_name(name, user_id) do
+              nil -> {:created, Agents.create_agent(Map.put(attrs, "user_id", user_id), opts)}
+              agent -> {:updated, Agents.update_agent(agent, attrs, opts)}
+            end
+
+          case outcome do
+            {action, {:ok, _agent}} ->
+              result("Agent", name, action, nil, [])
+
+            # Moving the agent's environment rebuilds its machine, which a
+            # running turn blocks (#1084). Reported against the field that
+            # caused it so `fountain apply` says what to do about it.
+            {_action, {:error, :sandbox_mid_turn}} ->
+              errors = %{
+                "environment" => [
+                  "the agent is running a turn on its own machine; changing its " <>
+                    "environment rebuilds that machine — retry once the turn ends"
+                ]
+              }
+
+              result("Agent", name, :error, errors, [])
+
+            {_action, {:error, cs}} ->
+              result("Agent", name, :error, changeset_errors(cs), [])
           end
 
-        case outcome do
-          {action, {:ok, _agent}} ->
-            result("Agent", name, action, nil, [])
-
-          # Moving the agent's environment rebuilds its machine, which a
-          # running turn blocks (#1084). Reported against the field that
-          # caused it so `fountain apply` says what to do about it.
-          {_action, {:error, :sandbox_mid_turn}} ->
-            errors = %{
-              "environment" => [
-                "the agent is running a turn on its own machine; changing its " <>
-                  "environment rebuilds that machine — retry once the turn ends"
-              ]
-            }
-
-            result("Agent", name, :error, errors, [])
-
-          {_action, {:error, cs}} ->
-            result("Agent", name, :error, changeset_errors(cs), [])
-        end
-
-      {:error, ref} ->
-        errors = %{"environment" => ["environment not found: #{ref}"]}
-        result("Agent", name, :error, errors, [])
+        {:error, ref} ->
+          errors = %{"environment" => ["environment not found: #{ref}"]}
+          result("Agent", name, :error, errors, [])
+      end
+    else
+      {:error, errors} -> result("Agent", name, :error, errors, [])
     end
   end
 
@@ -228,6 +240,20 @@ defmodule Fountain.Manifest do
   end
 
   defp valid_resource?(_res), do: false
+
+  # Use the changeset's cast fields, not every database field: timestamps,
+  # virtual counts and other read-only state must not look configurable.
+  defp validate_spec(res, schema, extra_keys) do
+    allowed =
+      Enum.map(schema.cast_fields(), &Atom.to_string/1) ++ extra_keys ++ ~w(id user_id created_by)
+
+    unknown = Map.keys(res["spec"] || %{}) -- allowed
+
+    case unknown do
+      [] -> :ok
+      keys -> {:error, Map.new(keys, &{&1, ["is not a supported spec key"]})}
+    end
+  end
 
   # The top-level resource name is authoritative — it is the upsert key, so
   # it overrides any `name` a spec happens to carry.

--- a/apps/fountain/lib/fountain/vaults/vault.ex
+++ b/apps/fountain/lib/fountain/vaults/vault.ex
@@ -23,9 +23,12 @@ defmodule Fountain.Vaults.Vault do
     timestamps(type: :utc_datetime)
   end
 
+  @doc false
+  def cast_fields, do: [:name, :description, :metadata, :user_id]
+
   def changeset(vault, attrs) do
     vault
-    |> cast(attrs, [:name, :description, :metadata, :user_id])
+    |> cast(attrs, cast_fields())
     |> validate_required([:name])
     |> validate_length(:name, min: 1, max: 200)
     |> unique_constraint(:name, name: :vaults_user_id_name_index)

--- a/apps/fountain/test/fountain/manifest_test.exs
+++ b/apps/fountain/test/fountain/manifest_test.exs
@@ -24,6 +24,69 @@ defmodule Fountain.ManifestTest do
     %{"kind" => "Agent", "name" => name, "spec" => spec}
   end
 
+  describe "spec keys" do
+    test "rejects unknown keys on each kind before it creates records", %{user: user} do
+      resources = [
+        env_resource("bad-env", %{
+          "network_policy" => "limited",
+          "allowed_hosts" => ["example.test"]
+        }),
+        vault_resource("bad-vault", %{"descrption" => "private"}),
+        agent_resource("bad-agent", %{"permisson_policy" => %{"default" => "auto_deny"}}),
+        vault_resource("good-vault")
+      ]
+
+      assert {:ok, [env, vault, good, agent]} = Manifest.apply_manifest(user.id, resources)
+      assert env.action == :error
+      assert Enum.sort(Map.keys(env.errors)) == ["allowed_hosts", "network_policy"]
+      assert vault.action == :error
+      assert Map.has_key?(vault.errors, "descrption")
+      assert agent.action == :error
+      assert Map.has_key?(agent.errors, "permisson_policy")
+      assert good.action == :created
+      refute Environments.get_environment_by_name("bad-env", user.id)
+      refute Vaults.get_vault_by_name("bad-vault", user.id)
+      refute Agents.get_agent_by_name("bad-agent", user.id)
+    end
+
+    test "a rejected update writes neither attributes nor secrets", %{user: user} do
+      assert {:ok, [%{action: :created}]} =
+               Manifest.apply_manifest(user.id, [
+                 env_resource("locked", %{
+                   "setup_script" => "original",
+                   "networking_type" => "limited",
+                   "networking_config" => %{"allowed_hosts" => ["example.test"]},
+                   "secrets" => %{"TOKEN" => "original"}
+                 })
+               ])
+
+      assert {:ok, [%{action: :error, secrets: []}]} =
+               Manifest.apply_manifest(user.id, [
+                 env_resource("locked", %{
+                   "setup_script" => "changed",
+                   "network_policy" => "unrestricted",
+                   "secrets" => %{"TOKEN" => "replacement"}
+                 })
+               ])
+
+      env = Environments.get_environment_by_name("locked", user.id)
+      assert env.setup_script == "original"
+      assert env.networking_type == "limited"
+      {:ok, dek} = Crypto.load_tenant_key(user.id)
+      assert Environments.decrypted_env(env, dek) == %{"TOKEN" => "original"}
+    end
+
+    test "database fields and secrets on an Agent are not accepted spec keys", %{user: user} do
+      for resource <- [
+            env_resource("e", %{"inserted_at" => "2026-01-01T00:00:00Z"}),
+            vault_resource("v", %{"secret_count" => 4}),
+            agent_resource("a", %{"avatar_media_type" => "image/png", "secrets" => %{}})
+          ] do
+        assert {:ok, [%{action: :error}]} = Manifest.apply_manifest(user.id, [resource])
+      end
+    end
+  end
+
   describe "apply_manifest/2 creation" do
     test "creates environments, vaults, and agents with secrets", %{user: user} do
       resources = [

--- a/apps/fountain/test/fountain_web/controllers/apply_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/apply_controller_test.exs
@@ -63,6 +63,41 @@ defmodule FountainWeb.ApplyControllerTest do
              }
     end
 
+    test "reports unknown spec keys per resource without applying them", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
+      payload = %{
+        "resources" => [
+          %{
+            "kind" => "Environment",
+            "name" => "locked",
+            "spec" => %{
+              "network_policy" => "limited",
+              "allowed_hosts" => ["example.test"],
+              "secrets" => %{"TOKEN" => "not-for-the-response"}
+            }
+          },
+          %{"kind" => "Vault", "name" => "valid", "spec" => %{}}
+        ]
+      }
+
+      response = conn |> authed_with_key(raw_key) |> post_json(~p"/api/apply", payload)
+      assert %{"data" => %{"results" => [bad, good]}} = json_response(response, 200)
+      assert bad["action"] == "error"
+
+      assert bad["errors"] == %{
+               "network_policy" => ["is not a supported spec key"],
+               "allowed_hosts" => ["is not a supported spec key"]
+             }
+
+      assert good["action"] == "created"
+      refute response.resp_body =~ "not-for-the-response"
+      refute Environments.get_environment_by_name("locked", user.id)
+      assert Vaults.get_vault_by_name("valid", user.id)
+    end
+
     test "never echoes secret values back", %{conn: conn, raw_key: raw_key} do
       payload = %{
         "resources" => [

--- a/docs/api.md
+++ b/docs/api.md
@@ -461,6 +461,12 @@ a `200`, with one result for each resource. Each result carries an `action` of
 `errors`. Each result also carries the outcome for each secret key. Fountain
 never echoes a secret value back.
 
+An unknown `spec` key gives that resource an `error` result, before Fountain
+writes its attributes or secrets. Use `networking_type` and
+`networking_config` for environment network restrictions; `network_policy`
+is not a supported field. Ownership keys (`id`, `user_id`, `created_by`)
+remain ignored: a manifest cannot change the account that owns a resource.
+
 ## Conversations
 
 A conversation takes many turns. Create one with a first prompt, then prompt

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -330,6 +330,10 @@ The server reconciles the environments, then the vaults, then the agents. It
 resolves an agent's `environment:` name reference, and that includes an
 environment that already exists on the server.
 
+The server rejects unknown `spec` keys per resource. The CLI prints those
+errors and exits nonzero; valid resources in the same manifest still apply.
+Correct a misspelled field before you retry.
+
 Against an older server with no `/api/apply`, the CLI falls back to one call
 for each resource.
 


### PR DESCRIPTION
A manifest with `network_policy: limited` currently reports success while silently retaining an unrestricted environment: Ecto drops keys outside its cast list. Reject unknown top-level `spec` keys before creating or updating that resource or its secrets, and name the offending keys in the resource's errors.

Closes #1496.

Share the writable-field lists with the Agent, Environment and Vault changesets. This avoids accepting read-only database fields merely because they exist in a schema. Keep the manifest-specific `environment` reference for Agents, `secrets` for Environments/Vaults, and the existing ownership-key stripping. Free-form map contents still use their existing validation.

Compatibility: manifests that relied on silently ignored keys must correct them. Preserve the established bulk-apply contract—HTTP 200 with per-resource errors, and valid resources still apply—rather than changing the whole request to 422. The CLI already exits nonzero for those errors. The changelog and API/CLI docs explain this behavior. No migration is needed.

Validation:
- 22 focused context/controller tests passed. New cases cover all three kinds, the network-policy typo, read-only fields, partial success, no secret-value echo, and rejection of updates without changing either attributes or secrets.
- Inspected the example/contract manifest files; the five actual resource specs in the shipped YAML examples contain no unsupported keys.
- Full `mix precommit` passed: static/release gates, 4,283 core tests and 6 doctests, 144 Buzz tests and 33 Support tests (7 excluded).
- Docs style, Vale (zero errors/warnings), and destink passed across 112 pages.
