### PR TITLE
feat(webhooks): conversation events carry the conversation's labels (#1637)

### DIFF
--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -732,6 +732,10 @@ defmodule Fountain.Conversations do
   for `limit: n` — which the console's dashboard uses to ask for the five it
   shows instead of every row a busy account has.
 
+  `labels: %{"env" => "prod"}` (#1637) keeps the conversations carrying every
+  one of those pairs — jsonb containment, so a row with more labels than the
+  filter names still matches, and the GIN index on the column serves it.
+
   Populates the `last_active_at` virtual field using `kind: "output"` log
   events only — stage events (reconnects, lifecycle) are excluded so
   reconnects don't produce false unread indicators.
@@ -764,6 +768,9 @@ defmodule Fountain.Conversations do
 
         {:channel_id, id}, q when is_binary(id) and id != "" ->
           where(q, [conv: c], c.channel_id == ^id)
+
+        {:labels, labels}, q when is_map(labels) and map_size(labels) > 0 ->
+          where(q, [conv: c], fragment("? @> ?", c.labels, type(^labels, :map)))
 
         {:status, [_ | _] = statuses}, q ->
           where(q, [conv: c], c.status in ^statuses)

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -991,9 +991,9 @@ defmodule Fountain.Conversations do
   `:sprite_may_not_label_another_conversation`. Without that check a worker
   holding an account-scoped callback key could relabel every other run on the
   account, which is exactly the loop ADR 0045 describes. That is why the
-  check lives here and not in a controller: more than one request path will
-  write labels, and the rule has to hold on the door rather than on whichever
-  of them remembered.
+  check lives here and not in each controller: `PATCH .../labels`, the team
+  message and a `channel_id` resume all write labels, and the rule has to
+  hold on the door rather than on whichever of them remembered.
 
   `labels` that is not a map at all is a validation failure, not a silent
   no-op, so every door refuses `{"labels": "env=prod"}` the same way.
@@ -1027,10 +1027,12 @@ defmodule Fountain.Conversations do
   Merge `labels` into a conversation row, with no tenant scoping and no
   credential rule.
 
-  Unscoped, hence the prefix. The legitimate caller is
+  Unscoped, hence the prefix. The legitimate callers are
   `set_conversation_labels/4`, which scopes and applies the sandbox rule
-  before delegating here. A request path that calls this directly has skipped
-  the rule that stops one sandbox relabelling another, so do not add one.
+  before delegating here, and `Labels._unsafe_stamp/2`, which runs inside the
+  conversation's own server and holds the row that server was started for. A
+  request path that calls this directly has skipped the rule that stops one
+  sandbox relabelling another, so do not add one.
 
   A merge that changes nothing writes nothing and records nothing — a
   deterministic run re-stamping the same outcome on every tick is the normal

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -794,15 +794,24 @@ defmodule Fountain.Conversations do
   the surface reading a channel — the team page — wants the last transcript
   even when nothing is running.
   """
-  def list_channel_conversations(user_id, channel_id)
+  def list_channel_conversations(user_id, channel_id, opts \\ [])
       when is_binary(user_id) and is_binary(channel_id) do
     from(c in annotated_query(user_id),
       where: c.channel_id == ^channel_id,
       order_by: [desc: c.inserted_at, desc: c.id]
     )
+    |> filter_by_labels(Keyword.get(opts, :labels))
     |> Repo.all()
     |> Repo.preload([:agent, :sandbox])
   end
+
+  # The same containment filter `list_conversations/2` applies (#1637), for
+  # the channel-bound list behind the team route.
+  defp filter_by_labels(query, labels) when is_map(labels) and map_size(labels) > 0 do
+    where(query, [conv: c], fragment("? @> ?", c.labels, type(^labels, :map)))
+  end
+
+  defp filter_by_labels(query, _labels), do: query
 
   @doc """
   Scoped fetch that also populates the read-model annotations —

--- a/apps/fountain/lib/fountain/conversations/conversation.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation.ex
@@ -56,10 +56,11 @@ defmodule Fountain.Conversations.Conversation do
     field :permission_policy, :map
     # The caller-defined tools of the bridge (#1202, `Fountain.CallerTools`).
     field :caller_tools, {:array, :map}, default: []
-    # Free-form `key => value` strings (#1637), set at launch.
-    # `Conversations.Labels` owns the limits and the merge; writes here go
-    # through `Labels.changeset/1` below, which is why every door enforces
-    # the same rule.
+    # Free-form `key => value` strings (#1637). Set at launch, merged by the
+    # labels route and by the agent's own `_fountain/labels` ACP notification,
+    # and filtered on with jsonb containment. `Conversations.Labels` owns the
+    # limits and the merge; writes here go through `Labels.changeset/1` below,
+    # which is why every door enforces the same rule.
     field :labels, :map, default: %{}
 
     # Populated by list_conversations_by_activity/1 — not persisted.

--- a/apps/fountain/lib/fountain/conversations/labels.ex
+++ b/apps/fountain/lib/fountain/conversations/labels.ex
@@ -27,6 +27,13 @@ defmodule Fountain.Conversations.Labels do
   whose value is `null` is removed. That is what lets a run add one label
   without reading the others first, and what makes a channel resume keep the
   labels the binding already carried.
+
+  ## The list filter
+
+  `GET /api/conversations?label=env:prod&label=drift:true` is repeatable and
+  AND-combined. Each value splits on its **first** colon only, so
+  `label=path:a:b` filters `path` for `a:b`. The query is jsonb containment,
+  which the GIN index on the column serves.
   """
 
   import Ecto.Changeset, only: [get_change: 2, add_error: 3]
@@ -253,5 +260,42 @@ defmodule Fountain.Conversations.Labels do
      |> Enum.map(&to_string(elem(&1, 0)))
      |> Enum.filter(&Map.has_key?(current, &1))
      |> Enum.sort()}
+  end
+
+  @doc """
+  Every `label` value in a raw query string, in the order they were sent.
+
+  Read from the query string rather than from the parsed params because Plug
+  collapses a repeated key to its last value, and the filter is repeatable by
+  design. `label[]=` is accepted as well, for a client whose HTTP layer only
+  builds arrays that way.
+  """
+  @spec from_query_string(String.t() | nil) :: [String.t()]
+  def from_query_string(nil), do: []
+
+  def from_query_string(query) when is_binary(query) do
+    for {key, value} <- URI.query_decoder(query), key in ["label", "label[]"], do: value
+  end
+
+  @doc """
+  Turn repeated `key:value` filter values into the map the list query
+  contains against. Splits on the first colon only, so a value may contain
+  colons of its own.
+
+  `{:error, :invalid_label_filter}` for a value with no colon or an empty
+  key: a caller who typed `?label=prod` meant something, and matching
+  everything would be the wrong guess.
+  """
+  @spec parse_filter([String.t()] | nil) :: {:ok, map()} | {:error, :invalid_label_filter}
+  def parse_filter(nil), do: {:ok, %{}}
+
+  def parse_filter(values) when is_list(values) do
+    Enum.reduce_while(values, {:ok, %{}}, fn value, {:ok, acc} ->
+      case value |> to_string() |> String.trim() |> String.split(":", parts: 2) do
+        ["" | _] -> {:halt, {:error, :invalid_label_filter}}
+        [key, filter_value] -> {:cont, {:ok, Map.put(acc, key, filter_value)}}
+        [_no_colon] -> {:halt, {:error, :invalid_label_filter}}
+      end
+    end)
   end
 end

--- a/apps/fountain/lib/fountain/conversations/labels.ex
+++ b/apps/fountain/lib/fountain/conversations/labels.ex
@@ -8,9 +8,9 @@ defmodule Fountain.Conversations.Labels do
   `env=prod`, `drift=true`, `gated=apply`. Those facts are not text worth
   searching, so they are not in the full-text index and never will be.
 
-  Every door that writes labels goes through `changeset/1` here, called from
-  `Fountain.Conversations.Conversation.changeset/2`, so the limits cannot
-  drift between one writer and the next:
+  Every door that writes labels goes through `changeset/1` here, so the
+  limits cannot drift between the create request, the labels route, the team
+  message and the ACP extension notification:
 
     * at most 32 entries;
     * a key is a non-empty string of at most 64 bytes;
@@ -37,6 +37,8 @@ defmodule Fountain.Conversations.Labels do
   """
 
   import Ecto.Changeset, only: [get_change: 2, add_error: 3]
+
+  require Logger
 
   @max_entries 32
   @max_key_bytes 64
@@ -261,6 +263,59 @@ defmodule Fountain.Conversations.Labels do
      |> Enum.filter(&Map.has_key?(current, &1))
      |> Enum.sort()}
   end
