### PR TITLE
chore: prepare reviewer dependencies through the trusted broker

### DIFF
--- a/.github/review-loop.yml
+++ b/.github/review-loop.yml
@@ -5,18 +5,26 @@ reviewers:
     runtime: codex
     model: openai/gpt-6-astra
     instructions: .github/review/correctness.md
+    setup: .github/review/reviewer-setup.sh
+    setup_timeout_minutes: 15
   - id: security-audit
     runtime: codex
     model: openai/gpt-6-astra
     instructions: .github/review/tenant-isolation.md
+    setup: .github/review/reviewer-setup.sh
+    setup_timeout_minutes: 15
   - id: product-api
     runtime: claude
     model: anthropic/opus
     instructions: .github/review/api-compatibility.md
+    setup: .github/review/reviewer-setup.sh
+    setup_timeout_minutes: 15
   - id: xp-reviewer
     runtime: claude
     model: anthropic/opus
     instructions: .github/review/simplicity.md
+    setup: .github/review/reviewer-setup.sh
+    setup_timeout_minutes: 15
 triage:
   blocking_severity: medium
   accept_nonblocking: true

--- a/.github/review/README.md
+++ b/.github/review/README.md
@@ -1,95 +1,20 @@
-# Fountain Review Loop
+# Reviewer workspace
 
-Four independent reviewers examine the entire current PR, including any fixes:
+`reviewer-setup.sh` prepares the exact PR checkout using the verifier bootstrap
+from `REVIEW_LOOP_BASE`, then installs locked Hex dependencies and migrates a
+local test database. Review Loop loads this script from the approved base and
+bounds setup to 15 minutes. A changed tracked file or failed setup stops review.
 
-| Reviewer | Runtime / model | Focus |
-|---|---|---|
-| `qa-team` | Codex / GPT-6 Astra | Correctness, regression tests, database behavior, concurrency and recovery |
-| `security-audit` | Codex / GPT-6 Astra | Tenant isolation, secrets, injection and authorization boundaries |
-| `product-api` | Claude / Opus | Documented product intent, naming, rollout and client compatibility |
-| `xp-reviewer` | Claude / Opus | Simplicity, useful tests and maintainability |
+Run diagnostics through `rl-env`. Setup success is not a passing test result;
+independent service verification still decides whether the revision passes.
 
-The PostHog-inspired cycle is review → triage → permitted fix → checks and
-independent verification → four fresh reviews. Review Loop posts inline finding
-threads and keeps one summary for the run updated. It consolidates duplicate
-findings, accepts low/info suggestions as nonblocking, and retains explanations.
-It resolves service-owned threads when policy permits; human objections remain
-blockers until a maintainer addresses them.
+Hex 2.5.1 passes only a proxy host/port to Erlang httpc, so it cannot directly
+use Fountain's HTTPS proxy. The recipe starts a loopback-only socat relay and
+wraps `rl-env` to use it. The remote connection validates the broker's certificate
+chain and hostname; authentication stays in process environments. The relay and
+database belong to this ephemeral worker and end when it is deleted.
 
