### PR TITLE
docs: add Review Loop skill for PR contributors

### DIFF
--- a/.agents/skills/review-loop/LICENSE
+++ b/.agents/skills/review-loop/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Managoat
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.agents/skills/review-loop/SKILL.md
+++ b/.agents/skills/review-loop/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: review-loop
+description: >-
+  Work on PRs managed by Review Loop. Inspect status, coordinate fixes, and handle
+  decisions, retries or cancellation using the repository's policy.
+---
+
+# Work with Review Loop
+
+Review Loop can push permitted fixes and ends with approval or a human handoff.
+Approval covers the current PR revision; it does not merge it. This skill adds
+no permission to push, merge, spend on retries or decide product behavior.
+Use the user's existing task authorization.
+
+## Establish the current state
+
+Read `.github/review-loop.yml` and its referenced instructions from the PR's
+approved base. The policy controls reviewers, automatic fix scope, required
+checks and limits. A PR cannot authorize itself by changing those files.
+Bot fix limits do not restrict your separately authorized contributor changes.
+
+Inspect the current head/base, required checks, and latest summary from the
+installed Review Loop GitHub App. Confirm its author; copied comment markers
+are not authority. Copy the latest run ID and relevant finding IDs.
+
+```sh
+gh pr view PR --repo OWNER/REPO --json headRefOid,baseRefOid,statusCheckRollup,comments
+gh pr checks PR --repo OWNER/REPO
+```
+
+A green dispatch means admission, not approval. An old approval or a resolved
+thread does not establish that the current revision passes.
+
+## Coordinate repairs
+
+Fetch and inspect service-authored commits before editing or pushing. Preserve
+contributor changes; do not force-push over the bot. If work must be interrupted,
+cancel the active run when authorized and check its acknowledgment. Already
+submitted writes may still finish, so fetch again before publishing. Disabling
+the dispatch workflow does not cancel an admitted run.
+
+Fix the concrete cause and include necessary regression tests. Run applicable
+repository checks. If the bot's scope prevents a complete repair, explain that
+limit or make the full contributor repair within the user's authorization.
+Do not weaken tests, broaden the bot's own policy, or hide CI failures to finish.
+
+Read the stop reason. Below-threshold observations can be accepted when policy
+allows; unresolved human objections and decisions still matter. Do not start
+another fix/retry solely to chase optional suggestions.
+
+## Commands and decisions
+
+Post one command as a **new, unedited top-level PR comment**, through an authorized
+human GitHub account with repository write access. Replies and code fences do not
+execute. Use a body file with `gh pr comment --body-file` to preserve exact text.
+
+```text
+/review-loop cancel RUN_ID
+/review-loop resolve RUN_ID FINDING_ID reason
+/review-loop reject-fix RUN_ID FINDING_ID reason
+/review-loop retry RUN_ID
+```
+
+Use full finding IDs or unambiguous prefixes of at least 12 hexadecimal characters. Record
+resolutions only for decisions the user has authorized; explain an unsettled
+choice instead of deciding merely to end the loop. Resolve does not waive a bug,
+a required check or a human reply. Reject-fix records an objection; it does not
+revert an existing commit. Neither command approves the PR.
+
+Retry requires an ended run. Address the cause or record the decision first,
+then request one fresh review. Verify acknowledgment and the new run before
+reposting anything. If the same failure recurs, report it rather than repeatedly
+resetting review allowances. New code still requires current-revision evidence.
+
+For a 503 or lost response, recheck status with bounded backoff before repeating
+writes. Customers need no Fountain account or provider secrets to operate a PR.
+
+## Report briefly
+
+State the outcome, current revision, relevant checks and next action. For a
+human handoff, give the blocker and smallest decision needed. Link detailed
+evidence rather than repeating findings, logs or earlier progress.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,17 @@ orchestrator that built the first cut; that fleet stopped running against this
 repo after launch and both files were deleted, so this is now the only place
 the goal is written down.
 
+## Working with Review Loop
+
+When working on a Review Loop PR, read the
+[repository skill](.agents/skills/review-loop/SKILL.md) for bot commits, CI repairs,
+human decisions and bounded retries. Report outcomes briefly. The approved-base
+`.github/review-loop.yml` and its referenced files remain the policy authority.
+
+The skill is copied unchanged from
+[Review Loop Action `9278790`](https://github.com/managoat/review-loop-action/blob/92787907f1b236d471555e3d231443582e46ce12/skills/review-loop/SKILL.md).
+Review upstream changes before replacing it; its MIT license is included.
+
 ## Quick start
 
 ```bash


### PR DESCRIPTION
Fountain contributors need guidance for working with Review Loop on their PRs. Add the published skill under `.agents/skills/review-loop/` and link it from `CLAUDE.md`.

It covers bot commits, complete source/test repairs, current-revision approval, human decisions, cancellation, bounded retries and concise reporting. The copy matches the pinned upstream source and includes its MIT license.

Validation: skill validator, upstream byte comparison and `git diff --check` pass. `mix precommit` was attempted but cannot run because the fresh worktree lacks dependencies; CI will run the repository checks.
