### PR TITLE
feat: set the platform inference keys from /admin/inference

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -366,6 +366,10 @@ STRIPE_WEBHOOK_SECRET=
 # Blank means off, per provider. Set none of these and the instance behaves
 # exactly as it did before: bring-your-own only. Anthropic is the one that
 # matters first — the default agent runs on the claude runtime.
+#
+# An admin can also set each key at /admin/inference, stored encrypted under
+# MASTER_SECRETS_KEY and used without a restart. A key set there wins over the
+# variable; clearing it falls back to the variable.
 # PLATFORM_ANTHROPIC_API_KEY=
 # PLATFORM_OPENAI_API_KEY=
 # PLATFORM_GEMINI_API_KEY=

--- a/apps/fountain/lib/fountain/audit/admin_event.ex
+++ b/apps/fountain/lib/fountain/audit/admin_event.ex
@@ -49,6 +49,8 @@ defmodule Fountain.Audit.AdminEvent do
     admin.user.viewed
     admin.conversation.viewed
     admin.credits.granted
+    admin.platform_inference_key.set
+    admin.platform_inference_key.cleared
   )
 
   def event_types, do: @event_types

--- a/apps/fountain/lib/fountain/crypto.ex
+++ b/apps/fountain/lib/fountain/crypto.ex
@@ -31,6 +31,7 @@ defmodule Fountain.Crypto do
 
   @aad "fountain.secret"
   @key_wrap_aad "fountain.key_wrap"
+  @platform_aad "fountain.platform_secret"
 
   @doc """
   Encrypt `plaintext` using AES-256-GCM with the given 32-byte `key`.
@@ -108,6 +109,30 @@ defmodule Fountain.Crypto do
           :error -> {:error, :unwrap_failed}
         end
     end
+  end
+
+  @doc """
+  Encrypt a value the *deployment* owns, not a tenant — a platform inference
+  key set from the admin panel (`Fountain.PlatformInference`).
+
+  Under the master key directly, with its own AAD, so a platform blob can
+  never be decrypted as a wrapped DEK or a tenant secret and vice versa.
+  There is deliberately no platform DEK: the master key is already the one
+  secret a self-hoster has to keep, and a second key to rotate would buy
+  nothing for a handful of rows.
+  """
+  @spec encrypt_platform(binary()) :: binary()
+  def encrypt_platform(plaintext) when is_binary(plaintext) do
+    encrypt(plaintext, master_key(), @platform_aad)
+  end
+
+  @doc """
+  Decrypt a blob produced by `encrypt_platform/1`. `:error` on a master key
+  that has changed since it was written, or corrupted data.
+  """
+  @spec decrypt_platform(binary()) :: {:ok, binary()} | :error
+  def decrypt_platform(blob) when is_binary(blob) do
+    decrypt(blob, master_key(), @platform_aad)
   end
 
   # Private

--- a/apps/fountain/lib/fountain/platform_inference.ex
+++ b/apps/fountain/lib/fountain/platform_inference.ex
@@ -10,9 +10,19 @@ defmodule Fountain.PlatformInference do
 
   ## What is here
 
-    * `enabled?/0` and `key_for/1` — the keys, from
+    * `enabled?/0` and `key_for/1` — the keys. A key set from
+      `/admin/inference` (`put_key/3`, one `platform_inference_keys` row per
+      provider, encrypted under the master key) wins; otherwise
       `PLATFORM_ANTHROPIC_API_KEY`, `PLATFORM_OPENAI_API_KEY` and
       `PLATFORM_GEMINI_API_KEY`. Blank is off, per provider.
+    * `put_key/3` and `clear_key/2` — the admin mutations, each leaving an
+      `admin.platform_inference_key.*` row on the privilege trail. Clearing
+      falls back to the variable rather than switching the provider off: the
+      variable is the seed a deployment was configured with, and the row is
+      the operator's later decision.
+    * `status/0` — one entry per provider for the admin page: where the live
+      key comes from, when and by whom it was set, and its last four
+      characters.
     * `gate/2` — the door check: may this user's next conversation on this
       model start? `:ok` unless it would run on a platform key and the
       deployment has spent its day.
@@ -46,15 +56,39 @@ defmodule Fountain.PlatformInference do
 
   require Logger
 
+  alias Fountain.Audit
+  alias Fountain.Crypto
+  alias Fountain.PlatformInference.Key
+  alias Fountain.Repo
+
   @providers %{
     "anthropic" => {:anthropic_api_key, :platform_anthropic_api_key},
     "openai" => {:openai_api_key, :platform_openai_api_key},
     "google" => {:gemini_api_key, :platform_gemini_api_key}
   }
 
+  @env_vars %{
+    "anthropic" => "PLATFORM_ANTHROPIC_API_KEY",
+    "openai" => "PLATFORM_OPENAI_API_KEY",
+    "google" => "PLATFORM_GEMINI_API_KEY"
+  }
+
+  # Long enough for any provider key seen so far, short enough that a pasted
+  # certificate or a whole .env file is refused rather than stored.
+  @max_key_bytes 1_024
+
+  @doc "The providers a platform key can be held for, in `Managoat.Runtimes.Model` order."
+  @spec providers() :: [String.t()]
+  def providers,
+    do: Enum.filter(Managoat.Runtimes.Model.providers(), &Map.has_key?(@providers, &1))
+
+  @doc "The environment variable that seeds a provider's key."
+  @spec env_var(String.t()) :: String.t() | nil
+  def env_var(provider), do: Map.get(@env_vars, provider)
+
   @doc "Whether this deployment holds a platform key for any provider at all."
   @spec enabled?() :: boolean()
-  def enabled?, do: Enum.any?(@providers, fn {provider, _} -> key_for(provider) != :none end)
+  def enabled?, do: configured_providers() != []
 
   @doc """
   The providers this deployment holds a key for, in `Managoat.Runtimes.Model`
