### PR TITLE
feat(workers): drain the queue when a sandbox frees its slot (#1033)

### DIFF
--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -263,11 +263,39 @@ defmodule Fountain.Conversations do
     case result do
       {:ok, {was, updated}} ->
         record_sandbox_usage(was, updated)
+        maybe_poke_sandbox_queue(was, updated)
         {:ok, updated}
 
       {:error, _} = error ->
         error
     end
+  end
+
+  # A transition out of a cap-counting status frees a tenant slot and the
+  # deployment-wide fleet slot at once, so every tenant with live queue work
+  # wants draining — not just this one (ADR 0042 decision 5). This is the
+  # choke point every sandbox status change goes through and almost every one
+  # of them happens with an empty queue, so the cost here is one existence
+  # probe against a partial index. When there is work it is one Oban insert,
+  # and the job does the scan that finds the tenants.
+  defp maybe_poke_sandbox_queue(was, %Sandbox{} = updated) do
+    active = Fountain.Quotas.active_statuses()
+
+    if was in active and updated.status not in active and
+         Fountain.SandboxQueue.any_active_requests?() do
+      Fountain.Workers.SandboxQueueDrainer.poke_all_later()
+    end
+
+    :ok
+  rescue
+    # Best-effort for the same reason `Billing.record_usage/5` rescues at this
+    # choke point: the row is already committed, nearly every call site matches
+    # `{:ok, _}` (ConversationServer's terminate path, `Accounts.Deletion`,
+    # `SandboxReaper`), and a failed poke must not take down a caller that only
+    # wanted to write a status. The cron backstop drains anyway.
+    e ->
+      Logger.warning("sandbox queue poke failed: #{Exception.message(e)}")
+      :ok
   end
 
   defp prevent_sandbox_revival(changeset) do

--- a/apps/fountain/lib/fountain/workers/sandbox_queue_drainer.ex
+++ b/apps/fountain/lib/fountain/workers/sandbox_queue_drainer.ex
@@ -1,0 +1,75 @@
+defmodule Fountain.Workers.SandboxQueueDrainer do
+  @moduledoc """
+  Drains sandbox requests after capacity changes (#1033, ADR 0042).
+
+  Two job shapes. `%{user_id: id}` drains one tenant. `%{scope: "all"}` (and
+  the cron's empty args) fans out to every tenant with live work. The choke
+  point that frees a slot schedules the fan-out, so a caller writing one
+  sandbox row pays for one insert rather than a scan plus an insert per
+  waiting tenant.
+
+  A drain is Oban work rather than a task started from the path that freed the
+  slot: it outlives the request, it must survive a replica going away
+  mid-drain, and an unawaited `Task.async` linked to a web request would take
+  that request down when a replay failed (#1040).
+
+  Uniqueness is `[:user_id, :scope]` over `:scheduled` only. `:scope` is in
+  the key so a fan-out job and a tenant job are never mistaken for each other.
+  Oban's own state groups are the only alternative to `:scheduled` here, and
+  every one of them includes `executing` — a poke reporting capacity that a
+  running drain has already read past must create a follow-up job, not vanish
+  into a uniqueness window.
+  """
+
+  use Oban.Worker,
+    queue: :maintenance,
+    max_attempts: 3,
+    unique: [keys: [:user_id, :scope], period: 30, states: :scheduled]
+
+  alias Fountain.SandboxQueue
+
+  require Logger
+
+  @doc "Enqueue a drain for one tenant."
+  def poke(user_id) when is_binary(user_id) do
+    %{user_id: user_id} |> new(schedule_in: 1) |> Oban.insert()
+    :ok
+  end
+
+  @doc """
+  Enqueue one job that fans out to every tenant with live requests.
+
+  One insert, not one per waiting tenant: the caller is
+  `Conversations.update_sandbox/2`, the choke point every sandbox status
+  change goes through, and the scan that finds those tenants belongs in a job
+  rather than on the path that wrote the row.
+  """
+  def poke_all_later do
+    %{scope: "all"} |> new(schedule_in: 1) |> Oban.insert()
+    :ok
+  end
+
+  @doc "Enqueue one drain for every tenant with live requests."
+  def poke_all do
+    Enum.each(SandboxQueue.user_ids_with_active_requests(), &poke/1)
+    :ok
+  end
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"user_id" => user_id}}) do
+    %{started: started, failed: failed, expired: expired} = SandboxQueue.drain(user_id)
+
+    if started + failed + expired > 0 do
+      Logger.info(
+        "sandbox queue: user #{user_id} started #{started}, failed #{failed}, expired #{expired}"
+      )
+    end
+
+    :ok
+  end
+
+  def perform(%Oban.Job{args: %{"scope" => "all"}}), do: poke_all()
+
+  # The cron backstop arrives with no args at all.
+  def perform(%Oban.Job{args: args}) when map_size(args) == 0, do: poke_all()
+end

