### PR TITLE
Route coding findings to agents and reserve human review for decisions

### DIFF
--- a/.agents/skills/review-loop/SKILL.md
+++ b/.agents/skills/review-loop/SKILL.md
@@ -7,7 +7,7 @@ description: >-
 
 # Work with Review Loop
 
-Review Loop can push permitted fixes and ends with approval or a human handoff.
+Review Loop can push permitted fixes and reports approval, changes requested, an explicit human decision, or incomplete execution.
 Approval covers the current PR revision; it does not merge it. This skill adds
 no permission to push, merge, spend on retries or decide product behavior.
 Use the user's existing task authorization.
@@ -30,6 +30,25 @@ gh pr checks PR --repo OWNER/REPO
 
 A green dispatch means admission, not approval. An old approval or a resolved
 thread does not establish that the current revision passes.
+
+## Route the result
+
+A current-head `CHANGES_REQUESTED` review by the installed Review Loop App is
+coding work. Repair the confirmed defect within your existing authorization,
+including when the service's automatic fixer is excluded from that path. Keep
+severity and required tests intact; a narrow bot policy does not require a human
+to write the code.
+
+`needs-human-review` means a decision or explicit approval requirement. Read the
+question and alternatives, apply decisions the user has already authorized, and
+ask only for an unsettled choice. A PR can carry both signals: make independent
+permitted repairs while preserving the decision. Incomplete review or provider
+failure requires diagnosing missing execution/evidence before a bounded retry;
+it is not proof of a code defect or a product decision.
+
+Check App identity and current head before acting on a review event. Historical
+reviews retain their original commit IDs. Avoid duplicate coding work by recording
+the review/run ID you are handling.
 
 ## Coordinate repairs
 

--- a/.github/review-loop.yml
+++ b/.github/review-loop.yml
@@ -1,4 +1,4 @@
-# Four independent whole-PR reviews, safe fixes, verified re-review, then approval or a human decision.
+# Four independent whole-PR reviews, safe fixes, verified re-review, then approval, changes requested, or an explicit human decision.
 version: 1
 reviewers:
   - id: qa-team
@@ -120,10 +120,8 @@ approval:
   require_all_reviewers: true
   require_independent_rereview: true
   human_review_when:
-    - unresolved_blocking_finding
     - unresolved_human_objection
     - reviewer_requests_product_decision
-    - incomplete_verification
   # A path here sends the PR to a maintainer even when all four reviewers
   # are satisfied and every check passed, so it is reserved for the places
   # where a wrong automatic approval is hard to undo or would weaken the

--- a/.github/review/README.md
+++ b/.github/review/README.md
@@ -23,26 +23,25 @@ Confidence is a reviewer judgment, not a separate numeric score enforced by
 the host. This setup does not impersonate Paul or launch an interactive
 pairing agent.
 