@@ -62,7 +96,21 @@ defmodule Fountain.PlatformInference do
   """
   @spec configured_providers() :: [String.t()]
   def configured_providers do
-    Enum.filter(Managoat.Runtimes.Model.providers(), &(key_for(&1) != :none))
+    rows = stored_rows()
+
+    Enum.filter(providers(), fn provider ->
+      {_credential, config_key} = Map.fetch!(@providers, provider)
+      resolve(provider, config_key, Map.get(rows, provider)) != :none
+    end)
+  end
+
+  # Every stored row in one read, keyed by provider, for the callers that
+  # ask about all providers at once.
+  defp stored_rows(preload \\ []) do
+    Key
+    |> Repo.all()
+    |> Repo.preload(preload)
+    |> Map.new(&{&1.provider, &1})
   end
 
   @doc """
@@ -70,9 +118,15 @@ defmodule Fountain.PlatformInference do
   atom `Fountain.InferenceCredentials` uses for it, so the value drops into
   the same map a tenant's own key lives in — or `:none`.
 
-  A blank value is `:none`, not an empty key: an unset variable and a variable
-  set to `""` are the same statement, and the second is what a Helm chart
-  with no value produces.
+  A row set from the admin page wins over the variable. A blank variable is
+  `:none`, not an empty key: an unset variable and a variable set to `""` are
+  the same statement, and the second is what a Helm chart with no value
+  produces.
+
+  One primary-key read per call. A stored row the master key no longer
+  decrypts is treated as absent (and logged), so a rotated
+  `MASTER_SECRETS_KEY` degrades to the variable rather than to a key that
+  fails every request.
   """
   @spec key_for(String.t() | nil) :: {:ok, atom(), String.t()} | :none
   def key_for(provider) when is_binary(provider) do
@@ -81,14 +135,176 @@ defmodule Fountain.PlatformInference do
         :none
 
       {credential, config_key} ->
-        case Application.get_env(:fountain, config_key) do
-          key when is_binary(key) and key != "" -> {:ok, credential, key}
-          _ -> :none
+        case resolve(provider, config_key, Repo.get(Key, provider)) do
+          {:ok, key, _source} -> {:ok, credential, key}
+          :none -> :none
         end
     end
   end
 
   def key_for(_provider), do: :none
+
+  # Stored first, then the variable. `:undecryptable` falls through to the
+  # variable on purpose — see key_for/1.
+  defp resolve(provider, config_key, row) do
+    case stored(provider, row) do
+      {:ok, key} ->
+        {:ok, key, :stored}
+
+      _ ->
+        case Application.get_env(:fountain, config_key) do
+          key when is_binary(key) and key != "" -> {:ok, key, :environment}
+          _ -> :none
+        end
+    end
+  end
+
+  defp stored(_provider, nil), do: :none
+
+  defp stored(provider, %Key{ciphertext: ciphertext}) do
+    case Crypto.decrypt_platform(ciphertext) do
+      {:ok, key} when key != "" ->
+        {:ok, key}
+
+      _ ->
+        Logger.warning(
+          "platform inference: the stored #{provider} key does not decrypt under " <>
+            "MASTER_SECRETS_KEY; falling back to #{env_var(provider)}. Set it again at /admin/inference."
+        )
+
+        :undecryptable
+    end
+  end
+
+  @doc """
+  Set a provider's platform key from the admin panel. The value is trimmed,
+  refused when empty (clear it with `clear_key/2` instead), when it has
+  whitespace inside it, or when it is longer than a key could be.
+
+  `opts` carries `:actor_user_id`, the operator, for the row and for the
+  `admin.platform_inference_key.set` event. The trail records the provider
+  and what the row replaced (`"stored"`, `"environment"` or `"none"`), never
+  any part of the value.
+  """
+  @spec put_key(String.t(), String.t(), keyword()) :: {:ok, Key.t()} | {:error, :invalid_key}
+  def put_key(provider, value, opts \\ []) when is_binary(provider) and is_binary(value) do
+    value = String.trim(value)
+
+    with :ok <- validate_key(value),
+         {_, config_key} <- Map.get(@providers, provider, :none) do
+      row = Repo.get(Key, provider)
+      previous = source_name(resolve(provider, config_key, row))
+      actor_user_id = Keyword.get(opts, :actor_user_id)
+
+      attrs = %{
+        provider: provider,
+        ciphertext: Crypto.encrypt_platform(value),
+        updated_by_user_id: actor_user_id
+      }
+
+      result =
+        (row || %Key{})
+        |> Key.changeset(attrs, providers())
+        |> Repo.insert_or_update()
+
+      case result do
+        {:ok, _} = ok ->
+          Audit.record_admin(%{
+            actor_user_id: actor_user_id,
+            event_type: "admin.platform_inference_key.set",
+            metadata: %{"provider" => provider, "replaced" => previous}
+          })
+
+          ok
+
+        {:error, _changeset} ->
+          {:error, :invalid_key}
+      end
+    else
+      _ -> {:error, :invalid_key}
+    end
+  end
+
+  @doc """
+  Remove a provider's stored key. The provider falls back to its variable,
+  or to off when that is blank too. `:ok` either way; the
+  `admin.platform_inference_key.cleared` event is recorded only when a row
+  was actually there, since a trail that logs attempts as changes is worse
+  than no trail (ADR 0013).
+  """
+  @spec clear_key(String.t(), keyword()) :: :ok
+  def clear_key(provider, opts \\ []) when is_binary(provider) do
+    case Repo.get(Key, provider) do
+      nil ->
+        :ok
+
+      %Key{} = key ->
+        Repo.delete!(key)
+
+        Audit.record_admin(%{
+          actor_user_id: Keyword.get(opts, :actor_user_id),
+          event_type: "admin.platform_inference_key.cleared",
+          metadata: %{"provider" => provider}
+        })
+
+        :ok
+    end
+  end
+
+  @doc """
+  One entry per provider for `/admin/inference`: `:source` is `:stored`,
+  `:environment`, `:undecryptable` or `:none`; `:hint` is the live key's last
+  four characters (enough to tell two keys apart, not enough to use one);
+  `:updated_at` and `:updated_by` describe the stored row when there is one;
+  `:env_var` names the variable that seeds it.
+  """
+  @spec status() :: [map()]
+  def status do
+    rows = stored_rows([:updated_by])
+
+    for provider <- providers() do
+      {_credential, config_key} = Map.fetch!(@providers, provider)
+      row = Map.get(rows, provider)
+
+      {source, hint} =
+        case stored(provider, row) do
+          {:ok, key} ->
+            {:stored, hint(key)}
+
+          :undecryptable ->
+            {:undecryptable, nil}
+
+          :none ->
+            case resolve(provider, config_key, nil) do
+              {:ok, key, :environment} -> {:environment, hint(key)}
+              :none -> {:none, nil}
+            end
+        end
+
+      %{
+        provider: provider,
+        env_var: env_var(provider),
+        source: source,
+        hint: hint,
+        updated_at: row && row.updated_at,
+        updated_by: row && row.updated_by && row.updated_by.email
+      }
+    end
+  end
+
+  defp hint(key) when byte_size(key) > 4, do: String.slice(key, -4, 4)
+  defp hint(_key), do: nil
+
+  defp source_name({:ok, _key, source}), do: Atom.to_string(source)
+  defp source_name(:none), do: "none"
+
+  defp validate_key(""), do: {:error, :invalid_key}
+
+  defp validate_key(value) when byte_size(value) > @max_key_bytes, do: {:error, :invalid_key}
+
+  defp validate_key(value) do
+    if Regex.match?(~r/[[:space:][:cntrl:]]/u, value), do: {:error, :invalid_key}, else: :ok
+  end
 
   @doc """
   The daily ceiling in cents (`PLATFORM_INFERENCE_DAILY_CENTS`, default 5000).
