### PR TITLE
feat(runtimes): Fountain.CommandRuntime, the acp runtime's module (#1634)

### DIFF
--- a/apps/fountain/lib/fountain/command_runtime.ex
+++ b/apps/fountain/lib/fountain/command_runtime.ex
@@ -1,0 +1,110 @@
+defmodule Fountain.CommandRuntime do
+  @moduledoc """
+  The `acp` runtime: launch the command the agent names and speak ACP to it.
+
+  Every other runtime Fountain has is a coding agent driven by a model.
+  `Managoat.Runtimes` knows four of them by name, installs a pinned adapter
+  for each and hands each one an inference credential. This one knows
+  nothing. The agent carries a `runtime_command`, Fountain runs it inside the
+  sandbox, and whatever comes back over stdio is the Agent Client Protocol
+  (ADR 0014) exactly as it is for claude or codex. That is the whole runtime.
+
+  It exists for a deterministic program that wants what Fountain gives an
+  agent and not what a model gives one. A convergent operation on a schedule,
+  inside a persistent sandbox that holds the repo and the toolchain, with the
+  run readable as a turn in a teammate's thread (#1634).
+
+  ## The name
+
+  Named for what varies, which is the command, and flat like its one sibling:
+  `Fountain.DeployedACPFixture` is the other runtime that is Fountain's
+  rather than the library's. `Managoat.Runtimes.ACP` was not available and
+  would have been wrong anyway, since that is the provisioning table saying
+  which adapter each of the four LLM runtimes reaches the protocol through.
+  `Command` alone would have read against `Managoat.Sandbox.Command`, which is
+  a struct the same call sites hold.
+
+  It lives in Fountain rather than in the library because the registry there
+  is a closed map and the field it reads (`agents.runtime_command`) is
+  Fountain's own column. `Fountain.RuntimeDispatch` is the host dispatch that
+  resolves this module for `"acp"` and delegates everything else.
+
+  ## What it does not do
+
+  There is no adapter to install, no config file to write, no bootstrap to
+  run and no credential to export. The command owns its own configuration,
+  which is the point of naming a command rather than a runtime.
+
+    * `write_config/2` and `prepare_sandbox/3` are not implemented at all, so
+      `Fountain.Conversations.Provisioning`'s `function_exported?` guards skip
+      them.
+    * `build_command/5` is not implemented either. The legacy spawn path is
+      dead for every runtime that speaks ACP, and this one always does.
+    * `default_env/2` ignores the credentials it is handed. It exports one
+      variable, `FOUNTAIN_SKILLS_DIR`, so the command can read the agent's
+      skills without knowing the layout convention below.
+
+  ## Skills still mount
+
+  A deterministic agent may read a skill the same way a model does, so the
+  ordinary skills pipeline runs. There is no CLI here with a directory of its
+  own, so the layout borrows claude-code's: inline skills are written under
+  `/home/sprite/.claude/skills`, and a github-source skill is installed by
+  skills.sh with `--agent claude-code`, which puts it in the same tree. One
+  location rather than two, and the path is exported so the command need not
+  know which one was chosen.
+
+  `Fountain.DeployedACPFixture` answers these two differently, with a private
+  root and an empty skills.sh id, and that is right for it: its changeset
+  refuses an agent that carries any skills at all, so the pair never has to
+  agree. This runtime accepts them, so the pair does.
+  """
+
+  @behaviour Managoat.Runtimes
+
+  # claude-code's tree, borrowed. skills.sh has no agent id for a command it
+  # has never heard of, and this is the layout the others copy. `skills_root/0`
+  # and `skills_sh_agent/0` have to agree or a github skill and an inline one
+  # land in different directories.
+  @skills_root "/home/sprite/.claude/skills"
+  @skills_sh_agent "claude-code"
+
+  @doc """
+  Where the command's argv comes from.
+
+  A shell line rather than a parsed argv, and always run through
+  `bash -lc`. Three reasons, all of them about the sandbox rather than about
+  us: the command is resolved against the sandbox's own PATH (a login shell
+  is what puts `~/.local/bin` and the language shims on it), an operator can
+  write `cd /srv/app && bin/agent acp` without Fountain inventing a
+  chdir field, and quoting is the shell's rule, which is the rule whoever
+  wrote the string already knows.
+
+  Returns `:error` when there is no command to run. The changeset requires
+  one for this runtime, so that means an agent deleted out from under a live
+  conversation. `Fountain.Conversations.TurnMachine.open/4` refuses the turn
+  there rather than opening one with nothing to spawn, which is what makes
+  `Fountain.RuntimeDispatch.command/2`'s match total.
+  """
+  @spec argv(map() | nil) :: {:ok, {String.t(), [String.t()]}} | :error
+  def argv(%{runtime_command: cmd}) when is_binary(cmd) do
+    case String.trim(cmd) do
+      "" -> :error
+      line -> {:ok, {"bash", ["-lc", line]}}
+    end
+  end
+
+  def argv(_agent), do: :error
+
+  @impl true
+  def skills_root, do: @skills_root
+
+  @impl true
+  def skills_sh_agent, do: @skills_sh_agent
+
+  # No inference credential, on purpose: a turn on this runtime resolves
+  # none, so an account that holds no key at all runs one. The skills path is
+  # here because the command has no convention to fall back on.
+  @impl true
+  def default_env(_agent, _inference_credentials), do: [{"FOUNTAIN_SKILLS_DIR", @skills_root}]
+end

