### PR TITLE
Add deployed canaries and confirmed-rollout verification

### DIFF
--- a/.github/workflows/deployed.yml
+++ b/.github/workflows/deployed.yml
@@ -1,0 +1,112 @@
+name: Deployed verification
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: Approved environment target
+        type: choice
+        options: [staging, production]
+        required: true
+      profile:
+        description: Required public checks (canary includes basic and execution)
+        type: choice
+        options: [basic, probe, execution, streaming, canary]
+        default: streaming
+        required: true
+      mode:
+        description: Rollout checks every serving pod against expected_digest
+        type: choice
+        options: [public, rollout]
+        default: public
+        required: true
+      expected_digest:
+        description: Expected runtime image digest (sha256...), required for rollout
+        type: string
+  schedule:
+    - cron: '23 */6 * * *'
+
+permissions:
+  contents: read
+
+# Includes both dispatches and schedules, across branches and profiles. Never
+# cancel an active fixture owner to make room for the next run.
+concurrency:
+  group: deployed-${{ inputs.target || 'production' }}
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    if: github.event_name != 'schedule' || vars.DEPLOYED_CANARY_ENABLED == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Require approved target and main checkout
+        env:
+          REQUESTED_TARGET: ${{ inputs.target || 'production' }}
+        run: |
+          test "$GITHUB_REF" = refs/heads/main || { echo 'Verification requires main'; exit 1; }
+          case "$REQUESTED_TARGET" in
+            staging|production) ;;
+            *) echo 'Target is not approved'; exit 1 ;;
+          esac
+  verify:
+    needs: validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    environment: deployed-${{ inputs.target || 'production' }}
+    env:
+      SUITE_TARGET: ${{ inputs.target || 'production' }}
+      SUITE_PROFILE: ${{ inputs.profile || 'canary' }}
+      SUITE_MODE: ${{ inputs.mode || 'public' }}
+      SUITE_EXPECTED_DIGEST: ${{ inputs.expected_digest }}
+      SUITE_ENABLED: ${{ vars.SUITE_ENABLED }}
+      SUITE_TARGET_JSON: ${{ vars.SUITE_TARGET_JSON }}
+      FOUNTAIN_SUITE_KEY: ${{ secrets.FOUNTAIN_SUITE_KEY }}
+      FOUNTAIN_SUITE_OTHER_KEY: ${{ secrets.FOUNTAIN_SUITE_OTHER_KEY }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+      - name: Start scheduled monitor
+        if: github.event_name == 'schedule'
+        env:
+          SUITE_MONITOR_URL: ${{ secrets.SUITE_MONITOR_URL }}
+        run: node deployed/monitor.mjs in_progress
+      - name: Configure deployment observer
+        if: inputs.mode == 'rollout'
+        env:
+          SUITE_KUBECONFIG: ${{ secrets.SUITE_KUBECONFIG }}
+        run: |
+          node --input-type=module <<'JS'
+          import { writeFileSync, appendFileSync } from 'node:fs';
+          import { join } from 'node:path';
+          if (!process.env.SUITE_KUBECONFIG) throw new Error('Missing read-only deployment credentials');
+          const path = join(process.env.RUNNER_TEMP, 'suite-kubeconfig');
+          writeFileSync(path, process.env.SUITE_KUBECONFIG, { mode: 0o600 });
+          appendFileSync(process.env.GITHUB_ENV, `KUBECONFIG=${path}\n`);
+          JS
+          kubectl version --client
+      - name: Verify public ingress and clean fixtures
+        id: suite
+        run: node deployed/ci.mjs
+      - name: Finish scheduled monitor
+        if: always() && github.event_name == 'schedule'
+        env:
+          SUITE_MONITOR_URL: ${{ secrets.SUITE_MONITOR_URL }}
+          MONITOR_STATUS: ${{ steps.suite.outcome == 'success' && 'ok' || 'error' }}
+        run: node deployed/monitor.mjs "$MONITOR_STATUS"
+      - name: Retain redacted evidence and cleanup manifests
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: deployed-${{ env.SUITE_TARGET }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/deployed-${{ github.run_id }}-${{ github.run_attempt }}/results/
+          retention-days: 30
+          if-no-files-found: warn
+      - name: Remove deployment credentials
+        if: always()
+        run: rm -f "$RUNNER_TEMP/suite-kubeconfig"

--- a/deployed/README.md
+++ b/deployed/README.md
@@ -169,9 +169,12 @@ activity inside a turn and provider charges are not a fixed price. Cleanup
 terminates the conversation after failure or cancellation; an unavailable
 server/provider can prevent that, which leaves a visible cleanup failure.
 
-The result explicitly reports that deployment revision is unverified. A URL
-and a successful response do not establish image identity. Confirmed rollout
-integration and deployment revision adapters belong to #1612.
+By default, deployment identity is unverified. The optional Kubernetes adapter
+checks the intended runtime image digest across every serving pod before and
+after the public suite. Reports record the suite checkout revision separately.
+See the [operating guide](../docs/guides/operate/deploy.md#verify-the-deployed-instance)
+for CI environments, rollout hooks, scheduled canaries, fixture provisioning
+and failure ownership. Public profiles need no cluster credentials.
 
 ## Interrupted runs and cleanup
 

--- a/deployed/adapters/kubernetes.mjs
+++ b/deployed/adapters/kubernetes.mjs
@@ -1,0 +1,71 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+const exec = promisify(execFile);
+const requireThat = (condition, message) => { if (!condition) throw new Error(message); };
+
+export function validateDeployment(config) {
+  requireThat(config?.adapter === 'kubernetes', 'Unsupported deployment adapter');
+  requireThat(Object.keys(config).every(k => ['adapter', 'context', 'namespace', 'deployment', 'service', 'container', 'expected_digest'].includes(k)), 'Unknown deployment setting');
+  for (const key of ['context', 'namespace', 'deployment', 'service', 'container']) {
+    requireThat(typeof config[key] === 'string' && /^[a-zA-Z0-9][a-zA-Z0-9_.:/-]*$/.test(config[key]), `Invalid deployment ${key}`);
+  }
+  requireThat(/^sha256:[a-f0-9]{64}$/.test(config.expected_digest), 'Expected a runtime image digest');
+  return config;
+}
+
+// Only selected metadata leaves this adapter. Raw Kubernetes objects can contain secrets.
+export function verifySnapshot(config, { deployment, service, pods, slices, replicaSets }) {
+  validateDeployment(config);
+  const desired = deployment.spec?.replicas ?? 1;
+  const status = deployment.status ?? {};
+  requireThat(desired > 0 && status.observedGeneration === deployment.metadata.generation &&
+    ['replicas', 'updatedReplicas', 'readyReplicas', 'availableReplicas'].every(k => status[k] === desired) &&
+    !status.unavailableReplicas, 'Deployment rollout is incomplete');
+  requireThat(!deployment.metadata.deletionTimestamp, 'Deployment is terminating');
+  requireThat(!service.spec?.publishNotReadyAddresses && service.spec?.selector &&
+    Object.keys(service.spec.selector).length > 0, 'Service must select ready pods');
+  const selected = pods.items.filter(p => Object.entries(service.spec.selector).every(([k, v]) => p.metadata.labels?.[k] === v));
+  requireThat(selected.length === desired, 'Service selector includes missing, extra, or terminating pods');
+  const rsIds = new Set(replicaSets.items.filter(rs => rs.metadata.ownerReferences?.some(o =>
+    o.controller && o.kind === 'Deployment' && o.uid === deployment.metadata.uid)).map(rs => rs.metadata.uid));
+  const members = selected.map(p => {
+    requireThat(!p.metadata.deletionTimestamp && p.status?.conditions?.some(c => c.type === 'Ready' && c.status === 'True'), 'Serving pod is not ready');
+    requireThat(p.metadata.ownerReferences?.some(o => o.controller && o.kind === 'ReplicaSet' && rsIds.has(o.uid)), 'Service routes outside the approved deployment');
+    const container = p.status.containerStatuses?.find(c => c.name === config.container);
+    requireThat(container?.ready && container.state?.running && container.imageID?.endsWith(`@${config.expected_digest}`), 'Serving container has the wrong image digest or is not running');
+    return { uid: p.metadata.uid, name: p.metadata.name, image_digest: config.expected_digest, restarts: container.restartCount };
+  }).sort((a, b) => a.uid.localeCompare(b.uid));
+  const endpoints = slices.items.flatMap(s => s.endpoints ?? []);
+  requireThat(endpoints.length > 0 && endpoints.every(e => e.conditions?.ready === true &&
+    e.conditions?.terminating !== true && e.conditions?.serving !== false && e.targetRef?.kind === 'Pod' &&
+    e.targetRef.namespace === config.namespace && members.some(p => p.uid === e.targetRef.uid)),
+  'EndpointSlices contain unready, unknown, or terminating backends');
+  requireThat(members.every(p => endpoints.some(e => e.targetRef.uid === p.uid)), 'EndpointSlices omit a deployment pod');
+  return { adapter: 'kubernetes', observed_at: new Date().toISOString(), context: config.context,
+    namespace: config.namespace, deployment: config.deployment, service: config.service,
+    deployment_uid: deployment.metadata.uid, generation: deployment.metadata.generation,
+    service_uid: service.metadata.uid, image_digest: config.expected_digest, pods: members };
+}
+
+export async function observeDeployment(config, signal) {
+  validateDeployment(config);
+  const get = async (...args) => {
+    try {
+      const { stdout } = await exec('kubectl', ['--context', config.context, '--namespace', config.namespace,
+        '--request-timeout=10s', 'get', ...args, '-o', 'json'], { timeout: 15000, maxBuffer: 4 * 1024 * 1024, signal });
+      return JSON.parse(stdout);
+    } catch { throw new Error('Deployment adapter could not read Kubernetes state; check connectivity and read-only RBAC'); }
+  };
+  const [deployment, service, pods, slices, replicaSets] = await Promise.all([
+    get('deployment', config.deployment), get('service', config.service), get('pods'),
+    get('endpointslices', '-l', `kubernetes.io/service-name=${config.service}`), get('replicasets'),
+  ]);
+  return verifySnapshot(config, { deployment, service, pods, slices, replicaSets });
+}
+
+export function verifyStable(before, after) {
+  const identity = ({ observed_at, ...value }) => JSON.stringify(value);
+  requireThat(identity(before) === identity(after), 'Serving deployment changed during verification');
+  return { verified: true, adapter: 'kubernetes', image_digest: after.image_digest, before, after,
+    scope: 'Approved URL-to-Service binding; every serving pod checked before and after the public suite' };
+}

--- a/deployed/ci.mjs
+++ b/deployed/ci.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { run } from './lib/runner.mjs';
+
+export function ciConfig(env) {
+  if (!['staging', 'production'].includes(env.SUITE_TARGET)) throw new Error('Target is not approved');
+  if (env.SUITE_ENABLED !== 'true') throw new Error('Target environment is not enabled');
+  if (!['probe', 'basic', 'execution', 'streaming', 'canary'].includes(env.SUITE_PROFILE)) throw new Error('Profile is not approved');
+  const config = JSON.parse(env.SUITE_TARGET_JSON || '{}');
+  const url = new URL(config.base_url);
+  if (url.protocol !== 'https:') throw new Error('CI targets require HTTPS ingress');
+  config.credentials = { primary: 'FOUNTAIN_SUITE_KEY', secondary: 'FOUNTAIN_SUITE_OTHER_KEY' };
+  config.profiles = env.SUITE_PROFILE === 'canary' ? ['basic', 'execution'] : [env.SUITE_PROFILE];
+  // Bound exposure even if an environment variable accidentally requests a longer run.
+  config.limits = { request_ms: 30000, run_ms: 420000, cleanup_ms: 90000, resources: 12 };
+  if (config.execution) config.execution = { ...config.execution, provision_ms: 120000, turn_ms: 90000, max_turns: 2 };
+  if (env.SUITE_MODE === 'rollout') {
+    if (!config.deployment) throw new Error('Rollout requires an environment-owned deployment adapter');
+    config.deployment.expected_digest = env.SUITE_EXPECTED_DIGEST;
+  } else if (env.SUITE_MODE === 'public') {
+    if (env.SUITE_EXPECTED_DIGEST) throw new Error('Expected digest requires rollout mode');
+    delete config.deployment;
+  } else throw new Error('Unknown verification mode');
+  return config;
+}
+
+export async function ciMain(env = process.env) {
+  const controller = new AbortController();
+  const cancel = () => controller.abort(new Error('Interrupted'));
+  process.on('SIGINT', cancel);
+  process.on('SIGTERM', cancel);
+  try {
+    const config = ciConfig(env);
+    const root = resolve(env.RUNNER_TEMP || '.', `deployed-${env.GITHUB_RUN_ID || 'local'}-${env.GITHUB_RUN_ATTEMPT || '1'}`);
+    mkdirSync(root, { mode: 0o700 });
+    const configPath = resolve(root, 'target.json');
+    writeFileSync(configPath, JSON.stringify(config), { mode: 0o600 });
+    return await run({ configPath, out: resolve(root, 'results'), signal: controller.signal, env });
+  } finally {
+    process.off('SIGINT', cancel);
+    process.off('SIGTERM', cancel);
+  }
+}
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try { process.exitCode = await ciMain(); }
+  catch { console.error('CI setup failed; check approved target configuration and required environment settings'); process.exitCode = 2; }
+}

--- a/deployed/lib/runner.mjs
+++ b/deployed/lib/runner.mjs
@@ -2,6 +2,8 @@ import { mkdirSync, readFileSync, appendFileSync, writeFileSync } from 'node:fs'
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { randomUUID } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import { observeDeployment, validateDeployment, verifyStable } from '../adapters/kubernetes.mjs';
 import { Contract } from './contract.mjs';
 import { Client, Redactor } from './http.mjs';
 import { atomicJson, Fixtures } from './fixtures.mjs';
@@ -22,7 +24,7 @@ function positive(value, fallback, max) {
 
 export function configFrom(path, env = process.env) {
   const config = JSON.parse(readFileSync(path, 'utf8'));
-  const allowed = ['base_url', 'credentials', 'profiles', 'contract', 'required_capabilities', 'optional_capabilities', 'limits', 'execution'];
+  const allowed = ['base_url', 'credentials', 'profiles', 'contract', 'required_capabilities', 'optional_capabilities', 'limits', 'execution', 'deployment'];
   requireThat(Object.keys(config).every(key => allowed.includes(key)), 'Unknown configuration field');
   const url = new URL(config.base_url);
   requireThat(['http:', 'https:'].includes(url.protocol) && !url.username && !url.password && !url.search && !url.hash,
@@ -71,6 +73,7 @@ export function configFrom(path, env = process.env) {
       }
     }
   }
+  if (config.deployment) validateDeployment(config.deployment);
   return config;
 }
 
@@ -84,12 +87,19 @@ export function writeReport(out, report, redactor) {
   return safe;
 }
 
-export async function run({ configPath, out, manifestPath, signal, env = process.env, log = console.log }) {
+export async function run({ configPath, out, manifestPath, signal, env = process.env, log = console.log, deploymentObserver = observeDeployment }) {
   mkdirSync(out, { mode: 0o700 }); // Exclusive run directory; never overwrite another run's evidence.
   const redactor = new Redactor();
   const report = { suite_version: VERSION, run_id: randomUUID(), started_at: new Date().toISOString(),
     mode: manifestPath ? 'cleanup' : 'run', status: 'setup_failed', checks: [], revision: { verified: false, reason: 'No deployment revision adapter configured' } };
-  let config, fixtures;
+  let config, fixtures, deploymentBefore;
+  try {
+    const git = (...args) => execFileSync('git', args, {
+      cwd: fileURLToPath(new URL('../..', import.meta.url)), encoding: 'utf8', timeout: 5000, stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    report.suite_revision = git('rev-parse', 'HEAD');
+    report.suite_dirty = Boolean(git('status', '--porcelain', '--untracked-files=normal'));
+  } catch { report.suite_revision = null; report.suite_dirty = null; }
   const check = async (name, fn) => {
     const started = performance.now();
     try {
@@ -115,6 +125,13 @@ export async function run({ configPath, out, manifestPath, signal, env = process
     const combined = signal ? AbortSignal.any([signal, timeout]) : timeout;
     const client = new Client({ baseUrl: config.base_url, key: config.key, redactor, contract, signal: combined,
       timeoutMs: config.limits.request_ms, trace: entry => appendFileSync(resolve(out, 'http.jsonl'), JSON.stringify(redactor.value(entry)) + '\n', { mode: 0o600 }) });
+    if (config.deployment && !manifestPath) {
+      const ready = await check('setup/deployment', async () => {
+        deploymentBefore = await deploymentObserver(config.deployment, combined);
+        report.revision = { verified: false, before: deploymentBefore, reason: 'Awaiting post-run deployment check' };
+      });
+      if (!ready) throw new Error('Intended deployment is not serving');
+    }
     let ownerId;
     const identityOk = await check('setup/identity', async () => {
       const { body } = await client.request('GET', '/api/auth/me', { expected: 200 });
@@ -165,6 +182,13 @@ export async function run({ configPath, out, manifestPath, signal, env = process
         report.status = 'cleanup_failed';
         report.checks.push({ name: 'cleanup', status: 'failed', duration_ms: 0, error: 'Resources remain; see cleanup manifest and result.json' });
       }
+    }
+    if (deploymentBefore) {
+      const stable = await check('deployment/stable', async () => {
+        const after = await deploymentObserver(config.deployment, AbortSignal.timeout(20000));
+        report.revision = verifyStable(deploymentBefore, after);
+      });
+      if (!stable && report.status === 'passed') report.status = 'failed';
     }
     if (signal?.aborted) report.status = 'cancelled';
     report.ended_at = new Date().toISOString();

--- a/deployed/monitor.mjs
+++ b/deployed/monitor.mjs
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+import { createHash } from 'node:crypto';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Reuses the Sentry Crons channel already used for backup monitoring. Never log its URL.
+export async function checkIn(status, env = process.env, send = fetch) {
+  try {
+    if (!['in_progress', 'ok', 'error'].includes(status) || !/^\d+$/.test(env.GITHUB_RUN_ID) ||
+      !/^\d+$/.test(env.GITHUB_RUN_ATTEMPT) || !env.GITHUB_REPOSITORY) throw new Error();
+    const url = new URL(env.SUITE_MONITOR_URL);
+    if (url.protocol !== 'https:' || url.username || url.password || url.hash) throw new Error();
+    const id = createHash('sha256').update(`${env.GITHUB_REPOSITORY}:${env.GITHUB_RUN_ID}:${env.GITHUB_RUN_ATTEMPT}`).digest('hex').slice(0, 32);
+    url.searchParams.set('check_in_id', id);
+    url.searchParams.set('status', status);
+    const response = await send(url, { redirect: 'error', signal: AbortSignal.timeout(10000) });
+    await response.body?.cancel();
+    if (!response.ok) throw new Error();
+  } catch { throw new Error('Canary monitor check-in failed; check environment configuration and Sentry availability'); }
+}
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try { await checkIn(process.argv[2]); console.log(`Canary monitor check-in: ${process.argv[2]}`); }
+  catch (error) { console.error(error.message); process.exitCode = 1; }
+}

--- a/deployed/test/deployment.test.mjs
+++ b/deployed/test/deployment.test.mjs
@@ -1,0 +1,78 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { validateDeployment, verifySnapshot, verifyStable } from '../adapters/kubernetes.mjs';
+import { ciConfig } from '../ci.mjs';
+
+const digest = `sha256:${'a'.repeat(64)}`;
+const config = { adapter: 'kubernetes', context: 'test', namespace: 'fountain', deployment: 'fountain', service: 'fountain', container: 'fountain', expected_digest: digest };
+function fixture() {
+  return {
+    deployment: { metadata: { uid: 'deployment-1', generation: 2 }, spec: { replicas: 2 },
+      status: { observedGeneration: 2, replicas: 2, updatedReplicas: 2, readyReplicas: 2, availableReplicas: 2 } },
+    replicaSets: { items: [{ metadata: { uid: 'rs-1', ownerReferences: [{ controller: true, kind: 'Deployment', uid: 'deployment-1' }] } }] },
+    service: { metadata: { uid: 'service-1' }, spec: { selector: { app: 'fountain' } } },
+    pods: { items: [1, 2].map(n => ({ metadata: { uid: `pod-${n}`, name: `fountain-${n}`, labels: { app: 'fountain' },
+      ownerReferences: [{ controller: true, kind: 'ReplicaSet', uid: 'rs-1' }] },
+    status: { conditions: [{ type: 'Ready', status: 'True' }], containerStatuses: [{ name: 'fountain', ready: true,
+      imageID: `ghcr.io/example/fountain@${digest}`, restartCount: 0, state: { running: {} } }] } })) },
+    slices: { items: [1, 2].map(n => ({ endpoints: [{ targetRef: { kind: 'Pod', namespace: 'fountain', uid: `pod-${n}` },
+      conditions: { ready: true, serving: true, terminating: false } }] })) },
+  };
+}
+test('deployment evidence covers every endpoint slice, digest, and deployment owner', () => {
+  const evidence = verifySnapshot(config, fixture());
+  assert.equal(evidence.pods.length, 2);
+  assert.equal(evidence.image_digest, digest);
+  assert.equal(verifyStable(evidence, { ...evidence, observed_at: 'later' }).verified, true);
+});
+for (const [name, change] of Object.entries({
+  'old observed generation': f => f.deployment.status.observedGeneration--,
+  'partial rollout': f => f.deployment.status.updatedReplicas--,
+  'zero replicas': f => f.deployment.spec.replicas = 0,
+  'old image on one backend': f => f.pods.items[1].status.containerStatuses[0].imageID = `example@sha256:${'b'.repeat(64)}`,
+  'unready pod': f => f.pods.items[0].status.conditions = [],
+  'terminating pod': f => f.pods.items[0].metadata.deletionTimestamp = 'now',
+  'unrelated deployment': f => f.replicaSets.items[0].metadata.ownerReferences[0].uid = 'other',
+  'extra selected pod': f => f.pods.items.push(structuredClone(f.pods.items[0])),
+  'missing slice': f => f.slices.items.pop(),
+  'unknown backend': f => f.slices.items[0].endpoints[0].targetRef.uid = 'external',
+  'unknown readiness': f => delete f.slices.items[0].endpoints[0].conditions.ready,
+  'draining endpoint': f => f.slices.items[0].endpoints[0].conditions.terminating = true,
+  'publish unready addresses': f => f.service.spec.publishNotReadyAddresses = true,
+  'selectorless service': f => f.service.spec.selector = {},
+})) test(`rejects ${name}`, () => {
+  const f = fixture(); change(f);
+  assert.throws(() => verifySnapshot(config, f));
+});
+test('a restart or replacement during a successful public run invalidates attribution', () => {
+  const before = verifySnapshot(config, fixture());
+  const after = structuredClone(before);
+  after.pods[0].restarts++;
+  assert.throws(() => verifyStable(before, after), /changed/);
+});
+test('adapter configuration rejects malformed identity and unsupported fields', () => {
+  assert.throws(() => validateDeployment({ ...config, expected_digest: 'latest' }));
+  assert.throws(() => validateDeployment({ ...config, context: '--server=evil' }));
+  assert.throws(() => validateDeployment({ ...config, command: 'arbitrary' }));
+});
+const env = { SUITE_TARGET: 'staging', SUITE_ENABLED: 'true', SUITE_PROFILE: 'canary', SUITE_MODE: 'public',
+  SUITE_TARGET_JSON: JSON.stringify({ base_url: 'https://example.test', deployment: config,
+    execution: { runtime: 'claude', model: 'anthropic/claude-haiku-4-5', sandbox_provider: 'sprites', max_turns: 100 } }) };
+test('public canary uses environment-owned target and fixed budgets without cluster credentials', () => {
+  const result = ciConfig(env);
+  assert.deepEqual(result.profiles, ['basic', 'execution']);
+  assert.equal(result.deployment, undefined);
+  assert.equal(result.execution.max_turns, 2);
+  assert.equal(result.limits.run_ms, 420000);
+  assert.equal(result.credentials.primary, 'FOUNTAIN_SUITE_KEY');
+});
+test('dispatch rejects missing activation, unknown targets/profiles, and unverified revision requests', () => {
+  for (const changes of [{ SUITE_ENABLED: '' }, { SUITE_TARGET: 'attacker' }, { SUITE_PROFILE: 'custom' },
+    { SUITE_EXPECTED_DIGEST: digest }, { SUITE_MODE: 'unknown' },
+    { SUITE_TARGET_JSON: '{' }, { SUITE_TARGET_JSON: '{"base_url":"http://example.test"}' }]) {
+    assert.throws(() => ciConfig({ ...env, ...changes }));
+  }
+  const result = ciConfig({ ...env, SUITE_MODE: 'rollout', SUITE_EXPECTED_DIGEST: digest });
+  assert.equal(result.deployment.expected_digest, digest);
+  assert.throws(() => ciConfig({ ...env, SUITE_MODE: 'rollout', SUITE_TARGET_JSON: '{"base_url":"https://example.test"}' }));
+});

--- a/deployed/test/monitor.test.mjs
+++ b/deployed/test/monitor.test.mjs
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { checkIn } from '../monitor.mjs';
+
+const env = { GITHUB_REPOSITORY: 'example/fountain', GITHUB_RUN_ID: '123', GITHUB_RUN_ATTEMPT: '1',
+  SUITE_MONITOR_URL: 'https://monitor.example.test/api/1/cron/canary/private-material/' };
+test('monitor correlates start/end and separates retried workflow attempts', async () => {
+  const requests = [];
+  const send = async (url, options) => { requests.push({ url, options }); return new Response(''); };
+  await checkIn('in_progress', env, send);
+  await checkIn('error', env, send);
+  await checkIn('ok', { ...env, GITHUB_RUN_ATTEMPT: '2' }, send);
+  const ids = requests.map(r => r.url.searchParams.get('check_in_id'));
+  assert.equal(ids[0], ids[1]);
+  assert.notEqual(ids[1], ids[2]);
+  assert.equal(requests[1].url.searchParams.get('status'), 'error');
+  assert.equal(requests[0].options.redirect, 'error');
+});
+test('monitor rejects missing credentials and does not expose URL in delivery failures', async () => {
+  let sent = false;
+  await assert.rejects(checkIn('in_progress', { ...env, SUITE_MONITOR_URL: '' }, async () => { sent = true; }), /monitor check-in failed/);
+  assert.equal(sent, false);
+  await assert.rejects(checkIn('ok', env, async () => { throw new Error(env.SUITE_MONITOR_URL); }), error =>
+    !error.message.includes('private-material') && /monitor check-in failed/.test(error.message));
+  await assert.rejects(checkIn('ok', env, async () => new Response('', { status: 503 })), /monitor check-in failed/);
+});

--- a/deployed/test/runner.test.mjs
+++ b/deployed/test/runner.test.mjs
@@ -283,3 +283,31 @@ test('contract checks requiredness, nullability, enums and unions while allowing
   assert.throws(() => c.validate('x', { oneOf: [{ type: 'string' }, { type: 'string' }] }), /oneOf/);
   assert.doesNotThrow(() => c.validate(3, { anyOf: [{ type: 'string' }, { type: 'integer' }] }));
 });
+
+const deployment = { adapter: 'kubernetes', context: 'test', namespace: 'test', deployment: 'test',
+  service: 'test', container: 'test', expected_digest: `sha256:${'a'.repeat(64)}` };
+test('deployment mismatch fails setup before public traffic or fixture mutations', async t => {
+  const f = await fixture(t);
+  const result = await f.execute({ deployment }, { deploymentObserver: async () => { throw new Error('Wrong image'); } });
+  assert.equal(result.code, 2);
+  assert.equal(result.report.revision.verified, false);
+  assert.equal(f.requests.length, 0);
+});
+test('deployment changing during a passing probe fails attribution after cleanup', async t => {
+  const f = await fixture(t);
+  let observations = 0;
+  const result = await f.execute({ deployment }, { deploymentObserver: async () => ({ generation: ++observations }) });
+  assert.equal(result.code, 1);
+  assert.equal(observations, 2);
+  assert.equal(result.report.cleanup.remaining, 0);
+  assert.equal(result.report.revision.verified, false);
+  assert.equal(result.report.checks.at(-1).name, 'deployment/stable');
+});
+test('stable external evidence is retained with suite revision and public verdict', async t => {
+  const f = await fixture(t);
+  const result = await f.execute({ deployment }, { deploymentObserver: async () => ({ image_digest: deployment.expected_digest }) });
+  assert.equal(result.code, 0);
+  assert.equal(result.report.revision.verified, true);
+  assert.equal(result.report.revision.image_digest, deployment.expected_digest);
+  assert.match(result.report.suite_revision, /^[a-f0-9]{40}$/);
+});

--- a/docs/guides/operate/deploy.md
+++ b/docs/guides/operate/deploy.md
@@ -164,3 +164,210 @@ database. Read
 - [Configuration reference](../../configuration.md).
 - [Architecture](../../architecture.md), for what runs, and what breaks when a
   dependency is down.
+
+## Verify the deployed instance
+
+The external suite checks public HTTP and SSE through your ingress. Use Node
+24 or newer from a pinned Fountain checkout. It needs no application database
+access. Provision two dedicated, verified test accounts and full-scope API
+keys through the console. Configure inference credentials on the primary
+account for execution checks. Keep both accounts separate from customer data;
+registration can remain closed. Limit provider spending on that account with
+the provider's own budget controls.
+
+Start with a local Compose target:
+
+```json
+{
+  "base_url": "http://localhost:4000",
+  "credentials": {
+    "primary": "FOUNTAIN_SUITE_KEY",
+    "secondary": "FOUNTAIN_SUITE_OTHER_KEY"
+  },
+  "profiles": ["basic"]
+}
+```
+
+Save it as `/tmp/fountain-target.json`, load the two keys into the named
+environment variables through your secret store, then run:
+
+```bash
+node deployed/cli.mjs run --config /tmp/fountain-target.json --out /tmp/fountain-check-001
+```
+
+For a remote self-hosted instance, change `base_url` to its HTTPS ingress.
+For a real conversation, select `streaming` and add explicit execution settings:
+
+```json
+{
+  "execution": {
+    "runtime": "claude",
+    "model": "anthropic/claude-haiku-4-5",
+    "sandbox_provider": "sprites",
+    "provision_ms": 120000,
+    "turn_ms": 90000,
+    "max_turns": 2
+  },
+  "limits": {
+    "request_ms": 30000,
+    "run_ms": 420000,
+    "cleanup_ms": 90000,
+    "resources": 12
+  }
+}
+```
+
+Merge those fields into the target file. This checks a nonce artifact, two
+real tool-using turns, tenant isolation, live output, reconnect, replay and
+history agreement, then terminates and deletes its fixtures. Select `basic`
+for API-only checks, `execution` for two turns without streaming conformance,
+or `probe` for identity, capability and health checks. Missing required
+credentials or capabilities fail; they never become passing skips.
+
+### Run in CI
+
+The `Deployed verification` workflow accepts only `staging` and `production`
+and runs code from `main`. Create the matching GitHub environment,
+`deployed-staging` or `deployed-production`, and restrict its deployment branch
+to `main`. Configure these environment settings:
+
+| Setting | Purpose |
+|---|---|
+| Variable `SUITE_ENABLED=true` | Explicitly enable this target. |
+| Variable `SUITE_TARGET_JSON` | Target JSON with approved HTTPS URL, required capabilities and execution settings. |
+| Secret `FOUNTAIN_SUITE_KEY` | Primary dedicated test account API key. |
+| Secret `FOUNTAIN_SUITE_OTHER_KEY` | Different verified account's API key. |
+| Secret `SUITE_KUBECONFIG` | Optional read-only Kubernetes access for rollout mode. |
+| Secret `SUITE_MONITOR_URL` | Sentry Crons check-in URL for the scheduled canary. |
+
+The workflow fixes credential variable names and bounds each run to seven
+minutes plus 90 seconds for cleanup. It creates at most 12 resources and
+attempts at most two inference prompts. These limits do not cap the monetary
+cost of a model turn. Profiles run sequentially. All dispatches and schedules
+share one concurrency group per target, and an active run is never cancelled
+by a newer one. GitHub can replace a pending run; use a separate workflow run
+ID when recording which rollout received verification.
+
+```bash
+gh workflow run deployed.yml --ref main \
+  -f target=staging -f profile=streaming -f mode=public
+```
+
+Public mode needs no cluster credentials and reports deployment identity as
+unverified. Every initialized suite run retains `result.json`, `junit.xml`,
+redacted traces and `cleanup.json` as a 30-day Actions artifact. Setup failures
+before runner initialization remain visible in the workflow log. Credential
+files are outside the uploaded directory and are removed at job completion.
+Copy unresolved cleanup manifests to durable incident storage before expiry.
+
+### Invoke after rollout completion
+
+The deployment owner invokes the same workflow **after** migrations and the
+serving deployment have finished rolling out. Neither image publication nor
+manifest publication invokes this workflow. In a Flux installation, wait for
+the relevant Kustomization's intended source revision and Deployment rollout,
+then dispatch verification. Do not treat Flux receiving a webhook as completion.
+
+For Kubernetes, add an adapter to the environment-owned `SUITE_TARGET_JSON`:
+
+```json
+{
+  "deployment": {
+    "adapter": "kubernetes",
+    "context": "staging",
+    "namespace": "fountain",
+    "deployment": "fountain",
+    "service": "fountain",
+    "container": "fountain"
+  }
+}
+```
+
+The deployment owner must verify that the configured public URL routes only
+to this Service, including any ingress, CDN, tunnel or regional routing. This
+binding is an explicit trust input; the adapter does not discover it from a
+successful HTTP response. Give its Kubernetes identity only `get` and `list`
+on Deployments, ReplicaSets, Pods, Services and EndpointSlices in this namespace.
+The CI runner must reach the API server. Public-only checks remain usable
+when it cannot.
+
+Obtain the intended image digest from the release's registry manifest or build
+provenance, independently of the running pods. Match the kind of identity
+reported by your container runtime: some report the multi-architecture image
+index digest; others report a platform manifest digest. The registry supplies
+both. This adapter requires one expected digest across the serving deployment;
+a fleet reporting different platform digests needs a future platform-aware
+adapter. Keep the registry's commit-to-digest provenance with the rollout
+record. The suite verifies the digest and does not independently claim a source
+commit from a mutable image tag.
+
+```bash
+kubectl --context staging -n fountain rollout status deployment/fountain --timeout=5m
+gh workflow run deployed.yml --ref main \
+  -f target=staging -f profile=streaming -f mode=rollout \
+  -f expected_digest="$EXPECTED_IMAGE_DIGEST"
+```
+
+The adapter checks observed generation, all desired replicas, Pod ownership,
+container readiness and the intended digest. It reads every EndpointSlice
+for the Service and rejects missing, extra or terminating backends. It repeats
+the observation after public checks and cleanup; changed membership,
+generation, image or restart counts invalidate attribution. Reports retain
+both observations without raw cluster objects. These observations establish
+identity at the boundaries; they are not a continuous audit of all routing
+changes during the run.
+
+For a local invocation of rollout mode, include `expected_digest` in the
+`deployment` object and run the normal CLI with your read-only kubeconfig.
+For other deployment types, run public mode until an external identity adapter
+covers all their serving replicas. Never relabel that result as revision-verified.
+
+### Schedule and failure ownership
+
+After a manual `canary` profile passes against the intended production target,
+configure its Sentry monitor and set the **repository** variable
+`DEPLOYED_CANARY_ENABLED=true`. The schedule runs basic API checks and two
+real execution turns at 00:23, 06:23, 12:23 and 18:23 UTC. It is disabled until
+that explicit configuration exists; this repository change alone does not
+activate production runs.
+
+Reuse the [Sentry Crons channel](../../integrations/sentry.md#crons-an-alert-when-a-scheduled-job-stops)
+for start, success and error check-ins, correlated by workflow run and attempt.
+Configure the monitor on the same
+six-hour schedule, a 30-minute check-in margin, a 12-minute maximum duration,
+an issue threshold of two consecutive failures and recovery after one success.
+Route its issues to the deployment's existing operational owner. Sentry keeps
+the consecutive-failure history and catches missed schedules; no repository
+cache is used as an incident ledger. A monitor delivery failure is visible in
+Actions, and a missing monitor URL fails a scheduled run before inference.
+Confirm the monitor's incident and recovery behavior before enabling the schedule.
+
+Use the existing [stage and provider alert policy](observability.md#which-alerts-you-get)
+to investigate canary failures alongside request IDs, provider health and
+runtime logs. A canary is additional external evidence for the same incident,
+not a separate rollback trigger. Assign setup, ingress, revision and cleanup
+failures to the deployment owner; assign runtime/provider failures to that
+owner for provider triage; assign reproducible contract failures to the API
+maintainer. Record the actual named owners in the environment's operations
+record before activation.
+
+Start with visible verification. Before making this a promotion gate, collect
+at least 28 consecutive scheduled successes over seven days, zero unresolved
+cleanup entries, tested failure/recovery notification delivery and a named
+responding owner. Review durations and provider spending, and separate observed
+provider outages from suite defects. Blocking promotion is a separate change;
+this workflow does not modify a release, deployment or rollback policy.
+
+On failure, inspect the failing phase and `revision` evidence in `result.json`.
+Check cleanup even when public assertions passed. Retry cleanup with the same
+URL and account:
+
+```bash
+node deployed/cli.mjs cleanup --config /tmp/fountain-target.json \
+  --manifest /tmp/fountain-check-001/cleanup.json --out /tmp/fountain-cleanup-001
+```
+
+Keep the manifest until every resource is cleaned. Never delete fixtures by a
+broad name prefix. An interrupted creation may commit after a timeout; an
+unresolved intent remains an incident until reconciled. Preserve failed-run
+evidence when repeating verification, and use a new output directory.


### PR DESCRIPTION
Manifest publication does not prove the intended image is serving or that clients can complete work. Add an on-demand deployed-suite workflow with approved environment targets, serialized runs, fixed resource/turn/deadline budgets, retained redacted evidence, and an opt-in six-hour basic/execution canary using the existing Sentry Crons channel.

Rollout mode checks the expected immutable image digest across every Service backend before and after the public suite and cleanup. It rejects partial rollouts, mixed images, unrelated or terminating backends, and changed pod membership/restart counts. Public mode remains usable without cluster credentials. The operating guide documents the trusted ingress-to-Service binding, fixture provisioning, activation, failure ownership, cleanup, and a measured stability bar before any promotion gate.

Refs #1612; part of #1606.

Validation:
- 58 deployed harness tests pass, including adverse rollout snapshots, pre-mutation failure, post-run attribution failure, CI configuration limits, and correlated monitor check-ins.
- `mix precommit` passes with pinned Elixir 1.19.2 / OTP 28.3 and isolated Postgres 16: static checks, release assembly, 4,474 tests and 6 doctests, zero failures.
- `actionlint`, documentation style, and destink pass.
- The read-only Kubernetes adapter passes against both current production backends, matching independently resolved registry digest `sha256:fca7dfaa3bb8ae02fab9d754b6e0249934245a69af40d88ac612fe404724db01` for timestamp-fix revision `9d643f9f31e03c43503cbb285bfc841d60a19882`.

Activation remains pending: configure dedicated CI environment credentials, monitor routing and named operations owners, prove manual and notification failure/recovery runs, then opt into scheduling. No production canary has been activated. The production streaming recheck passed with Codex/GPT-5.5 on Sprites, and #1624 is closed. That one-time verdict does not activate recurring canaries.


Stack: targets `main`. This is a draft for review; deployed acceptance evidence still outstanding in the linked tracker issues.
