### PR TITLE
fix(codex): a brokered turn stops paying a 300s websocket timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,8 @@ upgrade, is in
   out — around 300 seconds on every turn, before falling back to HTTP and
   answering in about a second. The built-in `openai` provider is reserved and
   cannot be overridden, so Fountain declares the same endpoint under an id of
-  its own, carrying across `OPENAI_BASE_URL` where an environment sets one. A
+  its own, carrying across `OPENAI_BASE_URL`, the OpenAI-Organization and
+  OpenAI-Project header mappings and standalone web search. A
   conversation whose spawn has no `OPENAI_API_KEY` keeps the built-in
   provider, which can still authenticate from `~/.codex/auth.json`. An agent
   that names its own provider in `CODEX_CONFIG` keeps it; a `model_provider`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,8 +52,12 @@ upgrade, is in
   out — around 300 seconds on every turn, before falling back to HTTP and
   answering in about a second. The built-in `openai` provider is reserved and
   cannot be overridden, so Fountain declares the same endpoint under an id of
-  its own. An agent already pointed at a gateway keeps the provider it names
-  (#1674).
+  its own, carrying across `OPENAI_BASE_URL` where an environment sets one. A
+  conversation whose spawn has no `OPENAI_API_KEY` keeps the built-in
+  provider, which can still authenticate from `~/.codex/auth.json`. An agent
+  that names its own provider in `CODEX_CONFIG` keeps it; a `model_provider`
+  written into `~/.codex/config.toml` by a setup script is not read, and is
+  overridden (#1674).
 
 - Codex launches on Sprites with inherited and ambient capabilities cleared,
   allowing its bubblewrap sandbox to start without falling back to approval

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,15 @@ upgrade, is in
   variables still win over everything: they are what makes egress brokered.
   Both halves of the rule are now in the manual, under Secrets (#1674).
 
+- A brokered Codex conversation reaches OpenAI over a provider with the
+  WebSocket transport turned off. Codex's `responses_websocket` dialer cannot
+  use an https-scheme proxy and spent the full connect timeout finding that
+  out — around 300 seconds on every turn, before falling back to HTTP and
+  answering in about a second. The built-in `openai` provider is reserved and
+  cannot be overridden, so Fountain declares the same endpoint under an id of
+  its own. An agent already pointed at a gateway keeps the provider it names
+  (#1674).
+
 - Codex launches on Sprites with inherited and ambient capabilities cleared,
   allowing its bubblewrap sandbox to start without falling back to approval
   escalation on every command (#1672). Existing adapter processes need a restart.

--- a/apps/fountain/lib/fountain/conversations/codex_transport.ex
+++ b/apps/fountain/lib/fountain/conversations/codex_transport.ex
@@ -5,6 +5,33 @@ defmodule Fountain.Conversations.CodexTransport do
   # Codex's default WebSocket dialer rejects HTTPS proxy URLs. Its explicit
   # proxy route supports TLS to the broker, but is opt-in in Codex 0.153.3.
   # Keep this process-local: persistent sandboxes are shared by conversations.
+
+  # Rejecting the proxy URL is not the expensive part — waiting to find out
+  # is. `responses_websocket` dials `wss://api.openai.com/v1/responses`, sits
+  # on the connect timeout, reports `Proxy URL scheme not supported` and only
+  # then falls back to HTTP. Measured on Sprites (#1674), that was 303, 292
+  # and 306 seconds on three consecutive turns whose actual work took about a
+  # second each.
+  #
+  # `supports_websockets` is a provider field, and the built-in `openai`
+  # provider cannot be overridden — `model_providers contains reserved
+  # built-in provider IDs` is a hard configuration error, from the file and
+  # from here alike (openai/codex#13103). A provider id of our own is not
+  # reserved, so declare the same endpoint with the websocket transport off
+  # and select it. `env_key` rather than the built-in's `auth.json`, because a
+  # custom provider does not read that store; `OPENAI_API_KEY` is in the
+  # sandbox env either way, and on a brokered conversation it is the
+  # placeholder the broker substitutes for the real key on the way out
+  # (`Fountain.Broker.split_inference/2`), so nothing about who pays changes.
+  @provider_id "fountain_openai_http"
+  @provider %{
+    "name" => "OpenAI",
+    "base_url" => "https://api.openai.com/v1",
+    "wire_api" => "responses",
+    "env_key" => "OPENAI_API_KEY",
+    "supports_websockets" => false
+  }
+
   def spawn_opts(%{broker: broker}, "codex", opts) when not is_nil(broker) do
     env = Keyword.get(opts, :env, [])
 
@@ -15,11 +42,13 @@ defmodule Fountain.Conversations.CodexTransport do
       end
 
     with {:ok, config} when is_map(config) <- Jason.decode(raw),
-         features when is_map(features) <- Map.get(config, "features", %{}) do
+         features when is_map(features) <- Map.get(config, "features", %{}),
+         providers when is_map(providers) <- Map.get(config, "model_providers", %{}) do
       config =
         config
         |> Map.put("features", Map.put(features, "respect_system_proxy", true))
         |> Map.delete("features.respect_system_proxy")
+        |> disable_websockets(providers)
 
       env = List.keystore(env, "CODEX_CONFIG", 0, {"CODEX_CONFIG", Jason.encode!(config)})
       {:ok, Keyword.put(opts, :env, env)}
@@ -30,4 +59,17 @@ defmodule Fountain.Conversations.CodexTransport do
   end
 
   def spawn_opts(_state, _runtime, opts), do: {:ok, opts}
+
+  # Only the conversation that would otherwise dial OpenAI directly. An agent
+  # already pointed at a gateway keeps the provider it names: that provider
+  # decides its own transport, and its base URL is not ours to replace.
+  defp disable_websockets(config, providers) do
+    if Map.get(config, "model_provider", "openai") in ["openai", @provider_id] do
+      config
+      |> Map.put("model_provider", @provider_id)
+      |> Map.put("model_providers", Map.put_new(providers, @provider_id, @provider))
+    else
+      config
+    end
+  end
 end

--- a/apps/fountain/lib/fountain/conversations/codex_transport.ex
+++ b/apps/fountain/lib/fountain/conversations/codex_transport.ex
@@ -65,6 +65,7 @@ defmodule Fountain.Conversations.CodexTransport do
       env =
         Enum.reject(env, &match?({"CODEX_CONFIG", _}, &1)) ++
           [{"CODEX_CONFIG", Jason.encode!(config)}]
+
       {:ok, Keyword.put(opts, :env, env)}
     else
       # Do not include the config: it may contain provider credentials.

--- a/apps/fountain/lib/fountain/conversations/codex_transport.ex
+++ b/apps/fountain/lib/fountain/conversations/codex_transport.ex
@@ -18,19 +18,36 @@ defmodule Fountain.Conversations.CodexTransport do
   # built-in provider IDs` is a hard configuration error, from the file and
   # from here alike (openai/codex#13103). A provider id of our own is not
   # reserved, so declare the same endpoint with the websocket transport off
-  # and select it. `env_key` rather than the built-in's `auth.json`, because a
-  # custom provider does not read that store; `OPENAI_API_KEY` is in the
-  # sandbox env either way, and on a brokered conversation it is the
-  # placeholder the broker substitutes for the real key on the way out
-  # (`Fountain.Broker.split_inference/2`), so nothing about who pays changes.
+  # and select it.
+  #
+  # Two things the substitution has to carry across, because the built-in
+  # provider has them and a custom one does not:
+  #
+  #   * **The endpoint.** The built-in reads `OPENAI_BASE_URL`, which is how
+  #     an environment points codex at a gateway. `base_url/1` reads the same
+  #     variable out of the spawn env, so hard-coding OpenAI's URL here does
+  #     not silently redirect a conversation that had been going elsewhere.
+  #   * **The credential.** A custom provider does not read `~/.codex/auth.json`,
+  #     which is where `codex login --with-api-key` puts the key at provision
+  #     time (ADR 0019 gate 3) and where a sandbox shared by several
+  #     conversations still holds one. So the substitution happens only when
+  #     `OPENAI_API_KEY` is in this spawn's env for `env_key` to name. Without
+  #     it the conversation keeps the built-in provider and pays the stall —
+  #     the wrong provider would cost it the turn instead.
+  #
+  # Brokered, `OPENAI_API_KEY` holds the placeholder the broker substitutes
+  # for the real key on the way out (`Fountain.Broker.split_inference/2`), so
+  # nothing about which key pays changes.
+  #
+  # **Scope.** This reads the CODEX_CONFIG overlay and nothing else. A
+  # `model_provider` an environment's setup script wrote into
+  # `~/.codex/config.toml` is invisible here, and the overlay outranks the
+  # file, so such a conversation is moved onto this provider. Fountain writes
+  # no `model_provider` of its own into that file; `env_vars` is the supported
+  # way to point codex somewhere else, and `OPENAI_BASE_URL` set there is
+  # carried across.
   @provider_id "fountain_openai_http"
-  @provider %{
-    "name" => "OpenAI",
-    "base_url" => "https://api.openai.com/v1",
-    "wire_api" => "responses",
-    "env_key" => "OPENAI_API_KEY",
-    "supports_websockets" => false
-  }
+  @openai_base_url "https://api.openai.com/v1"
 
   def spawn_opts(%{broker: broker}, "codex", opts) when not is_nil(broker) do
     env = Keyword.get(opts, :env, [])
@@ -48,7 +65,7 @@ defmodule Fountain.Conversations.CodexTransport do
         config
         |> Map.put("features", Map.put(features, "respect_system_proxy", true))
         |> Map.delete("features.respect_system_proxy")
-        |> disable_websockets(providers)
+        |> select_http_provider(providers, env)
 
       env = List.keystore(env, "CODEX_CONFIG", 0, {"CODEX_CONFIG", Jason.encode!(config)})
       {:ok, Keyword.put(opts, :env, env)}
@@ -60,16 +77,44 @@ defmodule Fountain.Conversations.CodexTransport do
 
   def spawn_opts(_state, _runtime, opts), do: {:ok, opts}
 
-  # Only the conversation that would otherwise dial OpenAI directly. An agent
-  # already pointed at a gateway keeps the provider it names: that provider
-  # decides its own transport, and its base URL is not ours to replace.
-  defp disable_websockets(config, providers) do
-    if Map.get(config, "model_provider", "openai") in ["openai", @provider_id] do
+  # Repoint the conversation at an equivalent provider with the websocket
+  # transport off. Only the one that would otherwise dial OpenAI directly: an
+  # agent already pointed at a gateway keeps the provider it names, because
+  # that provider decides its own transport and its endpoint is not ours to
+  # replace. A declaration of this id that the config already carries is the
+  # operator's, and is left alone.
+  defp select_http_provider(config, providers, env) do
+    if substitute?(config, env) do
       config
       |> Map.put("model_provider", @provider_id)
-      |> Map.put("model_providers", Map.put_new(providers, @provider_id, @provider))
+      |> Map.put("model_providers", Map.put_new(providers, @provider_id, provider(env)))
     else
       config
+    end
+  end
+
+  defp substitute?(config, env) do
+    Map.get(config, "model_provider", "openai") in ["openai", @provider_id] and
+      match?(
+        {_, value} when is_binary(value) and value != "",
+        List.keyfind(env, "OPENAI_API_KEY", 0)
+      )
+  end
+
+  defp provider(env) do
+    %{
+      "name" => "OpenAI",
+      "base_url" => base_url(env),
+      "wire_api" => "responses",
+      "env_key" => "OPENAI_API_KEY",
+      "supports_websockets" => false
+    }
+  end
+
+  defp base_url(env) do
+    case List.keyfind(env, "OPENAI_BASE_URL", 0) do
+      {_, url} when is_binary(url) and url != "" -> url
+      _ -> @openai_base_url
     end
   end
 end

--- a/apps/fountain/lib/fountain/conversations/codex_transport.ex
+++ b/apps/fountain/lib/fountain/conversations/codex_transport.ex
@@ -51,11 +51,7 @@ defmodule Fountain.Conversations.CodexTransport do
   def spawn_opts(%{broker: broker}, "codex", opts) when not is_nil(broker) do
     env = Keyword.get(opts, :env, [])
 
-    raw =
-      case List.keyfind(env, "CODEX_CONFIG", 0) do
-        nil -> "{}"
-        {_, value} -> value
-      end
+    raw = Map.get(Map.new(env), "CODEX_CONFIG", "{}")
 
     with {:ok, config} when is_map(config) <- Jason.decode(raw),
          features when is_map(features) <- Map.get(config, "features", %{}),
@@ -66,7 +62,9 @@ defmodule Fountain.Conversations.CodexTransport do
         |> Map.delete("features.respect_system_proxy")
         |> select_http_provider(providers, env)
 
-      env = List.keystore(env, "CODEX_CONFIG", 0, {"CODEX_CONFIG", Jason.encode!(config)})
+      env =
+        Enum.reject(env, &match?({"CODEX_CONFIG", _}, &1)) ++
+          [{"CODEX_CONFIG", Jason.encode!(config)}]
       {:ok, Keyword.put(opts, :env, env)}
     else
       # Do not include the config: it may contain provider credentials.

--- a/apps/fountain/lib/fountain/conversations/codex_transport.ex
+++ b/apps/fountain/lib/fountain/conversations/codex_transport.ex
@@ -51,16 +51,24 @@ defmodule Fountain.Conversations.CodexTransport do
   def spawn_opts(%{broker: broker}, "codex", opts) when not is_nil(broker) do
     env = Keyword.get(opts, :env, [])
 
-    raw = Map.get(Map.new(env), "CODEX_CONFIG", "{}")
+    # `SpriteEnv.build/4` concatenates its pieces without merging, so a name
+    # can appear more than once; its moduledoc's precedence is last entry
+    # wins. Resolved once here, for every read below.
+    resolved = Map.new(env)
+    raw = Map.get(resolved, "CODEX_CONFIG", "{}")
 
     with {:ok, config} when is_map(config) <- Jason.decode(raw),
          features when is_map(features) <- Map.get(config, "features", %{}),
+         # Type-checked here so a non-map is `:invalid_codex_config` rather
+         # than a crash; `select_http_provider/2` reads it from `config`.
          providers when is_map(providers) <- Map.get(config, "model_providers", %{}) do
+      _ = providers
+
       config =
         config
         |> Map.put("features", Map.put(features, "respect_system_proxy", true))
         |> Map.delete("features.respect_system_proxy")
-        |> select_http_provider(providers, env)
+        |> select_http_provider(resolved)
 
       env =
         Enum.reject(env, &match?({"CODEX_CONFIG", _}, &1)) ++
@@ -79,24 +87,33 @@ defmodule Fountain.Conversations.CodexTransport do
   # transport off. Only the one that would otherwise dial OpenAI directly: an
   # agent already pointed at a gateway keeps the provider it names, because
   # that provider decides its own transport and its endpoint is not ours to
-  # replace. A declaration of this id that the config already carries is the
-  # operator's, and is left alone.
-  defp select_http_provider(config, providers, env) do
-    # SpriteEnv appends secrets and broker placeholders after plain variables.
-    # Resolve both endpoint and credential with the same last-entry precedence.
-    env = Map.new(env)
+  # replace.
+  #
+  # Selecting and declaring have to agree. A config that *selects* this id
+  # chose the declaration beside it, so both are left alone. A config that
+  # merely *declares* it without selecting it has chosen nothing, and writing
+  # the selection over someone else's definition would hand the turn an
+  # endpoint nothing picked — possibly with `supports_websockets` unset, which
+  # is the stall this exists to remove. There, the definition is ours too.
+  defp select_http_provider(config, env) do
+    providers = Map.get(config, "model_providers", %{})
 
-    if substitute?(config, env) do
-      config
-      |> Map.put("model_provider", @provider_id)
-      |> Map.put("model_providers", Map.put_new(providers, @provider_id, provider(env)))
-    else
-      config
+    cond do
+      Map.get(config, "model_provider") == @provider_id ->
+        config
+
+      substitute?(config, env) ->
+        config
+        |> Map.put("model_provider", @provider_id)
+        |> Map.put("model_providers", Map.put(providers, @provider_id, provider(env)))
+
+      true ->
+        config
     end
   end
 
   defp substitute?(config, env) do
-    Map.get(config, "model_provider", "openai") in ["openai", @provider_id] and
+    Map.get(config, "model_provider", "openai") == "openai" and
       match?(
         value when is_binary(value) and value != "",
         Map.get(env, "OPENAI_API_KEY")

--- a/apps/fountain/lib/fountain/conversations/codex_transport.ex
+++ b/apps/fountain/lib/fountain/conversations/codex_transport.ex
@@ -20,8 +20,7 @@ defmodule Fountain.Conversations.CodexTransport do
   # reserved, so declare the same endpoint with the websocket transport off
   # and select it.
   #
-  # Two things the substitution has to carry across, because the built-in
-  # provider has them and a custom one does not:
+  # Endpoint and authentication need special handling in the substitution:
   #
   #   * **The endpoint.** The built-in reads `OPENAI_BASE_URL`, which is how
   #     an environment points codex at a gateway. `base_url/1` reads the same
@@ -84,6 +83,10 @@ defmodule Fountain.Conversations.CodexTransport do
   # replace. A declaration of this id that the config already carries is the
   # operator's, and is left alone.
   defp select_http_provider(config, providers, env) do
+    # SpriteEnv appends secrets and broker placeholders after plain variables.
+    # Resolve both endpoint and credential with the same last-entry precedence.
+    env = Map.new(env)
+
     if substitute?(config, env) do
       config
       |> Map.put("model_provider", @provider_id)
@@ -96,24 +99,46 @@ defmodule Fountain.Conversations.CodexTransport do
   defp substitute?(config, env) do
     Map.get(config, "model_provider", "openai") in ["openai", @provider_id] and
       match?(
-        {_, value} when is_binary(value) and value != "",
-        List.keyfind(env, "OPENAI_API_KEY", 0)
+        value when is_binary(value) and value != "",
+        Map.get(env, "OPENAI_API_KEY")
       )
   end
 
+  # Field audit: Codex rust-v0.147.0 (installed in the review image) and
+  # rust-v0.153.3, codex-rs/model-provider-info/src/lib.rs,
+  # built_in_model_providers -> create_openai_provider:
+  # https://github.com/openai/codex/blob/rust-v0.147.0/codex-rs/model-provider-info/src/lib.rs
+  # Both set name, base_url, wire_api, env_http_headers, http_headers,
+  # requires_openai_auth, supports_websockets and supports_standalone_web_search.
+  # Preserve organization/project mappings and standalone search. Their sole
+  # provider http_header is the compiled CLI version; deliberately omit it:
+  # Fountain does not know the conversation sandbox's CLI version, and using
+  # the review image's version would misidentify an unpinned installation.
+  # Neither version declares OpenAI-Beta or originator as provider headers.
+  # env_key replaces requires_openai_auth only with a spawn credential;
+  # supports_websockets is deliberately false. env_key_instructions,
+  # experimental_bearer_token, auth, aws and query_params are all unset.
+  # request_max_retries, stream_max_retries, stream_idle_timeout_ms and
+  # websocket_connect_timeout_ms are also unset, using the same global
+  # defaults for built-in and custom providers; keep them unset here.
   defp provider(env) do
     %{
       "name" => "OpenAI",
       "base_url" => base_url(env),
       "wire_api" => "responses",
       "env_key" => "OPENAI_API_KEY",
-      "supports_websockets" => false
+      "supports_websockets" => false,
+      "supports_standalone_web_search" => true,
+      "env_http_headers" => %{
+        "OpenAI-Organization" => "OPENAI_ORGANIZATION",
+        "OpenAI-Project" => "OPENAI_PROJECT"
+      }
     }
   end
 
   defp base_url(env) do
-    case List.keyfind(env, "OPENAI_BASE_URL", 0) do
-      {_, url} when is_binary(url) and url != "" -> url
+    case Map.get(env, "OPENAI_BASE_URL") do
+      url when is_binary(url) and url != "" -> url
       _ -> @openai_base_url
     end
   end

--- a/apps/fountain/lib/fountain/conversations/codex_transport.ex
+++ b/apps/fountain/lib/fountain/conversations/codex_transport.ex
@@ -48,12 +48,20 @@ defmodule Fountain.Conversations.CodexTransport do
   @provider_id "fountain_openai_http"
   @openai_base_url "https://api.openai.com/v1"
 
+  # The names this module reads and acts on. `CODEX_CONFIG` is already
+  # collapsed by the rewrite, which rejects every entry and appends one.
+  @resolved_names ["OPENAI_API_KEY", "OPENAI_BASE_URL"]
+
   def spawn_opts(%{broker: broker}, "codex", opts) when not is_nil(broker) do
     env = Keyword.get(opts, :env, [])
 
     # `SpriteEnv.build/4` concatenates its pieces without merging, so a name
-    # can appear more than once; its moduledoc's precedence is last entry
-    # wins. Resolved once here, for every read below.
+    # can appear more than once. Nothing states which duplicate the sandbox
+    # process then reads — `SpriteEnv`'s moduledoc is about `merge_secrets/3`,
+    # which runs before the list is built, and `Managoat.Sandbox.spawn/4` is a
+    # dependency. So this does not rely on the answer: it resolves last entry
+    # wins, and `collapse/2` leaves exactly that entry in the env it emits, so
+    # Fountain and codex cannot disagree whichever rule the adapter follows.
     resolved = Map.new(env)
     raw = Map.get(resolved, "CODEX_CONFIG", "{}")
 
@@ -74,7 +82,7 @@ defmodule Fountain.Conversations.CodexTransport do
         Enum.reject(env, &match?({"CODEX_CONFIG", _}, &1)) ++
           [{"CODEX_CONFIG", Jason.encode!(config)}]
 
-      {:ok, Keyword.put(opts, :env, env)}
+      {:ok, Keyword.put(opts, :env, collapse(env, @resolved_names))}
     else
       # Do not include the config: it may contain provider credentials.
       _ -> {:error, :invalid_codex_config}
@@ -150,6 +158,22 @@ defmodule Fountain.Conversations.CodexTransport do
         "OpenAI-Project" => "OPENAI_PROJECT"
       }
     }
+  end
+
+  # Leave one entry per name — the one `resolved` acted on. Reading a
+  # duplicate one way and handing codex a list it may read the other way is
+  # how the endpoint and the credential could disagree. Untouched when the
+  # name appears once, which is every ordinary conversation.
+  defp collapse(env, names) do
+    Enum.reduce(names, env, fn name, acc ->
+      case Enum.filter(acc, &match?({^name, _}, &1)) do
+        [_, _ | _] = duplicated ->
+          Enum.reject(acc, &match?({^name, _}, &1)) ++ [List.last(duplicated)]
+
+        _ ->
+          acc
+      end
+    end)
   end
 
   defp base_url(env) do

--- a/apps/fountain/test/fountain/conversations/codex_transport_test.exs
+++ b/apps/fountain/test/fountain/conversations/codex_transport_test.exs
@@ -55,12 +55,12 @@ defmodule Fountain.Conversations.CodexTransportTest do
 
   # `SpriteEnv.build/4` concatenates the runtime's defaults, the environment's
   # vars and the decrypted secrets without merging, so a vault entry for
-  # either variable appears twice. Resolve it the way that moduledoc says the
-  # list is meant to be read — last entry wins — so a value the tenant set
-  # later is the one acted on, including one deliberately emptied. What a
-  # duplicated `environ` means to the spawned process belongs to the sandbox
-  # adapter, not here.
-  test "a repeated variable resolves with SpriteEnv's last-entry precedence" do
+  # either variable appears twice. Nothing in this repository states which one
+  # the spawned process then reads — `SpriteEnv`'s moduledoc is about
+  # `merge_secrets/3`, which runs before the list exists — so the module does
+  # not depend on the answer: it resolves last entry wins and emits an env
+  # carrying only that entry.
+  test "a repeated variable resolves last-entry-wins and only that entry is emitted" do
     env = [
       key("sk-runtime-default"),
       {"OPENAI_BASE_URL", "https://api.openai.com/v1"},
@@ -274,11 +274,19 @@ defmodule Fountain.Conversations.CodexTransportTest do
   # stall comes back with nothing failing. Pinned the way
   # `conversation_server_broker_test.exs` pins the same fact for Claude.
   test "the runtime module exports the credential this module gates on" do
-    assert Managoat.Runtimes.Codex.default_env(nil, %{openai_api_key: "sk-__openai_api_key__"}) ==
-             [{"OPENAI_API_KEY", "sk-__openai_api_key__"}]
+    assert {"OPENAI_API_KEY", "sk-__openai_api_key__"} in Managoat.Runtimes.Codex.default_env(
+             nil,
+             %{openai_api_key: "sk-__openai_api_key__"}
+           )
 
+    # Membership, not equality: this pins the credential this module gates on,
+    # and an unrelated pair added upstream should not fail a test about it.
     for absent <- [%{}, %{openai_api_key: nil}, %{openai_api_key: ""}] do
-      assert Managoat.Runtimes.Codex.default_env(nil, absent) == []
+      refute List.keymember?(
+               Managoat.Runtimes.Codex.default_env(nil, absent),
+               "OPENAI_API_KEY",
+               0
+             )
     end
   end
 

--- a/apps/fountain/test/fountain/conversations/codex_transport_test.exs
+++ b/apps/fountain/test/fountain/conversations/codex_transport_test.exs
@@ -165,6 +165,32 @@ defmodule Fountain.Conversations.CodexTransportTest do
     assert updated["model_providers"]["custom"] == original["model_providers"]["custom"]
   end
 
+  # `List.keystore/4` rewrites the *first* entry, but a process with the
+  # variable twice sees the last. Rewriting the first would have left an
+  # untouched later entry winning, so the whole policy — proxy support and
+  # provider selection both — would silently not reach codex.
+  test "a repeated CODEX_CONFIG is read and rewritten as the process sees it" do
+    stale = Jason.encode!(%{"model" => "stale"})
+    live = Jason.encode!(%{"model" => "live"})
+
+    env = [
+      key("sk-x"),
+      {"CODEX_CONFIG", stale},
+      {"KEEP", "1"},
+      {"CODEX_CONFIG", live}
+    ]
+
+    assert {:ok, result} = CodexTransport.spawn_opts(%{broker: %{}}, "codex", env: env)
+
+    # Read from the effective entry, not the first.
+    assert config(result)["model"] == "live"
+
+    # And written as one entry, last, so nothing shadows it.
+    assert Enum.count(result[:env], &match?({"CODEX_CONFIG", _}, &1)) == 1
+    assert {"CODEX_CONFIG", _} = List.last(result[:env])
+    assert {"KEEP", "1"} in result[:env]
+  end
+
   test "unbrokered Codex and other runtimes retain their exact options" do
     opts = [env: [{"CODEX_CONFIG", "unchanged"}]]
     assert {:ok, ^opts} = CodexTransport.spawn_opts(%{broker: nil}, "codex", opts)

--- a/apps/fountain/test/fountain/conversations/codex_transport_test.exs
+++ b/apps/fountain/test/fountain/conversations/codex_transport_test.exs
@@ -26,24 +26,51 @@ defmodule Fountain.Conversations.CodexTransportTest do
   # own and select it.
   test "brokered Codex talks to OpenAI over a provider with no websocket transport" do
     assert {:ok, result} =
-             CodexTransport.spawn_opts(%{broker: %{}}, "codex", env: [])
+             CodexTransport.spawn_opts(%{broker: %{}}, "codex", env: [key("sk-x")])
 
     config = config(result)
 
     assert config["model_provider"] == "fountain_openai_http"
 
-    assert config["model_providers"]["fountain_openai_http"] == %{
-             "name" => "OpenAI",
-             "base_url" => "https://api.openai.com/v1",
-             "wire_api" => "responses",
-             "env_key" => "OPENAI_API_KEY",
-             "supports_websockets" => false
+    assert config["model_providers"] == %{
+             "fountain_openai_http" => %{
+               "name" => "OpenAI",
+               "base_url" => "https://api.openai.com/v1",
+               "wire_api" => "responses",
+               "env_key" => "OPENAI_API_KEY",
+               "supports_websockets" => false
+             }
            }
+  end
 
-    # Nothing else may name the built-in provider: codex rejects the whole
-    # configuration with "model_providers contains reserved built-in provider
-    # IDs" rather than ignoring the entry.
-    refute Map.has_key?(config["model_providers"], "openai")
+  # The built-in provider reads OPENAI_BASE_URL, so an environment pointing
+  # codex at a gateway through `env_vars` was already working. Hard-coding
+  # OpenAI's URL into the replacement would have redirected it silently.
+  test "the replacement provider keeps the endpoint OPENAI_BASE_URL names" do
+    env = [key("sk-x"), {"OPENAI_BASE_URL", "https://gw.example/v1"}]
+
+    assert {:ok, result} = CodexTransport.spawn_opts(%{broker: %{}}, "codex", env: env)
+
+    assert config(result)["model_providers"]["fountain_openai_http"]["base_url"] ==
+             "https://gw.example/v1"
+  end
+
+  # A custom provider does not read ~/.codex/auth.json, so a conversation
+  # with no OPENAI_API_KEY in its spawn env would have nothing to
+  # authenticate with. A shared sandbox may still hold the auth.json that
+  # `codex login --with-api-key` wrote for whoever provisioned it, and the
+  # built-in provider can use it. Paying the stall beats losing the turn.
+  test "a spawn with no OPENAI_API_KEY keeps the built-in provider" do
+    for env <- [[], [{"OPENAI_API_KEY", ""}]] do
+      assert {:ok, result} = CodexTransport.spawn_opts(%{broker: %{}}, "codex", env: env)
+
+      config = config(result)
+
+      refute Map.has_key?(config, "model_provider")
+      refute Map.has_key?(config, "model_providers")
+      # The proxy half does not depend on the credential.
+      assert config["features"]["respect_system_proxy"] == true
+    end
   end
 
   test "an agent already pointed at a gateway keeps the provider it names" do
@@ -54,7 +81,7 @@ defmodule Fountain.Conversations.CodexTransportTest do
 
     assert {:ok, result} =
              CodexTransport.spawn_opts(%{broker: %{}}, "codex",
-               env: [{"CODEX_CONFIG", Jason.encode!(original)}]
+               env: [key("sk-x"), {"CODEX_CONFIG", Jason.encode!(original)}]
              )
 
     config = config(result)
@@ -75,7 +102,7 @@ defmodule Fountain.Conversations.CodexTransportTest do
 
     assert {:ok, result} =
              CodexTransport.spawn_opts(%{broker: %{}}, "codex",
-               env: [{"CODEX_CONFIG", Jason.encode!(original)}]
+               env: [key("sk-x"), {"CODEX_CONFIG", Jason.encode!(original)}]
              )
 
     assert config(result)["model_providers"]["fountain_openai_http"] == mine
@@ -89,12 +116,17 @@ defmodule Fountain.Conversations.CodexTransportTest do
       "model_providers" => %{"custom" => %{"base_url" => "https://example.com"}}
     }
 
-    opts = [env: [{"CODEX_CONFIG", Jason.encode!(original)}]]
+    opts = [env: [key("sk-x"), {"CODEX_CONFIG", Jason.encode!(original)}]]
     assert {:ok, result} = CodexTransport.spawn_opts(%{broker: %{}}, "codex", opts)
     updated = config(result)
     assert updated["features"] == %{"multi_agent" => false, "respect_system_proxy" => true}
     refute Map.has_key?(updated, "features.respect_system_proxy")
     assert updated["model"] == original["model"]
+
+    # Exactly one entry added, every neighbour untouched.
+    assert Map.keys(updated["model_providers"]) |> Enum.sort() ==
+             ["custom", "fountain_openai_http"]
+
     assert updated["model_providers"]["custom"] == original["model_providers"]["custom"]
   end
 
@@ -120,6 +152,8 @@ defmodule Fountain.Conversations.CodexTransportTest do
                CodexTransport.spawn_opts(%{broker: %{}}, "codex", env: [{"CODEX_CONFIG", raw}])
     end
   end
+
+  defp key(value), do: {"OPENAI_API_KEY", value}
 
   defp config(opts) do
     {_, raw} = List.keyfind(opts[:env], "CODEX_CONFIG", 0)

--- a/apps/fountain/test/fountain/conversations/codex_transport_test.exs
+++ b/apps/fountain/test/fountain/conversations/codex_transport_test.exs
@@ -53,11 +53,14 @@ defmodule Fountain.Conversations.CodexTransportTest do
            }
   end
 
-  # `SpriteEnv.build/4` appends the decrypted secrets after the runtime's own
-  # defaults, so a vault entry for either variable appears twice and the last
-  # one is what the process gets. Reading the first would substitute on a key
-  # the conversation is not using, and would miss a deliberately emptied one.
-  test "the effective value of a repeated variable is the one that counts" do
+  # `SpriteEnv.build/4` concatenates the runtime's defaults, the environment's
+  # vars and the decrypted secrets without merging, so a vault entry for
+  # either variable appears twice. Resolve it the way that moduledoc says the
+  # list is meant to be read — last entry wins — so a value the tenant set
+  # later is the one acted on, including one deliberately emptied. What a
+  # duplicated `environ` means to the spawned process belongs to the sandbox
+  # adapter, not here.
+  test "a repeated variable resolves with SpriteEnv's last-entry precedence" do
     env = [
       key("sk-runtime-default"),
       {"OPENAI_BASE_URL", "https://api.openai.com/v1"},
@@ -127,6 +130,36 @@ defmodule Fountain.Conversations.CodexTransportTest do
     assert config["features"]["respect_system_proxy"] == true
   end
 
+  # `Map.put` for the selection and `Map.put_new` for the declaration
+  # disagreed on one shape: a config that declares this id without selecting
+  # it. The selection was written over a definition Fountain did not author,
+  # so the turn ran on an endpoint nothing picked — possibly with
+  # `supports_websockets` unset, which is the stall this module removes.
+  test "a declaration of our id that nothing selected does not become the endpoint" do
+    stray = %{
+      "base_url" => "https://someone-elses.example/v1",
+      "wire_api" => "responses"
+    }
+
+    for selected <- [nil, "openai"] do
+      original =
+        %{"model_providers" => %{"fountain_openai_http" => stray}}
+        |> then(&if(selected, do: Map.put(&1, "model_provider", selected), else: &1))
+
+      assert {:ok, result} =
+               CodexTransport.spawn_opts(%{broker: %{}}, "codex",
+                 env: [key("sk-x"), {"CODEX_CONFIG", Jason.encode!(original)}]
+               )
+
+      config = config(result)
+      provider = config["model_providers"]["fountain_openai_http"]
+
+      assert config["model_provider"] == "fountain_openai_http"
+      assert provider["base_url"] == "https://api.openai.com/v1"
+      assert provider["supports_websockets"] == false
+    end
+  end
+
   test "a provider declaration of our own id is left as the operator wrote it" do
     mine = %{"base_url" => "https://proxy.internal/v1", "supports_websockets" => false}
 
@@ -165,11 +198,12 @@ defmodule Fountain.Conversations.CodexTransportTest do
     assert updated["model_providers"]["custom"] == original["model_providers"]["custom"]
   end
 
-  # `List.keystore/4` rewrites the *first* entry, but a process with the
-  # variable twice sees the last. Rewriting the first would have left an
-  # untouched later entry winning, so the whole policy — proxy support and
-  # provider selection both — would silently not reach codex.
-  test "a repeated CODEX_CONFIG is read and rewritten as the process sees it" do
+  # `List.keystore/4` rewrites the *first* entry. Read under the same
+  # last-entry precedence, that would have left a later untouched entry
+  # carrying the config, so the whole policy — proxy support and provider
+  # selection both — would not have been the one applied. The write half is
+  # independent of the question: exactly one entry is emitted, last.
+  test "a repeated CODEX_CONFIG is read and rewritten under one precedence" do
     stale = Jason.encode!(%{"model" => "stale"})
     live = Jason.encode!(%{"model" => "live"})
 
@@ -211,6 +245,22 @@ defmodule Fountain.Conversations.CodexTransportTest do
         ] do
       assert {:error, :invalid_codex_config} =
                CodexTransport.spawn_opts(%{broker: %{}}, "codex", env: [{"CODEX_CONFIG", raw}])
+    end
+  end
+
+  # The gate below is only as good as this: `substitute?/2` is false without
+  # `OPENAI_API_KEY` in the spawn env, and for a conversation whose OpenAI key
+  # is an inference credential the only producer is the runtime module — a hex
+  # dependency. If a later `managoat_runtimes` stops exporting it, every
+  # brokered Codex turn quietly keeps the built-in provider and the 300-second
+  # stall comes back with nothing failing. Pinned the way
+  # `conversation_server_broker_test.exs` pins the same fact for Claude.
+  test "the runtime module exports the credential this module gates on" do
+    assert Managoat.Runtimes.Codex.default_env(nil, %{openai_api_key: "sk-__openai_api_key__"}) ==
+             [{"OPENAI_API_KEY", "sk-__openai_api_key__"}]
+
+    for absent <- [%{}, %{openai_api_key: nil}, %{openai_api_key: ""}] do
+      assert Managoat.Runtimes.Codex.default_env(nil, absent) == []
     end
   end
 

--- a/apps/fountain/test/fountain/conversations/codex_transport_test.exs
+++ b/apps/fountain/test/fountain/conversations/codex_transport_test.exs
@@ -79,6 +79,24 @@ defmodule Fountain.Conversations.CodexTransportTest do
 
     assert config(result)["model_providers"]["fountain_openai_http"]["base_url"] ==
              "https://gw.example/v1"
+
+    # And the duplicates are gone from what codex is handed, so it cannot
+    # resolve them the other way and reach a different endpoint or key.
+    for name <- ["OPENAI_API_KEY", "OPENAI_BASE_URL"] do
+      assert Enum.count(result[:env], &match?({^name, _}, &1)) == 1
+    end
+
+    assert {"OPENAI_BASE_URL", "https://gw.example/v1"} in result[:env]
+    assert {"OPENAI_API_KEY", "sk-vault"} in result[:env]
+  end
+
+  # A name that appears once is left where SpriteEnv put it.
+  test "an env with no duplicates is passed through untouched" do
+    env = [key("sk-x"), {"OPENAI_BASE_URL", "https://gw.example/v1"}, {"KEEP", "1"}]
+
+    assert {:ok, result} = CodexTransport.spawn_opts(%{broker: %{}}, "codex", env: env)
+
+    assert Enum.reject(result[:env], &match?({"CODEX_CONFIG", _}, &1)) == env
   end
 
   # The built-in provider reads OPENAI_BASE_URL, so an environment pointing

--- a/apps/fountain/test/fountain/conversations/codex_transport_test.exs
+++ b/apps/fountain/test/fountain/conversations/codex_transport_test.exs
@@ -18,6 +18,69 @@ defmodule Fountain.Conversations.CodexTransportTest do
     assert {:ok, ^result} = CodexTransport.spawn_opts(%{broker: %{}}, "codex", result)
   end
 
+  # #1674. `responses_websocket` cannot use an https-scheme proxy, but it
+  # spends the full connect timeout finding that out — 303, 292 and 306
+  # seconds on three consecutive Sprites turns whose work took about a
+  # second. `supports_websockets` lives on the provider and the built-in
+  # `openai` id is reserved, so declare the same endpoint under an id of our
+  # own and select it.
+  test "brokered Codex talks to OpenAI over a provider with no websocket transport" do
+    assert {:ok, result} =
+             CodexTransport.spawn_opts(%{broker: %{}}, "codex", env: [])
+
+    config = config(result)
+
+    assert config["model_provider"] == "fountain_openai_http"
+
+    assert config["model_providers"]["fountain_openai_http"] == %{
+             "name" => "OpenAI",
+             "base_url" => "https://api.openai.com/v1",
+             "wire_api" => "responses",
+             "env_key" => "OPENAI_API_KEY",
+             "supports_websockets" => false
+           }
+
+    # Nothing else may name the built-in provider: codex rejects the whole
+    # configuration with "model_providers contains reserved built-in provider
+    # IDs" rather than ignoring the entry.
+    refute Map.has_key?(config["model_providers"], "openai")
+  end
+
+  test "an agent already pointed at a gateway keeps the provider it names" do
+    original = %{
+      "model_provider" => "litellm",
+      "model_providers" => %{"litellm" => %{"base_url" => "https://gw.example/v1"}}
+    }
+
+    assert {:ok, result} =
+             CodexTransport.spawn_opts(%{broker: %{}}, "codex",
+               env: [{"CODEX_CONFIG", Jason.encode!(original)}]
+             )
+
+    config = config(result)
+
+    assert config["model_provider"] == "litellm"
+    assert config["model_providers"] == original["model_providers"]
+    # The proxy half still applies: that is about the transport, not the host.
+    assert config["features"]["respect_system_proxy"] == true
+  end
+
+  test "a provider declaration of our own id is left as the operator wrote it" do
+    mine = %{"base_url" => "https://proxy.internal/v1", "supports_websockets" => false}
+
+    original = %{
+      "model_provider" => "fountain_openai_http",
+      "model_providers" => %{"fountain_openai_http" => mine}
+    }
+
+    assert {:ok, result} =
+             CodexTransport.spawn_opts(%{broker: %{}}, "codex",
+               env: [{"CODEX_CONFIG", Jason.encode!(original)}]
+             )
+
+    assert config(result)["model_providers"]["fountain_openai_http"] == mine
+  end
+
   test "existing settings survive, including unrelated feature flags" do
     original = %{
       "model" => "gpt-5.3-codex",
@@ -32,7 +95,7 @@ defmodule Fountain.Conversations.CodexTransportTest do
     assert updated["features"] == %{"multi_agent" => false, "respect_system_proxy" => true}
     refute Map.has_key?(updated, "features.respect_system_proxy")
     assert updated["model"] == original["model"]
-    assert updated["model_providers"] == original["model_providers"]
+    assert updated["model_providers"]["custom"] == original["model_providers"]["custom"]
   end
 
   test "unbrokered Codex and other runtimes retain their exact options" do
@@ -46,7 +109,13 @@ defmodule Fountain.Conversations.CodexTransportTest do
   end
 
   test "invalid configuration fails without leaking its contents" do
-    for raw <- ["secret-invalid-json", "[]", "null", ~s({"features":false})] do
+    for raw <- [
+          "secret-invalid-json",
+          "[]",
+          "null",
+          ~s({"features":false}),
+          ~s({"model_providers":"openai"})
+        ] do
       assert {:error, :invalid_codex_config} =
                CodexTransport.spawn_opts(%{broker: %{}}, "codex", env: [{"CODEX_CONFIG", raw}])
     end

--- a/apps/fountain/test/fountain/conversations/codex_transport_test.exs
+++ b/apps/fountain/test/fountain/conversations/codex_transport_test.exs
@@ -32,15 +32,50 @@ defmodule Fountain.Conversations.CodexTransportTest do
 
     assert config["model_provider"] == "fountain_openai_http"
 
+    # Everything the built-in provider declares, minus the two fields that
+    # cannot carry across: `requires_openai_auth` (a custom provider cannot
+    # read auth.json, so `env_key` replaces it) and the compiled-in `version`
+    # header, which names the CLI build Fountain is not in a position to know.
+    # Audited against codex-rs/model-provider-info/src/lib.rs at rust-v0.153.3.
     assert config["model_providers"] == %{
              "fountain_openai_http" => %{
                "name" => "OpenAI",
                "base_url" => "https://api.openai.com/v1",
                "wire_api" => "responses",
                "env_key" => "OPENAI_API_KEY",
-               "supports_websockets" => false
+               "supports_websockets" => false,
+               "supports_standalone_web_search" => true,
+               "env_http_headers" => %{
+                 "OpenAI-Organization" => "OPENAI_ORGANIZATION",
+                 "OpenAI-Project" => "OPENAI_PROJECT"
+               }
              }
            }
+  end
+
+  # `SpriteEnv.build/4` appends the decrypted secrets after the runtime's own
+  # defaults, so a vault entry for either variable appears twice and the last
+  # one is what the process gets. Reading the first would substitute on a key
+  # the conversation is not using, and would miss a deliberately emptied one.
+  test "the effective value of a repeated variable is the one that counts" do
+    env = [
+      key("sk-runtime-default"),
+      {"OPENAI_BASE_URL", "https://api.openai.com/v1"},
+      key(""),
+      {"OPENAI_BASE_URL", "https://gw.example/v1"}
+    ]
+
+    assert {:ok, result} = CodexTransport.spawn_opts(%{broker: %{}}, "codex", env: env)
+
+    # Emptied by the later entry: no credential, so no substitution.
+    refute Map.has_key?(config(result), "model_provider")
+
+    env = List.keyreplace(env, "OPENAI_API_KEY", 0, key("sk-x")) ++ [key("sk-vault")]
+
+    assert {:ok, result} = CodexTransport.spawn_opts(%{broker: %{}}, "codex", env: env)
+
+    assert config(result)["model_providers"]["fountain_openai_http"]["base_url"] ==
+             "https://gw.example/v1"
   end
 
   # The built-in provider reads OPENAI_BASE_URL, so an environment pointing

--- a/docs/catalog/runtimes/codex.md
+++ b/docs/catalog/runtimes/codex.md
@@ -102,6 +102,12 @@ carries across `OPENAI_BASE_URL`, the OpenAI-Organization and OpenAI-Project
 header mappings, and standalone web search. A conversation with no
 `OPENAI_API_KEY` keeps the built-in provider, which reads `~/.codex/auth.json`.
 
+Fountain reads only the `CODEX_CONFIG` overlay when it does this. A
+`model_provider` that your setup script writes into `~/.codex/config.toml` is
+not read, and the overlay wins over the file. An agent that reached a gateway
+that way now reaches the endpoint above instead. To keep your own provider,
+name it in `CODEX_CONFIG`, which Fountain leaves alone.
+
 The sandbox images do not pin the Codex CLI. The field that turns the
 transport off is `supports_websockets`, which Codex 0.153.3 accepts. A later
 Codex that ignores the field brings the 300-second wait back, and nothing in

--- a/docs/catalog/runtimes/codex.md
+++ b/docs/catalog/runtimes/codex.md
@@ -93,6 +93,22 @@ The CLI takes the bare model id, so Fountain removes the `openai/` prefix
 before it calls the CLI. You never see that in normal use. It matters when you
 read a spawn command in the logs.
 
+On a deployment with the egress broker on, Fountain moves the conversation
+onto a model provider of its own. The provider is the same endpoint with the
+WebSocket transport off. Codex's WebSocket dialer cannot use the broker's
+https-scheme proxy. It waits out the full connect timeout before it falls back
+to HTTP, which was about 300 seconds on every turn. Fountain
+carries across `OPENAI_BASE_URL`, the OpenAI-Organization and OpenAI-Project
+header mappings, and standalone web search. A conversation with no
+`OPENAI_API_KEY` keeps the built-in provider, which reads `~/.codex/auth.json`.
+
+The sandbox images do not pin the Codex CLI. The field that turns the
+transport off is `supports_websockets`, which Codex 0.153.3 accepts. A later
+Codex that ignores the field brings the 300-second wait back, and nothing in
+Fountain reports it. The symptom is the gap between the `model` stream stage
+and the first agent output. See
+[openai/codex#13103](https://github.com/openai/codex/issues/13103).
+
 ## Related
 
 - [About agents](../../concepts/agent.md)


### PR DESCRIPTION
The first problem in #1674: every brokered codex turn paid a ~300 second
websocket timeout before doing about a second of work.

Codex dials `wss://api.openai.com/v1/responses` first. That dialer cannot use
an https-scheme proxy, which the broker is, but it waits out the full connect
timeout before saying so:

```
13:19:06 INFO  connecting to websocket: wss://api.openai.com/v1/responses
   … 303 seconds …
13:24:14 ERROR failed to connect: URL error: Proxy URL scheme not supported
13:24:21 WARN  falling back to HTTP
```

Measured on the conversation stream, `stage/model/done` to first agent
output: 303s, 292s, 306s on three consecutive turns.

`supports_websockets` is a `[model_providers.<id>]` field, and the built-in
`openai` id cannot be overridden — `model_providers contains reserved
built-in provider IDs` is a hard configuration error, from `config.toml` and
from `CODEX_CONFIG` alike (openai/codex#13103). An id of our own is not
reserved, so `CodexTransport` declares the same endpoint with the transport
off and selects it:

```json
"model_provider": "fountain_openai_http",
"model_providers": {
  "fountain_openai_http": {
    "name": "OpenAI",
    "base_url": "https://api.openai.com/v1",
    "wire_api": "responses",
    "env_key": "OPENAI_API_KEY",
    "supports_websockets": false
  }
}
```

`env_key` rather than the built-in's `~/.codex/auth.json`, which a custom
provider does not read. `OPENAI_API_KEY` is in the sandbox env either way
(`Managoat.Runtimes.Codex.default_env/2`), and on a brokered conversation it
is the placeholder `Broker.split_inference/2` swapped in, which the broker
substitutes for the real key on the way out — so nothing about which key pays
changes, for a tenant key or a platform one.

This is scoped exactly as the existing `respect_system_proxy` policy is:
brokered conversations, codex only, process-local (persistent sandboxes are
shared). An agent already pointed at a gateway keeps the provider it names —
that provider decides its own transport, and its base URL is not ours to
replace — and an operator who declares `fountain_openai_http` themselves
keeps their declaration.

## Testing

- `mix test` (core suite), `mix credo --strict`, `mix format --check-formatted`.
- Removing the provider switch fails the new test, so it guards.

Not verified against a live Sprite: that needs a brokered codex conversation,
and the measurement to repeat afterwards is the `stage/model/done` to first
output gap on the conversation stream.

Refs #1674. The broker CA race and the `env_vars` ordering are a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XT411VudYs1hw69mDDhvrm
