### PR TITLE
feat(telemetry): what the sandbox queue looks like from outside (#1033)

### DIFF
--- a/apps/fountain/lib/fountain/ops_gauges.ex
+++ b/apps/fountain/lib/fountain/ops_gauges.ex
@@ -40,6 +40,17 @@ defmodule Fountain.OpsGauges do
         Fountain.Conversations.Sandbox.statuses()
       )
 
+      # Waiting and claimed only, for the same reason the Oban states above
+      # exclude `completed`: the terminal statuses are history rows, so a
+      # `last_value` over them only ever climbs and says nothing about queue
+      # health now. Outcomes are counted as they happen, on
+      # `[:fountain, :sandbox_queue, :completed]`.
+      emit_status_counts(
+        [:fountain, :sandbox_queue, :requests],
+        Fountain.SandboxQueue.Request,
+        Fountain.SandboxQueue.Request.active_statuses()
+      )
+
       emit_sandbox_provider_counts()
       emit_oban_depths()
     end)
@@ -76,9 +87,18 @@ defmodule Fountain.OpsGauges do
     end
   end
 
+  # Scoped to the statuses asked for, which is a no-op for a caller passing its
+  # schema's whole list and the difference between a full-table group-by and an
+  # index read for one passing a subset. This runs every ten seconds.
   defp emit_status_counts(event, schema, statuses) do
     counts =
-      Repo.all(from(r in schema, group_by: r.status, select: {r.status, count(r.id)}))
+      Repo.all(
+        from(r in schema,
+          where: r.status in ^statuses,
+          group_by: r.status,
+          select: {r.status, count(r.id)}
+        )
+      )
       |> Map.new()
 
     for status <- statuses do

--- a/apps/fountain/lib/fountain/workers/retention_pruner.ex
+++ b/apps/fountain/lib/fountain/workers/retention_pruner.ex
@@ -24,6 +24,15 @@ defmodule Fountain.Workers.RetentionPruner do
   attempt of a failing endpoint writes another. It is a debugging aid, not an
   event store, so it gets the shortest window of the lot.
 
+  `sandbox_requests` is the same shape of bookkeeping (ADR 0042): a finished
+  request holds no prompt, because every terminal transition erases `attrs`.
+  What is left is provenance and an outcome that the audit trail already
+  carries at its own, longer window. Waiting and claimed rows are never pruned
+  whatever the window says: the cutoff must not be what decides that a row is
+  live. A waiting row is bounded by `SANDBOX_QUEUE_MAX_WAIT_SECONDS`, and a
+  claimed one by the drain reclaiming an abandoned claim rather than by any
+  expiry, so neither is the pruner's to reason about.
+
   `usage_events` gets the longest window because it is the input to billing
   history, and `turn_images` is deliberately absent — those rows are owned by
   their turn and go when the conversation does.
@@ -59,7 +68,8 @@ defmodule Fountain.Workers.RetentionPruner do
     stripe_events: 90,
     revoked_api_keys: 30,
     usage_events: 400,
-    webhook_deliveries: 30
+    webhook_deliveries: 30,
+    sandbox_requests: 30
   ]
 
   @impl Oban.Worker
@@ -162,6 +172,17 @@ defmodule Fountain.Workers.RetentionPruner do
   # aid rather than a second event store (#700).
   defp do_prune(:webhook_deliveries, cutoff) do
     delete_where("webhook_deliveries", dynamic([r], r.inserted_at < ^cutoff))
+  end
+
+  # Terminal rows only. A `queued` or `starting` row is live work, and the
+  # cutoff must never be what decides that.
+  defp do_prune(:sandbox_requests, cutoff) do
+    terminal = ~w(started failed cancelled expired)
+
+    delete_where(
+      "sandbox_requests",
+      dynamic([r], r.inserted_at < ^cutoff and r.status in ^terminal)
+    )
   end
 
   defp do_prune(:revoked_api_keys, cutoff) do

--- a/apps/fountain/lib/fountain_web/telemetry.ex
+++ b/apps/fountain/lib/fountain_web/telemetry.ex
@@ -244,6 +244,33 @@ defmodule FountainWeb.Telemetry do
         event_name: [:fountain, :sandbox, :suspended],
         description: "Sandboxes parked by the idle bound (sprite kept, decisions/0017)"
       ),
