### PR TITLE
Preserve channel bindings when rotation fails

### DIFF
--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -2011,7 +2011,11 @@ defmodule Fountain.Conversations do
   owner's `!rotate` — ACP `session/new` `_meta.freshSession` — through a
   binding that would otherwise hand the old conversation straight back.
   Unbinding, rather than relying on "newest wins", keeps the outcome
-  independent of `inserted_at`'s one-second precision.
+  independent of `inserted_at`'s one-second precision. Admission commits the
+  old unbinding and the replacement together. A refused replacement preserves
+  the old binding; a later startup/prompt failure restores it unless another
+  rotation has already moved the binding. Concurrent rotations of the same
+  binding return a channel validation error to the loser.
 
   Two concurrent first calls for one channel can both create; the next call
   resumes whichever is newer. Nothing is audited on the resume path — nothing
@@ -2031,8 +2035,8 @@ defmodule Fountain.Conversations do
       case find_channel_conversation(user_id, agent.id, vault_id, env_id, channel_id) do
         %Conversation{} = conv ->
           if fresh_requested?(attrs) do
-            with {:ok, _} <- unbind_channel(conv),
-                 {:ok, fresh} <- start_conversation(attrs, opts),
+            with {:ok, fresh} <-
+                   start_conversation(attrs, Keyword.put(opts, :rotate_from, conv.id)),
                  do: {:ok, fresh, :created}
           else
             with :ok <- _unsafe_check_saved_execution_allowance(conv.id),
@@ -2089,6 +2093,62 @@ defmodule Fountain.Conversations do
     conv
     |> Ecto.Changeset.change(channel_id: nil)
     |> Repo.update()
+  end
+
+  # Inside admission's transaction, before locking a sandbox: turn admission
+  # also takes conversation -> sandbox locks. A competing rotation must not
+  # replace a binding that has moved since the initial lookup.
+  defp unbind_rotated_channel(attrs, opts) do
+    case Keyword.get(opts, :rotate_from) do
+      nil ->
+        :ok
+
+      id ->
+        case lock_rotation_conversation(id, attrs) do
+          %Conversation{channel_id: channel} = conv when channel == attrs.channel_id ->
+            with {:ok, _} <- unbind_channel(conv), do: :ok
+
+          _ ->
+            {:error,
+             %Conversation{}
+             |> Ecto.Changeset.change()
+             |> Ecto.Changeset.add_error(:channel_id, "binding changed; retry the rotation")}
+        end
+    end
+  end
+
+  # Worker startup and attachment prompt delivery run after admission commits.
+  # Restore only while this replacement still owns the binding; a later
+  # rotation must win over this failure. Keep the old -> new row lock order.
+  defp restore_rotated_channel(conv, opts) do
+    if id = Keyword.get(opts, :rotate_from) do
+      Repo.transaction(fn ->
+        previous = lock_rotation_conversation(id, conv)
+        replacement = lock_rotation_conversation(conv.id, conv)
+
+        case {previous, replacement} do
+          {%Conversation{channel_id: nil} = previous,
+           %Conversation{channel_id: channel} = replacement}
+          when channel == conv.channel_id ->
+            replacement |> Ecto.Changeset.change(channel_id: nil) |> Repo.update!()
+            previous |> Ecto.Changeset.change(channel_id: channel) |> Repo.update!()
+
+          _ ->
+            :ok
+        end
+      end)
+    end
+  end
+
+  defp lock_rotation_conversation(id, attrs) do
+    # Channel/ownership writes must serialize, but FK references may proceed.
+    from(c in Conversation,
+      where: c.id == ^id and c.user_id == ^attrs.user_id and c.agent_id == ^attrs.agent_id,
+      lock: "FOR NO KEY UPDATE"
+    )
+    |> where_vault(attrs.vault_id)
+    |> where_environment(attrs.environment_id)
+    |> Repo.one()
   end
 
   # The newest conversation still worth resuming for this binding. `vault_id`
@@ -2234,7 +2294,8 @@ defmodule Fountain.Conversations do
                permission_policy: perm_policy,
                caller_tools: attrs["caller_tools"] || []
              },
-             attrs["execution_limits"]
+             attrs["execution_limits"],
+             opts
            ) do
       after_conversation_created(conv)
       record_execution_allowance_created(allowance, user_id, opts)
