### PR TITLE
feat: suggest claude-fable-5-1 again, now that the refusal is understood

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,6 +172,18 @@ upgrade, is in
   round trips and invalidates checkpoints when changed. The overall provisioning
   deadline and failed-setup handling remain in force.
 
+- `claude-fable-5-1` is suggested for anthropic again, so `GET /api/catalog`
+  lists it. It was removed on 2026-09-07 because the claude adapter refused
+  it; the refusal was not the adapter version but a cold cache. The Claude
+  Code binary learns an org's "additional models" (Fable among them) from a
+  fetch it makes after a session starts and caches for the next launch, so
+  the first session in a fresh sandbox never listed Fable on any adapter
+  version. Two `managoat_runtimes` releases fix that: 0.3.3 moves the adapter
+  pin to 0.75.1 (the bundled CLI must be 2.1.255 or later for Fable 5.1), and
+  0.3.4 warms the cache at provisioning. Verified with a real turn on the new
+  pin. `claude-fable-5` stays unsuggested: the adapter refuses it even with
+  the cache warm.
+
 - Vault secret expiry can be edited in the console or with a metadata-only PATCH, without replacing the encrypted value.
 - Conversation lists accept a `sandbox_id` filter, including through the TypeScript SDK.
 

--- a/apps/fountain/lib/fountain/agents/model_catalog.ex
+++ b/apps/fountain/lib/fountain/agents/model_catalog.ex
@@ -80,15 +80,49 @@ defmodule Fountain.Agents.ModelCatalog do
   # to users. `Managoat.Runtimes.Claude.prepare_sandbox/3` warms that cache
   # at provisioning (managoat_runtimes 0.3.4), and Fable 5.1 additionally
   # needs the CLI at 2.1.255 or later, which the 0.75.1 adapter pin bundles
