### PR TITLE
fix: fence sandbox resets until deletion succeeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,19 @@ upgrade, is in
   and version line; `@agentshit/fountain-sdk` keeps its published versions and
   receives no new ones. See `sdk/typescript/CHANGELOG.md`.
 
+- A sandbox reset is fenced until the provider confirms the deletion. The
+  fence commits before any provider call, so no turn starts on a machine that
+  is on its way out, and the quota slot stays held until the delete is
+  confirmed rather than released on an unconfirmed one. A second reset, an
+  attach and a wake all answer `409 sandbox_reset_pending` instead of sending
+  another delete. Only a `ready` or `suspended` machine resets now; `pending`
+  and `starting` answer `409 sandbox_not_resettable`, because a machine still
+  under construction has no disk to replace. A reset that the provider does
+  not confirm records `sandbox.reset_requested`; `sandbox.reset` now means the
+  delete succeeded. To clear an unconfirmed reset, reap the sandbox from the
+  admin sandbox list. That retires the row and releases the slot; the machine
+  at the provider is then the operator's to check.
+
 ### Added
 
 - **An `acp` runtime launches a named command, so a deterministic program can

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -2982,6 +2982,12 @@ defmodule Fountain.Conversations do
   See `create_agent/2` for the rest of `opts` (`:actor`, `:request_ip`).
   """
   def reset_sandbox(%Sandbox{} = sandbox, opts \\ []) do
+    if Repo.in_transaction?(),
+      do: {:error, :provider_transaction_open},
+      else: do_reset_sandbox(sandbox, opts)
+  end
+
+  defp do_reset_sandbox(sandbox, opts) do
     now = DateTime.utc_now()
 
     result =

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -220,6 +220,10 @@ defmodule Fountain.Conversations do
   The persisted previous status decides the transition. Terminal rows reject
   attempts to become active again, including callbacks holding an older struct.
   """
+  # The two statuses a sandbox stops at. `update_sandbox/2` reads this before
+  # `prevent_sandbox_revival/1` does, so it is declared here rather than beside it.
+  @billable_terminal ~w(terminated failed)
+
   def update_sandbox(%Sandbox{} = sandbox, attrs) do
     # A provider callback may still hold a starting/ready struct after reset,
     # cancellation or the provision watchdog retired the persisted row. Read
@@ -231,13 +235,24 @@ defmodule Fountain.Conversations do
           Repo.one(from s in Sandbox, where: s.id == ^sandbox.id, lock: "FOR UPDATE") ||
             Repo.rollback(:not_found)
 
-        if current.reset_requested_at, do: Repo.rollback(:sandbox_reset_pending)
-
         changeset =
           current
           |> Sandbox.changeset(attrs)
           |> prevent_sandbox_revival()
           |> stamp_terminated_at()
+
+        # A reset fence (`reset_sandbox/2`) stops this machine being re-used or
+        # re-purposed while its deletion is unconfirmed. It deliberately does
+        # NOT stop it being finished off, because a retiring write is how the
+        # fence is *meant* to end: the reset's own confirmed destroy, an
+        # operator reaping it from /admin/sandboxes, the agent being deleted,
+        # account deletion, or a ConversationServer giving up on it. Every one
+        # of those callers matches `{:ok, _}`, so refusing them would turn a
+        # provider timeout into a MatchError and strand the row with no way to
+        # retire it at all.
+        if not is_nil(current.reset_requested_at) and
+             Ecto.Changeset.get_field(changeset, :status) not in @billable_terminal,
+           do: Repo.rollback(:sandbox_reset_pending)
 
         case Repo.update(changeset) do
           {:ok, updated} -> {current.status, updated}
@@ -254,8 +269,6 @@ defmodule Fountain.Conversations do
         error
     end
   end
-
-  @billable_terminal ~w(terminated failed)
 
   defp prevent_sandbox_revival(changeset) do
     if changeset.data.status in @billable_terminal and
@@ -2964,14 +2977,30 @@ defmodule Fountain.Conversations do
   transcripts; each is told the machine is gone, so its next prompt takes the
   wake path, which provisions a fresh home and moves the others onto it.
 
-  `sandbox` came from the caller's scoped `get_sandbox/2`. Only a live
-  `persistent` sandbox resets: an ephemeral one is a conversation's own and
-  ends with it (`{:sandbox_not_resettable, "ephemeral"}`), a terminated or
-  failed one is already gone (`{:sandbox_not_resettable, status}`). Refused
-  with `:sandbox_mid_turn` while any conversation on it runs a turn — the
-  check and the durable reset fence share turn admission's advisory lock.
+  `sandbox` came from the caller's scoped `get_sandbox/2`, but the decision is
+  made on the row re-read under the lock, not on that struct. Only a
+  `persistent` sandbox that is **`ready` or `suspended`** resets: an ephemeral
+  one is a conversation's own and ends with it
+  (`{:sandbox_not_resettable, "ephemeral"}`), and any other status —
+  `pending` and `starting` as much as `terminated` and `failed` — answers
+  `{:sandbox_not_resettable, status}`. A machine still being built has no disk
+  to replace and no confirmed identity to delete, so it is the provision
+  watchdog's to finish, not this function's. Refused with `:sandbox_mid_turn`
+  while any conversation on it runs a turn — the check and the durable reset
+  fence share turn admission's advisory lock.
+
   A provider error or lost caller leaves the fence and capacity in place;
