### PR TITLE
fix: a save that changes nothing records nothing, and apply says so

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,12 @@ upgrade, is in
 
 ### Fixed
 
+- Updating an environment, vault, agent or webhook endpoint with the values it
+  already holds no longer records an `*.updated` audit event naming no changed
+  fields, and `fountain apply` reports those rows as `unchanged` rather than
+  claiming an update. A re-apply of the same manifest now writes nothing and
+  says so (#1680).
+
 - A secret edited or rotated in an environment or vault during a brokered
   conversation reaches the broker before the next turn. The broker's copy was
   split once, at provisioning, and only the tenant's connection tokens were

--- a/apps/fountain/lib/fountain/agents.ex
+++ b/apps/fountain/lib/fountain/agents.ex
@@ -192,9 +192,14 @@ defmodule Fountain.Agents do
         Repo.update(changeset)
       end
 
+    # A save that moves nothing records nothing, the same rule
+    # `Fountain.Environments.update_environment/3` follows (#1680).
     result =
-      result
-      |> audited("agent.updated", merge_metadata(opts, Audit.changed_fields(changeset)))
+      if changeset.changes == %{} do
+        result
+      else
+        audited(result, "agent.updated", merge_metadata(opts, Audit.changed_fields(changeset)))
+      end
 
     # Only once the new identity is the committed one: a home torn down
     # against an update that then failed would be rebuilt for nothing.

--- a/apps/fountain/lib/fountain/environments.ex
+++ b/apps/fountain/lib/fountain/environments.ex
@@ -137,10 +137,22 @@ defmodule Fountain.Environments do
   """
   def update_environment(%Environment{} = env, attrs, opts \\ []) do
     changeset = Environment.changeset(env, attrs)
+    result = Repo.update(changeset)
 
-    changeset
-    |> Repo.update()
-    |> audited("environment.updated", merge_metadata(opts, Audit.changed_fields(changeset)))
+    # A save that moves nothing is not a change, and records nothing
+    # (CLAUDE.md, "Only record what happened"). `Repo.update` already skips
+    # the SQL for an empty changeset, so an idempotent re-apply of a manifest
+    # left a trail of `environment.updated` rows with an empty changed list
+    # against a row nobody had touched (#1680).
+    if changeset.changes == %{} do
+      result
+    else
+      audited(
+        result,
+        "environment.updated",
+        merge_metadata(opts, Audit.changed_fields(changeset))
+      )
+    end
   end
 
   @doc """

--- a/apps/fountain/lib/fountain/manifest.ex
+++ b/apps/fountain/lib/fountain/manifest.ex
@@ -30,11 +30,16 @@ defmodule Fountain.Manifest do
 
   Returns `{:ok, results}` with one result map per resource in apply order
   (environments, vaults, agents, then any malformed entries). Each result
-  holds `:kind`, `:name`, an `:action` of `:created` / `:updated` / `:error`,
-  changeset-style `:errors` when the action is `:error`, a `:secrets`
-  list with the per-key upsert outcome, and the reconciled record's `:id`
-  (nil for errors and for kinds that carry no secrets). Secret values are
-  never echoed back.
+  holds `:kind`, `:name`, an `:action` of `:created` / `:updated` /
+  `:unchanged` / `:error`, changeset-style `:errors` when the action is
+  `:error`, a `:secrets` list with the per-key upsert outcome, and the
+  reconciled record's `:id` (nil for errors and for kinds that carry no
+  secrets). Secret values are never echoed back.
+
+  `:unchanged` means the record already matched the document, so nothing was
+  written to it. Inline `spec.secrets` are re-encrypted on every apply and
+  keep reporting `:upserted` in `:secrets`, whatever the row's own verdict
+  says: the stored ciphertext cannot be compared with the plaintext given.
   """
   def apply_manifest(user_id, resources, opts \\ [])
       when is_binary(user_id) and is_list(resources) do
@@ -76,24 +81,21 @@ defmodule Fountain.Manifest do
   defp apply_environment(user_id, %{"name" => name} = res, dek, opts) do
     with :ok <- validate_spec(res, Environments.Environment, ~w(secrets)) do
       {attrs, secrets} = split_spec(res, name)
+      existing = Environments.get_environment_by_name(name, user_id)
 
       outcome =
-        case Environments.get_environment_by_name(name, user_id) do
-          nil ->
-            {:created, Environments.create_environment(Map.put(attrs, "user_id", user_id), opts)}
-
-          env ->
-            {:updated, Environments.update_environment(env, attrs, opts)}
-        end
+        if existing,
+          do: Environments.update_environment(existing, attrs, opts),
+          else: Environments.create_environment(Map.put(attrs, "user_id", user_id), opts)
 
       case outcome do
-        {action, {:ok, env}} ->
+        {:ok, env} ->
           secret_results =
             upsert_secrets(secrets, &Environments.upsert_secret(env, &1, dek, secret_opts(opts)))
 
-          {result("Environment", name, action, nil, secret_results, env.id), env}
+          {result("Environment", name, verdict(existing, env), nil, secret_results, env.id), env}
 
-        {_action, {:error, changeset}} ->
+        {:error, changeset} ->
           {result("Environment", name, :error, changeset_errors(changeset), []), nil}
       end
     else
@@ -104,21 +106,21 @@ defmodule Fountain.Manifest do
   defp apply_vault(user_id, %{"name" => name} = res, dek, opts) do
     with :ok <- validate_spec(res, Vaults.Vault, ~w(secrets)) do
       {attrs, secrets} = split_spec(res, name)
+      existing = Vaults.get_vault_by_name(name, user_id)
 
       outcome =
-        case Vaults.get_vault_by_name(name, user_id) do
-          nil -> {:created, Vaults.create_vault(Map.put(attrs, "user_id", user_id), opts)}
-          vault -> {:updated, Vaults.update_vault(vault, attrs, opts)}
-        end
+        if existing,
+          do: Vaults.update_vault(existing, attrs, opts),
+          else: Vaults.create_vault(Map.put(attrs, "user_id", user_id), opts)
 
       case outcome do
-        {action, {:ok, vault}} ->
+        {:ok, vault} ->
           secret_results =
             upsert_secrets(secrets, &Vaults.upsert_secret(vault, &1, dek, secret_opts(opts)))
 
-          result("Vault", name, action, nil, secret_results, vault.id)
+          result("Vault", name, verdict(existing, vault), nil, secret_results, vault.id)
 
-        {_action, {:error, changeset}} ->
+        {:error, changeset} ->
           result("Vault", name, :error, changeset_errors(changeset), [])
       end
     else
@@ -135,20 +137,21 @@ defmodule Fountain.Manifest do
         {:ok, env_attrs} ->
           attrs = Map.merge(attrs, env_attrs)
 
+          existing = Agents.get_agent_by_name(name, user_id)
+
           outcome =
-            case Agents.get_agent_by_name(name, user_id) do
-              nil -> {:created, Agents.create_agent(Map.put(attrs, "user_id", user_id), opts)}
-              agent -> {:updated, Agents.update_agent(agent, attrs, opts)}
-            end
+            if existing,
+              do: Agents.update_agent(existing, attrs, opts),
+              else: Agents.create_agent(Map.put(attrs, "user_id", user_id), opts)
 
           case outcome do
-            {action, {:ok, _agent}} ->
-              result("Agent", name, action, nil, [])
+            {:ok, agent} ->
+              result("Agent", name, verdict(existing, agent), nil, [])
 
             # Moving the agent's environment rebuilds its machine, which a
             # running turn blocks (#1084). Reported against the field that
             # caused it so `fountain apply` says what to do about it.
-            {_action, {:error, :sandbox_mid_turn}} ->
+            {:error, :sandbox_mid_turn} ->
               errors = %{
                 "environment" => [
                   "the agent is running a turn on its own machine; changing its " <>
@@ -158,7 +161,7 @@ defmodule Fountain.Manifest do
 
               result("Agent", name, :error, errors, [])
 
-            {_action, {:error, cs}} ->
+            {:error, cs} ->
               result("Agent", name, :error, changeset_errors(cs), [])
           end
 
@@ -268,6 +271,18 @@ defmodule Fountain.Manifest do
   end
 
   defp split_spec(_res, name), do: {%{"name" => name}, %{}}
+
+  # The third verdict. A record the manifest did not move reads `unchanged`,
+  # so a second apply of the same file says plainly that it wrote nothing.
+  # Compared over the schema's own columns with the timestamps left out: an
+  # Ecto update with no changes moves neither.
+  defp verdict(nil, _updated), do: :created
+
+  defp verdict(%mod{} = before, %mod{} = updated) do
+    fields = mod.__schema__(:fields) -- [:inserted_at, :updated_at]
+
+    if Map.take(before, fields) == Map.take(updated, fields), do: :unchanged, else: :updated
+  end
 
   # `id` is the reconciled record's id when there is one. It is not serialized
   # in the API response; callers use it to attribute the secret writes this

--- a/apps/fountain/lib/fountain/vaults.ex
+++ b/apps/fountain/lib/fountain/vaults.ex
@@ -111,10 +111,15 @@ defmodule Fountain.Vaults do
   @doc "Update a vault. See `create_vault/2` for `opts`."
   def update_vault(%Vault{} = vault, attrs, opts \\ []) do
     changeset = Vault.changeset(vault, attrs)
+    result = Repo.update(changeset)
 
-    changeset
-    |> Repo.update()
-    |> audited("vault.updated", merge_metadata(opts, Audit.changed_fields(changeset)))
+    # See `Fountain.Environments.update_environment/3`: a save that moves
+    # nothing records nothing (#1680).
+    if changeset.changes == %{} do
+      result
+    else
+      audited(result, "vault.updated", merge_metadata(opts, Audit.changed_fields(changeset)))
+    end
   end
 
   @doc """

