### PR TITLE
fix: refuse new turns from stale sandbox actors

### DIFF
--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -1052,19 +1052,15 @@ defmodule Fountain.Conversations do
   Create a turn on a sandbox that may be shared, refusing when the runtime's
   capacity is used up by another conversation's running turn.
 
-  `capacity` is `Managoat.Runtimes.ACP.concurrency/1`: `:unbounded` (claude,
-  codex — several processes on one disk is the laptop shape) inserts exactly
-  as `_unsafe_create_turn/1` does; an integer is checked and inserted under
-  a per-sandbox advisory lock, so two conversations prompting the same
-  opencode or gemini machine at the same moment cannot both win. Answers
-  `{:error, :sandbox_at_capacity}` rather than queueing (ADR 0023 step 4).
+  `capacity` is `Managoat.Runtimes.ACP.concurrency/1`. All runtimes take the
+  per-sandbox advisory lock and verify that the conversation still belongs
+  to this nonterminal sandbox. An integer capacity also limits concurrent
+  turns; `:unbounded` skips only that capacity check. Refusal writes no turn.
   Usage is recorded after the transaction commits, never inside it.
   """
-  def _unsafe_create_turn_on_sandbox(attrs, _sandbox_id, :unbounded),
-    do: _unsafe_create_turn(attrs)
-
   def _unsafe_create_turn_on_sandbox(attrs, sandbox_id, capacity)
-      when is_binary(sandbox_id) and is_integer(capacity) and capacity > 0 do
+      when is_binary(sandbox_id) and
+             (capacity == :unbounded or (is_integer(capacity) and capacity > 0)) do
     conv_id = Map.fetch!(attrs, :conversation_id)
 
     result =
@@ -1074,7 +1070,20 @@ defmodule Fountain.Conversations do
           :erlang.phash2(sandbox_id)
         ])
 
-        if _unsafe_running_turns_elsewhere(sandbox_id, conv_id) >= capacity do
+        attached? =
+          Repo.exists?(
+            from c in Conversation,
+              join: s in Sandbox,
+              on: s.id == c.sandbox_id,
+              where:
+                c.id == ^conv_id and s.id == ^sandbox_id and c.user_id == s.user_id and
+                  s.status not in ["terminated", "failed"]
+          )
+
+        unless attached?, do: Repo.rollback(:sandbox_unavailable)
+
+        if capacity != :unbounded and
+             _unsafe_running_turns_elsewhere(sandbox_id, conv_id) >= capacity do
           Repo.rollback(:sandbox_at_capacity)
         else
           case %Turn{} |> Turn.changeset(attrs) |> Repo.insert() do

--- a/apps/fountain/lib/fountain/conversations/connection.ex
+++ b/apps/fountain/lib/fountain/conversations/connection.ex
@@ -257,34 +257,43 @@ defmodule Fountain.Conversations.Connection do
   Returns the row, the span opened over it and the tracer reading it; the
   caller holds them and arms the quiet timer.
   """
-  @spec open_autonomous_turn(String.t(), String.t()) :: {map(), term(), term()}
-  def open_autonomous_turn(conversation_id, user_id) do
-    # ownership: a server's own conversation, established at init.
+  @spec open_autonomous_turn(String.t(), String.t(), String.t() | nil) ::
+          {map(), term(), term()} | {:error, term()}
+  def open_autonomous_turn(conversation_id, user_id, sandbox_id \\ nil) do
+    # Ownership: a server's own conversation, established at init. The server
+    # passes its sandbox so an old connection cannot follow a moved row.
     conv = Conversations._unsafe_get_conversation!(conversation_id)
     turn_number = Conversations._unsafe_next_turn_number(conversation_id)
+    capacity = Fountain.RuntimeDispatch.concurrency(conv.runtime)
 