@@ -2305,6 +2366,7 @@ defmodule Fountain.Conversations do
 
           update_conversation(conv, %{status: "failed"})
           update_sandbox(sandbox, %{status: "failed"})
+          restore_rotated_channel(conv, opts)
           result = _unsafe_get_conversation!(conv.id)
           broadcast_sidebar_update(user_id)
           {:ok, result}
@@ -2343,7 +2405,7 @@ defmodule Fountain.Conversations do
   # Keep fleet -> user advisory lock order, then stabilize ownership and
   # recheck policy. A failed conversation or allowance must release the entire
   # reservation. Analytics, audit, worker startup and prompts run after commit.
-  defp reserve_initial_conversation(sandbox_attrs, conversation_attrs, request) do
+  defp reserve_initial_conversation(sandbox_attrs, conversation_attrs, request, opts) do
     Fountain.Quotas.with_sandbox_reservation(conversation_attrs.user_id, fn ->
       # Nothing in here may take a row lock. `with_sandbox_reservation/3` holds
       # `pg_advisory_xact_lock(@fleet_lock_key)` — one lock shared by every
@@ -2368,7 +2430,8 @@ defmodule Fountain.Conversations do
           select: a.id
       ) || Repo.rollback(:not_found)
 
-      with {:ok, limits} <- resolve_admission_limits(conversation_attrs.user_id, request),
+      with :ok <- unbind_rotated_channel(conversation_attrs, opts),
+           {:ok, limits} <- resolve_admission_limits(conversation_attrs.user_id, request),
            {:ok, sandbox} <- create_sandbox(sandbox_attrs),
            {:ok, conv} <-
              insert_conversation_row(Map.put(conversation_attrs, :sandbox_id, sandbox.id)),
@@ -2848,6 +2911,11 @@ defmodule Fountain.Conversations do
               lock: "FOR SHARE"
           ) || Repo.rollback(:not_found)
 
