### PR TITLE
feat(api): bulk apply reconciles Schedule documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ upgrade, is in
   existing launches retain `owner` behavior. Applications processing mutually
   untrusted work can keep all Fountain API authority on their service host.
 
+- A `fountain apply` manifest can declare a teammate's schedules. A `Schedule`
+  document names its teammate, its cron and its prompt, and is keyed by name
+  under that teammate. A teammate name that two teammates answer to fails that
+  row rather than binding to one of them (#1636).
+
 - A `fountain apply` manifest can declare team membership. A `Teammate`
   document names its agent, environment and vault, and the apply puts the agent
   on the team, which opens its conversation and provisions its computer.

--- a/apps/fountain/lib/fountain/manifest.ex
+++ b/apps/fountain/lib/fountain/manifest.ex
@@ -4,11 +4,12 @@ defmodule Fountain.Manifest do
 
   Takes the full list of resources the CLI compiled from a `fountain.yml`
   and reconciles them against the tenant's records in one pass, in a fixed
-  order: environments, vaults, agents, teammates. The
+  order: environments, vaults, agents, teammates, schedules, webhooks. The
   order is what lets a document reference another by name regardless of
   where it sits in the file. An Agent's `environment`, a Teammate's `agent`,
-  `environment` and `vault` all resolve against the documents applied earlier
-  in this manifest first, then against the tenant's existing records.
+  `environment` and `vault`, and a Schedule's `teammate` all resolve against
+  the documents applied earlier in this manifest first, then against the
+  tenant's existing records.
 
   Each kind has its own upsert key:
 
@@ -18,6 +19,7 @@ defmodule Fountain.Manifest do
   | `Vault` | `name` | `Fountain.Vaults` |
   | `Agent` | `name` | `Fountain.Agents` |
   | `Teammate` | `name`, which names the agent's membership | `Fountain.Team` |
+  | `Schedule` | `name`, under its `teammate` | `Fountain.Team.Schedules` |
 
   A teammate is one agent's membership of the team, so the document's `name`
   is what the teammate is called and the resolved `agent` is what it
@@ -45,10 +47,11 @@ defmodule Fountain.Manifest do
   require Logger
 
   alias Fountain.{Agents, Crypto, Environments, Team, Vaults}
+  alias Fountain.Team.Schedules
 
   @unexpected "apply failed unexpectedly; see the server log"
 
-  @kinds ~w(Environment Vault Agent Teammate)
+  @kinds ~w(Environment Vault Agent Teammate Schedule)
 
   def kinds, do: @kinds
 
@@ -60,7 +63,7 @@ defmodule Fountain.Manifest do
   Apply `resources` (maps with `"kind"`, `"name"`, and `"spec"`) for `user_id`.
 
   Returns `{:ok, results}` with one result map per resource in apply order
-  (the 4 kinds in the order above, then any malformed entries). Each result
+  (the 5 kinds in the order above, then any malformed entries). Each result
   holds `:kind`, `:name`, an `:action` of `:created` / `:updated` /
   `:unchanged` / `:error`, changeset-style `:errors` when the action is
   `:error`, a `:secrets` list with the per-key upsert outcome, the
@@ -79,6 +82,7 @@ defmodule Fountain.Manifest do
     vaults = Map.get(groups, "Vault", [])
     agents = Map.get(groups, "Agent", [])
     teammates = Map.get(groups, "Teammate", [])
+    schedules = Map.get(groups, "Schedule", [])
 
     dek = if Enum.any?(envs ++ vaults, &has_secrets?/1), do: load_dek!(user_id)
 
@@ -95,9 +99,16 @@ defmodule Fountain.Manifest do
 
     refs = %{agents: agent_ids, environments: env_ids, vaults: vault_ids}
 
-    {teammate_results, _teammate_ids} =
+    {teammate_results, teammate_ids} =
       reconcile("Teammate", teammates, fn res, claimed ->
         apply_teammate(user_id, res, refs, claimed, opts)
+      end)
+
+    known_teammates = teammate_refs(user_id, schedules, teammate_ids)
+
+    {schedule_results, _} =
+      reconcile("Schedule", schedules, fn res, _claimed ->
+        apply_schedule(user_id, res, known_teammates, opts)
       end)
 
     results =
@@ -105,6 +116,7 @@ defmodule Fountain.Manifest do
         vault_results ++
         agent_results ++
         teammate_results ++
+        schedule_results ++
         Enum.map(invalid, &invalid_result/1)
 
     {:ok, results}
@@ -314,6 +326,40 @@ defmodule Fountain.Manifest do
     end
   end
 
+  defp apply_schedule(user_id, %{"name" => name} = res, known_teammates, opts) do
+    spec = spec_of(res)
+
+    with :ok <- validate_keys(res, ~w(name teammate cron prompt one_off enabled)),
+         {:ok, agent_id} <- require_ref("teammate", user_id, spec["teammate"], known_teammates) do
+      attrs =
+        spec
+        |> Map.drop(~w(teammate))
+        |> Map.merge(%{"name" => name, "agent_id" => agent_id})
+
+      reconcile_schedule(user_id, name, agent_id, attrs, opts)
+    else
+      {:error, errors} -> {result("Schedule", name, :error, errors, []), nil}
+    end
+  end
+
+  defp reconcile_schedule(user_id, name, agent_id, attrs, opts) do
+    existing =
+      user_id |> Schedules.list_schedules(agent_id) |> Enum.find(&(&1.name == name))
+
+    outcome =
+      if existing,
+        do: Schedules.update_schedule(existing, attrs, opts),
+        else: Schedules.create_schedule(user_id, attrs, opts)
+
+    case outcome do
+      {:ok, schedule} ->
+        {result("Schedule", name, verdict(existing, schedule), nil, [], schedule.id), nil}
+
+      {:error, reason} ->
+        {result("Schedule", name, :error, context_errors(reason), []), nil}
+    end
+  end
+
   # ── references ────────────────────────────────────────────────────────────
 
   # Resolve a `<field>: <name>` reference: documents applied earlier in this
@@ -325,6 +371,9 @@ defmodule Fountain.Manifest do
   defp resolve_ref(field, user_id, ref, ids) when is_binary(ref) do
     case ids[ref] || tenant_ref(field, user_id, ref) do
       nil -> {:error, %{field => ["#{field} not found: #{ref}"]}}
+      # Two teammates answer to this name, so the document does not say which
+      # record it means. Guessing would bind a schedule to the wrong agent.
+      :ambiguous -> {:error, %{field => ["#{field} name is not unique: #{ref}"]}}
       id -> {:ok, id}
     end
   end
@@ -343,9 +392,31 @@ defmodule Fountain.Manifest do
 
   defp tenant_ref("vault", user_id, name), do: id_of(Vaults.get_vault_by_name(name, user_id))
   defp tenant_ref("agent", user_id, name), do: id_of(Agents.get_agent_by_name(name, user_id))
+  defp tenant_ref("teammate", _user_id, _name), do: nil
 
   defp id_of(nil), do: nil
   defp id_of(record), do: record.id
+
+  # The teammates a Schedule may name: the ones this manifest just reconciled,
+  # over the ones the tenant already has. Skipped entirely when the manifest
+  # holds no schedules, because listing the team is several queries.
+  #
+  # A teammate's name is its conversation's title, or its agent's name, and
+  # neither is unique. A name two of the tenant's teammates answer to maps to
+  # `:ambiguous` and fails the Schedule row that uses it; a name this manifest
+  # reconciled is unique among the documents (`unclaimed/3`) and wins.
+  defp teammate_refs(_user_id, [], teammate_ids), do: teammate_ids
+
+  defp teammate_refs(user_id, _schedules, teammate_ids) do
+    user_id
+    |> Team.list_teammates()
+    |> Enum.group_by(& &1.name, & &1.agent.id)
+    |> Map.new(fn
+      {name, [agent_id]} -> {name, agent_id}
+      {name, _several} -> {name, :ambiguous}
+    end)
+    |> Map.merge(teammate_ids)
+  end
 
   # ── secrets ───────────────────────────────────────────────────────────────
 

--- a/apps/fountain/lib/fountain_web/controllers/apply_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/apply_controller.ex
@@ -19,9 +19,10 @@ defmodule FountainWeb.ApplyController do
     description:
       "Applies all resources from a compiled fountain.yml manifest in one request. " <>
         "Resources are reconciled in a fixed order — environments, vaults, agents, " <>
-        "teammates — so a spec may name another document whatever the file's " <>
-        "order: an agent's `environment`, and a teammate's `agent`, `environment` " <>
-        "and `vault`. Every kind is keyed by the document's `name`. A `Teammate` " <>
+        "teammates, schedules — so a spec may name another document whatever the " <>
+        "file's order: an agent's `environment`, a teammate's `agent`, " <>
+        "`environment` and `vault`, and a schedule's `teammate`. Every kind is " <>
+        "keyed by the document's `name`. A `Teammate` " <>
         "is read as a whole declaration, so an absent `environment` or `vault` " <>
         "clears that binding, and moving either retires the computer the old " <>
         "binding named (refused with an error on that row while a turn is running " <>

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -3123,14 +3123,19 @@ defmodule FountainWeb.Schemas do
         "One compiled document from a fountain.yml manifest. `spec` matches the " <>
           "create/update schema for the kind, plus an inline `secrets` map " <>
           "(Environment and Vault). Specs reference other documents by name, and " <>
-          "the server resolves each to an id: an Agent's `environment`, and a " <>
-          "Teammate's `agent`, `environment` and `vault`. Teammate specs take " <>
-          "`agent`, `environment` and `vault`, and a Teammate document is read " <>
-          "as a whole declaration, so an absent `environment` or `vault` clears " <>
-          "that binding.",
+          "the server resolves each to an id: an Agent's `environment`, a " <>
+          "Teammate's `agent`, `environment` and `vault`, and a Schedule's " <>
+          "`teammate`. Teammate specs take `agent`, `environment` and `vault`, " <>
+          "and a Teammate document is read as a whole declaration, so an absent " <>
+          "`environment` or `vault` clears that binding. Schedule specs take " <>
+          "`teammate` plus the TeamScheduleCreateRequest fields `cron`, " <>
+          "`prompt`, `one_off` and `enabled`.",
       type: :object,
       properties: %{
-        kind: %Schema{type: :string, enum: ["Environment", "Vault", "Agent", "Teammate"]},
+        kind: %Schema{
+          type: :string,
+          enum: ["Environment", "Vault", "Agent", "Teammate", "Schedule"]
+        },
         name: %Schema{type: :string, minLength: 1, maxLength: 200},
         spec: %Schema{type: :object, additionalProperties: true}
       },

--- a/apps/fountain/priv/help/manifest.md
+++ b/apps/fountain/priv/help/manifest.md
@@ -8,7 +8,7 @@ A `fountain.yml` is a multi-document YAML file. Each doc is one resource with th
 
 ```yaml
 apiVersion: fountain/v1
-kind: Environment | Vault | Agent | Teammate
+kind: Environment | Vault | Agent | Teammate | Schedule
 metadata:
   name: <unique-on-operator-side>
 spec:
@@ -19,15 +19,16 @@ The `metadata.name` is the upsert key. If a resource with that name exists, it's
 
 ## Order is irrelevant inside the file
 
-`fountain apply` reconciles in a fixed order: **environments, vaults, agents, teammates** — so a doc can reference another by name even if that one is defined later in the file. An `Agent` references an `environment`; a `Teammate` references an `agent`, an `environment` and a `vault`. Every reference resolves against the manifest first and then against what **already exists** server-side, so a manifest can attach an agent to an environment managed elsewhere; a name that matches neither fails that doc and no other.
+`fountain apply` reconciles in a fixed order: **environments, vaults, agents, teammates, schedules** — so a doc can reference another by name even if that one is defined later in the file. An `Agent` references an `environment`; a `Teammate` references an `agent`, an `environment` and a `vault`; a `Schedule` references a `teammate`. Every reference resolves against the manifest first and then against what **already exists** server-side, so a manifest can attach an agent to an environment managed elsewhere; a name that matches neither fails that doc and no other.
 
 ## The team kinds
 
-A `Teammate` puts an agent on the team, which opens its conversation and provisions its computer. Re-applying moves what the teammate is called and which environment and vault it is bound to — it never provisions a second one, and it never resurrects a computer that is gone (message the teammate for that).
+A `Teammate` puts an agent on the team, which opens its conversation and provisions its computer. Re-applying moves what the teammate is called and which environment and vault it is bound to — it never provisions a second one, and it never resurrects a computer that is gone (message the teammate for that). A `Schedule` is a cron that runs a teammate with a prompt, keyed by its name under its teammate.
 
 Two things about it that surprise people:
 
-- **A `Teammate` doc is the whole teammate.** Unlike the other three kinds, where an absent `spec` key leaves that column alone, dropping `environment` or `vault` from a Teammate doc *clears* that binding — back to the agent's own environment and no vault. That is what makes the doc a declaration rather than a patch.
+- **A `Teammate` doc is the whole teammate.** Unlike the other four kinds, where an absent `spec` key leaves that column alone, dropping `environment` or `vault` from a Teammate doc *clears* that binding — back to the agent's own environment and no vault. That is what makes the doc a declaration rather than a patch.
+- **A teammate's name is not unique.** It is the conversation's title, or the agent's name. A `Schedule` naming a teammate that two of them answer to fails rather than binding to whichever the roster listed last; one this manifest reconciled is unique among the docs and wins.
 - **Rebinding moves the computer.** A home is keyed on `(user, agent, environment, vault)`, so changing either id retires the machine the old key named; the teammate's next message builds a fresh one. Refused with an error on that row while a turn is still running there — the same refusal `Agent`'s `environment` gives (#1084). A conversation that *shared* that machine and names a different environment or vault does not follow the teammate; it builds its own on its next prompt. And because there is only ever one home per identity, a rebind onto an identity the agent **already** has a home for is **refused**, not merged onto that home — reset or remove the existing one first (#1636).
 
 **Two Teammate docs can't name the same agent.** An agent is on the team once, so the second doc fails and the first applies.
@@ -42,6 +43,18 @@ spec:
   agent: researcher
   environment: my-project
   vault: alice
+
+---
+apiVersion: fountain/v1
+kind: Schedule
+metadata:
+  name: standup
+spec:
+  teammate: Ada
+  cron: "0 9 * * 1-5"          # five fields, UTC
+  prompt: What is on today?
+  one_off: false
+  enabled: true
 ```
 
 ## Nothing is pruned
@@ -50,7 +63,7 @@ Apply is additive. Deleting a doc from the manifest leaves its record in place; 
 
 ## What the trail says
 
-Each applied row leaves its context's own audit event, with the actor and IP of the request that applied it: `team.member.added` / `team.updated` for a Teammate. An `unchanged` row writes nothing at all.
+Each applied row leaves its context's own audit event, with the actor and IP of the request that applied it: `team.member.added` / `team.updated` for a Teammate, and `team.schedule.created` / `team.schedule.updated` for a Schedule. An `unchanged` row writes nothing at all.
 
 ## Example
 

--- a/apps/fountain/test/fountain/manifest_test.exs
+++ b/apps/fountain/test/fountain/manifest_test.exs
@@ -3,6 +3,7 @@ defmodule Fountain.ManifestTest do
   use Mimic
 
   alias Fountain.{Agents, Audit, Conversations, Crypto, Environments, Manifest, Team, Vaults}
+  alias Fountain.Team.Schedules
 
   setup do
     # No starter agent (ADR 0038): every assertion here counts what the
@@ -16,6 +17,10 @@ defmodule Fountain.ManifestTest do
 
   defp vault_resource(name, spec \\ %{}) do
     %{"kind" => "Vault", "name" => name, "spec" => spec}
+  end
+
+  defp schedule_resource(name, spec) do
+    %{"kind" => "Schedule", "name" => name, "spec" => spec}
   end
 
   defp teammate_resource(name, spec) do
@@ -370,6 +375,11 @@ defmodule Fountain.ManifestTest do
       # Deliberately out of order: the kinds reconcile in a fixed order,
       # whatever the file says.
       [
+        schedule_resource("standup", %{
+          "teammate" => "Ada",
+          "cron" => "0 9 * * 1-5",
+          "prompt" => "What is on today?"
+        }),
         teammate_resource("Ada", %{
           "agent" => "ada",
           "environment" => "proj",
@@ -381,7 +391,7 @@ defmodule Fountain.ManifestTest do
       ]
     end
 
-    test "the four kinds apply in one request, and a second apply changes nothing",
+    test "the five kinds apply in one request, and a second apply changes nothing",
          %{user: user} do
       inert_start_child()
       resources = estate_manifest()
@@ -392,7 +402,8 @@ defmodule Fountain.ManifestTest do
                {"Environment", "proj", :created},
                {"Vault", "alice", :created},
                {"Agent", "ada", :created},
-               {"Teammate", "Ada", :created}
+               {"Teammate", "Ada", :created},
+               {"Schedule", "standup", :created}
              ]
 
       env = Environments.get_environment_by_name("proj", user.id)
@@ -406,13 +417,17 @@ defmodule Fountain.ManifestTest do
       assert conv.environment_id == env.id
       assert conv.vault_id == vault.id
 
+      assert [%{name: "standup", cron: "0 9 * * 1-5", one_off: false, enabled: true}] =
+               Schedules.list_schedules(user.id, agent.id)
+
       {:ok, second} = Manifest.apply_manifest(user.id, resources)
 
-      assert Enum.map(second, & &1.action) == List.duplicate(:unchanged, 4)
+      assert Enum.map(second, & &1.action) == List.duplicate(:unchanged, 5)
       assert Enum.map(second, & &1.kind) == Enum.map(first, & &1.kind)
 
       # Nothing was duplicated by the second pass.
       assert length(Team.list_teammates(user.id)) == 1
+      assert length(Schedules.list_schedules(user.id, agent.id)) == 1
     end
 
     test "the applied rows are audited with the request's attribution", %{user: user} do
@@ -425,8 +440,9 @@ defmodule Fountain.ManifestTest do
       actions = Enum.map(events, & &1.action)
 
       assert "team.member.added" in actions
+      assert "team.schedule.created" in actions
 
-      for action <- ~w(team.member.added) do
+      for action <- ~w(team.member.added team.schedule.created) do
         event = Enum.find(events, &(&1.action == action))
         assert event.actor == "api", "#{action} was recorded as #{event.actor}"
         assert to_string(event.request_ip) == "203.0.113.5"
@@ -460,7 +476,12 @@ defmodule Fountain.ManifestTest do
         env_resource("proj", %{"setup_script" => "echo hi"}),
         vault_resource("alice"),
         agent_resource("ada", %{"environment" => "proj"}),
-        teammate_resource("Ada of proj", %{"agent" => "ada", "environment" => "proj"})
+        teammate_resource("Ada of proj", %{"agent" => "ada", "environment" => "proj"}),
+        schedule_resource("standup", %{
+          "teammate" => "Ada of proj",
+          "cron" => "@daily",
+          "prompt" => "What is on today?"
+        })
       ]
 
       {:ok, results} = Manifest.apply_manifest(user.id, moved, opts)
@@ -469,13 +490,14 @@ defmodule Fountain.ManifestTest do
                {"Environment", :unchanged},
                {"Vault", :unchanged},
                {"Agent", :unchanged},
-               {"Teammate", :updated}
+               {"Teammate", :updated},
+               {"Schedule", :updated}
              ]
 
       events = Audit.list_recent_for_user(user.id, 500)
       added = Enum.take(events, length(events) - before)
 
