### PR TITLE
Fence bounded transcripts and deduplicate delayed usage

### DIFF
--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -2225,9 +2225,6 @@ defmodule Fountain.Conversations do
     # used to raise inside the transaction and take the turn's usage
     # recording with it. Anything that is not a non-negative integer counts
     # as nothing, which is what an unreported figure already counts as.
-    input = counter_value(Map.get(usage, "input"))
-    output = counter_value(Map.get(usage, "output"))
-
     Repo.transaction(fn ->
       # Same parent-before-turn lock order as ExecutionGuard. Delayed accounting
       # survives retirement, but duplicate deliveries cannot debit twice.
@@ -2241,7 +2238,30 @@ defmodule Fountain.Conversations do
             lock: "FOR UPDATE"
         ) || Repo.rollback(:not_found)
 
-      if is_map(current.usage), do: Repo.rollback(:already_recorded)
+      # The row read under the lock is what decides, not the one the caller
+      # matched on — that is the whole point of re-reading it. But `usage` is
+      # not only a figure: a turn carries an inference stamp from the moment
+      # it starts (#1685), which is a map and is not a recorded usage. Refuse
+      # a real second figure, and merge over a stamp exactly as
+      # `_unsafe_record_turn_usage/2` does on the unlocked read above.
+      # Checking `is_map/1` alone refused every stamped turn, which is every
+      # turn on platform inference.
+      usage =
+        cond do
+          is_nil(current.usage) -> usage
+          Turn.inference_stamp_only?(current.usage) -> Map.merge(current.usage, usage)
+          true -> Repo.rollback(:already_recorded)
+        end
+
+      # After the merge, so a stamp that ever grows a counter still debits it.
+      # `usage` is whatever the runtime reported. The map is stored as it came,
+      # but the counters it increments are bigints: a string or an object here
+      # used to raise inside the transaction and take the turn's usage
+      # recording with it. Anything that is not a non-negative integer counts
+      # as nothing, which is what an unreported figure already counts as.
+      input = counter_value(Map.get(usage, "input"))
+      output = counter_value(Map.get(usage, "output"))
+
       {:ok, updated} = current |> Turn.changeset(%{usage: usage}) |> Repo.update()
 
       {1, _} =

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -2390,19 +2390,17 @@ defmodule Fountain.Conversations do
     # or its events can commit out from behind the cursor and never be seen.
     writer = fn -> %LogEvent{} |> LogEvent.changeset(attrs) |> insert_ordered_log_event!() end
 
+    # LOCK ORDER, before the call below: on the bounded path
+    # `_unsafe_write_event/3` already holds the conversation, journal and turn
+    # rows `FOR UPDATE`, so the advisory lock inside
+    # `insert_ordered_log_event!/1` is taken *after* those rows, while every
+    # other log-event write takes it *before* touching the conversation (its
+    # insert needs `KEY SHARE` on that row through the foreign key). Two
+    # writers on one account can therefore take these in opposite orders.
+    # Postgres aborts one rather than hanging, and the path is unreachable
+    # while no execution ceiling can be set, but the inversion is real.
     if attrs[:kind] == "output" do
       # ownership: callers supply the owned conversation and exact output turn.
