### PR TITLE
feat(sandboxes): reconcile skills rather than only install them (#1565)

### DIFF
--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -1150,6 +1150,10 @@ defmodule Fountain.Conversations.ConversationServer do
         Fountain.Conversations.Identity.disk_env(sprite_env)
       )
 
+      # An agent's skills reach the existing computer on its next wake too,
+      # and a skill it no longer names is taken off the disk (#1565).
+      Reapply.mount_skills(handle, conv, agent)
+
       # Same for the agent's system prompt: an edit reaches the existing
       # computer on its next wake (#848).
       runtime = conv.runtime || (agent && agent.runtime) || "claude"

--- a/apps/fountain/lib/fountain/conversations/reapply.ex
+++ b/apps/fountain/lib/fountain/conversations/reapply.ex
@@ -247,4 +247,33 @@ defmodule Fountain.Conversations.Reapply do
       version -> version.config["skills"] || []
     end
   end
+
+  @doc """
+  Reconcile the machine's skills with the conversation's current selection,
+  then record what is now on it.
+
+  Run on every wake, not only after a live reapply: a sleeping conversation
+  whose selection changed applies it when it next comes up, and a machine
+  built before the manifest existed gets one on its first pass. The recorded
+  set is only advanced when the reconciliation succeeded, so a failed pass
+  leaves the next one the same work rather than a wrong picture of the disk.
+  """
+  @spec mount_skills(Managoat.Sandbox.Handle.t(), map(), map() | nil) :: :ok | {:error, term()}
+  def mount_skills(handle, conv, agent) do
+    # ownership: conv came from the tenant-scoped API fetch or its own server.
+    sandbox = Conversations._unsafe_get_sandbox!(conv.sandbox_id)
+    skills = (agent && agent.skills) || []
+    runtime = conv.runtime || (agent && agent.runtime) || "claude"
+
+    with :ok <-
+           Fountain.SandboxSkills.reconcile(
+             handle,
+             runtime,
+             skills,
+             sandbox.applied_skills || previous_skills(conv)
+           ),
+         {:ok, _} <- Conversations.update_sandbox(sandbox, %{applied_skills: skills}) do
+      :ok
+    end
+  end
 end

--- a/apps/fountain/lib/fountain/sandbox_skills.ex
+++ b/apps/fountain/lib/fountain/sandbox_skills.ex
@@ -14,6 +14,9 @@ defmodule Fountain.SandboxSkills do
   require Logger
 
   @bundle_root "sprite_skills"
+  # Written at the skills root: which directories each Fountain-managed skill
+  # put there, so a later reconciliation knows what it owns.
+  @manifest_name ".fountain-managed-skills"
   @fountain_skill_name "fountain"
   # Every sandbox gets these, in this order: the API skill, then the team
   # set-up Q&A (#851) — so a first teammate can answer "/create-team".
@@ -55,7 +58,212 @@ defmodule Fountain.SandboxSkills do
   end
 
   def mount(handle, runtime_module, skills) when is_atom(runtime_module) do
