### PR TITLE
feat(conversations): merge labels onto a conversation, audited by key (#1637)

### DIFF
--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -11,7 +11,7 @@ defmodule Fountain.Conversations do
   require Logger
 
   alias Fountain.Audit
-  alias Fountain.Conversations.{Blocks, Conversation, LogEvent, Sandbox, Turn, TurnImage}
+  alias Fountain.Conversations.{Blocks, Conversation, Labels, LogEvent, Sandbox, Turn, TurnImage}
   alias Fountain.Conversations.{ExecutionAllowance, ExecutionLimits}
   alias Fountain.Repo
 
@@ -957,6 +957,132 @@ defmodule Fountain.Conversations do
           :ok
       end)
     end
+  end
+
+  @doc """
+  Merge `labels` into `conversation_id`'s. **The door every request-shaped
+  caller uses** (#1637).
+
+  Merge, not replace: a key that is not named is left alone and a key whose
+  value is `nil` is removed, so a run can stamp one outcome without reading
+  the rest first. `Conversations.Labels` owns the limits, and a write that
+  breaks one comes back as a changeset naming the offending key.
+
+  **A sandbox may label its own conversation only.** Pass
+  `sandbox_key_id: key.id` whenever the caller authenticated with a
+  `sprite`-scoped token: the conversation must be the one that token was
+  minted for (`callback_api_key_id`), or the write is refused with
+  `:sprite_may_not_label_another_conversation`. Without that check a worker
+  holding an account-scoped callback key could relabel every other run on the
+  account, which is exactly the loop ADR 0045 describes. That is why the
+  check lives here and not in a controller: more than one request path will
+  write labels, and the rule has to hold on the door rather than on whichever
+  of them remembered.
+
+  `labels` that is not a map at all is a validation failure, not a silent
+  no-op, so every door refuses `{"labels": "env=prod"}` the same way.
+
+  Tenant-scoped: an id belonging to another account reads as `:not_found`.
+  """
+  @spec set_conversation_labels(binary(), binary(), term(), keyword()) ::
+          {:ok, Conversation.t()} | {:error, term()}
+  def set_conversation_labels(conversation_id, user_id, labels, opts \\ [])
+      when is_binary(conversation_id) and is_binary(user_id) do
+    case get_conversation(conversation_id, user_id) do
+      nil ->
+        {:error, :not_found}
+
+      %Conversation{} = conv ->
+        if sandbox_owns?(conv, Keyword.get(opts, :sandbox_key_id)) do
+          # Ownership: `conv` came from the tenant-scoped fetch above.
+          _unsafe_merge_labels(conv, labels, opts)
+        else
+          {:error, :sprite_may_not_label_another_conversation}
+        end
+    end
+  end
+
+  # No sandbox key on the request is the owner's own credential, which may
+  # label any conversation it can already fetch.
+  defp sandbox_owns?(_conv, nil), do: true
+  defp sandbox_owns?(%Conversation{callback_api_key_id: id}, key_id), do: id == key_id
+
+  @doc """
+  Merge `labels` into a conversation row, with no tenant scoping and no
+  credential rule.
+
+  Unscoped, hence the prefix. The legitimate caller is
+  `set_conversation_labels/4`, which scopes and applies the sandbox rule
+  before delegating here. A request path that calls this directly has skipped
+  the rule that stops one sandbox relabelling another, so do not add one.
+
+  A merge that changes nothing writes nothing and records nothing — a
+  deterministic run re-stamping the same outcome on every tick is the normal
+  case. Audited as `conversation.labels_set` with the keys written and the
+  keys removed, never the values (ADR 0013).
+  """
+  @spec _unsafe_merge_labels(Conversation.t(), term(), keyword()) ::
+          {:ok, Conversation.t()} | {:error, Ecto.Changeset.t()}
+  def _unsafe_merge_labels(conv, labels, opts \\ [])
+
+  def _unsafe_merge_labels(%Conversation{} = conv, labels, opts) when is_map(labels) do
+    current = conv.labels || %{}
+    merged = Labels.merge(current, labels)
+
+    cond do
+      merged == current -> {:ok, conv}
+      true -> write_labels(conv, current, labels, merged, opts)
+    end
+  end
+
+  # Anything that is not a map is a validation failure with the same shape a
+  # broken limit produces, so a caller reads one answer whichever door it
+  # came through.
+  def _unsafe_merge_labels(%Conversation{} = conv, labels, _opts) do
+    {:error, label_refusal(conv, Labels.check(labels))}
+  end
+
+  defp write_labels(conv, current, labels, merged, opts) do
+    case Labels.check_merge(current, labels) do
+      :ok ->
+        {written, removed} = Labels.changed_keys(current, labels)
+
+        conv
+        |> Conversation.changeset(%{labels: merged})
+        |> Repo.update()
+        |> tap(fn
+          {:ok, updated} -> record_labels_set(updated, written, removed, merged, opts)
+          _ -> :ok
+        end)
+
+      refusal ->
+        {:error, label_refusal(conv, refusal)}
+    end
+  end
+
+  defp record_labels_set(conv, written, removed, merged, opts) do
+    Audit.record(%{
+      user_id: conv.user_id,
+      action: "conversation.labels_set",
+      resource_type: "conversation",
+      resource_id: conv.id,
+      actor: Keyword.get(opts, :actor, "self"),
+      request_ip: Keyword.get(opts, :request_ip),
+      metadata: %{
+        "keys" => written,
+        "removed_keys" => removed,
+        "label_count" => map_size(merged)
+      }
+    })
+  end
+
+  # `Labels.check_merge/2` words the refusal from the write the caller made;
+  # this is what turns that sentence into the `errors.labels` a 422 renders,
+  # the same key the changeset validator would have used.
+  defp label_refusal(%Conversation{} = conv, {:error, message}) do
+    conv
+    |> Ecto.Changeset.change()
+    |> Ecto.Changeset.add_error(:labels, message)
   end
 
   def update_conversation(%Conversation{} = conv, attrs) do