-      for action <- ~w(team.updated) do
+      for action <- ~w(team.updated team.schedule.updated) do
         event = Enum.find(added, &(&1.action == action))
 
         assert event,
@@ -737,6 +759,115 @@ defmodule Fountain.ManifestTest do
 
       assert teammate.errors == %{"environmnet" => ["is not a supported spec key"]}
       assert Team.list_teammates(user.id) == []
+    end
+
+    test "a Schedule naming a teammate two of them answer to fails that row", %{user: user} do
+      inert_start_child()
+      one = insert_agent(user_id: user.id, name: "one")
+      two = insert_agent(user_id: user.id, name: "two")
+      {:ok, _} = Team.add_teammate(user.id, one.id, %{"name" => "Ada"})
+      {:ok, _} = Team.add_teammate(user.id, two.id, %{"name" => "Ada"})
+
+      {:ok, [%{kind: "Schedule", action: :error, errors: errors}]} =
+        Manifest.apply_manifest(user.id, [
+          schedule_resource("s", %{"teammate" => "Ada", "cron" => "@daily", "prompt" => "x"})
+        ])
+
+      assert errors == %{"teammate" => ["teammate name is not unique: Ada"]}
+    end
+
+    test "a Schedule may name a teammate the tenant already has", %{user: user} do
+      inert_start_child()
+      agent = insert_agent(user_id: user.id, name: "ada")
+      {:ok, _} = Team.add_teammate(user.id, agent.id, %{"name" => "Ada"})
+
+      {:ok, [%{kind: "Schedule", name: "nightly", action: :created}]} =
+        Manifest.apply_manifest(user.id, [
+          schedule_resource("nightly", %{
+            "teammate" => "Ada",
+            "cron" => "@daily",
+            "prompt" => "sweep",
+            "one_off" => true
+          })
+        ])
+
+      assert [%{name: "nightly", one_off: true}] = Schedules.list_schedules(user.id, agent.id)
+    end
+
+    test "a Schedule naming no teammate fails only its own row", %{user: user} do
+      {:ok, [good, bad]} =
+        Manifest.apply_manifest(user.id, [
+          vault_resource("v"),
+          schedule_resource("s", %{"teammate" => "ghost", "cron" => "@daily", "prompt" => "x"})
+        ])
+
+      assert good.action == :created
+      assert bad.action == :error
+      assert bad.errors == %{"teammate" => ["teammate not found: ghost"]}
+    end
+
+    test "an invalid cron fails with the same error the create route gives", %{user: user} do
+      inert_start_child()
+      agent = insert_agent(user_id: user.id, name: "ada")
+      {:ok, _} = Team.add_teammate(user.id, agent.id, %{"name" => "Ada"})
+
+      {:ok, [%{kind: "Schedule", action: :error, errors: errors}]} =
+        Manifest.apply_manifest(user.id, [
+          schedule_resource("bad", %{
+            "teammate" => "Ada",
+            "cron" => "not a cron",
+            "prompt" => "x"
+          })
+        ])
+
+      {:error, changeset} =
+        Schedules.create_schedule(user.id, %{
+          "agent_id" => agent.id,
+          "name" => "bad",
+          "cron" => "not a cron",
+          "prompt" => "x"
+        })
+
+      # Same content, keyed by string: an apply row's errors are string-keyed
+      # whichever branch produced them.
+      assert errors == Map.new(errors_on(changeset), fn {k, v} -> {to_string(k), v} end)
+      assert Map.has_key?(errors, "cron")
+      assert Schedules.list_schedules(user.id, agent.id) == []
+    end
+
+    test "re-applying a Schedule moves its cron, prompt, one_off and enabled", %{user: user} do
+      inert_start_child()
+      agent = insert_agent(user_id: user.id, name: "ada")
+      {:ok, _} = Team.add_teammate(user.id, agent.id, %{"name" => "Ada"})
+
+      apply_schedule = fn spec ->
+        Manifest.apply_manifest(user.id, [
+          schedule_resource("standup", Map.put(spec, "teammate", "Ada"))
+        ])
+      end
+
+      {:ok, [%{action: :created}]} = apply_schedule.(%{"cron" => "@daily", "prompt" => "a"})
+      {:ok, [%{action: :unchanged}]} = apply_schedule.(%{"cron" => "@daily", "prompt" => "a"})
+
+      {:ok, [%{action: :updated}]} =
+        apply_schedule.(%{
+          "cron" => "0 9 * * 1-5",
+          "prompt" => "b",
+          "one_off" => true,
+          "enabled" => false
+        })
+
+      assert [%{cron: "0 9 * * 1-5", prompt: "b", one_off: true, enabled: false}] =
+               Schedules.list_schedules(user.id, agent.id)
+    end
+
+    test "unknown spec keys on a Schedule are rejected", %{user: user} do
+      {:ok, [schedule]} =
+        Manifest.apply_manifest(user.id, [
+          schedule_resource("s", %{"teammate" => "t", "crn" => "@daily"})
+        ])
+
+      assert schedule.errors == %{"crn" => ["is not a supported spec key"]}
     end
   end
 end

