### PR TITLE
fix: count turn progress and wake time as sandbox activity

### DIFF
--- a/apps/fountain/lib/fountain/workers/sandbox_reaper.ex
+++ b/apps/fountain/lib/fountain/workers/sandbox_reaper.ex
@@ -200,8 +200,8 @@ defmodule Fountain.Workers.SandboxReaper do
   `suspended` rows deliberately match no pass: that is the durable resting
   state, aged out by nothing (decisions/0017).
 
-  Activity is read from the conversation's most recent turn rather than from
-  `sandboxes.updated_at` or `conversations.updated_at`, both of which get
+  Activity includes turn insertion, start, completion and the last wake rather
+  than `sandboxes.updated_at` or `conversations.updated_at`, both of which get
   touched by bookkeeping the user had nothing to do with — the rehydrator moves
   `conversations.updated_at` on every boot, which would make an abandoned
   conversation look freshly active after each deploy.
@@ -253,22 +253,21 @@ defmodule Fountain.Workers.SandboxReaper do
     Lifecycle.check(started_at, last_activity_at(sandbox), false, now)
   end
 
-  # Newest turn across the sandbox's conversations, falling back to when the
-  # sandbox itself was created for one that never took a turn.
-  defp last_activity_at(%Sandbox{inserted_at: inserted_at, conversations: convs}) do
+  # A queued or long-running turn can finish long after insertion. Waking
+  # without a new turn is also activity; bookkeeping updates are not.
+  defp last_activity_at(%Sandbox{} = sandbox) do
+    %{inserted_at: inserted_at, last_resumed_at: resumed_at, conversations: convs} = sandbox
     conv_ids = Enum.map(convs, & &1.id)
 
-    latest =
-      if conv_ids == [] do
-        nil
-      else
-        Turn
-        |> where([t], t.conversation_id in ^conv_ids)
-        |> select([t], max(t.inserted_at))
-        |> Repo.one()
-      end
+    {inserted, started, ended} =
+      Turn
+      |> where([t], t.conversation_id in ^conv_ids)
+      |> select([t], {max(t.inserted_at), max(t.started_at), max(t.ended_at)})
+      |> Repo.one()
 
-    latest || inserted_at
+    [inserted_at, resumed_at, inserted, started, ended]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.max(DateTime)
   end
 
   # Idle with no server: park where the provider can preserve the disk,

--- a/apps/fountain/test/fountain/workers/sandbox_reaper_test.exs
+++ b/apps/fountain/test/fountain/workers/sandbox_reaper_test.exs
@@ -275,6 +275,38 @@ defmodule Fountain.Workers.SandboxReaperTest do
       assert Repo.reload(sandbox).status == "ready"
     end
 
+    for field <- [:started_at, :ended_at] do
+      test "recent turn #{field} keeps an old machine out of the idle sweep" do
+        user = insert_verified_user()
+        sandbox = insert_sandbox(user_id: user.id, status: "ready")
+        conv = insert_conversation(user_id: user.id, sandbox: sandbox)
+        turn = insert_turn(conv, %{status: "completed"})
+        sandbox = age_rows(sandbox, conv, 300)
+        turn |> change([{unquote(field), minutes_ago(20)}]) |> Repo.update!()
+
+        with_bounds([sandbox_idle_timeout_minutes: 60, sandbox_max_lifetime_hours: 24], fn ->
+          assert {0, 0} = SandboxReaper.sweep_abandoned_sandboxes()
+        end)
+
+        assert Repo.reload(sandbox).status == "ready"
+      end
+    end
+
+    test "a recent wake restarts the idle clock even without a new turn" do
+      user = insert_verified_user()
+      sandbox = insert_sandbox(user_id: user.id, status: "ready")
+      sandbox = age_rows(sandbox, nil, 48 * 60)
+      # Outside the 15-minute grace window, but inside the 60-minute idle limit.
+      sandbox |> change(last_resumed_at: minutes_ago(20)) |> Repo.update!()
+      sandbox = age_sandbox(sandbox, 20)
+
+      with_bounds([sandbox_idle_timeout_minutes: 60, sandbox_max_lifetime_hours: 24], fn ->
+        assert {0, 0} = SandboxReaper.sweep_abandoned_sandboxes()
+      end)
+
+      assert Repo.reload(sandbox).status == "ready"
+    end
+
     test "recent turn activity keeps a sandbox alive" do
       user = insert_verified_user()
       sandbox = insert_sandbox(user_id: user.id, status: "ready")


### PR DESCRIPTION
The reaper used only turn insertion time to measure inactivity, so an old sandbox could be swept soon after a queued turn started, a long turn completed, or the sandbox woke without a new turn.

Count the latest sandbox creation/wake and turn insertion/start/completion timestamp as activity. Bookkeeping timestamps remain excluded; absolute lifetime enforcement is unchanged.

Validation: all three regressions fail on main and pass with the fix (28 focused tests). Full `mix precommit` passed: 4,664 tests and 6 doctests, zero failures (2 skipped, 7 excluded).

Independent two-file extraction from the investigation in #1754; targets main.