@@ -2047,8 +2173,10 @@ defmodule Fountain.Conversations do
   binding return a channel validation error to the loser.
 
   Two concurrent first calls for one channel can both create; the next call
-  resumes whichever is newer. Nothing is audited on the resume path — nothing
-  changed.
+  resumes whichever is newer. Nothing is audited on the resume path unless
+  `attrs["labels"]` actually changes something: it is the same conversation,
+  so labels merge into the row it hands back (#1637) and that write records
+  `conversation.labels_set` like any other.
   """
   def start_or_resume_conversation(attrs, opts \\ [])
 
@@ -2070,6 +2198,7 @@ defmodule Fountain.Conversations do
           else
             with :ok <- _unsafe_check_saved_execution_allowance(conv.id),
                  :ok <- check_sandbox_api_resume(conv, attrs["sandbox_api_access"]),
+                 {:ok, conv} <- resume_labels(conv, attrs["labels"], opts),
                  do: {:ok, conv, :resumed}
           end
 
@@ -2109,6 +2238,20 @@ defmodule Fountain.Conversations do
         {:error, {:execution_limits_invalid, "object_required"}}
     end
   end
+
+  # A resume lands on the conversation the binding already has, so labels on
+  # the request are merged into it rather than dropped (#1637). A caller that
+  # sends none changes nothing, and the resume stays the silent path it was.
+  #
+  # Through `set_conversation_labels/4` rather than the writer beneath it:
+  # this runs on `POST /api/conversations`, which a sandbox's own token may
+  # call, and a resume names an *existing* conversation. Writing here
+  # directly would let a sprite minted for one conversation relabel any other
+  # of the tenant's by resuming its channel.
+  defp resume_labels(%Conversation{} = conv, nil, _opts), do: {:ok, conv}
+
+  defp resume_labels(%Conversation{} = conv, labels, opts),
+    do: set_conversation_labels(conv.id, conv.user_id, labels, opts)
 
   # `true` or `"true"` — the ACP adapter sends a JSON boolean, a hand-built
   # request may send a string. Anything else is not a request.

--- a/apps/fountain/lib/fountain/conversations/labels.ex
+++ b/apps/fountain/lib/fountain/conversations/labels.ex
@@ -18,7 +18,15 @@ defmodule Fountain.Conversations.Labels do
     * neither may contain a NUL byte, which Postgres refuses inside `jsonb`.
 
   A refusal names the offending key, because a caller sending thirty-two of
-  them cannot otherwise tell which one Fountain disliked.
+  them cannot otherwise tell which one Fountain disliked. On a merge the key
+  named is one the caller actually sent — see `check_merge/2`.
+
+  ## Merge, and how a key is removed
+
+  Writes merge (`merge/2`): a key that is not mentioned is left alone. A key
+  whose value is `null` is removed. That is what lets a run add one label
+  without reading the others first, and what makes a channel resume keep the
+  labels the binding already carried.
   """
 
   import Ecto.Changeset, only: [get_change: 2, add_error: 3]
@@ -69,6 +77,69 @@ defmodule Fountain.Conversations.Labels do
   end
 
   def check(_labels), do: {:error, "must be an object of string keys and string values"}
+
+  @doc """
+  Check what merging `incoming` into `current` would produce, wording the
+  refusal from the write the caller actually made.
+
+  `check/1` alone would blame an arbitrary key for the count: merging one new
+  label into a conversation that already holds 32 puts a *pre-existing* key
+  over the boundary in sorted order, and telling somebody their write of
+  `run` failed because of `env` — a label they never touched — sends them to
+  fix the wrong thing. So the count is reported against the first key this
+  write adds.
+
+  Entry-level problems need no such care: `current` is already on the row and
+  therefore already legal, so any entry `check/1` rejects came from
+  `incoming`.
+  """
+  @spec check_merge(map(), term()) :: :ok | {:error, String.t()}
+  def check_merge(current, incoming) when is_map(current) and is_map(incoming) do
+    merged = merge(current, incoming)
+
+    with :ok <- check_entries(merged) do
+      check_merged_count(current, incoming, merged)
+    end
+  end
+
+  def check_merge(_current, incoming), do: check(incoming)
+
+  defp check_merged_count(current, incoming, merged) do
+    if map_size(merged) > @max_entries do
+      {:error,
+       "at most #{@max_entries} labels; #{describe(blamed_key(current, incoming, merged))} does not fit"}
+    else
+      :ok
+    end
+  end
+
+  # The first key of this write that does not fit.
+  #
+  # The labels already on the row are kept — the caller did not ask to change
+  # them — so the room left is the ceiling minus what survives the merge, and
+  # what spills past it is one of the keys this write added. Adding `run` to a
+  # conversation that already holds 32 therefore names `run`, and sending 33
+  # at once names the 33rd rather than the first.
+  #
+  # The fallback covers a write that adds nothing and is over the limit
+  # anyway, which only a row already past the ceiling can produce.
+  defp blamed_key(current, incoming, merged) do
+    retained = Enum.count(Map.keys(current), &(not removed?(incoming, &1)))
+
+    added =
+      incoming
+      |> Enum.reject(fn {key, value} -> is_nil(value) or Map.has_key?(current, key) end)
+      |> Enum.map(&elem(&1, 0))
+      |> Enum.sort_by(&describe/1)
+      |> Enum.drop(max(@max_entries - retained, 0))
+
+    case added do
+      [key | _] -> key
+      [] -> merged |> Map.keys() |> Enum.sort_by(&describe/1) |> Enum.at(@max_entries)
+    end
+  end
+
+  defp removed?(incoming, key), do: Map.has_key?(incoming, key) and is_nil(Map.get(incoming, key))
 
   defp check_count(labels) do
     if map_size(labels) > @max_entries do
@@ -144,5 +215,43 @@ defmodule Fountain.Conversations.Labels do
   defp cut(binary, bytes) do
     candidate = binary_part(binary, 0, bytes)
     if String.valid?(candidate), do: candidate, else: cut(binary, bytes - 1)
+  end
+
+  @doc """
+  Merge `incoming` into `current`. A key with a `nil` value is removed; a key
+  that is absent is left alone.
+
+  Nothing is validated here — the merged map goes through `changeset/1` on
+  its way to the row, so a write that would break a limit is refused with the
+  key named rather than half-applied.
+  """
+  @spec merge(map() | nil, map()) :: map()
+  def merge(current, incoming) when is_map(incoming) do
+    Enum.reduce(incoming, current || %{}, fn
+      {key, nil}, acc -> Map.delete(acc, key)
+      {key, value}, acc -> Map.put(acc, key, value)
+    end)
+  end
+
+  @doc """
+  Which keys `merge/2` would change, as `{written, removed}` — both sorted,
+  both keys only.
+
+  The audit trail records these and never the values (ADR 0013).
+  """
+  @spec changed_keys(map() | nil, map()) :: {[String.t()], [String.t()]}
+  def changed_keys(current, incoming) when is_map(incoming) do
+    current = current || %{}
+
+    {removed, written} =
+      incoming
+      |> Enum.filter(fn {key, value} -> Map.get(current, key, :absent) != value end)
+      |> Enum.split_with(fn {_key, value} -> is_nil(value) end)
+
+    {written |> Enum.map(&to_string(elem(&1, 0))) |> Enum.sort(),
+     removed
+     |> Enum.map(&to_string(elem(&1, 0)))
+     |> Enum.filter(&Map.has_key?(current, &1))
+     |> Enum.sort()}
   end
 end

--- a/apps/fountain/test/fountain/audit_guardrail_test.exs
+++ b/apps/fountain/test/fountain/audit_guardrail_test.exs
@@ -57,6 +57,7 @@ defmodule Fountain.AuditGuardrailTest do
     {"inference credential clear", &__MODULE__.do_cred_clear/1, "inference_credential.delete"},
     {"conversation delete", &__MODULE__.do_conv_delete/1, "conversation.deleted"},
     {"conversation caller tools", &__MODULE__.do_caller_tools/1, "conversation.caller_tools_set"},
+    {"conversation labels", &__MODULE__.do_labels/1, "conversation.labels_set"},
     {"allowance creation", &__MODULE__.do_allowance_creation/1,
      "conversation.execution_allowance_created"},
     {"allowance narrowing", &__MODULE__.do_allowance_narrowing/1,
@@ -416,6 +417,12 @@ defmodule Fountain.AuditGuardrailTest do
       Conversations.set_caller_tools(conv, [
         %{"name" => "lookup", "description" => "", "parameters" => %{}}
       ])
+  end
+
+  def do_labels(user) do
+    conv = insert_conversation(user_id: user.id, agent: insert_agent(user_id: user.id))
+
+    {:ok, _} = Conversations._unsafe_merge_labels(conv, %{"env" => "prod"})
   end
 
   def do_sandbox_reset(user) do

--- a/apps/fountain/test/fountain/conversations/labels_test.exs
+++ b/apps/fountain/test/fountain/conversations/labels_test.exs
@@ -1,14 +1,15 @@
 defmodule Fountain.Conversations.LabelsTest do
   @moduledoc """
-  Labels on a conversation (#1637): the rule.
+  Labels on a conversation (#1637): the rule and the merge.
 
-  What is here is the behaviour every writer inherits, because
-  `Fountain.Conversations.Conversation.changeset/2` is the only thing that
-  puts the column on a row.
+  The doors are covered where they live, so what is here is the behaviour
+  every one of them inherits.
+
   """
 
   use Fountain.DataCase, async: true
 
+  alias Fountain.Audit
   alias Fountain.Conversations
   alias Fountain.Conversations.Labels
 
@@ -118,7 +119,7 @@ defmodule Fountain.Conversations.LabelsTest do
     # The wiring, not the rule: `Conversation.changeset/2` is what every
     # writer of the column goes through, so `check/1` running from there is
     # what makes the limits inescapable rather than advisory.
-    test "the changeset refuses a write over the limits, naming the key", %{user: user} do
+    test "a plain update through the changeset is held to the limits too", %{user: user} do
       conv = insert_conversation(user_id: user.id)
       long = String.duplicate("v", Labels.max_value_bytes() + 1)
 
@@ -129,11 +130,289 @@ defmodule Fountain.Conversations.LabelsTest do
       assert message =~ ~s("note")
     end
 
-    test "an unrelated update leaves the labels alone", %{user: user} do
+    test "the changeset refuses a write over the limits, naming the key", %{user: user} do
+      conv = insert_conversation(user_id: user.id)
+
+      assert {:error, changeset} =
+               Conversations._unsafe_merge_labels(conv, %{"note" => String.duplicate("v", 300)})
+
+      assert %{labels: [message]} = errors_on(changeset)
+      assert message =~ ~s("note")
+    end
+
+    test "the count ceiling counts the merged result, not the request", %{user: user} do
+      thirty_two = for n <- 1..32, into: %{}, do: {"k#{n}", "v"}
+      conv = insert_conversation(user_id: user.id, labels: thirty_two)
+
+      assert {:error, changeset} =
+               Conversations._unsafe_merge_labels(conv, %{"one-too-many" => "v"})
+
+      assert %{labels: [message]} = errors_on(changeset)
+      assert message =~ "at most 32 labels"
+
+      # And it names the key the caller sent, not whichever of the 32 already
+      # on the row happens to sort into the boundary position.
+      assert message =~ ~s("one-too-many")
+      refute message =~ ~s("k1")
+    end
+
+    test "a write of many at once names the one that does not fit", %{user: user} do
+      conv = insert_conversation(user_id: user.id)
+      labels = for n <- 1..33, into: %{}, do: {String.pad_leading("#{n}", 3, "0"), "x"}
+
+      assert {:error, changeset} = Conversations._unsafe_merge_labels(conv, labels)
+      assert %{labels: [message]} = errors_on(changeset)
+      assert message =~ ~s("033")
+    end
+
+    test "a merge that only removes keys never trips the ceiling", %{user: user} do
+      thirty_two = for n <- 1..32, into: %{}, do: {"k#{n}", "v"}
+      conv = insert_conversation(user_id: user.id, labels: thirty_two)
+
+      assert {:ok, updated} =
+               Conversations._unsafe_merge_labels(conv, %{"k1" => nil, "new" => "v"})
+
+      assert map_size(updated.labels) == 32
+      assert updated.labels["new"] == "v"
+      refute Map.has_key?(updated.labels, "k1")
+    end
+  end
+
+  describe "merge" do
+    test "adds and overwrites, leaves the rest alone" do
+      assert %{"a" => "2", "b" => "1"} = Labels.merge(%{"a" => "1", "b" => "1"}, %{"a" => "2"})
+    end
+
+    test "a null value removes the key" do
+      assert %{"b" => "1"} = Labels.merge(%{"a" => "1", "b" => "1"}, %{"a" => nil})
+    end
+
+    test "removing a key that is not there is not an error" do
+      assert %{"b" => "1"} = Labels.merge(%{"b" => "1"}, %{"a" => nil})
+    end
+
+    test "changed_keys reports written and removed, sorted" do
+      current = %{"a" => "1", "b" => "1", "z" => "1"}
+      incoming = %{"a" => "1", "b" => "2", "c" => "3", "z" => nil, "gone" => nil}
+
+      # "a" is unchanged so it is not written; "gone" was never there, so
+      # removing it removed nothing and the trail does not claim otherwise.
+      assert {["b", "c"], ["z"]} = Labels.changed_keys(current, incoming)
+    end
+  end
+
+  describe "_unsafe_merge_labels/3" do
+    setup do
+      user = insert_active_user()
+      conv = insert_conversation(user_id: user.id, labels: %{"env" => "staging"})
+      {:ok, user: user, conv: conv}
+    end
+
+    test "merges rather than replaces", %{conv: conv} do
+      assert {:ok, updated} = Conversations._unsafe_merge_labels(conv, %{"drift" => "true"})
+      assert updated.labels == %{"env" => "staging", "drift" => "true"}
+    end
+
+    test "a null value removes one key", %{conv: conv} do
+      assert {:ok, updated} = Conversations._unsafe_merge_labels(conv, %{"env" => nil})
+      assert updated.labels == %{}
+    end
+
+    test "records the keys that changed and never the values", %{user: user, conv: conv} do
+      assert {:ok, _} =
+               Conversations._unsafe_merge_labels(conv, %{"drift" => "true", "env" => nil})
+
+      assert [event] =
+               user.id
+               |> Audit.list_recent_for_user(50)
+               |> Enum.filter(&(&1.action == "conversation.labels_set"))
+
+      assert event.metadata["keys"] == ["drift"]
+      assert event.metadata["removed_keys"] == ["env"]
+      assert event.metadata["label_count"] == 1
+      refute event.metadata |> inspect() =~ "true"
+    end
+
+    test "a merge that changes nothing writes nothing and records nothing", %{
+      user: user,
+      conv: conv
+    } do
+      assert {:ok, same} = Conversations._unsafe_merge_labels(conv, %{"env" => "staging"})
+      assert same.updated_at == conv.updated_at
+
+      assert [] =
+               user.id
+               |> Audit.list_recent_for_user(50)
+               |> Enum.filter(&(&1.action == "conversation.labels_set"))
+    end
+  end
+
+  describe "set_conversation_labels/4" do
+    setup do
+      user = insert_active_user()
+      {key, _raw} = insert_sprite_api_key(user)
+
+      mine =
+        insert_conversation(user_id: user.id, callback_api_key_id: key.id, labels: %{"a" => "1"})
+
+      theirs = insert_conversation(user_id: user.id)
+
+      {:ok, user: user, key: key, mine: mine, theirs: theirs}
+    end
+
+    test "the owner's own key may label any of their conversations", %{
+      user: user,
+      theirs: theirs
+    } do
+      assert {:ok, updated} =
+               Conversations.set_conversation_labels(theirs.id, user.id, %{"env" => "prod"})
+
+      assert updated.labels == %{"env" => "prod"}
+    end
+
+    test "a sandbox token may label the conversation it was minted for", %{
+      user: user,
+      key: key,
+      mine: mine
+    } do
+      assert {:ok, updated} =
+               Conversations.set_conversation_labels(mine.id, user.id, %{"env" => "prod"},
+                 sandbox_key_id: key.id,
+                 actor: "sprite"
+               )
+
+      assert updated.labels == %{"a" => "1", "env" => "prod"}
+    end
+
+    test "a sandbox token may not label another conversation", %{
+      user: user,
+      key: key,
+      theirs: theirs
+    } do
+      assert {:error, :sprite_may_not_label_another_conversation} =
+               Conversations.set_conversation_labels(theirs.id, user.id, %{"env" => "prod"},
+                 sandbox_key_id: key.id
+               )
+
+      assert Conversations.get_conversation(theirs.id, user.id).labels == %{}
+    end
+
+    test "labels that are not a map at all are a validation failure, not a no-op", %{
+      user: user,
+      theirs: theirs
+    } do
+      assert {:error, changeset} =
+               Conversations.set_conversation_labels(theirs.id, user.id, "env=prod")
+
+      assert %{labels: [message]} = errors_on(changeset)
+      assert message =~ "object of string keys"
+      assert Conversations.get_conversation(theirs.id, user.id).labels == %{}
+    end
+
+    test "another tenant's conversation reads as not found", %{user: user} do
+      other = insert_conversation(user_id: insert_active_user().id)
+
+      assert {:error, :not_found} =
+               Conversations.set_conversation_labels(other.id, user.id, %{"env" => "prod"})
+    end
+  end
+
+  describe "labels and the rest of the row" do
+    setup do
+      {:ok, user: insert_active_user()}
+    end
+
+    test "an unrelated update leaves them alone", %{user: user} do
+      conv = insert_conversation(user_id: user.id, labels: %{"env" => "prod"})
+
+      assert {:ok, updated} = Conversations.update_conversation(conv, %{status: "idle"})
+      assert updated.status == "idle"
+      assert updated.labels == %{"env" => "prod"}
+      assert Conversations.get_conversation(conv.id, user.id).labels == %{"env" => "prod"}
+    end
+
+    test "a title change leaves them alone", %{user: user} do
       conv = insert_conversation(user_id: user.id, labels: %{"env" => "prod"})
 
       assert {:ok, updated} = Conversations.update_conversation(conv, %{title: "renamed"})
       assert updated.labels == %{"env" => "prod"}
+    end
+  end
+
+  describe "a channel resume" do
+    setup do
+      user = insert_active_user()
+      agent = insert_agent(user_id: user.id)
+
+      bound =
+        insert_conversation(
+          user_id: user.id,
+          agent: agent,
+          status: "idle",
+          channel_id: "chat:1",
+          labels: %{"env" => "prod"},
+          sandbox: insert_sandbox(user_id: user.id, status: "ready")
+        )
+
+      {:ok, user: user, agent: agent, bound: bound}
+    end
+
+    defp resume(context, extra) do
+      Conversations.start_or_resume_conversation(
+        Map.merge(
+          %{
+            "agent_id" => context.agent.id,
+            "user_id" => context.user.id,
+            "channel_id" => "chat:1"
+          },
+          extra
+        )
+      )
+    end
+
+    test "merges the request's labels into the conversation it hands back", context do
+      assert {:ok, conv, :resumed} = resume(context, %{"labels" => %{"run" => "17"}})
+      assert conv.id == context.bound.id
+      assert conv.labels == %{"env" => "prod", "run" => "17"}
+    end
+
+    test "a resume with no labels changes nothing", context do
+      assert {:ok, conv, :resumed} = resume(context, %{})
+      assert conv.labels == %{"env" => "prod"}
+    end
+
+    test "a null value removes a key on resume", context do
+      assert {:ok, conv, :resumed} = resume(context, %{"labels" => %{"env" => nil}})
+      assert conv.labels == %{}
+    end
+
+    test "a label the limits refuse fails the resume rather than being dropped", context do
+      assert {:error, changeset} =
+               resume(context, %{"labels" => %{"note" => String.duplicate("v", 300)}})
+
+      assert %{labels: [message]} = errors_on(changeset)
+      assert message =~ ~s("note")
+
+      assert Conversations.get_conversation(context.bound.id, context.user.id).labels ==
+               %{"env" => "prod"}
+    end
+
+    test "a sandbox token may not relabel a conversation it was not minted for", context do
+      {key, _raw} = insert_sprite_api_key(context.user)
+
+      assert {:error, :sprite_may_not_label_another_conversation} =
+               Conversations.start_or_resume_conversation(
+                 %{
+                   "agent_id" => context.agent.id,
+                   "user_id" => context.user.id,
+                   "channel_id" => "chat:1",
+                   "labels" => %{"run" => "17"}
+                 },
+                 sandbox_key_id: key.id
+               )
+
+      assert Conversations.get_conversation(context.bound.id, context.user.id).labels ==
+               %{"env" => "prod"}
     end
   end
 end


### PR DESCRIPTION
The writer the routes will use. Merge, not replace: a key the caller does not
name is left alone and a key whose value is `nil` is removed, so a run can
stamp one outcome without reading the rest of them first, and a channel
resume keeps the labels the binding already carried.

`set_conversation_labels/4` is the door. It scopes by `user_id` and applies
one rule the contexts cannot leave to a controller: **a sandbox may label its
own conversation only**. A conversation's `sprite`-scoped callback token
authenticates as the *account*, so every tenant check passes for every
conversation that account owns — the gap ADR 0045 describes. Pass
`sandbox_key_id:` and the conversation must be the one that token was minted
for, or the write is `:sprite_may_not_label_another_conversation`. Three
request paths will write labels, and the rule has to hold on the door rather
than on whichever of them remembered.

`_unsafe_merge_labels/3` is the unscoped writer beneath it, for callers that
have already established ownership.

Two details worth the words:

- **A count refusal names a key the caller sent.** `check/1` sees the merged
  map, so merging one label into a conversation that already holds 32 would
  otherwise blame whichever *pre-existing* key sorts into the boundary
  position and send somebody to fix a label they never touched.
  `check_merge/2` words it from the write instead.
- **A merge that changes nothing writes nothing and records nothing.** A
  deterministic run re-stamping the same outcome on every tick is the normal
  case, not an event.

Audited as `conversation.labels_set` with the keys written and the keys
removed, never the values (ADR 0013).

Second of nine on #1637.


---

### The stack for #1637

Nine PRs, each based on the one above it. Merge top down, and do not
`--delete-branch` while a child still points at a branch.

| # | branch | owns |
|---|---|---|
| 1 | `stack/1637-labels-column` | the jsonb column, the GIN index, `Conversations.Labels`'s limits, `labels` on create |
| 2 | `stack/1637-labels-writer` | `set_conversation_labels/4`, `_unsafe_merge_labels/3`, the sandbox rule, the audit event, the channel resume |
| 3 | `stack/1637-labels-api` | `PATCH /api/conversations/:id/labels`, `FountainWeb.SandboxKey`, the 403, `labels` on the wire |
| 4 | `stack/1637-label-filter` | `?label=key:value`, `RepeatedQueryParam`, `LabelFilter`, the SDK filter |
| 5 | `stack/1637-team-labels` | labels on a team message, and the same filter on a teammate's list |
| 6 | `stack/1637-acp-stamp` | `_fountain/labels` over the agent's own ACP session |
| 7 | `stack/1637-webhook-labels` | `data.labels` on every `conversation.*` payload |
| 8 | `stack/1637-console-chips` | chips on the console lists, and the dashboard URL filter |
| 9 | `stack/1637-release` | the manual, the CHANGELOG, one SDK release (1.27.0) |

This is #1676 re-cut under the no-big-PRs rule, rebased onto current `main` (re-rebased after #1832-#1839 landed).
The combined tip is byte-identical to #1676 over `apps/`, apart from three
prose fixes the destink and STE gates asked for and the regenerated contract
and SDK types.

Validation on the tip of the stack: `mix precommit` clean, core and ee
**4,911 tests, 0 failures**, `fountain_buzz` 144, `fountain_support` 33. The
SDK contract `--check`, the TypeScript typecheck and its 105 tests pass.
`docs-style.py`, `vale` (0 errors) and `destink` are clean.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SgxmwtJNGJBvgCxSfGBaf

