### PR TITLE
feat(api): a conversation lists the requests that outlived its turns, and answers one (#1635)

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
@@ -252,8 +252,18 @@ defmodule FountainWeb.ConversationController do
     # last_active_at, as the plain fetch would, is worse than not serving
     # the fields at all.
     case Conversations.get_conversation_with_activity(id, user.id) do
-      nil -> {:error, :not_found}
-      conv -> render(conn, :show, conversation: conv)
+      nil ->
+        {:error, :not_found}
+
+      conv ->
+        # Ownership: established by the tenant-scoped fetch above. Requests
+        # that outlived a turn (#1635) are served here rather than on the
+        # list, because a conversation is idle while one waits and the card
+        # has to survive a client reload.
+        render(conn, :show,
+          conversation: conv,
+          pending_requests: Conversations._unsafe_list_pending_requests(conv.id)
+        )
     end
   end
 
@@ -632,7 +642,12 @@ defmodule FountainWeb.ConversationController do
         "that block carried. Never send an option the agent did not offer.\n\n" <>
         "First answer wins: another attached client, the timeout, or the turn ending " <>
         "may already have resolved it, and all of those return 409. The resolution " <>
-        "appears on the stream as a `request` stage event with state `done`.",
+        "appears on the stream as a `request` stage event with state `done`.\n\n" <>
+        "A request that outlived its turn (#1635) is answered here too. The agent " <>
+        "ended that turn with stop reason `waiting`, so the conversation is idle and " <>
+        "the sandbox may be suspended; GET /api/conversations/{id} lists such " <>
+        "requests as `pending_requests`. Answering one resolves it and opens a new " <>
+        "turn carrying the request id and the option, which wakes the sandbox.",
     parameters: [
       conversation_id: [in: :path, type: :string, required: true],
       request_id: [in: :path, type: :string, required: true]
@@ -641,8 +656,12 @@ defmodule FountainWeb.ConversationController do
     responses: [
       ok: {"Answered", "application/json", Schemas.PermissionAnswerResponse},
       not_found: {"Not found", "application/json", Schemas.Error},
-      conflict: {"Already resolved", "application/json", Schemas.Error},
-      unprocessable_entity: {"Unknown option", "application/json", Schemas.Error}
+      conflict:
+        {"Already resolved, or resolved but not delivered", "application/json", Schemas.Error},
+      unprocessable_entity: {"Unknown option", "application/json", Schemas.Error},
+      bad_request: {"Busy", "application/json", Schemas.Error},
+      payment_required: {"Insufficient credits", "application/json", Schemas.Error},
+      forbidden: {"The sandbox may not answer", "application/json", Schemas.Error}
     ]
   )
 
@@ -690,6 +709,31 @@ defmodule FountainWeb.ConversationController do
   defp answer_response({:error, :not_found}, conn) do
     conn |> put_status(:not_found) |> json(%{error: "not_found"})
   end
+
+  # A turn is running, so the resume turn a detached answer opens cannot queue
+  # behind it (#1635). The request is untouched; try again when it is idle.
+  defp answer_response({:error, :busy}, _conn), do: {:error, "conversation_busy"}
+
+  # The request was resolved and the turn that carries it back could not be
+  # opened. Its own code, because the 409 above tells a client to give up on a
+  # request somebody else took, and this one has to say the opposite: the
+  # answer landed, the agent has not heard it, and a prompt is what wakes it.
+  defp answer_response({:error, :answer_not_delivered}, conn) do
+    conn
+    |> put_status(:conflict)
+    |> json(%{
+      error: "permission_answer_not_delivered",
+      message:
+        "The answer was recorded and the request is resolved, but the turn that " <>
+          "carries it to the agent could not be opened. Send a prompt to the " <>
+          "conversation to wake it."
+    })
+  end
+
+  # Everything else renders through the FallbackController, for the reason
+  # `do_prompt/5` gives: an error shape this function has not learned used to
+  # be a FunctionClauseError 500.
+  defp answer_response({:error, _} = err, _conn), do: err
 
   @doc """
   Infer the conversation's `source` and `parent_conversation_id` from

--- a/apps/fountain/lib/fountain_web/controllers/conversation_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_json.ex
@@ -7,6 +7,13 @@ defmodule FountainWeb.ConversationJSON do
   def show(%{conversation: conv, resumed: resumed?}),
     do: %{data: data(conv), meta: %{resumed: resumed?}}
 
+  # Requests that outlived a turn (#1635). Served on `show` only: the
+  # conversation is idle while one waits, so a client that reloads has
+  # nowhere else to learn the card is still up, and a list of conversations
+  # would pay a query per row for something almost always empty.
+  def show(%{conversation: conv, pending_requests: requests}),
+    do: %{data: Map.put(data(conv), :pending_requests, Enum.map(requests, &request_data/1))}
+
   def show(%{conversation: conv}), do: %{data: data(conv)}
   def turns(%{turns: turns}), do: %{data: Enum.map(turns, &turn_data/1)}
 
@@ -77,6 +84,19 @@ defmodule FountainWeb.ConversationJSON do
       usage_total: %{input: c.usage_input_tokens || 0, output: c.usage_output_tokens || 0},
       inserted_at: c.inserted_at,
       updated_at: c.updated_at
+    }
+  end
+
+  defp request_data(request) do
+    %{
+      request_id: request.request_id,
+      tool: request.tool,
+      # The agent's own option list, verbatim. Answer with an id from it and
+      # never with one from another runtime.
+      options: request.options,
+      asked_at: request.asked_at,
+      deadline: request.deadline,
+      turn_id: request.turn_id
     }
   end
 
@@ -183,6 +203,10 @@ defmodule FountainWeb.ConversationJSON do
       status: t.status,
       # `user` or `autonomous` (#817); rows from before the column read as user.
       origin: t.origin || "user",
+      # The turn ended with a permission request still open (#1635). The
+      # request is on GET /api/conversations/{id} as `pending_requests` until
+      # somebody answers it or its deadline passes.
+      waiting: t.waiting == true,
       exit_code: t.exit_code,
       started_at: t.started_at,
       ended_at: t.ended_at,

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -378,6 +378,50 @@ defmodule FountainWeb.Schemas do
     })
   end
 
+  defmodule PendingPermissionRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "PendingPermissionRequest",
+      description:
+        "A permission request that outlived its turn (#1635). The agent ended the " <>
+          "turn with stop reason `waiting` while this request was open, so the " <>
+          "conversation is idle, the sandbox may be suspended, and the request is " <>
+          "still waiting for an answer. Answer it at " <>
+          "POST /api/conversations/{id}/requests/{request_id}, which resolves it and " <>
+          "opens a new turn carrying the outcome to the agent.",
+      type: :object,
+      properties: %{
+        request_id: %Schema{type: :string},
+        tool: %Schema{
+          type: :string,
+          nullable: true,
+          description: "The tool the agent asked about, as the transcript labels it."
+        },
+        options: %Schema{
+          type: :array,
+          items: %Schema{type: :object, additionalProperties: true},
+          description:
+            "The options the agent offered, verbatim. `option_id` must be one of " <>
+              "these `optionId` values; an id from another runtime is refused."
+        },
+        asked_at: %Schema{type: :string, format: :"date-time", nullable: true},
+        deadline: %Schema{
+          type: :string,
+          format: :"date-time",
+          nullable: true,
+          description:
+            "When the request is denied for want of an answer. Set from the " <>
+              "request's own `_meta.fountain.timeout`, else the policy's " <>
+              "`ask_timeout`, else the global ask timeout."
+        },
+        turn_id: %Schema{type: :string, format: :uuid}
+      },
+      required: [:request_id, :options]
+    })
+  end
+
   defmodule Conversation do
     @moduledoc false
     require OpenApiSpex
@@ -520,7 +564,15 @@ defmodule FountainWeb.Schemas do
         },
         usage_total: UsageTotal,
         inserted_at: %Schema{type: :string, format: :"date-time"},
-        updated_at: %Schema{type: :string, format: :"date-time"}
+        updated_at: %Schema{type: :string, format: :"date-time"},
+        pending_requests: %Schema{
+          type: :array,
+          items: PendingPermissionRequest,
+          description:
+            "Permission requests that outlived a turn and are still waiting for an " <>
+              "answer (#1635). Served on GET /api/conversations/{id} only; absent " <>
+              "from the list and from the create response."
+        }
       },
       required: [:id, :runtime, :status]
     })
@@ -887,6 +939,13 @@ defmodule FountainWeb.Schemas do
             "Who opened the turn: `user` for a prompt somebody sent, `autonomous` " <>
               "for a turn the server opened for a background cycle the agent ran " <>
               "after its prompt was answered (#817)."
+        },
+        waiting: %Schema{
+          type: :boolean,
+          description:
+            "The turn ended with a permission request still open (#1635): the agent " <>
+              "answered with stop reason `waiting`, the turn is `completed` and the " <>
+              "request is on the conversation as a `pending_requests` entry."
         },
         exit_code: %Schema{type: :integer, nullable: true},
         started_at: %Schema{type: :string, format: :"date-time", nullable: true},

--- a/apps/fountain/test/fountain_web/controllers/conversation_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/conversation_controller_test.exs
@@ -197,6 +197,67 @@ defmodule FountainWeb.ConversationControllerTest do
       end
     end
 
+    # #1635. The conversation is idle while such a request waits, so a client
+    # that reloads has nowhere else to learn that the card is still up.
+    test "lists the permission requests that outlived a turn", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
+      conv = insert_conversation(user_id: user.id)
+
+      turn =
+        insert_turn(conv, %{
+          status: "completed",
+          waiting: true,
+          pending_permission: %{
+            "request_id" => "7.abc",
+            "tool" => "Bash",
+            "options" => [%{"optionId" => "yes", "kind" => "allow_once"}],
+            "asked_at" => "2026-09-07T09:00:00Z"
+          },
+          permission_deadline: ~U[2026-09-09 09:00:00Z]
+        })
+
+      body =
+        conn
+        |> authed_with_key(raw_key)
+        |> get("/api/conversations/#{conv.id}")
+        |> json_response(200)
+
+      assert [request] = body["data"]["pending_requests"]
+      assert request["request_id"] == "7.abc"
+      assert request["tool"] == "Bash"
+      assert request["options"] == [%{"optionId" => "yes", "kind" => "allow_once"}]
+      assert request["turn_id"] == turn.id
+      assert request["deadline"] == "2026-09-09T09:00:00Z"
+
+      turns =
+        conn
+        |> authed_with_key(raw_key)
+        |> get("/api/conversations/#{conv.id}/turns")
+        |> json_response(200)
+
+      assert [%{"waiting" => true}] = turns["data"]
+    end
+
+    test "serves an empty list when nothing is waiting", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
+      conv = insert_conversation(user_id: user.id)
+      _turn = insert_turn(conv, %{status: "completed"})
+
+      body =
+        conn
+        |> authed_with_key(raw_key)
+        |> get("/api/conversations/#{conv.id}")
+        |> json_response(200)
+
+      assert body["data"]["pending_requests"] == []
+    end
+
     test "returns 404 when the conversation belongs to a different user", %{
       conn: conn,
       raw_key: raw_key
@@ -909,6 +970,142 @@ defmodule FountainWeb.ConversationControllerTest do
         |> post_json("/api/conversations/#{other_conv.id}/prompts", %{"prompt" => "hello"})
 
       assert json_response(conn, 404)
+    end
+  end
+
+  describe "POST /api/conversations/:conversation_id/requests/:request_id" do
+    defp waiting_conv(user) do
+      sandbox = insert_sandbox(user_id: user.id, sprite_name: "test-sprite", status: "suspended")
+      conv = insert_conversation(user_id: user.id, sandbox: sandbox, status: "idle")
+
+      insert_turn(conv, %{
+        status: "completed",
+        waiting: true,
+        pending_permission: %{
+          "request_id" => "7.abc",
+          "tool" => "Bash",
+          "options" => [
+            %{"optionId" => "yes", "kind" => "allow_once"},
+            %{"optionId" => "no", "kind" => "reject_once"}
+          ]
+        },
+        permission_deadline: DateTime.add(DateTime.utc_now(), 3600) |> DateTime.truncate(:second)
+      })
+
+      conv
+    end
+
+    test "answers a request that outlived its turn", %{conn: conn, user: user, raw_key: raw_key} do
+      conv = waiting_conv(user)
+
+      # The wake is what carries the answer to the agent; only that it was
+      # asked for matters here.
+      stub(Fountain.Conversations, :wake_conversation, fn id, prompt ->
+        send(self(), {:woken, id, prompt})
+        {:ok, %{}}
+      end)
+
+      body =
+        conn
+        |> authed_with_key(raw_key)
+        |> put_req_header("content-type", "application/json")
+        |> post("/api/conversations/#{conv.id}/requests/7.abc", %{"option_id" => "yes"})
+        |> json_response(200)
+
+      assert body == %{"ok" => true}
+      assert_received {:woken, _id, prompt}
+      assert %{"fountain/permission_answer" => %{"option_id" => "yes"}} = Jason.decode!(prompt)
+    end
+
+    test "refuses an option the agent never offered", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
+      conv = waiting_conv(user)
+
+      body =
+        conn
+        |> authed_with_key(raw_key)
+        |> put_req_header("content-type", "application/json")
+        |> post("/api/conversations/#{conv.id}/requests/7.abc", %{"option_id" => "made-up"})
+        |> json_response(422)
+
+      assert body["error"] == "unknown_option"
+    end
+
+    test "refuses the sandbox's own token", %{conn: conn, user: user} do
+      # The sprite holds a FOUNTAIN_TOKEN and could otherwise approve the tool
+      # it just asked about, detached or not.
+      conv = waiting_conv(user)
+      {_record, sprite_key} = insert_sprite_api_key(user)
+
+      body =
+        conn
+        |> authed_with_key(sprite_key)
+        |> put_req_header("content-type", "application/json")
+        |> post("/api/conversations/#{conv.id}/requests/7.abc", %{"option_id" => "yes"})
+        |> json_response(403)
+
+      assert body["error"] == "sprite_may_not_answer"
+    end
+
+    test "a running turn is a 400, and the request is still there", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
+      conv = waiting_conv(user)
+      {:ok, _} = Fountain.Conversations.update_conversation(conv, %{status: "running"})
+
+      body =
+        conn
+        |> authed_with_key(raw_key)
+        |> put_req_header("content-type", "application/json")
+        |> post("/api/conversations/#{conv.id}/requests/7.abc", %{"option_id" => "yes"})
+        |> json_response(400)
+
+      assert body["error"] == "conversation_busy"
+
+      assert [%{request_id: "7.abc"}] =
+               Fountain.Conversations._unsafe_list_pending_requests(conv.id)
+    end
+
+    test "a resolved-but-undelivered answer says so in its own words", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
+      # Distinct from the 409 below, which tells a client somebody else
+      # answered. Here the answer landed and the agent has not heard it.
+      conv = waiting_conv(user)
+
+      stub(ConversationServer, :send_prompt, fn _id, _prompt, _images, _opts ->
+        {:error, :busy}
+      end)
+
+      body =
+        conn
+        |> authed_with_key(raw_key)
+        |> put_req_header("content-type", "application/json")
+        |> post("/api/conversations/#{conv.id}/requests/7.abc", %{"option_id" => "yes"})
+        |> json_response(409)
+
+      assert body["error"] == "permission_answer_not_delivered"
+      assert body["message"] =~ "Send a prompt"
+    end
+
+    test "a request nobody is waiting on is a 409", %{conn: conn, user: user, raw_key: raw_key} do
+      conv = waiting_conv(user)
+
+      body =
+        conn
+        |> authed_with_key(raw_key)
+        |> put_req_header("content-type", "application/json")
+        |> post("/api/conversations/#{conv.id}/requests/nope", %{"option_id" => "yes"})
+        |> json_response(409)
+
+      assert body["error"] == "permission_request_resolved"
     end
   end
 

--- a/sdk/contract/contract.json
+++ b/sdk/contract/contract.json
@@ -6286,7 +6286,17 @@
             "ref": "PermissionAnswerResponse"
           }
         },
+        "400": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
         "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "402": {
           "application/json": {
             "ref": "Error"
           }
@@ -10491,6 +10501,13 @@
           "required": false,
           "type": "string"
         },
+        "pending_requests": {
+          "items": {
+            "ref": "PendingPermissionRequest"
+          },
+          "required": false,
+          "type": "array"
+        },
         "permission_policy": {
           "additionalProperties": {
             "oneOf": [
@@ -11780,6 +11797,45 @@
         },
         "token": {
           "required": true,
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "PendingPermissionRequest": {
+      "properties": {
+        "asked_at": {
+          "format": "date-time",
+          "nullable": true,
+          "required": false,
+          "type": "string"
+        },
+        "deadline": {
+          "format": "date-time",
+          "nullable": true,
+          "required": false,
+          "type": "string"
+        },
+        "options": {
+          "items": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "required": true,
+          "type": "array"
+        },
+        "request_id": {
+          "required": true,
+          "type": "string"
+        },
+        "tool": {
+          "nullable": true,
+          "required": false,
+          "type": "string"
+        },
+        "turn_id": {
+          "format": "uuid",
+          "required": false,
           "type": "string"
         }
       },
@@ -13706,6 +13762,10 @@
             }
           ],
           "required": false
+        },
+        "waiting": {
+          "required": false,
+          "type": "boolean"
         }
       },
       "type": "object"

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -1307,6 +1307,8 @@ export interface paths {
          * @description Answers a `session/request_permission` the agent is blocked on (#940). The request and its options arrive as a `permission_request` block on the conversation's event stream; `option_id` must be one of the `optionId` values that block carried. Never send an option the agent did not offer.
          *
          *     First answer wins: another attached client, the timeout, or the turn ending may already have resolved it, and all of those return 409. The resolution appears on the stream as a `request` stage event with state `done`.
+         *
+         *     A request that outlived its turn (#1635) is answered here too. The agent ended that turn with stop reason `waiting`, so the conversation is idle and the sandbox may be suspended; GET /api/conversations/{id} lists such requests as `pending_requests`. Answering one resolves it and opens a new turn carrying the request id and the option, which wakes the sandbox.
          */
         post: operations["FountainWeb.ConversationController.answer_request"];
         delete?: never;
@@ -3663,6 +3665,8 @@ export interface components {
             last_read_at?: string | null;
             /** Format: uuid */
             parent_conversation_id?: string | null;
+            /** @description Permission requests that outlived a turn and are still waiting for an answer (#1635). Served on GET /api/conversations/{id} only; absent from the list and from the create response. */
+            pending_requests?: components["schemas"]["PendingPermissionRequest"][];
             /** @description The per-launch permission override this conversation was started with, or null if it had none. The policy actually in force is this merged with the agent's, taking the stricter of the two per tool. */
             permission_policy?: ({
                 /** @description Seconds a permission request that outlived its turn waits before it is denied (#1635). Names no tool, so it is the one key whose value is a number rather than a verdict, which is why the value schema below is a union. Absent leaves the global ask timeout. A request may shorten it with `_meta.fountain.timeout` on its own session/request_permission, and may not lengthen it. A launch may only shorten what the agent set, or the global ask timeout where the agent set nothing. Capped at a year, which is where the deadline stops fitting in a timestamp rather than a limit on how long a wait is useful. */
@@ -4236,6 +4240,28 @@ export interface components {
             password: string;
             /** @description From the reset email. */
             token: string;
+        };
+        /**
+         * PendingPermissionRequest
+         * @description A permission request that outlived its turn (#1635). The agent ended the turn with stop reason `waiting` while this request was open, so the conversation is idle, the sandbox may be suspended, and the request is still waiting for an answer. Answer it at POST /api/conversations/{id}/requests/{request_id}, which resolves it and opens a new turn carrying the outcome to the agent.
+         */
+        PendingPermissionRequest: {
+            /** Format: date-time */
+            asked_at?: string | null;
+            /**
+             * Format: date-time
+             * @description When the request is denied for want of an answer. Set from the request's own `_meta.fountain.timeout`, else the policy's `ask_timeout`, else the global ask timeout.
+             */
+            deadline?: string | null;
+            /** @description The options the agent offered, verbatim. `option_id` must be one of these `optionId` values; an id from another runtime is refused. */
+            options: {
+                [key: string]: unknown;
+            }[];
+            request_id: string;
+            /** @description The tool the agent asked about, as the transcript labels it. */
+            tool?: string | null;
+            /** Format: uuid */
+            turn_id?: string;
         };
         /** PermissionAnswerRequest */
         PermissionAnswerRequest: {
@@ -5064,6 +5090,8 @@ export interface components {
             turn_number: number;
             /** @description The end-of-turn token figure; null while the turn runs, when the runtime reported none, or on turns that predate the field. */
             usage?: components["schemas"]["TurnUsage"] | null;
+            /** @description The turn ended with a permission request still open (#1635): the agent answered with stop reason `waiting`, the turn is `completed` and the request is on the conversation as a `pending_requests` entry. */
+            waiting?: boolean;
         };
         /** TurnListResponse */
         TurnListResponse: {
@@ -11148,6 +11176,15 @@ export interface operations {
                     "application/json": components["schemas"]["PermissionAnswerResponse"];
                 };
             };
+            /** @description Busy */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Unauthorized */
             401: {
                 headers: {
@@ -11157,7 +11194,16 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
-            /** @description Forbidden */
+            /** @description Insufficient credits */
+            402: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description The sandbox may not answer */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -11184,7 +11230,7 @@ export interface operations {
                     "application/json": components["schemas"]["NegotiationError"];
                 };
             };
-            /** @description Already resolved */
+            /** @description Already resolved, or resolved but not delivered */
             409: {
                 headers: {
                     [name: string]: unknown;


### PR DESCRIPTION
`pending_requests` on GET /api/conversations/{id}, the answer endpoint taking a detached request with its own codes for busy (400) and recorded-but-undelivered (409), `waiting` on a turn, and the regenerated contract and types.

Part 8 of 9 for #1635, on #1858.


Part of #1635
