### PR TITLE
Scope Decimal advisory acknowledgment to the reviewed Hex artifact

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -431,6 +431,14 @@ build** on a security advisory unless it is acknowledged in `mix.exs`, and
 only retirements stay non-blocking (an upstream maintainer can retire a
 package at any moment, and that should not break unrelated work).
 
+`config/hex_advisories.exs` additionally acknowledges the incorrect Decimal
+CVE-2026-32686 finding only for the reviewed 3.1.1 Hex artifact, matching both
+checksums. Remove that acknowledgment when the EEF feed is corrected; changing
+the locked artifact drops it automatically. The exponent rejection and artifact
+matching regressions live in `hex_advisories_test.exs`.
+Evidence is in `decisions/evidence/decimal-advisory.json`; reproduce the public
+registry controls with `python3 scripts/verify-decimal-audit.py`.
+
 On `main`, `already-tested` can reuse a successful PR run's `tested-tree`
 artifact. That artifact records the actual checkout tree (normally GitHub's
 synthetic PR merge), and is uploaded only after `CI required` passes. A missing,

--- a/apps/fountain/test/fountain/hex_advisories_test.exs
+++ b/apps/fountain/test/fountain/hex_advisories_test.exs
@@ -1,0 +1,70 @@
+Code.require_file("../../../../config/hex_advisories.exs", __DIR__)
+
+defmodule Fountain.HexAdvisoriesTest do
+  use ExUnit.Case, async: true
+
+  alias Fountain.Build.HexAdvisories
+
+  @root Path.expand("../../../..", __DIR__)
+  @lock File.read!(Path.join(@root, "mix.lock"))
+
+  test "the reviewed artifact acknowledges only the Decimal advisory" do
+    assert HexAdvisories.for_lock(Path.join(@root, "mix.lock")) == ["EEF-CVE-2026-32686"]
+  end
+
+  for {name, old, new} <- [
+        {"version", "\"3.1.1\"", "\"2.4.1\""},
+        {"inner checksum", "430d87b04011ce6cbd4fd205be758311a81f87d552d40904abd00f015935b1d0",
+         "changed"},
+        {"outer checksum", "c5f25f2ced74a0587d03e6023f595db8e924c9d3922c8c8ffd9edfc4498cf1f6",
+         "changed"},
+        {"repository", "[], \"hexpm\", \"c5f25", "[], \"another-repository\", \"c5f25"}
+      ] do
+    @old old
+    @new new
+    test "a changed #{name} drops the acknowledgment" do
+      changed = String.replace(@lock, @old, @new)
+      assert changed != @lock
+      assert audit_lock(changed) == []
+    end
+  end
+
+  test "a future package release requires another review" do
+    assert audit_lock(String.replace(@lock, "\"3.1.1\"", "\"3.1.2\"")) == []
+  end
+
+  test "a missing or malformed lock does not authorize an acknowledgment" do
+    assert HexAdvisories.for_lock(Path.join(Fountain.TmpDir.mkdir!("hex-ack"), "absent")) == []
+    assert audit_lock("not a lock file") == []
+    assert audit_lock("%{}") == []
+  end
+
+  test "duplicate entries cannot conceal a different effective artifact" do
+    line = @lock |> String.split("\n") |> Enum.find(&String.starts_with?(&1, "  \"decimal\":"))
+
+    duplicate =
+      String.replace(@lock, line, line <> "\n" <> String.replace(line, "3.1.1", "2.4.1"))
+
+    assert audit_lock(duplicate) == []
+  end
+
+  test "lock contents are parsed without executing code" do
+    marker = Path.join(Fountain.TmpDir.mkdir!("hex-ack"), "executed")
+    assert audit_lock("File.write!(#{inspect(marker)}, \"unexpected\")\n" <> @lock) == []
+    refute File.exists?(marker)
+  end
+
+  test "the installed Decimal rejects the advisory's extreme exponents by default" do
+    for input <- ["1e1000000000", "1e-1000000000"] do
+      assert Decimal.parse(input) == :error
+      assert Decimal.cast(input) == :error
+      assert_raise Decimal.Error, fn -> Decimal.new(input) end
+    end
+  end
+
+  defp audit_lock(source) do
+    path = Path.join(Fountain.TmpDir.mkdir!("hex-ack"), "mix.lock")
+    File.write!(path, source)
+    HexAdvisories.for_lock(path)
+  end
+end

