### PR TITLE
feat(api): bulk apply reconciles Teammate documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ upgrade, is in
   existing launches retain `owner` behavior. Applications processing mutually
   untrusted work can keep all Fountain API authority on their service host.
 
+- A `fountain apply` manifest can declare team membership. A `Teammate`
+  document names its agent, environment and vault, and the apply puts the agent
+  on the team, which opens its conversation and provisions its computer.
+  Re-applying moves the name and the bindings and provisions no second
+  computer (#1636).
+
 ### Fixed
 
 - A teammate can be moved to a different environment or vault. Fountain retires

--- a/apps/fountain/lib/fountain/manifest.ex
+++ b/apps/fountain/lib/fountain/manifest.ex
@@ -3,25 +3,52 @@ defmodule Fountain.Manifest do
   Bulk apply for compiled IaC manifests (`fountain apply`).
 
   Takes the full list of resources the CLI compiled from a `fountain.yml`
-  and reconciles them against the tenant's records in one pass:
-  environments first, then vaults, then agents — the same fixed ordering
-  `fountain apply` has always used, so an Agent doc can reference an
-  Environment by name regardless of document order. Agent `environment`
-  references resolve against environments in this manifest first, then
-  against the tenant's existing environments.
+  and reconciles them against the tenant's records in one pass, in a fixed
+  order: environments, vaults, agents, teammates. The
+  order is what lets a document reference another by name regardless of
+  where it sits in the file. An Agent's `environment`, a Teammate's `agent`,
+  `environment` and `vault` all resolve against the documents applied earlier
+  in this manifest first, then against the tenant's existing records.
+
+  Each kind has its own upsert key:
+
+  | Kind | Key | Reconciled through |
+  |---|---|---|
+  | `Environment` | `name` | `Fountain.Environments` |
+  | `Vault` | `name` | `Fountain.Vaults` |
+  | `Agent` | `name` | `Fountain.Agents` |
+  | `Teammate` | `name`, which names the agent's membership | `Fountain.Team` |
+
+  A teammate is one agent's membership of the team, so the document's `name`
+  is what the teammate is called and the resolved `agent` is what it
+  reconciles against. Re-applying a Teammate with a different `name` renames
+  it rather than adding a second membership for the same agent, and two
+  documents naming one agent are refused past the first: they describe one
+  record, so without the refusal each pass would rename the other's
+  conversation and no apply would ever be `unchanged`.
+
+  A Teammate document is also the only one read as a whole declaration. On
+  the other five an absent `spec` key leaves that column alone; on a Teammate
+  an absent `environment` or `vault` clears the binding, back to the agent's
+  own environment and no vault. Moving either id moves the teammate's
+  computer, which `Fountain.Team.update_teammate/4` retires and refuses
+  mid-turn (#1084).
 
   Application is best-effort per resource: a document that fails validation,
   that a context refuses, or that raises is reported in its own result entry
   and does not stop the rest of the manifest.
+
+  Apply is additive. A document removed from the manifest leaves its record
+  in place; there is no prune.
   """
 
   require Logger
 
-  alias Fountain.{Agents, Crypto, Environments, Vaults}
+  alias Fountain.{Agents, Crypto, Environments, Team, Vaults}
 
   @unexpected "apply failed unexpectedly; see the server log"
 
-  @kinds ~w(Environment Vault Agent)
+  @kinds ~w(Environment Vault Agent Teammate)
 
   def kinds, do: @kinds
 
@@ -33,12 +60,11 @@ defmodule Fountain.Manifest do
   Apply `resources` (maps with `"kind"`, `"name"`, and `"spec"`) for `user_id`.
 
   Returns `{:ok, results}` with one result map per resource in apply order
-  (environments, vaults, agents, then any malformed entries). Each result
+  (the 4 kinds in the order above, then any malformed entries). Each result
   holds `:kind`, `:name`, an `:action` of `:created` / `:updated` /
   `:unchanged` / `:error`, changeset-style `:errors` when the action is
-  `:error`, a `:secrets` list with the per-key upsert outcome, and the
-  reconciled record's `:id` (nil for errors and for kinds that carry no
-  secrets). Secret values are never echoed back.
+  `:error`, a `:secrets` list with the per-key upsert outcome, the
+  reconciled record's `:id` (nil for errors).
 
   `:unchanged` means the record already matched the document, so nothing was
   written to it. Inline `spec.secrets` are re-encrypted on every apply and
@@ -52,46 +78,57 @@ defmodule Fountain.Manifest do
     envs = Map.get(groups, "Environment", [])
     vaults = Map.get(groups, "Vault", [])
     agents = Map.get(groups, "Agent", [])
+    teammates = Map.get(groups, "Teammate", [])
 
     dek = if Enum.any?(envs ++ vaults, &has_secrets?/1), do: load_dek!(user_id)
 
     {env_results, env_ids} =
-      reconcile("Environment", envs, fn res -> apply_environment(user_id, res, dek, opts) end)
+      reconcile("Environment", envs, fn res, _claimed ->
+        apply_environment(user_id, res, dek, opts)
+      end)
 
-    {vault_results, _} =
-      reconcile("Vault", vaults, fn res -> apply_vault(user_id, res, dek, opts) end)
+    {vault_results, vault_ids} =
+      reconcile("Vault", vaults, fn res, _claimed -> apply_vault(user_id, res, dek, opts) end)
 
-    {agent_results, _} =
-      reconcile("Agent", agents, fn res -> apply_agent(user_id, res, env_ids, opts) end)
+    {agent_results, agent_ids} =
+      reconcile("Agent", agents, fn res, _claimed -> apply_agent(user_id, res, env_ids, opts) end)
+
+    refs = %{agents: agent_ids, environments: env_ids, vaults: vault_ids}
+
+    {teammate_results, _teammate_ids} =
+      reconcile("Teammate", teammates, fn res, claimed ->
+        apply_teammate(user_id, res, refs, claimed, opts)
+      end)
 
     results =
       env_results ++
         vault_results ++
         agent_results ++
+        teammate_results ++
         Enum.map(invalid, &invalid_result/1)
 
     {:ok, results}
   end
 
   # One pass over one kind. Every `apply_*` returns `{result, id}`, so the
-  # pass leaves behind the name -> id map the next pass resolves references
-  # against.
+  # pass leaves behind the name → id map the next pass resolves against, and
+  # hands each document the map built so far (which is how a second Teammate
+  # naming an agent already claimed is caught).
   defp reconcile(kind, resources, fun) do
     Enum.map_reduce(resources, %{}, fn res, acc ->
-      case guarded(kind, res["name"], fn -> fun.(res) end) do
+      case guarded(kind, res["name"], fn -> fun.(res, acc) end) do
         {result, nil} -> {result, acc}
         {result, id} -> {result, Map.put(acc, res["name"], id)}
       end
     end)
   end
 
-  # Best-effort per resource means per resource. A raise or an exit in one
-  # document's reconcile would abandon a call that has already committed the
-  # documents above it, leaving the caller a 500 and no rows at all, against a
-  # moduledoc promising best effort per resource. Reported as this document's
-  # error instead, and logged, because a crash in a context is still a defect
-  # worth a stacktrace.
-  #
+  # Best-effort per resource means per resource. The Teammate pass reaches
+  # Horde, the sandbox quota lock, the credit gate and the sandbox provider,
+  # and a raise or an exit there would abandon a call that has already
+  # committed the environments, vaults and agents above it, leaving the caller
+  # a 500 and no rows at all. Reported as this document's error instead, and
+  # logged, because a crash in a context is still a defect worth a stacktrace.
   # The row says only that the pass failed. The exception text goes to the log
   # above and no further: this module promises that secret values are never
   # echoed back, and the environment and vault passes hold plaintext inside
@@ -177,72 +214,138 @@ defmodule Fountain.Manifest do
     end
   end
 
-  defp apply_agent(user_id, %{"name" => name} = res, env_id_by_name, opts) do
-    with :ok <- validate_spec(res, Agents.Agent, ~w(environment)) do
-      {attrs, _secrets} = split_spec(res, name)
-      {env_ref, attrs} = Map.pop(attrs, "environment")
+  defp apply_agent(user_id, %{"name" => name} = res, env_ids, opts) do
+    with :ok <- validate_spec(res, Agents.Agent, ~w(environment)),
+         {attrs, _secrets} = split_spec(res, name),
+         {env_ref, attrs} = Map.pop(attrs, "environment"),
+         {:ok, env_id} <- resolve_ref("environment", user_id, env_ref, env_ids) do
+      attrs = if env_id, do: Map.put(attrs, "environment_id", env_id), else: attrs
+      existing = Agents.get_agent_by_name(name, user_id)
 
-      case resolve_environment_ref(user_id, env_ref, env_id_by_name) do
-        {:ok, env_attrs} ->
-          attrs = Map.merge(attrs, env_attrs)
+      outcome =
+        if existing,
+          do: Agents.update_agent(existing, attrs, opts),
+          else: Agents.create_agent(Map.put(attrs, "user_id", user_id), opts)
 
-          existing = Agents.get_agent_by_name(name, user_id)
+      case outcome do
+        {:ok, agent} ->
+          {result("Agent", name, verdict(existing, agent), nil, [], agent.id), agent.id}
 
-          outcome =
-            if existing,
-              do: Agents.update_agent(existing, attrs, opts),
-              else: Agents.create_agent(Map.put(attrs, "user_id", user_id), opts)
+        # Moving the agent's environment rebuilds its machine, which a
+        # running turn blocks (#1084). Reported against the field that
+        # caused it so `fountain apply` says what to do about it.
+        {:error, :sandbox_mid_turn} ->
+          errors = %{
+            "environment" => [
+              "the agent is running a turn on its own machine; changing its " <>
+                "environment rebuilds that machine — retry once the turn ends"
+            ]
+          }
 
-          case outcome do
-            {:ok, agent} ->
-              {result("Agent", name, verdict(existing, agent), nil, [], agent.id), agent.id}
-
-            # Moving the agent's environment rebuilds its machine, which a
-            # running turn blocks (#1084). Reported against the field that
-            # caused it so `fountain apply` says what to do about it.
-            {:error, :sandbox_mid_turn} ->
-              errors = %{
-                "environment" => [
-                  "the agent is running a turn on its own machine; changing its " <>
-                    "environment rebuilds that machine — retry once the turn ends"
-                ]
-              }
-
-              {result("Agent", name, :error, errors, []), nil}
-
-            {:error, cs} ->
-              {result("Agent", name, :error, changeset_errors(cs), []), nil}
-          end
-
-        {:error, ref} ->
-          errors = %{"environment" => ["environment not found: #{ref}"]}
           {result("Agent", name, :error, errors, []), nil}
+
+        {:error, cs} ->
+          {result("Agent", name, :error, changeset_errors(cs), []), nil}
       end
     else
       {:error, errors} -> {result("Agent", name, :error, errors, []), nil}
     end
   end
 
-  # Resolve an agent's `environment: <name>` reference: environments applied
-  # earlier in this manifest win, then the tenant's existing environments.
-  defp resolve_environment_ref(_user_id, ref, _env_id_by_name) when ref in [nil, ""],
-    do: {:ok, %{}}
+  # A Teammate is an agent on the team, so the agent reference is the record
+  # this reconciles against and the document's name is what it is called.
+  # Adding one opens the teammate's conversation, which provisions its
+  # computer; re-applying only moves the name, environment and vault the next
+  # computer is built from, and never provisions a second one.
+  defp apply_teammate(user_id, %{"name" => name} = res, refs, claimed, opts) do
+    spec = spec_of(res)
 
-  defp resolve_environment_ref(user_id, ref, env_id_by_name) when is_binary(ref) do
-    case env_id_by_name[ref] || existing_env_id(user_id, ref) do
-      nil -> {:error, ref}
-      id -> {:ok, %{"environment_id" => id}}
+    with :ok <- validate_keys(res, ~w(name agent environment vault)),
+         {:ok, agent_id} <- require_ref("agent", user_id, spec["agent"], refs.agents),
+         :ok <- unclaimed(name, agent_id, claimed),
+         {:ok, env_id} <-
+           resolve_ref("environment", user_id, spec["environment"], refs.environments),
+         {:ok, vault_id} <- resolve_ref("vault", user_id, spec["vault"], refs.vaults) do
+      attrs = %{"name" => name, "environment_id" => env_id, "vault_id" => vault_id}
+      reconcile_teammate(user_id, name, agent_id, attrs, opts)
+    else
+      {:error, errors} -> {result("Teammate", name, :error, errors, []), nil}
     end
   end
 
-  defp resolve_environment_ref(_user_id, ref, _env_id_by_name), do: {:error, inspect(ref)}
+  # A teammate is one agent's membership of the team, so two documents naming
+  # the same agent describe one record: without this the second renames the
+  # first's conversation on every pass and the manifest is never idempotent.
+  # Two documents sharing a name are refused for the same reason — a Schedule
+  # naming that teammate could not say which one it meant.
+  defp unclaimed(name, agent_id, claimed) do
+    cond do
+      Map.has_key?(claimed, name) ->
+        {:error, %{"name" => ["is already used by another Teammate document"]}}
 
-  defp existing_env_id(user_id, name) do
-    case Environments.get_environment_by_name(name, user_id) do
-      nil -> nil
-      env -> env.id
+      agent_id in Map.values(claimed) ->
+        {:error, %{"agent" => ["is already claimed by another Teammate document"]}}
+
+      true ->
+        :ok
     end
   end
+
+  defp reconcile_teammate(user_id, name, agent_id, attrs, opts) do
+    opts = Keyword.put_new(opts, :source, "api")
+
+    case Team.get_teammate(user_id, agent_id) do
+      nil ->
+        case Team.add_teammate(user_id, agent_id, attrs, opts) do
+          {:ok, conv} -> {result("Teammate", name, :created, nil, [], conv.id), agent_id}
+          {:error, reason} -> {result("Teammate", name, :error, context_errors(reason), []), nil}
+        end
+
+      teammate ->
+        # The teammate map is handed on rather than the agent id: listing the
+        # roster is several queries and this call site has just done it.
+        case Team.update_teammate(user_id, teammate, attrs, opts) do
+          {:ok, conv, action} ->
+            {result("Teammate", name, action, nil, [], conv.id), agent_id}
+
+          {:error, reason} ->
+            {result("Teammate", name, :error, context_errors(reason), []), nil}
+        end
+    end
+  end
+
+  # ── references ────────────────────────────────────────────────────────────
+
+  # Resolve a `<field>: <name>` reference: documents applied earlier in this
+  # manifest win, then the tenant's own records. A blank reference is no
+  # reference, which is how an Agent with no environment or a Teammate with
+  # no vault reads.
+  defp resolve_ref(_field, _user_id, ref, _ids) when ref in [nil, ""], do: {:ok, nil}
+
+  defp resolve_ref(field, user_id, ref, ids) when is_binary(ref) do
+    case ids[ref] || tenant_ref(field, user_id, ref) do
+      nil -> {:error, %{field => ["#{field} not found: #{ref}"]}}
+      id -> {:ok, id}
+    end
+  end
+
+  defp resolve_ref(field, _user_id, ref, _ids),
+    do: {:error, %{field => ["#{field} not found: #{inspect(ref)}"]}}
+
+  # The same, for a reference the document cannot do without.
+  defp require_ref(field, _user_id, ref, _ids) when ref in [nil, ""],
+    do: {:error, %{field => ["can't be blank"]}}
+
+  defp require_ref(field, user_id, ref, ids), do: resolve_ref(field, user_id, ref, ids)
+
+  defp tenant_ref("environment", user_id, name),
+    do: id_of(Environments.get_environment_by_name(name, user_id))
+
+  defp tenant_ref("vault", user_id, name), do: id_of(Vaults.get_vault_by_name(name, user_id))
+  defp tenant_ref("agent", user_id, name), do: id_of(Agents.get_agent_by_name(name, user_id))
+
+  defp id_of(nil), do: nil
+  defp id_of(record), do: record.id
 
   # ── secrets ───────────────────────────────────────────────────────────────
 
@@ -296,12 +399,16 @@ defmodule Fountain.Manifest do
   # Use the changeset's cast fields, not every database field: timestamps,
   # virtual counts and other read-only state must not look configurable.
   defp validate_spec(res, schema, extra_keys) do
-    allowed =
-      Enum.map(schema.cast_fields(), &Atom.to_string/1) ++ extra_keys ++ ~w(id user_id created_by)
+    validate_keys(res, Enum.map(schema.cast_fields(), &Atom.to_string/1) ++ extra_keys)
+  end
 
-    unknown = Map.keys(res["spec"] || %{}) -- allowed
+  # The kinds with no Ecto schema of their own behind the manifest document
+  # (a Teammate is a conversation, a Webhook an endpoint) name their keys
+  # here, so an unsupported key still fails before anything is written.
+  defp validate_keys(res, allowed) do
+    allowed = allowed ++ ~w(id user_id created_by)
 
-    case unknown do
+    case Map.keys(res["spec"] || %{}) -- allowed do
       [] -> :ok
       keys -> {:error, Map.new(keys, &{&1, ["is not a supported spec key"]})}
     end
@@ -309,17 +416,20 @@ defmodule Fountain.Manifest do
 
   # The top-level resource name is authoritative — it is the upsert key, so
   # it overrides any `name` a spec happens to carry.
-  defp split_spec(%{"spec" => spec}, name) when is_map(spec) do
+  defp split_spec(res, name) do
+    spec = spec_of(res)
+
     secrets =
-      case Map.get(spec, "secrets") do
+      case Map.get(res["spec"] || %{}, "secrets") do
         m when is_map(m) -> m
         _other -> %{}
       end
 
-    {spec |> Map.drop(@stripped_keys) |> Map.put("name", name), secrets}
+    {Map.put(spec, "name", name), secrets}
   end
 
-  defp split_spec(_res, name), do: {%{"name" => name}, %{}}
+  defp spec_of(%{"spec" => spec}) when is_map(spec), do: Map.drop(spec, @stripped_keys)
+  defp spec_of(_res), do: %{}
 
   # The third verdict. A record the manifest did not move reads `unchanged`,
   # so a second apply of the same file says plainly that it wrote nothing.
@@ -342,7 +452,7 @@ defmodule Fountain.Manifest do
 
   defp invalid_result(res) do
     errors = %{
-      "resource" => ["must have kind (Environment | Vault | Agent), name, and a map spec"]
+      "resource" => ["must have kind (#{Enum.join(@kinds, " | ")}), name, and a map spec"]
     }
 
     result(str(res["kind"]), str(res["name"]), :error, errors, [])
@@ -351,11 +461,70 @@ defmodule Fountain.Manifest do
   defp str(value) when is_binary(value), do: value
   defp str(_value), do: ""
 
+  # What a context refused with, as the per-field errors an apply row carries.
+  # Every reason a Teammate or Schedule document can actually provoke is named
+  # here, because `inspect/1` on a bare atom is not a sentence anyone acts on.
+  defp context_errors(%Ecto.Changeset{} = changeset), do: changeset_errors(changeset)
+  defp context_errors(:not_found), do: %{"agent" => ["is not the caller's"]}
+
+  defp context_errors(:environment_not_found),
+    do: %{"environment" => ["environment not found"]}
+
+  defp context_errors(:environment_not_allowed),
+    do: %{"environment" => ["is not allowed by the agent"]}
+
+  defp context_errors(:vault_not_found), do: %{"vault" => ["vault not found"]}
+  defp context_errors(:vault_not_allowed), do: %{"vault" => ["is not allowed by the agent"]}
+  defp context_errors(:insufficient_credits), do: %{"base" => ["out of credit"]}
+
+  # The same hazard `Agent` reports, from the teammate's side: rebinding moves
+  # the computer out from under a turn that is running on it.
+  defp context_errors(:sandbox_mid_turn),
+    do: %{
+      "base" => [
+        "the teammate is running a turn on its computer; changing its environment " <>
+          "or vault rebuilds that computer, so retry once the turn ends"
+      ]
+    }
+
+  # One live computer per (agent, environment, vault): the teammate cannot be
+  # moved onto an identity that already has one, because its next wake would
+  # build a second and the index refuses it. Named so the row says what to do.
+  defp context_errors(:destination_home_occupied),
+    do: %{
+      "base" => [
+        "this agent already has a computer on that environment and vault; " <>
+          "reset or remove it before binding the teammate to them"
+      ]
+    }
+
+  defp context_errors(:provisioning), do: %{"base" => ["the computer is still starting"]}
+  defp context_errors(:busy), do: %{"base" => ["the teammate is running a turn"]}
+  defp context_errors(:runner_offline), do: %{"base" => ["the teammate's machine is offline"]}
+  defp context_errors(:fleet_full), do: %{"base" => ["the fleet is at capacity"]}
+
+  defp context_errors({:sandbox_quota_exceeded, %{count: count, limit: limit}}),
+    do: %{"base" => ["sandbox quota: #{count}/#{limit}"]}
+
+  defp context_errors({:sandbox_not_attachable, status}),
+    do: %{"base" => ["the teammate's computer is #{status}"]}
+
+  defp context_errors({:sandbox_not_resettable, status}),
+    do: %{"base" => ["the teammate's computer is #{status}"]}
+
+  defp context_errors(other), do: %{"base" => [inspect(other)]}
+
+  # String keys throughout. `traverse_errors/2` keys by field atom, while the
+  # hand-built maps above key by string, and a caller reading a result row
+  # should not have to know which branch produced it. The wire shape does not
+  # change: JSON stringifies either one.
   defp changeset_errors(changeset) do
-    Ecto.Changeset.traverse_errors(changeset, fn {msg, opts} ->
+    changeset
+    |> Ecto.Changeset.traverse_errors(fn {msg, opts} ->
       Enum.reduce(opts, msg, fn {key, value}, acc ->
         String.replace(acc, "%{#{key}}", to_string(value))
       end)
     end)
+    |> Map.new(fn {field, messages} -> {to_string(field), messages} end)
   end
 end

--- a/apps/fountain/lib/fountain_web/controllers/apply_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/apply_controller.ex
@@ -18,11 +18,18 @@ defmodule FountainWeb.ApplyController do
     summary: "Apply a compiled manifest (bulk upsert)",
     description:
       "Applies all resources from a compiled fountain.yml manifest in one request. " <>
-        "Resources are reconciled by name — environments first, then vaults, then " <>
-        "agents — so agent specs may reference an environment by name via " <>
-        "`spec.environment`. Application is best-effort per resource: the response " <>
-        "is 200 even when individual resources fail, with per-resource errors in " <>
-        "the result entries.",
+        "Resources are reconciled in a fixed order — environments, vaults, agents, " <>
+        "teammates — so a spec may name another document whatever the file's " <>
+        "order: an agent's `environment`, and a teammate's `agent`, `environment` " <>
+        "and `vault`. Every kind is keyed by the document's `name`. A `Teammate` " <>
+        "is read as a whole declaration, so an absent `environment` or `vault` " <>
+        "clears that binding, and moving either retires the computer the old " <>
+        "binding named (refused with an error on that row while a turn is running " <>
+        "on it). Two Teammate documents may not name the same agent. Apply is " <>
+        "additive: a document dropped from the manifest leaves its record in " <>
+        "place. Application is best-effort per resource: the response is 200 even " <>
+        "when an individual resource fails validation, is refused by its context " <>
+        "or raises, with per-resource errors in the result entries.",
     request_body: {"Compiled manifest", "application/json", Schemas.ApplyRequest},
     responses: [
       ok: {"Per-resource results", "application/json", Schemas.ApplyResponse},

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -3122,11 +3122,15 @@ defmodule FountainWeb.Schemas do
       description:
         "One compiled document from a fountain.yml manifest. `spec` matches the " <>
           "create/update schema for the kind, plus an inline `secrets` map " <>
-          "(Environment and Vault). Agent specs may reference an environment by " <>
-          "name via `environment`; the server resolves it to `environment_id`.",
+          "(Environment and Vault). Specs reference other documents by name, and " <>
+          "the server resolves each to an id: an Agent's `environment`, and a " <>
+          "Teammate's `agent`, `environment` and `vault`. Teammate specs take " <>
+          "`agent`, `environment` and `vault`, and a Teammate document is read " <>
+          "as a whole declaration, so an absent `environment` or `vault` clears " <>
+          "that binding.",
       type: :object,
       properties: %{
-        kind: %Schema{type: :string, enum: ["Environment", "Vault", "Agent"]},
+        kind: %Schema{type: :string, enum: ["Environment", "Vault", "Agent", "Teammate"]},
         name: %Schema{type: :string, minLength: 1, maxLength: 200},
         spec: %Schema{type: :object, additionalProperties: true}
       },

--- a/apps/fountain/priv/help/manifest.md
+++ b/apps/fountain/priv/help/manifest.md
@@ -8,7 +8,7 @@ A `fountain.yml` is a multi-document YAML file. Each doc is one resource with th
 
 ```yaml
 apiVersion: fountain/v1
-kind: Environment | Vault | Agent
+kind: Environment | Vault | Agent | Teammate
 metadata:
   name: <unique-on-operator-side>
 spec:
@@ -19,7 +19,38 @@ The `metadata.name` is the upsert key. If a resource with that name exists, it's
 
 ## Order is irrelevant inside the file
 
-`fountain apply` reconciles **environments first, vaults second, agents last** — so an agent doc can reference an environment by name (`spec.environment: my-env`) even if that environment is defined later in the file. The reference also resolves against environments that **already exist** server-side, so a manifest can attach an agent to an environment managed elsewhere; a name that matches neither the manifest nor an existing environment fails that agent doc. Vaults aren't referenced from agents (they're picked per-conversation), so the order between envs and vaults doesn't matter functionally; the predictable ordering just makes the apply output easier to skim.
+`fountain apply` reconciles in a fixed order: **environments, vaults, agents, teammates** — so a doc can reference another by name even if that one is defined later in the file. An `Agent` references an `environment`; a `Teammate` references an `agent`, an `environment` and a `vault`. Every reference resolves against the manifest first and then against what **already exists** server-side, so a manifest can attach an agent to an environment managed elsewhere; a name that matches neither fails that doc and no other.
+
+## The team kinds
+
+A `Teammate` puts an agent on the team, which opens its conversation and provisions its computer. Re-applying moves what the teammate is called and which environment and vault it is bound to — it never provisions a second one, and it never resurrects a computer that is gone (message the teammate for that).
+
+Two things about it that surprise people:
+
+- **A `Teammate` doc is the whole teammate.** Unlike the other three kinds, where an absent `spec` key leaves that column alone, dropping `environment` or `vault` from a Teammate doc *clears* that binding — back to the agent's own environment and no vault. That is what makes the doc a declaration rather than a patch.
+- **Rebinding moves the computer.** A home is keyed on `(user, agent, environment, vault)`, so changing either id retires the machine the old key named; the teammate's next message builds a fresh one. Refused with an error on that row while a turn is still running there — the same refusal `Agent`'s `environment` gives (#1084). A conversation that *shared* that machine and names a different environment or vault does not follow the teammate; it builds its own on its next prompt. And because there is only ever one home per identity, a rebind onto an identity the agent **already** has a home for is **refused**, not merged onto that home — reset or remove the existing one first (#1636).
+
+**Two Teammate docs can't name the same agent.** An agent is on the team once, so the second doc fails and the first applies.
+
+```yaml
+---
+apiVersion: fountain/v1
+kind: Teammate
+metadata:
+  name: Ada
+spec:
+  agent: researcher
+  environment: my-project
+  vault: alice
+```
+
+## Nothing is pruned
+
+Apply is additive. Deleting a doc from the manifest leaves its record in place; delete it through its own command or the console.
+
+## What the trail says
+
+Each applied row leaves its context's own audit event, with the actor and IP of the request that applied it: `team.member.added` / `team.updated` for a Teammate. An `unchanged` row writes nothing at all.
 
 ## Example
 

--- a/apps/fountain/test/fountain/manifest_test.exs
+++ b/apps/fountain/test/fountain/manifest_test.exs
@@ -2,7 +2,7 @@ defmodule Fountain.ManifestTest do
   use Fountain.DataCase, async: true
   use Mimic
 
-  alias Fountain.{Agents, Audit, Crypto, Environments, Manifest, Vaults}
+  alias Fountain.{Agents, Audit, Conversations, Crypto, Environments, Manifest, Team, Vaults}
 
   setup do
     # No starter agent (ADR 0038): every assertion here counts what the
@@ -16,6 +16,18 @@ defmodule Fountain.ManifestTest do
 
   defp vault_resource(name, spec \\ %{}) do
     %{"kind" => "Vault", "name" => name, "spec" => spec}
+  end
+
+  defp teammate_resource(name, spec) do
+    %{"kind" => "Teammate", "name" => name, "spec" => spec}
+  end
+
+  # Adding a teammate opens its conversation, which provisions its computer.
+  # The supervisor start is what a DataCase test cannot do for real.
+  defp inert_start_child do
+    stub(Horde.DynamicSupervisor, :start_child, fn _sup, _spec ->
+      {:ok, spawn(fn -> Process.sleep(:infinity) end)}
+    end)
   end
 
   defp agent_resource(name, spec \\ %{}) do
@@ -289,7 +301,7 @@ defmodule Fountain.ManifestTest do
         ])
 
       assert [
-               %{name: "broken", action: :error, errors: %{model: _}},
+               %{name: "broken", action: :error, errors: %{"model" => _}},
                %{name: "ok-agent", action: :created}
              ] = results
     end
@@ -350,6 +362,381 @@ defmodule Fountain.ManifestTest do
         ])
 
       assert errors == %{"environment" => ["environment not found: their-env"]}
+    end
+  end
+
+  describe "apply_manifest/2 the whole estate" do
+    defp estate_manifest(vault_spec \\ %{"secrets" => %{"GH" => "ghp_x"}}) do
+      # Deliberately out of order: the kinds reconcile in a fixed order,
+      # whatever the file says.
+      [
+        teammate_resource("Ada", %{
+          "agent" => "ada",
+          "environment" => "proj",
+          "vault" => "alice"
+        }),
+        agent_resource("ada", %{"environment" => "proj"}),
+        vault_resource("alice", vault_spec),
+        env_resource("proj", %{"setup_script" => "echo hi"})
+      ]
+    end
+
+    test "the four kinds apply in one request, and a second apply changes nothing",
+         %{user: user} do
+      inert_start_child()
+      resources = estate_manifest()
+
+      {:ok, first} = Manifest.apply_manifest(user.id, resources)
+
+      assert Enum.map(first, &{&1.kind, &1.name, &1.action}) == [
+               {"Environment", "proj", :created},
+               {"Vault", "alice", :created},
+               {"Agent", "ada", :created},
+               {"Teammate", "Ada", :created}
+             ]
+
+      env = Environments.get_environment_by_name("proj", user.id)
+      vault = Vaults.get_vault_by_name("alice", user.id)
+      agent = Agents.get_agent_by_name("ada", user.id)
+
+      assert [%{name: "Ada", agent: %{id: agent_id}, conversation: conv}] =
+               Team.list_teammates(user.id)
+
+      assert agent_id == agent.id
+      assert conv.environment_id == env.id
+      assert conv.vault_id == vault.id
+
+      {:ok, second} = Manifest.apply_manifest(user.id, resources)
+
+      assert Enum.map(second, & &1.action) == List.duplicate(:unchanged, 4)
+      assert Enum.map(second, & &1.kind) == Enum.map(first, & &1.kind)
+
+      # Nothing was duplicated by the second pass.
+      assert length(Team.list_teammates(user.id)) == 1
+    end
+
+    test "the applied rows are audited with the request's attribution", %{user: user} do
+      inert_start_child()
+      opts = [actor: "api", request_ip: "203.0.113.5"]
+
+      {:ok, _} = Manifest.apply_manifest(user.id, estate_manifest(), opts)
+
+      events = Audit.list_recent_for_user(user.id, 200)
+      actions = Enum.map(events, & &1.action)
+
+      assert "team.member.added" in actions
+
+      for action <- ~w(team.member.added) do
+        event = Enum.find(events, &(&1.action == action))
+        assert event.actor == "api", "#{action} was recorded as #{event.actor}"
+        assert to_string(event.request_ip) == "203.0.113.5"
+      end
+    end
+
+    # The one thing a no-op apply does write: an inline secret is encrypted
+    # again every time, because the stored ciphertext cannot be compared with
+    # the plaintext given.
+    test "a re-apply with inline secrets writes only the secret events", %{user: user} do
+      inert_start_child()
+      resources = estate_manifest()
+
+      {:ok, _} = Manifest.apply_manifest(user.id, resources)
+      before = actions_for(user)
+
+      {:ok, second} = Manifest.apply_manifest(user.id, resources)
+      assert Enum.all?(second, &(&1.action == :unchanged))
+
+      added = actions_for(user) -- before
+      assert added == ["vault.secret.write"]
+    end
+
+    test "the update path is audited with the request's attribution", %{user: user} do
+      inert_start_child()
+      opts = [actor: "api", request_ip: "203.0.113.5"]
+      {:ok, _} = Manifest.apply_manifest(user.id, estate_manifest(%{}), opts)
+      before = user.id |> Audit.list_recent_for_user(500) |> length()
+
+      moved = [
+        env_resource("proj", %{"setup_script" => "echo hi"}),
+        vault_resource("alice"),
+        agent_resource("ada", %{"environment" => "proj"}),
+        teammate_resource("Ada of proj", %{"agent" => "ada", "environment" => "proj"})
+      ]
+
+      {:ok, results} = Manifest.apply_manifest(user.id, moved, opts)
+
+      assert Enum.map(results, &{&1.kind, &1.action}) == [
+               {"Environment", :unchanged},
+               {"Vault", :unchanged},
+               {"Agent", :unchanged},
+               {"Teammate", :updated}
+             ]
+
+      events = Audit.list_recent_for_user(user.id, 500)
+      added = Enum.take(events, length(events) - before)
+
+      for action <- ~w(team.updated) do
+        event = Enum.find(added, &(&1.action == action))
+
+        assert event,
+               "the update path left no #{action}; saw #{inspect(Enum.map(added, & &1.action))}"
+
+        assert event.actor == "api"
+        assert to_string(event.request_ip) == "203.0.113.5"
+      end
+    end
+
+    test "a second Teammate naming the same agent fails instead of renaming the first",
+         %{user: user} do
+      inert_start_child()
+
+      {:ok, results} =
+        Manifest.apply_manifest(user.id, [
+          agent_resource("ada"),
+          teammate_resource("Ada", %{"agent" => "ada"}),
+          teammate_resource("Ada again", %{"agent" => "ada"}),
+          teammate_resource("Ada", %{"agent" => "ada"})
+        ])
+
+      assert [
+               %{kind: "Agent", action: :created},
+               %{name: "Ada", action: :created},
+               %{name: "Ada again", action: :error, errors: dup_agent},
+               %{name: "Ada", action: :error, errors: dup_name}
+             ] = results
+
+      assert dup_agent == %{"agent" => ["is already claimed by another Teammate document"]}
+      assert dup_name == %{"name" => ["is already used by another Teammate document"]}
+      assert [%{name: "Ada"}] = Team.list_teammates(user.id)
+    end
+
+    # Without the claim check the second document renamed the first's
+    # conversation on every pass, so no apply was ever `unchanged`.
+    test "a manifest with a duplicate Teammate is still idempotent for the rest",
+         %{user: user} do
+      inert_start_child()
+
+      resources = [
+        agent_resource("ada"),
+        teammate_resource("Ada", %{"agent" => "ada"}),
+        teammate_resource("Ada again", %{"agent" => "ada"})
+      ]
+
+      {:ok, _} = Manifest.apply_manifest(user.id, resources)
+      {:ok, second} = Manifest.apply_manifest(user.id, resources)
+
+      assert Enum.map(second, & &1.action) == [:unchanged, :unchanged, :error]
+      assert [%{name: "Ada"}] = Team.list_teammates(user.id)
+    end
+
+    test "a Teammate mid-turn on the computer it would rebind fails that row", %{user: user} do
+      env = insert_env(user_id: user.id, name: "proj")
+      other = insert_env(user_id: user.id, name: "other")
+
+      agent =
+        insert_agent(
+          user_id: user.id,
+          name: "ada",
+          environment_id: other.id,
+          sandbox_mode: "persistent"
+        )
+
+      home =
+        insert_sandbox(
+          user_id: user.id,
+          status: "ready",
+          mode: "persistent",
+          agent_id: agent.id,
+          environment_id: other.id,
+          provider: "sprites"
+        )
+
+      conv =
+        insert_conversation(
+          user_id: user.id,
+          agent: agent,
+          sandbox: home,
+          status: "running",
+          channel_id: Team.channel()
+        )
+
+      insert_turn(conv, status: "running")
+
+      {:ok, [%{kind: "Teammate", action: :error, errors: errors}]} =
+        Manifest.apply_manifest(user.id, [
+          teammate_resource("Ada", %{"agent" => "ada", "environment" => "proj"})
+        ])
+
+      assert %{"base" => [message]} = errors
+      assert message =~ "running a turn"
+      assert Conversations.get_conversation(conv.id, user.id).environment_id == nil
+      assert env.id
+    end
+
+    # A rebind onto an identity that already has a computer is refused rather
+    # than merged onto that computer. The row says what to do about it.
+    test "a Teammate rebound onto an occupied computer fails that row", %{user: user} do
+      env = insert_env(user_id: user.id, name: "proj")
+
+      agent =
+        insert_agent(user_id: user.id, name: "ada", sandbox_mode: "persistent")
+
+      home =
+        insert_sandbox(
+          user_id: user.id,
+          status: "ready",
+          mode: "persistent",
+          agent_id: agent.id,
+          environment_id: nil,
+          provider: "sprites"
+        )
+
+      occupied =
+        insert_sandbox(
+          user_id: user.id,
+          status: "ready",
+          mode: "persistent",
+          agent_id: agent.id,
+          environment_id: env.id,
+          provider: "sprites"
+        )
+
+      conv =
+        insert_conversation(
+          user_id: user.id,
+          agent: agent,
+          sandbox: home,
+          status: "idle",
+          channel_id: Team.channel()
+        )
+
+      {:ok, [%{kind: "Teammate", action: :error, errors: errors}]} =
+        Manifest.apply_manifest(user.id, [
+          teammate_resource("Ada", %{"agent" => "ada", "environment" => "proj"})
+        ])
+
+      assert %{"base" => [message]} = errors
+      assert message =~ "already has a computer on that environment and vault"
+      assert Conversations.get_conversation(conv.id, user.id).environment_id == nil
+      assert Conversations._unsafe_get_sandbox!(occupied.id).status == "ready"
+    end
+
+    test "re-applying a Teammate moves its name, environment and vault", %{user: user} do
+      inert_start_child()
+
+      {:ok, _} =
+        Manifest.apply_manifest(user.id, [
+          env_resource("proj"),
+          vault_resource("alice"),
+          agent_resource("ada"),
+          teammate_resource("Ada", %{"agent" => "ada"})
+        ])
+
+      {:ok, results} =
+        Manifest.apply_manifest(user.id, [
+          env_resource("proj"),
+          vault_resource("alice"),
+          agent_resource("ada"),
+          teammate_resource("Ada of proj", %{
+            "agent" => "ada",
+            "environment" => "proj",
+            "vault" => "alice"
+          })
+        ])
+
+      assert %{kind: "Teammate", name: "Ada of proj", action: :updated} =
+               List.last(results)
+
+      assert [%{name: "Ada of proj", conversation: conv}] = Team.list_teammates(user.id)
+      assert conv.environment_id == Environments.get_environment_by_name("proj", user.id).id
+      assert conv.vault_id == Vaults.get_vault_by_name("alice", user.id).id
+    end
+
+    # A Teammate document is the whole teammate, unlike the other five kinds,
+    # where an absent spec key leaves the column alone. Dropping `environment`
+    # therefore puts the teammate back on the agent's own environment.
+    test "dropping a Teammate's environment and vault clears the bindings", %{user: user} do
+      inert_start_child()
+
+      bound = [
+        env_resource("proj"),
+        vault_resource("alice"),
+        agent_resource("ada"),
+        teammate_resource("Ada", %{
+          "agent" => "ada",
+          "environment" => "proj",
+          "vault" => "alice"
+        })
+      ]
+
+      {:ok, _} = Manifest.apply_manifest(user.id, bound)
+      assert [%{conversation: conv}] = Team.list_teammates(user.id)
+      assert conv.environment_id
+      assert conv.vault_id
+
+      unbound = List.replace_at(bound, 3, teammate_resource("Ada", %{"agent" => "ada"}))
+      {:ok, results} = Manifest.apply_manifest(user.id, unbound)
+
+      assert %{kind: "Teammate", action: :updated} = List.last(results)
+      assert [%{conversation: cleared}] = Team.list_teammates(user.id)
+      assert cleared.environment_id == nil
+      assert cleared.vault_id == nil
+
+      # And it settles: a third apply of the same file writes nothing.
+      {:ok, again} = Manifest.apply_manifest(user.id, unbound)
+      assert Enum.all?(again, &(&1.action == :unchanged))
+    end
+
+    test "a Teammate naming an unknown agent, environment or vault fails only its own row",
+         %{user: user} do
+      inert_start_child()
+
+      {:ok, results} =
+        Manifest.apply_manifest(user.id, [
+          agent_resource("ada"),
+          teammate_resource("no-agent", %{"agent" => "ghost"}),
+          teammate_resource("no-env", %{"agent" => "ada", "environment" => "ghost"}),
+          teammate_resource("no-vault", %{"agent" => "ada", "vault" => "ghost"}),
+          teammate_resource("nameless", %{}),
+          teammate_resource("Ada", %{"agent" => "ada"})
+        ])
+
+      assert [
+               %{kind: "Agent", name: "ada", action: :created},
+               %{name: "no-agent", action: :error, errors: agent_errors},
+               %{name: "no-env", action: :error, errors: env_errors},
+               %{name: "no-vault", action: :error, errors: vault_errors},
+               %{name: "nameless", action: :error, errors: blank_errors},
+               %{name: "Ada", action: :created}
+             ] = results
+
+      assert agent_errors == %{"agent" => ["agent not found: ghost"]}
+      assert env_errors == %{"environment" => ["environment not found: ghost"]}
+      assert vault_errors == %{"vault" => ["vault not found: ghost"]}
+      assert blank_errors == %{"agent" => ["can't be blank"]}
+
+      assert [%{name: "Ada"}] = Team.list_teammates(user.id)
+    end
+
+    test "a Teammate cannot resolve another tenant's agent", %{user: user} do
+      other = insert_verified_user()
+      insert_agent(user_id: other.id, name: "theirs")
+
+      {:ok, [%{kind: "Teammate", action: :error, errors: errors}]} =
+        Manifest.apply_manifest(user.id, [teammate_resource("T", %{"agent" => "theirs"})])
+
+      assert errors == %{"agent" => ["agent not found: theirs"]}
+      assert Team.list_teammates(user.id) == []
+    end
+
+    test "unknown spec keys on a Teammate are rejected", %{user: user} do
+      {:ok, [teammate]} =
+        Manifest.apply_manifest(user.id, [
+          teammate_resource("t", %{"agent" => "a", "environmnet" => "x"})
+        ])
+
+      assert teammate.errors == %{"environmnet" => ["is not a supported spec key"]}
+      assert Team.list_teammates(user.id) == []
     end
   end
 end

--- a/cli/internal/cmd/apply.go
+++ b/cli/internal/cmd/apply.go
@@ -75,10 +75,11 @@ func runApply(cmd *cobra.Command, args []string) error {
 
 // applyKindOrder is the order the server reconciles in, and the order the
 // payload is built in so the printed output reads the same way. A document
-// may name another whatever the file's order — an agent's `spec.environment`
-// — and the server resolves it by name, including against records that
-// already exist and are not part of this manifest.
-var applyKindOrder = []string{"Environment", "Vault", "Agent"}
+// may name another whatever the file's order: an agent's `spec.environment`,
+// a teammate's `spec.agent`/`environment`/`vault`. The server resolves each by
+// name, including against records that already exist and are not part of this
+// manifest.
+var applyKindOrder = []string{"Environment", "Vault", "Agent", "Teammate"}
 
 // applyResource is one compiled manifest document. The whole manifest is
 // sent to POST /api/apply in a single request.
@@ -183,10 +184,21 @@ func formatResultErrors(errs map[string]any) string {
 
 // legacyApply is the pre-bulk reconciliation path: one GET+write per
 // resource and one POST per secret. Kept for servers without /api/apply.
+//
+// A server that has no /api/apply also has none of the kinds beyond the first
+// three, so those are reported rather than reconciled: the run failed to do
+// what the manifest asked.
 func legacyApply(c *api.Client, grouped map[string][]*manifest.Doc) {
 	envs, vaults, agents := grouped["Environment"], grouped["Vault"], grouped["Agent"]
 	envIDByName := map[string]string{}
 	anyFailed := false
+
+	for _, kind := range applyKindOrder[3:] {
+		for _, d := range grouped[kind] {
+			anyFailed = true
+			warnf("%s  !  %s: this server is too old to apply %s documents", strings.ToLower(kind), d.Name(), kind)
+		}
+	}
 
 	for _, d := range envs {
 		if envID, ok := applyEnvironment(c, d); ok {

--- a/cli/internal/cmd/apply_test.go
+++ b/cli/internal/cmd/apply_test.go
@@ -30,6 +30,7 @@ func TestBuildApplyPayloadOrdersAndStrips(t *testing.T) {
 			"runtime":     "claude",
 			"environment": "proj",
 		})},
+		"Teammate": {doc("Teammate", "Ada", map[string]any{"agent": "researcher"})},
 	}
 
 	// Payload order is the reconciliation order, whatever order the manifest
@@ -75,6 +76,7 @@ func TestGroupDocsBucketsEveryKind(t *testing.T) {
 	docs := []*manifest.Doc{
 		doc("Agent", "a", nil),
 		doc("Cluster", "nope", nil),
+		doc("Teammate", "Ada", nil),
 		doc("Environment", "e", nil),
 		doc("Vault", "v", nil),
 	}

--- a/cli/internal/manifest/examples_test.go
+++ b/cli/internal/manifest/examples_test.go
@@ -25,7 +25,12 @@ func TestExamplesParse(t *testing.T) {
 		t.Fatal("no .yml/.yaml files under examples/")
 	}
 
-	knownKinds := map[string]bool{"Environment": true, "Vault": true, "Agent": true}
+	knownKinds := map[string]bool{
+		"Environment": true,
+		"Vault":       true,
+		"Agent":       true,
+		"Teammate":    true,
+	}
 	total := 0
 	checked := 0
 	for _, f := range files {

--- a/docs/api.md
+++ b/docs/api.md
@@ -158,6 +158,37 @@ resources. The CLI compiles the manifest and submits the resource graph.
 Inspect every resource result. One failed resource does not mean that all
 other writes failed.
 
+A manifest holds four kinds. Fountain reconciles them in a fixed order, which
+is `Environment`, `Vault`, `Agent` and `Teammate`. A document can name another
+document whatever its position in the file. An `Agent` names an
+`environment`. A `Teammate` names an `agent`, an `environment` and a `vault`.
+Each name resolves against the manifest first, then against the records the
+account already holds. A name that matches neither fails that document alone.
+
+A `Teammate` document is the whole teammate. Drop `environment` or `vault`
+from it and the apply clears that binding, which puts the teammate back on
+the agent's own environment and on no vault. The other three kinds behave the
+other way around, where an absent `spec` key leaves that field alone.
+
+Rebinding a teammate moves its computer. Fountain retires the machine the old
+binding named, so the next message builds one from the new environment and
+vault. It refuses the whole row while a turn is running on that machine. A
+conversation that shared the retired machine, and that names a different
+environment or vault, does not follow the teammate onto the new one. It
+builds a machine from what it names on its own next message.
+
+Fountain keeps one machine for each agent, environment and vault. The row
+fails when the agent already has one on the environment and vault the
+teammate moves to. Fountain does not join the teammate to that machine.
+Reset or delete the machine first, then apply again.
+
+Apply is additive. A document that you delete from the manifest leaves its
+record in place. There is no prune.
+
+The audit trail names each applied row. Teammate rows record
+`team.member.added` and `team.updated`. Each row carries the actor and the IP
+address of the request that applied it.
+
 Each result row reports `created`, `updated`, `unchanged` or `error`. A
 second apply of an unchanged manifest reports `unchanged` for every row, and
 writes no audit event for those rows. Inline `spec.secrets` are encrypted

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -317,7 +317,8 @@ fountain apply -f dir/ --var REGION=eu-west-1 # ${VAR} substitution, repeatable
 ```
 
 Apply is idempotent. It creates what is new, and updates what changed. It
-supports three kinds, which are `Environment`, `Vault` and `Agent`.
+supports four kinds, which are `Environment`, `Vault`, `Agent` and
+`Teammate`.
 
 `--var` and `${VAR}` substitution apply to a `spec.secrets` value alone. A
 `${VAR}` anywhere else in the document goes across as it stands. A
@@ -326,9 +327,53 @@ supports three kinds, which are `Environment`, `Vault` and `Agent`.
 The CLI compiles each document into one manifest, and sends that to
 `POST /api/apply` in one request.
 
-The server reconciles the environments, then the vaults, then the agents. It
-resolves an agent's `environment:` name reference, and that includes an
-environment that already exists on the server.
+The server reconciles the four kinds in the order above. A document can name
+another document whatever its position in the file. An `Agent` names an
+`environment`. A `Teammate` names an `agent`, an `environment` and a `vault`.
+Each name resolves against the manifest first, then against the records your
+account already holds.
+
+```yaml
+---
+apiVersion: fountain/v1
+kind: Teammate
+metadata:
+  name: Ada
+spec:
+  agent: ada             # an Agent document, or an agent you already have
+  environment: my-project
+  vault: alice
+```
+
+A `Teammate` document adds the agent to the team, which opens the teammate's
+conversation and starts its computer. A later apply moves the name, the
+environment and the vault the teammate is bound to. It starts no second
+computer.
+
+A `Teammate` document is the whole teammate. Drop `environment` or `vault`
+from it and the next apply clears that binding, which puts the teammate back
+on the agent's own environment and on no vault. The other three kinds behave
+the other way around, where an absent `spec` key leaves that field alone.
+
+A teammate's computer is built for one environment and one vault. Move either
+of them and Fountain retires that computer, so the teammate's next message
+builds a new one with the files and tools of a fresh machine. It refuses the
+row while a turn is still running there, and prints what to do about it. A
+conversation that shared the retired computer, and that names a different
+environment or vault, does not follow the teammate. It builds a machine of
+its own from what it names.
+
+Fountain keeps one computer for each agent, environment and vault. It refuses
+the row when the agent already has a computer on the environment and vault
+you are moving the teammate to. It does not join the teammate to that
+computer. Reset or remove the computer first, then apply again.
+
+Two `Teammate` documents cannot name the same agent. An agent is on the team
+once, so the second document fails and the first one applies.
+
+Apply is additive. A document that you delete from the manifest leaves its
+record in place. There is no prune, so delete a record through its own
+command or the console.
 
 The CLI prints `+` for a create, `~` for an update, `=` for a resource that
 already matched the manifest, and `!` for a failure. A second apply of the
@@ -341,7 +386,8 @@ errors and exits nonzero; valid resources in the same manifest still apply.
 Correct a misspelled field before you retry.
 
 Against an older server with no `/api/apply`, the CLI falls back to one call
-for each resource.
+for each resource. That older server has no `Teammate` document, so the CLI
+reports those and exits nonzero.
 
 ### Secret references
 

--- a/sdk/contract/contract.json
+++ b/sdk/contract/contract.json
@@ -10889,6 +10889,7 @@
           "enum": [
             "Agent",
             "Environment",
+            "Teammate",
             "Vault"
           ],
           "required": true,

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -559,7 +559,7 @@ export interface paths {
         put?: never;
         /**
          * Apply a compiled manifest (bulk upsert)
-         * @description Applies all resources from a compiled fountain.yml manifest in one request. Resources are reconciled by name — environments first, then vaults, then agents — so agent specs may reference an environment by name via `spec.environment`. Application is best-effort per resource: the response is 200 even when individual resources fail, with per-resource errors in the result entries.
+         * @description Applies all resources from a compiled fountain.yml manifest in one request. Resources are reconciled in a fixed order — environments, vaults, agents, teammates — so a spec may name another document whatever the file's order: an agent's `environment`, and a teammate's `agent`, `environment` and `vault`. Every kind is keyed by the document's `name`. A `Teammate` is read as a whole declaration, so an absent `environment` or `vault` clears that binding, and moving either retires the computer the old binding named (refused with an error on that row while a turn is running on it). Two Teammate documents may not name the same agent. Apply is additive: a document dropped from the manifest leaves its record in place. Application is best-effort per resource: the response is 200 even when an individual resource fails validation, is refused by its context or raises, with per-resource errors in the result entries.
          */
         post: operations["FountainWeb.ApplyController.create"];
         delete?: never;
@@ -3909,11 +3909,11 @@ export interface components {
         };
         /**
          * ManifestResource
-         * @description One compiled document from a fountain.yml manifest. `spec` matches the create/update schema for the kind, plus an inline `secrets` map (Environment and Vault). Agent specs may reference an environment by name via `environment`; the server resolves it to `environment_id`.
+         * @description One compiled document from a fountain.yml manifest. `spec` matches the create/update schema for the kind, plus an inline `secrets` map (Environment and Vault). Specs reference other documents by name, and the server resolves each to an id: an Agent's `environment`, and a Teammate's `agent`, `environment` and `vault`. Teammate specs take `agent`, `environment` and `vault`, and a Teammate document is read as a whole declaration, so an absent `environment` or `vault` clears that binding.
          */
         ManifestResource: {
             /** @enum {string} */
-            kind: "Environment" | "Vault" | "Agent";
+            kind: "Environment" | "Vault" | "Agent" | "Teammate";
             name: string;
             spec?: {
                 [key: string]: unknown;


### PR DESCRIPTION
`POST /api/apply` reconciled `Environment`, `Vault` and `Agent`. Putting an
agent on the team was a separate call afterwards, so a checked-in manifest
could not declare who the team is.

A `Teammate` document does that. It is keyed by the document name, which is
what the teammate is called; `agent`, `environment` and `vault` resolve by
name, against the manifest first and then against the tenant's own records,
the way an Agent's `environment` already did. Adding one opens the teammate's
conversation through `Fountain.Team.add_teammate/4`; re-applying goes through
`Fountain.Team.update_teammate/4` (the PR before this one) and provisions no
second computer.

Three refusals are worth calling out, each failing its own row and no other:

- **A `Teammate` document is the whole teammate.** Unlike the other kinds,
  where an absent `spec` key leaves that column alone, dropping `environment`
  or `vault` clears that binding. That is what makes the document a
  declaration rather than a patch, and it is said in all three places a reader
  looks.
- **Two documents may not name the same agent.** A teammate is one agent's
  membership of the team, so two documents describe one record: without this
  the second renames the first's conversation on every pass and the manifest
  is never idempotent. Two documents sharing a *name* are refused for the same
  reason.
- **A reference that resolves to nothing fails.** Including another tenant's
  agent, which resolves to nothing here by construction.

Result-row error keys are strings now whichever branch produced them.
`traverse_errors/2` keys by field atom while the hand-built refusals key by
string, and a caller reading a row should not have to know which one it got.
The wire shape does not change; JSON stringifies either.

Sixth of eight PRs toward #1636. #1675 is the combined branch and stays open
as the reference until the stack is in.

Validation: `mix precommit`, `go test ./...` in `cli/`, the SDK contract check
and the TypeScript verifier. The SDK version bump for the whole stack lands in
the last PR, so no publish happens here.

---

**The stack** (each PR is based on the one above it; review and merge top down):

1. `stack/1680-unchanged-verdict` — a save that changes nothing records nothing (#1680)
2. `stack/1636-apply-isolation` — a raise in one apply document fails that row
3. `stack/1636-cotenant-identity` — a co-tenant follows a replacement only if it declared the same identity
4. `stack/1636-update-teammate` — Team.update_teammate/4
5. `stack/1636-cli-group-by-kind` — CLI: group apply documents by kind
6. `stack/1636-teammate-kind` — apply reconciles Teammate documents ← **this one**
7. `stack/1636-schedule-kind` — apply reconciles Schedule documents
8. `stack/1636-webhook-kind` — apply reconciles Webhook documents (#1636)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WQyc3wWWDAeZJE1Vr6etQa