### PR TITLE
feat(broker): add tenant-scoped session cleanup

### DIFF
--- a/apps/fountain/lib/fountain/broker.ex
+++ b/apps/fountain/lib/fountain/broker.ex
@@ -571,6 +571,15 @@ defmodule Fountain.Broker do
     end
   end
 
+  @doc """
+  Delete the session matching tenant, conversation and token, even after the
+  broker is disabled. Repeated cleanup succeeds without touching other tokens.
+  Subsequent lookups refuse the token; existing proxy tunnels are not closed.
+  """
+  @spec release_session(String.t(), String.t(), String.t()) :: :ok
+  def release_session(user_id, conversation_id, token),
+    do: Native.release_session(user_id, conversation_id, token)
+
   @typedoc "One outbound request the broker handled for a conversation."
   @type egress_event :: %{
           id: integer(),

--- a/apps/fountain/lib/fountain/broker/native.ex
+++ b/apps/fountain/lib/fountain/broker/native.ex
@@ -436,6 +436,11 @@ defmodule Fountain.Broker.Native do
   def release(conversation_id) when is_binary(conversation_id),
     do: Sessions.release(conversation_id)
 
+  @doc "Revoke one session matching tenant, conversation and token."
+  @spec release_session(String.t(), String.t(), String.t()) :: :ok
+  def release_session(user_id, conversation_id, token),
+    do: Sessions.release_session(user_id, conversation_id, token)
+
   @doc """
   The conversation's egress rows, newest first (gate 4, #1486). The same
   shape the Agent Vault backend answered with, `status`, `latency_ms` and

--- a/apps/fountain/lib/fountain/broker/native/sessions.ex
+++ b/apps/fountain/lib/fountain/broker/native/sessions.ex
@@ -146,6 +146,22 @@ defmodule Fountain.Broker.Native.Sessions do
     end
   end
 
+  @doc "Revoke one worker's token without touching a replacement's sessions."
+  @spec release_session(String.t(), String.t(), String.t()) :: :ok
+  def release_session(user_id, conversation_id, token)
+      when is_binary(user_id) and is_binary(conversation_id) and is_binary(token) do
+    token_hash = hash(token)
+
+    Repo.delete_all(
+      from s in Session,
+        where:
+          s.user_id == ^user_id and s.conversation_id == ^conversation_id and
+            s.token_hash == ^token_hash
+    )
+
+    :ok
+  end
+
   @doc "Delete every session of a conversation. Its tokens stop working at once."
   @spec release(String.t()) :: :ok
   def release(conversation_id) when is_binary(conversation_id) do

--- a/apps/fountain/test/fountain/broker_native_test.exs
+++ b/apps/fountain/test/fountain/broker_native_test.exs
@@ -362,6 +362,61 @@ defmodule Fountain.BrokerNativeTest do
       assert {:ok, _} = Sessions.lookup(b.token)
     end
 
+    test "session release preserves a replacement token, including on a repeated cleanup", %{
+      user: user,
+      conv: conv
+    } do
+      {:ok, old} = Broker.prepare(conv.id, %{"GH_TOKEN" => "old"}, %{}, user_id: user.id)
+      {:ok, replacement} = Broker.prepare(conv.id, %{"GH_TOKEN" => "new"}, %{}, user_id: user.id)
+
+      assert :ok = Broker.release_session(user.id, conv.id, old.token)
+      assert :error = Sessions.lookup(old.token)
+      assert {:ok, %{rules: [%Rule{credential: "new"} | _]}} = Sessions.lookup(replacement.token)
+
+      assert :ok = Broker.release_session(user.id, conv.id, old.token)
+      assert {:ok, _} = Sessions.lookup(replacement.token)
+    end
+
+    test "session release requires matching tenant, conversation and token", %{
+      user: user,
+      conv: conv
+    } do
+      other_user = insert_verified_user()
+      other = insert_conversation(user_id: user.id, agent: insert_agent(user_id: user.id))
+      {:ok, session} = Broker.prepare(conv.id, %{"GH_TOKEN" => "g"}, %{}, user_id: user.id)
+
+      for {user_id, conversation_id, token} <- [
+            {other_user.id, conv.id, session.token},
+            {user.id, other.id, session.token},
+            {user.id, conv.id, "fb_unknown"}
+          ] do
+        assert :ok = Broker.release_session(user_id, conversation_id, token)
+        assert {:ok, _} = Sessions.lookup(session.token)
+      end
+
+      assert :ok = Broker.release_session(user.id, conv.id, session.token)
+      assert :error = Sessions.lookup(session.token)
+    end
+
+    test "session release works after tenant unenrollment or broker shutdown", %{
+      user: user,
+      conv: conv
+    } do
+      {:ok, first} = Broker.prepare(conv.id, %{"GH_TOKEN" => "g"}, %{}, user_id: user.id)
+      {:ok, second} = Broker.prepare(conv.id, %{"GH_TOKEN" => "g"}, %{}, user_id: user.id)
+
+      Application.put_env(:fountain, :broker_tenants, [])
+      refute Broker.enabled_for?(user.id)
+      assert :ok = Broker.release_session(user.id, conv.id, first.token)
+      assert :error = Sessions.lookup(first.token)
+      assert {:ok, _} = Sessions.lookup(second.token)
+
+      Application.delete_env(:fountain, :broker_listen_port)
+      assert Broker.backend() == nil
+      assert :ok = Broker.release_session(user.id, conv.id, second.token)
+      assert :error = Sessions.lookup(second.token)
+    end
+
     test "an expired session is refused, and the sweep deletes it", %{user: user, conv: conv} do
       {:ok, live} = Broker.prepare(conv.id, %{"GH_TOKEN" => "g"}, %{}, user_id: user.id)
       {:ok, stale} = Broker.prepare(conv.id, %{"GH_TOKEN" => "g"}, %{}, user_id: user.id)


### PR DESCRIPTION
Worker cleanup needs to revoke its own broker token without removing a replacement session for the same conversation. Add `Broker.release_session/3`, scoped by tenant, conversation and token hash; repeated cleanup is harmless and works after broker shutdown or tenant unenrollment. Existing proxy tunnels are unaffected.

Extracted from #1754 onto #1796 (the one-file test-isolation fix): four files, +85 lines. This is an internal primitive; lifecycle caller integration remains separate.

Validation: 50 broker tests pass, covering replacement preservation, all three scope predicates, repeated cleanup and disabled-broker cleanup. Full `mix precommit --seed 828329` passes: 4,886 tests +6 doctests, zero failures.

Rebased onto current main through #1796; the fresh full gate passes (4,888 tests +6 doctests). CI passes for this head ([run](https://github.com/managoat/fountain/actions/runs/34473233390)). The earlier Hex connectivity failure remains recorded in [the old run](https://github.com/managoat/fountain/actions/runs/34465468509).



Part of #1864