-  repeated resets return `:sandbox_reset_pending` without another delete.
+  repeated resets return `:sandbox_reset_pending` without another delete, and
+  so does anything that would re-use the machine. **The fence is not a dead
+  end.** A write that retires the row still goes through (`update_sandbox/2`),
+  so an operator reaps it from `/admin/sandboxes`, deleting the agent still
+  works, and account deletion still completes. Reaping is the supported way
+  out of an unconfirmed reset; it terminates the row and releases the quota
+  slot, and whatever the provider did or did not do with the machine is then
+  the operator's to check. There is no automatic reconciliation.
+
+  Two audit rows, not one: `sandbox.reset_requested` when the fence commits,
+  and `sandbox.reset` only when the provider confirms the destroy.
 
   `opts[:reason]` says *why*, and reaches every transcript on the machine and
   the audit row: `"home_reset"` (the owner asked — the default),
@@ -3039,6 +3068,7 @@ defmodule Fountain.Conversations do
       end)
 
     with {:ok, {fenced, ids}} <- result,
+         :ok <- record_reset_requested(fenced, ids, opts),
          {:ok, completed} <- finish_sandbox_reset(fenced) do
       reason = Keyword.get(opts, :reason, "home_reset")
       message = reset_message(reason)
@@ -3079,6 +3109,32 @@ defmodule Fountain.Conversations do
 
       {:ok, completed}
     end
+  end
+
+  # The fence has committed and the sessions on the machine are already gone,
+  # so this much happened whatever the provider says next. `sandbox.reset` is
+  # kept for the confirmed destroy; without this row an unconfirmed reset
+  # changes tenant state and leaves no trail, and the operator asked to
+  # reconcile it cannot tell who requested it, when, or why. Recorded outside
+  # the transaction, as `record/1` requires. Answers `:ok` so it reads as a
+  # step in the caller's `with`.
+  defp record_reset_requested(sandbox, ids, opts) do
+    Audit.record(%{
+      user_id: sandbox.user_id,
+      action: "sandbox.reset_requested",
+      resource_type: "sandbox",
+      resource_id: sandbox.id,
+      actor: Keyword.get(opts, :actor, "self"),
+      request_ip: Keyword.get(opts, :request_ip),
+      metadata: %{
+        "agent_id" => sandbox.agent_id,
+        "provider" => sandbox.provider,
+        "conversations" => length(ids),
+        "reason" => Keyword.get(opts, :reason, "home_reset")
+      }
+    })
+
+    :ok
   end
 
   # Only a confirmed destroy releases capacity. Errors or caller loss leave
@@ -3287,7 +3343,8 @@ defmodule Fountain.Conversations do
   end
 
   defp check_attachable(%Sandbox{reset_requested_at: at}, _agent, _vault_id, _env_id)
-       when not is_nil(at), do: {:error, :sandbox_reset_pending}
+       when not is_nil(at),
+       do: {:error, :sandbox_reset_pending}
 
   defp check_attachable(%Sandbox{status: status}, _agent, _vault_id, _env_id)
        when status not in ["ready", "suspended"],

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -231,6 +231,8 @@ defmodule Fountain.Conversations do
           Repo.one(from s in Sandbox, where: s.id == ^sandbox.id, lock: "FOR UPDATE") ||
             Repo.rollback(:not_found)
 
+        if current.reset_requested_at, do: Repo.rollback(:sandbox_reset_pending)
+
         changeset =
           current
           |> Sandbox.changeset(attrs)
@@ -1305,7 +1307,7 @@ defmodule Fountain.Conversations do
               on: s.id == c.sandbox_id,
               where:
                 c.id == ^conv_id and s.id == ^sandbox_id and c.user_id == s.user_id and
-                  s.status not in ["terminated", "failed"]
+                  s.status not in ["terminated", "failed"] and is_nil(s.reset_requested_at)
           )
 
         unless attached?, do: Repo.rollback(:sandbox_unavailable)
@@ -2967,8 +2969,9 @@ defmodule Fountain.Conversations do
   ends with it (`{:sandbox_not_resettable, "ephemeral"}`), a terminated or
   failed one is already gone (`{:sandbox_not_resettable, status}`). Refused
   with `:sandbox_mid_turn` while any conversation on it runs a turn — the
-  check and the row flip share the per-sandbox advisory lock that turn
-  creation takes, so a turn cannot slip in between them.
+  check and the durable reset fence share turn admission's advisory lock.
+  A provider error or lost caller leaves the fence and capacity in place;
+  repeated resets return `:sandbox_reset_pending` without another delete.
 
   `opts[:reason]` says *why*, and reaches every transcript on the machine and
   the audit row: `"home_reset"` (the owner asked — the default),
