### PR TITLE
feat: validate host execution ceilings before launch

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -329,6 +329,15 @@ STRIPE_WEBHOOK_SECRET=
 # uses it and no sandbox meter reports it. An abuse ceiling, not an allowance.
 # BUZZ_IDENTITY_CEILING=10
 
+# Per-turn host execution ceiling, as JSON: wall_time_seconds and
+# max_model_turns are positive integers, max_estimated_cost_usd is a positive
+# number. Read at boot; invalid input refuses startup. A launch request
+# inherits the stricter of this and the account ceiling, and cannot widen it.
+# Leave unset: nothing enforces these controls yet, so a nonempty effective
+# ceiling refuses the launch with 422 execution_limits_unsupported. This is a
+# per-turn bound, not an aggregate spend cap.
+# FOUNTAIN_EXECUTION_LIMITS={"wall_time_seconds":3600,"max_model_turns":50}
+
 # Prepaid credits (ADR 0030): what the customer pays, in whole cents. Distinct
 # from the provider costs above. The turn-hour price defaults to 25 and is a
 # placeholder until a provider invoice has been reconciled. The four comms

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -2038,13 +2038,15 @@ defmodule Fountain.Conversations do
   defp check_execution_limits(user_id, request) do
     # Ownership: each caller just fetched the agent by this authenticated user.
     # Read the current account policy, never a request-supplied or cached map.
-    case Fountain.Accounts.get_user(user_id) do
-      %Fountain.Accounts.User{execution_limits: ceiling} when is_map(ceiling) ->
-        with {:ok, limits} <- ExecutionLimits.resolve(nil, ceiling, request) do
+    case {Fountain.Accounts.get_user(user_id),
+          Application.get_env(:fountain, :execution_limit_ceiling, %{})} do
+      {%Fountain.Accounts.User{execution_limits: ceiling}, host}
+      when is_map(ceiling) and is_map(host) ->
+        with {:ok, limits} <- ExecutionLimits.resolve(host, ceiling, request) do
           ExecutionLimits.require_controls(limits, [])
         end
 
-      nil ->
+      {nil, _} ->
         {:error, :not_found}
 
       _ ->

--- a/apps/fountain/test/fountain/execution_ceiling_config_test.exs
+++ b/apps/fountain/test/fountain/execution_ceiling_config_test.exs
@@ -1,0 +1,67 @@
+defmodule Fountain.ExecutionCeilingConfigTest do
+  use ExUnit.Case, async: false
+
+  @runtime_exs Path.expand("../../../../config/runtime.exs", __DIR__)
+  @variable "FOUNTAIN_EXECUTION_LIMITS"
+  @base %{
+    "PHX_SERVER" => "true",
+    "SECRET_KEY_BASE" => String.duplicate("a", 64),
+    "DATABASE_URL" => "postgres://u:p@localhost/db",
+    "EMAIL_DELIVERY" => "none",
+    "PUBLIC_URL" => "https://fountain.example.com",
+    "MASTER_SECRETS_KEY" => Base.url_encode64(<<0::256>>, padding: false)
+  }
+
+  setup do
+    previous = Map.new([@variable | Map.keys(@base)], &{&1, System.get_env(&1)})
+
+    on_exit(fn ->
+      for {key, value} <- previous do
+        if is_nil(value), do: System.delete_env(key), else: System.put_env(key, value)
+      end
+    end)
+
+    System.put_env(@base)
+    :ok
+  end
+
+  test "unset, blank and empty JSON preserve an empty host ceiling" do
+    for value <- [nil, "", "{}"] do
+      assert read(value) == %{}
+    end
+  end
+
+  test "boot reads all three typed controls" do
+    assert read(~s({"wall_time_seconds":30,"max_model_turns":2,"max_estimated_cost_usd":0.25})) ==
+             %{
+               "wall_time_seconds" => 30,
+               "max_model_turns" => 2,
+               "max_estimated_cost_usd" => 0.25
+             }
+  end
+
+  test "invalid host policy refuses boot without echoing input" do
+    for value <- [
+          "private-value",
+          "null",
+          "[]",
+          ~s({"private-field":"private-value"}),
+          ~s({"wall_time_seconds":0}),
+          ~s({"max_model_turns":"2"})
+        ] do
+      error = assert_raise RuntimeError, fn -> read(value) end
+      assert error.message =~ @variable
+      refute error.message =~ "private-value"
+      refute error.message =~ "private-field"
+    end
+  end
+
+  test "test runtime ignores the operator shell setting" do
+    assert read("private-value", :test) == %{}
+  end
+
+  defp read(value, env \\ :prod) do
+    if is_nil(value), do: System.delete_env(@variable), else: System.put_env(@variable, value)
+    Config.Reader.read!(@runtime_exs, env: env)[:fountain][:execution_limit_ceiling]
+  end
+end

