### PR TITLE
feat(api): set a conversation's labels over HTTP (#1637)

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
@@ -9,6 +9,7 @@ defmodule FountainWeb.ConversationController do
   alias Fountain.Conversations
   alias Fountain.Conversations.{ConversationServer, LogEvent}
   alias FountainWeb.Audited
+  alias FountainWeb.SandboxKey
   alias FountainWeb.Schemas
 
   action_fallback FountainWeb.FallbackController
@@ -147,6 +148,43 @@ defmodule FountainWeb.ConversationController do
       _conv ->
         :ok = Conversations.mark_read(id, user.id)
         send_resp(conn, :no_content, "")
+    end
+  end
+
+  operation(:labels,
+    summary: "Set a conversation's labels",
+    description:
+      "Merges `labels` into the conversation's own (#1637). A key the body does not name " <>
+        "is left alone, and a key whose value is `null` is removed, so a run can stamp one " <>
+        "outcome without reading the rest first.\n\n" <>
+        "At most 32 labels survive the merge; a key is at most 64 bytes and a value at most " <>
+        "256 bytes. A 422 names the offending key.\n\n" <>
+        "The account's own key may label any of its conversations. A sandbox callback token " <>
+        "may label **only the conversation it was minted for**; another id is refused with " <>
+        "403 `sprite_may_not_label_another_conversation`.",
+    parameters: [conversation_id: [in: :path, type: :string, required: true]],
+    request_body: {"Labels", "application/json", Schemas.ConversationLabelsRequest},
+    responses: [
+      ok: {"Conversation", "application/json", Schemas.ConversationResponse},
+      not_found: {"Not found", "application/json", Schemas.Error},
+      forbidden:
+        {"A sandbox token labelling another conversation", "application/json", Schemas.Error},
+      unprocessable_entity:
+        {"Invalid labels", "application/json", Schemas.UnprocessableEntityError}
+    ]
+  )
+
+  def labels(conn, %{"conversation_id" => id} = params) do
+    user = conn.assigns.current_user
+    opts = SandboxKey.opts(conn) ++ Audited.attribution(conn)
+
+    with {:ok, conv} <-
+           Conversations.set_conversation_labels(id, user.id, params["labels"], opts) do
+      # Re-read annotated, so this renders the same conversation object every
+      # other conversation route does rather than one with a null turn_count.
+      render(conn, :show,
+        conversation: Conversations.get_conversation_with_activity(conv.id, user.id)
+      )
     end
   end
 
@@ -419,6 +457,9 @@ defmodule FountainWeb.ConversationController do
         "With `channel_id`, resumes the latest live conversation already bound to that " <>
         "channel for the same agent and vault (200, `meta.resumed: true`) instead of " <>
         "opening a new one (201). " <>
+        "`labels` (#1637) are stamped on the new conversation; with `channel_id`, a resume " <>
+        "merges them into the conversation it hands back, and a sandbox callback token " <>
+        "resuming a conversation it was not minted for is refused with 403. " <>
         "Pass `X-Fountain-Parent-Conversation-Id` header to record which conversation spawned this one. " <>
         "Legacy `X-AoD-Parent-Conversation-Id` is still accepted for sprites provisioned before the rename.",
     request_body: {"Conversation attrs", "application/json", Schemas.ConversationCreateRequest},
@@ -429,6 +470,9 @@ defmodule FountainWeb.ConversationController do
       created: {"Conversation", "application/json", Schemas.ConversationResponse},
       ok:
         {"Conversation (resumed by channel_id)", "application/json", Schemas.ConversationResponse},
+      forbidden:
+        {"A sandbox token labelling the conversation a resume landed on", "application/json",
+         Schemas.Error},
       not_found: {"Agent not found", "application/json", Schemas.Error},
       unprocessable_entity:
         {"Validation error", "application/json", Schemas.UnprocessableEntityError},
@@ -466,9 +510,14 @@ defmodule FountainWeb.ConversationController do
       |> Map.put("parent_conversation_id", parent_id)
       |> Map.put("user_id", user.id)
 
+    # `SandboxKey.opts/1` rides along because a `channel_id` resume lands on an
+    # *existing* conversation and merges this request's labels into it (#1637);
+    # without it a sandbox token could relabel any conversation of the tenant
+    # by resuming its channel.
+    opts = SandboxKey.opts(conn) ++ Audited.attribution(conn)
+
     with :ok <- Billing.check_spend(user),
-         {:ok, conv, outcome} <-
-           Conversations.start_or_resume_conversation(params, Audited.attribution(conn)) do
+         {:ok, conv, outcome} <- Conversations.start_or_resume_conversation(params, opts) do
       # 201 when a conversation was opened; 200 when `channel_id` resumed an
       # existing one (#774). Same body either way, so a client that ignores
       # the status still gets the id it needs.

