### PR TITLE
Fence parent state and orphan recovery by turn generation

### DIFF
--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -1176,6 +1176,42 @@ defmodule Fountain.Conversations do
     end)
   end
 
+  @doc "Idle only the latest ended turn's still-running parent."
+  def _unsafe_idle_after_turn(%Turn{} = turn),
+    do: write_turn_parent(turn, :idle, %{status: "idle"})
+
+  @doc "Apply a runtime session report only for the current, unretired turn."
+  def _unsafe_set_turn_session(%Turn{} = turn, session_id),
+    do: write_turn_parent(turn, :session, %{runtime_session_id: session_id})
+
+  @doc "Clear an idle legacy peer's session only if its observed identity is still current."
+  def _unsafe_clear_idle_session(conv_id, expected) do
+    # ownership: this is the already-owned actor's conversation and session.
+    ExecutionGuard._unsafe_clear_idle_session(conv_id, expected, fn current ->
+      current |> Conversation.changeset(%{runtime_session_id: nil}) |> Repo.update()
+    end)
+    |> notify_parent_change()
+  end
+
+  defp write_turn_parent(turn, mode, attrs) do
+    # ownership: the calling actor/recovery path already owns this exact turn.
+    result =
+      ExecutionGuard._unsafe_write_parent(turn, mode, fn current ->
+        current |> Conversation.changeset(attrs) |> Repo.update()
+      end)
+
+    notify_parent_change(result)
+  end
+
+  defp notify_parent_change(result) do
+    case result do
+      {:ok, %{applied: true, conversation: conv}} -> broadcast_sidebar_update(conv.user_id)
+      _ -> :ok
+    end
+
+    result
+  end
+
   @doc """
   Re-resolve the Agent, Environment and Vault for an existing conversation,
   on the machine it is already running (#1565).
@@ -1726,6 +1762,15 @@ defmodule Fountain.Conversations do
 
         unless attached?, do: Repo.rollback(:sandbox_unavailable)
 
+        # A terminated or failed parent takes no more turns. `attached?` above
+        # checks the machine; this checks the conversation, which a retired
+        # actor can still reach with a queued prompt.
+        if Repo.exists?(
+             from c in Conversation,
+               where: c.id == ^conv_id and c.status in ["terminated", "failed"]
+           ),
+           do: Repo.rollback(:not_running)
+
         case _unsafe_check_saved_execution_allowance(conv_id) do
           :ok -> :ok
           {:error, reason} -> Repo.rollback(reason)
@@ -1762,11 +1807,21 @@ defmodule Fountain.Conversations do
         end
       end)
 
-    with {:ok, turn} <- result do
-      record_turn_usage(turn)
-      {:ok, turn}
-    end
+    record_started_turn(result)
   end
+
+  defp record_started_turn({:ok, turn}) do
+    record_turn_usage(turn)
+
+    case Repo.get(Conversation, turn.conversation_id) do
+      nil -> :ok
+      conv -> broadcast_sidebar_update(conv.user_id)
+    end
+
+    {:ok, turn}
+  end
+
+  defp record_started_turn(error), do: error
 
   @doc """
   Save an initial resolved allowance once, scoped to its conversation owner.
