### PR TITLE
fix: keep tenant foreign-key waits outside fleet reservation

### DIFF
--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -2458,42 +2458,73 @@ defmodule Fountain.Conversations do
     end
   end
 
-  # Keep fleet -> user advisory lock order, then stabilize ownership and
-  # recheck policy. A failed conversation or allowance must release the entire
-  # reservation. Analytics, audit, worker startup and prompts run after commit.
+  # Tenant row waits happen here, before the fleet lock, and the reservation
+  # runs inside them. `with_sandbox_reservation/3` holds
+  # `pg_advisory_xact_lock(@fleet_lock_key)` — one lock shared by every tenant —
+  # so anything that can wait on another transaction must be settled before it
+  # is taken, or one account stalls provisioning for all of them.
+  #
+  # An unlocked read was not enough: `create_sandbox/1` and the conversation
+  # insert take `KEY SHARE` on `users` through their foreign keys, and
+  # `Credits.insert_and_move/3` holds that row `FOR UPDATE` across a ledger
+  # insert, lot consumption and the balance move. Taking `FOR SHARE` out here
+  # both settles the wait outside the fleet lock and satisfies those foreign
+  # keys, so the inserts below cannot block on it. The rotation unbind is the
+  # same category of wait and joins them.
+  #
+  # This is one transaction: the nested `Repo.transaction` inside
+  # `with_sandbox_reservation/3` joins it rather than opening another, so the
+  # sandbox, conversation and allowance still commit or roll back together.
+  # That is also why the `case` below re-raises the inner rollback with its
+  # reason: a nested rollback the outer transaction does not re-raise reaches
+  # the caller as `{:error, :rollback}`, which would turn every credits, quota
+  # and fleet refusal into a 500 instead of a 402, 422 or 503.
+  #
+  # The wait does not disappear, it changes hands. This transaction holds
+  # `users FOR SHARE` for its whole life, the fleet-lock wait included, and
+  # `FOR SHARE` conflicts with `FOR UPDATE` — so this tenant's credit postings
+  # now queue behind its own in-flight launch, which may itself be queued
+  # behind every other tenant's. Turn burns, purchases, grants, expiry and
+  # refund clawbacks all post through `Credits.insert_and_move/3`. A
+  # tenant-scoped wait beats a fleet-wide one, which is why it is the right
+  # trade, but a slow credit posting starts here.
   defp reserve_initial_conversation(sandbox_attrs, conversation_attrs, request, opts) do