-      #
-      # LOCK ORDER, and the one thing to know before touching this: on the
-      # bounded path `_unsafe_write_event/3` already holds the conversation,
-      # journal and turn rows `FOR UPDATE`, so the advisory lock inside
-      # `insert_ordered_log_event!/1` is taken *after* those rows, while every
-      # other log-event write takes it *before* touching the conversation (its
-      # insert needs `KEY SHARE` on that row through the foreign key). Two
-      # writers on one account can therefore take these in opposite orders.
-      # Postgres would abort one rather than hang, and the path is unreachable
-      # while no execution ceiling can be set, but it is a real inversion and
-      # not something the rebase introduced deliberately.
       {:ok, event} =
         ExecutionGuard._unsafe_write_event(attrs[:conversation_id], attrs[:turn_id], writer)
 

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -2229,7 +2229,20 @@ defmodule Fountain.Conversations do
     output = counter_value(Map.get(usage, "output"))
 
     Repo.transaction(fn ->
-      {:ok, updated} = turn |> Turn.changeset(%{usage: usage}) |> Repo.update()
+      # Same parent-before-turn lock order as ExecutionGuard. Delayed accounting
+      # survives retirement, but duplicate deliveries cannot debit twice.
+      Repo.one(from c in Conversation, where: c.id == ^turn.conversation_id, lock: "FOR UPDATE") ||
+        Repo.rollback(:not_found)
+
+      current =
+        Repo.one(
+          from t in Turn,
+            where: t.id == ^turn.id and t.conversation_id == ^turn.conversation_id,
+            lock: "FOR UPDATE"
+        ) || Repo.rollback(:not_found)
+
+      if is_map(current.usage), do: Repo.rollback(:already_recorded)
+      {:ok, updated} = current |> Turn.changeset(%{usage: usage}) |> Repo.update()
 
       {1, _} =
         Repo.update_all(
@@ -2330,7 +2343,9 @@ defmodule Fountain.Conversations do
 
   @doc """
   Insert a log event. Returns the inserted struct (with integer `:id`,
-  used as the SSE event id).
+  used as the SSE event id), or nil for output from a retired bounded turn.
+  Stage callers use `publish_stage/4`; the deadline journal inserts its own
+  terminal event while holding the same locks.
   """
   def log!(attrs) do
     # Microsecond precision so the LiveView can compute stage durations
@@ -2344,9 +2359,31 @@ defmodule Fountain.Conversations do
     # log path is covered whether or not its author knew to.
     attrs = redact_attrs(attrs)
 
-    %LogEvent{}
-    |> LogEvent.changeset(attrs)
-    |> insert_ordered_log_event!()
+    # The writer is main's ordered insert (#1706), not a bare `Repo.insert!`:
+    # a bounded turn's output still has to take the account's SSE cursor lock,
+    # or its events can commit out from behind the cursor and never be seen.
+    writer = fn -> %LogEvent{} |> LogEvent.changeset(attrs) |> insert_ordered_log_event!() end
+
+    if attrs[:kind] == "output" do
+      # ownership: callers supply the owned conversation and exact output turn.
+      #
+      # LOCK ORDER, and the one thing to know before touching this: on the
+      # bounded path `_unsafe_write_event/3` already holds the conversation,
+      # journal and turn rows `FOR UPDATE`, so the advisory lock inside
+      # `insert_ordered_log_event!/1` is taken *after* those rows, while every
+      # other log-event write takes it *before* touching the conversation (its
+      # insert needs `KEY SHARE` on that row through the foreign key). Two
+      # writers on one account can therefore take these in opposite orders.
+      # Postgres would abort one rather than hang, and the path is unreachable
+      # while no execution ceiling can be set, but it is a real inversion and
+      # not something the rebase introduced deliberately.
+      {:ok, event} =
+        ExecutionGuard._unsafe_write_event(attrs[:conversation_id], attrs[:turn_id], writer)
+
+      event
+    else
+      writer.()
+    end
   end
 
   defp insert_ordered_log_event!(%Ecto.Changeset{valid?: true} = changeset) do
@@ -2391,9 +2428,12 @@ defmodule Fountain.Conversations do
   and fixed. `conv_id` stays in metadata and must never become a tag.
   """
   def publish_stage(conv_id, stage, status, meta \\ %{}) do
+    turn_id = Map.get(meta, :turn_id) || Map.get(meta, "turn_id")
+
     writer = fn ->
       log!(%{
         conversation_id: conv_id,
+        turn_id: turn_id,
         kind: "stage",
         stage: stage,
         state: status,
@@ -2401,20 +2441,22 @@ defmodule Fountain.Conversations do
       })
     end
 
-    turn_id = Map.get(meta, :turn_id) || Map.get(meta, "turn_id")
-
     result =
       if stage == "turn" and status in ["done", "failed", "interrupted"] and
            match?({:ok, _}, Ecto.UUID.cast(turn_id)) do
         # ownership: lifecycle caller owns conv_id; the journal query binds this
         # turn to that conversation and serializes it with deadline expiration.
-        {:ok, result} = ExecutionGuard._unsafe_terminal_stage(conv_id, turn_id, writer)
+        {:ok, result} = ExecutionGuard._unsafe_terminal_stage(conv_id, turn_id, status, writer)
         result
       else
-        {:new, writer.()}
+        {:ok, event} = ExecutionGuard._unsafe_write_event(conv_id, turn_id, writer)
+        {:new, event}
       end
 
     case result do
+      {:new, nil} ->
+        nil
+
       {:existing, event} ->
         event
 

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -2253,7 +2253,13 @@ defmodule Fountain.Conversations do
           true -> Repo.rollback(:already_recorded)
         end
 
-      # After the merge, so a stamp that ever grows a counter still debits it.
+      # Read from the merged map because that is what gets stored; the two
+      # agree either way, since the only map the merge folds in is a stamp and
+      # a stamp carries no counter. Do not read this as defending against a
+      # stamp that grows one — if that were possible the merge would debit it
+      # here and again when the real figure landed, so the ordering would be
+      # the bug rather than the guard.
+      #
       # `usage` is whatever the runtime reported. The map is stored as it came,
       # but the counters it increments are bigints: a string or an object here
       # used to raise inside the transaction and take the turn's usage

--- a/apps/fountain/lib/fountain/conversations/execution_guard.ex
+++ b/apps/fountain/lib/fountain/conversations/execution_guard.ex
@@ -329,6 +329,37 @@ defmodule Fountain.Conversations.ExecutionGuard do
     end)
   end
 
+  @doc "Serialize transcript writes with retirement; the callback must contain only database work."
+  def _unsafe_write_event(conv_id, turn_id, writer) do
+    case turn_id && Repo.get_by(TurnExecution, turn_id: turn_id) do
+      nil ->
+        {:ok, writer.()}
+
+      execution ->
+        with_execution(execution.id, fn current ->
+          now = DateTime.utc_now()
+
+          cond do
+            current.conversation_id != conv_id or not current_binding?(current) ->
+              {nil, nil, nil}
+
+            current.state != "active" ->
+              {nil, nil, nil}
+
+            DateTime.compare(now, current.deadline_at) != :lt ->
+              {_decision, changed, event} = expire(current, now)
+              {nil, changed, event}
+
+            not match?(%Turn{status: "running"}, Repo.get(Turn, current.turn_id)) ->
+              {nil, nil, nil}
+
+            true ->
+              {writer.(), nil, nil}
+          end
+        end)
+    end
+  end
+
   @doc """
   Serialize the existing turn writer with deadline and termination state.
 
@@ -365,19 +396,22 @@ defmodule Fountain.Conversations.ExecutionGuard do
 
           row = decision.turn || Repo.rollback(:turn_missing)
 
-          protected =
-            if decision.execution.state == "active",
-              do: [],
-              else: [:status, :exit_code, :ended_at, :pending_permission, :limit_reason]
+          # Once retired, a stale actor cannot rewrite its prompt, selection,
+          # reply or permission state. The winning terminal transition may
+          # retain its exit code; delayed usage has its own once-only writer.
+          allowed =
+            cond do
+              decision.execution.state == "active" ->
+                attrs
 
-          protected =
-            if Map.get(decision, :terminal_changed, false),
-              do: List.delete(protected, :exit_code),
-              else: protected
+              Map.get(decision, :terminal_changed, false) ->
+                Map.take(attrs, [:exit_code, "exit_code"])
 
-          protected = protected ++ Enum.map(protected, &Atom.to_string/1)
+              true ->
+                %{}
+            end
 
-          case writer.(row, Map.drop(attrs, protected)) do
+          case writer.(row, allowed) do
             {:ok, result} -> {result, changed, event}
             {:error, reason} -> Repo.rollback(reason)
           end
@@ -436,10 +470,13 @@ defmodule Fountain.Conversations.ExecutionGuard do
   end
 
   @doc "Serialize a terminal stage with expiration; reuse an existing deadline event."
-  def _unsafe_terminal_stage(conv_id, turn_id, writer) do
-    case Repo.get_by(TurnExecution, conversation_id: conv_id, turn_id: turn_id) do
+  def _unsafe_terminal_stage(conv_id, turn_id, status, writer) do
+    case Repo.get_by(TurnExecution, turn_id: turn_id) do
       nil ->
         {:ok, {:new, writer.()}}
+
+      execution when execution.conversation_id != conv_id ->
+        {:ok, {:existing, nil}}
 
       execution ->
         with_execution(execution.id, fn current ->
@@ -450,22 +487,44 @@ defmodule Fountain.Conversations.ExecutionGuard do
               do: expire(current, now),
               else: {%{execution: current, turn: lock_turn(current.turn_id)}, nil, nil}
 
-          result =
-            if is_nil(decision.turn) || decision.execution.deadline_event_id ||
-                 (decision.turn && decision.turn.limit_reason == "wall_time_limit") do
-              id = decision.execution.deadline_event_id
-
-              stored =
-                if id,
-                  do: Repo.get_by(LogEvent, id: id, conversation_id: conv_id, turn_id: turn_id)
-
-              {:existing, stored}
-            else
-              {:new, writer.()}
-            end
+          result = terminal_event(decision, conv_id, turn_id, status, writer)
 
           {result, changed, event}
         end)
+    end
+  end
+
+  defp terminal_event(decision, conv_id, turn_id, status, writer) do
+    execution = decision.execution
+    turn = decision.turn
+
+    cond do
+      execution.conversation_id != conv_id or is_nil(turn) ->
+        {:existing, nil}
+
+      execution.deadline_event_id || turn.limit_reason == "wall_time_limit" ->
+        stored =
+          if execution.deadline_event_id,
+            do:
+              Repo.get_by(LogEvent,
+                id: execution.deadline_event_id,
+                conversation_id: conv_id,
+                turn_id: turn_id
+              )
+
+        {:existing, stored}
+
+      not current_binding?(execution) ->
+        {:existing, nil}
+
+      Map.get(
+        %{"done" => "completed", "failed" => "failed", "interrupted" => "interrupted"},
+        status
+      ) != turn.status ->
+        {:existing, nil}
+
+      true ->
+        {:new, writer.()}
     end
   end
 

--- a/apps/fountain/lib/fountain/conversations/output.ex
+++ b/apps/fountain/lib/fountain/conversations/output.ex
@@ -160,18 +160,20 @@ defmodule Fountain.Conversations.Output do
         data: data
       })
 
