### PR TITLE
fix: prevent stale callbacks from reviving retired sandboxes

### DIFF
--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -213,19 +213,53 @@ defmodule Fountain.Conversations do
   path in `ConversationServer.terminate_conversation/2`. Metering at this choke point means a
   new caller cannot forget to record usage, which is how `Billing.emit/5` ended
   up with no call sites at all despite being documented, schema'd and tested.
+
+  The persisted previous status decides the transition. Terminal rows reject
+  attempts to become active again, including callbacks holding an older struct.
   """
   def update_sandbox(%Sandbox{} = sandbox, attrs) do
-    was = sandbox.status
+    # A provider callback may still hold a starting/ready struct after reset,
+    # cancellation or the provision watchdog retired the persisted row. Read
+    # and validate under the row lock; checking the caller's struct would let
+    # that delayed callback revive the machine. No provider I/O under this lock.
+    result =
+      Repo.transaction(fn ->
+        current =
+          Repo.one(from s in Sandbox, where: s.id == ^sandbox.id, lock: "FOR UPDATE") ||
+            Repo.rollback(:not_found)
 
-    changeset = sandbox |> Sandbox.changeset(attrs) |> stamp_terminated_at()
+        changeset =
+          current
+          |> Sandbox.changeset(attrs)
+          |> prevent_sandbox_revival()
+          |> stamp_terminated_at()
 
-    with {:ok, updated} <- Repo.update(changeset) do
-      record_sandbox_usage(was, updated)
-      {:ok, updated}
+        case Repo.update(changeset) do
+          {:ok, updated} -> {current.status, updated}
+          {:error, changeset} -> Repo.rollback(changeset)
+        end
+      end)
+
+    case result do
+      {:ok, {was, updated}} ->
+        record_sandbox_usage(was, updated)
+        {:ok, updated}
+
+      {:error, _} = error ->
+        error
     end
   end
 
   @billable_terminal ~w(terminated failed)
+
+  defp prevent_sandbox_revival(changeset) do
+    if changeset.data.status in @billable_terminal and
+         Ecto.Changeset.get_field(changeset, :status) not in @billable_terminal do
+      Ecto.Changeset.add_error(changeset, :status, "sandbox is retired")
+    else
+      changeset
+    end
+  end
 
   # `terminated_at` is when a sandbox stopped costing money, so spend
   # attribution reads it as the end of the billed interval

--- a/apps/fountain/test/fountain/conversations/attach_test.exs
+++ b/apps/fountain/test/fountain/conversations/attach_test.exs
@@ -59,12 +59,15 @@ defmodule Fountain.Conversations.AttachTest do
     assert {:error, :sandbox_not_found} = attach(ctx, %{"sandbox_id" => Ecto.UUID.generate()})
   end
 
-  test "only a ready or suspended machine takes a conversation", ctx do
-    for status <- ["pending", "starting", "terminated", "failed"] do
+  for status <- ["pending", "starting", "terminated", "failed"] do
+    test "a #{status} machine refuses a conversation", ctx do
+      status = unquote(status)
       {:ok, _} = Conversations.update_sandbox(ctx.sandbox, %{status: status})
       assert {:error, {:sandbox_not_attachable, ^status}} = attach(ctx)
     end
+  end
 
+  test "a suspended machine takes a conversation", ctx do
     {:ok, _} = Conversations.update_sandbox(ctx.sandbox, %{status: "suspended"})
     assert {:ok, _} = attach(ctx)
   end

--- a/apps/fountain/test/fountain/conversations/sandbox_test.exs
+++ b/apps/fountain/test/fountain/conversations/sandbox_test.exs
@@ -21,6 +21,40 @@ defmodule Fountain.Conversations.SandboxTest do
     end
   end
 
+  describe "retired sandbox updates" do
+    for retired <- ~w(terminated failed), requested <- ~w(pending starting ready suspended) do
+      test "a stale callback cannot move #{retired} to #{requested}" do
+        user = insert_user()
+        observed = insert_sandbox(user_id: user.id, status: "starting")
+
+        assert {:ok, _} =
+                 Fountain.Conversations.update_sandbox(observed, %{status: unquote(retired)})
+
+        assert {:error, changeset} =
+                 Fountain.Conversations.update_sandbox(observed, %{status: unquote(requested)})
+
+        assert "sandbox is retired" in errors_on(changeset).status
+        assert Fountain.Repo.reload!(observed).status == unquote(retired)
+      end
+    end
+
+    test "metadata updates preserve the current retired status" do
+      user = insert_user()
+      observed = insert_sandbox(user_id: user.id, status: "starting")
+
+      assert {:ok, retired} =
+               Fountain.Conversations.update_sandbox(observed, %{status: "terminated"})
+
+      assert {:ok, updated} =
+               Fountain.Conversations.update_sandbox(observed, %{
+                 provider_meta: %{"public_url" => "fixture"}
+               })
+
+      assert updated.status == "terminated"
+      assert updated.terminated_at == retired.terminated_at
+    end
+  end
+
   describe "struct defaults" do
     test "default status is 'pending'" do
       assert %Sandbox{}.status == "pending"


### PR DESCRIPTION
A delayed provisioning callback can hold an old sandbox struct after the persisted row has been terminated or failed. Updating that stale struct can revive the row or return stale status.

Reload the row under a lock before updating it, reject terminal-to-active transitions, and preserve the current status during metadata updates. This repair is based directly on main: three files, 78 additions and 7 deletions. It is the first focused extraction from the frozen investigation in #1754.

Validation: the new regression cases fail on unchanged main (9 failures); the focused suite passes with the fix (34 tests). Full precommit passed: 4,674 tests and 6 doctests, with no failures.