@@ -2117,53 +2172,56 @@ defmodule Fountain.Conversations do
   server and by the system reaper. Callers may supply audit attribution.
   """
   def _unsafe_orphan_turn(%Turn{} = turn, why, opts \\ []) do
-    now = DateTime.utc_now() |> DateTime.truncate(:second)
-    reply_text = turn.reply_text || _unsafe_turn_reply_text(turn)
-
-    updates =
-      [status: "interrupted", ended_at: now, orphaned_at: now]
-      |> maybe_set_reply_text(reply_text)
-
+    # ownership: this is the existing actor's turn or a system recovery candidate.
     result =
-      Repo.transaction(fn ->
-        {count, _} =
-          from(t in Turn, where: t.id == ^turn.id and t.status == "running")
-          |> Repo.update_all(set: updates)
+      ExecutionGuard._unsafe_recover_turn(turn, fn current, conv, latest?, bounded? ->
+        now = DateTime.utc_now() |> DateTime.truncate(:second)
+        reply_text = current.reply_text || _unsafe_turn_reply_text(current)
 
-        if count == 0 do
-          :noop
-        else
-          {conversation_count, _} =
-            from(c in Conversation,
-              where: c.id == ^turn.conversation_id and c.status == "running"
-            )
-            |> Repo.update_all(set: [status: "idle", updated_at: now])
+        updates =
+          if current.status == "running",
+            do: [status: "interrupted", ended_at: now, orphaned_at: now],
+            else: [orphaned_at: now]
 
-          {
-            Repo.get!(Turn, turn.id),
-            Repo.get!(Conversation, turn.conversation_id),
-            conversation_count == 1
-          }
-        end
+        updated =
+          current
+          |> Turn.changeset(Map.new(maybe_set_reply_text(updates, reply_text)))
+          |> Repo.update!()
+
+        conversation_changed? = latest? and conv.status == "running"
+
+        conv =
+          if conversation_changed?,
+            do: conv |> Conversation.changeset(%{status: "idle"}) |> Repo.update!(),
+            else: conv
+
+        {updated, conv, conversation_changed?, bounded?}
       end)
 
     case result do
       {:ok, :noop} ->
         :noop
 
-      {:ok, {updated_turn, conv, conversation_changed?}} ->
+      {:ok, {updated_turn, conv, conversation_changed?, bounded?}} ->
         if is_nil(turn.reply_text) and is_binary(updated_turn.reply_text) do
           Fountain.Activation.turn_replied(updated_turn)
         end
 
         if conversation_changed?, do: broadcast_sidebar_update(conv.user_id)
 
-        publish_stage(turn.conversation_id, "reattach", "interrupted", %{
+        metadata = %{
           outcome: "turn_orphaned",
           turn_id: turn.id,
           turn_number: turn.turn_number,
           reason: why
-        })
+        }
+
+        if bounded? do
+          status = if updated_turn.status == "failed", do: "failed", else: "interrupted"
+          publish_stage(turn.conversation_id, "turn", status, metadata)
+        else
+          publish_stage(turn.conversation_id, "reattach", "interrupted", metadata)
+        end
 
         Audit.record(%{
           user_id: conv.user_id,

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -1796,6 +1796,22 @@ defmodule Fountain.Conversations do
               {:error, changeset} -> Repo.rollback(changeset)
             end
 
+          # The parent goes `running` here rather than in the launch, so a turn
+          # and the conversation status that explains it commit together. A
+          # reader used to be able to see a `running` turn under an `idle`
+          # parent for the width of the launch, and a launch that failed left
+          # the pair disagreeing. `update_all`, not `update_conversation/2`:
+          # that one audits, and an audit insert must not run inside a
+          # transaction (ADR 0013).
+          if Map.get(attrs, :status) == "running" do
+            Repo.update_all(
+              from(c in Conversation,
+                where: c.id == ^conv_id and c.status != "running"
+              ),
+              set: [status: "running", updated_at: DateTime.utc_now()]
+            )
+          end
+
           # Same transaction as the turn: a bounded turn that exists without a
           # journal row is a turn nothing can expire. `conv` is the row this
           # transaction locked.

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -1999,8 +1999,7 @@ defmodule Fountain.Conversations.ConversationServer do
 
     emit_turn_completed(state, turn.status)
 
-    conv = Conversations._unsafe_get_conversation!(state.conversation_id)
-    {:ok, _} = Conversations.update_conversation(conv, %{status: "idle"})
+    {:ok, _} = Conversations._unsafe_idle_after_turn(turn)
 
     {:noreply,
      %{
@@ -2499,19 +2498,14 @@ defmodule Fountain.Conversations.ConversationServer do
   defp apply_effect(state, :open_autonomous_turn), do: open_autonomous_turn(state)
   defp apply_effect(state, :arm_autonomous_quiet), do: arm_autonomous_quiet(state)
 
-  defp apply_effect(state, {:session_id, id}) do
-    conv = Conversations._unsafe_get_conversation!(state.conversation_id)
-    {:ok, _} = Conversations.update_conversation(conv, %{runtime_session_id: id})
-    %{state | runtime_session_id: id}
-  end
+  defp apply_effect(state, {:session_id, id}),
+    do: TurnMachine.accept_runtime_session(state, id)
 
   # The row must stop naming a session that is not on the disk, or every later
   # turn resumes the same absent one. Re-read for the reason the clause above
   # re-reads it: what is written goes onto the row as it is now.
-  defp apply_effect(state, {:forget_runtime_session, reason, detail}) do
-    conv = Conversations._unsafe_get_conversation!(state.conversation_id)
-    TurnMachine.forget_runtime_session(state, conv, reason, detail)
-  end
+  defp apply_effect(state, {:forget_runtime_session, reason, detail}),
+    do: TurnMachine.forget_turn_session(state, reason, detail)
 
   defp apply_effect(state, {:ask_permission, request_id, tool, options}),
     do: Pending.ask(state, request_id, tool, options)

--- a/apps/fountain/lib/fountain/conversations/execution_guard.ex
+++ b/apps/fountain/lib/fountain/conversations/execution_guard.ex
@@ -329,6 +329,121 @@ defmodule Fountain.Conversations.ExecutionGuard do
     end)
   end
 
+  @doc "Serialize a turn's parent update with admission and retirement; callbacks only write rows."
+  def _unsafe_write_parent(%Turn{} = observed, mode, writer) when mode in [:idle, :session] do
+    transaction(fn ->
+      conv = lock_parent(observed.conversation_id) || Repo.rollback(:not_found)
+      execution = lock_execution_by_turn(observed.id)
+      turn = lock_turn(observed.id) || Repo.rollback(:turn_missing)
+      if turn.conversation_id != conv.id, do: Repo.rollback(:ownership_changed)
+
+      {execution, turn, changed, event} = parent_execution(execution, turn)
+
+      allowed =
+        latest_turn?(conv.id, turn.id) and parent_write_allowed?(conv, turn, execution, mode)
+
+      if allowed do
+        case writer.(conv) do
+          {:ok, updated} -> {%{applied: true, conversation: updated}, changed, event}
+          {:error, reason} -> Repo.rollback(reason)
+        end
+      else
+        {%{applied: false, conversation: conv}, changed, event}
+      end
+    end)
+  end
+
+  @doc "Retire an orphan's execution before recovery writes, in parent/journal/turn lock order."
+  def _unsafe_recover_turn(%Turn{} = observed, writer) do
+    transaction(fn ->
+      conv = lock_parent(observed.conversation_id) || Repo.rollback(:not_found)
+      execution = lock_execution_by_turn(observed.id)
+      turn = lock_turn(observed.id) || Repo.rollback(:turn_missing)
+      if turn.conversation_id != conv.id, do: Repo.rollback(:ownership_changed)
+
+      if execution && not cleanup_binding?(execution), do: Repo.rollback(:ownership_changed)
+      running? = turn.status == "running"
+      {turn, changed, event} = retire_orphan(execution, turn)
+
+      if running? do
+        result = writer.(turn, conv, latest_turn?(conv.id, turn.id), not is_nil(execution))
+        {result, changed, event}
+      else
+        {:noop, changed, event}
+      end
+    end)
+  end
+
+  defp retire_orphan(nil, turn), do: {turn, nil, nil}
+
+  defp retire_orphan(execution, turn) do
+    status = if turn.status == "running", do: "interrupted", else: turn.status
+    {decision, changed, event} = complete(execution, status, DateTime.utc_now())
+    {decision.turn, changed, event}
+  end
+
+  defp latest_turn?(conv_id, turn_id) do
+    Repo.one(
+      from t in Turn,
+        where: t.conversation_id == ^conv_id,
+        order_by: [desc: t.turn_number],
+        limit: 1,
+        select: t.id
+    ) == turn_id
+  end
+
+  @doc "An idle legacy connection may clear only its unchanged session, before any successor starts."
+  def _unsafe_clear_idle_session(conv_id, expected, writer) do
+    transaction(fn ->
+      conv = lock_parent(conv_id) || Repo.rollback(:not_found)
+
+      running? =
+        Repo.exists?(
+          from t in Turn, where: t.conversation_id == ^conv_id and t.status == "running"
+        )
+
+      bounded? = Repo.exists?(from e in TurnExecution, where: e.conversation_id == ^conv_id)
+
+      if conv.status in ["running", "idle"] and conv.runtime_session_id == expected and
+           not running? and not bounded? do
+        case writer.(conv) do
+          {:ok, updated} -> {%{applied: true, conversation: updated}, nil, nil}
+          {:error, reason} -> Repo.rollback(reason)
+        end
+      else
+        {%{applied: false, conversation: conv}, nil, nil}
+      end
+    end)
+  end
+
+  defp parent_execution(nil, turn), do: {nil, turn, nil, nil}
+
+  defp parent_execution(execution, turn) do
+    now = DateTime.utc_now()
+
+    if execution.state == "active" and current_binding?(execution) and
+         DateTime.compare(now, execution.deadline_at) != :lt do
+      {decision, changed, event} = expire(execution, now)
+      {decision.execution, decision.turn, changed, event}
+    else
+      {execution, turn, nil, nil}
+    end
+  end
+
+  defp parent_write_allowed?(conv, turn, execution, mode) do
+    bound? = is_nil(execution) or current_binding?(execution)
+
+    case mode do
+      :idle ->
+        bound? and conv.status == "running" and turn.status in @terminal_turns and
+          (is_nil(execution) or execution.state != "active")
+
+      :session ->
+        bound? and conv.status in ["running", "idle"] and turn.status == "running" and
+          (is_nil(execution) or execution.state == "active")
+    end
+  end
+
   @doc "Serialize transcript writes with retirement; the callback must contain only database work."
   def _unsafe_write_event(conv_id, turn_id, writer) do
     case turn_id && Repo.get_by(TurnExecution, turn_id: turn_id) do

--- a/apps/fountain/lib/fountain/conversations/turn_launch.ex
+++ b/apps/fountain/lib/fountain/conversations/turn_launch.ex
@@ -22,7 +22,41 @@ defmodule Fountain.Conversations.TurnLaunch do
   alias Fountain.Conversations.{CodexChatGPT, Connection, ExecutionLimits}
   alias Fountain.Conversations.{McpServers, Output, TurnMachine}
 
+  # Keep the legacy runtime fallback while it exists at this boundary. The
+  # admission path proves conv.runtime is present; this is the same scoped
+  # suppression carried by ConversationServer before extracting its launch.
+  @dialyzer {:nowarn_function, launch: 8}
   def run(state, conv, turn, prompt, agent, images, acp?, fail_before_start) do
+    case TurnMachine.session_plan(turn, state.runtime_session_id) do
+      {:ok, plan} ->
+        launch(state, conv, turn, prompt, agent, images, fail_before_start, %{
+          acp?: acp?,
+          session_plan: plan
+        })
+
+      {:error, _} ->
+        session_plan_refused(state, turn)
+    end
+  end
+
+  defp session_plan_refused(state, turn) do
+    # ownership: the conversation actor supplied its already admitted turn.
+    Logger.warning("conv #{state.conversation_id}: runtime session preparation refused")
+    {:ok, _} = Conversations._unsafe_update_turn(turn, %{status: "failed"})
+    {:ok, _} = Conversations._unsafe_idle_after_turn(turn)
+    if state.turn_execution, do: Connection.close_bounded(state), else: state
+  end
+
+  defp launch(
+         state,
+         conv,
+         turn,
+         prompt,
+         agent,
+         images,
+         fail_before_start,
+         %{acp?: acp?, session_plan: {mode, runtime_session_id}}
+       ) do
     turn_number = turn.turn_number
 
     # Write image temp files to sprite. Only on the legacy path: ACP carries
@@ -30,10 +64,6 @@ defmodule Fountain.Conversations.TurnLaunch do
     # the sandbox first would be a round trip whose product nothing reads.
     image_paths =
       if acp?, do: [], else: Output.write_image_temp_files(state.handle, turn.id, images)
-
-    {:ok, _} = Conversations.update_conversation(conv, %{status: "running"})
-
-    {mode, runtime_session_id} = TurnMachine.session_plan(conv, state.runtime_session_id)
 
     {cmd, args, build_opts} =
       TurnMachine.command(acp?, conv, agent, prompt, mode, runtime_session_id,

--- a/apps/fountain/lib/fountain/conversations/turn_machine.ex
+++ b/apps/fountain/lib/fountain/conversations/turn_machine.ex
@@ -654,8 +654,7 @@ defmodule Fountain.Conversations.TurnMachine do
 
     emit_completed(turn, row.status)
 
-    conv = Conversations._unsafe_get_conversation!(turn.conversation_id)
-    {:ok, _} = Conversations.update_conversation(conv, %{status: "idle"})
+    {:ok, _} = Conversations._unsafe_idle_after_turn(row)
 
     %{turn | row: nil, span: nil, metrics: nil, tracer: nil}
   end
@@ -707,8 +706,7 @@ defmodule Fountain.Conversations.TurnMachine do
 
     emit_completed(turn, "interrupted")
 
-    conv = Conversations._unsafe_get_conversation!(turn.conversation_id)
-    {:ok, _} = Conversations.update_conversation(conv, %{status: "idle"})
+    {:ok, _} = Conversations._unsafe_idle_after_turn(turn.row)
 
     %{turn | row: nil, span: nil, metrics: nil, tracer: nil}
   end
@@ -1142,35 +1140,19 @@ defmodule Fountain.Conversations.TurnMachine do
   `session/load` over `session/new`; with none, one is generated and
   persisted immediately so a server restart can resume.
   """
