### PR TITLE
chore(skills): point the project gardener at the org board

### DIFF
--- a/.agents/skills/fountain-project-gardener/references/project-policy.md
+++ b/.agents/skills/fountain-project-gardener/references/project-policy.md
@@ -3,10 +3,11 @@
 ## Scope and identity
 
 - Repository: `managoat/fountain`
-- Account-owned Project: `BinaryBourbon` Project `1`
-- Project URL: `https://github.com/users/BinaryBourbon/projects/1`
+- Organization-owned Project: `managoat` Project `1`
+- Project URL: `https://github.com/orgs/managoat/projects/1`
 - The Project is private. Repository collaborators should normally have Write access unless the caller specifies a narrower policy.
-- The browser may be signed in as `jhgaylor` while `gh` is signed in as `BinaryBourbon`. Verify identity at the point of mutation.
+- A superseded copy of the same board survives at `https://github.com/users/BinaryBourbon/projects/1` from before the move to the `managoat` organization. It is still private, still holds its items, and its auto-add still captures new `managoat/fountain` issues, so the two boards drift. Read it if you need history. Do not mutate it, and do not treat its contents as current.
+- Several GitHub identities can reach both boards, and the `project` scope is not on every token. Verify the active identity and the target owner at the point of mutation.
 
 Treat this as an expected configuration, not proof of current state. Query GitHub every time.
 


### PR DESCRIPTION
Part of #1815.

`.agents/skills/fountain-project-gardener/references/project-policy.md` named `users/BinaryBourbon/projects/1`. A gardening run would have read and mutated the board the project left.

### The old board is not inert

Worth recording, because the issue offers "leave it read-only as history" as an option and that is not what it is doing:

| | `users/BinaryBourbon/projects/1` | `orgs/managoat/projects/1` |
|---|---|---|
| Items | 247 | 249 |
| Has #1822, #1823 | yes | **no** |
| Has PRs #1820, #1745, #1754, #1760 | no | yes |

Both boards auto-added items today. New **issues** are landing on the old board and not on the new one; recent **pull requests** landed on the new one. So the two are already diverging in both directions, and the org board is missing the two newest issues.

The policy file now names the org board, records the old one as history that must not be mutated, and replaces the identity note that named a specific signed-in account with one about verifying identity and the `project` scope.

Deciding the old board's fate is a Projects setting, not a repository change, so #1815 stays open for it. The thing to fix there is the auto-add, not just the link.

### Checks

Reference prose in `.agents/`; no code, tests or docs pages touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RJBSE57BbSEDF5s5fvWEga
