### PR TITLE
Preserve replacement broker tokens when provisioning fails

### DIFF
--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -864,7 +864,10 @@ defmodule Fountain.Conversations.ConversationServer do
         # The broker session is minted before the env is built, because the
         # env carries it; the CA is installed before anything dials out,
         # because nothing dials out without it (ADR 0019 gate 1a).
-        with {:ok, state} <- broker_prepare(state),
+        # Keep the result outside `with`: its else cannot see the minted state.
+        prepared = Egress.prepare_state(state)
+
+        with {:ok, state} <- prepared,
              sprite_env = build_sprite_env(state, agent, env, secrets, sandbox_url),
              # A real step, not best effort: an agent whose MCP servers could
              # not be written would otherwise run without them and report
@@ -933,7 +936,7 @@ defmodule Fountain.Conversations.ConversationServer do
           {:error, reason} ->
             Logger.error("provision step failed: #{inspect(reason)}")
             _ = Managoat.Sandbox.destroy(handle)
-            Egress.release(state.user_id, state.conversation_id)
+            Egress.release_prepared(prepared)
             {:ok, _} = Conversations.update_sandbox(sandbox, %{status: "failed"})
 
             Output.publish_stage(state.conversation_id, "provision", "failed", %{
@@ -1037,7 +1040,7 @@ defmodule Fountain.Conversations.ConversationServer do
              fn -> Managoat.Sandbox.get(handle) end,
              label: "sprite lookup on wake"
            ),
-         {:ok, state} <- broker_prepare(state),
+         {:ok, state} <- Egress.prepare_state(state),
          :ok <- Egress.reattach_policy(handle, env, state.conversation_id, state.user_id) do
       Output.publish_stage(state.conversation_id, "reattach", "started", %{
         sprite_name: sandbox.sprite_name,
@@ -1378,21 +1381,6 @@ defmodule Fountain.Conversations.ConversationServer do
       sandbox_url: sandbox_url,
       brokered: Egress.sandbox_env(state.broker)
     )
-  end
-
-  # Keep the minted proxy session in server state; unbrokered state is unchanged.
-  defp broker_prepare(state) do
-    if Egress.brokered?(state.user_id) do
-      case Egress.prepare(state.conversation_id, state.brokered, state.broker_bindings,
-             network: state.broker_network,
-             user_id: state.user_id
-           ) do
-        {:ok, session} -> {:ok, %{state | broker: session}}
-        {:error, _} = error -> error
-      end
-    else
-      {:ok, state}
-    end
   end
 
   # The OAuth token was refused: forget it on both sides and, when brokered,

--- a/apps/fountain/lib/fountain/conversations/egress.ex
+++ b/apps/fountain/lib/fountain/conversations/egress.ex
@@ -304,7 +304,7 @@ defmodule Fountain.Conversations.Egress do
   hour into the conversation rather than at provisioning.
 
   There is no arm here for a list that carries no CA defaults:
-  `broker_prepare/1` runs before `build_sprite_env/5` on both entry paths
+  `prepare_state/1` runs before `build_sprite_env/5` on both entry paths
   (`ConversationServer` lines 863 and 1114), so a brokered conversation's env
   has always been assembled with them.
   """
@@ -459,6 +459,27 @@ defmodule Fountain.Conversations.Egress do
         :error
     end
   end
+
+  @doc "Keep the minted proxy session in server state; unbrokered state is unchanged."
+  def prepare_state(state) do
+    if brokered?(state.user_id) do
+      case prepare(state.conversation_id, state.brokered, state.broker_bindings,
+             network: state.broker_network,
+             user_id: state.user_id
+           ) do
+        {:ok, session} -> {:ok, %{state | broker: session}}
+        {:error, _} = error -> error
+      end
+    else
+      {:ok, state}
+    end
+  end
+
+  @doc "Revoke only the session this preparation returned; a failed mint owns no token."
+  def release_prepared({:ok, %{broker: %{token: token}} = state}),
+    do: Broker.release_session(state.user_id, state.conversation_id, token)
+
+  def release_prepared(_result), do: :ok
 
   @doc "Install the broker's CA into the sandbox; nothing to install without a session."
   @spec install_ca(session(), Managoat.Sandbox.Handle.t(), String.t()) :: :ok | {:error, term()}

--- a/apps/fountain/test/fountain/conversations/conversation_server_broker_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_broker_test.exs
@@ -399,7 +399,7 @@ defmodule Fountain.Conversations.ConversationServerBrokerTest do
       assert_receive {:spawned, _, _, _}, 2_000
     end
 
-    test "a failed session mint tears the sandbox down and releases the vault", %{
+    test "a failed session mint tears the sandbox down without revoking other sessions", %{
       user: user,
       agent: agent
     } do
@@ -413,10 +413,8 @@ defmodule Fountain.Conversations.ConversationServerBrokerTest do
         {:error, {:broker, :session, :timeout}}
       end)
 
-      stub(Fountain.Broker, :release, fn conv_id ->
-        send(test, {:released, conv_id})
-        :ok
-      end)
+      reject(Fountain.Broker, :release, 1)
+      reject(Fountain.Broker, :release_session, 3)
 
       Mimic.stub(Managoat.Sandbox.Sprites, :destroy, fn _h ->
         send(test, :destroyed)
@@ -426,9 +424,46 @@ defmodule Fountain.Conversations.ConversationServerBrokerTest do
       {_pid, _mon, :stopped} = start_server(conv)
 
       assert_receive :destroyed, 2_000
-      assert_receive {:released, conv_id}, 2_000
-      assert conv_id == conv.id
       assert Conversations._unsafe_get_conversation!(conv.id).status == "failed"
+    end
+
+    for broker_disabled? <- [false, true] do
+      @tag broker_disabled?: broker_disabled?
+      test "failed provisioning preserves a replacement token (disabled=#{broker_disabled?})", %{
+        user: user,
+        agent: agent,
+        broker_disabled?: broker_disabled?
+      } do
+        conv = insert_conversation(user_id: user.id, agent: agent)
+        test = self()
+        stub_happy_sprite()
+        stub(Fountain.Broker, :preflight, fn -> :ok end)
+        stub(Fountain.Broker, :ca_pem, fn -> {:ok, "PEM"} end)
+
+        # Use real session rows and deletion; only the provider boundary is fake.
+        stub(Fountain.Broker, :prepare, fn id, secrets, bindings, opts ->
+          {:ok, session} = Fountain.Broker.Native.prepare(id, secrets, bindings, opts)
+          send(test, {:original_token, session.token})
+          {:ok, session}
+        end)
+
+        stub(Fountain.Conversations.Provisioning, :install_packages, fn _h, _e, _se, _id ->
+          {:ok, replacement} =
+            Fountain.Broker.Native.prepare(conv.id, %{}, %{}, user_id: user.id)
+
+          send(test, {:replacement_token, replacement.token})
+          if broker_disabled?, do: Application.delete_env(:fountain, :broker_listen_port)
+          {:error, :apt_failed}
+        end)
+
+        {_pid, ref, :stopped} = start_server(conv)
+        assert :normal = assert_stopped(ref)
+        assert_receive {:original_token, original}
+        assert_receive {:replacement_token, replacement}
+        assert :error = Fountain.Broker.Native.Sessions.lookup(original)
+        assert {:ok, _} = Fountain.Broker.Native.Sessions.lookup(replacement)
+        assert Conversations._unsafe_get_conversation!(conv.id).status == "failed"
+      end
     end
 
     test "terminating the conversation releases the vault", %{user: user, agent: agent} do

--- a/apps/fountain/test/fountain/conversations/conversation_server_size_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_size_test.exs
@@ -15,7 +15,7 @@ defmodule Fountain.Conversations.ConversationServerSizeTest do
   accepts is downward. Lower it when you move something out; never raise it.
   """
 
-  @pin 2774
+  @pin 2762
 
   @server "apps/fountain/lib/fountain/conversations/conversation_server.ex"
 


### PR DESCRIPTION
A returned provisioning error revoked every broker session for the conversation, including a replacement worker's token. Preserve the mint result outside `with` and revoke only that attempt's tenant/conversation/token; a failed mint owns no token to revoke. Cleanup also works after brokerage is disabled.

Four files, +71/-27, extracted from #1754 onto #1797. Move session preparation and cleanup into Egress, reducing ConversationServer by 12 lines and lowering its size pin. Full actor/provider ownership fencing remains separate.

Validation: 22 broker/size tests pass, with real session rows. Both new behavior cases fail on the unchanged caller. Full `mix precommit --seed 828329` passes: 4,890 tests +6 doctests, zero failures. Staged secret scan passes. The initial full gate caught the server size limit; the helper extraction and lower pin fix that failure. CI passes ([run](https://github.com/managoat/fountain/actions/runs/34476805041)).



Part of #1864