--- a/apps/fountain/lib/fountain/webhooks.ex
+++ b/apps/fountain/lib/fountain/webhooks.ex
@@ -122,11 +122,15 @@ defmodule Fountain.Webhooks do
 
       case Repo.update(changeset) do
         {:ok, updated} ->
-          audit(
-            updated,
-            "webhook_endpoint.updated",
-            merge_metadata(opts, Audit.changed_fields(changeset))
-          )
+          # A save that moves nothing records nothing, the same rule
+          # `Fountain.Environments.update_environment/3` follows (#1680).
+          if changeset.changes != %{} do
+            audit(
+              updated,
+              "webhook_endpoint.updated",
+              merge_metadata(opts, Audit.changed_fields(changeset))
+            )
+          end
 
           {:ok, updated}
 

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -3175,7 +3175,15 @@ defmodule FountainWeb.Schemas do
       properties: %{
         kind: %Schema{type: :string},
         name: %Schema{type: :string},
-        action: %Schema{type: :string, enum: ["created", "updated", "error"]},
+        action: %Schema{
+          type: :string,
+          enum: ["created", "updated", "unchanged", "error"],
+          description:
+            "`unchanged` means the record already matched the document, so nothing " <>
+              "was written to it and no audit event was recorded. Inline " <>
+              "`spec.secrets` are re-encrypted on every apply and still report " <>
+              "`upserted` under `secrets`."
+        },
         errors: %Schema{type: :object, additionalProperties: true, nullable: true},
         secrets: %Schema{type: :array, items: ApplySecretResult}
       },