--- a/cli/internal/cmd/apply.go
+++ b/cli/internal/cmd/apply.go
@@ -76,10 +76,10 @@ func runApply(cmd *cobra.Command, args []string) error {
 // applyKindOrder is the order the server reconciles in, and the order the
 // payload is built in so the printed output reads the same way. A document
 // may name another whatever the file's order: an agent's `spec.environment`,
-// a teammate's `spec.agent`/`environment`/`vault`. The server resolves each by
-// name, including against records that already exist and are not part of this
-// manifest.
-var applyKindOrder = []string{"Environment", "Vault", "Agent", "Teammate"}
+// a teammate's `spec.agent`/`environment`/`vault`, a schedule's
+// `spec.teammate`. The server resolves each by name, including against records
+// that already exist and are not part of this manifest.
+var applyKindOrder = []string{"Environment", "Vault", "Agent", "Teammate", "Schedule"}
 
 // applyResource is one compiled manifest document. The whole manifest is
 // sent to POST /api/apply in a single request.

--- a/cli/internal/cmd/apply_test.go
+++ b/cli/internal/cmd/apply_test.go
@@ -31,6 +31,7 @@ func TestBuildApplyPayloadOrdersAndStrips(t *testing.T) {
 			"environment": "proj",
 		})},
 		"Teammate": {doc("Teammate", "Ada", map[string]any{"agent": "researcher"})},