-A human decision is the expensive outcome, and two things produce one. A
-reviewer can set `needsHuman` on a finding, which ends the run with `needs-
-human-review` at any severity: the host downgrades a low or info *defect* to
-nonblocking, but a low or info finding marked `needsHuman` or filed as a
-`product_decision` still goes to a maintainer. The instructions therefore name
-one case that always warrants `needsHuman`: a change that contradicts a
-decision an Accepted ADR records, cited by ADR and sentence. Beyond that they
-reserve it for a medium-or-higher finding whose remedy a maintainer must choose
-and which is hard to reverse once merged (a public contract, a migration or
-retention change, licensing, the authorization model, a repair outside the fix
-policy), and say that a low or info finding is never one. Intent the approved
-base already records is settled when the PR follows it. The other producer is
-`human_review_paths`, which is now the short list of places where a wrong
-automatic approval is hard to undo or would weaken a gate: the policy and these
-instructions, workflows, migrations, licensing, the release and deployment
-definitions, the SDK version files whose merge publishes, the gate thresholds
-and scripts, and the ADRs themselves, so a PR that edits a decision always
-reaches a maintainer. The first eleven runs against this repository all ended
-with the label, most of them for a dependency bump, a doc, or a low finding
-about wrapping or duplicated code; that is what both changes answer.
+Review Loop separates the next actor from the severity of a finding. Confirmed
+code defects receive a commit-specific GitHub `CHANGES_REQUESTED` review when
+the automatic fixer cannot complete them. A coding agent can make those repairs
+under its own repository authorization, including outside the bot's path or
+file allowance. Low/info defects remain nonblocking when policy permits.
+
+`needs-human-review` is reserved for an unsettled decision or explicit approval
+requirement. Reviewers use `kind: product_decision`, `needsHuman: true`, and a
+`humanDecision` containing the question, alternatives with consequences, and
+recommendation. Apply requirements already settled by the approved base: a
+repair restoring an accepted ADR is ordinary coding work; changing the ADR's
+decision needs authority. The trusted `human_review_paths` still cover review
+policy, workflows, migrations, licensing, deployment/release definitions, gate
+controls and ADR changes. Automatic fixer permissions remain unchanged.
+
+A PR with both repairs and a decision receives both signals. Provider failures,
+missing evidence and uncertainty alone are incomplete execution, not a human
+decision. The run API exposes `outcome`, `humanReviewRequired`, and reasons for
+routing. Check App identity and current commit before reacting to review events.
 
 An approval covers the entire evaluated PR and never merges it. A new revision,
 failed check or human objection can invalidate an earlier approval. Repository
