### PR TITLE
feat(api): bulk apply reconciles Teammate, Schedule and Webhook documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ upgrade, is in
   existing launches retain `owner` behavior. Applications processing mutually
   untrusted work can keep all Fountain API authority on their service host.
 
+- Bulk apply reconciles `Teammate`, `Schedule` and `Webhook` documents alongside
+  `Environment`, `Vault` and `Agent`, so one manifest declares a whole estate.
+  Teammates resolve their agent, environment and vault by name; schedules name
+  their teammate; webhooks are keyed by URL and hand back their signing secret
+  on the apply that creates them. Result rows now report `unchanged` when the
+  record already matched the document. Apply stays additive and prunes nothing.
+
 ### Fixed
 
 - Codex launches on Sprites with inherited and ambient capabilities cleared,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ upgrade, is in
   their teammate; webhooks are keyed by URL and hand back their signing secret
   on the apply that creates them. Result rows now report `unchanged` when the
   record already matched the document. Apply stays additive and prunes nothing.
+  Rebinding a teammate retires the computer its old environment and vault named,
+  and is refused while a turn is running on it.
 
 ### Fixed
 
@@ -67,6 +69,8 @@ upgrade, is in
 
 - The account event stream replays rapid failures missed before discovery and includes finished conversations on reconnect.
 - Registration and conversation creation declare both shapes of 422 refusal without schema-guard exceptions.
+- Updating an environment, vault, agent or webhook endpoint with values it already
+  holds no longer records an `*.updated` audit event naming no changed fields.
 
 ### Changed
 

--- a/apps/fountain/lib/fountain/agents.ex
+++ b/apps/fountain/lib/fountain/agents.ex
@@ -183,9 +183,14 @@ defmodule Fountain.Agents do
         Repo.update(changeset)
       end
 
+    # A save that moves nothing records nothing, the same rule
+    # `Fountain.Environments.update_environment/3` follows (#1636).
     result =
-      result
-      |> audited("agent.updated", merge_metadata(opts, Audit.changed_fields(changeset)))
+      if changeset.changes == %{} do
+        result
+      else
+        audited(result, "agent.updated", merge_metadata(opts, Audit.changed_fields(changeset)))
+      end
 
     # Only once the new identity is the committed one: a home torn down
     # against an update that then failed would be rebuilt for nothing.

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -2326,8 +2326,9 @@ defmodule Fountain.Conversations do
 
   `opts[:reason]` says *why*, and reaches every transcript on the machine and
   the audit row: `"home_reset"` (the owner asked — the default),
-  `"environment_changed"`, `"environment_deleted"` or `"vault_deleted"` when
-  the identity moved out from under the home (#1084).
+  `"environment_changed"`, `"environment_deleted"`, `"vault_deleted"` or
+  `"teammate_rebound"` when the identity moved out from under the home
+  (#1084, #1636).
 
   See `create_agent/2` for the rest of `opts` (`:actor`, `:request_ip`).
   """
@@ -2433,6 +2434,11 @@ defmodule Fountain.Conversations do
 
   defp reset_message("vault_deleted"),
     do: "The vault this machine was built for was deleted. " <> @reset_tail
+
+  defp reset_message("teammate_rebound"),
+    do:
+      "The teammate moved to a different environment or vault, so this machine is no " <>
+        "longer its " <> @reset_tail
 
   defp reset_message(_owner), do: "The sandbox was reset by its owner. " <> @reset_tail
 

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -1159,6 +1159,36 @@ defmodule Fountain.Conversations do
   end
 
   @doc """
+  `_unsafe_list_cotenant_ids/2`, with the identity each co-tenant declares:
+  `{id, environment_id, vault_id}`, where the environment is the *effective*
+  one a machine would be built from — the conversation's own override, and
+  the agent's environment when it has none. That is the pair a sandbox row
+  carries and `_unsafe_find_home/4` looks a home up by.
+
+  Co-tenants normally share one identity, because attaching to a machine
+  requires the same agent, environment and vault. They can diverge afterwards:
+  rebinding a teammate (`Fountain.Team.update_teammate/4`) moves one
+  conversation's environment or vault while its co-tenants keep theirs. A
+  lifecycle decision taken for the whole machine has to read this rather than
+  assume, or a replacement built for one identity is handed to a conversation
+  that declared another.
+  """
+  def _unsafe_list_cotenants_with_identity(sandbox_id, conv_id)
+      when is_binary(sandbox_id) and is_binary(conv_id) do
+    Repo.all(
+      from c in Conversation,
+        # Fully qualified: `alias Fountain.Agents` is declared further down
+        # this module, so it is not in scope here.
+        left_join: a in Fountain.Agents.Agent,
+        on: a.id == c.agent_id,
+        where:
+          c.sandbox_id == ^sandbox_id and c.id != ^conv_id and
+            c.status not in ["terminated", "failed"],
+        select: {c.id, coalesce(c.environment_id, a.environment_id), c.vault_id}
+    )
+  end
+
+  @doc """
   Whether any *other* conversation on `sandbox_id` is mid-turn, or was active
   within the last `idle_seconds`.
 
@@ -3296,7 +3326,7 @@ defmodule Fountain.Conversations do
 
           # The machine was gone for everyone on it, not just the conversation
           # that noticed (ADR 0023 gate 5).
-          move_cotenants(old_sandbox_id, new_sandbox.id, conv.id)
+          move_cotenants(old_sandbox_id, new_sandbox, conv.id)
 
           {:ok, _unsafe_get_conversation!(conv.id)}
 
@@ -3342,52 +3372,108 @@ defmodule Fountain.Conversations do
   # provisioning yet another machine on its own next prompt, and the shared
   # disk they were sharing ends up as N disks.
   #
+  # It follows only if it declared the same identity. The replacement was
+  # built from the *waking* conversation's environment and vault, so handing
+  # it to a co-tenant that names a different pair would run that conversation
+  # on another binding's environment files and vault material, and would make
+  # the machine depend on which conversation happened to wake first
+  # (#1636). One that declared something else keeps pointing at the retired
+  # row instead, which its own next wake reads as `:create_new` and builds
+  # from its own identity.
+  #
   # `old_sandbox_id` is the row the waking conversation *used* to name; by the
   # time this runs the waking conversation itself already names the new one,
   # so it is not among the co-tenants.
   #
-  # A co-tenant whose server is somehow alive holds a handle to the dead
-  # sprite; it is told the machine is gone, cuts any turn, and stops, so its
-  # next prompt takes the wake path onto the new row. `runtime_session_id` is
-  # cleared for each: a fresh disk has no session to resume (#778).
-  defp move_cotenants(nil, _new_sandbox_id, _conv_id), do: :ok
+  # Either way the disk is gone for all of them, so all of them are told. A
+  # co-tenant whose server is somehow alive holds a handle to the dead sprite;
+  # it is told the machine is gone, cuts any turn, and stops, so its next
+  # prompt takes the wake path. `runtime_session_id` is cleared for each: a
+  # fresh disk has no session to resume (#778).
+  defp move_cotenants(nil, _new_sandbox, _conv_id), do: :ok
 
-  defp move_cotenants(old_sandbox_id, new_sandbox_id, conv_id)
-       when is_binary(old_sandbox_id) and is_binary(new_sandbox_id) do
-    case _unsafe_list_cotenant_ids(old_sandbox_id, conv_id) do
+  defp move_cotenants(old_sandbox_id, %Sandbox{} = new_sandbox, conv_id)
+       when is_binary(old_sandbox_id) do
+    case _unsafe_list_cotenants_with_identity(old_sandbox_id, conv_id) do
       [] ->
         :ok
 
-      ids ->
-        message =
-          "The sandbox this conversation was on is gone; it moved to a fresh one together " <>
-            "with the conversations that shared it. The transcript is kept, but the agent " <>
-            "starts a new session and will not remember the earlier turns."
+      cotenants ->
+        identity = {new_sandbox.environment_id, new_sandbox.vault_id}
 
-        Enum.each(ids, fn id ->
-          case ConversationServer.whereis(id) do
-            nil -> :ok
-            pid -> GenServer.cast(pid, {:machine_gone, "replaced", "sprite_gone", message})
-          end
-        end)
+        {following, on_their_own} =
+          Enum.split_with(cotenants, fn {_id, env_id, vault_id} ->
+            {env_id, vault_id} == identity
+          end)
 
-        now = DateTime.utc_now() |> DateTime.truncate(:second)
-
-        Repo.update_all(from(c in Conversation, where: c.id in ^ids),
-          set: [sandbox_id: new_sandbox_id, runtime_session_id: nil, updated_at: now]
-        )
-
-        Enum.each(ids, fn id ->
-          publish_stage(id, "sandbox", "done", %{
-            event: "replaced",
-            reason: "sprite_gone",
-            sandbox_id: new_sandbox_id,
-            message: message
-          })
-        end)
-
+        follow_cotenants(Enum.map(following, &elem(&1, 0)), new_sandbox.id)
+        strand_cotenants(Enum.map(on_their_own, &elem(&1, 0)))
         :ok
     end
+  end
+
+  defp follow_cotenants([], _new_sandbox_id), do: :ok
+
+  defp follow_cotenants(ids, new_sandbox_id) do
+    message =
+      "The sandbox this conversation was on is gone; it moved to a fresh one together " <>
+        "with the conversations that shared it. The transcript is kept, but the agent " <>
+        "starts a new session and will not remember the earlier turns."
+
+    tell_cotenants(ids, "replaced", message)
+
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    Repo.update_all(from(c in Conversation, where: c.id in ^ids),
+      set: [sandbox_id: new_sandbox_id, runtime_session_id: nil, updated_at: now]
+    )
+
+    Enum.each(ids, fn id ->
+      publish_stage(id, "sandbox", "done", %{
+        event: "replaced",
+        reason: "sprite_gone",
+        sandbox_id: new_sandbox_id,
+        message: message
+      })
+    end)
+  end
+
+  defp strand_cotenants([]), do: :ok
+
+  defp strand_cotenants(ids) do
+    message =
+      "The sandbox this conversation was on is gone. It named a different environment " <>
+        "or vault from the conversation that replaced the machine, so it did not follow " <>
+        "onto that one; its next prompt builds a machine from what it declares. The " <>
+        "transcript is kept, and the agent starts a new session."
+
+    tell_cotenants(ids, "reset", message)
+
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    # `sandbox_id` is left naming the retired row on purpose: `wake_conversation/2`
+    # reads a terminated row as `:create_new` and provisions from this
+    # conversation's own environment and vault.
+    Repo.update_all(from(c in Conversation, where: c.id in ^ids),
+      set: [runtime_session_id: nil, updated_at: now]
+    )
+
+    Enum.each(ids, fn id ->
+      publish_stage(id, "sandbox", "done", %{
+        event: "reset",
+        reason: "sprite_gone",
+        message: message
+      })
+    end)
+  end
+
+  defp tell_cotenants(ids, event, message) do
+    Enum.each(ids, fn id ->
+      case ConversationServer.whereis(id) do
+        nil -> :ok
+        pid -> GenServer.cast(pid, {:machine_gone, event, "sprite_gone", message})
+      end
+    end)
   end
 
   defp mark_old_sandbox_terminated(nil), do: :ok

--- a/apps/fountain/lib/fountain/environments.ex
+++ b/apps/fountain/lib/fountain/environments.ex
@@ -134,10 +134,22 @@ defmodule Fountain.Environments do
   """
   def update_environment(%Environment{} = env, attrs, opts \\ []) do
     changeset = Environment.changeset(env, attrs)
+    result = Repo.update(changeset)
 
-    changeset
-    |> Repo.update()
-    |> audited("environment.updated", merge_metadata(opts, Audit.changed_fields(changeset)))
+    # A save that moves nothing is not a change, and records nothing
+    # (CLAUDE.md, "Only record what happened"). `Repo.update` already skips
+    # the SQL for an empty changeset, so an idempotent re-apply of a manifest
+    # left a trail of `environment.updated` rows with an empty changed list
+    # against a row nobody had touched (#1636).
+    if changeset.changes == %{} do
+      result
+    else
+      audited(
+        result,
+        "environment.updated",
+        merge_metadata(opts, Audit.changed_fields(changeset))
+      )
+    end
   end
 
   @doc """

--- a/apps/fountain/lib/fountain/manifest.ex
+++ b/apps/fountain/lib/fountain/manifest.ex
@@ -608,6 +608,17 @@ defmodule Fountain.Manifest do
       ]
     }
 
+  # One live computer per (agent, environment, vault): the teammate cannot be
+  # moved onto an identity that already has one, because its next wake would
+  # build a second and the index refuses it. Named so the row says what to do.
+  defp context_errors(:destination_home_occupied),
+    do: %{
+      "base" => [
+        "this agent already has a computer on that environment and vault; " <>
+          "reset or remove it before binding the teammate to them"
+      ]
+    }
+
   defp context_errors(:provisioning), do: %{"base" => ["the computer is still starting"]}
   defp context_errors(:busy), do: %{"base" => ["the teammate is running a turn"]}
   defp context_errors(:runner_offline), do: %{"base" => ["the teammate's machine is offline"]}

--- a/apps/fountain/lib/fountain/manifest.ex
+++ b/apps/fountain/lib/fountain/manifest.ex
@@ -3,21 +3,42 @@ defmodule Fountain.Manifest do
   Bulk apply for compiled IaC manifests (`fountain apply`).
 
   Takes the full list of resources the CLI compiled from a `fountain.yml`
-  and reconciles them against the tenant's records in one pass:
-  environments first, then vaults, then agents — the same fixed ordering
-  `fountain apply` has always used, so an Agent doc can reference an
-  Environment by name regardless of document order. Agent `environment`
-  references resolve against environments in this manifest first, then
-  against the tenant's existing environments.
+  and reconciles them against the tenant's records in one pass, in a fixed
+  order: environments, vaults, agents, teammates, schedules, webhooks. The
+  order is what lets a document reference another by name regardless of
+  where it sits in the file. An Agent's `environment`, a Teammate's `agent`,
+  `environment` and `vault`, and a Schedule's `teammate` all resolve against
+  the documents applied earlier in this manifest first, then against the
+  tenant's existing records.
+
+  Each kind has its own upsert key:
+
+  | Kind | Key | Reconciled through |
+  |---|---|---|
+  | `Environment` | `name` | `Fountain.Environments` |
+  | `Vault` | `name` | `Fountain.Vaults` |
+  | `Agent` | `name` | `Fountain.Agents` |
+  | `Teammate` | `name`, which names the agent's membership | `Fountain.Team` |
+  | `Schedule` | `name`, under its `teammate` | `Fountain.Team.Schedules` |
+  | `Webhook` | `spec.url` | `Fountain.Webhooks` |
+
+  A teammate is one agent's membership of the team, so the document's `name`
+  is what the teammate is called and the resolved `agent` is what it
+  reconciles against. Re-applying a Teammate with a different `name` renames
+  it rather than adding a second membership for the same agent.
 
   Application is best-effort per resource, mirroring the CLI's previous
   one-call-per-resource behavior: a resource that fails validation is
   reported in its result entry and does not stop the rest of the manifest.
+
+  Apply is additive. A document removed from the manifest leaves its record
+  in place; there is no prune.
   """
 
-  alias Fountain.{Agents, Crypto, Environments, Vaults}
+  alias Fountain.{Agents, Crypto, Environments, Team, Vaults, Webhooks}
+  alias Fountain.Team.Schedules
 
-  @kinds ~w(Environment Vault Agent)
+  @kinds ~w(Environment Vault Agent Teammate Schedule Webhook)
 
   def kinds, do: @kinds
 
@@ -29,12 +50,18 @@ defmodule Fountain.Manifest do
   Apply `resources` (maps with `"kind"`, `"name"`, and `"spec"`) for `user_id`.
 
   Returns `{:ok, results}` with one result map per resource in apply order
-  (environments, vaults, agents, then any malformed entries). Each result
-  holds `:kind`, `:name`, an `:action` of `:created` / `:updated` / `:error`,
-  changeset-style `:errors` when the action is `:error`, a `:secrets`
-  list with the per-key upsert outcome, and the reconciled record's `:id`
-  (nil for errors and for kinds that carry no secrets). Secret values are
-  never echoed back.
+  (the six kinds in the order above, then any malformed entries). Each result
+  holds `:kind`, `:name`, an `:action` of `:created` / `:updated` /
+  `:unchanged` / `:error`, changeset-style `:errors` when the action is
+  `:error`, a `:secrets` list with the per-key upsert outcome, the
+  reconciled record's `:id` (nil for errors), and `:secret`, which carries a
+  webhook endpoint's signing secret on the apply that created it and is nil
+  everywhere else.
+
+  `:unchanged` means the record already matched the document, so nothing was
+  written to it. Inline `spec.secrets` are re-encrypted on every apply and
+  keep reporting `:upserted` in `:secrets`, whatever the row's own verdict
+  says: the stored ciphertext cannot be compared with the plaintext given.
   """
   def apply_manifest(user_id, resources, opts \\ [])
       when is_binary(user_id) and is_list(resources) do
@@ -43,24 +70,44 @@ defmodule Fountain.Manifest do
     envs = Map.get(groups, "Environment", [])
     vaults = Map.get(groups, "Vault", [])
     agents = Map.get(groups, "Agent", [])
+    teammates = Map.get(groups, "Teammate", [])
+    schedules = Map.get(groups, "Schedule", [])
+    webhooks = Map.get(groups, "Webhook", [])
 
     dek = if Enum.any?(envs ++ vaults, &has_secrets?/1), do: load_dek!(user_id)
 
-    {env_results, env_id_by_name} =
-      Enum.map_reduce(envs, %{}, fn res, acc ->
-        case apply_environment(user_id, res, dek, opts) do
-          {result, nil} -> {result, acc}
-          {result, env} -> {result, Map.put(acc, env.name, env.id)}
-        end
-      end)
+    {env_results, env_ids} = reconcile(envs, &apply_environment(user_id, &1, dek, opts))
+    {vault_results, vault_ids} = reconcile(vaults, &apply_vault(user_id, &1, dek, opts))
+    {agent_results, agent_ids} = reconcile(agents, &apply_agent(user_id, &1, env_ids, opts))
+
+    refs = %{agents: agent_ids, environments: env_ids, vaults: vault_ids}
+
+    {teammate_results, teammate_ids} =
+      reconcile(teammates, &apply_teammate(user_id, &1, refs, opts))
+
+    known_teammates = teammate_refs(user_id, schedules, teammate_ids)
 
     results =
       env_results ++
-        Enum.map(vaults, &apply_vault(user_id, &1, dek, opts)) ++
-        Enum.map(agents, &apply_agent(user_id, &1, env_id_by_name, opts)) ++
+        vault_results ++
+        agent_results ++
+        teammate_results ++
+        Enum.map(schedules, &apply_schedule(user_id, &1, known_teammates, opts)) ++
+        Enum.map(webhooks, &apply_webhook(user_id, &1, opts)) ++
         Enum.map(invalid, &invalid_result/1)
 
     {:ok, results}
+  end
+
+  # Each kind that can be referenced by a later one returns `{result, id}`,
+  # so the pass leaves behind the name → id map the next pass resolves against.
+  defp reconcile(resources, fun) do
+    Enum.map_reduce(resources, %{}, fn res, acc ->
+      case fun.(res) do
+        {result, nil} -> {result, acc}
+        {result, id} -> {result, Map.put(acc, res["name"], id)}
+      end
+    end)
   end
 
   # Keeps the `via: apply` marker the ApplyController used to attach when it
@@ -76,24 +123,22 @@ defmodule Fountain.Manifest do
   defp apply_environment(user_id, %{"name" => name} = res, dek, opts) do
     with :ok <- validate_spec(res, Environments.Environment, ~w(secrets)) do
       {attrs, secrets} = split_spec(res, name)
+      existing = Environments.get_environment_by_name(name, user_id)
 
       outcome =
-        case Environments.get_environment_by_name(name, user_id) do
-          nil ->
-            {:created, Environments.create_environment(Map.put(attrs, "user_id", user_id), opts)}
-
-          env ->
-            {:updated, Environments.update_environment(env, attrs, opts)}
-        end
+        if existing,
+          do: Environments.update_environment(existing, attrs, opts),
+          else: Environments.create_environment(Map.put(attrs, "user_id", user_id), opts)
 
       case outcome do
-        {action, {:ok, env}} ->
+        {:ok, env} ->
           secret_results =
             upsert_secrets(secrets, &Environments.upsert_secret(env, &1, dek, secret_opts(opts)))
 
-          {result("Environment", name, action, nil, secret_results, env.id), env}
+          {result("Environment", name, verdict(existing, env), nil, secret_results, env.id),
+           env.id}
 
-        {_action, {:error, changeset}} ->
+        {:error, changeset} ->
           {result("Environment", name, :error, changeset_errors(changeset), []), nil}
       end
     else
@@ -104,92 +149,221 @@ defmodule Fountain.Manifest do
   defp apply_vault(user_id, %{"name" => name} = res, dek, opts) do
     with :ok <- validate_spec(res, Vaults.Vault, ~w(secrets)) do
       {attrs, secrets} = split_spec(res, name)
+      existing = Vaults.get_vault_by_name(name, user_id)
 
       outcome =
-        case Vaults.get_vault_by_name(name, user_id) do
-          nil -> {:created, Vaults.create_vault(Map.put(attrs, "user_id", user_id), opts)}
-          vault -> {:updated, Vaults.update_vault(vault, attrs, opts)}
-        end
+        if existing,
+          do: Vaults.update_vault(existing, attrs, opts),
+          else: Vaults.create_vault(Map.put(attrs, "user_id", user_id), opts)
 
       case outcome do
-        {action, {:ok, vault}} ->
+        {:ok, vault} ->
           secret_results =
             upsert_secrets(secrets, &Vaults.upsert_secret(vault, &1, dek, secret_opts(opts)))
 
-          result("Vault", name, action, nil, secret_results, vault.id)
+          {result("Vault", name, verdict(existing, vault), nil, secret_results, vault.id),
+           vault.id}
 
-        {_action, {:error, changeset}} ->
-          result("Vault", name, :error, changeset_errors(changeset), [])
+        {:error, changeset} ->
+          {result("Vault", name, :error, changeset_errors(changeset), []), nil}
       end
     else
-      {:error, errors} -> result("Vault", name, :error, errors, [])
+      {:error, errors} -> {result("Vault", name, :error, errors, []), nil}
     end
   end
 
-  defp apply_agent(user_id, %{"name" => name} = res, env_id_by_name, opts) do
-    with :ok <- validate_spec(res, Agents.Agent, ~w(environment)) do
-      {attrs, _secrets} = split_spec(res, name)
-      {env_ref, attrs} = Map.pop(attrs, "environment")
+  defp apply_agent(user_id, %{"name" => name} = res, env_ids, opts) do
+    with :ok <- validate_spec(res, Agents.Agent, ~w(environment)),
+         {attrs, _secrets} = split_spec(res, name),
+         {env_ref, attrs} = Map.pop(attrs, "environment"),
+         {:ok, env_id} <- resolve_ref("environment", user_id, env_ref, env_ids) do
+      attrs = if env_id, do: Map.put(attrs, "environment_id", env_id), else: attrs
+      existing = Agents.get_agent_by_name(name, user_id)
 
