### PR TITLE
feat(api): filter a conversation list by label, repeatable and AND-combined (#1637)

### DIFF
--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -732,6 +732,10 @@ defmodule Fountain.Conversations do
   for `limit: n` — which the console's dashboard uses to ask for the five it
   shows instead of every row a busy account has.
 
+  `labels: %{"env" => "prod"}` (#1637) keeps the conversations carrying every
+  one of those pairs — jsonb containment, so a row with more labels than the
+  filter names still matches, and the GIN index on the column serves it.
+
   Populates the `last_active_at` virtual field using `kind: "output"` log
   events only — stage events (reconnects, lifecycle) are excluded so
   reconnects don't produce false unread indicators.
@@ -764,6 +768,9 @@ defmodule Fountain.Conversations do
 
         {:channel_id, id}, q when is_binary(id) and id != "" ->
           where(q, [conv: c], c.channel_id == ^id)
+
+        {:labels, labels}, q when is_map(labels) and map_size(labels) > 0 ->
+          where(q, [conv: c], fragment("? @> ?", c.labels, type(^labels, :map)))
 
         {:status, [_ | _] = statuses}, q ->
           where(q, [conv: c], c.status in ^statuses)

--- a/apps/fountain/lib/fountain/conversations/labels.ex
+++ b/apps/fountain/lib/fountain/conversations/labels.ex
@@ -27,6 +27,13 @@ defmodule Fountain.Conversations.Labels do
   whose value is `null` is removed. That is what lets a run add one label
   without reading the others first, and what makes a channel resume keep the
   labels the binding already carried.
+
+  ## The list filter
+
+  `GET /api/conversations?label=env:prod&label=drift:true` is repeatable and
+  AND-combined. Each value splits on its **first** colon only, so
+  `label=path:a:b` filters `path` for `a:b`. The query is jsonb containment,
+  which the GIN index on the column serves.
   """
 
   import Ecto.Changeset, only: [get_change: 2, add_error: 3]
@@ -253,5 +260,42 @@ defmodule Fountain.Conversations.Labels do
      |> Enum.map(&to_string(elem(&1, 0)))
      |> Enum.filter(&Map.has_key?(current, &1))
      |> Enum.sort()}
+  end
+
+  @doc """
+  Every `label` value in a raw query string, in the order they were sent.
+
+  Read from the query string rather than from the parsed params because Plug
+  collapses a repeated key to its last value, and the filter is repeatable by
+  design. `label[]=` is accepted as well, for a client whose HTTP layer only
+  builds arrays that way.
+  """
+  @spec from_query_string(String.t() | nil) :: [String.t()]
+  def from_query_string(nil), do: []
+
+  def from_query_string(query) when is_binary(query) do
+    for {key, value} <- URI.query_decoder(query), key in ["label", "label[]"], do: value
+  end
+
+  @doc """
+  Turn repeated `key:value` filter values into the map the list query
+  contains against. Splits on the first colon only, so a value may contain
+  colons of its own.
+
+  `{:error, :invalid_label_filter}` for a value with no colon or an empty
+  key: a caller who typed `?label=prod` meant something, and matching
+  everything would be the wrong guess.
+  """
+  @spec parse_filter([String.t()] | nil) :: {:ok, map()} | {:error, :invalid_label_filter}
+  def parse_filter(nil), do: {:ok, %{}}
+
+  def parse_filter(values) when is_list(values) do
+    Enum.reduce_while(values, {:ok, %{}}, fn value, {:ok, acc} ->
+      case value |> to_string() |> String.trim() |> String.split(":", parts: 2) do
+        ["" | _] -> {:halt, {:error, :invalid_label_filter}}
+        [key, filter_value] -> {:cont, {:ok, Map.put(acc, key, filter_value)}}
+        [_no_colon] -> {:halt, {:error, :invalid_label_filter}}
+      end
+    end)
   end
 end

--- a/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
@@ -9,10 +9,16 @@ defmodule FountainWeb.ConversationController do
   alias Fountain.Conversations
   alias Fountain.Conversations.{ConversationServer, LogEvent}
   alias FountainWeb.Audited
+  alias FountainWeb.LabelFilter
   alias FountainWeb.SandboxKey
   alias FountainWeb.Schemas
 
   action_fallback FountainWeb.FallbackController
+
+  # Before the cast, and only where the parameter exists: `label` is a
+  # repeated key, and the cast reads query parameters out of Plug, which
+  # keeps only the last of them. See the plug's moduledoc.
+  plug FountainWeb.Plugs.RepeatedQueryParam, "label" when action in [:index]
 
   plug OpenApiSpex.Plug.CastAndValidate,
     replace_params: false,
@@ -68,6 +74,20 @@ defmodule FountainWeb.ConversationController do
             "400 outside that range). Without it the whole list is returned, which on a " <>
             "busy account is hundreds of rows per call — a client that needs one " <>
             "conversation should filter (`agent_id`, `sandbox_id`, `channel_id`) and cap."
+      ],
+      label: [
+        in: :query,
+        schema: %OpenApiSpex.Schema{type: :array, items: %OpenApiSpex.Schema{type: :string}},
+        style: :form,
+        explode: true,
+        required: false,
+        description:
+          "Only conversations carrying these `key:value` labels (#1637). Repeat the " <>
+            "parameter to combine them with AND: `?label=env:prod&label=drift:true` keeps " <>
+            "the conversations that carry both. `label[]=` is accepted as well. Each value " <>
+            "splits on its first colon only, so `label=path:a:b` matches the label `path` " <>
+            "with the value `a:b`. 400 `invalid_label_filter` on a value with no colon or " <>
+            "an empty key."
       ]
     ],
     responses: [
@@ -82,7 +102,8 @@ defmodule FountainWeb.ConversationController do
     roots_only = parse_bool_param(params["roots_only"], false)
 
     with {:ok, statuses} <- parse_statuses(params["status"]),
-         {:ok, limit} <- parse_list_limit(params["limit"]) do
+         {:ok, limit} <- parse_list_limit(params["limit"]),
+         {:ok, labels} <- LabelFilter.from(conn) do
       render(conn, :index,
         conversations:
           Conversations.list_conversations(user.id,
@@ -91,7 +112,8 @@ defmodule FountainWeb.ConversationController do
             channel_id: params["channel_id"],
             sandbox_id: params["sandbox_id"],
             status: statuses,
-            limit: limit
+            limit: limit,
+            labels: labels
           )
       )
     end

--- a/apps/fountain/lib/fountain_web/label_filter.ex
+++ b/apps/fountain/lib/fountain_web/label_filter.ex
@@ -1,0 +1,41 @@
+defmodule FountainWeb.LabelFilter do
+  @moduledoc """
+  The `?label=key:value` filter on a conversation list (#1637), for both
+  routes that take it.
+
+  `GET /api/conversations` and `GET /api/team/:agent_id/conversations` accept
+  the same repeatable, AND-combined parameter, and a second copy of the
+  parsing in the team controller is exactly how the two would drift.
+
+  Read from `conn.query_string` and not from `conn.params`, because Plug
+  collapses a repeated key to its last value and this filter is repeatable by
+  design. `Fountain.Conversations.Labels` owns the vocabulary; this is the
+  Plug half plus the error the fallback controller renders as a 400.
+  """
+
+  alias Fountain.Conversations.Labels
+
+  @doc """
+  The label filter on a request: `{:ok, %{"env" => "prod"}}`, or
+  `{:error, "invalid_label_filter"}` for a value with no colon or an empty
+  key, which `FountainWeb.FallbackController` renders as a 400.
+
+  Reads the list `FountainWeb.Plugs.RepeatedQueryParam` left on the request.
+  `List.wrap/1` rather than a match, so a route that has not been given that
+  plug degrades to the single value Plug kept instead of raising.
+  """
+  @spec from(Plug.Conn.t()) :: {:ok, map()} | {:error, String.t()}
+  def from(%Plug.Conn{} = conn) do
+    conn.params
+    |> Map.get("label")
+    |> List.wrap()
+    |> parse()
+  end
+
+  defp parse(values) do
+    case Labels.parse_filter(values) do
+      {:ok, labels} -> {:ok, labels}
+      {:error, :invalid_label_filter} -> {:error, "invalid_label_filter"}
+    end
+  end
+end

--- a/apps/fountain/lib/fountain_web/plugs/repeated_query_param.ex
+++ b/apps/fountain/lib/fountain_web/plugs/repeated_query_param.ex
@@ -1,0 +1,68 @@
+defmodule FountainWeb.Plugs.RepeatedQueryParam do
+  @moduledoc """
+  Collect a repeated query key into a list, before the OpenAPI cast sees it.
+
+  `?label=env:prod&label=drift:true` is one parameter sent twice, which is
+  what OpenAPI calls `style: form, explode: true` and what an array parameter
+  means on the wire. Two things get in the way:
+
+    * `Plug.Conn.Query` collapses a repeated key to its **last** value, so
+      `conn.params["label"]` is `"drift:true"` and the first filter is gone;
+    * `OpenApiSpex.CastParameters` reads query parameters straight out of
+      `Plug.Conn.fetch_query_params/1` and implements only the `explode:
+      false` (comma-joined) form itself, so a parameter *declared* as an
+      array would be handed that string and refuse it as "not an array" —
+      turning a perfectly ordinary `?label=env:prod` into a 422.
+
+  So the parameter cannot be declared honestly as an array until something
+  reshapes it first, and that is this plug. It reads the raw query string,
+  collects every occurrence of the named key, and writes the list back onto
+  both `query_params` and `params` so the cast and the action see the same
+  value. `name[]=` is collected too, for a client whose HTTP layer only knows
+  how to build arrays that way.
+
+  Declare it **before** `OpenApiSpex.Plug.CastAndValidate` in the controller,
+  and scope it to the actions that take the parameter:
+
+      plug FountainWeb.Plugs.RepeatedQueryParam, "label" when action in [:index]
+
+  A request that sends the key once still arrives as a one-element list, so
+  the action has one shape to read rather than two.
+  """
+
+  @behaviour Plug
+
+  @impl Plug
+  def init(name) when is_binary(name), do: name
+
+  @impl Plug
+  def call(%Plug.Conn{} = conn, name) do
+    conn = Plug.Conn.fetch_query_params(conn)
+
+    case collect(conn.query_string, name) do
+      [] -> conn
+      values -> put(conn, name, values)
+    end
+  end
+
+  defp collect(query, name) when is_binary(query) do
+    bracketed = name <> "[]"
+
+    for {key, value} <- URI.query_decoder(query), key in [name, bracketed], do: value
+  end
+
+  defp put(conn, name, values) do
+    %{
+      conn
+      | query_params: Map.put(conn.query_params, name, values),
+        params: put_param(conn.params, name, values)
+    }
+  end
+
+  # `params` is `%Plug.Conn.Unfetched{}` until the body parsers have run. Every
+  # route this plug is on has run them, but reshaping an unfetched struct into
+  # a map would quietly swallow the body, so leave it alone and let
+  # `query_params` carry the value.
+  defp put_param(%Plug.Conn.Unfetched{} = params, _name, _values), do: params
+  defp put_param(params, name, values) when is_map(params), do: Map.put(params, name, values)
+end

--- a/apps/fountain/test/fountain/conversations/labels_test.exs
+++ b/apps/fountain/test/fountain/conversations/labels_test.exs
@@ -1,6 +1,6 @@
 defmodule Fountain.Conversations.LabelsTest do
   @moduledoc """
-  Labels on a conversation (#1637): the rule and the merge.
+  Labels on a conversation (#1637): the rule, the merge, the filter.
 
   The doors are covered where they live, so what is here is the behaviour
   every one of them inherits.
@@ -413,6 +413,109 @@ defmodule Fountain.Conversations.LabelsTest do
 
       assert Conversations.get_conversation(context.bound.id, context.user.id).labels ==
                %{"env" => "prod"}
+    end
+  end
+
+  describe "the filter vocabulary" do
+    test "splits on the first colon only" do
+      assert {:ok, %{"path" => "a:b"}} = Labels.parse_filter(["path:a:b"])
+    end
+
+    test "combines repeated values" do
+      assert {:ok, %{"env" => "prod", "drift" => "true"}} =
+               Labels.parse_filter(["env:prod", "drift:true"])
+    end
+
+    test "an empty value is a legal filter" do
+      assert {:ok, %{"env" => ""}} = Labels.parse_filter(["env:"])
+    end
+
+    test "a value with no colon is refused rather than guessed at" do
+      assert {:error, :invalid_label_filter} = Labels.parse_filter(["prod"])
+    end
+
+    test "an empty key is refused" do
+      assert {:error, :invalid_label_filter} = Labels.parse_filter([":prod"])
+    end
+
+    test "reads every repetition out of a raw query string" do
+      assert ["env:prod", "drift:true"] =
+               Labels.from_query_string("roots_only=true&label=env:prod&label=drift:true")
+    end
+
+    test "accepts the bracketed array form too" do
+      assert ["env:prod"] = Labels.from_query_string("label%5B%5D=env%3Aprod")
+    end
+  end
+
+  describe "the list filter" do
+    setup do
+      user = insert_active_user()
+
+      prod_drift =
+        insert_conversation(user_id: user.id, labels: %{"env" => "prod", "drift" => "true"})
+
+      prod_clean =
+        insert_conversation(user_id: user.id, labels: %{"env" => "prod", "drift" => "false"})
+
+      staging = insert_conversation(user_id: user.id, labels: %{"env" => "staging"})
+      unlabelled = insert_conversation(user_id: user.id)
+
+      {:ok,
+       user: user,
+       prod_drift: prod_drift,
+       prod_clean: prod_clean,
+       staging: staging,
+       unlabelled: unlabelled}
+    end
+
+    defp ids(convs), do: convs |> Enum.map(& &1.id) |> MapSet.new()
+
+    test "one pair keeps every conversation carrying it", context do
+      found = Conversations.list_conversations(context.user.id, labels: %{"env" => "prod"})
+
+      assert ids(found) == MapSet.new([context.prod_drift.id, context.prod_clean.id])
+    end
+
+    test "two pairs are combined with AND", context do
+      found =
+        Conversations.list_conversations(context.user.id,
+          labels: %{"env" => "prod", "drift" => "true"}
+        )
+
+      assert ids(found) == MapSet.new([context.prod_drift.id])
+    end
+
+    test "a pair nothing carries matches nothing", context do
+      assert [] = Conversations.list_conversations(context.user.id, labels: %{"env" => "qa"})
+    end
+
+    test "no filter leaves the list alone", context do
+      assert MapSet.size(ids(Conversations.list_conversations(context.user.id))) == 4
+      assert MapSet.size(ids(Conversations.list_conversations(context.user.id, labels: %{}))) == 4
+    end
+
+    test "the filter is tenant-scoped like every other", context do
+      stranger = insert_active_user()
+      insert_conversation(user_id: stranger.id, labels: %{"env" => "prod"})
+
+      found = Conversations.list_conversations(context.user.id, labels: %{"env" => "prod"})
+      assert ids(found) == MapSet.new([context.prod_drift.id, context.prod_clean.id])
+    end
+
+    test "combines with the other filters", context do
+      agent = insert_agent(user_id: context.user.id)
+
+      mine =
+        insert_conversation(user_id: context.user.id, agent: agent, labels: %{"env" => "prod"})
+
+      found =
+        Conversations.list_conversations(context.user.id,
+          agent_id: agent.id,
+          labels: %{"env" => "prod"}
+        )
+
+      assert ids(found) == MapSet.new([mine.id])
     end
   end
 end

--- a/apps/fountain/test/fountain_web/controllers/conversation_labels_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/conversation_labels_test.exs
@@ -1,7 +1,7 @@
 defmodule FountainWeb.ConversationLabelsTest do
   @moduledoc """
-  Labels over the wire (#1637): create, read back, the merge route and who is
-  allowed to call it.
+  Labels over the wire (#1637): create, read back, the repeatable AND filter,
+  the merge route and who is allowed to call it.
   """
 
   use FountainWeb.ConnCase, async: true
@@ -87,6 +87,72 @@ defmodule FountainWeb.ConversationLabelsTest do
       conn = conn |> authed_with_key(raw_key) |> get("/api/conversations/#{conv.id}")
 
       assert %{"data" => %{"labels" => %{}}} = json_response(conn, 200)
+    end
+  end
+
+  describe "GET /api/conversations?label=" do
+    setup %{user: user} do
+      prod_drift =
+        insert_conversation(user_id: user.id, labels: %{"env" => "prod", "drift" => "true"})
+
+      prod_clean = insert_conversation(user_id: user.id, labels: %{"env" => "prod"})
+      staging = insert_conversation(user_id: user.id, labels: %{"env" => "staging"})
+
+      {:ok, prod_drift: prod_drift, prod_clean: prod_clean, staging: staging}
+    end
+
+    defp listed(conn),
+      do: conn |> json_response(200) |> Map.fetch!("data") |> Enum.map(& &1["id"])
+
+    test "one pair keeps the conversations carrying it", context do
+      ids =
+        context.conn
+        |> authed_with_key(context.raw_key)
+        |> get("/api/conversations?label=env:prod")
+        |> listed()
+
+      assert Enum.sort(ids) == Enum.sort([context.prod_drift.id, context.prod_clean.id])
+    end
+
+    test "a repeated label is combined with AND", context do
+      ids =
+        context.conn
+        |> authed_with_key(context.raw_key)
+        |> get("/api/conversations?label=env:prod&label=drift:true")
+        |> listed()
+
+      assert ids == [context.prod_drift.id]
+    end
+
+    test "combines with the other filters", context do
+      ids =
+        context.conn
+        |> authed_with_key(context.raw_key)
+        |> get("/api/conversations?status=pending&label=env:staging")
+        |> listed()
+
+      assert ids == [context.staging.id]
+    end
+
+    test "a value splits on its first colon only", %{conn: conn, user: user, raw_key: raw_key} do
+      conv = insert_conversation(user_id: user.id, labels: %{"path" => "apps/fountain:lib"})
+
+      ids =
+        conn
+        |> authed_with_key(raw_key)
+        |> get("/api/conversations?label=path:apps/fountain:lib")
+        |> listed()
+
+      assert ids == [conv.id]
+    end
+
+    test "a value with no colon is a 400 rather than a silent match-all", context do
+      conn =
+        context.conn
+        |> authed_with_key(context.raw_key)
+        |> get("/api/conversations?label=prod")
+
+      assert %{"error" => "invalid_label_filter"} = json_response(conn, 400)
     end
   end
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -272,6 +272,24 @@ curl --fail-with-body \
   "$FOUNTAIN_URL/api/conversations"
 ```
 
+Filter a list with a repeatable `label` parameter. Fountain combines the
+values with AND. The example keeps the conversations that carry both pairs.
+
+```bash
+curl --fail-with-body \
+  -H "Authorization: Bearer $FOUNTAIN_API_KEY" \
+  "$FOUNTAIN_URL/api/conversations?label=env:prod&label=drift:true"
+```
+
+Each value splits on its first colon. The key is the part before it, and the
+value is all of the rest. `label=path:apps/fountain:lib` therefore filters the
+key `path` for the value `apps/fountain:lib`. A value with no colon, or with
+an empty key, returns 400 `invalid_label_filter`.
+
+The parameter is an array in the OpenAPI document, with `style: form` and
+`explode: true`. A client that builds arrays as `label[]=env:prod` is
+accepted too.
+
 `PATCH /api/conversations/{id}/labels` merges labels into a conversation. A
 key the body does not name stays as it is. A key with a `null` value is
 removed.

--- a/sdk/contract/contract.json
+++ b/sdk/contract/contract.json
@@ -1865,6 +1865,13 @@
           "required": false,
           "type": "string"
         },
+        "label": {
+          "items": {
+            "type": "string"
+          },
+          "required": false,
+          "type": "array"
+        },
         "limit": {
           "required": false,
           "type": "integer"

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -177,10 +177,19 @@ export class Fountain {
    * Roots only by default: a conversation an agent spawned from inside a
    * sandbox is listed under its parent's tree, not again at the top level.
    * Pass `{ rootsOnly: false }` for the flat list, children included.
+   *
+   * `labels` keeps the conversations carrying every pair given — the wire is
+   * a repeatable `label=key:value`, combined with AND.
    */
-  async conversations(opts: { rootsOnly?: boolean; sandboxId?: string } = {}): Promise<ConversationRecord[]> {
+  async conversations(
+    opts: { rootsOnly?: boolean; sandboxId?: string; labels?: Record<string, string> } = {},
+  ): Promise<ConversationRecord[]> {
     return this.api.list<ConversationRecord>("/api/conversations", {
-      query: { roots_only: opts.rootsOnly === false ? undefined : "true", sandbox_id: opts.sandboxId },
+      query: {
+        roots_only: opts.rootsOnly === false ? undefined : "true",
+        sandbox_id: opts.sandboxId,
+        label: opts.labels && Object.entries(opts.labels).map(([k, v]) => `${k}:${v}`),
+      },
     });
   }
 

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -10137,6 +10137,8 @@ export interface operations {
                 status?: string;
                 /** @description Return at most this many conversations, most recently updated first (1 to 500; 400 outside that range). Without it the whole list is returned, which on a busy account is hundreds of rows per call — a client that needs one conversation should filter (`agent_id`, `sandbox_id`, `channel_id`) and cap. */
                 limit?: number;
+                /** @description Only conversations carrying these `key:value` labels (#1637). Repeat the parameter to combine them with AND: `?label=env:prod&label=drift:true` keeps the conversations that carry both. `label[]=` is accepted as well. Each value splits on its first colon only, so `label=path:a:b` matches the label `path` with the value `a:b`. 400 `invalid_label_filter` on a value with no colon or an empty key. */
+                label?: string[];
             };
             header?: never;
             path?: never;

--- a/sdk/typescript/src/http.ts
+++ b/sdk/typescript/src/http.ts
@@ -4,7 +4,7 @@ import type { ResolvedConfig } from "./config.ts";
 export type FetchLike = (input: string, init?: RequestInit) => Promise<Response>;
 
 export interface RequestOptions {
-  query?: Record<string, string | number | boolean | undefined | null>;
+  query?: Record<string, string | number | boolean | string[] | undefined | null>;
   body?: unknown;
   headers?: Record<string, string>;
   signal?: AbortSignal;
@@ -50,6 +50,14 @@ export class HttpClient {
     const url = new URL(path.startsWith("http") ? path : this.config.baseUrl + path);
     for (const [key, value] of Object.entries(query ?? {})) {
       if (value === undefined || value === null || value === "") continue;
+      // An array is a repeated key, not a comma-joined string. That is what
+      // `style: form, explode: true` means in the OpenAPI document, and it is
+      // how `?label=env:prod&label=drift:true` reaches the server; joining
+      // them would send one filter Fountain cannot parse.
+      if (Array.isArray(value)) {
+        for (const item of value) url.searchParams.append(key, String(item));
+        continue;
+      }
       url.searchParams.set(key, String(value));
     }
     return url.toString();

--- a/sdk/typescript/test/resources.test.ts
+++ b/sdk/typescript/test/resources.test.ts
@@ -276,6 +276,17 @@ describe("vault expiry metadata", () => {
     assert.equal(url.searchParams.get("roots_only"), "true");
   });
 
+  test("a label filter goes out as a repeated key, not a joined string", async () => {
+    let requested = "";
+    const fountain = new Fountain({
+      baseUrl: "https://fountain.test", apiKey: "fk_test",
+      fetch: async (url) => { requested = url; return Response.json({ data: [] }); },
+    });
+    await fountain.conversations({ labels: { env: "prod", drift: "true" } });
+    const url = new URL(requested);
+    assert.deepEqual(url.searchParams.getAll("label").sort(), ["drift:true", "env:prod"]);
+  });
+
   test("setLabels merges through PATCH and returns the record", async () => {
     const requests: { url: string; init?: RequestInit }[] = [];
     const fountain = new Fountain({


### PR DESCRIPTION
`GET /api/conversations?label=env:prod&label=drift:true` keeps the
conversations that carry both. The query is jsonb containment, which the GIN
index the column already has serves; a row with more labels than the filter
names still matches. Each value splits on its **first** colon only, so
`label=path:a:b` filters `path` for `a:b`, and a value with no colon or an
empty key is a 400 `invalid_label_filter` rather than a silent match-all.

The parameter is declared honestly as an array (`style: form, explode:
true`), which needed one piece of plumbing to be possible at all —
`FountainWeb.Plugs.RepeatedQueryParam`. Two things sit in the way of a
repeated query key here:

- `Plug.Conn.Query` collapses a repeated key to its **last** value, so
  `conn.params["label"]` would be `"drift:true"` and the first filter would
  be gone;
- `OpenApiSpex.CastParameters` reads query parameters straight out of Plug
  and implements only the `explode: false` comma-joined form itself, so a
  parameter declared as an array would be handed that string and refuse it
  as "not an array" — turning an ordinary `?label=env:prod` into a 422.

So the plug reads the raw query string, collects every occurrence, and writes
the list back onto both `query_params` and `params` before the cast runs.
`label[]=` is collected too, for a client whose HTTP layer only builds arrays
that way.

`FountainWeb.LabelFilter` is the parsing, in one place, because the team
route takes the same parameter next and a second copy is exactly how the two
would drift.

The TypeScript SDK gains `conversations({labels})`, and its query builder now
expands an array into a repeated key instead of joining it with commas —
joining would have sent one filter the server cannot parse.

Fourth of nine on #1637.


---

### The stack for #1637

Nine PRs, each based on the one above it. Merge top down, and do not
`--delete-branch` while a child still points at a branch.

| # | branch | owns |
|---|---|---|
| 1 | `stack/1637-labels-column` | the jsonb column, the GIN index, `Conversations.Labels`'s limits, `labels` on create |
| 2 | `stack/1637-labels-writer` | `set_conversation_labels/4`, `_unsafe_merge_labels/3`, the sandbox rule, the audit event, the channel resume |
| 3 | `stack/1637-labels-api` | `PATCH /api/conversations/:id/labels`, `FountainWeb.SandboxKey`, the 403, `labels` on the wire |
| 4 | `stack/1637-label-filter` | `?label=key:value`, `RepeatedQueryParam`, `LabelFilter`, the SDK filter |
| 5 | `stack/1637-team-labels` | labels on a team message, and the same filter on a teammate's list |
| 6 | `stack/1637-acp-stamp` | `_fountain/labels` over the agent's own ACP session |
| 7 | `stack/1637-webhook-labels` | `data.labels` on every `conversation.*` payload |
| 8 | `stack/1637-console-chips` | chips on the console lists, and the dashboard URL filter |
| 9 | `stack/1637-release` | the manual, the CHANGELOG, one SDK release (1.27.0) |

This is #1676 re-cut under the no-big-PRs rule, rebased onto current `main` (re-rebased after #1832-#1839 landed).
The combined tip is byte-identical to #1676 over `apps/`, apart from three
prose fixes the destink and STE gates asked for and the regenerated contract
and SDK types.

Validation on the tip of the stack: `mix precommit` clean, core and ee
**4,911 tests, 0 failures**, `fountain_buzz` 144, `fountain_support` 33. The
SDK contract `--check`, the TypeScript typecheck and its 105 tests pass.
`docs-style.py`, `vale` (0 errors) and `destink` are clean.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SgxmwtJNGJBvgCxSfGBaf

