### PR TITLE
Preserve accepted ACP turns across server and runner reconnects

### DIFF
--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -31,6 +31,7 @@ defmodule Fountain.Conversations.ConversationServer do
     Output,
     Pending,
     Provisioning,
+    Reattachment,
     SpriteEnv,
     TurnMachine
   }
@@ -466,6 +467,10 @@ defmodule Fountain.Conversations.ConversationServer do
       current_command: nil,
       current_command_ref: nil,
       current_turn: nil,
+      # A runner's processes survive its websocket. Keep an accepted ACP
+      # turn busy while its transport reconnects, with one bounded deadline.
+      runner_reconnect: nil,
+      runner_replay: nil,
       runtime_session_id: nil,
       # OTel span context for the in-flight turn (started in kick_turn,
       # ended in the :exit / :interrupt handlers).
@@ -1184,7 +1189,13 @@ defmodule Fountain.Conversations.ConversationServer do
           sandbox_started_at: Lifecycle.clock_start(sandbox)
       }
 
-      new_state = reattach_running_turn(new_state)
+      new_state = reattach_running_turn(%{new_state | current_turn: nil})
+
+      new_state =
+        Reattachment.finish_runner_reconnect(
+          new_state,
+          if(new_state.current_turn, do: "reattached", else: "turn_ended")
+        )
 
       {:noreply, new_state}
     else
@@ -1231,13 +1242,23 @@ defmodule Fountain.Conversations.ConversationServer do
             "transient; sandbox row left untouched"
         )
 
-        Output.publish_stage(state.conversation_id, "reattach", "failed", %{
-          reason: inspect(reason),
-          retryable: true,
-          node: to_string(node())
-        })
+        running_turn = find_running_turn(state.conversation_id)
 
-        {:stop, :normal, state}
+        if sandbox.provider == "runner" and
+             reason in [
+               {:unavailable, :runner_offline},
+               {:unavailable, :runner_disconnected}
+             ] and not is_nil(running_turn) and not is_nil(running_turn.acp_prompt_id) do
+          Reattachment.wait_for_runner(%{state | current_turn: running_turn}, &fail_transport/2)
+        else
+          Output.publish_stage(state.conversation_id, "reattach", "failed", %{
+            reason: inspect(reason),
+            retryable: true,
+            node: to_string(node())
+          })
+
+          {:stop, :normal, state}
+        end
     end
   end
 
@@ -1384,67 +1405,13 @@ defmodule Fountain.Conversations.ConversationServer do
             replay_skip: replay_skip
         }
 
-        if acp?, do: reattach_acp_peer(state, running_turn, conv), else: state
+        if acp?, do: Reattachment.acp_peer(state, running_turn, conv), else: state
 
       {:error, reason} ->
         Logger.warning("attach_session failed: #{inspect(reason)}")
         mark_orphan(state, running_turn, "attach_failed")
         state
     end
-  end
-
-  @replay_dedup_ttl_ms 10_000
-
-  # An ACP turn is only alive while something answers the agent: a
-  # `session/request_permission` left unanswered blocks it forever, and the
-  # `session/prompt` response is the only thing that ends it — the adapter
-  # keeps running until stdin closes. Before this, a reattached ACP turn had
-  # its stdout logged raw and no peer, so every turn in flight across a deploy
-  # hung until the user prompted again (which interrupts it) or the sandbox
-  # hit its lifetime ceiling.
-  #
-  # No tracer: the turn span belongs to a previous BEAM lifetime.
-  defp reattach_acp_peer(state, running_turn, conv) do
-    {:ok, peer} =
-      Managoat.ACP.Peer.start(
-        owner: self(),
-        # The transport seam (Managoat.ACP.Transport): the peer writes through
-        # this function and never sees the sandbox. `write_stdin/2` is total —
-        # a runtime that has already exited answers {:error, :command_exited},
-        # which the peer reports as {:failed, {:acp_write_failed, _}}.
-        writer: fn iodata -> Managoat.Sandbox.write_stdin(state.current_command, iodata) end,
-        ref: state.current_command_ref,
-        prompt: running_turn.prompt,
-        mode: :continue,
-        session_id: conv.runtime_session_id,
-        attach: running_turn.acp_prompt_id,
-        # A reattached peer answers `session/request_permission` exactly like a
-        # fresh one — the adapter in the sprite is mid-turn and still asking.
-        # Resolving from the agent here (rather than reading a policy frozen on
-        # the conversation row) is what makes a tightening apply across a
-        # deploy.
-        permission_policy:
-          TurnMachine.effective_permission_policy(conv, TurnMachine.agent_for(conv)),
-        # Hand back the request the previous peer was holding, if any (#940).
-        # The agent minted the JSON-RPC id and is still blocked on it, so the
-        # id outlives our process — but only if we wrote it down. This is the
-        # same trap `acp_prompt_id` exists for, and the reason the turn row
-        # carries `pending_permission` at all.
-        pending_permission: running_turn.pending_permission
-      )
-
-    dedup =
-      Conversations._unsafe_recent_output_lines(state.conversation_id, running_turn.id, "acp")
-
-    Process.send_after(self(), :clear_replay_dedup, @replay_dedup_ttl_ms)
-
-    %{
-      state
-      | acp_peer: peer,
-        acp_peer_mon: Process.monitor(peer),
-        stream_tracer: nil,
-        replay_dedup: dedup
-    }
   end
 
   defp mark_orphan(_state, running_turn, why),
@@ -1783,8 +1750,14 @@ defmodule Fountain.Conversations.ConversationServer do
         %{current_command_ref: ref, acp_peer: peer} = state
       )
       when is_pid(peer) do
-    Managoat.ACP.Peer.stdout(peer, data)
-    {:noreply, maybe_emit_first_output(state)}
+    case Fountain.Conversations.RunnerReplay.feed(state.runner_replay, data) do
+      {:ok, replay, output} ->
+        if output != "", do: Managoat.ACP.Peer.stdout(peer, output)
+        {:noreply, maybe_emit_first_output(%{state | runner_replay: replay})}
+
+      {:error, reason} ->
+        fail_transport(state, reason)
+    end
   end
 
   def handle_info({:stdout, %{ref: ref}, data}, %{current_command_ref: ref} = state) do
