### PR TITLE
Prepare bounded command transport and guarded ACP writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,11 @@ upgrade, is in
   immediate error. Starts carrying images or naming a `sandbox_id` never
   queue.
 
+- Prepare a supervised bounded-command transport that binds provider identity
+  before stdin, rechecks journal authority for each write, and retains uncertain
+  operations. Successful bounded replies now require connection retirement before
+  a fresh successor. Actor/spawn integration and public activation remain gated.
+
 - Commit deadline failure events and delivery jobs with the failed turn. Late
   completion and interruption reuse the original event, and notification retries
   retain its id. Public bounded execution remains disabled.

--- a/apps/fountain/lib/fountain/application.ex
+++ b/apps/fountain/lib/fountain/application.ex
@@ -57,6 +57,7 @@ defmodule Fountain.Application do
         # (#1040). Supervised and unlinked, a crash here is a log line.
         {Task.Supervisor, name: Fountain.TaskSupervisor},
         Fountain.PlatformChatGPT.Refresher,
+        {DynamicSupervisor, name: Fountain.ExecutionTransportSupervisor, strategy: :one_for_one},
         FountainWeb.Plugs.RateLimit.Sweeper,
         Fountain.Conversations.Redaction,
         Fountain.FeatureFlags.Cache,

--- a/apps/fountain/lib/fountain/conversations/execution_guard.ex
+++ b/apps/fountain/lib/fountain/conversations/execution_guard.ex
@@ -58,17 +58,9 @@ defmodule Fountain.Conversations.ExecutionGuard do
           if sandbox.user_id != conv.user_id, do: Repo.rollback(:ownership_changed)
           if sandbox.status != "ready", do: Repo.rollback(:sandbox_not_ready)
 
-          prior = prior_connection(connection_id)
-          if prior && prior.state != "completed", do: Repo.rollback(:connection_retired)
-
-          if prior &&
-               (prior.conversation_id != conv.id || prior.sandbox_id != sandbox.id ||
-                  prior.sandbox_name != sandbox.sprite_name || prior.provider != sandbox.provider ||
-                  prior.user_id != conv.user_id),
-             do: Repo.rollback(:connection_owned_elsewhere)
-
-          if prior && is_nil(prior.provider_session_id),
-            do: Repo.rollback(:connection_unidentified)
+          # Bounded turns never inherit a warm process: it may retain background
+          # work or SDK allowances from its previous prompt.
+          if prior_connection(connection_id), do: Repo.rollback(:connection_retired)
 
           limits = resolve_turn_limits(conv)
           enforce_deadline_ceiling!(turn, deadline_at, limits)
@@ -82,7 +74,6 @@ defmodule Fountain.Conversations.ExecutionGuard do
             sandbox_name: sandbox.sprite_name,
             provider: sandbox.provider,
             connection_id: connection_id,
-            provider_session_id: prior && prior.provider_session_id,
             deadline_at: deadline_at
           }
 
@@ -161,6 +152,37 @@ defmodule Fountain.Conversations.ExecutionGuard do
     else
       {:error, :invalid_session_id}
     end
+  end
+
+  @doc "Authorize an immediate write to the original identified execution."
+  def _unsafe_authorize_write(id, connection_id, opts \\ []) do
+    with_execution(id, fn execution ->
+      now = Keyword.get(opts, :now, DateTime.utc_now())
+
+      cond do
+        execution.connection_id != connection_id ->
+          Repo.rollback(:stale_connection)
+
+        execution.state != "active" ->
+          Repo.rollback(:execution_fenced)
+
+        DateTime.compare(now, execution.deadline_at) != :lt ->
+          {decision, changed, event} = expire(execution, now)
+          {Map.put(decision, :permitted, false), changed, event}
+
+        is_nil(execution.provider_session_id) ->
+          Repo.rollback(:identity_unconfirmed)
+
+        not match?(%Turn{status: "running"}, Repo.get(Turn, execution.turn_id)) ->
+          Repo.rollback(:turn_not_running)
+
+        not current_binding?(execution) ->
+          Repo.rollback(:ownership_changed)
+
+        true ->
+          {%{permitted: true, execution: execution}, nil, nil}
+      end
+    end)
   end
 
   @doc "A completion after the absolute deadline becomes a failed, fenced turn."
@@ -244,8 +266,7 @@ defmodule Fountain.Conversations.ExecutionGuard do
         stop(execution, turn, turn.status, now)
 
       execution.state == "active" and turn.status == "completed" ->
-        updated = update!(execution, %{state: "completed"})
-        {%{execution: updated, turn: turn}, updated, "completed"}
+        stop(execution, turn, "completed", now)
 
       execution.state == "active" and status in ["failed", "interrupted"] ->
         stop(execution, turn, status, now)
@@ -255,9 +276,7 @@ defmodule Fountain.Conversations.ExecutionGuard do
         Repo.rollback(:execution_not_started)
 
       execution.state == "active" and DateTime.compare(now, execution.deadline_at) == :lt ->
-        updated = update!(execution, %{state: "completed"})
-        turn = update!(turn, %{status: status, ended_at: DateTime.truncate(now, :second)})
-        {%{execution: updated, turn: turn, terminal_changed: true}, updated, "completed"}
+        stop(execution, turn, status, now)
 
       true ->
         {%{execution: execution, turn: Repo.get(Turn, execution.turn_id)}, nil, nil}
@@ -497,8 +516,7 @@ defmodule Fountain.Conversations.ExecutionGuard do
         stop(execution, turn, turn.status, now)
 
       turn.status == "completed" ->
-        updated = update!(execution, %{state: "completed"})
-        {%{execution: updated, turn: turn}, updated, "completed"}
+        stop(execution, turn, "completed", now)
 
       true ->
         state =
@@ -528,8 +546,8 @@ defmodule Fountain.Conversations.ExecutionGuard do
     end
   end
 
-  # A local failure or interruption is not evidence that the command stopped.
-  # Retire this connection only after the same remote confirmation as a timeout.
+  # No local turn outcome proves the command stopped. Even a successful reply
+  # may leave background work; every bounded connection requires remote cleanup.
   defp stop(execution, turn, status, now) do
     state =
       cond do

--- a/apps/fountain/lib/fountain/conversations/execution_transport.ex
+++ b/apps/fountain/lib/fountain/conversations/execution_transport.ex
@@ -11,6 +11,20 @@ defmodule Fountain.Conversations.ExecutionTransport do
   make an expired spawn cleanable; after a bounded drain, unresolved intent stays
   in the journal. Public admission remains disabled pending released identity
   support and complete lifecycle integration.
