### PR TITLE
test: separate permission timer expiry from message delivery

### DIFF
--- a/apps/fountain/test/fountain/conversations/pending_test.exs
+++ b/apps/fountain/test/fountain/conversations/pending_test.exs
@@ -69,7 +69,11 @@ defmodule Fountain.Conversations.PendingTest do
         })
 
       assert is_reference(pending.permission_timer)
-      assert_receive {:permission_timeout, "old-request"}
+      # The deadline is immediate; observing its message is subject to scheduler
+      # load. Pin the timer state before allowing time for delivery, so this
+      # cannot hide a regression that grants a new permission window.
+      assert Process.read_timer(pending.permission_timer) in [false, 0]
+      assert_receive {:permission_timeout, "old-request"}, 5_000
     end
 
     test "restoring a current request replaces its timer without extending its original deadline" do


### PR DESCRIPTION
An expired permission timer can miss the test's 100 ms message-delivery deadline under scheduler load (#1721).

Assert first that the timer is already expired or has zero milliseconds remaining, then allow up to five seconds for its message. This keeps the check against granting a fresh permission window while allowing delayed delivery. Production behavior is unchanged.

Validation: all 15 `PendingTest` tests pass. Full `mix precommit` passed: 4,661 tests and 6 doctests, zero failures (2 skipped, 7 excluded).

One-file extraction from #1754, directly against main. Fixes #1721.