-    Phoenix.PubSub.broadcast(
-      Fountain.PubSub,
-      "conv:#{ctx.conversation_id}",
-      {:log_event, event}
-    )
-
-    if ctx.user_id do
+    if event do
       Phoenix.PubSub.broadcast(
         Fountain.PubSub,
-        "sidebar:#{ctx.user_id}",
-        {:sidebar_update, ctx.user_id}
+        "conv:#{ctx.conversation_id}",
+        {:log_event, event}
       )
+
+      if ctx.user_id do
+        Phoenix.PubSub.broadcast(
+          Fountain.PubSub,
+          "sidebar:#{ctx.user_id}",
+          {:sidebar_update, ctx.user_id}
+        )
+      end
     end
 
     :ok

--- a/apps/fountain/test/fountain/analytics_bridges_test.exs
+++ b/apps/fountain/test/fountain/analytics_bridges_test.exs
@@ -319,10 +319,11 @@ defmodule Fountain.AnalyticsBridgesTest do
       user = insert_verified_user()
       agent = insert_agent(user_id: user.id)
       conv = insert_conversation(user_id: user.id, agent_id: agent.id)
+      turn = insert_turn(conv, status: "completed", exit_code: 0)
       forget_setup()
 
       Conversations.publish_stage(conv.id, "turn", "done", %{
-        turn_id: Ecto.UUID.generate(),
+        turn_id: turn.id,
         turn_number: 1,
         exit_code: 0
       })

--- a/apps/fountain/test/fountain/conversations/bounded_transcript_test.exs
+++ b/apps/fountain/test/fountain/conversations/bounded_transcript_test.exs
@@ -169,4 +169,63 @@ defmodule Fountain.Conversations.BoundedTranscriptTest do
     assert {:error, :not_found} =
              Conversations._unsafe_record_turn_usage(c.turn, %{"input" => 99})
   end
