### PR TITLE
fix: refuse unsupported saved allowances before wake

### DIFF
--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -2993,11 +2993,19 @@ defmodule Fountain.Conversations do
   (`terminated`, `failed`) — those don't auto-resume.
   """
   def wake_conversation(conv_id, initial_prompt \\ nil) do
-    # Ownership: called from ConversationServer (which established ownership
-    # before starting) and the boot-time rehydrator sweep. The agent fetched
-    # below is the conversation's own agent_id, same tenant by construction.
+    wake_conversation_for(conv_id, initial_prompt, :work)
+  end
+
+  defp wake_conversation_for(conv_id, initial_prompt, purpose) do
+    # Ownership is established by callers before reaching this internal wake
+    # path. The agent fetched below is the conversation's own agent_id,
+    # same tenant by construction.
     with %Conversation{} = conv <- _unsafe_get_conversation(conv_id) || {:error, :not_found},
          :ok <- assert_resumable(conv),
+         # Preflight only: no database lock spans provider I/O. Turn admission
+         # checks again under its transaction. Cancellation must remain reachable.
+         :ok <-
+           if(purpose == :interrupt, do: :ok, else: check_saved_execution_allowance(conv.id)),
          %Agents.Agent{} = agent <-
            (conv.agent_id && Agents._unsafe_get_agent(conv.agent_id)) || {:error, :no_agent},
          {:ok, runtime_module} <- Fountain.RuntimeDispatch.for_agent(conv) do
@@ -3104,7 +3112,7 @@ defmodule Fountain.Conversations do
         {:error, :not_found}
 
       %Conversation{status: "running"} ->
-        with {:ok, conv} <- wake_conversation(conv_id),
+        with {:ok, conv} <- wake_conversation_for(conv_id, nil, :interrupt),
              pid when is_pid(pid) <- ConversationServer.whereis(conv.id) do
           {:ok, pid}
         else

--- a/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
@@ -15,6 +15,24 @@ defmodule FountainWeb.FallbackController do
     |> json(%{error: "not_found"})
   end
 
+  def call(conn, {:error, {:execution_limits_invalid, field}}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{
+      error: "execution_limits_invalid",
+      errors: %{execution_limits: ["invalid #{field}"]}
+    })
+  end
+
+  def call(conn, {:error, {:execution_limits_unsupported, controls}}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{
+      error: "execution_limits_unsupported",
+      message: "Execution-limit enforcement is unavailable: #{Enum.join(controls, ", ")}."
+    })
+  end
+
   # start_conversation rejects an unknown / cross-tenant vault by returning
   # {:error, :vault_not_found}. Surface as 404 so callers can't tell the
   # difference between "no such vault" and "vault belongs to someone else".

--- a/apps/fountain/test/fountain_web/controllers/saved_allowance_wake_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/saved_allowance_wake_test.exs
@@ -1,0 +1,176 @@
+defmodule FountainWeb.SavedAllowanceWakeTest do
+  use FountainWeb.ConnCase, async: true
+  use Mimic
+
+  alias Fountain.{Conversations, Repo}
+  alias Fountain.Conversations.{ConversationServer, ExecutionAllowance, Sandbox}
+
+  setup do
+    user = insert_verified_user()
+    agent = insert_agent(user_id: user.id)
+    {_key, raw} = insert_api_key(user)
+    owner = self()
+
+    stub(Managoat.Sandbox.Sprites, :get, fn handle ->
+      send(owner, :provider_probe)
+      {:ok, %{status: :running, raw: %{name: handle.name}}}
+    end)
+
+    stub(Managoat.Sandbox.Sprites, :resume, fn handle ->
+      send(owner, :provider_resume)
+      {:ok, handle}
+    end)
+
+    stub(Horde.DynamicSupervisor, :start_child, fn _, _ ->
+      send(owner, :worker_start)
+      {:ok, owner}
+    end)
+
+    stub(ConversationServer, :queue_initial_prompt, fn _, _ ->
+      send(owner, :prompt_queued)
+      :ok
+    end)
+
+    %{user: user, agent: agent, raw: raw}
+  end
+
+  for status <- ~w(ready suspended pending starting terminated failed) do
+    test "saved limits refuse a #{status} sandbox wake before side effects", ctx do
+      sandbox = insert_sandbox(user_id: ctx.user.id, status: unquote(status))
+      conv = conversation(ctx, sandbox) |> Repo.reload!()
+      save(conv, %{max_model_turns: 2})
+      count = Repo.aggregate(Sandbox, :count)
+
+      for prompt <- [nil, "continue"] do
+        assert {:error, {:execution_limits_unsupported, ["max_model_turns"]}} =
+                 Conversations.wake_conversation(conv.id, prompt)
+      end
+
+      assert Repo.reload!(conv) == conv
+      assert Repo.reload!(sandbox) == sandbox
+      assert Repo.aggregate(Sandbox, :count) == count
+      assert Conversations._unsafe_list_turns(conv.id) == []
+      refute_side_effects()
+    end
+  end
+
+  test "the prompt API reports 422 instead of queueing a dormant conversation", ctx do
+    conv = conversation(ctx, insert_sandbox(user_id: ctx.user.id, status: "ready"))
+    save(conv, %{wall_time_seconds: 30})
+
+    body =
+      ctx.conn
+      |> authed_with_key(ctx.raw)
+      |> post_json("/api/conversations/#{conv.id}/prompts", %{prompt: "continue"})
+      |> json_response(422)
+
+    assert body["error"] == "execution_limits_unsupported"
+    assert body["message"] =~ "wall_time_seconds"
+    refute_side_effects()
+  end
+
+  test "malformed saved policy returns a safe 422", ctx do
+    conv = conversation(ctx, insert_sandbox(user_id: ctx.user.id, status: "ready"))
+    allowance = save(conv, %{})
+
+    allowance
+    |> Ecto.Changeset.change(limits: %{"private-value" => "do not echo"})
+    |> Repo.update!()
+
+    body =
+      ctx.conn
+      |> authed_with_key(ctx.raw)
+      |> post_json("/api/conversations/#{conv.id}/prompts", %{prompt: "continue"})
+      |> json_response(422)
+
+    assert body == %{
+             "error" => "execution_limits_invalid",
+             "errors" => %{"execution_limits" => ["invalid unknown_field"]}
+           }
+
+    refute_side_effects()
+  end
+
+  test "another tenant's conversation remains a 404", ctx do
+    other = insert_conversation()
+    save(other, %{max_model_turns: 2})
+
+    ctx.conn
+    |> authed_with_key(ctx.raw)
+    |> post_json("/api/conversations/#{other.id}/prompts", %{prompt: "continue"})
+    |> json_response(404)
+
+    refute_side_effects()
+  end
+
+  test "absent and empty allowances still wake and queue the prompt", ctx do
+    for limits <- [:absent, %{}] do
+      conv = conversation(ctx, insert_sandbox(user_id: ctx.user.id, status: "ready"))
+      if limits != :absent, do: save(conv, limits)
+      assert {:ok, _} = Conversations.wake_conversation(conv.id, "continue")
+      assert_received :provider_probe
+      assert_received :worker_start
+      assert_received :prompt_queued
+    end
+  end
+
+  test "a saved limit does not prevent reconnecting to interrupt a running turn", ctx do
+    conv = conversation(ctx, insert_sandbox(user_id: ctx.user.id, status: "ready"))
+    conv = conv |> Ecto.Changeset.change(status: "running") |> Repo.update!()
+    save(conv, %{max_model_turns: 2})
+    owner = self()
+
+    peer =
+      spawn(fn ->
+        receive do
+          {:"$gen_call", from, :interrupt} ->
+            send(owner, :interrupted)
+            GenServer.reply(from, :ok)
+        end
+      end)
+
+    on_exit(fn -> Process.exit(peer, :kill) end)
+    stub(Horde.DynamicSupervisor, :start_child, fn _, _ -> {:ok, peer} end)
+
+    expect(Horde.Registry, :lookup, fn Fountain.ConversationRegistry, id ->
+      assert id == conv.id
+      []
+    end)
+
+    expect(Horde.Registry, :lookup, fn Fountain.ConversationRegistry, id ->
+      assert id == conv.id
+      [{peer, nil}]
+    end)
+
+    assert :ok = ConversationServer.interrupt(conv.id)
+    assert_received :interrupted
+    assert_received :provider_probe
+    refute_received :prompt_queued
+  end
+
+  test "cancellation does not wake an idle conversation", ctx do
+    conv = conversation(ctx, insert_sandbox(user_id: ctx.user.id, status: "ready"))
+    save(conv, %{max_model_turns: 2})
+    assert {:error, :not_running} = Conversations.wake_for_interrupt(conv.id)
+    refute_side_effects()
+  end
+
+  defp conversation(ctx, sandbox),
+    do:
+      insert_conversation(
+        user_id: ctx.user.id,
+        agent: ctx.agent,
+        sandbox: sandbox,
+        status: "idle"
+      )
+
+  defp save(conv, limits),
+    do: conv.id |> ExecutionAllowance.new_changeset(limits) |> Repo.insert!()
+
+  defp refute_side_effects do
+    refute_received :provider_probe
+    refute_received :provider_resume
+    refute_received :worker_start
+    refute_received :prompt_queued
+  end
+end


### PR DESCRIPTION
A dormant conversation with an unsupported saved allowance could probe/resume a provider, start a worker and queue a prompt before turn admission refused it. Check the saved allowance first; prompt-triggered wake returns HTTP 422 without those effects. Missing or empty allowances retain ordinary behavior. Reconnecting to interrupt an existing running turn remains available, without a new prompt.

Stacked on #1776 (`fix/saved-allowance-turn-admission`). The two fallback clauses are reused **identically** from sibling #1774; no other sibling changes are imported. Focused replacement for part of #1745/#1754, tracked in #1732.

Validation: 12 new tests, including six sandbox states, real HTTP responses, tenant isolation and cancellation; eight fail against the parent. All 182 related tests pass. Full precommit passes 4,742 tests plus six doctests, zero failures; diff secret scan passes.

This is a preflight, not a lock held across provider operations; #1776 rechecks within turn admission. Active-server prompt admission, channel reuse, direct boot recovery, allowance saving/current ceilings and runtime enforcement remain separate. No new execution controls are enabled, and this is not live enforcement acceptance.
