### PR TITLE
fix: declare API failures, verify alerts, and use generated reference

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1757,6 +1757,14 @@ jobs:
       - name: Test CI decisions
         run: python3 -m unittest discover -s scripts/ci -p 'test_*.py' -v
 
+      - name: Install alert validation tools
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends prometheus python3-yaml
+
+      - name: Validate portable alerts
+        run: /usr/bin/python3 scripts/test-alerts.py
+
   gate:
     name: CI required
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1757,14 +1757,6 @@ jobs:
       - name: Test CI decisions
         run: python3 -m unittest discover -s scripts/ci -p 'test_*.py' -v
 
-      - name: Install alert validation tools
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends prometheus python3-yaml
-
-      - name: Validate portable alerts
-        run: /usr/bin/python3 scripts/test-alerts.py
-
   gate:
     name: CI required
     runs-on: ubuntu-24.04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ upgrade, is in
 
 ### Changed
 
+- OpenAPI operations declare shared pipeline failures and controller refusals. The schema guard no longer exempts missing response statuses.
+- The API manual is a workflow guide linking to the generated reference at `/api/docs`; existing section anchors remain available.
+- Portable Prometheus rules cover stage and reattach failures, per-provider turn failure rates, and slow first output. Thresholds have executable alert fixtures.
+
 - Manifest apply rejects unknown `spec` keys before writing that resource or its secrets. Previously, Ecto silently discarded them, including misspelled network restrictions. Correct these keys before upgrading. Bulk apply keeps its HTTP 200 response with per-resource errors; other valid resources still apply. Ownership keys remain ignored.
 
 - **Credential brokerage is on for every account on the hosted platform**

--- a/apps/fountain/lib/fountain_web/api_spec.ex
+++ b/apps/fountain/lib/fountain_web/api_spec.ex
@@ -6,7 +6,7 @@ defmodule FountainWeb.ApiSpec do
 
   alias OpenApiSpex.{Components, Info, OpenApi, Paths, SecurityScheme, Server}
   alias FountainWeb.{Endpoint, Router}
-  alias FountainWeb.ApiSpec.Compose
+  alias FountainWeb.ApiSpec.{Compose, PipelineResponses}
 
   @behaviour OpenApi
 
@@ -44,12 +44,15 @@ defmodule FountainWeb.ApiSpec do
       },
       security: [%{"bearer" => []}]
     }
-    |> OpenApiSpex.resolve_schema_modules()
+    # Resolve shared pipeline schemas before composition so extensions cannot
+    # silently replace them with a different schema of the same name.
+    |> PipelineResponses.apply(Router)
     # Installed extensions describe what they serve (ADR 0043, #1506). Composed
     # after the core resolves, so a schema title an extension shares with the
     # core is a loud failure rather than a silent overwrite. With nothing
     # installed this is the identity function and the spec is byte-identical to
     # what it was before extensions existed.
     |> Compose.compose!()
+    |> PipelineResponses.apply(Router)
   end
 end

--- a/apps/fountain/lib/fountain_web/api_spec/pipeline_responses.ex
+++ b/apps/fountain/lib/fountain_web/api_spec/pipeline_responses.ex
@@ -1,0 +1,87 @@
+defmodule FountainWeb.ApiSpec.PipelineResponses do
+  @moduledoc """
+  Adds the errors shared by a route's pipelines to its OpenAPI operation.
+
+  The router supplies membership; this module describes each pipeline's wire
+  responses. Controller declarations take precedence, including specialized
+  error envelopes. Controller-local plugs and context refusals remain declared
+  on the operation that can return them. Composed extension paths inherit the
+  pipelines of their real dispatch route too.
+  """
+
+  alias FountainWeb.Schemas
+  alias OpenApiSpex.{OpenApi, Operation}
+
+  defmodule NegotiationError do
+    @moduledoc false
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
+
+    OpenApiSpex.schema(%{
+      title: "NegotiationError",
+      type: :object,
+      properties: %{
+        errors: %Schema{
+          type: :object,
+          properties: %{detail: %Schema{type: :string}},
+          required: [:detail]
+        }
+      },
+      required: [:errors]
+    })
+  end
+
+  @doc "Add pipeline responses to all installed operations, then resolve their schemas."
+  def apply(%OpenApi{} = spec, router) do
+    paths =
+      Map.new(spec.paths, fn {path, item} ->
+        item =
+          Enum.reduce(Map.from_struct(item), item, fn
+            {verb, %Operation{} = operation}, item ->
+              info =
+                Phoenix.Router.route_info(
+                  router,
+                  String.upcase(to_string(verb)),
+                  path,
+                  "localhost"
+                )
+
+              responses =
+                info.pipe_through
+                |> Enum.flat_map(&statuses/1)
+                |> Enum.uniq()
+                |> Map.new(fn status -> {status, response(status)} end)
+                |> Map.merge(operation.responses || %{})
+
+              Map.put(item, verb, %{operation | responses: responses})
+
+            _, item ->
+              item
+          end)
+
+        {path, item}
+      end)
+
+    OpenApiSpex.resolve_schema_modules(%{spec | paths: paths})
+  end
+
+  defp statuses(:api), do: [401, 403, 429]
+  defp statuses(pipeline) when pipeline in [:api_public, :accepts_json], do: [406]
+
+  defp statuses(pipeline)
+       when pipeline in [:require_full_scope, :require_key_management, :require_admin_api],
+       do: [403]
+
+  defp statuses(_), do: []
+
+  defp response(406),
+    do: Operation.response("No acceptable representation", "application/json", NegotiationError)
+
+  defp response(status),
+    do:
+      Operation.response(
+        Plug.Conn.Status.reason_phrase(status),
+        "application/json",
+        Schemas.Error
+      )
+end

--- a/apps/fountain/lib/fountain_web/controllers/admin_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/admin_controller.ex
@@ -76,6 +76,7 @@ defmodule FountainWeb.AdminController do
       ]
     ],
     responses: [
+      unprocessable_entity: {"Invalid request parameters", "application/json", Schemas.Error},
       ok: {"Accounts", "application/json", Schemas.AdminUserListResponse},
       forbidden: {"Admin required", "application/json", Schemas.Error}
     ]

--- a/apps/fountain/lib/fountain_web/controllers/agent_version_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/agent_version_controller.ex
@@ -49,6 +49,7 @@ defmodule FountainWeb.AgentVersionController do
       version: [in: :path, type: :integer, required: true, description: "1-based."]
     ],
     responses: [
+      unprocessable_entity: {"Invalid request parameters", "application/json", Schemas.Error},
       ok: {"Version", "application/json", Schemas.AgentVersionResponse},
       not_found: {"Agent or version not found", "application/json", Schemas.Error}
     ]

