### PR TITLE
feat(api): queue: true on a start, and a cron firing that waits (#1033)

### DIFF
--- a/apps/fountain/lib/fountain/sandbox_queue.ex
+++ b/apps/fountain/lib/fountain/sandbox_queue.ex
@@ -199,6 +199,7 @@ defmodule Fountain.SandboxQueue do
     case swap(request.id, "queued", %{status: "cancelled", attrs: %{}}) do
       {:ok, cancelled} ->
         audited(cancelled, "sandbox_request.cancelled", opts)
+        note_schedule_outcome(cancelled)
         emit_depth(cancelled.user_id)
         {:ok, cancelled}
 
@@ -402,6 +403,17 @@ defmodule Fountain.SandboxQueue do
   defp put_unless_nil(attrs, _key, nil), do: attrs
   defp put_unless_nil(attrs, key, value), do: Map.put(attrs, key, value)
 
+  # A `schedule_run` that ended without running has to tell its schedule, or
+  # that row keeps reporting a wait that is over. `started` and `failed` went
+  # through `run_schedule/2`, which wrote the row itself; `expired` and
+  # `cancelled` never reach it.
+  defp note_schedule_outcome(%Request{kind: "schedule_run", schedule_id: id} = request)
+       when is_binary(id) do
+    Fountain.Team.Schedules.note_queued_run_ended(id, request.user_id, request.status)
+  end
+
+  defp note_schedule_outcome(%Request{}), do: :ok
+
   defp expire_overdue(user_id) do
     cutoff = DateTime.add(DateTime.utc_now(), -max_wait_seconds(), :second)
 
@@ -415,6 +427,7 @@ defmodule Fountain.SandboxQueue do
       case swap(request.id, "queued", %{status: "expired", attrs: %{}}) do
         {:ok, expired} ->
           audited(expired, "sandbox_request.expired", actor: @system_actor)
+          note_schedule_outcome(expired)
           emit_completed(expired, request.inserted_at)
           true
 

--- a/apps/fountain/lib/fountain/team/schedules.ex
+++ b/apps/fountain/lib/fountain/team/schedules.ex
@@ -36,6 +36,49 @@ defmodule Fountain.Team.Schedules do
 
   @actor "system:team_scheduler"
 
+  @doc """
+  What a schedule row says once its queued run ended without ever running.
+
+  `Fountain.SandboxQueue` calls this on the two terminal transitions that never
+  reach `run_schedule/2`: a request that expired at the wait bound, and one
+  somebody cancelled. Without it `last_error` keeps reporting a wait that is
+  over — a cron schedule self-corrects at its next firing, but a `one_off` has
+  no next firing, so its row would claim it was waiting for a slot nothing is
+  waiting for.
+
+  No `last_run_at`: nothing ran. Not audited either, because
+  `sandbox_request.expired` and `sandbox_request.cancelled` already record the
+  event this mirrors onto the schedule, and the trail is not a second copy of
+  it (ADR 0013).
+  """
+  def note_queued_run_ended(schedule_id, user_id, status)
+      when is_binary(schedule_id) and is_binary(user_id) and is_binary(status) do
+    case get_schedule(schedule_id, user_id) do
+      nil ->
+        :ok
+
+      schedule ->
+        {:ok, _} =
+          schedule
+          |> Schedule.run_changeset(%{last_error: describe_queue_outcome(status)})
+          |> Repo.update()
+
+        Team.broadcast_schedules_changed(user_id)
+        :ok
+    end
+  end
+
+  defp describe_queue_outcome("expired"), do: "timed out waiting for a free sandbox slot"
+  defp describe_queue_outcome("cancelled"), do: "the queued run was cancelled"
+  defp describe_queue_outcome(status), do: "the queued run ended: #{status}"
+
+  # What the row says while work sits in the queue. Reported by every caller,
+  # not only the one that enqueued: the drainer replays with
+  # `actor: "system:sandbox_queue"`, and a replay that met the ceiling again
+  # must leave the row saying "waiting" rather than flip it back to the
+  # capacity error the queue exists to absorb (ADR 0042 decision 3).
+  @waiting "waiting for a free sandbox slot"
+
   @doc "The audit actor a run fires as."
   def actor, do: @actor
 
@@ -161,9 +204,14 @@ defmodule Fountain.Team.Schedules do
   now". Returns `{:ok, conv}` with the conversation the prompt went to, or
   the `Team.send_message/5` / `Conversations.start_conversation/2` error
   unchanged (`:busy`, `:provisioning`, `:not_found`, `{:sandbox_quota_exceeded, _}`,
-  ...). Either way `last_run_at` is stamped, and `last_conversation_id` /
+  ...). A firing that ran stamps `last_run_at`, and `last_conversation_id` /
   `last_error` say how it went; the caller decides whether an error is worth
   retrying (the worker snoozes on `:busy` and `:provisioning`).
+
+  A capacity refusal is queued for the cron caller and nobody else — see
+  `await_capacity/2`. "Run now" gets the error unchanged. A firing that is
+  waiting on capacity stamps no `last_run_at` and records nothing: it is not a
+  run, and the request's own trail says what happened.
 
   `opts` is audit attribution: `Fountain.Workers.TeamScheduleRun` passes
   `actor: "system:team_scheduler"`, the UI passes the socket's. Recorded as
@@ -177,31 +225,69 @@ defmodule Fountain.Team.Schedules do
 
     now = DateTime.utc_now() |> DateTime.truncate(:second)
 
