### PR TITLE
feat(conversations): permission requests that outlive a turn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,8 +79,10 @@ upgrade, is in
   goes idle and the sandbox suspends as usual. `GET /api/conversations/{id}`
   lists such requests as `pending_requests`, and answering one opens a new turn
   carrying the request id and the chosen option, which wakes the sandbox. The
-  wait is bounded by `_meta.fountain.timeout` on the request, else an
-  `ask_timeout` in the permission policy, else the existing 5 minute ceiling.
+  wait is bounded by `_meta.fountain.timeout` on the request and by an
+  `ask_timeout` in the permission policy, the shorter of the two, else the
+  existing 5 minute ceiling. An answer is refused, and the request kept, when
+  the conversation cannot take the turn that carries it.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,13 @@ upgrade, is in
   `AgentUpdate["model"]` are `string | null` and optional. A client that
   assumed a string needs a null check. Nothing else on the wire changed
   shape.
+- Permission requests can outlive the turn that raised them. An agent that ends
+  a turn with stop reason `waiting` keeps its request open, the conversation
+  goes idle and the sandbox suspends as usual. `GET /api/conversations/{id}`
+  lists such requests as `pending_requests`, and answering one opens a new turn
+  carrying the request id and the chosen option, which wakes the sandbox. The
+  wait is bounded by `_meta.fountain.timeout` on the request, else an
+  `ask_timeout` in the permission policy, else the existing 5 minute ceiling.
 
 ### Fixed
 

--- a/apps/fountain/lib/fountain/agents/agent.ex
+++ b/apps/fountain/lib/fountain/agents/agent.ex
@@ -4,6 +4,7 @@ defmodule Fountain.Agents.Agent do
 
   alias Fountain.Accounts.User
   alias Fountain.Environments.Environment
+  alias Fountain.PermissionPolicy
   alias Fountain.RuntimeDispatch
   alias Managoat.Runtimes.Model
 
@@ -264,10 +265,33 @@ defmodule Fountain.Agents.Agent do
           [permission_policy: "must be a map of tool name to verdict"]
 
         true ->
-          Enum.flat_map(policy, fn {tool, verdict} -> policy_errors(tool, verdict) end) ++
-            runtime_errors(changeset, policy)
+          verdicts = PermissionPolicy.verdicts(policy)
+
+          Enum.flat_map(verdicts, fn {tool, verdict} -> policy_errors(tool, verdict) end) ++
+            reserved_errors(policy) ++
+            runtime_errors(changeset, verdicts)
       end
     end)
+  end
+
+  # `ask_timeout` names no tool, so it is validated on its own rather than as
+  # a verdict (#1635). Seconds, positive, and deliberately unbounded above:
+  # a request that outlives its turn is meant to be able to wait for days.
+  defp reserved_errors(policy) do
+    case Map.fetch(policy, "ask_timeout") do
+      {:ok, value} ->
+        if PermissionPolicy.valid_ask_timeout?(value) do
+          []
+        else
+          [
+            permission_policy:
+              "ask_timeout: #{inspect(value)} is not a positive number of seconds"
+          ]
+        end
+
+      :error ->
+        []
+    end
   end
 
   # A policy the runtime will never consult is refused rather than stored. The

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -11,7 +11,19 @@ defmodule Fountain.Conversations do
   require Logger
 
   alias Fountain.Audit
-  alias Fountain.Conversations.{Blocks, Conversation, Labels, LogEvent, Sandbox, Turn, TurnImage}
+
+  alias Fountain.Conversations.{
+    Blocks,
+    Conversation,
+    DetachedRequest,
+    Labels,
+    LogEvent,
+    Sandbox,
+    Turn,
+    TurnImage
+  }
+
+  alias Fountain.PermissionPolicy
   alias Fountain.Repo
 
   # ── on the _unsafe_ prefix ────────────────────────────────────────────────
@@ -2938,6 +2950,11 @@ defmodule Fountain.Conversations do
 
   Audited as a decision about tenant-owned state, per 0013: the tool and the
   verdict, never the tool's input.