-    Managoat.Runtimes.Skills.install(handle, bundled() ++ (skills || []), runtime: runtime_module)
+    reconcile(handle, runtime_module, skills, [])
+  end
+
+  @doc """
+  Replace the Fountain-managed skills on a machine, leaving everything else
+  under the skills root alone (#1565).
+
+  Installing is not enough once a conversation can be reapplied. A skill the
+  agent no longer names is still on the disk, and the runtime still reads it,
+  so removing one from an agent would change nothing until the machine was
+  rebuilt. Reconciling deletes what Fountain put there and is no longer
+  selected, and only that.
+
+  Three things make "only that" true:
+
+  - **A manifest, written at the skills root.** It maps each selected skill
+    to the directory names its install produced, so a later pass knows what
+    it owns. A GitHub install without a `--skill` name decides its own
+    directory names, which is why the manifest records what appeared rather
+    than what was asked for.
+  - **`previous`, for disks written before the manifest existed.** The
+    conversation's recorded Agent version names the skills that were
+    installed, and the skills.sh source lock names the directories an unnamed
+    GitHub install produced. Anything neither can account for is left where
+    it is: an entry with no ownership record is somebody else's.
+  - **Only direct children of the skills root are ever removed**, each one
+    matched against a conservative name pattern. Neither a forged manifest
+    nor a legacy skill name can turn reconciliation into a delete somewhere
+    else on the disk.
+
+  A remote skill that is still selected keeps its directory when its
+  reinstall fails, which is what an offline machine under a restrictive
+  network policy looks like: the copy on the disk is the working one.
+  """
+  @spec reconcile(Managoat.Sandbox.Handle.t(), String.t() | module(), [map()] | nil, [map()]) ::
+          :ok | {:error, term()}
+  def reconcile(handle, runtime, skills, previous) when is_binary(runtime) do
+    case Fountain.RuntimeDispatch.for_agent(%{runtime: runtime, user_id: nil}) do
+      {:ok, module} ->
+        reconcile(handle, module, skills, previous)
+
+      {:error, reason} ->
+        Logger.warning("skills not reconciled for runtime #{runtime}: #{reason}")
+        {:error, reason}
+    end
+  end
+
+  def reconcile(handle, runtime_module, skills, previous) when is_atom(runtime_module) do
+    root = runtime_module.skills_root()
+    manifest = Path.join(root, @manifest_name)
+    selected = bundled() ++ (skills || [])
+
+    with {:ok, raw} <-
+           run(
+             handle,
+             "if [ -f #{quote_shell(manifest)} ]; then cat -- #{quote_shell(manifest)}; fi"
+           ),
+         {:ok, legacy} <- legacy_manifest(handle, previous),
+         managed = Map.merge(legacy, decode_manifest(raw)),
+         obsolete = obsolete_names(managed, selected),
+         {:ok, _} <- run(handle, remove(root, obsolete)),
+         {:ok, installed} <- install_selected(handle, runtime_module, root, selected, managed) do
+      Managoat.Sandbox.write_file(handle, manifest, Jason.encode!(installed))
+    end
+  end
+
+  # Stable across content and ref edits: a retained remote skill stays usable
+  # when its best-effort reinstall is refused by the network policy.
+  defp identity(skill), do: Jason.encode!([skill["source"], skill["name"]])
+
+  defp normalize(skills),
+    do: Enum.map(skills || [], fn s -> Map.new(s, fn {k, v} -> {to_string(k), v} end) end)
+
+  defp named_manifest(skills),
+    do: Map.new(normalize(skills), fn s -> {identity(s), names(s)} end)
+
+  # skills.sh records globally installed names by source, including installs
+  # made without --skill. Recover those on disks predating Fountain's own
+  # manifest. Format: https://github.com/vercel-labs/skills/blob/main/src/skill-lock.ts
+  defp legacy_manifest(handle, previous) do
+    unnamed = Enum.filter(normalize(previous), &(is_binary(&1["source"]) and is_nil(&1["name"])))
+
+    if unnamed == [] do
+      {:ok, named_manifest(previous)}
+    else
+      script = ~S"""
+      if [ -n "${XDG_STATE_HOME:-}" ]; then
+        skills_lock="$XDG_STATE_HOME/skills/.skill-lock.json"
+      else
+        skills_lock="$HOME/.agents/.skill-lock.json"
+      fi
+      if [ -f "$skills_lock" ]; then cat -- "$skills_lock"; fi
+      """
+
+      with {:ok, raw} <- run(handle, script) do
+        locked =
+          case Jason.decode(raw) do
+            {:ok, %{"skills" => skills}} when is_map(skills) -> skills
+            _ -> %{}
+          end
+
+        recovered =
+          Map.new(unnamed, fn entry ->
+            names =
+              Enum.flat_map(locked, fn
+                {name, %{"source" => source, "sourceType" => "github"}} ->
+                  if source == entry["source"] and safe_name?(name), do: [name], else: []
+
+                _ ->
+                  []
+              end)
+
+            {identity(entry), names}
+          end)
+
+        {:ok, Map.merge(named_manifest(previous), recovered)}
+      end
+    end
+  end
+
+  defp decode_manifest(raw) do
+    case Jason.decode(raw) do
+      {:ok, map} when is_map(map) ->
+        Map.new(map, fn {key, values} ->
+          {key, if(is_list(values), do: Enum.filter(values, &safe_name?/1), else: [])}
+        end)
+
+      _ ->
+        %{}
+    end
+  end
+
+  # A name is obsolete when it belonged to a skill that is no longer selected
+  # and no selected skill claims it. Two skills can produce the same directory
+  # name, so a retained claim always wins over a dropped one.
+  defp obsolete_names(managed, selected) do
+    wanted = named_manifest(selected)
+    retained = managed |> Map.take(Map.keys(wanted)) |> Map.values() |> List.flatten()
+    removed = managed |> Map.drop(Map.keys(wanted)) |> Map.values() |> List.flatten()
+    Enum.uniq(removed -- (retained ++ (wanted |> Map.values() |> List.flatten())))
+  end
+
+  defp install_selected(handle, runtime, root, selected, managed) do
+    {inline, remote} = Enum.split_with(normalize(selected), &is_binary(&1["content"]))
+
+    # GitHub installs first, as in the library: their blocking exec is also the
+    # readiness barrier before the sandbox accepts inline file writes.
+    Enum.reduce_while(remote ++ inline, {:ok, %{}}, fn skill, {:ok, installed} ->
+      case install_skill(handle, runtime, root, skill, managed) do
+        {:ok, names} -> {:cont, {:ok, Map.put(installed, identity(skill), names)}}
+        {:error, _} = error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp install_skill(handle, runtime, _root, %{"content" => _} = skill, _managed) do
+    with :ok <- Managoat.Runtimes.Skills.install(handle, [skill], runtime: runtime),
+         do: {:ok, names(skill)}
+  end
+
+  # A remote install names its own directories, so they are read off the disk
+  # rather than assumed. The names already recorded for this skill are kept
+  # too, so a reinstall the network refused does not make the copy on disk
+  # look unowned and get deleted on the next pass.
+  defp install_skill(handle, runtime, root, skill, managed) do
+    with {:ok, before} <- run(handle, listing(root)),
+         :ok <- Managoat.Runtimes.Skills.install(handle, [skill], runtime: runtime),
+         {:ok, after_install} <- run(handle, listing(root)) do
+      {:ok,
+       Enum.uniq(
+         (entries(after_install) -- entries(before)) ++
+           names(skill) ++ Map.get(managed, identity(skill), [])
+       )}
+    end
+  end
+
+  defp names(skill), do: if(safe_name?(skill["name"]), do: [skill["name"]], else: [])
+
+  defp safe_name?(name) when is_binary(name),
+    do: Regex.match?(~r/\A[A-Za-z0-9][A-Za-z0-9._-]*\z/, name)
+
+  defp safe_name?(_), do: false
+  defp entries(text), do: text |> String.split("\n", trim: true) |> Enum.filter(&safe_name?/1)
+
+  defp remove(root, names) do
+    "mkdir -p -- #{quote_shell(root)}\n" <>
+      Enum.map_join(names, "\n", fn name -> "rm -rf -- #{quote_shell(Path.join(root, name))}" end)
+  end
+
+  defp listing(root) do
+    """
+    for path in #{quote_shell(root)}/*; do
+      [ -e "$path" ] || [ -L "$path" ] || continue
+      basename -- "$path"
+    done
+    """
+  end
+
+  defp quote_shell(value), do: "'" <> String.replace(value, "'", "'\\''") <> "'"
+
+  defp run(handle, script) do
+    case Managoat.Sandbox.exec(handle, "bash", ["-c", script], stderr_to_stdout: true) do
+      {:ok, output, 0} -> {:ok, output}
+      {:ok, _output, code} -> {:error, "skill reconciliation exited with #{code}"}
+      {:error, reason} -> {:error, reason}
+    end
   end
 
   @doc """

--- a/apps/fountain/test/fountain/conversations/conversation_server_refresh_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_refresh_test.exs
@@ -104,6 +104,35 @@ defmodule Fountain.Conversations.ConversationServerRefreshTest do
     GenServer.stop(pid)
   end
 
+  test "a sleeping conversation reconciles its skills on the next wake", ctx do
+    stub_happy_sprite()
+
+    {:ok, _} =
+      Conversations.update_sandbox(ctx.sandbox, %{
+        status: "suspended",
+        build_fingerprint: Fountain.Conversations.Reapply.fingerprint(ctx.env)
+      })
+
+    {:ok, conv} = Conversations.update_conversation(ctx.conv, %{status: "idle"})
+
+    skills = [%{"name" => "fresh", "content" => "Updated skill"}]
+    {:ok, _} = Fountain.Agents.update_agent(ctx.agent, %{skills: skills})
+    test = self()
+
+    Mimic.expect(Fountain.SandboxSkills, :reconcile, fn _handle, "claude", ^skills, _previous ->
+      send(test, :skills_reconciled)
+      :ok
+    end)
+
+    assert {:ok, updated} = Conversations.reapply_conversation(conv, %{})
+    {pid, _, :alive} = start_server(updated)
+
+    assert_received :skills_reconciled
+    assert Conversations._unsafe_get_sandbox!(ctx.sandbox.id).applied_skills == skills
+    assert :sys.get_state(pid).configuration_revision == updated.configuration_revision
+    GenServer.stop(pid)
+  end
+
   test "a prompt reloads configuration when the refresh notification was missed", ctx do
     stub_happy_sprite()
     {pid, _, :alive} = start_server(ctx.conv)

--- a/apps/fountain/test/fountain/conversations/conversation_server_size_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_size_test.exs
@@ -13,9 +13,16 @@ defmodule Fountain.Conversations.ConversationServerSizeTest do
   The shape is the docs-style allowlist that only shrinks (#911): the number
   is not a target, it is a record of where the file is, and the only edit it
   accepts is downward. Lower it when you move something out; never raise it.
+
+  **A stack in flight does not move it.** The pin is the length on `main`, and
+  a number measured against a branch is stale the moment any link below it
+  grows the file, which is what review rounds do. #1565 lowered it mid-stack to
+  the tip's exact length, left zero headroom, and went red two rounds later
+  when a fix four PRs down added lines. Land the shrink first, then lower the
+  pin in a follow-up, when the number has stopped moving.
   """
 
-  @pin 2716
+  @pin 2762
 
   @server "apps/fountain/lib/fountain/conversations/conversation_server.ex"
 

--- a/apps/fountain/test/fountain/conversations/conversation_server_size_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_size_test.exs
@@ -15,7 +15,7 @@ defmodule Fountain.Conversations.ConversationServerSizeTest do
   accepts is downward. Lower it when you move something out; never raise it.
   """
 
-  @pin 2762
+  @pin 2716
 
   @server "apps/fountain/lib/fountain/conversations/conversation_server.ex"
 

--- a/apps/fountain/test/fountain/sandbox_skills_test.exs
+++ b/apps/fountain/test/fountain/sandbox_skills_test.exs
@@ -27,7 +27,7 @@ defmodule Fountain.SandboxSkillsTest do
       :ok
     end)
 
-    reject(&Managoat.Sandbox.exec/4)
+    stub(Managoat.Sandbox, :exec, fn _, _, _, _ -> {:ok, "", 0} end)
 
     assert :ok = SandboxSkills.mount(@handle, "claude", [%{"name" => "mine", "content" => "# m"}])
 
@@ -48,6 +48,8 @@ defmodule Fountain.SandboxSkillsTest do
       :ok
     end)
 
+    stub(Managoat.Sandbox, :exec, fn _, _, _, _ -> {:ok, "", 0} end)
+
     assert :ok = SandboxSkills.mount(@handle, "acp", [%{"name" => "mine", "content" => "# m"}])
 
     root = Fountain.CommandRuntime.skills_root()
@@ -59,6 +61,7 @@ defmodule Fountain.SandboxSkillsTest do
   test "a module is passed straight through to the library" do
     test = self()
     stub(Managoat.Sandbox, :write_file, fn _h, path, _b -> send(test, {:wrote, path}) && :ok end)
+    stub(Managoat.Sandbox, :exec, fn _, _, _, _ -> {:ok, "", 0} end)
 
     assert :ok = SandboxSkills.mount(@handle, Fountain.CommandRuntime, nil)
     assert_receive {:wrote, "/home/sprite/.claude/skills/fountain/SKILL.md"}
@@ -78,11 +81,146 @@ defmodule Fountain.SandboxSkillsTest do
 
   test "a nil skills list mounts the bundled skills alone" do
     test = self()
+    stub(Managoat.Sandbox, :exec, fn _, _, _, _ -> {:ok, "", 0} end)
     stub(Managoat.Sandbox, :write_file, fn _h, path, _b -> send(test, {:wrote, path}) && :ok end)
 
     assert :ok = SandboxSkills.mount(@handle, "codex", nil)
     assert_receive {:wrote, "/home/sprite/.codex/skills/fountain/SKILL.md"}
     assert_receive {:wrote, "/home/sprite/.codex/skills/create-team/SKILL.md"}
+    assert_receive {:wrote, "/home/sprite/.codex/skills/.fountain-managed-skills"}
     refute_receive {:wrote, _}
+  end
+
+  defmodule DiskRuntime do
+    @moduledoc """
+    A runtime whose skills root is a real directory on this machine, so the
+    reconciliation can be measured against a filesystem rather than a mock.
+    """
+    def skills_root, do: Process.get(:skills_test_root)
+    def skills_sh_agent, do: "claude"
+  end
+
+  describe "reconciliation on disk" do
+    setup do
+      root = Fountain.TmpDir.mkdir!("fountain-skills")
+      Process.put(:skills_test_root, root)
+
+      stub(Managoat.Sandbox, :write_file, fn _, path, content ->
+        File.mkdir_p!(Path.dirname(path))
+        File.write(path, content)
+      end)
+
+      stub(Managoat.Sandbox, :exec, fn _, "bash", args, _ ->
+        {output, code} = System.cmd("bash", args, stderr_to_stdout: true)
+        {:ok, output, code}
+      end)
+
+      %{root: root}
+    end
+
+    test "removes an obsolete inline skill while preserving unrelated files", %{root: root} do
+      File.mkdir_p!(Path.join(root, "personal"))
+      File.write!(Path.join(root, "personal/SKILL.md"), "My local skill")
+
+      assert :ok =
+               SandboxSkills.mount(@handle, DiskRuntime, [
+                 %{"name" => "old", "content" => "Old skill"}
+               ])
+
+      assert :ok =
+               SandboxSkills.mount(@handle, DiskRuntime, [
+                 %{"name" => "new", "content" => "New skill"}
+               ])
+
+      refute File.exists?(Path.join(root, "old"))
+      assert File.read!(Path.join(root, "new/SKILL.md")) == "New skill"
+      # Not Fountain's, so not Fountain's to delete.
+      assert File.read!(Path.join(root, "personal/SKILL.md")) == "My local skill"
+      assert File.exists?(Path.join(root, "fountain/SKILL.md"))
+    end
+
+    test "seeds legacy named skills and ignores unsafe manifest paths", %{root: root} do
+      File.mkdir_p!(Path.join(root, "legacy"))
+      File.write!(Path.join(root, "legacy/SKILL.md"), "Old skill")
+      File.write!(Path.join(root, ".fountain-managed-skills"), "..\n../outside\n/absolute\n")
+
+      assert :ok =
+               SandboxSkills.reconcile(@handle, DiskRuntime, [], [
+                 %{"name" => "legacy", "content" => "Old skill"}
+               ])
+
+      refute File.exists?(Path.join(root, "legacy"))
+      # A manifest naming anything but a direct child removes nothing.
+      assert File.dir?(root)
+    end
+
+    test "recovers unnamed legacy GitHub skills from the source lock", %{root: root} do
+      File.mkdir_p!(Path.join(root, "legacy-remote"))
+      File.write!(Path.join(root, "legacy-remote/SKILL.md"), "Old remote skill")
+      File.mkdir_p!(Path.join(root, "unrelated"))
+
+      stub(Managoat.Sandbox, :exec, fn _, "bash", args, _ ->
+        if Enum.any?(args, &String.contains?(&1, "skills_lock=")) do
+          {:ok,
+           Jason.encode!(%{
+             "skills" => %{
+               "legacy-remote" => %{"source" => "owner/repo", "sourceType" => "github"},
+               "unrelated" => %{"source" => "another/repo", "sourceType" => "github"}
+             }
+           }), 0}
+        else
+          {output, code} = System.cmd("bash", args, stderr_to_stdout: true)
+          {:ok, output, code}
+        end
+      end)
+
+      assert :ok =
+               SandboxSkills.reconcile(@handle, DiskRuntime, [], [%{"source" => "owner/repo"}])
+
+      refute File.exists?(Path.join(root, "legacy-remote"))
+      # Installed from a source this conversation never named.
+      assert File.dir?(Path.join(root, "unrelated"))
+    end
+
+    test "a retained remote skill survives an offline reinstall", %{root: root} do
+      skill = %{"source" => "owner/repo", "name" => "remote"}
+      File.mkdir_p!(Path.join(root, "remote"))
+      File.write!(Path.join(root, "remote/SKILL.md"), "Already installed")
+
+      stub(Managoat.Sandbox, :exec, fn _, "bash", args, _ ->
+        case args do
+          ["-lc", "npx " <> _] ->
+            {:ok, "offline", 1}
+
+          _ ->
+            {output, code} = System.cmd("bash", args, stderr_to_stdout: true)
+            {:ok, output, code}
+        end
+      end)
+
+      assert :ok = SandboxSkills.reconcile(@handle, DiskRuntime, [skill], [skill])
+      assert File.read!(Path.join(root, "remote/SKILL.md")) == "Already installed"
+    end
+
+    test "tracks discovered GitHub skill names for a later removal", %{root: root} do
+      stub(Managoat.Sandbox, :exec, fn _, "bash", args, _ ->
+        case args do
+          ["-lc", "npx " <> _] ->
+            File.mkdir_p!(Path.join(root, "discovered"))
+            File.write!(Path.join(root, "discovered/SKILL.md"), "Remote skill")
+            {:ok, "", 0}
+
+          _ ->
+            {output, code} = System.cmd("bash", args, stderr_to_stdout: true)
+            {:ok, output, code}
+        end
+      end)
+
+      assert :ok = SandboxSkills.mount(@handle, DiskRuntime, [%{"source" => "owner/repo"}])
+      assert File.read!(Path.join(root, ".fountain-managed-skills")) =~ "discovered"
+
+      assert :ok = SandboxSkills.mount(@handle, DiskRuntime, [])
+      refute File.exists?(Path.join(root, "discovered"))
+    end
   end
 end

--- a/apps/fountain/test/support/conversation_server_case.ex
+++ b/apps/fountain/test/support/conversation_server_case.ex
@@ -77,6 +77,10 @@ defmodule Fountain.ConversationServerCase do
 
     Mimic.stub(Fountain.SandboxSkills, :mount, fn _handle, _runtime, _skills -> :ok end)
 
+    Mimic.stub(Fountain.SandboxSkills, :reconcile, fn _handle, _runtime, _skills, _previous ->
+      :ok
+    end)
+
     Mimic.stub(Fountain.Conversations.Provisioning, :write_env_file, fn _s, _e -> :ok end)
 
     Mimic.stub(Fountain.Conversations.Provisioning, :install_packages, fn _s, _e, _se, _c ->


### PR DESCRIPTION
Installing was enough while a conversation's agent was fixed at launch. It is not once the agent can be reapplied: a skill the agent no longer names is still on the disk and the runtime still reads it, so removing one from an agent changed nothing until the machine was rebuilt.

`SandboxSkills.reconcile/4` deletes what Fountain put under the skills root and no longer selects, and only that. `mount/3` is now the empty-history call to it, so a fresh provision is unchanged.

Three things make "only that" true:

- **A manifest at the skills root** maps each selected skill to the directories its install produced. A GitHub install without `--skill` picks its own names, so the manifest records what appeared rather than what was asked for.
- **A seed for disks written before the manifest existed**: the conversation's recorded Agent version names the skills that were installed, and skills.sh's own source lock names the directories an unnamed GitHub install produced. An entry neither can account for is somebody else's and is left where it is.
- **Only direct children of the skills root are removed**, each matched against a conservative name pattern, so neither a forged manifest nor a legacy name can turn reconciliation into a delete elsewhere on the disk.

A remote skill that is still selected keeps its directory when the reinstall fails, which is what an offline machine under a restrictive network policy looks like: the copy on the disk is the working one.

`Reapply.mount_skills/3` runs it on every wake, beside the `.env`, `.mcp.json` and instructions rewrites the wake path has always done, and records the new selection only when the pass succeeded. So a sleeping conversation applies a reapply when it next comes up, and a live one applies it when its server reloads.

The reconciliation tests run against a real directory rather than a mock, so "preserves unrelated files" is a statement about a filesystem.

### The size pin

The pin stays at main's value while the stack is in flight. This PR changes only the test's documentation; lowering the pin is a follow-up after the stack lands, when the server's size has stopped moving.

### Difference from #1569

The original resolved a runtime string through `Managoat.Runtimes.for_runtime/1`. This one goes through `Fountain.RuntimeDispatch`, for the reason #1634 gives: the library knows four runtimes and `acp` is not one of them, so the library's dispatcher would have left an acp sandbox with no skills and said nothing.

Part 6 of 8 for #1565, on #1890.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9jevFQT5MkF3rJUieeiHW


---

### The stack (#1565, re-cut from #1569)

| | PR | What it covers |
|---|---|---|
| 1 | #1886 | server subtraction, no behaviour change, room for the rest |
| 2 | #1887 | the revision, build-fingerprint and applied-skills columns |
| 3 | #1888 | `Reapply.check/2`: what can be reconfigured in place, and what cannot |
| 4 | #1889 | `Conversations.reapply_conversation/3`, audited, under the sandbox lock |
| 5 | #1890 | the revision at turn admission, and the live server refresh |
| 6 | #1891 | skills reconciliation, on a live reapply and on every wake |
| 7 | #1892 | `POST /api/conversations/:id/reapply` and its status-code contract |
| 8 | #1893 | the manual, Python, Elixir, Swift, and the version bump |

Merge top down. Do not `--delete-branch` while a child still points at a branch.




Part of #1565



### Queue preparation

Restacked onto current `main`. The skills implementation is unchanged (`git range-diff`); the size test passes its structural check at 2,689 lines against a 2,762-line pin. Queue before #1892 and #1893.

Validation on the restacked tip: `mix precommit` passed (5,457 core tests, 177 extension tests, zero failures); TypeScript 110, Python 44, Elixir SDK 52, and Swift 82 tests passed. OpenAPI/contract regeneration and TypeScript generation produced no drift.
