### PR TITLE
feat(api): register and manage OAuth clients over /api (#1125)

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/oauth_client_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/oauth_client_controller.ex
@@ -1,0 +1,150 @@
+defmodule FountainWeb.OAuthClientController do
+  @moduledoc """
+  The OAuth clients an account registered for itself (#1125).
+
+      GET    /api/oauth/clients      — the account's clients
+      POST   /api/oauth/clients      — register one
+      GET    /api/oauth/clients/:id  — one of them
+      PATCH  /api/oauth/clients/:id  — rename it, or change its redirect URIs
+      DELETE /api/oauth/clients/:id  — unregister it
+
+  Full scope, for the reason API key management is full scope: a client is a
+  standing way to obtain a full-scope key with one consent, so a sandbox's
+  per-conversation token must not be able to leave one behind (see
+  `Fountain.Accounts.ApiKey`).
+
+  Registering here is enough to *use* the client: it can sign in its owner at
+  `/oauth/authorize`, and its redirect origins are admitted by CORS, so no
+  operator has to touch `OAUTH_CLIENTS` or `API_CORS_ORIGINS`.
+  """
+
+  use FountainWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Fountain.OAuth
+  alias FountainWeb.Audited
+  alias FountainWeb.Schemas
+
+  action_fallback FountainWeb.FallbackController
+
+  tags(["OAuth clients"])
+
+  operation(:index,
+    summary: "List OAuth clients",
+    description:
+      "The OAuth clients this account registered. Each one is in development " <>
+        "mode until an operator publishes it, which means it signs in its " <>
+        "owner and refuses every other account.",
+    responses: [
+      ok: {"Clients", "application/json", Schemas.OAuthClientListResponse},
+      unauthorized: {"Missing or invalid key", "application/json", Schemas.Error},
+      forbidden: {"Insufficient scope", "application/json", Schemas.Error}
+    ]
+  )
+
+  def index(conn, _params) do
+    user = conn.assigns.current_user
+    render(conn, :index, clients: OAuth.list_clients(user.id))
+  end
+
+  operation(:create,
+    summary: "Register an OAuth client",
+    description:
+      "Register an app that can offer \"Sign in with Fountain\". The response " <>
+        "carries the generated `client_id` to put in the app. Redirect URIs " <>
+        "match exactly, must be https unless they are loopback, and a loopback " <>
+        "URI matches on any port. The client starts in development mode, so it " <>
+        "signs in nobody but you. A sandbox's public HTTPS URL is valid.",
+    request_body: {"Client", "application/json", Schemas.OAuthClientRequest, required: true},
+    responses: [
+      created: {"Client", "application/json", Schemas.OAuthClient},
+      unprocessable_entity: {"Validation error", "application/json", Schemas.Error},
+      unauthorized: {"Missing or invalid key", "application/json", Schemas.Error},
+      forbidden: {"Insufficient scope", "application/json", Schemas.Error}
+    ]
+  )
+
+  def create(conn, params) do
+    user = conn.assigns.current_user
+
+    with {:ok, client} <-
+           OAuth.create_client(user.id, client_attrs(params), Audited.attribution(conn)) do
+      conn |> put_status(:created) |> render(:show, client: client)
+    end
+  end
+
+  operation(:show,
+    summary: "Get an OAuth client",
+    parameters: [id: [in: :path, type: :string, description: "Client record id"]],
+    responses: [
+      ok: {"Client", "application/json", Schemas.OAuthClient},
+      not_found: {"No such client", "application/json", Schemas.Error},
+      unauthorized: {"Missing or invalid key", "application/json", Schemas.Error},
+      forbidden: {"Insufficient scope", "application/json", Schemas.Error}
+    ]
+  )
+
+  def show(conn, %{"id" => id}) do
+    user = conn.assigns.current_user
+
+    with %{} = client <- OAuth.get_client_record(id, user.id) || {:error, :not_found} do
+      render(conn, :show, client: client)
+    end
+  end
+
+  operation(:update,
+    summary: "Change an OAuth client",
+    description:
+      "Rename the client or replace its redirect URIs. `client_id` never " <>
+        "changes. Publishing is not a self-serve operation, and a published " <>
+        "client can only be changed by an operator.",
+    parameters: [id: [in: :path, type: :string, description: "Client record id"]],
+    request_body:
+      {"Client changes", "application/json", Schemas.OAuthClientUpdateRequest, required: true},
+    responses: [
+      ok: {"Client", "application/json", Schemas.OAuthClient},
+      unprocessable_entity: {"Validation error", "application/json", Schemas.Error},
+      not_found: {"No such client", "application/json", Schemas.Error},
+      unauthorized: {"Missing or invalid key", "application/json", Schemas.Error},
+      forbidden: {"Insufficient scope", "application/json", Schemas.Error}
+    ]
+  )
+
+  def update(conn, %{"id" => id} = params) do
+    user = conn.assigns.current_user
+
+    with %{} = client <- OAuth.get_client_record(id, user.id) || {:error, :not_found},
+         {:ok, client} <-
+           OAuth.update_client(client, client_attrs(params), Audited.attribution(conn)) do
+      render(conn, :show, client: client)
+    end
+  end
+
+  operation(:delete,
+    summary: "Unregister an OAuth client",
+    description:
+      "Deleting a client stops new sign-ins through it. Keys it already " <>
+        "issued are ordinary API keys and outlive it — revoke those under " <>
+        "the API keys endpoint. A published client can only be removed by " <>
+        "an operator, because every account signs in through it.",
+    parameters: [id: [in: :path, type: :string, description: "Client record id"]],
+    responses: [
+      no_content: "Deleted",
+      unprocessable_entity: {"Refused", "application/json", Schemas.Error},
+      not_found: {"No such client", "application/json", Schemas.Error},
+      unauthorized: {"Missing or invalid key", "application/json", Schemas.Error},
+      forbidden: {"Insufficient scope", "application/json", Schemas.Error}
+    ]
+  )
+
+  def delete(conn, %{"id" => id}) do
+    user = conn.assigns.current_user
+
+    with %{} = client <- OAuth.get_client_record(id, user.id) || {:error, :not_found},
+         {:ok, _} <- OAuth.delete_client(client, Audited.attribution(conn)) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+
+  defp client_attrs(params), do: Map.take(params, ~w(name redirect_uris))
+end

--- a/apps/fountain/lib/fountain_web/controllers/oauth_client_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/oauth_client_json.ex
@@ -1,0 +1,24 @@
+defmodule FountainWeb.OAuthClientJSON do
+  @moduledoc "JSON views for tenant-registered OAuth clients (#1125)."
+
+  alias Fountain.OAuth.Client
+
+  def index(%{clients: clients}), do: %{data: Enum.map(clients, &summary/1)}
+
+  def show(%{client: client}), do: summary(client)
+
+  # `origins` is derived rather than the stored lookup key, so a caller sees
+  # the origins it will actually be calling `/api` from.
+  defp summary(%Client{} = c) do
+    %{
+      id: c.id,
+      client_id: c.client_id,
+      name: c.name,
+      redirect_uris: c.redirect_uris,
+      origins: Client.origins_of(c.redirect_uris),
+      published: c.published,
+      created_at: c.inserted_at,
+      updated_at: c.updated_at
+    }
+  end
+end

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -332,6 +332,18 @@ defmodule FountainWeb.Router do
     post "/revoke", OAuthTokenController, :revoke
   end
 
+  # OAuth clients an account registers for itself (#1125). Full scope because
+  # a client is a standing path to a full-scope key after consent.
+  scope "/api/oauth", FountainWeb do
+    pipe_through [:accepts_json, :api, :require_full_scope]
+
+    get "/clients", OAuthClientController, :index
+    post "/clients", OAuthClientController, :create
+    get "/clients/:id", OAuthClientController, :show
+    patch "/clients/:id", OAuthClientController, :update
+    delete "/clients/:id", OAuthClientController, :delete
+  end
+
   # Key management is scope-gated: the per-conversation token a sprite holds
   # must not be able to mint a second key that survives conversation teardown.
   scope "/api/auth", FountainWeb do

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -3700,6 +3700,100 @@ defmodule FountainWeb.Schemas do
   # created; it only exists after that definition, hence the ordering.
   list_response(ApiKeyListResponse, of: ApiKey)
 
+  defmodule OAuthClient do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "OAuthClient",
+      description:
+        "A tenant-owned OAuth client. Unpublished clients are in development " <>
+          "mode and can sign in only their owner. Their redirect origins are " <>
+          "also admitted by CORS.",
+      type: :object,
+      properties: %{
+        id: %Schema{type: :string, format: :uuid},
+        client_id: %Schema{
+          type: :string,
+          description: "The client_id sent to /oauth/authorize."
+        },
+        name: %Schema{type: :string, description: "Shown on the consent page."},
+        redirect_uris: %Schema{
+          type: :array,
+          items: %Schema{type: :string},
+          description: "Exact match, except that an unpublished loopback URI matches on any port."
+        },
+        origins: %Schema{
+          type: :array,
+          items: %Schema{type: :string},
+          description:
+            "Origins derived from redirect_uris and admitted by CORS. A " <>
+              "loopback origin is admitted on any port, not only the port shown here."
+        },
+        published: %Schema{
+          type: :boolean,
+          description: "False means development mode with owner-only sign-in."
+        },
+        created_at: %Schema{type: :string, format: :"date-time"},
+        updated_at: %Schema{type: :string, format: :"date-time"}
+      },
+      required: [
+        :id,
+        :client_id,
+        :name,
+        :redirect_uris,
+        :origins,
+        :published,
+        :created_at,
+        :updated_at
+      ]
+    })
+  end
+
+  defmodule OAuthClientRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "OAuthClientRequest",
+      type: :object,
+      properties: %{
+        name: %Schema{type: :string, minLength: 1},
+        redirect_uris: %Schema{
+          type: :array,
+          items: %Schema{type: :string},
+          minItems: 1
+        }
+      },
+      required: [:name, :redirect_uris],
+      example: %{
+        name: "Notes",
+        redirect_uris: ["https://abc123.sprites.app/callback", "http://localhost:5173/callback"]
+      }
+    })
+  end
+
+  defmodule OAuthClientUpdateRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "OAuthClientUpdateRequest",
+      type: :object,
+      properties: %{
+        name: %Schema{type: :string, minLength: 1},
+        redirect_uris: %Schema{
+          type: :array,
+          items: %Schema{type: :string},
+          minItems: 1
+        }
+      },
+      example: %{name: "Notes for Fountain"}
+    })
+  end
+
+  list_response(OAuthClientListResponse, of: OAuthClient)
+
   defmodule Runner do
     @moduledoc false
     require OpenApiSpex