@@ -105,8 +321,8 @@ defmodule Fountain.PlatformInference do
   The door check, at every place a conversation begins: `:ok`, or
   `{:error, :platform_inference_unavailable}`.
 
-  Three questions, cheapest first, so a deployment with no platform key runs
-  no query at all:
+  Three questions, cheapest first, so a deployment with no platform key
+  costs one primary-key read and nothing else:
 
     1. does this deployment hold a key for the model's provider?
     2. would this user actually take it — that is, do they have none of their

--- a/apps/fountain/lib/fountain/platform_inference/key.ex
+++ b/apps/fountain/lib/fountain/platform_inference/key.ex
@@ -1,0 +1,35 @@
+defmodule Fountain.PlatformInference.Key do
+  @moduledoc """
+  A platform inference key an operator set from `/admin/inference`: one row
+  per provider, the value encrypted under the master key
+  (`Fountain.Crypto.encrypt_platform/1`).
+
+  `Fountain.PlatformInference.key_for/1` reads this before the
+  `PLATFORM_<PROVIDER>_API_KEY` variable, so a row here is the live key and
+  the variable is the seed. There is no plaintext column and no `_unsafe_`
+  reader: the deployment owns these, not a tenant, and the only writer is
+  the admin surface.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:provider, :string, autogenerate: false}
+  @foreign_key_type :binary_id
+
+  @type t :: %__MODULE__{}
+  schema "platform_inference_keys" do
+    field :ciphertext, :binary
+
+    belongs_to :updated_by, Fountain.Accounts.User, foreign_key: :updated_by_user_id
+
+    timestamps(type: :utc_datetime)
+  end
+
+  def changeset(key, attrs, providers) do
+    key
+    |> cast(attrs, [:provider, :ciphertext, :updated_by_user_id])
+    |> validate_required([:provider, :ciphertext])
+    |> validate_inclusion(:provider, providers)
+  end
+end

--- a/apps/fountain/lib/fountain_web/live/admin_live/activity.ex
+++ b/apps/fountain/lib/fountain_web/live/admin_live/activity.ex
@@ -93,7 +93,9 @@ defmodule FountainWeb.AdminLive.Activity do
                 >
                   {e.metadata["email"]}
                 </.link>
-                <span :if={is_nil(e.target_user_id)}>{e.metadata["email"]}</span>
+                <span :if={is_nil(e.target_user_id)}>
+                  {e.metadata["email"] || e.metadata["provider"]}
+                </span>
               </td>
               <td class="px-4 py-2 text-xs text-zinc-500">
                 <span :if={e.metadata["from"] != nil}>

--- a/apps/fountain/lib/fountain_web/live/admin_live/inference.ex
+++ b/apps/fountain/lib/fountain_web/live/admin_live/inference.ex
@@ -1,0 +1,210 @@
+defmodule FountainWeb.AdminLive.Inference do
+  @moduledoc """
+  `/admin/inference` — the deployment's own inference keys (ADR 0038
+  decision 3), one row per provider.
+
+  Until this page the keys were `PLATFORM_<PROVIDER>_API_KEY` and nothing
+  else, so rotating one meant a secret-store edit and a rollout. A key set
+  here is stored encrypted under the master key and wins over the variable
+  from the next conversation on, with no restart; clearing it hands the
+  provider back to the variable. The page shows where each provider's live
+  key comes from and its last four characters, which is what an operator
+  needs to answer "is the new key in yet?" — and nothing more of the value.
+
+  Every mutation goes through `Fountain.PlatformInference`, which records
+  the `admin.platform_inference_key.*` event; the page only says who asked.
+  """
+
+  use FountainWeb, :live_view
+
+  import FountainWeb.AdminLive.Helpers
+  import FountainWeb.AdminLive.Shell
+
+  alias Fountain.PlatformInference
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok,
+     socket
+     |> assign(:page_title, "Admin · Inference")
+     |> assign(:credits_enabled, Fountain.Credits.enabled?())
+     |> assign_keys()}
+  end
+
+  @impl true
+  def handle_event("set_key", %{"provider" => provider, "value" => value}, socket) do
+    case PlatformInference.put_key(provider, value, actor_user_id: socket.assigns.current_user.id) do
+      {:ok, _} ->
+        {:noreply,
+         socket
+         |> assign_keys()
+         |> put_flash(
+           :info,
+           "#{provider_label(provider)} key saved — in use from the next conversation"
+         )}
+
+      {:error, :invalid_key} ->
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           "That does not look like a key: paste one value with no spaces, or use Clear to remove it"
+         )}
+    end
+  end
+
+  def handle_event("clear_key", %{"provider" => provider}, socket) do
+    :ok = PlatformInference.clear_key(provider, actor_user_id: socket.assigns.current_user.id)
+
+    {:noreply,
+     socket
+     |> assign_keys()
+     |> put_flash(:info, "#{provider_label(provider)} key cleared")}
+  end
+
+  defp assign_keys(socket) do
+    socket
+    |> assign(:keys, PlatformInference.status())
+    |> assign(:ceiling_cents, PlatformInference.daily_ceiling_cents())
+    |> assign(:spent_today_cents, Fountain.Billing.platform_inference_spend_today())
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="space-y-6">
+      <.admin_header title="Inference" current={:inference} credits_enabled={@credits_enabled}>
+        <:subtitle>
+          The keys Fountain runs a tenant on when they have none of their own. A key set here
+          wins over its environment variable and needs no restart.
+        </:subtitle>
+      </.admin_header>
+
+      <div class="bg-white rounded shadow border border-zinc-200 px-4 py-3 text-sm space-y-1">
+        <div class="font-medium">Daily ceiling</div>
+        <div class="text-zinc-700">
+          <span class="font-semibold tabular-nums">
+            {Fountain.Credits.format_cents(@ceiling_cents)}
+          </span>
+          across every tenant per UTC day (<code class="text-xs">PLATFORM_INFERENCE_DAILY_CENTS</code>).
+          <span :if={@spent_today_cents != nil}>
+            Spent today:
+            <span class="font-semibold tabular-nums">
+              {Fountain.Credits.format_cents(@spent_today_cents)}
+            </span>
+          </span>
+          <span :if={@spent_today_cents == nil} class="text-zinc-500">
+            Credits are off, so nothing is counted against it.
+          </span>
+        </div>
+      </div>
+
+      <section class="space-y-3">
+        <div :for={key <- @keys} class="bg-white rounded shadow border border-zinc-200 px-4 py-3">
+          <div class="flex flex-wrap items-start justify-between gap-3">
+            <div class="space-y-1">
+              <div class="font-medium">{provider_label(key.provider)}</div>
+              <div class="text-sm text-zinc-700">
+                <.source key={key} />
+              </div>
+            </div>
+            <span class={[
+              "text-xs px-2 py-0.5 rounded border",
+              source_badge_class(key.source)
+            ]}>
+              {source_label(key.source)}
+            </span>
+          </div>
+
+          <div class="mt-3 flex flex-wrap items-end gap-2">
+            <form phx-submit="set_key" class="flex flex-wrap items-end gap-2">
+              <input type="hidden" name="provider" value={key.provider} />
+              <label class="block text-xs text-zinc-500">
+                New key
+                <input
+                  type="password"
+                  name="value"
+                  autocomplete="off"
+                  spellcheck="false"
+                  placeholder={placeholder(key.provider)}
+                  class="block mt-1 w-80 max-w-full rounded border-zinc-300 text-sm font-mono"
+                />
+              </label>
+              <button
+                type="submit"
+                class="px-3 py-1.5 text-sm rounded bg-zinc-900 text-white hover:bg-zinc-700"
+              >
+                Save
+              </button>
+            </form>
+            <button
+              :if={key.source in [:stored, :undecryptable]}
+              type="button"
+              phx-click="clear_key"
+              phx-value-provider={key.provider}
+              data-confirm={"Clear the stored #{provider_label(key.provider)} key? The provider falls back to #{key.env_var}, or to off if that is blank."}
+              class="px-3 py-1.5 text-sm rounded border border-zinc-300 hover:border-red-400 hover:text-red-700"
+            >
+              Clear
+            </button>
+          </div>
+        </div>
+      </section>
+
+      <p class="text-xs text-zinc-500">
+        A tenant's own credential always wins over these. Tokens on a platform key burn the
+        tenant's credit at the provider's list price; the finance page shows the total.
+      </p>
+    </div>
+    """
+  end
+
+  attr :key, :map, required: true
+
+  defp source(%{key: %{source: :stored}} = assigns) do
+    ~H"""
+    Set here{if @key.updated_at, do: " on #{format_ts(@key.updated_at)}"}{if @key.updated_by,
+      do: " by #{@key.updated_by}"}. Ends in <code class="font-mono">…{@key.hint}</code>.
+    """
+  end
+
+  defp source(%{key: %{source: :environment}} = assigns) do
+    ~H"""
+    From <code class="font-mono">{@key.env_var}</code>
+    in the environment. Ends in <code class="font-mono">…{@key.hint}</code>. Saving a key here overrides it.
+    """
+  end
+
+  defp source(%{key: %{source: :undecryptable}} = assigns) do
+    ~H"""
+    A key is stored but does not decrypt under the current <code class="font-mono">MASTER_SECRETS_KEY</code>. Set it again, or clear it to fall back
+    to <code class="font-mono">{@key.env_var}</code>.
+    """
+  end
+
+  defp source(assigns) do
+    ~H"""
+    Not set. Tenants must bring their own credential for this provider, or set <code class="font-mono">{@key.env_var}</code>.
+    """
+  end
+
+  defp provider_label("anthropic"), do: "Anthropic"
+  defp provider_label("openai"), do: "OpenAI"
+  defp provider_label("google"), do: "Google"
+  defp provider_label(other), do: other
+
+  defp placeholder("anthropic"), do: "sk-ant-…"
+  defp placeholder("openai"), do: "sk-…"
+  defp placeholder("google"), do: "AIza…"
+  defp placeholder(_), do: ""
+
+  defp source_label(:stored), do: "set in admin"
+  defp source_label(:environment), do: "from environment"
+  defp source_label(:undecryptable), do: "cannot decrypt"
+  defp source_label(:none), do: "not set"
+
+  defp source_badge_class(:stored), do: "bg-green-100 text-green-800 border-green-200"
+  defp source_badge_class(:environment), do: "bg-blue-100 text-blue-800 border-blue-200"
+  defp source_badge_class(:undecryptable), do: "bg-red-100 text-red-700 border-red-200"
+  defp source_badge_class(:none), do: "bg-zinc-100 text-zinc-500 border-zinc-200"
+end