--- a/apps/fountain/lib/fountain_web/controllers/conversation_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_json.ex
@@ -64,6 +64,9 @@ defmodule FountainWeb.ConversationJSON do
       source: c.source,
       parent_conversation_id: c.parent_conversation_id,
       channel_id: c.channel_id,
+      # Free-form key/value strings (#1637): what a program stamped on its own
+      # run, and what `?label=env:prod` filters the list by.
+      labels: c.labels || %{},
       turn_count: c.turn_count,
       last_active_at: c.last_active_at,
       last_read_at: c.last_read_at,

--- a/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
@@ -133,6 +133,24 @@ defmodule FountainWeb.FallbackController do
     })
   end
 
+  # A sandbox's per-conversation token naming a conversation it was not minted
+  # for (#1637). 403 rather than 404: the holder knows the conversation exists
+  # — it belongs to the account the token authenticates as — and what is being
+  # refused is the credential, not the id. The same shape and the same reason
+  # as `sprite_may_not_answer` on the permission route.
+  #
+  # Here rather than in a controller because three doors write labels: the
+  # labels route, a team message, and a `channel_id` resume on conversation
+  # create.
+  def call(conn, {:error, :sprite_may_not_label_another_conversation}) do
+    conn
+    |> put_status(:forbidden)
+    |> json(%{
+      error: "sprite_may_not_label_another_conversation",
+      message: "a sandbox callback token may label only the conversation it was minted for"
+    })
+  end
+
   # An unknown or cross-tenant parent conversation. 404 rather than 403 so the
   # caller cannot use the response to probe which conversation ids exist.
   def call(conn, {:error, :parent_not_found}) do

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -587,6 +587,13 @@ defmodule FountainWeb.Router do
       # The JSON read-model for the log feed; /stream below is the tail (#519).
       get "/events", ConversationController, :events, as: :events
       post "/read", ConversationController, :read, as: :read
+      # Labels (#1637). Not behind :require_full_scope on purpose: the point
+      # of the route is that a sandbox stamps its own conversation.
+      # `Conversations.set_conversation_labels/4` is what refuses a sandbox
+      # token naming a different one, and it is the door the team message and
+      # a channel resume write through as well — the two other places a
+      # request can change a conversation's labels.
+      patch "/labels", ConversationController, :labels, as: :labels
       # Answer a permission request the agent is blocked on (#940). Nested so
       # the conversation is tenant-scoped before the request id is looked at.
       post "/requests/:request_id", ConversationController, :answer_request, as: :answer_request

--- a/apps/fountain/lib/fountain_web/sandbox_key.ex
+++ b/apps/fountain/lib/fountain_web/sandbox_key.ex
@@ -1,0 +1,46 @@
+defmodule FountainWeb.SandboxKey do
+  @moduledoc """
+  Which sandbox credential a request was made with, for the contexts whose
+  rules depend on it.
+
+  A conversation hands its sandbox a `sprite`-scoped API key. That key
+  authenticates as the *account*, so every tenant-scoped check passes for
+  every conversation the account owns — which is exactly the gap ADR 0045
+  describes. A context that must tell "this sandbox's own conversation" from
+  "another conversation of the same tenant" needs the key's id, and
+  `FountainWeb.Audited.attribution/2` deliberately carries only the actor.
+
+  One derivation, in one place, so a new door cannot get it subtly wrong:
+  `opts/1` returns the keyword pair to append beside `attribution/1`, and is
+  `[]` for anything that is not a sandbox token (a session, the owner's own
+  full-scope key, a background caller), which every rule reads as "no sandbox
+  restriction applies".
+  """
+
+  alias Fountain.Accounts.ApiKey
+
+  @doc """
+  The api key id when the request carried a sandbox's per-conversation token,
+  and `nil` for anything else.
+  """
+  @spec id(Plug.Conn.t()) :: binary() | nil
+  def id(%Plug.Conn{} = conn) do
+    case conn.assigns[:current_api_key] do
+      %ApiKey{id: id, scopes: scopes} -> if "sprite" in scopes, do: id
+      _ -> nil
+    end
+  end
+
+  @doc """
+  `[sandbox_key_id: id]` for a sandbox token, `[]` otherwise. Append it to
+  `FountainWeb.Audited.attribution/1` on any door that writes a conversation
+  a sandbox might not own.
+  """
+  @spec opts(Plug.Conn.t()) :: keyword()
+  def opts(%Plug.Conn{} = conn) do
+    case id(conn) do
+      nil -> []
+      key_id -> [sandbox_key_id: key_id]
+    end
+  end
+end

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -390,6 +390,15 @@ defmodule FountainWeb.Schemas do
           description:
             "The external channel key this conversation is bound to, if it was created with one."
         },
