### PR TITLE
Land the one-off SDK bootstrap workflow so it can be dispatched

### DIFF
--- a/.github/workflows/sdk-bootstrap-publish.yml
+++ b/.github/workflows/sdk-bootstrap-publish.yml
@@ -1,0 +1,141 @@
+name: Bootstrap a renamed SDK package
+
+# ONE-OFF, and it deletes itself: see the PR that added it (the SDK's move to
+# the managoat scope, decisions/0048).
+#
+# npm configures a trusted publisher **per package, in that package's
+# settings**, and a package that does not exist yet has no settings page —
+# there is no PyPI-style pending publisher. So the very first version of a
+# renamed package cannot be an OIDC publish, however the repo is configured.
+#
+# This publishes that first version with a short-lived granular token, and does
+# it from CI rather than a laptop for the two reasons sdk/typescript's own
+# ci-publishes.mjs guard exists: the publish is attributable to a workflow and
+# a commit, and `--provenance` still attaches an attestation because the runner
+# can mint an OIDC token even when npm authenticates with the token.
+#
+# Order of operations:
+#   1. a granular token (read+write, @managoat scope, 2FA bypass, short expiry)
+#      lands in the NPM_TOKEN secret
+#   2. run this workflow on the branch that carries the renamed package
+#   3. configure the trusted publisher on the new package, then
+#      "Require two-factor authentication and disallow bypass 2fa tokens"
+#   4. revoke the token, delete the secret, delete this file
+#
+# After step 3 the ordinary path (sdk-publish.yml, OIDC, provenance generated
+# automatically) is the only publisher again.
+
+on:
+  workflow_dispatch:
+    inputs:
+      provenance:
+        description: "Attach provenance. Turn off only if npm's OIDC-first attempt refuses to fall back to the token."
+        type: boolean
+        default: true
+      dry_run:
+        description: "Pack and print what would be published, without publishing."
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish the version in sdk/typescript
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    permissions:
+      contents: read
+      # Provenance, not authentication: npm tries OIDC first and falls back to
+      # NODE_AUTH_TOKEN, which is the only credential that can work here.
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          cache: npm
+          cache-dependency-path: sdk/typescript/package-lock.json
+
+      # Same assertion sdk-publish.yml makes, for the same reason: a too-old
+      # npm fails provenance in a way that reads as an auth problem.
+      - name: npm is new enough for provenance
+        run: |
+          version=$(npm -v)
+          echo "npm $version"
+          major=${version%%.*}
+          rest=${version#*.}
+          minor=${rest%%.*}
+          if [ "$major" -lt 11 ] || { [ "$major" -eq 11 ] && [ "$minor" -lt 5 ]; }; then
+            echo "::error::npm $version is too old (need >= 11.5)." >&2
+            exit 1
+          fi
+
+      - name: The secret has to be there
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ -z "${NPM_TOKEN}" ]; then
+            echo "::error::NPM_TOKEN is not set. This workflow exists only to create a package that cannot yet have a trusted publisher; it needs a short-lived granular token with write access to the scope." >&2
+            exit 1
+          fi
+
+      - name: What are we publishing, and is it already there?
+        id: what
+        working-directory: sdk/typescript
+        run: |
+          set -euo pipefail
+          name=$(node -p "require('./package.json').name")
+          version=$(node -p "require('./package.json').version")
+          echo "$name@$version"
+          code=$(curl -sS -o /dev/null -w '%{http_code}' \
+            "https://registry.npmjs.org/$(node -p "encodeURIComponent('$name')")/$version")
+          case "$code" in
+            404) echo "not on npm yet" ;;
+            200) echo "::error::$name@$version is already on npm. npm never allows a version to be republished." >&2; exit 1 ;;
+            *) echo "::error::the registry answered $code for $name@$version." >&2; exit 1 ;;
+          esac
+          {
+            echo "name=$name"
+            echo "version=$version"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Install
+        working-directory: sdk/typescript
+        run: npm ci
+
+      # prepublishOnly runs typecheck, tests and the build, so a broken tree
+      # cannot become the first version anyone installs.
+      - name: Publish
+        working-directory: sdk/typescript
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          FOUNTAIN_CI_PUBLISH: "1"
+          NPM_CONFIG_PROVENANCE: ${{ inputs.provenance }}
+        run: |
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            npm publish --dry-run
+          else
+            npm publish
+          fi
+
+      - name: What to do next
+        if: ${{ success() && inputs.dry_run != true }}
+        env:
+          NAME: ${{ steps.what.outputs.name }}
+          VERSION: ${{ steps.what.outputs.version }}
+        run: |
+          {
+            echo "### Published \`$NAME@$VERSION\`"
+            echo
+            echo "Now close the bootstrap:"
+            echo
+            echo "1. npmjs.com → \`$NAME\` → Settings → Trusted Publisher → add GitHub Actions, \`${{ github.repository }}\`, \`sdk-publish.yml\`"
+            echo "2. Publishing access → *Require two-factor authentication and disallow bypass 2fa tokens*"
+            echo "3. Revoke the granular token, delete the \`NPM_TOKEN\` secret, delete \`.github/workflows/sdk-bootstrap-publish.yml\`"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Mechanics only. GitHub refuses to dispatch a `workflow_dispatch` workflow unless the file exists on the default branch, so this lands it there by itself; the publish still runs from the branch carrying the renamed package.

It does nothing until dispatched, refuses without `NPM_TOKEN`, refuses a version already on npm, and runs `prepublishOnly` (typecheck, tests, build) before publishing. Why it has to exist at all: npm configures a trusted publisher per package, in that package's settings, so the first version of a renamed package cannot be an OIDC publish — see #1809.

Deleted again once `@managoat/fountain-sdk` exists and has its publisher configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RJBSE57BbSEDF5s5fvWEga