### PR TITLE
feat(testing): verify real deployed conversations and sandbox cleanup

### DIFF
--- a/deployed/README.md
+++ b/deployed/README.md
@@ -7,9 +7,10 @@ catalog capabilities, liveness and database readiness. The `basic` profile
 adds resource CRUD, validation errors, key revocation, tenant isolation, and
 an independent check of the instance's advertised response schemas.
 
-The execution, integration, recovery and browser profiles in tracker #1606
-are not implemented yet. A passing probe does not prove that conversations
-work, and selecting an unimplemented profile fails setup.
+The `execution` profile verifies two real tool-using turns on a fresh
+ephemeral sandbox. Streaming reconnect conformance, integration, recovery and
+browser profiles remain tracked in #1606. A passing probe does not prove
+that conversations work, and selecting an unimplemented profile fails setup.
 
 ## Run
 
@@ -50,6 +51,47 @@ No configured sandbox is needed for `probe`.
 ```
 
 ## Results and limits
+
+For a real conversation, use two verified accounts and configure inference
+credentials on the primary account outside the suite. Select `execution` and
+pin its runtime, model and sandbox provider explicitly. This profile creates
+its own empty environment and agent and never attaches to an existing sandbox.
+
+```json
+{
+  "base_url": "https://your-fountain.example",
+  "credentials": {
+    "primary": "FOUNTAIN_SUITE_KEY",
+    "secondary": "FOUNTAIN_SUITE_OTHER_KEY"
+  },
+  "profiles": ["execution"],
+  "execution": {
+    "runtime": "claude",
+    "model": "anthropic/claude-haiku-4-5",
+    "sandbox_provider": "sprites",
+    "provision_ms": 120000,
+    "turn_ms": 90000,
+    "max_turns": 2
+  },
+  "limits": { "request_ms": 30000, "run_ms": 330000, "cleanup_ms": 90000, "resources": 5 }
+}
+```
+
+Execution observes provisioning through real SSE, writes a random nonce file
+in turn one, reads it in a follow-up, and checks the bytes through the sandbox
+file API. Both turns must have durable completion records and persisted tool
+activity. It checks the second tenant cannot read the conversation, events,
+stream or file, or interrupt/terminate the conversation. It then verifies
+terminal conversation/sandbox state before cleanup deletes the transcript and
+parent fixtures. Usage and IDs remain in the report after deletion.
+
+The fixture manifest records each prompt attempt **before** sending it. A
+lost reply still consumes the two-attempt budget; prompts are never retried
+automatically. Provisioning, each turn, the overall run, and cleanup have
+separate deadlines. A stream that ends early fails the execution check;
+automatic replay/reconnect assertions belong to #1610. SSE traces record
+redacted frames with receive times, and a closed consumer releases its HTTP
+connection. Each stream is capped at 4 MiB.
 
 For `basic`, supply two **different** verified test accounts through explicit
 environment-variable names. Two keys for the same account fail before any
@@ -104,10 +146,12 @@ and the number of created resources. HTTP responses are capped at 2 MiB and
 redirects are not followed. SIGINT/SIGTERM cancel requests and then allow the
 bounded cleanup pass. SIGKILL cannot run cleanup.
 
-The initial profiles invoke **zero inference turns**. They therefore do not
-estimate or enforce a monetary budget. Future execution profiles must account
-for accepted turns and runtime and distinguish any configured monetary
-estimate from a provider-enforced hard limit before invoking inference.
+`probe` and `basic` invoke **zero inference turns**. `execution` submits at
+most two prompts and records provider-reported usage. It does not enforce a
+monetary cap: prompt count and client deadlines are bounded, but model/tool
+activity inside a turn and provider charges are not a fixed price. Cleanup
+terminates the conversation after failure or cancellation; an unavailable
+server/provider can prevent that, which leaves a visible cleanup failure.
 
 The result explicitly reports that deployment revision is unverified. A URL
 and a successful response do not establish image identity. Confirmed rollout
@@ -133,9 +177,13 @@ visible match, it remains unresolved: the original request may still commit.
 Retry cleanup after the server settles and investigate a persistently
 unresolved intent; absence at one instant is not proof of successful cleanup.
 
-The foundation supports named agent, environment, vault and API-key fixtures.
-Conversation/sandbox lifecycle cleanup will be added with the execution
-profile. Keep manifests until every entry is cleaned. A cleanup failure stays
+The runner supports named agent, environment, vault and API-key fixtures,
+plus ephemeral conversations linked to its own recorded agent/environment.
+Conversation ownership is checked using the run-specific channel ID and both
+parent IDs. Cleanup verifies that the sandbox is terminal before deleting the
+conversation; it does not use the persistent-sandbox reset endpoint. A failed
+conversation cleanup retains its parent fixtures so ownership evidence is not
+lost. Keep manifests until every entry is cleaned. A cleanup failure stays
 visible even when the assertions themselves passed.
 
 ## Develop the suite

--- a/deployed/lib/execution.mjs
+++ b/deployed/lib/execution.mjs
@@ -1,0 +1,75 @@
+import { setTimeout as sleep } from 'node:timers/promises';
+import { streamEvents } from './sse.mjs';
+
+export function phaseSignal(parent, ms) { return AbortSignal.any([parent, AbortSignal.timeout(ms)]); }
+export function ensure(ok, message) { if (!ok) throw new Error(message); }
+
+export async function history(client, id, signal, pageSize = 100) {
+  const events = [];
+  let cursor = 0, pages = 0;
+  while (true) {
+    if (++pages > 100) throw new Error('Event history exceeded page budget');
+    const { body } = await client.request('GET', `/api/conversations/${id}/events?blocks=true&limit=${pageSize}&after=${cursor}`, { expected: 200, signal });
+    for (const event of body.data) {
+      ensure(event.id > cursor, 'History cursor did not advance in order');
+      cursor = event.id; events.push(event);
+    }
+    if (!body.meta.has_more) return { events, pages };
+    ensure(body.data.length > 0 && body.meta.next_cursor === cursor, 'History pagination is stuck');
+  }
+}
+
+export async function waitFor(client, path, signal, accept) {
+  while (true) {
+    const { body } = await client.request('GET', path, { expected: 200, signal });
+    if (accept(body.data)) return body.data;
+    await sleep(250, undefined, { signal });
+  }
+}
+
+export async function watchUntil(client, id, signal, accept, options = {}) {
+  const events = [];
+  let cursor = options.after ?? 0;
+  for await (const frame of streamEvents(client, `/api/conversations/${id}/stream?blocks=true`, { signal, ...options })) {
+    const event = frame.event;
+    ensure(event.id > cursor, 'Live SSE event IDs did not advance');
+    cursor = event.id; events.push(frame);
+    if (event.kind === 'stage' && ['failed', 'interrupted'].includes(event.state)) {
+      throw new Error(`Conversation ${id}: ${event.stage}/${event.state} (see event trace)`);
+    }
+    if (await accept(event, frame)) return { events, cursor };
+  }
+  throw new Error(`Conversation ${id}: stream closed before the expected stage`);
+}
+
+export function turnMetadata(event) {
+  if (event.kind !== 'stage' || event.stage !== 'turn') return null;
+  try { return JSON.parse(event.data); } catch { throw new Error('Turn stage metadata is not JSON'); }
+}
+
+export async function performTurn(ctx, conversation, prompt, number, after) {
+  const signal = phaseSignal(ctx.signal, ctx.config.execution.turn_ms);
+  ctx.fixtures.reserveTurn(conversation.id, ctx.config.execution.max_turns);
+  const queued = await ctx.client.request('POST', `/api/conversations/${conversation.id}/prompts`, { body: { prompt }, expected: 200, signal });
+  ensure(queued.body.status === 'queued', 'Prompt was not acknowledged as queued');
+  let startedId;
+  const streamed = await watchUntil(ctx.client, conversation.id, signal, event => {
+    const meta = turnMetadata(event);
+    if (meta?.turn_number !== number) return false;
+    if (event.state === 'started') startedId = meta.turn_id ?? event.turn_id;
+    return event.state === 'done';
+  }, { after });
+  ensure(typeof startedId === 'string', `Turn ${number} had no start event`);
+  const turns = await waitFor(ctx.client, `/api/conversations/${conversation.id}/turns`, signal, rows =>
+    rows.some(row => row.turn_number === number && row.status === 'completed'));
+  ensure(turns.length === number, 'Unexpected additional inference turn');
+  const turn = turns.find(t => t.turn_number === number);
+  ensure(turn.id === startedId && turn.prompt === prompt, 'Turn identity/prompt disagrees with accepted work');
+  ensure(turn.exit_code === 0 || turn.exit_code === null, 'Completed turn has a nonzero exit code');
+  const stored = await history(ctx.client, conversation.id, signal);
+  const ownEvents = stored.events.filter(event => event.turn_id === turn.id);
+  const tools = ownEvents.flatMap(event => event.blocks ?? []).filter(block => block.kind === 'tool_use');
+  ensure(tools.length > 0, `Turn ${number} produced no persisted tool activity`);
+  ctx.report.execution.turns.push({ id: turn.id, number, status: turn.status, usage: turn.usage ?? null, tools: tools.map(t => t.name) });
+  return { ...streamed, turn, stored: stored.events };
+}

--- a/deployed/lib/fixtures.mjs
+++ b/deployed/lib/fixtures.mjs
@@ -1,7 +1,8 @@
 import { writeFileSync, renameSync, readFileSync } from 'node:fs';
 import { randomUUID } from 'node:crypto';
+import { setTimeout as sleep } from 'node:timers/promises';
 
-const collections = { agent: '/api/agents', environment: '/api/environments', vault: '/api/vaults', api_key: '/api/auth/api-keys' };
+const collections = { agent: '/api/agents', environment: '/api/environments', vault: '/api/vaults', api_key: '/api/auth/api-keys', conversation: '/api/conversations' };
 const uuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 export function atomicJson(path, value) {
@@ -29,6 +30,14 @@ export class Fixtures {
           (r.id !== undefined && !uuid.test(r.id)) || !['pending', 'created', 'cleaned'].includes(r.state)) {
         throw new Error('Invalid cleanup resource; refusing the manifest');
       }
+      if (r.kind === 'conversation') {
+        if (![r.agent_id, r.environment_id].every(id => uuid.test(id)) ||
+            (r.sandbox_id !== undefined && !uuid.test(r.sandbox_id)) ||
+            !existing.resources.some(item => item.kind === 'agent' && item.id === r.agent_id) ||
+            !existing.resources.some(item => item.kind === 'environment' && item.id === r.environment_id)) {
+          throw new Error('Conversation manifest must reference recorded agent/environment fixtures');
+        }
+      }
     }
     return new Fixtures(path, client, { existing });
   }
@@ -37,10 +46,18 @@ export class Fixtures {
     if (!collections[kind]) throw new Error('Unsupported fixture kind');
     if (this.manifest.resources.length >= this.maxResources) throw new Error('Fixture resource budget exhausted');
     const resource = { kind, name: `suite-${this.manifest.run_id}-${kind}-${this.manifest.resources.length}`, state: 'pending' };
+    if (kind === 'conversation') {
+      for (const parent of ['agent', 'environment']) {
+        const id = attrs[`${parent}_id`];
+        if (!this.manifest.resources.some(r => r.kind === parent && r.id === id && r.state === 'created')) throw new Error('Conversation must use run-owned agent and environment');
+        resource[`${parent}_id`] = id;
+      }
+      if (attrs.prompt !== undefined || attrs.sandbox_id !== undefined) throw new Error('Create conversation without inference or an existing sandbox');
+    }
     this.manifest.resources.push(resource);
     this.save(); // Intent survives a response lost after the server commits.
     const result = await this.client.request('POST', collections[kind], {
-      body: { ...attrs, name: resource.name }, validate: false,
+      body: kind === 'conversation' ? { ...attrs, title: resource.name, channel_id: resource.name, sandbox_mode: 'ephemeral' } : { ...attrs, name: resource.name }, validate: false,
     });
     if (result.status >= 400 && result.status < 500) {
       resource.state = 'cleaned'; this.save();
@@ -49,24 +66,55 @@ export class Fixtures {
     const value = kind === 'api_key' ? result.body : result.body?.data;
     if (result.status !== 201 || !uuid.test(value?.id)) throw new Error(`Create ${kind}: no successful resource identity; cleanup intent retained`);
     resource.id = value.id;
+    if (kind === 'conversation' && value.sandbox_id) resource.sandbox_id = value.sandbox_id;
     resource.state = 'created';
     this.save(); // Record ID before schema assertions can fail.
     this.client.contract?.check('POST', collections[kind], result.status, result.body);
-    if (value.name !== resource.name) throw new Error(`Create ${kind}: returned name differs; cleanup will require ownership evidence`);
+    if ((kind === 'conversation' ? value.channel_id : value.name) !== resource.name) throw new Error(`Create ${kind}: returned ownership marker differs; cleanup will require ownership evidence`);
     return value;
+  }
+  reserveTurn(id, maxTurns) {
+    const r = this.manifest.resources.find(r => r.kind === 'conversation' && r.id === id && r.state === 'created');
+    if (!r) throw new Error('Inference requires a recorded conversation');
+    const attempts = this.manifest.inference_attempts ?? 0;
+    if (attempts >= maxTurns) throw new Error('Inference turn budget exhausted');
+    this.manifest.inference_attempts = attempts + 1;
+    this.save(); // Lost prompt replies still consume the budget; never auto-retry.
+  }
+  async terminateConversation(r, value, signal) {
+    if (value.agent_id !== r.agent_id || value.environment_id !== r.environment_id || value.channel_id !== r.name) throw new Error('Conversation ownership evidence differs');
+    if (value.sandbox && value.sandbox.mode !== 'ephemeral') throw new Error('Refusing to clean a non-ephemeral sandbox');
+    if (value.sandbox_id) {
+      if (r.sandbox_id && r.sandbox_id !== value.sandbox_id) throw new Error('Conversation sandbox identity changed');
+      r.sandbox_id = value.sandbox_id; this.save();
+    }
+    while (true) {
+      signal?.throwIfAborted();
+      const response = await this.client.request('POST', `/api/conversations/${r.id}/terminate`, { expected: [204, 404, 503], validate: false, signal });
+      if (response.status !== 503) break;
+      await sleep(500, undefined, { signal });
+    }
+    const conv = await this.client.request('GET', `/api/conversations/${r.id}`, { expected: [200, 404], validate: false, signal });
+    if (conv.status === 200 && !['terminated', 'failed'].includes(conv.body.data?.status)) throw new Error('Conversation did not terminate');
+    if (r.sandbox_id) {
+      const sandbox = await this.client.request('GET', `/api/sandboxes/${r.sandbox_id}`, { expected: [200, 404], validate: false, signal });
+      if (sandbox.status === 200 && (sandbox.body.data?.agent_id !== r.agent_id || !['terminated', 'failed'].includes(sandbox.body.data?.status))) throw new Error('Run-owned sandbox is still live or has changed owner');
+    }
   }
   async cleanup(signal) {
     const failures = [];
     for (const r of [...this.manifest.resources].reverse()) {
       if (r.state === 'cleaned') continue;
       try {
+        if (r.kind !== 'conversation' && this.manifest.resources.some(child => child.kind === 'conversation' && child.state !== 'cleaned' && [child.agent_id, child.environment_id].includes(r.id))) throw new Error('Retaining parent fixture until conversation cleanup succeeds');
         signal?.throwIfAborted();
         const collection = collections[r.kind];
         let value;
         if (!r.id || r.kind === 'api_key') {
-          const response = await this.client.request('GET', collection, { expected: 200, validate: false, recordBody: false, signal });
+          const listPath = r.kind === 'conversation' ? `${collection}?agent_id=${r.agent_id}` : collection;
+          const response = await this.client.request('GET', listPath, { expected: 200, validate: false, recordBody: false, signal });
           if (!Array.isArray(response.body?.data)) throw new Error('Cannot read cleanup ownership evidence');
-          const matches = response.body.data.filter(item => r.id ? item.id === r.id : item.name === r.name);
+          const matches = response.body.data.filter(item => r.id ? item.id === r.id : (r.kind === 'conversation' ? item.channel_id : item.name) === r.name);
           if (matches.length > 1) throw new Error('Ambiguous cleanup intent');
           value = matches[0];
           if (!value && !r.id) throw new Error('Unresolved create intent; retry cleanup after the server settles');
@@ -76,9 +124,14 @@ export class Fixtures {
           if (response.status === 200 && !value) throw new Error('Missing cleanup ownership evidence');
         }
         if (value) {
-          if (value.name !== r.name || !uuid.test(value.id)) throw new Error('Cleanup ownership evidence does not match');
+          if ((r.kind === 'conversation' ? value.channel_id : value.name) !== r.name || !uuid.test(value.id)) throw new Error('Cleanup ownership evidence does not match');
           r.id = value.id; this.save();
+          if (r.kind === 'conversation') await this.terminateConversation(r, value, signal);
           await this.client.request('DELETE', `${collection}/${r.id}`, { expected: [204, 404], validate: false, signal });
+        }
+        if (r.kind === 'conversation' && !value && r.sandbox_id) {
+          const sandbox = await this.client.request('GET', `/api/sandboxes/${r.sandbox_id}`, { expected: [200, 404], validate: false, signal });
+          if (sandbox.status === 200 && !['terminated', 'failed'].includes(sandbox.body.data?.status)) throw new Error('Deleted conversation still has a live sandbox');
         }
         r.state = 'cleaned'; this.save();
       } catch (error) { failures.push({ kind: r.kind, id: r.id, error: error.message }); }

--- a/deployed/lib/runner.mjs
+++ b/deployed/lib/runner.mjs
@@ -7,9 +7,10 @@ import { Client, Redactor } from './http.mjs';
 import { atomicJson, Fixtures } from './fixtures.mjs';
 import { probe } from '../profiles/probe.mjs';
 import { basic } from '../profiles/basic.mjs';
+import { execution } from '../profiles/execution.mjs';
 
 export const VERSION = '0.1.0';
-export const profiles = { probe, basic };
+export const profiles = { probe, basic, execution };
 const contractPath = fileURLToPath(new URL('../../sdk/contract/contract.json', import.meta.url));
 
 function requireThat(condition, message) { if (!condition) throw new Error(message); }
@@ -21,7 +22,7 @@ function positive(value, fallback, max) {
 
 export function configFrom(path, env = process.env) {
   const config = JSON.parse(readFileSync(path, 'utf8'));
-  const allowed = ['base_url', 'credentials', 'profiles', 'contract', 'required_capabilities', 'optional_capabilities', 'limits'];
+  const allowed = ['base_url', 'credentials', 'profiles', 'contract', 'required_capabilities', 'optional_capabilities', 'limits', 'execution'];
   requireThat(Object.keys(config).every(key => allowed.includes(key)), 'Unknown configuration field');
   const url = new URL(config.base_url);
   requireThat(['http:', 'https:'].includes(url.protocol) && !url.username && !url.password && !url.search && !url.hash,
@@ -35,10 +36,20 @@ export function configFrom(path, env = process.env) {
   requireThat(Array.isArray(config.profiles) && config.profiles.length > 0 && new Set(config.profiles).size === config.profiles.length &&
     config.profiles.every(name => Object.hasOwn(profiles, name)), 'Unknown, empty, or duplicate profile selection');
   requireThat(Object.keys(config.credentials).every(k => ['primary', 'secondary'].includes(k)), 'Unknown credential role');
-  if (config.profiles.includes('basic')) {
-    requireThat(typeof config.credentials.secondary === 'string' && /^[A-Z][A-Z0-9_]*$/.test(config.credentials.secondary), 'Basic profile requires credentials.secondary environment variable');
+  if (config.profiles.some(name => ['basic', 'execution'].includes(name))) {
+    requireThat(typeof config.credentials.secondary === 'string' && /^[A-Z][A-Z0-9_]*$/.test(config.credentials.secondary), 'Selected profile requires credentials.secondary environment variable');
     config.secondaryKey = env[config.credentials.secondary];
     requireThat(typeof config.secondaryKey === 'string' && config.secondaryKey.trim().length > 0, `Missing test credential: ${config.credentials.secondary}`);
+  }
+  if (config.profiles.includes('execution')) {
+    const settings = config.execution;
+    requireThat(settings && Object.keys(settings).every(k => ['runtime', 'model', 'sandbox_provider', 'provision_ms', 'turn_ms', 'max_turns'].includes(k)), 'Expected explicit execution configuration');
+    requireThat(['claude', 'codex', 'gemini', 'opencode'].includes(settings.runtime) &&
+      typeof settings.model === 'string' && /^[a-z0-9_-]+\/[a-z0-9._-]+$/.test(settings.model) &&
+      ['sprites', 'e2b', 'daytona', 'runner'].includes(settings.sandbox_provider), 'Pin an execution runtime, model, and sandbox provider');
+    settings.provision_ms = positive(settings.provision_ms, 120000, 300000);
+    settings.turn_ms = positive(settings.turn_ms, 90000, 300000);
+    requireThat(settings.max_turns === 2, 'Execution must explicitly authorize max_turns: 2');
   }
   config.contract = config.contract ? resolve(dirname(path), config.contract) : contractPath;
   const limits = config.limits ?? {};
@@ -96,7 +107,7 @@ export async function run({ configPath, out, manifestPath, signal, env = process
     redactor.add(config.secondaryKey);
     report.target = config.base_url;
     report.profiles = config.profiles;
-    report.limits = { ...config.limits, concurrency: 1, inference_turns: 0 };
+    report.limits = { ...config.limits, concurrency: 1, inference_turns: config.execution?.max_turns ?? 0 };
     const contract = new Contract(config.contract);
     report.contract_sha256 = contract.sha256;
     const timeout = AbortSignal.timeout(config.limits.run_ms);
@@ -119,6 +130,10 @@ export async function run({ configPath, out, manifestPath, signal, env = process
         const available = { runtimes: body.data?.runtimes, sandbox_providers: body.data?.sandbox_providers?.enabled };
         requireThat(Object.values(available).every(Array.isArray), 'Catalog capability arrays missing');
         report.capabilities = available;
+        if (config.profiles.includes('execution')) {
+          requireThat(available.runtimes.includes(config.execution.runtime), 'Execution runtime is unavailable');
+          requireThat(available.sandbox_providers.includes(config.execution.sandbox_provider), 'Execution sandbox provider is unavailable');
+        }
         for (const [kind, names] of Object.entries(config.required_capabilities)) {
           for (const name of names) requireThat(available[kind].includes(name), `Missing required ${kind}: ${name}`);
         }
@@ -144,6 +159,7 @@ export async function run({ configPath, out, manifestPath, signal, env = process
     if (fixtures) {
       const failures = await fixtures.cleanup(AbortSignal.timeout(config.limits.cleanup_ms));
       report.cleanup = { failures, remaining: fixtures.manifest.resources.filter(r => r.state !== 'cleaned').length };
+      report.inference_attempts = fixtures.manifest.inference_attempts ?? 0;
       if (failures.length) {
         report.status = 'cleanup_failed';
         report.checks.push({ name: 'cleanup', status: 'failed', duration_ms: 0, error: 'Resources remain; see cleanup manifest and result.json' });

--- a/deployed/lib/sse.mjs
+++ b/deployed/lib/sse.mjs
@@ -1,0 +1,81 @@
+// Strict enough to verify Fountain's wire, independent of its SDK followers.
+// TCP chunks are not frames; decode UTF-8 and CR/LF boundaries incrementally.
+export async function* parseSse(body, { maxBytes = 4 * 1024 * 1024 } = {}) {
+  const reader = body.getReader();
+  const decoder = new TextDecoder('utf-8', { fatal: true });
+  let buffer = '', bytes = 0, frame = [];
+  function finish() {
+    if (!frame.length) return null;
+    const raw = frame.join('\n') + '\n\n';
+    const result = { event: 'message', data: [], raw };
+    for (const line of frame) {
+      if (line.startsWith(':')) continue;
+      const colon = line.indexOf(':');
+      const field = colon < 0 ? line : line.slice(0, colon);
+      let value = colon < 0 ? '' : line.slice(colon + 1);
+      if (value.startsWith(' ')) value = value.slice(1);
+      if (field === 'data') result.data.push(value);
+      if (field === 'event') result.event = value;
+      if (field === 'id' && !value.includes('\0')) result.id = value;
+    }
+    frame = [];
+    return result.data.length ? { ...result, data: result.data.join('\n') } : null;
+  }
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) buffer += decoder.decode();
+      else {
+        bytes += value.length;
+        if (bytes > maxBytes) throw new Error('SSE response exceeds byte budget');
+        buffer += decoder.decode(value, { stream: true });
+      }
+      while (true) {
+        const index = buffer.search(/[\r\n]/);
+        if (index < 0 || (!done && buffer[index] === '\r' && index === buffer.length - 1)) break;
+        const line = buffer.slice(0, index);
+        const width = buffer[index] === '\r' && buffer[index + 1] === '\n' ? 2 : 1;
+        buffer = buffer.slice(index + width);
+        if (line) frame.push(line);
+        else { const ready = finish(); if (ready) yield ready; }
+      }
+      if (done) break;
+    }
+    // A trailing partial frame is a connection failure, not a successful turn.
+    if (buffer.trim() || frame.some(line => !line.startsWith(':'))) throw new Error('SSE connection ended mid-frame');
+  } finally { await reader.cancel().catch(() => {}); }
+}
+
+export async function* streamEvents(client, path, { signal = client.signal, after, maxBytes, trace = client.trace } = {}) {
+  if (!/^\/api\/conversations\/[a-f0-9-]+\/stream(?:\?|$)/i.test(path)) throw new Error('Expected a conversation stream path');
+  if (after !== undefined && (!Number.isSafeInteger(after) || after < 0)) throw new Error('Invalid SSE cursor');
+  const headers = { accept: 'text/event-stream', authorization: `Bearer ${client.key}` };
+  if (after !== undefined) headers['last-event-id'] = String(after);
+  const stop = new AbortController();
+  const combined = signal ? AbortSignal.any([signal, stop.signal]) : stop.signal;
+  const started = performance.now();
+  let response;
+  try {
+    response = await fetch(client.baseUrl + path, { headers, signal: combined, redirect: 'manual' });
+    trace({ method: 'GET', path, after, status: response.status, request_id: response.headers.get('x-request-id'), transport: 'sse' });
+    if (response.status !== 200 || !/^text\/event-stream(?:;|$)/i.test(response.headers.get('content-type') ?? '')) {
+      throw new Error(`SSE expected 200 text/event-stream, received ${response.status}`);
+    }
+    for await (const frame of parseSse(response.body, { maxBytes })) {
+      const receivedMs = performance.now();
+      let event;
+      try { event = JSON.parse(frame.data); } catch { throw new Error('SSE data is not JSON'); }
+      client.redactor.value(event);
+      trace({ transport: 'sse', path, after, received_ms: receivedMs - started, frame: client.redactor.text(frame.raw) });
+      if (frame.id === undefined) throw new Error(`SSE diagnostic without a durable ID (${event.stage ?? frame.event})`);
+      if (!/^\d+$/.test(frame.id) || !Number.isSafeInteger(Number(frame.id))) throw new Error('SSE event has an invalid ID');
+      event = { ...event, id: Number(frame.id) };
+      if (frame.event !== event.kind) throw new Error('SSE event kind disagrees with payload');
+      client.contract?.validate(event, { ref: 'LogEvent' });
+      yield { event, receivedMs };
+    }
+  } finally {
+    stop.abort();
+    if (response?.body && !response.body.locked) await response.body.cancel().catch(() => {});
+  }
+}

--- a/deployed/profiles/execution.mjs
+++ b/deployed/profiles/execution.mjs
@@ -1,0 +1,71 @@
+import { randomUUID } from 'node:crypto';
+import { ensure, phaseSignal, performTurn, watchUntil } from '../lib/execution.mjs';
+
+export async function execution(ctx) {
+  const { client, fixtures, config, check } = ctx;
+  const settings = config.execution;
+  ctx.report.execution = { runtime: settings.runtime, model: settings.model, sandbox_provider: settings.sandbox_provider, turns: [] };
+  let environment, agent, conversation, provision, first, second;
+  const file = `fountain-suite-${ctx.report.run_id}.txt`;
+  const nonce = randomUUID();
+  if (!await check('execution/second-tenant', async () => {
+    const { body } = await client.request('GET', '/api/auth/me', { key: config.secondaryKey, expected: 200 });
+    ensure(body.email_verified && body.id !== ctx.report.owner_id, 'Execution requires two distinct verified accounts');
+  })) return;
+  if (!await check('execution/fixtures', async () => {
+    environment = await fixtures.create('environment');
+    agent = await fixtures.create('agent', { runtime: settings.runtime, model: settings.model,
+      sandbox_provider: settings.sandbox_provider, sandbox_mode: 'ephemeral', environment_id: environment.id,
+      system: 'Perform only the requested small file task. Use a shell tool. Do not access the network or start background work.',
+      permission_policy: { default: 'auto_allow' } });
+    conversation = await fixtures.create('conversation', { agent_id: agent.id, environment_id: environment.id });
+    ctx.report.execution.conversation_id = conversation.id;
+    ctx.report.execution.sandbox_id = conversation.sandbox_id;
+  })) return;
+  if (!await check('execution/provision', async () => {
+    const signal = phaseSignal(ctx.signal, settings.provision_ms);
+    provision = await watchUntil(client, conversation.id, signal, event => event.kind === 'stage' && event.stage === 'provision' && event.state === 'done');
+    const { body } = await client.request('GET', `/api/conversations/${conversation.id}`, { expected: 200, signal });
+    conversation = body.data;
+    ensure(conversation.sandbox?.status === 'ready' && conversation.sandbox.mode === 'ephemeral' && conversation.sandbox.provider === settings.sandbox_provider,
+      'Provisioned sandbox does not match requested provider/mode');
+    ensure(conversation.agent_id === agent.id && conversation.environment_id === environment.id, 'Conversation fixture identity changed');
+    const turns = await client.request('GET', `/api/conversations/${conversation.id}/turns`, { expected: 200, signal });
+    ensure(turns.body.data.length === 0, 'Conversation invoked inference before a prompt was submitted');
+    ctx.report.execution.sandbox_id = conversation.sandbox_id;
+  })) return;
+  const readArtifact = async () => {
+    const response = await client.request('GET', `/api/sandboxes/${conversation.sandbox_id}/file?path=${file}&max_bytes=1024`, { expected: 200 });
+    const value = response.body.data;
+    const contents = value.encoding === 'base64' ? Buffer.from(value.content, 'base64').toString('utf8') : value.content;
+    ensure(!value.truncated && contents === nonce + '\n', 'Artifact bytes do not match the requested nonce');
+    return contents;
+  };
+  if (!await check('execution/first-turn-and-artifact', async () => {
+    first = await performTurn(ctx, conversation,
+      `Use a shell tool to write exactly the text ${nonce} followed by one newline into the relative file ${file}. Read the file with the tool to verify it. Do nothing else.`, 1, provision.cursor);
+    await readArtifact();
+  })) return;
+  if (!await check('execution/follow-up', async () => {
+    second = await performTurn(ctx, conversation,
+      `Use a shell tool to read the existing relative file ${file}. Do not rewrite it or infer its contents from history. Reply with the file contents. Do nothing else.`, 2, first.cursor);
+    await readArtifact();
+    const { body } = await client.request('GET', `/api/conversations/${conversation.id}`, { expected: 200 });
+    ensure(body.data.sandbox_id === conversation.sandbox_id && body.data.turn_count === 2, 'Follow-up did not preserve sandbox/turn continuity');
+    const text = second.stored.filter(e => e.turn_id === second.turn.id).flatMap(e => e.blocks ?? []).filter(b => b.kind === 'text').map(b => b.body ?? '').join('');
+    ensure(text.includes(nonce), 'Follow-up response did not contain the file nonce');
+    ctx.report.execution.usage_total = body.data.usage_total;
+  })) return;
+  await check('execution/tenant-isolation', async () => {
+    for (const path of [`/api/conversations/${conversation.id}`, `/api/conversations/${conversation.id}/events`,
+      `/api/conversations/${conversation.id}/stream?wait=false`, `/api/sandboxes/${conversation.sandbox_id}`,
+      `/api/sandboxes/${conversation.sandbox_id}/file?path=${file}`]) {
+      await client.request('GET', path, { key: config.secondaryKey, expected: 404 });
+    }
+    for (const action of ['interrupt', 'terminate']) await client.request('POST', `/api/conversations/${conversation.id}/${action}`, { key: config.secondaryKey, expected: 404 });
+  });
+  await check('execution/terminate', async () => {
+    const resource = fixtures.manifest.resources.find(r => r.kind === 'conversation' && r.id === conversation.id);
+    await fixtures.terminateConversation(resource, conversation, phaseSignal(ctx.signal, settings.provision_ms));
+  });
+}

--- a/deployed/test/execution.test.mjs
+++ b/deployed/test/execution.test.mjs
@@ -1,0 +1,132 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { parseSse, streamEvents } from '../lib/sse.mjs';
+import { Fixtures } from '../lib/fixtures.mjs';
+import { configFrom } from '../lib/runner.mjs';
+import { history } from '../lib/execution.mjs';
+import { createServer } from 'node:http';
+import { Redactor } from '../lib/http.mjs';
+
+function bytes(parts) {
+  return new ReadableStream({ start(controller) { for (const p of parts) controller.enqueue(typeof p === 'string' ? new TextEncoder().encode(p) : p); controller.close(); } });
+}
+async function collect(stream) { const all = []; for await (const item of stream) all.push(item); return all; }
+
+test('SSE parser handles UTF-8 fragmentation, comments, multiline data and split CRLF', async () => {
+  const wire = Buffer.from(': heartbeat\r\nid: 12\r\nevent: output\r\ndata: α\r\ndata: beta\r\n\r\n');
+  const frames = await collect(parseSse(bytes([...wire].map(n => Uint8Array.of(n)))));
+  assert.equal(frames.length, 1);
+  assert.equal(frames[0].id, '12');
+  assert.equal(frames[0].data, 'α\nbeta');
+  assert.equal((await collect(parseSse(bytes(['data: ok\r\r']))))[0].data, 'ok');
+});
+
+test('SSE parser fails truncated data and bounded oversized streams', async () => {
+  await assert.rejects(collect(parseSse(bytes(['id: 1\ndata: unfinished']))), /mid-frame/);
+  await assert.rejects(collect(parseSse(bytes(['data: too much\n\n']), { maxBytes: 4 })), /byte budget/);
+});
+
+test('breaking an SSE consumer closes its real HTTP connection', async t => {
+  let closed;
+  const disconnected = new Promise(resolve => { closed = resolve; });
+  const server = createServer((req, res) => {
+    req.on('close', closed);
+    res.writeHead(200, { 'content-type': 'text/event-stream' });
+    res.write('id: 1\nevent: output\ndata: {"kind":"output","data":"hi"}\n\n');
+  });
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  t.after(() => { server.closeAllConnections(); server.close(); });
+  const client = { baseUrl: `http://127.0.0.1:${server.address().port}`, key: randomUUID(), redactor: new Redactor(), trace() {} };
+  for await (const { event } of streamEvents(client, `/api/conversations/${randomUUID()}/stream`, { signal: AbortSignal.timeout(1000) })) {
+    assert.equal(event.id, 1); break;
+  }
+  await Promise.race([disconnected, new Promise((_, reject) => setTimeout(() => reject(new Error('SSE connection leaked')), 1500).unref())]);
+});
+
+function fixtures(t, request) {
+  const dir = mkdtempSync(join(tmpdir(), 'fountain-execution-test-'));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  const path = join(dir, 'cleanup.json');
+  const f = new Fixtures(path, { request, baseUrl: 'https://example.test' }, { runId: randomUUID(), ownerId: randomUUID(), baseUrl: 'https://example.test' });
+  const agent = { kind: 'agent', id: randomUUID(), name: `suite-${f.manifest.run_id}-agent-0`, state: 'created' };
+  const environment = { kind: 'environment', id: randomUUID(), name: `suite-${f.manifest.run_id}-environment-1`, state: 'created' };
+  f.manifest.resources.push(agent, environment); f.save();
+  return { f, agent, environment, path, dir };
+}
+
+test('conversation creation cannot attach to existing resources or invoke unbudgeted inference', async t => {
+  const { f, agent, environment } = fixtures(t, () => { throw new Error('Must not make a request'); });
+  await assert.rejects(f.create('conversation', { agent_id: randomUUID(), environment_id: environment.id }), /run-owned/);
+  await assert.rejects(f.create('conversation', { agent_id: agent.id, environment_id: environment.id, prompt: 'unbudgeted' }), /without inference/);
+  assert.equal(f.manifest.resources.length, 2);
+});
+
+test('turn budget is durable before a prompt can be sent and cannot exceed two attempts', async t => {
+  const { f, agent, environment, path } = fixtures(t, () => {});
+  const id = randomUUID();
+  f.manifest.resources.push({ kind: 'conversation', id, name: `suite-${f.manifest.run_id}-conversation-2`, agent_id: agent.id, environment_id: environment.id, state: 'created' });
+  f.reserveTurn(id, 2); f.reserveTurn(id, 2);
+  assert.equal(JSON.parse(readFileSync(path)).inference_attempts, 2);
+  assert.throws(() => f.reserveTurn(id, 2), /budget exhausted/);
+  assert.throws(() => f.reserveTurn(randomUUID(), 2), /recorded conversation/);
+});
+
+test('conversation cleanup verifies termination before deleting transcript and parent fixtures', async t => {
+  const requests = [];
+  let f, agent, environment, conversation, terminated = false;
+  const setup = fixtures(t, async (method, path) => {
+    requests.push([method, path]);
+    if (path.endsWith('/terminate')) { terminated = true; return { status: 204 }; }
+    if (path === `/api/conversations/${conversation.id}` && method === 'GET') return { status: 200, body: { data: { ...conversation, channel_id: conversation.name, status: terminated ? 'terminated' : 'idle', sandbox: { mode: 'ephemeral' } } } };
+    if (path === `/api/sandboxes/${conversation.sandbox_id}`) return { status: 200, body: { data: { status: terminated ? 'terminated' : 'ready', agent_id: agent.id } } };
+    if (method === 'GET') return { status: 200, body: { data: path.includes('agents') ? agent : environment } };
+    return { status: 204 };
+  });
+  ({ f, agent, environment } = setup);
+  conversation = { kind: 'conversation', id: randomUUID(), name: `suite-${f.manifest.run_id}-conversation-2`, agent_id: agent.id, environment_id: environment.id, sandbox_id: randomUUID(), state: 'created' };
+  f.manifest.resources.push(conversation); f.save();
+  assert.deepEqual(await f.cleanup(AbortSignal.timeout(1000)), []);
+  const terminatedAt = requests.findIndex(([, p]) => p.endsWith('/terminate'));
+  const deletedAt = requests.findIndex(([method, p]) => method === 'DELETE' && p.includes('conversations'));
+  assert.ok(terminatedAt >= 0 && deletedAt > terminatedAt);
+  assert.equal(requests.filter(([m]) => m === 'DELETE').length, 3);
+});
+
+test('a live leaked sandbox retains the conversation and its ownership fixtures', async t => {
+  let f, agent, environment, conversation;
+  const deleted = [];
+  ({ f, agent, environment } = fixtures(t, async (method, path) => {
+    if (method === 'DELETE') deleted.push(path);
+    if (path.endsWith('/terminate')) return { status: 204 };
+    if (path.includes('/sandboxes/')) return { status: 200, body: { data: { status: 'ready', agent_id: agent.id } } };
+    return { status: 200, body: { data: { ...conversation, channel_id: conversation.name, status: 'terminated', sandbox: { mode: 'ephemeral' } } } };
+  }));
+  conversation = { kind: 'conversation', id: randomUUID(), name: `suite-${f.manifest.run_id}-conversation-2`, agent_id: agent.id, environment_id: environment.id, sandbox_id: randomUUID(), state: 'created' };
+  f.manifest.resources.push(conversation); f.save();
+  assert.equal((await f.cleanup(AbortSignal.timeout(1000))).length, 3);
+  assert.deepEqual(deleted, []);
+  assert.equal(conversation.state, 'created');
+});
+
+test('history enforces cursor progress without assuming consecutive global IDs', async () => {
+  let n = 0;
+  const client = { request: async () => ({ body: n++ === 0 ? { data: [{ id: 2 }, { id: 17 }], meta: { has_more: true, next_cursor: 17 } } : { data: [{ id: 91 }], meta: { has_more: false, next_cursor: 91 } } }) };
+  assert.deepEqual((await history(client, randomUUID(), undefined, 2)).events.map(e => e.id), [2, 17, 91]);
+  await assert.rejects(history({ request: async () => ({ body: { data: [], meta: { has_more: true, next_cursor: null } } }) }, randomUUID()), /stuck/);
+});
+
+test('execution requires an explicit two-turn authorization and both credentials', t => {
+  const { dir } = fixtures(t, () => {});
+  const path = join(dir, 'config.json');
+  const cfg = { base_url: 'https://example.test', profiles: ['execution'], credentials: { primary: 'TEST_KEY', secondary: 'OTHER_KEY' }, execution: { runtime: 'claude', model: 'anthropic/claude-haiku-4-5', sandbox_provider: 'sprites' } };
+  const env = { TEST_KEY: randomUUID(), OTHER_KEY: randomUUID() };
+  writeFileSync(path, JSON.stringify(cfg));
+  assert.throws(() => configFrom(path, env), /max_turns/);
+  cfg.execution.max_turns = 2; writeFileSync(path, JSON.stringify(cfg));
+  assert.equal(configFrom(path, env).execution.max_turns, 2);
+  assert.throws(() => configFrom(path, { TEST_KEY: env.TEST_KEY }), /Missing test credential/);
+});

