### PR TITLE
feat(conversations): what can be reconfigured in place, and what cannot (#1565)

### DIFF
--- a/apps/fountain/lib/fountain/conversations/reapply.ex
+++ b/apps/fountain/lib/fountain/conversations/reapply.ex
@@ -37,11 +37,41 @@ defmodule Fountain.Conversations.Reapply do
   is refused. Relaxing that is a one-line change to `fingerprint/1`, once
   somebody has shown the re-application is safe.
 
-  This module is built across the #1565 stack. This first part is the digest
-  alone: the rule that reads it lands next.
+  One gap is worth naming. A skill whose source is a GitHub repository is a
+  clone, and by the time a reapply runs the machine's network policy is
+  already in force. Bundled skills are file writes and always land; a remote
+  one may not, under a restrictive policy.
+
+  So a reapply that needs either of those is refused, and says which field
+  forced it. Start a new conversation for that, or build the machine under
+  the conversation again with `DELETE /api/sandboxes/:id` (#1071).
+
+  ## The cotenant rule
+
+  Skills, the instructions file and `.mcp.json` sit at per-sandbox paths
+  (`Managoat.Runtimes.Layout`), not per-conversation ones, so rewriting them
+  rewrites them for every conversation on that machine. Sharing only happens
+  on a persistent home or an explicit `sandbox_id` attach, and
+  `Conversations.check_attachable/4` already pins every conversation on a
+  machine to one `(user, agent, environment, vault)`. A conversation that has
+  the machine to itself can therefore be reconfigured freely; one that shares
+  it may only be reapplied to the selection its cotenants already have, which
+  is what a refresh is. The context applies that rule and reports it as the
+  `:shared_sandbox` blocker below.
   """
 
+  alias Fountain.Conversations.Sandbox
   alias Fountain.Environments.Environment
+
+  @typedoc "Why a selection cannot be applied to the machine that is already there."
+  @type blocker ::
+          :runtime
+          | :packages
+          | :repositories
+          | :setup_script
+          | :networking
+          | :environment
+          | :shared_sandbox
 
   @doc """
   The digest of the Environment fields that provisioning turns into disk
@@ -66,4 +96,79 @@ defmodule Fountain.Conversations.Reapply do
     |> Base.encode16(case: :lower)
     |> binary_part(0, 32)
   end
+
+  @doc """
+  Whether the machine `sandbox` already is can be reconfigured into the
+  requested selection, or the first reason it cannot.
+
+  `:built_with` is the Environment the sandbox records, used only when the row
+  predates `build_fingerprint` and so cannot answer for itself.
+  """
+  @spec check(Sandbox.t() | nil, keyword()) :: :ok | {:error, {:rebuild_required, blocker()}}
+  def check(nil, _opts), do: :ok
+
+  def check(%Sandbox{} = sandbox, opts) do
+    current_runtime = Keyword.fetch!(opts, :current_runtime)
+    target_runtime = Keyword.fetch!(opts, :target_runtime)
+    target_env = Keyword.fetch!(opts, :target_environment)
+    built_with = Keyword.get(opts, :built_with)
+
+    cond do
+      target_runtime != current_runtime ->
+        {:error, {:rebuild_required, :runtime}}
+
+      built_fingerprint(sandbox, built_with) == fingerprint(target_env) ->
+        :ok
+
+      true ->
+        {:error, {:rebuild_required, build_field(built_with, target_env)}}
+    end
+  end
+
+  # A row written since #1565 answers for itself. An older one cannot, so the
+  # environment it records stands in: that catches a selection pointing at a
+  # different environment, and misses only an environment edited before this
+  # column existed.
+  defp built_fingerprint(%Sandbox{build_fingerprint: fp}, _built_with) when is_binary(fp), do: fp
+  defp built_fingerprint(_sandbox, built_with), do: fingerprint(built_with)
+
+  # Which field to name in the refusal. Falls back to `:environment` when the
+  # machine cannot say what it was built from and only the identity differs.
+  defp build_field(%Environment{} = was, %Environment{} = now) do
+    cond do
+      was.packages != now.packages -> :packages
+      was.repositories != now.repositories -> :repositories
+      was.setup_script != now.setup_script -> :setup_script
+      was.networking_type != now.networking_type -> :networking
+      was.networking_config != now.networking_config -> :networking
+      true -> :environment
+    end
+  end
+
+  defp build_field(_was, _now), do: :environment
+
+  @doc """
+  A sentence naming what forced a rebuild, for the API error and the log.
+  """
+  @spec explain(blocker()) :: String.t()
+  def explain(:runtime),
+    do:
+      "the selected agent runs a different runtime, and the ACP adapter is installed " <>
+        "before the network policy that would now block installing another"
+
+  def explain(:packages), do: "the selected environment installs different packages"
+  def explain(:repositories), do: "the selected environment clones different repositories"
+  def explain(:setup_script), do: "the selected environment runs a different setup script"
+
+  def explain(:networking),
+    do:
+      "the selected environment applies a different network policy, and the egress rules " <>
+        "are written once, when the machine is built"
+
+  def explain(:environment), do: "the selected environment builds the machine differently"
+
+  def explain(:shared_sandbox),
+    do:
+      "other conversations share this machine, and its skills, instructions and MCP " <>
+        "configuration are per-machine rather than per-conversation"
 end

--- a/apps/fountain/lib/fountain/conversations/reapply.ex
+++ b/apps/fountain/lib/fountain/conversations/reapply.ex
@@ -103,6 +103,20 @@ defmodule Fountain.Conversations.Reapply do
 
   `:built_with` is the Environment the sandbox records, used only when the row
   predates `build_fingerprint` and so cannot answer for itself.
+
+  ## What the refusal can name
+
+  A refusal carries the build field that forced it only when the selection
+  moves to a *different* Environment, because naming the field means diffing
+  the one the machine was built from against the one being asked for.
+
+  A refresh of the same Environment, edited in place, is the case that cannot.
+  Both sides are the same row read fresh, so every field compares equal however
+  far the build inputs moved. The stored digest still catches the move — it was
+  computed before the edit — but nothing left on the row says *which* input
+  changed, so the refusal is the general `:environment`. Recovering the field
+  there needs the digest to be per-field rather than one string, which is a
+  column change and not worth it for the message alone.
   """
   @spec check(Sandbox.t() | nil, keyword()) :: :ok | {:error, {:rebuild_required, blocker()}}
   def check(nil, _opts), do: :ok
@@ -132,8 +146,10 @@ defmodule Fountain.Conversations.Reapply do
   defp built_fingerprint(%Sandbox{build_fingerprint: fp}, _built_with) when is_binary(fp), do: fp
   defp built_fingerprint(_sandbox, built_with), do: fingerprint(built_with)
 
-  # Which field to name in the refusal. Falls back to `:environment` when the
-  # machine cannot say what it was built from and only the identity differs.
+  # Which field to name in the refusal. Falls back to `:environment` in two
+  # cases: the machine cannot say what it was built from, and both sides are
+  # the same Environment row, which is what a refresh of one edited in place
+  # looks like from here. See `check/2`.
   defp build_field(%Environment{} = was, %Environment{} = now) do
     cond do
       was.packages != now.packages -> :packages

--- a/apps/fountain/test/fountain/conversations/reapply_check_test.exs
+++ b/apps/fountain/test/fountain/conversations/reapply_check_test.exs
@@ -1,0 +1,111 @@
+defmodule Fountain.Conversations.ReapplyCheckTest do
+  use Fountain.DataCase, async: true
+
+  alias Fountain.Conversations.Reapply
+  alias Fountain.Environments
+
+  setup do
+    user = insert_verified_user()
+    env = insert_env(user_id: user.id, setup_script: "echo build")
+
+    sandbox =
+      insert_sandbox(
+        user_id: user.id,
+        status: "ready",
+        environment_id: env.id,
+        build_fingerprint: Reapply.fingerprint(env)
+      )
+
+    %{user: user, env: env, sandbox: sandbox}
+  end
+
+  defp check(sandbox, opts) do
+    Reapply.check(
+      sandbox,
+      Keyword.merge([current_runtime: "claude", target_runtime: "claude"], opts)
+    )
+  end
+
+  test "a conversation with no machine yet has nothing to refuse" do
+    assert :ok = Reapply.check(nil, current_runtime: "claude", target_runtime: "codex")
+  end
+
+  test "the same build inputs are applicable in place", ctx do
+    # Only the variables differ, and those reach the machine on its next spawn.
+    {:ok, sibling} =
+      Environments.update_environment(ctx.env, %{"env_vars" => %{"WHO" => "sibling"}})
+
+    assert :ok = check(ctx.sandbox, target_environment: sibling, built_with: ctx.env)
+  end
+
+  test "a different runtime is refused before anything else is compared", ctx do
+    assert {:error, {:rebuild_required, :runtime}} =
+             check(ctx.sandbox,
+               target_runtime: "codex",
+               target_environment: ctx.env,
+               built_with: ctx.env
+             )
+  end
+
+  test "each build field names itself in the refusal", ctx do
+    cases = [
+      {%{"packages" => %{"apt" => ["ripgrep"]}}, :packages},
+      {%{
+         "repositories" => [
+           %{"url" => "https://example.com/r.git", "mount_path" => "/home/sprite/r"}
+         ]
+       }, :repositories},
+      {%{"setup_script" => "echo something else"}, :setup_script},
+      {%{"networking_type" => "limited", "networking_config" => %{"allow" => ["a.test"]}},
+       :networking}
+    ]
+
+    for {change, field} <- cases do
+      {:ok, rebuilt} = Environments.update_environment(ctx.env, change)
+
+      assert {:error, {:rebuild_required, ^field}} =
+               check(ctx.sandbox, target_environment: rebuilt, built_with: ctx.env)
+    end
+  end
+
+  test "dropping the environment altogether needs the disk built again", ctx do
+    assert {:error, {:rebuild_required, :environment}} =
+             check(ctx.sandbox, target_environment: nil, built_with: ctx.env)
+  end
+
+  test "a row that predates the digest falls back to the environment it records", ctx do
+    # `build_fingerprint` is null on every row built before #1565. The
+    # environment the sandbox names stands in, so a selection pointing at a
+    # different environment is still caught.
+    legacy = %{ctx.sandbox | build_fingerprint: nil}
+    {:ok, other} = Environments.update_environment(ctx.env, %{"setup_script" => "echo other"})
+
+    assert :ok = check(legacy, target_environment: ctx.env, built_with: ctx.env)
+
+    assert {:error, {:rebuild_required, :setup_script}} =
+             check(legacy, target_environment: other, built_with: ctx.env)
+  end
+
+  test "a row that predates the digest and cannot name what it was built with", ctx do
+    legacy = %{ctx.sandbox | build_fingerprint: nil}
+
+    assert {:error, {:rebuild_required, :environment}} =
+             check(legacy, target_environment: ctx.env, built_with: nil)
+  end
+
+  test "every blocker has a sentence of its own" do
+    blockers = [
+      :runtime,
+      :packages,
+      :repositories,
+      :setup_script,
+      :networking,
+      :environment,
+      :shared_sandbox
+    ]
+
+    sentences = Enum.map(blockers, &Reapply.explain/1)
+    assert Enum.all?(sentences, &is_binary/1)
+    assert Enum.uniq(sentences) == sentences
+  end
+end

--- a/apps/fountain/test/fountain/conversations/reapply_check_test.exs
+++ b/apps/fountain/test/fountain/conversations/reapply_check_test.exs
@@ -47,7 +47,10 @@ defmodule Fountain.Conversations.ReapplyCheckTest do
              )
   end
 
-  test "each build field names itself in the refusal", ctx do
+  test "each build field names itself when the selection moves to another environment", ctx do
+    # `built_with` is the environment the machine was built from and
+    # `target_environment` the one being asked for, so the field is nameable
+    # only while those are two different rows. The refresh case is below.
     cases = [
       {%{"packages" => %{"apt" => ["ripgrep"]}}, :packages},
       {%{
@@ -66,6 +69,20 @@ defmodule Fountain.Conversations.ReapplyCheckTest do
       assert {:error, {:rebuild_required, ^field}} =
                check(ctx.sandbox, target_environment: rebuilt, built_with: ctx.env)
     end
+  end
+
+  test "a refresh of an environment edited in place cannot name the field", ctx do
+    # The per-field cases above rebind to a second environment, which is not
+    # what a refresh does: the production call site reads both sides from the
+    # database, so a refresh passes the same row twice. The digest stored at
+    # build time still catches that the build inputs moved; no field can be
+    # singled out, and the refusal is the general one. Pinned so the behaviour
+    # is deliberate rather than incidental — `check/2` says why.
+    {:ok, edited} =
+      Environments.update_environment(ctx.env, %{"packages" => %{"apt" => ["ripgrep"]}})
+
+    assert {:error, {:rebuild_required, :environment}} =
+             check(ctx.sandbox, target_environment: edited, built_with: edited)
   end
 
   test "dropping the environment altogether needs the disk built again", ctx do


### PR DESCRIPTION
`Reapply.check/2` answers one question: can the machine this conversation is already on be reconfigured into the selection being asked for.

Variables, the system prompt, skills, MCP servers, the model and the permission policy are either process environment or a file, and the wake path has rewritten both of those under a live sandbox since #848. A different runtime, different packages, different repositories, a different setup script or a different network policy are not: the ACP adapter is installed before the network policy that would now block installing another, `git clone` refuses a checkout that already exists, a setup script that starts services fails on its second run, and the egress rules are written exactly once.

So `check/2` compares the digest the machine recorded with the digest of the selection, and returns `{:error, {:rebuild_required, field}}` naming the first field that forced it. A row written before this stack has no digest and falls back to the environment it records, which still catches a selection pointing somewhere else. `explain/1` is the sentence each blocker gets, for the API error and the log.

The network policy is the cautious one of the five. Nothing has ever re-run `Egress.apply_policy/4` against a live machine, so rather than assume it is idempotent and find out in production, a networking change is refused. Relaxing that is a one-line change to `fingerprint/1` once somebody has shown the re-application is safe.

`:shared_sandbox` is declared here and reported by the context, which is the only place that can see a machine's cotenants. Nothing calls `check/2` yet.

Part 3 of 8 for #1565, on #1887.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9jevFQT5MkF3rJUieeiHW


---

### The stack (#1565, re-cut from #1569)

| | PR | What it covers |
|---|---|---|
| 1 | #1886 | server subtraction, no behaviour change, room for the rest |
| 2 | #1887 | the revision, build-fingerprint and applied-skills columns |
| 3 | #1888 | `Reapply.check/2`: what can be reconfigured in place, and what cannot |
| 4 | #1889 | `Conversations.reapply_conversation/3`, audited, under the sandbox lock |
| 5 | #1890 | the revision at turn admission, and the live server refresh |
| 6 | #1891 | skills reconciliation, on a live reapply and on every wake |
| 7 | #1892 | `POST /api/conversations/:id/reapply` and its status-code contract |
| 8 | #1893 | the manual, Python, Elixir, Swift, and the version bump |

Merge top down. Do not `--delete-branch` while a child still points at a branch.



Part of #1565
