### PR TITLE
fix(oauth): the consent page's form-action names one origin, this request's (#1125)

### DIFF
--- a/apps/fountain/lib/fountain/oauth.ex
+++ b/apps/fountain/lib/fountain/oauth.ex
@@ -202,6 +202,22 @@ defmodule Fountain.OAuth do
   end
 
   @doc """
+  The one redirect origin the consent response's `form-action` may name.
+
+  Derived from the request's validated `redirect_uri` rather than from the
+  registration, because a loopback client's port varies legally (RFC 8252):
+  a header naming the registered port would have Chrome block a redirect the
+  server had already approved.
+  """
+  @spec form_action_origins(String.t()) :: [String.t()]
+  def form_action_origins(redirect_uri) do
+    case Client.origin_of(redirect_uri) do
+      nil -> []
+      origin -> [origin]
+    end
+  end
+
+  @doc """
   Revoke the token (an API key) presented by an app that is signing out.
 
   Fountain's own, not the library's: the library never learns what a token

--- a/apps/fountain/lib/fountain_web/controllers/oauth_authorize_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/oauth_authorize_controller.ex
@@ -17,13 +17,14 @@ defmodule FountainWeb.OAuthAuthorizeController do
   alias FountainWeb.ReturnTo
 
   plug :put_layout, false
-  plug :allow_redirect_form_action
   plug :require_user
 
   def show(conn, params) do
     case OAuth.validate_request(params, conn.assigns.current_user.id) do
       {:ok, client} ->
-        render(conn, :consent, client: client, params: request_params(params), error: nil)
+        conn
+        |> allow_redirect_form_action(params["redirect_uri"])
+        |> render(:consent, client: client, params: request_params(params), error: nil)
 
       {:error, reason} ->
         conn |> put_status(:bad_request) |> render(:invalid, reason: reason)
@@ -35,9 +36,14 @@ defmodule FountainWeb.OAuthAuthorizeController do
 
     case OAuth.validate_request(params, user.id) do
       {:ok, _client} when decision == "allow" ->
+        # Widened on the branch that redirects, not before the mint: a
+        # :server_error renders an error page, and that page has no business
+        # naming an origin in its form-action.
         case OAuth.authorize(user.id, params, FountainWeb.Audited.attribution(conn)) do
           {:ok, code} ->
-            redirect(conn,
+            conn
+            |> allow_redirect_form_action(params["redirect_uri"])
+            |> redirect(
               external:
                 with_query(params["redirect_uri"], %{"code" => code, "state" => params["state"]})
             )
@@ -47,7 +53,9 @@ defmodule FountainWeb.OAuthAuthorizeController do
         end
 
       {:ok, _client} ->
-        redirect(conn,
+        conn
+        |> allow_redirect_form_action(params["redirect_uri"])
+        |> redirect(
           external:
             with_query(params["redirect_uri"], %{
               "error" => "access_denied",
@@ -81,10 +89,12 @@ defmodule FountainWeb.OAuthAuthorizeController do
 
   # The base browser CSP is `form-action 'self'`; a successful consent POST
   # redirects the browser to the app's own origin, which Chrome enforces
-  # form-action against on the redirect. Widen it — only here — to the
-  # registered clients' redirect origins (#818).
-  defp allow_redirect_form_action(conn, _opts) do
-    origins = Enum.join(["'self'" | OAuth.redirect_origins()], " ")
+  # form-action against on the redirect. Widen it — only here, and only to
+  # this request's already-validated redirect origin (#818, narrowed in
+  # #1125). The requested URI is the source, not the registration: an RFC
+  # 8252 loopback redirect's port varies legally.
+  defp allow_redirect_form_action(conn, redirect_uri) do
+    origins = Enum.join(["'self'" | OAuth.form_action_origins(redirect_uri)], " ")
 
     update_resp_header(conn, "content-security-policy", "", fn csp ->
       if String.contains?(csp, "form-action"),

--- a/apps/fountain/test/fountain/oauth_clients_test.exs
+++ b/apps/fountain/test/fountain/oauth_clients_test.exs
@@ -495,4 +495,28 @@ defmodule Fountain.OAuthClientsTest do
       refute OAuth.registered_origin?(nil)
     end
   end
+
+  describe "form_action_origins/1" do
+    test "is the origin of the redirect the browser will actually be sent to" do
+      assert OAuth.form_action_origins("https://mine.test/callback") == ["https://mine.test"]
+      assert OAuth.form_action_origins("https://mine.test:8443/cb") == ["https://mine.test:8443"]
+    end
+
+    # The registered URI is the wrong source: a loopback client registered
+    # against :5199 and legally asked for :5200 would get a header naming
+    # :5199, and Chrome would block a redirect the server had approved.
+    test "follows the requested port, not the registered one" do
+      assert OAuth.form_action_origins("http://localhost:5200/callback") ==
+               ["http://localhost:5200"]
+    end
+
+    test "keeps IPv6 loopback bracketed for the CSP" do
+      assert OAuth.form_action_origins("http://[::1]:5200/callback") ==
+               ["http://[::1]:5200"]
+    end
+
+    test "is empty for something with no origin" do
+      assert OAuth.form_action_origins("/callback") == []
+    end
+  end
 end

--- a/apps/fountain/test/fountain_web/controllers/oauth_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/oauth_test.exs
@@ -66,6 +66,77 @@ defmodule FountainWeb.OAuthControllerTest do
       assert csp =~ "form-action 'self' https://app.test"
     end
 
+    # The header used to name every registered client's origin. With
+    # tenant-registered apps that would hand the whole registry to any
+    # visitor, and grow without bound.
+    test "the form-action CSP names this request's origin and no other", %{conn: conn} do
+      insert_oauth_client(redirect_uris: ["https://someone-else.test/callback"])
+      client = insert_oauth_client(redirect_uris: ["https://mine.test/callback"])
+      owner = Accounts.get_user!(client.user_id)
+      {_v, c} = pkce()
+
+      conn =
+        conn
+        |> login_user(owner)
+        |> get(
+          "/oauth/authorize?" <>
+            authorize_qs(c, %{
+              "client_id" => client.client_id,
+              "redirect_uri" => "https://mine.test/callback"
+            })
+        )
+
+      [csp] = get_resp_header(conn, "content-security-policy")
+      assert csp =~ "form-action 'self' https://mine.test"
+      refute csp =~ "someone-else.test"
+      refute csp =~ "https://app.test"
+    end
+
+    # Found by driving Chrome, not by an HTTP assertion: a loopback client
+    # registered against :5199 and legally asked for :5200 got a header naming
+    # :5199, so Chrome blocked a redirect the server had approved. The header
+    # follows the request, not the registration.
+    test "the form-action CSP follows a loopback request to another port", %{conn: conn} do
+      client = insert_oauth_client(redirect_uris: ["http://localhost:5199/callback"])
+      owner = Accounts.get_user!(client.user_id)
+      {_v, c} = pkce()
+
+      conn =
+        conn
+        |> login_user(owner)
+        |> get(
+          "/oauth/authorize?" <>
+            authorize_qs(c, %{
+              "client_id" => client.client_id,
+              "redirect_uri" => "http://localhost:5200/callback"
+            })
+        )
+
+      assert html_response(conn, 200) =~ "In development"
+      [csp] = get_resp_header(conn, "content-security-policy")
+      assert csp =~ "form-action 'self' http://localhost:5200"
+      refute csp =~ "5199"
+    end
+
+    # A rejected request never reaches a redirect, so the header must stay at
+    # the base policy rather than naming an origin nobody validated.
+    test "an invalid request widens nothing", %{conn: conn} do
+      user = insert_verified_user()
+      {_v, c} = pkce()
+
+      conn =
+        conn
+        |> login_user(user)
+        |> get(
+          "/oauth/authorize?" <>
+            authorize_qs(c, %{"client_id" => "nope", "redirect_uri" => "https://evil.test/cb"})
+        )
+
+      assert html_response(conn, 400)
+      [csp] = get_resp_header(conn, "content-security-policy")
+      refute csp =~ "evil.test"
+    end
+
     test "an unregistered client or redirect renders, never redirects", %{conn: conn} do
       user = insert_verified_user()
       {_v, c} = pkce()


### PR DESCRIPTION
Part 5 of 9 for #1125 (re-cut of #1489). Based on #1879. **Its own PR because it is a security boundary.**

The base browser CSP is `form-action 'self'`, and a successful consent POST redirects to the app's own origin, which Chrome enforces form-action against on the redirect. #818 widened the header to *every* registered client's redirect origin. That was fine while the registry held two clients and both were ours.

It is not fine now. With tenant-registered apps the header would grow with the table and hand every visitor the whole registry — every origin anybody ever registered, disclosed on an unrelated account's consent page. So it names exactly one origin: the `redirect_uri` this request asked for, after `validate_request/2` has already accepted it.

Three things to look at:

- **The source is the requested URI, not the registration.** A loopback client registered against `:5199` may legally be asked for `:5200` (RFC 8252), and a header naming `:5199` has Chrome block a redirect the server has approved. That failure is invisible to an HTTP assertion — it was found by driving a browser — so the port is asserted in both directions.
- **The widening moved from a `plug` to the three response paths**, because a plug runs before there is a validated request to derive the origin from. A rejected request now widens nothing at all, and there is a test for it.
- **Nothing else widens.** The `refute` assertions check that neither another tenant's origin nor the configured `https://app.test` appears on a consent page for a different client.

`OAuth.redirect_origins/0` (the library's) is no longer called from here. It stays on the instance for anything else that wants the config registry's origins.

Left to the next PR: the API surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9jevFQT5MkF3rJUieeiHW


Part of #1125