+      # ── The bounded capacity queue (ADR 0042) ──────────────────────────
+      #
+      # Depth is observed after every queue mutation rather than polled, so a
+      # spike between two poller ticks is still in the histogram.
+      distribution("fountain.sandbox_queue.tenant_depth",
+        event_name: [:fountain, :sandbox_queue, :tenant_depth],
+        measurement: :depth,
+        reporter_options: [buckets: [0, 1, 2, 3, 5, 8, 10]],
+        description: "Live sandbox requests for a tenant, after a queue mutation"
+      ),
+      counter("fountain.sandbox_queue.completed.count",
+        event_name: [:fountain, :sandbox_queue, :completed],
+        measurement: :count,
+        tags: [:status, :kind],
+        description: "Sandbox requests that reached a terminal outcome, by outcome and kind"
+      ),
+      # The number that says whether the queue is a wait or a black hole, and
+      # the evidence for revisiting the one-hour bound.
+      distribution("fountain.sandbox_queue.completed.wait_ms",
+        event_name: [:fountain, :sandbox_queue, :completed],
+        measurement: :wait_ms,
+        tags: [:status, :kind],
+        reporter_options: [
+          buckets: [1000, 5000, 15_000, 30_000, 60_000, 300_000, 900_000, 1_800_000, 3_600_000]
+        ],
+        description: "How long a sandbox request waited before its terminal outcome"
+      ),
       # ── Credits and billing (#1169) ────────────────────────────────────
       #
       # ADR 0031 makes the balance the gate, so these workers are load-bearing
@@ -407,6 +434,12 @@ defmodule FountainWeb.Telemetry do
         measurement: :count,
         tags: [:status],
         description: "Sandbox rows by status"
+      ),
+      last_value("fountain.sandbox_queue.requests.count",
+        event_name: [:fountain, :sandbox_queue, :requests],
+        measurement: :count,
+        tags: [:status],
+        description: "Waiting and claimed sandbox request rows by status"
       ),
       # The live view of what the sandbox providers are charging for. Tagged
       # by provider because a minute on each is bought at a different price;

--- a/apps/fountain/test/fountain/ops_gauges_test.exs
+++ b/apps/fountain/test/fountain/ops_gauges_test.exs
@@ -54,6 +54,47 @@ defmodule Fountain.OpsGaugesTest do
     end
   end
 
+  test "counts waiting and claimed sandbox requests, and no history rows (#1033)" do
+    attach([[:fountain, :sandbox_queue, :requests]])
+
+    user = insert_verified_user()
+    agent = insert_agent(user_id: user.id)
+
+    {:ok, waiting} =
+      Fountain.SandboxQueue.enqueue(%{
+        user_id: user.id,
+        agent_id: agent.id,
+        kind: "start",
+        attrs: %{}
+      })
+
+    {:ok, done} =
+      Fountain.SandboxQueue.enqueue(%{
+        user_id: user.id,
+        agent_id: agent.id,
+        kind: "start",
+        attrs: %{}
+      })
+
+    {:ok, _} = Fountain.SandboxQueue.cancel_request(done)
+
+    assert :ok = OpsGauges.emit_telemetry()
+
+    assert_receive {:telemetry, [:fountain, :sandbox_queue, :requests], %{count: 1},
+                    %{status: "queued"}}
+
+    assert_receive {:telemetry, [:fountain, :sandbox_queue, :requests], %{count: 0},
+                    %{status: "starting"}}
+
+    # A `last_value` over terminal rows only ever climbs, so it says nothing
+    # about the queue now. Outcomes are counted as they happen instead.
+    for status <- ~w(started cancelled expired failed) do
+      refute_receive {:telemetry, [:fountain, :sandbox_queue, :requests], _, %{status: ^status}}
+    end
+
+    assert waiting.status == "queued"
+  end
+
   test "counts non-terminal sandboxes by provider and status" do
     # The live counterpart to the after-the-fact roll-up: which providers are
     # charging us right now. Tagged by provider, never by tenant — that would

--- a/apps/fountain/test/fountain/workers/retention_pruner_test.exs
+++ b/apps/fountain/test/fountain/workers/retention_pruner_test.exs
@@ -41,6 +41,56 @@ defmodule Fountain.Workers.RetentionPrunerTest do
     )
   end
 