+
+  describe "the unbounded path" do
+    test "an unbounded turn's output is published unchanged, in the same shape", c do
+      # The fence can only suppress; it never rewrites. So an unbounded turn's
+      # transcript is byte-for-byte what it was, which matters because the two
+      # apps that read it live outside this repo (ADR 0034) and nothing here
+      # can update them in lockstep.
+      plain_conv =
+        insert_conversation(user_id: c.ctx.user_id, sandbox: c.sandbox, status: "running")
+
+      plain_turn = insert_turn(plain_conv, status: "running")
+      refute ExecutionGuard._unsafe_for_turn(plain_turn.id)
+
+      Phoenix.PubSub.subscribe(Fountain.PubSub, "conv:#{plain_conv.id}")
+
+      assert :ok =
+               Output.persist(
+                 %{
+                   conversation_id: plain_conv.id,
+                   turn_id: plain_turn.id,
+                   user_id: c.ctx.user_id
+                 },
+                 "stdout",
+                 "hello"
+               )
+
+      assert_receive {:log_event, %LogEvent{} = event}
+      assert event.conversation_id == plain_conv.id
+      assert event.turn_id == plain_turn.id
+      assert event.kind == "output"
+      assert event.stream == "stdout"
+      assert event.data == "hello"
+      assert is_integer(event.id)
+      assert_receive {:sidebar_update, _}
+    end
+
+    test "a duplicate usage delivery is refused rather than overwriting, bounded or not", c do
+      plain_conv =
+        insert_conversation(user_id: c.ctx.user_id, sandbox: c.sandbox, status: "running")
+
+      plain_turn = insert_turn(plain_conv, status: "running")
+
+      assert {:ok, _} =
+               Conversations._unsafe_record_turn_usage(plain_turn, %{"input" => 5, "output" => 7})
+
+      # The dedup reaches the unbounded path too: a retried provider delivery
+      # used to overwrite and double-count the conversation's counters.
+      assert {:error, :already_recorded} =
+               Conversations._unsafe_record_turn_usage(plain_turn, %{
+                 "input" => 500,
+                 "output" => 700
+               })
+
+      assert Repo.get!(Turn, plain_turn.id).usage == %{"input" => 5, "output" => 7}
+      reloaded = Conversations._unsafe_get_conversation!(plain_conv.id)
+      assert reloaded.usage_input_tokens == 5
+      assert reloaded.usage_output_tokens == 7
+    end
+  end
 end

