### PR TITLE
feat(testing): exercise deployed API lifecycle and tenant isolation

### DIFF
--- a/deployed/README.md
+++ b/deployed/README.md
@@ -79,7 +79,9 @@ for the exercised API surface, permitting compatible added properties. It
 does not fetch the advertised schema to redefine the expected responses.
 Schema failures stay failures; there is no blanket bypass for the broader
 schema gaps tracked in #1432 and #1444. The OpenAPI document is summarized by
-hash/version rather than copied into response traces.
+hash/version rather than copied into response traces. Collection responses
+are checked in memory but omitted from traces so existing account resources
+and the second tenant's resources do not become suite artifacts.
 
 Every initialized run writes `result.json` and `junit.xml`, with check durations
 and failures. `http.jsonl` contains bounded JSON response evidence and request

--- a/deployed/README.md
+++ b/deployed/README.md
@@ -3,7 +3,9 @@
 This suite runs outside Fountain against a base URL. It requires Node 24 or
 newer and no package install, Elixir application, database connection, or SDK
 credential store. The initial `probe` profile checks authenticated identity,
-catalog capabilities, liveness and database readiness.
+catalog capabilities, liveness and database readiness. The `basic` profile
+adds resource CRUD, validation errors, key revocation, tenant isolation, and
+an independent check of the instance's advertised response schemas.
 
 The execution, integration, recovery and browser profiles in tracker #1606
 are not implemented yet. A passing probe does not prove that conversations
@@ -48,6 +50,36 @@ No configured sandbox is needed for `probe`.
 ```
 
 ## Results and limits
+
+For `basic`, supply two **different** verified test accounts through explicit
+environment-variable names. Two keys for the same account fail before any
+fixture mutation. This profile includes the probe checks, so select `basic`
+alone. Neither account needs inference credentials or a sandbox provider.
+
+```json
+{
+  "base_url": "http://localhost:4000",
+  "credentials": {
+    "primary": "FOUNTAIN_SUITE_KEY",
+    "secondary": "FOUNTAIN_SUITE_OTHER_KEY"
+  },
+  "profiles": ["basic"]
+}
+```
+
+Basic creates an environment, vault, agent, and disposable API key. It verifies
+read/update/list/delete behavior, field errors, missing resources, and denied
+cross-tenant reads and mutations. The agent uses the built-in Claude runtime
+with a model identifier accepted by the API; it is never started. A metadata
+update keeps the run-owned name stable for interrupted-run recovery.
+
+Actual responses always validate against the pinned contract. A separate
+check compares the advertised operations, statuses and response schema shapes
+for the exercised API surface, permitting compatible added properties. It
+does not fetch the advertised schema to redefine the expected responses.
+Schema failures stay failures; there is no blanket bypass for the broader
+schema gaps tracked in #1432 and #1444. The OpenAPI document is summarized by
+hash/version rather than copied into response traces.
 
 Every initialized run writes `result.json` and `junit.xml`, with check durations
 and failures. `http.jsonl` contains bounded JSON response evidence and request

--- a/deployed/lib/advertisement.mjs
+++ b/deployed/lib/advertisement.mjs
@@ -1,0 +1,49 @@
+// Compare advertised responses with the independently pinned projection for
+// the operations this profile exercises. Compatible added properties/statuses
+// are allowed. This does not replace validation of actual HTTP responses.
+export function verifyAdvertisement(spec, contract, operations) {
+  if (!spec.openapi?.startsWith('3.0.') || !spec.paths || !spec.components?.schemas) throw new Error('Expected an OpenAPI 3.0 document');
+  const seen = new Set();
+  function node(actual, expected, at) {
+    if (!actual || typeof actual !== 'object') throw new Error(`${at}: advertised schema missing`);
+    if (expected.ref) {
+      const name = expected.ref;
+      if (actual.$ref !== `#/components/schemas/${name}`) throw new Error(`${at}: advertised reference differs`);
+      if (!seen.has(name)) {
+        seen.add(name);
+        if (!contract.schemas[name]) throw new Error(`${at}: pinned reference missing`);
+        node(spec.components.schemas[name], contract.schemas[name], `schema/${name}`);
+      }
+      return;
+    }
+    for (const key of ['type', 'format']) {
+      if (expected[key] !== undefined && actual[key] !== expected[key]) throw new Error(`${at}: advertised ${key} differs`);
+    }
+    if (Boolean(actual.nullable) !== Boolean(expected.nullable)) throw new Error(`${at}: advertised nullability differs`);
+    if (expected.enum && (!Array.isArray(actual.enum) || expected.enum.some(v => !actual.enum.map(String).includes(v)))) {
+      throw new Error(`${at}: advertised enum removed a value`);
+    }
+    for (const [name, property] of Object.entries(expected.properties ?? {})) {
+      if (Boolean(property.required) !== Boolean(actual.required?.includes(name))) throw new Error(`${at}.${name}: advertised requiredness differs`);
+      node(actual.properties?.[name], property, `${at}.${name}`);
+    }
+    if (expected.items) node(actual.items, expected.items, `${at}[]`);
+    for (const keyword of ['oneOf', 'anyOf', 'allOf']) {
+      if (!expected[keyword]) continue;
+      if (actual[keyword]?.length !== expected[keyword].length) throw new Error(`${at}: advertised ${keyword} differs`);
+      expected[keyword].forEach((member, i) => node(actual[keyword][i], member, `${at}/${keyword}/${i}`));
+    }
+    if (typeof expected.additionalProperties === 'object') node(actual.additionalProperties, expected.additionalProperties, `${at}.*`);
+    if (typeof expected.additionalProperties === 'boolean' && actual.additionalProperties !== expected.additionalProperties) throw new Error(`${at}: advertised additional-property rule differs`);
+  }
+  for (const key of operations) {
+    const [method, path] = key.split(' ');
+    const expected = contract.operations[key];
+    const actual = spec.paths[path]?.[method.toLowerCase()];
+    if (!expected || !actual) throw new Error(`${key}: operation missing from pinned or advertised contract`);
+    for (const [status, content] of Object.entries(expected.responses)) {
+      if (!actual.responses?.[status]) throw new Error(`${key}: advertised ${status} response missing`);
+      if (content['application/json']) node(actual.responses[status].content?.['application/json']?.schema, content['application/json'], `${key}/${status}`);
+    }
+  }
+}