+		"Schedule": {doc("Schedule", "standup", map[string]any{"teammate": "Ada", "cron": "@daily"})},
 	}
 
 	// Payload order is the reconciliation order, whatever order the manifest
@@ -77,6 +78,7 @@ func TestGroupDocsBucketsEveryKind(t *testing.T) {
 		doc("Agent", "a", nil),
 		doc("Cluster", "nope", nil),
 		doc("Teammate", "Ada", nil),
+		doc("Schedule", "standup", nil),
 		doc("Environment", "e", nil),
 		doc("Vault", "v", nil),
 	}

--- a/cli/internal/manifest/examples_test.go
+++ b/cli/internal/manifest/examples_test.go
@@ -30,6 +30,7 @@ func TestExamplesParse(t *testing.T) {
 		"Vault":       true,
 		"Agent":       true,
 		"Teammate":    true,
+		"Schedule":    true,
 	}
 	total := 0
 	checked := 0

--- a/docs/api.md
+++ b/docs/api.md
@@ -158,16 +158,18 @@ resources. The CLI compiles the manifest and submits the resource graph.
 Inspect every resource result. One failed resource does not mean that all
 other writes failed.
 
-A manifest holds four kinds. Fountain reconciles them in a fixed order, which
-is `Environment`, `Vault`, `Agent` and `Teammate`. A document can name another
+A manifest holds five kinds. Fountain reconciles them in a fixed order, which
+is `Environment`, `Vault`, `Agent`, `Teammate` and `Schedule`. A document can name another
 document whatever its position in the file. An `Agent` names an
 `environment`. A `Teammate` names an `agent`, an `environment` and a `vault`.