--- a/apps/fountain/test/fountain_web/controllers/execution_limit_admission_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/execution_limit_admission_test.exs
@@ -1,5 +1,5 @@
 defmodule FountainWeb.ExecutionLimitAdmissionTest do
-  use FountainWeb.ConnCase, async: true
+  use FountainWeb.ConnCase, async: false
   use Mimic
 
   alias Fountain.{Conversations, Repo}
@@ -7,6 +7,16 @@ defmodule FountainWeb.ExecutionLimitAdmissionTest do
   alias Fountain.Conversations.{Conversation, Sandbox}
 
   setup do
+    previous = Application.fetch_env(:fountain, :execution_limit_ceiling)
+    Application.put_env(:fountain, :execution_limit_ceiling, %{})
+
+    on_exit(fn ->
+      case previous do
+        {:ok, value} -> Application.put_env(:fountain, :execution_limit_ceiling, value)
+        :error -> Application.delete_env(:fountain, :execution_limit_ceiling)
+      end
+    end)
+
     user = insert_active_user()
     {:ok, user} = Fountain.Accounts.update_sandbox_limit(user, 20)
     {_key, raw_key} = insert_api_key(user)
@@ -204,6 +214,63 @@ defmodule FountainWeb.ExecutionLimitAdmissionTest do
     foreign = insert_agent(user_id: other.id)
     params = %{"agent_id" => foreign.id}
     assert %{"error" => "not_found"} = request(ctx, params) |> json_response(404)
+    refute_received :worker_started
+  end
+
+  for path <- [:fresh, :attach, :resume, :rotate] do
+    test "#{path} inherits host controls before any launch effects", ctx do
+      Application.put_env(:fountain, :execution_limit_ceiling, %{"wall_time_seconds" => 30})
+      before_counts = counts()
+
+      for limit <- [:omitted, nil, %{}] do
+        params = Map.put(attrs(ctx, unquote(path)), "execution_limit_ceiling", %{})
+
+        params =
+          if limit == :omitted, do: params, else: Map.put(params, "execution_limits", limit)
+
+        assert %{"error" => "execution_limits_unsupported", "message" => message} =
+                 request(ctx, params) |> json_response(422)
+
+        assert message =~ "wall_time_seconds"
+        assert counts() == before_counts
+        assert Repo.reload!(ctx.conv).channel_id == "limits"
+        refute_received :worker_started
+      end
+    end
+  end
+
+  test "launch requests cannot widen the stricter host or account ceiling", ctx do
+    for {host, account} <- [{2, 10}, {10, 2}] do
+      Application.put_env(:fountain, :execution_limit_ceiling, %{"max_model_turns" => host})
+      save_ceiling(ctx.user, %{max_model_turns: account})
+      params = Map.put(attrs(ctx, :fresh), "execution_limits", %{"max_model_turns" => 3})
+      assert %{"error" => "execution_limits_widen"} = request(ctx, params) |> json_response(422)
+    end
+
+    refute_received :worker_started
+  end
+
+  test "host and account controls are both inherited", ctx do
+    Application.put_env(:fountain, :execution_limit_ceiling, %{"max_estimated_cost_usd" => 0.25})
+    save_ceiling(ctx.user, %{max_model_turns: 2})
+
+    assert %{"error" => "execution_limits_unsupported", "message" => message} =
+             request(ctx, attrs(ctx, :resume)) |> json_response(422)
+
+    assert message =~ "max_model_turns"
+    assert message =~ "max_estimated_cost_usd"
+    refute_received :worker_started
+  end
+
+  test "invalid host config fails without revealing its contents", ctx do
+    for policy <- [nil, [], %{"private-field" => "private-value"}] do
+      Application.put_env(:fountain, :execution_limit_ceiling, policy)
+      response = request(ctx, attrs(ctx, :fresh)) |> json_response(422)
+      assert response["error"] == "execution_limits_invalid"
+      refute Jason.encode!(response) =~ "private-value"
+      refute Jason.encode!(response) =~ "private-field"
+    end
+
     refute_received :worker_started
   end
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -975,6 +975,25 @@ credit_packs =
       |> Enum.sort()
   end
 
