### PR TITLE
feat(oauth): a row a tenant can register an OAuth client into (#1125)

### DIFF
--- a/apps/fountain/lib/fountain/oauth/client.ex
+++ b/apps/fountain/lib/fountain/oauth/client.ex
@@ -1,0 +1,222 @@
+defmodule Fountain.OAuth.Client do
+  @moduledoc """
+  An OAuth client a tenant registered for itself (#1125).
+
+  ADR 0021 kept the client registry in config because there were two clients
+  and both were ours. This is the row for everybody else's: a person building
+  an app inside a sprite, or on `localhost`, who wants "Sign in with Fountain"
+  against a running server without an operator editing `OAUTH_CLIENTS` and
+  redeploying.
+
+  ## `published` is the security boundary, not the redirect allowlist
+
+  The obvious answer — wildcard the sandbox domain in the redirect allowlist —
+  is a phishing kit: anyone with any sandbox could start a flow with their own
+  PKCE challenge and their own box as `redirect_uri`, and a consenting user's
+  full-scope key would land there. PKCE does not help when the attacker
+  initiates the flow.
+
+  So an unpublished client, which is every client registered here, may only
+  ever authorize **its own owner** (`Fountain.OAuth.validate_request/2`).
+  The only account it can capture belongs to the person who registered it,
+  which is what makes the next sentence safe: the owner may register an HTTPS
+  redirect or an HTTP loopback redirect — their sprite's public URL or a
+  `localhost` port — because no one else's account is reachable through it.
+
+  `published` is an operator flip (there is no self-serve path to it), and a
+  published client is an ordinary first-party client on config's terms.
+
+  ## `origin_keys`
+
+  Derived from `redirect_uris` on every write, and indexed, because a CORS
+  preflight carries no authentication: the only thing the plug can key on is
+  the origin, and "an origin some registered client redirects to" is exactly
+  the predicate that makes registering an app enough to call the API from it.
+
+  It holds a lookup *key* rather than the origin verbatim, because a loopback
+  redirect matches on any port (RFC 8252) and a CORS rule that did not would
+  half-work: the sign-in would land and the first API call would fail, the
+  moment Vite moved off 5173.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+
+  @max_redirect_uris 10
+  @max_uri_length 2000
+  @loopback_hosts ~w(localhost 127.0.0.1 ::1)
+
+  @type t :: %__MODULE__{}
+
+  schema "oauth_clients" do
+    field :client_id, :string
+    field :name, :string
+    field :redirect_uris, {:array, :string}, default: []
+    field :origin_keys, {:array, :string}, default: []
+    field :published, :boolean, default: false
+
+    belongs_to :user, Fountain.Accounts.User
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc """
+  Changeset for a tenant-registered client. `client_id` is generated here and
+  never accepted from the caller: it is the name the whole flow is keyed on,
+  so letting an app choose it would let one app claim another's identity.
+  Ownership comes from the context's third argument. Neither `user_id` nor
+  `published` is cast from caller attributes.
+  """
+  def changeset(client, attrs, user_id \\ nil) do
+    client
+    |> cast(attrs, [:name, :redirect_uris])
+    |> put_user_id(user_id)
+    |> put_client_id()
+    |> validate_required([:name, :user_id])
+    |> update_change(:name, &String.trim/1)
+    |> validate_length(:name, min: 1, max: 120)
+    |> validate_redirect_uris()
+    |> put_origin_keys()
+    |> unique_constraint(:client_id)
+    |> foreign_key_constraint(:user_id)
+  end
+
+  defp put_user_id(changeset, user_id) when is_binary(user_id),
+    do: put_change(changeset, :user_id, user_id)
+
+  defp put_user_id(changeset, _user_id), do: changeset
+
+  defp put_client_id(%Ecto.Changeset{data: %__MODULE__{client_id: nil}} = changeset),
+    do: put_change(changeset, :client_id, generate_client_id())
+
+  defp put_client_id(changeset), do: changeset
+
+  @doc """
+  A fresh client id: random, url-safe, and long enough that it is not
+  guessable. Not derived from the name — two people may both call their app
+  "notes", and an id that collides is an id that can be claimed.
+  """
+  @spec generate_client_id() :: String.t()
+  def generate_client_id do
+    "app_" <> Base.url_encode64(:crypto.strong_rand_bytes(18), padding: false)
+  end
+
+  # At least one URI, because a client with none can never complete a flow,
+  # and a registration that silently cannot work is worse than a rejection.
+  #
+  # Deduplicated before anything is counted or checked: the cap and the
+  # per-URI errors are about what gets stored, so eleven copies of one URI is
+  # one URI rather than eleven, and a repeated bad one is reported once.
+  defp validate_redirect_uris(changeset) do
+    uris = Enum.uniq(get_field(changeset, :redirect_uris) || [])
+    changeset = put_change(changeset, :redirect_uris, uris)
+
+    cond do
+      uris == [] ->
+        add_error(changeset, :redirect_uris, "add at least one redirect URI")
+
+      length(uris) > @max_redirect_uris ->
+        add_error(changeset, :redirect_uris, "at most #{@max_redirect_uris} redirect URIs")
+
+      true ->
+        Enum.reduce(uris, changeset, fn uri, acc ->
+          case uri_error(uri) do
+            nil -> acc
+            msg -> add_error(acc, :redirect_uris, "#{uri}: #{msg}")
+          end
+        end)
+    end
+  end
+
+  @doc """
+  Why `uri` cannot be a redirect URI, or nil. Public so the API and the
+  console can say the same thing before a write is attempted.
+  """
+  @spec uri_error(term()) :: String.t() | nil
+  def uri_error(uri) when is_binary(uri) do
+    parsed = URI.parse(uri)
+
+    cond do
+      String.length(uri) > @max_uri_length -> "too long"
+      String.trim(uri) != uri -> "has leading or trailing whitespace"
+      parsed.scheme not in ["http", "https"] -> "must start with https:// or http://"
+      is_nil(parsed.host) or parsed.host == "" -> "must have a host"
+      parsed.fragment != nil -> "must not have a #fragment"
+      parsed.userinfo != nil -> "must not carry a user:password@ prefix"
+      parsed.scheme == "http" and not loopback?(parsed.host) -> "must be https, unless loopback"
+      true -> nil
+    end
+  end
+
+  def uri_error(_), do: "must be a string"
+
+  @doc "Whether `host` is the developer's own machine (RFC 8252 §7.3)."
+  @spec loopback?(String.t() | nil) :: boolean()
+  def loopback?(host) when is_binary(host), do: String.downcase(host) in @loopback_hosts
+  def loopback?(_), do: false
+
+  # Kept in step with redirect_uris on every write, so the CORS lookup is one
+  # indexed array containment and never a scan over parsed URIs.
+  defp put_origin_keys(changeset) do
+    case get_field(changeset, :redirect_uris) do
+      uris when is_list(uris) ->
+        put_change(changeset, :origin_keys, uris |> origins_of() |> Enum.map(&origin_key/1))
+
+      _ ->
+        changeset
+    end
+  end
+
+  @doc "The distinct `scheme://host[:port]` origins of a list of redirect URIs."
+  @spec origins_of([String.t()]) :: [String.t()]
+  def origins_of(uris) when is_list(uris) do
+    uris |> Enum.map(&origin_of/1) |> Enum.reject(&is_nil/1) |> Enum.uniq()
+  end
+
+  @doc "The `scheme://host[:port]` origin of a URI, or nil if it has none."
+  @spec origin_of(term()) :: String.t() | nil
+  def origin_of(uri) when is_binary(uri) do
+    case URI.parse(uri) do
+      %URI{scheme: scheme, host: host} = parsed when is_binary(scheme) and is_binary(host) ->
+        port =
+          if parsed.port && parsed.port != URI.default_port(scheme),
+            do: ":#{parsed.port}",
+            else: ""
+
+        "#{scheme}://#{format_host(host)}#{port}"
+
+      _ ->
+        nil
+    end
+  end
+
+  def origin_of(_), do: nil
+
+  @doc """
+  What an origin is stored and looked up as. The origin itself, except on
+  loopback, where the port is dropped so that `http://localhost:5174` matches
+  a client registered against `http://localhost:5173` — the same any-port rule
+  the redirect URI gets (RFC 8252 §7.3), for the same reason: the port a local
+  dev server ends up on is not a fact anybody registered.
+  """
+  @spec origin_key(term()) :: String.t() | nil
+  def origin_key(origin) when is_binary(origin) do
+    case URI.parse(origin) do
+      %URI{scheme: scheme, host: host} when is_binary(scheme) and is_binary(host) ->
+        if loopback?(host), do: "#{scheme}://#{format_host(host)}", else: origin_of(origin)
+
+      _ ->
+        nil
+    end
+  end
+
+  def origin_key(_), do: nil
+
+  defp format_host(host) do
+    host = String.downcase(host)
+    if String.contains?(host, ":"), do: "[#{host}]", else: host
+  end
+end

--- a/apps/fountain/priv/repo/migrations/20260911000000_create_oauth_clients.exs
+++ b/apps/fountain/priv/repo/migrations/20260911000000_create_oauth_clients.exs
@@ -1,0 +1,27 @@
+defmodule Fountain.Repo.Migrations.CreateOauthClients do
+  use Ecto.Migration
+
+  # Tenant-owned OAuth clients (#1125). Operator-configured clients remain
+  # published first-party apps; rows start unpublished and may authorize only
+  # their owner.
+  #
+  # origin_keys is derived from redirect_uris. It lets the CORS plug answer an
+  # unauthenticated preflight with an indexed lookup. Loopback keys omit the
+  # port to match RFC 8252's any-port redirect behavior.
+  def change do
+    create table(:oauth_clients, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :user_id, references(:users, type: :binary_id, on_delete: :delete_all), null: false
+      add :client_id, :string, null: false
+      add :name, :string, null: false
+      add :redirect_uris, {:array, :string}, null: false, default: []
+      add :origin_keys, {:array, :string}, null: false, default: []
+      add :published, :boolean, null: false, default: false
+      timestamps(type: :utc_datetime)
+    end
+
+    create unique_index(:oauth_clients, [:client_id])
+    create index(:oauth_clients, [:user_id])
+    create index(:oauth_clients, [:origin_keys], using: :gin)
+  end
+end

--- a/apps/fountain/test/fountain/oauth/client_test.exs
+++ b/apps/fountain/test/fountain/oauth/client_test.exs
@@ -1,0 +1,214 @@
+defmodule Fountain.OAuth.ClientTest do
+  @moduledoc """
+  The row a tenant registers an OAuth client into (#1125), on its own, before
+  any context reads it: what a redirect URI may be, and what origin key the
+  CORS lookup will later ask for.
+  """
+  use Fountain.DataCase, async: true
+
+  alias Fountain.OAuth.Client
+  alias Fountain.Repo
+
+  defp insert(attrs, user_id) do
+    %Client{} |> Client.changeset(attrs, user_id) |> Repo.insert()
+  end
+
+  describe "changeset/3" do
+    test "generates a client_id and never takes one from the caller" do
+      user = insert_verified_user()
+
+      {:ok, client} =
+        insert(
+          %{
+            "name" => "Notes",
+            "redirect_uris" => ["https://notes.test/callback"],
+            "client_id" => "fountain-team"
+          },
+          user.id
+        )
+
+      assert client.client_id != "fountain-team"
+      assert String.starts_with?(client.client_id, "app_")
+      assert client.user_id == user.id
+    end
+
+    test "starts unpublished, whatever the caller says" do
+      user = insert_verified_user()
+
+      {:ok, client} =
+        insert(
+          %{
+            "name" => "Notes",
+            "redirect_uris" => ["https://notes.test/callback"],
+            "published" => true
+          },
+          user.id
+        )
+
+      refute client.published
+    end
+
+    test "never casts the owner from caller attributes" do
+      owner = insert_verified_user()
+      other = insert_verified_user()
+
+      {:ok, client} =
+        insert(
+          %{
+            "name" => "Notes",
+            "redirect_uris" => ["https://notes.test/callback"],
+            "user_id" => other.id
+          },
+          owner.id
+        )
+
+      assert client.user_id == owner.id
+    end
+
+    test "refuses a registration that could never complete a flow" do
+      user = insert_verified_user()
+
+      assert {:error, cs} = insert(%{"name" => "Notes"}, user.id)
+      assert "add at least one redirect URI" in errors_on(cs).redirect_uris
+    end
+
+    test "caps how many redirect URIs one client may carry" do
+      user = insert_verified_user()
+      uris = for n <- 1..11, do: "https://notes.test/cb#{n}"
+
+      assert {:error, cs} = insert(%{"name" => "Notes", "redirect_uris" => uris}, user.id)
+      assert "at most 10 redirect URIs" in errors_on(cs).redirect_uris
+    end
+
+    test "refuses plaintext http off loopback, a fragment, and a bare path" do
+      user = insert_verified_user()
+
+      for uri <- ["http://notes.test/callback", "https://notes.test/cb#frag", "/callback"] do
+        assert {:error, cs} = insert(%{"name" => "Notes", "redirect_uris" => [uri]}, user.id)
+        assert errors_on(cs).redirect_uris != []
+      end
+    end
+
+    test "takes http on loopback, which is the local dev loop" do
+      user = insert_verified_user()
+
+      assert {:ok, _} =
+               insert(%{"name" => "N", "redirect_uris" => ["http://127.0.0.1:5173/cb"]}, user.id)
+    end
+
+    test "derives the origin keys, dropping the port only on loopback" do
+      user = insert_verified_user()
+
+      {:ok, client} =
+        insert(
+          %{
+            "name" => "Notes",
+            "redirect_uris" => [
+              "https://notes.test/callback",
+              "https://notes.test:8443/other",
+              "http://localhost:5173/callback"
+            ]
+          },
+          user.id
+        )
+
+      assert Enum.sort(client.origin_keys) ==
+               Enum.sort(["https://notes.test", "https://notes.test:8443", "http://localhost"])
+    end
+
+    # The cap counts what will be stored. Eleven copies of one URI is one URI.
+    test "deduplicates before it counts, so repeats do not hit the cap" do
+      user = insert_verified_user()
+      uris = for _ <- 1..11, do: "https://notes.test/callback"
+
+      assert {:ok, client} = insert(%{"name" => "Notes", "redirect_uris" => uris}, user.id)
+      assert client.redirect_uris == ["https://notes.test/callback"]
+    end
+
+    test "reports a repeated bad URI once, not once per copy" do
+      user = insert_verified_user()
+
+      assert {:error, cs} =
+               insert(
+                 %{
+                   "name" => "Notes",
+                   "redirect_uris" => ["http://notes.test/cb", "http://notes.test/cb"]
+                 },
+                 user.id
+               )
+
+      assert length(errors_on(cs).redirect_uris) == 1
+    end
+
+    test "keeps the same redirect URI once" do
+      user = insert_verified_user()
+
+      {:ok, client} =
+        insert(
+          %{"name" => "N", "redirect_uris" => ["https://n.test/cb", "https://n.test/cb"]},
+          user.id
+        )
+
+      assert client.redirect_uris == ["https://n.test/cb"]
+    end
+  end
+
+  describe "uri_error/1" do
+    test "names the reason, or nothing when the URI is usable" do
+      assert Client.uri_error("https://notes.test/callback") == nil
+      assert Client.uri_error("http://localhost:5173/callback") == nil
+      assert Client.uri_error("ftp://notes.test/cb") =~ "https://"
+      assert Client.uri_error("https:///cb") =~ "host"
+      assert Client.uri_error("https://notes.test/cb#x") =~ "fragment"
+      assert Client.uri_error("https://user:pw@notes.test/cb") =~ "user:password@"
+      assert Client.uri_error(" https://notes.test/cb ") =~ "whitespace"
+      assert Client.uri_error("https://notes.test/" <> String.duplicate("a", 2001)) =~ "too long"
+      assert Client.uri_error(:not_a_string) =~ "string"
+    end
+  end
+
+  describe "loopback?/1" do
+    test "is the developer's own machine and nothing else" do
+      assert Client.loopback?("localhost")
+      assert Client.loopback?("127.0.0.1")
+      assert Client.loopback?("::1")
+      assert Client.loopback?("LOCALHOST")
+      refute Client.loopback?("notes.test")
+      refute Client.loopback?(nil)
+    end
+  end
+
+  describe "origin_of/1 and origins_of/1" do
+    test "keeps a non-default port and drops a default one" do
+      assert Client.origin_of("https://a.test/cb") == "https://a.test"
+      assert Client.origin_of("https://a.test:443/cb") == "https://a.test"
+      assert Client.origin_of("https://a.test:8443/cb") == "https://a.test:8443"
+      assert Client.origin_of("http://[::1]:5173/cb") == "http://[::1]:5173"
+      assert Client.origin_of("/cb") == nil
+      assert Client.origin_of(nil) == nil
+    end
+
+    test "collapses several URIs on one origin" do
+      assert Client.origins_of(["https://a.test/cb", "https://a.test/other", "/cb"]) ==
+               ["https://a.test"]
+    end
+  end
+
+  describe "origin_key/1" do
+    test "keeps the port off loopback and drops it on" do
+      assert Client.origin_key("https://a.test:8443") == "https://a.test:8443"
+      assert Client.origin_key("https://a.test") == "https://a.test"
+      assert Client.origin_key("http://localhost:5173") == "http://localhost"
+      assert Client.origin_key("http://127.0.0.1:5173") == "http://127.0.0.1"
+      assert Client.origin_key("http://[::1]:5173") == "http://[::1]"
+      assert Client.origin_key("not-an-origin") == nil
+      assert Client.origin_key(nil) == nil
+    end
+  end
+
+  describe "generate_client_id/0" do
+    test "is random, so two apps with one name do not collide" do
+      refute Client.generate_client_id() == Client.generate_client_id()
+    end
+  end
+end


### PR DESCRIPTION
Re-cut of #1489 as a stack of nine on `main`, under the no-big-PRs rule. The original was 3,074 lines across 41 files and 210 commits behind; this is re-derived against today's tree rather than rebased.

This is the row and nothing else: the `oauth_clients` table and `Fountain.OAuth.Client`. ADR 0021 kept the client registry in application config because there were two clients and both were ours; this is the table for everybody else's.

What the schema decides:

- `client_id` is generated here and never accepted from the caller, because it is the name the whole flow is keyed on.
- `published` and `user_id` are never cast from caller attributes.
- A redirect URI must be `https` unless its host is loopback, must have a host, and must not carry a fragment.
- `origin_keys` is derived from `redirect_uris` on every write and GIN-indexed, so a later CORS preflight — which carries no authentication — is one indexed containment rather than a scan over parsed URIs. The key drops the port on loopback, because RFC 8252 §7.3 lets a loopback redirect match on any port and a CORS rule that did not would half-work the moment Vite moved off 5173.

Nothing reads the table yet. Part 1 of 9 for #1125; the context that writes it is #1877.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9jevFQT5MkF3rJUieeiHW
