### PR TITLE
refactor(conversations): the pending family's state round trip moves into Pending

### DIFF
--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -1538,17 +1538,8 @@ defmodule Fountain.Conversations.ConversationServer do
   # another, so a second answer to the same request is "too late" rather
   # than an error in the caller.
   def handle_call({:answer_permission, request_id, option_id}, _from, state) do
-    {reply, turn, pending} =
-      Pending.answer_permission(
-        Pending.from_state(state),
-        state.conversation_id,
-        state.current_turn,
-        state.acp_peer,
-        request_id,
-        option_id
-      )
-
-    {:reply, reply, %{Pending.into_state(state, pending) | current_turn: turn}}
+    {reply, state} = Pending.answer(state, request_id, option_id)
+    {:reply, reply, state}
   end
 
   # A call needs a turn to belong to, and the client following that turn is
@@ -1777,12 +1768,12 @@ defmodule Fountain.Conversations.ConversationServer do
           current_turn: %{pending_permission: %{"request_id" => request_id}}
         } = state
       ) do
-    state = resolve_permission(state, request_id, "timeout", nil)
+    state = Pending.resolve(state, request_id, "timeout", nil)
     fail_transport(state, :permission_timeout_during_runner_reconnect)
   end
 
   def handle_info({:permission_timeout, request_id}, state) do
-    {:noreply, resolve_permission(state, request_id, "timeout", nil)}
+    {:noreply, Pending.resolve(state, request_id, "timeout", nil)}
   end
 
   # The caller never answered a parked tool call (#1202). The agent gets an
@@ -2043,44 +2034,10 @@ defmodule Fountain.Conversations.ConversationServer do
 
   def handle_info(_msg, state), do: {:noreply, state}
 
+  # `Pending.resolve_held/2` is the family's own (#1369); this call site came
+  # from the shared-sandbox reattach fix and moves with it.
   defp fail_transport(state, reason),
-    do: Reattachment.fail_transport(resolve_pending_permission(state, "turn_ended"), reason)
-
-  # The permission request's end: the turn row and timer are the server's to hold.
-  defp resolve_permission(state, request_id, outcome, option_id) do
-    {turn, pending} =
-      Pending.resolve_permission(
-        Pending.from_state(state),
-        state.conversation_id,
-        state.current_turn,
-        state.acp_peer,
-        request_id,
-        outcome,
-        option_id
-      )
-
-    %{Pending.into_state(state, pending) | current_turn: turn}
-  end
-
-  # Resolve whatever is held, if anything, as the turn ends.
-  defp resolve_pending_permission(state, outcome) do
-    {turn, pending} =
-      Pending.resolve_pending_permission(
-        Pending.from_state(state),
-        state.conversation_id,
-        state.current_turn,
-        state.acp_peer,
-        outcome
-      )
-
-    %{Pending.into_state(state, pending) | current_turn: turn}
-  end
-
-  # Everything still parked when the turn ends (`Pending.drop_calls/3`).
-  defp drop_caller_tools(state, outcome) do
-    pending = Pending.drop_calls(Pending.from_state(state), state.conversation_id, outcome)
-    Pending.into_state(state, pending)
-  end
+    do: Reattachment.fail_transport(Pending.resolve_held(state, "turn_ended"), reason)
 
   # The server's own clock stamp: the input `Lifecycle.check/4` reads. Nothing
   # but this process writes it.
@@ -2587,8 +2544,8 @@ defmodule Fountain.Conversations.ConversationServer do
     # Resolve a held permission request as the turn ends (#940): a card left
     # open is a client waiting on an answer that can never come, and the
     # turn's `pending_permission` would stay set on a turn that is over.
-    state = resolve_pending_permission(state, "turn_ended")
-    state = drop_caller_tools(state, "turn_ended")
+    state = Pending.resolve_held(state, "turn_ended")
+    state = Pending.drop(state, "turn_ended")
     state = cancel_autonomous_quiet(state)
 
     turn = TurnMachine.finish(TurnMachine.from_state(state), status, span_attrs, stage_meta)
@@ -2624,29 +2581,12 @@ defmodule Fountain.Conversations.ConversationServer do
   end
 
   defp apply_effect(state, {:ask_permission, request_id, tool, options}),
-    do: ask_permission(state, request_id, tool, options)
+    do: Pending.ask(state, request_id, tool, options)
 
   defp apply_effect(state, {:finish, status, span_attrs, stage_meta}),
     do: finish_acp_turn(state, status, span_attrs, stage_meta)
 
   defp apply_effect(state, {:drop_connection, why}), do: drop_connection(state, why)
