### PR TITLE
feat: narrow execution allowances by owner

### DIFF
--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -1152,6 +1152,72 @@ defmodule Fountain.Conversations do
   end
 
   @doc """
+  Narrow an existing allowance owned by `user_id`, retaining omitted controls.
+
+  This edits future policy only: it neither admits work nor resets an active
+  turn's usage/deadline. Initial allowance creation and current-ceiling checks
+  remain admission responsibilities. Missing and foreign records return the
+  same error. Concurrent writers revalidate against the latest locked value.
+  """
+  def narrow_execution_allowance(conversation_id, user_id, request, opts \\ []) do
+    result =
+      Repo.transaction(fn ->
+        # Keep ownership stable through the write; turn admission locks this
+        # conversation before its allowance too. No sandbox/provider work here.
+        Repo.one(
+          from c in Conversation,
+            where: c.id == ^conversation_id and c.user_id == ^user_id,
+            select: c.id,
+            lock: "FOR SHARE"
+        ) || Repo.rollback(:not_found)
+
+        allowance =
+          Repo.one(
+            from a in ExecutionAllowance,
+              where: a.conversation_id == ^conversation_id,
+              lock: "FOR UPDATE"
+          ) || Repo.rollback(:not_found)
+
+        unless is_map(allowance.limits),
+          do: Repo.rollback({:execution_limits_invalid, "object_required"})
+
+        changeset = ExecutionAllowance.narrow_changeset(allowance, request)
+
+        write =
+          if changeset.valid? and not Map.has_key?(changeset.changes, :limits),
+            do: {:ok, allowance},
+            else: Repo.update(changeset)
+
+        case write do
+          {:ok, updated} ->
+            changed =
+              Enum.filter(ExecutionLimits.keys(), &(updated.limits[&1] != allowance.limits[&1]))
+
+            {updated, changed}
+
+          {:error, changeset} ->
+            Repo.rollback(changeset)
+        end
+      end)
+
+    with {:ok, {updated, changed}} <- result do
+      if changed != [] do
+        Audit.record(%{
+          user_id: user_id,
+          action: "conversation.execution_allowance_narrowed",
+          resource_type: "conversation",
+          resource_id: conversation_id,
+          actor: Keyword.get(opts, :actor, "self"),
+          request_ip: Keyword.get(opts, :request_ip),
+          metadata: %{"changed" => changed}
+        })
+      end
+
+      {:ok, updated}
+    end
+  end
+
+  @doc """
   Refuse saved allowances that this deployment cannot enforce. Internal callers
   must establish conversation ownership first. Outside turn admission this is
   only a preflight; the turn transaction rechecks under its row locks.

--- a/apps/fountain/lib/fountain/conversations/execution_allowance.ex
+++ b/apps/fountain/lib/fountain/conversations/execution_allowance.ex
@@ -2,8 +2,9 @@ defmodule Fountain.Conversations.ExecutionAllowance do
   @moduledoc """
   Versioned storage for a conversation's resolved execution allowance.
 
-  This is a storage primitive, not an admission or enforcement API. No service
-  path writes these records yet. Admission must establish conversation ownership,
+  This is a storage primitive, not an admission or enforcement API. Use the
+  owner-scoped `Conversations.narrow_execution_allowance/3` for existing records.
+  Initial admission must establish conversation ownership,
   resolve current ceilings and prove runtime support before saving an allowance.
   Later turns and recovery must consult it before this becomes a usable setting.
 

--- a/apps/fountain/test/fountain/audit_guardrail_test.exs
+++ b/apps/fountain/test/fountain/audit_guardrail_test.exs
@@ -57,6 +57,8 @@ defmodule Fountain.AuditGuardrailTest do
     {"inference credential clear", &__MODULE__.do_cred_clear/1, "inference_credential.delete"},
     {"conversation delete", &__MODULE__.do_conv_delete/1, "conversation.deleted"},
     {"conversation caller tools", &__MODULE__.do_caller_tools/1, "conversation.caller_tools_set"},