+        labels: %Schema{
+          type: :object,
+          additionalProperties: %Schema{type: :string},
+          description:
+            "Free-form key/value strings on the conversation. A program stamps its own " <>
+              "run with them (`env=prod`, `drift=true`) and `GET /api/conversations?label=env:prod` " <>
+              "filters on them. At most 32 entries; a key is at most 64 bytes and a value " <>
+              "at most 256 bytes. Always an object, empty when nothing set one."
+        },
         turn_count: %Schema{type: :integer},
         first_prompt: %Schema{
           type: :string,
@@ -582,9 +591,43 @@ defmodule FountainWeb.Schemas do
             "With channel_id: skip the resume and open a new conversation (201), which then " <>
               "becomes the channel's binding. Sent by a chat harness relaying its owner's " <>
               "rotate command. Ignored without channel_id."
+        },
+        labels: %Schema{
+          type: :object,
+          nullable: true,
+          additionalProperties: %Schema{type: :string},
+          description:
+            "Key/value strings to stamp on the conversation. At most 32 entries; a key is " <>
+              "at most 64 bytes and a value at most 256 bytes, and a 422 names the offending " <>
+              "key under `errors.labels`. With channel_id, a resume merges these into the " <>
+              "conversation it hands back rather than dropping them."
         }
       },
       required: [:agent_id]
+    })
+  end
+
+  defmodule ConversationLabelsRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "ConversationLabelsRequest",
+      description:
+        "Labels to merge into a conversation. A key not named is left alone; a key whose " <>
+          "value is null is removed.",
+      type: :object,
+      properties: %{
+        labels: %Schema{
+          type: :object,
+          additionalProperties: %Schema{type: :string, nullable: true},
+          description:
+            "The pairs to merge. null removes a key. At most 32 entries survive the merge; " <>
+              "a key is at most 64 bytes and a value at most 256 bytes. A 422 names the " <>
+              "offending key under `errors.labels`."
+        }
+      },
+      required: [:labels]
     })
   end
 

