### PR TITLE
Preserve current state after a stale worker-start failure

### DIFF
--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -2615,12 +2615,17 @@ defmodule Fountain.Conversations do
             "ConversationServer failed to start for conv #{conv.id}: #{inspect(reason)}"
           )
 
-          update_conversation(conv, %{status: "failed"})
-          update_sandbox(sandbox, %{status: "failed"})
-          restore_rotated_channel(conv, opts)
-          result = _unsafe_get_conversation!(conv.id)
-          broadcast_sidebar_update(user_id)
-          {:ok, result}
+          if fail_initial_start(conv, sandbox) == :failed,
+            do: restore_rotated_channel(conv, opts)
+
+          case get_conversation(conv.id, user_id) do
+            nil ->
+              {:error, :not_found}
+
+            result ->
+              broadcast_sidebar_update(user_id)
+              {:ok, result}
+          end
       end
     else
       nil ->
@@ -2659,6 +2664,57 @@ defmodule Fountain.Conversations do
   # so anything that can wait on another transaction must be settled before it
   # is taken, or one account stalls provisioning for all of them.
   #
+  # A delayed start error owns only its original, still-pending binding.
+  # Match turn admission's machine -> parent -> sandbox lock order. Status
+  # changes commit together; metering follows commit and provider I/O is absent.
+  defp fail_initial_start(conv, sandbox) do
+    {:ok, result} =
+      Repo.transaction(fn ->
+        Repo.query!("SELECT pg_advisory_xact_lock($1, $2)", [
+          @sandbox_lock_namespace,
+          :erlang.phash2(sandbox.id)
+        ])
+
+        parent = Repo.one(from c in Conversation, where: c.id == ^conv.id, lock: "FOR UPDATE")
+        machine = Repo.one(from s in Sandbox, where: s.id == ^sandbox.id, lock: "FOR UPDATE")
+
+        if pending_initial_binding?(parent, machine, conv, sandbox) and
+             _unsafe_running_turns_elsewhere(sandbox.id, nil) == 0 do
+          parent |> Conversation.changeset(%{status: "failed"}) |> Repo.update!()
+
+          machine
+          |> Sandbox.changeset(%{status: "failed"})
+          |> stamp_terminated_at()
+          |> Repo.update!()
+        else
+          :stale
+        end
+      end)
+
+    case result do
+      %Sandbox{} = failed ->
+        record_sandbox_usage("pending", failed)
+        :failed
+
+      :stale ->
+        :stale
+    end
+  end
+
+  defp pending_initial_binding?(%Conversation{} = parent, %Sandbox{} = machine, conv, sandbox) do
+    Map.take(parent, [:user_id, :sandbox_id, :status]) ==
+      %{user_id: conv.user_id, sandbox_id: sandbox.id, status: "pending"} and
+      Map.take(machine, [:user_id, :provider, :sprite_name, :status]) ==
+        %{
+          user_id: conv.user_id,
+          provider: sandbox.provider,
+          sprite_name: sandbox.sprite_name,
+          status: "pending"
+        }
+  end
+
+  defp pending_initial_binding?(_, _, _, _), do: false
+
   # An unlocked read was not enough: `create_sandbox/1` and the conversation
   # insert take `KEY SHARE` on `users` through their foreign keys, and
   # `Credits.insert_and_move/3` holds that row `FOR UPDATE` across a ledger

