### PR TITLE
Publish the TypeScript SDK as @managoat/fountain-sdk (hold for npm setup)

### DIFF
--- a/.claude/skills/build-fountain-app/SKILL.md
+++ b/.claude/skills/build-fountain-app/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: build-fountain-app
-description: Build an application on top of the Fountain API — a browser app, a bot, an internal tool, anything that hires agents, sends them prompts and renders what they do. Use whenever the user says "build an app on Fountain", "a client for Fountain", "another fountain-team / workbench / demo app", "Sign in with Fountain", or wants to ship something that talks to /api from its own origin. Covers the published TypeScript SDK (@agentshit/fountain-sdk), the shape (static SPA on the SDK, or a small server in front), auth (OAuth code + PKCE, tokens are API keys), streaming, the server-side registration an app needs (API_CORS_ORIGINS, OAUTH_CLIENTS), a hosting recipe for any static host or container, and the traps every previous app hit.
+description: Build an application on top of the Fountain API — a browser app, a bot, an internal tool, anything that hires agents, sends them prompts and renders what they do. Use whenever the user says "build an app on Fountain", "a client for Fountain", "another fountain-team / workbench / demo app", "Sign in with Fountain", or wants to ship something that talks to /api from its own origin. Covers the published TypeScript SDK (@managoat/fountain-sdk), the shape (static SPA on the SDK, or a small server in front), auth (OAuth code + PKCE, tokens are API keys), streaming, the server-side registration an app needs (API_CORS_ORIGINS, OAUTH_CLIENTS), a hosting recipe for any static host or container, and the traps every previous app hit.
 ---
 
 # Build an app on Fountain
@@ -30,7 +30,7 @@ code, do not re-derive it**:
 
 ## The SDK is the client
 