+  describe "sandbox_requests" do
+    defp insert_request!(user, agent, status, at) do
+      %Fountain.SandboxQueue.Request{}
+      |> Fountain.SandboxQueue.Request.changeset(%{
+        user_id: user.id,
+        agent_id: agent.id,
+        kind: "start",
+        status: status
+      })
+      |> Repo.insert!()
+      # `sandbox_requests` timestamps are :utc_datetime_usec, and days_ago/1
+      # truncates to the second.
+      |> Ecto.Changeset.change(inserted_at: DateTime.add(at, 0, :microsecond))
+      |> Repo.update!()
+    end
+
+    test "prunes finished rows and never touches live work" do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+
+      old_started = insert_request!(user, agent, "started", days_ago(60))
+      old_failed = insert_request!(user, agent, "failed", days_ago(60))
+      recent = insert_request!(user, agent, "started", days_ago(1))
+      # Only reachable by a window shorter than the wait bound, or a clock
+      # that moved. Either way an unstarted request is not history.
+      stale_queued = insert_request!(user, agent, "queued", days_ago(60))
+
+      with_windows([sandbox_requests: 30], fn ->
+        assert RetentionPruner.prune(:sandbox_requests) == 2
+      end)
+
+      assert Repo.get(Fountain.SandboxQueue.Request, old_started.id) == nil
+      assert Repo.get(Fountain.SandboxQueue.Request, old_failed.id) == nil
+      assert Repo.get(Fountain.SandboxQueue.Request, recent.id)
+      assert Repo.get(Fountain.SandboxQueue.Request, stale_queued.id)
+    end
+
+    test "a claimed row is live work too" do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      claimed = insert_request!(user, agent, "starting", days_ago(60))
+
+      with_windows([sandbox_requests: 30], fn ->
+        assert RetentionPruner.prune(:sandbox_requests) == 0
+      end)
+
+      assert Repo.get(Fountain.SandboxQueue.Request, claimed.id)
+    end
+  end
+
   describe "log_events" do
     test "prunes rows past the window and keeps the rest" do
       user = insert_verified_user()

--- a/apps/fountain/test/fountain_web/metrics_test.exs
+++ b/apps/fountain/test/fountain_web/metrics_test.exs
@@ -173,6 +173,11 @@ defmodule FountainWeb.MetricsTest do
         [:fountain, :sandbox, :suspended],
         [:fountain, :reaper, :run],
         [:fountain, :reaper, :untracked],
+        # SandboxQueue emits depth after every mutation and completion at each
+        # terminal transition; OpsGauges emits the live row counts (#1033).
+        [:fountain, :sandbox_queue, :tenant_depth],
+        [:fountain, :sandbox_queue, :completed],
+        [:fountain, :sandbox_queue, :requests],
         # Audit.record_admin/1 rejection path (#451) — exercised by
         # Fountain.AuditTest's rejected-write telemetry test
         [:fountain, :audit, :admin_record_rejected],


### PR DESCRIPTION
Stacked on #1873.

Three series and a retention window. Parts 1 to 3 already emit these events; this declares the metrics over them, which is the direction `metrics_test.exs` checks ("every subscribed fountain event has a live producer").

- **`fountain.sandbox_queue.tenant_depth`** — a distribution observed after every queue mutation rather than polled, so a spike between two poller ticks is still in the histogram.
- **`fountain.sandbox_queue.completed.{count,wait_ms}`** — outcomes counted as they happen, tagged by status and kind, with the wait that preceded each one. The wait histogram is the number that says whether the queue is a wait or a black hole, and the evidence for revisiting the one-hour bound.
- **`fountain.sandbox_queue.requests.count`** — the `OpsGauges` poll, over **live rows only**. A `last_value` across terminal rows climbs forever and reports nothing about the queue now, which is why the Oban gauge excludes `completed` too. `ops_gauges_test.exs` asserts both halves: the live statuses are emitted with zeros, and the four terminal ones are not emitted at all.

`RetentionPruner` expires finished requests after 30 days. A finished row holds no prompt — every terminal transition erases `attrs` — so what is left is provenance and an outcome the audit trail already carries at its own, longer window. A `queued` or `starting` row is live work and is never pruned, whatever the window says; two tests pin that.

**Defers:** ADR 0042, the docs and the SDK version bump (part 7).

Part 6 of 7 for #1033.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9jevFQT5MkF3rJUieeiHW


---

### Review fixes (round 2)

- `emit_status_counts/3` takes a `where: r.status in ^statuses` — a no-op for the two existing callers, and the difference between a full-table group-by and an index read for this one, every ten seconds.
- The `RetentionPruner` docstring no longer claims a claimed row cannot outlive `SANDBOX_QUEUE_MAX_WAIT_SECONDS`. Nothing expires a `starting` row; the drain reclaiming an abandoned claim is what bounds it.



Part of #1033