--- a/apps/fountain/test/fountain_web/controllers/conversation_labels_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/conversation_labels_test.exs
@@ -1,0 +1,344 @@
+defmodule FountainWeb.ConversationLabelsTest do
+  @moduledoc """
+  Labels over the wire (#1637): create, read back, the merge route and who is
+  allowed to call it.
+  """
+
+  use FountainWeb.ConnCase, async: true
+  use Mimic
+
+  alias Fountain.Conversations
+
+  setup do
+    user = insert_active_user()
+    {_key, raw_key} = insert_api_key(user)
+    {:ok, user: user, raw_key: raw_key}
+  end
+
+  describe "POST /api/conversations with labels" do
+    # Nothing stubbed but the supervisor: the point is to exercise the real
+    # `start_conversation/2` attrs, which is where `labels` actually reaches
+    # the row. A stub of `start_or_resume_conversation/2` would test the view
+    # and leave the create path uncovered.
+    defp create_conversation(conn, raw_key, body) do
+      Mimic.stub(Horde.DynamicSupervisor, :start_child, fn _s, _spec ->
+        {:ok, spawn(fn -> :ok end)}
+      end)
+
+      conn |> authed_with_key(raw_key) |> post_json("/api/conversations", body)
+    end
+
+    test "creates with them and returns them", %{conn: conn, user: user, raw_key: raw_key} do
+      agent = insert_agent(user_id: user.id)
+
+      conn =
+        create_conversation(conn, raw_key, %{
+          "agent_id" => agent.id,
+          "labels" => %{"env" => "prod", "drift" => "true"}
+        })
+
+      assert %{"data" => data} = json_response(conn, 201)
+      assert data["labels"] == %{"env" => "prod", "drift" => "true"}
+
+      # And on the row, not only in the response the create rendered.
+      assert Conversations._unsafe_get_conversation!(data["id"]).labels ==
+               %{"env" => "prod", "drift" => "true"}
+    end
+
+    test "creating with none leaves an empty map on the row", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
+      agent = insert_agent(user_id: user.id)
+
+      conn = create_conversation(conn, raw_key, %{"agent_id" => agent.id})
+
+      assert %{"data" => %{"id" => id, "labels" => %{}}} = json_response(conn, 201)
+      assert Conversations._unsafe_get_conversation!(id).labels == %{}
+    end
+
+    test "a label the limits refuse is a 422 and creates nothing", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
+      agent = insert_agent(user_id: user.id)
+      before = length(Conversations.list_conversations(user.id))
+
+      conn =
+        create_conversation(conn, raw_key, %{
+          "agent_id" => agent.id,
+          "labels" => %{"note" => String.duplicate("v", 300)}
+        })
+
+      assert [message] = json_response(conn, 422)["errors"]["labels"]
+      assert message =~ ~s("note")
+      assert length(Conversations.list_conversations(user.id)) == before
+    end
+
+    test "a conversation with no labels serves an empty object, never null", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
+      conv = insert_conversation(user_id: user.id)
+
+      conn = conn |> authed_with_key(raw_key) |> get("/api/conversations/#{conv.id}")
+
+      assert %{"data" => %{"labels" => %{}}} = json_response(conn, 200)
+    end
+  end
+
+  describe "PATCH /api/conversations/:id/labels" do
+    setup %{user: user} do
+      conv = insert_conversation(user_id: user.id, labels: %{"env" => "staging"})
+      {:ok, conv: conv}
+    end
+
+    test "merges into what is already there", context do
+      conn =
+        context.conn
+        |> authed_with_key(context.raw_key)
+        |> patch_json("/api/conversations/#{context.conv.id}/labels", %{
+          "labels" => %{"drift" => "true"}
+        })
+
+      assert %{"data" => data} = json_response(conn, 200)
+      assert data["labels"] == %{"env" => "staging", "drift" => "true"}
+    end
+
+    test "a null value removes one key", context do
+      conn =
+        context.conn
+        |> authed_with_key(context.raw_key)
+        |> patch_json("/api/conversations/#{context.conv.id}/labels", %{
+          "labels" => %{"env" => nil, "run" => "17"}
+        })
+
+      assert %{"data" => %{"labels" => %{"run" => "17"}}} = json_response(conn, 200)
+    end
+
+    test "another tenant's conversation is a 404", context do
+      other = insert_conversation(user_id: insert_active_user().id)
+
+      conn =
+        context.conn
+        |> authed_with_key(context.raw_key)
+        |> patch_json("/api/conversations/#{other.id}/labels", %{"labels" => %{"env" => "prod"}})
+
+      assert json_response(conn, 404)
+    end
+
+    test "a body without a labels object is a 422", context do
+      conn =
+        context.conn
+        |> authed_with_key(context.raw_key)
+        |> patch_json("/api/conversations/#{context.conv.id}/labels", %{"labels" => "env=prod"})
+
+      assert %{"error" => _} = json_response(conn, 422)
+    end
+  end
+
+  describe "the limits over the wire" do
+    setup %{user: user} do
+      {:ok, conv: insert_conversation(user_id: user.id)}
+    end
+
+    defp label_error(context, labels) do
+      context.conn
+      |> authed_with_key(context.raw_key)
+      |> patch_json("/api/conversations/#{context.conv.id}/labels", %{"labels" => labels})
+      |> json_response(422)
+      |> get_in(["errors", "labels"])
+      |> List.first()
+    end
+
+    test "too many entries names the key over the limit", context do
+      labels = for n <- 1..33, into: %{}, do: {String.pad_leading("#{n}", 3, "0"), "x"}
+
+      message = label_error(context, labels)
+      assert message =~ "at most 32 labels"
+      assert message =~ ~s("033")
+    end
+
+    test "an over-long key names it", context do
+      message = label_error(context, %{String.duplicate("k", 65) => "v"})
+
+      assert message =~ "longer than 64 bytes"
+      assert message =~ String.duplicate("k", 64)
+    end
+
+    test "an over-long value names its key", context do
+      message = label_error(context, %{"note" => String.duplicate("v", 257)})
+
+      assert message =~ ~s("note")
+      assert message =~ "longer than 256 bytes"
+    end
+
+    # Postgres will not store a NUL inside a jsonb string. Unrejected, the
+    # write reaches Repo.update and comes back as a raised Postgrex.Error —
+    # a 500 on a request the caller should have been told was invalid.
+    test "a NUL byte in a value is a 422, not a 500", context do
+      message = label_error(context, %{"note" => "before\u0000after"})
+
+      assert message =~ ~s("note")
+      assert message =~ "NUL byte"
+    end
+
+    test "a NUL byte in a key is a 422, not a 500", context do
+      message = label_error(context, %{"ke\u0000y" => "v"})
+
+      assert message =~ "NUL byte"
+    end
+  end
+
+  describe "a channel resume merges labels (#1637)" do
+    setup %{user: user} do
+      agent = insert_agent(user_id: user.id)
+
+      bound =
+        insert_conversation(
+          user_id: user.id,
+          agent: agent,
+          status: "idle",
+          channel_id: "chat:42",
+          labels: %{"env" => "prod"},
+          sandbox: insert_sandbox(user_id: user.id, status: "ready")
+        )
+
+      {:ok, agent: agent, bound: bound}
+    end
+
+    test "into the conversation it hands back", context do
+      conn =
+        context.conn
+        |> authed_with_key(context.raw_key)
+        |> post_json("/api/conversations", %{
+          "agent_id" => context.agent.id,
+          "channel_id" => "chat:42",
+          "labels" => %{"run" => "17"}
+        })
+
+      # 200, not 201: the binding resumed rather than opening a conversation.
+      assert %{"data" => data, "meta" => %{"resumed" => true}} = json_response(conn, 200)
+      assert data["id"] == context.bound.id
+      assert data["labels"] == %{"env" => "prod", "run" => "17"}
+    end
+
+    test "a resume with no labels leaves the ones already there", context do
+      conn =
+        context.conn
+        |> authed_with_key(context.raw_key)
+        |> post_json("/api/conversations", %{
+          "agent_id" => context.agent.id,
+          "channel_id" => "chat:42"
+        })
+
+      assert %{"data" => %{"labels" => %{"env" => "prod"}}} = json_response(conn, 200)
+    end
+
+    test "a label the limits refuse is a 422", context do
+      conn =
+        context.conn
+        |> authed_with_key(context.raw_key)
+        |> post_json("/api/conversations", %{
+          "agent_id" => context.agent.id,
+          "channel_id" => "chat:42",
+          "labels" => %{"note" => String.duplicate("v", 300)}
+        })
+
+      assert [message] = json_response(conn, 422)["errors"]["labels"]
+      assert message =~ ~s("note")
+    end
+
+    test "a sandbox token may not relabel another conversation by resuming its channel",
+         context do
+      {_key, sprite_raw} = insert_sprite_api_key(context.user)
+
+      conn =
+        context.conn
+        |> authed_with_key(sprite_raw)
+        |> post_json("/api/conversations", %{
+          "agent_id" => context.agent.id,
+          "channel_id" => "chat:42",
+          "labels" => %{"run" => "17"}
+        })
+
+      assert %{"error" => "sprite_may_not_label_another_conversation"} = json_response(conn, 403)
+
+      assert Conversations._unsafe_get_conversation!(context.bound.id).labels == %{
+               "env" => "prod"
+             }
+    end
+
+    test "a sandbox token may relabel the conversation it was minted for", context do
+      {key, sprite_raw} = insert_sprite_api_key(context.user)
+
+      {:ok, _} =
+        Conversations.update_conversation(context.bound, %{callback_api_key_id: key.id})
+
+      conn =
+        context.conn
+        |> authed_with_key(sprite_raw)
+        |> post_json("/api/conversations", %{
+          "agent_id" => context.agent.id,
+          "channel_id" => "chat:42",
+          "labels" => %{"run" => "17"}
+        })
+
+      assert %{"data" => %{"labels" => labels}} = json_response(conn, 200)
+      assert labels == %{"env" => "prod", "run" => "17"}
+    end
+  end
+
+  describe "a sandbox callback token" do
+    setup %{user: user} do
+      {key, raw} = insert_sprite_api_key(user)
+      mine = insert_conversation(user_id: user.id, callback_api_key_id: key.id)
+      theirs = insert_conversation(user_id: user.id)
+
+      {:ok, sprite_key: raw, mine: mine, theirs: theirs}
+    end
+
+    test "labels the conversation it was minted for", context do
+      conn =
+        context.conn
+        |> authed_with_key(context.sprite_key)
+        |> patch_json("/api/conversations/#{context.mine.id}/labels", %{
+          "labels" => %{"drift" => "true"}
+        })
+
+      assert %{"data" => %{"labels" => %{"drift" => "true"}}} = json_response(conn, 200)
+    end
+
+    test "is refused on another conversation of the same account", context do
+      conn =
+        context.conn
+        |> authed_with_key(context.sprite_key)
+        |> patch_json("/api/conversations/#{context.theirs.id}/labels", %{
+          "labels" => %{"drift" => "true"}
+        })
+
+      assert %{"error" => "sprite_may_not_label_another_conversation"} = json_response(conn, 403)
+      assert Conversations._unsafe_get_conversation!(context.theirs.id).labels == %{}
+    end
+
+    test "records the write as the sprite, with keys and no values", context do
+      context.conn
+      |> authed_with_key(context.sprite_key)
+      |> patch_json("/api/conversations/#{context.mine.id}/labels", %{
+        "labels" => %{"drift" => "true"}
+      })
+
+      assert [event] =
+               context.user.id
+               |> Fountain.Audit.list_recent_for_user(50)
+               |> Enum.filter(&(&1.action == "conversation.labels_set"))
+
+      assert event.actor == "sprite"
+      assert event.metadata["keys"] == ["drift"]
+      refute inspect(event.metadata) =~ "true"
+    end
+  end
+end

