### PR TITLE
Refuse conversation release while remote execution is unresolved

### DIFF
--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -1193,6 +1193,19 @@ defmodule Fountain.Conversations do
     |> notify_parent_change()
   end
 
+  @doc "Terminate the owned conversation only when no turn or remote execution remains open."
+  def _unsafe_release_conversation(conversation_id) do
+    # ownership: the lifecycle client/actor received an already-owned conversation.
+    ExecutionGuard._unsafe_release_parent(conversation_id, fn current ->
+      current |> Conversation.changeset(%{status: "terminated"}) |> Repo.update()
+    end)
+    |> notify_parent_change()
+    |> case do
+      {:ok, _} -> :ok
+      error -> error
+    end
+  end
+
   defp write_turn_parent(turn, mode, attrs) do
     # ownership: the calling actor/recovery path already owns this exact turn.
     result =

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -1194,11 +1194,15 @@ defmodule Fountain.Conversations do
   end
 
   @doc "Terminate the owned conversation only when no turn or remote execution remains open."
-  def _unsafe_release_conversation(conversation_id) do
+  def _unsafe_release_conversation(conversation_id, opts \\ []) do
     # ownership: the lifecycle client/actor received an already-owned conversation.
-    ExecutionGuard._unsafe_release_parent(conversation_id, fn current ->
-      current |> Conversation.changeset(%{status: "terminated"}) |> Repo.update()
-    end)
+    ExecutionGuard._unsafe_release_parent(
+      conversation_id,
+      fn current ->
+        current |> Conversation.changeset(%{status: "terminated"}) |> Repo.update()
+      end,
+      opts
+    )
     |> notify_parent_change()
     |> case do
       {:ok, _} -> :ok

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -372,15 +372,19 @@ defmodule Fountain.Conversations.ConversationServer do
   takes the `sandbox_id`, and its first prompt reattaches through the
   ordinary wake path — a new runtime session on the same disk.
 
-  `{:error, :busy}` while a turn runs or remote execution remains unresolved;
-  nothing is interrupted. The same durable check applies with no server alive.
+  `{:error, :busy}` while a turn runs on a **live** server; nothing is
+  interrupted. With no server alive that row is as likely an orphan (see
+  `Conversations.wake_for_interrupt/1`), so release proceeds. Unresolved
+  bounded execution answers `{:error, :execution_fenced}` either way: a
+  durable fact rather than an inference, and bounded (ADR 0046).
+
   Audited as `conversation.released` unless `audit: false`.
   """
   def release_conversation(conv_id, opts \\ []) do
     result =
       case whereis(conv_id) do
         nil ->
-          Conversations._unsafe_release_conversation(conv_id)
+          Conversations._unsafe_release_conversation(conv_id, actor_alive?: false)
 
         pid ->
           call_server(pid, :release_conv)
@@ -2408,8 +2412,7 @@ defmodule Fountain.Conversations.ConversationServer do
     state = %{state | current_turn: nil}
 
     # A bounded turn that never started still holds a journal and a transport.
-    # Closing here is the retirement intent, not a confirmed remote stop — the
-    # coordinator owns the confirmation.
+    # Closing is retirement intent, not a confirmed stop; the coordinator confirms.
     if state.turn_execution, do: close_bounded_connection(state), else: state
   end
 

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -372,22 +372,15 @@ defmodule Fountain.Conversations.ConversationServer do
   takes the `sandbox_id`, and its first prompt reattaches through the
   ordinary wake path — a new runtime session on the same disk.
 
-  `{:error, :busy}` while a turn is running; nothing is interrupted. With no
-  server alive the row alone is marked, the same as `terminate_conversation/2`.
+  `{:error, :busy}` while a turn runs or remote execution remains unresolved;
+  nothing is interrupted. The same durable check applies with no server alive.
   Audited as `conversation.released` unless `audit: false`.
   """
   def release_conversation(conv_id, opts \\ []) do
     result =
       case whereis(conv_id) do
         nil ->
-          case Conversations._unsafe_get_conversation(conv_id) do
-            nil ->
-              {:error, :not_running}
-
-            conv ->
-              {:ok, _} = Conversations.update_conversation(conv, %{status: "terminated"})
-              :ok
-          end
+          Conversations._unsafe_release_conversation(conv_id)
 
         pid ->
           call_server(pid, :release_conv)