@@ -1820,6 +1793,17 @@ defmodule Fountain.Conversations.ConversationServer do
 
   # Nobody answered in time. Deny — the only safe default — and say so on the
   # stream so a card stops waiting.
+  def handle_info(
+        {:permission_timeout, request_id},
+        %{
+          runner_reconnect: %{},
+          current_turn: %{pending_permission: %{"request_id" => request_id}}
+        } = state
+      ) do
+    state = resolve_permission(state, request_id, "timeout", nil)
+    fail_transport(state, :permission_timeout_during_runner_reconnect)
+  end
+
   def handle_info({:permission_timeout, request_id}, state) do
     {:noreply, resolve_permission(state, request_id, "timeout", nil)}
   end
@@ -1994,47 +1978,22 @@ defmodule Fountain.Conversations.ConversationServer do
     {:noreply, connection_lost(state, "transport_error", %{reason: inspect(reason)})}
   end
 
+  def handle_info(
+        {:error, %{ref: ref}, :runner_disconnected},
+        %{
+          current_command_ref: ref,
+          current_turn: %{acp_prompt_id: prompt_id},
+          handle: %{provider: :runner}
+        } = state
+      )
+      when not is_nil(ref) and not is_nil(prompt_id) do
+    state = Reattachment.disconnect_runner(state)
+    Reattachment.wait_for_runner(state, &fail_transport/2)
+  end
+
   def handle_info({:error, %{ref: ref}, reason}, %{current_command_ref: ref} = state)
       when not is_nil(ref) do
-    Logger.error("sprite command error mid-turn: #{inspect(reason)} — failing the turn")
-
-    {:ok, turn} =
-      Conversations._unsafe_update_turn(state.current_turn, %{
-        status: "failed",
-        ended_at: now()
-      })
-
-    Output.publish_stage(state.conversation_id, "turn", "failed", %{
-      turn_id: turn.id,
-      turn_number: turn.turn_number,
-      reason: "sprite connection lost: #{inspect(reason)}"
-    })
-
-    TurnMachine.finalize_tracer(state.stream_tracer)
-
-    # An ACP turn can also end here — the adapter exits, is interrupted, or its
-    # socket drops before it ever answers `session/prompt`. The peer has nothing
-    # left to drive and must not outlive the turn.
-    stop_acp_peer(state)
-    TurnMachine.end_span(state.current_turn_span, :error, %{"error" => inspect(reason)})
-
-    emit_turn_completed(state, turn.status)
-
-    conv = Conversations._unsafe_get_conversation!(state.conversation_id)
-    {:ok, _} = Conversations.update_conversation(conv, %{status: "idle"})
-
-    {:noreply,
-     %{
-       touch_activity(state)
-       | current_command: nil,
-         current_command_ref: nil,
-         current_turn: nil,
-         current_turn_span: nil,
-         turn_metrics: nil,
-         stream_tracer: nil,
-         acp_peer: nil,
-         acp_peer_mon: nil
-     }}
+    fail_transport(state, reason)
   end
 
   # A stale ref — an error from a command already superseded or finished.
@@ -2042,6 +2001,30 @@ defmodule Fountain.Conversations.ConversationServer do
     Logger.error("sprite command error: #{inspect(reason)}")
     {:noreply, state}
   end
+
+  def handle_info(
+        {:runner_reconnect, token},
+        %{runner_reconnect: %{token: token}, current_turn: turn} = state
+      )
+      when not is_nil(turn) do
+    if Reattachment.runner_reconnect_expired?(state) do
+      fail_transport(state, :runner_reconnect_timeout)
+    else
+      # Reuse the ordinary reattach path, including scoped credentials,
+      # command tags, persisted prompt ID and pending permission restoration.
+      handle_continue(:provision, state)
+    end
+  end
+
+  def handle_info({:runner_reconnect, _token}, state), do: {:noreply, state}
+
+  def handle_info(
+        {:runner_replay_timeout, ref},
+        %{current_command_ref: ref, runner_replay: %{}} = state
+      ),
+      do: fail_transport(state, :runner_replay_boundary_missing)
+
+  def handle_info({:runner_replay_timeout, _ref}, state), do: {:noreply, state}
 
   # The ACP reattach window is over; anything still in the set is a persisted
   # line the replay did not repeat, and must not suppress a genuine repeat.
@@ -2083,8 +2066,10 @@ defmodule Fountain.Conversations.ConversationServer do
 
   def handle_info(_msg, state), do: {:noreply, state}
 
-  # The permission request's end, whichever way (`Pending.resolve_permission/7`):
-  # the turn row and the timer are the server's to hold.
+  defp fail_transport(state, reason),
+    do: Reattachment.fail_transport(resolve_pending_permission(state, "turn_ended"), reason)
+
+  # The permission request's end: the turn row and timer are the server's to hold.
   defp resolve_permission(state, request_id, outcome, option_id) do
     {turn, pending} =
       Pending.resolve_permission(
@@ -2316,6 +2301,7 @@ defmodule Fountain.Conversations.ConversationServer do
   # an agent that stops its tool calls and one that is shot mid-write. This is
   # the other reason stdin stays open on the ACP path.
   defp interrupt_turn(state) do
+    state = Reattachment.finish_runner_reconnect(state, "interrupted")
     if state.acp_peer, do: Managoat.ACP.Peer.cancel(state.acp_peer)
     # EOF before the handle goes: a detachable session survives its client
     # disconnecting, so closing the WebSocket alone would leave the adapter —
@@ -2338,7 +2324,9 @@ defmodule Fountain.Conversations.ConversationServer do
       | current_command: nil,
         current_command_ref: nil,
         acp_peer: nil,
-        acp_peer_mon: nil
+        acp_peer_mon: nil,
+        runner_reconnect: nil,
+        runner_replay: nil
     }
   end
 

