### PR TITLE
feat(api): list, read and cancel a sandbox request (#1033)

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/sandbox_queue_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/sandbox_queue_controller.ex
@@ -1,0 +1,77 @@
+defmodule FountainWeb.SandboxQueueController do
+  @moduledoc false
+  use FountainWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Fountain.SandboxQueue
+  alias FountainWeb.{Audited, Schemas}
+
+  action_fallback FountainWeb.FallbackController
+  plug OpenApiSpex.Plug.CastAndValidate, replace_params: false
+
+  tags(["Sandbox Queue"])
+
+  operation(:index,
+    summary: "List queued sandbox requests",
+    description:
+      "The caller's waiting requests, oldest first, each with its one-based position. " <>
+        "Only requests that are still waiting appear here. One the drainer has already " <>
+        "claimed is not listed, and neither is one that finished; read either by id " <>
+        "instead.",
+    responses: [
+      ok: {"Sandbox requests", "application/json", Schemas.SandboxRequestListResponse},
+      forbidden: {"Forbidden", "application/json", Schemas.Error}
+    ]
+  )
+
+  def index(conn, _params) do
+    render(conn, :index, requests: SandboxQueue.list_queued(conn.assigns.current_user.id))
+  end
+
+  operation(:show,
+    summary: "Get a sandbox request",
+    description:
+      "The request's current status. `conversation_id` is set once it started; `error` " <>
+        "says why if it failed. A request nobody else owns reads as 404.",
+    parameters: [id: [in: :path, type: :string, required: true]],
+    responses: [
+      ok: {"Sandbox request", "application/json", Schemas.SandboxRequestResponse},
+      not_found: {"Not found", "application/json", Schemas.Error},
+      forbidden: {"Forbidden", "application/json", Schemas.Error}
+    ]
+  )
+
+  def show(conn, %{"id" => id}) do
+    user = conn.assigns.current_user
+
+    case SandboxQueue.get_request(id, user.id) do
+      nil -> {:error, :not_found}
+      request -> render(conn, :show, request: request, position: SandboxQueue.position(request))
+    end
+  end
+
+  operation(:delete,
+    summary: "Cancel a queued sandbox request",
+    description:
+      "Gives up a request that is still waiting. A request the drainer has already " <>
+        "claimed reads as 404 rather than being cancelled out from under a start in " <>
+        "flight.",
+    parameters: [id: [in: :path, type: :string, required: true]],
+    responses: [
+      no_content: "Cancelled",
+      not_found: {"Not found or no longer queued", "application/json", Schemas.Error},
+      forbidden: {"Forbidden", "application/json", Schemas.Error}
+    ]
+  )
+
+  def delete(conn, %{"id" => id}) do
+    user = conn.assigns.current_user
+
+    with %{} = request <- SandboxQueue.get_request(id, user.id) || {:error, :not_found},
+         {:ok, _} <- SandboxQueue.cancel_request(request, Audited.attribution(conn)) do
+      send_resp(conn, :no_content, "")
+    else
+      _ -> {:error, :not_found}
+    end
+  end
+end

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -544,6 +544,13 @@ defmodule FountainWeb.Router do
     end
 
     resources "/agents", AgentController, except: [:new, :edit]
+
+    # The bounded sandbox-capacity queue (ADR 0042). Read and cancel only:
+    # work enters it through `POST /api/conversations` with `queue: true`, or
+    # through a teammate schedule's own cron firing.
+    get "/sandbox-queue", SandboxQueueController, :index
+    get "/sandbox-queue/:id", SandboxQueueController, :show
+    delete "/sandbox-queue/:id", SandboxQueueController, :delete
     # Config history (ADR 0029, #1051): read-only. Rollback stays a console action.
     get "/agents/:id/versions", AgentVersionController, :index
     get "/agents/:id/versions/:version", AgentVersionController, :show

--- a/apps/fountain/test/fountain_web/controllers/sandbox_queue_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/sandbox_queue_controller_test.exs
@@ -1,0 +1,212 @@
+defmodule FountainWeb.SandboxQueueControllerTest do
+  use FountainWeb.ConnCase, async: true
+
+  import Ecto.Query, only: [from: 2]
+
+  alias Fountain.SandboxQueue
+
+  setup do
+    user = insert_active_user()
+    {_key_record, raw_key} = insert_api_key(user)
+    agent = insert_agent(user_id: user.id)
+    {:ok, user: user, raw_key: raw_key, agent: agent}
+  end
+
+  defp enqueue!(user, agent, extra \\ %{}) do
+    {:ok, request} =
+      SandboxQueue.enqueue(
+        Map.merge(
+          %{user_id: user.id, agent_id: agent.id, kind: "start", attrs: %{"prompt" => "hi"}},
+          extra
+        )
+      )
+
+    request
+  end
+
+  describe "GET /api/sandbox-queue" do
+    test "lists waiting requests in position order", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key,
+      agent: agent
+    } do
+      first = enqueue!(user, agent)
+      second = enqueue!(user, agent)
+
+      body =
+        conn
+        |> authed_with_key(raw_key)
+        |> get("/api/sandbox-queue")
+        |> json_response(200)
+
+      assert [one, two] = body["data"]
+      assert one["id"] == first.id
+      assert one["position"] == 1
+      assert two["id"] == second.id
+      assert two["position"] == 2
+    end
+
+    test "omits a request that is no longer waiting", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key,
+      agent: agent
+    } do
+      request = enqueue!(user, agent)
+      {:ok, _} = SandboxQueue.cancel_request(request)
+
+      body = conn |> authed_with_key(raw_key) |> get("/api/sandbox-queue") |> json_response(200)
+      assert body["data"] == []
+    end
+
+    test "never lists another tenant's work", %{conn: conn, raw_key: raw_key} do
+      other = insert_active_user()
+      enqueue!(other, insert_agent(user_id: other.id))
+
+      body = conn |> authed_with_key(raw_key) |> get("/api/sandbox-queue") |> json_response(200)
+      assert body["data"] == []
+    end
+
+    test "requires a key", %{conn: conn} do
+      assert conn |> get("/api/sandbox-queue") |> json_response(401)
+    end
+  end
+
+  describe "GET /api/sandbox-queue/:id" do
+    test "reports a waiting request and its position", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key,
+      agent: agent
+    } do
+      request = enqueue!(user, agent)
+
+      body =
+        conn
+        |> authed_with_key(raw_key)
+        |> get("/api/sandbox-queue/#{request.id}")
+        |> json_response(200)
+
+      assert body["data"]["status"] == "queued"
+      assert body["data"]["position"] == 1
+    end
+
+    test "reports a terminal outcome and drops the position", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key,
+      agent: agent
+    } do
+      request = enqueue!(user, agent)
+      {:ok, _} = SandboxQueue.cancel_request(request)
+
+      body =
+        conn
+        |> authed_with_key(raw_key)
+        |> get("/api/sandbox-queue/#{request.id}")
+        |> json_response(200)
+
+      assert body["data"]["status"] == "cancelled"
+      assert body["data"]["position"] == nil
+    end
+
+    test "another tenant's request is 404, not 403", %{conn: conn, raw_key: raw_key} do
+      other = insert_active_user()
+      request = enqueue!(other, insert_agent(user_id: other.id))
+
+      assert conn
+             |> authed_with_key(raw_key)
+             |> get("/api/sandbox-queue/#{request.id}")
+             |> json_response(404)
+    end
+
+    test "an id that is not a uuid is 404, not a 500", %{conn: conn, raw_key: raw_key} do
+      assert conn
+             |> authed_with_key(raw_key)
+             |> get("/api/sandbox-queue/nope")
+             |> json_response(404)
+    end
+  end
+
+  describe "DELETE /api/sandbox-queue/:id" do
+    test "cancels a waiting request", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key,
+      agent: agent
+    } do
+      request = enqueue!(user, agent)
+
+      conn = conn |> authed_with_key(raw_key) |> delete("/api/sandbox-queue/#{request.id}")
+
+      assert response(conn, 204)
+      assert SandboxQueue.list_queued(user.id) == []
+      assert Fountain.Repo.get!(Fountain.SandboxQueue.Request, request.id).status == "cancelled"
+    end
+
+    test "cancelling twice is 404 the second time", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key,
+      agent: agent
+    } do
+      request = enqueue!(user, agent)
+
+      assert conn
+             |> authed_with_key(raw_key)
+             |> delete("/api/sandbox-queue/#{request.id}")
+             |> response(204)
+
+      assert conn
+             |> authed_with_key(raw_key)
+             |> delete("/api/sandbox-queue/#{request.id}")
+             |> json_response(404)
+    end
+
+    test "a request the drainer already claimed is 404", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key,
+      agent: agent
+    } do
+      request = enqueue!(user, agent)
+
+      {1, _} =
+        Fountain.Repo.update_all(
+          from(r in Fountain.SandboxQueue.Request, where: r.id == ^request.id),
+          set: [status: "starting"]
+        )
+
+      assert conn
+             |> authed_with_key(raw_key)
+             |> delete("/api/sandbox-queue/#{request.id}")
+             |> json_response(404)
+
+      assert Fountain.Repo.get!(Fountain.SandboxQueue.Request, request.id).status == "starting"
+    end
+
+    test "never cancels another tenant's request", %{conn: conn, raw_key: raw_key} do
+      other = insert_active_user()
+      request = enqueue!(other, insert_agent(user_id: other.id))
+
+      assert conn
+             |> authed_with_key(raw_key)
+             |> delete("/api/sandbox-queue/#{request.id}")
+             |> json_response(404)
+
+      assert Fountain.Repo.get!(Fountain.SandboxQueue.Request, request.id).status == "queued"
+    end
+
+    test "records who cancelled it", %{conn: conn, user: user, raw_key: raw_key, agent: agent} do
+      request = enqueue!(user, agent)
+
+      conn |> authed_with_key(raw_key) |> delete("/api/sandbox-queue/#{request.id}")
+
+      events = Fountain.Audit.list_for("sandbox_request", request.id, user.id)
+
+      assert event = Enum.find(events, &(&1.action == "sandbox_request.cancelled"))
+      assert event.actor == "api"
+    end
+  end
+end

