### PR TITLE
feat(conversations): a turn that ends waiting leaves its request open (#1635)

### DIFF
--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -21,7 +21,7 @@ defmodule Fountain.Conversations.ConversationServer do
   }
 
   alias Fountain.Conversations.{CallbackKey, Checkpoints, CodexChatGPT, Connection}
-  alias Fountain.Conversations.{Conversation, Egress}
+  alias Fountain.Conversations.{Conversation, DetachedRequest, Egress}
   alias Fountain.Conversations.{Lifecycle, McpServers, Output, Pending, Provisioning, Reapply}
   alias Fountain.Conversations.{Reattachment, Redaction, SpriteEnv, TurnMachine}
 
@@ -487,6 +487,10 @@ defmodule Fountain.Conversations.ConversationServer do
       acp_peer: nil,
       # Timer refusing an unanswered permission request (#940).
       permission_timer: nil,
+      # The last `session/request_permission` the peer relayed, as
+      # `DetachedRequest.request_line/2` reads it (#1635): the ask that follows
+      # carries no params, and the per-request timeout is in theirs.
+      acp_request_params: nil,
       # Caller-tool calls parked on the turn (#1202): id => %{name, arguments,
       # turn_id, waiter, timer, result}. `result` is nil while parked and the
       # answer once resolved; entries are dropped when the turn ends.
@@ -1456,9 +1460,14 @@ defmodule Fountain.Conversations.ConversationServer do
   # editor (#708) are peer clients of this door, not fallbacks for one
   # another, so a second answer to the same request is "too late" rather
   # than an error in the caller.
+  # `Pending.holds?/2` is the guard a detached request needs (#1635).
   def handle_call({:answer_permission, request_id, option_id}, _from, state) do
-    {reply, state} = Pending.answer(state, request_id, option_id)
-    {:reply, reply, state}
+    if Pending.holds?(state.current_turn, request_id) do
+      {reply, state} = Pending.answer(state, request_id, option_id)
+      {:reply, reply, state}
+    else
+      {:reply, {:error, :no_pending_permission}, state}
+    end
   end
 
   # A call needs a turn to belong to, and the client following that turn is
@@ -1692,7 +1701,7 @@ defmodule Fountain.Conversations.ConversationServer do
   end
 
   def handle_info({:permission_timeout, request_id}, state) do
-    {:noreply, Pending.resolve(state, request_id, "timeout", nil)}
+    {:noreply, Pending.resolve_if_held(state, request_id, "timeout", nil)}
   end
 
   # The caller never answered a parked tool call (#1202). The agent gets an
@@ -2376,7 +2385,11 @@ defmodule Fountain.Conversations.ConversationServer do
         new_state.stream_tracer
       end
 
-    %{new_state | stream_tracer: tracer}
+    %{
+      new_state
+      | stream_tracer: tracer,
+        acp_request_params: DetachedRequest.request_line(stream, data) || state.acp_request_params
+    }
   end
 
   # Terminal path for an ACP turn. The order matters: stdin closes first so the
@@ -2394,7 +2407,14 @@ defmodule Fountain.Conversations.ConversationServer do
     # Resolve a held permission request as the turn ends (#940): a card left
     # open is a client waiting on an answer that can never come, and the
     # turn's `pending_permission` would stay set on a turn that is over.
-    state = Pending.resolve_held(state, "turn_ended")
+    # Unless the agent asked to keep it (#1635): `:detach_permission` marked
+    # the row first, the connection is dropped right after this (the peer is
+    # still holding the request), and the answer arrives as a new turn.
+    state =
+      if Pending.detached?(state.current_turn),
+        do: state,
+        else: Pending.resolve_held(state, "turn_ended")
+
     state = Pending.drop(state, "turn_ended")
     state = cancel_autonomous_quiet(state)
 
@@ -2432,6 +2452,8 @@ defmodule Fountain.Conversations.ConversationServer do
 
   defp apply_effect(state, {:ask_permission, request_id, tool, options}),
     do: Pending.ask(state, request_id, tool, options)