--- a/apps/fountain/test/fountain/conversations/bounded_transcript_test.exs
+++ b/apps/fountain/test/fountain/conversations/bounded_transcript_test.exs
@@ -1,0 +1,172 @@
+defmodule Fountain.Conversations.BoundedTranscriptTest do
+  use Fountain.DataCase, async: true
+
+  alias Fountain.Conversations
+  alias Fountain.Conversations.{ExecutionGuard, LogEvent, Output, Turn, TurnExecution}
+
+  setup do
+    user = insert_verified_user()
+    sandbox = insert_sandbox(user_id: user.id, status: "ready")
+    conv = insert_conversation(user_id: user.id, sandbox: sandbox, status: "running")
+    turn = insert_turn(conv, status: "running")
+
+    {:ok, execution} =
+      ExecutionGuard._unsafe_register(
+        turn.id,
+        Ecto.UUID.generate(),
+        DateTime.add(DateTime.utc_now(), 60)
+      )
+
+    Phoenix.PubSub.subscribe(Fountain.PubSub, "conv:#{conv.id}")
+    Phoenix.PubSub.subscribe(Fountain.PubSub, "sidebar:#{user.id}")
+
+    %{
+      conv: conv,
+      turn: turn,
+      execution: execution,
+      sandbox: sandbox,
+      ctx: %{conversation_id: conv.id, turn_id: turn.id, user_id: user.id}
+    }
+  end
+
+  defp output(c, text), do: Output.persist(c.ctx, "stdout", text)
+  defp rows(c), do: Repo.all(from e in LogEvent, where: e.conversation_id == ^c.conv.id)
+
+  test "active output and stages retain the exact turn and broadcast after commit", c do
+    assert :ok = output(c, "before cancellation")
+    assert_receive {:log_event, %{kind: "output", turn_id: id}}
+    assert id == c.turn.id
+    assert_receive {:sidebar_update, _}
+    event = Conversations.publish_stage(c.conv.id, "model", "done", %{"turn_id" => c.turn.id})
+    assert event.turn_id == c.turn.id
+    assert_receive {:log_event, ^event}
+    assert length(rows(c)) == 2
+  end
+
+  test "retirement drops output and model stages without broadcasting nil or moving the sidebar",
+       c do
+    {:ok, _} = ExecutionGuard._unsafe_interrupt(c.conv.id)
+    assert :ok = output(c, "late reply")
+    assert nil == Conversations.publish_stage(c.conv.id, "model", "done", %{turn_id: c.turn.id})
+    assert rows(c) == []
+    refute_received {:log_event, _}
+    refute_received {:sidebar_update, _}
+  end
+
+  test "an elapsed deadline is enforced by the writer without a coordinator tick", c do
+    c.execution
+    |> Ecto.Changeset.change(deadline_at: DateTime.add(DateTime.utc_now(), -1))
+    |> Repo.update!()
+
+    assert :ok = output(c, "too late")
+    assert [%{kind: "stage", state: "failed", turn_id: id}] = rows(c)
+    assert id == c.turn.id
+    assert Repo.get!(Turn, id).limit_reason == "wall_time_limit"
+    refute_received {:log_event, _}
+    refute_received {:sidebar_update, _}
+  end
+
+  test "a wrong conversation cannot relabel another bounded turn's output or terminal event", c do
+    other = insert_conversation(user_id: insert_verified_user().id)
+    ctx = %{c.ctx | conversation_id: other.id}
+    assert :ok = Output.persist(ctx, "stdout", "crossed")
+    assert nil == Conversations.publish_stage(other.id, "turn", "done", %{turn_id: c.turn.id})
+    assert Repo.aggregate(LogEvent, :count) == 0
+    assert Repo.get!(TurnExecution, c.execution.id).state == "active"
+  end
+
+  test "changed sandbox identity refuses transcript writes", c do
+    c.sandbox |> Ecto.Changeset.change(sprite_name: "replacement") |> Repo.update!()
+    assert :ok = output(c, "old machine")
+    assert rows(c) == []
+  end
+
+  test "deleted parents cannot acquire late output", c do
+    {:ok, _} = ExecutionGuard._unsafe_interrupt(c.conv.id)
+    Repo.delete!(c.conv)
+    assert :ok = output(c, "orphaned output")
+    assert rows(c) == []
+  end
+
+  test "stale turn mutations cannot change the retired revision or its decision", c do
+    {:ok, _} = ExecutionGuard._unsafe_interrupt(c.conv.id)
+    original = Repo.get!(Turn, c.turn.id)
+
+    {:ok, result} =
+      Conversations._unsafe_update_turn(c.turn, %{
+        status: "completed",
+        exit_code: 0,
+        prompt: "replacement prompt",
+        reply_text: "late answer",
+        model_selection: %{status: "selected"},
+        pending_permission: %{id: "late"},
+        acp_prompt_id: 99,
+        usage: %{"input" => 999},
+        turn_number: 9
+      })
+
+    assert result == original
+  end
+
+  test "a cancellation cannot acquire a contradictory completion stage", c do
+    {:ok, _} = ExecutionGuard._unsafe_interrupt(c.conv.id)
+    assert nil == Conversations.publish_stage(c.conv.id, "turn", "done", %{turn_id: c.turn.id})
+
+    assert %{state: "interrupted"} =
+             Conversations.publish_stage(c.conv.id, "turn", "interrupted", %{turn_id: c.turn.id})
+
+    assert [%{state: "interrupted"}] = rows(c)
+  end
+
+  test "late old output cannot contaminate a successor on the same conversation", c do
+    {:ok, _} = ExecutionGuard._unsafe_interrupt(c.conv.id)
+    successor = insert_turn(c.conv, status: "running")
+
+    {:ok, _} =
+      ExecutionGuard._unsafe_register(
+        successor.id,
+        Ecto.UUID.generate(),
+        DateTime.add(DateTime.utc_now(), 60)
+      )
+
+    assert :ok = output(c, "old output")
+    assert :ok = Output.persist(%{c.ctx | turn_id: successor.id}, "stdout", "new output")
+    assert [%{data: "new output", turn_id: id}] = rows(c)
+    assert id == successor.id
+  end
+
+  test "delayed usage remains recordable after retirement and stale duplicates count once", c do
+    {:ok, _} = ExecutionGuard._unsafe_interrupt(c.conv.id)
+    usage = %{"input" => 7, "output" => 3, "accounting" => %{"complete" => false}}
+
+    assert {:ok, %{usage: ^usage, status: "interrupted"}} =
+             Conversations._unsafe_record_turn_usage(c.turn, usage)
+
+    assert {:error, :already_recorded} =
+             Conversations._unsafe_record_turn_usage(c.turn, %{"input" => 99})
+
+    conv = Conversations._unsafe_get_conversation!(c.conv.id)
+    assert conv.usage_input_tokens == 7
+    assert conv.usage_output_tokens == 3
+    assert Repo.get!(Turn, c.turn.id).usage == usage
+  end
+
+  test "usage refuses a stale parent binding without charging its counters", c do
+    other = insert_conversation(user_id: insert_verified_user().id)
+
+    assert {:error, :not_found} =
+             Conversations._unsafe_record_turn_usage(%{c.turn | conversation_id: other.id}, %{
+               "input" => 99
+             })
+
+    assert Conversations._unsafe_get_conversation!(other.id).usage_input_tokens == 0
+    assert Repo.get!(Turn, c.turn.id).usage == nil
+  end
+
+  test "deleted turns refuse delayed usage without a stale-entry crash", c do
+    Repo.delete!(c.turn)
+
+    assert {:error, :not_found} =
+             Conversations._unsafe_record_turn_usage(c.turn, %{"input" => 99})
+  end
+end

--- a/apps/fountain/test/fountain/conversations/turn_usage_test.exs
+++ b/apps/fountain/test/fountain/conversations/turn_usage_test.exs
@@ -46,6 +46,23 @@ defmodule Fountain.Conversations.TurnUsageTest do
              Conversations._unsafe_get_conversation!(conv.id)
   end
 
+  test "a delayed duplicate holding a stale turn struct is refused", %{conv: conv} do
+    t = insert_turn(conv, prompt: "one", status: "completed")
+
+    assert {:ok, _} =
+             Conversations._unsafe_record_turn_usage(t, %{"input" => 100, "output" => 20})
+
+    # `t` still carries usage: nil, so the unlocked clause lets this through and
+    # only the locked re-read can refuse it — which is why the re-read exists.
+    # Rebinding to the returned struct would route the second call into the
+    # unlocked clause and test nothing.
+    assert {:error, :already_recorded} =
+             Conversations._unsafe_record_turn_usage(t, %{"input" => 100, "output" => 20})
+
+    assert %{usage_input_tokens: 100, usage_output_tokens: 20} =
+             Conversations._unsafe_get_conversation!(conv.id)
+  end
+
   describe "over the turn-start inference stamp (#1685)" do
     test "the end-of-turn figure merges over the stamp instead of being refused", %{conv: conv} do
       t = insert_turn(conv, prompt: "one", status: "completed")