-  @spec session_plan(Conversation.t(), String.t() | nil) :: {:run | :continue, String.t()}
-  def session_plan(conv, runtime_session_id) do
-    mode =
-      cond do
-        is_nil(runtime_session_id) -> :run
-        true -> :continue
-      end
+  @spec session_plan(Conversations.Turn.t(), String.t() | nil) ::
+          {:ok, {:run | :continue, String.t()}} | {:error, term()}
+  def session_plan(turn, runtime_session_id) do
+    mode = if is_nil(runtime_session_id), do: :run, else: :continue
+    id = runtime_session_id || Ecto.UUID.generate()
 
-    runtime_session_id =
-      case runtime_session_id do
-        nil ->
-          # Generate one and persist immediately so a server restart can resume.
-          # Under ACP this value is a placeholder, not an identity: the spec
-          # makes the *agent* mint the session id, so `session/new` proposes
-          # nothing and the id that comes back overwrites this one (see the
-          # `{:acp, ref, {:session, id}}` handler). What the row still buys is
-          # the `mode` decision above — a persisted id means "a turn has
-          # happened", which is what picks `session/resume` or `session/load`
-          # over `session/new`. It used to buy gemini's legacy `--resume` the
-          # same signal; that argv is gone with #941.
-          new_id = Ecto.UUID.generate()
-          {:ok, _} = Conversations.update_conversation(conv, %{runtime_session_id: new_id})
-          new_id
-
-        existing ->
-          existing
-      end
-
-    {mode, runtime_session_id}
+    # A placeholder chooses run/resume, not ACP identity. Preparing even that
+    # placeholder must remain tied to the admitted turn across cancellation.
+    case Conversations._unsafe_set_turn_session(turn, id) do
+      {:ok, %{applied: true}} -> {:ok, {mode, id}}
+      {:ok, %{applied: false}} -> {:error, :execution_fenced}
+      {:error, _} = error -> error
+    end
   end
 
   @doc """
@@ -1360,11 +1342,7 @@ defmodule Fountain.Conversations.TurnMachine do
     # without this it stays "running" in the API and UI until some later turn
     # completes, even though nothing is executing. The :exit and :interrupt
     # handlers both do the same reset.
-    failed_conv = Conversations._unsafe_get_conversation!(conversation_id)
-
-    if failed_conv.status == "running" do
-      {:ok, _} = Conversations.update_conversation(failed_conv, %{status: "idle"})
-    end
+    {:ok, _} = Conversations._unsafe_idle_after_turn(turn)
 
     # The turn never started; close the span we just opened so it doesn't leak.
     if exit_code, do: OpenTelemetry.Tracer.set_attribute("exit_code", exit_code)
@@ -1483,6 +1461,52 @@ defmodule Fountain.Conversations.TurnMachine do
     })
 
     :ok
+  end
+
+  @doc "Persist a worker session report only while its exact turn remains current."
+  def accept_runtime_session(%{current_turn: %{} = turn} = state, id) do
+    case Conversations._unsafe_set_turn_session(turn, id) do
+      {:ok, %{applied: true}} -> %{state | runtime_session_id: id}
+      _ -> state
+    end
+  end
+
+  def accept_runtime_session(state, _id), do: state
+
+  @doc "Clear a worker's lost session through the same generation fence as session reports."
+  def forget_turn_session(%{current_turn: %{} = turn} = state, reason, detail) do
+    case Conversations._unsafe_set_turn_session(turn, nil) do
+      {:ok, %{applied: true}} ->
+        publish_stage(state.conversation_id, "session", "done", %{
+          turn_id: turn.id,
+          event: "reset",
+          reason: reason,
+          detail: detail
+        })
+
+        %{state | runtime_session_id: nil}
+
+      _ ->
+        state
+    end
+  end
+
+  def forget_turn_session(%{runtime_session_id: nil} = state, _reason, _detail), do: state
+
+  def forget_turn_session(state, reason, detail) do
+    case Conversations._unsafe_clear_idle_session(state.conversation_id, state.runtime_session_id) do
+      {:ok, %{applied: true}} ->
+        publish_stage(state.conversation_id, "session", "done", %{
+          event: "reset",
+          reason: reason,
+          detail: detail
+        })
+
+        %{state | runtime_session_id: nil}
+
+      _ ->
+        state
+    end
   end
 
   @doc """

