### PR TITLE
fix(tests): serialize global credit-pricing changes

### DIFF
--- a/ee/test/fountain/workers/credit_pricer_test.exs
+++ b/ee/test/fountain/workers/credit_pricer_test.exs
@@ -4,7 +4,8 @@ defmodule Fountain.Workers.CreditPricerTest do
   providers Fountain pays for, only from the configured instant.
   """
 
-  use Fountain.DataCase, async: true
+  # Message pricing changes global :credits configuration read by other suites.
+  use Fountain.DataCase, async: false
 
   alias Fountain.Billing
   alias Fountain.Credits


### PR DESCRIPTION
The credit-pricer suite changes global message prices while running asynchronously. A full-suite run at seed `828329` made `CreditsTest` observe those temporary prices and fail its default-price assertion.

Run the pricer suite synchronously so its existing `on_exit` restoration completes before other suites read pricing. One file, +2/-1, extracted from #1754 onto `main`.

Validation: both affected suites pass (38 tests, original seed). Rebased onto `ea7b8be5`; full `mix precommit --seed 828329` passes: 4,885 tests +6 doctests, zero failures. CI passes on this revision ([run](https://github.com/managoat/fountain/actions/runs/34471070392)); earlier attempts were blocked by Hex mirror connectivity.
