### PR TITLE
Verify console setup and a pinned Conversations app journey

### DIFF
--- a/deployed/README.md
+++ b/deployed/README.md
@@ -232,6 +232,12 @@ request. Do not inject database rows, import server factories, or substitute
 an in-process Fountain for a deployed verdict. Existing SDK conformance
 remains separate and runnable with its existing commands.
 
+## Console browser profile
+
+The independent [console browser profile](browser/README.md) covers sign-in,
+agent editing, API key lifecycle and credential-form validation. Its remaining
+app handoff and first-account bootstrap work is tracked in #1618.
+
 ## Provider and runtime matrix
 
 `deployed/matrix.mjs` applies the same execution scenario to an explicit,

--- a/deployed/README.md
+++ b/deployed/README.md
@@ -235,8 +235,10 @@ remains separate and runnable with its existing commands.
 ## Console browser profile
 
 The independent [console browser profile](browser/README.md) covers sign-in,
-agent editing, API key lifecycle and credential-form validation. Its remaining
-app handoff and first-account bootstrap work is tracked in #1618.
+agent editing, API key lifecycle and credential-form validation. Its optional
+pinned Conversations journey submits two artifact prompts through the app.
+Remaining live verification, credential setup and first-account bootstrap work
+is tracked in #1618.
 
 ## Provider and runtime matrix
 

--- a/deployed/browser-app.example.json
+++ b/deployed/browser-app.example.json
@@ -1,0 +1,58 @@
+{
+  "base_url": "https://fountain-staging.example.com",
+  "credentials": {
+    "primary": "FOUNTAIN_SUITE_KEY"
+  },
+  "profiles": [
+    "browser"
+  ],
+  "browser": {
+    "email": "FOUNTAIN_BROWSER_EMAIL",
+    "password": "FOUNTAIN_BROWSER_PASSWORD",
+    "agent": {
+      "runtime": "claude",
+      "model": "anthropic/claude-sonnet-4-6",
+      "sandbox_provider": "sprites"
+    },
+    "credential_provider": "anthropic_api_key",
+    "step_ms": 30000,
+    "conversations": {
+      "lock": {
+        "version": "fountain-browser-app/1",
+        "url": "https://conversations-staging.example.com/",
+        "source_revision": "862552d8ece9abef20535e9b9c0b19821bf614c4",
+        "assets": [
+          {
+            "path": "/assets/index-CdLHqM00.css",
+            "sha256": "f696e0bc631b774fde20b4515ac7d7e05b486b2df0a31ffc440f1a483d5d3e3f",
+            "bytes": 24186,
+            "content_type": "text/css"
+          },
+          {
+            "path": "/assets/index-doVjL0E7.js",
+            "sha256": "5cab0c7d9c40408271e42334107d86583fc43d6016cc70df112c678326964eee",
+            "bytes": 296439,
+            "content_type": "text/javascript"
+          },
+          {
+            "path": "/",
+            "sha256": "a03ba4011d31f6f1e6ed10859a50bbb6bf950dc44b10102384b6f59c334237e2",
+            "bytes": 647,
+            "content_type": "text/html"
+          }
+        ]
+      },
+      "auth": "ui_created_api_key",
+      "oauth": "deny",
+      "max_turns": 2,
+      "provision_ms": 120000,
+      "turn_ms": 90000
+    }
+  },
+  "limits": {
+    "run_ms": 600000,
+    "request_ms": 30000,
+    "cleanup_ms": 60000,
+    "resources": 4
+  }
+}

--- a/deployed/browser.example.json
+++ b/deployed/browser.example.json
@@ -1,0 +1,14 @@
+{
+  "base_url": "https://fountain-staging.example.com",
+  "credentials": { "primary": "FOUNTAIN_SUITE_KEY" },
+  "profiles": ["browser"],
+  "browser": {
+    "email": "FOUNTAIN_BROWSER_EMAIL",
+    "password": "FOUNTAIN_BROWSER_PASSWORD",
+    "agent": { "runtime": "claude", "model": "anthropic/claude-sonnet-4-6", "sandbox_provider": "sprites" },
+    "credential_provider": "anthropic_api_key",
+    "step_ms": 30000,
+    "conversations": null
+  },
+  "limits": { "run_ms": 600000, "request_ms": 30000, "cleanup_ms": 60000, "resources": 2 }
+}

--- a/deployed/browser/.gitignore
+++ b/deployed/browser/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/deployed/browser/README.md
+++ b/deployed/browser/README.md
@@ -1,0 +1,50 @@
+# Console browser profile
+
+This is the console portion of #1618. It is under development and has no complete
+profile verdict yet. A manual local Chrome check verified sign-in, agent creation
+and editing, and empty credential validation with registration disabled. The
+pinned Playwright driver and key lifecycle still need a complete live run.
+The profile is never selected by default or by rollout canaries.
+
+Install the pinned dependency with `npm ci --prefix deployed/browser`, then
+install its Chromium build with
+`deployed/browser/node_modules/.bin/playwright install chromium`.
+Copy `deployed/browser.example.json` and set its target and environment variable
+names. Run it with the ordinary deployed suite CLI described in the parent
+README. The existing cleanup command handles a stopped browser run's manifest.
+It retains an unresolved creation intent when no matching row exists: absence
+alone cannot prove that an in-flight submission will never commit. Reconcile a
+known rejected submission separately before marking that intent canceled.
+
+The API key and the email/password must belong to the same dedicated, verified
+test account. The profile signs in through the console; it does not depend on
+registration being enabled. A fresh browser context prevents reuse of another
+person's signed-in session. The run creates at most two resources and makes no
+inference calls.
+
+The journey creates and edits an agent through the console, verifies it through
+the public owner API, creates a key through the console, authenticates with that
+key, revokes it through the console, and requires a 401 from the revoked key.
+Each creation intent is saved before clicking. A lost reply leaves an exact
+run-owned name for the standard cleanup command to recover.
+
+Credential coverage currently checks that the selected provider's input masks
+its value and an empty submission produces validation feedback without changing
+provider status. It does **not** claim successful provider validation or storage
+of a valid credential. That part of #1618 remains unfinished.
+
+Evidence is an allowlisted `browser.jsonl` action/response trace plus cropped
+static-heading screenshots. Native Playwright traces, videos, HAR, DOM dumps,
+console messages and raw errors are excluded because they can contain passwords,
+keys, cookies and OAuth codes. Error reports identify the failing named step.
+Screenshots never capture the one-time key reveal. Debug tracing environment
+variables are rejected before entering credentials.
+
+The Conversations app handoff, OAuth/CORS checks and isolated fresh-Compose
+registration case remain unfinished. Configuration requires `conversations:
+null` until the handoff implementation exists, so configuring an app cannot
+silently yield a passing app verdict. The app source is maintained separately in
+`jhgaylor/fountain-conversations`; report app rendering, routing and client
+authentication defects there with the exact source and served asset hashes.
+Report server cookies, OAuth registration, CORS and console failures in Fountain.
+Broad app UI permutations belong in that app's own suite.

--- a/deployed/browser/README.md
+++ b/deployed/browser/README.md
@@ -19,8 +19,9 @@ known rejected submission separately before marking that intent canceled.
 The API key and the email/password must belong to the same dedicated, verified
 test account. The profile signs in through the console; it does not depend on
 registration being enabled. A fresh browser context prevents reuse of another
-person's signed-in session. The run creates at most two resources and makes no
-inference calls.
+person's signed-in session. A console-only run creates at most two resources and
+makes no inference calls. The optional app journey requires four resources and
+an explicit two-prompt budget.
 
 The journey creates and edits an agent through the console, verifies it through
 the public owner API, creates a key through the console, authenticates with that
@@ -40,10 +41,57 @@ keys, cookies and OAuth codes. Error reports identify the failing named step.
 Screenshots never capture the one-time key reveal. Debug tracing environment
 variables are rejected before entering credentials.
 
-The Conversations app handoff, OAuth/CORS checks and isolated fresh-Compose
-registration case remain unfinished. Configuration requires `conversations:
-null` until the handoff implementation exists, so configuring an app cannot
-silently yield a passing app verdict. The app source is maintained separately in
+## Conversations handoff
+
+Use `deployed/browser-app.example.json` for the optional app journey. Its bundle
+lock was built from Conversations revision
+`862552d8ece9abef20535e9b9c0b19821bf614c4` with that repository's frozen dependency
+lock. Build and host that revision, or replace the lock with the exact build you
+intend to test. Keep the build's source revision and dependency/build evidence.
+
+Generate a lock from the app's built `dist` directory with:
+
+```sh
+node deployed/browser/lock-app.mjs \
+  --root /absolute/path/to/dist \
+  --url https://conversations-staging.example.com/ \
+  --revision 862552d8ece9abef20535e9b9c0b19821bf614c4 \
+  --out /tmp/conversations-lock.json
+```
+
+Copy that JSON object into `browser.conversations.lock`. Set Fountain's
+`CONVERSATIONS_APP_URL`, `API_CORS_ORIGINS` and the `fountain-conversations`
+entry in `OAUTH_CLIENTS` to the same app URL/origin. The exact redirect URI is
+the app URL with its trailing slash. The suite does not change those settings.
+The app and Fountain must have distinct origins. HTTPS is required except for
+local loopback fixtures.
+
+The preflight checks each served asset against the lock. Browser routing then
+checks the bytes the browser actually receives, including the entry page, and
+refuses unpinned app resources, redirects, and third-party app requests outside
+the configured Fountain API. Service workers are blocked. The fixture must
+honor identity content encoding so verified bytes can be delivered with their
+original headers. OAuth denial permits one callback with the expected state;
+query parameters and state never enter the evidence trace. Debug source maps
+are excluded from the fixture.
+
+The journey provisions a conversation with the UI-created agent, follows
+Fountain's `/conversations/:id` redirect, checks the app's PKCE authorization
+request, and denies consent. It then signs in through the app's supported key
+entry flow using the run-owned UI key. Both artifact prompts are sent through
+the composer. Public turn/history/file checks independently require exactly
+two accepted turns, tool use, exact nonce bytes, and full/cursor replay. The
+second assistant reply must visibly render the nonce in the app. Browser
+request origins, CORS responses, and consumed app responses are checked. After
+app sign-out, the console revokes that exact key and the public API must reject
+it with 401.
+
+This path verifies OAuth denial and API-key authentication. It does not verify
+a successful OAuth grant. A complete authenticated live handoff verdict,
+valid provider credential save/clear, successful OAuth authorization, and the
+isolated fresh-Compose registration case remain unfinished under #1618.
+
+The app source is maintained separately in
 `jhgaylor/fountain-conversations`; report app rendering, routing and client
 authentication defects there with the exact source and served asset hashes.
 Report server cookies, OAuth registration, CORS and console failures in Fountain.

--- a/deployed/browser/README.md
+++ b/deployed/browser/README.md
@@ -29,10 +29,34 @@ key, revokes it through the console, and requires a 401 from the revoked key.
 Each creation intent is saved before clicking. A lost reply leaves an exact
 run-owned name for the standard cleanup command to recover.
 
-Credential coverage currently checks that the selected provider's input masks
-its value and an empty submission produces validation feedback without changing
-provider status. It does **not** claim successful provider validation or storage
-of a valid credential. That part of #1618 remains unfinished.
+The default credential check requires a masked input and empty-submission
+feedback without changing provider status. To exercise valid setup, add
+`browser.credential_setup` with the following settings and provide the value
+through the named environment variable.
+
+```json
+{
+  "mode": "save_and_clear",
+  "exclusive_account": true,
+  "value": "FOUNTAIN_BROWSER_PROVIDER_KEY"
+}
+```
+
+Reserve this test account exclusively until cleanup finishes. This setting is
+an operator assertion, not a server lock. The provider status API exposes no
+revision or compare-and-swap operation, so this mode cannot safely share an
+account with another writer. An already-set provider is refused. Increase the
+resource budget to three for console checks or five for the app journey.
+
+Setup runs before agent creation. It submits the supplied value once, requires
+the console's successful provider-validation message and public set status,
+and leaves the credential available during the optional app prompts. At the
+end, the console clears it and the API must report unset. Failure cleanup uses
+the public DELETE endpoint. The manifest records provider, initial unset state,
+account reservation and progress; it never records the value. An unset provider
+with an unresolved save intent remains pending because the save could still
+commit. Keep the account reserved until that submission is reconciled.
+This path has automated cleanup tests but still needs live browser validation.
 
 Evidence is an allowlisted `browser.jsonl` action/response trace plus cropped
 static-heading screenshots. Native Playwright traces, videos, HAR, DOM dumps,
@@ -88,7 +112,7 @@ it with 401.
 
 This path verifies OAuth denial and API-key authentication. It does not verify
 a successful OAuth grant. A complete authenticated live handoff verdict,
-valid provider credential save/clear, successful OAuth authorization, and the
+live provider credential save/clear, successful OAuth authorization, and the
 isolated fresh-Compose registration case remain unfinished under #1618.
 
 The app source is maintained separately in

--- a/deployed/browser/README.md
+++ b/deployed/browser/README.md
@@ -112,11 +112,76 @@ it with 401.
 
 This path verifies OAuth denial and API-key authentication. It does not verify
 a successful OAuth grant. A complete authenticated live handoff verdict,
-live provider credential save/clear, successful OAuth authorization, and the
-isolated fresh-Compose registration case remain unfinished under #1618.
+live provider credential save/clear and successful OAuth authorization remain
+unverified. The isolated bootstrap case is described below.
 
 The app source is maintained separately in
 `jhgaylor/fountain-conversations`; report app rendering, routing and client
 authentication defects there with the exact source and served asset hashes.
 Report server cookies, OAuth registration, CORS and console failures in Fountain.
 Broad app UI permutations belong in that app's own suite.
+
+## Fresh Compose bootstrap
+
+First-account registration runs separately from the existing-instance profile.
+It requires no preexisting account or API key. Copy this configuration, replace
+the image placeholders with registry digests and select a local Docker context.
+Pull both exact image references before starting the case.
+
+```json
+{
+  "app_image": "ghcr.io/binarybourbon/fountain@sha256:REPLACE_WITH_DIGEST",
+  "postgres_image": "postgres@sha256:REPLACE_WITH_DIGEST",
+  "context": "orbstack",
+  "port": 14826
+}
+```
+
+Use the same pinned browser dependency installed above.
+
+```sh
+node deployed/browser/bootstrap.mjs run \
+  --config /absolute/path/to/bootstrap-target.json \
+  --out /tmp/fountain-bootstrap-run
+```
+
+The output directory must be new. The case resolves this repository's Compose
+file without the operator's environment or service credentials. It records that
+source file's hash and each image's identity, including the app source revision.
+It runs the stock app and Postgres services with generated local encryption
+secrets, no email delivery, registration enabled and first-admin bootstrap on.
+These settings apply only to its new project. External app links are disabled.
+
+Each project gets a unique network and database volume. The app publishes only
+the selected loopback port; Postgres publishes no port. Before browser work,
+the adapter checks actual image identities and port bindings, host health and
+readiness responses, and an empty user/key database. A local Unix-socket Docker
+endpoint is required. The ordinary bridge network permits the host connection;
+this case does not claim an outbound network sandbox.
+
+The browser creates one synthetic account, signs in, opens Admin, signs out,
+and requires a subsequent Admin navigation to redirect to login. A fixed
+read-only database query independently requires exactly one verified admin and
+zero API keys. Evidence uses named browser steps and a static Admin-heading
+crop. No inference calls or API-key creation are part of this case.
+
+Cleanup checks the Docker endpoint, Compose configuration hash and both project
+and run labels before removing the containers, network and database volume.
+It verifies that no resources remain, then removes generated secret files.
+If interrupted, preserve the private output directory and run the following.
+
+```sh
+node deployed/browser/bootstrap.mjs cleanup --out /tmp/fountain-bootstrap-run
+```
+
+For an interactive browser check, use `prepare` in place of `run`. This leaves
+the verified fresh fixture running and prints its local URL. Run cleanup after
+the browser check. Never expose that fixture beyond loopback or reuse its
+account as an existing-instance test account.
+
+Local Chrome exercised registration, sign-in, first-admin access and sign-out
+against the Compose-pinned v0.16.0 image. Database counts confirmed one verified
+admin and zero keys; cleanup removed all four Docker resources. An initial
+Admin-heading lookup timed out in the browser transport. Subsequent DOM
+inspection verified the page, and the original timeout remains in the evidence.
+The standalone Playwright bootstrap driver still needs its own live verdict.

