### PR TITLE
feat(oauth): a registered client signs in its owner and nobody else (#1125)

### DIFF
--- a/apps/fountain/lib/fountain/oauth.ex
+++ b/apps/fountain/lib/fountain/oauth.ex
@@ -25,14 +25,27 @@ defmodule Fountain.OAuth do
   Two registries. Application config holds the operator's — `config :fountain,
   Fountain.OAuth, clients: [%{id, name, redirect_uris}]`, which runtime.exs
   reads from `OAUTH_CLIENTS` as JSON — and the `oauth_clients` table holds
-  the ones a tenant registers for itself (#1125). Redirect URIs match
-  **exactly**.
+  the ones a tenant registers for itself (#1125). Config wins on a collision,
+  so a row can never shadow a first-party client.
 
-  The client functions at the bottom of this module own the second registry:
-  a tenant's own rows, scoped by `user_id`, audited, and capped. A row starts
-  unpublished, and the authorization flow does not read the table yet. The
-  next change makes it, under the development-mode rule that is what makes a
-  self-chosen redirect URI safe.
+  **Development mode is the security boundary, not the redirect allowlist.**
+  A row starts unpublished, and an unpublished client authorizes only its
+  owner: every other account is rendered an error page, never redirected.
+  That is what makes a self-chosen redirect URI safe — the only account such
+  a client can capture belongs to the person who registered it — and it is
+  why its owner may name any HTTPS redirect or an HTTP loopback one.
+  `published` is an operator flip with no self-serve path, and a published
+  client is an ordinary first-party client on config's terms.
+
+  Redirect URIs match **exactly**, except that an unpublished loopback
+  redirect matches on any port (RFC 8252 §7.3), because the port a local dev
+  server lands on is not a fact anybody registered.
+
+  `redirect_registered?/2` is the **only** redirect gate in the server.
+  `grant_client/2` hands the library a client whose registered list is the
+  requested URI, so `Managoat.OAuth.Clients.validate_request/2` always agrees
+  and is no longer a second opinion. Loosening the check here loosens
+  everything; there is nothing behind it.
 
   ## Tokens are API keys
 
@@ -48,13 +61,145 @@ defmodule Fountain.OAuth do
 
   use Managoat.OAuth, otp_app: :fountain, host: Fountain.OAuth.Host
 
+  defoverridable get_client: 1, validate_request: 1, authorize: 2, authorize: 3
+
   alias Fountain.{Accounts, Audit, Repo}
   alias Fountain.OAuth.Client
+  alias Managoat.OAuth.Clients
 
   # An abuse ceiling, not an allowance: every row here will widen the
   # deployment's CORS allowlist (ADR 0021), so registration must not be
   # unbounded.
   @max_clients_per_account 25
+
+  @type client :: %{
+          id: String.t(),
+          name: String.t(),
+          redirect_uris: [String.t()],
+          published: boolean(),
+          owner_id: String.t() | nil,
+          record_id: String.t() | nil
+        }
+
+  @doc """
+  Operator-configured clients, treated as published.
+
+  Configuration is still the authority for first-party apps. It wins over a
+  database row with the same id, so a tenant cannot shadow an operator app.
+  """
+  @spec config_clients() :: [client()]
+  def config_clients do
+    __managoat_oauth__()
+    |> Managoat.OAuth.clients()
+    |> Enum.map(&Map.merge(&1, %{published: true, owner_id: nil, record_id: nil}))
+  end
+
+  @doc "The client with `id`, or nil. Operator configuration wins."
+  @spec get_client(term()) :: client() | nil
+  def get_client(id) when is_binary(id) do
+    Enum.find(config_clients(), &(&1.id == id)) || db_client(id)
+  end
+
+  def get_client(_), do: nil
+
+  defp db_client(id) do
+    case Repo.get_by(Client, client_id: id) do
+      nil -> nil
+      %Client{} = row -> to_client(row)
+    end
+  end
+
+  defp to_client(%Client{} = row) do
+    %{
+      id: row.client_id,
+      name: row.name,
+      redirect_uris: row.redirect_uris,
+      published: row.published,
+      owner_id: row.user_id,
+      record_id: row.id
+    }
+  end
+
+  @doc """
+  Validate an authorization request with no resolved subject.
+
+  Kept so that a caller with only configured clients still has the instance
+  API the library defines. A development-mode client fails closed here, until
+  the caller supplies the signed-in subject to `validate_request/2`.
+  """
+  @spec validate_request(map()) :: {:ok, client()} | {:error, atom()}
+  def validate_request(params), do: validate_request(params, nil)
+
+  @doc """
+  Validate the client, the development-mode boundary, the redirect and PKCE.
+
+  The owner check deliberately comes before redirect matching. A different
+  account learns only that the client is in development mode, never which
+  redirects its owner registered.
+  """
+  @spec validate_request(map(), String.t() | nil) :: {:ok, client()} | {:error, atom()}
+  def validate_request(params, user_id) when is_map(params) do
+    with %{} = client <- get_client(params["client_id"]) || {:error, :unknown_client},
+         true <- authorizable_by?(client, user_id) || {:error, :development_mode},
+         true <-
+           redirect_registered?(client, params["redirect_uri"]) ||
+             {:error, :redirect_uri_mismatch},
+         {:ok, _} <- Clients.validate_request([grant_client(client, params)], params) do
+      {:ok, client}
+    end
+  end
+
+  @doc "Whether a subject may authorize through a client."
+  @spec authorizable_by?(client(), String.t() | nil) :: boolean()
+  def authorizable_by?(%{published: true}, _user_id), do: true
+
+  def authorizable_by?(%{owner_id: owner_id}, user_id)
+      when is_binary(owner_id) and is_binary(user_id),
+      do: owner_id == user_id
+
+  def authorizable_by?(_client, _user_id), do: false
+
+  defp redirect_registered?(client, uri) when is_binary(uri) do
+    cond do
+      uri in client.redirect_uris -> true
+      client.published -> false
+      true -> Enum.any?(client.redirect_uris, &loopback_match?(&1, uri))
+    end
+  end
+
+  defp redirect_registered?(_client, _uri), do: false
+
+  defp loopback_match?(registered, requested) do
+    registered = URI.parse(registered)
+    requested = URI.parse(requested)
+
+    Client.loopback?(registered.host) and Client.loopback?(requested.host) and
+      registered.scheme == requested.scheme and
+      String.downcase(registered.host) == String.downcase(requested.host) and
+      registered.userinfo == requested.userinfo and registered.path == requested.path and
+      registered.query == requested.query and registered.fragment == requested.fragment
+  end
+
+  # Managoat validates exact redirect matches. Once Fountain has accepted an
+  # RFC 8252 any-port loopback redirect, give the state machine the validated
+  # requested URI so its second validation reaches the same conclusion.
+  #
+  # This is what makes redirect_registered?/2 the only gate: the library's
+  # check cannot fail here, by construction. Never call this with a URI
+  # validate_request/2 has not already accepted.
+  defp grant_client(client, params) do
+    client
+    |> Map.take([:id, :name])
+    |> Map.put(:redirect_uris, [params["redirect_uri"]])
+  end
+
+  @doc "Issue an authorization code after applying Fountain's client policy."
+  def authorize(subject, params, opts \\ []) when is_binary(subject) and is_map(params) do
+    with {:ok, client} <- validate_request(params, subject) do
+      config = %{__managoat_oauth__() | clients: [grant_client(client, params)]}
+      Managoat.OAuth.authorize(config, subject, params, opts)
+    end
+  end
 
   @doc """
   Revoke the token (an API key) presented by an app that is signing out.

--- a/apps/fountain/lib/fountain/oauth/host.ex
+++ b/apps/fountain/lib/fountain/oauth/host.ex
@@ -27,7 +27,7 @@ defmodule Fountain.OAuth.Host do
 
   @behaviour Managoat.OAuth.Host
 
-  alias Fountain.{Accounts, Audit}
+  alias Fountain.{Accounts, Audit, OAuth}
 
   @impl true
   def subject_allowed?(user_id) do
@@ -64,11 +64,19 @@ defmodule Fountain.OAuth.Host do
 
   @impl true
   def audit(:authorized, meta, opts) do
+    # A tenant-registered client is a row, so the trail can point at it. A
+    # configured one is not, and stays a client_id in the metadata.
+    resource_id =
+      case OAuth.get_client(meta.client_id) do
+        %{record_id: id} when is_binary(id) -> id
+        _ -> nil
+      end
+
     Audit.record(%{
       user_id: meta.subject_id,
       action: "oauth.authorized",
       resource_type: "oauth_client",
-      resource_id: nil,
+      resource_id: resource_id,
       actor: Keyword.get(opts, :actor, "ui"),
       request_ip: Keyword.get(opts, :request_ip),
       metadata: %{"client_id" => meta.client_id, "redirect_uri" => meta.redirect_uri}

--- a/apps/fountain/lib/fountain_web/controllers/oauth_authorize_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/oauth_authorize_controller.ex
@@ -8,7 +8,8 @@ defmodule FountainWeb.OAuthAuthorizeController do
   Browser route with the session and CSRF protection. Not signed in →
   remember this request and go to login; the login round-trips back here.
   A request whose client or redirect URI does not check out is **rendered**
-  as an error, never redirected — see `Fountain.OAuth.validate_request/1`.
+  as an error, never redirected — see `Fountain.OAuth.validate_request/2`.
+  That includes a development-mode client requested by anyone but its owner.
   """
   use FountainWeb, :controller
 
@@ -20,7 +21,7 @@ defmodule FountainWeb.OAuthAuthorizeController do
   plug :require_user
 
   def show(conn, params) do
-    case OAuth.validate_request(params) do
+    case OAuth.validate_request(params, conn.assigns.current_user.id) do
       {:ok, client} ->
         render(conn, :consent, client: client, params: request_params(params), error: nil)
 
@@ -32,7 +33,7 @@ defmodule FountainWeb.OAuthAuthorizeController do
   def create(conn, %{"decision" => decision} = params) do
     user = conn.assigns.current_user
 
-    case OAuth.validate_request(params) do
+    case OAuth.validate_request(params, user.id) do
       {:ok, _client} when decision == "allow" ->
         case OAuth.authorize(user.id, params, FountainWeb.Audited.attribution(conn)) do
           {:ok, code} ->

--- a/apps/fountain/lib/fountain_web/controllers/oauth_authorize_html.ex
+++ b/apps/fountain/lib/fountain_web/controllers/oauth_authorize_html.ex
@@ -15,6 +15,11 @@ defmodule FountainWeb.OAuthAuthorizeHTML do
         <div class="space-y-1">
           <div class="text-xs uppercase tracking-wide text-zinc-500">{Fountain.Brand.name()}</div>
           <h1 class="text-xl font-semibold">Sign in to {@client.name}?</h1>
+          <p :if={not @client.published} class="text-xs text-amber-700 bg-amber-50 rounded px-2 py-1">
+            <span class="font-medium">In development.</span>
+            You registered this app yourself, and it signs in nobody but you. Nothing here has been
+            reviewed, so read the address it returns to before you allow it.
+          </p>
           <p class="text-sm text-zinc-600">
             <span class="font-medium">{@client.name}</span>
             is asking to use your {Fountain.Brand.name()} account. Allowing it issues an API key it will use to
@@ -65,6 +70,11 @@ defmodule FountainWeb.OAuthAuthorizeHTML do
 
   defp reason_text(:unknown_client),
     do: "The app is not registered with this Fountain (unknown client_id)."
+
+  defp reason_text(:development_mode),
+    do:
+      "This app is in development. Only the account that registered it can sign in, " <>
+        "and that is not the account you are signed in as."
 
   defp reason_text(:redirect_uri_mismatch),
     do: "The app asked to send you somewhere it is not registered for (redirect_uri)."

--- a/apps/fountain/test/fountain/oauth_clients_test.exs
+++ b/apps/fountain/test/fountain/oauth_clients_test.exs
@@ -8,6 +8,22 @@ defmodule Fountain.OAuthClientsTest do
   alias Fountain.Audit
   alias Fountain.OAuth
 
+  defp pkce_challenge do
+    Base.url_encode64(:crypto.hash(:sha256, "verifier"), padding: false)
+  end
+
+  defp request(client_id, redirect, over \\ %{}) do
+    Map.merge(
+      %{
+        "client_id" => client_id,
+        "redirect_uri" => redirect,
+        "code_challenge" => pkce_challenge(),
+        "code_challenge_method" => "S256"
+      },
+      over
+    )
+  end
+
   describe "create_client/3" do
     test "caps how many clients one account may register" do
       user = insert_verified_user()
@@ -232,6 +248,216 @@ defmodule Fountain.OAuthClientsTest do
         |> Enum.map(& &1.id)
 
       assert ids == expected
+    end
+  end
+
+  describe "get_client/1" do
+    test "config wins, so a row can never shadow a first-party client" do
+      assert %{id: "test-app", published: true, owner_id: nil} = OAuth.get_client("test-app")
+    end
+
+    test "returns a row as an unpublished client owned by its registrant" do
+      client = insert_oauth_client()
+
+      assert %{id: id, published: false, owner_id: owner, record_id: record_id} =
+               OAuth.get_client(client.client_id)
+
+      assert id == client.client_id
+      assert owner == client.user_id
+      assert record_id == client.id
+    end
+
+    test "is nil for an id nobody registered" do
+      refute OAuth.get_client("app_nope")
+      refute OAuth.get_client(nil)
+    end
+
+    test "a deleted client stops being reachable by the flow" do
+      client = insert_oauth_client()
+      {:ok, _} = OAuth.delete_client(client)
+
+      refute OAuth.get_client(client.client_id)
+    end
+  end
+
+  describe "validate_request/2 — development mode" do
+    test "the owner may sign in to their own unpublished client" do
+      client = insert_oauth_client(redirect_uris: ["https://mine.test/c"])
+
+      assert {:ok, %{id: _}} =
+               OAuth.validate_request(
+                 request(client.client_id, "https://mine.test/c"),
+                 client.user_id
+               )
+    end
+
+    test "anyone else is refused, and told nothing about the redirect URI" do
+      stranger = insert_verified_user()
+      client = insert_oauth_client(redirect_uris: ["https://mine.test/c"])
+
+      assert {:error, :development_mode} =
+               OAuth.validate_request(
+                 request(client.client_id, "https://mine.test/c"),
+                 stranger.id
+               )
+
+      # A wrong redirect from a stranger is still development_mode: the
+      # identity gate answers first so the error page leaks no registration.
+      assert {:error, :development_mode} =
+               OAuth.validate_request(
+                 request(client.client_id, "https://evil.test/c"),
+                 stranger.id
+               )
+    end
+
+    test "fails closed when there is no signed-in user" do
+      client = insert_oauth_client(redirect_uris: ["https://mine.test/c"])
+
+      assert {:error, :development_mode} =
+               OAuth.validate_request(request(client.client_id, "https://mine.test/c"))
+    end
+
+    test "a published client takes any account" do
+      stranger = insert_verified_user()
+      client = insert_oauth_client(redirect_uris: ["https://mine.test/c"], published: true)
+
+      assert {:ok, _} =
+               OAuth.validate_request(
+                 request(client.client_id, "https://mine.test/c"),
+                 stranger.id
+               )
+    end
+
+    test "an id nobody registered is unknown_client" do
+      user = insert_verified_user()
+
+      assert {:error, :unknown_client} =
+               OAuth.validate_request(request("app_nope", "https://mine.test/c"), user.id)
+    end
+
+    test "the owner still gets an exact redirect check" do
+      client = insert_oauth_client(redirect_uris: ["https://mine.test/c"])
+
+      assert {:error, :redirect_uri_mismatch} =
+               OAuth.validate_request(
+                 request(client.client_id, "https://mine.test/other"),
+                 client.user_id
+               )
+    end
+
+    test "a missing redirect URI is a mismatch, not a crash" do
+      client = insert_oauth_client(redirect_uris: ["https://mine.test/c"])
+
+      assert {:error, :redirect_uri_mismatch} =
+               OAuth.validate_request(
+                 %{"client_id" => client.client_id},
+                 client.user_id
+               )
+    end
+
+    test "PKCE is still required once the client checks out" do
+      client = insert_oauth_client(redirect_uris: ["https://mine.test/c"])
+
+      assert {:error, _} =
+               OAuth.validate_request(
+                 %{"client_id" => client.client_id, "redirect_uri" => "https://mine.test/c"},
+                 client.user_id
+               )
+    end
+  end
+
+  describe "validate_request/2 — loopback ports" do
+    test "an unpublished loopback redirect matches on any port" do
+      client = insert_oauth_client(redirect_uris: ["http://localhost:5173/callback"])
+
+      assert {:ok, _} =
+               OAuth.validate_request(
+                 request(client.client_id, "http://localhost:5174/callback"),
+                 client.user_id
+               )
+    end
+
+    test "but not on another path, host or scheme" do
+      client = insert_oauth_client(redirect_uris: ["http://localhost:5173/callback"])
+
+      for uri <- [
+            "http://localhost:5174/other",
+            "http://evil.test:5174/callback",
+            "https://localhost:5174/callback",
+            "http://localhost:5174/callback#fragment"
+          ] do
+        assert {:error, :redirect_uri_mismatch} =
+                 OAuth.validate_request(request(client.client_id, uri), client.user_id)
+      end
+    end
+
+    test "a published client gets no port latitude" do
+      client =
+        insert_oauth_client(redirect_uris: ["http://localhost:5173/callback"], published: true)
+
+      assert {:error, :redirect_uri_mismatch} =
+               OAuth.validate_request(
+                 request(client.client_id, "http://localhost:5174/callback"),
+                 client.user_id
+               )
+    end
+  end
+
+  describe "authorize/3" do
+    test "the owner gets a code their own client can exchange" do
+      client = insert_oauth_client(redirect_uris: ["https://mine.test/c"])
+      verifier = "verifier"
+
+      assert {:ok, code} =
+               OAuth.authorize(client.user_id, request(client.client_id, "https://mine.test/c"))
+
+      assert {:ok, %{access_token: _}} =
+               OAuth.exchange(%{
+                 "code" => code,
+                 "code_verifier" => verifier,
+                 "client_id" => client.client_id,
+                 "redirect_uri" => "https://mine.test/c"
+               })
+    end
+
+    test "a stranger gets no code at all" do
+      stranger = insert_verified_user()
+      client = insert_oauth_client(redirect_uris: ["https://mine.test/c"])
+
+      assert {:error, :development_mode} =
+               OAuth.authorize(stranger.id, request(client.client_id, "https://mine.test/c"))
+    end
+
+    test "a loopback code is bound to the port that asked for it" do
+      client = insert_oauth_client(redirect_uris: ["http://localhost:5173/cb"])
+
+      assert {:ok, code} =
+               OAuth.authorize(
+                 client.user_id,
+                 request(client.client_id, "http://localhost:5200/cb")
+               )
+
+      assert {:ok, %{access_token: _}} =
+               OAuth.exchange(%{
+                 "code" => code,
+                 "code_verifier" => "verifier",
+                 "client_id" => client.client_id,
+                 "redirect_uri" => "http://localhost:5200/cb"
+               })
+    end
+
+    test "records the client row it authorized against" do
+      client = insert_oauth_client(redirect_uris: ["https://mine.test/c"])
+
+      {:ok, _} = OAuth.authorize(client.user_id, request(client.client_id, "https://mine.test/c"))
+
+      assert [event] =
+               client.user_id
+               |> Audit.list_recent_for_user(20)
+               |> Enum.filter(&(&1.action == "oauth.authorized"))
+
+      assert event.resource_id == client.id
+      assert event.metadata["client_id"] == client.client_id
     end
   end
 end

--- a/apps/fountain/test/fountain_web/controllers/oauth_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/oauth_test.exs
@@ -88,6 +88,122 @@ defmodule FountainWeb.OAuthControllerTest do
     end
   end
 
+  # #1125: a client an account registered for itself is in development mode,
+  # which is the boundary that lets its owner name any redirect URI at all.
+  describe "GET /oauth/authorize — a tenant-registered client" do
+    test "the owner sees a consent page badged as in development", %{conn: conn} do
+      client = insert_oauth_client(redirect_uris: ["https://mine.test/callback"])
+      owner = Accounts.get_user!(client.user_id)
+      {_v, c} = pkce()
+
+      html =
+        conn
+        |> login_user(owner)
+        |> get(
+          "/oauth/authorize?" <>
+            authorize_qs(c, %{
+              "client_id" => client.client_id,
+              "redirect_uri" => "https://mine.test/callback"
+            })
+        )
+        |> html_response(200)
+
+      assert html =~ "In development"
+      assert html =~ ~s(name="decision" value="allow")
+    end
+
+    test "anybody else is rendered an error, never redirected", %{conn: conn} do
+      client = insert_oauth_client(redirect_uris: ["https://mine.test/callback"])
+      stranger = insert_verified_user()
+      {_v, c} = pkce()
+
+      conn =
+        conn
+        |> login_user(stranger)
+        |> get(
+          "/oauth/authorize?" <>
+            authorize_qs(c, %{
+              "client_id" => client.client_id,
+              "redirect_uri" => "https://mine.test/callback"
+            })
+        )
+
+      assert html_response(conn, 400) =~ "in development"
+      assert get_resp_header(conn, "location") == []
+    end
+
+    test "a loopback client may be asked for on another port", %{conn: conn} do
+      client = insert_oauth_client(redirect_uris: ["http://localhost:5199/callback"])
+      owner = Accounts.get_user!(client.user_id)
+      {_v, c} = pkce()
+
+      html =
+        conn
+        |> login_user(owner)
+        |> get(
+          "/oauth/authorize?" <>
+            authorize_qs(c, %{
+              "client_id" => client.client_id,
+              "redirect_uri" => "http://localhost:5200/callback"
+            })
+        )
+        |> html_response(200)
+
+      assert html =~ "In development"
+    end
+
+    test "allow issues a code and lands on the owner's own redirect", %{conn: conn} do
+      client = insert_oauth_client(redirect_uris: ["https://mine.test/callback"])
+      owner = Accounts.get_user!(client.user_id)
+      {verifier, c} = pkce()
+
+      conn =
+        conn
+        |> login_user(owner)
+        |> post("/oauth/authorize", %{
+          "decision" => "allow",
+          "client_id" => client.client_id,
+          "redirect_uri" => "https://mine.test/callback",
+          "code_challenge" => c,
+          "code_challenge_method" => "S256",
+          "state" => "xyz"
+        })
+
+      location = redirected_to(conn)
+      assert location =~ "https://mine.test/callback?"
+      code = location |> URI.parse() |> Map.get(:query) |> URI.decode_query() |> Map.get("code")
+
+      assert {:ok, %{access_token: _}} =
+               OAuth.exchange(%{
+                 "code" => code,
+                 "code_verifier" => verifier,
+                 "client_id" => client.client_id,
+                 "redirect_uri" => "https://mine.test/callback"
+               })
+    end
+
+    test "a stranger cannot get a code by POSTing straight to the decision", %{conn: conn} do
+      client = insert_oauth_client(redirect_uris: ["https://mine.test/callback"])
+      stranger = insert_verified_user()
+      {_v, c} = pkce()
+
+      conn =
+        conn
+        |> login_user(stranger)
+        |> post("/oauth/authorize", %{
+          "decision" => "allow",
+          "client_id" => client.client_id,
+          "redirect_uri" => "https://mine.test/callback",
+          "code_challenge" => c,
+          "code_challenge_method" => "S256",
+          "state" => "xyz"
+        })
+
+      assert html_response(conn, 400) =~ "in development"
+      assert get_resp_header(conn, "location") == []
+    end
+  end
+
   describe "POST /oauth/authorize" do
     test "allow → redirect to the app with a code and the state; deny → access_denied", %{
       conn: conn


### PR DESCRIPTION
Part 3 of 9 for #1125 (re-cut of #1489). Based on #1877.

The authorization flow reads both registries now, and the second one is safe because of this rule rather than because of its redirect allowlist.

**The wrong answer, on the record.** Wildcard the sandbox domain in the redirect allowlist so an app built inside a sprite can point at a production Fountain. That is a phishing kit: anyone with any sandbox could start a flow with their own PKCE challenge and their own box as `redirect_uri`, and a consenting user's full-scope key would land there. PKCE does not help when the attacker initiates the flow.

**What is built instead.** An unpublished client authorizes only its owner. Every other account is rendered an error page, never redirected, and the identity check runs *before* the redirect check so a stranger's error page discloses no registration. Because the only account such a client can capture belongs to the person who registered it, its owner may name any HTTPS redirect or an HTTP loopback one. Config wins on an id collision, so a row cannot shadow a first-party client.

A loopback redirect matches on any port for an unpublished client (RFC 8252 §7.3) and not at all for a published one, because the port a local dev server lands on is not a fact anybody registered. `authorize/3` hands the library the validated requested URI so its own exact match reaches the same conclusion.

`oauth.authorized` now carries the client's row id when there is one.

Left to the next two PRs: CORS still reads only `API_CORS_ORIGINS`, and the consent page's `form-action` header still names every configured client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9jevFQT5MkF3rJUieeiHW


Part of #1125