--- a/apps/fountain/test/fountain/conversations/conversation_server_size_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_size_test.exs
@@ -22,7 +22,7 @@ defmodule Fountain.Conversations.ConversationServerSizeTest do
   pin in a follow-up, when the number has stopped moving.
   """
 
-  @pin 2652
+  @pin 2646
 
   @server "apps/fountain/lib/fountain/conversations/conversation_server.ex"
 

--- a/apps/fountain/test/fountain/conversations/turn_machine_test.exs
+++ b/apps/fountain/test/fountain/conversations/turn_machine_test.exs
@@ -432,6 +432,7 @@ defmodule Fountain.Conversations.TurnMachineTest do
       row: row
     } do
       attach_telemetry([[:fountain, :turn, :completed]])
+      {:ok, _} = Conversations.update_conversation(conv, %{status: "running"})
 
       marked = TurnMachine.mark_interrupted(m)
       assert marked.row == row
@@ -502,10 +503,11 @@ defmodule Fountain.Conversations.TurnMachineTest do
     end
 
     test "session_plan/2 runs fresh with a persisted placeholder, and continues an existing id",
-         %{conv: conv} do
-      assert {:run, id} = TurnMachine.session_plan(conv, nil)
+         %{conv: conv, row: row} do
+      {:ok, _} = Conversations.update_conversation(conv, %{status: "running"})
+      assert {:ok, {:run, id}} = TurnMachine.session_plan(row, nil)
       assert Conversations._unsafe_get_conversation!(conv.id).runtime_session_id == id
-      assert {:continue, "keep"} = TurnMachine.session_plan(conv, "keep")
+      assert {:ok, {:continue, "keep"}} = TurnMachine.session_plan(row, "keep")
     end
 
     test "command/7 is the ACP adapter with the sandbox's cwd, or the runtime's own argv",

--- a/apps/fountain/test/fountain/conversations/turn_parent_actor_test.exs
+++ b/apps/fountain/test/fountain/conversations/turn_parent_actor_test.exs
@@ -1,0 +1,124 @@
+defmodule Fountain.Conversations.TurnParentActorTest do
+  use Fountain.ConversationServerCase
+
+  alias Fountain.Conversations.{ExecutionGuard, Turn, TurnExecution}
+
+  setup do
+    user = insert_verified_user()
+    sandbox = insert_sandbox(user_id: user.id, status: "ready")
+    conv = insert_conversation(user_id: user.id, sandbox: sandbox, status: "idle")
+    stub_happy_sprite(sandbox.sprite_name)
+    {pid, _monitor, :alive} = start_server(conv)
+    on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+
+    turn = insert_turn(conv, status: "running")
+
+    {:ok, execution} =
+      ExecutionGuard._unsafe_register(
+        turn.id,
+        Ecto.UUID.generate(),
+        DateTime.add(DateTime.utc_now(), 60)
+      )
+
+    {:ok, _} = ExecutionGuard._unsafe_claim_spawn(execution.id)
+
+    {:ok, execution} =
+      ExecutionGuard._unsafe_bind_identity(
+        execution.id,
+        execution.connection_id,
+        "old-synthetic-command"
+      )
+
+    {:ok, _} = Conversations.update_conversation(conv, %{status: "running"})
+    ref = make_ref()
+
+    :sys.replace_state(pid, fn state ->
+      %{state | current_turn: turn, current_command_ref: ref, turn_execution: execution}
+    end)
+
+    %{pid: pid, turn: turn, execution: execution, conv: conv, ref: ref}
+  end
+
+  test "cancellation and successor admission after dispatch cannot let the old actor idle the parent",
+       %{pid: pid, turn: turn, execution: execution, conv: conv, ref: ref} do
+    test = self()
+
+    stub(Conversations, :_unsafe_update_turn, fn row, attrs ->
+      if self() == pid and row.id == turn.id do
+        send(test, :after_dispatch_before_write)
+
+        receive do
+          :continue -> :ok
+        after
+          5_000 -> flunk("callback barrier timed out")
+        end
+      end
+
+      Mimic.call_original(Conversations, :_unsafe_update_turn, [row, attrs])
+    end)
+
+    send(pid, {:acp, ref, {:done, "end_turn", nil}})
+    assert_receive :after_dispatch_before_write, 2_000
+    {:ok, _} = ExecutionGuard._unsafe_interrupt(conv.id)
+
+    {:ok, %{permitted: true, execution: claimed}} =
+      ExecutionGuard._unsafe_claim_termination(execution.id)
+
+    # Synthetic provider acknowledgment permits a successor. This test performs
+    # no remote termination and makes no claim about actual command deletion.
+    {:ok, _} = ExecutionGuard._unsafe_record_termination(execution.id, claimed.attempt_id, :ok)
+    next = insert_turn(conv, status: "running")
+
+    {:ok, next_execution} =
+      ExecutionGuard._unsafe_register(
+        next.id,
+        Ecto.UUID.generate(),
+        DateTime.add(DateTime.utc_now(), 60)
+      )
+
+    send(pid, :continue)
+    assert %{current_turn: nil} = :sys.get_state(pid)
+    assert Conversations._unsafe_get_conversation!(conv.id).status == "running"
+    assert Repo.get!(Turn, next.id).status == "running"
+    assert Repo.get!(TurnExecution, next_execution.id).state == "active"
+  end
+
+  test "a session callback passed by dispatch cannot overwrite a successor after cancellation",
+       c do
+    test = self()
+    :sys.replace_state(c.pid, &%{&1 | runtime_session_id: "original"})
+
+    stub(Conversations, :_unsafe_set_turn_session, fn row, session ->
+      if self() == c.pid and row.id == c.turn.id do
+        send(test, :session_after_dispatch)
+
+        receive do
+          :continue -> :ok
+        after
+          5_000 -> flunk("session barrier timed out")
+        end
+      end
+
+      Mimic.call_original(Conversations, :_unsafe_set_turn_session, [row, session])
+    end)
+
+    send(c.pid, {:acp, c.ref, {:session, "late"}})
+    assert_receive :session_after_dispatch, 2_000
+    {:ok, _} = ExecutionGuard._unsafe_interrupt(c.conv.id)
+    {:ok, %{execution: claimed}} = ExecutionGuard._unsafe_claim_termination(c.execution.id)
+    {:ok, _} = ExecutionGuard._unsafe_record_termination(c.execution.id, claimed.attempt_id, :ok)
+    next = insert_turn(c.conv, status: "running")
+
+    {:ok, _} =
+      ExecutionGuard._unsafe_register(
+        next.id,
+        Ecto.UUID.generate(),
+        DateTime.add(DateTime.utc_now(), 60)
+      )
+
+    {:ok, _} = Conversations.update_conversation(c.conv, %{runtime_session_id: "successor"})
+    send(c.pid, :continue)
+    assert %{runtime_session_id: "original"} = :sys.get_state(c.pid)
+    assert Conversations._unsafe_get_conversation!(c.conv.id).runtime_session_id == "successor"
+  end
+end

--- a/apps/fountain/test/fountain/conversations/turn_parent_test.exs
+++ b/apps/fountain/test/fountain/conversations/turn_parent_test.exs
@@ -294,6 +294,7 @@ defmodule Fountain.Conversations.TurnParentTest do
                  c.conv.user_id,
                  c.sandbox.id
                )
+
       assert Repo.get!(Conversation, c.conv.id).status == status
     end
 

--- a/apps/fountain/test/fountain/conversations/turn_parent_test.exs
+++ b/apps/fountain/test/fountain/conversations/turn_parent_test.exs
@@ -1,0 +1,338 @@
+defmodule Fountain.Conversations.TurnParentTest do
+  use Fountain.DataCase, async: true
+
+  alias Fountain.Conversations
+  alias Fountain.Conversations.{Conversation, ExecutionGuard, Turn, TurnExecution, TurnMachine}
+
+  setup do
+    user = insert_verified_user()
+    sandbox = insert_sandbox(user_id: user.id, status: "ready")
+
+    conv =
+      insert_conversation(
+        user_id: user.id,
+        sandbox: sandbox,
+        status: "running",
+        runtime_session_id: "original-session"
+      )
+
+    turn = insert_turn(conv, status: "running")
+
+    {:ok, execution} =
+      ExecutionGuard._unsafe_register(
+        turn.id,
+        Ecto.UUID.generate(),
+        DateTime.add(DateTime.utc_now(), 60)
+      )
+
+    %{conv: conv, turn: turn, execution: execution, sandbox: sandbox}
+  end
+
+  defp machine(c), do: %TurnMachine{conversation_id: c.conv.id, row: c.turn}
+
+  defp actor(c),
+    do: %{
+      conversation_id: c.conv.id,
+      current_turn: c.turn,
+      runtime_session_id: "original-session"
+    }
+
+  defp successor(c) do
+    {:ok, _} = ExecutionGuard._unsafe_interrupt(c.conv.id)
+    next = insert_turn(c.conv, status: "running")
+
+    {:ok, execution} =
+      ExecutionGuard._unsafe_register(
+        next.id,
+        Ecto.UUID.generate(),
+        DateTime.add(DateTime.utc_now(), 60)
+      )
+
+    {next, execution}
+  end
+
+  test "stale completion cannot idle a successor admitted after cancellation", c do
+    {next, execution} = successor(c)
+    TurnMachine.finish(machine(c), "completed", %{}, %{})
+    assert Repo.get!(Conversation, c.conv.id).status == "running"
+    assert Repo.get!(Turn, next.id).status == "running"
+    assert Repo.get!(TurnExecution, execution.id).state == "active"
+  end
+
+  test "the interrupt's delayed second half cannot idle a successor", c do
+    {next, _} = successor(c)
+    TurnMachine.close_interrupted(machine(c))
+    assert Repo.get!(Conversation, c.conv.id).status == "running"
+    assert Repo.get!(Turn, next.id).status == "running"
+  end
+
+  test "the current ended generation can idle its parent", c do
+    {:ok, _} = ExecutionGuard._unsafe_interrupt(c.conv.id)
+
+    assert {:ok, %{applied: true, conversation: %{status: "idle"}}} =
+             Conversations._unsafe_idle_after_turn(c.turn)
+
+    assert {:ok, %{applied: false}} = Conversations._unsafe_idle_after_turn(c.turn)
+  end
+
+  test "a running turn cannot idle itself", c do
+    assert {:ok, %{applied: false}} = Conversations._unsafe_idle_after_turn(c.turn)
+    assert Repo.get!(Conversation, c.conv.id).status == "running"
+  end
+
+  test "late terminal callbacks preserve terminated and failed parents", c do
+    {:ok, _} = ExecutionGuard._unsafe_interrupt(c.conv.id)
+
+    for status <- ["terminated", "failed"] do
+      c.conv |> Ecto.Changeset.change(status: status) |> Repo.update!()
+      TurnMachine.close_interrupted(machine(c))
+      assert Repo.get!(Conversation, c.conv.id).status == status
+    end
+  end
+
+  test "session reports update durable and actor state while their turn is current", c do
+    state = TurnMachine.accept_runtime_session(actor(c), "new-session")
+    assert state.runtime_session_id == "new-session"
+    assert Repo.get!(Conversation, c.conv.id).runtime_session_id == "new-session"
+  end
+
+  test "late session reports and resets cannot change the successor's session or old actor state",
+       c do
+    successor(c)
+    c.conv |> Ecto.Changeset.change(runtime_session_id: "successor-session") |> Repo.update!()
+    old = actor(c)
+    assert ^old = TurnMachine.accept_runtime_session(old, "late-session")
+    assert ^old = TurnMachine.forget_turn_session(old, "session_gone", "old peer")
+    assert Repo.get!(Conversation, c.conv.id).runtime_session_id == "successor-session"
+  end
+
+  test "retirement alone fences session writes even before a successor exists", c do
+    {:ok, _} = ExecutionGuard._unsafe_interrupt(c.conv.id)
+
+    assert {:ok, %{applied: false}} =
+             Conversations._unsafe_set_turn_session(c.turn, "late-session")
+
+    assert Repo.get!(Conversation, c.conv.id).runtime_session_id == "original-session"
+  end
+
+  test "the session writer enforces expiration without a coordinator tick", c do
+    c.execution
+    |> Ecto.Changeset.change(deadline_at: DateTime.add(DateTime.utc_now(), -1))
+    |> Repo.update!()
+
+    assert {:ok, %{applied: false}} =
+             Conversations._unsafe_set_turn_session(c.turn, "late-session")
+
+    assert Repo.get!(Turn, c.turn.id).limit_reason == "wall_time_limit"
+    assert Repo.get!(Conversation, c.conv.id).runtime_session_id == "original-session"
+  end
+
+  test "a current missing-session report clears only its own session", c do
+    assert %{runtime_session_id: nil} =
+             TurnMachine.forget_turn_session(actor(c), "session_gone", "gone")
+
+    assert Repo.get!(Conversation, c.conv.id).runtime_session_id == nil
+  end
+
+  test "changed sandbox identity and a forged parent cannot authorize a session write", c do
+    c.sandbox |> Ecto.Changeset.change(sprite_name: "replacement") |> Repo.update!()
+
+    assert {:ok, %{applied: false}} =
+             Conversations._unsafe_set_turn_session(c.turn, "wrong-machine")
+
+    other = insert_conversation(user_id: insert_verified_user().id)
+
+    assert {:error, :ownership_changed} =
+             Conversations._unsafe_set_turn_session(
+               %{c.turn | conversation_id: other.id},
+               "wrong-tenant"
+             )
+
+    assert Repo.get!(Conversation, c.conv.id).runtime_session_id == "original-session"
+    assert Repo.get!(Conversation, other.id).runtime_session_id == nil
+  end
+
+  test "a deleted parent returns an explicit refusal", c do
+    {:ok, _} = ExecutionGuard._unsafe_interrupt(c.conv.id)
+    Repo.delete!(c.conv)
+    assert {:error, :not_found} = Conversations._unsafe_idle_after_turn(c.turn)
+    assert {:error, :not_found} = Conversations._unsafe_set_turn_session(c.turn, "orphan")
+  end
+
+  test "an idle peer cannot erase a bounded session even after cleanup completed", c do
+    {:ok, _} = ExecutionGuard._unsafe_interrupt(c.conv.id)
+    state = %{actor(c) | current_turn: nil}
+    assert ^state = TurnMachine.forget_turn_session(state, "session_gone", "old")
+    assert Repo.get!(Conversation, c.conv.id).runtime_session_id == "original-session"
+  end
+
+  test "idle legacy reset preserves its behavior but cannot clear a changed session" do
+    conv =
+      insert_conversation(
+        user_id: insert_verified_user().id,
+        status: "idle",
+        runtime_session_id: "legacy"
+      )
+
+    state = %{conversation_id: conv.id, current_turn: nil, runtime_session_id: "old"}
+    assert ^state = TurnMachine.forget_turn_session(state, "session_gone", "gone")
+
+    assert %{runtime_session_id: nil} =
+             TurnMachine.forget_turn_session(
+               %{state | runtime_session_id: "legacy"},
+               "session_gone",
+               "gone"
+             )
+
+    assert Repo.get!(Conversation, conv.id).runtime_session_id == nil
+  end
+
+  test "orphan recovery retires a known command before idling the parent", c do
+    {:ok, _} = ExecutionGuard._unsafe_claim_spawn(c.execution.id)
+
+    {:ok, _} =
+      ExecutionGuard._unsafe_bind_identity(
+        c.execution.id,
+        c.execution.connection_id,
+        "orphan-command"
+      )
+
+    assert {:ok, updated, %{status: "idle"}} =
+             Conversations._unsafe_orphan_turn(c.turn, "lost_actor")
+
+    assert updated.status == "interrupted"
+    assert updated.orphaned_at
+    assert Repo.get!(TurnExecution, c.execution.id).state == "ready"
+    assert {:ok, %{permitted: true}} = ExecutionGuard._unsafe_claim_termination(c.execution.id)
+    assert :noop = Conversations._unsafe_orphan_turn(c.turn, "duplicate")
+  end
+
+  test "orphan recovery retains an unknown spawn and cannot authorize a replacement", c do
+    {:ok, _} = ExecutionGuard._unsafe_claim_spawn(c.execution.id)
+    assert {:ok, updated, _} = Conversations._unsafe_orphan_turn(c.turn, "lost_actor")
+    assert updated.orphaned_at
+    assert Repo.get!(TurnExecution, c.execution.id).state == "awaiting_identity"
+    assert {:error, :execution_fenced} = ExecutionGuard._unsafe_admission_gate(c.conv.id)
+  end
+
+  test "orphan recovery preserves a deadline outcome and its durable event", c do
+    c.execution
+    |> Ecto.Changeset.change(deadline_at: DateTime.add(DateTime.utc_now(), -1))
+    |> Repo.update!()
+
+    assert {:ok, updated, _} = Conversations._unsafe_orphan_turn(c.turn, "lost_actor")
+    assert updated.status == "failed"
+    assert updated.limit_reason == "wall_time_limit"
+    assert updated.orphaned_at
+    events = Repo.all(from e in Conversations.LogEvent, where: e.turn_id == ^c.turn.id)
+    assert [%{state: "failed"}] = events
+  end
+
+  test "recovering an old already-ended turn leaves its successor untouched", c do
+    {next, _} = successor(c)
+    assert :noop = Conversations._unsafe_orphan_turn(c.turn, "stale_candidate")
+    assert Repo.get!(Conversation, c.conv.id).status == "running"
+    assert Repo.get!(Turn, next.id).status == "running"
+  end
+
+  test "legacy recovery closes its old turn without idling a newer running generation" do
+    conv = insert_conversation(user_id: insert_verified_user().id, status: "running")
+    old = insert_turn(conv, status: "running")
+    next = insert_turn(conv, status: "running")
+
+    assert {:ok, %{status: "interrupted"}, %{status: "running"}} =
+             Conversations._unsafe_orphan_turn(old, "old_legacy")
+
+    assert Repo.get!(Turn, next.id).status == "running"
+  end
+
+  test "admission commits running status even when an older snapshot still said running", c do
+    {:ok, _} = ExecutionGuard._unsafe_interrupt(c.conv.id)
+    {:ok, _} = Conversations.update_conversation(c.conv, %{status: "idle"})
+
+    attrs = %{
+      conversation_id: c.conv.id,
+      turn_number: 2,
+      prompt: "next",
+      status: "running",
+      started_at: DateTime.utc_now()
+    }
+
+    assert {:ok, _} =
+             Conversations._unsafe_create_turn_on_sandbox(attrs, c.sandbox.id, :unbounded)
+
+    assert Repo.get!(Conversation, c.conv.id).status == "running"
+  end
+
+  test "failed admission cannot leave an idle parent running", c do
+    {:ok, _} = ExecutionGuard._unsafe_interrupt(c.conv.id)
+    {:ok, _} = Conversations.update_conversation(c.conv, %{status: "idle"})
+    attrs = %{conversation_id: c.conv.id, turn_number: 2, status: "running"}
+
+    assert {:error, %Ecto.Changeset{}} =
+             Conversations._unsafe_create_turn_on_sandbox(attrs, c.sandbox.id, :unbounded)
+
+    assert Repo.get!(Conversation, c.conv.id).status == "idle"
+  end
+
+  test "closed parents refuse user and background admission without revival", c do
+    {:ok, _} = ExecutionGuard._unsafe_interrupt(c.conv.id)
+    attrs = %{conversation_id: c.conv.id, turn_number: 2, prompt: "late", status: "running"}
+
+    for status <- ["terminated", "failed"] do
+      c.conv |> Ecto.Changeset.change(status: status) |> Repo.update!()
+
+      # Both doors are the same door: autonomous turns go through the
+      # sandbox-bound admission like any other (#1749), so one refusal covers
+      # the user prompt and the background follow-up.
+      assert {:error, :not_running} =
+               Conversations._unsafe_create_turn_on_sandbox(attrs, c.sandbox.id, :unbounded)
+
+      assert {:error, :not_running} =
+               Fountain.Conversations.Connection.open_autonomous_turn(
+                 c.conv.id,
+                 c.conv.user_id,
+                 c.sandbox.id
+               )
+      assert Repo.get!(Conversation, c.conv.id).status == status
+    end
+
+    assert Repo.aggregate(Turn, :count) == 1
+  end
+
+  test "a changed binding cannot expire or recover another machine's parent", c do
+    c.sandbox |> Ecto.Changeset.change(sprite_name: "replacement") |> Repo.update!()
+
+    c.execution
+    |> Ecto.Changeset.change(deadline_at: DateTime.add(DateTime.utc_now(), -1))
+    |> Repo.update!()
+
+    assert {:ok, %{applied: false}} = Conversations._unsafe_set_turn_session(c.turn, "late")
+    assert {:error, :ownership_changed} = Conversations._unsafe_orphan_turn(c.turn, "old_machine")
+    assert Repo.get!(Conversation, c.conv.id).status == "running"
+    assert Repo.get!(Turn, c.turn.id).status == "running"
+  end
+
+  test "session preparation and a late pre-start failure cannot change a successor", c do
+    {next, _} = successor(c)
+    assert {:error, :execution_fenced} = TurnMachine.session_plan(c.turn, nil)
+    assert :ok = TurnMachine.fail_before_start(c.turn, c.conv.id, "spawn", "late failure", 1)
+    assert Repo.get!(Conversation, c.conv.id).status == "running"
+    assert Repo.get!(Conversation, c.conv.id).runtime_session_id == "original-session"
+    assert Repo.get!(Turn, next.id).status == "running"
+  end
+
+  test "refused session preparation returns before command construction", c do
+    successor(c)
+    state = %{conversation_id: c.conv.id, runtime_session_id: nil, turn_execution: nil}
+
+    assert ^state =
+             Conversations.TurnLaunch.run(state, c.conv, c.turn, "late", nil, [], true, fn _,
+                                                                                           _,
+                                                                                           _ ->
+               flunk("unexpected output")
+             end)
+
+    assert Repo.get!(Conversation, c.conv.id).status == "running"
+  end
+end

--- a/decisions/evidence/turn-parent-fences.json
+++ b/decisions/evidence/turn-parent-fences.json
@@ -87,7 +87,7 @@
     },
     {
       "stage": "initial race",
-      "reason": "Unknown spawn recovery correctly returns failed with awaiting_identity and spawn_unconfirmed; corrected the expectation instead of weakening uncertainty policy.",
+      "reason": "Unknown spawn recovery returns failed with awaiting_identity and spawn_unconfirmed, which is the intended immediate outcome; corrected the expectation instead of weakening uncertainty policy. It is not the final state: awaiting_identity is an obligation with an age, and ExecutionGuard._unsafe_retire_unresolved/2 writes it off if no identity ever arrives (ADR 0046).",
       "log_sha256": "sha256:75953868977b003b0398b71babd62e13d9a02ec43f7ca5a29955133e06322282"
     },
     {

--- a/decisions/evidence/turn-parent-fences.json
+++ b/decisions/evidence/turn-parent-fences.json
@@ -1,0 +1,131 @@
+{
+  "recorded_at": "2026-09-08T04:37:34.338161+00:00",
+  "parent": "751f8b6db1ec5b86b5d0a70474adf652c06f7ed4",
+  "scope": "Prepared parent-generation, runtime-session, admission and orphan-recovery fences; public controls disabled",
+  "toolchain": {
+    "elixir": "1.19.2-otp-28",
+    "erlang": "28.3",
+    "selector": "mise exec"
+  },
+  "full_precommit": {
+    "status": "passed",
+    "tests": 4755,
+    "doctests": 6,
+    "failures": 0,
+    "skipped": 2,
+    "excluded": 7,
+    "log_sha256": "sha256:e6858cda2a4003fac8a4d4c262d84582981d20a6d5d72a5f19bc2232255aee88"
+  },
+  "focused": {
+    "tests": 138,
+    "new_regressions": 27,
+    "real_actor_callback_barriers": 2,
+    "failures": 0,
+    "log_sha256": "sha256:3f3eccf8829b69aeb0f0df55d6dd01b55a353cff9c5d1f3628b62027f8cd9e11",
+    "scope": "Passed before helper-arity/comments and equivalent explicit webhook call-site corrections; final source covered by full precommit"
+  },
+  "webhook_correction": {
+    "tests": 37,
+    "failures": 0,
+    "log_sha256": "sha256:82701edfb55888bf1265b3403221248c16012600fac2ac077181f5facd7d26ab",
+    "scope": "Webhook catalogue and both parent regression modules; an incorrectly supplied reaper path matched no file, so no focused reaper coverage is claimed here"
+  },
+  "races": {
+    "DEADLINE_RACE_RESULT": {
+      "scope": "Local PostgreSQL arbitration, event durability and write permissions only",
+      "separate_database_connections": true,
+      "provider_operations": 0,
+      "cases": 20,
+      "outcomes": {
+        "completion_won": 17,
+        "expiry_won": 3
+      },
+      "lock_wait_cannot_extend_deadline": true,
+      "delayed_lock_tables": [
+        "conversations",
+        "turns"
+      ],
+      "delayed_operations": [
+        "spawn",
+        "stdin_write"
+      ],
+      "completed_connections_require_cleanup": true,
+      "deadline_event_reuse_cases": 3
+    },
+    "PARENT_RACE_RESULT": {
+      "scope": "Local parent/session/recovery arbitration; capabilities stubbed only in this dedicated local proof",
+      "late_idle_vs_admission": 20,
+      "idle_outcomes": {
+        "idle_before_admission": 20
+      },
+      "session_vs_cancel": 20,
+      "session_outcomes": {
+        "cancel_before_session": 2,
+        "session_before_cancel": 18
+      },
+      "recovery_vs_usage": 20,
+      "recovery_vs_cancel": 20,
+      "recovery_outcomes": {
+        "recovery_before_cancel": 20
+      },
+      "delayed_lock_cases": 4,
+      "delayed_tables": [
+        "conversations",
+        "turns"
+      ],
+      "separate_database_connections": true,
+      "provider_operations": 0
+    }
+  },
+  "race_log_sha256": "sha256:38b8bb7598a42d9d010cc63a31d5a35d0226aad6cdceaa27abf94605c497d164",
+  "race_source_note": "After this successful run, an unused import was removed and the equivalent legacy webhook call was made explicit; neither changed arbitration. Final source is covered by full precommit.",
+  "prior_validation": [
+    {
+      "stage": "initial focused",
+      "reason": "Interrupt fixture left parent pending; corrected to running as real admission does, retaining assertions.",
+      "log_sha256": "sha256:3547e04dafc83574acb15dfaf0a3a8b984c266e32334b768506c9292f25b2668"
+    },
+    {
+      "stage": "initial race",
+      "reason": "Unknown spawn recovery correctly returns failed with awaiting_identity and spawn_unconfirmed; corrected the expectation instead of weakening uncertainty policy.",
+      "log_sha256": "sha256:75953868977b003b0398b71babd62e13d9a02ec43f7ca5a29955133e06322282"
+    },
+    {
+      "stage": "first precommit",
+      "reason": "Credo stopped before tests: helper arity exceeded eight and three ownership comments were missing. Replaced arguments with an options map and documented existing ownership.",
+      "log_sha256": "sha256:23d8387cb2359113239fdfa734328d5ff1a7a8e7fffb0d30d9d1b88b3e634577"
+    },
+    {
+      "stage": "second precommit",
+      "tests": 4755,
+      "doctests": 6,
+      "failures": 1,
+      "reason": "Dynamic legacy reattach/interrupted publication was invisible to the source catalogue guard. Made that existing call explicit; kept catalogue and assertions unchanged.",
+      "log_sha256": "sha256:ae1a64b24ff0f06170f99c2793896f29f2cfec3ba8b900959ca0b0a19deff9b1"
+    }
+  ],
+  "public_enforcement_enabled": false,
+  "deployment_performed": false,
+  "provider_operations_in_new_proofs": 0,
+  "limits": [
+    "Actor callback tests use synthetic remote identities and cleanup acknowledgments; no actual provider deletion is proven",
+    "Explicit wake/provisioning resets and untagged lifecycle events still require fencing",
+    "Sandbox release, transfer, park, reset, rehome, deletion and incarnation audit remains; release must preserve busy-without-interruption behavior",
+    "Final provider usage may be dropped before the accounting writer; reporting completeness is not proven",
+    "Database races do not establish remote process-tree cleanup, stopped billing or aggregate PR dollar reservations",
+    "Live acceptance requires released Sprites identity support"
+  ],
+  "source_sha256": {
+    "apps/fountain/lib/fountain/conversations.ex": "sha256:611f531f21b0937b4b8ff92c5157a4854736e25d8cc1f1b926445e50ad59ae1a",
+    "apps/fountain/lib/fountain/conversations/connection.ex": "sha256:eff1f77b7eb8bb84f5d9455cea6dd6467cfc5f6b076f06a9ca3bb38d6cee6973",
+    "apps/fountain/lib/fountain/conversations/conversation_server.ex": "sha256:0e939875164c91a1508e37af418d140fcda4c0d9a39e2bec1cb72efde5905845",
+    "apps/fountain/lib/fountain/conversations/execution_guard.ex": "sha256:c0d94f8db55294a059c48f28ecb0240cd25bfcd4e806a5e839a23cc19cbf4e64",
+    "apps/fountain/lib/fountain/conversations/turn_launch.ex": "sha256:864df63788e0c7b727c001d5048135e62824b21527b5882d3b9d102dae4a58c8",
+    "apps/fountain/lib/fountain/conversations/turn_machine.ex": "sha256:05903cd8911e07eac755c5091589fe3586277f292c743d4f810aa8c5b5e94031",
+    "apps/fountain/test/fountain/conversations/conversation_server_size_test.exs": "sha256:ad83ce9f97c5db0087f29863289c8073d79fef175b61a49c0391c0266dc5e3bd",
+    "apps/fountain/test/fountain/conversations/turn_machine_test.exs": "sha256:15c65b22fa5ad01ba55594efd4e7f6225404cb7ca5d3a980e6d6bd466a20fc64",
+    "apps/fountain/test/fountain/conversations/turn_parent_actor_test.exs": "sha256:602f4d42008562cc046ab0c45e1f5ce3607af39310dfda2ef789dc77dd48d372",
+    "apps/fountain/test/fountain/conversations/turn_parent_test.exs": "sha256:125b01ad3f30c680d17931e8c6b6919449bfcfae5121c21f2a2abbdf27174e54",
+    "scripts/verify-turn-parent-races.exs": "sha256:8873b253beac09aeded5cee86ebad310cefdfd46b63c4483874f5ce95ffc40be"
+  }
+}

--- a/scripts/verify-turn-parent-races.exs
+++ b/scripts/verify-turn-parent-races.exs
@@ -1,0 +1,224 @@
+# This prelude validates the dedicated local database and independent connections.
+Code.require_file("scripts/verify-turn-deadline-races.exs")
+alias Fountain.{Conversations, Repo}
+
+alias Fountain.Conversations.{
+  Conversation,
+  Sandbox,
+  Turn,
+  TurnExecution,
+  ExecutionGuard,
+  ExecutionLimits
+}
+
+{:ok, _} = Application.ensure_all_started(:mimic)
+:ok = Mimic.copy(ExecutionLimits)
+:ok = Mimic.set_mimic_global()
+Mimic.stub(ExecutionLimits, :enforced_controls, fn _ -> ExecutionLimits.keys() end)
+
+user =
+  Repo.insert!(%Fountain.Accounts.User{email: "parent-race-#{Ecto.UUID.generate()}@example.test"})
+
+fixture = fn ->
+  sandbox =
+    Repo.insert!(%Sandbox{
+      user_id: user.id,
+      sprite_name: "local-parent-#{Ecto.UUID.generate()}",
+      status: "ready"
+    })
+
+  conv =
+    Repo.insert!(%Conversation{
+      user_id: user.id,
+      sandbox_id: sandbox.id,
+      runtime: "claude",
+      status: "idle",
+      runtime_session_id: "original",
+      execution_limits: %{"wall_time_seconds" => 60}
+    })
+
+  attrs = %{
+    conversation_id: conv.id,
+    turn_number: 1,
+    prompt: "local parent fixture",
+    status: "running",
+    started_at: DateTime.utc_now() |> DateTime.truncate(:second)
+  }
+
+  {:ok, turn} = Conversations._unsafe_create_turn_on_sandbox(attrs, sandbox.id, :unbounded)
+  {sandbox, conv, turn, ExecutionGuard._unsafe_for_turn(turn.id), attrs}
+end
+
+idle_results =
+  for _ <- 1..20 do
+    {sandbox, conv, turn, _, attrs} = fixture.()
+    {:ok, _} = ExecutionGuard._unsafe_interrupt(conv.id)
+
+    [{:ok, old}, {:ok, next}] =
+      DeadlineRace.concurrently([
+        fn -> Conversations._unsafe_idle_after_turn(turn) end,
+        fn ->
+          Conversations._unsafe_create_turn_on_sandbox(
+            %{attrs | turn_number: 2},
+            sandbox.id,
+            :unbounded
+          )
+        end
+      ])
+
+    "running" = Repo.get!(Conversation, conv.id).status
+    "running" = Repo.get!(Turn, next.id).status
+    "active" = ExecutionGuard._unsafe_for_turn(next.id).state
+    {:ok, %{applied: false}} = Conversations._unsafe_idle_after_turn(turn)
+    if old.applied, do: "idle_before_admission", else: "admission_before_idle"
+  end
+
+session_results =
+  for _ <- 1..20 do
+    {_, conv, turn, _, _} = fixture.()
+
+    [{:ok, report}, {:ok, _}] =
+      DeadlineRace.concurrently([
+        fn -> Conversations._unsafe_set_turn_session(turn, "accepted-before-cancel") end,
+        fn -> ExecutionGuard._unsafe_interrupt(conv.id) end
+      ])
+
+    expected = if report.applied, do: "accepted-before-cancel", else: "original"
+    ^expected = Repo.get!(Conversation, conv.id).runtime_session_id
+    {:ok, %{applied: false}} = Conversations._unsafe_set_turn_session(turn, "too-late")
+    ^expected = Repo.get!(Conversation, conv.id).runtime_session_id
+    if report.applied, do: "session_before_cancel", else: "cancel_before_session"
+  end
+
+for _ <- 1..20 do
+  {_, conv, turn, execution, _} = fixture.()
+  {:ok, _} = ExecutionGuard._unsafe_claim_spawn(execution.id)
+
+  [{:ok, _, _}, {:ok, _}] =
+    DeadlineRace.concurrently([
+      fn -> Conversations._unsafe_orphan_turn(turn, "lost_actor") end,
+      fn -> Conversations._unsafe_record_turn_usage(turn, %{"input" => 7, "output" => 3}) end
+    ])
+
+  %{status: "failed", usage: %{"input" => 7}, orphaned_at: %DateTime{}} =
+    Repo.get!(Turn, turn.id)
+
+  %{status: "idle", usage_input_tokens: 7, usage_output_tokens: 3} =
+    Repo.get!(Conversation, conv.id)
+
+  %{state: "awaiting_identity", last_error: "spawn_unconfirmed"} =
+    Repo.get!(TurnExecution, execution.id)
+end
+
+recovery_results =
+  for _ <- 1..20 do
+    {_, conv, turn, execution, _} = fixture.()
+    {:ok, _} = ExecutionGuard._unsafe_claim_spawn(execution.id)
+
+    [recovery, {:ok, _}] =
+      DeadlineRace.concurrently([
+        fn -> Conversations._unsafe_orphan_turn(turn, "lost_actor") end,
+        fn -> ExecutionGuard._unsafe_interrupt(conv.id) end
+      ])
+
+    "failed" = Repo.get!(Turn, turn.id).status
+
+    %{state: "awaiting_identity", last_error: "spawn_unconfirmed"} =
+      Repo.get!(TurnExecution, execution.id)
+
+    if recovery == :noop, do: "cancel_before_recovery", else: "recovery_before_cancel"
+  end
+
+for operation <- [:session, :recovery], table <- ["conversations", "turns"] do
+  {_, conv, turn, execution, _} = fixture.()
+  deadline = DateTime.add(DateTime.utc_now(), 2)
+  execution |> Ecto.Changeset.change(deadline_at: deadline) |> Repo.update!()
+  owner = self()
+  id = if table == "conversations", do: conv.id, else: turn.id
+
+  holder =
+    Task.async(fn ->
+      Repo.transaction(fn ->
+        Repo.query!("SELECT id FROM #{table} WHERE id = $1 FOR UPDATE", [Ecto.UUID.dump!(id)])
+        send(owner, :locked)
+
+        receive do
+          :release -> :ok
+        after
+          10_000 -> raise "Lock holder timed out"
+        end
+      end)
+    end)
+
+  receive do
+    :locked -> :ok
+  after
+    10_000 -> raise "Lock acquisition timed out"
+  end
+
+  writer =
+    Task.async(fn ->
+      Repo.checkout(fn ->
+        %{rows: [[backend]]} = Repo.query!("SELECT pg_backend_pid()")
+        send(owner, {:writer_backend, backend})
+
+        case operation do
+          :session -> Conversations._unsafe_set_turn_session(turn, "too-late")
+          :recovery -> Conversations._unsafe_orphan_turn(turn, "lost_actor")
+        end
+      end)
+    end)
+
+  backend =
+    receive do
+      {:writer_backend, backend} -> backend
+    after
+      1_000 -> raise "Writer checkout timed out"
+    end
+
+  waiting =
+    Enum.reduce_while(1..100, false, fn _, _ ->
+      case Repo.query!("SELECT wait_event_type FROM pg_stat_activity WHERE pid = $1", [backend]).rows do
+        [["Lock"]] ->
+          {:halt, true}
+
+        _ ->
+          Process.sleep(5)
+          {:cont, false}
+      end
+    end)
+
+  true = waiting
+  :lt = DateTime.compare(DateTime.utc_now(), deadline)
+  Process.sleep(max(DateTime.diff(deadline, DateTime.utc_now(), :millisecond), 0) + 50)
+  send(holder.pid, :release)
+  Task.await(holder)
+  result = Task.await(writer)
+
+  case operation do
+    :session -> {:ok, %{applied: false}} = result
+    :recovery -> {:ok, %{limit_reason: "wall_time_limit"}, _} = result
+  end
+
+  %{status: "failed", limit_reason: "wall_time_limit"} = Repo.get!(Turn, turn.id)
+  "original" = Repo.get!(Conversation, conv.id).runtime_session_id
+end
+
+IO.puts(
+  "PARENT_RACE_RESULT=" <>
+    Jason.encode!(%{
+      late_idle_vs_admission: 20,
+      idle_outcomes: Enum.frequencies(idle_results),
+      session_vs_cancel: 20,
+      session_outcomes: Enum.frequencies(session_results),
+      recovery_vs_usage: 20,
+      recovery_vs_cancel: 20,
+      recovery_outcomes: Enum.frequencies(recovery_results),
+      delayed_lock_cases: 4,
+      delayed_tables: ["conversations", "turns"],
+      separate_database_connections: true,
+      provider_operations: 0,
+      scope:
+        "Local parent/session/recovery arbitration; capabilities stubbed only in this dedicated local proof"
+    })
+)


### PR DESCRIPTION
A late completion or session callback could overwrite parent state after cancellation and successor admission. Parent/session writes now check the exact turn generation under database locks. Admission commits running status with the turn; orphan recovery retires execution first and preserves uncertain spawns and deadline outcomes.

Stacked on #1750; **draft, public enforcement disabled**. Remaining gates: sandbox release/transfer/park/reset/incarnation safety, released Sprites identity support and live provider acceptance. Tracks #1732.

Full precommit: **4,755 tests + 6 doctests, zero failures**. Includes 27 new regressions and two real-actor callback barriers. Independent PostgreSQL proofs pass 80 new races and four delayed-lock cases, plus 20 earlier deadline races. Provider acknowledgments are synthetic; no provider operations occurred.

Evidence: `decisions/evidence/turn-parent-fences.json`. Records corrected fixture expectations, Credo findings and the webhook source-catalogue failure; no checks were weakened. ADR validation and secret scanning pass.

[CI at `8381e6a7`](https://github.com/BinaryBourbon/fountain/actions/runs/34187729039) passes the test partitions and other checks but fails the dependency audit: EEF-CVE-2026-32686 now includes Decimal 3.1.1. The [maintainer advisory](https://github.com/ericmj/decimal/security/advisories/GHSA-rhv4-8758-jx7v) lists 3.0.0 as patched; the current EEF feed lacks that fixed boundary. This discrepancy is under investigation; CI has not been waived.



Part of #1732 — **held**. Superseded on main by #1773–#1793; the residual hunks are being re-cut as focused PRs tracked by #1864, which keeps these frozen until each has a replacement or an explicitly linked deferral. Do not close: they are the reference for that mapping.
