### PR TITLE
feat(api): bulk apply reconciles Webhook documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,13 @@ upgrade, is in
   existing launches retain `owner` behavior. Applications processing mutually
   untrusted work can keep all Fountain API authority on their service host.
 
+- A `fountain apply` manifest can declare webhook endpoints. A `Webhook`
+  document is keyed by its `spec.url`, and the apply that creates one hands
+  back its signing secret on that result row and never again. A manifest that
+  holds a `Webhook` needs a full-scope credential, which is what
+  `POST /api/webhooks` needs, and a refused request writes none of the
+  manifest's other resources either (#1636).
+
 - A `fountain apply` manifest can declare a teammate's schedules. A `Schedule`
   document names its teammate, its cron and its prompt, and is keyed by name
   under that teammate. A teammate name that two teammates answer to fails that

--- a/apps/fountain/lib/fountain/manifest.ex
+++ b/apps/fountain/lib/fountain/manifest.ex
@@ -20,6 +20,7 @@ defmodule Fountain.Manifest do
   | `Agent` | `name` | `Fountain.Agents` |
   | `Teammate` | `name`, which names the agent's membership | `Fountain.Team` |
   | `Schedule` | `name`, under its `teammate` | `Fountain.Team.Schedules` |
+  | `Webhook` | `spec.url` | `Fountain.Webhooks` |
 
   A teammate is one agent's membership of the team, so the document's `name`
   is what the teammate is called and the resolved `agent` is what it
@@ -41,17 +42,18 @@ defmodule Fountain.Manifest do
   and does not stop the rest of the manifest.
 
   Apply is additive. A document removed from the manifest leaves its record
