### PR TITLE
feat: store typed account execution ceilings

### DIFF
--- a/apps/fountain/lib/fountain/accounts/user.ex
+++ b/apps/fountain/lib/fountain/accounts/user.ex
@@ -26,6 +26,10 @@ defmodule Fountain.Accounts.User do
     # `Fountain.Credits`, in the same transaction as the ledger row; never
     # cast from user input.
     field :credit_balance_cents, :integer, default: 0
+    # Operator-owned per-turn ceiling storage. Admission does not consume this
+    # field yet; leave it empty until ceiling enforcement is integrated.
+    # Never cast it through registration, OAuth, principal or profile changes.
+    field :execution_limits, :map, default: %{}
     field :role, :string, default: "user"
     # A claimable principal (ADR 0044): a tenant with no identity, opened by a
     # trusted application before its visitor has an account and claimed later
@@ -108,6 +112,22 @@ defmodule Fountain.Accounts.User do
     user
     |> cast(attrs, [:sandbox_limit_override])
     |> validate_number(:sandbox_limit_override, greater_than_or_equal_to: 0)
+  end
+
+  @doc """
+  Validate operator-owned execution ceiling storage; nil clears the override.
+
+  This primitive does not authorize an operator or enforce a ceiling. A future
+  context must establish operator authority and audit writes before exposing it.
+  """
+  def execution_limits_changeset(user, limits) do
+    case Fountain.Conversations.ExecutionLimits.normalize(limits) do
+      {:ok, normalized} ->
+        change(user, execution_limits: normalized)
+
+      {:error, {:execution_limits_invalid, field}} ->
+        user |> change() |> add_error(:execution_limits, "invalid #{field}")
+    end
   end
 
   @doc "Changeset for the Stripe customer id, written when a Checkout is opened."

--- a/apps/fountain/priv/repo/migrations/20260910020000_add_account_execution_limits.exs
+++ b/apps/fountain/priv/repo/migrations/20260910020000_add_account_execution_limits.exs
@@ -1,0 +1,32 @@
+defmodule Fountain.Repo.Migrations.AddAccountExecutionLimits do
+  use Ecto.Migration
+
+  def up do
+    alter table(:users) do
+      add :execution_limits, :map, null: false, default: %{}
+    end
+
+    create constraint(:users, :users_execution_limits_object,
+             check: "jsonb_typeof(execution_limits) = 'object'"
+           )
+  end
+
+  def down do
+    # Fence writes before checking: rollback must not silently discard a ceiling.
+    execute "LOCK TABLE users IN ACCESS EXCLUSIVE MODE"
+
+    execute """
+    DO $$ BEGIN
+      IF EXISTS (SELECT 1 FROM users WHERE execution_limits <> '{}'::jsonb) THEN
+        RAISE EXCEPTION 'cannot discard configured account execution ceilings';
+      END IF;
+    END $$;
+    """
+
+    drop constraint(:users, :users_execution_limits_object)
+
+    alter table(:users) do
+      remove :execution_limits
+    end
+  end
+end

