### PR TITLE
fix(api): a raise in one apply document fails that row, not the request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ upgrade, is in
 
 ### Fixed
 
+- A resource in a `fountain apply` manifest that raises unexpectedly now fails
+  its own result row instead of the whole request. Before, the exception
+  abandoned a call that had already written the resources above it, so the
+  caller got a 500 and no result rows for writes that had landed (#1636).
+
 - Updating an environment, vault, agent or webhook endpoint with the values it
   already holds no longer records an `*.updated` audit event naming no changed
   fields, and `fountain apply` reports those rows as `unchanged` rather than

--- a/apps/fountain/lib/fountain/manifest.ex
+++ b/apps/fountain/lib/fountain/manifest.ex
@@ -10,12 +10,16 @@ defmodule Fountain.Manifest do
   references resolve against environments in this manifest first, then
   against the tenant's existing environments.
 
-  Application is best-effort per resource, mirroring the CLI's previous
-  one-call-per-resource behavior: a resource that fails validation is
-  reported in its result entry and does not stop the rest of the manifest.
+  Application is best-effort per resource: a document that fails validation,
+  that a context refuses, or that raises is reported in its own result entry
+  and does not stop the rest of the manifest.
   """
 
+  require Logger
+
   alias Fountain.{Agents, Crypto, Environments, Vaults}
+
+  @unexpected "apply failed unexpectedly; see the server log"
 
   @kinds ~w(Environment Vault Agent)
 
@@ -51,21 +55,64 @@ defmodule Fountain.Manifest do
 
     dek = if Enum.any?(envs ++ vaults, &has_secrets?/1), do: load_dek!(user_id)
 
-    {env_results, env_id_by_name} =
-      Enum.map_reduce(envs, %{}, fn res, acc ->
-        case apply_environment(user_id, res, dek, opts) do
-          {result, nil} -> {result, acc}
-          {result, env} -> {result, Map.put(acc, env.name, env.id)}
-        end
-      end)
+    {env_results, env_ids} =
+      reconcile("Environment", envs, fn res -> apply_environment(user_id, res, dek, opts) end)
+
+    {vault_results, _} =
+      reconcile("Vault", vaults, fn res -> apply_vault(user_id, res, dek, opts) end)
+
+    {agent_results, _} =
+      reconcile("Agent", agents, fn res -> apply_agent(user_id, res, env_ids, opts) end)
 
     results =
       env_results ++
-        Enum.map(vaults, &apply_vault(user_id, &1, dek, opts)) ++
-        Enum.map(agents, &apply_agent(user_id, &1, env_id_by_name, opts)) ++
+        vault_results ++
+        agent_results ++
         Enum.map(invalid, &invalid_result/1)
 
     {:ok, results}
+  end
+
+  # One pass over one kind. Every `apply_*` returns `{result, id}`, so the
+  # pass leaves behind the name -> id map the next pass resolves references
+  # against.
+  defp reconcile(kind, resources, fun) do
+    Enum.map_reduce(resources, %{}, fn res, acc ->
+      case guarded(kind, res["name"], fn -> fun.(res) end) do
+        {result, nil} -> {result, acc}
+        {result, id} -> {result, Map.put(acc, res["name"], id)}
+      end
+    end)
+  end
+
+  # Best-effort per resource means per resource. A raise or an exit in one
+  # document's reconcile would abandon a call that has already committed the
+  # documents above it, leaving the caller a 500 and no rows at all, against a
+  # moduledoc promising best effort per resource. Reported as this document's
+  # error instead, and logged, because a crash in a context is still a defect
+  # worth a stacktrace.
+  #
+  # The row says only that the pass failed. The exception text goes to the log
+  # above and no further: this module promises that secret values are never
+  # echoed back, and the environment and vault passes hold plaintext inside
+  # this rescue, where Elixir's own MatchError, CaseClauseError, BadMapError
+  # and ArgumentError messages embed the value they choked on. A caller who
+  # needs the detail has an operator who can read the log.
+  defp guarded(kind, name, fun) do
+    fun.()
+  rescue
+    error ->
+      Logger.error(
+        "apply: #{kind} #{inspect(name)} raised: " <>
+          Exception.format(:error, error, __STACKTRACE__)
+      )
+
+      {result(kind, str(name), :error, %{"base" => [@unexpected]}, []), nil}
+  catch
+    thrown, reason ->
+      Logger.error("apply: #{kind} #{inspect(name)} #{thrown}: #{inspect(reason)}")
+
+      {result(kind, str(name), :error, %{"base" => [@unexpected]}, []), nil}
   end
 
   # Keeps the `via: apply` marker the ApplyController used to attach when it
@@ -93,7 +140,8 @@ defmodule Fountain.Manifest do
           secret_results =
             upsert_secrets(secrets, &Environments.upsert_secret(env, &1, dek, secret_opts(opts)))
 
-          {result("Environment", name, verdict(existing, env), nil, secret_results, env.id), env}
+          {result("Environment", name, verdict(existing, env), nil, secret_results, env.id),
+           env.id}
 
         {:error, changeset} ->
           {result("Environment", name, :error, changeset_errors(changeset), []), nil}
@@ -118,13 +166,14 @@ defmodule Fountain.Manifest do
           secret_results =
             upsert_secrets(secrets, &Vaults.upsert_secret(vault, &1, dek, secret_opts(opts)))
 
-          result("Vault", name, verdict(existing, vault), nil, secret_results, vault.id)
+          {result("Vault", name, verdict(existing, vault), nil, secret_results, vault.id),
+           vault.id}
 
         {:error, changeset} ->
-          result("Vault", name, :error, changeset_errors(changeset), [])
+          {result("Vault", name, :error, changeset_errors(changeset), []), nil}
       end
     else
-      {:error, errors} -> result("Vault", name, :error, errors, [])
+      {:error, errors} -> {result("Vault", name, :error, errors, []), nil}
     end
   end
 
@@ -146,7 +195,7 @@ defmodule Fountain.Manifest do
 
           case outcome do
             {:ok, agent} ->
-              result("Agent", name, verdict(existing, agent), nil, [])
+              {result("Agent", name, verdict(existing, agent), nil, [], agent.id), agent.id}
 
             # Moving the agent's environment rebuilds its machine, which a
             # running turn blocks (#1084). Reported against the field that
@@ -159,18 +208,18 @@ defmodule Fountain.Manifest do
                 ]
               }
 
-              result("Agent", name, :error, errors, [])
+              {result("Agent", name, :error, errors, []), nil}
 
             {:error, cs} ->
-              result("Agent", name, :error, changeset_errors(cs), [])
+              {result("Agent", name, :error, changeset_errors(cs), []), nil}
           end
 
         {:error, ref} ->
           errors = %{"environment" => ["environment not found: #{ref}"]}
-          result("Agent", name, :error, errors, [])
+          {result("Agent", name, :error, errors, []), nil}
       end
     else
-      {:error, errors} -> result("Agent", name, :error, errors, [])
+      {:error, errors} -> {result("Agent", name, :error, errors, []), nil}
     end
   end
 

--- a/apps/fountain/test/fountain/manifest_test.exs
+++ b/apps/fountain/test/fountain/manifest_test.exs
@@ -1,5 +1,6 @@
 defmodule Fountain.ManifestTest do
   use Fountain.DataCase, async: true
+  use Mimic
 
   alias Fountain.{Agents, Audit, Crypto, Environments, Manifest, Vaults}
 
@@ -201,6 +202,50 @@ defmodule Fountain.ManifestTest do
       {:ok, second} = Manifest.apply_manifest(user.id, resources)
       assert Enum.all?(second, &(&1.action == :unchanged))
       assert actions_for(user) == before
+    end
+
+    # Best-effort per resource means per resource. Before this, a raise in one
+    # document abandoned a call that had already committed the documents above
+    # it, so the caller got a 500 and no rows at all — for writes that had
+    # already landed.
+    test "an exception in one document fails that row and not the request", %{user: user} do
+      env = insert_env(user_id: user.id, name: "proj")
+      insert_agent(user_id: user.id, name: "moves")
+
+      # Moving an agent's environment asks whether the machine it would orphan
+      # is mid-turn. That is the reach outside the changeset on this path.
+      stub(Fountain.Conversations, :_unsafe_homes_orphaned_by_environment, fn _a, _e ->
+        raise "the sandbox provider fell over"
+      end)
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert {:ok, results} =
+                   Manifest.apply_manifest(user.id, [
+                     env_resource("proj"),
+                     agent_resource("moves", %{"environment" => "proj"}),
+                     agent_resource("fine", %{"environment" => "proj"})
+                   ])
+
+          assert [
+                   %{kind: "Environment", action: :unchanged},
+                   %{name: "moves", action: :error, errors: errors},
+                   %{name: "fine", action: :created}
+                 ] = results
+
+          # The row says the pass failed and nothing more. The raised text stays
+          # in the log: the environment and vault passes hold plaintext secrets
+          # inside the same rescue, and an Elixir exception message embeds the
+          # value it choked on.
+          assert errors == %{"base" => ["apply failed unexpectedly; see the server log"]}
+          refute inspect(errors) =~ "sandbox provider fell over"
+        end)
+
+      assert log =~ "sandbox provider fell over"
+
+      # The documents above the failure stayed, and the ones below still applied.
+      assert Environments.get_environment_by_name("proj", user.id).id == env.id
+      assert Agents.get_agent_by_name("fine", user.id).environment_id == env.id
     end
 
     defp actions_for(user),


### PR DESCRIPTION
`Fountain.Manifest` promises best effort per resource, and it delivered that
for a changeset that failed validation and nothing else. A raise or an exit
inside one document's reconcile abandoned a call that had already committed
the environments, vaults and agents above it, so the caller got a 500 and no
result rows at all, for writes that had already landed.

Each document's reconcile is now wrapped. A raise or an exit becomes that
document's `:error` row and the rest of the manifest still applies. The
stacktrace goes to the log, because a crash in a context is still a defect
worth reading.

The row itself says only that the pass failed. The exception text stops at
the log: this module promises that secret values are never echoed back, and
the environment and vault passes hold plaintext inside that rescue, where
Elixir's own `MatchError`, `CaseClauseError`, `BadMapError` and
`ArgumentError` messages embed the value they choked on.

The three per-kind passes now share one `reconcile/3`, which is what carries
the name-to-id map the later passes resolve references against. Environments
already worked this way; vaults and agents join them, and the map is what the
Teammate and Schedule kinds later in this stack need.

Second of eight PRs toward #1636. #1675 is the combined branch and stays open
as the reference until the stack is in.

Validation: `mix precommit`, `go test ./...` in `cli/`.

---

**The stack** (each PR is based on the one above it; review and merge top down):

1. `stack/1680-unchanged-verdict` — a save that changes nothing records nothing (#1680)
2. `stack/1636-apply-isolation` — a raise in one apply document fails that row ← **this one**
3. `stack/1636-cotenant-identity` — a co-tenant follows a replacement only if it declared the same identity
4. `stack/1636-update-teammate` — Team.update_teammate/4
5. `stack/1636-cli-group-by-kind` — CLI: group apply documents by kind
6. `stack/1636-teammate-kind` — apply reconciles Teammate documents
7. `stack/1636-schedule-kind` — apply reconciles Schedule documents
8. `stack/1636-webhook-kind` — apply reconciles Webhook documents (#1636)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WQyc3wWWDAeZJE1Vr6etQa