@@ -71,10 +70,10 @@ gate is skipped or changed to get an approval.
 An existing Go guest-handshake fixture race is tracked in
 [#1641](https://github.com/BinaryBourbon/fountain/issues/1641), reproduced in
 2 of 100 focused local runs on the inspected main revision. Its gate remains
-enabled. A failure produces incomplete verification and a human handoff;
+enabled. A confirmed failed check requests changes; missing execution is incomplete;
 rerunning until it turns green is not evidence that the defect was fixed.
 
-Deploy Review Loop support for `verification.command_timeout_minutes` first.
+Deploy Review Loop outcome-routing support before using these reviewer contracts.
 The expanded recipe needs a thirty-minute command allowance: its measured cold
 Credo/Dialyzer stage took about 23 minutes and the full recipe about 48 minutes.
 See [measured command budget](verification.md#measured-command-budget).

--- a/.github/review/api-compatibility.md
+++ b/.github/review/api-compatibility.md
@@ -41,20 +41,22 @@ A fix candidate must preserve intended public behavior and fit the trusted fix
 policy, including necessary regression tests, with a clear, high-confidence
 remedy. Use stable rule and semantic anchor text for recurring findings.
 
-needsHuman is expensive: one such finding, at any severity, ends the run with
-the human-review label. The one case that always warrants it is a change that
-contradicts a decision an Accepted ADR at the base records; cite the ADR and
-the sentence the PR breaks, and treat a PR that amends the ADR to fit as the
-same decision. Beyond that, reserve it for a medium-or-higher finding where
-preserving compatibility means choosing between product behaviors, where an
-existing caller breaks and the base does not say which side wins, or where a
-complete repair exceeds the fix policy. Set it with concrete alternatives.
-Intent the approved base already records (CONTRIBUTING.md, an ADR, the
-CHANGELOG, the OpenAPI spec, the linked issue) is settled when the PR follows
-it; do not ask a maintainer to confirm it again. A low or info finding is never
-needsHuman and never a product_decision: file it as a nonblocking defect. A
-name you would have chosen differently, a doc page that could say more, a stale
-cross-reference and an SDK left unbumped by design are nonblocking.
+
+A concrete code, test or documentation defect has `kind: defect` and
+`needsHuman: false`, including a repair outside the service's automatic fix
+permissions. A coding agent with repository access can make that repair. Do
+not lower a defect's severity because the service cannot repair it. Missing
+coverage, tools, provider responses or verification are incomplete execution.
+
+Reserve `kind: product_decision` and `needsHuman: true` for a choice requiring
+human authority that the approved base has not settled. Supply `humanDecision`
+with a precise `question`, at least two `options` and their consequences, and a
+`recommendation`. Apply settled contracts and decisions: repairing a violation
+of an accepted requirement does not require asking whether to keep that
+requirement. Escalate a proposed change to the requirement itself, an
+irreversible migration/retention choice, or an unresolved authority boundary.
+The server independently enforces protected paths and human objections.
+
 
 Be concise: trigger, consequence, evidence, remedy. Preserve uncertainty and
 material decision tradeoffs.

--- a/.github/review/correctness.md
+++ b/.github/review/correctness.md
@@ -33,24 +33,22 @@ must not become a confident defect without evidence. Explain uncertainty and
 alternatives. Give recurring findings stable rule and semantic anchor text so
 the service can consolidate duplicates and preserve discussion history.
 
-needsHuman is expensive: one such finding, at any severity, ends the run with
-the human-review label. The one case that always warrants it is a change that
-contradicts a decision an Accepted ADR at the base records; cite the ADR and
-the sentence the PR breaks, and treat a PR that amends the ADR to fit as the
-same decision. Beyond that, reserve it for a medium-or-higher finding whose
-remedy a maintainer must choose and which is hard to reverse once merged: a
-migration or data-retention change, a public behavior change with no
-compatibility contract, a licensing or pricing change, or a repair that exceeds
-the fix policy. Set it with the alternatives and their consequences. A low or
-info finding is never needsHuman and never a product_decision: file it as a
-nonblocking defect and say what you would prefer. Intent the approved base
-already records (CLAUDE.md, CONTRIBUTING.md, an ADR, the CHANGELOG, the linked
-issue) is settled when the PR follows it; do not ask a maintainer to confirm it
-again. A dependency bump the verification recipe passes, a test that could be
-tighter, duplicated code, wording and wrapping are nonblocking. An ADR is a
-constraint on the PR, not permission to expand the server's fix policy. Never
-push, merge, publish, create external resources or claim the service's
-verification ran from your own test output.
+
+A concrete code, test or documentation defect has `kind: defect` and
+`needsHuman: false`, including a repair outside the service's automatic fix
+permissions. A coding agent with repository access can make that repair. Do
+not lower a defect's severity because the service cannot repair it. Missing
+coverage, tools, provider responses or verification are incomplete execution.
+
+Reserve `kind: product_decision` and `needsHuman: true` for a choice requiring
+human authority that the approved base has not settled. Supply `humanDecision`
+with a precise `question`, at least two `options` and their consequences, and a
+`recommendation`. Apply settled contracts and decisions: repairing a violation
+of an accepted requirement does not require asking whether to keep that
+requirement. Escalate a proposed change to the requirement itself, an
+irreversible migration/retention choice, or an unresolved authority boundary.
+The server independently enforces protected paths and human objections.
+
 
 Be concise: trigger, consequence, evidence, remedy. Preserve uncertainty and
 material decision tradeoffs.

--- a/.github/review/simplicity.md
+++ b/.github/review/simplicity.md
@@ -23,23 +23,22 @@ fix policy, including necessary regression tests, and preserve intended public
 behavior. Do not silently drop an uncertain security concern or resolve someone
 else's objection as a stylistic nit.
 
-needsHuman is expensive: one such finding, at any severity, ends the run with
-the human-review label. The one case that always warrants it is a change that
-contradicts a decision an Accepted ADR at the base records; cite the ADR and
-the sentence the PR breaks, and treat a PR that amends the ADR to fit as the
-same decision. Beyond that it is rarely warranted from this lens: reserve it
-for a medium-or-higher finding where the simpler shape would change public
-behavior, a migration or a deployment definition, or where a complete repair
-exceeds the fix policy. Explain the alternatives and what the maintainer must
-decide. A low or info finding is never needsHuman and never a product_decision:
-file it as a nonblocking defect and say what you would prefer. Duplicated code,
-a condition written out more than once, a second table over one function, line
-wrapping, a comment that could be shorter, and a test that restates what
-another already checks are nonblocking suggestions, not decisions.
 
-Judge every new revision independently from a fixer's claims. Never push,
-approve, merge, publish, change labels, or operate production resources yourself;
-the service owns those writes and independently checks verification evidence.
+A concrete code, test or documentation defect has `kind: defect` and
+`needsHuman: false`, including a repair outside the service's automatic fix
+permissions. A coding agent with repository access can make that repair. Do
+not lower a defect's severity because the service cannot repair it. Missing
+coverage, tools, provider responses or verification are incomplete execution.
+
+Reserve `kind: product_decision` and `needsHuman: true` for a choice requiring
+human authority that the approved base has not settled. Supply `humanDecision`
+with a precise `question`, at least two `options` and their consequences, and a
+`recommendation`. Apply settled contracts and decisions: repairing a violation
+of an accepted requirement does not require asking whether to keep that
+requirement. Escalate a proposed change to the requirement itself, an
+irreversible migration/retention choice, or an unresolved authority boundary.
+The server independently enforces protected paths and human objections.
+
 
 Be concise: trigger, consequence, evidence, remedy. Preserve uncertainty and
 material decision tradeoffs.

--- a/.github/review/tenant-isolation.md
+++ b/.github/review/tenant-isolation.md
@@ -43,19 +43,22 @@ policy, including necessary regression tests. Do not downgrade an uncertain
 security concern into a style nit; describe the missing evidence explicitly.
 Give recurring findings stable rule and semantic anchor text for deduplication.
 
-needsHuman is expensive: one such finding, at any severity, ends the run with
-the human-review label. The one case that always warrants it is a change that
-contradicts a decision an Accepted ADR at the base records; cite the ADR and
-the sentence the PR breaks, and treat a PR that amends the ADR to fit as the
-same decision. Beyond that, reserve it for a medium-or-higher finding whose
-remedy a maintainer must choose: a change to the authorization or sharing
-model, a widening of what a credential or callback can reach, or a repair that
-exceeds the fix policy. Set it with the alternatives and their consequences. A
-concern you can neither confirm nor dismiss is a medium finding with the
-missing evidence named, not a low finding routed to a human. A low or info
-finding is never needsHuman and never a product_decision: file it as a
-nonblocking defect. An audit-actor or redaction fix with one obvious remedy is
-a fix candidate.
+
+A concrete code, test or documentation defect has `kind: defect` and
+`needsHuman: false`, including a repair outside the service's automatic fix
+permissions. A coding agent with repository access can make that repair. Do
+not lower a defect's severity because the service cannot repair it. Missing
+coverage, tools, provider responses or verification are incomplete execution.
+
+Reserve `kind: product_decision` and `needsHuman: true` for a choice requiring
+human authority that the approved base has not settled. Supply `humanDecision`
+with a precise `question`, at least two `options` and their consequences, and a
+`recommendation`. Apply settled contracts and decisions: repairing a violation
+of an accepted requirement does not require asking whether to keep that
+requirement. Escalate a proposed change to the requirement itself, an
+irreversible migration/retention choice, or an unresolved authority boundary.
+The server independently enforces protected paths and human objections.
+
 
 Be concise: trigger, consequence, evidence, remedy. Preserve uncertainty and
 material decision tradeoffs.


### PR DESCRIPTION
Coding findings need an agent repair, even when they exceed Review Loop's permitted fixes. Update all four reviewer lenses to return coding defects with `needsHuman: false`, preserve their severity, and reserve human escalation for a concrete unresolved decision with options, consequences, and a recommendation. Apply existing trusted requirements and ADRs as settled decisions.

Remove obsolete human-routing examples for unresolved findings and incomplete verification. Document current-head `CHANGES_REQUESTED` as the coding signal, `needs-human-review` as the human signal, and incomplete runs as retry/operator work. Fix permissions and limits remain unchanged.

Depends on deployment of https://github.com/managoat/review-loop/pull/83 before merging because structured human decisions require the updated backend.

Validation: the real Review Loop policy loader accepts this policy (four reviewers, twenty verification commands, three-file fix limit); skill validation and diff checks pass. `mix precommit` was attempted but this isolated checkout has no fetched dependencies; rely on the required CI gate for the unchanged application code.