+    {"allowance narrowing", &__MODULE__.do_allowance_narrowing/1,
+     "conversation.execution_allowance_narrowed"},
     {"sandbox reset", &__MODULE__.do_sandbox_reset/1, "sandbox.reset"},
     {"role change", &__MODULE__.do_role_change/1, "account.role_changed"},
     {"sandbox limit change", &__MODULE__.do_limit_change/1, "account.sandbox_limit_changed"},
@@ -386,6 +388,16 @@ defmodule Fountain.AuditGuardrailTest do
     sandbox = insert_sandbox(user_id: user.id, status: "ready")
     conv = insert_conversation(user_id: user.id, agent: agent, sandbox_id: sandbox.id)
     {:ok, _} = Conversations.delete_conversation(conv)
+  end
+
+  def do_allowance_narrowing(user) do
+    conv = insert_conversation(user_id: user.id)
+
+    conv.id
+    |> Fountain.Conversations.ExecutionAllowance.new_changeset(%{max_model_turns: 10})
+    |> Repo.insert!()
+
+    {:ok, _} = Conversations.narrow_execution_allowance(conv.id, user.id, %{max_model_turns: 2})
   end
 
   def do_caller_tools(user) do

--- a/apps/fountain/test/fountain/conversations/execution_allowance_test.exs
+++ b/apps/fountain/test/fountain/conversations/execution_allowance_test.exs
@@ -1,6 +1,7 @@
 defmodule Fountain.Conversations.ExecutionAllowanceTest do
   use Fountain.DataCase, async: true
 
+  alias Fountain.Conversations
   alias Fountain.Conversations.ExecutionAllowance, as: Allowance
 
   setup do
@@ -121,6 +122,123 @@ defmodule Fountain.Conversations.ExecutionAllowanceTest do
     assert Repo.reload!(other) == other
   end
 