@@ -2979,48 +2982,58 @@ defmodule Fountain.Conversations do
   See `create_agent/2` for the rest of `opts` (`:actor`, `:request_ip`).
   """
   def reset_sandbox(%Sandbox{} = sandbox, opts \\ []) do
-    cond do
-      sandbox.mode != "persistent" ->
-        {:error, {:sandbox_not_resettable, "ephemeral"}}
-
-      sandbox.status in ["terminated", "failed"] ->
-        {:error, {:sandbox_not_resettable, sandbox.status}}
-
-      true ->
-        do_reset_sandbox(sandbox, opts)
-    end
-  end
-
-  defp do_reset_sandbox(%Sandbox{id: sandbox_id} = sandbox, opts) do
-    now = DateTime.utc_now() |> DateTime.truncate(:second)
+    now = DateTime.utc_now()
 
     result =
       Repo.transaction(fn ->
         Repo.query!("SELECT pg_advisory_xact_lock($1, $2)", [
           @sandbox_lock_namespace,
-          :erlang.phash2(sandbox_id)
+          :erlang.phash2(sandbox.id)
         ])
 
-        if _unsafe_running_turns_elsewhere(sandbox_id, nil) > 0 do
-          Repo.rollback(:sandbox_mid_turn)
-        else
-          ids =
-            Repo.all(
-              from c in Conversation,
-                where: c.sandbox_id == ^sandbox_id and c.status not in ["terminated", "failed"],
-                select: c.id
-            )
+        current =
+          Repo.one(
+            from s in Sandbox,
+              where: s.id == ^sandbox.id and s.user_id == ^sandbox.user_id,
+              lock: "FOR UPDATE"
+          ) || Repo.rollback(:not_found)
 
-          # A fresh disk has no session to resume (#778).
-          Repo.update_all(from(c in Conversation, where: c.id in ^ids),
-            set: [runtime_session_id: nil, updated_at: now]
+        cond do
+          current.mode != "persistent" ->
+            Repo.rollback({:sandbox_not_resettable, "ephemeral"})
+
+          current.status not in ["ready", "suspended"] ->
+            Repo.rollback({:sandbox_not_resettable, current.status})
+
+          current.reset_requested_at ->
+            Repo.rollback(:sandbox_reset_pending)
+
+          _unsafe_running_turns_elsewhere(current.id, nil) > 0 ->
+            Repo.rollback(:sandbox_mid_turn)
+
+          true ->
+            :ok
+        end
+
+        fenced = current |> Ecto.Changeset.change(reset_requested_at: now) |> Repo.update!()
+
+        ids =
+          Repo.all(
+            from c in Conversation,
+              where: c.sandbox_id == ^current.id and c.status not in ["terminated", "failed"],
+              select: c.id
           )
 
-          ids
-        end
+        # Admission is fenced before these sessions become unusable.
+        Repo.update_all(from(c in Conversation, where: c.id in ^ids),
+          set: [runtime_session_id: nil, updated_at: DateTime.truncate(now, :second)]
+        )
+
+        {fenced, ids}
       end)
 
-    with {:ok, ids} <- result do
+    with {:ok, {fenced, ids}} <- result,
+         {:ok, completed} <- finish_sandbox_reset(fenced) do
       reason = Keyword.get(opts, :reason, "home_reset")
       message = reset_message(reason)
 
@@ -3043,24 +3056,41 @@ defmodule Fountain.Conversations do
         end
       end)
 
-      _unsafe_retire_home(sandbox)
-
       Audit.record(%{
-        user_id: sandbox.user_id,
+        user_id: completed.user_id,
         action: "sandbox.reset",
         resource_type: "sandbox",
-        resource_id: sandbox.id,
+        resource_id: completed.id,
         actor: Keyword.get(opts, :actor, "self"),
         request_ip: Keyword.get(opts, :request_ip),
         metadata: %{
-          "agent_id" => sandbox.agent_id,
-          "provider" => sandbox.provider,
+          "agent_id" => completed.agent_id,
+          "provider" => completed.provider,
           "conversations" => length(ids),
           "reason" => reason
         }
       })
 
-      {:ok, _unsafe_get_sandbox!(sandbox.id)}
+      {:ok, completed}
+    end
+  end
+
+  # Only a confirmed destroy releases capacity. Errors or caller loss leave
+  # the committed fence intact; neither a repeat reset nor the reaper retries it.
+  defp finish_sandbox_reset(sandbox) do
+    handle = Managoat.Sandbox.build_handle(sandbox_provider_atom(sandbox), sandbox.sprite_name)
+
+    case Managoat.Sandbox.destroy(handle) do
+      :ok ->
+        changeset = sandbox |> Sandbox.changeset(%{status: "terminated"}) |> stamp_terminated_at()
+
+        with {:ok, completed} <- Repo.update(changeset) do
+          record_sandbox_usage(sandbox.status, completed)
+          {:ok, completed}
+        end
+
+      {:error, _} ->
+        {:error, :sandbox_reset_pending}
     end
   end
 
@@ -3249,6 +3279,9 @@ defmodule Fountain.Conversations do
       {:ok, _unsafe_get_conversation!(conv.id)}
     end
   end
+
+  defp check_attachable(%Sandbox{reset_requested_at: at}, _agent, _vault_id, _env_id)
+       when not is_nil(at), do: {:error, :sandbox_reset_pending}
 
   defp check_attachable(%Sandbox{status: status}, _agent, _vault_id, _env_id)
        when status not in ["ready", "suspended"],
@@ -3802,6 +3835,10 @@ defmodule Fountain.Conversations do
 
   defp maybe_reuse_sandbox(%Conversation{sandbox_id: sandbox_id}) do
     case _unsafe_get_sandbox(sandbox_id) do
+      %Sandbox{reset_requested_at: at, status: status}
+      when not is_nil(at) and status not in ["terminated", "failed"] ->
+        {:error, :sandbox_reset_pending}
+
       %{status: status, sprite_name: name} = sandbox
       when status in ["ready", "suspended"] and is_binary(name) ->
         probe_reusable_sandbox(sandbox, sandbox_id)

--- a/apps/fountain/lib/fountain/conversations/home_checkpoint.ex
+++ b/apps/fountain/lib/fountain/conversations/home_checkpoint.ex
@@ -35,6 +35,11 @@ defmodule Fountain.Conversations.HomeCheckpoint do
   it has been recorded.
   """
   @spec on_park(Sandbox.t()) :: {:ok, String.t()} | :skipped | {:error, term()}