+
+  defp apply_effect(state, :detach_permission), do: Pending.detach(state)
 
   defp apply_effect(state, {:finish, status, span_attrs, stage_meta}),
     do: finish_acp_turn(state, status, span_attrs, stage_meta)

--- a/apps/fountain/lib/fountain/conversations/pending.ex
+++ b/apps/fountain/lib/fountain/conversations/pending.ex
@@ -4,7 +4,8 @@ defmodule Fountain.Conversations.Pending do
   request the peer asked (#940), and a caller-defined tool call the tool
   bridge parked (#1202).
 
-  A value and the functions that add, answer, deny, expire and drain it.
+  A value and the functions that add, answer, deny, expire, detach and drain
+  it.
   The value is the parked calls with their timers and the permission
   timeout; the permission request itself lives on the turn row, which is
   why a request raised before a deploy is still answerable after one.
@@ -20,7 +21,9 @@ defmodule Fountain.Conversations.Pending do
   """
 
   alias Fountain.Conversations
+  alias Fountain.Conversations.DetachedRequest
   alias Fountain.Conversations.Lifecycle
+  alias Fountain.Conversations.TurnMachine
 
   @type call :: %{
           id: String.t(),
@@ -58,14 +61,26 @@ defmodule Fountain.Conversations.Pending do
   Each of these is `from_state/1`, the operation, then `into_state/2` and the
   turn row written back. They lived in the `ConversationServer` as a private
   adapter apiece, which is one round trip of boilerplate per call site in a
-  file that only shrinks. Each takes what it needs from state.
+  file that only shrinks. `ask/4` reads the request params the server kept
+  (`DetachedRequest.request_line/2`); the rest take what they need from state.
   """
   @spec ask(map(), term(), String.t(), list()) :: map()
   def ask(state, request_id, tool, options) do
+    params = DetachedRequest.params_for(state.acp_request_params, request_id)
+
+    # Consumed, so dropped. Those params are the agent's whole request,
+    # `rawInput` included, and that is tenant data with no reason to sit in a
+    # server's state for the life of a connection.
+    state = %{state | acp_request_params: nil}
+
     over(state, fn pending, turn ->
-      ask(pending, state.conversation_id, turn, request_id, tool, options)
+      ask(pending, state.conversation_id, turn, request_id, tool, options, params)
     end)
   end
+
+  @doc "The turn is ending and its request outlives it (#1635)."
+  @spec detach(map()) :: map()
+  def detach(state), do: over(state, &detach(&1, &2))
 
   @doc "One request's end, whichever way."
   @spec resolve(map(), term(), String.t(), String.t() | nil) :: map()
@@ -81,6 +96,27 @@ defmodule Fountain.Conversations.Pending do
         option_id
       )
     end)
+  end
+
+  @doc """
+  `resolve/4`, but only while the current turn is still holding the request.
+
+  The in-turn permission timer is the one caller that can arrive too late
+  (#1635). `detach/1` cancels it, and `Process.cancel_timer/1` does not recall
+  a message that is already in the mailbox, so a timer that fired just before
+  the `waiting` frame lands against a turn that has detached. Resolving it then
+  would publish a `done` stage denying a request that is still open and still
+  answerable, and record a `conversation.permission_denied` row for something
+  that did not happen, which ADR 0013 forbids. A detached request's deadline is
+  read off the row by the sweep, not by this timer.
+  """
+  @spec resolve_if_held(map(), term(), String.t(), String.t() | nil) :: map()
+  def resolve_if_held(state, request_id, outcome, option_id) do
+    if holds?(state.current_turn, request_id) do
+      resolve(state, request_id, outcome, option_id)
+    else
+      state
+    end
   end
 
   @doc "Whatever is held, if anything, as the turn ends."
