### PR TITLE
feat: configure bounded environment setup timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ upgrade, is in
 
 ### Added
 
+- Environment `setup_timeout_seconds` (1–900, default 120) lets cold repository
+  toolchain setup run within an explicit bound. It persists through API/spec
+  round trips and invalidates checkpoints when changed. The overall provisioning
+  deadline and failed-setup handling remain in force.
+
 - Vault secret expiry can be edited in the console or with a metadata-only PATCH, without replacing the encrypted value.
 - Conversation lists accept a `sandbox_id` filter, including through the TypeScript SDK.
 

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -37,8 +37,9 @@ defmodule Fountain.Conversations.ConversationServer do
   }
 
   # Absolute ceiling on provisioning (#329). Generous against the summed
-  # per-step timeouts (packages 300s + clone 600s + setup 120s + slack), so
-  # it only ever fires when a step stalls without raising — the case where
+  # default step timeouts (packages 300s + clone 600s + setup 120s). Setup
+  # may opt into up to 900s, but this overall ceiling still applies. It also
+  # catches a step that stalls without raising — the case where
   # the row sat in `starting` holding a quota slot until the next deploy:
   # the reaper exempts rows whose server is alive, and the server's own
   # timers queue behind the stuck handle_continue. Overridable in tests.

--- a/apps/fountain/lib/fountain/conversations/provisioning.ex
+++ b/apps/fountain/lib/fountain/conversations/provisioning.ex
@@ -802,7 +802,7 @@ defmodule Fountain.Conversations.Provisioning do
   def run_setup_script(_handle, nil, _sprite_env, _conv_id), do: :ok
   def run_setup_script(_handle, %{setup_script: ""}, _sprite_env, _conv_id), do: :ok
 
