### PR TITLE
fix(tests): stop leaking crash-looping ConversationServers into the Horde supervisor (#1862)

### DIFF
--- a/apps/fountain/test/fountain/conversations_wake_test.exs
+++ b/apps/fountain/test/fountain/conversations_wake_test.exs
@@ -40,6 +40,14 @@ defmodule Fountain.ConversationsWakeTest do
       sandbox = insert_sandbox(user_id: user.id, status: "terminated")
       conv = insert_conversation(user_id: user.id, agent: agent, sandbox: sandbox, status: "idle")
 
+      # The wake succeeds here, so it starts a server. Without this it is a
+      # real one under the shared Horde supervisor, with no sandbox connection
+      # in an async test and `restart: :transient` to put it back after every
+      # raise (#1862).
+      stub(Horde.DynamicSupervisor, :start_child, fn _supervisor, _child_spec ->
+        {:ok, spawn(fn -> Process.sleep(:infinity) end)}
+      end)
+
       refute match?({:error, :gone}, Conversations.wake_conversation(conv.id))
     end
 

--- a/apps/fountain/test/fountain/team_test.exs
+++ b/apps/fountain/test/fountain/team_test.exs
@@ -15,10 +15,24 @@ defmodule Fountain.TeamTest do
     )
   end
 
-  defp inert_start_child do
+  # Every test in this file that reaches a wake or a start would otherwise put
+  # a real `ConversationServer` under the shared Horde supervisor (#1862). It
+  # has no sandbox connection in an async test, so it raises on
+  # `handle_continue(:provision)`, and `restart: :transient` puts it straight
+  # back — a crash loop that churns the CRDT for every other test in the
+  # partition. One test forgetting the stub cost 155 of those in a single run.
+  #
+  # Stubbed for the whole file rather than per test: nothing here asserts on
+  # the real start, and the failure mode of forgetting is invisible locally
+  # and lands on somebody else's test in CI.
+  setup :inert_start_child
+
+  defp inert_start_child(_context \\ nil) do
     stub(Horde.DynamicSupervisor, :start_child, fn _sup, _spec ->
       {:ok, spawn(fn -> Process.sleep(:infinity) end)}
     end)
+
+    :ok
   end
 
   describe "list_teammates/1" do


### PR DESCRIPTION

Two tests called `Conversations.wake_conversation/1` without stubbing
`Horde.DynamicSupervisor.start_child/2`, so the wake put a **real**
`ConversationServer` under the supervisor that every test in the partition
shares. In an `async: true` test that server holds no SQL Sandbox connection,
so it raises `DBConnection.OwnershipError` in `handle_continue(:provision)` —
and its child spec is `restart: :transient`, so Horde puts it straight back and
it raises again. A crash loop, for the rest of the run.

Measured over a whole-suite run: **409 of those raises before, 0 after**, and
the suite log drops from 21,561 lines to 4,715.

That churn is what #1862 reported. The visible failure was a *different* test
exiting inside `GenServer.call(ConversationSupervisor, {:start_child, …})` for a
conversation it had never heard of, while Horde was shutting the supervisor
down mid-`add_children`. Which test gets hit is scheduling luck, which is why
it reads as a new flake each time.

- `team_test.exs` already had an `inert_start_child/0` helper and eleven tests
  called it; the co-tenant wake-order test did not. Promoted to
  `setup :inert_start_child` for the file rather than adding a twelfth call:
  nothing in the file asserts on the real start, and forgetting it is invisible
  locally and lands on somebody else's test in CI.
- `conversations_wake_test.exs` — one test, "an idle conversation whose sandbox
  was reclaimed is still resumable", whose wake succeeds and so starts a
  server. Stubbed inline, matching that file's idiom; its assertion
  (`refute match?({:error, :gone}, …)`) is unchanged either way.

Every other test file that wakes or starts a conversation already stubbed
correctly — audited by running each one and counting the raises.

Verified by reverting: removing the `setup` line puts team_test back to 204
raises, and removing the inline stub puts the wake test back to 101. Full
suite: 4807 core, 144 fountain_buzz, 33 fountain_support, 0 failures.

**What this does not do.** It removes the mechanism, not the race. I could not
reproduce the original cross-test failure on demand — it needs a particular
interleaving inside a partition — so this fixes the cause that is demonstrable
and leaves the Horde shutdown path as it is. If it recurs, the next step is a
teardown guard that fails a test which leaves a `ConversationServer` alive for
a conversation it created. That needs the factory to record ids per test and
`DataCase` to check the registry, and because ExUnit runs `on_exit` in a
separate process from the test it needs an ETS table keyed by test pid — real
machinery, not worth inventing on the back of two missing stub calls.

Closes #1862

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A2iMoNvSvrkQQfnP4RzVi2



Closes #1862
