### PR TITLE
Scan for secrets with the gitleaks CLI, not the licensed action

### DIFF
--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -8,6 +8,17 @@ on:
 permissions:
   contents: read
 
+env:
+  # The gitleaks CLI, pinned and checksum-verified, the same way the docs job
+  # pins vale. NOT gitleaks/gitleaks-action: the action refuses to run for an
+  # organization-owned repository without a paid licence key
+  # ("[managoat] is an organization. License key is required."), which is how
+  # this job failed the moment the repo moved out of a user account (0048).
+  # The scanner itself is MIT and unmetered; only the action wrapper is
+  # licensed, so the gate survives by dropping the wrapper.
+  GITLEAKS_VERSION: 8.30.1
+  GITLEAKS_SHA256: 551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
+
 jobs:
   gitleaks:
     name: Detect secrets
@@ -16,20 +27,48 @@ jobs:
 
     permissions:
       contents: read
-      # gitleaks-action resolves the scan range from the event payload's
-      # `before`..`after` when it can. A force-pushed rebase leaves `before`
-      # unreachable, and it falls back to GET /pulls/:n/commits — which 403s
-      # without this, crashing the action before it scans a single byte. The
-      # failure reads as "Detect secrets: fail" with no finding attached, so
-      # it looks like a leak when it is the opposite: nothing was scanned.
-      pull-requests: read
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
         with:
+          # The scan is a commit range, so both ends have to be reachable.
           fetch-depth: 0
 
-      - name: Run gitleaks
-        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
+      - name: Install gitleaks
+        run: |
+          set -euo pipefail
+          curl -fsSL -o gitleaks.tar.gz \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          echo "${GITLEAKS_SHA256}  gitleaks.tar.gz" | sha256sum -c -
+          tar -xzf gitleaks.tar.gz gitleaks
+          ./gitleaks version
+
+      - name: Resolve the range to scan
+        id: range
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BEFORE_SHA: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          # A pull request scans base..HEAD, which is what the action did. A
+          # push to main scans what it pushed — unless `before` is unreachable
+          # (a force push, or the zero sha on a new branch), where the only
+          # honest range left is the tip commit itself. Never silently scan
+          # nothing: an empty range would pass this gate without reading a
+          # byte, which is the failure mode the old job's comment warned about.
+          if [ -n "${BASE_SHA}" ]; then
+            range="${BASE_SHA}..${HEAD_SHA}"
+          elif [ -n "${BEFORE_SHA}" ] && [ "${BEFORE_SHA}" != "0000000000000000000000000000000000000000" ] \
+               && git cat-file -e "${BEFORE_SHA}^{commit}" 2>/dev/null; then
+            range="${BEFORE_SHA}..${HEAD_SHA}"
+          else
+            range="-1 ${HEAD_SHA}"
+          fi
+          echo "scanning ${range}"
+          echo "log_opts=${range}" >> "$GITHUB_OUTPUT"
+
+      - name: Detect secrets
+        env:
+          LOG_OPTS: ${{ steps.range.outputs.log_opts }}
+        run: ./gitleaks git . --no-banner --redact --verbose --log-opts "${LOG_OPTS}"


### PR DESCRIPTION
Found by executing 0048, and blocking: `Detect secrets` is one of the two required status checks, and it fails on every PR now that the repo is org-owned.

```
[managoat] is an organization. License key is required.
🛑 missing gitleaks license. Go grab one at gitleaks.io and store it as a GitHub Secret named GITLEAKS_LICENSE
```

`gitleaks/gitleaks-action` is free for a user account and licensed for an organization. The scanner itself is MIT and unmetered — only the wrapper is licensed — so this drops the wrapper and keeps the gate: the job downloads the pinned `8.30.1` linux_x64 release, verifies its sha256, and runs `gitleaks git` over the same range the action scanned. The job name stays `Detect secrets` so the ruleset's required check still resolves.

Ranges, explicitly, because "scanned nothing" and "found nothing" look identical in a green check: a PR scans `base..HEAD`, a push to main scans `before..HEAD`, and when `before` is unreachable (force push, or the zero sha) it scans the tip commit rather than an empty range.

Verified locally with the same binary the workflow pins: clean over the coordinate sweep in both range shapes, and `exit 1` with `RuleID: github-pat` on a planted token, so the gate bites. One thing worth recording for whoever next doubts it — the canonical AWS example key from the docs is allowlisted upstream and reports nothing, which looks exactly like a dead scanner.

The alternative was buying a licence. Worth it if you want the action's PR comments and SARIF upload; this keeps the gate working today at no cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RJBSE57BbSEDF5s5fvWEga
