### PR TITLE
fix(conversations): preserve log-event timestamps across replay

### DIFF
--- a/apps/fountain/priv/repo/migrations/20260906020000_preserve_log_event_microseconds.exs
+++ b/apps/fountain/priv/repo/migrations/20260906020000_preserve_log_event_microseconds.exs
@@ -1,0 +1,27 @@
+defmodule Fountain.Repo.Migrations.PreserveLogEventMicroseconds do
+  use Ecto.Migration
+
+  # LogEvent has long used :utc_datetime_usec, but the initial migration made
+  # this timestamp(0). Live broadcasts use the inserted struct's microseconds;
+  # history and replay read a rounded database value (#1624).
+  #
+  # Widen the existing column, retaining old rows as stored. Lost fractional
+  # seconds cannot be recovered. ALTER TABLE still needs an exclusive lock on
+  # this high-volume table: fail promptly under contention and retry the
+  # migration once the blocker is gone, rather than queueing writes forever.
+  def up do
+    execute("SET LOCAL lock_timeout = '5s'")
+    execute("SET LOCAL statement_timeout = '30s'")
+
+    alter table(:log_events) do
+      modify :inserted_at, :utc_datetime_usec
+    end
+  end
+
+  # Older application code already expects microseconds and works with the
+  # widened column. Roll back the application without narrowing the data.
+  def down do
+    raise Ecto.MigrationError,
+      message: "Cannot narrow log_events.inserted_at without losing persisted microseconds"
+  end
+end

--- a/apps/fountain/test/fountain/conversations_log_events_test.exs
+++ b/apps/fountain/test/fountain/conversations_log_events_test.exs
@@ -13,6 +13,28 @@ defmodule Fountain.ConversationsLogEventsTest do
   # ────────────────────────────────────────────────────────────────────────────
 
   describe "log!/1" do
+    test "microseconds survive a database round trip (#1624)" do
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id)
+
+      for timestamp <- [~U[2026-09-06 01:30:46.094866Z], ~U[2026-09-06 01:30:46.987654Z]] do
+        event =
+          Conversations.log!(%{
+            conversation_id: conv.id,
+            kind: "output",
+            stream: "stdout",
+            data: "precision fixture",
+            inserted_at: timestamp
+          })
+
+        # The inserted struct is what live PubSub broadcasts; history and
+        # reconnect replay reload the row. Asserting only the struct missed
+        # the timestamp(0) column behind the utc_datetime_usec schema.
+        assert event.inserted_at == timestamp
+        assert Fountain.Repo.reload!(event).inserted_at == timestamp
+      end
+    end
+
     test "inserts a LogEvent and returns the struct" do
       user = insert_verified_user()
       conv = insert_conversation(user_id: user.id)

--- a/apps/fountain/test/fountain_web/controllers/sse_stream_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/sse_stream_test.exs
@@ -70,6 +70,39 @@ defmodule FountainWeb.SseStreamTest do
   end
 
   describe "replay" do
+    test "history and replay retain the timestamp supplied to live broadcasts (#1624)", %{
+      raw_key: key,
+      conv: conv
+    } do
+      timestamp = ~U[2026-09-06 01:30:46.094866Z]
+
+      event =
+        Fountain.Conversations.log!(%{
+          conversation_id: conv.id,
+          kind: "output",
+          stream: "stdout",
+          data: "precision fixture",
+          inserted_at: timestamp
+        })
+
+      replay = stream(key, "/api/conversations/#{conv.id}/stream?wait=false")
+
+      payload =
+        replay.resp_body
+        |> String.split("\n")
+        |> Enum.find(&String.starts_with?(&1, "data: "))
+        |> String.replace_prefix("data: ", "")
+        |> Jason.decode!()
+
+      feed =
+        stream(key, "/api/conversations/#{conv.id}/events") |> Phoenix.ConnTest.json_response(200)
+
+      assert [%{"id" => id, "ts" => ts}] = feed["data"]
+      assert id == event.id
+      assert ts == DateTime.to_iso8601(event.inserted_at)
+      assert payload["ts"] == ts
+    end
+
     test "drains buffered events and closes with wait=false", %{raw_key: key, conv: conv} do
       insert_log_event(conv, %{kind: "output", stream: "stdout", data: "first"})
       insert_log_event(conv, %{kind: "output", stream: "stdout", data: "second"})
@@ -213,12 +246,28 @@ defmodule FountainWeb.SseStreamTest do
       # Give the loop time to subscribe before publishing.
       Process.sleep(300)
 
-      publish(conv, %{kind: "output", stream: "stdout", data: "live-event"})
+      timestamp = ~U[2026-09-06 01:30:46.987654Z]
+
+      event =
+        publish(conv, %{
+          kind: "output",
+          stream: "stdout",
+          data: "live-event",
+          inserted_at: timestamp
+        })
 
       conn = Task.await(task, 5_000)
 
       assert conn.status == 200
       assert conn.resp_body =~ "live-event"
+      assert conn.resp_body =~ ~s("ts":"#{DateTime.to_iso8601(timestamp)}")
+
+      feed =
+        stream(key, "/api/conversations/#{conv.id}/events") |> Phoenix.ConnTest.json_response(200)
+
+      assert [%{"id" => id, "ts" => ts}] = feed["data"]
+      assert id == event.id
+      assert ts == DateTime.to_iso8601(timestamp)
     end
 
     test "a filtered-out live event is not streamed", %{raw_key: key, conv: conv} do


### PR DESCRIPTION
Refs #1624; discovered by deployed streaming PR #1625 under tracker #1606. Independent of the suite stack; targets main.

The same log event can have one timestamp on live SSE and a different one after reconnect or history retrieval. The first production canary caught `.094866Z` live becoming `.000000Z` on disk. LogEvent and log!/1 already use microseconds, but the original migration created timestamp(0), so the inserted struct broadcast to subscribers disagrees with its database reload.

Widen log_events.inserted_at to the existing Ecto schema's microsecond precision. New regression coverage checks database round trips with fractions below and above half a second, public history/replay timestamps, and the live PubSub stream against history.

Validation:
- Reproduced both new regressions against the original, fully migrated schema on isolated Postgres 16.
- Applied the new migration over 1,000 historical events: all retained their timestamps, and the table plus all four index relfilenodes were unchanged (no rewrite observed in this fixture).
- All 61 tests in the affected context and SSE modules pass after migration, using pinned Elixir 1.19.2 / OTP 28.3. Formatting and git diff --check pass.

Deployment: ALTER TABLE requires an exclusive lock; this transactional migration limits lock wait to 5 seconds and statement execution to 30 seconds. If it fails under contention, resolve the blocker and retry. Historical fractional timestamps cannot be recovered. The down migration refuses lossy precision narrowing; an application rollback can retain the wider column because the previous code already expects microseconds.

Production remains unmodified by this PR. Keep #1624 open for a deployed streaming rerun after release; the suite's timestamp assertion is unchanged and still catches the currently deployed defect.