+  # A machine whose reset is unconfirmed keeps no checkpoint: the disk is meant
+  # to be gone, and `record/2` writes through `update_sandbox/2`, which refuses
+  # a non-retiring write to a fenced row while this clause matches `{:ok, _}`.
+  def on_park(%Sandbox{reset_requested_at: at}) when not is_nil(at), do: :skipped
+
   def on_park(%Sandbox{mode: "persistent", sprite_name: name} = sandbox) when is_binary(name) do
     provider = Conversations.sandbox_provider_atom(sandbox)
 

--- a/apps/fountain/lib/fountain/conversations/lifecycle.ex
+++ b/apps/fountain/lib/fountain/conversations/lifecycle.ex
@@ -365,7 +365,13 @@ defmodule Fountain.Conversations.Lifecycle do
       # Ownership: as home?/1 above.
       sandbox = Conversations._unsafe_get_sandbox!(sandbox_id)
 
-      if sandbox.status not in ["terminated", "failed"] do
+      # A machine whose reset is unconfirmed is on its way out, not parking.
+      # `update_sandbox/2` lets a retiring write through the fence but refuses
+      # `suspended`, and this clause matches `{:ok, _}`. The reaper's own park
+      # pass filters the same rows; there is no checkpoint worth taking of a
+      # disk that is meant to be gone.
+      if sandbox.status not in ["terminated", "failed"] and
+           is_nil(sandbox.reset_requested_at) do
         # A home's disk is kept at its quietest moment, where the provider
         # can (ADR 0023, #1073). Best-effort: the park goes ahead either way.
         HomeCheckpoint.on_park(sandbox)

--- a/apps/fountain/lib/fountain/conversations/sandbox.ex
+++ b/apps/fountain/lib/fountain/conversations/sandbox.ex
@@ -40,6 +40,8 @@ defmodule Fountain.Conversations.Sandbox do
     field :mode, :string, default: "ephemeral"
     field :terminated_at, :utc_datetime
     field :last_resumed_at, :utc_datetime
+    # Internal reset fence; retained after completion as operation evidence.
+    field :reset_requested_at, :utc_datetime_usec
     belongs_to :environment, Environment
     # The identity the disk was materialized from, with the environment
     # (ADR 0023): env vars, packages, repos and setup scripts are written at

--- a/apps/fountain/lib/fountain/quotas.ex
+++ b/apps/fountain/lib/fountain/quotas.ex
@@ -29,7 +29,8 @@ defmodule Fountain.Quotas do
   ~nothing (decisions/0017) — which means this set is narrower than the admin
   sandbox view's "anything non-terminal": the admin table will list a suspended
   sandbox that the per-user counter ignores. Waking one re-runs the quota gate
-  (`Conversations.wake_suspended_sandbox/2`).
+  (`Conversations.wake_suspended_sandbox/2`). Unconfirmed resets also count,
+  even on parked machines, and cannot use the replacement exclusion.
   """
 
   import Ecto.Query
@@ -51,14 +52,14 @@ defmodule Fountain.Quotas do
   @spec active_sandbox_count(binary(), keyword()) :: non_neg_integer()
   def active_sandbox_count(user_id, opts \\ []) when is_binary(user_id) do
     query =
-      from s in Sandbox,
-        where: s.user_id == ^user_id and s.status in @active_statuses,
+      from s in active_sandboxes(),
+        where: s.user_id == ^user_id,
         select: count(s.id)
 
     query =
       case Keyword.get(opts, :exclude) do
         nil -> query
-        excluded -> from s in query, where: s.id != ^excluded
+        excluded -> from s in query, where: s.id != ^excluded or not is_nil(s.reset_requested_at)
       end
 
     Repo.one(query) || 0
@@ -73,8 +74,7 @@ defmodule Fountain.Quotas do
   """
   @spec active_sandbox_counts() :: %{optional(binary()) => non_neg_integer()}
   def active_sandbox_counts do
-    from(s in Sandbox,
-      where: s.status in @active_statuses,
+    from(s in active_sandboxes(),
       group_by: s.user_id,
       select: {s.user_id, count(s.id)}
     )
@@ -133,7 +133,16 @@ defmodule Fountain.Quotas do
   @doc "Live sandboxes across every tenant, against the fleet ceiling."
   @spec fleet_count() :: non_neg_integer()
   def fleet_count do
-    Repo.one(from(s in Sandbox, where: s.status in @active_statuses, select: count(s.id))) || 0
+    Repo.one(from(s in active_sandboxes(), select: count(s.id))) || 0
+  end
+
+  # A reset holds its slot until deletion is confirmed, including a reset
+  # requested while parked. Replacement exclusions cannot spend that slot.
+  defp active_sandboxes do
+    from s in Sandbox,
+      where:
+        s.status in @active_statuses or
+          (not is_nil(s.reset_requested_at) and s.status not in ["terminated", "failed"])
   end
 
   @doc "The reserve, floor, ceiling and fleet ceiling in force."
@@ -169,8 +178,8 @@ defmodule Fountain.Quotas do
 
         excluded ->
           Repo.one(
-            from(s in Sandbox,
-              where: s.status in @active_statuses and s.id != ^excluded,
+            from(s in active_sandboxes(),
+              where: s.id != ^excluded or not is_nil(s.reset_requested_at),
               select: count(s.id)
             )
           ) || 0

--- a/apps/fountain/lib/fountain/workers/sandbox_reaper.ex
+++ b/apps/fountain/lib/fountain/workers/sandbox_reaper.ex
@@ -120,7 +120,10 @@ defmodule Fountain.Workers.SandboxReaper do
     cutoff = DateTime.utc_now() |> DateTime.add(-@stuck_after_minutes * 60, :second)
 
     Sandbox
-    |> where([s], s.status in ^@active_statuses and s.updated_at < ^cutoff)
+    |> where(
+      [s],
+      s.status in ^@active_statuses and is_nil(s.reset_requested_at) and s.updated_at < ^cutoff
+    )
     |> Repo.all()
     |> Repo.preload(:conversations)
     |> Enum.reject(&server_alive?/1)
@@ -220,7 +223,10 @@ defmodule Fountain.Workers.SandboxReaper do
 
       verdicts =
         Sandbox
-        |> where([s], s.status == "ready" and s.updated_at < ^grace_cutoff)
+        |> where(
+          [s],
+          s.status == "ready" and is_nil(s.reset_requested_at) and s.updated_at < ^grace_cutoff
+        )
         |> Repo.all()
         |> Repo.preload(:conversations)
         |> Enum.reject(&server_alive?/1)

--- a/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
@@ -338,6 +338,15 @@ defmodule FountainWeb.FallbackController do
     })
   end
 
