### PR TITLE
feat(console): the acp runtime in the agent form (#1634)

### DIFF
--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -2299,9 +2299,9 @@ defmodule Fountain.Conversations.ConversationServer do
   defp kick_turn(state, prompt, agent, images) do
     state = touch_activity(state)
 
-    case TurnMachine.open(state.conversation_id, state.sandbox_id, prompt) do
+    case TurnMachine.open(state.conversation_id, state.sandbox_id, prompt, agent) do
       {:ok, conv, turn} -> run_turn(state, conv, turn, prompt, agent, images)
-      :at_capacity -> state
+      refused when refused in [:at_capacity, :no_command] -> state
       {:error, _} -> drop_connection(state, "admission_refused")
     end
   end

--- a/apps/fountain/lib/fountain/conversations/turn_machine.ex
+++ b/apps/fountain/lib/fountain/conversations/turn_machine.ex
@@ -831,11 +831,49 @@ defmodule Fountain.Conversations.TurnMachine do
   cannot both start. Refused, not queued: nothing is written, the
   conversation stays idle and the caller sends again when the other turn
   ends.
+
+  `:no_command` is the other refusal, and it belongs to the acp runtime alone
+  (#1634). The argv there is the agent's own `runtime_command`, and a
+  conversation outlives its agent, so a live server can be asked for a turn
+  it has nothing to spawn for. Refused here, before a turn row exists, for the
+  same reason capacity is: there is no run to record, and the stage event says
+  what happened.
   """
-  @spec open(String.t(), String.t(), String.t()) ::
-          {:ok, Conversation.t(), Conversations.Turn.t()} | :at_capacity | {:error, term()}
-  def open(conversation_id, sandbox_id, prompt) do
+  @spec open(String.t(), String.t(), String.t(), map() | nil) ::
+          {:ok, Conversation.t(), Conversations.Turn.t()}
+          | :at_capacity
+          | :no_command
+          | {:error, term()}
+  def open(conversation_id, sandbox_id, prompt, agent \\ nil) do
     conv = Conversations._unsafe_get_conversation!(conversation_id)
+
+    if runnable?(conv, agent),
+      do: open_turn(conv, sandbox_id, prompt),
+      else: refuse_no_command(conv)
+  end
+
+  # `RuntimeDispatch.command/2` is total for every other runtime, so the only
+  # question is whether the acp runtime's agent still carries one.
+  defp runnable?(conv, agent) do
+    not Fountain.RuntimeDispatch.command_required?(conv.runtime) or
+      match?({:ok, _}, Fountain.CommandRuntime.argv(agent))
+  end
+
+  defp refuse_no_command(conv) do
+    publish_stage(conv.id, "turn", "failed", %{
+      reason: "no_runtime_command",
+      runtime: conv.runtime,
+      message:
+        "This conversation runs the acp runtime, and the agent that carried its " <>
+          "command is gone. Create an agent with a runtime_command and start a " <>
+          "conversation on it."
+    })
+
+    :no_command
+  end
+
+  defp open_turn(conv, sandbox_id, prompt) do
+    conversation_id = conv.id
     turn_number = Conversations._unsafe_next_turn_number(conversation_id)
 
     attrs = %{
@@ -982,7 +1020,7 @@ defmodule Fountain.Conversations.TurnMachine do
   as flags).
 
   On the acp runtime the argv is the agent's own `runtime_command` (#1634),
-  which is why the agent is in hand here as well as the conversation.
+  and the match below is total because `open/4` refuses a turn that has none.
   """
   @spec command(
           boolean(),

--- a/apps/fountain/lib/fountain_web/live/agents_live/form.ex
+++ b/apps/fountain/lib/fountain_web/live/agents_live/form.ex
@@ -21,10 +21,7 @@ defmodule FountainWeb.AgentsLive.Form do
      |> assign(:user_id, user_id)
      |> assign(
        :missing_credential,
-       InferenceCredentials.missing_for_model(
-         user_id,
-         agent.model || "anthropic/claude-sonnet-5"
-       )
+       InferenceCredentials.missing_for_model(user_id, credential_model(agent))
      )
      |> assign(:credential_message, nil)
      |> assign(:envs, envs)
@@ -61,8 +58,9 @@ defmodule FountainWeb.AgentsLive.Form do
       "name" => a.name || "",
       "description" => a.description || "",
       "system" => a.system || "",
-      "model" => a.model || "anthropic/claude-sonnet-5",
+      "model" => a.model || default_model(a.runtime),
       "runtime" => a.runtime || "claude",
+      "runtime_command" => a.runtime_command || "",
       "sandbox_provider" => a.sandbox_provider || "",
       "sandbox_mode" => a.sandbox_mode || "ephemeral",
       "environment_id" => a.environment_id || "",
@@ -99,6 +97,36 @@ defmodule FountainWeb.AgentsLive.Form do
   end
 
   defp asks_permission?(runtime), do: ACP.asks_permission?(runtime || "claude")
+
+  # A new agent lands on claude, so it gets claude's model prefilled. An acp
+  # agent gets none: the field is optional there and nothing reads it, so a
+  # prefilled value would be a suggestion to configure something inert.
+  defp default_model("acp"), do: ""
+  defp default_model(_runtime), do: "anthropic/claude-sonnet-5"
+
+  # Which model the credential card asks about (#841). A new agent has none
+  # yet and lands on claude, so it is asked about claude's default. An acp
+  # agent has none and needs none, and asking its owner for an Anthropic key
+  # would claim its conversations cannot start until they set one (#1634).
+  defp credential_model(agent) do
+    cond do
+      is_binary(agent.model) -> agent.model
+      model_required?(agent.runtime) -> default_model(agent.runtime)
+      true -> nil
+    end
+  end
+
+  defp model_required?(runtime), do: Fountain.RuntimeDispatch.model_required?(runtime || "claude")
+  defp command_runtime?(runtime), do: Fountain.RuntimeDispatch.command_required?(runtime)
+
+  # The command belongs to the acp runtime alone, and the changeset refuses it
+  # on any other. Sending nil rather than whatever the form last held is what
+  # lets someone switch an agent off acp without hitting that refusal.
+  defp runtime_command_param(params) do
+    if Fountain.RuntimeDispatch.command_required?(params["runtime"]),
+      do: params["runtime_command"],
+      else: nil
+  end
 
   defp permission_override_count(form) do
     form
@@ -213,7 +241,13 @@ defmodule FountainWeb.AgentsLive.Form do
      |> assign(:mcp_servers, mcp_servers)
      |> assign(
        :missing_credential,
-       InferenceCredentials.missing_for_model(socket.assigns.user_id, params["model"])
+       # Keyed on the runtime, not only on the model box: picking acp must
+       # clear the card in the same render, and the box may still hold the
+       # value it had a moment ago (#1634).
+       if(model_required?(params["runtime"]),
+         do: InferenceCredentials.missing_for_model(socket.assigns.user_id, params["model"]),
+         else: nil
+       )
      )}
   end
 
@@ -390,8 +424,14 @@ defmodule FountainWeb.AgentsLive.Form do
         |> Map.put("mcp_servers", mcp_map)
         |> Map.put("permission_policy", form_to_permission_policy(params))
         |> Map.put("user_id", socket.assigns.user_id)
+        |> Map.put("runtime_command", runtime_command_param(params))
         |> nil_if_blank("environment_id")
         |> nil_if_blank("sandbox_provider")
+        |> nil_if_blank("runtime_command")
+        # Blank means "no model", which is a legal state on the acp runtime
+        # and a "can't be blank" on every other one. Left as "" it would be a
+        # format error instead, which points at the wrong thing.
+        |> nil_if_blank("model")
 
       case save(socket, attrs) do
         {:ok, socket} -> {:noreply, socket}
@@ -710,11 +750,7 @@ defmodule FountainWeb.AgentsLive.Form do
               name="agent[runtime]"
               class="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm"
             >
-              <option
-                :for={r <- ~w(claude codex gemini opencode)}
-                value={r}
-                selected={@form["runtime"] == r}
-              >
+              <option :for={r <- Agent.runtimes()} value={r} selected={@form["runtime"] == r}>
                 {r}
               </option>
             </select>
@@ -726,13 +762,30 @@ defmodule FountainWeb.AgentsLive.Form do
             value={@form["model"]}
             placeholder={model_placeholder(@form["runtime"])}
             list="model-options"
-            required
+            disabled={not model_required?(@form["runtime"])}
+            required={model_required?(@form["runtime"])}
           />
           <datalist id="model-options">
             <option :for={m <- ModelCatalog.suggestions(@form["runtime"])} value={m}></option>
           </datalist>
         </div>
         <.error_msg field="model" errors={@errors} />
+        <div :if={command_runtime?(@form["runtime"])} class="space-y-1">
+          <.input
+            id="runtime_command"
+            name="agent[runtime_command]"
+            label="Command"
+            value={@form["runtime_command"]}
+            placeholder="chant acp"
+            required
+          />
+          <.error_msg field="runtime_command" errors={@errors} />
+          <p class="text-zinc-500 text-xs">
+            The acp runtime runs this shell line inside the sandbox and speaks the Agent
+            Client Protocol to it. It needs no model and no inference key. Install the
+            program through the environment's packages or its setup script.
+          </p>
+        </div>
         <p
           :if={not Map.has_key?(@errors, "model") and unknown_model?(@form["model"])}
           class="text-zinc-500 text-xs"

--- a/apps/fountain/priv/help/agents.md
+++ b/apps/fountain/priv/help/agents.md
@@ -2,8 +2,9 @@
 
 An **Agent** is a named configuration for a single coding-agent CLI. It bundles together:
 
-- a **runtime** (`claude` / `codex` / `gemini` / `opencode`) — which binary runs in the sprite
-- a **model** (`anthropic/claude-sonnet-4-6`, `openai/gpt-5.3-codex`, `google/gemini-3.1-pro-preview`, etc.)
+- a **runtime** (`claude` / `codex` / `gemini` / `opencode`) — which binary runs in the sprite, or `acp` to run a command of your own
+- a **runtime_command** — the shell line the `acp` runtime launches, required there and rejected on the others
+- a **model** (`anthropic/claude-sonnet-4-6`, `openai/gpt-5.3-codex`, `google/gemini-3.1-pro-preview`, etc.); the `acp` runtime needs none
 - an optional **system prompt** (`system`)
 - an optional **environment** reference (`environment_id` or `environment` by name) — the sprite shape to provision
 - optional **skills** — names of bundled skills to mount into the sprite

--- a/apps/fountain/test/fountain/conversations/conversation_server_acp_runtime_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_acp_runtime_test.exs
@@ -329,4 +329,32 @@ defmodule Fountain.Conversations.ConversationServerAcpRuntimeTest do
       assert is_nil(:sys.get_state(pid).current_turn.pending_permission)
     end
   end
+
+  describe "an agent deleted under a live conversation" do
+    test "refuses the turn rather than spawning nothing" do
+      user = insert_verified_user()
+      agent = acp_agent(user)
+      conv = insert_conversation(agent: agent, user_id: user.id)
+
+      # Deleting an agent nilifies its conversations' pointer, and the command
+      # lived on the agent. Every other runtime resolves its argv from a table
+      # and carries on; this one has nothing left to run.
+      {:ok, _} = Fountain.Agents.delete_agent(agent)
+
+      {pid, _ref} = start_acp_turn(conv)
+
+      # No turn row, the way a sandbox at capacity opens none, and a stage
+      # event on the feed saying why.
+      assert [] = Conversations._unsafe_list_turns(conv.id)
+      refute_receive {:spawned, _cmd, _args, _opts}, 200
+
+      stage =
+        conv.id
+        |> Conversations._unsafe_list_log_events()
+        |> Enum.find(&(&1.kind == "stage" and &1.stage == "turn" and &1.state == "failed"))
+
+      assert stage.data =~ "no_runtime_command"
+      assert Process.alive?(pid)
+    end
+  end
 end

--- a/apps/fountain/test/fountain_web/live/agents_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/agents_live_test.exs
@@ -236,6 +236,89 @@ defmodule FountainWeb.AgentsLive.IndexTest do
     end
   end
 
+  describe "the acp runtime in the console (#1634)" do
+    test "the command field appears when the runtime is acp, and saves", %{conn: conn} do
+      user = insert_verified_user()
+      conn = login_user(conn, user)
+
+      {:ok, view, html} = live(conn, ~p"/agents/new")
+      refute html =~ "agent[runtime_command]"
+
+      html =
+        view
+        |> element("form[phx-change=validate]")
+        |> render_change(%{"agent" => %{"name" => "converger", "runtime" => "acp"}})
+
+      assert html =~ "agent[runtime_command]"
+      assert html =~ "It needs no model and no inference key"
+      # The model field is inert here, so it is disabled and nobody is asked
+      # for a key to run it.
+      assert has_element?(view, "input#model[disabled]")
+      refute html =~ "credential on this account yet"
+
+      view
+      |> form("form", %{
+        "agent" => %{
+          "name" => "converger",
+          "runtime" => "acp",
+          "runtime_command" => "chant acp --env prod"
+        }
+      })
+      |> render_submit()
+
+      agent = Fountain.Agents.get_agent_by_name("converger", user.id)
+      assert agent.runtime == "acp"
+      assert agent.runtime_command == "chant acp --env prod"
+      assert is_nil(agent.model)
+    end
+
+    test "switching an acp agent onto a model runtime drops the command", %{conn: conn} do
+      user = with_credential(insert_verified_user())
+
+      agent =
+        insert_agent(user_id: user.id, runtime: "acp", runtime_command: "chant acp")
+
+      conn = login_user(conn, user)
+
+      {:ok, view, html} = live(conn, ~p"/agents/#{agent.id}/edit")
+      # The model field is inert on this runtime, so the form disables it.
+      assert has_element?(view, "input#model[disabled]")
+
+      # And on first paint its owner is not asked for an Anthropic key to run
+      # an agent that needs none (#1634).
+      refute html =~ "credential on this account yet"
+
+      # Picking a model runtime re-renders the form: the model comes back and
+      # the command goes away, which is what the browser does on change.
+      html =
+        view
+        |> element("form[phx-change=validate]")
+        |> render_change(%{"agent" => %{"name" => agent.name, "runtime" => "claude"}})
+
+      refute html =~ "agent[runtime_command]"
+
+      # Submitted with the stale command still in the params, which is what a
+      # submit that crosses the re-render sends. The changeset refuses a
+      # command on this runtime, so the form has to drop it rather than
+      # forward it into a 422 the person cannot act on.
+      view
+      |> element("form[phx-change=validate]")
+      |> render_submit(%{
+        "agent" => %{
+          "name" => agent.name,
+          "runtime" => "claude",
+          "model" => "anthropic/claude-sonnet-5",
+          "runtime_command" => "chant acp"
+        }
+      })
+
+      reloaded = Fountain.Agents.get_agent(agent.id, user.id)
+      assert reloaded.runtime == "claude"
+      assert reloaded.model == "anthropic/claude-sonnet-5"
+      assert is_nil(reloaded.runtime_command)
+    end
+  end
+
   describe "edit" do
     test "renders edit form for existing agent", %{conn: conn} do
       user = insert_verified_user()


### PR DESCRIPTION
`acp` was already a value the API accepted; the console's runtime picker was a
hardcoded list of four and had no field for the command. It now reads
`Agent.runtimes()`, so a runtime added to the enum reaches the form by
construction.

- **A Command field**, shown only on `acp`, required there, with a line saying
  what runs it and that the program is yours to install.
- **The model input is disabled on `acp`** rather than required. The field is
  inert on that runtime, and a required box that does nothing is worse than no
  box. A blank model is sent as null, which is a legal state there and a
  "can't be blank" on every other runtime, rather than a format error pointing
  at the wrong thing.
- **Nobody is asked for a key they do not need.** The missing-credential card
  is keyed on the runtime rather than only on the model box, so picking `acp`
  clears it in the same render, and an acp agent's owner is not told their
  conversations cannot start until they add an Anthropic key.
- **Switching off `acp` drops the command.** The changeset refuses a command on
  any other runtime, so a submit that crosses the re-render would land as a 422
  the person cannot act on. The test submits the stale value deliberately;
  backing the scrub out fails it.

`priv/help/agents.md` gains the runtime and the field.



---

**Stack for #1634** (merge top down; each PR is based on the one below it in the list):

| | PR | What it is |
|---|---|---|
| 1 | #1832 | `Fountain.CommandRuntime` and the host dispatch for `acp` |
| 2 | #1833 | `agents.runtime_command`, and `acp` becomes a runtime you can name |
| 3 | #1834 | skills mount on a runtime the library does not know |
| 4 | #1835 | a turn on the acp runtime, end to end |
| 5 | #1836 | refuse a turn whose agent no longer carries a command |
| 6 | #1837 | the acp runtime in the agent form |
| 7 | #1838 | a real ACP program through a whole turn |
| 8 | #1839 | docs, CHANGELOG and SDK 1.25.0 |

Replaces #1677, which was the same feature as one 1,760-line branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A2iMoNvSvrkQQfnP4RzVi2