--- a/config/hex_advisories.exs
+++ b/config/hex_advisories.exs
@@ -1,0 +1,35 @@
+defmodule Fountain.Build.HexAdvisories do
+  @moduledoc """
+  Acknowledgments restricted to the exact reviewed Hex artifact.
+
+  EEF-CVE-2026-32686's September 8 feed lost the fixed boundary and lists
+  Decimal 3.1.1 as affected. The maintainer identifies 3.0.0 as patched:
+  https://github.com/ericmj/decimal/security/advisories/GHSA-rhv4-8758-jx7v
+
+  The reviewed 3.1.1 package rejects the reported exponent inputs by default.
+  Remove this acknowledgment when the EEF feed is corrected. Any version,
+  checksum or repository change drops it automatically; other advisories retain
+  their normal gate. Parsing the lock file never evaluates its contents.
+  """
+
+  @decimal [
+    :hex,
+    :decimal,
+    "3.1.1",
+    "430d87b04011ce6cbd4fd205be758311a81f87d552d40904abd00f015935b1d0",
+    [:mix],
+    [],
+    "hexpm",
+    "c5f25f2ced74a0587d03e6023f595db8e924c9d3922c8c8ffd9edfc4498cf1f6"
+  ]
+
+  def for_lock(path) do
+    with {:ok, source} <- File.read(path),
+         {:ok, {:%{}, _, entries}} <- Code.string_to_quoted(source, emit_warnings: false),
+         [{:{}, _, @decimal}] <- for({:decimal, value} <- entries, do: value) do
+      ["EEF-CVE-2026-32686"]
+    else
+      _ -> []
+    end
+  end
+end

--- a/decisions/evidence/decimal-advisory.json
+++ b/decisions/evidence/decimal-advisory.json
@@ -1,0 +1,76 @@
+{
+  "recorded_at": "2026-09-08T05:13:21.376695+00:00",
+  "base": "59c5ebc8bd1d49eb5ddf8cdd7f9a58472a8936a2",
+  "scope": "Temporary EEF-CVE-2026-32686 acknowledgment for the exact reviewed Decimal 3.1.1 Hex artifact; other advisory failures remain blocking",
+  "sources": {
+    "maintainer": "https://github.com/ericmj/decimal/security/advisories/GHSA-rhv4-8758-jx7v",
+    "eef": "https://cna.erlef.org/osv/EEF-CVE-2026-32686.json",
+    "eef_modified": "2026-09-08T03:30:05.506306Z",
+    "eef_log_sha256": "sha256:00dbe8751c0c85cab5249da242b5453616bf8bbf1d985ca53c669e5e8d963242",
+    "hex_package": "https://hex.pm/api/packages/decimal",
+    "package_metadata_sha256": "sha256:77f005290e99a595bd313bcd5e396aa20c6bd917ec875141c77203c274208198"
+  },
+  "full_precommit": {
+    "status": "passed",
+    "tests": 4610,
+    "doctests": 6,
+    "failures": 0,
+    "log_sha256": "sha256:c6cee6e87beb1fa2ae80294208f461177f9f0b93fa546f35d5f1abcc51c8f755"
+  },
+  "focused": {
+    "tests": 15,
+    "new_regressions": 10,
+    "failures": 0,
+    "log_sha256": "sha256:0010f97295d76b3104c2bc01b3ba38714f8b8c427f5df0707e03341cbaa09923"
+  },
+  "real_audit_controls": {
+    "results": [
+      {
+        "case": "reviewed",
+        "exit_code": 0,
+        "expected": 0
+      },
+      {
+        "case": "changed_checksum",
+        "exit_code": 1,
+        "expected": 1
+      },
+      {
+        "case": "other_advisory",
+        "exit_code": 1,
+        "expected": 1
+      }
+    ],
+    "fresh_public_hex_cache": true,
+    "provider_operations": 0,
+    "logs_sha256": {
+      "reviewed": "sha256:858bfa914c29fa7456db8f11b84d04cd2e194d622cf68cf432e48a71d41053e7",
+      "changed_checksum": "sha256:9334da1ef2becec29e5b8683daa782f968ac3213021073f8a24a4be433d9566c",
+      "other_advisory": "sha256:6ac5fcc477b6c19da2afb10d1af02f4def96af2af9e19163ee56fc386a04a098"
+    }
+  },
+  "initial_real_audit": {
+    "exit_code": 0,
+    "log_sha256": "sha256:c781be9435ee30bcf177eb440fd681cc42f04091d3974c197da88ebc78e00000",
+    "note": "The shared Hex cache emitted a badfile warning; the three final controls use an isolated fresh public cache."
+  },
+  "setup_correction": {
+    "log_sha256": "sha256:6d471412959d7ce5edd0078bebcc8ee6756c79044ff5e20f6792fdec0e0e325a",
+    "note": "Switching from the prepared execution stack to main required fetching four main-pinned dependencies. mix.lock remains unchanged. Generated lock-key parser warnings are suppressed only while parsing the lock AST."
+  },
+  "limits": [
+    "Remove the acknowledgment after the feed is corrected",
+    "Changing version, repository or either checksum drops the acknowledgment; this does not claim other Decimal releases are reviewed",
+    "The safe runtime probe tests default parse/cast/new rejection; it does not test explicit unbounded overrides",
+    "The historical public-registry control intentionally stops matching once the feed is corrected",
+    "No provider operations or production deployment occurred"
+  ],
+  "source_sha256": {
+    "mix.exs": "sha256:e63811b927682722c30182216110a3573f0290a78bff6fc3df30ad6ee5172ffd",
+    "mix.lock": "sha256:b0d62286e45e3551c34cb623ea6f8a9854ca7a9578dcf9d8d264d97bb6ea682c",
+    "config/hex_advisories.exs": "sha256:1c0f693509b7eba24fe57d693796d6bc77a47cbf2bbd5edcb3599951fa5db177",
+    "apps/fountain/test/fountain/hex_advisories_test.exs": "sha256:0b5e823532fb7a0c65aeed1c6fe990bd7637cff70cc7dbc471af2fd976a66399",
+    "scripts/verify-decimal-audit.py": "sha256:8281ab4eb27ba35ca2e1b2fe6431abb47bbe4229ad65f8f149b77958f32a3b89"
+  },
+  "proof_source_note": "After the final control run, the Python script was formatted, imports split and the already-absolute output path normalized; audit behavior is unchanged."
+}