@@ -77,6 +94,25 @@ defmodule Fountain.Conversations.TurnUsageTest do
 
       assert {:error, :already_recorded} =
                Conversations._unsafe_record_turn_usage(recorded, %{"input" => 100, "output" => 20})
+    end
+
+    test "a duplicate holding the pre-figure stamped struct is refused", %{conv: conv} do
+      t = insert_turn(conv, prompt: "one", status: "completed")
+      stamp = %{"inference" => "platform", "model" => "anthropic/claude-opus-5"}
+      {:ok, stamped} = Conversations._unsafe_update_turn(t, %{usage: stamp})
+
+      assert {:ok, _} =
+               Conversations._unsafe_record_turn_usage(stamped, %{"input" => 100, "output" => 20})
+
+      # The only shape that reaches the locked read's refusal from a struct the
+      # unlocked clause believes is stamp-only: it sees a stamp on `stamped`
+      # and merges happily, and only the row read under the lock knows a real
+      # figure already landed.
+      assert {:error, :already_recorded} =
+               Conversations._unsafe_record_turn_usage(stamped, %{"input" => 100, "output" => 20})
+
+      assert %{usage_input_tokens: 100, usage_output_tokens: 20} =
+               Conversations._unsafe_get_conversation!(conv.id)
     end
 
     test "an accounting-only map is an end-of-turn record, not a stamp", %{conv: conv} do

--- a/decisions/0046-durable-turn-deadlines.md
+++ b/decisions/0046-durable-turn-deadlines.md
@@ -164,6 +164,19 @@ explicit policy. Uncertainty must never be erased by transcript deletion — but
 it must not be permanent either, which is what the ageing exit above settles.
 The cutoff itself is the supervisor's to choose and is not fixed here.
 
+### The fence suppresses; it never rewrites
+
+A retired bounded turn's output events are not written and not broadcast:
+`log!/1` returns `nil` for `kind: "output"` behind the fence, and `Output`
+skips the PubSub publish rather than broadcasting a nil. No event changes
+*shape*, which matters because the two apps that read transcripts live outside
+this repo (ADR 0034) and cannot be updated in lockstep with the server.
+
+One change does reach the unbounded path, deliberately: a second usage delivery
+for a turn that already has usage is refused (`:already_recorded`) instead of
+overwriting it. A retried provider delivery used to double-count the
+conversation's token counters.
+
 ### Autonomous turns are bounded, not refused
 
 A configured allowance does not stop a conversation doing background work.

--- a/decisions/evidence/bounded-transcript.json
+++ b/decisions/evidence/bounded-transcript.json
@@ -1,0 +1,109 @@
+{
+  "recorded_at": "2026-09-08T03:50:49.484355+00:00",
+  "parent": "42e40c5954392580b196889d2e5a1d32175c752b",
+  "scope": "Prepared bounded transcript arbitration and once-only delayed accounting; public controls disabled",
+  "toolchain": {
+    "elixir": "1.19.2-otp-28",
+    "erlang": "28.3",
+    "selector": "mise exec"
+  },
+  "full_precommit": {
+    "status": "passed",
+    "tests": 4728,
+    "doctests": 6,
+    "failures": 0,
+    "skipped": 2,
+    "excluded": 7,
+    "log_sha256": "sha256:88f6ac209be80916d6e9816cc298f7c7187c1ce48b3060a53f5a1e3cc43eb509"
+  },
+  "focused": {
+    "tests": 90,
+    "new_regressions": 12,
+    "failures": 0,
+    "log_sha256": "sha256:46e4a60a2c2a84728f5b4ba8429ac218a650f82eabbf677bcb986ba34046a6c9"
+  },
+  "analytics_correction": {
+    "tests": 32,
+    "failures": 0,
+    "log_sha256": "sha256:566e3d51792a380cb3d81889c3ca155d1a9eb103e3cb09c2e804d34ec1512cd2"
+  },
+  "races": {
+    "DEADLINE_RACE_RESULT": {
+      "scope": "Local PostgreSQL arbitration, event durability and write permissions only",
+      "outcomes": {
+        "completion_won": 8,
+        "expiry_won": 12
+      },
+      "delayed_operations": [
+        "spawn",
+        "stdin_write"
+      ],
+      "provider_operations": 0,
+      "separate_database_connections": true,
+      "cases": 20,
+      "lock_wait_cannot_extend_deadline": true,
+      "delayed_lock_tables": [
+        "conversations",
+        "turns"
+      ],
+      "completed_connections_require_cleanup": true,
+      "deadline_event_reuse_cases": 12
+    },
+    "TRANSCRIPT_RACE_RESULT": {
+      "scope": "Local transcript arbitration and once-only accounting; no provider termination or billing proof",
+      "duplicate_usage": 20,
+      "usage_vs_cancellation": 20,
+      "output_vs_cancellation": 20,
+      "output_outcomes": {
+        "cancel_first": 20
+      },
+      "delayed_lock_cases": 4,
+      "delayed_tables": [
+        "conversations",
+        "turns"
+      ],
+      "delayed_operations": [
+        "output",
+        "model_stage"
+      ],
+      "provider_operations": 0,
+      "separate_database_connections": true
+    }
+  },
+  "race_log_sha256": "sha256:645d9a18efbbebf62f4c404fee013943ecf782c713bf6ab67947130c0d1addae",
+  "prior_validation": {
+    "first_full_precommit": {
+      "tests": 4728,
+      "doctests": 6,
+      "failures": 1,
+      "reason": "Analytics fixture supplied an invented turn ID; stage events now retain the actual turn foreign key. Fixture now inserts a completed turn and keeps all analytics assertions.",
+      "log_sha256": "sha256:ec5e7699ff976bdcd68e6c97d7d49b7909893f436b51fbaeebdc35e45dc8cbf7"
+    },
+    "environment_errors": {
+      "reason": "Initial commands used the unmigrated default local fountain_test database and Homebrew toolchain. Corrected to the existing dedicated deadline database and repository-pinned mise toolchain; no test gate was weakened.",
+      "logs_sha256": [
+        "sha256:6fcddb929388c48edeab24e9fe490e69a20c70ce2ceed32c5ccd7bdb48a830b4",
+        "sha256:5a550dd0e43f84188b1c80ed8d6d0d39e4ddb4a75b29b72c5ca0670aa3c768fe"
+      ]
+    }
+  },
+  "public_enforcement_enabled": false,
+  "deployment_performed": false,
+  "provider_operations_in_new_proofs": 0,
+  "limits": [
+    "Conversation/session metadata and untagged lifecycle events still need generation fencing",
+    "The actor may discard final usage before the separate accounting writer receives it; provider reporting completeness is not proven",
+    "Sandbox transfer, park, reset, release and incarnation audit remains",
+    "Release must retain its busy-without-interruption contract",
+    "Independent database proofs do not establish remote deletion, process-tree cleanup, billing or aggregate PR dollar reservations",
+    "Live acceptance requires released Sprites identity support"
+  ],
+  "source_sha256": {
+    "apps/fountain/lib/fountain/conversations.ex": "sha256:31d932d646f89d967058b87c6aa520bfe404728d6f4836702ea2077e789b1aa2",
+    "apps/fountain/lib/fountain/conversations/execution_guard.ex": "sha256:5a70546ceeb6c9ddb8a71b5f317bc49ab079da9895af69614456f8e49624e2b5",
+    "apps/fountain/lib/fountain/conversations/output.ex": "sha256:10355325b043d82cdbfcda21ea277b3b7c25c4969279bd637b33e604405dee14",
+    "apps/fountain/test/fountain/conversations/bounded_transcript_test.exs": "sha256:2b81796dc8287342e3723c1ff926b1ce009ecf82aa4340b370ee1d80ba73a863",
+    "apps/fountain/test/fountain/analytics_bridges_test.exs": "sha256:85daaa27e69e68441a6bbd05119e9b17f07d50e397e67ed1ed612c99c71d29d1",
+    "scripts/verify-bounded-transcript-races.exs": "sha256:daae54626014e1e3fcbd1d0d68a3fd1ddf81f073219d017cc76aa21e2186c328"
+  }
+}