+  test "scoped narrowing hides foreign and missing records before validating requests", %{
+    conversation: conv
+  } do
+    allowance = insert_allowance(conv.id)
+    other = insert_conversation()
+
+    for request <- [%{max_model_turns: 2}, %{"private-field" => "private-value"}] do
+      for {id, user_id} <- [
+            {conv.id, other.user_id},
+            {Ecto.UUID.generate(), conv.user_id},
+            {other.id, other.user_id}
+          ] do
+        assert Conversations.narrow_execution_allowance(id, user_id, request) ==
+                 {:error, :not_found}
+      end
+    end
+
+    assert Repo.reload!(allowance) == allowance
+    assert Repo.get(Allowance, other.id) == nil
+    assert allowance_events(conv) == []
+  end
+
+  test "scoped narrowing retains omitted fields without touching active work", %{
+    conversation: conv
+  } do
+    before = Repo.reload!(conv)
+    allowance = insert_allowance(conv.id)
+    turn = insert_turn(conv, status: "running")
+    sandbox = Repo.reload!(conv.sandbox)
+    other = insert_conversation() |> Map.fetch!(:id) |> insert_allowance()
+
+    assert {:ok, narrowed} =
+             Conversations.narrow_execution_allowance(
+               conv.id,
+               conv.user_id,
+               %{max_model_turns: 2},
+               actor: "api",
+               request_ip: "192.0.2.1"
+             )
+
+    assert narrowed.limits == %{"max_model_turns" => 2, "wall_time_seconds" => 60}
+    refute narrowed.revision == allowance.revision
+
+    for request <- [nil, %{}] do
+      assert {:ok, updated} =
+               Conversations.narrow_execution_allowance(conv.id, conv.user_id, request)
+
+      assert updated == narrowed
+    end
+
+    assert Repo.reload!(conv) == before
+    assert Repo.reload!(turn) == turn
+    assert Repo.reload!(sandbox) == sandbox
+    assert Repo.reload!(other) == other
+    assert [event] = allowance_events(conv)
+    assert event.user_id == conv.user_id
+    assert event.actor == "api"
+    assert event.request_ip == "192.0.2.1"
+    assert event.metadata == %{"changed" => ["max_model_turns"]}
+  end
+
+  test "scoped narrowing rejects wider, cleared and malformed requests", %{conversation: conv} do
+    allowance = insert_allowance(conv.id)
+
+    for request <- [%{max_model_turns: 11}, %{wall_time_seconds: nil}, %{unknown: 2}] do
+      assert {:error, changeset} =
+               Conversations.narrow_execution_allowance(conv.id, conv.user_id, request)
+
+      assert errors_on(changeset).limits != []
+      assert Repo.reload!(allowance) == allowance
+    end
+
+    assert allowance_events(conv) == []
+  end
+
+  test "scoped narrowing cannot erase corrupt saved policy", %{conversation: conv} do
+    allowance = insert_allowance(conv.id)
+
+    Repo.query!(
+      "UPDATE execution_allowances SET limits = 'null'::jsonb WHERE conversation_id = $1",
+      [Ecto.UUID.dump!(conv.id)]
+    )
+
+    corrupt = Repo.reload!(allowance)
+
+    for request <- [nil, %{}, %{max_model_turns: 2}] do
+      assert Conversations.narrow_execution_allowance(conv.id, conv.user_id, request) ==
+               {:error, {:execution_limits_invalid, "object_required"}}
+
+      assert Repo.reload!(corrupt) == corrupt
+    end
+
+    assert allowance_events(conv) == []
+  end
+
+  test "narrowing an empty policy does not admit an unsupported turn", %{conversation: conv} do
+    conv.id |> Allowance.new_changeset(%{}) |> Repo.insert!()
+
+    assert {:ok, allowance} =
+             Conversations.narrow_execution_allowance(conv.id, conv.user_id, %{max_model_turns: 2})
+
+    assert {:error, {:execution_limits_unsupported, ["max_model_turns"]}} =
+             Fountain.Conversations.TurnMachine.open(conv.id, conv.sandbox_id, "refused")
+
+    assert Repo.reload!(allowance).limits == %{"max_model_turns" => 2}
+    assert Conversations._unsafe_list_turns(conv.id) == []
+    refute Repo.exists?(from e in Fountain.Billing.UsageEvent, where: e.user_id == ^conv.user_id)
+  end
+
+  defp allowance_events(conv),
+    do:
+      Repo.all(
+        from e in Fountain.Audit.Event,
+          where:
+            e.resource_id == ^conv.id and e.action == "conversation.execution_allowance_narrowed"
+      )
+
   defp insert_allowance(conversation_id) do
     conversation_id
     |> Allowance.new_changeset(%{max_model_turns: 10, wall_time_seconds: 60})
@@ -132,12 +250,26 @@ defmodule Fountain.Conversations.ExecutionAllowanceRaceTest do
   use ExUnit.Case, async: false
 
   alias Fountain.Repo
+  alias Fountain.Conversations
   alias Fountain.Conversations.Sandbox
   alias Fountain.Conversations.ExecutionAllowance, as: Allowance
   import Fountain.DataCase, only: [errors_on: 1]
   import Fountain.Factory, only: [insert_conversation: 1]
+  import Ecto.Query, only: [from: 2]
 
   test "a writer blocked on another connection cannot restore a wider allowance" do