+
+  @doc """
+  Merge the labels an agent stamped on its own run over the ACP extension
+  notification (#1637).
+
+  Unscoped, hence the prefix: it takes a bare conversation id and writes to
+  that row without a `user_id` and without a credential check. The only
+  caller is `Fountain.Conversations.TurnMachine`, running inside the
+  conversation's own `ConversationServer`, holding the id that server was
+  started with — so it cannot name another tenant's conversation, or another
+  conversation of the same tenant. A request-shaped caller wants
+  `Fountain.Conversations.set_conversation_labels/4`, which scopes by
+  `user_id` and applies the sandbox rule.
+
+  Recorded as `sprite` — code in the sandbox acting on the tenant's behalf
+  (ADR 0013).
+
+  **Nothing a label contains can take the turn down.** A stamp the limits
+  refuse is logged and dropped, and so is one that raises on its way to the
+  database. The run is mid-turn and doing real work, and losing it because a
+  value was 300 bytes long, or held a byte `jsonb` will not store, would be
+  the worse outcome by a distance.
+  """
+  @spec _unsafe_stamp(String.t() | nil, map()) :: :ok
+  def _unsafe_stamp(conversation_id, labels)
+
+  def _unsafe_stamp(conversation_id, labels)
+      when is_binary(conversation_id) and is_map(labels) do
+    # ownership: `conversation_id` is the id the calling `ConversationServer`
+    # was started with, held by its own turn machine. It cannot name another
+    # conversation, so both unscoped calls below are on this server's own row.
+    with %{} = conv <- Fountain.Conversations._unsafe_get_conversation(conversation_id),
+         {:error, changeset} <-
+           Fountain.Conversations._unsafe_merge_labels(conv, labels, actor: "sprite") do
+      Logger.warning(
+        "conv #{conversation_id}: refused _fountain/labels update: #{inspect(changeset.errors)}"
+      )
+    end
+
+    :ok
+  rescue
+    error ->
+      # The belt to `check_entry/2`'s braces. Every shape we know of is
+      # refused above with a message; this is here so that a shape we do not
+      # know of costs the stamp and not the turn.
+      Logger.warning(
+        "conv #{conversation_id}: _fountain/labels update raised: #{Exception.message(error)}"
+      )
+
+      :ok
+  end
+
+  def _unsafe_stamp(_conversation_id, _labels), do: :ok
 
   @doc """
   Every `label` value in a raw query string, in the order they were sent.

--- a/apps/fountain/lib/fountain/conversations/turn_machine.ex
+++ b/apps/fountain/lib/fountain/conversations/turn_machine.ex
@@ -44,7 +44,7 @@ defmodule Fountain.Conversations.TurnMachine do
   require OpenTelemetry.Tracer
 
   alias Fountain.{Agents, Conversations}
-  alias Fountain.Conversations.Conversation
+  alias Fountain.Conversations.{Conversation, Labels}
 
   @typedoc "What the peer reports about a turn, with the command ref already matched."
   @type payload :: tuple()
@@ -185,12 +185,33 @@ defmodule Fountain.Conversations.TurnMachine do
   # the full quiet window: `running` status, deferred idle park, billed turn
   # time. Metadata is nothing the agent did, so it opens no turn and re-arms
   # no quiet timer; with a turn in flight it still lands on the transcript.
+  #
+  # `_fountain/labels` is the third exception (#1637). ACP reserves a leading
+  # underscore for extensions, and `session/update` is the only notification
+  # the peer forwards, so that is where a deterministic run stamps its own
+  # outcome. It is a control message and not something the agent said, so it
+  # opens no turn, re-arms no quiet timer and never reaches the transcript.
   def handle(%__MODULE__{} = turn, {:lines, stream, data}, ctx) do
+    labels = if stream == "acp", do: label_update(data)
+
     cond do
       stream == "acp" and MapSet.member?(turn.replay_dedup, data) ->
         # A replayed line we already hold (ACP reattach). Each persisted line
         # suppresses at most one arrival, so a legitimate later repeat survives.
         {%{turn | replay_dedup: MapSet.delete(turn.replay_dedup, data)}, []}
+
+      is_map(labels) ->
+        # Written here rather than handed back as an effect: nothing about it
+        # is the server's — no state, no process, no timer — and this machine
+        # already writes what a report means.
+        #
+        # Ownership: `turn.conversation_id` is the id this machine's own
+        # `ConversationServer` was started with, so the unscoped write below
+        # cannot name another conversation, of this tenant or any other.
+        # Nothing a stamp contains can fail the turn; `_unsafe_stamp/2` logs
+        # and drops instead.
+        Labels._unsafe_stamp(turn.conversation_id, labels)
+        {turn, []}
 
       stream == "acp" and Managoat.ACP.Protocol.session_metadata?(data) ->
         if is_nil(turn.row) do
@@ -505,6 +526,41 @@ defmodule Fountain.Conversations.TurnMachine do
       end
 
     {turn, finish ++ [{:drop_connection, "failed"}]}
+  end
+
+  # The extension update a run stamps its own outcome with (#1637):
+  #
+  #     {"jsonrpc":"2.0","method":"session/update","params":{
+  #       "sessionId":"...",
+  #       "update":{"sessionUpdate":"_fountain/labels",
+  #                 "labels":{"drift":"true","env":"prod"}}}}
+  #
+  # ACP reserves a leading `_` for extensions, and `Managoat.ACP.Peer`
+  # forwards `session/update` and drops every other notification method, so
+  # this rides there rather than on a method of its own.
+  #
+  # A cheap substring test before the decode: this runs on every protocol line
+  # of every turn, and all but a handful of them are agent output.
+  @label_kind "_fountain/labels"
+
+  defp label_update(data) do
+    if String.contains?(data, @label_kind), do: decode_label_update(data)
+  end
+
+  defp decode_label_update(data) do
+    case Managoat.ACP.Protocol.classify_line(data) do
+      {:notification, "session/update", %{"update" => %{"sessionUpdate" => @label_kind} = update}} ->
+        # An `update` carrying no `labels` object is read as an empty merge,
+        # which writes nothing. Raising on it would cost the run its turn for
+        # a stamp, which is the wrong trade.
+        case Map.get(update, "labels") do
+          labels when is_map(labels) -> labels
+          _ -> %{}
+        end
+
+      _ ->
+        nil
+    end
   end
 
   # ── ending a turn ─────────────────────────────────────────────────────────

--- a/apps/fountain/lib/fountain/team.ex
+++ b/apps/fountain/lib/fountain/team.ex
@@ -373,14 +373,35 @@ defmodule Fountain.Team do
 
       %{conversation: conv} ->
         if live?(conv) do
-          case ConversationServer.send_prompt(conv.id, text, images, opts) do
-            :ok -> {:ok, Conversations.get_conversation(conv.id, user_id) || conv}
-            {:error, :gone} -> start_fresh(user_id, agent_id, conv, text, images, opts)
-            {:error, _} = err -> err
+          # Labels before the prompt (#1637): merged first, so a label the
+          # limits refuse means nothing happened at all rather than "the
+          # message went and the labels did not".
+          with {:ok, conv} <- label(conv, opts) do
+            case ConversationServer.send_prompt(conv.id, text, images, opts) do
+              :ok -> {:ok, Conversations.get_conversation(conv.id, user_id) || conv}
+              {:error, :gone} -> start_fresh(user_id, agent_id, conv, text, images, opts)
+              {:error, _} = err -> err
+            end
           end
         else
           start_fresh(user_id, agent_id, conv, text, images, opts)
         end
+    end
+  end
+
+  # `opts[:labels]` goes onto the conversation the message lands on (#1637).
+  # On the fresh path they ride in the create attrs instead, so a conversation
+  # that never existed is not labelled twice.
+  #
+  # Through `Conversations.set_conversation_labels/4`, not the writer beneath
+  # it: this route accepts a sandbox's own `sprite` token, and the teammate's
+  # conversation is somebody else's conversation as far as that token is
+  # concerned. The door is where the rule lives, so the refusal is the same
+  # one `PATCH .../labels` gives.
+  defp label(%Conversation{} = conv, opts) do
+    case Keyword.get(opts, :labels) do
+      nil -> {:ok, conv}
+      labels -> Conversations.set_conversation_labels(conv.id, conv.user_id, labels, opts)
     end
   end
 
@@ -401,7 +422,8 @@ defmodule Fountain.Team do
           "images" => images,
           "title" => prev.title,
           "environment_id" => prev.environment_id,
-          "vault_id" => prev.vault_id
+          "vault_id" => prev.vault_id,
+          "labels" => Keyword.get(opts, :labels) || %{}
         },
         opts
       )
@@ -784,10 +806,10 @@ defmodule Fountain.Team do
   first (`live?/1`, else the newest), then the retired ones newest first — a previous computer's thread, still bound to the channel until the
   teammate is removed. `[]` when the agent is not on the team.
   """
-  def list_teammate_conversations(user_id, agent_id)
+  def list_teammate_conversations(user_id, agent_id, opts \\ [])
       when is_binary(user_id) and is_binary(agent_id) do
     case user_id
-         |> Conversations.list_channel_conversations(@channel)
+         |> Conversations.list_channel_conversations(@channel, opts)
          |> Enum.filter(&(&1.agent_id == agent_id)) do
       [] ->
         []

