### PR TITLE
feat(sandbox): claim before replay, fenced on the version claimed (#1033)

### DIFF
--- a/apps/fountain/lib/fountain/sandbox_queue.ex
+++ b/apps/fountain/lib/fountain/sandbox_queue.ex
@@ -15,20 +15,60 @@ defmodule Fountain.SandboxQueue do
   Bounded twice. A tenant holds at most `SANDBOX_QUEUE_MAX_DEPTH` active
   requests, and a request waits at most `SANDBOX_QUEUE_MAX_WAIT_SECONDS`.
   Beyond the depth bound the caller keeps its immediate capacity error.
+
+  ## Claiming
+
+  Several replicas can be told a slot freed at the same instant, so a drain
+  claims before it replays. Every write that moves a row out of a live status
+  is a compare-and-swap fenced on the `(status, updated_at)` the drain
+  observed, and a claim is the same compare-and-swap: `claim_next/2` will take
+  a `queued` row, or a `starting` row whose claim outran
+  `@claim_timeout_seconds` because the worker holding it died. Only the
+  replica that won the swap can write that row's outcome, so a zombie replay
+  cannot overwrite the row a recovering drain has since taken.
   """
 
   import Ecto.Query, only: [from: 2]
+
+  require Logger
 
   alias Fountain.Audit
   alias Fountain.Repo
   alias Fountain.SandboxQueue.Request
 
   @default_max_depth 10
+  @default_max_wait_seconds 3600
 
   # One source of truth. `Request.active_statuses/0` is what the ops gauge
   # reads too, and two copies would let the depth bound and the gauge disagree
   # silently if a status were ever added.
   @active_statuses Request.active_statuses()
+
+  # A worker can die after its compare-and-swap and before its replay
+  # finishes. Both replay paths normally return in milliseconds — provisioning
+  # happens in the ConversationServer, not under the claim — so five minutes
+  # identifies an abandoned claim with a wide margin.
+  @claim_timeout_seconds 300
+
+  # Not this request's fault and not this tenant's ceiling: the turn in flight
+  # ends, the home sandbox finishes provisioning, the runner comes back. The
+  # request goes back in line rather than burning its prompt on a condition
+  # that clears by itself. `Fountain.Workers.TeamScheduleRun` snoozes on
+  # exactly this list, for exactly this reason.
+  @transient_errors ~w(busy provisioning runner_offline sandbox_at_capacity)a
+
+  # Every replay and every terminal write the drain makes is attributed to the
+  # queue, not to whoever originally asked. The audit vocabulary is closed
+  # (ADR 0013) and `system:<worker>` is the shape a background caller takes.
+  @system_actor "system:sandbox_queue"
+
+  @doc """
+  The audit actor a replay runs as.
+
+  Exposed the way `Team.Schedules.actor/0` is, so a surface can tell the
+  drainer's replay from a person's own call without hardcoding the string.
+  """
+  def actor, do: @system_actor
 
   # Its own advisory-lock namespace. The depth bound counts rows in
   # `sandbox_requests` and has nothing to serialize against a sandbox
@@ -156,7 +196,7 @@ defmodule Fountain.SandboxQueue do
   reached a `starting` row would abandon a start already in flight.
   """
   def cancel_request(%Request{} = request, opts \\ []) do
-    case terminate(request.id, "queued", %{status: "cancelled", attrs: %{}}) do
+    case swap(request.id, "queued", %{status: "cancelled", attrs: %{}}) do
       {:ok, cancelled} ->
         audited(cancelled, "sandbox_request.cancelled", opts)
         emit_depth(cancelled.user_id)
@@ -167,19 +207,254 @@ defmodule Fountain.SandboxQueue do
     end
   end
 
-  # One compare-and-swap from `expected` to whatever `attrs` says, returning
-  # the row it wrote or `:stale` when somebody else moved it first. Every
-  # transition out of a live status goes through here, so no path in this
-  # module writes a status with a blind `Repo.update/1`.
-  defp terminate(id, expected, attrs) do
-    now = DateTime.utc_now()
-    sets = attrs |> Map.to_list() |> Keyword.put(:updated_at, now)
+  @doc """
+  Expire overdue work, then drain one tenant in FIFO claim order.
+
+  Returns `%{started:, failed:, expired:}`. Safe to run concurrently with
+  another drain of the same tenant: every row it touches is claimed first.
+  """
+  def drain(user_id) when is_binary(user_id) do
+    expired = expire_overdue(user_id)
+    {started, failed} = drain_loop(user_id, {0, 0})
+    emit_depth(user_id)
+    %{started: started, failed: failed, expired: expired}
+  end
+
+  @doc """
+  Whether any tenant has work waiting or claimed.
+
+  An existence probe against the partial index, for the choke point that has
+  to decide whether a freed slot is worth a job at all. Cheaper than
+  `user_ids_with_active_requests/0`, which scans for the distinct set.
+  """
+  def any_active_requests? do
+    Repo.exists?(from r in Request, where: r.status in ^@active_statuses)
+  end
+
+  @doc "Tenant ids with work waiting or currently claimed."
+  def user_ids_with_active_requests do
+    Repo.all(
+      from r in Request,
+        where: r.status in ^@active_statuses,
+        distinct: true,
+        select: r.user_id
+    )
+  end
+
+  # `skipped` holds the requests this pass released for a transient reason.
+  # Without it the loop would re-claim the row it just put back and spin.
+  defp drain_loop(user_id, counts, skipped \\ [])
+
+  defp drain_loop(user_id, {started, failed} = counts, skipped) do
+    case claim_next(user_id, skipped) do
+      nil ->
+        counts
+
+      {request, fence} ->
+        case attempt(request) do
+          {:ok, conversation_id} ->
+            finish(request, fence, %{status: "started", conversation_id: conversation_id})
+            drain_loop(user_id, {started + 1, failed}, skipped)
+
+          # Capacity did not free after all. Every request behind this one
+          # would meet the same wall, so stop the pass entirely rather than
+          # walk the whole queue into the same refusal.
+          {:error, {:sandbox_quota_exceeded, _}} ->
+            release(request, fence)
+            counts
+
+          {:error, :fleet_full} ->
+            release(request, fence)
+            counts
+
+          # Transient and specific to this request's teammate rather than to
+          # the tenant, so the rest of the queue can still make progress.
+          {:error, reason} when reason in @transient_errors ->
+            release(request, fence)
+            drain_loop(user_id, counts, [request.id | skipped])
+
+          {:error, reason} ->
+            finish(request, fence, %{status: "failed", error: describe(reason)})
+            drain_loop(user_id, {started, failed + 1}, skipped)
+        end
+    end
+  end
+
+  # The claim. Takes the oldest waiting row, or the oldest abandoned claim,
+  # and swaps it to `starting` fenced on the exact `(status, updated_at)` this
+  # read observed. Losing the swap means another replica got there first, so
+  # go round again rather than replaying a row somebody else owns.
+  defp claim_next(user_id, skipped) do
+    cutoff = DateTime.add(DateTime.utc_now(), -@claim_timeout_seconds, :second)
+
+    query =
+      from r in Request,
+        where:
+          r.user_id == ^user_id and r.id not in ^skipped and
+            (r.status == "queued" or (r.status == "starting" and r.updated_at < ^cutoff)),
+        order_by: [asc: r.inserted_at, asc: r.id],
+        limit: 1
+
+    case Repo.one(query) do
+      nil ->
+        nil
+
+      request ->
+        case swap_fenced(request, %{status: "starting"}) do
+          {:ok, claimed} ->
+            if request.status == "starting" do
+              Logger.info(
+                "sandbox queue: recovered request #{claimed.id} from an abandoned claim"
+              )
+            end
+
+            {claimed, claimed.updated_at}
+
+          # Another replica got there first. Skipping the row we lost makes
+          # termination structural — each turn round either claims a row or
+          # removes a candidate — rather than resting on the row no longer
+          # matching the query. A row that is claimed and released inside this
+          # pass simply waits for the next one.
+          :stale ->
+            claim_next(user_id, [request.id | skipped])
+        end
+    end
+  end
+
+  # Back in line, under the same fence. A lost swap means a recovering drain
+  # already took the claim: there is nothing left to release, and raising here
+  # would fail the job and strand every other request this tenant has waiting.
+  defp release(%Request{} = request, fence) do
+    case swap_fenced(%{request | status: "starting", updated_at: fence}, %{status: "queued"}) do
+      {:ok, _} ->
+        :ok
+
+      :stale ->
+        Logger.info("sandbox queue: request #{request.id} was no longer claimed on release")
+        :ok
+    end
+  end
+
+  # The terminal write, under the same fence for the same reason. A blind
+  # update here is the double-start hole: a replay slow enough to lose its
+  # claim would overwrite the row a recovering drain had already replayed.
+  defp finish(%Request{} = request, fence, attrs) do
+    case swap_fenced(
+           %{request | status: "starting", updated_at: fence},
+           Map.put(attrs, :attrs, %{})
+         ) do
+      {:ok, updated} ->
+        # The status names its own event. A `case` over today's two outcomes
+        # would be a `CaseClauseError` raised inside the pass the moment a
+        # third one is written through here, and it would strand every other
+        # request this tenant has waiting.
+        audited(updated, "sandbox_request.#{updated.status}", actor: @system_actor)
+        emit_completed(updated, request.inserted_at)
+        :ok
+
+      :stale ->
+        Logger.warning(
+          "sandbox queue: request #{request.id} lost its claim mid-replay; outcome not recorded"
+        )
+
+        :ok
+    end
+  end
+
+  defp attempt(%Request{kind: "start"} = request) do
+    attrs =
+      request.attrs
+      |> Map.put("user_id", request.user_id)
+      |> Map.put("agent_id", request.agent_id)
+      |> put_unless_nil("source", request.source)
+
+    with {:ok, conversation, _outcome} <-
+           Fountain.Conversations.start_or_resume_conversation(attrs, replay_opts(request)) do
+      {:ok, conversation.id}
+    end
+  end
+
+  defp attempt(%Request{kind: "schedule_run", schedule_id: schedule_id} = request) do
+    case Fountain.Team.Schedules.get_schedule(schedule_id, request.user_id) do
+      nil ->
+        {:error, :schedule_deleted}
+
+      schedule ->
+        with {:ok, conversation} <-
+               Fountain.Team.Schedules.run_schedule(schedule, actor: @system_actor) do
+          {:ok, conversation.id}
+        end
+    end
+  end
+
+  # What the door passed, minus what only a live request has. `source` is the
+  # provenance the API inferred from the parent-conversation header, so a
+  # queued fan-out has to replay as `agent` rather than default to `api`;
+  # `sandbox_key_id` is the ADR 0045 restriction, and dropping it would let a
+  # `sprite` token relabel a conversation it does not own by way of a
+  # `channel_id` resume the replay reaches an hour later. `request_ip` is
+  # deliberately absent: there is no request.
+  defp replay_opts(%Request{sandbox_key_id: nil}), do: [actor: @system_actor]
+
+  defp replay_opts(%Request{sandbox_key_id: key_id}),
+    do: [actor: @system_actor, sandbox_key_id: key_id]
+
+  defp put_unless_nil(attrs, _key, nil), do: attrs
+  defp put_unless_nil(attrs, key, value), do: Map.put(attrs, key, value)
+
+  defp expire_overdue(user_id) do
+    cutoff = DateTime.add(DateTime.utc_now(), -max_wait_seconds(), :second)
+
+    overdue =
+      Repo.all(
+        from r in Request,
+          where: r.user_id == ^user_id and r.status == "queued" and r.inserted_at < ^cutoff
+      )
+
+    Enum.count(overdue, fn request ->
+      case swap(request.id, "queued", %{status: "expired", attrs: %{}}) do
+        {:ok, expired} ->
+          audited(expired, "sandbox_request.expired", actor: @system_actor)
+          emit_completed(expired, request.inserted_at)
+          true
+
+        :stale ->
+          false
+      end
+    end)
+  end
+
+  # One compare-and-swap on status alone, for the transitions a caller makes
+  # from outside a claim. Returns the row it wrote, or `:stale` when somebody
+  # else moved it first. No path in this module writes a status with a blind
+  # `Repo.update/1`.
+  defp swap(id, expected_status, attrs) do
+    sets = attrs |> Map.to_list() |> Keyword.put(:updated_at, DateTime.utc_now())
 
     case Repo.update_all(
-           from(r in Request, where: r.id == ^id and r.status == ^expected),
+           from(r in Request, where: r.id == ^id and r.status == ^expected_status),
            set: sets
          ) do
       {1, _} -> {:ok, Repo.get!(Request, id)}
+      {0, _} -> :stale
+    end
+  end
+
+  # The same swap, fenced on the exact version observed. `updated_at` is
+  # microsecond-resolution and every write here changes it, so the pair is a
+  # version token: a writer holding an older one has been overtaken.
+  defp swap_fenced(observed, attrs) do
+    sets = attrs |> Map.to_list() |> Keyword.put(:updated_at, DateTime.utc_now())
+
+    case Repo.update_all(
+           from(r in Request,
+             where:
+               r.id == ^observed.id and r.status == ^observed.status and
+                 r.updated_at == ^observed.updated_at
+           ),
+           set: sets
+         ) do
+      {1, _} -> {:ok, Repo.get!(Request, observed.id)}
       {0, _} -> :stale
     end
   end
@@ -214,6 +489,24 @@ defmodule Fountain.SandboxQueue do
 
   defp existing_schedule_request(_params), do: nil
 
+  defp emit_completed(%Request{} = request, waiting_since) do
+    :telemetry.execute(
+      [:fountain, :sandbox_queue, :completed],
+      %{
+        wait_ms: DateTime.diff(DateTime.utc_now(), waiting_since, :millisecond),
+        count: 1
+      },
+      %{status: request.status, kind: request.kind}
+    )
+  end
+
+  defp describe({:sandbox_quota_exceeded, %{count: count, limit: limit}}),
+    do: "sandbox quota: #{count}/#{limit}"
+
+  defp describe(%Ecto.Changeset{}), do: "invalid conversation attrs"
+  defp describe(reason) when is_atom(reason), do: to_string(reason)
+  defp describe(reason), do: inspect(reason) |> String.slice(0, 250)
+
   defp emit_depth(user_id) do
     :telemetry.execute(
       [:fountain, :sandbox_queue, :tenant_depth],
@@ -246,4 +539,12 @@ defmodule Fountain.SandboxQueue do
 
   defp max_depth,
     do: Application.get_env(:fountain, :sandbox_queue_max_depth, @default_max_depth)
+
+  defp max_wait_seconds,
+    do:
+      Application.get_env(
+        :fountain,
+        :sandbox_queue_max_wait_seconds,
+        @default_max_wait_seconds
+      )
 end

--- a/apps/fountain/test/fountain/sandbox_queue_drain_test.exs
+++ b/apps/fountain/test/fountain/sandbox_queue_drain_test.exs
@@ -1,0 +1,437 @@
+defmodule Fountain.SandboxQueueDrainTest do
+  use Fountain.DataCase, async: true
+  use Mimic
+
+  alias Fountain.SandboxQueue
+  alias Fountain.SandboxQueue.Request
+
+  defp enqueue!(user, agent, extra \\ %{}) do
+    {:ok, request} =
+      SandboxQueue.enqueue(
+        Map.merge(
+          %{user_id: user.id, agent_id: agent.id, kind: "start", attrs: %{"prompt" => "hi"}},
+          extra
+        )
+      )
+
+    request
+  end
+
+  defp queue_events(user) do
+    user.id
+    |> Fountain.Audit.list_recent_for_user(50)
+    |> Enum.filter(&String.starts_with?(&1.action, "sandbox_request."))
+  end
+
+  defp queue_actions(user), do: queue_events(user) |> Enum.map(& &1.action)
+
+  defp fill_tenant_cap(user) do
+    for _ <- 1..Fountain.Quotas.sandbox_limit(user.id),
+        do: insert_sandbox(user_id: user.id, status: "ready")
+  end
+
+  defp fill_fleet do
+    hog = insert_verified_user(sandbox_limit_override: 100)
+
+    for _ <- 1..Fountain.Quotas.settings().fleet_ceiling,
+        do: insert_sandbox(user_id: hog.id, status: "ready")
+  end
+
+  # A persistent agent whose home is still building: a start for it reads
+  # `{:error, :provisioning}`, the transient shape the drain must not treat as
+  # terminal.
+  defp agent_mid_provision(user) do
+    agent = insert_agent(user_id: user.id, sandbox_mode: "persistent")
+    insert_sandbox(user_id: user.id, agent_id: agent.id, mode: "persistent", status: "pending")
+    agent
+  end
+
+  # The conversation row and the sandbox reservation are what this module is
+  # about; the runtime behind them is not. Stubbing the supervisor keeps the
+  # replay a database fact rather than a provisioning race.
+  defp inert_start_child do
+    stub(Horde.DynamicSupervisor, :start_child, fn _supervisor, _spec ->
+      {:ok, spawn(fn -> Process.sleep(:infinity) end)}
+    end)
+  end
+
+  describe "drain/1" do
+    test "starts work, links the conversation and erases queued attributes" do
+      user = insert_active_user()
+      agent = insert_agent(user_id: user.id)
+      request = enqueue!(user, agent)
+      inert_start_child()
+
+      assert %{started: 1, failed: 0, expired: 0} = SandboxQueue.drain(user.id)
+
+      reloaded = Repo.get!(Request, request.id)
+      assert reloaded.status == "started"
+      assert reloaded.attrs == %{}
+      assert Fountain.Conversations.get_conversation(reloaded.conversation_id, user.id)
+    end
+
+    test "an empty queue is a no-op" do
+      user = insert_active_user()
+      assert %{started: 0, failed: 0, expired: 0} = SandboxQueue.drain(user.id)
+    end
+
+    test "leaves a request waiting at the tenant cap" do
+      user = insert_active_user()
+      agent = insert_agent(user_id: user.id)
+      fill_tenant_cap(user)
+      request = enqueue!(user, agent)
+
+      assert %{started: 0, failed: 0, expired: 0} = SandboxQueue.drain(user.id)
+      assert Repo.get!(Request, request.id).status == "queued"
+    end
+
+    test "leaves a request waiting at the fleet ceiling" do
+      fill_fleet()
+      user = insert_active_user()
+      agent = insert_agent(user_id: user.id)
+      request = enqueue!(user, agent)
+
+      assert %{started: 0, failed: 0, expired: 0} = SandboxQueue.drain(user.id)
+      assert Repo.get!(Request, request.id).status == "queued"
+    end
+
+    test "a capacity refusal stops the pass instead of walking the whole queue" do
+      user = insert_active_user()
+      agent = insert_agent(user_id: user.id)
+      fill_tenant_cap(user)
+      first = enqueue!(user, agent)
+      second = enqueue!(user, agent)
+
+      assert %{started: 0, failed: 0} = SandboxQueue.drain(user.id)
+
+      # Both still waiting, and the one in front kept its place: every request
+      # behind it would have met the same wall.
+      assert Repo.get!(Request, first.id).status == "queued"
+      assert Repo.get!(Request, second.id).status == "queued"
+      assert SandboxQueue.position(Repo.get!(Request, first.id)) == 1
+    end
+
+    test "a request that lost its funding fails terminally and erases its prompt" do
+      user = insert_active_user()
+      agent = insert_agent(user_id: user.id)
+      request = enqueue!(user, agent)
+
+      {:ok, _} =
+        Fountain.Credits.debit(
+          user.id,
+          Fountain.Credits.balance(user.id) + 1,
+          "burn_turn",
+          idempotency_key: "queue-#{request.id}"
+        )
+
+      assert %{started: 0, failed: 1, expired: 0} = SandboxQueue.drain(user.id)
+
+      assert %{status: "failed", error: "insufficient_credits", attrs: %{}} =
+               Repo.get!(Request, request.id)
+    end
+
+    test "fails broken work without head-of-line blocking the next request" do
+      user = insert_active_user()
+      agent = insert_agent(user_id: user.id)
+      inert_start_child()
+
+      # A schedule id that names nothing: the replay reads :schedule_deleted,
+      # which is terminal.
+      {:ok, broken} =
+        SandboxQueue.enqueue(%{
+          user_id: user.id,
+          agent_id: agent.id,
+          kind: "schedule_run",
+          schedule_id: Ecto.UUID.generate()
+        })
+
+      alive = enqueue!(user, agent)
+
+      assert %{started: 1, failed: 1, expired: 0} = SandboxQueue.drain(user.id)
+      assert %{status: "failed", error: "schedule_deleted"} = Repo.get!(Request, broken.id)
+      assert Repo.get!(Request, alive.id).status == "started"
+    end
+
+    test "a transient failure goes back in line instead of burning the prompt" do
+      user = insert_active_user()
+      agent = agent_mid_provision(user)
+      request = enqueue!(user, agent)
+
+      assert %{started: 0, failed: 0, expired: 0} = SandboxQueue.drain(user.id)
+
+      reloaded = Repo.get!(Request, request.id)
+      assert reloaded.status == "queued"
+      assert reloaded.error == nil
+      assert reloaded.attrs["prompt"] == "hi"
+    end
+
+    test "a transient failure does not block the request behind it" do
+      user = insert_active_user()
+      waiting = enqueue!(user, agent_mid_provision(user))
+      alive = enqueue!(user, insert_agent(user_id: user.id))
+      inert_start_child()
+
+      assert %{started: 1, failed: 0, expired: 0} = SandboxQueue.drain(user.id)
+      assert Repo.get!(Request, waiting.id).status == "queued"
+      assert Repo.get!(Request, alive.id).status == "started"
+    end
+
+    test "records the outcome it wrote, attributed to the queue" do
+      user = insert_active_user()
+      agent = insert_agent(user_id: user.id)
+      request = enqueue!(user, agent)
+      inert_start_child()
+
+      assert %{started: 1} = SandboxQueue.drain(user.id)
+
+      assert event = Enum.find(queue_events(user), &(&1.action == "sandbox_request.started"))
+      assert event.actor == "system:sandbox_queue"
+      assert event.resource_type == "sandbox_request"
+      assert event.resource_id == request.id
+      assert event.metadata["conversation_id"] == Repo.get!(Request, request.id).conversation_id
+      # Provenance and an outcome, never the prompt (ADR 0013).
+      refute Map.has_key?(event.metadata, "prompt")
+    end
+
+    test "records a terminal failure with the reason, not the prompt" do
+      user = insert_active_user()
+      agent = insert_agent(user_id: user.id)
+      request = enqueue!(user, agent)
+
+      {:ok, _} =
+        Fountain.Credits.debit(
+          user.id,
+          Fountain.Credits.balance(user.id) + 1,
+          "burn_turn",
+          idempotency_key: "queue-#{request.id}"
+        )
+
+      assert %{failed: 1} = SandboxQueue.drain(user.id)
+
+      assert event = Enum.find(queue_events(user), &(&1.action == "sandbox_request.failed"))
+      assert event.actor == "system:sandbox_queue"
+      assert event.metadata["error"] == "insufficient_credits"
+      refute Map.has_key?(event.metadata, "prompt")
+    end
+
+    test "a release records nothing, because the request is still waiting" do
+      user = insert_active_user()
+      request = enqueue!(user, agent_mid_provision(user))
+
+      assert %{started: 0, failed: 0, expired: 0} = SandboxQueue.drain(user.id)
+
+      # A transient release is an attempt, not a change. Only the enqueue
+      # happened, so only the enqueue is on the trail (ADR 0013).
+      assert queue_actions(user) == ["sandbox_request.enqueued"]
+      assert Repo.get!(Request, request.id).status == "queued"
+    end
+
+    test "expires overdue work and erases its prompt" do
+      user = insert_active_user()
+      agent = insert_agent(user_id: user.id)
+      request = enqueue!(user, agent)
+
+      {1, _} =
+        Repo.update_all(from(r in Request, where: r.id == ^request.id),
+          set: [inserted_at: DateTime.add(DateTime.utc_now(), -2, :hour)]
+        )
+
+      assert %{started: 0, failed: 0, expired: 1} = SandboxQueue.drain(user.id)
+      assert %{status: "expired", attrs: %{}} = Repo.get!(Request, request.id)
+
+      assert event = Enum.find(queue_events(user), &(&1.action == "sandbox_request.expired"))
+      assert event.actor == "system:sandbox_queue"
+      assert event.resource_id == request.id
+    end
+  end
+
+  describe "what the door passed survives the replay" do
+    test "keeps the provenance the API inferred instead of defaulting to api" do
+      user = insert_active_user()
+      agent = insert_agent(user_id: user.id)
+      inert_start_child()
+
+      # A sandbox fan-out: `infer_provenance/1` reads the parent-conversation
+      # header and records `agent`. The request stores it in its own column, so
+      # the replay has to put it back — `start_conversation/2` defaults
+      # `attrs["source"] || "api"` and would otherwise relabel the fan-out as a
+      # plain API start.
+      request = enqueue!(user, agent, %{source: "agent"})
+
+      assert %{started: 1} = SandboxQueue.drain(user.id)
+
+      conversation_id = Repo.get!(Request, request.id).conversation_id
+      assert Fountain.Conversations.get_conversation(conversation_id, user.id).source == "agent"
+    end
+
+    test "holds a sprite token to the conversation it owns (ADR 0045)" do
+      user = insert_active_user()
+      agent = insert_agent(user_id: user.id)
+      inert_start_child()
+
+      # The conversation this channel is bound to belongs to another sandbox's
+      # token, and `labels` on a `channel_id` resume is a write to it. The door
+      # refuses that with `sandbox_key_id` in hand; the replay has to refuse it
+      # too, an hour later, or the queue is a way around the rule.
+      {their_key, _} = insert_sprite_api_key(user)
+      {our_key, _} = insert_sprite_api_key(user)
+
+      theirs =
+        insert_conversation(
+          user_id: user.id,
+          agent_id: agent.id,
+          channel_id: "fountain:team",
+          callback_api_key_id: their_key.id
+        )
+
+      request =
+        enqueue!(user, agent, %{
+          sandbox_key_id: our_key.id,
+          attrs: %{"channel_id" => "fountain:team", "labels" => %{"owner" => "someone-else"}}
+        })
+
+      assert %{failed: 1} = SandboxQueue.drain(user.id)
+
+      assert %{status: "failed", error: error} = Repo.get!(Request, request.id)
+      assert error == "sprite_may_not_label_another_conversation"
+      assert Fountain.Conversations.get_conversation(theirs.id, user.id).labels == %{}
+    end
+
+    test "a request with no sandbox restriction still resumes and labels" do
+      user = insert_active_user()
+      agent = insert_agent(user_id: user.id)
+      inert_start_child()
+
+      {their_key, _} = insert_sprite_api_key(user)
+
+      theirs =
+        insert_conversation(
+          user_id: user.id,
+          agent_id: agent.id,
+          channel_id: "fountain:team",
+          callback_api_key_id: their_key.id
+        )
+
+      # The owner's own credential carries no restriction, and the guard reads
+      # that as "may label any conversation it can already fetch". Pinned so
+      # the fix above cannot quietly become a blanket refusal.
+      request =
+        enqueue!(user, agent, %{
+          attrs: %{"channel_id" => "fountain:team", "labels" => %{"owner" => "me"}}
+        })
+
+      assert %{started: 1} = SandboxQueue.drain(user.id)
+      assert Repo.get!(Request, request.id).conversation_id == theirs.id
+
+      assert Fountain.Conversations.get_conversation(theirs.id, user.id).labels == %{
+               "owner" => "me"
+             }
+    end
+  end
+
+  describe "the claim" do
+    test "recovers a claim abandoned by a dead worker" do
+      user = insert_active_user()
+      agent = insert_agent(user_id: user.id)
+      request = enqueue!(user, agent)
+      inert_start_child()
+
+      {1, _} =
+        Repo.update_all(from(r in Request, where: r.id == ^request.id),
+          set: [
+            status: "starting",
+            updated_at: DateTime.add(DateTime.utc_now(), -10, :minute)
+          ]
+        )
+
+      assert %{started: 1, failed: 0, expired: 0} = SandboxQueue.drain(user.id)
+      assert Repo.get!(Request, request.id).status == "started"
+    end
+
+    test "leaves a claim that is still within its timeout alone" do
+      user = insert_active_user()
+      agent = insert_agent(user_id: user.id)
+      request = enqueue!(user, agent)
+
+      {1, _} =
+        Repo.update_all(from(r in Request, where: r.id == ^request.id),
+          set: [status: "starting", updated_at: DateTime.utc_now()]
+        )
+
+      assert %{started: 0, failed: 0, expired: 0} = SandboxQueue.drain(user.id)
+      assert Repo.get!(Request, request.id).status == "starting"
+    end
+
+    test "a claim recovered mid-replay does not have its outcome overwritten" do
+      user = insert_active_user()
+      agent = insert_agent(user_id: user.id)
+      request = enqueue!(user, agent)
+      inert_start_child()
+
+      # A replay that outran its claim timeout loses the row to a recovering
+      # drain, which may already have replayed and finished it. Injected at
+      # the last gate before the start returns, and moved to a terminal status
+      # so this pass cannot simply take it back.
+      #
+      # The blind `Repo.update/1` this fence replaced would write "started"
+      # and the loser's conversation id over the winner's row, so one request
+      # would read as one conversation while two were running.
+      stub(Fountain.Billing, :check_spend, fn user_id ->
+        Repo.update_all(from(r in Request, where: r.id == ^request.id),
+          set: [status: "cancelled", updated_at: DateTime.utc_now()]
+        )
+
+        Fountain.Credits.gate(user_id)
+      end)
+
+      assert %{started: 1, failed: 0, expired: 0} = SandboxQueue.drain(user.id)
+
+      reloaded = Repo.get!(Request, request.id)
+      assert reloaded.status == "cancelled"
+      assert reloaded.conversation_id == nil
+    end
+
+    test "a claim lost before release leaves the recovering drain's row alone" do
+      user = insert_active_user()
+      agent = agent_mid_provision(user)
+      request = enqueue!(user, agent)
+
+      stub(Fountain.Billing, :check_spend, fn user_id ->
+        Repo.update_all(from(r in Request, where: r.id == ^request.id),
+          set: [status: "cancelled", updated_at: DateTime.utc_now()]
+        )
+
+        Fountain.Credits.gate(user_id)
+      end)
+
+      assert %{started: 0, failed: 0, expired: 0} = SandboxQueue.drain(user.id)
+      assert Repo.get!(Request, request.id).status == "cancelled"
+    end
+  end
+
+  describe "the fan-out reads" do
+    test "any_active_requests? sees waiting and claimed work only" do
+      user = insert_active_user()
+      agent = insert_agent(user_id: user.id)
+      refute SandboxQueue.any_active_requests?()
+
+      request = enqueue!(user, agent)
+      assert SandboxQueue.any_active_requests?()
+
+      {:ok, _} = SandboxQueue.cancel_request(request)
+      refute SandboxQueue.any_active_requests?()
+    end
+
+    test "user_ids_with_active_requests lists each tenant once" do
+      user = insert_active_user()
+      other = insert_active_user()
+      agent = insert_agent(user_id: user.id)
+      enqueue!(user, agent)
+      enqueue!(user, agent)
+      enqueue!(other, insert_agent(user_id: other.id))
+
+      assert Enum.sort(SandboxQueue.user_ids_with_active_requests()) ==
+               Enum.sort([user.id, other.id])
+    end
+  end
+end


### PR DESCRIPTION
Stacked on #1869.

The claim/drain state machine. `drain/1` expires overdue work, then replays one tenant's queue in FIFO order, and a replay ends three ways:

- a **capacity** refusal (`sandbox_quota_exceeded`, `fleet_full`) returns the claim and stops the pass, because every request behind it would meet the same wall;
- a **transient** refusal (`:busy`, `:provisioning`, `:runner_offline`, `:sandbox_at_capacity`) returns the claim and the drain moves past it, for the reason `Workers.TeamScheduleRun` snoozes on that same list — the turn in flight ends, the home finishes building, the runner comes back, and treating those as terminal would destroy the prompt over a condition that clears by itself;
- anything else is terminal.

**The one place this departs from #1481's design.** Every write out of a live status is a compare-and-swap fenced on the `(status, updated_at)` the drain observed, and the claim is the same swap: `claim_next/2` takes a `queued` row, *or* a `starting` row whose claim outran five minutes because the worker holding it died. #1481 recovered stale claims in a separate `update_all` pass at the top of each drain and then wrote outcomes with a blind `Repo.update/1`. That leaves a window: a replay slow enough to lose its claim writes `"started"` and its own conversation id over the row a recovering drain has already replayed, so one request reads as one conversation while two are running. Folding recovery into the claim and fencing every later write closes it. `sandbox_queue_drain_test.exs` has the two regression tests ("a claim recovered mid-replay does not have its outcome overwritten", "a claim lost before release leaves the recovering drain's row alone").

Also here: `any_active_requests?/0` and `user_ids_with_active_requests/0`, the two reads the fan-out in part 3 needs.

**Defers:** nothing calls `drain/1` yet — the worker and the poke are part 3. Producers are part 4, endpoints part 5, telemetry declarations part 6, ADR and docs part 7.

Part 2 of 7 for #1033.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9jevFQT5MkF3rJUieeiHW


---

### Review fixes (round 2)

- **`attempt/1` restores `source`.** It was dropped, so every queued fan-out replayed as `source: "api"` instead of `"agent"`.
- **`attempt/1` carries `sandbox_key_id`** through `replay_opts/1`. Without it a `sprite`-scoped token could queue a `channel_id` start with `labels` and have the drainer merge them into a conversation the token does not own — the write ADR 0045 has `set_conversation_labels/4` refuse at the door.
- `finish/3` names its event from the status instead of a two-arm `case` that would be a `CaseClauseError` inside a drain pass.
- `claim_next/2` adds a lost row to `skipped`, so the loop terminates structurally.
- Audit assertions for `sandbox_request.started`, `.failed` and `.expired`, plus one that a transient release records nothing.

Both replay fixes were verified by reverting them: the ADR 0045 test fails with `started: 1` (the relabel going through) and the provenance test with `left: "api"`.


---

### Review fixes (round 3)

`SandboxQueue.actor/0` exposes `"system:sandbox_queue"` the way `Team.Schedules.actor/0` exposes its own, so a surface can tell the drainer's replay from a person's own call without hardcoding the string. Used by part 4 to decide which callers are silent about a wait.



Part of #1033