--- a/apps/fountain/test/fountain_web/controllers/oauth_client_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/oauth_client_controller_test.exs
@@ -1,0 +1,180 @@
+defmodule FountainWeb.OAuthClientControllerTest do
+  @moduledoc "The OAuth clients an account registers for itself over /api (#1125)."
+  use FountainWeb.ConnCase, async: true
+
+  alias Fountain.OAuth
+
+  setup %{conn: conn} do
+    user = insert_verified_user()
+    {:ok, {_key, raw}} = Fountain.Accounts.create_api_key(user.id, "t")
+
+    conn =
+      conn
+      |> put_req_header("authorization", "Bearer #{raw}")
+      |> put_req_header("accept", "application/json")
+
+    {:ok, conn: conn, user: user}
+  end
+
+  describe "POST /api/oauth/clients" do
+    test "registers a client and hands back the generated client_id", %{conn: conn} do
+      body =
+        conn
+        |> post("/api/oauth/clients", %{
+          "name" => "Notes",
+          "redirect_uris" => ["https://abc123.sprites.app/callback"]
+        })
+        |> json_response(201)
+
+      assert body["name"] == "Notes"
+      assert String.starts_with?(body["client_id"], "app_")
+      assert body["published"] == false
+      assert body["origins"] == ["https://abc123.sprites.app"]
+    end
+
+    test "422s a redirect URI that cannot work", %{conn: conn} do
+      body =
+        conn
+        |> post("/api/oauth/clients", %{"name" => "Notes", "redirect_uris" => []})
+        |> json_response(422)
+
+      assert body["errors"]["redirect_uris"] == ["add at least one redirect URI"]
+    end
+
+    test "the registration is enough for CORS from that origin", %{conn: conn} do
+      conn
+      |> post("/api/oauth/clients", %{
+        "name" => "Notes",
+        "redirect_uris" => ["https://abc123.sprites.app/callback"]
+      })
+      |> json_response(201)
+
+      assert OAuth.registered_origin?("https://abc123.sprites.app")
+    end
+  end
+
+  describe "GET /api/oauth/clients" do
+    test "lists only the caller's", %{conn: conn, user: user} do
+      mine = insert_oauth_client(user_id: user.id)
+      insert_oauth_client()
+
+      body = conn |> get("/api/oauth/clients") |> json_response(200)
+
+      assert [%{"id" => id}] = body["data"]
+      assert id == mine.id
+    end
+  end
+
+  describe "GET/PATCH/DELETE /api/oauth/clients/:id" do
+    test "another account's client is 404, not 403", %{conn: conn} do
+      theirs = insert_oauth_client()
+
+      assert conn |> get("/api/oauth/clients/#{theirs.id}") |> json_response(404)
+
+      assert conn
+             |> patch("/api/oauth/clients/#{theirs.id}", %{"name" => "x"})
+             |> json_response(404)
+
+      assert conn |> delete("/api/oauth/clients/#{theirs.id}") |> json_response(404)
+    end
+
+    test "updates the name and the URIs, never the client_id", %{conn: conn, user: user} do
+      client = insert_oauth_client(user_id: user.id)
+
+      body =
+        conn
+        |> patch("/api/oauth/clients/#{client.id}", %{
+          "name" => "Renamed",
+          "redirect_uris" => ["https://new.test/callback"]
+        })
+        |> json_response(200)
+
+      assert body["name"] == "Renamed"
+      assert body["client_id"] == client.client_id
+      assert body["origins"] == ["https://new.test"]
+    end
+
+    # No field of OAuthClientUpdateRequest is required, so a PATCH that repeats
+    # what it read is a legal request. It succeeds and records nothing.
+    test "a PATCH that moves nothing is a 200, not a 422", %{conn: conn, user: user} do
+      client = insert_oauth_client(user_id: user.id)
+
+      body =
+        conn
+        |> patch("/api/oauth/clients/#{client.id}", %{"name" => client.name})
+        |> json_response(200)
+
+      assert body["name"] == client.name
+      assert body["client_id"] == client.client_id
+    end
+
+    test "cannot publish itself over the API", %{conn: conn, user: user} do
+      client = insert_oauth_client(user_id: user.id)
+
+      body =
+        conn
+        |> patch("/api/oauth/clients/#{client.id}", %{"published" => true, "name" => "x"})
+        |> json_response(200)
+
+      assert body["published"] == false
+    end
+
+    test "cannot alter an operator-published registration", %{conn: conn, user: user} do
+      client = insert_oauth_client(user_id: user.id, published: true)
+
+      body =
+        conn
+        |> patch("/api/oauth/clients/#{client.id}", %{"name" => "x"})
+        |> json_response(422)
+
+      assert body["errors"]["base"] == [
+               "published clients can only be changed by an operator"
+             ]
+    end
+
+    test "deletes", %{conn: conn, user: user} do
+      client = insert_oauth_client(user_id: user.id)
+
+      assert conn |> delete("/api/oauth/clients/#{client.id}") |> response(204)
+      assert OAuth.list_clients(user.id) == []
+    end
+
+    test "cannot remove an operator-published registration", %{conn: conn, user: user} do
+      client = insert_oauth_client(user_id: user.id, published: true)
+
+      body = conn |> delete("/api/oauth/clients/#{client.id}") |> json_response(422)
+
+      assert body["errors"]["base"] == [
+               "published clients can only be removed by an operator"
+             ]
+
+      assert OAuth.get_client(client.client_id)
+    end
+
+    test "an id that is not a UUID is 404, not a cast error", %{conn: conn} do
+      assert conn |> get("/api/oauth/clients/not-a-uuid") |> json_response(404)
+
+      assert conn
+             |> patch("/api/oauth/clients/not-a-uuid", %{"name" => "x"})
+             |> json_response(404)
+
+      assert conn |> delete("/api/oauth/clients/not-a-uuid") |> json_response(404)
+    end
+  end
+
+  # A client is a standing way to obtain a full-scope key with one consent, so
+  # the sandbox's per-conversation token must not be able to leave one behind
+  # — the same argument that keeps API key management off the sprite scope.
+  describe "scope" do
+    test "a sprite-scoped key is refused on every route", %{conn: conn, user: user} do
+      client = insert_oauth_client(user_id: user.id)
+      {:ok, {_key, raw}} = Fountain.Accounts.create_api_key(user.id, "sprite", scopes: ["sprite"])
+
+      conn = conn |> recycle() |> put_req_header("authorization", "Bearer #{raw}")
+
+      assert conn |> get("/api/oauth/clients") |> json_response(403)
+      assert conn |> post("/api/oauth/clients", %{"name" => "x"}) |> json_response(403)
+      assert conn |> delete("/api/oauth/clients/#{client.id}") |> json_response(403)
+    end
+  end
+end