@@ -1652,11 +1645,15 @@ defmodule Fountain.Conversations.ConversationServer do
   end
 
   def handle_call(:release_conv, _from, state) do
-    state = drop_connection(state, "released")
-    conv = Conversations._unsafe_get_conversation!(state.conversation_id)
-    {:ok, _} = Conversations.update_conversation(conv, %{status: "terminated"})
-    Output.publish_stage(state.conversation_id, "terminate", "done", %{event: "released"})
-    {:stop, :normal, :ok, %{state | handle: nil}}
+    case Conversations._unsafe_release_conversation(state.conversation_id) do
+      :ok ->
+        state = drop_connection(state, "released")
+        Output.publish_stage(state.conversation_id, "terminate", "done", %{event: "released"})
+        {:stop, :normal, :ok, %{state | handle: nil}}
+
+      {:error, _} = error ->
+        {:reply, error, state}
+    end
   end
 
   # A notification for the revision this server already holds is a no-op: it

--- a/apps/fountain/lib/fountain/conversations/execution_guard.ex
+++ b/apps/fountain/lib/fountain/conversations/execution_guard.ex
@@ -118,16 +118,31 @@ defmodule Fountain.Conversations.ExecutionGuard do
   end
 
   @doc "Release only a durably idle parent; refusal never retires or interrupts execution."
-  def _unsafe_release_parent(conversation_id, writer) do
+  def _unsafe_release_parent(conversation_id, writer, opts \\ []) do
     transaction(fn ->
       conv = lock_parent(conversation_id) || Repo.rollback(:not_running)
 
-      running? =
-        Repo.exists?(
-          from t in Turn, where: t.conversation_id == ^conversation_id and t.status == "running"
-        )
+      # A `running` turn row is evidence of a live turn only when there is a
+      # server to run it. Without one it is as likely an orphan — a deploy, a
+      # Horde rebalance or a plain `{:stop, :normal, _}` left it behind, which
+      # `wake_for_interrupt/1` spells out — and release is what an owner
+      # reaches for in exactly that state. Refusing there took away a release
+      # that always worked. The caller says whether a server is alive.
+      if Keyword.get(opts, :actor_alive?, true) do
+        running? =
+          Repo.exists?(
+            from t in Turn, where: t.conversation_id == ^conversation_id and t.status == "running"
+          )
 
-      if running? or open_execution?(conversation_id), do: Repo.rollback(:busy)
+        if running?, do: Repo.rollback(:busy)
+      end
+
+      # The durable fence is unconditional. An unresolved bounded execution
+      # means a remote command may still be running, and releasing would drop
+      # the row that says so. This one has an age rather than being permanent
+      # — `_unsafe_retire_unresolved/2` writes it off — so the refusal is
+      # bounded, unlike the running-turn check it used to sit beside.
+      if open_execution?(conversation_id), do: Repo.rollback(:execution_fenced)
 
       case writer.(conv) do
         {:ok, updated} -> {%{applied: true, conversation: updated}, nil, nil}

--- a/apps/fountain/lib/fountain/conversations/execution_guard.ex
+++ b/apps/fountain/lib/fountain/conversations/execution_guard.ex
@@ -117,6 +117,25 @@ defmodule Fountain.Conversations.ExecutionGuard do
     end)
   end
 
+  @doc "Release only a durably idle parent; refusal never retires or interrupts execution."
+  def _unsafe_release_parent(conversation_id, writer) do
+    transaction(fn ->
+      conv = lock_parent(conversation_id) || Repo.rollback(:not_running)
+
+      running? =
+        Repo.exists?(
+          from t in Turn, where: t.conversation_id == ^conversation_id and t.status == "running"
+        )
+
+      if running? or open_execution?(conversation_id), do: Repo.rollback(:busy)
+
+      case writer.(conv) do
+        {:ok, updated} -> {%{applied: true, conversation: updated}, nil, nil}
+        {:error, reason} -> Repo.rollback(reason)
+      end
+    end)
+  end
+
   @doc "Find the immutable journal for an already-owned actor's turn."
   def _unsafe_for_turn(turn_id), do: Repo.get_by(TurnExecution, turn_id: turn_id)
 

