### PR TITLE
feat(runtimes): acp runtime launches a named command with no model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,24 @@ upgrade, is in
   and `GET /api/team/:agent_id/conversations` take a repeatable `label=key:value`
   filter, combined with AND. `conversation.*` webhook payloads carry `labels`,
   and the console's conversation lists render them as chips.
+- **An `acp` runtime launches a named command, so a deterministic program can
+  run as an agent** (#1634). `agents.runtime` accepts `"acp"`, and a new
+  `runtime_command` field carries the command it runs. The field is required
+  for that runtime and a 422 naming the field on every other one, which
+  resolves its own executable from a pinned table. `model` is optional there:
+  no inference credential is resolved, no model is pinned on the session, and
+  a turn succeeds on an account that holds no API key. Fountain installs no
+  adapter for it, and the command owns its own configuration; skills still
+  mount, and their path arrives as `FOUNTAIN_SKILLS_DIR`. Everything the
+  protocol carries is unchanged, including tool-call blocks on the transcript
+  and the SSE feed, `session/cancel` on interrupt, and the agent's permission
+  policy. With `CREDITS_ENABLED` the turn is priced by sandbox time alone and
+  `turn.usage` is null.
+
+  `runtime_command` is a **free string** rather than an entry in a catalog of
+  blessed commands. It is resolved inside the sandbox, under the same
+  isolation an environment's `setup_script` already runs under, so a catalog
+  would restrict a self-hoster and protect nobody.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,18 @@ upgrade, is in
   `runtime_command` is a **free string** rather than an entry in a catalog of
   blessed commands. It is resolved inside the sandbox, under the same
   isolation an environment's `setup_script` already runs under, so a catalog
-  would restrict a self-hoster and protect nobody.
+  would restrict a self-hoster and protect nobody. On a self-hosted runner
+  with the default backend that isolation is a directory and the daemon's own
+  user, which is what trusted mode already means for a setup script; the
+  runtime docs say so beside the field.
+
+  **Client note.** `Agent.model` is now nullable, in the response and in the
+  create and update bodies, so an agent converted to `acp` can clear the
+  model it no longer uses with `{"model": null}`. In the TypeScript SDK
+  `Agent["model"]` is `string | null`, and `AgentRequest["model"]` and
+  `AgentUpdate["model"]` are `string | null` and optional. A client that
+  assumed a string needs a null check. Nothing else on the wire changed
+  shape.
 
 ### Fixed
 

--- a/apps/fountain/lib/fountain/agents.ex
+++ b/apps/fountain/lib/fountain/agents.ex
@@ -356,6 +356,7 @@ defmodule Fountain.Agents do
     :system,
     :model,
     :runtime,
+    :runtime_command,
     :sandbox_provider,
     :sandbox_mode,
     :skills,

--- a/apps/fountain/lib/fountain/agents/agent.ex
+++ b/apps/fountain/lib/fountain/agents/agent.ex
@@ -4,12 +4,17 @@ defmodule Fountain.Agents.Agent do
 
   alias Fountain.Accounts.User
   alias Fountain.Environments.Environment
+  alias Fountain.RuntimeDispatch
   alias Managoat.Runtimes.Model
 
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
 
-  @runtimes ~w(claude codex gemini opencode)
+  # `acp` is the odd one (#1634): not a coding-agent CLI but a command the
+  # agent names, launched inside the sandbox and spoken to over the same
+  # protocol. It takes a `runtime_command` and needs no model, and the other
+  # four are the reverse of both. See `Fountain.RuntimeDispatch`.
+  @runtimes ~w(claude codex gemini opencode acp)
 
   @typedoc "A persisted agent."
   @type t :: %__MODULE__{}
@@ -20,6 +25,10 @@ defmodule Fountain.Agents.Agent do
     field :system, :string, default: ""
     field :model, :string
     field :runtime, :string
+    # The command the `acp` runtime launches, as a shell line resolved inside
+    # the sandbox (#1634). Required for that runtime and refused for every
+    # other one, which resolves its own executable from a pinned table.
+    field :runtime_command, :string
     # Optional sandbox-backend override; nil inherits the instance default
     # (SANDBOX_PROVIDER) at conversation start.
     field :sandbox_provider, :string
@@ -78,6 +87,7 @@ defmodule Fountain.Agents.Agent do
       :system,
       :model,
       :runtime,
+      :runtime_command,
       :sandbox_provider,
       :sandbox_mode,
       :skills,
@@ -93,10 +103,12 @@ defmodule Fountain.Agents.Agent do
   def changeset(agent, attrs) do
     agent
     |> cast(attrs, cast_fields())
-    |> validate_required([:name, :model, :runtime])
+    |> validate_required([:name, :runtime])
     |> validate_inclusion(:runtime, runtimes())
     |> validate_fixture_account()
     |> validate_inclusion(:sandbox_mode, @sandbox_modes)
+    |> validate_model_presence()
+    |> validate_runtime_command()
     |> validate_format(:model, ~r{^[a-z0-9_-]+/[a-z0-9._-]+$},
       message: "must be in canonical provider/model_id form"
     )
@@ -124,6 +136,45 @@ defmodule Fountain.Agents.Agent do
       end)
     else
       changeset
+    end
+  end
+
+  # `model` is required for every runtime but `acp`, where it is optional and
+  # inert: that runtime resolves no inference credential, so a model would be
+  # a field nothing reads. It is still accepted, and still has to parse and
+  # name a known provider if it is given, because a value that is stored and
+  # ignored is worse than one that is refused.
+  defp validate_model_presence(changeset) do
+    if RuntimeDispatch.model_required?(get_field(changeset, :runtime)) do
+      validate_required(changeset, [:model])
+    else
+      changeset
+    end
+  end
+
+  # The command is the whole configuration of the `acp` runtime and means
+  # nothing to any other, so it is required for one and refused for the rest.
+  # Refused rather than ignored: a `runtime_command` sitting on a claude agent
+  # reads as something that runs, and nothing would ever run it.
+  defp validate_runtime_command(changeset) do
+    runtime = get_field(changeset, :runtime)
+    command = get_field(changeset, :runtime_command)
+
+    cond do
+      RuntimeDispatch.command_required?(runtime) ->
+        # `validate_required/2` trims, so a blank line is a missing command
+        # rather than one that spawns an empty shell.
+        validate_required(changeset, [:runtime_command])
+
+      is_nil(command) or String.trim(command) == "" ->
+        changeset
+
+      true ->
+        add_error(
+          changeset,
+          :runtime_command,
+          "only the acp runtime launches a command; #{runtime || "this runtime"} resolves its own"
+        )
     end
   end
 

--- a/apps/fountain/lib/fountain/agents/model_catalog.ex
+++ b/apps/fountain/lib/fountain/agents/model_catalog.ex
@@ -131,6 +131,10 @@ defmodule Fountain.Agents.ModelCatalog do
   @spec suggestions(String.t() | nil) :: [String.t()]
   def suggestions("fountain-fixture"), do: ["fixture/deterministic-v1"]
 
+  # The acp runtime resolves no inference credential and reads no model, so
+  # suggesting one would be advice to fill in a field that does nothing.
+  def suggestions("acp"), do: []
+
   def suggestions(runtime) do
     case Model.provider_for_runtime(runtime) do
       nil -> Enum.flat_map(Model.providers(), &suggestions_for_provider/1)

--- a/apps/fountain/lib/fountain/command_runtime.ex
+++ b/apps/fountain/lib/fountain/command_runtime.ex
@@ -1,0 +1,110 @@
+defmodule Fountain.CommandRuntime do
+  @moduledoc """
+  The `acp` runtime: launch the command the agent names and speak ACP to it.
+
+  Every other runtime Fountain has is a coding agent driven by a model.
+  `Managoat.Runtimes` knows four of them by name, installs a pinned adapter
+  for each and hands each one an inference credential. This one knows
+  nothing. The agent carries a `runtime_command`, Fountain runs it inside the
+  sandbox, and whatever comes back over stdio is the Agent Client Protocol
+  (ADR 0014) exactly as it is for claude or codex. That is the whole runtime.
+
+  It exists for a deterministic program that wants what Fountain gives an
+  agent and not what a model gives one. A convergent operation on a schedule,
+  inside a persistent sandbox that holds the repo and the toolchain, with the
+  run readable as a turn in a teammate's thread (#1634).
+
+  ## The name
+
+  Named for what varies, which is the command, and flat like its one sibling:
+  `Fountain.DeployedACPFixture` is the other runtime that is Fountain's
+  rather than the library's. `Managoat.Runtimes.ACP` was not available and
+  would have been wrong anyway, since that is the provisioning table saying
+  which adapter each of the four LLM runtimes reaches the protocol through.
+  `Command` alone would have read against `Managoat.Sandbox.Command`, which is
+  a struct the same call sites hold.
+
+  It lives in Fountain rather than in the library because the registry there
+  is a closed map and the field it reads (`agents.runtime_command`) is
+  Fountain's own column. `Fountain.RuntimeDispatch` is the host dispatch that
+  resolves this module for `"acp"` and delegates everything else.
+
+  ## What it does not do
+
+  There is no adapter to install, no config file to write, no bootstrap to
+  run and no credential to export. The command owns its own configuration,
+  which is the point of naming a command rather than a runtime.
+
+    * `write_config/2` and `prepare_sandbox/3` are not implemented at all, so
+      `Fountain.Conversations.Provisioning`'s `function_exported?` guards skip
+      them.
+    * `build_command/5` is not implemented either. The legacy spawn path is
+      dead for every runtime that speaks ACP, and this one always does.
+    * `default_env/2` ignores the credentials it is handed. It exports one
+      variable, `FOUNTAIN_SKILLS_DIR`, so the command can read the agent's
+      skills without knowing the layout convention below.
+
+  ## Skills still mount
+
+  A deterministic agent may read a skill the same way a model does, so the
+  ordinary skills pipeline runs. There is no CLI here with a directory of its
+  own, so the layout borrows claude-code's: inline skills are written under
+  `/home/sprite/.claude/skills`, and a github-source skill is installed by
+  skills.sh with `--agent claude-code`, which puts it in the same tree. One
+  location rather than two, and the path is exported so the command need not
+  know which one was chosen.
+
+  `Fountain.DeployedACPFixture` answers these two differently, with a private
+  root and an empty skills.sh id, and that is right for it: its changeset
+  refuses an agent that carries any skills at all, so the pair never has to
+  agree. This runtime accepts them, so the pair does.
+  """
+
+  @behaviour Managoat.Runtimes
+
+  # claude-code's tree, borrowed. skills.sh has no agent id for a command it
+  # has never heard of, and this is the layout the others copy. `skills_root/0`
+  # and `skills_sh_agent/0` have to agree or a github skill and an inline one
+  # land in different directories.
+  @skills_root "/home/sprite/.claude/skills"
+  @skills_sh_agent "claude-code"
+
+  @doc """
+  Where the command's argv comes from.
+
+  A shell line rather than a parsed argv, and always run through
+  `bash -lc`. Three reasons, all of them about the sandbox rather than about
+  us: the command is resolved against the sandbox's own PATH (a login shell
+  is what puts `~/.local/bin` and the language shims on it), an operator can
+  write `cd /srv/app && bin/agent acp` without Fountain inventing a
+  chdir field, and quoting is the shell's rule, which is the rule whoever
+  wrote the string already knows.
+
+  Returns `:error` when there is no command to run. The changeset requires
+  one for this runtime, so that means an agent deleted out from under a live
+  conversation. `Fountain.Conversations.TurnMachine.open/4` refuses the turn
+  there rather than opening one with nothing to spawn, which is what makes
+  `Fountain.RuntimeDispatch.command/2`'s match total.
+  """
+  @spec argv(map() | nil) :: {:ok, {String.t(), [String.t()]}} | :error
+  def argv(%{runtime_command: cmd}) when is_binary(cmd) do
+    case String.trim(cmd) do
+      "" -> :error
+      line -> {:ok, {"bash", ["-lc", line]}}
+    end
+  end
+
+  def argv(_agent), do: :error
+
+  @impl true
+  def skills_root, do: @skills_root
+
+  @impl true
+  def skills_sh_agent, do: @skills_sh_agent
+
+  # No inference credential, on purpose: a turn on this runtime resolves
+  # none, so an account that holds no key at all runs one. The skills path is
+  # here because the command has no convention to fall back on.
+  @impl true
+  def default_env(_agent, _inference_credentials), do: [{"FOUNTAIN_SKILLS_DIR", @skills_root}]
+end

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -2319,9 +2319,9 @@ defmodule Fountain.Conversations.ConversationServer do
   defp kick_turn(state, prompt, agent, images) do
     state = touch_activity(state)
 
-    case TurnMachine.open(state.conversation_id, state.sandbox_id, prompt) do
+    case TurnMachine.open(state.conversation_id, state.sandbox_id, prompt, agent) do
       {:ok, conv, turn} -> run_turn(state, conv, turn, prompt, agent, images)
-      :at_capacity -> state
+      refused when refused in [:at_capacity, :no_command] -> state
     end
   end
 
@@ -2470,7 +2470,7 @@ defmodule Fountain.Conversations.ConversationServer do
                       ),
                     model:
                       agent &&