-  def run_setup_script(handle, %{setup_script: script}, sprite_env, conv_id) do
+  def run_setup_script(handle, %{setup_script: script} = environment, sprite_env, conv_id) do
     Fountain.Telemetry.span(
       [:setup_script],
       %{conv_id: conv_id, script_size: byte_size(script)},
@@ -812,7 +812,7 @@ defmodule Fountain.Conversations.Provisioning do
         case Managoat.Sandbox.exec(handle, "bash", ["-lc", script],
                env: sprite_env,
                stderr_to_stdout: true,
-               timeout: 120_000
+               timeout: Map.get(environment, :setup_timeout_seconds, 120) * 1000
              ) do
           {:ok, output, code} ->
             Conversations.log!(%{

--- a/apps/fountain/lib/fountain/environments/environment.ex
+++ b/apps/fountain/lib/fountain/environments/environment.ex
@@ -71,7 +71,10 @@ defmodule Fountain.Environments.Environment do
     env
     |> cast(attrs, cast_fields())
     |> validate_required([:name, :setup_timeout_seconds])
-    |> validate_number(:setup_timeout_seconds, greater_than_or_equal_to: 1, less_than_or_equal_to: 900)
+    |> validate_number(:setup_timeout_seconds,
+      greater_than_or_equal_to: 1,
+      less_than_or_equal_to: 900
+    )
     |> validate_inclusion(:networking_type, @networking)
     |> validate_length(:name, min: 1, max: 200)
     |> validate_change(:networking_config, &validate_networking_config/2)

--- a/apps/fountain/lib/fountain/environments/environment.ex
+++ b/apps/fountain/lib/fountain/environments/environment.ex
@@ -18,6 +18,7 @@ defmodule Fountain.Environments.Environment do
     :packages,
     :env_vars,
     :setup_script,
+    :setup_timeout_seconds,
     :networking_type,
     :networking_config,
     :repositories
@@ -28,6 +29,7 @@ defmodule Fountain.Environments.Environment do
     field :packages, :map, default: %{}
     field :env_vars, :map, default: %{}
     field :setup_script, :string, default: ""
+    field :setup_timeout_seconds, :integer, default: 120
     field :networking_type, :string, default: "unrestricted"
     field :networking_config, :map, default: %{}
     field :repositories, {:array, :map}, default: []
@@ -56,6 +58,7 @@ defmodule Fountain.Environments.Environment do
       :packages,
       :env_vars,
       :setup_script,
+      :setup_timeout_seconds,
       :networking_type,
       :networking_config,
       :repositories,
@@ -67,7 +70,8 @@ defmodule Fountain.Environments.Environment do
   def changeset(env, attrs) do
     env
     |> cast(attrs, cast_fields())
-    |> validate_required([:name])
+    |> validate_required([:name, :setup_timeout_seconds])
+    |> validate_number(:setup_timeout_seconds, greater_than_or_equal_to: 1, less_than_or_equal_to: 900)
     |> validate_inclusion(:networking_type, @networking)
     |> validate_length(:name, min: 1, max: 200)
     |> validate_change(:networking_config, &validate_networking_config/2)

--- a/apps/fountain/lib/fountain/exports.ex
+++ b/apps/fountain/lib/fountain/exports.ex
@@ -374,6 +374,7 @@ defmodule Fountain.Exports do
         "packages" => env.packages,
         "env_vars" => env.env_vars,
         "setup_script" => env.setup_script,
+        "setup_timeout_seconds" => env.setup_timeout_seconds,
         "networking_type" => env.networking_type,
         "networking_config" => env.networking_config,
         "repositories" => env.repositories,

--- a/apps/fountain/lib/fountain_web/controllers/environment_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/environment_json.ex
@@ -12,6 +12,7 @@ defmodule FountainWeb.EnvironmentJSON do
       packages: env.packages,
       env_vars: env.env_vars,
       setup_script: env.setup_script,
+      setup_timeout_seconds: env.setup_timeout_seconds,
       networking_type: env.networking_type,
       networking_config: env.networking_config,
       repositories: env.repositories,

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -1174,7 +1174,8 @@ defmodule FountainWeb.Schemas do
           type: :integer,
           minimum: 1,
           maximum: 900,
-          description: "Setup exec timeout in seconds; defaults to 120. The overall provisioning deadline still applies."
+          description:
+            "Setup exec timeout in seconds; defaults to 120. The overall provisioning deadline still applies."
         },
         networking_type: %Schema{type: :string, enum: ~w(unrestricted limited)},
         networking_config: %Schema{
@@ -1238,7 +1239,8 @@ defmodule FountainWeb.Schemas do
           type: :integer,
           minimum: 1,
           maximum: 900,
-          description: "Setup exec timeout in seconds; defaults to 120. The overall provisioning deadline still applies."
+          description:
+            "Setup exec timeout in seconds; defaults to 120. The overall provisioning deadline still applies."
         },
         networking_type: %Schema{type: :string, enum: ~w(unrestricted limited)},
         networking_config: %Schema{
@@ -1280,7 +1282,8 @@ defmodule FountainWeb.Schemas do
           type: :integer,
           minimum: 1,
           maximum: 900,
-          description: "Setup exec timeout in seconds; defaults to 120. The overall provisioning deadline still applies."
+          description:
+            "Setup exec timeout in seconds; defaults to 120. The overall provisioning deadline still applies."
         },
         networking_type: %Schema{type: :string, enum: ~w(unrestricted limited)},
         networking_config: %Schema{

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -1170,6 +1170,12 @@ defmodule FountainWeb.Schemas do
         packages: %Schema{type: :object, additionalProperties: true},
         env_vars: %Schema{type: :object, additionalProperties: %Schema{type: :string}},
         setup_script: %Schema{type: :string},
+        setup_timeout_seconds: %Schema{
+          type: :integer,
+          minimum: 1,
+          maximum: 900,
+          description: "Setup exec timeout in seconds; defaults to 120. The overall provisioning deadline still applies."
+        },
         networking_type: %Schema{type: :string, enum: ~w(unrestricted limited)},
         networking_config: %Schema{
           type: :object,
@@ -1228,6 +1234,12 @@ defmodule FountainWeb.Schemas do
         packages: %Schema{type: :object, additionalProperties: true},
         env_vars: %Schema{type: :object, additionalProperties: %Schema{type: :string}},
         setup_script: %Schema{type: :string},
+        setup_timeout_seconds: %Schema{
+          type: :integer,
+          minimum: 1,
+          maximum: 900,
+          description: "Setup exec timeout in seconds; defaults to 120. The overall provisioning deadline still applies."
+        },
         networking_type: %Schema{type: :string, enum: ~w(unrestricted limited)},
         networking_config: %Schema{
           type: :object,
@@ -1264,6 +1276,12 @@ defmodule FountainWeb.Schemas do
         packages: %Schema{type: :object, additionalProperties: true},
         env_vars: %Schema{type: :object, additionalProperties: %Schema{type: :string}},
         setup_script: %Schema{type: :string},
+        setup_timeout_seconds: %Schema{
+          type: :integer,
+          minimum: 1,
+          maximum: 900,
+          description: "Setup exec timeout in seconds; defaults to 120. The overall provisioning deadline still applies."
+        },
         networking_type: %Schema{type: :string, enum: ~w(unrestricted limited)},
         networking_config: %Schema{
           type: :object,

--- a/apps/fountain/priv/repo/migrations/20260907150000_add_environment_setup_timeout.exs
+++ b/apps/fountain/priv/repo/migrations/20260907150000_add_environment_setup_timeout.exs
@@ -1,0 +1,13 @@
+defmodule Fountain.Repo.Migrations.AddEnvironmentSetupTimeout do
+  use Ecto.Migration
+
+  def change do
+    alter table(:environments) do
+      add :setup_timeout_seconds, :integer, null: false, default: 120
+    end
+
+    create constraint(:environments, :setup_timeout_seconds_range,
+             check: "setup_timeout_seconds BETWEEN 1 AND 900"
+           )
+  end
+end

--- a/apps/fountain/test/fountain/conversations/provisioning_steps_test.exs
+++ b/apps/fountain/test/fountain/conversations/provisioning_steps_test.exs
@@ -85,6 +85,7 @@ defmodule Fountain.Conversations.ProvisioningStepsTest do
       stub(Managoat.Sandbox, :exec, fn _handle, "bash", ["-lc", "echo hi"], opts ->
         assert opts[:env] == sprite_env
         assert opts[:stderr_to_stdout]
+        assert opts[:timeout] == 120_000
         {:ok, "hi\n", 0}
       end)
 
@@ -104,6 +105,24 @@ defmodule Fountain.Conversations.ProvisioningStepsTest do
                )
 
       assert stages(conv.id, "setup") == [{"started", %{}}, {"done", %{"exit_code" => 0}}]
+    end
+
+    test "a persisted timeout reaches exec and timeout remains failed setup" do
+      conv = insert_conversation()
+      env = insert_env(setup_script: "install-dependencies", setup_timeout_seconds: 900)
+
+      expect(Managoat.Sandbox, :exec, fn _handle, "bash", ["-lc", "install-dependencies"], opts ->
+        assert opts[:timeout] == 900_000
+        {:error, :timeout}
+      end)
+
+      assert {:error, {:setup_unreachable, :timeout}} =
+               Provisioning.run_setup_script(handle(), env, [], conv.id)
+
+      assert stages(conv.id, "setup") == [
+               {"started", %{}},
+               {"failed", %{"reason" => ":timeout"}}
+             ]
     end
 
     test "a non-zero exit is the step's failure, with the exit code" do

--- a/apps/fountain/test/fountain/environments/environment_test.exs
+++ b/apps/fountain/test/fountain/environments/environment_test.exs
@@ -20,12 +20,13 @@ defmodule Fountain.Environments.EnvironmentTest do
   # ---------------------------------------------------------------------------
 
   describe "warm_start_fields/0" do
-    test "returns the 6 expected warm-start fields" do
+    test "returns the expected warm-start fields" do
       assert Environment.warm_start_fields() ==
                [
                  :packages,
                  :env_vars,
                  :setup_script,
+                 :setup_timeout_seconds,
                  :networking_type,
                  :networking_config,
                  :repositories

--- a/apps/fountain/test/fountain/environments_test.exs
+++ b/apps/fountain/test/fountain/environments_test.exs
@@ -19,6 +19,36 @@ defmodule Fountain.EnvironmentsTest do
     end
   end
 
+  describe "setup timeout" do
+    test "defaults to two minutes and validates persisted bounds" do
+      user = insert_verified_user()
+      assert insert_env(user_id: user.id).setup_timeout_seconds == 120
+
+      for seconds <- [1, 900] do
+        env = insert_env(user_id: user.id, setup_timeout_seconds: seconds)
+        assert Environments.get_environment!(env.id, user.id).setup_timeout_seconds == seconds
+      end
+
+      for invalid <- [0, 901, -1, 1.5, nil] do
+        assert {:error, changeset} =
+                 Environments.create_environment(
+                   env_attrs(user_id: user.id, setup_timeout_seconds: invalid)
+                 )
+
+        assert Keyword.has_key?(changeset.errors, :setup_timeout_seconds)
+      end
+    end
+
+    test "changing the timeout invalidates the provisioning checkpoint" do
+      user = insert_verified_user()
+      env = insert_env(user_id: user.id, checkpoint_id: "old-checkpoint")
+      assert {:ok, updated} = Environments.update_environment(env, %{setup_timeout_seconds: 900})
+      assert updated.checkpoint_id == nil
+      assert {:ok, renamed} = Environments.update_environment(updated, %{name: "renamed"})
+      assert renamed.setup_timeout_seconds == 900
+    end
+  end
+
   describe "get_environment/2" do
     test "returns environment scoped to user" do
       user = insert_verified_user()

--- a/apps/fountain/test/fountain_web/controllers/environment_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/environment_controller_test.exs
@@ -103,6 +103,56 @@ defmodule FountainWeb.EnvironmentControllerTest do
     end
   end
 
+  test "setup timeout round-trips without allowing another tenant to update it", %{
+    conn: conn,
+    raw_key: raw_key
+  } do
+    created =
+      conn
+      |> authed_with_key(raw_key)
+      |> post_json("/api/environments", %{name: "long-setup", setup_timeout_seconds: 900})
+      |> json_response(201)
+
+    id = created["data"]["id"]
+    assert created["data"]["setup_timeout_seconds"] == 900
+
+    updated =
+      build_conn()
+      |> authed_with_key(raw_key)
+      |> put_json("/api/environments/#{id}", %{setup_timeout_seconds: 600})
+      |> json_response(200)
+
+    assert updated["data"]["setup_timeout_seconds"] == 600
+    {_other_key, other_raw} = insert_api_key(insert_verified_user())
+
+    denied =
+      build_conn()
+      |> authed_with_key(other_raw)
+      |> put_json("/api/environments/#{id}", %{setup_timeout_seconds: 1})
+
+    assert json_response(denied, 404)
+
+    fetched =
+      build_conn()
+      |> authed_with_key(raw_key)
+      |> get("/api/environments/#{id}")
+      |> json_response(200)
+
+    assert fetched["data"]["setup_timeout_seconds"] == 600
+  end
+
+  test "setup timeout outside the allowed range is refused by the API", %{
+    conn: conn,
+    raw_key: raw_key
+  } do
+    response =
+      conn
+      |> authed_with_key(raw_key)
+      |> post_json("/api/environments", %{name: "unbounded-setup", setup_timeout_seconds: 901})
+
+    assert json_response(response, 422)
+  end
+
   describe "PUT /api/environments/:id" do
     test "updates the environment and returns 200", %{conn: conn, user: user, raw_key: raw_key} do
       env = insert_env(user_id: user.id)

--- a/docs/concepts/environment.md
+++ b/docs/concepts/environment.md
@@ -70,6 +70,12 @@ CLI's `${VAR}` substitution and secret-manager references resolve against.
 `packages` has two keys that install software, `apt` and `npm`. Other
 language toolchains go in `setup_script`.
 
+`setup_timeout_seconds` sets the setup exec timeout (1–900 seconds, default
+120). Use the API or an environment spec to give cold dependency/toolchain
+installation more time. Changing it invalidates the environment checkpoint.
+The overall 30-minute provisioning deadline still applies; a failed or timed-out
+setup does not start the agent. This controls setup, not inference time or spend.
+
 ### The network policy is not symmetric
 
 `unrestricted` does nothing. A Sprites sandbox is open by default, so the

--- a/sdk/contract/contract.json
+++ b/sdk/contract/contract.json
@@ -10427,6 +10427,10 @@
           "required": false,
           "type": "string"
         },
+        "setup_timeout_seconds": {
+          "required": false,
+          "type": "integer"
+        },
         "updated_at": {
           "format": "date-time",
           "required": false,
@@ -10502,6 +10506,10 @@
         "setup_script": {
           "required": false,
           "type": "string"
+        },
+        "setup_timeout_seconds": {
+          "required": false,
+          "type": "integer"
         }
       },
       "type": "object"
@@ -10570,6 +10578,10 @@
         "setup_script": {
           "required": false,
           "type": "string"
+        },
+        "setup_timeout_seconds": {
+          "required": false,
+          "type": "integer"
         }
       },
       "type": "object"

--- a/sdk/contract/manifests/swift.json
+++ b/sdk/contract/manifests/swift.json
@@ -97,7 +97,7 @@
     "ConversationListResponse": { "required": ["data"] },
     "ConversationResponse": { "required": ["data"] },
     "ConversationTreeResponse": { "required": ["data"] },
-    "Environment": { "required": ["id", "name"] },
+    "Environment": { "required": ["id", "name"], "optional": ["setup_timeout_seconds"] },
     "EnvironmentListResponse": { "required": ["data"] },
     "EnvironmentResponse": { "required": ["data"] },
     "Error": { "required": ["error"] },

--- a/sdk/swift/Sources/FountainKit/Models/Environments.swift
+++ b/sdk/swift/Sources/FountainKit/Models/Environments.swift
@@ -8,6 +8,7 @@ public struct Environment: Sendable, Decodable, Identifiable, Hashable {
   public var packages: JSONValue?
   public var envVars: [String: String]?
   public var setupScript: String?
+  public var setupTimeoutSeconds: Int?
   public var networkingType: NetworkingType?
   public var networkingConfig: JSONValue?
   public var repositories: [JSONValue]?
@@ -21,6 +22,7 @@ public struct Environment: Sendable, Decodable, Identifiable, Hashable {
     case id, name, packages, repositories, metadata
     case envVars = "env_vars"
     case setupScript = "setup_script"
+    case setupTimeoutSeconds = "setup_timeout_seconds"
     case networkingType = "networking_type"
     case networkingConfig = "networking_config"
     case secretCount = "secret_count"
@@ -35,6 +37,7 @@ public struct EnvironmentInput: Sendable, Encodable {
   public var packages: JSONValue?
   public var envVars: [String: String]?
   public var setupScript: String?
+  public var setupTimeoutSeconds: Int?
   public var networkingType: NetworkingType?
   public var networkingConfig: JSONValue?
   public var repositories: [JSONValue]?
@@ -45,6 +48,7 @@ public struct EnvironmentInput: Sendable, Encodable {
     packages: JSONValue? = nil,
     envVars: [String: String]? = nil,
     setupScript: String? = nil,
+    setupTimeoutSeconds: Int? = nil,
     networkingType: NetworkingType? = nil,
     networkingConfig: JSONValue? = nil,
     repositories: [JSONValue]? = nil,
@@ -54,6 +58,7 @@ public struct EnvironmentInput: Sendable, Encodable {
     self.packages = packages
     self.envVars = envVars
     self.setupScript = setupScript
+    self.setupTimeoutSeconds = setupTimeoutSeconds
     self.networkingType = networkingType
     self.networkingConfig = networkingConfig
     self.repositories = repositories
@@ -64,6 +69,7 @@ public struct EnvironmentInput: Sendable, Encodable {
     case name, packages, repositories, metadata
     case envVars = "env_vars"
     case setupScript = "setup_script"
+    case setupTimeoutSeconds = "setup_timeout_seconds"
     case networkingType = "networking_type"
     case networkingConfig = "networking_config"
   }

--- a/sdk/swift/Tests/FountainKitTests/EnvironmentSetupTests.swift
+++ b/sdk/swift/Tests/FountainKitTests/EnvironmentSetupTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+
 @testable import FountainKit
 
 @Test func environmentSetupTimeoutRoundTrips() throws {
@@ -12,5 +13,6 @@ import Testing
   let environment = try JSONDecoder().decode(FountainKit.Environment.self, from: payload)
   #expect(environment.setupTimeoutSeconds == 900)
   let older = Data(#"{"id":"env","name":"reviewer"}"#.utf8)
-  #expect(try JSONDecoder().decode(FountainKit.Environment.self, from: older).setupTimeoutSeconds == nil)
+  #expect(
+    try JSONDecoder().decode(FountainKit.Environment.self, from: older).setupTimeoutSeconds == nil)
 }

--- a/sdk/swift/Tests/FountainKitTests/EnvironmentSetupTests.swift
+++ b/sdk/swift/Tests/FountainKitTests/EnvironmentSetupTests.swift
@@ -1,0 +1,16 @@
+import Foundation
+import Testing
+@testable import FountainKit
+
+@Test func environmentSetupTimeoutRoundTrips() throws {
+  let input = EnvironmentInput(name: "reviewer", setupTimeoutSeconds: 900)
+  let encoded = try JSONEncoder().encode(input)
+  let json = try JSONSerialization.jsonObject(with: encoded) as! [String: Any]
+  #expect(json["setup_timeout_seconds"] as? Int == 900)
+
+  let payload = Data(#"{"id":"env","name":"reviewer","setup_timeout_seconds":900}"#.utf8)
+  let environment = try JSONDecoder().decode(FountainKit.Environment.self, from: payload)
+  #expect(environment.setupTimeoutSeconds == 900)
+  let older = Data(#"{"id":"env","name":"reviewer"}"#.utf8)
+  #expect(try JSONDecoder().decode(FountainKit.Environment.self, from: older).setupTimeoutSeconds == nil)
+}

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -10,6 +10,13 @@ server releases.
 
 ---
 
+## [1.23.0] - 2026-09-07
+
+### Added
+
+- Environment creation, update and response types expose `setup_timeout_seconds`
+  (1–900, default 120) for bounded cold setup.
+
 ## [1.22.0] — 2026-09-07
 
 ### Changed

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentshit/fountain-sdk",
-      "version": "1.22.0",
+      "version": "1.23.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^26.4.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "description": "Run a coding agent on a real computer, with your repos and your credentials, in one call.",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -3723,6 +3723,8 @@ export interface components {
             /** @description Secrets stored on this environment. */
             secret_count?: number;
             setup_script?: string;
+            /** @description Setup exec timeout in seconds; defaults to 120. The overall provisioning deadline still applies. */
+            setup_timeout_seconds?: number;
             /** Format: date-time */
             updated_at?: string;
         };
@@ -3753,6 +3755,8 @@ export interface components {
             };
             repositories?: components["schemas"]["Repository"][];
             setup_script?: string;
+            /** @description Setup exec timeout in seconds; defaults to 120. The overall provisioning deadline still applies. */
+            setup_timeout_seconds?: number;
         };
         /** EnvironmentResponse */
         EnvironmentResponse: {
@@ -3781,6 +3785,8 @@ export interface components {
             };
             repositories?: components["schemas"]["Repository"][];
             setup_script?: string;
+            /** @description Setup exec timeout in seconds; defaults to 120. The overall provisioning deadline still applies. */
+            setup_timeout_seconds?: number;
         };
         /** Error */
         Error: {

--- a/sdk/typescript/src/http.ts
+++ b/sdk/typescript/src/http.ts
@@ -19,7 +19,7 @@ export interface RequestOptions {
  * this string is already what Fountain's request logs are keyed on. The
  * version half is asserted against `package.json` by a test.
  */
-export const USER_AGENT = "fountain-sdk-js/1.22.0";
+export const USER_AGENT = "fountain-sdk-js/1.23.0";
 
 /**
  * The thin layer everything else is built on: one bearer token, JSON in and


### PR DESCRIPTION
Cold reviewer toolchain/database setup cannot fit Fountain’s fixed two-minute setup timeout. Add persisted `setup_timeout_seconds` to environments: 1–900 seconds, default 120, validated at the changeset/API and database boundaries. Provisioning passes it to exec; changing it invalidates the checkpoint. The overall 30-minute provisioning deadline still applies.

API responses, exports, OpenAPI and TypeScript/Swift models carry the field. TypeScript SDK 1.23.0 publishes the additive types. Existing setup failure handling remains in force; a longer timeout is not permission to start a model after failed setup. Review Loop supplies its own process-group timeout and original run deadline in [PR #90](https://github.com/managoat/review-loop/pull/90).

Validation: full `mix precommit --max-cases 8` passed (4,587 tests plus six doctests, zero failures; two skipped, seven excluded), including strict analysis and production assembly. API tests prove second-tenant update denial; tests cover bounds, persistence, checkpoint invalidation and exec timeout failure. TypeScript: 103 tests, typecheck/build/contract, 24 conformance scenarios. Swift: 78 tests. OpenAPI contract regenerated.

The first full suite caught an outdated checkpoint-field assertion; it now includes the new field. Local SDK conformance required loopback access (the restricted environment returns EPERM); the complete permitted run passed. Live setup and repository enrollment remain pending in [Review Loop #88](https://github.com/managoat/review-loop/issues/88).