+
+  A request that outlived its turn (#1635) is answered through the same door
+  and audited the same way. What differs is what the answer does: there is no
+  peer left to take it, so the request is resolved on the turn row and a new
+  turn is opened carrying it, which wakes a suspended sandbox on the way.
   """
   @spec answer_permission_request(binary(), binary(), String.t(), String.t(), keyword()) ::
           :ok | {:error, term()}
@@ -2945,34 +2962,211 @@ defmodule Fountain.Conversations do
       when is_binary(conv_id) and is_binary(user_id) do
     actor = Keyword.get(opts, :actor, "self")
 
-    cond do
-      actor == "sprite" ->
+    case {actor, get_conversation(conv_id, user_id)} do
+      {"sprite", _conv} ->
         {:error, :sprite_may_not_answer}
 
-      is_nil(get_conversation(conv_id, user_id)) ->
+      {_actor, nil} ->
         {:error, :not_found}
 
-      true ->
-        do_answer_permission(conv_id, user_id, request_id, option_id, opts)
+      # A conversation nobody can prompt cannot carry an answer back to the
+      # agent, so the request is left where it is rather than resolved into
+      # nothing.
+      {_actor, %Conversation{status: status}} when status not in ["idle", "running"] ->
+        {:error, :not_running}
+
+      {_actor, conv} ->
+        do_answer_permission(conv, user_id, request_id, option_id, opts)
     end
   end
 
-  defp do_answer_permission(conv_id, user_id, request_id, option_id, opts) do
+  # The detached row is looked at first, and deliberately. A turn that ended
+  # `waiting` (#1635) left the request on its row while the peer that raised
+  # it may still be idle on the sandbox holding the JSON-RPC id: asking the
+  # server first would answer a connection whose turn is over and report
+  # success, and the new turn that actually carries the answer would never
+  # open.
+  defp do_answer_permission(conv, user_id, request_id, option_id, opts) do
+    # Ownership: established by the tenant-scoped `get_conversation/2` in
+    # `answer_permission_request/5` immediately above this call.
+    case _unsafe_waiting_turn(conv.id, request_id) do
+      nil -> answer_held_permission(conv.id, user_id, request_id, option_id, opts)
+      turn -> answer_detached_permission(conv, turn, user_id, option_id, opts)
+    end
+  end
+
+  defp answer_held_permission(conv_id, user_id, request_id, option_id, opts) do
     case ConversationServer.answer_permission(conv_id, request_id, option_id) do
       :ok ->
-        Audit.record(%{
-          user_id: user_id,
-          action: "conversation.permission_answered",
-          resource_type: "conversation",
-          resource_id: conv_id,
-          actor: Keyword.get(opts, :actor, "self"),
-          request_ip: Keyword.get(opts, :request_ip),
-          metadata: %{"request_id" => request_id, "option_id" => option_id}
-        })
-
-        :ok
+        record_permission_answered(conv_id, user_id, request_id, option_id, opts)
 
       {:error, _} = err ->
+        err
+    end
+  end
+
+  # A request nobody is holding open any more: resolve the row, then open the
+  # turn that tells the agent. The order is the same as the in-turn path's —
+  # resolve, record, then act — so a crash between the two cannot leave a
+  # request answered twice.
+  defp answer_detached_permission(conv, turn, user_id, option_id, opts) do
+    request = turn.pending_permission
+    request_id = request["request_id"]
+
+    cond do
+      not DetachedRequest.offered?(request, option_id) ->
+        {:error, :unknown_option}
+
+      # A turn of its own is already running, and the resume turn cannot queue
+      # behind it. Refused before the row is touched, so the request is still
+      # there to answer once the conversation is idle again.
+      conv.status == "running" ->
+        {:error, :busy}
+
+      true ->
+        with :ok <- _unsafe_resolve_detached_request(turn, "answered", option_id),
+             :ok <-
+               record_permission_answered(
+                 turn.conversation_id,
+                 user_id,
+                 request_id,
+                 option_id,
+                 opts
+               ) do
+          resume_after_request(turn, request, "answered", option_id, opts)
+        end
+    end
+  end
+
+  defp record_permission_answered(conv_id, user_id, request_id, option_id, opts) do
+    Audit.record(%{
+      user_id: user_id,
+      action: "conversation.permission_answered",
+      resource_type: "conversation",
+      resource_id: conv_id,
+      actor: Keyword.get(opts, :actor, "self"),
+      request_ip: Keyword.get(opts, :request_ip),
+      metadata: %{"request_id" => request_id, "option_id" => option_id}
+    })
+
+    :ok
+  end
+
+  @doc """
+  The turn a detached request is waiting on, or nil (#1635).
+
+  WARNING: not scoped by owner. Call it after a tenant-scoped fetch of the
+  conversation, which is what `answer_permission_request/5` does.
+  """
+  @spec _unsafe_waiting_turn(binary(), String.t()) :: Turn.t() | nil
+  def _unsafe_waiting_turn(conv_id, request_id) do
+    Turn
+    |> where([t], t.conversation_id == ^conv_id and t.waiting == true)
+    |> where([t], fragment("?->>'request_id' = ?", t.pending_permission, ^request_id))
+    |> Repo.one()
+  end
+
+  @doc """
+  Every request this conversation is waiting on, oldest turn first (#1635).
+
+  WARNING: not scoped by owner. Call it after a tenant-scoped fetch, which is
+  what `ConversationController.show/2` does.
+  """
+  @spec _unsafe_list_pending_requests(binary()) :: [map()]
+  def _unsafe_list_pending_requests(conv_id) do
+    Turn
+    |> where([t], t.conversation_id == ^conv_id and t.waiting == true)
+    |> where([t], not is_nil(t.pending_permission))
+    |> order_by([t], asc: t.turn_number)
+    |> Repo.all()
+    |> Enum.map(&DetachedRequest.to_json(&1.pending_permission, &1))
+  end
+
+  @doc """
+  Take a detached request off its turn, once (#1635).
+
+  First answer wins, and here that is enforced by the update itself rather
+  than by a process holding the request: the `where` names the request id the
+  caller read, so a second answer, the sweep and a client racing the sweep all
+  find nothing to update and get `{:error, :no_pending_permission}`.
+
+  The `request`/`done` stage event is published by whoever won, exactly as the
+  in-turn path publishes it.
+
+  WARNING: not scoped by owner. Both callers establish ownership first — the
+  answer door by fetching the conversation for the user, the sweep by being a
+  system sweep.
+  """
+  @spec _unsafe_resolve_detached_request(Turn.t(), String.t(), String.t() | nil) ::
+          :ok | {:error, :no_pending_permission}
+  def _unsafe_resolve_detached_request(%Turn{} = turn, outcome, option_id) do
+    request_id = turn.pending_permission["request_id"]
+
+    {count, _} =
+      Turn
+      |> where([t], t.id == ^turn.id and t.waiting == true)
+      |> where([t], fragment("?->>'request_id' = ?", t.pending_permission, ^request_id))
+      |> Repo.update_all(set: [waiting: false, pending_permission: nil, permission_deadline: nil])
+
+    if count == 1 do
+      publish_stage(turn.conversation_id, "request", "done", %{
+        request_id: request_id,
+        outcome: outcome,
+        option_id: option_id,
+        detached: true
+      })
+
+      :ok
+    else
+      {:error, :no_pending_permission}
+    end
+  end
+
+  @doc """
+  Deny a detached request whose deadline has passed, and tell the agent
+  (#1635).
+
+  The denial picks from the options the agent itself offered, never an id it
+  did not send. Recorded as `conversation.permission_denied` with the sweep as
+  the actor, because no human was at the keyboard and saying otherwise would
+  be a lie about who decided.
+  """
+  @spec _unsafe_expire_detached_request(Turn.t(), keyword()) ::
+          :ok | {:error, term()}
+  def _unsafe_expire_detached_request(%Turn{} = turn, opts \\ []) do
+    request = turn.pending_permission
+    option_id = DetachedRequest.deny_option_id(request)
+    actor = Keyword.get(opts, :actor, "system:detached_request_sweeper")
+
+    with :ok <- _unsafe_resolve_detached_request(turn, "timeout", option_id) do
+      record_permission_denied(turn.conversation_id, request["tool"], "timeout", actor: actor)
+      resume_after_request(turn, request, "timeout", option_id, actor: actor)
+    end
+  end
+
+  # The resolution reaches the agent as a new turn, because the peer that
+  # raised the request is gone and its JSON-RPC id with it. `send_prompt/4`
+  # wakes a suspended sandbox on the way, which is the whole point of letting
+  # the request outlive the turn.
+  defp resume_after_request(turn, request, outcome, option_id, opts) do
+    case ConversationServer.send_prompt(
+           turn.conversation_id,
+           DetachedRequest.resume_prompt(request, outcome, option_id),
+           [],
+           opts
+         ) do
+      :ok ->
+        :ok
+
+      {:error, reason} = err ->
+        # The request is resolved either way; what failed is delivering the
+        # outcome. Logged with both ids because the row no longer holds them.
+        Logger.warning(
+          "conv #{turn.conversation_id}: resolved detached request " <>
+            "#{request["request_id"]} but could not open the turn that carries " <>
+            "the answer: #{inspect(reason)}"
+        )
+
         err
     end
   end
@@ -2981,17 +3175,19 @@ defmodule Fountain.Conversations do
   Record that the permission policy withheld a tool from a running agent.
 
   Called by the `ConversationServer` when its peer reports a refusal (#939).
-  The actor is `sprite`: the agent asked, the policy answered, and no human was
-  involved — attributing it to the person who happened to write the policy
-  would be a lie about who was at the keyboard.
+  The actor defaults to `sprite`: the agent asked, the policy answered, and no
+  human was involved — attributing it to the person who happened to write the
+  policy would be a lie about who was at the keyboard. A detached request that
+  ran out of time (#1635) passes the sweep instead, for the same reason.
 
   Only refusals are recorded. A turn makes dozens of tool calls and a row per
   allow would make the trail a second copy of the transcript, which 0013
   forbids for exactly this reason. The tool's *input* is never recorded, only
   its name and the verdict.
   """
-  @spec record_permission_denied(binary(), String.t() | nil, String.t()) :: :ok
-  def record_permission_denied(conversation_id, tool, verdict) when is_binary(conversation_id) do
+  @spec record_permission_denied(binary(), String.t() | nil, String.t(), keyword()) :: :ok
+  def record_permission_denied(conversation_id, tool, verdict, opts \\ [])
+      when is_binary(conversation_id) do
     case _unsafe_get_conversation(conversation_id) do
       nil ->
         :ok
@@ -3002,7 +3198,7 @@ defmodule Fountain.Conversations do
           action: "conversation.permission_denied",
           resource_type: "conversation",
           resource_id: conv.id,
-          actor: "sprite",
+          actor: Keyword.get(opts, :actor, "sprite"),
           metadata: %{"tool" => tool, "verdict" => verdict}
         })
 
@@ -3024,9 +3220,18 @@ defmodule Fountain.Conversations do
   defp resolve_permission_policy(policy, _agent) when policy == %{}, do: {:ok, nil}
 
   defp resolve_permission_policy(policy, agent) when is_map(policy) do
+    # The reserved keys are not tools, so the library never sees them and
+    # narrows them itself (#1635, `Fountain.PermissionPolicy`).
+    verdicts = PermissionPolicy.verdicts(policy)
+
     with :ok <- validate_policy_shape(policy),
-         :ok <- check_runtime_asks(policy, agent),
-         :ok <- Managoat.ACP.Permissions.check_narrows(agent.permission_policy, policy) do
+         :ok <- check_runtime_asks(verdicts, agent),
+         :ok <-
+           Managoat.ACP.Permissions.check_narrows(
+             PermissionPolicy.verdicts(agent.permission_policy),
+             verdicts
+           ),
+         :ok <- PermissionPolicy.check_narrows(agent.permission_policy, policy) do
       {:ok, policy}
     end
   end
@@ -3045,21 +3250,38 @@ defmodule Fountain.Conversations do
   end
 
   defp validate_policy_shape(policy) do
-    Enum.find_value(policy, :ok, fn {tool, verdict} ->
-      cond do
-        not is_binary(tool) or tool == "" ->
-          {:error, :permission_policy_invalid}
+    with :ok <- validate_reserved_keys(policy) do
+      policy
+      |> PermissionPolicy.verdicts()
+      |> Enum.find_value(:ok, fn {tool, verdict} ->
+        cond do
+          not is_binary(tool) or tool == "" ->
+            {:error, :permission_policy_invalid}
 
-        verdict not in Managoat.ACP.Permissions.verdicts() ->
-          {:error, :permission_policy_invalid}
+          verdict not in Managoat.ACP.Permissions.verdicts() ->
+            {:error, :permission_policy_invalid}
 
-        not Managoat.ACP.Permissions.buildable?(verdict) ->
-          {:error, {:permission_policy_unbuilt, verdict}}
+          not Managoat.ACP.Permissions.buildable?(verdict) ->
+            {:error, {:permission_policy_unbuilt, verdict}}
 
-        true ->
-          nil
-      end
-    end)
+          true ->
+            nil
+        end
+      end)
+    end
+  end
+
+  # `ask_timeout` is seconds, not a verdict (#1635).
+  defp validate_reserved_keys(policy) do
+    case Map.fetch(policy, "ask_timeout") do
+      {:ok, value} ->
+        if PermissionPolicy.valid_ask_timeout?(value),
+          do: :ok,
+          else: {:error, :permission_policy_invalid}
+
+      :error ->
+        :ok
+    end
   end
 
   @doc """

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -23,6 +23,7 @@ defmodule Fountain.Conversations do
     TurnImage
   }
 
+  alias Fountain.Conversations.Lifecycle
   alias Fountain.PermissionPolicy
   alias Fountain.Repo
 
@@ -3006,34 +3007,72 @@ defmodule Fountain.Conversations do
   end
 
   # A request nobody is holding open any more: resolve the row, then open the
-  # turn that tells the agent. The order is the same as the in-turn path's —
-  # resolve, record, then act — so a crash between the two cannot leave a
-  # request answered twice.
+  # turn that tells the agent.
+  #
+  # Every gate the wake path would apply is applied **first**, before the row
+  # is touched. Resolving and then failing to deliver loses the answer with
+  # nothing to retry from, and hands the caller a 409 that says somebody else
+  # answered — which is a lie about what happened.
   defp answer_detached_permission(conv, turn, user_id, option_id, opts) do
     request = turn.pending_permission
     request_id = request["request_id"]
 
-    cond do
-      not DetachedRequest.offered?(request, option_id) ->
-        {:error, :unknown_option}
+    if DetachedRequest.offered?(request, option_id) do
+      with :ok <- _unsafe_resume_gate(conv),
+           :ok <- _unsafe_resolve_detached_request(turn, "answered", option_id),
+           :ok <-
+             record_permission_answered(
+               turn.conversation_id,
+               user_id,
+               request_id,
+               option_id,
+               opts
+             ) do
+        resume_after_request(turn, request, "answered", option_id, opts)
+      end
+    else
+      {:error, :unknown_option}
+    end
+  end
 
-      # A turn of its own is already running, and the resume turn cannot queue
-      # behind it. Refused before the row is touched, so the request is still
-      # there to answer once the conversation is idle again.
-      conv.status == "running" ->
+  @doc """
+  Whether a resume turn can be opened on this conversation right now (#1635).
+
+  The gates the wake will run, run before the request row is resolved. The
+  three answers differ in what a caller should do about them:
+
+  * `:ok` — go ahead.
+  * `{:error, :busy}` — a turn is running, so the resume turn cannot queue
+    behind it. Retry when the conversation is idle; the sweep does, a minute
+    later.
+  * `{:error, :gone}` — the conversation is over, so no turn will ever carry
+    the answer.
+
+  Anything else is the account's own refusal (suspended, out of credit), and
+  is retryable once the account is not.
+
+  WARNING: not scoped by owner. The answer door establishes ownership first;
+  the sweep is a system sweep.
+  """
+  @spec _unsafe_resume_gate(Conversation.t() | binary()) :: :ok | {:error, term()}
+  def _unsafe_resume_gate(conv_id) when is_binary(conv_id) do
+    case _unsafe_get_conversation(conv_id) do
+      nil -> {:error, :gone}
+      conv -> _unsafe_resume_gate(conv)
+    end
+  end
+
+  def _unsafe_resume_gate(%Conversation{} = conv) do
+    cond do
+      conv.status in ["terminated", "failed"] ->
+        {:error, :gone}
+
+      conv.status != "idle" ->
         {:error, :busy}
 
       true ->
-        with :ok <- _unsafe_resolve_detached_request(turn, "answered", option_id),
-             :ok <-
-               record_permission_answered(
-                 turn.conversation_id,
-                 user_id,
-                 request_id,
-                 option_id,
-                 opts
-               ) do
-          resume_after_request(turn, request, "answered", option_id, opts)
+        with :ok <- Fountain.Accounts.check_not_suspended(conv.user_id) do
+          Fountain.Billing.check_spend(conv.user_id)
         end
     end
   end
@@ -3138,9 +3177,29 @@ defmodule Fountain.Conversations do
     option_id = DetachedRequest.deny_option_id(request)
     actor = Keyword.get(opts, :actor, "system:detached_request_sweeper")
 
-    with :ok <- _unsafe_resolve_detached_request(turn, "timeout", option_id) do
-      record_permission_denied(turn.conversation_id, request["tool"], "timeout", actor: actor)
-      resume_after_request(turn, request, "timeout", option_id, actor: actor)
+    # The gate first, for the same reason the answer door applies it first: a
+    # request resolved into a prompt nobody can deliver is gone, the agent is
+    # never told, and there is no second copy to retry from. The deadline has
+    # passed either way, so leaving the row is the safe half of the trade —
+    # the sweep is back in a minute.
+    #
+    # A conversation that is over is the exception: no turn will ever carry
+    # the denial, so the request is resolved and the card stops waiting.
+    case _unsafe_resume_gate(turn.conversation_id) do
+      :ok ->
+        with :ok <- _unsafe_resolve_detached_request(turn, "timeout", option_id) do
+          record_permission_denied(turn.conversation_id, request["tool"], "timeout", actor: actor)
+          resume_after_request(turn, request, "timeout", option_id, actor: actor)
+        end
+
+      {:error, :gone} ->
+        with :ok <- _unsafe_resolve_detached_request(turn, "timeout", option_id) do
+          record_permission_denied(turn.conversation_id, request["tool"], "timeout", actor: actor)
+          :ok
+        end
+
+      {:error, _} = err ->
+        err
     end
   end
 
@@ -3158,16 +3217,19 @@ defmodule Fountain.Conversations do
       :ok ->
         :ok
 
-      {:error, reason} = err ->
-        # The request is resolved either way; what failed is delivering the
-        # outcome. Logged with both ids because the row no longer holds them.
+      {:error, reason} ->
+        # The gates above passed and the row is already resolved, so this is a
+        # race rather than a refusal: something took the conversation between
+        # the two. Its own error would tell the caller to retry an answer that
+        # no longer exists, so it becomes one that says what actually
+        # happened.
         Logger.warning(
           "conv #{turn.conversation_id}: resolved detached request " <>
             "#{request["request_id"]} but could not open the turn that carries " <>
             "the answer: #{inspect(reason)}"
         )
 
-        err
+        {:error, :answer_not_delivered}
     end
   end
 
@@ -3231,7 +3293,12 @@ defmodule Fountain.Conversations do
              PermissionPolicy.verdicts(agent.permission_policy),
              verdicts
            ),
-         :ok <- PermissionPolicy.check_narrows(agent.permission_policy, policy) do
+         :ok <-
+           PermissionPolicy.check_narrows(
+             agent.permission_policy,
+             policy,
+             div(Lifecycle.ask_timeout_ms(), 1000)
+           ) do
       {:ok, policy}
     end
   end

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -25,6 +25,7 @@ defmodule Fountain.Conversations.ConversationServer do
     CallbackKey,
     Connection,
     Conversation,
+    DetachedRequest,
     Egress,
     Lifecycle,
     McpServers,
@@ -492,6 +493,13 @@ defmodule Fountain.Conversations.ConversationServer do
       acp_peer: nil,
       # Timer refusing an unanswered permission request (#940).
       permission_timer: nil,
+      # `{request_id, params}` of the last `session/request_permission` the
+      # peer relayed (#1635). The peer reports a held request's tool and its
+      # options, not the params they came from, and the per-request timeout
+      # rides in `_meta`; the peer persists the line immediately before it
+      # reports the ask, so the params are here by the time the ask arrives.
+      # nil until one does. See `Managoat.ACP.Peer`'s `hold_permission`.
+      acp_request_params: nil,
       # Caller-tool calls parked on the turn (#1202): id => %{name, arguments,
       # turn_id, waiter, timer, result}. `result` is nil while parked and the
       # answer once resolved; entries are dropped when the turn ends.
@@ -1559,18 +1567,18 @@ defmodule Fountain.Conversations.ConversationServer do
   # editor (#708) are peer clients of this door, not fallbacks for one
   # another, so a second answer to the same request is "too late" rather
   # than an error in the caller.
+  #
+  # The turn has to be the one holding this request. A turn that ended
+  # `waiting` (#1635) left the request on its row and the peer still holds the
+  # JSON-RPC id it was raised under, so without this guard an answer meant for
+  # the detached request would go down a connection whose turn is over, be
+  # reported as landed, and never open the turn that carries it back.
   def handle_call({:answer_permission, request_id, option_id}, _from, state) do
-    {reply, turn, pending} =
-      Pending.answer_permission(
-        Pending.from_state(state),
-        state.conversation_id,
-        state.current_turn,
-        state.acp_peer,
-        request_id,
-        option_id
-      )
-
-    {:reply, reply, %{Pending.into_state(state, pending) | current_turn: turn}}
+    if holding?(state.current_turn, request_id) do
+      answer_held_permission(state, request_id, option_id)
+    else
+      {:reply, {:error, :no_pending_permission}, state}
+    end
   end
 
   # A call needs a turn to belong to, and the client following that turn is
@@ -2067,7 +2075,27 @@ defmodule Fountain.Conversations.ConversationServer do
   defp fail_transport(state, reason),
     do: Reattachment.fail_transport(resolve_pending_permission(state, "turn_ended"), reason)
 
-  # The permission request's end: the turn row and timer are the server's to hold.
+  defp holding?(%{pending_permission: %{"request_id" => id}, waiting: waiting}, request_id),
+    do: id == request_id and waiting != true
+
+  defp holding?(_turn, _request_id), do: false
+
+  defp answer_held_permission(state, request_id, option_id) do
+    {reply, turn, pending} =
+      Pending.answer_permission(
+        Pending.from_state(state),
+        state.conversation_id,
+        state.current_turn,
+        state.acp_peer,
+        request_id,
+        option_id
+      )
+
+    {:reply, reply, %{Pending.into_state(state, pending) | current_turn: turn}}
+  end
+
+  # The permission request's end, whichever way (`Pending.resolve_permission/7`):
+  # the turn row and the timer are the server's to hold.
   defp resolve_permission(state, request_id, outcome, option_id) do
     {turn, pending} =
       Pending.resolve_permission(
@@ -2588,8 +2616,29 @@ defmodule Fountain.Conversations.ConversationServer do
         new_state.stream_tracer
       end
 
-    %{new_state | stream_tracer: tracer}
+    %{
+      new_state
+      | stream_tracer: tracer,
+        acp_request_params: request_params_of(stream, data) || state.acp_request_params
+    }
   end
+
+  # The `session/request_permission` line the peer relays carries the
+  # per-request timeout, and the ask that follows it does not (#1635). The
+  # peer writes the line under the **minted** request id, so the pair can be
+  # matched rather than assumed. Decoded only for a line that names the
+  # method, so an ordinary turn's thousands of updates pay a substring search
+  # and nothing else.
+  defp request_params_of("acp", data) do
+    if String.contains?(data, "session/request_permission") do
+      case Managoat.ACP.Protocol.classify_line(data) do
+        {:request, id, "session/request_permission", params} -> {id, params}
+        _ -> nil
+      end
+    end
+  end
+
+  defp request_params_of(_stream, _data), do: nil
 
   # Terminal path for an ACP turn. The order matters: stdin closes first so the
   # adapter starts exiting while we do the bookkeeping, and `current_command_ref`
@@ -2606,7 +2655,15 @@ defmodule Fountain.Conversations.ConversationServer do
     # Resolve a held permission request as the turn ends (#940): a card left
     # open is a client waiting on an answer that can never come, and the
     # turn's `pending_permission` would stay set on a turn that is over.
-    state = resolve_pending_permission(state, "turn_ended")
+    #
+    # Unless the agent asked to keep it (#1635). `:detach_permission` ran
+    # first and marked the row, and from here the answer that can come is a
+    # new turn rather than this one's peer, so the card stays up on purpose.
+    state =
+      if Pending.detached?(state.current_turn),
+        do: state,
+        else: resolve_pending_permission(state, "turn_ended")
+
     state = drop_caller_tools(state, "turn_ended")
     state = cancel_autonomous_quiet(state)
 
@@ -2650,6 +2707,8 @@ defmodule Fountain.Conversations.ConversationServer do
   defp apply_effect(state, {:ask_permission, request_id, tool, options}),
     do: ask_permission(state, request_id, tool, options)
 
+  defp apply_effect(state, :detach_permission), do: detach_permission(state)
+
   defp apply_effect(state, {:finish, status, span_attrs, stage_meta}),
     do: finish_acp_turn(state, status, span_attrs, stage_meta)
 
@@ -2666,10 +2725,42 @@ defmodule Fountain.Conversations.ConversationServer do
         state.current_turn,
         request_id,
         tool,
-        options
+        options,
+        detached_timeout_ms(state, request_id)
       )
 
     %{Pending.into_state(state, pending) | current_turn: turn}
+  end
+
+  # What this request would get if the agent ends the turn waiting on it
+  # (#1635): its own `_meta.fountain.timeout`, else the effective
+  # `ask_timeout`, else the global ceiling. Decided at ask time so the
+  # `request`/`started` event can announce it, and stored on the request.
+  defp detached_timeout_ms(state, request_id) do
+    conv = Conversations._unsafe_get_conversation!(state.conversation_id)
+
+    DetachedRequest.timeout_ms(
+      request_params(state, request_id),
+      TurnMachine.effective_ask_timeout_seconds(conv, TurnMachine.agent_for(conv))
+    )
+  end
+
+  defp request_params(%{acp_request_params: {id, params}}, request_id) when id == request_id,
+    do: params
+
+  defp request_params(_state, _request_id), do: nil
+
+  # The turn is ending with its request still open (`Pending.detach/2`): the
+  # row keeps it, the deadline goes on the row, and the sweep takes over.
+  defp detach_permission(state) do
+    case state.current_turn do
+      %{pending_permission: request} = turn when is_map(request) ->
+        {turn, pending} = Pending.detach(Pending.from_state(state), turn)
+        %{Pending.into_state(state, pending) | current_turn: turn}
+
+      _ ->
+        state
+    end
   end
 
   # ── the connection (#817) ─────────────────────────────────────────────────

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -493,12 +493,9 @@ defmodule Fountain.Conversations.ConversationServer do
       acp_peer: nil,
       # Timer refusing an unanswered permission request (#940).
       permission_timer: nil,
-      # `{request_id, params}` of the last `session/request_permission` the
-      # peer relayed (#1635). The peer reports a held request's tool and its
-      # options, not the params they came from, and the per-request timeout
-      # rides in `_meta`; the peer persists the line immediately before it
-      # reports the ask, so the params are here by the time the ask arrives.
-      # nil until one does. See `Managoat.ACP.Peer`'s `hold_permission`.
+      # The last `session/request_permission` the peer relayed, as
+      # `DetachedRequest.request_line/2` reads it (#1635): the ask that follows
+      # carries no params, and the per-request timeout is in theirs.
       acp_request_params: nil,
       # Caller-tool calls parked on the turn (#1202): id => %{name, arguments,
       # turn_id, waiter, timer, result}. `result` is nil while parked and the
@@ -1567,15 +1564,11 @@ defmodule Fountain.Conversations.ConversationServer do
   # editor (#708) are peer clients of this door, not fallbacks for one
   # another, so a second answer to the same request is "too late" rather
   # than an error in the caller.
-  #
-  # The turn has to be the one holding this request. A turn that ended
-  # `waiting` (#1635) left the request on its row and the peer still holds the
-  # JSON-RPC id it was raised under, so without this guard an answer meant for
-  # the detached request would go down a connection whose turn is over, be
-  # reported as landed, and never open the turn that carries it back.
+  # `Pending.holds?/2` is the guard a detached request needs (#1635).
   def handle_call({:answer_permission, request_id, option_id}, _from, state) do
-    if holding?(state.current_turn, request_id) do
-      answer_held_permission(state, request_id, option_id)
+    if Pending.holds?(state.current_turn, request_id) do
+      {reply, state} = Pending.answer(state, request_id, option_id)
+      {:reply, reply, state}
     else
       {:reply, {:error, :no_pending_permission}, state}
     end
@@ -1806,12 +1799,12 @@ defmodule Fountain.Conversations.ConversationServer do
           current_turn: %{pending_permission: %{"request_id" => request_id}}
         } = state
       ) do
-    state = resolve_permission(state, request_id, "timeout", nil)
+    state = Pending.resolve(state, request_id, "timeout", nil)
     fail_transport(state, :permission_timeout_during_runner_reconnect)
   end
 
   def handle_info({:permission_timeout, request_id}, state) do
-    {:noreply, resolve_permission(state, request_id, "timeout", nil)}
+    {:noreply, Pending.resolve(state, request_id, "timeout", nil)}
   end
 
   # The caller never answered a parked tool call (#1202). The agent gets an
@@ -2072,64 +2065,10 @@ defmodule Fountain.Conversations.ConversationServer do
 
   def handle_info(_msg, state), do: {:noreply, state}
 
+  # `Pending.resolve_held/2` is the family's own (#1369); this call site came
+  # from the shared-sandbox reattach fix and moves with it.
   defp fail_transport(state, reason),
-    do: Reattachment.fail_transport(resolve_pending_permission(state, "turn_ended"), reason)
-
-  defp holding?(%{pending_permission: %{"request_id" => id}, waiting: waiting}, request_id),
-    do: id == request_id and waiting != true
-
-  defp holding?(_turn, _request_id), do: false
-
-  defp answer_held_permission(state, request_id, option_id) do
-    {reply, turn, pending} =
-      Pending.answer_permission(
-        Pending.from_state(state),
-        state.conversation_id,
-        state.current_turn,
-        state.acp_peer,
-        request_id,
-        option_id
-      )
-
-    {:reply, reply, %{Pending.into_state(state, pending) | current_turn: turn}}
-  end
-
-  # The permission request's end, whichever way (`Pending.resolve_permission/7`):
-  # the turn row and the timer are the server's to hold.
-  defp resolve_permission(state, request_id, outcome, option_id) do
-    {turn, pending} =
-      Pending.resolve_permission(
-        Pending.from_state(state),
-        state.conversation_id,
-        state.current_turn,
-        state.acp_peer,
-        request_id,
-        outcome,
-        option_id
-      )
-
-    %{Pending.into_state(state, pending) | current_turn: turn}
-  end
-
-  # Resolve whatever is held, if anything, as the turn ends.
-  defp resolve_pending_permission(state, outcome) do
-    {turn, pending} =
-      Pending.resolve_pending_permission(
-        Pending.from_state(state),
-        state.conversation_id,
-        state.current_turn,
-        state.acp_peer,
-        outcome
-      )
-
-    %{Pending.into_state(state, pending) | current_turn: turn}
-  end
-
-  # Everything still parked when the turn ends (`Pending.drop_calls/3`).
-  defp drop_caller_tools(state, outcome) do
-    pending = Pending.drop_calls(Pending.from_state(state), state.conversation_id, outcome)
-    Pending.into_state(state, pending)
-  end
+    do: Reattachment.fail_transport(Pending.resolve_held(state, "turn_ended"), reason)
 
   # The server's own clock stamp: the input `Lifecycle.check/4` reads. Nothing
   # but this process writes it.
@@ -2619,26 +2558,9 @@ defmodule Fountain.Conversations.ConversationServer do
     %{
       new_state
       | stream_tracer: tracer,
-        acp_request_params: request_params_of(stream, data) || state.acp_request_params
+        acp_request_params: DetachedRequest.request_line(stream, data) || state.acp_request_params
     }
   end
-
-  # The `session/request_permission` line the peer relays carries the
-  # per-request timeout, and the ask that follows it does not (#1635). The
-  # peer writes the line under the **minted** request id, so the pair can be
-  # matched rather than assumed. Decoded only for a line that names the
-  # method, so an ordinary turn's thousands of updates pay a substring search
-  # and nothing else.
-  defp request_params_of("acp", data) do
-    if String.contains?(data, "session/request_permission") do
-      case Managoat.ACP.Protocol.classify_line(data) do
-        {:request, id, "session/request_permission", params} -> {id, params}
-        _ -> nil
-      end
-    end
-  end
-
-  defp request_params_of(_stream, _data), do: nil
 
   # Terminal path for an ACP turn. The order matters: stdin closes first so the
   # adapter starts exiting while we do the bookkeeping, and `current_command_ref`
@@ -2655,16 +2577,15 @@ defmodule Fountain.Conversations.ConversationServer do
     # Resolve a held permission request as the turn ends (#940): a card left
     # open is a client waiting on an answer that can never come, and the
     # turn's `pending_permission` would stay set on a turn that is over.
-    #
-    # Unless the agent asked to keep it (#1635). `:detach_permission` ran
-    # first and marked the row, and from here the answer that can come is a
-    # new turn rather than this one's peer, so the card stays up on purpose.
+    # Unless the agent asked to keep it (#1635): `:detach_permission` ran
+    # first and marked the row, and the answer that can still come is a new
+    # turn rather than this peer, so the card stays up on purpose.
     state =
       if Pending.detached?(state.current_turn),
         do: state,
-        else: resolve_pending_permission(state, "turn_ended")
+        else: Pending.resolve_held(state, "turn_ended")
 
-    state = drop_caller_tools(state, "turn_ended")
+    state = Pending.drop(state, "turn_ended")
     state = cancel_autonomous_quiet(state)
 
     turn = TurnMachine.finish(TurnMachine.from_state(state), status, span_attrs, stage_meta)
@@ -2705,63 +2626,14 @@ defmodule Fountain.Conversations.ConversationServer do
   end
 
   defp apply_effect(state, {:ask_permission, request_id, tool, options}),
-    do: ask_permission(state, request_id, tool, options)
+    do: Pending.ask(state, request_id, tool, options)
 
-  defp apply_effect(state, :detach_permission), do: detach_permission(state)
+  defp apply_effect(state, :detach_permission), do: Pending.detach(state)
 
   defp apply_effect(state, {:finish, status, span_attrs, stage_meta}),
     do: finish_acp_turn(state, status, span_attrs, stage_meta)
 
   defp apply_effect(state, {:drop_connection, why}), do: drop_connection(state, why)
-
-  # `ask`: the agent is blocked and a human has to answer (#940). The request
-  # goes on the turn row first, then the stage, then the timeout
-  # (`Pending.ask/6`); the server holds the row and the timer.
-  defp ask_permission(state, request_id, tool, options) do
-    {turn, pending} =
-      Pending.ask(
-        Pending.from_state(state),
-        state.conversation_id,
-        state.current_turn,
-        request_id,
-        tool,
-        options,
-        detached_timeout_ms(state, request_id)
-      )
-
-    %{Pending.into_state(state, pending) | current_turn: turn}
-  end
-
-  # What this request would get if the agent ends the turn waiting on it
-  # (#1635): its own `_meta.fountain.timeout`, else the effective
-  # `ask_timeout`, else the global ceiling. Decided at ask time so the
-  # `request`/`started` event can announce it, and stored on the request.
-  defp detached_timeout_ms(state, request_id) do
-    conv = Conversations._unsafe_get_conversation!(state.conversation_id)
-
-    DetachedRequest.timeout_ms(
-      request_params(state, request_id),
-      TurnMachine.effective_ask_timeout_seconds(conv, TurnMachine.agent_for(conv))
-    )
-  end
-
-  defp request_params(%{acp_request_params: {id, params}}, request_id) when id == request_id,
-    do: params
-
-  defp request_params(_state, _request_id), do: nil
-
-  # The turn is ending with its request still open (`Pending.detach/2`): the
-  # row keeps it, the deadline goes on the row, and the sweep takes over.
-  defp detach_permission(state) do
-    case state.current_turn do
-      %{pending_permission: request} = turn when is_map(request) ->
-        {turn, pending} = Pending.detach(Pending.from_state(state), turn)
-        %{Pending.into_state(state, pending) | current_turn: turn}
-
-      _ ->
-        state
-    end
-  end
 
   # ── the connection (#817) ─────────────────────────────────────────────────
 

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -2577,9 +2577,9 @@ defmodule Fountain.Conversations.ConversationServer do
     # Resolve a held permission request as the turn ends (#940): a card left
     # open is a client waiting on an answer that can never come, and the
     # turn's `pending_permission` would stay set on a turn that is over.
-    # Unless the agent asked to keep it (#1635): `:detach_permission` ran
-    # first and marked the row, and the answer that can still come is a new
-    # turn rather than this peer, so the card stays up on purpose.
+    # Unless the agent asked to keep it (#1635): `:detach_permission` marked
+    # the row first, the connection is dropped right after this (the peer is
+    # still holding the request), and the answer arrives as a new turn.
     state =
       if Pending.detached?(state.current_turn),
         do: state,

--- a/apps/fountain/lib/fountain/conversations/detached_request.ex
+++ b/apps/fountain/lib/fountain/conversations/detached_request.ex
@@ -42,13 +42,17 @@ defmodule Fountain.Conversations.DetachedRequest do
 
   ## The deadline
 
-  In seconds, most specific first:
+  In seconds:
 
   1. `_meta.fountain.timeout` on the `session/request_permission` params;
   2. `ask_timeout` in the effective permission policy
      (`Fountain.PermissionPolicy`);
   3. the global `:permission_ask_timeout_seconds` ceiling, five minutes by
      default.
+
+  Where 1 and 2 are both set the **shorter** wins: 1 is written inside the
+  sandbox and 2 is the tenant's, so the agent bounds its own wait and cannot
+  extend the tenant's. Either alone is honoured, and neither leaves 3.
 
   Only a detached request reads 1 and 2. A request held inside a running turn
   keeps the global ceiling, which still has to sit under the idle bound.
@@ -82,12 +86,20 @@ defmodule Fountain.Conversations.DetachedRequest do
 
   `params` is the request's own `session/request_permission` params (nil when
   none reached us) and `policy_seconds` the effective `ask_timeout`.
+
+  **The shorter of the two, where both are set.** The request comes from
+  inside the sandbox and the policy comes from the tenant, so letting the
+  request name the longer one would let an agent hold a tool open for days
+  against a policy that said minutes. Either alone is honoured; neither
+  leaves the global ceiling.
   """
   @spec timeout_ms(map() | nil, pos_integer() | nil) :: pos_integer()
   def timeout_ms(params, policy_seconds) do
-    case timeout_seconds(params) || policy_seconds do
-      seconds when is_integer(seconds) and seconds > 0 -> seconds * 1000
-      _ -> Lifecycle.ask_timeout_ms()
+    case {timeout_seconds(params), policy_seconds} do
+      {nil, nil} -> Lifecycle.ask_timeout_ms()
+      {request, nil} -> request * 1000
+      {nil, policy} -> policy * 1000
+      {request, policy} -> min(request, policy) * 1000
     end
   end
 

--- a/apps/fountain/lib/fountain/conversations/detached_request.ex
+++ b/apps/fountain/lib/fountain/conversations/detached_request.ex
@@ -91,6 +91,34 @@ defmodule Fountain.Conversations.DetachedRequest do
     end
   end
 
+  @doc """
+  The `session/request_permission` a relayed `acp` line carries, as
+  `{request_id, params}`, or nil.
+
+  The peer reports a held request's tool and its options, not the params they
+  came from, and the per-request timeout rides in `_meta`. It persists the
+  line immediately before it reports the ask, and under the **minted** request
+  id, so the owner can keep the last one and match it by id rather than assume
+  it. Decoded only for a line that names the method, so an ordinary turn's
+  thousands of updates pay a substring search and nothing else.
+  """
+  @spec request_line(String.t(), binary()) :: {term(), map()} | nil
+  def request_line("acp", data) do
+    if String.contains?(data, "session/request_permission") do
+      case Managoat.ACP.Protocol.classify_line(data) do
+        {:request, id, "session/request_permission", params} -> {id, params}
+        _ -> nil
+      end
+    end
+  end
+
+  def request_line(_stream, _data), do: nil
+
+  @doc "The kept `request_line/2` pair's params, when it is this request's."
+  @spec params_for({term(), map()} | nil, term()) :: map() | nil
+  def params_for({id, params}, request_id) when id == request_id, do: params
+  def params_for(_kept, _request_id), do: nil
+
   @doc "When a request raised now, waiting `timeout_ms`, is denied."
   @spec deadline(pos_integer(), DateTime.t()) :: DateTime.t()
   def deadline(timeout_ms, now \\ DateTime.utc_now()) do

--- a/apps/fountain/lib/fountain/conversations/detached_request.ex
+++ b/apps/fountain/lib/fountain/conversations/detached_request.ex
@@ -1,0 +1,173 @@
+defmodule Fountain.Conversations.DetachedRequest do
+  @moduledoc """
+  A permission request that outlived its turn (#1635): its deadline, and the
+  prompt that carries its answer back to the agent.
+
+  ## Why there is a second shape of request at all
+
+  The `ask` verdict was built for an LLM blocked mid-thought
+  (`Fountain.Conversations.Pending`). The request is held inside a running
+  turn, and the turn holding it defers idle reclaim, so the wait has to end
+  well inside the idle bound or the sandbox is destroyed by the max-lifetime
+  ceiling rather than parked (0014 gate 3, 0017).
+
+  A deterministic operation waits on something else. "Approve this production
+  apply", "confirm the DNS delegation landed", "sign off these deletes" take
+  hours or days, and nothing in the sandbox needs to run while they do. So the
+  agent sends `session/request_permission` and then answers `session/prompt`
+  with the `waiting` stop reason. The turn ends `completed` with `waiting:
+  true` on its row, the request stays `pending`, the conversation goes `idle`
+  and the sandbox parks on the usual bound.
+
+  ## What the agent gets back
+
+  The old peer cannot carry the answer. The sandbox may be suspended, and the
+  `session/request_permission` JSON-RPC id died with the connection that
+  raised it. So the answer opens a **new turn** whose `session/prompt` is one
+  line of JSON, and nothing else:
+
+      {"fountain/permission_answer":{"request_id":"7.1f0c…","tool":"Bash",
+       "outcome":"answered","option_id":"allow","answered_at":"2026-09-07T…Z"}}
+
+  `outcome` is `answered` or `timeout`. `option_id` is the option the answerer
+  picked, or the rejection the expiry chose from the agent's own list, and is
+  null where the agent offered no rejection at all (the protocol's
+  `cancelled`). The agent decides what to do with it.
+
+  One line of JSON in the prompt rather than a `_meta` field on
+  `session/prompt` because `Managoat.ACP.Peer.prompt/3` takes text and images
+  and offers no hook for protocol extensions. The map is the shape a `_meta`
+  key would carry, under the same name, so the day the peer grows one this
+  becomes a move rather than a redesign.
+
+  ## The deadline
+
+  In seconds, most specific first:
+
+  1. `_meta.fountain.timeout` on the `session/request_permission` params;
+  2. `ask_timeout` in the effective permission policy
+     (`Fountain.PermissionPolicy`);
+  3. the global `:permission_ask_timeout_seconds` ceiling, five minutes by
+     default.
+
+  Only a detached request reads 1 and 2. A request held inside a running turn
+  keeps the global ceiling, which still has to sit under the idle bound.
+  """
+
+  alias Fountain.Conversations.Lifecycle
+  alias Managoat.ACP.Permissions
+
+  @answer_key "fountain/permission_answer"
+
+  @doc "The `_meta` key an answer travels under, in both directions."
+  @spec answer_key() :: String.t()
+  def answer_key, do: @answer_key
+
+  @doc """
+  The per-request timeout in seconds, from the `session/request_permission`
+  params, or nil.
+
+  Read from `_meta.fountain.timeout`. A value that is not a positive number of
+  seconds reads as nil, so a typo falls back to the policy rather than
+  becoming "deny at once" or "never deny".
+  """
+  @spec timeout_seconds(map() | nil) :: pos_integer() | nil
+  def timeout_seconds(%{"_meta" => %{"fountain" => %{"timeout" => value}}}),
+    do: positive_seconds(value)
+
+  def timeout_seconds(_params), do: nil
+
+  @doc """
+  How long this request waits once it has detached, in milliseconds.
+
+  `params` is the request's own `session/request_permission` params (nil when
+  none reached us) and `policy_seconds` the effective `ask_timeout`.
+  """
+  @spec timeout_ms(map() | nil, pos_integer() | nil) :: pos_integer()
+  def timeout_ms(params, policy_seconds) do
+    case timeout_seconds(params) || policy_seconds do
+      seconds when is_integer(seconds) and seconds > 0 -> seconds * 1000
+      _ -> Lifecycle.ask_timeout_ms()
+    end
+  end
+
+  @doc "When a request raised now, waiting `timeout_ms`, is denied."
+  @spec deadline(pos_integer(), DateTime.t()) :: DateTime.t()
+  def deadline(timeout_ms, now \\ DateTime.utc_now()) do
+    now |> DateTime.add(timeout_ms, :millisecond) |> DateTime.truncate(:second)
+  end
+
+  @doc """
+  Whether the agent offered `option_id` for this request.
+
+  The fail-closed rule the in-turn path applies in the peer, applied here
+  where no peer is left to apply it: an option Fountain never saw the agent
+  offer is refused rather than relayed.
+  """
+  @spec offered?(map(), String.t()) :: boolean()
+  def offered?(request, option_id) do
+    request
+    |> options()
+    |> Enum.any?(&(is_map(&1) and &1["optionId"] == option_id))
+  end
+
+  @doc """
+  The option id a denial picks, or nil.
+
+  `Managoat.ACP.Permissions.deny_outcome/1` chooses from the agent's own
+  list — a `reject_*` where it offered one, and the protocol's `cancelled`
+  where it did not. Never an option the agent did not send.
+  """
+  @spec deny_option_id(map()) :: String.t() | nil
+  def deny_option_id(request) do
+    case request |> options() |> Permissions.deny_outcome() do
+      %{optionId: id} -> id
+      _ -> nil
+    end
+  end
+
+  @doc """
+  The `session/prompt` text that carries a resolution back to the agent.
+
+  One line, one JSON object, the shape at the top of this module.
+  """
+  @spec resume_prompt(map(), String.t(), String.t() | nil) :: String.t()
+  def resume_prompt(request, outcome, option_id) do
+    Jason.encode!(%{
+      @answer_key => %{
+        "request_id" => request["request_id"],
+        "tool" => request["tool"],
+        "outcome" => outcome,
+        "option_id" => option_id,
+        "answered_at" => DateTime.utc_now() |> DateTime.to_iso8601()
+      }
+    })
+  end
+
+  @doc "A pending request as a client reads it, from the turn row that holds it."
+  @spec to_json(map(), map()) :: map()
+  def to_json(request, turn) do
+    %{
+      request_id: request["request_id"],
+      tool: request["tool"],
+      options: options(request),
+      asked_at: request["asked_at"],
+      deadline: turn.permission_deadline,
+      turn_id: turn.id
+    }
+  end
+
+  defp options(%{"options" => options}) when is_list(options), do: options
+  defp options(_request), do: []
+
+  defp positive_seconds(n) when is_integer(n) and n > 0, do: n
+
+  defp positive_seconds(n) when is_binary(n) do
+    case Integer.parse(n) do
+      {i, ""} when i > 0 -> i
+      _ -> nil
+    end
+  end
+
+  defp positive_seconds(_n), do: nil
+end

--- a/apps/fountain/lib/fountain/conversations/lifecycle.ex
+++ b/apps/fountain/lib/fountain/conversations/lifecycle.ex
@@ -105,6 +105,11 @@ defmodule Fountain.Conversations.Lifecycle do
   to cost a turn rather than the agent's memory; `lifecycle_test.exs` pins
   the bound.
 
+  This is the bound for a request **held inside a turn**. A request that
+  outlived its turn (#1635) holds nothing open, so the reasoning above does
+  not reach it and its deadline may be days out; see
+  `Fountain.Conversations.DetachedRequest`.
+
   Lived on `Fountain.Runtimes.ACP` until that module left for
   `Managoat.Runtimes` (#1368); it is the one thing there that read Fountain's
   configuration, and it belongs with the bound it has to stay under.

--- a/apps/fountain/lib/fountain/conversations/pending.ex
+++ b/apps/fountain/lib/fountain/conversations/pending.ex
@@ -4,7 +4,8 @@ defmodule Fountain.Conversations.Pending do
   request the peer asked (#940), and a caller-defined tool call the tool
   bridge parked (#1202).
 
-  A value and the functions that add, answer, deny, expire and drain it.
+  A value and the functions that add, answer, deny, expire, detach and drain
+  it.
   The value is the parked calls with their timers and the permission
   timeout; the permission request itself lives on the turn row, which is
   why a request raised before a deploy is still answerable after one.
@@ -20,6 +21,7 @@ defmodule Fountain.Conversations.Pending do
   """
 
   alias Fountain.Conversations
+  alias Fountain.Conversations.DetachedRequest
   alias Fountain.Conversations.Lifecycle
 
   @type call :: %{
@@ -54,12 +56,24 @@ defmodule Fountain.Conversations.Pending do
 
   # ── permission requests (#940) ────────────────────────────────────────────
 
-  @doc "Re-arm a persisted request using its original ask time after transport recovery."
+  @doc """
+  Re-arm a persisted request using its original ask time after transport
+  recovery.
+
+  A request that outlived its turn (#1635) is skipped. Its deadline is on the
+  row and its own, and the sweep owns it; arming the in-turn timer over it
+  would deny it at the five-minute ceiling the detach exists to escape. The
+  reattach path only ever passes a `running` turn, and a detached one is
+  `completed`, so this is the belt to that braces.
+  """
   def restore_permission_timer(%__MODULE__{} = pending, turn) do
     if pending.permission_timer, do: Process.cancel_timer(pending.permission_timer)
 
     timer =
       case turn do
+        %{waiting: true} ->
+          nil
+
         %{pending_permission: %{"request_id" => id} = request} ->
           remaining =
             case DateTime.from_iso8601(request["asked_at"] || "") do
@@ -95,17 +109,40 @@ defmodule Fountain.Conversations.Pending do
   hang forever; it burns the whole lifetime and then takes the agent's memory
   with it (#649).
 
+  That reasoning stops at the turn's end, which is what `detach/2` exists for
+  (#1635): an agent that ends the turn waiting holds nothing open, so its
+  request keeps `detached_timeout_ms` instead and the sweep fires it.
+
   Returns the turn row with the request on it (unchanged when there is no
   turn) and the value with the timer armed.
   """
-  @spec ask(t(), String.t(), Conversations.Turn.t() | nil, term(), String.t(), list()) ::
-          {Conversations.Turn.t() | nil, t()}
-  def ask(%__MODULE__{} = pending, conversation_id, turn, request_id, tool, options) do
+  @spec ask(
+          t(),
+          String.t(),
+          Conversations.Turn.t() | nil,
+          term(),
+          String.t(),
+          list(),
+          pos_integer()
+        ) :: {Conversations.Turn.t() | nil, t()}
+  def ask(
+        %__MODULE__{} = pending,
+        conversation_id,
+        turn,
+        request_id,
+        tool,
+        options,
+        detached_timeout_ms
+      ) do
     request = %{
       "request_id" => request_id,
       "tool" => tool,
       "options" => options,
-      "asked_at" => DateTime.utc_now() |> DateTime.to_iso8601()
+      "asked_at" => DateTime.utc_now() |> DateTime.to_iso8601(),
+      # Decided here, spent only if the turn ends waiting (#1635). Announced
+      # now so a card can say how long it has once it detaches, rather than
+      # learning it from a second event.
+      "detached_timeout_ms" => detached_timeout_ms
     }
 
     turn =
@@ -124,7 +161,11 @@ defmodule Fountain.Conversations.Pending do
       # The agent's own list, verbatim. A client must never offer an option
       # that is not on it.
       options: options,
-      timeout_ms: Lifecycle.ask_timeout_ms()
+      timeout_ms: Lifecycle.ask_timeout_ms(),
+      # What the request gets instead if the agent ends the turn waiting on it
+      # (#1635). The two differ only where a per-request or policy-level
+      # `ask_timeout` is set.
+      detached_timeout_ms: detached_timeout_ms
     })
 
     timer =
@@ -240,6 +281,48 @@ defmodule Fountain.Conversations.Pending do
 
     {turn, %{pending | permission_timer: nil}}
   end
+
+  @doc """
+  The turn is ending and the agent asked to keep its request (#1635).
+
+  The agent answered `session/prompt` with the `waiting` stop reason while a
+  request was still held, so instead of denying it as the turn's end normally
+  does, the request outlives the turn: the row is marked `waiting`, the
+  deadline decided at ask time is written onto it, and the in-process timer is
+  dropped. From here the request is the sweep's
+  (`Fountain.Workers.DetachedRequestSweeper`), because the sandbox is about to
+  park and this process is about to have nothing left to do.
+
+  Returns the turn row with the flag on it and the value with no timer.
+  """
+  @spec detach(t(), Conversations.Turn.t()) :: {Conversations.Turn.t(), t()}
+  def detach(%__MODULE__{} = pending, %{pending_permission: request} = turn)
+      when is_map(request) do
+    if pending.permission_timer, do: Process.cancel_timer(pending.permission_timer)
+
+    deadline =
+      request
+      |> Map.get("detached_timeout_ms")
+      |> case do
+        ms when is_integer(ms) and ms > 0 -> ms
+        _ -> Lifecycle.ask_timeout_ms()
+      end
+      |> DetachedRequest.deadline()
+
+    {:ok, turn} =
+      Conversations._unsafe_update_turn(turn, %{
+        waiting: true,
+        permission_deadline: deadline,
+        pending_permission: Map.put(request, "deadline", DateTime.to_iso8601(deadline))
+      })
+
+    {turn, %{pending | permission_timer: nil}}
+  end
+
+  @doc "Whether this turn ended holding a request that outlived it (#1635)."
+  @spec detached?(Conversations.Turn.t() | nil) :: boolean()
+  def detached?(%{waiting: true, pending_permission: request}) when is_map(request), do: true
+  def detached?(_turn), do: false
 
   @doc "The tool the turn is blocked on, or nil."
   @spec pending_tool(Conversations.Turn.t() | nil) :: String.t() | nil

--- a/apps/fountain/lib/fountain/conversations/pending.ex
+++ b/apps/fountain/lib/fountain/conversations/pending.ex
@@ -23,6 +23,7 @@ defmodule Fountain.Conversations.Pending do
   alias Fountain.Conversations
   alias Fountain.Conversations.DetachedRequest
   alias Fountain.Conversations.Lifecycle
+  alias Fountain.Conversations.TurnMachine
 
   @type call :: %{
           id: String.t(),
@@ -53,6 +54,85 @@ defmodule Fountain.Conversations.Pending do
   @spec into_state(map(), t()) :: map()
   def into_state(state, %__MODULE__{} = pending),
     do: %{state | caller_calls: pending.calls, permission_timer: pending.permission_timer}
+
+  @doc """
+  The server's whole pending family, over the server's state (#1369).
+
+  Each of these is `from_state/1`, the operation, then `into_state/2` and the
+  turn row written back. They lived in the `ConversationServer` as a private
+  adapter apiece, which is one round trip of boilerplate per call site in a
+  file that only shrinks. `ask/4` reads the request params the server kept
+  (`DetachedRequest.request_line/2`); the rest take what they need from state.
+  """
+  @spec ask(map(), term(), String.t(), list()) :: map()
+  def ask(state, request_id, tool, options) do
+    over(state, fn pending, turn ->
+      ask(
+        pending,
+        state.conversation_id,
+        turn,
+        request_id,
+        tool,
+        options,
+        DetachedRequest.params_for(state.acp_request_params, request_id)
+      )
+    end)
+  end
+
+  @doc "The turn is ending and its request outlives it (#1635)."
+  @spec detach(map()) :: map()
+  def detach(state), do: over(state, &detach(&1, &2))
+
+  @doc "One request's end, whichever way."
+  @spec resolve(map(), term(), String.t(), String.t() | nil) :: map()
+  def resolve(state, request_id, outcome, option_id) do
+    over(state, fn pending, turn ->
+      resolve_permission(
+        pending,
+        state.conversation_id,
+        turn,
+        state.acp_peer,
+        request_id,
+        outcome,
+        option_id
+      )
+    end)
+  end
+
+  @doc "Whatever is held, if anything, as the turn ends."
+  @spec resolve_held(map(), String.t()) :: map()
+  def resolve_held(state, outcome) do
+    over(state, fn pending, turn ->
+      resolve_pending_permission(pending, state.conversation_id, turn, state.acp_peer, outcome)
+    end)
+  end
+
+  @doc "Everything still parked when the turn ends."
+  @spec drop(map(), String.t()) :: map()
+  def drop(state, outcome) do
+    into_state(state, drop_calls(from_state(state), state.conversation_id, outcome))
+  end
+
+  @doc "A human's answer, with the reply to hand back to them."
+  @spec answer(map(), term(), String.t()) :: {:ok | {:error, term()}, map()}
+  def answer(state, request_id, option_id) do
+    {reply, turn, pending} =
+      answer_permission(
+        from_state(state),
+        state.conversation_id,
+        state.current_turn,
+        state.acp_peer,
+        request_id,
+        option_id
+      )
+
+    {reply, %{into_state(state, pending) | current_turn: turn}}
+  end
+
+  defp over(state, fun) do
+    {turn, pending} = fun.(from_state(state), state.current_turn)
+    %{into_state(state, pending) | current_turn: turn}
+  end
 
   # ── permission requests (#940) ────────────────────────────────────────────
 
@@ -123,17 +203,12 @@ defmodule Fountain.Conversations.Pending do
           term(),
           String.t(),
           list(),
-          pos_integer()
+          map() | nil
         ) :: {Conversations.Turn.t() | nil, t()}
-  def ask(
-        %__MODULE__{} = pending,
-        conversation_id,
-        turn,
-        request_id,
-        tool,
-        options,
-        detached_timeout_ms
-      ) do
+  def ask(%__MODULE__{} = pending, conversation_id, turn, request_id, tool, options, params) do
+    detached_timeout_ms =
+      DetachedRequest.timeout_ms(params, effective_ask_timeout_seconds(conversation_id))
+
     request = %{
       "request_id" => request_id,
       "tool" => tool,
@@ -176,6 +251,14 @@ defmodule Fountain.Conversations.Pending do
       )
 
     {turn, %{pending | permission_timer: timer}}
+  end
+
+  # The conversation's own `ask_timeout`, agent and launch merged
+  # (`Fountain.PermissionPolicy`). Ownership: the caller is the server for this
+  # conversation, established at its `init/1`.
+  defp effective_ask_timeout_seconds(conversation_id) do
+    conv = Conversations._unsafe_get_conversation!(conversation_id)
+    TurnMachine.effective_ask_timeout_seconds(conv, TurnMachine.agent_for(conv))
   end
 
   @doc """
@@ -295,7 +378,7 @@ defmodule Fountain.Conversations.Pending do
 
   Returns the turn row with the flag on it and the value with no timer.
   """
-  @spec detach(t(), Conversations.Turn.t()) :: {Conversations.Turn.t(), t()}
+  @spec detach(t(), Conversations.Turn.t() | nil) :: {Conversations.Turn.t() | nil, t()}
   def detach(%__MODULE__{} = pending, %{pending_permission: request} = turn)
       when is_map(request) do
     if pending.permission_timer, do: Process.cancel_timer(pending.permission_timer)
@@ -318,6 +401,21 @@ defmodule Fountain.Conversations.Pending do
 
     {turn, %{pending | permission_timer: nil}}
   end
+
+  def detach(%__MODULE__{} = pending, turn), do: {turn, pending}
+
+  @doc """
+  Whether this turn is holding `request_id` open inside itself.
+
+  False for a turn that ended `waiting` (#1635): its request is on the row,
+  but the peer that raised it is driving nothing, so an answer relayed down
+  that connection would be reported as landed and reach nobody.
+  """
+  @spec holds?(Conversations.Turn.t() | nil, term()) :: boolean()
+  def holds?(%{pending_permission: %{"request_id" => id}, waiting: waiting}, request_id),
+    do: id == request_id and waiting != true
+
+  def holds?(_turn, _request_id), do: false
 
   @doc "Whether this turn ended holding a request that outlived it (#1635)."
   @spec detached?(Conversations.Turn.t() | nil) :: boolean()

--- a/apps/fountain/lib/fountain/conversations/pending.ex
+++ b/apps/fountain/lib/fountain/conversations/pending.ex
@@ -66,16 +66,15 @@ defmodule Fountain.Conversations.Pending do
   """
   @spec ask(map(), term(), String.t(), list()) :: map()
   def ask(state, request_id, tool, options) do
+    params = DetachedRequest.params_for(state.acp_request_params, request_id)
+
+    # Consumed, so dropped. Those params are the agent's whole request,
+    # `rawInput` included, and that is tenant data with no reason to sit in a
+    # server's state for the life of a connection.
+    state = %{state | acp_request_params: nil}
+
     over(state, fn pending, turn ->
-      ask(
-        pending,
-        state.conversation_id,
-        turn,
-        request_id,
-        tool,
-        options,
-        DetachedRequest.params_for(state.acp_request_params, request_id)
-      )
+      ask(pending, state.conversation_id, turn, request_id, tool, options, params)
     end)
   end
 

--- a/apps/fountain/lib/fountain/conversations/turn.ex
+++ b/apps/fountain/lib/fountain/conversations/turn.ex
@@ -34,6 +34,18 @@ defmodule Fountain.Conversations.Turn do
     # nothing is outstanding. Persisted so a request raised before a deploy is
     # still answerable after one.
     field :pending_permission, :map
+    # The turn ended with that request still open (#1635): the agent answered
+    # `session/prompt` with the `waiting` stop reason instead of holding the
+    # turn until a human decided. The turn is `completed`, the conversation is
+    # `idle` and the sandbox may park; the request stays on the row until it
+    # is answered or `permission_deadline` passes. False on every other turn.
+    field :waiting, :boolean, default: false
+    # When a detached request is denied for want of an answer. A column rather
+    # than a key inside `pending_permission` because the sweep that fires it
+    # (`Fountain.Workers.DetachedRequestSweeper`) is an indexed query, and
+    # because a process timer cannot outlive the suspend this whole path
+    # exists to allow. nil while nothing is waiting.
+    field :permission_deadline, :utc_datetime
     # The turn's token usage as the runtime reported it when the turn ended
     # (#827): `%{"input" => n, "output" => n, "cache_read" => n?,
     # "cache_write" => n?}`. Written once by `Conversations._unsafe_record_turn_usage/2`,
@@ -68,6 +80,8 @@ defmodule Fountain.Conversations.Turn do
       :orphaned_at,
       :acp_prompt_id,
       :pending_permission,
+      :waiting,
+      :permission_deadline,
       :usage,
       :model_selection,
       :reply_text,

--- a/apps/fountain/lib/fountain/conversations/turn_machine.ex
+++ b/apps/fountain/lib/fountain/conversations/turn_machine.ex
@@ -29,6 +29,9 @@ defmodule Fountain.Conversations.TurnMachine do
       by the failure rather than by a wake);
     * `{:ask_permission, request_id, tool, options}` — the held request:
       its row, its stage, its timeout (the pending family, #1375);
+    * `:detach_permission` — the turn is ending `waiting` and its request
+      outlives it (#1635); applied before `{:finish, …}`, which then leaves
+      the request alone;
     * `{:finish, status, span_attrs, stage_meta}` — end the turn: the
       server resolves what is pending, cancels the quiet timer, then calls
       `finish/4`;
@@ -45,6 +48,7 @@ defmodule Fountain.Conversations.TurnMachine do
 
   alias Fountain.{Agents, Conversations}
   alias Fountain.Conversations.{Conversation, Labels}
+  alias Fountain.PermissionPolicy
 
   @typedoc "What the peer reports about a turn, with the command ref already matched."
   @type payload :: tuple()
@@ -72,6 +76,7 @@ defmodule Fountain.Conversations.TurnMachine do
           | {:session_id, String.t()}
           | {:forget_runtime_session, String.t(), String.t()}
           | {:ask_permission, term(), String.t(), list()}
+          | :detach_permission
           | {:finish, String.t(), map(), map()}
           | {:drop_connection, String.t()}
 
@@ -352,14 +357,25 @@ defmodule Fountain.Conversations.TurnMachine do
   # `usage` is the turn's end-of-turn token figure (#827), recorded once here
   # — the response is the only place the runtime reports it — before the turn
   # row is closed. nil records nothing.
+  #
+  # `waiting` is the fourth stop reason, and the only one that changes what
+  # the turn's end does rather than what it is called (#1635). An agent that
+  # sends `session/request_permission` and then answers the prompt with it is
+  # saying the wait is longer than a turn: the request is detached instead of
+  # denied, the turn still ends `completed`, and the sandbox parks on the
+  # usual bound with the card still up. With nothing held it means nothing,
+  # and the turn ends as any other completed turn does.
   def handle(%__MODULE__{} = turn, {:done, stop_reason, usage}, ctx) do
     status = if stop_reason in ["refusal", "cancelled"], do: "failed", else: "completed"
     record_usage(turn, with_inference(usage, ctx))
 
+    detach = if waiting?(stop_reason, turn.row), do: [:detach_permission], else: []
+
     {turn,
-     [
-       {:finish, status, %{"stop_reason" => stop_reason}, %{stop_reason: stop_reason}}
-     ]}
+     detach ++
+       [
+         {:finish, status, %{"stop_reason" => stop_reason}, %{stop_reason: stop_reason}}
+       ]}
   end
 
   # #655: the org has refused this account's Claude OAuth token. Left alone,
@@ -569,7 +585,9 @@ defmodule Fountain.Conversations.TurnMachine do
       turn.conversation_id,
       "turn",
       if(status == "completed", do: "done", else: "failed"),
-      Map.merge(%{turn_id: row.id, turn_number: row.turn_number}, stage_meta)
+      %{turn_id: row.id, turn_number: row.turn_number}
+      |> Map.merge(stage_meta)
+      |> Map.merge(waiting_meta(row))
     )
 
     end_span(
@@ -585,6 +603,19 @@ defmodule Fountain.Conversations.TurnMachine do
 
     %{turn | row: nil, span: nil, metrics: nil, tracer: nil}
   end
+
+  defp waiting?("waiting", %{pending_permission: %{"request_id" => _}}), do: true
+  defp waiting?(_stop_reason, _row), do: false
+
+  # A turn that ended holding a request (#1635) says so where every client
+  # already looks. The `request`/`started` event announced the request; this
+  # is what tells a card watching the stream that the request outlived the
+  # turn and by when it has to be answered.
+  defp waiting_meta(%{waiting: true, pending_permission: %{"request_id" => id}} = row) do
+    %{waiting: true, request_id: id, deadline: row.permission_deadline}
+  end
+
+  defp waiting_meta(_row), do: %{}
 
   @doc """
   The interrupt's first half: the row `interrupted`, the stage, the tracer
@@ -1117,7 +1148,25 @@ defmodule Fountain.Conversations.TurnMachine do
   # tightening an agent tightens the conversations already running under it.
   @spec effective_permission_policy(Conversation.t(), map() | nil) :: term()
   def effective_permission_policy(conv, agent) do
-    Managoat.ACP.Permissions.effective(agent && agent.permission_policy, conv.permission_policy)
+    Managoat.ACP.Permissions.effective(
+      PermissionPolicy.verdicts(agent && agent.permission_policy),
+      PermissionPolicy.verdicts(conv.permission_policy)
+    )
+  end
+
+  @doc """
+  How long a request that outlives this conversation's turn waits, in
+  seconds, or nil for the global ceiling (#1635).
+
+  Beside `effective_permission_policy/2` because it is the other half of the
+  same two maps: the tool half goes to the peer, and this one stays here.
+  """
+  @spec effective_ask_timeout_seconds(Conversation.t(), map() | nil) :: pos_integer() | nil
+  def effective_ask_timeout_seconds(conv, agent) do
+    PermissionPolicy.effective_ask_timeout_seconds(
+      agent && agent.permission_policy,
+      conv.permission_policy
+    )
   end
 
   # Ownership is already established: this server exists for this conversation.

--- a/apps/fountain/lib/fountain/conversations/turn_machine.ex
+++ b/apps/fountain/lib/fountain/conversations/turn_machine.ex
@@ -31,7 +31,8 @@ defmodule Fountain.Conversations.TurnMachine do
       its row, its stage, its timeout (the pending family, #1375);
     * `:detach_permission` — the turn is ending `waiting` and its request
       outlives it (#1635); applied before `{:finish, …}`, which then leaves
-      the request alone;
+      the request alone, and followed by `{:drop_connection, …}`, because
+      the peer is still holding the request it raised;
     * `{:finish, status, span_attrs, stage_meta}` — end the turn: the
       server resolves what is pending, cancels the quiet timer, then calls
       `finish/4`;
@@ -365,17 +366,29 @@ defmodule Fountain.Conversations.TurnMachine do
   # denied, the turn still ends `completed`, and the sandbox parks on the
   # usual bound with the card still up. With nothing held it means nothing,
   # and the turn ends as any other completed turn does.
+  #
+  # **The connection goes with it**, which the usual end (#817) keeps alive.
+  # The peer still holds the request it raised: `hold_permission` filled its
+  # single `pending_permission` slot, and only an answer or a denial clears
+  # it — neither of which the detached path sends, since the answer arrives
+  # as a new turn instead. claude-agent-acp and codex both number their
+  # requests from 0 *per turn* (`mint_request_id/1`), so the resume turn's
+  # first `session/request_permission` would arrive under the same JSON-RPC
+  # id, match the peer's `held?/2` against the stale hold, and be swallowed:
+  # no response, no report, no card, no timeout, and an agent blocked with
+  # nothing to reclaim it (`SANDBOX_MAX_LIFETIME_HOURS` is 0 by default).
+  # A fresh peer costs one handshake, and is what the idle park does minutes
+  # later anyway.
   def handle(%__MODULE__{} = turn, {:done, stop_reason, usage}, ctx) do
     status = if stop_reason in ["refusal", "cancelled"], do: "failed", else: "completed"
     record_usage(turn, with_inference(usage, ctx))
+    finish = {:finish, status, %{"stop_reason" => stop_reason}, %{stop_reason: stop_reason}}
 
-    detach = if waiting?(stop_reason, turn.row), do: [:detach_permission], else: []
-
-    {turn,
-     detach ++
-       [
-         {:finish, status, %{"stop_reason" => stop_reason}, %{stop_reason: stop_reason}}
-       ]}
+    if waiting?(stop_reason, turn.row) do
+      {turn, [:detach_permission, finish, {:drop_connection, "permission_detached"}]}
+    else
+      {turn, [finish]}
+    end
   end
 
   # #655: the org has refused this account's Claude OAuth token. Left alone,
@@ -611,8 +624,12 @@ defmodule Fountain.Conversations.TurnMachine do
   # already looks. The `request`/`started` event announced the request; this
   # is what tells a card watching the stream that the request outlived the
   # turn and by when it has to be answered.
+  #
+  # The two fields are prefixed rather than bare. A client pairs a permission
+  # card to its resolution on `request_id`, and a bare one on a `turn` event
+  # would pair to a card that event is not about.
   defp waiting_meta(%{waiting: true, pending_permission: %{"request_id" => id}} = row) do
-    %{waiting: true, request_id: id, deadline: row.permission_deadline}
+    %{waiting: true, waiting_request_id: id, waiting_deadline: row.permission_deadline}
   end
 
   defp waiting_meta(_row), do: %{}

--- a/apps/fountain/lib/fountain/permission_policy.ex
+++ b/apps/fountain/lib/fountain/permission_policy.ex
@@ -1,0 +1,137 @@
+defmodule Fountain.PermissionPolicy do
+  @moduledoc """
+  The Fountain half of a `permission_policy` map (#1635).
+
+  `Managoat.ACP.Permissions` owns the tool half: a key is a tool title or an
+  ACP kind, a value is one of the three verdicts, and `"default"` covers the
+  rest. That library reads every key it is given as a tool, so a key that is
+  not one has to be taken out before the map reaches it. This module owns the
+  taking out, and the one such key that exists.
+
+  ## `ask_timeout`
+
+  How long a request that outlived its turn waits, in seconds. Only detached
+  requests read it. A request held inside a running turn keeps the global
+  `:permission_ask_timeout_seconds` ceiling, which has to stay under the idle
+  bound because the turn holding it defers idle reclaim
+  (`Fountain.Conversations.Lifecycle.ask_timeout_ms/0`). A detached request
+  holds nothing open, so that reasoning does not reach it and the value may
+  be days.
+
+  ## Narrowing
+
+  A launch policy may only narrow the agent's, and the same rule applies
+  here: a **shorter** wait is the stricter one, because the tool is refused
+  sooner. `effective_ask_timeout_seconds/2` takes the smaller of the two, and
+  `check_narrows/2` refuses a launch that asks for a longer one.
+  """
+
+  @ask_timeout "ask_timeout"
+
+  # Keys of a permission policy that name no tool. Everything here is stripped
+  # before the map reaches `Managoat.ACP.Permissions`, whose every function
+  # reads a key as a tool and a value as a verdict.
+  @reserved [@ask_timeout]
+
+  @doc "Policy keys that name something other than a tool."
+  @spec reserved_keys() :: [String.t()]
+  def reserved_keys, do: @reserved
+
+  @doc "Whether `key` names something other than a tool."
+  @spec reserved?(term()) :: boolean()
+  def reserved?(key), do: key in @reserved
+
+  @doc """
+  The tool half of a policy: what `Managoat.ACP.Permissions` is given.
+
+  Every call into that library goes through here. A reserved key left in
+  would be read as a tool whose verdict is not a verdict, which
+  `verdict_for/2` treats as `auto_deny` and `effective/2` would then write
+  back into the merged map.
+  """
+  @spec verdicts(map() | nil) :: map()
+  def verdicts(policy) when is_map(policy), do: Map.drop(policy, @reserved)
+  def verdicts(_policy), do: %{}
+
+  @doc """
+  Carry the reserved keys of `previous` onto `policy`.
+
+  The console's agent form rebuilds the tool half from its own inputs and
+  knows nothing about the rest, so without this a save from that form would
+  silently drop a configured `ask_timeout`.
+  """
+  @spec keep_reserved(map(), map() | nil) :: map()
+  def keep_reserved(policy, previous) when is_map(policy) do
+    Map.merge(policy, Map.take(previous || %{}, @reserved))
+  end
+
+  @doc """
+  The `ask_timeout` a policy names, in seconds, or nil.
+
+  A positive integer, or a string of one. Anything else reads as nil rather
+  than as zero, because "not a number" must not become "deny at once".
+  """
+  @spec ask_timeout_seconds(map() | nil) :: pos_integer() | nil
+  def ask_timeout_seconds(policy) when is_map(policy) do
+    to_positive_seconds(Map.get(policy, @ask_timeout))
+  end
+
+  def ask_timeout_seconds(_policy), do: nil
+
+  @doc """
+  The `ask_timeout` in force for a conversation, in seconds, or nil.
+
+  The smaller of the agent's and the launch's, which is the stricter of the
+  two. Either side alone is honoured; neither leaves nil, and the caller
+  falls back to the global ceiling.
+  """
+  @spec effective_ask_timeout_seconds(map() | nil, map() | nil) :: pos_integer() | nil
+  def effective_ask_timeout_seconds(agent_policy, launch_policy) do
+    case {ask_timeout_seconds(agent_policy), ask_timeout_seconds(launch_policy)} do
+      {nil, nil} -> nil
+      {agent, nil} -> agent
+      {nil, launch} -> launch
+      {agent, launch} -> min(agent, launch)
+    end
+  end
+
+  @doc """
+  Whether `launch` narrows `agent` on every reserved key.
+
+  `:ok`, or `{:error, {:permission_policy_widens, key}}` naming the first key
+  the launch would loosen — the same shape `Managoat.ACP.Permissions.check_narrows/2`
+  returns, so a caller checks both and reports either the same way.
+  """
+  @spec check_narrows(map() | nil, map() | nil) ::
+          :ok | {:error, {:permission_policy_widens, String.t()}}
+  def check_narrows(agent, launch) do
+    case {ask_timeout_seconds(agent), ask_timeout_seconds(launch)} do
+      {a, l} when is_integer(a) and is_integer(l) and l > a ->
+        {:error, {:permission_policy_widens, @ask_timeout}}
+
+      _ ->
+        :ok
+    end
+  end
+
+  @doc """
+  Whether `value` is an acceptable `ask_timeout`, for a changeset.
+
+  Deliberately not bounded above: the point of a detached request is that it
+  can wait for days, and a ceiling here would be a second, quieter copy of
+  the idle bound this key exists to escape.
+  """
+  @spec valid_ask_timeout?(term()) :: boolean()
+  def valid_ask_timeout?(value), do: not is_nil(to_positive_seconds(value))
+
+  defp to_positive_seconds(n) when is_integer(n) and n > 0, do: n
+
+  defp to_positive_seconds(n) when is_binary(n) do
+    case Integer.parse(n) do
+      {i, ""} when i > 0 -> i
+      _ -> nil
+    end
+  end
+
+  defp to_positive_seconds(_n), do: nil
+end

--- a/apps/fountain/lib/fountain/permission_policy.ex
+++ b/apps/fountain/lib/fountain/permission_policy.ex
@@ -101,11 +101,18 @@ defmodule Fountain.PermissionPolicy do
   `:ok`, or `{:error, {:permission_policy_widens, key}}` naming the first key
   the launch would loosen — the same shape `Managoat.ACP.Permissions.check_narrows/2`
   returns, so a caller checks both and reports either the same way.
+
+  `ceiling_seconds` is what applies when the agent names no `ask_timeout`, and
+  it is the host's own global ask timeout. Without it an agent that never set
+  the key would let any launch buy a wait of days, which is the escalation the
+  narrowing rule exists to stop: a longer wait is more time for somebody to
+  approve the tool, so longer is looser. The host reads its configuration and
+  passes it, as `Managoat.ACP.Permissions.ask_timeout_ms/1` is given its own.
   """
-  @spec check_narrows(map() | nil, map() | nil) ::
+  @spec check_narrows(map() | nil, map() | nil, pos_integer() | nil) ::
           :ok | {:error, {:permission_policy_widens, String.t()}}
-  def check_narrows(agent, launch) do
-    case {ask_timeout_seconds(agent), ask_timeout_seconds(launch)} do
+  def check_narrows(agent, launch, ceiling_seconds \\ nil) do
+    case {ask_timeout_seconds(agent) || ceiling_seconds, ask_timeout_seconds(launch)} do
       {a, l} when is_integer(a) and is_integer(l) and l > a ->
         {:error, {:permission_policy_widens, @ask_timeout}}
 

--- a/apps/fountain/lib/fountain/workers/detached_request_sweeper.ex
+++ b/apps/fountain/lib/fountain/workers/detached_request_sweeper.ex
@@ -59,6 +59,12 @@ defmodule Fountain.Workers.DetachedRequestSweeper do
   # a legitimate caller. The resolution is guarded on the request id, so a
   # client answering in the same second wins or loses cleanly rather than
   # both landing.
+  #
+  # A conversation that cannot take the resume turn right now — a turn of its
+  # own is running, the account is suspended, the balance is spent — leaves
+  # the row exactly as it was. The deadline has passed, so the denial is owed
+  # either way, but resolving it into a prompt nobody delivers loses it with
+  # nothing to retry from. This runs every minute; the next one carries it.
   defp expire(%Turn{} = turn) do
     case Conversations._unsafe_expire_detached_request(turn) do
       :ok ->
@@ -73,14 +79,12 @@ defmodule Fountain.Workers.DetachedRequestSweeper do
         false
 
       {:error, reason} ->
-        Logger.warning(
-          "detached_request_sweeper: could not resume conversation " <>
-            "#{turn.conversation_id} after denying its request: #{inspect(reason)}"
+        Logger.info(
+          "detached_request_sweeper: leaving the request on turn #{turn.id} " <>
+            "(conversation #{turn.conversation_id}) for the next sweep: #{inspect(reason)}"
         )
 
-        # The request itself is resolved either way; only the resume turn
-        # failed to open, and that is what the log line is for.
-        true
+        false
     end
   end
 end

--- a/apps/fountain/lib/fountain/workers/detached_request_sweeper.ex
+++ b/apps/fountain/lib/fountain/workers/detached_request_sweeper.ex
@@ -1,0 +1,86 @@
+defmodule Fountain.Workers.DetachedRequestSweeper do
+  @moduledoc """
+  Denies permission requests that outlived their turn and then ran out of
+  time (#1635).
+
+  A request held inside a running turn is timed by a process timer in the
+  `ConversationServer`. A detached one cannot be: the whole point of it is
+  that the sandbox parks and the server stops while the request waits, and a
+  deploy in the middle of a two-day wait would drop the timer with nothing to
+  notice. So the deadline lives on the turn row (`turns.permission_deadline`,
+  with a partial index over `waiting`) and this sweep is what reads it.
+
+  Expiry is a denial, which is the only safe default, and the denial reaches
+  the agent the same way an answer does: the request is resolved on the row
+  and a new turn is opened carrying the outcome, waking the sandbox. The
+  option it names is one the agent itself offered.
+
+  The grain is a minute. A detached deadline is hours or days, so a minute of
+  overshoot is immaterial, and the query is one indexed read that is empty
+  almost every time. The batch is capped so a backlog cannot wake a hundred
+  sandboxes at once.
+  """
+
+  use Oban.Worker, queue: :maintenance, max_attempts: 3
+
+  import Ecto.Query
+
+  require Logger
+
+  alias Fountain.Conversations
+  alias Fountain.Conversations.Turn
+  alias Fountain.Repo
+
+  @sweep_limit 25
+
+  @impl Oban.Worker
+  def perform(_job) do
+    expired = sweep_expired_requests()
+
+    if expired > 0, do: Logger.info("detached_request_sweeper: expired=#{expired}")
+
+    :telemetry.execute([:fountain, :detached_request_sweeper, :run], %{expired: expired}, %{})
+
+    :ok
+  end
+
+  @doc false
+  def sweep_expired_requests(now \\ DateTime.utc_now()) do
+    Turn
+    |> where([t], t.waiting == true and not is_nil(t.pending_permission))
+    |> where([t], t.permission_deadline <= ^now)
+    |> order_by([t], asc: t.permission_deadline)
+    |> limit(^@sweep_limit)
+    |> Repo.all()
+    |> Enum.count(&expire/1)
+  end
+
+  # Ownership: a system sweep, which ADR 0013 and the `_unsafe_` rules name as
+  # a legitimate caller. The resolution is guarded on the request id, so a
+  # client answering in the same second wins or loses cleanly rather than
+  # both landing.
+  defp expire(%Turn{} = turn) do
+    case Conversations._unsafe_expire_detached_request(turn) do
+      :ok ->
+        Logger.info(
+          "detached_request_sweeper: denied request on turn #{turn.id} " <>
+            "(conversation #{turn.conversation_id}) after its deadline"
+        )
+
+        true
+
+      {:error, :no_pending_permission} ->
+        false
+
+      {:error, reason} ->
+        Logger.warning(
+          "detached_request_sweeper: could not resume conversation " <>
+            "#{turn.conversation_id} after denying its request: #{inspect(reason)}"
+        )
+
+        # The request itself is resolved either way; only the resume turn
+        # failed to open, and that is what the log line is for.
+        true
+    end
+  end
+end

--- a/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
@@ -557,8 +557,12 @@ defmodule FountainWeb.ConversationController do
     responses: [
       ok: {"Answered", "application/json", Schemas.PermissionAnswerResponse},
       not_found: {"Not found", "application/json", Schemas.Error},
-      conflict: {"Already resolved", "application/json", Schemas.Error},
-      unprocessable_entity: {"Unknown option", "application/json", Schemas.Error}
+      conflict:
+        {"Already resolved, or resolved but not delivered", "application/json", Schemas.Error},
+      unprocessable_entity: {"Unknown option", "application/json", Schemas.Error},
+      bad_request: {"Busy", "application/json", Schemas.Error},
+      payment_required: {"Insufficient credits", "application/json", Schemas.Error},
+      forbidden: {"The sandbox may not answer", "application/json", Schemas.Error}
     ]
   )
 
@@ -610,6 +614,22 @@ defmodule FountainWeb.ConversationController do
   # A turn is running, so the resume turn a detached answer opens cannot queue
   # behind it (#1635). The request is untouched; try again when it is idle.
   defp answer_response({:error, :busy}, _conn), do: {:error, "conversation_busy"}
+
+  # The request was resolved and the turn that carries it back could not be
+  # opened. Its own code, because the 409 above tells a client to give up on a
+  # request somebody else took, and this one has to say the opposite: the
+  # answer landed, the agent has not heard it, and a prompt is what wakes it.
+  defp answer_response({:error, :answer_not_delivered}, conn) do
+    conn
+    |> put_status(:conflict)
+    |> json(%{
+      error: "permission_answer_not_delivered",
+      message:
+        "The answer was recorded and the request is resolved, but the turn that " <>
+          "carries it to the agent could not be opened. Send a prompt to the " <>
+          "conversation to wake it."
+    })
+  end
 
   # Everything else renders through the FallbackController, for the reason
   # `do_prompt/5` gives: an error shape this function has not learned used to

--- a/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
@@ -225,8 +225,18 @@ defmodule FountainWeb.ConversationController do
     # last_active_at, as the plain fetch would, is worse than not serving
     # the fields at all.
     case Conversations.get_conversation_with_activity(id, user.id) do
-      nil -> {:error, :not_found}
-      conv -> render(conn, :show, conversation: conv)
+      nil ->
+        {:error, :not_found}
+
+      conv ->
+        # Ownership: established by the tenant-scoped fetch above. Requests
+        # that outlived a turn (#1635) are served here rather than on the
+        # list, because a conversation is idle while one waits and the card
+        # has to survive a client reload.
+        render(conn, :show,
+          conversation: conv,
+          pending_requests: Conversations._unsafe_list_pending_requests(conv.id)
+        )
     end
   end
 
@@ -533,7 +543,12 @@ defmodule FountainWeb.ConversationController do
         "that block carried. Never send an option the agent did not offer.\n\n" <>
         "First answer wins: another attached client, the timeout, or the turn ending " <>
         "may already have resolved it, and all of those return 409. The resolution " <>
-        "appears on the stream as a `request` stage event with state `done`.",
+        "appears on the stream as a `request` stage event with state `done`.\n\n" <>
+        "A request that outlived its turn (#1635) is answered here too. The agent " <>
+        "ended that turn with stop reason `waiting`, so the conversation is idle and " <>
+        "the sandbox may be suspended; GET /api/conversations/{id} lists such " <>
+        "requests as `pending_requests`. Answering one resolves it and opens a new " <>
+        "turn carrying the request id and the option, which wakes the sandbox.",
     parameters: [
       conversation_id: [in: :path, type: :string, required: true],
       request_id: [in: :path, type: :string, required: true]
@@ -591,6 +606,15 @@ defmodule FountainWeb.ConversationController do
   defp answer_response({:error, :not_found}, conn) do
     conn |> put_status(:not_found) |> json(%{error: "not_found"})
   end
+
+  # A turn is running, so the resume turn a detached answer opens cannot queue
+  # behind it (#1635). The request is untouched; try again when it is idle.
+  defp answer_response({:error, :busy}, _conn), do: {:error, "conversation_busy"}
+
+  # Everything else renders through the FallbackController, for the reason
+  # `do_prompt/5` gives: an error shape this function has not learned used to
+  # be a FunctionClauseError 500.
+  defp answer_response({:error, _} = err, _conn), do: err
 
   @doc """
   Infer the conversation's `source` and `parent_conversation_id` from

--- a/apps/fountain/lib/fountain_web/controllers/conversation_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_json.ex
@@ -7,6 +7,13 @@ defmodule FountainWeb.ConversationJSON do
   def show(%{conversation: conv, resumed: resumed?}),
     do: %{data: data(conv), meta: %{resumed: resumed?}}
 
+  # Requests that outlived a turn (#1635). Served on `show` only: the
+  # conversation is idle while one waits, so a client that reloads has
+  # nowhere else to learn the card is still up, and a list of conversations
+  # would pay a query per row for something almost always empty.
+  def show(%{conversation: conv, pending_requests: requests}),
+    do: %{data: Map.put(data(conv), :pending_requests, Enum.map(requests, &request_data/1))}
+
   def show(%{conversation: conv}), do: %{data: data(conv)}
   def turns(%{turns: turns}), do: %{data: Enum.map(turns, &turn_data/1)}
 
@@ -77,6 +84,19 @@ defmodule FountainWeb.ConversationJSON do
       usage_total: %{input: c.usage_input_tokens || 0, output: c.usage_output_tokens || 0},
       inserted_at: c.inserted_at,
       updated_at: c.updated_at
+    }
+  end
+
+  defp request_data(request) do
+    %{
+      request_id: request.request_id,
+      tool: request.tool,
+      # The agent's own option list, verbatim. Answer with an id from it and
+      # never with one from another runtime.
+      options: request.options,
+      asked_at: request.asked_at,
+      deadline: request.deadline,
+      turn_id: request.turn_id
     }
   end
 
@@ -183,6 +203,10 @@ defmodule FountainWeb.ConversationJSON do
       status: t.status,
       # `user` or `autonomous` (#817); rows from before the column read as user.
       origin: t.origin || "user",
+      # The turn ended with a permission request still open (#1635). The
+      # request is on GET /api/conversations/{id} as `pending_requests` until
+      # somebody answers it or its deadline passes.
+      waiting: t.waiting == true,
       exit_code: t.exit_code,
       started_at: t.started_at,
       ended_at: t.ended_at,

--- a/apps/fountain/lib/fountain_web/live/agents_live/form.ex
+++ b/apps/fountain/lib/fountain_web/live/agents_live/form.ex
@@ -83,7 +83,11 @@ defmodule FountainWeb.AgentsLive.Form do
   # empty default plus no overrides is an empty policy rather than
   # `%{"default" => "auto_allow"}`, so an agent nobody has touched keeps the
   # empty map it has always had.
-  defp form_to_permission_policy(params) do
+  #
+  # `previous` is the policy as stored. The form knows only the tool half, so
+  # a key that names something else (`ask_timeout`, #1635) is carried across
+  # rather than dropped by a save from a screen that cannot show it.
+  defp form_to_permission_policy(params, previous) do
     kinds =
       params
       |> Map.get("permission_kinds", %{})
@@ -94,6 +98,7 @@ defmodule FountainWeb.AgentsLive.Form do
       verdict when verdict in ["ask", "auto_deny"] -> Map.put(kinds, "default", verdict)
       _ -> kinds
     end
+    |> Fountain.PermissionPolicy.keep_reserved(previous)
   end
 
   defp asks_permission?(runtime), do: ACP.asks_permission?(runtime || "claude")
@@ -422,7 +427,10 @@ defmodule FountainWeb.AgentsLive.Form do
         params
         |> Map.put("skills", skills)
         |> Map.put("mcp_servers", mcp_map)
-        |> Map.put("permission_policy", form_to_permission_policy(params))
+        |> Map.put(
+          "permission_policy",
+          form_to_permission_policy(params, socket.assigns.agent.permission_policy)
+        )
         |> Map.put("user_id", socket.assigns.user_id)
         |> Map.put("runtime_command", runtime_command_param(params))
         |> nil_if_blank("environment_id")

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -284,6 +284,50 @@ defmodule FountainWeb.Schemas do
     })
   end
 
+  defmodule PendingPermissionRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "PendingPermissionRequest",
+      description:
+        "A permission request that outlived its turn (#1635). The agent ended the " <>
+          "turn with stop reason `waiting` while this request was open, so the " <>
+          "conversation is idle, the sandbox may be suspended, and the request is " <>
+          "still waiting for an answer. Answer it at " <>
+          "POST /api/conversations/{id}/requests/{request_id}, which resolves it and " <>
+          "opens a new turn carrying the outcome to the agent.",
+      type: :object,
+      properties: %{
+        request_id: %Schema{type: :string},
+        tool: %Schema{
+          type: :string,
+          nullable: true,
+          description: "The tool the agent asked about, as the transcript labels it."
+        },
+        options: %Schema{
+          type: :array,
+          items: %Schema{type: :object, additionalProperties: true},
+          description:
+            "The options the agent offered, verbatim. `option_id` must be one of " <>
+              "these `optionId` values; an id from another runtime is refused."
+        },
+        asked_at: %Schema{type: :string, format: :"date-time", nullable: true},
+        deadline: %Schema{
+          type: :string,
+          format: :"date-time",
+          nullable: true,
+          description:
+            "When the request is denied for want of an answer. Set from the " <>
+              "request's own `_meta.fountain.timeout`, else the policy's " <>
+              "`ask_timeout`, else the global ask timeout."
+        },
+        turn_id: %Schema{type: :string, format: :uuid}
+      },
+      required: [:request_id, :options]
+    })
+  end
+
   defmodule Conversation do
     @moduledoc false
     require OpenApiSpex
@@ -330,6 +374,18 @@ defmodule FountainWeb.Schemas do
         permission_policy: %Schema{
           type: :object,
           nullable: true,
+          properties: %{
+            ask_timeout: %Schema{
+              type: :integer,
+              minimum: 1,
+              description:
+                "Seconds a permission request that outlived its turn waits before it " <>
+                  "is denied (#1635). Names no tool, so it is the one key whose value " <>
+                  "is not a verdict. Absent leaves the global ask timeout. A request " <>
+                  "may override it with `_meta.fountain.timeout` on its own " <>
+                  "session/request_permission. A launch may only shorten it."
+            }
+          },
           additionalProperties: %Schema{
             type: :string,
             enum: Managoat.ACP.Permissions.buildable_verdicts()
@@ -406,7 +462,15 @@ defmodule FountainWeb.Schemas do
         },
         usage_total: UsageTotal,
         inserted_at: %Schema{type: :string, format: :"date-time"},
-        updated_at: %Schema{type: :string, format: :"date-time"}
+        updated_at: %Schema{type: :string, format: :"date-time"},
+        pending_requests: %Schema{
+          type: :array,
+          items: PendingPermissionRequest,
+          description:
+            "Permission requests that outlived a turn and are still waiting for an " <>
+              "answer (#1635). Served on GET /api/conversations/{id} only; absent " <>
+              "from the list and from the create response."
+        }
       },
       required: [:id, :runtime, :status]
     })
@@ -496,6 +560,18 @@ defmodule FountainWeb.Schemas do
         permission_policy: %Schema{
           type: :object,
           nullable: true,
+          properties: %{
+            ask_timeout: %Schema{
+              type: :integer,
+              minimum: 1,
+              description:
+                "Seconds a permission request that outlived its turn waits before it " <>
+                  "is denied (#1635). Names no tool, so it is the one key whose value " <>
+                  "is not a verdict. Absent leaves the global ask timeout. A request " <>
+                  "may override it with `_meta.fountain.timeout` on its own " <>
+                  "session/request_permission. A launch may only shorten it."
+            }
+          },
           additionalProperties: %Schema{
             type: :string,
             enum: Managoat.ACP.Permissions.buildable_verdicts()
@@ -699,6 +775,13 @@ defmodule FountainWeb.Schemas do
               "for a turn the server opened for a background cycle the agent ran " <>
               "after its prompt was answered (#817)."
         },
+        waiting: %Schema{
+          type: :boolean,
+          description:
+            "The turn ended with a permission request still open (#1635): the agent " <>
+              "answered with stop reason `waiting`, the turn is `completed` and the " <>
+              "request is on the conversation as a `pending_requests` entry."
+        },
         exit_code: %Schema{type: :integer, nullable: true},
         started_at: %Schema{type: :string, format: :"date-time", nullable: true},
         ended_at: %Schema{type: :string, format: :"date-time", nullable: true},
@@ -805,6 +888,18 @@ defmodule FountainWeb.Schemas do
         permission_policy: %Schema{
           type: :object,
           nullable: true,
+          properties: %{
+            ask_timeout: %Schema{
+              type: :integer,
+              minimum: 1,
+              description:
+                "Seconds a permission request that outlived its turn waits before it " <>
+                  "is denied (#1635). Names no tool, so it is the one key whose value " <>
+                  "is not a verdict. Absent leaves the global ask timeout. A request " <>
+                  "may override it with `_meta.fountain.timeout` on its own " <>
+                  "session/request_permission. A launch may only shorten it."
+            }
+          },
           additionalProperties: %Schema{
             type: :string,
             enum: Managoat.ACP.Permissions.buildable_verdicts()
@@ -981,6 +1076,18 @@ defmodule FountainWeb.Schemas do
         permission_policy: %Schema{
           type: :object,
           nullable: true,
+          properties: %{
+            ask_timeout: %Schema{
+              type: :integer,
+              minimum: 1,
+              description:
+                "Seconds a permission request that outlived its turn waits before it " <>
+                  "is denied (#1635). Names no tool, so it is the one key whose value " <>
+                  "is not a verdict. Absent leaves the global ask timeout. A request " <>
+                  "may override it with `_meta.fountain.timeout` on its own " <>
+                  "session/request_permission. A launch may only shorten it."
+            }
+          },
           additionalProperties: %Schema{
             type: :string,
             enum: Managoat.ACP.Permissions.buildable_verdicts()
@@ -1114,6 +1221,18 @@ defmodule FountainWeb.Schemas do
         permission_policy: %Schema{
           type: :object,
           nullable: true,
+          properties: %{
+            ask_timeout: %Schema{
+              type: :integer,
+              minimum: 1,
+              description:
+                "Seconds a permission request that outlived its turn waits before it " <>
+                  "is denied (#1635). Names no tool, so it is the one key whose value " <>
+                  "is not a verdict. Absent leaves the global ask timeout. A request " <>
+                  "may override it with `_meta.fountain.timeout` on its own " <>
+                  "session/request_permission. A launch may only shorten it."
+            }
+          },
           additionalProperties: %Schema{
             type: :string,
             enum: Managoat.ACP.Permissions.buildable_verdicts()

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -381,14 +381,19 @@ defmodule FountainWeb.Schemas do
               description:
                 "Seconds a permission request that outlived its turn waits before it " <>
                   "is denied (#1635). Names no tool, so it is the one key whose value " <>
-                  "is not a verdict. Absent leaves the global ask timeout. A request " <>
-                  "may override it with `_meta.fountain.timeout` on its own " <>
-                  "session/request_permission. A launch may only shorten it."
+                  "is a number rather than a verdict, which is why the value schema " <>
+                  "below is a union. Absent leaves the global ask timeout. A request " <>
+                  "may shorten it with `_meta.fountain.timeout` on its own " <>
+                  "session/request_permission, and may not lengthen it. A launch may " <>
+                  "only shorten what the agent set, or the global ask timeout where " <>
+                  "the agent set nothing."
             }
           },
           additionalProperties: %Schema{
-            type: :string,
-            enum: Managoat.ACP.Permissions.buildable_verdicts()
+            oneOf: [
+              %Schema{type: :string, enum: Managoat.ACP.Permissions.buildable_verdicts()},
+              %Schema{type: :integer, minimum: 1}
+            ]
           },
           description:
             "The per-launch permission override this conversation was started with, or " <>
@@ -567,14 +572,19 @@ defmodule FountainWeb.Schemas do
               description:
                 "Seconds a permission request that outlived its turn waits before it " <>
                   "is denied (#1635). Names no tool, so it is the one key whose value " <>
-                  "is not a verdict. Absent leaves the global ask timeout. A request " <>
-                  "may override it with `_meta.fountain.timeout` on its own " <>
-                  "session/request_permission. A launch may only shorten it."
+                  "is a number rather than a verdict, which is why the value schema " <>
+                  "below is a union. Absent leaves the global ask timeout. A request " <>
+                  "may shorten it with `_meta.fountain.timeout` on its own " <>
+                  "session/request_permission, and may not lengthen it. A launch may " <>
+                  "only shorten what the agent set, or the global ask timeout where " <>
+                  "the agent set nothing."
             }
           },
           additionalProperties: %Schema{
-            type: :string,
-            enum: Managoat.ACP.Permissions.buildable_verdicts()
+            oneOf: [
+              %Schema{type: :string, enum: Managoat.ACP.Permissions.buildable_verdicts()},
+              %Schema{type: :integer, minimum: 1}
+            ]
           },
           description:
             "Per-launch permission override (#939). Keys are matched against the tool " <>
@@ -895,14 +905,19 @@ defmodule FountainWeb.Schemas do
               description:
                 "Seconds a permission request that outlived its turn waits before it " <>
                   "is denied (#1635). Names no tool, so it is the one key whose value " <>
-                  "is not a verdict. Absent leaves the global ask timeout. A request " <>
-                  "may override it with `_meta.fountain.timeout` on its own " <>
-                  "session/request_permission. A launch may only shorten it."
+                  "is a number rather than a verdict, which is why the value schema " <>
+                  "below is a union. Absent leaves the global ask timeout. A request " <>
+                  "may shorten it with `_meta.fountain.timeout` on its own " <>
+                  "session/request_permission, and may not lengthen it. A launch may " <>
+                  "only shorten what the agent set, or the global ask timeout where " <>
+                  "the agent set nothing."
             }
           },
           additionalProperties: %Schema{
-            type: :string,
-            enum: Managoat.ACP.Permissions.buildable_verdicts()
+            oneOf: [
+              %Schema{type: :string, enum: Managoat.ACP.Permissions.buildable_verdicts()},
+              %Schema{type: :integer, minimum: 1}
+            ]
           },
           description:
             "Per-tool permission policy: a map of key to verdict, plus an optional " <>
@@ -1083,14 +1098,19 @@ defmodule FountainWeb.Schemas do
               description:
                 "Seconds a permission request that outlived its turn waits before it " <>
                   "is denied (#1635). Names no tool, so it is the one key whose value " <>
-                  "is not a verdict. Absent leaves the global ask timeout. A request " <>
-                  "may override it with `_meta.fountain.timeout` on its own " <>
-                  "session/request_permission. A launch may only shorten it."
+                  "is a number rather than a verdict, which is why the value schema " <>
+                  "below is a union. Absent leaves the global ask timeout. A request " <>
+                  "may shorten it with `_meta.fountain.timeout` on its own " <>
+                  "session/request_permission, and may not lengthen it. A launch may " <>
+                  "only shorten what the agent set, or the global ask timeout where " <>
+                  "the agent set nothing."
             }
           },
           additionalProperties: %Schema{
-            type: :string,
-            enum: Managoat.ACP.Permissions.buildable_verdicts()
+            oneOf: [
+              %Schema{type: :string, enum: Managoat.ACP.Permissions.buildable_verdicts()},
+              %Schema{type: :integer, minimum: 1}
+            ]
           },
           description:
             "Per-tool permission policy: a map of key to verdict, plus an optional " <>
@@ -1228,14 +1248,19 @@ defmodule FountainWeb.Schemas do
               description:
                 "Seconds a permission request that outlived its turn waits before it " <>
                   "is denied (#1635). Names no tool, so it is the one key whose value " <>
-                  "is not a verdict. Absent leaves the global ask timeout. A request " <>
-                  "may override it with `_meta.fountain.timeout` on its own " <>
-                  "session/request_permission. A launch may only shorten it."
+                  "is a number rather than a verdict, which is why the value schema " <>
+                  "below is a union. Absent leaves the global ask timeout. A request " <>
+                  "may shorten it with `_meta.fountain.timeout` on its own " <>
+                  "session/request_permission, and may not lengthen it. A launch may " <>
+                  "only shorten what the agent set, or the global ask timeout where " <>
+                  "the agent set nothing."
             }
           },
           additionalProperties: %Schema{
-            type: :string,
-            enum: Managoat.ACP.Permissions.buildable_verdicts()
+            oneOf: [
+              %Schema{type: :string, enum: Managoat.ACP.Permissions.buildable_verdicts()},
+              %Schema{type: :integer, minimum: 1}
+            ]
           },
           description:
             "Per-tool permission policy: a map of key to verdict, plus an optional " <>

