### PR TITLE
chore: pin Review Loop Action with bounded dispatch recovery

### DIFF
--- a/.github/workflows/review-loop.yml
+++ b/.github/workflows/review-loop.yml
@@ -16,6 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
-      - uses: managoat/review-loop-action@f10fac7d0e21607dd4aa0da7d794e94780db2a65 # v1.0.0
+      - uses: managoat/review-loop-action@8a2df42f250063b33f253bec2c3b0e7abffd50d1 # v1.0.1
         with:
           service-url: ${{ vars.REVIEW_LOOP_URL }}


### PR DESCRIPTION
Pin Review Loop Action v1.0.1 so brief service outages and lost acknowledgments retry with the same admission identity. The release adds bounded backoff, honors Retry-After, and leaves authentication refusals and invalid results as failures.

Release: https://github.com/managoat/review-loop-action/releases/tag/v1.0.1

Validation: Fountain precommit passed 4,587 tests and six doctests, with two skips and seven exclusions. The public Action passed 13 Node tests and its public-consumer smoke check.

Draft while the designated #1665 acceptance run uses the current approved base. Merge after that run ends so its policy revision is not replaced mid-test. This workflow change becomes authorized only after it reaches the trusted base.
