### PR TITLE
chore: join execution admission prerequisites

### DIFF
--- a/apps/fountain/lib/fountain/accounts/user.ex
+++ b/apps/fountain/lib/fountain/accounts/user.ex
@@ -26,8 +26,8 @@ defmodule Fountain.Accounts.User do
     # `Fountain.Credits`, in the same transaction as the ledger row; never
     # cast from user input.
     field :credit_balance_cents, :integer, default: 0
-    # Operator-owned per-turn ceiling storage. Admission does not consume this
-    # field yet; leave it empty until ceiling enforcement is integrated.
+    # Operator-owned per-turn ceilings, read by launch preflight. Later-turn and
+    # recovery ceiling checks remain unwired; leave overrides empty until integrated.
     # Never cast it through registration, OAuth, principal or profile changes.
     field :execution_limits, :map, default: %{}
     field :role, :string, default: "user"

--- a/apps/fountain/lib/fountain/accounts/user.ex
+++ b/apps/fountain/lib/fountain/accounts/user.ex
@@ -26,6 +26,10 @@ defmodule Fountain.Accounts.User do
     # `Fountain.Credits`, in the same transaction as the ledger row; never
     # cast from user input.
     field :credit_balance_cents, :integer, default: 0
+    # Operator-owned per-turn ceiling storage. Admission does not consume this
+    # field yet; leave it empty until ceiling enforcement is integrated.
+    # Never cast it through registration, OAuth, principal or profile changes.
+    field :execution_limits, :map, default: %{}
     field :role, :string, default: "user"
     # A claimable principal (ADR 0044): a tenant with no identity, opened by a
     # trusted application before its visitor has an account and claimed later
@@ -108,6 +112,22 @@ defmodule Fountain.Accounts.User do
     user
     |> cast(attrs, [:sandbox_limit_override])
     |> validate_number(:sandbox_limit_override, greater_than_or_equal_to: 0)
+  end
+
+  @doc """
+  Validate operator-owned execution ceiling storage; nil clears the override.
+
+  This primitive does not authorize an operator or enforce a ceiling. A future
+  context must establish operator authority and audit writes before exposing it.
+  """
+  def execution_limits_changeset(user, limits) do
+    case Fountain.Conversations.ExecutionLimits.normalize(limits) do
+      {:ok, normalized} ->
+        change(user, execution_limits: normalized)
+
+      {:error, {:execution_limits_invalid, field}} ->
+        user |> change() |> add_error(:execution_limits, "invalid #{field}")
+    end
   end
 
   @doc "Changeset for the Stripe customer id, written when a Checkout is opened."

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -1864,13 +1864,15 @@ defmodule Fountain.Conversations do
   defp check_execution_limits(user_id, request) do
     # Ownership: each caller just fetched the agent by this authenticated user.
     # Read the current account policy, never a request-supplied or cached map.
-    case Fountain.Accounts.get_user(user_id) do
-      %Fountain.Accounts.User{execution_limits: ceiling} when is_map(ceiling) ->
-        with {:ok, limits} <- ExecutionLimits.resolve(nil, ceiling, request) do
+    case {Fountain.Accounts.get_user(user_id),
+          Application.get_env(:fountain, :execution_limit_ceiling, %{})} do
+      {%Fountain.Accounts.User{execution_limits: ceiling}, host}
+      when is_map(ceiling) and is_map(host) ->
+        with {:ok, limits} <- ExecutionLimits.resolve(host, ceiling, request) do
           ExecutionLimits.require_controls(limits, [])
         end
 
-      nil ->
+      {nil, _} ->
         {:error, :not_found}
 
       _ ->

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -1792,7 +1792,7 @@ defmodule Fountain.Conversations do
   # ── high-level lifecycle ──────────────────────────────────────────────────────────
 
   alias Fountain.Agents