--- a/sdk/contract/contract.json
+++ b/sdk/contract/contract.json
@@ -552,6 +552,40 @@
         }
       }
     },
+    "DELETE /api/sandbox-queue/{id}": {
+      "operation_id": "FountainWeb.SandboxQueueController.delete",
+      "path_params": [
+        "id"
+      ],
+      "responses": {
+        "204": {},
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
+          "application/json": {
+            "ref": "Error"
+          }
+        }
+      }
+    },
     "DELETE /api/sandboxes/{id}": {
       "operation_id": "FountainWeb.SandboxController.delete",
       "path_params": [
@@ -2587,6 +2621,75 @@
         "409": {
           "application/json": {
             "ref": "Error"
+          }
+        },
+        "429": {
+          "application/json": {
+            "ref": "Error"
+          }
+        }
+      }
+    },
+    "GET /api/sandbox-queue": {
+      "operation_id": "FountainWeb.SandboxQueueController.index",
+      "path_params": [],
+      "responses": {
+        "200": {
+          "application/json": {
+            "ref": "SandboxRequestListResponse"
+          }
+        },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
+          "application/json": {
+            "ref": "Error"
+          }
+        }
+      }
+    },
+    "GET /api/sandbox-queue/{id}": {
+      "operation_id": "FountainWeb.SandboxQueueController.show",
+      "path_params": [
+        "id"
+      ],
+      "responses": {
+        "200": {
+          "application/json": {
+            "ref": "SandboxRequestResponse"
+          }
+        },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
           }
         },
         "429": {
@@ -12457,6 +12560,18 @@
           ],
           "required": true,
           "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "SandboxRequestListResponse": {
