### PR TITLE
Persist fresh launch allowances atomically

### DIFF
--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -911,7 +911,8 @@ defmodule Fountain.Conversations do
   # *not* inside `insert_conversation_row/1`: a caller in a transaction must
   # fire it after that transaction commits, so a rolled-back write reports no
   # request. Every door that inserts a conversation calls it exactly once —
-  # `create_conversation/1`, `create_attached_conversation/3` — and
+  # `create_conversation/1`, `create_attached_conversation/3`,
+  # `reserve_initial_conversation/3` — and
   # `conversation_creation_seam_test.exs` drives each of them and fails if one
   # stops firing.
   defp after_conversation_created(%Conversation{} = conv) do
@@ -2235,7 +2236,7 @@ defmodule Fountain.Conversations do
              },
              attrs["execution_limits"]
            ) do
-      Fountain.Activation.conversation_created(conv)
+      after_conversation_created(conv)
       record_execution_allowance_created(allowance, user_id, opts)
 
       # Recorded here rather than in either branch below: both of them return
@@ -2344,27 +2345,33 @@ defmodule Fountain.Conversations do
   # reservation. Analytics, audit, worker startup and prompts run after commit.
   defp reserve_initial_conversation(sandbox_attrs, conversation_attrs, request) do
     Fountain.Quotas.with_sandbox_reservation(conversation_attrs.user_id, fn ->
+      # Nothing in here may take a row lock. `with_sandbox_reservation/3` holds
+      # `pg_advisory_xact_lock(@fleet_lock_key)` — one lock shared by every
+      # tenant, the thing that enforces SANDBOX_FLEET_CEILING — for the whole
+      # of this function. A `SELECT ... FOR SHARE` on `users` conflicts with
+      # the `FOR UPDATE` that `Credits.insert_and_move/3` holds across a ledger
+      # insert, lot consumption and the balance move, so one tenant's credit
+      # posting would stall provisioning for every other tenant. `agents` is
+      # the same story against a `last_used_at` stamp. These stay plain
+      # ownership rechecks: MVCC reads never block, the ceiling below is read
+      # the same way, and the inserts' foreign keys enforce integrity.
       Repo.one(
         from u in Fountain.Accounts.User,
           where: u.id == ^conversation_attrs.user_id,
-          select: u.id,
-          lock: "FOR SHARE"
+          select: u.id
       ) || Repo.rollback(:not_found)
 
       Repo.one(
         from a in Agents.Agent,
           where:
             a.id == ^conversation_attrs.agent_id and a.user_id == ^conversation_attrs.user_id,
-          select: a.id,
-          lock: "FOR SHARE"
+          select: a.id
       ) || Repo.rollback(:not_found)
 
       with {:ok, limits} <- resolve_admission_limits(conversation_attrs.user_id, request),
            {:ok, sandbox} <- create_sandbox(sandbox_attrs),
            {:ok, conv} <-
-             %Conversation{}
-             |> Conversation.changeset(Map.put(conversation_attrs, :sandbox_id, sandbox.id))
-             |> Repo.insert(),
+             insert_conversation_row(Map.put(conversation_attrs, :sandbox_id, sandbox.id)),
            {:ok, allowance} <-
              conv.id |> ExecutionAllowance.new_changeset(limits) |> Repo.insert() do
         {:ok, {sandbox, conv, allowance}}

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -2202,12 +2202,9 @@ defmodule Fountain.Conversations do
          :new <- home_or_new(mode, user_id, agent, env_id || agent.environment_id, vault_id),
          {:ok, provider} <- resolve_sandbox_provider(agent),
          {:ok, sprite_name} <- mint_sprite_name(provider, user_id, attrs["sprite_name"]),
-         # Quota check + row insert under one per-user advisory lock: checked
-         # separately they are check-then-insert, and N concurrent requests at
-         # the cap could each pass and provision N-1 sprites over it (#330).
-         {:ok, sandbox} <-
-           Fountain.Quotas.with_sandbox_reservation(user_id, fn ->
-             create_sandbox(%{
+         {:ok, {sandbox, conv, allowance}} <-
+           reserve_initial_conversation(
+             %{
                environment_id: env_id || agent.environment_id,
                # The identity the disk is built from (ADR 0023); an attach
                # later must name the same three.
@@ -2218,27 +2215,29 @@ defmodule Fountain.Conversations do
                status: "pending",
                provider: Atom.to_string(provider),
                user_id: user_id
-             })
-           end),
-         {:ok, conv} <-
-           create_conversation(%{
-             sandbox_id: sandbox.id,
-             agent_id: agent.id,
-             # Ownership: agent came from the scoped get_agent above.
-             agent_version_id: Agents._unsafe_current_version_id(agent.id),
-             vault_id: vault_id,
-             environment_id: env_id,
-             user_id: user_id,
-             runtime: agent.runtime,
-             status: "pending",
-             source: attrs["source"] || "api",
-             parent_conversation_id: parent_id,
-             channel_id: attrs["channel_id"],
-             title: attrs["title"],
-             sandbox_api_access: api_access,
-             permission_policy: perm_policy,
-             caller_tools: attrs["caller_tools"] || []
-           }) do
+             },
+             %{
+               agent_id: agent.id,
+               # Ownership: agent came from the scoped get_agent above.
+               agent_version_id: Agents._unsafe_current_version_id(agent.id),
+               vault_id: vault_id,
+               environment_id: env_id,
+               user_id: user_id,
+               runtime: agent.runtime,
+               status: "pending",
+               source: attrs["source"] || "api",
+               parent_conversation_id: parent_id,
+               channel_id: attrs["channel_id"],
+               title: attrs["title"],
+               sandbox_api_access: api_access,
+               permission_policy: perm_policy,
+               caller_tools: attrs["caller_tools"] || []
+             },
+             attrs["execution_limits"]
+           ) do
+      Fountain.Activation.conversation_created(conv)
+      record_execution_allowance_created(allowance, user_id, opts)
+
       # Recorded here rather than in either branch below: both of them return
       # {:ok, conv}. The row exists and the sandbox reservation is spent even
       # when the server fails to start, so "a conversation was created" is
@@ -2338,6 +2337,39 @@ defmodule Fountain.Conversations do
       {:error, _} = err ->
         err
     end
+  end
+
+  # Keep fleet -> user advisory lock order, then stabilize ownership and
+  # recheck policy. A failed conversation or allowance must release the entire
+  # reservation. Analytics, audit, worker startup and prompts run after commit.
+  defp reserve_initial_conversation(sandbox_attrs, conversation_attrs, request) do
+    Fountain.Quotas.with_sandbox_reservation(conversation_attrs.user_id, fn ->
+      Repo.one(
+        from u in Fountain.Accounts.User,
+          where: u.id == ^conversation_attrs.user_id,
+          select: u.id,
+          lock: "FOR SHARE"
+      ) || Repo.rollback(:not_found)
+
+      Repo.one(
+        from a in Agents.Agent,
+          where:
+            a.id == ^conversation_attrs.agent_id and a.user_id == ^conversation_attrs.user_id,
+          select: a.id,
+          lock: "FOR SHARE"
+      ) || Repo.rollback(:not_found)
+
+      with {:ok, limits} <- resolve_admission_limits(conversation_attrs.user_id, request),
+           {:ok, sandbox} <- create_sandbox(sandbox_attrs),
+           {:ok, conv} <-
+             %Conversation{}
+             |> Conversation.changeset(Map.put(conversation_attrs, :sandbox_id, sandbox.id))
+             |> Repo.insert(),
+           {:ok, allowance} <-
+             conv.id |> ExecutionAllowance.new_changeset(limits) |> Repo.insert() do
+        {:ok, {sandbox, conv, allowance}}
+      end
+    end)
   end
 
   defp resolve_sandbox_api_access(access, _mode) when access in [nil, "owner"],

--- a/apps/fountain/test/fountain/conversation_creation_seam_test.exs
+++ b/apps/fountain/test/fountain/conversation_creation_seam_test.exs
@@ -33,7 +33,7 @@ defmodule Fountain.ConversationCreationSeamTest do
     %{user: user, agent: agent, env: env, sandbox: sandbox}
   end
 
-  @doors [:attach, :team]
+  @doors [:fresh, :attach, :team]
 
   for door <- @doors do
     test "the #{door} door reports the conversation it created", ctx do
@@ -49,16 +49,28 @@ defmodule Fountain.ConversationCreationSeamTest do
     end
   end
 
-  test "a rolled-back write reports nothing", ctx do
-    reject(&Fountain.Activation.conversation_created/1)
+  for door <- [:fresh, :attach] do
+    test "a rolled-back #{door} write reports nothing", ctx do
+      reject(&Fountain.Activation.conversation_created/1)
 
-    stub(Fountain.Conversations.ExecutionAllowance, :new_changeset, fn _, _ ->
-      %Fountain.Conversations.ExecutionAllowance{}
-      |> Ecto.Changeset.change()
-      |> Ecto.Changeset.add_error(:limits, "fixture rejection")
-    end)
+      stub(Fountain.Conversations.ExecutionAllowance, :new_changeset, fn _, _ ->
+        %Fountain.Conversations.ExecutionAllowance{}
+        |> Ecto.Changeset.change()
+        |> Ecto.Changeset.add_error(:limits, "fixture rejection")
+      end)
 
-    assert {:error, %Ecto.Changeset{}} = open(:attach, ctx)
+      assert {:error, %Ecto.Changeset{}} = open(unquote(door), ctx)
+    end
+  end
+
+  defp open(:fresh, ctx) do
+    with {:ok, conv} <-
+           Conversations.start_conversation(%{
+             "user_id" => ctx.user.id,
+             "agent_id" => ctx.agent.id,
+             "sandbox_mode" => "ephemeral"
+           }),
+         do: {:ok, conv.id}
   end
 
   defp open(:attach, ctx) do

--- a/apps/fountain/test/fountain/conversations/execution_allowance_test.exs
+++ b/apps/fountain/test/fountain/conversations/execution_allowance_test.exs
@@ -506,10 +506,17 @@ defmodule Fountain.Conversations.ExecutionAllowanceRaceTest do
 
   # The account ceiling is re-resolved inside the admission transaction, so a
   # change another connection commits after the early preflight still refuses.
-  # The `users` row is read unlocked on purpose (locking it would park
-  # admission behind a credit posting), so this asserts the recheck reads
-  # current committed state — not a lock ordering.
-  test "attachment honours a ceiling committed after its preflight" do
+  # Both `users` and `agents` are read unlocked on purpose — inside
+  # `with_sandbox_reservation/3` a row lock would be held under the global
+  # fleet lock — so this asserts the recheck reads current committed state,
+  # not a lock ordering.
+  for path <- [:attach, :fresh] do
+    test "#{path} honours a ceiling committed after its preflight" do
+      admission_race(unquote(path))
+    end
+  end
+
+  defp admission_race(path) do
     Ecto.Adapters.SQL.Sandbox.unboxed_run(Repo, fn ->
       user =
         Repo.insert!(%Fountain.Accounts.User{
@@ -535,6 +542,11 @@ defmodule Fountain.Conversations.ExecutionAllowanceRaceTest do
       try do
         admitting =
           independent_writer(fn ->
+            Mimic.stub(Horde.DynamicSupervisor, :start_child, fn _, _ ->
+              send(owner, :unexpected_worker_started)
+              {:error, :fixture_rejection}
+            end)
+
             # Runs immediately after the early preflight read the ceiling and
             # allowed the launch. Hold here until the new ceiling is committed.
             Mimic.stub(Fountain.RuntimeDispatch, :for_agent, fn agent ->
@@ -549,11 +561,15 @@ defmodule Fountain.Conversations.ExecutionAllowanceRaceTest do
               Mimic.call_original(Fountain.RuntimeDispatch, :for_agent, [agent])
             end)
 
-            Conversations.start_conversation(%{
-              "user_id" => user.id,
-              "agent_id" => agent.id,
-              "sandbox_id" => sandbox.id
-            })
+            params = %{"user_id" => user.id, "agent_id" => agent.id}
+
+            params =
+              case path do
+                :attach -> Map.put(params, "sandbox_id", sandbox.id)
+                :fresh -> Map.put(params, "sandbox_mode", "ephemeral")
+              end
+
+            Conversations.start_conversation(params)
           end)
 
         try do
@@ -586,14 +602,16 @@ defmodule Fountain.Conversations.ExecutionAllowanceRaceTest do
                          ]
                  )
 
-          assert Repo.reload!(sandbox) == sandbox
+          assert Repo.all(from s in Sandbox, where: s.user_id == ^user.id) == [sandbox]
+          refute_received :unexpected_worker_started
         after
           Task.shutdown(admitting, :brutal_kill)
         end
       after
         Repo.delete_all(from e in Fountain.Audit.Event, where: e.user_id == ^user.id)
+        sandboxes = Repo.all(from s in Sandbox, where: s.user_id == ^user.id)
         Repo.delete!(user)
-        Repo.get!(Sandbox, sandbox.id) |> Repo.delete!()
+        for saved <- sandboxes, do: Repo.delete!(saved)
       end
     end)
   end

--- a/apps/fountain/test/fountain_web/controllers/execution_limit_admission_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/execution_limit_admission_test.exs
@@ -2,9 +2,11 @@ defmodule FountainWeb.ExecutionLimitAdmissionTest do
   use FountainWeb.ConnCase, async: false
   use Mimic
 
+  import Ecto.Query, only: [from: 2]
+
   alias Fountain.{Conversations, Repo}
   alias Fountain.Accounts.User
-  alias Fountain.Conversations.{Conversation, Sandbox}
+  alias Fountain.Conversations.{Conversation, ExecutionAllowance, Sandbox}
 
   setup do
     previous = Application.fetch_env(:fountain, :execution_limit_ceiling)
@@ -272,6 +274,103 @@ defmodule FountainWeb.ExecutionLimitAdmissionTest do
     end
 
     refute_received :worker_started
+  end
+
+  test "fresh allowance is committed before worker startup and its initial prompt", ctx do
+    owner = self()
+
+    stub(Horde.DynamicSupervisor, :start_child, fn _, {_, opts} ->
+      id = Keyword.fetch!(opts, :conversation_id)
+      assert Repo.get!(ExecutionAllowance, id).limits == %{}
+      refute Repo.in_transaction?()
+      send(owner, {:admitted, id})
+      {:ok, owner}
+    end)
+
+    stub(Fountain.Conversations.ConversationServer, :queue_initial_prompt, fn pid,
+                                                                              prompt,
+                                                                              images ->
+      assert pid == owner
+      assert prompt == "check the branch"
+      assert images == []
+      assert_received {:admitted, id}
+      assert Repo.get!(ExecutionAllowance, id).limits == %{}
+      send(owner, {:prompt_queued, id})
+      :ok
+    end)
+
+    params = Map.put(attrs(ctx, :fresh), "prompt", "check the branch")
+    assert %{"data" => %{"id" => id}} = request(ctx, params) |> json_response(201)
+    assert_received {:prompt_queued, ^id}
+    assert creation_audits(ctx.user.id) == 2
+  end
+
+  test "failed fresh allowance insert rolls back the sandbox and conversation", ctx do
+    before_counts = counts()
+
+    stub(ExecutionAllowance, :new_changeset, fn id, limits ->
+      Mimic.call_original(ExecutionAllowance, :new_changeset, [id, limits])
+      |> Ecto.Changeset.add_error(:limits, "fixture rejection")
+    end)
+
+    assert request(ctx, attrs(ctx, :fresh)) |> json_response(422)
+    assert counts() == before_counts
+    assert Repo.aggregate(ExecutionAllowance, :count) == 0
+    assert creation_audits(ctx.user.id) == 0
+    refute_received :worker_started
+  end
+
+  test "failed fresh conversation validation rolls back its sandbox reservation", ctx do
+    before_counts = counts()
+
+    params =
+      attrs(ctx, :fresh)
+      |> Map.put("user_id", ctx.user.id)
+      |> Map.put("title", %{})
+
+    assert {:error, %Ecto.Changeset{}} = Conversations.start_conversation(params)
+    assert counts() == before_counts
+    assert creation_audits(ctx.user.id) == 0
+    refute_received :worker_started
+  end
+
+  test "fresh admission rechecks a ceiling changed after early preflight", ctx do
+    before_counts = counts()
+
+    stub(Fountain.RuntimeDispatch, :for_agent, fn agent ->
+      save_ceiling(ctx.user, %{max_model_turns: 2})
+      Mimic.call_original(Fountain.RuntimeDispatch, :for_agent, [agent])
+    end)
+
+    assert %{"error" => "execution_limits_unsupported"} =
+             request(ctx, attrs(ctx, :fresh)) |> json_response(422)
+
+    assert counts() == before_counts
+    assert creation_audits(ctx.user.id) == 0
+    refute_received :worker_started
+  end
+
+  test "worker startup failure retains the admitted allowance with its failed rows", ctx do
+    stub(Horde.DynamicSupervisor, :start_child, fn _, _ -> {:error, :fixture_rejection} end)
+
+    assert %{"data" => %{"id" => id, "status" => "failed"}} =
+             request(ctx, attrs(ctx, :fresh)) |> json_response(201)
+
+    conv = Repo.get!(Conversation, id)
+    assert Repo.get!(Sandbox, conv.sandbox_id).status == "failed"
+    assert Repo.get!(ExecutionAllowance, id).limits == %{}
+    assert creation_audits(ctx.user.id) == 2
+  end
+
+  defp creation_audits(user_id) do
+    Repo.aggregate(
+      from(e in Fountain.Audit.Event,
+        where:
+          e.user_id == ^user_id and
+            e.action in ["conversation.created", "conversation.execution_allowance_created"]
+      ),
+      :count
+    )
   end
 
   defp save_ceiling(user, limits),

--- a/apps/fountain/test/fountain_web/controllers/saved_allowance_channel_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/saved_allowance_channel_test.exs
@@ -133,7 +133,8 @@ defmodule FountainWeb.SavedAllowanceChannelTest do
 
     refute fresh.id == conv.id
     assert Repo.reload!(conv).channel_id == nil
-    assert Repo.get_by(ExecutionAllowance, conversation_id: fresh.id) == nil
+    assert Repo.get!(ExecutionAllowance, fresh.id).limits == %{}
+    assert Repo.get!(ExecutionAllowance, conv.id).limits == %{"max_model_turns" => 2}
     assert_received :worker_started
   end
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -176,9 +176,10 @@ empty `execution_limits` do not remove it. Wider requests return
 These preflight checks cover fresh launches, sandbox attachments and channel
 resumes before worker start or channel changes. This is not an atomic reservation
 against later policy changes. Keep host and account ceilings empty until later-turn and
-recovery checks and runtime enforcement are integrated. Attachments save their
-initial allowance before prompt delivery. Fresh worker launches still do not
-save an allowance.
+recovery checks and runtime enforcement are integrated. Fresh launches and
+attachments save their initial allowance with the conversation before worker
+startup or prompt delivery. Fresh launches also reserve the sandbox in that
+transaction; a failed insert leaves no sandbox or conversation.
 
 ```bash
 curl --fail-with-body \


### PR DESCRIPTION
A failed fresh conversation insert could leave a reserved sandbox, and launches had no saved initial execution allowance. Commit the sandbox, conversation and resolved allowance together under the existing quota locks. Recheck account/agent ownership and current ceilings before inserting; start the worker and emit creation events after commit.

Failed inserts roll everything back. A worker startup failure still retains the admitted allowance with its failed conversation and sandbox. Unsupported controls remain refused.

Stacked on #1789; five files, +190/-40. Four reproduced parent failures; 229 related tests passed, including a real PostgreSQL lock wait on an account-ceiling update. Full precommit passed 4,832 tests and 6 doctests with zero failures. Channel rotation retains the old allowance and gives the new conversation its own policy. Staged secret scan passed; prose reports reviewed. [CI passed](https://github.com/BinaryBourbon/fountain/actions/runs/34447732132). Later-turn/recovery checks against current ceilings and runtime enforcement remain separate.