--- a/scripts/verify-bounded-transcript-races.exs
+++ b/scripts/verify-bounded-transcript-races.exs
@@ -1,0 +1,183 @@
+# Validates the dedicated local database and supplies separate-connection barriers.
+Code.require_file("scripts/verify-turn-deadline-races.exs")
+
+alias Fountain.{Conversations, Repo}
+alias Fountain.Conversations.{Conversation, ExecutionGuard, LogEvent, Sandbox, Turn}
+import Ecto.Query
+
+user =
+  Repo.insert!(%Fountain.Accounts.User{
+    email: "transcript-race-#{Ecto.UUID.generate()}@example.test"
+  })
+
+fixture = fn seconds ->
+  sandbox =
+    Repo.insert!(%Sandbox{
+      user_id: user.id,
+      sprite_name: "local-transcript-#{Ecto.UUID.generate()}",
+      status: "ready"
+    })
+
+  conv =
+    Repo.insert!(%Conversation{
+      user_id: user.id,
+      sandbox_id: sandbox.id,
+      runtime: "claude",
+      status: "running"
+    })
+
+  turn =
+    Repo.insert!(%Turn{
+      conversation_id: conv.id,
+      turn_number: 1,
+      prompt: "local transcript race",
+      status: "running"
+    })
+
+  deadline = DateTime.add(DateTime.utc_now(), seconds)
+  {:ok, execution} = ExecutionGuard._unsafe_register(turn.id, Ecto.UUID.generate(), deadline)
+  {conv, turn, execution, deadline}
+end
+
+write = fn conv, turn ->
+  Conversations.log!(%{
+    conversation_id: conv.id,
+    turn_id: turn.id,
+    kind: "output",
+    stream: "stdout",
+    data: "fixture output"
+  })
+end
+
+for _ <- 1..20 do
+  {conv, turn, _, _} = fixture.(60)
+
+  results =
+    DeadlineRace.concurrently([
+      fn -> Conversations._unsafe_record_turn_usage(turn, %{"input" => 7, "output" => 3}) end,
+      fn -> Conversations._unsafe_record_turn_usage(turn, %{"input" => 7, "output" => 3}) end
+    ])
+
+  1 = Enum.count(results, &match?({:ok, _}, &1))
+  1 = Enum.count(results, &match?({:error, :already_recorded}, &1))
+  %{usage_input_tokens: 7, usage_output_tokens: 3} = Repo.get!(Conversation, conv.id)
+end
+
+for _ <- 1..20 do
+  {conv, turn, _, _} = fixture.(60)
+
+  [{:ok, _}, {:ok, _}] =
+    DeadlineRace.concurrently([
+      fn -> Conversations._unsafe_record_turn_usage(turn, %{"input" => 7, "output" => 3}) end,
+      fn -> ExecutionGuard._unsafe_interrupt(conv.id) end
+    ])
+
+  %{usage_input_tokens: 7, usage_output_tokens: 3} = Repo.get!(Conversation, conv.id)
+  %{status: "interrupted", usage: %{"input" => 7, "output" => 3}} = Repo.get!(Turn, turn.id)
+end
+
+output_results =
+  for _ <- 1..20 do
+    {conv, turn, _, _} = fixture.(60)
+
+    [event, {:ok, _}] =
+      DeadlineRace.concurrently([
+        fn -> write.(conv, turn) end,
+        fn -> ExecutionGuard._unsafe_interrupt(conv.id) end
+      ])
+
+    nil = write.(conv, turn)
+    count = Repo.aggregate(from(e in LogEvent, where: e.turn_id == ^turn.id), :count)
+    expected = if is_nil(event), do: 0, else: 1
+    ^expected = count
+    if is_nil(event), do: "cancel_first", else: "output_first"
+  end
+
+# The real output/stage writers must re-read the clock AFTER waiting on either
+# parent or turn locks. A pre-dispatch actor check cannot satisfy this proof.
+for operation <- [:output, :stage], table <- ["conversations", "turns"] do
+  {conv, turn, _, deadline} = fixture.(2)
+  owner = self()
+  id = if table == "conversations", do: conv.id, else: turn.id
+
+  holder =
+    Task.async(fn ->
+      Repo.transaction(fn ->
+        Repo.query!("SELECT id FROM #{table} WHERE id = $1 FOR UPDATE", [Ecto.UUID.dump!(id)])
+        send(owner, :locked)
+
+        receive do
+          :release -> :ok
+        after
+          10_000 -> raise "Lock holder timed out"
+        end
+      end)
+    end)
+
+  receive do
+    :locked -> :ok
+  after
+    10_000 -> raise "Lock acquisition timed out"
+  end
+
+  writer =
+    Task.async(fn ->
+      Repo.checkout(fn ->
+        %{rows: [[backend]]} = Repo.query!("SELECT pg_backend_pid()")
+        send(owner, {:writer_backend, backend})
+
+        case operation do
+          :output -> write.(conv, turn)
+          :stage -> Conversations.publish_stage(conv.id, "model", "done", %{turn_id: turn.id})
+        end
+      end)
+    end)
+
+  backend =
+    receive do
+      {:writer_backend, backend} -> backend
+    after
+      1_000 -> raise "Writer checkout timed out"
+    end
+
+  waiting =
+    Enum.reduce_while(1..100, false, fn _, _ ->
+      case Repo.query!("SELECT wait_event_type FROM pg_stat_activity WHERE pid = $1", [backend]).rows do
+        [["Lock"]] ->
+          {:halt, true}
+
+        _ ->
+          Process.sleep(5)
+          {:cont, false}
+      end
+    end)
+
+  true = waiting
+  :lt = DateTime.compare(DateTime.utc_now(), deadline)
+  Process.sleep(max(DateTime.diff(deadline, DateTime.utc_now(), :millisecond), 0) + 50)
+  send(holder.pid, :release)
+  Task.await(holder)
+  nil = Task.await(writer)
+
+  [%{kind: "stage", state: "failed", stage: "turn"}] =
+    Repo.all(from e in LogEvent, where: e.turn_id == ^turn.id)
+
+  %{status: "failed", limit_reason: "wall_time_limit"} = Repo.get!(Turn, turn.id)
+end
+
+IO.puts(
+  "TRANSCRIPT_RACE_RESULT=" <>
+    Jason.encode!(%{
+      duplicate_usage: 20,
+      usage_vs_cancellation: 20,
+      output_vs_cancellation: 20,
+      output_outcomes: Enum.frequencies(output_results),
+      delayed_lock_cases: 4,
+      delayed_tables: ["conversations", "turns"],
+      delayed_operations: ["output", "model_stage"],
+      provider_operations: 0,
+      separate_database_connections: true,
+      scope:
+        "Local transcript arbitration and once-only accounting; no provider termination or billing proof"
+    })
+)