--- a/sdk/contract/contract.json
+++ b/sdk/contract/contract.json
@@ -479,6 +479,45 @@
         }
       }
     },
+    "DELETE /api/oauth/clients/{id}": {
+      "operation_id": "FountainWeb.OAuthClientController.delete",
+      "path_params": [
+        "id"
+      ],
+      "responses": {
+        "204": {},
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "422": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
+          "application/json": {
+            "ref": "Error"
+          }
+        }
+      }
+    },
     "DELETE /api/runners/{id}": {
       "operation_id": "FountainWeb.RunnerController.delete",
       "path_params": [
@@ -2394,6 +2433,75 @@
         }
       }
     },
+    "GET /api/oauth/clients": {
+      "operation_id": "FountainWeb.OAuthClientController.index",
+      "path_params": [],
+      "responses": {
+        "200": {
+          "application/json": {
+            "ref": "OAuthClientListResponse"
+          }
+        },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
+          "application/json": {
+            "ref": "Error"
+          }
+        }
+      }
+    },
+    "GET /api/oauth/clients/{id}": {
+      "operation_id": "FountainWeb.OAuthClientController.show",
+      "path_params": [
+        "id"
+      ],
+      "responses": {
+        "200": {
+          "application/json": {
+            "ref": "OAuthClient"
+          }
+        },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "429": {
+          "application/json": {
+            "ref": "Error"
+          }
+        }
+      }
+    },
     "GET /api/runners": {
       "operation_id": "FountainWeb.RunnerController.index",
       "path_params": [],
@@ -4059,6 +4167,57 @@
         "422": {
           "application/json": {
             "ref": "ChangesetError"
+          }
+        },
+        "429": {
+          "application/json": {
+            "ref": "Error"
+          }
+        }
+      }
+    },
+    "PATCH /api/oauth/clients/{id}": {
+      "operation_id": "FountainWeb.OAuthClientController.update",
+      "path_params": [
+        "id"
+      ],
+      "request_body": {
+        "content": {
+          "application/json": {
+            "ref": "OAuthClientUpdateRequest"
+          }
+        },
+        "required": true
+      },
+      "responses": {
+        "200": {
+          "application/json": {
+            "ref": "OAuthClient"
+          }
+        },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "422": {
+          "application/json": {
+            "ref": "Error"
           }
         },
         "429": {
@@ -6181,6 +6340,50 @@
         "422": {
           "application/json": {
             "ref": "ChangesetError"
+          }
+        },
+        "429": {
+          "application/json": {
+            "ref": "Error"
+          }
+        }
+      }
+    },
+    "POST /api/oauth/clients": {
+      "operation_id": "FountainWeb.OAuthClientController.create",
+      "path_params": [],
+      "request_body": {
+        "content": {
+          "application/json": {
+            "ref": "OAuthClientRequest"
+          }
+        },
+        "required": true
+      },
+      "responses": {
+        "201": {
+          "application/json": {
+            "ref": "OAuthClient"
+          }
+        },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "422": {
+          "application/json": {
+            "ref": "Error"
           }
         },
         "429": {
@@ -11237,6 +11440,96 @@
           },
           "required": true,
           "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "OAuthClient": {
+      "properties": {
+        "client_id": {
+          "required": true,
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time",
+          "required": true,
+          "type": "string"
+        },
+        "id": {
+          "format": "uuid",
+          "required": true,
+          "type": "string"
+        },
+        "name": {
+          "required": true,
+          "type": "string"
+        },
+        "origins": {
+          "items": {
+            "type": "string"
+          },
+          "required": true,
+          "type": "array"
+        },
+        "published": {
+          "required": true,
+          "type": "boolean"
+        },
+        "redirect_uris": {
+          "items": {
+            "type": "string"
+          },
+          "required": true,
+          "type": "array"
+        },
+        "updated_at": {
+          "format": "date-time",
+          "required": true,
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "OAuthClientListResponse": {
+      "properties": {
+        "data": {
+          "items": {
+            "ref": "OAuthClient"
+          },
+          "required": true,
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "OAuthClientRequest": {
+      "properties": {
+        "name": {
+          "required": true,
+          "type": "string"
+        },
+        "redirect_uris": {
+          "items": {
+            "type": "string"
+          },
+          "required": true,
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "OAuthClientUpdateRequest": {
+      "properties": {
+        "name": {
+          "required": false,
+          "type": "string"
+        },
+        "redirect_uris": {
+          "items": {
+            "type": "string"
+          },
+          "required": false,
+          "type": "array"
         }
       },
       "type": "object"

--- a/sdk/contract/omissions.json
+++ b/sdk/contract/omissions.json
@@ -29,6 +29,10 @@
       "reason": "Claimable principals (ADR 0044). A trusted application opens and claims these with its own full-scope key; the credential that comes back is an ordinary API key, so an SDK's job starts after this point and every endpoint it already models is what the principal then uses. Paddock is the first caller and reaches these four over plain HTTP."
     },
     {
+      "operations": ["* /api/oauth/clients*"],
+      "reason": "Self-service OAuth client registration (#1125, ADR 0021). A person registers an app once, in the console or with `fountain oauth-client`, and then puts the returned client_id in the app. An SDK caller's work starts after that point, with the API key the flow mints, and every endpoint a client then calls is already modelled."
+    },
+    {
       "operations": ["POST /api/oauth/token", "POST /api/oauth/revoke"],
       "reason": "Sign in with Fountain. The browser apps run the code+PKCE dance themselves against these two, and the token they get IS an API key, so the SDK starts after this point."
     },

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -1539,6 +1539,55 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/oauth/clients": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List OAuth clients
+         * @description The OAuth clients this account registered. Each one is in development mode until an operator publishes it, which means it signs in its owner and refuses every other account.
+         */
+        get: operations["FountainWeb.OAuthClientController.index"];
+        put?: never;
+        /**
+         * Register an OAuth client
+         * @description Register an app that can offer "Sign in with Fountain". The response carries the generated `client_id` to put in the app. Redirect URIs match exactly, must be https unless they are loopback, and a loopback URI matches on any port. The client starts in development mode, so it signs in nobody but you. A sandbox's public HTTPS URL is valid.
+         */
+        post: operations["FountainWeb.OAuthClientController.create"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/oauth/clients/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get an OAuth client */
+        get: operations["FountainWeb.OAuthClientController.show"];
+        put?: never;
+        post?: never;
+        /**
+         * Unregister an OAuth client
+         * @description Deleting a client stops new sign-ins through it. Keys it already issued are ordinary API keys and outlive it — revoke those under the API keys endpoint. A published client can only be removed by an operator, because every account signs in through it.
+         */
+        delete: operations["FountainWeb.OAuthClientController.delete"];
+        options?: never;
+        head?: never;
+        /**
+         * Change an OAuth client
+         * @description Rename the client or replace its redirect URIs. `client_id` never changes. Publishing is not a self-serve operation, and a published client can only be changed by an operator.
+         */
+        patch: operations["FountainWeb.OAuthClientController.update"];
+        trace?: never;
+    };
     "/api/oauth/revoke": {
         parameters: {
             query?: never;
@@ -4032,6 +4081,56 @@ export interface components {
             errors: {
                 detail: string;
             };
+        };
+        /**
+         * OAuthClient
+         * @description A tenant-owned OAuth client. Unpublished clients are in development mode and can sign in only their owner. Their redirect origins are also admitted by CORS.
+         */
+        OAuthClient: {
+            /** @description The client_id sent to /oauth/authorize. */
+            client_id: string;
+            /** Format: date-time */
+            created_at: string;
+            /** Format: uuid */
+            id: string;
+            /** @description Shown on the consent page. */
+            name: string;
+            /** @description Origins derived from redirect_uris and admitted by CORS. A loopback origin is admitted on any port, not only the port shown here. */
+            origins: string[];
+            /** @description False means development mode with owner-only sign-in. */
+            published: boolean;
+            /** @description Exact match, except that an unpublished loopback URI matches on any port. */
+            redirect_uris: string[];
+            /** Format: date-time */
+            updated_at: string;
+        };
+        /** OAuthClientListResponse */
+        OAuthClientListResponse: {
+            data: components["schemas"]["OAuthClient"][];
+        };
+        /**
+         * OAuthClientRequest
+         * @example {
+         *       "name": "Notes",
+         *       "redirect_uris": [
+         *         "https://abc123.sprites.app/callback",
+         *         "http://localhost:5173/callback"
+         *       ]
+         *     }
+         */
+        OAuthClientRequest: {
+            name: string;
+            redirect_uris: string[];
+        };
+        /**
+         * OAuthClientUpdateRequest
+         * @example {
+         *       "name": "Notes for Fountain"
+         *     }
+         */
+        OAuthClientUpdateRequest: {
+            name?: string;
+            redirect_uris?: string[];
         };
         /** OAuthTokenRequest */
         OAuthTokenRequest: {
@@ -12184,6 +12283,357 @@ export interface operations {
             };
             /** @description Forbidden */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    "FountainWeb.OAuthClientController.index": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Clients */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OAuthClientListResponse"];
+                };
+            };
+            /** @description Missing or invalid key */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Insufficient scope */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    "FountainWeb.OAuthClientController.create": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Client */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["OAuthClientRequest"];
+            };
+        };
+        responses: {
+            /** @description Client */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OAuthClient"];
+                };
+            };
+            /** @description Missing or invalid key */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Insufficient scope */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Validation error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    "FountainWeb.OAuthClientController.show": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Client record id */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Client */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OAuthClient"];
+                };
+            };
+            /** @description Missing or invalid key */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Insufficient scope */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No such client */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    "FountainWeb.OAuthClientController.delete": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Client record id */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Deleted */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Missing or invalid key */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Insufficient scope */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No such client */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Refused */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    "FountainWeb.OAuthClientController.update": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Client record id */
+                id: string;
+            };
+            cookie?: never;
+        };
+        /** @description Client changes */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["OAuthClientUpdateRequest"];
+            };
+        };
+        responses: {
+            /** @description Client */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OAuthClient"];
+                };
+            };
+            /** @description Missing or invalid key */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Insufficient scope */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No such client */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description Validation error */
+            422: {
                 headers: {
                     [name: string]: unknown;
                 };


### PR DESCRIPTION
Part 6 of 9 for #1125 (re-cut of #1489). Based on #1880.

`GET/POST /api/oauth/clients` and `GET/PATCH/DELETE /api/oauth/clients/:id`, with the OpenAPI operations, the three schemas and the regenerated wire contract.

**Full scope, not the sprite scope #1125 originally proposed.** A registered client is a standing way to obtain a full-scope thirty-day key with one consent, which is exactly the escalation the sprite scope exists to prevent: a sandbox's per-conversation token must not be able to leave one behind. Registering from the console, the CLI or the API with the owner's own key still removes the operator, which was the point.

Two details worth naming:

- Another account's client answers 404 rather than 403, like every other tenant-scoped resource, and **so does an id that is not a UUID** — casting a path segment to `:binary_id` raises, and phoenix_ecto turns that into a 400, so the documented 404 would never reach anybody who mistyped an id.
- `origins` is derived for the response rather than being the stored lookup key, so a caller sees the origins it will actually be calling `/api` from.

**Fixed against #1489:** the original declared these routes in neither `sdk/contract/manifests/*` nor `sdk/contract/omissions.json`, so `scripts/sdk-contract/build.sh --check` would have failed. They are recorded as an omission here: registering is a once-per-app setup step a person does in the console or with `fountain oauth-client`, and an SDK caller's work starts after it, with the key the flow mints.

`sdk-no-release`: `src/generated/openapi.ts` is regenerated here with no version bump. The bump is in #1885, the last PR of the stack.

**On size.** This is the largest PR in the stack at ~1,190 lines, and 747 of those are machine-written: `sdk/contract/contract.json` and `src/generated/openapi.ts` are regenerated by `scripts/sdk-contract/build.sh` and `npm run generate`, not edited. The hand-written half is ~440 lines across the controller, the view, the router and the schemas.

Left to the next PRs: the console page, the CLI, and the docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9jevFQT5MkF3rJUieeiHW



Part of #1125