--- a/apps/fountain/priv/repo/migrations/20260907093000_add_waiting_to_turns.exs
+++ b/apps/fountain/priv/repo/migrations/20260907093000_add_waiting_to_turns.exs
@@ -1,0 +1,28 @@
+defmodule Fountain.Repo.Migrations.AddWaitingToTurns do
+  use Ecto.Migration
+
+  # A turn that ended with its permission request still open (#1635).
+  #
+  # `pending_permission` on its own cannot say whether a request is held
+  # inside a running turn or has outlived one: the row looks the same either
+  # way. `waiting` is that discriminator, and it is what every sweep reads —
+  # a waiting turn is `completed`, so nothing that hunts for `running` rows
+  # finds it.
+  #
+  # `permission_deadline` is the request's own expiry, on a column rather
+  # than only inside the JSON, because the deadline has to survive the
+  # sandbox suspending and the server restarting. A process timer cannot,
+  # so `Fountain.Workers.DetachedRequestSweeper` reads this instead. The
+  # partial index is the sweep's whole query.
+  def change do
+    alter table(:turns) do
+      add :waiting, :boolean, null: false, default: false
+      add :permission_deadline, :utc_datetime
+    end
+
+    create index(:turns, [:permission_deadline],
+             where: "waiting",
+             name: :turns_waiting_permission_deadline_index
+           )
+  end
+end