--- a/apps/fountain/test/fountain/conversations/release_fence_actor_test.exs
+++ b/apps/fountain/test/fountain/conversations/release_fence_actor_test.exs
@@ -1,0 +1,38 @@
+defmodule Fountain.Conversations.ReleaseFenceActorTest do
+  use Fountain.ConversationServerCase
+
+  alias Fountain.Conversations.ExecutionGuard
+
+  test "an idle actor refuses unresolved remote work before closing anything" do
+    user = insert_verified_user()
+    sandbox = insert_sandbox(user_id: user.id, status: "ready")
+    conv = insert_conversation(user_id: user.id, sandbox: sandbox, status: "idle")
+    stub_happy_sprite(sandbox.sprite_name)
+    {pid, _monitor, :alive} = start_server(conv)
+    on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+    turn = insert_turn(conv, status: "running")
+
+    {:ok, execution} =
+      ExecutionGuard._unsafe_register(
+        turn.id,
+        Ecto.UUID.generate(),
+        DateTime.add(DateTime.utc_now(), 60)
+      )
+
+    {:ok, _} = ExecutionGuard._unsafe_claim_spawn(execution.id)
+    {:ok, _} = ExecutionGuard._unsafe_interrupt(conv.id)
+    before = :sys.get_state(pid)
+    assert is_nil(before.current_turn)
+    parent = Conversations._unsafe_get_conversation!(conv.id)
+    key = Repo.get!(Fountain.Accounts.ApiKey, parent.callback_api_key_id)
+    events = Conversations._unsafe_list_log_events(conv.id)
+
+    assert {:error, :busy} = GenServer.call(pid, :release_conv)
+    assert :sys.get_state(pid) == before
+    assert Conversations._unsafe_get_conversation!(conv.id) == parent
+    assert Repo.reload!(key) == key
+    assert Conversations._unsafe_list_log_events(conv.id) == events
+    assert ExecutionGuard._unsafe_for_turn(turn.id).state == "awaiting_identity"
+    assert Repo.reload!(sandbox).status == "ready"
+  end
+end

--- a/apps/fountain/test/fountain/conversations/release_fence_actor_test.exs
+++ b/apps/fountain/test/fountain/conversations/release_fence_actor_test.exs
@@ -27,7 +27,7 @@ defmodule Fountain.Conversations.ReleaseFenceActorTest do
     key = Repo.get!(Fountain.Accounts.ApiKey, parent.callback_api_key_id)
     events = Conversations._unsafe_list_log_events(conv.id)
 
-    assert {:error, :busy} = GenServer.call(pid, :release_conv)
+    assert {:error, :execution_fenced} = GenServer.call(pid, :release_conv)
     assert :sys.get_state(pid) == before
     assert Conversations._unsafe_get_conversation!(conv.id) == parent
     assert Repo.reload!(key) == key

--- a/apps/fountain/test/fountain/conversations/release_fence_test.exs
+++ b/apps/fountain/test/fountain/conversations/release_fence_test.exs
@@ -11,11 +11,47 @@ defmodule Fountain.Conversations.ReleaseFenceTest do
     %{conv: Repo.reload!(conv), sandbox: sandbox}
   end
 
-  test "an absent actor does not authorize release of a running legacy turn", c do
+  test "an orphaned running turn does not block release", c do
+    # This test used to assert the opposite, and the opposite took away a
+    # release that always worked. With no server alive a `running` turn row is
+    # as likely an orphan as a live turn — a deploy, a Horde rebalance or a
+    # plain `{:stop, :normal, _}` leaves one behind, which is what
+    # `wake_for_interrupt/1` exists for — and release is what an owner reaches
+    # for in exactly that state. Inferring "busy" from the row there fences
+    # the owner out of their own recovery with nothing to un-fence it.
     turn = insert_turn(c.conv, status: "running")