-      case resolve_environment_ref(user_id, env_ref, env_id_by_name) do
-        {:ok, env_attrs} ->
-          attrs = Map.merge(attrs, env_attrs)
+      outcome =
+        if existing,
+          do: Agents.update_agent(existing, attrs, opts),
+          else: Agents.create_agent(Map.put(attrs, "user_id", user_id), opts)
 
-          outcome =
-            case Agents.get_agent_by_name(name, user_id) do
-              nil -> {:created, Agents.create_agent(Map.put(attrs, "user_id", user_id), opts)}
-              agent -> {:updated, Agents.update_agent(agent, attrs, opts)}
-            end
+      case outcome do
+        {:ok, agent} ->
+          {result("Agent", name, verdict(existing, agent), nil, [], agent.id), agent.id}
 
-          case outcome do
-            {action, {:ok, _agent}} ->
-              result("Agent", name, action, nil, [])
+        # Moving the agent's environment rebuilds its machine, which a
+        # running turn blocks (#1084). Reported against the field that
+        # caused it so `fountain apply` says what to do about it.
+        {:error, :sandbox_mid_turn} ->
+          errors = %{
+            "environment" => [
+              "the agent is running a turn on its own machine; changing its " <>
+                "environment rebuilds that machine — retry once the turn ends"
+            ]
+          }
 
-            # Moving the agent's environment rebuilds its machine, which a
-            # running turn blocks (#1084). Reported against the field that
-            # caused it so `fountain apply` says what to do about it.
-            {_action, {:error, :sandbox_mid_turn}} ->
-              errors = %{
-                "environment" => [
-                  "the agent is running a turn on its own machine; changing its " <>
-                    "environment rebuilds that machine — retry once the turn ends"
-                ]
-              }
+          {result("Agent", name, :error, errors, []), nil}
 
-              result("Agent", name, :error, errors, [])
-
-            {_action, {:error, cs}} ->
-              result("Agent", name, :error, changeset_errors(cs), [])
-          end
-
-        {:error, ref} ->
-          errors = %{"environment" => ["environment not found: #{ref}"]}
-          result("Agent", name, :error, errors, [])
+        {:error, cs} ->
+          {result("Agent", name, :error, changeset_errors(cs), []), nil}
       end
     else
-      {:error, errors} -> result("Agent", name, :error, errors, [])
+      {:error, errors} -> {result("Agent", name, :error, errors, []), nil}
     end
   end
 
-  # Resolve an agent's `environment: <name>` reference: environments applied
-  # earlier in this manifest win, then the tenant's existing environments.
-  defp resolve_environment_ref(_user_id, ref, _env_id_by_name) when ref in [nil, ""],
-    do: {:ok, %{}}
+  # A Teammate is an agent on the team, so the agent reference is the record
+  # this reconciles against and the document's name is what it is called.
+  # Adding one opens the teammate's conversation, which provisions its
+  # computer; re-applying only moves the name, environment and vault the next
+  # computer is built from, and never provisions a second one.
+  defp apply_teammate(user_id, %{"name" => name} = res, refs, opts) do
+    spec = spec_of(res)
 
-  defp resolve_environment_ref(user_id, ref, env_id_by_name) when is_binary(ref) do
-    case env_id_by_name[ref] || existing_env_id(user_id, ref) do
-      nil -> {:error, ref}
-      id -> {:ok, %{"environment_id" => id}}
+    with :ok <- validate_keys(res, ~w(name agent environment vault)),
+         {:ok, agent_id} <- require_ref("agent", user_id, spec["agent"], refs.agents),
+         {:ok, env_id} <-
+           resolve_ref("environment", user_id, spec["environment"], refs.environments),
+         {:ok, vault_id} <- resolve_ref("vault", user_id, spec["vault"], refs.vaults) do
+      attrs = %{"name" => name, "environment_id" => env_id, "vault_id" => vault_id}
+      reconcile_teammate(user_id, name, agent_id, attrs, opts)
+    else
+      {:error, errors} -> {result("Teammate", name, :error, errors, []), nil}
     end
   end
 
-  defp resolve_environment_ref(_user_id, ref, _env_id_by_name), do: {:error, inspect(ref)}
+  defp reconcile_teammate(user_id, name, agent_id, attrs, opts) do
+    opts = Keyword.put_new(opts, :source, "api")
 
-  defp existing_env_id(user_id, name) do
-    case Environments.get_environment_by_name(name, user_id) do
-      nil -> nil
-      env -> env.id
+    case Team.get_teammate(user_id, agent_id) do
+      nil ->
+        case Team.add_teammate(user_id, agent_id, attrs, opts) do
+          {:ok, conv} -> {result("Teammate", name, :created, nil, [], conv.id), agent_id}
+          {:error, reason} -> {result("Teammate", name, :error, context_errors(reason), []), nil}
+        end
+
+      %{conversation: before} ->
+        case Team.update_teammate(user_id, agent_id, attrs, opts) do
+          {:ok, conv} ->
+            {result("Teammate", name, verdict(before, conv), nil, [], conv.id), agent_id}
+
+          {:error, reason} ->
+            {result("Teammate", name, :error, context_errors(reason), []), nil}
+        end
     end
+  end
+
+  defp apply_schedule(user_id, %{"name" => name} = res, known_teammates, opts) do
+    spec = spec_of(res)
+
+    with :ok <- validate_keys(res, ~w(name teammate cron prompt one_off enabled)),
+         {:ok, agent_id} <- require_ref("teammate", user_id, spec["teammate"], known_teammates) do
+      attrs =
+        spec
+        |> Map.drop(~w(teammate))
+        |> Map.merge(%{"name" => name, "agent_id" => agent_id})
+
+      reconcile_schedule(user_id, name, agent_id, attrs, opts)
+    else
+      {:error, errors} -> result("Schedule", name, :error, errors, [])
+    end
+  end
+
+  defp reconcile_schedule(user_id, name, agent_id, attrs, opts) do
+    existing =
+      user_id |> Schedules.list_schedules(agent_id) |> Enum.find(&(&1.name == name))
+
+    outcome =
+      if existing,
+        do: Schedules.update_schedule(existing, attrs, opts),
+        else: Schedules.create_schedule(user_id, attrs, opts)
+
+    case outcome do
+      {:ok, schedule} ->
+        result("Schedule", name, verdict(existing, schedule), nil, [], schedule.id)
+
+      {:error, reason} ->
+        result("Schedule", name, :error, context_errors(reason), [])
+    end
+  end
+
+  # Keyed by `spec.url`: the endpoint the tenant already has for that URL is
+  # the one this document describes. The document's name is a label, carried
+  # into the result row so `fountain apply` prints something a reader picked.
+  defp apply_webhook(user_id, %{"name" => name} = res, opts) do
+    with :ok <- validate_keys(res, ~w(url description event_types)) do
+      attrs = spec_of(res)
+      existing = Enum.find(Webhooks.list_endpoints(user_id), &(&1.url == attrs["url"]))
+
+      case reconcile_webhook(user_id, existing, attrs, opts) do
+        {:ok, endpoint, secret} ->
+          %{
+            result("Webhook", name, verdict(existing, endpoint), nil, [], endpoint.id)
+            | secret: secret
+          }
+
+        {:error, reason} ->
+          result("Webhook", name, :error, context_errors(reason), [])
+      end
+    else
+      {:error, errors} -> result("Webhook", name, :error, errors, [])
+    end
+  end
+
+  # The signing secret comes back on creation only, exactly as
+  # `POST /api/webhooks` gives it: an update has none to return.
+  defp reconcile_webhook(user_id, nil, attrs, opts) do
+    with {:ok, {endpoint, secret}} <- Webhooks.create_endpoint(user_id, attrs, opts),
+         do: {:ok, endpoint, secret}
+  end
+
+  defp reconcile_webhook(_user_id, endpoint, attrs, opts) do
+    with {:ok, updated} <- Webhooks.update_endpoint(endpoint, attrs, opts),
+         do: {:ok, updated, nil}
+  end
+
+  # ── references ────────────────────────────────────────────────────────────
+
+  # Resolve a `<field>: <name>` reference: documents applied earlier in this
+  # manifest win, then the tenant's own records. A blank reference is no
+  # reference, which is how an Agent with no environment or a Teammate with
+  # no vault reads.
+  defp resolve_ref(_field, _user_id, ref, _ids) when ref in [nil, ""], do: {:ok, nil}
+
+  defp resolve_ref(field, user_id, ref, ids) when is_binary(ref) do
+    case ids[ref] || tenant_ref(field, user_id, ref) do
+      nil -> {:error, %{field => ["#{field} not found: #{ref}"]}}
+      id -> {:ok, id}
+    end
+  end
+
+  defp resolve_ref(field, _user_id, ref, _ids),
+    do: {:error, %{field => ["#{field} not found: #{inspect(ref)}"]}}
+
+  # The same, for a reference the document cannot do without.
+  defp require_ref(field, _user_id, ref, _ids) when ref in [nil, ""],
+    do: {:error, %{field => ["can't be blank"]}}
+
+  defp require_ref(field, user_id, ref, ids), do: resolve_ref(field, user_id, ref, ids)
+
+  defp tenant_ref("environment", user_id, name),
+    do: id_of(Environments.get_environment_by_name(name, user_id))
+
+  defp tenant_ref("vault", user_id, name), do: id_of(Vaults.get_vault_by_name(name, user_id))
+  defp tenant_ref("agent", user_id, name), do: id_of(Agents.get_agent_by_name(name, user_id))
+  defp tenant_ref("teammate", _user_id, _name), do: nil
+
+  defp id_of(nil), do: nil
+  defp id_of(record), do: record.id
+
+  # The teammates a Schedule may name: the ones this manifest just reconciled,
+  # over the ones the tenant already has. Skipped entirely when the manifest
+  # holds no schedules, because listing the team is several queries.
+  defp teammate_refs(_user_id, [], teammate_ids), do: teammate_ids
+
+  defp teammate_refs(user_id, _schedules, teammate_ids) do
+    user_id
+    |> Team.list_teammates()
+    |> Map.new(&{&1.name, &1.agent.id})
+    |> Map.merge(teammate_ids)
   end
 
   # ── secrets ───────────────────────────────────────────────────────────────
@@ -244,12 +418,16 @@ defmodule Fountain.Manifest do
   # Use the changeset's cast fields, not every database field: timestamps,
   # virtual counts and other read-only state must not look configurable.
   defp validate_spec(res, schema, extra_keys) do
-    allowed =
-      Enum.map(schema.cast_fields(), &Atom.to_string/1) ++ extra_keys ++ ~w(id user_id created_by)
+    validate_keys(res, Enum.map(schema.cast_fields(), &Atom.to_string/1) ++ extra_keys)
+  end
 
-    unknown = Map.keys(res["spec"] || %{}) -- allowed
+  # The kinds with no Ecto schema of their own behind the manifest document
+  # (a Teammate is a conversation, a Webhook an endpoint) name their keys
+  # here, so an unsupported key still fails before anything is written.
+  defp validate_keys(res, allowed) do
+    allowed = allowed ++ ~w(id user_id created_by)
 
-    case unknown do
+    case Map.keys(res["spec"] || %{}) -- allowed do
       [] -> :ok
       keys -> {:error, Map.new(keys, &{&1, ["is not a supported spec key"]})}
     end
@@ -257,28 +435,53 @@ defmodule Fountain.Manifest do
 
   # The top-level resource name is authoritative — it is the upsert key, so
   # it overrides any `name` a spec happens to carry.
-  defp split_spec(%{"spec" => spec}, name) when is_map(spec) do
+  defp split_spec(res, name) do
+    spec = spec_of(res)
+
     secrets =
-      case Map.get(spec, "secrets") do
+      case Map.get(res["spec"] || %{}, "secrets") do
         m when is_map(m) -> m
         _other -> %{}
       end
 
-    {spec |> Map.drop(@stripped_keys) |> Map.put("name", name), secrets}
+    {Map.put(spec, "name", name), secrets}
   end
 
-  defp split_spec(_res, name), do: {%{"name" => name}, %{}}
+  defp spec_of(%{"spec" => spec}) when is_map(spec), do: Map.drop(spec, @stripped_keys)
+  defp spec_of(_res), do: %{}
+
+  # The third verdict. A record the manifest did not move reads `unchanged`,
+  # so a second apply of the same file says plainly that it wrote nothing.
+  # Compared over the schema's own columns with the timestamps left out: an
+  # Ecto update with no changes moves neither.
+  defp verdict(nil, _updated), do: :created
+
+  defp verdict(%mod{} = before, %mod{} = updated) do
+    fields = mod.__schema__(:fields) -- [:inserted_at, :updated_at]
+
+    if Map.take(before, fields) == Map.take(updated, fields), do: :unchanged, else: :updated
+  end
 
   # `id` is the reconciled record's id when there is one. It is not serialized
   # in the API response; callers use it to attribute the secret writes this
   # manifest performed to a concrete resource in the audit trail (#530).
+  # `secret` is a webhook endpoint's signing secret on the apply that minted
+  # it, and nil on every other row and every later apply.
   defp result(kind, name, action, errors, secrets, id \\ nil) do
-    %{kind: kind, name: name, action: action, errors: errors, secrets: secrets, id: id}
+    %{
+      kind: kind,
+      name: name,
+      action: action,
+      errors: errors,
+      secrets: secrets,
+      id: id,
+      secret: nil
+    }
   end
 
   defp invalid_result(res) do
     errors = %{
-      "resource" => ["must have kind (Environment | Vault | Agent), name, and a map spec"]
+      "resource" => ["must have kind (#{Enum.join(@kinds, " | ")}), name, and a map spec"]
     }
 
     result(str(res["kind"]), str(res["name"]), :error, errors, [])
@@ -286,6 +489,25 @@ defmodule Fountain.Manifest do
 
   defp str(value) when is_binary(value), do: value
   defp str(_value), do: ""