--- a/apps/fountain/test/fountain/workers/sandbox_queue_drainer_test.exs
+++ b/apps/fountain/test/fountain/workers/sandbox_queue_drainer_test.exs
@@ -1,0 +1,131 @@
+defmodule Fountain.Workers.SandboxQueueDrainerTest do
+  use Fountain.DataCase, async: true
+  use Mimic
+
+  alias Fountain.SandboxQueue
+  alias Fountain.SandboxQueue.Request
+  alias Fountain.Workers.SandboxQueueDrainer
+
+  defp enqueue!(user, agent) do
+    {:ok, request} =
+      SandboxQueue.enqueue(%{
+        user_id: user.id,
+        agent_id: agent.id,
+        kind: "start",
+        attrs: %{"prompt" => "hi"}
+      })
+
+    request
+  end
+
+  defp inert_start_child do
+    stub(Horde.DynamicSupervisor, :start_child, fn _supervisor, _spec ->
+      {:ok, spawn(fn -> Process.sleep(:infinity) end)}
+    end)
+  end
+
+  describe "perform/1" do
+    test "a tenant job drains that tenant's queue" do
+      user = insert_active_user()
+      request = enqueue!(user, insert_agent(user_id: user.id))
+      inert_start_child()
+
+      assert :ok = perform_job(SandboxQueueDrainer, %{"user_id" => user.id})
+      assert Repo.get!(Request, request.id).status == "started"
+    end
+
+    test "the fan-out job pokes every tenant with live work" do
+      user = insert_active_user()
+      enqueue!(user, insert_agent(user_id: user.id))
+
+      assert :ok = perform_job(SandboxQueueDrainer, %{"scope" => "all"})
+      assert_enqueued(worker: SandboxQueueDrainer, args: %{user_id: user.id})
+    end
+
+    test "the cron backstop pokes every tenant with live work" do
+      users = for _ <- 1..2, do: insert_active_user()
+      for user <- users, do: enqueue!(user, insert_agent(user_id: user.id))
+
+      assert :ok = perform_job(SandboxQueueDrainer, %{})
+
+      for user <- users do
+        assert_enqueued(worker: SandboxQueueDrainer, args: %{user_id: user.id})
+      end
+    end
+
+    test "the fan-out skips a tenant whose only request already finished" do
+      user = insert_active_user()
+      request = enqueue!(user, insert_agent(user_id: user.id))
+      {:ok, _} = SandboxQueue.cancel_request(request)
+
+      assert :ok = perform_job(SandboxQueueDrainer, %{"scope" => "all"})
+      refute_enqueued(worker: SandboxQueueDrainer, args: %{user_id: user.id})
+    end
+  end
+
+  describe "the poke on a freed slot" do
+    test "a slot-freeing transition schedules one fan-out, not one job per tenant" do
+      owner = insert_verified_user()
+      waiting = insert_verified_user()
+      enqueue!(waiting, insert_agent(user_id: waiting.id))
+      sandbox = insert_sandbox(user_id: owner.id, status: "ready")
+
+      {:ok, _} = Fountain.Conversations.update_sandbox(sandbox, %{status: "terminated"})
+
+      assert_enqueued(worker: SandboxQueueDrainer, args: %{scope: "all"})
+      refute_enqueued(worker: SandboxQueueDrainer, args: %{user_id: waiting.id})
+
+      # The tenant job is the fan-out job's work, not the caller's.
+      assert :ok = perform_job(SandboxQueueDrainer, %{"scope" => "all"})
+      assert_enqueued(worker: SandboxQueueDrainer, args: %{user_id: waiting.id})
+    end
+
+    test "a slot-freeing transition with an empty queue schedules nothing" do
+      user = insert_verified_user()
+      sandbox = insert_sandbox(user_id: user.id, status: "ready")
+
+      {:ok, _} = Fountain.Conversations.update_sandbox(sandbox, %{status: "terminated"})
+
+      refute_enqueued(worker: SandboxQueueDrainer)
+    end
+
+    test "a transition that frees nothing schedules nothing" do
+      user = insert_verified_user()
+      waiting = insert_verified_user()
+      enqueue!(waiting, insert_agent(user_id: waiting.id))
+      sandbox = insert_sandbox(user_id: user.id, status: "pending")
+
+      # pending -> ready is still a cap-counting status on both sides.
+      {:ok, _} = Fountain.Conversations.update_sandbox(sandbox, %{status: "ready"})
+
+      refute_enqueued(worker: SandboxQueueDrainer)
+    end
+
+    test "parking a sandbox frees a slot and pokes" do
+      user = insert_verified_user()
+      waiting = insert_verified_user()
+      enqueue!(waiting, insert_agent(user_id: waiting.id))
+      sandbox = insert_sandbox(user_id: user.id, status: "ready")
+
+      # `suspended` is deliberately outside `Quotas.active_statuses/0`, so a
+      # park releases capacity exactly as a terminate does (ADR 0017).
+      {:ok, _} = Fountain.Conversations.update_sandbox(sandbox, %{status: "suspended"})
+
+      assert_enqueued(worker: SandboxQueueDrainer, args: %{scope: "all"})
+    end
+
+    test "a poke that raises never takes down the caller that freed the slot" do
+      user = insert_verified_user()
+      waiting = insert_verified_user()
+      enqueue!(waiting, insert_agent(user_id: waiting.id))
+      sandbox = insert_sandbox(user_id: user.id, status: "ready")
+
+      stub(SandboxQueueDrainer, :poke_all_later, fn ->
+        raise DBConnection.ConnectionError, "connection not available"
+      end)
+
+      assert {:ok, %{status: "terminated"}} =
+               Fountain.Conversations.update_sandbox(sandbox, %{status: "terminated"})
+    end
+  end
+end