--- a/apps/fountain/priv/help/manifest.md
+++ b/apps/fountain/priv/help/manifest.md
@@ -71,14 +71,14 @@ fountain apply -f ./fountain-specs/     # directory: walks **/*.{yml,yaml}
 
 Directory mode walks recursively. Any YAML document carrying both `apiVersion` and `kind` is treated as a resource; anything else (a doc without front-matter, an unrelated `.yaml` config) is silently ignored. So `fountain-specs/agents/*.yml`, `fountain-specs/environments/*.yml`, plus an unrelated `.github/workflows/ci.yml` in the same tree all coexist cleanly. Files are processed in alphabetical order; if you want strict ordering for any reason, prefix names like `10-envs.yml` / `20-agents.yml` (though reconciliation order is fixed internally — envs first, then vaults, then agents — regardless).
 
-Output uses `+` for create, `~` for update, one line per resource:
+Output uses `+` for create, `~` for update, `=` for a resource that already matched, one line per resource:
 
 ```
 env    +  my-project
 vault  +  alice
   secret  ~  alice/GITHUB_TOKEN
   secret  ~  alice/NPM_TOKEN
-agent  ~  researcher
+agent  =  researcher
 ```
 
 Errors per-resource go to stderr but don't stop the run; other resources still apply.
@@ -87,7 +87,7 @@ Under the hood the CLI compiles the whole manifest into one document and sends i
 
 ## Idempotency
 
