### PR TITLE
fix: check account ceilings before launch admission

### DIFF
--- a/apps/fountain/lib/fountain/accounts/user.ex
+++ b/apps/fountain/lib/fountain/accounts/user.ex
@@ -26,8 +26,8 @@ defmodule Fountain.Accounts.User do
     # `Fountain.Credits`, in the same transaction as the ledger row; never
     # cast from user input.
     field :credit_balance_cents, :integer, default: 0
-    # Operator-owned per-turn ceiling storage. Admission does not consume this
-    # field yet; leave it empty until ceiling enforcement is integrated.
+    # Operator-owned per-turn ceilings, read by launch preflight. Later-turn and
+    # recovery ceiling checks remain unwired; leave overrides empty until integrated.
     # Never cast it through registration, OAuth, principal or profile changes.
     field :execution_limits, :map, default: %{}
     field :role, :string, default: "user"

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -1792,7 +1792,7 @@ defmodule Fountain.Conversations do
   # ── high-level lifecycle ──────────────────────────────────────────────────────────
 
   alias Fountain.Agents
-  alias Fountain.Conversations.ConversationServer
+  alias Fountain.Conversations.{ConversationServer, ExecutionLimits}
 
   @doc """
   Like `start_conversation/2`, but a conversation already bound to
@@ -1834,6 +1834,7 @@ defmodule Fountain.Conversations do
       )
       when is_binary(channel_id) and channel_id != "" do
     with %Agents.Agent{} = agent <- Agents.get_agent(agent_id, user_id) || {:error, :not_found},
+         :ok <- check_execution_limits(attrs["execution_limits"]),
          {:ok, vault_id} <- resolve_vault_id(attrs["vault_id"], user_id, agent),
          {:ok, env_id} <- resolve_environment_id(attrs["environment_id"], user_id, agent) do
       case find_channel_conversation(user_id, agent.id, vault_id, env_id, channel_id) do
@@ -1855,6 +1856,15 @@ defmodule Fountain.Conversations do
 
   def start_or_resume_conversation(attrs, opts) do
     with {:ok, conv} <- start_conversation(attrs, opts), do: {:ok, conv, :created}
+  end
+
+  # No runtime has integrated end-to-end enforcement yet. Refuse a requested
+  # control before reserving capacity, attaching or unbinding a channel; an
+  # SDK option alone must not make admission promise a bounded execution.
+  defp check_execution_limits(request) do
+    with {:ok, limits} <- ExecutionLimits.normalize(request) do
+      ExecutionLimits.require_controls(limits, [])
+    end
   end
 
   # `true` or `"true"` — the ACP adapter sends a JSON boolean, a hand-built
@@ -1962,6 +1972,7 @@ defmodule Fountain.Conversations do
   def start_conversation(%{"agent_id" => agent_id, "user_id" => user_id} = attrs, opts)
       when is_binary(user_id) do
     with %Agents.Agent{} = agent <- Agents.get_agent(agent_id, user_id) || {:error, :not_found},
+         :ok <- check_execution_limits(attrs["execution_limits"]),
          {:ok, runtime_module} <- Fountain.RuntimeDispatch.for_agent(agent),
          {:ok, vault_id} <- resolve_vault_id(attrs["vault_id"], user_id, agent),
          {:ok, env_id} <- resolve_environment_id(attrs["environment_id"], user_id, agent),
@@ -2500,6 +2511,7 @@ defmodule Fountain.Conversations do
        )
        when is_binary(user_id) do
     with %Agents.Agent{} = agent <- Agents.get_agent(agent_id, user_id) || {:error, :not_found},
+         :ok <- check_execution_limits(attrs["execution_limits"]),
          {:ok, _runtime_module} <- Fountain.RuntimeDispatch.for_agent(agent),
          {:ok, vault_id} <- resolve_vault_id(attrs["vault_id"], user_id, agent),
          {:ok, env_id} <- resolve_environment_id(attrs["environment_id"], user_id, agent),

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -1834,7 +1834,7 @@ defmodule Fountain.Conversations do
       )
       when is_binary(channel_id) and channel_id != "" do
     with %Agents.Agent{} = agent <- Agents.get_agent(agent_id, user_id) || {:error, :not_found},
-         :ok <- check_execution_limits(attrs["execution_limits"]),
+         :ok <- check_execution_limits(user_id, attrs["execution_limits"]),
          {:ok, vault_id} <- resolve_vault_id(attrs["vault_id"], user_id, agent),
          {:ok, env_id} <- resolve_environment_id(attrs["environment_id"], user_id, agent) do
       case find_channel_conversation(user_id, agent.id, vault_id, env_id, channel_id) do
@@ -1861,9 +1861,20 @@ defmodule Fountain.Conversations do
   # No runtime has integrated end-to-end enforcement yet. Refuse a requested
   # control before reserving capacity, attaching or unbinding a channel; an
   # SDK option alone must not make admission promise a bounded execution.
-  defp check_execution_limits(request) do
-    with {:ok, limits} <- ExecutionLimits.normalize(request) do
-      ExecutionLimits.require_controls(limits, [])
+  defp check_execution_limits(user_id, request) do
+    # Ownership: each caller just fetched the agent by this authenticated user.
+    # Read the current account policy, never a request-supplied or cached map.
+    case Fountain.Accounts.get_user(user_id) do
+      %Fountain.Accounts.User{execution_limits: ceiling} when is_map(ceiling) ->
+        with {:ok, limits} <- ExecutionLimits.resolve(nil, ceiling, request) do
+          ExecutionLimits.require_controls(limits, [])
+        end
+
+      nil ->
+        {:error, :not_found}
+
+      _ ->
+        {:error, {:execution_limits_invalid, "object_required"}}
     end
   end
 
@@ -1972,7 +1983,7 @@ defmodule Fountain.Conversations do
   def start_conversation(%{"agent_id" => agent_id, "user_id" => user_id} = attrs, opts)
       when is_binary(user_id) do
     with %Agents.Agent{} = agent <- Agents.get_agent(agent_id, user_id) || {:error, :not_found},
-         :ok <- check_execution_limits(attrs["execution_limits"]),
+         :ok <- check_execution_limits(user_id, attrs["execution_limits"]),
          {:ok, runtime_module} <- Fountain.RuntimeDispatch.for_agent(agent),
          {:ok, vault_id} <- resolve_vault_id(attrs["vault_id"], user_id, agent),
          {:ok, env_id} <- resolve_environment_id(attrs["environment_id"], user_id, agent),
@@ -2511,7 +2522,7 @@ defmodule Fountain.Conversations do
        )
        when is_binary(user_id) do
     with %Agents.Agent{} = agent <- Agents.get_agent(agent_id, user_id) || {:error, :not_found},
-         :ok <- check_execution_limits(attrs["execution_limits"]),
+         :ok <- check_execution_limits(user_id, attrs["execution_limits"]),
          {:ok, _runtime_module} <- Fountain.RuntimeDispatch.for_agent(agent),
          {:ok, vault_id} <- resolve_vault_id(attrs["vault_id"], user_id, agent),
          {:ok, env_id} <- resolve_environment_id(attrs["environment_id"], user_id, agent),

--- a/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
@@ -15,6 +15,24 @@ defmodule FountainWeb.FallbackController do
     |> json(%{error: "not_found"})
   end
 
+  def call(conn, {:error, {:execution_limits_invalid, field}}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{
+      error: "execution_limits_invalid",
+      errors: %{execution_limits: ["invalid #{field}"]}
+    })
+  end
+
+  def call(conn, {:error, {:execution_limits_unsupported, controls}}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{
+      error: "execution_limits_unsupported",
+      message: "Execution-limit enforcement is unavailable: #{Enum.join(controls, ", ")}."
+    })
+  end
+
   # start_conversation rejects an unknown / cross-tenant vault by returning
   # {:error, :vault_not_found}. Surface as 404 so callers can't tell the
   # difference between "no such vault" and "vault belongs to someone else".

--- a/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
@@ -24,6 +24,15 @@ defmodule FountainWeb.FallbackController do
     })
   end
 
+  def call(conn, {:error, {:execution_limits_widen, field}}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{
+      error: "execution_limits_widen",
+      errors: %{execution_limits: ["cannot widen #{field}"]}
+    })
+  end
+
   def call(conn, {:error, {:execution_limits_unsupported, controls}}) do
     conn
     |> put_status(:unprocessable_entity)

--- a/apps/fountain/test/fountain_web/controllers/execution_limit_admission_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/execution_limit_admission_test.exs
@@ -3,6 +3,7 @@ defmodule FountainWeb.ExecutionLimitAdmissionTest do
   use Mimic
 
   alias Fountain.{Conversations, Repo}
+  alias Fountain.Accounts.User
   alias Fountain.Conversations.{Conversation, Sandbox}
 
   setup do
@@ -117,6 +118,97 @@ defmodule FountainWeb.ExecutionLimitAdmissionTest do
     assert %{"error" => "not_found"} = request(ctx, params) |> json_response(404)
     refute_received :worker_started
   end
+
+  for path <- [:fresh, :attach, :resume, :rotate] do
+    test "#{path} inherits the stored account ceiling even when the request omits it", ctx do
+      save_ceiling(ctx.user, %{max_model_turns: 2})
+      before_counts = counts()
+
+      for request_limit <- [:omitted, nil, %{}] do
+        params = Map.put(attrs(ctx, unquote(path)), "account_execution_limits", %{})
+
+        params =
+          if request_limit == :omitted,
+            do: params,
+            else: Map.put(params, "execution_limits", request_limit)
+
+        assert %{"error" => "execution_limits_unsupported", "message" => message} =
+                 request(ctx, params) |> json_response(422)
+
+        assert message =~ "max_model_turns"
+        assert counts() == before_counts
+        assert Repo.reload!(ctx.conv).channel_id == "limits"
+        refute_received :worker_started
+      end
+    end
+  end
+
+  test "every configured account control is inherited", ctx do
+    for field <- Conversations.ExecutionLimits.keys() do
+      save_ceiling(ctx.user, %{field => 1})
+
+      assert %{"error" => "execution_limits_unsupported", "message" => message} =
+               request(ctx, attrs(ctx, :fresh)) |> json_response(422)
+
+      assert message =~ field
+    end
+
+    refute_received :worker_started
+  end
+
+  test "account ceilings are reread on each resume", ctx do
+    assert request(ctx, attrs(ctx, :resume)) |> json_response(200)
+    save_ceiling(ctx.user, %{wall_time_seconds: 30})
+
+    assert %{"error" => "execution_limits_unsupported"} =
+             request(ctx, attrs(ctx, :resume)) |> json_response(422)
+
+    save_ceiling(ctx.user, nil)
+    assert request(ctx, attrs(ctx, :resume)) |> json_response(200)
+  end
+
+  test "wider requests are rejected before runtime capability checks", ctx do
+    save_ceiling(ctx.user, %{max_model_turns: 2})
+    params = Map.put(attrs(ctx, :fresh), "execution_limits", %{"max_model_turns" => 3})
+
+    assert %{
+             "error" => "execution_limits_widen",
+             "errors" => %{"execution_limits" => ["cannot widen max_model_turns"]}
+           } =
+             request(ctx, params) |> json_response(422)
+
+    refute_received :worker_started
+  end
+
+  test "malformed account policy fails without exposing its contents", ctx do
+    corrupt =
+      ctx.user
+      |> Ecto.Changeset.change(execution_limits: %{"private-field" => "private-value"})
+      |> Repo.update!()
+      |> Repo.reload!()
+
+    response = request(ctx, attrs(ctx, :fresh)) |> json_response(422)
+    assert response["error"] == "execution_limits_invalid"
+    refute Jason.encode!(response) =~ "private-value"
+    refute Jason.encode!(response) =~ "private-field"
+    assert Repo.reload!(corrupt) == corrupt
+    refute_received :worker_started
+  end
+
+  test "another account's ceiling is neither inherited nor disclosed", ctx do
+    other = insert_active_user() |> save_ceiling(%{wall_time_seconds: 30})
+    assert request(ctx, attrs(ctx, :fresh)) |> json_response(201)
+    assert_received :worker_started
+
+    save_ceiling(ctx.user, %{max_model_turns: 2})
+    foreign = insert_agent(user_id: other.id)
+    params = %{"agent_id" => foreign.id}
+    assert %{"error" => "not_found"} = request(ctx, params) |> json_response(404)
+    refute_received :worker_started
+  end
+
+  defp save_ceiling(user, limits),
+    do: user |> Repo.reload!() |> User.execution_limits_changeset(limits) |> Repo.update!()
 
   defp counts, do: {Repo.aggregate(Conversation, :count), Repo.aggregate(Sandbox, :count)}
   defp attrs(ctx, :fresh), do: %{"agent_id" => ctx.agent.id, "sandbox_mode" => "ephemeral"}

--- a/apps/fountain/test/fountain_web/controllers/execution_limit_admission_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/execution_limit_admission_test.exs
@@ -1,0 +1,133 @@
+defmodule FountainWeb.ExecutionLimitAdmissionTest do
+  use FountainWeb.ConnCase, async: true
+  use Mimic
+
+  alias Fountain.{Conversations, Repo}
+  alias Fountain.Conversations.{Conversation, Sandbox}
+
+  setup do
+    user = insert_active_user()
+    {:ok, user} = Fountain.Accounts.update_sandbox_limit(user, 20)
+    {_key, raw_key} = insert_api_key(user)
+    env = insert_env(user_id: user.id)
+    agent = insert_agent(user_id: user.id, runtime: "claude", environment_id: env.id)
+
+    sandbox =
+      insert_sandbox(
+        user_id: user.id,
+        agent_id: agent.id,
+        environment_id: env.id,
+        status: "ready"
+      )
+
+    conv =
+      insert_conversation(
+        user_id: user.id,
+        agent: agent,
+        sandbox: sandbox,
+        status: "idle",
+        channel_id: "limits"
+      )
+
+    owner = self()
+
+    stub(Horde.DynamicSupervisor, :start_child, fn _, _ ->
+      send(owner, :worker_started)
+      {:ok, spawn(fn -> :ok end)}
+    end)
+
+    {:ok, user: user, raw_key: raw_key, agent: agent, sandbox: sandbox, conv: conv}
+  end
+
+  for path <- [:fresh, :attach, :resume, :rotate] do
+    test "#{path} refuses unenforced limits before changing state", ctx do
+      before_counts = counts()
+      attrs = Map.put(attrs(ctx, unquote(path)), "execution_limits", %{"wall_time_seconds" => 60})
+      response = request(ctx, attrs) |> json_response(422)
+      assert response["error"] == "execution_limits_unsupported"
+      assert response["message"] =~ "wall_time_seconds"
+      assert counts() == before_counts
+      assert Repo.reload!(ctx.conv).channel_id == "limits"
+      refute_received :worker_started
+    end
+  end
+
+  test "all allowlisted controls are refused until enforcement is integrated", ctx do
+    for field <- Conversations.ExecutionLimits.keys() do
+      params = Map.put(attrs(ctx, :fresh), "execution_limits", %{field => 1})
+
+      assert %{"error" => "execution_limits_unsupported"} =
+               request(ctx, params) |> json_response(422)
+    end
+
+    refute_received :worker_started
+  end
+
+  test "invalid limits fail with a stable error without echoing input", ctx do
+    before_counts = counts()
+
+    for limits <- [
+          %{"secret" => "do-not-echo"},
+          %{"wall_time_seconds" => "60"},
+          %{"max_model_turns" => nil},
+          []
+        ] do
+      params = Map.put(attrs(ctx, :fresh), "execution_limits", limits)
+      response = request(ctx, params) |> json_response(422)
+      assert response["error"] == "execution_limits_invalid"
+      refute Jason.encode!(response) =~ "do-not-echo"
+    end
+
+    assert counts() == before_counts
+    refute_received :worker_started
+  end
+
+  test "direct context callers cannot bypass fresh or attach admission", ctx do
+    before_counts = counts()
+
+    for path <- [:fresh, :attach] do
+      params =
+        attrs(ctx, path)
+        |> Map.put("user_id", ctx.user.id)
+        |> Map.put("execution_limits", %{max_model_turns: 1})
+
+      assert {:error, {:execution_limits_unsupported, ["max_model_turns"]}} =
+               Conversations.start_conversation(params)
+    end
+
+    assert counts() == before_counts
+    refute_received :worker_started
+  end
+
+  test "omitted and empty limits preserve ordinary admission", ctx do
+    for limits <- [:omitted, nil, %{}], path <- [:fresh, :attach, :resume] do
+      params = attrs(ctx, path)
+
+      params =
+        if limits == :omitted, do: params, else: Map.put(params, "execution_limits", limits)
+
+      status = if path == :resume, do: 200, else: 201
+      assert %{"data" => _} = request(ctx, params) |> json_response(status)
+    end
+  end
+
+  test "a foreign agent remains hidden before limit validation", ctx do
+    foreign = insert_agent(user_id: insert_active_user().id)
+    params = %{"agent_id" => foreign.id, "execution_limits" => %{"max_model_turns" => 1}}
+    assert %{"error" => "not_found"} = request(ctx, params) |> json_response(404)
+    refute_received :worker_started
+  end
+
+  defp counts, do: {Repo.aggregate(Conversation, :count), Repo.aggregate(Sandbox, :count)}
+  defp attrs(ctx, :fresh), do: %{"agent_id" => ctx.agent.id, "sandbox_mode" => "ephemeral"}
+  defp attrs(ctx, :attach), do: %{"agent_id" => ctx.agent.id, "sandbox_id" => ctx.sandbox.id}
+  defp attrs(ctx, :resume), do: %{"agent_id" => ctx.agent.id, "channel_id" => "limits"}
+  defp attrs(ctx, :rotate), do: Map.put(attrs(ctx, :resume), "fresh", true)
+
+  defp request(ctx, params) do
+    ctx.conn
+    |> authed_with_key(ctx.raw_key)
+    |> put_req_header("content-type", "application/json")
+    |> post("/api/conversations", Jason.encode!(params))
+  end
+end

--- a/docs/api.md
+++ b/docs/api.md
@@ -168,12 +168,16 @@ Create a conversation with an agent and a first prompt, follow its events,
 and send later prompts to that same conversation. Keep the returned ID.
 A new conversation creates another thread.
 
-Launch requests with nonempty `execution_limits` return
+Launch requests inherit the current account execution ceiling. Omitted, null or
+empty `execution_limits` do not remove it. Wider requests return
+`422 execution_limits_widen`; malformed requests or account policy return
+`422 execution_limits_invalid`. Nonempty effective limits return
 `422 execution_limits_unsupported`; Fountain cannot yet enforce these controls.
-Malformed limits return `422 execution_limits_invalid`. These checks apply to
-fresh launches, sandbox attachments and channel resumes before starting a worker
-or changing a channel binding. Omitted, null or empty limits preserve ordinary
-admission.
+These preflight checks cover fresh launches, sandbox attachments and channel
+resumes before worker start or channel changes. This is not an atomic reservation
+against later policy changes. Keep account ceilings empty until later-turn and
+recovery checks and runtime enforcement are integrated. Host ceilings and initial
+allowance persistence remain unwired.
 
 ```bash
 curl --fail-with-body \

--- a/docs/api.md
+++ b/docs/api.md
@@ -168,6 +168,13 @@ Create a conversation with an agent and a first prompt, follow its events,
 and send later prompts to that same conversation. Keep the returned ID.
 A new conversation creates another thread.
 
+Launch requests with nonempty `execution_limits` return
+`422 execution_limits_unsupported`; Fountain cannot yet enforce these controls.
+Malformed limits return `422 execution_limits_invalid`. These checks apply to
+fresh launches, sandbox attachments and channel resumes before starting a worker
+or changing a channel binding. Omitted, null or empty limits preserve ordinary
+admission.
+
 ```bash
 curl --fail-with-body \
   -H "Authorization: Bearer $FOUNTAIN_API_KEY" \


### PR DESCRIPTION
Launches ignored stored account ceilings when callers omitted `execution_limits`. Resolve each request against a fresh, owner-scoped account read before launch, sandbox attachment or channel changes. Omitted/null/empty requests inherit the ceiling; wider requests return `422 execution_limits_widen`. Malformed policy fails without exposing its contents, and unsupported controls remain refused.

Stacked on #1784. Reuses #1774's requested-limit preflight and its nine tests; the remaining nine regressions cover account inheritance, changed policy and tenant isolation. Five files, +289/-3 relative to #1784.

Validation: eight reproduced account-policy regressions; 187 related tests passed. Full precommit passed 4,732 tests and 6 doctests with zero failures. [CI passed](https://github.com/BinaryBourbon/fountain/actions/runs/34434666719). Documentation reports reviewed: destink clean; docs-style findings are in unchanged files, and Vale suggestions retain precise API terminology.

This is read-only preflight, not an atomic reservation against concurrent policy changes. Keep account overrides empty until later-turn/recovery checks and runtime enforcement are integrated. Host ceilings and initial allowance persistence remain separate. No runtime control, operator endpoint or deployment is enabled.

Extraction tracking: #1745, #1754; acceptance remains #1732.
