### PR TITLE
feat(oauth): a tenant registers, renames and removes its own clients (#1125)

### DIFF
--- a/apps/fountain/lib/fountain/oauth.ex
+++ b/apps/fountain/lib/fountain/oauth.ex
@@ -22,10 +22,17 @@ defmodule Fountain.OAuth do
 
   ## Clients
 
-  A registry in application config, not a table: there are two of them and
-  they are ours. `config :fountain, Fountain.OAuth, clients: [%{id, name,
-  redirect_uris}]` (runtime.exs reads `OAUTH_CLIENTS` as JSON). Redirect
-  URIs match **exactly**.
+  Two registries. Application config holds the operator's — `config :fountain,
+  Fountain.OAuth, clients: [%{id, name, redirect_uris}]`, which runtime.exs
+  reads from `OAUTH_CLIENTS` as JSON — and the `oauth_clients` table holds
+  the ones a tenant registers for itself (#1125). Redirect URIs match
+  **exactly**.
+
+  The client functions at the bottom of this module own the second registry:
+  a tenant's own rows, scoped by `user_id`, audited, and capped. A row starts
+  unpublished, and the authorization flow does not read the table yet. The
+  next change makes it, under the development-mode rule that is what makes a
+  self-chosen redirect URI safe.
 
   ## Tokens are API keys
 
@@ -37,9 +44,17 @@ defmodule Fountain.OAuth do
   the host, not the library's.
   """
 
+  import Ecto.Query, warn: false
+
   use Managoat.OAuth, otp_app: :fountain, host: Fountain.OAuth.Host
 
-  alias Fountain.Accounts
+  alias Fountain.{Accounts, Audit, Repo}
+  alias Fountain.OAuth.Client
+
+  # An abuse ceiling, not an allowance: every row here will widen the
+  # deployment's CORS allowlist (ADR 0021), so registration must not be
+  # unbounded.
+  @max_clients_per_account 25
 
   @doc """
   Revoke the token (an API key) presented by an app that is signing out.
@@ -52,4 +67,140 @@ defmodule Fountain.OAuth do
   def revoke(%Accounts.ApiKey{} = key, opts \\ []) do
     Accounts.revoke_api_key(key.user_id, key.id, opts)
   end
+
+  @doc "A tenant's registered clients, newest first."
+  @spec list_clients(String.t()) :: [Client.t()]
+  def list_clients(user_id) when is_binary(user_id) do
+    # `id` breaks the tie: timestamps are second-precision, so two clients
+    # registered in the same second would otherwise come back in whatever
+    # order the planner chose, and the console list would reorder itself.
+    Repo.all(
+      from c in Client,
+        where: c.user_id == ^user_id,
+        order_by: [desc: c.inserted_at, desc: c.id]
+    )
+  end
+
+  @doc "One tenant-owned client by record id, or nil."
+  @spec get_client_record(String.t(), String.t()) :: Client.t() | nil
+  def get_client_record(id, user_id) when is_binary(id) and is_binary(user_id) do
+    # A path segment is whatever the caller typed. Casting a non-UUID to
+    # :binary_id raises, which phoenix_ecto turns into a 400 -- so the
+    # documented 404 would never reach a client that mistyped an id.
+    if valid_uuid?(id), do: Repo.get_by(Client, id: id, user_id: user_id)
+  end
+
+  @doc """
+  Register an unpublished client for a tenant.
+
+  The ceiling is per account rather than per deployment, and it is reported as
+  an ordinary changeset error so every surface says the same thing.
+  """
+  @spec create_client(String.t(), map(), keyword()) ::
+          {:ok, Client.t()} | {:error, Ecto.Changeset.t()}
+  def create_client(user_id, attrs, opts \\ []) when is_binary(user_id) and is_map(attrs) do
+    changeset = Client.changeset(%Client{}, attrs, user_id)
+
+    if client_count(user_id) >= @max_clients_per_account do
+      {:error,
+       changeset
+       |> Ecto.Changeset.add_error(
+         :base,
+         "at most #{@max_clients_per_account} apps per account"
+       )
+       |> Map.put(:action, :insert)}
+    else
+      changeset |> Repo.insert() |> audited("oauth_client.created", opts)
+    end
+  end
+
+  @doc """
+  Rename a client or replace its redirect URIs.
+
+  A call that moves no field succeeds and records nothing.
+
+  `client_id`, the owner and `published` are dropped rather than rejected:
+  they are not the caller's to set, and a surface that hands back what it read
+  should not fail for sending a field it was given.
+  """
+  @spec update_client(Client.t(), map(), keyword()) ::
+          {:ok, Client.t()} | {:error, Ecto.Changeset.t()}
+  def update_client(%Client{} = client, attrs, opts \\ []) when is_map(attrs) do
+    changeset =
+      client
+      |> Client.changeset(Map.drop(attrs, ["user_id", "client_id", "published"]))
+      |> prevent_published_update(client)
+
+    if changeset.valid? and changeset.changes == %{} do
+      # A request that moves nothing is not a change. Recording it would put a
+      # row in the trail whose `changed` list is empty, which is the "logs
+      # attempts as changes" shape ADR 0013 rules out. `Repo.update/1` would
+      # not issue a statement here either.
+      {:ok, client}
+    else
+      changeset
+      |> Repo.update()
+      |> audited(
+        "oauth_client.updated",
+        Keyword.put(opts, :metadata, Audit.changed_fields(changeset))
+      )
+    end
+  end
+
+  @doc """
+  Delete a tenant-owned client.
+
+  Refused once the client is published, for the reason `update_client/3` is:
+  publication moved the trust boundary to every account, and deleting the row
+  would break sign-in for all of them with a `client_id` nobody can recreate.
+  """
+  @spec delete_client(Client.t(), keyword()) ::
+          {:ok, Client.t()} | {:error, Ecto.Changeset.t()}
+  def delete_client(%Client{} = client, opts \\ []) do
+    if client.published do
+      {:error,
+       client
+       |> Ecto.Changeset.change()
+       |> Ecto.Changeset.add_error(
+         :base,
+         "published clients can only be removed by an operator"
+       )
+       |> Map.put(:action, :delete)}
+    else
+      client |> Repo.delete() |> audited("oauth_client.deleted", opts)
+    end
+  end
+
+  defp client_count(user_id) do
+    Repo.aggregate(from(c in Client, where: c.user_id == ^user_id), :count)
+  end
+
+  defp valid_uuid?(id), do: match?({:ok, _}, Ecto.UUID.cast(id))
+
+  # Publishing changes the trust boundary from owner-only to every account.
+  # The owner must not be able to change that operator-approved registration
+  # afterward. An operator can unpublish it before handing control back.
+  defp prevent_published_update(changeset, %Client{published: true}) do
+    Ecto.Changeset.add_error(
+      changeset,
+      :base,
+      "published clients can only be changed by an operator"
+    )
+  end
+
+  defp prevent_published_update(changeset, _client), do: changeset
+
+  # The trail names the client and where it sends people, never a secret:
+  # there is none here, and the redirect URIs are what an operator reading the
+  # trail actually needs (ADR 0013).
+  defp audited({:ok, %Client{} = client} = ok, action, opts) do
+    metadata =
+      %{"client_id" => client.client_id, "redirect_uris" => client.redirect_uris}
+      |> Map.merge(Keyword.get(opts, :metadata, %{}))
+
+    Audit.record_resource(action, "oauth_client", client, Keyword.put(opts, :metadata, metadata))
+    ok
+  end
+
+  defp audited(other, _action, _opts), do: other
 end

--- a/apps/fountain/test/fountain/audit_guardrail_test.exs
+++ b/apps/fountain/test/fountain/audit_guardrail_test.exs
@@ -30,6 +30,7 @@ defmodule Fountain.AuditGuardrailTest do
     Conversations,
     Environments,
     InferenceCredentials,
+    OAuth,
     Principals,
     Vaults,
     Webhooks
@@ -125,6 +126,9 @@ defmodule Fountain.AuditGuardrailTest do
     {"secret binding create", &__MODULE__.do_binding_create/1, "secret_binding.created"},
     {"secret binding update", &__MODULE__.do_binding_update/1, "secret_binding.updated"},
     {"secret binding delete", &__MODULE__.do_binding_delete/1, "secret_binding.deleted"},
+    {"oauth client create", &__MODULE__.do_oauth_client_create/1, "oauth_client.created"},
+    {"oauth client update", &__MODULE__.do_oauth_client_update/1, "oauth_client.updated"},
+    {"oauth client delete", &__MODULE__.do_oauth_client_delete/1, "oauth_client.deleted"},
     {"connection connect", &__MODULE__.do_connection_connect/1, "connection.created"},
     {"connection revoke", &__MODULE__.do_connection_revoke/1, "connection.revoked"},
     {"connection expire", &__MODULE__.do_connection_expire/1, "connection.expired"},
@@ -733,6 +737,18 @@ defmodule Fountain.AuditGuardrailTest do
   end
 
   def do_oauth_authorize(user), do: {:ok, _} = Fountain.OAuth.authorize(user.id, oauth_request())
+
+  def do_oauth_client_create(user) do
+    {:ok, _} = OAuth.create_client(user.id, oauth_client_attrs())
+  end
+
+  def do_oauth_client_update(user) do
+    {:ok, _} = OAuth.update_client(insert_oauth_client(user_id: user.id), %{"name" => "renamed"})
+  end
+
+  def do_oauth_client_delete(user) do
+    {:ok, _} = OAuth.delete_client(insert_oauth_client(user_id: user.id))
+  end
 
   def do_oauth_device_approve(user) do
     {:ok, %{user_code: code}} = Fountain.OAuth.start_device_grant()

--- a/apps/fountain/test/fountain/oauth_clients_test.exs
+++ b/apps/fountain/test/fountain/oauth_clients_test.exs
@@ -1,0 +1,237 @@
+defmodule Fountain.OAuthClientsTest do
+  @moduledoc """
+  The registry of OAuth clients a tenant registered for itself (#1125): what
+  one account may write, what it may never write, and what the trail keeps.
+  """
+  use Fountain.DataCase, async: true
+
+  alias Fountain.Audit
+  alias Fountain.OAuth
+
+  describe "create_client/3" do
+    test "caps how many clients one account may register" do
+      user = insert_verified_user()
+
+      for n <- 1..25 do
+        {:ok, _} =
+          OAuth.create_client(user.id, %{
+            "name" => "App #{n}",
+            "redirect_uris" => ["https://app#{n}.test/callback"]
+          })
+      end
+
+      assert {:error, changeset} =
+               OAuth.create_client(user.id, %{
+                 "name" => "One too many",
+                 "redirect_uris" => ["https://nope.test/callback"]
+               })
+
+      assert "at most 25 apps per account" in errors_on(changeset).base
+      assert length(OAuth.list_clients(user.id)) == 25
+
+      # The ceiling is per account, not per deployment.
+      assert {:ok, _} =
+               OAuth.create_client(insert_verified_user().id, %{
+                 "name" => "Someone else",
+                 "redirect_uris" => ["https://other.test/callback"]
+               })
+    end
+
+    test "records oauth_client.created with the client_id and the URIs" do
+      user = insert_verified_user()
+
+      {:ok, client} =
+        OAuth.create_client(user.id, %{"name" => "N", "redirect_uris" => ["https://n.test/c"]})
+
+      assert [event] =
+               user.id
+               |> Audit.list_recent_for_user(20)
+               |> Enum.filter(&(&1.action == "oauth_client.created"))
+
+      assert event.resource_type == "oauth_client"
+      assert event.resource_id == client.id
+      assert event.metadata["client_id"] == client.client_id
+      assert event.metadata["redirect_uris"] == ["https://n.test/c"]
+    end
+
+    test "a rejected registration leaves no trail" do
+      user = insert_verified_user()
+
+      assert {:error, _} = OAuth.create_client(user.id, %{"name" => "N"})
+
+      assert user.id
+             |> Audit.list_recent_for_user(20)
+             |> Enum.filter(&(&1.action == "oauth_client.created")) == []
+    end
+  end
+
+  describe "update_client/3" do
+    test "renames and re-derives the origin keys" do
+      client = insert_oauth_client(redirect_uris: ["https://old.test/c"])
+
+      {:ok, updated} =
+        OAuth.update_client(client, %{
+          "name" => "New",
+          "redirect_uris" => ["https://new.test/c"]
+        })
+
+      assert updated.name == "New"
+      assert updated.origin_keys == ["https://new.test"]
+      assert updated.client_id == client.client_id
+    end
+
+    test "cannot publish itself or change owner" do
+      other = insert_verified_user()
+      client = insert_oauth_client()
+
+      {:ok, updated} =
+        OAuth.update_client(client, %{"published" => true, "user_id" => other.id})
+
+      refute updated.published
+      assert updated.user_id == client.user_id
+    end
+
+    test "cannot change owner with atom-keyed attributes either" do
+      other = insert_verified_user()
+      client = insert_oauth_client()
+
+      {:ok, updated} = OAuth.update_client(client, %{user_id: other.id, name: "Renamed"})
+
+      assert updated.user_id == client.user_id
+      assert updated.name == "Renamed"
+    end
+
+    test "cannot change an operator-published registration" do
+      client = insert_oauth_client(published: true)
+
+      assert {:error, changeset} = OAuth.update_client(client, %{name: "Renamed"})
+      assert "published clients can only be changed by an operator" in errors_on(changeset).base
+      assert OAuth.get_client_record(client.id, client.user_id).name == client.name
+    end
+
+    test "names the fields that changed" do
+      client = insert_oauth_client(name: "Before")
+
+      {:ok, _} = OAuth.update_client(client, %{"name" => "After"})
+
+      assert [event] =
+               client.user_id
+               |> Audit.list_recent_for_user(20)
+               |> Enum.filter(&(&1.action == "oauth_client.updated"))
+
+      assert event.metadata["changed"] == ["name"]
+    end
+
+    # ADR 0013: only record what happened. A PATCH with the same values is a
+    # legal request (no field of OAuthClientUpdateRequest is required), and an
+    # `oauth_client.updated` row whose `changed` list is empty is worse than
+    # no row.
+    test "an update that moves nothing succeeds and leaves no trail" do
+      client = insert_oauth_client(name: "Same")
+
+      assert {:ok, same} =
+               OAuth.update_client(client, %{
+                 "name" => "Same",
+                 "redirect_uris" => client.redirect_uris
+               })
+
+      assert same.id == client.id
+      assert same.name == "Same"
+
+      assert client.user_id
+             |> Audit.list_recent_for_user(20)
+             |> Enum.filter(&(&1.action == "oauth_client.updated")) == []
+    end
+
+    test "an empty change set is a no-op too" do
+      client = insert_oauth_client()
+
+      assert {:ok, _} = OAuth.update_client(client, %{})
+
+      assert client.user_id
+             |> Audit.list_recent_for_user(20)
+             |> Enum.filter(&(&1.action == "oauth_client.updated")) == []
+    end
+
+    test "a refused update leaves no trail" do
+      client = insert_oauth_client(published: true)
+
+      assert {:error, _} = OAuth.update_client(client, %{"name" => "Renamed"})
+
+      assert client.user_id
+             |> Audit.list_recent_for_user(20)
+             |> Enum.filter(&(&1.action == "oauth_client.updated")) == []
+    end
+  end
+
+  describe "delete_client/2" do
+    test "removes the row and records it" do
+      client = insert_oauth_client()
+
+      {:ok, _} = OAuth.delete_client(client)
+
+      assert OAuth.list_clients(client.user_id) == []
+
+      assert [event] =
+               client.user_id
+               |> Audit.list_recent_for_user(20)
+               |> Enum.filter(&(&1.action == "oauth_client.deleted"))
+
+      assert event.metadata["client_id"] == client.client_id
+    end
+
+    test "cannot remove an operator-published registration" do
+      client = insert_oauth_client(published: true)
+
+      assert {:error, changeset} = OAuth.delete_client(client)
+      assert "published clients can only be removed by an operator" in errors_on(changeset).base
+      assert OAuth.get_client_record(client.id, client.user_id)
+    end
+  end
+
+  describe "list_clients/1 and get_client_record/2" do
+    test "are scoped to the tenant" do
+      mine = insert_oauth_client()
+      theirs = insert_oauth_client()
+
+      assert [found] = OAuth.list_clients(mine.user_id)
+      assert found.id == mine.id
+
+      assert OAuth.get_client_record(mine.id, mine.user_id)
+      refute OAuth.get_client_record(theirs.id, mine.user_id)
+    end
+
+    test "get_client_record/2 returns nil for an id that is not a UUID" do
+      client = insert_oauth_client()
+
+      refute OAuth.get_client_record("foo", client.user_id)
+      refute OAuth.get_client_record("", client.user_id)
+    end
+
+    test "lists every client the account holds" do
+      user = insert_verified_user()
+      one = insert_oauth_client(user_id: user.id, name: "One")
+      two = insert_oauth_client(user_id: user.id, name: "Two")
+
+      assert user.id |> OAuth.list_clients() |> Enum.map(& &1.id) |> Enum.sort() ==
+               Enum.sort([one.id, two.id])
+    end
+
+    # Timestamps are second-precision, so these two almost certainly share one.
+    # Without the id tie-break the order here is the planner's choice.
+    test "orders deterministically when two land in the same second" do
+      user = insert_verified_user()
+      for n <- 1..5, do: insert_oauth_client(user_id: user.id, name: "App #{n}")
+
+      ids = user.id |> OAuth.list_clients() |> Enum.map(& &1.id)
+
+      expected =
+        user.id
+        |> OAuth.list_clients()
+        |> Enum.sort_by(&{DateTime.to_unix(&1.inserted_at), &1.id}, :desc)
+        |> Enum.map(& &1.id)
+
+      assert ids == expected
+    end
+  end
+end

--- a/apps/fountain/test/support/factory.ex
+++ b/apps/fountain/test/support/factory.ex
@@ -124,6 +124,36 @@ defmodule Fountain.Factory do
     insert_api_key(user, "sprite:#{uniq()}", Keyword.put_new(opts, :scopes, ["sprite"]))
   end
 
+  # ── OAuth clients (#1125) ─────────────────────────────────────────────────
+
+  def oauth_client_attrs(overrides \\ %{}) do
+    Map.merge(
+      %{"name" => "app-#{uniq()}", "redirect_uris" => ["https://app-#{uniq()}.test/callback"]},
+      to_string_map(overrides)
+    )
+  end
+
+  @doc """
+  A registered OAuth client. `published: true` is written straight to the row
+  because publishing is an operator flip with no self-serve path -- there is
+  no context function that would do it.
+  """
+  def insert_oauth_client(overrides \\ %{}) do
+    overrides = to_string_map(overrides)
+    {user_id, overrides} = Map.pop_lazy(overrides, "user_id", fn -> insert_verified_user().id end)
+    {published, overrides} = Map.pop(overrides, "published", false)
+
+    {:ok, client} = Fountain.OAuth.create_client(user_id, oauth_client_attrs(overrides))
+
+    if published do
+      client
+      |> Ecto.Changeset.change(published: true)
+      |> Fountain.Repo.update!()
+    else
+      client
+    end
+  end
+
   # ── connections (#1178) ───────────────────────────────────────────────────
 
   @doc """


### PR DESCRIPTION
Part 2 of 9 for #1125 (re-cut of #1489). Based on #1875.

The second registry, scoped by `user_id` like every other tenant-owned thing: `list_clients/1`, `get_client_record/2`, `create_client/3`, `update_client/3` and `delete_client/2` on `Fountain.OAuth`. Each records its own event, so every door is covered by construction (ADR 0013); `audit_guardrail_test.exs` carries the three new rows.

Two refusals are worth reading twice.

- **Twenty-five clients an account.** An abuse ceiling rather than an allowance, because a row will shortly widen the deployment's CORS allowlist and registration is self-serve.
- **A published client can be changed or deleted by nobody but an operator.** Publication moves the trust boundary from the owner to every account, and the row's `client_id` is random, so a deletion would break sign-in for all of them with an id nobody can recreate.

`client_id`, the owner and `published` are dropped from update attributes rather than rejected, so a surface that hands back what it read does not fail for sending a field it was given.

The authorization flow still reads only the config registry. Reading these rows into it is the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9jevFQT5MkF3rJUieeiHW


Part of #1125
