### PR TITLE
refactor(images): share the prompt image byte limit

### DIFF
--- a/apps/fountain/lib/fountain/images.ex
+++ b/apps/fountain/lib/fountain/images.ex
@@ -12,6 +12,8 @@ defmodule Fountain.Images do
 
   @valid_media_types ~w(image/png image/jpeg image/gif image/webp)
 
+  def max_prompt_image_bytes, do: 10 * 1024 * 1024
+
   def valid_media_types, do: @valid_media_types
 
   def valid_media_type?(media_type), do: media_type in @valid_media_types

--- a/apps/fountain/lib/fountain_web/prompt_images.ex
+++ b/apps/fountain/lib/fountain_web/prompt_images.ex
@@ -14,9 +14,7 @@ defmodule FountainWeb.PromptImages do
   `{:error, message}`.
   """
 
-  @max_image_bytes 10 * 1024 * 1024
-
-  def max_image_bytes, do: @max_image_bytes
+  def max_image_bytes, do: Fountain.Images.max_prompt_image_bytes()
 
   def decode(nil), do: {:ok, []}
   def decode([]), do: {:ok, []}
@@ -65,7 +63,7 @@ defmodule FountainWeb.PromptImages do
   defp decode_base64(_), do: {:error, "image data is required"}
 
   defp validate_size(data) do
-    if byte_size(data) > @max_image_bytes,
+    if byte_size(data) > max_image_bytes(),
       do: {:error, "image exceeds the 10MB limit"},
       else: :ok
   end


### PR DESCRIPTION
Move the existing 10 MiB prompt-image limit into `Fountain.Images` and delegate the HTTP decoder's limit to it. Future durable ingestion can share the same ceiling; current acceptance, rejection and error text are unchanged.

Two files, +4/-4, extracted from #1754. Stacked on #1796 to keep the known global-pricing test race out of validation.

Validation: 10 image-ingestion tests pass, including oversized-image rejection. Full `mix precommit --seed 828329` passes: 4,885 tests +6 doctests, zero failures.

CI passes on this revision ([run](https://github.com/managoat/fountain/actions/runs/34472143358)).



Part of #1864