-    assert {:error, :busy} = ConversationServer.release_conversation(c.conv.id)
+    assert is_nil(ConversationServer.whereis(c.conv.id))
+    assert :ok = ConversationServer.release_conversation(c.conv.id)
+    assert Conversations._unsafe_get_conversation!(c.conv.id).status == "terminated"
+    # Release terminates the parent; it does not rewrite the turn's history.
+    assert Repo.reload!(turn).status == "running"
+  end
+
+  test "a live actor's running turn still refuses release", c do
+    # The row is only authoritative when something is there to run it.
+    turn = insert_turn(c.conv, status: "running")
+
+    assert {:error, :busy} =
+             Conversations._unsafe_release_conversation(c.conv.id, actor_alive?: true)
+
     assert Conversations._unsafe_get_conversation!(c.conv.id).status == "idle"
     assert Repo.reload!(turn).status == "running"
+  end
+
+  test "a durable execution fence refuses release with or without an actor", c do
+    execution = execution(c, "ready")
+
+    # Unlike the running-turn inference, this one is a fact the journal holds,
+    # so it refuses either way — and it is bounded, because the coordinator
+    # writes an obligation off once nothing can resolve it.
+    assert {:error, :execution_fenced} =
+             Conversations._unsafe_release_conversation(c.conv.id, actor_alive?: false)
+
+    assert {:error, :execution_fenced} =
+             Conversations._unsafe_release_conversation(c.conv.id, actor_alive?: true)
+
+    assert Repo.get!(TurnExecution, execution.id).state == "ready"
+    assert Conversations._unsafe_get_conversation!(c.conv.id).status == "idle"
   end
 
   for state <- ~w(active awaiting_identity ready submitted uncertain) do
@@ -24,7 +60,7 @@ defmodule Fountain.Conversations.ReleaseFenceTest do
       execution = execution(c, @state)
       turn = Repo.get!(Conversations.Turn, execution.turn_id)
       assert is_nil(ConversationServer.whereis(c.conv.id))
-      assert {:error, :busy} = ConversationServer.release_conversation(c.conv.id)
+      assert {:error, :execution_fenced} = ConversationServer.release_conversation(c.conv.id)
       assert Repo.reload!(execution) == execution
       assert Repo.reload!(turn) == turn
       assert Repo.reload!(c.conv) == c.conv

--- a/apps/fountain/test/fountain/conversations/release_fence_test.exs
+++ b/apps/fountain/test/fountain/conversations/release_fence_test.exs
@@ -1,0 +1,117 @@
+defmodule Fountain.Conversations.ReleaseFenceTest do
+  use Fountain.DataCase, async: true
+
+  alias Fountain.Conversations
+  alias Fountain.Conversations.{ConversationServer, ExecutionGuard, TurnExecution}
+
+  setup do
+    user = insert_verified_user()
+    sandbox = insert_sandbox(user_id: user.id, status: "ready")
+    conv = insert_conversation(user_id: user.id, sandbox: sandbox, status: "idle")
+    %{conv: Repo.reload!(conv), sandbox: sandbox}
+  end
+
+  test "an absent actor does not authorize release of a running legacy turn", c do
+    turn = insert_turn(c.conv, status: "running")
+    assert {:error, :busy} = ConversationServer.release_conversation(c.conv.id)
+    assert Conversations._unsafe_get_conversation!(c.conv.id).status == "idle"
+    assert Repo.reload!(turn).status == "running"
+  end
+
+  for state <- ~w(active awaiting_identity ready submitted uncertain) do
+    @state state
+    test "release refuses #{@state} execution without changing it", c do
+      execution = execution(c, @state)
+      turn = Repo.get!(Conversations.Turn, execution.turn_id)
+      assert is_nil(ConversationServer.whereis(c.conv.id))
+      assert {:error, :busy} = ConversationServer.release_conversation(c.conv.id)
+      assert Repo.reload!(execution) == execution
+      assert Repo.reload!(turn) == turn
+      assert Repo.reload!(c.conv) == c.conv
+      assert Repo.reload!(c.sandbox) == c.sandbox
+    end
+  end
+
+  test "confirmed cleanup permits release and later admission cannot revive the parent", c do
+    execution = execution(c, "submitted")
+
+    # Synthetic cleanup acknowledgment; no provider deletion is claimed.
+    {:ok, _} =
+      ExecutionGuard._unsafe_record_termination(execution.id, execution.attempt_id, :ok)
+
+    assert :ok = ConversationServer.release_conversation(c.conv.id)
+    assert Repo.reload!(c.conv).status == "terminated"
+    assert Repo.reload!(c.sandbox) == c.sandbox
+
+    attrs = %{
+      conversation_id: c.conv.id,
+      turn_number: 2,
+      prompt: "too late",
+      status: "running",
+      started_at: DateTime.utc_now()
+    }
+
+    assert {:error, :not_running} =
+             Conversations._unsafe_create_turn_on_sandbox(attrs, c.sandbox.id, :unbounded)
+  end
+
+  test "an unrelated co-tenant may keep working when this idle conversation releases", c do
+    other =
+      insert_conversation(user_id: c.conv.user_id, sandbox: c.sandbox, status: "running")
+
+    turn = insert_turn(other, status: "running")
+    other = Repo.reload!(other)
+    assert :ok = ConversationServer.release_conversation(c.conv.id)
+    assert Repo.reload!(other) == other
+    assert Repo.reload!(turn) == turn
+    assert Repo.reload!(c.sandbox) == c.sandbox
+  end
+
+  test "a deleted parent returns not_running", c do
+    Repo.delete!(c.conv)
+    assert {:error, :not_running} = ConversationServer.release_conversation(c.conv.id)
+  end
+
+  defp execution(c, state) do
+    turn = insert_turn(c.conv, status: "running")
+
+    {:ok, execution} =
+      ExecutionGuard._unsafe_register(
+        turn.id,
+        Ecto.UUID.generate(),
+        DateTime.add(DateTime.utc_now(), 60)
+      )
+
+    if state != "active" do
+      {:ok, _} = ExecutionGuard._unsafe_claim_spawn(execution.id)
+
+      if state != "awaiting_identity" do
+        {:ok, _} =
+          ExecutionGuard._unsafe_bind_identity(
+            execution.id,
+            execution.connection_id,
+            "synthetic-release-command"
+          )
+      end
+
+      {:ok, _} = ExecutionGuard._unsafe_interrupt(c.conv.id)
+
+      if state in ["submitted", "uncertain"] do
+        {:ok, %{execution: claimed}} = ExecutionGuard._unsafe_claim_termination(execution.id)
+
+        if state == "uncertain" do
+          {:ok, _} =
+            ExecutionGuard._unsafe_record_termination(
+              execution.id,
+              claimed.attempt_id,
+              {:error, :timeout}
+            )
+        end
+      end
+    end
+
+    result = Repo.get!(TurnExecution, execution.id)
+    assert result.state == state
+    result
+  end
+end