--- a/deployed/lib/fixtures.mjs
+++ b/deployed/lib/fixtures.mjs
@@ -64,7 +64,7 @@ export class Fixtures {
         const collection = collections[r.kind];
         let value;
         if (!r.id || r.kind === 'api_key') {
-          const response = await this.client.request('GET', collection, { expected: 200, validate: false, signal });
+          const response = await this.client.request('GET', collection, { expected: 200, validate: false, recordBody: false, signal });
           if (!Array.isArray(response.body?.data)) throw new Error('Cannot read cleanup ownership evidence');
           const matches = response.body.data.filter(item => r.id ? item.id === r.id : item.name === r.name);
           if (matches.length > 1) throw new Error('Ambiguous cleanup intent');

--- a/deployed/lib/http.mjs
+++ b/deployed/lib/http.mjs
@@ -28,7 +28,7 @@ export class Client {
   constructor({ baseUrl, key, redactor, trace, signal, timeoutMs = 10000, contract }) {
     Object.assign(this, { baseUrl, key, redactor, trace, signal, timeoutMs, contract });
   }
-  async request(method, path, { body, key = this.key, expected, validate = true, signal = this.signal } = {}) {
+  async request(method, path, { body, key = this.key, expected, validate = true, recordBody = true, signal = this.signal } = {}) {
     if (!path.startsWith('/') || path.startsWith('//') || path.includes('..')) throw new Error('Expected a relative API path');
     const started = performance.now();
     const headers = { accept: 'application/json' };
@@ -65,9 +65,9 @@ export class Client {
         if (!/^application\/json(?:;|$)/i.test(response.headers.get('content-type') ?? '')) throw new Error('Response is not application/json');
       }
       // Collect secrets throughout the body before redacting sibling fields.
-      this.redactor.value(json);
+      if (recordBody) this.redactor.value(json);
       this.trace({ method, path, status: response.status, duration_ms: performance.now() - started,
-        request_id: response.headers.get('x-request-id'), body: this.redactor.value(json) });
+        request_id: response.headers.get('x-request-id'), body: recordBody ? this.redactor.value(json) : undefined, response_bytes: size });
       if (expected !== undefined && ![expected].flat().includes(response.status)) {
         throw new Error(`${method} ${path}: expected ${[expected].flat().join('/')} but received ${response.status}`);
       }

--- a/deployed/lib/runner.mjs
+++ b/deployed/lib/runner.mjs
@@ -6,9 +6,10 @@ import { Contract } from './contract.mjs';
 import { Client, Redactor } from './http.mjs';
 import { atomicJson, Fixtures } from './fixtures.mjs';
 import { probe } from '../profiles/probe.mjs';
+import { basic } from '../profiles/basic.mjs';
 
 export const VERSION = '0.1.0';
-export const profiles = { probe };
+export const profiles = { probe, basic };
 const contractPath = fileURLToPath(new URL('../../sdk/contract/contract.json', import.meta.url));
 
 function requireThat(condition, message) { if (!condition) throw new Error(message); }
@@ -33,6 +34,12 @@ export function configFrom(path, env = process.env) {
   config.profiles ??= ['probe'];
   requireThat(Array.isArray(config.profiles) && config.profiles.length > 0 && new Set(config.profiles).size === config.profiles.length &&
     config.profiles.every(name => Object.hasOwn(profiles, name)), 'Unknown, empty, or duplicate profile selection');
+  requireThat(Object.keys(config.credentials).every(k => ['primary', 'secondary'].includes(k)), 'Unknown credential role');
+  if (config.profiles.includes('basic')) {
+    requireThat(typeof config.credentials.secondary === 'string' && /^[A-Z][A-Z0-9_]*$/.test(config.credentials.secondary), 'Basic profile requires credentials.secondary environment variable');
+    config.secondaryKey = env[config.credentials.secondary];
+    requireThat(typeof config.secondaryKey === 'string' && config.secondaryKey.trim().length > 0, `Missing test credential: ${config.credentials.secondary}`);
+  }
   config.contract = config.contract ? resolve(dirname(path), config.contract) : contractPath;
   const limits = config.limits ?? {};
   requireThat(Object.keys(limits).every(k => ['request_ms', 'run_ms', 'cleanup_ms', 'resources'].includes(k)), 'Unknown limit');
@@ -86,6 +93,7 @@ export async function run({ configPath, out, manifestPath, signal, env = process
   try {
     config = configFrom(configPath, env);
     redactor.add(config.key);
+    redactor.add(config.secondaryKey);
     report.target = config.base_url;
     report.profiles = config.profiles;
     report.limits = { ...config.limits, concurrency: 1, inference_turns: 0 };

--- a/deployed/profiles/basic.mjs
+++ b/deployed/profiles/basic.mjs
@@ -1,0 +1,80 @@
+import { randomUUID, createHash } from 'node:crypto';
+import { probe } from './probe.mjs';
+import { verifyAdvertisement } from '../lib/advertisement.mjs';
+
+export async function basic(ctx) {
+  const { client, fixtures, config, require: need, check } = ctx;
+  const other = config.secondaryKey;
+  // Establish both identities before creating anything. Reusing the same
+  // account with another key would turn an isolation test into a false verdict.
+  const distinct = await check('basic/second-tenant', async () => {
+    const { body } = await client.request('GET', '/api/auth/me', { key: other, expected: 200 });
+    need(body.email_verified === true && body.id !== ctx.report.owner_id, 'Basic profile requires two distinct verified test accounts');
+    ctx.report.secondary_owner_id = body.id;
+  });
+  if (!distinct) return;
+  await probe(ctx);
+  await check('basic/authentication', async () => {
+    for (const key of [null, `ftn_invalid_${randomUUID()}`]) {
+      const { body } = await client.request('GET', '/api/auth/me', { key, expected: 401 });
+      need(typeof body.error === 'string', 'Authentication denial must carry an error');
+    }
+  });
+  const operations = new Set(['GET /api/auth/me', 'GET /api/catalog', 'GET /health', 'GET /health/ready']);
+  for (const [kind, collection, attrs] of [
+    ['environment', '/api/environments', {}],
+    ['vault', '/api/vaults', {}],
+    ['agent', '/api/agents', { runtime: 'claude', model: 'anthropic/claude-sonnet-4-6' }],
+  ]) {
+    for (const op of [`GET ${collection}`, `POST ${collection}`, `GET ${collection}/{id}`, `PUT ${collection}/{id}`, `DELETE ${collection}/{id}`]) operations.add(op);
+    await check(`basic/${kind}/lifecycle-and-isolation`, async () => {
+      const value = await fixtures.create(kind, attrs);
+      const path = `${collection}/${value.id}`;
+      const marker = { suite_revision: randomUUID() };
+      const read = await client.request('GET', path, { expected: 200 });
+      need(read.body.data.id === value.id && read.body.data.name === value.name, 'Created resource did not round-trip');
+      const update = await client.request('PUT', path, { expected: 200, body: { metadata: marker } });
+      need(update.body.data.metadata?.suite_revision === marker.suite_revision, 'Resource metadata update was lost');
+      const listed = await client.request('GET', collection, { expected: 200 });
+      need(listed.body.data.some(item => item.id === value.id), 'Own list omitted created resource');
+      const otherList = await client.request('GET', collection, { key: other, expected: 200 });
+      need(!otherList.body.data.some(item => item.id === value.id), 'Other tenant list disclosed resource');
+      for (const method of ['GET', 'PUT', 'DELETE']) {
+        const denied = await client.request(method, path, { key: other, expected: 404,
+          body: method === 'PUT' ? { metadata: { suite_revision: 'unauthorized' } } : undefined });
+        need(typeof denied.body.error === 'string', 'Cross-tenant denial has no error');
+      }
+      const preserved = await client.request('GET', path, { expected: 200 });
+      need(preserved.body.data.metadata?.suite_revision === marker.suite_revision, 'Denied mutation changed the resource');
+      await client.request('GET', `${collection}/${randomUUID()}`, { expected: 404 });
+      const invalid = await client.request('PUT', path, { expected: 422, body: { name: '' } });
+      need(invalid.body.errors && Object.hasOwn(invalid.body.errors, 'name'), 'Validation response lost name field errors');
+      // Name remains stable throughout the test so recovery can prove ownership.
+      const unchanged = await client.request('GET', path, { expected: 200 });
+      need(unchanged.body.data.name === value.name, 'Invalid mutation changed the fixture name');
+      await client.request('DELETE', path, { expected: 204 });
+      await client.request('GET', path, { expected: 404 });
+      // The final cleanup pass reconciles the already-deleted manifest entry.
+    });
+  }
+  await check('basic/key-lifecycle', async () => {
+    const key = await fixtures.create('api_key');
+    need(typeof key.key === 'string' && key.key.length > 0, 'New key is missing its one-time plaintext');
+    const identity = await client.request('GET', '/api/auth/me', { key: key.key, expected: 200 });
+    need(identity.body.id === ctx.report.owner_id, 'Minted key authenticated as another account');
+    const listed = await client.request('GET', '/api/auth/api-keys', { expected: 200 });
+    need(listed.body.data.some(item => item.id === key.id), 'Minted key is absent from key list');
+    need(!JSON.stringify(listed.body).includes(key.key), 'Key listing disclosed plaintext key material');
+    await client.request('DELETE', `/api/auth/api-keys/${key.id}`, { key: other, expected: 404 });
+    await client.request('DELETE', `/api/auth/api-keys/${key.id}`, { expected: 204 });
+    await client.request('GET', '/api/auth/me', { key: key.key, expected: 401 });
+    await client.request('GET', '/api/auth/me', { expected: 200 });
+  });
+  ['GET /api/auth/api-keys', 'POST /api/auth/api-keys', 'DELETE /api/auth/api-keys/{id}'].forEach(op => operations.add(op));
+  await check('basic/advertised-contract', async () => {
+    const { body } = await client.request('GET', '/api/openapi.json', { expected: 200, validate: false, recordBody: false });
+    ctx.report.advertised_schema = { version: body.info?.version ?? null,
+      sha256: createHash('sha256').update(JSON.stringify(body)).digest('hex'), operations_checked: [...operations] };
+    verifyAdvertisement(body, client.contract.document, [...operations]);
+  });
+}

--- a/deployed/profiles/basic.mjs
+++ b/deployed/profiles/basic.mjs
@@ -35,9 +35,9 @@ export async function basic(ctx) {
       need(read.body.data.id === value.id && read.body.data.name === value.name, 'Created resource did not round-trip');
       const update = await client.request('PUT', path, { expected: 200, body: { metadata: marker } });
       need(update.body.data.metadata?.suite_revision === marker.suite_revision, 'Resource metadata update was lost');
-      const listed = await client.request('GET', collection, { expected: 200 });
+      const listed = await client.request('GET', collection, { expected: 200, recordBody: false });
       need(listed.body.data.some(item => item.id === value.id), 'Own list omitted created resource');
-      const otherList = await client.request('GET', collection, { key: other, expected: 200 });
+      const otherList = await client.request('GET', collection, { key: other, expected: 200, recordBody: false });
       need(!otherList.body.data.some(item => item.id === value.id), 'Other tenant list disclosed resource');
       for (const method of ['GET', 'PUT', 'DELETE']) {
         const denied = await client.request(method, path, { key: other, expected: 404,
@@ -62,7 +62,7 @@ export async function basic(ctx) {
     need(typeof key.key === 'string' && key.key.length > 0, 'New key is missing its one-time plaintext');
     const identity = await client.request('GET', '/api/auth/me', { key: key.key, expected: 200 });
     need(identity.body.id === ctx.report.owner_id, 'Minted key authenticated as another account');
-    const listed = await client.request('GET', '/api/auth/api-keys', { expected: 200 });
+    const listed = await client.request('GET', '/api/auth/api-keys', { expected: 200, recordBody: false });
     need(listed.body.data.some(item => item.id === key.id), 'Minted key is absent from key list');
     need(!JSON.stringify(listed.body).includes(key.key), 'Key listing disclosed plaintext key material');
     await client.request('DELETE', `/api/auth/api-keys/${key.id}`, { key: other, expected: 404 });

--- a/deployed/test/advertisement.test.mjs
+++ b/deployed/test/advertisement.test.mjs
@@ -1,0 +1,31 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { verifyAdvertisement } from '../lib/advertisement.mjs';
+
+const contract = { operations: { 'GET /api/widgets': { responses: { 200: { 'application/json': { ref: 'Widget' } } } } },
+  schemas: { Widget: { type: 'object', properties: { id: { type: 'string', required: true }, count: { type: 'integer', required: false } } } } };
+const spec = { openapi: '3.0.0', paths: { '/api/widgets': { get: { responses: { 200: {
+  content: { 'application/json': { schema: { $ref: '#/components/schemas/Widget' } } },
+} } } } }, components: { schemas: { Widget: { type: 'object', required: ['id'], properties: { id: { type: 'string' }, count: { type: 'integer' } } } } } };
+const operations = ['GET /api/widgets'];
+
+test('advertised contract can add fields without redefining the pinned contract', () => {
+  const changed = structuredClone(spec);
+  changed.components.schemas.Widget.properties.extra = { type: 'boolean' };
+  assert.doesNotThrow(() => verifyAdvertisement(changed, contract, operations));
+});
+
+test('advertised schema cannot remove an operation, required field, or change its type', () => {
+  const removedOperation = structuredClone(spec);
+  delete removedOperation.paths['/api/widgets'];
+  assert.throws(() => verifyAdvertisement(removedOperation, contract, operations), /operation missing/);
+  const removedField = structuredClone(spec);
+  delete removedField.components.schemas.Widget.properties.id;
+  assert.throws(() => verifyAdvertisement(removedField, contract, operations), /schema missing/);
+  const optional = structuredClone(spec);
+  optional.components.schemas.Widget.required = [];
+  assert.throws(() => verifyAdvertisement(optional, contract, operations), /requiredness/);
+  const changedType = structuredClone(spec);
+  changedType.components.schemas.Widget.properties.count.type = 'string';
+  assert.throws(() => verifyAdvertisement(changedType, contract, operations), /type differs/);
+});

--- a/deployed/test/runner.test.mjs
+++ b/deployed/test/runner.test.mjs
@@ -78,6 +78,29 @@ test('missing credential and unknown profile are setup failures before network t
   assert.equal(f.requests.length, 0);
 });
 
+test('basic requires two explicit credentials and refuses two keys for one tenant before mutation', async t => {
+  const f = await fixture(t);
+  assert.equal((await f.execute({ profiles: ['basic'] })).code, 2);
+  assert.equal(f.requests.length, 0);
+  const same = await f.execute({ profiles: ['basic'], credentials: { primary: 'SUITE_TEST_KEY', secondary: 'SUITE_OTHER_KEY' } },
+    { env: { SUITE_TEST_KEY: 'first-key', SUITE_OTHER_KEY: 'second-key' } });
+  assert.equal(same.code, 1);
+  assert.match(same.report.checks.find(c => c.name === 'basic/second-tenant').error, /distinct/);
+  assert.ok(f.requests.every(([method]) => method === 'GET'));
+});
+
+test('schema documents are summarized without treating property schemas as secret values', async t => {
+  const f = await fixture(t, (req, res) => {
+    if (req.url !== '/api/openapi.json') return false;
+    send(res, 200, { components: { schemas: { Password: { properties: { password: { type: 'string' } } } } } });
+    return true;
+  });
+  await f.client.request('GET', '/api/openapi.json', { recordBody: false });
+  assert.equal(f.trace[0].body, undefined);
+  assert.ok(f.trace[0].response_bytes > 0);
+  assert.equal(f.client.redactor.text('expected string'), 'expected string');
+});
+
 test('required capability disappearance fails; optional omissions carry a reason', async t => {
   const f = await fixture(t);
   const missing = await f.execute({ required_capabilities: { sandbox_providers: ['sprites'] } });


### PR DESCRIPTION
Add the `basic` profile to verify a deployed Fountain's public API with two distinct test tenants. It exercises environment/vault/agent CRUD, invalid updates, missing resources, cross-tenant read/write denial, and disposable API-key issuance/revocation without starting a sandbox or invoking inference.

Actual responses validate against the pinned contract. A separate check compares the deployed OpenAPI response declarations for the exercised operations; the server's own schema never defines the suite's expected behavior. Fixtures retain stable run-owned names and cleanup reconciles deleted resources.

Stacked on #1621; merge the runner first, then retarget this PR to `main`.

Validation:
- `node --test deployed/test/*.test.mjs`: 19 passed; also verified on Node 24 in a disposable container.
- Two complete basic-profile runs against the exact published `sha-466c0edc7e1047866c1e71c0e5de02f9b0a00f7c` image in isolated Compose: all 11 checks passed, four resources cleaned each time.
- Repeated cleanup command passed; artifact checks found no bootstrap credentials and confirmed private file permissions.
- `gitleaks dir deployed --redact --no-banner` and `git diff --check` passed.

Fixes #1608. Tracker #1606. This profile does not claim execution/provider health; those remain #1609 onward. Production verification also passed against `https://managoat.com`: all 11 checks passed using two distinct authorized local profiles, with all four run-owned resources cleaned. Collection responses are inspected in memory but omitted from traces to keep unrelated account resources out of artifacts.
