### PR TITLE
Allow explicitly bounded production recovery restarts

### DIFF
--- a/deployed/README.md
+++ b/deployed/README.md
@@ -650,13 +650,15 @@ local fixture diagnostics do not count as a deployed hosted-runtime verdict.
 ## Deterministic ACP fixture
 
 The `deterministic` profile runs the pinned `fountain-fixture` runtime in a
-real sandbox. Enable it only on an isolated test instance. On the server,
+real sandbox. Use an isolated test instance by default. An explicitly selected
+production target must follow [production recovery controls](recovery-controls.md#production-opt-in)
+and restrict the fixture to a dedicated test account. On the server,
 set both `DEPLOYED_ACP_FIXTURE_ENABLED=true` and
 `DEPLOYED_ACP_FIXTURE_USER_ID` to the dedicated, verified test account's UUID.
 The runtime is absent by default. Another account cannot create a fixture
 agent or start one, and disabling it prevents launch and rehydration. The
 normal account suspension, billing, sandbox placement and quota checks still
-apply. Do not enable this runtime on the public production instance.
+apply. Keep the fixture disabled for ordinary production accounts.
 
 The fixture is a fixed Node program bundled in
 `apps/fountain/priv/deployed/acp-fixture.mjs`. Provisioning writes its exact

--- a/deployed/adapters/recovery-kubernetes.mjs
+++ b/deployed/adapters/recovery-kubernetes.mjs
@@ -21,9 +21,9 @@ function observerConfig(config, expected_digest) {
 }
 
 export function validateRecoveryDeployment(config) {
-  check(config?.adapter === 'kubernetes' && config.environment === 'staging', 'Recovery requires an explicit staging target');
+  check(config?.adapter === 'kubernetes' && ['staging', 'production'].includes(config.environment), 'Recovery requires an explicit staging or production target');
   const keys = ['adapter', 'environment', 'base_url', 'context', 'namespace', 'deployment', 'service', 'container',
-    'deployment_uid', 'before_image', 'target_image', 'before_digest', 'target_digest', 'timeout_ms'];
+    'deployment_uid', 'before_image', 'target_image', 'before_digest', 'target_digest', 'timeout_ms', 'allow_production_restart'];
   check(Object.keys(config).every(key => keys.includes(key)), 'Unknown recovery deployment setting');
   const url = new URL(config.base_url);
   check(url.protocol === 'https:' && url.origin === config.base_url && !url.username && !url.password,
@@ -34,6 +34,11 @@ export function validateRecoveryDeployment(config) {
   check(uuid.test(config.deployment_uid), 'Recovery requires a pinned deployment UID');
   check(Number.isInteger(config.timeout_ms) && config.timeout_ms >= 1000 && config.timeout_ms <= 300000,
     'Recovery rollout timeout must be 1–300 seconds');
+  if (config.environment === 'production') {
+    check(config.allow_production_restart === true, 'Production recovery requires allow_production_restart:true');
+    check(config.before_image === config.target_image && config.before_digest === config.target_digest,
+      'Production recovery restarts the pinned serving image; release upgrades and downgrades require a separate deployment');
+  } else check(config.allow_production_restart === undefined, 'Production restart acknowledgement belongs only to a production target');
   return config;
 }
 
@@ -76,7 +81,7 @@ function kubernetesIO(config) {
 
 function guardedState(config, state, identities) {
   const { namespace, deployment, service } = state;
-  check(namespace.metadata?.labels?.['fountain.dev/environment'] === 'staging', 'Namespace is not labelled staging');
+  check(namespace.metadata?.labels?.['fountain.dev/environment'] === config.environment, `Namespace is not labelled ${config.environment}`);
   check(deployment.metadata?.labels?.['fountain.dev/recovery-tests'] === 'enabled', 'Deployment has not enabled recovery tests');
   check(deployment.metadata?.uid === config.deployment_uid, 'Deployment UID changed');
   for (const resource of [namespace, deployment, service]) {
@@ -103,6 +108,30 @@ function tests(state) {
     { op: 'test', path: `/spec/template/spec/containers/${state.index}/image`, value: state.image }];
 }
 
+function rolloutCount(value, replicas, round) {
+  if (Number.isInteger(value) && value >= 0) return value;
+  if (typeof value === 'string' && /^(?:100|[0-9]{1,2})%$/.test(value)) return round(replicas * Number(value.slice(0, -1)) / 100);
+  throw new Error('Invalid production rolling-update quantity');
+}
+
+// Admission checks run before either preparation or the fault mutation. They
+// deliberately do not gate restoration: an unhealthy rollout still needs to
+// remove its own marker and restore its recorded template using the CAS guards.
+function productionAdmission(config, state) {
+  if (config.environment !== 'production') return;
+  const { spec, status, metadata } = state.deployment;
+  const replicas = spec.replicas;
+  check(Number.isInteger(replicas) && replicas >= 2, 'Production recovery requires at least two replicas');
+  check((spec.strategy?.type ?? 'RollingUpdate') === 'RollingUpdate', 'Production recovery requires RollingUpdate');
+  const rolling = spec.strategy?.rollingUpdate ?? {};
+  check(rolloutCount(rolling.maxUnavailable ?? '25%', replicas, Math.floor) === 0 &&
+    rolloutCount(rolling.maxSurge ?? '25%', replicas, Math.ceil) === 1,
+  'Production recovery requires zero unavailable replicas and exactly one surge replica');
+  check(status?.observedGeneration === metadata.generation &&
+    ['replicas', 'updatedReplicas', 'readyReplicas', 'availableReplicas'].every(key => status[key] === replicas) && !status.unavailableReplicas,
+  'Production recovery requires a fully available, converged deployment');
+}
+
 // Control-plane evidence is separate from the recovery profile's public API assertions.
 export class RecoveryDeployment {
   constructor(config, journalPath, overrides = {}) {
@@ -125,6 +154,7 @@ export class RecoveryDeployment {
     catch (error) { if (error.code !== 'ENOENT') throw error; }
     const raw = await this.io.read(signal);
     const state = guardedState(this.config, raw);
+    productionAdmission(this.config, state);
     check(state.image === this.config.before_image && state.marker === undefined, 'Deployment does not match the unclaimed baseline');
     const before = await this.io.observe(this.config.before_digest, signal);
     check(before.deployment_uid === this.config.deployment_uid && before.service_uid === raw.service.metadata.uid &&
@@ -140,6 +170,7 @@ export class RecoveryDeployment {
   async roll(signal) {
     check(this.record?.phase === 'prepared', 'Recovery rollout has already been attempted or was not prepared');
     const state = guardedState(this.config, await this.io.read(signal), this.record);
+    productionAdmission(this.config, state);
     check(state.image === this.config.before_image && state.marker === undefined &&
       state.deployment.metadata.generation === this.record.before.generation, 'Deployment changed before recovery rollout');
     const patch = tests(state);

--- a/deployed/lib/recovery.mjs
+++ b/deployed/lib/recovery.mjs
@@ -9,7 +9,7 @@ import { ensure } from './execution.mjs';
 export function validateRecovery(config, env) {
   const settings = config.recovery;
   ensure(config.profiles.length === 1 && !config.execution && !config.deployment && !config.fixture,
-    'Run recovery independently with its own staging deployment configuration');
+    'Run recovery independently with its own explicit deployment configuration');
   ensure(settings && Object.keys(settings).every(k => ['deployment', 'relay', 'runner_id', 'provision_ms', 'turn_ms', 'idle_wait_ms', 'max_turns'].includes(k)),
     'Expected explicit recovery settings');
   validateRecoveryDeployment(settings.deployment);
@@ -23,7 +23,8 @@ export function validateRecovery(config, env) {
   ensure(/^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$/.test(relay.runner_name), 'Invalid dedicated runner name');
   ensure(Number.isInteger(relay.disconnect_ms) && relay.disconnect_ms >= 5000 && relay.disconnect_ms <= 60000,
     'Recovery requires a 5–60 second runner disconnection');
-  for (const [key, minimum, maximum] of [['provision_ms', 1000, 300000], ['turn_ms', 10000, 360000], ['idle_wait_ms', 60000, 600000]]) {
+  const production = settings.deployment.environment === 'production';
+  for (const [key, minimum, maximum] of [['provision_ms', 1000, 300000], ['turn_ms', 10000, 360000], ['idle_wait_ms', 60000, production ? 4200000 : 600000]]) {
     ensure(Number.isInteger(settings[key]) && settings[key] >= minimum && settings[key] <= maximum, `Invalid recovery ${key}`);
   }
   ensure(settings.turn_ms >= settings.deployment.timeout_ms + 30000 && settings.max_turns === 4,
@@ -53,7 +54,7 @@ export async function restoreRecoveryControls(ctx, directory, runId) {
     const restored = await ctx.check('recovery/deployment-cleanup', async () => {
       const control = await RecoveryDeployment.resume(resolve(directory, 'recovery.json'));
       ensure(control.record.run_id === runId && isDeepStrictEqual(control.config, ctx.config.recovery.deployment),
-        'Recovery journal differs from the selected run or staging target');
+        'Recovery journal differs from the selected run or deployment target');
       report.restored = await control.restore(AbortSignal.timeout(ctx.config.recovery.deployment.timeout_ms + 30000));
     });
     ok &&= restored;

--- a/deployed/lib/runner.mjs
+++ b/deployed/lib/runner.mjs
@@ -118,7 +118,8 @@ export function configFrom(path, env = process.env) {
   const limits = config.limits ?? {};
   requireThat(Object.keys(limits).every(k => ['request_ms', 'run_ms', 'cleanup_ms', 'resources'].includes(k)), 'Unknown limit');
   config.limits = {
-    request_ms: positive(limits.request_ms, 10000, 120000), run_ms: positive(limits.run_ms, 120000, 3600000),
+    request_ms: positive(limits.request_ms, 10000, 120000),
+    run_ms: positive(limits.run_ms, 120000, config.profiles.includes('recovery') && config.recovery.deployment.environment === 'production' ? 7200000 : 3600000),
     cleanup_ms: positive(limits.cleanup_ms, 30000, 300000), resources: positive(limits.resources, 20, 100),
   };
   if (config.profiles.includes('browser')) validateBrowser(config, env);
@@ -136,8 +137,11 @@ export function configFrom(path, env = process.env) {
     requireThat(config.limits.run_ms <= 900000 && config.limits.resources >= 4 && config.limits.cleanup_ms >= 30000, 'Schedules require a fifteen-minute run bound, four resources and thirty seconds for cleanup');
   }
   if (config.profiles.includes('recovery')) {
-    requireThat(config.limits.run_ms <= 1800000 && config.limits.resources >= 3 && config.limits.cleanup_ms >= 30000,
-      'Recovery requires a thirty-minute run bound, three resources and thirty seconds for fixture cleanup');
+    const production = config.recovery.deployment.environment === 'production';
+    requireThat(config.limits.run_ms <= (production ? 7200000 : 1800000) && config.limits.resources >= 3 && config.limits.cleanup_ms >= 30000,
+      'Recovery requires its environment-specific run bound, three resources and thirty seconds for fixture cleanup');
+    if (production) requireThat(config.limits.run_ms >= config.recovery.idle_wait_ms + 4 * config.recovery.turn_ms + config.recovery.provision_ms + 300000,
+      'Production recovery must budget the existing idle policy, four turns, provisioning and control overhead');
   }
   for (const field of ['required_capabilities', 'optional_capabilities']) {
     config[field] ??= {};

--- a/deployed/recovery-controls.md
+++ b/deployed/recovery-controls.md
@@ -1,4 +1,4 @@
-# Staging recovery controls
+# Recovery controls
 
 These controls support the explicit `recovery` profile for tracker #1617.
 Neither control runs in the default suite or a canary. Control-plane evidence
@@ -6,7 +6,8 @@ is separate from the profile's public transcript, turn and artifact assertions.
 
 ## Public profile
 
-Copy `recovery.example.json`, replace all example targets and identities, and
+Copy `recovery.example.json` for staging or `recovery-production.example.json`
+for production. Replace all example targets and identities, and
 provide the two dedicated suite account keys and separate relay admin key through
 the configured environment variables. The target must enable the deterministic
 ACP fixture for the primary account and have exactly one online runner for that
@@ -34,8 +35,9 @@ seconds; the profile must independently observe the same public runner ID become
 offline and then online. It does not retry a prompt, permission answer or fault
 injection after a lost response.
 
-Configure the isolated staging target with a short idle policy, such as
-`SANDBOX_IDLE_TIMEOUT_MINUTES=1`, before running. The profile only observes this
+An isolated staging target can use a short idle policy, such as
+`SANDBOX_IDLE_TIMEOUT_MINUTES=1`. Retain production's existing idle policy and
+use the production budget described below. The profile only observes this
 policy: it waits for public `sandbox.status=suspended` and fails if the configured
 `idle_wait_ms` expires. It then submits its final read, requiring the same home,
 session and baseline file, and exactly one live home for its owned agent.
@@ -65,10 +67,50 @@ that each fixture start appears exactly once under its accepted turn.
 
 The failed runs remain separate evidence. The passing local run restarts a
 source process and uses a real Go runner; it does not verify a released image,
-Kubernetes rollout, or hosted provider. A deployed staging verdict is still
-required for #1617.
+Kubernetes rollout, or hosted provider. A verdict on the explicitly selected
+deployment is still required for #1617.
 
 ## Rollout adapter
+
+### Production opt-in
+
+When no staging environment exists, use `recovery-production.example.json` and
+set `environment: "production"` plus `allow_production_restart: true`. The
+namespace label must say `production`; do not relabel production as staging.
+The existing deployment enablement label, exact URL bindings and immutable
+image/UID checks still apply. The adapter never installs those markers itself.
+
+Production mode accepts only a restart of the pinned serving image. The baseline
+and target image references and digests must be identical. A release upgrade or
+downgrade belongs to the normal deployment process, separate from this test.
+Before preparation and again before the fault, the Deployment must have at least
+two fully available, updated replicas, an observed current generation, and a
+RollingUpdate strategy allowing zero unavailable replicas and exactly one surge
+replica. Percentage values use Kubernetes rounding. The adapter changes neither
+the replica count nor the rollout strategy. These checks do not promise that
+existing sessions cannot be interrupted by a restart.
+
+Availability admission does not block restoration of an unhealthy rollout.
+Cleanup still checks ownership and concurrent changes, removes only this run's
+annotation, and requires healthy serving endpoints afterward. Removing the
+annotation can itself replace pods, so budget and schedule the restoration too.
+
+Deploy the tested Fountain reconnect fixes and an updated dedicated runner
+before running production recovery. Enable the deterministic fixture only for
+its dedicated test account. Both image references in the Deployment and test
+configuration must already use the recorded immutable digest. No production
+restart verdict is claimed by the adapter's local tests.
+
+Keep the production idle policy. The production example allows 70 minutes for
+the default 60-minute idle park and has an explicit two-hour overall bound.
+It still permits only four fixture prompts and no inference, and requires time
+for the idle wait, four bounded turns, provisioning and control overhead.
+Staging retains its ten-minute idle-wait cap and thirty-minute run cap; ordinary
+profiles retain their existing limits. Use an appropriate explicit budget if
+the deployed policy differs. The profile never changes global idle settings or
+skips the public suspend/wake assertion.
+
+### Configuration
 
 `adapters/recovery-kubernetes.mjs` exports `RecoveryDeployment`. Its caller first
 prepares a durable journal, then calls `roll` during a deterministic turn, and
@@ -101,7 +143,8 @@ image identity reported by each serving container; verify these against the
 cluster's container runtime before preparing the target. The baseline and target
 may be the same image when testing a restart.
 
-The namespace must have label `fountain.dev/environment=staging`. The Deployment
+The namespace must have label `fountain.dev/environment` matching the configured
+environment (`staging` or `production`). The Deployment
 must have label `fountain.dev/recovery-tests=enabled`. Both Deployment and Service
 must have annotation `fountain.dev/deployed-suite-base-url` equal to `base_url`.
 The adapter reads and validates these settings; it never creates them. The
@@ -153,7 +196,7 @@ headers, websocket contents or runner filesystem paths are logged or retained.
 
 Configure:
 
-- `FOUNTAIN_RELAY_UPSTREAM`: staging Fountain HTTPS origin.
+- `FOUNTAIN_RELAY_UPSTREAM`: the selected Fountain HTTPS origin.
 - `FOUNTAIN_RELAY_RUNNER_NAME`: dedicated runner name, at most 64 characters.
 - `FOUNTAIN_RELAY_RUNNER_KEY_SHA256`: lowercase SHA-256 of its exact API key.
 - `FOUNTAIN_RELAY_ADMIN_KEY`: separate credential of at least 32 characters.

--- a/deployed/recovery-production.example.json
+++ b/deployed/recovery-production.example.json
@@ -1,0 +1,53 @@
+{
+  "base_url": "https://production.example.test",
+  "credentials": {
+    "primary": "FOUNTAIN_SUITE_KEY",
+    "secondary": "FOUNTAIN_SUITE_OTHER_KEY"
+  },
+  "profiles": [
+    "recovery"
+  ],
+  "required_capabilities": {
+    "runtimes": [
+      "fountain-fixture"
+    ],
+    "sandbox_providers": [
+      "runner"
+    ]
+  },
+  "limits": {
+    "run_ms": 7200000,
+    "cleanup_ms": 90000,
+    "resources": 3
+  },
+  "recovery": {
+    "runner_id": "cccccccc-cccc-cccc-cccc-cccccccccccc",
+    "max_turns": 4,
+    "provision_ms": 120000,
+    "turn_ms": 300000,
+    "idle_wait_ms": 4200000,
+    "relay": {
+      "receiver_url": "https://runner-relay.example.test",
+      "admin_credential": "FOUNTAIN_RELAY_ADMIN_KEY",
+      "runner_name": "recovery-production",
+      "disconnect_ms": 10000
+    },
+    "deployment": {
+      "adapter": "kubernetes",
+      "environment": "production",
+      "base_url": "https://production.example.test",
+      "context": "production",
+      "namespace": "fountain",
+      "deployment": "fountain",
+      "service": "fountain",
+      "container": "fountain",
+      "deployment_uid": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+      "before_image": "registry.example.test/fountain@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "target_image": "registry.example.test/fountain@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "before_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "target_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "timeout_ms": 240000,
+      "allow_production_restart": true
+    }
+  }
+}

--- a/deployed/test/recovery-deployment.test.mjs
+++ b/deployed/test/recovery-deployment.test.mjs
@@ -13,13 +13,13 @@ const config = { adapter: 'kubernetes', environment: 'staging', base_url: 'https
   context: 'staging', namespace: 'fountain', deployment: 'fountain', service: 'fountain', container: 'fountain',
   deployment_uid: uid, before_image: `registry.test/fountain@${beforeDigest}`,
   target_image: `registry.test/fountain@${targetDigest}`, before_digest: beforeDigest, target_digest: targetDigest, timeout_ms: 3000 };
-const binding = { 'fountain.dev/deployed-suite-base-url': config.base_url };
 
 async function fixture(t, overrides = {}) {
   const directory = await mkdtemp(join(tmpdir(), 'fountain-recovery-control-'));
   t.after(() => rm(directory, { recursive: true, force: true }));
   const path = join(directory, 'recovery.json');
   const selected = { ...config, ...overrides };
+  const binding = { 'fountain.dev/deployed-suite-base-url': selected.base_url };
   const state = {
     namespace: { metadata: { uid: 'namespace-1', labels: { 'fountain.dev/environment': 'staging' } } },
     service: { metadata: { uid: 'service-1', annotations: binding } },
@@ -56,6 +56,62 @@ async function fixture(t, overrides = {}) {
   };
   return { control: new RecoveryDeployment(selected, path, io), io, state, path, patches, config: selected };
 }
+
+async function productionFixture(t) {
+  const f = await fixture(t, { environment: 'production', allow_production_restart: true,
+    base_url: 'https://production.example.test', target_image: config.before_image, target_digest: beforeDigest });
+  f.state.namespace.metadata.labels['fountain.dev/environment'] = 'production';
+  Object.assign(f.state.deployment.spec, { replicas: 2, strategy: { type: 'RollingUpdate', rollingUpdate: { maxUnavailable: 0, maxSurge: 1 } } });
+  f.state.deployment.status = { observedGeneration: 1, replicas: 2, updatedReplicas: 2, readyReplicas: 2, availableReplicas: 2, unavailableReplicas: 0 };
+  return f;
+}
+
+test('explicit production restart preserves its image and can restore after availability drops', async t => {
+  const f = await productionFixture(t);
+  await f.control.prepare(runId); await f.control.roll();
+  assert.equal(f.state.deployment.spec.template.spec.containers[1].image, config.before_image);
+  f.state.deployment.status.readyReplicas = 0;
+  f.state.deployment.status.availableReplicas = 0;
+  const resumed = await RecoveryDeployment.resume(f.path, f.io);
+  await resumed.restore();
+  assert.equal(f.patches.length, 2);
+  assert.equal(f.state.deployment.spec.template.metadata.annotations, undefined);
+  assert.equal(f.state.deployment.spec.replicas, 2);
+  assert.deepEqual(f.state.deployment.spec.strategy, { type: 'RollingUpdate', rollingUpdate: { maxUnavailable: 0, maxSurge: 1 } });
+});
+
+test('production acknowledgement never authorizes an image upgrade or downgrade', () => {
+  assert.throws(() => validateRecoveryDeployment({ ...config, environment: 'production', allow_production_restart: true }), /pinned serving image/);
+  assert.throws(() => validateRecoveryDeployment({ ...config, allow_production_restart: true }), /only to a production/);
+});
+
+for (const [name, mutate] of Object.entries({
+  'single replica': s => s.spec.replicas = 1,
+  'Recreate strategy': s => s.spec.strategy.type = 'Recreate',
+  'unavailable replicas allowed': s => s.spec.strategy.rollingUpdate.maxUnavailable = 1,
+  'multiple surge replicas': s => s.spec.strategy.rollingUpdate.maxSurge = 2,
+  'invalid percentage': s => s.spec.strategy.rollingUpdate.maxSurge = '101%',
+  'unobserved generation': s => s.status.observedGeneration = 0,
+  'incomplete rollout': s => s.status.updatedReplicas = 1,
+  'extra replica still present': s => s.status.replicas = 3,
+  'unready replica': s => s.status.readyReplicas = 1,
+  'unavailable replica': s => s.status.availableReplicas = 1,
+})) test(`production refuses ${name} before preparing any mutation`, async t => {
+  const f = await productionFixture(t); mutate(f.state.deployment);
+  await assert.rejects(f.control.prepare(runId));
+  assert.equal(f.patches.length, 0);
+  await assert.rejects(readFile(f.path), { code: 'ENOENT' });
+});
+
+test('production rechecks availability before the fault and interprets Kubernetes percentage rounding', async t => {
+  const f = await productionFixture(t);
+  f.state.deployment.spec.strategy.rollingUpdate = { maxUnavailable: '25%', maxSurge: '25%' };
+  await f.control.prepare(runId);
+  f.state.deployment.status.readyReplicas = 1;
+  await assert.rejects(f.control.roll(), /fully available/);
+  assert.equal(f.patches.length, 0);
+  assert.equal(JSON.parse(await readFile(f.path)).phase, 'prepared');
+});
 
 test('rollout and restoration preserve unrelated fields and save private durable evidence', async t => {
   const f = await fixture(t);
@@ -198,7 +254,7 @@ test('restoration preserves annotations added while the recovery rollout is acti
   assert.deepEqual(f.state.deployment.spec.template.metadata.annotations, { added: 'keep' });
 });
 
-test('strict configuration rejects production, mutable images, shell arguments, and unbounded waits', () => {
+test('strict configuration rejects unacknowledged production, mutable images, shell arguments, and unbounded waits', () => {
   for (const change of [{ environment: 'production' }, { before_image: 'repo:latest' }, { base_url: 'http://localhost' },
     { context: '--server=evil' }, { timeout_ms: 300001 }, { deployment_uid: 'name' }, { command: 'sh' }]) {
     assert.throws(() => validateRecoveryDeployment({ ...config, ...change }));

--- a/deployed/test/recovery-profile.test.mjs
+++ b/deployed/test/recovery-profile.test.mjs
@@ -49,7 +49,7 @@ test('terminal public evidence fails recovery immediately instead of waiting for
   assert.equal(recoveredAttachment([attached], 'turn-2'), attached);
   assert.throws(() => recoveredAttachment([attached, event], 'turn-2'), /ended before permission/);
 });
-test('recovery selection pins staging, independent controls, a dedicated runner and four prompts', t => {
+test('recovery selection pins an explicit environment, independent controls, a dedicated runner and four prompts', t => {
   const dir = mkdtempSync(join(tmpdir(), 'fountain-recovery-config-'));
   t.after(() => rmSync(dir, { force: true, recursive: true }));
   const example = JSON.parse(readFileSync(new URL('../recovery.example.json', import.meta.url)));
@@ -67,6 +67,24 @@ test('recovery selection pins staging, independent controls, a dedicated runner 
   }
   assert.throws(() => ciConfig({ SUITE_ENABLED: 'true', SUITE_TARGET: 'production', SUITE_PROFILE: 'recovery',
     SUITE_TARGET_JSON: JSON.stringify(example) }));
+});
+
+test('production budgets the existing hourly idle policy without changing staging or ordinary run limits', t => {
+  const dir = mkdtempSync(join(tmpdir(), 'fountain-production-config-'));
+  t.after(() => rmSync(dir, { force: true, recursive: true }));
+  const example = JSON.parse(readFileSync(new URL('../recovery-production.example.json', import.meta.url)));
+  const path = join(dir, 'target.json');
+  const env = { FOUNTAIN_SUITE_KEY: 'primary', FOUNTAIN_SUITE_OTHER_KEY: 'secondary', FOUNTAIN_RELAY_ADMIN_KEY: 'x'.repeat(40) };
+  const parse = value => { writeFileSync(path, JSON.stringify(value)); return configFrom(path, env); };
+  const production = parse(example);
+  assert.equal(production.recovery.idle_wait_ms, 4200000);
+  assert.equal(production.limits.run_ms, 7200000);
+  assert.equal(production.fixture.max_turns, 4);
+  for (const mutate of [c => c.recovery.deployment.allow_production_restart = false,
+    c => c.limits.run_ms = 1800000, c => c.limits.run_ms = 7200001, c => c.recovery.idle_wait_ms = 4200001]) {
+    const changed = structuredClone(example); mutate(changed); assert.throws(() => parse(changed));
+  }
+  assert.throws(() => parse({ base_url: example.base_url, credentials: example.credentials, profiles: ['probe'], limits: { run_ms: 7200000 } }));
 });
 
 test('interrupted cleanup checks both control manifests and preserves failure without mutating another run', async t => {


### PR DESCRIPTION
Recovery tests previously required staging, preventing their use on an explicitly selected production target. Add a production mode that restarts the same immutable serving image, requires explicit opt-in and a fully converged Deployment with at least two replicas, and admits only zero unavailable replicas with one surge replica. Ownership, UID, image and resource-version checks still apply; restoration remains possible when rollout health degrades.

The production example retains the existing 60-minute idle policy, allows 70 minutes to observe park/wake and bounds the whole run to two hours and four deterministic prompts. The adapter changes neither replica count nor rollout strategy. A restart can interrupt existing sessions, and restoration may replace pods again.

Validation: all 185 deployed harness tests passed; documentation style and diff checks passed. The inherited Elixir/Go tree is unchanged from the base validated by full `mix precommit` (4,490 tests and six doctests) and Go race tests. Production recovery has not run: deploy the fixture/reconnect fixes and updated dedicated runner, and configure immutable image pins and recovery markers before attempting it.

Stack: targets `codex/deployed-browser` (#1651). Part of #1617 and tracker #1606. This follow-up implements the user's production-only target choice; it does not claim a deployed recovery verdict.
