### PR TITLE
fix: enable HTTPS proxy transport for brokered Codex sessions

### DIFF
--- a/apps/fountain/lib/fountain/conversations/codex_transport.ex
+++ b/apps/fountain/lib/fountain/conversations/codex_transport.ex
@@ -1,0 +1,33 @@
+defmodule Fountain.Conversations.CodexTransport do
+  @moduledoc false
+
+  # codex-acp 1.10 passes CODEX_CONFIG to thread/start and thread/resume.
+  # Codex's default WebSocket dialer rejects HTTPS proxy URLs. Its explicit
+  # proxy route supports TLS to the broker, but is opt-in in Codex 0.153.3.
+  # Keep this process-local: persistent sandboxes are shared by conversations.
+  def spawn_opts(%{broker: broker}, "codex", opts) when not is_nil(broker) do
+    env = Keyword.get(opts, :env, [])
+
+    raw =
+      case List.keyfind(env, "CODEX_CONFIG", 0) do
+        nil -> "{}"
+        {_, value} -> value
+      end
+
+    with {:ok, config} when is_map(config) <- Jason.decode(raw),
+         features when is_map(features) <- Map.get(config, "features", %{}) do
+      config =
+        config
+        |> Map.put("features", Map.put(features, "respect_system_proxy", true))
+        |> Map.delete("features.respect_system_proxy")
+
+      env = List.keystore(env, "CODEX_CONFIG", 0, {"CODEX_CONFIG", Jason.encode!(config)})
+      {:ok, Keyword.put(opts, :env, env)}
+    else
+      # Do not include the config: it may contain provider credentials.
+      _ -> {:error, :invalid_codex_config}
+    end
+  end
+
+  def spawn_opts(_state, _runtime, opts), do: {:ok, opts}
+end

--- a/apps/fountain/lib/fountain/conversations/connection.ex
+++ b/apps/fountain/lib/fountain/conversations/connection.ex
@@ -144,7 +144,8 @@ defmodule Fountain.Conversations.Connection do
   @spec spawn_command(map(), String.t(), String.t(), list(), keyword()) ::
           {:ok, Managoat.Sandbox.Command.t()} | {:error, term()}
   def spawn_command(state, runtime, cmd, args, opts) do
-    with :ok <- Provisioning.prepare_acp_adapter(state.handle, runtime, state.sprite_env) do
+    with {:ok, opts} <- Fountain.Conversations.CodexTransport.spawn_opts(state, runtime, opts),
+         :ok <- Provisioning.prepare_acp_adapter(state.handle, runtime, state.sprite_env) do
       Managoat.Sandbox.spawn(state.handle, cmd, args, opts)
     end
   end

--- a/apps/fountain/test/fountain/conversations/codex_transport_test.exs
+++ b/apps/fountain/test/fountain/conversations/codex_transport_test.exs
@@ -1,0 +1,59 @@
+defmodule Fountain.Conversations.CodexTransportTest do
+  use ExUnit.Case, async: true
+
+  alias Fountain.Conversations.CodexTransport
+
+  test "brokered Codex gets TLS proxy support without changing proxy credentials or spawn options" do
+    opts = [
+      env: [{"HTTPS_PROXY", "https://token:label@broker.example:443"}],
+      dir: "/track",
+      stdin: true
+    ]
+
+    assert {:ok, result} = CodexTransport.spawn_opts(%{broker: %{}}, "codex", opts)
+    assert Keyword.delete(result, :env) == Keyword.delete(opts, :env)
+    assert List.keyfind(result[:env], "HTTPS_PROXY", 0) == hd(opts[:env])
+    assert config(result)["features"]["respect_system_proxy"] == true
+    # Applying the policy again must not duplicate CODEX_CONFIG.
+    assert {:ok, ^result} = CodexTransport.spawn_opts(%{broker: %{}}, "codex", result)
+  end
+
+  test "existing settings survive, including unrelated feature flags" do
+    original = %{
+      "model" => "gpt-5.3-codex",
+      "features" => %{"multi_agent" => false, "respect_system_proxy" => false},
+      "features.respect_system_proxy" => false,
+      "model_providers" => %{"custom" => %{"base_url" => "https://example.com"}}
+    }
+
+    opts = [env: [{"CODEX_CONFIG", Jason.encode!(original)}]]
+    assert {:ok, result} = CodexTransport.spawn_opts(%{broker: %{}}, "codex", opts)
+    updated = config(result)
+    assert updated["features"] == %{"multi_agent" => false, "respect_system_proxy" => true}
+    refute Map.has_key?(updated, "features.respect_system_proxy")
+    assert updated["model"] == original["model"]
+    assert updated["model_providers"] == original["model_providers"]
+  end
+
+  test "unbrokered Codex and other runtimes retain their exact options" do
+    opts = [env: [{"CODEX_CONFIG", "unchanged"}]]
+    assert {:ok, ^opts} = CodexTransport.spawn_opts(%{broker: nil}, "codex", opts)
+    assert {:ok, ^opts} = CodexTransport.spawn_opts(%{}, "codex", opts)
+
+    for runtime <- ["claude", "gemini", "opencode"] do
+      assert {:ok, ^opts} = CodexTransport.spawn_opts(%{broker: %{}}, runtime, opts)
+    end
+  end
+
+  test "invalid configuration fails without leaking its contents" do
+    for raw <- ["secret-invalid-json", "[]", "null", ~s({"features":false})] do
+      assert {:error, :invalid_codex_config} =
+               CodexTransport.spawn_opts(%{broker: %{}}, "codex", env: [{"CODEX_CONFIG", raw}])
+    end
+  end
+
+  defp config(opts) do
+    {_, raw} = List.keyfind(opts[:env], "CODEX_CONFIG", 0)
+    Jason.decode!(raw)
+  end
+end


### PR DESCRIPTION
Brokered Codex sessions need the explicit system-proxy transport to connect through an HTTPS broker. Enable `features.respect_system_proxy` in the spawned process's `CODEX_CONFIG` before preparing the adapter and spawning the command.

Preserve existing settings, unrelated feature flags, proxy credentials, and spawn options; remove the conflicting dotted feature key. Unbrokered Codex and other runtimes keep their exact options. Invalid configuration returns `:invalid_codex_config` without exposing its contents. Persistent sandbox configuration is unchanged.

Applies AoD's client-supplied patch unchanged.

Validation:
- Focused transport, connection, and ACP server tests: 81 passed.
- `mix precommit`: compilation, unused-dependency check, formatting, Credo, Dialyzer, Sobelow, and production release assembly passed.
- Full suite: core completed with 6 doctests, 4330 tests, 1 failure (7 excluded); extension suites passed (144 and 33 tests). The failure was the unrelated credits default-price assertion tracked in #1654. The credits module passed all 24 tests in isolation with the same seed and no code changes; an existing async credit-pricer test mutates shared pricing configuration.
- Live HTTPS broker connectivity has not been tested.