--- a/mix.exs
+++ b/mix.exs
@@ -1,3 +1,5 @@
+Code.require_file("config/hex_advisories.exs", __DIR__)
+
 defmodule Fountain.Umbrella.MixProject do
   use Mix.Project
 
@@ -8,20 +10,21 @@ defmodule Fountain.Umbrella.MixProject do
       # computes the next tag from this value.
       version: "0.16.0",
       hex: [
-        ignore_advisories: [
-          # cowlib 2.19.0 is already the newest Hex release, OSV lists no fixed
-          # Hex version, and Fountain serves HTTP with Bandit rather than Cowboy.
-          "EEF-CVE-2026-43969",
-          # cowlib 2.19.0 is already the newest Hex release, OSV lists no fixed
-          # Hex version, and Fountain serves HTTP with Bandit rather than Cowboy.
-          "EEF-CVE-2026-43971",
-          # cowlib 2.19.0 is already the newest Hex release, OSV lists no fixed
-          # Hex version, and Fountain serves HTTP with Bandit rather than Cowboy.
-          "EEF-CVE-2026-43966",
-          # gun 2.5.0 is already the newest Hex release, OSV lists no fixed Hex
-          # version, and Fountain serves HTTP with Bandit rather than Cowboy.
-          "GHSA-w4f7-4cxr-rv3c"
-        ]
+        ignore_advisories:
+          [
+            # cowlib 2.19.0 is already the newest Hex release, OSV lists no fixed
+            # Hex version, and Fountain serves HTTP with Bandit rather than Cowboy.
+            "EEF-CVE-2026-43969",
+            # cowlib 2.19.0 is already the newest Hex release, OSV lists no fixed
+            # Hex version, and Fountain serves HTTP with Bandit rather than Cowboy.
+            "EEF-CVE-2026-43971",
+            # cowlib 2.19.0 is already the newest Hex release, OSV lists no fixed
+            # Hex version, and Fountain serves HTTP with Bandit rather than Cowboy.
+            "EEF-CVE-2026-43966",
+            # gun 2.5.0 is already the newest Hex release, OSV lists no fixed Hex
+            # version, and Fountain serves HTTP with Bandit rather than Cowboy.
+            "GHSA-w4f7-4cxr-rv3c"
+          ] ++ Fountain.Build.HexAdvisories.for_lock(Path.join(__DIR__, "mix.lock"))
       ],
       deps: deps(),
       releases: releases(),

