### PR TITLE
feat(conversations): store versioned execution allowances

### DIFF
--- a/apps/fountain/lib/fountain/conversations/execution_allowance.ex
+++ b/apps/fountain/lib/fountain/conversations/execution_allowance.ex
@@ -1,0 +1,53 @@
+defmodule Fountain.Conversations.ExecutionAllowance do
+  @moduledoc """
+  Versioned storage for a conversation's resolved execution allowance.
+
+  This is a storage primitive, not an admission or enforcement API. No service
+  path writes these records yet. Admission must establish conversation ownership,
+  resolve current ceilings and prove runtime support before saving an allowance.
+  Later turns and recovery must consult it before this becomes a usable setting.
+
+  Updates must use `narrow_changeset/2`. A stale revision fails with
+  `Ecto.StaleEntryError` (or a changeset error with `stale_error_field: :revision`).
+  Reload and revalidate the request after a conflict; never retry the old map as
+  a replacement. An opaque revision avoids counter rollover accepting old writes.
+  This record does not reset or replace an in-flight turn's deadline or usage.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Fountain.Conversations.{Conversation, ExecutionLimits}
+
+  @primary_key false
+  @foreign_key_type :binary_id
+  schema "execution_allowances" do
+    belongs_to :conversation, Conversation, primary_key: true
+    field :limits, :map, default: %{}
+    field :revision, :binary_id
+    timestamps(type: :utc_datetime_usec)
+  end
+
+  @doc "Insert a resolved allowance once; a duplicate cannot replace it."
+  def new_changeset(conversation_id, limits) do
+    %__MODULE__{}
+    |> change(conversation_id: conversation_id, revision: Ecto.UUID.generate())
+    |> put_limits(ExecutionLimits.normalize(limits))
+    |> validate_required([:conversation_id, :revision])
+    |> foreign_key_constraint(:conversation_id)
+    |> unique_constraint(:conversation_id, name: :execution_allowances_pkey)
+  end
+
+  @doc "Narrow the saved allowance, retaining omitted fields and checking its revision."
+  def narrow_changeset(%__MODULE__{} = allowance, request) do
+    allowance
+    |> change()
+    |> put_limits(ExecutionLimits.for_resume(nil, nil, allowance.limits, request))
+    |> optimistic_lock(:revision, fn _ -> Ecto.UUID.generate() end)
+  end
+
+  defp put_limits(changeset, {:ok, limits}), do: put_change(changeset, :limits, limits)
+
+  defp put_limits(changeset, {:error, {reason, field}}),
+    do: add_error(changeset, :limits, "#{reason}: #{field}")
+end

--- a/apps/fountain/priv/repo/migrations/20260909090000_create_execution_allowances.exs
+++ b/apps/fountain/priv/repo/migrations/20260909090000_create_execution_allowances.exs
@@ -1,0 +1,29 @@
+defmodule Fountain.Repo.Migrations.CreateExecutionAllowances do
+  use Ecto.Migration
+
+  def up do
+    create table(:execution_allowances, primary_key: false) do
+      add :conversation_id, references(:conversations, type: :binary_id, on_delete: :delete_all),
+        primary_key: true
+
+      add :limits, :map, null: false, default: %{}
+      add :revision, :binary_id, null: false
+      timestamps(type: :utc_datetime_usec)
+    end
+  end
+
+  def down do
+    # Lock before checking, so a concurrent insert cannot lose an allowance.
+    execute "LOCK TABLE execution_allowances IN ACCESS EXCLUSIVE MODE"
+
+    execute """
+    DO $$ BEGIN
+      IF EXISTS (SELECT 1 FROM execution_allowances) THEN
+        RAISE EXCEPTION 'cannot discard saved execution allowances';
+      END IF;
+    END $$;
+    """
+
+    drop table(:execution_allowances)
+  end
+end

--- a/apps/fountain/test/fountain/conversations/execution_allowance_test.exs
+++ b/apps/fountain/test/fountain/conversations/execution_allowance_test.exs
@@ -1,0 +1,236 @@
+defmodule Fountain.Conversations.ExecutionAllowanceTest do
+  use Fountain.DataCase, async: true
+
+  alias Fountain.Conversations.ExecutionAllowance, as: Allowance
+
+  setup do
+    %{conversation: insert_conversation()}
+  end
+
+  test "persists canonical limits and a revision across reloads", %{conversation: conversation} do
+    allowance = insert_allowance(conversation.id)
+    assert Repo.reload!(allowance) == allowance
+    assert allowance.limits == %{"max_model_turns" => 10, "wall_time_seconds" => 60}
+    assert {:ok, _} = Ecto.UUID.cast(allowance.revision)
+  end
+
+  test "a duplicate insert cannot replace a saved allowance", %{conversation: conversation} do
+    allowance = insert_allowance(conversation.id)
+
+    assert {:error, changeset} =
+             conversation.id |> Allowance.new_changeset(nil) |> Repo.insert()
+
+    assert errors_on(changeset).conversation_id == ["has already been taken"]
+    assert Repo.reload!(allowance) == allowance
+  end
+
+  test "requires an existing conversation" do
+    assert {:error, changeset} =
+             Ecto.UUID.generate() |> Allowance.new_changeset(%{}) |> Repo.insert()
+
+    assert errors_on(changeset).conversation_id == ["does not exist"]
+  end
+
+  test "malformed limits cannot be saved", %{conversation: conversation} do
+    for limits <- [%{max_model_turns: 0}, %{wall_time_seconds: nil}, %{revision: "override"}] do
+      assert {:error, changeset} =
+               conversation.id |> Allowance.new_changeset(limits) |> Repo.insert()
+
+      assert errors_on(changeset).limits != []
+    end
+
+    assert Repo.get(Allowance, conversation.id) == nil
+  end
+
+  test "partial narrowing retains omitted fields and advances the revision", %{
+    conversation: conversation
+  } do
+    allowance = insert_allowance(conversation.id)
+
+    updated =
+      allowance |> Allowance.narrow_changeset(%{max_model_turns: 3}) |> Repo.update!()
+
+    assert updated.limits == %{"max_model_turns" => 3, "wall_time_seconds" => 60}
+    refute updated.revision == allowance.revision
+
+    for request <- [nil, %{}] do
+      updated = Repo.reload!(updated) |> Allowance.narrow_changeset(request) |> Repo.update!()
+      assert updated.limits == %{"max_model_turns" => 3, "wall_time_seconds" => 60}
+    end
+  end
+
+  test "widening or clearing a field is refused", %{conversation: conversation} do
+    allowance = insert_allowance(conversation.id)
+
+    for request <- [%{max_model_turns: 11}, %{wall_time_seconds: nil}] do
+      assert {:error, changeset} =
+               allowance |> Allowance.narrow_changeset(request) |> Repo.update()
+
+      assert errors_on(changeset).limits != []
+      assert Repo.reload!(allowance) == allowance
+    end
+  end
+
+  test "stale narrowing cannot overwrite a tighter stored value", %{conversation: conversation} do
+    stale = insert_allowance(conversation.id)
+    winner = stale |> Allowance.narrow_changeset(%{max_model_turns: 2}) |> Repo.update!()
+
+    assert_raise Ecto.StaleEntryError, fn ->
+      stale |> Allowance.narrow_changeset(%{max_model_turns: 5}) |> Repo.update!()
+    end
+
+    assert Repo.reload!(stale) == winner
+  end
+
+  test "stale omission cannot restore another field's old allowance", %{
+    conversation: conversation
+  } do
+    stale = insert_allowance(conversation.id)
+    winner = stale |> Allowance.narrow_changeset(%{wall_time_seconds: 10}) |> Repo.update!()
+
+    assert {:error, changeset} =
+             stale
+             |> Allowance.narrow_changeset(%{max_model_turns: 2})
+             |> Repo.update(stale_error_field: :revision)
+
+    assert errors_on(changeset).revision == ["is stale"]
+    assert Repo.reload!(stale) == winner
+
+    revalidated =
+      Repo.reload!(stale) |> Allowance.narrow_changeset(%{max_model_turns: 2}) |> Repo.update!()
+
+    assert revalidated.limits == %{"max_model_turns" => 2, "wall_time_seconds" => 10}
+  end
+
+  test "ordinary conversation updates cannot touch the separate allowance", %{
+    conversation: conversation
+  } do
+    allowance = insert_allowance(conversation.id)
+
+    assert {:ok, _} =
+             Fountain.Conversations.update_conversation(conversation, %{title: "renamed"})
+
+    assert Repo.reload!(allowance) == allowance
+  end
+
+  test "conversation deletion removes only its own allowance", %{conversation: conversation} do
+    allowance = insert_allowance(conversation.id)
+    other = insert_conversation() |> Map.fetch!(:id) |> insert_allowance()
+    Repo.delete!(conversation)
+    assert Repo.get(Allowance, allowance.conversation_id) == nil
+    assert Repo.reload!(other) == other
+  end
+
+  defp insert_allowance(conversation_id) do
+    conversation_id
+    |> Allowance.new_changeset(%{max_model_turns: 10, wall_time_seconds: 60})
+    |> Repo.insert!()
+  end
+end
+
+defmodule Fountain.Conversations.ExecutionAllowanceRaceTest do
+  use ExUnit.Case, async: false
+
+  alias Fountain.Repo
+  alias Fountain.Conversations.Sandbox
+  alias Fountain.Conversations.ExecutionAllowance, as: Allowance
+  import Fountain.DataCase, only: [errors_on: 1]
+  import Fountain.Factory, only: [insert_conversation: 1]
+
+  test "a writer blocked on another connection cannot restore a wider allowance" do
+    Ecto.Adapters.SQL.Sandbox.unboxed_run(Repo, fn ->
+      # These rows must be committed: sharing the test's sandbox connection would
+      # serialize the queries in Elixir and never exercise PostgreSQL contention.
+      {:ok, {user, allowance, sandbox_id}} =
+        Repo.transaction(fn ->
+          user =
+            Repo.insert!(%Fountain.Accounts.User{
+              email: "allowance-race-#{Ecto.UUID.generate()}@example.test"
+            })
+
+          conversation = insert_conversation(user_id: user.id)
+          {user, insert_allowance(conversation.id), conversation.sandbox_id}
+        end)
+
+      owner = self()
+
+      winner =
+        independent_writer(fn ->
+          Repo.transaction(fn ->
+            updated =
+              allowance |> Allowance.narrow_changeset(%{max_model_turns: 2}) |> Repo.update!()
+
+            send(owner, :narrowed)
+
+            receive do
+              :commit -> updated
+            after
+              5_000 -> raise "commit barrier timed out"
+            end
+          end)
+        end)
+
+      try do
+        assert_receive :narrowed, 5_000
+
+        loser =
+          independent_writer(fn ->
+            allowance
+            |> Allowance.narrow_changeset(%{max_model_turns: 5})
+            |> Repo.update(stale_error_field: :revision)
+          end)
+
+        try do
+          assert_receive {:backend, winner_pid, winner_backend}, 5_000
+          assert winner_pid == winner.pid
+          assert_receive {:backend, loser_pid, loser_backend}, 5_000
+          assert loser_pid == loser.pid
+          refute winner_backend == loser_backend
+          await_blocked(loser_backend, System.monotonic_time(:millisecond) + 5_000)
+          send(winner.pid, :commit)
+          assert {:ok, updated} = Task.await(winner)
+          assert {:error, changeset} = Task.await(loser)
+          assert errors_on(changeset).revision == ["is stale"]
+          assert Repo.reload!(allowance) == updated
+          assert updated.limits["max_model_turns"] == 2
+        after
+          Task.shutdown(loser, :brutal_kill)
+        end
+      after
+        Task.shutdown(winner, :brutal_kill)
+        Repo.delete!(user)
+        Repo.get!(Sandbox, sandbox_id) |> Repo.delete!()
+        assert Repo.get(Allowance, allowance.conversation_id) == nil
+        assert Repo.get(Sandbox, sandbox_id) == nil
+      end
+    end)
+  end
+
+  defp independent_writer(fun) do
+    owner = self()
+
+    Task.async(fn ->
+      Ecto.Adapters.SQL.Sandbox.unboxed_run(Repo, fn ->
+        %{rows: [[backend]]} = Repo.query!("SELECT pg_backend_pid()")
+        send(owner, {:backend, self(), backend})
+        fun.()
+      end)
+    end)
+  end
+
+  defp await_blocked(backend, deadline) do
+    %{rows: [[blocked]]} = Repo.query!("SELECT cardinality(pg_blocking_pids($1)) > 0", [backend])
+
+    unless blocked do
+      assert System.monotonic_time(:millisecond) < deadline, "no PostgreSQL lock wait observed"
+      Process.sleep(5)
+      await_blocked(backend, deadline)
+    end
+  end
+
+  defp insert_allowance(conversation_id) do
+    conversation_id
+    |> Allowance.new_changeset(%{max_model_turns: 10, wall_time_seconds: 60})
+    |> Repo.insert!()
+  end
+end


### PR DESCRIPTION
Store each conversation's resolved allowance separately from ordinary conversation metadata. Partial updates retain omitted controls; widening fails; revision checks reject stale writes. A second database writer cannot replace a committed tighter allowance. Duplicate inserts fail, and rollback refuses to discard saved allowances.

Storage primitive only: this adds no user setting, endpoint, admission caller or runtime enforcement. Based on #1773; a focused replacement for part of #1745/#1754. Tenant-scoped admission and later-turn/recovery integration remain in #1732, alongside the requested-limit refusal in #1774.

Validation: 46 affected tests passed, including separate PostgreSQL connections with an observed lock wait. Removing revision checking produces four regression failures. Empty migration down/up passed; occupied rollback preserved both the allowance and migration version. The first full run caught retained test sandboxes; cleanup now removes them explicitly and asserts their absence. Full precommit passed 4,719 tests and six doctests; the dedicated database was empty afterward. Secret scanning passed. [CI passed](https://github.com/BinaryBourbon/fountain/actions/runs/34331964389) on `241d884f`. No provider calls or live execution-limit acceptance.