--- a/apps/fountain/test/fountain/accounts/execution_limits_test.exs
+++ b/apps/fountain/test/fountain/accounts/execution_limits_test.exs
@@ -1,0 +1,114 @@
+defmodule Fountain.Accounts.ExecutionLimitsTest do
+  use Fountain.DataCase, async: true
+
+  alias Fountain.Accounts.User
+
+  test "operator changes persist canonical ceilings without changing another account" do
+    user = insert_user()
+    other = insert_user()
+    assert user.execution_limits == %{}
+
+    updated =
+      user
+      |> User.execution_limits_changeset(%{
+        wall_time_seconds: 60,
+        max_model_turns: 10,
+        max_estimated_cost_usd: 0.5
+      })
+      |> Repo.update!()
+
+    assert Repo.reload!(updated).execution_limits == %{
+             "wall_time_seconds" => 60,
+             "max_model_turns" => 10,
+             "max_estimated_cost_usd" => 0.5
+           }
+
+    assert Repo.reload!(other).execution_limits == %{}
+  end
+
+  test "an operator can replace or clear its account override" do
+    user = insert_user()
+
+    for limits <- [%{max_model_turns: 2}, %{max_model_turns: 20}, nil, %{}] do
+      updated = Repo.reload!(user) |> User.execution_limits_changeset(limits) |> Repo.update!()
+
+      expected =
+        if limits in [nil, %{}], do: %{}, else: %{"max_model_turns" => limits.max_model_turns}
+
+      assert Repo.reload!(updated).execution_limits == expected
+    end
+  end
+
+  test "invalid ceilings are refused without changing stored values or echoing input" do
+    user =
+      insert_user() |> User.execution_limits_changeset(%{max_model_turns: 2}) |> Repo.update!()
+
+    for {limits, field} <- [
+          {%{wall_time_seconds: nil}, "wall_time_seconds"},
+          {%{max_model_turns: "2"}, "max_model_turns"},
+          {%{max_estimated_cost_usd: 0}, "max_estimated_cost_usd"},
+          {%{"private-field" => "private-value"}, "unknown_field"},
+          {%{:max_model_turns => 2, "max_model_turns" => 3}, "duplicate_field"},
+          {[], "object_required"}
+        ] do
+      assert {:error, changeset} =
+               user |> User.execution_limits_changeset(limits) |> Repo.update()
+
+      assert errors_on(changeset).execution_limits == ["invalid #{field}"]
+      assert Repo.reload!(user) == user
+    end
+  end
+
+  test "registration, OAuth and principal creation cannot set ceilings" do
+    attrs = %{
+      email: "ceiling-#{Ecto.UUID.generate()}@example.test",
+      password: "valid-password",
+      execution_limits: %{max_model_turns: 999}
+    }
+
+    for changeset <- [
+          User.registration_changeset(%User{}, attrs),
+          User.oauth_registration_changeset(%User{}, %{attrs | email: "oauth-#{attrs.email}"}),
+          User.principal_changeset(%User{}, attrs)
+        ] do
+      assert Repo.insert!(changeset).execution_limits == %{}
+    end
+  end
+
+  test "ordinary account changes cannot clear or widen stored ceilings" do
+    user =
+      insert_user() |> User.execution_limits_changeset(%{max_model_turns: 2}) |> Repo.update!()
+
+    for limits <- [nil, %{}, %{"max_model_turns" => 999}] do
+      attrs = %{
+        "execution_limits" => limits,
+        "theme_preference" => "dark",
+        "conversation_view_mode" => "raw"
+      }
+
+      for changeset <- [
+            User.theme_changeset(user, attrs),
+            User.preferences_changeset(user, attrs)
+          ] do
+        assert Repo.update!(changeset).execution_limits == user.execution_limits
+        assert Repo.reload!(user).execution_limits == user.execution_limits
+      end
+    end
+  end
+
+  test "the database rejects SQL null, JSON null and non-object ceilings" do
+    user = insert_user()
+
+    for json <- [nil, "null", "[]", "1", "\"value\""] do
+      assert {:error, %Postgrex.Error{postgres: %{code: code}}} =
+               Repo.query(
+                 "UPDATE users SET execution_limits = $1::text::jsonb WHERE id = $2",
+                 [json, Ecto.UUID.dump!(user.id)],
+                 mode: :savepoint
+               )
+
+      assert code == if(is_nil(json), do: :not_null_violation, else: :check_violation)
+      assert Repo.reload!(user).execution_limits == %{}
+    end
+  end
+end


### PR DESCRIPTION
Add typed storage for operator-owned account execution ceilings, with an empty default for existing accounts. A dedicated changeset validates the three supported controls; registration, OAuth, principal creation and ordinary profile changes cannot set or clear them. The database rejects SQL/JSON null and non-object values.

Rollback locks the user table and refuses to discard configured ceilings. Once all overrides are empty, rollback removes only the new column and constraint.

Stacked directly on #1773 (`feat/execution-limit-policy`). Focused replacement for the account-storage portion of #1745/#1754; tracked in #1732.

Validation: 40 account/policy tests pass. On a fresh local database, an existing account received the empty default; a configured ceiling survived a refused rollback; empty rollback and reapply preserved the account. Full precommit passed: 4,714 tests and 6 doctests, zero failures (2 skipped, 7 excluded).

Storage only: admission does not read this field yet. Leave overrides empty until current-ceiling admission and runtime enforcement are integrated. No operator endpoint, host setting, allowance creation or runtime control is enabled; a future write context must authorize the operator and audit changes.