--- a/apps/fountain/lib/fountain_web/controllers/agui_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/agui_controller.ex
@@ -121,6 +121,7 @@ defmodule FountainWeb.AguiController do
     ],
     request_body: {"AG-UI run input", "application/json", @run_input},
     responses: [
+      conflict: {"Conflicting state", "application/json", FountainWeb.Schemas.Error},
       ok: {"AG-UI event stream", "text/event-stream", %OpenApiSpex.Schema{type: :string}},
       bad_request: {"Malformed run input", "application/json", FountainWeb.Schemas.Error},
       not_found: {"No such agent", "application/json", FountainWeb.Schemas.Error}

--- a/apps/fountain/lib/fountain_web/controllers/auth_token_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/auth_token_controller.ex
@@ -33,6 +33,7 @@ defmodule FountainWeb.AuthTokenController do
     security: [],
     request_body: {"Credentials", "application/json", Schemas.AuthTokenRequest, required: true},
     responses: [
+      too_many_requests: {"Rate limited", "application/json", Schemas.Error},
       created: {"A new API key", "application/json", Schemas.AuthTokenResponse},
       unauthorized: {"Invalid email or password", "application/json", Schemas.Error},
       forbidden: {"Email not verified", "application/json", Schemas.AuthError},

--- a/apps/fountain/lib/fountain_web/controllers/avatar_generate_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/avatar_generate_controller.ex
@@ -31,6 +31,7 @@ defmodule FountainWeb.AvatarGenerateController do
         "provider refused.",
     request_body: {"Base and mood", "application/json", Schemas.AvatarGenerateRequest},
     responses: [
+      bad_request: {"Invalid request", "application/json", Schemas.Error},
       ok: {"Generated image", "application/json", Schemas.AvatarGenerateResponse},
       unprocessable_entity:
         {"No OpenAI credential, or unknown base/mood", "application/json", Schemas.Error},

--- a/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
@@ -316,6 +316,7 @@ defmodule FountainWeb.ConversationController do
       ]
     ],
     responses: [
+      unprocessable_entity: {"Invalid request parameters", "application/json", Schemas.Error},
       ok: {"Log events", "application/json", Schemas.LogEventListResponse},
       not_found: {"Not found", "application/json", Schemas.Error}
     ]
@@ -387,6 +388,9 @@ defmodule FountainWeb.ConversationController do
         "Legacy `X-AoD-Parent-Conversation-Id` is still accepted for sprites provisioned before the rename.",
     request_body: {"Conversation attrs", "application/json", Schemas.ConversationCreateRequest},
     responses: [
+      bad_request: {"Invalid request", "application/json", Schemas.Error},
+      conflict: {"Conflicting state", "application/json", Schemas.Error},
+      service_unavailable: {"Sandbox or fleet unavailable", "application/json", Schemas.Error},
       created: {"Conversation", "application/json", Schemas.ConversationResponse},
       ok:
         {"Conversation (resumed by channel_id)", "application/json", Schemas.ConversationResponse},
@@ -532,6 +536,10 @@ defmodule FountainWeb.ConversationController do
     parameters: [conversation_id: [in: :path, type: :string, required: true]],
     request_body: {"Prompt", "application/json", Schemas.PromptRequest},
     responses: [
+      payment_required: {"Insufficient credits", "application/json", Schemas.Error},
+      gone: {"Conversation is terminal", "application/json", Schemas.Error},
+      unprocessable_entity: {"Invalid request parameters", "application/json", Schemas.Error},
+      service_unavailable: {"Sandbox or fleet unavailable", "application/json", Schemas.Error},
       ok: {"Queued", "application/json", Schemas.PromptResponse},
       not_found: {"Not found", "application/json", Schemas.Error},
       bad_request: {"Busy", "application/json", Schemas.Error}
@@ -580,6 +588,7 @@ defmodule FountainWeb.ConversationController do
         "for already-dead conversations.",
     parameters: [conversation_id: [in: :path, type: :string, required: true]],
     responses: [
+      service_unavailable: {"Sandbox or fleet unavailable", "application/json", Schemas.Error},
       no_content: "Terminated",
       not_found: {"Not found", "application/json", Schemas.Error}
     ]
@@ -613,6 +622,7 @@ defmodule FountainWeb.ConversationController do
         "not be woken.",
     parameters: [conversation_id: [in: :path, type: :string, required: true]],
     responses: [
+      service_unavailable: {"Sandbox or fleet unavailable", "application/json", Schemas.Error},
       no_content: "Interrupted",
       not_found: {"Not found", "application/json", Schemas.Error},
       conflict: {"Nothing to interrupt", "application/json", Schemas.Error}

--- a/apps/fountain/lib/fountain_web/controllers/openai_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/openai_controller.ex
@@ -287,6 +287,7 @@ defmodule FountainWeb.OpenAIController do
     ],
     request_body: {"Chat-completions request", "application/json", @chat_request},
     responses: [
+      internal_server_error: {"Internal error", "application/json", @openai_error},
       ok:
         {"The completion (or, with `stream: true`, its SSE stream)", "application/json",
          @chat_response},
@@ -302,6 +303,7 @@ defmodule FountainWeb.OpenAIController do
       "OpenAI's `GET /v1/models`, so a base-URL client's model picker fills itself. Each " <>
         "agent is a model whose `id` is the agent's name.",
     responses: [
+      not_found: {"Not found", "application/json", @openai_error},
       ok:
         {"Model list", "application/json",
          %OpenApiSpex.Schema{

--- a/apps/fountain/lib/fountain_web/controllers/team_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/team_controller.ex
@@ -227,6 +227,8 @@ defmodule FountainWeb.TeamController do
       {"The number whose texts become prompts", "application/json", Schemas.TeamContactRequest,
        required: true},
     responses: [
+      failed_dependency:
+        {"Contact provider unavailable", "application/json", FountainWeb.Schemas.Error},
       created: {"Teammate, now with a contact", "application/json", Schemas.TeammateResponse},
       not_found: {"Not on the team, or the feature is off", "application/json", Schemas.Error},
       conflict: {"Already has a contact", "application/json", Schemas.Error},

--- a/apps/fountain/test/fountain_web/api_pipeline_responses_test.exs
+++ b/apps/fountain/test/fountain_web/api_pipeline_responses_test.exs
@@ -1,0 +1,82 @@
+defmodule FountainWeb.ApiPipelineResponsesTest do
+  use FountainWeb.ConnCase, async: true
+
+  alias FountainWeb.{ApiSpec, SchemaGuard}
+
+  test "authenticated operations include the errors of their router pipelines" do
+    spec = ApiSpec.spec()
+
+    for route <- FountainWeb.Router.__routes__(),
+        info =
+          Phoenix.Router.route_info(
+            FountainWeb.Router,
+            String.upcase(to_string(route.verb)),
+            route.path,
+            "localhost"
+          ),
+        :api in info.pipe_through,
+        path = Regex.replace(~r/:([^\/]+)/, route.path, "{\\1}"),
+        item = Map.get(spec.paths, path),
+        item != nil,
+        operation = Map.get(item, route.verb),
+        operation != nil do
+      for status <- [401, 403, 429] do
+        assert Map.has_key?(operation.responses, status), "#{route.verb} #{path} lacks #{status}"
+      end
+    end
+  end
+
+  test "public endpoints do not inherit tenant auth, and SSE does not inherit JSON negotiation" do
+    spec = ApiSpec.spec()
+    refute Map.has_key?(spec.paths["/health"].get.responses, 401)
+    refute Map.has_key?(spec.paths["/api/auth/register"].post.responses, 401)
+
+    refute Map.has_key?(
+             spec.paths["/api/conversations/{conversation_id}/stream"].get.responses,
+             406
+           )
+
+    assert Map.has_key?(spec.paths["/api/conversations"].get.responses, 406)
+  end
+
+  test "installed extension operations inherit the dispatch pipeline's errors" do
+    spec = ApiSpec.spec()
+
+    for {path, item} <- Fountain.Extensions.openapi_paths(),
+        {verb, %OpenApiSpex.Operation{}} <- Map.from_struct(item) do
+      responses = Map.fetch!(spec.paths[path], verb).responses
+
+      for status <- [401, 403, 406, 429] do
+        assert Map.has_key?(responses, status), "#{verb} #{path} lacks #{status}"
+      end
+    end
+  end
+
+  test "composition preserves operation-specific schemas" do
+    spec = ApiSpec.spec()
+    response = spec.paths["/api/conversations"].post.responses[402]
+    assert response.content["application/json"].schema.properties[:upgrade_url]
+
+    assert spec.paths["/api/conversations"].post.responses[422].content["application/json"].schema ==
+             %OpenApiSpex.Reference{"$ref": "#/components/schemas/ChangesetError"}
+  end
+
+  test "real pipeline refusals validate without an allowlist" do
+    conn = build_conn() |> get("/api/agents")
+    assert json_response(conn, 401)["reason"] == "api_key_invalid"
+    assert {:ok, _} = SchemaGuard.check(conn)
+
+    user = insert_verified_user()
+    {_record, key} = insert_api_key(user)
+
+    assert {406, _, body} =
+             assert_error_sent(406, fn ->
+               build_conn()
+               |> authed_with_key(key)
+               |> put_req_header("accept", "text/event-stream")
+               |> get("/api/conversations")
+             end)
+
+    assert Jason.decode!(body) == %{"errors" => %{"detail" => "Not Acceptable"}}
+  end
+end

--- a/apps/fountain/test/fountain_web/schema_guardrail_test.exs
+++ b/apps/fountain/test/fountain_web/schema_guardrail_test.exs
@@ -48,7 +48,7 @@ defmodule FountainWeb.SchemaGuardrailTest do
 
   # The allowlist may shrink freely. Growing it means editing this number in
   # the same diff, which is the whole ratchet: a reviewer sees the number move.
-  @ceiling 69
+  @ceiling 3
 
   describe "the ratchet" do
     test "the allowlist has not grown" do

--- a/apps/fountain/test/support/schema_guard_allowlist.ex
+++ b/apps/fountain/test/support/schema_guard_allowlist.ex
@@ -30,18 +30,11 @@ defmodule FountainWeb.SchemaGuardAllowlist do
   like a fix landing.
 
   So an extension declares the statuses on its own operations instead — there
-  were 8 of them across both extensions, against the 66 core operations #1432
-  still owes. `FountainWeb.ExtensionSchemaGuardCase` enforces it from each
+  were 8 of them across both extensions. Core pipeline responses are
+  composed from router membership; controller-specific refusals stay explicit. `FountainWeb.ExtensionSchemaGuardCase` enforces it from each
   extension's suite, which is the only run that can.
 
   ## The families
-
-  `:plug_status` — the operation does not declare a status something in the
-  pipeline can return on any route. `Plugs.TenantAPIAuth` answers 401,
-  `require_admin` 403, `Plugs.RateLimit` 429, an unready sandbox 503,
-  `plug :accepts` 406. The document describes controllers; these come from
-  plugs, which is why 68 of them appear at once. Declaring each per operation
-  is a large, mechanical documentation change (#1432).
 
   `:mixed_422_shapes` — the operation declares `ChangesetError` for 422, which
   requires `errors`, and can also refuse with a coded
@@ -56,7 +49,6 @@ defmodule FountainWeb.SchemaGuardAllowlist do
   """
 
   @reasons %{
-    plug_status: "a status a pipeline plug returns that the operation does not declare (#1432)",
     mixed_422_shapes: "declares ChangesetError for 422 but can also refuse with a code (#1444)",
     test_fixture_vocabulary: "the fixture inserts an out-of-vocabulary value on purpose"
   }
@@ -64,75 +56,6 @@ defmodule FountainWeb.SchemaGuardAllowlist do
   # The list may shrink, never grow, without a deliberate edit here and in the
   # guardrail's own ceiling.
   @entries %{
-    # ── plug_status (66) ─────────────────────────────
-    {"DELETE /api/account", 401} => :plug_status,
-    {"DELETE /api/agents/{id}", 401} => :plug_status,
-    {"DELETE /api/conversations/{id}", 401} => :plug_status,
-    {"DELETE /api/environments/{id}", 401} => :plug_status,
-    {"DELETE /api/vaults/{id}", 401} => :plug_status,
-    {"GET /api/account/billing", 401} => :plug_status,
-    {"GET /api/account/inference-credentials", 401} => :plug_status,
-    {"GET /api/admin/users", 401} => :plug_status,
-    {"GET /api/admin/users", 422} => :plug_status,
-    {"GET /api/agents", 401} => :plug_status,
-    {"GET /api/agents", 429} => :plug_status,
-    {"GET /api/agents/{id}", 401} => :plug_status,
-    {"GET /api/agents/{id}/avatar", 401} => :plug_status,
-    {"GET /api/agents/{id}/versions", 401} => :plug_status,
-    {"GET /api/agents/{id}/versions/{version}", 422} => :plug_status,
-    {"GET /api/audit", 401} => :plug_status,
-    {"GET /api/catalog", 401} => :plug_status,
-    {"GET /api/connection-providers", 403} => :plug_status,
-    {"GET /api/connections", 403} => :plug_status,
-    {"GET /api/conversations", 401} => :plug_status,
-    {"GET /api/conversations", 406} => :plug_status,
-    {"GET /api/conversations/{conversation_id}/events", 401} => :plug_status,
-    {"GET /api/conversations/{conversation_id}/events", 422} => :plug_status,
-    {"GET /api/conversations/{conversation_id}/stream", 401} => :plug_status,
-    {"GET /api/conversations/{conversation_id}/tree", 401} => :plug_status,
-    {"GET /api/conversations/{conversation_id}/turns/{turn_id}/images/{position}", 401} =>
-      :plug_status,
-    {"GET /api/conversations/{id}", 401} => :plug_status,
-    {"GET /api/environments", 401} => :plug_status,
-    {"GET /api/environments/{environment_id}/secrets", 401} => :plug_status,
-    {"GET /api/environments/{id}", 401} => :plug_status,
-    {"GET /api/sandboxes/{sandbox_id}/file", 403} => :plug_status,
-    {"GET /api/sandboxes/{sandbox_id}/files", 403} => :plug_status,
-    {"GET /api/search", 401} => :plug_status,
-    {"GET /api/team", 401} => :plug_status,
-    {"GET /api/team/schedules", 401} => :plug_status,
-    {"GET /api/vaults", 401} => :plug_status,
-    {"GET /api/vaults/{id}", 401} => :plug_status,
-    {"GET /api/webhooks", 403} => :plug_status,
-    {"GET /v1/models", 404} => :plug_status,
-    {"POST /api/account/onboarding/complete", 401} => :plug_status,
-    {"POST /api/agents", 401} => :plug_status,
-    {"POST /api/agui/{agent_id}", 401} => :plug_status,
-    {"POST /api/agui/{agent_id}", 409} => :plug_status,
-    {"POST /api/apply", 401} => :plug_status,
-    {"POST /api/auth/token", 429} => :plug_status,
-    {"POST /api/avatars/generate", 400} => :plug_status,
-    {"POST /api/conversations", 400} => :plug_status,
-    {"POST /api/conversations", 409} => :plug_status,
-    {"POST /api/conversations", 429} => :plug_status,
-    {"POST /api/conversations", 503} => :plug_status,
-    {"POST /api/conversations/{conversation_id}/interrupt", 503} => :plug_status,
-    {"POST /api/conversations/{conversation_id}/prompts", 402} => :plug_status,
-    {"POST /api/conversations/{conversation_id}/prompts", 410} => :plug_status,
-    {"POST /api/conversations/{conversation_id}/prompts", 422} => :plug_status,
-    {"POST /api/conversations/{conversation_id}/prompts", 429} => :plug_status,
-    {"POST /api/conversations/{conversation_id}/prompts", 503} => :plug_status,
-    {"POST /api/conversations/{conversation_id}/terminate", 503} => :plug_status,
-    {"POST /api/environments", 401} => :plug_status,
-    {"POST /api/team/{agent_id}/contact", 424} => :plug_status,
-    {"POST /api/vaults", 401} => :plug_status,
-    {"POST /api/webhooks", 403} => :plug_status,
-    {"POST /v1/chat/completions", 401} => :plug_status,
-    {"POST /v1/chat/completions", 500} => :plug_status,
-    {"PUT /api/agents/{id}", 401} => :plug_status,
-    {"PUT /api/environments/{id}", 401} => :plug_status,
-    {"PUT /api/vaults/{id}", 401} => :plug_status,
-
     # ── mixed_422_shapes (2) ─────────────────────────────
     {"POST /api/auth/register", 422} => :mixed_422_shapes,
     {"POST /api/conversations", 422} => :mixed_422_shapes,

--- a/deploy/k8s/prometheusrule.yaml
+++ b/deploy/k8s/prometheusrule.yaml
@@ -189,6 +189,66 @@ spec:
               concurrency cap. Triage:
               https://managoat.com/docs/troubleshooting/sandbox-errors
 
+        - alert: FountainStageFailures
+          # Keep provisioning's existing sensitivity; cover later setup stages.
+          expr: |
+            sum by (stage) (increase(fountain_stage_count{namespace="fountain", stage!="provision", status="failed"}[30m])) > 2
+          labels:
+            severity: warning
+          annotations:
+            summary: "Fountain conversation stages are failing"
+            description: "Stage {{ $labels.stage }} failed more than twice in 30 minutes. Inspect conversation stages and provider health."
+
+        - alert: FountainTurnFailureRate
+          # Histogram counts are events, so sum across replicas. Require ten
+          # terminal turns per provider to avoid paging on one failed attempt.
+          # Zero-fill missing failure series with the SAME provider labels.
+          # Round the ratio to avoid floating-point noise paging at exactly 25%.
+          expr: |
+            (
+              round((
+                sum by (provider) (increase(fountain_turn_completed_duration_ms_count{namespace="fountain", status="failed"}[30m]))
+                or
+                0 * sum by (provider) (increase(fountain_turn_completed_duration_ms_count{namespace="fountain"}[30m]))
+              )
+              / sum by (provider) (increase(fountain_turn_completed_duration_ms_count{namespace="fountain"}[30m])), 0.000001)
+              > 0.25
+            )
+            and on (provider)
+            sum by (provider) (increase(fountain_turn_completed_duration_ms_count{namespace="fountain"}[30m])) >= 10
+          labels:
+            severity: warning
+          annotations:
+            summary: "Fountain turn failures exceed 25% for a provider"
+            description: "More than a quarter of at least ten terminal turns failed on {{ $labels.provider }} in 30 minutes. Inspect failed conversations and provider status."
+
+        - alert: FountainReattachFailures
+          # Reattach's duration histogram has no outcome label. The stage
+          # counter records failures even when the operation rescues them.
+          expr: |
+            sum(increase(fountain_stage_count{namespace="fountain", stage="reattach", status="failed"}[1h])) > 0
+          labels:
+            severity: warning
+          annotations:
+            summary: "Fountain could not reattach a conversation"
+            description: "A reattach failed in the last hour. Inspect the conversation and sandbox before any manual cleanup."
+
+        - alert: FountainTurnFirstOutputSlow
+          # First-output samples exist only when output arrives: this detects
+          # slow observed output, not a turn that never emits any bytes.
+          expr: |
+            histogram_quantile(0.95,
+              sum by (provider, le) (rate(fountain_turn_first_output_elapsed_ms_bucket{namespace="fountain"}[30m]))
+            ) > 30000
+            and on (provider)
+            sum by (provider) (increase(fountain_turn_first_output_elapsed_ms_count{namespace="fountain"}[30m])) >= 10
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Fountain first output is slow for a provider"
+            description: "Observed first-output p95 exceeds 30 seconds on {{ $labels.provider }} for 15 minutes, with at least ten samples per 30-minute window. Inspect runtime startup and provider latency."
+
         - alert: FountainProvisionDeadlineExceeded
           # The provision watchdog (#329) declared a provision wedged and
           # force-failed it. The accompanying sprite destroy is best-effort

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,4 +1,4 @@
-# API guide
+# API reference
 
 Use the [generated API reference](/api/docs) for endpoints, parameters,
 request bodies, response schemas, and error statuses. Fountain builds that

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,1190 +1,294 @@
-# API reference
+# API guide
 
-Fountain serves a REST API. Each endpoint sits under `/api/`, and each one
-returns JSON.
+Use the [generated API reference](/api/docs) for endpoints, parameters,
+request bodies, response schemas, and error statuses. Fountain builds that
+reference from the same OpenAPI descriptions that define its SDK contract.
+The [OpenAPI document](/api/openapi.json) is public and needs no credential.
 
-!!! tip "Do you write a script, and not an integration?"
+The reference describes the instance that serves it, with its installed
+extensions. On a self-hosted instance, open `/api/docs` on that instance.
+This guide explains workflows; it does not maintain a second endpoint catalog.
 
-    The [TypeScript](sdk.md), [Python](python-sdk.md) and
-    [Swift](swift-sdk.md) SDKs put one `run`
-    call over the conversation endpoints below.
-
-    Reach for the raw API when you need a surface the SDKs do not wrap, or a
-    language nobody wrote it in.
-
-The authority is the OpenAPI spec that the server serves. It is always
-current.
-
-- `GET /api/openapi.json`, the OpenAPI 3.1 spec, generated from the code. It
-  is public, and it needs no auth.
-- `GET /api/docs`, a Swagger UI over that same spec.
-
-The endpoint lists below summarise that spec, for convenience. Each `/api/`
-endpoint is in the spec, and the auth surface with them.
-
-A test walks the router, and fails when somebody adds a route with no spec
-entry. So a generated client covers the whole API. It does not cover the parts
-that somebody remembered to document.
+For a script, start with the [TypeScript](sdk.md), [Python](python-sdk.md),
+[Elixir](elixir-sdk.md), or [Swift](swift-sdk.md) SDK. Use HTTP directly when
+your language or workflow needs a surface the SDK does not expose.
 
 ## Authentication
 
-**An API key. Use this for a script and for CI.**
-
-Create a key under Account, then API Keys. Or exchange your credentials at
-`POST /api/auth/token`, which is what `fountain auth login` does. Then pass
-the key as a Bearer token.
+Create an API key in the console under Account, then API keys. Store it
+outside your source tree. Pass the key as a bearer token.
 
 ```bash
-curl -H "Authorization: Bearer $FOUNTAIN_API_KEY" \
-     https://your-fountain.example.com/api/agents
+curl --fail-with-body \
+  -H "Authorization: Bearer $FOUNTAIN_API_KEY" \
+  "$FOUNTAIN_URL/api/agents"
 ```
 
-```
-POST   /api/auth/token             # email + password -> a fresh API key
-POST   /api/auth/device            # start a device login: user_code + verification URL
-POST   /api/auth/device/token      # poll with device_code -> the key, once approved
-GET    /api/auth/me                # identity of the authenticated user
-POST   /api/auth/api-keys          # create a key (plaintext returned once)
-DELETE /api/auth/api-keys/:id      # revoke a key
-```
+Set `FOUNTAIN_URL` to your instance URL, without a slash at the end.
+Use `fountain auth login` for a password account, or
+`fountain auth login --device` for an account that uses GitHub sign-in.
+Reuse that credential; repeated token exchanges create more keys.
 
-The two device endpoints serve accounts without a password, such as one from
-the "Sign up with GitHub" button. `fountain auth login --device` drives them.
-You approve the code in the console at `/device`. The poll then returns a
-fresh key.
-
-**Registration and account recovery.** These need no auth. The token in the
-email authenticates the last step.
-
-```
-POST   /api/auth/register          # {email, password}
-POST   /api/auth/resend-verification
-POST   /api/auth/verify            # {token} -> activate the account
-POST   /api/auth/forgot            # {email}. Always 200, never reveals whether it exists
-POST   /api/auth/reset             # {token, password}
-POST   /api/auth/email/confirm     # {token}. Completes a pending email change
-```
-
-The verification and reset emails still link to the browser pages. These
-endpoints accept the same tokens, so a CLI can ask you to paste the code from
-your email, and open no browser.
-
-`verify` is idempotent, so an account somebody already verified gets a 200. It
-issues no session, so mint a key at `POST /api/auth/token` once the account is
-live. A token failure is a `422`, with an `error` of `invalid_token` or
-`expired`.
-
-A reset that completes bumps `session_version`, and so does an email change
-that completes. That signs out each session that exists.
-
-**Credential changes.** These need the bearer token **and** the current
-password. They take a `full`-scoped key alone.
-
-```
-POST   /api/auth/password          # {current_password, new_password}
-POST   /api/auth/email             # {new_email, current_password}. Sends a confirmation link
-```
-
-A change of password signs out the browser sessions, because `session_version`
-bumps. It does **not** revoke an API key. Those are separate credentials, with
-their own expiries.
-
-The response says so, in `sessions_invalidated` and `api_keys_revoked`. If you
-rotate because something leaked, revoke the keys yourself, with
-`DELETE /api/auth/api-keys/:id`.
-
-The email endpoint answers the same way whether the address is free or not, so
-it tells nobody which addresses exist. The address changes only when somebody
-submits the emailed token to `POST /api/auth/email/confirm`.
-
-**A session cookie.** You get one from OAuth at `/auth/oauth/:provider`, or
-from an email and password login. Fountain's own console uses it.
+Check the Auth operations in the [generated reference](/api/docs) for
+account recovery, verification, key creation, revocation, and credential
+expiry. A sandbox credential has restricted scope. Use an account credential
+for administrative workflows.
 
 ### Sign in with Fountain (OAuth 2.0 for browser apps)
 
-Fountain's own browser apps sit on other origins. Those are
-[team](https://github.com/jhgaylor/fountain-team) and
-[conversations](https://github.com/jhgaylor/fountain-conversations), and
-neither pastes a key.
+Browser apps use the authorization code flow with PKCE. The returned token
+is a Fountain API key. Register the client and its exact redirect URIs with
+the instance operator before you start the flow.
 
-They use the **authorization code grant with PKCE (S256)**, as public
-clients. The token they get *is* an API key (`decisions/0021`).
-
-```
-GET  /oauth/authorize?client_id=…&redirect_uri=…&code_challenge=…&code_challenge_method=S256&state=…
-     # browser: consent page (login round-trips back here) → 302 redirect_uri?code=…&state=…
-POST /api/oauth/token    # {grant_type: "authorization_code", code, code_verifier, client_id, redirect_uri}
-                         # → {access_token, token_type: "bearer", expires_in}   (400 invalid_grant otherwise)
-POST /api/oauth/revoke   # bearer: revoke the presented token (sign-out)
-```
-
-You register a client on the server, in `OAUTH_CLIENTS`, with exact redirect
-URIs. A client or a redirect that nobody registered renders an error page, and
-Fountain redirects nowhere.
-
-A code lives five minutes, and it works once. The key is full-scope, it
-expires in 30 days, and it lists under Account, then API keys, as
-`oauth:<client_id>`.
+Keep the verifier in the app that initiated sign-in, and validate `state`
+on return. See [Build a team chat](build/team-chat.md) for an application
+example and the OAuth operations in the [generated reference](/api/docs)
+for the token exchange.
 
 ## Account state
 
-```
-GET    /api/account/onboarding           # {completed, completed_at}
-POST   /api/account/onboarding/complete  # idempotent
-```
+Read account identity before you display account-specific controls. The console
+uses onboarding state to show setup progress. An API integration can complete
+setup without following the console checklist.
 
-An account that somebody configured through the API alone never passes through
-the browser wizard. So nothing marks it onboarded, and a later browser visit
-re-enters that wizard. Complete it over the API and the loop closes.
-
-`GET /api/auth/me` also carries `email_verified` and `onboarding_completed`.
+See the account and Auth operations in the [generated reference](/api/docs).
 
 ### Billing
 
-```
-GET    /api/account/billing                   # balance, cap, current-month usage
-POST   /api/account/billing/credits/checkout  # Stripe Checkout URL for a credit pack
-```
+Hosted work spends a credit balance. An idle machine does not burn turn
+credits. Check the account's available balance before you offer a workflow
+that starts paid work, and handle a refusal when admission occurs.
 
-Stripe needs a browser to finish, so the URL is what you get. Mint it here,
-and open it there. The server chooses the return URLs. A URL that a caller
-supplied would be an open redirect.
-
-`credits/checkout` returns a one-time Stripe Checkout URL for a credit pack.
-The balance moves when Stripe's webhook confirms the payment.
-
-The checkout refuses a comped account with `422`. It answers `502` when
-Stripe is unreachable, and guesses nothing. On an instance with payment off,
-both endpoints are a `404` with `"billing": "disabled"`.
-
-`GET /api/account/billing` reports the month as `usage`. The `conversations`
-count is the conversations that ran a turn in the month. The
-`credit_burned_cents` value is the credit the ledger took in the month, and
-`turn_hours` is the metered time. The two do not agree to the cent, because the
-pricer charges a turn when it ends.
-
-`GET /api/auth/me` carries `comped`. It is `true` for an account an operator
-made free, and `null` when payment is off. It also carries `brokered`. It is
-`true` when the account runs behind the egress credential broker. See
-[Secrets](concepts/secrets.md).
+See [Billing](guides/operate/billing.md) for operation and
+[Sandbox spend](guides/operate/sandbox-spend.md) for the distinction between
+turn usage and provider usage. The [generated reference](/api/docs) describes
+account balances, purchases, and payment errors.
 
 ### Data export and deletion
 
-```
-POST   /api/account/exports              # 202 with a pending export; 429 + Retry-After inside the hour
-GET    /api/account/exports              # status (zero- or one-element list)
-GET    /api/account/exports/:id
-GET    /api/account/exports/:id/download # gzipped JSON
-DELETE /api/account                      # {"confirm": "<your account email>"}. Irreversible
-```
-
-An export builds in the background, and the API has no PubSub. So poll
-`GET /api/account/exports` until `downloadable` is true. One account holds one
-export at most, and takes one request each hour.
-
-To delete the account destroys the sandboxes, and
-removes each resource **and the tenant encryption key**. It needs the
-confirmation body, which is the API's version of the typed-email gate in the
-UI. It also needs a `full`-scoped key.
+Export account data before you delete an account if you need an archive.
+Treat deletion as a separate, explicit user action. See the account operations
+in the [generated reference](/api/docs) for the export and deletion contracts.
 
 ## Inference credentials
 
-A conversation runs on your own provider token, and Fountain never sees your
-inference traffic. So a new account cannot start a conversation until you set
-at least one.
+Inference credentials pay the model provider. Fountain credits pay for
+Fountain's hosted work. Configure both when the selected runtime needs them.
+A configured credential does not imply that a provider will accept it.
 
-```
-GET    /api/account/inference-credentials             # per-provider set/not-set
-PUT    /api/account/inference-credentials/:provider   # {"value": "...", "validate": true}
-DELETE /api/account/inference-credentials/:provider   # clear
-```
-
-The providers are `anthropic_api_key`, `claude_code_oauth_token`,
-`openai_api_key` and `gemini_api_key`.
-
-`PUT` pings the provider to check the credential before it stores it. The
-outcomes differ, so a client knows whether to ask for the value again or to
-try again.
-
-| Status | Meaning |
-|---|---|
-| `200` | Stored, encrypted under your tenant key. |
-| `422` | `invalid`. The provider rejected it, and `provider_status` carries the upstream code. Or the value was blank. Or nobody knows that provider. |
-| `502` | `network`. This instance could not reach the provider. |
-| `504` | `timeout`. The provider did not answer in time. |
-
-Send `{"validate": false}` to store a credential with no ping.
-
-A value is **write-only**, so these endpoints report which providers hold one,
-and no more. They need a `full`-scoped key, because the token a sandbox holds
-for one conversation can neither read nor replace the account's credentials.
+See [Vaults](concepts/vault.md) and the account credential operations in the
+[generated reference](/api/docs). Read responses describe credential state;
+secret values remain write-only.
 
 ## Claimable principals
 
-```
-POST   /api/claimable-users            # open one; Idempotency-Key header
-GET    /api/claimable-users/:id        # reconcile a lost response
-POST   /api/claimable-users/:id/claim  # attach an owner
-DELETE /api/claimable-users/:id        # abandon one
-```
+A claimable principal lets an application start a computer before its visitor
+has a Fountain account. A claim attaches an owner; resource IDs and the
+tenant stay the same.
 
-An application can start a computer for a visitor who has no Fountain account.
-A claimable principal is the tenant that computer belongs to. It has its own
-agents, environments, vaults, conversations and sandboxes, and no other
-principal can read them.
-
-The claim attaches an owner and moves nothing. So `principal_id` is the same
-value before and after, and so is every id under it. **Start before sign-in**
-is the guide, and
-[ADR 0044](https://github.com/BinaryBourbon/fountain/blob/main/decisions/0044-claimable-principals.md)
-is the decision.
-
-Every route here needs a `full`-scoped key. The key a principal holds has the
-`principal` scope, which reaches the resource surface and nothing that changes
-an account. A principal therefore cannot open a second principal, mint another
-credential, or release its own grant. Each refusal is a `403` with
-`"reason": "insufficient_scope"`.
-
-Send an `Idempotency-Key` header on create and on claim. A repeat returns the
-same principal and a **new** credential, because Fountain stores no secret it
-could give you twice.
-
-A claim answers `409` when somebody claimed it first. It answers `410` when
-the grant expired, or when the application released it. It answers `403` for a
-bad token, or for an account that cannot fund the work.
+Follow [Start before sign-in](build/anonymous-visitors.md). Use the documented
+idempotency key to reconcile a lost create or claim response. A repeated
+request can return a fresh credential, so keep the latest successful result.
+The [generated reference](/api/docs) defines required scopes and refusals.
 
 ## Rate limiting
 
-Fountain rate-limits a request by client IP, whether it carries auth or not.
-The limiter does not key on the API key. On a limit you get
-`429 Too Many Requests`, with a `Retry-After` header.
+Honor `Retry-After` when a request is rate limited. Avoid immediate retry
+loops. A lost response to a mutation does not prove that the mutation failed;
+reconcile the resource before you repeat an operation that could spend money.
+See each operation's responses in the [generated reference](/api/docs).
 
 ## Agents
 
-```
-GET    /api/agents              # list (?search=, ?runtime=, ?environment_id=, ?has_skills=, ?has_mcp=)
-POST   /api/agents              # create
-GET    /api/agents/:id
-PUT    /api/agents/:id
-DELETE /api/agents/:id
-```
+An agent is reusable configuration for a runtime and model. Create its
+[environment](concepts/environment.md) and [vault](concepts/vault.md) first,
+then reference them when you configure the agent.
 
-```
-GET    /api/agents/:id/versions            # config history, newest first
-GET    /api/agents/:id/versions/:version   # one version, with its full config
-```
-
-Fountain writes a version each time an agent's config changes. Version 1 is
-the config at create time. Each version carries the full config
-and a `version` number. The API serves versions as read-only data. A rollback
-is a console action.
-
-```
-GET    /api/agents/:id/avatar   # image bytes (bearer token)
-PUT    /api/agents/:id/avatar   # raw bytes with an image content-type, or {"data": base64, "media_type": ...}
-DELETE /api/agents/:id/avatar
-```
-
-An avatar takes `image/png`, `image/jpeg`, `image/gif` or `image/webp`, up to
-5 MB. The agent object carries `avatar_media_type`, which is null when there
-is no avatar.
-
-Fountain refuses another type with `415`, and an upload that is too large with
-`413`. It serves the bytes with `nosniff` and a CSP that sandboxes them, and it
-checks the media type again at serve time.
-
-An agent object carries `conversation_count`. An environment carries
-`secret_count` and `agent_count`. A vault carries `secret_count`.
-
-An agent carries `sandbox_mode`, which is `ephemeral` or `persistent`. With
-`ephemeral`, each conversation gets a sandbox of its own. With `persistent`,
-the agent has one machine, and each conversation with the same environment
-and vault lands on it. That machine survives a conversation that ends, and
-nothing stops it while it runs. A launch can name the
-other mode with `sandbox_mode` on `POST /api/conversations`.
-
-They are on the list read and on the single-resource read. So "does this
-environment have a user, and is it safe to delete" is one request.
+Use version history to inspect configuration changes before a rollback.
+See [Agents](concepts/agent.md) for the model and the Agents operations in
+the [generated reference](/api/docs) for the complete contract.
 
 ## Catalog
 
-```
-GET  /api/catalog             # runtimes, model suggestions per runtime, sandbox providers, package managers, avatar bases/moods, app URLs
-POST /api/avatars/generate    # {base, mood} → {data (base64 PNG), media_type}; attach with PUT /api/agents/:id/avatar
-```
-
-This is the vocabulary that builds the agent and environment forms. A client
-somewhere else can read it, and hard-code nothing.
-
-A model list is a set of suggestions, and not an allowlist. Fountain accepts
-any `provider/model` under a provider it knows.
-
-`package_managers` names what Fountain installs from an environment's
-`packages`, which is `apt` and `npm`. It stores another key and ignores it.
-
-To draw an avatar, Fountain uses the tenant's own OpenAI credential. Without
-one it answers `422 no_openai_key`.
-
-`apps` is where this instance sends a person to *read* something. Those are
-the standalone
-[conversations](https://github.com/jhgaylor/fountain-conversations) and
-[team](https://github.com/jhgaylor/fountain-team) apps, which route on the
-fragment, as `…/#/c/<conversation_id>` and `…/#/team/<agent_id>`.
-
-Either one is null where the deployment has no such app. Use `apps`, and do
-not compose a URL against the API host. Fountain's own UI is a console, and it
-serves no transcript.
+Read the instance catalog before you offer runtime, provider, or app choices.
+An integration should distinguish an unavailable capability from one that its
+workflow does not require. The [generated reference](/api/docs) describes the
+catalog response; the [Catalog](catalog/index.md) explains shipped resources.
 
 ## Environments
 
-```
-GET    /api/environments
-POST   /api/environments
-GET    /api/environments/:id
-PUT    /api/environments/:id
-DELETE /api/environments/:id
-GET    /api/environments/:id/secrets          # keys + timestamps only
-POST   /api/environments/:id/secrets          # upsert
-DELETE /api/environments/:id/secrets/:key
-```
-
-A secret value is **write-only**. Once Fountain stores it, the API never
-returns it. A list returns each secret's key, its id, and its timestamps.
+An environment supplies the packages, repositories, scripts, network policy,
+and baseline secrets a machine needs. See [Environments](concepts/environment.md).
+The [generated reference](/api/docs) defines the editable configuration and
+secret operations. Changes can affect persistent machines built from it.
 
 ## Vaults
 
-```
-GET    /api/vaults
-POST   /api/vaults
-GET    /api/vaults/:id
-PUT    /api/vaults/:id
-DELETE /api/vaults/:id
-GET    /api/vaults/:id/secrets                # keys, timestamps, expiry only
-POST   /api/vaults/:id/secrets
-DELETE /api/vaults/:id/secrets/:key
-```
-
-The same write-only rule covers a vault secret value.
+A vault supplies secret overrides without a duplicate environment.
+See [Vaults](concepts/vault.md) for precedence and reuse. Submit secret values
+through the write operations in the [generated reference](/api/docs); do not
+expect read operations to return them.
 
 ## Secret bindings
 
-<!-- vale STE.IngForms = NO -->
-These routes answer only when the credential broker is on for the account.
-The broker is on for every account on the hosted platform. Read
-[Feature status](reference/feature-status.md), and
-[Where a secret comes from](concepts/secrets.md#bindings-when-the-broker-is-on)
-for what a binding does.
+Use broker bindings when a sandbox should reference a credential while the
+broker supplies its value to an approved destination. The credential value stays outside the sandbox.
 
-```
-GET    /api/secret-bindings                # each binding: secret name, host, shape
-GET    /api/secret-bindings/presets        # the shapes a binding can take
-POST   /api/secret-bindings
-PATCH  /api/secret-bindings/:id
-DELETE /api/secret-bindings/:id
-```
-
-A binding is about the name of a secret, so it applies to every environment
-and vault that holds a secret of that name. A conversation-scoped token
-cannot reach these routes. They need a full-scope key.
-<!-- vale STE.IngForms = YES -->
+See [Secrets](concepts/secrets.md) for the security model and the binding
+operations in the [generated reference](/api/docs) for configuration.
 
 ## Connections
 
-These routes answer only when the credential broker is on for the account.
-Elsewhere they answer 404 `connections_not_enabled`. The broker is on for
-every account on the hosted platform. Read
-[Connections](catalog/connections/index.md) for what a connection is.
-
-```
-GET    /api/connections                    # the account's connections, with provider, provider_id and status
-GET    /api/connections/providers          # where to send the owner to connect one
-GET    /api/connections/:id
-DELETE /api/connections/:id                # revoke at the provider, then forget the token
-```
-
-A status is `active`, `revoked` or `expired`. To connect an account needs a
-browser and a session, so it is not an API operation.
+A connection authorizes access to an external service through its OAuth flow.
+It is distinct from an API key for Fountain. See
+[Connections](catalog/connections/index.md) for supported services and setup.
+The [generated reference](/api/docs) describes discovery and connection state.
 
 ### Connection providers
 
-```
-GET    /api/connection-providers               # Google, then the account's own
-POST   /api/connection-providers               # define an oauth2 provider, or discover an mcp one from its URL
-GET    /api/connection-providers/:id           # `google` is the platform provider
-PATCH  /api/connection-providers/:id           # a blank client_secret keeps the stored one
-DELETE /api/connection-providers/:id           # deletes the provider and every connection on it
-POST   /api/connection-providers/:id/discover  # run MCP discovery again
-```
-
-A `POST` with `kind: oauth2` takes the account's own app registration. The
-authorize and token URLs, the scopes, the client id and secret, the token
-endpoint auth, `pkce`, `env_key` and `token_hosts`. A `POST` with
-`kind: mcp` takes `mcp_url` alone. Fountain fetches the server's metadata
-chain and registers a client where it can. Pass `client_id` and
-`client_secret` for a server with no registration. A discovery failure
-answers 422 with `error: discovery_failed` and a `detail`.
-
-Every URL must be `https` and public. The response carries `redirect_uri`,
-to register at the service, and `connect_url`, where the owner connects.
-The client secret is write-only. A `PATCH` or `DELETE` on the platform provider
-answers 404. All of these routes need a key with full scope. Read
-[Connect a service with your own OAuth app](guides/connect/own-oauth-app.md)
-and [Connect a remote MCP server](guides/connect/remote-mcp-server.md).
+An instance must configure a provider before an account can connect it.
+For an external service, follow [Register your own OAuth app](guides/connect/own-oauth-app.md).
+Use provider discovery from the [generated reference](/api/docs) to decide
+which connection choices the UI can offer.
 
 ## Bulk apply
 
-```
-POST   /api/apply                # apply a compiled manifest in one request
-```
+Use `fountain apply` when a checked-in manifest should define several related
+resources. The CLI compiles the manifest and submits the resource graph.
+Inspect every resource result: one failed resource does not mean that all
+other writes failed.
 
-This takes the compiled form of a `fountain.yml` manifest, which is what
-`fountain apply` sends.
-
-```json
-{
-  "resources": [
-    {"kind": "Environment", "name": "proj", "spec": {"setup_script": "...", "secrets": {"TOKEN": "..."}}},
-    {"kind": "Vault", "name": "alice", "spec": {"secrets": {"GH": "..."}}},
-    {"kind": "Agent", "name": "researcher", "spec": {"model": "...", "runtime": "claude", "environment": "proj"}}
-  ]
-}
-```
-
-Fountain upserts a resource by name, in a fixed order. Environments first,
-then vaults, then agents. So an agent's `spec.environment` name reference
-resolves against an environment in the same manifest, **or** against one that
-already exists.
-
-Fountain applies each resource on a best-effort basis. The response is always
-a `200`, with one result for each resource. Each result carries an `action` of
-`created`, `updated` or `error`, and an `error` carries changeset-style
-`errors`. Each result also carries the outcome for each secret key. Fountain
-never echoes a secret value back.
-
-An unknown `spec` key gives that resource an `error` result, before Fountain
-writes its attributes or secrets. Use `networking_type` and
-`networking_config` for environment network restrictions; `network_policy`
-is not a supported field. Ownership keys (`id`, `user_id`, `created_by`)
-remain ignored: a manifest cannot change the account that owns a resource.
+See [CLI](cli.md) for the workflow and the Apply operation in the
+[generated reference](/api/docs) for its wire format. Unknown configuration
+keys fail validation before Fountain writes that resource's attributes or secrets.
 
 ## Conversations
 
-A conversation takes many turns. Create one with a first prompt, then prompt
-it again and again.
+Create a conversation with an agent and a first prompt, follow its events,
+and send later prompts to that same conversation. Keep the returned ID.
+A new conversation creates another thread.
 
-```
-GET    /api/conversations                  # list (?roots_only=true; ?agent_id= ?channel_id= ?status=idle,terminated)
-POST   /api/conversations                  # start (agent_id; optional vault_id, environment_id, sandbox_id, sandbox_mode, prompt, images)
-GET    /api/conversations/:id
-DELETE /api/conversations/:id
-POST   /api/conversations/:id/read         # clear unread state
-POST   /api/conversations/:id/requests/:request_id   # answer a permission request ({option_id})
-GET    /api/conversations/:id/tree         # the whole spawn tree this conversation belongs to
-POST   /api/conversations/:id/prompts      # follow-up turn
-POST   /api/conversations/:id/interrupt    # stop the running turn
-POST   /api/conversations/:id/terminate    # end the conversation; destroys the sandbox unless it is persistent or shared
-GET    /api/conversations/:id/turns
-GET    /api/conversations/:id/events       # log events as JSON (?streams=  ?after=  ?limit=)
-GET    /api/conversations/:id/stream       # SSE log stream (?streams=stdout,stderr,stage  ?wait=false)
-GET    /api/conversations/:id/turns/:turn_id/images/:position   # image bytes
-GET    /api/conversations/:id/egress       # what left the sandbox through the broker (limited access)
+```bash
+curl --fail-with-body \
+  -H "Authorization: Bearer $FOUNTAIN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"agent_id":"YOUR_AGENT_ID","prompt":"Describe the files in the workspace."}' \
+  "$FOUNTAIN_URL/api/conversations"
 ```
 
-<!-- vale STE.IngForms = NO -->
-`GET /api/conversations/:id/egress` is there only when the credential broker
-is on for the account. Read [Feature status](reference/feature-status.md). It
-lists each request that left the sandbox through the broker, with the host,
-the binding that matched, the status and the latency. A refused host shows
-the refusal. The broker writes a row when the request ends, so a long stream
-gets its row at the end of the stream. The latency is the duration of the
-whole request, not the time to the first byte. The list stays for
-`BROKER_LOG_RETENTION_HOURS` after the conversation ends.
-<!-- vale STE.IngForms = YES -->
+This starts real work and can consume credits and provider usage.
+[Conversation states](reference/conversation-states.md) explains lifecycle
+transitions. The Conversations operations in the
+[generated reference](/api/docs) define prompt admission, permission answers,
+interruption, termination, history, images, and event streams.
 
-A turn carries `image_count`. The image endpoint takes a `position` into that
-count, which starts at zero, and returns the raw bytes with the stored media
-type.
-
-A turn also carries `origin`. It is `user` for a prompt that somebody sent.
-It is `autonomous` for a turn that the server opened for a background cycle
-of the agent, after the answer to its prompt. In that case `prompt` holds a
-marker, not the words of a person.
-
-`sandbox_id` attaches the new conversation to a sandbox you already have.
-Fountain then provisions nothing. The sandbox must be `ready` or `suspended`,
-and Fountain must have built it for the same agent, environment and vault.
-Otherwise you get `404 sandbox_not_found`, `409 sandbox_not_attachable` or
-`422 sandbox_identity_mismatch`. Several conversations can then run on one
-disk at the same time. On an opencode or gemini sandbox, only one turn runs
-at a time. A second prompt gets `409 sandbox_at_capacity` while the first
-one runs.
-
-`sandbox_mode` is `ephemeral` or `persistent`, and it replaces the agent's
-default for this conversation. A persistent conversation lands on the agent's
-own machine. Fountain makes that machine on the first persistent launch of an
-agent, environment and vault. A second launch while the first still builds
-it gets `503 provisioning`, so send again shortly.
-
-`POST /api/conversations/:id/requests/:request_id` answers a permission
-request that blocks the agent. The request and its options arrive as a
-`permission_request` block on the event stream. Send `{option_id}`, and
-choose one of the `optionId` values that the block carried. The first answer
-wins. A request that another client, the timeout or the end of the turn
-resolved gets `409 permission_request_resolved`. An option the agent did not
-offer gets `422 unknown_option`. A sandbox's own token cannot answer, and
-gets `403 sprite_may_not_answer`.
-
-`POST /api/conversations/:id/interrupt` stops the turn in flight. It also
-wakes a conversation whose server died with a turn still marked `running`, so
-a turn that nothing else can close still ends.
-
-The error tells you about the conversation, never about your access. A status
-of `404` means no such conversation. A status of `409 no_turn_running` means
-the conversation sits idle between turns. A status of `409 not_running` means
-the conversation ended, or a wake did not restore it.
-
-Whatever does not resolve is a `404`, so nobody can probe for an id.
-
-That covers four cases. A conversation nobody knows. A turn from a different
-conversation. A position that is not there. A stored media type that is not an
-image.
-
-The list takes three filters, and you can combine each of them with
-`roots_only`.
-
-`agent_id`. `channel_id`, which names the channel that holds a conversation,
-and the team's is `fountain:team`. Remove a teammate and its conversation comes
-free, so it no longer matches. A teammate's full history is therefore
-`GET /api/team/:agent_id/conversations`.
-
-`status`, which takes a comma-separated list. A value outside the vocabulary
-gives a `400 invalid_status`.
-
-The list has no pages.
-
-A conversation object carries `title`, `turn_count`, `last_active_at`,
-`last_read_at` and a computed `unread`, next to the lifecycle fields.
-
-`unread` is true when `last_active_at` is later than `last_read_at`, and for a
-conversation that nobody read. `POST /api/conversations/:id/read` clears it.
-
-**Token usage.** Each turn carries `usage`, as
-`{input, output, cache_read?, cache_write?}`. That is the figure the runtime
-reports when the turn ends, in the `usage` of the ACP `session/prompt`
-response. claude-agent-acp and codex-acp report it.
-
-It is `null` in three cases. While the turn runs. When the runtime reported
-none. On a turn older than the field.
-
-Fountain records it once for each turn. It never sums the `usage_update`
-notifications that stream while a turn runs. Those report how full the context
-window is, and each runtime means something different by that.
-
-Each conversation carries `agent_version_id` and `agent_version`. They name
-the agent config version that the conversation started with. Both are null
-for a conversation that predates config versions. The list and get endpoints
-resolve `agent_version`; other endpoints that embed a conversation return
-null for it. Read the version at `/api/agents/:id/versions/:version`.
-
-Each conversation carries `usage_total: {input, output}`, a sum over its
-turns. A `/api/team` roster entry carries `usage_total` summed over each
-conversation the agent has had on the team.
-
-`/tree` returns each conversation in the same spawn tree. Ancestors and
-descendants, flat, and each one with a `parent_id`.
-
-```json
-{"data": [{"id": "…", "source": "ui", "status": "idle", "parent_id": null},
-          {"id": "…", "source": "agent", "status": "running", "parent_id": "…"}]}
-```
-
-A sub-conversation arrives over the API, with
-`X-Fountain-Parent-Conversation-Id`. So this is how an agent that fanned out
-lists what it started, and keeps no records of its own.
-
-`/events` is the read model for the log feed, and `/stream` is the tail.
-
-The JSON endpoint returns the rows that the stream sends, which are `kind`,
-`stream`, `data`, `stage`, `state`, `duration_ms`, `turn_id` and `ts`. It adds
-each event's `id`, and it returns the oldest first.
-
-```json
-{"data": [{"id": 41, "kind": "output", "stream": "stdout", "data": "...", "ts": "..."}],
- "meta": {"limit": 100, "has_more": true, "next_cursor": 41}}
-```
-
-To page, pass the previous response's `meta.next_cursor` as `after`. Continue
-while `meta.has_more` is true. `limit` defaults to 100, and caps at 1000.
-
-The `id` is the value that the SSE route uses as `Last-Event-ID`. So a client
-can drain the history as JSON, then attach the stream where it stopped.
-
-`?blocks=true` works on `/events`, on `/stream` and on
-`/api/events/stream`. It adds `blocks` to each event.
-
-That is the event's `data`, parsed on the server into the structured blocks
-that a transcript renders. It is the parse the conversations app uses,
-`Fountain.Conversations.Blocks`. So a client never writes a runtime's dialect
-again. That is ADR 0014, applied to the wire.
-
-Here are the kinds, and their fields.
-
-| kind | fields |
-|---|---|
-| `text`, `thinking` | `body` |
-| `tool_use` | `id`, `name`, `summary`, `body`, which is the input. |
-| `tool_result` | `tool_id`, `body`, `error`. Pair it with the `tool_use` that has the same id. |
-| `init` | `summary`, `body` |
-| `result` | `body`, `raw` |
-| `error` | `body` |
-| `raw` | `body`, `summary`. It is a line nobody recognised. Fountain shows it, and drops nothing. |
-
-An event that is not output carries `blocks: []`. Without the flag, the field
-is absent.
+Use history for a durable transcript and SSE for live delivery. Persist the
+event cursor so a reconnect can resume after the last event processed.
+Request structured blocks to render runtime output; clients should not
+parse each runtime's native dialect.
 
 ### Every conversation on one stream
 
-```
-GET /api/events/stream          # SSE (?streams=  ?blocks=true)
-```
+Use the account event stream for a conversation list with live updates.
+Refresh the list when a conversation-change notification arrives. Keep each
+conversation's history available for reconciliation after a reconnect.
 
-This is one `text/event-stream` for each conversation the caller owns that has
-not finished. A conversation list with live status and unread dots needs that,
-and it needs no socket for each conversation.
-
-Each event is the payload of the stream for one conversation, with
-`conversation_id` added.
-
-Fountain sends a `conversations` event, `{"reason":"changed"}`, when the list
-changes. That is a create, a title, a read, a delete or a finish, and Fountain
-sends at most one each second. The stream follows a new conversation on its
-own, and the client lists them again.
-
-`Last-Event-ID` replays what you missed, across each conversation the stream
-follows. The first byte is a `: connected` comment. A heartbeat arrives every
-15 s. The stream closes after 60 s idle, so the client reconnects.
+The Events operations in the [generated reference](/api/docs) define stream
+selection, cursors, and framing. See [Build a chat app](build/index.md) for
+how a client combines the list, transcript, and live stream.
 
 ## Sandboxes
 
-A sandbox is the computer a conversation runs on. One sandbox can hold
-several conversations.
+A sandbox is the machine that hosts a conversation. Several conversations
+can share it. Keep the distinction between a transcript and its machine
+when you present reset or termination controls.
 
-```
-GET    /api/sandboxes          # list (?status=ready,suspended)
-GET    /api/sandboxes/:id
-DELETE /api/sandboxes/:id      # reset a persistent sandbox
-```
-
-Each sandbox carries `status`, `mode`, `provider` and `url`. It also carries
-the `agent_id`, `environment_id` and `vault_id` that Fountain built it for,
-and `conversations`. Each entry there carries `mid_turn`, which is true while
-that conversation runs a turn. To put a second conversation on a sandbox,
-pass its id as `sandbox_id` to `POST /api/conversations`.
-
-`DELETE` resets a `persistent` sandbox. Fountain destroys the machine and
-keeps the conversations on it. The next prompt on one of them builds a clean
-machine for the same agent, environment and vault. The response is `204`.
-An ephemeral sandbox, or one that is already `terminated` or `failed`, gets
-`422 sandbox_not_resettable`. While a conversation on the sandbox runs a
-turn, the request gets `409 sandbox_mid_turn`.
-
-Three other requests retire a persistent sandbox, because each one moves the
-identity that the sandbox belongs to. A `PATCH /api/agents/:id` with a new
-`environment_id` retires the sandboxes built on the old environment. A
-`DELETE` on `/api/environments/:id` or on `/api/vaults/:id` retires the
-sandboxes built on that environment or that vault. Each request behaves like
-a reset. Fountain destroys the machine, keeps the conversations, and builds a
-new machine on the next prompt. A request also gets `409 sandbox_mid_turn`
-while a conversation on one of those sandboxes runs a turn.
+See [Sandboxes](concepts/sandboxes.md) and
+[Sandbox lifetime](guides/operate/sandbox-lifetime.md). The Sandboxes operations
+in the [generated reference](/api/docs) describe attachment identity, reset
+conditions, and refusal during a turn.
 
 ### Files and git diff
 
-Three read-only requests show the disk of a sandbox. An app that watches an
-agent uses them when the transcript is not enough. There is no request that
-runs a command. To run a command, send a prompt.
+Use the sandbox read operations to inspect files and tracked changes while
+an agent works. Reads do not wake a parked machine. A diff does not include
+untracked files, so it is not a complete inventory of the working directory.
 
-```
-GET /api/sandboxes/:id/files?path=src           # list a directory
-GET /api/sandboxes/:id/file?path=src/app.ex     # read a file
-GET /api/sandboxes/:id/diff?path=repo&staged=true&ref=main
-```
-
-All three need a key with the `full` scope. The `sprite` key that a sandbox
-holds gets `403 insufficient_scope`. A `path` is absolute, or relative to the
-current directory of the agent. That directory is `/home/sprite` for claude
-and codex, `/tmp/gemini-workspace` for gemini, and `/tmp/opencode-workspace`
-for opencode. A path must stay in `/home/sprite` or in that directory.
-Any other path gets `422 path_outside_sandbox`. Fountain reads a `ready`
-sandbox only. A parked sandbox gets `409 sandbox_not_ready` and stays parked.
-A path that does not exist gets `404 path_not_found`.
-
-`files` lists one directory, directories first, then by name. Without `path`,
-it lists the current directory of the agent. Each entry has a `name`, a
-`type` and a `size`. The `type` is `file`, `directory`, `symlink` or `other`.
-The response holds at most 2000 entries. `truncated` is `true` when the
-directory holds more. A path that is a file gets `422 not_a_directory`.
-
-`file` returns one file. `size` is the size of the whole file. `content`
-holds at most `max_bytes` of it. The default is 262144 and the limit is
-4194304. `truncated` is `true` when `content` stops before the end.
-`encoding` is `utf-8` when `content` is the text itself. It is `base64` when
-the bytes are not valid UTF-8. A path that is a directory gets
-`422 is_a_directory`.
-
-`diff` returns `git diff` of the repository that holds `path`. `repo_root` is
-the top directory of that repository. `staged=true` compares the index
-(`--cached`). `ref` compares against one commit, branch or tag. A `ref` with
-a flag or a range gets `422 invalid_ref`. A `ref` that git does not know gets
-`404 ref_not_found`. A directory outside a repository gets
-`422 not_a_repository`. `max_bytes` and `truncated` work as for `file`.
-
-Fountain redacts every response. Each value of the environment and the vault
-of the sandbox reads `[REDACTED]`, as it does in the transcript. Values
-shorter than eight bytes stay as they are.
+The [generated reference](/api/docs) defines path confinement, byte limits,
+truncation, encoding, and comparison options. Check truncation before you show
+a response as a complete file. Treat redacted output as a display value.
 
 ## Search
 
-
-This is full-text search across the caller's conversations. A command palette
-uses it, to jump to a message.
-
-```
-GET /api/search?q=<text>[&limit=20][&offset=0][&agent_id=][&conversation_id=][&since=][&kinds=title,prompt,reply]
-```
-
-```json
-{"data": [{"kind": "reply", "conversation_id": "…", "agent_id": "…", "turn_id": "…",
-           "turn_number": 3, "snippet": "… the gate lives in the billing plug …",
-           "ts": "2026-08-19T02:00:00Z"}],
- "meta": {"limit": 20, "offset": 0, "has_more": false}}
-```
-
-There are three sources, in one shape.
-
-`title` is a conversation's title, and its `turn_id` is null. `prompt` is a
-turn's prompt. `reply` is a turn's assistant text, which is the `text` blocks
-of its events. Fountain materialises a reply when the turn ends, so you can
-search a turn in flight by its prompt, and not yet by its reply.
-
-It is Postgres full-text, with `websearch` syntax. That is a
-`"quoted phrase"`, a `-excluded` word, and `or`. It matches an exact token and
-stems nothing, so an identifier and a code fragment match as themselves.
-
-Fountain ranks the hits, and puts the newest first among equals. The
-`snippet` is plain text with no markup. The `ts` is the creation time of the
-turn, or of the conversation itself. A `limit` caps at 100.
-
-The query itself scopes each source to the caller. Fountain indexes nothing
-across tenants. The rate limit on the rest of `/api` covers this too.
-
-A turn that ended before the `reply_text` column existed is searchable by its
-prompt alone. Run the one-time backfill on the server to fix that, with
-`bin/fountain_server eval 'Fountain.Release.backfill_turn_replies()'`.
+Use account-scoped search to find resources and conversation content the caller
+can access. Search results are navigation aids; fetch the selected resource
+before you act on its current state. See Search in the
+[generated reference](/api/docs).
 
 ## Team
 
-These routes serve the roster that [`/team`](concepts/teammates.md) shows, to
-a client that is not this web app. A teammate is a conversation bound to the
-reserved channel `fountain:team`.
+A teammate is an agent with a stable conversation and optional communication
+channels. Follow [Teammates](concepts/teammates.md) for the model and
+[Build a team chat](build/team-chat.md) for the app workflow.
 
-Each route here wraps the `Fountain.Team` that the page wraps. So a standalone
-client gets the page's exact semantics, and writes none of them again over
-`/api/conversations`.
-
-Those semantics are three. An add is idempotent. A message wakes a parked
-machine, or opens a fresh conversation when nobody can resume the old one. A
-remove terminates the conversation and unbinds it.
-
-```
-GET    /api/team                    # roster: agent, conversation, presence, unread, preview
-POST   /api/team                    # add (agent_id; optional name, environment_id, vault_id)
-GET    /api/team/:agent_id
-PATCH  /api/team/:agent_id          # rename ({name}; null or blank → the agent's name)
-DELETE /api/team/:agent_id          # remove: terminate the live conversation, unbind history
-POST   /api/team/:agent_id/messages # a turn (prompt; optional images) → {conversation_id}
-GET    /api/team/:agent_id/conversations  # history: every conversation on the team, newest first, `current` flagged
-POST   /api/team/:agent_id/contact  # give the teammate an email address + phone number ({prompt_from_number}; flag `team_comms`)
-PATCH  /api/team/:agent_id/contact  # change prompt_from_number (nothing bought or released)
-DELETE /api/team/:agent_id/contact  # release them
-GET    /api/team/comms              # {enabled, configured}: may this caller, and can this instance
-GET    /api/team/stream             # SSE: every teammate's events on one connection (`?blocks=true`)
-```
-
-`PATCH /api/team/:agent_id` sets the teammate's name, which is its
-conversation's `title`. That name carries onto the fresh conversation that
-Fountain opens when nobody can resume this one. The audit trail records
-`team.renamed`, and the stream sends `team`.
-
-`GET /api/team/:agent_id/conversations` is the teammate's history. A retired
-conversation is a previous machine's thread. It stays bound to the team
-channel until somebody removes the teammate, so the list shows it behind the
-current one, with `current: false`. Read it with
-`GET /api/conversations/:id/events`.
-
-`POST /api/team/:agent_id/conversations` starts the teammate over, and keeps
-its machine.
-
-Fountain retires the current conversation. It goes `terminated`, and the list
-shows it behind the new one with `current: false`. Fountain opens a new
-conversation on the same channel. That one carries the name, the environment
-and the vault. It points at the **same sandbox**.
-
-Fountain provisions nothing and interrupts nothing. The next message wakes
-that sandbox through the usual reattach path, and starts a fresh runtime
-session on it. So the agent's context is new, and its files, clones and
-installed tools are where it left them.
-
-You get a `201`, with the teammate and its new conversation. You get
-`400 conversation_busy` while a turn runs, so interrupt it first. You get
-`503 provisioning` while the machine still starts.
-
-When the machine has gone, Fountain provisions a new sandbox instead, exactly
-as `POST /api/team` would. The machine has gone when the sandbox is
-`terminated` or `failed`, or when nobody can resume the conversation.
-
-The audit trail records `team.conversation.rotated`, and the stream sends
-`team`.
-
-To retire the thread *and* the machine, the old way still works. Send
-`POST /api/conversations/:id/terminate` on the current conversation. The next
-message then opens a fresh one on a new sandbox.
-
-`POST /api/team` answers `201` with the teammate. It answers `200` when the
-agent was on the team already, and returns that agent's live conversation and
-ignores the attributes you sent.
-
-`name` becomes the conversation's `title`. `environment_id` and `vault_id` go
-through the agent's `allowed_environment_ids` and `allowed_vault_ids`, exactly
-as they do on `POST /api/conversations`. One that nobody knows, or that
-belongs to another tenant, is a `404`. One the agent does not permit is a
-`422`.
-
-Each roster entry carries seven things. `name`, which is the title, or else
-the agent's name. The full `agent` object. The full `conversation` object.
-`presence`. `unread`. `last_turn`. `preview`, as
-`{kind: "you"|"them"|"typing", text}`, or null when there are no messages.
-
-`presence` carries a `state`, one of `working`, `starting`, `online`,
-`asleep`, `away`, `machine_offline`, `failed` and `offline`. It carries a
-`label` for a person to read.
-
-`machine_offline` is a teammate on a
-[self-hosted runner](integrations/runners.md) whose machine is not connected.
-A message cannot wake it, and you get `503 runner_offline`. It comes back when
-the daemon reconnects.
-
-The conversation's `sandbox` carries `provider`. On a runner it also carries
-`runner: {id, name, hostname, online, path}`.
-
-**Email and phone. Alpha, behind the `team_comms` flag.** Off by default on
-the hosted platform. Read [Feature status](reference/feature-status.md).
-
-`POST /api/team/:agent_id/contact` gives the teammate an inbox, from
-[AgentMail](https://agentmail.to), and a number, from
-[AgentPhone](https://agentphone.ai). Both sit under the instance's own keys,
-and the roster entry gains `contact: {email, phone}`.
-
-From its next turn, the teammate holds seven MCP tools. Those are
-`email_send`, `email_reply`, `email_list`, `email_get`, `sms_send`,
-`sms_list` and `my_contact_info`. Fountain serves them itself, at
-`POST /api/mcp/team-comms/:conversation_id`, with the conversation's sprite
-token. So no provider key enters the sandbox. The audit trail records each
-send as `team.contact.sent`, and never the content.
-
-There are five refusals. You get `404 team_comms_not_enabled` when the flag is
-off for the caller. You get `503 team_comms_not_configured` when the instance
-holds no keys. You get `409 contact_already_provisioned` for a second contact.
-You get `402 contact_limit_reached` when the account holds as many contacts
-as `TEAM_CONTACT_CEILING` permits, and the body carries `count` and `limit`.
-You get `424 provider_error` when a provider refuses, where `channel` names
-which one. A provision is all or nothing.
-
-`DELETE` releases both upstream, then forgets them. `GET /api/team/comms`
-answers `{enabled, configured}`, so a client knows whether to offer it. Read
-[configuration](configuration.md#teammate-email-and-phone).
-
-The request body must carry `prompt_from_number`. Any common format works, and
-Fountain stores E.164. It is **your** phone.
-
-A text from that number to the teammate's number arrives as a prompt in the
-teammate's conversation. AgentPhone delivers it to
-`POST /api/webhooks/agentphone`, and `AGENTPHONE_WEBHOOK_SECRET` verifies the
-HMAC. Fountain wraps it, so the teammate knows it came by SMS and can answer
-with its `sms_send` tool.
-
-Fountain acknowledges a text from any other number, and ignores it. It
-deduplicates a delivery by AgentPhone's `X-Webhook-ID`. The audit trail
-records `team.contact.prompted`, with the byte count, and never the text.
-
-A `STOP` from that number opts it out, and so does `UNSUBSCRIBE`, `CANCEL`,
-`END` or `QUIT`. Fountain sets `contact.prompt_opted_out_at`, and drops that
-number's texts until a `START`, or until somebody changes the number, which is
-fresh consent. Fountain answers a `HELP`.
-
-Each keyword gets a confirmation, texted back from the teammate's number, on a
-best-effort basis.
-
-`/messages` returns `202 {status: "queued", conversation_id}`. The id names
-the conversation the message went to. That is a new conversation when somebody
-terminated the teammate's previous one.
-
-You get `400 conversation_busy` while the last turn still runs. You get
-`503 provisioning` while the machine starts. You get `503 runner_offline`
-while the machine behind a runner-backed teammate is off.
-
-**Teammates know each other.** Each conversation on the team channel carries
-an MCP server, `fountain-team`. Fountain serves it at
-`POST /api/mcp/team/:conversation_id`, and the sandbox's own token
-authenticates the call. It holds four tools.
-
-`list_teammates`.
-
-`get_teammate`, by name, by role or by keyword, and "the engineer" resolves.
-
-`send_to_teammate`. The message lands in their thread, with the sender named
-in front. It carries a note that the owner and their teammates alone can send
-such a message.
-
-A teammate that is busy, that still starts, or whose machine is off comes back
-as a tool error, so the agent can try again. The tool returns the turn it
-created.
-
-`wait_for_teammate`, which blocks for up to 90 s for the reply. `since_turn`
-pins it to one turn. A `timed_out: true` means call it again.
-
-`read_teammate`, which returns the recent prompts and replies.
-
-So "send this to the steward", inside one teammate's turn, is two tool calls.
-The team page shows the exchange in both threads.
-
-`/stream` is one `text/event-stream` for the whole team. Each event is the
-payload of the stream for one conversation, with `conversation_id` and
-`agent_id` added. A client routes it to a roster row, and needs no socket for
-each teammate.
-
-Fountain sends a `team` event, `{"reason":"changed"}`, when the roster
-changes. Three things change it. Somebody adds or removes a teammate. Fountain
-opens a fresh conversation for one. A self-hosted runner connects or drops,
-which changes presence for the teammates on it.
-
-The stream then follows the new conversation itself, and the client lists them
-again.
-
-The stream honours `Last-Event-ID`, replayed across each teammate, and it
-honours `?streams=`. A heartbeat arrives every 15 s. It closes after 60 s
-idle, so the client reconnects.
+The Team operations in the [generated reference](/api/docs) describe roster,
+messages, contact provisioning, and access. Check capability availability
+before you offer email or phone features.
 
 ### Schedules
 
-These are the routines that the team page offers, over the API. A routine is a
-cron that runs a teammate with a prompt. It runs in the teammate's own thread,
-or on a one-off machine.
-
-Each route wraps `Fountain.Team.Schedules`, so a standalone client gets the
-page's exact semantics.
-
-```
-GET    /api/team/schedules                       # every schedule of the caller, soonest first
-GET    /api/team/:agent_id/schedules
-POST   /api/team/:agent_id/schedules             # cron (5 fields, UTC), prompt; optional name, one_off, enabled
-GET    /api/team/:agent_id/schedules/:id
-PATCH  /api/team/:agent_id/schedules/:id
-DELETE /api/team/:agent_id/schedules/:id
-POST   /api/team/:agent_id/schedules/:id/run     # run now → 202 {status: "queued", conversation_id}
-```
-
-A schedule carries `id`, `agent_id`, `name`, `cron`, `prompt`, `one_off`,
-`enabled`, `next_run_at`, `last_run_at`, `last_conversation_id` and
-`last_error`.
-
-Fountain evaluates `cron` in UTC. A `0 9 * * 1-5` is 09:00 UTC on a weekday.
-A name in the `@daily` style works, and `@reboot` does not.
-
-`one_off: false` is the default. It sends the prompt into the teammate's own
-conversation, as a typed message would.
-
-`one_off: true` opens a fresh conversation on a new machine for each run. It
-uses the teammate's agent, environment and vault.
-
-The agent must be the caller's. It need not be on the team yet.
-
-A schedule has the address `(agent_id, id)`. The same row under another
-agent's path is a `404`, as another tenant's row is.
-
-`/run` takes the path that the page's "Run now" takes, and it answers as
-`/messages` does.
-
-You get `400 conversation_busy` while the teammate's previous turn still runs.
-You get `503` while its machine starts. You get `404` when the agent of an
-in-thread schedule is not on the team. Fountain stamps `last_run_at` and
-`last_error` either way.
-
-The audit trail records a create, an update, a delete and a run, as
-`team.schedule.*`, with the request's attribution.
-
-The team stream sends a `schedule` event, `{"reason":"changed"}`, whenever
-anybody creates, updates, deletes or fires a schedule. That holds for the API,
-for the page and for the scheduler. So a client lists them again, and polls
-nothing.
-
-A browser client on another origin needs `API_CORS_ORIGINS` set on the server.
-Read [configuration](configuration.md). A bearer key is the one credential
-that crosses an origin.
+A schedule runs work without a person at the keyboard. Choose the intended
+timezone and verify the next execution before you enable unattended work.
+See [Teammates](concepts/teammates.md) for how schedules relate to a teammate.
+The [generated reference](/api/docs) defines timing fields and run history.
 
 ## Support
 
-This is "Report a problem" from a client (#843). Fountain stores the report
-with whatever context the client attaches, then forwards it to the operator
-out of band.
+Use the console's support action to report a problem or request access to a
+feature. Include the conversation ID and the time of the failure. Review any
+attached transcript for sensitive content before you submit it.
 
-That context is the conversation, the agent, the sandbox, the presence, the
-recent events, the app version and the page URL. Those are the facts that
-triage needs, and never a secret.
-
-```
-POST   /api/support/reports         # {category, message, context?, client?, screenshot?} → 201 the report
-GET    /api/support/reports         # the caller's reports, newest first
-GET    /api/support/reports/:id
-```
-
-The `category` is one of `bug`, `stuck`, `question`, `idea` and `other`. The
-`message` takes up to 20 KB. The `context` is an object of up to 64 KB. The
-`client` is a string of a name and a version.
-
-`screenshot` takes the `{data: base64, media_type}` shape that a prompt image
-takes. It accepts png, jpeg, gif and webp, up to 5 MB.
-
-The response carries `status`, which goes `new` and then `forwarded` or
-`failed`. It carries `forwarded_at`, and `external_url`, which names the GitHub issue
-when Fountain opened one, and `forward_error`. It reports that a screenshot is
-there, and never inlines it.
-
-The audit trail records `support.report.created`, with the category, the sizes
-and the context keys. It never records the message.
-
-An Oban job forwards the report. It opens a GitHub issue when the instance
-sets `SUPPORT_GITHUB_REPO` and `SUPPORT_GITHUB_TOKEN`, which needs
-issues:write, and it labels the issue `support` and the category. It mails
-`SUPPORT_EMAIL`, with the screenshot attached. It can do one, the other, or
-both.
-
-Neither one configured is fine, because the rows are the inbox. The rate limit
-on the rest of `/api` covers this too.
+Support is an optional extension. Its operations appear in the
+[generated reference](/api/docs) only when the instance installs it.
 
 ## Admin
 
-These are for an operator account, with `role: "admin"`, that holds a
-`full`-scoped key.
+Administrative workflows require an operator account and an appropriate key.
+Use tenant-scoped resource reads for ordinary application work. An operator's
+metadata access does not grant access to another tenant's prompt or output.
 
-Each action mirrors the admin UI, and its refusals with it. Each one records
-the same privilege-trail event.
-
-```
-GET    /api/admin/users                     # ?q= ?comped= ?role= ?verified= ?sort= ?dir= ?page= ?per_page=
-GET    /api/admin/users/:id
-POST   /api/admin/users/:id/role            # {"role": "admin"|"user"}
-POST   /api/admin/users/:id/sandbox-limit   # {"limit": n}
-POST   /api/admin/users/:id/comp            # {"comped": true|false}
-POST   /api/admin/users/:id/suspend         # {"suspended": true|false}
-POST   /api/admin/users/:id/credits         # {"cents": n, "note": "..."}: grant credit
-DELETE /api/admin/users/:id
-GET    /api/admin/sandboxes
-POST   /api/admin/sandboxes/:id/reap
-GET    /api/admin/audit                     # cross-tenant audit events
-GET    /api/admin/events                    # the privilege trail: who did what to whom
-```
-
-Here are the refusals. You cannot suspend your own account, delete it, or
-change its role. Use another admin, or `DELETE /api/account` to delete your
-own.
-
-The payment actions are `404` with `"billing": "disabled"` on an instance
-with payment off. Those actions are comp and credits.
-
-A read across tenants returns metadata alone. Prompt content and output
-content never cross a tenant boundary, whatever the role.
+See Admin in the [generated reference](/api/docs) for account controls,
+credit grants, sandbox maintenance, and privilege-trail events.
 
 ## Webhooks
 
-```
-GET    /api/webhooks                                  # list endpoints
-POST   /api/webhooks                                  # create one; the secret is in this response only
-GET    /api/webhooks/:id
-PATCH  /api/webhooks/:id                              # url, description, event_types, status
-DELETE /api/webhooks/:id
-POST   /api/webhooks/:id/rotate-secret                # a new secret; the old one stops verifying
-POST   /api/webhooks/:id/test                         # queue a signed `webhook.test` event
-GET    /api/webhooks/:id/deliveries                   # ?limit= (default 50, max 200)
-POST   /api/webhooks/:id/deliveries/:delivery_id/redeliver
-```
-
-Fountain sends conversation lifecycle transitions to a URL you own. An
-integration that cannot hold a socket open does not have to poll. The payload
-carries ids, a stage and a duration, and never conversation content.
-
-These routes need a full-scope key. A sandbox's per-conversation token must
-not point the account's events at a URL that the sandbox picks.
-
-The [webhooks reference](reference/webhooks.md) holds the full event
-catalogue, the payload shape, a worked signature verifier and the
-at-least-once contract.
+Use webhooks when another server must react to Fountain events. Verify the
+signature before you process an event. Make the delivery handler idempotent.
+Follow [Webhooks](reference/webhooks.md) for delivery and retry behavior.
+The [generated reference](/api/docs) describes endpoint registration and replay.
 
 ## Audit
 
-```
-GET    /api/audit    # ?limit= ?before= ?action_prefix= ?resource_type= ?since= ?until=
-```
-
-This is the account's own append-only trail, newest first. Each row carries
-`id`, `inserted_at`, `actor`, `action`, `resource_type`, `resource_id`,
-`metadata` and `request_ip`.
-
-`actor` tells four things apart. `ui` is a browser session. `api` is a bearer
-key. `sprite` is the token a sandbox holds for one conversation. `system` is
-Fountain itself.
-
-To page backwards, pass `meta.next_cursor` as `before`. `limit` defaults to
-100, and caps at 500.
-
-`action_prefix` matches a family of actions, such as `vault.`. Fountain treats
-it as a literal, and not as a LIKE pattern.
-
-`since` and `until` take ISO 8601 timestamps. Fountain refuses a malformed one
-with a `400`, and ignores none of them without a sound.
-
-You see this tenant's events, and no other tenant's.
-
-The `/audit` page in the browser takes the same four filters, as `?action=`,
-`?resource=`, `?since=` and `?until=`. It runs them through the same query, so
-a filtered view is a link you can share.
-
-That page shows the newest 200 matches, and it has no pages. Use this endpoint
-to walk the whole trail.
+Use the audit trail to investigate who changed a resource and when.
+A transcript describes agent work; the audit trail describes account and
+resource actions. The [generated reference](/api/docs) defines filters,
+pagination, and returned metadata.
 
 ## Error responses
 
-```json
-{"error": "not_found", "message": "Agent not found"}
-```
+Handle errors with the operation's status and documented machine-readable
+fields. Validation failures can include field errors; coded refusals need not.
+Do not assume every error uses the same envelope. Content-negotiation errors
+and compatibility endpoints can use different shapes.
 
-| Status | Meaning |
-|---|---|
-| `400` | The request body is invalid. |
-| `401` | The auth is absent or invalid. |
-| `402` | Your credit balance is zero or below. The code is `insufficient_credits`, and the body carries `upgrade_url`. The old `subscription_required` code does not occur. A teammate contact past the account's ceiling is `contact_limit_reached`. |
-| `403` | The wrong tenant. |
-| `404` | Nothing found. |
-| `409` | The request conflicts with the current state. The codes are `no_runner_online`, `sandbox_at_capacity`, `sandbox_not_attachable`, `sandbox_mid_turn`, `permission_request_resolved`, `contact_already_provisioned`, `no_turn_running` and `not_running`. |
-| `410` | Somebody terminated the conversation. The code is `conversation_terminated`. Stop, and do not try again. |
-| `422` | A validation error. |
-| `429` | The rate limit stopped you. |
-| `500` | An internal error. |
-| `503` | The instance is at its fleet ceiling, or a sandbox is not up yet. The codes are `fleet_full`, `provisioning` and `sprite_probe_failed`, and the response carries `Retry-After`. |
+The [generated reference](/api/docs) declares shared pipeline errors alongside
+controller responses. Reconcile state after a timeout before you retry a
+mutation. Honor retry guidance where present, and refresh credentials when
+the response identifies an expired or revoked key.
 
 ## LLM-native discovery
 
-- `/llms.txt`, a short API summary.
-- `/llms-full.txt`, the full API reference.
-- `/skill`, a drop-in skill for Claude Code, Cursor, Continue and Aider.
-
-Read [LLM integration](llm-integration.md) for the detail.
+Use `/llms.txt` for a short introduction, `/llms-full.txt` for the manual,
+and `/skill` for an editor skill. Use the [OpenAPI document](/api/openapi.json)
+for machine-readable endpoint contracts.
+See [LLM integration](llm-integration.md) for integration guidance.

--- a/docs/guides/operate/observability.md
+++ b/docs/guides/operate/observability.md
@@ -60,6 +60,10 @@ thresholds or selectors in the overlay.
 | `FountainUnhandledExceptions` | Request handlers raise exceptions. |
 | `FountainDatabasePoolSaturated` | Requests wait for database connections. |
 | `FountainProvisionFailures` | Sandbox provision attempts fail. |
+| `FountainStageFailures` | A stage after provisioning fails more than twice in 30 minutes. |
+| `FountainTurnFailureRate` | More than 25% of at least ten terminal turns fail per provider over 30 minutes. |
+| `FountainReattachFailures` | A conversation reattach fails within the last hour. |
+| `FountainTurnFirstOutputSlow` | Observed first-output p95 exceeds 30 seconds for 15 minutes, with at least ten samples per window. |
 | `FountainProvisionDeadlineExceeded` | A provision attempt reaches its watchdog deadline. |
 | `FountainSandboxBudgetExceeded` | Sandbox concurrency exceeds the configured budget. |
 | `FountainConversationsAboveBudget` | Live conversations exceed the configured budget. |
@@ -68,6 +72,17 @@ thresholds or selectors in the overlay.
 | `FountainObanJobsRaising` | Background jobs raise exceptions. |
 | `FountainObanJobsDiscarded` | Background jobs exhaust their retries. |
 | `FountainObanQueueBacklog` | A background queue has a sustained backlog. |
+
+Turn alerts group by provider and sum event counters across replicas.
+The first-output rule measures turns that produce output. A turn that emits
+nothing produces no latency sample. Use conversation failure events and
+deployed execution checks to investigate that case.
+
+These rules do not add an automatic rollback. Before you enable them, assign
+an alert receiver and tune the thresholds for your traffic. The hosted
+overlay requires its own rollout; a merge of this file does not update it.
+Run `python3 scripts/test-alerts.py` with PyYAML and `promtool` installed to
+check the shipped expressions and their failure fixtures.
 
 ### Added by the hosted overlay
 

--- a/docs/nav.yml
+++ b/docs/nav.yml
@@ -122,7 +122,7 @@ nav:
   - Reference:
       - CLI: cli.md
       - All CLI commands: cli/commands.md
-      - API: api.md
+      - API guide and generated reference: api.md
       - Webhooks: reference/webhooks.md
       - TypeScript SDK: sdk.md
       - Elixir SDK: elixir-sdk.md

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -74,8 +74,8 @@ elixir scripts/ci/timing-formatter-test.exs
 
 ## Portable alert rules
 
-The CI policy job also runs `scripts/test-alerts.py` with Prometheus `promtool`
-and PyYAML. It extracts the actual PrometheusRule spec and checks syntax,
+The `Alert rules` workflow runs `scripts/test-alerts.py` with Prometheus
+`promtool` and PyYAML. It extracts the actual PrometheusRule spec and checks syntax,
 replica aggregation, failure thresholds, counter resets, absent series, low
 traffic, and first-output alert hold time. Run the same command locally
 after changing `deploy/k8s/prometheusrule.yaml`.

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -71,3 +71,11 @@ actionlint -shellcheck= .github/workflows/ci.yml
 shellcheck scripts/ci/*.sh
 elixir scripts/ci/timing-formatter-test.exs
 ```
+
+## Portable alert rules
+
+The CI policy job also runs `scripts/test-alerts.py` with Prometheus `promtool`
+and PyYAML. It extracts the actual PrometheusRule spec and checks syntax,
+replica aggregation, failure thresholds, counter resets, absent series, low
+traffic, and first-output alert hold time. Run the same command locally
+after changing `deploy/k8s/prometheusrule.yaml`.

--- a/scripts/test-alerts.py
+++ b/scripts/test-alerts.py
@@ -10,10 +10,79 @@ import yaml
 ROOT = Path(__file__).resolve().parent.parent
 
 
+def conversation_cases(rules):
+    cases = []
+
+    def series(metric, labels, values):
+        return {"series": metric + '{namespace="fountain",' + labels + '}', "values": values}
+
+    def case(name, alert, inputs, labels=None):
+        cases.append({
+            "name": name, "interval": "1m", "input_series": inputs,
+            "promql_expr_test": [{
+                "expr": "(" + rules[alert]["expr"].strip() + ") > bool 0",
+                "eval_time": "60m",
+                "exp_samples": [] if labels is None else [{"labels": labels, "value": 1}],
+            }],
+        })
+
+    names = ("FountainStageFailures", "FountainTurnFailureRate",
+             "FountainReattachFailures", "FountainTurnFirstOutputSlow")
+    for alert in names:
+        case(alert + ": no series", alert, [])
+
+    for stage in ("clone", "packages", "network_policy", "provision"):
+        case("failed stage " + stage, "FountainStageFailures", [
+            series("fountain_stage_count", f'stage="{stage}",status="failed"', "0+1x120")
+        ], None if stage == "provision" else f'{{stage="{stage}"}}')
+    case("healthy stages", "FountainStageFailures", [
+        series("fountain_stage_count", 'stage="clone",status="done"', "0+1x120")])
+    for fails in (False, True):
+        case("reattach fails=" + str(fails), "FountainReattachFailures", [
+            series("fountain_stage_count", 'stage="reattach",status="failed"',
+                   "0+0x30 1+0x89" if fails else "0+0x120")], "{}" if fails else None)
+
+    count = "fountain_turn_completed_duration_ms_count"
+    for name, failed, done, fires in (
+        ("healthy, no failure series", None, "0+1x120", False),
+        ("idle", "0+0x120", "0+0x120", False),
+        ("too little traffic", "0+0.1x120", "0+0x120", False),
+        ("exactly 25 percent", "0+1x120", "0+3x120", False),
+        ("half fail", "0+1x120", "0+1x120", True),
+        ("all fail, no success series", "0+1x120", None, True),
+        ("counter reset", "0+1x39 0+1x80", "0+1x39 0+1x80", True),
+    ):
+        inputs = [series(count, 'provider="sprites",status="' + status + '"', values)
+                  for status, values in (("failed", failed), ("completed", done)) if values is not None]
+        # A healthy, much busier provider must not dilute the failing one.
+        inputs.append(series(count, 'provider="e2b",status="completed"', "0+100x120"))
+        case("turns: " + name, "FountainTurnFailureRate", inputs,
+             '{provider="sprites"}' if fires else None)
+
+    for name, slow, traffic in (("slow", True, 1), ("fast", False, 1), ("low traffic", True, 0.1)):
+        inputs = [series("fountain_turn_first_output_elapsed_ms_bucket",
+                         f'provider="sprites",le="{le}"', f"0+{step}x120")
+                  for le, step in (("30000", 0 if slow else traffic), ("60000", traffic), ("+Inf", traffic))]
+        inputs.append(series("fountain_turn_first_output_elapsed_ms_count", 'provider="sprites"', f"0+{traffic}x120"))
+        case("first output: " + name, "FountainTurnFirstOutputSlow", inputs,
+             '{provider="sprites"}' if slow and traffic == 1 else None)
+        if name == "slow":
+            rule = rules["FountainTurnFirstOutputSlow"]
+            cases[-1]["alert_rule_test"] = [
+                {"eval_time": "14m", "alertname": "FountainTurnFirstOutputSlow", "exp_alerts": []},
+                {"eval_time": "60m", "alertname": "FountainTurnFirstOutputSlow", "exp_alerts": [{
+                    "exp_labels": {"provider": "sprites", "severity": "warning"},
+                    "exp_annotations": {key: value.replace("{{ $labels.provider }}", "sprites")
+                                        for key, value in rule["annotations"].items()},
+                }]},
+            ]
+    return cases
+
+
 def main():
     spec = yaml.safe_load((ROOT / "deploy/k8s/prometheusrule.yaml").read_text())["spec"]
     rules = {r["alert"]: r for g in spec["groups"] for r in g["rules"]}
-    cases = []
+    cases = conversation_cases(rules)
     for replicas in (1, 2, 3):
         for alert, metric, statuses in (
             ("FountainSandboxBudgetExceeded", "fountain_sandboxes_count", ("pending", "ready")),

--- a/sdk/conformance/lint.py
+++ b/sdk/conformance/lint.py
@@ -242,15 +242,6 @@ def check_body(
         problems.add(where, "the schema says %s, the fixture has %s" % (kind, type(body).__name__))
 
 
-# Statuses a plug can produce on any route, which the OpenAPI document
-# therefore does not enumerate per operation. `Plugs.RateLimit` sits in the
-# pipeline and answers 429 anywhere; `Billing.check_spend/1` answers 402 in the
-# context (ADR 0031); the auth plug answers 401 on every authenticated route
-# even though only 34 of 158 operations declare it. A fixture for one of these
-# is still checked, against the error envelope rather than against nothing.
-PLUG_STATUSES = {401, 402, 403, 429, 500, 502, 503}
-
-
 def response_schema(
     contract: Dict[str, Any], method: str, path: str, status: int, body: Any
 ) -> Optional[Any]:
@@ -264,9 +255,6 @@ def response_schema(
     declared = media.get("application/json")
     if declared is not None:
         return declared
-    if status in PLUG_STATUSES:
-        envelope = "ChangesetError" if isinstance(body, dict) and "errors" in body else "Error"
-        return {"ref": envelope}
     return None
 
 

--- a/sdk/contract/contract.json
+++ b/sdk/contract/contract.json
@@ -19,12 +19,27 @@
             "ref": "AccountDeletedResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "403": {
           "application/json": {
             "ref": "Error"
           }
         },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
         "422": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -43,12 +58,27 @@
       ],
       "responses": {
         "204": {},
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "403": {
           "application/json": {
             "ref": "Error"
           }
         },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
         "422": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -66,6 +96,11 @@
             "ref": "AccountDeletedResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "403": {
           "application/json": {
             "ref": "Error"
@@ -76,7 +111,17 @@
             "ref": "Error"
           }
         },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
         "422": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -95,7 +140,27 @@
       ],
       "responses": {
         "204": {},
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -109,7 +174,22 @@
       ],
       "responses": {
         "204": {},
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -137,6 +217,16 @@
           "application/json": {
             "ref": "Error"
           }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
+          "application/json": {
+            "ref": "Error"
+          }
         }
       }
     },
@@ -152,7 +242,22 @@
             "ref": "Error"
           }
         },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -171,12 +276,27 @@
             "ref": "Error"
           }
         },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
           "application/json": {
             "ref": "Error"
           }
         },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
         "409": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -195,7 +315,22 @@
             "ref": "Error"
           }
         },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -214,7 +349,22 @@
             "ref": "Error"
           }
         },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -228,7 +378,27 @@
       ],
       "responses": {
         "204": {},
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -243,7 +413,27 @@
       ],
       "responses": {
         "204": {},
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -257,12 +447,32 @@
       ],
       "responses": {
         "204": {},
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
           "application/json": {
             "ref": "Error"
           }
         },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
         "409": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -281,7 +491,22 @@
             "ref": "Error"
           }
         },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -295,9 +520,24 @@
       ],
       "responses": {
         "204": {},
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
           "application/json": {
             "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
           }
         },
         "409": {
@@ -306,6 +546,11 @@
           }
         },
         "422": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -324,7 +569,22 @@
             "ref": "Error"
           }
         },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -338,7 +598,27 @@
       ],
       "responses": {
         "204": {},
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -352,12 +632,32 @@
       ],
       "responses": {
         "204": {},
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
           "application/json": {
             "ref": "Error"
           }
         },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
         "424": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -372,7 +672,27 @@
       ],
       "responses": {
         "204": {},
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -386,12 +706,32 @@
       ],
       "responses": {
         "204": {},
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
           "application/json": {
             "ref": "Error"
           }
         },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
         "409": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -406,7 +746,27 @@
       ],
       "responses": {
         "204": {},
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -425,7 +785,22 @@
             "ref": "Error"
           }
         },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -441,12 +816,27 @@
             "ref": "BillingResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "403": {
           "application/json": {
             "ref": "Error"
           }
         },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -462,7 +852,22 @@
             "ref": "ExportListResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -480,12 +885,27 @@
             "ref": "ExportResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "403": {
           "application/json": {
             "ref": "Error"
           }
         },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -503,12 +923,27 @@
             "type": "string"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "403": {
           "application/json": {
             "ref": "Error"
           }
         },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -524,7 +959,22 @@
             "ref": "InferenceCredentialListResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -540,7 +990,22 @@
             "ref": "OnboardingResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -562,7 +1027,22 @@
             "ref": "AdminAuditListResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -584,7 +1064,22 @@
             "ref": "AdminEventListResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -600,7 +1095,22 @@
             "ref": "AdminSandboxListResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -663,7 +1173,27 @@
             "ref": "AdminUserListResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "422": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -681,12 +1211,27 @@
             "ref": "AdminUserResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "403": {
           "application/json": {
             "ref": "Error"
           }
         },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -723,6 +1268,26 @@
           "application/json": {
             "ref": "AgentListResponse"
           }
+        },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
+          "application/json": {
+            "ref": "Error"
+          }
         }
       }
     },
@@ -737,7 +1302,27 @@
             "ref": "AgentResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -756,7 +1341,22 @@
             "type": "string"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -774,7 +1374,27 @@
             "ref": "AgentVersionListResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -793,7 +1413,32 @@
             "ref": "AgentVersionResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "422": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -839,6 +1484,26 @@
           "application/json": {
             "ref": "Error"
           }
+        },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
+          "application/json": {
+            "ref": "Error"
+          }
         }
       }
     },
@@ -860,6 +1525,16 @@
           "application/json": {
             "ref": "Error"
           }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
+          "application/json": {
+            "ref": "Error"
+          }
         }
       }
     },
@@ -873,6 +1548,21 @@
           }
         },
         "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -892,6 +1582,21 @@
           "application/json": {
             "ref": "Error"
           }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
+          "application/json": {
+            "ref": "Error"
+          }
         }
       }
     },
@@ -902,6 +1607,26 @@
         "200": {
           "application/json": {
             "ref": "CatalogResponse"
+          }
+        },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
+          "application/json": {
+            "ref": "Error"
           }
         }
       }
@@ -922,7 +1647,22 @@
             "ref": "Error"
           }
         },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -943,7 +1683,22 @@
             "ref": "Error"
           }
         },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -966,7 +1721,22 @@
             "ref": "Error"
           }
         },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -987,7 +1757,22 @@
             "ref": "Error"
           }
         },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -1008,7 +1793,22 @@
             "ref": "Error"
           }
         },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -1031,7 +1831,22 @@
             "ref": "Error"
           }
         },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -1069,6 +1884,26 @@
           "application/json": {
             "ref": "Error"
           }
+        },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
+          "application/json": {
+            "ref": "Error"
+          }
         }
       }
     },
@@ -1093,12 +1928,27 @@
             "ref": "EgressListResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "403": {
           "application/json": {
             "ref": "Error"
           }
         },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -1139,7 +1989,32 @@
             "ref": "LogEventListResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "422": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -1177,7 +2052,22 @@
             "type": "string"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -1195,7 +2085,27 @@
             "ref": "ConversationTreeResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -1213,7 +2123,27 @@
             "ref": "TurnListResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -1234,7 +2164,22 @@
             "type": "string"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -1252,7 +2197,27 @@
             "ref": "ConversationResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -1266,6 +2231,26 @@
         "200": {
           "application/json": {
             "ref": "EnvironmentListResponse"
+          }
+        },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
+          "application/json": {
+            "ref": "Error"
           }
         }
       }
@@ -1281,7 +2266,27 @@
             "ref": "SecretListResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -1299,7 +2304,27 @@
             "ref": "EnvironmentResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -1330,6 +2355,21 @@
           "text/event-stream": {
             "type": "string"
           }
+        },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
+          "application/json": {
+            "ref": "Error"
+          }
         }
       }
     },
@@ -1343,6 +2383,21 @@
           }
         },
         "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -1404,6 +2459,11 @@
           "application/json": {
             "ref": "Error"
           }
+        },
+        "429": {
+          "application/json": {
+            "ref": "Error"
+          }
         }
       }
     },
@@ -1426,6 +2486,26 @@
           "application/json": {
             "ref": "Error"
           }
+        },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
+          "application/json": {
+            "ref": "Error"
+          }
         }
       }
     },
@@ -1440,7 +2520,27 @@
             "ref": "SandboxResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -1476,9 +2576,24 @@
             "ref": "SandboxDiffResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
           "application/json": {
             "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
           }
         },
         "409": {
@@ -1487,6 +2602,11 @@
           }
         },
         "422": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -1519,9 +2639,24 @@
             "ref": "SandboxFileResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
           "application/json": {
             "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
           }
         },
         "409": {
@@ -1530,6 +2665,11 @@
           }
         },
         "422": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -1558,9 +2698,24 @@
             "ref": "SandboxListingResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
           "application/json": {
             "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
           }
         },
         "409": {
@@ -1569,6 +2724,11 @@
           }
         },
         "422": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -1625,7 +2785,27 @@
             "ref": "Error"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
         "422": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -1646,7 +2826,22 @@
             "ref": "Error"
           }
         },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -1667,7 +2862,22 @@
             "ref": "Error"
           }
         },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -1684,6 +2894,21 @@
           }
         },
         "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -1706,7 +2931,22 @@
             "ref": "Error"
           }
         },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -1721,6 +2961,26 @@
           "application/json": {
             "ref": "TeammateListResponse"
           }
+        },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
+          "application/json": {
+            "ref": "Error"
+          }
         }
       }
     },
@@ -1732,6 +2992,26 @@
           "application/json": {
             "ref": "TeamCommsStatusResponse"
           }
+        },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
+          "application/json": {
+            "ref": "Error"
+          }
         }
       }
     },
@@ -1742,6 +3022,26 @@
         "200": {
           "application/json": {
             "ref": "TeamScheduleListResponse"
+          }
+        },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
+          "application/json": {
+            "ref": "Error"
           }
         }
       }
@@ -1770,6 +3070,21 @@
           "text/event-stream": {
             "type": "string"
           }
+        },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
+          "application/json": {
+            "ref": "Error"
+          }
         }
       }
     },
@@ -1784,7 +3099,27 @@
             "ref": "TeammateResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -1802,7 +3137,27 @@
             "ref": "TeammateConversationListResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -1819,6 +3174,26 @@
           "application/json": {
             "ref": "TeamScheduleListResponse"
           }
+        },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
+          "application/json": {
+            "ref": "Error"
+          }
         }
       }
     },
@@ -1834,7 +3209,27 @@
             "ref": "TeamScheduleResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -1848,6 +3243,26 @@
         "200": {
           "application/json": {
             "ref": "VaultListResponse"
+          }
+        },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
+          "application/json": {
+            "ref": "Error"
           }
         }
       }
@@ -1863,7 +3278,27 @@
             "ref": "VaultResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -1881,7 +3316,27 @@
             "ref": "VaultSecretListResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -1898,6 +3353,21 @@
           }
         },
         "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -1920,7 +3390,22 @@
             "ref": "Error"
           }
         },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -1949,7 +3434,22 @@
             "ref": "Error"
           }
         },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -1964,6 +3464,11 @@
           "application/json": {
             "ref": "HealthResponse"
           }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
         }
       }
     },
@@ -1974,6 +3479,11 @@
         "200": {
           "application/json": {
             "ref": "ReadinessResponse"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
           }
         },
         "503": {
@@ -2047,6 +3557,52 @@
             },
             "type": "object"
           }
+        },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "404": {
+          "application/json": {
+            "properties": {
+              "error": {
+                "properties": {
+                  "code": {
+                    "nullable": true,
+                    "required": false,
+                    "type": "string"
+                  },
+                  "message": {
+                    "required": false,
+                    "type": "string"
+                  },
+                  "param": {
+                    "nullable": true,
+                    "required": false,
+                    "type": "string"
+                  },
+                  "type": {
+                    "required": false,
+                    "type": "string"
+                  }
+                },
+                "required": false,
+                "type": "object"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "429": {
+          "application/json": {
+            "ref": "Error"
+          }
         }
       }
     },
@@ -2101,6 +3657,16 @@
             "type": "object"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
           "application/json": {
             "properties": {
@@ -2131,6 +3697,11 @@
             },
             "type": "object"
           }
+        },
+        "429": {
+          "application/json": {
+            "ref": "Error"
+          }
         }
       }
     },
@@ -2153,9 +3724,24 @@
             "ref": "AgentResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
           "application/json": {
             "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
           }
         },
         "409": {
@@ -2166,6 +3752,11 @@
         "422": {
           "application/json": {
             "ref": "ChangesetError"
+          }
+        },
+        "429": {
+          "application/json": {
+            "ref": "Error"
           }
         }
       }
@@ -2194,12 +3785,27 @@
             "ref": "Error"
           }
         },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
           "application/json": {
             "ref": "Error"
           }
         },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
         "422": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -2230,12 +3836,27 @@
             "ref": "Error"
           }
         },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
           "application/json": {
             "ref": "Error"
           }
         },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
         "422": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -2261,14 +3882,34 @@
             "ref": "EnvironmentResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
           "application/json": {
             "ref": "Error"
           }
         },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
         "422": {
           "application/json": {
             "ref": "ChangesetError"
+          }
+        },
+        "429": {
+          "application/json": {
+            "ref": "Error"
           }
         }
       }
@@ -2297,12 +3938,27 @@
             "ref": "Error"
           }
         },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
           "application/json": {
             "ref": "Error"
           }
         },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
         "422": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -2328,12 +3984,32 @@
             "ref": "TeammateResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
           "application/json": {
             "ref": "Error"
           }
         },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
         "422": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -2359,12 +4035,32 @@
             "ref": "TeammateResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
           "application/json": {
             "ref": "Error"
           }
         },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
         "422": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -2391,12 +4087,32 @@
             "ref": "TeamScheduleResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
           "application/json": {
             "ref": "Error"
           }
         },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
         "422": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -2422,14 +4138,34 @@
             "ref": "VaultResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
           "application/json": {
             "ref": "Error"
           }
         },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
         "422": {
           "application/json": {
             "ref": "ChangesetError"
+          }
+        },
+        "429": {
+          "application/json": {
+            "ref": "Error"
           }
         }
       }
@@ -2458,12 +4194,27 @@
             "ref": "Error"
           }
         },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
           "application/json": {
             "ref": "Error"
           }
         },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
         "422": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -2487,6 +4238,11 @@
             "ref": "StripeUrlResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "403": {
           "application/json": {
             "ref": "Error"
@@ -2497,7 +4253,17 @@
             "ref": "Error"
           }
         },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
         "422": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -2518,9 +4284,19 @@
             "ref": "ExportResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "403": {
           "application/json": {
             "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
           }
         },
         "429": {
@@ -2539,7 +4315,22 @@
             "ref": "OnboardingResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -2557,12 +4348,27 @@
             "ref": "AdminReapResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "403": {
           "application/json": {
             "ref": "Error"
           }
         },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -2588,6 +4394,11 @@
             "ref": "AdminUserResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "403": {
           "application/json": {
             "ref": "Error"
@@ -2598,7 +4409,17 @@
             "ref": "Error"
           }
         },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
         "422": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -2624,6 +4445,11 @@
             "ref": "AdminUserResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "403": {
           "application/json": {
             "ref": "Error"
@@ -2634,7 +4460,17 @@
             "ref": "Error"
           }
         },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
         "422": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -2660,6 +4496,11 @@
             "ref": "AdminUserResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "403": {
           "application/json": {
             "ref": "Error"
@@ -2670,7 +4511,17 @@
             "ref": "Error"
           }
         },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
         "422": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -2696,6 +4547,11 @@
             "ref": "AdminUserResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "403": {
           "application/json": {
             "ref": "Error"
@@ -2706,7 +4562,17 @@
             "ref": "Error"
           }
         },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
         "422": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -2732,6 +4598,11 @@
             "ref": "AdminUserResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "403": {
           "application/json": {
             "ref": "Error"
@@ -2742,7 +4613,17 @@
             "ref": "Error"
           }
         },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
         "422": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -2766,9 +4647,29 @@
             "ref": "AgentResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
         "422": {
           "application/json": {
             "ref": "ChangesetError"
+          }
+        },
+        "429": {
+          "application/json": {
+            "ref": "Error"
           }
         }
       }
@@ -2842,7 +4743,27 @@
             "ref": "Error"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "409": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -2866,9 +4787,29 @@
             "ref": "ApplyResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
         "422": {
           "application/json": {
             "ref": "ChangesetError"
+          }
+        },
+        "429": {
+          "application/json": {
+            "ref": "Error"
           }
         }
       }
@@ -2900,7 +4841,17 @@
             "ref": "Error"
           }
         },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
         "422": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -2914,6 +4865,11 @@
         "201": {
           "application/json": {
             "ref": "DeviceAuthResponse"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
           }
         }
       }
@@ -2938,6 +4894,11 @@
         "400": {
           "application/json": {
             "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
           }
         }
       }
@@ -2969,9 +4930,19 @@
             "ref": "AuthError"
           }
         },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
         "422": {
           "application/json": {
             "ref": "AuthError"
+          }
+        },
+        "429": {
+          "application/json": {
+            "ref": "Error"
           }
         }
       }
@@ -2991,6 +4962,11 @@
         "200": {
           "application/json": {
             "ref": "EmailChangedResponse"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
           }
         },
         "422": {
@@ -3015,6 +4991,11 @@
         "200": {
           "application/json": {
             "ref": "MessageResponse"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
           }
         }
       }
@@ -3046,9 +5027,19 @@
             "ref": "AuthError"
           }
         },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
         "422": {
           "application/json": {
             "ref": "AuthError"
+          }
+        },
+        "429": {
+          "application/json": {
+            "ref": "Error"
           }
         }
       }
@@ -3075,6 +5066,11 @@
             "ref": "AuthError"
           }
         },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
         "422": {
           "application/json": {
             "ref": "ChangesetError"
@@ -3098,6 +5094,11 @@
           "application/json": {
             "ref": "MessageResponse"
           }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
         }
       }
     },
@@ -3116,6 +5117,11 @@
         "200": {
           "application/json": {
             "ref": "MessageResponse"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
           }
         },
         "422": {
@@ -3152,7 +5158,17 @@
             "ref": "AuthError"
           }
         },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
         "422": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -3174,6 +5190,11 @@
         "200": {
           "application/json": {
             "ref": "VerifyEmailResponse"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
           }
         },
         "422": {
@@ -3200,7 +5221,32 @@
             "ref": "AvatarGenerateResponse"
           }
         },
+        "400": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
         "422": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -3239,12 +5285,27 @@
             "ref": "Error"
           }
         },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
           "application/json": {
             "ref": "Error"
           }
         },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
         "422": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -3322,6 +5383,11 @@
             "ref": "Error"
           }
         },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
         "429": {
           "application/json": {
             "ref": "Error"
@@ -3375,12 +5441,22 @@
             "ref": "Error"
           }
         },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
         "409": {
           "application/json": {
             "ref": "Error"
           }
         },
         "410": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -3409,12 +5485,27 @@
             "ref": "Error"
           }
         },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
           "application/json": {
             "ref": "Error"
           }
         },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
         "422": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -3437,12 +5528,27 @@
             "ref": "Error"
           }
         },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
           "application/json": {
             "ref": "Error"
           }
         },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
         "422": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -3471,6 +5577,16 @@
             "ref": "ConversationResponse"
           }
         },
+        "400": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "402": {
           "application/json": {
             "properties": {
@@ -3486,7 +5602,22 @@
             "type": "object"
           }
         },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "409": {
           "application/json": {
             "ref": "Error"
           }
@@ -3494,6 +5625,16 @@
         "422": {
           "application/json": {
             "ref": "ChangesetError"
+          }
+        },
+        "429": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "503": {
+          "application/json": {
+            "ref": "Error"
           }
         }
       }
@@ -3505,12 +5646,37 @@
       ],
       "responses": {
         "204": {},
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
           "application/json": {
             "ref": "Error"
           }
         },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
         "409": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "503": {
           "application/json": {
             "ref": "Error"
           }
@@ -3541,7 +5707,47 @@
             "ref": "Error"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "402": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "410": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "422": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "503": {
           "application/json": {
             "ref": "Error"
           }
@@ -3555,7 +5761,27 @@
       ],
       "responses": {
         "204": {},
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -3582,9 +5808,24 @@
             "ref": "PermissionAnswerResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
           "application/json": {
             "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
           }
         },
         "409": {
@@ -3593,6 +5834,11 @@
           }
         },
         "422": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -3606,7 +5852,32 @@
       ],
       "responses": {
         "204": {},
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "503": {
           "application/json": {
             "ref": "Error"
           }
@@ -3630,9 +5901,29 @@
             "ref": "EnvironmentResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
         "422": {
           "application/json": {
             "ref": "ChangesetError"
+          }
+        },
+        "429": {
+          "application/json": {
+            "ref": "Error"
           }
         }
       }
@@ -3656,14 +5947,34 @@
             "ref": "SecretResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
           "application/json": {
             "ref": "Error"
           }
         },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
         "422": {
           "application/json": {
             "ref": "ChangesetError"
+          }
+        },
+        "429": {
+          "application/json": {
+            "ref": "Error"
           }
         }
       }
@@ -3672,7 +5983,27 @@
       "operation_id": "FountainWeb.OAuthTokenController.revoke",
       "path_params": [],
       "responses": {
-        "204": {}
+        "204": {},
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
+          "application/json": {
+            "ref": "Error"
+          }
+        }
       }
     },
     "POST /api/oauth/token": {
@@ -3695,6 +6026,11 @@
         "400": {
           "application/json": {
             "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
           }
         }
       }
@@ -3721,12 +6057,27 @@
             "ref": "Error"
           }
         },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
           "application/json": {
             "ref": "Error"
           }
         },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
         "422": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -3755,7 +6106,22 @@
             "ref": "Error"
           }
         },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
         "422": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -3784,12 +6150,32 @@
             "ref": "TeammateResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
           "application/json": {
             "ref": "Error"
           }
         },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
         "422": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -3815,9 +6201,24 @@
             "ref": "TeammateResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
           "application/json": {
             "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
           }
         },
         "409": {
@@ -3826,6 +6227,16 @@
           }
         },
         "422": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "424": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -3858,7 +6269,27 @@
             "ref": "Error"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -3894,7 +6325,27 @@
             "ref": "Error"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -3920,12 +6371,32 @@
             "ref": "TeamScheduleResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
           "application/json": {
             "ref": "Error"
           }
         },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
         "422": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -3949,7 +6420,27 @@
             "ref": "Error"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -3973,9 +6464,29 @@
             "ref": "VaultResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
         "422": {
           "application/json": {
             "ref": "ChangesetError"
+          }
+        },
+        "429": {
+          "application/json": {
+            "ref": "Error"
           }
         }
       }
@@ -3999,14 +6510,34 @@
             "ref": "VaultSecretResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
           "application/json": {
             "ref": "Error"
           }
         },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
         "422": {
           "application/json": {
             "ref": "ChangesetError"
+          }
+        },
+        "429": {
+          "application/json": {
+            "ref": "Error"
           }
         }
       }
@@ -4033,7 +6564,22 @@
             "ref": "Error"
           }
         },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
         "422": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -4057,7 +6603,22 @@
             "ref": "Error"
           }
         },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -4080,7 +6641,22 @@
             "ref": "Error"
           }
         },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -4103,7 +6679,22 @@
             "ref": "Error"
           }
         },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -4308,6 +6899,16 @@
             "type": "object"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
           "application/json": {
             "properties": {
@@ -4340,6 +6941,42 @@
           }
         },
         "409": {
+          "application/json": {
+            "properties": {
+              "error": {
+                "properties": {
+                  "code": {
+                    "nullable": true,
+                    "required": false,
+                    "type": "string"
+                  },
+                  "message": {
+                    "required": false,
+                    "type": "string"
+                  },
+                  "param": {
+                    "nullable": true,
+                    "required": false,
+                    "type": "string"
+                  },
+                  "type": {
+                    "required": false,
+                    "type": "string"
+                  }
+                },
+                "required": false,
+                "type": "object"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "429": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "500": {
           "application/json": {
             "properties": {
               "error": {
@@ -4391,12 +7028,27 @@
             "ref": "InferenceCredentialResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "403": {
           "application/json": {
             "ref": "Error"
           }
         },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
         "422": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -4432,9 +7084,24 @@
             "ref": "AgentResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
           "application/json": {
             "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
           }
         },
         "409": {
@@ -4445,6 +7112,11 @@
         "422": {
           "application/json": {
             "ref": "ChangesetError"
+          }
+        },
+        "429": {
+          "application/json": {
+            "ref": "Error"
           }
         }
       }
@@ -4468,6 +7140,16 @@
             "ref": "AgentResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
           "application/json": {
             "ref": "Error"
@@ -4484,6 +7166,11 @@
           }
         },
         "422": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -4514,12 +7201,27 @@
             "ref": "Error"
           }
         },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
           "application/json": {
             "ref": "Error"
           }
         },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
         "422": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
           "application/json": {
             "ref": "Error"
           }
@@ -4545,14 +7247,34 @@
             "ref": "EnvironmentResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
           "application/json": {
             "ref": "Error"
           }
         },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
         "422": {
           "application/json": {
             "ref": "ChangesetError"
+          }
+        },
+        "429": {
+          "application/json": {
+            "ref": "Error"
           }
         }
       }
@@ -4576,14 +7298,34 @@
             "ref": "VaultResponse"
           }
         },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "404": {
           "application/json": {
             "ref": "Error"
           }
         },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
         "422": {
           "application/json": {
             "ref": "ChangesetError"
+          }
+        },
+        "429": {
+          "application/json": {
+            "ref": "Error"
           }
         }
       }
@@ -8066,6 +10808,21 @@
         "owned_by": {
           "required": false,
           "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "NegotiationError": {
+      "properties": {
+        "errors": {
+          "properties": {
+            "detail": {
+              "required": true,
+              "type": "string"
+            }
+          },
+          "required": true,
+          "type": "object"
         }
       },
       "type": "object"

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -10,6 +10,12 @@ server releases.
 
 ---
 
+## [1.20.2] — 2026-09-06
+
+### Fixed
+
+- Generated operation types include shared authentication, rate-limit and content-negotiation errors, plus documented controller refusals. Runtime request behavior is unchanged.
+
 ## [1.20.1] — 2026-09-05
 
 ### Added

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "1.20.1",
+  "version": "1.20.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentshit/fountain-sdk",
-      "version": "1.20.1",
+      "version": "1.20.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^26.4.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "1.20.1",
+  "version": "1.20.2",
   "description": "Run a coding agent on a real computer, with your repos and your credentials, in one call.",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -3913,6 +3913,12 @@ export interface components {
             object?: "model";
             owned_by?: string;
         };
+        /** NegotiationError */
+        NegotiationError: {
+            errors: {
+                detail: string;
+            };
+        };
         /** OAuthTokenRequest */
         OAuthTokenRequest: {
             client_id: string;
@@ -4964,6 +4970,15 @@ export interface operations {
                     "application/json": components["schemas"]["AccountDeletedResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Insufficient scope */
             403: {
                 headers: {
@@ -4973,8 +4988,26 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
             /** @description Confirmation mismatch */
             422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -5011,6 +5044,15 @@ export interface operations {
                     "application/json": components["schemas"]["BillingResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Insufficient scope */
             403: {
                 headers: {
@@ -5022,6 +5064,24 @@ export interface operations {
             };
             /** @description Billing disabled */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -5054,6 +5114,15 @@ export interface operations {
                     "application/json": components["schemas"]["StripeUrlResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Insufficient scope */
             403: {
                 headers: {
@@ -5072,8 +5141,26 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
             /** @description Refused */
             422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -5110,8 +5197,35 @@ export interface operations {
                     "application/json": components["schemas"]["ExportListResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Insufficient scope */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -5139,6 +5253,15 @@ export interface operations {
                     "application/json": components["schemas"]["ExportResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Insufficient scope */
             403: {
                 headers: {
@@ -5146,6 +5269,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
                 };
             };
             /** @description Rate limited */
@@ -5179,6 +5311,15 @@ export interface operations {
                     "application/json": components["schemas"]["ExportResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Insufficient scope */
             403: {
                 headers: {
@@ -5190,6 +5331,24 @@ export interface operations {
             };
             /** @description Not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -5219,6 +5378,15 @@ export interface operations {
                     "application/json": string;
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Insufficient scope */
             403: {
                 headers: {
@@ -5230,6 +5398,24 @@ export interface operations {
             };
             /** @description Not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -5257,8 +5443,35 @@ export interface operations {
                     "application/json": components["schemas"]["InferenceCredentialListResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Insufficient scope */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -5293,6 +5506,15 @@ export interface operations {
                     "application/json": components["schemas"]["InferenceCredentialResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Insufficient scope */
             403: {
                 headers: {
@@ -5302,8 +5524,26 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
             /** @description Rejected credential, blank value, or unknown provider */
             422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -5349,6 +5589,15 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Insufficient scope */
             403: {
                 headers: {
@@ -5358,8 +5607,26 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
             /** @description Unknown provider */
             422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -5387,8 +5654,35 @@ export interface operations {
                     "application/json": components["schemas"]["OnboardingResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Insufficient scope */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -5416,8 +5710,35 @@ export interface operations {
                     "application/json": components["schemas"]["OnboardingResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Insufficient scope */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -5448,8 +5769,35 @@ export interface operations {
                     "application/json": components["schemas"]["AdminAuditListResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Admin required */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -5480,8 +5828,35 @@ export interface operations {
                     "application/json": components["schemas"]["AdminEventListResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Admin required */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -5509,8 +5884,35 @@ export interface operations {
                     "application/json": components["schemas"]["AdminSandboxListResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Admin required */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -5540,6 +5942,15 @@ export interface operations {
                     "application/json": components["schemas"]["AdminReapResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Admin required */
             403: {
                 headers: {
@@ -5551,6 +5962,24 @@ export interface operations {
             };
             /** @description Not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -5590,8 +6019,44 @@ export interface operations {
                     "application/json": components["schemas"]["AdminUserListResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Admin required */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Invalid request parameters */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -5621,6 +6086,15 @@ export interface operations {
                     "application/json": components["schemas"]["AdminUserResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Admin required */
             403: {
                 headers: {
@@ -5632,6 +6106,24 @@ export interface operations {
             };
             /** @description Not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -5661,6 +6153,15 @@ export interface operations {
                     "application/json": components["schemas"]["AccountDeletedResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Admin required */
             403: {
                 headers: {
@@ -5679,8 +6180,26 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
             /** @description Refused */
             422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -5724,6 +6243,15 @@ export interface operations {
                     "application/json": components["schemas"]["AdminUserResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Admin required */
             403: {
                 headers: {
@@ -5742,8 +6270,26 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
             /** @description Refused */
             422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -5778,6 +6324,15 @@ export interface operations {
                     "application/json": components["schemas"]["AdminUserResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Admin required */
             403: {
                 headers: {
@@ -5796,8 +6351,26 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
             /** @description Refused */
             422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -5832,6 +6405,15 @@ export interface operations {
                     "application/json": components["schemas"]["AdminUserResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Admin required */
             403: {
                 headers: {
@@ -5850,8 +6432,26 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
             /** @description Refused */
             422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -5886,6 +6486,15 @@ export interface operations {
                     "application/json": components["schemas"]["AdminUserResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Admin required */
             403: {
                 headers: {
@@ -5904,8 +6513,26 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
             /** @description Refused */
             422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -5940,6 +6567,15 @@ export interface operations {
                     "application/json": components["schemas"]["AdminUserResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Admin required */
             403: {
                 headers: {
@@ -5958,8 +6594,26 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
             /** @description Refused */
             422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -5998,6 +6652,42 @@ export interface operations {
                     "application/json": components["schemas"]["AgentListResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
         };
     };
     "FountainWeb.AgentController.create": {
@@ -6023,6 +6713,33 @@ export interface operations {
                     "application/json": components["schemas"]["AgentResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
             /** @description Validation error */
             422: {
                 headers: {
@@ -6030,6 +6747,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ChangesetError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
                 };
             };
         };
@@ -6054,8 +6780,44 @@ export interface operations {
                     "application/json": components["schemas"]["AgentResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -6090,6 +6852,24 @@ export interface operations {
                     "application/json": components["schemas"]["AgentResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not found */
             404: {
                 headers: {
@@ -6097,6 +6877,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
                 };
             };
             /** @description An agent is mid-turn on a persistent sandbox the change retires */
@@ -6115,6 +6904,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ChangesetError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
                 };
             };
         };
@@ -6137,8 +6935,44 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -6173,6 +7007,24 @@ export interface operations {
                     "application/json": components["schemas"]["AgentResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not found */
             404: {
                 headers: {
@@ -6180,6 +7032,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
                 };
             };
             /** @description An agent is mid-turn on a persistent sandbox the change retires */
@@ -6198,6 +7059,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ChangesetError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
                 };
             };
         };
@@ -6222,8 +7092,35 @@ export interface operations {
                     "image/*": string;
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description No avatar */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -6256,6 +7153,24 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AgentResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
                 };
             };
             /** @description Not found */
@@ -6294,6 +7209,15 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
         };
     };
     "FountainWeb.AgentAvatarController.api_delete": {
@@ -6314,8 +7238,35 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -6345,8 +7296,44 @@ export interface operations {
                     "application/json": components["schemas"]["AgentVersionListResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Agent not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -6378,8 +7365,53 @@ export interface operations {
                     "application/json": components["schemas"]["AgentVersionResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Agent or version not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Invalid request parameters */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -6439,8 +7471,44 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description No such agent */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Conflicting state */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -6473,6 +7541,33 @@ export interface operations {
                     "application/json": components["schemas"]["ApplyResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
             /** @description Validation error */
             422: {
                 headers: {
@@ -6480,6 +7575,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ChangesetError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
                 };
             };
         };
@@ -6524,6 +7628,42 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
         };
     };
     "FountainWeb.ApiKeyController.index": {
@@ -6555,6 +7695,24 @@ export interface operations {
             };
             /** @description The presented key lacks key-management scope */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -6605,8 +7763,26 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
             /** @description Missing or invalid name */
             422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -6662,6 +7838,24 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
         };
     };
     "FountainWeb.DeviceAuthController.create": {
@@ -6680,6 +7874,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["DeviceAuthResponse"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
                 };
             };
         };
@@ -6714,6 +7917,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
                 };
             };
         };
@@ -6759,6 +7971,15 @@ export interface operations {
                     "application/json": components["schemas"]["AuthError"];
                 };
             };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
             /** @description `no_password`, `invalid_email`, `same_email`, or missing fields */
             422: {
                 headers: {
@@ -6766,6 +7987,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AuthError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
                 };
             };
         };
@@ -6791,6 +8021,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["EmailChangedResponse"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
                 };
             };
             /** @description `email_taken`, `expired`, `invalid_token`, or a missing token */
@@ -6827,6 +8066,15 @@ export interface operations {
                     "application/json": components["schemas"]["MessageResponse"];
                 };
             };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
         };
     };
     "FountainWeb.AuthMeController.show": {
@@ -6849,6 +8097,33 @@ export interface operations {
             };
             /** @description Missing or invalid key */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -6899,6 +8174,15 @@ export interface operations {
                     "application/json": components["schemas"]["AuthError"];
                 };
             };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
             /** @description `no_password` (OAuth-only account), missing fields, or a password that fails validation */
             422: {
                 headers: {
@@ -6906,6 +8190,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AuthError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
                 };
             };
         };
@@ -6942,6 +8235,15 @@ export interface operations {
                     "application/json": components["schemas"]["AuthError"];
                 };
             };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
             /** @description Missing fields or validation errors */
             422: {
                 headers: {
@@ -6976,6 +8278,15 @@ export interface operations {
                     "application/json": components["schemas"]["MessageResponse"];
                 };
             };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
         };
     };
     "FountainWeb.PasswordResetController.api_reset": {
@@ -6999,6 +8310,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["MessageResponse"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
                 };
             };
             /** @description `expired`, `invalid_token`, missing fields, or a password that fails validation */
@@ -7053,8 +8373,26 @@ export interface operations {
                     "application/json": components["schemas"]["AuthError"];
                 };
             };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
             /** @description Missing email or password */
             422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Rate limited */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -7085,6 +8423,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["VerifyEmailResponse"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
                 };
             };
             /** @description `expired`, `invalid_token`, or a missing token */
@@ -7121,8 +8468,53 @@ export interface operations {
                     "application/json": components["schemas"]["AvatarGenerateResponse"];
                 };
             };
+            /** @description Invalid request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
             /** @description No OpenAI credential, or unknown base/mood */
             422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -7161,6 +8553,33 @@ export interface operations {
             };
             /** @description Missing or invalid API key */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -7211,6 +8630,15 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description The named environment does not exist */
             404: {
                 headers: {
@@ -7220,8 +8648,26 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
             /** @description Validation error */
             422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -7266,6 +8712,15 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not found */
             404: {
                 headers: {
@@ -7275,8 +8730,26 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
             /** @description Validation error */
             422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -7314,8 +8787,35 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -7360,6 +8860,15 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not found */
             404: {
                 headers: {
@@ -7369,8 +8878,26 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
             /** @description Validation error */
             422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -7396,6 +8923,42 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["CatalogResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
                 };
             };
         };
@@ -7472,6 +9035,15 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
             /** @description Too many principals, or too fast */
             429: {
                 headers: {
@@ -7513,8 +9085,35 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description No such grant */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -7552,6 +9151,15 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description No such grant */
             404: {
                 headers: {
@@ -7561,8 +9169,26 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
             /** @description Already claimed */
             409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -7630,6 +9256,15 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
             /** @description Already claimed */
             409: {
                 headers: {
@@ -7641,6 +9276,15 @@ export interface operations {
             };
             /** @description Expired or released */
             410: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -7677,8 +9321,35 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Connections are not enabled for this account */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -7720,6 +9391,15 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Connections are not enabled for this account */
             404: {
                 headers: {
@@ -7729,8 +9409,26 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
             /** @description Validation or discovery failed */
             422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -7770,8 +9468,35 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -7809,8 +9534,35 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -7855,6 +9607,15 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not found */
             404: {
                 headers: {
@@ -7864,8 +9625,26 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
             /** @description Validation failed */
             422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -7905,6 +9684,15 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not found, or not an mcp provider */
             404: {
                 headers: {
@@ -7914,8 +9702,26 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
             /** @description Discovery failed */
             422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -7952,8 +9758,35 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Connections are not enabled for this account */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -7990,8 +9823,35 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Connections are not enabled for this account */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -8031,8 +9891,35 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -8070,8 +9957,35 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -8117,6 +10031,42 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
         };
     };
     "FountainWeb.ConversationController.create": {
@@ -8151,6 +10101,24 @@ export interface operations {
                     "application/json": components["schemas"]["ConversationResponse"];
                 };
             };
+            /** @description Invalid request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Insufficient credits */
             402: {
                 headers: {
@@ -8163,8 +10131,35 @@ export interface operations {
                     };
                 };
             };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Agent not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Conflicting state */
+            409: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -8179,6 +10174,24 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ChangesetError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Sandbox or fleet unavailable */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
                 };
             };
         };
@@ -8208,6 +10221,15 @@ export interface operations {
                     "application/json": components["schemas"]["EgressListResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description The key lacks full scope */
             403: {
                 headers: {
@@ -8219,6 +10241,24 @@ export interface operations {
             };
             /** @description Not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -8266,8 +10306,53 @@ export interface operations {
                     "application/json": components["schemas"]["LogEventListResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Invalid request parameters */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -8295,6 +10380,24 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not found */
             404: {
                 headers: {
@@ -8304,8 +10407,35 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
             /** @description Nothing to interrupt */
             409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Sandbox or fleet unavailable */
+            503: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -8349,8 +10479,80 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Insufficient credits */
+            402: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Conversation is terminal */
+            410: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Invalid request parameters */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Sandbox or fleet unavailable */
+            503: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -8378,8 +10580,44 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -8415,6 +10653,24 @@ export interface operations {
                     "application/json": components["schemas"]["PermissionAnswerResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not found */
             404: {
                 headers: {
@@ -8422,6 +10678,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
                 };
             };
             /** @description Already resolved */
@@ -8435,6 +10700,15 @@ export interface operations {
             };
             /** @description Unknown option */
             422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -8482,8 +10756,35 @@ export interface operations {
                     "text/event-stream": string;
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -8511,8 +10812,53 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Sandbox or fleet unavailable */
+            503: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -8542,8 +10888,44 @@ export interface operations {
                     "application/json": components["schemas"]["ConversationTreeResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -8573,8 +10955,44 @@ export interface operations {
                     "application/json": components["schemas"]["TurnListResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -8607,8 +11025,35 @@ export interface operations {
                     "image/*": string;
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description No such image */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -8638,8 +11083,44 @@ export interface operations {
                     "application/json": components["schemas"]["ConversationResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -8667,8 +11148,44 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -8696,6 +11213,42 @@ export interface operations {
                     "application/json": components["schemas"]["EnvironmentListResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
         };
     };
     "FountainWeb.EnvironmentController.create": {
@@ -8721,6 +11274,33 @@ export interface operations {
                     "application/json": components["schemas"]["EnvironmentResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
             /** @description Validation error */
             422: {
                 headers: {
@@ -8728,6 +11308,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ChangesetError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
                 };
             };
         };
@@ -8752,8 +11341,44 @@ export interface operations {
                     "application/json": components["schemas"]["SecretListResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -8788,6 +11413,24 @@ export interface operations {
                     "application/json": components["schemas"]["SecretResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not found */
             404: {
                 headers: {
@@ -8797,6 +11440,15 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
             /** @description Validation error */
             422: {
                 headers: {
@@ -8804,6 +11456,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ChangesetError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
                 };
             };
         };
@@ -8828,8 +11489,44 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -8859,8 +11556,44 @@ export interface operations {
                     "application/json": components["schemas"]["EnvironmentResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -8895,6 +11628,24 @@ export interface operations {
                     "application/json": components["schemas"]["EnvironmentResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not found */
             404: {
                 headers: {
@@ -8904,6 +11655,15 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
             /** @description Validation error */
             422: {
                 headers: {
@@ -8911,6 +11671,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ChangesetError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
                 };
             };
         };
@@ -8933,6 +11702,24 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not found */
             404: {
                 headers: {
@@ -8942,8 +11729,26 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
             /** @description An agent is mid-turn on a persistent sandbox built on this environment */
             409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -8978,6 +11783,24 @@ export interface operations {
                     "application/json": components["schemas"]["EnvironmentResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not found */
             404: {
                 headers: {
@@ -8987,6 +11810,15 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
             /** @description Validation error */
             422: {
                 headers: {
@@ -8994,6 +11826,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ChangesetError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
                 };
             };
         };
@@ -9024,6 +11865,33 @@ export interface operations {
                     "text/event-stream": string;
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
         };
     };
     "FountainWeb.OAuthTokenController.revoke": {
@@ -9041,6 +11909,42 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
             };
         };
     };
@@ -9076,6 +11980,15 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
         };
     };
     "FountainWeb.RunnerController.index": {
@@ -9098,6 +12011,33 @@ export interface operations {
             };
             /** @description Missing or invalid key */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -9178,6 +12118,15 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
         };
     };
     "FountainWeb.RunnerController.delete": {
@@ -9208,8 +12157,35 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description No such runner */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -9249,6 +12225,42 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
         };
     };
     "FountainWeb.SandboxController.show": {
@@ -9271,8 +12283,44 @@ export interface operations {
                     "application/json": components["schemas"]["SandboxResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -9300,6 +12348,24 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not found */
             404: {
                 headers: {
@@ -9307,6 +12373,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
                 };
             };
             /** @description A conversation on it is mid-turn */
@@ -9320,6 +12395,15 @@ export interface operations {
             };
             /** @description Not a live persistent sandbox */
             422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -9358,6 +12442,24 @@ export interface operations {
                     "application/json": components["schemas"]["SandboxDiffResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description No such sandbox, path or ref */
             404: {
                 headers: {
@@ -9365,6 +12467,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
                 };
             };
             /** @description Sandbox is not ready */
@@ -9378,6 +12489,15 @@ export interface operations {
             };
             /** @description Not a repository, bad ref, or outside the sandbox */
             422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -9421,6 +12541,24 @@ export interface operations {
                     "application/json": components["schemas"]["SandboxFileResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description No such sandbox or path */
             404: {
                 headers: {
@@ -9428,6 +12566,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
                 };
             };
             /** @description Sandbox is not ready */
@@ -9441,6 +12588,15 @@ export interface operations {
             };
             /** @description A directory, unreadable, or outside the sandbox */
             422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -9482,6 +12638,24 @@ export interface operations {
                     "application/json": components["schemas"]["SandboxListingResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description No such sandbox or path */
             404: {
                 headers: {
@@ -9489,6 +12663,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
                 };
             };
             /** @description Sandbox is not ready */
@@ -9502,6 +12685,15 @@ export interface operations {
             };
             /** @description Not a directory, or outside the sandbox */
             422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -9562,8 +12754,44 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
             /** @description Missing `q`, or a malformed parameter */
             422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -9600,8 +12828,35 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Brokerage is not enabled for this account */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -9643,6 +12898,15 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Brokerage is not enabled for this account */
             404: {
                 headers: {
@@ -9652,8 +12916,26 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
             /** @description Validation error */
             422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -9690,8 +12972,35 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Brokerage is not enabled for this account */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -9729,8 +13038,35 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description No such binding, or brokerage is not enabled */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -9775,6 +13111,15 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description No such binding, or brokerage is not enabled */
             404: {
                 headers: {
@@ -9784,8 +13129,26 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
             /** @description Validation error */
             422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -9815,6 +13178,33 @@ export interface operations {
             };
             /** @description Missing or invalid API key */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -9856,8 +13246,35 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
             /** @description Validation errors */
             422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -9896,8 +13313,35 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -9923,6 +13367,42 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["TeammateListResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
                 };
             };
         };
@@ -9959,6 +13439,24 @@ export interface operations {
                     "application/json": components["schemas"]["TeammateResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Unknown agent, environment or vault */
             404: {
                 headers: {
@@ -9968,8 +13466,26 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
             /** @description Not allowed by the agent */
             422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -9997,6 +13513,42 @@ export interface operations {
                     "application/json": components["schemas"]["TeamCommsStatusResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
         };
     };
     "FountainWeb.TeamScheduleController.index_all": {
@@ -10015,6 +13567,42 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["TeamScheduleListResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
                 };
             };
         };
@@ -10045,6 +13633,33 @@ export interface operations {
                     "text/event-stream": string;
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
         };
     };
     "FountainWeb.TeamController.show": {
@@ -10067,8 +13682,44 @@ export interface operations {
                     "application/json": components["schemas"]["TeammateResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not on the team */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -10096,8 +13747,44 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not on the team */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -10132,6 +13819,24 @@ export interface operations {
                     "application/json": components["schemas"]["TeammateResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not on the team */
             404: {
                 headers: {
@@ -10141,8 +13846,26 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
             /** @description Name too long */
             422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -10177,6 +13900,24 @@ export interface operations {
                     "application/json": components["schemas"]["TeammateResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not on the team, or the feature is off */
             404: {
                 headers: {
@@ -10184,6 +13925,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
                 };
             };
             /** @description Already has a contact */
@@ -10197,6 +13947,24 @@ export interface operations {
             };
             /** @description Bad prompt_from_number */
             422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Contact provider unavailable */
+            424: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -10242,6 +14010,24 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description No contact, or not on the team */
             404: {
                 headers: {
@@ -10251,8 +14037,26 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
             /** @description A provider refused */
             424: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -10287,6 +14091,24 @@ export interface operations {
                     "application/json": components["schemas"]["TeammateResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description No contact, or not on the team */
             404: {
                 headers: {
@@ -10296,8 +14118,26 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
             /** @description Bad prompt_from_number */
             422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -10327,8 +14167,44 @@ export interface operations {
                     "application/json": components["schemas"]["TeammateConversationListResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not on the team */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -10367,8 +14243,44 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not on the team */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -10421,8 +14333,44 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not on the team */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -10452,6 +14400,42 @@ export interface operations {
                     "application/json": components["schemas"]["TeamScheduleListResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
         };
     };
     "FountainWeb.TeamScheduleController.create": {
@@ -10479,6 +14463,24 @@ export interface operations {
                     "application/json": components["schemas"]["TeamScheduleResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Unknown agent */
             404: {
                 headers: {
@@ -10488,8 +14490,26 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
             /** @description Validation errors */
             422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -10520,8 +14540,44 @@ export interface operations {
                     "application/json": components["schemas"]["TeamScheduleResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -10550,8 +14606,44 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -10587,6 +14679,24 @@ export interface operations {
                     "application/json": components["schemas"]["TeamScheduleResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not found */
             404: {
                 headers: {
@@ -10596,8 +14706,26 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
             /** @description Validation errors */
             422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -10637,8 +14765,44 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not found, or not on the team */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -10666,6 +14830,42 @@ export interface operations {
                     "application/json": components["schemas"]["VaultListResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
         };
     };
     "FountainWeb.VaultController.create": {
@@ -10691,6 +14891,33 @@ export interface operations {
                     "application/json": components["schemas"]["VaultResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
             /** @description Validation error */
             422: {
                 headers: {
@@ -10698,6 +14925,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ChangesetError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
                 };
             };
         };
@@ -10722,8 +14958,44 @@ export interface operations {
                     "application/json": components["schemas"]["VaultResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -10758,6 +15030,24 @@ export interface operations {
                     "application/json": components["schemas"]["VaultResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not found */
             404: {
                 headers: {
@@ -10767,6 +15057,15 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
             /** @description Validation error */
             422: {
                 headers: {
@@ -10774,6 +15073,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ChangesetError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
                 };
             };
         };
@@ -10796,6 +15104,24 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not found */
             404: {
                 headers: {
@@ -10805,8 +15131,26 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
             /** @description An agent is mid-turn on a persistent sandbox built on this vault */
             409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -10841,6 +15185,24 @@ export interface operations {
                     "application/json": components["schemas"]["VaultResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not found */
             404: {
                 headers: {
@@ -10850,6 +15212,15 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
             /** @description Validation error */
             422: {
                 headers: {
@@ -10857,6 +15228,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ChangesetError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
                 };
             };
         };
@@ -10881,8 +15261,44 @@ export interface operations {
                     "application/json": components["schemas"]["VaultSecretListResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -10917,6 +15333,24 @@ export interface operations {
                     "application/json": components["schemas"]["VaultSecretResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not found */
             404: {
                 headers: {
@@ -10926,6 +15360,15 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
             /** @description Validation error */
             422: {
                 headers: {
@@ -10933,6 +15376,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ChangesetError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
                 };
             };
         };
@@ -10957,8 +15409,44 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -10988,6 +15476,33 @@ export interface operations {
             };
             /** @description Missing or invalid key */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -11029,8 +15544,35 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
             /** @description Invalid URL or event filter */
             422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -11069,8 +15611,35 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description No such endpoint on this account */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -11107,8 +15676,35 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description No such endpoint on this account */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -11152,6 +15748,15 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description No such endpoint on this account */
             404: {
                 headers: {
@@ -11161,8 +15766,26 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
             /** @description Invalid URL or event filter */
             422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -11204,8 +15827,35 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description No such endpoint on this account */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -11245,8 +15895,35 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description No such endpoint or delivery on this account */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -11285,8 +15962,35 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description No such endpoint on this account */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -11325,8 +16029,35 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description No such endpoint on this account */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -11354,6 +16085,15 @@ export interface operations {
                     "application/json": components["schemas"]["HealthResponse"];
                 };
             };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
         };
     };
     "FountainWeb.HealthController.ready": {
@@ -11372,6 +16112,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ReadinessResponse"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
                 };
             };
             /** @description Not ready */
@@ -11478,6 +16227,24 @@ export interface operations {
                     };
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description No such model (agent) */
             404: {
                 headers: {
@@ -11496,6 +16263,31 @@ export interface operations {
             };
             /** @description The thread is running a turn; retry */
             409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: {
+                            code?: string | null;
+                            message?: string;
+                            param?: string | null;
+                            type?: string;
+                        };
+                    };
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Internal error */
+            500: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -11546,6 +16338,49 @@ export interface operations {
                     };
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: {
+                            code?: string | null;
+                            message?: string;
+                            param?: string | null;
+                            type?: string;
+                        };
+                    };
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
         };
     };
     "FountainWeb.OpenAIController.show_model": {
@@ -11581,6 +16416,24 @@ export interface operations {
                     };
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description No such model (agent) */
             404: {
                 headers: {
@@ -11595,6 +16448,15 @@ export interface operations {
                             type?: string;
                         };
                     };
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
                 };
             };
         };

--- a/sdk/typescript/src/http.ts
+++ b/sdk/typescript/src/http.ts
@@ -19,7 +19,7 @@ export interface RequestOptions {
  * this string is already what Fountain's request logs are keyed on. The
  * version half is asserted against `package.json` by a test.
  */
-export const USER_AGENT = "fountain-sdk-js/1.20.1";
+export const USER_AGENT = "fountain-sdk-js/1.20.2";
 
 /**
  * The thin layer everything else is built on: one bearer token, JSON in and


### PR DESCRIPTION
OpenAPI omitted errors returned by shared pipelines and several controllers, while the manual duplicated endpoint details. This declares those responses, makes Swagger the endpoint reference, and adds tested alerts for failures after provisioning.

- Derive auth, scope, rate-limit, and content-negotiation responses from router membership, including extension dispatch. Preserve controller-specific schemas and declare local refusals explicitly. Remove all 66 missing-status exceptions from the schema guard and the SDK conformance linter's blanket status exemption.
- Regenerate the wire contract and TypeScript types. The semantic comparison adds 538 responses without changing any existing operation field or schema. TypeScript 1.20.2 carries the corrected types; request behavior is unchanged.
- Add stage, reattach, per-provider turn-failure, and first-output latency alerts. Promtool fixtures cover absent series, quiet traffic, provider isolation, counter resets, exact thresholds, and the latency alert's hold time. CI runs the fixtures.
- Replace the endpoint inventory in `docs/api.md` with a workflow guide linking to the instance's generated reference. Preserve all 29 existing section anchors and expose the reference through documentation navigation.

Validation completed:
- API contract, pipeline, and docs structural tests pass.
- 101 TypeScript tests, typecheck, build, and all four SDK contract checks pass.
- 45 Promtool cases and 13 CI policy tests pass; 24 conformance scenarios validate.
- Generated-contract staleness check, SDK release gate, docs style, and destink pass. STE report reviewed; remaining warnings name technical terms.
- `mix precommit` on the implementation passes, including static analysis and production release assembly: core 4,300 tests plus 6 doctests, Buzz 144 tests, Support 33 tests, zero failures.

After merging current main, all 34 deployed-runner tests and 95 affected SSE, timestamp, API, and docs tests pass. The local database was migrated to main’s new microsecond timestamp schema before that integration run.

The portable alerts need deployment and an alert receiver to become operational. First-output latency measures output that arrives; it does not detect a turn that emits no bytes. No production configuration is changed by this PR.

Fixes #1432.
Fixes #1168.
Fixes #912.