-    {:ok, turn} =
-      Conversations._unsafe_create_turn(%{
-        conversation_id: conv.id,
+    attrs = %{
+      conversation_id: conv.id,
+      turn_number: turn_number,
+      prompt: "(background task follow-up)",
+      origin: "autonomous",
+      status: "running",
+      started_at: now()
+    }
+
+    with {:ok, turn} <-
+           Conversations._unsafe_create_turn_on_sandbox(
+             attrs,
+             sandbox_id || conv.sandbox_id,
+             capacity
+           ) do
+      turn_span =
+        TurnMachine.open_span(user_id, conv, turn, :autonomous, TurnMachine.agent_for(conv))
+
+      Output.publish_stage(conversation_id, "turn", "started", %{
+        turn_id: turn.id,
         turn_number: turn_number,
-        prompt: "(background task follow-up)",
-        origin: "autonomous",
-        status: "running",
-        started_at: now()
+        origin: "autonomous"
       })
 
-    turn_span =
-      TurnMachine.open_span(user_id, conv, turn, :autonomous, TurnMachine.agent_for(conv))
+      {:ok, _} = Conversations.update_conversation(conv, %{status: "running"})
 
-    Output.publish_stage(conversation_id, "turn", "started", %{
-      turn_id: turn.id,
-      turn_number: turn_number,
-      origin: "autonomous"
-    })
-
-    {:ok, _} = Conversations.update_conversation(conv, %{status: "running"})
-
-    {turn, turn_span, Managoat.ACP.Tracer.new(turn_span, prefix: "fountain")}
+      {turn, turn_span, Managoat.ACP.Tracer.new(turn_span, prefix: "fountain")}
+    end
   end
 
   @doc """

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -2302,6 +2302,7 @@ defmodule Fountain.Conversations.ConversationServer do
     case TurnMachine.open(state.conversation_id, state.sandbox_id, prompt) do
       {:ok, conv, turn} -> run_turn(state, conv, turn, prompt, agent, images)
       :at_capacity -> state
+      {:error, _} -> drop_connection(state, "admission_refused")
     end
   end
 
@@ -2597,13 +2598,8 @@ defmodule Fountain.Conversations.ConversationServer do
   # One peer report through the turn state machine (#1374): the turn the
   # server holds goes in, the next one comes back with the effects to apply,
   # in order. `ctx` is what the machine needs that is not the turn's own.
-  defp drive_turn(state, payload, extra \\ []) do
-    ctx = TurnMachine.ctx(state, extra)
-    {turn, effects} = TurnMachine.handle(TurnMachine.from_state(state), payload, ctx)
-    state = TurnMachine.into_state(state, turn)
-
-    Enum.reduce(effects, state, &apply_effect(&2, &1))
-  end
+  defp drive_turn(state, payload, extra \\ []),
+    do: TurnMachine.drive(state, payload, extra, &apply_effect/2)
 
   # What the machine hands back: the server's state, processes, timers,
   # output persistence and pending registries, one clause each.
@@ -2717,19 +2713,22 @@ defmodule Fountain.Conversations.ConversationServer do
   end
 
   # An out-of-turn protocol line opened a background cycle
-  # (`Connection.open_autonomous_turn/2`). The row, its span and its tracer are
+  # (`Connection.open_autonomous_turn/3`). The row, its span and its tracer are
   # the server's to hold; the quiet timer is armed in this process.
   defp open_autonomous_turn(state) do
-    {turn, turn_span, tracer} =
-      Connection.open_autonomous_turn(state.conversation_id, state.user_id)
+    case Connection.open_autonomous_turn(state.conversation_id, state.user_id, state.sandbox_id) do
+      {:error, _} ->
+        drop_connection(state, "admission_refused")
 
-    arm_autonomous_quiet(%{
-      touch_activity(state)
-      | current_turn: turn,
-        current_turn_span: turn_span,
-        turn_metrics: nil,
-        stream_tracer: tracer
-    })
+      {turn, turn_span, tracer} ->
+        arm_autonomous_quiet(%{
+          touch_activity(state)
+          | current_turn: turn,
+            current_turn_span: turn_span,
+            turn_metrics: nil,
+            stream_tracer: tracer
+        })
+    end
   end
 
   defp close_autonomous_turn(state, why) do

--- a/apps/fountain/lib/fountain/conversations/turn_machine.ex
+++ b/apps/fountain/lib/fountain/conversations/turn_machine.ex
@@ -150,6 +150,22 @@ defmodule Fountain.Conversations.TurnMachine do
   def autonomous_turn?(%{current_turn: %{origin: "autonomous"}}), do: true
   def autonomous_turn?(_state), do: false
 
+  @doc "Apply one peer report, stopping its effects if background admission is refused."
+  @spec drive(map(), payload(), keyword(), (map(), effect() -> map())) :: map()
+  def drive(state, payload, extra, apply_effect) do
+    {turn, effects} = handle(from_state(state), payload, ctx(state, extra))
+    state = into_state(state, turn)
+
+    Enum.reduce_while(effects, state, fn effect, state ->
+      state = apply_effect.(state, effect)
+
+      # A refused background turn must not persist its output or ask permission.
+      if effect == :open_autonomous_turn and is_nil(state.current_turn),
+        do: {:halt, state},
+        else: {:cont, state}
+    end)
+  end
+
   @doc "One peer report: the next turn and the effects the server applies."
   @spec handle(t(), payload(), ctx()) :: {t(), [effect()]}
   def handle(turn, payload, ctx \\ %{})
@@ -817,7 +833,7 @@ defmodule Fountain.Conversations.TurnMachine do
   ends.
   """
   @spec open(String.t(), String.t(), String.t()) ::
-          {:ok, Conversation.t(), Conversations.Turn.t()} | :at_capacity
+          {:ok, Conversation.t(), Conversations.Turn.t()} | :at_capacity | {:error, term()}
   def open(conversation_id, sandbox_id, prompt) do
     conv = Conversations._unsafe_get_conversation!(conversation_id)
     turn_number = Conversations._unsafe_next_turn_number(conversation_id)
@@ -847,6 +863,15 @@ defmodule Fountain.Conversations.TurnMachine do
         })
 
         :at_capacity