-[`@agentshit/fountain-sdk`](https://www.npmjs.com/package/@agentshit/fountain-sdk)
+[`@managoat/fountain-sdk`](https://www.npmjs.com/package/@managoat/fountain-sdk)
 is published on npm (1.0.0, Apache-2.0, no runtime dependencies, Node ≥ 20.19,
 browser-safe by default). Its source is `sdk/typescript/` in this repo;
 `docs/sdk.md` is the manual and `sdk/typescript/examples/*.ts` are compiled
@@ -39,11 +39,11 @@ parser — the SDK is those, done once, and its types are generated from the
 server's OpenAPI document so they cannot drift.
 
 ```bash
-npm install @agentshit/fountain-sdk
+npm install @managoat/fountain-sdk
 ```
 
 ```ts
-import { Fountain, ConversationBusyError } from "@agentshit/fountain-sdk";
+import { Fountain, ConversationBusyError } from "@managoat/fountain-sdk";
 
 const fountain = new Fountain({ baseUrl, apiKey });   // in a browser: what the person gave you
 const me = await fountain.me();                        // the cheapest check that a key works
@@ -87,7 +87,7 @@ Ask one question: **does anyone besides the key's owner need to see the
 data?**
 
 - **No** → a static SPA. No backend. Key in `localStorage`, OAuth for
-  sign-in, `@agentshit/fountain-sdk` in the browser. This is fountain-team,
+  sign-in, `@managoat/fountain-sdk` in the browser. This is fountain-team,
   fountain-conversations, dns-desk and all six demo apps. Default here.
 - **Yes** (sharing, cross-user rooms, a credential the browser must not
   hold, your own data model) → the workbench shape: a small server that
@@ -105,7 +105,7 @@ channel must not *resume* an existing conversation.
 
 ## 2. Stack
 
-bun + vite + react + TypeScript, `@agentshit/fountain-sdk` (current
+bun + vite + react + TypeScript, `@managoat/fountain-sdk` (current
 `1.0.0`; the `browser` export condition works under Vite, no runtime deps).
 Use the SDK. fountain-team and the demo apps predate it and vendor a
 hand-rolled `src/api/client.ts` + `lib/sse.ts` + `lib/acp.ts` from dns-desk;

--- a/.claude/skills/build-fountain-app/references/traps.md
+++ b/.claude/skills/build-fountain-app/references/traps.md
@@ -44,6 +44,6 @@ noted.
 
 ## SDK
 
-- `@agentshit/fountain-sdk` 1.0.0 (2026-08-25): credits vocabulary; `402 insufficient_credits` maps to `SubscriptionRequiredError` (name kept); `fleet_full` → `NotReadyError`.
+- `@managoat/fountain-sdk` 1.0.0 (2026-08-25): credits vocabulary; `402 insufficient_credits` maps to `SubscriptionRequiredError` (name kept); `fleet_full` → `NotReadyError`.
 - Anything the SDK does not wrap: `fountain.request(method, path, { query, body })` or `fountain.api.raw(...)` for bytes.
 - An OpenAPI property with a `default:` generates as **required** in the SDK types; if a call won't typecheck for a field the server defaults, that is why (fix in `schemas.ex` → regenerate, not in the app).

--- a/.github/workflows/sdk-bootstrap-publish.yml
+++ b/.github/workflows/sdk-bootstrap-publish.yml
@@ -1,0 +1,141 @@
+name: Bootstrap a renamed SDK package
+
+# ONE-OFF, and it deletes itself: see the PR that added it (the SDK's move to
+# the managoat scope, decisions/0048).
+#
+# npm configures a trusted publisher **per package, in that package's
+# settings**, and a package that does not exist yet has no settings page —
+# there is no PyPI-style pending publisher. So the very first version of a
+# renamed package cannot be an OIDC publish, however the repo is configured.
+#
+# This publishes that first version with a short-lived granular token, and does
+# it from CI rather than a laptop for the two reasons sdk/typescript's own
+# ci-publishes.mjs guard exists: the publish is attributable to a workflow and
+# a commit, and `--provenance` still attaches an attestation because the runner
+# can mint an OIDC token even when npm authenticates with the token.
+#
+# Order of operations:
+#   1. a granular token (read+write, @managoat scope, 2FA bypass, short expiry)
+#      lands in the NPM_TOKEN secret
+#   2. run this workflow on the branch that carries the renamed package
+#   3. configure the trusted publisher on the new package, then
+#      "Require two-factor authentication and disallow bypass 2fa tokens"
+#   4. revoke the token, delete the secret, delete this file
+#
+# After step 3 the ordinary path (sdk-publish.yml, OIDC, provenance generated
+# automatically) is the only publisher again.
+
+on:
+  workflow_dispatch:
+    inputs:
+      provenance:
+        description: "Attach provenance. Turn off only if npm's OIDC-first attempt refuses to fall back to the token."
+        type: boolean
+        default: true
+      dry_run:
+        description: "Pack and print what would be published, without publishing."
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish the version in sdk/typescript
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    permissions:
+      contents: read
+      # Provenance, not authentication: npm tries OIDC first and falls back to
+      # NODE_AUTH_TOKEN, which is the only credential that can work here.
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          cache: npm
+          cache-dependency-path: sdk/typescript/package-lock.json
+
+      # Same assertion sdk-publish.yml makes, for the same reason: a too-old
+      # npm fails provenance in a way that reads as an auth problem.
+      - name: npm is new enough for provenance
+        run: |
+          version=$(npm -v)
+          echo "npm $version"
+          major=${version%%.*}
+          rest=${version#*.}
+          minor=${rest%%.*}
+          if [ "$major" -lt 11 ] || { [ "$major" -eq 11 ] && [ "$minor" -lt 5 ]; }; then
+            echo "::error::npm $version is too old (need >= 11.5)." >&2
+            exit 1
+          fi
+
+      - name: The secret has to be there
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ -z "${NPM_TOKEN}" ]; then
+            echo "::error::NPM_TOKEN is not set. This workflow exists only to create a package that cannot yet have a trusted publisher; it needs a short-lived granular token with write access to the scope." >&2
+            exit 1
+          fi
+
+      - name: What are we publishing, and is it already there?
+        id: what
+        working-directory: sdk/typescript
+        run: |
+          set -euo pipefail
+          name=$(node -p "require('./package.json').name")
+          version=$(node -p "require('./package.json').version")
+          echo "$name@$version"
+          code=$(curl -sS -o /dev/null -w '%{http_code}' \
+            "https://registry.npmjs.org/$(node -p "encodeURIComponent('$name')")/$version")
+          case "$code" in
+            404) echo "not on npm yet" ;;
+            200) echo "::error::$name@$version is already on npm. npm never allows a version to be republished." >&2; exit 1 ;;
+            *) echo "::error::the registry answered $code for $name@$version." >&2; exit 1 ;;
+          esac
+          {
+            echo "name=$name"
+            echo "version=$version"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Install
+        working-directory: sdk/typescript
+        run: npm ci
+
+      # prepublishOnly runs typecheck, tests and the build, so a broken tree
+      # cannot become the first version anyone installs.
+      - name: Publish
+        working-directory: sdk/typescript
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          FOUNTAIN_CI_PUBLISH: "1"
+          NPM_CONFIG_PROVENANCE: ${{ inputs.provenance }}
+        run: |
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            npm publish --dry-run
+          else
+            npm publish
+          fi
+
+      - name: What to do next
+        if: ${{ success() && inputs.dry_run != true }}
+        env:
+          NAME: ${{ steps.what.outputs.name }}
+          VERSION: ${{ steps.what.outputs.version }}
+        run: |
+          {
+            echo "### Published \`$NAME@$VERSION\`"
+            echo
+            echo "Now close the bootstrap:"
+            echo
+            echo "1. npmjs.com → \`$NAME\` → Settings → Trusted Publisher → add GitHub Actions, \`${{ github.repository }}\`, \`sdk-publish.yml\`"
+            echo "2. Publishing access → *Require two-factor authentication and disallow bypass 2fa tokens*"
+            echo "3. Revoke the granular token, delete the \`NPM_TOKEN\` secret, delete \`.github/workflows/sdk-bootstrap-publish.yml\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/sdk-publish.yml
+++ b/.github/workflows/sdk-publish.yml
@@ -1,6 +1,6 @@
 name: Publish SDK
 
-# Publishes `@agentshit/fountain-sdk` to npm. **CI is the only publisher** —
+# Publishes `@managoat/fountain-sdk` to npm. **CI is the only publisher** —
 # nothing is ever released from a laptop.
 #
 # The trigger is the version itself: merge a PR that bumps
@@ -149,7 +149,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag -a "$TAG" -m "@agentshit/fountain-sdk ${TAG#sdk-v}" "$GITHUB_SHA"
+          git tag -a "$TAG" -m "@managoat/fountain-sdk ${TAG#sdk-v}" "$GITHUB_SHA"
           git push origin "$TAG"
 
       - name: Say what happened
@@ -159,9 +159,9 @@ jobs:
         run: |
           if [ "$NEEDED" = "yes" ]; then
             {
-              echo "### Published \`@agentshit/fountain-sdk@$VERSION\`"
+              echo "### Published \`@managoat/fountain-sdk@$VERSION\`"
               echo
-              echo "https://www.npmjs.com/package/@agentshit/fountain-sdk/v/$VERSION"
+              echo "https://www.npmjs.com/package/@managoat/fountain-sdk/v/$VERSION"
               echo
               echo "Tagged \`sdk-v$VERSION\` at \`$GITHUB_SHA\`. Verify the provenance with"
               echo '`npm audit signatures` after installing.'
@@ -173,7 +173,7 @@ jobs:
             {
               echo "### Nothing to publish"
               echo
-              echo "\`@agentshit/fountain-sdk@$VERSION\` is already on npm. This push"
+              echo "\`@managoat/fountain-sdk@$VERSION\` is already on npm. This push"
               echo "changed the SDK without changing its version, which is fine for"
               echo "tests, examples and the changelog."
             } >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,23 @@ upgrade, is in
 
 ## [Unreleased]
 
+### Changed
+
+- **The project moved to `github.com/managoat/fountain`** and every coordinate
+  that named the old owner moved with it (`decisions/0048`). The container
+  image is `ghcr.io/managoat/fountain`, the Homebrew tap is
+  `brew install managoat/tap/fountain`, and the Go module paths are
+  `github.com/managoat/fountain/cli` and `.../apps/fountain_buzz/cli`. Old
+  URLs redirect, so a clone, a `git remote`, an issue link or a release-asset
+  download keeps working; the published image tags `v0.16.0` and `v0.16` exist
+  at both paths. Two things do not follow a redirect and need an edit:
+  `go install` of the old module path now refuses with a module-path mismatch,
+  and the retired GitHub Pages doc URLs under the old account are gone.
+
+- **The TypeScript SDK is published as `@managoat/fountain-sdk`.** Same library
+  and version line; `@agentshit/fountain-sdk` keeps its published versions and
+  receives no new ones. See `sdk/typescript/CHANGELOG.md`.
+
 ### Added
 
 - Environment `setup_timeout_seconds` (1–900, default 120) lets cold repository

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ code actually reaches for.
 The CLI and the SDKs are convenience wrappers over the REST API. Everything they do, you can do with `curl`.
 
 ```bash
-npm install @agentshit/fountain-sdk
+npm install @managoat/fountain-sdk
 # or
 pip install fountain-agent-sdk
 # or add {:fountain_sdk, "~> 0.1.0"} to mix.exs
@@ -112,7 +112,7 @@ Add Fountain with Swift Package Manager:
 ```
 
 ```ts
-import { Fountain } from "@agentshit/fountain-sdk";
+import { Fountain } from "@managoat/fountain-sdk";
 
 const run = await new Fountain().run("Upgrade us to Phoenix 1.8 and open a PR", {
   agent: "reposage",

--- a/apps/fountain/lib/fountain_web/controllers/llms_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/llms_controller.ex
@@ -208,7 +208,7 @@ defmodule FountainWeb.LlmsController do
 
       - [OpenAPI 3 spec](#{base}/api/openapi.json): machine-readable, the authority on request and response shapes
       - [Swagger UI](#{base}/api/docs): interactive try-it, click "Authorize" to set your bearer token
-      - [TypeScript SDK](https://www.npmjs.com/package/@agentshit/fountain-sdk): `npm install @agentshit/fountain-sdk`
+      - [TypeScript SDK](https://www.npmjs.com/package/@managoat/fountain-sdk): `npm install @managoat/fountain-sdk`
       - [Python SDK](#{base}/docs/python-sdk): `pip install fountain-agent-sdk`
       - [CLI (Homebrew)](https://github.com/managoat/homebrew-tap): `brew install managoat/tap/fountain`
       - [Example agent specs](https://github.com/jhgaylor/agent-specs): public manifest tree you can `fountain apply`

--- a/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
+++ b/apps/fountain/lib/fountain_web/controllers/marketing_html.ex
@@ -167,7 +167,7 @@ defmodule FountainWeb.MarketingHTML do
   """
   def sdk_example do
     """
-    import { Fountain } from "@agentshit/fountain-sdk";
+    import { Fountain } from "@managoat/fountain-sdk";
 
     const fountain = new Fountain(); // FOUNTAIN_API_KEY
 
@@ -203,7 +203,7 @@ defmodule FountainWeb.MarketingHTML do
         body:
           "Repositories, packages, env vars and setup scripts. The Environment is reusable across agents and runs.",
         code: """
-        import { Fountain } from "@agentshit/fountain-sdk";
+        import { Fountain } from "@managoat/fountain-sdk";
 
         const fountain = new Fountain(); // FOUNTAIN_API_KEY
 
@@ -274,7 +274,7 @@ defmodule FountainWeb.MarketingHTML do
   @doc "The two-turn launch example, kept out of the template so its braces are not HEEx."
   def launch_example do
     """
-    import { Fountain } from "@agentshit/fountain-sdk";
+    import { Fountain } from "@managoat/fountain-sdk";
 
     const fountain = new Fountain(); // FOUNTAIN_API_KEY
 
@@ -853,7 +853,7 @@ defmodule FountainWeb.MarketingHTML do
           },
           %{name: "Team", slug: nil, note: "the team messenger, on the same public API"},
           %{name: "Workbench", slug: nil, note: "the shared engineering workbench"},
-          %{name: "TypeScript", slug: "typescript", note: "@agentshit/fountain-sdk on npm"},
+          %{name: "TypeScript", slug: "typescript", note: "@managoat/fountain-sdk on npm"},
           %{name: "Python", slug: "python", note: "fountain-agent-sdk on PyPI"},
           %{name: "Go", slug: "go", note: "the fountain CLI, and its source"},
           %{
@@ -1078,7 +1078,7 @@ defmodule FountainWeb.MarketingHTML do
         lang: "ts",
         docs: "/docs/build",
         code: """
-        import { Fountain } from "@agentshit/fountain-sdk";
+        import { Fountain } from "@managoat/fountain-sdk";
 
         const fountain = new Fountain({ apiKey: token }); // from the OAuth flow
         const conv = await fountain.conversations.create({ agent: "reviewer" });
@@ -2183,7 +2183,7 @@ defmodule FountainWeb.MarketingHTML do
   def review_bot_webhook do
     """
     // api/github/webhook.ts
-    import { Fountain } from "@agentshit/fountain-sdk";
+    import { Fountain } from "@managoat/fountain-sdk";
     import { verify } from "@octokit/webhooks-methods";
 
     export async function POST(req: Request) {

--- a/apps/fountain/lib/fountain_web/live/start_live.ex
+++ b/apps/fountain/lib/fountain_web/live/start_live.ex
@@ -315,7 +315,7 @@ defmodule FountainWeb.StartLive do
           </div>
           <pre class="bg-[var(--color-bg-2)] rounded border border-[var(--color-border)] px-3 py-2 text-xs font-mono overflow-x-auto"><code id="start-ts">{typescript(assigns)}</code></pre>
           <p class="text-xs text-[var(--color-text-muted)]">
-            <code class="font-mono">npm install @agentshit/fountain-sdk</code>
+            <code class="font-mono">npm install @managoat/fountain-sdk</code>
           </p>
         </div>
       </section>

--- a/apps/fountain/test/fountain/onboarding_test.exs
+++ b/apps/fountain/test/fountain/onboarding_test.exs
@@ -29,7 +29,7 @@ defmodule Fountain.OnboardingTest do
     test "the curl posts a conversation and the TypeScript runs the SDK" do
       assert Onboarding.curl_template() =~ "/api/conversations"
       assert Onboarding.curl_template() =~ "Authorization: Bearer"
-      assert Onboarding.typescript_template() =~ "@agentshit/fountain-sdk"
+      assert Onboarding.typescript_template() =~ "@managoat/fountain-sdk"
       assert Onboarding.typescript_template() =~ "fountain.run("
     end
 

--- a/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/marketing_controller_test.exs
@@ -183,7 +183,7 @@ defmodule FountainWeb.MarketingControllerTest do
       assert body =~ "obra/superpowers"
       assert body =~ "https://mcp.deepwiki.com/mcp"
       assert body =~ "vault: &quot;ci-bot&quot;"
-      assert body =~ "@agentshit/fountain-sdk"
+      assert body =~ "@managoat/fountain-sdk"
       assert length(Regex.scan(~r/data-role="sdk-walkthrough-step"/, body)) == 4
       refute body =~ "kind: Environment"
       refute body =~ "fountain apply -f fountain.yml"
@@ -382,7 +382,7 @@ defmodule FountainWeb.MarketingControllerTest do
       assert body =~ "@ag-ui/client"
       assert body =~ "fountain acp"
       assert body =~ "/v1/chat/completions"
-      assert body =~ "@agentshit/fountain-sdk"
+      assert body =~ "@managoat/fountain-sdk"
     end
 
     test "carries its own card", %{conn: conn} do

--- a/docs/build/team-chat.md
+++ b/docs/build/team-chat.md
@@ -13,7 +13,7 @@ bearer token.
 ## 1. A client
 
 ```ts
-import { Fountain } from "@agentshit/fountain-sdk";
+import { Fountain } from "@managoat/fountain-sdk";
 
 const fountain = new Fountain({
   baseUrl: "https://fountain.example.com",   // your instance
@@ -202,7 +202,7 @@ Each turn is a pair of bubbles. The words, and everything the agent did about
 them. Group the feed by `turn_id` and you have both.
 
 ```ts
-import type { Block, LogEvent, Turn } from "@agentshit/fountain-sdk";
+import type { Block, LogEvent, Turn } from "@managoat/fountain-sdk";
 
 function bubbles(turns: Turn[], events: LogEvent[]) {
   const byTurn = new Map<string, Block[]>();
@@ -261,7 +261,7 @@ ACP parser. Do not repeat that.
 message sent mid-turn, and the right answer is not an error toast.
 
 ```ts
-import { ConversationBusyError } from "@agentshit/fountain-sdk";
+import { ConversationBusyError } from "@managoat/fountain-sdk";
 
 try {
   await fountain.team.message("watchtower", text);

--- a/docs/open-source.md
+++ b/docs/open-source.md
@@ -43,7 +43,7 @@ holds the third-party attribution.
 | The reasons behind the design | `decisions/` in the repo. The ADRs are not on this site. |
 | The hosted instance | [managoat.com](https://managoat.com) |
 | The CLI | `brew install managoat/tap/fountain`, or the [CLI reference](cli.md). |
-| The TypeScript SDK | `@agentshit/fountain-sdk` on npm, or the [TypeScript reference](sdk.md). |
+| The TypeScript SDK | `@managoat/fountain-sdk` on npm, or the [TypeScript reference](sdk.md). |
 | The Python SDK | `fountain-agent-sdk` on PyPI, or the [Python reference](python-sdk.md). |
 | The Elixir SDK | [`fountain_sdk`](https://hex.pm/packages/fountain_sdk) on Hex, the [`sdk/elixir`](https://github.com/managoat/fountain/tree/main/sdk/elixir) source, or the [Elixir reference](elixir-sdk.md). |
 | The Swift SDK | The [`sdk/swift`](https://github.com/managoat/fountain/tree/main/sdk/swift) source, or the [Swift reference](swift-sdk.md). SwiftPM reads the `Package.swift` at the repository root. |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -49,7 +49,7 @@ request.
 ## The same request from the SDK
 
 ```bash
-npm install @agentshit/fountain-sdk
+npm install @managoat/fountain-sdk
 ```
 
 ```ts

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -4,7 +4,7 @@ The REST API describes machinery. Conversations, turns, log events, blocks.
 The SDK describes the job.
 
 ```ts
-import { Fountain } from "@agentshit/fountain-sdk";
+import { Fountain } from "@managoat/fountain-sdk";
 
 const fountain = new Fountain();
 
@@ -22,7 +22,7 @@ The source lives in
 It has no runtime dependency, and it needs Node 20.19 or newer.
 
 ```bash
-npm install @agentshit/fountain-sdk
+npm install @managoat/fountain-sdk
 ```
 
 ## What the second argument is for
@@ -420,7 +420,7 @@ schema in Elixir reaches the SDK on the next build. A type here can never
 describe an API that has gone.
 
 ```ts
-import type { components, paths } from "@agentshit/fountain-sdk";
+import type { components, paths } from "@managoat/fountain-sdk";
 
 type Teammate = components["schemas"]["Teammate"];
 ```

--- a/docs/snippets/first-request.ts
+++ b/docs/snippets/first-request.ts
@@ -1,4 +1,4 @@
-import { Fountain } from "@agentshit/fountain-sdk";
+import { Fountain } from "@managoat/fountain-sdk";
 
 const fountain = new Fountain();
 const run = await fountain.run(

--- a/docs/tour.md
+++ b/docs/tour.md
@@ -22,11 +22,11 @@ has answered on your account yet.
   the smallest one that works.
 
 ```bash
-npm install @agentshit/fountain-sdk
+npm install @managoat/fountain-sdk
 ```
 
 ```ts
-import { Fountain } from "@agentshit/fountain-sdk";
+import { Fountain } from "@managoat/fountain-sdk";
 
 const fountain = new Fountain();          // FOUNTAIN_API_KEY
 const REPO = "https://github.com/you/your-app";

--- a/scripts/sdk-publish-tag.test.mjs
+++ b/scripts/sdk-publish-tag.test.mjs
@@ -40,10 +40,10 @@ test("registry errors and malformed data fail closed", async () => {
   for (const body of [null, {}, { versions: null }, { versions: [] }]) {
     assert.throws(() => publishTag("1.18.0", body), /versions map/);
   }
-  await assert.rejects(registryState("@agentshit/fountain-sdk", async () => new Response("unavailable", { status: 503 })), /503/);
-  await assert.rejects(registryState("@agentshit/fountain-sdk", async () => new Response("not JSON")), SyntaxError);
-  assert.deepEqual(await registryState("@agentshit/fountain-sdk", async (url) => {
-    assert.equal(url, "https://registry.npmjs.org/%40agentshit%2Ffountain-sdk");
+  await assert.rejects(registryState("@managoat/fountain-sdk", async () => new Response("unavailable", { status: 503 })), /503/);
+  await assert.rejects(registryState("@managoat/fountain-sdk", async () => new Response("not JSON")), SyntaxError);
+  assert.deepEqual(await registryState("@managoat/fountain-sdk", async (url) => {
+    assert.equal(url, "https://registry.npmjs.org/%40managoat%2Ffountain-sdk");
     return new Response("missing", { status: 404 });
   }), { versions: {} });
 });

--- a/sdk/contract/manifests/typescript.json
+++ b/sdk/contract/manifests/typescript.json
@@ -1,6 +1,6 @@
 {
   "sdk": "typescript",
-  "package": "@agentshit/fountain-sdk",
+  "package": "@managoat/fountain-sdk",
   "directory": "sdk/typescript",
   "verify": "npm run verify-contract",
   "note": "Wire types for the whole document are generated into src/generated/openapi.ts and `npm run generate` proves they are current. What this manifest adds is the hand-written layer above them: the fields run(), the turn follower and the resources reach for by name, which no type check can pin to the wire.",

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
-Notable changes to `@agentshit/fountain-sdk`. Format:
+Notable changes to `@managoat/fountain-sdk`, published as
+`@agentshit/fountain-sdk` up to 1.23.0. Format:
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [SemVer](https://semver.org/).
 
@@ -9,6 +10,25 @@ API, which is additive, so a given SDK release keeps working against later
 server releases.
 
 ---
+
+## [1.24.0] - 2026-09-10
+
+### Changed
+
+- **The package is now `@managoat/fountain-sdk`.** Same library, same API, same
+  version line: 1.24.0 follows 1.23.0. Update the dependency and the import
+  specifier; nothing else about your code changes.
+
+  ```
+  npm remove @agentshit/fountain-sdk
+  npm install @managoat/fountain-sdk
+  ```
+
+  `@agentshit/fountain-sdk` keeps every version it has ever published, so
+  existing installs and lockfiles go on resolving. It will receive no new
+  ones. The move follows the repository into the managoat organization
+  (`decisions/0048`), which is also where the scope that publishes this
+  package now lives.
 
 ## [1.23.0] - 2026-09-07
 

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -1,9 +1,9 @@
-# @agentshit/fountain-sdk
+# @managoat/fountain-sdk
 
 Give an agent a computer, your repos and your credentials — in one call.
 
 ```ts
-import { Fountain } from "@agentshit/fountain-sdk";
+import { Fountain } from "@managoat/fountain-sdk";
 
 const fountain = new Fountain();
 
@@ -91,7 +91,7 @@ tests.
 ## Install
 
 ```bash
-npm install @agentshit/fountain-sdk
+npm install @managoat/fountain-sdk
 ```
 
 Node 20.19+ (native `fetch` and ESM). No runtime dependencies.
@@ -327,7 +327,7 @@ sent more than one person hunting through their own code.
 
 `src/generated/openapi.ts` is produced from the same OpenAPI document the
 server serves, and CI regenerates it and fails on a diff — so the types cannot
-drift from the API. `import type { components, paths } from "@agentshit/fountain-sdk"` for
+drift from the API. `import type { components, paths } from "@managoat/fountain-sdk"` for
 the raw shapes. What is hand-written is what a spec cannot express: that many
 log events fold into one turn, and which of 85 paths are worth a verb.
 

--- a/sdk/typescript/examples/pull-request.ts
+++ b/sdk/typescript/examples/pull-request.ts
@@ -16,7 +16,7 @@
  * (Inside this repository the import below resolves to the SDK itself, so run
  * `npm run build` in sdk/typescript first. Installed from npm it just works.)
  */
-import { Fountain } from "@agentshit/fountain-sdk";
+import { Fountain } from "@managoat/fountain-sdk";
 
 const repo = process.env.REPO_URL;
 const token = process.env.GITHUB_TOKEN;

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@agentshit/fountain-sdk",
-  "version": "1.23.0",
+  "name": "@managoat/fountain-sdk",
+  "version": "1.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@agentshit/fountain-sdk",
-      "version": "1.23.0",
+      "name": "@managoat/fountain-sdk",
+      "version": "1.24.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^26.4.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@agentshit/fountain-sdk",
-  "version": "1.23.0",
+  "name": "@managoat/fountain-sdk",
+  "version": "1.24.0",
   "description": "Run a coding agent on a real computer, with your repos and your credentials, in one call.",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/sdk/typescript/src/config.ts
+++ b/sdk/typescript/src/config.ts
@@ -35,7 +35,7 @@ function unquote(value: string): string {
  *
  * The eleven apps built on Fountain so far are browser apps, and a bare
  * `import "node:fs"` at the top of this module breaks their bundles. So the
- * file reader is injected: `@agentshit/fountain-sdk` resolves to a Node entry that
+ * file reader is injected: `@managoat/fountain-sdk` resolves to a Node entry that
  * installs one, and to this browser-safe module everywhere else. Nothing here
  * touches a Node built-in.
  */

--- a/sdk/typescript/src/http.ts
+++ b/sdk/typescript/src/http.ts
@@ -15,11 +15,11 @@ export interface RequestOptions {
 
 /**
  * The product token this client sends. Deliberately not the package name: a
- * scope reads as a second token in a User-Agent (`@agentshit/…/0.1.1`), and
+ * scope reads as a second token in a User-Agent (`@managoat/…/0.1.1`), and
  * this string is already what Fountain's request logs are keyed on. The
  * version half is asserted against `package.json` by a test.
  */
-export const USER_AGENT = "fountain-sdk-js/1.23.0";
+export const USER_AGENT = "fountain-sdk-js/1.24.0";
 
 /**
  * The thin layer everything else is built on: one bearer token, JSON in and

--- a/sdk/typescript/src/node.ts
+++ b/sdk/typescript/src/node.ts
@@ -3,7 +3,7 @@
  *
  * Everything the SDK does works in a browser, and `src/index.ts` is what a
  * bundler gets. The one thing that cannot work there is reading
- * `~/.fountain/credentials`, so that lives here: importing `@agentshit/fountain-sdk`
+ * `~/.fountain/credentials`, so that lives here: importing `@managoat/fountain-sdk`
  * under Node resolves to this module, which installs the reader and then
  * re-exports the same API.
  */

--- a/sdk/typescript/tsconfig.json
+++ b/sdk/typescript/tsconfig.json
@@ -22,7 +22,7 @@
     // it. Node resolves that through this package's own `exports` (to `dist`);
     // this mapping points the *typechecker* at the sources instead, so a
     // typecheck never depends on a build having happened first.
-    "paths": { "@agentshit/fountain-sdk": ["./src/node.ts"] }
+    "paths": { "@managoat/fountain-sdk": ["./src/node.ts"] }
   },
   "include": ["src/**/*.ts", "test/**/*.ts", "examples/**/*.ts"]
 }


### PR DESCRIPTION
**Draft, because merging this publishes** — and the npm side needs two things from you first (below).

The package follows the repo into the org: `@agentshit/fountain-sdk` → **`@managoat/fountain-sdk`**, 1.24.0 continuing the same version line so a consumer changes the dependency and the import specifier and nothing else.

This is not only tidiness. npm publishing here is **OIDC trusted publishing with no `NPM_TOKEN`**, and a trusted publisher names the owner, the repo *and* the workflow file — so the binding on `@agentshit/fountain-sdk` still names `BinaryBourbon/fountain`, and the next publish under the old name would fail exactly the way the PyPI one would have. I got this wrong earlier in the session when I said npm needed no configuration; provenance reads `package.json`, but the publisher binding is a separate thing and the transfer broke it.

**Before merging, on npm:**

1. The **`@managoat` scope must exist** and your account must be able to publish into it.
2. **`@managoat/fountain-sdk` needs a trusted publisher** naming `managoat/fountain` + `.github/workflows/sdk-publish.yml`. If npm won't let you configure a publisher for a package that doesn't exist yet (PyPI allows pending publishers; I couldn't verify npm's behaviour without your account), then the first version has to go up with a token once, after which OIDC takes over. Either way, merging before that is a failed publish.
3. Afterwards, worth doing: `npm deprecate "@agentshit/fountain-sdk" "moved to @managoat/fountain-sdk"`. Its published versions stay resolvable forever either way — it just stops receiving new ones.

**Renamed everywhere the name is live** (27 files): `package.json`, `package-lock.json`, the tsconfig path mapping, `src/http.ts`, `src/config.ts`, `src/node.ts`, the contract manifest, `sdk-publish.yml`'s messages and release tag, the SDK README and examples, docs (`sdk`, `quickstart`, `tour`, `open-source`, `build/team-chat`, the snippet), `README.md`, the `build-fountain-app` skill, and the runtime strings the console and `/llms.txt` render — including the onboarding and marketing tests that assert them.

**Left with the name it shipped under:** both CHANGELOGs' history and `decisions/`.

Also in here, because the next release needs it and it was the gap I flagged: a `[Unreleased]` entry for **the org move itself** — image path, tap, Go module paths, what redirects and what doesn't.

Verified locally: `npm ci`, `npm run build` and the **103-test** suite green in `sdk/typescript`; `scripts/sdk-publish-tag.test.mjs` green; `scripts/sdk-release.mjs guard` reports *"Release looks well-formed. Merging this publishes 1.24.0."*

Consumers to update after this lands, each tracked separately: `managoat/fountain-template-{chat,workflow,service-account}`, `managoat/demos`, `jhgaylor/fountain-conversations`, `jhgaylor/fountain-team`, the Workbench and `managoat/salon`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RJBSE57BbSEDF5s5fvWEga
