### PR TITLE
fix(docs): remove a stray conflict marker from the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,6 @@ upgrade, is in
   `AgentUpdate["model"]` are `string | null` and optional. A client that
   assumed a string needs a null check. Nothing else on the wire changed
   shape.
->>>>>>> theirs
 
 - Environment `setup_timeout_seconds` (1–900, default 120) lets cold repository
   toolchain setup run within an explicit bound. It persists through API/spec


### PR DESCRIPTION
`CHANGELOG.md` line 67 on `main` contains a leftover `>>>>>>> theirs` conflict marker from a botched resolution.

This is not just repo furniture. `Fountain.Docs` declares the repo-root changelog on its `extra_resources:` line (`apps/fountain/lib/fountain/docs.ex:48`) and `docs/changelog.md` pulls it in as a snippet, with `Changelog: changelog.md` in `docs/nav.yml`. So the marker is embedded at compile time and served to readers at `/docs/changelog`.

The paragraph above it (the `Agent.model` client note) is intact and the bullet below it is the next entry, so the marker is vestigial — the line just goes. No other markers in the file.

Found while rebasing the #1635 stack; unrelated to it, so it lands on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9jevFQT5MkF3rJUieeiHW