--- a/decisions/0046-durable-turn-deadlines.md
+++ b/decisions/0046-durable-turn-deadlines.md
@@ -164,6 +164,22 @@ explicit policy. Uncertainty must never be erased by transcript deletion — but
 it must not be permanent either, which is what the ageing exit above settles.
 The cutoff itself is the supervisor's to choose and is not fixed here.
 
+### Release refuses on a fact, not an inference
+
+Releasing a conversation refuses while a bounded execution is unresolved,
+because that is a durable fact and the journal row saying so would be dropped
+with the parent. It does **not** refuse on a `running` turn row when no server
+is alive: there, the row is as likely an orphan as a live turn — a deploy, a
+Horde rebalance or a plain `{:stop, :normal, _}` leaves one behind — and
+release is what an owner reaches for in exactly that state. Inferring "busy"
+from the row fenced the owner out of their own recovery with nothing able to
+un-fence it, which is the same failure as the permanent reset refusal above.
+A live server keeps the row authoritative and still refuses.
+
+The two refusals therefore say different things: `:busy` is a turn a live
+actor is running, and `:execution_fenced` is remote work Fountain cannot yet
+account for. The second has an age; the first ends on its own.
+
 ### The fence suppresses; it never rewrites
 
 A retired bounded turn's output events are not written and not broadcast:

--- a/decisions/evidence/release-fence.json
+++ b/decisions/evidence/release-fence.json
@@ -1,0 +1,95 @@
+{
+  "recorded_at": "2026-09-08T04:53:27.010739+00:00",
+  "parent": "8381e6a7a8ce600f8b52589286683e16cc4336d3",
+  "scope": "Durable release refusal without interrupting remote work; public execution controls disabled",
+  "toolchain": {
+    "elixir": "1.19.2-otp-28",
+    "erlang": "28.3",
+    "selector": "mise exec"
+  },
+  "reproducer": {
+    "result": "confirmed before fix: absent actor release succeeded with awaiting_identity execution",
+    "provider_operations": 0,
+    "log_sha256": "sha256:a6d4852e18328606562d0a4f422f0d6a9e01442db36625c5836dde4a0de11ee9",
+    "script_sha256": "sha256:8fe84e679a5cadde865a39d242066f933998824dbc3cdb91d5be00754c5cef23"
+  },
+  "full_precommit": {
+    "status": "passed",
+    "tests": 4765,
+    "doctests": 6,
+    "failures": 0,
+    "skipped": 2,
+    "excluded": 7,
+    "log_sha256": "sha256:7fac86f4192979c4f28cb145c11fe8aa238ce8e7fa59f260b1ffd91a16c0df96"
+  },
+  "focused": {
+    "tests": 103,
+    "new_regressions": 10,
+    "real_actor_tests": 1,
+    "failures": 0,
+    "log_sha256": "sha256:1d615bb189f9ca5a069f03f1dd7a30a532d0b207b8ad0766efa145fe10205288"
+  },
+  "races": {
+    "DEADLINE_RACE_RESULT": {
+      "scope": "Local PostgreSQL arbitration, event durability and write permissions only",
+      "separate_database_connections": true,
+      "provider_operations": 0,
+      "cases": 20,
+      "outcomes": {
+        "completion_won": 13,
+        "expiry_won": 7
+      },
+      "lock_wait_cannot_extend_deadline": true,
+      "delayed_lock_tables": [
+        "conversations",
+        "turns"
+      ],
+      "delayed_operations": [
+        "spawn",
+        "stdin_write"
+      ],
+      "completed_connections_require_cleanup": true,
+      "deadline_event_reuse_cases": 7
+    },
+    "RELEASE_RACE_RESULT": {
+      "scope": "Local release/admission/recovery/cleanup arbitration; synthetic identities and acknowledgments",
+      "admission_outcomes": {
+        "release_before_admission": 20
+      },
+      "cleanup_outcomes": {
+        "release_before_cleanup": 20
+      },
+      "release_vs_admission": 20,
+      "release_vs_orphan_recovery": 20,
+      "release_vs_cleanup_ack": 20,
+      "separate_database_connections": true,
+      "provider_operations": 0
+    }
+  },
+  "race_log_sha256": "sha256:157d208e16c35f20f4f7f94eae11df99819d5cbdf8f220cc7bdafa1f3e787b70",
+  "prior_validation": {
+    "focused_tests": 103,
+    "failures": 6,
+    "reason": "Fixture snapshots compared preloaded associations with unloaded reloaded rows. Reloaded both snapshots consistently; retained every row-preservation assertion. Removed one unused test alias.",
+    "log_sha256": "sha256:4727e2aa1c84cbebc6f921230e92f6d569d21df18248389a53e6d1b9622937e1"
+  },
+  "public_enforcement_enabled": false,
+  "deployment_performed": false,
+  "provider_operations_in_new_proofs": 0,
+  "limits": [
+    "This fences release of the exact conversation; unrelated co-tenants may continue. It does not establish machine transfer, park, reset, rehome, deletion or incarnation safety",
+    "All command identities and cleanup acknowledgments are synthetic; no provider operation or stopped billing is proven",
+    "Registration in the race proof uses locally stubbed capabilities; public controls remain disabled",
+    "Live provider acceptance still requires released Sprites identity support",
+    "Parent PR CI is blocked by Decimal advisory-data discrepancy EEF-CVE-2026-32686; local precommit does not include the separate CI audit gate"
+  ],
+  "source_sha256": {
+    "apps/fountain/lib/fountain/conversations.ex": "sha256:6c18efb25e194aaf7de634fcfffee95701a46f091693a9ca1036986bbbce7864",
+    "apps/fountain/lib/fountain/conversations/conversation_server.ex": "sha256:dccb0815d82cf8080b17b844f0c6c23401ddff7c7545ea8d079687ac8a44a35a",
+    "apps/fountain/lib/fountain/conversations/execution_guard.ex": "sha256:3309a296adc238508eced69a979539cc49ce0b5bba93f2cafe502b939a61b426",
+    "apps/fountain/test/fountain/conversations/conversation_server_size_test.exs": "sha256:3179155bff068fdbbd8cb21f872d08a66496c80bf3768ca9ea32259eba7f3ee1",
+    "apps/fountain/test/fountain/conversations/release_fence_actor_test.exs": "sha256:d32912399e73cd070bc2754cdd59402f4d1d5616dd868933ff7b8e304ccec141",
+    "apps/fountain/test/fountain/conversations/release_fence_test.exs": "sha256:d97386a19dc4156748fc3ee5baf72c8786bd03deb6cc66c26280fb28d0c1cb75",
+    "scripts/verify-release-fence-races.exs": "sha256:48d84c8634e2fe0ac1d932ac4761ce3626b1bbdd988f2ba2854d6bef2be2290a"
+  }
+}

