### PR TITLE
fix: refuse narrowing corrupt saved allowances

### DIFF
--- a/apps/fountain/lib/fountain/conversations/execution_allowance.ex
+++ b/apps/fountain/lib/fountain/conversations/execution_allowance.ex
@@ -12,6 +12,7 @@ defmodule Fountain.Conversations.ExecutionAllowance do
   Reload and revalidate the request after a conflict; never retry the old map as
   a replacement. An opaque revision avoids counter rollover accepting old writes.
   This record does not reset or replace an in-flight turn's deadline or usage.
+  A null saved policy is corrupt, not an unrestricted allowance to narrow.
   """
 
   use Ecto.Schema
@@ -39,11 +40,17 @@ defmodule Fountain.Conversations.ExecutionAllowance do
   end
 
   @doc "Narrow the saved allowance, retaining omitted fields and checking its revision."
-  def narrow_changeset(%__MODULE__{} = allowance, request) do
+  def narrow_changeset(%__MODULE__{limits: limits} = allowance, request) when is_map(limits) do
     allowance
     |> change()
     |> put_limits(ExecutionLimits.for_resume(nil, nil, allowance.limits, request))
     |> optimistic_lock(:revision, fn _ -> Ecto.UUID.generate() end)
+  end
+
+  def narrow_changeset(%__MODULE__{} = allowance, _request) do
+    allowance
+    |> change()
+    |> put_limits({:error, {:execution_limits_invalid, "object_required"}})
   end
 
   defp put_limits(changeset, {:ok, limits}), do: put_change(changeset, :limits, limits)

--- a/apps/fountain/test/fountain/conversations/execution_allowance_test.exs
+++ b/apps/fountain/test/fountain/conversations/execution_allowance_test.exs
@@ -71,6 +71,49 @@ defmodule Fountain.Conversations.ExecutionAllowanceTest do
     end
   end
 
+  test "narrowing cannot replace a saved JSON null with an unrestricted or fresh allowance", %{
+    conversation: conversation
+  } do
+    allowance = insert_allowance(conversation.id)
+
+    Repo.query!(
+      "UPDATE execution_allowances SET limits = 'null'::jsonb WHERE conversation_id = $1",
+      [Ecto.UUID.dump!(conversation.id)]
+    )
+
+    corrupt = Repo.reload!(allowance)
+    assert corrupt.limits == nil
+
+    for request <- [nil, %{}, %{max_model_turns: 2}] do
+      assert {:error, changeset} = corrupt |> Allowance.narrow_changeset(request) |> Repo.update()
+      assert errors_on(changeset).limits == ["execution_limits_invalid: object_required"]
+      assert Repo.reload!(corrupt) == corrupt
+    end
+  end
+
+  test "narrowing preserves malformed saved maps and does not expose their contents", %{
+    conversation: conversation
+  } do
+    corrupt =
+      insert_allowance(conversation.id)
+      |> Ecto.Changeset.change(limits: %{"private-field" => "private-value"})
+      |> Repo.update!()
+
+    for request <- [nil, %{}, %{max_model_turns: 2}] do
+      assert {:error, changeset} = corrupt |> Allowance.narrow_changeset(request) |> Repo.update()
+      assert errors_on(changeset).limits == ["execution_limits_invalid: unknown_field"]
+      assert Repo.reload!(corrupt) == corrupt
+    end
+  end
+
+  test "an explicitly empty saved allowance can still be narrowed", %{conversation: conversation} do
+    allowance = conversation.id |> Allowance.new_changeset(%{}) |> Repo.insert!()
+    updated = allowance |> Allowance.narrow_changeset(%{max_model_turns: 2}) |> Repo.update!()
+
+    assert updated.limits == %{"max_model_turns" => 2}
+    refute updated.revision == allowance.revision
+  end
+
   test "stale narrowing cannot overwrite a tighter stored value", %{conversation: conversation} do
     stale = insert_allowance(conversation.id)
     winner = stale |> Allowance.narrow_changeset(%{max_model_turns: 2}) |> Repo.update!()


### PR DESCRIPTION
Narrowing a saved JSON `null` allowance treated it as unrestricted: even an omitted request replaced it with `{}` and advanced its revision. Reject non-object saved policy before narrowing so corrupt limits, revision and timestamps remain unchanged. Explicitly empty allowances still narrow normally.

Stacked directly on #1775 (`feat/versioned-execution-allowances`); this storage repair does not need the later admission guards. Further extraction from #1745/#1754, tracked in #1732.

Validation: reproduced the JSON-null replacement on the parent. Three new database tests cover null and malformed saved policy, omitted/empty/nonempty requests, row preservation, normalized errors and valid empty-policy narrowing. All 32 allowance/policy tests pass, including the independent-connection PostgreSQL stale-writer race. Full precommit passed: 4,722 tests and 6 doctests, zero failures (2 skipped, 7 excluded).

No public policy writer or runtime control is enabled. Tenant-scoped saving, current-ceiling checks and live bounded-execution acceptance remain required.
