### PR TITLE
refactor(conversations): four function families move out of the server (#1565)

### DIFF
--- a/apps/fountain/lib/fountain/conversations/callback_key.ex
+++ b/apps/fountain/lib/fountain/conversations/callback_key.ex
@@ -156,4 +156,36 @@ defmodule Fountain.Conversations.CallbackKey do
         {:error, conv}
     end
   end
+
+  @doc """
+  Revoke the key a stopping server minted, if the row still names it.
+
+  A server that stops for any reason gives its sprite's callback key back.
+  The row check keeps a server that already handed the conversation on from
+  revoking its successor's key: reading the row's id at call time made a
+  dying duplicate (Horde's CRDT merge mass-terminates losers) revoke the
+  SURVIVING server's live credential, and its sprite then 401'd on every
+  callback and sub-agent spawn, surfaced nowhere. Best-effort: a key that is
+  already gone or inert is not an error.
+
+  If the BEAM dies hard (SIGKILL is untrappable) the `api_keys` row stays, but
+  it is not dangerous. `api_key_opts/0` sets an `expires_at`, so an unrevoked
+  key stops authenticating on its own and RetentionPruner deletes long-expired
+  rows. `SandboxReaper` is the sprite half, which does not self-heal.
+  """
+  def revoke(conversation_id, key_id) when is_binary(conversation_id) and is_binary(key_id) do
+    # ownership: the caller is the conversation's own server, which
+    # established ownership before it started. This read only confirms the row
+    # still names this key, and attributes the revocation to that owner.
+    case Conversations._unsafe_get_conversation(conversation_id) do
+      %Conversation{user_id: user_id, callback_api_key_id: ^key_id} when is_binary(user_id) ->
+        _ = Accounts.revoke_api_key(user_id, key_id, actor: "system:conversation_server")
+        :ok
+
+      _ ->
+        :ok
+    end
+  end
+
+  def revoke(_conversation_id, _key_id), do: :ok
 end

--- a/apps/fountain/lib/fountain/conversations/checkpoints.ex
+++ b/apps/fountain/lib/fountain/conversations/checkpoints.ex
@@ -1,0 +1,109 @@
+defmodule Fountain.Conversations.Checkpoints do
+  @moduledoc """
+  An environment's disk checkpoint: the warm start that restores one onto a
+  freshly created machine, and the best-effort snapshot taken after a machine
+  finishes provisioning (#1369).
+
+  `Fountain.Conversations.Provisioning` owns the two sandbox calls
+  (`restore_checkpoint/2` and `create_checkpoint/2`); what lives here is when
+  to make them, what a failed restore does to the stale id, and the flag that
+  keeps creation off.
+  """
+
+  require Logger
+
+  alias Fountain.Conversations.{Output, Provisioning}
+  alias Fountain.Environments.Environment
+
+  @doc """
+  Restore this environment's checkpoint onto a freshly created machine, or
+  `:cold` when there is nothing to restore (#1369).
+
+  A failed restore clears the stale `checkpoint_id` rather than retrying it on
+  every later conversation, and provisions cold.
+  """
+  @spec attempt_warm_start(Managoat.Sandbox.Handle.t(), map() | nil, String.t()) ::
+          :warm_started | :cold
+  def attempt_warm_start(_handle, nil, _conv_id), do: :cold
+  def attempt_warm_start(_handle, %{checkpoint_id: nil}, _conv_id), do: :cold
+  def attempt_warm_start(_handle, %{checkpoint_id: ""}, _conv_id), do: :cold
+
+  def attempt_warm_start(handle, %{checkpoint_id: id} = env, conv_id) do
+    Output.publish_stage(conv_id, "checkpoint_restore", "started", %{checkpoint_id: id})
+
+    # `restore_checkpoint/2` returns a bare `:ok` — `Fountain.Telemetry.span/3`
+    # unwraps the `{result, metadata}` pair it is given, so the `{:ok, _}` this
+    # used to match never occurred and a successful restore raised
+    # CaseClauseError. Latent only because #652 kept `checkpoint_id` nil, so
+    # this branch was unreachable.
+    case Provisioning.restore_checkpoint(handle, id) do
+      ok when ok == :ok or (is_tuple(ok) and elem(ok, 0) == :ok) ->
+        Output.publish_stage(conv_id, "checkpoint_restore", "done", %{checkpoint_id: id})
+        :warm_started
+
+      {:error, reason} ->
+        Logger.warning(
+          "checkpoint #{id} on env #{env.name} restore failed (#{inspect(reason)}); clearing + cold provisioning"
+        )
+
+        Output.publish_stage(conv_id, "checkpoint_restore", "failed", %{
+          checkpoint_id: id,
+          reason: inspect(reason)
+        })
+
+        # Clear the stale checkpoint so future runs don't keep retrying.
+        Fountain.Environments.update_environment(env, %{"checkpoint_id" => nil},
+          actor: "system:conversation_server"
+        )
+
+        :cold
+    end
+  end
+
+  @doc """
+  Snapshot a fully provisioned machine so later conversations on the same
+  environment can warm-start from it. Best-effort and off the caller's path,
+  so it cannot delay a first turn.
+
+  No catch-all clause: callers pass nil or an `%Environment{}`, both covered.
+  A new caller passing anything else should crash loudly here rather than
+  silently skip checkpointing.
+  """
+  def maybe_create_async(_handle, nil), do: :ok
+
+  def maybe_create_async(_handle, %{checkpoint_id: id})
+      when is_binary(id) and id != "",
+      do: :ok
+
+  def maybe_create_async(handle, %Environment{} = env) do
+    if checkpoint_creation_enabled?() do
+      Task.start(fn ->
+        try do
+          Provisioning.create_checkpoint(handle, env)
+        rescue
+          # Best-effort: if the env was deleted or the DB is gone (test
+          # teardown), don't crash the Task and pollute logs.
+          _ -> :ok
+        end
+      end)
+    end
+
+    :ok
+  end
+
+  # Off by default since #654: a checkpoint id is scoped to the sprite that
+  # created it, and an environment's checkpoint is only ever restored into a
+  # *different* sprite (sandboxes are per-conversation, with a fresh name each
+  # time). Measured against the API — a fresh sprite lists only `Current`, and
+  # restoring another sprite's `v1` answers `checkpoint not found: checkpoint
+  # with path checkpoints/v1 not found`. So the warm start this feature exists
+  # for cannot happen, and creating checkpoints only spends time and storage to
+  # record an id that every later conversation will fail to restore.
+  #
+  # Left as a flag rather than deleted: if the platform grows a fork-from-
+  # checkpoint or create-sprite-from-checkpoint call, this becomes a one-line
+  # re-enable plus a restore that can finally work.
+  defp checkpoint_creation_enabled? do
+    Application.get_env(:fountain, :checkpoint_creation_enabled, false)
+  end
+end

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -14,16 +14,16 @@ defmodule Fountain.Conversations.ConversationServer do
   require OpenTelemetry.Tracer
 
   alias Fountain.{
-    Accounts,
     Agents,
     Conversations,
     Environments,
     Vaults
   }
 
-  alias Fountain.Conversations.{CallbackKey, CodexChatGPT, Connection, Conversation, Egress}
+  alias Fountain.Conversations.{CallbackKey, Checkpoints, CodexChatGPT, Connection}
+  alias Fountain.Conversations.{Conversation, Egress}
   alias Fountain.Conversations.{Lifecycle, McpServers, Output, Pending, Provisioning}
-  alias Fountain.Conversations.{Reattachment, SpriteEnv, TurnMachine}
+  alias Fountain.Conversations.{Reattachment, Redaction, SpriteEnv, TurnMachine}
 
   # Absolute ceiling on provisioning (#329). Generous against the summed
   # default step timeouts (packages 300s + clone 600s + setup 120s). Setup
@@ -912,7 +912,7 @@ defmodule Fountain.Conversations.ConversationServer do
           # Best-effort: snapshot the fully-provisioned state so subsequent
           # conversations on this env can warm-start from it. Async so it
           # doesn't block the user's first turn.
-          maybe_create_checkpoint_async(handle, env)
+          Checkpoints.maybe_create_async(handle, env)
 
           state = TurnMachine.forget_runtime_session(state, conv)
 
@@ -970,7 +970,7 @@ defmodule Fountain.Conversations.ConversationServer do
   # unrestricted one, silently, and reported `provision/done`. It costs one
   # fast API call, so the warm start pays nothing for it.
   defp run_provisioning_pipeline(handle, env, sprite_env, secrets, conv_id, brokered?) do
-    case attempt_warm_start(handle, env, conv_id) do
+    case Checkpoints.attempt_warm_start(handle, env, conv_id) do
       :warm_started ->
         Egress.apply_policy(handle, env, conv_id, brokered?)
 
@@ -994,84 +994,6 @@ defmodule Fountain.Conversations.ConversationServer do
           Provisioning.run_setup_script(handle, env, sprite_env, conv_id)
         end
     end
-  end
-
-  defp attempt_warm_start(_handle, nil, _conv_id), do: :cold
-  defp attempt_warm_start(_handle, %{checkpoint_id: nil}, _conv_id), do: :cold
-  defp attempt_warm_start(_handle, %{checkpoint_id: ""}, _conv_id), do: :cold
-
-  defp attempt_warm_start(handle, %{checkpoint_id: id} = env, conv_id) do
-    Output.publish_stage(conv_id, "checkpoint_restore", "started", %{checkpoint_id: id})
-
-    # `restore_checkpoint/2` returns a bare `:ok` — `Fountain.Telemetry.span/3`
-    # unwraps the `{result, metadata}` pair it is given, so the `{:ok, _}` this
-    # used to match never occurred and a successful restore raised
-    # CaseClauseError. Latent only because #652 kept `checkpoint_id` nil, so
-    # this branch was unreachable.
-    case Fountain.Conversations.Provisioning.restore_checkpoint(handle, id) do
-      ok when ok == :ok or (is_tuple(ok) and elem(ok, 0) == :ok) ->
-        Output.publish_stage(conv_id, "checkpoint_restore", "done", %{checkpoint_id: id})
-        :warm_started
-
-      {:error, reason} ->
-        Logger.warning(
-          "checkpoint #{id} on env #{env.name} restore failed (#{inspect(reason)}); clearing + cold provisioning"
-        )
-
-        Output.publish_stage(conv_id, "checkpoint_restore", "failed", %{
-          checkpoint_id: id,
-          reason: inspect(reason)
-        })
-
-        # Clear the stale checkpoint so future runs don't keep retrying.
-        Fountain.Environments.update_environment(env, %{"checkpoint_id" => nil},
-          actor: "system:conversation_server"
-        )
-
-        :cold
-    end
-  end
-
-  defp maybe_create_checkpoint_async(_handle, nil), do: :ok
-
-  defp maybe_create_checkpoint_async(_handle, %{checkpoint_id: id})
-       when is_binary(id) and id != "",
-       do: :ok
-
-  defp maybe_create_checkpoint_async(handle, %Fountain.Environments.Environment{} = env) do
-    if checkpoint_creation_enabled?() do
-      Task.start(fn ->
-        try do
-          Fountain.Conversations.Provisioning.create_checkpoint(handle, env)
-        rescue
-          # Best-effort: if the env was deleted or the DB is gone (test
-          # teardown), don't crash the Task and pollute logs.
-          _ -> :ok
-        end
-      end)
-    end
-
-    :ok
-  end
-
-  # No catch-all clause: callers pass nil or an %Environment{}, both covered
-  # above. A new caller passing anything else should crash loudly here rather
-  # than silently skip checkpointing.
-
-  # Off by default since #654: a checkpoint id is scoped to the sprite that
-  # created it, and an environment's checkpoint is only ever restored into a
-  # *different* sprite (sandboxes are per-conversation, with a fresh name each
-  # time). Measured against the API — a fresh sprite lists only `Current`, and
-  # restoring another sprite's `v1` answers `checkpoint not found: checkpoint
-  # with path checkpoints/v1 not found`. So the warm start this feature exists
-  # for cannot happen, and creating checkpoints only spends time and storage to
-  # record an id that every later conversation will fail to restore.
-  #
-  # Left as a flag rather than deleted: if the platform grows a fork-from-
-  # checkpoint or create-sprite-from-checkpoint call, this becomes a one-line
-  # re-enable plus a restore that can finally work.
-  defp checkpoint_creation_enabled? do
-    Application.get_env(:fountain, :checkpoint_creation_enabled, false)
   end
 
   defp reattach(state, conv, sandbox, agent, env, secrets) do
@@ -1828,7 +1750,7 @@ defmodule Fountain.Conversations.ConversationServer do
     # with the outgoing env, not a replacement: the refused OAuth token is
     # still sitting in the sprite's `/home/sprite/.env` until a wake rewrites
     # it, so it stays worth scrubbing.
-    Fountain.Conversations.Redaction.put(
+    Redaction.put(
       state.conversation_id,
       state.sprite_env ++ fallback_env
     )
@@ -2150,91 +2072,22 @@ defmodule Fountain.Conversations.ConversationServer do
   # Best-effort revoke of the per-conversation API key when this server
   # exits — clean termination (`:terminate_conv`), crash paths that hit
   # `{:stop, :normal, state}`, and (because init/1 traps exits, #322)
-  # supervisor shutdown on deploys and Horde rebalances.
-  #
-  # Revokes only the key THIS server minted, and only while the
-  # conversation row still points at it. Reading the row's id at call time
-  # made a dying duplicate (Horde's CRDT merge mass-terminates losers)
-  # revoke the SURVIVING server's live credential — its sprite then 401'd
-  # on every callback and sub-agent spawn, surfaced nowhere. If the row has
-  # moved past our key, a successor owns the live credential and ours is
-  # already dead or inert.
-  #
-  # If the BEAM crashes hard (SIGKILL — untrappable) the row in `api_keys`
-  # is left behind, but it is not dangerous: `CallbackKey.api_key_opts/0`
-  # sets an `expires_at`, so an un-revoked key stops authenticating on its
-  # own, and RetentionPruner deletes long-expired rows. See SandboxReaper
-  # for the sprite half, which does not self-heal.
+  # supervisor shutdown on deploys and Horde rebalances. `CallbackKey.revoke/2`
+  # owns the rule about whose key it is safe to take back.
   @impl true
   def terminate(reason, state) do
-    Fountain.Conversations.Redaction.delete(state.conversation_id)
+    Redaction.delete(state.conversation_id)
+    _ = CallbackKey.revoke(state.conversation_id, state.callback_api_key_id)
 
-    if state.conversation_id && state.callback_api_key_id do
-      case Conversations._unsafe_get_conversation(state.conversation_id) do
-        %Conversation{user_id: user_id, callback_api_key_id: row_id}
-        when is_binary(user_id) and row_id == state.callback_api_key_id ->
-          _ =
-            Accounts.revoke_api_key(user_id, state.callback_api_key_id,
-              actor: "system:conversation_server"
-            )
-
-        _ ->
-          :ok
-      end
-    end
-
-    # A normal stop is not restarted, and its quiet timer dies with it. Leave
-    # supervisor shutdowns and crashes running for reattach. This stays last
-    # and best-effort so it cannot skip callback-key revocation.
-    if reason == :normal and state.current_turn do
-      try do
-        _ =
-          Conversations._unsafe_orphan_turn(state.current_turn, "server_terminated_normally")
-      rescue
-        error ->
-          Logger.error(
-            "terminate/2: orphaning turn for conv #{inspect(state.conversation_id)} raised: " <>
-              Exception.format(:error, error, __STACKTRACE__)
-          )
-      end
-    end
-
+    # Last and best-effort, so it cannot skip the revocation above.
+    _ = TurnMachine.orphan_on_normal_stop(reason, state.current_turn, state.conversation_id)
     :ok
   end
 
-  # Redacts secrets from crash reports and :sys.get_status output (#315). An
-  # unhandled raise in any callback logs `State:` via inspect — without this,
-  # that meant plaintext env secrets, the raw tenant DEK, decrypted BYO
-  # inference credentials, the callback API key, and the platform Sprites
-  # token (inside sprite.client) on stdout and, with SENTRY_DSN set, in a
-  # Sentry event body. Sentry's PlugContext scrubbing never sees process
-  # crash reports, so the redaction has to happen here.
-  #
-  # Key names are kept (values replaced) so crash reports stay debuggable.
+  # Keeps secrets out of crash reports and :sys.get_status output (#315). The
+  # redactor itself is `Redaction.server_state/1`.
   @impl true
-  def format_status(status) do
-    Map.new(status, fn
-      {:state, %{conversation_id: _} = state} -> {:state, redact_state(state)}
-      other -> other
-    end)
-  end
-
-  defp redact_state(state) do
-    %{
-      state
-      | handle: state.handle && %{state.handle | private: nil},
-        sprite_env: Enum.map(state.sprite_env, fn {k, _v} -> {k, "[REDACTED]"} end),
-        tenant_key: redact(state.tenant_key),
-        inference_credentials: redact_map(state.inference_credentials),
-        callback_token: redact(state.callback_token)
-    }
-  end
-
-  defp redact_map(%{} = map), do: Map.new(map, fn {k, _v} -> {k, "[REDACTED]"} end)
-  defp redact_map(other), do: redact(other)
-
-  defp redact(nil), do: nil
-  defp redact(_present), do: "[REDACTED]"
+  def format_status(status), do: Redaction.server_status(status)
 
   # ── turns ─────────────────────────────────────────────────────────────────
 

--- a/apps/fountain/lib/fountain/conversations/redaction.ex
+++ b/apps/fountain/lib/fountain/conversations/redaction.ex
@@ -136,4 +136,45 @@ defmodule Fountain.Conversations.Redaction do
   catch
     :error, :badarg -> :ok
   end
+
+  @doc """
+  A `ConversationServer` state with every secret in it replaced, for
+  `format_status/1` (#315).
+
+  An unhandled raise in any callback logs `State:` through `inspect`. Without
+  this that meant plaintext env secrets, the raw tenant DEK, decrypted BYO
+  inference credentials, the callback API key and the platform Sprites token
+  (inside `sprite.client`) on stdout and, with `SENTRY_DSN` set, in a Sentry
+  event body. Sentry's PlugContext scrubbing never sees process crash reports,
+  so the redaction has to happen at the server.
+
+  Key names are kept and only values are replaced, so crash reports stay
+  debuggable.
+  """
+  def server_state(state) do
+    %{
+      state
+      | handle: state.handle && %{state.handle | private: nil},
+        sprite_env: Enum.map(state.sprite_env, fn {k, _v} -> {k, "[REDACTED]"} end),
+        tenant_key: secret(state.tenant_key),
+        inference_credentials: secrets(state.inference_credentials),
+        callback_token: secret(state.callback_token)
+    }
+  end
+
+  @doc """
+  `server_state/1` applied to the `:state` entry of a `format_status/1` map.
+  """
+  def server_status(status) do
+    Map.new(status, fn
+      {:state, %{conversation_id: _} = state} -> {:state, server_state(state)}
+      other -> other
+    end)
+  end
+
+  defp secrets(%{} = map), do: Map.new(map, fn {k, _v} -> {k, "[REDACTED]"} end)
+  defp secrets(other), do: secret(other)
+
+  defp secret(nil), do: nil
+  defp secret(_present), do: "[REDACTED]"
 end

--- a/apps/fountain/lib/fountain/conversations/turn_machine.ex
+++ b/apps/fountain/lib/fountain/conversations/turn_machine.ex
@@ -1426,4 +1426,30 @@ defmodule Fountain.Conversations.TurnMachine do
   end
 
   defp now, do: DateTime.utc_now() |> DateTime.truncate(:second)
+
+  @doc """
+  Close a turn that a normally-stopping server leaves behind.
+
+  A normal stop is not restarted and its quiet timer dies with it, so a turn
+  still marked `running` would never be closed by anything else. Supervisor
+  shutdowns and crashes are left alone, because those servers come back and
+  reattach. Best-effort by design: the caller runs this on the way out of
+  `terminate/2`, and a raise here must not take the rest of that callback
+  with it.
+  """
+  @spec orphan_on_normal_stop(term(), Conversations.Turn.t() | nil, String.t() | nil) :: :ok
+  def orphan_on_normal_stop(:normal, turn, conversation_id) when not is_nil(turn) do
+    _ = Conversations._unsafe_orphan_turn(turn, "server_terminated_normally")
+    :ok
+  rescue
+    error ->
+      Logger.error(
+        "terminate/2: orphaning turn for conv #{inspect(conversation_id)} raised: " <>
+          Exception.format(:error, error, __STACKTRACE__)
+      )
+
+      :ok
+  end
+
+  def orphan_on_normal_stop(_reason, _turn, _conversation_id), do: :ok
 end

--- a/apps/fountain/test/fountain/webhooks/events_test.exs
+++ b/apps/fountain/test/fountain/webhooks/events_test.exs
@@ -22,6 +22,7 @@ defmodule Fountain.Webhooks.EventsTest do
   @sources [
     "lib/fountain/conversations.ex",
     "lib/fountain/conversations/conversation_server.ex",
+    "lib/fountain/conversations/checkpoints.ex",
     "lib/fountain/conversations/reattachment.ex",
     "lib/fountain/conversations/provisioning.ex",
     "lib/fountain/conversations/egress.ex",


### PR DESCRIPTION
Re-cut of #1569 as a stack of eight on `main`, under the no-big-PRs rule. #1569 was 2,351 lines across 56 files and 161 commits behind; this stack is re-derived against today's code rather than rebased.

This is the room-making half. Four function families leave `ConversationServer` for the modules that already own their subject, with no behaviour change:

- the callback-key revocation in `terminate/2` becomes `CallbackKey.revoke/2`;
- the orphaning of a turn a normally-stopping server leaves behind becomes `TurnMachine.orphan_on_normal_stop/3`;
- the `format_status/1` redactor becomes `Redaction.server_state/1` and `Redaction.server_status/1`;
- the checkpoint pair becomes `Fountain.Conversations.Checkpoints`, a module of its own beside the `Provisioning.restore_checkpoint/2` and `create_checkpoint/2` it calls.

That last one is a module of its own rather than more of `Provisioning` for a reason worth knowing: those two calls are what the server tests stub, and **Mimic cannot intercept a call a module makes to itself**. Folding the family into `Provisioning` compiled, passed every targeted test, and silently took two warm-start tests off the stub and onto the real Sprites client. The full suite caught it.

2,774 lines to 2,627.

**Why the size pin does not move here.** Later links of this stack add to the server, so lowering it now would mean raising it two PRs later, and the pin only ever goes down. ~~#1891 lowers it once, to 2,716, which is what the file is with everything this stack adds.~~

**Corrected 2026-09-11.** #1891 did lower it to 2,716, which left zero headroom, and two rounds of review fixes below it took the file to 2,739 — turning #1891, #1892 and #1893 red on the pin they had set themselves. The pin now stays at main's 2,774 for the whole stack, which still passes at every link because the stack is a net reduction (2,774 to 2,739). Lowering it is a follow-up once the shrink is on `main` and the number has stopped moving; #1891 carries that rule in the size test's moduledoc.

`events_test.exs` gets `checkpoints.ex` on its source list. The webhook catalogue guard reads `publish_stage` call sites out of a named set of files, and the `checkpoint_restore` stage moved with the code; without the line the guard reports three catalogue entries as stale. The same class of thing as the Mimic seam above, and also caught by the full suite rather than by a targeted one.

`checkpoint_test.exs`, `home_checkpoint_test.exs`, `conversation_server_redaction_test.exs` and `conversation_server_shutdown_revoke_test.exs` are the existing proof and all pass unchanged.

## The stack

| | PR | What |
|---|---|---|
| 1 | this | server subtraction, no behaviour change |
| 2 | #1887 | the revision, fingerprint and applied-skills columns |
| 3 | #1888 | what can be reconfigured in place, and what cannot |
| 4 | #1889 | `Conversations.reapply_conversation/3` |
| 5 | #1890 | the revision at turn admission, and the live server refresh |
| 6 | #1891 | skills reconciliation |
| 7 | #1892 | `POST /api/conversations/:id/reapply` |
| 8 | #1893 | the manual, three SDKs and the version bump |

Part 1 of 8 for #1565.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9jevFQT5MkF3rJUieeiHW


---

### The stack (#1565, re-cut from #1569)

| | PR | What it covers |
|---|---|---|
| 1 | #1886 | server subtraction, no behaviour change, room for the rest |
| 2 | #1887 | the revision, build-fingerprint and applied-skills columns |
| 3 | #1888 | `Reapply.check/2`: what can be reconfigured in place, and what cannot |
| 4 | #1889 | `Conversations.reapply_conversation/3`, audited, under the sandbox lock |
| 5 | #1890 | the revision at turn admission, and the live server refresh |
| 6 | #1891 | skills reconciliation, on a live reapply and on every wake |
| 7 | #1892 | `POST /api/conversations/:id/reapply` and its status-code contract |
| 8 | #1893 | the manual, Python, Elixir, Swift, and the version bump |

Merge top down. Do not `--delete-branch` while a child still points at a branch.



