### PR TITLE
feat: extract execution-limit policy resolver

### DIFF
--- a/apps/fountain/lib/fountain/conversations/execution_limits.ex
+++ b/apps/fountain/lib/fountain/conversations/execution_limits.ex
@@ -1,0 +1,143 @@
+defmodule Fountain.Conversations.ExecutionLimits do
+  @moduledoc """
+  Typed per-turn policy, independent of provider-operation state.
+
+  Host and account maps are ceilings. Every configured ceiling is inherited;
+  omitting a request, an empty map, or an omitted field never disables one.
+  A launch request may tighten the effective ceiling, never widen it. Explicit
+  null fields, numeric strings, unknown keys and duplicate atom/string keys are
+  invalid. Clearing an operator ceiling is outside the launch/resume request path.
+
+  Callers supply a conversation's saved launch allowance. A new turn
+  intersects that allowance with current host/account ceilings; a policy
+  change can tighten future turns, but cannot grant an existing conversation a
+  larger allowance. Recovery must reuse the original turn's persisted deadline
+  and SDK limits rather than call this resolver to create another allowance.
+
+  SDK request/dollar limits apply to a supported SDK Query, not a durable spend
+  ledger. They do not bound blocked tools, work already in flight, or billed cost.
+  The transport must separately prove support for every resolved control before
+  admitting work. This module alone does not enable execution-limit enforcement.
+  """
+
+  @keys ~w(wall_time_seconds max_model_turns max_estimated_cost_usd)
+  @atoms [:wall_time_seconds, :max_model_turns, :max_estimated_cost_usd]
+  @key_map Map.new(Enum.zip(@atoms, @keys))
+  @max_safe_integer 9_007_199_254_740_991
+  # A wire-format bound, not a default allowance. Keeps deadline arithmetic
+  # representable and leaves actual allowances to the host/account policy.
+  @max_wall_seconds 31_536_000
+
+  @type t :: %{optional(String.t()) => pos_integer() | float()}
+  @type error :: {:execution_limits_invalid, String.t()} | {:execution_limits_widen, String.t()}
+
+  def keys, do: @keys
+  def max_wall_seconds, do: @max_wall_seconds
+
+  @doc "Parse the operator's JSON environment setting without echoing its input."
+  def from_json_env(value) when value in [nil, ""], do: {:ok, %{}}
+
+  def from_json_env(value) when is_binary(value) do
+    case Jason.decode(value) do
+      {:ok, attrs} when is_map(attrs) -> normalize(attrs)
+      {:ok, _} -> invalid("object_required")
+      {:error, _} -> invalid("invalid_json")
+    end
+  end
+
+  @doc "Normalize API or internal fields to the durable JSON representation."
+  @spec normalize(term()) :: {:ok, t()} | {:error, error()}
+  def normalize(nil), do: {:ok, %{}}
+
+  def normalize(attrs) when is_map(attrs) and not is_struct(attrs) do
+    Enum.reduce_while(attrs, {:ok, %{}}, fn {key, value}, {:ok, normalized} ->
+      field = if key in @keys, do: key, else: Map.get(@key_map, key)
+
+      cond do
+        is_nil(field) -> {:halt, invalid("unknown_field")}
+        Map.has_key?(normalized, field) -> {:halt, invalid("duplicate_field")}
+        not valid_value?(field, value) -> {:halt, invalid(field)}
+        true -> {:cont, {:ok, Map.put(normalized, field, value)}}
+      end
+    end)
+  end
+
+  def normalize(_), do: invalid("object_required")
+
+  @doc "Resolve a launch request against all configured host/account ceilings."
+  @spec resolve(term(), term(), term()) :: {:ok, t()} | {:error, error()}
+  def resolve(host, account, request) do
+    with {:ok, ceilings} <- intersect(host, account),
+         {:ok, requested} <- normalize(request),
+         :ok <- check_narrows(ceilings, requested) do
+      {:ok, Map.merge(ceilings, requested)}
+    end
+  end
+
+  @doc "Tighten an existing allowance without creating a fresh recovery budget."
+  @spec for_new_turn(term(), term(), term()) :: {:ok, t()} | {:error, error()}
+  def for_new_turn(host, account, launch_allowance) do
+    with {:ok, ceilings} <- intersect(host, account) do
+      intersect(ceilings, launch_allowance)
+    end
+  end
+
+  @doc "A channel resume may narrow the saved allowance, never clear or widen it."
+  @spec for_resume(term(), term(), term(), term()) :: {:ok, t()} | {:error, error()}
+  def for_resume(host, account, launch_allowance, request) do
+    with {:ok, allowance} <- for_new_turn(host, account, launch_allowance),
+         {:ok, requested} <- normalize(request),
+         :ok <- check_narrows(allowance, requested) do
+      {:ok, Map.merge(allowance, requested)}
+    end
+  end
+
+  @doc "Refuse every control the actual transport/runtime cannot enforce."
+  @spec require_controls(t(), [String.t()]) ::
+          :ok | {:error, {:execution_limits_unsupported, [String.t()]}}
+  def require_controls(limits, supported) do
+    missing = @keys |> Enum.filter(&(Map.has_key?(limits, &1) and &1 not in supported))
+    if missing == [], do: :ok, else: {:error, {:execution_limits_unsupported, missing}}
+  end
+
+  @doc "The two allowlisted SDK fields, converted without creating atoms from input."
+  @spec sdk_options(t()) :: map() | nil
+  def sdk_options(limits) do
+    options =
+      for {atom, field} <- @key_map,
+          field != "wall_time_seconds",
+          Map.has_key?(limits, field),
+          into: %{},
+          do: {atom, Map.fetch!(limits, field)}
+
+    if options == %{}, do: nil, else: options
+  end
+
+  defp intersect(left, right) do
+    with {:ok, left} <- normalize(left),
+         {:ok, right} <- normalize(right) do
+      {:ok, Map.merge(left, right, fn _, a, b -> min(a, b) end)}
+    end
+  end
+
+  defp check_narrows(ceilings, requested) do
+    case Enum.find(@keys, fn key ->
+           Map.has_key?(ceilings, key) and Map.has_key?(requested, key) and
+             requested[key] > ceilings[key]
+         end) do
+      nil -> :ok
+      field -> {:error, {:execution_limits_widen, field}}
+    end
+  end
+
+  defp valid_value?("wall_time_seconds", value),
+    do: is_integer(value) and value > 0 and value <= @max_wall_seconds
+
+  defp valid_value?("max_model_turns", value),
+    do: is_integer(value) and value > 0 and value <= @max_safe_integer
+
+  defp valid_value?("max_estimated_cost_usd", value),
+    do: is_number(value) and value > 0 and value <= @max_safe_integer
+
+  defp invalid(field), do: {:error, {:execution_limits_invalid, field}}
+end