--- a/apps/fountain/lib/fountain/conversations/provisioning.ex
+++ b/apps/fountain/lib/fountain/conversations/provisioning.ex
@@ -889,7 +889,9 @@ defmodule Fountain.Conversations.Provisioning do
   # Install during provisioning and check the pin before opening a fresh
   # connection on a persistent sandbox. Use the runtime's env (including its
   # broker proxy) for registry access; never relax the sandbox network policy.
-  # Keyed on the conversation's runtime, matching the spawn decision.
+  # Keyed on the conversation's runtime, matching the spawn decision. The acp
+  # runtime installs nothing, since the command is whatever the environment's
+  # packages and setup script already put on the machine (#1634).
   def prepare_acp_adapter(handle, runtime, sprite_env) do
     if Fountain.RuntimeDispatch.acp_enabled?(runtime) do
       Fountain.RuntimeDispatch.install(handle, runtime, sprite_env)

--- a/apps/fountain/lib/fountain/conversations/turn_machine.ex
+++ b/apps/fountain/lib/fountain/conversations/turn_machine.ex
@@ -980,6 +980,9 @@ defmodule Fountain.Conversations.TurnMachine do
   a PTY so `isatty(0)` is true), `dir` (a workspace with a local .git) and
   `prompt_suffix` (image references for a runtime that cannot take images
   as flags).
+
+  On the acp runtime the argv is the agent's own `runtime_command` (#1634),
+  which is why the agent is in hand here as well as the conversation.
   """
   @spec command(
           boolean(),
@@ -992,7 +995,7 @@ defmodule Fountain.Conversations.TurnMachine do
         ) :: {String.t(), [String.t()], keyword()}
   def command(acp?, conv, agent, prompt, mode, runtime_session_id, opts) do
     if acp? do
-      {c, a} = Fountain.RuntimeDispatch.command(conv.runtime)
+      {c, a} = Fountain.RuntimeDispatch.command(conv.runtime, agent)
       # The ACP `cwd` is validated in band by the agent CLI against the real
       # filesystem, so it must be the path a process inside the sandbox sees
       # — identity on hosted providers, the mapped directory on a runner
@@ -1053,7 +1056,7 @@ defmodule Fountain.Conversations.TurnMachine do
   def acp_model(_conv, nil), do: nil
 
   def acp_model(conv, agent),
-    do: Managoat.Runtimes.Model.acp_model(conv.runtime || agent.runtime, agent.model)
+    do: Fountain.RuntimeDispatch.acp_model(conv.runtime || agent.runtime, agent.model)
 
   # The permission policy in force for this turn (#939): the agent's own,
   # clamped by whatever narrowing the launch asked for. Resolved per turn from

--- a/apps/fountain/lib/fountain/runtime_dispatch.ex
+++ b/apps/fountain/lib/fountain/runtime_dispatch.ex
@@ -1,14 +1,23 @@
 defmodule Fountain.RuntimeDispatch do
   @moduledoc """
