### PR TITLE
test(sdk): monitor the owner atomically at spawn

### DIFF
--- a/sdk/elixir/test/run_test.exs
+++ b/sdk/elixir/test/run_test.exs
@@ -128,13 +128,15 @@ defmodule Fountain.RunTest do
   test "run server and worker are cleaned up when their owner exits" do
     parent = self()
 
-    owner =
-      spawn(fn ->
+    # spawn_monitor, not spawn + Process.monitor: the fun below finishes in
+    # microseconds, so a monitor placed after the spawn regularly attaches to a
+    # process that has already exited and fires :noproc instead of :normal.
+    {owner, monitor} =
+      spawn_monitor(fn ->
         run = Run.new(%{}, fn -> Process.sleep(:infinity) end)
         send(parent, {:run_server, run.server})
       end)
 
-    monitor = Process.monitor(owner)
     assert_receive {:run_server, server}
     assert_receive {:DOWN, ^monitor, :process, ^owner, :normal}
     server_monitor = Process.monitor(server)


### PR DESCRIPTION
Closes #1629.

`Fountain.RunTest`'s "run server and worker are cleaned up when their owner exits" spawns the owner and then monitors it. The fun starts a `Run` server and returns, so it finishes in microseconds; when it exits before `Process.monitor/1` runs, the monitor attaches to a dead pid and fires with `:noproc` rather than `:normal`, and the `assert_receive` pinned to `:normal` times out.

That is one red step in `SDK clients, CLI and plugins`, which reds the job and `CI required` with it. It is what is currently blocking #1628, whose diff does not touch this file.

`spawn_monitor/1` places the monitor atomically with the spawn, so `:noproc` is unreachable. The assertion on `:normal` stays exact rather than being widened to accept both reasons — the second monitor in the same test tolerates `:noproc` because it genuinely races the server's shutdown, which is a different situation.

## Verification

The failure needs scheduler load, so `--repeat-until-failure 300` on the line alone stays green. Reproduced outside the suite instead: 2,000 spawn-then-monitor rounds with the schedulers busy gave `%{normal: 1999, noproc: 1}`; the same 2,000 rounds through `spawn_monitor/1` gave `%{normal: 2000}`.

`mix test` in `sdk/elixir`: 52 tests, 0 failures. `mix format --check-formatted` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RdPb3NN8NqfnkHf6c1YSiY