### PR TITLE
fix(conversations): refuse a turn whose agent no longer carries a command (#1634)

### DIFF
--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -2299,9 +2299,9 @@ defmodule Fountain.Conversations.ConversationServer do
   defp kick_turn(state, prompt, agent, images) do
     state = touch_activity(state)
 
-    case TurnMachine.open(state.conversation_id, state.sandbox_id, prompt) do
+    case TurnMachine.open(state.conversation_id, state.sandbox_id, prompt, agent) do
       {:ok, conv, turn} -> run_turn(state, conv, turn, prompt, agent, images)
-      :at_capacity -> state
+      refused when refused in [:at_capacity, :no_command] -> state
       {:error, _} -> drop_connection(state, "admission_refused")
     end
   end

--- a/apps/fountain/lib/fountain/conversations/turn_machine.ex
+++ b/apps/fountain/lib/fountain/conversations/turn_machine.ex
@@ -831,11 +831,49 @@ defmodule Fountain.Conversations.TurnMachine do
   cannot both start. Refused, not queued: nothing is written, the
   conversation stays idle and the caller sends again when the other turn
   ends.
+
+  `:no_command` is the other refusal, and it belongs to the acp runtime alone
+  (#1634). The argv there is the agent's own `runtime_command`, and a
+  conversation outlives its agent, so a live server can be asked for a turn
+  it has nothing to spawn for. Refused here, before a turn row exists, for the
+  same reason capacity is: there is no run to record, and the stage event says
+  what happened.
   """
-  @spec open(String.t(), String.t(), String.t()) ::
-          {:ok, Conversation.t(), Conversations.Turn.t()} | :at_capacity | {:error, term()}
-  def open(conversation_id, sandbox_id, prompt) do
+  @spec open(String.t(), String.t(), String.t(), map() | nil) ::
+          {:ok, Conversation.t(), Conversations.Turn.t()}
+          | :at_capacity
+          | :no_command
+          | {:error, term()}
+  def open(conversation_id, sandbox_id, prompt, agent \\ nil) do
     conv = Conversations._unsafe_get_conversation!(conversation_id)
+
+    if runnable?(conv, agent),
+      do: open_turn(conv, sandbox_id, prompt),
+      else: refuse_no_command(conv)
+  end
+
+  # `RuntimeDispatch.command/2` is total for every other runtime, so the only
+  # question is whether the acp runtime's agent still carries one.
+  defp runnable?(conv, agent) do
+    not Fountain.RuntimeDispatch.command_required?(conv.runtime) or
+      match?({:ok, _}, Fountain.CommandRuntime.argv(agent))
+  end
+
+  defp refuse_no_command(conv) do
+    publish_stage(conv.id, "turn", "failed", %{
+      reason: "no_runtime_command",
+      runtime: conv.runtime,
+      message:
+        "This conversation runs the acp runtime, and the agent that carried its " <>
+          "command is gone. Create an agent with a runtime_command and start a " <>
+          "conversation on it."
+    })
+
+    :no_command
+  end
+
+  defp open_turn(conv, sandbox_id, prompt) do
+    conversation_id = conv.id
     turn_number = Conversations._unsafe_next_turn_number(conversation_id)
 
     attrs = %{
@@ -982,7 +1020,7 @@ defmodule Fountain.Conversations.TurnMachine do
   as flags).
 
   On the acp runtime the argv is the agent's own `runtime_command` (#1634),
-  which is why the agent is in hand here as well as the conversation.
+  and the match below is total because `open/4` refuses a turn that has none.
   """
   @spec command(
           boolean(),

--- a/apps/fountain/test/fountain/conversations/conversation_server_acp_runtime_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_acp_runtime_test.exs
@@ -329,4 +329,32 @@ defmodule Fountain.Conversations.ConversationServerAcpRuntimeTest do
       assert is_nil(:sys.get_state(pid).current_turn.pending_permission)
     end
   end
+
+  describe "an agent deleted under a live conversation" do
+    test "refuses the turn rather than spawning nothing" do
+      user = insert_verified_user()
+      agent = acp_agent(user)
+      conv = insert_conversation(agent: agent, user_id: user.id)
+
+      # Deleting an agent nilifies its conversations' pointer, and the command
+      # lived on the agent. Every other runtime resolves its argv from a table
+      # and carries on; this one has nothing left to run.
+      {:ok, _} = Fountain.Agents.delete_agent(agent)
+
+      {pid, _ref} = start_acp_turn(conv)
+
+      # No turn row, the way a sandbox at capacity opens none, and a stage
+      # event on the feed saying why.
+      assert [] = Conversations._unsafe_list_turns(conv.id)
+      refute_receive {:spawned, _cmd, _args, _opts}, 200
+
+      stage =
+        conv.id
+        |> Conversations._unsafe_list_log_events()
+        |> Enum.find(&(&1.kind == "stage" and &1.stage == "turn" and &1.state == "failed"))
+
+      assert stage.data =~ "no_runtime_command"
+      assert Process.alive?(pid)
+    end
+  end
 end


### PR DESCRIPTION
An agent's deletion nilifies its conversations' pointer, and on the `acp`
runtime the argv lives on the agent. A live `ConversationServer` could
therefore be asked for a turn it had nothing to spawn for, and
`RuntimeDispatch.command/2`'s `{:ok, argv} = CommandRuntime.argv(agent)` raised
a `MatchError` inside the server, after a turn row already existed. Every
other runtime resolves its argv from a pinned table and cannot reach this.

`TurnMachine.open/4` refuses it instead, before a turn row is written, for the
same reason `:at_capacity` is refused there: there is nothing to record, and a
`turn`/`failed` stage event says what happened and what to do about it. The
server treats `:no_command` as it treats `:at_capacity` — stay idle, drop
nothing — while `{:error, _}` keeps dropping the connection as before.

Backing the guard out puts the `MatchError` back in the one test that covers
this and leaves the other ten green.



---

**Stack for #1634** (merge top down; each PR is based on the one below it in the list):

| | PR | What it is |
|---|---|---|
| 1 | #1832 | `Fountain.CommandRuntime` and the host dispatch for `acp` |
| 2 | #1833 | `agents.runtime_command`, and `acp` becomes a runtime you can name |
| 3 | #1834 | skills mount on a runtime the library does not know |
| 4 | #1835 | a turn on the acp runtime, end to end |
| 5 | #1836 | refuse a turn whose agent no longer carries a command |
| 6 | #1837 | the acp runtime in the agent form |
| 7 | #1838 | a real ACP program through a whole turn |
| 8 | #1839 | docs, CHANGELOG and SDK 1.25.0 |

Replaces #1677, which was the same feature as one 1,760-line branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A2iMoNvSvrkQQfnP4RzVi2
