### PR TITLE
refactor(cli): group apply documents by kind

### DIFF
--- a/cli/internal/cmd/apply.go
+++ b/cli/internal/cmd/apply.go
@@ -42,7 +42,7 @@ func runApply(cmd *cobra.Command, args []string) error {
 		Fatal(err.Error())
 	}
 
-	envs, vaults, agents, unknown := groupDocs(docs)
+	grouped, unknown := groupDocs(docs)
 	if len(unknown) > 0 {
 		names := make([]string, len(unknown))
 		for i, d := range unknown {
@@ -51,15 +51,15 @@ func runApply(cmd *cobra.Command, args []string) error {
 		Fatalf("unsupported kinds in %s: %s", path, strings.Join(names, ", "))
 	}
 
-	envs, vaults = expandApplySecrets(envs, vaults, applyVars)
+	grouped["Environment"], grouped["Vault"] = expandApplySecrets(grouped["Environment"], grouped["Vault"], applyVars)
 
 	c := activeClient()
 
-	results, err := postApply(c, buildApplyPayload(envs, vaults, agents))
+	results, err := postApply(c, buildApplyPayload(grouped))
 	if err != nil {
 		if api.StatusCode(err) == 404 {
 			// Server predates POST /api/apply — reconcile resource-by-resource.
-			legacyApply(c, envs, vaults, agents)
+			legacyApply(c, grouped)
 			return nil
 		}
 		Fatalf("apply failed: %v", err)
@@ -73,11 +73,15 @@ func runApply(cmd *cobra.Command, args []string) error {
 
 // ── bulk apply ─────────────────────────────────────────────────────────
 
+// applyKindOrder is the order the server reconciles in, and the order the
+// payload is built in so the printed output reads the same way. A document
+// may name another whatever the file's order — an agent's `spec.environment`
+// — and the server resolves it by name, including against records that
+// already exist and are not part of this manifest.
+var applyKindOrder = []string{"Environment", "Vault", "Agent"}
+
 // applyResource is one compiled manifest document. The whole manifest is
-// sent to POST /api/apply in a single request; the server reconciles by
-// name (environments first, then vaults, then agents) and resolves agent
-// `spec.environment` references server-side — including environments that
-// already exist but aren't part of this manifest.
+// sent to POST /api/apply in a single request.
 type applyResource struct {
 	Kind string         `json:"kind"`
 	Name string         `json:"name"`
@@ -98,10 +102,10 @@ type applyResult struct {
 	Secrets []applySecretResult `json:"secrets"`
 }
 
-func buildApplyPayload(envs, vaults, agents []*manifest.Doc) []applyResource {
+func buildApplyPayload(grouped map[string][]*manifest.Doc) []applyResource {
 	var out []applyResource
-	for _, group := range [][]*manifest.Doc{envs, vaults, agents} {
-		for _, d := range group {
+	for _, kind := range applyKindOrder {
+		for _, d := range grouped[kind] {
 			name := requireName(d)
 			spec := cloneMap(d.Spec)
 			// Ownership fields are server-assigned; don't transmit fields the
@@ -179,7 +183,8 @@ func formatResultErrors(errs map[string]any) string {
 
 // legacyApply is the pre-bulk reconciliation path: one GET+write per
 // resource and one POST per secret. Kept for servers without /api/apply.
-func legacyApply(c *api.Client, envs, vaults, agents []*manifest.Doc) {
+func legacyApply(c *api.Client, grouped map[string][]*manifest.Doc) {
+	envs, vaults, agents := grouped["Environment"], grouped["Vault"], grouped["Agent"]
 	envIDByName := map[string]string{}
 	anyFailed := false
 
@@ -210,20 +215,23 @@ func legacyApply(c *api.Client, envs, vaults, agents []*manifest.Doc) {
 
 // ── grouping ───────────────────────────────────────────────────────────
 
-func groupDocs(docs []*manifest.Doc) (envs, vaults, agents, unknown []*manifest.Doc) {
+// groupDocs buckets the parsed documents by kind. The returned map is keyed
+// by the kind name, so a caller reads it in applyKindOrder; anything outside
+// that list comes back in `unknown` and stops the run.
+func groupDocs(docs []*manifest.Doc) (grouped map[string][]*manifest.Doc, unknown []*manifest.Doc) {
+	grouped = map[string][]*manifest.Doc{}
+	known := map[string]bool{}
+	for _, kind := range applyKindOrder {
+		known[kind] = true
+	}
 	for _, d := range docs {
-		switch d.Kind {
-		case "Environment":
-			envs = append(envs, d)
-		case "Vault":
-			vaults = append(vaults, d)
-		case "Agent":
-			agents = append(agents, d)
-		default:
+		if known[d.Kind] {
+			grouped[d.Kind] = append(grouped[d.Kind], d)
+		} else {
 			unknown = append(unknown, d)
 		}
 	}
-	return
+	return grouped, unknown
 }
 
 // ── apply-time secret resolution ───────────────────────────────────────

--- a/cli/internal/cmd/apply_test.go
+++ b/cli/internal/cmd/apply_test.go
@@ -17,27 +17,32 @@ func doc(kind, name string, spec map[string]any) *manifest.Doc {
 }
 
 func TestBuildApplyPayloadOrdersAndStrips(t *testing.T) {
-	envs := []*manifest.Doc{doc("Environment", "proj", map[string]any{
-		"setup_script": "echo hi",
-		"secrets":      map[string]any{"TOKEN": "t0"},
-		"user_id":      "someone-else",
-		"created_by":   "mallory",
-		"id":           "forced-id",
-	})}
-	vaults := []*manifest.Doc{doc("Vault", "alice", nil)}
-	agents := []*manifest.Doc{doc("Agent", "researcher", map[string]any{
-		"runtime":     "claude",
-		"environment": "proj",
-	})}
-
-	// Payload order is envs, vaults, agents regardless of manifest order.
-	got := buildApplyPayload(envs, vaults, agents)
-
-	if len(got) != 3 {
-		t.Fatalf("want 3 resources, got %d", len(got))
+	grouped := map[string][]*manifest.Doc{
+		"Environment": {doc("Environment", "proj", map[string]any{
+			"setup_script": "echo hi",
+			"secrets":      map[string]any{"TOKEN": "t0"},
+			"user_id":      "someone-else",
+			"created_by":   "mallory",
+			"id":           "forced-id",
+		})},
+		"Vault": {doc("Vault", "alice", nil)},
+		"Agent": {doc("Agent", "researcher", map[string]any{
+			"runtime":     "claude",
+			"environment": "proj",
+		})},
 	}
-	if got[0].Kind != "Environment" || got[1].Kind != "Vault" || got[2].Kind != "Agent" {
-		t.Fatalf("wrong kind order: %v, %v, %v", got[0].Kind, got[1].Kind, got[2].Kind)
+
+	// Payload order is the reconciliation order, whatever order the manifest
+	// listed the documents in.
+	got := buildApplyPayload(grouped)
+
+	if len(got) != len(applyKindOrder) {
+		t.Fatalf("want %d resources, got %d", len(applyKindOrder), len(got))
+	}
+	for i, want := range applyKindOrder {
+		if got[i].Kind != want {
+			t.Fatalf("resource %d: want kind %q, got %q", i, want, got[i].Kind)
+		}
 	}
 
 	env := got[0]
@@ -63,6 +68,26 @@ func TestBuildApplyPayloadOrdersAndStrips(t *testing.T) {
 	// A nil spec still yields a non-nil map so the JSON encodes as {}.
 	if got[1].Spec == nil {
 		t.Errorf("nil spec must be sent as an empty object")
+	}
+}
+
+func TestGroupDocsBucketsEveryKind(t *testing.T) {
+	docs := []*manifest.Doc{
+		doc("Agent", "a", nil),
+		doc("Cluster", "nope", nil),
+		doc("Environment", "e", nil),
+		doc("Vault", "v", nil),
+	}
+
+	grouped, unknown := groupDocs(docs)
+
+	for _, kind := range applyKindOrder {
+		if len(grouped[kind]) != 1 {
+			t.Errorf("%s: want 1 doc, got %d", kind, len(grouped[kind]))
+		}
+	}
+	if len(unknown) != 1 || unknown[0].Kind != "Cluster" {
+		t.Errorf("an unsupported kind must come back as unknown, got %v", unknown)
 	}
 }
 


### PR DESCRIPTION
Pure refactor, no behaviour change, cut out of the apply-kinds stack so the
three feature PRs after it each touch the CLI by one line.

`groupDocs` returned four named slices, and `buildApplyPayload` and
`legacyApply` took them positionally. Three more kinds are coming, and each
would have widened both signatures. It now returns a map keyed by kind, and
one `applyKindOrder` list is both the set of kinds the CLI accepts and the
order the payload is built in.

`applyKindOrder` still holds the three kinds the server reconciles today, so
the compiled payload, the unknown-kind refusal and the legacy fallback all
behave exactly as they did.

Fifth of eight PRs toward #1636. #1675 is the combined branch and stays open
as the reference until the stack is in.

Validation: `go test ./...` and `go vet ./...` in `cli/`.

---

**The stack** (each PR is based on the one above it; review and merge top down):

1. `stack/1680-unchanged-verdict` — a save that changes nothing records nothing (#1680)
2. `stack/1636-apply-isolation` — a raise in one apply document fails that row
3. `stack/1636-cotenant-identity` — a co-tenant follows a replacement only if it declared the same identity
4. `stack/1636-update-teammate` — Team.update_teammate/4
5. `stack/1636-cli-group-by-kind` — CLI: group apply documents by kind ← **this one**
6. `stack/1636-teammate-kind` — apply reconciles Teammate documents
7. `stack/1636-schedule-kind` — apply reconciles Schedule documents
8. `stack/1636-webhook-kind` — apply reconciles Webhook documents (#1636)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WQyc3wWWDAeZJE1Vr6etQa