--- a/apps/fountain/test/test_helper.exs
+++ b/apps/fountain/test/test_helper.exs
@@ -91,6 +91,7 @@ Mimic.copy(Fountain.Health)
 Mimic.copy(FountainWeb.OAuth)
 Mimic.copy(Fountain.Mailer)
 Mimic.copy(Fountain.InferenceCredentials)
+Mimic.copy(Fountain.Workers.SandboxQueueDrainer)
 
 # ─── The schema guard (#1427) ────────────────────────────────────────────────
 #

--- a/config/config.exs
+++ b/config/config.exs
@@ -66,7 +66,11 @@ config :fountain, Oban,
        # 06:47 UTC daily: rent for numbers and inboxes, the grace reminders,
        # and the release on day seven (ADR 0030 decision 4). No-ops until a
        # rent price is set.
-       {"47 6 * * *", Fountain.Workers.CreditRentCollector}
+       {"47 6 * * *", Fountain.Workers.CreditRentCollector},
+       # Five-minute backstop for the event-driven sandbox queue (ADR 0042).
+       # Normal drains come from a sandbox leaving a cap-counting status; this
+       # catches a lost poke and expires work that waited too long.
+       {"*/5 * * * *", Fountain.Workers.SandboxQueueDrainer}
      ]}
   ]
 


### PR DESCRIPTION
Stacked on #1870.

What makes a freed slot drain the queue. `Conversations.update_sandbox/2` is the choke point every sandbox status change goes through, and a transition out of a cap-counting status frees both a tenant slot and the deployment-wide fleet slot — so the poke fans out to every tenant with live work, not just this one. A slot another tenant freed is exactly what lets this one start.

The cost on the caller's path is one existence probe against the partial index, and almost every status change happens with an empty queue. When there is work it is one Oban insert, and the job does the scan that finds the tenants — never a scan plus an insert per waiting tenant on the path that wrote the row. The poke is best-effort for the same reason metering is at that choke point: the row is already committed, nearly every call site matches `{:ok, _}`, and a failed poke must not take down a caller that only wanted to write a status.

A drain is Oban work rather than a task started from the request path. It outlives the request, it has to survive a replica going away mid-drain, and an unawaited `Task.async` linked to a web request would take that request down when a replay failed (#1040).

Uniqueness is `[:user_id, :scope]` over `:scheduled` only. Every Oban state group that includes `executing` would let a poke reporting capacity a running drain has already read past vanish into the uniqueness window. A five-minute cron is the lost-poke and expiry backstop.

`sandbox_queue_drainer_test.exs` covers the three job shapes and five properties of the poke, including that `suspended` frees a slot (it is outside `Quotas.active_statuses/0`, ADR 0017), that `pending -> ready` frees nothing, and that a raising poke never takes down the caller.

**Defers:** producers (part 4), endpoints (part 5), the metric declarations for the events already emitted (part 6), ADR and docs (part 7).

Part 3 of 7 for #1033.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9jevFQT5MkF3rJUieeiHW



Part of #1033