--- a/deployed/browser/bootstrap.mjs
+++ b/deployed/browser/bootstrap.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { parseArgs } from 'node:util';
+import { randomBytes } from 'node:crypto';
+import { FreshCompose } from '../lib/fresh-compose.mjs';
+import { BrowserEvidence } from '../lib/browser-evidence.mjs';
+import { browserBootstrap } from '../profiles/browser-bootstrap.mjs';
+
+// Separate from the deployed-instance CLI: this case needs no existing user
+// or API key and cannot enable registration on an existing instance.
+let fixture, engine;
+try {
+  const { values, positionals } = parseArgs({ allowPositionals: true, options: { config: { type: 'string' }, out: { type: 'string' } } });
+  if (positionals.length !== 1 || !['run', 'prepare', 'cleanup'].includes(positionals[0]) || !values.out) throw new Error('Use bootstrap.mjs run|prepare --config FILE --out DIRECTORY, or cleanup --out DIRECTORY');
+  const action = positionals[0];
+  const out = resolve(values.out);
+  if (action === 'cleanup') {
+    await FreshCompose.load(out).cleanup();
+    console.log('Bootstrap cleanup complete');
+  } else {
+    if (!values.config) throw new Error('Bootstrap configuration is required');
+    if (process.env.DEBUG || process.env.PWDEBUG || process.env.PW_TRACE) throw new Error('Disable browser debug/native tracing before bootstrap');
+    fixture = await FreshCompose.prepare(out, JSON.parse(readFileSync(values.config)));
+    await fixture.up();
+    if (action === 'prepare') {
+      console.log(`Fresh Compose ready at ${fixture.manifest.url}; use cleanup --out with this directory after browser checks`);
+      fixture = undefined; // Explicit prepared-fixture mode retains its journal.
+    } else {
+      const { chromium } = await import('./node_modules/playwright/index.mjs');
+      engine = await chromium.launch({ headless: true });
+      const context = await engine.newContext({ acceptDownloads: false, serviceWorkers: 'block' });
+      const page = await context.newPage();
+      page.setDefaultTimeout(30000); page.setDefaultNavigationTimeout(30000);
+      const evidence = new BrowserEvidence(resolve(out, 'browser'), [fixture.manifest.url]);
+      await browserBootstrap(fixture, page, evidence, {
+        email: `bootstrap-${fixture.manifest.run_id}@example.test`, password: randomBytes(24).toString('base64url'),
+      });
+      console.log('Fresh Compose registration, first-admin sign-in and sign-out passed');
+    }
+  }
+} catch {
+  console.error('Bootstrap failed; inspect bootstrap.json and named steps in browser/browser.jsonl. Raw browser/command errors are withheld.');
+  process.exitCode = 1;
+} finally {
+  if (engine) await engine.close().catch(() => { process.exitCode = 1; });
+  if (fixture) await fixture.cleanup().catch(() => {
+    console.error('Bootstrap cleanup incomplete; retain the private fixture directory and run cleanup --out again.');
+    process.exitCode = 1;
+  });
+}

--- a/deployed/browser/lock-app.mjs
+++ b/deployed/browser/lock-app.mjs
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+import { parseArgs } from 'node:util';
+import { writeFileSync } from 'node:fs';
+import { buildAppLock } from '../lib/browser-app-lock.mjs';
+
+try {
+  const { values } = parseArgs({ options: { root: { type: 'string' }, url: { type: 'string' }, revision: { type: 'string' }, out: { type: 'string' } } });
+  if (!values.root || !values.url || !values.revision || !values.out) throw new Error('Usage: node deployed/browser/lock-app.mjs --root DIST --url APP_URL --revision COMMIT_SHA --out LOCK.json');
+  writeFileSync(values.out, JSON.stringify(buildAppLock(values.root, values.url, values.revision), null, 2) + '\n', { mode: 0o600, flag: 'wx' });
+} catch (error) { console.error(error.message); process.exitCode = 1; }

--- a/deployed/browser/package-lock.json
+++ b/deployed/browser/package-lock.json
@@ -1,0 +1,40 @@
+{
+  "name": "fountain-deployed-browser",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "fountain-deployed-browser",
+      "dependencies": {
+        "playwright": "1.63.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.63.0.tgz",
+      "integrity": "sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.63.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.63.0.tgz",
+      "integrity": "sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    }
+  }
+}

--- a/deployed/browser/package.json
+++ b/deployed/browser/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "fountain-deployed-browser",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "playwright": "1.63.0"
+  }
+}

--- a/deployed/lib/browser-app-lock.mjs
+++ b/deployed/lib/browser-app-lock.mjs
@@ -1,0 +1,141 @@
+import { createHash } from 'node:crypto';
+import { readFileSync, readdirSync, lstatSync } from 'node:fs';
+import { resolve, relative, sep } from 'node:path';
+import { ensure } from './execution.mjs';
+
+export const APP_LOCK_VERSION = 'fountain-browser-app/1';
+const digest = bytes => createHash('sha256').update(bytes).digest('hex');
+const maxFile = 4 * 1024 * 1024;
+const maxTotal = 24 * 1024 * 1024;
+const mime = { '.html': 'text/html', '.js': 'text/javascript', '.css': 'text/css', '.json': 'application/json', '.svg': 'image/svg+xml', '.png': 'image/png', '.ico': 'image/x-icon', '.woff2': 'font/woff2' };
+
+export function appUrl(value) {
+  const url = new URL(value);
+  ensure((url.protocol === 'https:' || (url.protocol === 'http:' && ['127.0.0.1', 'localhost', '[::1]'].includes(url.hostname))) &&
+    !url.username && !url.password && !url.search && !url.hash && url.pathname.endsWith('/') && assetPath(url.pathname), 'App URL must be HTTPS (or local loopback), without credentials/query/fragment, ending in /');
+  return url;
+}
+
+function assetPath(path) {
+  return typeof path === 'string' && path.length <= 240 && path.startsWith('/') && !path.includes('//') &&
+    !path.split('/').some(part => ['.', '..'].includes(part)) && /^\/[a-zA-Z0-9_./-]*$/.test(path);
+}
+
+export function validateAppLock(lock) {
+  ensure(lock && Object.keys(lock).every(k => ['version', 'url', 'source_revision', 'assets'].includes(k)) && lock.version === APP_LOCK_VERSION, 'Unknown browser app lock');
+  const url = appUrl(lock.url);
+  lock.url = url.href;
+  ensure(/^[a-f0-9]{40}$/.test(lock.source_revision), 'App source revision must be a full commit SHA');
+  ensure(Array.isArray(lock.assets) && lock.assets.length > 0 && lock.assets.length <= 128, 'App lock requires 1-128 assets');
+  let total = 0;
+  const paths = new Set();
+  for (const asset of lock.assets) {
+    ensure(asset && Object.keys(asset).every(k => ['path', 'sha256', 'bytes', 'content_type'].includes(k)) &&
+      assetPath(asset.path) && asset.path.startsWith(url.pathname) && !paths.has(asset.path) &&
+      /^[a-f0-9]{64}$/.test(asset.sha256) && Number.isSafeInteger(asset.bytes) && asset.bytes > 0 && asset.bytes <= maxFile &&
+      Object.values(mime).includes(asset.content_type), 'Invalid, duplicate, or unbounded app asset');
+    paths.add(asset.path); total += asset.bytes;
+  }
+  ensure(total <= maxTotal && lock.assets.some(a => a.path === url.pathname && a.content_type === 'text/html'), 'App lock must contain its entry page and fit the bundle budget');
+  return lock;
+}
+
+export function buildAppLock(root, urlString, revision) {
+  const url = appUrl(urlString);
+  root = resolve(root);
+  ensure(lstatSync(root).isDirectory() && !lstatSync(root).isSymbolicLink(), 'Bundle root must be a real directory');
+  const assets = [];
+  function visit(directory) {
+    for (const name of readdirSync(directory).sort()) {
+      const file = resolve(directory, name), stat = lstatSync(file);
+      ensure(!stat.isSymbolicLink(), 'Bundle cannot contain symbolic links');
+      if (stat.isDirectory()) { visit(file); continue; }
+      ensure(stat.isFile(), 'Bundle contains a non-file');
+      if (name.endsWith('.map')) continue; // Debug source maps are not served by this fixture.
+      const extension = name.slice(name.lastIndexOf('.'));
+      ensure(mime[extension] && stat.size > 0 && stat.size <= maxFile, 'Unsupported or oversized bundle asset');
+      const local = relative(root, file).split(sep).join('/');
+      const path = url.pathname + (local === 'index.html' ? '' : local);
+      ensure(assetPath(path), 'Bundle asset path is not canonical');
+      assets.push({ path, sha256: digest(readFileSync(file)), bytes: stat.size, content_type: mime[extension] });
+      ensure(assets.length <= 128, 'Bundle asset count exceeded');
+    }
+  }
+  visit(root);
+  return validateAppLock({ version: APP_LOCK_VERSION, url: url.href, source_revision: revision, assets });
+}
+
+export function verifyAppBytes(asset, status, headers, bytes) {
+  ensure(status === 200, 'Pinned app asset did not return 200 without redirect');
+  ensure(!headers['content-encoding'] || headers['content-encoding'] === 'identity', 'Pinned app fixture must honor identity content encoding');
+  ensure(bytes.length === asset.bytes && digest(bytes) === asset.sha256, 'Pinned app asset bytes changed');
+  const actual = (headers['content-type'] ?? '').split(';')[0].trim().toLowerCase();
+  const accepted = asset.content_type === 'text/javascript' ? ['text/javascript', 'application/javascript'] : [asset.content_type];
+  ensure(accepted.includes(actual), 'Pinned app asset content type changed');
+}
+
+export async function fetchPinnedApp(lock, { signal, fetchImpl = fetch } = {}) {
+  validateAppLock(lock);
+  const url = appUrl(lock.url), observed = [];
+  for (const asset of lock.assets) {
+    const response = await fetchImpl(new URL(asset.path, url.origin), { redirect: 'manual', credentials: 'omit', headers: { 'accept-encoding': 'identity' }, signal });
+    ensure(response.status === 200, 'Pinned app asset did not return 200 without redirect');
+    const chunks = []; let size = 0;
+    try {
+      for await (const chunk of response.body) {
+        size += chunk.length;
+        ensure(size <= asset.bytes, 'Pinned app asset exceeded expected byte length');
+        chunks.push(chunk);
+      }
+    } finally { await response.body?.cancel().catch(() => {}); }
+    verifyAppBytes(asset, response.status, Object.fromEntries(response.headers), Buffer.concat(chunks));
+    observed.push({ path: asset.path, sha256: asset.sha256, bytes: size });
+  }
+  return { source_revision: lock.source_revision, assets: observed };
+}
+
+// Verify the response the browser actually consumes, not just an earlier GET.
+// Fulfill with the same bytes, status and headers; never rewrite a broken app.
+export async function guardBrowserApp(context, lock, { apiOrigin } = {}) {
+  validateAppLock(lock);
+  const origin = appUrl(lock.url).origin, observed = new Set();
+  let failure, deniedState;
+  await context.route('**/*', async route => {
+    try {
+      const request = route.request(), url = new URL(request.url());
+      if (url.origin !== origin) {
+        const fromApp = new URL(request.frame().url()).origin === origin;
+        ensure(!fromApp || (url.origin === apiOrigin && (request.isNavigationRequest() || url.pathname.startsWith('/api/'))),
+          'App requested a resource outside its pinned bundle and Fountain API');
+        await route.continue();
+        return;
+      }
+      const asset = lock.assets.find(a => a.path === url.pathname);
+      const deniedCallback = url.pathname === appUrl(lock.url).pathname && deniedState && url.searchParams.size === 2 &&
+        url.searchParams.get('error') === 'access_denied' && url.searchParams.get('state') === deniedState;
+      ensure(request.method() === 'GET' && (!url.search || deniedCallback) && asset, 'Browser requested an unpinned app resource');
+      if (deniedCallback) deniedState = undefined;
+      // Identity encoding lets the exact verified bytes be fulfilled without
+      // changing compression headers or repairing a broken response.
+      const response = await route.fetch({ maxRedirects: 0, maxRetries: 0,
+        headers: { ...request.headers(), 'accept-encoding': 'identity' } });
+      const bytes = await response.body();
+      verifyAppBytes(asset, response.status(), response.headers(), bytes);
+      observed.add(asset.path);
+      await route.fulfill({ response, body: bytes });
+    } catch {
+      failure = 'Browser app resource failed its immutable bundle check';
+      await route.abort().catch(() => {});
+    }
+  });
+  return {
+    expectDeniedCallback(state) {
+      ensure(/^[A-Za-z0-9_-]{16,128}$/.test(state), 'Invalid expected OAuth denial state');
+      deniedState = state;
+    },
+    verify() {
+      ensure(!failure && observed.has(appUrl(lock.url).pathname), failure ?? 'Browser did not load the pinned entry page');
+      return { source_revision: lock.source_revision, observed_assets: [...observed].sort() };
+    },
+  };
+}

--- a/deployed/lib/browser-config.mjs
+++ b/deployed/lib/browser-config.mjs
@@ -1,8 +1,10 @@
 import { ensure } from './execution.mjs';