-    run_attrs =
+    # Two different questions, and conflating them is what made a person's
+    # refused "Run now" stop being recorded at all.
+    #
+    # `waiting?` decides what the ROW says. A live request means this
+    # schedule's work is waiting, whoever asked.
+    #
+    # `queued_by_us?` decides whether this CALLER fired. The cron caller
+    # queued instead of firing, and the drainer is replaying a firing already
+    # on the trail; both are silent. Anybody else fired and got an answer, and
+    # a refusal that writes the row is a mutation that records (ADR 0013).
+    waiting? =
       case result do
-        {:ok, conv} -> %{last_run_at: now, last_conversation_id: conv.id, last_error: nil}
-        {:error, reason} -> %{last_run_at: now, last_error: describe_error(reason)}
+        {:error, {:sandbox_quota_exceeded, _}} -> await_capacity(schedule, opts)
+        {:error, :fleet_full} -> await_capacity(schedule, opts)
+        _ -> false
+      end
+
+    queued_by_us? = Keyword.get(opts, :actor) in [@actor, Fountain.SandboxQueue.actor()]
+
+    run_attrs =
+      cond do
+        # Nothing fired, so `last_run_at` keeps saying when the schedule last
+        # actually ran.
+        waiting? and queued_by_us? -> %{last_error: @waiting}
+        # Somebody fired and was refused while the work waits. The attempt is
+        # stamped and recorded; the row still reports the wait, because that is
+        # what is true of the schedule.
+        waiting? -> %{last_run_at: now, last_error: @waiting}
+        true -> ran_attrs(result, now)
       end
 
     {:ok, _} = schedule |> Schedule.run_changeset(run_attrs) |> Repo.update()
     Team.broadcast_schedules_changed(schedule.user_id)
 
-    record(
-      "team.schedule.fired",
-      schedule,
-      opts,
-      Map.merge(describe(schedule), %{
-        "outcome" => if(match?({:ok, _}, result), do: "ok", else: run_attrs.last_error),
-        "conversation_id" =>
-          case result do
-            {:ok, conv} -> conv.id
-            _ -> nil
-          end
-      })
-    )
+    unless waiting? and queued_by_us? do
+      record(
+        "team.schedule.fired",
+        schedule,
+        opts,
+        Map.merge(describe(schedule), %{
+          # The outcome this caller got, not what the row displays: a person
+          # refused while work waits was refused, and the trail should say so.
+          "outcome" => outcome(result),
+          "conversation_id" =>
+            case result do
+              {:ok, conv} -> conv.id
+              _ -> nil
+            end
+        })
+      )
+    end
 
     result
   end
+
+  defp outcome({:ok, _conv}), do: "ok"
+  defp outcome({:error, reason}), do: describe_error(reason)
+
+  defp ran_attrs({:ok, conv}, now),
+    do: %{last_run_at: now, last_conversation_id: conv.id, last_error: nil}
+
+  defp ran_attrs({:error, reason}, now),
+    do: %{last_run_at: now, last_error: describe_error(reason)}
 
   # A fresh conversation with what the teammate has: its agent, and the
   # environment override and vault its current team conversation carries.
@@ -282,6 +368,42 @@ defmodule Fountain.Team.Schedules do
     end
   end
 
+  # Scheduled work opts into the bounded queue: unlike an interactive caller,
+  # a cron firing has nobody present to retry it when capacity frees, and a
+  # 09:00 run that meets a fan-out at 08:59 is simply lost.
+  #
+  # Only the cron caller enqueues. `run_schedule/2` is also the page's and the
+  # API's "Run now" (`POST /api/team/:agent_id/schedules/:id/run`), and
+  # queueing there would hand a person a 429 or 503 while a conversation
+  # started on its own up to an hour later, with no request id in the response
+  # to watch or cancel. ADR 0042 decision 3 buys the queue with "a cron firing
+  # has nobody there to retry it", which is exactly what somebody pressing a
+  # button is not. The queue's own replay is excluded by the same test: the
+  # drainer already holds the claim, so re-entering would stack a second
+  # request behind the one being replayed.
+  #
+  # Returns whether the work is waiting, which is a different question from
+  # who was allowed to put it there. A depth-bound refusal leaves no request,
+  # so the caller gets the capacity error it was about to get anyway.
+  defp await_capacity(%Schedule{} = schedule, opts) do
+    if Keyword.get(opts, :actor) == @actor, do: enqueue_run(schedule, opts)
+
+    Fountain.SandboxQueue.schedule_request(schedule.user_id, schedule.id) != nil
+  end
+
+  defp enqueue_run(%Schedule{} = schedule, opts) do
+    Fountain.SandboxQueue.enqueue(
+      %{
+        user_id: schedule.user_id,
+        agent_id: schedule.agent_id,
+        kind: "schedule_run",
+        schedule_id: schedule.id,
+        source: "schedule"
+      },
+      opts
+    )
+  end
+
   # What a run's failure reads as on the row and in the UI. Never the prompt.
   def describe_error(:busy), do: "teammate was busy"
 
@@ -291,6 +413,7 @@ defmodule Fountain.Team.Schedules do
   def describe_error(:provisioning), do: "teammate's computer was still starting"
   def describe_error(:not_found), do: "agent is not on the team"
   def describe_error(:insufficient_credits), do: "out of credit"
+  def describe_error(:fleet_full), do: "sandbox fleet is full"
   def describe_error(:runner_offline), do: "teammate's machine is offline"
   def describe_error(:sprite_probe_failed), do: "could not reach the sandbox provider"
 