--- a/apps/fountain/test/fountain/agents_test.exs
+++ b/apps/fountain/test/fountain/agents_test.exs
@@ -562,6 +562,62 @@ defmodule Fountain.AgentsTest do
       assert agent.permission_policy == %{"default" => "auto_allow"}
     end
 
+    test "ask_timeout is seconds, not a verdict, and is stored beside the tools (#1635)" do
+      user = insert_verified_user()
+
+      agent =
+        insert_agent(
+          user_id: user.id,
+          permission_policy: %{"execute" => "ask", "ask_timeout" => 172_800}
+        )
+
+      assert agent.permission_policy == %{"execute" => "ask", "ask_timeout" => 172_800}
+      assert Fountain.PermissionPolicy.ask_timeout_seconds(agent.permission_policy) == 172_800
+
+      # And it names no tool, so it never reaches the library that reads a key
+      # as one.
+      refute Map.has_key?(
+               Fountain.PermissionPolicy.verdicts(agent.permission_policy),
+               "ask_timeout"
+             )
+    end
+
+    test "an ask_timeout that is not a positive number of seconds is refused" do
+      user = insert_verified_user()
+
+      for value <- [0, -1, "soon", "60s"] do
+        assert {:error, changeset} =
+                 Agents.create_agent(
+                   agent_attrs(%{
+                     "user_id" => user.id,
+                     "permission_policy" => %{"ask_timeout" => value}
+                   })
+                 )
+
+        assert %{permission_policy: [msg]} = errors_on(changeset)
+        assert msg =~ "positive number of seconds"
+      end
+    end
+
+    test "an ask_timeout alone asks nothing of the runtime" do
+      # `needs_enforcement?/1` reads verdicts; a policy that names only the
+      # timeout is still auto_allow everywhere, so a runtime that never asks
+      # must not refuse it.
+      user = insert_verified_user()
+
+      assert {:ok, agent} =
+               Agents.create_agent(
+                 agent_attrs(%{
+                   "user_id" => user.id,
+                   "runtime" => "opencode",
+                   "model" => "anthropic/claude-sonnet-5",
+                   "permission_policy" => %{"ask_timeout" => 600}
+                 })
+               )
+
+      assert agent.permission_policy == %{"ask_timeout" => 600}
+    end
+
     test "a policy change is audited by the existing agent.updated trail" do
       user = insert_verified_user()
       agent = insert_agent(user_id: user.id)

