### PR TITLE
fix(review-loop): cover all core precommit stages

### DIFF
--- a/.github/review-loop.yml
+++ b/.github/review-loop.yml
@@ -85,9 +85,12 @@ verification:
         - .github/workflows/sdk-release-gate.yml
     - path: .github/workflows/secrets-scan.yml
   commands:
-    - rl-env mix deps.get
+    # Match precommit's lockfile guard; && preserves each stage's failure.
+    - rl-env sh -c 'mix deps.get && mix deps.unlock --unused && git diff --exit-code -- mix.lock'
     - rl-env mix format --check-formatted
-    - rl-env mix compile --warnings-as-errors
+    # Assemble prod as precommit does. Plain deps.get preserves test/dev deps.
+    - rl-env sh -c 'mix compile --warnings-as-errors && MIX_ENV=prod mix deps.get && MIX_ENV=prod mix
+      release fountain_server --overwrite'
     - rl-env sh -c 'mix ecto.create --quiet && mix ecto.migrate --quiet'
     - rl-env env MIX_TEST_PARTITION=1 bash scripts/test-partition.sh 6
     - rl-env env MIX_TEST_PARTITION=2 bash scripts/test-partition.sh 6
@@ -96,7 +99,7 @@ verification:
     - rl-env env MIX_TEST_PARTITION=5 bash scripts/test-partition.sh 6
     - rl-env env MIX_TEST_PARTITION=6 bash scripts/test-partition.sh 6
     - rl-env bash scripts/test-libraries.sh
-    - rl-env mix credo --strict
+    - rl-env sh -c 'mix credo --strict && MIX_ENV=dev mix dialyzer'
     - rl-env elixir scripts/hex-audit-gate.exs
     - rl-env bash scripts/sobelow.sh
     - rl-env bash scripts/sdk-contract/build.sh --check

--- a/.github/review-loop.yml
+++ b/.github/review-loop.yml
@@ -84,6 +84,8 @@ verification:
         - .github/workflows/sdk-publish.yml
         - .github/workflows/sdk-release-gate.yml
     - path: .github/workflows/secrets-scan.yml
+  # Cold Credo/Dialyzer took ~23 minutes on the measured fresh worker.
+  command_timeout_minutes: 30
   commands:
     # Clean-checkout lockfile guard; && preserves each stage's failure.
     - rl-env sh -c 'mix deps.get && mix deps.unlock --unused && git diff --exit-code -- mix.lock'

--- a/.github/review-loop.yml
+++ b/.github/review-loop.yml
@@ -85,7 +85,7 @@ verification:
         - .github/workflows/sdk-release-gate.yml
     - path: .github/workflows/secrets-scan.yml
   commands:
-    # Match precommit's lockfile guard; && preserves each stage's failure.
+    # Clean-checkout lockfile guard; && preserves each stage's failure.
     - rl-env sh -c 'mix deps.get && mix deps.unlock --unused && git diff --exit-code -- mix.lock'
     - rl-env mix format --check-formatted
     # Assemble prod as precommit does. Plain deps.get preserves test/dev deps.
@@ -98,7 +98,8 @@ verification:
     - rl-env env MIX_TEST_PARTITION=4 bash scripts/test-partition.sh 6
     - rl-env env MIX_TEST_PARTITION=5 bash scripts/test-partition.sh 6
     - rl-env env MIX_TEST_PARTITION=6 bash scripts/test-partition.sh 6
-    - rl-env bash scripts/test-libraries.sh
+    # Root tests share one VM and catch cross-app config leaks missed by partitions.
+    - rl-env sh -c 'bash scripts/test-libraries.sh && mix test'
     - rl-env sh -c 'mix credo --strict && MIX_ENV=dev mix dialyzer'
     - rl-env elixir scripts/hex-audit-gate.exs
     - rl-env bash scripts/sobelow.sh

--- a/.github/review/README.md
+++ b/.github/review/README.md
@@ -55,6 +55,11 @@ An existing Go guest-handshake fixture race is tracked in
 enabled. A failure produces incomplete verification and a human handoff;
 rerunning until it turns green is not evidence that the defect was fixed.
 
