### PR TITLE
feat: execution-limit admission (#1773-#1786)

### DIFF
--- a/apps/fountain/lib/fountain/accounts/user.ex
+++ b/apps/fountain/lib/fountain/accounts/user.ex
@@ -26,8 +26,8 @@ defmodule Fountain.Accounts.User do
     # `Fountain.Credits`, in the same transaction as the ledger row; never
     # cast from user input.
     field :credit_balance_cents, :integer, default: 0
-    # Operator-owned per-turn ceiling storage. Admission does not consume this
-    # field yet; leave it empty until ceiling enforcement is integrated.
+    # Operator-owned per-turn ceilings, read by launch preflight. Later-turn and
+    # recovery ceiling checks remain unwired; leave overrides empty until integrated.
     # Never cast it through registration, OAuth, principal or profile changes.
     field :execution_limits, :map, default: %{}
     field :role, :string, default: "user"

--- a/apps/fountain/lib/fountain/accounts/user.ex
+++ b/apps/fountain/lib/fountain/accounts/user.ex
@@ -26,6 +26,10 @@ defmodule Fountain.Accounts.User do
     # `Fountain.Credits`, in the same transaction as the ledger row; never
     # cast from user input.
     field :credit_balance_cents, :integer, default: 0
+    # Operator-owned per-turn ceiling storage. Admission does not consume this
+    # field yet; leave it empty until ceiling enforcement is integrated.
+    # Never cast it through registration, OAuth, principal or profile changes.
+    field :execution_limits, :map, default: %{}
     field :role, :string, default: "user"
     # A claimable principal (ADR 0044): a tenant with no identity, opened by a
     # trusted application before its visitor has an account and claimed later
@@ -108,6 +112,22 @@ defmodule Fountain.Accounts.User do
     user
     |> cast(attrs, [:sandbox_limit_override])
     |> validate_number(:sandbox_limit_override, greater_than_or_equal_to: 0)
+  end
+
+  @doc """
+  Validate operator-owned execution ceiling storage; nil clears the override.
+
+  This primitive does not authorize an operator or enforce a ceiling. A future
+  context must establish operator authority and audit writes before exposing it.
+  """
+  def execution_limits_changeset(user, limits) do
+    case Fountain.Conversations.ExecutionLimits.normalize(limits) do
+      {:ok, normalized} ->
+        change(user, execution_limits: normalized)
+
+      {:error, {:execution_limits_invalid, field}} ->
+        user |> change() |> add_error(:execution_limits, "invalid #{field}")
+    end
   end
 
   @doc "Changeset for the Stripe customer id, written when a Checkout is opened."

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -1885,7 +1885,8 @@ defmodule Fountain.Conversations do
                  {:ok, fresh} <- start_conversation(attrs, opts),
                  do: {:ok, fresh, :created}
           else
-            with :ok <- check_sandbox_api_resume(conv, attrs["sandbox_api_access"]),
+            with :ok <- _unsafe_check_saved_execution_allowance(conv.id),
+                 :ok <- check_sandbox_api_resume(conv, attrs["sandbox_api_access"]),
                  do: {:ok, conv, :resumed}
           end
 

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -1152,6 +1152,50 @@ defmodule Fountain.Conversations do
   end
 
   @doc """
+  Save an initial resolved allowance once, scoped to its conversation owner.
+
+  Internal persistence only: the caller must resolve trusted current ceilings
+  and prove runtime support before admission. This function does not admit work
+  or reset an active turn. No launch or HTTP path calls it yet. A duplicate
+  fails without replacing the saved policy; use `narrow_execution_allowance/3`
+  for subsequent changes. Ownership stays locked through insertion.
+  """
+  def create_execution_allowance(conversation_id, user_id, resolved_limits, opts \\ []) do
+    result =
+      Repo.transaction(fn ->
+        Repo.one(
+          from c in Conversation,
+            where: c.id == ^conversation_id and c.user_id == ^user_id,
+            select: c.id,
+            lock: "FOR SHARE"
+        ) || Repo.rollback(:not_found)
+
+        case conversation_id
+             |> ExecutionAllowance.new_changeset(resolved_limits)
+             |> Repo.insert() do
+          {:ok, allowance} -> allowance
+          {:error, changeset} -> Repo.rollback(changeset)
+        end
+      end)
+
+    with {:ok, allowance} <- result do
+      Audit.record(%{
+        user_id: user_id,
+        action: "conversation.execution_allowance_created",
+        resource_type: "conversation",
+        resource_id: conversation_id,
+        actor: Keyword.get(opts, :actor, "self"),
+        request_ip: Keyword.get(opts, :request_ip),
+        metadata: %{
+          "controls" => Enum.filter(ExecutionLimits.keys(), &Map.has_key?(allowance.limits, &1))
+        }
+      })
+
+      {:ok, allowance}
+    end
+  end
+
+  @doc """
   Narrow an existing allowance owned by `user_id`, retaining omitted controls.
 
   This edits future policy only: it neither admits work nor resets an active

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -12,6 +12,7 @@ defmodule Fountain.Conversations do
 
   alias Fountain.Audit
   alias Fountain.Conversations.{Blocks, Conversation, LogEvent, Sandbox, Turn, TurnImage}
+  alias Fountain.Conversations.{ExecutionAllowance, ExecutionLimits}
   alias Fountain.Repo
 
   # ── on the _unsafe_ prefix ────────────────────────────────────────────────
@@ -1089,7 +1090,9 @@ defmodule Fountain.Conversations do
   `capacity` is `Managoat.Runtimes.ACP.concurrency/1`. All runtimes take the
   per-sandbox advisory lock and verify that the conversation still belongs
   to this nonterminal sandbox. An integer capacity also limits concurrent
-  turns; `:unbounded` skips only that capacity check. Refusal writes no turn.
+  turns; `:unbounded` skips only that capacity check. Saved execution allowances
+  are checked under row locks; no runtime control is supported yet, so any
+  nonempty allowance refuses the turn. Refusal writes no turn.
   Usage is recorded after the transaction commits, never inside it.
   """
   def _unsafe_create_turn_on_sandbox(attrs, sandbox_id, capacity)
@@ -1104,6 +1107,16 @@ defmodule Fountain.Conversations do
           :erlang.phash2(sandbox_id)
         ])
 
+        # The allowance's FK takes KEY SHARE on this row when first inserted.
+        # UPDATE also fences that first insert when there is no allowance row
+        # to lock yet. Keep both locks through the turn insert.
+        Repo.one(
+          from c in Conversation,
+            where: c.id == ^conv_id,
+            select: c.id,
+            lock: "FOR UPDATE"
+        ) || Repo.rollback(:sandbox_unavailable)
+
         attached? =
           Repo.exists?(
             from c in Conversation,
@@ -1115,6 +1128,11 @@ defmodule Fountain.Conversations do
           )
 
         unless attached?, do: Repo.rollback(:sandbox_unavailable)
+
+        case check_saved_execution_allowance(conv_id) do
+          :ok -> :ok
+          {:error, reason} -> Repo.rollback(reason)
+        end
 
         if capacity != :unbounded and
              _unsafe_running_turns_elsewhere(sandbox_id, conv_id) >= capacity do
@@ -1130,6 +1148,25 @@ defmodule Fountain.Conversations do
     with {:ok, turn} <- result do
       record_turn_usage(turn)
       {:ok, turn}
+    end
+  end
+
+  defp check_saved_execution_allowance(conversation_id) do
+    case Repo.one(
+           from a in ExecutionAllowance,
+             where: a.conversation_id == ^conversation_id,
+             lock: "FOR SHARE"
+         ) do
+      nil ->
+        :ok
+
+      %ExecutionAllowance{limits: limits} when is_map(limits) ->
+        with {:ok, normalized} <- ExecutionLimits.normalize(limits) do
+          ExecutionLimits.require_controls(normalized, [])
+        end
+
+      _ ->
+        {:error, {:execution_limits_invalid, "object_required"}}
     end
   end
 

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -1792,7 +1792,7 @@ defmodule Fountain.Conversations do
   # ── high-level lifecycle ──────────────────────────────────────────────────────────
 
   alias Fountain.Agents
-  alias Fountain.Conversations.ConversationServer
+  alias Fountain.Conversations.{ConversationServer, ExecutionLimits}
 
   @doc """
   Like `start_conversation/2`, but a conversation already bound to
@@ -1834,6 +1834,7 @@ defmodule Fountain.Conversations do
       )
       when is_binary(channel_id) and channel_id != "" do
     with %Agents.Agent{} = agent <- Agents.get_agent(agent_id, user_id) || {:error, :not_found},
+         :ok <- check_execution_limits(attrs["execution_limits"]),
          {:ok, vault_id} <- resolve_vault_id(attrs["vault_id"], user_id, agent),
          {:ok, env_id} <- resolve_environment_id(attrs["environment_id"], user_id, agent) do
       case find_channel_conversation(user_id, agent.id, vault_id, env_id, channel_id) do
@@ -1855,6 +1856,15 @@ defmodule Fountain.Conversations do
 
   def start_or_resume_conversation(attrs, opts) do
     with {:ok, conv} <- start_conversation(attrs, opts), do: {:ok, conv, :created}
+  end
+
+  # No runtime has integrated end-to-end enforcement yet. Refuse a requested
+  # control before reserving capacity, attaching or unbinding a channel; an
+  # SDK option alone must not make admission promise a bounded execution.
+  defp check_execution_limits(request) do
+    with {:ok, limits} <- ExecutionLimits.normalize(request) do
+      ExecutionLimits.require_controls(limits, [])
+    end
   end
 
   # `true` or `"true"` — the ACP adapter sends a JSON boolean, a hand-built
@@ -1962,6 +1972,7 @@ defmodule Fountain.Conversations do
   def start_conversation(%{"agent_id" => agent_id, "user_id" => user_id} = attrs, opts)
       when is_binary(user_id) do
     with %Agents.Agent{} = agent <- Agents.get_agent(agent_id, user_id) || {:error, :not_found},
+         :ok <- check_execution_limits(attrs["execution_limits"]),
          {:ok, runtime_module} <- Fountain.RuntimeDispatch.for_agent(agent),
          {:ok, vault_id} <- resolve_vault_id(attrs["vault_id"], user_id, agent),
          {:ok, env_id} <- resolve_environment_id(attrs["environment_id"], user_id, agent),
@@ -2500,6 +2511,7 @@ defmodule Fountain.Conversations do
        )
        when is_binary(user_id) do
     with %Agents.Agent{} = agent <- Agents.get_agent(agent_id, user_id) || {:error, :not_found},
+         :ok <- check_execution_limits(attrs["execution_limits"]),
          {:ok, _runtime_module} <- Fountain.RuntimeDispatch.for_agent(agent),
          {:ok, vault_id} <- resolve_vault_id(attrs["vault_id"], user_id, agent),
          {:ok, env_id} <- resolve_environment_id(attrs["environment_id"], user_id, agent),

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -1834,7 +1834,7 @@ defmodule Fountain.Conversations do
       )
       when is_binary(channel_id) and channel_id != "" do
     with %Agents.Agent{} = agent <- Agents.get_agent(agent_id, user_id) || {:error, :not_found},
-         :ok <- check_execution_limits(attrs["execution_limits"]),
+         :ok <- check_execution_limits(user_id, attrs["execution_limits"]),
          {:ok, vault_id} <- resolve_vault_id(attrs["vault_id"], user_id, agent),
          {:ok, env_id} <- resolve_environment_id(attrs["environment_id"], user_id, agent) do
       case find_channel_conversation(user_id, agent.id, vault_id, env_id, channel_id) do
@@ -1861,9 +1861,20 @@ defmodule Fountain.Conversations do
   # No runtime has integrated end-to-end enforcement yet. Refuse a requested
   # control before reserving capacity, attaching or unbinding a channel; an
   # SDK option alone must not make admission promise a bounded execution.
-  defp check_execution_limits(request) do
-    with {:ok, limits} <- ExecutionLimits.normalize(request) do
-      ExecutionLimits.require_controls(limits, [])
+  defp check_execution_limits(user_id, request) do
+    # Ownership: each caller just fetched the agent by this authenticated user.
+    # Read the current account policy, never a request-supplied or cached map.
+    case Fountain.Accounts.get_user(user_id) do
+      %Fountain.Accounts.User{execution_limits: ceiling} when is_map(ceiling) ->
+        with {:ok, limits} <- ExecutionLimits.resolve(nil, ceiling, request) do
+          ExecutionLimits.require_controls(limits, [])
+        end
+
+      nil ->
+        {:error, :not_found}
+
+      _ ->
+        {:error, {:execution_limits_invalid, "object_required"}}
     end
   end
 
@@ -1972,7 +1983,7 @@ defmodule Fountain.Conversations do
   def start_conversation(%{"agent_id" => agent_id, "user_id" => user_id} = attrs, opts)
       when is_binary(user_id) do
     with %Agents.Agent{} = agent <- Agents.get_agent(agent_id, user_id) || {:error, :not_found},
-         :ok <- check_execution_limits(attrs["execution_limits"]),
+         :ok <- check_execution_limits(user_id, attrs["execution_limits"]),
          {:ok, runtime_module} <- Fountain.RuntimeDispatch.for_agent(agent),
          {:ok, vault_id} <- resolve_vault_id(attrs["vault_id"], user_id, agent),
          {:ok, env_id} <- resolve_environment_id(attrs["environment_id"], user_id, agent),
@@ -2511,7 +2522,7 @@ defmodule Fountain.Conversations do
        )
        when is_binary(user_id) do
     with %Agents.Agent{} = agent <- Agents.get_agent(agent_id, user_id) || {:error, :not_found},
-         :ok <- check_execution_limits(attrs["execution_limits"]),
+         :ok <- check_execution_limits(user_id, attrs["execution_limits"]),
          {:ok, _runtime_module} <- Fountain.RuntimeDispatch.for_agent(agent),
          {:ok, vault_id} <- resolve_vault_id(attrs["vault_id"], user_id, agent),
          {:ok, env_id} <- resolve_environment_id(attrs["environment_id"], user_id, agent),

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -2993,11 +2993,19 @@ defmodule Fountain.Conversations do
   (`terminated`, `failed`) — those don't auto-resume.
   """
   def wake_conversation(conv_id, initial_prompt \\ nil) do
-    # Ownership: called from ConversationServer (which established ownership
-    # before starting) and the boot-time rehydrator sweep. The agent fetched
-    # below is the conversation's own agent_id, same tenant by construction.
+    wake_conversation_for(conv_id, initial_prompt, :work)
+  end
+
+  defp wake_conversation_for(conv_id, initial_prompt, purpose) do
+    # Ownership is established by callers before reaching this internal wake
+    # path. The agent fetched below is the conversation's own agent_id,
+    # same tenant by construction.
     with %Conversation{} = conv <- _unsafe_get_conversation(conv_id) || {:error, :not_found},
          :ok <- assert_resumable(conv),
+         # Preflight only: no database lock spans provider I/O. Turn admission
+         # checks again under its transaction. Cancellation must remain reachable.
+         :ok <-
+           if(purpose == :interrupt, do: :ok, else: check_saved_execution_allowance(conv.id)),
          %Agents.Agent{} = agent <-
            (conv.agent_id && Agents._unsafe_get_agent(conv.agent_id)) || {:error, :no_agent},
          {:ok, runtime_module} <- Fountain.RuntimeDispatch.for_agent(conv) do
@@ -3104,7 +3112,7 @@ defmodule Fountain.Conversations do
         {:error, :not_found}
 
       %Conversation{status: "running"} ->
-        with {:ok, conv} <- wake_conversation(conv_id),
+        with {:ok, conv} <- wake_conversation_for(conv_id, nil, :interrupt),
              pid when is_pid(pid) <- ConversationServer.whereis(conv.id) do
           {:ok, pid}
         else

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -1129,7 +1129,7 @@ defmodule Fountain.Conversations do
 
         unless attached?, do: Repo.rollback(:sandbox_unavailable)
 
-        case check_saved_execution_allowance(conv_id) do
+        case _unsafe_check_saved_execution_allowance(conv_id) do
           :ok -> :ok
           {:error, reason} -> Repo.rollback(reason)
         end
@@ -1151,7 +1151,12 @@ defmodule Fountain.Conversations do
     end
   end
 
