### PR TITLE
Distinguish completed source review from optional worker diagnostics

### DIFF
--- a/.github/review/api-compatibility.md
+++ b/.github/review/api-compatibility.md
@@ -45,8 +45,7 @@ remedy. Use stable rule and semantic anchor text for recurring findings.
 A concrete code, test or documentation defect has `kind: defect` and
 `needsHuman: false`, including a repair outside the service's automatic fix
 permissions. A coding agent with repository access can make that repair. Do
-not lower a defect's severity because the service cannot repair it. Missing
-coverage, tools, provider responses or verification are incomplete execution.
+not lower a defect's severity because the service cannot repair it. Missing required coverage or context is incomplete review, never a human decision.
 
 Reserve `kind: product_decision` and `needsHuman: true` for a choice requiring
 human authority that the approved base has not settled. Supply `humanDecision`
@@ -60,3 +59,12 @@ The server independently enforces protected paths and human objections.
 
 Be concise: trigger, consequence, evidence, remedy. Preserve uncertainty and
 material decision tradeoffs.
+
+`complete` describes completion of this source review, not whether diagnostic
+commands ran in this worker. The server executes the required verification
+commands independently before approval. An unavailable optional local test or
+missing worker dependency does not by itself make an otherwise completed source
+review incomplete. Inspect the changed code, relevant callers and regression
+assertions; do not claim tests passed when they did not. Return `complete: false`
+when missing files, required context or unresolved uncertainty prevents completing
+the review. Preserve any concrete findings supported by the files inspected.

--- a/.github/review/correctness.md
+++ b/.github/review/correctness.md
@@ -37,8 +37,7 @@ the service can consolidate duplicates and preserve discussion history.
 A concrete code, test or documentation defect has `kind: defect` and
 `needsHuman: false`, including a repair outside the service's automatic fix
 permissions. A coding agent with repository access can make that repair. Do
-not lower a defect's severity because the service cannot repair it. Missing
-coverage, tools, provider responses or verification are incomplete execution.
+not lower a defect's severity because the service cannot repair it. Missing required coverage or context is incomplete review, never a human decision.
 
 Reserve `kind: product_decision` and `needsHuman: true` for a choice requiring
 human authority that the approved base has not settled. Supply `humanDecision`
@@ -52,3 +51,12 @@ The server independently enforces protected paths and human objections.
 
 Be concise: trigger, consequence, evidence, remedy. Preserve uncertainty and
 material decision tradeoffs.
+
+`complete` describes completion of this source review, not whether diagnostic
+commands ran in this worker. The server executes the required verification
+commands independently before approval. An unavailable optional local test or
+missing worker dependency does not by itself make an otherwise completed source
+review incomplete. Inspect the changed code, relevant callers and regression
+assertions; do not claim tests passed when they did not. Return `complete: false`
+when missing files, required context or unresolved uncertainty prevents completing
+the review. Preserve any concrete findings supported by the files inspected.

--- a/.github/review/simplicity.md
+++ b/.github/review/simplicity.md
@@ -27,8 +27,7 @@ else's objection as a stylistic nit.
 A concrete code, test or documentation defect has `kind: defect` and
 `needsHuman: false`, including a repair outside the service's automatic fix
 permissions. A coding agent with repository access can make that repair. Do
-not lower a defect's severity because the service cannot repair it. Missing
-coverage, tools, provider responses or verification are incomplete execution.
+not lower a defect's severity because the service cannot repair it. Missing required coverage or context is incomplete review, never a human decision.
 
 Reserve `kind: product_decision` and `needsHuman: true` for a choice requiring
 human authority that the approved base has not settled. Supply `humanDecision`
@@ -42,3 +41,12 @@ The server independently enforces protected paths and human objections.
 
 Be concise: trigger, consequence, evidence, remedy. Preserve uncertainty and
 material decision tradeoffs.
+
+`complete` describes completion of this source review, not whether diagnostic
+commands ran in this worker. The server executes the required verification
+commands independently before approval. An unavailable optional local test or
+missing worker dependency does not by itself make an otherwise completed source
+review incomplete. Inspect the changed code, relevant callers and regression
+assertions; do not claim tests passed when they did not. Return `complete: false`
+when missing files, required context or unresolved uncertainty prevents completing
+the review. Preserve any concrete findings supported by the files inspected.

--- a/.github/review/tenant-isolation.md
+++ b/.github/review/tenant-isolation.md
@@ -47,8 +47,7 @@ Give recurring findings stable rule and semantic anchor text for deduplication.
 A concrete code, test or documentation defect has `kind: defect` and
 `needsHuman: false`, including a repair outside the service's automatic fix
 permissions. A coding agent with repository access can make that repair. Do
-not lower a defect's severity because the service cannot repair it. Missing
-coverage, tools, provider responses or verification are incomplete execution.
+not lower a defect's severity because the service cannot repair it. Missing required coverage or context is incomplete review, never a human decision.
 
 Reserve `kind: product_decision` and `needsHuman: true` for a choice requiring
 human authority that the approved base has not settled. Supply `humanDecision`
@@ -62,3 +61,12 @@ The server independently enforces protected paths and human objections.
 
 Be concise: trigger, consequence, evidence, remedy. Preserve uncertainty and
 material decision tradeoffs.
+
+`complete` describes completion of this source review, not whether diagnostic
+commands ran in this worker. The server executes the required verification
+commands independently before approval. An unavailable optional local test or
+missing worker dependency does not by itself make an otherwise completed source
+review incomplete. Inspect the changed code, relevant callers and regression
+assertions; do not claim tests passed when they did not. Return `complete: false`
+when missing files, required context or unresolved uncertainty prevents completing
+the review. Preserve any concrete findings supported by the files inspected.


### PR DESCRIPTION
Live Review Loop acceptance found that a reviewer completed its source inspection and confirmed the repair, but marked the review incomplete solely because its optional diagnostic tests could not download dependencies. The service already executes required verification independently.

Clarify all four reviewer instructions: complete describes completion of the assigned source review, not local diagnostic success. Missing files, required context or unresolved uncertainty still produce an incomplete report; optional unavailable worker tests alone do not. Never claim tests ran when they did not, and retain concrete findings supported by inspected source. Required verification and fix permissions remain unchanged.

Validation: diff checks pass; this is reviewer prose only. The required CI gate will validate the unchanged application tree. Companion Review Loop prompt clarification follows the same contract.
