### PR TITLE
fix(conversations): a co-tenant follows a replacement only if it declared the same identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,14 @@ upgrade, is in
 
 ### Fixed
 
+- A conversation that shares a sandbox follows the replacement machine only
+  when it declares the same environment and vault. The replacement is built
+  from the waking conversation's pair, so a co-tenant that named a different
+  one was run on another conversation's environment files and vault material,
+  and which pair won depended on which conversation woke first. One that names
+  something else now keeps its own pair and builds a machine from it on its
+  next prompt (#1636).
+
 - A resource in a `fountain apply` manifest that raises unexpectedly now fails
   its own result row instead of the whole request. Before, the exception
   abandoned a call that had already written the resources above it, so the

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -1393,6 +1393,35 @@ defmodule Fountain.Conversations do
   end
 
   @doc """
+  `_unsafe_list_cotenant_ids/2`, with the identity each co-tenant declares:
+  `{id, environment_id, vault_id}`, where the environment is the *effective*
+  one a machine would be built from — the conversation's own override, and
+  the agent's environment when it has none. That is the pair a sandbox row
+  carries and `_unsafe_find_home/4` looks a home up by.
+
+  Co-tenants normally share one identity, because attaching to a machine
+  requires the same agent, environment and vault. They can diverge afterwards:
+  rebinding a teammate moves one conversation's environment or vault while its
+  co-tenants keep theirs. A lifecycle decision taken for the whole machine has
+  to read this rather than assume, or a replacement built for one identity is
+  handed to a conversation that declared another.
+  """
+  def _unsafe_list_cotenants_with_identity(sandbox_id, conv_id)
+      when is_binary(sandbox_id) and is_binary(conv_id) do
+    Repo.all(
+      from c in Conversation,
+        # Fully qualified: `alias Fountain.Agents` is declared further down
+        # this module, so it is not in scope here.
+        left_join: a in Fountain.Agents.Agent,
+        on: a.id == c.agent_id,
+        where:
+          c.sandbox_id == ^sandbox_id and c.id != ^conv_id and
+            c.status not in ["terminated", "failed"],
+        select: {c.id, coalesce(c.environment_id, a.environment_id), c.vault_id}
+    )
+  end
+
+  @doc """
   Whether any *other* conversation on `sandbox_id` is mid-turn, or was active
   within the last `idle_seconds`.
 
@@ -3827,7 +3856,7 @@ defmodule Fountain.Conversations do
 
           # The machine was gone for everyone on it, not just the conversation
           # that noticed (ADR 0023 gate 5).
-          move_cotenants(old_sandbox_id, new_sandbox.id, conv.id)
+          move_cotenants(old_sandbox_id, new_sandbox, conv.id)
 
           {:ok, _unsafe_get_conversation!(conv.id)}
 
@@ -3877,48 +3906,104 @@ defmodule Fountain.Conversations do
   # time this runs the waking conversation itself already names the new one,
   # so it is not among the co-tenants.
   #
-  # A co-tenant whose server is somehow alive holds a handle to the dead
-  # sprite; it is told the machine is gone, cuts any turn, and stops, so its
-  # next prompt takes the wake path onto the new row. `runtime_session_id` is
-  # cleared for each: a fresh disk has no session to resume (#778).
-  defp move_cotenants(nil, _new_sandbox_id, _conv_id), do: :ok
+  # It follows only if it declared the same identity. The replacement was
+  # built from the *waking* conversation's environment and vault, so handing
+  # it to a co-tenant that names a different pair would run that conversation
+  # on another binding's environment files and vault material, and would make
+  # the machine depend on which conversation happened to wake first
+  # (#1636). One that declared something else keeps pointing at the retired
+  # row instead, which its own next wake reads as `:create_new` and builds
+  # from its own identity.
+  #
+  # Either way the disk is gone for all of them, so all of them are told. A
+  # co-tenant whose server is somehow alive holds a handle to the dead sprite;
+  # it is told the machine is gone, cuts any turn, and stops, so its next
+  # prompt takes the wake path. `runtime_session_id` is cleared for each: a
+  # fresh disk has no session to resume (#778).
+  defp move_cotenants(nil, _new_sandbox, _conv_id), do: :ok
 
-  defp move_cotenants(old_sandbox_id, new_sandbox_id, conv_id)
-       when is_binary(old_sandbox_id) and is_binary(new_sandbox_id) do
-    case _unsafe_list_cotenant_ids(old_sandbox_id, conv_id) do
+  defp move_cotenants(old_sandbox_id, %Sandbox{} = new_sandbox, conv_id)
+       when is_binary(old_sandbox_id) do
+    case _unsafe_list_cotenants_with_identity(old_sandbox_id, conv_id) do
       [] ->
         :ok
 
-      ids ->
-        message =
-          "The sandbox this conversation was on is gone; it moved to a fresh one together " <>
-            "with the conversations that shared it. The transcript is kept, but the agent " <>
-            "starts a new session and will not remember the earlier turns."
+      cotenants ->
+        identity = {new_sandbox.environment_id, new_sandbox.vault_id}
 
-        Enum.each(ids, fn id ->
-          case ConversationServer.whereis(id) do
-            nil -> :ok
-            pid -> GenServer.cast(pid, {:machine_gone, "replaced", "sprite_gone", message})
-          end
-        end)
+        {following, on_their_own} =
+          Enum.split_with(cotenants, fn {_id, env_id, vault_id} ->
+            {env_id, vault_id} == identity
+          end)
 
-        now = DateTime.utc_now() |> DateTime.truncate(:second)
-
-        Repo.update_all(from(c in Conversation, where: c.id in ^ids),
-          set: [sandbox_id: new_sandbox_id, runtime_session_id: nil, updated_at: now]
-        )
-
-        Enum.each(ids, fn id ->
-          publish_stage(id, "sandbox", "done", %{
-            event: "replaced",
-            reason: "sprite_gone",
-            sandbox_id: new_sandbox_id,
-            message: message
-          })
-        end)
-
+        follow_cotenants(Enum.map(following, &elem(&1, 0)), new_sandbox.id)
+        strand_cotenants(Enum.map(on_their_own, &elem(&1, 0)))
         :ok
     end
+  end
+
+  defp follow_cotenants([], _new_sandbox_id), do: :ok
+
+  defp follow_cotenants(ids, new_sandbox_id) do
+    message =
+      "The sandbox this conversation was on is gone; it moved to a fresh one together " <>
+        "with the conversations that shared it. The transcript is kept, but the agent " <>
+        "starts a new session and will not remember the earlier turns."
+
+    tell_cotenants(ids, "replaced", message)
+
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    Repo.update_all(from(c in Conversation, where: c.id in ^ids),
+      set: [sandbox_id: new_sandbox_id, runtime_session_id: nil, updated_at: now]
+    )
+
+    Enum.each(ids, fn id ->
+      publish_stage(id, "sandbox", "done", %{
+        event: "replaced",
+        reason: "sprite_gone",
+        sandbox_id: new_sandbox_id,
+        message: message
+      })
+    end)
+  end
+
+  defp strand_cotenants([]), do: :ok
+
+  defp strand_cotenants(ids) do
+    message =
+      "The sandbox this conversation was on is gone. It named a different environment " <>
+        "or vault from the conversation that replaced the machine, so it did not follow " <>
+        "onto that one; its next prompt builds a machine from what it declares. The " <>
+        "transcript is kept, and the agent starts a new session."
+
+    tell_cotenants(ids, "reset", message)
+
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    # `sandbox_id` is left naming the retired row on purpose: `wake_conversation/2`
+    # reads a terminated row as `:create_new` and provisions from this
+    # conversation's own environment and vault.
+    Repo.update_all(from(c in Conversation, where: c.id in ^ids),
+      set: [runtime_session_id: nil, updated_at: now]
+    )
+
+    Enum.each(ids, fn id ->
+      publish_stage(id, "sandbox", "done", %{
+        event: "reset",
+        reason: "sprite_gone",
+        message: message
+      })
+    end)
+  end
+
+  defp tell_cotenants(ids, event, message) do
+    Enum.each(ids, fn id ->
+      case ConversationServer.whereis(id) do
+        nil -> :ok
+        pid -> GenServer.cast(pid, {:machine_gone, event, "sprite_gone", message})
+      end
+    end)
   end
 
   defp mark_old_sandbox_terminated(nil), do: :ok

--- a/apps/fountain/test/fountain/conversations/sandbox_reset_test.exs
+++ b/apps/fountain/test/fountain/conversations/sandbox_reset_test.exs
@@ -141,6 +141,64 @@ defmodule Fountain.Conversations.SandboxResetTest do
     assert Conversations._unsafe_get_conversation!(ctx.b.id).sandbox_id == woken.sandbox_id
   end
 
+  # #1636: co-tenants normally share one identity, because attaching to a
+  # machine requires the same agent, environment and vault. Rebinding a
+  # teammate moves one conversation's environment while its co-tenants keep
+  # theirs, and the replacement a wake builds carries only the waking
+  # conversation's pair. Handing it to the other one would run it on another
+  # binding's environment files and vault material, and would make the machine
+  # depend on which conversation happened to wake first.
+  describe "a co-tenant that declares a different identity" do
+    setup ctx do
+      other_env = insert_env(user_id: ctx.user.id)
+      {:ok, b} = Conversations.update_conversation(ctx.b, %{environment_id: other_env.id})
+      stub(Managoat.Sandbox.Sprites, :destroy, fn _h -> :ok end)
+      {:ok, _} = Conversations.reset_sandbox(ctx.home)
+      Map.merge(ctx, %{other_env: other_env, b: b})
+    end
+
+    test "waking the one that kept the identity leaves the rebound one behind", ctx do
+      assert {:ok, woken_a} = Conversations.wake_conversation(ctx.a.id)
+      refute woken_a.sandbox_id == ctx.home.id
+      assert Conversations._unsafe_get_sandbox!(woken_a.sandbox_id).environment_id == ctx.env.id
+
+      # It did not follow: it names something else, so it keeps the retired
+      # row until its own wake.
+      assert Conversations._unsafe_get_conversation!(ctx.b.id).sandbox_id == ctx.home.id
+
+      assert {:ok, woken_b} = Conversations.wake_conversation(ctx.b.id)
+      refute woken_b.sandbox_id == woken_a.sandbox_id
+
+      assert Conversations._unsafe_get_sandbox!(woken_b.sandbox_id).environment_id ==
+               ctx.other_env.id
+    end
+
+    test "waking the rebound one first does not pull the other onto its machine", ctx do
+      assert {:ok, woken_b} = Conversations.wake_conversation(ctx.b.id)
+
+      assert Conversations._unsafe_get_sandbox!(woken_b.sandbox_id).environment_id ==
+               ctx.other_env.id
+
+      assert Conversations._unsafe_get_conversation!(ctx.a.id).sandbox_id == ctx.home.id
+
+      assert {:ok, woken_a} = Conversations.wake_conversation(ctx.a.id)
+      refute woken_a.sandbox_id == woken_b.sandbox_id
+      assert Conversations._unsafe_get_sandbox!(woken_a.sandbox_id).environment_id == ctx.env.id
+    end
+
+    test "the one left behind is told its machine is gone", ctx do
+      assert {:ok, _} = Conversations.wake_conversation(ctx.a.id)
+
+      messages =
+        ctx.b.id
+        |> Conversations._unsafe_list_log_events(0)
+        |> Enum.filter(&(&1.kind == "stage" and &1.stage == "sandbox"))
+        |> Enum.map(&Jason.decode!(&1.data)["message"])
+
+      assert Enum.any?(messages, &(&1 =~ "different environment"))
+    end
+  end
+
   test "records sandbox.reset with the actor", ctx do
     stub(Managoat.Sandbox.Sprites, :destroy, fn _h -> :ok end)
     {:ok, _} = Conversations.reset_sandbox(ctx.home, actor: "api", request_ip: "10.0.0.1")


### PR DESCRIPTION
When a sandbox is gone and a conversation wakes onto a replacement,
`move_cotenants/3` repointed every live conversation that shared the old
machine at the new one. It did that without looking at what those
conversations declared. The replacement was built from the *waking*
conversation's environment and vault, so a co-tenant that named a different
pair ended up running on another conversation's environment files and vault
material, while its own row said something else. Which binding won depended
on which conversation happened to wake first.

Co-tenants normally share one identity, because attaching to a machine
requires the same agent, environment and vault. They can diverge afterwards,
and the next PR in this stack is what makes them diverge: rebinding a teammate
moves one conversation's environment or vault and leaves its co-tenants
where they were. This is the invariant that rebinding needs, landed on its
own so the change to the wake path can be read by itself.

`_unsafe_list_cotenants_with_identity/2` reads each co-tenant's *effective*
pair — the conversation's own override, falling back to its agent's
environment — which is what a sandbox row carries and what
`_unsafe_find_home/4` keys on. Only the co-tenants that match the replacement
follow onto it. One that declared something else keeps pointing at the retired
row, which its own next wake reads as `:create_new` and builds from its own
pair.

Every co-tenant is still told the disk is gone, because for every one of them
it is. The ones left behind are told why they did not follow.

Third of eight PRs toward #1636. #1675 is the combined branch and stays open
as the reference until the stack is in.

Validation: `mix precommit`. The three new cases were checked against the old
`move_cotenants/3` and fail there.

---

**The stack** (each PR is based on the one above it; review and merge top down):

1. `stack/1680-unchanged-verdict` — a save that changes nothing records nothing (#1680)
2. `stack/1636-apply-isolation` — a raise in one apply document fails that row
3. `stack/1636-cotenant-identity` — a co-tenant follows a replacement only if it declared the same identity ← **this one**
4. `stack/1636-update-teammate` — Team.update_teammate/4
5. `stack/1636-cli-group-by-kind` — CLI: group apply documents by kind
6. `stack/1636-teammate-kind` — apply reconciles Teammate documents
7. `stack/1636-schedule-kind` — apply reconciles Schedule documents
8. `stack/1636-webhook-kind` — apply reconciles Webhook documents (#1636)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WQyc3wWWDAeZJE1Vr6etQa