--- a/apps/fountain/lib/fountain_web/live/admin_live/shell.ex
+++ b/apps/fountain/lib/fountain_web/live/admin_live/shell.ex
@@ -95,7 +95,8 @@ defmodule FountainWeb.AdminLive.Shell do
     [
       {:overview, "Overview", ~p"/admin"},
       {:users, "Users", ~p"/admin/users"},
-      {:sandboxes, "Sandboxes", ~p"/admin/sandboxes"}
+      {:sandboxes, "Sandboxes", ~p"/admin/sandboxes"},
+      {:inference, "Inference", ~p"/admin/inference"}
     ] ++ billing ++ [{:activity, "Activity", ~p"/admin/activity"}]
   end
 end

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -771,6 +771,7 @@ defmodule FountainWeb.Router do
       live "/admin", AdminLive.Index, :index
       live "/admin/users", AdminLive.Users, :index
       live "/admin/sandboxes", AdminLive.Sandboxes, :index
+      live "/admin/inference", AdminLive.Inference, :index
       live "/admin/activity", AdminLive.Activity, :index
       # Lives in ee/ with the rest of billing (#472): it is a revenue page.
       live "/admin/finance", Live.AdminFinanceLive, :index

--- a/apps/fountain/priv/repo/migrations/20260907080000_create_platform_inference_keys.exs
+++ b/apps/fountain/priv/repo/migrations/20260907080000_create_platform_inference_keys.exs
@@ -1,0 +1,23 @@
+defmodule Fountain.Repo.Migrations.CreatePlatformInferenceKeys do
+  use Ecto.Migration
+
+  # The deployment's own inference keys, set from `/admin/inference` (ADR 0038
+  # decision 3, amended). One row per provider; the value is encrypted under
+  # the master key (`Fountain.Crypto.encrypt_platform/1`), never stored plain.
+  # A row here wins over the `PLATFORM_<PROVIDER>_API_KEY` variable, which
+  # stays as the seed for a deployment configured from its environment.
+  #
+  # `updated_by_user_id` is who set it, for the admin page; it is nilified
+  # rather than cascaded so deleting an operator's account does not delete
+  # the deployment's key.
+  def change do
+    create table(:platform_inference_keys, primary_key: false) do
+      add :provider, :string, primary_key: true
+      add :ciphertext, :binary, null: false
+
+      add :updated_by_user_id, references(:users, type: :binary_id, on_delete: :nilify_all)
+
+      timestamps(type: :utc_datetime)
+    end
+  end
+end

