### PR TITLE
fix(conversations): stop the list read-model scanning every log event; per-key rate limit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -339,7 +339,10 @@ There is no router-level billing gate. The gate that protects spend is
 
 ## Rate limiter
 
-`FountainWeb.Plugs.RateLimit` — ETS-backed, keyed by IP in prod. In tests:
+`FountainWeb.Plugs.RateLimit` — ETS-backed, per node. The `:api` pipeline
+runs it twice: keyed by IP before auth (600/min) and keyed by API key after
+it (`key: :api_key`, 600/min), because every app deployed beside the server
+arrives through one ingress address. In tests:
 
 ```elixir
 # config/test.exs

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -381,31 +381,19 @@ defmodule Fountain.Conversations do
   that reconnects don't artificially bump a conversation to the top.
   """
   def list_conversations_by_activity(user_id) when is_binary(user_id) do
-    turn_counts =
-      from t in Turn,
-        group_by: t.conversation_id,
-        select: %{conversation_id: t.conversation_id, count: count(t.id)}
-
-    last_turn_at =
-      from t in Turn,
-        group_by: t.conversation_id,
-        select: %{conversation_id: t.conversation_id, last_at: max(t.inserted_at)}
-
-    last_log_at =
-      from le in LogEvent,
-        where: le.kind == "output",
-        group_by: le.conversation_id,
-        select: %{conversation_id: le.conversation_id, last_at: max(le.inserted_at)}
-
+    # Lateral per conversation for the same reason as `annotated_query/1`:
+    # the grouped shape read every turn and every output log event in the
+    # deployment to rank one tenant's list.
     Repo.all(
       from c in Conversation,
+        as: :conv,
         where: c.user_id == ^user_id and c.status != "terminated",
-        left_join: tc in subquery(turn_counts),
-        on: tc.conversation_id == c.id,
-        left_join: lt in subquery(last_turn_at),
-        on: lt.conversation_id == c.id,
-        left_join: ll in subquery(last_log_at),
-        on: ll.conversation_id == c.id,
+        left_lateral_join: tc in subquery(turn_count_of_conv()),
+        on: true,
+        left_lateral_join: lt in subquery(last_turn_at_of_conv()),
+        on: true,
+        left_lateral_join: ll in subquery(last_output_at_of_conv()),
+        on: true,
         order_by: [
           desc:
             fragment(
@@ -783,31 +771,30 @@ defmodule Fountain.Conversations do
   end
 
   # The conversation list read-model: turn counts and last activity, both as
-  # LEFT JOINed subqueries so the result stays a plain list of structs and no
-  # caller N+1s.
+  # LEFT JOIN LATERAL subqueries so the result stays a plain list of structs
+  # and no caller N+1s.
+  #
+  # Lateral, per conversation, rather than one GROUP BY over the whole table
+  # joined back (2026-09-07). The grouped shape aggregated every output log
+  # event in the deployment on every call — a full scan of log_events, the
+  # largest table, for a list of one tenant's conversations — and a client
+  # polling this list 14 times a second turned that into 6.4M sequential
+  # scans and a pool exhausted for everyone. Per conversation, the newest
+  # output event is one backward probe of the partial index
+  # `log_events_output_conversation_id_inserted_at_index`, and the cost
+  # scales with the tenant's conversation count instead of the table.
   #
   # Only `kind: "output"` log events count toward `last_active_at` — stage
   # events (reconnects, sandbox lifecycle) would otherwise produce false
   # unread indicators.
   defp annotated_query(user_id) do
-    turn_counts =
-      from t in Turn,
-        group_by: t.conversation_id,
-        select: %{conversation_id: t.conversation_id, count: count(t.id)}
-
-    last_log_at =
-      from le in LogEvent,
-        where: le.kind == "output",
-        group_by: le.conversation_id,
-        select: %{conversation_id: le.conversation_id, last_at: max(le.inserted_at)}
-
     from c in Conversation,
       as: :conv,
       where: c.user_id == ^user_id,
-      left_join: tc in subquery(turn_counts),
-      on: tc.conversation_id == c.id,
-      left_join: ll in subquery(last_log_at),
-      on: ll.conversation_id == c.id,
+      left_lateral_join: tc in subquery(turn_count_of_conv()),
+      on: true,
+      left_lateral_join: ll in subquery(last_output_at_of_conv()),
+      on: true,
       select: %{
         c
         | turn_count: fragment("COALESCE(?, 0)", tc.count),
@@ -818,6 +805,27 @@ defmodule Fountain.Conversations do
               c.inserted_at
             )
       }
+  end
+
+  # The lateral halves of the read-model. Each answers for the conversation
+  # bound as `:conv` in the outer query, so they compose only under a `from`
+  # that names that binding.
+  defp turn_count_of_conv do
+    from t in Turn,
+      where: t.conversation_id == parent_as(:conv).id,
+      select: %{count: count(t.id)}
+  end
+
+  defp last_turn_at_of_conv do
+    from t in Turn,
+      where: t.conversation_id == parent_as(:conv).id,
+      select: %{last_at: max(t.inserted_at)}
+  end
+
+  defp last_output_at_of_conv do
+    from le in LogEvent,
+      where: le.conversation_id == parent_as(:conv).id and le.kind == "output",
+      select: %{last_at: max(le.inserted_at)}
   end
 
   @doc """

--- a/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
@@ -57,11 +57,21 @@ defmodule FountainWeb.ConversationController do
         required: false,
         description:
           "Comma-separated statuses to keep (`idle,terminated`); 400 on a value outside the vocabulary."
+      ],
+      limit: [
+        in: :query,
+        schema: %OpenApiSpex.Schema{type: :integer, minimum: 1, maximum: 500},
+        required: false,
+        description:
+          "Return at most this many conversations, most recently updated first (1 to 500; " <>
+            "400 outside that range). Without it the whole list is returned, which on a " <>
+            "busy account is hundreds of rows per call — a client that needs one " <>
+            "conversation should filter (`agent_id`, `sandbox_id`, `channel_id`) and cap."
       ]
     ],
     responses: [
       ok: {"Conversations", "application/json", Schemas.ConversationListResponse},
-      bad_request: {"Unknown status", "application/json", Schemas.Error},
+      bad_request: {"Unknown status or limit out of range", "application/json", Schemas.Error},
       unprocessable_entity: {"Invalid filter", "application/json", Schemas.ChangesetError}
     ]
   )
@@ -70,7 +80,8 @@ defmodule FountainWeb.ConversationController do
     user = conn.assigns.current_user
     roots_only = parse_bool_param(params["roots_only"], false)
 
-    with {:ok, statuses} <- parse_statuses(params["status"]) do
+    with {:ok, statuses} <- parse_statuses(params["status"]),
+         {:ok, limit} <- parse_list_limit(params["limit"]) do
       render(conn, :index,
         conversations:
           Conversations.list_conversations(user.id,
@@ -78,9 +89,25 @@ defmodule FountainWeb.ConversationController do
             agent_id: params["agent_id"],
             channel_id: params["channel_id"],
             sandbox_id: params["sandbox_id"],
-            status: statuses
+            status: statuses,
+            limit: limit
           )
       )
+    end
+  end
+
+  @max_list_limit 500
+
+  # Absent means the whole list, as it always has; a value outside 1..500 is
+  # a 400 rather than a silent clamp, for the same reason as a bad status —
+  # a client that asked for 0 or 10,000 should find out.
+  defp parse_list_limit(nil), do: {:ok, nil}
+  defp parse_list_limit(""), do: {:ok, nil}
+
+  defp parse_list_limit(raw) do
+    case Integer.parse(to_string(raw)) do
+      {n, ""} when n in 1..@max_list_limit -> {:ok, n}
+      _ -> {:error, "invalid_limit"}
     end
   end
 

--- a/apps/fountain/lib/fountain_web/plugs/rate_limit.ex
+++ b/apps/fountain/lib/fountain_web/plugs/rate_limit.ex
@@ -1,12 +1,21 @@
 defmodule FountainWeb.Plugs.RateLimit do
   @moduledoc """
   Lightweight ETS-based fixed-window rate limiter. Fountain is multi-tenant;
-  per-IP limiting is a coarse abuse control, not a per-tenant quota — the
-  goal is to stop a buggy or hostile client from spamming sprite spawns or
-  saturating the BEAM, not to meter individual tenants.
+  this is a coarse abuse control, not a per-tenant quota — the goal is to
+  stop a buggy or hostile client from spamming sprite spawns or saturating
+  the BEAM, not to meter individual tenants.
 
-  Buckets are per-IP. The ETS table is created in `Fountain.Application`
-  startup. Returns 429 + `Retry-After` (seconds) when the bucket is full.
+  Buckets are per-IP by default, or per API key with `key: :api_key` on a
+  plug that runs after `TenantAPIAuth`. The per-key shape exists because an
+  address is not a client: every app deployed beside the server reaches it
+  through the same ingress, so one address is several clients sharing a
+  bucket (and hiding behind each other), while one client's runaway loop
+  (2026-09-04: 14 list calls a second, for four days) is invisible to a
+  limit that only counts addresses.
+
+  The ETS table is created in `Fountain.Application` startup. Returns 429 +
+  `Retry-After` (seconds) when the bucket is full. The table is per node,
+  so a limit is per replica.
 
   ## Options
 
@@ -14,6 +23,10 @@ defmodule FountainWeb.Plugs.RateLimit do
       counter (e.g. an "api" bucket and a "conversations" bucket).
     * `:max` — maximum requests per window.
     * `:window_ms` — window length in ms (default 60_000).
+    * `:key` — `:ip` (default) or `:api_key`. With `:api_key`, the bucket is
+      the id of `conn.assigns.current_api_key`; a request that reaches the
+      plug without one (the plug runs before auth) falls back to the
+      address, so a misordered pipeline still limits something.
 
   ## Example
 
@@ -67,16 +80,23 @@ defmodule FountainWeb.Plugs.RateLimit do
   end
 
   def init(opts) do
+    key = Keyword.get(opts, :key, :ip)
+
+    if key not in [:ip, :api_key] do
+      raise ArgumentError, "RateLimit key must be :ip or :api_key, got: #{inspect(key)}"
+    end
+
     %{
       bucket: Keyword.fetch!(opts, :bucket),
       max: Keyword.fetch!(opts, :max),
-      window_ms: Keyword.get(opts, :window_ms, 60_000)
+      window_ms: Keyword.get(opts, :window_ms, 60_000),
+      key: key
     }
   end
 
   def call(conn, opts) do
     ensure_table()
-    key = key_for(conn, opts.bucket)
+    key = key_for(conn, opts)
 
     case bump(key, opts) do
       :ok ->
@@ -119,15 +139,38 @@ defmodule FountainWeb.Plugs.RateLimit do
     end
   end
 
-  defp key_for(conn, bucket) do
-    # In test isolation mode, key by the calling process PID rather than IP.
-    # This prevents async ExUnit tests from sharing rate limit counters while
-    # still allowing dedicated rate-limit tests to accumulate counts naturally
-    # (all requests in a test run in the same process).
+  # Exposed for tests: the bucket key a request lands in.
+  @doc false
+  def key_for(conn, %{bucket: bucket, key: :api_key}) do
+    case conn.assigns[:current_api_key] do
+      %{id: id} when is_binary(id) -> isolate_key({bucket, id})
+      _ -> isolate({bucket, format_ip(conn.remote_ip)})
+    end
+  end
+
+  def key_for(conn, %{bucket: bucket}) do
+    isolate({bucket, format_ip(conn.remote_ip)})
+  end
+
+  # In test isolation mode, key by the calling process PID as well. This
+  # prevents async ExUnit tests from sharing rate limit counters while still
+  # allowing dedicated rate-limit tests to accumulate counts naturally (all
+  # requests in a test run in the same process). The PID replaces the
+  # address — every test's conn has the same loopback address — and joins
+  # the key id, so a per-key test still sees two keys as two buckets.
+  defp isolate({bucket, _ip} = key) do
     if Application.get_env(:fountain, :rate_limit_test_isolation, false) do
       {bucket, self()}
     else
-      {bucket, format_ip(conn.remote_ip)}
+      key
+    end
+  end
+
+  defp isolate_key({bucket, id}) do
+    if Application.get_env(:fountain, :rate_limit_test_isolation, false) do
+      {bucket, id, self()}
+    else
+      {bucket, id}
     end
   end
 

--- a/apps/fountain/lib/fountain_web/plugs/tenant_api_auth.ex
+++ b/apps/fountain/lib/fountain_web/plugs/tenant_api_auth.ex
@@ -22,6 +22,8 @@ defmodule FountainWeb.Plugs.TenantAPIAuth do
   import Plug.Conn
   import Phoenix.Controller, only: [json: 2]
 
+  require Logger
+
   alias Fountain.Accounts
 
   def init(opts), do: opts
@@ -37,6 +39,13 @@ defmodule FountainWeb.Plugs.TenantAPIAuth do
       Task.Supervisor.start_child(Fountain.TaskSupervisor, fn ->
         Accounts.touch_api_key(raw_key)
       end)
+
+      # The key's display prefix on every log line of the request. Never the
+      # key: the prefix is what the console shows next to the key's name, so
+      # a request log can be traced to a key without holding one. Four days
+      # of a client polling the API fourteen times a second could be traced
+      # only as far as an ingress address without this (2026-09-04).
+      Logger.metadata(api_key: api_key.key_prefix)
 
       conn
       |> assign(:current_user, user)

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -29,6 +29,14 @@ defmodule FountainWeb.Router do
     # POST /api/auth/token all have one.
     plug FountainWeb.Plugs.RateLimit, bucket: "api", max: 600
     plug FountainWeb.Plugs.TenantAPIAuth
+    # And AFTER it, per key (2026-09-07): the address bucket above cannot see
+    # one client's runaway loop when every app beside the server arrives
+    # through the same ingress address, and cannot stop it without stopping
+    # them all. 600 a minute per key per replica is ten a second — a
+    # transcript viewer polling `/events` once a second and holding a stream
+    # is well inside it; a client listing the account fourteen times a
+    # second (the 09-04 incident) is not.
+    plug FountainWeb.Plugs.RateLimit, bucket: "api-key", max: 600, key: :api_key
     plug FountainWeb.Plugs.Audit
   end
 

--- a/apps/fountain/priv/repo/migrations/20260907060000_index_log_events_output_by_conversation.exs
+++ b/apps/fountain/priv/repo/migrations/20260907060000_index_log_events_output_by_conversation.exs
@@ -1,0 +1,27 @@
+defmodule Fountain.Repo.Migrations.IndexLogEventsOutputByConversation do
+  use Ecto.Migration
+
+  # Built concurrently: migrations run at boot while the previous replica is
+  # still appending to log_events, and a plain CREATE INDEX would hold every
+  # one of those writes for the duration.
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  @moduledoc """
+  The conversation list's `last_active_at` is the newest `output` log event
+  per conversation. It used to be computed as one aggregate over every
+  output row in the table, joined back to the tenant's conversations, so
+  every `GET /api/conversations` read all of log_events (6.4M sequential
+  scans and 470 billion tuples read, on a 315 MB table, when this was
+  found). The query now asks per conversation, and this partial index turns
+  that question into one backward probe.
+  """
+
+  def change do
+    create index(:log_events, [:conversation_id, :inserted_at],
+             where: "kind = 'output'",
+             name: :log_events_output_conversation_id_inserted_at_index,
+             concurrently: true
+           )
+  end
+end

--- a/apps/fountain/priv/repo/migrations/20260907060000_index_log_events_output_by_conversation.exs
+++ b/apps/fountain/priv/repo/migrations/20260907060000_index_log_events_output_by_conversation.exs
@@ -5,7 +5,8 @@ defmodule Fountain.Repo.Migrations.IndexLogEventsOutputByConversation do
   # still appending to log_events, and a plain CREATE INDEX would hold every
   # one of those writes for the duration.
   @disable_ddl_transaction true
-  @disable_migration_lock true
+  # Keep the configured Postgres advisory migration lock so simultaneous
+  # boots serialize this index build (#1770). It works without a DDL transaction.
 
   @moduledoc """
   The conversation list's `last_active_at` is the newest `output` log event

--- a/apps/fountain/test/fountain_web/controllers/conversation_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/conversation_controller_test.exs
@@ -1340,4 +1340,48 @@ defmodule FountainWeb.ConversationControllerTest do
       assert json_response(conn, 201)
     end
   end
+
+  describe "GET /api/conversations?limit=" do
+    test "caps the page at the most recently updated conversations", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
+      older = insert_conversation(user_id: user.id)
+      newer = insert_conversation(user_id: user.id)
+
+      # updated_at is the sort key; make the order unambiguous.
+      later =
+        DateTime.utc_now()
+        |> DateTime.add(60, :second)
+        |> DateTime.truncate(:second)
+
+      newer |> Ecto.Changeset.change(updated_at: later) |> Fountain.Repo.update!()
+
+      conn = conn |> authed_with_key(raw_key) |> get("/api/conversations?limit=1")
+
+      body = json_response(conn, 200)
+      assert [%{"id" => id}] = body["data"]
+      assert id == newer.id
+      refute id == older.id
+    end
+
+    test "without a limit the whole list comes back, as before", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
+      for _ <- 1..3, do: insert_conversation(user_id: user.id)
+
+      conn = conn |> authed_with_key(raw_key) |> get("/api/conversations")
+      assert length(json_response(conn, 200)["data"]) == 3
+    end
+
+    test "a limit outside 1..500 is refused, not clamped", %{conn: conn, raw_key: raw_key} do
+      for bad <- ["0", "501", "ten"] do
+        conn = conn |> authed_with_key(raw_key) |> get("/api/conversations?limit=#{bad}")
+        assert conn.status in [400, 422], "limit=#{bad} answered #{conn.status}"
+      end
+    end
+  end
 end

--- a/apps/fountain/test/fountain_web/plugs/rate_limit_test.exs
+++ b/apps/fountain/test/fountain_web/plugs/rate_limit_test.exs
@@ -171,4 +171,48 @@ defmodule FountainWeb.Plugs.RateLimitTest do
       assert String.to_integer(retry_after) >= 1
     end
   end
+
+  describe "key: :api_key" do
+    defp with_key(conn, id), do: Plug.Conn.assign(conn, :current_api_key, %{id: id})
+
+    test "init/1 accepts :ip and :api_key and refuses anything else" do
+      assert RateLimit.init(bucket: "b", max: 1).key == :ip
+      assert RateLimit.init(bucket: "b", max: 1, key: :api_key).key == :api_key
+
+      assert_raise ArgumentError, fn ->
+        RateLimit.init(bucket: "b", max: 1, key: :user)
+      end
+    end
+
+    test "two keys are two buckets; the same key is one", %{conn: conn} do
+      opts = RateLimit.init(bucket: unique_bucket(), max: 1, key: :api_key)
+
+      assert RateLimit.key_for(with_key(conn, "k1"), opts) ==
+               RateLimit.key_for(with_key(conn, "k1"), opts)
+
+      refute RateLimit.key_for(with_key(conn, "k1"), opts) ==
+               RateLimit.key_for(with_key(conn, "k2"), opts)
+    end
+
+    test "a request with no key assigned falls back to the address bucket", %{conn: conn} do
+      by_key = RateLimit.init(bucket: unique_bucket(), max: 1, key: :api_key)
+      by_ip = %{by_key | key: :ip}
+
+      assert RateLimit.key_for(conn, by_key) == RateLimit.key_for(conn, by_ip)
+    end
+
+    test "exhausting one key's bucket leaves another key's requests alone", %{conn: conn} do
+      opts = RateLimit.init(bucket: unique_bucket(), max: 2, key: :api_key)
+      noisy = with_key(conn, Ecto.UUID.generate())
+      quiet = with_key(conn, Ecto.UUID.generate())
+
+      refute RateLimit.call(noisy, opts).halted
+      refute RateLimit.call(noisy, opts).halted
+      limited = RateLimit.call(noisy, opts)
+      assert limited.halted
+      assert limited.status == 429
+
+      refute RateLimit.call(quiet, opts).halted
+    end
+  end
 end

--- a/config/config.exs
+++ b/config/config.exs
@@ -170,7 +170,7 @@ config :fountain, FountainWeb.Endpoint,
 
 config :logger, :default_formatter,
   format: "$time $metadata[$level] $message\n",
-  metadata: [:request_id, :remote_ip]
+  metadata: [:request_id, :remote_ip, :api_key]
 
 config :phoenix, :json_library, Jason
 

--- a/docs/concepts/conversation.md
+++ b/docs/concepts/conversation.md
@@ -122,7 +122,9 @@ Use a schedule when the run must happen without you. Read the
 
 Use `GET /api/conversations?sandbox_id=<uuid>` to list conversations on a
 machine you own. Combine it with `agent_id`, `channel_id`, `status` or
-`roots_only`. The TypeScript SDK accepts
+`roots_only`, and add `limit` (1 to 500) to cap the page. A client that polls
+the list must filter and cap it. The whole account is the default, and on a
+busy account that is hundreds of rows per call. The TypeScript SDK accepts
 `fountain.conversations({sandboxId: id, rootsOnly: false})`.
 
 `GET /api/events/stream` includes new events from conversations that finish

--- a/sdk/contract/contract.json
+++ b/sdk/contract/contract.json
@@ -1865,6 +1865,10 @@
           "required": false,
           "type": "string"
         },
+        "limit": {
+          "required": false,
+          "type": "integer"
+        },
         "roots_only": {
           "required": false,
           "type": "boolean"

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -10052,6 +10052,8 @@ export interface operations {
                 channel_id?: string;
                 /** @description Comma-separated statuses to keep (`idle,terminated`); 400 on a value outside the vocabulary. */
                 status?: string;
+                /** @description Return at most this many conversations, most recently updated first (1 to 500; 400 outside that range). Without it the whole list is returned, which on a busy account is hundreds of rows per call — a client that needs one conversation should filter (`agent_id`, `sandbox_id`, `channel_id`) and cap. */
+                limit?: number;
             };
             header?: never;
             path?: never;
@@ -10068,7 +10070,7 @@ export interface operations {
                     "application/json": components["schemas"]["ConversationListResponse"];
                 };
             };
-            /** @description Unknown status */
+            /** @description Unknown status or limit out of range */
             400: {
                 headers: {
                     [name: string]: unknown;


### PR DESCRIPTION
## What this fixes

Four days of `PodOOMKilled`, `FountainUnhandledExceptions` and `FountainObanJobsDiscarded` on the hosted deployment (2026-09-04 to 09-07), which six estate-medic PRs in home-cloud attributed to the `BROKER_TENANTS=*` flip. The flip was not the cause. Prometheus puts the working-set jump (375 → 918 MiB) at 08:00Z on 09-04, the hour three demo apps started calling `GET /api/conversations` ~50,000 times an hour (14/s) plus ~13,000 sandbox file reads and ~7,000 SSE opens an hour; the broker flip at 11:33Z moved memory 954 → 958 MiB with under 200 broker requests an hour. On 09-06 00:00–11:00Z the polling paused and memory sat at ~450 MiB with the broker still `*`.

The exceptions were DB pool exhaustion (`DBConnection.ConnectionError: connection not available and request was dropped from queue`, stacks in `ConversationController.index/2` and `authenticate_api_key/1`), and the query behind them is what this PR changes.

## The query

`annotated_query/1` (the conversation list read-model) LEFT JOINed a subquery that aggregated **every `kind = "output"` row in log_events**, unscoped by tenant, with no index on `kind`, then joined it back to one tenant's conversations. `pg_stat_user_tables` on prod: 6.4M sequential scans and 470 billion tuples read on log_events (288k rows, 315 MB). `EXPLAIN ANALYZE` of the list for the busiest account: ~46 ms plus two parallel workers, 137 MB of buffers, on every call, 14 times a second. `list_conversations_by_activity/1` had the same shape three times over.

Both now use `LEFT JOIN LATERAL` subqueries bound to the outer conversation (`parent_as(:conv)`), and a new partial index `log_events (conversation_id, inserted_at) WHERE kind = 'output'` turns "newest output event of this conversation" into one backward index probe. Cost scales with the tenant's conversation count, not the table. Verified on a synthetic 286k-row dataset of the same shape: `Index Only Scan Backward ... rows=1 loops=1040`. The lateral shape **without** the index is far worse than the old one (the planner walks the global `inserted_at` index backwards per conversation, 48 s on prod data), so the migration and the query change must ship together; they do here. The index is built `concurrently` because migrations run at boot while the previous replica is still appending.

## The other three changes

- **Per-key rate limit.** The `:api` pipeline keeps the pre-auth 600/min per-IP bucket (#316) and adds a 600/min per-API-key bucket after `TenantAPIAuth`. Every app deployed beside the server arrives through Traefik's address, so the IP bucket both throttles them collectively and cannot see one of them looping. `RateLimit` gains `key: :ip | :api_key`; a request that reaches an `:api_key` plug unauthenticated falls back to the address bucket.
- **`api_key=<prefix>` on every request log line.** `TenantAPIAuth` sets `Logger.metadata(api_key: key_prefix)`; the formatter prints it. The incident could be attributed only as far as two ingress addresses without this. The prefix is what the console shows next to a key's name, never the key.
- **`?limit=` on `GET /api/conversations`** (1–500, opt-in, no default). The context already supported `:limit`; the endpoint did not expose it. A default would silently truncate clients that expect the whole list (CLI, conversations app), so that needs pagination first and is deliberately not in this PR. `sdk/contract/contract.json` and the generated TypeScript types are regenerated; no SDK method changes (and no SDK version bump).

## What is not here

- The clients. paddock lists the whole account on every proxied request, switchyard looks the machine up per operation, and paddock re-reads a receipt file that 409s on a suspended box 13,000 times an hour. Those fixes are going to managoat/demos separately.
- A default page size / pagination for the list endpoint (see above).
- `POOL_SIZE` is still 10 per replica. With the query fixed it should not need to move; revisit if `fountain_repo_query_queue_time` p99 climbs again.

## Verification

- `mix precommit` in a worktree against a dedicated test DB (compile with warnings-as-errors, format, credo, sobelow, dialyzer, release assemble, full suite).
- `scripts/sdk-contract/build.sh --check` ok; `npm run generate` in `sdk/typescript`.
- vale / docs-style / destink clean on the edited docs page.
- New tests: per-key buckets (two keys are two buckets, same key is one, unassigned key falls back to IP, one key's exhaustion leaves another alone), `limit` caps at the most recently updated, absent limit returns everything, out-of-range refused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018R1XyyWd9MDMYXqFL71owk
