### PR TITLE
test(deployed): verify incremental SSE and durable replay

### DIFF
--- a/deployed/README.md
+++ b/deployed/README.md
@@ -8,8 +8,9 @@ adds resource CRUD, validation errors, key revocation, tenant isolation, and
 an independent check of the instance's advertised response schemas.
 
 The `execution` profile verifies two real tool-using turns on a fresh
-ephemeral sandbox. Streaming reconnect conformance, integration, recovery and
-browser profiles remain tracked in #1606. A passing probe does not prove
+ephemeral sandbox. `streaming` adds incremental output, reconnect and replay
+conformance to those same two turns. Integration, recovery and browser
+profiles remain tracked in #1606. A passing probe does not prove
 that conversations work, and selecting an unimplemented profile fails setup.
 
 ## Run
@@ -89,9 +90,24 @@ The fixture manifest records each prompt attempt **before** sending it. A
 lost reply still consumes the two-attempt budget; prompts are never retried
 automatically. Provisioning, each turn, the overall run, and cleanup have
 separate deadlines. A stream that ends early fails the execution check;
-automatic replay/reconnect assertions belong to #1610. SSE traces record
+use the `streaming` profile for intentional reconnect/replay assertions. SSE traces record
 redacted frames with receive times, and a closed consumer releases its HTTP
 connection. Each stream is capped at 4 MiB.
+
+To verify ingress and replay, select `"profiles": ["streaming"]` with the same
+explicit execution settings. It includes execution; selecting both is an
+error. During turn one, the suite observes output and confirms that the
+durable turn record is still running. It then closes the stream, waits for
+at least one new persisted event, and reconnects with `Last-Event-ID`.
+
+After turn two, it drains history with a three-event page size and compares
+the live/reconnected events and two `wait=false` replay streams against a
+fixed durable event prefix. IDs must increase without duplicates; they need
+not be consecutive. Matching IDs with different payloads still fail. Events
+newer than the completed-turn cursor may arrive while the checks run and do
+not change that prefix. The report records the reconnect/missed-event IDs,
+comparison counts and pagination evidence. Controlled idle-heartbeat timing
+can be added with the deterministic fixture in #1611.
 
 For `basic`, supply two **different** verified test accounts through explicit
 environment-variable names. Two keys for the same account fail before any

--- a/deployed/lib/execution.mjs
+++ b/deployed/lib/execution.mjs
@@ -47,18 +47,40 @@ export function turnMetadata(event) {
   try { return JSON.parse(event.data); } catch { throw new Error('Turn stage metadata is not JSON'); }
 }
 