--- a/apps/fountain/test/fountain/platform_inference_test.exs
+++ b/apps/fountain/test/fountain/platform_inference_test.exs
@@ -9,6 +9,8 @@ defmodule Fountain.PlatformInferenceTest do
 
   use Fountain.DataCase, async: false
 
+  import Ecto.Query, only: [from: 2]
+
   alias Fountain.Credits
   alias Fountain.InferenceCredentials
   alias Fountain.PlatformInference
@@ -60,6 +62,130 @@ defmodule Fountain.PlatformInferenceTest do
       with_platform_key()
       assert PlatformInference.key_for("ollama") == :none
       assert PlatformInference.key_for(nil) == :none
+    end
+  end
+
+  describe "keys set from the admin panel (put_key/3, clear_key/2, status/0)" do
+    setup do
+      %{admin: insert_verified_user()}
+    end
+
+    test "a stored key wins over the variable, and clearing it falls back", %{admin: admin} do
+      with_platform_key(:platform_openai_api_key, "sk-from-env")
+
+      assert {:ok, %PlatformInference.Key{provider: "openai"}} =
+               PlatformInference.put_key("openai", "sk-from-admin", actor_user_id: admin.id)
+
+      assert PlatformInference.key_for("openai") == {:ok, :openai_api_key, "sk-from-admin"}
+      assert PlatformInference.configured_providers() == ["openai"]
+
+      assert :ok = PlatformInference.clear_key("openai", actor_user_id: admin.id)
+      assert PlatformInference.key_for("openai") == {:ok, :openai_api_key, "sk-from-env"}
+    end
+
+    test "a stored key turns a provider on with no variable at all", %{admin: admin} do
+      refute PlatformInference.enabled?()
+
+      {:ok, _} = PlatformInference.put_key("google", "AIza-stored", actor_user_id: admin.id)
+
+      assert PlatformInference.enabled?()
+      assert PlatformInference.key_for("google") == {:ok, :gemini_api_key, "AIza-stored"}
+
+      assert InferenceCredentials.select("google/gemini-3.1-pro-preview", %{}) ==
+               {:ok, :platform, %{gemini_api_key: "AIza-stored"}}
+
+      :ok = PlatformInference.clear_key("google")
+      refute PlatformInference.enabled?()
+    end
+
+    test "the value is trimmed, and a value that is not one key is refused", %{admin: admin} do
+      {:ok, _} = PlatformInference.put_key("anthropic", "  sk-trimmed\n", actor_user_id: admin.id)
+      assert PlatformInference.key_for("anthropic") == {:ok, :anthropic_api_key, "sk-trimmed"}
+
+      assert PlatformInference.put_key("anthropic", "") == {:error, :invalid_key}
+      assert PlatformInference.put_key("anthropic", "   ") == {:error, :invalid_key}
+      assert PlatformInference.put_key("anthropic", "sk-two words") == {:error, :invalid_key}
+      assert PlatformInference.put_key("anthropic", "sk-a\tb") == {:error, :invalid_key}
+
+      assert PlatformInference.put_key("anthropic", String.duplicate("k", 1_025)) ==
+               {:error, :invalid_key}
+
+      assert PlatformInference.put_key("ollama", "anything") == {:error, :invalid_key}
+      # None of the refusals touched the stored key.
+      assert PlatformInference.key_for("anthropic") == {:ok, :anthropic_api_key, "sk-trimmed"}
+    end
+
+    test "the value is encrypted at rest and never in the trail", %{admin: admin} do
+      {:ok, row} = PlatformInference.put_key("openai", "sk-secret-value", actor_user_id: admin.id)
+
+      refute row.ciphertext =~ "sk-secret-value"
+      assert {:ok, "sk-secret-value"} = Fountain.Crypto.decrypt_platform(row.ciphertext)
+
+      [event] = admin_events("admin.platform_inference_key.set")
+      assert event.actor_user_id == admin.id
+      assert event.metadata == %{"provider" => "openai", "replaced" => "none"}
+      refute inspect(event) =~ "sk-secret"
+    end
+
+    test "the trail says what a key replaced, and a clear with nothing stored records nothing",
+         %{admin: admin} do
+      with_platform_key(:platform_anthropic_api_key, "sk-env")
+      {:ok, _} = PlatformInference.put_key("anthropic", "sk-one", actor_user_id: admin.id)
+      {:ok, _} = PlatformInference.put_key("anthropic", "sk-two", actor_user_id: admin.id)
+
+      assert ["environment", "stored"] =
+               "admin.platform_inference_key.set"
+               |> admin_events()
+               |> Enum.map(& &1.metadata["replaced"])
+               |> Enum.sort()
+
+      :ok = PlatformInference.clear_key("anthropic", actor_user_id: admin.id)
+      :ok = PlatformInference.clear_key("anthropic", actor_user_id: admin.id)
+      :ok = PlatformInference.clear_key("openai", actor_user_id: admin.id)
+
+      assert [%{metadata: %{"provider" => "anthropic"}}] =
+               admin_events("admin.platform_inference_key.cleared")
+    end
+
+    test "status/0 names the source, the operator and the key's tail", %{admin: admin} do
+      with_platform_key(:platform_anthropic_api_key, "env-1234")
+
+      {:ok, _} =
+        PlatformInference.put_key("openai", "admin-5678", actor_user_id: admin.id)
+
+      assert [anthropic, openai, google] = PlatformInference.status()
+
+      assert %{provider: "anthropic", source: :environment, hint: "1234", updated_by: nil} =
+               anthropic
+
+      assert anthropic.env_var == "PLATFORM_ANTHROPIC_API_KEY"
+
+      assert %{provider: "openai", source: :stored, hint: "5678"} = openai
+      assert openai.updated_by == admin.email
+      assert %DateTime{} = openai.updated_at
+
+      assert %{provider: "google", source: :none, hint: nil, updated_at: nil} = google
+    end
+
+    test "a stored key the master key no longer decrypts falls back to the variable",
+         %{admin: admin} do
+      with_platform_key(:platform_openai_api_key, "sk-env")
+      {:ok, row} = PlatformInference.put_key("openai", "sk-stored", actor_user_id: admin.id)
+
+      # Corrupt the blob the way a rotated MASTER_SECRETS_KEY would: the row
+      # is there, the bytes no longer authenticate.
+      row
+      |> Ecto.Changeset.change(ciphertext: :crypto.strong_rand_bytes(byte_size(row.ciphertext)))
+      |> Repo.update!()
+
+      assert PlatformInference.key_for("openai") == {:ok, :openai_api_key, "sk-env"}
+
+      assert [%{provider: "openai", source: :undecryptable, hint: nil}] =
+               Enum.filter(PlatformInference.status(), &(&1.provider == "openai"))
+
+      # And with no variable either the provider is simply off, not broken.
+      Application.put_env(:fountain, :platform_openai_api_key, "")
+      assert PlatformInference.key_for("openai") == :none
     end
   end
 
