### PR TITLE
feat(api): POST /api/conversations/:id/reapply (#1565)

### DIFF
--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -1150,6 +1150,10 @@ defmodule Fountain.Conversations.ConversationServer do
         Fountain.Conversations.Identity.disk_env(sprite_env)
       )
 
+      # An agent's skills reach the existing computer on its next wake too,
+      # and a skill it no longer names is taken off the disk (#1565).
+      Reapply.mount_skills(handle, conv, agent)
+
       # Same for the agent's system prompt: an edit reaches the existing
       # computer on its next wake (#848).
       runtime = conv.runtime || (agent && agent.runtime) || "claude"

--- a/apps/fountain/lib/fountain/conversations/reapply.ex
+++ b/apps/fountain/lib/fountain/conversations/reapply.ex
@@ -247,4 +247,33 @@ defmodule Fountain.Conversations.Reapply do
       version -> version.config["skills"] || []
     end
   end
+
+  @doc """
+  Reconcile the machine's skills with the conversation's current selection,
+  then record what is now on it.
+
+  Run on every wake, not only after a live reapply: a sleeping conversation
+  whose selection changed applies it when it next comes up, and a machine
+  built before the manifest existed gets one on its first pass. The recorded
+  set is only advanced when the reconciliation succeeded, so a failed pass
+  leaves the next one the same work rather than a wrong picture of the disk.
+  """
+  @spec mount_skills(Managoat.Sandbox.Handle.t(), map(), map() | nil) :: :ok | {:error, term()}
+  def mount_skills(handle, conv, agent) do
+    # ownership: conv came from the tenant-scoped API fetch or its own server.
+    sandbox = Conversations._unsafe_get_sandbox!(conv.sandbox_id)
+    skills = (agent && agent.skills) || []
+    runtime = conv.runtime || (agent && agent.runtime) || "claude"
+
+    with :ok <-
+           Fountain.SandboxSkills.reconcile(
+             handle,
+             runtime,
+             skills,
+             sandbox.applied_skills || previous_skills(conv)
+           ),
+         {:ok, _} <- Conversations.update_sandbox(sandbox, %{applied_skills: skills}) do
+      :ok
+    end
+  end
 end

--- a/apps/fountain/lib/fountain/sandbox_skills.ex
+++ b/apps/fountain/lib/fountain/sandbox_skills.ex
@@ -14,6 +14,9 @@ defmodule Fountain.SandboxSkills do
   require Logger
 
   @bundle_root "sprite_skills"
+  # Written at the skills root: which directories each Fountain-managed skill
+  # put there, so a later reconciliation knows what it owns.
+  @manifest_name ".fountain-managed-skills"
   @fountain_skill_name "fountain"
   # Every sandbox gets these, in this order: the API skill, then the team
   # set-up Q&A (#851) — so a first teammate can answer "/create-team".
@@ -55,7 +58,212 @@ defmodule Fountain.SandboxSkills do
   end
 
   def mount(handle, runtime_module, skills) when is_atom(runtime_module) do
