### PR TITLE
chore(review-loop): increase reported token allowance 100x

### DIFF
--- a/.github/review-loop.yml
+++ b/.github/review-loop.yml
@@ -171,4 +171,4 @@ limits:
   max_elapsed_minutes: 120
   max_parallel_reviewers: 4
   max_agent_tasks: 30
-  max_reported_tokens: 500000
+  max_reported_tokens: 50000000

--- a/.github/review/README.md
+++ b/.github/review/README.md
@@ -32,7 +32,7 @@ A PR cannot authorize itself by editing these files.
 
 Reviewer runtimes and models are pinned in `.github/review-loop.yml`. The fixer
 uses the operator-selected default. Parallelism is bounded by host and Fountain capacity. The repository policy permits four
-reviewers at once, 30 tasks, 500,000 reported tokens and 120 minutes per run.
+reviewers at once, 30 tasks, 50,000,000 reported tokens and 120 minutes per run.
 Daily budgets are separate operator settings. Neither token nor task counts
 are dollar-cost reporting.
 


### PR DESCRIPTION
Raise `limits.max_reported_tokens` from 500,000 to 50,000,000 (100×) to give reviews more room before token-exhaustion handoff. Update the documented allowance to match.

**Blocked before merge:** Review Loop currently caps this field at 10,000,000 in `server/policy.ts`. The service must accept 50,000,000 before this policy lands; otherwise it will reject the configuration. This PR remains a draft pending that change and deployment.

Validation: YAML parses; confirmed an exact 100× increase with every other policy value unchanged; docs match; `git diff --check` passes. `mix precommit` was attempted but cannot run because this isolated checkout lacks dependencies.