@@ -173,17 +209,35 @@ defmodule Fountain.Conversations.Pending do
   hang forever; it burns the whole lifetime and then takes the agent's memory
   with it (#649).
 
+  That reasoning stops at the turn's end, which is what `detach/2` exists for
+  (#1635): an agent that ends the turn waiting holds nothing open, so its
+  request keeps `detached_timeout_ms` instead and the sweep fires it.
+
   Returns the turn row with the request on it (unchanged when there is no
   turn) and the value with the timer armed.
   """
-  @spec ask(t(), String.t(), Conversations.Turn.t() | nil, term(), String.t(), list()) ::
-          {Conversations.Turn.t() | nil, t()}
-  def ask(%__MODULE__{} = pending, conversation_id, turn, request_id, tool, options) do
+  @spec ask(
+          t(),
+          String.t(),
+          Conversations.Turn.t() | nil,
+          term(),
+          String.t(),
+          list(),
+          map() | nil
+        ) :: {Conversations.Turn.t() | nil, t()}
+  def ask(%__MODULE__{} = pending, conversation_id, turn, request_id, tool, options, params) do
+    detached_timeout_ms =
+      DetachedRequest.timeout_ms(params, effective_ask_timeout_seconds(conversation_id))
+
     request = %{
       "request_id" => request_id,
       "tool" => tool,
       "options" => options,
-      "asked_at" => DateTime.utc_now() |> DateTime.to_iso8601()
+      "asked_at" => DateTime.utc_now() |> DateTime.to_iso8601(),
+      # Decided here, spent only if the turn ends waiting (#1635). Announced
+      # now so a card can say how long it has once it detaches, rather than
+      # learning it from a second event.
+      "detached_timeout_ms" => detached_timeout_ms
     }
 
     turn =
@@ -202,7 +256,11 @@ defmodule Fountain.Conversations.Pending do
       # The agent's own list, verbatim. A client must never offer an option
       # that is not on it.
       options: options,
-      timeout_ms: Lifecycle.ask_timeout_ms()
+      timeout_ms: Lifecycle.ask_timeout_ms(),
+      # What the request gets instead if the agent ends the turn waiting on it
+      # (#1635). The two differ only where a per-request or policy-level
+      # `ask_timeout` is set.
+      detached_timeout_ms: detached_timeout_ms
     })
 
     timer =
@@ -213,6 +271,14 @@ defmodule Fountain.Conversations.Pending do
       )
 
     {turn, %{pending | permission_timer: timer}}
+  end
+
+  # The conversation's own `ask_timeout`, agent and launch merged
+  # (`Fountain.PermissionPolicy`). Ownership: the caller is the server for this
+  # conversation, established at its `init/1`.
+  defp effective_ask_timeout_seconds(conversation_id) do
+    conv = Conversations._unsafe_get_conversation!(conversation_id)
+    TurnMachine.effective_ask_timeout_seconds(conv, TurnMachine.agent_for(conv))
   end
 
   @doc """
@@ -318,6 +384,63 @@ defmodule Fountain.Conversations.Pending do
 
     {turn, %{pending | permission_timer: nil}}
   end
+
+  @doc """
+  The turn is ending and the agent asked to keep its request (#1635).
+
+  The agent answered `session/prompt` with the `waiting` stop reason while a
+  request was still held, so instead of denying it as the turn's end normally
+  does, the request outlives the turn: the row is marked `waiting`, the
+  deadline decided at ask time is written onto it, and the in-process timer is
+  dropped. From here the request is the sweep's
+  (`Fountain.Workers.DetachedRequestSweeper`), because the sandbox is about to
+  park and this process is about to have nothing left to do.
+
+  Returns the turn row with the flag on it and the value with no timer.
+  """
+  @spec detach(t(), Conversations.Turn.t() | nil) :: {Conversations.Turn.t() | nil, t()}
+  def detach(%__MODULE__{} = pending, %{pending_permission: request} = turn)
+      when is_map(request) do
+    if pending.permission_timer, do: Process.cancel_timer(pending.permission_timer)
+
+    deadline =
+      request
+      |> Map.get("detached_timeout_ms")
+      |> case do
+        ms when is_integer(ms) and ms > 0 -> ms
+        _ -> Lifecycle.ask_timeout_ms()
+      end
+      |> DetachedRequest.deadline()
+
+    {:ok, turn} =
+      Conversations._unsafe_update_turn(turn, %{
+        waiting: true,
+        permission_deadline: deadline,
+        pending_permission: Map.put(request, "deadline", DateTime.to_iso8601(deadline))
+      })
+
+    {turn, %{pending | permission_timer: nil}}
+  end
+
+  def detach(%__MODULE__{} = pending, turn), do: {turn, pending}
+
+  @doc """
+  Whether this turn is holding `request_id` open inside itself.
+
+  False for a turn that ended `waiting` (#1635): its request is on the row,
+  but the peer that raised it is driving nothing, so an answer relayed down
+  that connection would be reported as landed and reach nobody.
+  """
+  @spec holds?(Conversations.Turn.t() | nil, term()) :: boolean()
+  def holds?(%{pending_permission: %{"request_id" => id}, waiting: waiting}, request_id),
+    do: id == request_id and waiting != true
+
+  def holds?(_turn, _request_id), do: false
+
+  @doc "Whether this turn ended holding a request that outlived it (#1635)."
+  @spec detached?(Conversations.Turn.t() | nil) :: boolean()
+  def detached?(%{waiting: true, pending_permission: request}) when is_map(request), do: true
+  def detached?(_turn), do: false
 
   @doc "The tool the turn is blocked on, or nil."
   @spec pending_tool(Conversations.Turn.t() | nil) :: String.t() | nil

--- a/apps/fountain/lib/fountain/conversations/turn_machine.ex
+++ b/apps/fountain/lib/fountain/conversations/turn_machine.ex
@@ -29,6 +29,10 @@ defmodule Fountain.Conversations.TurnMachine do
       by the failure rather than by a wake);
     * `{:ask_permission, request_id, tool, options}` — the held request:
       its row, its stage, its timeout (the pending family, #1375);
+    * `:detach_permission` — the turn is ending `waiting` and its request
+      outlives it (#1635); applied before `{:finish, …}`, which then leaves
+      the request alone, and followed by `{:drop_connection, …}`, because
+      the peer is still holding the request it raised;
     * `{:finish, status, span_attrs, stage_meta}` — end the turn: the
       server resolves what is pending, cancels the quiet timer, then calls
       `finish/4`;
@@ -73,6 +77,7 @@ defmodule Fountain.Conversations.TurnMachine do
           | {:session_id, String.t()}
           | {:forget_runtime_session, String.t(), String.t()}
           | {:ask_permission, term(), String.t(), list()}
+          | :detach_permission
           | {:finish, String.t(), map(), map()}
           | {:drop_connection, String.t()}
 
@@ -369,16 +374,42 @@ defmodule Fountain.Conversations.TurnMachine do
   # `usage` is the turn's end-of-turn token figure (#827), recorded once here
   # — the response is the only place the runtime reports it — before the turn
   # row is closed. nil records nothing.
+  #
+  # `waiting` is the fourth stop reason, and the only one that changes what
+  # the turn's end does rather than what it is called (#1635). An agent that
+  # sends `session/request_permission` and then answers the prompt with it is
+  # saying the wait is longer than a turn: the request is detached instead of
+  # denied, the turn still ends `completed`, and the sandbox parks on the
+  # usual bound with the card still up. With nothing held it means nothing,
+  # and the turn ends as any other completed turn does.
+  #
+  # **The connection goes with it**, which the usual end (#817) keeps alive.
+  # The peer still holds the request it raised: `hold_permission` filled its
+  # single `pending_permission` slot, and only an answer or a denial clears
+  # it — neither of which the detached path sends, since the answer arrives
+  # as a new turn instead. claude-agent-acp and codex both number their
+  # requests from 0 *per turn* (`mint_request_id/1`), so the resume turn's
+  # first `session/request_permission` would arrive under the same JSON-RPC
+  # id, match the peer's `held?/2` against the stale hold, and be swallowed:
+  # no response, no report, no card, no timeout, and an agent blocked with
+  # nothing to reclaim it (`SANDBOX_MAX_LIFETIME_HOURS` is 0 by default).
+  # A fresh peer costs one handshake, and is what the idle park does minutes
+  # later anyway.
   def handle(%__MODULE__{} = turn, {:done, stop_reason, usage}, ctx) do
     # An answered prompt is not necessarily finished work. Token/request limits
     # and unknown future stop reasons must not become success for API consumers.
-    status = if stop_reason == "end_turn", do: "completed", else: "failed"
+    # `waiting` is the one other stop reason that is not a failure (#1635):
+    # the agent chose to end the turn, and it is `completed` whether or not a
+    # request was held. Everything else stays `failed`, as 8a05804c made it.
+    status = if stop_reason in ["end_turn", "waiting"], do: "completed", else: "failed"
     record_usage(turn, with_inference(usage, ctx))
+    finish = {:finish, status, %{"stop_reason" => stop_reason}, %{stop_reason: stop_reason}}
 
-    {turn,
-     [
-       {:finish, status, %{"stop_reason" => stop_reason}, %{stop_reason: stop_reason}}
-     ]}
+    if waiting?(stop_reason, turn.row) do
+      {turn, [:detach_permission, finish, {:drop_connection, "permission_detached"}]}
+    else
+      {turn, [finish]}
+    end
   end
 
   # #655: the org has refused this account's Claude OAuth token. Left alone,
@@ -588,7 +619,9 @@ defmodule Fountain.Conversations.TurnMachine do
       turn.conversation_id,
       "turn",
       if(status == "completed", do: "done", else: "failed"),
-      Map.merge(%{turn_id: row.id, turn_number: row.turn_number}, stage_meta)
+      %{turn_id: row.id, turn_number: row.turn_number}
+      |> Map.merge(stage_meta)
+      |> Map.merge(waiting_meta(row))
     )
 
     end_span(
@@ -604,6 +637,23 @@ defmodule Fountain.Conversations.TurnMachine do
 
     %{turn | row: nil, span: nil, metrics: nil, tracer: nil}
   end
+
+  defp waiting?("waiting", %{pending_permission: %{"request_id" => _}}), do: true
+  defp waiting?(_stop_reason, _row), do: false
+
+  # A turn that ended holding a request (#1635) says so where every client
+  # already looks. The `request`/`started` event announced the request; this
+  # is what tells a card watching the stream that the request outlived the
+  # turn and by when it has to be answered.
+  #
+  # The two fields are prefixed rather than bare. A client pairs a permission
+  # card to its resolution on `request_id`, and a bare one on a `turn` event
+  # would pair to a card that event is not about.
+  defp waiting_meta(%{waiting: true, pending_permission: %{"request_id" => id}} = row) do
+    %{waiting: true, waiting_request_id: id, waiting_deadline: row.permission_deadline}
+  end
+
+  defp waiting_meta(_row), do: %{}
 
   @doc """
   The interrupt's first half: the row `interrupted`, the stage, the tracer

--- a/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
@@ -10,6 +10,7 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
 
   use Fountain.ConversationServerCase
 
+  alias Fountain.Conversations.Lifecycle
   alias Managoat.Runtimes.ACP
 
   defp acp_agent(user, runtime \\ "claude") do
@@ -1632,6 +1633,239 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
 
       assert [event] = done
       assert Jason.decode!(event.data)["outcome"] == "turn_ended"
+    end
+  end
+
+  describe "requests that outlive a turn (#1635)" do
+    defp waiting_agent(user, policy \\ %{"Bash" => "ask"}) do
+      insert_agent(user_id: user.id, runtime: "claude", permission_policy: policy)
+    end
+
+    # Same frame as `raise_permission/3`, plus whatever the agent puts in the
+    # request's own `_meta`.
+    defp raise_permission_with(pid, ref, id, meta) do
+      params =
+        %{
+          "toolCall" => %{"title" => "Bash", "kind" => "execute"},
+          "options" => [
+            %{"optionId" => "yes", "kind" => "allow_once"},
+            %{"optionId" => "no", "kind" => "reject_once"}
+          ]
+        }
+        |> then(&if meta == %{}, do: &1, else: Map.put(&1, "_meta", meta))
+
+      line =
+        Jason.encode!(%{
+          "jsonrpc" => "2.0",
+          "id" => id,
+          "method" => "session/request_permission",
+          "params" => params
+        }) <> "\n"
+
+      send(pid, {:stdout, %{ref: ref}, line})
+      settle(pid)
+
+      :sys.get_state(pid).current_turn.pending_permission["request_id"]
+    end
+
+    # The harness starts servers outside Horde, so `ConversationServer.whereis/1`
+    # cannot see them. A detached answer goes through `send_prompt/4`, which
+    # asks the registry first, so the resume turn has to be able to find this
+    # server rather than waking a second one.
+    defp stages(conv_id, stage, state) do
+      conv_id
+      |> Conversations._unsafe_list_log_events()
+      |> Enum.filter(&(&1.kind == "stage" and &1.stage == stage and &1.state == state))
+      |> Enum.map(&Jason.decode!(&1.data))
+    end
+
+    defp waiting_turn(conv_id) do
+      Fountain.Repo.one!(
+        from(t in Fountain.Conversations.Turn,
+          where: t.conversation_id == ^conv_id and t.waiting == true
+        )
+      )
+    end
+
+    test "the agent ends the turn waiting and the request stays pending" do
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id, agent: waiting_agent(user))
+      {pid, ref} = start_acp_turn(conv)
+      prompt_id = drive_to_prompt(pid, ref)
+
+      request_id = raise_permission_with(pid, ref, 401, %{})
+      reply(pid, ref, prompt_id, %{"stopReason" => "waiting"})
+
+      # The turn is over, and it is a completed turn, not a failed one.
+      state = :sys.get_state(pid)
+      assert state.current_turn == nil
+
+      turn = waiting_turn(conv.id)
+      assert turn.status == "completed"
+      assert turn.waiting
+      assert turn.pending_permission["request_id"] == request_id
+      assert turn.permission_deadline
+
+      # And nothing denied it on the way out.
+      assert stages(conv.id, "request", "done") == []
+
+      # The conversation is idle, which is what lets the sandbox park.
+      assert Fountain.Repo.reload(conv).status == "idle"
+    end
+
+    test "the turn stage says the turn ended waiting, and on what" do
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id, agent: waiting_agent(user))
+      {pid, ref} = start_acp_turn(conv)
+      prompt_id = drive_to_prompt(pid, ref)
+
+      request_id = raise_permission_with(pid, ref, 402, %{})
+      reply(pid, ref, prompt_id, %{"stopReason" => "waiting"})
+
+      assert [done] = stages(conv.id, "turn", "done")
+      assert done["waiting"] == true
+      assert done["stop_reason"] == "waiting"
+      assert done["waiting_deadline"]
+
+      # Prefixed, so a client pairing permission cards on `request_id` does not
+      # pair one to this event.
+      assert done["waiting_request_id"] == request_id
+      refute Map.has_key?(done, "request_id")
+    end
+
+    test "waiting with nothing held is an ordinary completed turn" do
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id, agent: waiting_agent(user))
+      {pid, ref} = start_acp_turn(conv)
+      prompt_id = drive_to_prompt(pid, ref)
+
+      reply(pid, ref, prompt_id, %{"stopReason" => "waiting"})
+
+      turn = Fountain.Repo.one!(from(t in Fountain.Conversations.Turn))
+      assert turn.status == "completed"
+      refute turn.waiting
+      refute turn.permission_deadline
+
+      assert [done] = stages(conv.id, "turn", "done")
+      refute Map.has_key?(done, "waiting")
+    end
+
+    test "a request still held when the turn ends normally is still denied" do
+      # The `waiting` stop reason is the only thing that changes this, and a
+      # turn that simply ends must not start leaving cards open.
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id, agent: waiting_agent(user))
+      {pid, ref} = start_acp_turn(conv)
+      prompt_id = drive_to_prompt(pid, ref)
+
+      _request_id = raise_permission_with(pid, ref, 403, %{})
+      reply(pid, ref, prompt_id, %{"stopReason" => "end_turn"})
+
+      assert [done] = stages(conv.id, "request", "done")
+      assert done["outcome"] == "turn_ended"
+
+      assert Fountain.Repo.all(from(t in Fountain.Conversations.Turn, where: t.waiting == true)) ==
+               []
+    end
+
+    test "the request's own _meta timeout is honoured, past the idle bound" do
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id, agent: waiting_agent(user))
+      {pid, ref} = start_acp_turn(conv)
+      prompt_id = drive_to_prompt(pid, ref)
+
+      two_days = 2 * 24 * 3600
+
+      _request_id =
+        raise_permission_with(pid, ref, 404, %{"fountain" => %{"timeout" => two_days}})
+
+      # Announced at ask time, so a card knows what it gets if the turn ends.
+      assert [started] = stages(conv.id, "request", "started")
+      assert started["detached_timeout_ms"] == two_days * 1000
+      assert started["timeout_ms"] == Lifecycle.ask_timeout_ms()
+
+      reply(pid, ref, prompt_id, %{"stopReason" => "waiting"})
+
+      deadline = waiting_turn(conv.id).permission_deadline
+      idle_seconds = Lifecycle.idle_timeout_seconds()
+
+      assert DateTime.diff(deadline, DateTime.utc_now()) > idle_seconds
+    end
+
+    test "the policy ask_timeout is used when the request names none" do
+      user = insert_verified_user()
+      agent = waiting_agent(user, %{"Bash" => "ask", "ask_timeout" => 4 * 3600})
+      conv = insert_conversation(user_id: user.id, agent: agent)
+      {pid, ref} = start_acp_turn(conv)
+      prompt_id = drive_to_prompt(pid, ref)
+
+      _request_id = raise_permission_with(pid, ref, 405, %{})
+      assert [started] = stages(conv.id, "request", "started")
+      assert started["detached_timeout_ms"] == 4 * 3600 * 1000
+
+      reply(pid, ref, prompt_id, %{"stopReason" => "waiting"})
+
+      deadline = waiting_turn(conv.id).permission_deadline
+      assert_in_delta DateTime.diff(deadline, DateTime.utc_now()), 4 * 3600, 30
+    end
+
+    test "with neither, a detached request keeps the global ceiling" do
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id, agent: waiting_agent(user))
+      {pid, ref} = start_acp_turn(conv)
+      prompt_id = drive_to_prompt(pid, ref)
+
+      _request_id = raise_permission_with(pid, ref, 406, %{})
+      reply(pid, ref, prompt_id, %{"stopReason" => "waiting"})
+
+      deadline = waiting_turn(conv.id).permission_deadline
+      expected = div(Lifecycle.ask_timeout_ms(), 1000)
+      assert_in_delta DateTime.diff(deadline, DateTime.utc_now()), expected, 30
+    end
+
+    test "the turn's end closes the connection, so the resume turn gets a fresh peer" do
+      # The peer holds the request it raised in a single slot that only an
+      # answer or a denial clears, and the detached path sends neither. Keeping
+      # the connection would carry that hold into the resume turn.
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id, agent: waiting_agent(user))
+      {pid, ref} = start_acp_turn(conv)
+      prompt_id = drive_to_prompt(pid, ref)
+
+      _request_id = raise_permission_with(pid, ref, 407, %{})
+      assert :sys.get_state(pid).acp_peer
+
+      reply(pid, ref, prompt_id, %{"stopReason" => "waiting"})
+
+      state = :sys.get_state(pid)
+      assert state.acp_peer == nil
+      assert state.current_command == nil
+    end
+
+    test "a permission timeout still in flight when the turn detaches is ignored" do
+      # `Process.cancel_timer/1` does not recall a message already in the
+      # mailbox, so the in-turn timer can fire between the ask and the
+      # `waiting` frame. Resolving it here would deny a request that is still
+      # open: every attached card would settle, and a
+      # `conversation.permission_denied` row would record what did not happen.
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id, agent: waiting_agent(user))
+      {pid, ref} = start_acp_turn(conv)
+      prompt_id = drive_to_prompt(pid, ref)
+
+      request_id = raise_permission_with(pid, ref, 499, %{})
+      reply(pid, ref, prompt_id, %{"stopReason" => "waiting"})
+
+      turn = waiting_turn(conv.id)
+
+      send(pid, {:permission_timeout, request_id})
+      settle(pid)
+
+      after_turn = Fountain.Repo.reload(turn)
+      assert after_turn.waiting
+      assert after_turn.pending_permission["request_id"] == request_id
+      assert after_turn.permission_deadline == turn.permission_deadline
+      assert stages(conv.id, "request", "done") == []
     end
   end
 

--- a/apps/fountain/test/fountain/conversations/pending_test.exs
+++ b/apps/fountain/test/fountain/conversations/pending_test.exs
@@ -92,12 +92,12 @@ defmodule Fountain.Conversations.PendingTest do
       Process.cancel_timer(pending.permission_timer)
     end
 
-    test "ask/6 puts it on the row, announces it and arms the timeout", %{
+    test "ask/7 puts it on the row, announces it and arms the timeout", %{
       conv: conv,
       turn: turn,
       pending: pending
     } do
-      {turn, pending} = Pending.ask(pending, conv.id, turn, 7, "bash", ["yes", "no"])
+      {turn, pending} = Pending.ask(pending, conv.id, turn, 7, "bash", ["yes", "no"], 60_000)
 
       assert %{"request_id" => 7, "tool" => "bash", "options" => ["yes", "no"], "asked_at" => _} =
                turn.pending_permission
@@ -113,11 +113,11 @@ defmodule Fountain.Conversations.PendingTest do
       Process.cancel_timer(pending.permission_timer)
     end
 
-    test "ask/6 with no turn announces and arms, with nothing to persist on", %{
+    test "ask/7 with no turn announces and arms, with nothing to persist on", %{
       conv: conv,
       pending: pending
     } do
-      {nil, pending} = Pending.ask(pending, conv.id, nil, 7, "bash", [])
+      {nil, pending} = Pending.ask(pending, conv.id, nil, 7, "bash", [], 60_000)
       assert [{"started", _}] = stages(conv.id, "request")
       Process.cancel_timer(pending.permission_timer)
     end
@@ -133,7 +133,7 @@ defmodule Fountain.Conversations.PendingTest do
       turn: turn,
       pending: pending
     } do
-      {turn, pending} = Pending.ask(pending, conv.id, turn, 7, "bash", ["yes"])
+      {turn, pending} = Pending.ask(pending, conv.id, turn, 7, "bash", ["yes"], 60_000)
       timer = pending.permission_timer
       peer = fake_peer()
 
@@ -156,7 +156,7 @@ defmodule Fountain.Conversations.PendingTest do
       turn: turn,
       pending: pending
     } do
-      {turn, pending} = Pending.ask(pending, conv.id, turn, 7, "bash", ["yes"])
+      {turn, pending} = Pending.ask(pending, conv.id, turn, 7, "bash", ["yes"], 60_000)
       peer = fake_peer()
 
       {turn, _pending} =
@@ -182,7 +182,7 @@ defmodule Fountain.Conversations.PendingTest do
       assert {nil, ^pending} =
                Pending.resolve_pending_permission(pending, conv.id, nil, nil, "turn_ended")
 
-      {turn, pending} = Pending.ask(pending, conv.id, turn, 9, "rm", [])
+      {turn, pending} = Pending.ask(pending, conv.id, turn, 9, "rm", [], 60_000)
 
       {turn, pending} =
         Pending.resolve_pending_permission(pending, conv.id, turn, nil, "turn_ended")
@@ -212,7 +212,7 @@ defmodule Fountain.Conversations.PendingTest do
           end
         end)
 
-      {turn, pending} = Pending.ask(pending, conv.id, turn, 7, "bash", ["yes"])
+      {turn, pending} = Pending.ask(pending, conv.id, turn, 7, "bash", ["yes"], 60_000)
 
       assert {:ok, turn, pending} =
                Pending.answer_permission(pending, conv.id, turn, peer, 7, "yes")


### PR DESCRIPTION
The `waiting` stop reason: the request is detached instead of denied, the turn ends `completed`, the deadline goes on the row and the connection is dropped so the resume turn's first request cannot collide with the held one. One deviation from #1678: `waiting` joins `end_turn` as a completed stop reason, because 8a05804c narrowed that rule after the branch was cut.

Part 4 of 9 for #1635, on #1854.


Part of #1635
