### PR TITLE
fix: refuse saved limits before active prompt handoff

### DIFF
--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -1129,7 +1129,7 @@ defmodule Fountain.Conversations do
 
         unless attached?, do: Repo.rollback(:sandbox_unavailable)
 
-        case check_saved_execution_allowance(conv_id) do
+        case _unsafe_check_saved_execution_allowance(conv_id) do
           :ok -> :ok
           {:error, reason} -> Repo.rollback(reason)
         end
@@ -1151,7 +1151,12 @@ defmodule Fountain.Conversations do
     end
   end
 
-  defp check_saved_execution_allowance(conversation_id) do
+  @doc """
+  Refuse saved allowances that this deployment cannot enforce. Internal callers
+  must establish conversation ownership first. Outside turn admission this is
+  only a preflight; the turn transaction rechecks under its row locks.
+  """
+  def _unsafe_check_saved_execution_allowance(conversation_id) do
     case Repo.one(
            from a in ExecutionAllowance,
              where: a.conversation_id == ^conversation_id,
@@ -3005,7 +3010,11 @@ defmodule Fountain.Conversations do
          # Preflight only: no database lock spans provider I/O. Turn admission
          # checks again under its transaction. Cancellation must remain reachable.
          :ok <-
-           if(purpose == :interrupt, do: :ok, else: check_saved_execution_allowance(conv.id)),
+           if(purpose == :interrupt,
+             do: :ok,
+             else: _unsafe_check_saved_execution_allowance(conv.id)
+           ),
+         # Ownership: conv.agent_id belongs to this established-owner conversation.
          %Agents.Agent{} = agent <-
            (conv.agent_id && Agents._unsafe_get_agent(conv.agent_id)) || {:error, :no_agent},
          {:ok, runtime_module} <- Fountain.RuntimeDispatch.for_agent(conv) do

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -1506,15 +1506,14 @@ defmodule Fountain.Conversations.ConversationServer do
     if Connection.user_turn_running?(state.current_turn) do
       {:reply, {:error, :busy}, state}
     else
-      # A background cycle the agent was still narrating is closed by the
-      # human's prompt, not queued behind it (#817): its updates are already
-      # on the transcript, and the agent will fold whatever it was doing into
-      # the answer to this prompt.
-      state = close_autonomous_turn(state, "superseded_by_prompt")
+      # This server already owns the conversation. Refuse before superseding
+      # autonomous work or touching its connection; turn admission rechecks.
       conv = Conversations._unsafe_get_conversation!(state.conversation_id)
 
-      with :ok <- TurnMachine.gate(conv.user_id, state.inference_source),
+      with :ok <- Conversations._unsafe_check_saved_execution_allowance(conv.id),
+           :ok <- TurnMachine.gate(conv.user_id, state.inference_source),
            :ok <- TurnMachine.capacity_gate(state.sandbox_id, conv) do
+        state = close_autonomous_turn(state, "superseded_by_prompt")
         agent = if conv.agent_id, do: Agents._unsafe_get_agent!(conv.agent_id)
         {:reply, :ok, kick_turn(state, prompt, agent, images)}
       else

--- a/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
@@ -404,6 +404,112 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
       assert length(Conversations._unsafe_list_turns(conv.id)) == 2
     end
 
+    for active <- [false, true], malformed <- [false, true] do
+      test "saved policy refusal preserves active=#{active}, malformed=#{malformed}", ctx do
+        prompt_id = drive_to_prompt(ctx.pid, ctx.ref)
+        reply(ctx.pid, ctx.ref, prompt_id, %{"stopReason" => "end_turn"})
+
+        if unquote(active) do
+          notify(ctx.pid, ctx.ref, %{
+            "sessionUpdate" => "agent_message_chunk",
+            "text" => "working"
+          })
+
+          assert :sys.get_state(ctx.pid).current_turn.origin == "autonomous"
+        end
+
+        allowance =
+          ctx.conv.id
+          |> Fountain.Conversations.ExecutionAllowance.new_changeset(%{max_model_turns: 2})
+          |> Fountain.Repo.insert!()
+
+        if unquote(malformed) do
+          allowance
+          |> Ecto.Changeset.change(limits: %{"private-field" => "do not echo"})
+          |> Fountain.Repo.update!()
+        end
+
+        before = :sys.get_state(ctx.pid)
+        turns = Conversations._unsafe_list_turns(ctx.conv.id)
+        conv = Fountain.Repo.reload!(ctx.conv)
+        usage_count = Fountain.Repo.aggregate(Fountain.Billing.UsageEvent, :count)
+        {_key, raw} = insert_api_key(Fountain.Accounts.get_user!(ctx.conv.user_id))
+
+        expect(Horde.Registry, :lookup, fn Fountain.ConversationRegistry, id ->
+          assert id == ctx.conv.id
+          [{ctx.pid, nil}]
+        end)
+
+        response =
+          Phoenix.ConnTest.build_conn()
+          |> FountainWeb.ConnCase.authed_with_key(raw)
+          |> FountainWeb.ConnCase.post_json("/api/conversations/#{ctx.conv.id}/prompts", %{
+            prompt: "continue"
+          })
+          |> Phoenix.ConnTest.json_response(422)
+
+        if unquote(malformed) do
+          assert response == %{
+                   "error" => "execution_limits_invalid",
+                   "errors" => %{"execution_limits" => ["invalid unknown_field"]}
+                 }
+        else
+          assert response["error"] == "execution_limits_unsupported"
+          assert response["message"] =~ "max_model_turns"
+        end
+
+        assert FountainWeb.SchemaGuard.take(self()) == []
+        assert :sys.get_state(ctx.pid) == before
+        assert Conversations._unsafe_list_turns(ctx.conv.id) == turns
+        assert Fountain.Repo.reload!(ctx.conv) == conv
+        assert Fountain.Repo.aggregate(Fountain.Billing.UsageEvent, :count) == usage_count
+        refute_received :stdin_closed
+        refute_received {:wrote, _}
+
+        if unquote(active) do
+          assert :ok = GenServer.call(ctx.pid, :interrupt)
+          assert is_nil(:sys.get_state(ctx.pid).current_turn)
+          assert List.last(Conversations._unsafe_list_turns(ctx.conv.id)).status == "interrupted"
+        end
+      end
+    end
+
+    test "empty saved policy still supersedes autonomous work on the same connection", ctx do
+      prompt_id = drive_to_prompt(ctx.pid, ctx.ref)
+      reply(ctx.pid, ctx.ref, prompt_id, %{"stopReason" => "end_turn"})
+      notify(ctx.pid, ctx.ref, %{"sessionUpdate" => "agent_message_chunk", "text" => "working"})
+      peer = :sys.get_state(ctx.pid).acp_peer
+
+      ctx.conv.id
+      |> Fountain.Conversations.ExecutionAllowance.new_changeset(%{})
+      |> Fountain.Repo.insert!()
+
+      assert :ok = GenServer.call(ctx.pid, {:send_prompt, "again", []})
+      assert :sys.get_state(ctx.pid).acp_peer == peer
+
+      assert [
+               %{status: "completed"},
+               %{origin: "autonomous", status: "completed"},
+               %{origin: "user", status: "running"}
+             ] = Conversations._unsafe_list_turns(ctx.conv.id)
+
+      %{"method" => "session/set_model", "id" => set_id} = next_write()
+      reply(ctx.pid, ctx.ref, set_id, %{})
+      assert %{"method" => "session/prompt"} = next_write()
+    end
+
+    test "a running user turn remains busy under a saved limit", ctx do
+      drive_to_prompt(ctx.pid, ctx.ref)
+
+      ctx.conv.id
+      |> Fountain.Conversations.ExecutionAllowance.new_changeset(%{max_model_turns: 2})
+      |> Fountain.Repo.insert!()
+
+      before = :sys.get_state(ctx.pid)
+      assert {:error, :busy} = GenServer.call(ctx.pid, {:send_prompt, "again", []})
+      assert :sys.get_state(ctx.pid) == before
+    end
+
     test "an out-of-turn update opens an autonomous turn; cycle_end closes it (#817)", %{
       conv: conv,
       pid: pid,


### PR DESCRIPTION
When a prompt reaches an existing server, an unsupported saved allowance previously returned HTTP 200 `queued` after turn admission refused it. It could also complete autonomous work and close the connection. Check saved policy before superseding that work, returning HTTP 422 with the current state intact. Billing and capacity preflights also precede supersession; user-busy precedence and cancellation remain unchanged.

Stacked on #1777 (`fix/saved-allowance-wake-guard`). Reuses its saved-policy check and HTTP mapping. Focused replacement for #1745/#1754; tracked in #1732.

Validation: six new real-server regressions, including idle/autonomous HTTP refusals for unsupported/malformed policy, unchanged turns/usage/connection, cancellation, empty-policy handoff and busy-user behavior. Four reproduce `200 queued` on the parent. All 159 related tests pass. Full precommit passes 4,748 tests plus six doctests, zero failures; diff secret scan passes.

This is preflight: #1776 still rechecks inside turn admission if policy changes concurrently. It does not add an atomic prompt receipt, enforce running-turn limits or enable saved-policy writes. Initial prompt casts, channel reuse, direct boot recovery, ceilings and runtime enforcement remain separate; live enforcement acceptance is still required.