-Re-applying the same file is a no-op (every resource shows `~` because existing resources are always re-written, but the spec doesn't change). Useful for CI: keep `fountain.yml` in source control, run `fountain apply -f fountain.yml` from your deploy pipeline.
+Re-applying the same file is a no-op, and says so: every resource shows `=` (`unchanged`) because nothing was written to it. Inline `spec.secrets` are the exception — they are re-encrypted on every apply, so they keep showing `~` under a resource that shows `=`. Useful for CI: keep `fountain.yml` in source control, run `fountain apply -f fountain.yml` from your deploy pipeline.
 
 ## Apply-time secret resolution (so you can commit `fountain.yml`)
 

--- a/apps/fountain/test/fountain/manifest_test.exs
+++ b/apps/fountain/test/fountain/manifest_test.exs
@@ -1,7 +1,7 @@
 defmodule Fountain.ManifestTest do
   use Fountain.DataCase, async: true
 
-  alias Fountain.{Agents, Crypto, Environments, Manifest, Vaults}
+  alias Fountain.{Agents, Audit, Crypto, Environments, Manifest, Vaults}
 
   setup do
     # No starter agent (ADR 0038): every assertion here counts what the
@@ -158,7 +158,7 @@ defmodule Fountain.ManifestTest do
   end
 
   describe "apply_manifest/2 updates" do
-    test "re-applying the same manifest is an idempotent update", %{user: user} do
+    test "re-applying the same manifest writes nothing and says so", %{user: user} do
       resources = [
         env_resource("proj", %{"secrets" => %{"TOKEN" => "t0"}}),
         agent_resource("researcher", %{"environment" => "proj"})
@@ -167,14 +167,44 @@ defmodule Fountain.ManifestTest do
       {:ok, _} = Manifest.apply_manifest(user.id, resources)
       {:ok, results} = Manifest.apply_manifest(user.id, resources)
 
+      # The secret is re-encrypted on every apply, so it keeps reporting
+      # `upserted` while the row it belongs to reports `unchanged`.
       assert [
-               %{kind: "Environment", action: :updated, secrets: [%{action: :upserted}]},
-               %{kind: "Agent", action: :updated}
+               %{kind: "Environment", action: :unchanged, secrets: [%{action: :upserted}]},
+               %{kind: "Agent", action: :unchanged}
              ] = results
 
       assert length(Environments.list_environments(user.id)) == 1
       assert length(Agents.list_agents(user.id, [])) == 1
     end
+
+    test "a changed spec still reports updated", %{user: user} do
+      {:ok, _} = Manifest.apply_manifest(user.id, [env_resource("proj")])
+
+      {:ok, [%{kind: "Environment", action: :updated}]} =
+        Manifest.apply_manifest(user.id, [env_resource("proj", %{"setup_script" => "echo hi"})])
+
+      assert Environments.get_environment_by_name("proj", user.id).setup_script == "echo hi"
+    end
+
+    # CLAUDE.md: "Only record what happened. ... a no-op sync records nothing."
+    # An apply that writes nothing must leave the trail exactly as it found it,
+    # or every CI run adds a row per resource saying a record nobody touched
+    # was updated.
+    test "an identical re-apply writes no audit rows at all", %{user: user} do
+      resources = [env_resource("proj"), agent_resource("researcher", %{"environment" => "proj"})]
+
+      {:ok, first} = Manifest.apply_manifest(user.id, resources)
+      assert Enum.all?(first, &(&1.action == :created))
+      before = actions_for(user)
+
+      {:ok, second} = Manifest.apply_manifest(user.id, resources)
+      assert Enum.all?(second, &(&1.action == :unchanged))
+      assert actions_for(user) == before
+    end
+
+    defp actions_for(user),
+      do: user.id |> Audit.list_recent_for_user(500) |> Enum.map(& &1.action)
 
     test "agent can reference a pre-existing environment not in the manifest", %{user: user} do
       env = insert_env(user_id: user.id, name: "existing-env")

--- a/apps/fountain/test/fountain_web/controllers/apply_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/apply_controller_test.exs
@@ -176,7 +176,10 @@ defmodule FountainWeb.ApplyControllerTest do
       refute conn.resp_body =~ "sekrit-value"
     end
 
-    test "re-apply reports updated actions", %{conn: conn, raw_key: raw_key} do
+    test "re-apply reports unchanged, and a changed spec reports updated", %{
+      conn: conn,
+      raw_key: raw_key
+    } do
       payload = %{
         "resources" => [%{"kind" => "Vault", "name" => "v", "spec" => %{}}]
       }
@@ -186,8 +189,17 @@ defmodule FountainWeb.ApplyControllerTest do
       assert %{"data" => %{"results" => [%{"action" => "created"}]}} =
                conn |> auth.() |> post_json(~p"/api/apply", payload) |> json_response(200)
 
-      assert %{"data" => %{"results" => [%{"action" => "updated"}]}} =
+      assert %{"data" => %{"results" => [%{"action" => "unchanged"}]}} =
                build_conn() |> auth.() |> post_json(~p"/api/apply", payload) |> json_response(200)
+
+      moved = %{
+        "resources" => [
+          %{"kind" => "Vault", "name" => "v", "spec" => %{"description" => "moved"}}
+        ]
+      }
+
+      assert %{"data" => %{"results" => [%{"action" => "updated"}]}} =
+               build_conn() |> auth.() |> post_json(~p"/api/apply", moved) |> json_response(200)
     end
 
     test "returns 200 with per-resource errors on partial failure", %{

--- a/cli/internal/cmd/apply.go
+++ b/cli/internal/cmd/apply.go
@@ -135,8 +135,8 @@ var applyKindLabels = map[string]string{
 }
 
 // renderApplyResults prints one line per resource in the same format the
-// per-resource loop used (`+` create, `~` update, `!` error to stderr) and
-// reports whether any resource or secret failed.
+// per-resource loop used (`+` create, `~` update, `=` no change, `!` error to
+// stderr) and reports whether any resource or secret failed.
 func renderApplyResults(results []applyResult) (anyFailed bool) {
 	for _, r := range results {
 		label := applyKindLabels[r.Kind]
@@ -148,6 +148,8 @@ func renderApplyResults(results []applyResult) (anyFailed bool) {
 			fmt.Printf("%s  +  %s\n", label, r.Name)
 		case "updated":
 			fmt.Printf("%s  ~  %s\n", label, r.Name)
+		case "unchanged":
+			fmt.Printf("%s  =  %s\n", label, r.Name)
 		default:
 			anyFailed = true
 			warnf("%s  !  %s: %s", label, r.Name, formatResultErrors(r.Errors))

--- a/cli/internal/cmd/apply_test.go
+++ b/cli/internal/cmd/apply_test.go
@@ -75,6 +75,7 @@ func TestRenderApplyResultsFailureDetection(t *testing.T) {
 		{"all ok", []applyResult{
 			{Kind: "Environment", Name: "e", Action: "created"},
 			{Kind: "Agent", Name: "a", Action: "updated"},
+			{Kind: "Vault", Name: "v", Action: "unchanged"},
 		}, false},
 		{"resource error", []applyResult{
 			{Kind: "Agent", Name: "a", Action: "error", Errors: map[string]any{"model": []any{"can't be blank"}}},

--- a/docs/api.md
+++ b/docs/api.md
@@ -155,8 +155,14 @@ which connection choices the UI can offer.
 
 Use `fountain apply` when a checked-in manifest should define several related
 resources. The CLI compiles the manifest and submits the resource graph.
-Inspect every resource result: one failed resource does not mean that all
+Inspect every resource result. One failed resource does not mean that all
 other writes failed.
+
+Each result row reports `created`, `updated`, `unchanged` or `error`. A
+second apply of an unchanged manifest reports `unchanged` for every row, and
+writes no audit event for those rows. Inline `spec.secrets` are encrypted
+again on each apply, so they keep reporting `upserted` under a row that
+reports `unchanged`.
 
 See [CLI](cli.md) for the workflow and the Apply operation in the
 [generated reference](/api/docs) for its wire format. Unknown configuration

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -330,6 +330,12 @@ The server reconciles the environments, then the vaults, then the agents. It
 resolves an agent's `environment:` name reference, and that includes an
 environment that already exists on the server.
 
+The CLI prints `+` for a create, `~` for an update, `=` for a resource that
+already matched the manifest, and `!` for a failure. A second apply of the
+same file prints `=` on every row, because Fountain wrote to none of them.
+Inline `spec.secrets` are the exception. Fountain encrypts them again on each
+apply, so they keep printing `~` under a row that prints `=`.
+
 The server rejects unknown `spec` keys per resource. The CLI prints those
 errors and exits nonzero; valid resources in the same manifest still apply.
 Correct a misspelled field before you retry.

--- a/sdk/contract/contract.json
+++ b/sdk/contract/contract.json
@@ -8380,6 +8380,7 @@
           "enum": [
             "created",
             "error",
+            "unchanged",
             "updated"
           ],
           "required": true,

--- a/sdk/swift/Sources/FountainKit/Models/Account.swift
+++ b/sdk/swift/Sources/FountainKit/Models/Account.swift
@@ -134,7 +134,8 @@ public struct Catalog: Sendable, Decodable {
 public struct ApplyResult: Sendable, Decodable, Hashable {
   public var kind: String
   public var name: String
-  /// `created | updated | error`.
+  /// `created | updated | unchanged | error`. `unchanged` means the record
+  /// already matched the document, so nothing was written to it.
   public var action: String
   public var errors: JSONValue?
   public var secrets: [SecretResult]?

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -2799,8 +2799,11 @@ export interface components {
         };
         /** ApplyResult */
         ApplyResult: {
-            /** @enum {string} */
-            action: "created" | "updated" | "error";
+            /**
+             * @description `unchanged` means the record already matched the document, so nothing was written to it and no audit event was recorded. Inline `spec.secrets` are re-encrypted on every apply and still report `upserted` under `secrets`.
+             * @enum {string}
+             */
+            action: "created" | "updated" | "unchanged" | "error";
             errors?: {
                 [key: string]: unknown;
             } | null;


### PR DESCRIPTION
`Repo.update` on an empty changeset skips the SQL, but `Environments`,
`Vaults`, `Agents` and `Webhooks` audited the `{:ok, _}` either way. An
idempotent re-apply of a manifest therefore wrote one `*.updated` row per
resource, each naming an empty changed-field list, about a record nobody had
touched. That is what CLAUDE.md's "only record what happened" forbids. The
four contexts now gate the recording on a non-empty changeset, the way
`Fountain.Team.Schedules.update_schedule/3` already did.

The same re-apply also *reported* an update it had not made. `Manifest` now
compares the record before and after over the schema's own columns (timestamps
left out) and reports a third verdict, `unchanged`, so a second apply of the
same file says plainly that it wrote nothing. Inline `spec.secrets` are the
exception and keep reporting `upserted`: the stored ciphertext cannot be
compared with the plaintext given, so they are re-encrypted on every apply.

`fountain apply` prints `=` for such a row, next to `+` and `~`.

This is the first of eight PRs that together land #1636 (one manifest
reconciles a whole estate). #1675 is the combined branch and stays open as the
reference until the stack is in.

Closes #1680

Validation:

- `mix test` over the touched suites, `mix precommit` clean.
- `go test ./...` in `cli/`.
- The contract and TypeScript types are regenerated; the SDK version bump for
  the whole stack lands in the last PR, so no publish happens here.

---

**The stack** (each PR is based on the one above it; review and merge top down):

1. `stack/1680-unchanged-verdict` — a save that changes nothing records nothing (#1680) ← **this one**
2. `stack/1636-apply-isolation` — a raise in one apply document fails that row
3. `stack/1636-cotenant-identity` — a co-tenant follows a replacement only if it declared the same identity
4. `stack/1636-update-teammate` — Team.update_teammate/4
5. `stack/1636-cli-group-by-kind` — CLI: group apply documents by kind
6. `stack/1636-teammate-kind` — apply reconciles Teammate documents
7. `stack/1636-schedule-kind` — apply reconciles Schedule documents
8. `stack/1636-webhook-kind` — apply reconciles Webhook documents (#1636)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WQyc3wWWDAeZJE1Vr6etQa