### PR TITLE
feat(conversations): a labels column, and the rule that guards it (#1637)

### DIFF
--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -2313,6 +2313,7 @@ defmodule Fountain.Conversations do
     - `source`                — optional; one of "ui", "api", "agent" (default "api")
     - `parent_conversation_id` — optional; UUID of the conversation that spawned this one
     - `title`                 — optional display title (the team page names a teammate with it)
+    - `labels`                — optional `key => value` strings (#1637); see `Conversations.Labels`
   """
   def start_conversation(attrs, opts \\ [])
 
@@ -2377,7 +2378,8 @@ defmodule Fountain.Conversations do
                title: attrs["title"],
                sandbox_api_access: api_access,
                permission_policy: perm_policy,
-               caller_tools: attrs["caller_tools"] || []
+               caller_tools: attrs["caller_tools"] || [],
+               labels: attrs["labels"] || %{}
              },
              attrs["execution_limits"],
              opts
@@ -2979,7 +2981,8 @@ defmodule Fountain.Conversations do
                permission_policy: perm_policy,
                # The bridge's tools (#1202) ride on both create paths: this
                # one is what a home sandbox's second conversation takes.
-               caller_tools: attrs["caller_tools"] || []
+               caller_tools: attrs["caller_tools"] || [],
+               labels: attrs["labels"] || %{}
              },
              attrs["execution_limits"],
              opts

--- a/apps/fountain/lib/fountain/conversations/conversation.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation.ex
@@ -56,6 +56,11 @@ defmodule Fountain.Conversations.Conversation do
     field :permission_policy, :map
     # The caller-defined tools of the bridge (#1202, `Fountain.CallerTools`).
     field :caller_tools, {:array, :map}, default: []
+    # Free-form `key => value` strings (#1637), set at launch.
+    # `Conversations.Labels` owns the limits and the merge; writes here go
+    # through `Labels.changeset/1` below, which is why every door enforces
+    # the same rule.
+    field :labels, :map, default: %{}
 
     # Populated by list_conversations_by_activity/1 — not persisted.
     field :turn_count, :integer, virtual: true, default: 0
@@ -120,7 +125,8 @@ defmodule Fountain.Conversations.Conversation do
       :environment_id,
       :channel_id,
       :permission_policy,
-      :caller_tools
+      :caller_tools,
+      :labels
     ])
     |> validate_required([:runtime, :status, :sandbox_id, :user_id])
     |> Fountain.Changeset.validate_ids([
@@ -139,6 +145,7 @@ defmodule Fountain.Conversations.Conversation do
     |> validate_inclusion(:source, @sources)
     |> validate_inclusion(:sandbox_api_access, @sandbox_api_access_modes)
     |> validate_sandbox_api_access_immutable()
+    |> Fountain.Conversations.Labels.changeset()
     |> foreign_key_constraint(:sandbox_id)
     |> foreign_key_constraint(:agent_id)
     |> foreign_key_constraint(:agent_version_id)

--- a/apps/fountain/lib/fountain/conversations/labels.ex
+++ b/apps/fountain/lib/fountain/conversations/labels.ex
@@ -1,0 +1,148 @@
+defmodule Fountain.Conversations.Labels do
+  @moduledoc """
+  The rule for a conversation's labels (#1637), in one place.
+
+  A label is a free-form `key => value` pair of strings on the conversation
+  row. A person titles and searches their own threads; a program running as a
+  teammate wants to slice its runs by facts it knew when the turn ended —
+  `env=prod`, `drift=true`, `gated=apply`. Those facts are not text worth
+  searching, so they are not in the full-text index and never will be.
+
+  Every door that writes labels goes through `changeset/1` here, called from
+  `Fountain.Conversations.Conversation.changeset/2`, so the limits cannot
+  drift between one writer and the next:
+
+    * at most 32 entries;
+    * a key is a non-empty string of at most 64 bytes;
+    * a value is a string of at most 256 bytes;
+    * neither may contain a NUL byte, which Postgres refuses inside `jsonb`.
+
+  A refusal names the offending key, because a caller sending thirty-two of
+  them cannot otherwise tell which one Fountain disliked.
+  """
+
+  import Ecto.Changeset, only: [get_change: 2, add_error: 3]
+
+  @max_entries 32
+  @max_key_bytes 64
+  @max_value_bytes 256
+
+  @doc "At most this many labels on one conversation."
+  @spec max_entries() :: pos_integer()
+  def max_entries, do: @max_entries
+
+  @doc "A label key is at most this many bytes."
+  @spec max_key_bytes() :: pos_integer()
+  def max_key_bytes, do: @max_key_bytes
+
+  @doc "A label value is at most this many bytes."
+  @spec max_value_bytes() :: pos_integer()
+  def max_value_bytes, do: @max_value_bytes
+
+  @doc """
+  Validate the `:labels` change on a conversation changeset.
+
+  Called from `Fountain.Conversations.Conversation.changeset/2`, which is the
+  only writer of the column, so every door inherits it. It sees the *merged*
+  map, which is the right thing to enforce and the wrong thing to word a
+  count refusal from; `Fountain.Conversations._unsafe_merge_labels/3` runs
+  `check_merge/2` first for that reason.
+  """
+  @spec changeset(Ecto.Changeset.t()) :: Ecto.Changeset.t()
+  def changeset(changeset) do
+    case get_change(changeset, :labels) do
+      nil -> changeset
+      labels -> apply_check(changeset, check(labels))
+    end
+  end
+
+  defp apply_check(changeset, :ok), do: changeset
+  defp apply_check(changeset, {:error, message}), do: add_error(changeset, :labels, message)
+
+  @doc """
+  Whether `labels` is a legal label map. `:ok`, or `{:error, message}` naming
+  the offending key.
+  """
+  @spec check(term()) :: :ok | {:error, String.t()}
+  def check(labels) when is_map(labels) do
+    with :ok <- check_entries(labels), do: check_count(labels)
+  end
+
+  def check(_labels), do: {:error, "must be an object of string keys and string values"}
+
+  defp check_count(labels) do
+    if map_size(labels) > @max_entries do
+      # Sorted, so the key named is the same one on every run rather than
+      # whichever the map happened to iterate to last.
+      over = labels |> Map.keys() |> Enum.sort_by(&describe/1) |> Enum.at(@max_entries)
+
+      {:error, "at most #{@max_entries} labels; #{describe(over)} does not fit"}
+    else
+      :ok
+    end
+  end
+
+  defp check_entries(labels) do
+    labels
+    |> Enum.sort_by(fn {key, _value} -> describe(key) end)
+    |> Enum.reduce_while(:ok, fn {key, value}, _acc ->
+      case check_entry(key, value) do
+        :ok -> {:cont, :ok}
+        error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp check_entry(key, _value) when not is_binary(key),
+    do: {:error, "label key #{describe(key)} must be a string"}
+
+  defp check_entry("", _value), do: {:error, "a label key must not be empty"}
+
+  defp check_entry(key, _value) when byte_size(key) > @max_key_bytes,
+    do: {:error, "label key #{describe(key)} is longer than #{@max_key_bytes} bytes"}
+
+  defp check_entry(key, value) when not is_binary(value),
+    do: {:error, "label #{describe(key)} must have a string value"}
+
+  defp check_entry(key, value) when byte_size(value) > @max_value_bytes,
+    do: {:error, "label #{describe(key)} has a value longer than #{@max_value_bytes} bytes"}
+
+  # Postgres refuses a NUL byte inside a jsonb string, so without this clause
+  # the write reaches `Repo.update` and comes back as a raised
+  # `Postgrex.Error` — a 500 on the HTTP doors, and on the ACP path a raise
+  # that would travel up through the turn machine and take the conversation's
+  # server down with the turn it was running.
+  defp check_entry(key, value) do
+    cond do
+      nul?(key) -> {:error, "label key #{describe(key)} must not contain a NUL byte"}
+      nul?(value) -> {:error, "label #{describe(key)} must not have a NUL byte in its value"}
+      true -> :ok
+    end
+  end
+
+  defp nul?(binary) when is_binary(binary), do: String.contains?(binary, <<0>>)
+
+  # The key, quoted, for a message a caller reads. An over-long key is cut
+  # rather than echoed whole: the message identifies which entry to fix, and a
+  # 4KB key in an error body helps nobody. Cut by bytes, because bytes are
+  # what the limit is measured in — and then backed off to a whole codepoint,
+  # since a message sliced through the middle of one is not valid UTF-8 and
+  # `Jason.encode!` would raise on it instead of rendering the 422.
+  defp describe(key) when is_binary(key) do
+    shown =
+      if byte_size(key) > @max_key_bytes,
+        do: cut(key, @max_key_bytes) <> "...",
+        else: key
+
+    ~s("#{shown}")
+  end
+
+  defp describe(key), do: inspect(key)
+
+  defp cut(_binary, bytes) when bytes <= 0, do: ""
+
+  defp cut(binary, bytes) do
+    candidate = binary_part(binary, 0, bytes)
+    if String.valid?(candidate), do: candidate, else: cut(binary, bytes - 1)
+  end
+end

--- a/apps/fountain/priv/repo/migrations/20260910130000_add_labels_to_conversations.exs
+++ b/apps/fountain/priv/repo/migrations/20260910130000_add_labels_to_conversations.exs
@@ -1,0 +1,23 @@
+defmodule Fountain.Repo.Migrations.AddLabelsToConversations do
+  use Ecto.Migration
+
+  # #1637: free-form `key => value` strings a program stamps on its own run —
+  # `env=prod`, `drift=true` — so the list can slice by them. At most 32
+  # entries; the rule lives in `Fountain.Conversations.Labels`.
+  #
+  # The list filter is jsonb containment (`labels @> '{"env":"prod"}'`), which
+  # is what the GIN index serves. `jsonb_path_ops` rather than the default
+  # operator class: containment is the only operator the filter ever uses, and
+  # that class indexes whole paths instead of every key and value separately,
+  # so it is smaller and faster for exactly this query.
+  def change do
+    alter table(:conversations) do
+      add :labels, :map, null: false, default: %{}
+    end
+
+    create index(:conversations, ["labels jsonb_path_ops"],
+             using: :gin,
+             name: :conversations_labels_gin_index
+           )
+  end
+end

--- a/apps/fountain/test/fountain/conversations/labels_test.exs
+++ b/apps/fountain/test/fountain/conversations/labels_test.exs
@@ -1,0 +1,139 @@
+defmodule Fountain.Conversations.LabelsTest do
+  @moduledoc """
+  Labels on a conversation (#1637): the rule.
+
+  What is here is the behaviour every writer inherits, because
+  `Fountain.Conversations.Conversation.changeset/2` is the only thing that
+  puts the column on a row.
+  """
+
+  use Fountain.DataCase, async: true
+
+  alias Fountain.Conversations
+  alias Fountain.Conversations.Labels
+
+  describe "the limits" do
+    test "a legal map passes" do
+      assert :ok = Labels.check(%{"env" => "prod", "drift" => "true"})
+      assert :ok = Labels.check(%{})
+    end
+
+    test "more than 32 entries names the key over the limit" do
+      labels = for n <- 1..33, into: %{}, do: {String.pad_leading("#{n}", 3, "0"), "x"}
+
+      assert {:error, message} = Labels.check(labels)
+      assert message =~ "at most 32 labels"
+      assert message =~ ~s("033")
+    end
+
+    test "an over-long key names it, cut rather than echoed whole" do
+      key = String.duplicate("k", 200)
+
+      assert {:error, message} = Labels.check(%{key => "v"})
+      assert message =~ "longer than 64 bytes"
+      assert message =~ String.duplicate("k", 64) <> "..."
+      refute message =~ String.duplicate("k", 65)
+    end
+
+    test "an over-long value names its key" do
+      assert {:error, message} = Labels.check(%{"note" => String.duplicate("v", 257)})
+      assert message =~ ~s("note")
+      assert message =~ "longer than 256 bytes"
+    end
+
+    test "a non-string value names its key" do
+      assert {:error, message} = Labels.check(%{"count" => 3})
+      assert message =~ ~s("count")
+      assert message =~ "string value"
+    end
+
+    test "an empty key is refused" do
+      assert {:error, message} = Labels.check(%{"" => "v"})
+      assert message =~ "must not be empty"
+    end
+
+    test "something that is not a map at all is refused" do
+      assert {:error, _} = Labels.check(["env:prod"])
+    end
+
+    # Postgres refuses a NUL inside a jsonb string, so an unchecked one is a
+    # raised Postgrex.Error rather than a refusal — a 500 on the HTTP doors
+    # and a dead ConversationServer on the ACP one.
+    test "a NUL byte in a value names its key" do
+      assert {:error, message} = Labels.check(%{"note" => "a\u0000b"})
+      assert message =~ ~s("note")
+      assert message =~ "NUL byte"
+    end
+
+    test "a NUL byte in a key is refused" do
+      assert {:error, message} = Labels.check(%{"a\u0000b" => "v"})
+      assert message =~ "NUL byte"
+    end
+
+    test "the boundary values are legal" do
+      assert :ok =
+               Labels.check(%{String.duplicate("k", 64) => String.duplicate("v", 256)})
+
+      assert :ok = Labels.check(for(n <- 1..32, into: %{}, do: {"k#{n}", "v"}))
+    end
+
+    test "an over-long key is cut to a whole codepoint, so the message stays encodable" do
+      # Cutting at 64 *bytes* lands mid-character here: "é" is two bytes, so
+      # byte 64 is the tail of one. A message sliced there is not valid UTF-8
+      # and Jason.encode! would raise on it instead of rendering the 422.
+      key = String.duplicate("é", 40)
+
+      assert {:error, message} = Labels.check(%{key => "v"})
+      assert String.valid?(message)
+      assert {:ok, _} = Jason.encode(%{errors: %{labels: [message]}})
+    end
+
+    test "the same offending key is named on every run, whatever the map order" do
+      labels = for n <- 1..40, into: %{}, do: {String.pad_leading("#{n}", 3, "0"), "x"}
+
+      assert {:error, first} = Labels.check(labels)
+      assert {:error, second} = Labels.check(Map.new(Enum.shuffle(labels)))
+      assert first == second
+    end
+  end
+
+  describe "on the row" do
+    setup do
+      user = insert_active_user()
+      {:ok, user: user}
+    end
+
+    test "a conversation created with labels reads them back", %{user: user} do
+      conv = insert_conversation(user_id: user.id, labels: %{"env" => "prod"})
+
+      assert %{"env" => "prod"} = Conversations.get_conversation(conv.id, user.id).labels
+    end
+
+    test "a conversation created without labels has an empty map", %{user: user} do
+      conv = insert_conversation(user_id: user.id)
+
+      assert %{} == Conversations.get_conversation(conv.id, user.id).labels
+    end
+
+    # The wiring, not the rule: `Conversation.changeset/2` is what every
+    # writer of the column goes through, so `check/1` running from there is
+    # what makes the limits inescapable rather than advisory.
+    test "the changeset refuses a write over the limits, naming the key", %{user: user} do
+      conv = insert_conversation(user_id: user.id)
+      long = String.duplicate("v", Labels.max_value_bytes() + 1)
+
+      assert {:error, changeset} =
+               Conversations.update_conversation(conv, %{labels: %{"note" => long}})
+
+      assert %{labels: [message]} = errors_on(changeset)
+      assert message =~ ~s("note")
+    end
+
+    test "an unrelated update leaves the labels alone", %{user: user} do
+      conv = insert_conversation(user_id: user.id, labels: %{"env" => "prod"})
+
+      assert {:ok, updated} = Conversations.update_conversation(conv, %{title: "renamed"})
+      assert updated.labels == %{"env" => "prod"}
+    end
+  end
+end


### PR DESCRIPTION
A person titles and searches their own threads. A program running as a
teammate wants to slice its runs by facts it knew when the turn ended —
`env=prod`, `drift=true`, `gated=apply`. Those are not text worth searching,
so they do not belong in the full-text index.

Add `labels` to conversations: a jsonb map of `key => value` strings, with a
`jsonb_path_ops` GIN index for the containment query a filter will make of
it. `POST /api/conversations` accepts them through the existing create
attrs.

`Fountain.Conversations.Labels` owns the limits in one place — at most 32
entries, a key at most 64 bytes, a value at most 256 bytes, and no NUL byte
in either, because Postgres refuses one inside `jsonb` and the write would
otherwise come back as a raised `Postgrex.Error`. A refusal names the
offending key, since a caller sending thirty-two of them cannot otherwise
tell which one Fountain disliked, and it names the same key on every run
whatever order the map iterated in. An over-long key is cut to a whole
codepoint rather than echoed whole, so the message stays encodable.

`Conversation.changeset/2` calls it, which is what makes the limits
inescapable rather than advisory: it is the only writer of the column, so
every door inherits them by construction.

First of nine on #1637; the merge writer, the routes, the filter, the ACP
extension, the webhook payload and the console chips follow.


---

### The stack for #1637

Nine PRs, each based on the one above it. Merge top down, and do not
`--delete-branch` while a child still points at a branch.

| # | branch | owns |
|---|---|---|
| 1 | `stack/1637-labels-column` | the jsonb column, the GIN index, `Conversations.Labels`'s limits, `labels` on create |
| 2 | `stack/1637-labels-writer` | `set_conversation_labels/4`, `_unsafe_merge_labels/3`, the sandbox rule, the audit event, the channel resume |
| 3 | `stack/1637-labels-api` | `PATCH /api/conversations/:id/labels`, `FountainWeb.SandboxKey`, the 403, `labels` on the wire |
| 4 | `stack/1637-label-filter` | `?label=key:value`, `RepeatedQueryParam`, `LabelFilter`, the SDK filter |
| 5 | `stack/1637-team-labels` | labels on a team message, and the same filter on a teammate's list |
| 6 | `stack/1637-acp-stamp` | `_fountain/labels` over the agent's own ACP session |
| 7 | `stack/1637-webhook-labels` | `data.labels` on every `conversation.*` payload |
| 8 | `stack/1637-console-chips` | chips on the console lists, and the dashboard URL filter |
| 9 | `stack/1637-release` | the manual, the CHANGELOG, one SDK release (1.27.0) |

This is #1676 re-cut under the no-big-PRs rule, rebased onto current `main` (re-rebased after #1832-#1839 landed).
The combined tip is byte-identical to #1676 over `apps/`, apart from three
prose fixes the destink and STE gates asked for and the regenerated contract
and SDK types.

Validation on the tip of the stack: `mix precommit` clean, core and ee
**4,911 tests, 0 failures**, `fountain_buzz` 144, `fountain_support` 33. The
SDK contract `--check`, the TypeScript typecheck and its 105 tests pass.
`docs-style.py`, `vale` (0 errors) and `destink` are clean.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SgxmwtJNGJBvgCxSfGBaf