-Clear medium-or-higher defects can receive an automatic fix within the
-configured file and path bounds. The host enforces the configured file bound,
-permitted paths, three-round limit, exact-revision checks and final approval.
-Confidence is a reviewer judgment, not a separate numeric score enforced by
-the host. This setup does not impersonate Paul or launch an interactive
-pairing agent.
-
-Review Loop separates the next actor from the severity of a finding. Confirmed
-code defects receive a commit-specific GitHub `CHANGES_REQUESTED` review when
-the automatic fixer cannot complete them. A coding agent can make those repairs
-under its own repository authorization, including outside the bot's path or
-file allowance. Low/info defects remain nonblocking when policy permits.
-
-`needs-human-review` is reserved for an unsettled decision or explicit approval
-requirement. Reviewers use `kind: product_decision`, `needsHuman: true`, and a
-`humanDecision` containing the question, alternatives with consequences, and
-recommendation. Apply requirements already settled by the approved base: a
-repair restoring an accepted ADR is ordinary coding work; changing the ADR's
-decision needs authority. The trusted `human_review_paths` still cover review
-policy, workflows, migrations, licensing, deployment/release definitions, gate
-controls and ADR changes. Automatic fixer permissions remain unchanged.
-
-A PR with both repairs and a decision receives both signals. Provider failures,
-missing evidence and uncertainty alone are incomplete execution, not a human
-decision. The run API exposes `outcome`, `humanReviewRequired`, and reasons for
-routing. Check App identity and current commit before reacting to review events.
-
-An approval covers the entire evaluated PR and never merges it. A new revision,
-failed check or human objection can invalidate an earlier approval. Repository
-policy and all reviewer/setup instructions come from the trusted base revision.
-A PR cannot authorize itself by editing these files.
-
-Reviewer runtimes and models are pinned in `.github/review-loop.yml`. The fixer
-uses the operator-selected default. Parallelism is bounded by host and Fountain capacity. The repository policy permits four
-reviewers at once, 30 tasks, 50,000,000 reported tokens and 120 minutes per run.
-Daily budgets are separate operator settings. Neither token nor task counts
-are dollar-cost reporting.
-
-## Verification and activation
-
-`setup.sh` installs pinned, hash-checked toolchains on a fresh Ubuntu 24.04 or
-26.04 worker before PR checkout, plus a disposable local PostgreSQL database
-(the supported distro major, 16 or 18). GitHub CI separately verifies PostgreSQL 16.
-Twenty commands run the core/ee partitions, extension and single-VM umbrella
-tests, precommit static checks, Dialyzer, prod release assembly,
-contracts, SDKs, CLIs and plugin tests. The eight required workflow definitions
-and their path filters were checked against Fountain main at
-`539a300207728bebc5216af586e497ce07778f94`. GitHub CI additionally supplies
-coverage, release boot, Swift, docs and distribution gates. No failed
-gate is skipped or changed to get an approval.
-
-An existing Go guest-handshake fixture race is tracked in
-[#1641](https://github.com/BinaryBourbon/fountain/issues/1641), reproduced in
-2 of 100 focused local runs on the inspected main revision. Its gate remains
-enabled. A confirmed failed check requests changes; missing execution is incomplete;
-rerunning until it turns green is not evidence that the defect was fixed.
-
-Deploy Review Loop outcome-routing support before using these reviewer contracts.
-The expanded recipe needs a thirty-minute command allowance: its measured cold
-Credo/Dialyzer stage took about 23 minutes and the full recipe about 48 minutes.
-See [measured command budget](verification.md#measured-command-budget).
-
-Merge this configuration through Fountain's normal reviewed PR process. Its
-own changes require human review; no live run can use its policy before merge.
-The dispatch workflow uses the public `managoat/review-loop-action` at an
-immutable release commit, with no inline script. Configure repository variables
-`REVIEW_LOOP_URL` to
-`https://review-loop.demo.managoat.com` and `REVIEW_LOOP_ENABLED` to `true` after
-the policy is trusted. The workflow admits opened, updated, reopened or
-ready-for-review PRs from branches in this repository. Draft and fork PRs are
-excluded. Existing PRs need a subsequent event or an explicit run from the app.
-
-Repository access comes from the Managoat Review Loop GitHub App installation;
-no Fountain login or inference secret belongs in repository Actions secrets.
-To stop automatic admission, set `REVIEW_LOOP_ENABLED` to `false`; cancel active
-runs separately in Review Loop. Maintainer commands and decisions are documented
-in the service's [GitHub lifecycle guide](https://github.com/managoat/review-loop/blob/main/docs/GITHUB-LIFECYCLE.md).
+Test the relay with `python3 scripts/test-reviewer-proxy.py` on Linux with Python 3,
+OpenSSL, and socat installed. It executes the recipe's relay code using temporary
+paths and local certificates, covering valid TLS, wrong hostnames, untrusted
+issuers, changed endpoints, and credential placement. It needs no provider keys.

--- a/.github/review/README.md
+++ b/.github/review/README.md
@@ -1,4 +1,100 @@
-# Reviewer workspace
+# Fountain Review Loop
+
+Four independent reviewers examine the entire current PR, including any fixes:
+
+| Reviewer | Runtime / model | Focus |
+|---|---|---|
+| `qa-team` | Codex / GPT-6 Astra | Correctness, regression tests, database behavior, concurrency and recovery |
+| `security-audit` | Codex / GPT-6 Astra | Tenant isolation, secrets, injection and authorization boundaries |
+| `product-api` | Claude / Opus | Documented product intent, naming, rollout and client compatibility |
+| `xp-reviewer` | Claude / Opus | Simplicity, useful tests and maintainability |
+
+The PostHog-inspired cycle is review → triage → permitted fix → checks and
+independent verification → four fresh reviews. Review Loop posts inline finding
+threads and keeps one summary for the run updated. It consolidates duplicate
+findings, accepts low/info suggestions as nonblocking, and retains explanations.
+It resolves service-owned threads when policy permits; human objections remain
+blockers until a maintainer addresses them.
+
+Clear medium-or-higher defects can receive an automatic fix within the
+configured file and path bounds. The host enforces the configured file bound,
+permitted paths, three-round limit, exact-revision checks and final approval.
+Confidence is a reviewer judgment, not a separate numeric score enforced by
+the host. This setup does not impersonate Paul or launch an interactive
+pairing agent.
+
+Review Loop separates the next actor from the severity of a finding. Confirmed
+code defects receive a commit-specific GitHub `CHANGES_REQUESTED` review when
+the automatic fixer cannot complete them. A coding agent can make those repairs
+under its own repository authorization, including outside the bot's path or
+file allowance. Low/info defects remain nonblocking when policy permits.
+
+`needs-human-review` is reserved for an unsettled decision or explicit approval
+requirement. Reviewers use `kind: product_decision`, `needsHuman: true`, and a
+`humanDecision` containing the question, alternatives with consequences, and
+recommendation. Apply requirements already settled by the approved base: a
+repair restoring an accepted ADR is ordinary coding work; changing the ADR's
+decision needs authority. The trusted `human_review_paths` still cover review
+policy, workflows, migrations, licensing, deployment/release definitions, gate
+controls and ADR changes. Automatic fixer permissions remain unchanged.
+
+A PR with both repairs and a decision receives both signals. Provider failures,
+missing evidence and uncertainty alone are incomplete execution, not a human
+decision. The run API exposes `outcome`, `humanReviewRequired`, and reasons for
+routing. Check App identity and current commit before reacting to review events.
+
+An approval covers the entire evaluated PR and never merges it. A new revision,
+failed check or human objection can invalidate an earlier approval. Repository
+policy and all reviewer/setup instructions come from the trusted base revision.
+A PR cannot authorize itself by editing these files.
+
+Reviewer runtimes and models are pinned in `.github/review-loop.yml`. The fixer
+uses the operator-selected default. Parallelism is bounded by host and Fountain capacity. The repository policy permits four
+reviewers at once, 30 tasks, 50,000,000 reported tokens and 120 minutes per run.
+Daily budgets are separate operator settings. Neither token nor task counts
+are dollar-cost reporting.
+
+## Verification and activation
+
+`setup.sh` installs pinned, hash-checked toolchains on a fresh Ubuntu 24.04 or
+26.04 worker before PR checkout, plus a disposable local PostgreSQL database
+(the supported distro major, 16 or 18). GitHub CI separately verifies PostgreSQL 16.
+Twenty commands run the core/ee partitions, extension and single-VM umbrella
+tests, precommit static checks, Dialyzer, prod release assembly,
+contracts, SDKs, CLIs and plugin tests. The eight required workflow definitions
+and their path filters were checked against Fountain main at
+`539a300207728bebc5216af586e497ce07778f94`. GitHub CI additionally supplies
+coverage, release boot, Swift, docs and distribution gates. No failed
+gate is skipped or changed to get an approval.
+
+An existing Go guest-handshake fixture race is tracked in
+[#1641](https://github.com/BinaryBourbon/fountain/issues/1641), reproduced in
+2 of 100 focused local runs on the inspected main revision. Its gate remains
+enabled. A confirmed failed check requests changes; missing execution is incomplete;
+rerunning until it turns green is not evidence that the defect was fixed.
+
+Deploy Review Loop outcome-routing support before using these reviewer contracts.
+The expanded recipe needs a thirty-minute command allowance: its measured cold
+Credo/Dialyzer stage took about 23 minutes and the full recipe about 48 minutes.
+See [measured command budget](verification.md#measured-command-budget).
+
+Merge this configuration through Fountain's normal reviewed PR process. Its
+own changes require human review; no live run can use its policy before merge.
+The dispatch workflow uses the public `managoat/review-loop-action` at an
+immutable release commit, with no inline script. Configure repository variables
+`REVIEW_LOOP_URL` to
+`https://review-loop.demo.managoat.com` and `REVIEW_LOOP_ENABLED` to `true` after
+the policy is trusted. The workflow admits opened, updated, reopened or
+ready-for-review PRs from branches in this repository. Draft and fork PRs are
+excluded. Existing PRs need a subsequent event or an explicit run from the app.
+
+Repository access comes from the Managoat Review Loop GitHub App installation;
+no Fountain login or inference secret belongs in repository Actions secrets.
+To stop automatic admission, set `REVIEW_LOOP_ENABLED` to `false`; cancel active
+runs separately in Review Loop. Maintainer commands and decisions are documented
+in the service's [GitHub lifecycle guide](https://github.com/managoat/review-loop/blob/main/docs/GITHUB-LIFECYCLE.md).
+
+## Reviewer workspace preparation
 
 `reviewer-setup.sh` prepares the exact PR checkout using the verifier bootstrap
 from `REVIEW_LOOP_BASE`, then installs locked Hex dependencies and migrates a

--- a/.github/review/README.md
+++ b/.github/review/README.md
@@ -99,7 +99,7 @@ in the service's [GitHub lifecycle guide](https://github.com/managoat/review-loo
 `reviewer-setup.sh` prepares the exact PR checkout using the verifier bootstrap
 from `REVIEW_LOOP_BASE`, then installs locked Hex dependencies and migrates a
 local test database. Review Loop loads this script from the approved base and
-bounds setup to 15 minutes. A changed tracked file or failed setup stops review.
+bounds setup to 15 minutes; the [cold preparation sample](verification.md#measured-reviewer-preparation) took 6m30s including a targeted test. A changed tracked file or failed setup stops review.
 
 Run diagnostics through `rl-env`. Setup success is not a passing test result;
 independent service verification still decides whether the revision passes.
@@ -114,3 +114,6 @@ Test the relay with `python3 scripts/test-reviewer-proxy.py` on Linux with Pytho
 OpenSSL, and socat installed. It executes the recipe's relay code using temporary
 paths and local certificates, covering valid TLS, wrong hostnames, untrusted
 issuers, changed endpoints, and credential placement. It needs no provider keys.
+
+`python3 scripts/test-reviewer-setup-cwd.py` checks that bootstrap ignores PR-local
+Python modules while repository dependency/database commands enter the checkout.

--- a/.github/review/api-compatibility.md
+++ b/.github/review/api-compatibility.md
@@ -68,3 +68,9 @@ review incomplete. Inspect the changed code, relevant callers and regression
 assertions; do not claim tests passed when they did not. Return `complete: false`
 when missing files, required context or unresolved uncertainty prevents completing
 the review. Preserve any concrete findings supported by the files inspected.
+
+The service prepares this reviewer with trusted toolchains, dependencies and a
+local test database before your turn. Run targeted diagnostic commands through
+`rl-env` (for example `rl-env mix test path/to/test.exs`) so they use the prepared
+BEAM and database. Setup success does not mean tests passed; report actual command
+results and missing evidence. Independent service verification remains required.

--- a/.github/review/correctness.md
+++ b/.github/review/correctness.md
@@ -60,3 +60,9 @@ review incomplete. Inspect the changed code, relevant callers and regression
 assertions; do not claim tests passed when they did not. Return `complete: false`
 when missing files, required context or unresolved uncertainty prevents completing
 the review. Preserve any concrete findings supported by the files inspected.
+
+The service prepares this reviewer with trusted toolchains, dependencies and a
+local test database before your turn. Run targeted diagnostic commands through
+`rl-env` (for example `rl-env mix test path/to/test.exs`) so they use the prepared
+BEAM and database. Setup success does not mean tests passed; report actual command
+results and missing evidence. Independent service verification remains required.

--- a/.github/review/reviewer-setup.sh
+++ b/.github/review/reviewer-setup.sh
@@ -1,0 +1,93 @@
+#!/bin/sh
+# Review Loop executes these bytes from the approved base after exact-head checkout.
+set -eu
+: "${REVIEW_LOOP_BASE:?missing trusted base}"
+: "${REVIEW_LOOP_HEAD:?missing expected head}"
+: "${REVIEW_LOOP_WORKSPACE:?missing checkout path}"
+cd "$REVIEW_LOOP_WORKSPACE"
+test "$(git rev-parse HEAD)" = "$REVIEW_LOOP_HEAD"
+
+# Reuse the protected verifier bootstrap at the approved revision. Never source
+# the PR's copy. The temporary file also preserves a failed git-show exit code.
+rl_reviewer_bootstrap=$(mktemp)
+trap 'rm -f "$rl_reviewer_bootstrap"' EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+git show "$REVIEW_LOOP_BASE:.github/review/setup.sh" > "$rl_reviewer_bootstrap"
+sh "$rl_reviewer_bootstrap"
+# Hex 2.5.1/httpc ignores an HTTPS proxy's scheme. Keep the remote hop
+# encrypted and authenticated: a loopback-only TLS relay carries its CONNECT.
+# The proxy credential stays in child process environments, never a file/argv.
+if [ -n "${HTTPS_PROXY:-}" ]; then
+  if [ "$(id -u)" = 0 ]; then
+    env DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends socat
+  else
+    sudo -n env DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends socat
+  fi
+  python3 - <<'PY_RELAY'
+import os
+import pathlib
+import re
+import socket
+import subprocess
+import time
+from urllib.parse import urlsplit
+
+proxy = urlsplit(os.environ["HTTPS_PROXY"])
+if proxy.scheme != "https" or not proxy.hostname or not re.fullmatch(r"[A-Za-z0-9.-]+", proxy.hostname):
+    raise SystemExit("Reviewer setup requires an HTTPS broker with a DNS hostname")
+port = 18443
+# Fail rather than reuse a listener left by unrelated work.
+with socket.socket() as check:
+    check.bind(("127.0.0.1", port))
+relay = subprocess.Popen([
+    "socat", f"TCP4-LISTEN:{port},bind=127.0.0.1,reuseaddr,fork",
+    f"OPENSSL:{proxy.hostname}:{proxy.port or 443},verify=1,"
+    f"cafile=/etc/ssl/certs/ca-certificates.crt,commonname={proxy.hostname},snihost={proxy.hostname}",
+], stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+   start_new_session=True)
+for _ in range(50):
+    if relay.poll() is not None:
+        raise SystemExit("Reviewer broker TLS relay failed to start")
+    try:
+        with socket.create_connection(("127.0.0.1", port), timeout=0.1):
+            break
+    except OSError:
+        time.sleep(0.1)
+else:
+    relay.terminate()
+    raise SystemExit("Reviewer broker TLS relay did not become ready")
+
+# The verified bootstrap owns this directory. Wrap its explicit test settings;
+# normal curl/git can keep their native HTTPS-proxy support outside rl-env.
+root = pathlib.Path("/opt/review-loop-tools")
+(root / "rl-env").rename(root / "rl-env-direct")
+wrapper = """#!/usr/bin/python3
+import os
+import sys
+from urllib.parse import urlsplit, urlunsplit
+
+env = os.environ.copy()
+for key in ("HTTPS_PROXY", "HTTP_PROXY", "https_proxy", "http_proxy"):
+    value = env.get(key)
+    if not value:
+        continue
+    proxy = urlsplit(value)
+    if proxy.scheme != "https":
+        raise SystemExit("Reviewer command requires an HTTPS broker")
+    if (proxy.hostname, proxy.port or 443) != BROKER_ENDPOINT:
+        raise SystemExit("Reviewer broker endpoint changed; start a fresh worker")
+    authority = proxy.netloc.rsplit("@", 1)
+    credentials = authority[0] + "@" if len(authority) == 2 else ""
+    env[key] = urlunsplit(("http", credentials + "127.0.0.1:18443", "", "", ""))
+os.execve("/opt/review-loop-tools/rl-env-direct", ["rl-env", *sys.argv[1:]], env)
+"""
+wrapper = wrapper.replace("BROKER_ENDPOINT", repr((proxy.hostname, proxy.port or 443)))
+(root / "rl-env").write_text(wrapper)
+(root / "rl-env").chmod(0o755)
+PY_RELAY
+fi
+rl-env mix deps.get
+rl-env sh -c 'mix deps.unlock --unused && git diff --exit-code -- mix.lock'
+rl-env sh -c 'mix ecto.create --quiet && mix ecto.migrate --quiet'

--- a/.github/review/reviewer-setup.sh
+++ b/.github/review/reviewer-setup.sh
@@ -15,6 +15,8 @@ trap 'exit 129' HUP
 trap 'exit 130' INT
 trap 'exit 143' TERM
 git show "$REVIEW_LOOP_BASE:.github/review/setup.sh" > "$rl_reviewer_bootstrap"
+# Toolchain and relay bootstrap must not evaluate PR-local Mix/Python modules.
+cd /
 sh "$rl_reviewer_bootstrap"
 # Hex 2.5.1/httpc ignores an HTTPS proxy's scheme. Keep the remote hop
 # encrypted and authenticated: a loopback-only TLS relay carries its CONNECT.
@@ -88,6 +90,7 @@ wrapper = wrapper.replace("BROKER_ENDPOINT", repr((proxy.hostname, proxy.port or
 (root / "rl-env").chmod(0o755)
 PY_RELAY
 fi
+cd "$REVIEW_LOOP_WORKSPACE"
 rl-env mix deps.get
 rl-env sh -c 'mix deps.unlock --unused && git diff --exit-code -- mix.lock'
 rl-env sh -c 'mix ecto.create --quiet && mix ecto.migrate --quiet'

--- a/.github/review/simplicity.md
+++ b/.github/review/simplicity.md
@@ -50,3 +50,9 @@ review incomplete. Inspect the changed code, relevant callers and regression
 assertions; do not claim tests passed when they did not. Return `complete: false`
 when missing files, required context or unresolved uncertainty prevents completing
 the review. Preserve any concrete findings supported by the files inspected.
+
+The service prepares this reviewer with trusted toolchains, dependencies and a
+local test database before your turn. Run targeted diagnostic commands through
+`rl-env` (for example `rl-env mix test path/to/test.exs`) so they use the prepared
+BEAM and database. Setup success does not mean tests passed; report actual command
+results and missing evidence. Independent service verification remains required.

--- a/.github/review/tenant-isolation.md
+++ b/.github/review/tenant-isolation.md
@@ -70,3 +70,9 @@ review incomplete. Inspect the changed code, relevant callers and regression
 assertions; do not claim tests passed when they did not. Return `complete: false`
 when missing files, required context or unresolved uncertainty prevents completing
 the review. Preserve any concrete findings supported by the files inspected.
+
+The service prepares this reviewer with trusted toolchains, dependencies and a
+local test database before your turn. Run targeted diagnostic commands through
+`rl-env` (for example `rl-env mix test path/to/test.exs`) so they use the prepared
+BEAM and database. Setup success does not mean tests passed; report actual command
+results and missing evidence. Independent service verification remains required.

--- a/.github/review/verification.md
+++ b/.github/review/verification.md
@@ -49,3 +49,21 @@ or raise a deadline merely to report success.
 Deploy a Review Loop version supporting `verification.command_timeout_minutes`
 before merging this policy. The measured standalone recipe is not evidence of
 a production candidate check or PR approval at this configuration.
+
+## Measured reviewer preparation
+
+A cold, isolated Ubuntu worker on September 7, 2026 completed the reviewer
+bootstrap, locked dependency installation, database migration, and the additional
+environment-controller diagnostic in **6m30s**. The diagnostic returned **18 tests,
+0 failures**, including the second-tenant setup-timeout denial case. The configured
+15-minute setup bound provides over eight minutes of headroom over this sample;
+it is not a worst-case guarantee. This excludes Credo, Dialyzer, full test suites,
+and the independent verifier's broader recipe above.
+
+The subsequent model review stalled; cancellation and physical worker deletion
+succeeded. A second cold probe completed preparation, the same 18-test diagnostic,
+and delivery of a correctly identified result artifact within **8m25s total**;
+physical worker deletion also passed. That artifact deliberately marked full PR
+coverage incomplete. These samples prove preparation and diagnostic delivery,
+not full PR approval or enrolled-policy acceptance. The bootstrap now also runs
+outside the PR checkout, with a local regression for PR module shadowing.

--- a/scripts/test-reviewer-proxy.py
+++ b/scripts/test-reviewer-proxy.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Exercise the recipe's TLS relay with local certificates; needs socat/openssl."""
+import json
+import os
+from pathlib import Path
+import signal
+import socket
+import subprocess
+import tempfile
+import time
+from unittest.mock import patch
+
+
+def port():
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def run():
+    source = (Path(__file__).resolve().parents[1] / ".github/review/reviewer-setup.sh").read_text()
+    bootstrap = source.split("python3 - <<'PY_RELAY'\n", 1)[1].split("\nPY_RELAY", 1)[0]
+    servers = []
+    state = {}
+    with tempfile.TemporaryDirectory(prefix="reviewer-proxy-") as directory:
+        root = Path(directory)
+        tools = root / "tools"
+        tools.mkdir()
+        remote_port, relay_port = port(), port()
+        try:
+            for name, hostname in [("good", "localhost"), ("wrong", "wrong.invalid"), ("untrusted", "localhost")]:
+                subprocess.run([
+                    "openssl", "req", "-x509", "-newkey", "rsa:2048", "-nodes",
+                    "-keyout", str(root / f"{name}.key"), "-out", str(root / f"{name}.crt"),
+                    "-days", "1", "-subj", f"/CN={hostname}", "-addext", f"subjectAltName=DNS:{hostname}",
+                ], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            ca = root / "trusted.pem"
+            ca.write_bytes((root / "good.crt").read_bytes() + (root / "wrong.crt").read_bytes())
+            wrapper = tools / "rl-env"
+            wrapper.write_text('#!/usr/bin/python3\nimport os,json\nprint(json.dumps({k:os.environ.get(k) for k in ["HTTPS_PROXY","HTTP_PROXY","https_proxy","http_proxy"]}))\n')
+            wrapper.chmod(0o755)
+            bootstrap = bootstrap.replace("/opt/review-loop-tools", str(tools)).replace(
+                "/etc/ssl/certs/ca-certificates.crt", str(ca)
+            ).replace("18443", str(relay_port))
+            env = {"PATH": os.environ["PATH"]}
+            for key in ("HTTPS_PROXY", "HTTP_PROXY", "https_proxy", "http_proxy"):
+                env[key] = f"https://fixture-user:fixture-password@localhost:{remote_port}"
+
+            def serve(name):
+                server = subprocess.Popen([
+                    "openssl", "s_server", "-accept", str(remote_port), "-cert", str(root / f"{name}.crt"),
+                    "-key", str(root / f"{name}.key"), "-www", "-quiet",
+                ], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+                servers.append(server)
+                for _ in range(50):
+                    if server.poll() is not None:
+                        raise AssertionError("TLS fixture exited before accepting connections")
+                    try:
+                        with socket.create_connection(("127.0.0.1", remote_port), timeout=.1):
+                            return server
+                    except OSError:
+                        time.sleep(.02)
+                raise AssertionError("TLS fixture did not become ready")
+
+            def request():
+                with socket.create_connection(("127.0.0.1", relay_port), timeout=3) as sock:
+                    sock.sendall(b"GET / HTTP/1.0\r\n\r\n")
+                    try:
+                        return sock.recv(16384)
+                    except ConnectionResetError:
+                        return b""
+
+            server = serve("good")
+            with patch.dict(os.environ, env, clear=True):
+                exec(compile(bootstrap, "reviewer-setup.sh:PY_RELAY", "exec"), state)
+            result = json.loads(subprocess.check_output([str(wrapper)], env=env))
+            expected = f"http://fixture-user:fixture-password@127.0.0.1:{relay_port}"
+            assert all(value == expected for value in result.values())
+            assert "fixture-password" not in wrapper.read_text()
+            assert b"HTTP/1.0 200" in request(), "trusted TLS relay failed"
+            print("PASS: trusted TLS and process-only credentials")
+            server.terminate()
+            server.wait(timeout=5)
+            for name in ("wrong", "untrusted"):
+                server = serve(name)
+                assert request() == b"", f"{name} certificate accepted"
+                print(f"PASS: {name} certificate rejected")
+                server.terminate()
+                server.wait(timeout=5)
+            env["HTTPS_PROXY"] = f"https://fixture-user:fixture-password@wrong.invalid:{remote_port}"
+            result = subprocess.run([str(wrapper)], env=env, capture_output=True)
+            assert result.returncode and b"endpoint changed" in result.stderr
+            print("PASS: changed broker endpoint rejected")
+        finally:
+            relay = state.get("relay")
+            if relay is not None and relay.poll() is None:
+                os.killpg(relay.pid, signal.SIGTERM)
+                relay.wait(timeout=5)
+            for server in servers:
+                if server.poll() is None:
+                    server.terminate()
+                    server.wait(timeout=5)
+
+
+if __name__ == "__main__":
+    run()

--- a/scripts/test-reviewer-setup-cwd.py
+++ b/scripts/test-reviewer-setup-cwd.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Bootstrap must ignore PR-local modules; project commands use the checkout."""
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+
+source = Path(__file__).resolve().parents[1] / ".github/review/reviewer-setup.sh"
+with tempfile.TemporaryDirectory(prefix="reviewer-cwd-") as directory:
+    root = Path(directory)
+    checkout = root / "checkout"
+    checkout.mkdir()
+    bin_dir = root / "bin"
+    bin_dir.mkdir()
+    bootstrap = checkout / ".github/review/setup.sh"
+    bootstrap.parent.mkdir(parents=True)
+    bootstrap.write_text('set -eu\ntest "$PWD" = /\npython3 -c "import json"\nprintf "bootstrap-ok\\n" > "$REVIEWER_CWD_EVIDENCE"\n')
+    (checkout / "json.py").write_text('raise RuntimeError("PR module executed during bootstrap")\n')
+    command = bin_dir / "rl-env"
+    command.write_text('#!/bin/sh\nset -eu\ntest "$PWD" = "$REVIEW_LOOP_WORKSPACE"\nprintf "workspace-command-ok\\n" >> "$REVIEWER_CWD_EVIDENCE"\n')
+    command.chmod(0o755)
+    def git(*args):
+        return subprocess.check_output([
+            "git", "-c", "core.hooksPath=/dev/null", "-c", "commit.gpgsign=false",
+            "-c", "user.name=Fixture", "-c", "user.email=fixture@example.invalid", *args,
+        ], cwd=checkout, stderr=subprocess.DEVNULL, text=True).strip()
+    git("init")
+    git("add", ".")
+    git("commit", "-m", "fixture")
+    revision = git("rev-parse", "HEAD")
+    evidence = root / "evidence"
+    env = {**os.environ, "PATH": f"{bin_dir}:{os.environ['PATH']}", "HTTPS_PROXY": "",
+           "REVIEW_LOOP_BASE": revision, "REVIEW_LOOP_HEAD": revision,
+           "REVIEW_LOOP_WORKSPACE": str(checkout), "REVIEWER_CWD_EVIDENCE": str(evidence)}
+    subprocess.run(["sh", str(source)], cwd=checkout, env=env, check=True)
+    assert evidence.read_text().splitlines() == ["bootstrap-ok"] + ["workspace-command-ok"] * 3
+    print("PASS: neutral bootstrap ignores PR Python module; project commands enter the checkout")


### PR DESCRIPTION
Prepare all four reviewers with trusted toolchains, locked Hex dependencies, and an isolated test database. Bootstrap runs outside the PR checkout; repository commands run through `rl-env`. Models and source-review completion policy are preserved, and independent service verification remains required.

Hex 2.5.1/httpc ignores an HTTPS proxy's scheme. A loopback TLS relay preserves broker authentication, certificate/hostname verification, and process-only credentials. Regression checks cover TLS failures and PR module shadowing.

Validation: full precommit passed twice (4,587 tests plus six doctests; two skipped, seven excluded). Linux TLS and bootstrap tests pass. A cold live sample completed preparation and the 18-test tenant-denial diagnostic in 6m30s; a second delivered a correctly identified result artifact within 8m25s total. Worker deletion was confirmed. That artifact intentionally marked full PR coverage incomplete; enrolled-policy acceptance follows merge. One earlier review stalled after successful setup and was cancelled and deleted; its cause remains tracked separately.

Review Loop #90/#93 setup support is deployed; Fountain #1741 is deployed. Measured timeout evidence and reproduction commands are in `.github/review/verification.md` and `.github/review/README.md`.