--- a/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
@@ -492,6 +492,9 @@ defmodule FountainWeb.ConversationController do
       conflict: {"Conflicting state", "application/json", Schemas.Error},
       service_unavailable: {"Sandbox or fleet unavailable", "application/json", Schemas.Error},
       created: {"Conversation", "application/json", Schemas.ConversationResponse},
+      accepted:
+        {"Queued for sandbox capacity", "application/json", Schemas.SandboxRequestResponse},
+      too_many_requests: {"Tenant concurrency cap reached", "application/json", Schemas.Error},
       ok:
         {"Conversation (resumed by channel_id)", "application/json", Schemas.ConversationResponse},
       forbidden:
@@ -548,6 +551,75 @@ defmodule FountainWeb.ConversationController do
       conn
       |> put_status(if(outcome == :created, do: :created, else: :ok))
       |> render(:show, conversation: conv, resumed: outcome == :resumed)
+    else
+      {:error, {:sandbox_quota_exceeded, _} = reason} ->
+        maybe_enqueue(conn, params, user, reason)
+
+      {:error, :fleet_full = reason} ->
+        maybe_enqueue(conn, params, user, reason)
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  # Exactly the launch keys `Conversations.start_conversation/2` reads, minus
+  # the ones this path sets itself (`user_id`, `agent_id`, `source`) and the
+  # two it refuses to queue. An allow list rather than a drop list:
+  # `ConversationCreateRequest` does not set `additionalProperties: false`, so
+  # dropping the keys we know would park whatever else a caller sent in
+  # `attrs` until the request expired.
+  @queued_attr_keys ~w(prompt title vault_id environment_id permission_policy
+                       sandbox_mode sandbox_api_access sprite_name channel_id
+                       fresh parent_conversation_id caller_tools labels
+                       execution_limits)
+
+  # Queueing is opt-in (ADR 0042 decision 2). A caller that did not ask keeps
+  # the immediate 429 or 503 its client already handles.
+  #
+  # Images never queue: the server does not hold image bytes for an hour. An
+  # explicit `sandbox_id` never queues either — that is an attach to a machine
+  # the caller already has, not a request for capacity. That arm is belt and
+  # braces rather than a path with a test: `attach_conversation/4` takes no
+  # sandbox reservation, so it cannot raise either capacity error for this
+  # clause to intercept. It is here so a future attach that *does* reserve
+  # cannot start queueing by accident.
+  defp maybe_enqueue(conn, params, user, reason) do
+    if params["queue"] == true and params["images"] in [nil, []] and
+         params["sandbox_id"] in [nil, ""] do
+      enqueue_params = %{
+        user_id: user.id,
+        agent_id: params["agent_id"],
+        kind: "start",
+        source: params["source"],
+        # The restriction this request arrived under, carried so the replay is
+        # held to it an hour later. Without it a `sprite` token could queue a
+        # `channel_id` start with `labels` and have the drainer merge them into
+        # a conversation the token does not own, which is the write
+        # `Conversations.set_conversation_labels/4` refuses at this door
+        # (ADR 0045). `nil` for any other credential, which every rule reads as
+        # "no sandbox restriction applies".
+        sandbox_key_id: SandboxKey.id(conn),
+        attrs: Map.take(params, @queued_attr_keys)
+      }
+
+      case Fountain.SandboxQueue.enqueue(enqueue_params, Audited.attribution(conn)) do
+        {:ok, request} ->
+          conn
+          |> put_status(:accepted)
+          |> put_view(FountainWeb.SandboxQueueJSON)
+          |> render(:show, request: request, position: Fountain.SandboxQueue.position(request))
+
+        # At the depth bound the caller gets the capacity error it was about
+        # to get anyway. The queue delays the cap; it never raises it.
+        {:error, :queue_full} ->
+          {:error, reason}
+
+        {:error, _} = error ->
+          error
+      end
+    else
+      {:error, reason}
     end
   end
 

--- a/apps/fountain/lib/fountain_web/controllers/sandbox_queue_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/sandbox_queue_json.ex
@@ -1,0 +1,33 @@
+defmodule FountainWeb.SandboxQueueJSON do
+  @moduledoc false
+  alias Fountain.SandboxQueue.Request
+
+  @doc """
+  A tenant's waiting requests. The list is already in FIFO order, so position
+  is the index rather than a count query per row.
+  """
+  def index(%{requests: requests}) do
+    %{
+      data:
+        requests
+        |> Enum.with_index(1)
+        |> Enum.map(fn {request, position} -> data(request, position) end)
+    }
+  end
+
+  def show(%{request: request, position: position}), do: %{data: data(request, position)}
+
+  def data(%Request{} = request, position) do
+    %{
+      id: request.id,
+      agent_id: request.agent_id,
+      kind: request.kind,
+      status: request.status,
+      source: request.source,
+      conversation_id: request.conversation_id,
+      error: request.error,
+      position: position,
+      inserted_at: request.inserted_at
+    }
+  end
+end

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -719,11 +719,55 @@ defmodule FountainWeb.Schemas do
               "at most 64 bytes and a value at most 256 bytes, and a 422 names the offending " <>
               "key under `errors.labels`. With channel_id, a resume merges these into the " <>
               "conversation it hands back rather than dropping them."
