### PR TITLE
fix: guard saved limits before queued prompt handoff

### DIFF
--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -1671,15 +1671,16 @@ defmodule Fountain.Conversations.ConversationServer do
     else
       conv = Conversations._unsafe_get_conversation!(state.conversation_id)
 
-      case TurnMachine.gate(conv.user_id, state.inference_source) do
-        :ok ->
-          state = close_autonomous_turn(state, "superseded_by_prompt")
-          agent = if conv.agent_id, do: Agents._unsafe_get_agent!(conv.agent_id)
-          {:noreply, kick_turn(state, prompt, agent, images)}
-
+      # Ownership: this server owns conv. Policy may have changed since wake.
+      with :ok <- Conversations._unsafe_check_saved_execution_allowance(conv.id),
+           :ok <- TurnMachine.gate(conv.user_id, state.inference_source) do
+        state = close_autonomous_turn(state, "superseded_by_prompt")
+        agent = if conv.agent_id, do: Agents._unsafe_get_agent!(conv.agent_id)
+        {:noreply, kick_turn(state, prompt, agent, images)}
+      else
         {:error, reason} ->
-          # No caller to reply to — the wake door reports the same refusal
-          # synchronously; this backstop only has to not run the turn.
+          # A cast has no caller to reply to. Preserve existing work and its
+          # connection when this queued prompt cannot be admitted.
           Logger.info(
             "conv #{state.conversation_id}: dropping initial prompt (#{inspect(reason)})"
           )

--- a/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
@@ -510,6 +510,90 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
       assert :sys.get_state(ctx.pid) == before
     end
 
+    for active <- [false, true], malformed <- [false, true] do
+      test "queued policy refusal preserves active=#{active}, malformed=#{malformed}", ctx do
+        prompt_id = drive_to_prompt(ctx.pid, ctx.ref)
+        reply(ctx.pid, ctx.ref, prompt_id, %{"stopReason" => "end_turn"})
+
+        if unquote(active) do
+          notify(ctx.pid, ctx.ref, %{
+            "sessionUpdate" => "agent_message_chunk",
+            "text" => "working"
+          })
+
+          assert :sys.get_state(ctx.pid).current_turn.origin == "autonomous"
+        end
+
+        allowance =
+          ctx.conv.id
+          |> Fountain.Conversations.ExecutionAllowance.new_changeset(%{max_model_turns: 2})
+          |> Fountain.Repo.insert!()
+
+        if unquote(malformed) do
+          allowance
+          |> Ecto.Changeset.change(limits: %{"private-field" => "do not echo"})
+          |> Fountain.Repo.update!()
+        end
+
+        before = :sys.get_state(ctx.pid)
+        turns = Conversations._unsafe_list_turns(ctx.conv.id)
+        conv = Fountain.Repo.reload!(ctx.conv)
+        usage_count = Fountain.Repo.aggregate(Fountain.Billing.UsageEvent, :count)
+
+        ConversationServer.queue_initial_prompt(ctx.pid, "queued")
+
+        # Same-sender mailbox ordering waits for the queued cast to finish.
+        assert :sys.get_state(ctx.pid) == before
+        assert Conversations._unsafe_list_turns(ctx.conv.id) == turns
+        assert Fountain.Repo.reload!(ctx.conv) == conv
+        assert Fountain.Repo.aggregate(Fountain.Billing.UsageEvent, :count) == usage_count
+        refute_received :stdin_closed
+        refute_received {:wrote, _}
+
+        if unquote(active) do
+          assert :ok = GenServer.call(ctx.pid, :interrupt)
+          assert is_nil(:sys.get_state(ctx.pid).current_turn)
+          assert List.last(Conversations._unsafe_list_turns(ctx.conv.id)).status == "interrupted"
+        end
+      end
+    end
+
+    test "an empty saved allowance permits queued handoff on the same connection", ctx do
+      prompt_id = drive_to_prompt(ctx.pid, ctx.ref)
+      reply(ctx.pid, ctx.ref, prompt_id, %{"stopReason" => "end_turn"})
+      notify(ctx.pid, ctx.ref, %{"sessionUpdate" => "agent_message_chunk", "text" => "working"})
+      peer = :sys.get_state(ctx.pid).acp_peer
+
+      ctx.conv.id
+      |> Fountain.Conversations.ExecutionAllowance.new_changeset(%{})
+      |> Fountain.Repo.insert!()
+
+      ConversationServer.queue_initial_prompt(ctx.pid, "queued")
+      assert :sys.get_state(ctx.pid).acp_peer == peer
+
+      assert [
+               %{status: "completed"},
+               %{origin: "autonomous", status: "completed"},
+               %{origin: "user", status: "running", prompt: "queued"}
+             ] = Conversations._unsafe_list_turns(ctx.conv.id)
+
+      %{"method" => "session/set_model", "id" => set_id} = next_write()
+      reply(ctx.pid, ctx.ref, set_id, %{})
+      assert %{"method" => "session/prompt"} = next_write()
+    end
+
+    test "a queued prompt leaves a running user turn alone under saved limits", ctx do
+      drive_to_prompt(ctx.pid, ctx.ref)
+
+      ctx.conv.id
+      |> Fountain.Conversations.ExecutionAllowance.new_changeset(%{max_model_turns: 2})
+      |> Fountain.Repo.insert!()
+
+      before = :sys.get_state(ctx.pid)
+      ConversationServer.queue_initial_prompt(ctx.pid, "queued")
+      assert :sys.get_state(ctx.pid) == before
+    end
+
     test "an out-of-turn update opens an autonomous turn; cycle_end closes it (#817)", %{
       conv: conv,
       pid: pid,


### PR DESCRIPTION
A queued initial prompt could complete autonomous work and close its connection before turn admission refused an unsupported saved allowance. Check saved policy when consuming the cast, before handoff; refusal preserves the current turn, connection, activity and usage. Cancellation and ordinary empty-policy handoff remain available.

Stacked on #1778 (`fix/saved-allowance-active-prompt`), reusing its policy helper. Focused replacement for part of #1745/#1754; tracked in #1732.

Validation: six new real-server tests cover idle/autonomous refusals for unsupported/malformed policy, cancellation, empty-policy handoff and busy-user preservation. Four fail against the parent. All 165 related tests pass. Full precommit passes 4,754 tests plus six doctests, zero failures; diff secret scan passes.

A cast has no synchronous caller response. This is preflight, with #1776's transactional recheck retained for intervening policy writes. It adds no atomic prompt receipt, retroactive enforcement, policy writer or runtime controls. Channel/boot admission, ceilings and live bounded-execution acceptance remain required.