--- a/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
@@ -1415,14 +1415,21 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
     end
 
     # The detach closes the connection, so a resume turn re-handshakes:
-    # `initialize`, then `session/resume` (the caps advertise it), then the
-    # prompt. Returns the prompt's params.
+    # `initialize`, `session/resume` (the caps advertise it), the model pin,
+    # then the prompt. Returns the prompt's params.
+    #
+    # `models` on the session response is not decoration: a runtime that
+    # exposes no model selection fails the turn, so a resume turn has to be
+    # answered the way `drive_to_prompt/2` answers `session/new`.
     defp drive_to_resume_prompt(pid, ref) do
       %{"id" => init_id, "method" => "initialize"} = next_write()
       reply(pid, ref, init_id, %{"agentCapabilities" => @caps})
 
       %{"id" => session_id, "method" => "session/resume"} = next_write()
-      reply(pid, ref, session_id, %{})
+      reply(pid, ref, session_id, %{"models" => %{}})
+
+      %{"id" => set_id, "method" => "session/set_model"} = next_write()
+      reply(pid, ref, set_id, %{})
 
       %{"method" => "session/prompt", "params" => params} = next_write()
       settle(pid)

--- a/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
@@ -10,6 +10,7 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
 
   use Fountain.ConversationServerCase
 
+  alias Fountain.Conversations.Lifecycle
   alias Managoat.Runtimes.ACP
 
   defp acp_agent(user, runtime \\ "claude") do
@@ -1367,6 +1368,344 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
 
       assert [event] = done
       assert Jason.decode!(event.data)["outcome"] == "turn_ended"
+    end
+  end
+
+  describe "requests that outlive a turn (#1635)" do
+    defp waiting_agent(user, policy \\ %{"Bash" => "ask"}) do
+      insert_agent(user_id: user.id, runtime: "claude", permission_policy: policy)
+    end
+
+    # Same frame as `raise_permission/3`, plus whatever the agent puts in the
+    # request's own `_meta`.
+    defp raise_permission_with(pid, ref, id, meta) do
+      params =
+        %{
+          "toolCall" => %{"title" => "Bash", "kind" => "execute"},
+          "options" => [
+            %{"optionId" => "yes", "kind" => "allow_once"},
+            %{"optionId" => "no", "kind" => "reject_once"}
+          ]
+        }
+        |> then(&if meta == %{}, do: &1, else: Map.put(&1, "_meta", meta))
+
+      line =
+        Jason.encode!(%{
+          "jsonrpc" => "2.0",
+          "id" => id,
+          "method" => "session/request_permission",
+          "params" => params
+        }) <> "\n"
+
+      send(pid, {:stdout, %{ref: ref}, line})
+      settle(pid)
+
+      :sys.get_state(pid).current_turn.pending_permission["request_id"]
+    end
+
+    # The harness starts servers outside Horde, so `ConversationServer.whereis/1`
+    # cannot see them. A detached answer goes through `send_prompt/4`, which
+    # asks the registry first, so the resume turn has to be able to find this
+    # server rather than waking a second one.
+    defp register(pid, conv_id) do
+      Mimic.stub(Horde.Registry, :lookup, fn
+        Fountain.ConversationRegistry, ^conv_id -> [{pid, nil}]
+        _registry, _key -> []
+      end)
+    end
+
+    defp stages(conv_id, stage, state) do
+      conv_id
+      |> Conversations._unsafe_list_log_events()
+      |> Enum.filter(&(&1.kind == "stage" and &1.stage == stage and &1.state == state))
+      |> Enum.map(&Jason.decode!(&1.data))
+    end
+
+    defp waiting_turn(conv_id) do
+      Fountain.Repo.one!(
+        from(t in Fountain.Conversations.Turn,
+          where: t.conversation_id == ^conv_id and t.waiting == true
+        )
+      )
+    end
+
+    test "the agent ends the turn waiting and the request stays pending" do
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id, agent: waiting_agent(user))
+      {pid, ref} = start_acp_turn(conv)
+      prompt_id = drive_to_prompt(pid, ref)
+
+      request_id = raise_permission_with(pid, ref, 401, %{})
+      reply(pid, ref, prompt_id, %{"stopReason" => "waiting"})
+
+      # The turn is over, and it is a completed turn, not a failed one.
+      state = :sys.get_state(pid)
+      assert state.current_turn == nil
+
+      turn = waiting_turn(conv.id)
+      assert turn.status == "completed"
+      assert turn.waiting
+      assert turn.pending_permission["request_id"] == request_id
+      assert turn.permission_deadline
+
+      # And nothing denied it on the way out.
+      assert stages(conv.id, "request", "done") == []
+
+      # The conversation is idle, which is what lets the sandbox park.
+      assert Fountain.Repo.reload(conv).status == "idle"
+    end
+
+    test "the turn stage says the turn ended waiting, and on what" do
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id, agent: waiting_agent(user))
+      {pid, ref} = start_acp_turn(conv)
+      prompt_id = drive_to_prompt(pid, ref)
+
+      request_id = raise_permission_with(pid, ref, 402, %{})
+      reply(pid, ref, prompt_id, %{"stopReason" => "waiting"})
+
+      assert [done] = stages(conv.id, "turn", "done")
+      assert done["waiting"] == true
+      assert done["request_id"] == request_id
+      assert done["stop_reason"] == "waiting"
+      assert done["deadline"]
+    end
+
+    test "waiting with nothing held is an ordinary completed turn" do
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id, agent: waiting_agent(user))
+      {pid, ref} = start_acp_turn(conv)
+      prompt_id = drive_to_prompt(pid, ref)
+
+      reply(pid, ref, prompt_id, %{"stopReason" => "waiting"})
+
+      turn = Fountain.Repo.one!(from(t in Fountain.Conversations.Turn))
+      assert turn.status == "completed"
+      refute turn.waiting
+      refute turn.permission_deadline
+
+      assert [done] = stages(conv.id, "turn", "done")
+      refute Map.has_key?(done, "waiting")
+    end
+
+    test "a request still held when the turn ends normally is still denied" do
+      # The `waiting` stop reason is the only thing that changes this, and a
+      # turn that simply ends must not start leaving cards open.
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id, agent: waiting_agent(user))
+      {pid, ref} = start_acp_turn(conv)
+      prompt_id = drive_to_prompt(pid, ref)
+
+      _request_id = raise_permission_with(pid, ref, 403, %{})
+      reply(pid, ref, prompt_id, %{"stopReason" => "end_turn"})
+
+      assert [done] = stages(conv.id, "request", "done")
+      assert done["outcome"] == "turn_ended"
+
+      assert Fountain.Repo.all(from(t in Fountain.Conversations.Turn, where: t.waiting == true)) ==
+               []
+    end
+
+    test "the request's own _meta timeout is honoured, past the idle bound" do
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id, agent: waiting_agent(user))
+      {pid, ref} = start_acp_turn(conv)
+      prompt_id = drive_to_prompt(pid, ref)
+
+      two_days = 2 * 24 * 3600
+
+      _request_id =
+        raise_permission_with(pid, ref, 404, %{"fountain" => %{"timeout" => two_days}})
+
+      # Announced at ask time, so a card knows what it gets if the turn ends.
+      assert [started] = stages(conv.id, "request", "started")
+      assert started["detached_timeout_ms"] == two_days * 1000
+      assert started["timeout_ms"] == Lifecycle.ask_timeout_ms()
+
+      reply(pid, ref, prompt_id, %{"stopReason" => "waiting"})
+
+      deadline = waiting_turn(conv.id).permission_deadline
+      idle_seconds = Lifecycle.idle_timeout_seconds()
+
+      assert DateTime.diff(deadline, DateTime.utc_now()) > idle_seconds
+    end
+
+    test "the policy ask_timeout is used when the request names none" do
+      user = insert_verified_user()
+      agent = waiting_agent(user, %{"Bash" => "ask", "ask_timeout" => 4 * 3600})
+      conv = insert_conversation(user_id: user.id, agent: agent)
+      {pid, ref} = start_acp_turn(conv)
+      prompt_id = drive_to_prompt(pid, ref)
+
+      _request_id = raise_permission_with(pid, ref, 405, %{})
+      assert [started] = stages(conv.id, "request", "started")
+      assert started["detached_timeout_ms"] == 4 * 3600 * 1000
+
+      reply(pid, ref, prompt_id, %{"stopReason" => "waiting"})
+
+      deadline = waiting_turn(conv.id).permission_deadline
+      assert_in_delta DateTime.diff(deadline, DateTime.utc_now()), 4 * 3600, 30
+    end
+
+    test "with neither, a detached request keeps the global ceiling" do
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id, agent: waiting_agent(user))
+      {pid, ref} = start_acp_turn(conv)
+      prompt_id = drive_to_prompt(pid, ref)
+
+      _request_id = raise_permission_with(pid, ref, 406, %{})
+      reply(pid, ref, prompt_id, %{"stopReason" => "waiting"})
+
+      deadline = waiting_turn(conv.id).permission_deadline
+      expected = div(Lifecycle.ask_timeout_ms(), 1000)
+      assert_in_delta DateTime.diff(deadline, DateTime.utc_now()), expected, 30
+    end
+
+    test "answering opens a new turn whose prompt carries the request and the option" do
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id, agent: waiting_agent(user))
+      {pid, ref} = start_acp_turn(conv)
+      prompt_id = drive_to_prompt(pid, ref)
+
+      request_id = raise_permission_with(pid, ref, 407, %{})
+      reply(pid, ref, prompt_id, %{"stopReason" => "waiting"})
+      register(pid, conv.id)
+
+      assert :ok =
+               Conversations.answer_permission_request(conv.id, user.id, request_id, "yes",
+                 actor: "api"
+               )
+
+      settle(pid)
+
+      # A new `session/prompt` on the same connection, and it is the answer.
+      assert %{"method" => "session/prompt", "params" => params} = next_write()
+      assert [%{"type" => "text", "text" => text}] = params["prompt"]
+
+      assert %{"fountain/permission_answer" => answer} = Jason.decode!(text)
+      assert answer["request_id"] == request_id
+      assert answer["option_id"] == "yes"
+      assert answer["outcome"] == "answered"
+      assert answer["tool"] == "Bash"
+
+      # The old JSON-RPC id is never answered: the peer's connection outlived
+      # the turn, and answering it would resolve a request nobody is on.
+      refute_receive {:wrote, _}, 200
+    end
+
+    test "answering is refused for the sandbox's own token" do
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id, agent: waiting_agent(user))
+      {pid, ref} = start_acp_turn(conv)
+      prompt_id = drive_to_prompt(pid, ref)
+
+      request_id = raise_permission_with(pid, ref, 408, %{})
+      reply(pid, ref, prompt_id, %{"stopReason" => "waiting"})
+
+      assert {:error, :sprite_may_not_answer} =
+               Conversations.answer_permission_request(conv.id, user.id, request_id, "yes",
+                 actor: "sprite"
+               )
+
+      assert waiting_turn(conv.id).pending_permission["request_id"] == request_id
+    end
+
+    test "the resolution is audited with the answerer, not the sandbox" do
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id, agent: waiting_agent(user))
+      {pid, ref} = start_acp_turn(conv)
+      prompt_id = drive_to_prompt(pid, ref)
+
+      request_id = raise_permission_with(pid, ref, 409, %{})
+      reply(pid, ref, prompt_id, %{"stopReason" => "waiting"})
+      register(pid, conv.id)
+
+      assert :ok =
+               Conversations.answer_permission_request(conv.id, user.id, request_id, "yes",
+                 actor: "ui",
+                 request_ip: "198.51.100.7"
+               )
+
+      assert answered =
+               user.id
+               |> Fountain.Audit.list_recent_for_user(50)
+               |> Enum.find(&(&1.action == "conversation.permission_answered"))
+
+      assert answered.actor == "ui"
+      assert answered.request_ip == "198.51.100.7"
+      assert answered.metadata["request_id"] == request_id
+    end
+
+    test "the expiry opens the same resume turn, with the denial" do
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id, agent: waiting_agent(user))
+      {pid, ref} = start_acp_turn(conv)
+      prompt_id = drive_to_prompt(pid, ref)
+
+      request_id = raise_permission_with(pid, ref, 410, %{})
+      reply(pid, ref, prompt_id, %{"stopReason" => "waiting"})
+      register(pid, conv.id)
+
+      # Age the deadline past, as a sweep an hour later would find it.
+      turn = waiting_turn(conv.id)
+
+      {:ok, _} =
+        Fountain.Repo.update(
+          Ecto.Changeset.change(turn,
+            permission_deadline:
+              DateTime.utc_now() |> DateTime.add(-60) |> DateTime.truncate(:second)
+          )
+        )
+
+      assert Fountain.Workers.DetachedRequestSweeper.sweep_expired_requests() == 1
+      settle(pid)
+
+      assert %{"method" => "session/prompt", "params" => params} = next_write()
+      assert [%{"text" => text}] = params["prompt"]
+
+      assert %{"fountain/permission_answer" => answer} = Jason.decode!(text)
+      assert answer["request_id"] == request_id
+      assert answer["outcome"] == "timeout"
+      # The agent's own rejection, never an invented id.
+      assert answer["option_id"] == "no"
+    end
+
+    test "the request webhooks fire on the ask and on the resolution" do
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id, agent: waiting_agent(user))
+
+      {:ok, {endpoint, _secret}} =
+        Fountain.Webhooks.create_endpoint(user.id, %{
+          "url" => "https://hooks.example.com/f",
+          "event_types" => ["conversation.request.started", "conversation.request.done"]
+        })
+
+      {pid, ref} = start_acp_turn(conv)
+      prompt_id = drive_to_prompt(pid, ref)
+
+      request_id = raise_permission_with(pid, ref, 411, %{})
+      reply(pid, ref, prompt_id, %{"stopReason" => "waiting"})
+      register(pid, conv.id)
+
+      assert [started] = webhook_types(endpoint)
+      assert started == "conversation.request.started"
+
+      assert :ok = Conversations.answer_permission_request(conv.id, user.id, request_id, "yes")
+
+      assert webhook_types(endpoint) == [
+               "conversation.request.started",
+               "conversation.request.done"
+             ]
+    end
+
+    defp webhook_types(endpoint) do
+      Fountain.Repo.all(
+        from(j in Oban.Job,
+          where: fragment("?->>'endpoint_id' = ?", j.args, ^endpoint.id),
+          order_by: j.id,
+          select: fragment("?->'payload'->>'type'", j.args)
+        )
+      )
     end
   end
 

--- a/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
@@ -1414,6 +1414,21 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
       end)
     end
 
+    # The detach closes the connection, so a resume turn re-handshakes:
+    # `initialize`, then `session/resume` (the caps advertise it), then the
+    # prompt. Returns the prompt's params.
+    defp drive_to_resume_prompt(pid, ref) do
+      %{"id" => init_id, "method" => "initialize"} = next_write()
+      reply(pid, ref, init_id, %{"agentCapabilities" => @caps})
+
+      %{"id" => session_id, "method" => "session/resume"} = next_write()
+      reply(pid, ref, session_id, %{})
+
+      %{"method" => "session/prompt", "params" => params} = next_write()
+      settle(pid)
+      params
+    end
+
     defp stages(conv_id, stage, state) do
       conv_id
       |> Conversations._unsafe_list_log_events()
@@ -1466,9 +1481,13 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
 
       assert [done] = stages(conv.id, "turn", "done")
       assert done["waiting"] == true
-      assert done["request_id"] == request_id
       assert done["stop_reason"] == "waiting"
-      assert done["deadline"]
+      assert done["waiting_deadline"]
+
+      # Prefixed, so a client pairing permission cards on `request_id` does not
+      # pair one to this event.
+      assert done["waiting_request_id"] == request_id
+      refute Map.has_key?(done, "request_id")
     end
 
     test "waiting with nothing held is an ordinary completed turn" do
@@ -1561,13 +1580,32 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
       assert_in_delta DateTime.diff(deadline, DateTime.utc_now()), expected, 30
     end
 
+    test "the turn's end closes the connection, so the resume turn gets a fresh peer" do
+      # The peer holds the request it raised in a single slot that only an
+      # answer or a denial clears, and the detached path sends neither. Keeping
+      # the connection would carry that hold into the resume turn.
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id, agent: waiting_agent(user))
+      {pid, ref} = start_acp_turn(conv)
+      prompt_id = drive_to_prompt(pid, ref)
+
+      _request_id = raise_permission_with(pid, ref, 407, %{})
+      assert :sys.get_state(pid).acp_peer
+
+      reply(pid, ref, prompt_id, %{"stopReason" => "waiting"})
+
+      state = :sys.get_state(pid)
+      assert state.acp_peer == nil
+      assert state.current_command == nil
+    end
+
     test "answering opens a new turn whose prompt carries the request and the option" do
       user = insert_verified_user()
       conv = insert_conversation(user_id: user.id, agent: waiting_agent(user))
       {pid, ref} = start_acp_turn(conv)
       prompt_id = drive_to_prompt(pid, ref)
 
-      request_id = raise_permission_with(pid, ref, 407, %{})
+      request_id = raise_permission_with(pid, ref, 408, %{})
       reply(pid, ref, prompt_id, %{"stopReason" => "waiting"})
       register(pid, conv.id)
 
@@ -1578,8 +1616,9 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
 
       settle(pid)
 
-      # A new `session/prompt` on the same connection, and it is the answer.
-      assert %{"method" => "session/prompt", "params" => params} = next_write()
+      # A fresh connection: the old one went with the detach, so the resume
+      # turn handshakes and resumes the session on the same disk.
+      params = drive_to_resume_prompt(pid, ref)
       assert [%{"type" => "text", "text" => text}] = params["prompt"]
 
       assert %{"fountain/permission_answer" => answer} = Jason.decode!(text)
@@ -1587,10 +1626,96 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
       assert answer["option_id"] == "yes"
       assert answer["outcome"] == "answered"
       assert answer["tool"] == "Bash"
+    end
 
-      # The old JSON-RPC id is never answered: the peer's connection outlived
-      # the turn, and answering it would resolve a request nobody is on.
-      refute_receive {:wrote, _}, 200
+    test "a colliding request id in the resume turn is reported, carded and timed" do
+      # claude-agent-acp and codex number their requests from 0 per turn, so
+      # the resume turn's first request arrives under the id the detached one
+      # used. Against a kept peer it matched the stale hold and vanished.
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id, agent: waiting_agent(user))
+      {pid, ref} = start_acp_turn(conv)
+      prompt_id = drive_to_prompt(pid, ref)
+
+      first_id = raise_permission_with(pid, ref, 0, %{})
+      assert first_id =~ ~r/^0\./
+      reply(pid, ref, prompt_id, %{"stopReason" => "waiting"})
+      register(pid, conv.id)
+
+      assert :ok = Conversations.answer_permission_request(conv.id, user.id, first_id, "yes")
+      settle(pid)
+      _params = drive_to_resume_prompt(pid, ref)
+
+      # The same JSON-RPC id the detached request used.
+      second_id = raise_permission_with(pid, ref, 0, %{})
+
+      assert second_id =~ ~r/^0\./
+      refute second_id == first_id
+
+      turn = :sys.get_state(pid).current_turn
+      assert turn.pending_permission["request_id"] == second_id
+      assert turn.pending_permission["tool"] == "Bash"
+
+      started =
+        conv.id
+        |> Conversations._unsafe_list_log_events()
+        |> Enum.filter(&(&1.kind == "stage" and &1.stage == "request" and &1.state == "started"))
+        |> Enum.map(&Jason.decode!(&1.data))
+
+      assert Enum.map(started, & &1["request_id"]) == [first_id, second_id]
+
+      # And it is timed, so nobody answering still ends it.
+      assert :sys.get_state(pid).permission_timer
+      send(pid, {:permission_timeout, second_id})
+      settle(pid)
+
+      assert %{"id" => 0, "result" => %{"outcome" => %{"optionId" => "no"}}} = next_write()
+    end
+
+    test "a restart between the detach and the answer changes nothing: the row drives it" do
+      # Nothing about a detached request lives in a process. The server that
+      # raised it is gone by the time it is answered in the normal case
+      # (the sandbox parked), so a deploy in the middle has to be the same
+      # thing happening sooner.
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id, agent: waiting_agent(user))
+      {pid, ref} = start_acp_turn(conv)
+      prompt_id = drive_to_prompt(pid, ref)
+
+      request_id = raise_permission_with(pid, ref, 413, %{})
+      reply(pid, ref, prompt_id, %{"stopReason" => "waiting"})
+
+      # The BEAM this was raised on goes away.
+      GenServer.stop(pid)
+
+      # Ownership: the tenant-scoped answer door below establishes it; this is
+      # the assertion that the row alone still describes the request.
+      assert [%{request_id: ^request_id, tool: "Bash"}] =
+               Conversations._unsafe_list_pending_requests(conv.id)
+
+      # No server, so the answer takes the wake path.
+      test = self()
+
+      Mimic.stub(Horde.DynamicSupervisor, :start_child, fn _sup, _spec ->
+        {:ok, spawn(fn -> Process.sleep(:infinity) end)}
+      end)
+
+      Mimic.stub(ConversationServer, :queue_initial_prompt, fn _pid, prompt ->
+        send(test, {:resume_prompt, prompt})
+        :ok
+      end)
+
+      assert :ok = Conversations.answer_permission_request(conv.id, user.id, request_id, "yes")
+
+      assert_receive {:resume_prompt, prompt}
+
+      assert %{
+               "fountain/permission_answer" => %{
+                 "request_id" => ^request_id,
+                 "option_id" => "yes"
+               }
+             } =
+               Jason.decode!(prompt)
     end
 
     test "answering is refused for the sandbox's own token" do
@@ -1599,7 +1724,7 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
       {pid, ref} = start_acp_turn(conv)
       prompt_id = drive_to_prompt(pid, ref)
 
-      request_id = raise_permission_with(pid, ref, 408, %{})
+      request_id = raise_permission_with(pid, ref, 412, %{})
       reply(pid, ref, prompt_id, %{"stopReason" => "waiting"})
 
       assert {:error, :sprite_may_not_answer} =
@@ -1660,7 +1785,7 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
       assert Fountain.Workers.DetachedRequestSweeper.sweep_expired_requests() == 1
       settle(pid)
 
-      assert %{"method" => "session/prompt", "params" => params} = next_write()
+      params = drive_to_resume_prompt(pid, ref)
       assert [%{"text" => text}] = params["prompt"]
 
       assert %{"fountain/permission_answer" => answer} = Jason.decode!(text)

--- a/apps/fountain/test/fountain/conversations/conversation_server_lifetime_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_lifetime_test.exs
@@ -119,6 +119,50 @@ defmodule Fountain.Conversations.ConversationServerLifetimeTest do
       assert Fountain.Repo.reload(conv).status == "idle"
     end
 
+    test "a request that outlived its turn does not hold the sandbox open" do
+      # The whole point of #1635. A request held inside a running turn defers
+      # idle reclaim, which is why its ceiling has to sit under the idle
+      # bound; a detached one holds nothing, so the machine parks with the
+      # card still up and the answer wakes it.
+      {conv, sandbox} = aged_conversation(180)
+      stub_reattach()
+      reject(&Managoat.Sandbox.Sprites.destroy/1)
+
+      turn =
+        insert_turn(conv, %{
+          status: "completed",
+          waiting: true,
+          pending_permission: %{
+            "request_id" => "7.abc",
+            "tool" => "Bash",
+            "options" => [%{"optionId" => "yes", "kind" => "allow_once"}]
+          },
+          permission_deadline:
+            DateTime.utc_now()
+            |> DateTime.add(2 * 24 * 3600, :second)
+            |> DateTime.truncate(:second)
+        })
+
+      with_bounds([sandbox_idle_timeout_minutes: 60, sandbox_max_lifetime_hours: 24], fn ->
+        {pid, ref, :alive} = start_server(conv)
+
+        :sys.replace_state(pid, fn state ->
+          %{state | last_activity_at: DateTime.add(DateTime.utc_now(), -7200, :second)}
+        end)
+
+        send(pid, :lifecycle_check)
+        assert :normal = assert_stopped(ref)
+      end)
+
+      assert Fountain.Repo.reload(sandbox).status == "suspended"
+
+      # And the request survived the park, disk and row alike.
+      reloaded = Fountain.Repo.reload(turn)
+      assert reloaded.waiting
+      assert reloaded.pending_permission["request_id"] == "7.abc"
+      assert [%{request_id: "7.abc"}] = Conversations._unsafe_list_pending_requests(conv.id)
+    end
+
     test "a recently active server is left running" do
       {conv, sandbox} = aged_conversation(180)
       stub_reattach()