+        },
+        queue: %Schema{
+          type: :boolean,
+          nullable: true,
+          description:
+            "When a fresh start reaches the tenant or the fleet concurrency ceiling, wait " <>
+              "in the bounded sandbox queue and return 202 with a SandboxRequest instead " <>
+              "of 429 or 503 (ADR 0042). Starts carrying images or an explicit sandbox_id " <>
+              "are never queued, and a full queue keeps the immediate error."
         }
       },
       required: [:agent_id]
     })
   end
+
+  defmodule SandboxRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "SandboxRequest",
+      description: "Work waiting for sandbox capacity (ADR 0042).",
+      type: :object,
+      properties: %{
+        id: %Schema{type: :string, format: :uuid},
+        agent_id: %Schema{type: :string, format: :uuid},
+        kind: %Schema{type: :string, enum: Fountain.SandboxQueue.Request.kinds()},
+        status: %Schema{type: :string, enum: Fountain.SandboxQueue.Request.statuses()},
+        source: %Schema{type: :string, nullable: true},
+        conversation_id: %Schema{
+          type: :string,
+          format: :uuid,
+          nullable: true,
+          description: "The conversation the request became, once it started."
+        },
+        error: %Schema{type: :string, nullable: true},
+        position: %Schema{
+          type: :integer,
+          nullable: true,
+          description: "One-based place in the tenant's queue; null once it stops waiting."
+        },
+        inserted_at: %Schema{type: :string, format: :"date-time"}
+      },
+      required: [:id, :agent_id, :kind, :status]
+    })
+  end
+
+  item_response(SandboxRequestResponse, of: SandboxRequest)
+  list_response(SandboxRequestListResponse, of: SandboxRequest)
 
   defmodule ConversationLabelsRequest do
     @moduledoc false

--- a/apps/fountain/test/fountain/team/schedules_test.exs
+++ b/apps/fountain/test/fountain/team/schedules_test.exs
@@ -333,4 +333,245 @@ defmodule Fountain.Team.SchedulesTest do
   test "a broke scheduled run is described in words, not as an atom (#1126)" do
     assert Schedules.describe_error(:insufficient_credits) == "out of credit"
   end