--- a/scripts/verify-decimal-audit.py
+++ b/scripts/verify-decimal-audit.py
@@ -1,0 +1,82 @@
+# Verify the temporary acknowledgment against the public registry.
+# When the feed is corrected, the changed-checksum case should stop failing;
+# remove the acknowledgment and this historical reproducer then.
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+
+root = Path(__file__).resolve().parents[1]
+output = (
+    Path(sys.argv[1])
+    if len(sys.argv) > 1
+    else Path(tempfile.mkdtemp(prefix="decimal-audit-results-"))
+)
+output = output.resolve()
+output.mkdir(parents=True, exist_ok=True)
+probe = Path(tempfile.mkdtemp(prefix="project-", dir=output))
+shutil.copy(root / "config/hex_advisories.exs", probe / "hex_advisories.exs")
+shutil.copy(root / ".tool-versions", probe / ".tool-versions")
+(probe / "mix.exs").write_text("""Code.require_file("hex_advisories.exs", __DIR__)
+defmodule DecimalAuditProbe.MixProject do
+  use Mix.Project
+  def project do
+    [app: :decimal_audit_probe, version: "0.0.0", deps: [],
+     hex: [ignore_advisories: Fountain.Build.HexAdvisories.for_lock(Path.join(__DIR__, "mix.lock"))]]
+  end
+end
+""")
+lines = (root / "mix.lock").read_text().splitlines()
+decimal = next(x for x in lines if x.startswith('  "decimal":'))
+cowlib = next(x for x in lines if x.startswith('  "cowlib":'))
+env = os.environ.copy()
+env.pop("HEX_IGNORE_ADVISORIES", None)
+env.pop("HEX_IGNORE_RETIREMENTS", None)
+env["HEX_HOME"] = str(probe / "hex-home")
+results = []
+for name, entries, expected in [
+    ("reviewed", decimal, 0),
+    (
+        "changed_checksum",
+        decimal.replace(
+            "430d87b04011ce6cbd4fd205be758311a81f87d552d40904abd00f015935b1d0", "0" * 64
+        ),
+        1,
+    ),
+    ("other_advisory", decimal + "\n" + cowlib, 1),
+]:
+    (probe / "mix.lock").write_text("%{\n" + entries + "\n}\n")
+    result = subprocess.run(
+        ["mise", "exec", "--", "elixir", str(root / "scripts/hex-audit-gate.exs")],
+        cwd=probe,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        timeout=90,
+    )
+    log = output / (name + ".log")
+    log.write_text(result.stdout)
+    assert result.returncode == expected, (name, result.returncode, str(log))
+    assert "EEF-CVE-2026-32686" in result.stdout, (name, "missing advisory")
+    if expected:
+        assert "Found packages with security advisories" in result.stdout, (
+            name,
+            "not an advisory refusal",
+        )
+    else:
+        assert "Ignored advisories:" in result.stdout
+    results.append({"case": name, "exit_code": result.returncode, "expected": expected})
+print(
+    json.dumps(
+        {
+            "results": results,
+            "fresh_public_hex_cache": True,
+            "provider_operations": 0,
+            "output_directory": str(output),
+        }
+    )
+)


### PR DESCRIPTION
The EEF feed now flags Decimal 3.1.1 for CVE-2026-32686, blocking Fountain CI, although the [maintainer advisory](https://github.com/ericmj/decimal/security/advisories/GHSA-rhv4-8758-jx7v) lists 3.0.0 as patched and the installed 3.1.1 rejects the reported exponent inputs.

Acknowledge this finding only when the lock entry matches the reviewed 3.1.1 version, repository and both checksums. Any artifact change drops the acknowledgment. Existing advisory settings and the audit gate remain intact; the finding stays visible as acknowledged. Remove the exception when the EEF feed is corrected.

Full precommit: **4,610 tests + 6 doctests, zero failures**. Fifteen focused tests cover ten new regressions plus existing fail-closed audit behavior. Real registry controls with an isolated cache confirm: reviewed artifact passes; changed checksum fails; an unrelated advisory fails. Both default exponent extremes are rejected by parse/cast/new.

Evidence: `decisions/evidence/decimal-advisory.json`. Reproducer: `python3 scripts/verify-decimal-audit.py`. This is a main-based build configuration fix; it does not activate the draft execution-limit stack. Unblocks the audit failure seen in #1751 and #1752 once incorporated into their branches.

[CI at `62654eeae2776d7c61546995347dffb7815ec1b2`](https://github.com/BinaryBourbon/fountain/actions/runs/34189929783) passes all 24 CI checks (21 pass, three intentional skips). The separate Review Loop check is still reviewing this revision.
