### PR TITLE
ci: reflow the secret-scan range comment

### DIFF
--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -56,13 +56,13 @@ jobs:
           HEAD_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-          # A pull request or a merge group scans base..HEAD, which is what
-          # the action did. A
-          # push to main scans what it pushed — unless `before` is unreachable
-          # (a force push, or the zero sha on a new branch), where the only
-          # honest range left is the tip commit itself. Never silently scan
-          # nothing: an empty range would pass this gate without reading a
-          # byte, which is the failure mode the old job's comment warned about.
+          # A pull request or a merge group scans base..HEAD, which is what the
+          # action did. A push to main scans what it pushed — unless `before`
+          # is unreachable (a force push, or the zero sha on a new branch),
+          # where the only honest range left is the tip commit itself. Never
+          # silently scan nothing: an empty range would pass this gate without
+          # reading a byte, which is the failure mode the old job's comment
+          # warned about.
           if [ -n "${BASE_SHA}" ]; then
             range="${BASE_SHA}..${HEAD_SHA}"
           elif [ -n "${BEFORE_SHA}" ] && [ "${BEFORE_SHA}" != "0000000000000000000000000000000000000000" ] \


### PR DESCRIPTION
Comment-only. #1867 added "or a merge group" to this comment's first sentence and left the paragraph wrapped mid-clause — `A` ended one line and `push to main` began the next. Same words, readable line breaks.

**This is also the first PR through the merge queue** (ADR 0050), deliberately chosen to be a non-docs path so the merge group runs the full suite rather than taking the docs-only skip.

What it should demonstrate:
1. It needs an approving review before GitHub will enqueue it at all.
2. Once queued, a `merge_group` CI run appears on a `gh-readonly-queue/main/pr-…` branch.
3. That run publishes `tested-tree`, and main's push afterwards short-circuits off it instead of running the suite a second time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RJBSE57BbSEDF5s5fvWEga