--- a/apps/fountain/lib/fountain/webhooks.ex
+++ b/apps/fountain/lib/fountain/webhooks.ex
@@ -327,7 +327,8 @@ defmodule Fountain.Webhooks do
               user_id: c.user_id,
               agent_id: c.agent_id,
               parent_conversation_id: c.parent_conversation_id,
-              status: c.status
+              status: c.status,
+              labels: c.labels
             },
             e
           }
@@ -340,7 +341,8 @@ defmodule Fountain.Webhooks do
   end
 
   @doc """
-  The event envelope. Ids, a stage, a status, a duration. Nothing else, ever.
+  The event envelope. Ids, a stage, a status, a duration, the labels.
+  Nothing else, ever.
 
   `status` is the conversation's status as read at dispatch time, which can
   be stale by a hair against the transition that triggered it. Documented as
@@ -357,6 +359,10 @@ defmodule Fountain.Webhooks do
         "agent_id" => conv.agent_id,
         "parent_conversation_id" => conv.parent_conversation_id,
         "status" => conv.status,
+        # The conversation's labels (#1637). Ids and facts a program put
+        # there itself, never content, which is what keeps them inside the
+        # "ids, a stage, a status, a duration" rule above.
+        "labels" => conv.labels || %{},
         "stage" => event.stage,
         "state" => event.state,
         "turn_id" => event.turn_id,

--- a/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
@@ -9,10 +9,16 @@ defmodule FountainWeb.ConversationController do
   alias Fountain.Conversations
   alias Fountain.Conversations.{ConversationServer, LogEvent}
   alias FountainWeb.Audited
+  alias FountainWeb.LabelFilter
   alias FountainWeb.SandboxKey
   alias FountainWeb.Schemas
 
   action_fallback FountainWeb.FallbackController
+
+  # Before the cast, and only where the parameter exists: `label` is a
+  # repeated key, and the cast reads query parameters out of Plug, which
+  # keeps only the last of them. See the plug's moduledoc.
+  plug FountainWeb.Plugs.RepeatedQueryParam, "label" when action in [:index]
 
   plug OpenApiSpex.Plug.CastAndValidate,
     replace_params: false,
@@ -68,6 +74,20 @@ defmodule FountainWeb.ConversationController do
             "400 outside that range). Without it the whole list is returned, which on a " <>
             "busy account is hundreds of rows per call — a client that needs one " <>
             "conversation should filter (`agent_id`, `sandbox_id`, `channel_id`) and cap."
+      ],
+      label: [
+        in: :query,
+        schema: %OpenApiSpex.Schema{type: :array, items: %OpenApiSpex.Schema{type: :string}},
+        style: :form,
+        explode: true,
+        required: false,
+        description:
+          "Only conversations carrying these `key:value` labels (#1637). Repeat the " <>
+            "parameter to combine them with AND: `?label=env:prod&label=drift:true` keeps " <>
+            "the conversations that carry both. `label[]=` is accepted as well. Each value " <>
+            "splits on its first colon only, so `label=path:a:b` matches the label `path` " <>
+            "with the value `a:b`. 400 `invalid_label_filter` on a value with no colon or " <>
+            "an empty key."
       ]
     ],
     responses: [
@@ -82,7 +102,8 @@ defmodule FountainWeb.ConversationController do
     roots_only = parse_bool_param(params["roots_only"], false)
 
     with {:ok, statuses} <- parse_statuses(params["status"]),
-         {:ok, limit} <- parse_list_limit(params["limit"]) do
+         {:ok, limit} <- parse_list_limit(params["limit"]),
+         {:ok, labels} <- LabelFilter.from(conn) do
       render(conn, :index,
         conversations:
           Conversations.list_conversations(user.id,
@@ -91,7 +112,8 @@ defmodule FountainWeb.ConversationController do
             channel_id: params["channel_id"],
             sandbox_id: params["sandbox_id"],
             status: statuses,
-            limit: limit
+            limit: limit,
+            labels: labels
           )
       )
     end

--- a/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
@@ -183,7 +183,9 @@ defmodule FountainWeb.ConversationController do
         "256 bytes. A 422 names the offending key.\n\n" <>
         "The account's own key may label any of its conversations. A sandbox callback token " <>
         "may label **only the conversation it was minted for**; another id is refused with " <>
-        "403 `sprite_may_not_label_another_conversation`.",
+        "403 `sprite_may_not_label_another_conversation`. An agent inside a turn does not " <>
+        "need this route at all: it sends the `_fountain/labels` ACP extension update " <>
+        "instead.",
     parameters: [conversation_id: [in: :path, type: :string, required: true]],
     request_body: {"Labels", "application/json", Schemas.ConversationLabelsRequest},
     responses: [

--- a/apps/fountain/lib/fountain_web/controllers/team_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/team_controller.ex
@@ -19,6 +19,9 @@ defmodule FountainWeb.TeamController do
 
   action_fallback FountainWeb.FallbackController
 
+  # Before the cast: `label` is a repeated key. See the plug's moduledoc.
+  plug FountainWeb.Plugs.RepeatedQueryParam, "label" when action in [:conversations]
+
   plug OpenApiSpex.Plug.CastAndValidate,
     replace_params: false,
     render_error: FountainWeb.Plugs.CastRenderError
@@ -120,9 +123,23 @@ defmodule FountainWeb.TeamController do
         "thread, read-only — behind it. Each is a full conversation object; read a " <>
         "retired thread with `GET /api/conversations/:id/events`. 404 when the agent is " <>
         "not on the team.",
-    parameters: [agent_id: [in: :path, type: :string, required: true]],
+    parameters: [
+      agent_id: [in: :path, type: :string, required: true],
+      label: [
+        in: :query,
+        schema: %OpenApiSpex.Schema{type: :array, items: %OpenApiSpex.Schema{type: :string}},
+        style: :form,
+        explode: true,
+        required: false,
+        description:
+          "Only conversations carrying these `key:value` labels (#1637). Repeatable and " <>
+            "AND-combined, exactly as on `GET /api/conversations`. 400 " <>
+            "`invalid_label_filter` on a value with no colon or an empty key."
+      ]
+    ],
     responses: [
       ok: {"Conversations", "application/json", Schemas.TeammateConversationListResponse},
+      bad_request: {"Invalid label filter", "application/json", Schemas.Error},
       not_found: {"Not on the team", "application/json", Schemas.Error}
     ]
   )
@@ -130,15 +147,12 @@ defmodule FountainWeb.TeamController do
   def conversations(conn, %{"agent_id" => agent_id}) do
     user = conn.assigns.current_user
 
-    case Team.get_teammate(user.id, agent_id) do
-      nil ->
-        {:error, :not_found}
-
-      %{conversation: current} ->
-        render(conn, :conversations,
-          conversations: Team.list_teammate_conversations(user.id, agent_id),
-          current_id: current.id
-        )
+    with {:ok, labels} <- FountainWeb.LabelFilter.from(conn),
+         %{conversation: current} <- Team.get_teammate(user.id, agent_id) || {:error, :not_found} do
+      render(conn, :conversations,
+        conversations: Team.list_teammate_conversations(user.id, agent_id, labels: labels),
+        current_id: current.id
+      )
     end
   end
 
@@ -370,12 +384,17 @@ defmodule FountainWeb.TeamController do
         "seeded with this message, so the response names the conversation the message " <>
         "went to. 400 `conversation_busy` while the previous turn is still running " <>
         "(the same shape as `POST /api/conversations/:id/prompts`), 503 while the " <>
-        "computer is still starting.",
+        "computer is still starting.\n\n" <>
+        "`labels` merges onto the conversation the message lands on (#1637), before the " <>
+        "turn is queued, so a label the limits refuse leaves the message unsent.",
     parameters: [agent_id: [in: :path, type: :string, required: true]],
     request_body: {"Message", "application/json", Schemas.TeamMessageRequest},
     responses: [
       accepted: {"Queued", "application/json", Schemas.TeamMessageResponse},
       not_found: {"Not on the team", "application/json", Schemas.Error},
+      unprocessable_entity: {"Invalid labels", "application/json", Schemas.ChangesetError},
+      forbidden:
+        {"A sandbox token labelling another conversation", "application/json", Schemas.Error},
       bad_request: {"A turn is still running", "application/json", Schemas.Error}
     ]
   )
@@ -383,8 +402,12 @@ defmodule FountainWeb.TeamController do
   def message(conn, %{"agent_id" => agent_id, "prompt" => prompt} = params) do
     user = conn.assigns.current_user
 
+    # `SandboxKey.opts/1`: this route writes labels onto the teammate's
+    # conversation (#1637), which a sandbox's own token does not own.
     with {:ok, images} <- FountainWeb.PromptImages.decode(params["images"]),
-         opts = [source: "api"] ++ Audited.attribution(conn),
+         opts =
+           [source: "api", labels: params["labels"]] ++
+             FountainWeb.SandboxKey.opts(conn) ++ Audited.attribution(conn),
          {:ok, conv} <- Team.send_message(user.id, agent_id, prompt, images, opts) do
       conn
       |> put_status(:accepted)

--- a/apps/fountain/lib/fountain_web/label_filter.ex
+++ b/apps/fountain/lib/fountain_web/label_filter.ex
@@ -1,0 +1,41 @@
+defmodule FountainWeb.LabelFilter do
+  @moduledoc """
+  The `?label=key:value` filter on a conversation list (#1637), for both
+  routes that take it.
+
+  `GET /api/conversations` and `GET /api/team/:agent_id/conversations` accept
+  the same repeatable, AND-combined parameter, and a second copy of the
+  parsing in the team controller is exactly how the two would drift.
+
+  Read from `conn.query_string` and not from `conn.params`, because Plug
+  collapses a repeated key to its last value and this filter is repeatable by
+  design. `Fountain.Conversations.Labels` owns the vocabulary; this is the
+  Plug half plus the error the fallback controller renders as a 400.
+  """
+
+  alias Fountain.Conversations.Labels
+
+  @doc """
+  The label filter on a request: `{:ok, %{"env" => "prod"}}`, or
+  `{:error, "invalid_label_filter"}` for a value with no colon or an empty
+  key, which `FountainWeb.FallbackController` renders as a 400.
+
+  Reads the list `FountainWeb.Plugs.RepeatedQueryParam` left on the request.
+  `List.wrap/1` rather than a match, so a route that has not been given that
+  plug degrades to the single value Plug kept instead of raising.
+  """
+  @spec from(Plug.Conn.t()) :: {:ok, map()} | {:error, String.t()}
+  def from(%Plug.Conn{} = conn) do
+    conn.params
+    |> Map.get("label")
+    |> List.wrap()
+    |> parse()
+  end
+
+  defp parse(values) do
+    case Labels.parse_filter(values) do
+      {:ok, labels} -> {:ok, labels}
+      {:error, :invalid_label_filter} -> {:error, "invalid_label_filter"}
+    end
+  end
+end

--- a/apps/fountain/lib/fountain_web/plugs/repeated_query_param.ex
+++ b/apps/fountain/lib/fountain_web/plugs/repeated_query_param.ex
@@ -1,0 +1,68 @@
+defmodule FountainWeb.Plugs.RepeatedQueryParam do
+  @moduledoc """
+  Collect a repeated query key into a list, before the OpenAPI cast sees it.
+
+  `?label=env:prod&label=drift:true` is one parameter sent twice, which is
+  what OpenAPI calls `style: form, explode: true` and what an array parameter
+  means on the wire. Two things get in the way:
+
+    * `Plug.Conn.Query` collapses a repeated key to its **last** value, so
+      `conn.params["label"]` is `"drift:true"` and the first filter is gone;
+    * `OpenApiSpex.CastParameters` reads query parameters straight out of
+      `Plug.Conn.fetch_query_params/1` and implements only the `explode:
+      false` (comma-joined) form itself, so a parameter *declared* as an
+      array would be handed that string and refuse it as "not an array" —
+      turning a perfectly ordinary `?label=env:prod` into a 422.
+
+  So the parameter cannot be declared honestly as an array until something
+  reshapes it first, and that is this plug. It reads the raw query string,
+  collects every occurrence of the named key, and writes the list back onto
+  both `query_params` and `params` so the cast and the action see the same
+  value. `name[]=` is collected too, for a client whose HTTP layer only knows
+  how to build arrays that way.
+
+  Declare it **before** `OpenApiSpex.Plug.CastAndValidate` in the controller,
+  and scope it to the actions that take the parameter:
+
+      plug FountainWeb.Plugs.RepeatedQueryParam, "label" when action in [:index]
+
+  A request that sends the key once still arrives as a one-element list, so
+  the action has one shape to read rather than two.
+  """
+
+  @behaviour Plug
+
+  @impl Plug
+  def init(name) when is_binary(name), do: name
+
+  @impl Plug
+  def call(%Plug.Conn{} = conn, name) do
+    conn = Plug.Conn.fetch_query_params(conn)
+
+    case collect(conn.query_string, name) do
+      [] -> conn
+      values -> put(conn, name, values)
+    end
+  end
+
+  defp collect(query, name) when is_binary(query) do
+    bracketed = name <> "[]"
+
+    for {key, value} <- URI.query_decoder(query), key in [name, bracketed], do: value
+  end
+
+  defp put(conn, name, values) do
+    %{
+      conn
+      | query_params: Map.put(conn.query_params, name, values),
+        params: put_param(conn.params, name, values)
+    }
+  end
+
+  # `params` is `%Plug.Conn.Unfetched{}` until the body parsers have run. Every
+  # route this plug is on has run them, but reshaping an unfetched struct into
+  # a map would quietly swallow the body, so leave it alone and let
+  # `query_params` carry the value.
+  defp put_param(%Plug.Conn.Unfetched{} = params, _name, _values), do: params
+  defp put_param(params, name, values) when is_map(params), do: Map.put(params, name, values)
+end

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -2553,7 +2553,16 @@ defmodule FountainWeb.Schemas do
       type: :object,
       properties: %{
         prompt: %Schema{type: :string},
-        images: %Schema{type: :array, items: ImageInput, nullable: true}
+        images: %Schema{type: :array, items: ImageInput, nullable: true},
+        labels: %Schema{
+          type: :object,
+          nullable: true,
+          additionalProperties: %Schema{type: :string, nullable: true},
+          description:
+            "Labels to merge into the conversation this message lands on, whether that is " <>
+              "the teammate's current one or the fresh one a retired thread is replaced by. " <>
+              "Same limits as everywhere else; null removes a key."
+        }
       },
       required: [:prompt]
     })

--- a/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
@@ -1769,4 +1769,160 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
                GenServer.call(pid, {:park_caller_tool, "lookup_order", %{}, self()})
     end
   end
+
+  describe "labels over the ACP extension (#1637)" do
+    setup do
+      user = insert_verified_user()
+      conv = insert_conversation(agent: acp_agent(user), user_id: user.id)
+      {pid, ref} = start_acp_turn(conv)
+      {:ok, user: user, conv: conv, pid: pid, ref: ref}
+    end
+
+    defp labels_of(conv_id), do: Conversations._unsafe_get_conversation!(conv_id).labels
+
+    test "the agent stamps its own conversation mid-turn", %{conv: conv, pid: pid, ref: ref} do
+      drive_to_prompt(pid, ref)
+
+      notify(pid, ref, %{
+        "sessionUpdate" => "_fountain/labels",
+        "labels" => %{"drift" => "true", "env" => "prod"}
+      })
+
+      assert labels_of(conv.id) == %{"drift" => "true", "env" => "prod"}
+    end
+
+    test "a second stamp merges rather than replaces", %{conv: conv, pid: pid, ref: ref} do
+      drive_to_prompt(pid, ref)
+
+      notify(pid, ref, %{"sessionUpdate" => "_fountain/labels", "labels" => %{"env" => "prod"}})
+      notify(pid, ref, %{"sessionUpdate" => "_fountain/labels", "labels" => %{"run" => "17"}})
+
+      assert labels_of(conv.id) == %{"env" => "prod", "run" => "17"}
+    end
+
+    test "a null value removes a key", %{conv: conv, pid: pid, ref: ref} do
+      drive_to_prompt(pid, ref)
+
+      notify(pid, ref, %{
+        "sessionUpdate" => "_fountain/labels",
+        "labels" => %{"env" => "prod", "run" => "17"}
+      })
+
+      notify(pid, ref, %{"sessionUpdate" => "_fountain/labels", "labels" => %{"env" => nil}})
+
+      assert labels_of(conv.id) == %{"run" => "17"}
+    end
+
+    test "the stamp never reaches the transcript", %{conv: conv, pid: pid, ref: ref} do
+      drive_to_prompt(pid, ref)
+
+      notify(pid, ref, %{"sessionUpdate" => "_fountain/labels", "labels" => %{"env" => "prod"}})
+
+      events = Conversations._unsafe_list_log_events(conv.id)
+      refute Enum.any?(events, &(&1.data =~ "_fountain/labels"))
+    end
+
+    test "a stamp the limits refuse is dropped and the turn survives", %{
+      conv: conv,
+      pid: pid,
+      ref: ref
+    } do
+      prompt_id = drive_to_prompt(pid, ref)
+
+      notify(pid, ref, %{
+        "sessionUpdate" => "_fountain/labels",
+        "labels" => %{"note" => String.duplicate("v", 300)}
+      })
+
+      assert labels_of(conv.id) == %{}
+      assert Process.alive?(pid)
+
+      # And the turn still ends normally.
+      reply(pid, ref, prompt_id, %{"stopReason" => "end_turn"})
+      assert Conversations._unsafe_get_conversation!(conv.id).status == "idle"
+    end
+
+    # Postgres refuses a NUL inside a jsonb string. Before `check_entry/2`
+    # rejected it, the write raised a Postgrex.Error inside the turn machine,
+    # which travelled up through `drive_turn/2` and killed the server and the
+    # turn it was running — a label costing a run.
+    test "a NUL byte in a stamp costs the stamp and not the turn", %{
+      conv: conv,
+      pid: pid,
+      ref: ref
+    } do
+      prompt_id = drive_to_prompt(pid, ref)
+
+      notify(pid, ref, %{
+        "sessionUpdate" => "_fountain/labels",
+        "labels" => %{"note" => "before\u0000after"}
+      })
+
+      assert labels_of(conv.id) == %{}
+      assert Process.alive?(pid)
+
+      # The turn still ends, and a later legal stamp still lands.
+      notify(pid, ref, %{"sessionUpdate" => "_fountain/labels", "labels" => %{"env" => "prod"}})
+      assert labels_of(conv.id) == %{"env" => "prod"}
+
+      reply(pid, ref, prompt_id, %{"stopReason" => "end_turn"})
+      assert Conversations._unsafe_get_conversation!(conv.id).status == "idle"
+    end
+
+    # The extension is recognised by a decode, not by a substring: the cheap
+    # `String.contains?` in front of it is an optimisation, and agent prose
+    # that happens to mention the kind is still prose.
+    test "agent output that mentions the kind is still transcript", %{
+      conv: conv,
+      pid: pid,
+      ref: ref
+    } do
+      drive_to_prompt(pid, ref)
+
+      notify(pid, ref, %{
+        "sessionUpdate" => "agent_message_chunk",
+        "content" => %{
+          "type" => "text",
+          "text" => ~s|stamp it with {"sessionUpdate":"_fountain/labels"}|
+        }
+      })
+
+      events = Conversations._unsafe_list_log_events(conv.id)
+      assert Enum.any?(events, &(&1.stream == "acp" and &1.data =~ "_fountain/labels"))
+
+      # And it labelled nothing.
+      assert labels_of(conv.id) == %{}
+    end
+
+    test "a stamp out of turn opens no autonomous turn", %{conv: conv, pid: pid, ref: ref} do
+      prompt_id = drive_to_prompt(pid, ref)
+      reply(pid, ref, prompt_id, %{"stopReason" => "end_turn"})
+
+      before = length(Conversations._unsafe_list_turns(conv.id))
+
+      notify(pid, ref, %{"sessionUpdate" => "_fountain/labels", "labels" => %{"env" => "prod"}})
+
+      assert labels_of(conv.id) == %{"env" => "prod"}
+      assert length(Conversations._unsafe_list_turns(conv.id)) == before
+    end
+
+    test "the write is recorded as the sprite, with keys and no values", %{
+      user: user,
+      pid: pid,
+      ref: ref
+    } do
+      drive_to_prompt(pid, ref)
+
+      notify(pid, ref, %{"sessionUpdate" => "_fountain/labels", "labels" => %{"drift" => "true"}})
+
+      assert [event] =
+               user.id
+               |> Fountain.Audit.list_recent_for_user(50)
+               |> Enum.filter(&(&1.action == "conversation.labels_set"))
+
+      assert event.actor == "sprite"
+      assert event.metadata["keys"] == ["drift"]
+      refute inspect(event.metadata) =~ "true"
+    end
+  end
 end

--- a/apps/fountain/test/fountain/conversations/labels_test.exs
+++ b/apps/fountain/test/fountain/conversations/labels_test.exs
@@ -1,6 +1,6 @@
 defmodule Fountain.Conversations.LabelsTest do
   @moduledoc """
-  Labels on a conversation (#1637): the rule and the merge.
+  Labels on a conversation (#1637): the rule, the merge, the filter.
 
   The doors are covered where they live, so what is here is the behaviour
   every one of them inherits.
@@ -413,6 +413,109 @@ defmodule Fountain.Conversations.LabelsTest do
 
       assert Conversations.get_conversation(context.bound.id, context.user.id).labels ==
                %{"env" => "prod"}
+    end
+  end
+
+  describe "the filter vocabulary" do
+    test "splits on the first colon only" do
+      assert {:ok, %{"path" => "a:b"}} = Labels.parse_filter(["path:a:b"])
+    end
+
+    test "combines repeated values" do
+      assert {:ok, %{"env" => "prod", "drift" => "true"}} =
+               Labels.parse_filter(["env:prod", "drift:true"])
+    end
+
+    test "an empty value is a legal filter" do
+      assert {:ok, %{"env" => ""}} = Labels.parse_filter(["env:"])
+    end
+
+    test "a value with no colon is refused rather than guessed at" do
+      assert {:error, :invalid_label_filter} = Labels.parse_filter(["prod"])
+    end
+
+    test "an empty key is refused" do
+      assert {:error, :invalid_label_filter} = Labels.parse_filter([":prod"])
+    end
+
+    test "reads every repetition out of a raw query string" do
+      assert ["env:prod", "drift:true"] =
+               Labels.from_query_string("roots_only=true&label=env:prod&label=drift:true")
+    end
+
+    test "accepts the bracketed array form too" do
+      assert ["env:prod"] = Labels.from_query_string("label%5B%5D=env%3Aprod")
+    end
+  end
+
+  describe "the list filter" do
+    setup do
+      user = insert_active_user()
+
+      prod_drift =
+        insert_conversation(user_id: user.id, labels: %{"env" => "prod", "drift" => "true"})
+
+      prod_clean =
+        insert_conversation(user_id: user.id, labels: %{"env" => "prod", "drift" => "false"})
+
+      staging = insert_conversation(user_id: user.id, labels: %{"env" => "staging"})
+      unlabelled = insert_conversation(user_id: user.id)
+
+      {:ok,
+       user: user,
+       prod_drift: prod_drift,
+       prod_clean: prod_clean,
+       staging: staging,
+       unlabelled: unlabelled}
+    end
+
+    defp ids(convs), do: convs |> Enum.map(& &1.id) |> MapSet.new()
+
+    test "one pair keeps every conversation carrying it", context do
+      found = Conversations.list_conversations(context.user.id, labels: %{"env" => "prod"})
+
+      assert ids(found) == MapSet.new([context.prod_drift.id, context.prod_clean.id])
+    end
+
+    test "two pairs are combined with AND", context do
+      found =
+        Conversations.list_conversations(context.user.id,
+          labels: %{"env" => "prod", "drift" => "true"}
+        )
+
+      assert ids(found) == MapSet.new([context.prod_drift.id])
+    end
+
+    test "a pair nothing carries matches nothing", context do
+      assert [] = Conversations.list_conversations(context.user.id, labels: %{"env" => "qa"})
+    end
+
+    test "no filter leaves the list alone", context do
+      assert MapSet.size(ids(Conversations.list_conversations(context.user.id))) == 4
+      assert MapSet.size(ids(Conversations.list_conversations(context.user.id, labels: %{}))) == 4
+    end
+
+    test "the filter is tenant-scoped like every other", context do
+      stranger = insert_active_user()
+      insert_conversation(user_id: stranger.id, labels: %{"env" => "prod"})
+
+      found = Conversations.list_conversations(context.user.id, labels: %{"env" => "prod"})
+      assert ids(found) == MapSet.new([context.prod_drift.id, context.prod_clean.id])
+    end
+
+    test "combines with the other filters", context do
+      agent = insert_agent(user_id: context.user.id)
+
+      mine =
+        insert_conversation(user_id: context.user.id, agent: agent, labels: %{"env" => "prod"})
+
+      found =
+        Conversations.list_conversations(context.user.id,
+          agent_id: agent.id,
+          labels: %{"env" => "prod"}
+        )
+
+      assert ids(found) == MapSet.new([mine.id])
     end
   end
 end

--- a/apps/fountain/test/fountain/webhooks_test.exs
+++ b/apps/fountain/test/fountain/webhooks_test.exs
@@ -202,12 +202,32 @@ defmodule Fountain.WebhooksTest do
                "agent_id",
                "conversation_id",
                "duration_ms",
+               "labels",
                "parent_conversation_id",
                "stage",
                "state",
                "status",
                "turn_id"
              ]
+    end
+
+    test "the payload carries the conversation's labels (#1637)", %{user: user, conv: conv} do
+      {endpoint, _} = endpoint_for(user, %{"event_types" => ["*"]})
+      {:ok, _} = Conversations._unsafe_merge_labels(conv, %{"env" => "prod", "drift" => "true"})
+
+      Conversations.publish_stage(conv.id, "turn", "done", %{turn_id: nil})
+
+      assert [job] = jobs_for(endpoint)
+      assert job.args["payload"]["data"]["labels"] == %{"env" => "prod", "drift" => "true"}
+    end
+
+    test "an unlabelled conversation still carries an object", %{user: user, conv: conv} do
+      {endpoint, _} = endpoint_for(user, %{"event_types" => ["*"]})
+
+      Conversations.publish_stage(conv.id, "turn", "done", %{turn_id: nil})
+
+      assert [job] = jobs_for(endpoint)
+      assert job.args["payload"]["data"]["labels"] == %{}
     end
 
     test "output events never dispatch", %{user: user, conv: conv} do

--- a/apps/fountain/test/fountain_web/controllers/conversation_labels_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/conversation_labels_test.exs
@@ -1,7 +1,7 @@
 defmodule FountainWeb.ConversationLabelsTest do
   @moduledoc """
-  Labels over the wire (#1637): create, read back, the merge route and who is
-  allowed to call it.
+  Labels over the wire (#1637): create, read back, the repeatable AND filter,
+  the merge route and who is allowed to call it.
   """
 
   use FountainWeb.ConnCase, async: true
@@ -87,6 +87,72 @@ defmodule FountainWeb.ConversationLabelsTest do
       conn = conn |> authed_with_key(raw_key) |> get("/api/conversations/#{conv.id}")
 
       assert %{"data" => %{"labels" => %{}}} = json_response(conn, 200)
+    end
+  end
+
+  describe "GET /api/conversations?label=" do
+    setup %{user: user} do
+      prod_drift =
+        insert_conversation(user_id: user.id, labels: %{"env" => "prod", "drift" => "true"})
+
+      prod_clean = insert_conversation(user_id: user.id, labels: %{"env" => "prod"})
+      staging = insert_conversation(user_id: user.id, labels: %{"env" => "staging"})
+
+      {:ok, prod_drift: prod_drift, prod_clean: prod_clean, staging: staging}
+    end
+
+    defp listed(conn),
+      do: conn |> json_response(200) |> Map.fetch!("data") |> Enum.map(& &1["id"])
+
+    test "one pair keeps the conversations carrying it", context do
+      ids =
+        context.conn
+        |> authed_with_key(context.raw_key)
+        |> get("/api/conversations?label=env:prod")
+        |> listed()
+
+      assert Enum.sort(ids) == Enum.sort([context.prod_drift.id, context.prod_clean.id])
+    end
+
+    test "a repeated label is combined with AND", context do
+      ids =
+        context.conn
+        |> authed_with_key(context.raw_key)
+        |> get("/api/conversations?label=env:prod&label=drift:true")
+        |> listed()
+
+      assert ids == [context.prod_drift.id]
+    end
+
+    test "combines with the other filters", context do
+      ids =
+        context.conn
+        |> authed_with_key(context.raw_key)
+        |> get("/api/conversations?status=pending&label=env:staging")
+        |> listed()
+
+      assert ids == [context.staging.id]
+    end
+
+    test "a value splits on its first colon only", %{conn: conn, user: user, raw_key: raw_key} do
+      conv = insert_conversation(user_id: user.id, labels: %{"path" => "apps/fountain:lib"})
+
+      ids =
+        conn
+        |> authed_with_key(raw_key)
+        |> get("/api/conversations?label=path:apps/fountain:lib")
+        |> listed()
+
+      assert ids == [conv.id]
+    end
+
+    test "a value with no colon is a 400 rather than a silent match-all", context do
+      conn =
+        context.conn
+        |> authed_with_key(context.raw_key)
+        |> get("/api/conversations?label=prod")
+
+      assert %{"error" => "invalid_label_filter"} = json_response(conn, 400)
     end
   end
 

--- a/apps/fountain/test/fountain_web/controllers/team_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/team_controller_test.exs
@@ -380,6 +380,37 @@ defmodule FountainWeb.TeamControllerTest do
              |> get("/api/team/#{loner.id}/conversations")
              |> json_response(404)
     end
+
+    test "the label filter is repeatable and AND-combined (#1637)", %{
+      conn: conn,
+      user: user,
+      raw_key: key
+    } do
+      ada = insert_agent(user_id: user.id, name: "Ada")
+      drifted = insert_teammate_conv(user, ada, labels: %{"env" => "prod", "drift" => "true"})
+      insert_teammate_conv(user, ada, labels: %{"env" => "prod"})
+      insert_teammate_conv(user, ada, labels: %{"env" => "staging"})
+
+      body =
+        conn
+        |> authed_with_key(key)
+        |> get("/api/team/#{ada.id}/conversations?label=env:prod&label=drift:true")
+        |> json_response(200)
+
+      assert Enum.map(body["data"], & &1["id"]) == [drifted.id]
+      assert hd(body["data"])["labels"] == %{"env" => "prod", "drift" => "true"}
+    end
+
+    test "a label filter with no colon is a 400", %{conn: conn, user: user, raw_key: key} do
+      ada = insert_agent(user_id: user.id, name: "Ada")
+      insert_teammate_conv(user, ada)
+
+      assert %{"error" => "invalid_label_filter"} =
+               conn
+               |> authed_with_key(key)
+               |> get("/api/team/#{ada.id}/conversations?label=prod")
+               |> json_response(400)
+    end
   end
 
   describe "POST /api/team/:agent_id/conversations" do
@@ -498,6 +529,155 @@ defmodule FountainWeb.TeamControllerTest do
       assert body == %{"status" => "queued", "conversation_id" => conv.id}
       conv_id = conv.id
       assert_received {:sent, ^conv_id, "hello", [], "api"}
+    end
+
+    test "labels on the message land on the conversation it goes to (#1637)", %{
+      conn: conn,
+      user: user,
+      raw_key: key
+    } do
+      ada = insert_agent(user_id: user.id, name: "Ada")
+      conv = insert_teammate_conv(user, ada, labels: %{"env" => "prod"})
+      stub(ConversationServer, :send_prompt, fn _id, _text, _images, _opts -> :ok end)
+
+      assert %{"conversation_id" => _} =
+               conn
+               |> authed_with_key(key)
+               |> post_json("/api/team/#{ada.id}/messages", %{
+                 prompt: "hello",
+                 labels: %{"run" => "17"}
+               })
+               |> json_response(202)
+
+      assert Fountain.Conversations._unsafe_get_conversation!(conv.id).labels ==
+               %{"env" => "prod", "run" => "17"}
+    end
+
+    test "labels ride onto the fresh conversation when the thread is past resuming (#1637)", %{
+      conn: conn,
+      user: user,
+      raw_key: key
+    } do
+      ada = insert_agent(user_id: user.id, name: "Ada")
+      dead = insert_teammate_conv(user, ada, status: "terminated")
+      inert_start_child()
+
+      body =
+        conn
+        |> authed_with_key(key)
+        |> post_json("/api/team/#{ada.id}/messages", %{
+          prompt: "are you there?",
+          labels: %{"env" => "prod"}
+        })
+        |> json_response(202)
+
+      refute body["conversation_id"] == dead.id
+
+      assert Fountain.Conversations._unsafe_get_conversation!(body["conversation_id"]).labels ==
+               %{"env" => "prod"}
+    end
+
+    test "a sandbox token may not label the teammate's conversation (#1637)", %{
+      conn: conn,
+      user: user
+    } do
+      ada = insert_agent(user_id: user.id, name: "Ada")
+      conv = insert_teammate_conv(user, ada, labels: %{"env" => "prod"})
+      {_sprite, sprite_raw} = insert_sprite_api_key(user)
+      test_pid = self()
+
+      stub(ConversationServer, :send_prompt, fn _id, _text, _images, _opts ->
+        send(test_pid, :sent)
+        :ok
+      end)
+
+      assert %{"error" => "sprite_may_not_label_another_conversation"} =
+               conn
+               |> authed_with_key(sprite_raw)
+               |> post_json("/api/team/#{ada.id}/messages", %{
+                 prompt: "hello",
+                 labels: %{"run" => "17"}
+               })
+               |> json_response(403)
+
+      assert Fountain.Conversations._unsafe_get_conversation!(conv.id).labels == %{
+               "env" => "prod"
+             }
+
+      refute_received :sent
+    end
+
+    test "a sandbox token may label the conversation it was minted for (#1637)", %{
+      conn: conn,
+      user: user
+    } do
+      ada = insert_agent(user_id: user.id, name: "Ada")
+      conv = insert_teammate_conv(user, ada, labels: %{"env" => "prod"})
+      {sprite, sprite_raw} = insert_sprite_api_key(user)
+
+      {:ok, _} =
+        Fountain.Conversations.update_conversation(conv, %{callback_api_key_id: sprite.id})
+
+      stub(ConversationServer, :send_prompt, fn _id, _text, _images, _opts -> :ok end)
+
+      assert %{"status" => "queued"} =
+               conn
+               |> authed_with_key(sprite_raw)
+               |> post_json("/api/team/#{ada.id}/messages", %{
+                 prompt: "hello",
+                 labels: %{"run" => "17"}
+               })
+               |> json_response(202)
+
+      assert Fountain.Conversations._unsafe_get_conversation!(conv.id).labels ==
+               %{"env" => "prod", "run" => "17"}
+    end
+
+    test "a message with no labels leaves the ones already there (#1637)", %{
+      conn: conn,
+      user: user,
+      raw_key: key
+    } do
+      ada = insert_agent(user_id: user.id, name: "Ada")
+      conv = insert_teammate_conv(user, ada, labels: %{"env" => "prod"})
+      stub(ConversationServer, :send_prompt, fn _id, _text, _images, _opts -> :ok end)
+
+      conn
+      |> authed_with_key(key)
+      |> post_json("/api/team/#{ada.id}/messages", %{prompt: "hello"})
+      |> json_response(202)
+
+      assert Fountain.Conversations._unsafe_get_conversation!(conv.id).labels == %{
+               "env" => "prod"
+             }
+    end
+
+    test "a label the limits refuse leaves the message unsent, naming the key", %{
+      conn: conn,
+      user: user,
+      raw_key: key
+    } do
+      ada = insert_agent(user_id: user.id, name: "Ada")
+      insert_teammate_conv(user, ada)
+      test_pid = self()
+
+      stub(ConversationServer, :send_prompt, fn _id, _text, _images, _opts ->
+        send(test_pid, :sent)
+        :ok
+      end)
+
+      body =
+        conn
+        |> authed_with_key(key)
+        |> post_json("/api/team/#{ada.id}/messages", %{
+          prompt: "hello",
+          labels: %{"note" => String.duplicate("v", 300)}
+        })
+        |> json_response(422)
+
+      assert [message] = body["errors"]["labels"]
+      assert message =~ ~s("note")
+      refute_received :sent
     end
 
     test "400 conversation_busy while the teammate is busy, 404 when not on the team", %{

--- a/docs/api.md
+++ b/docs/api.md
@@ -284,7 +284,8 @@ curl --fail-with-body \
 Each value splits on its first colon. The key is the part before it, and the
 value is all of the rest. `label=path:apps/fountain:lib` therefore filters the
 key `path` for the value `apps/fountain:lib`. A value with no colon, or with
-an empty key, returns 400 `invalid_label_filter`.
+an empty key, returns 400 `invalid_label_filter`. The same parameter works on
+`GET /api/team/{agent_id}/conversations`.
 
 The parameter is an array in the OpenAPI document, with `style: form` and
 `explode: true`. A client that builds arrays as `label[]=env:prod` is
@@ -309,11 +310,16 @@ of these limits returns 422 and names the offending key under
 against labels that are already there. The key named is one you sent, and
 never one that was already on the conversation.
 
+A team message to `POST /api/team/{agent_id}/messages` also takes `labels`.
+Fountain merges them into the conversation that receives the message, before
+it queues the turn. A create call to `POST /api/conversations` with a
+`channel_id` that resumes a conversation merges them into that conversation.
+
 The account's own API key can label any of its conversations. A sandbox
 callback token can label only the conversation it was minted for. Another
 conversation returns 403 `sprite_may_not_label_another_conversation`. This
-applies to the labels route and to a `channel_id` resume, which merges the
-request's labels into the conversation it hands back.
+applies to all three doors that write labels, which are the labels route, a
+team message, and a `channel_id` resume.
 
 ### Workers without Fountain API access
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -321,6 +321,24 @@ conversation returns 403 `sprite_may_not_label_another_conversation`. This
 applies to all three doors that write labels, which are the labels route, a
 team message, and a `channel_id` resume.
 
+### An agent that labels its own run
+
+An agent inside a turn does not need the route above. It sends an ACP
+extension notification on the session it already holds. ACP keeps names that
+start with `_` for extensions.
+
+```json
+{"jsonrpc":"2.0","method":"session/update","params":{
+  "sessionId":"sess_1",
+  "update":{"sessionUpdate":"_fountain/labels",
+            "labels":{"drift":"true","env":"prod"}}}}
+```
+
+Fountain merges the map with the same rules as the route. A `null` value
+removes a key. The notification never reaches the transcript, and it opens no
+turn of its own. A stamp that breaks a limit is logged and dropped, and the
+turn continues. Nothing in a stamp can end a run.
+
 ### Workers without Fountain API access
 
 Set `sandbox_api_access` to `none` when the host must retain Fountain API

--- a/docs/api.md
+++ b/docs/api.md
@@ -321,6 +321,9 @@ conversation returns 403 `sprite_may_not_label_another_conversation`. This
 applies to all three doors that write labels, which are the labels route, a
 team message, and a `channel_id` resume.
 
+`conversation.*` webhook payloads carry `labels` under `data`. See
+[Webhooks](reference/webhooks.md).
+
 ### An agent that labels its own run
 
 An agent inside a turn does not need the route above. It sends an ACP

--- a/docs/api.md
+++ b/docs/api.md
@@ -272,6 +272,24 @@ curl --fail-with-body \
   "$FOUNTAIN_URL/api/conversations"
 ```
 
+Filter a list with a repeatable `label` parameter. Fountain combines the
+values with AND. The example keeps the conversations that carry both pairs.
+
+```bash
+curl --fail-with-body \
+  -H "Authorization: Bearer $FOUNTAIN_API_KEY" \
+  "$FOUNTAIN_URL/api/conversations?label=env:prod&label=drift:true"
+```
+
+Each value splits on its first colon. The key is the part before it, and the
+value is all of the rest. `label=path:apps/fountain:lib` therefore filters the
+key `path` for the value `apps/fountain:lib`. A value with no colon, or with
+an empty key, returns 400 `invalid_label_filter`.
+
+The parameter is an array in the OpenAPI document, with `style: form` and
+`explode: true`. A client that builds arrays as `label[]=env:prod` is
+accepted too.
+
 `PATCH /api/conversations/{id}/labels` merges labels into a conversation. A
 key the body does not name stays as it is. A key with a `null` value is
 removed.

--- a/docs/reference/webhooks.md
+++ b/docs/reference/webhooks.md
@@ -102,6 +102,7 @@ ends. Use the SSE endpoint for output.
     "agent_id": "7ab1…",
     "parent_conversation_id": null,
     "status": "idle",
+    "labels": {"env": "prod", "drift": "true"},
     "stage": "turn",
     "state": "done",
     "turn_id": "3d90…",
@@ -116,11 +117,15 @@ ends. Use the SSE endpoint for output.
 | `type` | `conversation.<stage>.<status>`. |
 | `created_at` | The time Fountain recorded the transition, in UTC, to the microsecond. |
 | `data.status` | The conversation status Fountain read at dispatch time. Treat it as advisory. |
+| `data.labels` | The conversation's labels, read at dispatch time. An empty object when it has none. |
 | `data.turn_id` | A turn event carries it. Every other event carries null. |
 | `data.duration_ms` | How long the stage took, where the stage records a duration. |
 
 **The payload carries no values.** It has no transcript text, no prompt, no
-environment variable names and no secret values. The audit trail obeys the
+environment variable names and no secret values. Labels are the one free-form
+field, and they are there because a caller put them there itself. The agent
+in the sandbox can also stamp them over its ACP session. Treat a label as
+data your own run wrote, and not as a value Fountain derived. The audit trail obeys the
 same rule ([ADR 0013](https://github.com/managoat/fountain/blob/main/decisions/0013-audit-trail.md)),
 for the same reason. A payload is tenant data that leaves the building over a
 URL somebody typed into a form. The delivery log would otherwise hold a

--- a/sdk/contract/contract.json
+++ b/sdk/contract/contract.json
@@ -3152,10 +3152,24 @@
       "path_params": [
         "agent_id"
       ],
+      "query_params": {
+        "label": {
+          "items": {
+            "type": "string"
+          },
+          "required": false,
+          "type": "array"
+        }
+      },
       "responses": {
         "200": {
           "application/json": {
             "ref": "TeammateConversationListResponse"
+          }
+        },
+        "400": {
+          "application/json": {
+            "ref": "Error"
           }
         },
         "401": {
@@ -6472,6 +6486,11 @@
         "406": {
           "application/json": {
             "ref": "NegotiationError"
+          }
+        },
+        "422": {
+          "application/json": {
+            "ref": "ChangesetError"
           }
         },
         "429": {
@@ -12467,6 +12486,15 @@
           "nullable": true,
           "required": false,
           "type": "array"
+        },
+        "labels": {
+          "additionalProperties": {
+            "nullable": true,
+            "type": "string"
+          },
+          "nullable": true,
+          "required": false,
+          "type": "object"
         },
         "prompt": {
           "required": true,

--- a/sdk/contract/contract.json
+++ b/sdk/contract/contract.json
@@ -1865,6 +1865,13 @@
           "required": false,
           "type": "string"
         },
+        "label": {
+          "items": {
+            "type": "string"
+          },
+          "required": false,
+          "type": "array"
+        },
         "limit": {
           "required": false,
           "type": "integer"

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -177,10 +177,19 @@ export class Fountain {
    * Roots only by default: a conversation an agent spawned from inside a
    * sandbox is listed under its parent's tree, not again at the top level.
    * Pass `{ rootsOnly: false }` for the flat list, children included.
+   *
+   * `labels` keeps the conversations carrying every pair given — the wire is
+   * a repeatable `label=key:value`, combined with AND.
    */
-  async conversations(opts: { rootsOnly?: boolean; sandboxId?: string } = {}): Promise<ConversationRecord[]> {
+  async conversations(
+    opts: { rootsOnly?: boolean; sandboxId?: string; labels?: Record<string, string> } = {},
+  ): Promise<ConversationRecord[]> {
     return this.api.list<ConversationRecord>("/api/conversations", {
-      query: { roots_only: opts.rootsOnly === false ? undefined : "true", sandbox_id: opts.sandboxId },
+      query: {
+        roots_only: opts.rootsOnly === false ? undefined : "true",
+        sandbox_id: opts.sandboxId,
+        label: opts.labels && Object.entries(opts.labels).map(([k, v]) => `${k}:${v}`),
+      },
     });
   }
 

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -1248,7 +1248,7 @@ export interface paths {
          *
          *     At most 32 labels survive the merge; a key is at most 64 bytes and a value at most 256 bytes. A 422 names the offending key.
          *
-         *     The account's own key may label any of its conversations. A sandbox callback token may label **only the conversation it was minted for**; another id is refused with 403 `sprite_may_not_label_another_conversation`.
+         *     The account's own key may label any of its conversations. A sandbox callback token may label **only the conversation it was minted for**; another id is refused with 403 `sprite_may_not_label_another_conversation`. An agent inside a turn does not need this route at all: it sends the `_fountain/labels` ACP extension update instead.
          */
         patch: operations["FountainWeb.ConversationController.labels"];
         trace?: never;

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -10137,6 +10137,8 @@ export interface operations {
                 status?: string;
                 /** @description Return at most this many conversations, most recently updated first (1 to 500; 400 outside that range). Without it the whole list is returned, which on a busy account is hundreds of rows per call — a client that needs one conversation should filter (`agent_id`, `sandbox_id`, `channel_id`) and cap. */
                 limit?: number;
+                /** @description Only conversations carrying these `key:value` labels (#1637). Repeat the parameter to combine them with AND: `?label=env:prod&label=drift:true` keeps the conversations that carry both. `label[]=` is accepted as well. Each value splits on its first colon only, so `label=path:a:b` matches the label `path` with the value `a:b`. 400 `invalid_label_filter` on a value with no colon or an empty key. */
+                label?: string[];
             };
             header?: never;
             path?: never;

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -2033,6 +2033,8 @@ export interface paths {
         /**
          * Message a teammate
          * @description A turn on the teammate's conversation. A parked or reaped sandbox wakes; a conversation past resuming is replaced by a fresh one under the same binding, seeded with this message, so the response names the conversation the message went to. 400 `conversation_busy` while the previous turn is still running (the same shape as `POST /api/conversations/:id/prompts`), 503 while the computer is still starting.
+         *
+         *     `labels` merges onto the conversation the message lands on (#1637), before the turn is queued, so a label the limits refuse leaves the message unsent.
          */
         post: operations["FountainWeb.TeamController.message"];
         delete?: never;
@@ -4599,6 +4601,10 @@ export interface components {
         /** TeamMessageRequest */
         TeamMessageRequest: {
             images?: components["schemas"]["ImageInput"][] | null;
+            /** @description Labels to merge into the conversation this message lands on, whether that is the teammate's current one or the fresh one a retired thread is replaced by. Same limits as everywhere else; null removes a key. */
+            labels?: {
+                [key: string]: string | null;
+            } | null;
             prompt: string;
         };
         /** TeamMessageResponse */
@@ -14372,7 +14378,10 @@ export interface operations {
     };
     "FountainWeb.TeamController.conversations": {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Only conversations carrying these `key:value` labels (#1637). Repeatable and AND-combined, exactly as on `GET /api/conversations`. 400 `invalid_label_filter` on a value with no colon or an empty key. */
+                label?: string[];
+            };
             header?: never;
             path: {
                 agent_id: string;
@@ -14388,6 +14397,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["TeammateConversationListResponse"];
+                };
+            };
+            /** @description Invalid label filter */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
                 };
             };
             /** @description Unauthorized */
@@ -14565,7 +14583,7 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
-            /** @description Forbidden */
+            /** @description A sandbox token labelling another conversation */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -14590,6 +14608,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Invalid labels */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ChangesetError"];
                 };
             };
             /** @description Too Many Requests */

--- a/sdk/typescript/src/http.ts
+++ b/sdk/typescript/src/http.ts
@@ -4,7 +4,7 @@ import type { ResolvedConfig } from "./config.ts";
 export type FetchLike = (input: string, init?: RequestInit) => Promise<Response>;
 
 export interface RequestOptions {
-  query?: Record<string, string | number | boolean | undefined | null>;
+  query?: Record<string, string | number | boolean | string[] | undefined | null>;
   body?: unknown;
   headers?: Record<string, string>;
   signal?: AbortSignal;
@@ -50,6 +50,14 @@ export class HttpClient {
     const url = new URL(path.startsWith("http") ? path : this.config.baseUrl + path);
     for (const [key, value] of Object.entries(query ?? {})) {
       if (value === undefined || value === null || value === "") continue;
+      // An array is a repeated key, not a comma-joined string. That is what
+      // `style: form, explode: true` means in the OpenAPI document, and it is
+      // how `?label=env:prod&label=drift:true` reaches the server; joining
+      // them would send one filter Fountain cannot parse.
+      if (Array.isArray(value)) {
+        for (const item of value) url.searchParams.append(key, String(item));
+        continue;
+      }
       url.searchParams.set(key, String(value));
     }
     return url.toString();

--- a/sdk/typescript/test/resources.test.ts
+++ b/sdk/typescript/test/resources.test.ts
@@ -276,6 +276,17 @@ describe("vault expiry metadata", () => {
     assert.equal(url.searchParams.get("roots_only"), "true");
   });
 
+  test("a label filter goes out as a repeated key, not a joined string", async () => {
+    let requested = "";
+    const fountain = new Fountain({
+      baseUrl: "https://fountain.test", apiKey: "fk_test",
+      fetch: async (url) => { requested = url; return Response.json({ data: [] }); },
+    });
+    await fountain.conversations({ labels: { env: "prod", drift: "true" } });
+    const url = new URL(requested);
+    assert.deepEqual(url.searchParams.getAll("label").sort(), ["drift:true", "env:prod"]);
+  });
+
   test("setLabels merges through PATCH and returns the record", async () => {
     const requests: { url: string; init?: RequestInit }[] = [];
     const fountain = new Fountain({


### PR DESCRIPTION
A receiver that routes on `env=prod` or files a `drift=true` run should not
have to call back for the labels it was already told about. `data.labels`
rides on every `conversation.*` payload, read at dispatch time, and is an
object — empty rather than null — when the conversation carries none.

This stays inside the payload's standing rule, which is ids, a stage, a
status and a duration and nothing else. Labels are ids and facts a caller put
there itself, never content. The manual says so plainly, because the agent in
the sandbox can stamp them too: a label is data your own run wrote, not a
value Fountain derived.

Seventh of nine on #1637.


---

### The stack for #1637

Nine PRs, each based on the one above it. Merge top down, and do not
`--delete-branch` while a child still points at a branch.

| # | branch | owns |
|---|---|---|
| 1 | `stack/1637-labels-column` | the jsonb column, the GIN index, `Conversations.Labels`'s limits, `labels` on create |
| 2 | `stack/1637-labels-writer` | `set_conversation_labels/4`, `_unsafe_merge_labels/3`, the sandbox rule, the audit event, the channel resume |
| 3 | `stack/1637-labels-api` | `PATCH /api/conversations/:id/labels`, `FountainWeb.SandboxKey`, the 403, `labels` on the wire |
| 4 | `stack/1637-label-filter` | `?label=key:value`, `RepeatedQueryParam`, `LabelFilter`, the SDK filter |
| 5 | `stack/1637-team-labels` | labels on a team message, and the same filter on a teammate's list |
| 6 | `stack/1637-acp-stamp` | `_fountain/labels` over the agent's own ACP session |
| 7 | `stack/1637-webhook-labels` | `data.labels` on every `conversation.*` payload |
| 8 | `stack/1637-console-chips` | chips on the console lists, and the dashboard URL filter |
| 9 | `stack/1637-release` | the manual, the CHANGELOG, one SDK release (1.27.0) |

This is #1676 re-cut under the no-big-PRs rule, rebased onto current `main` (re-rebased after #1832-#1839 landed).
The combined tip is byte-identical to #1676 over `apps/`, apart from three
prose fixes the destink and STE gates asked for and the regenerated contract
and SDK types.

Validation on the tip of the stack: `mix precommit` clean, core and ee
**4,911 tests, 0 failures**, `fountain_buzz` 144, `fountain_support` 33. The
SDK contract `--check`, the TypeScript typecheck and its 105 tests pass.
`docs-style.py`, `vale` (0 errors) and `destink` are clean.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SgxmwtJNGJBvgCxSfGBaf