+        case unbind_rotated_channel(attrs, opts) do
+          :ok -> :ok
+          {:error, reason} -> Repo.rollback(reason)
+        end
+
         sandbox =
           Repo.one(
             from s in Sandbox,
@@ -2884,6 +2952,7 @@ defmodule Fountain.Conversations do
         {:error, _} = err ->
           # Nothing ran. Take the row back so a refused request created
           # nothing, exactly like a refused fresh launch.
+          restore_rotated_channel(conv, opts)
           _ = Repo.delete(conv)
           broadcast_sidebar_update(conv.user_id)
           err

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -2095,9 +2095,9 @@ defmodule Fountain.Conversations do
     |> Repo.update()
   end
 
-  # Inside admission's transaction, before locking a sandbox: turn admission
-  # also takes conversation -> sandbox locks. A competing rotation must not
-  # replace a binding that has moved since the initial lookup.
+  # Inside admission's transaction, before the attachment's sandbox row lock.
+  # Keep the selected conversation stable while replacing its binding; reject
+  # a competing rotation that has already moved it.
   defp unbind_rotated_channel(attrs, opts) do
     case Keyword.get(opts, :rotate_from) do
       nil ->

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -2108,11 +2108,11 @@ defmodule Fountain.Conversations do
           %Conversation{channel_id: channel} = conv when channel == attrs.channel_id ->
             with {:ok, _} <- unbind_channel(conv), do: :ok
 
+          :busy ->
+            {:error, rotation_conflict("the previous conversation is busy; retry the rotation")}
+
           _ ->
-            {:error,
-             %Conversation{}
-             |> Ecto.Changeset.change()
-             |> Ecto.Changeset.add_error(:channel_id, "binding changed; retry the rotation")}
+            {:error, rotation_conflict("binding changed; retry the rotation")}
         end
     end
   end
@@ -2121,34 +2121,90 @@ defmodule Fountain.Conversations do
   # Restore only while this replacement still owns the binding; a later
   # rotation must win over this failure. Keep the old -> new row lock order.
   defp restore_rotated_channel(conv, opts) do
-    if id = Keyword.get(opts, :rotate_from) do
-      Repo.transaction(fn ->
-        previous = lock_rotation_conversation(id, conv)
-        replacement = lock_rotation_conversation(conv.id, conv)
-
-        case {previous, replacement} do
-          {%Conversation{channel_id: nil} = previous,
-           %Conversation{channel_id: channel} = replacement}
-          when channel == conv.channel_id ->
-            replacement |> Ecto.Changeset.change(channel_id: nil) |> Repo.update!()
-            previous |> Ecto.Changeset.change(channel_id: channel) |> Repo.update!()
-
-          _ ->
-            :ok
-        end
-      end)
+    case Keyword.get(opts, :rotate_from) do
+      nil -> :ok
+      id -> report_restore(conv, id, attempt_restore(conv, id))
     end
   end
 
+  defp attempt_restore(conv, id) do
+    Repo.transaction(fn ->
+      with %Conversation{channel_id: nil} = previous <- lock_rotation_conversation(id, conv),
+           %Conversation{channel_id: channel} = replacement
+           when channel == conv.channel_id <- lock_rotation_conversation(conv.id, conv) do
+        replacement |> Ecto.Changeset.change(channel_id: nil) |> Repo.update!()
+        previous |> Ecto.Changeset.change(channel_id: channel) |> Repo.update!()
+        :restored
+      else
+        # Contention on a row this compensation cannot wait for.
+        :busy -> Repo.rollback(:busy)
+        # A newer rotation already owns the binding, or the rows moved. That
+        # rotation must win over this failure, so leaving them alone is right.
+        _ -> :superseded
+      end
+    end)
+  rescue
+    e -> {:error, e}
+  end
+
+  defp report_restore(_conv, _id, {:ok, _outcome}), do: :ok
+
+  # A compensation, not a rollback: nothing retries it and no caller can act on
+  # it. Failing silently leaves a channel bound to nothing, which is the bug
+  # this path exists to prevent wearing a different hat, so say so.
+  defp report_restore(conv, id, other) do
+    Logger.warning(
+      "conv #{conv.id}: could not restore channel #{inspect(conv.channel_id)} to conv #{id} " <>
+        "after a failed rotation: #{inspect(other)}"
+    )
+
+    :ok
+  end
+
+  defp rotation_conflict(message) do
+    %Conversation{}
+    |> Ecto.Changeset.change()
+    |> Ecto.Changeset.add_error(:channel_id, message)
+  end
+
+  # How long a rotation may wait for the row it is replacing. On the fresh path
+  # this runs inside `with_sandbox_reservation/3`, which holds the global fleet
+  # advisory lock, and the row it wants is the one `_unsafe_create_turn_on_sandbox/3`
+  # takes `FOR UPDATE` — so an unbounded wait would let one busy channel stall
+  # provisioning for every tenant. Turn admission holds that row for a handful
+  # of local queries, so this is orders of magnitude more than it ever
+  # legitimately needs, and exceeding it means contention worth reporting
+  # rather than waiting out.
+  @rotation_lock_timeout_ms 250
+
   defp lock_rotation_conversation(id, attrs) do
     # Channel/ownership writes must serialize, but FK references may proceed.
-    from(c in Conversation,
-      where: c.id == ^id and c.user_id == ^attrs.user_id and c.agent_id == ^attrs.agent_id,
-      lock: "FOR NO KEY UPDATE"
-    )
-    |> where_vault(attrs.vault_id)
-    |> where_environment(attrs.environment_id)
-    |> Repo.one()
+    #
+    # The bound is scoped to this read and handed straight back: `SET LOCAL`
+    # lasts for the whole transaction, and admission goes on to insert rows
+    # whose foreign keys take `KEY SHARE` on `users` — which a credit posting's
+    # `FOR UPDATE` conflicts with. Leaving 250ms in force over those would turn
+    # a slow billing write into an unrescued error on a path that has none.
+    Repo.query!("SET LOCAL lock_timeout = '#{@rotation_lock_timeout_ms}ms'")
+
+    conversation =
+      from(c in Conversation,
+        where: c.id == ^id and c.user_id == ^attrs.user_id and c.agent_id == ^attrs.agent_id,
+        lock: "FOR NO KEY UPDATE"
+      )
+      |> where_vault(attrs.vault_id)
+      |> where_environment(attrs.environment_id)
+      |> Repo.one()
+
+    Repo.query!("SET LOCAL lock_timeout = DEFAULT")
+    conversation
+  rescue
+    e in Postgrex.Error ->
+      if e.postgres[:code] == :lock_not_available do
+        :busy
+      else
+        reraise(e, __STACKTRACE__)
+      end
   end
 
   # The newest conversation still worth resuming for this binding. `vault_id`

--- a/apps/fountain/test/fountain/conversations/execution_allowance_test.exs
+++ b/apps/fountain/test/fountain/conversations/execution_allowance_test.exs
@@ -402,7 +402,7 @@ defmodule Fountain.Conversations.ExecutionAllowanceRaceTest do
 
   alias Fountain.Repo
   alias Fountain.Conversations
-  alias Fountain.Conversations.Sandbox
+  alias Fountain.Conversations.{Conversation, Sandbox}
   alias Fountain.Conversations.ExecutionAllowance, as: Allowance
   import Fountain.DataCase, only: [errors_on: 1]
   import Fountain.Factory, only: [insert_conversation: 1]
@@ -620,6 +620,115 @@ defmodule Fountain.Conversations.ExecutionAllowanceRaceTest do
     test "concurrent #{path} rotations retain only the winner after a PostgreSQL lock wait" do
       rotation_race(unquote(path))
     end
+  end
+
+  # The fresh rotation unbinds the old conversation inside
+  # `with_sandbox_reservation/3`, which holds the global fleet advisory lock.
+  # The row it needs is the one turn admission takes `FOR UPDATE`, so the wait
+  # is bounded: a rotation that cannot have it is refused promptly rather than
+  # holding every other tenant's provisioning behind it.
+  test "a rotation that cannot take the old binding is refused, not left waiting" do
+    Ecto.Adapters.SQL.Sandbox.unboxed_run(Repo, fn ->
+      user =
+        Repo.insert!(%Fountain.Accounts.User{
+          email: "rotation-busy-#{Ecto.UUID.generate()}@example.test",
+          credit_balance_cents: 500,
+          sandbox_limit_override: 20
+        })
+
+      env = Fountain.Factory.insert_env(user_id: user.id)
+
+      agent =
+        Fountain.Factory.insert_agent(user_id: user.id, runtime: "claude", environment_id: env.id)
+
+      sandbox =
+        Fountain.Factory.insert_sandbox(
+          user_id: user.id,
+          agent_id: agent.id,
+          environment_id: env.id,
+          status: "ready"
+        )
+
+      previous =
+        insert_conversation(
+          user_id: user.id,
+          agent: agent,
+          sandbox: sandbox,
+          status: "idle",
+          channel_id: "rotation"
+        )
+
+      owner = self()
+
+      params = %{
+        "user_id" => user.id,
+        "agent_id" => agent.id,
+        "channel_id" => "rotation",
+        "fresh" => true,
+        "sandbox_mode" => "ephemeral"
+      }
+
+      try do
+        # Stands in for a turn being admitted on the conversation being rotated.
+        holder =
+          independent_writer(fn ->
+            Repo.transaction(fn ->
+              Repo.one(
+                from c in Conversation, where: c.id == ^previous.id, lock: "FOR NO KEY UPDATE"
+              )
+
+              send(owner, :held)
+
+              receive do
+                :release -> :ok
+              after
+                15_000 -> raise "hold barrier timed out"
+              end
+            end)
+          end)
+
+        try do
+          assert_receive :held, 5_000
+
+          rotating =
+            independent_writer(fn ->
+              Mimic.stub(Horde.DynamicSupervisor, :start_child, fn _, _ ->
+                send(owner, :unexpected_worker_started)
+                {:error, :fixture_rejection}
+              end)
+
+              started = System.monotonic_time(:millisecond)
+              result = Conversations.start_or_resume_conversation(params)
+              {result, System.monotonic_time(:millisecond) - started}
+            end)
+
+          assert {{:error, changeset}, elapsed} = Task.await(rotating, 10_000)
+
+          assert errors_on(changeset).channel_id == [
+                   "the previous conversation is busy; retry the rotation"
+                 ]
+
+          # The point of the bound: it gave up while the holder was still
+          # holding, rather than waiting the lock out under the fleet lock.
+          assert elapsed < 5_000
+
+          assert Repo.reload!(previous).channel_id == "rotation"
+          assert Conversations.channel_conversation(params).id == previous.id
+          refute_received :unexpected_worker_started
+        after
+          # Let it commit and drop the row lock before cleanup runs: a
+          # brutal_kill here leaves the backend holding `previous` long enough
+          # for the cascading delete below to fail, and the fixtures leak.
+          send(holder.pid, :release)
+          Task.yield(holder, 5_000) || Task.shutdown(holder, :brutal_kill)
+        end
+      after
+        Repo.delete_all(from e in Fountain.Audit.Event, where: e.user_id == ^user.id)
+        sandboxes = Repo.all(from s in Sandbox, where: s.user_id == ^user.id)
+        Repo.delete!(user)
+        for saved <- sandboxes, do: Repo.delete!(saved)
+      end
+    end)
   end
 
   defp rotation_race(path) do

--- a/apps/fountain/test/fountain/conversations/execution_allowance_test.exs
+++ b/apps/fountain/test/fountain/conversations/execution_allowance_test.exs
@@ -616,6 +616,132 @@ defmodule Fountain.Conversations.ExecutionAllowanceRaceTest do
     end)
   end
 