-  alias Fountain.Conversations.ConversationServer
+  alias Fountain.Conversations.{ConversationServer, ExecutionLimits}
 
   @doc """
   Like `start_conversation/2`, but a conversation already bound to
@@ -1834,6 +1834,7 @@ defmodule Fountain.Conversations do
       )
       when is_binary(channel_id) and channel_id != "" do
     with %Agents.Agent{} = agent <- Agents.get_agent(agent_id, user_id) || {:error, :not_found},
+         :ok <- check_execution_limits(attrs["execution_limits"]),
          {:ok, vault_id} <- resolve_vault_id(attrs["vault_id"], user_id, agent),
          {:ok, env_id} <- resolve_environment_id(attrs["environment_id"], user_id, agent) do
       case find_channel_conversation(user_id, agent.id, vault_id, env_id, channel_id) do
@@ -1855,6 +1856,15 @@ defmodule Fountain.Conversations do
 
   def start_or_resume_conversation(attrs, opts) do
     with {:ok, conv} <- start_conversation(attrs, opts), do: {:ok, conv, :created}
+  end
+
+  # No runtime has integrated end-to-end enforcement yet. Refuse a requested
+  # control before reserving capacity, attaching or unbinding a channel; an
+  # SDK option alone must not make admission promise a bounded execution.
+  defp check_execution_limits(request) do
+    with {:ok, limits} <- ExecutionLimits.normalize(request) do
+      ExecutionLimits.require_controls(limits, [])
+    end
   end
 
   # `true` or `"true"` — the ACP adapter sends a JSON boolean, a hand-built
@@ -1962,6 +1972,7 @@ defmodule Fountain.Conversations do
   def start_conversation(%{"agent_id" => agent_id, "user_id" => user_id} = attrs, opts)
       when is_binary(user_id) do
     with %Agents.Agent{} = agent <- Agents.get_agent(agent_id, user_id) || {:error, :not_found},
+         :ok <- check_execution_limits(attrs["execution_limits"]),
          {:ok, runtime_module} <- Fountain.RuntimeDispatch.for_agent(agent),
          {:ok, vault_id} <- resolve_vault_id(attrs["vault_id"], user_id, agent),
          {:ok, env_id} <- resolve_environment_id(attrs["environment_id"], user_id, agent),
@@ -2500,6 +2511,7 @@ defmodule Fountain.Conversations do
        )
        when is_binary(user_id) do
     with %Agents.Agent{} = agent <- Agents.get_agent(agent_id, user_id) || {:error, :not_found},
+         :ok <- check_execution_limits(attrs["execution_limits"]),
          {:ok, _runtime_module} <- Fountain.RuntimeDispatch.for_agent(agent),
          {:ok, vault_id} <- resolve_vault_id(attrs["vault_id"], user_id, agent),
          {:ok, env_id} <- resolve_environment_id(attrs["environment_id"], user_id, agent),

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -1834,7 +1834,7 @@ defmodule Fountain.Conversations do
       )
       when is_binary(channel_id) and channel_id != "" do
     with %Agents.Agent{} = agent <- Agents.get_agent(agent_id, user_id) || {:error, :not_found},
-         :ok <- check_execution_limits(attrs["execution_limits"]),
+         :ok <- check_execution_limits(user_id, attrs["execution_limits"]),
          {:ok, vault_id} <- resolve_vault_id(attrs["vault_id"], user_id, agent),
          {:ok, env_id} <- resolve_environment_id(attrs["environment_id"], user_id, agent) do
       case find_channel_conversation(user_id, agent.id, vault_id, env_id, channel_id) do
@@ -1861,9 +1861,20 @@ defmodule Fountain.Conversations do
   # No runtime has integrated end-to-end enforcement yet. Refuse a requested
   # control before reserving capacity, attaching or unbinding a channel; an
   # SDK option alone must not make admission promise a bounded execution.
-  defp check_execution_limits(request) do
-    with {:ok, limits} <- ExecutionLimits.normalize(request) do
-      ExecutionLimits.require_controls(limits, [])
+  defp check_execution_limits(user_id, request) do
+    # Ownership: each caller just fetched the agent by this authenticated user.
+    # Read the current account policy, never a request-supplied or cached map.
+    case Fountain.Accounts.get_user(user_id) do
+      %Fountain.Accounts.User{execution_limits: ceiling} when is_map(ceiling) ->
+        with {:ok, limits} <- ExecutionLimits.resolve(nil, ceiling, request) do
+          ExecutionLimits.require_controls(limits, [])
+        end
+
+      nil ->
+        {:error, :not_found}
+
+      _ ->
+        {:error, {:execution_limits_invalid, "object_required"}}
     end
   end
 
@@ -1972,7 +1983,7 @@ defmodule Fountain.Conversations do
   def start_conversation(%{"agent_id" => agent_id, "user_id" => user_id} = attrs, opts)
       when is_binary(user_id) do
     with %Agents.Agent{} = agent <- Agents.get_agent(agent_id, user_id) || {:error, :not_found},
-         :ok <- check_execution_limits(attrs["execution_limits"]),
+         :ok <- check_execution_limits(user_id, attrs["execution_limits"]),
          {:ok, runtime_module} <- Fountain.RuntimeDispatch.for_agent(agent),
          {:ok, vault_id} <- resolve_vault_id(attrs["vault_id"], user_id, agent),
          {:ok, env_id} <- resolve_environment_id(attrs["environment_id"], user_id, agent),
@@ -2511,7 +2522,7 @@ defmodule Fountain.Conversations do
        )
        when is_binary(user_id) do
     with %Agents.Agent{} = agent <- Agents.get_agent(agent_id, user_id) || {:error, :not_found},
-         :ok <- check_execution_limits(attrs["execution_limits"]),
+         :ok <- check_execution_limits(user_id, attrs["execution_limits"]),
          {:ok, _runtime_module} <- Fountain.RuntimeDispatch.for_agent(agent),
          {:ok, vault_id} <- resolve_vault_id(attrs["vault_id"], user_id, agent),
          {:ok, env_id} <- resolve_environment_id(attrs["environment_id"], user_id, agent),

--- a/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
@@ -15,6 +15,24 @@ defmodule FountainWeb.FallbackController do
     |> json(%{error: "not_found"})
   end
 
+  def call(conn, {:error, {:execution_limits_invalid, field}}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{
+      error: "execution_limits_invalid",
+      errors: %{execution_limits: ["invalid #{field}"]}
+    })
+  end
+
+  def call(conn, {:error, {:execution_limits_unsupported, controls}}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{
+      error: "execution_limits_unsupported",
+      message: "Execution-limit enforcement is unavailable: #{Enum.join(controls, ", ")}."
+    })
+  end
+
   # start_conversation rejects an unknown / cross-tenant vault by returning
   # {:error, :vault_not_found}. Surface as 404 so callers can't tell the
   # difference between "no such vault" and "vault belongs to someone else".

--- a/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
@@ -24,6 +24,15 @@ defmodule FountainWeb.FallbackController do
     })
   end
 
+  def call(conn, {:error, {:execution_limits_widen, field}}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{
+      error: "execution_limits_widen",
+      errors: %{execution_limits: ["cannot widen #{field}"]}
+    })
+  end
+
   def call(conn, {:error, {:execution_limits_unsupported, controls}}) do
     conn
     |> put_status(:unprocessable_entity)

--- a/apps/fountain/priv/repo/migrations/20260910020000_add_account_execution_limits.exs
+++ b/apps/fountain/priv/repo/migrations/20260910020000_add_account_execution_limits.exs
@@ -1,0 +1,32 @@
+defmodule Fountain.Repo.Migrations.AddAccountExecutionLimits do
+  use Ecto.Migration
+
+  def up do
+    alter table(:users) do
+      add :execution_limits, :map, null: false, default: %{}
+    end
+
+    create constraint(:users, :users_execution_limits_object,
+             check: "jsonb_typeof(execution_limits) = 'object'"
+           )
+  end
+
+  def down do
+    # Fence writes before checking: rollback must not silently discard a ceiling.
+    execute "LOCK TABLE users IN ACCESS EXCLUSIVE MODE"
+
+    execute """
+    DO $$ BEGIN
+      IF EXISTS (SELECT 1 FROM users WHERE execution_limits <> '{}'::jsonb) THEN
+        RAISE EXCEPTION 'cannot discard configured account execution ceilings';
+      END IF;
+    END $$;
+    """
+
+    drop constraint(:users, :users_execution_limits_object)
+
+    alter table(:users) do
+      remove :execution_limits
+    end
+  end
+end

--- a/apps/fountain/test/fountain/accounts/execution_limits_test.exs
+++ b/apps/fountain/test/fountain/accounts/execution_limits_test.exs
@@ -1,0 +1,114 @@
+defmodule Fountain.Accounts.ExecutionLimitsTest do
+  use Fountain.DataCase, async: true
+
+  alias Fountain.Accounts.User
+
+  test "operator changes persist canonical ceilings without changing another account" do
+    user = insert_user()
+    other = insert_user()
+    assert user.execution_limits == %{}
+
+    updated =
+      user
+      |> User.execution_limits_changeset(%{
+        wall_time_seconds: 60,
+        max_model_turns: 10,
+        max_estimated_cost_usd: 0.5
+      })
+      |> Repo.update!()
+
+    assert Repo.reload!(updated).execution_limits == %{
+             "wall_time_seconds" => 60,
+             "max_model_turns" => 10,
+             "max_estimated_cost_usd" => 0.5
+           }
+
+    assert Repo.reload!(other).execution_limits == %{}
+  end
+
+  test "an operator can replace or clear its account override" do
+    user = insert_user()
+
+    for limits <- [%{max_model_turns: 2}, %{max_model_turns: 20}, nil, %{}] do
+      updated = Repo.reload!(user) |> User.execution_limits_changeset(limits) |> Repo.update!()
+
+      expected =
+        if limits in [nil, %{}], do: %{}, else: %{"max_model_turns" => limits.max_model_turns}
+
+      assert Repo.reload!(updated).execution_limits == expected
+    end
+  end
+
+  test "invalid ceilings are refused without changing stored values or echoing input" do
+    user =
+      insert_user() |> User.execution_limits_changeset(%{max_model_turns: 2}) |> Repo.update!()
+
+    for {limits, field} <- [
+          {%{wall_time_seconds: nil}, "wall_time_seconds"},
+          {%{max_model_turns: "2"}, "max_model_turns"},
+          {%{max_estimated_cost_usd: 0}, "max_estimated_cost_usd"},
+          {%{"private-field" => "private-value"}, "unknown_field"},
+          {%{:max_model_turns => 2, "max_model_turns" => 3}, "duplicate_field"},
+          {[], "object_required"}
+        ] do
+      assert {:error, changeset} =
+               user |> User.execution_limits_changeset(limits) |> Repo.update()
+
+      assert errors_on(changeset).execution_limits == ["invalid #{field}"]
+      assert Repo.reload!(user) == user
+    end
+  end
+
+  test "registration, OAuth and principal creation cannot set ceilings" do
+    attrs = %{
+      email: "ceiling-#{Ecto.UUID.generate()}@example.test",
+      password: "valid-password",
+      execution_limits: %{max_model_turns: 999}
+    }
+
+    for changeset <- [
+          User.registration_changeset(%User{}, attrs),
+          User.oauth_registration_changeset(%User{}, %{attrs | email: "oauth-#{attrs.email}"}),
+          User.principal_changeset(%User{}, attrs)
+        ] do
+      assert Repo.insert!(changeset).execution_limits == %{}
+    end
+  end
+
+  test "ordinary account changes cannot clear or widen stored ceilings" do
+    user =
+      insert_user() |> User.execution_limits_changeset(%{max_model_turns: 2}) |> Repo.update!()
+
+    for limits <- [nil, %{}, %{"max_model_turns" => 999}] do
+      attrs = %{
+        "execution_limits" => limits,
+        "theme_preference" => "dark",
+        "conversation_view_mode" => "raw"
+      }
+
+      for changeset <- [
+            User.theme_changeset(user, attrs),
+            User.preferences_changeset(user, attrs)
+          ] do
+        assert Repo.update!(changeset).execution_limits == user.execution_limits
+        assert Repo.reload!(user).execution_limits == user.execution_limits
+      end
+    end
+  end
+
+  test "the database rejects SQL null, JSON null and non-object ceilings" do
+    user = insert_user()
+
+    for json <- [nil, "null", "[]", "1", "\"value\""] do
+      assert {:error, %Postgrex.Error{postgres: %{code: code}}} =
+               Repo.query(
+                 "UPDATE users SET execution_limits = $1::text::jsonb WHERE id = $2",
+                 [json, Ecto.UUID.dump!(user.id)],
+                 mode: :savepoint
+               )
+
+      assert code == if(is_nil(json), do: :not_null_violation, else: :check_violation)
+      assert Repo.reload!(user).execution_limits == %{}
+    end
+  end
+end

--- a/apps/fountain/test/fountain/execution_ceiling_config_test.exs
+++ b/apps/fountain/test/fountain/execution_ceiling_config_test.exs
@@ -1,0 +1,67 @@
+defmodule Fountain.ExecutionCeilingConfigTest do
+  use ExUnit.Case, async: false
+
+  @runtime_exs Path.expand("../../../../config/runtime.exs", __DIR__)
+  @variable "FOUNTAIN_EXECUTION_LIMITS"
+  @base %{
+    "PHX_SERVER" => "true",
+    "SECRET_KEY_BASE" => String.duplicate("a", 64),
+    "DATABASE_URL" => "postgres://u:p@localhost/db",
+    "EMAIL_DELIVERY" => "none",
+    "PUBLIC_URL" => "https://fountain.example.com",
+    "MASTER_SECRETS_KEY" => Base.url_encode64(<<0::256>>, padding: false)
+  }
+
+  setup do
+    previous = Map.new([@variable | Map.keys(@base)], &{&1, System.get_env(&1)})
+
+    on_exit(fn ->
+      for {key, value} <- previous do
+        if is_nil(value), do: System.delete_env(key), else: System.put_env(key, value)
+      end
+    end)
+
+    System.put_env(@base)
+    :ok
+  end
+
+  test "unset, blank and empty JSON preserve an empty host ceiling" do
+    for value <- [nil, "", "{}"] do
+      assert read(value) == %{}
+    end
+  end
+
+  test "boot reads all three typed controls" do
+    assert read(~s({"wall_time_seconds":30,"max_model_turns":2,"max_estimated_cost_usd":0.25})) ==
+             %{
+               "wall_time_seconds" => 30,
+               "max_model_turns" => 2,
+               "max_estimated_cost_usd" => 0.25
+             }
+  end
+
+  test "invalid host policy refuses boot without echoing input" do
+    for value <- [
+          "private-value",
+          "null",
+          "[]",
+          ~s({"private-field":"private-value"}),
+          ~s({"wall_time_seconds":0}),
+          ~s({"max_model_turns":"2"})
+        ] do
+      error = assert_raise RuntimeError, fn -> read(value) end
+      assert error.message =~ @variable
+      refute error.message =~ "private-value"
+      refute error.message =~ "private-field"
+    end
+  end
+
+  test "test runtime ignores the operator shell setting" do
+    assert read("private-value", :test) == %{}
+  end
+
+  defp read(value, env \\ :prod) do
+    if is_nil(value), do: System.delete_env(@variable), else: System.put_env(@variable, value)
+    Config.Reader.read!(@runtime_exs, env: env)[:fountain][:execution_limit_ceiling]
+  end
+end

--- a/apps/fountain/test/fountain_web/controllers/execution_limit_admission_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/execution_limit_admission_test.exs
@@ -3,6 +3,7 @@ defmodule FountainWeb.ExecutionLimitAdmissionTest do
   use Mimic
 
   alias Fountain.{Conversations, Repo}
+  alias Fountain.Accounts.User
   alias Fountain.Conversations.{Conversation, Sandbox}
 
   setup do
@@ -117,6 +118,97 @@ defmodule FountainWeb.ExecutionLimitAdmissionTest do
     assert %{"error" => "not_found"} = request(ctx, params) |> json_response(404)
     refute_received :worker_started
   end
+
+  for path <- [:fresh, :attach, :resume, :rotate] do
+    test "#{path} inherits the stored account ceiling even when the request omits it", ctx do
+      save_ceiling(ctx.user, %{max_model_turns: 2})
+      before_counts = counts()
+
+      for request_limit <- [:omitted, nil, %{}] do
+        params = Map.put(attrs(ctx, unquote(path)), "account_execution_limits", %{})
+
+        params =
+          if request_limit == :omitted,
+            do: params,
+            else: Map.put(params, "execution_limits", request_limit)
+
+        assert %{"error" => "execution_limits_unsupported", "message" => message} =
+                 request(ctx, params) |> json_response(422)
+
+        assert message =~ "max_model_turns"
+        assert counts() == before_counts
+        assert Repo.reload!(ctx.conv).channel_id == "limits"
+        refute_received :worker_started
+      end
+    end
+  end
+
+  test "every configured account control is inherited", ctx do
+    for field <- Conversations.ExecutionLimits.keys() do
+      save_ceiling(ctx.user, %{field => 1})
+
+      assert %{"error" => "execution_limits_unsupported", "message" => message} =
+               request(ctx, attrs(ctx, :fresh)) |> json_response(422)
+
+      assert message =~ field
+    end
+
+    refute_received :worker_started
+  end
+
+  test "account ceilings are reread on each resume", ctx do
+    assert request(ctx, attrs(ctx, :resume)) |> json_response(200)
+    save_ceiling(ctx.user, %{wall_time_seconds: 30})
+
+    assert %{"error" => "execution_limits_unsupported"} =
+             request(ctx, attrs(ctx, :resume)) |> json_response(422)
+
+    save_ceiling(ctx.user, nil)
+    assert request(ctx, attrs(ctx, :resume)) |> json_response(200)
+  end
+
+  test "wider requests are rejected before runtime capability checks", ctx do
+    save_ceiling(ctx.user, %{max_model_turns: 2})
+    params = Map.put(attrs(ctx, :fresh), "execution_limits", %{"max_model_turns" => 3})
+
+    assert %{
+             "error" => "execution_limits_widen",
+             "errors" => %{"execution_limits" => ["cannot widen max_model_turns"]}
+           } =
+             request(ctx, params) |> json_response(422)
+
+    refute_received :worker_started
+  end
+
+  test "malformed account policy fails without exposing its contents", ctx do
+    corrupt =
+      ctx.user
+      |> Ecto.Changeset.change(execution_limits: %{"private-field" => "private-value"})
+      |> Repo.update!()
+      |> Repo.reload!()
+
+    response = request(ctx, attrs(ctx, :fresh)) |> json_response(422)
+    assert response["error"] == "execution_limits_invalid"
+    refute Jason.encode!(response) =~ "private-value"
+    refute Jason.encode!(response) =~ "private-field"
+    assert Repo.reload!(corrupt) == corrupt
+    refute_received :worker_started
+  end
+
+  test "another account's ceiling is neither inherited nor disclosed", ctx do
+    other = insert_active_user() |> save_ceiling(%{wall_time_seconds: 30})
+    assert request(ctx, attrs(ctx, :fresh)) |> json_response(201)
+    assert_received :worker_started
+
+    save_ceiling(ctx.user, %{max_model_turns: 2})
+    foreign = insert_agent(user_id: other.id)
+    params = %{"agent_id" => foreign.id}
+    assert %{"error" => "not_found"} = request(ctx, params) |> json_response(404)
+    refute_received :worker_started
+  end
+
+  defp save_ceiling(user, limits),
+    do: user |> Repo.reload!() |> User.execution_limits_changeset(limits) |> Repo.update!()
 
   defp counts, do: {Repo.aggregate(Conversation, :count), Repo.aggregate(Sandbox, :count)}
   defp attrs(ctx, :fresh), do: %{"agent_id" => ctx.agent.id, "sandbox_mode" => "ephemeral"}

--- a/apps/fountain/test/fountain_web/controllers/execution_limit_admission_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/execution_limit_admission_test.exs
@@ -1,0 +1,133 @@
+defmodule FountainWeb.ExecutionLimitAdmissionTest do
+  use FountainWeb.ConnCase, async: true
+  use Mimic
+
+  alias Fountain.{Conversations, Repo}
+  alias Fountain.Conversations.{Conversation, Sandbox}
+
+  setup do
+    user = insert_active_user()
+    {:ok, user} = Fountain.Accounts.update_sandbox_limit(user, 20)
+    {_key, raw_key} = insert_api_key(user)
+    env = insert_env(user_id: user.id)
+    agent = insert_agent(user_id: user.id, runtime: "claude", environment_id: env.id)
+
+    sandbox =
+      insert_sandbox(
+        user_id: user.id,
+        agent_id: agent.id,
+        environment_id: env.id,
+        status: "ready"
+      )
+
+    conv =
+      insert_conversation(
+        user_id: user.id,
+        agent: agent,
+        sandbox: sandbox,
+        status: "idle",
+        channel_id: "limits"
+      )
+
+    owner = self()
+
+    stub(Horde.DynamicSupervisor, :start_child, fn _, _ ->
+      send(owner, :worker_started)
+      {:ok, spawn(fn -> :ok end)}
+    end)
+
+    {:ok, user: user, raw_key: raw_key, agent: agent, sandbox: sandbox, conv: conv}
+  end
+
+  for path <- [:fresh, :attach, :resume, :rotate] do
+    test "#{path} refuses unenforced limits before changing state", ctx do
+      before_counts = counts()
+      attrs = Map.put(attrs(ctx, unquote(path)), "execution_limits", %{"wall_time_seconds" => 60})
+      response = request(ctx, attrs) |> json_response(422)
+      assert response["error"] == "execution_limits_unsupported"
+      assert response["message"] =~ "wall_time_seconds"
+      assert counts() == before_counts
+      assert Repo.reload!(ctx.conv).channel_id == "limits"
+      refute_received :worker_started
+    end
+  end
+
+  test "all allowlisted controls are refused until enforcement is integrated", ctx do
+    for field <- Conversations.ExecutionLimits.keys() do
+      params = Map.put(attrs(ctx, :fresh), "execution_limits", %{field => 1})
+
+      assert %{"error" => "execution_limits_unsupported"} =
+               request(ctx, params) |> json_response(422)
+    end
+
+    refute_received :worker_started
+  end
+
+  test "invalid limits fail with a stable error without echoing input", ctx do
+    before_counts = counts()
+
+    for limits <- [
+          %{"secret" => "do-not-echo"},
+          %{"wall_time_seconds" => "60"},
+          %{"max_model_turns" => nil},
+          []
+        ] do
+      params = Map.put(attrs(ctx, :fresh), "execution_limits", limits)
+      response = request(ctx, params) |> json_response(422)
+      assert response["error"] == "execution_limits_invalid"
+      refute Jason.encode!(response) =~ "do-not-echo"
+    end
+
+    assert counts() == before_counts
+    refute_received :worker_started
+  end
+
+  test "direct context callers cannot bypass fresh or attach admission", ctx do
+    before_counts = counts()
+
+    for path <- [:fresh, :attach] do
+      params =
+        attrs(ctx, path)
+        |> Map.put("user_id", ctx.user.id)
+        |> Map.put("execution_limits", %{max_model_turns: 1})
+
+      assert {:error, {:execution_limits_unsupported, ["max_model_turns"]}} =
+               Conversations.start_conversation(params)
+    end
+
+    assert counts() == before_counts
+    refute_received :worker_started
+  end
+
+  test "omitted and empty limits preserve ordinary admission", ctx do
+    for limits <- [:omitted, nil, %{}], path <- [:fresh, :attach, :resume] do
+      params = attrs(ctx, path)
+
+      params =
+        if limits == :omitted, do: params, else: Map.put(params, "execution_limits", limits)
+
+      status = if path == :resume, do: 200, else: 201
+      assert %{"data" => _} = request(ctx, params) |> json_response(status)
+    end
+  end
+
+  test "a foreign agent remains hidden before limit validation", ctx do
+    foreign = insert_agent(user_id: insert_active_user().id)
+    params = %{"agent_id" => foreign.id, "execution_limits" => %{"max_model_turns" => 1}}
+    assert %{"error" => "not_found"} = request(ctx, params) |> json_response(404)
+    refute_received :worker_started
+  end
+
+  defp counts, do: {Repo.aggregate(Conversation, :count), Repo.aggregate(Sandbox, :count)}
+  defp attrs(ctx, :fresh), do: %{"agent_id" => ctx.agent.id, "sandbox_mode" => "ephemeral"}
+  defp attrs(ctx, :attach), do: %{"agent_id" => ctx.agent.id, "sandbox_id" => ctx.sandbox.id}
+  defp attrs(ctx, :resume), do: %{"agent_id" => ctx.agent.id, "channel_id" => "limits"}
+  defp attrs(ctx, :rotate), do: Map.put(attrs(ctx, :resume), "fresh", true)
+
+  defp request(ctx, params) do
+    ctx.conn
+    |> authed_with_key(ctx.raw_key)
+    |> put_req_header("content-type", "application/json")
+    |> post("/api/conversations", Jason.encode!(params))
+  end
+end

--- a/apps/fountain/test/fountain_web/controllers/execution_limit_admission_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/execution_limit_admission_test.exs
@@ -1,5 +1,5 @@
 defmodule FountainWeb.ExecutionLimitAdmissionTest do
-  use FountainWeb.ConnCase, async: true
+  use FountainWeb.ConnCase, async: false
   use Mimic
 
   alias Fountain.{Conversations, Repo}
@@ -7,6 +7,16 @@ defmodule FountainWeb.ExecutionLimitAdmissionTest do
   alias Fountain.Conversations.{Conversation, Sandbox}
 
   setup do
+    previous = Application.fetch_env(:fountain, :execution_limit_ceiling)
+    Application.put_env(:fountain, :execution_limit_ceiling, %{})
+
+    on_exit(fn ->
+      case previous do
+        {:ok, value} -> Application.put_env(:fountain, :execution_limit_ceiling, value)
+        :error -> Application.delete_env(:fountain, :execution_limit_ceiling)
+      end
+    end)
+
     user = insert_active_user()
     {:ok, user} = Fountain.Accounts.update_sandbox_limit(user, 20)
     {_key, raw_key} = insert_api_key(user)
@@ -204,6 +214,63 @@ defmodule FountainWeb.ExecutionLimitAdmissionTest do
     foreign = insert_agent(user_id: other.id)
     params = %{"agent_id" => foreign.id}
     assert %{"error" => "not_found"} = request(ctx, params) |> json_response(404)
+    refute_received :worker_started
+  end
+
+  for path <- [:fresh, :attach, :resume, :rotate] do
+    test "#{path} inherits host controls before any launch effects", ctx do
+      Application.put_env(:fountain, :execution_limit_ceiling, %{"wall_time_seconds" => 30})
+      before_counts = counts()
+
+      for limit <- [:omitted, nil, %{}] do
+        params = Map.put(attrs(ctx, unquote(path)), "execution_limit_ceiling", %{})
+
+        params =
+          if limit == :omitted, do: params, else: Map.put(params, "execution_limits", limit)
+
+        assert %{"error" => "execution_limits_unsupported", "message" => message} =
+                 request(ctx, params) |> json_response(422)
+
+        assert message =~ "wall_time_seconds"
+        assert counts() == before_counts
+        assert Repo.reload!(ctx.conv).channel_id == "limits"
+        refute_received :worker_started
+      end
+    end
+  end
+
+  test "launch requests cannot widen the stricter host or account ceiling", ctx do
+    for {host, account} <- [{2, 10}, {10, 2}] do
+      Application.put_env(:fountain, :execution_limit_ceiling, %{"max_model_turns" => host})
+      save_ceiling(ctx.user, %{max_model_turns: account})
+      params = Map.put(attrs(ctx, :fresh), "execution_limits", %{"max_model_turns" => 3})
+      assert %{"error" => "execution_limits_widen"} = request(ctx, params) |> json_response(422)
+    end
+
+    refute_received :worker_started
+  end
+
+  test "host and account controls are both inherited", ctx do
+    Application.put_env(:fountain, :execution_limit_ceiling, %{"max_estimated_cost_usd" => 0.25})
+    save_ceiling(ctx.user, %{max_model_turns: 2})
+
+    assert %{"error" => "execution_limits_unsupported", "message" => message} =
+             request(ctx, attrs(ctx, :resume)) |> json_response(422)
+
+    assert message =~ "max_model_turns"
+    assert message =~ "max_estimated_cost_usd"
+    refute_received :worker_started
+  end
+
+  test "invalid host config fails without revealing its contents", ctx do
+    for policy <- [nil, [], %{"private-field" => "private-value"}] do
+      Application.put_env(:fountain, :execution_limit_ceiling, policy)
+      response = request(ctx, attrs(ctx, :fresh)) |> json_response(422)
+      assert response["error"] == "execution_limits_invalid"
+      refute Jason.encode!(response) =~ "private-value"
+      refute Jason.encode!(response) =~ "private-field"
+    end
+
     refute_received :worker_started
   end
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -975,6 +975,25 @@ credit_packs =
       |> Enum.sort()
   end
 
+# Per-turn host ceiling. Empty until runtime enforcement and later-turn/recovery
+# ceiling checks are integrated. Never inherit an operator's shell policy in tests.
+execution_limit_ceiling =
+  if env == :test do
+    %{}
+  else
+    case Fountain.Conversations.ExecutionLimits.from_json_env(
+           System.get_env("FOUNTAIN_EXECUTION_LIMITS")
+         ) do
+      {:ok, limits} ->
+        limits
+
+      {:error, {:execution_limits_invalid, field}} ->
+        raise "FOUNTAIN_EXECUTION_LIMITS is invalid: #{field}"
+    end
+  end
+
+config :fountain, :execution_limit_ceiling, execution_limit_ceiling
+
 # Concurrency (ADR 0031): the reserve one live sandbox needs in the balance,
 # the per-account floor and ceiling the balance rule is clamped to, and the
 # fleet ceiling — the most live sandboxes the deployment will run in total,

--- a/docs/api.md
+++ b/docs/api.md
@@ -168,16 +168,16 @@ Create a conversation with an agent and a first prompt, follow its events,
 and send later prompts to that same conversation. Keep the returned ID.
 A new conversation creates another thread.
 
-Launch requests inherit the current account execution ceiling. Omitted, null or
+Launch requests inherit the stricter host and account execution ceilings. Omitted, null or
 empty `execution_limits` do not remove it. Wider requests return
-`422 execution_limits_widen`; malformed requests or account policy return
+`422 execution_limits_widen`; malformed requests or configured policy return
 `422 execution_limits_invalid`. Nonempty effective limits return
 `422 execution_limits_unsupported`; Fountain cannot yet enforce these controls.
 These preflight checks cover fresh launches, sandbox attachments and channel
 resumes before worker start or channel changes. This is not an atomic reservation
-against later policy changes. Keep account ceilings empty until later-turn and
-recovery checks and runtime enforcement are integrated. Host ceilings and initial
-allowance persistence remain unwired.
+against later policy changes. Keep host and account ceilings empty until later-turn and
+recovery checks and runtime enforcement are integrated. Initial allowance
+persistence remains unwired.
 
 ```bash
 curl --fail-with-body \

--- a/docs/api.md
+++ b/docs/api.md
@@ -168,12 +168,16 @@ Create a conversation with an agent and a first prompt, follow its events,
 and send later prompts to that same conversation. Keep the returned ID.
 A new conversation creates another thread.
 
-Launch requests with nonempty `execution_limits` return
+Launch requests inherit the current account execution ceiling. Omitted, null or
+empty `execution_limits` do not remove it. Wider requests return
+`422 execution_limits_widen`; malformed requests or account policy return
+`422 execution_limits_invalid`. Nonempty effective limits return
 `422 execution_limits_unsupported`; Fountain cannot yet enforce these controls.
-Malformed limits return `422 execution_limits_invalid`. These checks apply to
-fresh launches, sandbox attachments and channel resumes before starting a worker
-or changing a channel binding. Omitted, null or empty limits preserve ordinary
-admission.
+These preflight checks cover fresh launches, sandbox attachments and channel
+resumes before worker start or channel changes. This is not an atomic reservation
+against later policy changes. Keep account ceilings empty until later-turn and
+recovery checks and runtime enforcement are integrated. Host ceilings and initial
+allowance persistence remain unwired.
 
 ```bash
 curl --fail-with-body \

--- a/docs/api.md
+++ b/docs/api.md
@@ -168,6 +168,13 @@ Create a conversation with an agent and a first prompt, follow its events,
 and send later prompts to that same conversation. Keep the returned ID.
 A new conversation creates another thread.
 
+Launch requests with nonempty `execution_limits` return
+`422 execution_limits_unsupported`; Fountain cannot yet enforce these controls.
+Malformed limits return `422 execution_limits_invalid`. These checks apply to
+fresh launches, sandbox attachments and channel resumes before starting a worker
+or changing a channel binding. Omitted, null or empty limits preserve ordinary
+admission.
+
 ```bash
 curl --fail-with-body \
   -H "Authorization: Bearer $FOUNTAIN_API_KEY" \

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -158,6 +158,7 @@ at a dead end, with no error to see. Read [Email](guides/operate/email.md).
 | `SANDBOX_CAP_FLOOR` | `2` | No. | The fewest sandboxes a tenant with a positive balance may run at once. |
 | `SANDBOX_CAP_CEILING` | `20` | No. | The most sandboxes one tenant may run at once, unless an admin override raises it. |
 | `SANDBOX_FLEET_CEILING` | `20` | No. | The most live sandboxes across every tenant. Set it to what your sandbox provider plan allows. A start beyond it gets `503 fleet_full`. |
+| `FOUNTAIN_EXECUTION_LIMITS` | `{}` | No. | JSON per-turn host ceiling: `wall_time_seconds`, `max_model_turns`, `max_estimated_cost_usd`. Each configured value must be positive; time and turns must be integers. Read at boot; invalid input refuses startup. Requests inherit the stricter host/account ceiling. Keep unset until runtime enforcement and later-turn/recovery checks are integrated: nonempty effective limits currently refuse launch with `422 execution_limits_unsupported`. This is not an aggregate spend cap. |
 | `CREDIT_OPENING_CENTS` | `500` | No. | The credit a new account starts with, in cents. |
 | `CREDIT_OPENING_DAYS` | `14` | No. | How many days the opening credit lasts. |
 | `TEAM_CONTACT_CEILING` | `10` | No. | The most teammate contacts one account may hold at once. |


### PR DESCRIPTION
Join #1787's host/account launch checks with #1786's saved-allowance storage and recovery guards for the attachment-persistence follow-up in #1789.

Base: #1786. This preserves both branches' commits. The diff is 10 files, +590, mostly existing tests from #1784/#1785/#1787. Resolution keeps the widening HTTP error and both channel guards, and removes a duplicate alias. It adds no new runtime capability or launch writer.

Validation: 81 combined admission/storage/configuration tests passed in a fresh database with both migrations. The first test attempt stopped before tests because the new database was unmigrated; migration resolved it. Full precommit passed 4,821 tests and 6 doctests with zero failures. [CI passed](https://github.com/BinaryBourbon/fountain/actions/runs/34443300234). The inherited documentation retains the previously reviewed prose reports.

Keep host/account ceilings empty until later-turn/recovery ceiling checks and runtime enforcement integrate. This preflight is not an atomic policy reservation or aggregate spend cap. Existing activation and live-acceptance holds remain.

Extraction: #1745, #1754. Acceptance: #1732.