-export async function performTurn(ctx, conversation, prompt, number, after) {
+export async function performTurn(ctx, conversation, prompt, number, after, { verifyStreaming = false } = {}) {
+  const startedMs = performance.now();
   const signal = phaseSignal(ctx.signal, ctx.config.execution.turn_ms);
   ctx.fixtures.reserveTurn(conversation.id, ctx.config.execution.max_turns);
   const queued = await ctx.client.request('POST', `/api/conversations/${conversation.id}/prompts`, { body: { prompt }, expected: 200, signal });
   ensure(queued.body.status === 'queued', 'Prompt was not acknowledged as queued');
   let startedId;
-  const streamed = await watchUntil(ctx.client, conversation.id, signal, event => {
+  const isDone = event => {
     const meta = turnMetadata(event);
     if (meta?.turn_number !== number) return false;
     if (event.state === 'started') startedId = meta.turn_id ?? event.turn_id;
     return event.state === 'done';
-  }, { after });
+  };
+  let streamed;
+  if (verifyStreaming) {
+    const initial = await watchUntil(ctx.client, conversation.id, signal, async (event, frame) => {
+      if (isDone(event)) throw new Error('Turn completed before incremental output could be verified');
+      if (event.kind !== 'output' || !startedId || event.turn_id !== startedId) return false;
+      const { body } = await ctx.client.request('GET', `/api/conversations/${conversation.id}/turns`, { expected: 200, signal });
+      ensure(body.data.some(turn => turn.id === startedId && turn.status === 'running'), 'Output arrived after the turn finished; ingress may be buffering SSE');
+      ctx.report.streaming = { provision_cursor: after, reconnect_cursor: event.id,
+        observed_running_turn_id: startedId, output_received_ms: frame.receivedMs - startedMs, incremental_output_verified: true };
+      return true;
+    }, { after });
+    // Let at least one persisted event be missed while disconnected. Then the
+    // reconnect must replay it before entering the live tail.
+    const missed = await waitFor(ctx.client, `/api/conversations/${conversation.id}/events?after=${initial.cursor}&limit=1&blocks=true`, signal, events => events.length > 0);
+    ensure(missed[0].id > initial.cursor, 'No durable event accumulated during the disconnection');
+    ctx.report.streaming.missed_event_id = missed[0].id;
+    const resumed = await watchUntil(ctx.client, conversation.id, signal, isDone, { after: initial.cursor });
+    ensure(resumed.events.some(frame => frame.event.id === missed[0].id), 'Reconnect lost the event persisted while disconnected');
+    streamed = { cursor: resumed.cursor, events: [...initial.events, ...resumed.events] };
+    ctx.report.streaming.resumed_events = resumed.events.length;
+  } else streamed = await watchUntil(ctx.client, conversation.id, signal, isDone, { after });
   ensure(typeof startedId === 'string', `Turn ${number} had no start event`);
   const turns = await waitFor(ctx.client, `/api/conversations/${conversation.id}/turns`, signal, rows =>
     rows.some(row => row.turn_number === number && row.status === 'completed'));

--- a/deployed/lib/replay.mjs
+++ b/deployed/lib/replay.mjs
@@ -1,0 +1,43 @@
+import { ensure, history } from './execution.mjs';
+import { streamEvents } from './sse.mjs';
+import { isDeepStrictEqual } from 'node:util';
+
+const shared = ['id', 'kind', 'stream', 'data', 'stage', 'state', 'turn_id', 'ts', 'blocks'];
+const projection = event => Object.fromEntries(shared.filter(key => Object.hasOwn(event, key)).map(key => [key, event[key]]));
+
+export function compareEvents(actual, expected, { after = 0, through }) {
+  ensure(Number.isSafeInteger(after) && after >= 0 && Number.isSafeInteger(through) && through >= after, 'Invalid replay comparison bounds');
+  ensure(expected.some(event => event.id === through), 'History does not contain the durable high-water event');
+  let cursor = after;
+  for (const event of actual) {
+    ensure(Number.isSafeInteger(event.id) && event.id > cursor, 'Replay duplicated, reordered, or ignored the requested cursor');
+    cursor = event.id;
+  }
+  const received = actual.filter(e => e.id <= through);
+  const stored = expected.filter(e => e.id > after && e.id <= through);
+  ensure(received.length === stored.length, `Stream/history event count differs (${received.length}/${stored.length})`);
+  for (let i = 0; i < stored.length; i++) {
+    const actual = projection(received[i]), expected = projection(stored[i]);
+    const differences = shared.filter(key => Object.hasOwn(actual, key) !== Object.hasOwn(expected, key) || !isDeepStrictEqual(actual[key], expected[key]));
+    ensure(differences.length === 0, `Stream/history payload differs at event ${stored[i].id} (${differences.join(', ')})`);
+  }
+  return stored.length;
+}
+
+export async function verifyReplay(ctx, conversationId, first, second, signal) {
+  const paginated = await history(ctx.client, conversationId, signal, 3);
+  ensure(paginated.pages > 1, 'Fixture did not exercise history pagination');
+  Object.assign(ctx.report.streaming, { history_pages: paginated.pages, high_water_cursor: second.cursor });
+  const all = [];
+  for await (const { event } of streamEvents(ctx.client, `/api/conversations/${conversationId}/stream?blocks=true&wait=false`, { signal })) all.push(event);
+  const count = compareEvents(all, paginated.events, { through: second.cursor });
+  ctx.report.streaming.replay_events_compared = count;
+  const after = ctx.report.streaming.reconnect_cursor;
+  const resumed = [];
+  for await (const { event } of streamEvents(ctx.client, `/api/conversations/${conversationId}/stream?blocks=true&wait=false`, { signal, after })) resumed.push(event);
+  ctx.report.streaming.resumed_replay_events_compared = compareEvents(resumed, paginated.events, { after, through: second.cursor });
+  ctx.report.streaming.wait_false_closed = true;
+  const live = [...first.events, ...second.events].map(frame => frame.event);
+  const liveCount = compareEvents(live, paginated.events, { after: ctx.report.streaming.provision_cursor, through: second.cursor });
+  ctx.report.streaming.live_events_compared = liveCount;
+}

--- a/deployed/lib/runner.mjs
+++ b/deployed/lib/runner.mjs
@@ -10,7 +10,7 @@ import { basic } from '../profiles/basic.mjs';
 import { execution } from '../profiles/execution.mjs';
 
 export const VERSION = '0.1.0';
-export const profiles = { probe, basic, execution };
+export const profiles = { probe, basic, execution, streaming: execution };
 const contractPath = fileURLToPath(new URL('../../sdk/contract/contract.json', import.meta.url));
 
 function requireThat(condition, message) { if (!condition) throw new Error(message); }
@@ -36,12 +36,13 @@ export function configFrom(path, env = process.env) {
   requireThat(Array.isArray(config.profiles) && config.profiles.length > 0 && new Set(config.profiles).size === config.profiles.length &&
     config.profiles.every(name => Object.hasOwn(profiles, name)), 'Unknown, empty, or duplicate profile selection');
   requireThat(Object.keys(config.credentials).every(k => ['primary', 'secondary'].includes(k)), 'Unknown credential role');
-  if (config.profiles.some(name => ['basic', 'execution'].includes(name))) {
+  requireThat(!(config.profiles.includes('execution') && config.profiles.includes('streaming')), 'Select streaming or execution; streaming already includes execution');
+  if (config.profiles.some(name => ['basic', 'execution', 'streaming'].includes(name))) {
     requireThat(typeof config.credentials.secondary === 'string' && /^[A-Z][A-Z0-9_]*$/.test(config.credentials.secondary), 'Selected profile requires credentials.secondary environment variable');
     config.secondaryKey = env[config.credentials.secondary];
     requireThat(typeof config.secondaryKey === 'string' && config.secondaryKey.trim().length > 0, `Missing test credential: ${config.credentials.secondary}`);
   }
-  if (config.profiles.includes('execution')) {
+  if (config.profiles.some(name => ['execution', 'streaming'].includes(name))) {
     const settings = config.execution;
     requireThat(settings && Object.keys(settings).every(k => ['runtime', 'model', 'sandbox_provider', 'provision_ms', 'turn_ms', 'max_turns'].includes(k)), 'Expected explicit execution configuration');
     requireThat(['claude', 'codex', 'gemini', 'opencode'].includes(settings.runtime) &&
@@ -130,7 +131,7 @@ export async function run({ configPath, out, manifestPath, signal, env = process
         const available = { runtimes: body.data?.runtimes, sandbox_providers: body.data?.sandbox_providers?.enabled };
         requireThat(Object.values(available).every(Array.isArray), 'Catalog capability arrays missing');
         report.capabilities = available;
-        if (config.profiles.includes('execution')) {
+        if (config.profiles.some(name => ['execution', 'streaming'].includes(name))) {
           requireThat(available.runtimes.includes(config.execution.runtime), 'Execution runtime is unavailable');
           requireThat(available.sandbox_providers.includes(config.execution.sandbox_provider), 'Execution sandbox provider is unavailable');
         }

--- a/deployed/profiles/execution.mjs
+++ b/deployed/profiles/execution.mjs
@@ -1,9 +1,11 @@
 import { randomUUID } from 'node:crypto';
 import { ensure, phaseSignal, performTurn, watchUntil } from '../lib/execution.mjs';
+import { verifyReplay } from '../lib/replay.mjs';
 
 export async function execution(ctx) {
   const { client, fixtures, config, check } = ctx;
   const settings = config.execution;
+  const streaming = config.profiles.includes('streaming');
   ctx.report.execution = { runtime: settings.runtime, model: settings.model, sandbox_provider: settings.sandbox_provider, turns: [] };
   let environment, agent, conversation, provision, first, second;
   const file = `fountain-suite-${ctx.report.run_id}.txt`;
@@ -43,7 +45,7 @@ export async function execution(ctx) {
   };
   if (!await check('execution/first-turn-and-artifact', async () => {
     first = await performTurn(ctx, conversation,
-      `Use a shell tool to write exactly the text ${nonce} followed by one newline into the relative file ${file}. Read the file with the tool to verify it. Do nothing else.`, 1, provision.cursor);
+      `${streaming ? 'First say you are starting, then include a two-second sleep in your shell command. ' : ''}Use a shell tool to write exactly the text ${nonce} followed by one newline into the relative file ${file}. Read the file with the tool to verify it. Do nothing else.`, 1, provision.cursor, { verifyStreaming: streaming });
     await readArtifact();
   })) return;
   if (!await check('execution/follow-up', async () => {
@@ -56,6 +58,9 @@ export async function execution(ctx) {
     ensure(text.includes(nonce), 'Follow-up response did not contain the file nonce');
     ctx.report.execution.usage_total = body.data.usage_total;
   })) return;
+  if (streaming) await check('streaming/replay-and-history', async () => {
+    await verifyReplay(ctx, conversation.id, first, second, phaseSignal(ctx.signal, settings.turn_ms));
+  });
   await check('execution/tenant-isolation', async () => {
     for (const path of [`/api/conversations/${conversation.id}`, `/api/conversations/${conversation.id}/events`,
       `/api/conversations/${conversation.id}/stream?wait=false`, `/api/sandboxes/${conversation.sandbox_id}`,

--- a/deployed/test/execution.test.mjs
+++ b/deployed/test/execution.test.mjs
@@ -47,6 +47,26 @@ test('breaking an SSE consumer closes its real HTTP connection', async t => {
   await Promise.race([disconnected, new Promise((_, reject) => setTimeout(() => reject(new Error('SSE connection leaked')), 1500).unref())]);
 });
 
+test('SSE reconnect sends the cursor header and wait=false drains to connection end', async t => {
+  const headers = [];
+  const server = createServer((req, res) => {
+    headers.push(req.headers['last-event-id']);
+    assert.ok(req.url.endsWith('wait=false'));
+    res.writeHead(200, { 'content-type': 'text/event-stream' });
+    for (const id of req.headers['last-event-id'] ? [41] : [12, 41]) {
+      res.write(`id: ${id}\nevent: output\ndata: {"kind":"output","data":"ok"}\n\n`);
+    }
+    res.end();
+  });
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  t.after(() => { server.closeAllConnections(); server.close(); });
+  const client = { baseUrl: `http://127.0.0.1:${server.address().port}`, key: randomUUID(), redactor: new Redactor(), trace() {} };
+  const path = `/api/conversations/${randomUUID()}/stream?wait=false`;
+  assert.deepEqual((await collect(streamEvents(client, path, { signal: AbortSignal.timeout(1000) }))).map(f => f.event.id), [12, 41]);
+  assert.deepEqual((await collect(streamEvents(client, path, { after: 12, signal: AbortSignal.timeout(1000) }))).map(f => f.event.id), [41]);
+  assert.deepEqual(headers, [undefined, '12']);
+});
+
 function fixtures(t, request) {
   const dir = mkdtempSync(join(tmpdir(), 'fountain-execution-test-'));
   t.after(() => rmSync(dir, { recursive: true, force: true }));

--- a/deployed/test/replay.test.mjs
+++ b/deployed/test/replay.test.mjs
@@ -1,0 +1,38 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { compareEvents } from '../lib/replay.mjs';
+
+const events = [3, 9, 41].map(id => ({ id, kind: 'output', stream: 'acp', data: `event ${id}`, stage: null, state: null, turn_id: 'turn', ts: '2026-09-06T00:00:00Z', blocks: [] }));
+
+test('replay compares a fixed durable prefix while allowing later live events', () => {
+  assert.equal(compareEvents(events, events, { through: 9 }), 2);
+  assert.equal(compareEvents(events.slice(1), events, { after: 3, through: 41 }), 2);
+  assert.equal(compareEvents(events, events.map(e => ({ ...e, duration_ms: 8 })), { through: 41 }), 3);
+});
+
+test('replay rejects gaps, duplicates, reordered IDs and ignored Last-Event-ID', () => {
+  assert.throws(() => compareEvents([events[0], events[2]], events, { through: 41 }), /count differs/);
+  assert.throws(() => compareEvents([events[0], events[0], events[1]], events, { through: 41 }), /duplicated/);
+  assert.throws(() => compareEvents([events[1], events[0], events[2]], events, { through: 41 }), /reordered/);
+  assert.throws(() => compareEvents(events, events, { after: 3, through: 41 }), /ignored/);
+});
+
+test('matching event IDs cannot hide different SSE and history payloads', () => {
+  const changed = structuredClone(events); changed[1].state = '';
+  assert.throws(() => compareEvents(changed, events, { through: 41 }), /payload differs at event 9/);
+  changed[1] = { ...events[1], data: 'different output' };
+  assert.throws(() => compareEvents(changed, events, { through: 41 }), /payload differs at event 9/);
+});
+
+test('a missing high-water event or invalid boundary cannot produce a vacuous pass', () => {
+  assert.throws(() => compareEvents(events, events, {}), /bounds/);
+  assert.throws(() => compareEvents([], [], { through: 41 }), /high-water/);
+});
+
+test('nested JSON property order is immaterial but timestamp precision is preserved', () => {
+  const stored = [{ ...events[0], blocks: [{ kind: 'text', text: 'hello' }] }];
+  const replayed = [{ ...events[0], blocks: [{ text: 'hello', kind: 'text' }] }];
+  assert.equal(compareEvents(replayed, stored, { through: 3 }), 1);
+  replayed[0].ts = '2026-09-06T00:00:00.094866Z';
+  assert.throws(() => compareEvents(replayed, stored, { through: 3 }), /payload differs at event 3 \(ts\)/);
+});


### PR DESCRIPTION
Fixes #1610. Tracker: #1606. Stacked on #1623 (`codex/deployed-suite-execution`).

Adds a deployed `streaming` profile to the existing two-turn execution fixture. It verifies output arrives while the durable turn is still running, deliberately disconnects, waits for a missed persisted event, reconnects with Last-Event-ID, and compares live/reconnected output plus wait=false replay against paginated history. Comparison uses an explicit durable prefix, increasing non-contiguous IDs, and equivalent fields including timestamps and blocks. Raw redacted frames, receipt times, cursors and partial comparison evidence remain available on failure. No extra inference turns are introduced.

Validation: all 34 harness tests pass on Node 24, including connection cancellation, Last-Event-ID transport, malformed/fragmented streams, replay gaps/duplicates/reordering, payload mismatches, timestamp precision, and nested property order. Gitleaks and git diff --check pass.

Live verification against managoat.com exercised real Claude/Haiku on Sprites with the authorized local account credentials. Provisioning, both tool-using turns, nonce file verification, incremental delivery, disconnect/reconnect, tenant isolation and termination passed. The full streaming verdict correctly **failed** on a real live/history timestamp disagreement, filed as #1624: event 269734 changed from .094866Z live to .000000Z after persistence. The assertion remains strict; this PR does not claim production streaming conformance is green. Two prompt attempts; cleanup reported zero remaining resources. Recheck after #1624 is deployed. Controlled idle/heartbeat coverage remains the explicit follow-on in #1611.
