### PR TITLE
Add an isolated deterministic ACP sandbox fixture

### DIFF
--- a/apps/fountain/lib/fountain/agents/agent.ex
+++ b/apps/fountain/lib/fountain/agents/agent.ex
@@ -56,7 +56,14 @@ defmodule Fountain.Agents.Agent do
     timestamps(type: :utc_datetime)
   end
 
-  def runtimes, do: @runtimes
+  @doc "Every runtime that can appear in persisted data, including the opt-in test fixture."
+  def known_runtimes, do: @runtimes ++ ["fountain-fixture"]
+
+  def runtimes do
+    if Fountain.DeployedACPFixture.enabled?(),
+      do: known_runtimes(),
+      else: @runtimes
+  end
 
   @sandbox_modes ~w(ephemeral persistent)
 
@@ -87,7 +94,8 @@ defmodule Fountain.Agents.Agent do
     agent
     |> cast(attrs, cast_fields())
     |> validate_required([:name, :model, :runtime])
-    |> validate_inclusion(:runtime, @runtimes)
+    |> validate_inclusion(:runtime, runtimes())
+    |> validate_fixture_account()
     |> validate_inclusion(:sandbox_mode, @sandbox_modes)
     |> validate_format(:model, ~r{^[a-z0-9_-]+/[a-z0-9._-]+$},
       message: "must be in canonical provider/model_id form"
@@ -100,6 +108,23 @@ defmodule Fountain.Agents.Agent do
     |> validate_permission_policy()
     |> unique_constraint(:name, name: :agents_user_id_name_index)
     |> foreign_key_constraint(:environment_id)
+  end
+
+  defp validate_fixture_account(changeset) do
+    if get_field(changeset, :runtime) == "fountain-fixture" do
+      changeset =
+        if Fountain.DeployedACPFixture.allowed?(get_field(changeset, :user_id)),
+          do: changeset,
+          else: add_error(changeset, :runtime, "fixture is not enabled for this account")
+
+      Enum.reduce([:skills, :mcp_servers, :system], changeset, fn field, acc ->
+        if get_field(acc, field) in [nil, [], %{}, ""],
+          do: acc,
+          else: add_error(acc, field, "is not supported by the scripted fixture")
+      end)
+    else
+      changeset
+    end
   end
 
   # claude / codex / gemini each drive a single provider's CLI and take a
@@ -118,6 +143,14 @@ defmodule Fountain.Agents.Agent do
   # The model id itself is never checked — a model released since the last
   # deploy has to work the day it ships.
   defp validate_model_provider(changeset) do
+    if get_field(changeset, :runtime) == "fountain-fixture" do
+      validate_inclusion(changeset, :model, ["fixture/deterministic-v1"])
+    else
+      validate_packaged_model_provider(changeset)
+    end
+  end
+
+  defp validate_packaged_model_provider(changeset) do
     case Model.provider(get_field(changeset, :model)) do
       nil -> changeset
       actual -> validate_provider(changeset, actual, get_field(changeset, :runtime))
@@ -195,7 +228,7 @@ defmodule Fountain.Agents.Agent do
     runtime = Ecto.Changeset.get_field(changeset, :runtime)
 
     if not Managoat.ACP.Permissions.needs_enforcement?(policy) or
-         Managoat.Runtimes.ACP.asks_permission?(runtime) do
+         Fountain.RuntimeDispatch.asks_permission?(runtime) do
       []
     else
       [

--- a/apps/fountain/lib/fountain/agents/model_catalog.ex
+++ b/apps/fountain/lib/fountain/agents/model_catalog.ex
@@ -102,6 +102,8 @@ defmodule Fountain.Agents.ModelCatalog do
   model id under a known provider.
   """
   @spec suggestions(String.t() | nil) :: [String.t()]
+  def suggestions("fountain-fixture"), do: ["fixture/deterministic-v1"]
+
   def suggestions(runtime) do
     case Model.provider_for_runtime(runtime) do
       nil -> Enum.flat_map(Model.providers(), &suggestions_for_provider/1)

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -1886,7 +1886,7 @@ defmodule Fountain.Conversations do
   def start_conversation(%{"agent_id" => agent_id, "user_id" => user_id} = attrs, opts)
       when is_binary(user_id) do
     with %Agents.Agent{} = agent <- Agents.get_agent(agent_id, user_id) || {:error, :not_found},
-         {:ok, runtime_module} <- Managoat.Runtimes.for_runtime(agent.runtime),
+         {:ok, runtime_module} <- Fountain.RuntimeDispatch.for_agent(agent),
          {:ok, vault_id} <- resolve_vault_id(attrs["vault_id"], user_id, agent),
          {:ok, env_id} <- resolve_environment_id(attrs["environment_id"], user_id, agent),
          {:ok, mode} <- resolve_sandbox_mode(attrs["sandbox_mode"], agent),
@@ -2397,7 +2397,7 @@ defmodule Fountain.Conversations do
        )
        when is_binary(user_id) do
     with %Agents.Agent{} = agent <- Agents.get_agent(agent_id, user_id) || {:error, :not_found},
-         {:ok, _runtime_module} <- Managoat.Runtimes.for_runtime(agent.runtime),
+         {:ok, _runtime_module} <- Fountain.RuntimeDispatch.for_agent(agent),
          {:ok, vault_id} <- resolve_vault_id(attrs["vault_id"], user_id, agent),
          {:ok, env_id} <- resolve_environment_id(attrs["environment_id"], user_id, agent),
          {:ok, perm_policy} <- resolve_permission_policy(attrs["permission_policy"], agent),
@@ -2506,7 +2506,7 @@ defmodule Fountain.Conversations do
   # `ConversationServer` as any prompt is.
   defp check_attach_capacity(%Sandbox{} = sandbox, %Agents.Agent{runtime: runtime}, prompt)
        when is_binary(prompt) and prompt != "" do
-    capacity = Managoat.Runtimes.ACP.concurrency(runtime)
+    capacity = Fountain.RuntimeDispatch.concurrency(runtime)
 
     if _unsafe_sandbox_at_capacity?(sandbox.id, nil, capacity),
       do: {:error, :sandbox_at_capacity},
@@ -2806,7 +2806,7 @@ defmodule Fountain.Conversations do
   # rather than accepted-and-ignored — see `ACP.asks_permission?/1`, measured.
   defp check_runtime_asks(policy, agent) do
     if not Managoat.ACP.Permissions.needs_enforcement?(policy) or
-         Managoat.Runtimes.ACP.asks_permission?(agent.runtime) do
+         Fountain.RuntimeDispatch.asks_permission?(agent.runtime) do
       :ok
     else
       {:error, {:permission_policy_unenforceable, agent.runtime}}
@@ -2859,7 +2859,7 @@ defmodule Fountain.Conversations do
          :ok <- assert_resumable(conv),
          %Agents.Agent{} = agent <-
            (conv.agent_id && Agents._unsafe_get_agent(conv.agent_id)) || {:error, :no_agent},
-         {:ok, runtime_module} <- Managoat.Runtimes.for_runtime(conv.runtime) do
+         {:ok, runtime_module} <- Fountain.RuntimeDispatch.for_agent(conv) do
       case maybe_reuse_sandbox(conv) do
         {:reuse, sandbox_id} ->
           # Reuse provisions nothing, so the fresh-path gates below never ran

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -1330,7 +1330,7 @@ defmodule Fountain.Conversations.ConversationServer do
 
   defp attempt_session_attach(state, running_turn, session, matched_by) do
     conv = Conversations._unsafe_get_conversation!(state.conversation_id)
-    acp? = Managoat.Runtimes.ACP.enabled?(conv.runtime)
+    acp? = Fountain.RuntimeDispatch.acp_enabled?(conv.runtime)
 
     case Managoat.Sandbox.attach(state.handle, session.id, owner: self(), stdin: true) do
       {:ok, idle_command} when acp? and is_nil(running_turn.acp_prompt_id) ->
@@ -2358,7 +2358,7 @@ defmodule Fountain.Conversations.ConversationServer do
     # Keyed on the conversation's runtime, not the agent: a conversation
     # outlives its agent (deletion nilifies agent_id), and for a supported
     # runtime the legacy spawn path no longer exists to fall back to.
-    acp? = Managoat.Runtimes.ACP.enabled?(conv.runtime)
+    acp? = Fountain.RuntimeDispatch.acp_enabled?(conv.runtime)
 
     # The connection outlives the turn (#817). If a peer from an earlier turn
     # is still idle on this machine, this turn rides it — no spawn, no

--- a/apps/fountain/lib/fountain/conversations/provisioning.ex
+++ b/apps/fountain/lib/fountain/conversations/provisioning.ex
@@ -817,8 +817,8 @@ defmodule Fountain.Conversations.Provisioning do
   # install would fail in a way that reads as a protocol bug. Keyed on the
   # conversation's runtime, matching the spawn decision in kick_turn/4.
   def prepare_acp_adapter(handle, runtime, sprite_env) do
-    if Managoat.Runtimes.ACP.enabled?(runtime) do
-      Managoat.Runtimes.ACP.install(handle, runtime, sprite_env)
+    if Fountain.RuntimeDispatch.acp_enabled?(runtime) do
+      Fountain.RuntimeDispatch.install(handle, runtime, sprite_env)
     else
       :ok
     end

--- a/apps/fountain/lib/fountain/conversations/rehydrator.ex
+++ b/apps/fountain/lib/fountain/conversations/rehydrator.ex
@@ -33,7 +33,6 @@ defmodule Fountain.Conversations.Rehydrator do
   require Logger
 
   alias Fountain.{Agents, Conversations}
-  alias Managoat.Runtimes
   alias Fountain.Conversations.ConversationServer
 
   def run(opts \\ []) do
@@ -129,7 +128,7 @@ defmodule Fountain.Conversations.Rehydrator do
   defp spawn_server(conv) do
     with %Agents.Agent{} = _agent <-
            (conv.agent_id && Agents._unsafe_get_agent(conv.agent_id)) || {:skip, :no_agent},
-         {:ok, runtime_module} <- Runtimes.for_runtime(conv.runtime) do
+         {:ok, runtime_module} <- Fountain.RuntimeDispatch.for_agent(conv) do
       Fountain.ConversationSupervisor
       |> Horde.DynamicSupervisor.start_child(
         {ConversationServer,

--- a/apps/fountain/lib/fountain/conversations/turn_machine.ex
+++ b/apps/fountain/lib/fountain/conversations/turn_machine.ex
@@ -683,7 +683,7 @@ defmodule Fountain.Conversations.TurnMachine do
   # a refusal to render rather than an `:ok` followed by a refused stage.
   @spec capacity_gate(String.t(), Conversation.t()) :: :ok | {:error, :sandbox_at_capacity}
   def capacity_gate(sandbox_id, conv) do
-    capacity = Managoat.Runtimes.ACP.concurrency(conv.runtime)
+    capacity = Fountain.RuntimeDispatch.concurrency(conv.runtime)
 
     if Conversations._unsafe_sandbox_at_capacity?(sandbox_id, conv.id, capacity),
       do: {:error, :sandbox_at_capacity},
@@ -712,7 +712,7 @@ defmodule Fountain.Conversations.TurnMachine do
       started_at: now()
     }
 
-    capacity = Managoat.Runtimes.ACP.concurrency(conv.runtime)
+    capacity = Fountain.RuntimeDispatch.concurrency(conv.runtime)
 
     case Conversations._unsafe_create_turn_on_sandbox(attrs, sandbox_id, capacity) do
       {:ok, turn} ->
@@ -849,7 +849,7 @@ defmodule Fountain.Conversations.TurnMachine do
         ) :: {String.t(), [String.t()], keyword()}
   def command(acp?, conv, agent, prompt, mode, runtime_session_id, opts) do
     if acp? do
-      {c, a} = Managoat.Runtimes.ACP.command(conv.runtime)
+      {c, a} = Fountain.RuntimeDispatch.command(conv.runtime)
       # The ACP `cwd` is validated in band by the agent CLI against the real
       # filesystem, so it must be the path a process inside the sandbox sees
       # — identity on hosted providers, the mapped directory on a runner
@@ -857,7 +857,7 @@ defmodule Fountain.Conversations.TurnMachine do
       acp_cwd =
         Managoat.Sandbox.host_path(
           Keyword.fetch!(opts, :handle),
-          Managoat.Runtimes.ACP.cwd(conv.runtime)
+          Fountain.RuntimeDispatch.cwd(conv.runtime)
         )
 
       {c, a, stdin?: true, dir: acp_cwd}

--- a/apps/fountain/lib/fountain/deployed_acp_fixture.ex
+++ b/apps/fountain/lib/fountain/deployed_acp_fixture.ex
@@ -1,0 +1,47 @@
+defmodule Fountain.DeployedACPFixture do
+  @moduledoc """
+  Pinned ACP fixture installed only for the explicitly configured test account.
+
+  This bypasses inference credentials, provider CLI installation and model
+  behavior. Sandbox provisioning, process transport and ACP remain real.
+  The test runner supplies structured scenario prompts, not arbitrary code.
+  """
+
+  @behaviour Managoat.Runtimes
+  @source Path.expand("../../priv/deployed/acp-fixture.mjs", __DIR__)
+  @external_resource @source
+  @script File.read!(@source)
+  @sha256 :crypto.hash(:sha256, @script) |> Base.encode16(case: :lower)
+
+  def enabled? do
+    case Application.get_env(:fountain, :deployed_acp_fixture) do
+      %{enabled: true, user_id: id} when is_binary(id) -> match?({:ok, _}, Ecto.UUID.cast(id))
+      _ -> false
+    end
+  end
+
+  def allowed?(user_id) when is_binary(user_id) do
+    enabled?() and Application.fetch_env!(:fountain, :deployed_acp_fixture).user_id == user_id
+  end
+
+  def allowed?(_), do: false
+  def sha256, do: @sha256
+
+  @impl true
+  def default_env(_agent, _credentials), do: []
+
+  @impl true
+  def prepare_sandbox(handle, agent, _env) do
+    if allowed?(agent.user_id) do
+      Managoat.Sandbox.write_file(handle, "/home/sprite/.fountain-acp-fixture.mjs", @script)
+    else
+      {:error, :fixture_disabled}
+    end
+  end
+
+  @impl true
+  def skills_root, do: "/home/sprite/.fountain-acp-fixture/skills"
+
+  @impl true
+  def skills_sh_agent, do: ""
+end

--- a/apps/fountain/lib/fountain/runtime_dispatch.ex
+++ b/apps/fountain/lib/fountain/runtime_dispatch.ex
@@ -1,0 +1,39 @@
+defmodule Fountain.RuntimeDispatch do
+  @moduledoc """
+  Host dispatch for the four packaged runtimes and the opt-in deployed ACP fixture.
+
+  The fixture is one fixed, account-restricted testing seam for #1611/#1007.
+  It does not register tenant-provided code or replace a packaged runtime.
+  """
+
+  alias Fountain.DeployedACPFixture
+  alias Managoat.Runtimes
+  alias Managoat.Runtimes.ACP
+
+  def for_agent(%{runtime: "fountain-fixture", user_id: user_id}) do
+    if DeployedACPFixture.allowed?(user_id),
+      do: {:ok, DeployedACPFixture},
+      else: {:error, "deployed ACP fixture is not enabled for this account"}
+  end
+
+  def for_agent(%{runtime: runtime}), do: Runtimes.for_runtime(runtime)
+
+  def acp_enabled?(%{runtime: runtime}), do: acp_enabled?(runtime)
+  def acp_enabled?("fountain-fixture"), do: DeployedACPFixture.enabled?()
+  def acp_enabled?(runtime), do: ACP.enabled?(runtime)
+
+  def command("fountain-fixture"), do: {"node", [".fountain-acp-fixture.mjs"]}
+  def command(runtime), do: ACP.command(runtime)
+
+  def cwd("fountain-fixture"), do: "/home/sprite"
+  def cwd(runtime), do: ACP.cwd(runtime)
+
+  def concurrency("fountain-fixture"), do: 1
+  def concurrency(runtime), do: ACP.concurrency(runtime)
+
+  def asks_permission?("fountain-fixture"), do: true
+  def asks_permission?(runtime), do: ACP.asks_permission?(runtime)
+
+  def install(_handle, "fountain-fixture", _env), do: :ok
+  def install(handle, runtime, env), do: ACP.install(handle, runtime, env)
+end

--- a/apps/fountain/lib/fountain/sandbox_files.ex
+++ b/apps/fountain/lib/fountain/sandbox_files.ex
@@ -106,7 +106,7 @@ defmodule Fountain.SandboxFiles do
   def cwd(%Sandbox{} = sandbox) do
     case with_agent(sandbox) do
       %Sandbox{agent: %{runtime: runtime}} when is_binary(runtime) ->
-        Managoat.Runtimes.ACP.cwd(runtime)
+        Fountain.RuntimeDispatch.cwd(runtime)
 
       _ ->
         @home

--- a/apps/fountain/lib/fountain_web/controllers/agent_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/agent_json.ex
@@ -19,7 +19,7 @@ defmodule FountainWeb.AgentJSON do
       # asks this before it opens a session (#702) — the alternative was a
       # hardcoded runtime list in the Go CLI, which would go stale the day a
       # held-back runtime is converted.
-      acp: Managoat.Runtimes.ACP.enabled?(a.runtime),
+      acp: Fountain.RuntimeDispatch.acp_enabled?(a.runtime),
       sandbox_provider: a.sandbox_provider,
       sandbox_mode: a.sandbox_mode,
       environment_id: a.environment_id,

--- a/apps/fountain/lib/fountain_web/controllers/conversation_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_json.ex
@@ -57,7 +57,7 @@ defmodule FountainWeb.ConversationJSON do
       # Derived, never stored — the same signal as on an agent (#702). A
       # protocol client asks before reopening a conversation, because a
       # legacy-runtime one has no ACP transcript to replay.
-      acp: Managoat.Runtimes.ACP.enabled?(c.runtime),
+      acp: Fountain.RuntimeDispatch.acp_enabled?(c.runtime),
       status: c.status,
       runtime_session_id: c.runtime_session_id,
       source: c.source,

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -111,7 +111,7 @@ defmodule FountainWeb.Schemas do
         id: %Schema{type: :string, format: :uuid},
         status: %Schema{type: :string, enum: ~w(pending running idle failed terminated)},
         title: %Schema{type: :string, nullable: true},
-        runtime: %Schema{type: :string, enum: ~w(claude codex gemini opencode)},
+        runtime: %Schema{type: :string, enum: Fountain.Agents.Agent.known_runtimes()},
         mid_turn: %Schema{
           type: :boolean,
           description: "True while this conversation is running a turn on the machine."
@@ -339,7 +339,7 @@ defmodule FountainWeb.Schemas do
           nullable: true,
           description: "Per-launch environment override; null means the agent's environment."
         },
-        runtime: %Schema{type: :string, enum: ~w(claude codex gemini opencode)},
+        runtime: %Schema{type: :string, enum: Fountain.Agents.Agent.known_runtimes()},
         acp: %Schema{
           type: :boolean,
           readOnly: true,
@@ -687,10 +687,11 @@ defmodule FountainWeb.Schemas do
               "codex, google for gemini; opencode accepts any of the three. Other " <>
               "providers are rejected: Fountain has no credentials to export for " <>
               "them. The model id is not checked against a list, so a newly " <>
-              "released model works without a Fountain release.",
+              "released model works without a Fountain release. The isolated fountain-fixture " <>
+              "runtime is the exception: it accepts only fixture/deterministic-v1.",
           pattern: "^[a-z0-9_-]+/[a-z0-9._-]+$"
         },
-        runtime: %Schema{type: :string, enum: ~w(claude codex gemini opencode)},
+        runtime: %Schema{type: :string, enum: Fountain.Agents.Agent.known_runtimes()},
         acp: %Schema{
           type: :boolean,
           readOnly: true,
@@ -860,7 +861,7 @@ defmodule FountainWeb.Schemas do
           type: :string,
           pattern: "^[a-z0-9_-]+/[a-z0-9._-]+$"
         },
-        runtime: %Schema{type: :string, enum: ~w(claude codex gemini opencode)},
+        runtime: %Schema{type: :string, enum: Fountain.Agents.Agent.known_runtimes()},
         sandbox_provider: %Schema{
           type: :string,
           enum: ~w(sprites e2b daytona runner),
@@ -978,7 +979,7 @@ defmodule FountainWeb.Schemas do
         description: %Schema{type: :string},
         system: %Schema{type: :string},
         model: %Schema{type: :string, pattern: "^[a-z0-9_-]+/[a-z0-9._-]+$"},
-        runtime: %Schema{type: :string, enum: ~w(claude codex gemini opencode)},
+        runtime: %Schema{type: :string, enum: Fountain.Agents.Agent.known_runtimes()},
         sandbox_provider: %Schema{
           type: :string,
           enum: ~w(sprites e2b daytona runner),

--- a/apps/fountain/priv/deployed/acp-fixture.mjs
+++ b/apps/fountain/priv/deployed/acp-fixture.mjs
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+// Pinned, dependency-free ACP process for an explicitly enabled test deployment.
+import { randomUUID } from 'node:crypto';
+import { mkdirSync, readFileSync, writeFileSync, renameSync, existsSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+
+const VERSION = 'fountain-acp-fixture/1';
+const MODEL = 'fixture/deterministic-v1';
+const models = { currentModelId: MODEL, availableModels: [{ modelId: MODEL, name: 'Deterministic fixture v1' }] };
+if (process.argv.includes('--version')) { console.log(VERSION); process.exit(0); }
+const root = resolve(process.cwd(), '.fountain-acp-fixture');
+mkdirSync(root, { recursive: true, mode: 0o700 });
+const uuid = value => typeof value === 'string' && /^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$/.test(value);
+const requireThat = condition => { if (!condition) throw new Error('Invalid fixture request'); };
+const send = message => process.stdout.write(JSON.stringify({ jsonrpc: '2.0', ...message }) + '\n');
+const respond = (id, result) => send({ id, result });
+const failure = (id, code, message) => send({ id, error: { code, message } });
+let session, active, initialized = false, permissionCounter = 0;
+const sessionPath = id => join(root, `${id}.json`);
+const artifactPath = nonce => join(root, `${session.id}-${nonce}.txt`);
+function persist() {
+  const path = sessionPath(session.id);
+  writeFileSync(`${path}.tmp`, JSON.stringify(session), { mode: 0o600 });
+  renameSync(`${path}.tmp`, path);
+}
+const update = value => send({ method: 'session/update', params: { sessionId: session.id, update: value } });
+const text = value => update({ sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: value } });
+function tool(nonce, status, content) {
+  update({ sessionUpdate: status === 'pending' ? 'tool_call' : 'tool_call_update', toolCallId: nonce,
+    title: 'fixture-artifact', kind: 'edit', status,
+    ...(content ? { content: [{ type: 'content', content: { type: 'text', text: content } }] } : {}) });
+}
+function finish(turn, result, error) {
+  if (active !== turn) return;
+  session.turns.at(-1).status = error ? 'failed' : result.stopReason;
+  persist();
+  active = null;
+  turn.permission?.resolve(false);
+  if (error) failure(turn.id, -32000, 'Scripted fixture failure');
+  else respond(turn.id, result);
+}
+async function askPermission(turn, nonce) {
+  const id = `fixture-permission-${++permissionCounter}`;
+  const answer = new Promise(resolveAnswer => { turn.permission = { id, resolve: resolveAnswer }; });
+  send({ id, method: 'session/request_permission', params: { sessionId: session.id,
+    toolCall: { toolCallId: nonce, title: 'fixture-artifact', kind: 'edit', status: 'pending' },
+    options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' },
+      { optionId: 'reject-once', name: 'Reject once', kind: 'reject_once' }] } });
+  return answer;
+}
+async function execute(turn, spec) {
+  try {
+    text(`fixture:started:${spec.scenario}:${spec.nonce}\n`);
+    if (spec.delay_ms) await sleep(spec.delay_ms, undefined, { signal: turn.controller.signal });
+    if (spec.scenario === 'fail') return finish(turn, null, true);
+    if (spec.scenario === 'wait') {
+      // The runner must cancel this turn; a bounded fallback makes a lost client visible.
+      await sleep(120000, undefined, { signal: turn.controller.signal });
+      return finish(turn, null, true);
+    }
+    const path = artifactPath(spec.nonce);
+    if (spec.scenario === 'write' || spec.scenario === 'permission') {
+      tool(spec.nonce, 'pending');
+      if (spec.scenario === 'permission' && !await askPermission(turn, spec.nonce)) {
+        if (active !== turn) return;
+        text(`fixture:permission:denied:${spec.nonce}\n`);
+        tool(spec.nonce, 'failed', 'Permission denied; no file written');
+        return finish(turn, { stopReason: 'end_turn' });
+      }
+      turn.controller.signal.throwIfAborted();
+      requireThat(!existsSync(path));
+      writeFileSync(path, `${spec.nonce}\n`, { flag: 'wx', mode: 0o600 });
+      session.artifacts[spec.nonce] = { writes: 1 };
+      persist();
+      tool(spec.nonce, 'completed', `Wrote ${path}`);
+    } else {
+      requireThat(session.artifacts[spec.nonce]?.writes === 1);
+      tool(spec.nonce, 'pending');
+      requireThat(readFileSync(path, 'utf8') === `${spec.nonce}\n`);
+      tool(spec.nonce, 'completed', `Read ${path}`);
+    }
+    text(`fixture:artifact:${spec.nonce}:writes=1:turns=${session.turns.length}:path=${path}\n`);
+    finish(turn, { stopReason: 'end_turn', usage: { inputTokens: 0, outputTokens: 0 } });
+  } catch {
+    if (active === turn) finish(turn, null, true);
+  }
+}
+function dispatch(message) {
+  const { id, method, params = {} } = message;
+  if (method === undefined && id === active?.permission?.id) {
+    const permission = active.permission;
+    active.permission = null;
+    const outcome = message.result?.outcome;
+    permission.resolve(outcome?.outcome === 'selected' && outcome.optionId === 'allow-once');
+    return;
+  }
+  if (method === 'initialize') {
+    requireThat(!initialized && params.protocolVersion === 1 && id !== undefined);
+    initialized = true;
+    return respond(id, { protocolVersion: 1,
+    agentInfo: { name: VERSION, version: '1' }, authMethods: [],
+    agentCapabilities: { sessionCapabilities: { resume: {} } } });
+  }
+  requireThat(initialized);
+  if (method === 'session/new') {
+    requireThat(!active && !session);
+    session = { version: VERSION, id: randomUUID(), turns: [], artifacts: {} };
+    persist();
+    return respond(id, { sessionId: session.id, models });
+  }
+  if (method === 'session/resume') {
+    requireThat(!active && !session && uuid(params.sessionId));
+    const stored = JSON.parse(readFileSync(sessionPath(params.sessionId), 'utf8'));
+    requireThat(stored.version === VERSION && stored.id === params.sessionId);
+    session = stored;
+    return respond(id, { models });
+  }
+  if (method === 'session/set_model') {
+    requireThat(session && params.sessionId === session.id && params.modelId === MODEL);
+    return respond(id, {});
+  }
+  if (method === 'session/cancel') {
+    if (active && params.sessionId === session.id) {
+      const turn = active;
+      turn.controller.abort();
+      finish(turn, { stopReason: 'cancelled' });
+    }
+    return;
+  }
+  if (method === 'session/prompt') {
+    requireThat(session && params.sessionId === session.id && !active && id !== undefined);
+    requireThat(Array.isArray(params.prompt) && params.prompt.length === 1 && params.prompt[0].type === 'text');
+    const spec = JSON.parse(params.prompt[0].text);
+    requireThat(spec.fixture === VERSION && ['write', 'read', 'permission', 'wait', 'fail'].includes(spec.scenario) && uuid(spec.nonce));
+    requireThat(Object.keys(spec).every(k => ['fixture', 'scenario', 'nonce', 'delay_ms'].includes(k)));
+    requireThat(spec.delay_ms === undefined || (Number.isSafeInteger(spec.delay_ms) && spec.delay_ms >= 0 && spec.delay_ms <= 30000));
+    requireThat(session.turns.length < 16);
+    const turn = { id, controller: new AbortController(), permission: null };
+    session.turns.push({ scenario: spec.scenario, nonce: spec.nonce, status: 'running' });
+    persist();
+    active = turn;
+    void execute(turn, spec);
+    return;
+  }
+  if (id !== undefined) failure(id, -32601, 'Unsupported fixture method');
+}
+let pending = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', chunk => {
+  pending += chunk;
+  while (pending.includes('\n')) {
+    const newline = pending.indexOf('\n');
+    const line = pending.slice(0, newline);
+    pending = pending.slice(newline + 1);
+    if (Buffer.byteLength(line) > 65536) { process.exitCode = 2; stop(); break; }
+    let message;
+    try { message = JSON.parse(line); requireThat(message?.jsonrpc === '2.0'); dispatch(message); }
+    catch { failure(message?.id ?? null, -32602, 'Invalid fixture request'); }
+  }
+  if (Buffer.byteLength(pending) > 65536) { process.exitCode = 2; stop(); }
+});
+function stop() {
+  if (active) { const turn = active; turn.controller.abort(); finish(turn, { stopReason: 'cancelled' }); }
+  process.stdin.destroy();
+}
+process.stdin.on('end', stop);
+process.on('SIGTERM', stop);
+process.on('SIGINT', stop);

--- a/apps/fountain/test/fountain/deployed_acp_fixture_test.exs
+++ b/apps/fountain/test/fountain/deployed_acp_fixture_test.exs
@@ -1,0 +1,103 @@
+defmodule Fountain.DeployedACPFixtureTest do
+  # Enabling this runtime changes application-wide admission and catalog state.
+  use ExUnit.Case, async: false
+
+  alias Fountain.Agents.Agent
+  alias Fountain.DeployedACPFixture
+  alias Fountain.RuntimeDispatch
+
+  @owner "aaaaaaaa-1111-4111-8111-111111111111"
+  @other "bbbbbbbb-2222-4222-8222-222222222222"
+
+  setup do
+    previous = Application.get_env(:fountain, :deployed_acp_fixture)
+    Application.delete_env(:fountain, :deployed_acp_fixture)
+
+    on_exit(fn ->
+      if previous,
+        do: Application.put_env(:fountain, :deployed_acp_fixture, previous),
+        else: Application.delete_env(:fountain, :deployed_acp_fixture)
+    end)
+
+    :ok
+  end
+
+  defp attrs(user_id \\ @owner) do
+    %{
+      name: "fixture",
+      runtime: "fountain-fixture",
+      model: "fixture/deterministic-v1",
+      user_id: user_id
+    }
+  end
+
+  defp enable do
+    Application.put_env(:fountain, :deployed_acp_fixture, %{enabled: true, user_id: @owner})
+  end
+
+  test "fixture is absent and denied by default, and requires a valid configured account" do
+    refute DeployedACPFixture.enabled?()
+    refute "fountain-fixture" in Agent.runtimes()
+    refute Agent.changeset(%Agent{}, attrs()).valid?
+    assert {:error, _} = RuntimeDispatch.for_agent(attrs())
+
+    Application.put_env(:fountain, :deployed_acp_fixture, %{enabled: true, user_id: "invalid"})
+    refute DeployedACPFixture.enabled?()
+  end
+
+  test "explicit fixture admission is restricted at creation and runtime dispatch" do
+    enable()
+    assert "fountain-fixture" in Agent.runtimes()
+    assert Agent.changeset(%Agent{}, attrs()).valid?
+    assert {:ok, DeployedACPFixture} = RuntimeDispatch.for_agent(attrs())
+    refute Agent.changeset(%Agent{}, attrs(@other)).valid?
+    assert {:error, _} = RuntimeDispatch.for_agent(attrs(@other))
+
+    assert {:error, :fixture_disabled} =
+             DeployedACPFixture.prepare_sandbox(nil, attrs(@other), [])
+
+    Application.put_env(:fountain, :deployed_acp_fixture, %{enabled: false, user_id: @owner})
+    assert {:error, _} = RuntimeDispatch.for_agent(attrs())
+  end
+
+  test "fixture cannot present a real model, ignored persona, skill or MCP configuration as working" do
+    enable()
+
+    for additions <- [
+          %{model: "anthropic/claude-haiku-4-5"},
+          %{system: "ignored persona"},
+          %{skills: [%{"name" => "ignored"}]},
+          %{mcp_servers: %{"ignored" => %{"command" => "echo"}}}
+        ] do
+      refute Agent.changeset(%Agent{}, Map.merge(attrs(), additions)).valid?
+    end
+
+    assert DeployedACPFixture.default_env(attrs(), %{anthropic_api_key: "not-exported"}) == []
+  end
+
+  test "packaged runtimes retain their dispatcher, ACP command, concurrency and permissions" do
+    enable()
+
+    for runtime <- ~w(claude codex gemini opencode) do
+      assert RuntimeDispatch.for_agent(%{runtime: runtime}) ==
+               Managoat.Runtimes.for_runtime(runtime)
+
+      assert RuntimeDispatch.command(runtime) == Managoat.Runtimes.ACP.command(runtime)
+      assert RuntimeDispatch.concurrency(runtime) == Managoat.Runtimes.ACP.concurrency(runtime)
+
+      assert RuntimeDispatch.asks_permission?(runtime) ==
+               Managoat.Runtimes.ACP.asks_permission?(runtime)
+    end
+
+    assert RuntimeDispatch.command("fountain-fixture") == {"node", [".fountain-acp-fixture.mjs"]}
+    assert RuntimeDispatch.concurrency("fountain-fixture") == 1
+    assert RuntimeDispatch.acp_enabled?("fountain-fixture")
+  end
+
+  test "the installed source has stable digest evidence" do
+    source = Application.app_dir(:fountain, "priv/deployed/acp-fixture.mjs") |> File.read!()
+
+    assert DeployedACPFixture.sha256() ==
+             Base.encode16(:crypto.hash(:sha256, source), case: :lower)
+  end
+end

--- a/apps/fountain/test/fountain_web/schema_enum_guardrail_test.exs
+++ b/apps/fountain/test/fountain_web/schema_enum_guardrail_test.exs
@@ -68,9 +68,12 @@ defmodule FountainWeb.SchemaEnumGuardrailTest do
     {FountainWeb.Schemas.AdminRoleRequest, "role"} => {User, :roles},
     {FountainWeb.Schemas.AdminUser, "role"} => {User, :roles},
     {FountainWeb.Schemas.AuthMeResponse, "role"} => {User, :roles},
-    {FountainWeb.Schemas.Agent, "runtime"} => {Agent, :runtimes},
-    {FountainWeb.Schemas.AgentRequest, "runtime"} => {Agent, :runtimes},
-    {FountainWeb.Schemas.AgentUpdate, "runtime"} => {Agent, :runtimes},
+    # Known values include fixture rows retained after a test runtime is disabled.
+    # Catalog/admission use the separately tested enabled-runtime list, as sandbox
+    # providers distinguish known_providers/0 from enabled_providers/0.
+    {FountainWeb.Schemas.Agent, "runtime"} => {Agent, :known_runtimes},
+    {FountainWeb.Schemas.AgentRequest, "runtime"} => {Agent, :known_runtimes},
+    {FountainWeb.Schemas.AgentUpdate, "runtime"} => {Agent, :known_runtimes},
     {FountainWeb.Schemas.Agent, "sandbox_provider"} =>
       {Fountain.SandboxProviders, :known_providers},
     {FountainWeb.Schemas.Sandbox, "provider"} => {Fountain.SandboxProviders, :known_providers},
@@ -81,7 +84,7 @@ defmodule FountainWeb.SchemaEnumGuardrailTest do
     # A conversation's runtime is copied from its agent at spawn, so it must
     # speak the same vocabulary even though the column carries no inclusion
     # validation of its own.
-    {FountainWeb.Schemas.Conversation, "runtime"} => {Agent, :runtimes},
+    {FountainWeb.Schemas.Conversation, "runtime"} => {Agent, :known_runtimes},
     {FountainWeb.Schemas.Agent, "avatar_media_type"} => {Images, :valid_media_types},
     {FountainWeb.Schemas.AvatarRequest, "media_type"} => {Images, :valid_media_types},
     {FountainWeb.Schemas.ImageInput, "media_type"} => {Images, :valid_media_types},
@@ -126,7 +129,7 @@ defmodule FountainWeb.SchemaEnumGuardrailTest do
     {FountainWeb.Schemas.SandboxDetail, "provider"} =>
       {Fountain.SandboxProviders, :known_providers},
     {FountainWeb.Schemas.SandboxConversation, "status"} => {Conversation, :statuses},
-    {FountainWeb.Schemas.SandboxConversation, "runtime"} => {Agent, :runtimes},
+    {FountainWeb.Schemas.SandboxConversation, "runtime"} => {Agent, :known_runtimes},
     {FountainWeb.Schemas.Turn, "status"} => {Turn, :statuses},
     {FountainWeb.Schemas.Turn, "origin"} => {Turn, :origins},
     {FountainWeb.Schemas.Teammate, "presence.state"} =>

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -40,6 +40,15 @@ config :fountain, FountainWeb.Endpoint,
 
 env = config_env()
 
+# Fixed testing runtime; never enabled by the presence of ordinary provider keys.
+# Keep tests independent of the operator's shell environment.
+if env != :test do
+  config :fountain, :deployed_acp_fixture, %{
+    enabled: System.get_env("DEPLOYED_ACP_FIXTURE_ENABLED") == "true",
+    user_id: System.get_env("DEPLOYED_ACP_FIXTURE_USER_ID")
+  }
+end
+
 # The dev fallback below is derived from a constant committed to this repo, so it
 # must never be reachable in :prod. The guard is deliberately on config_env()
 # alone — gating it on `server?` too would hand that public key to every prod

--- a/deployed/README.md
+++ b/deployed/README.md
@@ -222,3 +222,85 @@ Add profiles as ordinary modules using `ctx.check`, `ctx.client`, and
 request. Do not inject database rows, import server factories, or substitute
 an in-process Fountain for a deployed verdict. Existing SDK conformance
 remains separate and runnable with its existing commands.
+
+## Deterministic ACP fixture
+
+The `deterministic` profile runs the pinned `fountain-fixture` runtime in a
+real sandbox. Enable it only on an isolated test instance. On the server,
+set both `DEPLOYED_ACP_FIXTURE_ENABLED=true` and
+`DEPLOYED_ACP_FIXTURE_USER_ID` to the dedicated, verified test account's UUID.
+The runtime is absent by default. Another account cannot create a fixture
+agent or start one, and disabling it prevents launch and rehydration. The
+normal account suspension, billing, sandbox placement and quota checks still
+apply. Do not enable this runtime on the public production instance.
+
+The fixture is a fixed Node program bundled in
+`apps/fountain/priv/deployed/acp-fixture.mjs`. Provisioning writes its exact
+bytes to the sandbox; the suite independently reads those bytes through the
+public file API and checks their SHA-256 against its pinned checkout. It uses
+Node from the sandbox image or runner's PATH and requires Node 18 or newer.
+There is no npm install and no arbitrary script URL, command or code supplied
+by a tenant. Use the normal real-model profile as separate required evidence.
+
+```json
+{
+  "base_url": "https://your-test-instance.example",
+  "credentials": {
+    "primary": "FOUNTAIN_SUITE_KEY",
+    "secondary": "FOUNTAIN_SUITE_OTHER_KEY"
+  },
+  "profiles": ["deterministic"],
+  "required_capabilities": {
+    "runtimes": ["fountain-fixture"],
+    "sandbox_providers": ["runner"]
+  },
+  "fixture": {
+    "sandbox_provider": "runner",
+    "provision_ms": 120000,
+    "turn_ms": 30000,
+    "max_turns": 7
+  },
+  "limits": {
+    "request_ms": 10000,
+    "run_ms": 300000,
+    "cleanup_ms": 60000,
+    "resources": 3
+  }
+}
+```
+
+Run this configuration with the normal `deployed/cli.mjs run` command.
+For a runner target, start a real `fountain runner` under the primary test
+account, with a separate temporary sandbox root. Its process backend runs
+as the runner's user; use a dedicated test machine. Hosted sandbox providers
+use the same profile, but require their own provider credentials and validation.
+Missing runtime or provider capability fails setup before fixture creation.
+
+Seven sequential prompts check delayed output while a turn is still running,
+a real nonce file and follow-up, strict stream/history replay agreement,
+permission approval and denial through the public request API, cancellation,
+an explicit ACP error, and a successful resume after that error. The permission
+checks reject an unknown option and a second tenant's answer. File reads prove
+that denied or cancelled work did not write an artifact. Session identity and
+the fixture's persisted turn/write counts prove that the final follow-up used
+the existing session and wrote the original artifact only once. Each phase
+checks its terminal turn and rejects any extra or dangling active turn.
+Cleanup terminates the sandbox and removes all three run-owned resources.
+
+`fixture` in the report records process version, source digest, scenario,
+permission outcome and session evidence. `prompt_attempts` counts all seven
+submissions; `inference_attempts` is zero. The cleanup manifest retains its
+legacy `inference_attempts` field as the durable **prompt** reservation counter.
+Do not treat fixture success as evidence of model quality, provider inference
+credentials, built-in CLI/adapter installation, model selection in those CLIs,
+MCP configuration, system prompts or skill consumption. Fixture agents reject
+personas, tenant skills and MCP settings instead of silently ignoring them.
+The fixture has only one model, `fixture/deterministic-v1`.
+
+This is the narrow host seam for #1611 and gate 1 of #1007. Runtime dispatch
+continues to delegate the four built-ins to `Managoat.Runtimes`; the fixture
+has a separate name, fixed command, account admission rule and one-turn sandbox
+capacity. There is no tenant runtime CRUD, general harness registry, custom
+bootstrap or permission claim for arbitrary code. Those remain #1007 work.
+The deterministic profile runs separately from real-model canaries and is not
+an option in the production CI workflow.

--- a/deployed/lib/runner.mjs
+++ b/deployed/lib/runner.mjs
@@ -10,9 +10,10 @@ import { atomicJson, Fixtures } from './fixtures.mjs';
 import { probe } from '../profiles/probe.mjs';
 import { basic } from '../profiles/basic.mjs';
 import { execution } from '../profiles/execution.mjs';
+import { deterministic } from '../profiles/deterministic.mjs';
 
 export const VERSION = '0.1.0';
-export const profiles = { probe, basic, execution, streaming: execution };
+export const profiles = { probe, basic, execution, streaming: execution, deterministic };
 const contractPath = fileURLToPath(new URL('../../sdk/contract/contract.json', import.meta.url));
 
 function requireThat(condition, message) { if (!condition) throw new Error(message); }
@@ -24,7 +25,7 @@ function positive(value, fallback, max) {
 
 export function configFrom(path, env = process.env) {
   const config = JSON.parse(readFileSync(path, 'utf8'));
-  const allowed = ['base_url', 'credentials', 'profiles', 'contract', 'required_capabilities', 'optional_capabilities', 'limits', 'execution', 'deployment'];
+  const allowed = ['base_url', 'credentials', 'profiles', 'contract', 'required_capabilities', 'optional_capabilities', 'limits', 'execution', 'deployment', 'fixture'];
   requireThat(Object.keys(config).every(key => allowed.includes(key)), 'Unknown configuration field');
   const url = new URL(config.base_url);
   requireThat(['http:', 'https:'].includes(url.protocol) && !url.username && !url.password && !url.search && !url.hash,
@@ -39,7 +40,7 @@ export function configFrom(path, env = process.env) {
     config.profiles.every(name => Object.hasOwn(profiles, name)), 'Unknown, empty, or duplicate profile selection');
   requireThat(Object.keys(config.credentials).every(k => ['primary', 'secondary'].includes(k)), 'Unknown credential role');
   requireThat(!(config.profiles.includes('execution') && config.profiles.includes('streaming')), 'Select streaming or execution; streaming already includes execution');
-  if (config.profiles.some(name => ['basic', 'execution', 'streaming'].includes(name))) {
+  if (config.profiles.some(name => ['basic', 'execution', 'streaming', 'deterministic'].includes(name))) {
     requireThat(typeof config.credentials.secondary === 'string' && /^[A-Z][A-Z0-9_]*$/.test(config.credentials.secondary), 'Selected profile requires credentials.secondary environment variable');
     config.secondaryKey = env[config.credentials.secondary];
     requireThat(typeof config.secondaryKey === 'string' && config.secondaryKey.trim().length > 0, `Missing test credential: ${config.credentials.secondary}`);
@@ -53,6 +54,15 @@ export function configFrom(path, env = process.env) {
     settings.provision_ms = positive(settings.provision_ms, 120000, 300000);
     settings.turn_ms = positive(settings.turn_ms, 90000, 300000);
     requireThat(settings.max_turns === 2, 'Execution must explicitly authorize max_turns: 2');
+  }
+  if (config.profiles.includes('deterministic')) {
+    requireThat(config.profiles.length === 1 && !config.execution, 'Run deterministic fixture separately from real-model profiles');
+    const fixture = config.fixture;
+    requireThat(fixture && Object.keys(fixture).every(k => ['sandbox_provider', 'provision_ms', 'turn_ms', 'max_turns'].includes(k)), 'Expected explicit fixture configuration');
+    requireThat(['sprites', 'e2b', 'daytona', 'runner'].includes(fixture.sandbox_provider), 'Pin a fixture sandbox provider');
+    fixture.provision_ms = positive(fixture.provision_ms, 120000, 300000);
+    fixture.turn_ms = positive(fixture.turn_ms, 30000, 60000);
+    requireThat(fixture.max_turns === 7, 'Fixture requires an explicit seven-prompt budget');
   }
   config.contract = config.contract ? resolve(dirname(path), config.contract) : contractPath;
   const limits = config.limits ?? {};
@@ -118,7 +128,7 @@ export async function run({ configPath, out, manifestPath, signal, env = process
     redactor.add(config.secondaryKey);
     report.target = config.base_url;
     report.profiles = config.profiles;
-    report.limits = { ...config.limits, concurrency: 1, inference_turns: config.execution?.max_turns ?? 0 };
+    report.limits = { ...config.limits, concurrency: 1, inference_turns: config.execution?.max_turns ?? 0, fixture_prompts: config.fixture?.max_turns ?? 0 };
     const contract = new Contract(config.contract);
     report.contract_sha256 = contract.sha256;
     const timeout = AbortSignal.timeout(config.limits.run_ms);
@@ -152,6 +162,10 @@ export async function run({ configPath, out, manifestPath, signal, env = process
           requireThat(available.runtimes.includes(config.execution.runtime), 'Execution runtime is unavailable');
           requireThat(available.sandbox_providers.includes(config.execution.sandbox_provider), 'Execution sandbox provider is unavailable');
         }
+        if (config.profiles.includes('deterministic')) {
+          requireThat(available.runtimes.includes('fountain-fixture'), 'Deterministic runtime is not enabled on this target');
+          requireThat(available.sandbox_providers.includes(config.fixture.sandbox_provider), 'Fixture sandbox provider is unavailable');
+        }
         for (const [kind, names] of Object.entries(config.required_capabilities)) {
           for (const name of names) requireThat(available[kind].includes(name), `Missing required ${kind}: ${name}`);
         }
@@ -177,7 +191,8 @@ export async function run({ configPath, out, manifestPath, signal, env = process
     if (fixtures) {
       const failures = await fixtures.cleanup(AbortSignal.timeout(config.limits.cleanup_ms));
       report.cleanup = { failures, remaining: fixtures.manifest.resources.filter(r => r.state !== 'cleaned').length };
-      report.inference_attempts = fixtures.manifest.inference_attempts ?? 0;
+      report.prompt_attempts = fixtures.manifest.inference_attempts ?? 0;
+      report.inference_attempts = config.profiles.includes('deterministic') ? 0 : report.prompt_attempts;
       if (failures.length) {
         report.status = 'cleanup_failed';
         report.checks.push({ name: 'cleanup', status: 'failed', duration_ms: 0, error: 'Resources remain; see cleanup manifest and result.json' });

--- a/deployed/profiles/deterministic.mjs
+++ b/deployed/profiles/deterministic.mjs
@@ -1,0 +1,130 @@
+import { randomUUID, createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { ensure, phaseSignal, history, turnMetadata, waitFor, watchUntil } from '../lib/execution.mjs';
+import { streamEvents } from '../lib/sse.mjs';
+import { verifyReplay } from '../lib/replay.mjs';
+
+const version = 'fountain-acp-fixture/1';
+const source = new URL('../../apps/fountain/priv/deployed/acp-fixture.mjs', import.meta.url);
+export async function deterministic(ctx) {
+  const { client, fixtures, config, check } = ctx;
+  const settings = config.fixture;
+  const report = ctx.report.fixture = { version, runtime: 'fountain-fixture', model: 'fixture/deterministic-v1',
+    sandbox_provider: settings.sandbox_provider, source_sha256: createHash('sha256').update(readFileSync(source)).digest('hex'),
+    inference: false, turns: [] };
+  let conversation, provision, sessionId, cursor, number = 0, first, second;
+  const nonce = randomUUID();
+  const artifact = n => `.fountain-acp-fixture/${sessionId}-${n}.txt`;
+  const readFile = async (path, expected = 200) => {
+    const { body } = await client.request('GET', `/api/sandboxes/${conversation.sandbox_id}/file?path=${encodeURIComponent(path)}&max_bytes=65536`, { expected });
+    if (expected !== 200) return;
+    ensure(!body.data.truncated, 'Fixture file was truncated');
+    return body.data.encoding === 'base64' ? Buffer.from(body.data.content, 'base64') : Buffer.from(body.data.content);
+  };
+  if (!await check('fixture/setup', async () => {
+    const { body } = await client.request('GET', '/api/auth/me', { key: config.secondaryKey, expected: 200 });
+    ensure(body.email_verified && body.id !== ctx.report.owner_id, 'Fixture requires a distinct verified second tenant');
+    const environment = await fixtures.create('environment');
+    const agent = await fixtures.create('agent', { runtime: report.runtime, model: report.model,
+      environment_id: environment.id, sandbox_provider: settings.sandbox_provider, sandbox_mode: 'ephemeral',
+      permission_policy: { default: 'ask' } });
+    conversation = await fixtures.create('conversation', { agent_id: agent.id, environment_id: environment.id });
+    const signal = phaseSignal(ctx.signal, settings.provision_ms);
+    provision = await watchUntil(client, conversation.id, signal, event => event.kind === 'stage' && event.stage === 'provision' && event.state === 'done');
+    cursor = provision.cursor;
+    const detail = await client.request('GET', `/api/conversations/${conversation.id}`, { expected: 200 });
+    conversation = detail.body.data;
+    ensure(conversation.sandbox?.status === 'ready' && conversation.sandbox.mode === 'ephemeral' &&
+      conversation.sandbox.provider === settings.sandbox_provider, 'Fixture sandbox does not match requested provider/mode');
+    ensure(createHash('sha256').update(await readFile('.fountain-acp-fixture.mjs')).digest('hex') === report.source_sha256,
+      'Installed ACP fixture bytes differ from the pinned suite source');
+    report.conversation_id = conversation.id;
+    report.sandbox_id = conversation.sandbox_id;
+  })) return;
+
+  async function scenario(name, n, { answer, interrupt = false, expected = 'completed', delay = 0 } = {}) {
+    const signal = phaseSignal(ctx.signal, settings.turn_ms);
+    const prompt = JSON.stringify({ fixture: version, scenario: name, nonce: n, delay_ms: delay });
+    fixtures.reserveTurn(conversation.id, settings.max_turns);
+    number++;
+    const response = await client.request('POST', `/api/conversations/${conversation.id}/prompts`, { body: { prompt }, expected: 200, signal });
+    ensure(response.body.status === 'queued', 'Fixture prompt was not acknowledged');
+    const events = [];
+    let terminal, permissionAnswered = false, interrupted = false, observedRunning = false;
+    for await (const frame of streamEvents(client, `/api/conversations/${conversation.id}/stream?blocks=true`, { signal, after: cursor })) {
+      const event = frame.event;
+      ensure(event.id > cursor, 'Fixture stream duplicated or reordered an event');
+      cursor = event.id;
+      events.push(frame);
+      const blocks = event.blocks ?? [];
+      if (blocks.some(b => b.kind === 'text' && b.body?.includes(`fixture:started:${name}:${n}`)) && (delay || interrupt)) {
+        const running = await client.request('GET', `/api/conversations/${conversation.id}/turns`, { expected: 200, signal });
+        ensure(running.body.data.some(t => t.turn_number === number && t.status === 'running'), 'Fixture output arrived after turn completion');
+        observedRunning = true;
+        if (interrupt && !interrupted) {
+          await client.request('POST', `/api/conversations/${conversation.id}/interrupt`, { expected: 204, signal });
+          interrupted = true;
+        }
+      }
+      const permission = blocks.find(b => b.kind === 'permission_request');
+      if (permission && !permissionAnswered) {
+        ensure(answer && permission.options.some(o => o.optionId === answer), 'Fixture requested an unexpected permission');
+        const path = `/api/conversations/${conversation.id}/requests/${encodeURIComponent(permission.request_id)}`;
+        await client.request('POST', path, { key: config.secondaryKey, body: { option_id: answer }, expected: 404, signal });
+        await client.request('POST', path, { body: { option_id: 'not-offered' }, expected: 422, signal });
+        await client.request('POST', path, { body: { option_id: answer }, expected: 200, signal });
+        permissionAnswered = true;
+      }
+      const meta = turnMetadata(event);
+      if (meta?.turn_number === number && ['done', 'failed', 'interrupted'].includes(event.state)) { terminal = event; break; }
+    }
+    ensure(terminal?.state === { completed: 'done', failed: 'failed', interrupted: 'interrupted' }[expected], 'Fixture turn ended in an unexpected SSE state');
+    ensure(!answer || permissionAnswered, 'Fixture never requested public permission');
+    ensure(!interrupt || interrupted, 'Fixture was not interrupted through the public API');
+    ensure(!(delay || interrupt) || observedRunning, 'Fixture did not prove incremental output while running');
+    const turns = await waitFor(client, `/api/conversations/${conversation.id}/turns`, signal,
+      rows => rows.some(t => t.turn_number === number && t.status === expected));
+    ensure(turns.length === number && turns.every(t => t.status !== 'running'), 'Fixture left an extra or active turn');
+    const turn = turns.find(t => t.turn_number === number);
+    ensure(turn.prompt === prompt && turn.id === (turnMetadata(terminal)?.turn_id ?? terminal.turn_id), 'Fixture turn identity differs from accepted work');
+    const detail = await client.request('GET', `/api/conversations/${conversation.id}`, { expected: 200, signal });
+    if (sessionId) ensure(detail.body.data.runtime_session_id === sessionId, 'Fixture lost the persisted ACP session');
+    else sessionId = detail.body.data.runtime_session_id;
+    ensure(typeof sessionId === 'string', 'Fixture did not expose a runtime session');
+    const stored = await history(client, conversation.id, signal);
+    report.turns.push({ number, scenario: name, id: turn.id, status: turn.status, permission_answer: answer ?? null,
+      observed_running: observedRunning, interrupted, session_id: sessionId });
+    return { events, cursor, stored: stored.events };
+  }
+  if (!await check('fixture/artifact-and-incremental-output', async () => {
+    first = await scenario('write', nonce, { delay: 1500 });
+    ensure((await readFile(artifact(nonce))).toString() === `${nonce}\n`, 'Fixture artifact bytes differ');
+  })) return;
+  if (!await check('fixture/follow-up-and-replay', async () => {
+    second = await scenario('read', nonce);
+    ctx.report.streaming = { provision_cursor: provision.cursor, reconnect_cursor: first.cursor };
+    await verifyReplay(ctx, conversation.id, first, second, phaseSignal(ctx.signal, settings.turn_ms));
+  })) return;
+  for (const answer of ['allow-once', 'reject-once']) {
+    if (!await check(`fixture/permission-${answer}`, async () => {
+      const n = randomUUID();
+      await scenario('permission', n, { answer });
+      if (answer === 'allow-once') ensure((await readFile(artifact(n))).toString() === `${n}\n`, 'Approved permission did not write the artifact');
+      else await readFile(artifact(n), 404);
+    })) return;
+  }
+  if (!await check('fixture/cancellation', async () => {
+    const n = randomUUID();
+    await scenario('wait', n, { interrupt: true, expected: 'interrupted' });
+    await readFile(artifact(n), 404);
+  })) return;
+  if (!await check('fixture/explicit-failure', async () => {
+    await scenario('fail', randomUUID(), { expected: 'failed' });
+  })) return;
+  await check('fixture/resume-after-failure', async () => {
+    const last = await scenario('read', nonce);
+    ensure((await readFile(artifact(nonce))).toString() === `${nonce}\n`, 'Resume lost the artifact');
+    const text = last.events.flatMap(f => f.event.blocks ?? []).filter(b => b.kind === 'text').map(b => b.body ?? '').join('');
+    ensure(text.includes(`writes=1:turns=${settings.max_turns}:`), 'Resume did not preserve fixture side-effect/turn accounting');
+  });
+}

--- a/deployed/test/acp-fixture.test.mjs
+++ b/deployed/test/acp-fixture.test.mjs
@@ -1,0 +1,152 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { mkdtempSync, readFileSync, existsSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { randomUUID } from 'node:crypto';
+import { EventEmitter, once } from 'node:events';
+
+const executable = fileURLToPath(new URL('../../apps/fountain/priv/deployed/acp-fixture.mjs', import.meta.url));
+const version = 'fountain-acp-fixture/1';
+async function processFixture(t, existingRoot) {
+  const root = existingRoot ?? mkdtempSync(join(tmpdir(), 'fountain-acp-process-'));
+  const child = spawn(process.execPath, [executable], { cwd: root, stdio: ['pipe', 'pipe', 'pipe'] });
+  const events = new EventEmitter();
+  const frames = [];
+  let pending = '', errors = '', nextId = 0;
+  child.stdout.setEncoding('utf8');
+  child.stderr.setEncoding('utf8');
+  child.stdout.on('data', chunk => {
+    pending += chunk;
+    while (pending.includes('\n')) {
+      const at = pending.indexOf('\n');
+      frames.push(JSON.parse(pending.slice(0, at)));
+      pending = pending.slice(at + 1);
+      events.emit('frame');
+    }
+  });
+  child.stderr.on('data', chunk => { errors += chunk; });
+  child.on('exit', () => events.emit('frame'));
+  async function waitFor(match) {
+    const signal = AbortSignal.timeout(3000);
+    while (true) {
+      const found = frames.find(match);
+      if (found) return found;
+      if (child.exitCode !== null) throw new Error(`Fixture exited ${child.exitCode}: ${errors}`);
+      await once(events, 'frame', { signal });
+    }
+  }
+  function send(value) { child.stdin.write(JSON.stringify({ jsonrpc: '2.0', ...value }) + '\n'); }
+  function request(method, params = {}) {
+    const id = ++nextId;
+    send({ id, method, params });
+    return { id, response: waitFor(frame => frame.id === id) };
+  }
+  async function stop() {
+    if (child.exitCode === null && child.signalCode === null) { const exited = once(child, 'exit'); child.stdin.end(); await exited; }
+  }
+  t.after(async () => { await stop(); if (!existingRoot) rmSync(root, { recursive: true, force: true }); });
+  const initialized = await request('initialize', { protocolVersion: 1 }).response;
+  assert.ok(initialized.result.agentCapabilities.sessionCapabilities.resume);
+  const prompt = (sessionId, scenario, nonce = randomUUID(), extra = {}) => ({ nonce,
+    ...request('session/prompt', { sessionId, prompt: [{ type: 'text', text: JSON.stringify({ fixture: version, scenario, nonce, ...extra }) }] }) });
+  return { root, child, frames, waitFor, send, request, prompt, stop,
+    artifact: (sessionId, nonce) => join(root, '.fountain-acp-fixture', `${sessionId}-${nonce}.txt`),
+    state: sessionId => JSON.parse(readFileSync(join(root, '.fountain-acp-fixture', `${sessionId}.json`), 'utf8')) };
+}
+const newSession = async f => (await f.request('session/new', { cwd: f.root }).response).result.sessionId;
+
+test('real ACP process emits incremental output, writes real bytes, follows up and resumes in a new process', async t => {
+  const f = await processFixture(t);
+  const session = await newSession(f);
+  const first = f.prompt(session, 'write', randomUUID(), { delay_ms: 150 });
+  await f.waitFor(frame => frame.params?.update?.content?.text?.startsWith('fixture:started:'));
+  assert.ok(!f.frames.some(frame => frame.id === first.id));
+  assert.equal((await first.response).result.stopReason, 'end_turn');
+  assert.equal(readFileSync(f.artifact(session, first.nonce), 'utf8'), `${first.nonce}\n`);
+  assert.ok(f.frames.some(frame => frame.params?.update?.sessionUpdate === 'tool_call'));
+  assert.ok(f.frames.some(frame => frame.params?.update?.status === 'completed'));
+  assert.equal((await f.prompt(session, 'read', first.nonce).response).result.stopReason, 'end_turn');
+  await f.stop();
+  const resumed = await processFixture(t, f.root);
+  assert.equal((await resumed.request('session/resume', { sessionId: session }).response).result.models.currentModelId, 'fixture/deterministic-v1');
+  assert.equal((await resumed.prompt(session, 'read', first.nonce).response).result.stopReason, 'end_turn');
+  assert.equal(resumed.state(session).turns.length, 3);
+  assert.equal(resumed.state(session).artifacts[first.nonce].writes, 1);
+  await resumed.stop();
+});
+
+test('permission blocks the actual write until approved, and denial leaves no artifact', async t => {
+  const f = await processFixture(t);
+  const session = await newSession(f);
+  for (const optionId of ['allow-once', 'reject-once']) {
+    const turn = f.prompt(session, 'permission');
+    const request = await f.waitFor(frame => frame.method === 'session/request_permission' && frame.params.toolCall.toolCallId === turn.nonce);
+    assert.equal(existsSync(f.artifact(session, turn.nonce)), false);
+    assert.ok(!f.frames.some(frame => frame.id === turn.id));
+    f.send({ id: request.id, result: { outcome: { outcome: 'selected', optionId } } });
+    assert.equal((await turn.response).result.stopReason, 'end_turn');
+    assert.equal(existsSync(f.artifact(session, turn.nonce)), optionId === 'allow-once');
+  }
+});
+
+test('cancellation answers exactly once and a late permission answer cannot produce a side effect', async t => {
+  const f = await processFixture(t);
+  const session = await newSession(f);
+  const turn = f.prompt(session, 'permission');
+  const permission = await f.waitFor(frame => frame.method === 'session/request_permission');
+  f.send({ method: 'session/cancel', params: { sessionId: session } });
+  assert.equal((await turn.response).result.stopReason, 'cancelled');
+  f.send({ id: permission.id, result: { outcome: { outcome: 'selected', optionId: 'allow-once' } } });
+  const next = f.prompt(session, 'write');
+  assert.equal((await next.response).result.stopReason, 'end_turn');
+  assert.equal(f.frames.filter(frame => frame.id === turn.id).length, 1);
+  assert.equal(existsSync(f.artifact(session, turn.nonce)), false);
+  assert.deepEqual(f.state(session).turns.map(t => t.status), ['cancelled', 'end_turn']);
+});
+
+test('delayed work and long-running work cancel promptly, then explicit failure remains distinguishable', async t => {
+  const f = await processFixture(t);
+  const session = await newSession(f);
+  for (const scenario of ['write', 'wait']) {
+    const turn = f.prompt(session, scenario, randomUUID(), { delay_ms: 30000 });
+    await f.waitFor(frame => frame.params?.update?.content?.text?.includes(turn.nonce));
+    f.send({ method: 'session/cancel', params: { sessionId: session } });
+    assert.equal((await turn.response).result.stopReason, 'cancelled');
+    assert.equal(existsSync(f.artifact(session, turn.nonce)), false);
+  }
+  const failed = f.prompt(session, 'fail');
+  assert.equal((await failed.response).error.code, -32000);
+  assert.equal(f.state(session).turns.at(-1).status, 'failed');
+  assert.equal((await f.prompt(session, 'write').response).result.stopReason, 'end_turn');
+});
+
+test('fixture rejects arbitrary paths, excessive delay, duplicate writes, and concurrent prompts', async t => {
+  const f = await processFixture(t);
+  const session = await newSession(f);
+  assert.equal((await f.prompt(session, 'write', '../../secret').response).error.code, -32602);
+  assert.equal((await f.prompt(session, 'write', randomUUID(), { delay_ms: 30001 }).response).error.code, -32602);
+  assert.equal((await f.prompt(session, 'write', randomUUID(), { command: 'anything' }).response).error.code, -32602);
+  const first = f.prompt(session, 'write');
+  await first.response;
+  assert.equal((await f.prompt(session, 'write', first.nonce).response).error.code, -32000);
+  assert.equal(f.state(session).artifacts[first.nonce].writes, 1);
+  const waiting = f.prompt(session, 'wait');
+  await f.waitFor(frame => frame.params?.update?.content?.text?.includes(waiting.nonce));
+  assert.equal((await f.prompt(session, 'write').response).error.code, -32602);
+  f.send({ method: 'session/cancel', params: { sessionId: session } });
+  await waiting.response;
+});
+
+test('oversized unterminated input exits instead of retaining an active turn', async t => {
+  const f = await processFixture(t);
+  const session = await newSession(f);
+  const turn = f.prompt(session, 'wait');
+  await f.waitFor(frame => frame.params?.update?.content?.text?.includes(turn.nonce));
+  const exited = once(f.child, 'exit', { signal: AbortSignal.timeout(3000) });
+  f.child.stdin.write('x'.repeat(65537));
+  assert.equal((await turn.response).result.stopReason, 'cancelled');
+  assert.equal((await exited)[0], 2);
+});

--- a/deployed/test/runner.test.mjs
+++ b/deployed/test/runner.test.mjs
@@ -311,3 +311,17 @@ test('stable external evidence is retained with suite revision and public verdic
   assert.equal(result.report.revision.image_digest, deployment.expected_digest);
   assert.match(result.report.suite_revision, /^[a-f0-9]{40}$/);
 });
+
+test('deterministic fixture requires its own budget and advertised runtime before mutation', async t => {
+  const f = await fixture(t);
+  const config = { profiles: ['deterministic'], credentials: { primary: 'SUITE_TEST_KEY', secondary: 'SUITE_OTHER_KEY' },
+    fixture: { sandbox_provider: 'runner', max_turns: 7 } };
+  const options = { env: { SUITE_TEST_KEY: 'primary', SUITE_OTHER_KEY: 'secondary' } };
+  const invalid = await f.execute({ ...config, fixture: { ...config.fixture, max_turns: 8 } }, options);
+  assert.equal(invalid.code, 2);
+  assert.equal(f.requests.length, 0);
+  const missing = await f.execute(config, options);
+  assert.equal(missing.code, 2);
+  assert.ok(missing.report.checks.some(c => /Deterministic runtime is not enabled/.test(c.error ?? '')));
+  assert.ok(f.requests.every(([method]) => method === 'GET'));
+});

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -70,6 +70,17 @@ message.
 | `CHECKPOINT_CREATION_ENABLED` | `false` | — | Set to `true`, and Fountain takes a checkpoint of each persistent home when it parks, on a provider that has checkpoints (Sprites). The checkpoint belongs to that one machine. It can roll the machine back, and it cannot rebuild a machine that the provider lost. Each park adds one checkpoint, and Fountain does not delete old ones. The same flag also makes Fountain checkpoint each environment after it provisions a sandbox, which Sprites cannot restore into a new sandbox. |
 | `LOG_OUTPUT_BUDGET_MB` | `50` | — | The durable log volume for one conversation. Once a conversation has persisted this much sandbox output, Fountain writes one truncation marker and discards the rest. Retention bounds age, and this bounds rate. The same `0` rule and the same boot refusal apply. |
 
+## Deployed ACP fixture
+
+Use these only on an isolated test instance. The fixed fixture runtime exercises
+the real sandbox/ACP path without model inference. It does not enable arbitrary
+custom harnesses. See [Test the deployed ACP path](integrations/acp.md#test-the-deployed-acp-path).
+
+| Variable | Default | Required | Meaning |
+|---|---|---|---|
+| `DEPLOYED_ACP_FIXTURE_ENABLED` | `false` | — | Set exactly `true` to offer the fixed `fountain-fixture` runtime on a test deployment. The account UUID below is also required. |
+| `DEPLOYED_ACP_FIXTURE_USER_ID` | — | With the fixture enabled | UUID of the dedicated verified test account allowed to create and launch fixture agents. Other accounts are refused. |
+
 ## Webhooks
 
 | Variable | Default | Required | Effect |

--- a/docs/integrations/acp.md
+++ b/docs/integrations/acp.md
@@ -198,3 +198,23 @@ on stdin, which proves that the process starts and finds its credentials.
 | Zed and other ACP editors | The editor, from its agent-server config. | [Editors](editors.md) |
 | OpenClaw, on Telegram, Discord or Slack | The `acpx` plugin on the OpenClaw host. | [OpenClaw](openclaw.md) |
 | Buzz, on Nostr | `buzz-acp`, which **Fountain itself** supervises on the gateway, one for each hosted identity. | Buzz |
+
+## Test the deployed ACP path
+
+An isolated test instance can enable the fixed `fountain-fixture` runtime with
+`DEPLOYED_ACP_FIXTURE_ENABLED=true` and `DEPLOYED_ACP_FIXTURE_USER_ID` set to
+one dedicated verified account. It stays absent by default and rejects other
+accounts. The four built-in runtimes keep their existing installation paths.
+This is a testing seam for #1611 and #1007, not a custom-harness registry.
+
+The external `deterministic` profile provisions a real sandbox, verifies the
+installed fixture program's digest through the file API, and submits seven
+structured prompts over the public conversation API. It checks incremental
+SSE, nonce file bytes, permission approval and denial, cancellation, explicit
+failure, replay and resume. Cleanup must leave no active turn or sandbox.
+The fixture bypasses inference and built-in CLI installation; keep a separate
+real-model canary for those guarantees.
+
+See the [deployed suite instructions](https://github.com/BinaryBourbon/fountain/blob/main/deployed/README.md#deterministic-acp-fixture)
+for the target configuration and account/provider requirements. Run this
+profile only on a test deployment; it is excluded from production canaries.

--- a/sdk/contract/contract.json
+++ b/sdk/contract/contract.json
@@ -5030,6 +5030,7 @@
           "enum": [
             "claude",
             "codex",
+            "fountain-fixture",
             "gemini",
             "opencode"
           ],
@@ -5169,6 +5170,7 @@
           "enum": [
             "claude",
             "codex",
+            "fountain-fixture",
             "gemini",
             "opencode"
           ],
@@ -5300,6 +5302,7 @@
           "enum": [
             "claude",
             "codex",
+            "fountain-fixture",
             "gemini",
             "opencode"
           ],
@@ -7121,6 +7124,7 @@
           "enum": [
             "claude",
             "codex",
+            "fountain-fixture",
             "gemini",
             "opencode"
           ],
@@ -8577,6 +8581,7 @@
           "enum": [
             "claude",
             "codex",
+            "fountain-fixture",
             "gemini",
             "opencode"
           ],

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -2582,7 +2582,7 @@ export interface components {
             metadata?: {
                 [key: string]: unknown;
             };
-            /** @description Canonical provider/model_id (e.g. anthropic/claude-sonnet-4-6). The provider must match the runtime — anthropic for claude, openai for codex, google for gemini; opencode accepts any of the three. Other providers are rejected: Fountain has no credentials to export for them. The model id is not checked against a list, so a newly released model works without a Fountain release. */
+            /** @description Canonical provider/model_id (e.g. anthropic/claude-sonnet-4-6). The provider must match the runtime — anthropic for claude, openai for codex, google for gemini; opencode accepts any of the three. Other providers are rejected: Fountain has no credentials to export for them. The model id is not checked against a list, so a newly released model works without a Fountain release. The isolated fountain-fixture runtime is the exception: it accepts only fixture/deterministic-v1. */
             model: string;
             name: string;
             /** @description Per-tool permission policy: a map of key to verdict, plus an optional "default" key. A key is matched against the tool card's title first and then ACP's kind (execute, edit, read, fetch, …); prefer a kind, because claude titles a tool call with the command it is about to run. Unset keys fall back to the default, and an unset default is auto_allow — today's behaviour. "ask" holds the tool until a human answers it on the conversation stream, and denies if nobody does before the timeout. A runtime that never asks (opencode) refuses anything stricter than auto_allow with 422 permission_policy_unenforceable. */
@@ -2590,7 +2590,7 @@ export interface components {
                 [key: string]: "auto_allow" | "ask" | "auto_deny";
             } | null;
             /** @enum {string} */
-            runtime: "claude" | "codex" | "gemini" | "opencode";
+            runtime: "claude" | "codex" | "gemini" | "opencode" | "fountain-fixture";
             /**
              * @description Where a conversation of this agent runs by default (ADR 0023). ephemeral: a sandbox per conversation, reclaimed with it. persistent: one sandbox per agent identity (agent, environment, vault) — the agent's computer — that every conversation of that identity lands on and shares; it survives a conversation ending and is parked, not destroyed, at the ceiling. A launch may name the other with sandbox_mode on POST /api/conversations.
              * @enum {string}
@@ -2643,7 +2643,7 @@ export interface components {
                 [key: string]: "auto_allow" | "ask" | "auto_deny";
             } | null;
             /** @enum {string} */
-            runtime: "claude" | "codex" | "gemini" | "opencode";
+            runtime: "claude" | "codex" | "gemini" | "opencode" | "fountain-fixture";
             /**
              * @description Where a conversation of this agent runs by default (ADR 0023). ephemeral: a sandbox per conversation, reclaimed with it. persistent: one sandbox per agent identity (agent, environment, vault) — the agent's computer — that every conversation of that identity lands on and shares; it survives a conversation ending and is parked, not destroyed, at the ceiling. A launch may name the other with sandbox_mode on POST /api/conversations.
              * @enum {string}
@@ -2693,7 +2693,7 @@ export interface components {
                 [key: string]: "auto_allow" | "ask" | "auto_deny";
             } | null;
             /** @enum {string} */
-            runtime?: "claude" | "codex" | "gemini" | "opencode";
+            runtime?: "claude" | "codex" | "gemini" | "opencode" | "fountain-fixture";
             /**
              * @description Where a conversation of this agent runs by default (ADR 0023). ephemeral: a sandbox per conversation, reclaimed with it. persistent: one sandbox per agent identity (agent, environment, vault) — the agent's computer — that every conversation of that identity lands on and shares; it survives a conversation ending and is parked, not destroyed, at the ceiling. A launch may name the other with sandbox_mode on POST /api/conversations.
              * @enum {string}
@@ -3497,7 +3497,7 @@ export interface components {
                 [key: string]: "auto_allow" | "ask" | "auto_deny";
             } | null;
             /** @enum {string} */
-            runtime: "claude" | "codex" | "gemini" | "opencode";
+            runtime: "claude" | "codex" | "gemini" | "opencode" | "fountain-fixture";
             runtime_session_id?: string | null;
             sandbox?: components["schemas"]["Sandbox"] | null;
             /** Format: uuid */
@@ -4139,7 +4139,7 @@ export interface components {
             /** @description True while this conversation is running a turn on the machine. */
             mid_turn: boolean;
             /** @enum {string} */
-            runtime?: "claude" | "codex" | "gemini" | "opencode";
+            runtime?: "claude" | "codex" | "gemini" | "opencode" | "fountain-fixture";
             /** @enum {string} */
             status: "pending" | "running" | "idle" | "failed" | "terminated";
             title?: string | null;


### PR DESCRIPTION
Add an explicitly enabled `fountain-fixture` runtime for deterministic deployed ACP checks. Admission is restricted to one configured verified test account. The fixed bundled Node process uses the real sandbox and ACP transport; ordinary runtimes continue through the packaged runtime library. It accepts bounded scenario prompts and rejects arbitrary code, personas, skills and MCP settings.

The external `deterministic` profile verifies installed source bytes through the file API, then checks delayed output while running, a nonce artifact and follow-up, strict SSE/history replay, public permission approval/denial and tenant isolation, cancellation, an explicit ACP failure, and resume preserving the original session and single-write accounting. Each run reserves seven prompts before submission and cleans up the conversation, ephemeral sandbox, agent and environment. The profile stays separate from real-model production canaries.

Refs #1611 and the narrow gate-1 runtime seam in #1007. Stacked on the local #1612 canary branch; no general tenant-managed harness registry is added.

Validation:
- Three consecutive public-profile runs passed against a source-built local Fountain instance and the actual Go process runner. Seven prompts per run, zero model inference, all resources cleaned, and no sandbox files remained. This is local runner evidence, not released-image or hosted-provider verification.
- 65 Node harness/process tests, 60 focused agent/catalog/admission tests, and 101 TypeScript SDK tests passed. TypeScript generation, contract verification and typecheck passed.
- Full `mix precommit` passed: 4,479 tests and six doctests, static analysis, Dialyzer, and production release assembly. Documentation style and destink passed.
- An earlier full run found two corrected integration gaps and an unexplained docs-render timeout. The unchanged heading test passed in 818 ms in a focused run and then passed in the full run. Original failure evidence is retained in `/private/tmp/fountain-acp-precommit.log` and a follow-up issue draft.

The first live run found a harness identity lookup error: durable stage events carry their turn ID in metadata. The strict assertion now compares the documented field; that failed run also cleaned every resource.

Verification on an explicitly configured released test deployment remains pending. Keep the real-model canary separately required; this fixture bypasses inference and built-in CLI installation.


Stack: targets `codex/deployed-canaries`. This is a draft for review; deployed acceptance evidence still outstanding in the linked tracker issues.


SDK release intent: no standalone SDK release for this opt-in deployed-test fixture. The generated runtime union does change, but `fountain-fixture` is disabled by default and restricted to the explicitly configured test account; this PR does not enable a new ordinary-tenant runtime. The generated type addition will ship with the next normal SDK release. Applying the documented `sdk-no-release` exception for this narrow fixture change.