-
-  # `ask`: the agent is blocked and a human has to answer (#940). The request
-  # goes on the turn row first, then the stage, then the timeout
-  # (`Pending.ask/6`); the server holds the row and the timer.
-  defp ask_permission(state, request_id, tool, options) do
-    {turn, pending} =
-      Pending.ask(
-        Pending.from_state(state),
-        state.conversation_id,
-        state.current_turn,
-        request_id,
-        tool,
-        options
-      )
-
-    %{Pending.into_state(state, pending) | current_turn: turn}
-  end
 
   # ── the connection (#817) ─────────────────────────────────────────────────
 

--- a/apps/fountain/lib/fountain/conversations/pending.ex
+++ b/apps/fountain/lib/fountain/conversations/pending.ex
@@ -52,14 +52,92 @@ defmodule Fountain.Conversations.Pending do
   def into_state(state, %__MODULE__{} = pending),
     do: %{state | caller_calls: pending.calls, permission_timer: pending.permission_timer}
 
+  @doc """
+  The server's whole pending family, over the server's state (#1369).
+
+  Each of these is `from_state/1`, the operation, then `into_state/2` and the
+  turn row written back. They lived in the `ConversationServer` as a private
+  adapter apiece, which is one round trip of boilerplate per call site in a
+  file that only shrinks. Each takes what it needs from state.
+  """
+  @spec ask(map(), term(), String.t(), list()) :: map()
+  def ask(state, request_id, tool, options) do
+    over(state, fn pending, turn ->
+      ask(pending, state.conversation_id, turn, request_id, tool, options)
+    end)
+  end
+
+  @doc "One request's end, whichever way."
+  @spec resolve(map(), term(), String.t(), String.t() | nil) :: map()
+  def resolve(state, request_id, outcome, option_id) do
+    over(state, fn pending, turn ->
+      resolve_permission(
+        pending,
+        state.conversation_id,
+        turn,
+        state.acp_peer,
+        request_id,
+        outcome,
+        option_id
+      )
+    end)
+  end
+
+  @doc "Whatever is held, if anything, as the turn ends."
+  @spec resolve_held(map(), String.t()) :: map()
+  def resolve_held(state, outcome) do
+    over(state, fn pending, turn ->
+      resolve_pending_permission(pending, state.conversation_id, turn, state.acp_peer, outcome)
+    end)
+  end
+
+  @doc "Everything still parked when the turn ends."
+  @spec drop(map(), String.t()) :: map()
+  def drop(state, outcome) do
+    into_state(state, drop_calls(from_state(state), state.conversation_id, outcome))
+  end
+
+  @doc "A human's answer, with the reply to hand back to them."
+  @spec answer(map(), term(), String.t()) :: {:ok | {:error, term()}, map()}
+  def answer(state, request_id, option_id) do
+    {reply, turn, pending} =
+      answer_permission(
+        from_state(state),
+        state.conversation_id,
+        state.current_turn,
+        state.acp_peer,
+        request_id,
+        option_id
+      )
+
+    {reply, %{into_state(state, pending) | current_turn: turn}}
+  end
+
+  defp over(state, fun) do
+    {turn, pending} = fun.(from_state(state), state.current_turn)
+    %{into_state(state, pending) | current_turn: turn}
+  end
+
   # ── permission requests (#940) ────────────────────────────────────────────
 
-  @doc "Re-arm a persisted request using its original ask time after transport recovery."
+  @doc """
+  Re-arm a persisted request using its original ask time after transport
+  recovery.
+
+  A request that outlived its turn (#1635) is skipped. Its deadline is on the
+  row and its own, and the sweep owns it; arming the in-turn timer over it
+  would deny it at the five-minute ceiling the detach exists to escape. The
+  reattach path only ever passes a `running` turn, and a detached one is
+  `completed`, so this is the belt to that braces.
+  """
   def restore_permission_timer(%__MODULE__{} = pending, turn) do
     if pending.permission_timer, do: Process.cancel_timer(pending.permission_timer)
 
     timer =
       case turn do
+        %{waiting: true} ->
+          nil
+
         %{pending_permission: %{"request_id" => id} = request} ->
           remaining =
             case DateTime.from_iso8601(request["asked_at"] || "") do


### PR DESCRIPTION
The five private round-trip adapters in the server become `Pending` functions over the server's state. No behaviour changes; the server shrinks.

Part 2 of 9 for #1635, on #1852.


Part of #1635