--- a/docs/api.md
+++ b/docs/api.md
@@ -255,6 +255,48 @@ event cursor so a reconnect can resume after the last event processed.
 Request structured blocks to render runtime output; clients should not
 parse each runtime's native dialect.
 
+### Labels
+
+A label is a `key=value` pair of strings on a conversation. A program stamps
+its own runs with the facts it knew when the turn ended. Examples are
+`env=prod`, `drift=true` and `gated=apply`. Labels are not searched. Use them
+to slice a list.
+
+Set them at creation, and read them back on every conversation object.
+
+```bash
+curl --fail-with-body \
+  -H "Authorization: Bearer $FOUNTAIN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"agent_id":"YOUR_AGENT_ID","labels":{"env":"prod"}}' \
+  "$FOUNTAIN_URL/api/conversations"
+```
+
+`PATCH /api/conversations/{id}/labels` merges labels into a conversation. A
+key the body does not name stays as it is. A key with a `null` value is
+removed.
+
+```bash
+curl --fail-with-body -X PATCH \
+  -H "Authorization: Bearer $FOUNTAIN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"labels":{"drift":"true","env":null}}' \
+  "$FOUNTAIN_URL/api/conversations/$CONVERSATION_ID/labels"
+```
+
+A conversation holds at most 32 labels. A key is at most 64 bytes and a value
+is at most 256 bytes. Neither can contain a NUL byte. A write that breaks one
+of these limits returns 422 and names the offending key under
+`errors.labels`. The count applies to the merged result, so a merge can fail
+against labels that are already there. The key named is one you sent, and
+never one that was already on the conversation.
+
+The account's own API key can label any of its conversations. A sandbox
+callback token can label only the conversation it was minted for. Another
+conversation returns 403 `sprite_may_not_label_another_conversation`. This
+applies to the labels route and to a `channel_id` resume, which merges the
+request's labels into the conversation it hands back.
+
 ### Workers without Fountain API access
 
 Set `sandbox_api_access` to `none` when the host must retain Fountain API