-  in place; there is no prune.
+  in place; there is no prune. A `Webhook` whose `spec.url` changes is a new
+  endpoint for that reason, and the one the old URL named keeps delivering.
   """
 
   require Logger
 
-  alias Fountain.{Agents, Crypto, Environments, Team, Vaults}
+  alias Fountain.{Agents, Crypto, Environments, Team, Vaults, Webhooks}
   alias Fountain.Team.Schedules
 
   @unexpected "apply failed unexpectedly; see the server log"
 
-  @kinds ~w(Environment Vault Agent Teammate Schedule)
+  @kinds ~w(Environment Vault Agent Teammate Schedule Webhook)
 
   def kinds, do: @kinds
 
@@ -63,11 +65,13 @@ defmodule Fountain.Manifest do
   Apply `resources` (maps with `"kind"`, `"name"`, and `"spec"`) for `user_id`.
 
   Returns `{:ok, results}` with one result map per resource in apply order
-  (the 5 kinds in the order above, then any malformed entries). Each result
+  (the six kinds in the order above, then any malformed entries). Each result
   holds `:kind`, `:name`, an `:action` of `:created` / `:updated` /
   `:unchanged` / `:error`, changeset-style `:errors` when the action is
   `:error`, a `:secrets` list with the per-key upsert outcome, the
-  reconciled record's `:id` (nil for errors).
+  reconciled record's `:id` (nil for errors), and `:secret`, which carries a
+  webhook endpoint's signing secret on the apply that created it and is nil
+  everywhere else.
 
   `:unchanged` means the record already matched the document, so nothing was
   written to it. Inline `spec.secrets` are re-encrypted on every apply and
@@ -83,6 +87,7 @@ defmodule Fountain.Manifest do
     agents = Map.get(groups, "Agent", [])
     teammates = Map.get(groups, "Teammate", [])
     schedules = Map.get(groups, "Schedule", [])
+    webhooks = Map.get(groups, "Webhook", [])
 
     dek = if Enum.any?(envs ++ vaults, &has_secrets?/1), do: load_dek!(user_id)
 
@@ -111,12 +116,16 @@ defmodule Fountain.Manifest do
         apply_schedule(user_id, res, known_teammates, opts)
       end)
 
+    {webhook_results, _} =
+      reconcile("Webhook", webhooks, fn res, _claimed -> apply_webhook(user_id, res, opts) end)
+
     results =
       env_results ++
         vault_results ++
         agent_results ++
         teammate_results ++
         schedule_results ++
+        webhook_results ++
         Enum.map(invalid, &invalid_result/1)
 
     {:ok, results}
@@ -360,6 +369,44 @@ defmodule Fountain.Manifest do
     end
   end
 
+  # Keyed by `spec.url`: the endpoint the tenant already has for that URL is
+  # the one this document describes. The document's name is a label, carried
+  # into the result row so `fountain apply` prints something a reader picked.
+  defp apply_webhook(user_id, %{"name" => name} = res, opts) do
+    with :ok <- validate_keys(res, ~w(url description event_types)) do
+      attrs = spec_of(res)
+      existing = Enum.find(Webhooks.list_endpoints(user_id), &(&1.url == attrs["url"]))
+
+      case reconcile_webhook(user_id, existing, attrs, opts) do
+        {:ok, endpoint, secret} ->
+          row =
+            %{
+              result("Webhook", name, verdict(existing, endpoint), nil, [], endpoint.id)
+              | secret: secret
+            }
+
+          {row, nil}
+
+        {:error, reason} ->
+          {result("Webhook", name, :error, context_errors(reason), []), nil}
+      end
+    else
+      {:error, errors} -> {result("Webhook", name, :error, errors, []), nil}
+    end
+  end
+
+  # The signing secret comes back on creation only, exactly as
+  # `POST /api/webhooks` gives it: an update has none to return.
+  defp reconcile_webhook(user_id, nil, attrs, opts) do
+    with {:ok, {endpoint, secret}} <- Webhooks.create_endpoint(user_id, attrs, opts),
+         do: {:ok, endpoint, secret}
+  end
+
+  defp reconcile_webhook(_user_id, endpoint, attrs, opts) do
+    with {:ok, updated} <- Webhooks.update_endpoint(endpoint, attrs, opts),
+         do: {:ok, updated, nil}
+  end
+
   # ── references ────────────────────────────────────────────────────────────
 
   # Resolve a `<field>: <name>` reference: documents applied earlier in this
@@ -517,8 +564,18 @@ defmodule Fountain.Manifest do
   # `id` is the reconciled record's id when there is one. It is not serialized
   # in the API response; callers use it to attribute the secret writes this
   # manifest performed to a concrete resource in the audit trail (#530).
+  # `secret` is a webhook endpoint's signing secret on the apply that minted
+  # it, and nil on every other row and every later apply.
   defp result(kind, name, action, errors, secrets, id \\ nil) do
-    %{kind: kind, name: name, action: action, errors: errors, secrets: secrets, id: id}
+    %{
+      kind: kind,
+      name: name,
+      action: action,
+      errors: errors,
+      secrets: secrets,
+      id: id,
+      secret: nil
+    }
   end
 
   defp invalid_result(res) do

--- a/apps/fountain/lib/fountain_web/controllers/apply_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/apply_controller.ex
@@ -19,10 +19,13 @@ defmodule FountainWeb.ApplyController do
     description:
       "Applies all resources from a compiled fountain.yml manifest in one request. " <>
         "Resources are reconciled in a fixed order — environments, vaults, agents, " <>
-        "teammates, schedules — so a spec may name another document whatever the " <>
-        "file's order: an agent's `environment`, a teammate's `agent`, " <>
-        "`environment` and `vault`, and a schedule's `teammate`. Every kind is " <>
-        "keyed by the document's `name`. A `Teammate` " <>
+        "teammates, schedules, webhooks — so a spec may name another document " <>
+        "whatever the file's order: an agent's `environment`, a teammate's " <>
+        "`agent`, `environment` and `vault`, and a schedule's `teammate`. Every " <>
+        "kind is keyed by the document's `name`, except `Webhook`, which is " <>
+        "keyed by `spec.url`. A `Webhook` created here returns its signing " <>
+        "secret once, on that result row, and a manifest that holds one needs a " <>
+        "full-scope credential. A `Teammate` " <>
         "is read as a whole declaration, so an absent `environment` or `vault` " <>
         "clears that binding, and moving either retires the computer the old " <>
         "binding named (refused with an error on that row while a turn is running " <>
@@ -41,8 +44,24 @@ defmodule FountainWeb.ApplyController do
   def create(conn, %{"resources" => resources}) do
     user = conn.assigns.current_user
 
-    with {:ok, results} <- Manifest.apply_manifest(user.id, resources, Audited.attribution(conn)) do
-      render(conn, :create, results: results)
+    # `POST /api/webhooks` is behind RequireFullScope, so a manifest that mints
+    # an endpoint is held to the same bar. Checked over the whole manifest
+    # before any resource is written, so a refused request writes none of the
+    # others either.
+    conn =
+      if Enum.any?(resources, &match?(%{"kind" => "Webhook"}, &1)) do
+        FountainWeb.Plugs.RequireFullScope.call(conn, [])
+      else
+        conn
+      end
+
+    if conn.halted do
+      conn
+    else
+      with {:ok, results} <-
+             Manifest.apply_manifest(user.id, resources, Audited.attribution(conn)) do
+        render(conn, :create, results: results)
+      end
     end
   end
 end

--- a/apps/fountain/lib/fountain_web/controllers/apply_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/apply_json.ex
@@ -11,7 +11,8 @@ defmodule FountainWeb.ApplyJSON do
       name: result.name,
       action: result.action,
       errors: result.errors,
-      secrets: Enum.map(result.secrets, &Map.take(&1, [:key, :action, :errors]))
+      secrets: Enum.map(result.secrets, &Map.take(&1, [:key, :action, :errors])),
+      secret: result.secret
     }
   end
 end

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -3129,12 +3129,14 @@ defmodule FountainWeb.Schemas do
           "and a Teammate document is read as a whole declaration, so an absent " <>
           "`environment` or `vault` clears that binding. Schedule specs take " <>
           "`teammate` plus the TeamScheduleCreateRequest fields `cron`, " <>
-          "`prompt`, `one_off` and `enabled`.",
+          "`prompt`, `one_off` and `enabled`; Webhook specs take the " <>
+          "WebhookEndpointCreateRequest fields `url`, `description` and " <>
+          "`event_types`, and are keyed by `url` rather than by `name`.",
       type: :object,
       properties: %{
         kind: %Schema{
           type: :string,
-          enum: ["Environment", "Vault", "Agent", "Teammate", "Schedule"]
+          enum: ["Environment", "Vault", "Agent", "Teammate", "Schedule", "Webhook"]
         },
         name: %Schema{type: :string, minLength: 1, maxLength: 200},
         spec: %Schema{type: :object, additionalProperties: true}
@@ -3194,7 +3196,16 @@ defmodule FountainWeb.Schemas do
               "`upserted` under `secrets`."
         },
         errors: %Schema{type: :object, additionalProperties: true, nullable: true},
-        secrets: %Schema{type: :array, items: ApplySecretResult}
+        secrets: %Schema{type: :array, items: ApplySecretResult},
+        secret: %Schema{
+          type: :string,
+          nullable: true,
+          description:
+            "A Webhook endpoint's HMAC-SHA256 signing secret, on the apply that " <>
+              "created it. Store it; it is not shown again, and an update never " <>
+              "returns it. Null on every other row.",
+          example: "whsec_Zm91bnRhaW4tZXhhbXBsZS1zZWNyZXQtdmFsdWU"
+        }
       },
       required: [:kind, :name, :action]
     })

--- a/apps/fountain/priv/help/manifest.md
+++ b/apps/fountain/priv/help/manifest.md
@@ -8,30 +8,30 @@ A `fountain.yml` is a multi-document YAML file. Each doc is one resource with th
 
 ```yaml
 apiVersion: fountain/v1
-kind: Environment | Vault | Agent | Teammate | Schedule
+kind: Environment | Vault | Agent | Teammate | Schedule | Webhook
 metadata:
   name: <unique-on-operator-side>
 spec:
   # ... fields matching the API schema for the kind ...
 ```
 
-The `metadata.name` is the upsert key. If a resource with that name exists, it's updated; if not, it's created.
+The `metadata.name` is the upsert key for five of the six kinds. If a resource with that name exists, it's updated; if not, it's created. A `Webhook` is keyed by its `spec.url` instead, so its `metadata.name` is a label that shows up in the apply output.
 
 ## Order is irrelevant inside the file
 
-`fountain apply` reconciles in a fixed order: **environments, vaults, agents, teammates, schedules** — so a doc can reference another by name even if that one is defined later in the file. An `Agent` references an `environment`; a `Teammate` references an `agent`, an `environment` and a `vault`; a `Schedule` references a `teammate`. Every reference resolves against the manifest first and then against what **already exists** server-side, so a manifest can attach an agent to an environment managed elsewhere; a name that matches neither fails that doc and no other.
+`fountain apply` reconciles in a fixed order: **environments, vaults, agents, teammates, schedules, webhooks** — so a doc can reference another by name even if that one is defined later in the file. An `Agent` references an `environment`; a `Teammate` references an `agent`, an `environment` and a `vault`; a `Schedule` references a `teammate`. Every reference resolves against the manifest first and then against what **already exists** server-side, so a manifest can attach an agent to an environment managed elsewhere; a name that matches neither fails that doc and no other.
 
 ## The team kinds
 
-A `Teammate` puts an agent on the team, which opens its conversation and provisions its computer. Re-applying moves what the teammate is called and which environment and vault it is bound to — it never provisions a second one, and it never resurrects a computer that is gone (message the teammate for that). A `Schedule` is a cron that runs a teammate with a prompt, keyed by its name under its teammate.
+A `Teammate` puts an agent on the team, which opens its conversation and provisions its computer. Re-applying moves what the teammate is called and which environment and vault it is bound to — it never provisions a second one, and it never resurrects a computer that is gone (message the teammate for that). A `Schedule` is a cron that runs a teammate with a prompt, keyed by its name under its teammate. A `Webhook` is an endpoint Fountain POSTs conversation lifecycle events to; the apply that creates one prints its signing secret **once**, and no later apply ever prints it again. A manifest holding one needs a full-scope credential, which is what `POST /api/webhooks` needs.
 
 Two things about it that surprise people:
 
-- **A `Teammate` doc is the whole teammate.** Unlike the other four kinds, where an absent `spec` key leaves that column alone, dropping `environment` or `vault` from a Teammate doc *clears* that binding — back to the agent's own environment and no vault. That is what makes the doc a declaration rather than a patch.
+- **A `Teammate` doc is the whole teammate.** Unlike the other five kinds, where an absent `spec` key leaves that column alone, dropping `environment` or `vault` from a Teammate doc *clears* that binding — back to the agent's own environment and no vault. That is what makes the doc a declaration rather than a patch.
 - **A teammate's name is not unique.** It is the conversation's title, or the agent's name. A `Schedule` naming a teammate that two of them answer to fails rather than binding to whichever the roster listed last; one this manifest reconciled is unique among the docs and wins.
 - **Rebinding moves the computer.** A home is keyed on `(user, agent, environment, vault)`, so changing either id retires the machine the old key named; the teammate's next message builds a fresh one. Refused with an error on that row while a turn is still running there — the same refusal `Agent`'s `environment` gives (#1084). A conversation that *shared* that machine and names a different environment or vault does not follow the teammate; it builds its own on its next prompt. And because there is only ever one home per identity, a rebind onto an identity the agent **already** has a home for is **refused**, not merged onto that home — reset or remove the existing one first (#1636).
 
-**Two Teammate docs can't name the same agent.** An agent is on the team once, so the second doc fails and the first applies.
+**Two Teammate docs can't name the same agent**, and a `Webhook` whose `spec.url` changes creates a *second* endpoint (nothing is pruned; delete the old one with `fountain webhooks delete`).
 
 ```yaml
 ---
@@ -55,6 +55,15 @@ spec:
   prompt: What is on today?
   one_off: false
   enabled: true
+
+---
+apiVersion: fountain/v1
+kind: Webhook
+metadata:
+  name: ci
+spec:
+  url: https://ci.example.com/hooks/fountain
+  event_types: [conversation.turn.done]
 ```
 
 ## Nothing is pruned
@@ -63,7 +72,7 @@ Apply is additive. Deleting a doc from the manifest leaves its record in place; 
 
 ## What the trail says
 
-Each applied row leaves its context's own audit event, with the actor and IP of the request that applied it: `team.member.added` / `team.updated` for a Teammate, and `team.schedule.created` / `team.schedule.updated` for a Schedule. An `unchanged` row writes nothing at all.
+Each applied row leaves its context's own audit event, with the actor and IP of the request that applied it: `team.member.added` / `team.updated` for a Teammate, `team.schedule.created` / `team.schedule.updated` for a Schedule, and `webhook_endpoint.created` / `webhook_endpoint.updated` for a Webhook — the `webhook_endpoint` prefix the webhook routes have always written, not a shorter `webhook` one. An `unchanged` row writes nothing at all.
 
 ## Example
 
@@ -123,6 +132,11 @@ vault  +  alice
   secret  ~  alice/GITHUB_TOKEN
   secret  ~  alice/NPM_TOKEN
 agent  =  researcher
+teammate  =  Ada
+schedule  +  standup
+webhook  +  ci
+  signing secret  ci  whsec_...
+  save it now, it is not shown again
 ```
 
 Errors per-resource go to stderr but don't stop the run; other resources still apply.

--- a/apps/fountain/test/fountain/manifest_test.exs
+++ b/apps/fountain/test/fountain/manifest_test.exs
@@ -4,6 +4,7 @@ defmodule Fountain.ManifestTest do
 
   alias Fountain.{Agents, Audit, Conversations, Crypto, Environments, Manifest, Team, Vaults}
   alias Fountain.Team.Schedules
+  alias Fountain.Webhooks
 
   setup do
     # No starter agent (ADR 0038): every assertion here counts what the
@@ -17,6 +18,10 @@ defmodule Fountain.ManifestTest do
 
   defp vault_resource(name, spec \\ %{}) do
     %{"kind" => "Vault", "name" => name, "spec" => spec}
+  end
+
+  defp webhook_resource(name, spec) do
+    %{"kind" => "Webhook", "name" => name, "spec" => spec}
   end
 
   defp schedule_resource(name, spec) do
@@ -371,10 +376,16 @@ defmodule Fountain.ManifestTest do
   end
 
   describe "apply_manifest/2 the whole estate" do
+    @hook_url "https://hooks.example.com/fountain"
+
     defp estate_manifest(vault_spec \\ %{"secrets" => %{"GH" => "ghp_x"}}) do
       # Deliberately out of order: the kinds reconcile in a fixed order,
       # whatever the file says.
       [
+        webhook_resource("ci", %{
+          "url" => @hook_url,
+          "event_types" => ["conversation.turn.done"]
+        }),
         schedule_resource("standup", %{
           "teammate" => "Ada",
           "cron" => "0 9 * * 1-5",
@@ -391,7 +402,7 @@ defmodule Fountain.ManifestTest do
       ]
     end
 
-    test "the five kinds apply in one request, and a second apply changes nothing",
+    test "all six kinds apply in one request, and a second apply changes nothing",
          %{user: user} do
       inert_start_child()
       resources = estate_manifest()
@@ -403,7 +414,8 @@ defmodule Fountain.ManifestTest do
                {"Vault", "alice", :created},
                {"Agent", "ada", :created},
                {"Teammate", "Ada", :created},
-               {"Schedule", "standup", :created}
+               {"Schedule", "standup", :created},
+               {"Webhook", "ci", :created}
              ]
 
       env = Environments.get_environment_by_name("proj", user.id)
@@ -420,14 +432,18 @@ defmodule Fountain.ManifestTest do
       assert [%{name: "standup", cron: "0 9 * * 1-5", one_off: false, enabled: true}] =
                Schedules.list_schedules(user.id, agent.id)
 
+      assert [%{url: @hook_url, event_types: ["conversation.turn.done"]}] =
+               Webhooks.list_endpoints(user.id)
+
       {:ok, second} = Manifest.apply_manifest(user.id, resources)
 
-      assert Enum.map(second, & &1.action) == List.duplicate(:unchanged, 5)
+      assert Enum.map(second, & &1.action) == List.duplicate(:unchanged, 6)
       assert Enum.map(second, & &1.kind) == Enum.map(first, & &1.kind)
 
       # Nothing was duplicated by the second pass.
       assert length(Team.list_teammates(user.id)) == 1
       assert length(Schedules.list_schedules(user.id, agent.id)) == 1
+      assert length(Webhooks.list_endpoints(user.id)) == 1
     end
 
     test "the applied rows are audited with the request's attribution", %{user: user} do
@@ -441,8 +457,9 @@ defmodule Fountain.ManifestTest do
 
       assert "team.member.added" in actions
       assert "team.schedule.created" in actions
+      assert "webhook_endpoint.created" in actions
 
-      for action <- ~w(team.member.added team.schedule.created) do
+      for action <- ~w(team.member.added team.schedule.created webhook_endpoint.created) do
         event = Enum.find(events, &(&1.action == action))
         assert event.actor == "api", "#{action} was recorded as #{event.actor}"
         assert to_string(event.request_ip) == "203.0.113.5"
@@ -481,7 +498,8 @@ defmodule Fountain.ManifestTest do
           "teammate" => "Ada of proj",
           "cron" => "@daily",
           "prompt" => "What is on today?"
-        })
+        }),
+        webhook_resource("ci", %{"url" => @hook_url, "description" => "CI"})
       ]
 
       {:ok, results} = Manifest.apply_manifest(user.id, moved, opts)
@@ -491,13 +509,14 @@ defmodule Fountain.ManifestTest do
                {"Vault", :unchanged},
                {"Agent", :unchanged},
                {"Teammate", :updated},
-               {"Schedule", :updated}
+               {"Schedule", :updated},
+               {"Webhook", :updated}
              ]
 
       events = Audit.list_recent_for_user(user.id, 500)
       added = Enum.take(events, length(events) - before)
 
-      for action <- ~w(team.updated team.schedule.updated) do
+      for action <- ~w(team.updated team.schedule.updated webhook_endpoint.updated) do
         event = Enum.find(added, &(&1.action == action))
 
         assert event,
@@ -868,6 +887,75 @@ defmodule Fountain.ManifestTest do
         ])
 
       assert schedule.errors == %{"crn" => ["is not a supported spec key"]}
+    end
+
+    test "a Webhook hands back its secret once and never on update", %{user: user} do
+      hook = fn spec -> [webhook_resource("ci", Map.put(spec, "url", @hook_url))] end
+
+      {:ok, [created]} = Manifest.apply_manifest(user.id, hook.(%{}))
+      assert created.action == :created
+      assert String.starts_with?(created.secret, "whsec_")
+
+      {:ok, [again]} = Manifest.apply_manifest(user.id, hook.(%{}))
+      assert again.action == :unchanged
+      assert again.secret == nil
+
+      {:ok, [updated]} = Manifest.apply_manifest(user.id, hook.(%{"description" => "CI"}))
+      assert updated.action == :updated
+      assert updated.secret == nil
+
+      assert [endpoint] = Webhooks.list_endpoints(user.id)
+      assert endpoint.description == "CI"
+      # The secret handed back on the create is still the one that signs.
+      assert Webhooks.secret(endpoint) == {:ok, created.secret}
+    end
+
+    test "a Webhook is keyed by its url, not by the document name", %{user: user} do
+      {:ok, [%{action: :created}]} =
+        Manifest.apply_manifest(user.id, [webhook_resource("ci", %{"url" => @hook_url})])
+
+      {:ok, [%{action: :unchanged}]} =
+        Manifest.apply_manifest(user.id, [webhook_resource("renamed", %{"url" => @hook_url})])
+
+      assert length(Webhooks.list_endpoints(user.id)) == 1
+    end
+
+    test "a Webhook the endpoint refuses fails that row only", %{user: user} do
+      {:ok, [good, bad]} =
+        Manifest.apply_manifest(user.id, [
+          vault_resource("v"),
+          webhook_resource("bad", %{"url" => "http://127.0.0.1/hook"})
+        ])
+
+      assert good.action == :created
+      assert bad.action == :error
+      assert Map.has_key?(bad.errors, "url")
+      assert Webhooks.list_endpoints(user.id) == []
+    end
+
+    test "changing a Webhook's url leaves the old endpoint and adds a new one", %{user: user} do
+      {:ok, [%{action: :created}]} =
+        Manifest.apply_manifest(user.id, [webhook_resource("ci", %{"url" => @hook_url})])
+
+      {:ok, [%{action: :created, secret: secret}]} =
+        Manifest.apply_manifest(user.id, [
+          webhook_resource("ci", %{"url" => "https://hooks.example.com/second"})
+        ])
+
+      assert String.starts_with?(secret, "whsec_")
+      # No prune: the endpoint the old URL named is still there and still
+      # delivering, and has to be deleted through its own route.
+      assert length(Webhooks.list_endpoints(user.id)) == 2
+    end
+
+    test "unknown spec keys on a Webhook are rejected", %{user: user} do
+      {:ok, [webhook]} =
+        Manifest.apply_manifest(user.id, [
+          webhook_resource("w", %{"url" => @hook_url, "status" => "disabled"})
+        ])
+
+      assert webhook.errors == %{"status" => ["is not a supported spec key"]}
+      assert Webhooks.list_endpoints(user.id) == []
     end
   end
 end

--- a/apps/fountain/test/fountain_web/controllers/apply_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/apply_controller_test.exs
@@ -1,12 +1,90 @@
 defmodule FountainWeb.ApplyControllerTest do
   use FountainWeb.ConnCase, async: true
+  use Mimic
 
-  alias Fountain.{Agents, Crypto, Environments, Vaults}
+  alias Fountain.{Agents, Crypto, Environments, Team, Vaults, Webhooks}
+  alias Fountain.Team.Schedules
 
   setup do
     user = insert_verified_user()
     {_key_record, raw_key} = insert_api_key(user)
     {:ok, user: user, raw_key: raw_key}
+  end
+
+  describe "POST /api/apply — the webhook scope boundary" do
+    setup %{user: user} do
+      {_key, sprite_key} = insert_sprite_api_key(user)
+      %{sprite_key: sprite_key}
+    end
+
+    test "a sandbox token cannot create a webhook endpoint through a manifest", %{
+      conn: conn,
+      user: user,
+      sprite_key: sprite_key
+    } do
+      payload = %{
+        "resources" => [
+          %{"kind" => "Environment", "name" => "proj", "spec" => %{"setup_script" => "echo hi"}},
+          %{
+            "kind" => "Webhook",
+            "name" => "ops",
+            "spec" => %{"url" => "https://example.test/hook", "event_types" => ["*"]}
+          }
+        ]
+      }
+
+      conn = conn |> authed_with_key(sprite_key) |> post_json(~p"/api/apply", payload)
+
+      body = json_response(conn, 403)
+      assert body["reason"] == "insufficient_scope"
+      assert body["required_scope"] == "full"
+
+      # Refused before any resource is written, so the environment sharing the
+      # manifest with the webhook does not land either.
+      assert Fountain.Environments.list_environments(user.id) == []
+      assert Fountain.Webhooks.list_endpoints(user.id) == []
+    end
+
+    test "a sandbox token may still apply a manifest with no webhook in it", %{
+      conn: conn,
+      user: user,
+      sprite_key: sprite_key
+    } do
+      payload = %{
+        "resources" => [
+          %{"kind" => "Environment", "name" => "proj", "spec" => %{"setup_script" => "echo hi"}}
+        ]
+      }
+
+      conn = conn |> authed_with_key(sprite_key) |> post_json(~p"/api/apply", payload)
+
+      assert %{"data" => %{"results" => [%{"action" => "created"}]}} = json_response(conn, 200)
+      assert [_] = Fountain.Environments.list_environments(user.id)
+    end
+
+    test "a full-scope key applies the same webhook manifest", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
+      payload = %{
+        "resources" => [
+          %{
+            "kind" => "Webhook",
+            "name" => "ops",
+            "spec" => %{"url" => "https://example.test/hook", "event_types" => ["*"]}
+          }
+        ]
+      }
+
+      conn = conn |> authed_with_key(raw_key) |> post_json(~p"/api/apply", payload)
+
+      assert %{"data" => %{"results" => [%{"action" => "created", "secret" => secret}]}} =
+               json_response(conn, 200)
+
+      assert is_binary(secret)
+      assert [_] = Fountain.Webhooks.list_endpoints(user.id)
+    end
   end
 
   describe "POST /api/apply" do
@@ -161,6 +239,75 @@ defmodule FountainWeb.ApplyControllerTest do
       refute response.resp_body =~ "not-for-the-response"
       refute Environments.get_environment_by_name("locked", user.id)
       assert Vaults.get_vault_by_name("valid", user.id)
+    end
+
+    test "reconciles the three team and webhook kinds in one request", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
+      # Adding a teammate opens its conversation, which provisions its computer.
+      stub(Horde.DynamicSupervisor, :start_child, fn _sup, _spec ->
+        {:ok, spawn(fn -> Process.sleep(:infinity) end)}
+      end)
+
+      payload = %{
+        "resources" => [
+          %{"kind" => "Environment", "name" => "proj", "spec" => %{}},
+          %{"kind" => "Vault", "name" => "alice", "spec" => %{}},
+          %{
+            "kind" => "Agent",
+            "name" => "ada",
+            "spec" => %{"model" => "anthropic/claude-sonnet-4-6", "runtime" => "claude"}
+          },
+          %{
+            "kind" => "Teammate",
+            "name" => "Ada",
+            "spec" => %{"agent" => "ada", "environment" => "proj", "vault" => "alice"}
+          },
+          %{
+            "kind" => "Schedule",
+            "name" => "standup",
+            "spec" => %{"teammate" => "Ada", "cron" => "0 9 * * 1-5", "prompt" => "morning"}
+          },
+          %{
+            "kind" => "Webhook",
+            "name" => "ci",
+            "spec" => %{"url" => "https://hooks.example.com/fountain"}
+          }
+        ]
+      }
+
+      response = conn |> authed_with_key(raw_key) |> post_json(~p"/api/apply", payload)
+      assert %{"data" => %{"results" => results}} = json_response(response, 200)
+
+      assert Enum.map(results, &{&1["kind"], &1["action"]}) == [
+               {"Environment", "created"},
+               {"Vault", "created"},
+               {"Agent", "created"},
+               {"Teammate", "created"},
+               {"Schedule", "created"},
+               {"Webhook", "created"}
+             ]
+
+      # The signing secret is on the webhook row and nowhere else.
+      assert [%{"kind" => "Webhook", "secret" => secret}] =
+               Enum.filter(results, &(&1["secret"] != nil))
+
+      assert String.starts_with?(secret, "whsec_")
+
+      agent = Agents.get_agent_by_name("ada", user.id)
+      assert [%{name: "Ada"}] = Team.list_teammates(user.id)
+      assert [%{name: "standup"}] = Schedules.list_schedules(user.id, agent.id)
+
+      # A second apply writes nothing and returns no secret.
+      second =
+        build_conn() |> authed_with_key(raw_key) |> post_json(~p"/api/apply", payload)
+
+      assert %{"data" => %{"results" => rows}} = json_response(second, 200)
+      assert Enum.map(rows, & &1["action"]) == List.duplicate("unchanged", 6)
+      assert Enum.all?(rows, &(&1["secret"] == nil))
+      assert length(Webhooks.list_endpoints(user.id)) == 1
     end
 
     test "never echoes secret values back", %{conn: conn, raw_key: raw_key} do

--- a/cli/internal/cmd/apply.go
+++ b/cli/internal/cmd/apply.go
@@ -79,7 +79,7 @@ func runApply(cmd *cobra.Command, args []string) error {
 // a teammate's `spec.agent`/`environment`/`vault`, a schedule's
 // `spec.teammate`. The server resolves each by name, including against records
 // that already exist and are not part of this manifest.
-var applyKindOrder = []string{"Environment", "Vault", "Agent", "Teammate", "Schedule"}
+var applyKindOrder = []string{"Environment", "Vault", "Agent", "Teammate", "Schedule", "Webhook"}
 
 // applyResource is one compiled manifest document. The whole manifest is
 // sent to POST /api/apply in a single request.
@@ -101,6 +101,9 @@ type applyResult struct {
 	Action  string              `json:"action"`
 	Errors  map[string]any      `json:"errors"`
 	Secrets []applySecretResult `json:"secrets"`
+	// Secret is a webhook endpoint's signing secret, sent on the apply that
+	// created it and never again.
+	Secret string `json:"secret"`
 }
 
 func buildApplyPayload(grouped map[string][]*manifest.Doc) []applyResource {
@@ -158,6 +161,12 @@ func renderApplyResults(results []applyResult) (anyFailed bool) {
 		default:
 			anyFailed = true
 			warnf("%s  !  %s: %s", label, r.Name, formatResultErrors(r.Errors))
+		}
+		// A webhook endpoint's signing secret comes back on the apply that
+		// created it and never again, so print it where the reader is looking.
+		if r.Secret != "" {
+			fmt.Printf("  signing secret  %s  %s\n", r.Name, r.Secret)
+			fmt.Println("  save it now, it is not shown again")
 		}
 		for _, s := range r.Secrets {
 			if s.Action == "upserted" {

--- a/cli/internal/cmd/apply_test.go
+++ b/cli/internal/cmd/apply_test.go
@@ -32,6 +32,7 @@ func TestBuildApplyPayloadOrdersAndStrips(t *testing.T) {
 		})},
 		"Teammate": {doc("Teammate", "Ada", map[string]any{"agent": "researcher"})},
 		"Schedule": {doc("Schedule", "standup", map[string]any{"teammate": "Ada", "cron": "@daily"})},
+		"Webhook":  {doc("Webhook", "ci", map[string]any{"url": "https://example.com/h"})},
 	}
 
 	// Payload order is the reconciliation order, whatever order the manifest
@@ -79,6 +80,7 @@ func TestGroupDocsBucketsEveryKind(t *testing.T) {
 		doc("Cluster", "nope", nil),
 		doc("Teammate", "Ada", nil),
 		doc("Schedule", "standup", nil),
+		doc("Webhook", "ci", nil),
 		doc("Environment", "e", nil),
 		doc("Vault", "v", nil),
 	}
@@ -105,6 +107,7 @@ func TestRenderApplyResultsFailureDetection(t *testing.T) {
 			{Kind: "Environment", Name: "e", Action: "created"},
 			{Kind: "Agent", Name: "a", Action: "updated"},
 			{Kind: "Vault", Name: "v", Action: "unchanged"},
+			{Kind: "Webhook", Name: "ci", Action: "created", Secret: "whsec_x"},
 		}, false},
 		{"resource error", []applyResult{
 			{Kind: "Agent", Name: "a", Action: "error", Errors: map[string]any{"model": []any{"can't be blank"}}},

--- a/cli/internal/manifest/examples_test.go
+++ b/cli/internal/manifest/examples_test.go
@@ -31,6 +31,7 @@ func TestExamplesParse(t *testing.T) {
 		"Agent":       true,
 		"Teammate":    true,
 		"Schedule":    true,
+		"Webhook":     true,
 	}
 	total := 0
 	checked := 0

--- a/docs/api.md
+++ b/docs/api.md
@@ -158,18 +158,24 @@ resources. The CLI compiles the manifest and submits the resource graph.
 Inspect every resource result. One failed resource does not mean that all
 other writes failed.
 
-A manifest holds five kinds. Fountain reconciles them in a fixed order, which
-is `Environment`, `Vault`, `Agent`, `Teammate` and `Schedule`. A document can name another
-document whatever its position in the file. An `Agent` names an
+A manifest holds six kinds. Fountain reconciles them in a fixed order, which
+is `Environment`, `Vault`, `Agent`, `Teammate`, `Schedule` and `Webhook`. A
+document can name another document whatever its position in the file. An `Agent` names an
 `environment`. A `Teammate` names an `agent`, an `environment` and a `vault`.
 A `Schedule` names a `teammate`. A teammate's name is not unique, so a name
 that two teammates answer to fails that row rather than binding to one of
-them. Each name resolves against the manifest first, then against the records the
-account already holds. A name that matches neither fails that document alone.
+them. Each name resolves against the manifest first, then against the records
+the account already holds. A name that matches neither fails that document
+alone.
+
+The document name is the key for five of the kinds. `Webhook` is the
+exception, and is keyed by `spec.url`. Change that URL and the apply creates
+a second endpoint. The first one stays, and keeps delivering, until you
+delete it through the webhook routes.
 
 A `Teammate` document is the whole teammate. Drop `environment` or `vault`
 from it and the apply clears that binding, which puts the teammate back on
-the agent's own environment and on no vault. The other four kinds behave the
+the agent's own environment and on no vault. The other five kinds behave the
 other way around, where an absent `spec` key leaves that field alone.
 
 Rebinding a teammate moves its computer. Fountain retires the machine the old
@@ -189,8 +195,17 @@ record in place. There is no prune.
 
 The audit trail names each applied row. Teammate rows record
 `team.member.added` and `team.updated`, and schedule rows record
-`team.schedule.created` and `team.schedule.updated`. Each row carries the
-actor and the IP address of the request that applied it.
+`team.schedule.created` and `team.schedule.updated`, and webhook rows record
+`webhook_endpoint.created` and `webhook_endpoint.updated`. The webhook actions
+carry the `webhook_endpoint` prefix that the webhook routes have always
+written, not a shorter `webhook` one. Each row carries the actor and the IP
+address of the request that applied it.
+
+A `Webhook` that an apply creates carries its signing secret in that result
+row. Fountain shows the secret one time. An update of the same endpoint
+carries no secret. A manifest that holds a `Webhook` needs a full-scope
+credential, which is what `POST /api/webhooks` needs. A sandbox-scoped
+credential is refused before any resource in that manifest is written.
 
 Each result row reports `created`, `updated`, `unchanged` or `error`. A
 second apply of an unchanged manifest reports `unchanged` for every row, and

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -317,8 +317,8 @@ fountain apply -f dir/ --var REGION=eu-west-1 # ${VAR} substitution, repeatable
 ```
 
 Apply is idempotent. It creates what is new, and updates what changed. It
-supports five kinds, which are `Environment`, `Vault`, `Agent`, `Teammate`
-and `Schedule`.
+supports six kinds, which are `Environment`, `Vault`, `Agent`, `Teammate`,
+`Schedule` and `Webhook`.
 
 `--var` and `${VAR}` substitution apply to a `spec.secrets` value alone. A
 `${VAR}` anywhere else in the document goes across as it stands. A
@@ -327,11 +327,16 @@ and `Schedule`.
 The CLI compiles each document into one manifest, and sends that to
 `POST /api/apply` in one request.
 
-The server reconciles the five kinds in the order above. A document can name
+The server reconciles the six kinds in the order above. A document can name
 another document whatever its position in the file. An `Agent` names an
-`environment`. A `Teammate` names an `agent`, an `environment` and a `vault`. A `Schedule`
-names a `teammate`. Each name resolves against the manifest first, then against the records your
-account already holds.
+`environment`. A `Teammate` names an `agent`, an `environment` and a `vault`.
+A `Schedule` names a `teammate`. Each name resolves against the manifest
+first, then against the records your account already holds.
+
+The `metadata.name` is the key for five of the kinds. A `Webhook` is keyed by
+its `spec.url`, so the document name is a label alone. Change that URL and the
+next apply creates a second endpoint. The first one stays, and keeps
+delivering, until you delete it with `fountain webhooks delete`.
 
 ```yaml
 ---
@@ -355,6 +360,16 @@ spec:
   prompt: What is on today?
   one_off: false
   enabled: true
+
+---
+apiVersion: fountain/v1
+kind: Webhook
+metadata:
+  name: ci
+spec:
+  url: https://ci.example.com/hooks/fountain
+  description: CI receiver
+  event_types: [conversation.turn.done]
 ```
 
 A `Teammate` document adds the agent to the team, which opens the teammate's
@@ -364,7 +379,7 @@ computer.
 
 A `Teammate` document is the whole teammate. Drop `environment` or `vault`
 from it and the next apply clears that binding, which puts the teammate back
-on the agent's own environment and on no vault. The other four kinds behave
+on the agent's own environment and on no vault. The other five kinds behave
 the other way around, where an absent `spec` key leaves that field alone.
 
 A teammate's computer is built for one environment and one vault. Move either
@@ -383,6 +398,9 @@ computer. Reset or remove the computer first, then apply again.
 Two `Teammate` documents cannot name the same agent. An agent is on the team
 once, so the second document fails and the first one applies.
 
+A `Webhook` that an apply creates prints its signing secret one time. Save it
+then. An apply that updates the same endpoint prints no secret.
+
 A `Schedule` names its teammate. A teammate's name is not unique, so a name
 that two of your teammates answer to fails that row. Rename one of them, or
 name the teammate in the same manifest, which makes the name unambiguous.
@@ -392,7 +410,20 @@ record in place. There is no prune, so delete a record through its own
 command or the console.
 
 The CLI prints `+` for a create, `~` for an update, `=` for a resource that
-already matched the manifest, and `!` for a failure. A second apply of the
+already matched the manifest, and `!` for a failure.
+
+```
+env  =  my-project
+vault  =  alice
+agent  ~  ada
+teammate  +  Ada
+schedule  +  standup
+webhook  +  ci
+  signing secret  ci  whsec_...
+  save it now, it is not shown again
+```
+
+A second apply of the
 same file prints `=` on every row, because Fountain wrote to none of them.
 Inline `spec.secrets` are the exception. Fountain encrypts them again on each
 apply, so they keep printing `~` under a row that prints `=`.
@@ -402,8 +433,8 @@ errors and exits nonzero; valid resources in the same manifest still apply.
 Correct a misspelled field before you retry.
 
 Against an older server with no `/api/apply`, the CLI falls back to one call
-for each resource. That older server has no `Teammate` or `Schedule`
-document, so the CLI reports those and exits nonzero.
+for each resource. That older server has no `Teammate`, `Schedule` or
+`Webhook` document, so the CLI reports those and exits nonzero.
 
 ### Secret references
 

--- a/sdk/contract/contract.json
+++ b/sdk/contract/contract.json
@@ -8400,6 +8400,11 @@
           "required": true,
           "type": "string"
         },
+        "secret": {
+          "nullable": true,
+          "required": false,
+          "type": "string"
+        },
         "secrets": {
           "items": {
             "ref": "ApplySecretResult"
@@ -10891,7 +10896,8 @@
             "Environment",
             "Schedule",
             "Teammate",
-            "Vault"
+            "Vault",
+            "Webhook"
           ],
           "required": true,
           "type": "string"

--- a/sdk/swift/Sources/FountainKit/Client/FountainClient.swift
+++ b/sdk/swift/Sources/FountainKit/Client/FountainClient.swift
@@ -39,7 +39,8 @@ public struct FountainClient: Sendable {
     try await api.data(.get, "/api/catalog")
   }
 
-  /// Declarative bulk apply (`Environment`/`Vault`/`Agent` manifests).
+  /// Declarative bulk apply. One manifest reconciles `Environment`, `Vault`,
+  /// `Agent`, `Teammate`, `Schedule` and `Webhook` documents, in that order.
   public func apply(resources: [JSONValue]) async throws -> [ApplyResult] {
     struct Response: Decodable {
       var results: [ApplyResult]

--- a/sdk/swift/Sources/FountainKit/Models/Account.swift
+++ b/sdk/swift/Sources/FountainKit/Models/Account.swift
@@ -139,6 +139,9 @@ public struct ApplyResult: Sendable, Decodable, Hashable {
   public var action: String
   public var errors: JSONValue?
   public var secrets: [SecretResult]?
+  /// A `Webhook` endpoint's signing secret, on the apply that created it.
+  /// Nil on every other row, and on every later apply of the same endpoint.
+  public var secret: String?
 
   public struct SecretResult: Sendable, Decodable, Hashable {
     public var key: String

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -10,6 +10,12 @@ server releases.
 
 ---
 
+## [1.24.0] — 2026-09-10
+
+### Added
+
+- Generated types cover the `Teammate`, `Schedule` and `Webhook` documents bulk apply now reconciles, the `unchanged` result action, and a webhook row's one-time `secret`.
+
 ## [1.23.0] - 2026-09-07
 
 ### Added

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "1.23.0",
+  "version": "1.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentshit/fountain-sdk",
-      "version": "1.23.0",
+      "version": "1.24.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^26.4.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentshit/fountain-sdk",
-  "version": "1.23.0",
+  "version": "1.24.0",
   "description": "Run a coding agent on a real computer, with your repos and your credentials, in one call.",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -559,7 +559,7 @@ export interface paths {
         put?: never;
         /**
          * Apply a compiled manifest (bulk upsert)
-         * @description Applies all resources from a compiled fountain.yml manifest in one request. Resources are reconciled in a fixed order — environments, vaults, agents, teammates, schedules — so a spec may name another document whatever the file's order: an agent's `environment`, a teammate's `agent`, `environment` and `vault`, and a schedule's `teammate`. Every kind is keyed by the document's `name`. A `Teammate` is read as a whole declaration, so an absent `environment` or `vault` clears that binding, and moving either retires the computer the old binding named (refused with an error on that row while a turn is running on it). Two Teammate documents may not name the same agent. Apply is additive: a document dropped from the manifest leaves its record in place. Application is best-effort per resource: the response is 200 even when an individual resource fails validation, is refused by its context or raises, with per-resource errors in the result entries.
+         * @description Applies all resources from a compiled fountain.yml manifest in one request. Resources are reconciled in a fixed order — environments, vaults, agents, teammates, schedules, webhooks — so a spec may name another document whatever the file's order: an agent's `environment`, a teammate's `agent`, `environment` and `vault`, and a schedule's `teammate`. Every kind is keyed by the document's `name`, except `Webhook`, which is keyed by `spec.url`. A `Webhook` created here returns its signing secret once, on that result row, and a manifest that holds one needs a full-scope credential. A `Teammate` is read as a whole declaration, so an absent `environment` or `vault` clears that binding, and moving either retires the computer the old binding named (refused with an error on that row while a turn is running on it). Two Teammate documents may not name the same agent. Apply is additive: a document dropped from the manifest leaves its record in place. Application is best-effort per resource: the response is 200 even when an individual resource fails validation, is refused by its context or raises, with per-resource errors in the result entries.
          */
         post: operations["FountainWeb.ApplyController.create"];
         delete?: never;
@@ -2809,6 +2809,11 @@ export interface components {
             } | null;
             kind: string;
             name: string;
+            /**
+             * @description A Webhook endpoint's HMAC-SHA256 signing secret, on the apply that created it. Store it; it is not shown again, and an update never returns it. Null on every other row.
+             * @example whsec_Zm91bnRhaW4tZXhhbXBsZS1zZWNyZXQtdmFsdWU
+             */
+            secret?: string | null;
             secrets?: components["schemas"]["ApplySecretResult"][];
         };
         /**
@@ -3909,11 +3914,11 @@ export interface components {
         };
         /**
          * ManifestResource
-         * @description One compiled document from a fountain.yml manifest. `spec` matches the create/update schema for the kind, plus an inline `secrets` map (Environment and Vault). Specs reference other documents by name, and the server resolves each to an id: an Agent's `environment`, a Teammate's `agent`, `environment` and `vault`, and a Schedule's `teammate`. Teammate specs take `agent`, `environment` and `vault`, and a Teammate document is read as a whole declaration, so an absent `environment` or `vault` clears that binding. Schedule specs take `teammate` plus the TeamScheduleCreateRequest fields `cron`, `prompt`, `one_off` and `enabled`.
+         * @description One compiled document from a fountain.yml manifest. `spec` matches the create/update schema for the kind, plus an inline `secrets` map (Environment and Vault). Specs reference other documents by name, and the server resolves each to an id: an Agent's `environment`, a Teammate's `agent`, `environment` and `vault`, and a Schedule's `teammate`. Teammate specs take `agent`, `environment` and `vault`, and a Teammate document is read as a whole declaration, so an absent `environment` or `vault` clears that binding. Schedule specs take `teammate` plus the TeamScheduleCreateRequest fields `cron`, `prompt`, `one_off` and `enabled`; Webhook specs take the WebhookEndpointCreateRequest fields `url`, `description` and `event_types`, and are keyed by `url` rather than by `name`.
          */
         ManifestResource: {
             /** @enum {string} */
-            kind: "Environment" | "Vault" | "Agent" | "Teammate" | "Schedule";
+            kind: "Environment" | "Vault" | "Agent" | "Teammate" | "Schedule" | "Webhook";
             name: string;
             spec?: {
                 [key: string]: unknown;

--- a/sdk/typescript/src/http.ts
+++ b/sdk/typescript/src/http.ts
@@ -19,7 +19,7 @@ export interface RequestOptions {
  * this string is already what Fountain's request logs are keyed on. The
  * version half is asserted against `package.json` by a test.
  */
-export const USER_AGENT = "fountain-sdk-js/1.23.0";
+export const USER_AGENT = "fountain-sdk-js/1.24.0";
 
 /**
  * The thin layer everything else is built on: one bearer token, JSON in and


### PR DESCRIPTION
The last kind, and the last PR of the stack.

A `Webhook` document is keyed by `spec.url` rather than by the document name —
the endpoint the tenant already has for that URL is the one the document
describes, and the name is a label carried into the result row so
`fountain apply` prints something a reader picked. Change the URL and the next
apply creates a *second* endpoint; nothing is pruned, and the first one keeps
delivering until it is deleted.

`Fountain.Webhooks.create_endpoint/3` hands the signing secret back on the
apply that mints it. The result row carries it once, exactly as
`POST /api/webhooks` does, and an update never does. The CLI prints it where
the reader is looking, with the line saying it is not shown again.

**The scope boundary.** `POST /api/webhooks` is behind `RequireFullScope`, and
apply is not, so without this a sandbox-scoped token could mint an endpoint
through a manifest that the dedicated route refuses it. The controller now
runs the same plug over any manifest containing a `Webhook`, before
`apply_manifest/3`, and returns the halted connection — so a refused mixed
manifest writes none of its *other* resources either.

That completes #1636: one manifest now reconciles `Environment`, `Vault`,
`Agent`, `Teammate`, `Schedule` and `Webhook`, in that order. Apply stays
additive and prunes nothing. The audit actions keep their existing names
(`team.*`, `team.schedule.*`, `webhook_endpoint.*`) rather than the `webhook.*`
the issue wrote, because renaming a live audit vocabulary breaks every trail
already recorded; the deviation is stated in the manual.

This PR carries the SDK version bump for the whole stack — the generated types
for all three kinds, the `unchanged` action and the one-time `secret` — so the
package publishes once, at the end, rather than racing on `main` eight times.

Closes #1636
Closes #1675

Validation: `mix precommit`, `go test ./...` and `go vet ./...` in `cli/`, the
SDK contract check, the TypeScript and Python verifiers, the conformance lint.

---

**The stack** (each PR is based on the one above it; review and merge top down):

1. `stack/1680-unchanged-verdict` — a save that changes nothing records nothing (#1680)
2. `stack/1636-apply-isolation` — a raise in one apply document fails that row
3. `stack/1636-cotenant-identity` — a co-tenant follows a replacement only if it declared the same identity
4. `stack/1636-update-teammate` — Team.update_teammate/4
5. `stack/1636-cli-group-by-kind` — CLI: group apply documents by kind
6. `stack/1636-teammate-kind` — apply reconciles Teammate documents
7. `stack/1636-schedule-kind` — apply reconciles Schedule documents
8. `stack/1636-webhook-kind` — apply reconciles Webhook documents (#1636) ← **this one**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WQyc3wWWDAeZJE1Vr6etQa