--- a/apps/fountain/test/fountain/conversations/execution_limits_test.exs
+++ b/apps/fountain/test/fountain/conversations/execution_limits_test.exs
@@ -1,0 +1,177 @@
+defmodule Fountain.Conversations.ExecutionLimitsTest do
+  use ExUnit.Case, async: true
+  alias Fountain.Conversations.ExecutionLimits, as: Limits
+
+  test "omission inherits every host and account ceiling" do
+    for request <- [nil, %{}] do
+      assert {:ok, %{"wall_time_seconds" => 60, "max_model_turns" => 10}} =
+               Limits.resolve(%{"wall_time_seconds" => 60}, %{max_model_turns: 10}, request)
+    end
+  end
+
+  test "the smaller configured ceiling wins independently for each field" do
+    assert {:ok, %{"wall_time_seconds" => 20, "max_model_turns" => 5}} =
+             Limits.resolve(
+               %{wall_time_seconds: 20, max_model_turns: 10},
+               %{wall_time_seconds: 30, max_model_turns: 5},
+               nil
+             )
+  end
+
+  test "a partial request narrows one field and retains all other ceilings" do
+    assert {:ok, %{"wall_time_seconds" => 10, "max_model_turns" => 5}} =
+             Limits.resolve(%{wall_time_seconds: 20}, %{max_model_turns: 5}, %{
+               wall_time_seconds: 10
+             })
+  end
+
+  test "requests cannot exceed either effective ceiling" do
+    for {host, account} <- [{%{max_model_turns: 5}, nil}, {nil, %{max_model_turns: 5}}] do
+      assert {:error, {:execution_limits_widen, "max_model_turns"}} =
+               Limits.resolve(host, account, %{max_model_turns: 6})
+    end
+  end
+
+  test "no configured ceiling still permits a valid voluntarily bounded request" do
+    assert {:ok, %{"wall_time_seconds" => 60}} =
+             Limits.resolve(nil, nil, %{wall_time_seconds: 60})
+
+    assert {:ok, %{}} = Limits.resolve(nil, nil, nil)
+  end
+
+  test "explicit nulls cannot disable inherited controls" do
+    for field <- Limits.keys() do
+      assert {:error, {:execution_limits_invalid, ^field}} =
+               Limits.resolve(%{field => 5}, nil, %{field => nil})
+    end
+  end
+
+  test "unknown fields, arbitrary metadata and nonobjects are refused" do
+    for request <- [
+          %{"maxTurns" => 5},
+          %{"_meta" => %{}},
+          %{"options" => %{}},
+          %URI{host: "example.test"},
+          %{123 => 5},
+          3,
+          false,
+          [],
+          "10"
+        ] do
+      assert {:error, {:execution_limits_invalid, _}} = Limits.normalize(request)
+    end
+  end
+
+  test "duplicate atom/string keys cannot pick a value by enumeration order" do
+    assert {:error, {:execution_limits_invalid, "duplicate_field"}} =
+             Limits.normalize(%{:max_model_turns => 2, "max_model_turns" => 200})
+  end
+
+  test "integers stay integers and dollar fractions stay numeric" do
+    assert {:ok, %{"max_model_turns" => 3, "max_estimated_cost_usd" => 0.25}} =
+             Limits.normalize(%{max_model_turns: 3, max_estimated_cost_usd: 0.25})
+
+    for field <- ["max_model_turns", "wall_time_seconds"], value <- ["5", 5.0, 0, -1, true] do
+      assert {:error, {:execution_limits_invalid, ^field}} = Limits.normalize(%{field => value})
+    end
+  end
+
+  test "wire bounds refuse nonrepresentable deadlines and unsafe JSON integers" do
+    assert {:error, _} = Limits.normalize(%{wall_time_seconds: Limits.max_wall_seconds() + 1})
+    assert {:error, _} = Limits.normalize(%{max_model_turns: 9_007_199_254_740_992})
+    assert {:error, _} = Limits.normalize(%{max_estimated_cost_usd: 9_007_199_254_740_992})
+
+    for value <- [0, -0.1, "0.25", nil, false] do
+      assert {:error, _} = Limits.normalize(%{max_estimated_cost_usd: value})
+    end
+  end
+
+  test "loosening or removing account policy never widens an existing conversation" do
+    launch = %{"wall_time_seconds" => 20, "max_model_turns" => 5}
+    assert {:ok, ^launch} = Limits.for_new_turn(nil, %{wall_time_seconds: 200}, launch)
+    assert {:ok, ^launch} = Limits.for_new_turn(nil, nil, launch)
+  end
+
+  test "new turns inherit tightened ceilings without losing other saved limits" do
+    assert {:ok, %{"wall_time_seconds" => 10, "max_model_turns" => 5}} =
+             Limits.for_new_turn(nil, %{wall_time_seconds: 10}, %{
+               wall_time_seconds: 20,
+               max_model_turns: 5
+             })
+  end
+
+  test "channel resume cannot reset a narrower launch allowance" do
+    assert {:error, {:execution_limits_widen, "max_model_turns"}} =
+             Limits.for_resume(nil, %{max_model_turns: 100}, %{max_model_turns: 5}, %{
+               max_model_turns: 10
+             })
+
+    assert {:ok, %{"max_model_turns" => 5}} =
+             Limits.for_resume(nil, nil, %{max_model_turns: 5}, nil)
+  end
+
+  test "malformed host or saved policy fails closed instead of dropping a ceiling" do
+    for {host, account, saved} <- [
+          {%{wall_time_seconds: "60"}, nil, nil},
+          {nil, %{max_model_turns: 0}, nil},
+          {nil, nil, %{wall_time_seconds: nil}}
+        ] do
+      assert {:error, {:execution_limits_invalid, _}} = Limits.for_new_turn(host, account, saved)
+    end
+  end
+
+  test "runtime capability checks cover inherited controls as well as requested ones" do
+    {:ok, limits} = Limits.resolve(%{wall_time_seconds: 60}, nil, %{max_model_turns: 3})
+
+    assert {:error, {:execution_limits_unsupported, ["wall_time_seconds"]}} =
+             Limits.require_controls(limits, ["max_model_turns"])
+
+    assert :ok = Limits.require_controls(limits, ["wall_time_seconds", "max_model_turns"])
+    assert :ok = Limits.require_controls(%{}, [])
+  end
+
+  test "new-turn allowances never exceed a saved or current ceiling" do
+    for field <- Limits.keys(), host <- [1, 5, 20], account <- [2, 10], saved <- [3, 15] do
+      assert {:ok, %{^field => allowance}} =
+               Limits.for_new_turn(%{field => host}, %{field => account}, %{field => saved})
+
+      assert allowance <= host
+      assert allowance <= account
+      assert allowance <= saved
+
+      assert {:error, {:execution_limits_widen, ^field}} =
+               Limits.for_resume(%{field => host}, %{field => account}, %{field => saved}, %{
+                 field => allowance + 1
+               })
+    end
+  end
+
+  test "host JSON configuration validates its shape instead of disabling malformed limits" do
+    assert {:ok, %{}} = Limits.from_json_env(nil)
+
+    assert {:ok, %{"wall_time_seconds" => 60}} =
+             Limits.from_json_env(~s({"wall_time_seconds":60}))
+
+    for value <- [
+          "null",
+          "[]",
+          "not-json",
+          ~s({"wall_time_seconds":null}),
+          ~s({"secret":"never echo me"})
+        ] do
+      assert {:error, {:execution_limits_invalid, reason}} = Limits.from_json_env(value)
+      refute reason =~ "never echo me"
+    end
+  end
+
+  test "SDK options contain only adapter fields and never the host deadline" do
+    assert %{max_model_turns: 3, max_estimated_cost_usd: 0.25} =
+             Limits.sdk_options(%{
+               "wall_time_seconds" => 60,
+               "max_model_turns" => 3,
+               "max_estimated_cost_usd" => 0.25
+             })
+
+    assert nil == Limits.sdk_options(%{"wall_time_seconds" => 60})
+  end
+end


### PR DESCRIPTION
Execution-limit admission needs one resolver that preserves every host/account ceiling and refuses requests that widen an existing allowance.

Extract the pure `ExecutionLimits` module and its tests from #1745: validate the three allowlisted fields, inherit omitted ceilings, narrow launch/new-turn/resume allowances, reject unsupported controls, and map SDK options. For example, a saved five-turn allowance remains five after the account ceiling rises to 100.

Two files, 320 added lines, based on main. This is a policy foundation: API/storage wiring, runtime enforcement and live acceptance remain in #1732. It introduces no admission caller, configuration setting, migration or SDK release. The rest of #1745 remains draft.

Validation: 18 focused tests passed, including 36 ceiling combinations and malformed input. Secret scan passed. Full `mix precommit` passed: 4,708 tests and six doctests, zero failures. CI passed on `c8d221d6`.