+# Per-turn host ceiling. Empty until runtime enforcement and later-turn/recovery
+# ceiling checks are integrated. Never inherit an operator's shell policy in tests.
+execution_limit_ceiling =
+  if env == :test do
+    %{}
+  else
+    case Fountain.Conversations.ExecutionLimits.from_json_env(
+           System.get_env("FOUNTAIN_EXECUTION_LIMITS")
+         ) do
+      {:ok, limits} ->
+        limits
+
+      {:error, {:execution_limits_invalid, field}} ->
+        raise "FOUNTAIN_EXECUTION_LIMITS is invalid: #{field}"
+    end
+  end
+
+config :fountain, :execution_limit_ceiling, execution_limit_ceiling
+
 # Concurrency (ADR 0031): the reserve one live sandbox needs in the balance,
 # the per-account floor and ceiling the balance rule is clamped to, and the
 # fleet ceiling — the most live sandboxes the deployment will run in total,

--- a/docs/api.md
+++ b/docs/api.md
@@ -168,16 +168,16 @@ Create a conversation with an agent and a first prompt, follow its events,
 and send later prompts to that same conversation. Keep the returned ID.
 A new conversation creates another thread.
 
-Launch requests inherit the current account execution ceiling. Omitted, null or
+Launch requests inherit the stricter host and account execution ceilings. Omitted, null or
 empty `execution_limits` do not remove it. Wider requests return
-`422 execution_limits_widen`; malformed requests or account policy return
+`422 execution_limits_widen`; malformed requests or configured policy return
 `422 execution_limits_invalid`. Nonempty effective limits return
 `422 execution_limits_unsupported`; Fountain cannot yet enforce these controls.
 These preflight checks cover fresh launches, sandbox attachments and channel
 resumes before worker start or channel changes. This is not an atomic reservation
-against later policy changes. Keep account ceilings empty until later-turn and
-recovery checks and runtime enforcement are integrated. Host ceilings and initial
-allowance persistence remain unwired.
+against later policy changes. Keep host and account ceilings empty until later-turn and
+recovery checks and runtime enforcement are integrated. Initial allowance
+persistence remains unwired.
 
 ```bash
 curl --fail-with-body \

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -158,6 +158,7 @@ at a dead end, with no error to see. Read [Email](guides/operate/email.md).
 | `SANDBOX_CAP_FLOOR` | `2` | No. | The fewest sandboxes a tenant with a positive balance may run at once. |
 | `SANDBOX_CAP_CEILING` | `20` | No. | The most sandboxes one tenant may run at once, unless an admin override raises it. |
 | `SANDBOX_FLEET_CEILING` | `20` | No. | The most live sandboxes across every tenant. Set it to what your sandbox provider plan allows. A start beyond it gets `503 fleet_full`. |
+| `FOUNTAIN_EXECUTION_LIMITS` | `{}` | No. | JSON per-turn host ceiling: `wall_time_seconds`, `max_model_turns`, `max_estimated_cost_usd`. Each configured value must be positive; time and turns must be integers. Read at boot; invalid input refuses startup. Requests inherit the stricter host/account ceiling. Keep unset until runtime enforcement and later-turn/recovery checks are integrated: nonempty effective limits currently refuse launch with `422 execution_limits_unsupported`. This is not an aggregate spend cap. |
 | `CREDIT_OPENING_CENTS` | `500` | No. | The credit a new account starts with, in cents. |
 | `CREDIT_OPENING_DAYS` | `14` | No. | How many days the opening credit lasts. |
 | `TEAM_CONTACT_CEILING` | `10` | No. | The most teammate contacts one account may hold at once. |


### PR DESCRIPTION
Host execution ceilings had no configuration or launch reader. Add `FOUNTAIN_EXECUTION_LIMITS`, parsed at boot with the existing typed validator. Invalid input refuses startup without echoing its contents. Launch preflight now resolves requests against both host and current account ceilings; omission cannot remove a limit, and requests cannot widen the stricter ceiling.

Stacked on #1785. Six files, +166/-10. The setting defaults to an empty map; the test runtime ignores operator shell policy, and tests that change application configuration run serially.

Validation: all 11 new tests failed against the parent; 65 related tests now pass, covering boot parsing, four launch paths, inherited controls, widening, redaction and configuration guardrails. Full precommit passed 4,743 tests and 6 doctests with zero failures. [CI passed](https://github.com/BinaryBourbon/fountain/actions/runs/34440792649). Prose reports reviewed: destink clean; docs-style findings are in unchanged files; Vale advice retains precise API terminology.

Keep host/account ceilings empty until runtime enforcement and later-turn/recovery ceiling checks are integrated. Nonempty effective limits still return `422 execution_limits_unsupported`. This is preflight, not an atomic reservation or aggregate spend cap. Initial allowance persistence remains on sibling #1786 and is not wired into launch admission.

Extraction: #1745, #1754. Live acceptance remains #1732.
