### PR TITLE
docs: requests that outlive a turn, and SDK 1.28.0 (#1635)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,8 +201,9 @@ upgrade, is in
   carrying the request id and the chosen option, which wakes the sandbox. The
   wait is bounded by `_meta.fountain.timeout` on the request and by an
   `ask_timeout` in the permission policy, the shorter of the two, else the
-  existing 5 minute ceiling. An answer is refused, and the request kept, when
-  the conversation cannot take the turn that carries it.
+  existing 5 minute ceiling, and at most a year either way. An answer is
+  refused, and the request kept, when the conversation cannot take the turn
+  that carries it.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,6 +194,15 @@ upgrade, is in
   and `GET /api/team/:agent_id/conversations` take a repeatable `label=key:value`
   filter, combined with AND. `conversation.*` webhook payloads carry `labels`,
   and the console's conversation lists render them as chips.
+- Permission requests can outlive the turn that raised them. An agent that ends
+  a turn with stop reason `waiting` keeps its request open, the conversation
+  goes idle and the sandbox suspends as usual. `GET /api/conversations/{id}`
+  lists such requests as `pending_requests`, and answering one opens a new turn
+  carrying the request id and the chosen option, which wakes the sandbox. The
+  wait is bounded by `_meta.fountain.timeout` on the request and by an
+  `ask_timeout` in the permission policy, the shorter of the two, else the
+  existing 5 minute ceiling. An answer is refused, and the request kept, when
+  the conversation cannot take the turn that carries it.
 
 ### Fixed
 

--- a/decisions/0014-agent-client-protocol.md
+++ b/decisions/0014-agent-client-protocol.md
@@ -745,6 +745,58 @@ bound suspends while the ceiling **destroys**. Left alone, an unanswered
 prompt does not hang forever; it burns the maximum lifetime and then takes the
 agent's memory with it (#649).
 
+> **Amendment, 2026-09-07 (#1635). A request may outlive its turn, and then
+> this bound does not apply to it.** The paragraph above is right about a
+> request held inside a running turn, and that is still the only shape an LLM
+> blocked mid-thought produces. A deterministic operation waits on something
+> else: approve a production apply, confirm a DNS delegation, sign off a set of
+> deletes. Those take hours or days, and nothing in the sandbox needs to run
+> while they do.
+>
+> So an agent may send `session/request_permission` and then answer
+> `session/prompt` with the stop reason **`waiting`**. The turn ends
+> `completed` with `turns.waiting` set, the request row stays pending, the
+> conversation goes `idle` and the sandbox parks on the idle bound exactly as
+> it would have anyway. No sandbox is held open, so the cost rule this ADR
+> keeps is untouched: what changes is that the *card* outlives the turn, not
+> the machine.
+>
+> The answer cannot go back down the connection that raised the request — the
+> sandbox may be suspended and the JSON-RPC id died with the peer. It opens a
+> **new turn** instead, whose `session/prompt` is one line of JSON under
+> `fountain/permission_answer` carrying the request id, the option and the
+> outcome. That is the shape a `_meta` key would carry, under the same name;
+> `Managoat.ACP.Peer.prompt/3` has no hook for protocol extensions, so it
+> travels in the prompt text until the library grows one.
+>
+> The deadline is per request (`_meta.fountain.timeout`) and per policy
+> (`ask_timeout`), the shorter of the two where both are set, else this
+> five-minute ceiling. The request half comes from inside the sandbox, so it
+> may bound its own wait and may not extend the tenant's; a launch policy may
+> shorten the agent's, or the five-minute ceiling where the agent set none,
+> because a longer wait is more time for the tool to be approved and so is the
+> looser direction. The deadline lives on the turn row rather than in a
+> process timer, because a two-day wait outlives every process involved, and
+> `Fountain.Workers.DetachedRequestSweeper` is what fires it. Expiry is still
+> a deny, and it opens the same resume turn.
+>
+> **The connection does not survive the detach**, which is the one place this
+> departs from #817's sandbox-scoped rule. The peer holds the request it
+> raised in a single slot that only an answer or a denial clears, and the
+> detached path sends neither; both shippable adapters number their requests
+> from 0 per turn, so the resume turn's first request would collide with the
+> stale hold and be swallowed — no response, no card, no timeout, and an
+> agent blocked with the ceiling off by default. The turn's end therefore
+> closes the connection, and the resume turn pays one handshake. That is what
+> the idle park would have done minutes later regardless.
+>
+> **Nothing is resolved that cannot be delivered.** The gates the wake runs —
+> a turn already in flight, a suspended account, a spent balance — run before
+> the request row is touched, by the answer door and by the sweep alike. A
+> request resolved into a prompt nobody delivers is gone with the agent never
+> told and no second copy to retry from, so the row stays and the sweep comes
+> back a minute later.
+
 **Survival across a restart.** The JSON-RPC request id lives in the peer and
 dies with it, so a request minted before a deploy cannot be answered after one
 unless the id is persisted the way `acp_prompt_id` already is — the same trap

--- a/docs/concepts/permissions.md
+++ b/docs/concepts/permissions.md
@@ -159,6 +159,12 @@ Where the request and the policy both name one, the **shorter** wins. The
 request is written inside the sandbox and the policy belongs to the tenant, so
 an agent can bound its own wait and cannot extend the tenant's.
 
+An `ask_timeout` cannot be longer than a year. Fountain refuses a longer one
+when you save the agent or when you start the conversation. A database
+timestamp cannot hold a longer deadline. This is not a limit on how long a
+wait is useful. A per-request `_meta.fountain.timeout` above the same limit
+falls back to the policy, or to the 5 minute ceiling.
+
 A launch policy may shorten the agent's `ask_timeout` and may not lengthen it.
 Where the agent named none, the 5 minute ceiling is what a launch may only
 shorten. A longer wait is more time for somebody to approve the tool, so

--- a/docs/concepts/permissions.md
+++ b/docs/concepts/permissions.md
@@ -66,13 +66,110 @@ Some rules keep that safe.
 
 - **The first answer wins.** The other clients see a request that no longer
   waits. No client is a fallback for another.
-- **Nobody is also an answer.** After 5 minutes, Fountain refuses the tool. The
-  timeout sits below the idle bound, so a request that waits costs a turn and
-  not the sandbox.
+- **Nobody is also an answer.** Two timeouts do this, and which one applies
+  depends on whether the request is still inside a turn. A request held inside
+  a turn is refused after 5 minutes. That ceiling sits below the idle bound, so
+  a request that waits costs a turn and not the sandbox. A request that
+  outlived its turn is refused at its own deadline, which may be days away.
+  See [Requests that outlive a turn](#requests-that-outlive-a-turn).
 - **An option must come from the runtime.** Fountain refuses an option id that
   the runtime did not offer.
 - **The agent cannot answer itself.** The sandbox holds an API token, and
   Fountain refuses that loop by name.
+
+## Requests that outlive a turn
+
+The 5 minute ceiling above assumes an agent blocked mid-thought. Some waits are
+longer than that. Approve a production apply, confirm a DNS delegation landed,
+sign off the deletes in a plan. Those take hours or days, and nothing in the
+sandbox has to run while they do.
+
+An agent can say so. It sends `session/request_permission`, and then it answers
+`session/prompt` with the stop reason `waiting`. The turn ends as a completed
+turn with `waiting: true` on it. The request stays open. The conversation goes
+idle, and the sandbox suspends on the idle bound like any other idle sandbox.
+
+The card stays up. `GET /api/conversations/{id}` lists every such request under
+`pending_requests`, with the tool, the options the agent offered, and the
+deadline. The `turn` stage event that ended the turn carries `waiting: true`
+and the request id, so a client watching the stream learns it there too.
+
+A `waiting` stop reason with no open request means nothing. That turn ends the
+way any completed turn does.
+
+### Answering one
+
+Answer it at `POST /api/conversations/{id}/requests/{request_id}`, the same
+door an in-turn request uses. The rules above still hold. The first answer
+wins, the option must come from the runtime, and the agent cannot answer
+itself.
+
+What happens next is different. The connection that raised the request is gone,
+so Fountain cannot hand the answer back down it. Instead Fountain resolves the
+request and opens a **new turn** whose prompt carries the outcome. Opening that
+turn wakes the sandbox.
+
+The prompt is one line of JSON and nothing else. It is broken up here to read
+it.
+
+```json
+{"fountain/permission_answer":{
+  "request_id": "7.1f0c9a",
+  "tool": "Bash",
+  "outcome": "answered",
+  "option_id": "allow",
+  "answered_at": "2026-09-07T09:14:02.113Z"
+}}
+```
+
+`outcome` is `answered` or `timeout`. `option_id` is the option somebody
+picked, or the rejection the expiry chose from the agent's own list. It is null
+where the agent offered no rejection at all. The agent decides what to do with
+it.
+
+The turn's `origin` is `user`, like any other prompted turn. A client that
+wants to render this as a system event and not as something a person typed can
+tell it by the prompt itself, which is one JSON object whose only key is
+`fountain/permission_answer`.
+
+The connection the request was raised on is closed when the turn ends
+`waiting`, so the resume turn starts a fresh one. The old peer is still holding
+that request, and the runtimes number their requests from 0 on each turn, so
+keeping it would make the resume turn's first request collide with the one it
+still holds.
+
+An answer is refused, and the request left where it is, when the conversation
+cannot take the turn that carries it. A turn of its own is running, the account
+is suspended, or the balance is spent. Answer again once that is fixed. The
+expiry sweep does the same, and comes back a minute later.
+
+### The deadline
+
+A detached request is refused when its deadline passes, and the refusal opens
+the same resume turn with `outcome: "timeout"`. Fountain reads the deadline
+from the first of these that is set.
+
+1. `_meta.fountain.timeout` on the `session/request_permission` itself, in
+  seconds. The agent sets this per request.
+2. `ask_timeout` in the permission policy, in seconds. This is the one policy
+  key that names no tool.
+3. The 5 minute ceiling, which is what an in-turn request gets.
+
+Where the request and the policy both name one, the **shorter** wins. The
+request is written inside the sandbox and the policy belongs to the tenant, so
+an agent can bound its own wait and cannot extend the tenant's.
+
+A launch policy may shorten the agent's `ask_timeout` and may not lengthen it.
+Where the agent named none, the 5 minute ceiling is what a launch may only
+shorten. A longer wait is more time for somebody to approve the tool, so
+longer is looser.
+
+Only a detached request reads the first two. A request inside a turn always
+gets the 5 minute ceiling, because the turn holding it keeps the sandbox from
+parking.
+
+The deadline is stored on the turn, not in a timer, so it survives the sandbox
+suspending and the server restarting. A sweep every minute is what fires it.
 
 ## What each runtime can do
 

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -11,6 +11,14 @@ server releases.
 
 ---
 
+## [1.30.0] - 2026-09-11
+
+### Added
+
+- Generated types carry a conversation's `pending_requests`, the permission requests that outlived a turn and are still waiting for an answer. Each entry has the request id, the tool, the options the agent offered, when it was asked and when it expires.
+- Generated types carry a turn's `waiting`, true when the turn ended with such a request still open.
+- `permission_policy` accepts `ask_timeout`, a number of seconds a request that outlived its turn waits before it is denied. It is the one policy key whose value is a number rather than a verdict, so the value type is now a union of the verdict enum and a number.
+
 ## [1.29.0] - 2026-09-11
 
 ### Changed

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@managoat/fountain-sdk",
-  "version": "1.29.0",
+  "version": "1.30.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@managoat/fountain-sdk",
-      "version": "1.29.0",
+      "version": "1.30.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^26.4.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@managoat/fountain-sdk",
-  "version": "1.29.0",
+  "version": "1.30.0",
   "description": "Run a coding agent on a real computer, with your repos and your credentials, in one call.",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/sdk/typescript/src/http.ts
+++ b/sdk/typescript/src/http.ts
@@ -19,7 +19,7 @@ export interface RequestOptions {
  * this string is already what Fountain's request logs are keyed on. The
  * version half is asserted against `package.json` by a test.
  */
-export const USER_AGENT = "fountain-sdk-js/1.29.0";
+export const USER_AGENT = "fountain-sdk-js/1.30.0";
 
 /**
  * The thin layer everything else is built on: one bearer token, JSON in and


### PR DESCRIPTION
The permissions page, ADR 0014, the CHANGELOG and SDK 1.28.0.

The version has moved twice while this stack was open: 1.26.0 went to #1634 (#1839) and 1.27.0 to #1637 (#1849), and both are tagged. So this bump is 1.28.0, and whichever SDK release lands next re-bumps again. The bump is four edits, not three: `package.json`, the lockfile's two entries, the `USER_AGENT` in `src/http.ts` and the changelog heading, which sits above the 1.27.0 entry rather than replacing it.

Part 9 of 9 for #1635, on #1859.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9jevFQT5MkF3rJUieeiHW



Closes #1635
