### PR TITLE
Refuse launches inside an enclosing transaction

### DIFF
--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -2490,7 +2490,8 @@ defmodule Fountain.Conversations do
 
   def start_conversation(%{"agent_id" => agent_id, "user_id" => user_id} = attrs, opts)
       when is_binary(user_id) do
-    with %Agents.Agent{} = agent <- Agents.get_agent(agent_id, user_id) || {:error, :not_found},
+    with :ok <- require_provider_commit_boundary(),
+         %Agents.Agent{} = agent <- Agents.get_agent(agent_id, user_id) || {:error, :not_found},
          :ok <- check_execution_limits(user_id, attrs["execution_limits"]),
          {:ok, runtime_module} <- Fountain.RuntimeDispatch.for_agent(agent),
          {:ok, vault_id} <- resolve_vault_id(attrs["vault_id"], user_id, agent),
@@ -3108,7 +3109,8 @@ defmodule Fountain.Conversations do
          opts
        )
        when is_binary(user_id) do
-    with %Agents.Agent{} = agent <- Agents.get_agent(agent_id, user_id) || {:error, :not_found},
+    with :ok <- require_provider_commit_boundary(),
+         %Agents.Agent{} = agent <- Agents.get_agent(agent_id, user_id) || {:error, :not_found},
          :ok <- check_execution_limits(user_id, attrs["execution_limits"]),
          {:ok, _runtime_module} <- Fountain.RuntimeDispatch.for_agent(agent),
          {:ok, vault_id} <- resolve_vault_id(attrs["vault_id"], user_id, agent),
@@ -3227,6 +3229,12 @@ defmodule Fountain.Conversations do
       record_execution_allowance_created(allowance, conv.user_id, opts)
       {:ok, conv}
     end
+  end
+
+  # A nested transaction does not commit: workers and provider calls must not
+  # escape a caller's transaction that can still roll back the accepted rows.
+  defp require_provider_commit_boundary do
+    if Repo.in_transaction?(), do: {:error, :provider_transaction_open}, else: :ok
   end
 
   defp deliver_attach_prompt(conv, attrs, opts) do
@@ -3667,7 +3675,8 @@ defmodule Fountain.Conversations do
     # Ownership is established by callers before reaching this internal wake
     # path. The agent fetched below is the conversation's own agent_id,
     # same tenant by construction.
-    with %Conversation{} = conv <- _unsafe_get_conversation(conv_id) || {:error, :not_found},
+    with :ok <- require_provider_commit_boundary(),
+         %Conversation{} = conv <- _unsafe_get_conversation(conv_id) || {:error, :not_found},
          :ok <- assert_resumable(conv),
          # Preflight only: no database lock spans provider I/O. Turn admission
          # checks again under its transaction. Cancellation must remain reachable.

--- a/apps/fountain/test/fountain/conversations/launch_commit_boundary_test.exs
+++ b/apps/fountain/test/fountain/conversations/launch_commit_boundary_test.exs
@@ -1,0 +1,58 @@
+defmodule Fountain.Conversations.LaunchCommitBoundaryTest do
+  use Fountain.DataCase, async: true
+  use Mimic
+
+  alias Fountain.Conversations
+  alias Fountain.Conversations.{Conversation, Sandbox}
+
+  setup do
+    user = insert_active_user()
+    env = insert_env(user_id: user.id)
+    agent = insert_agent(user_id: user.id, runtime: "claude", environment_id: env.id)
+
+    sandbox =
+      insert_sandbox(
+        user_id: user.id,
+        status: "ready",
+        agent_id: agent.id,
+        environment_id: env.id
+      )
+
+    conv = insert_conversation(user_id: user.id, agent: agent, sandbox: sandbox, status: "idle")
+    {:ok, user: user, agent: agent, sandbox: sandbox, conv: conv}
+  end
+
+  for path <- [:create, :attach, :wake] do
+    @tag path: path
+    test "#{path} refuses an enclosing transaction before external work or row changes", ctx do
+      reject(Horde.DynamicSupervisor, :start_child, 2)
+      reject(Managoat.Sandbox.Sprites, :get, 1)
+      reject(Managoat.Sandbox.Sprites, :create, 2)
+      reject(Managoat.Sandbox.Sprites, :resume, 1)
+      counts = {Repo.aggregate(Conversation, :count), Repo.aggregate(Sandbox, :count)}
+      attrs = %{"user_id" => ctx.user.id, "agent_id" => ctx.agent.id, "prompt" => "hello"}
+
+      # The caller deliberately commits. Refusal must leave no pending rows,
+      # even when the caller does not turn the returned error into a rollback.
+      assert {:ok, {:error, :provider_transaction_open}} =
+               Repo.transaction(fn ->
+                 case ctx.path do
+                   :create ->
+                     Conversations.start_conversation(attrs)
+
+                   :attach ->
+                     Conversations.start_conversation(
+                       Map.put(attrs, "sandbox_id", ctx.sandbox.id)
+                     )
+
+                   :wake ->
+                     Conversations.wake_conversation(ctx.conv.id, "hello")
+                 end
+               end)
+
+      assert counts == {Repo.aggregate(Conversation, :count), Repo.aggregate(Sandbox, :count)}
+      assert Repo.reload!(ctx.sandbox).status == "ready"
+      assert Repo.reload!(ctx.conv).status == "idle"
+    end
+  end
+end


### PR DESCRIPTION
Create, attach and wake could start a worker or contact its provider inside a caller's still-open database transaction. A later rollback could remove the rows after that work escaped. Refuse these entrances with `{:error, :provider_transaction_open}` before writes or external work; callers must commit before launching.

Two files, +70/-3, extracted from #1754 onto #1796. No new tables or worker protocol.

Validation: 65 create/attach/transaction tests pass. All three new regression cases fail on the unchanged callers. Tests commit the enclosing transaction after refusal and verify no rows or sandbox status changed. Full `mix precommit --seed 828329` passes: 4,888 tests +6 doctests, zero failures. Staged secret scan passes. CI passes ([run](https://github.com/managoat/fountain/actions/runs/34476314381)). Follow-up #1831 scopes initial worker-start failures.



Part of #1864