--- a/sdk/contract/contract.json
+++ b/sdk/contract/contract.json
@@ -3877,6 +3877,57 @@
         }
       }
     },
+    "PATCH /api/conversations/{conversation_id}/labels": {
+      "operation_id": "FountainWeb.ConversationController.labels",
+      "path_params": [
+        "conversation_id"
+      ],
+      "request_body": {
+        "content": {
+          "application/json": {
+            "ref": "ConversationLabelsRequest"
+          }
+        },
+        "required": false
+      },
+      "responses": {
+        "200": {
+          "application/json": {
+            "ref": "ConversationResponse"
+          }
+        },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "422": {
+          "application/json": {
+            "ref": "UnprocessableEntityError"
+          }
+        },
+        "429": {
+          "application/json": {
+            "ref": "Error"
+          }
+        }
+      }
+    },
     "PATCH /api/environments/{id}": {
       "operation_id": "FountainWeb.EnvironmentController.update (2)",
       "path_params": [
@@ -9971,6 +10022,13 @@
           "required": false,
           "type": "string"
         },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "required": false,
+          "type": "object"
+        },
         "last_active_at": {
           "format": "date-time",
           "nullable": true,
@@ -10124,6 +10182,14 @@
           "required": false,
           "type": "array"
         },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "nullable": true,