### PR DESCRIPTION
Cancellation could race an actor's deadline check and still admit a late transcript write. Bounded output and turn-tagged stages now check and write under the journal locks. Retired turns reject stale edits; terminal stages must match the stored outcome. Duplicate usage deliveries lock the parent and turn before incrementing totals, while allowing delayed accounting after retirement.

Stacked on #1749; **draft, public enforcement disabled**. Remaining gates include conversation/session metadata, untagged lifecycle events, sandbox transfer/parking/incarnation safety, released Sprites identity support and live provider acceptance.

Full precommit passes **4,728 tests + 6 doctests, zero failures**. The pinned-toolchain focused suite passes 90 tests, including 12 new regressions. Independent PostgreSQL proofs pass 60 new races and four lock-delay cases, plus 20 existing deadline races. No provider operations occurred. Tracks #1732.

Evidence: `decisions/evidence/bounded-transcript.json`. The first full gate caught an analytics fixture with an invented turn ID; it now inserts a real completed turn and retains all assertions.

[All 24 CI checks passed or intentionally skipped](https://github.com/BinaryBourbon/fountain/actions/runs/34184936407) at `751f8b6db1ec5b86b5d0a70474adf652c06f7ed4`.



Part of #1732 — **held**. Superseded on main by #1773–#1793; the residual hunks are being re-cut as focused PRs tracked by #1864, which keeps these frozen until each has a replacement or an explicitly linked deferral. Do not close: they are the reference for that mapping.