+  def call(conn, {:error, :sandbox_reset_pending}) do
+    conn
+    |> put_status(:conflict)
+    |> json(%{
+      error: "sandbox_reset_pending",
+      message: "reset is pending confirmation; contact the operator before retrying"
+    })
+  end
+
   # Sandbox files (ADR 0039). A read never wakes a parked sandbox: 409 with
   # the status, and the caller decides whether a prompt is worth the wake.
   def call(conn, {:error, {:sandbox_not_ready, status}}) do

--- a/apps/fountain/priv/repo/migrations/20260909050000_fence_sandbox_resets.exs
+++ b/apps/fountain/priv/repo/migrations/20260909050000_fence_sandbox_resets.exs
@@ -1,0 +1,26 @@
+defmodule Fountain.Repo.Migrations.FenceSandboxResets do
+  use Ecto.Migration
+
+  def up do
+    alter table(:sandboxes) do
+      add :reset_requested_at, :utc_datetime_usec
+    end
+  end
+
+  def down do
+    # Keep a concurrent reset from adding evidence after the emptiness check.
+    execute "LOCK TABLE sandboxes IN ACCESS EXCLUSIVE MODE"
+
+    execute """
+    DO $$ BEGIN
+      IF EXISTS (SELECT 1 FROM sandboxes WHERE reset_requested_at IS NOT NULL) THEN
+        RAISE EXCEPTION 'cannot discard sandbox reset evidence';
+      END IF;
+    END $$;
+    """
+
+    alter table(:sandboxes) do
+      remove :reset_requested_at
+    end
+  end
+end

--- a/apps/fountain/priv/repo/migrations/20260909050000_fence_sandbox_resets.exs
+++ b/apps/fountain/priv/repo/migrations/20260909050000_fence_sandbox_resets.exs
@@ -1,26 +1,50 @@
 defmodule Fountain.Repo.Migrations.FenceSandboxResets do
   use Ecto.Migration
 
+  require Logger
+
   def up do
     alter table(:sandboxes) do
       add :reset_requested_at, :utc_datetime_usec
     end
   end
 
+  # A rollback has to work. Refusing it whenever evidence exists would brick
+  # the deploy-rollback path permanently, because a *successful* reset keeps
+  # its `reset_requested_at` by design, so the first reset in production would
+  # be the last time this migration could be reversed.
+  #
+  # Dropping the column is also the correct rollback semantic: the code being
+  # rolled back to has no concept of a fence, and reads these rows as the
+  # ordinary sandboxes they were. What the operator loses is the record of
+  # which machines had an unconfirmed delete, so name them on the way out.
   def down do
-    # Keep a concurrent reset from adding evidence after the emptiness check.
+    # Keep a concurrent reset from adding evidence between the count and the drop.
     execute "LOCK TABLE sandboxes IN ACCESS EXCLUSIVE MODE"
 
-    execute """
-    DO $$ BEGIN
-      IF EXISTS (SELECT 1 FROM sandboxes WHERE reset_requested_at IS NOT NULL) THEN
-        RAISE EXCEPTION 'cannot discard sandbox reset evidence';
-      END IF;
-    END $$;
-    """
+    warn_about_unconfirmed_resets()
 
     alter table(:sandboxes) do
       remove :reset_requested_at
+    end
+  end
+
+  defp warn_about_unconfirmed_resets do
+    %{rows: rows} =
+      repo().query!("""
+      -- id::text, because a raw query hands back the 16-byte UUID and the
+      -- Logger formatter raises on the invalid UTF-8 that interpolates into.
+      SELECT id::text, sprite_name, provider
+        FROM sandboxes
+       WHERE reset_requested_at IS NOT NULL
+         AND status NOT IN ('terminated', 'failed')
+      """)
+
+    for [id, name, provider] <- rows do
+      Logger.warning(
+        "rollback: sandbox #{id} (#{provider}/#{name}) had an unconfirmed reset. " <>
+          "Its machine may still exist at the provider; check it by hand."
+      )
     end
   end
 end

--- a/apps/fountain/test/fountain/conversations/orphaned_home_test.exs
+++ b/apps/fountain/test/fountain/conversations/orphaned_home_test.exs
@@ -351,12 +351,16 @@ defmodule Fountain.Conversations.OrphanedHomeTest do
   end
 
   describe "a provider that cannot destroy" do
