### PR TITLE
fix(conversations): fail ACP turns stopped by runtime limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ upgrade, is in
 
 ### Fixed
 
+- ACP token/request limits and unknown stop reasons now fail the turn instead
+  of reporting completion. Reported usage and the original stop reason remain
+  available; only `end_turn` establishes normal completion (#1732).
+
 - The broker's root CA is installed under a lock, and the operating-system
   trust store is rebuilt only when the bundle on the machine is not the one
   that CA produces. Conversations sharing a sandbox each ran

--- a/apps/fountain/lib/fountain/conversations/turn_machine.ex
+++ b/apps/fountain/lib/fountain/conversations/turn_machine.ex
@@ -332,7 +332,9 @@ defmodule Fountain.Conversations.TurnMachine do
   # — the response is the only place the runtime reports it — before the turn
   # row is closed. nil records nothing.
   def handle(%__MODULE__{} = turn, {:done, stop_reason, usage}, ctx) do
-    status = if stop_reason in ["refusal", "cancelled"], do: "failed", else: "completed"
+    # An answered prompt is not necessarily finished work. Token/request limits
+    # and unknown future stop reasons must not become success for API consumers.
+    status = if stop_reason == "end_turn", do: "completed", else: "failed"
     record_usage(turn, with_inference(usage, ctx))
 
     {turn,

--- a/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
@@ -543,6 +543,36 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
       assert turn.status == "failed"
     end
 
+    for reason <- ["max_tokens", "max_turn_requests", "unknown_future_reason"] do
+      test "#{reason} fails the turn and retains its reported usage", %{
+        conv: conv,
+        pid: pid,
+        ref: ref
+      } do
+        prompt_id = drive_to_prompt(pid, ref)
+
+        reply(pid, ref, prompt_id, %{
+          "stopReason" => unquote(reason),
+          "usage" => %{"inputTokens" => 100, "outputTokens" => 25, "totalTokens" => 125}
+        })
+
+        assert [turn] = Conversations._unsafe_list_turns(conv.id)
+        assert turn.status == "failed"
+        assert turn.usage == %{"input" => 100, "output" => 25}
+        assert turn.ended_at
+
+        # A subsequent adapter exit cannot convert the incomplete turn to success
+        # or count its partial work twice.
+        send(pid, {:exit, %{ref: ref}, 0})
+        _ = :sys.get_state(pid)
+        assert [persisted] = Conversations._unsafe_list_turns(conv.id)
+        assert persisted.status == "failed"
+        conv = Conversations._unsafe_get_conversation!(conv.id)
+        assert conv.usage_input_tokens == 100
+        assert conv.usage_output_tokens == 25
+      end
+    end
+
     test "the conversation accepts another prompt afterwards", %{conv: conv, pid: pid, ref: ref} do
       prompt_id = drive_to_prompt(pid, ref)
       reply(pid, ref, prompt_id, %{"stopReason" => "end_turn"})


### PR DESCRIPTION
ACP `max_tokens` and `max_turn_requests` currently produce a completed Fountain turn. API consumers can therefore treat an exhausted worker as successful. Normal completion now requires `end_turn`; limits and unknown stop reasons fail the turn while retaining reported usage and the original stop metadata.

The peer-to-server regression cases also send a later zero exit and verify the failed outcome remains and usage is counted once. Existing refusal, cancellation and normal-completion behavior stays covered. This is a prerequisite for #1732, not a new execution-limit API or a claim of enforced spend caps.

Validation: all three new cases fail before the change; 108 focused tests pass afterward. Full `mix precommit --max-cases 8` passed, including strict analysis, production release assembly, 6 doctests and 4,582 tests (0 failures, 2 skipped, 7 excluded).

The initial full run with 20 cases produced database ownership/checkout timeouts and 596 failures. Its log is preserved; the same source passed with 8 cases and the unchanged 20-connection pool. Exact contention cause is not established. No assertions or timeouts were weakened.
