### PR TITLE
test(runtimes): conformance, a real ACP program through a whole turn (#1634)

### DIFF
--- a/apps/fountain/test/fixtures/acp_agent.exs
+++ b/apps/fountain/test/fixtures/acp_agent.exs
@@ -1,0 +1,118 @@
+# A deterministic ACP agent, as a real program (#1634).
+#
+# This is what the `acp` runtime is for: not a model, just something that
+# reads the Agent Client Protocol on stdin and answers it on stdout. It runs
+# as its own OS process under `elixir`, uses OTP's own `:json` and depends on
+# nothing else, so `conversation_server_acp_fixture_test.exs` drives a whole
+# turn against a program rather than against a mock of one.
+#
+# One turn: `initialize`, `session/new`, then a `session/prompt` answered with
+# a tool call, its completion, a message and a stop reason. A prompt whose
+# text contains "ask" requests permission first and does as it is told.
+
+defmodule FixtureAcpAgent do
+  def run do
+    case IO.read(:stdio, :line) do
+      line when is_binary(line) ->
+        line |> String.trim() |> dispatch()
+        run()
+
+      _eof_or_error ->
+        :ok
+    end
+  end
+
+  defp dispatch(""), do: :ok
+
+  defp dispatch(line) do
+    case :json.decode(line) do
+      %{"method" => method, "id" => id, "params" => params} -> request(method, id, params)
+      %{"id" => id, "result" => result} -> answer(id, result)
+      _other -> :ok
+    end
+  rescue
+    _ -> :ok
+  end
+
+  defp request("initialize", id, _params) do
+    reply(id, %{"protocolVersion" => 1, "agentCapabilities" => %{"loadSession" => false}})
+  end
+
+  defp request("session/new", id, _params) do
+    reply(id, %{"sessionId" => "fixture-session"})
+  end
+
+  defp request("session/prompt", id, params) do
+    Process.put(:prompt_id, id)
+
+    if params |> inspect() |> String.contains?("ask") do
+      # Wait for the client's verdict before doing anything.
+      write(%{
+        "jsonrpc" => "2.0",
+        "id" => 1,
+        "method" => "session/request_permission",
+        "params" => %{
+          "sessionId" => "fixture-session",
+          "toolCall" => %{"title" => "converge", "kind" => "execute"},
+          "options" => [
+            %{"optionId" => "go", "kind" => "allow_once"},
+            %{"optionId" => "stop", "kind" => "reject_once"}
+          ]
+        }
+      })
+    else
+      converge()
+      reply(id, %{"stopReason" => "end_turn"})
+    end
+  end
+
+  defp request(_method, _id, _params), do: :ok
+
+  # The only response this agent asks for is the permission verdict.
+  defp answer(1, %{"outcome" => %{"optionId" => "go"}}) do
+    converge()
+    reply(Process.get(:prompt_id), %{"stopReason" => "end_turn"})
+  end
+
+  defp answer(1, _result) do
+    reply(Process.get(:prompt_id), %{"stopReason" => "refusal"})
+  end
+
+  defp answer(_id, _result), do: :ok
+
+  defp converge do
+    update(%{
+      "sessionUpdate" => "tool_call",
+      "toolCallId" => "converge",
+      "title" => "lifecycle apply",
+      "kind" => "execute",
+      "status" => "pending"
+    })
+
+    update(%{
+      "sessionUpdate" => "tool_call_update",
+      "toolCallId" => "converge",
+      "status" => "completed"
+    })
+
+    update(%{
+      "sessionUpdate" => "agent_message_chunk",
+      "content" => %{"type" => "text", "text" => "converged 3 resources"}
+    })
+  end
+
+  defp update(payload) do
+    write(%{
+      "jsonrpc" => "2.0",
+      "method" => "session/update",
+      "params" => %{"sessionId" => "fixture-session", "update" => payload}
+    })
+  end
+
+  defp reply(nil, _result), do: :ok
+  defp reply(id, result), do: write(%{"jsonrpc" => "2.0", "id" => id, "result" => result})
+
+  defp write(message), do: IO.puts(:json.encode(message))
+end
+
+FixtureAcpAgent.run()

--- a/apps/fountain/test/fountain/conversations/conversation_server_acp_fixture_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_acp_fixture_test.exs
@@ -1,0 +1,164 @@
+defmodule Fountain.Conversations.ConversationServerAcpFixtureTest do
+  @moduledoc """
+  Conformance: a whole turn against a real ACP program (#1634).
+
+  Every other test in this tree hand-feeds the protocol, so it proves what
+  Fountain does with bytes it wrote itself. This one runs
+  `test/fixtures/acp_agent.exs` as its own OS process, hands its stdio to a
+  `ConversationServer` through `Fountain.FixtureAcpProcess`, and asserts on
+  what lands in the transcript. Nothing in the loop knows the program, and
+  the program knows nothing about Fountain.
+
+  It is the acp runtime end to end: an agent that names a command, a turn
+  with no model and no inference credential, tool-call and message blocks on
+  the feed, the stop reason closing the turn, and a permission request the
+  agent's policy answers.
+  """
+
+  use Fountain.ConversationServerCase
+
+  alias Fountain.Conversations.Blocks
+
+  defp launch(prompt, agent_overrides \\ []) do
+    user = insert_verified_user()
+
+    agent =
+      insert_agent(
+        Keyword.merge(
+          [
+            user_id: user.id,
+            runtime: "acp",
+            # `elixir` is on PATH inside the test VM, and the fixture is what
+            # `FixtureAcpProcess` actually runs; the string is here so the
+            # agent is configured the way a real one would be.
+            runtime_command: "elixir #{Fountain.FixtureAcpProcess.fixture_path()}"
+          ],
+          agent_overrides
+        )
+      )
+
+    conv = insert_conversation(agent: agent, user_id: user.id)
+
+    stub_happy_sprite()
+
+    Mimic.stub(Fountain.Conversations.TitleGenerator, :generate, fn _prompt, _creds ->
+      {:error, :stubbed_in_test}
+    end)
+
+    _ref = Fountain.FixtureAcpProcess.stub_spawn()
+
+    {pid, _mon, :alive} =
+      start_server(conv, initial_prompt: prompt, runtime: Fountain.CommandRuntime)
+
+    on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+
+    {conv, pid}
+  end
+
+  # The agent is a separate OS process, so there is nothing to synchronise on
+  # but the result. Poll the row the turn writes.
+  defp await_turn(conv_id, status, timeout \\ 15_000) do
+    deadline = System.monotonic_time(:millisecond) + timeout
+    await_turn(conv_id, status, deadline, nil)
+  end
+
+  defp await_turn(conv_id, status, deadline, last) do
+    turn = conv_id |> Conversations._unsafe_list_turns() |> List.first()
+
+    cond do
+      turn && turn.status == status ->
+        turn
+
+      System.monotonic_time(:millisecond) > deadline ->
+        flunk("turn never reached #{status}; last was #{inspect(last || turn)}")
+
+      true ->
+        Process.sleep(50)
+        await_turn(conv_id, status, deadline, turn)
+    end
+  end
+
+  # The conversation row goes back to idle *after* the turn row closes, so a
+  # turn that reached `completed` is not yet proof the conversation did. Wait
+  # on the row the assertion reads.
+  defp await_conversation(conv_id, status, timeout \\ 15_000) do
+    deadline = System.monotonic_time(:millisecond) + timeout
+    await_conversation(conv_id, status, deadline, nil)
+  end
+
+  defp await_conversation(conv_id, status, deadline, last) do
+    conv = Conversations._unsafe_get_conversation!(conv_id)
+
+    cond do
+      conv.status == status ->
+        conv
+
+      System.monotonic_time(:millisecond) > deadline ->
+        flunk("conversation never reached #{status}; last was #{inspect(last || conv.status)}")
+
+      true ->
+        Process.sleep(50)
+        await_conversation(conv_id, status, deadline, conv.status)
+    end
+  end
+
+  defp blocks(conv_id) do
+    conv_id
+    |> Conversations._unsafe_list_log_events()
+    |> Enum.filter(&(&1.stream == "acp"))
+    |> Enum.flat_map(&Blocks.for_event(&1, "acp"))
+  end
+
+  describe "a real ACP program, driven to completion" do
+    test "the turn completes on the agent's stop reason, with its blocks on the feed" do
+      {conv, _pid} = launch("converge the fleet")
+
+      turn = await_turn(conv.id, "completed")
+
+      # No model was pinned and no token figure came back, so metering has
+      # sandbox time and nothing else.
+      assert is_nil(turn.usage)
+      refute is_nil(turn.ended_at)
+
+      blocks = blocks(conv.id)
+      assert Enum.any?(blocks, &(&1.kind == :tool_use and &1.name == "lifecycle apply"))
+      assert Enum.any?(blocks, &(&1.kind == :tool_result and &1.tool_id == "converge"))
+      assert Enum.any?(blocks, &(&1.kind == :text and &1.body =~ "converged 3 resources"))
+
+      conv_row = await_conversation(conv.id, "idle")
+      assert conv_row.runtime_session_id == "fixture-session"
+    end
+
+    test "protocol chatter stays off the transcript" do
+      {conv, _pid} = launch("converge the fleet")
+      _turn = await_turn(conv.id, "completed")
+
+      events = Conversations._unsafe_list_log_events(conv.id)
+      refute Enum.any?(events, &(is_binary(&1.data) and &1.data =~ "protocolVersion"))
+    end
+
+    test "a permission request the policy denies ends the turn without a human" do
+      # The fixture asks before it converges when the prompt mentions "ask",
+      # and answers a denial with a `refusal` stop reason.
+      {conv, _pid} =
+        launch("ask before you converge", permission_policy: %{"execute" => "auto_deny"})
+
+      turn = await_turn(conv.id, "failed")
+      assert is_nil(turn.pending_permission)
+
+      # Denied, so the fixture never ran its tool call.
+      refute Enum.any?(blocks(conv.id), &(&1.kind == :tool_use))
+    end
+
+    test "a permission request the policy allows lets the program carry on" do
+      {conv, _pid} =
+        launch("ask before you converge", permission_policy: %{"execute" => "auto_allow"})
+
+      _turn = await_turn(conv.id, "completed")
+
+      blocks = blocks(conv.id)
+      assert Enum.any?(blocks, &(&1.kind == :tool_use and &1.name == "lifecycle apply"))
+      assert Enum.any?(blocks, &(&1.kind == :text and &1.body =~ "converged 3 resources"))
+    end
+  end
+end

--- a/apps/fountain/test/support/fixture_acp_process.ex
+++ b/apps/fountain/test/support/fixture_acp_process.ex
@@ -1,0 +1,117 @@
+defmodule Fountain.FixtureAcpProcess do
+  @moduledoc """
+  Run a fixture ACP agent as a real OS process, framed as a sandbox command.
+
+  `Managoat.Sandbox.Fake` speaks a scripted instruction vocabulary rather than
+  running programs, so it cannot host an agent that has to read what the
+  client wrote and answer it. This does the smallest thing that can: a port to
+  `test/fixtures/acp_agent.exs`, and a relay that turns the port's frames into
+  the `{:stdout | :exit, %{ref: ref}, _}` messages `Managoat.Sandbox` promises
+  a command's owner.
+
+  It is the test sandbox provider for one purpose (#1634): proving that a
+  `ConversationServer` drives a whole turn against a program it did not write,
+  over the same stdio the four LLM runtimes use. Everything else about the
+  sandbox stays stubbed by `Fountain.ConversationServerCase`.
+  """
+
+  @fixture "acp_agent.exs"
+
+  @doc """
+  Stub `Managoat.Sandbox.Sprites`'s streaming calls onto a real fixture agent.
+
+  Returns the ref every frame from it will carry. The relay is started here
+  and opens its port when the spawn arrives, so it can send to that spawn's
+  `:owner` (the conversation server) without anybody knowing the pid first.
+  """
+  @spec stub_spawn() :: reference()
+  def stub_spawn do
+    ref = make_ref()
+    relay = spawn(fn -> await_start(ref) end)
+
+    # The conversation server does not stop its command on terminate, so
+    # without this the fixture's own OS process would outlive the test.
+    ExUnit.Callbacks.on_exit(fn -> send(relay, :stop) end)
+
+    Mimic.stub(Managoat.Sandbox.Sprites, :spawn, fn _handle, _cmd, _args, opts ->
+      send(relay, {:start, Keyword.fetch!(opts, :owner)})
+      {:ok, %Managoat.Sandbox.Command{provider: :sprites, ref: ref}}
+    end)
+
+    Mimic.stub(Managoat.Sandbox.Sprites, :write_stdin, fn _command, data ->
+      send(relay, {:write, IO.iodata_to_binary(data)})
+      :ok
+    end)
+
+    # A port has no half-close, and this turn ends on the stop reason rather
+    # than on EOF, so the close is a no-op and `stop_command/1` is what ends
+    # the process.
+    Mimic.stub(Managoat.Sandbox.Sprites, :close_stdin, fn _command -> :ok end)
+
+    Mimic.stub(Managoat.Sandbox.Sprites, :stop_command, fn _command ->
+      send(relay, :stop)
+      :ok
+    end)
+
+    ref
+  end
+
+  @doc "Absolute path of the checked-in fixture agent."
+  @spec fixture_path() :: String.t()
+  def fixture_path, do: Path.expand(Path.join([__DIR__, "..", "fixtures", @fixture]))
+
+  # Unlinked, and it waits rather than opening the port eagerly: writes that
+  # somehow arrive first stay in the mailbox until the loop reaches them.
+  defp await_start(ref) do
+    receive do
+      {:start, owner} ->
+        port =
+          Port.open({:spawn_executable, elixir_executable()}, [
+            :binary,
+            :exit_status,
+            :use_stdio,
+            {:line, 1_000_000},
+            {:args, [fixture_path()]}
+          ])
+
+        relay(port, owner, ref)
+
+      :stop ->
+        :ok
+    end
+  end
+
+  defp elixir_executable do
+    System.find_executable("elixir") ||
+      raise "elixir is not on PATH; the fixture ACP agent cannot run"
+  end
+
+  defp relay(port, owner, ref) do
+    receive do
+      {:write, data} ->
+        Port.command(port, data)
+        relay(port, owner, ref)
+
+      :stop ->
+        safe_close(port)
+        send(owner, {:exit, %{ref: ref}, 0})
+
+      {^port, {:data, {:eol, line}}} ->
+        send(owner, {:stdout, %{ref: ref}, line <> "\n"})
+        relay(port, owner, ref)
+
+      {^port, {:data, {:noeol, chunk}}} ->
+        send(owner, {:stdout, %{ref: ref}, chunk})
+        relay(port, owner, ref)
+
+      {^port, {:exit_status, code}} ->
+        send(owner, {:exit, %{ref: ref}, code})
+    end
+  end
+
+  defp safe_close(port) do
+    Port.close(port)
+  catch
+    _, _ -> :ok
+  end
+end


### PR DESCRIPTION
Every other test in this tree hand-feeds the protocol, so it proves what
Fountain does with bytes Fountain wrote. This one runs a checked-in ACP agent,
`test/fixtures/acp_agent.exs`, as its own OS process, hands its stdio to a
real `ConversationServer` through `Fountain.FixtureAcpProcess`, and asserts on
what lands in the transcript. Nothing in the loop knows the program, and the
program knows nothing about Fountain.

That makes it the acceptance for the `acp` runtime as a whole: an agent that
names a command, a turn with no model and no inference credential, tool-call
and message blocks reaching the feed, protocol chatter staying off the
transcript, the stop reason closing the turn, and a `session/request_permission`
that the agent's policy answers on both verdicts.

A small Elixir program rather than a Node or Go one: `elixir` is already on
PATH in the test VM, so the fixture adds no toolchain to CI and no build step,
and it is readable by anyone who can read the server it talks to.

Test-only. Ran on 25 seeds with no failure.

One thing worth reading, because it is the kind of test this file invites.
The completion test waited on the **turn** row reaching `completed` and then
asserted the **conversation** row was `idle`, which the server writes after
the turn closes. It reproduced on the first seed once the timing shifted, so
the wait is now on the row the assertion reads (`await_conversation/3`).



---

**Stack for #1634** (merge top down; each PR is based on the one below it in the list):

| | PR | What it is |
|---|---|---|
| 1 | #1832 | `Fountain.CommandRuntime` and the host dispatch for `acp` |
| 2 | #1833 | `agents.runtime_command`, and `acp` becomes a runtime you can name |
| 3 | #1834 | skills mount on a runtime the library does not know |
| 4 | #1835 | a turn on the acp runtime, end to end |
| 5 | #1836 | refuse a turn whose agent no longer carries a command |
| 6 | #1837 | the acp runtime in the agent form |
| 7 | #1838 | a real ACP program through a whole turn |
| 8 | #1839 | docs, CHANGELOG and SDK 1.25.0 |

Replaces #1677, which was the same feature as one 1,760-line branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A2iMoNvSvrkQQfnP4RzVi2