+import { validateAppLock, appUrl } from './browser-app-lock.mjs';
 
 const variable = /^[A-Z][A-Z0-9_]*$/;
 export function validateBrowser(config, env) {
   const b = config.browser;
+  ensure(new URL(config.base_url).pathname === '/', 'Browser console target must be the instance origin without a path prefix');
   ensure(config.profiles.length === 1 && !config.execution && !config.fixture, 'Run the browser console profile independently');
   ensure(b && Object.keys(b).every(k => ['email', 'password', 'agent', 'credential_provider', 'step_ms', 'conversations'].includes(k)), 'Expected explicit browser configuration');
   for (const name of ['email', 'password']) {
@@ -17,6 +19,20 @@ export function validateBrowser(config, env) {
   ensure(['anthropic_api_key', 'claude_code_oauth_token', 'openai_api_key', 'gemini_api_key'].includes(b.credential_provider), 'Select a credential setup provider');
   b.step_ms ??= 30000;
   ensure(Number.isSafeInteger(b.step_ms) && b.step_ms >= 1000 && b.step_ms <= 60000, 'Browser step_ms must be 1000-60000');
-  ensure(b.conversations === null, 'This console profile requires conversations:null; app handoff coverage is not implemented yet');
+  ensure(b.conversations === null || (b.conversations && typeof b.conversations === 'object'), 'Declare conversations:null or an explicit pinned app journey');
+  if (b.conversations) {
+    const app = b.conversations;
+    ensure(Object.keys(app).every(k => ['lock', 'auth', 'oauth', 'max_turns', 'provision_ms', 'turn_ms'].includes(k)), 'Unknown Conversations app setting');
+    validateAppLock(app.lock);
+    ensure(appUrl(app.lock.url).origin !== new URL(config.base_url).origin, 'Conversations app must use a separate origin to verify CORS');
+    ensure(app.auth === 'ui_created_api_key' && app.oauth === 'deny', 'This adapter supports UI-created API key sign-in and OAuth denial; successful OAuth grants are not verified');
+    ensure(app.max_turns === 2, 'Browser artifact journey requires an explicit two-prompt budget');
+    for (const key of ['provision_ms', 'turn_ms']) {
+      app[key] ??= key === 'provision_ms' ? 120000 : 90000;
+      ensure(Number.isSafeInteger(app[key]) && app[key] >= 1000 && app[key] <= 300000, `Browser ${key} must be 1000-300000`);
+    }
+    ensure(config.limits.resources >= 4 && config.limits.run_ms >= app.provision_ms + 2 * app.turn_ms + 6 * b.step_ms,
+      'App journey needs four resources and time for provision, two turns and sign-in');
+  }
   ensure(config.limits.run_ms <= 600000 && config.limits.resources >= 2, 'Browser console requires a ten-minute bound and two-resource budget');
 }

--- a/deployed/lib/browser-config.mjs
+++ b/deployed/lib/browser-config.mjs
@@ -6,7 +6,7 @@ export function validateBrowser(config, env) {
   const b = config.browser;
   ensure(new URL(config.base_url).pathname === '/', 'Browser console target must be the instance origin without a path prefix');
   ensure(config.profiles.length === 1 && !config.execution && !config.fixture, 'Run the browser console profile independently');
-  ensure(b && Object.keys(b).every(k => ['email', 'password', 'agent', 'credential_provider', 'step_ms', 'conversations'].includes(k)), 'Expected explicit browser configuration');
+  ensure(b && Object.keys(b).every(k => ['email', 'password', 'agent', 'credential_provider', 'credential_setup', 'step_ms', 'conversations'].includes(k)), 'Expected explicit browser configuration');
   for (const name of ['email', 'password']) {
     ensure(variable.test(b[name]) && typeof env[b[name]] === 'string' && env[b[name]].length > 0, `Browser ${name} must name a populated environment variable`);
   }
@@ -17,6 +17,14 @@ export function validateBrowser(config, env) {
     typeof a.model === 'string' && /^[a-z0-9_-]+\/[a-z0-9._-]+$/.test(a.model) &&
     ['sprites', 'e2b', 'daytona', 'runner'].includes(a.sandbox_provider), 'Pin the browser agent runtime, model and sandbox provider');
   ensure(['anthropic_api_key', 'claude_code_oauth_token', 'openai_api_key', 'gemini_api_key'].includes(b.credential_provider), 'Select a credential setup provider');
+  if (b.credential_setup !== undefined) {
+    const setup = b.credential_setup;
+    ensure(setup && Object.keys(setup).sort().join(',') === 'exclusive_account,mode,value' &&
+      setup.mode === 'save_and_clear' && setup.exclusive_account === true, 'Credential save/clear requires explicit exclusive-account reservation');
+    ensure(variable.test(setup.value) && typeof env[setup.value] === 'string' && env[setup.value].trim().length > 0,
+      'Credential value must name a populated environment variable');
+    ensure(config.limits.resources >= (b.conversations ? 5 : 3), 'Credential setup needs an additional resource slot');
+  }
   b.step_ms ??= 30000;
   ensure(Number.isSafeInteger(b.step_ms) && b.step_ms >= 1000 && b.step_ms <= 60000, 'Browser step_ms must be 1000-60000');
   ensure(b.conversations === null || (b.conversations && typeof b.conversations === 'object'), 'Declare conversations:null or an explicit pinned app journey');

--- a/deployed/lib/browser-config.mjs
+++ b/deployed/lib/browser-config.mjs
@@ -1,0 +1,22 @@
+import { ensure } from './execution.mjs';
+
+const variable = /^[A-Z][A-Z0-9_]*$/;
+export function validateBrowser(config, env) {
+  const b = config.browser;
+  ensure(config.profiles.length === 1 && !config.execution && !config.fixture, 'Run the browser console profile independently');
+  ensure(b && Object.keys(b).every(k => ['email', 'password', 'agent', 'credential_provider', 'step_ms', 'conversations'].includes(k)), 'Expected explicit browser configuration');
+  for (const name of ['email', 'password']) {
+    ensure(variable.test(b[name]) && typeof env[b[name]] === 'string' && env[b[name]].length > 0, `Browser ${name} must name a populated environment variable`);
+  }
+  ensure(!env.DEBUG && !env.PWDEBUG && !env.PW_TRACE, 'Disable browser debug/native trace environment variables before entering credentials');
+  const a = b.agent;
+  ensure(a && Object.keys(a).every(k => ['runtime', 'model', 'sandbox_provider'].includes(k)) &&
+    ['claude', 'codex', 'gemini', 'opencode'].includes(a.runtime) &&
+    typeof a.model === 'string' && /^[a-z0-9_-]+\/[a-z0-9._-]+$/.test(a.model) &&
+    ['sprites', 'e2b', 'daytona', 'runner'].includes(a.sandbox_provider), 'Pin the browser agent runtime, model and sandbox provider');
+  ensure(['anthropic_api_key', 'claude_code_oauth_token', 'openai_api_key', 'gemini_api_key'].includes(b.credential_provider), 'Select a credential setup provider');
+  b.step_ms ??= 30000;
+  ensure(Number.isSafeInteger(b.step_ms) && b.step_ms >= 1000 && b.step_ms <= 60000, 'Browser step_ms must be 1000-60000');
+  ensure(b.conversations === null, 'This console profile requires conversations:null; app handoff coverage is not implemented yet');
+  ensure(config.limits.run_ms <= 600000 && config.limits.resources >= 2, 'Browser console requires a ten-minute bound and two-resource budget');
+}

--- a/deployed/lib/browser-credentials.mjs
+++ b/deployed/lib/browser-credentials.mjs
@@ -1,0 +1,54 @@
+const providers = ['anthropic_api_key', 'claude_code_oauth_token', 'openai_api_key', 'gemini_api_key'];
+export const credentialPath = '/api/account/inference-credentials';
+
+export function validateCredentialManifest(manifest) {
+  const entry = manifest.browser_credential;
+  if (entry === undefined) return;
+  if (!entry || Object.keys(entry).sort().join(',') !== 'exclusive_account,initial_set,provider,state' ||
+      entry.exclusive_account !== true || entry.initial_set !== false || !providers.includes(entry.provider) ||
+      !['pending', 'saved', 'cleaned'].includes(entry.state)) {
+    throw new Error('Invalid browser credential cleanup intent');
+  }
+}
+
+export async function credentialStatus(client, provider, signal) {
+  const { body } = await client.request('GET', credentialPath, { expected: 200, recordBody: false, signal });
+  const rows = body?.data?.filter(row => row.provider === provider);
+  if (rows?.length !== 1 || typeof rows[0].set !== 'boolean') throw new Error('Cannot establish provider credential status');
+  return rows[0].set;
+}
+
+export async function reserveCredential(fixtures, provider, exclusiveAccount, signal) {
+  if (exclusiveAccount !== true || !providers.includes(provider) || fixtures.manifest.browser_credential) {
+    throw new Error('Credential setup requires one exclusive-account intent');
+  }
+  if (fixtures.manifest.resources.length >= fixtures.maxResources) throw new Error('Fixture resource budget exhausted');
+  if (await credentialStatus(fixtures.client, provider, signal)) throw new Error('Refusing to replace a preexisting provider credential');
+  const entry = { provider, exclusive_account: true, initial_set: false, state: 'pending' };
+  fixtures.manifest.browser_credential = entry;
+  fixtures.save(); // No value is persisted. Record intent before the UI submission.
+  return entry;
+}
+
+// The singleton API has no revision/CAS or run marker. The operator must reserve
+// this account exclusively through cleanup. This is not safe on a shared account.
+export async function cleanupCredential(fixtures, signal) {
+  const entry = fixtures.manifest.browser_credential;
+  if (!entry || entry.state === 'cleaned') return [];
+  try {
+    validateCredentialManifest(fixtures.manifest);
+    const set = await credentialStatus(fixtures.client, entry.provider, signal);
+    if (!set && entry.state === 'pending') throw new Error('Unresolved credential submission; retain account reservation until it settles');
+    if (set) {
+      // Seeing the one submitted value establishes that its save has committed,
+      // including when the browser lost the success response. Never resubmit it.
+      entry.state = 'saved'; fixtures.save();
+      await fixtures.client.request('DELETE', `${credentialPath}/${entry.provider}`, { expected: 204, recordBody: false, signal });
+      if (await credentialStatus(fixtures.client, entry.provider, signal)) throw new Error('Provider credential remains set after cleanup');
+    }
+    entry.state = 'cleaned'; fixtures.save();
+    return [];
+  } catch (error) {
+    return [{ kind: 'browser_credential', provider: entry.provider, error: error.message }];
+  }
+}

--- a/deployed/lib/browser-evidence.mjs
+++ b/deployed/lib/browser-evidence.mjs
@@ -1,0 +1,56 @@
+import { appendFileSync, mkdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// Browser engines' native traces include form values, cookies and response
+// bodies. Keep a deliberately small action/network trace instead. Values and
+// exception messages never enter this recorder, even on a failed sign-in.
+export class BrowserEvidence {
+  constructor(directory, origins) {
+    this.directory = directory;
+    this.origins = new Set(origins);
+    this.entries = [];
+    mkdirSync(directory, { recursive: true, mode: 0o700 });
+  }
+  write(entry) {
+    if (this.entries.length >= 500) throw new Error('Browser evidence budget exhausted');
+    this.entries.push(entry);
+    appendFileSync(resolve(this.directory, 'browser.jsonl'), JSON.stringify(entry) + '\n', { mode: 0o600 });
+  }
+  action(step, state) {
+    if (!/^[a-z][a-z0-9/-]{0,79}$/.test(step) || !['started', 'passed', 'failed'].includes(state)) {
+      throw new Error('Invalid browser evidence action');
+    }
+    this.write({ kind: 'action', step, state, at: new Date().toISOString() });
+  }
+  response(method, rawUrl, status) {
+    let url;
+    try { url = new URL(rawUrl); } catch { return; }
+    if (!this.origins.has(url.origin)) return;
+    // Only fixed, nonsensitive routes. Queries contain OAuth codes/state and
+    // cannot be retained; arbitrary paths can contain credentials too.
+    const route = ['/api/auth/me', '/api/oauth/token', '/api/oauth/revoke', '/auth/login', '/oauth/authorize']
+      .find(path => url.pathname === path);
+    if (!route || !['GET', 'POST', 'OPTIONS'].includes(method) || !Number.isInteger(status)) return;
+    this.write({ kind: 'response', method, origin: url.origin, route, status });
+  }
+  async step(name, fn) {
+    this.action(name, 'started');
+    try {
+      const value = await fn();
+      this.action(name, 'passed');
+      return value;
+    } catch {
+      this.action(name, 'failed');
+      // Playwright's error/call log can contain fill() arguments and page text.
+      throw new Error(`Browser step ${name} failed; inspect browser.jsonl`);
+    }
+  }
+  async heading(page, name, text) {
+    if (!/^[a-z][a-z0-9-]{0,59}$/.test(name)) throw new Error('Invalid screenshot name');
+    // Capture only a known static heading after checking exact text. Neither
+    // the page's form values nor the one-time key modal is in the crop.
+    const heading = page.getByRole('heading', { name: text, exact: true });
+    if ((await heading.innerText()).trim() !== text) throw new Error('Screenshot heading changed');
+    await heading.screenshot({ path: resolve(this.directory, `${name}.png`) });
+  }
+}

--- a/deployed/lib/browser-fixtures.mjs
+++ b/deployed/lib/browser-fixtures.mjs
@@ -8,7 +8,7 @@ const uuid = /^[a-f0-9]{8}(?:-[a-f0-9]{4}){3}-[a-f0-9]{12}$/i;
 // The ordinary cleanup command already understands these manifest entries.
 export function reserveBrowserFixture(fixtures, kind) {
   ensure(Object.hasOwn(collections, kind), 'Unsupported browser fixture kind');
-  ensure(fixtures.manifest.resources.length < fixtures.maxResources, 'Fixture resource budget exhausted');
+  ensure(fixtures.manifest.resources.length + Number(Boolean(fixtures.manifest.browser_credential)) < fixtures.maxResources, 'Fixture resource budget exhausted');
   const resource = { kind, name: `suite-${fixtures.manifest.run_id}-${kind}-${fixtures.manifest.resources.length}`, state: 'pending' };
   fixtures.manifest.resources.push(resource);
   fixtures.save();

--- a/deployed/lib/browser-fixtures.mjs
+++ b/deployed/lib/browser-fixtures.mjs
@@ -1,0 +1,27 @@
+import { ensure } from './execution.mjs';
+
+const collections = { agent: '/api/agents', api_key: '/api/auth/api-keys' };
+const uuid = /^[a-f0-9]{8}(?:-[a-f0-9]{4}){3}-[a-f0-9]{12}$/i;
+
+// UI creation has the same lost-response problem as POST. Record the intent
+// before clicking, then recover its unique name through the public owner list.
+// The ordinary cleanup command already understands these manifest entries.
+export function reserveBrowserFixture(fixtures, kind) {
+  ensure(Object.hasOwn(collections, kind), 'Unsupported browser fixture kind');
+  ensure(fixtures.manifest.resources.length < fixtures.maxResources, 'Fixture resource budget exhausted');
+  const resource = { kind, name: `suite-${fixtures.manifest.run_id}-${kind}-${fixtures.manifest.resources.length}`, state: 'pending' };
+  fixtures.manifest.resources.push(resource);
+  fixtures.save();
+  return resource;
+}
+
+export async function adoptBrowserFixture(fixtures, resource, signal) {
+  ensure(fixtures.manifest.resources.includes(resource) && resource.state === 'pending', 'Browser intent is not pending');
+  const { body } = await fixtures.client.request('GET', collections[resource.kind], { expected: 200, recordBody: false, signal });
+  const found = body.data.filter(item => item.name === resource.name);
+  ensure(found.length === 1 && uuid.test(found[0].id), 'UI fixture is missing or its ownership is ambiguous');
+  resource.id = found[0].id;
+  resource.state = 'created';
+  fixtures.save();
+  return found[0];
+}

--- a/deployed/lib/execution.mjs
+++ b/deployed/lib/execution.mjs
@@ -47,11 +47,12 @@ export function turnMetadata(event) {
   try { return JSON.parse(event.data); } catch { throw new Error('Turn stage metadata is not JSON'); }
 }
 
-export async function performTurn(ctx, conversation, prompt, number, after, { verifyStreaming = false } = {}) {
+export async function performTurn(ctx, conversation, prompt, number, after, { verifyStreaming = false, submit } = {}) {
   const startedMs = performance.now();
   const signal = phaseSignal(ctx.signal, ctx.config.execution.turn_ms);
   ctx.fixtures.reserveTurn(conversation.id, ctx.config.execution.max_turns);
-  const queued = await ctx.client.request('POST', `/api/conversations/${conversation.id}/prompts`, { body: { prompt }, expected: 200, signal });
+  const queued = submit ? await submit({ prompt, signal }) :
+    await ctx.client.request('POST', `/api/conversations/${conversation.id}/prompts`, { body: { prompt }, expected: 200, signal });
   ensure(queued.body.status === 'queued', 'Prompt was not acknowledged as queued');
   let startedId;
   const isDone = event => {

--- a/deployed/lib/fixtures.mjs
+++ b/deployed/lib/fixtures.mjs
@@ -2,6 +2,7 @@ import { writeFileSync, renameSync, readFileSync } from 'node:fs';
 import { randomUUID } from 'node:crypto';
 import { setTimeout as sleep } from 'node:timers/promises';
 import { cleanupSchedule, validateScheduleManifest } from './scheduled-fixtures.mjs';
+import { cleanupCredential, validateCredentialManifest } from './browser-credentials.mjs';
 
 const collections = { agent: '/api/agents', environment: '/api/environments', vault: '/api/vaults', binding: '/api/secret-bindings', api_key: '/api/auth/api-keys', conversation: '/api/conversations', webhook: '/api/webhooks' };
 const uuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -47,17 +48,19 @@ export class Fixtures {
       }
     }
     validateScheduleManifest(existing);
+    validateCredentialManifest(existing);
     return new Fixtures(path, client, { existing });
   }
   save() { atomicJson(this.path, this.manifest); }
   remainingCount() {
     const s = this.manifest.schedule;
     return this.manifest.resources.filter(r => r.state !== 'cleaned').length +
-      (s ? Number(s.state !== 'cleaned') + s.conversations.filter(c => c.state !== 'cleaned').length : 0);
+      (s ? Number(s.state !== 'cleaned') + s.conversations.filter(c => c.state !== 'cleaned').length : 0) +
+      Number(Boolean(this.manifest.browser_credential && this.manifest.browser_credential.state !== 'cleaned'));
   }
   async create(kind, attrs = {}) {
     if (!collections[kind]) throw new Error('Unsupported fixture kind');
-    if (this.manifest.resources.length + (this.manifest.schedule ? 2 : 0) >= this.maxResources) throw new Error('Fixture resource budget exhausted');
+    if (this.manifest.resources.length + (this.manifest.schedule ? 2 : 0) + Number(Boolean(this.manifest.browser_credential)) >= this.maxResources) throw new Error('Fixture resource budget exhausted');
     const resource = { kind, name: `suite-${this.manifest.run_id}-${kind}-${this.manifest.resources.length}`, state: 'pending' };
     if (kind === 'webhook') {
       if (typeof attrs.url !== 'string' || !attrs.url.startsWith('https://')) throw new Error('Webhook requires an explicit HTTPS target');
@@ -198,6 +201,7 @@ export class Fixtures {
         r.state = 'cleaned'; this.save();
       } catch (error) { failures.push({ kind: r.kind, id: r.id, error: error.message }); }
     }
+    failures.push(...await cleanupCredential(this, signal));
     return failures;
   }
 }

--- a/deployed/lib/fresh-compose.mjs
+++ b/deployed/lib/fresh-compose.mjs
@@ -1,0 +1,198 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { mkdirSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { randomBytes, randomUUID, createHash } from 'node:crypto';
+import { atomicJson } from './fixtures.mjs';
+
+const exec = promisify(execFile);
+const label = 'io.fountain.deployed-bootstrap';
+const sha = value => createHash('sha256').update(value).digest('hex');
+const imagePin = /^[a-z0-9./_-]+@sha256:[a-f0-9]{64}$/;
+const uuid = /^[a-f0-9]{8}(?:-[a-f0-9]{4}){3}-[a-f0-9]{12}$/;
+const assert = (ok, message) => { if (!ok) throw new Error(message); };
+
+export function validateBootstrap(options) {
+  assert(options && Object.keys(options).sort().join(',') === 'app_image,context,port,postgres_image', 'Expected explicit bootstrap image pins, local context and port');
+  assert(imagePin.test(options.app_image) && imagePin.test(options.postgres_image), 'Bootstrap images must use immutable registry digests');
+  assert(/^[a-zA-Z0-9_.-]{1,64}$/.test(options.context), 'Invalid Docker context');
+  assert(Number.isInteger(options.port) && options.port >= 1024 && options.port <= 65535, 'Bootstrap port must be 1024-65535');
+}
+
+// Start from the actual repository Compose configuration, resolved without the
+// operator's .env or service credentials. Only these two stock services run.
+export function isolateCompose(config, options, runId) {
+  validateBootstrap(options);
+  assert(uuid.test(runId), 'Invalid bootstrap run ID');
+  const project = `fountain-bootstrap-${runId}`;
+  assert(config.name === project && config.services?.app && config.services?.postgres, 'Unexpected resolved Compose project');
+  const app = structuredClone(config.services.app);
+  const postgres = structuredClone(config.services.postgres);
+  assert(!app.volumes?.length && postgres.volumes?.length === 1 && postgres.volumes[0].type === 'volume' &&
+    postgres.volumes[0].source === 'postgres_data', 'Bootstrap refuses unexpected mounts');
+  for (const service of [app, postgres]) {
+    assert(!service.privileged && !service.network_mode && !service.container_name && !service.build &&
+      !service.devices && !service.secrets && !service.configs && !service.external_links && !service.volumes_from &&
+      Object.keys(service.networks ?? { default: null }).every(name => name === 'default'), 'Bootstrap refuses unexpected service access');
+    service.labels = { ...service.labels, [label]: runId };
+    service.restart = 'no';
+  }
+  app.image = options.app_image; postgres.image = options.postgres_image;
+  app.ports = [{ target: 4000, published: String(options.port), host_ip: '127.0.0.1', protocol: 'tcp' }];
+  postgres.ports = [];
+  assert(app.environment.EMAIL_DELIVERY === 'none' && app.environment.FIRST_USER_ADMIN === 'true' &&
+    app.environment.REGISTRATION_ENABLED === 'true', 'Resolved Compose bootstrap defaults differ');
+  return {
+    name: project, services: { app, postgres },
+    volumes: { postgres_data: { name: `${project}_postgres_data`, labels: { [label]: runId } } },
+    networks: { default: { name: `${project}_default`, labels: { [label]: runId } } },
+  };
+}
+
+export class FreshCompose {
+  constructor(out, manifest, command) {
+    this.out = resolve(out); this.manifest = manifest;
+    this.command = command ?? (async args => {
+      try {
+        const { stdout } = await exec('docker', ['--context', manifest.options.context, ...args], {
+          cwd: this.out, env: { PATH: process.env.PATH, HOME: process.env.HOME },
+          timeout: 180000, maxBuffer: 8 * 1024 * 1024,
+        });
+        return stdout.trim();
+      } catch { throw new Error(`Bootstrap Docker ${args[0]} operation failed; raw command output withheld`); }
+    });
+  }
+  save() { atomicJson(resolve(this.out, 'bootstrap.json'), this.manifest); }
+  compose(...args) {
+    return this.command(['compose', '--project-name', this.manifest.project, '--env-file', resolve(this.out, 'fixture.env'),
+      '--file', resolve(this.out, 'compose.json'), ...args]);
+  }
+  static async prepare(out, options, { source = new URL('../../docker-compose.yml', import.meta.url), command } = {}) {
+    validateBootstrap(options);
+    mkdirSync(out, { mode: 0o700 }); // Exclusive directory; never adopt a previous run.
+    const runId = randomUUID();
+    const manifest = { version: 'fountain-bootstrap/1', run_id: runId, project: `fountain-bootstrap-${runId}`,
+      options, state: 'preparing', url: `http://127.0.0.1:${options.port}` };
+    const fixture = new FreshCompose(out, manifest, command);
+    fixture.save();
+    try {
+      const endpoint = JSON.parse(await fixture.command(['context', 'inspect', options.context, '--format', '{{json .Endpoints.docker.Host}}']));
+      assert(typeof endpoint === 'string' && endpoint.startsWith('unix:///'), 'Bootstrap requires a local Unix-socket Docker context');
+      manifest.endpoint = endpoint;
+      assert((await fixture.inventory()).length === 0, 'Fresh bootstrap project already has resources');
+      manifest.images = {};
+      for (const [service, pin] of [['app', options.app_image], ['postgres', options.postgres_image]]) {
+        const info = JSON.parse(await fixture.command(['image', 'inspect', pin, '--format', '{{json .}}']));
+        assert(/^sha256:[a-f0-9]{64}$/.test(info.Id) && info.RepoDigests?.includes(pin), 'Pinned image must already exist locally with its expected digest');
+        manifest.images[service] = { id: info.Id, pin, revision: info.Config?.Labels?.['org.opencontainers.image.revision'] ?? null };
+      }
+      assert(/^[a-f0-9]{40}$/.test(manifest.images.app.revision), 'App image must record its source revision');
+      const sourceBytes = readFileSync(source);
+      manifest.source_sha256 = sha(sourceBytes);
+      writeFileSync(resolve(out, 'source-compose.yml'), sourceBytes, { flag: 'wx', mode: 0o600 });
+      const env = [
+        `SECRET_KEY_BASE=${randomBytes(48).toString('base64')}`, `MASTER_SECRETS_KEY=${randomBytes(32).toString('base64url')}`,
+        `POSTGRES_PASSWORD=${randomBytes(24).toString('hex')}`, `PUBLIC_URL=${manifest.url}`,
+        'EMAIL_DELIVERY=none', 'FIRST_USER_ADMIN=true', 'REGISTRATION_ENABLED=true', 'CREDITS_ENABLED=false',
+        'CONVERSATIONS_APP_URL=', 'TEAM_APP_URL=', 'API_CORS_ORIGINS=', 'OAUTH_CLIENTS=[]',
+      ].join('\n') + '\n';
+      writeFileSync(resolve(out, 'fixture.env'), env, { flag: 'wx', mode: 0o600 });
+      const baseline = JSON.parse(await fixture.command(['compose', '--project-name', manifest.project, '--env-file', resolve(out, 'fixture.env'),
+        '--file', resolve(out, 'source-compose.yml'), 'config', '--format', 'json']));
+      const config = JSON.stringify(isolateCompose(baseline, options, runId), null, 2) + '\n';
+      writeFileSync(resolve(out, 'compose.json'), config, { flag: 'wx', mode: 0o600 });
+      manifest.config_sha256 = sha(config);
+      manifest.state = 'prepared'; fixture.save();
+      return fixture;
+    } catch (error) {
+      // Preparation never starts Docker resources. Remove generated secrets
+      // even if interpolation, image inspection or validation failed.
+      for (const file of ['fixture.env', 'compose.json']) rmSync(resolve(out, file), { force: true });
+      manifest.state = 'prepare_failed'; fixture.save();
+      throw error;
+    }
+  }
+  static load(out, command) {
+    const manifest = JSON.parse(readFileSync(resolve(out, 'bootstrap.json')));
+    validateBootstrap(manifest.options);
+    assert(manifest.version === 'fountain-bootstrap/1' && uuid.test(manifest.run_id) &&
+      manifest.project === `fountain-bootstrap-${manifest.run_id}` && manifest.url === `http://127.0.0.1:${manifest.options.port}`,
+    'Invalid bootstrap cleanup manifest');
+    return new FreshCompose(out, manifest, command);
+  }
+  async inventory() {
+    const found = [];
+    for (const [kind, list] of [['container', ['ps', '-aq']], ['volume', ['volume', 'ls', '-q']], ['network', ['network', 'ls', '-q']]]) {
+      const ids = (await this.command([...list, '--filter', `label=com.docker.compose.project=${this.manifest.project}`])).split(/\s+/).filter(Boolean);
+      assert(ids.length <= (kind === 'container' ? 2 : 1), 'Unexpected bootstrap resource count');
+      for (const id of ids) {
+        const object = JSON.parse(await this.command([kind, 'inspect', id, '--format', '{{json .}}']));
+        const labels = kind === 'container' ? object.Config?.Labels : object.Labels;
+        assert(labels?.[label] === this.manifest.run_id && labels?.['com.docker.compose.project'] === this.manifest.project,
+          'Refusing resources without both bootstrap ownership labels');
+        found.push({ kind, id, image: kind === 'container' ? object.Image : undefined,
+          service: labels['com.docker.compose.service'], ports: kind === 'container' ? object.NetworkSettings?.Ports : undefined });
+      }
+    }
+    return found;
+  }
+  async verifyContext() {
+    const endpoint = JSON.parse(await this.command(['context', 'inspect', this.manifest.options.context, '--format', '{{json .Endpoints.docker.Host}}']));
+    assert(endpoint === this.manifest.endpoint && endpoint.startsWith('unix:///'), 'Bootstrap Docker endpoint changed');
+    assert(sha(readFileSync(resolve(this.out, 'compose.json'))) === this.manifest.config_sha256, 'Bootstrap Compose configuration changed');
+  }
+  async up() {
+    assert(this.manifest.state === 'prepared', 'Bootstrap may start only once');
+    await this.verifyContext();
+    assert((await this.inventory()).length === 0, 'Bootstrap no longer has a fresh project');
+    this.manifest.state = 'starting'; this.save();
+    await this.compose('up', '-d', '--pull', 'never', '--wait', '--wait-timeout', '120');
+    const resources = await this.inventory();
+    for (const service of ['app', 'postgres']) {
+      const matches = resources.filter(r => r.kind === 'container' && r.service === service);
+      assert(matches.length === 1 && matches[0].image === this.manifest.images[service].id, 'Bootstrap serving image differs from its pin');
+      if (service === 'app') {
+        const bindings = matches[0].ports?.['4000/tcp'];
+        assert(bindings?.length === 1 && bindings[0].HostIp === '127.0.0.1' && bindings[0].HostPort === String(this.manifest.options.port),
+          'Bootstrap app is not published exclusively on its pinned loopback port');
+      } else assert(Object.values(matches[0].ports ?? {}).every(bindings => !bindings?.length), 'Bootstrap database must not publish a host port');
+    }
+    await this.probe();
+    this.manifest.resources = resources;
+    this.manifest.before = await this.databaseStatus();
+    assert(this.manifest.before.users === 0 && this.manifest.before.api_keys === 0, 'Bootstrap database is not empty');
+    this.manifest.state = 'ready'; this.save();
+  }
+  async probe() {
+    for (const path of ['/health', '/health/ready']) {
+      const response = await fetch(this.manifest.url + path, { redirect: 'manual', signal: AbortSignal.timeout(5000) });
+      await response.body?.cancel();
+      assert(response.status === 200, 'Bootstrap health must answer 200 through the host loopback port');
+    }
+  }
+  async databaseStatus() {
+    await this.verifyContext(); await this.inventory();
+    // Fixed read-only statement, only inside this run's two-label-owned DB.
+    // No hashes, addresses, tokens or credential columns leave Postgres.
+    const sql = "SELECT json_build_object('users', (SELECT count(*) FROM users), 'admins', (SELECT count(*) FROM users WHERE role = 'admin'), 'verified', (SELECT count(*) FROM users WHERE email_verified_at IS NOT NULL), 'api_keys', (SELECT count(*) FROM api_keys));";
+    const value = JSON.parse(await this.compose('exec', '-T', 'postgres', 'psql', '-U', 'postgres', '-d', 'fountain', '-tA', '-c', sql));
+    assert(['users', 'admins', 'verified', 'api_keys'].every(k => Number.isSafeInteger(value[k]) && value[k] >= 0), 'Invalid bootstrap database evidence');
+    return value;
+  }
+  async verifyRegistered() {
+    assert(this.manifest.state === 'ready', 'Bootstrap registration requires its fresh ready instance');
+    const status = await this.databaseStatus();
+    assert(status.users === 1 && status.admins === 1 && status.verified === 1 && status.api_keys === 0, 'Expected one verified first admin and no issued API keys');
+    this.manifest.after = status; this.manifest.state = 'registered'; this.save();
+    return status;
+  }
+  async cleanup() {
+    if (this.manifest.state !== 'cleaned') {
+      await this.verifyContext(); await this.inventory();
+      await this.compose('down', '--volumes', '--timeout', '10');
+      assert((await this.inventory()).length === 0, 'Bootstrap resources remain after cleanup');
+      this.manifest.state = 'cleaned'; this.manifest.remaining = 0; this.save();
+    }
+    for (const file of ['fixture.env', 'compose.json']) rmSync(resolve(this.out, file), { force: true });
+  }
+}

--- a/deployed/lib/runner.mjs
+++ b/deployed/lib/runner.mjs
@@ -200,7 +200,10 @@ export async function run({ configPath, out, manifestPath, signal, env = process
     if (config.mcp) redactor.add(env[config.mcp.admin_credential]);
     if (config.webhooks) redactor.add(env[config.webhooks.admin_credential]);
     if (config.recovery) redactor.add(env[config.recovery.relay.admin_credential]);
-    if (config.browser) { redactor.add(env[config.browser.email]); redactor.add(env[config.browser.password]); }
+    if (config.browser) {
+      redactor.add(env[config.browser.email]); redactor.add(env[config.browser.password]);
+      if (config.browser.credential_setup) redactor.add(env[config.browser.credential_setup.value]?.trim());
+    }
     report.target = config.base_url;
     report.profiles = config.profiles;
     report.limits = { ...config.limits, concurrency: 1, inference_turns: config.execution?.max_turns ?? config.browser?.conversations?.max_turns ?? 0, fixture_prompts: config.fixture?.max_turns ?? 0 };
@@ -300,6 +303,7 @@ export async function run({ configPath, out, manifestPath, signal, env = process
     if (fixtures) {
       const failures = await fixtures.cleanup(AbortSignal.timeout(config.limits.cleanup_ms));
       report.cleanup = { failures, remaining: fixtures.remainingCount() };
+      if (fixtures.manifest.browser_credential) report.cleanup.provider_setup = { ...fixtures.manifest.browser_credential };
       if (fixtures.manifest.schedule) report.cleanup.schedule = { state: fixtures.manifest.schedule.state, deleted: fixtures.manifest.schedule.deleted, conversations: fixtures.manifest.schedule.conversations, remaining_sandbox_ids: fixtures.manifest.schedule.remaining_sandbox_ids ?? [] };
       report.prompt_attempts = fixtures.manifest.inference_attempts ?? 0;
       report.inference_attempts = config.profiles.some(name => ['deterministic', 'recovery'].includes(name)) ? 0 : report.prompt_attempts;

--- a/deployed/lib/runner.mjs
+++ b/deployed/lib/runner.mjs
@@ -11,6 +11,8 @@ import { probe } from '../profiles/probe.mjs';
 import { basic } from '../profiles/basic.mjs';
 import { execution } from '../profiles/execution.mjs';
 import { deterministic } from '../profiles/deterministic.mjs';
+import { browser } from '../profiles/browser.mjs';
+import { validateBrowser } from './browser-config.mjs';
 import { recovery } from '../profiles/recovery.mjs';
 import { validateRecovery, restoreRecoveryControls } from './recovery.mjs';
 import { schedules } from '../profiles/schedules.mjs';
@@ -23,7 +25,7 @@ import { secrets } from '../profiles/secrets.mjs';
 import { receiverOrigins, ReceiverSession } from './receiver.mjs';
 
 export const VERSION = '0.1.0';
-export const profiles = { probe, basic, execution, streaming: execution, secrets, mcp, webhooks, schedules, deterministic, recovery };
+export const profiles = { probe, basic, execution, streaming: execution, secrets, mcp, webhooks, schedules, deterministic, recovery, browser };
 const contractPath = fileURLToPath(new URL('../../sdk/contract/contract.json', import.meta.url));
 
 function requireThat(condition, message) { if (!condition) throw new Error(message); }
@@ -35,7 +37,7 @@ function positive(value, fallback, max) {
 
 export function configFrom(path, env = process.env) {
   const config = JSON.parse(readFileSync(path, 'utf8'));
-  const allowed = ['base_url', 'credentials', 'profiles', 'contract', 'required_capabilities', 'optional_capabilities', 'limits', 'execution', 'deployment', 'secrets', 'mcp', 'webhooks', 'schedules', 'fixture', 'recovery'];
+  const allowed = ['base_url', 'credentials', 'profiles', 'contract', 'required_capabilities', 'optional_capabilities', 'limits', 'execution', 'deployment', 'secrets', 'mcp', 'webhooks', 'schedules', 'fixture', 'recovery', 'browser'];
   requireThat(Object.keys(config).every(key => allowed.includes(key)), 'Unknown configuration field');
   const url = new URL(config.base_url);
   requireThat(['http:', 'https:'].includes(url.protocol) && !url.username && !url.password && !url.search && !url.hash,
@@ -119,6 +121,7 @@ export function configFrom(path, env = process.env) {
     request_ms: positive(limits.request_ms, 10000, 120000), run_ms: positive(limits.run_ms, 120000, 3600000),
     cleanup_ms: positive(limits.cleanup_ms, 30000, 300000), resources: positive(limits.resources, 20, 100),
   };
+  if (config.profiles.includes('browser')) validateBrowser(config, env);
   if (config.profiles.includes('secrets')) {
     requireThat(config.limits.run_ms <= 600000, 'Secrets run must fit within receiver retention');
     requireThat(config.limits.resources >= 5, 'Secrets profile requires a five-resource budget');
@@ -197,6 +200,7 @@ export async function run({ configPath, out, manifestPath, signal, env = process
     if (config.mcp) redactor.add(env[config.mcp.admin_credential]);
     if (config.webhooks) redactor.add(env[config.webhooks.admin_credential]);
     if (config.recovery) redactor.add(env[config.recovery.relay.admin_credential]);
+    if (config.browser) { redactor.add(env[config.browser.email]); redactor.add(env[config.browser.password]); }
     report.target = config.base_url;
     report.profiles = config.profiles;
     report.limits = { ...config.limits, concurrency: 1, inference_turns: config.execution?.max_turns ?? 0, fixture_prompts: config.fixture?.max_turns ?? 0 };

--- a/deployed/lib/runner.mjs
+++ b/deployed/lib/runner.mjs
@@ -203,7 +203,7 @@ export async function run({ configPath, out, manifestPath, signal, env = process
     if (config.browser) { redactor.add(env[config.browser.email]); redactor.add(env[config.browser.password]); }
     report.target = config.base_url;
     report.profiles = config.profiles;
-    report.limits = { ...config.limits, concurrency: 1, inference_turns: config.execution?.max_turns ?? 0, fixture_prompts: config.fixture?.max_turns ?? 0 };
+    report.limits = { ...config.limits, concurrency: 1, inference_turns: config.execution?.max_turns ?? config.browser?.conversations?.max_turns ?? 0, fixture_prompts: config.fixture?.max_turns ?? 0 };
     const contract = new Contract(config.contract);
     report.contract_sha256 = contract.sha256;
     const timeout = AbortSignal.timeout(config.limits.run_ms);

--- a/deployed/profiles/browser-bootstrap.mjs
+++ b/deployed/profiles/browser-bootstrap.mjs
@@ -1,0 +1,33 @@
+import { ensure } from '../lib/execution.mjs';
+
+// Only a FreshCompose instance in the ready state can supply this target.
+// Registration and sign-in create no API key; account cleanup removes the
+// complete disposable database through its recorded Compose ownership.
+export async function browserBootstrap(fixture, page, evidence, { email, password }) {
+  ensure(fixture.manifest.state === 'ready' && fixture.manifest.before?.users === 0, 'Browser bootstrap requires a newly verified empty Compose instance');
+  const url = fixture.manifest.url;
+  await evidence.step('bootstrap/register', async () => {
+    await page.goto(`${url}/auth/register`);
+    await page.locator('input[name="user[email]"]').fill(email);
+    await page.locator('input[name="user[password]"]').fill(password);
+    await page.getByRole('button', { name: 'Create account', exact: true }).click();
+    await page.waitForURL(`${url}/auth/login`);
+  });
+  await evidence.step('bootstrap/sign-in', async () => {
+    await page.locator('input[name="email"]').fill(email);
+    await page.locator('input[name="password"]').fill(password);
+    await page.getByRole('button', { name: 'Sign in', exact: true }).click();
+    await page.waitForURL(`${url}/dashboard`);
+    await page.goto(`${url}/admin`);
+    await page.getByRole('heading', { name: 'Admin', exact: true }).waitFor({ state: 'visible' });
+    await evidence.heading(page, 'bootstrap-admin', 'Admin');
+    await fixture.verifyRegistered();
+  });
+  await evidence.step('bootstrap/sign-out', async () => {
+    await page.getByRole('link', { name: 'Sign out', exact: true }).click();
+    await page.waitForURL(`${url}/auth/login`);
+    await page.goto(`${url}/admin`);
+    await page.waitForURL(`${url}/auth/login`);
+  });
+  fixture.manifest.browser_verified = true; fixture.save();
+}

--- a/deployed/profiles/browser-console.mjs
+++ b/deployed/profiles/browser-console.mjs
@@ -4,7 +4,7 @@ import { ensure } from '../lib/execution.mjs';
 // Called with a fresh browser context by the browser driver. All writes go
 // through visible console forms. Public API reads independently establish
 // identity, persistence and revocation; they never create the UI fixtures.
-export async function browserConsole(ctx, page, evidence) {
+export async function browserConsole(ctx, page, evidence, { handoff } = {}) {
   const { config, fixtures, client, env, report, redactor } = ctx;
   const settings = config.browser;
   const email = env[settings.email];
@@ -29,6 +29,7 @@ export async function browserConsole(ctx, page, evidence) {
     await page.goto(`${config.base_url}/agents/new`);
     await page.getByLabel('Name', { exact: true }).fill(intent.name);
     await page.getByLabel('Description', { exact: true }).fill('Dedicated deployed browser fixture');
+    await page.getByLabel('System prompt', { exact: true }).fill('Perform only the requested small file task. Use a shell tool. Do not access the network or start background work.');
     await page.locator('select[name="agent[runtime]"]').selectOption(settings.agent.runtime);
     await page.getByLabel('Model', { exact: true }).fill(settings.agent.model);
     const provider = page.locator('select[name="agent[sandbox_provider]"]');
@@ -69,6 +70,7 @@ export async function browserConsole(ctx, page, evidence) {
     const me = await client.request('GET', '/api/auth/me', { key, expected: 200, recordBody: false });
     ensure(me.body.id === report.owner_id, 'UI key authenticated as another account');
     await page.getByRole('button', { name: "I've copied it, dismiss", exact: true }).click();
+    if (settings.conversations) await handoff(agent, key);
     const row = page.getByRole('row').filter({ hasText: intent.name });
     page.once('dialog', dialog => dialog.accept());
     await row.getByRole('button', { name: 'Revoke', exact: true }).click();

--- a/deployed/profiles/browser-console.mjs
+++ b/deployed/profiles/browser-console.mjs
@@ -1,5 +1,6 @@
 import { reserveBrowserFixture, adoptBrowserFixture } from '../lib/browser-fixtures.mjs';
 import { ensure } from '../lib/execution.mjs';
+import { browserCredentials } from './browser-credentials.mjs';
 
 // Called with a fresh browser context by the browser driver. All writes go
 // through visible console forms. Public API reads independently establish
@@ -23,6 +24,7 @@ export async function browserConsole(ctx, page, evidence, { handoff } = {}) {
     report.browser.console.sign_in = true;
   });
 
+  const clearCredential = await browserCredentials(ctx, page, evidence);
   let agent;
   await evidence.step('console/create-agent', async () => {
     const intent = reserveBrowserFixture(fixtures, 'agent');
@@ -81,17 +83,6 @@ export async function browserConsole(ctx, page, evidence, { handoff } = {}) {
     await evidence.heading(page, 'api-keys', 'API keys');
   });
 
-  await evidence.step('console/credential-validation', async () => {
-    const before = await client.request('GET', '/api/account/inference-credentials', { expected: 200, recordBody: false });
-    await page.goto(`${config.base_url}/account/inference-credentials`);
-    const form = page.locator('form').filter({ has: page.locator(`input[name="provider"][value="${settings.credential_provider}"]`) });
-    ensure(await form.locator('input[name="value"]').getAttribute('type') === 'password', 'Credential field must hide its value');
-    await form.getByRole('button', { name: 'Save', exact: true }).click();
-    await page.getByText('Paste a value before saving.', { exact: true }).waitFor({ state: 'visible' });
-    const after = await client.request('GET', '/api/account/inference-credentials', { expected: 200, recordBody: false });
-    ensure(JSON.stringify(before.body) === JSON.stringify(after.body), 'Empty credential submission changed provider configuration');
-    report.browser.console.credential_validation = { provider: settings.credential_provider, mode: 'empty_submission', saved_credential_verified: false };
-    await evidence.heading(page, 'inference-credentials', 'Inference credentials');
-  });
+  await clearCredential();
   return agent;
 }

--- a/deployed/profiles/browser-console.mjs
+++ b/deployed/profiles/browser-console.mjs
@@ -1,0 +1,95 @@
+import { reserveBrowserFixture, adoptBrowserFixture } from '../lib/browser-fixtures.mjs';
+import { ensure } from '../lib/execution.mjs';
+
+// Called with a fresh browser context by the browser driver. All writes go
+// through visible console forms. Public API reads independently establish
+// identity, persistence and revocation; they never create the UI fixtures.
+export async function browserConsole(ctx, page, evidence) {
+  const { config, fixtures, client, env, report, redactor } = ctx;
+  const settings = config.browser;
+  const email = env[settings.email];
+  const password = env[settings.password];
+  redactor.add(email); redactor.add(password);
+  const identity = await client.request('GET', '/api/auth/me', { expected: 200, recordBody: false });
+  ensure(identity.body.id === report.owner_id && identity.body.email === email, 'Browser login must match the dedicated API fixture owner');
+  report.browser ??= { console: {}, app: { status: 'not_run' } };
+
+  await evidence.step('console/sign-in', async () => {
+    await page.goto(`${config.base_url}/auth/login`);
+    await page.locator('input[name="email"]').fill(email);
+    await page.locator('input[name="password"]').fill(password);
+    await page.getByRole('button', { name: 'Sign in', exact: true }).click();
+    await page.waitForURL(`${config.base_url}/dashboard`);
+    report.browser.console.sign_in = true;
+  });
+
+  let agent;
+  await evidence.step('console/create-agent', async () => {
+    const intent = reserveBrowserFixture(fixtures, 'agent');
+    await page.goto(`${config.base_url}/agents/new`);
+    await page.getByLabel('Name', { exact: true }).fill(intent.name);
+    await page.getByLabel('Description', { exact: true }).fill('Dedicated deployed browser fixture');
+    await page.locator('select[name="agent[runtime]"]').selectOption(settings.agent.runtime);
+    await page.getByLabel('Model', { exact: true }).fill(settings.agent.model);
+    const provider = page.locator('select[name="agent[sandbox_provider]"]');
+    if (await provider.count()) await provider.selectOption(settings.agent.sandbox_provider);
+    else {
+      const { body } = await client.request('GET', '/api/catalog', { expected: 200 });
+      ensure(JSON.stringify(body.data.sandbox_providers.enabled) === JSON.stringify([settings.agent.sandbox_provider]), 'Hidden provider selector does not imply the pinned sole provider');
+    }
+    await page.getByRole('button', { name: 'Save', exact: true }).click();
+    await page.waitForURL(`${config.base_url}/agents`);
+    agent = await adoptBrowserFixture(fixtures, intent, ctx.signal);
+    ensure(agent.runtime === settings.agent.runtime && agent.model === settings.agent.model, 'UI agent runtime/model did not persist');
+    report.browser.console.agent_id = agent.id;
+  });
+
+  await evidence.step('console/edit-agent', async () => {
+    await page.goto(`${config.base_url}/agents/${agent.id}/edit`);
+    const description = `Browser edit verified for ${report.run_id}`;
+    await page.getByLabel('Description', { exact: true }).fill(description);
+    await page.getByRole('button', { name: 'Save', exact: true }).click();
+    await page.waitForURL(`${config.base_url}/agents`);
+    const { body } = await client.request('GET', `/api/agents/${agent.id}`, { expected: 200 });
+    ensure(body.data.name === agent.name && body.data.description === description, 'UI agent edit did not persist');
+    await evidence.heading(page, 'agents', 'Agents');
+  });
+
+  await evidence.step('console/api-key-lifecycle', async () => {
+    const intent = reserveBrowserFixture(fixtures, 'api_key');
+    await page.goto(`${config.base_url}/api-keys`);
+    await page.getByLabel('Key label', { exact: true }).fill(intent.name);
+    await page.getByRole('button', { name: 'Create key', exact: true }).click();
+    await page.getByText('New API key created', { exact: true }).waitFor({ state: 'visible' });
+    // No screenshot, native trace or DOM dump is taken while the key is shown.
+    const key = (await page.locator('#new-api-key').innerText()).trim();
+    redactor.add(key);
+    ensure(key.startsWith('ftn_'), 'UI key reveal did not contain an API key');
+    const minted = await adoptBrowserFixture(fixtures, intent, ctx.signal);
+    const me = await client.request('GET', '/api/auth/me', { key, expected: 200, recordBody: false });
+    ensure(me.body.id === report.owner_id, 'UI key authenticated as another account');
+    await page.getByRole('button', { name: "I've copied it, dismiss", exact: true }).click();
+    const row = page.getByRole('row').filter({ hasText: intent.name });
+    page.once('dialog', dialog => dialog.accept());
+    await row.getByRole('button', { name: 'Revoke', exact: true }).click();
+    await page.getByText('Key revoked', { exact: true }).waitFor({ state: 'visible' });
+    await client.request('GET', '/api/auth/me', { key, expected: 401, recordBody: false });
+    await client.request('GET', '/api/auth/me', { expected: 200, recordBody: false });
+    report.browser.console.revoked_key_id = minted.id;
+    await evidence.heading(page, 'api-keys', 'API keys');
+  });
+
+  await evidence.step('console/credential-validation', async () => {
+    const before = await client.request('GET', '/api/account/inference-credentials', { expected: 200, recordBody: false });
+    await page.goto(`${config.base_url}/account/inference-credentials`);
+    const form = page.locator('form').filter({ has: page.locator(`input[name="provider"][value="${settings.credential_provider}"]`) });
+    ensure(await form.locator('input[name="value"]').getAttribute('type') === 'password', 'Credential field must hide its value');
+    await form.getByRole('button', { name: 'Save', exact: true }).click();
+    await page.getByText('Paste a value before saving.', { exact: true }).waitFor({ state: 'visible' });
+    const after = await client.request('GET', '/api/account/inference-credentials', { expected: 200, recordBody: false });
+    ensure(JSON.stringify(before.body) === JSON.stringify(after.body), 'Empty credential submission changed provider configuration');
+    report.browser.console.credential_validation = { provider: settings.credential_provider, mode: 'empty_submission', saved_credential_verified: false };
+    await evidence.heading(page, 'inference-credentials', 'Inference credentials');
+  });
+  return agent;
+}

--- a/deployed/profiles/browser-credentials.mjs
+++ b/deployed/profiles/browser-credentials.mjs
@@ -1,0 +1,47 @@
+import { credentialPath, credentialStatus, reserveCredential } from '../lib/browser-credentials.mjs';
+import { ensure } from '../lib/execution.mjs';
+
+export async function browserCredentials(ctx, page, evidence) {
+  const { config, fixtures, client, report, env, redactor, signal } = ctx;
+  const settings = config.browser;
+  const provider = settings.credential_provider;
+  const setup = settings.credential_setup;
+  const form = () => page.locator('form').filter({ has: page.locator(`input[name="provider"][value="${provider}"]`) });
+  await evidence.step('console/credential-validation', async () => {
+    const before = await client.request('GET', credentialPath, { expected: 200, recordBody: false });
+    await page.goto(`${config.base_url}/account/inference-credentials`);
+    ensure(await form().locator('input[name="value"]').getAttribute('type') === 'password', 'Credential field must hide its value');
+    await form().getByRole('button', { name: 'Save', exact: true }).click();
+    await page.getByText('Paste a value before saving.', { exact: true }).waitFor({ state: 'visible' });
+    const after = await client.request('GET', credentialPath, { expected: 200, recordBody: false });
+    ensure(JSON.stringify(before.body) === JSON.stringify(after.body), 'Empty credential submission changed provider configuration');
+    report.browser.console.provider_setup = { provider, mode: 'empty_submission', saved_verified: false };
+    await evidence.heading(page, 'inference-credentials', 'Inference credentials');
+  });
+  if (!setup) return async () => {};
+
+  let entry;
+  await evidence.step('console/credential-save', async () => {
+    const value = env[setup.value].trim();
+    redactor.add(value);
+    entry = await reserveCredential(fixtures, provider, setup.exclusive_account, signal);
+    // No screenshot or native trace captures this field. There is one save
+    // attempt: a timeout retains the intent for public-status reconciliation.
+    await form().locator('input[name="value"]').fill(value);
+    await form().getByRole('button', { name: 'Save', exact: true }).click();
+    await page.getByText('Saved and validated.', { exact: true }).waitFor({ state: 'visible' });
+    entry.state = 'saved'; fixtures.save();
+    ensure(await credentialStatus(client, provider, signal), 'Validated provider credential did not persist');
+    report.browser.console.provider_setup = { provider, mode: 'save_and_clear', saved_verified: true, cleared: false };
+  });
+
+  return async () => evidence.step('console/credential-clear', async () => {
+    await page.goto(`${config.base_url}/account/inference-credentials`);
+    await form().getByRole('button', { name: 'Clear', exact: true }).click();
+    await page.getByText('Credential cleared.', { exact: true }).waitFor({ state: 'visible' });
+    ensure(!await credentialStatus(client, provider, signal), 'Cleared provider credential remains set');
+    entry.state = 'cleaned'; fixtures.save();
+    report.browser.console.provider_setup.cleared = true;
+    await evidence.heading(page, 'inference-credentials-cleared', 'Inference credentials');
+  });
+}

--- a/deployed/profiles/browser-handoff.mjs
+++ b/deployed/profiles/browser-handoff.mjs
@@ -1,0 +1,138 @@
+import { randomUUID } from 'node:crypto';
+import { ensure, phaseSignal, performTurn, watchUntil } from '../lib/execution.mjs';
+import { verifyReplay } from '../lib/replay.mjs';
+
+export function verifyBrowserCors(requestOrigin, allowOrigin, appOrigin) {
+  ensure(requestOrigin === appOrigin && [appOrigin, '*'].includes(allowOrigin), 'App request origin or server CORS response disagrees with the configured app');
+}
+
+export function verifyOAuthDenialRequest(rawUrl, baseUrl, appUrl) {
+  const url = new URL(rawUrl);
+  ensure(url.origin === new URL(baseUrl).origin && url.pathname === '/oauth/authorize' &&
+    url.searchParams.get('client_id') === 'fountain-conversations' &&
+    url.searchParams.get('redirect_uri') === appUrl && url.searchParams.get('response_type') === 'code' &&
+    url.searchParams.get('code_challenge_method') === 'S256' && /^[A-Za-z0-9_-]{43}$/.test(url.searchParams.get('code_challenge')) &&
+    /^[A-Za-z0-9_-]{16,128}$/.test(url.searchParams.get('state')), 'App OAuth request does not match the pinned client, redirect and PKCE flow');
+  ensure([...url.searchParams.keys()].length === 6 && new Set(url.searchParams.keys()).size === 6, 'OAuth request contains unexpected or repeated parameters');
+  return url.searchParams.get('state');
+}
+
+export async function browserHandoff(ctx, page, evidence, agent, key, appGuard) {
+  const app = ctx.config.browser.conversations;
+  const appOrigin = new URL(app.lock.url).origin;
+  const settings = { ...ctx.config.browser.agent, ...app, sandbox_mode: 'ephemeral' };
+  const turnCtx = { ...ctx, config: { ...ctx.config, execution: settings } };
+  ctx.report.execution = { runtime: settings.runtime, model: settings.model, sandbox_provider: settings.sandbox_provider, sandbox_mode: 'ephemeral', turns: [] };
+  const report = ctx.report.browser.app = { status: 'running', authentication: 'ui_created_api_key', oauth: 'not_run', turns: [] };
+  let conversation, provision, first, second;
+  const file = `fountain-suite-${ctx.report.run_id}.txt`, nonce = randomUUID();
+
+  await evidence.step('app/owned-conversation', async () => {
+    const environment = await ctx.fixtures.create('environment');
+    conversation = await ctx.fixtures.create('conversation', { agent_id: agent.id, environment_id: environment.id, sandbox_mode: 'ephemeral' });
+    const signal = phaseSignal(ctx.signal, settings.provision_ms);
+    provision = await watchUntil(ctx.client, conversation.id, signal, e => e.kind === 'stage' && e.stage === 'provision' && e.state === 'done');
+    const { body } = await ctx.client.request('GET', `/api/conversations/${conversation.id}`, { expected: 200, signal });
+    conversation = body.data;
+    ensure(conversation.agent_id === agent.id && conversation.environment_id === environment.id &&
+      conversation.sandbox?.status === 'ready' && conversation.sandbox.mode === 'ephemeral' && conversation.sandbox.provider === settings.sandbox_provider,
+    'App conversation did not provision the UI agent on its pinned provider');
+    const turns = await ctx.client.request('GET', `/api/conversations/${conversation.id}/turns`, { expected: 200, signal });
+    ensure(turns.body.data.length === 0, 'App fixture invoked inference before browser submission');
+    report.conversation_id = conversation.id;
+    ctx.report.streaming = { provision_cursor: provision.cursor };
+  });
+
+  async function handoff() {
+    await page.goto(`${ctx.config.base_url}/conversations/${conversation.id}`);
+    await page.waitForURL(app.lock.url + `#/c/${conversation.id}`);
+    appGuard.verify();
+  }
+
+  await evidence.step('app/oauth-denial', async () => {
+    await handoff();
+    await page.getByLabel('Fountain URL', { exact: true }).fill(ctx.config.base_url);
+    await page.getByRole('button', { name: 'Sign in with Fountain', exact: true }).click();
+    await page.waitForURL(url => url.origin === new URL(ctx.config.base_url).origin && url.pathname === '/oauth/authorize');
+    appGuard.expectDeniedCallback(verifyOAuthDenialRequest(page.url(), ctx.config.base_url, app.lock.url));
+    await page.getByRole('button', { name: 'Deny', exact: true }).click();
+    await page.getByText('Sign-in was denied.', { exact: true }).waitFor({ state: 'visible' });
+    report.oauth = 'denial_verified';
+    report.oauth_authorization = 'not_run'; // This journey authenticates with the UI-created run-owned key.
+  });
+
+  await evidence.step('app/key-sign-in-and-cors', async () => {
+    await handoff();
+    await page.getByLabel('Fountain URL', { exact: true }).fill(ctx.config.base_url);
+    await page.getByRole('button', { name: 'or paste an API key', exact: true }).click();
+    await page.getByLabel('API key', { exact: true }).fill(key);
+    const [response] = await Promise.all([
+      page.waitForResponse(response => response.url() === ctx.config.base_url + '/api/auth/me' && response.request().method() === 'GET'),
+      page.getByRole('button', { name: 'Connect with key', exact: true }).click(),
+    ]);
+    ensure(response.status() === 200, 'App key sign-in did not authenticate');
+    const me = await response.json();
+    ensure(me.id === ctx.report.owner_id, 'App authenticated as another account');
+    verifyBrowserCors((await response.request().allHeaders()).origin, response.headers()['access-control-allow-origin'], appOrigin);
+    // The app only renders its composer after consuming the CORS-protected response.
+    await page.getByPlaceholder('Follow-up prompt… (Enter to send, Shift+Enter for a new line)', { exact: true }).waitFor({ state: 'visible' });
+    report.cors = { request_origin: appOrigin, response_allowed_origin: response.headers()['access-control-allow-origin'], browser_consumed_identity: true };
+  });
+
+  const submit = async ({ prompt, signal }) => {
+    // A turn deadline also cancels browser actionability waits: an element
+    // becoming clickable later must not submit work after its phase expired.
+    const abort = () => { void page.close().catch(() => {}); };
+    signal.addEventListener('abort', abort, { once: true });
+    try {
+      signal.throwIfAborted();
+      const path = `${ctx.config.base_url}/api/conversations/${conversation.id}/prompts`;
+      const [response] = await Promise.all([
+        page.waitForResponse(response => response.url() === path && response.request().method() === 'POST'),
+        (async () => {
+          await page.getByPlaceholder('Follow-up prompt… (Enter to send, Shift+Enter for a new line)', { exact: true }).fill(prompt);
+          signal.throwIfAborted();
+          await page.getByRole('button', { name: 'Send', exact: true }).click();
+        })(),
+      ]);
+      signal.throwIfAborted();
+      verifyBrowserCors((await response.request().allHeaders()).origin, response.headers()['access-control-allow-origin'], appOrigin);
+      ensure(response.status() === 200 && response.request().postDataJSON().prompt === prompt, 'Browser submitted another prompt or did not receive acceptance');
+      await page.getByText('Queued', { exact: true }).waitFor({ state: 'visible' });
+      return { status: response.status(), body: await response.json() };
+    } finally { signal.removeEventListener('abort', abort); }
+  };
+  async function artifact() {
+    const { body } = await ctx.client.request('GET', `/api/sandboxes/${conversation.sandbox_id}/file?path=${file}&max_bytes=1024`, { expected: 200 });
+    const value = body.data;
+    const contents = value.encoding === 'base64' ? Buffer.from(value.content, 'base64').toString('utf8') : value.content;
+    ensure(!value.truncated && contents === nonce + '\n', 'Browser artifact bytes do not match the requested nonce');
+  }
+  await evidence.step('app/write-artifact', async () => {
+    first = await performTurn(turnCtx, conversation,
+      `Use a shell tool to write exactly the text ${nonce} followed by one newline into the relative file ${file}. Read the file with the tool to verify it. Do nothing else.`, 1, provision.cursor, { submit });
+    await artifact();
+    ctx.report.streaming.reconnect_cursor = first.cursor;
+  });
+  await evidence.step('app/read-artifact-and-render', async () => {
+    second = await performTurn(turnCtx, conversation,
+      `Use a shell tool to read the existing relative file ${file}. Do not rewrite it or infer its contents from history. Reply with the file contents. Do nothing else.`, 2, first.cursor, { submit });
+    await artifact();
+    const text = second.stored.filter(e => e.turn_id === second.turn.id).flatMap(e => e.blocks ?? []).filter(b => b.kind === 'text').map(b => b.body ?? '').join('');
+    ensure(text.includes(nonce), 'App follow-up did not persist the read nonce');
+    // Scope to the second assistant reply, excluding the user's echoed prompt.
+    await page.locator('.turn').nth(1).locator('.bubble.them').filter({ hasText: nonce }).first().waitFor({ state: 'visible' });
+    await verifyReplay(turnCtx, conversation.id, first, second, phaseSignal(ctx.signal, settings.turn_ms));
+    report.turns = [first.turn.id, second.turn.id];
+    report.assistant_nonce_rendered = true;
+    report.bundle = appGuard.verify();
+  });
+  await evidence.step('app/sign-out', async () => {
+    await page.getByRole('button', { name: 'Sign out', exact: true }).click();
+    await page.getByRole('button', { name: 'Sign in with Fountain', exact: true }).waitFor({ state: 'visible' });
+    // Pasted credentials remain valid until the console revokes this exact key.
+    await page.goto(`${ctx.config.base_url}/api-keys`);
+    await page.getByRole('heading', { name: 'API keys', exact: true }).waitFor({ state: 'visible' });
+    report.status = 'passed';
+  });
+}

--- a/deployed/profiles/browser.mjs
+++ b/deployed/profiles/browser.mjs
@@ -1,0 +1,40 @@
+import { resolve } from 'node:path';
+import { BrowserEvidence } from '../lib/browser-evidence.mjs';
+import { browserConsole } from './browser-console.mjs';
+
+export async function browser(ctx) {
+  const evidence = new BrowserEvidence(resolve(ctx.out, 'browser'), [new URL(ctx.config.base_url).origin]);
+  await ctx.check('browser/console', async () => {
+    let engine, close;
+    try {
+      const { chromium } = await import('../browser/node_modules/playwright/index.mjs');
+      engine = await chromium.launch({ headless: true });
+      close = () => { void engine.close().catch(() => {}); };
+      ctx.signal.addEventListener('abort', close, { once: true });
+      ctx.signal.throwIfAborted();
+      const context = await engine.newContext({ acceptDownloads: false });
+      // This disposable context has no saved sign-in, cookies or app storage.
+      // Native tracing, HAR capture and video stay disabled.
+      const page = await context.newPage();
+      page.setDefaultTimeout(ctx.config.browser.step_ms);
+      page.setDefaultNavigationTimeout(ctx.config.browser.step_ms);
+      let traceFailure;
+      page.on('response', response => {
+        try { evidence.response(response.request().method(), response.url(), response.status()); }
+        catch { traceFailure = true; close(); }
+      });
+      await browserConsole(ctx, page, evidence);
+      ctx.require(!traceFailure, 'Browser evidence exceeded its bounded trace budget');
+      ctx.report.browser.app = { status: 'not_run', reason: 'No Conversations app journey configured; #1618 handoff remains incomplete' };
+    } catch (error) {
+      if (/^Browser step [a-z0-9/-]+ failed; inspect browser.jsonl$/.test(error.message)) throw error;
+      throw new Error('Browser setup or bounded driver failed; verify the pinned dependency, installed Chromium and browser.jsonl');
+    } finally {
+      if (close) ctx.signal.removeEventListener('abort', close);
+      if (engine) {
+        try { await engine.close(); }
+        catch { throw new Error('Browser shutdown failed'); }
+      }
+    }
+  });
+}

--- a/deployed/profiles/browser.mjs
+++ b/deployed/profiles/browser.mjs
@@ -1,9 +1,16 @@
 import { resolve } from 'node:path';
 import { BrowserEvidence } from '../lib/browser-evidence.mjs';
 import { browserConsole } from './browser-console.mjs';
+import { browserHandoff } from './browser-handoff.mjs';
+import { fetchPinnedApp, guardBrowserApp } from '../lib/browser-app-lock.mjs';
+import { phaseSignal } from '../lib/execution.mjs';
 
 export async function browser(ctx) {
   const evidence = new BrowserEvidence(resolve(ctx.out, 'browser'), [new URL(ctx.config.base_url).origin]);
+  const app = ctx.config.browser.conversations;
+  if (app && !await ctx.check('browser/app-bundle', async () => {
+    ctx.report.browser_bundle = await fetchPinnedApp(app.lock, { signal: phaseSignal(ctx.signal, 60000) });
+  })) return;
   await ctx.check('browser/console', async () => {
     let engine, close;
     try {
@@ -12,7 +19,8 @@ export async function browser(ctx) {
       close = () => { void engine.close().catch(() => {}); };
       ctx.signal.addEventListener('abort', close, { once: true });
       ctx.signal.throwIfAborted();
-      const context = await engine.newContext({ acceptDownloads: false });
+      const context = await engine.newContext({ acceptDownloads: false, serviceWorkers: 'block' });
+      const appGuard = app ? await guardBrowserApp(context, app.lock, { apiOrigin: new URL(ctx.config.base_url).origin }) : undefined;
       // This disposable context has no saved sign-in, cookies or app storage.
       // Native tracing, HAR capture and video stay disabled.
       const page = await context.newPage();
@@ -23,10 +31,11 @@ export async function browser(ctx) {
         try { evidence.response(response.request().method(), response.url(), response.status()); }
         catch { traceFailure = true; close(); }
       });
-      await browserConsole(ctx, page, evidence);
+      await browserConsole(ctx, page, evidence, { handoff: (agent, key) => browserHandoff(ctx, page, evidence, agent, key, appGuard) });
       ctx.require(!traceFailure, 'Browser evidence exceeded its bounded trace budget');
-      ctx.report.browser.app = { status: 'not_run', reason: 'No Conversations app journey configured; #1618 handoff remains incomplete' };
+      if (!app) ctx.report.browser.app = { status: 'not_run', reason: 'No Conversations app journey configured' };
     } catch (error) {
+      if (ctx.report.browser?.app?.status === 'running') ctx.report.browser.app.status = 'failed';
       if (/^Browser step [a-z0-9/-]+ failed; inspect browser.jsonl$/.test(error.message)) throw error;
       throw new Error('Browser setup or bounded driver failed; verify the pinned dependency, installed Chromium and browser.jsonl');
     } finally {

--- a/deployed/test/browser-app-lock.test.mjs
+++ b/deployed/test/browser-app-lock.test.mjs
@@ -1,0 +1,96 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, symlinkSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { buildAppLock, validateAppLock, fetchPinnedApp, guardBrowserApp, verifyAppBytes } from '../lib/browser-app-lock.mjs';
+
+const revision = '862552d8ece9abef20535e9b9c0b19821bf614c4';
+function bundle() {
+  const root = mkdtempSync(join(tmpdir(), 'fountain-app-lock-'));
+  mkdirSync(join(root, 'assets'));
+  writeFileSync(join(root, 'index.html'), '<!doctype html><script type="module" src="./assets/app.js"></script>');
+  writeFileSync(join(root, 'assets/app.js'), 'document.body.dataset.ready = "yes";');
+  writeFileSync(join(root, 'assets/app.js.map'), '{}');
+  return root;
+}
+
+test('app locks pin actual bytes and reject symlinks, duplicate paths, traversal and excess size', () => {
+  const root = bundle();
+  try {
+    const lock = buildAppLock(root, 'https://app.example.test/console/', revision);
+    assert.deepEqual(lock.assets.map(a => a.path).sort(), ['/console/', '/console/assets/app.js']);
+    assert.equal(lock.source_revision, revision);
+    assert.throws(() => validateAppLock({ ...lock, source_revision: 'main' }), /commit SHA/);
+    assert.throws(() => validateAppLock({ ...lock, assets: [...lock.assets, lock.assets[0]] }), /duplicate/);
+    assert.throws(() => validateAppLock({ ...lock, assets: [{ ...lock.assets[0], path: '/console/../app.js' }] }), /Invalid/);
+    assert.throws(() => validateAppLock({ ...lock, assets: [{ ...lock.assets[0], bytes: 5 * 1024 * 1024 }] }), /unbounded/);
+    assert.throws(() => buildAppLock(root, 'http://remote.example.test/', revision), /HTTPS/);
+    symlinkSync(join(root, 'index.html'), join(root, 'alias.html'));
+    assert.throws(() => buildAppLock(root, 'https://app.example.test/', revision), /symbolic/);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('live app preflight and browser response guard reject a changed build after preflight', async () => {
+  const root = bundle();
+  let changed = false, redirect = false, requests = [];
+  const server = createServer((req, res) => {
+    requests.push({ url: req.url, authorization: req.headers.authorization, cookie: req.headers.cookie });
+    if (redirect) { res.writeHead(302, { location: '/app/' }).end(); return; }
+    const html = new URL(req.url, 'http://localhost').pathname === '/app/';
+    res.writeHead(200, { 'content-type': html ? 'text/html' : 'application/javascript' });
+    res.end(html ? '<!doctype html><script type="module" src="./assets/app.js"></script>' : changed ? 'different application' : 'document.body.dataset.ready = "yes";');
+  });
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  const origin = `http://127.0.0.1:${server.address().port}`;
+  try {
+    const lock = buildAppLock(root, origin + '/app/', revision);
+    assert.equal((await fetchPinnedApp(lock)).assets.length, 2);
+    assert.ok(requests.every(r => r.authorization === undefined && r.cookie === undefined));
+    let handler;
+    const guard = await guardBrowserApp({ async route(_match, fn) { handler = fn; } }, lock);
+    let fulfilled = 0, aborted = 0;
+    async function consume(path) {
+      await handler({
+        request: () => ({ url: () => path.startsWith('http') ? path : origin + path, method: () => 'GET', headers: () => ({}),
+          frame: () => ({ url: () => origin + '/app/' }), isNavigationRequest: () => false }),
+        async fetch(options) {
+          assert.equal(options.maxRedirects, 0); assert.equal(options.maxRetries, 0);
+          assert.equal(options.headers['accept-encoding'], 'identity');
+          const res = await fetch(origin + path, { redirect: 'manual', headers: options.headers });
+          return { status: () => res.status, headers: () => Object.fromEntries(res.headers), body: async () => Buffer.from(await res.arrayBuffer()) };
+        },
+        async fulfill() { fulfilled++; }, async abort() { aborted++; },
+      });
+    }
+    await consume('/app/');
+    changed = true;
+    await consume('/app/assets/app.js');
+    assert.equal(fulfilled, 1); assert.equal(aborted, 1);
+    assert.throws(() => guard.verify(), /immutable bundle/);
+    await assert.rejects(fetchPinnedApp(lock), /bytes changed|byte length/);
+    redirect = true;
+    await assert.rejects(fetchPinnedApp(lock), /without redirect/);
+    const js = lock.assets.find(a => a.path.endsWith('.js'));
+    assert.throws(() => verifyAppBytes(js, 200, { 'content-type': 'text/html' }, Buffer.from('document.body.dataset.ready = "yes";')), /content type/);
+    changed = false; redirect = false; fulfilled = 0; aborted = 0;
+    const callbackGuard = await guardBrowserApp({ async route(_match, fn) { handler = fn; } }, lock);
+    callbackGuard.expectDeniedCallback('s'.repeat(22));
+    const callback = '/app/?error=access_denied&state=' + 's'.repeat(22);
+    await consume(callback);
+    assert.deepEqual(callbackGuard.verify().observed_assets, ['/app/']);
+    await consume(callback);
+    assert.equal(fulfilled, 1); assert.equal(aborted, 1);
+    assert.throws(() => callbackGuard.verify(), /immutable bundle/);
+    const externalGuard = await guardBrowserApp({ async route(_match, fn) { handler = fn; } }, lock);
+    await consume('/app/');
+    const before = requests.length;
+    await consume('https://unpinned.example.test/executable.js');
+    assert.equal(requests.length, before, 'Unpinned origin must be refused before fetching');
+    assert.throws(() => externalGuard.verify(), /immutable bundle/);
+  } finally {
+    await new Promise(resolve => server.close(resolve));
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/deployed/test/browser-credentials.test.mjs
+++ b/deployed/test/browser-credentials.test.mjs
@@ -1,0 +1,106 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Fixtures } from '../lib/fixtures.mjs';
+import { reserveBrowserFixture } from '../lib/browser-fixtures.mjs';
+import { credentialPath, reserveCredential } from '../lib/browser-credentials.mjs';
+import { configFrom } from '../lib/runner.mjs';
+
+const ownerId = '7037a408-be33-48db-8766-d7c057b8da75';
+const runId = '99ae3e20-6453-4f7b-8c8f-416446e41dde';
+const provider = 'anthropic_api_key';
+function fixture(t) {
+  const dir = mkdtempSync(join(tmpdir(), 'browser-credential-'));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  const path = join(dir, 'cleanup.json');
+  const state = { set: false, deletes: 0, loseDeleteReply: false, keepAfterDelete: false };
+  const client = { baseUrl: 'https://fountain.test', async request(method, route) {
+    if (method === 'GET' && route === credentialPath) return { body: { data: [{ provider, set: state.set }] } };
+    assert.equal(method, 'DELETE'); assert.equal(route, `${credentialPath}/${provider}`);
+    state.deletes++;
+    if (!state.keepAfterDelete) state.set = false;
+    if (state.loseDeleteReply) throw new Error('Lost delete response');
+    return { status: 204 };
+  } };
+  const fixtures = new Fixtures(path, client, { runId, ownerId, baseUrl: client.baseUrl, maxResources: 1 });
+  return { dir, path, fixtures, client, state };
+}
+
+test('credential setup refuses preexisting credentials and requires explicit account reservation', async t => {
+  const { fixtures, state, path } = fixture(t);
+  await assert.rejects(reserveCredential(fixtures, provider, false), /exclusive-account/);
+  state.set = true;
+  await assert.rejects(reserveCredential(fixtures, provider, true), /preexisting/);
+  assert.equal(JSON.parse(readFileSync(path)).browser_credential, undefined);
+  assert.equal(state.deletes, 0);
+  state.set = false;
+  await reserveCredential(fixtures, provider, true);
+  assert.equal(fixtures.remainingCount(), 1);
+  assert.throws(() => reserveBrowserFixture(fixtures, 'api_key'), /budget/);
+  await assert.rejects(fixtures.create('agent'), /budget/);
+  await assert.rejects(reserveCredential(fixtures, provider, true), /one exclusive-account/);
+  assert.deepEqual(Object.keys(JSON.parse(readFileSync(path)).browser_credential).sort(), ['exclusive_account', 'initial_set', 'provider', 'state']);
+});
+
+test('interrupted browser cleanup retains unset pending submission, then clears its committed value', async t => {
+  const { fixtures, state, path, client } = fixture(t);
+  await reserveCredential(fixtures, provider, true);
+  const reloaded = Fixtures.load(path, client, ownerId);
+  const pending = await reloaded.cleanup();
+  assert.match(pending[0].error, /Unresolved credential submission/);
+  assert.equal(reloaded.remainingCount(), 1);
+  assert.equal(state.deletes, 0);
+  // The browser never received success, but its single request now commits.
+  state.set = true;
+  assert.deepEqual(await reloaded.cleanup(), []);
+  assert.equal(state.deletes, 1);
+  assert.equal(state.set, false);
+  assert.equal(reloaded.remainingCount(), 0);
+  assert.deepEqual(await Fixtures.load(path, client, ownerId).cleanup(), []);
+  assert.equal(state.deletes, 1);
+});
+
+test('lost credential delete response survives restart without treating an unset pending save as resolved', async t => {
+  const { fixtures, state, path, client } = fixture(t);
+  await reserveCredential(fixtures, provider, true);
+  state.set = true; state.loseDeleteReply = true;
+  assert.match((await fixtures.cleanup())[0].error, /Lost delete response/);
+  assert.equal(JSON.parse(readFileSync(path)).browser_credential.state, 'saved');
+  const reloaded = Fixtures.load(path, client, ownerId);
+  assert.deepEqual(await reloaded.cleanup(), []);
+  assert.equal(reloaded.remainingCount(), 0);
+  assert.equal(state.deletes, 1);
+});
+
+test('credential cleanup reports failed deletion and refuses malformed or differently owned manifests', async t => {
+  const { fixtures, state, path, client } = fixture(t);
+  await reserveCredential(fixtures, provider, true);
+  state.set = true; state.keepAfterDelete = true;
+  assert.match((await fixtures.cleanup())[0].error, /remains set/);
+  assert.equal(fixtures.remainingCount(), 1);
+  assert.throws(() => Fixtures.load(path, client, runId), /owner/);
+  assert.throws(() => Fixtures.load(path, { ...client, baseUrl: 'https://other.test' }, ownerId), /target/);
+  const original = JSON.parse(readFileSync(path));
+  for (const change of [{ provider: '../auth/api-keys' }, { initial_set: true }, { exclusive_account: false }, { state: 'cancelled' }, { value: 'must-not-be-journaled' }]) {
+    writeFileSync(path, JSON.stringify({ ...original, browser_credential: { ...original.browser_credential, ...change } }));
+    assert.throws(() => Fixtures.load(path, client, ownerId), /credential cleanup intent/);
+  }
+});
+
+test('provider save/clear is opt-in, secret-referenced, and included in the resource budget', t => {
+  const { dir } = fixture(t);
+  const config = JSON.parse(readFileSync(new URL('../browser.example.json', import.meta.url)));
+  const env = { FOUNTAIN_SUITE_KEY: 'test', FOUNTAIN_BROWSER_EMAIL: 'test@example.test', FOUNTAIN_BROWSER_PASSWORD: 'test', PROVIDER_TEST_KEY: 'synthetic-provider-value' };
+  const parse = () => { const path = join(dir, 'target.json'); writeFileSync(path, JSON.stringify(config)); return configFrom(path, env); };
+  config.browser.credential_setup = { mode: 'save_and_clear', exclusive_account: true, value: 'PROVIDER_TEST_KEY' };
+  assert.throws(parse, /additional resource slot/);
+  config.limits.resources = 3;
+  assert.equal(parse().browser.credential_setup.value, 'PROVIDER_TEST_KEY');
+  config.browser.credential_setup.exclusive_account = false;
+  assert.throws(parse, /exclusive-account/);
+  config.browser.credential_setup.exclusive_account = true;
+  config.browser.credential_setup.value = 'literal-secret';
+  assert.throws(parse, /environment variable/);
+});

--- a/deployed/test/browser-evidence.test.mjs
+++ b/deployed/test/browser-evidence.test.mjs
@@ -42,7 +42,7 @@ test('UI fixture intent survives a lost create reply and refuses ambiguous owner
   assert.throws(() => reserveBrowserFixture(fixtures, 'conversation'), /Unsupported/);
 });
 
-test('browser profile is explicit, bounded, credential-referenced and rejects unimplemented app coverage', () => {
+test('browser profile is explicit, bounded, credential-referenced and rejects an unpinned app', () => {
   const dir = mkdtempSync(join(tmpdir(), 'browser-config-'));
   const example = JSON.parse(readFileSync(new URL('../browser.example.json', import.meta.url), 'utf8'));
   const env = { FOUNTAIN_SUITE_KEY: 'test-key', FOUNTAIN_BROWSER_EMAIL: 'dedicated@example.test', FOUNTAIN_BROWSER_PASSWORD: 'private-password' };
@@ -56,7 +56,7 @@ test('browser profile is explicit, bounded, credential-referenced and rejects un
     assert.throws(() => parse({ profiles: ['browser', 'probe'] }), /independently/);
     assert.throws(() => parse({}, { ...env, DEBUG: 'pw:api' }), /trace environment/);
     assert.throws(() => parse({}, { ...env, FOUNTAIN_BROWSER_PASSWORD: '' }), /populated/);
-    assert.throws(() => parse({ browser: { ...example.browser, conversations: { url: 'https://app.example.test' } } }), /not implemented/);
+    assert.throws(() => parse({ browser: { ...example.browser, conversations: { url: 'https://app.example.test' } } }), /Unknown Conversations/);
     assert.throws(() => parse({ browser: { ...example.browser, step_ms: 60001 } }), /step_ms/);
     assert.throws(() => parse({ limits: { run_ms: 600001, resources: 2 } }), /ten-minute/);
   } finally { rmSync(dir, { recursive: true, force: true }); }

--- a/deployed/test/browser-evidence.test.mjs
+++ b/deployed/test/browser-evidence.test.mjs
@@ -1,0 +1,63 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { BrowserEvidence } from '../lib/browser-evidence.mjs';
+import { reserveBrowserFixture, adoptBrowserFixture } from '../lib/browser-fixtures.mjs';
+import { configFrom } from '../lib/runner.mjs';
+
+test('browser failure trace discards secret arguments, query codes and unapproved paths', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'browser-evidence-'));
+  try {
+    const evidence = new BrowserEvidence(dir, ['https://fountain.test']);
+    evidence.response('POST', 'https://fountain.test/api/oauth/token?code=private-code', 200);
+    evidence.response('GET', 'https://fountain.test/private-secret', 200);
+    evidence.response('POST', 'https://elsewhere.test/api/oauth/token', 200);
+    await assert.rejects(evidence.step('console/sign-in', async () => { throw new Error('fill(private-password) failed'); }), /console\/sign-in failed/);
+    const trace = readFileSync(join(dir, 'browser.jsonl'), 'utf8');
+    assert.ok(!trace.includes('private-'));
+    assert.deepEqual(evidence.entries.map(e => e.kind), ['response', 'action', 'action']);
+    assert.equal(evidence.entries[0].route, '/api/oauth/token');
+    await assert.rejects(evidence.heading({ getByRole: () => ({ innerText: async () => 'API keys private-secret' }) }, 'keys', 'API keys'), /heading changed/);
+    assert.equal(evidence.entries.at(-1).state, 'failed');
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('UI fixture intent survives a lost create reply and refuses ambiguous owner lists', async () => {
+  let saved, rows = [];
+  const fixtures = { maxResources: 2, manifest: { run_id: '99ae3e20-6453-4f7b-8c8f-416446e41dde', resources: [] },
+    save() { saved = structuredClone(this.manifest); },
+    client: { async request() { return { body: { data: rows } }; } } };
+  const resource = reserveBrowserFixture(fixtures, 'agent');
+  assert.equal(saved.resources[0].state, 'pending');
+  const row = { id: '7037a408-be33-48db-8766-d7c057b8da75', name: resource.name };
+  rows = [row, row];
+  await assert.rejects(adoptBrowserFixture(fixtures, resource), /ambiguous/);
+  assert.equal(saved.resources[0].state, 'pending');
+  rows = [row];
+  await adoptBrowserFixture(fixtures, resource);
+  assert.equal(saved.resources[0].id, row.id);
+  assert.equal(saved.resources[0].state, 'created');
+  assert.throws(() => reserveBrowserFixture(fixtures, 'conversation'), /Unsupported/);
+});
+
+test('browser profile is explicit, bounded, credential-referenced and rejects unimplemented app coverage', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'browser-config-'));
+  const example = JSON.parse(readFileSync(new URL('../browser.example.json', import.meta.url), 'utf8'));
+  const env = { FOUNTAIN_SUITE_KEY: 'test-key', FOUNTAIN_BROWSER_EMAIL: 'dedicated@example.test', FOUNTAIN_BROWSER_PASSWORD: 'private-password' };
+  const parse = (change = {}, variables = env) => {
+    const path = join(dir, 'target.json');
+    writeFileSync(path, JSON.stringify({ ...structuredClone(example), ...change }));
+    return configFrom(path, variables);
+  };
+  try {
+    assert.deepEqual(parse().profiles, ['browser']);
+    assert.throws(() => parse({ profiles: ['browser', 'probe'] }), /independently/);
+    assert.throws(() => parse({}, { ...env, DEBUG: 'pw:api' }), /trace environment/);
+    assert.throws(() => parse({}, { ...env, FOUNTAIN_BROWSER_PASSWORD: '' }), /populated/);
+    assert.throws(() => parse({ browser: { ...example.browser, conversations: { url: 'https://app.example.test' } } }), /not implemented/);
+    assert.throws(() => parse({ browser: { ...example.browser, step_ms: 60001 } }), /step_ms/);
+    assert.throws(() => parse({ limits: { run_ms: 600001, resources: 2 } }), /ten-minute/);
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});

--- a/deployed/test/browser-handoff.test.mjs
+++ b/deployed/test/browser-handoff.test.mjs
@@ -1,0 +1,79 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import { randomUUID } from 'node:crypto';
+import { performTurn } from '../lib/execution.mjs';
+import { Redactor } from '../lib/http.mjs';
+import { validateBrowser } from '../lib/browser-config.mjs';
+import { verifyBrowserCors, verifyOAuthDenialRequest } from '../profiles/browser-handoff.mjs';
+
+test('handoff configuration requires distinct pinned origins, explicit authentication and prompt/resource budgets', () => {
+  const env = { EMAIL: 'dedicated@example.test', PASSWORD: 'test-password' };
+  const config = { base_url: 'https://fountain.example.test', profiles: ['browser'], limits: { run_ms: 600000, resources: 4 }, browser: {
+    email: 'EMAIL', password: 'PASSWORD', agent: { runtime: 'claude', model: 'anthropic/claude-sonnet-4-6', sandbox_provider: 'sprites' }, credential_provider: 'anthropic_api_key',
+    conversations: { lock: { version: 'fountain-browser-app/1', url: 'https://app.example.test/', source_revision: 'a'.repeat(40), assets: [{ path: '/', sha256: 'b'.repeat(64), bytes: 1, content_type: 'text/html' }] }, auth: 'ui_created_api_key', oauth: 'deny', max_turns: 2 },
+  } };
+  validateBrowser(config, env);
+  for (const [change, error] of [
+    [c => { c.browser.conversations.max_turns = 3; }, /two-prompt/],
+    [c => { c.browser.conversations.auth = 'oauth'; }, /successful OAuth/],
+    [c => { c.browser.conversations.lock.url = c.base_url + '/'; }, /separate origin/],
+    [c => { c.limits.resources = 3; }, /four resources/],
+    [c => { c.limits.run_ms = 120000; }, /time for provision/],
+  ]) {
+    const copy = structuredClone(config); change(copy); assert.throws(() => validateBrowser(copy, env), error);
+  }
+});
+
+test('browser CORS and OAuth denial assertions bind the real app origin and redirect', () => {
+  const app = 'https://app.example.test/', base = 'https://fountain.example.test';
+  verifyBrowserCors(new URL(app).origin, '*', new URL(app).origin);
+  assert.throws(() => verifyBrowserCors('https://elsewhere.test', '*', new URL(app).origin), /origin/);
+  assert.throws(() => verifyBrowserCors(new URL(app).origin, 'https://elsewhere.test', new URL(app).origin), /CORS/);
+  const url = new URL('/oauth/authorize', base);
+  url.search = new URLSearchParams({ client_id: 'fountain-conversations', redirect_uri: app, response_type: 'code', code_challenge: 'c'.repeat(43), code_challenge_method: 'S256', state: 's'.repeat(22) });
+  assert.equal(verifyOAuthDenialRequest(url, base, app), 's'.repeat(22));
+  url.searchParams.append('state', 'another-state-value');
+  assert.throws(() => verifyOAuthDenialRequest(url, base, app), /repeated/);
+  url.searchParams.delete('state'); url.searchParams.set('state', 's'.repeat(22));
+  url.searchParams.set('redirect_uri', 'https://elsewhere.test/');
+  assert.throws(() => verifyOAuthDenialRequest(url, base, app), /redirect/);
+});
+
+test('browser submission consumes the prompt budget and still requires independent public turn evidence', async t => {
+  const id = randomUUID(), turnId = randomUUID(), prompt = 'read this fixture nonce';
+  const order = [];
+  const events = [
+    { id: 1, kind: 'stage', stage: 'turn', state: 'started', turn_id: turnId, data: JSON.stringify({ turn_id: turnId, turn_number: 1 }) },
+    { id: 2, kind: 'output', stream: 'acp', turn_id: turnId, data: '{}', blocks: [{ kind: 'tool_use', name: 'shell' }] },
+    { id: 3, kind: 'stage', stage: 'turn', state: 'done', turn_id: turnId, data: JSON.stringify({ turn_id: turnId, turn_number: 1 }) },
+  ];
+  const server = createServer((_req, res) => {
+    order.push('public-stream');
+    res.writeHead(200, { 'content-type': 'text/event-stream' });
+    for (const event of events) res.write(`id: ${event.id}\nevent: ${event.kind}\ndata: ${JSON.stringify(event)}\n\n`);
+    res.end();
+  });
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  t.after(() => { server.closeAllConnections(); server.close(); });
+  let storedPrompt = prompt;
+  const ctx = {
+    config: { execution: { max_turns: 2, turn_ms: 2000 } }, signal: AbortSignal.timeout(10000), report: { execution: { turns: [] } },
+    fixtures: { reserveTurn(actual, budget) { assert.equal(actual, id); assert.equal(budget, 2); order.push('budget'); } },
+    client: { baseUrl: `http://127.0.0.1:${server.address().port}`, key: 'inert-test-value', redactor: new Redactor(), trace() {}, async request(method, path) {
+      assert.equal(method, 'GET', 'Browser journey must not submit via the backend API client');
+      if (path.endsWith('/turns')) return { body: { data: [{ id: turnId, turn_number: 1, status: 'completed', prompt: storedPrompt, exit_code: 0 }] } };
+      return { body: { data: events, meta: { has_more: false } } };
+    } },
+  };
+  const submit = async ({ prompt: value }) => { assert.equal(value, prompt); order.push('browser-submit'); return { body: { status: 'queued' } }; };
+  const result = await performTurn(ctx, { id }, prompt, 1, 0, { submit });
+  assert.deepEqual(order.slice(0, 3), ['budget', 'browser-submit', 'public-stream']);
+  assert.equal(result.turn.id, turnId);
+  storedPrompt = 'another prompt';
+  await assert.rejects(performTurn(ctx, { id }, prompt, 1, 0, { submit }), /identity\/prompt/);
+  const denied = { ...ctx, fixtures: { reserveTurn() { throw new Error('budget exhausted'); } } };
+  let called = false;
+  await assert.rejects(performTurn(denied, { id }, prompt, 1, 0, { submit: () => { called = true; } }), /budget exhausted/);
+  assert.equal(called, false);
+});

--- a/deployed/test/fresh-compose.test.mjs
+++ b/deployed/test/fresh-compose.test.mjs
@@ -1,0 +1,120 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, writeFileSync, existsSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { FreshCompose, isolateCompose, validateBootstrap } from '../lib/fresh-compose.mjs';
+
+const pin = `registry.test/fountain@sha256:${'a'.repeat(64)}`;
+const options = { app_image: pin, postgres_image: pin, context: 'local', port: 14826 };
+const runId = '99ae3e20-6453-4f7b-8c8f-416446e41dde';
+function baseline(project) {
+  return { name: project, services: {
+    app: { image: 'moving-tag', ports: [{ published: '4000', target: 4000 }], environment: { EMAIL_DELIVERY: 'none', FIRST_USER_ADMIN: 'true', REGISTRATION_ENABLED: 'true' }, networks: { default: null } },
+    postgres: { image: 'postgres:16', ports: [{ published: '5432', target: 5432 }], volumes: [{ type: 'volume', source: 'postgres_data', target: '/var/lib/postgresql/data' }], networks: { default: null } },
+  } };
+}
+
+test('fresh Compose pins images, binds only loopback and isolates its network and owned volume', () => {
+  const config = isolateCompose(baseline(`fountain-bootstrap-${runId}`), options, runId);
+  assert.equal(config.services.app.image, pin);
+  assert.deepEqual(config.services.app.ports, [{ target: 4000, published: '14826', host_ip: '127.0.0.1', protocol: 'tcp' }]);
+  assert.deepEqual(config.services.postgres.ports, []);
+  assert.equal(config.networks.default.name, `fountain-bootstrap-${runId}_default`);
+  assert.equal(config.volumes.postgres_data.name, `fountain-bootstrap-${runId}_postgres_data`);
+  assert.throws(() => validateBootstrap({ ...options, app_image: 'fountain:latest' }), /immutable/);
+  assert.throws(() => validateBootstrap({ ...options, port: 80 }), /port/);
+  for (const change of [{ volumes: [{ type: 'bind', source: '/operator-data', target: '/data' }] }, { privileged: true }, { network_mode: 'host' }, { networks: { operator: null } }]) {
+    const modified = baseline(`fountain-bootstrap-${runId}`);
+    Object.assign(modified.services.app, change);
+    assert.throws(() => isolateCompose(modified, options, runId), /refuses/);
+  }
+});
+
+async function fixture(t) {
+  const parent = mkdtempSync(join(tmpdir(), 'fresh-compose-'));
+  t.after(() => rmSync(parent, { recursive: true, force: true }));
+  const out = join(parent, 'run');
+  const state = { endpoint: 'unix:///local.sock', count: 0, wrongOwner: false,
+    ports: [{ HostIp: '127.0.0.1', HostPort: '14826' }], database: { users: 0, admins: 0, verified: 0, api_keys: 0 }, calls: [] };
+  let project, actualRunId;
+  const command = async args => {
+    state.calls.push(args);
+    if (args[0] === 'context') return JSON.stringify(state.endpoint);
+    if (args[0] === 'image') return JSON.stringify({ Id: `sha256:${'b'.repeat(64)}`, RepoDigests: [pin], Config: { Labels: { 'org.opencontainers.image.revision': 'c'.repeat(40) } } });
+    if (args[0] === 'ps' || args.includes('ls')) {
+      if (state.count === 0) return '';
+      return args[0] === 'ps' ? 'app-id\npostgres-id' : args[0] === 'volume' ? 'volume-id' : 'network-id';
+    }
+    if (args[1] === 'inspect') {
+      const labels = { 'com.docker.compose.project': project, 'io.fountain.deployed-bootstrap': state.wrongOwner ? runId : actualRunId,
+        'com.docker.compose.service': args[2] === 'app-id' ? 'app' : 'postgres' };
+      return JSON.stringify({ Image: `sha256:${'b'.repeat(64)}`, Config: { Labels: labels }, Labels: labels,
+        NetworkSettings: { Ports: args[2] === 'app-id' ? { '4000/tcp': state.ports } : { '5432/tcp': null } } });
+    }
+    if (args[0] === 'compose') {
+      project = args[args.indexOf('--project-name') + 1]; actualRunId = project.slice('fountain-bootstrap-'.length);
+      if (args.includes('config')) return JSON.stringify(baseline(project));
+      if (args.includes('up')) { state.count = 4; return ''; }
+      if (args.includes('down')) { state.count = 0; return ''; }
+      if (args.includes('exec')) return JSON.stringify(state.database);
+    }
+    throw new Error('Unexpected test Docker command');
+  };
+  const prepared = await FreshCompose.prepare(out, options, { command });
+  prepared.probe = async () => {};
+  return { prepared, state, out, command };
+}
+
+test('fresh database proof precedes registration and cleanup removes only labeled project resources', async t => {
+  const { prepared, state, out, command } = await fixture(t);
+  await prepared.up();
+  assert.equal(prepared.manifest.state, 'ready');
+  await assert.rejects(prepared.up(), /only once/);
+  await assert.rejects(prepared.verifyRegistered(), /one verified/);
+  state.database = { users: 1, admins: 1, verified: 1, api_keys: 1 };
+  await assert.rejects(prepared.verifyRegistered(), /no issued API keys/);
+  state.database.api_keys = 0;
+  await prepared.verifyRegistered();
+  assert.equal(prepared.manifest.state, 'registered');
+  await FreshCompose.load(out, command).cleanup();
+  assert.equal(state.count, 0);
+  assert.equal(existsSync(join(out, 'fixture.env')), false);
+  assert.equal(existsSync(join(out, 'compose.json')), false);
+  assert.equal(JSON.parse(readFileSync(join(out, 'bootstrap.json'))).remaining, 0);
+  await FreshCompose.load(out, command).cleanup();
+  assert.equal(state.calls.filter(args => args.includes('down')).length, 1);
+});
+
+test('changed Docker endpoint, configuration and resource ownership prevent destructive cleanup', async t => {
+  const { prepared, state, out } = await fixture(t);
+  await prepared.up();
+  state.endpoint = 'ssh://production';
+  await assert.rejects(prepared.cleanup(), /endpoint changed/);
+  state.endpoint = 'unix:///local.sock'; state.wrongOwner = true;
+  await assert.rejects(prepared.cleanup(), /ownership labels/);
+  state.wrongOwner = false;
+  writeFileSync(join(out, 'compose.json'), '{}');
+  await assert.rejects(prepared.cleanup(), /configuration changed/);
+  assert.equal(state.calls.filter(args => args.includes('down')).length, 0);
+});
+
+test('nonempty database is refused before any browser registration and remains cleanable', async t => {
+  const { prepared, state } = await fixture(t);
+  state.database.users = 1;
+  await assert.rejects(prepared.up(), /not empty/);
+  assert.equal(prepared.manifest.state, 'starting');
+  await prepared.cleanup();
+  assert.equal(state.count, 0);
+});
+
+test('missing or public Docker port binding cannot be reported ready', async t => {
+  for (const ports of [null, [{ HostIp: '0.0.0.0', HostPort: '14826' }]]) {
+    const { prepared, state } = await fixture(t);
+    state.ports = ports;
+    await assert.rejects(prepared.up(), /published exclusively/);
+    assert.equal(prepared.manifest.before, undefined);
+    assert.equal(prepared.manifest.state, 'starting');
+    await prepared.cleanup();
+  }
+});


### PR DESCRIPTION
# Verify console setup and a pinned Conversations app journey

Add an explicitly selected browser profile for a dedicated account. It signs into the console, creates and edits a run-owned agent through UI forms, verifies UI key issuance and revocation through the public API, and checks masking and empty-value validation on the credential form. Optional provider setup submits a valid credential through the console before agent/app work, requires provider-validation feedback and public persistence, then clears it through the console. This mode requires an exclusively reserved test account with that provider initially unset; a secret-free cleanup intent survives interrupted saves and deletes. The API has no revision/CAS, so shared-account use is refused by the explicit configuration contract, not prevented by a server lock. Creation intents are persisted before UI submission and use the ordinary public fixture cleanup manifest.

The optional Conversations journey pins the built page and assets, verifies the bytes served both before navigation and when the browser consumes them, follows the console handoff, verifies OAuth denial and supported API-key sign-in, and submits two artifact prompts through the app composer. Public turn/history/file checks require matching accepted work, tool activity, exact nonce bytes and replay; the second assistant response must also visibly render the nonce. Origin and CORS assertions use actual app requests and consumed responses. Successful OAuth authorization remains outside the verified scope.

Pin Playwright 1.63.0. Retain allowlisted action/response metadata and cropped static headings while excluding native traces, HAR, video, DOM dumps and raw errors. The profile remains outside automatic canaries. Console-only mode makes no inference calls; app mode requires an explicit two-prompt and four-resource budget. Provider setup adds one resource slot.

Validation: 171 deployed harness tests passed, with eight focused credential/evidence tests passing after final redaction/report changes. The initial full test run had 42 loopback listen EPERM failures; the complete rerun with socket access passed. Documentation style and diff checks passed. Conversations revision 862552d8ece9abef20535e9b9c0b19821bf614c4 built from its frozen dependency lock; its three local served assets matched their hashes and Chrome rendered the expected sign-in and masked key input. A prior manual local Chrome console check with registration disabled verified sign-in, agent creation/editing and credential validation, then cleaned all fixtures. The full Playwright driver, key lifecycle and authenticated app artifact journey have no passing live verdict yet. Live provider credential save/clear validation and successful OAuth authorization remain unverified under #1618.

Local commits: bdf08045, e831e7c9, 77de2af5 and b8eb889a, based on validated recovery commit 9088c3f7. Console diagnostic: /private/tmp/fountain-browser-live-1/result.json (partial). App byte proof: /private/tmp/fountain-conversations-app-preflight.json. No deployed browser verdict or completed #1618 claim.

Add a separate fresh-Compose browser bootstrap case that needs no existing key. It verifies immutable images, actual loopback publication, host health and an empty database before one HTML registration, first-admin sign-in and sign-out. Independent aggregate database checks require one verified admin and zero issued API keys. Cleanup verifies endpoint/configuration/dual ownership labels, removes the complete disposable project, and deletes generated secret files.

Manual Chrome bootstrap evidence against the Compose-pinned v0.16.0 image (source fbe833f61c8a043606f063efb13ffb6092185af4): registration, dashboard login, Admin access, logout and protected-route redirect observed; database counts and zero-resource cleanup verified. The initial internal-network publishing failure was diagnosed and fixed with regression coverage. An Admin-heading CDP timeout remains recorded; later DOM inspection confirmed the page. This is supplemental manual evidence, not a passing standalone Playwright-driver verdict. Evidence: /private/tmp/fountain-bootstrap-live-2/result.json.


Stack: targets `codex/runner-recovery-fix`. This is a draft for review; deployed acceptance evidence still outstanding in the linked tracker issues.