-                        Managoat.Runtimes.Model.acp_model(
+                        Fountain.RuntimeDispatch.acp_model(
                           conv.runtime || agent.runtime,
                           agent.model
                         ),

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -847,7 +847,8 @@ defmodule Fountain.Conversations.ConversationServer do
       {:ok, handle} ->
         skills = (agent && agent.skills) || []
         # conv.runtime is validated-required and outlives the agent; the agent
-        # fallback only covers rows predating the runtime column.
+        # fallback only covers rows predating the runtime column. The mount is
+        # best effort and logs whatever it could not do (#1634).
         runtime = conv.runtime || (agent && agent.runtime) || "claude"
         Fountain.SandboxSkills.mount(handle, runtime, skills)
 

--- a/apps/fountain/lib/fountain/conversations/provisioning.ex
+++ b/apps/fountain/lib/fountain/conversations/provisioning.ex
@@ -815,7 +815,9 @@ defmodule Fountain.Conversations.Provisioning do
   # Install during provisioning and check the pin before opening a fresh
   # connection on a persistent sandbox. Use the runtime's env (including its
   # broker proxy) for registry access; never relax the sandbox network policy.
-  # Keyed on the conversation's runtime, matching the spawn decision.
+  # Keyed on the conversation's runtime, matching the spawn decision. The acp
+  # runtime installs nothing, since the command is whatever the environment's
+  # packages and setup script already put on the machine (#1634).
   def prepare_acp_adapter(handle, runtime, sprite_env) do
     if Fountain.RuntimeDispatch.acp_enabled?(runtime) do
       Fountain.RuntimeDispatch.install(handle, runtime, sprite_env)

--- a/apps/fountain/lib/fountain/conversations/turn_machine.ex
+++ b/apps/fountain/lib/fountain/conversations/turn_machine.ex
@@ -869,11 +869,46 @@ defmodule Fountain.Conversations.TurnMachine do
   cannot both start. Refused, not queued: nothing is written, the
   conversation stays idle and the caller sends again when the other turn
   ends.
+
+  `:no_command` is the other refusal, and it belongs to the acp runtime alone
+  (#1634). The argv there is the agent's own `runtime_command`, and a
+  conversation outlives its agent, so a live server can be asked for a turn
+  it has nothing to spawn for. Refused here, before a turn row exists, for the
+  same reason capacity is: there is no run to record, and the stage event says
+  what happened.
   """
-  @spec open(String.t(), String.t(), String.t()) ::
-          {:ok, Conversation.t(), Conversations.Turn.t()} | :at_capacity
-  def open(conversation_id, sandbox_id, prompt) do
+  @spec open(String.t(), String.t(), String.t(), map() | nil) ::
+          {:ok, Conversation.t(), Conversations.Turn.t()} | :at_capacity | :no_command
+  def open(conversation_id, sandbox_id, prompt, agent \\ nil) do
     conv = Conversations._unsafe_get_conversation!(conversation_id)
+
+    if runnable?(conv, agent),
+      do: open_turn(conv, sandbox_id, prompt),
+      else: refuse_no_command(conv)
+  end
+
+  # `RuntimeDispatch.command/2` is total for every other runtime, so the only
+  # question is whether the acp runtime's agent still carries one.
+  defp runnable?(conv, agent) do
+    not Fountain.RuntimeDispatch.command_required?(conv.runtime) or
+      match?({:ok, _}, Fountain.CommandRuntime.argv(agent))
+  end
+
+  defp refuse_no_command(conv) do
+    publish_stage(conv.id, "turn", "failed", %{
+      reason: "no_runtime_command",
+      runtime: conv.runtime,
+      message:
+        "This conversation runs the acp runtime, and the agent that carried its " <>
+          "command is gone. Create an agent with a runtime_command and start a " <>
+          "conversation on it."
+    })
+
+    :no_command
+  end
+
+  defp open_turn(conv, sandbox_id, prompt) do
+    conversation_id = conv.id
     turn_number = Conversations._unsafe_next_turn_number(conversation_id)
 
     attrs = %{
@@ -1009,6 +1044,9 @@ defmodule Fountain.Conversations.TurnMachine do
   a PTY so `isatty(0)` is true), `dir` (a workspace with a local .git) and
   `prompt_suffix` (image references for a runtime that cannot take images
   as flags).
+
+  On the acp runtime the argv is the agent's own `runtime_command` (#1634),
+  and the match below is total because `open/4` refuses a turn that has none.
   """
   @spec command(
           boolean(),
@@ -1021,7 +1059,7 @@ defmodule Fountain.Conversations.TurnMachine do
         ) :: {String.t(), [String.t()], keyword()}
   def command(acp?, conv, agent, prompt, mode, runtime_session_id, opts) do
     if acp? do
-      {c, a} = Fountain.RuntimeDispatch.command(conv.runtime)
+      {c, a} = Fountain.RuntimeDispatch.command(conv.runtime, agent)
       # The ACP `cwd` is validated in band by the agent CLI against the real
       # filesystem, so it must be the path a process inside the sandbox sees
       # — identity on hosted providers, the mapped directory on a runner

--- a/apps/fountain/lib/fountain/exports.ex
+++ b/apps/fountain/lib/fountain/exports.ex
@@ -344,6 +344,7 @@ defmodule Fountain.Exports do
         "system" => agent.system,
         "model" => agent.model,
         "runtime" => agent.runtime,
+        "runtime_command" => agent.runtime_command,
         "skills" => agent.skills,
         "mcp_servers" => agent.mcp_servers,
         "metadata" => agent.metadata,

--- a/apps/fountain/lib/fountain/runtime_dispatch.ex
+++ b/apps/fountain/lib/fountain/runtime_dispatch.ex
@@ -1,14 +1,23 @@
 defmodule Fountain.RuntimeDispatch do
   @moduledoc """
-  Host dispatch for the four packaged runtimes and the opt-in deployed ACP fixture.
+  Host dispatch for the four packaged runtimes and the two that are Fountain's.
 
-  The fixture is one fixed, account-restricted testing seam for #1611/#1007.
-  It does not register tenant-provided code or replace a packaged runtime.
+  `Fountain.DeployedACPFixture` is one fixed, account-restricted testing seam
+  for #1611/#1007. It does not register tenant-provided code or replace a
+  packaged runtime.
+
+  `Fountain.CommandRuntime` is the `acp` runtime (#1634): the agent names a
+  command, Fountain launches it inside the sandbox and speaks the protocol to
+  it. It is generally available rather than account-restricted, and it is the
+  one runtime whose command is not a property of the runtime name, which is
+  why `command/2` takes the agent.
   """
 
+  alias Fountain.CommandRuntime
   alias Fountain.DeployedACPFixture
   alias Managoat.Runtimes
   alias Managoat.Runtimes.ACP
+  alias Managoat.Runtimes.Model
 
   def for_agent(%{runtime: "fountain-fixture", user_id: user_id}) do
     if DeployedACPFixture.allowed?(user_id),
@@ -16,14 +25,31 @@ defmodule Fountain.RuntimeDispatch do
       else: {:error, "deployed ACP fixture is not enabled for this account"}
   end
 
+  def for_agent(%{runtime: "acp"}), do: {:ok, CommandRuntime}
   def for_agent(%{runtime: runtime}), do: Runtimes.for_runtime(runtime)
 
   def acp_enabled?(%{runtime: runtime}), do: acp_enabled?(runtime)
   def acp_enabled?("fountain-fixture"), do: DeployedACPFixture.enabled?()
+  def acp_enabled?("acp"), do: true
   def acp_enabled?(runtime), do: ACP.enabled?(runtime)
 
-  def command("fountain-fixture"), do: {"node", [".fountain-acp-fixture.mjs"]}
-  def command(runtime), do: ACP.command(runtime)
+  @doc """
+  Argv for the process a turn spawns.
+
+  Takes the agent as well as the runtime because the `acp` runtime's argv is
+  the agent's own `runtime_command`. The match is total by the time a spawn
+  asks: `Fountain.Conversations.TurnMachine.open/4` refuses a turn whose
+  agent has no command, before a turn row exists.
+  """
+  def command(runtime, agent \\ nil)
+
+  def command("acp", agent) do
+    {:ok, argv} = CommandRuntime.argv(agent)
+    argv
+  end
+
+  def command("fountain-fixture", _agent), do: {"node", [".fountain-acp-fixture.mjs"]}
+  def command(runtime, _agent), do: ACP.command(runtime)
 
   def cwd("fountain-fixture"), do: "/home/sprite"
   def cwd(runtime), do: ACP.cwd(runtime)
@@ -35,5 +61,36 @@ defmodule Fountain.RuntimeDispatch do
   def asks_permission?(runtime), do: ACP.asks_permission?(runtime)
 
   def install(_handle, "fountain-fixture", _env), do: :ok
+  def install(_handle, "acp", _env), do: :ok
   def install(handle, runtime, env), do: ACP.install(handle, runtime, env)
+
+  @doc """
+  The model id to pin on the ACP session, or nil to leave the runtime's own.
+
+  Always nil for `acp`. A model is optional there and nothing reads it, so
+  pinning one could only fail. That closes the pin path, which is where the
+  `model`/`failed` stage comes from for the runtimes that do drive a model.
+  """
+  def acp_model("acp", _model), do: nil
+  def acp_model(runtime, model), do: Model.acp_model(runtime, model)
+
+  @doc """
+  Whether this runtime needs a `model` on the agent.
+
+  Only `acp` does not. Every other runtime is a model driving something, and
+  an agent with no model there runs whatever that thing defaults to, which is
+  the defect `Agent.changeset/2`'s provider check exists to prevent. The
+  fixture needs one too: its changeset pins it to `fixture/deterministic-v1`.
+  """
+  def model_required?("acp"), do: false
+  def model_required?(_runtime), do: true
+
+  @doc """
+  Whether this runtime takes a `runtime_command`.
+
+  Only `acp`. On any other runtime the field would be stored, shown in the
+  console and never run, which reads as configuration and is not.
+  """
+  def command_required?("acp"), do: true
+  def command_required?(_runtime), do: false
 end

--- a/apps/fountain/lib/fountain/sandbox_skills.ex
+++ b/apps/fountain/lib/fountain/sandbox_skills.ex
@@ -11,6 +11,8 @@ defmodule Fountain.SandboxSkills do
   inside the sprite.
   """
 
+  require Logger
+
   @bundle_root "sprite_skills"
   @fountain_skill_name "fountain"
   # Every sandbox gets these, in this order: the API skill, then the team
@@ -21,11 +23,39 @@ defmodule Fountain.SandboxSkills do
   Mount `skills` (a list of inline/github maps, the agent's `skills` field)
   on the sandbox behind `handle` for the named runtime. The bundled skills
   are always prepended.
+
+  A runtime **string** is resolved here, through `Fountain.RuntimeDispatch`
+  rather than through the library's own dispatcher (#1634).
+  `Managoat.Runtimes.Skills` resolves a string through
+  `Managoat.Runtimes.for_runtime/1`, which is a closed map of the four
+  packaged runtimes and knows neither `acp` nor the deployed fixture — so
+  passing the string straight through returned
+  `{:error, "unsupported runtime: acp"}` and an acp sandbox came up with no
+  skills at all and nothing said so.
+
+  Failure is logged rather than raised, and returned for a caller that wants
+  it. A missing skill is a degraded agent, not a broken one, which is the
+  trade `Managoat.Runtimes.Skills` already makes for one skill that will not
+  install; this extends it to a runtime that cannot be resolved.
   """
   @spec mount(Managoat.Sandbox.Handle.t(), String.t() | module(), [map()] | nil) ::
           :ok | {:error, String.t()}
-  def mount(handle, runtime, skills) do
-    Managoat.Runtimes.Skills.install(handle, bundled() ++ (skills || []), runtime: runtime)
+  def mount(handle, runtime, skills) when is_binary(runtime) do
+    # `for_agent/1` takes the agent because the deployed fixture is scoped to
+    # one account. Skills are refused on a fixture agent by its own changeset,
+    # so a nil user here resolves to the refusal, which is the right answer.
+    case Fountain.RuntimeDispatch.for_agent(%{runtime: runtime, user_id: nil}) do
+      {:ok, module} ->
+        mount(handle, module, skills)
+
+      {:error, reason} ->
+        Logger.warning("skills not mounted for runtime #{runtime}: #{reason}")
+        {:error, reason}
+    end
+  end
+
+  def mount(handle, runtime_module, skills) when is_atom(runtime_module) do
+    Managoat.Runtimes.Skills.install(handle, bundled() ++ (skills || []), runtime: runtime_module)
   end
 
   @doc """

--- a/apps/fountain/lib/fountain_web/controllers/agent_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/agent_json.ex
@@ -13,6 +13,9 @@ defmodule FountainWeb.AgentJSON do
       system: a.system,
       model: a.model,
       runtime: a.runtime,
+      # The command the acp runtime launches, and null on every other one
+      # (#1634).
+      runtime_command: a.runtime_command,
       # Derived, never stored: whether this agent's runtime speaks ACP, and so
       # whether a client outside the server can render its output as protocol
       # rather than as one of the four proprietary dialects. `fountain acp`

--- a/apps/fountain/lib/fountain_web/live/agents_live/form.ex
+++ b/apps/fountain/lib/fountain_web/live/agents_live/form.ex
@@ -61,8 +61,9 @@ defmodule FountainWeb.AgentsLive.Form do
       "name" => a.name || "",
       "description" => a.description || "",
       "system" => a.system || "",
-      "model" => a.model || "anthropic/claude-sonnet-4-6",
+      "model" => a.model || default_model(a.runtime),
       "runtime" => a.runtime || "claude",
+      "runtime_command" => a.runtime_command || "",
       "sandbox_provider" => a.sandbox_provider || "",
       "sandbox_mode" => a.sandbox_mode || "ephemeral",
       "environment_id" => a.environment_id || "",
@@ -99,6 +100,24 @@ defmodule FountainWeb.AgentsLive.Form do
   end
 
   defp asks_permission?(runtime), do: ACP.asks_permission?(runtime || "claude")
+
+  # A new agent lands on claude, so it gets claude's model prefilled. An acp
+  # agent gets none: the field is optional there and nothing reads it, so a
+  # prefilled value would be a suggestion to configure something inert.
+  defp default_model("acp"), do: ""
+  defp default_model(_runtime), do: "anthropic/claude-sonnet-4-6"
+
+  defp model_required?(runtime), do: Fountain.RuntimeDispatch.model_required?(runtime || "claude")
+  defp command_runtime?(runtime), do: Fountain.RuntimeDispatch.command_required?(runtime)
+
+  # The command belongs to the acp runtime alone, and the changeset refuses it
+  # on any other. Sending nil rather than whatever the form last held is what
+  # lets someone switch an agent off acp without hitting that refusal.
+  defp runtime_command_param(params) do
+    if Fountain.RuntimeDispatch.command_required?(params["runtime"]),
+      do: params["runtime_command"],
+      else: nil
+  end
 
   defp permission_override_count(form) do
     form
@@ -390,8 +409,14 @@ defmodule FountainWeb.AgentsLive.Form do
         |> Map.put("mcp_servers", mcp_map)
         |> Map.put("permission_policy", form_to_permission_policy(params))
         |> Map.put("user_id", socket.assigns.user_id)
+        |> Map.put("runtime_command", runtime_command_param(params))
         |> nil_if_blank("environment_id")
         |> nil_if_blank("sandbox_provider")
+        |> nil_if_blank("runtime_command")
+        # Blank means "no model", which is a legal state on the acp runtime
+        # and a "can't be blank" on every other one. Left as "" it would be a
+        # format error instead, which points at the wrong thing.
+        |> nil_if_blank("model")
 
       case save(socket, attrs) do
         {:ok, socket} -> {:noreply, socket}
@@ -710,11 +735,7 @@ defmodule FountainWeb.AgentsLive.Form do
               name="agent[runtime]"
               class="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm"
             >
-              <option
-                :for={r <- ~w(claude codex gemini opencode)}
-                value={r}
-                selected={@form["runtime"] == r}
-              >
+              <option :for={r <- Agent.runtimes()} value={r} selected={@form["runtime"] == r}>
                 {r}
               </option>
             </select>
@@ -726,13 +747,30 @@ defmodule FountainWeb.AgentsLive.Form do
             value={@form["model"]}
             placeholder={model_placeholder(@form["runtime"])}
             list="model-options"
-            required
+            disabled={not model_required?(@form["runtime"])}
+            required={model_required?(@form["runtime"])}
           />
           <datalist id="model-options">
             <option :for={m <- ModelCatalog.suggestions(@form["runtime"])} value={m}></option>
           </datalist>
         </div>
         <.error_msg field="model" errors={@errors} />
+        <div :if={command_runtime?(@form["runtime"])} class="space-y-1">
+          <.input
+            id="runtime_command"
+            name="agent[runtime_command]"
+            label="Command"
+            value={@form["runtime_command"]}
+            placeholder="chant acp"
+            required
+          />
+          <.error_msg field="runtime_command" errors={@errors} />
+          <p class="text-zinc-500 text-xs">
+            The acp runtime runs this shell line inside the sandbox and speaks the Agent
+            Client Protocol to it. It needs no model and no inference key. Install the
+            program through the environment's packages or its setup script.
+          </p>
+        </div>
         <p
           :if={not Map.has_key?(@errors, "model") and unknown_model?(@form["model"])}
           class="text-zinc-500 text-xs"

--- a/apps/fountain/lib/fountain_web/live/agents_live/form.ex
+++ b/apps/fountain/lib/fountain_web/live/agents_live/form.ex
@@ -21,10 +21,7 @@ defmodule FountainWeb.AgentsLive.Form do
      |> assign(:user_id, user_id)
      |> assign(
        :missing_credential,
-       InferenceCredentials.missing_for_model(
-         user_id,
-         agent.model || "anthropic/claude-sonnet-4-6"
-       )
+       InferenceCredentials.missing_for_model(user_id, credential_model(agent))
      )
      |> assign(:credential_message, nil)
      |> assign(:envs, envs)
@@ -106,6 +103,18 @@ defmodule FountainWeb.AgentsLive.Form do
   # prefilled value would be a suggestion to configure something inert.
   defp default_model("acp"), do: ""
   defp default_model(_runtime), do: "anthropic/claude-sonnet-4-6"
+
+  # Which model the credential card asks about (#841). A new agent has none
+  # yet and lands on claude, so it is asked about claude's default. An acp
+  # agent has none and needs none, and asking its owner for an Anthropic key
+  # would claim its conversations cannot start until they set one (#1634).
+  defp credential_model(agent) do
+    cond do
+      is_binary(agent.model) -> agent.model
+      model_required?(agent.runtime) -> default_model(agent.runtime)
+      true -> nil
+    end
+  end
 
   defp model_required?(runtime), do: Fountain.RuntimeDispatch.model_required?(runtime || "claude")
   defp command_runtime?(runtime), do: Fountain.RuntimeDispatch.command_required?(runtime)
@@ -232,7 +241,13 @@ defmodule FountainWeb.AgentsLive.Form do
      |> assign(:mcp_servers, mcp_servers)
      |> assign(
        :missing_credential,
-       InferenceCredentials.missing_for_model(socket.assigns.user_id, params["model"])
+       # Keyed on the runtime, not only on the model box: picking acp must
+       # clear the card in the same render, and the box may still hold the
+       # value it had a moment ago (#1634).
+       if(model_required?(params["runtime"]),
+         do: InferenceCredentials.missing_for_model(socket.assigns.user_id, params["model"]),
+         else: nil
+       )
      )}
   end
 

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -941,6 +941,11 @@ defmodule FountainWeb.Schemas do
         system: %Schema{type: :string},
         model: %Schema{
           type: :string,
+          # Nullable so an agent converted to the acp runtime can clear the
+          # model it no longer uses. CastAndValidate runs before the
+          # changeset, so a non-nullable string here would reject the null
+          # with a 400 and leave the stale value on the row forever.
+          nullable: true,
           pattern: "^[a-z0-9_-]+/[a-z0-9._-]+$"
         },
         runtime: %Schema{type: :string, enum: Fountain.Agents.Agent.known_runtimes()},
@@ -1073,7 +1078,9 @@ defmodule FountainWeb.Schemas do
         name: %Schema{type: :string, minLength: 1, maxLength: 200},
         description: %Schema{type: :string},
         system: %Schema{type: :string},
-        model: %Schema{type: :string, pattern: "^[a-z0-9_-]+/[a-z0-9._-]+$"},
+        # Nullable for the same reason AgentRequest's is: converting an agent
+        # to the acp runtime has to be able to clear the model.
+        model: %Schema{type: :string, nullable: true, pattern: "^[a-z0-9_-]+/[a-z0-9._-]+$"},
         runtime: %Schema{type: :string, enum: Fountain.Agents.Agent.known_runtimes()},
         runtime_command: %Schema{
           type: :string,

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -755,10 +755,23 @@ defmodule FountainWeb.Schemas do
               "providers are rejected: Fountain has no credentials to export for " <>
               "them. The model id is not checked against a list, so a newly " <>
               "released model works without a Fountain release. The isolated fountain-fixture " <>
-              "runtime is the exception: it accepts only fixture/deterministic-v1.",
+              "runtime is the exception: it accepts only fixture/deterministic-v1. Null " <>
+              "on the acp runtime, which resolves no inference credential and reads no " <>
+              "model.",
+          nullable: true,
           pattern: "^[a-z0-9_-]+/[a-z0-9._-]+$"
         },
         runtime: %Schema{type: :string, enum: Fountain.Agents.Agent.known_runtimes()},
+        runtime_command: %Schema{
+          type: :string,
+          nullable: true,
+          description:
+            "The command the acp runtime launches inside the sandbox, as a shell line " <>
+              "resolved there (for example `chant acp`). Required when runtime is " <>
+              "acp, and rejected on every other runtime, which resolves its own " <>
+              "executable. A free string by design: it runs under the same isolation " <>
+              "as an environment's setup script."
+        },
         acp: %Schema{
           type: :boolean,
           readOnly: true,
@@ -878,6 +891,8 @@ defmodule FountainWeb.Schemas do
         inserted_at: %Schema{type: :string, format: :"date-time"},
         updated_at: %Schema{type: :string, format: :"date-time"}
       },
+      # `model` stays required: the response always carries the key, and the
+      # acp runtime's value for it is null rather than absent.
       required: [:id, :name, :model, :runtime]
     })
   end
@@ -929,6 +944,16 @@ defmodule FountainWeb.Schemas do
           pattern: "^[a-z0-9_-]+/[a-z0-9._-]+$"
         },
         runtime: %Schema{type: :string, enum: Fountain.Agents.Agent.known_runtimes()},
+        runtime_command: %Schema{
+          type: :string,
+          nullable: true,
+          description:
+            "The command the acp runtime launches inside the sandbox, as a shell line " <>
+              "resolved there (for example `chant acp`). Required when runtime is " <>
+              "acp, and rejected on every other runtime, which resolves its own " <>
+              "executable. A free string by design: it runs under the same isolation " <>
+              "as an environment's setup script."
+        },
         sandbox_provider: %Schema{
           type: :string,
           enum: ~w(sprites e2b daytona runner),
@@ -1027,7 +1052,10 @@ defmodule FountainWeb.Schemas do
               "non-empty list is an allowlist. The agent's own environment always passes."
         }
       },
-      required: [:name, :model, :runtime]
+      # `model` is required for every runtime but acp, which needs none. A
+      # conditional requirement is not expressible here, so the changeset is
+      # where it is enforced and a missing model is a 422 rather than a 400.
+      required: [:name, :runtime]
     })
   end
 
@@ -1047,6 +1075,16 @@ defmodule FountainWeb.Schemas do
         system: %Schema{type: :string},
         model: %Schema{type: :string, pattern: "^[a-z0-9_-]+/[a-z0-9._-]+$"},
         runtime: %Schema{type: :string, enum: Fountain.Agents.Agent.known_runtimes()},
+        runtime_command: %Schema{
+          type: :string,
+          nullable: true,
+          description:
+            "The command the acp runtime launches inside the sandbox, as a shell line " <>
+              "resolved there (for example `chant acp`). Required when runtime is " <>
+              "acp, and rejected on every other runtime, which resolves its own " <>
+              "executable. A free string by design: it runs under the same isolation " <>
+              "as an environment's setup script."
+        },
         sandbox_provider: %Schema{
           type: :string,
           enum: ~w(sprites e2b daytona runner),

--- a/apps/fountain/priv/help/agents.md
+++ b/apps/fountain/priv/help/agents.md
@@ -2,8 +2,9 @@
 
 An **Agent** is a named configuration for a single coding-agent CLI. It bundles together:
 
-- a **runtime** (`claude` / `codex` / `gemini` / `opencode`) — which binary runs in the sprite
-- a **model** (`anthropic/claude-sonnet-4-6`, `openai/gpt-5.3-codex`, `google/gemini-3.1-pro-preview`, etc.)
+- a **runtime** (`claude` / `codex` / `gemini` / `opencode`) — which binary runs in the sprite, or `acp` to run a command of your own
+- a **runtime_command** — the shell line the `acp` runtime launches, required there and rejected on the others
+- a **model** (`anthropic/claude-sonnet-4-6`, `openai/gpt-5.3-codex`, `google/gemini-3.1-pro-preview`, etc.); the `acp` runtime needs none
 - an optional **system prompt** (`system`)
 - an optional **environment** reference (`environment_id` or `environment` by name) — the sprite shape to provision
 - optional **skills** — names of bundled skills to mount into the sprite

--- a/apps/fountain/priv/repo/migrations/20260906120000_add_runtime_command_to_agents.exs
+++ b/apps/fountain/priv/repo/migrations/20260906120000_add_runtime_command_to_agents.exs
@@ -1,0 +1,31 @@
+defmodule Fountain.Repo.Migrations.AddRuntimeCommandToAgents do
+  use Ecto.Migration
+
+  @moduledoc """
+  The command the `acp` runtime launches (#1634).
+
+  Every other runtime resolves its own executable from a pinned table, so the
+  column is null for all of them and required for `acp` alone. The value is a
+  free string, deliberately: it is resolved inside the sandbox, under the same
+  isolation an agent's `setup_script` already runs under, so a catalogue of
+  blessed commands would buy nothing and would stop a self-hoster running
+  their own program.
+
+  Text rather than a bounded varchar. A command may be a whole shell line
+  ("cd /srv/app && bin/agent acp"), and the changeset is where a length rule
+  belongs if one is ever wanted.
+
+  `model` loses its NOT NULL in the same migration. It is required for every
+  runtime that drives one and meaningless for this one, and that difference
+  is a rule about the pair of columns rather than about either alone, so it
+  belongs in `Fountain.Agents.Agent.changeset/2` where both are in hand. The
+  column stays for every existing row.
+  """
+
+  def change do
+    alter table(:agents) do
+      add :runtime_command, :text
+      modify :model, :string, null: true, from: {:string, null: false}
+    end
+  end
+end

--- a/apps/fountain/test/fixtures/acp_agent.exs
+++ b/apps/fountain/test/fixtures/acp_agent.exs
@@ -1,0 +1,118 @@
+# A deterministic ACP agent, as a real program (#1634).
+#
+# This is what the `acp` runtime is for: not a model, just something that
+# reads the Agent Client Protocol on stdin and answers it on stdout. It runs
+# as its own OS process under `elixir`, uses OTP's own `:json` and depends on
+# nothing else, so `conversation_server_acp_fixture_test.exs` drives a whole
+# turn against a program rather than against a mock of one.
+#
+# One turn: `initialize`, `session/new`, then a `session/prompt` answered with
+# a tool call, its completion, a message and a stop reason. A prompt whose
+# text contains "ask" requests permission first and does as it is told.
+
+defmodule FixtureAcpAgent do
+  def run do
+    case IO.read(:stdio, :line) do
+      line when is_binary(line) ->
+        line |> String.trim() |> dispatch()
+        run()
+
+      _eof_or_error ->
+        :ok
+    end
+  end
+
+  defp dispatch(""), do: :ok
+
+  defp dispatch(line) do
+    case :json.decode(line) do
+      %{"method" => method, "id" => id, "params" => params} -> request(method, id, params)
+      %{"id" => id, "result" => result} -> answer(id, result)
+      _other -> :ok
+    end
+  rescue
+    _ -> :ok
+  end
+
+  defp request("initialize", id, _params) do
+    reply(id, %{"protocolVersion" => 1, "agentCapabilities" => %{"loadSession" => false}})
+  end
+
+  defp request("session/new", id, _params) do
+    reply(id, %{"sessionId" => "fixture-session"})
+  end
+
+  defp request("session/prompt", id, params) do
+    Process.put(:prompt_id, id)
+
+    if params |> inspect() |> String.contains?("ask") do
+      # Wait for the client's verdict before doing anything.
+      write(%{
+        "jsonrpc" => "2.0",
+        "id" => 1,
+        "method" => "session/request_permission",
+        "params" => %{
+          "sessionId" => "fixture-session",
+          "toolCall" => %{"title" => "converge", "kind" => "execute"},
+          "options" => [
+            %{"optionId" => "go", "kind" => "allow_once"},
+            %{"optionId" => "stop", "kind" => "reject_once"}
+          ]
+        }
+      })
+    else
+      converge()
+      reply(id, %{"stopReason" => "end_turn"})
+    end
+  end
+
+  defp request(_method, _id, _params), do: :ok
+
+  # The only response this agent asks for is the permission verdict.
+  defp answer(1, %{"outcome" => %{"optionId" => "go"}}) do
+    converge()
+    reply(Process.get(:prompt_id), %{"stopReason" => "end_turn"})
+  end
+
+  defp answer(1, _result) do
+    reply(Process.get(:prompt_id), %{"stopReason" => "refusal"})
+  end
+
+  defp answer(_id, _result), do: :ok
+
+  defp converge do
+    update(%{
+      "sessionUpdate" => "tool_call",
+      "toolCallId" => "converge",
+      "title" => "lifecycle apply",
+      "kind" => "execute",
+      "status" => "pending"
+    })
+
+    update(%{
+      "sessionUpdate" => "tool_call_update",
+      "toolCallId" => "converge",
+      "status" => "completed"
+    })
+
+    update(%{
+      "sessionUpdate" => "agent_message_chunk",
+      "content" => %{"type" => "text", "text" => "converged 3 resources"}
+    })
+  end
+
+  defp update(payload) do
+    write(%{
+      "jsonrpc" => "2.0",
+      "method" => "session/update",
+      "params" => %{"sessionId" => "fixture-session", "update" => payload}
+    })
+  end
+
+  defp reply(nil, _result), do: :ok
+  defp reply(id, result), do: write(%{"jsonrpc" => "2.0", "id" => id, "result" => result})
+
+  defp write(message), do: IO.puts(:json.encode(message))
+end
+
+FixtureAcpAgent.run()

--- a/apps/fountain/test/fountain/agents/agent_test.exs
+++ b/apps/fountain/test/fountain/agents/agent_test.exs
@@ -20,7 +20,7 @@ defmodule Fountain.Agents.AgentTest do
 
   describe "runtimes/0" do
     test "returns the expected list of runtimes" do
-      assert Agent.runtimes() == ~w(claude codex gemini opencode)
+      assert Agent.runtimes() == ~w(claude codex gemini opencode acp)
     end
   end
 
@@ -46,6 +46,78 @@ defmodule Fountain.Agents.AgentTest do
       changeset = Agent.changeset(%Agent{}, Map.delete(@valid_attrs, :runtime))
       refute changeset.valid?
       assert "can't be blank" in errors_on(changeset).runtime
+    end
+  end
+
+  describe "changeset/2 — the acp runtime (#1634)" do
+    @acp_attrs %{name: "converger", runtime: "acp", runtime_command: "chant acp"}
+
+    test "a command and no model is valid" do
+      changeset = Agent.changeset(%Agent{}, @acp_attrs)
+      assert changeset.valid?
+      assert get_change(changeset, :runtime_command) == "chant acp"
+      assert is_nil(get_change(changeset, :model))
+    end
+
+    test "a whole shell line is a legal command" do
+      attrs = %{@acp_attrs | runtime_command: "cd /srv/app && ./bin/agent acp --env prod"}
+      assert Agent.changeset(%Agent{}, attrs).valid?
+    end
+
+    test "no runtime_command names the field" do
+      changeset = Agent.changeset(%Agent{}, Map.delete(@acp_attrs, :runtime_command))
+      refute changeset.valid?
+      assert "can't be blank" in errors_on(changeset).runtime_command
+    end
+
+    test "a blank runtime_command names the field" do
+      changeset = Agent.changeset(%Agent{}, %{@acp_attrs | runtime_command: "   "})
+      refute changeset.valid?
+      assert "can't be blank" in errors_on(changeset).runtime_command
+    end
+
+    test "a model is optional but still has to parse and name a known provider" do
+      assert Agent.changeset(%Agent{}, Map.put(@acp_attrs, :model, "anthropic/x")).valid?
+      refute Agent.changeset(%Agent{}, Map.put(@acp_attrs, :model, "nope")).valid?
+
+      changeset = Agent.changeset(%Agent{}, Map.put(@acp_attrs, :model, "anthopic/x"))
+      refute changeset.valid?
+      assert Enum.any?(errors_on(changeset).model, &(&1 =~ "unknown provider"))
+    end
+
+    for runtime <- ~w(claude codex gemini opencode) do
+      test "runtime_command on the #{runtime} runtime names the field" do
+        attrs =
+          Map.merge(@valid_attrs, %{
+            runtime: unquote(runtime),
+            model: @model_for[unquote(runtime)],
+            runtime_command: "chant acp"
+          })
+
+        changeset = Agent.changeset(%Agent{}, attrs)
+        refute changeset.valid?
+        assert Enum.any?(errors_on(changeset).runtime_command, &(&1 =~ "only the acp runtime"))
+      end
+    end
+
+    test "a model is still required on every other runtime" do
+      changeset = Agent.changeset(%Agent{}, Map.delete(@valid_attrs, :model))
+      refute changeset.valid?
+      assert "can't be blank" in errors_on(changeset).model
+    end
+
+    test "switching an agent off acp clears the command it no longer takes" do
+      {:ok, agent} =
+        Fountain.Agents.create_agent(Map.put(@acp_attrs, :user_id, insert_verified_user().id))
+
+      # Left in place, the stored command is refused for the new runtime.
+      refute Agent.changeset(agent, %{runtime: "claude", model: "anthropic/x"}).valid?
+
+      assert Agent.changeset(agent, %{
+               runtime: "claude",
+               model: "anthropic/x",
+               runtime_command: nil
+             }).valid?
     end
   end
 

--- a/apps/fountain/test/fountain/conversations/conversation_server_acp_fixture_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_acp_fixture_test.exs
@@ -1,0 +1,142 @@
+defmodule Fountain.Conversations.ConversationServerAcpFixtureTest do
+  @moduledoc """
+  Conformance: a whole turn against a real ACP program (#1634).
+
+  Every other test in this tree hand-feeds the protocol, so it proves what
+  Fountain does with bytes it wrote itself. This one runs
+  `test/fixtures/acp_agent.exs` as its own OS process, hands its stdio to a
+  `ConversationServer` through `Fountain.FixtureAcpProcess`, and asserts on
+  what lands in the transcript. Nothing in the loop knows the program, and
+  the program knows nothing about Fountain.
+
+  It is the acp runtime end to end: an agent that names a command, a turn
+  with no model and no inference credential, tool-call and message blocks on
+  the feed, the stop reason closing the turn, and a permission request the
+  agent's policy answers.
+  """
+
+  use Fountain.ConversationServerCase
+
+  alias Fountain.Conversations.Blocks
+
+  defp launch(prompt, agent_overrides \\ []) do
+    user = insert_verified_user()
+
+    agent =
+      insert_agent(
+        Keyword.merge(
+          [
+            user_id: user.id,
+            runtime: "acp",
+            # `elixir` is on PATH inside the test VM, and the fixture is what
+            # `FixtureAcpProcess` actually runs; the string is here so the
+            # agent is configured the way a real one would be.
+            runtime_command: "elixir #{Fountain.FixtureAcpProcess.fixture_path()}"
+          ],
+          agent_overrides
+        )
+      )
+
+    conv = insert_conversation(agent: agent, user_id: user.id)
+
+    stub_happy_sprite()
+
+    Mimic.stub(Fountain.Conversations.TitleGenerator, :generate, fn _prompt, _creds ->
+      {:error, :stubbed_in_test}
+    end)
+
+    _ref = Fountain.FixtureAcpProcess.stub_spawn()
+
+    {pid, _mon, :alive} =
+      start_server(conv, initial_prompt: prompt, runtime: Fountain.CommandRuntime)
+
+    on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+
+    {conv, pid}
+  end
+
+  # The agent is a separate OS process, so there is nothing to synchronise on
+  # but the result. Poll the row the turn writes.
+  defp await_turn(conv_id, status, timeout \\ 15_000) do
+    deadline = System.monotonic_time(:millisecond) + timeout
+    await_turn(conv_id, status, deadline, nil)
+  end
+
+  defp await_turn(conv_id, status, deadline, last) do
+    turn = conv_id |> Conversations._unsafe_list_turns() |> List.first()
+
+    cond do
+      turn && turn.status == status ->
+        turn
+
+      System.monotonic_time(:millisecond) > deadline ->
+        flunk("turn never reached #{status}; last was #{inspect(last || turn)}")
+
+      true ->
+        Process.sleep(50)
+        await_turn(conv_id, status, deadline, turn)
+    end
+  end
+
+  defp blocks(conv_id) do
+    conv_id
+    |> Conversations._unsafe_list_log_events()
+    |> Enum.filter(&(&1.stream == "acp"))
+    |> Enum.flat_map(&Blocks.for_event(&1, "acp"))
+  end
+
+  describe "a real ACP program, driven to completion" do
+    test "the turn completes on the agent's stop reason, with its blocks on the feed" do
+      {conv, _pid} = launch("converge the fleet")
+
+      turn = await_turn(conv.id, "completed")
+
+      # No model was pinned and no token figure came back, so metering has
+      # sandbox time and nothing else.
+      assert is_nil(turn.usage)
+      refute is_nil(turn.ended_at)
+
+      blocks = blocks(conv.id)
+      assert Enum.any?(blocks, &(&1.kind == :tool_use and &1.name == "lifecycle apply"))
+      assert Enum.any?(blocks, &(&1.kind == :tool_result and &1.tool_id == "converge"))
+      assert Enum.any?(blocks, &(&1.kind == :text and &1.body =~ "converged 3 resources"))
+
+      assert Conversations._unsafe_get_conversation!(conv.id).status == "idle"
+
+      assert Conversations._unsafe_get_conversation!(conv.id).runtime_session_id ==
+               "fixture-session"
+    end
+
+    test "protocol chatter stays off the transcript" do
+      {conv, _pid} = launch("converge the fleet")
+      _turn = await_turn(conv.id, "completed")
+
+      events = Conversations._unsafe_list_log_events(conv.id)
+      refute Enum.any?(events, &(is_binary(&1.data) and &1.data =~ "protocolVersion"))
+    end
+
+    test "a permission request the policy denies ends the turn without a human" do
+      # The fixture asks before it converges when the prompt mentions "ask",
+      # and answers a denial with a `refusal` stop reason.
+      {conv, _pid} =
+        launch("ask before you converge", permission_policy: %{"execute" => "auto_deny"})
+
+      turn = await_turn(conv.id, "failed")
+      assert is_nil(turn.pending_permission)
+
+      # Denied, so the fixture never ran its tool call.
+      refute Enum.any?(blocks(conv.id), &(&1.kind == :tool_use))
+    end
+
+    test "a permission request the policy allows lets the program carry on" do
+      {conv, _pid} =
+        launch("ask before you converge", permission_policy: %{"execute" => "auto_allow"})
+
+      _turn = await_turn(conv.id, "completed")
+
+      blocks = blocks(conv.id)
+      assert Enum.any?(blocks, &(&1.kind == :tool_use and &1.name == "lifecycle apply"))
+      assert Enum.any?(blocks, &(&1.kind == :text and &1.body =~ "converged 3 resources"))
+    end
+  end
+end

--- a/apps/fountain/test/fountain/conversations/conversation_server_acp_runtime_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_acp_runtime_test.exs
@@ -137,7 +137,7 @@ defmodule Fountain.Conversations.ConversationServerAcpRuntimeTest do
       assert :ok = RuntimeDispatch.install(nil, "acp", [])
       assert is_nil(RuntimeDispatch.acp_model("acp", nil))
       # Even when a model was set anyway: it is inert, so it is never pinned
-      # and `model.failed` cannot happen.
+      # and the pin path that reports `model`/`failed` is unreachable.
       assert is_nil(RuntimeDispatch.acp_model("acp", "anthropic/claude-sonnet-4-6"))
     end
 

--- a/apps/fountain/test/fountain/conversations/conversation_server_acp_runtime_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_acp_runtime_test.exs
@@ -1,0 +1,407 @@
+defmodule Fountain.Conversations.ConversationServerAcpRuntimeTest do
+  @moduledoc """
+  A turn on the `acp` runtime (#1634), through a real `ConversationServer`.
+
+  The protocol half is already pinned by `conversation_server_acp_test.exs`
+  and is the same code here. What this file pins is what is different: the
+  command the agent named is what gets spawned, no inference credential is
+  resolved and no model is pinned, the stop reason still ends the turn with a
+  null usage, `session/cancel` still reaches the process, and
+  `session/request_permission` still honours the agent's policy.
+  """
+
+  use Fountain.ConversationServerCase
+
+  alias Fountain.Agents.Agent
+  alias Fountain.RuntimeDispatch
+
+  @command "chant acp --env prod"
+
+  defp acp_agent(user, overrides \\ []) do
+    insert_agent(
+      Keyword.merge([user_id: user.id, runtime: "acp", runtime_command: @command], overrides)
+    )
+  end
+
+  # The same wiring `conversation_server_acp_test.exs` uses: every byte the
+  # server writes to stdin arrives here as `{:wrote, line}`, and the command's
+  # ref is ours so a test can feed stdout back.
+  #
+  # `decrypted_for_user` is left at `stub_happy_sprite/1`'s empty map on
+  # purpose. This runtime must run a turn on an account that holds no
+  # inference credential at all.
+  defp start_acp_turn(conv) do
+    stub_happy_sprite()
+
+    Mimic.stub(Fountain.Conversations.TitleGenerator, :generate, fn _prompt, _creds ->
+      {:error, :stubbed_in_test}
+    end)
+
+    test = self()
+    ref = make_ref()
+
+    Mimic.stub(Managoat.Sandbox.Sprites, :spawn, fn _h, cmd, args, opts ->
+      send(test, {:spawned, cmd, args, opts})
+      {:ok, %Managoat.Sandbox.Command{provider: :sprites, ref: ref}}
+    end)
+
+    Mimic.stub(Managoat.Sandbox.Sprites, :close_stdin, fn _c ->
+      send(test, :stdin_closed)
+      :ok
+    end)
+
+    Mimic.stub(Managoat.Sandbox.Sprites, :stop_command, fn _c ->
+      send(test, :command_stopped)
+      :ok
+    end)
+
+    Mimic.stub(Managoat.Sandbox.Sprites, :write_stdin, fn _c, data ->
+      send(test, {:wrote, IO.iodata_to_binary(data)})
+      :ok
+    end)
+
+    {pid, _mon, :alive} =
+      start_server(conv, initial_prompt: "converge", runtime: Fountain.CommandRuntime)
+
+    on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+
+    {pid, ref}
+  end
+
+  defp next_write do
+    assert_receive {:wrote, line}, 1_000
+    Jason.decode!(line)
+  end
+
+  defp reply(pid, ref, id, result) do
+    line = Jason.encode!(%{"jsonrpc" => "2.0", "id" => id, "result" => result}) <> "\n"
+    send(pid, {:stdout, %{ref: ref}, line})
+    settle(pid)
+  end
+
+  defp notify(pid, ref, update) do
+    line =
+      Jason.encode!(%{
+        "jsonrpc" => "2.0",
+        "method" => "session/update",
+        "params" => %{"sessionId" => "sess_1", "update" => update}
+      }) <> "\n"
+
+    send(pid, {:stdout, %{ref: ref}, line})
+    settle(pid)
+  end
+
+  # See the note on `settle/1` in conversation_server_acp_test.exs: a report
+  # crosses three mailboxes, and the peer may already be gone.
+  defp settle(pid) do
+    peer = :sys.get_state(pid).acp_peer
+
+    if is_pid(peer) do
+      try do
+        _ = :sys.get_state(peer)
+      catch
+        :exit, _ -> :ok
+      end
+    end
+
+    _ = :sys.get_state(pid)
+    :ok
+  end
+
+  defp drive_to_prompt(pid, ref) do
+    %{"id" => init_id, "method" => "initialize"} = next_write()
+    reply(pid, ref, init_id, %{"agentCapabilities" => %{"loadSession" => true}})
+
+    %{"id" => new_id, "method" => "session/new"} = next_write()
+    reply(pid, ref, new_id, %{"sessionId" => "sess_1"})
+
+    %{"id" => prompt_id, "method" => "session/prompt"} = next_write()
+    settle(pid)
+    prompt_id
+  end
+
+  describe "the runtime" do
+    test "acp is a runtime an agent may name, and it speaks the protocol" do
+      assert "acp" in Agent.runtimes()
+      assert RuntimeDispatch.acp_enabled?("acp")
+      assert {:ok, Fountain.CommandRuntime} = RuntimeDispatch.for_agent(%{runtime: "acp"})
+    end
+
+    test "the packaged runtimes still resolve to their own modules" do
+      assert {:ok, Managoat.Runtimes.Claude} = RuntimeDispatch.for_agent(%{runtime: "claude"})
+      assert {:ok, Managoat.Runtimes.OpenCode} = RuntimeDispatch.for_agent(%{runtime: "opencode"})
+      assert {:error, _} = RuntimeDispatch.for_agent(%{runtime: "nonesuch"})
+    end
+
+    test "there is no adapter to install and no model to pin" do
+      assert :ok = RuntimeDispatch.install(nil, "acp", [])
+      assert is_nil(RuntimeDispatch.acp_model("acp", nil))
+      # Even when a model was set anyway: it is inert, so it is never pinned
+      # and `model.failed` cannot happen.
+      assert is_nil(RuntimeDispatch.acp_model("acp", "anthropic/claude-sonnet-4-6"))
+    end
+
+    test "the command comes from the agent, and a missing one is answerable" do
+      assert :error = Fountain.CommandRuntime.argv(nil)
+      assert :error = Fountain.CommandRuntime.argv(%{runtime_command: "   "})
+
+      assert {:ok, {"bash", ["-lc", "run me"]}} =
+               Fountain.CommandRuntime.argv(%{runtime_command: "run me"})
+
+      assert {"bash", ["-lc", "run me"]} =
+               RuntimeDispatch.command("acp", %{runtime_command: "run me"})
+    end
+
+    test "no inference credential env reaches the command" do
+      env =
+        Fountain.CommandRuntime.default_env(
+          %{model: "anthropic/claude-sonnet-4-6"},
+          %{anthropic_api_key: "sk-live", openai_api_key: "sk-openai"}
+        )
+
+      refute Enum.any?(env, fn {_k, v} -> v =~ "sk-" end)
+      assert {"FOUNTAIN_SKILLS_DIR", "/home/sprite/.claude/skills"} in env
+    end
+  end
+
+  describe "spawn" do
+    setup do
+      user = insert_verified_user()
+      conv = insert_conversation(agent: acp_agent(user), user_id: user.id)
+      {pid, ref} = start_acp_turn(conv)
+      {:ok, user: user, conv: conv, pid: pid, ref: ref}
+    end
+
+    test "runs the agent's own command as a shell line inside the sandbox" do
+      assert_receive {:spawned, "env", ["FOUNTAIN_CONVERSATION_ID=" <> _ | argv], opts}
+      assert argv == ["bash", "-lc", @command]
+      assert opts[:stdin] == true
+    end
+
+    test "writes initialize rather than the prompt, exactly as the LLM runtimes do" do
+      assert %{"method" => "initialize"} = next_write()
+    end
+
+    test "session/new carries no model to pin", %{pid: pid, ref: ref} do
+      %{"id" => init_id} = next_write()
+      reply(pid, ref, init_id, %{"agentCapabilities" => %{"loadSession" => true}})
+
+      assert %{"method" => "session/new", "params" => params} = next_write()
+      refute Map.has_key?(params, "model")
+    end
+  end
+
+  describe "a full turn on an account with no inference credential" do
+    setup do
+      user = insert_verified_user()
+      conv = insert_conversation(agent: acp_agent(user), user_id: user.id)
+      {pid, ref} = start_acp_turn(conv)
+      {:ok, user: user, conv: conv, pid: pid, ref: ref}
+    end
+
+    test "blocks reach the transcript and the stop reason closes the turn", %{
+      conv: conv,
+      pid: pid,
+      ref: ref
+    } do
+      prompt_id = drive_to_prompt(pid, ref)
+
+      notify(pid, ref, %{
+        "sessionUpdate" => "tool_call",
+        "toolCallId" => "t1",
+        "title" => "lifecycle apply",
+        "kind" => "execute",
+        "status" => "pending"
+      })
+
+      notify(pid, ref, %{
+        "sessionUpdate" => "tool_call_update",
+        "toolCallId" => "t1",
+        "status" => "completed"
+      })
+
+      notify(pid, ref, %{
+        "sessionUpdate" => "agent_message_chunk",
+        "content" => %{"type" => "text", "text" => "3 resources converged"}
+      })
+
+      reply(pid, ref, prompt_id, %{"stopReason" => "end_turn"})
+
+      events = Conversations._unsafe_list_log_events(conv.id)
+      acp_events = Enum.filter(events, &(&1.stream == "acp"))
+
+      blocks = Enum.flat_map(acp_events, &Fountain.Conversations.Blocks.for_event(&1, "acp"))
+      assert Enum.any?(blocks, &(&1.kind == :tool_use and &1.name == "lifecycle apply"))
+      assert Enum.any?(blocks, &(&1.kind == :tool_result and &1.tool_id == "t1"))
+      assert Enum.any?(blocks, &(&1.kind == :text and &1.body =~ "converged"))
+
+      assert [turn] = Conversations._unsafe_list_turns(conv.id)
+      assert turn.status == "completed"
+      refute is_nil(turn.ended_at)
+      assert Conversations._unsafe_get_conversation!(conv.id).status == "idle"
+    end
+
+    test "the turn carries no usage, so nothing prices it by tokens", %{
+      conv: conv,
+      pid: pid,
+      ref: ref
+    } do
+      prompt_id = drive_to_prompt(pid, ref)
+      reply(pid, ref, prompt_id, %{"stopReason" => "end_turn"})
+
+      assert [%{usage: nil}] = Conversations._unsafe_list_turns(conv.id)
+
+      conv = Conversations._unsafe_get_conversation!(conv.id)
+      assert conv.usage_input_tokens == 0
+      assert conv.usage_output_tokens == 0
+    end
+
+    test "the model selection reports that nothing was requested", %{
+      conv: conv,
+      pid: pid,
+      ref: ref
+    } do
+      prompt_id = drive_to_prompt(pid, ref)
+      reply(pid, ref, prompt_id, %{"stopReason" => "end_turn"})
+
+      stages =
+        conv.id
+        |> Conversations._unsafe_list_log_events()
+        |> Enum.filter(&(&1.kind == "stage" and &1.stage == "model"))
+
+      # Every turn reports its selection. This runtime pins nothing, so the
+      # report is "the runtime's own", and the failed state that a refused
+      # pin produces is unreachable here.
+      assert [%{state: "done"} = selected] = stages
+      assert %{"requested_model" => nil, "status" => "selected"} = Jason.decode!(selected.data)
+      refute Enum.any?(stages, &(&1.state == "failed"))
+    end
+
+    test "a refusal stop reason still ends the turn", %{conv: conv, pid: pid, ref: ref} do
+      prompt_id = drive_to_prompt(pid, ref)
+      reply(pid, ref, prompt_id, %{"stopReason" => "refusal"})
+
+      assert [turn] = Conversations._unsafe_list_turns(conv.id)
+      refute turn.status == "running"
+      assert Conversations._unsafe_get_conversation!(conv.id).status == "idle"
+    end
+  end
+
+  describe "interrupt" do
+    test "reaches the command as session/cancel and ends the turn interrupted" do
+      user = insert_verified_user()
+      conv = insert_conversation(agent: acp_agent(user), user_id: user.id)
+      {pid, ref} = start_acp_turn(conv)
+      _prompt_id = drive_to_prompt(pid, ref)
+
+      assert :ok = GenServer.call(pid, :interrupt)
+
+      assert %{"method" => "session/cancel", "params" => %{"sessionId" => "sess_1"}} =
+               next_write()
+
+      assert_receive :stdin_closed, 1_000
+      assert_receive :command_stopped, 1_000
+
+      assert [turn] = Conversations._unsafe_list_turns(conv.id)
+      assert turn.status == "interrupted"
+    end
+  end
+
+  describe "an agent deleted under a live conversation" do
+    test "refuses the turn rather than spawning nothing" do
+      user = insert_verified_user()
+      agent = acp_agent(user)
+      conv = insert_conversation(agent: agent, user_id: user.id)
+
+      # Deleting an agent nilifies its conversations' pointer, and the command
+      # lived on the agent. Every other runtime resolves its argv from a table
+      # and carries on; this one has nothing left to run.
+      {:ok, _} = Fountain.Agents.delete_agent(agent)
+
+      {pid, _ref} = start_acp_turn(conv)
+
+      # No turn row, the way a sandbox at capacity opens none, and a stage
+      # event on the feed saying why.
+      assert [] = Conversations._unsafe_list_turns(conv.id)
+      refute_receive {:spawned, _cmd, _args, _opts}, 200
+
+      stage =
+        conv.id
+        |> Conversations._unsafe_list_log_events()
+        |> Enum.find(&(&1.kind == "stage" and &1.stage == "turn" and &1.state == "failed"))
+
+      assert stage.data =~ "no_runtime_command"
+      assert Process.alive?(pid)
+    end
+  end
+
+  describe "permission requests" do
+    test "a request from the command is held and rendered, and the answer goes back" do
+      user = insert_verified_user()
+      agent = acp_agent(user, permission_policy: %{"execute" => "ask"})
+      conv = insert_conversation(agent: agent, user_id: user.id)
+      {pid, ref} = start_acp_turn(conv)
+      _init = next_write()
+
+      line =
+        Jason.encode!(%{
+          "jsonrpc" => "2.0",
+          "id" => 401,
+          "method" => "session/request_permission",
+          "params" => %{
+            "toolCall" => %{"title" => "lifecycle apply", "kind" => "execute"},
+            "options" => [
+              %{"optionId" => "yes", "kind" => "allow_once"},
+              %{"optionId" => "no", "kind" => "reject_once"}
+            ]
+          }
+        }) <> "\n"
+
+      send(pid, {:stdout, %{ref: ref}, line})
+      settle(pid)
+
+      request_id = :sys.get_state(pid).current_turn.pending_permission["request_id"]
+      assert request_id =~ ~r/^401\./
+
+      blocks =
+        conv.id
+        |> Conversations._unsafe_list_log_events()
+        |> Enum.filter(&(&1.stream == "acp"))
+        |> Enum.flat_map(&Fountain.Conversations.Blocks.for_event(&1, "acp"))
+
+      assert block = Enum.find(blocks, &(&1.kind == :permission_request))
+      assert block.name == "lifecycle apply"
+
+      assert :ok = GenServer.call(pid, {:answer_permission, request_id, "yes"})
+      assert %{"id" => 401, "result" => %{"outcome" => %{"optionId" => "yes"}}} = next_write()
+    end
+
+    test "an auto_deny policy answers without asking anybody" do
+      user = insert_verified_user()
+      agent = acp_agent(user, permission_policy: %{"execute" => "auto_deny"})
+      conv = insert_conversation(agent: agent, user_id: user.id)
+      {pid, ref} = start_acp_turn(conv)
+      _init = next_write()
+
+      line =
+        Jason.encode!(%{
+          "jsonrpc" => "2.0",
+          "id" => 402,
+          "method" => "session/request_permission",
+          "params" => %{
+            "toolCall" => %{"title" => "rm -rf /", "kind" => "execute"},
+            "options" => [
+              %{"optionId" => "yes", "kind" => "allow_once"},
+              %{"optionId" => "no", "kind" => "reject_once"}
+            ]
+          }
+        }) <> "\n"
+
+      send(pid, {:stdout, %{ref: ref}, line})
+      settle(pid)
+
+      assert %{"id" => 402, "result" => %{"outcome" => %{"optionId" => "no"}}} = next_write()
+      assert is_nil(:sys.get_state(pid).current_turn.pending_permission)
+    end
+  end
+end

--- a/apps/fountain/test/fountain/exports_test.exs
+++ b/apps/fountain/test/fountain/exports_test.exs
@@ -139,7 +139,9 @@ defmodule Fountain.ExportsTest do
       doc = export.payload |> :zlib.gunzip() |> Jason.decode!()
 
       assert doc["account"]["email"] == user.email
-      assert [%{"name" => "export-agent"}] = doc["agents"]
+      assert [%{"name" => "export-agent"} = agent_doc] = doc["agents"]
+      # Every config field an agent carries, so an export is a restorable copy.
+      assert Map.has_key?(agent_doc, "runtime_command")
 
       assert [env_doc] = doc["environments"]
       assert env_doc["name"] == "export-env"

--- a/apps/fountain/test/fountain/sandbox_skills_test.exs
+++ b/apps/fountain/test/fountain/sandbox_skills_test.exs
@@ -36,6 +36,46 @@ defmodule Fountain.SandboxSkillsTest do
     assert_receive {:wrote, "/home/sprite/.claude/skills/mine/SKILL.md"}
   end
 
+  # #1634: the string used to be forwarded to the library's own dispatcher,
+  # which is a closed map of the four LLM runtimes. It answered
+  # {:error, "unsupported runtime: acp"} and the sandbox came up with no
+  # skills at all, silently.
+  test "mount/3 resolves the acp runtime through Fountain.Runtimes" do
+    test = self()
+
+    stub(Managoat.Sandbox, :write_file, fn @handle, path, _body ->
+      send(test, {:wrote, path})
+      :ok
+    end)
+
+    assert :ok = SandboxSkills.mount(@handle, "acp", [%{"name" => "mine", "content" => "# m"}])
+
+    root = Fountain.CommandRuntime.skills_root()
+    assert_receive {:wrote, ^root <> "/fountain/SKILL.md"}
+    assert_receive {:wrote, ^root <> "/create-team/SKILL.md"}
+    assert_receive {:wrote, ^root <> "/mine/SKILL.md"}
+  end
+
+  test "a module is passed straight through to the library" do
+    test = self()
+    stub(Managoat.Sandbox, :write_file, fn _h, path, _b -> send(test, {:wrote, path}) && :ok end)
+
+    assert :ok = SandboxSkills.mount(@handle, Fountain.CommandRuntime, nil)
+    assert_receive {:wrote, "/home/sprite/.claude/skills/fountain/SKILL.md"}
+  end
+
+  test "a runtime nothing implements is logged and returned, never silent" do
+    reject(&Managoat.Sandbox.write_file/3)
+
+    log =
+      ExUnit.CaptureLog.capture_log(fn ->
+        assert {:error, reason} = SandboxSkills.mount(@handle, "nonesuch", [])
+        assert reason =~ "unsupported runtime"
+      end)
+
+    assert log =~ "skills not mounted for runtime nonesuch"
+  end
+
   test "a nil skills list mounts the bundled skills alone" do
     test = self()
     stub(Managoat.Sandbox, :write_file, fn _h, path, _b -> send(test, {:wrote, path}) && :ok end)

--- a/apps/fountain/test/fountain_web/controllers/agent_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/agent_controller_test.exs
@@ -70,6 +70,47 @@ defmodule FountainWeb.AgentControllerTest do
       end
     end
 
+    # A non-nullable model in the request schema made this a 400 from
+    # CastAndValidate, before the changeset ever saw it, so a converted agent
+    # kept a provider/model it no longer uses forever (#1634).
+    test "converts an agent to acp and clears the model it no longer uses", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
+      agent = insert_agent(user_id: user.id, runtime: "claude")
+
+      conn =
+        conn
+        |> authed_with_key(raw_key)
+        |> put_json("/api/agents/#{agent.id}", %{
+          runtime: "acp",
+          model: nil,
+          runtime_command: "chant acp"
+        })
+
+      body = json_response(conn, 200)
+      assert body["data"]["runtime"] == "acp"
+      assert body["data"]["runtime_command"] == "chant acp"
+      assert is_nil(body["data"]["model"])
+      assert is_nil(Fountain.Agents.get_agent(agent.id, user.id).model)
+    end
+
+    test "a null model on a model-driven runtime is a 422 naming the field", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
+      agent = insert_agent(user_id: user.id, runtime: "claude")
+
+      conn =
+        conn
+        |> authed_with_key(raw_key)
+        |> put_json("/api/agents/#{agent.id}", %{model: nil})
+
+      assert json_response(conn, 422)["errors"]["model"] == ["can't be blank"]
+    end
+
     test "returns 404 when the agent belongs to a different user", %{conn: conn, raw_key: raw_key} do
       other_user = insert_verified_user()
       other_agent = insert_agent(user_id: other_user.id)

--- a/apps/fountain/test/fountain_web/controllers/agent_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/agent_controller_test.exs
@@ -108,6 +108,71 @@ defmodule FountainWeb.AgentControllerTest do
       assert json_response(conn, 401)
     end
 
+    test "creates an acp agent from a command, with no model (#1634)", %{
+      conn: conn,
+      raw_key: raw_key
+    } do
+      payload = %{name: "converger", runtime: "acp", runtime_command: "chant acp --env prod"}
+
+      conn =
+        conn
+        |> authed_with_key(raw_key)
+        |> post_json("/api/agents", payload)
+
+      body = json_response(conn, 201)
+      assert body["data"]["runtime"] == "acp"
+      assert body["data"]["runtime_command"] == "chant acp --env prod"
+      assert is_nil(body["data"]["model"])
+      assert body["data"]["acp"] == true
+    end
+
+    test "returns 422 naming runtime_command when an acp agent has none", %{
+      conn: conn,
+      raw_key: raw_key
+    } do
+      conn =
+        conn
+        |> authed_with_key(raw_key)
+        |> post_json("/api/agents", %{name: "converger", runtime: "acp"})
+
+      body = json_response(conn, 422)
+      assert body["errors"]["runtime_command"] == ["can't be blank"]
+    end
+
+    test "returns 422 naming runtime_command when another runtime carries one", %{
+      conn: conn,
+      raw_key: raw_key
+    } do
+      payload = %{
+        name: "confused",
+        model: "anthropic/claude-sonnet-4-6",
+        runtime: "claude",
+        runtime_command: "chant acp"
+      }
+
+      conn =
+        conn
+        |> authed_with_key(raw_key)
+        |> post_json("/api/agents", payload)
+
+      body = json_response(conn, 422)
+      assert [message] = body["errors"]["runtime_command"]
+      assert message =~ "only the acp runtime"
+    end
+
+    test "returns 422 naming model when a model-driven runtime has none", %{
+      conn: conn,
+      raw_key: raw_key
+    } do
+      conn =
+        conn
+        |> authed_with_key(raw_key)
+        |> post_json("/api/agents", %{name: "modelless", runtime: "claude"})
+
+      body = json_response(conn, 422)
+      assert body["errors"]["model"] == ["can't be blank"]
+    end
+
     test "returns 422 when a skill entry has neither content nor source", %{
       conn: conn,
       raw_key: raw_key

--- a/apps/fountain/test/fountain_web/controllers/conversation_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/conversation_controller_test.exs
@@ -715,6 +715,35 @@ defmodule FountainWeb.ConversationControllerTest do
       assert conn.status == 204
     end
 
+    # The acp runtime carries no special case at this door, and that is the
+    # claim (#1634). The other half of the path, `:interrupt` becoming a
+    # `session/cancel` on the command and an `interrupted` turn, is pinned in
+    # conversation_server_acp_runtime_test.exs against a live server.
+    test "an acp conversation interrupts through the same door", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
+      agent = insert_agent(user_id: user.id, runtime: "acp", runtime_command: "chant acp")
+      conv = insert_conversation(user_id: user.id, agent: agent)
+      assert conv.runtime == "acp"
+
+      test = self()
+
+      stub(ConversationServer, :interrupt, fn id, _opts ->
+        send(test, {:interrupted, id}) && :ok
+      end)
+
+      conn =
+        conn
+        |> authed_with_key(raw_key)
+        |> post("/api/conversations/#{conv.id}/interrupt")
+
+      assert conn.status == 204
+      assert_receive {:interrupted, id}
+      assert id == conv.id
+    end
+
     # Ownership is established before the server is asked, so "not running" is
     # a state conflict on a conversation the caller can see, not a missing one
     # (#1179 — the owner of a stuck conversation got a 404 saying it was the

--- a/apps/fountain/test/fountain_web/live/agents_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/agents_live_test.exs
@@ -180,6 +180,77 @@ defmodule FountainWeb.AgentsLive.IndexTest do
     end
   end
 
+  describe "the acp runtime in the console (#1634)" do
+    test "the command field appears when the runtime is acp, and saves", %{conn: conn} do
+      user = insert_verified_user()
+      conn = login_user(conn, user)
+
+      {:ok, view, html} = live(conn, ~p"/agents/new")
+      refute html =~ "agent[runtime_command]"
+
+      html =
+        view
+        |> element("form[phx-change=validate]")
+        |> render_change(%{"agent" => %{"name" => "converger", "runtime" => "acp"}})
+
+      assert html =~ "agent[runtime_command]"
+      assert html =~ "It needs no model and no inference key"
+
+      view
+      |> form("form", %{
+        "agent" => %{
+          "name" => "converger",
+          "runtime" => "acp",
+          "runtime_command" => "chant acp --env prod"
+        }
+      })
+      |> render_submit()
+
+      agent = Fountain.Agents.get_agent_by_name("converger", user.id)
+      assert agent.runtime == "acp"
+      assert agent.runtime_command == "chant acp --env prod"
+      assert is_nil(agent.model)
+    end
+
+    test "switching an acp agent onto a model runtime drops the command", %{conn: conn} do
+      user = with_credential(insert_verified_user())
+
+      agent =
+        insert_agent(user_id: user.id, runtime: "acp", runtime_command: "chant acp")
+
+      conn = login_user(conn, user)
+
+      {:ok, view, html} = live(conn, ~p"/agents/#{agent.id}/edit")
+      # The model field is inert on this runtime, so the form disables it.
+      assert html =~ ~s(name="agent[model]")
+      assert html =~ "disabled"
+
+      # Picking a model runtime re-renders the form: the model comes back and
+      # the command goes away, which is what the browser does on change.
+      html =
+        view
+        |> element("form[phx-change=validate]")
+        |> render_change(%{"agent" => %{"name" => agent.name, "runtime" => "claude"}})
+
+      refute html =~ "agent[runtime_command]"
+
+      view
+      |> form("form", %{
+        "agent" => %{
+          "name" => agent.name,
+          "runtime" => "claude",
+          "model" => "anthropic/claude-sonnet-5"
+        }
+      })
+      |> render_submit()
+
+      reloaded = Fountain.Agents.get_agent(agent.id, user.id)
+      assert reloaded.runtime == "claude"
+      assert reloaded.model == "anthropic/claude-sonnet-5"
+      assert is_nil(reloaded.runtime_command)
+    end
+  end
+
   describe "edit" do
     test "renders edit form for existing agent", %{conn: conn} do
       user = insert_verified_user()

--- a/apps/fountain/test/fountain_web/live/agents_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/agents_live_test.exs
@@ -195,6 +195,10 @@ defmodule FountainWeb.AgentsLive.IndexTest do
 
       assert html =~ "agent[runtime_command]"
       assert html =~ "It needs no model and no inference key"
+      # The model field is inert here, so it is disabled and nobody is asked
+      # for a key to run it.
+      assert has_element?(view, "input#model[disabled]")
+      refute html =~ "credential on this account yet"
 
       view
       |> form("form", %{
@@ -222,8 +226,11 @@ defmodule FountainWeb.AgentsLive.IndexTest do
 
       {:ok, view, html} = live(conn, ~p"/agents/#{agent.id}/edit")
       # The model field is inert on this runtime, so the form disables it.
-      assert html =~ ~s(name="agent[model]")
-      assert html =~ "disabled"
+      assert has_element?(view, "input#model[disabled]")
+
+      # And on first paint its owner is not asked for an Anthropic key to run
+      # an agent that needs none (#1634).
+      refute html =~ "credential on this account yet"
 
       # Picking a model runtime re-renders the form: the model comes back and
       # the command goes away, which is what the browser does on change.

--- a/apps/fountain/test/support/factory.ex
+++ b/apps/fountain/test/support/factory.ex
@@ -251,20 +251,26 @@ defmodule Fountain.Factory do
         "name" => "agent-#{uniq()}",
         # The changeset requires the provider prefix to match the runtime
         # (#553), so a call site that overrides only :runtime still gets a
-        # model its runtime can actually reach.
+        # model its runtime can actually reach. The acp runtime is the
+        # inverse: no model at all, and a command instead (#1634).
         "model" => default_model_for(runtime),
         "runtime" => runtime,
         "skills" => [],
         "mcp_servers" => %{},
         "metadata" => %{}
-      },
+      }
+      |> Map.merge(default_command_for(runtime)),
       overrides
     )
   end
 
   defp default_model_for("codex"), do: "openai/gpt-5.3-codex"
   defp default_model_for("gemini"), do: "google/gemini-3.1-pro-preview"
+  defp default_model_for("acp"), do: nil
   defp default_model_for(_runtime), do: "anthropic/claude-sonnet-4-6"
+
+  defp default_command_for("acp"), do: %{"runtime_command" => "fixture-agent"}
+  defp default_command_for(_runtime), do: %{}
 
   def insert_agent(overrides \\ %{}) do
     overrides = to_string_map(overrides)

--- a/apps/fountain/test/support/fixture_acp_process.ex
+++ b/apps/fountain/test/support/fixture_acp_process.ex
@@ -1,0 +1,117 @@
+defmodule Fountain.FixtureAcpProcess do
+  @moduledoc """
+  Run a fixture ACP agent as a real OS process, framed as a sandbox command.
+
+  `Managoat.Sandbox.Fake` speaks a scripted instruction vocabulary rather than
+  running programs, so it cannot host an agent that has to read what the
+  client wrote and answer it. This does the smallest thing that can: a port to
+  `test/fixtures/acp_agent.exs`, and a relay that turns the port's frames into
+  the `{:stdout | :exit, %{ref: ref}, _}` messages `Managoat.Sandbox` promises
+  a command's owner.
+
+  It is the test sandbox provider for one purpose (#1634): proving that a
+  `ConversationServer` drives a whole turn against a program it did not write,
+  over the same stdio the four LLM runtimes use. Everything else about the
+  sandbox stays stubbed by `Fountain.ConversationServerCase`.
+  """
+
+  @fixture "acp_agent.exs"
+
+  @doc """
+  Stub `Managoat.Sandbox.Sprites`'s streaming calls onto a real fixture agent.
+
+  Returns the ref every frame from it will carry. The relay is started here
+  and opens its port when the spawn arrives, so it can send to that spawn's
+  `:owner` (the conversation server) without anybody knowing the pid first.
+  """
+  @spec stub_spawn() :: reference()
+  def stub_spawn do
+    ref = make_ref()
+    relay = spawn(fn -> await_start(ref) end)
+
+    # The conversation server does not stop its command on terminate, so
+    # without this the fixture's own OS process would outlive the test.
+    ExUnit.Callbacks.on_exit(fn -> send(relay, :stop) end)
+
+    Mimic.stub(Managoat.Sandbox.Sprites, :spawn, fn _handle, _cmd, _args, opts ->
+      send(relay, {:start, Keyword.fetch!(opts, :owner)})
+      {:ok, %Managoat.Sandbox.Command{provider: :sprites, ref: ref}}
+    end)
+
+    Mimic.stub(Managoat.Sandbox.Sprites, :write_stdin, fn _command, data ->
+      send(relay, {:write, IO.iodata_to_binary(data)})
+      :ok
+    end)
+
+    # A port has no half-close, and this turn ends on the stop reason rather
+    # than on EOF, so the close is a no-op and `stop_command/1` is what ends
+    # the process.
+    Mimic.stub(Managoat.Sandbox.Sprites, :close_stdin, fn _command -> :ok end)
+
+    Mimic.stub(Managoat.Sandbox.Sprites, :stop_command, fn _command ->
+      send(relay, :stop)
+      :ok
+    end)
+
+    ref
+  end
+
+  @doc "Absolute path of the checked-in fixture agent."
+  @spec fixture_path() :: String.t()
+  def fixture_path, do: Path.expand(Path.join([__DIR__, "..", "fixtures", @fixture]))
+
+  # Unlinked, and it waits rather than opening the port eagerly: writes that
+  # somehow arrive first stay in the mailbox until the loop reaches them.
+  defp await_start(ref) do
+    receive do
+      {:start, owner} ->
+        port =
+          Port.open({:spawn_executable, elixir_executable()}, [
+            :binary,
+            :exit_status,
+            :use_stdio,
+            {:line, 1_000_000},
+            {:args, [fixture_path()]}
+          ])
+
+        relay(port, owner, ref)
+
+      :stop ->
+        :ok
+    end
+  end
+
+  defp elixir_executable do
+    System.find_executable("elixir") ||
+      raise "elixir is not on PATH; the fixture ACP agent cannot run"
+  end
+
+  defp relay(port, owner, ref) do
+    receive do
+      {:write, data} ->
+        Port.command(port, data)
+        relay(port, owner, ref)
+
+      :stop ->
+        safe_close(port)
+        send(owner, {:exit, %{ref: ref}, 0})
+
+      {^port, {:data, {:eol, line}}} ->
+        send(owner, {:stdout, %{ref: ref}, line <> "\n"})
+        relay(port, owner, ref)
+
+      {^port, {:data, {:noeol, chunk}}} ->
+        send(owner, {:stdout, %{ref: ref}, chunk})
+        relay(port, owner, ref)
+
+      {^port, {:exit_status, code}} ->
+        send(owner, {:exit, %{ref: ref}, code})
+    end
+  end
+
+  defp safe_close(port) do
+    Port.close(port)
+  catch
+    _, _ -> :ok
+  end
+end

--- a/docs/build/index.md
+++ b/docs/build/index.md
@@ -74,7 +74,7 @@ bearer token.
 | You write | Fountain does |
 |---|---|
 | The roster, the thread, the composer. | Provisions and holds one sandbox for each teammate. |
-| The name of a bot, and how it looks. | Starts `claude`, `codex`, `gemini` or `opencode` in it. |
+| The name of a bot, and how it looks. | Starts `claude`, `codex`, `gemini` or `opencode` in it, or the command that an `acp` agent names. |
 | Which connectors you offer. | Encrypts the tokens, injects them at spawn, and redacts them from the output. |
 | Your own sign-in, or none. | Accounts, API keys, OAuth, isolation for each user, quota, audit. |
 | What a routine is for. | Runs it on a cron. |

--- a/docs/catalog/runtimes/gemini.md
+++ b/docs/catalog/runtimes/gemini.md
@@ -27,7 +27,7 @@ then use the agent definition below.
 
 You want a Gemini model in particular. That is the whole case.
 
-All four runtimes speak ACP, so the transport no longer decides this. Choose
+Every runtime speaks ACP, so the transport no longer decides this. Choose
 [opencode](opencode.md) instead to move one agent definition between
 providers.
 

--- a/docs/catalog/runtimes/index.md
+++ b/docs/catalog/runtimes/index.md
@@ -51,7 +51,7 @@ metadata:
   name: converger
 spec:
   runtime: acp
-  runtime_command: chant acp --env prod
+  runtime_command: exec chant acp --env prod
   environment: chant-toolchain
 ```
 
@@ -59,7 +59,14 @@ Five things follow from that.
 
 - **The command is a shell line.** Fountain runs it inside the sandbox with
   the login shell, so the sandbox's own `PATH` resolves it and
-  `cd /srv/app && ./bin/agent acp` is a legal value.
+  `cd /srv/app && exec ./bin/agent acp` is a legal value. Write `exec` before
+  the program. Without it the shell stays as the parent, and an interrupt
+  stops the shell and can leave the program running on a persistent sandbox.
+- **Nothing may print on stdout before the program starts.** The login shell
+  reads your profiles first. A profile that writes a banner puts those bytes
+  in front of the first protocol message, and the turn fails on a line the
+  client cannot read. Send that output to stderr, or guard it on an
+  interactive shell.
 - **You install the program.** Name it in the environment's packages, or in
   the environment's setup script. Fountain installs no adapter for this
   runtime.
@@ -74,6 +81,13 @@ Five things follow from that.
 The field is a free string rather than an entry in a catalog. It runs inside
 the sandbox, under the same isolation as an environment's setup script, so a
 catalog would restrict a self-hoster and protect nobody.
+
+**Know what that isolation is on a runner.** On a hosted sandbox provider it
+is a machine of its own. On `sandbox_provider: runner` with the default
+backend it is a directory, and the command runs as the daemon's user with the
+host's `PATH` and network. Read
+[trusted mode](../../integrations/runners.md#read-this-first-trusted-mode)
+before you name a command there.
 
 With credits on, a turn on this runtime is priced by sandbox time. There is no
 token count to record, so `usage` on the turn is null.

--- a/docs/catalog/runtimes/index.md
+++ b/docs/catalog/runtimes/index.md
@@ -1,11 +1,11 @@
 # Runtimes
 
-A runtime is the coding-agent CLI that a sandbox runs. It is one field on an
-[Agent](../../concepts/agent.md). It decides which provider's credential that
-agent needs, how skills land on disk, and where Fountain writes the system
-prompt.
+A runtime is what a sandbox runs. For four of the five it is a coding-agent
+CLI. It is one field on an [Agent](../../concepts/agent.md), and it decides
+which provider's credential that agent needs, how skills land on disk, and
+where Fountain writes the system prompt.
 
-## All four
+## The five
 
 | Runtime | Provider | Transport | Multi-provider |
 |---|---|---|---|
@@ -13,6 +13,7 @@ prompt.
 | [codex](codex.md) | `openai` | ACP | No |
 | [opencode](opencode.md) | Any of the three | ACP | **Yes** |
 | [gemini](gemini.md) | `google` | ACP, through `gemini --acp` | No |
+| `acp` | None | ACP, through the command you name | Not applicable |
 
 ## How to choose
 
@@ -26,10 +27,56 @@ providers. Read
 is the only multi-provider runtime. It takes the canonical `provider/model-id`
 string word for word, then reads the prefix to decide which key to export.
 
-**All four speak ACP.** Gemini was the last one off it, and it joined on
-2026-08-22. So editor integration, the permission flow and the shared block
-format reach every runtime. The choice is about the provider and the CLI
+**Choose `acp` to run a program instead of a model.** The agent names a
+command in `runtime_command`, Fountain launches it inside the sandbox, and it
+speaks the protocol back. There is no model, no inference credential and no
+adapter to install. A deterministic operation that wants a warm machine, a
+vault, a thread and a schedule is what this is for. Read
+[Running a program as an agent](#running-a-program-as-an-agent).
+
+**Every runtime speaks ACP.** Gemini was the last CLI onto it, and it joined
+on 2026-08-22. So editor integration, the permission flow and the shared block
+format reach every runtime. The choice is about the provider and the program
 rather than about the transport.
+
+## Running a program as an agent
+
+The `acp` runtime takes one extra field. Set it in the console, in a manifest
+you send with `fountain apply`, or on `POST /api/agents`.
+
+```yaml
+apiVersion: fountain.dev/v1
+kind: Agent
+metadata:
+  name: converger
+spec:
+  runtime: acp
+  runtime_command: chant acp --env prod
+  environment: chant-toolchain
+```
+
+Five things follow from that.
+
+- **The command is a shell line.** Fountain runs it inside the sandbox with
+  the login shell, so the sandbox's own `PATH` resolves it and
+  `cd /srv/app && ./bin/agent acp` is a legal value.
+- **You install the program.** Name it in the environment's packages, or in
+  the environment's setup script. Fountain installs no adapter for this
+  runtime.
+- **`model` is optional, and it does nothing.** Fountain resolves no inference
+  credential, so a turn runs on an account that holds no API key at all.
+- **`runtime_command` is a 422 on each other runtime.** Those resolve their
+  own executable from a pinned table, and a command there would never run.
+- **Everything else is unchanged.** Skills mount, MCP servers reach the
+  session, `session/cancel` reaches the process on an interrupt, and the
+  permission policy holds for each `session/request_permission` that arrives.
+
+The field is a free string rather than an entry in a catalog. It runs inside
+the sandbox, under the same isolation as an environment's setup script, so a
+catalog would restrict a self-hoster and protect nobody.
+
+With credits on, a turn on this runtime is priced by sandbox time. There is no
+token count to record, so `usage` on the turn is null.
 
 ## The rule that catches people
 
@@ -67,10 +114,15 @@ different paths.
 | `codex` | `/home/sprite/.codex/skills` | `codex` | `~/.codex/AGENTS.md` |
 | `opencode` | `/tmp/.config/opencode/skills` | `opencode` | `~/.config/opencode/AGENTS.md` |
 | `gemini` | `/tmp/.gemini/skills` | `gemini-cli` | `~/.gemini/GEMINI.md` |
+| `acp` | `/home/sprite/.claude/skills` | `claude-code` | None |
+
+The `acp` runtime has no CLI of its own, so it borrows claude-code's layout
+for skills and gets the path as `FOUNTAIN_SKILLS_DIR` in its environment. It
+reads no system prompt file, because the command owns its own configuration.
 
 ## Related
 
 - [About agents](../../concepts/agent.md), where you set `runtime`.
 - [Skills](../skills/index.md).
-- [`fountain acp`](../../integrations/acp.md), the adapter that drives all
-  four from an editor or a chat surface.
+- [`fountain acp`](../../integrations/acp.md), the adapter that drives each of
+  them from an editor or a chat surface.

--- a/docs/concepts/agent.md
+++ b/docs/concepts/agent.md
@@ -10,11 +10,11 @@ An Agent is a named configuration for a coding agent that you can run again
 and again. It is config, and not a process. Nothing runs until a
 [Conversation](conversation.md) runs it.
 
-An Agent decides eight things.
+An Agent decides nine things.
 
 - **`model`**, as `provider/model-id`. An example is
   `anthropic/claude-sonnet-5`.
-- **`runtime`**, one of `claude`, `codex`, `gemini` or `opencode`.
+- **`runtime`**, one of `claude`, `codex`, `gemini`, `opencode` or `acp`.
 - **`environment`**, an optional [Environment](environment.md) to start from.
 - **`system`** and **`description`**, the system prompt and a summary that a
   person reads.
@@ -24,6 +24,8 @@ An Agent decides eight things.
 - **`metadata`**, a free-form map for your own records.
 - **`sandbox_mode`**, `ephemeral` or `persistent`. Read
   [About sandboxes](sandboxes.md).
+- **`runtime_command`**, the command that the `acp` runtime launches. It is
+  null on each other runtime.
 
 ## Why it exists
 
@@ -40,7 +42,8 @@ This asymmetry surprises people, and it is deliberate.
 
 The provider must match the runtime. Use `anthropic` for `claude`, `openai`
 for `codex`, and `google` for `gemini`. `opencode` takes any of the three, and
-the prefix picks which API key to export.
+the prefix picks which API key to export. `acp` takes none, because it runs a
+program rather than a model.
 
 Fountain rejects a provider outside that set at write time. It holds no
 credential for such a provider. A sandbox from that config would start with no
@@ -67,6 +70,9 @@ reattach.
 | `codex` | `~/.codex/AGENTS.md` |
 | `opencode` | `~/.config/opencode/AGENTS.md` |
 | `gemini` | `~/.gemini/GEMINI.md` |
+
+The `acp` runtime has no such file, and Fountain writes none. The command owns
+its own configuration.
 
 Fountain rewrites the file on reattach. An edit to an Agent's system prompt
 therefore reaches a sandbox that already exists, the next time that sandbox
@@ -159,6 +165,6 @@ launch.
 - [Agents as teammates](teammates.md), which is one Conversation for each
   Agent.
 - [About environments](environment.md), which an Agent names.
-- [Runtimes](../catalog/runtimes/index.md), with all four compared.
+- [Runtimes](../catalog/runtimes/index.md), compared.
 - [Skills](../catalog/skills/index.md), and the two that each sandbox gets.
 - [Glossary](../reference/glossary.md), for the three senses of "agent".

--- a/docs/concepts/permissions.md
+++ b/docs/concepts/permissions.md
@@ -82,6 +82,7 @@ Some rules keep that safe.
 | codex | Yes | Measured on codex-acp 1.1.14. |
 | opencode | **No** | It decides this in its own server, and sends nothing. Fountain refuses a policy stricter than `auto_allow` on this runtime, with 422 `permission_policy_unenforceable` ([#959](https://github.com/BinaryBourbon/fountain/issues/959)). |
 | gemini | Yes | Measured on gemini 0.53 with `gemini-2.5-flash`. Google removed that model for new API keys after this measurement. Its option ids are its own (`proceed_once`, `cancel`), so answer with an id from the request, never a name you know from another runtime. |
+| acp | If the command does | Fountain runs the command that the agent names, and the command decides whether to send `session/request_permission`. Fountain assumes that it does, so a policy is accepted and enforced on each request that arrives. A command that never asks gets no protection from a policy, and Fountain has no way to know that in advance. |
 
 ## An "always" answer does not always hold
 
@@ -94,6 +95,7 @@ decides how long its own grant lasts, and the three runtimes disagree.
 | claude | It writes a rule to a file in the sandbox. The rule holds for later turns. |
 | codex | `Allow for Session` lasts the whole sandbox wake (#817). The option that amends the command policy goes to a file, and it holds. |
 | opencode | This runtime never asks, so it grants nothing. |
+| acp | The command decides. Fountain sends the option id that the command offered, and keeps no record of the answer. |
 
 Every grant lives inside the sandbox. A new sandbox starts with none of them.
 

--- a/docs/integrations/acp.md
+++ b/docs/integrations/acp.md
@@ -182,7 +182,7 @@ terminal.
 | Message | Meaning |
 |---|---|
 | `no Fountain agent configured` | The entry has no `--agent`. |
-| `agent "x" runs the … runtime, which does not speak ACP` | All four runtimes speak ACP. This names a conversation whose runtime column holds a name that no adapter covers. Use that agent from the conversations app, or with `fountain run`. |
+| `agent "x" runs the … runtime, which does not speak ACP` | Every runtime Fountain ships speaks ACP. This names a conversation whose runtime column holds a name that no adapter covers. Use that agent from the conversations app, or with `fountain run`. |
 | `credentials for … were rejected` | Run `fountain auth login`. The message names the instance it tried, and that is usually the surprise. |
 | `could not resolve agent "x" on …` | The wrong name, or the right name on a different instance. |
 | `the sandbox never started: …` | The provision failed, and the reason belongs to the sandbox provider. |

--- a/docs/integrations/editors.md
+++ b/docs/integrations/editors.md
@@ -199,7 +199,7 @@ terminal.
 | Message | Meaning |
 |---|---|
 | `no Fountain agent configured` | The entry has no `--agent`. |
-| `agent "x" runs the … runtime, which does not speak ACP` | All four runtimes speak ACP. This names a conversation whose runtime column holds a name that no adapter covers. |
+| `agent "x" runs the … runtime, which does not speak ACP` | Every runtime Fountain ships speaks ACP. This names a conversation whose runtime column holds a name that no adapter covers. |
 | `credentials for … were rejected` | Run `fountain auth login`. The message names the instance it tried, and that is usually the surprise. |
 | `could not resolve agent "x" on …` | The wrong name, or the right name on a different instance. |
 

--- a/docs/integrations/openclaw.md
+++ b/docs/integrations/openclaw.md
@@ -284,7 +284,7 @@ fountain acp --agent researcher --log-level debug
 | Message | Meaning |
 |---|---|
 | `no Fountain agent configured` | The entry has no `--agent`. |
-| `agent "x" runs the … runtime, which does not speak ACP` | All four runtimes speak ACP. This names a conversation whose runtime column holds a name that no adapter covers. |
+| `agent "x" runs the … runtime, which does not speak ACP` | Every runtime Fountain ships speaks ACP. This names a conversation whose runtime column holds a name that no adapter covers. |
 | `credentials for … were rejected` | Run `fountain auth login` on the host. The message names the instance it tried. |
 | `could not resolve agent "x" on …` | The wrong name, or the right name on a different instance. |
 

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -66,7 +66,7 @@ on. The docs say **sandbox**.
 | **MCP server** | A Model Context Protocol server that an Agent gives its runtime. You declare it in `mcp_servers`. |
 | **Reaper** | The background sweep that suspends an idle sandbox, and destroys one that passed a configured ceiling. |
 | **Runner** | A machine you own that runs `fountain runner` and acts as a sandbox provider. Read [Self-hosted runners](../integrations/runners.md). |
-| **Runtime** | The coding-agent CLI that a sandbox runs. One of `claude`, `codex`, `gemini`, `opencode`. |
+| **Runtime** | What a sandbox runs. One of `claude`, `codex`, `gemini`, `opencode`, which are coding-agent CLIs, or `acp`, which is a command the Agent names. |
 | **Sandbox** | The isolated machine that a Conversation runs in. Several Conversations can share one. Fountain provisions it at launch and reclaims it on the lifetime rules. `GET /api/sandboxes` lists them. |
 | **Sandbox provider** | A backend that Fountain provisions sandboxes on. Sprites, E2B, Daytona, or a self-hosted runner. Read [the sandbox contract](../integrations/sandbox-contract.md). |
 | **Skill** | A `SKILL.md` that Fountain writes into the sandbox, inline or from GitHub. |

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -177,8 +177,9 @@ Here are the fields that need a word.
 
 | Field | What it decides |
 |---|---|
-| `runtime` | `claude`, `codex`, `gemini` or `opencode`. The provider in `model` must match it. |
-| `model` | The canonical `provider/model_id`. Fountain checks it against no list, so a model that ships today works today. |
+| `runtime` | `claude`, `codex`, `gemini`, `opencode` or `acp`. The provider in `model` must match it, and `acp` needs no model at all. |
+| `runtime_command` | The command that the `acp` runtime launches. It is a shell line, and Fountain resolves it inside the sandbox. The field is required for `acp`, and a 422 on each other runtime. |
+| `model` | The canonical `provider/model_id`. Fountain checks it against no list, so a model that ships today works today. Leave it out on `acp`. |
 | `system` | The agent's system prompt. |
 | `skills` | Either `{ source, ref? }`, which installs from GitHub, or `{ name, content }`, which Fountain writes into the sandbox word for word. Each entry takes exactly one shape. |
 | `sandbox_provider` | `sprites`, `e2b`, `daytona` or `runner`. A `null` takes the instance default. |

--- a/sdk/contract/contract.json
+++ b/sdk/contract/contract.json
@@ -7887,6 +7887,7 @@
           "type": "object"
         },
         "model": {
+          "nullable": true,
           "required": true,
           "type": "string"
         },
@@ -7909,6 +7910,7 @@
         },
         "runtime": {
           "enum": [
+            "acp",
             "claude",
             "codex",
             "fountain-fixture",
@@ -7916,6 +7918,11 @@
             "opencode"
           ],
           "required": true,
+          "type": "string"
+        },
+        "runtime_command": {
+          "nullable": true,
+          "required": false,
           "type": "string"
         },
         "sandbox_mode": {
@@ -8027,7 +8034,7 @@
           "type": "object"
         },
         "model": {
-          "required": true,
+          "required": false,
           "type": "string"
         },
         "name": {
@@ -8049,6 +8056,7 @@
         },
         "runtime": {
           "enum": [
+            "acp",
             "claude",
             "codex",
             "fountain-fixture",
@@ -8056,6 +8064,11 @@
             "opencode"
           ],
           "required": true,
+          "type": "string"
+        },
+        "runtime_command": {
+          "nullable": true,
+          "required": false,
           "type": "string"
         },
         "sandbox_mode": {
@@ -8181,12 +8194,18 @@
         },
         "runtime": {
           "enum": [
+            "acp",
             "claude",
             "codex",
             "fountain-fixture",
             "gemini",
             "opencode"
           ],
+          "required": false,
+          "type": "string"
+        },
+        "runtime_command": {
+          "nullable": true,
           "required": false,
           "type": "string"
         },
@@ -10027,6 +10046,7 @@
         },
         "runtime": {
           "enum": [
+            "acp",
             "claude",
             "codex",
             "fountain-fixture",
@@ -11539,6 +11559,7 @@
         },
         "runtime": {
           "enum": [
+            "acp",
             "claude",
             "codex",
             "fountain-fixture",

--- a/sdk/contract/contract.json
+++ b/sdk/contract/contract.json
@@ -8034,6 +8034,7 @@
           "type": "object"
         },
         "model": {
+          "nullable": true,
           "required": false,
           "type": "string"
         },
@@ -8172,6 +8173,7 @@
           "type": "object"
         },
         "model": {
+          "nullable": true,
           "required": false,
           "type": "string"
         },

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -10,6 +10,13 @@ server releases.
 
 ---
 
+## [1.22.1] — 2026-09-06
+
+### Changed
+
+- Generated types carry an agent's `runtime_command`, the shell line the new `acp` runtime launches inside the sandbox, and `acp` joins the runtime enum.
+- `Agent["model"]` is `string | null`, and `AgentRequest["model"]` and `AgentUpdate["model"]` are optional and nullable. An `acp` agent needs no model, and clearing one is how an existing agent converts to that runtime. Code that assumed a string needs a null check.
+
 ## [1.22.0] — 2026-09-06
 
 ### Added

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "1.22.0",
+  "version": "1.22.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentshit/fountain-sdk",
-      "version": "1.22.0",
+      "version": "1.22.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^26.4.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "1.22.0",
+  "version": "1.22.1",
   "description": "Run a coding agent on a real computer, with your repos and your credentials, in one call.",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -2612,15 +2612,17 @@ export interface components {
             metadata?: {
                 [key: string]: unknown;
             };
-            /** @description Canonical provider/model_id (e.g. anthropic/claude-sonnet-4-6). The provider must match the runtime — anthropic for claude, openai for codex, google for gemini; opencode accepts any of the three. Other providers are rejected: Fountain has no credentials to export for them. The model id is not checked against a list, so a newly released model works without a Fountain release. The isolated fountain-fixture runtime is the exception: it accepts only fixture/deterministic-v1. */
-            model: string;
+            /** @description Canonical provider/model_id (e.g. anthropic/claude-sonnet-4-6). The provider must match the runtime — anthropic for claude, openai for codex, google for gemini; opencode accepts any of the three. Other providers are rejected: Fountain has no credentials to export for them. The model id is not checked against a list, so a newly released model works without a Fountain release. The isolated fountain-fixture runtime is the exception: it accepts only fixture/deterministic-v1. Null on the acp runtime, which resolves no inference credential and reads no model. */
+            model: string | null;
             name: string;
             /** @description Per-tool permission policy: a map of key to verdict, plus an optional "default" key. A key is matched against the tool card's title first and then ACP's kind (execute, edit, read, fetch, …); prefer a kind, because claude titles a tool call with the command it is about to run. Unset keys fall back to the default, and an unset default is auto_allow — today's behaviour. "ask" holds the tool until a human answers it on the conversation stream, and denies if nobody does before the timeout. A runtime that never asks (opencode) refuses anything stricter than auto_allow with 422 permission_policy_unenforceable. */
             permission_policy?: {
                 [key: string]: "auto_allow" | "ask" | "auto_deny";
             } | null;
             /** @enum {string} */
-            runtime: "claude" | "codex" | "gemini" | "opencode" | "fountain-fixture";
+            runtime: "claude" | "codex" | "gemini" | "opencode" | "acp" | "fountain-fixture";
+            /** @description The command the acp runtime launches inside the sandbox, as a shell line resolved there (for example `chant acp`). Required when runtime is acp, and rejected on every other runtime, which resolves its own executable. A free string by design: it runs under the same isolation as an environment's setup script. */
+            runtime_command?: string | null;
             /**
              * @description Where a conversation of this agent runs by default (ADR 0023). ephemeral: a sandbox per conversation, reclaimed with it. persistent: one sandbox per agent identity (agent, environment, vault) — the agent's computer — that every conversation of that identity lands on and shares; it survives a conversation ending and is parked, not destroyed, at the ceiling. A launch may name the other with sandbox_mode on POST /api/conversations.
              * @enum {string}
@@ -2666,14 +2668,16 @@ export interface components {
             metadata?: {
                 [key: string]: unknown;
             };
-            model: string;
+            model?: string;
             name: string;
             /** @description Per-tool permission policy: a map of key to verdict, plus an optional "default" key. A key is matched against the tool card's title first and then ACP's kind (execute, edit, read, fetch, …); prefer a kind, because claude titles a tool call with the command it is about to run. Unset keys fall back to the default, and an unset default is auto_allow. "ask" holds the tool until a human answers it on the conversation stream, and denies if nobody does before the timeout. A conversation may narrow this at launch, never widen it. A runtime that never asks (opencode) refuses anything stricter than auto_allow with 422 permission_policy_unenforceable. */
             permission_policy?: {
                 [key: string]: "auto_allow" | "ask" | "auto_deny";
             } | null;
             /** @enum {string} */
-            runtime: "claude" | "codex" | "gemini" | "opencode" | "fountain-fixture";
+            runtime: "claude" | "codex" | "gemini" | "opencode" | "acp" | "fountain-fixture";
+            /** @description The command the acp runtime launches inside the sandbox, as a shell line resolved there (for example `chant acp`). Required when runtime is acp, and rejected on every other runtime, which resolves its own executable. A free string by design: it runs under the same isolation as an environment's setup script. */
+            runtime_command?: string | null;
             /**
              * @description Where a conversation of this agent runs by default (ADR 0023). ephemeral: a sandbox per conversation, reclaimed with it. persistent: one sandbox per agent identity (agent, environment, vault) — the agent's computer — that every conversation of that identity lands on and shares; it survives a conversation ending and is parked, not destroyed, at the ceiling. A launch may name the other with sandbox_mode on POST /api/conversations.
              * @enum {string}
@@ -2723,7 +2727,9 @@ export interface components {
                 [key: string]: "auto_allow" | "ask" | "auto_deny";
             } | null;
             /** @enum {string} */
-            runtime?: "claude" | "codex" | "gemini" | "opencode" | "fountain-fixture";
+            runtime?: "claude" | "codex" | "gemini" | "opencode" | "acp" | "fountain-fixture";
+            /** @description The command the acp runtime launches inside the sandbox, as a shell line resolved there (for example `chant acp`). Required when runtime is acp, and rejected on every other runtime, which resolves its own executable. A free string by design: it runs under the same isolation as an environment's setup script. */
+            runtime_command?: string | null;
             /**
              * @description Where a conversation of this agent runs by default (ADR 0023). ephemeral: a sandbox per conversation, reclaimed with it. persistent: one sandbox per agent identity (agent, environment, vault) — the agent's computer — that every conversation of that identity lands on and shares; it survives a conversation ending and is parked, not destroyed, at the ceiling. A launch may name the other with sandbox_mode on POST /api/conversations.
              * @enum {string}
@@ -3540,7 +3546,7 @@ export interface components {
                 [key: string]: "auto_allow" | "ask" | "auto_deny";
             } | null;
             /** @enum {string} */
-            runtime: "claude" | "codex" | "gemini" | "opencode" | "fountain-fixture";
+            runtime: "claude" | "codex" | "gemini" | "opencode" | "acp" | "fountain-fixture";
             runtime_session_id?: string | null;
             sandbox?: components["schemas"]["Sandbox"] | null;
             /**
@@ -4212,7 +4218,7 @@ export interface components {
             /** @description True while this conversation is running a turn on the machine. */
             mid_turn: boolean;
             /** @enum {string} */
-            runtime?: "claude" | "codex" | "gemini" | "opencode" | "fountain-fixture";
+            runtime?: "claude" | "codex" | "gemini" | "opencode" | "acp" | "fountain-fixture";
             /** @enum {string} */
             status: "pending" | "running" | "idle" | "failed" | "terminated";
             title?: string | null;

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -2668,7 +2668,7 @@ export interface components {
             metadata?: {
                 [key: string]: unknown;
             };
-            model?: string;
+            model?: string | null;
             name: string;
             /** @description Per-tool permission policy: a map of key to verdict, plus an optional "default" key. A key is matched against the tool card's title first and then ACP's kind (execute, edit, read, fetch, …); prefer a kind, because claude titles a tool call with the command it is about to run. Unset keys fall back to the default, and an unset default is auto_allow. "ask" holds the tool until a human answers it on the conversation stream, and denies if nobody does before the timeout. A conversation may narrow this at launch, never widen it. A runtime that never asks (opencode) refuses anything stricter than auto_allow with 422 permission_policy_unenforceable. */
             permission_policy?: {
@@ -2720,7 +2720,7 @@ export interface components {
             metadata?: {
                 [key: string]: unknown;
             };
-            model?: string;
+            model?: string | null;
             name?: string;
             /** @description Per-tool permission policy: a map of key to verdict, plus an optional "default" key. A key is matched against the tool card's title first and then ACP's kind (execute, edit, read, fetch, …); prefer a kind, because claude titles a tool call with the command it is about to run. Unset keys fall back to the default, and an unset default is auto_allow. "ask" holds the tool until a human answers it on the conversation stream, and denies if nobody does before the timeout. A conversation may narrow this at launch, never widen it. A runtime that never asks (opencode) refuses anything stricter than auto_allow with 422 permission_policy_unenforceable. */
             permission_policy?: {

--- a/sdk/typescript/src/http.ts
+++ b/sdk/typescript/src/http.ts
@@ -19,7 +19,7 @@ export interface RequestOptions {
  * this string is already what Fountain's request logs are keyed on. The
  * version half is asserted against `package.json` by a test.
  */
-export const USER_AGENT = "fountain-sdk-js/1.22.0";
+export const USER_AGENT = "fountain-sdk-js/1.22.1";
 
 /**
  * The thin layer everything else is built on: one bearer token, JSON in and


### PR DESCRIPTION
Every runtime Fountain has is an LLM coding agent. A deterministic program that wants a warm machine, a vault, a thread, a schedule and a human who can read what happened could not be launched: the runtime registry is a closed map, the model parser expects a `provider/model_id`, and a turn resolves inference credentials it will never use. This PR adds an `acp` runtime that launches a named command and speaks ACP to it over stdio like the four existing runtimes.

- Add `Fountain.Runtimes.Command`, a `Managoat.Runtimes` implementation for a command the agent names, and a `Fountain.Runtimes` facade that answers `acp` itself and delegates everything else to the library registry. Every runtime lookup, including skills installation, goes through the facade.
- Add `agents.runtime_command`, required for `acp` and refused on any other runtime, and make `agents.model` optional for `acp` only. Both refusals are 422s naming the field. The command is a free string, run as `bash -lc` inside the sandbox.
- Resolve no inference credential and pin no model on an `acp` turn, so `model.failed` cannot come from the pin path and a turn on an account with no credentials succeeds. `turn.usage` is null; credits price the turn by sandbox time only.
- Expose the field in the API, the console form (which disables the model input on `acp`) and the account export. Model suggestions return nothing for `acp`.
- Add a conformance test that runs a checked-in fixture ACP agent, a small Elixir program, as a real OS process through a whole turn, plus scripted-agent tests for tool-call blocks, the stop reason, interrupt and all three permission verdicts.
- Document the runtime in the catalog, `docs/sdk.md`, `docs/concepts/permissions.md` and the integrations pages, including what "the same isolation" means on a self-hosted runner.

Closes #1634

Stacked on #1637; merge that first.

Validation:

- Full suite on the four-branch stack: 4579 tests, 0 failures (core and ee), 144 (fountain_buzz), 33 (fountain_support).
- `mix compile --warnings-as-errors`, `mix format --check-formatted`, `mix credo --strict`, dialyzer, sobelow and `deps.unlock --unused` are clean. The prod release assembles.
- The SDK contract check, the TypeScript verifier and tests, the Python verifier and the conformance lint pass. `scripts/docs-style.py` is clean.
- Not run here: vale, okf and destink (not installed on the build machine).