--- a/apps/fountain/lib/fountain/conversations/pending.ex
+++ b/apps/fountain/lib/fountain/conversations/pending.ex
@@ -54,6 +54,32 @@ defmodule Fountain.Conversations.Pending do
 
   # ── permission requests (#940) ────────────────────────────────────────────
 
+  @doc "Re-arm a persisted request using its original ask time after transport recovery."
+  def restore_permission_timer(%__MODULE__{} = pending, turn) do
+    if pending.permission_timer, do: Process.cancel_timer(pending.permission_timer)
+
+    timer =
+      case turn do
+        %{pending_permission: %{"request_id" => id} = request} ->
+          remaining =
+            case DateTime.from_iso8601(request["asked_at"] || "") do
+              {:ok, asked_at, _} ->
+                elapsed = max(DateTime.diff(DateTime.utc_now(), asked_at, :millisecond), 0)
+                max(Lifecycle.ask_timeout_ms() - elapsed, 0)
+
+              _ ->
+                0
+            end
+
+          Process.send_after(self(), {:permission_timeout, id}, remaining)
+
+        _ ->
+          nil
+      end
+
+    %{pending | permission_timer: timer}
+  end
+
   @doc """
   `ask`: the agent is blocked and a human has to answer (#940).
 

--- a/apps/fountain/lib/fountain/conversations/reattachment.ex
+++ b/apps/fountain/lib/fountain/conversations/reattachment.ex
@@ -1,0 +1,184 @@
+defmodule Fountain.Conversations.Reattachment do
+  @moduledoc "ACP peer restoration and bounded recovery of an accepted runner turn."
+
+  require Logger
+
+  alias Fountain.Conversations
+  alias Fountain.Conversations.{Connection, Output, Pending, TurnMachine}
+
+  @replay_dedup_ttl_ms 10_000
+
+  # An ACP turn is only alive while something answers the agent: a
+  # `session/request_permission` left unanswered blocks it forever, and the
+  # `session/prompt` response is the only thing that ends it — the adapter
+  # keeps running until stdin closes. Before this, a reattached ACP turn had
+  # its stdout logged raw and no peer, so every turn in flight across a deploy
+  # hung until the user prompted again (which interrupts it) or the sandbox
+  # hit its lifetime ceiling.
+  #
+  # No tracer: the turn span belongs to a previous BEAM lifetime.
+  def acp_peer(state, running_turn, conv) do
+    {:ok, peer} =
+      Managoat.ACP.Peer.start(
+        owner: self(),
+        # The transport seam (Managoat.ACP.Transport): the peer writes through
+        # this function and never sees the sandbox. `write_stdin/2` is total —
+        # a runtime that has already exited answers {:error, :command_exited},
+        # which the peer reports as {:failed, {:acp_write_failed, _}}.
+        writer: fn iodata -> Managoat.Sandbox.write_stdin(state.current_command, iodata) end,
+        ref: state.current_command_ref,
+        prompt: running_turn.prompt,
+        mode: :continue,
+        session_id: conv.runtime_session_id,
+        attach: running_turn.acp_prompt_id,
+        # A reattached peer answers `session/request_permission` exactly like a
+        # fresh one — the adapter in the sprite is mid-turn and still asking.
+        # Resolving from the agent here (rather than reading a policy frozen on
+        # the conversation row) is what makes a tightening apply across a
+        # deploy.
+        permission_policy:
+          TurnMachine.effective_permission_policy(conv, TurnMachine.agent_for(conv)),
+        # Hand back the request the previous peer was holding, if any (#940).
+        # The agent minted the JSON-RPC id and is still blocked on it, so the
+        # id outlives our process — but only if we wrote it down. This is the
+        # same trap `acp_prompt_id` exists for, and the reason the turn row
+        # carries `pending_permission` at all.
+        pending_permission: running_turn.pending_permission
+      )
+
+    # ownership: ConversationServer passes its bound conversation and that
+    # conversation's persisted running turn; neither ID comes from a request here.
+    dedup =
+      Conversations._unsafe_recent_output_lines(state.conversation_id, running_turn.id, "acp")
+
+    Process.send_after(self(), :clear_replay_dedup, @replay_dedup_ttl_ms)
+
+    runner_replay =
+      if state.handle.provider == :runner do
+        Process.send_after(
+          self(),
+          {:runner_replay_timeout, state.current_command_ref},
+          @replay_dedup_ttl_ms
+        )
+
+        Fountain.Conversations.RunnerReplay.new(running_turn.acp_prompt_id)
+      end
+
+    state =
+      Pending.into_state(
+        state,
+        Pending.restore_permission_timer(Pending.from_state(state), running_turn)
+      )
+
+    %{
+      state
+      | acp_peer: peer,
+        acp_peer_mon: Process.monitor(peer),
+        runner_replay: runner_replay,
+        stream_tracer: nil,
+        replay_dedup: dedup
+    }
+  end
+
+  @runner_reconnect_ms 120_000
+  def wait_for_runner(state, on_expired) do
+    recovery =
+      state.runner_reconnect ||
+        %{deadline: System.monotonic_time(:millisecond) + @runner_reconnect_ms, token: make_ref()}
+
+    if is_nil(state.runner_reconnect) do
+      Output.publish_stage(state.conversation_id, "connection", "started", %{
+        reason: "runner_disconnected",
+        turn_id: state.current_turn.id,
+        timeout_ms: @runner_reconnect_ms
+      })
+    end
+
+    state = %{state | runner_reconnect: recovery}
+
+    if runner_reconnect_expired?(state) do
+      on_expired.(state, :runner_reconnect_timeout)
+    else
+      Process.send_after(self(), {:runner_reconnect, recovery.token}, 1_000)
+      {:noreply, state}
+    end
+  end
+
+  def runner_reconnect_expired?(state),
+    do: System.monotonic_time(:millisecond) >= state.runner_reconnect.deadline
+
+  def finish_runner_reconnect(%{runner_reconnect: nil} = state, _outcome), do: state
+
+  def finish_runner_reconnect(state, outcome) do
+    Output.publish_stage(state.conversation_id, "connection", "done", %{
+      reason: "runner_reconnect",
+      outcome: outcome
+    })
+
+    %{state | runner_reconnect: nil}
+  end
+
+  def fail_transport(state, reason) do
+    Logger.error("sprite command error mid-turn: #{inspect(reason)} — failing the turn")
+    state = finish_runner_reconnect(state, "failed")
+
+    # ownership: current_turn belongs to the conversation this server owns.
+    {:ok, turn} =
+      Conversations._unsafe_update_turn(state.current_turn, %{
+        status: "failed",
+        ended_at: DateTime.utc_now() |> DateTime.truncate(:second)
+      })
+
+    Output.publish_stage(state.conversation_id, "turn", "failed", %{
+      turn_id: turn.id,
+      turn_number: turn.turn_number,
+      reason: "sprite connection lost: #{inspect(reason)}"
+    })
+
+    TurnMachine.finalize_tracer(state.stream_tracer)
+
+    # An ACP turn can also end here — the adapter exits, is interrupted, or its
+    # socket drops before it ever answers `session/prompt`. The peer has nothing
+    # left to drive and must not outlive the turn.
+    Connection.stop_peer(Connection.from_state(state))
+    TurnMachine.end_span(state.current_turn_span, :error, %{"error" => inspect(reason)})
+
+    TurnMachine.emit_completed(TurnMachine.from_state(state), turn.status)
+
+    # ownership: state.conversation_id is the server's bound conversation.
+    conv = Conversations._unsafe_get_conversation!(state.conversation_id)
+    {:ok, _} = Conversations.update_conversation(conv, %{status: "idle"})
+
+    {:noreply,
+     %{
+       %{state | last_activity_at: DateTime.utc_now()}
+       | current_command: nil,
+         current_command_ref: nil,
+         current_turn: nil,
+         current_turn_span: nil,
+         turn_metrics: nil,
+         stream_tracer: nil,
+         runner_reconnect: nil,
+         runner_replay: nil,
+         acp_peer: nil,
+         acp_peer_mon: nil
+     }}
+  end
+
+  def disconnect_runner(state) do
+    # Do not cancel the remote command: only the socket disappeared. The
+    # daemon journals output until a new connection attaches to this turn.
+    Connection.stop_peer(Connection.from_state(state))
+    TurnMachine.finalize_tracer(state.stream_tracer)
+
+    %{
+      state
+      | current_command: nil,
+        current_command_ref: nil,
+        acp_peer: nil,
+        acp_peer_mon: nil,
+        stream_tracer: nil,
+        runner_replay: nil
+    }
+  end
+end

--- a/apps/fountain/lib/fountain/conversations/runner_replay.ex
+++ b/apps/fountain/lib/fountain/conversations/runner_replay.ex
@@ -1,0 +1,52 @@
+defmodule Fountain.Conversations.RunnerReplay do
+  @moduledoc """
+  Locate an active ACP turn in a runner's complete process journal.
+
+  The ACP peer allocates consecutive request IDs and sends a new prompt only
+  after the previous request has answered. The response immediately before the
+  persisted prompt ID separates earlier turns and handshake output from the
+  active turn. Hosted providers may replay a partial tail and do not use this
+  boundary; the process runner guarantees replay from byte zero.
+  """
+
+  @max_line_bytes 4 * 1024 * 1024
+
+  def new(prompt_id) when is_integer(prompt_id) and prompt_id > 0,
+    do: %{previous_id: prompt_id - 1, buffer: ""}
+
+  def feed(nil, data), do: {:ok, nil, data}
+
+  def feed(state, data) when is_binary(data) do
+    scan(%{state | buffer: state.buffer <> data})
+  end
+
+  defp scan(state) do
+    case :binary.match(state.buffer, "\n") do
+      :nomatch ->
+        if byte_size(state.buffer) <= @max_line_bytes,
+          do: {:ok, state, ""},
+          else: {:error, :runner_replay_line_too_large}
+
+      {at, 1} when at <= @max_line_bytes ->
+        <<line::binary-size(at), "\n", rest::binary>> = state.buffer
+
+        if boundary?(line, state.previous_id),
+          do: {:ok, nil, rest},
+          else: scan(%{state | buffer: rest})
+
+      _ ->
+        {:error, :runner_replay_line_too_large}
+    end
+  end
+
+  defp boundary?(line, previous_id) do
+    case Jason.decode(line) do
+      {:ok, %{"jsonrpc" => "2.0", "id" => ^previous_id} = response} ->
+        not Map.has_key?(response, "method") and
+          (Map.has_key?(response, "result") or Map.has_key?(response, "error"))
+
+      _ ->
+        false
+    end
+  end
+end

--- a/apps/fountain/lib/fountain/webhooks/events.ex
+++ b/apps/fountain/lib/fountain/webhooks/events.ex
@@ -26,6 +26,7 @@ defmodule Fountain.Webhooks.Events do
     {"setup", ~w(started done failed)},
     {"checkpoint_restore", ~w(started done failed)},
     {"reattach", ~w(started done failed interrupted)},
+    {"connection", ~w(started done)},
     {"turn", ~w(started done failed interrupted)},
     {"request", ~w(started done)},
     {"caller_tool", ~w(started done)},

--- a/apps/fountain/test/fountain/conversations/conversation_server_size_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_size_test.exs
@@ -15,7 +15,7 @@ defmodule Fountain.Conversations.ConversationServerSizeTest do
   accepts is downward. Lower it when you move something out; never raise it.
   """
 