-  defp check_saved_execution_allowance(conversation_id) do
+  @doc """
+  Refuse saved allowances that this deployment cannot enforce. Internal callers
+  must establish conversation ownership first. Outside turn admission this is
+  only a preflight; the turn transaction rechecks under its row locks.
+  """
+  def _unsafe_check_saved_execution_allowance(conversation_id) do
     case Repo.one(
            from a in ExecutionAllowance,
              where: a.conversation_id == ^conversation_id,
@@ -3005,7 +3010,11 @@ defmodule Fountain.Conversations do
          # Preflight only: no database lock spans provider I/O. Turn admission
          # checks again under its transaction. Cancellation must remain reachable.
          :ok <-
-           if(purpose == :interrupt, do: :ok, else: check_saved_execution_allowance(conv.id)),
+           if(purpose == :interrupt,
+             do: :ok,
+             else: _unsafe_check_saved_execution_allowance(conv.id)
+           ),
+         # Ownership: conv.agent_id belongs to this established-owner conversation.
          %Agents.Agent{} = agent <-
            (conv.agent_id && Agents._unsafe_get_agent(conv.agent_id)) || {:error, :no_agent},
          {:ok, runtime_module} <- Fountain.RuntimeDispatch.for_agent(conv) do

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -1152,6 +1152,72 @@ defmodule Fountain.Conversations do
   end
 
   @doc """
+  Narrow an existing allowance owned by `user_id`, retaining omitted controls.
+
+  This edits future policy only: it neither admits work nor resets an active
+  turn's usage/deadline. Initial allowance creation and current-ceiling checks
+  remain admission responsibilities. Missing and foreign records return the
+  same error. Concurrent writers revalidate against the latest locked value.
+  """
+  def narrow_execution_allowance(conversation_id, user_id, request, opts \\ []) do
+    result =
+      Repo.transaction(fn ->
+        # Keep ownership stable through the write; turn admission locks this
+        # conversation before its allowance too. No sandbox/provider work here.
+        Repo.one(
+          from c in Conversation,
+            where: c.id == ^conversation_id and c.user_id == ^user_id,
+            select: c.id,
+            lock: "FOR SHARE"
+        ) || Repo.rollback(:not_found)
+
+        allowance =
+          Repo.one(
+            from a in ExecutionAllowance,
+              where: a.conversation_id == ^conversation_id,
+              lock: "FOR UPDATE"
+          ) || Repo.rollback(:not_found)
+
+        unless is_map(allowance.limits),
+          do: Repo.rollback({:execution_limits_invalid, "object_required"})
+
+        changeset = ExecutionAllowance.narrow_changeset(allowance, request)
+
+        write =
+          if changeset.valid? and not Map.has_key?(changeset.changes, :limits),
+            do: {:ok, allowance},
+            else: Repo.update(changeset)
+
+        case write do
+          {:ok, updated} ->
+            changed =
+              Enum.filter(ExecutionLimits.keys(), &(updated.limits[&1] != allowance.limits[&1]))
+
+            {updated, changed}
+
+          {:error, changeset} ->
+            Repo.rollback(changeset)
+        end
+      end)
+
+    with {:ok, {updated, changed}} <- result do
+      if changed != [] do
+        Audit.record(%{
+          user_id: user_id,
+          action: "conversation.execution_allowance_narrowed",
+          resource_type: "conversation",
+          resource_id: conversation_id,
+          actor: Keyword.get(opts, :actor, "self"),
+          request_ip: Keyword.get(opts, :request_ip),
+          metadata: %{"changed" => changed}
+        })
+      end
+
+      {:ok, updated}
+    end
+  end
+
+  @doc """
   Refuse saved allowances that this deployment cannot enforce. Internal callers
   must establish conversation ownership first. Outside turn admission this is
   only a preflight; the turn transaction rechecks under its row locks.

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -1671,15 +1671,16 @@ defmodule Fountain.Conversations.ConversationServer do
     else
       conv = Conversations._unsafe_get_conversation!(state.conversation_id)
 
-      case TurnMachine.gate(conv.user_id, state.inference_source) do
-        :ok ->
-          state = close_autonomous_turn(state, "superseded_by_prompt")
-          agent = if conv.agent_id, do: Agents._unsafe_get_agent!(conv.agent_id)
-          {:noreply, kick_turn(state, prompt, agent, images)}
-
+      # Ownership: this server owns conv. Policy may have changed since wake.
+      with :ok <- Conversations._unsafe_check_saved_execution_allowance(conv.id),
+           :ok <- TurnMachine.gate(conv.user_id, state.inference_source) do
+        state = close_autonomous_turn(state, "superseded_by_prompt")
+        agent = if conv.agent_id, do: Agents._unsafe_get_agent!(conv.agent_id)
+        {:noreply, kick_turn(state, prompt, agent, images)}
+      else
         {:error, reason} ->
-          # No caller to reply to — the wake door reports the same refusal
-          # synchronously; this backstop only has to not run the turn.
+          # A cast has no caller to reply to. Preserve existing work and its
+          # connection when this queued prompt cannot be admitted.
           Logger.info(
             "conv #{state.conversation_id}: dropping initial prompt (#{inspect(reason)})"
           )

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -1506,15 +1506,14 @@ defmodule Fountain.Conversations.ConversationServer do
     if Connection.user_turn_running?(state.current_turn) do
       {:reply, {:error, :busy}, state}
     else
-      # A background cycle the agent was still narrating is closed by the
-      # human's prompt, not queued behind it (#817): its updates are already
-      # on the transcript, and the agent will fold whatever it was doing into
-      # the answer to this prompt.
-      state = close_autonomous_turn(state, "superseded_by_prompt")
+      # This server already owns the conversation. Refuse before superseding
+      # autonomous work or touching its connection; turn admission rechecks.
       conv = Conversations._unsafe_get_conversation!(state.conversation_id)
 
-      with :ok <- TurnMachine.gate(conv.user_id, state.inference_source),
+      with :ok <- Conversations._unsafe_check_saved_execution_allowance(conv.id),
+           :ok <- TurnMachine.gate(conv.user_id, state.inference_source),
            :ok <- TurnMachine.capacity_gate(state.sandbox_id, conv) do
+        state = close_autonomous_turn(state, "superseded_by_prompt")
         agent = if conv.agent_id, do: Agents._unsafe_get_agent!(conv.agent_id)
         {:reply, :ok, kick_turn(state, prompt, agent, images)}
       else

--- a/apps/fountain/lib/fountain/conversations/execution_allowance.ex
+++ b/apps/fountain/lib/fountain/conversations/execution_allowance.ex
@@ -1,0 +1,53 @@
+defmodule Fountain.Conversations.ExecutionAllowance do
+  @moduledoc """
+  Versioned storage for a conversation's resolved execution allowance.
+
+  This is a storage primitive, not an admission or enforcement API. No service
+  path writes these records yet. Admission must establish conversation ownership,
+  resolve current ceilings and prove runtime support before saving an allowance.
+  Later turns and recovery must consult it before this becomes a usable setting.
+
+  Updates must use `narrow_changeset/2`. A stale revision fails with
+  `Ecto.StaleEntryError` (or a changeset error with `stale_error_field: :revision`).
+  Reload and revalidate the request after a conflict; never retry the old map as
+  a replacement. An opaque revision avoids counter rollover accepting old writes.
+  This record does not reset or replace an in-flight turn's deadline or usage.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Fountain.Conversations.{Conversation, ExecutionLimits}
+
+  @primary_key false
+  @foreign_key_type :binary_id
+  schema "execution_allowances" do
+    belongs_to :conversation, Conversation, primary_key: true
+    field :limits, :map, default: %{}
+    field :revision, :binary_id
+    timestamps(type: :utc_datetime_usec)
+  end
+
+  @doc "Insert a resolved allowance once; a duplicate cannot replace it."
+  def new_changeset(conversation_id, limits) do
+    %__MODULE__{}
+    |> change(conversation_id: conversation_id, revision: Ecto.UUID.generate())
+    |> put_limits(ExecutionLimits.normalize(limits))
+    |> validate_required([:conversation_id, :revision])
+    |> foreign_key_constraint(:conversation_id)
+    |> unique_constraint(:conversation_id, name: :execution_allowances_pkey)
+  end
+
+  @doc "Narrow the saved allowance, retaining omitted fields and checking its revision."
+  def narrow_changeset(%__MODULE__{} = allowance, request) do
+    allowance
+    |> change()
+    |> put_limits(ExecutionLimits.for_resume(nil, nil, allowance.limits, request))
+    |> optimistic_lock(:revision, fn _ -> Ecto.UUID.generate() end)
+  end
+
+  defp put_limits(changeset, {:ok, limits}), do: put_change(changeset, :limits, limits)
+
+  defp put_limits(changeset, {:error, {reason, field}}),
+    do: add_error(changeset, :limits, "#{reason}: #{field}")
+end

--- a/apps/fountain/lib/fountain/conversations/execution_allowance.ex
+++ b/apps/fountain/lib/fountain/conversations/execution_allowance.ex
@@ -12,6 +12,7 @@ defmodule Fountain.Conversations.ExecutionAllowance do
   Reload and revalidate the request after a conflict; never retry the old map as
   a replacement. An opaque revision avoids counter rollover accepting old writes.
   This record does not reset or replace an in-flight turn's deadline or usage.
+  A null saved policy is corrupt, not an unrestricted allowance to narrow.
   """
 
   use Ecto.Schema
@@ -39,11 +40,17 @@ defmodule Fountain.Conversations.ExecutionAllowance do
   end
 
   @doc "Narrow the saved allowance, retaining omitted fields and checking its revision."
-  def narrow_changeset(%__MODULE__{} = allowance, request) do
+  def narrow_changeset(%__MODULE__{limits: limits} = allowance, request) when is_map(limits) do
     allowance
     |> change()
     |> put_limits(ExecutionLimits.for_resume(nil, nil, allowance.limits, request))
     |> optimistic_lock(:revision, fn _ -> Ecto.UUID.generate() end)
+  end
+
+  def narrow_changeset(%__MODULE__{} = allowance, _request) do
+    allowance
+    |> change()
+    |> put_limits({:error, {:execution_limits_invalid, "object_required"}})
   end
 
   defp put_limits(changeset, {:ok, limits}), do: put_change(changeset, :limits, limits)

--- a/apps/fountain/lib/fountain/conversations/execution_allowance.ex
+++ b/apps/fountain/lib/fountain/conversations/execution_allowance.ex
@@ -3,7 +3,8 @@ defmodule Fountain.Conversations.ExecutionAllowance do
   Versioned storage for a conversation's resolved execution allowance.
 
   This is a storage primitive, not an admission or enforcement API. Use the
-  owner-scoped `Conversations.narrow_execution_allowance/3` for existing records.
+  owner-scoped `Conversations.create_execution_allowance/3` for initial records
+  and `Conversations.narrow_execution_allowance/3` for subsequent changes.
   Initial admission must establish conversation ownership,
   resolve current ceilings and prove runtime support before saving an allowance.
   Later turns and recovery must consult it before this becomes a usable setting.

--- a/apps/fountain/lib/fountain/conversations/execution_allowance.ex
+++ b/apps/fountain/lib/fountain/conversations/execution_allowance.ex
@@ -2,8 +2,9 @@ defmodule Fountain.Conversations.ExecutionAllowance do
   @moduledoc """
   Versioned storage for a conversation's resolved execution allowance.
 
-  This is a storage primitive, not an admission or enforcement API. No service
-  path writes these records yet. Admission must establish conversation ownership,
+  This is a storage primitive, not an admission or enforcement API. Use the
+  owner-scoped `Conversations.narrow_execution_allowance/3` for existing records.
+  Initial admission must establish conversation ownership,
   resolve current ceilings and prove runtime support before saving an allowance.
   Later turns and recovery must consult it before this becomes a usable setting.
 

--- a/apps/fountain/lib/fountain/conversations/execution_limits.ex
+++ b/apps/fountain/lib/fountain/conversations/execution_limits.ex
@@ -1,0 +1,143 @@
+defmodule Fountain.Conversations.ExecutionLimits do
+  @moduledoc """
+  Typed per-turn policy, independent of provider-operation state.
+
+  Host and account maps are ceilings. Every configured ceiling is inherited;
+  omitting a request, an empty map, or an omitted field never disables one.
+  A launch request may tighten the effective ceiling, never widen it. Explicit
+  null fields, numeric strings, unknown keys and duplicate atom/string keys are
+  invalid. Clearing an operator ceiling is outside the launch/resume request path.
+
+  Callers supply a conversation's saved launch allowance. A new turn
+  intersects that allowance with current host/account ceilings; a policy
+  change can tighten future turns, but cannot grant an existing conversation a
+  larger allowance. Recovery must reuse the original turn's persisted deadline
+  and SDK limits rather than call this resolver to create another allowance.
+
+  SDK request/dollar limits apply to a supported SDK Query, not a durable spend
+  ledger. They do not bound blocked tools, work already in flight, or billed cost.
+  The transport must separately prove support for every resolved control before
+  admitting work. This module alone does not enable execution-limit enforcement.
+  """
+
+  @keys ~w(wall_time_seconds max_model_turns max_estimated_cost_usd)
+  @atoms [:wall_time_seconds, :max_model_turns, :max_estimated_cost_usd]
+  @key_map Map.new(Enum.zip(@atoms, @keys))
+  @max_safe_integer 9_007_199_254_740_991
+  # A wire-format bound, not a default allowance. Keeps deadline arithmetic
+  # representable and leaves actual allowances to the host/account policy.
+  @max_wall_seconds 31_536_000
+
+  @type t :: %{optional(String.t()) => pos_integer() | float()}
+  @type error :: {:execution_limits_invalid, String.t()} | {:execution_limits_widen, String.t()}
+
+  def keys, do: @keys
+  def max_wall_seconds, do: @max_wall_seconds
+
+  @doc "Parse the operator's JSON environment setting without echoing its input."
+  def from_json_env(value) when value in [nil, ""], do: {:ok, %{}}
+
+  def from_json_env(value) when is_binary(value) do
+    case Jason.decode(value) do
+      {:ok, attrs} when is_map(attrs) -> normalize(attrs)
+      {:ok, _} -> invalid("object_required")
+      {:error, _} -> invalid("invalid_json")
+    end
+  end
+
+  @doc "Normalize API or internal fields to the durable JSON representation."
+  @spec normalize(term()) :: {:ok, t()} | {:error, error()}
+  def normalize(nil), do: {:ok, %{}}
+
+  def normalize(attrs) when is_map(attrs) and not is_struct(attrs) do
+    Enum.reduce_while(attrs, {:ok, %{}}, fn {key, value}, {:ok, normalized} ->
+      field = if key in @keys, do: key, else: Map.get(@key_map, key)
+
+      cond do
+        is_nil(field) -> {:halt, invalid("unknown_field")}
+        Map.has_key?(normalized, field) -> {:halt, invalid("duplicate_field")}
+        not valid_value?(field, value) -> {:halt, invalid(field)}
+        true -> {:cont, {:ok, Map.put(normalized, field, value)}}
+      end
+    end)
+  end
+
+  def normalize(_), do: invalid("object_required")
+
+  @doc "Resolve a launch request against all configured host/account ceilings."
+  @spec resolve(term(), term(), term()) :: {:ok, t()} | {:error, error()}
+  def resolve(host, account, request) do
+    with {:ok, ceilings} <- intersect(host, account),
+         {:ok, requested} <- normalize(request),
+         :ok <- check_narrows(ceilings, requested) do
+      {:ok, Map.merge(ceilings, requested)}
+    end
+  end
+
+  @doc "Tighten an existing allowance without creating a fresh recovery budget."
+  @spec for_new_turn(term(), term(), term()) :: {:ok, t()} | {:error, error()}
+  def for_new_turn(host, account, launch_allowance) do
+    with {:ok, ceilings} <- intersect(host, account) do
+      intersect(ceilings, launch_allowance)
+    end
+  end
+
+  @doc "A channel resume may narrow the saved allowance, never clear or widen it."
+  @spec for_resume(term(), term(), term(), term()) :: {:ok, t()} | {:error, error()}
+  def for_resume(host, account, launch_allowance, request) do
+    with {:ok, allowance} <- for_new_turn(host, account, launch_allowance),
+         {:ok, requested} <- normalize(request),
+         :ok <- check_narrows(allowance, requested) do
+      {:ok, Map.merge(allowance, requested)}
+    end
+  end
+
+  @doc "Refuse every control the actual transport/runtime cannot enforce."
+  @spec require_controls(t(), [String.t()]) ::
+          :ok | {:error, {:execution_limits_unsupported, [String.t()]}}
+  def require_controls(limits, supported) do
+    missing = @keys |> Enum.filter(&(Map.has_key?(limits, &1) and &1 not in supported))
+    if missing == [], do: :ok, else: {:error, {:execution_limits_unsupported, missing}}
+  end
+
+  @doc "The two allowlisted SDK fields, converted without creating atoms from input."
+  @spec sdk_options(t()) :: map() | nil
+  def sdk_options(limits) do
+    options =
+      for {atom, field} <- @key_map,
+          field != "wall_time_seconds",
+          Map.has_key?(limits, field),
+          into: %{},
+          do: {atom, Map.fetch!(limits, field)}
+
+    if options == %{}, do: nil, else: options
+  end
+
+  defp intersect(left, right) do
+    with {:ok, left} <- normalize(left),
+         {:ok, right} <- normalize(right) do
+      {:ok, Map.merge(left, right, fn _, a, b -> min(a, b) end)}
+    end
+  end
+
+  defp check_narrows(ceilings, requested) do
+    case Enum.find(@keys, fn key ->
+           Map.has_key?(ceilings, key) and Map.has_key?(requested, key) and
+             requested[key] > ceilings[key]
+         end) do
+      nil -> :ok
+      field -> {:error, {:execution_limits_widen, field}}
+    end
+  end
+
+  defp valid_value?("wall_time_seconds", value),
+    do: is_integer(value) and value > 0 and value <= @max_wall_seconds
+
+  defp valid_value?("max_model_turns", value),
+    do: is_integer(value) and value > 0 and value <= @max_safe_integer
+
+  defp valid_value?("max_estimated_cost_usd", value),
+    do: is_number(value) and value > 0 and value <= @max_safe_integer
+
+  defp invalid(field), do: {:error, {:execution_limits_invalid, field}}
+end

--- a/apps/fountain/lib/fountain/conversations/rehydrator.ex
+++ b/apps/fountain/lib/fountain/conversations/rehydrator.ex
@@ -11,6 +11,10 @@ defmodule Fountain.Conversations.Rehydrator do
   sandboxes from a crashed mid-provision are left as-is — the user's next
   action lazily resolves them via `wake_conversation`.
 
+  Saved execution allowances must be enforceable before a server is started.
+  Refused rows remain unchanged; this preflight does not stop provider work
+  that was already running. Turn admission still rechecks the saved policy.
+
   ## Clustered boot
 
   `run/1` fires on every node as it boots, but libcluster needs a few
@@ -126,7 +130,9 @@ defmodule Fountain.Conversations.Rehydrator do
   end
 
   defp spawn_server(conv) do
-    with %Agents.Agent{} = _agent <-
+    # Ownership: internal boot sweep; each conversation supplies its own agent_id.
+    with :ok <- Conversations._unsafe_check_saved_execution_allowance(conv.id),
+         %Agents.Agent{} = _agent <-
            (conv.agent_id && Agents._unsafe_get_agent(conv.agent_id)) || {:skip, :no_agent},
          {:ok, runtime_module} <- Fountain.RuntimeDispatch.for_agent(conv) do
       Fountain.ConversationSupervisor

--- a/apps/fountain/lib/fountain_web/controllers/agui_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/agui_controller.ex
@@ -121,6 +121,8 @@ defmodule FountainWeb.AguiController do
     ],
     request_body: {"AG-UI run input", "application/json", @run_input},
     responses: [
+      unprocessable_entity:
+        {"Saved execution policy refused", "application/json", FountainWeb.Schemas.Error},
       conflict: {"Conflicting state", "application/json", FountainWeb.Schemas.Error},
       ok: {"AG-UI event stream", "text/event-stream", %OpenApiSpex.Schema{type: :string}},
       bad_request: {"Malformed run input", "application/json", FountainWeb.Schemas.Error},

--- a/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
@@ -15,6 +15,24 @@ defmodule FountainWeb.FallbackController do
     |> json(%{error: "not_found"})
   end
 
+  def call(conn, {:error, {:execution_limits_invalid, field}}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{
+      error: "execution_limits_invalid",
+      errors: %{execution_limits: ["invalid #{field}"]}
+    })
+  end
+
+  def call(conn, {:error, {:execution_limits_unsupported, controls}}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{
+      error: "execution_limits_unsupported",
+      message: "Execution-limit enforcement is unavailable: #{Enum.join(controls, ", ")}."
+    })
+  end
+
   # start_conversation rejects an unknown / cross-tenant vault by returning
   # {:error, :vault_not_found}. Surface as 404 so callers can't tell the
   # difference between "no such vault" and "vault belongs to someone else".

--- a/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
@@ -24,6 +24,15 @@ defmodule FountainWeb.FallbackController do
     })
   end
 