-  Host dispatch for the four packaged runtimes and the opt-in deployed ACP fixture.
+  Host dispatch for the four packaged runtimes and the two that are Fountain's.
 
-  The fixture is one fixed, account-restricted testing seam for #1611/#1007.
-  It does not register tenant-provided code or replace a packaged runtime.
+  `Fountain.DeployedACPFixture` is one fixed, account-restricted testing seam
+  for #1611/#1007. It does not register tenant-provided code or replace a
+  packaged runtime.
+
+  `Fountain.CommandRuntime` is the `acp` runtime (#1634): the agent names a
+  command, Fountain launches it inside the sandbox and speaks the protocol to
+  it. It is generally available rather than account-restricted, and it is the
+  one runtime whose command is not a property of the runtime name, which is
+  why `command/2` takes the agent.
   """
 
+  alias Fountain.CommandRuntime
   alias Fountain.DeployedACPFixture
   alias Managoat.Runtimes
   alias Managoat.Runtimes.ACP
+  alias Managoat.Runtimes.Model
 
   def for_agent(%{runtime: "fountain-fixture", user_id: user_id}) do
     if DeployedACPFixture.allowed?(user_id),
@@ -16,14 +25,31 @@ defmodule Fountain.RuntimeDispatch do
       else: {:error, "deployed ACP fixture is not enabled for this account"}
   end
 
+  def for_agent(%{runtime: "acp"}), do: {:ok, CommandRuntime}
   def for_agent(%{runtime: runtime}), do: Runtimes.for_runtime(runtime)
 
   def acp_enabled?(%{runtime: runtime}), do: acp_enabled?(runtime)
   def acp_enabled?("fountain-fixture"), do: DeployedACPFixture.enabled?()
+  def acp_enabled?("acp"), do: true
   def acp_enabled?(runtime), do: ACP.enabled?(runtime)
 
-  def command("fountain-fixture"), do: {"node", [".fountain-acp-fixture.mjs"]}
-  def command(runtime), do: ACP.command(runtime)
+  @doc """
+  Argv for the process a turn spawns.
+
+  Takes the agent as well as the runtime because the `acp` runtime's argv is
+  the agent's own `runtime_command`. The match is total by the time a spawn
+  asks: `Fountain.Conversations.TurnMachine.open/4` refuses a turn whose
+  agent has no command, before a turn row exists.
+  """
+  def command(runtime, agent \\ nil)
+
+  def command("acp", agent) do
+    {:ok, argv} = CommandRuntime.argv(agent)
+    argv
+  end
+
+  def command("fountain-fixture", _agent), do: {"node", [".fountain-acp-fixture.mjs"]}
+  def command(runtime, _agent), do: ACP.command(runtime)
 
   def cwd("fountain-fixture"), do: "/home/sprite"
   def cwd(runtime), do: ACP.cwd(runtime)
@@ -35,5 +61,36 @@ defmodule Fountain.RuntimeDispatch do
   def asks_permission?(runtime), do: ACP.asks_permission?(runtime)
 
   def install(_handle, "fountain-fixture", _env), do: :ok
+  def install(_handle, "acp", _env), do: :ok
   def install(handle, runtime, env), do: ACP.install(handle, runtime, env)
+
+  @doc """
+  The model id to pin on the ACP session, or nil to leave the runtime's own.
+
+  Always nil for `acp`. A model is optional there and nothing reads it, so
+  pinning one could only fail. That closes the pin path, which is where the
+  `model`/`failed` stage comes from for the runtimes that do drive a model.
+  """
+  def acp_model("acp", _model), do: nil
+  def acp_model(runtime, model), do: Model.acp_model(runtime, model)
+
+  @doc """
+  Whether this runtime needs a `model` on the agent.
+
+  Only `acp` does not. Every other runtime is a model driving something, and
+  an agent with no model there runs whatever that thing defaults to, which is
+  the defect `Agent.changeset/2`'s provider check exists to prevent. The
+  fixture needs one too: its changeset pins it to `fixture/deterministic-v1`.
+  """
+  def model_required?("acp"), do: false
+  def model_required?(_runtime), do: true
+
+  @doc """
+  Whether this runtime takes a `runtime_command`.
+
+  Only `acp`. On any other runtime the field would be stored, shown in the
+  console and never run, which reads as configuration and is not.
+  """
+  def command_required?("acp"), do: true
+  def command_required?(_runtime), do: false
 end

--- a/apps/fountain/test/fountain/command_runtime_test.exs
+++ b/apps/fountain/test/fountain/command_runtime_test.exs
@@ -1,0 +1,99 @@
+defmodule Fountain.CommandRuntimeTest do
+  @moduledoc """
+  The `acp` runtime and the host dispatch that resolves it (#1634).
+
+  Nothing reaches this module yet: `"acp"` is not a value `Agent.changeset/2`
+  accepts, and the `runtime_command` column it reads does not exist. What is
+  pinned here is the runtime in isolation, so the PR that opens the door has
+  only the schema to argue about.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Fountain.CommandRuntime
+  alias Fountain.RuntimeDispatch
+
+  describe "dispatch" do
+    test "acp resolves to the command runtime, and speaks the protocol" do
+      assert RuntimeDispatch.acp_enabled?("acp")
+      assert {:ok, CommandRuntime} = RuntimeDispatch.for_agent(%{runtime: "acp"})
+    end
+
+    test "the packaged runtimes still resolve to their own modules" do
+      assert {:ok, Managoat.Runtimes.Claude} = RuntimeDispatch.for_agent(%{runtime: "claude"})
+      assert {:ok, Managoat.Runtimes.OpenCode} = RuntimeDispatch.for_agent(%{runtime: "opencode"})
+      assert {:error, _} = RuntimeDispatch.for_agent(%{runtime: "nonesuch"})
+    end
+
+    test "there is no adapter to install and no model to pin" do
+      assert :ok = RuntimeDispatch.install(nil, "acp", [])
+      assert is_nil(RuntimeDispatch.acp_model("acp", nil))
+      # Even when a model was set anyway: it is inert, so it is never pinned
+      # and the pin path that reports `model`/`failed` is unreachable.
+      assert is_nil(RuntimeDispatch.acp_model("acp", "anthropic/claude-sonnet-4-6"))
+    end
+
+    test "a model-driven runtime still pins the model it was given" do
+      assert RuntimeDispatch.acp_model("claude", "anthropic/claude-sonnet-4-6")
+    end
+
+    test "only acp takes a command, and only acp goes without a model" do
+      assert RuntimeDispatch.command_required?("acp")
+      refute RuntimeDispatch.model_required?("acp")
+
+      for runtime <- ~w(claude codex gemini opencode fountain-fixture) do
+        refute RuntimeDispatch.command_required?(runtime)
+        assert RuntimeDispatch.model_required?(runtime)
+      end
+    end
+  end
+
+  describe "argv" do
+    test "the command comes from the agent, and a missing one is answerable" do
+      assert :error = CommandRuntime.argv(nil)
+      assert :error = CommandRuntime.argv(%{})
+      assert :error = CommandRuntime.argv(%{runtime_command: nil})
+      assert :error = CommandRuntime.argv(%{runtime_command: "   "})
+
+      assert {:ok, {"bash", ["-lc", "run me"]}} =
+               CommandRuntime.argv(%{runtime_command: "run me"})
+    end
+
+    test "a whole shell line is handed to the login shell unparsed" do
+      line = "cd /srv/app && exec ./bin/agent acp --env prod"
+
+      assert {"bash", ["-lc", ^line]} =
+               RuntimeDispatch.command("acp", %{runtime_command: line})
+    end
+
+    test "the packaged runtimes ignore the agent and resolve their own argv" do
+      assert {_cmd, _args} = RuntimeDispatch.command("claude", %{runtime_command: "ignored"})
+    end
+  end
+
+  describe "the sandbox environment" do
+    test "no inference credential reaches the command" do
+      env =
+        CommandRuntime.default_env(
+          %{model: "anthropic/claude-sonnet-4-6"},
+          %{anthropic_api_key: "sk-live", openai_api_key: "sk-openai"}
+        )
+
+      refute Enum.any?(env, fn {_k, v} -> v =~ "sk-" end)
+      assert {"FOUNTAIN_SKILLS_DIR", "/home/sprite/.claude/skills"} in env
+    end
+
+    test "the skills root and the skills.sh agent id agree" do
+      # They have to: an inline skill is written to the root and a github one
+      # is installed by id, and a disagreement puts them in different trees.
+      assert CommandRuntime.skills_root() == "/home/sprite/.claude/skills"
+      assert CommandRuntime.skills_sh_agent() == "claude-code"
+    end
+
+    test "provisioning finds nothing to write and nothing to prepare" do
+      refute function_exported?(CommandRuntime, :write_config, 2)
+      refute function_exported?(CommandRuntime, :prepare_sandbox, 3)
+      refute function_exported?(CommandRuntime, :build_command, 5)
+    end
+  end
+end


### PR DESCRIPTION
Every runtime Fountain has is an LLM coding agent. A deterministic program
that wants a warm machine, a vault, a thread, a schedule and a human who can
read what happened has nowhere to run: `Managoat.Runtimes` is a closed map of
four CLIs, each with a pinned adapter, a provider and an inference credential.

This adds the runtime module and the host dispatch that resolves it, and
nothing else. `"acp"` is not yet a value `Agent.changeset/2` accepts and the
`runtime_command` column it reads does not exist, so no request reaches this
code until the next PR in the stack opens the door.

- `Fountain.CommandRuntime` implements `Managoat.Runtimes` for a command the
  agent names. It writes no config, prepares no sandbox and builds no legacy
  command, so `Provisioning`'s `function_exported?` guards skip it. Its
  `default_env/2` ignores the credentials it is handed and exports one
  variable, `FOUNTAIN_SKILLS_DIR`.
- `Fountain.RuntimeDispatch` answers `acp` itself: `for_agent/1`,
  `acp_enabled?/1` and an `install/3` that has nothing to install. It gains
  `acp_model/2` (always nil for `acp`, so the pin path that reports
  `model`/`failed` is unreachable there), and the two predicates the schema
  needs next, `model_required?/1` and `command_required?/1`.
- `command/1` becomes `command/2`. The argv of this runtime is a property of
  the agent rather than of the runtime name, so the agent has to be in hand;
  every other clause ignores it. `TurnMachine.command/7` passes it through.



---

**Stack for #1634** (merge top down; each PR is based on the one below it in the list):

| | PR | What it is |
|---|---|---|
| 1 | #1832 | `Fountain.CommandRuntime` and the host dispatch for `acp` |
| 2 | #1833 | `agents.runtime_command`, and `acp` becomes a runtime you can name |
| 3 | #1834 | skills mount on a runtime the library does not know |
| 4 | #1835 | a turn on the acp runtime, end to end |
| 5 | #1836 | refuse a turn whose agent no longer carries a command |
| 6 | #1837 | the acp runtime in the agent form |
| 7 | #1838 | a real ACP program through a whole turn |
| 8 | #1839 | docs, CHANGELOG and SDK 1.25.0 |

Replaces #1677, which was the same feature as one 1,760-line branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A2iMoNvSvrkQQfnP4RzVi2