--- a/scripts/verify-release-fence-races.exs
+++ b/scripts/verify-release-fence-races.exs
@@ -1,0 +1,130 @@
+# The prelude refuses non-test/non-local databases and verifies independent connections.
+Code.require_file("scripts/verify-turn-deadline-races.exs")
+alias Fountain.{Conversations, Repo}
+alias Fountain.Conversations.{Conversation, ExecutionGuard, ExecutionLimits, Sandbox, Turn}
+
+{:ok, _} = Application.ensure_all_started(:mimic)
+:ok = Mimic.copy(ExecutionLimits)
+:ok = Mimic.set_mimic_global()
+Mimic.stub(ExecutionLimits, :enforced_controls, fn _ -> ExecutionLimits.keys() end)
+
+user = Repo.insert!(%Fountain.Accounts.User{email: "release-race-#{Ecto.UUID.generate()}@example.test"})
+
+fixture = fn ->
+  sandbox =
+    Repo.insert!(%Sandbox{
+      user_id: user.id,
+      sprite_name: "local-release-#{Ecto.UUID.generate()}",
+      status: "ready"
+    })
+
+  conv =
+    Repo.insert!(%Conversation{
+      user_id: user.id,
+      sandbox_id: sandbox.id,
+      runtime: "claude",
+      status: "idle",
+      execution_limits: %{"wall_time_seconds" => 60}
+    })
+
+  attrs = %{
+    conversation_id: conv.id,
+    turn_number: 1,
+    prompt: "local release proof",
+    status: "running",
+    started_at: DateTime.utc_now() |> DateTime.truncate(:second)
+  }
+
+  {sandbox, conv, attrs}
+end
+
+admission_outcomes =
+  for _ <- 1..20 do
+    {sandbox, conv, attrs} = fixture.()
+
+    [release, admission] =
+      DeadlineRace.concurrently([
+        fn -> Conversations._unsafe_release_conversation(conv.id) end,
+        fn -> Conversations._unsafe_create_turn_on_sandbox(attrs, sandbox.id, :unbounded) end
+      ])
+
+    case {release, admission} do
+      {:ok, {:error, :not_running}} ->
+        "terminated" = Repo.get!(Conversation, conv.id).status
+        [] = Conversations._unsafe_list_turns(conv.id)
+        "release_before_admission"
+
+      {{:error, :busy}, {:ok, turn}} ->
+        "running" = Repo.get!(Conversation, conv.id).status
+        "running" = Repo.get!(Turn, turn.id).status
+        "active" = ExecutionGuard._unsafe_for_turn(turn.id).state
+        {:ok, _} = ExecutionGuard._unsafe_interrupt(conv.id)
+        "admission_before_release"
+    end
+  end
+
+for _ <- 1..20 do
+  {sandbox, conv, attrs} = fixture.()
+  {:ok, turn} = Conversations._unsafe_create_turn_on_sandbox(attrs, sandbox.id, :unbounded)
+  execution = ExecutionGuard._unsafe_for_turn(turn.id)
+  {:ok, _} = ExecutionGuard._unsafe_claim_spawn(execution.id)
+
+  [{:error, :busy}, {:ok, _, _}] =
+    DeadlineRace.concurrently([
+      fn -> Conversations._unsafe_release_conversation(conv.id) end,
+      fn -> Conversations._unsafe_orphan_turn(turn, "local_release_race") end
+    ])
+
+  "awaiting_identity" = ExecutionGuard._unsafe_for_turn(turn.id).state
+  "idle" = Repo.get!(Conversation, conv.id).status
+  {:error, :busy} = Conversations._unsafe_release_conversation(conv.id)
+end
+
+cleanup_outcomes =
+  for _ <- 1..20 do
+    {sandbox, conv, attrs} = fixture.()
+    {:ok, turn} = Conversations._unsafe_create_turn_on_sandbox(attrs, sandbox.id, :unbounded)
+    execution = ExecutionGuard._unsafe_for_turn(turn.id)
+    {:ok, _} = ExecutionGuard._unsafe_claim_spawn(execution.id)
+
+    {:ok, _} =
+      ExecutionGuard._unsafe_bind_identity(
+        execution.id,
+        execution.connection_id,
+        "synthetic-release-command"
+      )
+
+    {:ok, _} = ExecutionGuard._unsafe_interrupt(conv.id)
+    {:ok, %{execution: claimed}} = ExecutionGuard._unsafe_claim_termination(execution.id)
+
+    # This is a synthetic acknowledgment, not provider termination evidence.
+    [release, {:ok, _}] =
+      DeadlineRace.concurrently([
+        fn -> Conversations._unsafe_release_conversation(conv.id) end,
+        fn -> ExecutionGuard._unsafe_record_termination(execution.id, claimed.attempt_id, :ok) end
+      ])
+
+    "stopped" = ExecutionGuard._unsafe_for_turn(turn.id).state
+
+    case release do
+      :ok ->
+        "terminated" = Repo.get!(Conversation, conv.id).status
+        "cleanup_before_release"
+
+      {:error, :busy} ->
+        "running" = Repo.get!(Conversation, conv.id).status
+        :ok = Conversations._unsafe_release_conversation(conv.id)
+        "release_before_cleanup"
+    end
+  end
+
+IO.puts("RELEASE_RACE_RESULT=" <> Jason.encode!(%{
+  scope: "Local release/admission/recovery/cleanup arbitration; synthetic identities and acknowledgments",
+  release_vs_admission: 20,
+  admission_outcomes: Enum.frequencies(admission_outcomes),
+  release_vs_orphan_recovery: 20,
+  release_vs_cleanup_ack: 20,
+  cleanup_outcomes: Enum.frequencies(cleanup_outcomes),
+  separate_database_connections: true,
+  provider_operations: 0
+}))