+      "properties": {
+        "data": {
+          "items": {
+            "ref": "SandboxRequest"
+          },
+          "required": true,
+          "type": "array"
         }
       },
       "type": "object"

--- a/sdk/contract/omissions.json
+++ b/sdk/contract/omissions.json
@@ -45,6 +45,10 @@
       "reason": "Webhook registration and delivery replay. Server-to-server configuration a person does once in the console; nothing an SDK caller does per run."
     },
     {
+      "operations": ["* /api/sandbox-queue*"],
+      "reason": "The opt-in asynchronous start lifecycle (ADR 0042). Every SDK's run handle promises an immediate conversation, while a queued start first hands back a sandbox request; callers can reach these three over the raw HTTP client until a queued-run handle owns the polling and the cancellation without weakening that promise."
+    },
+    {
       "operations": ["* /api/secret-bindings*"],
       "reason": "Egress broker bindings (ADR 0019). Configuration of where a credential lives, set once per account; the run-time effect is invisible to a client."
     },

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -1688,6 +1688,50 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/sandbox-queue": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List queued sandbox requests
+         * @description The caller's waiting requests, oldest first, each with its one-based position. Only requests that are still waiting appear here. One the drainer has already claimed is not listed, and neither is one that finished; read either by id instead.
+         */
+        get: operations["FountainWeb.SandboxQueueController.index"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/sandbox-queue/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get a sandbox request
+         * @description The request's current status. `conversation_id` is set once it started; `error` says why if it failed. A request nobody else owns reads as 404.
+         */
+        get: operations["FountainWeb.SandboxQueueController.show"];
+        put?: never;
+        post?: never;
+        /**
+         * Cancel a queued sandbox request
+         * @description Gives up a request that is still waiting. A request the drainer has already claimed reads as 404 rather than being cancelled out from under a start in flight.
+         */
+        delete: operations["FountainWeb.SandboxQueueController.delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/sandboxes": {
         parameters: {
             query?: never;
@@ -4538,6 +4582,10 @@ export interface components {
             source?: string | null;
             /** @enum {string} */
             status: "queued" | "starting" | "started" | "cancelled" | "expired" | "failed";
+        };
+        /** SandboxRequestListResponse */
+        SandboxRequestListResponse: {
+            data: components["schemas"]["SandboxRequest"][];
         };
         /** SandboxRequestResponse */
         SandboxRequestResponse: {
@@ -12965,6 +13013,194 @@ export interface operations {
                 };
             };
             /** @description No such runner */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    "FountainWeb.SandboxQueueController.index": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Sandbox requests */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SandboxRequestListResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    "FountainWeb.SandboxQueueController.show": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Sandbox request */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SandboxRequestResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    "FountainWeb.SandboxQueueController.delete": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Cancelled */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found or no longer queued */
             404: {
                 headers: {
                     [name: string]: unknown;


### PR DESCRIPTION
Stacked on #1872.

Three routes, read and cancel only. Work enters the queue through `POST /api/conversations` with `queue: true` or through a schedule's own cron firing; nothing posts to `/api/sandbox-queue`.

- `GET /api/sandbox-queue` — the waiting list, in position order.
- `GET /api/sandbox-queue/:id` — where a 202 caller learns the outcome and the conversation id.
- `DELETE /api/sandbox-queue/:id` — gives up work that is still waiting. A request the drainer has already claimed is 404 rather than being cancelled out from under a start in flight.

Another tenant's request is 404 and never 403 — the same answer a request that does not exist gets. The id of a row you do not own is not something this API confirms.

The SDKs **omit** the three rather than claim them, with the reason recorded in `omissions.json`: every SDK's run handle promises an immediate conversation, and a queued start hands back a sandbox request first. Wrapping that properly means a queued-run handle that owns the polling and the cancellation, which is separate work; until then the raw HTTP client reaches them.

Seven gates for a new API route: operation declarations ✓, a `forbidden` response on each ✓, enums derived from `Request.kinds/0` and `Request.statuses/0` rather than duplicated (guard row added in part 4) ✓, `scripts/sdk-contract/build.sh --check` green with the omission claim ✓, `npm run generate` ✓, prose gates in part 7.

Generated artifacts are rebuilt, not hand-edited. **No SDK version bump here** — part 7 owns it. Label this `sdk-no-release`.

**Defers:** telemetry and retention (part 6), ADR 0042 and the docs (part 7).

Part 5 of 7 for #1033.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9jevFQT5MkF3rJUieeiHW


---

### Review fixes (round 2)

- `index`'s description no longer enumerates the terminal statuses, because a request the drainer has **claimed** is neither "already started" nor listed. It now says only waiting requests appear, and to read the rest by id.



Part of #1033