-    Fountain.Quotas.with_sandbox_reservation(conversation_attrs.user_id, fn ->
-      # Nothing in here may take a row lock. `with_sandbox_reservation/3` holds
-      # `pg_advisory_xact_lock(@fleet_lock_key)` — one lock shared by every
-      # tenant, the thing that enforces SANDBOX_FLEET_CEILING — for the whole
-      # of this function. A `SELECT ... FOR SHARE` on `users` conflicts with
-      # the `FOR UPDATE` that `Credits.insert_and_move/3` holds across a ledger
-      # insert, lot consumption and the balance move, so one tenant's credit
-      # posting would stall provisioning for every other tenant. `agents` is
-      # the same story against a `last_used_at` stamp. These stay plain
-      # ownership rechecks: MVCC reads never block, the ceiling below is read
-      # the same way, and the inserts' foreign keys enforce integrity.
+    Repo.transaction(fn ->
       Repo.one(
         from u in Fountain.Accounts.User,
           where: u.id == ^conversation_attrs.user_id,
-          select: u.id
+          select: u.id,
+          lock: "FOR SHARE"
       ) || Repo.rollback(:not_found)
 
       Repo.one(
         from a in Agents.Agent,
           where:
             a.id == ^conversation_attrs.agent_id and a.user_id == ^conversation_attrs.user_id,
-          select: a.id
+          select: a.id,
+          lock: "FOR SHARE"
       ) || Repo.rollback(:not_found)
 
-      with :ok <- unbind_rotated_channel(conversation_attrs, opts),
-           {:ok, limits} <- resolve_admission_limits(conversation_attrs.user_id, request),
-           {:ok, sandbox} <- create_sandbox(sandbox_attrs),
-           {:ok, conv} <-
-             insert_conversation_row(Map.put(conversation_attrs, :sandbox_id, sandbox.id)),
-           {:ok, allowance} <-
-             conv.id |> ExecutionAllowance.new_changeset(limits) |> Repo.insert() do
-        {:ok, {sandbox, conv, allowance}}
+      case unbind_rotated_channel(conversation_attrs, opts) do
+        :ok -> :ok
+        {:error, reason} -> Repo.rollback(reason)
+      end
+
+      result =
+        Fountain.Quotas.with_sandbox_reservation(conversation_attrs.user_id, fn ->
+          with {:ok, limits} <- resolve_admission_limits(conversation_attrs.user_id, request),
+               {:ok, sandbox} <- create_sandbox(sandbox_attrs),
+               {:ok, conv} <-
+                 insert_conversation_row(Map.put(conversation_attrs, :sandbox_id, sandbox.id)),
+               {:ok, allowance} <-
+                 conv.id |> ExecutionAllowance.new_changeset(limits) |> Repo.insert() do
+            {:ok, {sandbox, conv, allowance}}
+          end
+        end)
+
+      case result do
+        {:ok, reserved} -> reserved
+        {:error, reason} -> Repo.rollback(reason)
       end
     end)
   end

--- a/apps/fountain/test/fountain/conversations/admission_lock_isolation_test.exs
+++ b/apps/fountain/test/fountain/conversations/admission_lock_isolation_test.exs
@@ -1,0 +1,126 @@
+defmodule Fountain.Conversations.AdmissionLockIsolationTest do
+  use Fountain.DataCase, async: false
+  use Mimic
+
+  alias Fountain.Conversations
+  alias Fountain.Conversations.Sandbox
+
+  for row <- [:account, :agent] do
+    test "a launch waiting on its #{row} does not hold the fleet lock" do
+      Ecto.Adapters.SQL.Sandbox.unboxed_run(Repo, fn ->
+        first = tenant()
+        second = tenant()
+        owner = self()
+        row = unquote(row)
+
+        blocker =
+          independent(fn ->
+            Repo.transaction(fn ->
+              # Credits.insert_and_move/3 takes this mode on users; an
+              # exclusive agent write can likewise block its foreign keys.
+              Repo.one!(lock(row_query(row, first), "FOR UPDATE"))
+              send(owner, :row_locked)
+
+              receive do
+                :commit -> :ok
+              after
+                10_000 -> raise "row lock release timed out"
+              end
+            end)
+          end)
+
+        try do
+          assert_receive :row_locked, 5_000
+          waiting = launch(first)
+
+          try do
+            assert_receive {:backend, blocker_pid, blocker_backend}, 5_000
+            assert blocker_pid == blocker.pid
+            assert_receive {:backend, waiting_pid, waiting_backend}, 5_000
+            assert waiting_pid == waiting.pid
+            refute blocker_backend == waiting_backend
+            await_blocked(waiting_backend, System.monotonic_time(:millisecond) + 5_000)
+            other = launch(second)
+
+            try do
+              # Another real launch must commit while the first tenant remains
+              # blocked. Checking lock acquisition alone would miss later waits.
+              assert {:ok, {:ok, created}} = Task.yield(other, 2_000)
+              assert created.user_id == second.user.id
+              assert Task.yield(waiting, 0) == nil
+              send(blocker.pid, :commit)
+              assert {:ok, :ok} = Task.await(blocker)
+              assert {:ok, created} = Task.await(waiting)
+              assert created.user_id == first.user.id
+            after
+              Task.shutdown(other, :brutal_kill)
+            end
+          after
+            Task.shutdown(waiting, :brutal_kill)
+          end
+        after
+          Task.shutdown(blocker, :brutal_kill)
+
+          for %{user: user} <- [first, second] do
+            sandboxes = Repo.all(from s in Sandbox, where: s.user_id == ^user.id)
+            Repo.delete_all(from e in Fountain.Audit.Event, where: e.user_id == ^user.id)
+            Repo.delete!(user)
+            for sandbox <- sandboxes, do: Repo.delete!(sandbox)
+          end
+        end
+      end)
+    end
+  end
+
+  defp row_query(:account, tenant),
+    do: from(u in Fountain.Accounts.User, where: u.id == ^tenant.user.id)
+
+  defp row_query(:agent, tenant),
+    do: from(a in Fountain.Agents.Agent, where: a.id == ^tenant.agent.id)
+
+  defp tenant do
+    user =
+      Repo.insert!(%Fountain.Accounts.User{
+        email: "admission-lock-#{Ecto.UUID.generate()}@example.test",
+        credit_balance_cents: 500
+      })
+
+    %{user: user, agent: insert_agent(user_id: user.id, runtime: "claude")}
+  end
+
+  defp launch(tenant) do
+    independent(fn ->
+      Mimic.stub(Horde.DynamicSupervisor, :start_child, fn _, _ -> {:ok, self()} end)
+
+      Conversations.start_conversation(%{
+        "user_id" => tenant.user.id,
+        "agent_id" => tenant.agent.id,
+        "sandbox_mode" => "ephemeral"
+      })
+    end)
+  end
+
+  defp independent(fun) do
+    owner = self()
+
+    Task.async(fn ->
+      Ecto.Adapters.SQL.Sandbox.unboxed_run(Repo, fn ->
+        %{rows: [[backend]]} = Repo.query!("SELECT pg_backend_pid()")
+        send(owner, {:backend, self(), backend})
+        fun.()
+      end)
+    end)
+  end
+
+  defp await_blocked(backend, deadline) do
+    %{rows: [[blocked]]} = Repo.query!("SELECT cardinality(pg_blocking_pids($1)) > 0", [backend])
+
+    unless blocked do
+      assert System.monotonic_time(:millisecond) < deadline,
+             "no PostgreSQL row-lock wait observed"
+
+      Process.sleep(5)
+      await_blocked(backend, deadline)
+    end
+  end
+end


### PR DESCRIPTION
Fresh launches could still stall every tenant while a credit posting held `users FOR UPDATE`. #1790 removed the explicit `FOR SHARE` from inside `with_sandbox_reservation/3`, but that was only half of it: `create_sandbox/1` and the conversation insert take `KEY SHARE` on `users` through their foreign keys, and `KEY SHARE` conflicts with the `FOR UPDATE` that `Credits.insert_and_move/3` holds across a ledger insert, lot consumption and the balance move. The wait moved from an explicit lock to an implicit one and stayed under the global fleet advisory lock.

Take the account and scoped agent rows `FOR SHARE` in an outer transaction, before the reservation. That does two things at once: it settles the wait before `pg_advisory_xact_lock(@fleet_lock_key)` is taken, and — because `FOR SHARE` is compatible with `KEY SHARE` and is already held by this transaction — it satisfies the foreign-key checks inside, so the inserts cannot block on that row either. Both halves are needed; acquiring the lock is what makes the inserts non-blocking, not just the reordering.

The rotation unbind from #1791 moves out with them. It is the same category of wait, on a row turn admission takes `FOR UPDATE`, and leaving it inside would keep a wait under the fleet lock that this change exists to remove.

## The tradeoff

**This does not remove the wait, it changes who does the waiting.** The outer transaction holds `users FOR SHARE` for its whole life, including the wait for the global fleet lock, and `FOR SHARE` conflicts with `FOR UPDATE`. So a tenant's credit postings now queue behind that tenant's in-flight launch, which may itself be queued behind every other tenant's launch. Turn burns, purchases, grants, expiry and refund clawbacks all post through `Credits.insert_and_move/3`.

A tenant-scoped wait is strictly better than a fleet-wide one, which is why this is the right trade — but it is a real inversion, and someone debugging a slow credit posting should start here. Recorded in the comment on `reserve_initial_conversation/4` as well as here.

## The nested-transaction trap

The nested `Repo.transaction` inside `with_sandbox_reservation/3` joins the outer one rather than opening another, so the sandbox, conversation and allowance still commit or roll back together. The `case result` re-rollback is load-bearing rather than defensive: a nested rollback the outer transaction does not re-raise with its reason reaches the caller as `{:error, :rollback}`. Without it, every refusal `with_sandbox_reservation/3` produces — `:insufficient_credits` (402 with `upgrade_url`), `:fleet_full` (503), a quota changeset (422) — would fall through `FallbackController` as a 500. Verified directly rather than assumed.

## Validation

Two contention tests, for the account row and the agent row: a second tenant's launch commits while the first is still blocked on its own row, on real independent connections with an observed lock wait. Asserting that the blocked launch eventually acquires its lock would prove nothing; the second tenant committing is the property.

Both fail on `997ed65f`. Reverting only the two `lock: "FOR SHARE"` clauses, keeping the restructuring, also fails them — so the locks carry the fix.

Compile with `--warnings-as-errors`, format at both roots, `credo --strict` (6994 mods/funs, no issues), 131 tests across the admission and allowance suites, no leftover fixtures in the database.

Rebased onto `main` after #1787, #1789, #1790 and #1791 landed; it was still based on `feat/fresh-initial-execution-allowance` at the pre-rebase `fc005df5`, which inflated the diff to +882.

Trackers: #1732, #1754.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EzUPkXKdmnZYeJ1sqjpnp9
