### PR TITLE
feat(workers): deny a request that outlived its turn and then ran out of time (#1635)

### DIFF
--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -4262,6 +4262,48 @@ defmodule Fountain.Conversations do
     end
   end
 
+  @doc """
+  Deny a detached request whose deadline has passed, and tell the agent
+  (#1635).
+
+  The denial picks from the options the agent itself offered, never an id it
+  did not send. Recorded as `conversation.permission_denied` with the sweep as
+  the actor, because no human was at the keyboard and saying otherwise would
+  be a lie about who decided.
+  """
+  @spec _unsafe_expire_detached_request(Turn.t(), keyword()) ::
+          :ok | {:error, term()}
+  def _unsafe_expire_detached_request(%Turn{} = turn, opts \\ []) do
+    request = turn.pending_permission
+    option_id = DetachedRequest.deny_option_id(request)
+    actor = Keyword.get(opts, :actor, "system:detached_request_sweeper")
+
+    # The gate first, for the same reason the answer door applies it first: a
+    # request resolved into a prompt nobody can deliver is gone, the agent is
+    # never told, and there is no second copy to retry from. The deadline has
+    # passed either way, so leaving the row is the safe half of the trade —
+    # the sweep is back in a minute.
+    #
+    # A conversation that is over is the exception: no turn will ever carry
+    # the denial, so the request is resolved and the card stops waiting.
+    case _unsafe_resume_gate(turn.conversation_id) do
+      :ok ->
+        with :ok <- _unsafe_resolve_detached_request(turn, "timeout", option_id) do
+          record_permission_denied(turn.conversation_id, request["tool"], "timeout", actor: actor)
+          resume_after_request(turn, request, "timeout", option_id, actor: actor)
+        end
+
+      {:error, :gone} ->
+        with :ok <- _unsafe_resolve_detached_request(turn, "timeout", option_id) do
+          record_permission_denied(turn.conversation_id, request["tool"], "timeout", actor: actor)
+          :ok
+        end
+
+      {:error, _} = err ->
+        err
+    end
+  end
+
   # The resolution reaches the agent as a new turn, because the peer that
   # raised the request is gone and its JSON-RPC id with it. `send_prompt/4`
   # wakes a suspended sandbox on the way, which is the whole point of letting
@@ -4296,17 +4338,19 @@ defmodule Fountain.Conversations do
   Record that the permission policy withheld a tool from a running agent.
 
   Called by the `ConversationServer` when its peer reports a refusal (#939).
-  The actor is `sprite`: the agent asked, the policy answered, and no human was
-  involved — attributing it to the person who happened to write the policy
-  would be a lie about who was at the keyboard.
+  The actor defaults to `sprite`: the agent asked, the policy answered, and no
+  human was involved — attributing it to the person who happened to write the
+  policy would be a lie about who was at the keyboard. A detached request that
+  ran out of time (#1635) passes the sweep instead, for the same reason.
 
   Only refusals are recorded. A turn makes dozens of tool calls and a row per
   allow would make the trail a second copy of the transcript, which 0013
   forbids for exactly this reason. The tool's *input* is never recorded, only
   its name and the verdict.
   """
-  @spec record_permission_denied(binary(), String.t() | nil, String.t()) :: :ok
-  def record_permission_denied(conversation_id, tool, verdict) when is_binary(conversation_id) do
+  @spec record_permission_denied(binary(), String.t() | nil, String.t(), keyword()) :: :ok
+  def record_permission_denied(conversation_id, tool, verdict, opts \\ [])
+      when is_binary(conversation_id) do
     case _unsafe_get_conversation(conversation_id) do
       nil ->
         :ok
@@ -4317,7 +4361,7 @@ defmodule Fountain.Conversations do
           action: "conversation.permission_denied",
           resource_type: "conversation",
           resource_id: conv.id,
-          actor: "sprite",
+          actor: Keyword.get(opts, :actor, "sprite"),
           metadata: %{"tool" => tool, "verdict" => verdict}
         })
 

--- a/apps/fountain/lib/fountain/workers/detached_request_sweeper.ex
+++ b/apps/fountain/lib/fountain/workers/detached_request_sweeper.ex
@@ -1,0 +1,90 @@
+defmodule Fountain.Workers.DetachedRequestSweeper do
+  @moduledoc """
+  Denies permission requests that outlived their turn and then ran out of
+  time (#1635).
+
+  A request held inside a running turn is timed by a process timer in the
+  `ConversationServer`. A detached one cannot be: the whole point of it is
+  that the sandbox parks and the server stops while the request waits, and a
+  deploy in the middle of a two-day wait would drop the timer with nothing to
+  notice. So the deadline lives on the turn row (`turns.permission_deadline`,
+  with a partial index over `waiting`) and this sweep is what reads it.
+
+  Expiry is a denial, which is the only safe default, and the denial reaches
+  the agent the same way an answer does: the request is resolved on the row
+  and a new turn is opened carrying the outcome, waking the sandbox. The
+  option it names is one the agent itself offered.
+
+  The grain is a minute. A detached deadline is hours or days, so a minute of
+  overshoot is immaterial, and the query is one indexed read that is empty
+  almost every time. The batch is capped so a backlog cannot wake a hundred
+  sandboxes at once.
+  """
+
+  use Oban.Worker, queue: :maintenance, max_attempts: 3
+
+  import Ecto.Query
+
+  require Logger
+
+  alias Fountain.Conversations
+  alias Fountain.Conversations.Turn
+  alias Fountain.Repo
+
+  @sweep_limit 25
+
+  @impl Oban.Worker
+  def perform(_job) do
+    expired = sweep_expired_requests()
+
+    if expired > 0, do: Logger.info("detached_request_sweeper: expired=#{expired}")
+
+    :telemetry.execute([:fountain, :detached_request_sweeper, :run], %{expired: expired}, %{})
+
+    :ok
+  end
+
+  @doc false
+  def sweep_expired_requests(now \\ DateTime.utc_now()) do
+    Turn
+    |> where([t], t.waiting == true and not is_nil(t.pending_permission))
+    |> where([t], t.permission_deadline <= ^now)
+    |> order_by([t], asc: t.permission_deadline)
+    |> limit(^@sweep_limit)
+    |> Repo.all()
+    |> Enum.count(&expire/1)
+  end
+
+  # Ownership: a system sweep, which ADR 0013 and the `_unsafe_` rules name as
+  # a legitimate caller. The resolution is guarded on the request id, so a
+  # client answering in the same second wins or loses cleanly rather than
+  # both landing.
+  #
+  # A conversation that cannot take the resume turn right now — a turn of its
+  # own is running, the account is suspended, the balance is spent — leaves
+  # the row exactly as it was. The deadline has passed, so the denial is owed
+  # either way, but resolving it into a prompt nobody delivers loses it with
+  # nothing to retry from. This runs every minute; the next one carries it.
+  defp expire(%Turn{} = turn) do
+    case Conversations._unsafe_expire_detached_request(turn) do
+      :ok ->
+        Logger.info(
+          "detached_request_sweeper: denied request on turn #{turn.id} " <>
+            "(conversation #{turn.conversation_id}) after its deadline"
+        )
+
+        true
+
+      {:error, :no_pending_permission} ->
+        false
+
+      {:error, reason} ->
+        Logger.info(
+          "detached_request_sweeper: leaving the request on turn #{turn.id} " <>
+            "(conversation #{turn.conversation_id}) for the next sweep: #{inspect(reason)}"
+        )
+
+        false
+    end
+  end
+end

--- a/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
@@ -2059,6 +2059,40 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
       assert answered.metadata["request_id"] == request_id
     end
 
+    test "the expiry opens the same resume turn, with the denial" do
+      user = insert_verified_user()
+      conv = insert_conversation(user_id: user.id, agent: waiting_agent(user))
+      {pid, ref} = start_acp_turn(conv)
+      prompt_id = drive_to_prompt(pid, ref)
+
+      request_id = raise_permission_with(pid, ref, 410, %{})
+      reply(pid, ref, prompt_id, %{"stopReason" => "waiting"})
+      register(pid, conv.id)
+
+      # Age the deadline past, as a sweep an hour later would find it.
+      turn = waiting_turn(conv.id)
+
+      {:ok, _} =
+        Fountain.Repo.update(
+          Ecto.Changeset.change(turn,
+            permission_deadline:
+              DateTime.utc_now() |> DateTime.add(-60) |> DateTime.truncate(:second)
+          )
+        )
+
+      assert Fountain.Workers.DetachedRequestSweeper.sweep_expired_requests() == 1
+      settle(pid)
+
+      params = drive_to_resume_prompt(pid, ref)
+      assert [%{"text" => text}] = params["prompt"]
+
+      assert %{"fountain/permission_answer" => answer} = Jason.decode!(text)
+      assert answer["request_id"] == request_id
+      assert answer["outcome"] == "timeout"
+      # The agent's own rejection, never an invented id.
+      assert answer["option_id"] == "no"
+    end
+
     test "the request webhooks fire on the ask and on the resolution" do
       user = insert_verified_user()
       conv = insert_conversation(user_id: user.id, agent: waiting_agent(user))

--- a/apps/fountain/test/fountain/conversations/detached_request_test.exs
+++ b/apps/fountain/test/fountain/conversations/detached_request_test.exs
@@ -16,6 +16,7 @@ defmodule Fountain.Conversations.DetachedRequestTest do
   alias Fountain.Audit
   alias Fountain.Conversations
   alias Fountain.Conversations.{ConversationServer, DetachedRequest}
+  alias Fountain.Workers.DetachedRequestSweeper
 
   @options [
     %{"optionId" => "allow", "kind" => "allow_once", "name" => "Apply"},
@@ -356,6 +357,120 @@ defmodule Fountain.Conversations.DetachedRequestTest do
                Conversations.answer_permission_request(conv.id, user.id, "7.abc", "allow")
 
       assert Repo.reload(turn).waiting
+    end
+  end
+
+  describe "the sweep" do
+    test "denies a request past its deadline and tells the agent" do
+      %{conv: conv, turn: turn} = waiting_conversation(deadline: hours_from_now(-1))
+      record_wake()
+
+      assert DetachedRequestSweeper.sweep_expired_requests() == 1
+
+      reloaded = Repo.reload(turn)
+      refute reloaded.waiting
+      refute reloaded.pending_permission
+
+      assert [event] = request_stages(conv.id, "done")
+      assert event["outcome"] == "timeout"
+      # Chosen from the agent's own list, never invented.
+      assert event["option_id"] == "deny"
+
+      assert_receive {:resume_prompt, prompt}
+
+      assert %{"fountain/permission_answer" => %{"outcome" => "timeout", "option_id" => "deny"}} =
+               Jason.decode!(prompt)
+    end
+
+    test "the denial is audited to the sweep, because no human decided it" do
+      %{user: user} = waiting_conversation(deadline: hours_from_now(-1))
+      record_wake()
+
+      assert DetachedRequestSweeper.sweep_expired_requests() == 1
+
+      assert denied =
+               user.id
+               |> Audit.list_recent_for_user(50)
+               |> Enum.find(&(&1.action == "conversation.permission_denied"))
+
+      assert denied.actor == "system:detached_request_sweeper"
+      assert denied.metadata["tool"] == "Bash"
+      assert denied.metadata["verdict"] == "timeout"
+    end
+
+    test "a running turn leaves the request for the next sweep" do
+      # The denial is owed, but the turn that carries it cannot queue behind a
+      # turn already in flight. Resolving anyway would lose it with nothing to
+      # retry from.
+      %{conv: conv, turn: turn} = waiting_conversation(deadline: hours_from_now(-1))
+      {:ok, _} = Conversations.update_conversation(conv, %{status: "running"})
+      reject(&ConversationServer.send_prompt/4)
+
+      assert DetachedRequestSweeper.sweep_expired_requests() == 0
+
+      reloaded = Repo.reload(turn)
+      assert reloaded.waiting
+      assert reloaded.pending_permission["request_id"] == "7.abc"
+      assert request_stages(conv.id, "done") == []
+    end
+
+    test "a spent balance leaves the request for the next sweep" do
+      %{user: user, conv: conv, turn: turn} = waiting_conversation(deadline: hours_from_now(-1))
+      drain_credit(user)
+
+      # No `reject/1` here: the second half of this test needs the delivery to
+      # work. The untouched row and the silent stream are what say the first
+      # sweep delivered nothing.
+      assert DetachedRequestSweeper.sweep_expired_requests() == 0
+      assert Repo.reload(turn).waiting
+      assert request_stages(conv.id, "done") == []
+
+      # And it is not lost: the next sweep, after a top-up, carries it.
+      {:ok, _} = Fountain.Credits.grant(user.id, 500, "grant_admin", idempotency_key: "topup")
+      record_wake()
+
+      assert DetachedRequestSweeper.sweep_expired_requests() == 1
+      refute Repo.reload(turn).waiting
+    end
+
+    test "a conversation that is over resolves the request without a resume turn" do
+      # No turn will ever carry the denial, so the card stops waiting rather
+      # than the sweep finding the same row every minute forever.
+      %{conv: conv, turn: turn} = waiting_conversation(deadline: hours_from_now(-1))
+      {:ok, _} = Conversations.update_conversation(conv, %{status: "terminated"})
+      reject(&ConversationServer.send_prompt/4)
+
+      assert DetachedRequestSweeper.sweep_expired_requests() == 1
+
+      refute Repo.reload(turn).waiting
+      assert [%{"outcome" => "timeout"}] = request_stages(conv.id, "done")
+      assert DetachedRequestSweeper.sweep_expired_requests() == 0
+    end
+
+    test "a request still inside its deadline is left alone" do
+      %{turn: turn} = waiting_conversation(deadline: hours_from_now(24))
+
+      assert DetachedRequestSweeper.sweep_expired_requests() == 0
+      assert Repo.reload(turn).waiting
+    end
+
+    test "a turn that is not waiting is never a candidate, whatever its deadline" do
+      # A request held inside a running turn is the process timer's, and this
+      # sweep must not reach into one.
+      %{turn: turn} = waiting_conversation(deadline: hours_from_now(-1))
+
+      {:ok, _} =
+        Repo.update(Ecto.Changeset.change(turn, waiting: false, status: "running"))
+
+      assert DetachedRequestSweeper.sweep_expired_requests() == 0
+    end
+
+    test "the worker runs the sweep" do
+      %{turn: turn} = waiting_conversation(deadline: hours_from_now(-1))
+      record_wake()
+
+      assert :ok = DetachedRequestSweeper.perform(%Oban.Job{args: %{}})
+      refute Repo.reload(turn).waiting
     end
   end
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -28,6 +28,12 @@ config :fountain, Oban,
        # A server's autonomous quiet timer is in memory. Sweep old, silent
        # running turns whose server disappeared before that timer fired.
        {"*/5 * * * *", Fountain.Workers.AutonomousTurnReaper},
+       # Every minute: deny permission requests that outlived their turn and
+       # then ran out of time (#1635). Their deadline is on the turn row
+       # rather than in a process timer, because the sandbox parks and the
+       # server stops while such a request waits. One indexed query, usually
+       # empty.
+       {"* * * * *", Fountain.Workers.DetachedRequestSweeper},
        # Every 5 minutes: expire claimable principals nobody claimed (ADR
        # 0044). Latency here is money — an expired principal is a sprite still
        # running for a visitor who has gone — so the sweep runs on the same


### PR DESCRIPTION
The Oban sweep that denies a detached request past its deadline, from the options the agent itself offered, audited to the sweep, delivered as a resume turn. A conversation that cannot take the turn keeps the row for the next minute.

Part 7 of 9 for #1635, on #1857.


Part of #1635