### PR DESCRIPTION
Release could succeed with no actor even while its cancelled spawn remained unresolved. Both live and absent-actor paths now check persisted turns and execution journals under the parent lock before changing state or closing anything. Unresolved work returns `busy` without interruption; confirmed cleanup permits release. Unrelated co-tenants keep running on the unchanged sandbox.

Stacked on #1751; **draft, public execution controls disabled**. Tracks #1732. Machine transfer/park/reset/rehome/deletion, provider incarnation and live acceptance remain separate gates.

Full precommit passes **4,765 tests + 6 doctests, zero failures**. The focused suite passes 103 tests, including ten new regressions and a real-actor refusal. Sixty independent PostgreSQL races cover release/admission, release/recovery and release/cleanup, plus twenty earlier deadline races. Provider identities and acknowledgments are synthetic; no provider operations occurred. Evidence: `decisions/evidence/release-fence.json`.

Known CI blocker inherited from #1751: the EEF feed for CVE-2026-32686 currently flags Decimal 3.1.1, while the [maintainer advisory](https://github.com/ericmj/decimal/security/advisories/GHSA-rhv4-8758-jx7v) identifies 3.0.0 as patched. The dependency audit has not been waived.

[CI at the exact release head](https://github.com/BinaryBourbon/fountain/actions/runs/34188648525) finished: 18 checks pass, four skip, and the dependency audit plus required rollup fail. Test partitions, coverage, SDKs and release boot pass. The only root failure is EEF-CVE-2026-32686 on Decimal 3.1.1: the [maintainer advisory](https://github.com/ericmj/decimal/security/advisories/GHSA-rhv4-8758-jx7v) identifies 3.0.0 as patched, but the current EEF feed omits that fixed boundary. The audit has not been waived.



Part of #1732 — **held**. Superseded on main by #1773–#1793; the residual hunks are being re-cut as focused PRs tracked by #1864, which keeps these frozen until each has a replacement or an explicitly linked deferral. Do not close: they are the reference for that mapping.