+Deploy Review Loop support for `verification.command_timeout_minutes` first.
+The expanded recipe needs a thirty-minute command allowance: its measured cold
+Credo/Dialyzer stage took about 23 minutes and the full recipe about 48 minutes.
+See [measured command budget](verification.md#measured-command-budget).
+
 Merge this configuration through Fountain's normal reviewed PR process. Its
 own changes require human review; no live run can use its policy before merge.
 The dispatch workflow uses the public `managoat/review-loop-action` at an

--- a/.github/review/README.md
+++ b/.github/review/README.md
@@ -41,11 +41,12 @@ are dollar-cost reporting.
 `setup.sh` installs pinned, hash-checked toolchains on a fresh Ubuntu 24.04 or
 26.04 worker before PR checkout, plus a disposable local PostgreSQL database
 (the supported distro major, 16 or 18). GitHub CI separately verifies PostgreSQL 16.
-Twenty commands run the core/ee partitions, extension tests, static checks,
+Twenty commands run the core/ee partitions, extension and single-VM umbrella
+tests, precommit static checks, Dialyzer, prod release assembly,
 contracts, SDKs, CLIs and plugin tests. The eight required workflow definitions
 and their path filters were checked against Fountain main at
 `539a300207728bebc5216af586e497ce07778f94`. GitHub CI additionally supplies
-coverage, release/boot, Dialyzer, Swift, docs and distribution gates. No failed
+coverage, release boot, Swift, docs and distribution gates. No failed
 gate is skipped or changed to get an approval.
 
 An existing Go guest-handshake fixture race is tracked in

--- a/.github/review/verification.md
+++ b/.github/review/verification.md
@@ -10,10 +10,11 @@ GitHub write token or provider credential belongs in this machine.
 
 Independent verification runs all six core and ee test partitions sequentially
 using the upstream runner's nonzero-test and coverage-export guards, then runs
-every sibling app's suite. It covers the core `mix precommit` stages: compilation,
+every sibling app's suite and root umbrella tests in one VM. The root run catches
+cross-app configuration leaks that separate CI partitions cannot. It covers the core `mix precommit` stages: compilation,
 unused-dependency/lockfile checks, formatting, Credo, Dialyzer in dev, security
-scanning, release assembly in prod, and tests. Related commands use `&&` so a
-failed stage stops execution. Plain `mix deps.get` preserves dev/test dependencies
+scanning, release assembly in prod, and tests. Commands fail fast, including grouped stages that keep the policy within
+20 entries; any failed stage makes verification incomplete. Plain `mix deps.get` preserves dev/test dependencies
 when preparing prod. It also checks the wire contract, conformance fixtures, the TypeScript,
 Python and Elixir SDKs, both Go modules and the Hermes plugin. Each command must
 exit successfully; a failed stage is not excused by a later successful one.

--- a/.github/review/verification.md
+++ b/.github/review/verification.md
@@ -10,13 +10,16 @@ GitHub write token or provider credential belongs in this machine.
 
 Independent verification runs all six core and ee test partitions sequentially
 using the upstream runner's nonzero-test and coverage-export guards, then runs
-every sibling app's suite. It also checks formatting, compilation, Credo,
-security scanning, the wire contract, conformance fixtures, the TypeScript,
+every sibling app's suite. It covers the core `mix precommit` stages: compilation,
+unused-dependency/lockfile checks, formatting, Credo, Dialyzer in dev, security
+scanning, release assembly in prod, and tests. Related commands use `&&` so a
+failed stage stops execution. Plain `mix deps.get` preserves dev/test dependencies
+when preparing prod. It also checks the wire contract, conformance fixtures, the TypeScript,
 Python and Elixir SDKs, both Go modules and the Hermes plugin. Each command must
 exit successfully; a failed stage is not excused by a later successful one.
 
 The complete GitHub CI workflow additionally supplies the six-way partitioned
-coverage gate, release boot, Dialyzer, generated-type freshness, Swift on Linux
+coverage gate, release boot, generated-type freshness, Swift on Linux
 and macOS, docs prose, core distribution and Compose checks. The secret scan
 always applies. Other required workflows follow the actual SDK, ADR and sandbox
 image path filters in the base policy. Only success for the recorded PR, head

--- a/.github/review/verification.md
+++ b/.github/review/verification.md
@@ -31,3 +31,21 @@ test run or exhausted deadline leaves incomplete work. Do not skip tests, lower
 coverage thresholds, rewrite verification scripts or add release-bypass labels
 to obtain approval. Docs-only PRs still receive independent core verification
 in this initial recipe; their conditional GitHub CI path is preserved.
+
+## Measured command budget
+
+At `d7b668a27dbeaeb3e32434b7800075ab6a849f2c`, all twenty commands passed on a
+fresh isolated worker in about 48 minutes, with two BEAM schedulers. The
+library/umbrella command took 8m49s and cold Credo/Dialyzer took 22m50s. The
+worker was deleted afterward. An earlier ten-minute attempt timed out during
+library/umbrella tests; that failure and its deletion remain recorded.
+
+The policy therefore gives each command up to thirty minutes, within the
+existing 120-minute run deadline. Pre-push and post-push independent verification
+can together consume roughly 96 minutes before review and GitHub CI; extra fix
+rounds are permitted only while the remaining budget allows. Do not skip gates
+or raise a deadline merely to report success.
+
+Deploy a Review Loop version supporting `verification.command_timeout_minutes`
+before merging this policy. The measured standalone recipe is not evidence of
+a production candidate check or PR approval at this configuration.


### PR DESCRIPTION
Complete the independent precommit recipe: unused-dependency/lockfile checks, production release assembly, development Dialyzer, and root umbrella tests alongside the six CI partitions. A repair can now be checked with the core contributor gates before publication.

All twenty commands passed at `d7b668a27dbeaeb3e32434b7800075ab6a849f2c` on a fresh isolated worker in about 48 minutes; deletion was confirmed. Cold Credo/Dialyzer took 22m50s, so the updated policy sets `command_timeout_minutes: 30` within the existing 120-minute run deadline. An earlier ten-minute attempt timed out in the library/umbrella command and remains recorded. The twenty command strings are unchanged by the timeout follow-up.

**Deployment prerequisite:** deploy a Review Loop version supporting this timeout field before merging the configuration. The PR is draft until then. Two independent check passes can consume roughly 96 minutes; remaining review/CI and further repairs still obey the run deadline. Standalone recipe success is not production PR acceptance.

Local `mix precommit` was attempted but this worktree lacks its Hex dependencies. The unchanged core stages passed on the isolated worker; current-head GitHub CI remains a separate gate.