--- a/deployed/test/runner.test.mjs
+++ b/deployed/test/runner.test.mjs
@@ -74,7 +74,7 @@ test('missing credential and unknown profile are setup failures before network t
   const missing = await f.execute({}, { env: {} });
   assert.equal(missing.code, 2);
   assert.equal(f.requests.length, 0);
-  assert.equal((await f.execute({ profiles: ['execution'] })).code, 2);
+  assert.equal((await f.execute({ profiles: ['unbuilt-profile'] })).code, 2);
   assert.equal(f.requests.length, 0);
 });
 


### PR DESCRIPTION
Add an `execution` profile that proves a deployed Fountain can provision a fresh ephemeral sandbox, complete a tool-using turn, preserve its file in a follow-up, deny cross-tenant access, and release its resources. It uses public HTTP/SSE interfaces with an explicitly pinned runtime/model/provider and exactly two authorized prompt attempts.

The durable cleanup manifest now records conversation creation intent and parent ownership before sending requests. Lost prompt replies consume the budget without automatic retries. Cleanup verifies terminal sandbox state before deleting the transcript and retains parent fixtures if cleanup fails. SSE handling bounds bytes and phase deadlines and closes connections when consumers finish.

Stacked on #1622 (which depends on #1621). Merge predecessors first, then retarget to `main`.

Validation:
- 28 harness tests pass, including real-socket SSE closure, UTF-8/framing, prompt-budget persistence, lost-create handling, and leaked-sandbox cleanup retention.
- The full profile passed on `https://managoat.com` using the explicitly authorized local profiles: Claude Haiku 4.5 on Sprites, two completed turns, persisted Terminal tool activity, exact file bytes and follow-up continuity, tenant isolation, and termination.
- Production report: 9 checks passed, 2 prompt attempts, zero cleanup failures or remaining resources. Provider-reported output: 861 tokens across the two turns. The report preserves the fuller usage breakdown; no dollar cap is claimed.
- `gitleaks dir deployed --redact --no-banner` and `git diff --check` passed.

Fixes #1609; tracker #1606. This exercises normal live SSE; explicit mid-stream reconnect and replay/history conformance remain #1610. A public URL does not prove image identity, so the report continues to mark deployment revision unverified.