+    race(:stale)
+  end
+
+  test "a scoped writer revalidates widening after a concurrent narrowing commits" do
+    race(:widen)
+  end
+
+  test "concurrent scoped writers retain each other's tighter fields" do
+    race(:disjoint)
+  end
+
+  defp race(mode) do
     Ecto.Adapters.SQL.Sandbox.unboxed_run(Repo, fn ->
       # These rows must be committed: sharing the test's sandbox connection would
       # serialize the queries in Elixir and never exercise PostgreSQL contention.
@@ -158,7 +290,16 @@ defmodule Fountain.Conversations.ExecutionAllowanceRaceTest do
         independent_writer(fn ->
           Repo.transaction(fn ->
             updated =
-              allowance |> Allowance.narrow_changeset(%{max_model_turns: 2}) |> Repo.update!()
+              if mode == :stale do
+                allowance |> Allowance.narrow_changeset(%{max_model_turns: 2}) |> Repo.update!()
+              else
+                {:ok, updated} =
+                  Conversations.narrow_execution_allowance(allowance.conversation_id, user.id, %{
+                    max_model_turns: 2
+                  })
+
+                updated
+              end
 
             send(owner, :narrowed)
 
@@ -175,9 +316,20 @@ defmodule Fountain.Conversations.ExecutionAllowanceRaceTest do
 
         loser =
           independent_writer(fn ->
-            allowance
-            |> Allowance.narrow_changeset(%{max_model_turns: 5})
-            |> Repo.update(stale_error_field: :revision)
+            if mode == :stale do
+              allowance
+              |> Allowance.narrow_changeset(%{max_model_turns: 5})
+              |> Repo.update(stale_error_field: :revision)
+            else
+              request =
+                if mode == :widen, do: %{max_model_turns: 5}, else: %{wall_time_seconds: 10}
+
+              Conversations.narrow_execution_allowance(
+                allowance.conversation_id,
+                user.id,
+                request
+              )
+            end
           end)
 
         try do
@@ -189,15 +341,28 @@ defmodule Fountain.Conversations.ExecutionAllowanceRaceTest do
           await_blocked(loser_backend, System.monotonic_time(:millisecond) + 5_000)
           send(winner.pid, :commit)
           assert {:ok, updated} = Task.await(winner)
-          assert {:error, changeset} = Task.await(loser)
-          assert errors_on(changeset).revision == ["is stale"]
-          assert Repo.reload!(allowance) == updated
+
+          case {mode, Task.await(loser)} do
+            {:stale, {:error, changeset}} ->
+              assert errors_on(changeset).revision == ["is stale"]
+              assert Repo.reload!(allowance) == updated
+
+            {:widen, {:error, changeset}} ->
+              assert errors_on(changeset).limits == ["execution_limits_widen: max_model_turns"]
+              assert Repo.reload!(allowance) == updated
+
+            {:disjoint, {:ok, final}} ->
+              assert final.limits == %{"max_model_turns" => 2, "wall_time_seconds" => 10}
+              assert Repo.reload!(allowance) == final
+          end
+
           assert updated.limits["max_model_turns"] == 2
         after
           Task.shutdown(loser, :brutal_kill)
         end
       after
         Task.shutdown(winner, :brutal_kill)
+        Repo.delete_all(from e in Fountain.Audit.Event, where: e.user_id == ^user.id)
         Repo.delete!(user)
         Repo.get!(Sandbox, sandbox_id) |> Repo.delete!()
         assert Repo.get(Allowance, allowance.conversation_id) == nil


### PR DESCRIPTION
Add an owner-scoped context operation for narrowing an existing execution allowance. Missing and foreign records return the same error; omitted controls stay in force, wider or corrupt policy is refused, and concurrent updates revalidate the locked current value. Unchanged requests leave the row untouched.

The context audits successful changes after its transaction, recording only changed control names with caller attribution. Narrowing does not start work or reset an active turn. Initial allowance creation, current host/account ceiling checks and HTTP enrollment remain separate.

Stacked on #1781 (`fix/saved-allowance-boot-guard`) so saved-policy admission and recovery guards are present. Focused replacement for part of #1745/#1754, tracked in #1732. The context rejects stored JSON null itself; sibling #1782 still repairs direct storage-primitive callers.

Validation: 117 related tests pass, including tenant denial, no-op/error audit behavior, unchanged active state, unsupported-turn refusal, and two observed PostgreSQL lock interleavings for concurrent scoped writers. The existing stale-writer and admission races remain covered. Full precommit passed: 4,778 tests and 6 doctests, zero failures (2 skipped, 7 excluded).

No endpoint, runtime control or new recovery behavior is enabled. Bounded live stop/restart/deletion acceptance remains required.