+
+      {:error, reason} = error ->
+        publish_stage(conversation_id, "sandbox", "done", %{
+          event: "admission_refused",
+          reason: if(is_atom(reason), do: Atom.to_string(reason), else: "invalid_turn"),
+          message: "This connection could not start another turn."
+        })
+
+        error
     end
   end
 

--- a/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
@@ -433,6 +433,51 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
       assert Enum.any?(turns, &(&1.origin == "autonomous" and &1.status == "completed"))
     end
 
+    for change <- [:retire, :move], input <- [:prompt, :background, :permission] do
+      test "a stale actor cannot start #{input} work after #{change}", ctx do
+        prompt_id = drive_to_prompt(ctx.pid, ctx.ref)
+        reply(ctx.pid, ctx.ref, prompt_id, %{"stopReason" => "end_turn"})
+        conv = Conversations._unsafe_get_conversation!(ctx.conv.id)
+
+        case unquote(change) do
+          :retire ->
+            sandbox = Conversations._unsafe_get_sandbox!(conv.sandbox_id)
+            {:ok, _} = Conversations.update_sandbox(sandbox, %{status: "terminated"})
+
+          :move ->
+            fresh = insert_sandbox(user_id: conv.user_id, status: "ready")
+            {:ok, _} = Conversations.update_conversation(conv, %{sandbox_id: fresh.id})
+        end
+
+        case unquote(input) do
+          :prompt ->
+            assert :ok = GenServer.call(ctx.pid, {:send_prompt, "late prompt", []})
+
+          :permission ->
+            send(ctx.pid, {:acp, ctx.ref, {:permission_ask, "late-request", "Bash", []}})
+
+          :background ->
+            notify(ctx.pid, ctx.ref, %{
+              "sessionUpdate" => "agent_message_chunk",
+              "text" => "late output"
+            })
+        end
+
+        state = :sys.get_state(ctx.pid)
+        assert is_nil(state.current_turn)
+        assert is_nil(state.acp_peer)
+        assert is_nil(state.permission_timer)
+        assert state.caller_calls == %{}
+        assert [%{status: "completed"}] = Conversations._unsafe_list_turns(conv.id)
+        assert Conversations._unsafe_get_conversation!(conv.id).status == "idle"
+
+        refute Enum.any?(
+                 Conversations._unsafe_list_log_events(conv.id),
+                 &String.contains?(&1.data || "", "late output")
+               )
+      end
+    end
+
     test "an out-of-turn session_info_update opens no autonomous turn (#1300)", %{
       conv: conv,
       pid: pid,

--- a/apps/fountain/test/fountain/conversations/conversation_server_size_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_size_test.exs
@@ -15,7 +15,7 @@ defmodule Fountain.Conversations.ConversationServerSizeTest do
   accepts is downward. Lower it when you move something out; never raise it.
   """
 
-  @pin 2775
+  @pin 2774
 
   @server "apps/fountain/lib/fountain/conversations/conversation_server.ex"
 

--- a/apps/fountain/test/fountain/conversations/shared_sandbox_test.exs
+++ b/apps/fountain/test/fountain/conversations/shared_sandbox_test.exs
@@ -63,6 +63,61 @@ defmodule Fountain.Conversations.SharedSandboxTest do
       assert Conversations._unsafe_list_turns(a.id) == []
     end
 
+    for capacity <- [1, :unbounded], status <- ["terminated", "failed"] do
+      test "#{inspect(capacity)} admission refuses a persisted #{status} sandbox", ctx do
+        ctx.sandbox |> Ecto.Changeset.change(status: unquote(status)) |> Repo.update!()
+
+        assert {:error, :sandbox_unavailable} =
+                 Conversations._unsafe_create_turn_on_sandbox(
+                   %{
+                     conversation_id: ctx.a.id,
+                     turn_number: 1,
+                     status: "running",
+                     prompt: "late"
+                   },
+                   ctx.sandbox.id,
+                   unquote(capacity)
+                 )
+
+        assert Conversations._unsafe_list_turns(ctx.a.id) == []
+      end
+    end
+
+    for capacity <- [1, :unbounded] do
+      test "#{inspect(capacity)} admission refuses the previous sandbox after a move", ctx do
+        fresh = insert_sandbox(user_id: ctx.user.id, status: "ready")
+        ctx.a |> Ecto.Changeset.change(sandbox_id: fresh.id) |> Repo.update!()
+
+        assert {:error, :sandbox_unavailable} =
+                 Conversations._unsafe_create_turn_on_sandbox(
+                   %{
+                     conversation_id: ctx.a.id,
+                     turn_number: 1,
+                     status: "running",
+                     prompt: "late"
+                   },
+                   ctx.sandbox.id,
+                   unquote(capacity)
+                 )
+
+        assert Conversations._unsafe_list_turns(ctx.a.id) == []
+      end
+    end
+
+    test "autonomous admission honors the runtime capacity too", ctx do
+      running_turn(ctx.b)
+
+      assert {:error, :sandbox_at_capacity} =
+               Fountain.Conversations.Connection.open_autonomous_turn(
+                 ctx.a.id,
+                 ctx.user.id,
+                 ctx.sandbox.id
+               )
+
+      assert Conversations._unsafe_list_turns(ctx.a.id) == []
+      assert Conversations._unsafe_get_conversation!(ctx.a.id).status == "idle"
+    end
+
     test "inserts below capacity", %{a: a, sandbox: sandbox} do
       attrs = %{
         conversation_id: a.id,


### PR DESCRIPTION
A stale conversation actor can accept a new prompt or background update after its sandbox is retired or the conversation moves to another sandbox. That creates a running turn on the old connection.

User and autonomous admission now check the persisted sandbox association and terminal status under the shared sandbox lock. Unbounded runtimes skip only the capacity limit; autonomous turns honor that limit too. On refusal the actor closes the old connection and drops the background output or permission request.

Validation: ten regression failures reproduced on main; all 165 focused tests pass, including late permission requests and bounded autonomous admission. Full `mix precommit` passed: 4,674 tests and 6 doctests, zero failures (2 skipped, 7 excluded). Effect dispatch moved into the existing turn module to keep the server below its size limit; the refusal uses the existing sandbox event type.

Seven-file extraction (including the lowered server size pin) from #1754, directly against main. This guards stale admission after retirement/reassignment. Moving reset's retirement into its admission transaction remains a separate change; this PR does not claim to close that remaining race.
