### PR TITLE
feat(sandbox): a table for work waiting on capacity (#1033)

### DIFF
--- a/apps/fountain/lib/fountain/sandbox_queue.ex
+++ b/apps/fountain/lib/fountain/sandbox_queue.ex
@@ -1,0 +1,249 @@
+defmodule Fountain.SandboxQueue do
+  @moduledoc """
+  The bounded per-tenant queue for sandbox capacity (#1033, ADR 0042).
+
+  A start reaches a capacity limit two ways: the tenant's own cap, funded by
+  its credit balance under ADR 0031, and `SANDBOX_FLEET_CEILING` across the
+  whole deployment. `Quotas.with_sandbox_reservation/3` refuses both
+  immediately, which is the right answer for a caller that can retry and the
+  wrong one for a cron firing with nobody there to retry it.
+
+  This module holds that work instead. It never raises a limit: the queue
+  delays admission and every replay re-enters the same reservation, the same
+  credit gate and the same platform-inference gate.
+
+  Bounded twice. A tenant holds at most `SANDBOX_QUEUE_MAX_DEPTH` active
+  requests, and a request waits at most `SANDBOX_QUEUE_MAX_WAIT_SECONDS`.
+  Beyond the depth bound the caller keeps its immediate capacity error.
+  """
+
+  import Ecto.Query, only: [from: 2]
+
+  alias Fountain.Audit
+  alias Fountain.Repo
+  alias Fountain.SandboxQueue.Request
+
+  @default_max_depth 10
+
+  # One source of truth. `Request.active_statuses/0` is what the ops gauge
+  # reads too, and two copies would let the depth bound and the gauge disagree
+  # silently if a status were ever added.
+  @active_statuses Request.active_statuses()
+
+  # Its own advisory-lock namespace. The depth bound counts rows in
+  # `sandbox_requests` and has nothing to serialize against a sandbox
+  # reservation, and every namespace here hashes a different kind of id into
+  # the same 32 bits: sharing one would let a `phash2` collision between a
+  # user and a sandbox block an unrelated writer. Taken: 4315
+  # `Fountain.Quotas`, 4316 `Conversations`, 4331 `Fountain.Connections`.
+  @lock_namespace 4317
+
+  @doc """
+  Queue a start or a scheduled run, subject to the per-tenant depth bound.
+
+  `params` is a map the caller builds key by key — never a request body cast
+  wholesale. Returns `{:error, :queue_full}` at the depth bound, which the
+  caller turns back into the capacity error it was about to send.
+
+  A `schedule_run` is deduplicated against the schedule's own live request, so
+  a cron that keeps firing while the first one waits does not stack ten copies
+  of the same run. That dedup wins over the depth bound: it removes a row
+  rather than adding one.
+  """
+  def enqueue(params, opts \\ []) do
+    with {:ok, outcome} <- insert_bounded(params) do
+      case outcome do
+        # The schedule already had a live request. Nothing was written, so
+        # nothing is recorded: a trail that logs an attempt as a change is
+        # worse than no trail (ADR 0013).
+        {:deduplicated, request} ->
+          {:ok, request}
+
+        # Audited outside the transaction: `Audit.record/1` is best-effort
+        # by rescuing, and a rescue does not survive a transaction — a
+        # failed audit insert would abort the enclosing one and take the
+        # request with it.
+        {:inserted, request} ->
+          audited(request, "sandbox_request.enqueued", opts)
+          emit_depth(request.user_id)
+          {:ok, request}
+      end
+    end
+  end
+
+  @doc """
+  The tenant's live request for a schedule, if it has one.
+
+  What lets a surface say "waiting for a free slot" rather than repeating the
+  capacity error a replay just met again.
+  """
+  def schedule_request(user_id, schedule_id)
+      when is_binary(user_id) and is_binary(schedule_id) do
+    existing_schedule_request(%{user_id: user_id, schedule_id: schedule_id})
+  end
+
+  # The depth bound is a check followed by an insert, so it needs the same
+  # protection `Quotas.with_sandbox_reservation/3` gives the sandbox cap: two
+  # requests that both read "room for one more" at the last slot is precisely
+  # how #330 got past that cap before its advisory lock existed.
+  #
+  # The schedule dedup reads under the same lock, for the same reason: two
+  # firings of one schedule that both read "no live request" would both insert,
+  # which is the stacking the dedup exists to prevent.
+  defp insert_bounded(params) do
+    Repo.transaction(fn ->
+      Repo.query!("SELECT pg_advisory_xact_lock($1, $2)", [
+        @lock_namespace,
+        :erlang.phash2(params.user_id)
+      ])
+
+      case existing_schedule_request(params) do
+        %Request{} = request ->
+          {:deduplicated, request}
+
+        nil ->
+          with :ok <- check_depth(params.user_id),
+               {:ok, request} <-
+                 %Request{}
+                 |> Request.changeset(Map.put_new(params, :status, "queued"))
+                 |> Repo.insert() do
+            {:inserted, request}
+          else
+            {:error, reason} -> Repo.rollback(reason)
+          end
+      end
+    end)
+  end
+
+  @doc "List a tenant's waiting requests, oldest first."
+  def list_queued(user_id) when is_binary(user_id), do: Repo.all(queued_query(user_id))
+
+  @doc "Get a request scoped to its tenant."
+  def get_request(id, user_id) when is_binary(id) and is_binary(user_id) do
+    case Ecto.UUID.cast(id) do
+      {:ok, request_id} -> Repo.get_by(Request, id: request_id, user_id: user_id)
+      :error -> nil
+    end
+  end
+
+  @doc """
+  A waiting request's one-based position.
+
+  Counts claimed (`starting`) rows as well as waiting ones: a request being
+  replayed right now is still ahead of this one, and leaving it out reports
+  `position: 1` to a caller that has someone in front of it. `nil` once the
+  request is no longer waiting.
+  """
+  def position(%Request{status: "queued"} = request) do
+    Repo.aggregate(
+      from(r in Request,
+        where:
+          r.user_id == ^request.user_id and r.status in ^@active_statuses and
+            (r.inserted_at < ^request.inserted_at or
+               (r.inserted_at == ^request.inserted_at and r.id < ^request.id))
+      ),
+      :count
+    ) + 1
+  end
+
+  def position(%Request{}), do: nil
+
+  @doc """
+  Cancel a request if it is still waiting.
+
+  A compare-and-swap, not a read-then-write: the drainer may have claimed the
+  row between the caller's fetch and this call, and a cancellation that
+  reached a `starting` row would abandon a start already in flight.
+  """
+  def cancel_request(%Request{} = request, opts \\ []) do
+    case terminate(request.id, "queued", %{status: "cancelled", attrs: %{}}) do
+      {:ok, cancelled} ->
+        audited(cancelled, "sandbox_request.cancelled", opts)
+        emit_depth(cancelled.user_id)
+        {:ok, cancelled}
+
+      :stale ->
+        {:error, :not_found}
+    end
+  end
+
+  # One compare-and-swap from `expected` to whatever `attrs` says, returning
+  # the row it wrote or `:stale` when somebody else moved it first. Every
+  # transition out of a live status goes through here, so no path in this
+  # module writes a status with a blind `Repo.update/1`.
+  defp terminate(id, expected, attrs) do
+    now = DateTime.utc_now()
+    sets = attrs |> Map.to_list() |> Keyword.put(:updated_at, now)
+
+    case Repo.update_all(
+           from(r in Request, where: r.id == ^id and r.status == ^expected),
+           set: sets
+         ) do
+      {1, _} -> {:ok, Repo.get!(Request, id)}
+      {0, _} -> :stale
+    end
+  end
+
+  defp queued_query(user_id) do
+    from r in Request,
+      where: r.user_id == ^user_id and r.status == "queued",
+      order_by: [asc: r.inserted_at, asc: r.id]
+  end
+
+  defp check_depth(user_id) do
+    if active_depth(user_id) < max_depth(), do: :ok, else: {:error, :queue_full}
+  end
+
+  defp active_depth(user_id) do
+    Repo.aggregate(
+      from(r in Request, where: r.user_id == ^user_id and r.status in ^@active_statuses),
+      :count
+    )
+  end
+
+  defp existing_schedule_request(%{schedule_id: schedule_id, user_id: user_id})
+       when is_binary(schedule_id) do
+    Repo.one(
+      from r in Request,
+        where:
+          r.user_id == ^user_id and r.schedule_id == ^schedule_id and
+            r.status in ^@active_statuses,
+        limit: 1
+    )
+  end
+
+  defp existing_schedule_request(_params), do: nil
+
+  defp emit_depth(user_id) do
+    :telemetry.execute(
+      [:fountain, :sandbox_queue, :tenant_depth],
+      %{depth: active_depth(user_id)},
+      %{}
+    )
+  end
+
+  # Keys, sizes and provenance — never the prompt, which lives in `attrs` and
+  # is erased at every terminal transition anyway.
+  defp audited(%Request{} = request, action, opts) do
+    Audit.record(%{
+      user_id: request.user_id,
+      action: action,
+      resource_type: "sandbox_request",
+      resource_id: request.id,
+      actor: Keyword.get(opts, :actor, "self"),
+      request_ip: Keyword.get(opts, :request_ip),
+      metadata: %{
+        "kind" => request.kind,
+        "agent_id" => request.agent_id,
+        "schedule_id" => request.schedule_id,
+        "conversation_id" => request.conversation_id,
+        "error" => request.error
+      }
+    })
+
+    request
+  end
+
+  defp max_depth,
+    do: Application.get_env(:fountain, :sandbox_queue_max_depth, @default_max_depth)
+end

--- a/apps/fountain/lib/fountain/sandbox_queue/request.ex
+++ b/apps/fountain/lib/fountain/sandbox_queue/request.ex
@@ -1,0 +1,81 @@
+defmodule Fountain.SandboxQueue.Request do
+  @moduledoc """
+  Work waiting for sandbox capacity (#1033, ADR 0042).
+
+  A request is its own row rather than a conversation status because it has no
+  sandbox and no conversation yet. A `queued` conversation would leak a row
+  with no machine into every conversation list, every stream and every client
+  enum.
+
+  `sandbox_key_id` is the restriction the request arrived under, not a
+  credential: a `sprite`-scoped token may label only its own conversation
+  (ADR 0045), and a replay an hour later has to be held to the same rule as
+  the door. Absent means the caller had no sandbox restriction.
+
+  `"start"` carries the JSON-safe launch attributes the API call arrived with.
+  `"schedule_run"` carries a schedule id and re-fires that schedule. Every
+  terminal transition erases `attrs`, so a finished row keeps provenance and
+  an outcome but never a prompt.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Fountain.Accounts.User
+  alias Fountain.Agents.Agent
+  alias Fountain.Conversations.Conversation
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+
+  @kinds ~w(start schedule_run)
+  @statuses ~w(queued starting started cancelled expired failed)
+  @active_statuses ~w(queued starting)
+
+  @type t :: %__MODULE__{}
+
+  schema "sandbox_requests" do
+    field :kind, :string, default: "start"
+    field :attrs, :map, default: %{}
+    field :schedule_id, :binary_id
+    field :sandbox_key_id, :binary_id
+    field :source, :string
+    field :status, :string, default: "queued"
+    field :error, :string
+    belongs_to :user, User
+    belongs_to :agent, Agent
+    belongs_to :conversation, Conversation
+    timestamps(type: :utc_datetime_usec)
+  end
+
+  def kinds, do: @kinds
+  def statuses, do: @statuses
+
+  @doc "The statuses that mean live work, as opposed to a history row."
+  def active_statuses, do: @active_statuses
+
+  @doc """
+  Internal changeset. Callers never cast request parameters wholesale — the
+  queue builds the map itself from keys it names.
+  """
+  def changeset(request, attrs) do
+    request
+    |> cast(attrs, [
+      :kind,
+      :attrs,
+      :schedule_id,
+      :sandbox_key_id,
+      :source,
+      :status,
+      :error,
+      :user_id,
+      :agent_id,
+      :conversation_id
+    ])
+    |> validate_required([:kind, :status, :user_id, :agent_id])
+    |> validate_inclusion(:kind, @kinds)
+    |> validate_inclusion(:status, @statuses)
+    |> foreign_key_constraint(:user_id)
+    |> foreign_key_constraint(:agent_id)
+  end
+end

--- a/apps/fountain/priv/repo/migrations/20260910140000_create_sandbox_requests.exs
+++ b/apps/fountain/priv/repo/migrations/20260910140000_create_sandbox_requests.exs
@@ -1,0 +1,39 @@
+defmodule Fountain.Repo.Migrations.CreateSandboxRequests do
+  use Ecto.Migration
+
+  def change do
+    create table(:sandbox_requests, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :user_id, references(:users, type: :binary_id, on_delete: :delete_all), null: false
+      add :agent_id, references(:agents, type: :binary_id, on_delete: :delete_all), null: false
+      add :kind, :string, null: false, default: "start"
+      add :attrs, :map, null: false, default: %{}
+      # Deliberately not a `references/2`, both of them. A schedule or an API
+      # key that goes away must leave the id dangling rather than be nilified:
+      # a dangling `schedule_id` replays as `:schedule_deleted` (terminal), and
+      # a dangling `sandbox_key_id` fails the ownership comparison in
+      # `Conversations.set_conversation_labels/4`. Nilifying either would turn a
+      # refusal into a permission the original request never had.
+      add :schedule_id, :binary_id
+      add :sandbox_key_id, :binary_id
+      add :source, :string
+      add :status, :string, null: false, default: "queued"
+
+      add :conversation_id,
+          references(:conversations, type: :binary_id, on_delete: :nilify_all)
+
+      add :error, :string
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    # The FIFO read, the depth count and the position count are all
+    # "this tenant, these statuses, in insertion order".
+    create index(:sandbox_requests, [:user_id, :status, :inserted_at])
+
+    # The fan-out probe asks "does any tenant have live work" before it
+    # schedules anything, and the answer is no on almost every sandbox status
+    # change. Partial, so the index stays the size of the live queue rather
+    # than of its history.
+    create index(:sandbox_requests, [:status], where: "status IN ('queued', 'starting')")
+  end
+end

--- a/apps/fountain/test/fountain/audit_guardrail_test.exs
+++ b/apps/fountain/test/fountain/audit_guardrail_test.exs
@@ -45,6 +45,10 @@ defmodule Fountain.AuditGuardrailTest do
     {"agent update", &__MODULE__.do_agent_update/1, "agent.updated"},
     {"agent delete", &__MODULE__.do_agent_delete/1, "agent.deleted"},
     {"agent rollback", &__MODULE__.do_agent_rollback/1, "agent.updated"},
+    {"sandbox request enqueue", &__MODULE__.do_sandbox_request_enqueue/1,
+     "sandbox_request.enqueued"},
+    {"sandbox request cancel", &__MODULE__.do_sandbox_request_cancel/1,
+     "sandbox_request.cancelled"},
     {"environment create", &__MODULE__.do_env_create/1, "environment.created"},
     {"environment update", &__MODULE__.do_env_update/1, "environment.updated"},
     {"environment delete", &__MODULE__.do_env_delete/1, "environment.deleted"},
@@ -205,6 +209,8 @@ defmodule Fountain.AuditGuardrailTest do
           {Agents, :update_agent, 3},
           {Agents, :delete_agent, 2},
           {Agents, :rollback_agent, 3},
+          {Fountain.SandboxQueue, :enqueue, 2},
+          {Fountain.SandboxQueue, :cancel_request, 2},
           {Environments, :create_environment, 2},
           {Environments, :update_environment, 3},
           {Environments, :delete_environment, 2},
@@ -279,6 +285,32 @@ defmodule Fountain.AuditGuardrailTest do
     {:ok, _} = Agents.update_agent(agent, %{"description" => "edited"})
     version = Agents.get_agent_version(agent.id, 1, user.id)
     {:ok, _} = Agents.rollback_agent(agent, version)
+  end
+
+  def do_sandbox_request_enqueue(user) do
+    agent = insert_agent(user_id: user.id)
+
+    {:ok, _} =
+      Fountain.SandboxQueue.enqueue(%{
+        user_id: user.id,
+        agent_id: agent.id,
+        kind: "start",
+        attrs: %{"prompt" => "queued work"}
+      })
+  end
+
+  def do_sandbox_request_cancel(user) do
+    agent = insert_agent(user_id: user.id)
+
+    {:ok, request} =
+      Fountain.SandboxQueue.enqueue(%{
+        user_id: user.id,
+        agent_id: agent.id,
+        kind: "start",
+        attrs: %{}
+      })
+
+    {:ok, _} = Fountain.SandboxQueue.cancel_request(request)
   end
 
   def do_env_create(user),

--- a/apps/fountain/test/fountain/sandbox_queue_test.exs
+++ b/apps/fountain/test/fountain/sandbox_queue_test.exs
@@ -1,0 +1,266 @@
+defmodule Fountain.SandboxQueueTest do
+  use Fountain.DataCase, async: true
+
+  alias Fountain.SandboxQueue
+  alias Fountain.SandboxQueue.Request
+
+  defp enqueue!(user, agent, extra \\ %{}) do
+    {:ok, request} =
+      SandboxQueue.enqueue(
+        Map.merge(
+          %{user_id: user.id, agent_id: agent.id, kind: "start", attrs: %{"prompt" => "hi"}},
+          extra
+        )
+      )
+
+    request
+  end
+
+  defp enqueued_events(user) do
+    user.id
+    |> Fountain.Audit.list_recent_for_user(50)
+    |> Enum.filter(&(&1.action == "sandbox_request.enqueued"))
+  end
+
+  describe "enqueue/2" do
+    test "orders requests and reports their positions" do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+
+      first = enqueue!(user, agent)
+      second = enqueue!(user, agent)
+
+      assert SandboxQueue.position(first) == 1
+      assert SandboxQueue.position(second) == 2
+      assert Enum.map(SandboxQueue.list_queued(user.id), & &1.id) == [first.id, second.id]
+    end
+
+    test "position counts a request that is already being replayed" do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      first = enqueue!(user, agent)
+      second = enqueue!(user, agent)
+
+      {1, _} =
+        Repo.update_all(from(r in Request, where: r.id == ^first.id), set: [status: "starting"])
+
+      assert SandboxQueue.position(Repo.get!(Request, second.id)) == 2
+    end
+
+    test "a request that is no longer waiting has no position" do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      request = enqueue!(user, agent)
+
+      assert SandboxQueue.position(%{request | status: "started"}) == nil
+    end
+
+    test "refuses work beyond the depth bound" do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+
+      for _ <- 1..10, do: enqueue!(user, agent)
+
+      assert {:error, :queue_full} =
+               SandboxQueue.enqueue(%{
+                 user_id: user.id,
+                 agent_id: agent.id,
+                 kind: "start",
+                 attrs: %{}
+               })
+    end
+
+    test "the depth bound counts claimed rows, not just waiting ones" do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+
+      for _ <- 1..10, do: enqueue!(user, agent)
+
+      {10, _} = Repo.update_all(Request, set: [status: "starting"])
+
+      assert {:error, :queue_full} =
+               SandboxQueue.enqueue(%{
+                 user_id: user.id,
+                 agent_id: agent.id,
+                 kind: "start",
+                 attrs: %{}
+               })
+    end
+
+    test "the depth bound is per tenant" do
+      user = insert_verified_user()
+      other = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      other_agent = insert_agent(user_id: other.id)
+
+      for _ <- 1..10, do: enqueue!(user, agent)
+
+      assert {:ok, _} =
+               SandboxQueue.enqueue(%{
+                 user_id: other.id,
+                 agent_id: other_agent.id,
+                 kind: "start",
+                 attrs: %{}
+               })
+    end
+
+    test "deduplicates a scheduled run even when the queue is full" do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      schedule_id = Ecto.UUID.generate()
+
+      {:ok, first} =
+        SandboxQueue.enqueue(%{
+          user_id: user.id,
+          agent_id: agent.id,
+          kind: "schedule_run",
+          schedule_id: schedule_id
+        })
+
+      for _ <- 1..9, do: enqueue!(user, agent)
+
+      assert {:ok, again} =
+               SandboxQueue.enqueue(%{
+                 user_id: user.id,
+                 agent_id: agent.id,
+                 kind: "schedule_run",
+                 schedule_id: schedule_id
+               })
+
+      assert again.id == first.id
+    end
+
+    test "a schedule whose last request already finished queues a fresh one" do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      schedule_id = Ecto.UUID.generate()
+
+      {:ok, first} =
+        SandboxQueue.enqueue(%{
+          user_id: user.id,
+          agent_id: agent.id,
+          kind: "schedule_run",
+          schedule_id: schedule_id
+        })
+
+      {1, _} =
+        Repo.update_all(from(r in Request, where: r.id == ^first.id), set: [status: "started"])
+
+      assert {:ok, second} =
+               SandboxQueue.enqueue(%{
+                 user_id: user.id,
+                 agent_id: agent.id,
+                 kind: "schedule_run",
+                 schedule_id: schedule_id
+               })
+
+      refute second.id == first.id
+    end
+
+    test "a deduplicated firing records nothing, because nothing was written" do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      schedule_id = Ecto.UUID.generate()
+
+      params = %{
+        user_id: user.id,
+        agent_id: agent.id,
+        kind: "schedule_run",
+        schedule_id: schedule_id
+      }
+
+      {:ok, _} = SandboxQueue.enqueue(params)
+      {:ok, _} = SandboxQueue.enqueue(params)
+      {:ok, _} = SandboxQueue.enqueue(params)
+
+      # One row, and one audit event for it. A trail that logged the two
+      # firings that wrote nothing would report three enqueues for one request.
+      assert enqueued_events(user) |> length() == 1
+    end
+
+    test "carries the sandbox restriction the request arrived under" do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      key_id = Ecto.UUID.generate()
+
+      request = enqueue!(user, agent, %{sandbox_key_id: key_id})
+
+      # Not a credential — the rule a replay has to be held to (ADR 0045).
+      assert Repo.get!(Request, request.id).sandbox_key_id == key_id
+    end
+  end
+
+  describe "schedule_request/2" do
+    test "finds a schedule's live request and stops once it is terminal" do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      schedule_id = Ecto.UUID.generate()
+
+      refute SandboxQueue.schedule_request(user.id, schedule_id)
+
+      request =
+        enqueue!(user, agent, %{kind: "schedule_run", schedule_id: schedule_id, attrs: %{}})
+
+      assert SandboxQueue.schedule_request(user.id, schedule_id).id == request.id
+
+      {1, _} =
+        Repo.update_all(from(r in Request, where: r.id == ^request.id),
+          set: [status: "started"]
+        )
+
+      refute SandboxQueue.schedule_request(user.id, schedule_id)
+    end
+
+    test "does not cross tenant scope" do
+      user = insert_verified_user()
+      other = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      schedule_id = Ecto.UUID.generate()
+
+      enqueue!(user, agent, %{kind: "schedule_run", schedule_id: schedule_id, attrs: %{}})
+
+      refute SandboxQueue.schedule_request(other.id, schedule_id)
+    end
+  end
+
+  test "reads are tenant-scoped" do
+    user = insert_verified_user()
+    other = insert_verified_user()
+    agent = insert_agent(user_id: user.id)
+    request = enqueue!(user, agent)
+
+    assert SandboxQueue.get_request(request.id, other.id) == nil
+    assert SandboxQueue.list_queued(other.id) == []
+    assert SandboxQueue.get_request(request.id, user.id).id == request.id
+  end
+
+  test "a malformed id reads as missing rather than raising" do
+    user = insert_verified_user()
+    assert SandboxQueue.get_request("not-a-uuid", user.id) == nil
+  end
+
+  test "cancellation is a compare-and-swap and erases the prompt" do
+    user = insert_verified_user()
+    agent = insert_agent(user_id: user.id)
+    request = enqueue!(user, agent)
+
+    assert {:ok, cancelled} = SandboxQueue.cancel_request(request)
+    assert cancelled.status == "cancelled"
+    assert cancelled.attrs == %{}
+    assert {:error, :not_found} = SandboxQueue.cancel_request(request)
+  end
+
+  test "cancellation refuses a request the drainer already claimed" do
+    user = insert_verified_user()
+    agent = insert_agent(user_id: user.id)
+    request = enqueue!(user, agent)
+
+    {1, _} =
+      Repo.update_all(from(r in Request, where: r.id == ^request.id), set: [status: "starting"])
+
+    # The caller still holds the `queued` struct it fetched a moment ago.
+    # Cancelling on that stale read would abandon a start already in flight.
+    assert {:error, :not_found} = SandboxQueue.cancel_request(request)
+    assert Repo.get!(Request, request.id).status == "starting"
+  end
+end

--- a/config/config.exs
+++ b/config/config.exs
@@ -104,6 +104,13 @@ config :fountain, :sandboxes,
   cap_ceiling: 20,
   fleet_ceiling: 20
 
+# The bounded wait in front of those two ceilings (ADR 0042). Depth is per
+# tenant; the wait bound is what stops a queued start outliving the intent
+# behind its prompt.
+config :fountain,
+  sandbox_queue_max_depth: 10,
+  sandbox_queue_max_wait_seconds: 3600
+
 # Prepaid credits (ADR 0030). Cents. `turn_hour_cents` is the customer price
 # of one hour of turn time; the comms prices are nil until an operator sets
 # them, and nil burns nothing (#1042). runtime.exs overrides from CREDIT_*.

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1017,6 +1017,11 @@ config :fountain, :sandboxes,
   cap_ceiling: whole_number.("SANDBOX_CAP_CEILING", 20),
   fleet_ceiling: whole_number.("SANDBOX_FLEET_CEILING", 20)
 
+# The bounded sandbox-capacity queue (ADR 0042).
+config :fountain,
+  sandbox_queue_max_depth: whole_number.("SANDBOX_QUEUE_MAX_DEPTH", 10),
+  sandbox_queue_max_wait_seconds: whole_number.("SANDBOX_QUEUE_MAX_WAIT_SECONDS", 3600)
+
 # Teammate contacts one account may hold at once — an abuse ceiling.
 config :fountain, :team_contact_ceiling, whole_number.("TEAM_CONTACT_CEILING", 10)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -158,6 +158,8 @@ at a dead end, with no error to see. Read [Email](guides/operate/email.md).
 | `SANDBOX_CAP_FLOOR` | `2` | No. | The fewest sandboxes a tenant with a positive balance may run at once. |
 | `SANDBOX_CAP_CEILING` | `20` | No. | The most sandboxes one tenant may run at once, unless an admin override raises it. |
 | `SANDBOX_FLEET_CEILING` | `20` | No. | The most live sandboxes across every tenant. Set it to what your sandbox provider plan allows. A start beyond it gets `503 fleet_full`. |
+| `SANDBOX_QUEUE_MAX_DEPTH` | `10` | No. | The most sandbox requests one tenant holds at once. A request beyond it keeps the immediate capacity error. |
+| `SANDBOX_QUEUE_MAX_WAIT_SECONDS` | `3600` | No. | How long a sandbox request waits for capacity before Fountain expires it. |
 | `FOUNTAIN_EXECUTION_LIMITS` | `{}` | No. | JSON per-turn host ceiling: `wall_time_seconds`, `max_model_turns`, `max_estimated_cost_usd`. Each configured value must be positive; time and turns must be integers. Read at boot; invalid input refuses startup. Requests inherit the stricter host/account ceiling. Keep unset until runtime enforcement and later-turn/recovery checks are integrated: nonempty effective limits currently refuse launch with `422 execution_limits_unsupported`. This is not an aggregate spend cap. |
 | `CREDIT_OPENING_CENTS` | `500` | No. | The credit a new account starts with, in cents. |
 | `CREDIT_OPENING_DAYS` | `14` | No. | How many days the opening credit lasts. |


### PR DESCRIPTION
Re-cut of #1481 as a stack of seven on `main`, under the no-big-PRs rule. The original is 2,171 lines across 44 files and 207 commits behind; this is re-derived against today's code rather than rebased.

This is the table and the tenant-scoped half of the context. `sandbox_requests` holds a start or a scheduled run before it has a sandbox or a conversation — a `queued` conversation status was the alternative, and it would put a row with no machine into every conversation list, every stream and every client enum.

`Fountain.SandboxQueue` gets `enqueue/2`, `list_queued/1`, `get_request/2`, `position/1` and `cancel_request/2`, plus the `SANDBOX_QUEUE_*` config keys. The depth bound is a check followed by an insert, so it takes a per-tenant advisory lock in its own namespace (4317), for the reason `Quotas.with_sandbox_reservation/3` holds one (#330). Cancellation is a compare-and-swap, not a read-then-write, so it can never reach a row the drainer has already claimed.

Audit rows for `sandbox_request.enqueued` and `sandbox_request.cancelled` are in `audit_guardrail_test.exs`, recorded outside the transaction.

**Defers:** the drain (part 2), everything that enqueues (parts 3 and 4), the HTTP endpoints (part 5), telemetry and retention (part 6), and ADR 0042 and the docs (part 7). Nothing enqueues and nothing drains yet.

Part 1 of 7 for #1033.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9jevFQT5MkF3rJUieeiHW


---

### Review fixes (round 2)

- The schedule dedup moved **inside** the advisory lock, so two firings of one schedule cannot both read "no live request" and both insert. `insert_bounded/1` returns `{:deduplicated, _}` or `{:inserted, _}`, and only an insert audits.
- `@active_statuses` is now `Request.active_statuses()` rather than a second copy of `~w(queued starting)`.
- **New `sandbox_key_id` column** — the restriction a request arrived under, so the replay can be held to ADR 0045 an hour later. Not a `references/2`, deliberately: a nilified id would turn a refusal into a permission the request never had. `schedule_id` gains the same note.
- New public `schedule_request/2`, which part 4 uses to keep a schedule row saying *waiting* instead of repeating a capacity error.