-Each name resolves against the manifest first, then against the records the
+A `Schedule` names a `teammate`. A teammate's name is not unique, so a name
+that two teammates answer to fails that row rather than binding to one of
+them. Each name resolves against the manifest first, then against the records the
 account already holds. A name that matches neither fails that document alone.
 
 A `Teammate` document is the whole teammate. Drop `environment` or `vault`
 from it and the apply clears that binding, which puts the teammate back on
-the agent's own environment and on no vault. The other three kinds behave the
+the agent's own environment and on no vault. The other four kinds behave the
 other way around, where an absent `spec` key leaves that field alone.
 
 Rebinding a teammate moves its computer. Fountain retires the machine the old
@@ -186,8 +188,9 @@ Apply is additive. A document that you delete from the manifest leaves its
 record in place. There is no prune.
 
 The audit trail names each applied row. Teammate rows record
-`team.member.added` and `team.updated`. Each row carries the actor and the IP
-address of the request that applied it.
+`team.member.added` and `team.updated`, and schedule rows record
+`team.schedule.created` and `team.schedule.updated`. Each row carries the
+actor and the IP address of the request that applied it.
 
 Each result row reports `created`, `updated`, `unchanged` or `error`. A
 second apply of an unchanged manifest reports `unchanged` for every row, and

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -317,8 +317,8 @@ fountain apply -f dir/ --var REGION=eu-west-1 # ${VAR} substitution, repeatable
 ```
 
 Apply is idempotent. It creates what is new, and updates what changed. It
-supports four kinds, which are `Environment`, `Vault`, `Agent` and
-`Teammate`.
+supports five kinds, which are `Environment`, `Vault`, `Agent`, `Teammate`
+and `Schedule`.
 
 `--var` and `${VAR}` substitution apply to a `spec.secrets` value alone. A
 `${VAR}` anywhere else in the document goes across as it stands. A
@@ -327,10 +327,10 @@ supports four kinds, which are `Environment`, `Vault`, `Agent` and
 The CLI compiles each document into one manifest, and sends that to
 `POST /api/apply` in one request.
 
-The server reconciles the four kinds in the order above. A document can name
+The server reconciles the five kinds in the order above. A document can name
 another document whatever its position in the file. An `Agent` names an
-`environment`. A `Teammate` names an `agent`, an `environment` and a `vault`.
-Each name resolves against the manifest first, then against the records your
+`environment`. A `Teammate` names an `agent`, an `environment` and a `vault`. A `Schedule`
+names a `teammate`. Each name resolves against the manifest first, then against the records your
 account already holds.
 
 ```yaml