-  @pin 2813
+  @pin 2800
 
   @server "apps/fountain/lib/fountain/conversations/conversation_server.ex"
 

--- a/apps/fountain/test/fountain/conversations/pending_test.exs
+++ b/apps/fountain/test/fountain/conversations/pending_test.exs
@@ -60,6 +60,34 @@ defmodule Fountain.Conversations.PendingTest do
   end
 
   describe "a permission request" do
+    test "restoring an old request expires it without granting a new timeout window" do
+      old = DateTime.utc_now() |> DateTime.add(-86_400, :second) |> DateTime.to_iso8601()
+
+      pending =
+        Pending.restore_permission_timer(%Pending{}, %{
+          pending_permission: %{"request_id" => "old-request", "asked_at" => old}
+        })
+
+      assert is_reference(pending.permission_timer)
+      assert_receive {:permission_timeout, "old-request"}
+    end
+
+    test "restoring a current request replaces its timer without extending its original deadline" do
+      asked = DateTime.utc_now() |> DateTime.add(-30, :second) |> DateTime.to_iso8601()
+      previous = Process.send_after(self(), :old_timer, 300_000)
+
+      pending =
+        Pending.restore_permission_timer(%Pending{permission_timer: previous}, %{
+          pending_permission: %{"request_id" => "held-request", "asked_at" => asked}
+        })
+
+      assert Process.read_timer(previous) == false
+      remaining = Process.read_timer(pending.permission_timer)
+      assert remaining > 0
+      assert remaining <= Fountain.Conversations.Lifecycle.ask_timeout_ms() - 30_000
+      Process.cancel_timer(pending.permission_timer)
+    end
+
     test "ask/6 puts it on the row, announces it and arms the timeout", %{
       conv: conv,
       turn: turn,

--- a/apps/fountain/test/fountain/conversations/runner_recovery_test.exs
+++ b/apps/fountain/test/fountain/conversations/runner_recovery_test.exs
@@ -1,0 +1,178 @@
+defmodule Fountain.Conversations.RunnerRecoveryTest do
+  use Fountain.ConversationServerCase
+
+  alias Fountain.Repo
+
+  defp fixture(online? \\ true) do
+    user = insert_verified_user()
+    agent = insert_agent(user_id: user.id, permission_policy: %{"default" => "ask"})
+    sandbox = insert_sandbox(user_id: user.id, provider: "runner", status: "ready")
+
+    conv =
+      insert_conversation(
+        user_id: user.id,
+        agent: agent,
+        sandbox: sandbox,
+        status: "running",
+        runtime_session_id: "live-session"
+      )
+
+    turn = insert_turn(conv, %{status: "running", acp_prompt_id: 4, prompt: "write one nonce"})
+    stub_happy_sprite()
+    test = self()
+    online = start_supervised!({Agent, fn -> online? end})
+
+    Mimic.stub(Managoat.Sandbox, :get, fn _ ->
+      if Agent.get(online, & &1),
+        do: {:ok, %{status: :running}},
+        else: {:error, {:unavailable, :runner_offline}}
+    end)
+
+    Mimic.stub(Managoat.Sandbox, :exec, fn _, _, _, _ -> {:ok, "", 0} end)
+    Mimic.stub(Managoat.Sandbox, :write_file, fn _, _, _, _ -> :ok end)
+
+    Mimic.stub(Managoat.Sandbox, :list_sessions, fn _ ->
+      {:ok, [%Managoat.Sandbox.Session{id: "live-command"}]}
+    end)
+
+    Mimic.stub(Managoat.Sandbox, :attach, fn _, "live-command", _ ->
+      ref = make_ref()
+      send(test, {:attached, ref})
+      boundary = Jason.encode!(%{jsonrpc: "2.0", id: 3, result: %{}}) <> "\n"
+      send(self(), {:stdout, %{ref: ref}, boundary})
+      {:ok, %Managoat.Sandbox.Command{provider: :runner, ref: ref}}
+    end)
+
+    Mimic.stub(Managoat.Sandbox, :write_stdin, fn _, data ->
+      send(test, {:wrote, IO.iodata_to_binary(data)})
+      :ok
+    end)
+
+    Mimic.stub(Managoat.Sandbox, :close_stdin, fn _ -> send(test, :closed_stdin) && :ok end)
+    Mimic.stub(Managoat.Sandbox, :stop_command, fn _ -> send(test, :stopped_command) && :ok end)
+
+    {pid, _, :alive} = start_server(conv)
+    on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+    %{pid: pid, conv: conv, turn: turn, online: online}
+  end
+
+  defp settle(pid) do
+    state = :sys.get_state(pid)
+    if state.acp_peer, do: :sys.get_state(state.acp_peer)
+    :sys.get_state(pid)
+  end
+
+  defp permission(pid, ref) do
+    message = %{
+      "jsonrpc" => "2.0",
+      "id" => 5,
+      "method" => "session/request_permission",
+      "params" => %{
+        "toolCall" => %{"toolCallId" => "nonce", "title" => "write nonce", "kind" => "edit"},
+        "options" => [%{"optionId" => "allow", "kind" => "allow_once"}]
+      }
+    }
+
+    send(pid, {:stdout, %{ref: ref}, Jason.encode!(message) <> "\n"})
+    settle(pid).current_turn.pending_permission
+  end
+
+  test "disconnect preserves the accepted turn and its pending permission, then reattaches once" do
+    f = fixture()
+    assert_receive {:attached, old_ref}
+    pending = permission(f.pid, old_ref)
+    assert pending["request_id"]
+    Agent.update(f.online, fn _ -> false end)
+    send(f.pid, {:error, %{ref: old_ref}, :runner_disconnected})
+    waiting = settle(f.pid)
+    assert waiting.current_turn.id == f.turn.id
+    assert Repo.reload!(f.turn).status == "running"
+    assert Repo.reload!(f.turn).pending_permission == pending
+    assert GenServer.call(f.pid, {:send_prompt, "duplicate", []}) == {:error, :busy}
+    refute_receive :closed_stdin
+    refute_receive :stopped_command
+
+    Agent.update(f.online, fn _ -> true end)
+    send(f.pid, {:runner_reconnect, waiting.runner_reconnect.token})
+    assert_receive {:attached, ref}, 1_000
+    assert ref != old_ref
+    assert permission(f.pid, ref)["request_id"] == pending["request_id"]
+    assert GenServer.call(f.pid, {:answer_permission, pending["request_id"], "allow"}) == :ok
+    assert_receive {:wrote, answer}
+    assert Jason.decode!(answer)["id"] == 5
+
+    # An old connection's late error must not fail the replacement command.
+    send(f.pid, {:error, %{ref: old_ref}, :runner_disconnected})
+    response = Jason.encode!(%{jsonrpc: "2.0", id: 4, result: %{stopReason: "end_turn"}})
+    send(f.pid, {:stdout, %{ref: ref}, response <> "\n"})
+    settle(f.pid)
+    assert Repo.reload!(f.turn).status == "completed"
+    assert [%{id: id}] = Conversations._unsafe_list_turns(f.conv.id)
+    assert id == f.turn.id
+    assert :sys.get_state(f.pid).runner_reconnect == nil
+  end
+
+  test "boot before the runner reconnects retains the running turn until attachment" do
+    f = fixture(false)
+    waiting = :sys.get_state(f.pid)
+    assert waiting.runner_reconnect
+    assert waiting.current_turn.id == f.turn.id
+    assert Repo.reload!(f.turn).status == "running"
+    Agent.update(f.online, fn _ -> true end)
+    send(f.pid, {:runner_reconnect, waiting.runner_reconnect.token})
+    assert_receive {:attached, _}, 1_000
+    assert settle(f.pid).current_turn.id == f.turn.id
+    assert :sys.get_state(f.pid).runner_reconnect == nil
+  end
+
+  test "an expired reconnect deadline ends the turn and clears busy state" do
+    f = fixture()
+    assert_receive {:attached, ref}
+    send(f.pid, {:error, %{ref: ref}, :runner_disconnected})
+    waiting = settle(f.pid)
+
+    :sys.replace_state(f.pid, fn state ->
+      put_in(state.runner_reconnect.deadline, System.monotonic_time(:millisecond) - 1)
+    end)
+
+    send(f.pid, {:runner_reconnect, waiting.runner_reconnect.token})
+    state = settle(f.pid)
+    assert state.current_turn == nil
+    assert state.runner_reconnect == nil
+    assert Repo.reload!(f.turn).status == "failed"
+  end
+
+  test "interrupt cancels recovery and a late retry cannot resurrect its turn" do
+    f = fixture()
+    assert_receive {:attached, ref}
+    send(f.pid, {:error, %{ref: ref}, :runner_disconnected})
+    waiting = settle(f.pid)
+    assert GenServer.call(f.pid, :interrupt) == :ok
+    send(f.pid, {:runner_reconnect, waiting.runner_reconnect.token})
+    assert settle(f.pid).current_turn == nil
+    assert Repo.reload!(f.turn).status == "interrupted"
+    refute_receive {:attached, _}
+  end
+
+  test "other transport failures retain terminal behavior" do
+    f = fixture()
+    assert_receive {:attached, ref}
+    send(f.pid, {:error, %{ref: ref}, :protocol_failure})
+    assert settle(f.pid).current_turn == nil
+    assert Repo.reload!(f.turn).status == "failed"
+  end
+
+  test "permission expiry while disconnected ends recovery without granting the request" do
+    f = fixture()
+    assert_receive {:attached, ref}
+    pending = permission(f.pid, ref)
+    send(f.pid, {:error, %{ref: ref}, :runner_disconnected})
+    settle(f.pid)
+    send(f.pid, {:permission_timeout, pending["request_id"]})
+    assert settle(f.pid).runner_reconnect == nil
+    turn = Repo.reload!(f.turn)
+    assert turn.status == "failed"
+    assert turn.pending_permission == nil
+    refute_receive {:wrote, _}
+  end
+end

--- a/apps/fountain/test/fountain/conversations/runner_replay_test.exs
+++ b/apps/fountain/test/fountain/conversations/runner_replay_test.exs
@@ -1,0 +1,43 @@
+defmodule Fountain.Conversations.RunnerReplayTest do
+  use ExUnit.Case, async: true
+  alias Fountain.Conversations.RunnerReplay
+
+  test "old turns and permission requests are discarded before the active prompt boundary" do
+    old =
+      Jason.encode!(%{jsonrpc: "2.0", id: "old-permission", method: "session/request_permission"})
+
+    boundary = Jason.encode!(%{jsonrpc: "2.0", id: 4, result: %{stopReason: "end_turn"}})
+
+    active =
+      Jason.encode!(%{
+        jsonrpc: "2.0",
+        id: "current-permission",
+        method: "session/request_permission"
+      }) <> "\n"
+
+    wire = old <> "\n" <> boundary <> "\n" <> active
+
+    for split <- 0..byte_size(wire) do
+      <<first::binary-size(split), second::binary>> = wire
+      assert {:ok, state, left} = RunnerReplay.feed(RunnerReplay.new(5), first)
+      assert {:ok, nil, right} = RunnerReplay.feed(state, second)
+      assert left <> right == active
+    end
+  end
+
+  test "only a response with the preceding request ID opens the boundary" do
+    request = Jason.encode!(%{jsonrpc: "2.0", id: 4, method: "session/request_permission"})
+    wrong = Jason.encode!(%{jsonrpc: "2.0", id: 3, result: %{}})
+
+    assert {:ok, state, ""} =
+             RunnerReplay.feed(RunnerReplay.new(5), request <> "\n" <> wrong <> "\n")
+
+    error = Jason.encode!(%{jsonrpc: "2.0", id: 4, error: %{code: -1}})
+    assert {:ok, nil, "live"} = RunnerReplay.feed(state, error <> "\nlive")
+  end
+
+  test "a missing boundary cannot grow an unbounded partial line" do
+    assert {:error, :runner_replay_line_too_large} =
+             RunnerReplay.feed(RunnerReplay.new(5), :binary.copy("x", 4 * 1024 * 1024 + 1))
+  end
+end

--- a/apps/fountain/test/fountain/webhooks/events_test.exs
+++ b/apps/fountain/test/fountain/webhooks/events_test.exs
@@ -22,6 +22,7 @@ defmodule Fountain.Webhooks.EventsTest do
   @sources [
     "lib/fountain/conversations.ex",
     "lib/fountain/conversations/conversation_server.ex",
+    "lib/fountain/conversations/reattachment.ex",
     "lib/fountain/conversations/provisioning.ex",
     "lib/fountain/conversations/egress.ex",
     "lib/fountain/conversations/turn_machine.ex",

--- a/cli/internal/runner/daemon_test.go
+++ b/cli/internal/runner/daemon_test.go
@@ -209,6 +209,37 @@ func TestExec(t *testing.T) {
 	}
 }
 
+func TestReattachMovesReplayAndLiveOutputToNewConnection(t *testing.T) {
+	d := newDaemon(t)
+	first, second := newRecorder(), newRecorder()
+	do(t, d, Request{Op: "create", Name: "sb"}, first)
+	result, after, err := d.Handle(Request{ID: 7, Op: "spawn", Name: "sb", Cmd: "sh",
+		Args: []string{"-c", "echo ready; while read l; do echo echo:$l; done"}, Stdin: true}, first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sid := result["session_id"].(string)
+	after()
+	first.waitFor(t, func(fs []Frame) bool {
+		return strings.Contains(stdoutOf(fs, sid, true)+stdoutOf(fs, sid, false), "ready")
+	})
+	_, reattach, err := d.Handle(Request{ID: 9, Op: "attach", SessionID: sid}, second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reattach()
+	second.waitFor(t, func(fs []Frame) bool { return strings.Contains(stdoutOf(fs, sid, true), "ready") })
+	do(t, d, Request{Op: "stdin", SessionID: sid, Data: base64.StdEncoding.EncodeToString([]byte("reconnected\n"))}, second)
+	second.waitFor(t, func(fs []Frame) bool { return strings.Contains(stdoutOf(fs, sid, false), "echo:reconnected") })
+	do(t, d, Request{Op: "stdin_close", SessionID: sid}, second)
+	second.waitFor(t, func(fs []Frame) bool { return hasExit(fs, sid) })
+	first.mu.Lock()
+	defer first.mu.Unlock()
+	if strings.Contains(stdoutOf(first.frames, sid, false), "reconnected") || hasExit(first.frames, sid) {
+		t.Fatal("live output or exit was sent to the old connection")
+	}
+}
+
 func TestSpawnStreamsAfterReplyAndReplaysOnAttach(t *testing.T) {
 	d := newDaemon(t)
 	rec := newRecorder()

--- a/cli/internal/runner/process.go
+++ b/cli/internal/runner/process.go
@@ -388,7 +388,7 @@ func (p *Process) Spawn(req Request, emit Emitter) (map[string]any, func(), erro
 	p.mu.Unlock()
 
 	reqID := req.ID
-	after := func() { s.attach(reqID) }
+	after := func() { s.attach(reqID, emit) }
 	return map[string]any{"session_id": id}, after, nil
 }
 
@@ -487,7 +487,7 @@ func (p *Process) Attach(req Request, emit Emitter) (map[string]any, func(), err
 		return nil, nil, err
 	}
 	reqID := req.ID
-	return map[string]any{"session_id": s.id}, func() { s.attach(reqID) }, nil
+	return map[string]any{"session_id": s.id}, func() { s.attach(reqID, emit) }, nil
 }
 
 // stopSessions terminates every live session of a sandbox (suspend/destroy).

--- a/cli/internal/runner/session.go
+++ b/cli/internal/runner/session.go
@@ -167,9 +167,12 @@ func (s *Session) finish(code int) {
 // attach replays the journal from byte zero, tagged for the requester, and
 // switches live emission on — under one lock, so no frame is missed or
 // delivered twice around the switch.
-func (s *Session) attach(reqID int) {
+func (s *Session) attach(reqID int, emit Emitter) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	// A session outlives its websocket. Replay and future output must use
+	// the connection that requested this attachment, not the spawn's socket.
+	s.emit = emit
 	for _, f := range s.journal {
 		replay := make(Frame, len(f)+1)
 		for k, v := range f {

--- a/deployed/profiles/recovery.mjs
+++ b/deployed/profiles/recovery.mjs
@@ -37,6 +37,15 @@ export function recoveredAttachment(events, turnId) {
   }
   return events.find(e => e.stage === 'reattach' && e.state === 'done' && JSON.parse(e.data).outcome === 'session_attached');
 }
+export function verifyRecoveryTranscript(events, accepted) {
+  const starts = events.flatMap(event => (event.blocks ?? []).filter(b => b.kind === 'text' && b.body?.includes('fixture:started:'))
+    .map(block => ({ turn_id: event.turn_id, body: block.body })));
+  for (const turn of accepted) {
+    const own = starts.filter(item => item.turn_id === turn.id);
+    ensure(own.length === 1 && own[0].body === `fixture:started:${turn.scenario}:${turn.nonce}\n`,
+      'Recovery duplicated or misattributed a fixture turn in the transcript');
+  }
+}
 
 export async function recovery(ctx, dependencies = {}) {
   const { config, client, fixtures, check } = ctx, settings = config.recovery;
@@ -80,6 +89,7 @@ export async function recovery(ctx, dependencies = {}) {
     await identity(signal);
     const state = JSON.parse((await file(`.fountain-acp-fixture/${sessionId}.json`, signal)).toString());
     verifyRecoveryState(state, sessionId, accepted, completed);
+    verifyRecoveryTranscript((await history(client, conversation.id, signal)).events, accepted);
     for (const item of accepted.slice(0, completed).filter(a => a.scenario !== 'read')) {
       ensure((await file(`.fountain-acp-fixture/${sessionId}-${item.nonce}.txt`, signal)).toString() === `${item.nonce}\n`, 'Recovery lost or changed artifact bytes');
     }

--- a/deployed/recovery-controls.md
+++ b/deployed/recovery-controls.md
@@ -55,12 +55,18 @@ and run ID, and restores controls before trying public account authentication.
 Failure to restore a control is reported as `cleanup_failed`, even when public
 fixture deletion succeeds. Kubernetes evidence never satisfies the public checks.
 
-A local source-server diagnostic currently fails the rollout continuity check:
-graceful shutdown disconnects the runner socket while the conversation server is
-still alive, and the accepted turn becomes `failed` with `runner_disconnected`.
-The profile rejects that terminal event without waiting for an impossible
-attachment. The failure and successful fixture cleanup are retained separately;
-this profile has no passing deployed staging verdict yet.
+Local source-server validation with the corrected server and runner passes all
+four prompts, both recovery boundaries, and the persistent-home wake. Earlier
+failures exposed three defects: shutdown failed the accepted turn, the runner
+kept sending replay to the old socket, and whole-process replay could replace
+the current permission with an earlier turn's request. The fixes require both
+an updated Fountain server and an updated runner binary. The profile also checks
+that each fixture start appears exactly once under its accepted turn.
+
+The failed runs remain separate evidence. The passing local run restarts a
+source process and uses a real Go runner; it does not verify a released image,
+Kubernetes rollout, or hosted provider. A deployed staging verdict is still
+required for #1617.
 
 ## Rollout adapter
 

--- a/deployed/test/recovery-profile.test.mjs
+++ b/deployed/test/recovery-profile.test.mjs
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { mkdtempSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { verifyRecoveryTurns, verifyRecoveryState, recoveredAttachment } from '../profiles/recovery.mjs';
+import { verifyRecoveryTurns, verifyRecoveryState, recoveredAttachment, verifyRecoveryTranscript } from '../profiles/recovery.mjs';
 import { configFrom } from '../lib/runner.mjs';
 import { ciConfig } from '../ci.mjs';
 import { restoreRecoveryControls } from '../lib/recovery.mjs';
@@ -23,6 +23,12 @@ test('recovery verifier requires the same accepted turns, including the pending 
     const changed = structuredClone(rows); mutate(changed);
     assert.throws(() => verifyRecoveryTurns(changed, accepted, 'running'));
   }
+});
+test('recovery transcript rejects prior-turn output replayed under the current turn', () => {
+  const events = accepted.map(turn => ({ turn_id: turn.id, blocks: [{ kind: 'text', body: `fixture:started:${turn.scenario}:${turn.nonce}\n` }] }));
+  verifyRecoveryTranscript(events, accepted);
+  assert.throws(() => verifyRecoveryTranscript([...events, { ...events[0], turn_id: accepted[1].id }], accepted), /misattributed/);
+  assert.throws(() => verifyRecoveryTranscript([...events, events[0]], accepted), /duplicated/);
 });
 test('fixture accounting rejects duplicate prompts, premature effects and lost prior files', () => {
   verifyRecoveryState(state, 'session', accepted, 1);

--- a/docs/integrations/runners.md
+++ b/docs/integrations/runners.md
@@ -251,6 +251,19 @@ resumed still answers, as a Sprites sandbox does on its next exec.
 
 ## On the team page and the API
 
+An accepted ACP turn keeps its place during a transient runner socket drop.
+Fountain holds the turn busy for up to two minutes while the runner reconnects,
+including when the server boots before the runner returns. It attaches to the
+same process and prompt instead of submitting the prompt again. A reconnect
+does not extend a pending permission's original timeout.
+
+The runner switches both replay and live output to the new connection. Fountain
+skips earlier turns in that process journal before restoring the active turn,
+so an old permission request cannot replace the one currently waiting. If the
+runner does not return within the recovery window, the turn fails and becomes
+available for a new prompt. Interrupting the turn cancels recovery. Stopping the
+runner daemon still terminates its processes.
+
 A teammate whose sandbox lives on a runner shows where it runs. The roster
 entry's `sandbox`, and that of each conversation object, carries `provider`,
 one of `sprites|e2b|daytona|runner`. For a runner it also carries

--- a/docs/reference/webhooks.md
+++ b/docs/reference/webhooks.md
@@ -65,6 +65,7 @@ counter uses the same pair as its tags.
 | `broker` | `started` `done` `failed` | Fountain prepares the egress credential broker for the conversation, when brokerage is on for the tenant. A `failed` before any sandbox exists names the cause: the broker did not answer, or the provider cannot enforce the network floor. |
 | `setup` | `started` `done` `failed` | The environment's setup script runs. |
 | `checkpoint_restore` | `started` `done` `failed` | Fountain restores a checkpoint into the sandbox. |
+| `connection` | `started` `done` | An accepted runner turn waits for its socket to reconnect. The outcome records recovery, interruption or failure. |
 | `reattach` | `started` `done` `failed` `interrupted` | The server reconnects to a sandbox after a restart. |
 | `turn` | `started` `done` `failed` `interrupted` | One prompt and its reply. |
 | `request` | `started` `done` | The agent asked permission for a tool. It got an answer, or the request expired. |


### PR DESCRIPTION
# Preserve accepted ACP turns across runner reconnects

A runner websocket loss used to fail an accepted ACP turn even though its process survived. Reattachment also retained the old socket emitter and replayed earlier turns into the active turn. Preserve the accepted turn for a bounded reconnect window, restore its original permission deadline, move journal/live output to the attaching socket, and locate the active ACP prompt boundary before delivering replay to its peer.

Deadline expiry, interruption and other transport failures remain terminal. Register the new connection lifecycle events for webhook subscribers. Extract reattachment logic from ConversationServer and lower its size pin to 2800 lines. Strengthen the deployed recovery profile to reject duplicate or misattributed start markers.

Validation: full mix precommit passed with 4490 tests and 6 doctests, including compile, Credo, Dialyzer, Sobelow and release assembly. Go runner race tests passed. 153 deployed harness tests and public documentation checks passed. A real local source restart and process-runner socket cut passed the public recovery journey, including same-turn permissions, transcript replay, exact nonce writes and persistent-home wake, with zero resources left. That live result predates the behavior-preserving module extraction; the final extraction passed focused and full tests.

Local commit: 9088c3f7, based on 4959b7ff. Live evidence: /private/tmp/fountain-recovery-live-4/result.json. Failed live runs 1-3 and all first failing validation logs are retained. Both server and runner updates are required. This does not establish a released-image or Kubernetes staging verdict. #1617 remains open for those acceptance criteria.


Stack: targets `codex/deployed-recovery`. This is a draft for review; deployed acceptance evidence still outstanding in the linked tracker issues.