-    test "the row still retires, so the reaper sees a terminal row", ctx do
+    test "an uncertain reset stays fenced and counted after the identity changes", ctx do
       stub(Managoat.Sandbox.Sprites, :destroy, fn _h -> {:error, :boom} end)
       old = home(ctx)
 
       assert {:ok, _} = Agents.update_agent(ctx.agent, %{"environment_id" => ctx.other_env.id})
-      assert Conversations._unsafe_get_sandbox!(old.id).status == "terminated"
+      held = Conversations._unsafe_get_sandbox!(old.id)
+      assert held.status == "ready"
+      refute is_nil(held.reset_requested_at)
+      assert Fountain.Quotas.active_sandbox_count(ctx.user.id) == 1
+      assert {:error, :sandbox_reset_pending} = Conversations.reset_sandbox(old)
     end
   end
 end

--- a/apps/fountain/test/fountain/conversations/sandbox_reset_test.exs
+++ b/apps/fountain/test/fountain/conversations/sandbox_reset_test.exs
@@ -37,6 +37,18 @@ defmodule Fountain.Conversations.SandboxResetTest do
     {:ok, user: user, env: env, agent: agent, home: home, a: a, b: b}
   end
 
+  test "an enclosing transaction cannot start provider deletion or persist a reset fence", ctx do
+    reject(Managoat.Sandbox.Sprites, :destroy, 1)
+
+    assert {:ok, {:error, :provider_transaction_open}} =
+             Repo.transaction(fn -> Conversations.reset_sandbox(ctx.home) end)
+
+    assert Repo.reload!(ctx.home).status == "ready"
+    refute Repo.reload!(ctx.home).reset_requested_at
+    assert Repo.reload!(ctx.a).runtime_session_id == "sess-a"
+    assert Conversations._unsafe_list_log_events(ctx.a.id) == []
+  end
+
   test "destroys the sprite, retires the row, keeps the conversations", ctx do
     test = self()
     stub(Managoat.Sandbox.Sprites, :destroy, fn h -> send(test, {:destroyed, h.name}) && :ok end)

--- a/apps/fountain/test/fountain/conversations/sandbox_reset_test.exs
+++ b/apps/fountain/test/fountain/conversations/sandbox_reset_test.exs
@@ -119,10 +119,79 @@ defmodule Fountain.Conversations.SandboxResetTest do
              Conversations.reset_sandbox(gone)
   end
 
-  test "the row retires even when the provider refuses the destroy", ctx do
-    stub(Managoat.Sandbox.Sprites, :destroy, fn _h -> {:error, :boom} end)
-    assert {:ok, sandbox} = Conversations.reset_sandbox(ctx.home)
-    assert sandbox.status == "terminated"
+  for capacity <- [1, :unbounded] do
+    test "reset fences #{inspect(capacity)} admission before calling the provider", ctx do
+      expect(Managoat.Sandbox.Sprites, :destroy, fn _ ->
+        refute Repo.in_transaction?()
+        assert Fountain.Quotas.active_sandbox_count(ctx.user.id) == 1
+
+        assert {:error, :sandbox_unavailable} =
+                 Conversations._unsafe_create_turn_on_sandbox(
+                   %{
+                     conversation_id: ctx.a.id,
+                     turn_number: 1,
+                     status: "running",
+                     prompt: "late"
+                   },
+                   ctx.home.id,
+                   unquote(capacity)
+                 )
+
+        assert {:error, :sandbox_reset_pending} = Conversations.reset_sandbox(ctx.home)
+        :ok
+      end)
+
+      assert {:ok, %{status: "terminated"}} = Conversations.reset_sandbox(ctx.home)
+      assert Fountain.Quotas.active_sandbox_count(ctx.user.id) == 0
+    end
+  end
+
+  test "an uncertain destroy retains capacity and cannot be retried or swept", ctx do
+    expect(Managoat.Sandbox.Sprites, :destroy, fn _ -> {:error, :timeout} end)
+    assert {:error, :sandbox_reset_pending} = Conversations.reset_sandbox(ctx.home)
+    assert {:error, :sandbox_reset_pending} = Conversations.reset_sandbox(ctx.home)
+    assert {:error, :sandbox_reset_pending} = Conversations.wake_conversation(ctx.a.id)
+
+    assert {:error, :sandbox_reset_pending} =
+             Conversations.update_sandbox(ctx.home, %{status: "terminated"})
+
+    Repo.update_all(from(s in Conversations.Sandbox, where: s.id == ^ctx.home.id),
+      set: [updated_at: DateTime.add(DateTime.utc_now(), -172_800, :second)]
+    )
+
+    assert {0, 0} = Fountain.Workers.SandboxReaper.sweep_abandoned_sandboxes()
+    assert Fountain.Quotas.active_sandbox_count(ctx.user.id) == 1
+    assert Repo.reload!(ctx.home).status == "ready"
+    refute Enum.any?(Fountain.Audit.list_for_user(ctx.user.id), &(&1.action == "sandbox.reset"))
+  end
+
+  test "a parked reset holds capacity even through replacement exclusions", ctx do
+    {:ok, home} = Conversations.update_sandbox(ctx.home, %{status: "suspended"})
+    expect(Managoat.Sandbox.Sprites, :destroy, fn _ -> {:error, :timeout} end)
+    assert {:error, :sandbox_reset_pending} = Conversations.reset_sandbox(home)
+    assert Fountain.Quotas.active_sandbox_count(ctx.user.id, exclude: home.id) == 1
+    assert Fountain.Quotas.active_sandbox_counts()[ctx.user.id] == 1
+    assert Fountain.Quotas.fleet_count() == 1
+  end
+
+  test "a lost reset caller leaves the admission fence in place", ctx do
+    expect(Managoat.Sandbox.Sprites, :destroy, fn _ -> raise "caller lost" end)
+    assert_raise RuntimeError, "caller lost", fn -> Conversations.reset_sandbox(ctx.home) end
+    assert {:error, :sandbox_reset_pending} = Conversations.reset_sandbox(ctx.home)
+
+    assert {:error, :sandbox_unavailable} =
+             Fountain.Conversations.Connection.open_autonomous_turn(
+               ctx.a.id,
+               ctx.user.id,
+               ctx.home.id
+             )
+  end
+
+  test "reset rechecks persisted mode instead of trusting the supplied struct", ctx do
+    ctx.home |> Ecto.Changeset.change(mode: "ephemeral") |> Repo.update!()
+
+    assert {:error, {:sandbox_not_resettable, "ephemeral"}} =
+             Conversations.reset_sandbox(ctx.home)
   end
 
   test "the next prompt builds a fresh home on the same identity", ctx do