+
+  **Sprites only, and that is a real limit rather than a staging detail.**
+  `_unsafe_start/5` refuses any other provider with `:provider_not_supported`,
+  and admission rolls back the same way, because binding a provider-issued
+  session id from trusted control metadata is a per-adapter capability and only
+  the Sprites adapter has it. E2B, Daytona and self-hosted runners (ADR 0018,
+  ADR 0022) therefore cannot carry a bounded turn at all. They get a refusal at
+  admission, not a silently unbounded turn — a caller that asks for a limit and
+  is told no is fine; one that asks and is ignored is not.
+
+  The `:deadline` timer set in `init/1` is not the enforcement mechanism. It is
+  a local convenience for a process that happens to still be alive; the
+  guarantee is the absolute `deadline_at` on the journal row, which
+  `ExecutionDeadlineWorker` acts on whether or not this process survived.
   """
   use GenServer, restart: :temporary
 
@@ -47,13 +61,18 @@ defmodule Fountain.Conversations.ExecutionTransport do
 
   def start_link(opts), do: GenServer.start_link(__MODULE__, opts)
   def await_ready(pid, timeout \\ 30_000), do: call(pid, :ready, timeout)
-  def write(pid, data), do: call(pid, {:write, data}, 30_000)
+  def write(pid, data, timeout \\ 30_000), do: call(pid, {:write, data}, timeout)
   @doc "Acknowledge persisted retirement intent, not confirmed remote termination."
   def close(pid), do: call(pid, :close, 30_000)
 
+  # A dead transport and a transport that did not answer in time mean different
+  # things to the journal: the first cannot be mid-write, the second may be. Both
+  # used to arrive as `:transport_unavailable`, which reads as "nothing
+  # happened" and is only true of the first.
   defp call(pid, message, timeout) do
     GenServer.call(pid, message, timeout)
   catch
+    :exit, {:timeout, _} -> {:error, :transport_timeout}
     :exit, _ -> {:error, :transport_unavailable}
   end
 

--- a/apps/fountain/lib/fountain/conversations/execution_transport.ex
+++ b/apps/fountain/lib/fountain/conversations/execution_transport.ex
@@ -1,0 +1,347 @@
+defmodule Fountain.Conversations.ExecutionTransport do
+  @moduledoc """
+  Owns one bounded command outside the conversation actor.
+
+  Spawn intent precedes I/O. Only provider control metadata matching the returned
+  command reference can bind identity; stdin remains closed to callers until
+  that binding succeeds. Each write rechecks the durable journal. A failed or
+  timed-out write retires the entire execution and is never replayed.
+
+  Local task termination is not remote confirmation. Late identity can still
+  make an expired spawn cleanable; after a bounded drain, unresolved intent stays
+  in the journal. Public admission remains disabled pending released identity
+  support and complete lifecycle integration.
+  """
+  use GenServer, restart: :temporary
+
+  alias Fountain.Repo
+  alias Fountain.Conversations.{ExecutionGuard, TurnExecution}
+  alias Managoat.Sandbox
+  alias Managoat.Sandbox.Command
+
+  @buffer_bytes 262_144
+  @buffer_frames 64
+
+  @doc "System-owned launch of an already registered execution; never retries a spawn."
+  def _unsafe_start(id, owner, program, args, opts \\ []) do
+    # ownership: internal caller registered this execution for its owned actor;
+    # the spawn claim rechecks the immutable tenant/sandbox binding before I/O.
+    with %TurnExecution{provider: "sprites"} <- Repo.get(TurnExecution, id),
+         {:ok, execution} <- ExecutionGuard._unsafe_claim_spawn(id),
+         {:ok, pid} <-
+           DynamicSupervisor.start_child(
+             Fountain.ExecutionTransportSupervisor,
+             {__MODULE__,
+              execution: execution,
+              owner: owner,
+              io_timeout_ms: Keyword.get(opts, :io_timeout_ms, 30_000)}
+           ),
+         :ok <- call(pid, {:spawn, program, args, opts}, 30_000) do
+      {:ok, pid}
+    else
+      nil -> {:error, :not_found}
+      %TurnExecution{} -> {:error, :provider_not_supported}
+      error -> error
+    end
+  end
+
+  def start_link(opts), do: GenServer.start_link(__MODULE__, opts)
+  def await_ready(pid, timeout \\ 30_000), do: call(pid, :ready, timeout)
+  def write(pid, data), do: call(pid, {:write, data}, 30_000)
+  @doc "Acknowledge persisted retirement intent, not confirmed remote termination."
+  def close(pid), do: call(pid, :close, 30_000)
+
+  defp call(pid, message, timeout) do
+    GenServer.call(pid, message, timeout)
+  catch
+    :exit, _ -> {:error, :transport_unavailable}
+  end
+
+  @impl true
+  def init(opts) do
+    Process.flag(:trap_exit, true)
+    execution = Keyword.fetch!(opts, :execution)
+    owner = Keyword.fetch!(opts, :owner)
+    remaining = max(DateTime.diff(execution.deadline_at, DateTime.utc_now(), :millisecond), 0)
+    Process.send_after(self(), :deadline, remaining)
+    Process.send_after(self(), :drain_end, remaining + 30_000)
+
+    {:ok,
+     %{
+       execution: execution,
+       owner: owner,
+       owner_ref: Process.monitor(owner),
+       command: nil,
+       phase: :new,
+       ready_waiter: nil,
+       close_waiter: nil,
+       retired: false,
+       jobs: %{},
+       buffer: [],
+       bytes: 0,
+       io_timeout: Keyword.fetch!(opts, :io_timeout_ms)
+     }}
+  end
+
+  @impl true
+  def handle_call({:spawn, program, args, opts}, _from, %{phase: :new} = state) do
+    owner = self()
+    name = state.execution.sandbox_name
+
+    # No credential-bearing spawn options enter the supervisor's child spec.
+    opts =
+      Keyword.take(opts, [:env, :dir, :tty]) ++
+        [owner: owner, session_info: true, stdin: true, detachable: true]
+
+    state =
+      start_job(%{state | phase: :spawning}, :spawn, nil, fn ->
+        handle = Sandbox.build_handle(:sprites, name)
+        Sandbox.spawn(handle, program, args, opts)
+      end)
+
+    {:reply, :ok, state}
+  end
+
+  def handle_call({:spawn, _, _, _}, _from, state),
+    do: {:reply, {:error, :execution_fenced}, state}
+
+  def handle_call(:close, from, state) do
+    cond do
+      state.retired -> {:reply, :ok, state}
+      state.close_waiter -> {:reply, {:error, :already_closing}, state}
+      true -> {:noreply, retire(%{state | close_waiter: from})}
+    end
+  end
+
+  def handle_call(:ready, from, state) do
+    cond do
+      live?(state) -> {:reply, {:ok, state.command}, state}
+      state.phase in [:fenced, :exited] -> {:reply, {:error, :execution_fenced}, state}
+      state.ready_waiter -> {:reply, {:error, :already_waiting}, state}
+      true -> {:noreply, %{state | ready_waiter: from}}
+    end
+  end
+
+  def handle_call({:write, data}, from, state) do
+    cond do
+      not live?(state) ->
+        {:reply, {:error, :execution_fenced}, state}
+
+      Enum.any?(state.jobs, fn {_, job} -> job.kind == :write end) ->
+        {:reply, {:error, :write_pending}, state}
+
+      true ->
+        execution = state.execution
+        command = state.command
+
+        task = fn ->
+          # ownership: this transport holds the original registered connection;
+          # the journal rechecks its tenant, command identity and absolute deadline.
+          case ExecutionGuard._unsafe_authorize_write(execution.id, execution.connection_id) do
+            {:ok, %{permitted: true}} -> Sandbox.write_stdin(command, data)
+            _ -> {:refused, :execution_fenced}
+          end
+        end
+
+        {:noreply, start_job(state, :write, from, task)}
+    end
+  end
+
+  @impl true
+  def handle_info({ref, result}, state) when is_reference(ref) do
+    case Map.pop(state.jobs, ref) do
+      {nil, _} ->
+        {:noreply, state}
+
+      {job, jobs} ->
+        Process.demonitor(ref, [:flush])
+        {:noreply, complete_job(job, result, %{state | jobs: jobs})}
+    end
+  end
+
+  def handle_info({:DOWN, ref, :process, _pid, _reason}, %{owner_ref: ref} = state),
+    do: {:noreply, retire(state)}
+
+  def handle_info({:DOWN, ref, :process, _pid, _reason}, state) do
+    case Map.pop(state.jobs, ref) do
+      {nil, _} ->
+        {:noreply, state}
+
+      {job, jobs} ->
+        if job.from, do: GenServer.reply(job.from, {:error, :operation_unconfirmed})
+        state = %{state | jobs: jobs}
+        if job.kind == :retire, do: Process.send_after(self(), :retry_retire, 1_000)
+        {:noreply, retire(state)}
+    end
+  end
+
+  def handle_info({kind, %{ref: _}, _} = frame, state)
+      when kind in [:session_info, :stdout, :stderr, :exit, :error] do
+    {:noreply, accept_frame(frame, state)}
+  end
+
+  def handle_info(:deadline, state), do: {:noreply, retire(state)}
+  def handle_info(:retry_retire, state), do: {:noreply, request_retirement(state)}
+  def handle_info(:drain_end, state), do: {:stop, :normal, state}
+  def handle_info(_message, state), do: {:noreply, state}
+
+  defp complete_job(%{kind: :spawn}, {:ok, %Command{provider: :sprites} = command}, state) do
+    buffered = Enum.reverse(state.buffer)
+    state = %{state | command: command, buffer: [], bytes: 0}
+    Enum.reduce(buffered, state, &accept_frame/2)
+  end
+
+  defp complete_job(%{kind: :spawn}, _result, state), do: retire(state)
+
+  defp complete_job(%{kind: :write, from: from}, :ok, state) do
+    GenServer.reply(from, if(live?(state), do: :ok, else: {:error, :execution_fenced}))
+    state
+  end
+
+  defp complete_job(%{kind: :write, from: from}, {:refused, reason}, state) do
+    GenServer.reply(from, {:error, reason})
+    retire(state)
+  end
+
+  defp complete_job(%{kind: :write, from: from}, _result, state) do
+    GenServer.reply(from, {:error, :operation_unconfirmed})
+    retire(state)
+  end
+
+  defp complete_job(%{kind: :retire}, {:ok, _}, state) do
+    if state.close_waiter, do: GenServer.reply(state.close_waiter, :ok)
+    Process.send_after(self(), :drain_end, 30_000)
+    %{state | retired: true, close_waiter: nil}
+  end
+
+  defp complete_job(%{kind: :retire}, _result, state) do
+    Process.send_after(self(), :retry_retire, 1_000)
+    state
+  end
+
+  defp accept_frame(frame, %{command: nil} = state) do
+    bytes = :erlang.external_size(frame)
+
+    if length(state.buffer) < @buffer_frames and state.bytes + bytes <= @buffer_bytes,
+      do: %{state | buffer: [frame | state.buffer], bytes: state.bytes + bytes},
+      else: retire(state)
+  end
+
+  # Seal writes on exit but let the actor interpret its terminal frame. Racing
+  # that decision with an invented interruption can overwrite a valid reply.
+  # The original deadline and owner monitor remain active until it records one.
+  defp accept_frame(_frame, %{phase: :exited} = state), do: state
+
+  defp accept_frame({:session_info, %{ref: ref}, id}, %{command: %{ref: ref}} = state) do
+    execution = state.execution
+
+    # ownership: provider control metadata matches this transport's command ref;
+    # bind it only to the original journal and connection, including after expiry.
+    case ExecutionGuard._unsafe_bind_identity(execution.id, execution.connection_id, id) do
+      {:ok, %{state: "active", provider_session_id: ^id} = bound} when state.phase != :fenced ->
+        state = %{state | execution: bound, phase: :ready}
+
+        if live?(state) do
+          if state.ready_waiter, do: GenServer.reply(state.ready_waiter, {:ok, state.command})
+          %{state | ready_waiter: nil}
+        else
+          retire(state)
+        end
+
+      _ ->
+        retire(state)
+    end
+  end
+
+  defp accept_frame({:exit, %{ref: ref}, _} = frame, %{command: %{ref: ref}} = state) do
+    if live?(state) do
+      send(state.owner, frame)
+      %{state | phase: :exited}
+    else
+      retire(state)
+    end
+  end
+
+  defp accept_frame({kind, %{ref: ref}, _} = frame, %{command: %{ref: ref}} = state) do
+    if live?(state), do: send(state.owner, frame)
+    if kind in [:exit, :error], do: retire(state), else: state
+  end
+
+  defp accept_frame(_frame, state), do: state
+
+  defp live?(state),
+    do:
+      state.phase == :ready and
+        DateTime.compare(DateTime.utc_now(), state.execution.deadline_at) == :lt
+
+  defp retire(%{phase: :fenced} = state), do: request_retirement(state)
+
+  defp retire(state) do
+    if state.ready_waiter, do: GenServer.reply(state.ready_waiter, {:error, :execution_fenced})
+    state = %{state | phase: :fenced, ready_waiter: nil}
+    request_retirement(state)
+  end
+
+  defp request_retirement(%{retired: true} = state), do: state
+
+  defp request_retirement(state) do
+    if Enum.any?(state.jobs, fn {_, job} -> job.kind == :retire end) do
+      state
+    else
+      execution = state.execution
+
+      start_job(state, :retire, nil, fn ->
+        # ownership: retire only this transport's original journal; remote cleanup
+        # is driven independently from its persisted intent by the deadline worker.
+        ExecutionGuard._unsafe_complete(execution.id, "interrupted")
+      end)
+    end
+  end
+
+  defp start_job(state, kind, from, fun) do
+    timeout = if kind == :write, do: min(state.io_timeout, 5_000), else: state.io_timeout
+
+    task =
+      Task.Supervisor.async_nolink(Fountain.TaskSupervisor, fn ->
+        {:ok, timer} = :timer.kill_after(timeout)
+
+        try do
+          fun.()
+        rescue
+          _ -> {:error, :operation_unconfirmed}
+        catch
+          _, _ -> {:error, :operation_unconfirmed}
+        after
+          :timer.cancel(timer)
+        end
+      end)
+
+    %{state | jobs: Map.put(state.jobs, task.ref, %{task: task, kind: kind, from: from})}
+  end
+
+  @impl true
+  def terminate(_reason, state) do
+    state.jobs
+    |> Enum.map(fn {_, job} -> job.task end)
+    |> Task.yield_many(timeout: 1_000)
+    |> Enum.each(fn {task, result} ->
+      if is_nil(result), do: Task.shutdown(task, :brutal_kill)
+    end)
+
+    # This closes only the local transport. The journal retains its remote
+    # cleanup obligation even when the SDK confirms local shutdown.
+    if state.command, do: Sandbox.stop_command(state.command)
+
+    :ok
+  end
+
+  @impl true
+  def format_status(status) do
+    Map.new(status, fn
+      {:state, state} -> {:state, %{execution_id: state.execution.id, phase: state.phase}}
+      {key, _value} when key in [:message, :reason] -> {key, :redacted}
+      {:log, _value} -> {:log, []}
+      entry -> entry
+    end)
+  end
+end

--- a/apps/fountain/lib/fountain/conversations/turn_machine.ex
+++ b/apps/fountain/lib/fountain/conversations/turn_machine.ex
@@ -1247,7 +1247,7 @@ defmodule Fountain.Conversations.TurnMachine do
       Managoat.ACP.Peer.start(
         owner: self(),
         # See reattach_acp_peer/3 for the writer's contract.
-        writer: fn iodata -> Managoat.Sandbox.write_stdin(command, iodata) end,
+        writer: command_writer(command, opts),
         ref: command.ref,
         prompt: prompt,
         mode: mode,
@@ -1260,7 +1260,8 @@ defmodule Fountain.Conversations.TurnMachine do
         # A codex spawn on the deployment's ChatGPT grant must not be
         # authenticated with codex-acp's api-key method (ADR 0047); see
         # `Fountain.Conversations.CodexChatGPT.peer_auth/2`.
-        auth: Keyword.get(opts, :auth, :api_key)
+        auth: Keyword.get(opts, :auth, :api_key),
+        execution_limits: Keyword.get(opts, :execution_limits)
       )
 
     {peer, Process.monitor(peer)}
@@ -1272,6 +1273,16 @@ defmodule Fountain.Conversations.TurnMachine do
 
   def acp_model(conv, agent),
     do: Fountain.RuntimeDispatch.acp_model(conv.runtime || agent.runtime, agent.model)
+
+  defp command_writer(command, opts) do
+    case Keyword.get(opts, :execution_transport) do
+      nil ->
+        fn data -> Managoat.Sandbox.write_stdin(command, data) end
+
+      pid when is_pid(pid) ->
+        fn data -> Fountain.Conversations.ExecutionTransport.write(pid, data) end
+    end
+  end
 
   # The permission policy in force for this turn (#939): the agent's own,
   # clamped by whatever narrowing the launch asked for. Resolved per turn from

--- a/apps/fountain/test/fountain/conversations/execution_guard_test.exs
+++ b/apps/fountain/test/fountain/conversations/execution_guard_test.exs
@@ -105,27 +105,72 @@ defmodule Fountain.Conversations.ExecutionGuardTest do
     assert deadline == c.deadline
   end
 
-  test "early completion prevents a stale deadline from killing a reused connection", c do
+  test "successful replies retire background work before a fresh successor", c do
     bind(c)
 
-    assert {:ok, %{turn: %{status: "completed"}}} =
+    assert {:ok, %{execution: %{state: "ready"}, turn: %{status: "completed"}}} =
              ExecutionGuard._unsafe_complete(c.execution.id, "completed", now: c.now)
 
     successor = insert_turn(c.conversation, status: "running")
+    next_connection = Ecto.UUID.generate()
+
+    assert {:error, :execution_fenced} =
+             ExecutionGuard._unsafe_register(successor.id, next_connection, c.deadline)
+
+    assert {:ok, %{permitted: true, execution: attempt}} =
+             ExecutionGuard._unsafe_claim_termination(c.execution.id)
+
+    assert {:ok, _} =
+             ExecutionGuard._unsafe_record_termination(attempt.id, attempt.attempt_id, :ok)
+
+    assert {:error, :connection_retired} =
+             ExecutionGuard._unsafe_register(successor.id, c.connection, c.deadline)
 
     assert {:ok, next} =
-             ExecutionGuard._unsafe_register(
-               successor.id,
-               c.connection,
-               DateTime.add(c.deadline, 60)
-             )
+             ExecutionGuard._unsafe_register(successor.id, next_connection, c.deadline)
 
-    assert {:ok, %{execution: %{state: "completed"}, turn: %{status: "completed"}}} =
+    assert {:ok, %{execution: %{state: "stopped"}, turn: %{status: "completed"}}} =
              ExecutionGuard._unsafe_expire(c.execution.id, now: DateTime.add(c.deadline, 1))
 
     assert {:error, :not_ready} = ExecutionGuard._unsafe_claim_termination(c.execution.id)
     assert Repo.get!(TurnExecution, next.id).state == "active"
     assert Repo.get!(Turn, successor.id).status == "running"
+  end
+
+  test "writes require a known identity, current connection and unfinished turn", c do
+    assert {:error, :identity_unconfirmed} =
+             ExecutionGuard._unsafe_authorize_write(c.execution.id, c.connection)
+
+    bind(c)
+
+    assert {:error, :stale_connection} =
+             ExecutionGuard._unsafe_authorize_write(c.execution.id, Ecto.UUID.generate())
+
+    assert {:ok, %{permitted: true}} =
+             ExecutionGuard._unsafe_authorize_write(c.execution.id, c.connection)
+
+    ExecutionGuard._unsafe_complete(c.execution.id, "completed")
+
+    assert {:error, :execution_fenced} =
+             ExecutionGuard._unsafe_authorize_write(c.execution.id, c.connection)
+  end
+
+  test "an overdue write expires the turn without granting provider I/O", c do
+    bind(c)
+
+    assert {:ok, %{permitted: false, turn: %{limit_reason: "wall_time_limit"}}} =
+             ExecutionGuard._unsafe_authorize_write(c.execution.id, c.connection, now: c.deadline)
+
+    assert Repo.get!(TurnExecution, c.execution.id).deadline_event_id
+  end
+
+  test "a changed sandbox cannot receive a write under the original journal", c do
+    bind(c)
+    replacement = insert_sandbox(user_id: c.user.id, status: "ready")
+    c.conversation |> change(sandbox_id: replacement.id) |> Repo.update!()
+
+    assert {:error, :ownership_changed} =
+             ExecutionGuard._unsafe_authorize_write(c.execution.id, c.connection)
   end
 
   test "completion exactly at the deadline is failure and retains partial usage", c do

--- a/apps/fountain/test/fountain/conversations/execution_guard_test.exs
+++ b/apps/fountain/test/fountain/conversations/execution_guard_test.exs
@@ -583,12 +583,52 @@ defmodule Fountain.Conversations.ExecutionGuardTest do
                )
     end
 
-    test "a completed or stopped row is never touched by the sweep", c do
+    test "a resolved row is never touched by the sweep", c do
+      bind(c)
+
+      # Since this PR every bounded connection owes remote cleanup, a
+      # successful reply included, so a completed turn lands in `ready` rather
+      # than `completed` — the sweep must not confuse "still owed" with
+      # "unresolvable", so drive it all the way to a confirmed stop.
+      {:ok, _} = ExecutionGuard._unsafe_complete(c.execution.id, "completed", now: c.now)
+      assert Repo.get!(TurnExecution, c.execution.id).state == "ready"
+
+      {:ok, %{execution: attempt}} = ExecutionGuard._unsafe_claim_termination(c.execution.id)
+
+      {:ok, _} =
+        ExecutionGuard._unsafe_record_termination(c.execution.id, attempt.attempt_id, :ok)
+
+      assert Repo.get!(TurnExecution, c.execution.id).state == "stopped"
+      assert ExecutionGuard._unsafe_retire_unresolved(DateTime.add(DateTime.utc_now(), 1)) == []
+      assert Repo.get!(TurnExecution, c.execution.id).state == "stopped"
+    end
+
+    test "a successful turn whose cleanup never confirms still ages out", c do
+      # The corollary of this PR's change: the fence now reaches the happy path.
+      # A turn that answered correctly, whose remote cleanup is then lost, would
+      # otherwise fence its conversation and its machine as surely as a timeout.
       bind(c)
       {:ok, _} = ExecutionGuard._unsafe_complete(c.execution.id, "completed", now: c.now)
-      assert Repo.get!(TurnExecution, c.execution.id).state == "completed"
-      assert ExecutionGuard._unsafe_retire_unresolved(DateTime.add(DateTime.utc_now(), 1)) == []
-      assert Repo.get!(TurnExecution, c.execution.id).state == "completed"
+      {:ok, %{execution: attempt}} = ExecutionGuard._unsafe_claim_termination(c.execution.id)
+
+      {:ok, _} =
+        ExecutionGuard._unsafe_record_termination(
+          c.execution.id,
+          attempt.attempt_id,
+          {:error, :timeout}
+        )
+
+      assert Repo.get!(Turn, c.turn.id).status == "completed"
+      assert ExecutionGuard._unsafe_fenced?(c.conversation.id)
+
+      assert [{:ok, retired}] =
+               ExecutionGuard._unsafe_retire_unresolved(DateTime.add(DateTime.utc_now(), 1))
+
+      assert retired.state == "stopped"
+      assert retired.last_error == "termination_unconfirmed"
+      refute ExecutionGuard._unsafe_fenced?(c.conversation.id)
+      # The turn's own outcome is untouched: it did succeed.
+      assert Repo.get!(Turn, c.turn.id).status == "completed"
     end
   end
 end

--- a/apps/fountain/test/fountain/conversations/execution_transport_test.exs
+++ b/apps/fountain/test/fountain/conversations/execution_transport_test.exs
@@ -276,7 +276,19 @@ defmodule Fountain.Conversations.ExecutionTransportTest do
         execution_limits: limits
       )
 
-    on_exit(fn -> if Process.alive?(peer), do: GenServer.stop(peer) end)
+    # Not `if Process.alive?(peer)`: this test drives the peer into a failed
+    # state on purpose, so teardown races its exit. The check-then-act version
+    # saw it alive, it exited, and `GenServer.stop/1` then died with `no
+    # process` — a green test body with a red teardown. Tolerating the exit is
+    # what the rest of the suite does (`ConversationServerCase`).
+    on_exit(fn ->
+      try do
+        GenServer.stop(peer)
+      catch
+        :exit, _ -> :ok
+      end
+    end)
+
     :ok = Managoat.ACP.Testing.ScriptedAgent.connect(agent, peer)
     assert_receive {:acp, ^ref, {:done, "end_turn", _}}, 2_000
     assert_received {:scripted_agent, :wrote, %{"method" => "session/prompt"}}

--- a/apps/fountain/test/fountain/conversations/execution_transport_test.exs
+++ b/apps/fountain/test/fountain/conversations/execution_transport_test.exs
@@ -299,4 +299,49 @@ defmodule Fountain.Conversations.ExecutionTransportTest do
     refute_received {:scripted_agent, :wrote, %{"method" => "session/prompt"}}
     assert Repo.get!(Turn, c.turn.id).status == "completed"
   end
+
+  test "a provider without trusted session identity is refused, not silently unbounded", c do
+    # Only the Sprites adapter reports a provider-issued session id from control
+    # metadata, and without one there is nothing to terminate by name. A caller
+    # that asks for a bound and is told no is fine; one that is ignored is not.
+    execution = register(c)
+
+    for provider <- ~w(e2b daytona runner) do
+      Repo.update_all(
+        from(e in TurnExecution, where: e.id == ^execution.id),
+        set: [provider: provider]
+      )
+
+      assert {:error, :provider_not_supported} =
+               ExecutionTransport._unsafe_start(execution.id, self(), "prog", [])
+
+      # Refusal is not a spawn: no intent is recorded, so the turn stays
+      # retryable rather than landing in the awaiting_identity fence.
+      assert row(execution).spawn_submitted_at == nil
+      assert row(execution).state == "active"
+    end
+  end
+
+  test "a timeout and a dead transport are different answers", c do
+    execution = register(c)
+
+    # A process that never replies: the caller must not be told "nothing
+    # happened", because a write may be in flight.
+    silent =
+      spawn(fn ->
+        receive do
+          :never -> :ok
+        end
+      end)
+
+    assert {:error, :transport_timeout} = ExecutionTransport.write(silent, "x", 50)
+
+    # A process that is gone cannot be mid-write, and that is a different fact.
+    dead = spawn(fn -> :ok end)
+    ref = Process.monitor(dead)
+    assert_receive {:DOWN, ^ref, :process, ^dead, _}
+    assert {:error, :transport_unavailable} = ExecutionTransport.write(dead, "x", 50)
+
+    assert row(execution).state == "active"
+  end
 end

--- a/apps/fountain/test/fountain/conversations/execution_transport_test.exs
+++ b/apps/fountain/test/fountain/conversations/execution_transport_test.exs
@@ -1,0 +1,302 @@
+defmodule Fountain.Conversations.ExecutionTransportTest do
+  use Fountain.DataCase, async: false
+  use Mimic
+
+  setup :set_mimic_global
+
+  alias Fountain.Conversations.{ExecutionGuard, ExecutionTransport, Turn, TurnExecution}
+  alias Managoat.Sandbox
+  alias Managoat.Sandbox.{Command, Handle}
+
+  setup do
+    user = insert_verified_user()
+    sandbox = insert_sandbox(user_id: user.id, status: "ready")
+    conv = insert_conversation(user_id: user.id, sandbox: sandbox, status: "running")
+    now = DateTime.utc_now()
+    turn = insert_turn(conv, status: "running", started_at: DateTime.truncate(now, :second))
+    %{conv: conv, turn: turn, sandbox: sandbox, now: now}
+  end
+
+  defp register(c, milliseconds \\ 10_000) do
+    {:ok, execution} =
+      ExecutionGuard._unsafe_register(
+        c.turn.id,
+        Ecto.UUID.generate(),
+        DateTime.add(DateTime.utc_now(), milliseconds, :millisecond)
+      )
+
+    execution
+  end
+
+  defp launch(execution, behavior, opts \\ []) do
+    test = self()
+    name = execution.sandbox_name
+    ref = make_ref()
+    command = %Command{provider: :sprites, ref: ref}
+
+    expect(Sandbox, :build_handle, fn :sprites, ^name ->
+      %Handle{provider: :sprites, name: name}
+    end)
+
+    expect(Sandbox, :spawn, fn %Handle{name: ^name}, "acp", [], spawn_opts ->
+      transport = Keyword.fetch!(spawn_opts, :owner)
+      assert spawn_opts[:session_info] == true
+      assert spawn_opts[:stdin] == true
+      assert spawn_opts[:detachable] == true
+      send(test, {:spawn, transport, ref, self()})
+      behavior.(transport, ref)
+      {:ok, command}
+    end)
+
+    owner = Keyword.get(opts, :actor, self())
+    {:ok, pid} = ExecutionTransport._unsafe_start(execution.id, owner, "acp", [], opts)
+
+    on_exit(fn ->
+      DynamicSupervisor.terminate_child(Fountain.ExecutionTransportSupervisor, pid)
+    end)
+
+    {pid, ref}
+  end
+
+  defp identify(owner, ref), do: send(owner, {:session_info, %{ref: ref}, "19"})
+  defp row(execution), do: Repo.get!(TurnExecution, execution.id)
+
+  defp await_state(execution, expected, attempts \\ 200)
+  defp await_state(_execution, expected, 0), do: flunk("journal never reached #{expected}")
+
+  defp await_state(execution, expected, attempts) do
+    current = row(execution)
+
+    if current.state == expected do
+      current
+    else
+      Process.sleep(10)
+      await_state(execution, expected, attempts - 1)
+    end
+  end
+
+  test "trusted identity binds outside an unresponsive actor and permits the actual writer", c do
+    owner = spawn(fn -> receive do: (:stop -> :ok) end)
+    on_exit(fn -> Process.exit(owner, :kill) end)
+    execution = register(c)
+    {pid, ref} = launch(execution, &identify/2, actor: owner)
+    assert {:ok, %Command{ref: ^ref}} = ExecutionTransport.await_ready(pid)
+    assert Process.alive?(owner)
+    assert row(execution).provider_session_id == "19"
+
+    expect(Sandbox, :write_stdin, fn %Command{ref: ^ref}, "initialize" -> :ok end)
+    assert :ok = ExecutionTransport.write(pid, "initialize")
+  end
+
+  test "stdout and another command's control metadata cannot bind identity", c do
+    execution = register(c)
+
+    {pid, ref} =
+      launch(execution, fn owner, ref ->
+        send(owner, {:stdout, %{ref: ref}, ~s({"type":"session_info","id":"forged"})})
+        send(owner, {:session_info, %{ref: make_ref()}, "wrong-command"})
+      end)
+
+    assert_receive {:spawn, ^pid, ^ref, _}
+    assert {:error, :execution_fenced} = ExecutionTransport.write(pid, "must not write")
+    assert row(execution).provider_session_id == nil
+    identify(pid, ref)
+    assert {:ok, %Command{ref: ^ref}} = ExecutionTransport.await_ready(pid)
+    assert row(execution).provider_session_id == "19"
+  end
+
+  test "conflicting control identities fence the original execution", c do
+    execution = register(c)
+    {pid, ref} = launch(execution, &identify/2)
+    assert {:ok, _} = ExecutionTransport.await_ready(pid)
+    send(pid, {:session_info, %{ref: ref}, "20"})
+    current = await_state(execution, "uncertain")
+    assert current.provider_session_id == "19"
+    assert current.last_error == "conflicting_identity"
+    assert {:error, :execution_fenced} = ExecutionTransport.write(pid, "must not write")
+  end
+
+  test "identity received before a delayed spawn result still enables cleanup after expiry", c do
+    execution = register(c, 200)
+
+    {pid, ref} =
+      launch(execution, fn owner, ref ->
+        identify(owner, ref)
+        receive do: (:release -> :ok)
+      end)
+
+    assert_receive {:spawn, ^pid, ^ref, task}
+    await_state(execution, "awaiting_identity")
+    assert Repo.get!(Turn, c.turn.id).limit_reason == "wall_time_limit"
+    send(task, :release)
+    current = await_state(execution, "ready")
+    assert current.provider_session_id == "19"
+    assert current.deadline_at == execution.deadline_at
+    assert {:error, :execution_fenced} = ExecutionTransport.write(pid, "late prompt")
+    assert {:ok, %{permitted: true}} = ExecutionGuard._unsafe_claim_termination(execution.id)
+  end
+
+  test "an unconfirmed spawn is never replayed", c do
+    execution = register(c)
+    {pid, _} = launch(execution, fn _, _ -> receive do: (:never -> :ok) end, io_timeout_ms: 100)
+    await_state(execution, "awaiting_identity")
+    assert {:error, :execution_fenced} = ExecutionTransport.await_ready(pid)
+
+    assert {:error, :spawn_not_ready} =
+             ExecutionTransport._unsafe_start(execution.id, self(), "acp", [])
+
+    assert row(execution).spawn_submitted_at
+  end
+
+  test "a blocked writer times out and retires the session without replay", c do
+    execution = register(c)
+    {pid, ref} = launch(execution, &identify/2, io_timeout_ms: 100)
+    assert {:ok, _} = ExecutionTransport.await_ready(pid)
+
+    expect(Sandbox, :write_stdin, fn %Command{ref: ^ref}, "prompt" ->
+      receive do: (:never -> :ok)
+    end)
+
+    assert {:error, :operation_unconfirmed} = ExecutionTransport.write(pid, "prompt")
+    await_state(execution, "ready")
+    assert {:error, :execution_fenced} = ExecutionTransport.write(pid, "prompt")
+    assert Repo.get!(Turn, c.turn.id).status == "interrupted"
+  end
+
+  test "actor death records retirement independently of its mailbox", c do
+    owner = spawn(fn -> receive do: (:stop -> :ok) end)
+    on_exit(fn -> Process.exit(owner, :kill) end)
+    execution = register(c)
+    {pid, _} = launch(execution, &identify/2, actor: owner)
+    assert {:ok, _} = ExecutionTransport.await_ready(pid)
+    Process.exit(owner, :kill)
+    await_state(execution, "ready")
+    assert {:error, :execution_fenced} = ExecutionTransport.write(pid, "late prompt")
+  end
+
+  test "close acknowledges the durable intent without claiming remote confirmation", c do
+    execution = register(c)
+    {pid, _} = launch(execution, &identify/2)
+    assert {:ok, _} = ExecutionTransport.await_ready(pid)
+    assert :ok = ExecutionTransport.close(pid)
+    assert row(execution).state == "ready"
+    assert row(execution).confirmed_at == nil
+    assert Repo.get!(Turn, c.turn.id).status == "interrupted"
+    assert :ok = ExecutionTransport.close(pid)
+  end
+
+  test "an orphaned spawn task still times out after abrupt transport death", c do
+    execution = register(c)
+    {pid, ref} = launch(execution, fn _, _ -> receive do: (:never -> :ok) end, io_timeout_ms: 200)
+    assert_receive {:spawn, ^pid, ^ref, task}
+    task_ref = Process.monitor(task)
+    Process.exit(pid, :kill)
+    assert_receive {:DOWN, ^task_ref, :process, ^task, :killed}, 2_000
+    assert row(execution).spawn_submitted_at
+    assert {:error, :transport_unavailable} = ExecutionTransport.write(pid, "late prompt")
+    ExecutionGuard._unsafe_expire(execution.id, now: execution.deadline_at)
+    assert row(execution).state == "awaiting_identity"
+
+    assert {:error, :spawn_not_ready} =
+             ExecutionTransport._unsafe_start(execution.id, self(), "acp", [])
+  end
+
+  test "a completed turn cannot authorize more writes while its connection retires", c do
+    execution = register(c)
+    {pid, _} = launch(execution, &identify/2)
+    assert {:ok, _} = ExecutionTransport.await_ready(pid)
+    ExecutionGuard._unsafe_complete(execution.id, "completed")
+    assert {:error, :execution_fenced} = ExecutionTransport.write(pid, "late prompt")
+    assert row(execution).state == "ready"
+    assert Repo.get!(Turn, c.turn.id).status == "completed"
+  end
+
+  test "invalid identity never grants a writer", c do
+    execution = register(c)
+
+    {pid, _} =
+      launch(execution, fn owner, ref ->
+        send(owner, {:session_info, %{ref: ref}, "../invalid"})
+      end)
+
+    await_state(execution, "awaiting_identity")
+    assert row(execution).provider_session_id == nil
+    assert {:error, :execution_fenced} = ExecutionTransport.write(pid, "must not write")
+  end
+
+  test "a terminal command frame seals writes without racing the actor's completion", c do
+    execution = register(c)
+    {pid, ref} = launch(execution, &identify/2)
+    assert {:ok, _} = ExecutionTransport.await_ready(pid)
+    send(pid, {:exit, %{ref: ref}, 0})
+    assert_receive {:exit, %{ref: ^ref}, 0}
+    assert {:error, :execution_fenced} = ExecutionTransport.write(pid, "late prompt")
+    assert Repo.get!(Turn, c.turn.id).status == "running"
+    ExecutionGuard._unsafe_complete(execution.id, "completed")
+    assert :ok = ExecutionTransport.close(pid)
+    assert Repo.get!(Turn, c.turn.id).status == "completed"
+    assert row(execution).state == "ready"
+  end
+
+  test "crash status does not reveal spawn options, messages or buffered output" do
+    status =
+      ExecutionTransport.format_status(%{
+        state: %{execution: %{id: "journal"}, phase: :spawning, buffer: ["private-output"]},
+        message: {:spawn, "acp", [], env: [KEY: "private-key"]},
+        reason: "private-provider-response",
+        log: ["private-log"]
+      })
+
+    refute inspect(status) =~ "private-"
+    assert status.state == %{execution_id: "journal", phase: :spawning}
+  end
+
+  test "the real ACP peer uses the guarded writer and cannot prompt after completion", c do
+    execution = register(c)
+    {pid, ref} = launch(execution, &identify/2)
+    {:ok, command} = ExecutionTransport.await_ready(pid)
+    {:ok, agent} = Managoat.ACP.Testing.ScriptedAgent.start_link(observer: self())
+    writer = Managoat.ACP.Testing.ScriptedAgent.writer(agent)
+
+    stub(Sandbox, :write_stdin, fn %Command{ref: ^ref}, data -> writer.(data) end)
+
+    {:ok, limits} =
+      Managoat.ACP.ExecutionLimits.new(:claude, %{
+        max_model_turns: 2,
+        max_estimated_cost_usd: 0.25
+      })
+
+    {peer, _monitor} =
+      Fountain.Conversations.TurnMachine.start_acp_peer(
+        command,
+        "first prompt",
+        :run,
+        nil,
+        execution_transport: pid,
+        execution_limits: limits
+      )
+
+    on_exit(fn -> if Process.alive?(peer), do: GenServer.stop(peer) end)
+    :ok = Managoat.ACP.Testing.ScriptedAgent.connect(agent, peer)
+    assert_receive {:acp, ^ref, {:done, "end_turn", _}}, 2_000
+    assert_received {:scripted_agent, :wrote, %{"method" => "session/prompt"}}
+
+    assert_received {:scripted_agent, :wrote,
+                     %{
+                       "method" => "session/new",
+                       "params" => %{
+                         "_meta" => %{
+                           "claudeCode" => %{
+                             "options" => %{"maxTurns" => 2, "maxBudgetUsd" => 0.25}
+                           }
+                         }
+                       }
+                     }}
+
+    ExecutionGuard._unsafe_complete(execution.id, "completed")
+    assert {:error, {:not_idle, :failed}} = Managoat.ACP.Peer.prompt(peer, "late prompt", [])
+    assert_receive {:acp, ^ref, {:failed, {:acp_write_failed, :execution_fenced}}}, 2_000
+    refute_received {:scripted_agent, :wrote, %{"method" => "session/prompt"}}
+    assert Repo.get!(Turn, c.turn.id).status == "completed"
+  end
+end

--- a/decisions/0046-durable-turn-deadlines.md
+++ b/decisions/0046-durable-turn-deadlines.md
@@ -150,7 +150,7 @@ Integration surfaces already inspected:
 | --- | --- |
 | `TurnMachine.open` and autonomous starts | Atomically reserve authorized limits and register before any provider work. |
 | `ConversationServer.run_turn` and warm reuse | Preserve the deadline and connection identity; gate every prompt before writing it. |
-| `TurnMachine.start_acp_peer` | Route the writer through a supervised transport that captures trusted session metadata outside the actor mailbox. |
+| `TurnMachine.start_acp_peer` | Implemented for Sprites (`ExecutionTransport`): spawn intent before I/O, stdin closed until identity binds, every write rechecking the journal. Other providers refuse. |
 | `ConversationServer.interrupt_turn` | Persist cancellation before blocking I/O; drive confirmed remote termination independently. |
 | `wake_conversation`, `Rehydrator`, Horde starts | Honor open journal entries before reconnecting or replacing execution. |
 | Interrupted provisioning and parent deletion | Preserve original ownership/incarnation and unresolved obligations through teardown or replacement. |
@@ -160,6 +160,32 @@ Journal retention after confirmed cleanup and account deletion also needs an
 explicit policy. Uncertainty must never be erased by transcript deletion — but
 it must not be permanent either, which is what the ageing exit above settles.
 The cutoff itself is the supervisor's to choose and is not fixed here.
+
+### A successful reply is not evidence the command stopped
+
+Every bounded connection owes remote cleanup, a successful turn included, so a
+completed turn's journal row lands in `ready` rather than `completed`. A runtime
+that answered correctly can still hold background work — the out-of-turn
+`session_info_update` that produced phantom follow-up turns is the same shape —
+and a warm connection carries whatever SDK allowance its previous prompt left.
+A bounded turn therefore never inherits a warm process: `prior_connection/1`
+refuses any reuse.
+
+The corollary is that the fence reaches the happy path, which is why the ageing
+exit above is load-bearing rather than a corner case: a turn that answered
+correctly, whose cleanup is then lost, would otherwise fence its conversation
+and its machine as surely as a timeout. Ageing it out leaves the turn's own
+outcome alone; it only gives up on the cleanup.
+
+### Bounded turns are a Sprites-only capability
+
+`ExecutionTransport` refuses every provider but Sprites, and admission rolls
+back `:provider_not_supported` to match. Binding a provider-issued session id
+from trusted control metadata is a per-adapter capability, and only the Sprites
+adapter has it; without it there is nothing to terminate by name. E2B, Daytona
+and self-hosted runners (ADR 0018, ADR 0022) therefore cannot carry a bounded
+turn, and they get a refusal at admission rather than a silently unbounded one.
+A provider joins in the PR that teaches its adapter to report session identity.
 
 ### What the public surface does and does not yet promise
 

--- a/decisions/evidence/execution-transport.json
+++ b/decisions/evidence/execution-transport.json
@@ -1,0 +1,76 @@
+{
+  "recorded_at": "2026-09-08T02:18:59.678753+00:00",
+  "scope": "Local supervised command transport and real ACP peer over a simulated sandbox; no production activation",
+  "parent": "b339383a7404597b3e3f5fe3b04edecc160c8de0",
+  "precommit": {
+    "tests": 4699,
+    "doctests": 6,
+    "failures": 0,
+    "skipped": 2,
+    "excluded": 7,
+    "log_sha256": "sha256:4172d32f3ca2d54b6488e2f1f22aceeba7e7238773e9886cc88f1c9cb266b2ae"
+  },
+  "focused": {
+    "tests": 66,
+    "transport_tests": 14,
+    "failures": 0,
+    "log_sha256": "sha256:53fad95abcec79291a31cd4967e87aacc61eb9c6fa38c5a95f52718a90ec9506"
+  },
+  "database_races": {
+    "scope": "Local PostgreSQL arbitration, event durability and write permissions only",
+    "outcomes": {
+      "completion_won": 16,
+      "expiry_won": 4
+    },
+    "cases": 20,
+    "separate_database_connections": true,
+    "provider_operations": 0,
+    "lock_wait_cannot_extend_deadline": true,
+    "delayed_lock_tables": [
+      "conversations",
+      "turns"
+    ],
+    "delayed_operations": [
+      "spawn",
+      "stdin_write"
+    ],
+    "completed_connections_require_cleanup": true,
+    "deadline_event_reuse_cases": 4
+  },
+  "race_log_sha256": "sha256:ad3fc770dae8fed9f58126903aae6e4ba1e7953f055743f8eb5007754267a172",
+  "proved": [
+    "Trusted matching control metadata gates stdin; stdout and wrong references cannot bind",
+    "Delayed identity can make an expired spawn cleanable without reopening writes",
+    "Unknown spawns and failed or timed-out writes are never replayed",
+    "Owner death and close persist retirement intent; close does not acknowledge remote termination",
+    "Local operation timers survive transport death",
+    "Successful bounded turns retain cleanup obligations and cannot reuse retired connections",
+    "Terminal command frames seal writes without racing the actor with an invented interruption",
+    "Real ACP peer completes handshake/prompt with typed Claude SDK limits then refuses another prompt after completion",
+    "Crash status omits credential-bearing messages and buffers"
+  ],
+  "prior_validation": {
+    "peer_expectation_failure": "One local test incorrectly expected the peer to return :ok and exit on write refusal. Corrected to its actual failed phase/error contract; subsequent focused and full gates passed.",
+    "log_sha256": "sha256:3647213d2a35c35847622bf086fb6d3c98ee4e7e1a8307f1248eb34e7130d7ff"
+  },
+  "provider_operations": 0,
+  "deployment_performed": false,
+  "public_enforcement_enabled": false,
+  "remaining": [
+    "Released Sprites trusted identity support",
+    "Adapter installation inside the tracked provider command",
+    "All fresh/warm/autonomous actor, cancellation, recovery and sandbox lifecycle integration",
+    "Late output and actor generation fencing",
+    "Public timeout, cancellation, restart, neighboring-session and actual cleanup acceptance",
+    "Aggregate accounting and real billing/escaped-descendant proof"
+  ],
+  "source_sha256": {
+    "apps/fountain/lib/fountain/application.ex": "sha256:e98c48617cd7ec3243b550274ec24d48500b2ee2f37e56caf64b961d8c7cb732",
+    "apps/fountain/lib/fountain/conversations/execution_transport.ex": "sha256:0102c5f177dec76abcd98084af515bea472f7e59a21bdfc6f940bf9725aa3f35",
+    "apps/fountain/lib/fountain/conversations/execution_guard.ex": "sha256:12886ebfad0b99da25b0923b466ae8bee4d2c8fbb85a2cff5127a1fe1db165de",
+    "apps/fountain/lib/fountain/conversations/turn_machine.ex": "sha256:7dbe1f677f522c9e73350c03856ba2d03dd22adbeeee6a54d33029a74a9b1781",
+    "apps/fountain/test/fountain/conversations/execution_transport_test.exs": "sha256:9107f762a4e3bc9ec1a8654cab769be445693e9d260647a289f07121f800ef75",
+    "apps/fountain/test/fountain/conversations/execution_guard_test.exs": "sha256:a97a4d3ca042e0078fa35b349262e59a1618d3fa28676daa4e01ffc53707b235",
+    "scripts/verify-turn-deadline-races.exs": "sha256:9f547453301b8936abf973c0d2578ad12933821a78616e0d408d81117bac9243"
+  }
+}

--- a/deps
+++ b/deps
@@ -1,0 +1,1 @@
+/private/tmp/claude-501/-Users-jake-dev-BinaryBourbon-fountain/9b86f823-5f5f-46ba-b9d9-dd55978fc91f/scratchpad/wt1744/deps

--- a/scripts/verify-turn-deadline-races.exs
+++ b/scripts/verify-turn-deadline-races.exs
@@ -103,9 +103,25 @@ results =
     turn = Repo.get!(Turn, turn.id)
 
     case {execution.state, turn.status} do
-      {"completed", "completed"} ->
+      {"ready", "completed"} ->
         nil = execution.deadline_event_id
-        {:error, :not_ready} = ExecutionGuard._unsafe_claim_termination(execution.id)
+
+        {:error, :execution_fenced} =
+          ExecutionGuard._unsafe_authorize_write(execution.id, connection)
+
+        claims =
+          DeadlineRace.concurrently([
+            fn -> ExecutionGuard._unsafe_claim_termination(execution.id) end,
+            fn -> ExecutionGuard._unsafe_claim_termination(execution.id) end
+          ])
+
+        [%{execution: claimed}] = for {:ok, %{permitted: true} = claim} <- claims, do: claim
+        [{:error, :not_ready}] = Enum.filter(claims, &match?({:error, _}, &1))
+
+        {:ok, %{state: "stopped"}} =
+          ExecutionGuard._unsafe_record_termination(claimed.id, claimed.attempt_id, :ok)
+
+        "completed" = Repo.get!(Turn, turn.id).status
         "completion_won"
 
       {"ready", "failed"} ->
@@ -165,13 +181,13 @@ results =
         "expiry_won"
 
       _ ->
-        raise "Completion and termination were not mutually exclusive"
+        raise "Completion/expiry failed to retain the required cleanup obligation"
     end
   end
 
 # A caller can reach the journal before its deadline, then wait behind a lock
 # until after it. Authorization must use the time after acquiring the lock.
-for lock_table <- ["conversations", "turns"] do
+for operation <- [:spawn, :write], lock_table <- ["conversations", "turns"] do
   sandbox =
     Repo.insert!(%Sandbox{
       user_id: user.id,
@@ -198,7 +214,13 @@ for lock_table <- ["conversations", "turns"] do
   owner = self()
   lock_id = if lock_table == "conversations", do: conv.id, else: turn.id
   deadline = DateTime.add(DateTime.utc_now(), 2, :second)
-  {:ok, execution} = ExecutionGuard._unsafe_register(turn.id, Ecto.UUID.generate(), deadline)
+  connection = Ecto.UUID.generate()
+  {:ok, execution} = ExecutionGuard._unsafe_register(turn.id, connection, deadline)
+
+  if operation == :write do
+    {:ok, _} = ExecutionGuard._unsafe_claim_spawn(execution.id)
+    {:ok, _} = ExecutionGuard._unsafe_bind_identity(execution.id, connection, "controlled-write")
+  end
 
   holder =
     Task.async(fn ->
@@ -228,7 +250,11 @@ for lock_table <- ["conversations", "turns"] do
       Repo.checkout(fn ->
         %{rows: [[backend]]} = Repo.query!("SELECT pg_backend_pid()")
         send(owner, {:claim_backend, backend})
-        ExecutionGuard._unsafe_claim_spawn(execution.id)
+
+        case operation do
+          :spawn -> ExecutionGuard._unsafe_claim_spawn(execution.id)
+          :write -> ExecutionGuard._unsafe_authorize_write(execution.id, connection)
+        end
       end)
     end)
 
@@ -256,8 +282,15 @@ for lock_table <- ["conversations", "turns"] do
   Process.sleep(max(DateTime.diff(deadline, DateTime.utc_now(), :millisecond), 0) + 50)
   send(holder.pid, :release)
   Task.await(holder)
-  {:error, :deadline_expired} = Task.await(claim)
-  true = is_nil(Repo.get!(TurnExecution, execution.id).spawn_submitted_at)
+
+  case operation do
+    :spawn ->
+      {:error, :deadline_expired} = Task.await(claim)
+      true = is_nil(Repo.get!(TurnExecution, execution.id).spawn_submitted_at)
+
+    :write ->
+      {:ok, %{permitted: false, turn: %{limit_reason: "wall_time_limit"}}} = Task.await(claim)
+  end
 end
 
 IO.puts(
@@ -269,6 +302,8 @@ IO.puts(
       provider_operations: 0,
       lock_wait_cannot_extend_deadline: true,
       delayed_lock_tables: ["conversations", "turns"],
+      delayed_operations: ["spawn", "stdin_write"],
+      completed_connections_require_cleanup: true,
       deadline_event_reuse_cases: Enum.count(results, &(&1 == "expiry_won")),
       scope: "Local PostgreSQL arbitration, event durability and write permissions only"
     })


### PR DESCRIPTION
A bounded turn needs its provider command tracked even when the conversation actor blocks or the turn succeeds. This adds a supervised transport that binds trusted command identity, checks durable authority before each ACP write, and retains cleanup obligations for every outcome. Unknown spawns and uncertain writes are never replayed. Successful turns require confirmed cleanup before a fresh connection can proceed.

Stacked on #1747. **Draft; public enforcement remains disabled.** The conversation actor does not select this transport yet. Activation still requires tracked adapter setup, complete actor/cancellation/recovery wiring, released Sprites identity support, and live acceptance. Local shutdown and a completed reply do not prove remote termination or stopped billing.

Validation: full precommit **4,699 tests and 6 doctests, zero failures**; 66 focused tests; 20 independent PostgreSQL races. A real ACP peer runs through the guarded writer against a simulated provider, then refuses a post-completion prompt. Tests cover identity forgery/conflicts, delayed spawn results, blocked writes, owner death, durable close acknowledgment, orphan task timeouts, terminal outcome arbitration and redacted crash state. No provider operations occurred. ADR 0046 and `decisions/evidence/execution-transport.json` record scope and evidence.

Tracks #1732. Internal preparation only; `sdk-no-release` applies.

[All 24 CI checks pass or intentionally skip at `9b1fb2ea8a26e9d32823d7c0e5c0a8ed5f2b4a83`](https://github.com/BinaryBourbon/fountain/actions/runs/34179844997).



Part of #1732 — **held**. Superseded on main by #1773–#1793; the residual hunks are being re-cut as focused PRs tracked by #1864, which keeps these frozen until each has a replacement or an explicitly linked deferral. Do not close: they are the reference for that mapping.