+  for path <- [:fresh, :attach] do
+    test "concurrent #{path} rotations retain only the winner after a PostgreSQL lock wait" do
+      rotation_race(unquote(path))
+    end
+  end
+
+  defp rotation_race(path) do
+    Ecto.Adapters.SQL.Sandbox.unboxed_run(Repo, fn ->
+      user =
+        Repo.insert!(%Fountain.Accounts.User{
+          email: "rotation-race-#{Ecto.UUID.generate()}@example.test",
+          credit_balance_cents: 500,
+          sandbox_limit_override: 20
+        })
+
+      env = Fountain.Factory.insert_env(user_id: user.id)
+
+      agent =
+        Fountain.Factory.insert_agent(user_id: user.id, runtime: "claude", environment_id: env.id)
+
+      sandbox =
+        Fountain.Factory.insert_sandbox(
+          user_id: user.id,
+          agent_id: agent.id,
+          environment_id: env.id,
+          status: "ready"
+        )
+
+      previous =
+        insert_conversation(
+          user_id: user.id,
+          agent: agent,
+          sandbox: sandbox,
+          status: "idle",
+          channel_id: "rotation"
+        )
+
+      owner = self()
+
+      params = %{
+        "user_id" => user.id,
+        "agent_id" => agent.id,
+        "channel_id" => "rotation",
+        "fresh" => true
+      }
+
+      params =
+        if path == :fresh,
+          do: Map.put(params, "sandbox_mode", "ephemeral"),
+          else: Map.put(params, "sandbox_id", sandbox.id)
+
+      try do
+        Repo.transaction(fn ->
+          # An actual FK insert holds KEY SHARE on the old conversation.
+          # Rotating its channel must coexist with references to that row.
+          insert_allowance(previous.id)
+
+          winner =
+            independent_writer(fn ->
+              Mimic.stub(Horde.DynamicSupervisor, :start_child, fn _, _ -> {:ok, self()} end)
+
+              Mimic.stub(Allowance, :new_changeset, fn id, limits ->
+                send(owner, :rotation_reserved)
+
+                receive do
+                  :commit -> Mimic.call_original(Allowance, :new_changeset, [id, limits])
+                after
+                  5_000 -> raise "rotation barrier timed out"
+                end
+              end)
+
+              Conversations.start_or_resume_conversation(params)
+            end)
+
+          try do
+            assert_receive :rotation_reserved, 5_000
+            # Uncommitted unbinding is invisible: the existing conversation remains
+            # the channel's binding while the winner waits to commit admission.
+            assert Conversations.channel_conversation(params).id == previous.id
+
+            loser =
+              independent_writer(fn ->
+                Mimic.stub(Horde.DynamicSupervisor, :start_child, fn _, _ ->
+                  send(owner, :unexpected_worker_started)
+                  {:error, :fixture_rejection}
+                end)
+
+                Conversations.start_or_resume_conversation(params)
+              end)
+
+            try do
+              assert_receive {:backend, winner_pid, winner_backend}, 5_000
+              assert winner_pid == winner.pid
+              assert_receive {:backend, loser_pid, loser_backend}, 5_000
+              assert loser_pid == loser.pid
+              refute winner_backend == loser_backend
+              await_blocked(loser_backend, System.monotonic_time(:millisecond) + 5_000)
+              send(winner.pid, :commit)
+              assert {:ok, replacement, :created} = Task.await(winner)
+              assert {:error, changeset} = Task.await(loser)
+              assert errors_on(changeset).channel_id == ["binding changed; retry the rotation"]
+              assert Conversations.channel_conversation(params).id == replacement.id
+              assert Repo.reload!(previous).channel_id == nil
+              assert length(Conversations.list_conversations(user.id)) == 2
+              expected_sandboxes = if path == :fresh, do: 2, else: 1
+
+              assert Repo.aggregate(from(s in Sandbox, where: s.user_id == ^user.id), :count) ==
+                       expected_sandboxes
+
+              refute_received :unexpected_worker_started
+            after
+              Task.shutdown(loser, :brutal_kill)
+            end
+          after
+            Task.shutdown(winner, :brutal_kill)
+          end
+        end)
+      after
+        Repo.delete_all(from e in Fountain.Audit.Event, where: e.user_id == ^user.id)
+        sandboxes = Repo.all(from s in Sandbox, where: s.user_id == ^user.id)
+        Repo.delete!(user)
+        for saved <- sandboxes, do: Repo.delete!(saved)
+      end
+    end)
+  end
+
   defp race(mode) do
     Ecto.Adapters.SQL.Sandbox.unboxed_run(Repo, fn ->
       # These rows must be committed: sharing the test's sandbox connection would

--- a/apps/fountain/test/fountain_web/controllers/execution_limit_admission_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/execution_limit_admission_test.exs
@@ -362,6 +362,158 @@ defmodule FountainWeb.ExecutionLimitAdmissionTest do
     assert creation_audits(ctx.user.id) == 2
   end
 
+  for path <- [:fresh, :attach], failure <- [:conversation, :allowance, :ceiling] do
+    test "#{path} rotation keeps the old binding on #{failure} refusal", ctx do
+      before_counts = counts()
+      params = rotation_attrs(ctx, unquote(path))
+
+      params =
+        case unquote(failure) do
+          :conversation ->
+            Map.put(params, "title", %{})
+
+          :allowance ->
+            stub(ExecutionAllowance, :new_changeset, fn id, limits ->
+              Mimic.call_original(ExecutionAllowance, :new_changeset, [id, limits])
+              |> Ecto.Changeset.add_error(:limits, "fixture rejection")
+            end)
+
+            params
+
+          :ceiling ->
+            stub(Fountain.RuntimeDispatch, :for_agent, fn agent ->
+              save_ceiling(ctx.user, %{max_model_turns: 2})
+              Mimic.call_original(Fountain.RuntimeDispatch, :for_agent, [agent])
+            end)
+
+            params
+        end
+
+      assert {:error, _} = Conversations.start_or_resume_conversation(params)
+      assert Repo.reload!(ctx.conv).channel_id == "limits"
+      assert counts() == before_counts
+      assert creation_audits(ctx.user.id) == 0
+      refute_received :worker_started
+    end
+  end
+
+  test "quota refusal keeps the channel bound", ctx do
+    {:ok, _} = Fountain.Accounts.update_sandbox_limit(ctx.user, 1)
+    assert {:error, _} = Conversations.start_or_resume_conversation(rotation_attrs(ctx, :fresh))
+    assert Repo.reload!(ctx.conv).channel_id == "limits"
+    refute_received :worker_started
+  end
+
+  for path <- [:fresh, :attach] do
+    test "#{path} rotation commits the replacement before worker or prompt delivery", ctx do
+      owner = self()
+
+      check_binding = fn id ->
+        refute Repo.in_transaction?()
+        assert Repo.reload!(ctx.conv).channel_id == nil
+        assert Conversations.channel_conversation(rotation_attrs(ctx, unquote(path))).id == id
+        send(owner, :binding_checked)
+      end
+
+      stub(Horde.DynamicSupervisor, :start_child, fn _, {_, opts} ->
+        check_binding.(Keyword.fetch!(opts, :conversation_id))
+        {:ok, owner}
+      end)
+
+      stub(Fountain.Conversations.ConversationServer, :send_prompt, fn id, _, _, _ ->
+        check_binding.(id)
+        :ok
+      end)
+
+      params = rotation_attrs(ctx, unquote(path))
+
+      params =
+        if unquote(path) == :attach, do: Map.put(params, "prompt", "continue"), else: params
+
+      assert {:ok, _, :created} = Conversations.start_or_resume_conversation(params)
+      assert_received :binding_checked
+    end
+  end
+
+  test "worker startup failure restores the old binding", ctx do
+    stub(Horde.DynamicSupervisor, :start_child, fn _, _ -> {:error, :fixture_rejection} end)
+
+    assert {:ok, failed, :created} =
+             Conversations.start_or_resume_conversation(rotation_attrs(ctx, :fresh))
+
+    assert failed.status == "failed"
+    assert failed.channel_id == nil
+    assert Conversations.channel_conversation(rotation_attrs(ctx, :fresh)).id == ctx.conv.id
+    assert Repo.get!(ExecutionAllowance, failed.id).limits == %{}
+  end
+
+  test "attachment prompt refusal restores the old binding", ctx do
+    before_counts = counts()
+
+    stub(Fountain.Conversations.ConversationServer, :send_prompt, fn _, _, _, _ ->
+      {:error, :busy}
+    end)
+
+    params = Map.put(rotation_attrs(ctx, :attach), "prompt", "continue")
+    assert {:error, :busy} = Conversations.start_or_resume_conversation(params)
+    assert Conversations.channel_conversation(params).id == ctx.conv.id
+    assert counts() == before_counts
+  end
+
+  test "failed startup cannot restore the old binding over a newer rotation", ctx do
+    owner = self()
+
+    stub(Horde.DynamicSupervisor, :start_child, fn _, {_, opts} ->
+      replacement = Repo.get!(Conversation, Keyword.fetch!(opts, :conversation_id))
+      replacement |> Ecto.Changeset.change(channel_id: nil) |> Repo.update!()
+
+      winner =
+        insert_conversation(
+          user_id: ctx.user.id,
+          agent: ctx.agent,
+          sandbox: ctx.sandbox,
+          status: "idle",
+          channel_id: "limits"
+        )
+
+      send(owner, {:winner, winner.id})
+      {:error, :fixture_rejection}
+    end)
+
+    assert {:ok, _, :created} =
+             Conversations.start_or_resume_conversation(rotation_attrs(ctx, :fresh))
+
+    assert_received {:winner, id}
+    assert Conversations.channel_conversation(rotation_attrs(ctx, :fresh)).id == id
+    assert Repo.reload!(ctx.conv).channel_id == nil
+  end
+
+  test "rotation cannot unbind a conversation reassigned after lookup", ctx do
+    other = insert_active_user()
+    before_counts = counts()
+
+    stub(Fountain.RuntimeDispatch, :for_agent, fn agent ->
+      ctx.conv |> Ecto.Changeset.change(user_id: other.id) |> Repo.update!()
+      Mimic.call_original(Fountain.RuntimeDispatch, :for_agent, [agent])
+    end)
+
+    params = rotation_attrs(ctx, :fresh) |> Map.delete("user_id")
+
+    assert %{"errors" => %{"channel_id" => ["binding changed; retry the rotation"]}} =
+             request(ctx, params) |> json_response(422)
+
+    assert Repo.reload!(ctx.conv).user_id == other.id
+    assert Repo.reload!(ctx.conv).channel_id == "limits"
+    assert counts() == before_counts
+    assert creation_audits(ctx.user.id) == 0
+    refute_received :worker_started
+  end
+
+  defp rotation_attrs(ctx, path),
+    do:
+      attrs(ctx, path)
+      |> Map.merge(%{"user_id" => ctx.user.id, "channel_id" => "limits", "fresh" => true})
+
   defp creation_audits(user_id) do
     Repo.aggregate(
       from(e in Fountain.Audit.Event,


### PR DESCRIPTION
Failed channel rotations could clear the old binding before replacement admission. Commit the unbinding with the replacement and roll it back on refusal. Competing rotations recheck the owned binding under a lock that permits foreign-key references.

Synchronous worker-start or attachment-prompt failures restore the original binding only while the failed replacement still owns it. Newer rotations and reassigned conversations are preserved. Worker and prompt effects occur after commit. This handles rotation of an existing binding.

Stacked on #1790: three files, +353/-6 (75 net production lines). Validation: nine reproduced parent failures; 254 related tests, including two PostgreSQL rotation races with open foreign-key references; full precommit passed 4,847 tests and 6 doctests with zero failures. [CI passed](https://github.com/BinaryBourbon/fountain/actions/runs/34451936941).