@@ -179,6 +305,14 @@ defmodule Fountain.PlatformInferenceTest do
       Application.delete_env(:fountain, :platform_inference_daily_cents)
       assert PlatformInference.daily_ceiling_cents() == 5_000
     end
+  end
+
+  defp admin_events(event_type) do
+    Repo.all(
+      from e in Fountain.Audit.AdminEvent,
+        where: e.event_type == ^event_type,
+        order_by: [asc: e.id]
+    )
   end
 
   defp burn_inference(user, cents) do

--- a/apps/fountain/test/fountain_web/live/admin_inference_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/admin_inference_live_test.exs
@@ -1,0 +1,127 @@
+defmodule FountainWeb.AdminInferenceLiveTest do
+  @moduledoc """
+  `/admin/inference`: the page reads and writes only through
+  `Fountain.PlatformInference`, so what is asserted here is the door — who
+  may open it, what it shows, and that a save or a clear lands as a stored
+  row and a privilege-trail event. The resolution rules (stored beats the
+  variable, the fallback on clear) are `platform_inference_test.exs`'s.
+
+  No `Application.put_env` here, so the file stays async: every fixture is a
+  row in the sandboxed database.
+  """
+
+  use FountainWeb.ConnCase, async: true
+
+  import Ecto.Query, only: [from: 2]
+  import Phoenix.LiveViewTest
+
+  alias Fountain.Accounts
+  alias Fountain.PlatformInference
+  alias Fountain.Repo
+
+  defp insert_admin do
+    user = insert_active_user()
+    {:ok, admin} = Accounts.update_user_role(user, "admin")
+    admin
+  end
+
+  describe "access control" do
+    test "an admin can open the page and sees one card per provider", %{conn: conn} do
+      conn = login_user(conn, insert_admin())
+      {:ok, _lv, html} = live(conn, ~p"/admin/inference")
+
+      assert html =~ "Inference"
+      assert html =~ "Anthropic"
+      assert html =~ "OpenAI"
+      assert html =~ "Google"
+      assert html =~ "PLATFORM_INFERENCE_DAILY_CENTS"
+    end
+
+    test "a regular user is sent to the dashboard", %{conn: conn} do
+      conn = login_user(conn, insert_active_user())
+      assert {:error, {:live_redirect, _}} = live(conn, ~p"/admin/inference")
+    end
+
+    test "an anonymous visitor is sent to login", %{conn: conn} do
+      assert {:error, {:redirect, %{to: path}}} = live(conn, ~p"/admin/inference")
+      assert path =~ "/auth/login"
+    end
+
+    test "the tab is in the admin bar", %{conn: conn} do
+      conn = login_user(conn, insert_admin())
+      {:ok, _lv, html} = live(conn, ~p"/admin")
+      assert html =~ ~s(href="/admin/inference")
+    end
+  end
+
+  describe "saving a key" do
+    test "stores it, shows its tail and who set it, and records the admin event", %{conn: conn} do
+      admin = insert_admin()
+      conn = login_user(conn, admin)
+      {:ok, lv, _html} = live(conn, ~p"/admin/inference")
+
+      html =
+        render_submit(lv, "set_key", %{"provider" => "openai", "value" => "sk-live-key-9876"})
+
+      assert html =~ "OpenAI key saved"
+      assert html =~ "set in admin"
+      assert html =~ "…9876"
+      assert html =~ admin.email
+      refute html =~ "sk-live-key"
+
+      assert PlatformInference.key_for("openai") == {:ok, :openai_api_key, "sk-live-key-9876"}
+
+      assert [event] =
+               Repo.all(
+                 from e in Fountain.Audit.AdminEvent,
+                   where: e.event_type == "admin.platform_inference_key.set"
+               )
+
+      assert event.actor_user_id == admin.id
+      assert event.metadata["provider"] == "openai"
+    end
+
+    test "a value that is not a key is refused and nothing is stored", %{conn: conn} do
+      conn = login_user(conn, insert_admin())
+      {:ok, lv, _html} = live(conn, ~p"/admin/inference")
+
+      html = render_submit(lv, "set_key", %{"provider" => "anthropic", "value" => "   "})
+
+      assert html =~ "does not look like a key"
+      assert PlatformInference.key_for("anthropic") == :none
+      refute html =~ "set in admin"
+    end
+  end
+
+  describe "clearing a key" do
+    test "removes the stored row and the Clear button with it", %{conn: conn} do
+      admin = insert_admin()
+      {:ok, _} = PlatformInference.put_key("google", "AIza-stored-key", actor_user_id: admin.id)
+
+      conn = login_user(conn, admin)
+      {:ok, lv, html} = live(conn, ~p"/admin/inference")
+      assert has_element?(lv, "button[phx-click=clear_key][phx-value-provider=google]")
+      assert html =~ "set in admin"
+
+      html =
+        lv
+        |> element("button[phx-click=clear_key][phx-value-provider=google]")
+        |> render_click()
+
+      assert html =~ "Google key cleared"
+      refute has_element?(lv, "button[phx-click=clear_key][phx-value-provider=google]")
+      assert PlatformInference.key_for("google") == :none
+
+      assert Repo.exists?(
+               from e in Fountain.Audit.AdminEvent,
+                 where: e.event_type == "admin.platform_inference_key.cleared"
+             )
+    end
+
+    test "there is no Clear button for a provider with nothing stored", %{conn: conn} do
+      conn = login_user(conn, insert_admin())
+      {:ok, lv, _html} = live(conn, ~p"/admin/inference")
+      refute has_element?(lv, "button[phx-click=clear_key]")
+    end
+  end
+end