+
+  test "a full fleet is described in words too (#1033)" do
+    assert Schedules.describe_error(:fleet_full) == "sandbox fleet is full"
+  end
+
+  describe "run_schedule/2 at a sandbox ceiling" do
+    defp fill_cap(user) do
+      for _ <- 1..Fountain.Quotas.sandbox_limit(user.id),
+          do: insert_sandbox(user_id: user.id, status: "ready")
+    end
+
+    defp events(user) do
+      Fountain.Audit.list_recent_for_user(user.id, 50)
+    end
+
+    defp fired_events(user) do
+      events(user) |> Enum.filter(&(&1.action == "team.schedule.fired"))
+    end
+
+    defp queue_events(user, action) do
+      events(user) |> Enum.filter(&(&1.action == action))
+    end
+
+    test "the cron firing waits in the queue instead of being lost" do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      schedule = create!(user, agent, %{"one_off" => true})
+      fill_cap(user)
+      opts = [actor: Schedules.actor()]
+
+      # The caller still gets the refusal unchanged; what changes is that the
+      # run is not lost with it.
+      assert {:error, {:sandbox_quota_exceeded, _}} = Schedules.run_schedule(schedule, opts)
+
+      assert Schedules.get_schedule(schedule.id, user.id).last_error ==
+               "waiting for a free sandbox slot"
+
+      assert [request] = Fountain.SandboxQueue.list_queued(user.id)
+      assert request.kind == "schedule_run"
+      assert request.schedule_id == schedule.id
+      assert request.source == "schedule"
+    end
+
+    test "a schedule that keeps firing while it waits does not stack copies" do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      schedule = create!(user, agent, %{"one_off" => true})
+      fill_cap(user)
+      opts = [actor: Schedules.actor()]
+
+      assert {:error, _} = Schedules.run_schedule(schedule, opts)
+      assert {:error, _} = Schedules.run_schedule(schedule, opts)
+      assert {:error, _} = Schedules.run_schedule(schedule, opts)
+
+      assert [_one] = Fountain.SandboxQueue.list_queued(user.id)
+    end
+
+    test ~s("Run now" gets the refusal and starts nothing behind the caller's back) do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      schedule = create!(user, agent, %{"one_off" => true})
+      fill_cap(user)
+
+      assert {:error, {:sandbox_quota_exceeded, _}} =
+               Schedules.run_schedule(schedule, actor: "api")
+
+      assert Fountain.SandboxQueue.list_queued(user.id) == []
+
+      assert Schedules.get_schedule(schedule.id, user.id).last_error !=
+               "waiting for a free sandbox slot"
+    end
+
+    test "a waiting firing is not a run, and is not recorded as one" do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      schedule = create!(user, agent, %{"one_off" => true})
+      fill_cap(user)
+
+      assert {:error, _} = Schedules.run_schedule(schedule, actor: Schedules.actor())
+
+      reloaded = Schedules.get_schedule(schedule.id, user.id)
+      assert reloaded.last_error == "waiting for a free sandbox slot"
+
+      # Nothing ran, so `last_run_at` is untouched and no firing is on the
+      # trail. `sandbox_request.enqueued` is the event that did happen.
+      assert is_nil(reloaded.last_run_at)
+      assert fired_events(user) == []
+      assert [_] = queue_events(user, "sandbox_request.enqueued")
+    end
+
+    test ~s(a person's "Run now" during a queued window is still recorded) do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      schedule = create!(user, agent, %{"one_off" => true})
+      fill_cap(user)
+
+      # The cron fires first and queues. The row now says "waiting", and the
+      # next caller is a person pressing the button.
+      assert {:error, _} = Schedules.run_schedule(schedule, actor: Schedules.actor())
+      assert fired_events(user) == []
+
+      assert {:error, {:sandbox_quota_exceeded, _}} =
+               Schedules.run_schedule(schedule, actor: "ui", request_ip: "1.2.3.4")
+
+      # They fired and were refused. That is a mutation, and it records —
+      # deciding "is anybody waiting" rather than "did this caller wait" left
+      # a person's action with no audit trace at all.
+      assert [event] = fired_events(user)
+      assert event.actor == "ui"
+      assert event.metadata["outcome"] =~ "sandbox quota"
+
+      reloaded = Schedules.get_schedule(schedule.id, user.id)
+      assert reloaded.last_run_at, "a refused firing is still an attempt"
+      # The row reports the schedule's state, which is that work is waiting.
+      assert reloaded.last_error == "waiting for a free sandbox slot"
+    end
+
+    test "a replay that meets the ceiling again keeps saying it is waiting" do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      schedule = create!(user, agent, %{"one_off" => true})
+      fill_cap(user)
+
+      assert {:error, _} = Schedules.run_schedule(schedule, actor: Schedules.actor())
+
+      assert Schedules.get_schedule(schedule.id, user.id).last_error ==
+               "waiting for a free sandbox slot"
+
+      # The drainer claims the request and replays it. Capacity has not freed,
+      # so the replay is refused again — and the row must not flip back to the
+      # capacity error, which is the one thing a person reading it needs to
+      # know is not the whole story (ADR 0042 decision 3).
+      assert %{started: 0, failed: 0} = Fountain.SandboxQueue.drain(user.id)
+
+      assert Schedules.get_schedule(schedule.id, user.id).last_error ==
+               "waiting for a free sandbox slot"
+
+      assert [_still_waiting] = Fountain.SandboxQueue.list_queued(user.id)
+    end
+
+    test "a refusal past the depth bound reports the capacity error, not a wait" do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      schedule = create!(user, agent, %{"one_off" => true})
+      fill_cap(user)
+
+      # Fill the queue with other work, so the schedule's own firing cannot get
+      # a row. The queue delays the cap; it never raises it.
+      for _ <- 1..10 do
+        {:ok, _} =
+          Fountain.SandboxQueue.enqueue(%{
+            user_id: user.id,
+            agent_id: agent.id,
+            kind: "start",
+            attrs: %{}
+          })
+      end
+
+      assert {:error, {:sandbox_quota_exceeded, _}} =
+               Schedules.run_schedule(schedule, actor: Schedules.actor())
+
+      reloaded = Schedules.get_schedule(schedule.id, user.id)
+      assert reloaded.last_error =~ "sandbox quota"
+      assert reloaded.last_run_at
+    end
+
+    test "the row stops saying it is waiting once the request expires" do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      schedule = create!(user, agent, %{"one_off" => true})
+      fill_cap(user)
+
+      assert {:error, _} = Schedules.run_schedule(schedule, actor: Schedules.actor())
+      assert [request] = Fountain.SandboxQueue.list_queued(user.id)
+
+      {1, _} =
+        Repo.update_all(
+          from(r in Fountain.SandboxQueue.Request, where: r.id == ^request.id),
+          set: [inserted_at: DateTime.add(DateTime.utc_now(), -2, :hour)]
+        )
+
+      assert %{expired: 1} = Fountain.SandboxQueue.drain(user.id)
+
+      # A cron schedule self-corrects at its next firing. A one-off has no next
+      # firing, so without this the row claims it is waiting for a slot nothing
+      # is waiting for, permanently.
+      assert Schedules.get_schedule(schedule.id, user.id).last_error ==
+               "timed out waiting for a free sandbox slot"
+    end
+
+    test "the row stops saying it is waiting once the request is cancelled" do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      schedule = create!(user, agent, %{"one_off" => true})
+      fill_cap(user)
+
+      assert {:error, _} = Schedules.run_schedule(schedule, actor: Schedules.actor())
+      assert [request] = Fountain.SandboxQueue.list_queued(user.id)
+
+      {:ok, _} = Fountain.SandboxQueue.cancel_request(request, actor: "ui")
+
+      assert Schedules.get_schedule(schedule.id, user.id).last_error ==
+               "the queued run was cancelled"
+    end
+
+    test "a start request ending touches no schedule" do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      schedule = create!(user, agent, %{"one_off" => true})
+      fill_cap(user)
+
+      assert {:error, _} = Schedules.run_schedule(schedule, actor: Schedules.actor())
+
+      {:ok, plain} =
+        Fountain.SandboxQueue.enqueue(%{
+          user_id: user.id,
+          agent_id: agent.id,
+          kind: "start",
+          attrs: %{}
+        })
+
+      {:ok, _} = Fountain.SandboxQueue.cancel_request(plain, actor: "ui")
+
+      # The schedule's own request is untouched, so its row still reports the
+      # wait. A `start` has no schedule to notify and must not guess at one.
+      assert Schedules.get_schedule(schedule.id, user.id).last_error ==
+               "waiting for a free sandbox slot"
+    end
+
+    test "the queue's own replay does not re-enter the queue" do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      schedule = create!(user, agent, %{"one_off" => true})
+      fill_cap(user)
+
+      assert {:error, {:sandbox_quota_exceeded, _}} =
+               Schedules.run_schedule(schedule, actor: "system:sandbox_queue")
+
+      assert Fountain.SandboxQueue.list_queued(user.id) == []
+    end
+  end
 end

--- a/apps/fountain/test/fountain_web/controllers/conversation_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/conversation_controller_test.exs
@@ -474,6 +474,201 @@ defmodule FountainWeb.ConversationControllerTest do
     end
   end
 
+  describe "queue: true at a capacity ceiling (#1033)" do
+    defp fill_cap(user) do
+      limit = Fountain.Quotas.sandbox_limit(user.id)
+      for _ <- 1..limit, do: insert_sandbox(user_id: user.id, status: "ready")
+      limit
+    end
+
+    test "202 with the request and its position instead of 429", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
+      agent = insert_agent(user_id: user.id)
+      fill_cap(user)
+
+      conn =
+        conn
+        |> authed_with_key(raw_key)
+        |> post_json("/api/conversations", %{
+          "agent_id" => agent.id,
+          "prompt" => "later is fine",
+          "queue" => true
+        })
+
+      body = json_response(conn, 202)["data"]
+      assert body["status"] == "queued"
+      assert body["kind"] == "start"
+      assert body["agent_id"] == agent.id
+      assert body["position"] == 1
+      assert body["conversation_id"] == nil
+      assert [request] = Fountain.SandboxQueue.list_queued(user.id)
+      assert request.id == body["id"]
+      assert request.attrs["prompt"] == "later is fine"
+    end
+
+    test "the queued attrs carry only launch keys, never whatever else was sent", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
+      agent = insert_agent(user_id: user.id)
+      fill_cap(user)
+
+      conn
+      |> authed_with_key(raw_key)
+      |> post_json("/api/conversations", %{
+        "agent_id" => agent.id,
+        "prompt" => "hi",
+        "title" => "nightly",
+        "labels" => %{"team" => "ops"},
+        "queue" => true,
+        "junk" => String.duplicate("x", 64)
+      })
+      |> json_response(202)
+
+      assert [request] = Fountain.SandboxQueue.list_queued(user.id)
+      assert request.attrs["title"] == "nightly"
+      assert request.attrs["labels"] == %{"team" => "ops"}
+      # `ConversationCreateRequest` allows unknown properties, so an allow
+      # list is the only thing standing between the table and arbitrary JSON.
+      refute Map.has_key?(request.attrs, "junk")
+      refute Map.has_key?(request.attrs, "queue")
+      refute Map.has_key?(request.attrs, "user_id")
+    end
+
+    test "a caller that did not ask still gets 429", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
+      agent = insert_agent(user_id: user.id)
+      fill_cap(user)
+
+      conn =
+        conn
+        |> authed_with_key(raw_key)
+        |> post_json("/api/conversations", %{"agent_id" => agent.id})
+
+      assert json_response(conn, 429)["error"] == "sandbox_quota_exceeded"
+      assert Fountain.SandboxQueue.list_queued(user.id) == []
+    end
+
+    test "a start carrying images is never queued", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
+      agent = insert_agent(user_id: user.id)
+      fill_cap(user)
+
+      conn =
+        conn
+        |> authed_with_key(raw_key)
+        |> post_json("/api/conversations", %{
+          "agent_id" => agent.id,
+          "queue" => true,
+          # Images need opening text of their own (#1840); without it the launch
+          # is refused 422 before it ever reaches the capacity decision this
+          # test is about.
+          "prompt" => "look at this",
+          "images" => [
+            %{"media_type" => "image/png", "data" => Base.encode64("fake-image-bytes")}
+          ]
+        })
+
+      # The server does not hold image bytes for an hour, so this keeps the
+      # immediate refusal rather than accepting work it cannot replay.
+      assert json_response(conn, 429)["error"] == "sandbox_quota_exceeded"
+      assert Fountain.SandboxQueue.list_queued(user.id) == []
+    end
+
+    test "a full queue keeps the immediate refusal", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
+      agent = insert_agent(user_id: user.id)
+      fill_cap(user)
+
+      for _ <- 1..10 do
+        {:ok, _} =
+          Fountain.SandboxQueue.enqueue(%{
+            user_id: user.id,
+            agent_id: agent.id,
+            kind: "start",
+            attrs: %{}
+          })
+      end
+
+      conn =
+        conn
+        |> authed_with_key(raw_key)
+        |> post_json("/api/conversations", %{"agent_id" => agent.id, "queue" => true})
+
+      assert json_response(conn, 429)["error"] == "sandbox_quota_exceeded"
+      assert length(Fountain.SandboxQueue.list_queued(user.id)) == 10
+    end
+
+    test "a sprite token's queued start carries its ADR 0045 restriction", %{
+      conn: conn,
+      user: user
+    } do
+      agent = insert_agent(user_id: user.id)
+      fill_cap(user)
+      {key, raw_sprite_key} = insert_sprite_api_key(user)
+
+      conn
+      |> authed_with_key(raw_sprite_key)
+      |> post_json("/api/conversations", %{"agent_id" => agent.id, "queue" => true})
+      |> json_response(202)
+
+      # Stored, not consulted here: the drainer is what has to be held to it an
+      # hour later, and a replay that dropped it could merge this request's
+      # labels into a conversation the token does not own.
+      assert [request] = Fountain.SandboxQueue.list_queued(user.id)
+      assert request.sandbox_key_id == key.id
+    end
+
+    test "an owner's own key queues with no restriction attached", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
+      agent = insert_agent(user_id: user.id)
+      fill_cap(user)
+
+      conn
+      |> authed_with_key(raw_key)
+      |> post_json("/api/conversations", %{"agent_id" => agent.id, "queue" => true})
+      |> json_response(202)
+
+      # `nil` is what every rule reads as "no sandbox restriction applies", so
+      # a full-scope caller must not pick one up by accident.
+      assert [request] = Fountain.SandboxQueue.list_queued(user.id)
+      assert is_nil(request.sandbox_key_id)
+    end
+
+    test "a start that succeeds is unaffected by the flag", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
+      agent = insert_agent(user_id: user.id)
+      stub(Horde.DynamicSupervisor, :start_child, fn _s, _spec -> {:ok, spawn(fn -> :ok end)} end)
+
+      conn =
+        conn
+        |> authed_with_key(raw_key)
+        |> post_json("/api/conversations", %{"agent_id" => agent.id, "queue" => true})
+
+      assert json_response(conn, 201)
+      assert Fountain.SandboxQueue.list_queued(user.id) == []
+    end
+  end
+
   describe "DELETE /api/conversations/:id" do
     test "deletes the conversation and returns 204", %{conn: conn, user: user, raw_key: raw_key} do
       conv = insert_conversation(user_id: user.id)

--- a/apps/fountain/test/fountain_web/schema_enum_guardrail_test.exs
+++ b/apps/fountain/test/fountain_web/schema_enum_guardrail_test.exs
@@ -127,6 +127,8 @@ defmodule FountainWeb.SchemaEnumGuardrailTest do
     {FountainWeb.Schemas.LogEvent, "state"} => {LogEvent, :states},
     {FountainWeb.Schemas.ManifestResource, "kind"} => {Manifest, :kinds},
     {FountainWeb.Schemas.Sandbox, "status"} => {Sandbox, :statuses},
+    {FountainWeb.Schemas.SandboxRequest, "kind"} => {Fountain.SandboxQueue.Request, :kinds},
+    {FountainWeb.Schemas.SandboxRequest, "status"} => {Fountain.SandboxQueue.Request, :statuses},
     # The sandbox mode (ADR 0023 gate 6): on the agent as a default, on a
     # launch as the choice, on the sandbox row as what it is.
     {FountainWeb.Schemas.Sandbox, "mode"} => {Sandbox, :modes},

--- a/sdk/contract/contract.json
+++ b/sdk/contract/contract.json
@@ -5947,6 +5947,11 @@
             "ref": "ConversationResponse"
           }
         },