+  def call(conn, {:error, {:execution_limits_widen, field}}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{
+      error: "execution_limits_widen",
+      errors: %{execution_limits: ["cannot widen #{field}"]}
+    })
+  end
+
   def call(conn, {:error, {:execution_limits_unsupported, controls}}) do
     conn
     |> put_status(:unprocessable_entity)

--- a/apps/fountain/lib/fountain_web/controllers/openai_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/openai_controller.ex
@@ -287,6 +287,7 @@ defmodule FountainWeb.OpenAIController do
     ],
     request_body: {"Chat-completions request", "application/json", @chat_request},
     responses: [
+      unprocessable_entity: {"Saved execution policy refused", "application/json", @openai_error},
       internal_server_error: {"Internal error", "application/json", @openai_error},
       ok:
         {"The completion (or, with `stream: true`, its SSE stream)", "application/json",
@@ -660,6 +661,26 @@ defmodule FountainWeb.OpenAIController do
   # OpenAI's envelope for what this dialect owns; the rest of the context's
   # refusal vocabulary keeps FallbackController's status codes, which are
   # what a client acts on, wrapped in the same envelope so an SDK parses them.
+  defp respond_error(conn, {:error, {:execution_limits_invalid, field}}),
+    do:
+      openai_error(
+        conn,
+        422,
+        "Invalid execution limits: #{field}.",
+        "invalid_request_error",
+        "execution_limits_invalid"
+      )
+
+  defp respond_error(conn, {:error, {:execution_limits_unsupported, controls}}),
+    do:
+      openai_error(
+        conn,
+        422,
+        "Execution-limit enforcement is unavailable: #{Enum.join(controls, ", ")}.",
+        "invalid_request_error",
+        "execution_limits_unsupported"
+      )
+
   defp respond_error(conn, {:error, {:invalid_request, message}}),
     do: openai_error(conn, 400, message, "invalid_request_error", nil)
 

--- a/apps/fountain/priv/repo/migrations/20260909090000_create_execution_allowances.exs
+++ b/apps/fountain/priv/repo/migrations/20260909090000_create_execution_allowances.exs
@@ -1,0 +1,29 @@
+defmodule Fountain.Repo.Migrations.CreateExecutionAllowances do
+  use Ecto.Migration
+
+  def up do
+    create table(:execution_allowances, primary_key: false) do
+      add :conversation_id, references(:conversations, type: :binary_id, on_delete: :delete_all),
+        primary_key: true
+
+      add :limits, :map, null: false, default: %{}
+      add :revision, :binary_id, null: false
+      timestamps(type: :utc_datetime_usec)
+    end
+  end
+
+  def down do
+    # Lock before checking, so a concurrent insert cannot lose an allowance.
+    execute "LOCK TABLE execution_allowances IN ACCESS EXCLUSIVE MODE"
+
+    execute """
+    DO $$ BEGIN
+      IF EXISTS (SELECT 1 FROM execution_allowances) THEN
+        RAISE EXCEPTION 'cannot discard saved execution allowances';
+      END IF;
+    END $$;
+    """
+
+    drop table(:execution_allowances)
+  end
+end

--- a/apps/fountain/priv/repo/migrations/20260910020000_add_account_execution_limits.exs
+++ b/apps/fountain/priv/repo/migrations/20260910020000_add_account_execution_limits.exs
@@ -1,0 +1,32 @@
+defmodule Fountain.Repo.Migrations.AddAccountExecutionLimits do
+  use Ecto.Migration
+
+  def up do
+    alter table(:users) do
+      add :execution_limits, :map, null: false, default: %{}
+    end
+
+    create constraint(:users, :users_execution_limits_object,
+             check: "jsonb_typeof(execution_limits) = 'object'"
+           )
+  end
+
+  def down do
+    # Fence writes before checking: rollback must not silently discard a ceiling.
+    execute "LOCK TABLE users IN ACCESS EXCLUSIVE MODE"
+
+    execute """
+    DO $$ BEGIN
+      IF EXISTS (SELECT 1 FROM users WHERE execution_limits <> '{}'::jsonb) THEN
+        RAISE EXCEPTION 'cannot discard configured account execution ceilings';
+      END IF;
+    END $$;
+    """
+
+    drop constraint(:users, :users_execution_limits_object)
+
+    alter table(:users) do
+      remove :execution_limits
+    end
+  end
+end

--- a/apps/fountain/test/fountain/accounts/execution_limits_test.exs
+++ b/apps/fountain/test/fountain/accounts/execution_limits_test.exs
@@ -1,0 +1,114 @@
+defmodule Fountain.Accounts.ExecutionLimitsTest do
+  use Fountain.DataCase, async: true
+
+  alias Fountain.Accounts.User
+
+  test "operator changes persist canonical ceilings without changing another account" do
+    user = insert_user()
+    other = insert_user()
+    assert user.execution_limits == %{}
+
+    updated =
+      user
+      |> User.execution_limits_changeset(%{
+        wall_time_seconds: 60,
+        max_model_turns: 10,
+        max_estimated_cost_usd: 0.5
+      })
+      |> Repo.update!()
+
+    assert Repo.reload!(updated).execution_limits == %{
+             "wall_time_seconds" => 60,
+             "max_model_turns" => 10,
+             "max_estimated_cost_usd" => 0.5
+           }
+
+    assert Repo.reload!(other).execution_limits == %{}
+  end
+
+  test "an operator can replace or clear its account override" do
+    user = insert_user()
+
+    for limits <- [%{max_model_turns: 2}, %{max_model_turns: 20}, nil, %{}] do
+      updated = Repo.reload!(user) |> User.execution_limits_changeset(limits) |> Repo.update!()
+
+      expected =
+        if limits in [nil, %{}], do: %{}, else: %{"max_model_turns" => limits.max_model_turns}
+
+      assert Repo.reload!(updated).execution_limits == expected
+    end
+  end
+
+  test "invalid ceilings are refused without changing stored values or echoing input" do
+    user =
+      insert_user() |> User.execution_limits_changeset(%{max_model_turns: 2}) |> Repo.update!()
+
+    for {limits, field} <- [
+          {%{wall_time_seconds: nil}, "wall_time_seconds"},
+          {%{max_model_turns: "2"}, "max_model_turns"},
+          {%{max_estimated_cost_usd: 0}, "max_estimated_cost_usd"},
+          {%{"private-field" => "private-value"}, "unknown_field"},
+          {%{:max_model_turns => 2, "max_model_turns" => 3}, "duplicate_field"},
+          {[], "object_required"}
+        ] do
+      assert {:error, changeset} =
+               user |> User.execution_limits_changeset(limits) |> Repo.update()
+
+      assert errors_on(changeset).execution_limits == ["invalid #{field}"]
+      assert Repo.reload!(user) == user
+    end
+  end
+
+  test "registration, OAuth and principal creation cannot set ceilings" do
+    attrs = %{
+      email: "ceiling-#{Ecto.UUID.generate()}@example.test",
+      password: "valid-password",
+      execution_limits: %{max_model_turns: 999}
+    }
+
+    for changeset <- [
+          User.registration_changeset(%User{}, attrs),
+          User.oauth_registration_changeset(%User{}, %{attrs | email: "oauth-#{attrs.email}"}),
+          User.principal_changeset(%User{}, attrs)
+        ] do
+      assert Repo.insert!(changeset).execution_limits == %{}
+    end
+  end
+
+  test "ordinary account changes cannot clear or widen stored ceilings" do
+    user =
+      insert_user() |> User.execution_limits_changeset(%{max_model_turns: 2}) |> Repo.update!()
+
+    for limits <- [nil, %{}, %{"max_model_turns" => 999}] do
+      attrs = %{
+        "execution_limits" => limits,
+        "theme_preference" => "dark",
+        "conversation_view_mode" => "raw"
+      }
+
+      for changeset <- [
+            User.theme_changeset(user, attrs),
+            User.preferences_changeset(user, attrs)
+          ] do
+        assert Repo.update!(changeset).execution_limits == user.execution_limits
+        assert Repo.reload!(user).execution_limits == user.execution_limits
+      end
+    end
+  end
+
+  test "the database rejects SQL null, JSON null and non-object ceilings" do
+    user = insert_user()
+
+    for json <- [nil, "null", "[]", "1", "\"value\""] do
+      assert {:error, %Postgrex.Error{postgres: %{code: code}}} =
+               Repo.query(
+                 "UPDATE users SET execution_limits = $1::text::jsonb WHERE id = $2",
+                 [json, Ecto.UUID.dump!(user.id)],
+                 mode: :savepoint
+               )
+
+      assert code == if(is_nil(json), do: :not_null_violation, else: :check_violation)
+      assert Repo.reload!(user).execution_limits == %{}
+    end
+  end
+end

--- a/apps/fountain/test/fountain/audit_guardrail_test.exs
+++ b/apps/fountain/test/fountain/audit_guardrail_test.exs
@@ -57,6 +57,8 @@ defmodule Fountain.AuditGuardrailTest do
     {"inference credential clear", &__MODULE__.do_cred_clear/1, "inference_credential.delete"},
     {"conversation delete", &__MODULE__.do_conv_delete/1, "conversation.deleted"},
     {"conversation caller tools", &__MODULE__.do_caller_tools/1, "conversation.caller_tools_set"},
+    {"allowance narrowing", &__MODULE__.do_allowance_narrowing/1,
+     "conversation.execution_allowance_narrowed"},
     {"sandbox reset", &__MODULE__.do_sandbox_reset/1, "sandbox.reset"},
     {"role change", &__MODULE__.do_role_change/1, "account.role_changed"},
     {"sandbox limit change", &__MODULE__.do_limit_change/1, "account.sandbox_limit_changed"},
@@ -386,6 +388,16 @@ defmodule Fountain.AuditGuardrailTest do
     sandbox = insert_sandbox(user_id: user.id, status: "ready")
     conv = insert_conversation(user_id: user.id, agent: agent, sandbox_id: sandbox.id)
     {:ok, _} = Conversations.delete_conversation(conv)
+  end
+
+  def do_allowance_narrowing(user) do
+    conv = insert_conversation(user_id: user.id)
+
+    conv.id
+    |> Fountain.Conversations.ExecutionAllowance.new_changeset(%{max_model_turns: 10})
+    |> Repo.insert!()
+
+    {:ok, _} = Conversations.narrow_execution_allowance(conv.id, user.id, %{max_model_turns: 2})
   end
 
   def do_caller_tools(user) do

--- a/apps/fountain/test/fountain/audit_guardrail_test.exs
+++ b/apps/fountain/test/fountain/audit_guardrail_test.exs
@@ -57,6 +57,8 @@ defmodule Fountain.AuditGuardrailTest do
     {"inference credential clear", &__MODULE__.do_cred_clear/1, "inference_credential.delete"},
     {"conversation delete", &__MODULE__.do_conv_delete/1, "conversation.deleted"},
     {"conversation caller tools", &__MODULE__.do_caller_tools/1, "conversation.caller_tools_set"},
+    {"allowance creation", &__MODULE__.do_allowance_creation/1,
+     "conversation.execution_allowance_created"},
     {"allowance narrowing", &__MODULE__.do_allowance_narrowing/1,
      "conversation.execution_allowance_narrowed"},
     {"sandbox reset", &__MODULE__.do_sandbox_reset/1, "sandbox.reset"},
@@ -388,6 +390,11 @@ defmodule Fountain.AuditGuardrailTest do
     sandbox = insert_sandbox(user_id: user.id, status: "ready")
     conv = insert_conversation(user_id: user.id, agent: agent, sandbox_id: sandbox.id)
     {:ok, _} = Conversations.delete_conversation(conv)
+  end
+
+  def do_allowance_creation(user) do
+    conv = insert_conversation(user_id: user.id)
+    {:ok, _} = Conversations.create_execution_allowance(conv.id, user.id, %{})
   end
 
   def do_allowance_narrowing(user) do

--- a/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
@@ -510,6 +510,90 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
       assert :sys.get_state(ctx.pid) == before
     end
 
+    for active <- [false, true], malformed <- [false, true] do
+      test "queued policy refusal preserves active=#{active}, malformed=#{malformed}", ctx do
+        prompt_id = drive_to_prompt(ctx.pid, ctx.ref)
+        reply(ctx.pid, ctx.ref, prompt_id, %{"stopReason" => "end_turn"})
+
+        if unquote(active) do
+          notify(ctx.pid, ctx.ref, %{
+            "sessionUpdate" => "agent_message_chunk",
+            "text" => "working"
+          })
+
+          assert :sys.get_state(ctx.pid).current_turn.origin == "autonomous"
+        end
+
+        allowance =
+          ctx.conv.id
+          |> Fountain.Conversations.ExecutionAllowance.new_changeset(%{max_model_turns: 2})
+          |> Fountain.Repo.insert!()
+
+        if unquote(malformed) do
+          allowance
+          |> Ecto.Changeset.change(limits: %{"private-field" => "do not echo"})
+          |> Fountain.Repo.update!()
+        end
+
+        before = :sys.get_state(ctx.pid)
+        turns = Conversations._unsafe_list_turns(ctx.conv.id)
+        conv = Fountain.Repo.reload!(ctx.conv)
+        usage_count = Fountain.Repo.aggregate(Fountain.Billing.UsageEvent, :count)
+
+        ConversationServer.queue_initial_prompt(ctx.pid, "queued")
+
+        # Same-sender mailbox ordering waits for the queued cast to finish.
+        assert :sys.get_state(ctx.pid) == before
+        assert Conversations._unsafe_list_turns(ctx.conv.id) == turns
+        assert Fountain.Repo.reload!(ctx.conv) == conv
+        assert Fountain.Repo.aggregate(Fountain.Billing.UsageEvent, :count) == usage_count
+        refute_received :stdin_closed
+        refute_received {:wrote, _}
+
+        if unquote(active) do
+          assert :ok = GenServer.call(ctx.pid, :interrupt)
+          assert is_nil(:sys.get_state(ctx.pid).current_turn)
+          assert List.last(Conversations._unsafe_list_turns(ctx.conv.id)).status == "interrupted"
+        end
+      end
+    end
+
+    test "an empty saved allowance permits queued handoff on the same connection", ctx do
+      prompt_id = drive_to_prompt(ctx.pid, ctx.ref)
+      reply(ctx.pid, ctx.ref, prompt_id, %{"stopReason" => "end_turn"})
+      notify(ctx.pid, ctx.ref, %{"sessionUpdate" => "agent_message_chunk", "text" => "working"})
+      peer = :sys.get_state(ctx.pid).acp_peer
+
+      ctx.conv.id
+      |> Fountain.Conversations.ExecutionAllowance.new_changeset(%{})
+      |> Fountain.Repo.insert!()
+
+      ConversationServer.queue_initial_prompt(ctx.pid, "queued")
+      assert :sys.get_state(ctx.pid).acp_peer == peer
+
+      assert [
+               %{status: "completed"},
+               %{origin: "autonomous", status: "completed"},
+               %{origin: "user", status: "running", prompt: "queued"}
+             ] = Conversations._unsafe_list_turns(ctx.conv.id)
+
+      %{"method" => "session/set_model", "id" => set_id} = next_write()
+      reply(ctx.pid, ctx.ref, set_id, %{})
+      assert %{"method" => "session/prompt"} = next_write()
+    end
+
+    test "a queued prompt leaves a running user turn alone under saved limits", ctx do
+      drive_to_prompt(ctx.pid, ctx.ref)
+
+      ctx.conv.id
+      |> Fountain.Conversations.ExecutionAllowance.new_changeset(%{max_model_turns: 2})
+      |> Fountain.Repo.insert!()
+
+      before = :sys.get_state(ctx.pid)
+      ConversationServer.queue_initial_prompt(ctx.pid, "queued")
+      assert :sys.get_state(ctx.pid) == before
+    end
+
     test "an out-of-turn update opens an autonomous turn; cycle_end closes it (#817)", %{
       conv: conv,
       pid: pid,

--- a/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
@@ -404,6 +404,112 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
       assert length(Conversations._unsafe_list_turns(conv.id)) == 2
     end
 
+    for active <- [false, true], malformed <- [false, true] do
+      test "saved policy refusal preserves active=#{active}, malformed=#{malformed}", ctx do
+        prompt_id = drive_to_prompt(ctx.pid, ctx.ref)
+        reply(ctx.pid, ctx.ref, prompt_id, %{"stopReason" => "end_turn"})
+
+        if unquote(active) do
+          notify(ctx.pid, ctx.ref, %{
+            "sessionUpdate" => "agent_message_chunk",
+            "text" => "working"
+          })
+
+          assert :sys.get_state(ctx.pid).current_turn.origin == "autonomous"
+        end
+
+        allowance =
+          ctx.conv.id
+          |> Fountain.Conversations.ExecutionAllowance.new_changeset(%{max_model_turns: 2})
+          |> Fountain.Repo.insert!()
+
+        if unquote(malformed) do
+          allowance
+          |> Ecto.Changeset.change(limits: %{"private-field" => "do not echo"})
+          |> Fountain.Repo.update!()
+        end
+
+        before = :sys.get_state(ctx.pid)
+        turns = Conversations._unsafe_list_turns(ctx.conv.id)
+        conv = Fountain.Repo.reload!(ctx.conv)
+        usage_count = Fountain.Repo.aggregate(Fountain.Billing.UsageEvent, :count)
+        {_key, raw} = insert_api_key(Fountain.Accounts.get_user!(ctx.conv.user_id))
+
+        expect(Horde.Registry, :lookup, fn Fountain.ConversationRegistry, id ->
+          assert id == ctx.conv.id
+          [{ctx.pid, nil}]
+        end)
+
+        response =
+          Phoenix.ConnTest.build_conn()
+          |> FountainWeb.ConnCase.authed_with_key(raw)
+          |> FountainWeb.ConnCase.post_json("/api/conversations/#{ctx.conv.id}/prompts", %{
+            prompt: "continue"
+          })
+          |> Phoenix.ConnTest.json_response(422)
+
+        if unquote(malformed) do
+          assert response == %{
+                   "error" => "execution_limits_invalid",
+                   "errors" => %{"execution_limits" => ["invalid unknown_field"]}
+                 }
+        else
+          assert response["error"] == "execution_limits_unsupported"
+          assert response["message"] =~ "max_model_turns"
+        end
+
+        assert FountainWeb.SchemaGuard.take(self()) == []
+        assert :sys.get_state(ctx.pid) == before
+        assert Conversations._unsafe_list_turns(ctx.conv.id) == turns
+        assert Fountain.Repo.reload!(ctx.conv) == conv
+        assert Fountain.Repo.aggregate(Fountain.Billing.UsageEvent, :count) == usage_count
+        refute_received :stdin_closed
+        refute_received {:wrote, _}
+
+        if unquote(active) do
+          assert :ok = GenServer.call(ctx.pid, :interrupt)
+          assert is_nil(:sys.get_state(ctx.pid).current_turn)
+          assert List.last(Conversations._unsafe_list_turns(ctx.conv.id)).status == "interrupted"
+        end
+      end
+    end
+
+    test "empty saved policy still supersedes autonomous work on the same connection", ctx do
+      prompt_id = drive_to_prompt(ctx.pid, ctx.ref)
+      reply(ctx.pid, ctx.ref, prompt_id, %{"stopReason" => "end_turn"})
+      notify(ctx.pid, ctx.ref, %{"sessionUpdate" => "agent_message_chunk", "text" => "working"})
+      peer = :sys.get_state(ctx.pid).acp_peer
+
+      ctx.conv.id
+      |> Fountain.Conversations.ExecutionAllowance.new_changeset(%{})
+      |> Fountain.Repo.insert!()
+
+      assert :ok = GenServer.call(ctx.pid, {:send_prompt, "again", []})
+      assert :sys.get_state(ctx.pid).acp_peer == peer
+
+      assert [
+               %{status: "completed"},
+               %{origin: "autonomous", status: "completed"},
+               %{origin: "user", status: "running"}
+             ] = Conversations._unsafe_list_turns(ctx.conv.id)
+
+      %{"method" => "session/set_model", "id" => set_id} = next_write()
+      reply(ctx.pid, ctx.ref, set_id, %{})
+      assert %{"method" => "session/prompt"} = next_write()
+    end
+
+    test "a running user turn remains busy under a saved limit", ctx do
+      drive_to_prompt(ctx.pid, ctx.ref)
+
+      ctx.conv.id
+      |> Fountain.Conversations.ExecutionAllowance.new_changeset(%{max_model_turns: 2})
+      |> Fountain.Repo.insert!()
+
+      before = :sys.get_state(ctx.pid)
+      assert {:error, :busy} = GenServer.call(ctx.pid, {:send_prompt, "again", []})
+      assert :sys.get_state(ctx.pid) == before
+    end
+
     test "an out-of-turn update opens an autonomous turn; cycle_end closes it (#817)", %{
       conv: conv,
       pid: pid,

--- a/apps/fountain/test/fountain/conversations/execution_allowance_test.exs
+++ b/apps/fountain/test/fountain/conversations/execution_allowance_test.exs
@@ -1,0 +1,236 @@
+defmodule Fountain.Conversations.ExecutionAllowanceTest do
+  use Fountain.DataCase, async: true
+
+  alias Fountain.Conversations.ExecutionAllowance, as: Allowance
+
+  setup do
+    %{conversation: insert_conversation()}
+  end
+
+  test "persists canonical limits and a revision across reloads", %{conversation: conversation} do
+    allowance = insert_allowance(conversation.id)
+    assert Repo.reload!(allowance) == allowance
+    assert allowance.limits == %{"max_model_turns" => 10, "wall_time_seconds" => 60}
+    assert {:ok, _} = Ecto.UUID.cast(allowance.revision)
+  end
+
+  test "a duplicate insert cannot replace a saved allowance", %{conversation: conversation} do
+    allowance = insert_allowance(conversation.id)
+
+    assert {:error, changeset} =
+             conversation.id |> Allowance.new_changeset(nil) |> Repo.insert()
+
+    assert errors_on(changeset).conversation_id == ["has already been taken"]
+    assert Repo.reload!(allowance) == allowance
+  end
+
+  test "requires an existing conversation" do
+    assert {:error, changeset} =
+             Ecto.UUID.generate() |> Allowance.new_changeset(%{}) |> Repo.insert()
+
+    assert errors_on(changeset).conversation_id == ["does not exist"]
+  end
+
+  test "malformed limits cannot be saved", %{conversation: conversation} do
+    for limits <- [%{max_model_turns: 0}, %{wall_time_seconds: nil}, %{revision: "override"}] do
+      assert {:error, changeset} =
+               conversation.id |> Allowance.new_changeset(limits) |> Repo.insert()
+
+      assert errors_on(changeset).limits != []
+    end
+
+    assert Repo.get(Allowance, conversation.id) == nil
+  end
+
+  test "partial narrowing retains omitted fields and advances the revision", %{
+    conversation: conversation
+  } do
+    allowance = insert_allowance(conversation.id)
+
+    updated =
+      allowance |> Allowance.narrow_changeset(%{max_model_turns: 3}) |> Repo.update!()
+
+    assert updated.limits == %{"max_model_turns" => 3, "wall_time_seconds" => 60}
+    refute updated.revision == allowance.revision
+
+    for request <- [nil, %{}] do
+      updated = Repo.reload!(updated) |> Allowance.narrow_changeset(request) |> Repo.update!()
+      assert updated.limits == %{"max_model_turns" => 3, "wall_time_seconds" => 60}
+    end
+  end
+
+  test "widening or clearing a field is refused", %{conversation: conversation} do
+    allowance = insert_allowance(conversation.id)
+
+    for request <- [%{max_model_turns: 11}, %{wall_time_seconds: nil}] do
+      assert {:error, changeset} =
+               allowance |> Allowance.narrow_changeset(request) |> Repo.update()
+
+      assert errors_on(changeset).limits != []
+      assert Repo.reload!(allowance) == allowance
+    end
+  end
+
+  test "stale narrowing cannot overwrite a tighter stored value", %{conversation: conversation} do
+    stale = insert_allowance(conversation.id)
+    winner = stale |> Allowance.narrow_changeset(%{max_model_turns: 2}) |> Repo.update!()
+
+    assert_raise Ecto.StaleEntryError, fn ->
+      stale |> Allowance.narrow_changeset(%{max_model_turns: 5}) |> Repo.update!()
+    end
+
+    assert Repo.reload!(stale) == winner
+  end
+
+  test "stale omission cannot restore another field's old allowance", %{
+    conversation: conversation
+  } do
+    stale = insert_allowance(conversation.id)
+    winner = stale |> Allowance.narrow_changeset(%{wall_time_seconds: 10}) |> Repo.update!()
+
+    assert {:error, changeset} =
+             stale
+             |> Allowance.narrow_changeset(%{max_model_turns: 2})
+             |> Repo.update(stale_error_field: :revision)
+
+    assert errors_on(changeset).revision == ["is stale"]
+    assert Repo.reload!(stale) == winner
+
+    revalidated =
+      Repo.reload!(stale) |> Allowance.narrow_changeset(%{max_model_turns: 2}) |> Repo.update!()
+
+    assert revalidated.limits == %{"max_model_turns" => 2, "wall_time_seconds" => 10}
+  end
+
+  test "ordinary conversation updates cannot touch the separate allowance", %{
+    conversation: conversation
+  } do
+    allowance = insert_allowance(conversation.id)
+
+    assert {:ok, _} =
+             Fountain.Conversations.update_conversation(conversation, %{title: "renamed"})
+
+    assert Repo.reload!(allowance) == allowance
+  end
+
+  test "conversation deletion removes only its own allowance", %{conversation: conversation} do
+    allowance = insert_allowance(conversation.id)
+    other = insert_conversation() |> Map.fetch!(:id) |> insert_allowance()
+    Repo.delete!(conversation)
+    assert Repo.get(Allowance, allowance.conversation_id) == nil
+    assert Repo.reload!(other) == other
+  end
+
+  defp insert_allowance(conversation_id) do
+    conversation_id
+    |> Allowance.new_changeset(%{max_model_turns: 10, wall_time_seconds: 60})
+    |> Repo.insert!()
+  end
+end
+
+defmodule Fountain.Conversations.ExecutionAllowanceRaceTest do
+  use ExUnit.Case, async: false
+
+  alias Fountain.Repo
+  alias Fountain.Conversations.Sandbox
+  alias Fountain.Conversations.ExecutionAllowance, as: Allowance
+  import Fountain.DataCase, only: [errors_on: 1]
+  import Fountain.Factory, only: [insert_conversation: 1]
+
+  test "a writer blocked on another connection cannot restore a wider allowance" do
+    Ecto.Adapters.SQL.Sandbox.unboxed_run(Repo, fn ->
+      # These rows must be committed: sharing the test's sandbox connection would
+      # serialize the queries in Elixir and never exercise PostgreSQL contention.
+      {:ok, {user, allowance, sandbox_id}} =
+        Repo.transaction(fn ->
+          user =
+            Repo.insert!(%Fountain.Accounts.User{
+              email: "allowance-race-#{Ecto.UUID.generate()}@example.test"
+            })
+
+          conversation = insert_conversation(user_id: user.id)
+          {user, insert_allowance(conversation.id), conversation.sandbox_id}
+        end)
+
+      owner = self()
+
+      winner =
+        independent_writer(fn ->
+          Repo.transaction(fn ->
+            updated =
+              allowance |> Allowance.narrow_changeset(%{max_model_turns: 2}) |> Repo.update!()
+
+            send(owner, :narrowed)
+
+            receive do
+              :commit -> updated
+            after
+              5_000 -> raise "commit barrier timed out"
+            end
+          end)
+        end)
+
+      try do
+        assert_receive :narrowed, 5_000
+
+        loser =
+          independent_writer(fn ->
+            allowance
+            |> Allowance.narrow_changeset(%{max_model_turns: 5})
+            |> Repo.update(stale_error_field: :revision)
+          end)
+
+        try do
+          assert_receive {:backend, winner_pid, winner_backend}, 5_000
+          assert winner_pid == winner.pid
+          assert_receive {:backend, loser_pid, loser_backend}, 5_000
+          assert loser_pid == loser.pid
+          refute winner_backend == loser_backend
+          await_blocked(loser_backend, System.monotonic_time(:millisecond) + 5_000)
+          send(winner.pid, :commit)
+          assert {:ok, updated} = Task.await(winner)
+          assert {:error, changeset} = Task.await(loser)
+          assert errors_on(changeset).revision == ["is stale"]
+          assert Repo.reload!(allowance) == updated
+          assert updated.limits["max_model_turns"] == 2
+        after
+          Task.shutdown(loser, :brutal_kill)
+        end
+      after
+        Task.shutdown(winner, :brutal_kill)
+        Repo.delete!(user)
+        Repo.get!(Sandbox, sandbox_id) |> Repo.delete!()
+        assert Repo.get(Allowance, allowance.conversation_id) == nil
+        assert Repo.get(Sandbox, sandbox_id) == nil
+      end
+    end)
+  end
+
+  defp independent_writer(fun) do
+    owner = self()
+
+    Task.async(fn ->
+      Ecto.Adapters.SQL.Sandbox.unboxed_run(Repo, fn ->
+        %{rows: [[backend]]} = Repo.query!("SELECT pg_backend_pid()")
+        send(owner, {:backend, self(), backend})
+        fun.()
+      end)
+    end)
+  end
+
+  defp await_blocked(backend, deadline) do
+    %{rows: [[blocked]]} = Repo.query!("SELECT cardinality(pg_blocking_pids($1)) > 0", [backend])
+
+    unless blocked do
+      assert System.monotonic_time(:millisecond) < deadline, "no PostgreSQL lock wait observed"
+      Process.sleep(5)
+      await_blocked(backend, deadline)
+    end
+  end
+
+  defp insert_allowance(conversation_id) do
+    conversation_id
+    |> Allowance.new_changeset(%{max_model_turns: 10, wall_time_seconds: 60})
+    |> Repo.insert!()
+  end
+end

--- a/apps/fountain/test/fountain/conversations/execution_allowance_test.exs
+++ b/apps/fountain/test/fountain/conversations/execution_allowance_test.exs
@@ -1,6 +1,7 @@
 defmodule Fountain.Conversations.ExecutionAllowanceTest do
   use Fountain.DataCase, async: true
 
+  alias Fountain.Conversations
   alias Fountain.Conversations.ExecutionAllowance, as: Allowance
 
   setup do
@@ -121,6 +122,123 @@ defmodule Fountain.Conversations.ExecutionAllowanceTest do
     assert Repo.reload!(other) == other
   end
 
+  test "scoped narrowing hides foreign and missing records before validating requests", %{
+    conversation: conv
+  } do
+    allowance = insert_allowance(conv.id)
+    other = insert_conversation()
+
+    for request <- [%{max_model_turns: 2}, %{"private-field" => "private-value"}] do
+      for {id, user_id} <- [
+            {conv.id, other.user_id},
+            {Ecto.UUID.generate(), conv.user_id},
+            {other.id, other.user_id}
+          ] do
+        assert Conversations.narrow_execution_allowance(id, user_id, request) ==
+                 {:error, :not_found}
+      end
+    end
+
+    assert Repo.reload!(allowance) == allowance
+    assert Repo.get(Allowance, other.id) == nil
+    assert allowance_events(conv) == []
+  end
+
+  test "scoped narrowing retains omitted fields without touching active work", %{
+    conversation: conv
+  } do
+    before = Repo.reload!(conv)
+    allowance = insert_allowance(conv.id)
+    turn = insert_turn(conv, status: "running")
+    sandbox = Repo.reload!(conv.sandbox)
+    other = insert_conversation() |> Map.fetch!(:id) |> insert_allowance()
+
+    assert {:ok, narrowed} =
+             Conversations.narrow_execution_allowance(
+               conv.id,
+               conv.user_id,
+               %{max_model_turns: 2},
+               actor: "api",
+               request_ip: "192.0.2.1"
+             )
+
+    assert narrowed.limits == %{"max_model_turns" => 2, "wall_time_seconds" => 60}
+    refute narrowed.revision == allowance.revision
+
+    for request <- [nil, %{}] do
+      assert {:ok, updated} =
+               Conversations.narrow_execution_allowance(conv.id, conv.user_id, request)
+
+      assert updated == narrowed
+    end
+
+    assert Repo.reload!(conv) == before
+    assert Repo.reload!(turn) == turn
+    assert Repo.reload!(sandbox) == sandbox
+    assert Repo.reload!(other) == other
+    assert [event] = allowance_events(conv)
+    assert event.user_id == conv.user_id
+    assert event.actor == "api"
+    assert event.request_ip == "192.0.2.1"
+    assert event.metadata == %{"changed" => ["max_model_turns"]}
+  end
+
+  test "scoped narrowing rejects wider, cleared and malformed requests", %{conversation: conv} do
+    allowance = insert_allowance(conv.id)
+
+    for request <- [%{max_model_turns: 11}, %{wall_time_seconds: nil}, %{unknown: 2}] do
+      assert {:error, changeset} =
+               Conversations.narrow_execution_allowance(conv.id, conv.user_id, request)
+
+      assert errors_on(changeset).limits != []
+      assert Repo.reload!(allowance) == allowance
+    end
+
+    assert allowance_events(conv) == []
+  end
+
+  test "scoped narrowing cannot erase corrupt saved policy", %{conversation: conv} do
+    allowance = insert_allowance(conv.id)
+
+    Repo.query!(
+      "UPDATE execution_allowances SET limits = 'null'::jsonb WHERE conversation_id = $1",
+      [Ecto.UUID.dump!(conv.id)]
+    )
+
+    corrupt = Repo.reload!(allowance)
+
+    for request <- [nil, %{}, %{max_model_turns: 2}] do
+      assert Conversations.narrow_execution_allowance(conv.id, conv.user_id, request) ==
+               {:error, {:execution_limits_invalid, "object_required"}}
+
+      assert Repo.reload!(corrupt) == corrupt
+    end
+
+    assert allowance_events(conv) == []
+  end
+
+  test "narrowing an empty policy does not admit an unsupported turn", %{conversation: conv} do
+    conv.id |> Allowance.new_changeset(%{}) |> Repo.insert!()
+
+    assert {:ok, allowance} =
+             Conversations.narrow_execution_allowance(conv.id, conv.user_id, %{max_model_turns: 2})
+
+    assert {:error, {:execution_limits_unsupported, ["max_model_turns"]}} =
+             Fountain.Conversations.TurnMachine.open(conv.id, conv.sandbox_id, "refused")
+
+    assert Repo.reload!(allowance).limits == %{"max_model_turns" => 2}
+    assert Conversations._unsafe_list_turns(conv.id) == []
+    refute Repo.exists?(from e in Fountain.Billing.UsageEvent, where: e.user_id == ^conv.user_id)
+  end
+
+  defp allowance_events(conv),
+    do:
+      Repo.all(
+        from e in Fountain.Audit.Event,
+          where:
+            e.resource_id == ^conv.id and e.action == "conversation.execution_allowance_narrowed"
+      )
+
   defp insert_allowance(conversation_id) do
     conversation_id
     |> Allowance.new_changeset(%{max_model_turns: 10, wall_time_seconds: 60})
@@ -132,12 +250,26 @@ defmodule Fountain.Conversations.ExecutionAllowanceRaceTest do
   use ExUnit.Case, async: false
 
   alias Fountain.Repo
+  alias Fountain.Conversations
   alias Fountain.Conversations.Sandbox
   alias Fountain.Conversations.ExecutionAllowance, as: Allowance
   import Fountain.DataCase, only: [errors_on: 1]
   import Fountain.Factory, only: [insert_conversation: 1]
+  import Ecto.Query, only: [from: 2]
 
   test "a writer blocked on another connection cannot restore a wider allowance" do
+    race(:stale)
+  end
+
+  test "a scoped writer revalidates widening after a concurrent narrowing commits" do
+    race(:widen)
+  end
+
+  test "concurrent scoped writers retain each other's tighter fields" do
+    race(:disjoint)
+  end
+
+  defp race(mode) do
     Ecto.Adapters.SQL.Sandbox.unboxed_run(Repo, fn ->
       # These rows must be committed: sharing the test's sandbox connection would
       # serialize the queries in Elixir and never exercise PostgreSQL contention.
@@ -158,7 +290,16 @@ defmodule Fountain.Conversations.ExecutionAllowanceRaceTest do
         independent_writer(fn ->
           Repo.transaction(fn ->
             updated =
-              allowance |> Allowance.narrow_changeset(%{max_model_turns: 2}) |> Repo.update!()
+              if mode == :stale do
+                allowance |> Allowance.narrow_changeset(%{max_model_turns: 2}) |> Repo.update!()
+              else
+                {:ok, updated} =
+                  Conversations.narrow_execution_allowance(allowance.conversation_id, user.id, %{
+                    max_model_turns: 2
+                  })
+
+                updated
+              end
 
             send(owner, :narrowed)
 
@@ -175,9 +316,20 @@ defmodule Fountain.Conversations.ExecutionAllowanceRaceTest do
 
         loser =
           independent_writer(fn ->
-            allowance
-            |> Allowance.narrow_changeset(%{max_model_turns: 5})
-            |> Repo.update(stale_error_field: :revision)
+            if mode == :stale do
+              allowance
+              |> Allowance.narrow_changeset(%{max_model_turns: 5})
+              |> Repo.update(stale_error_field: :revision)
+            else
+              request =
+                if mode == :widen, do: %{max_model_turns: 5}, else: %{wall_time_seconds: 10}
+
+              Conversations.narrow_execution_allowance(
+                allowance.conversation_id,
+                user.id,
+                request
+              )
+            end
           end)
 
         try do
@@ -189,15 +341,28 @@ defmodule Fountain.Conversations.ExecutionAllowanceRaceTest do
           await_blocked(loser_backend, System.monotonic_time(:millisecond) + 5_000)
           send(winner.pid, :commit)
           assert {:ok, updated} = Task.await(winner)
-          assert {:error, changeset} = Task.await(loser)
-          assert errors_on(changeset).revision == ["is stale"]
-          assert Repo.reload!(allowance) == updated
+
+          case {mode, Task.await(loser)} do
+            {:stale, {:error, changeset}} ->
+              assert errors_on(changeset).revision == ["is stale"]
+              assert Repo.reload!(allowance) == updated
+
+            {:widen, {:error, changeset}} ->
+              assert errors_on(changeset).limits == ["execution_limits_widen: max_model_turns"]
+              assert Repo.reload!(allowance) == updated
+
+            {:disjoint, {:ok, final}} ->
+              assert final.limits == %{"max_model_turns" => 2, "wall_time_seconds" => 10}
+              assert Repo.reload!(allowance) == final
+          end
+
           assert updated.limits["max_model_turns"] == 2
         after
           Task.shutdown(loser, :brutal_kill)
         end
       after
         Task.shutdown(winner, :brutal_kill)
+        Repo.delete_all(from e in Fountain.Audit.Event, where: e.user_id == ^user.id)
         Repo.delete!(user)
         Repo.get!(Sandbox, sandbox_id) |> Repo.delete!()
         assert Repo.get(Allowance, allowance.conversation_id) == nil

--- a/apps/fountain/test/fountain/conversations/execution_allowance_test.exs
+++ b/apps/fountain/test/fountain/conversations/execution_allowance_test.exs
@@ -71,6 +71,49 @@ defmodule Fountain.Conversations.ExecutionAllowanceTest do
     end
   end
 
+  test "narrowing cannot replace a saved JSON null with an unrestricted or fresh allowance", %{
+    conversation: conversation
+  } do
+    allowance = insert_allowance(conversation.id)
+
+    Repo.query!(
+      "UPDATE execution_allowances SET limits = 'null'::jsonb WHERE conversation_id = $1",
+      [Ecto.UUID.dump!(conversation.id)]
+    )
+
+    corrupt = Repo.reload!(allowance)
+    assert corrupt.limits == nil
+
+    for request <- [nil, %{}, %{max_model_turns: 2}] do
+      assert {:error, changeset} = corrupt |> Allowance.narrow_changeset(request) |> Repo.update()
+      assert errors_on(changeset).limits == ["execution_limits_invalid: object_required"]
+      assert Repo.reload!(corrupt) == corrupt
+    end
+  end
+
+  test "narrowing preserves malformed saved maps and does not expose their contents", %{
+    conversation: conversation
+  } do
+    corrupt =
+      insert_allowance(conversation.id)
+      |> Ecto.Changeset.change(limits: %{"private-field" => "private-value"})
+      |> Repo.update!()
+
+    for request <- [nil, %{}, %{max_model_turns: 2}] do
+      assert {:error, changeset} = corrupt |> Allowance.narrow_changeset(request) |> Repo.update()
+      assert errors_on(changeset).limits == ["execution_limits_invalid: unknown_field"]
+      assert Repo.reload!(corrupt) == corrupt
+    end
+  end
+
+  test "an explicitly empty saved allowance can still be narrowed", %{conversation: conversation} do
+    allowance = conversation.id |> Allowance.new_changeset(%{}) |> Repo.insert!()
+    updated = allowance |> Allowance.narrow_changeset(%{max_model_turns: 2}) |> Repo.update!()
+
+    assert updated.limits == %{"max_model_turns" => 2}
+    refute updated.revision == allowance.revision
+  end
+
   test "stale narrowing cannot overwrite a tighter stored value", %{conversation: conversation} do
     stale = insert_allowance(conversation.id)
     winner = stale |> Allowance.narrow_changeset(%{max_model_turns: 2}) |> Repo.update!()

--- a/apps/fountain/test/fountain/conversations/execution_allowance_test.exs
+++ b/apps/fountain/test/fountain/conversations/execution_allowance_test.exs
@@ -231,6 +231,114 @@ defmodule Fountain.Conversations.ExecutionAllowanceTest do
     refute Repo.exists?(from e in Fountain.Billing.UsageEvent, where: e.user_id == ^conv.user_id)
   end
 
+  test "scoped creation hides foreign and missing conversations before validation", %{
+    conversation: conv
+  } do
+    other = insert_conversation()
+
+    for limits <- [%{}, %{"private-field" => "private-value"}],
+        {id, user_id} <- [{conv.id, other.user_id}, {Ecto.UUID.generate(), conv.user_id}] do
+      assert Conversations.create_execution_allowance(id, user_id, limits) == {:error, :not_found}
+    end
+
+    assert Repo.get(Allowance, conv.id) == nil
+    assert Repo.get(Allowance, other.id) == nil
+    assert creation_events(conv) == []
+  end
+
+  test "scoped creation records only control names and leaves active work unchanged", %{
+    conversation: conv
+  } do
+    before = Repo.reload!(conv)
+    turn = insert_turn(conv, status: "running")
+    sandbox = Repo.reload!(conv.sandbox)
+    other = insert_conversation() |> Map.fetch!(:id) |> insert_allowance()
+
+    assert {:ok, allowance} =
+             Conversations.create_execution_allowance(
+               conv.id,
+               conv.user_id,
+               %{max_model_turns: 2, wall_time_seconds: 30, max_estimated_cost_usd: 0.25},
+               actor: "api",
+               request_ip: "192.0.2.1"
+             )
+
+    assert allowance.limits == %{
+             "max_model_turns" => 2,
+             "wall_time_seconds" => 30,
+             "max_estimated_cost_usd" => 0.25
+           }
+
+    assert Repo.reload!(allowance) == allowance
+    assert Repo.reload!(conv) == before
+    assert Repo.reload!(turn) == turn
+    assert Repo.reload!(sandbox) == sandbox
+    assert Repo.reload!(other) == other
+    assert [event] = creation_events(conv)
+    assert event.user_id == conv.user_id
+    assert event.actor == "api"
+    assert event.request_ip == "192.0.2.1"
+
+    assert event.metadata == %{
+             "controls" => ["wall_time_seconds", "max_model_turns", "max_estimated_cost_usd"]
+           }
+  end
+
+  test "scoped creation cannot replace an existing policy even with omission", %{
+    conversation: conv
+  } do
+    allowance = insert_allowance(conv.id)
+
+    for limits <- [nil, %{}, %{max_model_turns: 1}, %{max_model_turns: 20}] do
+      assert {:error, changeset} =
+               Conversations.create_execution_allowance(conv.id, conv.user_id, limits)
+
+      assert errors_on(changeset).conversation_id == ["has already been taken"]
+      assert Repo.reload!(allowance) == allowance
+    end
+
+    assert creation_events(conv) == []
+  end
+
+  test "scoped creation refuses invalid controls without a row or audit", %{conversation: conv} do
+    for limits <- [
+          %{"private-field" => "private-value"},
+          %{max_model_turns: 0},
+          %{wall_time_seconds: nil}
+        ] do
+      assert {:error, changeset} =
+               Conversations.create_execution_allowance(conv.id, conv.user_id, limits)
+
+      errors = Jason.encode!(errors_on(changeset))
+      refute errors =~ "private-field"
+      refute errors =~ "private-value"
+      assert errors_on(changeset).limits != []
+    end
+
+    assert Repo.get(Allowance, conv.id) == nil
+    assert creation_events(conv) == []
+  end
+
+  test "a saved initial allowance does not grant unsupported execution", %{conversation: conv} do
+    assert {:ok, allowance} =
+             Conversations.create_execution_allowance(conv.id, conv.user_id, %{max_model_turns: 2})
+
+    assert {:error, {:execution_limits_unsupported, ["max_model_turns"]}} =
+             Fountain.Conversations.TurnMachine.open(conv.id, conv.sandbox_id, "refused")
+
+    assert Repo.reload!(allowance).limits == %{"max_model_turns" => 2}
+    assert Conversations._unsafe_list_turns(conv.id) == []
+    refute Repo.exists?(from e in Fountain.Billing.UsageEvent, where: e.user_id == ^conv.user_id)
+  end
+
+  defp creation_events(conv),
+    do:
+      Repo.all(
+        from e in Fountain.Audit.Event,
+          where:
+            e.resource_id == ^conv.id and e.action == "conversation.execution_allowance_created"
+      )
+
   defp allowance_events(conv),
     do:
       Repo.all(
@@ -267,6 +375,90 @@ defmodule Fountain.Conversations.ExecutionAllowanceRaceTest do
 
   test "concurrent scoped writers retain each other's tighter fields" do
     race(:disjoint)
+  end
+
+  for mode <- [:duplicate, :ownership] do
+    test "initial creation rechecks #{mode} after a PostgreSQL lock wait" do
+      creation_race(unquote(mode))
+    end
+  end
+
+  defp creation_race(mode) do
+    Ecto.Adapters.SQL.Sandbox.unboxed_run(Repo, fn ->
+      users =
+        for _ <- 1..2,
+            do:
+              Repo.insert!(%Fountain.Accounts.User{
+                email: "initial-allowance-race-#{Ecto.UUID.generate()}@example.test"
+              })
+
+      [user, other] = users
+      conv = insert_conversation(user_id: user.id)
+      owner = self()
+
+      winner =
+        independent_writer(fn ->
+          Repo.transaction(fn ->
+            value =
+              case mode do
+                :duplicate -> insert_allowance(conv.id)
+                :ownership -> conv |> Ecto.Changeset.change(user_id: other.id) |> Repo.update!()
+              end
+
+            send(owner, :changed)
+
+            receive do
+              :commit -> value
+            after
+              5_000 -> raise "commit barrier timed out"
+            end
+          end)
+        end)
+
+      try do
+        assert_receive :changed, 5_000
+
+        loser =
+          independent_writer(fn ->
+            Conversations.create_execution_allowance(conv.id, user.id, %{})
+          end)
+
+        try do
+          assert_receive {:backend, winner_pid, winner_backend}, 5_000
+          assert winner_pid == winner.pid
+          assert_receive {:backend, loser_pid, loser_backend}, 5_000
+          assert loser_pid == loser.pid
+          refute winner_backend == loser_backend
+          await_blocked(loser_backend, System.monotonic_time(:millisecond) + 5_000)
+          send(winner.pid, :commit)
+          assert {:ok, saved} = Task.await(winner)
+
+          case {mode, Task.await(loser)} do
+            {:duplicate, {:error, changeset}} ->
+              assert errors_on(changeset).conversation_id == ["has already been taken"]
+              assert Repo.get!(Allowance, conv.id) == saved
+
+            {:ownership, {:error, :not_found}} ->
+              assert Repo.reload!(conv).user_id == other.id
+              assert Repo.get(Allowance, conv.id) == nil
+          end
+
+          refute Repo.exists?(
+                   from e in Fountain.Audit.Event,
+                     where:
+                       e.resource_id == ^conv.id and
+                         e.action == "conversation.execution_allowance_created"
+                 )
+        after
+          Task.shutdown(loser, :brutal_kill)
+        end
+      after
+        Task.shutdown(winner, :brutal_kill)
+        for user <- users, do: Repo.delete!(user)
+        Repo.get!(Sandbox, conv.sandbox_id) |> Repo.delete!()
+        assert Repo.get(Allowance, conv.id) == nil
+      end
+    end)
   end
 
   defp race(mode) do

--- a/apps/fountain/test/fountain/conversations/execution_limits_test.exs
+++ b/apps/fountain/test/fountain/conversations/execution_limits_test.exs
@@ -1,0 +1,177 @@
+defmodule Fountain.Conversations.ExecutionLimitsTest do
+  use ExUnit.Case, async: true
+  alias Fountain.Conversations.ExecutionLimits, as: Limits
+
+  test "omission inherits every host and account ceiling" do
+    for request <- [nil, %{}] do
+      assert {:ok, %{"wall_time_seconds" => 60, "max_model_turns" => 10}} =
+               Limits.resolve(%{"wall_time_seconds" => 60}, %{max_model_turns: 10}, request)
+    end
+  end
+
+  test "the smaller configured ceiling wins independently for each field" do
+    assert {:ok, %{"wall_time_seconds" => 20, "max_model_turns" => 5}} =
+             Limits.resolve(
+               %{wall_time_seconds: 20, max_model_turns: 10},
+               %{wall_time_seconds: 30, max_model_turns: 5},
+               nil
+             )
+  end
+
+  test "a partial request narrows one field and retains all other ceilings" do
+    assert {:ok, %{"wall_time_seconds" => 10, "max_model_turns" => 5}} =
+             Limits.resolve(%{wall_time_seconds: 20}, %{max_model_turns: 5}, %{
+               wall_time_seconds: 10
+             })
+  end
+
+  test "requests cannot exceed either effective ceiling" do
+    for {host, account} <- [{%{max_model_turns: 5}, nil}, {nil, %{max_model_turns: 5}}] do
+      assert {:error, {:execution_limits_widen, "max_model_turns"}} =
+               Limits.resolve(host, account, %{max_model_turns: 6})
+    end
+  end
+
+  test "no configured ceiling still permits a valid voluntarily bounded request" do
+    assert {:ok, %{"wall_time_seconds" => 60}} =
+             Limits.resolve(nil, nil, %{wall_time_seconds: 60})
+
+    assert {:ok, %{}} = Limits.resolve(nil, nil, nil)
+  end
+
+  test "explicit nulls cannot disable inherited controls" do
+    for field <- Limits.keys() do
+      assert {:error, {:execution_limits_invalid, ^field}} =
+               Limits.resolve(%{field => 5}, nil, %{field => nil})
+    end
+  end
+
+  test "unknown fields, arbitrary metadata and nonobjects are refused" do
+    for request <- [
+          %{"maxTurns" => 5},
+          %{"_meta" => %{}},
+          %{"options" => %{}},
+          %URI{host: "example.test"},
+          %{123 => 5},
+          3,
+          false,
+          [],
+          "10"
+        ] do
+      assert {:error, {:execution_limits_invalid, _}} = Limits.normalize(request)
+    end
+  end
+
+  test "duplicate atom/string keys cannot pick a value by enumeration order" do
+    assert {:error, {:execution_limits_invalid, "duplicate_field"}} =
+             Limits.normalize(%{:max_model_turns => 2, "max_model_turns" => 200})
+  end
+
+  test "integers stay integers and dollar fractions stay numeric" do
+    assert {:ok, %{"max_model_turns" => 3, "max_estimated_cost_usd" => 0.25}} =
+             Limits.normalize(%{max_model_turns: 3, max_estimated_cost_usd: 0.25})
+
+    for field <- ["max_model_turns", "wall_time_seconds"], value <- ["5", 5.0, 0, -1, true] do
+      assert {:error, {:execution_limits_invalid, ^field}} = Limits.normalize(%{field => value})
+    end
+  end
+
+  test "wire bounds refuse nonrepresentable deadlines and unsafe JSON integers" do
+    assert {:error, _} = Limits.normalize(%{wall_time_seconds: Limits.max_wall_seconds() + 1})
+    assert {:error, _} = Limits.normalize(%{max_model_turns: 9_007_199_254_740_992})
+    assert {:error, _} = Limits.normalize(%{max_estimated_cost_usd: 9_007_199_254_740_992})
+
+    for value <- [0, -0.1, "0.25", nil, false] do
+      assert {:error, _} = Limits.normalize(%{max_estimated_cost_usd: value})
+    end
+  end
+
+  test "loosening or removing account policy never widens an existing conversation" do
+    launch = %{"wall_time_seconds" => 20, "max_model_turns" => 5}
+    assert {:ok, ^launch} = Limits.for_new_turn(nil, %{wall_time_seconds: 200}, launch)
+    assert {:ok, ^launch} = Limits.for_new_turn(nil, nil, launch)
+  end
+
+  test "new turns inherit tightened ceilings without losing other saved limits" do
+    assert {:ok, %{"wall_time_seconds" => 10, "max_model_turns" => 5}} =
+             Limits.for_new_turn(nil, %{wall_time_seconds: 10}, %{
+               wall_time_seconds: 20,
+               max_model_turns: 5
+             })
+  end
+
+  test "channel resume cannot reset a narrower launch allowance" do
+    assert {:error, {:execution_limits_widen, "max_model_turns"}} =
+             Limits.for_resume(nil, %{max_model_turns: 100}, %{max_model_turns: 5}, %{
+               max_model_turns: 10
+             })
+
+    assert {:ok, %{"max_model_turns" => 5}} =
+             Limits.for_resume(nil, nil, %{max_model_turns: 5}, nil)
+  end
+
+  test "malformed host or saved policy fails closed instead of dropping a ceiling" do
+    for {host, account, saved} <- [
+          {%{wall_time_seconds: "60"}, nil, nil},
+          {nil, %{max_model_turns: 0}, nil},
+          {nil, nil, %{wall_time_seconds: nil}}
+        ] do
+      assert {:error, {:execution_limits_invalid, _}} = Limits.for_new_turn(host, account, saved)
+    end
+  end
+
+  test "runtime capability checks cover inherited controls as well as requested ones" do
+    {:ok, limits} = Limits.resolve(%{wall_time_seconds: 60}, nil, %{max_model_turns: 3})
+
+    assert {:error, {:execution_limits_unsupported, ["wall_time_seconds"]}} =
+             Limits.require_controls(limits, ["max_model_turns"])
+
+    assert :ok = Limits.require_controls(limits, ["wall_time_seconds", "max_model_turns"])
+    assert :ok = Limits.require_controls(%{}, [])
+  end
+
+  test "new-turn allowances never exceed a saved or current ceiling" do
+    for field <- Limits.keys(), host <- [1, 5, 20], account <- [2, 10], saved <- [3, 15] do
+      assert {:ok, %{^field => allowance}} =
+               Limits.for_new_turn(%{field => host}, %{field => account}, %{field => saved})
+
+      assert allowance <= host
+      assert allowance <= account
+      assert allowance <= saved
+
+      assert {:error, {:execution_limits_widen, ^field}} =
+               Limits.for_resume(%{field => host}, %{field => account}, %{field => saved}, %{
+                 field => allowance + 1
+               })
+    end
+  end
+
+  test "host JSON configuration validates its shape instead of disabling malformed limits" do
+    assert {:ok, %{}} = Limits.from_json_env(nil)
+
+    assert {:ok, %{"wall_time_seconds" => 60}} =
+             Limits.from_json_env(~s({"wall_time_seconds":60}))
+
+    for value <- [
+          "null",
+          "[]",
+          "not-json",
+          ~s({"wall_time_seconds":null}),
+          ~s({"secret":"never echo me"})
+        ] do
+      assert {:error, {:execution_limits_invalid, reason}} = Limits.from_json_env(value)
+      refute reason =~ "never echo me"
+    end
+  end
+
+  test "SDK options contain only adapter fields and never the host deadline" do
+    assert %{max_model_turns: 3, max_estimated_cost_usd: 0.25} =
+             Limits.sdk_options(%{
+               "wall_time_seconds" => 60,
+               "max_model_turns" => 3,
+               "max_estimated_cost_usd" => 0.25
+             })
+
+    assert nil == Limits.sdk_options(%{"wall_time_seconds" => 60})
+  end
+end

--- a/apps/fountain/test/fountain/conversations/rehydrator_test.exs
+++ b/apps/fountain/test/fountain/conversations/rehydrator_test.exs
@@ -1,7 +1,125 @@
 defmodule Fountain.Conversations.RehydratorTest do
-  use ExUnit.Case, async: true
+  # The sweep queries all resumable rows; do not overlap independent-connection
+  # admission race fixtures in the async suites.
+  use Fountain.DataCase, async: false
+  use Mimic
 
-  alias Fountain.Conversations.Rehydrator
+  alias Fountain.Conversations.{ConversationServer, ExecutionAllowance, Rehydrator}
+
+  setup do
+    owner = self()
+
+    stub(Horde.DynamicSupervisor, :start_child, fn _, {ConversationServer, args} ->
+      send(owner, {:worker_start, args})
+      {:ok, owner}
+    end)
+
+    :ok
+  end
+
+  for status <- ["idle", "running"] do
+    test "boot refuses every saved control for a #{status} conversation without mutation" do
+      conv = resumable(unquote(status))
+      before = Repo.reload!(conv)
+      sandbox = Repo.reload!(conv.sandbox)
+      turn = if unquote(status == "running"), do: insert_turn(conv, status: "running")
+
+      for {control, limit} <- [
+            wall_time_seconds: 30,
+            max_model_turns: 2,
+            max_estimated_cost_usd: 0.5
+          ] do
+        allowance = save(conv, %{control => limit})
+
+        for _ <- 1..2 do
+          assert sweep() == 0
+          assert Repo.reload!(conv) == before
+          assert Repo.reload!(conv.sandbox) == sandbox
+          assert Repo.reload!(allowance) == allowance
+          if turn, do: assert(Repo.reload!(turn) == turn)
+          refute_received {:worker_start, _}
+        end
+
+        Repo.delete!(allowance)
+      end
+    end
+  end
+
+  for malformed <- [:map, :null] do
+    test "boot skips corrupt #{malformed} policy without exposing its contents" do
+      conv = resumable("idle")
+      allowance = save(conv, %{})
+
+      if unquote(malformed == :map) do
+        allowance
+        |> Ecto.Changeset.change(limits: %{"private-field" => "private-value"})
+        |> Repo.update!()
+      else
+        Repo.query!(
+          "UPDATE execution_allowances SET limits = 'null'::jsonb WHERE conversation_id = $1",
+          [Ecto.UUID.dump!(conv.id)]
+        )
+      end
+
+      log = ExUnit.CaptureLog.capture_log(fn -> assert sweep() == 0 end)
+      assert log =~ "execution_limits_invalid"
+      refute log =~ "private-field"
+      refute log =~ "private-value"
+      refute_received {:worker_start, _}
+      assert Repo.reload!(conv).status == "idle"
+    end
+  end
+
+  test "one refused tenant does not block absent or empty allowances, including an existing server" do
+    limited = resumable("running")
+    save(limited, %{max_model_turns: 2})
+    ordinary = resumable("idle")
+    existing = resumable("running")
+    save(existing, %{})
+    owner = self()
+
+    stub(Horde.DynamicSupervisor, :start_child, fn _, {ConversationServer, args} ->
+      send(owner, {:worker_start, args})
+
+      if args[:conversation_id] == existing.id,
+        do: {:error, {:already_started, owner}},
+        else: {:ok, owner}
+    end)
+
+    assert sweep() == 2
+    assert_received {:worker_start, first}
+    assert_received {:worker_start, second}
+
+    assert Enum.sort([first[:conversation_id], second[:conversation_id]]) ==
+             Enum.sort([ordinary.id, existing.id])
+
+    assert first[:initial_prompt] == nil
+    assert second[:initial_prompt] == nil
+    refute_received {:worker_start, _}
+    assert Repo.reload!(limited).status == "running"
+  end
+
+  test "boot still leaves non-ready sandboxes to lazy recovery" do
+    for status <- ["pending", "starting", "suspended", "terminated", "failed"] do
+      conv = resumable("idle")
+      conv.sandbox |> Ecto.Changeset.change(status: status) |> Repo.update!()
+    end
+
+    assert sweep() == 0
+    refute_received {:worker_start, _}
+  end
+
+  defp resumable(status) do
+    agent = insert_agent()
+    sandbox = insert_sandbox(user_id: agent.user_id, status: "ready")
+    insert_conversation(agent: agent, sandbox: sandbox, status: status)
+  end
+
+  defp save(conv, limits),
+    do: conv.id |> ExecutionAllowance.new_changeset(limits) |> Repo.insert!()
+
+  defp sweep,
+    do: Rehydrator.run(cluster_wait_ms: 0, stabilize_ms: 0, poll_ms: 1)
 
   describe "leader election" do
     test "a lone node (no peers) is always the leader" do

--- a/apps/fountain/test/fountain/conversations/saved_allowance_admission_test.exs
+++ b/apps/fountain/test/fountain/conversations/saved_allowance_admission_test.exs
@@ -1,0 +1,228 @@
+defmodule Fountain.Conversations.SavedAllowanceAdmissionTest do
+  use Fountain.DataCase, async: true
+
+  alias Fountain.Conversations
+  alias Fountain.Conversations.{Connection, ExecutionAllowance, TurnMachine}
+
+  setup do
+    %{conversation: insert_conversation(status: "idle")}
+  end
+
+  for capacity <- [1, :unbounded] do
+    test "#{inspect(capacity)} admission refuses every saved control", %{conversation: conv} do
+      for {field, value} <- [
+            wall_time_seconds: 30,
+            max_model_turns: 2,
+            max_estimated_cost_usd: 0.5
+          ] do
+        allowance =
+          conv.id |> ExecutionAllowance.new_changeset(%{field => value}) |> Repo.insert!()
+
+        assert {:error, {:execution_limits_unsupported, [key]}} =
+                 admit(conv, unquote(capacity))
+
+        assert key == Atom.to_string(field)
+        assert Conversations._unsafe_list_turns(conv.id) == []
+        assert Repo.reload!(allowance) == allowance
+        Repo.delete!(allowance)
+      end
+    end
+
+    test "#{inspect(capacity)} admission accepts absent and empty allowances", %{
+      conversation: conv
+    } do
+      assert {:ok, first} = admit(conv, unquote(capacity))
+      Repo.delete!(first)
+      conv.id |> ExecutionAllowance.new_changeset(%{}) |> Repo.insert!()
+      assert {:ok, _} = admit(conv, unquote(capacity))
+    end
+  end
+
+  test "both user and autonomous turn openers propagate the refusal", %{conversation: conv} do
+    conv.id |> ExecutionAllowance.new_changeset(%{max_model_turns: 2}) |> Repo.insert!()
+    expected = {:error, {:execution_limits_unsupported, ["max_model_turns"]}}
+    assert TurnMachine.open(conv.id, conv.sandbox_id, "user prompt") == expected
+    assert Connection.open_autonomous_turn(conv.id, conv.user_id, conv.sandbox_id) == expected
+    assert Conversations._unsafe_list_turns(conv.id) == []
+    assert Repo.reload!(conv).status == "idle"
+
+    refute Repo.exists?(
+             from e in Fountain.Billing.UsageEvent,
+               where: e.user_id == ^conv.user_id and e.event_type == "turn_started"
+           )
+  end
+
+  test "malformed saved policy is refused rather than treated as unbounded", %{conversation: conv} do
+    allowance = conv.id |> ExecutionAllowance.new_changeset(%{}) |> Repo.insert!()
+
+    for limits <- [%{"max_model_turns" => 0}, %{"unknown" => 10}] do
+      allowance |> Ecto.Changeset.change(limits: limits) |> Repo.update!()
+      assert {:error, {:execution_limits_invalid, _}} = admit(conv, :unbounded)
+      assert Conversations._unsafe_list_turns(conv.id) == []
+    end
+
+    # JSON null is distinct from SQL NULL and can bypass the NOT NULL column.
+    Repo.query!(
+      "UPDATE execution_allowances SET limits = 'null'::jsonb WHERE conversation_id = $1",
+      [
+        Ecto.UUID.dump!(conv.id)
+      ]
+    )
+
+    assert {:error, {:execution_limits_invalid, "object_required"}} = admit(conv, :unbounded)
+  end
+
+  test "a different tenant's allowance neither blocks nor authorizes this conversation", %{
+    conversation: conv
+  } do
+    other = insert_conversation()
+    other.id |> ExecutionAllowance.new_changeset(%{max_model_turns: 2}) |> Repo.insert!()
+    assert {:ok, _} = admit(conv, :unbounded)
+
+    assert {:error, :sandbox_unavailable} =
+             Conversations._unsafe_create_turn_on_sandbox(
+               attrs(other),
+               conv.sandbox_id,
+               :unbounded
+             )
+
+    assert Conversations._unsafe_list_turns(other.id) == []
+  end
+
+  defp admit(conv, capacity),
+    do: Conversations._unsafe_create_turn_on_sandbox(attrs(conv), conv.sandbox_id, capacity)
+
+  defp attrs(conv),
+    do: %{conversation_id: conv.id, turn_number: 1, prompt: "probe", status: "running"}
+end
+
+defmodule Fountain.Conversations.SavedAllowanceAdmissionRaceTest do
+  use ExUnit.Case, async: false
+
+  alias Fountain.{Conversations, Repo}
+  alias Fountain.Conversations.{ExecutionAllowance, Sandbox}
+  import Ecto.Query, only: [from: 2]
+  import Fountain.Factory, only: [insert_conversation: 1]
+
+  for existing <- [false, true], write_first <- [false, true] do
+    test "existing=#{existing}, write_first=#{write_first}: allowance and turn writes serialize" do
+      Ecto.Adapters.SQL.Sandbox.unboxed_run(Repo, fn ->
+        {:ok, {user, conv, allowance}} =
+          Repo.transaction(fn ->
+            user =
+              Repo.insert!(%Fountain.Accounts.User{
+                email: "admission-race-#{Ecto.UUID.generate()}@example.test"
+              })
+
+            conv = insert_conversation(user_id: user.id, status: "idle")
+
+            allowance =
+              if unquote(existing),
+                do: conv.id |> ExecutionAllowance.new_changeset(%{}) |> Repo.insert!()
+
+            {user, conv, allowance}
+          end)
+
+        try do
+          race(conv, allowance, unquote(write_first))
+        after
+          # Billing history survives user deletion; remove this fixture's rows
+          # before deleting its user so they cannot become anonymous test data.
+          Repo.delete_all(from e in Fountain.Billing.UsageEvent, where: e.user_id == ^user.id)
+          Repo.delete!(user)
+          Repo.get!(Sandbox, conv.sandbox_id) |> Repo.delete!()
+          assert Repo.get(ExecutionAllowance, conv.id) == nil
+          assert Repo.get(Sandbox, conv.sandbox_id) == nil
+        end
+      end)
+    end
+  end
+
+  defp race(conv, allowance, write_first) do
+    write = fn -> save_limit(conv, allowance) end
+
+    admit = fn ->
+      Conversations._unsafe_create_turn_on_sandbox(
+        %{conversation_id: conv.id, turn_number: 1, prompt: "probe", status: "running"},
+        conv.sandbox_id,
+        :unbounded
+      )
+    end
+
+    {first_op, second_op} = if write_first, do: {write, admit}, else: {admit, write}
+    owner = self()
+
+    first =
+      independent(fn ->
+        Repo.transaction(fn ->
+          result = first_op.()
+          send(owner, :first_done)
+
+          receive do
+            :commit -> result
+          after
+            10_000 -> raise "commit barrier timed out"
+          end
+        end)
+      end)
+
+    try do
+      assert_receive :first_done, 5_000
+      second = independent(second_op)
+
+      try do
+        assert_receive {:backend, first_pid, first_backend}, 5_000
+        assert first_pid == first.pid
+        assert_receive {:backend, second_pid, second_backend}, 5_000
+        assert second_pid == second.pid
+        refute first_backend == second_backend
+        await_blocked(second_backend, System.monotonic_time(:millisecond) + 5_000)
+        send(first.pid, :commit)
+        assert {:ok, {:ok, _}} = Task.await(first)
+        result = Task.await(second)
+
+        if write_first do
+          assert result == {:error, {:execution_limits_unsupported, ["max_model_turns"]}}
+          assert Conversations._unsafe_list_turns(conv.id) == []
+        else
+          assert {:ok, %ExecutionAllowance{}} = result
+          assert [_] = Conversations._unsafe_list_turns(conv.id)
+        end
+
+        assert Repo.get!(ExecutionAllowance, conv.id).limits == %{"max_model_turns" => 2}
+      after
+        Task.shutdown(second, :brutal_kill)
+      end
+    after
+      Task.shutdown(first, :brutal_kill)
+    end
+  end
+
+  defp save_limit(conv, nil),
+    do: conv.id |> ExecutionAllowance.new_changeset(%{max_model_turns: 2}) |> Repo.insert()
+
+  defp save_limit(_conv, allowance),
+    do: allowance |> ExecutionAllowance.narrow_changeset(%{max_model_turns: 2}) |> Repo.update()
+
+  defp independent(fun) do
+    owner = self()
+
+    Task.async(fn ->
+      Ecto.Adapters.SQL.Sandbox.unboxed_run(Repo, fn ->
+        %{rows: [[backend]]} = Repo.query!("SELECT pg_backend_pid()")
+        send(owner, {:backend, self(), backend})
+        fun.()
+      end)
+    end)
+  end
+
+  defp await_blocked(backend, deadline) do
+    %{rows: [[blocked]]} = Repo.query!("SELECT cardinality(pg_blocking_pids($1)) > 0", [backend])
+
+    unless blocked do
+      assert System.monotonic_time(:millisecond) < deadline, "no PostgreSQL lock wait observed"
+      Process.sleep(5)
+      await_blocked(backend, deadline)
+    end
+  end
+end

--- a/apps/fountain/test/fountain_web/controllers/execution_limit_admission_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/execution_limit_admission_test.exs
@@ -3,6 +3,7 @@ defmodule FountainWeb.ExecutionLimitAdmissionTest do
   use Mimic
 
   alias Fountain.{Conversations, Repo}
+  alias Fountain.Accounts.User
   alias Fountain.Conversations.{Conversation, Sandbox}
 
   setup do
@@ -117,6 +118,97 @@ defmodule FountainWeb.ExecutionLimitAdmissionTest do
     assert %{"error" => "not_found"} = request(ctx, params) |> json_response(404)
     refute_received :worker_started
   end
+
+  for path <- [:fresh, :attach, :resume, :rotate] do
+    test "#{path} inherits the stored account ceiling even when the request omits it", ctx do
+      save_ceiling(ctx.user, %{max_model_turns: 2})
+      before_counts = counts()
+
+      for request_limit <- [:omitted, nil, %{}] do
+        params = Map.put(attrs(ctx, unquote(path)), "account_execution_limits", %{})
+
+        params =
+          if request_limit == :omitted,
+            do: params,
+            else: Map.put(params, "execution_limits", request_limit)
+
+        assert %{"error" => "execution_limits_unsupported", "message" => message} =
+                 request(ctx, params) |> json_response(422)
+
+        assert message =~ "max_model_turns"
+        assert counts() == before_counts
+        assert Repo.reload!(ctx.conv).channel_id == "limits"
+        refute_received :worker_started
+      end
+    end
+  end
+
+  test "every configured account control is inherited", ctx do
+    for field <- Conversations.ExecutionLimits.keys() do
+      save_ceiling(ctx.user, %{field => 1})
+
+      assert %{"error" => "execution_limits_unsupported", "message" => message} =
+               request(ctx, attrs(ctx, :fresh)) |> json_response(422)
+
+      assert message =~ field
+    end
+
+    refute_received :worker_started
+  end
+
+  test "account ceilings are reread on each resume", ctx do
+    assert request(ctx, attrs(ctx, :resume)) |> json_response(200)
+    save_ceiling(ctx.user, %{wall_time_seconds: 30})
+
+    assert %{"error" => "execution_limits_unsupported"} =
+             request(ctx, attrs(ctx, :resume)) |> json_response(422)
+
+    save_ceiling(ctx.user, nil)
+    assert request(ctx, attrs(ctx, :resume)) |> json_response(200)
+  end
+
+  test "wider requests are rejected before runtime capability checks", ctx do
+    save_ceiling(ctx.user, %{max_model_turns: 2})
+    params = Map.put(attrs(ctx, :fresh), "execution_limits", %{"max_model_turns" => 3})
+
+    assert %{
+             "error" => "execution_limits_widen",
+             "errors" => %{"execution_limits" => ["cannot widen max_model_turns"]}
+           } =
+             request(ctx, params) |> json_response(422)
+
+    refute_received :worker_started
+  end
+
+  test "malformed account policy fails without exposing its contents", ctx do
+    corrupt =
+      ctx.user
+      |> Ecto.Changeset.change(execution_limits: %{"private-field" => "private-value"})
+      |> Repo.update!()
+      |> Repo.reload!()
+
+    response = request(ctx, attrs(ctx, :fresh)) |> json_response(422)
+    assert response["error"] == "execution_limits_invalid"
+    refute Jason.encode!(response) =~ "private-value"
+    refute Jason.encode!(response) =~ "private-field"
+    assert Repo.reload!(corrupt) == corrupt
+    refute_received :worker_started
+  end
+
+  test "another account's ceiling is neither inherited nor disclosed", ctx do
+    other = insert_active_user() |> save_ceiling(%{wall_time_seconds: 30})
+    assert request(ctx, attrs(ctx, :fresh)) |> json_response(201)
+    assert_received :worker_started
+
+    save_ceiling(ctx.user, %{max_model_turns: 2})
+    foreign = insert_agent(user_id: other.id)
+    params = %{"agent_id" => foreign.id}
+    assert %{"error" => "not_found"} = request(ctx, params) |> json_response(404)
+    refute_received :worker_started
+  end
+
+  defp save_ceiling(user, limits),
+    do: user |> Repo.reload!() |> User.execution_limits_changeset(limits) |> Repo.update!()
 
   defp counts, do: {Repo.aggregate(Conversation, :count), Repo.aggregate(Sandbox, :count)}
   defp attrs(ctx, :fresh), do: %{"agent_id" => ctx.agent.id, "sandbox_mode" => "ephemeral"}

--- a/apps/fountain/test/fountain_web/controllers/execution_limit_admission_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/execution_limit_admission_test.exs
@@ -1,0 +1,133 @@
+defmodule FountainWeb.ExecutionLimitAdmissionTest do
+  use FountainWeb.ConnCase, async: true
+  use Mimic
+
+  alias Fountain.{Conversations, Repo}
+  alias Fountain.Conversations.{Conversation, Sandbox}
+
+  setup do
+    user = insert_active_user()
+    {:ok, user} = Fountain.Accounts.update_sandbox_limit(user, 20)
+    {_key, raw_key} = insert_api_key(user)
+    env = insert_env(user_id: user.id)
+    agent = insert_agent(user_id: user.id, runtime: "claude", environment_id: env.id)
+
+    sandbox =
+      insert_sandbox(
+        user_id: user.id,
+        agent_id: agent.id,
+        environment_id: env.id,
+        status: "ready"
+      )
+
+    conv =
+      insert_conversation(
+        user_id: user.id,
+        agent: agent,
+        sandbox: sandbox,
+        status: "idle",
+        channel_id: "limits"
+      )
+
+    owner = self()
+
+    stub(Horde.DynamicSupervisor, :start_child, fn _, _ ->
+      send(owner, :worker_started)
+      {:ok, spawn(fn -> :ok end)}
+    end)
+
+    {:ok, user: user, raw_key: raw_key, agent: agent, sandbox: sandbox, conv: conv}
+  end
+
+  for path <- [:fresh, :attach, :resume, :rotate] do
+    test "#{path} refuses unenforced limits before changing state", ctx do
+      before_counts = counts()
+      attrs = Map.put(attrs(ctx, unquote(path)), "execution_limits", %{"wall_time_seconds" => 60})
+      response = request(ctx, attrs) |> json_response(422)
+      assert response["error"] == "execution_limits_unsupported"
+      assert response["message"] =~ "wall_time_seconds"
+      assert counts() == before_counts
+      assert Repo.reload!(ctx.conv).channel_id == "limits"
+      refute_received :worker_started
+    end
+  end
+
+  test "all allowlisted controls are refused until enforcement is integrated", ctx do
+    for field <- Conversations.ExecutionLimits.keys() do
+      params = Map.put(attrs(ctx, :fresh), "execution_limits", %{field => 1})
+
+      assert %{"error" => "execution_limits_unsupported"} =
+               request(ctx, params) |> json_response(422)
+    end
+
+    refute_received :worker_started
+  end
+
+  test "invalid limits fail with a stable error without echoing input", ctx do
+    before_counts = counts()
+
+    for limits <- [
+          %{"secret" => "do-not-echo"},
+          %{"wall_time_seconds" => "60"},
+          %{"max_model_turns" => nil},
+          []
+        ] do
+      params = Map.put(attrs(ctx, :fresh), "execution_limits", limits)
+      response = request(ctx, params) |> json_response(422)
+      assert response["error"] == "execution_limits_invalid"
+      refute Jason.encode!(response) =~ "do-not-echo"
+    end
+
+    assert counts() == before_counts
+    refute_received :worker_started
+  end
+
+  test "direct context callers cannot bypass fresh or attach admission", ctx do
+    before_counts = counts()
+
+    for path <- [:fresh, :attach] do
+      params =
+        attrs(ctx, path)
+        |> Map.put("user_id", ctx.user.id)
+        |> Map.put("execution_limits", %{max_model_turns: 1})
+
+      assert {:error, {:execution_limits_unsupported, ["max_model_turns"]}} =
+               Conversations.start_conversation(params)
+    end
+
+    assert counts() == before_counts
+    refute_received :worker_started
+  end
+
+  test "omitted and empty limits preserve ordinary admission", ctx do
+    for limits <- [:omitted, nil, %{}], path <- [:fresh, :attach, :resume] do
+      params = attrs(ctx, path)
+
+      params =
+        if limits == :omitted, do: params, else: Map.put(params, "execution_limits", limits)
+
+      status = if path == :resume, do: 200, else: 201
+      assert %{"data" => _} = request(ctx, params) |> json_response(status)
+    end
+  end
+
+  test "a foreign agent remains hidden before limit validation", ctx do
+    foreign = insert_agent(user_id: insert_active_user().id)
+    params = %{"agent_id" => foreign.id, "execution_limits" => %{"max_model_turns" => 1}}
+    assert %{"error" => "not_found"} = request(ctx, params) |> json_response(404)
+    refute_received :worker_started
+  end
+
+  defp counts, do: {Repo.aggregate(Conversation, :count), Repo.aggregate(Sandbox, :count)}
+  defp attrs(ctx, :fresh), do: %{"agent_id" => ctx.agent.id, "sandbox_mode" => "ephemeral"}
+  defp attrs(ctx, :attach), do: %{"agent_id" => ctx.agent.id, "sandbox_id" => ctx.sandbox.id}
+  defp attrs(ctx, :resume), do: %{"agent_id" => ctx.agent.id, "channel_id" => "limits"}
+  defp attrs(ctx, :rotate), do: Map.put(attrs(ctx, :resume), "fresh", true)
+
+  defp request(ctx, params) do
+    ctx.conn
+    |> authed_with_key(ctx.raw_key)
+    |> put_req_header("content-type", "application/json")
+    |> post("/api/conversations", Jason.encode!(params))
+  end
+end

--- a/apps/fountain/test/fountain_web/controllers/saved_allowance_channel_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/saved_allowance_channel_test.exs
@@ -1,0 +1,193 @@
+defmodule FountainWeb.SavedAllowanceChannelTest do
+  use FountainWeb.ConnCase, async: false
+  use Mimic
+
+  alias Fountain.{Conversations, Repo}
+  alias Fountain.Conversations.{ConversationServer, ExecutionAllowance}
+  alias FountainWeb.{AguiController, OpenAIController}
+
+  setup do
+    user = insert_verified_user()
+    agent = insert_agent(user_id: user.id)
+    {_key, raw} = insert_api_key(user)
+    flags = Application.get_env(:fountain, :feature_flag_overrides)
+    Application.put_env(:fountain, :feature_flag_overrides, %{"openai_compat" => true})
+
+    on_exit(fn ->
+      if flags,
+        do: Application.put_env(:fountain, :feature_flag_overrides, flags),
+        else: Application.delete_env(:fountain, :feature_flag_overrides)
+    end)
+
+    owner = self()
+    stub(ConversationServer, :pending_caller_calls, fn _ -> [] end)
+    stub(ConversationServer, :queue_initial_prompt, fn _, _ -> send(owner, :queued) end)
+
+    stub(Horde.DynamicSupervisor, :start_child, fn _, _ ->
+      send(owner, :worker_started)
+      {:ok, owner}
+    end)
+
+    %{user: user, agent: agent, raw: raw}
+  end
+
+  for api <- [:native, :openai, :agui], malformed <- [false, true] do
+    test "#{api} refuses malformed=#{malformed} policy before changing caller tools", ctx do
+      api = unquote(api)
+      channel = channel(api)
+      conv = bound(ctx, channel)
+      {:ok, conv} = Conversations.set_caller_tools(conv, [tool("original")])
+      allowance = save(conv, %{max_model_turns: 2})
+
+      error =
+        if unquote(malformed) do
+          allowance
+          |> Ecto.Changeset.change(limits: %{"private-field" => "do not echo"})
+          |> Repo.update!()
+
+          {:error, {:execution_limits_invalid, "unknown_field"}}
+        else
+          {:error, {:execution_limits_unsupported, ["max_model_turns"]}}
+        end
+
+      # Model the downstream prompt guard: it already refuses, but that is
+      # too late if channel admission let the controller replace tools first.
+      owner = self()
+
+      stub(ConversationServer, :send_prompt, fn _, _, _, _ ->
+        send(owner, :prompt_attempted)
+        error
+      end)
+
+      before = Repo.reload!(conv)
+      conn = request(ctx, api, channel)
+      assert Repo.reload!(conv) == before
+      refute_received :prompt_attempted
+      refute_received :queued
+      refute_received :worker_started
+      assert Conversations._unsafe_list_turns(conv.id) == []
+      body = json_response(conn, 422)
+
+      code =
+        if unquote(malformed),
+          do: "execution_limits_invalid",
+          else: "execution_limits_unsupported"
+
+      if unquote(api == :openai) do
+        assert body["error"]["code"] == code
+        assert body["error"]["type"] == "invalid_request_error"
+      else
+        assert body["error"] == code
+      end
+
+      refute Jason.encode!(body) =~ "private-field"
+      refute Jason.encode!(body) =~ "do not echo"
+    end
+  end
+
+  test "a suspended binding is refused and remains available for read-only lookup", ctx do
+    conv = bound(ctx, "parked")
+    conv.sandbox |> Ecto.Changeset.change(status: "suspended") |> Repo.update!()
+    save(conv, %{wall_time_seconds: 30})
+    attrs = attrs(ctx, "parked")
+
+    assert {:error, {:execution_limits_unsupported, ["wall_time_seconds"]}} =
+             Conversations.start_or_resume_conversation(attrs)
+
+    assert Conversations.channel_conversation(attrs).id == conv.id
+    assert Repo.reload!(conv.sandbox).status == "suspended"
+    refute_received :worker_started
+  end
+
+  test "absent and empty allowances resume the existing binding", ctx do
+    for {channel, limits} <- [{"absent", nil}, {"empty", %{}}] do
+      conv = bound(ctx, channel)
+      if limits, do: save(conv, limits)
+
+      assert {:ok, resumed, :resumed} =
+               Conversations.start_or_resume_conversation(attrs(ctx, channel))
+
+      assert resumed.id == conv.id
+      refute_received :worker_started
+    end
+  end
+
+  test "another tenant cannot resume the binding or inspect its policy", ctx do
+    conv = bound(ctx, "private")
+    save(conv, %{max_model_turns: 2})
+    foreign = insert_verified_user()
+    foreign_attrs = Map.put(attrs(ctx, "private"), "user_id", foreign.id)
+    assert {:error, :not_found} = Conversations.start_or_resume_conversation(foreign_attrs)
+    assert Conversations.channel_conversation(foreign_attrs) == nil
+    refute_received :worker_started
+  end
+
+  test "explicit fresh rotation does not inherit the old conversation allowance", ctx do
+    conv = bound(ctx, "rotate")
+    save(conv, %{max_model_turns: 2})
+
+    assert {:ok, fresh, :created} =
+             Conversations.start_or_resume_conversation(
+               Map.put(attrs(ctx, "rotate"), "fresh", true)
+             )
+
+    refute fresh.id == conv.id
+    assert Repo.reload!(conv).channel_id == nil
+    assert Repo.get_by(ExecutionAllowance, conversation_id: fresh.id) == nil
+    assert_received :worker_started
+  end
+
+  defp bound(ctx, channel),
+    do:
+      insert_conversation(
+        user_id: ctx.user.id,
+        agent: ctx.agent,
+        channel_id: channel,
+        status: "idle"
+      )
+
+  defp attrs(ctx, channel),
+    do: %{"user_id" => ctx.user.id, "agent_id" => ctx.agent.id, "channel_id" => channel}
+
+  defp save(conv, limits),
+    do: conv.id |> ExecutionAllowance.new_changeset(limits) |> Repo.insert!()
+
+  defp tool(name),
+    do: %{
+      "name" => name,
+      "description" => name,
+      "parameters" => %{"type" => "object", "properties" => %{}}
+    }
+
+  defp channel(:native), do: "native-thread"
+  defp channel(:openai), do: OpenAIController.channel_id("thread")
+  defp channel(:agui), do: AguiController.channel_id("thread")
+
+  defp request(ctx, :native, channel),
+    do:
+      ctx.conn
+      |> authed_with_key(ctx.raw)
+      |> post_json("/api/conversations", Map.delete(attrs(ctx, channel), "user_id"))
+
+  defp request(ctx, :openai, _channel) do
+    ctx.conn
+    |> authed_with_key(ctx.raw)
+    |> put_req_header("x-fountain-thread", "thread")
+    |> post_json("/v1/chat/completions", %{
+      "model" => ctx.agent.id,
+      "messages" => [%{"role" => "user", "content" => "continue"}],
+      "tools" => [%{"type" => "function", "function" => tool("replacement")}]
+    })
+  end
+
+  defp request(ctx, :agui, _channel) do
+    ctx.conn
+    |> authed_with_key(ctx.raw)
+    |> post_json("/api/agui/#{ctx.agent.id}", %{
+      "threadId" => "thread",
+      "runId" => "run",
+      "messages" => [%{"role" => "user", "content" => "continue"}],
+      "tools" => [tool("replacement")]
+    })
+  end
+end

--- a/apps/fountain/test/fountain_web/controllers/saved_allowance_wake_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/saved_allowance_wake_test.exs
@@ -1,0 +1,176 @@
+defmodule FountainWeb.SavedAllowanceWakeTest do
+  use FountainWeb.ConnCase, async: true
+  use Mimic
+
+  alias Fountain.{Conversations, Repo}
+  alias Fountain.Conversations.{ConversationServer, ExecutionAllowance, Sandbox}
+
+  setup do
+    user = insert_verified_user()
+    agent = insert_agent(user_id: user.id)
+    {_key, raw} = insert_api_key(user)
+    owner = self()
+
+    stub(Managoat.Sandbox.Sprites, :get, fn handle ->
+      send(owner, :provider_probe)
+      {:ok, %{status: :running, raw: %{name: handle.name}}}
+    end)
+
+    stub(Managoat.Sandbox.Sprites, :resume, fn handle ->
+      send(owner, :provider_resume)
+      {:ok, handle}
+    end)
+
+    stub(Horde.DynamicSupervisor, :start_child, fn _, _ ->
+      send(owner, :worker_start)
+      {:ok, owner}
+    end)
+
+    stub(ConversationServer, :queue_initial_prompt, fn _, _ ->
+      send(owner, :prompt_queued)
+      :ok
+    end)
+
+    %{user: user, agent: agent, raw: raw}
+  end
+
+  for status <- ~w(ready suspended pending starting terminated failed) do
+    test "saved limits refuse a #{status} sandbox wake before side effects", ctx do
+      sandbox = insert_sandbox(user_id: ctx.user.id, status: unquote(status))
+      conv = conversation(ctx, sandbox) |> Repo.reload!()
+      save(conv, %{max_model_turns: 2})
+      count = Repo.aggregate(Sandbox, :count)
+
+      for prompt <- [nil, "continue"] do
+        assert {:error, {:execution_limits_unsupported, ["max_model_turns"]}} =
+                 Conversations.wake_conversation(conv.id, prompt)
+      end
+
+      assert Repo.reload!(conv) == conv
+      assert Repo.reload!(sandbox) == sandbox
+      assert Repo.aggregate(Sandbox, :count) == count
+      assert Conversations._unsafe_list_turns(conv.id) == []
+      refute_side_effects()
+    end
+  end
+
+  test "the prompt API reports 422 instead of queueing a dormant conversation", ctx do
+    conv = conversation(ctx, insert_sandbox(user_id: ctx.user.id, status: "ready"))
+    save(conv, %{wall_time_seconds: 30})
+
+    body =
+      ctx.conn
+      |> authed_with_key(ctx.raw)
+      |> post_json("/api/conversations/#{conv.id}/prompts", %{prompt: "continue"})
+      |> json_response(422)
+
+    assert body["error"] == "execution_limits_unsupported"
+    assert body["message"] =~ "wall_time_seconds"
+    refute_side_effects()
+  end
+
+  test "malformed saved policy returns a safe 422", ctx do
+    conv = conversation(ctx, insert_sandbox(user_id: ctx.user.id, status: "ready"))
+    allowance = save(conv, %{})
+
+    allowance
+    |> Ecto.Changeset.change(limits: %{"private-value" => "do not echo"})
+    |> Repo.update!()
+
+    body =
+      ctx.conn
+      |> authed_with_key(ctx.raw)
+      |> post_json("/api/conversations/#{conv.id}/prompts", %{prompt: "continue"})
+      |> json_response(422)
+
+    assert body == %{
+             "error" => "execution_limits_invalid",
+             "errors" => %{"execution_limits" => ["invalid unknown_field"]}
+           }
+
+    refute_side_effects()
+  end
+
+  test "another tenant's conversation remains a 404", ctx do
+    other = insert_conversation()
+    save(other, %{max_model_turns: 2})
+
+    ctx.conn
+    |> authed_with_key(ctx.raw)
+    |> post_json("/api/conversations/#{other.id}/prompts", %{prompt: "continue"})
+    |> json_response(404)
+
+    refute_side_effects()
+  end
+
+  test "absent and empty allowances still wake and queue the prompt", ctx do
+    for limits <- [:absent, %{}] do
+      conv = conversation(ctx, insert_sandbox(user_id: ctx.user.id, status: "ready"))
+      if limits != :absent, do: save(conv, limits)
+      assert {:ok, _} = Conversations.wake_conversation(conv.id, "continue")
+      assert_received :provider_probe
+      assert_received :worker_start
+      assert_received :prompt_queued
+    end
+  end
+
+  test "a saved limit does not prevent reconnecting to interrupt a running turn", ctx do
+    conv = conversation(ctx, insert_sandbox(user_id: ctx.user.id, status: "ready"))
+    conv = conv |> Ecto.Changeset.change(status: "running") |> Repo.update!()
+    save(conv, %{max_model_turns: 2})
+    owner = self()
+
+    peer =
+      spawn(fn ->
+        receive do
+          {:"$gen_call", from, :interrupt} ->
+            send(owner, :interrupted)
+            GenServer.reply(from, :ok)
+        end
+      end)
+
+    on_exit(fn -> Process.exit(peer, :kill) end)
+    stub(Horde.DynamicSupervisor, :start_child, fn _, _ -> {:ok, peer} end)
+
+    expect(Horde.Registry, :lookup, fn Fountain.ConversationRegistry, id ->
+      assert id == conv.id
+      []
+    end)
+
+    expect(Horde.Registry, :lookup, fn Fountain.ConversationRegistry, id ->
+      assert id == conv.id
+      [{peer, nil}]
+    end)
+
+    assert :ok = ConversationServer.interrupt(conv.id)
+    assert_received :interrupted
+    assert_received :provider_probe
+    refute_received :prompt_queued
+  end
+
+  test "cancellation does not wake an idle conversation", ctx do
+    conv = conversation(ctx, insert_sandbox(user_id: ctx.user.id, status: "ready"))
+    save(conv, %{max_model_turns: 2})
+    assert {:error, :not_running} = Conversations.wake_for_interrupt(conv.id)
+    refute_side_effects()
+  end
+
+  defp conversation(ctx, sandbox),
+    do:
+      insert_conversation(
+        user_id: ctx.user.id,
+        agent: ctx.agent,
+        sandbox: sandbox,
+        status: "idle"
+      )
+
+  defp save(conv, limits),
+    do: conv.id |> ExecutionAllowance.new_changeset(limits) |> Repo.insert!()
+
+  defp refute_side_effects do
+    refute_received :provider_probe
+    refute_received :provider_resume
+    refute_received :worker_start
+    refute_received :prompt_queued
+  end
+end

--- a/docs/api.md
+++ b/docs/api.md
@@ -168,12 +168,16 @@ Create a conversation with an agent and a first prompt, follow its events,
 and send later prompts to that same conversation. Keep the returned ID.
 A new conversation creates another thread.
 
-Launch requests with nonempty `execution_limits` return
+Launch requests inherit the current account execution ceiling. Omitted, null or
+empty `execution_limits` do not remove it. Wider requests return
+`422 execution_limits_widen`; malformed requests or account policy return
+`422 execution_limits_invalid`. Nonempty effective limits return
 `422 execution_limits_unsupported`; Fountain cannot yet enforce these controls.
-Malformed limits return `422 execution_limits_invalid`. These checks apply to
-fresh launches, sandbox attachments and channel resumes before starting a worker
-or changing a channel binding. Omitted, null or empty limits preserve ordinary
-admission.
+These preflight checks cover fresh launches, sandbox attachments and channel
+resumes before worker start or channel changes. This is not an atomic reservation
+against later policy changes. Keep account ceilings empty until later-turn and
+recovery checks and runtime enforcement are integrated. Host ceilings and initial
+allowance persistence remain unwired.
 
 ```bash
 curl --fail-with-body \

--- a/docs/api.md
+++ b/docs/api.md
@@ -168,6 +168,13 @@ Create a conversation with an agent and a first prompt, follow its events,
 and send later prompts to that same conversation. Keep the returned ID.
 A new conversation creates another thread.
 
+Launch requests with nonempty `execution_limits` return
+`422 execution_limits_unsupported`; Fountain cannot yet enforce these controls.
+Malformed limits return `422 execution_limits_invalid`. These checks apply to
+fresh launches, sandbox attachments and channel resumes before starting a worker
+or changing a channel binding. Omitted, null or empty limits preserve ordinary
+admission.
+
 ```bash
 curl --fail-with-body \
   -H "Authorization: Bearer $FOUNTAIN_API_KEY" \

--- a/sdk/contract/contract.json
+++ b/sdk/contract/contract.json
@@ -4825,6 +4825,11 @@
             "ref": "Error"
           }
         },
+        "422": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "429": {
           "application/json": {
             "ref": "Error"
@@ -7003,6 +7008,37 @@
           }
         },
         "409": {
+          "application/json": {
+            "properties": {
+              "error": {
+                "properties": {
+                  "code": {
+                    "nullable": true,
+                    "required": false,
+                    "type": "string"
+                  },
+                  "message": {
+                    "required": false,
+                    "type": "string"
+                  },
+                  "param": {
+                    "nullable": true,
+                    "required": false,
+                    "type": "string"
+                  },
+                  "type": {
+                    "required": false,
+                    "type": "string"
+                  }
+                },
+                "required": false,
+                "type": "object"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "422": {
           "application/json": {
             "properties": {
               "error": {

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -7569,6 +7569,15 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description Saved execution policy refused */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Too Many Requests */
             429: {
                 headers: {
@@ -16419,6 +16428,22 @@ export interface operations {
             };
             /** @description The thread is running a turn; retry */
             409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: {
+                            code?: string | null;
+                            message?: string;
+                            param?: string | null;
+                            type?: string;
+                        };
+                    };
+                };
+            };
+            /** @description Saved execution policy refused */
+            422: {
                 headers: {
                     [name: string]: unknown;
                 };


### PR DESCRIPTION
Combines the reviewed and approved execution-limit admission stack — #1773 through #1786, minus the host-ceiling work — into one PR against `main`.

## What this is

Execution limits (`wall_time_seconds`, `max_model_turns`, `max_estimated_cost_usd`) get a typed policy resolver, versioned per-conversation storage, owner-scoped write operations, and a refusal at every door that could otherwise promise a bounded execution it cannot deliver.

**Nothing is enforced yet, and that is the point.** Every control is refused end-to-end via `require_controls(limits, [])`, so a saved allowance is always `%{}` today. The stack makes it impossible to accept a limit the runtime cannot honour, ahead of the runtime work that will honour them.

## What it contains

| PR | Change |
|---|---|
| #1773 | `Fountain.Conversations.ExecutionLimits` — the pure resolver: validate, inherit ceilings, narrow, refuse widening |
| #1774 | Refuse requested limits at launch, attach and channel mutation, before any write |
| #1775 | `execution_allowances` — versioned storage, opaque revision, optimistic locking |
| #1776 | Check the saved allowance inside the turn transaction, under row locks |
| #1777 | Refuse before wake probes a provider or starts a worker; interrupt stays reachable |
| #1778 | Refuse before a prompt supersedes autonomous work on a live server |
| #1779 | Same for the queued initial-prompt cast |
| #1780 | Refuse before a channel resume replaces caller tools (native, OpenAI, AG-UI) |
| #1781 | Close the boot-recovery bypass in `Rehydrator.spawn_server/1` |
| #1782 | A saved JSON `null` is corrupt, not an unrestricted allowance to narrow |
| #1783 | `Conversations.narrow_execution_allowance/4` — owner-scoped, audited |
| #1784 | Typed operator-owned account ceiling storage on `users` |
| #1785 | Resolve launch requests against the current account ceiling |
| #1786 | `Conversations.create_execution_allowance/4` — owner-scoped, audited |

Two new migrations: `20260909090000_create_execution_allowances`, `20260910020000_add_account_execution_limits`.

## What it deliberately excludes

**#1787** (host ceilings / `FOUNTAIN_EXECUTION_LIMITS`) is left out — it has changes requested for a missing `.env.example` entry. #1788 (the two-stack join) is made moot by this PR. #1789 through #1791 (allowance persistence at launch, rotation) also have changes requested, mostly about row locks taken inside the global fleet advisory lock.

## How the merge was built

Three merges on top of the #1786 chain: #1782, then the #1784 -> #1774 -> #1785 chain, then current `main`.

Only one textual conflict, in `fallback_controller.ex` — resolved by keeping the `execution_limits_widen` clause, plus dropping a duplicate `ExecutionLimits` alias in `conversations.ex`. Both match the resolution CI already verified on #1788.

The result was checked structurally rather than by eye: the merged tree equals #1788's CI-verified tree **minus** #1787's commit **plus** #1782's commit, with both deltas fully accounted for and nothing else. All eight guard call sites survive the `main` merge intact.

`#1774`'s commit appears once, not twice — `71ce96c8` and `d4ea7e76` have identical patch-ids, and the copy on the #1785 chain is the one included.

## Validation

Run locally on the merged tree, on a dedicated database:

- `mix compile --warnings-as-errors` — clean
- `mix format --check-formatted` at the root and in `apps/fountain` — clean, exit 0
- `mix credo --strict` — 769 files, 6963 mods/funs, no issues
- `mix deps.unlock --unused` — clean
- Both migrations apply from empty
- 191 tests across the ten execution-limit suites — 0 failures
- 280 tests across the suites `main`'s two new commits touched (`conversations_start`, `conversations_context`, `changeset`, `conversation_controller`, `conversations_wake`, `conversation_server_acp`) — 0 failures
- The dedicated database was **empty** afterward, confirming the `unboxed_run` race fixtures clean up their committed rows

Closes #1773
Closes #1774
Closes #1775
Closes #1776
Closes #1777
Closes #1778
Closes #1779
Closes #1780
Closes #1781
Closes #1782
Closes #1783
Closes #1784
Closes #1785
Closes #1786

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EzUPkXKdmnZYeJ1sqjpnp9