--- a/apps/fountain/test/fountain/conversations/sandbox_reset_test.exs
+++ b/apps/fountain/test/fountain/conversations/sandbox_reset_test.exs
@@ -164,8 +164,10 @@ defmodule Fountain.Conversations.SandboxResetTest do
     assert {:error, :sandbox_reset_pending} = Conversations.reset_sandbox(ctx.home)
     assert {:error, :sandbox_reset_pending} = Conversations.wake_conversation(ctx.a.id)
 
+    # A write that would keep the machine alive is refused. A write that
+    # retires it is not, and is covered in the describe block below.
     assert {:error, :sandbox_reset_pending} =
-             Conversations.update_sandbox(ctx.home, %{status: "terminated"})
+             Conversations.update_sandbox(ctx.home, %{status: "suspended"})
 
     Repo.update_all(from(s in Conversations.Sandbox, where: s.id == ^ctx.home.id),
       set: [updated_at: DateTime.add(DateTime.utc_now(), -172_800, :second)]
@@ -175,6 +177,96 @@ defmodule Fountain.Conversations.SandboxResetTest do
     assert Fountain.Quotas.active_sandbox_count(ctx.user.id) == 1
     assert Repo.reload!(ctx.home).status == "ready"
     refute Enum.any?(Fountain.Audit.list_for_user(ctx.user.id), &(&1.action == "sandbox.reset"))
+  end
+
+  describe "an unconfirmed reset is fenced, not a dead end" do
+    setup ctx do
+      expect(Managoat.Sandbox.Sprites, :destroy, fn _ -> {:error, :timeout} end)
+      assert {:error, :sandbox_reset_pending} = Conversations.reset_sandbox(ctx.home)
+      :ok
+    end
+
+    test "an operator reaps the row, which releases the slot", ctx do
+      assert {:ok, :released} = Conversations._unsafe_reap_sandbox(ctx.home.id)
+      assert Repo.reload!(ctx.home).status == "terminated"
+      assert Fountain.Quotas.active_sandbox_count(ctx.user.id) == 0
+    end
+
+    test "deleting the agent still retires its home", ctx do
+      stub(Managoat.Sandbox.Sprites, :destroy, fn _ -> :ok end)
+      assert {:ok, _} = Fountain.Agents.delete_agent(ctx.agent, actor: "ui")
+      assert Repo.reload!(ctx.home).status == "terminated"
+      assert Fountain.Quotas.active_sandbox_count(ctx.user.id) == 0
+    end
+
+    test "a server that gives up can still mark the machine failed", ctx do
+      assert {:ok, failed} = Conversations.update_sandbox(ctx.home, %{status: "failed"})
+      assert failed.status == "failed"
+      assert Fountain.Quotas.active_sandbox_count(ctx.user.id) == 0
+    end
+
+    test "a park is skipped rather than raised, and takes no checkpoint", ctx do
+      reject(Managoat.Sandbox.Sprites, :create_checkpoint, 2)
+
+      assert :skipped = Fountain.Conversations.HomeCheckpoint.on_park(Repo.reload!(ctx.home))
+      assert :ok = Fountain.Conversations.Lifecycle.park(ctx.a.id, ctx.home.id, nil, :idle)
+
+      held = Repo.reload!(ctx.home)
+      assert held.status == "ready"
+      refute is_nil(held.reset_requested_at)
+      assert Repo.reload!(ctx.a).status == "idle"
+    end
+
+    test "anything that would re-use the machine is still refused", ctx do
+      assert {:error, :sandbox_reset_pending} = Conversations.reset_sandbox(ctx.home)
+      assert {:error, :sandbox_reset_pending} = Conversations.wake_conversation(ctx.a.id)
+
+      assert {:error, :sandbox_reset_pending} =
+               Conversations.update_sandbox(ctx.home, %{status: "suspended"})
+
+      assert Repo.reload!(ctx.home).status == "ready"
+    end
+
+    test "the request is on the trail even though the reset is not", ctx do
+      actions =
+        ctx.user.id
+        |> Fountain.Audit.list_for_user()
+        |> Enum.map(& &1.action)
+
+      assert "sandbox.reset_requested" in actions
+      refute "sandbox.reset" in actions
+
+      assert [event] =
+               ctx.user.id
+               |> Fountain.Audit.list_for_user()
+               |> Enum.filter(&(&1.action == "sandbox.reset_requested"))
+
+      assert event.resource_id == ctx.home.id
+      assert event.metadata["reason"] == "home_reset"
+      assert event.metadata["conversations"] == 2
+    end
+  end
+
+  test "a confirmed reset records both the request and the reset", ctx do
+    stub(Managoat.Sandbox.Sprites, :destroy, fn _ -> :ok end)
+    assert {:ok, %{status: "terminated"}} = Conversations.reset_sandbox(ctx.home)
+
+    actions =
+      ctx.user.id |> Fountain.Audit.list_for_user() |> Enum.map(& &1.action) |> Enum.sort()
+
+    assert "sandbox.reset_requested" in actions
+    assert "sandbox.reset" in actions
+  end
+
+  test "a sandbox that is still building is not resettable", ctx do
+    reject(Managoat.Sandbox.Sprites, :destroy, 1)
+
+    for status <- ["pending", "starting"] do
+      ctx.home |> Ecto.Changeset.change(status: status) |> Repo.update!()
+
+      assert {:error, {:sandbox_not_resettable, ^status}} = Conversations.reset_sandbox(ctx.home)
+      refute Repo.reload!(ctx.home).reset_requested_at
+    end
   end
 
   test "a parked reset holds capacity even through replacement exclusions", ctx do

--- a/apps/fountain/test/fountain_web/controllers/fallback_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/fallback_controller_test.exs
@@ -5,6 +5,11 @@ defmodule FountainWeb.FallbackControllerTest do
   """
   use FountainWeb.ConnCase, async: true
 
+  test "an uncertain reset reports an explicit conflict", %{conn: conn} do
+    conn = FountainWeb.FallbackController.call(conn, {:error, :sandbox_reset_pending})
+    assert %{"error" => "sandbox_reset_pending"} = json_response(conn, 409)
+  end
+
   describe "{:error, %Ecto.Changeset{}} → 422" do
     test "POST /api/agents with missing required fields returns 422 with errors body", %{
       conn: conn

--- a/docs/concepts/sandboxes.md
+++ b/docs/concepts/sandboxes.md
@@ -49,13 +49,22 @@ now. Fountain refuses each change with `409 sandbox_mid_turn` while a
 conversation on that machine runs a turn. Let the turn end, or stop it, then
 send the request again.
 
+Only a `ready` or `suspended` machine resets. A machine in the `pending` or
+`starting` status answers `409 sandbox_not_resettable` with that status. It
+has no disk to replace yet.
+
 A reset blocks new turns before it calls the provider. It releases capacity
 only after the provider confirms deletion. A timeout or lost request keeps
 the reset fence and quota reservation. Another reset returns
-`409 sandbox_reset_pending`; it does not send another delete. The operator
-must reconcile the provider outcome. Do not clear the fence or repeat the
-operation based only on a missing provider response. Automatic reconciliation
-is not implemented.
+`409 sandbox_reset_pending`, and so does an attach or a wake. None of them
+send a second delete. Automatic reconciliation is not implemented.
+
+To clear an unconfirmed reset, an operator reaps the sandbox from the admin
+sandbox list. That terminates the row and releases the quota slot. The
+machine at the provider is then the operator's to check, because Fountain
+has no evidence that the delete completed. Do not use a reap as a routine
+retry. The audit trail shows `sandbox.reset_requested` when the fence commits
+and `sandbox.reset` only when the provider confirms the deletion.
 
 When a home parks, Fountain can take a checkpoint of its disk. The operator
 turns this on with `CHECKPOINT_CREATION_ENABLED`, and only a provider with

--- a/docs/concepts/sandboxes.md
+++ b/docs/concepts/sandboxes.md
@@ -49,6 +49,14 @@ now. Fountain refuses each change with `409 sandbox_mid_turn` while a
 conversation on that machine runs a turn. Let the turn end, or stop it, then
 send the request again.
 
+A reset blocks new turns before it calls the provider. It releases capacity
+only after the provider confirms deletion. A timeout or lost request keeps
+the reset fence and quota reservation. Another reset returns
+`409 sandbox_reset_pending`; it does not send another delete. The operator
+must reconcile the provider outcome. Do not clear the fence or repeat the
+operation based only on a missing provider response. Automatic reconciliation
+is not implemented.
+
 When a home parks, Fountain can take a checkpoint of its disk. The operator
 turns this on with `CHECKPOINT_CREATION_ENABLED`, and only a provider with
 checkpoints (Sprites) does it. The checkpoint belongs to that one machine.


### PR DESCRIPTION
Reset released admission's lock before deleting the provider sandbox: a new turn could enter the gap, and a failed delete still freed quota. Commit a reset fence under the shared admission lock, call the provider after commit, and retire the row only after successful deletion. Timeout or caller loss retains the fence and capacity for reconciliation.

An enclosing caller transaction now returns `provider_transaction_open` before deletion or fence writes. Pending resets refuse turns, wakes, repeat resets and updates; the reaper skips them, and migration rollback preserves reset evidence. Main's locked retirement guard is retained.

Refreshed onto #1796: 10 files, +248/-55. The new guard adds 18 lines across two existing files. Automatic reconciliation, instance-conditional deletion and cross-action arbitration remain separate work.

Validation: 62 focused reset/sandbox/reaper tests pass. The new regression fails on the previous handler because provider deletion starts inside the caller transaction; the fixed test commits the refusal and verifies unchanged state. Full `mix precommit --seed 828329` passes: 4,892 tests +6 doctests, zero failures. Staged secret scan passes. The unchanged migration's rollback safeguards and 24 independent PostgreSQL interleavings have prior validation recorded in this PR. CI passes on the refreshed base ([run](https://github.com/managoat/fountain/actions/runs/34481301915)); the base change cancelled the superseded push run before tests.



Part of #1864