+        "202": {
+          "application/json": {
+            "ref": "SandboxRequestResponse"
+          }
+        },
         "400": {
           "application/json": {
             "ref": "Error"
@@ -10569,6 +10574,11 @@
           "required": false,
           "type": "string"
         },
+        "queue": {
+          "nullable": true,
+          "required": false,
+          "type": "boolean"
+        },
         "sandbox_api_access": {
           "enum": [
             "none",
@@ -12385,6 +12395,76 @@
       "properties": {
         "data": {
           "ref": "SandboxListing",
+          "required": true
+        }
+      },
+      "type": "object"
+    },
+    "SandboxRequest": {
+      "properties": {
+        "agent_id": {
+          "format": "uuid",
+          "required": true,
+          "type": "string"
+        },
+        "conversation_id": {
+          "format": "uuid",
+          "nullable": true,
+          "required": false,
+          "type": "string"
+        },
+        "error": {
+          "nullable": true,
+          "required": false,
+          "type": "string"
+        },
+        "id": {
+          "format": "uuid",
+          "required": true,
+          "type": "string"
+        },
+        "inserted_at": {
+          "format": "date-time",
+          "required": false,
+          "type": "string"
+        },
+        "kind": {
+          "enum": [
+            "schedule_run",
+            "start"
+          ],
+          "required": true,
+          "type": "string"
+        },
+        "position": {
+          "nullable": true,
+          "required": false,
+          "type": "integer"
+        },
+        "source": {
+          "nullable": true,
+          "required": false,
+          "type": "string"
+        },
+        "status": {
+          "enum": [
+            "cancelled",
+            "expired",
+            "failed",
+            "queued",
+            "started",
+            "starting"
+          ],
+          "required": true,
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "SandboxRequestResponse": {
+      "properties": {
+        "data": {
+          "ref": "SandboxRequest",
           "required": true
         }
       },

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -3680,6 +3680,8 @@ export interface components {
             }) | null;
             /** @description Optional first turn prompt. A launch may open with no prompt at all, but a prompt that is present must carry words: blank and whitespace-only text is refused with 422 invalid_prompt, before the launch reserves a sandbox. */
             prompt?: string;
+            /** @description When a fresh start reaches the tenant or the fleet concurrency ceiling, wait in the bounded sandbox queue and return 202 with a SandboxRequest instead of 429 or 503 (ADR 0042). Starts carrying images or an explicit sandbox_id are never queued, and a full queue keeps the immediate error. */
+            queue?: boolean | null;
             /**
              * @description none omits the sandbox Fountain credential on provision and every wake. Requires a fresh ephemeral sandbox; unavailable on attach or policy-changing channel resume.
              * @enum {string}
@@ -4511,6 +4513,35 @@ export interface components {
         /** SandboxListingResponse */
         SandboxListingResponse: {
             data: components["schemas"]["SandboxListing"];
+        };
+        /**
+         * SandboxRequest
+         * @description Work waiting for sandbox capacity (ADR 0042).
+         */
+        SandboxRequest: {
+            /** Format: uuid */
+            agent_id: string;
+            /**
+             * Format: uuid
+             * @description The conversation the request became, once it started.
+             */
+            conversation_id?: string | null;
+            error?: string | null;
+            /** Format: uuid */
+            id: string;
+            /** Format: date-time */
+            inserted_at?: string;
+            /** @enum {string} */
+            kind: "start" | "schedule_run";
+            /** @description One-based place in the tenant's queue; null once it stops waiting. */
+            position?: number | null;
+            source?: string | null;
+            /** @enum {string} */
+            status: "queued" | "starting" | "started" | "cancelled" | "expired" | "failed";
+        };
+        /** SandboxRequestResponse */
+        SandboxRequestResponse: {
+            data: components["schemas"]["SandboxRequest"];
         };
         /** SandboxResponse */
         SandboxResponse: {
@@ -10427,6 +10458,15 @@ export interface operations {
                     "application/json": components["schemas"]["ConversationResponse"];
                 };
             };
+            /** @description Queued for sandbox capacity */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SandboxRequestResponse"];
+                };
+            };
             /** @description Invalid request */
             400: {
                 headers: {
@@ -10502,7 +10542,7 @@ export interface operations {
                     "application/json": components["schemas"]["UnprocessableEntityError"];
                 };
             };
-            /** @description Too Many Requests */
+            /** @description Tenant concurrency cap reached */
             429: {
                 headers: {
                     [name: string]: unknown;


### PR DESCRIPTION
Stacked on #1871.

The two producers, and they opt in differently on purpose.

**`queue: true` on `POST /api/conversations`** turns a tenant-cap 429 or a fleet-cap 503 into 202 with the request and its position. Every existing caller keeps the error its client already handles. Starts carrying images do not queue — the server does not hold image bytes for an hour — and starts naming an explicit `sandbox_id` do not either, being an attach to a machine the caller already has rather than a request for capacity. At the depth bound the caller gets the capacity error it was about to get anyway: the queue delays the cap, it never raises it.

What a queued start stores is an **allow list** of the launch keys `start_conversation/2` reads, not a drop list of the ones this path sets. `ConversationCreateRequest` does not set `additionalProperties: false`, so a drop list would park whatever else a caller sent in the table until the request expired. The list is today's keys, which is why it carries three #1481 did not have: `labels` (#1637), `execution_limits` and `sandbox_api_access`.

**A cron firing of a teammate schedule** opts in by itself, because it has nobody present to retry it — a 09:00 run that meets a fan-out at 08:59 is otherwise simply lost. The gate is the audit actor, so the page's and the API's "Run now" still gets the refusal: queueing there would answer a person with an error while a conversation started on its own up to an hour later, with no request id in the response to watch or cancel. The queue's own replay (`actor: "system:sandbox_queue"`) is excluded by the same test, so a replay cannot stack a second request behind the one it is replaying. `describe_error(:fleet_full)` gains the words it was missing.

Generated artifacts (`sdk/contract/contract.json`, `sdk/typescript/src/generated/openapi.ts`) are rebuilt with `scripts/sdk-contract/build.sh` and `npm run generate`, not hand-edited. **No SDK version bump here** — the bump lands once, in part 7. Label this `sdk-no-release`.

**Defers:** `/api/sandbox-queue` (part 5), telemetry declarations (part 6), ADR 0042 and the docs (part 7).

Part 4 of 7 for #1033.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9jevFQT5MkF3rJUieeiHW


---

### Review fixes (round 2)

- **`maybe_enqueue/4` stores `SandboxKey.id(conn)`**, closing the ADR 0045 bypass: a queued start is now held to the same label rule as the door it came through. Column in part 1, replay in part 2.
- **A waiting firing keeps saying it is waiting.** `await_capacity/2` replaces `maybe_queue_run/3` and answers "is this work waiting" rather than "who may enqueue" — so the drainer's own replay, which may meet the ceiling again, no longer flips `last_error` back to `sandbox quota: N/N`. Who enqueues is unchanged, and both existing gate tests pass untouched.
- **A waiting firing is not a run.** It stamps no `last_run_at` and records no `team.schedule.fired`; `sandbox_request.enqueued` is the event that happened. Previously each replay attempt wrote a firing row and re-stamped the timestamp.
- The `sandbox_id` clause is documented as belt and braces — `attach_conversation/4` takes no reservation, so it cannot raise a capacity error for it to intercept, and no honest test of it exists.


---

### Review fixes (round 3)

Two regressions the round-2 fix introduced, both found by re-review and both reproduced as tests before changing anything:

- **A person's "Run now" during a queued window recorded nothing.** `waiting?` answered "is anybody waiting" where it needed "did *this caller* wait", so `unless waiting?` suppressed the audit row for a human action too. Now two values: `waiting?` decides what the row says, `queued_by_us?` decides whether this caller fired. A person refused while work waits is stamped and recorded with the refusal they got, while the row goes on reporting the wait.
- **The row said "waiting" forever once the request died.** Nothing retracted `@waiting` on expiry or cancellation, and a `one_off` has no next firing to self-correct. `SandboxQueue` now calls `Schedules.note_queued_run_ended/3` from `expire_overdue/1` and `cancel_request/2` — `timed out waiting for a free sandbox slot` or `the queued run was cancelled`.

Four new tests, plus `SandboxQueue.actor/0` in part 2 and ADR 0042 decision 3 extended to cover both halves.



Part of #1033