--- a/decisions/0038-onboarding-first-reply.md
+++ b/decisions/0038-onboarding-first-reply.md
@@ -52,6 +52,16 @@ selection rule, a `burn_inference` debit per closed platform turn from
 `PLATFORM_INFERENCE_DAILY_CENTS` (default 5000) as a deployment-wide daily
 circuit breaker answering 503.
 
+*Amended 2026-09-07:* the keys are also settable from `/admin/inference`
+(`Fountain.PlatformInference.put_key/3`), one `platform_inference_keys` row
+per provider encrypted under the master key, recorded as
+`admin.platform_inference_key.*` on the privilege trail. A stored key wins
+over the variable and takes effect at the next conversation with no rollout;
+clearing it falls back to the variable. The variable stays as the seed for a
+deployment configured from its environment. Rotating the production OpenAI
+key on 2026-09-07 took a secret-store edit and a rollout of every pod, which
+is what this removes.
+
 **The price is pass-through at provider list, a 1.0x margin, no markup**
 (decided with Jake on 2026-09-02). Fountain's margin is sandbox time
 (`CREDIT_TURN_HOUR_CENTS`, [0031](0031-credits-are-the-product.md)). Marking

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -205,6 +205,21 @@ behaves as it always did, and each tenant supplies a credential of their own.
 | `PLATFORM_ANTHROPIC_API_KEY` | — | No. | The Anthropic key Fountain runs a tenant on when that tenant has none. This is the first key to set. The default agent uses the claude runtime. |
 | `PLATFORM_OPENAI_API_KEY` | — | No. | The same, for an agent on an `openai/` model. |
 | `PLATFORM_GEMINI_API_KEY` | — | No. | The same, for an agent on a `google/` model. |