-  # (managoat_runtimes 0.3.3). Check both when this entry misbehaves.
+  # (managoat_runtimes 0.3.3).
+  #
+  # ## And the accepted set also varies by credential type
+  #
+  # The warm-up only populates on an API key. Measured in production on
+  # 2026-09-11, same commit and pods, a fresh sandbox each time, one variable
+  # changed:
+  #
+  #   * `ANTHROPIC_API_KEY` (a tenant's own, or the platform key a tenant with
+  #     no anthropic credential falls back to): the cache warms in a couple of
+  #     seconds and the turn selects `claude-fable-5-1[1m]`.
+  #   * `CLAUDE_CODE_OAUTH_TOKEN` (a Claude.ai subscription): the fetch never
+  #     populates `additionalModelOptionsCache`, the warm-up polls out its 30s
+  #     bound and logs "claude model list did not warm", and the turn fails at
+  #     `session/set_config_option` with "Invalid value for config option
+  #     model" — the #1669 refusal exactly.
+  #
+  # Egress is not the cause: `cachedGrowthBookFeatures` comes back from the
+  # server on the failing path, so the sandbox reached Anthropic and only the
+  # additional-models fetch came back empty. `Claude.default_env/2` prefers
+  # OAuth whenever it is set, so a tenant holding a subscription token always
+  # takes the failing path.
+  #
+  # **This entry is therefore knowingly suggested to accounts it cannot serve.**
+  # `@catalog` is one global list, so `GET /api/catalog` offers Fable to every
+  # account while only the API-key path resolves it. That is a deliberate
+  # choice, not an oversight: the id is live and correct for the platform-key
+  # majority, and it is listed rather than hidden from them. A Fable refusal
+  # reported by a tenant with their own Claude subscription is this, and is
+  # expected until the warm-up populates on that path.
+  #
+  # Check all three when this entry misbehaves: the provider, the adapter pin,
+  # and which credential the conversation ran on (the `broker` log event names
+  # the keys).
   @catalog %{
     # `claude-fable-5-1`: added 2026-09-06 (#1659) from the published id with
     # no adapter check, removed 2026-09-07 (#1669) after two refused turns,
     # re-added 2026-09-07 on the 0.75.1 adapter pin with the cache warm-up
     # above, verified with a real turn ("Reply with the single word OK" →
-    # `stopReason: end_turn`, confirmed model `claude-fable-5-1[1m]`). The
-    # 2026-09-06 refusals were the cold-cache case, not a version the
-    # provider does not serve. `claude-fable-5` is refused by 0.75.1 even
+    # `stopReason: end_turn`, confirmed model `claude-fable-5-1[1m]`) — on an
+    # API-key credential. It is refused on the OAuth path, knowingly; see the
+    # credential-type note above `@catalog`. The 2026-09-06 refusals were the
+    # cold-cache case, not a version the provider does not serve. `claude-fable-5` is refused by 0.75.1 even
     # warm — the org's additional list carries 5.1 only — and stays out.
     #
     # `claude-opus-4-8`, `claude-opus-4-7` and `claude-sonnet-4-6` were removed

--- a/apps/fountain/lib/fountain/agents/model_catalog.ex
+++ b/apps/fountain/lib/fountain/agents/model_catalog.ex
@@ -46,7 +46,8 @@ defmodule Fountain.Agents.ModelCatalog do
   #
   # Every id below was checked with a real inference call on 2026-08-22, per
   # provider, on this instance's own keys, and re-checked against the pinned
-  # ACP adapters on 2026-09-06.
+  # ACP adapters on 2026-09-06 (and `claude-fable-5-1` on 2026-09-07, against
+  # claude-agent-acp 0.75.1).
   #
   # ## A suggestion has to clear two gates, not one
   #
@@ -65,16 +66,30 @@ defmodule Fountain.Agents.ModelCatalog do
   # requested model in `log_events` (`stage='model', state='failed'`) against
   # turns for the same model — a suggestion refused on most of its turns is
   # not a suggestion, it is an outage waiting for someone to enforce it.
+  #
+  # ## And the claude adapter's accepted set is not fixed per version
+  #
+  # The claude adapter advertises whatever the Claude Code binary bundled in
+  # its SDK reports, and that binary has two lists: a built-in one (`opus`,
+  # `sonnet`, `haiku`) and an "additional models" list it fetches per org
+  # from Anthropic *after* a session has started, caching it in
+  # `~/.claude.json` for the next launch. Fable is only ever on the second
+  # list. So on a cold sandbox the first session refuses `claude-fable-5-1`
+  # on every adapter version, and a warm one accepts it — which is why #1669
+  # read as "the pinned adapter refuses it" on 2026-09-06 and as intermittent
+  # to users. `Managoat.Runtimes.Claude.prepare_sandbox/3` warms that cache
+  # at provisioning (managoat_runtimes 0.3.4), and Fable 5.1 additionally
+  # needs the CLI at 2.1.255 or later, which the 0.75.1 adapter pin bundles
+  # (managoat_runtimes 0.3.3). Check both when this entry misbehaves.
   @catalog %{
-    # `claude-fable-5-1` was added on 2026-09-06 (#1659) from Anthropic's
-    # published model id, with no local inference check and no adapter check,
-    # and removed on 2026-09-07 (#1669) once it had run turns: the pinned
-    # `claude-agent-acp` refuses it at `session/set_model` with "Invalid value
-    # for config option model", exactly like the three below. It was added in
-    # the same window this file's two-gates note was written and survived the
-    # clean-up that removed the others, because a published provider id looks
-    # like the check has already been done. It is gate one; the adapter is the
-    # gate that decides a turn.
+    # `claude-fable-5-1`: added 2026-09-06 (#1659) from the published id with
+    # no adapter check, removed 2026-09-07 (#1669) after two refused turns,
+    # re-added 2026-09-07 on the 0.75.1 adapter pin with the cache warm-up
+    # above, verified with a real turn ("Reply with the single word OK" →
+    # `stopReason: end_turn`, confirmed model `claude-fable-5-1[1m]`). The
+    # 2026-09-06 refusals were the cold-cache case, not a version the
+    # provider does not serve. `claude-fable-5` is refused by 0.75.1 even
+    # warm — the org's additional list carries 5.1 only — and stays out.
     #
     # `claude-opus-4-8`, `claude-opus-4-7` and `claude-sonnet-4-6` were removed
     # on 2026-09-06. All three answer a real inference call — the 2026-08-22
@@ -83,6 +98,7 @@ defmodule Fountain.Agents.ModelCatalog do
     # so a turn never reaches the provider at all. See the two-gates note
     # above `@catalog`.
     "anthropic" => ~w(
+      claude-fable-5-1
       claude-opus-5
       claude-sonnet-5
       claude-haiku-4-5

--- a/apps/fountain/test/support/refused_models.ex
+++ b/apps/fountain/test/support/refused_models.ex
@@ -61,16 +61,18 @@ defmodule Fountain.RefusedModels do
     # claude-agent-acp 0.66.0 — "Invalid value for config option model".
     # 289 refusals for claude-sonnet-4-6 alone, 2026-08-16..2026-09-06.
     "anthropic/claude-sonnet-4-6" => "2026-09-06",
-    # Both observed refused on real turns, one turn each, minutes apart:
-    # claude-fable-5-1 at 11:42:46 UTC and claude-fable-5 at 11:45:46 UTC, both
-    # "Invalid value for config option model" (#1669). claude-fable-5-1 was
-    # suggested for one day (#1659); claude-fable-5 never was, and reached a
-    # turn only because one agent is pinned to it by hand.
+    # Observed refused on a real turn at 11:45:46 UTC on 2026-09-06, "Invalid
+    # value for config option model" (#1669); never suggested, reached a turn
+    # only because one agent is pinned to it by hand. Still refused by
+    # claude-agent-acp 0.75.1 with the model cache warm (2026-09-07): the
+    # org's additional-models list carries Fable 5.1 only, so this id has no
+    # row to resolve onto. A live published Anthropic id, so this row bars a
+    # current model rather than a retired one — deliberate while the adapter
+    # refuses it.
     #
-    # Both are live published Anthropic ids, so these two rows bar a current
-    # model rather than a retired one. Deliberate while the adapter refuses
-    # them, and the pair the "drive one real turn" clause above exists for.
-    "anthropic/claude-fable-5-1" => "2026-09-06",
+    # `claude-fable-5-1` sat beside it from 2026-09-06 to 2026-09-07. Its
+    # refusal was the cold model cache (see `ModelCatalog`), not the version;
+    # cleared by the "drive one real turn" clause above on the 0.75.1 pin.
     "anthropic/claude-fable-5" => "2026-09-06",
     "anthropic/claude-opus-4-7" => "2026-08-27",
     "anthropic/claude-opus-4-8" => "2026-08-23",


### PR DESCRIPTION
## Why

#1724 dropped `claude-fable-5-1` as "an id the pinned adapter refuses". The adapter version was half the story. The claude adapter advertises whatever the Claude Code binary bundled in its SDK reports, and that binary learns an org's "additional models" (Fable among them) from a fetch it makes *after* a session has started, caching it in `~/.claude.json` for the *next* launch. So the first session in a fresh sandbox never lists Fable on any adapter version, and the second one does — which is exactly the two refusals #1669 recorded, and why users read it as intermittent.

Measured 2026-09-07 with a fresh `CLAUDE_CONFIG_DIR` per run:

| adapter | cold | warm |
|---|---|---|
| 0.66.0 (old pin, CLI 2.1.220) | no Fable | `claude-fable-5[1m]` only; 5.1 "disabled, update to 2.1.255+" |
| 0.75.1 (CLI 2.1.257) | no Fable | `claude-fable-5-1[1m]`, accepted |

Both fixes are now on `main` and deployed: `managoat_runtimes` 0.3.3 (adapter pin 0.75.1) and 0.3.4 (`prepare_sandbox/3` warms the cache at provisioning), consumed by #2004.

## The production gate ran, and it splits by credential type

Driven on 2026-09-11 against the deployed 0.3.4, twice — same commit, same pods, a fresh cold sandbox each time, the same `"Reply with the single word OK"` prompt, one variable changed:

| credential in `sprite_env` | provisioning | warm-up | turn |
|---|---|---|---|
| `ANTHROPIC_API_KEY` | 15s | warms (silent) | **completed**, `effective_model: claude-fable-5-1[1m]` |
| `CLAUDE_CODE_OAUTH_TOKEN` | 41s | polls out its 30s bound, logs the warning | **failed** — `Invalid value for config option model` |

The passing turn:

```json
"model_selection": {
  "effective_model": "claude-fable-5-1[1m]",
  "requested_model": "claude-fable-5-1",
  "source": "runtime", "status": "selected"
},
"usage": {"input": 2, "output": 4, "cache_write": 6935, "cache_read": 10248}
```

The failing one is the #1669 refusal verbatim, and the warm-up reports its own failure:

```
claude model list did not warm before the first session;
the org's additional models (Fable) will not be selectable in it
```

`/home/sprite/.claude.json` on that sandbox has no `additionalModelOptionsCache` key. Egress is not the cause — `cachedGrowthBookFeatures` comes back from the server on the failing path, so the sandbox reached Anthropic and only the additional-models fetch returned nothing. The brokered placeholder is not implicated.

`Claude.default_env/2` prefers OAuth whenever it is set, so any tenant holding a Claude subscription token takes the failing path.

## What this ships, deliberately

`@catalog` is one global list. `GET /api/catalog` will therefore offer `claude-fable-5-1` to every account while only the API-key path resolves it — including every tenant with no anthropic credential of their own, who fall back to `PLATFORM_ANTHROPIC_API_KEY` and get a working model.

**That is the decision, not an oversight.** The id is live, correct and useful for the platform-key majority, and it is listed for them rather than withheld. A Fable refusal reported by a tenant using their own Claude subscription is this, is expected, and clears when the warm-up populates on that path. The `ModelCatalog` comment says so at the point a reader will look, with the third thing to check — which credential the conversation ran on, named by the `broker` log event.

## What

- `claude-fable-5-1` back at the top of the anthropic suggestions.
- `claude-fable-5-1` leaves `Fountain.RefusedModels`. `claude-fable-5` stays: 0.75.1 refuses it even warm, because the org's additional list carries 5.1 only.
- The two-gates note gains a third gate: the accepted set varies by credential type, not just by adapter version and config-dir state.
- Changelog entry under Unreleased.

## Gate

Rebased onto current `main` (it was 4 days stale and predated the 0.3.4 lock). Local, from `apps/fountain` with the pinned compiler: `mix format --check-formatted` clean, `mix compile --warnings-as-errors` clean, `mix credo --strict` no issues. `model_catalog_test`, `starter_test`, `agents_live_test`, `docs_test`: **71 tests, 0 failures**. `catalog_controller_test` + `acp_model_contract_test`: **9 tests, 0 failures**.

The refused-model guard was checked for vacuity rather than assumed: putting `anthropic/claude-fable-5-1` back into `RefusedModels` while it is suggested fails `model_catalog_test.exs:56` with the intended message. It passes here because the id is no longer in the registry, which is the point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkZYEpwKRZTwhTc8cXMtLP