--- a/apps/fountain/test/fountain/conversations/initial_start_failure_test.exs
+++ b/apps/fountain/test/fountain/conversations/initial_start_failure_test.exs
@@ -1,0 +1,107 @@
+defmodule Fountain.Conversations.InitialStartFailureTest do
+  use Fountain.DataCase, async: true
+  use Mimic
+
+  alias Fountain.Conversations
+  alias Fountain.Conversations.{Conversation, ConversationServer, Sandbox}
+
+  setup do
+    user = insert_active_user()
+    agent = insert_agent(user_id: user.id)
+    {:ok, user: user, agent: agent}
+  end
+
+  test "an unchanged initial start failure retires both pending rows", ctx do
+    expect(Fountain.Billing, :record_usage, 2, fn user_id, event, sandbox_id, "sandbox", _ ->
+      assert user_id == ctx.user.id
+      assert event in ["sandbox_provision_failed", "sandbox_terminated"]
+      refute Repo.in_transaction?()
+      assert Repo.get!(Sandbox, sandbox_id).status == "failed"
+
+      assert Repo.one!(from c in Conversation, where: c.sandbox_id == ^sandbox_id).status ==
+               "failed"
+
+      :ok
+    end)
+
+    expect(Horde.DynamicSupervisor, :start_child, fn _, _ -> {:error, :max_children} end)
+    assert {:ok, conv} = start(ctx)
+    assert conv.status == "failed"
+    sandbox = Repo.get!(Sandbox, conv.sandbox_id)
+    assert sandbox.status == "failed"
+    assert sandbox.terminated_at
+  end
+
+  test "a delayed start error preserves a replacement binding and both machines", ctx do
+    test = self()
+
+    expect(Horde.DynamicSupervisor, :start_child, fn _, {ConversationServer, args} ->
+      conv = Repo.get!(Conversation, args[:conversation_id])
+      original = Repo.get!(Sandbox, args[:sandbox_id])
+      replacement = insert_sandbox(user_id: ctx.user.id, status: "ready")
+
+      {:ok, _} =
+        Conversations.update_conversation(conv, %{sandbox_id: replacement.id, status: "idle"})
+
+      send(test, {:bindings, original.id, replacement.id})
+      {:error, :max_children}
+    end)
+
+    assert {:ok, conv} = start(ctx)
+    assert_received {:bindings, original_id, replacement_id}
+    assert conv.status == "idle"
+    assert conv.sandbox_id == replacement_id
+    assert Repo.get!(Sandbox, original_id).status == "pending"
+    assert Repo.get!(Sandbox, replacement_id).status == "ready"
+  end
+
+  test "a start error cannot overwrite an already-provisioned conversation", ctx do
+    expect(Horde.DynamicSupervisor, :start_child, fn _, {ConversationServer, args} ->
+      conv = Repo.get!(Conversation, args[:conversation_id])
+      sandbox = Repo.get!(Sandbox, args[:sandbox_id])
+      {:ok, _} = Conversations.update_sandbox(sandbox, %{status: "ready"})
+      {:ok, _} = Conversations.update_conversation(conv, %{status: "idle"})
+      {:error, :max_children}
+    end)
+
+    assert {:ok, conv} = start(ctx)
+    assert conv.status == "idle"
+    assert Repo.get!(Sandbox, conv.sandbox_id).status == "ready"
+  end
+
+  test "a cancelled parent keeps its terminal status", ctx do
+    expect(Horde.DynamicSupervisor, :start_child, fn _, {ConversationServer, args} ->
+      conv = Repo.get!(Conversation, args[:conversation_id])
+      {:ok, _} = Conversations.update_conversation(conv, %{status: "terminated"})
+      {:error, :max_children}
+    end)
+
+    assert {:ok, conv} = start(ctx)
+    assert conv.status == "terminated"
+  end
+
+  for change <- [:deleted, :reassigned] do
+    @tag change: change
+    test "a #{change} parent is not returned to the original caller", ctx do
+      other = insert_active_user()
+
+      expect(Horde.DynamicSupervisor, :start_child, fn _, {ConversationServer, args} ->
+        conv = Repo.get!(Conversation, args[:conversation_id])
+
+        case ctx.change do
+          :deleted -> Repo.delete!(conv)
+          :reassigned -> conv |> Ecto.Changeset.change(user_id: other.id) |> Repo.update!()
+        end
+
+        {:error, :max_children}
+      end)
+
+      assert {:error, :not_found} = start(ctx)
+      assert [sandbox] = Repo.all(from s in Sandbox, where: s.user_id == ^ctx.user.id)
+      assert sandbox.status == "pending"
+    end
+  end
+
+  defp start(ctx),
+    do: Conversations.start_conversation(%{"user_id" => ctx.user.id, "agent_id" => ctx.agent.id})
+end


### PR DESCRIPTION
A delayed initial worker-start error could mark a replacement binding, completed conversation or cancellation as failed. Lock and recheck the original tenant/machine binding and pending state before atomically failing both rows. Only an applied failure restores a rotated channel; missing or reassigned parents return not found. Usage is recorded after commit.

Two files, +169/-6, extracted from #1754 onto #1826. This is initial-start error handling; actor-incarnation and uncertain provider recovery remain separate. A changed binding leaves the original sandbox untouched.

Validation: six launch-path regressions cover ordinary failure, replacement, completed work, cancellation, deletion and reassignment. Five fail on the unchanged caller. All 82 focused regression/rotation/admission tests pass, including an assertion that usage sees both failed rows after commit; the earlier start-path run passed 54 tests. Full `mix precommit --seed 828329` passes: 4,894 tests +6 doctests, zero failures. Staged secret scan passes. CI passes ([run](https://github.com/managoat/fountain/actions/runs/34479441710)).



Part of #1864