--- a/apps/fountain/test/fountain/conversations/conversation_server_size_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_size_test.exs
@@ -15,7 +15,7 @@ defmodule Fountain.Conversations.ConversationServerSizeTest do
   accepts is downward. Lower it when you move something out; never raise it.
   """
 
-  @pin 2800
+  @pin 2758
 
   @server "apps/fountain/lib/fountain/conversations/conversation_server.ex"
 

--- a/apps/fountain/test/fountain/conversations/detached_request_test.exs
+++ b/apps/fountain/test/fountain/conversations/detached_request_test.exs
@@ -116,9 +116,19 @@ defmodule Fountain.Conversations.DetachedRequestTest do
   end
 
   describe "the deadline" do
-    test "the request's own _meta wins over the policy" do
+    test "the shorter of the request and the policy wins, either way round" do
+      # The request is written inside the sandbox and the policy is the
+      # tenant's, so an agent may bound its own wait and may not extend one.
+      long = %{"_meta" => %{"fountain" => %{"timeout" => 172_800}}}
+      short = %{"_meta" => %{"fountain" => %{"timeout" => 60}}}
+
+      assert DetachedRequest.timeout_ms(long, 600) == 600_000
+      assert DetachedRequest.timeout_ms(short, 600) == 60_000
+    end
+
+    test "the request alone is honoured, past the policy's absence" do
       params = %{"_meta" => %{"fountain" => %{"timeout" => 172_800}}}
-      assert DetachedRequest.timeout_ms(params, 600) == 172_800_000
+      assert DetachedRequest.timeout_ms(params, nil) == 172_800_000
     end
 
     test "the policy is used when the request names none" do
@@ -273,6 +283,43 @@ defmodule Fountain.Conversations.DetachedRequestTest do
       assert Repo.reload(turn).waiting
     end
 
+    test "a spent balance refuses the answer, and the request survives to be answered again" do
+      # The wake would refuse this anyway; running the gate first is what keeps
+      # the answer from being resolved into a prompt nobody delivers, and the
+      # caller from being told somebody else answered.
+      %{user: user, conv: conv, turn: turn} = waiting_conversation()
+      drain_credit(user)
+
+      assert {:error, :insufficient_credits} =
+               Conversations.answer_permission_request(conv.id, user.id, "7.abc", "allow")
+
+      assert Repo.reload(turn).waiting
+      refute Repo.reload(turn).pending_permission == nil
+
+      # Topped up, the same answer lands.
+      {:ok, _} = Fountain.Credits.grant(user.id, 500, "grant_admin", idempotency_key: "topup")
+      record_wake()
+
+      assert :ok = Conversations.answer_permission_request(conv.id, user.id, "7.abc", "allow")
+      refute Repo.reload(turn).waiting
+    end
+
+    test "a delivery that fails after the row is resolved says so in its own words" do
+      # The gates passed and something took the conversation in between. The
+      # answer is gone, so the caller must not be told to retry it, and must
+      # not be told somebody else answered either.
+      %{user: user, conv: conv, turn: turn} = waiting_conversation()
+
+      stub(ConversationServer, :send_prompt, fn _id, _prompt, _images, _opts ->
+        {:error, :busy}
+      end)
+
+      assert {:error, :answer_not_delivered} =
+               Conversations.answer_permission_request(conv.id, user.id, "7.abc", "allow")
+
+      refute Repo.reload(turn).waiting
+    end
+
     test "a terminated conversation cannot carry an answer, so the request is left alone" do
       %{user: user, conv: conv, turn: turn} = waiting_conversation()
       {:ok, _} = Conversations.update_conversation(conv, %{status: "terminated"})
@@ -322,6 +369,55 @@ defmodule Fountain.Conversations.DetachedRequestTest do
       assert denied.metadata["verdict"] == "timeout"
     end
 
+    test "a running turn leaves the request for the next sweep" do
+      # The denial is owed, but the turn that carries it cannot queue behind a
+      # turn already in flight. Resolving anyway would lose it with nothing to
+      # retry from.
+      %{conv: conv, turn: turn} = waiting_conversation(deadline: hours_from_now(-1))
+      {:ok, _} = Conversations.update_conversation(conv, %{status: "running"})
+      reject(&ConversationServer.send_prompt/4)
+
+      assert DetachedRequestSweeper.sweep_expired_requests() == 0
+
+      reloaded = Repo.reload(turn)
+      assert reloaded.waiting
+      assert reloaded.pending_permission["request_id"] == "7.abc"
+      assert request_stages(conv.id, "done") == []
+    end
+
+    test "a spent balance leaves the request for the next sweep" do
+      %{user: user, conv: conv, turn: turn} = waiting_conversation(deadline: hours_from_now(-1))
+      drain_credit(user)
+
+      # No `reject/1` here: the second half of this test needs the delivery to
+      # work. The untouched row and the silent stream are what say the first
+      # sweep delivered nothing.
+      assert DetachedRequestSweeper.sweep_expired_requests() == 0
+      assert Repo.reload(turn).waiting
+      assert request_stages(conv.id, "done") == []
+
+      # And it is not lost: the next sweep, after a top-up, carries it.
+      {:ok, _} = Fountain.Credits.grant(user.id, 500, "grant_admin", idempotency_key: "topup")
+      record_wake()
+
+      assert DetachedRequestSweeper.sweep_expired_requests() == 1
+      refute Repo.reload(turn).waiting
+    end
+
+    test "a conversation that is over resolves the request without a resume turn" do
+      # No turn will ever carry the denial, so the card stops waiting rather
+      # than the sweep finding the same row every minute forever.
+      %{conv: conv, turn: turn} = waiting_conversation(deadline: hours_from_now(-1))
+      {:ok, _} = Conversations.update_conversation(conv, %{status: "terminated"})
+      reject(&ConversationServer.send_prompt/4)
+
+      assert DetachedRequestSweeper.sweep_expired_requests() == 1
+
+      refute Repo.reload(turn).waiting
+      assert [%{"outcome" => "timeout"}] = request_stages(conv.id, "done")
+      assert DetachedRequestSweeper.sweep_expired_requests() == 0
+    end
+
     test "a request still inside its deadline is left alone" do
       %{turn: turn} = waiting_conversation(deadline: hours_from_now(24))
 
@@ -366,6 +462,21 @@ defmodule Fountain.Conversations.DetachedRequestTest do
       assert [event] = request_stages(conv.id, "done")
       assert event["detached"] == true
     end
+  end
+
+  # `insert_verified_user/1` holds the $5 opening credit (ADR 0031), so
+  # refusal has to be arranged rather than assumed. Exactly the balance, so a
+  # later grant puts the account back above zero rather than into a hole no
+  # top-up in a test would fill.
+  defp drain_credit(user) do
+    balance = Repo.reload!(user).credit_balance_cents
+
+    if balance > 0 do
+      {:ok, _} =
+        Fountain.Credits.debit(user.id, balance, "burn_turn", idempotency_key: "drain-#{user.id}")
+    end
+
+    :ok
   end
 
   defp request_stages(conv_id, state) do

--- a/apps/fountain/test/fountain/conversations/detached_request_test.exs
+++ b/apps/fountain/test/fountain/conversations/detached_request_test.exs
@@ -1,0 +1,377 @@
+defmodule Fountain.Conversations.DetachedRequestTest do
+  @moduledoc """
+  A permission request that outlived its turn (#1635), from the row it lives
+  on to the turn its answer opens.
+
+  The `ConversationServer` half — the `waiting` stop reason, the deadline the
+  ask decides and the `session/prompt` the resume turn writes — is in
+  `conversation_server_acp_test.exs`, where a real peer is driven. What is
+  here is what happens with no peer at all, which is the state a detached
+  request spends its life in.
+  """
+
+  use Fountain.DataCase, async: true
+  use Mimic
+
+  alias Fountain.Audit
+  alias Fountain.Conversations
+  alias Fountain.Conversations.{ConversationServer, DetachedRequest}
+  alias Fountain.Workers.DetachedRequestSweeper
+
+  @options [
+    %{"optionId" => "allow", "kind" => "allow_once", "name" => "Apply"},
+    %{"optionId" => "deny", "kind" => "reject_once", "name" => "Stop"}
+  ]
+
+  defp waiting_conversation(opts \\ []) do
+    user = insert_verified_user()
+    agent = insert_agent(user_id: user.id, runtime: "claude")
+
+    # Parked, which is where a conversation with a detached request spends
+    # its wait (0017): the answer has to wake it.
+    sandbox = insert_sandbox(user_id: user.id, sprite_name: "test-sprite", status: "suspended")
+
+    conv =
+      insert_conversation(user_id: user.id, agent: agent, sandbox: sandbox, status: "idle")
+
+    request = %{
+      "request_id" => Keyword.get(opts, :request_id, "7.abc"),
+      "tool" => "Bash",
+      "options" => @options,
+      "asked_at" => DateTime.utc_now() |> DateTime.to_iso8601(),
+      "detached_timeout_ms" => 86_400_000
+    }
+
+    turn = insert_turn(conv, %{prompt: "apply the plan", status: "completed"})
+
+    {:ok, turn} =
+      Conversations._unsafe_update_turn(turn, %{
+        waiting: true,
+        pending_permission: request,
+        permission_deadline: Keyword.get(opts, :deadline, hours_from_now(24))
+      })
+
+    %{user: user, conv: conv, sandbox: sandbox, turn: turn, request: request}
+  end
+
+  defp hours_from_now(hours) do
+    DateTime.utc_now() |> DateTime.add(hours * 3600, :second) |> DateTime.truncate(:second)
+  end
+
+  # The wake path starts a server through Horde. Only the prompt it is handed
+  # matters here, so record it and start nothing.
+  defp record_wake do
+    test = self()
+
+    stub(Horde.DynamicSupervisor, :start_child, fn _sup, _spec ->
+      {:ok, spawn(fn -> Process.sleep(:infinity) end)}
+    end)
+
+    stub(ConversationServer, :queue_initial_prompt, fn _pid, prompt ->
+      send(test, {:resume_prompt, prompt})
+      :ok
+    end)
+
+    stub(Managoat.Sandbox.Sprites, :get, fn _handle ->
+      {:ok, %{status: :suspended, raw: %{name: "test-sprite"}}}
+    end)
+
+    stub(Managoat.Sandbox.Sprites, :resume, fn handle -> {:ok, handle} end)
+  end
+
+  describe "the wire shape of the resume prompt" do
+    test "is one line of JSON under the key a _meta field would use" do
+      request = %{"request_id" => "7.abc", "tool" => "Bash"}
+      prompt = DetachedRequest.resume_prompt(request, "answered", "allow")
+
+      refute String.contains?(prompt, "\n")
+
+      assert %{"fountain/permission_answer" => answer} = Jason.decode!(prompt)
+      assert answer["request_id"] == "7.abc"
+      assert answer["tool"] == "Bash"
+      assert answer["outcome"] == "answered"
+      assert answer["option_id"] == "allow"
+      assert {:ok, _, _} = DateTime.from_iso8601(answer["answered_at"])
+    end
+
+    test "an expiry carries the outcome and the option the agent itself offered" do
+      request = %{"request_id" => "7.abc", "tool" => "Bash", "options" => @options}
+      option_id = DetachedRequest.deny_option_id(request)
+      assert option_id == "deny"
+
+      assert %{"fountain/permission_answer" => %{"outcome" => "timeout", "option_id" => "deny"}} =
+               request
+               |> DetachedRequest.resume_prompt("timeout", option_id)
+               |> Jason.decode!()
+    end
+
+    test "an agent that offered no rejection gets a null option, never an invented one" do
+      request = %{
+        "request_id" => "7.abc",
+        "options" => [%{"optionId" => "yes", "kind" => "allow_once"}]
+      }
+
+      assert DetachedRequest.deny_option_id(request) == nil
+    end
+  end
+
+  describe "the deadline" do
+    test "the request's own _meta wins over the policy" do
+      params = %{"_meta" => %{"fountain" => %{"timeout" => 172_800}}}
+      assert DetachedRequest.timeout_ms(params, 600) == 172_800_000
+    end
+
+    test "the policy is used when the request names none" do
+      assert DetachedRequest.timeout_ms(%{}, 600) == 600_000
+      assert DetachedRequest.timeout_ms(nil, 600) == 600_000
+    end
+
+    test "with neither, the global ask timeout stands" do
+      assert DetachedRequest.timeout_ms(nil, nil) ==
+               Fountain.Conversations.Lifecycle.ask_timeout_ms()
+    end
+
+    test "a timeout that is not a positive number of seconds falls through" do
+      for value <- [0, -5, "soon", "60s", nil] do
+        params = %{"_meta" => %{"fountain" => %{"timeout" => value}}}
+        assert DetachedRequest.timeout_ms(params, 600) == 600_000
+      end
+    end
+
+    test "a deadline longer than the idle bound is accepted, which is the point" do
+      # The in-turn ceiling has to sit under the idle bound because the turn
+      # holding it defers idle reclaim. A detached request holds nothing open,
+      # so nothing here clamps it.
+      params = %{"_meta" => %{"fountain" => %{"timeout" => 2 * 24 * 3600}}}
+      idle_ms = Fountain.Conversations.Lifecycle.idle_timeout_seconds() * 1000
+
+      assert DetachedRequest.timeout_ms(params, nil) > idle_ms
+    end
+  end
+
+  describe "listing what a conversation waits on" do
+    test "GET-shaped data for every request that outlived a turn" do
+      %{conv: conv, turn: turn} = waiting_conversation()
+
+      assert [request] = Conversations._unsafe_list_pending_requests(conv.id)
+      assert request.request_id == "7.abc"
+      assert request.tool == "Bash"
+      assert Enum.map(request.options, & &1["optionId"]) == ["allow", "deny"]
+      assert request.turn_id == turn.id
+      assert request.deadline
+    end
+
+    test "a turn that ended without one is not listed" do
+      %{conv: conv, turn: turn} = waiting_conversation()
+
+      {:ok, _} =
+        Conversations._unsafe_update_turn(turn, %{waiting: false, pending_permission: nil})
+
+      assert Conversations._unsafe_list_pending_requests(conv.id) == []
+    end
+  end
+
+  describe "answering" do
+    test "resolves the row, says done on the stream and opens the resume turn" do
+      %{user: user, conv: conv, turn: turn} = waiting_conversation()
+      record_wake()
+
+      assert :ok =
+               Conversations.answer_permission_request(conv.id, user.id, "7.abc", "allow",
+                 actor: "api"
+               )
+
+      reloaded = Repo.reload(turn)
+      refute reloaded.waiting
+      refute reloaded.pending_permission
+      refute reloaded.permission_deadline
+
+      assert [event] = request_stages(conv.id, "done")
+      assert event["outcome"] == "answered"
+      assert event["option_id"] == "allow"
+
+      assert_receive {:resume_prompt, prompt}
+
+      assert %{"fountain/permission_answer" => %{"request_id" => "7.abc", "option_id" => "allow"}} =
+               Jason.decode!(prompt)
+    end
+
+    test "the audit row carries the answerer, exactly as an in-turn answer does" do
+      %{user: user, conv: conv} = waiting_conversation()
+      record_wake()
+
+      assert :ok =
+               Conversations.answer_permission_request(conv.id, user.id, "7.abc", "allow",
+                 actor: "api",
+                 request_ip: "203.0.113.9"
+               )
+
+      assert answered =
+               user.id
+               |> Audit.list_recent_for_user(50)
+               |> Enum.find(&(&1.action == "conversation.permission_answered"))
+
+      assert answered.actor == "api"
+      assert answered.request_ip == "203.0.113.9"
+      assert answered.metadata["request_id"] == "7.abc"
+      assert answered.metadata["option_id"] == "allow"
+    end
+
+    test "the first answer wins and the second is too late" do
+      %{user: user, conv: conv} = waiting_conversation()
+      record_wake()
+
+      assert :ok = Conversations.answer_permission_request(conv.id, user.id, "7.abc", "allow")
+
+      # Every "too late" is one 409 at the door, so which of the two reasons
+      # comes back is not a distinction a client can act on.
+      assert {:error, reason} =
+               Conversations.answer_permission_request(conv.id, user.id, "7.abc", "allow")
+
+      assert reason in [:no_pending_permission, :not_running]
+    end
+
+    test "an option the agent never offered is refused rather than relayed" do
+      # The fail-closed rule the peer applies in turn, applied here where no
+      # peer is left to apply it.
+      %{user: user, conv: conv, turn: turn} = waiting_conversation()
+
+      assert {:error, :unknown_option} =
+               Conversations.answer_permission_request(conv.id, user.id, "7.abc", "made-up")
+
+      assert Repo.reload(turn).waiting
+    end
+
+    test "a sprite may not answer its own prompt, detached or not" do
+      %{user: user, conv: conv, turn: turn} = waiting_conversation()
+
+      assert {:error, :sprite_may_not_answer} =
+               Conversations.answer_permission_request(conv.id, user.id, "7.abc", "allow",
+                 actor: "sprite"
+               )
+
+      assert Repo.reload(turn).waiting
+    end
+
+    test "another tenant gets not_found rather than a hint" do
+      %{conv: conv} = waiting_conversation()
+      other = insert_verified_user()
+
+      assert {:error, :not_found} =
+               Conversations.answer_permission_request(conv.id, other.id, "7.abc", "allow")
+    end
+
+    test "a turn already running refuses the answer before the row is touched" do
+      # The resume turn cannot queue behind one, so refusing beats resolving
+      # the request into a prompt nobody delivers.
+      %{user: user, conv: conv, turn: turn} = waiting_conversation()
+      {:ok, _} = Conversations.update_conversation(conv, %{status: "running"})
+
+      assert {:error, :busy} =
+               Conversations.answer_permission_request(conv.id, user.id, "7.abc", "allow")
+
+      assert Repo.reload(turn).waiting
+    end
+
+    test "a terminated conversation cannot carry an answer, so the request is left alone" do
+      %{user: user, conv: conv, turn: turn} = waiting_conversation()
+      {:ok, _} = Conversations.update_conversation(conv, %{status: "terminated"})
+
+      assert {:error, :not_running} =
+               Conversations.answer_permission_request(conv.id, user.id, "7.abc", "allow")
+
+      assert Repo.reload(turn).waiting
+    end
+  end
+
+  describe "the sweep" do
+    test "denies a request past its deadline and tells the agent" do
+      %{conv: conv, turn: turn} = waiting_conversation(deadline: hours_from_now(-1))
+      record_wake()
+
+      assert DetachedRequestSweeper.sweep_expired_requests() == 1
+
+      reloaded = Repo.reload(turn)
+      refute reloaded.waiting
+      refute reloaded.pending_permission
+
+      assert [event] = request_stages(conv.id, "done")
+      assert event["outcome"] == "timeout"
+      # Chosen from the agent's own list, never invented.
+      assert event["option_id"] == "deny"
+
+      assert_receive {:resume_prompt, prompt}
+
+      assert %{"fountain/permission_answer" => %{"outcome" => "timeout", "option_id" => "deny"}} =
+               Jason.decode!(prompt)
+    end
+
+    test "the denial is audited to the sweep, because no human decided it" do
+      %{user: user} = waiting_conversation(deadline: hours_from_now(-1))
+      record_wake()
+
+      assert DetachedRequestSweeper.sweep_expired_requests() == 1
+
+      assert denied =
+               user.id
+               |> Audit.list_recent_for_user(50)
+               |> Enum.find(&(&1.action == "conversation.permission_denied"))
+
+      assert denied.actor == "system:detached_request_sweeper"
+      assert denied.metadata["tool"] == "Bash"
+      assert denied.metadata["verdict"] == "timeout"
+    end
+
+    test "a request still inside its deadline is left alone" do
+      %{turn: turn} = waiting_conversation(deadline: hours_from_now(24))
+
+      assert DetachedRequestSweeper.sweep_expired_requests() == 0
+      assert Repo.reload(turn).waiting
+    end
+
+    test "a turn that is not waiting is never a candidate, whatever its deadline" do
+      # A request held inside a running turn is the process timer's, and this
+      # sweep must not reach into one.
+      %{turn: turn} = waiting_conversation(deadline: hours_from_now(-1))
+
+      {:ok, _} =
+        Repo.update(Ecto.Changeset.change(turn, waiting: false, status: "running"))
+
+      assert DetachedRequestSweeper.sweep_expired_requests() == 0
+    end
+
+    test "the worker runs the sweep" do
+      %{turn: turn} = waiting_conversation(deadline: hours_from_now(-1))
+      record_wake()
+
+      assert :ok = DetachedRequestSweeper.perform(%Oban.Job{args: %{}})
+      refute Repo.reload(turn).waiting
+    end
+  end
+
+  describe "the row-level resolution" do
+    test "a second resolution of the same request finds nothing to update" do
+      %{turn: turn} = waiting_conversation()
+
+      assert :ok = Conversations._unsafe_resolve_detached_request(turn, "answered", "allow")
+
+      assert {:error, :no_pending_permission} =
+               Conversations._unsafe_resolve_detached_request(turn, "timeout", "deny")
+    end
+
+    test "the stage event marks the resolution as a detached one" do
+      %{conv: conv, turn: turn} = waiting_conversation()
+
+      assert :ok = Conversations._unsafe_resolve_detached_request(turn, "answered", "allow")
+      assert [event] = request_stages(conv.id, "done")
+      assert event["detached"] == true
+    end
+  end
+
+  defp request_stages(conv_id, state) do
+    conv_id
+    |> Conversations._unsafe_list_log_events()
+    |> Enum.filter(&(&1.kind == "stage" and &1.stage == "request" and &1.state == state))
+    |> Enum.map(&Jason.decode!(&1.data))
+  end
+end

--- a/apps/fountain/test/fountain/conversations/pending_test.exs
+++ b/apps/fountain/test/fountain/conversations/pending_test.exs
@@ -88,12 +88,12 @@ defmodule Fountain.Conversations.PendingTest do
       Process.cancel_timer(pending.permission_timer)
     end
 
-    test "ask/6 puts it on the row, announces it and arms the timeout", %{
+    test "ask/7 puts it on the row, announces it and arms the timeout", %{
       conv: conv,
       turn: turn,
       pending: pending
     } do
-      {turn, pending} = Pending.ask(pending, conv.id, turn, 7, "bash", ["yes", "no"])
+      {turn, pending} = Pending.ask(pending, conv.id, turn, 7, "bash", ["yes", "no"], 60_000)
 
       assert %{"request_id" => 7, "tool" => "bash", "options" => ["yes", "no"], "asked_at" => _} =
                turn.pending_permission
@@ -109,11 +109,11 @@ defmodule Fountain.Conversations.PendingTest do
       Process.cancel_timer(pending.permission_timer)
     end
 
-    test "ask/6 with no turn announces and arms, with nothing to persist on", %{
+    test "ask/7 with no turn announces and arms, with nothing to persist on", %{
       conv: conv,
       pending: pending
     } do
-      {nil, pending} = Pending.ask(pending, conv.id, nil, 7, "bash", [])
+      {nil, pending} = Pending.ask(pending, conv.id, nil, 7, "bash", [], 60_000)
       assert [{"started", _}] = stages(conv.id, "request")
       Process.cancel_timer(pending.permission_timer)
     end
@@ -129,7 +129,7 @@ defmodule Fountain.Conversations.PendingTest do
       turn: turn,
       pending: pending
     } do
-      {turn, pending} = Pending.ask(pending, conv.id, turn, 7, "bash", ["yes"])
+      {turn, pending} = Pending.ask(pending, conv.id, turn, 7, "bash", ["yes"], 60_000)
       timer = pending.permission_timer
       peer = fake_peer()
 
@@ -152,7 +152,7 @@ defmodule Fountain.Conversations.PendingTest do
       turn: turn,
       pending: pending
     } do
-      {turn, pending} = Pending.ask(pending, conv.id, turn, 7, "bash", ["yes"])
+      {turn, pending} = Pending.ask(pending, conv.id, turn, 7, "bash", ["yes"], 60_000)
       peer = fake_peer()
 
       {turn, _pending} =
@@ -178,7 +178,7 @@ defmodule Fountain.Conversations.PendingTest do
       assert {nil, ^pending} =
                Pending.resolve_pending_permission(pending, conv.id, nil, nil, "turn_ended")
 
-      {turn, pending} = Pending.ask(pending, conv.id, turn, 9, "rm", [])
+      {turn, pending} = Pending.ask(pending, conv.id, turn, 9, "rm", [], 60_000)
 
       {turn, pending} =
         Pending.resolve_pending_permission(pending, conv.id, turn, nil, "turn_ended")
@@ -208,7 +208,7 @@ defmodule Fountain.Conversations.PendingTest do
           end
         end)
 
-      {turn, pending} = Pending.ask(pending, conv.id, turn, 7, "bash", ["yes"])
+      {turn, pending} = Pending.ask(pending, conv.id, turn, 7, "bash", ["yes"], 60_000)
 
       assert {:ok, turn, pending} =
                Pending.answer_permission(pending, conv.id, turn, peer, 7, "yes")

--- a/apps/fountain/test/fountain/conversations_start_test.exs
+++ b/apps/fountain/test/fountain/conversations_start_test.exs
@@ -399,6 +399,27 @@ defmodule Fountain.ConversationsStartTest do
                launch(ctx, strict, %{"Bash" => "ask"})
     end
 
+    test "a launch may shorten ask_timeout and may not lengthen it (#1635)", ctx do
+      agent =
+        insert_agent(
+          user_id: ctx.user.id,
+          permission_policy: %{"execute" => "ask", "ask_timeout" => 3600}
+        )
+
+      assert {:ok, conv} = launch(ctx, agent, %{"execute" => "ask", "ask_timeout" => 600})
+      assert conv.permission_policy["ask_timeout"] == 600
+
+      assert Fountain.Conversations.TurnMachine.effective_ask_timeout_seconds(conv, agent) == 600
+
+      assert {:error, {:permission_policy_widens, "ask_timeout"}} =
+               launch(ctx, agent, %{"execute" => "ask", "ask_timeout" => 86_400})
+    end
+
+    test "an ask_timeout that is not seconds is refused at the door", ctx do
+      agent = insert_agent(user_id: ctx.user.id)
+      assert {:error, :permission_policy_invalid} = launch(ctx, agent, %{"ask_timeout" => "soon"})
+    end
+
     test "an unknown verdict is refused", ctx do
       agent = insert_agent(user_id: ctx.user.id)
       assert {:error, :permission_policy_invalid} = launch(ctx, agent, %{"Bash" => "banana"})

--- a/apps/fountain/test/fountain/conversations_start_test.exs
+++ b/apps/fountain/test/fountain/conversations_start_test.exs
@@ -415,6 +415,17 @@ defmodule Fountain.ConversationsStartTest do
                launch(ctx, agent, %{"execute" => "ask", "ask_timeout" => 86_400})
     end
 
+    test "a launch cannot buy a longer wait than the global ceiling the agent left", ctx do
+      agent = insert_agent(user_id: ctx.user.id, permission_policy: %{"execute" => "ask"})
+      ceiling = div(Fountain.Conversations.Lifecycle.ask_timeout_ms(), 1000)
+
+      assert {:error, {:permission_policy_widens, "ask_timeout"}} =
+               launch(ctx, agent, %{"execute" => "ask", "ask_timeout" => ceiling + 1})
+
+      assert {:ok, conv} = launch(ctx, agent, %{"execute" => "ask", "ask_timeout" => ceiling})
+      assert conv.permission_policy["ask_timeout"] == ceiling
+    end
+
     test "an ask_timeout that is not seconds is refused at the door", ctx do
       agent = insert_agent(user_id: ctx.user.id)
       assert {:error, :permission_policy_invalid} = launch(ctx, agent, %{"ask_timeout" => "soon"})

--- a/apps/fountain/test/fountain/permission_policy_test.exs
+++ b/apps/fountain/test/fountain/permission_policy_test.exs
@@ -1,0 +1,107 @@
+defmodule Fountain.PermissionPolicyTest do
+  @moduledoc """
+  The Fountain half of a permission policy (#1635): the one key that names no
+  tool, and keeping it away from the library that reads every key as one.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Fountain.PermissionPolicy
+
+  describe "verdicts/1" do
+    test "hands the library the tool half and nothing else" do
+      policy = %{"default" => "ask", "execute" => "auto_deny", "ask_timeout" => 86_400}
+
+      assert PermissionPolicy.verdicts(policy) == %{
+               "default" => "ask",
+               "execute" => "auto_deny"
+             }
+    end
+
+    test "a reserved key left in would come back as a verdict" do
+      # This is why the stripping exists rather than being tidiness:
+      # `verdict_for/2` reads an unrecognised value as auto_deny, and
+      # `effective/2` writes that reading back into the merged map, so a
+      # policy round-tripped through the library would grow
+      # `"ask_timeout" => "auto_deny"`.
+      merged = Managoat.ACP.Permissions.effective(%{"ask_timeout" => 600}, %{})
+      assert merged["ask_timeout"] == "auto_deny"
+
+      stripped =
+        Managoat.ACP.Permissions.effective(
+          PermissionPolicy.verdicts(%{"ask_timeout" => 600}),
+          %{}
+        )
+
+      refute Map.has_key?(stripped, "ask_timeout")
+    end
+
+    test "a policy that is not a map is an empty one" do
+      assert PermissionPolicy.verdicts(nil) == %{}
+      assert PermissionPolicy.verdicts("nope") == %{}
+    end
+  end
+
+  describe "ask_timeout_seconds/1" do
+    test "reads a positive integer or a string of one" do
+      assert PermissionPolicy.ask_timeout_seconds(%{"ask_timeout" => 3600}) == 3600
+      assert PermissionPolicy.ask_timeout_seconds(%{"ask_timeout" => "3600"}) == 3600
+    end
+
+    test "anything else is nil, so the caller falls back rather than denying at once" do
+      for value <- [0, -1, "", "soon", "60s", 1.5, nil, %{}] do
+        assert PermissionPolicy.ask_timeout_seconds(%{"ask_timeout" => value}) == nil
+      end
+
+      assert PermissionPolicy.ask_timeout_seconds(%{}) == nil
+      assert PermissionPolicy.ask_timeout_seconds(nil) == nil
+    end
+  end
+
+  describe "effective_ask_timeout_seconds/2 and check_narrows/2" do
+    test "the smaller of the two wins, because a shorter wait withholds more" do
+      assert PermissionPolicy.effective_ask_timeout_seconds(
+               %{"ask_timeout" => 86_400},
+               %{"ask_timeout" => 600}
+             ) == 600
+    end
+
+    test "either side alone is honoured, and neither leaves nil" do
+      assert PermissionPolicy.effective_ask_timeout_seconds(%{"ask_timeout" => 60}, %{}) == 60
+      assert PermissionPolicy.effective_ask_timeout_seconds(%{}, %{"ask_timeout" => 60}) == 60
+      assert PermissionPolicy.effective_ask_timeout_seconds(%{}, %{}) == nil
+    end
+
+    test "a launch may shorten the wait and may not lengthen it" do
+      assert PermissionPolicy.check_narrows(%{"ask_timeout" => 600}, %{"ask_timeout" => 60}) ==
+               :ok
+
+      assert PermissionPolicy.check_narrows(%{"ask_timeout" => 60}, %{"ask_timeout" => 600}) ==
+               {:error, {:permission_policy_widens, "ask_timeout"}}
+    end
+
+    test "a launch that names one where the agent named none is not a widening" do
+      # There is nothing to widen: with no agent value the global ceiling
+      # applies, and that ceiling is what a request escapes by detaching at
+      # all. Refusing here would make the key unusable per launch.
+      assert PermissionPolicy.check_narrows(%{}, %{"ask_timeout" => 86_400}) == :ok
+    end
+  end
+
+  describe "keep_reserved/2" do
+    test "a form that rebuilds the tool half does not drop the rest" do
+      rebuilt = %{"default" => "ask"}
+      stored = %{"default" => "auto_allow", "ask_timeout" => 7200}
+
+      assert PermissionPolicy.keep_reserved(rebuilt, stored) == %{
+               "default" => "ask",
+               "ask_timeout" => 7200
+             }
+    end
+
+    test "nothing to keep leaves the policy alone" do
+      assert PermissionPolicy.keep_reserved(%{"default" => "ask"}, nil) == %{"default" => "ask"}
+      assert PermissionPolicy.keep_reserved(%{}, %{"execute" => "ask"}) == %{}
+    end
+  end
+end

--- a/apps/fountain/test/fountain/permission_policy_test.exs
+++ b/apps/fountain/test/fountain/permission_policy_test.exs
@@ -80,11 +80,30 @@ defmodule Fountain.PermissionPolicyTest do
                {:error, {:permission_policy_widens, "ask_timeout"}}
     end
 
-    test "a launch that names one where the agent named none is not a widening" do
-      # There is nothing to widen: with no agent value the global ceiling
-      # applies, and that ceiling is what a request escapes by detaching at
-      # all. Refusing here would make the key unusable per launch.
-      assert PermissionPolicy.check_narrows(%{}, %{"ask_timeout" => 86_400}) == :ok
+    test "with no agent value, the ceiling the host passes is what a launch may not exceed" do
+      # A longer wait is more time for the tool to be approved, so longer is
+      # looser. Without the ceiling an agent that never set the key would let
+      # any launch buy days, which is the escalation the rule exists to stop.
+      assert PermissionPolicy.check_narrows(%{}, %{"ask_timeout" => 60}, 300) == :ok
+
+      assert PermissionPolicy.check_narrows(%{}, %{"ask_timeout" => 86_400}, 300) ==
+               {:error, {:permission_policy_widens, "ask_timeout"}}
+    end
+
+    test "the agent's own value outranks the ceiling, in both directions" do
+      assert PermissionPolicy.check_narrows(
+               %{"ask_timeout" => 86_400},
+               %{"ask_timeout" => 3600},
+               300
+             ) == :ok
+
+      assert PermissionPolicy.check_narrows(%{"ask_timeout" => 60}, %{"ask_timeout" => 120}, 300) ==
+               {:error, {:permission_policy_widens, "ask_timeout"}}
+    end
+
+    test "a launch that names none is never a widening" do
+      assert PermissionPolicy.check_narrows(%{"ask_timeout" => 60}, %{}, 300) == :ok
+      assert PermissionPolicy.check_narrows(%{}, %{}, 300) == :ok
     end
   end
 

--- a/apps/fountain/test/fountain_web/controllers/conversation_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/conversation_controller_test.exs
@@ -796,6 +796,51 @@ defmodule FountainWeb.ConversationControllerTest do
       assert body["error"] == "sprite_may_not_answer"
     end
 
+    test "a running turn is a 400, and the request is still there", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
+      conv = waiting_conv(user)
+      {:ok, _} = Fountain.Conversations.update_conversation(conv, %{status: "running"})
+
+      body =
+        conn
+        |> authed_with_key(raw_key)
+        |> put_req_header("content-type", "application/json")
+        |> post("/api/conversations/#{conv.id}/requests/7.abc", %{"option_id" => "yes"})
+        |> json_response(400)
+
+      assert body["error"] == "conversation_busy"
+
+      assert [%{request_id: "7.abc"}] =
+               Fountain.Conversations._unsafe_list_pending_requests(conv.id)
+    end
+
+    test "a resolved-but-undelivered answer says so in its own words", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
+      # Distinct from the 409 below, which tells a client somebody else
+      # answered. Here the answer landed and the agent has not heard it.
+      conv = waiting_conv(user)
+
+      stub(ConversationServer, :send_prompt, fn _id, _prompt, _images, _opts ->
+        {:error, :busy}
+      end)
+
+      body =
+        conn
+        |> authed_with_key(raw_key)
+        |> put_req_header("content-type", "application/json")
+        |> post("/api/conversations/#{conv.id}/requests/7.abc", %{"option_id" => "yes"})
+        |> json_response(409)
+
+      assert body["error"] == "permission_answer_not_delivered"
+      assert body["message"] =~ "Send a prompt"
+    end
+
     test "a request nobody is waiting on is a 409", %{conn: conn, user: user, raw_key: raw_key} do
       conv = waiting_conv(user)
 

--- a/apps/fountain/test/fountain_web/controllers/conversation_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/conversation_controller_test.exs
@@ -197,6 +197,67 @@ defmodule FountainWeb.ConversationControllerTest do
       end
     end
 
+    # #1635. The conversation is idle while such a request waits, so a client
+    # that reloads has nowhere else to learn that the card is still up.
+    test "lists the permission requests that outlived a turn", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
+      conv = insert_conversation(user_id: user.id)
+
+      turn =
+        insert_turn(conv, %{
+          status: "completed",
+          waiting: true,
+          pending_permission: %{
+            "request_id" => "7.abc",
+            "tool" => "Bash",
+            "options" => [%{"optionId" => "yes", "kind" => "allow_once"}],
+            "asked_at" => "2026-09-07T09:00:00Z"
+          },
+          permission_deadline: ~U[2026-09-09 09:00:00Z]
+        })
+
+      body =
+        conn
+        |> authed_with_key(raw_key)
+        |> get("/api/conversations/#{conv.id}")
+        |> json_response(200)
+
+      assert [request] = body["data"]["pending_requests"]
+      assert request["request_id"] == "7.abc"
+      assert request["tool"] == "Bash"
+      assert request["options"] == [%{"optionId" => "yes", "kind" => "allow_once"}]
+      assert request["turn_id"] == turn.id
+      assert request["deadline"] == "2026-09-09T09:00:00Z"
+
+      turns =
+        conn
+        |> authed_with_key(raw_key)
+        |> get("/api/conversations/#{conv.id}/turns")
+        |> json_response(200)
+
+      assert [%{"waiting" => true}] = turns["data"]
+    end
+
+    test "serves an empty list when nothing is waiting", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
+      conv = insert_conversation(user_id: user.id)
+      _turn = insert_turn(conv, %{status: "completed"})
+
+      body =
+        conn
+        |> authed_with_key(raw_key)
+        |> get("/api/conversations/#{conv.id}")
+        |> json_response(200)
+
+      assert body["data"]["pending_requests"] == []
+    end
+
     test "returns 404 when the conversation belongs to a different user", %{
       conn: conn,
       raw_key: raw_key
@@ -655,6 +716,97 @@ defmodule FountainWeb.ConversationControllerTest do
         |> post_json("/api/conversations/#{other_conv.id}/prompts", %{"prompt" => "hello"})
 
       assert json_response(conn, 404)
+    end
+  end
+
+  describe "POST /api/conversations/:conversation_id/requests/:request_id" do
+    defp waiting_conv(user) do
+      sandbox = insert_sandbox(user_id: user.id, sprite_name: "test-sprite", status: "suspended")
+      conv = insert_conversation(user_id: user.id, sandbox: sandbox, status: "idle")
+
+      insert_turn(conv, %{
+        status: "completed",
+        waiting: true,
+        pending_permission: %{
+          "request_id" => "7.abc",
+          "tool" => "Bash",
+          "options" => [
+            %{"optionId" => "yes", "kind" => "allow_once"},
+            %{"optionId" => "no", "kind" => "reject_once"}
+          ]
+        },
+        permission_deadline: DateTime.add(DateTime.utc_now(), 3600) |> DateTime.truncate(:second)
+      })
+
+      conv
+    end
+
+    test "answers a request that outlived its turn", %{conn: conn, user: user, raw_key: raw_key} do
+      conv = waiting_conv(user)
+
+      # The wake is what carries the answer to the agent; only that it was
+      # asked for matters here.
+      stub(Fountain.Conversations, :wake_conversation, fn id, prompt ->
+        send(self(), {:woken, id, prompt})
+        {:ok, %{}}
+      end)
+
+      body =
+        conn
+        |> authed_with_key(raw_key)
+        |> put_req_header("content-type", "application/json")
+        |> post("/api/conversations/#{conv.id}/requests/7.abc", %{"option_id" => "yes"})
+        |> json_response(200)
+
+      assert body == %{"ok" => true}
+      assert_received {:woken, _id, prompt}
+      assert %{"fountain/permission_answer" => %{"option_id" => "yes"}} = Jason.decode!(prompt)
+    end
+
+    test "refuses an option the agent never offered", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
+      conv = waiting_conv(user)
+
+      body =
+        conn
+        |> authed_with_key(raw_key)
+        |> put_req_header("content-type", "application/json")
+        |> post("/api/conversations/#{conv.id}/requests/7.abc", %{"option_id" => "made-up"})
+        |> json_response(422)
+
+      assert body["error"] == "unknown_option"
+    end
+
+    test "refuses the sandbox's own token", %{conn: conn, user: user} do
+      # The sprite holds a FOUNTAIN_TOKEN and could otherwise approve the tool
+      # it just asked about, detached or not.
+      conv = waiting_conv(user)
+      {_record, sprite_key} = insert_sprite_api_key(user)
+
+      body =
+        conn
+        |> authed_with_key(sprite_key)
+        |> put_req_header("content-type", "application/json")
+        |> post("/api/conversations/#{conv.id}/requests/7.abc", %{"option_id" => "yes"})
+        |> json_response(403)
+
+      assert body["error"] == "sprite_may_not_answer"
+    end
+
+    test "a request nobody is waiting on is a 409", %{conn: conn, user: user, raw_key: raw_key} do
+      conv = waiting_conv(user)
+
+      body =
+        conn
+        |> authed_with_key(raw_key)
+        |> put_req_header("content-type", "application/json")
+        |> post("/api/conversations/#{conv.id}/requests/nope", %{"option_id" => "yes"})
+        |> json_response(409)
+
+      assert body["error"] == "permission_request_resolved"
     end
   end
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -28,6 +28,12 @@ config :fountain, Oban,
        # A server's autonomous quiet timer is in memory. Sweep old, silent
        # running turns whose server disappeared before that timer fired.
        {"*/5 * * * *", Fountain.Workers.AutonomousTurnReaper},
+       # Every minute: deny permission requests that outlived their turn and
+       # then ran out of time (#1635). Their deadline is on the turn row
+       # rather than in a process timer, because the sandbox parks and the
+       # server stops while such a request waits. One indexed query, usually
+       # empty.
+       {"* * * * *", Fountain.Workers.DetachedRequestSweeper},
        # Every 5 minutes: expire claimable principals nobody claimed (ADR
        # 0044). Latency here is money — an expired principal is a sprite still
        # running for a visitor who has gone — so the sweep runs on the same

--- a/decisions/0014-agent-client-protocol.md
+++ b/decisions/0014-agent-client-protocol.md
@@ -745,6 +745,36 @@ bound suspends while the ceiling **destroys**. Left alone, an unanswered
 prompt does not hang forever; it burns the maximum lifetime and then takes the
 agent's memory with it (#649).
 
+> **Amendment, 2026-09-07 (#1635). A request may outlive its turn, and then
+> this bound does not apply to it.** The paragraph above is right about a
+> request held inside a running turn, and that is still the only shape an LLM
+> blocked mid-thought produces. A deterministic operation waits on something
+> else: approve a production apply, confirm a DNS delegation, sign off a set of
+> deletes. Those take hours or days, and nothing in the sandbox needs to run
+> while they do.
+>
+> So an agent may send `session/request_permission` and then answer
+> `session/prompt` with the stop reason **`waiting`**. The turn ends
+> `completed` with `turns.waiting` set, the request row stays pending, the
+> conversation goes `idle` and the sandbox parks on the idle bound exactly as
+> it would have anyway. No sandbox is held open, so the cost rule this ADR
+> keeps is untouched: what changes is that the *card* outlives the turn, not
+> the machine.
+>
+> The answer cannot go back down the connection that raised the request — the
+> sandbox may be suspended and the JSON-RPC id died with the peer. It opens a
+> **new turn** instead, whose `session/prompt` is one line of JSON under
+> `fountain/permission_answer` carrying the request id, the option and the
+> outcome. That is the shape a `_meta` key would carry, under the same name;
+> `Managoat.ACP.Peer.prompt/3` has no hook for protocol extensions, so it
+> travels in the prompt text until the library grows one.
+>
+> The deadline is per request (`_meta.fountain.timeout`), else the policy's
+> `ask_timeout`, else this five-minute ceiling. It lives on the turn row rather
+> than in a process timer, because a two-day wait outlives every process
+> involved, and `Fountain.Workers.DetachedRequestSweeper` is what fires it.
+> Expiry is still a deny, and it opens the same resume turn.
+
 **Survival across a restart.** The JSON-RPC request id lives in the peer and
 dies with it, so a request minted before a deploy cannot be answered after one
 unless the id is persisted the way `acp_prompt_id` already is — the same trap

--- a/decisions/0014-agent-client-protocol.md
+++ b/decisions/0014-agent-client-protocol.md
@@ -769,11 +769,33 @@ agent's memory with it (#649).
 > `Managoat.ACP.Peer.prompt/3` has no hook for protocol extensions, so it
 > travels in the prompt text until the library grows one.
 >
-> The deadline is per request (`_meta.fountain.timeout`), else the policy's
-> `ask_timeout`, else this five-minute ceiling. It lives on the turn row rather
-> than in a process timer, because a two-day wait outlives every process
-> involved, and `Fountain.Workers.DetachedRequestSweeper` is what fires it.
-> Expiry is still a deny, and it opens the same resume turn.
+> The deadline is per request (`_meta.fountain.timeout`) and per policy
+> (`ask_timeout`), the shorter of the two where both are set, else this
+> five-minute ceiling. The request half comes from inside the sandbox, so it
+> may bound its own wait and may not extend the tenant's; a launch policy may
+> shorten the agent's, or the five-minute ceiling where the agent set none,
+> because a longer wait is more time for the tool to be approved and so is the
+> looser direction. The deadline lives on the turn row rather than in a
+> process timer, because a two-day wait outlives every process involved, and
+> `Fountain.Workers.DetachedRequestSweeper` is what fires it. Expiry is still
+> a deny, and it opens the same resume turn.
+>
+> **The connection does not survive the detach**, which is the one place this
+> departs from #817's sandbox-scoped rule. The peer holds the request it
+> raised in a single slot that only an answer or a denial clears, and the
+> detached path sends neither; both shippable adapters number their requests
+> from 0 per turn, so the resume turn's first request would collide with the
+> stale hold and be swallowed — no response, no card, no timeout, and an
+> agent blocked with the ceiling off by default. The turn's end therefore
+> closes the connection, and the resume turn pays one handshake. That is what
+> the idle park would have done minutes later regardless.
+>
+> **Nothing is resolved that cannot be delivered.** The gates the wake runs —
+> a turn already in flight, a suspended account, a spent balance — run before
+> the request row is touched, by the answer door and by the sweep alike. A
+> request resolved into a prompt nobody delivers is gone with the agent never
+> told and no second copy to retry from, so the row stays and the sweep comes
+> back a minute later.
 
 **Survival across a restart.** The JSON-RPC request id lives in the peer and
 dies with it, so a request minted before a deploy cannot be answered after one

--- a/docs/concepts/permissions.md
+++ b/docs/concepts/permissions.md
@@ -79,10 +79,10 @@ Some rules keep that safe.
 
 ## Requests that outlive a turn
 
-The rule above assumes an agent blocked mid-thought. Some waits are longer than
-that. Approve a production apply, confirm a DNS delegation landed, sign off the
-deletes in a plan. Those take hours or days, and nothing in the sandbox has to
-run while they do.
+The 5 minute ceiling above assumes an agent blocked mid-thought. Some waits are
+longer than that. Approve a production apply, confirm a DNS delegation landed,
+sign off the deletes in a plan. Those take hours or days, and nothing in the
+sandbox has to run while they do.
 
 An agent can say so. It sends `session/request_permission`, and then it answers
 `session/prompt` with the stop reason `waiting`. The turn ends as a completed
@@ -109,7 +109,8 @@ so Fountain cannot hand the answer back down it. Instead Fountain resolves the
 request and opens a **new turn** whose prompt carries the outcome. Opening that
 turn wakes the sandbox.
 
-The prompt is one line, and it is this JSON object:
+The prompt is one line of JSON and nothing else. It is broken up here to read
+it.
 
 ```json
 {"fountain/permission_answer":{

--- a/docs/concepts/permissions.md
+++ b/docs/concepts/permissions.md
@@ -66,13 +66,84 @@ Some rules keep that safe.
 
 - **The first answer wins.** The other clients see a request that no longer
   waits. No client is a fallback for another.
-- **Nobody is also an answer.** After 5 minutes, Fountain refuses the tool. The
-  timeout sits below the idle bound, so a request that waits costs a turn and
-  not the sandbox.
+- **Nobody is also an answer.** Two timeouts do this, and which one applies
+  depends on whether the request is still inside a turn. A request held inside
+  a turn is refused after 5 minutes. That ceiling sits below the idle bound, so
+  a request that waits costs a turn and not the sandbox. A request that
+  outlived its turn is refused at its own deadline, which may be days away.
+  See [Requests that outlive a turn](#requests-that-outlive-a-turn).
 - **An option must come from the runtime.** Fountain refuses an option id that
   the runtime did not offer.
 - **The agent cannot answer itself.** The sandbox holds an API token, and
   Fountain refuses that loop by name.
+
+## Requests that outlive a turn
+
+The rule above assumes an agent blocked mid-thought. Some waits are longer than
+that. Approve a production apply, confirm a DNS delegation landed, sign off the
+deletes in a plan. Those take hours or days, and nothing in the sandbox has to
+run while they do.
+
+An agent can say so. It sends `session/request_permission`, and then it answers
+`session/prompt` with the stop reason `waiting`. The turn ends as a completed
+turn with `waiting: true` on it. The request stays open. The conversation goes
+idle, and the sandbox suspends on the idle bound like any other idle sandbox.
+
+The card stays up. `GET /api/conversations/{id}` lists every such request under
+`pending_requests`, with the tool, the options the agent offered, and the
+deadline. The `turn` stage event that ended the turn carries `waiting: true`
+and the request id, so a client watching the stream learns it there too.
+
+A `waiting` stop reason with no open request means nothing. That turn ends the
+way any completed turn does.
+
+### Answering one
+
+Answer it at `POST /api/conversations/{id}/requests/{request_id}`, the same
+door an in-turn request uses. The rules above still hold. The first answer
+wins, the option must come from the runtime, and the agent cannot answer
+itself.
+
+What happens next is different. The connection that raised the request is gone,
+so Fountain cannot hand the answer back down it. Instead Fountain resolves the
+request and opens a **new turn** whose prompt carries the outcome. Opening that
+turn wakes the sandbox.
+
+The prompt is one line, and it is this JSON object:
+
+```json
+{"fountain/permission_answer":{
+  "request_id": "7.1f0c9a",
+  "tool": "Bash",
+  "outcome": "answered",
+  "option_id": "allow",
+  "answered_at": "2026-09-07T09:14:02.113Z"
+}}
+```
+
+`outcome` is `answered` or `timeout`. `option_id` is the option somebody
+picked, or the rejection the expiry chose from the agent's own list. It is null
+where the agent offered no rejection at all. The agent decides what to do with
+it.
+
+### The deadline
+
+A detached request is refused when its deadline passes, and the refusal opens
+the same resume turn with `outcome: "timeout"`. Fountain reads the deadline
+from the first of these that is set.
+
+1. `_meta.fountain.timeout` on the `session/request_permission` itself, in
+  seconds. The agent sets this per request.
+2. `ask_timeout` in the permission policy, in seconds. This is the one policy
+  key that names no tool. A launch may shorten it and may not lengthen it.
+3. The 5 minute ceiling, which is what an in-turn request gets.
+
+Only a detached request reads the first two. A request inside a turn always
+gets the 5 minute ceiling, because the turn holding it keeps the sandbox from
+parking.
+
+The deadline is stored on the turn, not in a timer, so it survives the sandbox
+suspending and the server restarting. A sweep every minute is what fires it.
 
 ## What each runtime can do
 

--- a/docs/concepts/permissions.md
+++ b/docs/concepts/permissions.md
@@ -127,6 +127,22 @@ picked, or the rejection the expiry chose from the agent's own list. It is null
 where the agent offered no rejection at all. The agent decides what to do with
 it.
 
+The turn's `origin` is `user`, like any other prompted turn. A client that
+wants to render this as a system event and not as something a person typed can
+tell it by the prompt itself, which is one JSON object whose only key is
+`fountain/permission_answer`.
+
+The connection the request was raised on is closed when the turn ends
+`waiting`, so the resume turn starts a fresh one. The old peer is still holding
+that request, and the runtimes number their requests from 0 on each turn, so
+keeping it would make the resume turn's first request collide with the one it
+still holds.
+
+An answer is refused, and the request left where it is, when the conversation
+cannot take the turn that carries it. A turn of its own is running, the account
+is suspended, or the balance is spent. Answer again once that is fixed. The
+expiry sweep does the same, and comes back a minute later.
+
 ### The deadline
 
 A detached request is refused when its deadline passes, and the refusal opens
@@ -136,8 +152,17 @@ from the first of these that is set.
 1. `_meta.fountain.timeout` on the `session/request_permission` itself, in
   seconds. The agent sets this per request.
 2. `ask_timeout` in the permission policy, in seconds. This is the one policy
-  key that names no tool. A launch may shorten it and may not lengthen it.
+  key that names no tool.
 3. The 5 minute ceiling, which is what an in-turn request gets.
+
+Where the request and the policy both name one, the **shorter** wins. The
+request is written inside the sandbox and the policy belongs to the tenant, so
+an agent can bound its own wait and cannot extend the tenant's.
+
+A launch policy may shorten the agent's `ask_timeout` and may not lengthen it.
+Where the agent named none, the 5 minute ceiling is what a launch may only
+shorten. A longer wait is more time for somebody to approve the tool, so
+longer is looser.
 
 Only a detached request reads the first two. A request inside a turn always
 gets the 5 minute ceiling, because the turn holding it keeps the sandbox from

--- a/sdk/contract/contract.json
+++ b/sdk/contract/contract.json
@@ -5942,7 +5942,17 @@
             "ref": "PermissionAnswerResponse"
           }
         },
+        "400": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "402": {
           "application/json": {
             "ref": "Error"
           }
@@ -7897,12 +7907,19 @@
         },
         "permission_policy": {
           "additionalProperties": {
-            "enum": [
-              "ask",
-              "auto_allow",
-              "auto_deny"
-            ],
-            "type": "string"
+            "oneOf": [
+              {
+                "enum": [
+                  "ask",
+                  "auto_allow",
+                  "auto_deny"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              }
+            ]
           },
           "nullable": true,
           "properties": {
@@ -8050,12 +8067,19 @@
         },
         "permission_policy": {
           "additionalProperties": {
-            "enum": [
-              "ask",
-              "auto_allow",
-              "auto_deny"
-            ],
-            "type": "string"
+            "oneOf": [
+              {
+                "enum": [
+                  "ask",
+                  "auto_allow",
+                  "auto_deny"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              }
+            ]
           },
           "nullable": true,
           "properties": {
@@ -8195,12 +8219,19 @@
         },
         "permission_policy": {
           "additionalProperties": {
-            "enum": [
-              "ask",
-              "auto_allow",
-              "auto_deny"
-            ],
-            "type": "string"
+            "oneOf": [
+              {
+                "enum": [
+                  "ask",
+                  "auto_allow",
+                  "auto_deny"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              }
+            ]
           },
           "nullable": true,
           "properties": {
@@ -10060,12 +10091,19 @@
         },
         "permission_policy": {
           "additionalProperties": {
-            "enum": [
-              "ask",
-              "auto_allow",
-              "auto_deny"
-            ],
-            "type": "string"
+            "oneOf": [
+              {
+                "enum": [
+                  "ask",
+                  "auto_allow",
+                  "auto_deny"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              }
+            ]
           },
           "nullable": true,
           "properties": {
@@ -10209,12 +10247,19 @@
         },
         "permission_policy": {
           "additionalProperties": {
-            "enum": [
-              "ask",
-              "auto_allow",
-              "auto_deny"
-            ],
-            "type": "string"
+            "oneOf": [
+              {
+                "enum": [
+                  "ask",
+                  "auto_allow",
+                  "auto_deny"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              }
+            ]
           },
           "nullable": true,
           "properties": {

--- a/sdk/contract/contract.json
+++ b/sdk/contract/contract.json
@@ -7905,6 +7905,12 @@
             "type": "string"
           },
           "nullable": true,
+          "properties": {
+            "ask_timeout": {
+              "required": false,
+              "type": "integer"
+            }
+          },
           "required": false,
           "type": "object"
         },
@@ -8052,6 +8058,12 @@
             "type": "string"
           },
           "nullable": true,
+          "properties": {
+            "ask_timeout": {
+              "required": false,
+              "type": "integer"
+            }
+          },
           "required": false,
           "type": "object"
         },
@@ -8191,6 +8203,12 @@
             "type": "string"
           },
           "nullable": true,
+          "properties": {
+            "ask_timeout": {
+              "required": false,
+              "type": "integer"
+            }
+          },
           "required": false,
           "type": "object"
         },
@@ -10033,6 +10051,13 @@
           "required": false,
           "type": "string"
         },
+        "pending_requests": {
+          "items": {
+            "ref": "PendingPermissionRequest"
+          },
+          "required": false,
+          "type": "array"
+        },
         "permission_policy": {
           "additionalProperties": {
             "enum": [
@@ -10043,6 +10068,12 @@
             "type": "string"
           },
           "nullable": true,
+          "properties": {
+            "ask_timeout": {
+              "required": false,
+              "type": "integer"
+            }
+          },
           "required": false,
           "type": "object"
         },
@@ -10186,6 +10217,12 @@
             "type": "string"
           },
           "nullable": true,
+          "properties": {
+            "ask_timeout": {
+              "required": false,
+              "type": "integer"
+            }
+          },
           "required": false,
           "type": "object"
         },
@@ -11189,6 +11226,45 @@
         },
         "token": {
           "required": true,
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "PendingPermissionRequest": {
+      "properties": {
+        "asked_at": {
+          "format": "date-time",
+          "nullable": true,
+          "required": false,
+          "type": "string"
+        },
+        "deadline": {
+          "format": "date-time",
+          "nullable": true,
+          "required": false,
+          "type": "string"
+        },
+        "options": {
+          "items": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "required": true,
+          "type": "array"
+        },
+        "request_id": {
+          "required": true,
+          "type": "string"
+        },
+        "tool": {
+          "nullable": true,
+          "required": false,
+          "type": "string"
+        },
+        "turn_id": {
+          "format": "uuid",
+          "required": false,
           "type": "string"
         }
       },
@@ -12940,6 +13016,10 @@
             }
           ],
           "required": false
+        },
+        "waiting": {
+          "required": false,
+          "type": "boolean"
         }
       },
       "type": "object"

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -10,6 +10,14 @@ server releases.
 
 ---
 
+## [1.22.2] — 2026-09-06
+
+### Added
+
+- Generated types carry a conversation's `pending_requests`, the permission requests that outlived a turn and are still waiting for an answer. Each entry has the request id, the tool, the options the agent offered, when it was asked and when it expires.
+- Generated types carry a turn's `waiting`, true when the turn ended with such a request still open.
+- `permission_policy` accepts `ask_timeout`, a number of seconds a request that outlived its turn waits before it is denied. It is the one policy key whose value is a number rather than a verdict, so the value type is now a union of the verdict enum and a number.
+
 ## [1.22.1] — 2026-09-06
 
 ### Changed

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "1.22.1",
+  "version": "1.22.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentshit/fountain-sdk",
-      "version": "1.22.1",
+      "version": "1.22.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^26.4.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "1.22.1",
+  "version": "1.22.2",
   "description": "Run a coding agent on a real computer, with your repos and your credentials, in one call.",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -2619,10 +2619,10 @@ export interface components {
             name: string;
             /** @description Per-tool permission policy: a map of key to verdict, plus an optional "default" key. A key is matched against the tool card's title first and then ACP's kind (execute, edit, read, fetch, …); prefer a kind, because claude titles a tool call with the command it is about to run. Unset keys fall back to the default, and an unset default is auto_allow — today's behaviour. "ask" holds the tool until a human answers it on the conversation stream, and denies if nobody does before the timeout. A runtime that never asks (opencode) refuses anything stricter than auto_allow with 422 permission_policy_unenforceable. */
             permission_policy?: ({
-                /** @description Seconds a permission request that outlived its turn waits before it is denied (#1635). Names no tool, so it is the one key whose value is not a verdict. Absent leaves the global ask timeout. A request may override it with `_meta.fountain.timeout` on its own session/request_permission. A launch may only shorten it. */
+                /** @description Seconds a permission request that outlived its turn waits before it is denied (#1635). Names no tool, so it is the one key whose value is a number rather than a verdict, which is why the value schema below is a union. Absent leaves the global ask timeout. A request may shorten it with `_meta.fountain.timeout` on its own session/request_permission, and may not lengthen it. A launch may only shorten what the agent set, or the global ask timeout where the agent set nothing. */
                 ask_timeout?: number;
             } & {
-                [key: string]: "auto_allow" | "ask" | "auto_deny";
+                [key: string]: ("auto_allow" | "ask" | "auto_deny") | number;
             }) | null;
             /** @enum {string} */
             runtime: "claude" | "codex" | "gemini" | "opencode" | "acp" | "fountain-fixture";
@@ -2677,10 +2677,10 @@ export interface components {
             name: string;
             /** @description Per-tool permission policy: a map of key to verdict, plus an optional "default" key. A key is matched against the tool card's title first and then ACP's kind (execute, edit, read, fetch, …); prefer a kind, because claude titles a tool call with the command it is about to run. Unset keys fall back to the default, and an unset default is auto_allow. "ask" holds the tool until a human answers it on the conversation stream, and denies if nobody does before the timeout. A conversation may narrow this at launch, never widen it. A runtime that never asks (opencode) refuses anything stricter than auto_allow with 422 permission_policy_unenforceable. */
             permission_policy?: ({
-                /** @description Seconds a permission request that outlived its turn waits before it is denied (#1635). Names no tool, so it is the one key whose value is not a verdict. Absent leaves the global ask timeout. A request may override it with `_meta.fountain.timeout` on its own session/request_permission. A launch may only shorten it. */
+                /** @description Seconds a permission request that outlived its turn waits before it is denied (#1635). Names no tool, so it is the one key whose value is a number rather than a verdict, which is why the value schema below is a union. Absent leaves the global ask timeout. A request may shorten it with `_meta.fountain.timeout` on its own session/request_permission, and may not lengthen it. A launch may only shorten what the agent set, or the global ask timeout where the agent set nothing. */
                 ask_timeout?: number;
             } & {
-                [key: string]: "auto_allow" | "ask" | "auto_deny";
+                [key: string]: ("auto_allow" | "ask" | "auto_deny") | number;
             }) | null;
             /** @enum {string} */
             runtime: "claude" | "codex" | "gemini" | "opencode" | "acp" | "fountain-fixture";
@@ -2732,10 +2732,10 @@ export interface components {
             name?: string;
             /** @description Per-tool permission policy: a map of key to verdict, plus an optional "default" key. A key is matched against the tool card's title first and then ACP's kind (execute, edit, read, fetch, …); prefer a kind, because claude titles a tool call with the command it is about to run. Unset keys fall back to the default, and an unset default is auto_allow. "ask" holds the tool until a human answers it on the conversation stream, and denies if nobody does before the timeout. A conversation may narrow this at launch, never widen it. A runtime that never asks (opencode) refuses anything stricter than auto_allow with 422 permission_policy_unenforceable. */
             permission_policy?: ({
-                /** @description Seconds a permission request that outlived its turn waits before it is denied (#1635). Names no tool, so it is the one key whose value is not a verdict. Absent leaves the global ask timeout. A request may override it with `_meta.fountain.timeout` on its own session/request_permission. A launch may only shorten it. */
+                /** @description Seconds a permission request that outlived its turn waits before it is denied (#1635). Names no tool, so it is the one key whose value is a number rather than a verdict, which is why the value schema below is a union. Absent leaves the global ask timeout. A request may shorten it with `_meta.fountain.timeout` on its own session/request_permission, and may not lengthen it. A launch may only shorten what the agent set, or the global ask timeout where the agent set nothing. */
                 ask_timeout?: number;
             } & {
-                [key: string]: "auto_allow" | "ask" | "auto_deny";
+                [key: string]: ("auto_allow" | "ask" | "auto_deny") | number;
             }) | null;
             /** @enum {string} */
             runtime?: "claude" | "codex" | "gemini" | "opencode" | "acp" | "fountain-fixture";
@@ -3556,10 +3556,10 @@ export interface components {
             pending_requests?: components["schemas"]["PendingPermissionRequest"][];
             /** @description The per-launch permission override this conversation was started with, or null if it had none. The policy actually in force is this merged with the agent's, taking the stricter of the two per tool. */
             permission_policy?: ({
-                /** @description Seconds a permission request that outlived its turn waits before it is denied (#1635). Names no tool, so it is the one key whose value is not a verdict. Absent leaves the global ask timeout. A request may override it with `_meta.fountain.timeout` on its own session/request_permission. A launch may only shorten it. */
+                /** @description Seconds a permission request that outlived its turn waits before it is denied (#1635). Names no tool, so it is the one key whose value is a number rather than a verdict, which is why the value schema below is a union. Absent leaves the global ask timeout. A request may shorten it with `_meta.fountain.timeout` on its own session/request_permission, and may not lengthen it. A launch may only shorten what the agent set, or the global ask timeout where the agent set nothing. */
                 ask_timeout?: number;
             } & {
-                [key: string]: "auto_allow" | "ask" | "auto_deny";
+                [key: string]: ("auto_allow" | "ask" | "auto_deny") | number;
             }) | null;
             /** @enum {string} */
             runtime: "claude" | "codex" | "gemini" | "opencode" | "acp" | "fountain-fixture";
@@ -3608,10 +3608,10 @@ export interface components {
             } | null;
             /** @description Per-launch permission override (#939). Keys are matched against the tool card's title first and then ACP's kind (execute, edit, read, fetch, …); "default" covers the rest. Prefer a kind: claude titles a tool call with the command it is about to run, so a title matches one invocation only. Merged with the agent's own policy, taking the stricter of the two. It may only narrow: a policy that would loosen any tool is refused with 422 permission_policy_widens rather than silently clamped, and one the runtime never consults is refused with 422 permission_policy_unenforceable. */
             permission_policy?: ({
-                /** @description Seconds a permission request that outlived its turn waits before it is denied (#1635). Names no tool, so it is the one key whose value is not a verdict. Absent leaves the global ask timeout. A request may override it with `_meta.fountain.timeout` on its own session/request_permission. A launch may only shorten it. */
+                /** @description Seconds a permission request that outlived its turn waits before it is denied (#1635). Names no tool, so it is the one key whose value is a number rather than a verdict, which is why the value schema below is a union. Absent leaves the global ask timeout. A request may shorten it with `_meta.fountain.timeout` on its own session/request_permission, and may not lengthen it. A launch may only shorten what the agent set, or the global ask timeout where the agent set nothing. */
                 ask_timeout?: number;
             } & {
-                [key: string]: "auto_allow" | "ask" | "auto_deny";
+                [key: string]: ("auto_allow" | "ask" | "auto_deny") | number;
             }) | null;
             /** @description Optional first turn prompt. */
             prompt?: string;
@@ -10896,6 +10896,15 @@ export interface operations {
                     "application/json": components["schemas"]["PermissionAnswerResponse"];
                 };
             };
+            /** @description Busy */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Unauthorized */
             401: {
                 headers: {
@@ -10905,7 +10914,16 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
-            /** @description Forbidden */
+            /** @description Insufficient credits */
+            402: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description The sandbox may not answer */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -10932,7 +10950,7 @@ export interface operations {
                     "application/json": components["schemas"]["NegotiationError"];
                 };
             };
-            /** @description Already resolved */
+            /** @description Already resolved, or resolved but not delivered */
             409: {
                 headers: {
                     [name: string]: unknown;

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -1307,6 +1307,8 @@ export interface paths {
          * @description Answers a `session/request_permission` the agent is blocked on (#940). The request and its options arrive as a `permission_request` block on the conversation's event stream; `option_id` must be one of the `optionId` values that block carried. Never send an option the agent did not offer.
          *
          *     First answer wins: another attached client, the timeout, or the turn ending may already have resolved it, and all of those return 409. The resolution appears on the stream as a `request` stage event with state `done`.
+         *
+         *     A request that outlived its turn (#1635) is answered here too. The agent ended that turn with stop reason `waiting`, so the conversation is idle and the sandbox may be suspended; GET /api/conversations/{id} lists such requests as `pending_requests`. Answering one resolves it and opens a new turn carrying the request id and the option, which wakes the sandbox.
          */
         post: operations["FountainWeb.ConversationController.answer_request"];
         delete?: never;
@@ -2616,9 +2618,12 @@ export interface components {
             model: string | null;
             name: string;
             /** @description Per-tool permission policy: a map of key to verdict, plus an optional "default" key. A key is matched against the tool card's title first and then ACP's kind (execute, edit, read, fetch, …); prefer a kind, because claude titles a tool call with the command it is about to run. Unset keys fall back to the default, and an unset default is auto_allow — today's behaviour. "ask" holds the tool until a human answers it on the conversation stream, and denies if nobody does before the timeout. A runtime that never asks (opencode) refuses anything stricter than auto_allow with 422 permission_policy_unenforceable. */
-            permission_policy?: {
+            permission_policy?: ({
+                /** @description Seconds a permission request that outlived its turn waits before it is denied (#1635). Names no tool, so it is the one key whose value is not a verdict. Absent leaves the global ask timeout. A request may override it with `_meta.fountain.timeout` on its own session/request_permission. A launch may only shorten it. */
+                ask_timeout?: number;
+            } & {
                 [key: string]: "auto_allow" | "ask" | "auto_deny";
-            } | null;
+            }) | null;
             /** @enum {string} */
             runtime: "claude" | "codex" | "gemini" | "opencode" | "acp" | "fountain-fixture";
             /** @description The command the acp runtime launches inside the sandbox, as a shell line resolved there (for example `chant acp`). Required when runtime is acp, and rejected on every other runtime, which resolves its own executable. A free string by design: it runs under the same isolation as an environment's setup script. */
@@ -2671,9 +2676,12 @@ export interface components {
             model?: string | null;
             name: string;
             /** @description Per-tool permission policy: a map of key to verdict, plus an optional "default" key. A key is matched against the tool card's title first and then ACP's kind (execute, edit, read, fetch, …); prefer a kind, because claude titles a tool call with the command it is about to run. Unset keys fall back to the default, and an unset default is auto_allow. "ask" holds the tool until a human answers it on the conversation stream, and denies if nobody does before the timeout. A conversation may narrow this at launch, never widen it. A runtime that never asks (opencode) refuses anything stricter than auto_allow with 422 permission_policy_unenforceable. */
-            permission_policy?: {
+            permission_policy?: ({
+                /** @description Seconds a permission request that outlived its turn waits before it is denied (#1635). Names no tool, so it is the one key whose value is not a verdict. Absent leaves the global ask timeout. A request may override it with `_meta.fountain.timeout` on its own session/request_permission. A launch may only shorten it. */
+                ask_timeout?: number;
+            } & {
                 [key: string]: "auto_allow" | "ask" | "auto_deny";
-            } | null;
+            }) | null;
             /** @enum {string} */
             runtime: "claude" | "codex" | "gemini" | "opencode" | "acp" | "fountain-fixture";
             /** @description The command the acp runtime launches inside the sandbox, as a shell line resolved there (for example `chant acp`). Required when runtime is acp, and rejected on every other runtime, which resolves its own executable. A free string by design: it runs under the same isolation as an environment's setup script. */
@@ -2723,9 +2731,12 @@ export interface components {
             model?: string | null;
             name?: string;
             /** @description Per-tool permission policy: a map of key to verdict, plus an optional "default" key. A key is matched against the tool card's title first and then ACP's kind (execute, edit, read, fetch, …); prefer a kind, because claude titles a tool call with the command it is about to run. Unset keys fall back to the default, and an unset default is auto_allow. "ask" holds the tool until a human answers it on the conversation stream, and denies if nobody does before the timeout. A conversation may narrow this at launch, never widen it. A runtime that never asks (opencode) refuses anything stricter than auto_allow with 422 permission_policy_unenforceable. */
-            permission_policy?: {
+            permission_policy?: ({
+                /** @description Seconds a permission request that outlived its turn waits before it is denied (#1635). Names no tool, so it is the one key whose value is not a verdict. Absent leaves the global ask timeout. A request may override it with `_meta.fountain.timeout` on its own session/request_permission. A launch may only shorten it. */
+                ask_timeout?: number;
+            } & {
                 [key: string]: "auto_allow" | "ask" | "auto_deny";
-            } | null;
+            }) | null;
             /** @enum {string} */
             runtime?: "claude" | "codex" | "gemini" | "opencode" | "acp" | "fountain-fixture";
             /** @description The command the acp runtime launches inside the sandbox, as a shell line resolved there (for example `chant acp`). Required when runtime is acp, and rejected on every other runtime, which resolves its own executable. A free string by design: it runs under the same isolation as an environment's setup script. */
@@ -3541,10 +3552,15 @@ export interface components {
             last_read_at?: string | null;
             /** Format: uuid */
             parent_conversation_id?: string | null;
+            /** @description Permission requests that outlived a turn and are still waiting for an answer (#1635). Served on GET /api/conversations/{id} only; absent from the list and from the create response. */
+            pending_requests?: components["schemas"]["PendingPermissionRequest"][];
             /** @description The per-launch permission override this conversation was started with, or null if it had none. The policy actually in force is this merged with the agent's, taking the stricter of the two per tool. */
-            permission_policy?: {
+            permission_policy?: ({
+                /** @description Seconds a permission request that outlived its turn waits before it is denied (#1635). Names no tool, so it is the one key whose value is not a verdict. Absent leaves the global ask timeout. A request may override it with `_meta.fountain.timeout` on its own session/request_permission. A launch may only shorten it. */
+                ask_timeout?: number;
+            } & {
                 [key: string]: "auto_allow" | "ask" | "auto_deny";
-            } | null;
+            }) | null;
             /** @enum {string} */
             runtime: "claude" | "codex" | "gemini" | "opencode" | "acp" | "fountain-fixture";
             runtime_session_id?: string | null;
@@ -3591,9 +3607,12 @@ export interface components {
                 [key: string]: string;
             } | null;
             /** @description Per-launch permission override (#939). Keys are matched against the tool card's title first and then ACP's kind (execute, edit, read, fetch, …); "default" covers the rest. Prefer a kind: claude titles a tool call with the command it is about to run, so a title matches one invocation only. Merged with the agent's own policy, taking the stricter of the two. It may only narrow: a policy that would loosen any tool is refused with 422 permission_policy_widens rather than silently clamped, and one the runtime never consults is refused with 422 permission_policy_unenforceable. */
-            permission_policy?: {
+            permission_policy?: ({
+                /** @description Seconds a permission request that outlived its turn waits before it is denied (#1635). Names no tool, so it is the one key whose value is not a verdict. Absent leaves the global ask timeout. A request may override it with `_meta.fountain.timeout` on its own session/request_permission. A launch may only shorten it. */
+                ask_timeout?: number;
+            } & {
                 [key: string]: "auto_allow" | "ask" | "auto_deny";
-            } | null;
+            }) | null;
             /** @description Optional first turn prompt. */
             prompt?: string;
             /**
@@ -4050,6 +4069,28 @@ export interface components {
             password: string;
             /** @description From the reset email. */
             token: string;
+        };
+        /**
+         * PendingPermissionRequest
+         * @description A permission request that outlived its turn (#1635). The agent ended the turn with stop reason `waiting` while this request was open, so the conversation is idle, the sandbox may be suspended, and the request is still waiting for an answer. Answer it at POST /api/conversations/{id}/requests/{request_id}, which resolves it and opens a new turn carrying the outcome to the agent.
+         */
+        PendingPermissionRequest: {
+            /** Format: date-time */
+            asked_at?: string | null;
+            /**
+             * Format: date-time
+             * @description When the request is denied for want of an answer. Set from the request's own `_meta.fountain.timeout`, else the policy's `ask_timeout`, else the global ask timeout.
+             */
+            deadline?: string | null;
+            /** @description The options the agent offered, verbatim. `option_id` must be one of these `optionId` values; an id from another runtime is refused. */
+            options: {
+                [key: string]: unknown;
+            }[];
+            request_id: string;
+            /** @description The tool the agent asked about, as the transcript labels it. */
+            tool?: string | null;
+            /** Format: uuid */
+            turn_id?: string;
         };
         /** PermissionAnswerRequest */
         PermissionAnswerRequest: {
@@ -4801,6 +4842,8 @@ export interface components {
             turn_number: number;
             /** @description The end-of-turn token figure; null while the turn runs, when the runtime reported none, or on turns that predate the field. */
             usage?: components["schemas"]["TurnUsage"] | null;
+            /** @description The turn ended with a permission request still open (#1635): the agent answered with stop reason `waiting`, the turn is `completed` and the request is on the conversation as a `pending_requests` entry. */
+            waiting?: boolean;
         };
         /** TurnListResponse */
         TurnListResponse: {

--- a/sdk/typescript/src/http.ts
+++ b/sdk/typescript/src/http.ts
@@ -19,7 +19,7 @@ export interface RequestOptions {
  * this string is already what Fountain's request logs are keyed on. The
  * version half is asserted against `package.json` by a test.
  */
-export const USER_AGENT = "fountain-sdk-js/1.22.1";
+export const USER_AGENT = "fountain-sdk-js/1.22.2";
 
 /**
  * The thin layer everything else is built on: one bearer token, JSON in and

--- a/sdk/typescript/test/permission_policy.test.ts
+++ b/sdk/typescript/test/permission_policy.test.ts
@@ -1,0 +1,38 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import type { components } from "../src/generated/openapi.ts";
+
+type AgentRequest = components["schemas"]["AgentRequest"];
+type PermissionPolicy = NonNullable<AgentRequest["permission_policy"]>;
+
+// `ask_timeout` is the one key of a permission policy whose value is not a
+// verdict (#1635). The generated type is an intersection of the named
+// property with the index signature, so the index signature has to admit a
+// number: with a verdict-only one, `ask_timeout` narrows to `never` and the
+// key is untypeable even though the server accepts it.
+describe("permission_policy", () => {
+  test("ask_timeout takes a number of seconds", () => {
+    const policy: PermissionPolicy = { ask_timeout: 3600 };
+
+    // Read it back through the named property, which is what would be `never`.
+    const seconds: number | undefined = policy.ask_timeout;
+    assert.equal(seconds, 3600);
+  });
+
+  test("a tool key takes a verdict, beside the timeout", () => {
+    const policy: PermissionPolicy = {
+      default: "auto_allow",
+      execute: "ask",
+      ask_timeout: 172_800,
+    };
+
+    assert.equal(policy.execute, "ask");
+    assert.equal(policy.ask_timeout, 172_800);
+  });
+
+  test("a value that is neither a verdict nor a number is refused", () => {
+    // @ts-expect-error "maybe" is not a verdict.
+    const policy: PermissionPolicy = { execute: "maybe" };
+    assert.ok(policy);
+  });
+});


### PR DESCRIPTION
An `ask` verdict holds the agent's tool call until a human answers and denies it after five minutes, because the request is held inside a running turn that must not outlive the idle bound. A deterministic op has waits of a different shape: approve this production apply, confirm the DNS delegation happened. Those take hours or days, and nothing in the sandbox needs to stay running while they do. This PR lets a request outlive its turn.

- An agent that sends `session/request_permission` and then answers `session/prompt` with the stop reason `waiting` ends its turn `completed` with `waiting: true` on the turn row and the request still pending. The conversation goes idle and the sandbox suspends as usual. The connection is dropped at detach, since the ACP client cannot release a held request without answering it; the resume turn always handshakes a fresh peer.
- Answering through `POST /api/conversations/:id/requests/:request_id` resolves the request with a guarded single-row update (first answer wins) and opens a new turn whose prompt is one JSON line under the key `fountain/permission_answer`, carrying the request id, the tool, the outcome and the option. The wake's gates run before the row is touched, and a delivery that still fails afterwards is reported distinctly.
- A per-request timeout in the request's `_meta` or a policy-level `ask_timeout` replaces the global ceiling for detached requests, the smaller of the two when both are set; a launch may not raise the agent's value or the global ceiling. `Fountain.Workers.DetachedRequestSweeper` expires overdue requests every minute, denies with the agent's own reject option, and opens the same resume turn. It leaves a request alone when the conversation cannot take a turn yet.
- `GET /api/conversations/:id` lists pending requests; the `turn` stage carries `waiting`; `conversation.request.*` webhooks fire on detach and on resolution; a sandbox token is still refused; the audit trail records the resolution with the caller's attribution.
- Move the pending family's state round trip into `Pending` to keep the conversation server under its size pin.
- Document the detached path in `docs/concepts/permissions.md` and amend ADR 0014.

Three follow-ups for the `managoat_acp` library are noted in the commits: a `Peer.release_permission/2` that clears a hold without writing a response, a `_meta` hook on `Peer.prompt`, and reporting request params with `{:permission_ask, ...}`.

Closes #1635

Stacked on #1634; merge that first.

Validation:

- Full suite on the four-branch stack: 4579 tests, 0 failures (core and ee), 144 (fountain_buzz), 33 (fountain_support).
- `mix compile --warnings-as-errors`, `mix format --check-formatted`, `mix credo --strict`, dialyzer, sobelow and `deps.unlock --unused` are clean. The prod release assembles.
- The SDK contract check, the TypeScript verifier, typecheck and tests, the Python verifier and the conformance lint pass. `scripts/docs-style.py` is clean.
- Not run here: vale, okf and destink (not installed on the build machine).