+
+  # What a context refused with, as the per-field errors an apply row carries.
+  defp context_errors(%Ecto.Changeset{} = changeset), do: changeset_errors(changeset)
+  defp context_errors(:not_found), do: %{"agent" => ["is not the caller's"]}
+
+  defp context_errors(:environment_not_found),
+    do: %{"environment" => ["environment not found"]}
+
+  defp context_errors(:environment_not_allowed),
+    do: %{"environment" => ["is not allowed by the agent"]}
+
+  defp context_errors(:vault_not_found), do: %{"vault" => ["vault not found"]}
+  defp context_errors(:vault_not_allowed), do: %{"vault" => ["is not allowed by the agent"]}
+  defp context_errors(:insufficient_credits), do: %{"base" => ["out of credit"]}
+
+  defp context_errors({:sandbox_quota_exceeded, %{count: count, limit: limit}}),
+    do: %{"base" => ["sandbox quota: #{count}/#{limit}"]}
+
+  defp context_errors(other), do: %{"base" => [inspect(other)]}
 
   defp changeset_errors(changeset) do
     Ecto.Changeset.traverse_errors(changeset, fn {msg, opts} ->

--- a/apps/fountain/lib/fountain/manifest.ex
+++ b/apps/fountain/lib/fountain/manifest.ex
@@ -25,15 +25,28 @@ defmodule Fountain.Manifest do
   A teammate is one agent's membership of the team, so the document's `name`
   is what the teammate is called and the resolved `agent` is what it
   reconciles against. Re-applying a Teammate with a different `name` renames
-  it rather than adding a second membership for the same agent.
+  it rather than adding a second membership for the same agent, and two
+  documents naming one agent are refused past the first: they describe one
+  record, so without the refusal each pass would rename the other's
+  conversation and no apply would ever be `unchanged`.
 
-  Application is best-effort per resource, mirroring the CLI's previous
-  one-call-per-resource behavior: a resource that fails validation is
-  reported in its result entry and does not stop the rest of the manifest.
+  A Teammate document is also the only one read as a whole declaration. On
+  the other five an absent `spec` key leaves that column alone; on a Teammate
+  an absent `environment` or `vault` clears the binding, back to the agent's
+  own environment and no vault. Moving either id moves the teammate's
+  computer, which `Fountain.Team.update_teammate/4` retires and refuses
+  mid-turn (#1084).
+
+  Application is best-effort per resource: a document that fails validation,
+  that a context refuses, or that raises is reported in its own result entry
+  and does not stop the rest of the manifest.
 
   Apply is additive. A document removed from the manifest leaves its record
-  in place; there is no prune.
+  in place; there is no prune. A `Webhook` whose `spec.url` changes is a new
+  endpoint for that reason, and the one the old URL named keeps delivering.
   """
+
+  require Logger
 
   alias Fountain.{Agents, Crypto, Environments, Team, Vaults, Webhooks}
   alias Fountain.Team.Schedules
@@ -76,38 +89,81 @@ defmodule Fountain.Manifest do
 
     dek = if Enum.any?(envs ++ vaults, &has_secrets?/1), do: load_dek!(user_id)
 
-    {env_results, env_ids} = reconcile(envs, &apply_environment(user_id, &1, dek, opts))
-    {vault_results, vault_ids} = reconcile(vaults, &apply_vault(user_id, &1, dek, opts))
-    {agent_results, agent_ids} = reconcile(agents, &apply_agent(user_id, &1, env_ids, opts))
+    {env_results, env_ids} =
+      reconcile("Environment", envs, fn res, _claimed ->
+        apply_environment(user_id, res, dek, opts)
+      end)
+
+    {vault_results, vault_ids} =
+      reconcile("Vault", vaults, fn res, _claimed -> apply_vault(user_id, res, dek, opts) end)
+
+    {agent_results, agent_ids} =
+      reconcile("Agent", agents, fn res, _claimed -> apply_agent(user_id, res, env_ids, opts) end)
 
     refs = %{agents: agent_ids, environments: env_ids, vaults: vault_ids}
 
     {teammate_results, teammate_ids} =
-      reconcile(teammates, &apply_teammate(user_id, &1, refs, opts))
+      reconcile("Teammate", teammates, fn res, claimed ->
+        apply_teammate(user_id, res, refs, claimed, opts)
+      end)
 
     known_teammates = teammate_refs(user_id, schedules, teammate_ids)
+
+    {schedule_results, _} =
+      reconcile("Schedule", schedules, fn res, _claimed ->
+        apply_schedule(user_id, res, known_teammates, opts)
+      end)
+
+    {webhook_results, _} =
+      reconcile("Webhook", webhooks, fn res, _claimed -> apply_webhook(user_id, res, opts) end)
 
     results =
       env_results ++
         vault_results ++
         agent_results ++
         teammate_results ++
-        Enum.map(schedules, &apply_schedule(user_id, &1, known_teammates, opts)) ++
-        Enum.map(webhooks, &apply_webhook(user_id, &1, opts)) ++
+        schedule_results ++
+        webhook_results ++
         Enum.map(invalid, &invalid_result/1)
 
     {:ok, results}
   end
 
-  # Each kind that can be referenced by a later one returns `{result, id}`,
-  # so the pass leaves behind the name → id map the next pass resolves against.
-  defp reconcile(resources, fun) do
+  # One pass over one kind. Every `apply_*` returns `{result, id}`, so the
+  # pass leaves behind the name → id map the next pass resolves against, and
+  # hands each document the map built so far (which is how a second Teammate
+  # naming an agent already claimed is caught).
+  defp reconcile(kind, resources, fun) do
     Enum.map_reduce(resources, %{}, fn res, acc ->
-      case fun.(res) do
+      case guarded(kind, res["name"], fn -> fun.(res, acc) end) do
         {result, nil} -> {result, acc}
         {result, id} -> {result, Map.put(acc, res["name"], id)}
       end
     end)
+  end
+
+  # Best-effort per resource means per resource. The Teammate pass reaches
+  # Horde, the sandbox quota lock, the credit gate and the sandbox provider,
+  # and a raise or an exit there would abandon a call that has already
+  # committed the environments, vaults and agents above it, leaving the caller
+  # a 500 and no rows at all. Reported as this document's error instead, and
+  # logged, because a crash in a context is still a defect worth a stacktrace.
+  defp guarded(kind, name, fun) do
+    fun.()
+  rescue
+    error ->
+      Logger.error(
+        "apply: #{kind} #{inspect(name)} raised: " <>
+          Exception.format(:error, error, __STACKTRACE__)
+      )
+
+      {result(kind, str(name), :error, %{"base" => [Exception.message(error)]}, []), nil}
+  catch
+    thrown, reason ->
+      Logger.error("apply: #{kind} #{inspect(name)} #{thrown}: #{inspect(reason)}")
+
+      {result(kind, str(name), :error, %{"base" => ["apply failed: #{inspect(reason)}"]}, []),
+       nil}
   end
 
   # Keeps the `via: apply` marker the ApplyController used to attach when it
@@ -215,11 +271,12 @@ defmodule Fountain.Manifest do
   # Adding one opens the teammate's conversation, which provisions its
   # computer; re-applying only moves the name, environment and vault the next
   # computer is built from, and never provisions a second one.
-  defp apply_teammate(user_id, %{"name" => name} = res, refs, opts) do
+  defp apply_teammate(user_id, %{"name" => name} = res, refs, claimed, opts) do
     spec = spec_of(res)
 
     with :ok <- validate_keys(res, ~w(name agent environment vault)),
          {:ok, agent_id} <- require_ref("agent", user_id, spec["agent"], refs.agents),
+         :ok <- unclaimed(name, agent_id, claimed),
          {:ok, env_id} <-
            resolve_ref("environment", user_id, spec["environment"], refs.environments),
          {:ok, vault_id} <- resolve_ref("vault", user_id, spec["vault"], refs.vaults) do
@@ -227,6 +284,24 @@ defmodule Fountain.Manifest do
       reconcile_teammate(user_id, name, agent_id, attrs, opts)
     else
       {:error, errors} -> {result("Teammate", name, :error, errors, []), nil}
+    end
+  end
+
+  # A teammate is one agent's membership of the team, so two documents naming
+  # the same agent describe one record: without this the second renames the
+  # first's conversation on every pass and the manifest is never idempotent.
+  # Two documents sharing a name are refused for the same reason — a Schedule
+  # naming that teammate could not say which one it meant.
+  defp unclaimed(name, agent_id, claimed) do
+    cond do
+      Map.has_key?(claimed, name) ->
+        {:error, %{"name" => ["is already used by another Teammate document"]}}
+
+      agent_id in Map.values(claimed) ->
+        {:error, %{"agent" => ["is already claimed by another Teammate document"]}}
+
+      true ->
+        :ok
     end
   end
 
@@ -240,10 +315,12 @@ defmodule Fountain.Manifest do
           {:error, reason} -> {result("Teammate", name, :error, context_errors(reason), []), nil}
         end
 
-      %{conversation: before} ->
-        case Team.update_teammate(user_id, agent_id, attrs, opts) do
-          {:ok, conv} ->
-            {result("Teammate", name, verdict(before, conv), nil, [], conv.id), agent_id}
+      teammate ->
+        # The teammate map is handed on rather than the agent id: listing the
+        # roster is several queries and this call site has just done it.
+        case Team.update_teammate(user_id, teammate, attrs, opts) do
+          {:ok, conv, action} ->
+            {result("Teammate", name, action, nil, [], conv.id), agent_id}
 
           {:error, reason} ->
             {result("Teammate", name, :error, context_errors(reason), []), nil}
@@ -263,7 +340,7 @@ defmodule Fountain.Manifest do
 
       reconcile_schedule(user_id, name, agent_id, attrs, opts)
     else
-      {:error, errors} -> result("Schedule", name, :error, errors, [])
+      {:error, errors} -> {result("Schedule", name, :error, errors, []), nil}
     end
   end
 
@@ -278,10 +355,10 @@ defmodule Fountain.Manifest do
 
     case outcome do
       {:ok, schedule} ->
-        result("Schedule", name, verdict(existing, schedule), nil, [], schedule.id)
+        {result("Schedule", name, verdict(existing, schedule), nil, [], schedule.id), nil}
 
       {:error, reason} ->
-        result("Schedule", name, :error, context_errors(reason), [])
+        {result("Schedule", name, :error, context_errors(reason), []), nil}
     end
   end
 
@@ -295,16 +372,19 @@ defmodule Fountain.Manifest do
 
       case reconcile_webhook(user_id, existing, attrs, opts) do
         {:ok, endpoint, secret} ->
-          %{
-            result("Webhook", name, verdict(existing, endpoint), nil, [], endpoint.id)
-            | secret: secret
-          }
+          row =
+            %{
+              result("Webhook", name, verdict(existing, endpoint), nil, [], endpoint.id)
+              | secret: secret
+            }
+
+          {row, nil}
 
         {:error, reason} ->
-          result("Webhook", name, :error, context_errors(reason), [])
+          {result("Webhook", name, :error, context_errors(reason), []), nil}
       end
     else
-      {:error, errors} -> result("Webhook", name, :error, errors, [])
+      {:error, errors} -> {result("Webhook", name, :error, errors, []), nil}
     end
   end
 
@@ -331,6 +411,9 @@ defmodule Fountain.Manifest do
   defp resolve_ref(field, user_id, ref, ids) when is_binary(ref) do
     case ids[ref] || tenant_ref(field, user_id, ref) do
       nil -> {:error, %{field => ["#{field} not found: #{ref}"]}}
+      # Two teammates answer to this name, so the document does not say which
+      # record it means. Guessing would bind a schedule to the wrong agent.
+      :ambiguous -> {:error, %{field => ["#{field} name is not unique: #{ref}"]}}
       id -> {:ok, id}
     end
   end
@@ -357,12 +440,21 @@ defmodule Fountain.Manifest do
   # The teammates a Schedule may name: the ones this manifest just reconciled,
   # over the ones the tenant already has. Skipped entirely when the manifest
   # holds no schedules, because listing the team is several queries.
+  #
+  # A teammate's name is its conversation's title, or its agent's name, and
+  # neither is unique. A name two of the tenant's teammates answer to maps to
+  # `:ambiguous` and fails the Schedule row that uses it; a name this manifest
+  # reconciled is unique among the documents (`unclaimed/3`) and wins.
   defp teammate_refs(_user_id, [], teammate_ids), do: teammate_ids
 
   defp teammate_refs(user_id, _schedules, teammate_ids) do
     user_id
     |> Team.list_teammates()
-    |> Map.new(&{&1.name, &1.agent.id})
+    |> Enum.group_by(& &1.name, & &1.agent.id)
+    |> Map.new(fn
+      {name, [agent_id]} -> {name, agent_id}
+      {name, _several} -> {name, :ambiguous}
+    end)
     |> Map.merge(teammate_ids)
   end
 
@@ -491,6 +583,8 @@ defmodule Fountain.Manifest do
   defp str(_value), do: ""
 
   # What a context refused with, as the per-field errors an apply row carries.
+  # Every reason a Teammate or Schedule document can actually provoke is named
+  # here, because `inspect/1` on a bare atom is not a sentence anyone acts on.
   defp context_errors(%Ecto.Changeset{} = changeset), do: changeset_errors(changeset)
   defp context_errors(:not_found), do: %{"agent" => ["is not the caller's"]}
 
@@ -504,16 +598,43 @@ defmodule Fountain.Manifest do
   defp context_errors(:vault_not_allowed), do: %{"vault" => ["is not allowed by the agent"]}
   defp context_errors(:insufficient_credits), do: %{"base" => ["out of credit"]}
 
+  # The same hazard `Agent` reports, from the teammate's side: rebinding moves
+  # the computer out from under a turn that is running on it.
+  defp context_errors(:sandbox_mid_turn),
+    do: %{
+      "base" => [
+        "the teammate is running a turn on its computer; changing its environment " <>
+          "or vault rebuilds that computer, so retry once the turn ends"
+      ]
+    }
+
+  defp context_errors(:provisioning), do: %{"base" => ["the computer is still starting"]}
+  defp context_errors(:busy), do: %{"base" => ["the teammate is running a turn"]}
+  defp context_errors(:runner_offline), do: %{"base" => ["the teammate's machine is offline"]}
+  defp context_errors(:fleet_full), do: %{"base" => ["the fleet is at capacity"]}
+
   defp context_errors({:sandbox_quota_exceeded, %{count: count, limit: limit}}),
     do: %{"base" => ["sandbox quota: #{count}/#{limit}"]}
 
+  defp context_errors({:sandbox_not_attachable, status}),
+    do: %{"base" => ["the teammate's computer is #{status}"]}
+
+  defp context_errors({:sandbox_not_resettable, status}),
+    do: %{"base" => ["the teammate's computer is #{status}"]}
+
   defp context_errors(other), do: %{"base" => [inspect(other)]}
 
+  # String keys throughout. `traverse_errors/2` keys by field atom, while the
+  # hand-built maps above key by string, and a caller reading a result row
+  # should not have to know which branch produced it. The wire shape does not
+  # change: JSON stringifies either one.
   defp changeset_errors(changeset) do
-    Ecto.Changeset.traverse_errors(changeset, fn {msg, opts} ->
+    changeset
+    |> Ecto.Changeset.traverse_errors(fn {msg, opts} ->
       Enum.reduce(opts, msg, fn {key, value}, acc ->
         String.replace(acc, "%{#{key}}", to_string(value))
       end)
     end)
+    |> Map.new(fn {field, messages} -> {to_string(field), messages} end)
   end
 end

--- a/apps/fountain/lib/fountain/manifest.ex
+++ b/apps/fountain/lib/fountain/manifest.ex
@@ -51,6 +51,8 @@ defmodule Fountain.Manifest do
   alias Fountain.{Agents, Crypto, Environments, Team, Vaults, Webhooks}
   alias Fountain.Team.Schedules
 
+  @unexpected "apply failed unexpectedly; see the server log"
+
   @kinds ~w(Environment Vault Agent Teammate Schedule Webhook)
 
   def kinds, do: @kinds
@@ -148,6 +150,12 @@ defmodule Fountain.Manifest do
   # committed the environments, vaults and agents above it, leaving the caller
   # a 500 and no rows at all. Reported as this document's error instead, and
   # logged, because a crash in a context is still a defect worth a stacktrace.
+  # The row says only that the pass failed. The exception text goes to the log
+  # above and no further: this module promises that secret values are never
+  # echoed back, and the environment and vault passes hold plaintext inside
+  # this rescue, where Elixir's own MatchError, CaseClauseError, BadMapError
+  # and ArgumentError messages embed the value they choked on. A caller who
+  # needs the detail has an operator who can read the log.
   defp guarded(kind, name, fun) do
     fun.()
   rescue
@@ -157,13 +165,12 @@ defmodule Fountain.Manifest do
           Exception.format(:error, error, __STACKTRACE__)
       )
 
-      {result(kind, str(name), :error, %{"base" => [Exception.message(error)]}, []), nil}
+      {result(kind, str(name), :error, %{"base" => [@unexpected]}, []), nil}
   catch
     thrown, reason ->
       Logger.error("apply: #{kind} #{inspect(name)} #{thrown}: #{inspect(reason)}")
 
-      {result(kind, str(name), :error, %{"base" => ["apply failed: #{inspect(reason)}"]}, []),
-       nil}
+      {result(kind, str(name), :error, %{"base" => [@unexpected]}, []), nil}
   end
 
   # Keeps the `via: apply` marker the ApplyController used to attach when it

--- a/apps/fountain/lib/fountain/team.ex
+++ b/apps/fountain/lib/fountain/team.ex
@@ -448,6 +448,88 @@ defmodule Fountain.Team do
     end
   end
 
+  # What a teammate is, in one map: the public attribute name, and the
+  # conversation column it lands on.
+  @bindings [{"name", :title}, {"environment_id", :environment_id}, {"vault_id", :vault_id}]
+
+  @doc """
+  Reconcile the teammate for `agent_id` against `attrs` (#1636).
+
+  `attrs` is string-keyed and takes the same three keys `add_teammate/4`
+  does: `"name"`, `"environment_id"` and `"vault_id"`. A key that is absent
+  leaves that binding alone; a blank value clears it, which for the two ids
+  means the agent's own environment and no vault. Both ids go through the
+  agent's allowlists, as an add does, so a teammate cannot be bound to an
+  environment or vault its agent refuses.
+
+  The three live on the teammate's current conversation, where they already
+  are, so `open_fresh_conversation/3` and `start_fresh/6` build the next
+  computer from them. The machine already running is not rebuilt, and nothing
+  is provisioned here.
+
+  Returns `{:ok, conv}` with the teammate's conversation, unchanged when
+  `attrs` matched it already. `{:error, :not_found}` when the agent is not on
+  the team, `{:error, :environment_not_allowed}` / `{:error,
+  :vault_not_allowed}` when an id is not the caller's own or not on the
+  agent's allowlist. Audited as `team.updated` with the changed field names,
+  and nothing is recorded when nothing changed.
+  """
+  def update_teammate(user_id, agent_id, attrs, opts \\ [])
+      when is_binary(user_id) and is_binary(agent_id) and is_map(attrs) do
+    case get_teammate(user_id, agent_id) do
+      nil ->
+        {:error, :not_found}
+
+      %{agent: agent, conversation: conv} ->
+        changes = binding_changes(attrs, conv)
+
+        with :ok <- bindings_allowed(user_id, agent, changes) do
+          # Ownership: `conv` and `agent` came from the scoped get_teammate.
+          write_bindings(user_id, conv, changes, opts)
+        end
+    end
+  end
+
+  # Only what actually moves: a value the conversation already holds is not a
+  # change, which is what lets a re-apply say it wrote nothing.
+  defp binding_changes(attrs, %Conversation{} = conv) do
+    @bindings
+    |> Enum.filter(fn {key, _field} -> Map.has_key?(attrs, key) end)
+    |> Enum.map(fn {key, field} -> {field, blank_to_nil(attrs[key])} end)
+    |> Enum.reject(fn {field, value} -> Map.get(conv, field) == value end)
+    |> Map.new()
+  end
+
+  defp bindings_allowed(user_id, %Agents.Agent{} = agent, changes) do
+    options = addable_options(user_id, agent)
+
+    with :ok <- binding_allowed(changes, :environment_id, options.environments, :environment) do
+      binding_allowed(changes, :vault_id, options.vaults, :vault)
+    end
+  end
+
+  defp binding_allowed(changes, field, allowed, what) do
+    case Map.get(changes, field) do
+      nil -> :ok
+      id -> if Enum.any?(allowed, &(&1.id == id)), do: :ok, else: {:error, :"#{what}_not_allowed"}
+    end
+  end
+
+  defp write_bindings(_user_id, conv, changes, _opts) when map_size(changes) == 0, do: {:ok, conv}
+
+  defp write_bindings(user_id, conv, changes, opts) do
+    case Conversations.update_conversation(conv, changes) do
+      {:ok, updated} ->
+        fields = for {key, field} <- @bindings, Map.has_key?(changes, field), do: key
+        record(user_id, "team.updated", updated, opts, %{"fields" => fields})
+        broadcast_changed(user_id)
+        {:ok, updated}
+
+      {:error, _} = err ->
+        err
+    end
+  end
+
   @doc """
   Open a fresh conversation for the teammate on its current computer.
 

--- a/apps/fountain/lib/fountain/team.ex
+++ b/apps/fountain/lib/fountain/team.ex
@@ -558,15 +558,21 @@ defmodule Fountain.Team do
   defp bindings_allowed(user_id, %Agents.Agent{} = agent, changes) do
     options = addable_options(user_id, agent)
 
-    with :ok <- binding_allowed(changes, :environment_id, options.environments, :environment) do
-      binding_allowed(changes, :vault_id, options.vaults, :vault)
+    with :ok <-
+           binding_allowed(
+             changes,
+             :environment_id,
+             options.environments,
+             :environment_not_allowed
+           ) do
+      binding_allowed(changes, :vault_id, options.vaults, :vault_not_allowed)
     end
   end
 
-  defp binding_allowed(changes, field, allowed, what) do
+  defp binding_allowed(changes, field, allowed, refusal) do
     case Map.get(changes, field) do
       nil -> :ok
-      id -> if Enum.any?(allowed, &(&1.id == id)), do: :ok, else: {:error, :"#{what}_not_allowed"}
+      id -> if Enum.any?(allowed, &(&1.id == id)), do: :ok, else: {:error, refusal}
     end
   end
 

--- a/apps/fountain/lib/fountain/team.ex
+++ b/apps/fountain/lib/fountain/team.ex
@@ -479,13 +479,21 @@ defmodule Fountain.Team do
   committed one. An ephemeral computer is a conversation's own and is left
   alone.
 
+  A rebinding onto an identity the agent already has a live home for is
+  refused with `{:error, :destination_home_occupied}`, and nothing is written.
+  There is one home per `(user, agent, environment, vault)`, and the wake path
+  builds a home rather than attaching to one, so writing the binding anyway
+  would leave a teammate that cannot wake at all. Merging the teammate onto
+  the machine that is already there is deliberately not done here; it needs
+  the readiness, runtime and quota checks `attach_conversation/3` makes.
+
   Returns `{:ok, conv, :updated}`, or `{:ok, conv, :unchanged}` when `attrs`
   matched the teammate already. `{:error, :not_found}` when the agent is not
   on the team, `{:error, :environment_not_allowed}` / `{:error,
   :vault_not_allowed}` when an id is not the caller's own or not on the
-  agent's allowlist, `{:error, :sandbox_mid_turn}` as above. Audited as
-  `team.updated` with the changed field names, and nothing is recorded when
-  nothing changed.
+  agent's allowlist, `{:error, :sandbox_mid_turn}` and `{:error,
+  :destination_home_occupied}` as above. Audited as `team.updated` with the
+  changed field names, and nothing is recorded when nothing changed.
 
   The second argument is the agent's id, or the teammate map a caller already
   holds from `get_teammate/2` or `list_teammates/1` for the same `user_id` —
@@ -504,10 +512,12 @@ defmodule Fountain.Team do
   def update_teammate(user_id, %{agent: agent, conversation: conv}, attrs, opts)
       when is_binary(user_id) and is_map(attrs) and is_list(opts) do
     changes = binding_changes(attrs, conv)
+    identity = effective_identity(conv, agent, changes)
     # Ownership: `conv` and `agent` came from the scoped get_teammate.
-    orphans = homes_orphaned_by_rebinding(conv, agent, changes)
+    orphans = homes_orphaned_by_rebinding(conv, identity)
 
     with :ok <- bindings_allowed(user_id, agent, changes),
+         :ok <- destination_free(user_id, agent, conv, identity),
          :ok <- no_home_mid_turn(orphans) do
       write_bindings(user_id, conv, changes, orphans, opts)
     end
@@ -523,28 +533,56 @@ defmodule Fountain.Team do
     |> Map.new()
   end
 
-  # The teammate's computer, when the new binding no longer names it. The
-  # identity a home is found under is the *effective* pair, so a cleared
-  # override falls back to the agent's own environment before the comparison.
-  # Nothing moves for a name-only change, and nothing is orphaned by a
-  # rebinding that keeps the same pair.
-  defp homes_orphaned_by_rebinding(
-         %Conversation{sandbox: %Sandbox{} = home} = conv,
-         agent,
-         changes
-       ) do
-    env_id = Map.get(changes, :environment_id, conv.environment_id) || agent.environment_id
-    vault_id = Map.get(changes, :vault_id, conv.vault_id)
+  # The pair a machine for this teammate would be built from once `changes`
+  # land. A cleared override falls back to the agent's own environment, which
+  # is what a sandbox row carries and what `_unsafe_find_home/4` looks up by.
+  defp effective_identity(%Conversation{} = conv, %Agents.Agent{} = agent, changes) do
+    {Map.get(changes, :environment_id, conv.environment_id) || agent.environment_id,
+     Map.get(changes, :vault_id, conv.vault_id)}
+  end
 
+  # The teammate's computer, when the new binding no longer names it. Nothing
+  # moves for a name-only change, and nothing is orphaned by a rebinding that
+  # keeps the same pair.
+  defp homes_orphaned_by_rebinding(%Conversation{sandbox: %Sandbox{} = home}, identity) do
     if home.mode == "persistent" and home.status not in ["terminated", "failed"] and
-         {home.environment_id, home.vault_id} != {env_id, vault_id} do
+         {home.environment_id, home.vault_id} != identity do
       [home]
     else
       []
     end
   end
 
-  defp homes_orphaned_by_rebinding(_conv, _agent, _changes), do: []
+  defp homes_orphaned_by_rebinding(_conv, _identity), do: []
+
+  # One live home per identity, enforced by `sandboxes_home_identity_index`.
+  # If the agent already has a home for the pair this rebinding moves to, the
+  # teammate would be written onto an identity it cannot wake into: the wake
+  # path provisions a *new* home rather than attaching to an existing one, and
+  # the index rejects the insert, so the teammate is stranded and re-applying
+  # the same manifest reports `unchanged` and does not recover it.
+  #
+  # Refused rather than merged. Attaching to the machine that is already there
+  # is the other half of this and needs its own change — readiness, the
+  # runtime the disk was shaped for, and the quota a second tenant of that
+  # machine implies are all checks `attach_conversation/3` makes and this
+  # function does not. Refusing cannot strand anybody; attaching wrongly can.
+  #
+  # Ownership: `agent` and `conv` came from the scoped get_teammate, and a
+  # home carries the same `user_id` as the identity it is keyed on.
+  defp destination_free(user_id, %Agents.Agent{} = agent, %Conversation{} = conv, identity) do
+    {env_id, vault_id} = identity
+
+    if identity == effective_identity(conv, agent, %{}) do
+      :ok
+    else
+      case Conversations._unsafe_find_home(user_id, agent.id, env_id, vault_id) do
+        nil -> :ok
+        %Sandbox{id: id} when id == conv.sandbox_id -> :ok
+        %Sandbox{} -> {:error, :destination_home_occupied}
+      end
+    end
+  end
 
   # Asked before anything is written, so a mid-turn refusal costs the caller
   # nothing. Ownership: the homes came from the scoped get_teammate's

--- a/apps/fountain/lib/fountain/team.ex
+++ b/apps/fountain/lib/fountain/team.ex
@@ -41,7 +41,7 @@ defmodule Fountain.Team do
   require Logger
 
   alias Fountain.{Agents, Audit, Conversations, Repo}
-  alias Fountain.Conversations.{Conversation, ConversationServer, Turn}
+  alias Fountain.Conversations.{Conversation, ConversationServer, Sandbox, Turn}
 
   @channel "fountain:team"
 
@@ -458,35 +458,58 @@ defmodule Fountain.Team do
   `attrs` is string-keyed and takes the same three keys `add_teammate/4`
   does: `"name"`, `"environment_id"` and `"vault_id"`. A key that is absent
   leaves that binding alone; a blank value clears it, which for the two ids
-  means the agent's own environment and no vault. Both ids go through the
-  agent's allowlists, as an add does, so a teammate cannot be bound to an
-  environment or vault its agent refuses.
+  means the agent's own environment and no vault. Bulk apply
+  (`Fountain.Manifest`) always sends all three, so a Teammate document that
+  names no environment clears the override rather than keeping the last one.
+  Both ids go through the agent's allowlists, as an add does, so a teammate
+  cannot be bound to an environment or vault its agent refuses.
 
   The three live on the teammate's current conversation, where they already
   are, so `open_fresh_conversation/3` and `start_fresh/6` build the next
-  computer from them. The machine already running is not rebuilt, and nothing
-  is provisioned here.
+  computer from them.
 
-  Returns `{:ok, conv}` with the teammate's conversation, unchanged when
-  `attrs` matched it already. `{:error, :not_found}` when the agent is not on
-  the team, `{:error, :environment_not_allowed}` / `{:error,
+  A home is keyed on `(user, agent, environment, vault)`, so moving either id
+  moves the teammate's computer out from under it: the next launch looks
+  under the new key, finds nothing and provisions a fresh machine, while the
+  old one stays `ready` holding a concurrency slot and a disk carrying the
+  old environment's secrets (#1084). This is the hazard
+  `Fountain.Agents.update_agent/3` refuses, and it is refused the same way —
+  `{:error, :sandbox_mid_turn}` while a turn is running on that machine, and
+  the orphan retired through `reset_sandbox/2` once the new binding is the
+  committed one. An ephemeral computer is a conversation's own and is left
+  alone.
+
+  Returns `{:ok, conv, :updated}`, or `{:ok, conv, :unchanged}` when `attrs`
+  matched the teammate already. `{:error, :not_found}` when the agent is not
+  on the team, `{:error, :environment_not_allowed}` / `{:error,
   :vault_not_allowed}` when an id is not the caller's own or not on the
-  agent's allowlist. Audited as `team.updated` with the changed field names,
-  and nothing is recorded when nothing changed.
+  agent's allowlist, `{:error, :sandbox_mid_turn}` as above. Audited as
+  `team.updated` with the changed field names, and nothing is recorded when
+  nothing changed.
+
+  The second argument is the agent's id, or the teammate map a caller already
+  holds from `get_teammate/2` or `list_teammates/1` for the same `user_id` —
+  listing the roster is several queries, and bulk apply has just done it.
   """
-  def update_teammate(user_id, agent_id, attrs, opts \\ [])
+  def update_teammate(user_id, agent_or_teammate, attrs, opts \\ [])
+
+  def update_teammate(user_id, agent_id, attrs, opts)
       when is_binary(user_id) and is_binary(agent_id) and is_map(attrs) do
     case get_teammate(user_id, agent_id) do
-      nil ->
-        {:error, :not_found}
+      nil -> {:error, :not_found}
+      teammate -> update_teammate(user_id, teammate, attrs, opts)
+    end
+  end
 
-      %{agent: agent, conversation: conv} ->
-        changes = binding_changes(attrs, conv)
+  def update_teammate(user_id, %{agent: agent, conversation: conv}, attrs, opts)
+      when is_binary(user_id) and is_map(attrs) and is_list(opts) do
+    changes = binding_changes(attrs, conv)
+    # Ownership: `conv` and `agent` came from the scoped get_teammate.
+    orphans = homes_orphaned_by_rebinding(conv, agent, changes)
 
-        with :ok <- bindings_allowed(user_id, agent, changes) do
-          # Ownership: `conv` and `agent` came from the scoped get_teammate.
-          write_bindings(user_id, conv, changes, opts)
-        end
+    with :ok <- bindings_allowed(user_id, agent, changes),
+         :ok <- no_home_mid_turn(orphans) do
+      write_bindings(user_id, conv, changes, orphans, opts)
     end
   end
 
@@ -498,6 +521,38 @@ defmodule Fountain.Team do
     |> Enum.map(fn {key, field} -> {field, blank_to_nil(attrs[key])} end)
     |> Enum.reject(fn {field, value} -> Map.get(conv, field) == value end)
     |> Map.new()
+  end
+
+  # The teammate's computer, when the new binding no longer names it. The
+  # identity a home is found under is the *effective* pair, so a cleared
+  # override falls back to the agent's own environment before the comparison.
+  # Nothing moves for a name-only change, and nothing is orphaned by a
+  # rebinding that keeps the same pair.
+  defp homes_orphaned_by_rebinding(
+         %Conversation{sandbox: %Sandbox{} = home} = conv,
+         agent,
+         changes
+       ) do
+    env_id = Map.get(changes, :environment_id, conv.environment_id) || agent.environment_id
+    vault_id = Map.get(changes, :vault_id, conv.vault_id)
+
+    if home.mode == "persistent" and home.status not in ["terminated", "failed"] and
+         {home.environment_id, home.vault_id} != {env_id, vault_id} do
+      [home]
+    else
+      []
+    end
+  end
+
+  defp homes_orphaned_by_rebinding(_conv, _agent, _changes), do: []
+
+  # Asked before anything is written, so a mid-turn refusal costs the caller
+  # nothing. Ownership: the homes came from the scoped get_teammate's
+  # conversation.
+  defp no_home_mid_turn(homes) do
+    if Conversations._unsafe_any_home_mid_turn?(homes),
+      do: {:error, :sandbox_mid_turn},
+      else: :ok
   end
 
   defp bindings_allowed(user_id, %Agents.Agent{} = agent, changes) do
@@ -515,15 +570,22 @@ defmodule Fountain.Team do
     end
   end
 
-  defp write_bindings(_user_id, conv, changes, _opts) when map_size(changes) == 0, do: {:ok, conv}
+  defp write_bindings(_user_id, conv, changes, _orphans, _opts) when map_size(changes) == 0,
+    do: {:ok, conv, :unchanged}
 
-  defp write_bindings(user_id, conv, changes, opts) do
+  defp write_bindings(user_id, conv, changes, orphans, opts) do
     case Conversations.update_conversation(conv, changes) do
       {:ok, updated} ->
         fields = for {key, field} <- @bindings, Map.has_key?(changes, field), do: key
         record(user_id, "team.updated", updated, opts, %{"fields" => fields})
+
+        # Only once the new binding is the committed one: a machine torn down
+        # against a write that then failed would be rebuilt for nothing.
+        # Ownership: established above, by the scoped get_teammate.
+        _ = Conversations._unsafe_retire_orphaned_homes(orphans, "teammate_rebound", opts)
+
         broadcast_changed(user_id)
-        {:ok, updated}
+        {:ok, updated, :updated}
 
       {:error, _} = err ->
         err

--- a/apps/fountain/lib/fountain/vaults.ex
+++ b/apps/fountain/lib/fountain/vaults.ex
@@ -108,10 +108,15 @@ defmodule Fountain.Vaults do
   @doc "Update a vault. See `create_vault/2` for `opts`."
   def update_vault(%Vault{} = vault, attrs, opts \\ []) do
     changeset = Vault.changeset(vault, attrs)
+    result = Repo.update(changeset)
 
-    changeset
-    |> Repo.update()
-    |> audited("vault.updated", merge_metadata(opts, Audit.changed_fields(changeset)))
+    # See `Fountain.Environments.update_environment/3`: a save that moves
+    # nothing records nothing (#1636).
+    if changeset.changes == %{} do
+      result
+    else
+      audited(result, "vault.updated", merge_metadata(opts, Audit.changed_fields(changeset)))
+    end
   end
 
   @doc """

--- a/apps/fountain/lib/fountain/webhooks.ex
+++ b/apps/fountain/lib/fountain/webhooks.ex
@@ -122,11 +122,15 @@ defmodule Fountain.Webhooks do
 
       case Repo.update(changeset) do
         {:ok, updated} ->
-          audit(
-            updated,
-            "webhook_endpoint.updated",
-            merge_metadata(opts, Audit.changed_fields(changeset))
-          )
+          # A save that moves nothing records nothing, the same rule
+          # `Fountain.Environments.update_environment/3` follows (#1636).
+          if changeset.changes != %{} do
+            audit(
+              updated,
+              "webhook_endpoint.updated",
+              merge_metadata(opts, Audit.changed_fields(changeset))
+            )
+          end
 
           {:ok, updated}
 

--- a/apps/fountain/lib/fountain_web/controllers/apply_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/apply_controller.ex
@@ -54,7 +54,8 @@ defmodule FountainWeb.ApplyController do
     if conn.halted do
       conn
     else
-      with {:ok, results} <- Manifest.apply_manifest(user.id, resources, Audited.attribution(conn)) do
+      with {:ok, results} <-
+             Manifest.apply_manifest(user.id, resources, Audited.attribution(conn)) do
         render(conn, :create, results: results)
       end
     end

--- a/apps/fountain/lib/fountain_web/controllers/apply_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/apply_controller.ex
@@ -18,11 +18,16 @@ defmodule FountainWeb.ApplyController do
     summary: "Apply a compiled manifest (bulk upsert)",
     description:
       "Applies all resources from a compiled fountain.yml manifest in one request. " <>
-        "Resources are reconciled by name — environments first, then vaults, then " <>
-        "agents — so agent specs may reference an environment by name via " <>
-        "`spec.environment`. Application is best-effort per resource: the response " <>
-        "is 200 even when individual resources fail, with per-resource errors in " <>
-        "the result entries.",
+        "Resources are reconciled in a fixed order — environments, vaults, agents, " <>
+        "teammates, schedules, webhooks — so a spec may name another document " <>
+        "whatever the file's order: an agent's `environment`, a teammate's " <>
+        "`agent`, `environment` and `vault`, and a schedule's `teammate`. Every " <>
+        "kind is keyed by the document's `name`, except `Webhook`, which is keyed " <>
+        "by `spec.url`. A `Webhook` created here returns its signing secret once, " <>
+        "on that result row. Apply is additive: a document dropped from the " <>
+        "manifest leaves its record in place. Application is best-effort per " <>
+        "resource: the response is 200 even when individual resources fail, with " <>
+        "per-resource errors in the result entries.",
     request_body: {"Compiled manifest", "application/json", Schemas.ApplyRequest},
     responses: [
       ok: {"Per-resource results", "application/json", Schemas.ApplyResponse},

--- a/apps/fountain/lib/fountain_web/controllers/apply_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/apply_controller.ex
@@ -43,8 +43,20 @@ defmodule FountainWeb.ApplyController do
   def create(conn, %{"resources" => resources}) do
     user = conn.assigns.current_user
 
-    with {:ok, results} <- Manifest.apply_manifest(user.id, resources, Audited.attribution(conn)) do
-      render(conn, :create, results: results)
+    # Check the whole manifest before any resource writes, as on /api/webhooks.
+    conn =
+      if Enum.any?(resources, &match?(%{"kind" => "Webhook"}, &1)) do
+        FountainWeb.Plugs.RequireFullScope.call(conn, [])
+      else
+        conn
+      end
+
+    if conn.halted do
+      conn
+    else
+      with {:ok, results} <- Manifest.apply_manifest(user.id, resources, Audited.attribution(conn)) do
+        render(conn, :create, results: results)
+      end
     end
   end
 end

--- a/apps/fountain/lib/fountain_web/controllers/apply_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/apply_controller.ex
@@ -24,10 +24,15 @@ defmodule FountainWeb.ApplyController do
         "`agent`, `environment` and `vault`, and a schedule's `teammate`. Every " <>
         "kind is keyed by the document's `name`, except `Webhook`, which is keyed " <>
         "by `spec.url`. A `Webhook` created here returns its signing secret once, " <>
-        "on that result row. Apply is additive: a document dropped from the " <>
+        "on that result row. A `Teammate` is read as a whole declaration, so an " <>
+        "absent `environment` or `vault` clears that binding, and moving either " <>
+        "retires the computer the old binding named (refused with an error on " <>
+        "that row while a turn is running on it). Two Teammate documents may not " <>
+        "name the same agent. Apply is additive: a document dropped from the " <>
         "manifest leaves its record in place. Application is best-effort per " <>
-        "resource: the response is 200 even when individual resources fail, with " <>
-        "per-resource errors in the result entries.",
+        "resource: the response is 200 even when an individual resource fails " <>
+        "validation, is refused by its context or raises, with per-resource " <>
+        "errors in the result entries.",
     request_body: {"Compiled manifest", "application/json", Schemas.ApplyRequest},
     responses: [
       ok: {"Per-resource results", "application/json", Schemas.ApplyResponse},

--- a/apps/fountain/lib/fountain_web/controllers/apply_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/apply_json.ex
@@ -11,7 +11,8 @@ defmodule FountainWeb.ApplyJSON do
       name: result.name,
       action: result.action,
       errors: result.errors,
-      secrets: Enum.map(result.secrets, &Map.take(&1, [:key, :action, :errors]))
+      secrets: Enum.map(result.secrets, &Map.take(&1, [:key, :action, :errors])),
+      secret: result.secret
     }
   end
 end

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -3146,8 +3146,9 @@ defmodule FountainWeb.Schemas do
           enum: ["created", "updated", "unchanged", "error"],
           description:
             "`unchanged` means the record already matched the document, so nothing " <>
-              "was written to it. Inline `spec.secrets` are re-encrypted on every " <>
-              "apply and still report `upserted` under `secrets`."
+              "was written to it and no audit event was recorded. Inline " <>
+              "`spec.secrets` are re-encrypted on every apply and still report " <>
+              "`upserted` under `secrets`."
         },
         errors: %Schema{type: :object, additionalProperties: true, nullable: true},
         secrets: %Schema{type: :array, items: ApplySecretResult},

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -3079,11 +3079,20 @@ defmodule FountainWeb.Schemas do
       description:
         "One compiled document from a fountain.yml manifest. `spec` matches the " <>
           "create/update schema for the kind, plus an inline `secrets` map " <>
-          "(Environment and Vault). Agent specs may reference an environment by " <>
-          "name via `environment`; the server resolves it to `environment_id`.",
+          "(Environment and Vault). Specs reference other documents by name, and " <>
+          "the server resolves each to an id: an Agent's `environment`, a " <>
+          "Teammate's `agent`, `environment` and `vault`, and a Schedule's " <>
+          "`teammate`. Teammate specs take `agent`, `environment` and `vault`; " <>
+          "Schedule specs take `teammate` plus the TeamScheduleCreateRequest " <>
+          "fields `cron`, `prompt`, `one_off` and `enabled`; Webhook specs take " <>
+          "the WebhookEndpointCreateRequest fields `url`, `description` and " <>
+          "`event_types`, and are keyed by `url` rather than by `name`.",
       type: :object,
       properties: %{
-        kind: %Schema{type: :string, enum: ["Environment", "Vault", "Agent"]},
+        kind: %Schema{
+          type: :string,
+          enum: ["Environment", "Vault", "Agent", "Teammate", "Schedule", "Webhook"]
+        },
         name: %Schema{type: :string, minLength: 1, maxLength: 200},
         spec: %Schema{type: :object, additionalProperties: true}
       },
@@ -3132,9 +3141,25 @@ defmodule FountainWeb.Schemas do
       properties: %{
         kind: %Schema{type: :string},
         name: %Schema{type: :string},
-        action: %Schema{type: :string, enum: ["created", "updated", "error"]},
+        action: %Schema{
+          type: :string,
+          enum: ["created", "updated", "unchanged", "error"],
+          description:
+            "`unchanged` means the record already matched the document, so nothing " <>
+              "was written to it. Inline `spec.secrets` are re-encrypted on every " <>
+              "apply and still report `upserted` under `secrets`."
+        },
         errors: %Schema{type: :object, additionalProperties: true, nullable: true},
-        secrets: %Schema{type: :array, items: ApplySecretResult}
+        secrets: %Schema{type: :array, items: ApplySecretResult},
+        secret: %Schema{
+          type: :string,
+          nullable: true,
+          description:
+            "A Webhook endpoint's HMAC-SHA256 signing secret, on the apply that " <>
+              "created it. Store it; it is not shown again, and an update never " <>
+              "returns it. Null on every other row.",
+          example: "whsec_Zm91bnRhaW4tZXhhbXBsZS1zZWNyZXQtdmFsdWU"
+        }
       },
       required: [:kind, :name, :action]
     })

--- a/apps/fountain/priv/help/manifest.md
+++ b/apps/fountain/priv/help/manifest.md
@@ -23,7 +23,13 @@ The `metadata.name` is the upsert key for five of the six kinds. If a resource w
 
 ## The team kinds
 
-A `Teammate` puts an agent on the team, which opens its conversation and provisions its computer. Re-applying moves what the teammate is called and which environment and vault the *next* computer is built from — it never provisions a second one, and it never resurrects a computer that is gone (message the teammate for that). A `Schedule` is a cron that runs a teammate with a prompt, keyed by its name under its teammate. A `Webhook` is an endpoint Fountain POSTs conversation lifecycle events to; the apply that creates one prints its signing secret **once**, and no later apply ever prints it again.
+A `Teammate` puts an agent on the team, which opens its conversation and provisions its computer. Re-applying moves what the teammate is called and which environment and vault it is bound to — it never provisions a second one, and it never resurrects a computer that is gone (message the teammate for that). A `Schedule` is a cron that runs a teammate with a prompt, keyed by its name under its teammate. A `Webhook` is an endpoint Fountain POSTs conversation lifecycle events to; the apply that creates one prints its signing secret **once**, and no later apply ever prints it again.
+
+Three things about these that surprise people:
+
+- **A `Teammate` doc is the whole teammate.** Unlike the other five kinds, where an absent `spec` key leaves that column alone, dropping `environment` or `vault` from a Teammate doc *clears* that binding — back to the agent's own environment and no vault. That is what makes the doc a declaration rather than a patch.
+- **Rebinding moves the computer.** A home is keyed on `(user, agent, environment, vault)`, so changing either id retires the machine the old key named; the teammate's next message builds a fresh one. Refused with an error on that row while a turn is still running there — the same refusal `Agent`'s `environment` gives (#1084).
+- **Two Teammate docs can't name the same agent**, and a `Webhook` whose `spec.url` changes creates a *second* endpoint (nothing is pruned; delete the old one with `fountain webhooks delete`).
 
 ```yaml
 ---
@@ -61,6 +67,10 @@ spec:
 ## Nothing is pruned
 
 Apply is additive. Deleting a doc from the manifest leaves its record in place; delete it through its own command or the console.
+
+## What the trail says
+
+Each applied row leaves its context's own audit event, with the actor and IP of the request that applied it: `team.member.added` / `team.updated` for a Teammate, `team.schedule.created` / `team.schedule.updated` for a Schedule, and `webhook_endpoint.created` / `webhook_endpoint.updated` for a Webhook — the `webhook_endpoint` prefix the webhook routes have always written, not a shorter `webhook` one. An `unchanged` row writes nothing at all.
 
 ## Example
 

--- a/apps/fountain/priv/help/manifest.md
+++ b/apps/fountain/priv/help/manifest.md
@@ -8,18 +8,59 @@ A `fountain.yml` is a multi-document YAML file. Each doc is one resource with th
 
 ```yaml
 apiVersion: fountain/v1
-kind: Environment | Vault | Agent
+kind: Environment | Vault | Agent | Teammate | Schedule | Webhook
 metadata:
   name: <unique-on-operator-side>
 spec:
   # ... fields matching the API schema for the kind ...
 ```
 
-The `metadata.name` is the upsert key. If a resource with that name exists, it's updated; if not, it's created.
+The `metadata.name` is the upsert key for five of the six kinds. If a resource with that name exists, it's updated; if not, it's created. A `Webhook` is keyed by its `spec.url` instead, so its `metadata.name` is a label that shows up in the apply output.
 
 ## Order is irrelevant inside the file
 
-`fountain apply` reconciles **environments first, vaults second, agents last** — so an agent doc can reference an environment by name (`spec.environment: my-env`) even if that environment is defined later in the file. The reference also resolves against environments that **already exist** server-side, so a manifest can attach an agent to an environment managed elsewhere; a name that matches neither the manifest nor an existing environment fails that agent doc. Vaults aren't referenced from agents (they're picked per-conversation), so the order between envs and vaults doesn't matter functionally; the predictable ordering just makes the apply output easier to skim.
+`fountain apply` reconciles in a fixed order: **environments, vaults, agents, teammates, schedules, webhooks** — so a doc can reference another by name even if that one is defined later in the file. An `Agent` references an `environment`; a `Teammate` references an `agent`, an `environment` and a `vault`; a `Schedule` references a `teammate`. Every reference resolves against the manifest first and then against what **already exists** server-side, so a manifest can attach an agent to an environment managed elsewhere; a name that matches neither fails that doc and no other.
+
+## The team kinds
+
+A `Teammate` puts an agent on the team, which opens its conversation and provisions its computer. Re-applying moves what the teammate is called and which environment and vault the *next* computer is built from — it never provisions a second one, and it never resurrects a computer that is gone (message the teammate for that). A `Schedule` is a cron that runs a teammate with a prompt, keyed by its name under its teammate. A `Webhook` is an endpoint Fountain POSTs conversation lifecycle events to; the apply that creates one prints its signing secret **once**, and no later apply ever prints it again.
+
+```yaml
+---
+apiVersion: fountain/v1
+kind: Teammate
+metadata:
+  name: Ada
+spec:
+  agent: researcher
+  environment: my-project
+  vault: alice
+
+---
+apiVersion: fountain/v1
+kind: Schedule
+metadata:
+  name: standup
+spec:
+  teammate: Ada
+  cron: "0 9 * * 1-5"          # five fields, UTC
+  prompt: What is on today?
+  one_off: false
+  enabled: true
+
+---
+apiVersion: fountain/v1
+kind: Webhook
+metadata:
+  name: ci
+spec:
+  url: https://ci.example.com/hooks/fountain
+  event_types: [conversation.turn.done]
+```
+
+## Nothing is pruned
+
+Apply is additive. Deleting a doc from the manifest leaves its record in place; delete it through its own command or the console.
 
 ## Example
 
@@ -71,14 +112,19 @@ fountain apply -f ./fountain-specs/     # directory: walks **/*.{yml,yaml}
 
 Directory mode walks recursively. Any YAML document carrying both `apiVersion` and `kind` is treated as a resource; anything else (a doc without front-matter, an unrelated `.yaml` config) is silently ignored. So `fountain-specs/agents/*.yml`, `fountain-specs/environments/*.yml`, plus an unrelated `.github/workflows/ci.yml` in the same tree all coexist cleanly. Files are processed in alphabetical order; if you want strict ordering for any reason, prefix names like `10-envs.yml` / `20-agents.yml` (though reconciliation order is fixed internally — envs first, then vaults, then agents — regardless).
 
-Output uses `+` for create, `~` for update, one line per resource:
+Output uses `+` for create, `~` for update, `=` for a resource that already matched, one line per resource:
 
 ```
-env    +  my-project
+env  +  my-project
 vault  +  alice
   secret  ~  alice/GITHUB_TOKEN
   secret  ~  alice/NPM_TOKEN
 agent  ~  researcher
+teammate  =  Ada
+schedule  +  standup
+webhook  +  ci
+  signing secret  ci  whsec_...
+  save it now, it is not shown again
 ```
 
 Errors per-resource go to stderr but don't stop the run; other resources still apply.
@@ -87,7 +133,7 @@ Under the hood the CLI compiles the whole manifest into one document and sends i
 
 ## Idempotency
 
-Re-applying the same file is a no-op (every resource shows `~` because existing resources are always re-written, but the spec doesn't change). Useful for CI: keep `fountain.yml` in source control, run `fountain apply -f fountain.yml` from your deploy pipeline.
+Re-applying the same file is a no-op, and says so: every resource shows `=` (`unchanged`) because nothing was written to it. Inline `spec.secrets` are the exception — they are re-encrypted on every apply, so they keep showing `~` under a resource that shows `=`. Useful for CI: keep `fountain.yml` in source control, run `fountain apply -f fountain.yml` from your deploy pipeline.
 
 ## Apply-time secret resolution (so you can commit `fountain.yml`)
 

--- a/apps/fountain/priv/help/manifest.md
+++ b/apps/fountain/priv/help/manifest.md
@@ -28,7 +28,7 @@ A `Teammate` puts an agent on the team, which opens its conversation and provisi
 Three things about these that surprise people:
 
 - **A `Teammate` doc is the whole teammate.** Unlike the other five kinds, where an absent `spec` key leaves that column alone, dropping `environment` or `vault` from a Teammate doc *clears* that binding — back to the agent's own environment and no vault. That is what makes the doc a declaration rather than a patch.
-- **Rebinding moves the computer.** A home is keyed on `(user, agent, environment, vault)`, so changing either id retires the machine the old key named; the teammate's next message builds a fresh one. Refused with an error on that row while a turn is still running there — the same refusal `Agent`'s `environment` gives (#1084).
+- **Rebinding moves the computer.** A home is keyed on `(user, agent, environment, vault)`, so changing either id retires the machine the old key named; the teammate's next message builds a fresh one. Refused with an error on that row while a turn is still running there — the same refusal `Agent`'s `environment` gives (#1084). A conversation that *shared* that machine and names a different environment or vault does not follow the teammate; it builds its own on its next prompt. And because there is only ever one home per identity, a rebind onto an identity the agent **already** has a home for is **refused**, not merged onto that home — reset or remove the existing one first (#1636).
 - **Two Teammate docs can't name the same agent**, and a `Webhook` whose `spec.url` changes creates a *second* endpoint (nothing is pruned; delete the old one with `fountain webhooks delete`).
 
 ```yaml

--- a/apps/fountain/test/fountain/audit_guardrail_test.exs
+++ b/apps/fountain/test/fountain/audit_guardrail_test.exs
@@ -449,7 +449,8 @@ defmodule Fountain.AuditGuardrailTest do
       channel_id: Fountain.Team.channel()
     )
 
-    {:ok, _} = Fountain.Team.update_teammate(user.id, agent.id, %{"vault_id" => vault.id})
+    {:ok, _, :updated} =
+      Fountain.Team.update_teammate(user.id, agent.id, %{"vault_id" => vault.id})
   end
 
   def do_team_rotate(user) do

--- a/apps/fountain/test/fountain/audit_guardrail_test.exs
+++ b/apps/fountain/test/fountain/audit_guardrail_test.exs
@@ -83,6 +83,7 @@ defmodule Fountain.AuditGuardrailTest do
     {"team member add", &__MODULE__.do_team_add/1, "team.member.added"},
     {"team member remove", &__MODULE__.do_team_remove/1, "team.member.removed"},
     {"team member rename", &__MODULE__.do_team_rename/1, "team.renamed"},
+    {"team member rebind", &__MODULE__.do_team_update/1, "team.updated"},
     {"team conversation rotate", &__MODULE__.do_team_rotate/1, "team.conversation.rotated"},
     # Team schedules: a cron that runs a teammate with a prompt. A run leaves
     # conversation events underneath; `.fired` is the schedule-side record.
@@ -435,6 +436,20 @@ defmodule Fountain.AuditGuardrailTest do
     )
 
     {:ok, _} = Fountain.Team.rename_teammate(user.id, agent.id, "Renamed")
+  end
+
+  def do_team_update(user) do
+    agent = insert_agent(user_id: user.id)
+    vault = insert_vault(user_id: user.id)
+
+    insert_conversation(
+      user_id: user.id,
+      agent: agent,
+      status: "idle",
+      channel_id: Fountain.Team.channel()
+    )
+
+    {:ok, _} = Fountain.Team.update_teammate(user.id, agent.id, %{"vault_id" => vault.id})
   end
 
   def do_team_rotate(user) do

--- a/apps/fountain/test/fountain/conversations/sandbox_reset_test.exs
+++ b/apps/fountain/test/fountain/conversations/sandbox_reset_test.exs
@@ -141,6 +141,64 @@ defmodule Fountain.Conversations.SandboxResetTest do
     assert Conversations._unsafe_get_conversation!(ctx.b.id).sandbox_id == woken.sandbox_id
   end
 
+  # #1636: co-tenants normally share one identity, because attaching to a
+  # machine requires the same agent, environment and vault. Rebinding a
+  # teammate moves one conversation's environment while its co-tenants keep
+  # theirs, and the replacement a wake builds carries only the waking
+  # conversation's pair. Handing it to the other one would run it on another
+  # binding's environment files and vault material, and would make the machine
+  # depend on which conversation happened to wake first.
+  describe "a co-tenant that declares a different identity" do
+    setup ctx do
+      other_env = insert_env(user_id: ctx.user.id)
+      {:ok, b} = Conversations.update_conversation(ctx.b, %{environment_id: other_env.id})
+      stub(Managoat.Sandbox.Sprites, :destroy, fn _h -> :ok end)
+      {:ok, _} = Conversations.reset_sandbox(ctx.home)
+      Map.merge(ctx, %{other_env: other_env, b: b})
+    end
+
+    test "waking the one that kept the identity leaves the rebound one behind", ctx do
+      assert {:ok, woken_a} = Conversations.wake_conversation(ctx.a.id)
+      refute woken_a.sandbox_id == ctx.home.id
+      assert Conversations._unsafe_get_sandbox!(woken_a.sandbox_id).environment_id == ctx.env.id
+
+      # It did not follow: it names something else, so it keeps the retired
+      # row until its own wake.
+      assert Conversations._unsafe_get_conversation!(ctx.b.id).sandbox_id == ctx.home.id
+
+      assert {:ok, woken_b} = Conversations.wake_conversation(ctx.b.id)
+      refute woken_b.sandbox_id == woken_a.sandbox_id
+
+      assert Conversations._unsafe_get_sandbox!(woken_b.sandbox_id).environment_id ==
+               ctx.other_env.id
+    end
+
+    test "waking the rebound one first does not pull the other onto its machine", ctx do
+      assert {:ok, woken_b} = Conversations.wake_conversation(ctx.b.id)
+
+      assert Conversations._unsafe_get_sandbox!(woken_b.sandbox_id).environment_id ==
+               ctx.other_env.id
+
+      assert Conversations._unsafe_get_conversation!(ctx.a.id).sandbox_id == ctx.home.id
+
+      assert {:ok, woken_a} = Conversations.wake_conversation(ctx.a.id)
+      refute woken_a.sandbox_id == woken_b.sandbox_id
+      assert Conversations._unsafe_get_sandbox!(woken_a.sandbox_id).environment_id == ctx.env.id
+    end
+
+    test "the one left behind is told its machine is gone", ctx do
+      assert {:ok, _} = Conversations.wake_conversation(ctx.a.id)
+
+      messages =
+        ctx.b.id
+        |> Conversations._unsafe_list_log_events(0)
+        |> Enum.filter(&(&1.kind == "stage" and &1.stage == "sandbox"))
+        |> Enum.map(&Jason.decode!(&1.data)["message"])
+
+      assert Enum.any?(messages, &(&1 =~ "different environment"))
+    end
+  end
+
   test "records sandbox.reset with the actor", ctx do
     stub(Managoat.Sandbox.Sprites, :destroy, fn _h -> :ok end)
     {:ok, _} = Conversations.reset_sandbox(ctx.home, actor: "api", request_ip: "10.0.0.1")

--- a/apps/fountain/test/fountain/manifest_test.exs
+++ b/apps/fountain/test/fountain/manifest_test.exs
@@ -559,7 +559,13 @@ defmodule Fountain.ManifestTest do
                %{kind: "Webhook", action: :created}
              ] = results
 
-      assert errors == %{"base" => ["the sandbox provider fell over"]}
+      # The row says the pass failed and nothing more. The raised text stays in
+      # the log: the environment and vault passes hold plaintext secrets inside
+      # the same rescue, and an Elixir exception message embeds the value it
+      # choked on.
+      assert errors == %{"base" => ["apply failed unexpectedly; see the server log"]}
+      refute inspect(errors) =~ "sandbox provider fell over"
+
       # The documents on either side of it were still applied.
       assert Environments.get_environment_by_name("proj", user.id)
       assert [_endpoint] = Webhooks.list_endpoints(user.id)

--- a/apps/fountain/test/fountain/manifest_test.exs
+++ b/apps/fountain/test/fountain/manifest_test.exs
@@ -2,7 +2,18 @@ defmodule Fountain.ManifestTest do
   use Fountain.DataCase, async: true
   use Mimic
 
-  alias Fountain.{Agents, Audit, Crypto, Environments, Manifest, Team, Vaults, Webhooks}
+  alias Fountain.{
+    Agents,
+    Audit,
+    Conversations,
+    Crypto,
+    Environments,
+    Manifest,
+    Team,
+    Vaults,
+    Webhooks
+  }
+
   alias Fountain.Team.Schedules
 
   setup do
@@ -247,7 +258,7 @@ defmodule Fountain.ManifestTest do
         ])
 
       assert [
-               %{name: "broken", action: :error, errors: %{model: _}},
+               %{name: "broken", action: :error, errors: %{"model" => _}},
                %{name: "ok-agent", action: :created}
              ] = results
     end
@@ -314,7 +325,7 @@ defmodule Fountain.ManifestTest do
   describe "apply_manifest/2 the whole estate" do
     @hook_url "https://hooks.example.com/fountain"
 
-    defp estate_manifest do
+    defp estate_manifest(vault_spec \\ %{"secrets" => %{"GH" => "ghp_x"}}) do
       # Deliberately out of order: the six kinds reconcile in a fixed order,
       # whatever the file says.
       [
@@ -333,10 +344,13 @@ defmodule Fountain.ManifestTest do
           "vault" => "alice"
         }),
         agent_resource("ada", %{"environment" => "proj"}),
-        vault_resource("alice", %{"secrets" => %{"GH" => "ghp_x"}}),
+        vault_resource("alice", vault_spec),
         env_resource("proj", %{"setup_script" => "echo hi"})
       ]
     end
+
+    defp actions_for(user),
+      do: user.id |> Audit.list_recent_for_user(500) |> Enum.map(& &1.action)
 
     test "all six kinds apply in one request, and a second apply changes nothing",
          %{user: user} do
@@ -402,6 +416,214 @@ defmodule Fountain.ManifestTest do
       end
     end
 
+    # CLAUDE.md: "Only record what happened. ... a no-op sync records nothing."
+    # An apply that writes nothing must leave the trail exactly as it found it,
+    # or every CI run adds six rows saying a record nobody touched was updated.
+    test "an identical re-apply writes no audit rows at all", %{user: user} do
+      inert_start_child()
+      resources = estate_manifest(%{})
+
+      {:ok, first} = Manifest.apply_manifest(user.id, resources)
+      assert Enum.all?(first, &(&1.action == :created))
+      before = actions_for(user)
+
+      {:ok, second} = Manifest.apply_manifest(user.id, resources)
+      assert Enum.all?(second, &(&1.action == :unchanged))
+      assert actions_for(user) == before
+    end
+
+    # The one thing a no-op apply does write: an inline secret is encrypted
+    # again every time, because the stored ciphertext cannot be compared with
+    # the plaintext given.
+    test "a re-apply with inline secrets writes only the secret events", %{user: user} do
+      inert_start_child()
+      resources = estate_manifest()
+
+      {:ok, _} = Manifest.apply_manifest(user.id, resources)
+      before = actions_for(user)
+
+      {:ok, second} = Manifest.apply_manifest(user.id, resources)
+      assert Enum.all?(second, &(&1.action == :unchanged))
+
+      added = actions_for(user) -- before
+      assert added == ["vault.secret.write"]
+    end
+
+    test "the update path is audited with the request's attribution", %{user: user} do
+      inert_start_child()
+      opts = [actor: "api", request_ip: "203.0.113.5"]
+      {:ok, _} = Manifest.apply_manifest(user.id, estate_manifest(%{}), opts)
+      before = user.id |> Audit.list_recent_for_user(500) |> length()
+
+      moved = [
+        env_resource("proj", %{"setup_script" => "echo hi"}),
+        vault_resource("alice"),
+        agent_resource("ada", %{"environment" => "proj"}),
+        teammate_resource("Ada of proj", %{"agent" => "ada", "environment" => "proj"}),
+        schedule_resource("standup", %{
+          "teammate" => "Ada of proj",
+          "cron" => "@daily",
+          "prompt" => "What is on today?"
+        }),
+        webhook_resource("ci", %{"url" => @hook_url, "description" => "CI"})
+      ]
+
+      {:ok, results} = Manifest.apply_manifest(user.id, moved, opts)
+
+      assert Enum.map(results, &{&1.kind, &1.action}) == [
+               {"Environment", :unchanged},
+               {"Vault", :unchanged},
+               {"Agent", :unchanged},
+               {"Teammate", :updated},
+               {"Schedule", :updated},
+               {"Webhook", :updated}
+             ]
+
+      events = Audit.list_recent_for_user(user.id, 500)
+      added = Enum.take(events, length(events) - before)
+
+      for action <- ~w(team.updated team.schedule.updated webhook_endpoint.updated) do
+        event = Enum.find(added, &(&1.action == action))
+
+        assert event,
+               "the update path left no #{action}; saw #{inspect(Enum.map(added, & &1.action))}"
+
+        assert event.actor == "api"
+        assert to_string(event.request_ip) == "203.0.113.5"
+      end
+    end
+
+    test "a second Teammate naming the same agent fails instead of renaming the first",
+         %{user: user} do
+      inert_start_child()
+
+      {:ok, results} =
+        Manifest.apply_manifest(user.id, [
+          agent_resource("ada"),
+          teammate_resource("Ada", %{"agent" => "ada"}),
+          teammate_resource("Ada again", %{"agent" => "ada"}),
+          teammate_resource("Ada", %{"agent" => "ada"})
+        ])
+
+      assert [
+               %{kind: "Agent", action: :created},
+               %{name: "Ada", action: :created},
+               %{name: "Ada again", action: :error, errors: dup_agent},
+               %{name: "Ada", action: :error, errors: dup_name}
+             ] = results
+
+      assert dup_agent == %{"agent" => ["is already claimed by another Teammate document"]}
+      assert dup_name == %{"name" => ["is already used by another Teammate document"]}
+      assert [%{name: "Ada"}] = Team.list_teammates(user.id)
+    end
+
+    # Without the claim check the second document renamed the first's
+    # conversation on every pass, so no apply was ever `unchanged`.
+    test "a manifest with a duplicate Teammate is still idempotent for the rest",
+         %{user: user} do
+      inert_start_child()
+
+      resources = [
+        agent_resource("ada"),
+        teammate_resource("Ada", %{"agent" => "ada"}),
+        teammate_resource("Ada again", %{"agent" => "ada"})
+      ]
+
+      {:ok, _} = Manifest.apply_manifest(user.id, resources)
+      {:ok, second} = Manifest.apply_manifest(user.id, resources)
+
+      assert Enum.map(second, & &1.action) == [:unchanged, :unchanged, :error]
+      assert [%{name: "Ada"}] = Team.list_teammates(user.id)
+    end
+
+    # The Teammate pass reaches Horde, the quota lock, the credit gate and the
+    # sandbox provider. A raise there used to abandon the whole call after the
+    # environments, vaults and agents had already been committed.
+    test "an exception in one document fails that row and not the request", %{user: user} do
+      stub(Fountain.Conversations, :start_or_resume_conversation, fn _attrs, _opts ->
+        raise "the sandbox provider fell over"
+      end)
+
+      {:ok, results} =
+        Manifest.apply_manifest(user.id, [
+          env_resource("proj"),
+          agent_resource("ada"),
+          teammate_resource("Ada", %{"agent" => "ada"}),
+          webhook_resource("ci", %{"url" => @hook_url})
+        ])
+
+      assert [
+               %{kind: "Environment", action: :created},
+               %{kind: "Agent", action: :created},
+               %{kind: "Teammate", action: :error, errors: errors},
+               %{kind: "Webhook", action: :created}
+             ] = results
+
+      assert errors == %{"base" => ["the sandbox provider fell over"]}
+      # The documents on either side of it were still applied.
+      assert Environments.get_environment_by_name("proj", user.id)
+      assert [_endpoint] = Webhooks.list_endpoints(user.id)
+    end
+
+    test "a Schedule naming a teammate two of them answer to fails that row", %{user: user} do
+      inert_start_child()
+      one = insert_agent(user_id: user.id, name: "one")
+      two = insert_agent(user_id: user.id, name: "two")
+      {:ok, _} = Team.add_teammate(user.id, one.id, %{"name" => "Ada"})
+      {:ok, _} = Team.add_teammate(user.id, two.id, %{"name" => "Ada"})
+
+      {:ok, [%{kind: "Schedule", action: :error, errors: errors}]} =
+        Manifest.apply_manifest(user.id, [
+          schedule_resource("s", %{"teammate" => "Ada", "cron" => "@daily", "prompt" => "x"})
+        ])
+
+      assert errors == %{"teammate" => ["teammate name is not unique: Ada"]}
+    end
+
+    test "a Teammate mid-turn on the computer it would rebind fails that row", %{user: user} do
+      env = insert_env(user_id: user.id, name: "proj")
+      other = insert_env(user_id: user.id, name: "other")
+
+      agent =
+        insert_agent(
+          user_id: user.id,
+          name: "ada",
+          environment_id: other.id,
+          sandbox_mode: "persistent"
+        )
+
+      home =
+        insert_sandbox(
+          user_id: user.id,
+          status: "ready",
+          mode: "persistent",
+          agent_id: agent.id,
+          environment_id: other.id,
+          provider: "sprites"
+        )
+
+      conv =
+        insert_conversation(
+          user_id: user.id,
+          agent: agent,
+          sandbox: home,
+          status: "running",
+          channel_id: Team.channel()
+        )
+
+      insert_turn(conv, status: "running")
+
+      {:ok, [%{kind: "Teammate", action: :error, errors: errors}]} =
+        Manifest.apply_manifest(user.id, [
+          teammate_resource("Ada", %{"agent" => "ada", "environment" => "proj"})
+        ])
+
+      assert %{"base" => [message]} = errors
+      assert message =~ "running a turn"
+      assert Conversations.get_conversation(conv.id, user.id).environment_id == nil
+      assert env.id
+    end
+
     test "re-applying a Teammate moves its name, environment and vault", %{user: user} do
       inert_start_child()
 
@@ -431,6 +653,56 @@ defmodule Fountain.ManifestTest do
       assert [%{name: "Ada of proj", conversation: conv}] = Team.list_teammates(user.id)
       assert conv.environment_id == Environments.get_environment_by_name("proj", user.id).id
       assert conv.vault_id == Vaults.get_vault_by_name("alice", user.id).id
+    end
+
+    # A Teammate document is the whole teammate, unlike the other five kinds,
+    # where an absent spec key leaves the column alone. Dropping `environment`
+    # therefore puts the teammate back on the agent's own environment.
+    test "dropping a Teammate's environment and vault clears the bindings", %{user: user} do
+      inert_start_child()
+
+      bound = [
+        env_resource("proj"),
+        vault_resource("alice"),
+        agent_resource("ada"),
+        teammate_resource("Ada", %{
+          "agent" => "ada",
+          "environment" => "proj",
+          "vault" => "alice"
+        })
+      ]
+
+      {:ok, _} = Manifest.apply_manifest(user.id, bound)
+      assert [%{conversation: conv}] = Team.list_teammates(user.id)
+      assert conv.environment_id
+      assert conv.vault_id
+
+      unbound = List.replace_at(bound, 3, teammate_resource("Ada", %{"agent" => "ada"}))
+      {:ok, results} = Manifest.apply_manifest(user.id, unbound)
+
+      assert %{kind: "Teammate", action: :updated} = List.last(results)
+      assert [%{conversation: cleared}] = Team.list_teammates(user.id)
+      assert cleared.environment_id == nil
+      assert cleared.vault_id == nil
+
+      # And it settles: a third apply of the same file writes nothing.
+      {:ok, again} = Manifest.apply_manifest(user.id, unbound)
+      assert Enum.all?(again, &(&1.action == :unchanged))
+    end
+
+    test "changing a Webhook's url leaves the old endpoint and adds a new one", %{user: user} do
+      {:ok, [%{action: :created}]} =
+        Manifest.apply_manifest(user.id, [webhook_resource("ci", %{"url" => @hook_url})])
+
+      {:ok, [%{action: :created, secret: secret}]} =
+        Manifest.apply_manifest(user.id, [
+          webhook_resource("ci", %{"url" => "https://hooks.example.com/second"})
+        ])
+
+      assert String.starts_with?(secret, "whsec_")
+      # No prune: the endpoint the old URL named is still there and still
+      # delivering, and has to be deleted through its own route.
+      assert length(Webhooks.list_endpoints(user.id)) == 2
     end
 
     test "a Teammate naming an unknown agent, environment or vault fails only its own row",
@@ -527,8 +799,10 @@ defmodule Fountain.ManifestTest do
           "prompt" => "x"
         })
 
-      assert errors == errors_on(changeset)
-      assert Map.has_key?(errors, :cron)
+      # Same content, keyed by string: an apply row's errors are string-keyed
+      # whichever branch produced them.
+      assert errors == Map.new(errors_on(changeset), fn {k, v} -> {to_string(k), v} end)
+      assert Map.has_key?(errors, "cron")
       assert Schedules.list_schedules(user.id, agent.id) == []
     end
 
@@ -598,7 +872,7 @@ defmodule Fountain.ManifestTest do
 
       assert good.action == :created
       assert bad.action == :error
-      assert Map.has_key?(bad.errors, :url)
+      assert Map.has_key?(bad.errors, "url")
       assert Webhooks.list_endpoints(user.id) == []
     end
 

--- a/apps/fountain/test/fountain/manifest_test.exs
+++ b/apps/fountain/test/fountain/manifest_test.exs
@@ -624,6 +624,54 @@ defmodule Fountain.ManifestTest do
       assert env.id
     end
 
+    # A rebind onto an identity that already has a computer is refused rather
+    # than merged onto that computer. The row says what to do about it.
+    test "a Teammate rebound onto an occupied computer fails that row", %{user: user} do
+      env = insert_env(user_id: user.id, name: "proj")
+
+      agent =
+        insert_agent(user_id: user.id, name: "ada", sandbox_mode: "persistent")
+
+      home =
+        insert_sandbox(
+          user_id: user.id,
+          status: "ready",
+          mode: "persistent",
+          agent_id: agent.id,
+          environment_id: nil,
+          provider: "sprites"
+        )
+
+      occupied =
+        insert_sandbox(
+          user_id: user.id,
+          status: "ready",
+          mode: "persistent",
+          agent_id: agent.id,
+          environment_id: env.id,
+          provider: "sprites"
+        )
+
+      conv =
+        insert_conversation(
+          user_id: user.id,
+          agent: agent,
+          sandbox: home,
+          status: "idle",
+          channel_id: Team.channel()
+        )
+
+      {:ok, [%{kind: "Teammate", action: :error, errors: errors}]} =
+        Manifest.apply_manifest(user.id, [
+          teammate_resource("Ada", %{"agent" => "ada", "environment" => "proj"})
+        ])
+
+      assert %{"base" => [message]} = errors
+      assert message =~ "already has a computer on that environment and vault"
+      assert Conversations.get_conversation(conv.id, user.id).environment_id == nil
+      assert Conversations._unsafe_get_sandbox!(occupied.id).status == "ready"
+    end
+
     test "re-applying a Teammate moves its name, environment and vault", %{user: user} do
       inert_start_child()
 

--- a/apps/fountain/test/fountain/manifest_test.exs
+++ b/apps/fountain/test/fountain/manifest_test.exs
@@ -1,7 +1,9 @@
 defmodule Fountain.ManifestTest do
   use Fountain.DataCase, async: true
+  use Mimic
 
-  alias Fountain.{Agents, Crypto, Environments, Manifest, Vaults}
+  alias Fountain.{Agents, Audit, Crypto, Environments, Manifest, Team, Vaults, Webhooks}
+  alias Fountain.Team.Schedules
 
   setup do
     # No starter agent (ADR 0038): every assertion here counts what the
@@ -22,6 +24,26 @@ defmodule Fountain.ManifestTest do
       Map.merge(%{"model" => "anthropic/claude-sonnet-4-6", "runtime" => "claude"}, spec)
 
     %{"kind" => "Agent", "name" => name, "spec" => spec}
+  end
+
+  defp teammate_resource(name, spec) do
+    %{"kind" => "Teammate", "name" => name, "spec" => spec}
+  end
+
+  defp schedule_resource(name, spec) do
+    %{"kind" => "Schedule", "name" => name, "spec" => spec}
+  end
+
+  defp webhook_resource(name, spec) do
+    %{"kind" => "Webhook", "name" => name, "spec" => spec}
+  end
+
+  # Adding a teammate opens its conversation, which provisions its computer.
+  # The supervisor start is what a DataCase test cannot do for real.
+  defp inert_start_child do
+    stub(Horde.DynamicSupervisor, :start_child, fn _sup, _spec ->
+      {:ok, spawn(fn -> Process.sleep(:infinity) end)}
+    end)
   end
 
   describe "spec keys" do
@@ -158,7 +180,7 @@ defmodule Fountain.ManifestTest do
   end
 
   describe "apply_manifest/2 updates" do
-    test "re-applying the same manifest is an idempotent update", %{user: user} do
+    test "re-applying the same manifest writes nothing and says so", %{user: user} do
       resources = [
         env_resource("proj", %{"secrets" => %{"TOKEN" => "t0"}}),
         agent_resource("researcher", %{"environment" => "proj"})
@@ -167,13 +189,24 @@ defmodule Fountain.ManifestTest do
       {:ok, _} = Manifest.apply_manifest(user.id, resources)
       {:ok, results} = Manifest.apply_manifest(user.id, resources)
 
+      # The secret is re-encrypted on every apply, so it keeps reporting
+      # `upserted` while the row it belongs to reports `unchanged`.
       assert [
-               %{kind: "Environment", action: :updated, secrets: [%{action: :upserted}]},
-               %{kind: "Agent", action: :updated}
+               %{kind: "Environment", action: :unchanged, secrets: [%{action: :upserted}]},
+               %{kind: "Agent", action: :unchanged}
              ] = results
 
       assert length(Environments.list_environments(user.id)) == 1
       assert length(Agents.list_agents(user.id, [])) == 1
+    end
+
+    test "a changed spec still reports updated", %{user: user} do
+      {:ok, _} = Manifest.apply_manifest(user.id, [env_resource("proj")])
+
+      {:ok, [%{kind: "Environment", action: :updated}]} =
+        Manifest.apply_manifest(user.id, [env_resource("proj", %{"setup_script" => "echo hi"})])
+
+      assert Environments.get_environment_by_name("proj", user.id).setup_script == "echo hi"
     end
 
     test "agent can reference a pre-existing environment not in the manifest", %{user: user} do
@@ -275,6 +308,313 @@ defmodule Fountain.ManifestTest do
         ])
 
       assert errors == %{"environment" => ["environment not found: their-env"]}
+    end
+  end
+
+  describe "apply_manifest/2 the whole estate" do
+    @hook_url "https://hooks.example.com/fountain"
+
+    defp estate_manifest do
+      # Deliberately out of order: the six kinds reconcile in a fixed order,
+      # whatever the file says.
+      [
+        webhook_resource("ci", %{
+          "url" => @hook_url,
+          "event_types" => ["conversation.turn.done"]
+        }),
+        schedule_resource("standup", %{
+          "teammate" => "Ada",
+          "cron" => "0 9 * * 1-5",
+          "prompt" => "What is on today?"
+        }),
+        teammate_resource("Ada", %{
+          "agent" => "ada",
+          "environment" => "proj",
+          "vault" => "alice"
+        }),
+        agent_resource("ada", %{"environment" => "proj"}),
+        vault_resource("alice", %{"secrets" => %{"GH" => "ghp_x"}}),
+        env_resource("proj", %{"setup_script" => "echo hi"})
+      ]
+    end
+
+    test "all six kinds apply in one request, and a second apply changes nothing",
+         %{user: user} do
+      inert_start_child()
+      resources = estate_manifest()
+
+      {:ok, first} = Manifest.apply_manifest(user.id, resources)
+
+      assert Enum.map(first, &{&1.kind, &1.name, &1.action}) == [
+               {"Environment", "proj", :created},
+               {"Vault", "alice", :created},
+               {"Agent", "ada", :created},
+               {"Teammate", "Ada", :created},
+               {"Schedule", "standup", :created},
+               {"Webhook", "ci", :created}
+             ]
+
+      env = Environments.get_environment_by_name("proj", user.id)
+      vault = Vaults.get_vault_by_name("alice", user.id)
+      agent = Agents.get_agent_by_name("ada", user.id)
+
+      assert [%{name: "Ada", agent: %{id: agent_id}, conversation: conv}] =
+               Team.list_teammates(user.id)
+
+      assert agent_id == agent.id
+      assert conv.environment_id == env.id
+      assert conv.vault_id == vault.id
+
+      assert [%{name: "standup", cron: "0 9 * * 1-5", one_off: false, enabled: true}] =
+               Schedules.list_schedules(user.id, agent.id)
+
+      assert [%{url: @hook_url, event_types: ["conversation.turn.done"]}] =
+               Webhooks.list_endpoints(user.id)
+
+      {:ok, second} = Manifest.apply_manifest(user.id, resources)
+
+      assert Enum.map(second, & &1.action) == List.duplicate(:unchanged, 6)
+      assert Enum.map(second, & &1.kind) == Enum.map(first, & &1.kind)
+
+      # Nothing was duplicated by the second pass.
+      assert length(Team.list_teammates(user.id)) == 1
+      assert length(Schedules.list_schedules(user.id, agent.id)) == 1
+      assert length(Webhooks.list_endpoints(user.id)) == 1
+    end
+
+    test "the applied rows are audited with the request's attribution", %{user: user} do
+      inert_start_child()
+      opts = [actor: "api", request_ip: "203.0.113.5"]
+
+      {:ok, _} = Manifest.apply_manifest(user.id, estate_manifest(), opts)
+
+      events = Audit.list_recent_for_user(user.id, 200)
+      actions = Enum.map(events, & &1.action)
+
+      assert "team.member.added" in actions
+      assert "team.schedule.created" in actions
+      assert "webhook_endpoint.created" in actions
+
+      for action <- ~w(team.member.added team.schedule.created webhook_endpoint.created) do
+        event = Enum.find(events, &(&1.action == action))
+        assert event.actor == "api", "#{action} was recorded as #{event.actor}"
+        assert to_string(event.request_ip) == "203.0.113.5"
+      end
+    end
+
+    test "re-applying a Teammate moves its name, environment and vault", %{user: user} do
+      inert_start_child()
+
+      {:ok, _} =
+        Manifest.apply_manifest(user.id, [
+          env_resource("proj"),
+          vault_resource("alice"),
+          agent_resource("ada"),
+          teammate_resource("Ada", %{"agent" => "ada"})
+        ])
+
+      {:ok, results} =
+        Manifest.apply_manifest(user.id, [
+          env_resource("proj"),
+          vault_resource("alice"),
+          agent_resource("ada"),
+          teammate_resource("Ada of proj", %{
+            "agent" => "ada",
+            "environment" => "proj",
+            "vault" => "alice"
+          })
+        ])
+
+      assert %{kind: "Teammate", name: "Ada of proj", action: :updated} =
+               List.last(results)
+
+      assert [%{name: "Ada of proj", conversation: conv}] = Team.list_teammates(user.id)
+      assert conv.environment_id == Environments.get_environment_by_name("proj", user.id).id
+      assert conv.vault_id == Vaults.get_vault_by_name("alice", user.id).id
+    end
+
+    test "a Teammate naming an unknown agent, environment or vault fails only its own row",
+         %{user: user} do
+      inert_start_child()
+
+      {:ok, results} =
+        Manifest.apply_manifest(user.id, [
+          agent_resource("ada"),
+          teammate_resource("no-agent", %{"agent" => "ghost"}),
+          teammate_resource("no-env", %{"agent" => "ada", "environment" => "ghost"}),
+          teammate_resource("no-vault", %{"agent" => "ada", "vault" => "ghost"}),
+          teammate_resource("nameless", %{}),
+          teammate_resource("Ada", %{"agent" => "ada"})
+        ])
+
+      assert [
+               %{kind: "Agent", name: "ada", action: :created},
+               %{name: "no-agent", action: :error, errors: agent_errors},
+               %{name: "no-env", action: :error, errors: env_errors},
+               %{name: "no-vault", action: :error, errors: vault_errors},
+               %{name: "nameless", action: :error, errors: blank_errors},
+               %{name: "Ada", action: :created}
+             ] = results
+
+      assert agent_errors == %{"agent" => ["agent not found: ghost"]}
+      assert env_errors == %{"environment" => ["environment not found: ghost"]}
+      assert vault_errors == %{"vault" => ["vault not found: ghost"]}
+      assert blank_errors == %{"agent" => ["can't be blank"]}
+
+      assert [%{name: "Ada"}] = Team.list_teammates(user.id)
+    end
+
+    test "a Teammate cannot resolve another tenant's agent", %{user: user} do
+      other = insert_verified_user()
+      insert_agent(user_id: other.id, name: "theirs")
+
+      {:ok, [%{kind: "Teammate", action: :error, errors: errors}]} =
+        Manifest.apply_manifest(user.id, [teammate_resource("T", %{"agent" => "theirs"})])
+
+      assert errors == %{"agent" => ["agent not found: theirs"]}
+      assert Team.list_teammates(user.id) == []
+    end
+
+    test "a Schedule may name a teammate the tenant already has", %{user: user} do
+      inert_start_child()
+      agent = insert_agent(user_id: user.id, name: "ada")
+      {:ok, _} = Team.add_teammate(user.id, agent.id, %{"name" => "Ada"})
+
+      {:ok, [%{kind: "Schedule", name: "nightly", action: :created}]} =
+        Manifest.apply_manifest(user.id, [
+          schedule_resource("nightly", %{
+            "teammate" => "Ada",
+            "cron" => "@daily",
+            "prompt" => "sweep",
+            "one_off" => true
+          })
+        ])
+
+      assert [%{name: "nightly", one_off: true}] = Schedules.list_schedules(user.id, agent.id)
+    end
+
+    test "a Schedule naming no teammate fails only its own row", %{user: user} do
+      {:ok, [good, bad]} =
+        Manifest.apply_manifest(user.id, [
+          vault_resource("v"),
+          schedule_resource("s", %{"teammate" => "ghost", "cron" => "@daily", "prompt" => "x"})
+        ])
+
+      assert good.action == :created
+      assert bad.action == :error
+      assert bad.errors == %{"teammate" => ["teammate not found: ghost"]}
+    end
+
+    test "an invalid cron fails with the same error the create route gives", %{user: user} do
+      inert_start_child()
+      agent = insert_agent(user_id: user.id, name: "ada")
+      {:ok, _} = Team.add_teammate(user.id, agent.id, %{"name" => "Ada"})
+
+      {:ok, [%{kind: "Schedule", action: :error, errors: errors}]} =
+        Manifest.apply_manifest(user.id, [
+          schedule_resource("bad", %{
+            "teammate" => "Ada",
+            "cron" => "not a cron",
+            "prompt" => "x"
+          })
+        ])
+
+      {:error, changeset} =
+        Schedules.create_schedule(user.id, %{
+          "agent_id" => agent.id,
+          "name" => "bad",
+          "cron" => "not a cron",
+          "prompt" => "x"
+        })
+
+      assert errors == errors_on(changeset)
+      assert Map.has_key?(errors, :cron)
+      assert Schedules.list_schedules(user.id, agent.id) == []
+    end
+
+    test "re-applying a Schedule moves its cron, prompt, one_off and enabled", %{user: user} do
+      inert_start_child()
+      agent = insert_agent(user_id: user.id, name: "ada")
+      {:ok, _} = Team.add_teammate(user.id, agent.id, %{"name" => "Ada"})
+
+      apply_schedule = fn spec ->
+        Manifest.apply_manifest(user.id, [
+          schedule_resource("standup", Map.put(spec, "teammate", "Ada"))
+        ])
+      end
+
+      {:ok, [%{action: :created}]} = apply_schedule.(%{"cron" => "@daily", "prompt" => "a"})
+      {:ok, [%{action: :unchanged}]} = apply_schedule.(%{"cron" => "@daily", "prompt" => "a"})
+
+      {:ok, [%{action: :updated}]} =
+        apply_schedule.(%{
+          "cron" => "0 9 * * 1-5",
+          "prompt" => "b",
+          "one_off" => true,
+          "enabled" => false
+        })
+
+      assert [%{cron: "0 9 * * 1-5", prompt: "b", one_off: true, enabled: false}] =
+               Schedules.list_schedules(user.id, agent.id)
+    end
+
+    test "a Webhook hands back its secret once and never on update", %{user: user} do
+      hook = fn spec -> [webhook_resource("ci", Map.put(spec, "url", @hook_url))] end
+
+      {:ok, [created]} = Manifest.apply_manifest(user.id, hook.(%{}))
+      assert created.action == :created
+      assert String.starts_with?(created.secret, "whsec_")
+
+      {:ok, [again]} = Manifest.apply_manifest(user.id, hook.(%{}))
+      assert again.action == :unchanged
+      assert again.secret == nil
+
+      {:ok, [updated]} = Manifest.apply_manifest(user.id, hook.(%{"description" => "CI"}))
+      assert updated.action == :updated
+      assert updated.secret == nil
+
+      assert [endpoint] = Webhooks.list_endpoints(user.id)
+      assert endpoint.description == "CI"
+      # The secret handed back on the create is still the one that signs.
+      assert Webhooks.secret(endpoint) == {:ok, created.secret}
+    end
+
+    test "a Webhook is keyed by its url, not by the document name", %{user: user} do
+      {:ok, [%{action: :created}]} =
+        Manifest.apply_manifest(user.id, [webhook_resource("ci", %{"url" => @hook_url})])
+
+      {:ok, [%{action: :unchanged}]} =
+        Manifest.apply_manifest(user.id, [webhook_resource("renamed", %{"url" => @hook_url})])
+
+      assert length(Webhooks.list_endpoints(user.id)) == 1
+    end
+
+    test "a Webhook the endpoint refuses fails that row only", %{user: user} do
+      {:ok, [good, bad]} =
+        Manifest.apply_manifest(user.id, [
+          vault_resource("v"),
+          webhook_resource("bad", %{"url" => "http://127.0.0.1/hook"})
+        ])
+
+      assert good.action == :created
+      assert bad.action == :error
+      assert Map.has_key?(bad.errors, :url)
+      assert Webhooks.list_endpoints(user.id) == []
+    end
+
+    test "unknown spec keys on the three new kinds are rejected", %{user: user} do
+      {:ok, results} =
+        Manifest.apply_manifest(user.id, [
+          teammate_resource("t", %{"agent" => "a", "environmnet" => "x"}),
+          schedule_resource("s", %{"teammate" => "t", "crn" => "@daily"}),
+          webhook_resource("w", %{"url" => @hook_url, "status" => "disabled"})
+        ])
+
+      assert [teammate, schedule, webhook] = results
+      assert teammate.errors == %{"environmnet" => ["is not a supported spec key"]}
+      assert schedule.errors == %{"crn" => ["is not a supported spec key"]}
+      assert webhook.errors == %{"status" => ["is not a supported spec key"]}
+      assert Webhooks.list_endpoints(user.id) == []
     end
   end
 end

--- a/apps/fountain/test/fountain/team_test.exs
+++ b/apps/fountain/test/fountain/team_test.exs
@@ -404,6 +404,136 @@ defmodule Fountain.TeamTest do
       assert Conversations._unsafe_get_sandbox!(sandbox.id).status == "ready"
     end
 
+    # #1636: the teammate's home may be shared. Retiring it must not let
+    # whichever conversation wakes first decide what the other one runs on.
+    test "a co-tenant of the retired computer keeps its own binding, either wake order" do
+      for order <- [:teammate_first, :cotenant_first] do
+        user = insert_active_user()
+        {:ok, user} = Fountain.Accounts.update_sandbox_limit(user, 10)
+        env = insert_env(user_id: user.id)
+        other = insert_env(user_id: user.id)
+
+        agent =
+          insert_agent(
+            user_id: user.id,
+            runtime: "claude",
+            environment_id: env.id,
+            sandbox_mode: "persistent"
+          )
+
+        home =
+          insert_sandbox(
+            user_id: user.id,
+            status: "ready",
+            mode: "persistent",
+            agent_id: agent.id,
+            environment_id: env.id,
+            provider: "sprites"
+          )
+
+        mate = insert_teammate_conv(user, agent, sandbox: home)
+
+        cotenant =
+          insert_conversation(user_id: user.id, agent: agent, sandbox: home, status: "idle")
+
+        stub(Managoat.Sandbox.Sprites, :destroy, fn _h -> :ok end)
+
+        assert {:ok, _, :updated} =
+                 Team.update_teammate(user.id, agent.id, %{"environment_id" => other.id})
+
+        [first, second] =
+          if order == :teammate_first, do: [mate, cotenant], else: [cotenant, mate]
+
+        {:ok, _} = Conversations.wake_conversation(first.id)
+        {:ok, _} = Conversations.wake_conversation(second.id)
+
+        mate_sandbox =
+          Conversations._unsafe_get_conversation!(mate.id).sandbox_id
+          |> Conversations._unsafe_get_sandbox!()
+
+        cotenant_sandbox =
+          Conversations._unsafe_get_conversation!(cotenant.id).sandbox_id
+          |> Conversations._unsafe_get_sandbox!()
+
+        assert mate_sandbox.environment_id == other.id,
+               "#{order}: the teammate ran on #{inspect(mate_sandbox.environment_id)}"
+
+        assert cotenant_sandbox.environment_id == env.id,
+               "#{order}: the co-tenant ran on #{inspect(cotenant_sandbox.environment_id)}"
+
+        refute mate_sandbox.id == cotenant_sandbox.id
+      end
+    end
+
+    # One live home per (user, agent, environment, vault). Writing the binding
+    # anyway would leave a teammate whose next wake cannot insert its home and
+    # cannot attach to the one that is there, so the rebind is refused whole.
+    test "a rebinding onto an identity that already has a computer is refused" do
+      user = insert_active_user()
+      env = insert_env(user_id: user.id)
+      other = insert_env(user_id: user.id)
+
+      agent =
+        insert_agent(user_id: user.id, environment_id: env.id, sandbox_mode: "persistent")
+
+      home =
+        insert_sandbox(
+          user_id: user.id,
+          status: "ready",
+          mode: "persistent",
+          agent_id: agent.id,
+          environment_id: env.id,
+          provider: "sprites"
+        )
+
+      occupied =
+        insert_sandbox(
+          user_id: user.id,
+          status: "ready",
+          mode: "persistent",
+          agent_id: agent.id,
+          environment_id: other.id,
+          provider: "sprites"
+        )
+
+      conv = insert_teammate_conv(user, agent, sandbox: home)
+
+      assert {:error, :destination_home_occupied} =
+               Team.update_teammate(user.id, agent.id, %{"environment_id" => other.id})
+
+      # Nothing was written and nothing was retired.
+      assert Conversations.get_conversation(conv.id, user.id).environment_id == nil
+      assert Conversations._unsafe_get_sandbox!(home.id).status == "ready"
+      assert Conversations._unsafe_get_sandbox!(occupied.id).status == "ready"
+      assert [%{name: name}] = Team.list_teammates(user.id)
+      assert name == agent.name
+    end
+
+    test "a rebinding onto the identity of the computer it is already on is allowed" do
+      user = insert_active_user()
+      env = insert_env(user_id: user.id)
+      agent = insert_agent(user_id: user.id, sandbox_mode: "persistent")
+
+      home =
+        insert_sandbox(
+          user_id: user.id,
+          status: "ready",
+          mode: "persistent",
+          agent_id: agent.id,
+          environment_id: env.id,
+          provider: "sprites"
+        )
+
+      insert_teammate_conv(user, agent, sandbox: home, environment_id: env.id)
+
+      # Naming the same environment explicitly is not a move, so the home it
+      # is sitting on is not "occupied by something else".
+      assert {:ok, _, :unchanged} =
+               Team.update_teammate(user.id, agent.id, %{"environment_id" => env.id})
+
+      assert Conversations._unsafe_get_sandbox!(home.id).status == "ready"
+    end
+
     test "an agent that is not on the team is not found" do
       user = insert_verified_user()
       agent = insert_agent(user_id: user.id)

--- a/apps/fountain/test/fountain/team_test.exs
+++ b/apps/fountain/test/fountain/team_test.exs
@@ -200,7 +200,7 @@ defmodule Fountain.TeamTest do
       vault = insert_vault(user_id: user.id)
       conv = insert_teammate_conv(user, agent)
 
-      assert {:ok, updated} =
+      assert {:ok, updated, :updated} =
                Team.update_teammate(
                  user.id,
                  agent.id,
@@ -233,7 +233,7 @@ defmodule Fountain.TeamTest do
       vault = insert_vault(user_id: user.id)
       insert_teammate_conv(user, agent, environment_id: env.id, vault_id: vault.id, title: "Ada")
 
-      assert {:ok, updated} =
+      assert {:ok, updated, :updated} =
                Team.update_teammate(user.id, agent.id, %{"environment_id" => ""})
 
       assert updated.environment_id == nil
@@ -247,7 +247,7 @@ defmodule Fountain.TeamTest do
       insert_teammate_conv(user, agent, title: "Ada")
       before = length(Audit.list_recent_for_user(user.id, 50))
 
-      assert {:ok, _} = Team.update_teammate(user.id, agent.id, %{"name" => "Ada"})
+      assert {:ok, _, :unchanged} = Team.update_teammate(user.id, agent.id, %{"name" => "Ada"})
       assert length(Audit.list_recent_for_user(user.id, 50)) == before
     end
 
@@ -283,6 +283,125 @@ defmodule Fountain.TeamTest do
                Team.update_teammate(user.id, agent.id, %{
                  "vault_id" => insert_vault(user_id: other.id).id
                })
+    end
+
+    # #1084 from the teammate's side: a home is keyed on (user, agent,
+    # environment, vault), so rebinding a teammate moves its computer out from
+    # under it. Refused mid-turn, and retired once the new binding is written.
+    test "the computer the binding moved away from is retired" do
+      user = insert_active_user()
+      env = insert_env(user_id: user.id)
+      other = insert_env(user_id: user.id)
+      agent = insert_agent(user_id: user.id, environment_id: env.id, sandbox_mode: "persistent")
+
+      home =
+        insert_sandbox(
+          user_id: user.id,
+          status: "ready",
+          mode: "persistent",
+          agent_id: agent.id,
+          environment_id: env.id,
+          provider: "sprites"
+        )
+
+      insert_teammate_conv(user, agent, sandbox: home, environment_id: env.id)
+
+      test = self()
+
+      stub(Managoat.Sandbox.Sprites, :destroy, fn h -> send(test, {:destroyed, h.name}) && :ok end)
+
+      assert {:ok, _, :updated} =
+               Team.update_teammate(user.id, agent.id, %{"environment_id" => other.id})
+
+      assert_received {:destroyed, name}
+      assert name == home.sprite_name
+      assert Conversations._unsafe_get_sandbox!(home.id).status == "terminated"
+    end
+
+    test "a rebinding is refused while a turn runs on that computer" do
+      user = insert_active_user()
+      env = insert_env(user_id: user.id)
+      other = insert_env(user_id: user.id)
+      agent = insert_agent(user_id: user.id, environment_id: env.id, sandbox_mode: "persistent")
+
+      home =
+        insert_sandbox(
+          user_id: user.id,
+          status: "ready",
+          mode: "persistent",
+          agent_id: agent.id,
+          environment_id: env.id,
+          provider: "sprites"
+        )
+
+      conv =
+        insert_teammate_conv(user, agent,
+          sandbox: home,
+          environment_id: env.id,
+          status: "running"
+        )
+
+      insert_turn(conv, status: "running")
+
+      assert {:error, :sandbox_mid_turn} =
+               Team.update_teammate(user.id, agent.id, %{"environment_id" => other.id})
+
+      # The refusal is the whole answer: the binding did not move and the
+      # machine is still there.
+      assert Conversations.get_conversation(conv.id, user.id).environment_id == env.id
+      assert Conversations._unsafe_get_sandbox!(home.id).status == "ready"
+    end
+
+    test "a name-only change leaves the computer alone, mid-turn or not" do
+      user = insert_active_user()
+      env = insert_env(user_id: user.id)
+      agent = insert_agent(user_id: user.id, environment_id: env.id, sandbox_mode: "persistent")
+
+      home =
+        insert_sandbox(
+          user_id: user.id,
+          status: "ready",
+          mode: "persistent",
+          agent_id: agent.id,
+          environment_id: env.id,
+          provider: "sprites"
+        )
+
+      conv =
+        insert_teammate_conv(user, agent,
+          sandbox: home,
+          environment_id: env.id,
+          status: "running"
+        )
+
+      insert_turn(conv, status: "running")
+
+      assert {:ok, _, :updated} = Team.update_teammate(user.id, agent.id, %{"name" => "Ada"})
+      assert Conversations._unsafe_get_sandbox!(home.id).status == "ready"
+    end
+
+    test "an ephemeral computer is not a home and is left standing" do
+      user = insert_active_user()
+      env = insert_env(user_id: user.id)
+      other = insert_env(user_id: user.id)
+      agent = insert_agent(user_id: user.id, environment_id: env.id)
+
+      sandbox =
+        insert_sandbox(
+          user_id: user.id,
+          status: "ready",
+          mode: "ephemeral",
+          agent_id: agent.id,
+          environment_id: env.id,
+          provider: "sprites"
+        )
+
+      insert_teammate_conv(user, agent, sandbox: sandbox, environment_id: env.id)
+
+      assert {:ok, _, :updated} =
+               Team.update_teammate(user.id, agent.id, %{"environment_id" => other.id})
+
+      assert Conversations._unsafe_get_sandbox!(sandbox.id).status == "ready"
     end
 
     test "an agent that is not on the team is not found" do

--- a/apps/fountain/test/fountain/team_test.exs
+++ b/apps/fountain/test/fountain/team_test.exs
@@ -192,6 +192,107 @@ defmodule Fountain.TeamTest do
     end
   end
 
+  describe "update_teammate/4" do
+    test "moves the name, the environment and the vault, and records the fields" do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id, name: "Ada")
+      env = insert_env(user_id: user.id)
+      vault = insert_vault(user_id: user.id)
+      conv = insert_teammate_conv(user, agent)
+
+      assert {:ok, updated} =
+               Team.update_teammate(
+                 user.id,
+                 agent.id,
+                 %{
+                   "name" => "  Ada (staging)  ",
+                   "environment_id" => env.id,
+                   "vault_id" => vault.id
+                 },
+                 actor: "api"
+               )
+
+      assert updated.id == conv.id
+      assert updated.title == "Ada (staging)"
+      assert updated.environment_id == env.id
+      assert updated.vault_id == vault.id
+
+      assert [%{name: "Ada (staging)"}] = Team.list_teammates(user.id)
+
+      assert event =
+               Enum.find(Audit.list_recent_for_user(user.id, 20), &(&1.action == "team.updated"))
+
+      assert event.actor == "api"
+      assert Enum.sort(event.metadata["fields"]) == ["environment_id", "name", "vault_id"]
+    end
+
+    test "a blank value clears the binding; an absent key leaves it alone" do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      env = insert_env(user_id: user.id)
+      vault = insert_vault(user_id: user.id)
+      insert_teammate_conv(user, agent, environment_id: env.id, vault_id: vault.id, title: "Ada")
+
+      assert {:ok, updated} =
+               Team.update_teammate(user.id, agent.id, %{"environment_id" => ""})
+
+      assert updated.environment_id == nil
+      assert updated.vault_id == vault.id
+      assert updated.title == "Ada"
+    end
+
+    test "records nothing when nothing moves" do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      insert_teammate_conv(user, agent, title: "Ada")
+      before = length(Audit.list_recent_for_user(user.id, 50))
+
+      assert {:ok, _} = Team.update_teammate(user.id, agent.id, %{"name" => "Ada"})
+      assert length(Audit.list_recent_for_user(user.id, 50)) == before
+    end
+
+    test "the agent's allowlists gate the environment and the vault" do
+      user = insert_verified_user()
+      env = insert_env(user_id: user.id)
+      vault = insert_vault(user_id: user.id)
+
+      agent =
+        insert_agent(user_id: user.id, allowed_environment_ids: [], allowed_vault_ids: [])
+
+      insert_teammate_conv(user, agent)
+
+      assert {:error, :environment_not_allowed} =
+               Team.update_teammate(user.id, agent.id, %{"environment_id" => env.id})
+
+      assert {:error, :vault_not_allowed} =
+               Team.update_teammate(user.id, agent.id, %{"vault_id" => vault.id})
+    end
+
+    test "another tenant's environment or vault is refused" do
+      user = insert_verified_user()
+      other = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      insert_teammate_conv(user, agent)
+
+      assert {:error, :environment_not_allowed} =
+               Team.update_teammate(user.id, agent.id, %{
+                 "environment_id" => insert_env(user_id: other.id).id
+               })
+
+      assert {:error, :vault_not_allowed} =
+               Team.update_teammate(user.id, agent.id, %{
+                 "vault_id" => insert_vault(user_id: other.id).id
+               })
+    end
+
+    test "an agent that is not on the team is not found" do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+
+      assert {:error, :not_found} = Team.update_teammate(user.id, agent.id, %{"name" => "x"})
+    end
+  end
+
   describe "addable_options/2" do
     test "the user's environments and vaults, narrowed by the agent's allowlists" do
       user = insert_verified_user()

--- a/apps/fountain/test/fountain_web/controllers/apply_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/apply_controller_test.exs
@@ -1,7 +1,9 @@
 defmodule FountainWeb.ApplyControllerTest do
   use FountainWeb.ConnCase, async: true
+  use Mimic
 
-  alias Fountain.{Agents, Crypto, Environments, Vaults}
+  alias Fountain.{Agents, Crypto, Environments, Team, Vaults, Webhooks}
+  alias Fountain.Team.Schedules
 
   setup do
     user = insert_verified_user()
@@ -98,6 +100,75 @@ defmodule FountainWeb.ApplyControllerTest do
       assert Vaults.get_vault_by_name("valid", user.id)
     end
 
+    test "reconciles the three team and webhook kinds in one request", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
+      # Adding a teammate opens its conversation, which provisions its computer.
+      stub(Horde.DynamicSupervisor, :start_child, fn _sup, _spec ->
+        {:ok, spawn(fn -> Process.sleep(:infinity) end)}
+      end)
+
+      payload = %{
+        "resources" => [
+          %{"kind" => "Environment", "name" => "proj", "spec" => %{}},
+          %{"kind" => "Vault", "name" => "alice", "spec" => %{}},
+          %{
+            "kind" => "Agent",
+            "name" => "ada",
+            "spec" => %{"model" => "anthropic/claude-sonnet-4-6", "runtime" => "claude"}
+          },
+          %{
+            "kind" => "Teammate",
+            "name" => "Ada",
+            "spec" => %{"agent" => "ada", "environment" => "proj", "vault" => "alice"}
+          },
+          %{
+            "kind" => "Schedule",
+            "name" => "standup",
+            "spec" => %{"teammate" => "Ada", "cron" => "0 9 * * 1-5", "prompt" => "morning"}
+          },
+          %{
+            "kind" => "Webhook",
+            "name" => "ci",
+            "spec" => %{"url" => "https://hooks.example.com/fountain"}
+          }
+        ]
+      }
+
+      response = conn |> authed_with_key(raw_key) |> post_json(~p"/api/apply", payload)
+      assert %{"data" => %{"results" => results}} = json_response(response, 200)
+
+      assert Enum.map(results, &{&1["kind"], &1["action"]}) == [
+               {"Environment", "created"},
+               {"Vault", "created"},
+               {"Agent", "created"},
+               {"Teammate", "created"},
+               {"Schedule", "created"},
+               {"Webhook", "created"}
+             ]
+
+      # The signing secret is on the webhook row and nowhere else.
+      assert [%{"kind" => "Webhook", "secret" => secret}] =
+               Enum.filter(results, &(&1["secret"] != nil))
+
+      assert String.starts_with?(secret, "whsec_")
+
+      agent = Agents.get_agent_by_name("ada", user.id)
+      assert [%{name: "Ada"}] = Team.list_teammates(user.id)
+      assert [%{name: "standup"}] = Schedules.list_schedules(user.id, agent.id)
+
+      # A second apply writes nothing and returns no secret.
+      second =
+        build_conn() |> authed_with_key(raw_key) |> post_json(~p"/api/apply", payload)
+
+      assert %{"data" => %{"results" => rows}} = json_response(second, 200)
+      assert Enum.map(rows, & &1["action"]) == List.duplicate("unchanged", 6)
+      assert Enum.all?(rows, &(&1["secret"] == nil))
+      assert length(Webhooks.list_endpoints(user.id)) == 1
+    end
+
     test "never echoes secret values back", %{conn: conn, raw_key: raw_key} do
       payload = %{
         "resources" => [
@@ -111,7 +182,10 @@ defmodule FountainWeb.ApplyControllerTest do
       refute conn.resp_body =~ "sekrit-value"
     end
 
-    test "re-apply reports updated actions", %{conn: conn, raw_key: raw_key} do
+    test "re-apply reports unchanged, and a changed spec reports updated", %{
+      conn: conn,
+      raw_key: raw_key
+    } do
       payload = %{
         "resources" => [%{"kind" => "Vault", "name" => "v", "spec" => %{}}]
       }
@@ -121,8 +195,17 @@ defmodule FountainWeb.ApplyControllerTest do
       assert %{"data" => %{"results" => [%{"action" => "created"}]}} =
                conn |> auth.() |> post_json(~p"/api/apply", payload) |> json_response(200)
 
-      assert %{"data" => %{"results" => [%{"action" => "updated"}]}} =
+      assert %{"data" => %{"results" => [%{"action" => "unchanged"}]}} =
                build_conn() |> auth.() |> post_json(~p"/api/apply", payload) |> json_response(200)
+
+      moved = %{
+        "resources" => [
+          %{"kind" => "Vault", "name" => "v", "spec" => %{"description" => "moved"}}
+        ]
+      }
+
+      assert %{"data" => %{"results" => [%{"action" => "updated"}]}} =
+               build_conn() |> auth.() |> post_json(~p"/api/apply", moved) |> json_response(200)
     end
 
     test "returns 200 with per-resource errors on partial failure", %{

--- a/apps/fountain/test/fountain_web/controllers/apply_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/apply_controller_test.exs
@@ -11,6 +11,82 @@ defmodule FountainWeb.ApplyControllerTest do
     {:ok, user: user, raw_key: raw_key}
   end
 
+  describe "POST /api/apply — the webhook scope boundary" do
+    setup %{user: user} do
+      {_key, sprite_key} = insert_sprite_api_key(user)
+      %{sprite_key: sprite_key}
+    end
+
+    test "a sandbox token cannot create a webhook endpoint through a manifest", %{
+      conn: conn,
+      user: user,
+      sprite_key: sprite_key
+    } do
+      payload = %{
+        "resources" => [
+          %{"kind" => "Environment", "name" => "proj", "spec" => %{"setup_script" => "echo hi"}},
+          %{
+            "kind" => "Webhook",
+            "name" => "ops",
+            "spec" => %{"url" => "https://example.test/hook", "event_types" => ["*"]}
+          }
+        ]
+      }
+
+      conn = conn |> authed_with_key(sprite_key) |> post_json(~p"/api/apply", payload)
+
+      body = json_response(conn, 403)
+      assert body["reason"] == "insufficient_scope"
+      assert body["required_scope"] == "full"
+
+      # Refused before any resource is written, so the environment sharing the
+      # manifest with the webhook does not land either.
+      assert Fountain.Environments.list_environments(user.id) == []
+      assert Fountain.Webhooks.list_endpoints(user.id) == []
+    end
+
+    test "a sandbox token may still apply a manifest with no webhook in it", %{
+      conn: conn,
+      user: user,
+      sprite_key: sprite_key
+    } do
+      payload = %{
+        "resources" => [
+          %{"kind" => "Environment", "name" => "proj", "spec" => %{"setup_script" => "echo hi"}}
+        ]
+      }
+
+      conn = conn |> authed_with_key(sprite_key) |> post_json(~p"/api/apply", payload)
+
+      assert %{"data" => %{"results" => [%{"action" => "created"}]}} = json_response(conn, 200)
+      assert [_] = Fountain.Environments.list_environments(user.id)
+    end
+
+    test "a full-scope key applies the same webhook manifest", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
+      payload = %{
+        "resources" => [
+          %{
+            "kind" => "Webhook",
+            "name" => "ops",
+            "spec" => %{"url" => "https://example.test/hook", "event_types" => ["*"]}
+          }
+        ]
+      }
+
+      conn = conn |> authed_with_key(raw_key) |> post_json(~p"/api/apply", payload)
+
+      assert %{"data" => %{"results" => [%{"action" => "created", "secret" => secret}]}} =
+               json_response(conn, 200)
+
+      assert is_binary(secret)
+      assert [_] = Fountain.Webhooks.list_endpoints(user.id)
+    end
+  end
+
   describe "POST /api/apply" do
     test "applies a full manifest in one request", %{conn: conn, user: user, raw_key: raw_key} do
       payload = %{

--- a/cli/internal/cmd/apply.go
+++ b/cli/internal/cmd/apply.go
@@ -42,7 +42,7 @@ func runApply(cmd *cobra.Command, args []string) error {
 		Fatal(err.Error())
 	}
 
-	envs, vaults, agents, unknown := groupDocs(docs)
+	grouped, unknown := groupDocs(docs)
 	if len(unknown) > 0 {
 		names := make([]string, len(unknown))
 		for i, d := range unknown {
@@ -51,15 +51,15 @@ func runApply(cmd *cobra.Command, args []string) error {
 		Fatalf("unsupported kinds in %s: %s", path, strings.Join(names, ", "))
 	}
 
-	envs, vaults = expandApplySecrets(envs, vaults, applyVars)
+	grouped["Environment"], grouped["Vault"] = expandApplySecrets(grouped["Environment"], grouped["Vault"], applyVars)
 
 	c := activeClient()
 
-	results, err := postApply(c, buildApplyPayload(envs, vaults, agents))
+	results, err := postApply(c, buildApplyPayload(grouped))
 	if err != nil {
 		if api.StatusCode(err) == 404 {
 			// Server predates POST /api/apply — reconcile resource-by-resource.
-			legacyApply(c, envs, vaults, agents)
+			legacyApply(c, grouped)
 			return nil
 		}
 		Fatalf("apply failed: %v", err)
@@ -73,11 +73,16 @@ func runApply(cmd *cobra.Command, args []string) error {
 
 // ── bulk apply ─────────────────────────────────────────────────────────
 
+// applyKindOrder is the order the server reconciles in, and the order the
+// payload is built in so the printed output reads the same way. A document
+// may name another whatever the file's order: an agent's `spec.environment`,
+// a teammate's `spec.agent`/`environment`/`vault`, a schedule's
+// `spec.teammate`. The server resolves each by name, including against
+// records that already exist and are not part of this manifest.
+var applyKindOrder = []string{"Environment", "Vault", "Agent", "Teammate", "Schedule", "Webhook"}
+
 // applyResource is one compiled manifest document. The whole manifest is
-// sent to POST /api/apply in a single request; the server reconciles by
-// name (environments first, then vaults, then agents) and resolves agent
-// `spec.environment` references server-side — including environments that
-// already exist but aren't part of this manifest.
+// sent to POST /api/apply in a single request.
 type applyResource struct {
 	Kind string         `json:"kind"`
 	Name string         `json:"name"`
@@ -96,12 +101,15 @@ type applyResult struct {
 	Action  string              `json:"action"`
 	Errors  map[string]any      `json:"errors"`
 	Secrets []applySecretResult `json:"secrets"`
+	// Secret is a webhook endpoint's signing secret, sent on the apply that
+	// created it and never again.
+	Secret string `json:"secret"`
 }
 
-func buildApplyPayload(envs, vaults, agents []*manifest.Doc) []applyResource {
+func buildApplyPayload(grouped map[string][]*manifest.Doc) []applyResource {
 	var out []applyResource
-	for _, group := range [][]*manifest.Doc{envs, vaults, agents} {
-		for _, d := range group {
+	for _, kind := range applyKindOrder {
+		for _, d := range grouped[kind] {
 			name := requireName(d)
 			spec := cloneMap(d.Spec)
 			// Ownership fields are server-assigned; don't transmit fields the
@@ -135,8 +143,8 @@ var applyKindLabels = map[string]string{
 }
 
 // renderApplyResults prints one line per resource in the same format the
-// per-resource loop used (`+` create, `~` update, `!` error to stderr) and
-// reports whether any resource or secret failed.
+// per-resource loop used (`+` create, `~` update, `=` no change, `!` error to
+// stderr) and reports whether any resource or secret failed.
 func renderApplyResults(results []applyResult) (anyFailed bool) {
 	for _, r := range results {
 		label := applyKindLabels[r.Kind]
@@ -148,9 +156,17 @@ func renderApplyResults(results []applyResult) (anyFailed bool) {
 			fmt.Printf("%s  +  %s\n", label, r.Name)
 		case "updated":
 			fmt.Printf("%s  ~  %s\n", label, r.Name)
+		case "unchanged":
+			fmt.Printf("%s  =  %s\n", label, r.Name)
 		default:
 			anyFailed = true
 			warnf("%s  !  %s: %s", label, r.Name, formatResultErrors(r.Errors))
+		}
+		// A webhook endpoint's signing secret comes back on the apply that
+		// created it and never again, so print it where the reader is looking.
+		if r.Secret != "" {
+			fmt.Printf("  signing secret  %s  %s\n", r.Name, r.Secret)
+			fmt.Println("  save it now, it is not shown again")
 		}
 		for _, s := range r.Secrets {
 			if s.Action == "upserted" {
@@ -177,9 +193,21 @@ func formatResultErrors(errs map[string]any) string {
 
 // legacyApply is the pre-bulk reconciliation path: one GET+write per
 // resource and one POST per secret. Kept for servers without /api/apply.
-func legacyApply(c *api.Client, envs, vaults, agents []*manifest.Doc) {
+//
+// A server that has no /api/apply also has no Teammate, Schedule or Webhook
+// document, so those are reported rather than reconciled: the run failed to
+// do what the manifest asked.
+func legacyApply(c *api.Client, grouped map[string][]*manifest.Doc) {
+	envs, vaults, agents := grouped["Environment"], grouped["Vault"], grouped["Agent"]
 	envIDByName := map[string]string{}
 	anyFailed := false
+
+	for _, kind := range []string{"Teammate", "Schedule", "Webhook"} {
+		for _, d := range grouped[kind] {
+			anyFailed = true
+			warnf("%s  !  %s: this server is too old to apply %s documents", strings.ToLower(kind), d.Name(), kind)
+		}
+	}
 
 	for _, d := range envs {
 		if envID, ok := applyEnvironment(c, d); ok {
@@ -208,20 +236,23 @@ func legacyApply(c *api.Client, envs, vaults, agents []*manifest.Doc) {
 
 // ── grouping ───────────────────────────────────────────────────────────
 
-func groupDocs(docs []*manifest.Doc) (envs, vaults, agents, unknown []*manifest.Doc) {
+// groupDocs buckets the parsed documents by kind. The returned map is keyed
+// by the kind name, so a caller reads it in applyKindOrder; anything outside
+// that list comes back in `unknown` and stops the run.
+func groupDocs(docs []*manifest.Doc) (grouped map[string][]*manifest.Doc, unknown []*manifest.Doc) {
+	grouped = map[string][]*manifest.Doc{}
+	known := map[string]bool{}
+	for _, kind := range applyKindOrder {
+		known[kind] = true
+	}
 	for _, d := range docs {
-		switch d.Kind {
-		case "Environment":
-			envs = append(envs, d)
-		case "Vault":
-			vaults = append(vaults, d)
-		case "Agent":
-			agents = append(agents, d)
-		default:
+		if known[d.Kind] {
+			grouped[d.Kind] = append(grouped[d.Kind], d)
+		} else {
 			unknown = append(unknown, d)
 		}
 	}
-	return
+	return grouped, unknown
 }
 
 // ── apply-time secret resolution ───────────────────────────────────────

--- a/cli/internal/cmd/apply_test.go
+++ b/cli/internal/cmd/apply_test.go
@@ -17,27 +17,36 @@ func doc(kind, name string, spec map[string]any) *manifest.Doc {
 }
 
 func TestBuildApplyPayloadOrdersAndStrips(t *testing.T) {
-	envs := []*manifest.Doc{doc("Environment", "proj", map[string]any{
-		"setup_script": "echo hi",
-		"secrets":      map[string]any{"TOKEN": "t0"},
-		"user_id":      "someone-else",
-		"created_by":   "mallory",
-		"id":           "forced-id",
-	})}
-	vaults := []*manifest.Doc{doc("Vault", "alice", nil)}
-	agents := []*manifest.Doc{doc("Agent", "researcher", map[string]any{
-		"runtime":     "claude",
-		"environment": "proj",
-	})}
-
-	// Payload order is envs, vaults, agents regardless of manifest order.
-	got := buildApplyPayload(envs, vaults, agents)
-
-	if len(got) != 3 {
-		t.Fatalf("want 3 resources, got %d", len(got))
+	grouped := map[string][]*manifest.Doc{
+		"Environment": {doc("Environment", "proj", map[string]any{
+			"setup_script": "echo hi",
+			"secrets":      map[string]any{"TOKEN": "t0"},
+			"user_id":      "someone-else",
+			"created_by":   "mallory",
+			"id":           "forced-id",
+		})},
+		"Vault": {doc("Vault", "alice", nil)},
+		"Agent": {doc("Agent", "researcher", map[string]any{
+			"runtime":     "claude",
+			"environment": "proj",
+		})},
+		"Teammate": {doc("Teammate", "Ada", map[string]any{"agent": "researcher"})},
+		"Schedule": {doc("Schedule", "standup", map[string]any{"teammate": "Ada", "cron": "@daily"})},
+		"Webhook":  {doc("Webhook", "ci", map[string]any{"url": "https://example.com/h"})},
 	}
-	if got[0].Kind != "Environment" || got[1].Kind != "Vault" || got[2].Kind != "Agent" {
-		t.Fatalf("wrong kind order: %v, %v, %v", got[0].Kind, got[1].Kind, got[2].Kind)
+
+	// Payload order is the six kinds in reconciliation order, whatever order
+	// the manifest listed them in.
+	got := buildApplyPayload(grouped)
+
+	if len(got) != 6 {
+		t.Fatalf("want 6 resources, got %d", len(got))
+	}
+	wantKinds := []string{"Environment", "Vault", "Agent", "Teammate", "Schedule", "Webhook"}
+	for i, want := range wantKinds {
+		if got[i].Kind != want {
+			t.Fatalf("resource %d: want kind %q, got %q", i, want, got[i].Kind)
+		}
 	}
 
 	env := got[0]
@@ -66,6 +75,29 @@ func TestBuildApplyPayloadOrdersAndStrips(t *testing.T) {
 	}
 }
 
+func TestGroupDocsBucketsEveryKind(t *testing.T) {
+	docs := []*manifest.Doc{
+		doc("Webhook", "ci", nil),
+		doc("Agent", "a", nil),
+		doc("Cluster", "nope", nil),
+		doc("Teammate", "Ada", nil),
+		doc("Schedule", "standup", nil),
+		doc("Environment", "e", nil),
+		doc("Vault", "v", nil),
+	}
+
+	grouped, unknown := groupDocs(docs)
+
+	for _, kind := range []string{"Environment", "Vault", "Agent", "Teammate", "Schedule", "Webhook"} {
+		if len(grouped[kind]) != 1 {
+			t.Errorf("%s: want 1 doc, got %d", kind, len(grouped[kind]))
+		}
+	}
+	if len(unknown) != 1 || unknown[0].Kind != "Cluster" {
+		t.Errorf("an unsupported kind must come back as unknown, got %v", unknown)
+	}
+}
+
 func TestRenderApplyResultsFailureDetection(t *testing.T) {
 	cases := []struct {
 		name    string
@@ -75,6 +107,8 @@ func TestRenderApplyResultsFailureDetection(t *testing.T) {
 		{"all ok", []applyResult{
 			{Kind: "Environment", Name: "e", Action: "created"},
 			{Kind: "Agent", Name: "a", Action: "updated"},
+			{Kind: "Teammate", Name: "Ada", Action: "unchanged"},
+			{Kind: "Webhook", Name: "ci", Action: "created", Secret: "whsec_x"},
 		}, false},
 		{"resource error", []applyResult{
 			{Kind: "Agent", Name: "a", Action: "error", Errors: map[string]any{"model": []any{"can't be blank"}}},

--- a/cli/internal/manifest/examples_test.go
+++ b/cli/internal/manifest/examples_test.go
@@ -25,7 +25,14 @@ func TestExamplesParse(t *testing.T) {
 		t.Fatal("no .yml/.yaml files under examples/")
 	}
 
-	knownKinds := map[string]bool{"Environment": true, "Vault": true, "Agent": true}
+	knownKinds := map[string]bool{
+		"Environment": true,
+		"Vault":       true,
+		"Agent":       true,
+		"Teammate":    true,
+		"Schedule":    true,
+		"Webhook":     true,
+	}
 	total := 0
 	checked := 0
 	for _, f := range files {

--- a/docs/api.md
+++ b/docs/api.md
@@ -155,8 +155,31 @@ which connection choices the UI can offer.
 
 Use `fountain apply` when a checked-in manifest should define several related
 resources. The CLI compiles the manifest and submits the resource graph.
-Inspect every resource result: one failed resource does not mean that all
+Inspect every resource result. One failed resource does not mean that all
 other writes failed.
+
+A manifest holds six kinds. Fountain reconciles them in a fixed order, which
+is `Environment`, `Vault`, `Agent`, `Teammate`, `Schedule` and `Webhook`. A
+document can name another document whatever its position in the file. An
+`Agent` names an `environment`. A `Teammate` names an `agent`, an
+`environment` and a `vault`. A `Schedule` names a `teammate`. Each name
+resolves against the manifest first, then against the records the account
+already holds. A name that matches neither fails that document alone.
+
+The document name is the key for five of the kinds. `Webhook` is the
+exception, and is keyed by `spec.url`.
+
+Each result row reports `created`, `updated`, `unchanged` or `error`. A
+second apply of an unchanged manifest reports `unchanged` for every row.
+Inline `spec.secrets` are encrypted again on each apply, so they keep
+reporting `upserted` under a row that reports `unchanged`.
+
+A `Webhook` that an apply creates carries its signing secret in that result
+row. Fountain shows the secret one time. An update of the same endpoint
+carries no secret.
+
+Apply is additive. A document that you delete from the manifest leaves its
+record in place. There is no prune.
 
 See [CLI](cli.md) for the workflow and the Apply operation in the
 [generated reference](/api/docs) for its wire format. Unknown configuration

--- a/docs/api.md
+++ b/docs/api.md
@@ -167,7 +167,18 @@ resolves against the manifest first, then against the records the account
 already holds. A name that matches neither fails that document alone.
 
 The document name is the key for five of the kinds. `Webhook` is the
-exception, and is keyed by `spec.url`.
+exception, and is keyed by `spec.url`. Change that URL and the apply creates
+a second endpoint. The first one stays, and keeps delivering, until you
+delete it through the webhook routes.
+
+A `Teammate` document is the whole teammate. Drop `environment` or `vault`
+from it and the apply clears that binding, which puts the teammate back on
+the agent's own environment and on no vault. The other five kinds behave the
+other way around, where an absent `spec` key leaves that field alone.
+
+Rebinding a teammate moves its computer. Fountain retires the machine the old
+binding named, so the next message builds one from the new environment and
+vault. It refuses the whole row while a turn is running on that machine.
 
 Each result row reports `created`, `updated`, `unchanged` or `error`. A
 second apply of an unchanged manifest reports `unchanged` for every row.
@@ -180,6 +191,14 @@ carries no secret.
 
 Apply is additive. A document that you delete from the manifest leaves its
 record in place. There is no prune.
+
+The audit trail names each applied row. Teammate rows record `team.member.added`
+and `team.updated`, schedule rows record `team.schedule.created` and
+`team.schedule.updated`, and webhook rows record `webhook_endpoint.created` and
+`webhook_endpoint.updated`. The webhook actions carry the `webhook_endpoint`
+prefix that the webhook routes have always written, not a shorter `webhook`
+one. Each row carries the actor and the IP address of the request that applied
+it.
 
 See [CLI](cli.md) for the workflow and the Apply operation in the
 [generated reference](/api/docs) for its wire format. Unknown configuration

--- a/docs/api.md
+++ b/docs/api.md
@@ -178,7 +178,15 @@ other way around, where an absent `spec` key leaves that field alone.
 
 Rebinding a teammate moves its computer. Fountain retires the machine the old
 binding named, so the next message builds one from the new environment and
-vault. It refuses the whole row while a turn is running on that machine.
+vault. It refuses the whole row while a turn is running on that machine. A
+conversation that shared the retired machine, and that names a different
+environment or vault, does not follow the teammate onto the new one. It
+builds a machine from what it names on its own next message.
+
+Fountain keeps one machine for each agent, environment and vault. The row
+fails when the agent already has one on the environment and vault the
+teammate moves to. Fountain does not join the teammate to that machine.
+Reset or delete the machine first, then apply again.
 
 Each result row reports `created`, `updated`, `unchanged` or `error`. A
 second apply of an unchanged manifest reports `unchanged` for every row.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -317,7 +317,8 @@ fountain apply -f dir/ --var REGION=eu-west-1 # ${VAR} substitution, repeatable
 ```
 
 Apply is idempotent. It creates what is new, and updates what changed. It
-supports three kinds, which are `Environment`, `Vault` and `Agent`.
+supports six kinds, which are `Environment`, `Vault`, `Agent`, `Teammate`,
+`Schedule` and `Webhook`.
 
 `--var` and `${VAR}` substitution apply to a `spec.secrets` value alone. A
 `${VAR}` anywhere else in the document goes across as it stands. A
@@ -326,16 +327,82 @@ supports three kinds, which are `Environment`, `Vault` and `Agent`.
 The CLI compiles each document into one manifest, and sends that to
 `POST /api/apply` in one request.
 
-The server reconciles the environments, then the vaults, then the agents. It
-resolves an agent's `environment:` name reference, and that includes an
-environment that already exists on the server.
+The server reconciles the six kinds in the order above. A document can name
+another document whatever its position in the file. An `Agent` names an
+`environment`. A `Teammate` names an `agent`, an `environment` and a `vault`.
+A `Schedule` names a `teammate`. Each name resolves against the manifest
+first, then against the records your account already holds.
+
+The `metadata.name` is the key for five of the kinds. A `Webhook` is keyed by
+its `spec.url`, so the document name is a label alone.
+
+```yaml
+---
+apiVersion: fountain/v1
+kind: Teammate
+metadata:
+  name: Ada
+spec:
+  agent: ada             # an Agent document, or an agent you already have
+  environment: my-project
+  vault: alice
+
+---
+apiVersion: fountain/v1
+kind: Schedule
+metadata:
+  name: standup
+spec:
+  teammate: Ada
+  cron: "0 9 * * 1-5"    # five fields, UTC
+  prompt: What is on today?
+  one_off: false
+  enabled: true
+
+---
+apiVersion: fountain/v1
+kind: Webhook
+metadata:
+  name: ci
+spec:
+  url: https://ci.example.com/hooks/fountain
+  description: CI receiver
+  event_types: [conversation.turn.done]
+```
+
+A `Teammate` document adds the agent to the team, which opens the teammate's
+conversation and starts its computer. A later apply moves the name, the
+environment and the vault the next computer is built from. It starts no
+second computer.
+
+A `Webhook` that an apply creates prints its signing secret one time. Save it
+then. An apply that updates the same endpoint prints no secret.
+
+The CLI prints `+` for a create, `~` for an update, `=` for a resource that
+already matched the manifest, and `!` for a failure.
+
+```
+env  =  my-project
+vault  =  alice
+agent  ~  ada
+teammate  +  Ada
+schedule  +  standup
+webhook  +  ci
+  signing secret  ci  whsec_...
+  save it now, it is not shown again
+```
+
+Apply is additive. A document that you delete from the manifest leaves its
+record in place. There is no prune, so delete a record through its own
+command or the console.
 
 The server rejects unknown `spec` keys per resource. The CLI prints those
 errors and exits nonzero; valid resources in the same manifest still apply.
 Correct a misspelled field before you retry.
 
 Against an older server with no `/api/apply`, the CLI falls back to one call
-for each resource.
+for each resource. That older server has no `Teammate`, `Schedule` or
+`Webhook` document, so the CLI reports those and exits nonzero.
 
 ### Secret references
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -385,7 +385,15 @@ the other way around, where an absent `spec` key leaves that field alone.
 A teammate's computer is built for one environment and one vault. Move either
 of them and Fountain retires that computer, so the teammate's next message
 builds a new one with the files and tools of a fresh machine. It refuses the
-row while a turn is still running there, and prints what to do about it.
+row while a turn is still running there, and prints what to do about it. A
+conversation that shared the retired computer, and that names a different
+environment or vault, does not follow the teammate. It builds a machine of
+its own from what it names.
+
+Fountain keeps one computer for each agent, environment and vault. It refuses
+the row when the agent already has a computer on the environment and vault
+you are moving the teammate to. It does not join the teammate to that
+computer. Reset or remove the computer first, then apply again.
 
 Two `Teammate` documents cannot name the same agent. An agent is on the team
 once, so the second document fails and the first one applies.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -334,7 +334,9 @@ A `Schedule` names a `teammate`. Each name resolves against the manifest
 first, then against the records your account already holds.
 
 The `metadata.name` is the key for five of the kinds. A `Webhook` is keyed by
-its `spec.url`, so the document name is a label alone.
+its `spec.url`, so the document name is a label alone. Change that URL and the
+next apply creates a second endpoint. The first one stays, and keeps
+delivering, until you delete it with `fountain webhooks delete`.
 
 ```yaml
 ---
@@ -372,8 +374,21 @@ spec:
 
 A `Teammate` document adds the agent to the team, which opens the teammate's
 conversation and starts its computer. A later apply moves the name, the
-environment and the vault the next computer is built from. It starts no
-second computer.
+environment and the vault the teammate is bound to. It starts no second
+computer.
+
+A `Teammate` document is the whole teammate. Drop `environment` or `vault`
+from it and the next apply clears that binding, which puts the teammate back
+on the agent's own environment and on no vault. The other five kinds behave
+the other way around, where an absent `spec` key leaves that field alone.
+
+A teammate's computer is built for one environment and one vault. Move either
+of them and Fountain retires that computer, so the teammate's next message
+builds a new one with the files and tools of a fresh machine. It refuses the
+row while a turn is still running there, and prints what to do about it.
+
+Two `Teammate` documents cannot name the same agent. An agent is on the team
+once, so the second document fails and the first one applies.
 
 A `Webhook` that an apply creates prints its signing secret one time. Save it
 then. An apply that updates the same endpoint prints no secret.

--- a/sdk/contract/contract.json
+++ b/sdk/contract/contract.json
@@ -8340,6 +8340,7 @@
           "enum": [
             "created",
             "error",
+            "unchanged",
             "updated"
           ],
           "required": true,
@@ -8357,6 +8358,11 @@
         },
         "name": {
           "required": true,
+          "type": "string"
+        },
+        "secret": {
+          "nullable": true,
+          "required": false,
           "type": "string"
         },
         "secrets": {
@@ -10836,7 +10842,10 @@
           "enum": [
             "Agent",
             "Environment",
-            "Vault"
+            "Schedule",
+            "Teammate",
+            "Vault",
+            "Webhook"
           ],
           "required": true,
           "type": "string"

--- a/sdk/swift/Sources/FountainKit/Client/FountainClient.swift
+++ b/sdk/swift/Sources/FountainKit/Client/FountainClient.swift
@@ -39,7 +39,8 @@ public struct FountainClient: Sendable {
     try await api.data(.get, "/api/catalog")
   }
 
-  /// Declarative bulk apply (`Environment`/`Vault`/`Agent` manifests).
+  /// Declarative bulk apply. One manifest reconciles `Environment`, `Vault`,
+  /// `Agent`, `Teammate`, `Schedule` and `Webhook` documents, in that order.
   public func apply(resources: [JSONValue]) async throws -> [ApplyResult] {
     struct Response: Decodable {
       var results: [ApplyResult]

--- a/sdk/swift/Sources/FountainKit/Models/Account.swift
+++ b/sdk/swift/Sources/FountainKit/Models/Account.swift
@@ -134,10 +134,14 @@ public struct Catalog: Sendable, Decodable {
 public struct ApplyResult: Sendable, Decodable, Hashable {
   public var kind: String
   public var name: String
-  /// `created | updated | error`.
+  /// `created | updated | unchanged | error`. `unchanged` means the record
+  /// already matched the document, so nothing was written to it.
   public var action: String
   public var errors: JSONValue?
   public var secrets: [SecretResult]?
+  /// A `Webhook` endpoint's signing secret, on the apply that created it.
+  /// Nil on every other row, and on every later apply of the same endpoint.
+  public var secret: String?
 
   public struct SecretResult: Sendable, Decodable, Hashable {
     public var key: String

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -10,6 +10,12 @@ server releases.
 
 ---
 
+## [1.21.2] — 2026-09-06
+
+### Added
+
+- Generated types cover the `Teammate`, `Schedule` and `Webhook` documents bulk apply now reconciles, the `unchanged` result action, and a webhook row's one-time `secret`.
+
 ## [1.21.1] — 2026-09-06
 
 ### Fixed

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "1.21.1",
+  "version": "1.21.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentshit/fountain-sdk",
-      "version": "1.21.1",
+      "version": "1.21.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^26.4.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "1.21.1",
+  "version": "1.21.2",
   "description": "Run a coding agent on a real computer, with your repos and your credentials, in one call.",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -559,7 +559,7 @@ export interface paths {
         put?: never;
         /**
          * Apply a compiled manifest (bulk upsert)
-         * @description Applies all resources from a compiled fountain.yml manifest in one request. Resources are reconciled in a fixed order — environments, vaults, agents, teammates, schedules, webhooks — so a spec may name another document whatever the file's order: an agent's `environment`, a teammate's `agent`, `environment` and `vault`, and a schedule's `teammate`. Every kind is keyed by the document's `name`, except `Webhook`, which is keyed by `spec.url`. A `Webhook` created here returns its signing secret once, on that result row. Apply is additive: a document dropped from the manifest leaves its record in place. Application is best-effort per resource: the response is 200 even when individual resources fail, with per-resource errors in the result entries.
+         * @description Applies all resources from a compiled fountain.yml manifest in one request. Resources are reconciled in a fixed order — environments, vaults, agents, teammates, schedules, webhooks — so a spec may name another document whatever the file's order: an agent's `environment`, a teammate's `agent`, `environment` and `vault`, and a schedule's `teammate`. Every kind is keyed by the document's `name`, except `Webhook`, which is keyed by `spec.url`. A `Webhook` created here returns its signing secret once, on that result row. A `Teammate` is read as a whole declaration, so an absent `environment` or `vault` clears that binding, and moving either retires the computer the old binding named (refused with an error on that row while a turn is running on it). Two Teammate documents may not name the same agent. Apply is additive: a document dropped from the manifest leaves its record in place. Application is best-effort per resource: the response is 200 even when an individual resource fails validation, is refused by its context or raises, with per-resource errors in the result entries.
          */
         post: operations["FountainWeb.ApplyController.create"];
         delete?: never;
@@ -2800,7 +2800,7 @@ export interface components {
         /** ApplyResult */
         ApplyResult: {
             /**
-             * @description `unchanged` means the record already matched the document, so nothing was written to it. Inline `spec.secrets` are re-encrypted on every apply and still report `upserted` under `secrets`.
+             * @description `unchanged` means the record already matched the document, so nothing was written to it and no audit event was recorded. Inline `spec.secrets` are re-encrypted on every apply and still report `upserted` under `secrets`.
              * @enum {string}
              */
             action: "created" | "updated" | "unchanged" | "error";

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -559,7 +559,7 @@ export interface paths {
         put?: never;
         /**
          * Apply a compiled manifest (bulk upsert)
-         * @description Applies all resources from a compiled fountain.yml manifest in one request. Resources are reconciled by name — environments first, then vaults, then agents — so agent specs may reference an environment by name via `spec.environment`. Application is best-effort per resource: the response is 200 even when individual resources fail, with per-resource errors in the result entries.
+         * @description Applies all resources from a compiled fountain.yml manifest in one request. Resources are reconciled in a fixed order — environments, vaults, agents, teammates, schedules, webhooks — so a spec may name another document whatever the file's order: an agent's `environment`, a teammate's `agent`, `environment` and `vault`, and a schedule's `teammate`. Every kind is keyed by the document's `name`, except `Webhook`, which is keyed by `spec.url`. A `Webhook` created here returns its signing secret once, on that result row. Apply is additive: a document dropped from the manifest leaves its record in place. Application is best-effort per resource: the response is 200 even when individual resources fail, with per-resource errors in the result entries.
          */
         post: operations["FountainWeb.ApplyController.create"];
         delete?: never;
@@ -2799,13 +2799,21 @@ export interface components {
         };
         /** ApplyResult */
         ApplyResult: {
-            /** @enum {string} */
-            action: "created" | "updated" | "error";
+            /**
+             * @description `unchanged` means the record already matched the document, so nothing was written to it. Inline `spec.secrets` are re-encrypted on every apply and still report `upserted` under `secrets`.
+             * @enum {string}
+             */
+            action: "created" | "updated" | "unchanged" | "error";
             errors?: {
                 [key: string]: unknown;
             } | null;
             kind: string;
             name: string;
+            /**
+             * @description A Webhook endpoint's HMAC-SHA256 signing secret, on the apply that created it. Store it; it is not shown again, and an update never returns it. Null on every other row.
+             * @example whsec_Zm91bnRhaW4tZXhhbXBsZS1zZWNyZXQtdmFsdWU
+             */
+            secret?: string | null;
             secrets?: components["schemas"]["ApplySecretResult"][];
         };
         /**
@@ -3900,11 +3908,11 @@ export interface components {
         };
         /**
          * ManifestResource
-         * @description One compiled document from a fountain.yml manifest. `spec` matches the create/update schema for the kind, plus an inline `secrets` map (Environment and Vault). Agent specs may reference an environment by name via `environment`; the server resolves it to `environment_id`.
+         * @description One compiled document from a fountain.yml manifest. `spec` matches the create/update schema for the kind, plus an inline `secrets` map (Environment and Vault). Specs reference other documents by name, and the server resolves each to an id: an Agent's `environment`, a Teammate's `agent`, `environment` and `vault`, and a Schedule's `teammate`. Teammate specs take `agent`, `environment` and `vault`; Schedule specs take `teammate` plus the TeamScheduleCreateRequest fields `cron`, `prompt`, `one_off` and `enabled`; Webhook specs take the WebhookEndpointCreateRequest fields `url`, `description` and `event_types`, and are keyed by `url` rather than by `name`.
          */
         ManifestResource: {
             /** @enum {string} */
-            kind: "Environment" | "Vault" | "Agent";
+            kind: "Environment" | "Vault" | "Agent" | "Teammate" | "Schedule" | "Webhook";
             name: string;
             spec?: {
                 [key: string]: unknown;

--- a/sdk/typescript/src/http.ts
+++ b/sdk/typescript/src/http.ts
@@ -19,7 +19,7 @@ export interface RequestOptions {
  * this string is already what Fountain's request logs are keyed on. The
  * version half is asserted against `package.json` by a test.
  */
-export const USER_AGENT = "fountain-sdk-js/1.21.1";
+export const USER_AGENT = "fountain-sdk-js/1.21.2";
 
 /**
  * The thin layer everything else is built on: one bearer token, JSON in and


### PR DESCRIPTION
`POST /api/apply` reconciles a manifest of `Environment`, `Vault` and `Agent` documents, and everything else a declared estate needs (team membership, schedules, webhook endpoints) had to be driven by hand through their own routes afterwards. This PR extends the manifest vocabulary so one apply reconciles the whole estate.

- Add `Teammate`, `Schedule` and `Webhook` kinds, reconciled after the existing three in that order. A Teammate resolves `agent`, `environment` and `vault` by name against the manifest first, then the tenant; a Schedule is keyed by `(teammate, name)`; a Webhook is keyed by `url` and returns its signing secret only on the apply that creates it.
- Add an `unchanged` verdict for all six kinds (#1680), so a second identical apply reports every row unchanged. The environment, vault, agent and webhook contexts now record no audit event on a no-op update, which is what the audit rules require and what schedules already did.
- Add `Team.update_teammate/4` to move a teammate's environment and vault binding. It refuses while a turn is running on the teammate's computer and retires the home the old identity named, mirroring `Agents.update_agent/3`.
- Fail a Teammate row whose reference resolves to nothing, two Teammate documents that claim the same agent, and a Schedule whose teammate name is ambiguous, each without stopping the rest of the manifest. Every per-document reconcile is now isolated from exceptions.
- Extend the OpenAPI schemas, regenerate the SDK contract and TypeScript types, update the Swift model, extend the Go CLI's kind list and legacy fallback, and document the kinds under "Bulk apply" and "Apply manifests".

Prune is left out; apply stays additive. The audit actions keep their existing names (`team.*`, `team.schedule.*`, `webhook_endpoint.*`) rather than the `webhook.*` the issue wrote.

Closes #1636
Closes #1680

Validation:

- Full suite on the four-branch stack: 4579 tests, 0 failures (core and ee), 144 (fountain_buzz), 33 (fountain_support).
- `mix compile --warnings-as-errors`, `mix format --check-formatted`, `mix credo --strict`, dialyzer, sobelow and `deps.unlock --unused` are clean. The prod release assembles.
- `go test ./...` and `go vet ./...` in `cli/`; the SDK contract check, the TypeScript and Python verifiers and the conformance lint pass. `scripts/docs-style.py` is clean.
- Not run here: vale, okf and destink (not installed on the build machine); `swift test` does not compile on this machine's toolchain on main either.