@@ -343,6 +343,18 @@ spec:
   agent: ada             # an Agent document, or an agent you already have
   environment: my-project
   vault: alice
+
+---
+apiVersion: fountain/v1
+kind: Schedule
+metadata:
+  name: standup
+spec:
+  teammate: Ada
+  cron: "0 9 * * 1-5"    # five fields, UTC
+  prompt: What is on today?
+  one_off: false
+  enabled: true
 ```
 
 A `Teammate` document adds the agent to the team, which opens the teammate's
@@ -352,7 +364,7 @@ computer.
 
 A `Teammate` document is the whole teammate. Drop `environment` or `vault`
 from it and the next apply clears that binding, which puts the teammate back
-on the agent's own environment and on no vault. The other three kinds behave
+on the agent's own environment and on no vault. The other four kinds behave
 the other way around, where an absent `spec` key leaves that field alone.
 
 A teammate's computer is built for one environment and one vault. Move either
@@ -371,6 +383,10 @@ computer. Reset or remove the computer first, then apply again.
 Two `Teammate` documents cannot name the same agent. An agent is on the team
 once, so the second document fails and the first one applies.
 
+A `Schedule` names its teammate. A teammate's name is not unique, so a name
+that two of your teammates answer to fails that row. Rename one of them, or
+name the teammate in the same manifest, which makes the name unambiguous.
+
 Apply is additive. A document that you delete from the manifest leaves its
 record in place. There is no prune, so delete a record through its own
 command or the console.
@@ -386,8 +402,8 @@ errors and exits nonzero; valid resources in the same manifest still apply.
 Correct a misspelled field before you retry.
 
 Against an older server with no `/api/apply`, the CLI falls back to one call
-for each resource. That older server has no `Teammate` document, so the CLI
-reports those and exits nonzero.
+for each resource. That older server has no `Teammate` or `Schedule`
+document, so the CLI reports those and exits nonzero.
 
 ### Secret references
 

--- a/sdk/contract/contract.json
+++ b/sdk/contract/contract.json
@@ -10889,6 +10889,7 @@
           "enum": [
             "Agent",
             "Environment",
+            "Schedule",
             "Teammate",
             "Vault"
           ],

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -559,7 +559,7 @@ export interface paths {
         put?: never;
         /**
          * Apply a compiled manifest (bulk upsert)
-         * @description Applies all resources from a compiled fountain.yml manifest in one request. Resources are reconciled in a fixed order — environments, vaults, agents, teammates — so a spec may name another document whatever the file's order: an agent's `environment`, and a teammate's `agent`, `environment` and `vault`. Every kind is keyed by the document's `name`. A `Teammate` is read as a whole declaration, so an absent `environment` or `vault` clears that binding, and moving either retires the computer the old binding named (refused with an error on that row while a turn is running on it). Two Teammate documents may not name the same agent. Apply is additive: a document dropped from the manifest leaves its record in place. Application is best-effort per resource: the response is 200 even when an individual resource fails validation, is refused by its context or raises, with per-resource errors in the result entries.
+         * @description Applies all resources from a compiled fountain.yml manifest in one request. Resources are reconciled in a fixed order — environments, vaults, agents, teammates, schedules — so a spec may name another document whatever the file's order: an agent's `environment`, a teammate's `agent`, `environment` and `vault`, and a schedule's `teammate`. Every kind is keyed by the document's `name`. A `Teammate` is read as a whole declaration, so an absent `environment` or `vault` clears that binding, and moving either retires the computer the old binding named (refused with an error on that row while a turn is running on it). Two Teammate documents may not name the same agent. Apply is additive: a document dropped from the manifest leaves its record in place. Application is best-effort per resource: the response is 200 even when an individual resource fails validation, is refused by its context or raises, with per-resource errors in the result entries.
          */
         post: operations["FountainWeb.ApplyController.create"];
         delete?: never;
@@ -3909,11 +3909,11 @@ export interface components {
         };
         /**
          * ManifestResource
-         * @description One compiled document from a fountain.yml manifest. `spec` matches the create/update schema for the kind, plus an inline `secrets` map (Environment and Vault). Specs reference other documents by name, and the server resolves each to an id: an Agent's `environment`, and a Teammate's `agent`, `environment` and `vault`. Teammate specs take `agent`, `environment` and `vault`, and a Teammate document is read as a whole declaration, so an absent `environment` or `vault` clears that binding.
+         * @description One compiled document from a fountain.yml manifest. `spec` matches the create/update schema for the kind, plus an inline `secrets` map (Environment and Vault). Specs reference other documents by name, and the server resolves each to an id: an Agent's `environment`, a Teammate's `agent`, `environment` and `vault`, and a Schedule's `teammate`. Teammate specs take `agent`, `environment` and `vault`, and a Teammate document is read as a whole declaration, so an absent `environment` or `vault` clears that binding. Schedule specs take `teammate` plus the TeamScheduleCreateRequest fields `cron`, `prompt`, `one_off` and `enabled`.
          */
         ManifestResource: {
             /** @enum {string} */
-            kind: "Environment" | "Vault" | "Agent" | "Teammate";
+            kind: "Environment" | "Vault" | "Agent" | "Teammate" | "Schedule";
             name: string;
             spec?: {
                 [key: string]: unknown;


### PR DESCRIPTION
A `Schedule` document declares a cron that runs a teammate with a prompt. It
is keyed by the document name under its `teammate`, and carries the
`TeamScheduleCreateRequest` fields, so it goes through
`Fountain.Team.Schedules` and an invalid cron fails with the create route's
own changeset error.

The one thing that needed a decision: a teammate's name is its conversation's
title, or its agent's name, and neither is unique. A name two of the tenant's
teammates answer to resolves to `:ambiguous` and fails the Schedule row that
used it, rather than binding to whichever the roster listed last. A name this
manifest reconciled is unique among the documents and wins over the tenant's.

The roster read is skipped entirely when the manifest holds no schedules,
because listing the team is several queries.

Seventh of eight PRs toward #1636. #1675 is the combined branch and stays open
as the reference until the stack is in.

Validation: `mix precommit`, `go test ./...` in `cli/`, the SDK contract check
and the TypeScript verifier.

---

**The stack** (each PR is based on the one above it; review and merge top down):

1. `stack/1680-unchanged-verdict` — a save that changes nothing records nothing (#1680)
2. `stack/1636-apply-isolation` — a raise in one apply document fails that row
3. `stack/1636-cotenant-identity` — a co-tenant follows a replacement only if it declared the same identity
4. `stack/1636-update-teammate` — Team.update_teammate/4
5. `stack/1636-cli-group-by-kind` — CLI: group apply documents by kind
6. `stack/1636-teammate-kind` — apply reconciles Teammate documents
7. `stack/1636-schedule-kind` — apply reconciles Schedule documents ← **this one**
8. `stack/1636-webhook-kind` — apply reconciles Webhook documents (#1636)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WQyc3wWWDAeZJE1Vr6etQa