-    Managoat.Runtimes.Skills.install(handle, bundled() ++ (skills || []), runtime: runtime_module)
+    reconcile(handle, runtime_module, skills, [])
+  end
+
+  @doc """
+  Replace the Fountain-managed skills on a machine, leaving everything else
+  under the skills root alone (#1565).
+
+  Installing is not enough once a conversation can be reapplied. A skill the
+  agent no longer names is still on the disk, and the runtime still reads it,
+  so removing one from an agent would change nothing until the machine was
+  rebuilt. Reconciling deletes what Fountain put there and is no longer
+  selected, and only that.
+
+  Three things make "only that" true:
+
+  - **A manifest, written at the skills root.** It maps each selected skill
+    to the directory names its install produced, so a later pass knows what
+    it owns. A GitHub install without a `--skill` name decides its own
+    directory names, which is why the manifest records what appeared rather
+    than what was asked for.
+  - **`previous`, for disks written before the manifest existed.** The
+    conversation's recorded Agent version names the skills that were
+    installed, and the skills.sh source lock names the directories an unnamed
+    GitHub install produced. Anything neither can account for is left where
+    it is: an entry with no ownership record is somebody else's.
+  - **Only direct children of the skills root are ever removed**, each one
+    matched against a conservative name pattern. Neither a forged manifest
+    nor a legacy skill name can turn reconciliation into a delete somewhere
+    else on the disk.
+
+  A remote skill that is still selected keeps its directory when its
+  reinstall fails, which is what an offline machine under a restrictive
+  network policy looks like: the copy on the disk is the working one.
+  """
+  @spec reconcile(Managoat.Sandbox.Handle.t(), String.t() | module(), [map()] | nil, [map()]) ::
+          :ok | {:error, term()}
+  def reconcile(handle, runtime, skills, previous) when is_binary(runtime) do
+    case Fountain.RuntimeDispatch.for_agent(%{runtime: runtime, user_id: nil}) do
+      {:ok, module} ->
+        reconcile(handle, module, skills, previous)
+
+      {:error, reason} ->
+        Logger.warning("skills not reconciled for runtime #{runtime}: #{reason}")
+        {:error, reason}
+    end
+  end
+
+  def reconcile(handle, runtime_module, skills, previous) when is_atom(runtime_module) do
+    root = runtime_module.skills_root()
+    manifest = Path.join(root, @manifest_name)
+    selected = bundled() ++ (skills || [])
+
+    with {:ok, raw} <-
+           run(
+             handle,
+             "if [ -f #{quote_shell(manifest)} ]; then cat -- #{quote_shell(manifest)}; fi"
+           ),
+         {:ok, legacy} <- legacy_manifest(handle, previous),
+         managed = Map.merge(legacy, decode_manifest(raw)),
+         obsolete = obsolete_names(managed, selected),
+         {:ok, _} <- run(handle, remove(root, obsolete)),
+         {:ok, installed} <- install_selected(handle, runtime_module, root, selected, managed) do
+      Managoat.Sandbox.write_file(handle, manifest, Jason.encode!(installed))
+    end
+  end
+
+  # Stable across content and ref edits: a retained remote skill stays usable
+  # when its best-effort reinstall is refused by the network policy.
+  defp identity(skill), do: Jason.encode!([skill["source"], skill["name"]])
+
+  defp normalize(skills),
+    do: Enum.map(skills || [], fn s -> Map.new(s, fn {k, v} -> {to_string(k), v} end) end)
+
+  defp named_manifest(skills),
+    do: Map.new(normalize(skills), fn s -> {identity(s), names(s)} end)
+
+  # skills.sh records globally installed names by source, including installs
+  # made without --skill. Recover those on disks predating Fountain's own
+  # manifest. Format: https://github.com/vercel-labs/skills/blob/main/src/skill-lock.ts
+  defp legacy_manifest(handle, previous) do
+    unnamed = Enum.filter(normalize(previous), &(is_binary(&1["source"]) and is_nil(&1["name"])))
+
+    if unnamed == [] do
+      {:ok, named_manifest(previous)}
+    else
+      script = ~S"""
+      if [ -n "${XDG_STATE_HOME:-}" ]; then
+        skills_lock="$XDG_STATE_HOME/skills/.skill-lock.json"
+      else
+        skills_lock="$HOME/.agents/.skill-lock.json"
+      fi
+      if [ -f "$skills_lock" ]; then cat -- "$skills_lock"; fi
+      """
+
+      with {:ok, raw} <- run(handle, script) do
+        locked =
+          case Jason.decode(raw) do
+            {:ok, %{"skills" => skills}} when is_map(skills) -> skills
+            _ -> %{}
+          end
+
+        recovered =
+          Map.new(unnamed, fn entry ->
+            names =
+              Enum.flat_map(locked, fn
+                {name, %{"source" => source, "sourceType" => "github"}} ->
+                  if source == entry["source"] and safe_name?(name), do: [name], else: []
+
+                _ ->
+                  []
+              end)
+
+            {identity(entry), names}
+          end)
+
+        {:ok, Map.merge(named_manifest(previous), recovered)}
+      end
+    end
+  end
+
+  defp decode_manifest(raw) do
+    case Jason.decode(raw) do
+      {:ok, map} when is_map(map) ->
+        Map.new(map, fn {key, values} ->
+          {key, if(is_list(values), do: Enum.filter(values, &safe_name?/1), else: [])}
+        end)
+
+      _ ->
+        %{}
+    end
+  end
+
+  # A name is obsolete when it belonged to a skill that is no longer selected
+  # and no selected skill claims it. Two skills can produce the same directory
+  # name, so a retained claim always wins over a dropped one.
+  defp obsolete_names(managed, selected) do
+    wanted = named_manifest(selected)
+    retained = managed |> Map.take(Map.keys(wanted)) |> Map.values() |> List.flatten()
+    removed = managed |> Map.drop(Map.keys(wanted)) |> Map.values() |> List.flatten()
+    Enum.uniq(removed -- (retained ++ (wanted |> Map.values() |> List.flatten())))
+  end
+
+  defp install_selected(handle, runtime, root, selected, managed) do
+    {inline, remote} = Enum.split_with(normalize(selected), &is_binary(&1["content"]))
+
+    # GitHub installs first, as in the library: their blocking exec is also the
+    # readiness barrier before the sandbox accepts inline file writes.
+    Enum.reduce_while(remote ++ inline, {:ok, %{}}, fn skill, {:ok, installed} ->
+      case install_skill(handle, runtime, root, skill, managed) do
+        {:ok, names} -> {:cont, {:ok, Map.put(installed, identity(skill), names)}}
+        {:error, _} = error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp install_skill(handle, runtime, _root, %{"content" => _} = skill, _managed) do
+    with :ok <- Managoat.Runtimes.Skills.install(handle, [skill], runtime: runtime),
+         do: {:ok, names(skill)}
+  end
+
+  # A remote install names its own directories, so they are read off the disk
+  # rather than assumed. The names already recorded for this skill are kept
+  # too, so a reinstall the network refused does not make the copy on disk
+  # look unowned and get deleted on the next pass.
+  defp install_skill(handle, runtime, root, skill, managed) do
+    with {:ok, before} <- run(handle, listing(root)),
+         :ok <- Managoat.Runtimes.Skills.install(handle, [skill], runtime: runtime),
+         {:ok, after_install} <- run(handle, listing(root)) do
+      {:ok,
+       Enum.uniq(
+         (entries(after_install) -- entries(before)) ++
+           names(skill) ++ Map.get(managed, identity(skill), [])
+       )}
+    end
+  end
+
+  defp names(skill), do: if(safe_name?(skill["name"]), do: [skill["name"]], else: [])
+
+  defp safe_name?(name) when is_binary(name),
+    do: Regex.match?(~r/\A[A-Za-z0-9][A-Za-z0-9._-]*\z/, name)
+
+  defp safe_name?(_), do: false
+  defp entries(text), do: text |> String.split("\n", trim: true) |> Enum.filter(&safe_name?/1)
+
+  defp remove(root, names) do
+    "mkdir -p -- #{quote_shell(root)}\n" <>
+      Enum.map_join(names, "\n", fn name -> "rm -rf -- #{quote_shell(Path.join(root, name))}" end)
+  end
+
+  defp listing(root) do
+    """
+    for path in #{quote_shell(root)}/*; do
+      [ -e "$path" ] || [ -L "$path" ] || continue
+      basename -- "$path"
+    done
+    """
+  end
+
+  defp quote_shell(value), do: "'" <> String.replace(value, "'", "'\\''") <> "'"
+
+  defp run(handle, script) do
+    case Managoat.Sandbox.exec(handle, "bash", ["-c", script], stderr_to_stdout: true) do
+      {:ok, output, 0} -> {:ok, output}
+      {:ok, _output, code} -> {:error, "skill reconciliation exited with #{code}"}
+      {:error, reason} -> {:error, reason}
+    end
   end
 
   @doc """

--- a/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
@@ -633,6 +633,52 @@ defmodule FountainWeb.ConversationController do
     end
   end
 
+  operation(:reapply,
+    summary: "Reapply a conversation's Agent, Environment and Vault",
+    description:
+      "Applies a selection to the machine this conversation already runs on, so its files " <>
+        "stay where the agent left them. Variables, the system prompt, skills and MCP " <>
+        "configuration are rewritten, and the next prompt reads them. An omitted field keeps " <>
+        "its current selection; null clears the Environment override or the Vault; an empty " <>
+        "object reapplies what is already selected.\n\n" <>
+        "Refused with 409 `conversation_busy` while a turn runs, 409 `rebuild_required` when " <>
+        "the selection would need the machine built again (the `field` says which one forced " <>
+        "it), 503 while the machine is still being built, and 410 once the conversation has " <>
+        "ended.",
+    parameters: [conversation_id: [in: :path, type: :string, required: true]],
+    request_body:
+      {"Configuration selection", "application/json", Schemas.ConversationReapplyRequest},
+    responses: [
+      ok: {"Reapplied conversation", "application/json", Schemas.ConversationResponse},
+      forbidden:
+        {"Sprite keys may not reapply a conversation", "application/json", Schemas.Error},
+      not_found:
+        {"Conversation or selected resource not found", "application/json", Schemas.Error},
+      conflict:
+        {"The conversation has a running turn, or the selection needs the machine built again",
+         "application/json", Schemas.Error},
+      gone: {"Conversation has ended", "application/json", Schemas.Error},
+      unprocessable_entity: {"Selection is not allowed", "application/json", Schemas.Error},
+      service_unavailable: {"The machine is still being built", "application/json", Schemas.Error}
+    ]
+  )
+
+  def reapply(conn, %{"conversation_id" => id} = params) do
+    user = conn.assigns.current_user
+
+    case Conversations.get_conversation(id, user.id) do
+      nil ->
+        {:error, :not_found}
+
+      conv ->
+        # Ownership was established by the scoped fetch above.
+        with {:ok, updated} <-
+               Conversations.reapply_conversation(conv, params, Audited.attribution(conn)) do
+          render(conn, :show, conversation: updated)
+        end
+    end
+  end
+
   operation(:answer_request,
     summary: "Answer a permission request",
     description:

--- a/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
@@ -295,6 +295,37 @@ defmodule FountainWeb.FallbackController do
     })
   end
 
+  # A reapply that would need the machine built again (#1565). 409 rather than
+  # 422: the selection is valid, it just cannot be applied to the computer
+  # this conversation is already on. `field` says which one forced it, so a
+  # client can tell "your agent runs a different runtime" from "your
+  # environment installs different packages".
+  def call(conn, {:error, {:rebuild_required, field}}) do
+    conn
+    |> put_status(:conflict)
+    |> json(%{
+      error: "rebuild_required",
+      field: to_string(field),
+      message:
+        "this conversation's machine cannot be reconfigured in place because " <>
+          Fountain.Conversations.Reapply.explain(field) <>
+          "; start a new conversation, or build this one's machine again with " <>
+          "DELETE /api/sandboxes/:id"
+    })
+  end
+
+  # A conversation is reconfigured between turns, never during one. 409 and
+  # not 503: waiting does not help by itself, the caller either waits for the
+  # turn to end or interrupts it.
+  def call(conn, {:error, :conversation_busy}) do
+    conn
+    |> put_status(:conflict)
+    |> json(%{
+      error: "conversation_busy",
+      message: "the conversation has a running turn; wait for it to finish or interrupt it"
+    })
+  end
+
   # A turn refused because another conversation is running one on the same
   # sandbox and the runtime takes one at a time (ADR 0023 step 4). Not a
   # queue: the caller sends again when the other turn ends, or interrupts it.

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -599,6 +599,7 @@ defmodule FountainWeb.Router do
 
     resources "/conversations", ConversationController, only: [:index, :show, :create, :delete] do
       post "/prompts", ConversationController, :prompt, as: :prompt
+      post "/reapply", ConversationController, :reapply, as: :reapply
       post "/interrupt", ConversationController, :interrupt, as: :interrupt
       post "/terminate", ConversationController, :terminate, as: :terminate
       get "/turns", ConversationController, :turns, as: :turns

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -850,6 +850,41 @@ defmodule FountainWeb.Schemas do
     })
   end
 
+  defmodule ConversationReapplyRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "ConversationReapplyRequest",
+      description:
+        "A selection of Agent, Environment and Vault to apply to the machine an existing " <>
+          "conversation already runs on. An omitted field keeps its current selection. An " <>
+          "explicit null clears the Environment override or the Vault. An empty object " <>
+          "reapplies the current selection.",
+      type: :object,
+      properties: %{
+        agent_id: %Schema{
+          type: :string,
+          format: :uuid,
+          description: "Agent to use; omitted keeps the current Agent."
+        },
+        environment_id: %Schema{
+          type: :string,
+          format: :uuid,
+          nullable: true,
+          description:
+            "Environment override to use; null returns to the selected Agent's Environment."
+        },
+        vault_id: %Schema{
+          type: :string,
+          format: :uuid,
+          nullable: true,
+          description: "Vault to use; null detaches the current Vault."
+        }
+      }
+    })
+  end
+
   defmodule PromptRequest do
     @moduledoc false
     require OpenApiSpex

--- a/apps/fountain/test/fountain/conversations/conversation_server_refresh_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_refresh_test.exs
@@ -104,6 +104,35 @@ defmodule Fountain.Conversations.ConversationServerRefreshTest do
     GenServer.stop(pid)
   end
 
+  test "a sleeping conversation reconciles its skills on the next wake", ctx do
+    stub_happy_sprite()
+
+    {:ok, _} =
+      Conversations.update_sandbox(ctx.sandbox, %{
+        status: "suspended",
+        build_fingerprint: Fountain.Conversations.Reapply.fingerprint(ctx.env)
+      })
+
+    {:ok, conv} = Conversations.update_conversation(ctx.conv, %{status: "idle"})
+
+    skills = [%{"name" => "fresh", "content" => "Updated skill"}]
+    {:ok, _} = Fountain.Agents.update_agent(ctx.agent, %{skills: skills})
+    test = self()
+
+    Mimic.expect(Fountain.SandboxSkills, :reconcile, fn _handle, "claude", ^skills, _previous ->
+      send(test, :skills_reconciled)
+      :ok
+    end)
+
+    assert {:ok, updated} = Conversations.reapply_conversation(conv, %{})
+    {pid, _, :alive} = start_server(updated)
+
+    assert_received :skills_reconciled
+    assert Conversations._unsafe_get_sandbox!(ctx.sandbox.id).applied_skills == skills
+    assert :sys.get_state(pid).configuration_revision == updated.configuration_revision
+    GenServer.stop(pid)
+  end
+
   test "a prompt reloads configuration when the refresh notification was missed", ctx do
     stub_happy_sprite()
     {pid, _, :alive} = start_server(ctx.conv)

--- a/apps/fountain/test/fountain/conversations/conversation_server_size_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_size_test.exs
@@ -13,9 +13,16 @@ defmodule Fountain.Conversations.ConversationServerSizeTest do
   The shape is the docs-style allowlist that only shrinks (#911): the number
   is not a target, it is a record of where the file is, and the only edit it
   accepts is downward. Lower it when you move something out; never raise it.
+
+  **A stack in flight does not move it.** The pin is the length on `main`, and
+  a number measured against a branch is stale the moment any link below it
+  grows the file, which is what review rounds do. #1565 lowered it mid-stack to
+  the tip's exact length, left zero headroom, and went red two rounds later
+  when a fix four PRs down added lines. Land the shrink first, then lower the
+  pin in a follow-up, when the number has stopped moving.
   """
 
-  @pin 2716
+  @pin 2762
 
   @server "apps/fountain/lib/fountain/conversations/conversation_server.ex"
 

--- a/apps/fountain/test/fountain/conversations/conversation_server_size_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_size_test.exs
@@ -15,7 +15,7 @@ defmodule Fountain.Conversations.ConversationServerSizeTest do
   accepts is downward. Lower it when you move something out; never raise it.
   """
 
-  @pin 2762
+  @pin 2716
 
   @server "apps/fountain/lib/fountain/conversations/conversation_server.ex"
 

--- a/apps/fountain/test/fountain/sandbox_skills_test.exs
+++ b/apps/fountain/test/fountain/sandbox_skills_test.exs
@@ -27,7 +27,7 @@ defmodule Fountain.SandboxSkillsTest do
       :ok
     end)
 
-    reject(&Managoat.Sandbox.exec/4)
+    stub(Managoat.Sandbox, :exec, fn _, _, _, _ -> {:ok, "", 0} end)
 
     assert :ok = SandboxSkills.mount(@handle, "claude", [%{"name" => "mine", "content" => "# m"}])
 
@@ -48,6 +48,8 @@ defmodule Fountain.SandboxSkillsTest do
       :ok
     end)
 
+    stub(Managoat.Sandbox, :exec, fn _, _, _, _ -> {:ok, "", 0} end)
+
     assert :ok = SandboxSkills.mount(@handle, "acp", [%{"name" => "mine", "content" => "# m"}])
 
     root = Fountain.CommandRuntime.skills_root()
@@ -59,6 +61,7 @@ defmodule Fountain.SandboxSkillsTest do
   test "a module is passed straight through to the library" do
     test = self()
     stub(Managoat.Sandbox, :write_file, fn _h, path, _b -> send(test, {:wrote, path}) && :ok end)
+    stub(Managoat.Sandbox, :exec, fn _, _, _, _ -> {:ok, "", 0} end)
 
     assert :ok = SandboxSkills.mount(@handle, Fountain.CommandRuntime, nil)
     assert_receive {:wrote, "/home/sprite/.claude/skills/fountain/SKILL.md"}
@@ -78,11 +81,146 @@ defmodule Fountain.SandboxSkillsTest do
 
   test "a nil skills list mounts the bundled skills alone" do
     test = self()
+    stub(Managoat.Sandbox, :exec, fn _, _, _, _ -> {:ok, "", 0} end)
     stub(Managoat.Sandbox, :write_file, fn _h, path, _b -> send(test, {:wrote, path}) && :ok end)
 
     assert :ok = SandboxSkills.mount(@handle, "codex", nil)
     assert_receive {:wrote, "/home/sprite/.codex/skills/fountain/SKILL.md"}
     assert_receive {:wrote, "/home/sprite/.codex/skills/create-team/SKILL.md"}
+    assert_receive {:wrote, "/home/sprite/.codex/skills/.fountain-managed-skills"}
     refute_receive {:wrote, _}
+  end
+
+  defmodule DiskRuntime do
+    @moduledoc """
+    A runtime whose skills root is a real directory on this machine, so the
+    reconciliation can be measured against a filesystem rather than a mock.
+    """
+    def skills_root, do: Process.get(:skills_test_root)
+    def skills_sh_agent, do: "claude"
+  end
+
+  describe "reconciliation on disk" do
+    setup do
+      root = Fountain.TmpDir.mkdir!("fountain-skills")
+      Process.put(:skills_test_root, root)
+
+      stub(Managoat.Sandbox, :write_file, fn _, path, content ->
+        File.mkdir_p!(Path.dirname(path))
+        File.write(path, content)
+      end)
+
+      stub(Managoat.Sandbox, :exec, fn _, "bash", args, _ ->
+        {output, code} = System.cmd("bash", args, stderr_to_stdout: true)
+        {:ok, output, code}
+      end)
+
+      %{root: root}
+    end
+
+    test "removes an obsolete inline skill while preserving unrelated files", %{root: root} do
+      File.mkdir_p!(Path.join(root, "personal"))
+      File.write!(Path.join(root, "personal/SKILL.md"), "My local skill")
+
+      assert :ok =
+               SandboxSkills.mount(@handle, DiskRuntime, [
+                 %{"name" => "old", "content" => "Old skill"}
+               ])
+
+      assert :ok =
+               SandboxSkills.mount(@handle, DiskRuntime, [
+                 %{"name" => "new", "content" => "New skill"}
+               ])
+
+      refute File.exists?(Path.join(root, "old"))
+      assert File.read!(Path.join(root, "new/SKILL.md")) == "New skill"
+      # Not Fountain's, so not Fountain's to delete.
+      assert File.read!(Path.join(root, "personal/SKILL.md")) == "My local skill"
+      assert File.exists?(Path.join(root, "fountain/SKILL.md"))
+    end
+
+    test "seeds legacy named skills and ignores unsafe manifest paths", %{root: root} do
+      File.mkdir_p!(Path.join(root, "legacy"))
+      File.write!(Path.join(root, "legacy/SKILL.md"), "Old skill")
+      File.write!(Path.join(root, ".fountain-managed-skills"), "..\n../outside\n/absolute\n")
+
+      assert :ok =
+               SandboxSkills.reconcile(@handle, DiskRuntime, [], [
+                 %{"name" => "legacy", "content" => "Old skill"}
+               ])
+
+      refute File.exists?(Path.join(root, "legacy"))
+      # A manifest naming anything but a direct child removes nothing.
+      assert File.dir?(root)
+    end
+
+    test "recovers unnamed legacy GitHub skills from the source lock", %{root: root} do
+      File.mkdir_p!(Path.join(root, "legacy-remote"))
+      File.write!(Path.join(root, "legacy-remote/SKILL.md"), "Old remote skill")
+      File.mkdir_p!(Path.join(root, "unrelated"))
+
+      stub(Managoat.Sandbox, :exec, fn _, "bash", args, _ ->
+        if Enum.any?(args, &String.contains?(&1, "skills_lock=")) do
+          {:ok,
+           Jason.encode!(%{
+             "skills" => %{
+               "legacy-remote" => %{"source" => "owner/repo", "sourceType" => "github"},
+               "unrelated" => %{"source" => "another/repo", "sourceType" => "github"}
+             }
+           }), 0}
+        else
+          {output, code} = System.cmd("bash", args, stderr_to_stdout: true)
+          {:ok, output, code}
+        end
+      end)
+
+      assert :ok =
+               SandboxSkills.reconcile(@handle, DiskRuntime, [], [%{"source" => "owner/repo"}])
+
+      refute File.exists?(Path.join(root, "legacy-remote"))
+      # Installed from a source this conversation never named.
+      assert File.dir?(Path.join(root, "unrelated"))
+    end
+
+    test "a retained remote skill survives an offline reinstall", %{root: root} do
+      skill = %{"source" => "owner/repo", "name" => "remote"}
+      File.mkdir_p!(Path.join(root, "remote"))
+      File.write!(Path.join(root, "remote/SKILL.md"), "Already installed")
+
+      stub(Managoat.Sandbox, :exec, fn _, "bash", args, _ ->
+        case args do
+          ["-lc", "npx " <> _] ->
+            {:ok, "offline", 1}
+
+          _ ->
+            {output, code} = System.cmd("bash", args, stderr_to_stdout: true)
+            {:ok, output, code}
+        end
+      end)
+
+      assert :ok = SandboxSkills.reconcile(@handle, DiskRuntime, [skill], [skill])
+      assert File.read!(Path.join(root, "remote/SKILL.md")) == "Already installed"
+    end
+
+    test "tracks discovered GitHub skill names for a later removal", %{root: root} do
+      stub(Managoat.Sandbox, :exec, fn _, "bash", args, _ ->
+        case args do
+          ["-lc", "npx " <> _] ->
+            File.mkdir_p!(Path.join(root, "discovered"))
+            File.write!(Path.join(root, "discovered/SKILL.md"), "Remote skill")
+            {:ok, "", 0}
+
+          _ ->
+            {output, code} = System.cmd("bash", args, stderr_to_stdout: true)
+            {:ok, output, code}
+        end
+      end)
+
+      assert :ok = SandboxSkills.mount(@handle, DiskRuntime, [%{"source" => "owner/repo"}])
+      assert File.read!(Path.join(root, ".fountain-managed-skills")) =~ "discovered"
+
+      assert :ok = SandboxSkills.mount(@handle, DiskRuntime, [])
+      refute File.exists?(Path.join(root, "discovered"))
+    end
   end
 end

--- a/apps/fountain/test/fountain_web/controllers/conversation_reapply_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/conversation_reapply_controller_test.exs
@@ -1,0 +1,161 @@
+defmodule FountainWeb.ConversationReapplyControllerTest do
+  @moduledoc """
+  `POST /api/conversations/:id/reapply` and its status-code contract (#1565).
+
+  Four refusals, four different meanings: 409 for a conversation mid-turn,
+  409 with a `field` for a selection the machine cannot be reconfigured into,
+  503 while the machine is still being built, and 410 once the conversation
+  has ended.
+  """
+
+  use FountainWeb.ConnCase, async: true
+
+  alias Fountain.{Agents, Conversations}
+  alias Fountain.Conversations.Reapply
+
+  setup do
+    user = insert_active_user()
+    {_key, raw_key} = insert_api_key(user)
+    env = insert_env(user_id: user.id)
+    vault = insert_vault(user_id: user.id)
+
+    agent =
+      insert_agent(
+        user_id: user.id,
+        runtime: "claude",
+        environment_id: env.id,
+        allowed_vault_ids: [vault.id]
+      )
+
+    sandbox =
+      insert_sandbox(
+        user_id: user.id,
+        status: "ready",
+        agent_id: agent.id,
+        environment_id: env.id,
+        vault_id: vault.id,
+        build_fingerprint: Reapply.fingerprint(env)
+      )
+
+    conv =
+      insert_conversation(
+        user_id: user.id,
+        agent: agent,
+        agent_version_id: Agents._unsafe_current_version_id(agent.id),
+        sandbox: sandbox,
+        vault_id: vault.id,
+        runtime_session_id: "old-session",
+        status: "idle"
+      )
+
+    {:ok,
+     user: user,
+     raw_key: raw_key,
+     agent: agent,
+     env: env,
+     vault: vault,
+     sandbox: sandbox,
+     conv: conv}
+  end
+
+  defp reapply(ctx, body, conv \\ nil) do
+    ctx.conn
+    |> authed_with_key(ctx.raw_key)
+    |> post_json("/api/conversations/#{(conv || ctx.conv).id}/reapply", body)
+  end
+
+  test "200 keeps the thread and clears explicit nulls", ctx do
+    response =
+      ctx
+      |> reapply(%{"vault_id" => nil})
+      |> json_response(200)
+      |> Map.fetch!("data")
+
+    assert response["id"] == ctx.conv.id
+    assert response["agent_id"] == ctx.agent.id
+    assert response["vault_id"] == nil
+    assert response["sandbox_id"] == ctx.conv.sandbox_id
+
+    # The machine survives, so the runtime session on its disk is still
+    # resumable and the agent keeps its memory of this thread.
+    assert response["runtime_session_id"] == "old-session"
+
+    [audit] =
+      Fountain.Audit.list_for_user(ctx.user.id)
+      |> Enum.filter(&(&1.action == "conversation.configuration_reapplied"))
+
+    assert audit.actor == "api"
+  end
+
+  test "an empty body reapplies the current selection", ctx do
+    response = ctx |> reapply(%{}) |> json_response(200) |> Map.fetch!("data")
+    assert response["agent_id"] == ctx.agent.id
+    assert response["vault_id"] == ctx.vault.id
+  end
+
+  test "404 for another tenant's conversation", ctx do
+    other = insert_active_user()
+    theirs = insert_conversation(user_id: other.id, status: "idle")
+
+    assert %{"error" => "not_found"} =
+             ctx |> reapply(%{}, theirs) |> json_response(404)
+  end
+
+  test "409 conversation_busy leaves a conversation mid-turn unchanged", ctx do
+    insert_turn(ctx.conv, status: "running")
+
+    assert %{"error" => "conversation_busy", "message" => message} =
+             ctx |> reapply(%{}) |> json_response(409)
+
+    assert message =~ "running turn"
+    assert Conversations._unsafe_get_conversation!(ctx.conv.id).configuration_revision == 0
+  end
+
+  test "409 rebuild_required names the field that forced it", ctx do
+    codex = insert_agent(user_id: ctx.user.id, runtime: "codex", environment_id: ctx.env.id)
+
+    body =
+      ctx
+      |> reapply(%{"agent_id" => codex.id, "vault_id" => nil})
+      |> json_response(409)
+
+    assert body["error"] == "rebuild_required"
+    assert body["field"] == "runtime"
+    assert body["message"] =~ "different runtime"
+    assert body["message"] =~ "DELETE /api/sandboxes/:id"
+    assert Conversations._unsafe_get_conversation!(ctx.conv.id).agent_id == ctx.agent.id
+  end
+
+  test "503 while the machine is still being built", ctx do
+    {:ok, _} = Conversations.update_sandbox(ctx.sandbox, %{status: "starting"})
+    {:ok, _} = Conversations.update_conversation(ctx.conv, %{status: "pending"})
+
+    conn = reapply(ctx, %{})
+    assert %{"error" => "provisioning"} = json_response(conn, 503)
+    assert get_resp_header(conn, "retry-after") == ["30"]
+  end
+
+  test "410 once the conversation has ended", ctx do
+    {:ok, _} = Conversations.update_conversation(ctx.conv, %{status: "terminated"})
+
+    assert %{"error" => "conversation_terminated"} =
+             ctx |> reapply(%{}) |> json_response(410)
+  end
+
+  test "422 for a selection the agent's allowlist forbids", ctx do
+    locked =
+      insert_agent(
+        user_id: ctx.user.id,
+        runtime: "claude",
+        environment_id: ctx.env.id,
+        allowed_vault_ids: []
+      )
+
+    other_vault = insert_vault(user_id: ctx.user.id)
+
+    assert %{"error" => "vault_not_allowed"} =
+             ctx
+             |> reapply(%{"agent_id" => locked.id, "vault_id" => other_vault.id})
+             |> json_response(422)
+  end
+end

--- a/apps/fountain/test/support/conversation_server_case.ex
+++ b/apps/fountain/test/support/conversation_server_case.ex
@@ -77,6 +77,10 @@ defmodule Fountain.ConversationServerCase do
 
     Mimic.stub(Fountain.SandboxSkills, :mount, fn _handle, _runtime, _skills -> :ok end)
 
+    Mimic.stub(Fountain.SandboxSkills, :reconcile, fn _handle, _runtime, _skills, _previous ->
+      :ok
+    end)
+
     Mimic.stub(Fountain.Conversations.Provisioning, :write_env_file, fn _s, _e -> :ok end)
 
     Mimic.stub(Fountain.Conversations.Provisioning, :install_packages, fn _s, _e, _se, _c ->

--- a/sdk/contract/contract.json
+++ b/sdk/contract/contract.json
@@ -6266,6 +6266,72 @@
         }
       }
     },
+    "POST /api/conversations/{conversation_id}/reapply": {
+      "operation_id": "FountainWeb.ConversationController.reapply",
+      "path_params": [
+        "conversation_id"
+      ],
+      "request_body": {
+        "content": {
+          "application/json": {
+            "ref": "ConversationReapplyRequest"
+          }
+        },
+        "required": false
+      },
+      "responses": {
+        "200": {
+          "application/json": {
+            "ref": "ConversationResponse"
+          }
+        },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "409": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "410": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "422": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "503": {
+          "application/json": {
+            "ref": "Error"
+          }
+        }
+      }
+    },
     "POST /api/conversations/{conversation_id}/requests/{request_id}": {
       "operation_id": "FountainWeb.ConversationController.answer_request",
       "path_params": [
@@ -10761,6 +10827,28 @@
           },
           "required": true,
           "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "ConversationReapplyRequest": {
+      "properties": {
+        "agent_id": {
+          "format": "uuid",
+          "required": false,
+          "type": "string"
+        },
+        "environment_id": {
+          "format": "uuid",
+          "nullable": true,
+          "required": false,
+          "type": "string"
+        },
+        "vault_id": {
+          "format": "uuid",
+          "nullable": true,
+          "required": false,
+          "type": "string"
         }
       },
       "type": "object"

--- a/sdk/contract/manifests/typescript.json
+++ b/sdk/contract/manifests/typescript.json
@@ -67,6 +67,7 @@
     "POST /api/conversations/{conversation_id}/interrupt",
     "POST /api/conversations/{conversation_id}/prompts",
     "POST /api/conversations/{conversation_id}/read",
+    "POST /api/conversations/{conversation_id}/reapply",
     "POST /api/conversations/{conversation_id}/requests/{request_id}",
     "POST /api/conversations/{conversation_id}/terminate",
     "POST /api/environments",

--- a/sdk/typescript/src/conversation.ts
+++ b/sdk/typescript/src/conversation.ts
@@ -9,6 +9,15 @@ export interface SendOptions extends RunOptions {
   images?: unknown[];
 }
 
+export interface ReapplyOptions {
+  /** Change the agent; omit to keep the current one. */
+  agentId?: string;
+  /** Change the environment, pass null to clear it, or omit it to keep it. */
+  environmentId?: string | null;
+  /** Change the vault, pass null to clear it, or omit it to keep it. */
+  vaultId?: string | null;
+}
+
 /**
  * A conversation you already have — the sandbox is still there, and so is
  * everything the agent learned in it.
@@ -167,6 +176,23 @@ export class Conversation {
   /** The conversations this one spawned, as a tree. */
   async tree(): Promise<unknown> {
     return this.http.data("GET", `/api/conversations/${this.id}/tree`);
+  }
+
+  /**
+   * Re-select this conversation's agent, environment and vault on the machine
+   * it is already running. The conversation, the transcript and the files on
+   * disk all stay; the next prompt starts a runtime that reads the new
+   * selection. Call it with nothing to refresh what is already selected.
+   *
+   * A selection that would need the machine built again is refused with 409
+   * `rebuild_required`, naming the field that forced it.
+   */
+  async reapply(options: ReapplyOptions = {}): Promise<ConversationRecord> {
+    const body: Record<string, unknown> = {};
+    if (options.agentId !== undefined) body.agent_id = options.agentId;
+    if (options.environmentId !== undefined) body.environment_id = options.environmentId;
+    if (options.vaultId !== undefined) body.vault_id = options.vaultId;
+    return this.http.data("POST", `/api/conversations/${this.id}/reapply`, { body });
   }
 
   /** Ask the agent to stop the turn it is on. The sandbox stays up. */

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -1293,6 +1293,28 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/conversations/{conversation_id}/reapply": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Reapply a conversation's Agent, Environment and Vault
+         * @description Applies a selection to the machine this conversation already runs on, so its files stay where the agent left them. Variables, the system prompt, skills and MCP configuration are rewritten, and the next prompt reads them. An omitted field keeps its current selection; null clears the Environment override or the Vault; an empty object reapplies what is already selected.
+         *
+         *     Refused with 409 `conversation_busy` while a turn runs, 409 `rebuild_required` when the selection would need the machine built again (the `field` says which one forced it), 503 while the machine is still being built, and 410 once the conversation has ended.
+         */
+        post: operations["FountainWeb.ConversationController.reapply"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/conversations/{conversation_id}/requests/{request_id}": {
         parameters: {
             query?: never;
@@ -3768,6 +3790,27 @@ export interface components {
         /** ConversationListResponse */
         ConversationListResponse: {
             data: components["schemas"]["Conversation"][];
+        };
+        /**
+         * ConversationReapplyRequest
+         * @description A selection of Agent, Environment and Vault to apply to the machine an existing conversation already runs on. An omitted field keeps its current selection. An explicit null clears the Environment override or the Vault. An empty object reapplies the current selection.
+         */
+        ConversationReapplyRequest: {
+            /**
+             * Format: uuid
+             * @description Agent to use; omitted keeps the current Agent.
+             */
+            agent_id?: string;
+            /**
+             * Format: uuid
+             * @description Environment override to use; null returns to the selected Agent's Environment.
+             */
+            environment_id?: string | null;
+            /**
+             * Format: uuid
+             * @description Vault to use; null detaches the current Vault.
+             */
+            vault_id?: string | null;
         };
         /** ConversationResponse */
         ConversationResponse: {
@@ -11143,6 +11186,114 @@ export interface operations {
             };
             /** @description Too Many Requests */
             429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    "FountainWeb.ConversationController.reapply": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                conversation_id: string;
+            };
+            cookie?: never;
+        };
+        /** @description Configuration selection */
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["ConversationReapplyRequest"];
+            };
+        };
+        responses: {
+            /** @description Reapplied conversation */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ConversationResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Sprite keys may not reapply a conversation */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Conversation or selected resource not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description The conversation has a running turn, or the selection needs the machine built again */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Conversation has ended */
+            410: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Selection is not allowed */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description The machine is still being built */
+            503: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -1,6 +1,6 @@
 export { Fountain, type FountainOptions, type RunConfig } from "./client.ts";
 export { Run, type RunOptions } from "./run.ts";
-export { Conversation, type SendOptions } from "./conversation.ts";
+export { Conversation, type ReapplyOptions, type SendOptions } from "./conversation.ts";
 export { HttpClient, type FetchLike, type RequestOptions } from "./http.ts";
 export { Agents, ConnectionProviders, Connections, Environments, Vaults } from "./resources.ts";
 export { Team, TeamSchedules, type MessageOptions } from "./team.ts";

--- a/sdk/typescript/test/run.test.ts
+++ b/sdk/typescript/test/run.test.ts
@@ -451,6 +451,24 @@ describe("errors", () => {
     });
   });
 
+  // Omitted means "keep it", null means "clear it", and the two have to stay
+  // distinguishable all the way to the wire.
+  test("reapply sends only the fields it was given, null included", async () => {
+    fake.onTurn = (conversation, turnNumber) => {
+      fake.scriptTurn(conversation.id, { turnNumber, turnId: "t1", text: ["ok"] });
+    };
+    const run = client().run("go", { agent: "reposage" });
+    const id = await run.conversationId;
+    await run;
+
+    await client().resume(id).reapply();
+    assert.deepEqual(fake.reapplies.at(-1)?.body, {});
+
+    const updated = await client().resume(id).reapply({ agentId: "agent-2", vaultId: null });
+    assert.deepEqual(fake.reapplies.at(-1)?.body, { agent_id: "agent-2", vault_id: null });
+    assert.equal((updated as { vault_id?: unknown }).vault_id, null);
+  });
+
   test("a missing key fails before any request", async () => {
     const bare = new Fountain({ baseUrl, apiKey: "", profile: "no-such-profile" });
     await assert.rejects(() => bare.me(), /No Fountain API key/);

--- a/sdk/typescript/test/server.ts
+++ b/sdk/typescript/test/server.ts
@@ -125,6 +125,8 @@ export class FakeFountain {
   readonly busyTeammates = new Set<string>();
   /** Every permission answer that arrived, in order. */
   readonly answers: { conversationId: string; requestId: string; optionId: string }[] = [];
+  /** Every reapply body the server was sent, in order. */
+  readonly reapplies: { conversationId: string; body: Record<string, unknown> }[] = [];
   /** Called when one lands — script the rest of the held turn from here. */
   onAnswer: ((conversationId: string, requestId: string, optionId: string) => void) | null = null;
 
@@ -360,6 +362,11 @@ export class FakeFountain {
 
       if (rest === "/interrupt" || rest === "/terminate") return json(res, 200, { status: "ok" });
       if (rest === "/read" && req.method === "POST") return json(res, 204, null);
+      if (rest === "/reapply" && req.method === "POST") {
+        const selection = (body ?? {}) as Record<string, unknown>;
+        this.reapplies.push({ conversationId: conversation.id, body: selection });
+        return json(res, 200, { data: { ...summary(conversation), ...selection } });
+      }
       if (rest === "/tree") return json(res, 200, { data: { id: conversation.id, children: [] } });
       if (rest === "/events") return this.eventPage(res, conversation, url);
       if (rest === "/stream") return this.stream(req, res, conversation, url);


### PR DESCRIPTION
The door onto the context function the stack has been building. An empty body reapplies the current selection; `agent_id`, `environment_id` and `vault_id` change one each; an omitted field keeps what is selected and an explicit null clears the Environment override or the Vault.

## The status codes

This is the decision worth reviewing on its own, because four different things can go wrong and they mean four different things to a client.

| Status | Body | When | Why not something else |
|---|---|---|---|
| `409` | `conversation_busy` | a turn is running | not 503: waiting does not help by itself, the caller waits for the turn to end or interrupts it |
| `409` | `rebuild_required` + `field` | the machine cannot be reconfigured into this selection | not 422: nothing about the request is malformed, the selection is perfectly valid |
| `503` | `provisioning` + `Retry-After` | the machine is still being built | here retrying is exactly right, which is why it is not one of the 409s |
| `410` | `conversation_terminated` | the conversation has ended | the id was real and there is nothing to come back for |

422 keeps its usual meaning: a selection the agent's allowlists forbid.

The `field` on `rebuild_required` is what lets a client say "your agent runs a different runtime" rather than "something needs a rebuild", and the message names the two ways forward (a new conversation, or `DELETE /api/sandboxes/:id`).

Both new refusals live in `FallbackController` rather than the controller, because `:conversation_busy` is a fact about a conversation that other doors will want to report the same way.

## Gates

The operation declares every status it can render, 403 included. The contract and the TypeScript types are regenerated, never hand-edited. `Conversation.reapply()` is the hand-written method that claims the operation so `scripts/sdk-contract/build.sh --check` passes; its test asserts the one thing types cannot, that an omitted field and an explicit null reach the wire differently.

**This PR changes `sdk/typescript/src/generated/openapi.ts` without bumping the version, so it carries `sdk-no-release`.** The bump is #1893.

Part 7 of 8 for #1565, on #1891.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9jevFQT5MkF3rJUieeiHW


---

### The stack (#1565, re-cut from #1569)

| | PR | What it covers |
|---|---|---|
| 1 | #1886 | server subtraction, no behaviour change, room for the rest |
| 2 | #1887 | the revision, build-fingerprint and applied-skills columns |
| 3 | #1888 | `Reapply.check/2`: what can be reconfigured in place, and what cannot |
| 4 | #1889 | `Conversations.reapply_conversation/3`, audited, under the sandbox lock |
| 5 | #1890 | the revision at turn admission, and the live server refresh |
| 6 | #1891 | skills reconciliation, on a live reapply and on every wake |
| 7 | #1892 | `POST /api/conversations/:id/reapply` and its status-code contract |
| 8 | #1893 | the manual, Python, Elixir, Swift, and the version bump |

Merge top down. Do not `--delete-branch` while a child still points at a branch.




Part of #1565



### Queue preparation

Targets `main` for the merge queue and retains #1891 as its ancestor. Queue after #1891 and before #1893. The API patch is unchanged by the restack (`git range-diff`); generated OpenAPI and contract artifacts match regeneration against the updated server.

Validation on the restacked tip: `mix precommit` passed (5,457 core tests, 177 extension tests, zero failures); TypeScript 110, Python 44, Elixir SDK 52, and Swift 82 tests passed. OpenAPI/contract regeneration and TypeScript generation produced no drift.