+          "required": false,
+          "type": "object"
+        },
         "permission_policy": {
           "additionalProperties": {
             "enum": [
@@ -10178,6 +10244,19 @@
           "nullable": true,
           "required": false,
           "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ConversationLabelsRequest": {
+      "properties": {
+        "labels": {
+          "additionalProperties": {
+            "nullable": true,
+            "type": "string"
+          },
+          "required": true,
+          "type": "object"
         }
       },
       "type": "object"

--- a/sdk/contract/manifests/typescript.json
+++ b/sdk/contract/manifests/typescript.json
@@ -53,6 +53,7 @@
     "GET /api/vaults/{vault_id}/secrets",
     "PATCH /api/agents/{id}",
     "PATCH /api/connection-providers/{id}",
+    "PATCH /api/conversations/{conversation_id}/labels",
     "PATCH /api/environments/{id}",
     "PATCH /api/team/{agent_id}",
     "PATCH /api/team/{agent_id}/schedules/{id}",

--- a/sdk/typescript/src/conversation.ts
+++ b/sdk/typescript/src/conversation.ts
@@ -48,6 +48,21 @@ export class Conversation {
     return this.http.list<Turn>(`/api/conversations/${this.id}/turns`);
   }
 
+  /**
+   * Merge labels into this conversation, and return the updated record.
+   *
+   * A key you do not name is left alone; `null` removes one. At most 32
+   * labels, a key at most 64 bytes and a value at most 256 bytes — a write
+   * over any of those is a 422 naming the offending key.
+   */
+  async setLabels(labels: Record<string, string | null>): Promise<ConversationRecord> {
+    return this.http.data<ConversationRecord>(
+      "PATCH",
+      `/api/conversations/${this.id}/labels`,
+      { body: { labels } },
+    );
+  }
+
   /** Send the next turn. Returns a `Run` — await it, or stream it. */
   send(prompt: string, options: SendOptions = {}): Run {
     const body: Record<string, unknown> = { prompt };

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -1158,7 +1158,7 @@ export interface paths {
         put?: never;
         /**
          * Start a conversation
-         * @description Creates a sandbox + conversation pair, starts the runtime in a fresh sprite, and (if `prompt` is supplied) sends it as turn 1. With `channel_id`, resumes the latest live conversation already bound to that channel for the same agent and vault (200, `meta.resumed: true`) instead of opening a new one (201). Pass `X-Fountain-Parent-Conversation-Id` header to record which conversation spawned this one. Legacy `X-AoD-Parent-Conversation-Id` is still accepted for sprites provisioned before the rename.
+         * @description Creates a sandbox + conversation pair, starts the runtime in a fresh sprite, and (if `prompt` is supplied) sends it as turn 1. With `channel_id`, resumes the latest live conversation already bound to that channel for the same agent and vault (200, `meta.resumed: true`) instead of opening a new one (201). `labels` (#1637) are stamped on the new conversation; with `channel_id`, a resume merges them into the conversation it hands back, and a sandbox callback token resuming a conversation it was not minted for is refused with 403. Pass `X-Fountain-Parent-Conversation-Id` header to record which conversation spawned this one. Legacy `X-AoD-Parent-Conversation-Id` is still accepted for sprites provisioned before the rename.
          */
         post: operations["FountainWeb.ConversationController.create"];
         delete?: never;
@@ -1227,6 +1227,30 @@ export interface paths {
         options?: never;
         head?: never;
         patch?: never;
+        trace?: never;
+    };
+    "/api/conversations/{conversation_id}/labels": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Set a conversation's labels
+         * @description Merges `labels` into the conversation's own (#1637). A key the body does not name is left alone, and a key whose value is `null` is removed, so a run can stamp one outcome without reading the rest first.
+         *
+         *     At most 32 labels survive the merge; a key is at most 64 bytes and a value at most 256 bytes. A 422 names the offending key.
+         *
+         *     The account's own key may label any of its conversations. A sandbox callback token may label **only the conversation it was minted for**; another id is refused with 403 `sprite_may_not_label_another_conversation`.
+         */
+        patch: operations["FountainWeb.ConversationController.labels"];
         trace?: never;
     };
     "/api/conversations/{conversation_id}/prompts": {
@@ -3499,6 +3523,10 @@ export interface components {
             id: string;
             /** Format: date-time */
             inserted_at?: string;
+            /** @description Free-form key/value strings on the conversation. A program stamps its own run with them (`env=prod`, `drift=true`) and `GET /api/conversations?label=env:prod` filters on them. At most 32 entries; a key is at most 64 bytes and a value at most 256 bytes. Always an object, empty when nothing set one. */
+            labels?: {
+                [key: string]: string;
+            };
             /**
              * Format: date-time
              * @description Most recent runtime output, falling back to creation time. Stage events (reconnects, sandbox lifecycle) do not count.
@@ -3556,6 +3584,10 @@ export interface components {
             fresh?: boolean | null;
             /** @description Optional images to attach to the initial prompt. */
             images?: components["schemas"]["ImageInput"][] | null;
+            /** @description Key/value strings to stamp on the conversation. At most 32 entries; a key is at most 64 bytes and a value at most 256 bytes, and a 422 names the offending key under `errors.labels`. With channel_id, a resume merges these into the conversation it hands back rather than dropping them. */
+            labels?: {
+                [key: string]: string;
+            } | null;
             /** @description Per-launch permission override (#939). Keys are matched against the tool card's title first and then ACP's kind (execute, edit, read, fetch, …); "default" covers the rest. Prefer a kind: claude titles a tool call with the command it is about to run, so a title matches one invocation only. Merged with the agent's own policy, taking the stricter of the two. It may only narrow: a policy that would loosen any tool is refused with 422 permission_policy_widens rather than silently clamped, and one the runtime never consults is refused with 422 permission_policy_unenforceable. */
             permission_policy?: {
                 [key: string]: "auto_allow" | "ask" | "auto_deny";
@@ -3586,6 +3618,16 @@ export interface components {
              * @description Optional vault whose secrets override the environment's baseline at sprite spawn. Must satisfy the agent's allowed_vault_ids when that allowlist is set.
              */
             vault_id?: string | null;
+        };
+        /**
+         * ConversationLabelsRequest
+         * @description Labels to merge into a conversation. A key not named is left alone; a key whose value is null is removed.
+         */
+        ConversationLabelsRequest: {
+            /** @description The pairs to merge. null removes a key. At most 32 entries survive the merge; a key is at most 64 bytes and a value at most 256 bytes. A 422 names the offending key under `errors.labels`. */
+            labels: {
+                [key: string]: string | null;
+            };
         };
         /** ConversationListResponse */
         ConversationListResponse: {
@@ -10229,7 +10271,7 @@ export interface operations {
                     };
                 };
             };
-            /** @description Forbidden */
+            /** @description A sandbox token labelling the conversation a resume landed on */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -10534,6 +10576,87 @@ export interface operations {
             };
             /** @description Sandbox or fleet unavailable */
             503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    "FountainWeb.ConversationController.labels": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                conversation_id: string;
+            };
+            cookie?: never;
+        };
+        /** @description Labels */
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["ConversationLabelsRequest"];
+            };
+        };
+        responses: {
+            /** @description Conversation */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ConversationResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description A sandbox token labelling another conversation */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Invalid labels */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UnprocessableEntityError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/sdk/typescript/test/resources.test.ts
+++ b/sdk/typescript/test/resources.test.ts
@@ -275,4 +275,22 @@ describe("vault expiry metadata", () => {
     assert.equal(url.searchParams.get("sandbox_id"), "sandbox-id");
     assert.equal(url.searchParams.get("roots_only"), "true");
   });
+
+  test("setLabels merges through PATCH and returns the record", async () => {
+    const requests: { url: string; init?: RequestInit }[] = [];
+    const fountain = new Fountain({
+      baseUrl: "https://fountain.test", apiKey: "fk_test",
+      fetch: async (url, init) => {
+        requests.push({ url, init });
+        return Response.json({ data: { id: "c1", labels: { env: "prod" } } });
+      },
+    });
+    const record = await fountain.resume("c1").setLabels({ env: "prod", drift: null });
+    assert.deepEqual(record.labels, { env: "prod" });
+    assert.equal(requests[0]!.init?.method, "PATCH");
+    assert.equal(new URL(requests[0]!.url).pathname, "/api/conversations/c1/labels");
+    assert.deepEqual(JSON.parse(String(requests[0]!.init?.body)), {
+      labels: { env: "prod", drift: null },
+    });
+  });
 });


### PR DESCRIPTION
The doors. `POST /api/conversations` takes `labels`, every conversation
object renders them (an object, never null), and `PATCH
/api/conversations/:id/labels` merges: a key the body does not name is left
alone, a key whose value is `null` is removed.

The labels route is deliberately **not** behind `RequireFullScope`, because
the point of it is that a sandbox stamps its own conversation. What holds
that open safely is `FountainWeb.SandboxKey`: one derivation of "was this
request made with a sandbox's per-conversation token", passed to
`Conversations.set_conversation_labels/4` beside the attribution. A sprite
naming a different conversation is 403
`sprite_may_not_label_another_conversation` — 403 and not 404, because the
holder knows the conversation exists (it belongs to the account the token
authenticates as) and what is refused is the credential, not the id.

The same opts ride on `POST /api/conversations`, because a `channel_id`
resume lands on an *existing* conversation and merges the request's labels
into it. Without them a sandbox token could relabel any conversation of the
tenant by resuming its channel.

The 403 lives in `FallbackController` rather than in the controller because
more than one door renders it.

Regenerates the wire contract and the TypeScript types, and adds
`Conversation#setLabels()`. No version bump — one release lands at the top of
the stack.

Third of nine on #1637.


---

### The stack for #1637

Nine PRs, each based on the one above it. Merge top down, and do not
`--delete-branch` while a child still points at a branch.

| # | branch | owns |
|---|---|---|
| 1 | `stack/1637-labels-column` | the jsonb column, the GIN index, `Conversations.Labels`'s limits, `labels` on create |
| 2 | `stack/1637-labels-writer` | `set_conversation_labels/4`, `_unsafe_merge_labels/3`, the sandbox rule, the audit event, the channel resume |
| 3 | `stack/1637-labels-api` | `PATCH /api/conversations/:id/labels`, `FountainWeb.SandboxKey`, the 403, `labels` on the wire |
| 4 | `stack/1637-label-filter` | `?label=key:value`, `RepeatedQueryParam`, `LabelFilter`, the SDK filter |
| 5 | `stack/1637-team-labels` | labels on a team message, and the same filter on a teammate's list |
| 6 | `stack/1637-acp-stamp` | `_fountain/labels` over the agent's own ACP session |
| 7 | `stack/1637-webhook-labels` | `data.labels` on every `conversation.*` payload |
| 8 | `stack/1637-console-chips` | chips on the console lists, and the dashboard URL filter |
| 9 | `stack/1637-release` | the manual, the CHANGELOG, one SDK release (1.27.0) |

This is #1676 re-cut under the no-big-PRs rule, rebased onto current `main` (re-rebased after #1832-#1839 landed).
The combined tip is byte-identical to #1676 over `apps/`, apart from three
prose fixes the destink and STE gates asked for and the regenerated contract
and SDK types.

Validation on the tip of the stack: `mix precommit` clean, core and ee
**4,911 tests, 0 failures**, `fountain_buzz` 144, `fountain_support` 33. The
SDK contract `--check`, the TypeScript typecheck and its 105 tests pass.
`docs-style.py`, `vale` (0 errors) and `destink` are clean.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SgxmwtJNGJBvgCxSfGBaf