+
+### Set a key from the admin panel
+
+An admin can also set each key at `/admin/inference`. Fountain stores that
+key in the database, encrypted under `MASTER_SECRETS_KEY`, and uses it from
+the next conversation on. No restart is necessary.
+
+A key set in the panel wins over the variable. Clear the key in the panel to
+go back to the variable. The page shows the source of each provider's live
+key, the last four characters of that key, and who set it. Each save and each
+clear leaves an `admin.platform_inference_key` event on the admin activity
+page.
+
+Use the variable to seed a new deployment. Use the panel to rotate a key on a
+deployment that already runs.
 | `PLATFORM_INFERENCE_DAILY_CENTS` | `5000` | No. | The most the keys above may cost in one UTC day, across every tenant. A conversation beyond it gets `503 platform_inference_unavailable`. It works only with `CREDITS_ENABLED=true`. |
 | `PLATFORM_INFERENCE_RATES` | — | No. | Per-model prices, in cents per million tokens. See below. |
 


### PR DESCRIPTION
## What

The deployment's own inference keys (ADR 0038 decision 3) were `PLATFORM_<PROVIDER>_API_KEY` and nothing else, so rotating one meant a secret-store edit and a rollout of every pod (which is exactly what rotating the production OpenAI key took this morning). An admin can now set each key at **`/admin/inference`**, a new tab in the admin bar.

- One `platform_inference_keys` row per provider (anthropic, openai, google), encrypted under the master key with its own AAD (`Crypto.encrypt_platform/1` / `decrypt_platform/1`). No plaintext column, no `_unsafe_` reader.
- `PlatformInference.key_for/1` reads the row before the variable, so a saved key is live from the next conversation with no restart. `enabled?/0` and `configured_providers/0` load all rows in one read.
- **Clearing falls back to the variable**, not to off: the variable is the seed a deployment was configured with, the row is the operator's later decision.
- A stored row the master key no longer decrypts is logged and treated as absent, so a rotated `MASTER_SECRETS_KEY` degrades to the variable rather than to a key that fails every request. The page shows that state and offers set-again or clear.
- Both mutations live in the context (`put_key/3`, `clear_key/2`) and record `admin.platform_inference_key.set` / `.cleared` on the privilege trail with the provider and what was replaced (`stored` / `environment` / `none`), never any part of the value. A clear with nothing stored records nothing.
- `put_key/3` trims, and refuses an empty value, internal whitespace or control characters, or anything over 1 KiB.
- The page shows each provider's source (badge), the last four characters of the live key, when and by whom it was set, and the daily ceiling with today's spend. The activity page now shows the provider for an admin event with no target account.

## Docs

`docs/configuration.md` gains "Set a key from the admin panel" under Platform inference; `.env.example` gets the same note; ADR 0038 decision 3 carries a dated amendment. `okf validate decisions` is clean and the index is unchanged (no frontmatter change).

## Tests

- `platform_inference_test.exs` (sync, it writes app env): stored beats the variable, clear falls back, a stored key turns a provider on with no variable, trimming and refusals, encrypted at rest and absent from the trail, what the trail says a key replaced, `status/0`, and the undecryptable fallback.
- `admin_inference_live_test.exs` (async, DB rows only): access control for admin / user / anonymous, the tab, save → row + tail + operator + event, refusal, clear → row gone and button gone.

`mix precommit` green locally: 4,400 core tests + both extension suites, 0 failures; credo no issues; dialyzer passed; prod release assembled.

## Not in this PR

No API endpoint for these keys; this is an operator lever on the console, like the sandbox-limit override. Happy to add `PUT /api/admin/inference/:provider` if a script needs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YChmLndKqQbBMrSrxoQpXE
