### PR TITLE
docs: reapply a conversation's configuration, and the four SDKs (#1565)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,16 @@ upgrade, is in
   Connections off is the broker: an account is offered the feature only while
   `BROKER_TENANTS` names it.
 
+### Added
+
+- `POST /api/conversations/:id/reapply` re-selects a conversation's Agent,
+  Environment and Vault on the machine it is already running, keeping the
+  conversation, its transcript and the files on its disk. A selection that would
+  need the machine built again is refused, naming what forced it. Adds the
+  `configuration` webhook stage and three columns
+  (`conversations.configuration_revision`, `sandboxes.build_fingerprint`,
+  `sandboxes.applied_skills`) (#1565).
+
 ### Changed
 
 - **The claude runtime's ACP adapter moves to 0.75.1, and a fresh sandbox now

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -1150,6 +1150,10 @@ defmodule Fountain.Conversations.ConversationServer do
         Fountain.Conversations.Identity.disk_env(sprite_env)
       )
 
+      # An agent's skills reach the existing computer on its next wake too,
+      # and a skill it no longer names is taken off the disk (#1565).
+      Reapply.mount_skills(handle, conv, agent)
+
       # Same for the agent's system prompt: an edit reaches the existing
       # computer on its next wake (#848).
       runtime = conv.runtime || (agent && agent.runtime) || "claude"

--- a/apps/fountain/lib/fountain/conversations/reapply.ex
+++ b/apps/fountain/lib/fountain/conversations/reapply.ex
@@ -247,4 +247,33 @@ defmodule Fountain.Conversations.Reapply do
       version -> version.config["skills"] || []
     end
   end
+
+  @doc """
+  Reconcile the machine's skills with the conversation's current selection,
+  then record what is now on it.
+
+  Run on every wake, not only after a live reapply: a sleeping conversation
+  whose selection changed applies it when it next comes up, and a machine
+  built before the manifest existed gets one on its first pass. The recorded
+  set is only advanced when the reconciliation succeeded, so a failed pass
+  leaves the next one the same work rather than a wrong picture of the disk.
+  """
+  @spec mount_skills(Managoat.Sandbox.Handle.t(), map(), map() | nil) :: :ok | {:error, term()}
+  def mount_skills(handle, conv, agent) do
+    # ownership: conv came from the tenant-scoped API fetch or its own server.
+    sandbox = Conversations._unsafe_get_sandbox!(conv.sandbox_id)
+    skills = (agent && agent.skills) || []
+    runtime = conv.runtime || (agent && agent.runtime) || "claude"
+
+    with :ok <-
+           Fountain.SandboxSkills.reconcile(
+             handle,
+             runtime,
+             skills,
+             sandbox.applied_skills || previous_skills(conv)
+           ),
+         {:ok, _} <- Conversations.update_sandbox(sandbox, %{applied_skills: skills}) do
+      :ok
+    end
+  end
 end

--- a/apps/fountain/lib/fountain/sandbox_skills.ex
+++ b/apps/fountain/lib/fountain/sandbox_skills.ex
@@ -14,6 +14,9 @@ defmodule Fountain.SandboxSkills do
   require Logger
 
   @bundle_root "sprite_skills"
+  # Written at the skills root: which directories each Fountain-managed skill
+  # put there, so a later reconciliation knows what it owns.
+  @manifest_name ".fountain-managed-skills"
   @fountain_skill_name "fountain"
   # Every sandbox gets these, in this order: the API skill, then the team
   # set-up Q&A (#851) — so a first teammate can answer "/create-team".
@@ -55,7 +58,212 @@ defmodule Fountain.SandboxSkills do
   end
 
   def mount(handle, runtime_module, skills) when is_atom(runtime_module) do
-    Managoat.Runtimes.Skills.install(handle, bundled() ++ (skills || []), runtime: runtime_module)
+    reconcile(handle, runtime_module, skills, [])
+  end
+
+  @doc """
+  Replace the Fountain-managed skills on a machine, leaving everything else
+  under the skills root alone (#1565).
+
+  Installing is not enough once a conversation can be reapplied. A skill the
+  agent no longer names is still on the disk, and the runtime still reads it,
+  so removing one from an agent would change nothing until the machine was
+  rebuilt. Reconciling deletes what Fountain put there and is no longer
+  selected, and only that.
+
+  Three things make "only that" true:
+
+  - **A manifest, written at the skills root.** It maps each selected skill
+    to the directory names its install produced, so a later pass knows what
+    it owns. A GitHub install without a `--skill` name decides its own
+    directory names, which is why the manifest records what appeared rather
+    than what was asked for.
+  - **`previous`, for disks written before the manifest existed.** The
+    conversation's recorded Agent version names the skills that were
+    installed, and the skills.sh source lock names the directories an unnamed
+    GitHub install produced. Anything neither can account for is left where
+    it is: an entry with no ownership record is somebody else's.
+  - **Only direct children of the skills root are ever removed**, each one
+    matched against a conservative name pattern. Neither a forged manifest
+    nor a legacy skill name can turn reconciliation into a delete somewhere
+    else on the disk.
+
+  A remote skill that is still selected keeps its directory when its
+  reinstall fails, which is what an offline machine under a restrictive
+  network policy looks like: the copy on the disk is the working one.
+  """
+  @spec reconcile(Managoat.Sandbox.Handle.t(), String.t() | module(), [map()] | nil, [map()]) ::
+          :ok | {:error, term()}
+  def reconcile(handle, runtime, skills, previous) when is_binary(runtime) do
+    case Fountain.RuntimeDispatch.for_agent(%{runtime: runtime, user_id: nil}) do
+      {:ok, module} ->
+        reconcile(handle, module, skills, previous)
+
+      {:error, reason} ->
+        Logger.warning("skills not reconciled for runtime #{runtime}: #{reason}")
+        {:error, reason}
+    end
+  end
+
+  def reconcile(handle, runtime_module, skills, previous) when is_atom(runtime_module) do
+    root = runtime_module.skills_root()
+    manifest = Path.join(root, @manifest_name)
+    selected = bundled() ++ (skills || [])
+
+    with {:ok, raw} <-
+           run(
+             handle,
+             "if [ -f #{quote_shell(manifest)} ]; then cat -- #{quote_shell(manifest)}; fi"
+           ),
+         {:ok, legacy} <- legacy_manifest(handle, previous),
+         managed = Map.merge(legacy, decode_manifest(raw)),
+         obsolete = obsolete_names(managed, selected),
+         {:ok, _} <- run(handle, remove(root, obsolete)),
+         {:ok, installed} <- install_selected(handle, runtime_module, root, selected, managed) do
+      Managoat.Sandbox.write_file(handle, manifest, Jason.encode!(installed))
+    end
+  end
+
+  # Stable across content and ref edits: a retained remote skill stays usable
+  # when its best-effort reinstall is refused by the network policy.
+  defp identity(skill), do: Jason.encode!([skill["source"], skill["name"]])
+
+  defp normalize(skills),
+    do: Enum.map(skills || [], fn s -> Map.new(s, fn {k, v} -> {to_string(k), v} end) end)
+
+  defp named_manifest(skills),
+    do: Map.new(normalize(skills), fn s -> {identity(s), names(s)} end)
+
+  # skills.sh records globally installed names by source, including installs
+  # made without --skill. Recover those on disks predating Fountain's own
+  # manifest. Format: https://github.com/vercel-labs/skills/blob/main/src/skill-lock.ts
+  defp legacy_manifest(handle, previous) do
+    unnamed = Enum.filter(normalize(previous), &(is_binary(&1["source"]) and is_nil(&1["name"])))
+
+    if unnamed == [] do
+      {:ok, named_manifest(previous)}
+    else
+      script = ~S"""
+      if [ -n "${XDG_STATE_HOME:-}" ]; then
+        skills_lock="$XDG_STATE_HOME/skills/.skill-lock.json"
+      else
+        skills_lock="$HOME/.agents/.skill-lock.json"
+      fi
+      if [ -f "$skills_lock" ]; then cat -- "$skills_lock"; fi
+      """
+
+      with {:ok, raw} <- run(handle, script) do
+        locked =
+          case Jason.decode(raw) do
+            {:ok, %{"skills" => skills}} when is_map(skills) -> skills
+            _ -> %{}
+          end
+
+        recovered =
+          Map.new(unnamed, fn entry ->
+            names =
+              Enum.flat_map(locked, fn
+                {name, %{"source" => source, "sourceType" => "github"}} ->
+                  if source == entry["source"] and safe_name?(name), do: [name], else: []
+
+                _ ->
+                  []
+              end)
+
+            {identity(entry), names}
+          end)
+
+        {:ok, Map.merge(named_manifest(previous), recovered)}
+      end
+    end
+  end
+
+  defp decode_manifest(raw) do
+    case Jason.decode(raw) do
+      {:ok, map} when is_map(map) ->
+        Map.new(map, fn {key, values} ->
+          {key, if(is_list(values), do: Enum.filter(values, &safe_name?/1), else: [])}
+        end)
+
+      _ ->
+        %{}
+    end
+  end
+
+  # A name is obsolete when it belonged to a skill that is no longer selected
+  # and no selected skill claims it. Two skills can produce the same directory
+  # name, so a retained claim always wins over a dropped one.
+  defp obsolete_names(managed, selected) do
+    wanted = named_manifest(selected)
+    retained = managed |> Map.take(Map.keys(wanted)) |> Map.values() |> List.flatten()
+    removed = managed |> Map.drop(Map.keys(wanted)) |> Map.values() |> List.flatten()
+    Enum.uniq(removed -- (retained ++ (wanted |> Map.values() |> List.flatten())))
+  end
+
+  defp install_selected(handle, runtime, root, selected, managed) do
+    {inline, remote} = Enum.split_with(normalize(selected), &is_binary(&1["content"]))
+
+    # GitHub installs first, as in the library: their blocking exec is also the
+    # readiness barrier before the sandbox accepts inline file writes.
+    Enum.reduce_while(remote ++ inline, {:ok, %{}}, fn skill, {:ok, installed} ->
+      case install_skill(handle, runtime, root, skill, managed) do
+        {:ok, names} -> {:cont, {:ok, Map.put(installed, identity(skill), names)}}
+        {:error, _} = error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp install_skill(handle, runtime, _root, %{"content" => _} = skill, _managed) do
+    with :ok <- Managoat.Runtimes.Skills.install(handle, [skill], runtime: runtime),
+         do: {:ok, names(skill)}
+  end
+
+  # A remote install names its own directories, so they are read off the disk
+  # rather than assumed. The names already recorded for this skill are kept
+  # too, so a reinstall the network refused does not make the copy on disk
+  # look unowned and get deleted on the next pass.
+  defp install_skill(handle, runtime, root, skill, managed) do
+    with {:ok, before} <- run(handle, listing(root)),
+         :ok <- Managoat.Runtimes.Skills.install(handle, [skill], runtime: runtime),
+         {:ok, after_install} <- run(handle, listing(root)) do
+      {:ok,
+       Enum.uniq(
+         (entries(after_install) -- entries(before)) ++
+           names(skill) ++ Map.get(managed, identity(skill), [])
+       )}
+    end
+  end
+
+  defp names(skill), do: if(safe_name?(skill["name"]), do: [skill["name"]], else: [])
+
+  defp safe_name?(name) when is_binary(name),
+    do: Regex.match?(~r/\A[A-Za-z0-9][A-Za-z0-9._-]*\z/, name)
+
+  defp safe_name?(_), do: false
+  defp entries(text), do: text |> String.split("\n", trim: true) |> Enum.filter(&safe_name?/1)
+
+  defp remove(root, names) do
+    "mkdir -p -- #{quote_shell(root)}\n" <>
+      Enum.map_join(names, "\n", fn name -> "rm -rf -- #{quote_shell(Path.join(root, name))}" end)
+  end
+
+  defp listing(root) do
+    """
+    for path in #{quote_shell(root)}/*; do
+      [ -e "$path" ] || [ -L "$path" ] || continue
+      basename -- "$path"
+    done
+    """
+  end
+
+  defp quote_shell(value), do: "'" <> String.replace(value, "'", "'\\''") <> "'"
+
+  defp run(handle, script) do
+    case Managoat.Sandbox.exec(handle, "bash", ["-c", script], stderr_to_stdout: true) do
+      {:ok, output, 0} -> {:ok, output}
+      {:ok, _output, code} -> {:error, "skill reconciliation exited with #{code}"}
+      {:error, reason} -> {:error, reason}
+    end
   end
 
   @doc """

--- a/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_controller.ex
@@ -633,6 +633,52 @@ defmodule FountainWeb.ConversationController do
     end
   end
 
+  operation(:reapply,
+    summary: "Reapply a conversation's Agent, Environment and Vault",
+    description:
+      "Applies a selection to the machine this conversation already runs on, so its files " <>
+        "stay where the agent left them. Variables, the system prompt, skills and MCP " <>
+        "configuration are rewritten, and the next prompt reads them. An omitted field keeps " <>
+        "its current selection; null clears the Environment override or the Vault; an empty " <>
+        "object reapplies what is already selected.\n\n" <>
+        "Refused with 409 `conversation_busy` while a turn runs, 409 `rebuild_required` when " <>
+        "the selection would need the machine built again (the `field` says which one forced " <>
+        "it), 503 while the machine is still being built, and 410 once the conversation has " <>
+        "ended.",
+    parameters: [conversation_id: [in: :path, type: :string, required: true]],
+    request_body:
+      {"Configuration selection", "application/json", Schemas.ConversationReapplyRequest},
+    responses: [
+      ok: {"Reapplied conversation", "application/json", Schemas.ConversationResponse},
+      forbidden:
+        {"Sprite keys may not reapply a conversation", "application/json", Schemas.Error},
+      not_found:
+        {"Conversation or selected resource not found", "application/json", Schemas.Error},
+      conflict:
+        {"The conversation has a running turn, or the selection needs the machine built again",
+         "application/json", Schemas.Error},
+      gone: {"Conversation has ended", "application/json", Schemas.Error},
+      unprocessable_entity: {"Selection is not allowed", "application/json", Schemas.Error},
+      service_unavailable: {"The machine is still being built", "application/json", Schemas.Error}
+    ]
+  )
+
+  def reapply(conn, %{"conversation_id" => id} = params) do
+    user = conn.assigns.current_user
+
+    case Conversations.get_conversation(id, user.id) do
+      nil ->
+        {:error, :not_found}
+
+      conv ->
+        # Ownership was established by the scoped fetch above.
+        with {:ok, updated} <-
+               Conversations.reapply_conversation(conv, params, Audited.attribution(conn)) do
+          render(conn, :show, conversation: updated)
+        end
+    end
+  end
+
   operation(:answer_request,
     summary: "Answer a permission request",
     description:

--- a/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
@@ -295,6 +295,37 @@ defmodule FountainWeb.FallbackController do
     })
   end
 
+  # A reapply that would need the machine built again (#1565). 409 rather than
+  # 422: the selection is valid, it just cannot be applied to the computer
+  # this conversation is already on. `field` says which one forced it, so a
+  # client can tell "your agent runs a different runtime" from "your
+  # environment installs different packages".
+  def call(conn, {:error, {:rebuild_required, field}}) do
+    conn
+    |> put_status(:conflict)
+    |> json(%{
+      error: "rebuild_required",
+      field: to_string(field),
+      message:
+        "this conversation's machine cannot be reconfigured in place because " <>
+          Fountain.Conversations.Reapply.explain(field) <>
+          "; start a new conversation, or build this one's machine again with " <>
+          "DELETE /api/sandboxes/:id"
+    })
+  end
+
+  # A conversation is reconfigured between turns, never during one. 409 and
+  # not 503: waiting does not help by itself, the caller either waits for the
+  # turn to end or interrupts it.
+  def call(conn, {:error, :conversation_busy}) do
+    conn
+    |> put_status(:conflict)
+    |> json(%{
+      error: "conversation_busy",
+      message: "the conversation has a running turn; wait for it to finish or interrupt it"
+    })
+  end
+
   # A turn refused because another conversation is running one on the same
   # sandbox and the runtime takes one at a time (ADR 0023 step 4). Not a
   # queue: the caller sends again when the other turn ends, or interrupts it.

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -599,6 +599,7 @@ defmodule FountainWeb.Router do
 
     resources "/conversations", ConversationController, only: [:index, :show, :create, :delete] do
       post "/prompts", ConversationController, :prompt, as: :prompt
+      post "/reapply", ConversationController, :reapply, as: :reapply
       post "/interrupt", ConversationController, :interrupt, as: :interrupt
       post "/terminate", ConversationController, :terminate, as: :terminate
       get "/turns", ConversationController, :turns, as: :turns

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -850,6 +850,41 @@ defmodule FountainWeb.Schemas do
     })
   end
 
+  defmodule ConversationReapplyRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "ConversationReapplyRequest",
+      description:
+        "A selection of Agent, Environment and Vault to apply to the machine an existing " <>
+          "conversation already runs on. An omitted field keeps its current selection. An " <>
+          "explicit null clears the Environment override or the Vault. An empty object " <>
+          "reapplies the current selection.",
+      type: :object,
+      properties: %{
+        agent_id: %Schema{
+          type: :string,
+          format: :uuid,
+          description: "Agent to use; omitted keeps the current Agent."
+        },
+        environment_id: %Schema{
+          type: :string,
+          format: :uuid,
+          nullable: true,
+          description:
+            "Environment override to use; null returns to the selected Agent's Environment."
+        },
+        vault_id: %Schema{
+          type: :string,
+          format: :uuid,
+          nullable: true,
+          description: "Vault to use; null detaches the current Vault."
+        }
+      }
+    })
+  end
+
   defmodule PromptRequest do
     @moduledoc false
     require OpenApiSpex

--- a/apps/fountain/test/fountain/conversations/conversation_server_refresh_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_refresh_test.exs
@@ -104,6 +104,35 @@ defmodule Fountain.Conversations.ConversationServerRefreshTest do
     GenServer.stop(pid)
   end
 
+  test "a sleeping conversation reconciles its skills on the next wake", ctx do
+    stub_happy_sprite()
+
+    {:ok, _} =
+      Conversations.update_sandbox(ctx.sandbox, %{
+        status: "suspended",
+        build_fingerprint: Fountain.Conversations.Reapply.fingerprint(ctx.env)
+      })
+
+    {:ok, conv} = Conversations.update_conversation(ctx.conv, %{status: "idle"})
+
+    skills = [%{"name" => "fresh", "content" => "Updated skill"}]
+    {:ok, _} = Fountain.Agents.update_agent(ctx.agent, %{skills: skills})
+    test = self()
+
+    Mimic.expect(Fountain.SandboxSkills, :reconcile, fn _handle, "claude", ^skills, _previous ->
+      send(test, :skills_reconciled)
+      :ok
+    end)
+
+    assert {:ok, updated} = Conversations.reapply_conversation(conv, %{})
+    {pid, _, :alive} = start_server(updated)
+
+    assert_received :skills_reconciled
+    assert Conversations._unsafe_get_sandbox!(ctx.sandbox.id).applied_skills == skills
+    assert :sys.get_state(pid).configuration_revision == updated.configuration_revision
+    GenServer.stop(pid)
+  end
+
   test "a prompt reloads configuration when the refresh notification was missed", ctx do
     stub_happy_sprite()
     {pid, _, :alive} = start_server(ctx.conv)

--- a/apps/fountain/test/fountain/conversations/conversation_server_size_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_size_test.exs
@@ -13,9 +13,16 @@ defmodule Fountain.Conversations.ConversationServerSizeTest do
   The shape is the docs-style allowlist that only shrinks (#911): the number
   is not a target, it is a record of where the file is, and the only edit it
   accepts is downward. Lower it when you move something out; never raise it.
+
+  **A stack in flight does not move it.** The pin is the length on `main`, and
+  a number measured against a branch is stale the moment any link below it
+  grows the file, which is what review rounds do. #1565 lowered it mid-stack to
+  the tip's exact length, left zero headroom, and went red two rounds later
+  when a fix four PRs down added lines. Land the shrink first, then lower the
+  pin in a follow-up, when the number has stopped moving.
   """
 
-  @pin 2716
+  @pin 2762
 
   @server "apps/fountain/lib/fountain/conversations/conversation_server.ex"
 

--- a/apps/fountain/test/fountain/conversations/conversation_server_size_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_size_test.exs
@@ -15,7 +15,7 @@ defmodule Fountain.Conversations.ConversationServerSizeTest do
   accepts is downward. Lower it when you move something out; never raise it.
   """
 
-  @pin 2762
+  @pin 2716
 
   @server "apps/fountain/lib/fountain/conversations/conversation_server.ex"
 

--- a/apps/fountain/test/fountain/sandbox_skills_test.exs
+++ b/apps/fountain/test/fountain/sandbox_skills_test.exs
@@ -27,7 +27,7 @@ defmodule Fountain.SandboxSkillsTest do
       :ok
     end)
 
-    reject(&Managoat.Sandbox.exec/4)
+    stub(Managoat.Sandbox, :exec, fn _, _, _, _ -> {:ok, "", 0} end)
 
     assert :ok = SandboxSkills.mount(@handle, "claude", [%{"name" => "mine", "content" => "# m"}])
 
@@ -48,6 +48,8 @@ defmodule Fountain.SandboxSkillsTest do
       :ok
     end)
 
+    stub(Managoat.Sandbox, :exec, fn _, _, _, _ -> {:ok, "", 0} end)
+
     assert :ok = SandboxSkills.mount(@handle, "acp", [%{"name" => "mine", "content" => "# m"}])
 
     root = Fountain.CommandRuntime.skills_root()
@@ -59,6 +61,7 @@ defmodule Fountain.SandboxSkillsTest do
   test "a module is passed straight through to the library" do
     test = self()
     stub(Managoat.Sandbox, :write_file, fn _h, path, _b -> send(test, {:wrote, path}) && :ok end)
+    stub(Managoat.Sandbox, :exec, fn _, _, _, _ -> {:ok, "", 0} end)
 
     assert :ok = SandboxSkills.mount(@handle, Fountain.CommandRuntime, nil)
     assert_receive {:wrote, "/home/sprite/.claude/skills/fountain/SKILL.md"}
@@ -78,11 +81,146 @@ defmodule Fountain.SandboxSkillsTest do
 
   test "a nil skills list mounts the bundled skills alone" do
     test = self()
+    stub(Managoat.Sandbox, :exec, fn _, _, _, _ -> {:ok, "", 0} end)
     stub(Managoat.Sandbox, :write_file, fn _h, path, _b -> send(test, {:wrote, path}) && :ok end)
 
     assert :ok = SandboxSkills.mount(@handle, "codex", nil)
     assert_receive {:wrote, "/home/sprite/.codex/skills/fountain/SKILL.md"}
     assert_receive {:wrote, "/home/sprite/.codex/skills/create-team/SKILL.md"}
+    assert_receive {:wrote, "/home/sprite/.codex/skills/.fountain-managed-skills"}
     refute_receive {:wrote, _}
+  end
+
+  defmodule DiskRuntime do
+    @moduledoc """
+    A runtime whose skills root is a real directory on this machine, so the
+    reconciliation can be measured against a filesystem rather than a mock.
+    """
+    def skills_root, do: Process.get(:skills_test_root)
+    def skills_sh_agent, do: "claude"
+  end
+
+  describe "reconciliation on disk" do
+    setup do
+      root = Fountain.TmpDir.mkdir!("fountain-skills")
+      Process.put(:skills_test_root, root)
+
+      stub(Managoat.Sandbox, :write_file, fn _, path, content ->
+        File.mkdir_p!(Path.dirname(path))
+        File.write(path, content)
+      end)
+
+      stub(Managoat.Sandbox, :exec, fn _, "bash", args, _ ->
+        {output, code} = System.cmd("bash", args, stderr_to_stdout: true)
+        {:ok, output, code}
+      end)
+
+      %{root: root}
+    end
+
+    test "removes an obsolete inline skill while preserving unrelated files", %{root: root} do
+      File.mkdir_p!(Path.join(root, "personal"))
+      File.write!(Path.join(root, "personal/SKILL.md"), "My local skill")
+
+      assert :ok =
+               SandboxSkills.mount(@handle, DiskRuntime, [
+                 %{"name" => "old", "content" => "Old skill"}
+               ])
+
+      assert :ok =
+               SandboxSkills.mount(@handle, DiskRuntime, [
+                 %{"name" => "new", "content" => "New skill"}
+               ])
+
+      refute File.exists?(Path.join(root, "old"))
+      assert File.read!(Path.join(root, "new/SKILL.md")) == "New skill"
+      # Not Fountain's, so not Fountain's to delete.
+      assert File.read!(Path.join(root, "personal/SKILL.md")) == "My local skill"
+      assert File.exists?(Path.join(root, "fountain/SKILL.md"))
+    end
+
+    test "seeds legacy named skills and ignores unsafe manifest paths", %{root: root} do
+      File.mkdir_p!(Path.join(root, "legacy"))
+      File.write!(Path.join(root, "legacy/SKILL.md"), "Old skill")
+      File.write!(Path.join(root, ".fountain-managed-skills"), "..\n../outside\n/absolute\n")
+
+      assert :ok =
+               SandboxSkills.reconcile(@handle, DiskRuntime, [], [
+                 %{"name" => "legacy", "content" => "Old skill"}
+               ])
+
+      refute File.exists?(Path.join(root, "legacy"))
+      # A manifest naming anything but a direct child removes nothing.
+      assert File.dir?(root)
+    end
+
+    test "recovers unnamed legacy GitHub skills from the source lock", %{root: root} do
+      File.mkdir_p!(Path.join(root, "legacy-remote"))
+      File.write!(Path.join(root, "legacy-remote/SKILL.md"), "Old remote skill")
+      File.mkdir_p!(Path.join(root, "unrelated"))
+
+      stub(Managoat.Sandbox, :exec, fn _, "bash", args, _ ->
+        if Enum.any?(args, &String.contains?(&1, "skills_lock=")) do
+          {:ok,
+           Jason.encode!(%{
+             "skills" => %{
+               "legacy-remote" => %{"source" => "owner/repo", "sourceType" => "github"},
+               "unrelated" => %{"source" => "another/repo", "sourceType" => "github"}
+             }
+           }), 0}
+        else
+          {output, code} = System.cmd("bash", args, stderr_to_stdout: true)
+          {:ok, output, code}
+        end
+      end)
+
+      assert :ok =
+               SandboxSkills.reconcile(@handle, DiskRuntime, [], [%{"source" => "owner/repo"}])
+
+      refute File.exists?(Path.join(root, "legacy-remote"))
+      # Installed from a source this conversation never named.
+      assert File.dir?(Path.join(root, "unrelated"))
+    end
+
+    test "a retained remote skill survives an offline reinstall", %{root: root} do
+      skill = %{"source" => "owner/repo", "name" => "remote"}
+      File.mkdir_p!(Path.join(root, "remote"))
+      File.write!(Path.join(root, "remote/SKILL.md"), "Already installed")
+
+      stub(Managoat.Sandbox, :exec, fn _, "bash", args, _ ->
+        case args do
+          ["-lc", "npx " <> _] ->
+            {:ok, "offline", 1}
+
+          _ ->
+            {output, code} = System.cmd("bash", args, stderr_to_stdout: true)
+            {:ok, output, code}
+        end
+      end)
+
+      assert :ok = SandboxSkills.reconcile(@handle, DiskRuntime, [skill], [skill])
+      assert File.read!(Path.join(root, "remote/SKILL.md")) == "Already installed"
+    end
+
+    test "tracks discovered GitHub skill names for a later removal", %{root: root} do
+      stub(Managoat.Sandbox, :exec, fn _, "bash", args, _ ->
+        case args do
+          ["-lc", "npx " <> _] ->
+            File.mkdir_p!(Path.join(root, "discovered"))
+            File.write!(Path.join(root, "discovered/SKILL.md"), "Remote skill")
+            {:ok, "", 0}
+
+          _ ->
+            {output, code} = System.cmd("bash", args, stderr_to_stdout: true)
+            {:ok, output, code}
+        end
+      end)
+
+      assert :ok = SandboxSkills.mount(@handle, DiskRuntime, [%{"source" => "owner/repo"}])
+      assert File.read!(Path.join(root, ".fountain-managed-skills")) =~ "discovered"
+
+      assert :ok = SandboxSkills.mount(@handle, DiskRuntime, [])
+      refute File.exists?(Path.join(root, "discovered"))
+    end
   end
 end

--- a/apps/fountain/test/fountain_web/controllers/conversation_reapply_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/conversation_reapply_controller_test.exs
@@ -1,0 +1,161 @@
+defmodule FountainWeb.ConversationReapplyControllerTest do
+  @moduledoc """
+  `POST /api/conversations/:id/reapply` and its status-code contract (#1565).
+
+  Four refusals, four different meanings: 409 for a conversation mid-turn,
+  409 with a `field` for a selection the machine cannot be reconfigured into,
+  503 while the machine is still being built, and 410 once the conversation
+  has ended.
+  """
+
+  use FountainWeb.ConnCase, async: true
+
+  alias Fountain.{Agents, Conversations}
+  alias Fountain.Conversations.Reapply
+
+  setup do
+    user = insert_active_user()
+    {_key, raw_key} = insert_api_key(user)
+    env = insert_env(user_id: user.id)
+    vault = insert_vault(user_id: user.id)
+
+    agent =
+      insert_agent(
+        user_id: user.id,
+        runtime: "claude",
+        environment_id: env.id,
+        allowed_vault_ids: [vault.id]
+      )
+
+    sandbox =
+      insert_sandbox(
+        user_id: user.id,
+        status: "ready",
+        agent_id: agent.id,
+        environment_id: env.id,
+        vault_id: vault.id,
+        build_fingerprint: Reapply.fingerprint(env)
+      )
+
+    conv =
+      insert_conversation(
+        user_id: user.id,
+        agent: agent,
+        agent_version_id: Agents._unsafe_current_version_id(agent.id),
+        sandbox: sandbox,
+        vault_id: vault.id,
+        runtime_session_id: "old-session",
+        status: "idle"
+      )
+
+    {:ok,
+     user: user,
+     raw_key: raw_key,
+     agent: agent,
+     env: env,
+     vault: vault,
+     sandbox: sandbox,
+     conv: conv}
+  end
+
+  defp reapply(ctx, body, conv \\ nil) do
+    ctx.conn
+    |> authed_with_key(ctx.raw_key)
+    |> post_json("/api/conversations/#{(conv || ctx.conv).id}/reapply", body)
+  end
+
+  test "200 keeps the thread and clears explicit nulls", ctx do
+    response =
+      ctx
+      |> reapply(%{"vault_id" => nil})
+      |> json_response(200)
+      |> Map.fetch!("data")
+
+    assert response["id"] == ctx.conv.id
+    assert response["agent_id"] == ctx.agent.id
+    assert response["vault_id"] == nil
+    assert response["sandbox_id"] == ctx.conv.sandbox_id
+
+    # The machine survives, so the runtime session on its disk is still
+    # resumable and the agent keeps its memory of this thread.
+    assert response["runtime_session_id"] == "old-session"
+
+    [audit] =
+      Fountain.Audit.list_for_user(ctx.user.id)
+      |> Enum.filter(&(&1.action == "conversation.configuration_reapplied"))
+
+    assert audit.actor == "api"
+  end
+
+  test "an empty body reapplies the current selection", ctx do
+    response = ctx |> reapply(%{}) |> json_response(200) |> Map.fetch!("data")
+    assert response["agent_id"] == ctx.agent.id
+    assert response["vault_id"] == ctx.vault.id
+  end
+
+  test "404 for another tenant's conversation", ctx do
+    other = insert_active_user()
+    theirs = insert_conversation(user_id: other.id, status: "idle")
+
+    assert %{"error" => "not_found"} =
+             ctx |> reapply(%{}, theirs) |> json_response(404)
+  end
+
+  test "409 conversation_busy leaves a conversation mid-turn unchanged", ctx do
+    insert_turn(ctx.conv, status: "running")
+
+    assert %{"error" => "conversation_busy", "message" => message} =
+             ctx |> reapply(%{}) |> json_response(409)
+
+    assert message =~ "running turn"
+    assert Conversations._unsafe_get_conversation!(ctx.conv.id).configuration_revision == 0
+  end
+
+  test "409 rebuild_required names the field that forced it", ctx do
+    codex = insert_agent(user_id: ctx.user.id, runtime: "codex", environment_id: ctx.env.id)
+
+    body =
+      ctx
+      |> reapply(%{"agent_id" => codex.id, "vault_id" => nil})
+      |> json_response(409)
+
+    assert body["error"] == "rebuild_required"
+    assert body["field"] == "runtime"
+    assert body["message"] =~ "different runtime"
+    assert body["message"] =~ "DELETE /api/sandboxes/:id"
+    assert Conversations._unsafe_get_conversation!(ctx.conv.id).agent_id == ctx.agent.id
+  end
+
+  test "503 while the machine is still being built", ctx do
+    {:ok, _} = Conversations.update_sandbox(ctx.sandbox, %{status: "starting"})
+    {:ok, _} = Conversations.update_conversation(ctx.conv, %{status: "pending"})
+
+    conn = reapply(ctx, %{})
+    assert %{"error" => "provisioning"} = json_response(conn, 503)
+    assert get_resp_header(conn, "retry-after") == ["30"]
+  end
+
+  test "410 once the conversation has ended", ctx do
+    {:ok, _} = Conversations.update_conversation(ctx.conv, %{status: "terminated"})
+
+    assert %{"error" => "conversation_terminated"} =
+             ctx |> reapply(%{}) |> json_response(410)
+  end
+
+  test "422 for a selection the agent's allowlist forbids", ctx do
+    locked =
+      insert_agent(
+        user_id: ctx.user.id,
+        runtime: "claude",
+        environment_id: ctx.env.id,
+        allowed_vault_ids: []
+      )
+
+    other_vault = insert_vault(user_id: ctx.user.id)
+
+    assert %{"error" => "vault_not_allowed"} =
+             ctx
+             |> reapply(%{"agent_id" => locked.id, "vault_id" => other_vault.id})
+             |> json_response(422)
+  end
+end

--- a/apps/fountain/test/support/conversation_server_case.ex
+++ b/apps/fountain/test/support/conversation_server_case.ex
@@ -77,6 +77,10 @@ defmodule Fountain.ConversationServerCase do
 
     Mimic.stub(Fountain.SandboxSkills, :mount, fn _handle, _runtime, _skills -> :ok end)
 
+    Mimic.stub(Fountain.SandboxSkills, :reconcile, fn _handle, _runtime, _skills, _previous ->
+      :ok
+    end)
+
     Mimic.stub(Fountain.Conversations.Provisioning, :write_env_file, fn _s, _e -> :ok end)
 
     Mimic.stub(Fountain.Conversations.Provisioning, :install_packages, fn _s, _e, _se, _c ->

--- a/docs/api.md
+++ b/docs/api.md
@@ -422,6 +422,52 @@ removes a key. The notification never reaches the transcript, and it opens no
 turn of its own. A stamp that breaks a limit is logged and dropped, and the
 turn continues. Nothing in a stamp can end a run.
 
+### Reapply the configuration
+
+`POST /api/conversations/{id}/reapply` selects a different Agent, Environment
+or Vault for a conversation that exists. The machine stays, so the files on
+its disk stay with it. Fountain rewrites the variables, the system prompt, the
+skills and the MCP configuration. The next prompt starts a runtime that reads
+them.
+
+An empty body reapplies the current selection. A field that the body does not
+name keeps its selection. A field with a `null` value clears the Environment
+override or the Vault.
+
+```bash
+curl --fail-with-body \
+  -H "Authorization: Bearer $FOUNTAIN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"agent_id":"YOUR_AGENT_ID","vault_id":null}' \
+  "$FOUNTAIN_URL/api/conversations/$CONVERSATION_ID/reapply"
+```
+
+The machine also takes the new identity. A later attachment must name the new
+Agent, Environment and Vault. A target identity that already has a persistent
+home fails the request and moves neither binding.
+
+A conversation that sleeps applies the change on its next wake. A
+configuration revision stops a prompt against a configuration that a live
+worker did not read yet. Fountain removes the managed skills that the Agent no
+longer names, and keeps the other files in the skills directory. On an older
+machine with no skill manifest, Fountain recovers the names from the recorded
+Agent version and from the installer's source lock. An entry with no ownership
+record stays where it is.
+
+Some selections need a new disk. Fountain refuses those with
+`409 rebuild_required` and a `field` that names the cause. A different runtime
+needs one, because Fountain installs the agent adapter before the network
+policy, and that policy now blocks a second install. A different set of
+packages, repositories, setup script or network policy needs one too. A
+machine that other conversations share accepts only the selection that those
+conversations have, because the skills and the instructions belong to the
+machine. For the rest, start a new conversation. You can also build this
+conversation's machine again with `DELETE /api/sandboxes/{id}`.
+
+Fountain refuses the request with `409 conversation_busy` while a turn runs,
+with `503` while it still builds the machine, and with `410` after the
+conversation ends.
+
 ### Workers without Fountain API access
 
 Set `sandbox_api_access` to `none` when the host must retain Fountain API

--- a/docs/api.md
+++ b/docs/api.md
@@ -448,14 +448,19 @@ home fails the request and moves neither binding.
 
 A conversation that sleeps applies the change on its next wake. A
 configuration revision stops a prompt against a configuration that a live
-worker did not read yet. Fountain removes the managed skills that the Agent no
+worker did not read yet. The `configuration` stage event reports which of the
+two happened. The status is `done` when a machine holds the new selection, and
+`failed` when the selection stands and the machine has yet to read it. The
+request succeeds in both cases. Fountain removes the managed skills that the Agent no
 longer names, and keeps the other files in the skills directory. On an older
 machine with no skill manifest, Fountain recovers the names from the recorded
 Agent version and from the installer's source lock. An entry with no ownership
 record stays where it is.
 
 Some selections need a new disk. Fountain refuses those with
-`409 rebuild_required` and a `field` that names the cause. A different runtime
+`409 rebuild_required` and a `field` that names the cause. Fountain answers
+`environment` when you edit one Environment in place. The machine records one
+digest of its build inputs, not a digest for each field. A different runtime
 needs one, because Fountain installs the agent adapter before the network
 policy, and that policy now blocks a second install. A different set of
 packages, repositories, setup script or network policy needs one too. A

--- a/docs/concepts/conversation.md
+++ b/docs/concepts/conversation.md
@@ -51,6 +51,16 @@ run the turn, stream log events over SSE
 The same machine runs another turn for a follow-up prompt. You can interrupt a
 turn that runs, and you can end the whole conversation early.
 
+You can also select a different Agent, Environment or Vault for a
+Conversation that exists. A reapply keeps the id, the turns, the transcript
+and the machine. The files that the agent has on disk stay where it left them.
+Fountain rewrites the variables, the system prompt, the skills and the MCP
+configuration. The next prompt starts a runtime that reads them.
+
+Fountain refuses a selection that needs a new disk, and the answer names the
+field that needs it. A different runtime needs one. A different set of
+packages, repositories or setup script needs one too.
+
 Log events stream in real time over
 `GET /api/conversations/:id/stream`. Add `?blocks=true` and the server parses
 the runtime dialect, so a client never has to.

--- a/docs/reference/webhooks.md
+++ b/docs/reference/webhooks.md
@@ -73,6 +73,7 @@ counter uses the same pair as its tags.
 | `model` | `done`, `failed` | The runtime confirmed the selected model, or selection or provider access failed. |
 | `session` | `done` | The runtime reported a session id for the conversation. |
 | `sandbox` | `done` | Fountain reclaimed the sandbox. The conversation stays resumable. |
+| `configuration` | `done` | Fountain applied a new Agent, Environment or Vault. The machine stays. |
 | `terminate` | `done` | The conversation ended. |
 
 An endpoint filter accepts three shapes.

--- a/docs/reference/webhooks.md
+++ b/docs/reference/webhooks.md
@@ -73,7 +73,7 @@ counter uses the same pair as its tags.
 | `model` | `done`, `failed` | The runtime confirmed the selected model, or selection or provider access failed. |
 | `session` | `done` | The runtime reported a session id for the conversation. |
 | `sandbox` | `done` | Fountain reclaimed the sandbox. The conversation stays resumable. |
-| `configuration` | `done` | Fountain applied a new Agent, Environment or Vault. The machine stays. |
+| `configuration` | `done`, `failed` | Fountain applied a new Agent, Environment or Vault, or selected one that the machine has yet to read. The machine stays. |
 | `terminate` | `done` | The conversation ended. |
 
 An endpoint filter accepts three shapes.

--- a/sdk/contract/contract.json
+++ b/sdk/contract/contract.json
@@ -6266,6 +6266,72 @@
         }
       }
     },
+    "POST /api/conversations/{conversation_id}/reapply": {
+      "operation_id": "FountainWeb.ConversationController.reapply",
+      "path_params": [
+        "conversation_id"
+      ],
+      "request_body": {
+        "content": {
+          "application/json": {
+            "ref": "ConversationReapplyRequest"
+          }
+        },
+        "required": false
+      },
+      "responses": {
+        "200": {
+          "application/json": {
+            "ref": "ConversationResponse"
+          }
+        },
+        "401": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "403": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "404": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "406": {
+          "application/json": {
+            "ref": "NegotiationError"
+          }
+        },
+        "409": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "410": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "422": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "429": {
+          "application/json": {
+            "ref": "Error"
+          }
+        },
+        "503": {
+          "application/json": {
+            "ref": "Error"
+          }
+        }
+      }
+    },
     "POST /api/conversations/{conversation_id}/requests/{request_id}": {
       "operation_id": "FountainWeb.ConversationController.answer_request",
       "path_params": [
@@ -10761,6 +10827,28 @@
           },
           "required": true,
           "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "ConversationReapplyRequest": {
+      "properties": {
+        "agent_id": {
+          "format": "uuid",
+          "required": false,
+          "type": "string"
+        },
+        "environment_id": {
+          "format": "uuid",
+          "nullable": true,
+          "required": false,
+          "type": "string"
+        },
+        "vault_id": {
+          "format": "uuid",
+          "nullable": true,
+          "required": false,
+          "type": "string"
         }
       },
       "type": "object"

--- a/sdk/contract/manifests/elixir.json
+++ b/sdk/contract/manifests/elixir.json
@@ -64,6 +64,7 @@
     "POST /api/conversations/{conversation_id}/interrupt",
     "POST /api/conversations/{conversation_id}/prompts",
     "POST /api/conversations/{conversation_id}/read",
+    "POST /api/conversations/{conversation_id}/reapply",
     "POST /api/conversations/{conversation_id}/requests/{request_id}",
     "POST /api/conversations/{conversation_id}/terminate",
     "POST /api/environments",

--- a/sdk/contract/manifests/python.json
+++ b/sdk/contract/manifests/python.json
@@ -61,6 +61,7 @@
     "POST /api/conversations/{conversation_id}/interrupt",
     "POST /api/conversations/{conversation_id}/prompts",
     "POST /api/conversations/{conversation_id}/read",
+    "POST /api/conversations/{conversation_id}/reapply",
     "POST /api/conversations/{conversation_id}/requests/{request_id}",
     "POST /api/conversations/{conversation_id}/terminate",
     "POST /api/environments",

--- a/sdk/contract/manifests/swift.json
+++ b/sdk/contract/manifests/swift.json
@@ -63,6 +63,7 @@
     "POST /api/conversations/{conversation_id}/interrupt",
     "POST /api/conversations/{conversation_id}/prompts",
     "POST /api/conversations/{conversation_id}/read",
+    "POST /api/conversations/{conversation_id}/reapply",
     "POST /api/conversations/{conversation_id}/requests/{request_id}",
     "POST /api/conversations/{conversation_id}/terminate",
     "POST /api/environments",

--- a/sdk/contract/manifests/typescript.json
+++ b/sdk/contract/manifests/typescript.json
@@ -67,6 +67,7 @@
     "POST /api/conversations/{conversation_id}/interrupt",
     "POST /api/conversations/{conversation_id}/prompts",
     "POST /api/conversations/{conversation_id}/read",
+    "POST /api/conversations/{conversation_id}/reapply",
     "POST /api/conversations/{conversation_id}/requests/{request_id}",
     "POST /api/conversations/{conversation_id}/terminate",
     "POST /api/environments",

--- a/sdk/elixir/CHANGELOG.md
+++ b/sdk/elixir/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.2.0] - 2026-09-10
+
+- Add `Fountain.Conversation.reapply/2` for `POST /api/conversations/{id}/reapply`: re-select a conversation's agent, environment and vault on the machine it is already running.
+
 ## [0.1.0] - 2026-09-02
 
 - Initial Elixir SDK release.

--- a/sdk/elixir/lib/fountain/conversation.ex
+++ b/sdk/elixir/lib/fountain/conversation.ex
@@ -86,6 +86,26 @@ defmodule Fountain.Conversation do
 
   def tree(value), do: HTTP.data(value.http, "GET", "/api/conversations/#{value.id}/tree")
 
+  @doc """
+  Reapply this conversation's agent, environment and vault in place.
+
+  The machine, the transcript and the files on disk all stay. An option that
+  is not given keeps its current selection; `nil` clears the environment
+  override or the vault. Called with no options it reapplies what is already
+  selected.
+  """
+  def reapply(value, opts \\ []) do
+    body =
+      [:agent_id, :environment_id, :vault_id]
+      |> Enum.reduce(%{}, fn key, acc ->
+        if Keyword.has_key?(opts, key),
+          do: Map.put(acc, Atom.to_string(key), Keyword.get(opts, key)),
+          else: acc
+      end)
+
+    HTTP.data(value.http, "POST", "/api/conversations/#{value.id}/reapply", body: body)
+  end
+
   @doc "Fetches all history pages, requesting server-parsed blocks."
   def history(value, opts \\ []),
     do:

--- a/sdk/elixir/lib/fountain/http.ex
+++ b/sdk/elixir/lib/fountain/http.ex
@@ -3,7 +3,7 @@ defmodule Fountain.HTTP do
 
   alias Fountain.{Config, Error}
 
-  @user_agent "fountain-sdk-elixir/0.1.0"
+  @user_agent "fountain-sdk-elixir/0.2.0"
   defstruct [:config, :transport, timeout: 30_000]
 
   @type t :: %__MODULE__{config: Config.t(), transport: module(), timeout: timeout()}

--- a/sdk/elixir/mix.exs
+++ b/sdk/elixir/mix.exs
@@ -1,7 +1,7 @@
 defmodule FountainSdk.MixProject do
   use Mix.Project
 
-  @version "0.1.0"
+  @version "0.2.0"
 
   def project do
     [

--- a/sdk/elixir/test/surface_test.exs
+++ b/sdk/elixir/test/surface_test.exs
@@ -77,6 +77,14 @@ defmodule Fountain.SurfaceTest do
     assert {:ok, 2} = Conversation.cursor(conversation)
     assert :ok = Conversation.answer(conversation, "req/1", "allow")
     assert :ok = Conversation.mark_read(conversation)
+
+    # Omitted keeps a binding, an explicit nil clears it, and the two have to
+    # stay distinguishable all the way to the wire.
+    assert {:ok, %{"id" => "thread"}} = Conversation.reapply(conversation)
+
+    assert {:ok, %{"id" => "thread"}} =
+             Conversation.reapply(conversation, agent_id: "a1", vault_id: nil)
+
     assert :ok = Conversation.interrupt(conversation)
     assert :ok = Conversation.terminate(conversation)
     assert :ok = Conversation.delete(conversation)
@@ -110,6 +118,12 @@ defmodule Fountain.SurfaceTest do
                     %{path: "/api/conversations/thread/requests/req%2F1", body: permission_body}}
 
     assert Jason.decode!(permission_body) == %{"option_id" => "allow"}
+
+    assert_receive {:seen, %{path: "/api/conversations/thread/reapply", body: refresh_body}}
+    assert Jason.decode!(refresh_body) == %{}
+
+    assert_receive {:seen, %{path: "/api/conversations/thread/reapply", body: select_body}}
+    assert Jason.decode!(select_body) == %{"agent_id" => "a1", "vault_id" => nil}
   end
 
   test "root run sends all options and channel continuation uses the next turn" do
@@ -347,6 +361,9 @@ defmodule Fountain.SurfaceTest do
 
       {"POST", "/api/conversations/thread/read"} ->
         {204, [], ""}
+
+      {"POST", "/api/conversations/thread/reapply"} ->
+        json(200, %{"data" => %{"id" => "thread"}})
 
       {"POST", "/api/conversations/thread/interrupt"} ->
         {204, [], ""}

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.0
+
+- Add `Conversation.reapply()` for `POST /api/conversations/{id}/reapply`: re-select a conversation's agent, environment and vault on the machine it is already running.
+
 ## 0.1.1
 
 - Bound idle stream reads to five seconds so cancellation completes behind a silent proxy.

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fountain-agent-sdk"
-version = "0.1.1"
+version = "0.2.0"
 description = "Run coding agents on Fountain, with real computers, repositories, and credentials."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/sdk/python/src/fountain/__init__.py
+++ b/sdk/python/src/fountain/__init__.py
@@ -72,4 +72,4 @@ __all__ = [
     "stream_path",
 ]
 
-__version__ = "0.1.1"
+__version__ = "0.2.0"

--- a/sdk/python/src/fountain/conversation.py
+++ b/sdk/python/src/fountain/conversation.py
@@ -8,6 +8,10 @@ from .http import HttpClient
 from .run import Run
 from .sse import stream_events
 
+# Distinguishes "not given" from an explicit None, which the reapply body
+# needs: the first keeps a binding and the second clears it.
+_UNSET = object()
+
 
 class Conversation:
     def __init__(self, http: HttpClient, conversation_id: str, cursor: int = 0) -> None:
@@ -101,6 +105,31 @@ class Conversation:
 
     def tree(self) -> Any:
         return self._http.data("GET", "/api/conversations/%s/tree" % self.id)
+
+    def reapply(
+        self,
+        *,
+        agent_id: Optional[str] = None,
+        environment_id: Any = _UNSET,
+        vault_id: Any = _UNSET,
+    ) -> Dict[str, Any]:
+        """Reapply this conversation's agent, environment and vault in place.
+
+        The machine, the transcript and the files on disk all stay. An omitted
+        value keeps its current selection; pass ``None`` for the environment or
+        the vault to clear it. Calling with no arguments reapplies what is
+        already selected.
+        """
+        body: Dict[str, Any] = {}
+        if agent_id is not None:
+            body["agent_id"] = agent_id
+        if environment_id is not _UNSET:
+            body["environment_id"] = environment_id
+        if vault_id is not _UNSET:
+            body["vault_id"] = vault_id
+        return self._http.data(
+            "POST", "/api/conversations/%s/reapply" % self.id, body=body
+        )
 
     def interrupt(self) -> None:
         self._http.request("POST", "/api/conversations/%s/interrupt" % self.id)

--- a/sdk/python/src/fountain/http.py
+++ b/sdk/python/src/fountain/http.py
@@ -10,7 +10,7 @@ from urllib.request import Request, urlopen
 from .config import ResolvedConfig
 from .errors import AuthError, ConnectionError, error_for_status
 
-USER_AGENT = "fountain-sdk-python/0.1.1"
+USER_AGENT = "fountain-sdk-python/0.2.0"
 
 
 class Response(Protocol):

--- a/sdk/python/tests/test_sdk.py
+++ b/sdk/python/tests/test_sdk.py
@@ -222,6 +222,8 @@ class Handler(BaseHTTPRequestHandler):
             return self._json(
                 201, {"data": {"id": "c-1", "status": "running", "turn_count": 1}}
             )
+        if parsed.path == "/api/conversations/c-1/reapply":
+            return self._json(200, {"data": {"id": "c-1", **(body or {})}})
         return self._json(404, {"error": "not_found"})
 
 
@@ -390,6 +392,21 @@ class ClientTests(unittest.TestCase):
                 },
             )
             self.assertEqual(create[4]["User-Agent"], USER_AGENT)
+
+    # An omitted value keeps a binding and an explicit None clears it, so the
+    # two have to stay distinguishable all the way to the wire.
+    def test_reapply_sends_only_the_fields_it_was_given(self):
+        with FakeFountain() as fake:
+            client = fountain.Fountain(api_key="k", base_url=fake.base_url)
+            conversation = client.resume("c-1")
+
+            self.assertEqual(conversation.reapply(), {"id": "c-1"})
+            self.assertEqual(fake.state.requests[-1][3], {})
+
+            conversation.reapply(agent_id="a-1", vault_id=None)
+            self.assertEqual(
+                fake.state.requests[-1][3], {"agent_id": "a-1", "vault_id": None}
+            )
 
     def test_resolution_error_lists_available_names(self):
         with FakeFountain() as fake:

--- a/sdk/swift/Sources/Fountain/Conversation.swift
+++ b/sdk/swift/Sources/Fountain/Conversation.swift
@@ -89,6 +89,22 @@ public final class Conversation: @unchecked Sendable {
   public func tree() async throws -> JSONObject {
     try await http.data("GET", "/api/conversations/\(id)/tree")
   }
+
+  /// Reapply this conversation's agent, environment and vault in place. The
+  /// machine, the transcript and the files on disk all stay. Omit a value to
+  /// keep it; pass `.null` for the environment or the vault to clear it.
+  public func reapply(
+    agentID: String? = nil,
+    environmentID: JSONValue? = nil,
+    vaultID: JSONValue? = nil
+  ) async throws -> JSONObject {
+    var body: JSONObject = [:]
+    if let agentID { body["agent_id"] = .string(agentID) }
+    if let environmentID { body["environment_id"] = environmentID }
+    if let vaultID { body["vault_id"] = vaultID }
+    return try await http.data("POST", "/api/conversations/\(id)/reapply", body: body)
+  }
+
   public func interrupt() async throws {
     _ = try await http.request("POST", "/api/conversations/\(id)/interrupt")
   }

--- a/sdk/swift/Sources/FountainKit/Models/Conversations.swift
+++ b/sdk/swift/Sources/FountainKit/Models/Conversations.swift
@@ -185,3 +185,55 @@ public struct ConversationCreateRequest: Sendable, Encodable {
     case channelID = "channel_id"
   }
 }
+
+/// How a nullable conversation binding changes during a reapply. Three states,
+/// because "leave it alone" and "remove it" are different requests and a plain
+/// optional cannot tell them apart.
+public enum ConversationBindingUpdate: Sendable, Equatable {
+  /// Leave the current binding unchanged.
+  case unchanged
+  /// Remove the current binding.
+  case clear
+  /// Replace it with the resource identified by this id.
+  case use(String)
+}
+
+/// `POST /api/conversations/{id}/reapply` body.
+public struct ConversationReapplyRequest: Sendable, Encodable {
+  public var agentID: String?
+  public var environment: ConversationBindingUpdate
+  public var vault: ConversationBindingUpdate
+
+  public init(
+    agentID: String? = nil,
+    environment: ConversationBindingUpdate = .unchanged,
+    vault: ConversationBindingUpdate = .unchanged
+  ) {
+    self.agentID = agentID
+    self.environment = environment
+    self.vault = vault
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case agentID = "agent_id"
+    case environmentID = "environment_id"
+    case vaultID = "vault_id"
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encodeIfPresent(agentID, forKey: .agentID)
+
+    switch environment {
+    case .unchanged: break
+    case .clear: try container.encodeNil(forKey: .environmentID)
+    case .use(let id): try container.encode(id, forKey: .environmentID)
+    }
+
+    switch vault {
+    case .unchanged: break
+    case .clear: try container.encodeNil(forKey: .vaultID)
+    case .use(let id): try container.encode(id, forKey: .vaultID)
+    }
+  }
+}

--- a/sdk/swift/Sources/FountainKit/Resources/ConversationsResource.swift
+++ b/sdk/swift/Sources/FountainKit/Resources/ConversationsResource.swift
@@ -42,6 +42,16 @@ public struct ConversationsResource: Sendable {
     try await client.send(.delete, "/api/conversations/\(id)")
   }
 
+  /// Reapply a conversation's agent, environment and vault on the machine it
+  /// is already running. The conversation, its transcript and the files on
+  /// disk all stay. An empty request reapplies what is already selected.
+  public func reapply(
+    _ id: String,
+    _ request: ConversationReapplyRequest = ConversationReapplyRequest()
+  ) async throws -> Conversation {
+    try await client.data(.post, "/api/conversations/\(id)/reapply", body: request)
+  }
+
   /// Queue a follow-up turn. The 200 is not the answer — the words arrive
   /// on the stream. Throws `.conversationBusy` mid-turn; queue and retry
   /// on turn end.

--- a/sdk/swift/Tests/FountainKitTests/ClientTests.swift
+++ b/sdk/swift/Tests/FountainKitTests/ClientTests.swift
@@ -131,6 +131,23 @@ import Testing
     #expect(plainWire["runtime_command"] == nil)
   }
 
+  /// Omitted keeps a binding, `.clear` removes it, and the two have to stay
+  /// distinguishable all the way to the wire.
+  @Test func encodesTheThreeBindingStatesOnReapply() throws {
+    let refresh = try JSONEncoder().encode(ConversationReapplyRequest())
+    let refreshWire = try #require(
+      JSONSerialization.jsonObject(with: refresh) as? [String: Any])
+    #expect(refreshWire.isEmpty)
+
+    let selection = ConversationReapplyRequest(
+      agentID: "a-1", environment: .use("e-1"), vault: .clear)
+    let body = try JSONEncoder().encode(selection)
+    let wire = try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
+    #expect(wire["agent_id"] as? String == "a-1")
+    #expect(wire["environment_id"] as? String == "e-1")
+    #expect(wire["vault_id"] is NSNull)
+  }
+
   @Test func unknownEnumValuesSurvive() throws {
     let json = Data(#"{"id":"x","name":"n","model":"m","runtime":"zed","status":"paused"}"#.utf8)
     struct Row: Decodable {

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -11,6 +11,16 @@ server releases.
 
 ---
 
+## [1.31.0] — 2026-09-11
+
+### Added
+
+- `Conversation.reapply()` calls `POST /api/conversations/{id}/reapply`: re-select a conversation's agent, environment and vault on the machine it is already running. The conversation, the transcript and the files on disk all stay. An omitted option keeps its selection, and `null` clears the environment override or the vault.
+
+### Changed
+
+- Generated types carry the new operation and its `ConversationReapplyRequest` body.
+
 ## [1.30.0] - 2026-09-11
 
 ### Added

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@managoat/fountain-sdk",
-  "version": "1.30.0",
+  "version": "1.31.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@managoat/fountain-sdk",
-      "version": "1.30.0",
+      "version": "1.31.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^26.4.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@managoat/fountain-sdk",
-  "version": "1.30.0",
+  "version": "1.31.0",
   "description": "Run a coding agent on a real computer, with your repos and your credentials, in one call.",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/sdk/typescript/src/conversation.ts
+++ b/sdk/typescript/src/conversation.ts
@@ -9,6 +9,15 @@ export interface SendOptions extends RunOptions {
   images?: unknown[];
 }
 
+export interface ReapplyOptions {
+  /** Change the agent; omit to keep the current one. */
+  agentId?: string;
+  /** Change the environment, pass null to clear it, or omit it to keep it. */
+  environmentId?: string | null;
+  /** Change the vault, pass null to clear it, or omit it to keep it. */
+  vaultId?: string | null;
+}
+
 /**
  * A conversation you already have — the sandbox is still there, and so is
  * everything the agent learned in it.
@@ -167,6 +176,23 @@ export class Conversation {
   /** The conversations this one spawned, as a tree. */
   async tree(): Promise<unknown> {
     return this.http.data("GET", `/api/conversations/${this.id}/tree`);
+  }
+
+  /**
+   * Re-select this conversation's agent, environment and vault on the machine
+   * it is already running. The conversation, the transcript and the files on
+   * disk all stay; the next prompt starts a runtime that reads the new
+   * selection. Call it with nothing to refresh what is already selected.
+   *
+   * A selection that would need the machine built again is refused with 409
+   * `rebuild_required`, naming the field that forced it.
+   */
+  async reapply(options: ReapplyOptions = {}): Promise<ConversationRecord> {
+    const body: Record<string, unknown> = {};
+    if (options.agentId !== undefined) body.agent_id = options.agentId;
+    if (options.environmentId !== undefined) body.environment_id = options.environmentId;
+    if (options.vaultId !== undefined) body.vault_id = options.vaultId;
+    return this.http.data("POST", `/api/conversations/${this.id}/reapply`, { body });
   }
 
   /** Ask the agent to stop the turn it is on. The sandbox stays up. */

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -1293,6 +1293,28 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/conversations/{conversation_id}/reapply": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Reapply a conversation's Agent, Environment and Vault
+         * @description Applies a selection to the machine this conversation already runs on, so its files stay where the agent left them. Variables, the system prompt, skills and MCP configuration are rewritten, and the next prompt reads them. An omitted field keeps its current selection; null clears the Environment override or the Vault; an empty object reapplies what is already selected.
+         *
+         *     Refused with 409 `conversation_busy` while a turn runs, 409 `rebuild_required` when the selection would need the machine built again (the `field` says which one forced it), 503 while the machine is still being built, and 410 once the conversation has ended.
+         */
+        post: operations["FountainWeb.ConversationController.reapply"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/conversations/{conversation_id}/requests/{request_id}": {
         parameters: {
             query?: never;
@@ -3768,6 +3790,27 @@ export interface components {
         /** ConversationListResponse */
         ConversationListResponse: {
             data: components["schemas"]["Conversation"][];
+        };
+        /**
+         * ConversationReapplyRequest
+         * @description A selection of Agent, Environment and Vault to apply to the machine an existing conversation already runs on. An omitted field keeps its current selection. An explicit null clears the Environment override or the Vault. An empty object reapplies the current selection.
+         */
+        ConversationReapplyRequest: {
+            /**
+             * Format: uuid
+             * @description Agent to use; omitted keeps the current Agent.
+             */
+            agent_id?: string;
+            /**
+             * Format: uuid
+             * @description Environment override to use; null returns to the selected Agent's Environment.
+             */
+            environment_id?: string | null;
+            /**
+             * Format: uuid
+             * @description Vault to use; null detaches the current Vault.
+             */
+            vault_id?: string | null;
         };
         /** ConversationResponse */
         ConversationResponse: {
@@ -11143,6 +11186,114 @@ export interface operations {
             };
             /** @description Too Many Requests */
             429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    "FountainWeb.ConversationController.reapply": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                conversation_id: string;
+            };
+            cookie?: never;
+        };
+        /** @description Configuration selection */
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["ConversationReapplyRequest"];
+            };
+        };
+        responses: {
+            /** @description Reapplied conversation */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ConversationResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Sprite keys may not reapply a conversation */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Conversation or selected resource not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No acceptable representation */
+            406: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NegotiationError"];
+                };
+            };
+            /** @description The conversation has a running turn, or the selection needs the machine built again */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Conversation has ended */
+            410: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Selection is not allowed */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description The machine is still being built */
+            503: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/sdk/typescript/src/http.ts
+++ b/sdk/typescript/src/http.ts
@@ -19,7 +19,7 @@ export interface RequestOptions {
  * this string is already what Fountain's request logs are keyed on. The
  * version half is asserted against `package.json` by a test.
  */
-export const USER_AGENT = "fountain-sdk-js/1.30.0";
+export const USER_AGENT = "fountain-sdk-js/1.31.0";
 
 /**
  * The thin layer everything else is built on: one bearer token, JSON in and

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -1,6 +1,6 @@
 export { Fountain, type FountainOptions, type RunConfig } from "./client.ts";
 export { Run, type RunOptions } from "./run.ts";
-export { Conversation, type SendOptions } from "./conversation.ts";
+export { Conversation, type ReapplyOptions, type SendOptions } from "./conversation.ts";
 export { HttpClient, type FetchLike, type RequestOptions } from "./http.ts";
 export { Agents, ConnectionProviders, Connections, Environments, Vaults } from "./resources.ts";
 export { Team, TeamSchedules, type MessageOptions } from "./team.ts";

--- a/sdk/typescript/test/run.test.ts
+++ b/sdk/typescript/test/run.test.ts
@@ -451,6 +451,24 @@ describe("errors", () => {
     });
   });
 
+  // Omitted means "keep it", null means "clear it", and the two have to stay
+  // distinguishable all the way to the wire.
+  test("reapply sends only the fields it was given, null included", async () => {
+    fake.onTurn = (conversation, turnNumber) => {
+      fake.scriptTurn(conversation.id, { turnNumber, turnId: "t1", text: ["ok"] });
+    };
+    const run = client().run("go", { agent: "reposage" });
+    const id = await run.conversationId;
+    await run;
+
+    await client().resume(id).reapply();
+    assert.deepEqual(fake.reapplies.at(-1)?.body, {});
+
+    const updated = await client().resume(id).reapply({ agentId: "agent-2", vaultId: null });
+    assert.deepEqual(fake.reapplies.at(-1)?.body, { agent_id: "agent-2", vault_id: null });
+    assert.equal((updated as { vault_id?: unknown }).vault_id, null);
+  });
+
   test("a missing key fails before any request", async () => {
     const bare = new Fountain({ baseUrl, apiKey: "", profile: "no-such-profile" });
     await assert.rejects(() => bare.me(), /No Fountain API key/);

--- a/sdk/typescript/test/server.ts
+++ b/sdk/typescript/test/server.ts
@@ -125,6 +125,8 @@ export class FakeFountain {
   readonly busyTeammates = new Set<string>();
   /** Every permission answer that arrived, in order. */
   readonly answers: { conversationId: string; requestId: string; optionId: string }[] = [];
+  /** Every reapply body the server was sent, in order. */
+  readonly reapplies: { conversationId: string; body: Record<string, unknown> }[] = [];
   /** Called when one lands — script the rest of the held turn from here. */
   onAnswer: ((conversationId: string, requestId: string, optionId: string) => void) | null = null;
 
@@ -360,6 +362,11 @@ export class FakeFountain {
 
       if (rest === "/interrupt" || rest === "/terminate") return json(res, 200, { status: "ok" });
       if (rest === "/read" && req.method === "POST") return json(res, 204, null);
+      if (rest === "/reapply" && req.method === "POST") {
+        const selection = (body ?? {}) as Record<string, unknown>;
+        this.reapplies.push({ conversationId: conversation.id, body: selection });
+        return json(res, 200, { data: { ...summary(conversation), ...selection } });
+      }
       if (rest === "/tree") return json(res, 200, { data: { id: conversation.id, children: [] } });
       if (rest === "/events") return this.eventPage(res, conversation, url);
       if (rest === "/stream") return this.stream(req, res, conversation, url);


### PR DESCRIPTION
The manual and the three SDKs #1892 left, plus the one version bump the stack makes.

`docs/api.md` gets the endpoint, the three-state body, what moves with it (the machine's binding identity, the skills reconciliation, the revision) and every refusal by status. `docs/concepts/conversation.md` gets the short version beside prompts and interrupts, and `docs/reference/webhooks.md` gets the `configuration`/`done` stage.

Python, Elixir and Swift get the method, each in its own idiom for the one thing the wire format needs: an omitted field and an explicit null are different requests. Python uses an `_UNSET` sentinel, Elixir reads `Keyword.has_key?`, and Swift has a three-case `ConversationBindingUpdate` rather than a plain optional that cannot tell "leave it" from "remove it". Each SDK's test asserts the encoded body, not just the call.

Versions: TypeScript 1.30.0 → **1.31.0**, Python 0.1.1 → 0.2.0, Elixir 0.1.0 → 0.2.0. Swift is unversioned.

The TypeScript bump is re-cut on top of 1.30.0 on `main`, preserving the intervening OAuth, sandbox-queue, and detached-permission releases.

> [!IMPORTANT]
> **Re-check the TypeScript version against `main` immediately before merge.** Concurrent bumps must land in ascending order, and this one has already been re-bumped once for exactly that reason. Merging a bump publishes, and a publish moves the `latest` tag.

Checked: `docs-style.py` (two pre-existing findings, neither on a page this touches), `vale lint` (no new hit on any of the six gating rules), `destink` (112 pages clean), `docs_test.exs`, and all four SDK suites and contract checks including `swift test` (82 tests).

## What this stack carries from #1569, and what it does not

Everything #1569 decided is here, re-derived against today's code. Two deliberate departures, both noted on the PR that makes them:

- **The shared attach/reapply transaction** (#1889). `main`'s `create_attached_conversation/3` already rechecks `check_attachable/4` under `FOR SHARE` on the sandbox row, which a reapply's `update_sandbox` conflicts with, so the attach path needs no change and the lock helper is private to `Conversations`.
- **Runtime resolution in the skills reconciliation** (#1891) goes through `Fountain.RuntimeDispatch`, not the library's own dispatcher, for the reason #1634 gives.

One thing #1569 got wrong and this does not: its docs and SDK doc comments said a reapply moves the conversation to "a fresh machine", which contradicts the change itself. The machine is kept; that is the whole point.

Out of scope in #1569 and still out of scope here: the conversations UI, which lives in its own repository.

Part 8 of 8 for #1565, on #1892.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9jevFQT5MkF3rJUieeiHW


---

### The stack (#1565, re-cut from #1569)

| | PR | What it covers |
|---|---|---|
| 1 | #1886 | server subtraction, no behaviour change, room for the rest |
| 2 | #1887 | the revision, build-fingerprint and applied-skills columns |
| 3 | #1888 | `Reapply.check/2`: what can be reconfigured in place, and what cannot |
| 4 | #1889 | `Conversations.reapply_conversation/3`, audited, under the sandbox lock |
| 5 | #1890 | the revision at turn admission, and the live server refresh |
| 6 | #1891 | skills reconciliation, on a live reapply and on every wake |
| 7 | #1892 | `POST /api/conversations/:id/reapply` and its status-code contract |
| 8 | #1893 | the manual, Python, Elixir, Swift, and the version bump |

Merge top down. Do not `--delete-branch` while a child still points at a branch.




Closes #1565



### Queue preparation

Targets `main` for the merge queue and retains #1891 and #1892 as ancestors. Queue after #1892. TypeScript is now 1.31.0, above main's 1.30.0; Python and Elixir remain 0.2.0. The restack preserves the reviewed feature patches and intervening changelog entries.

Validation on the restacked tip: `mix precommit` passed (5,457 core tests, 177 extension tests, zero failures); TypeScript 110, Python 44, Elixir SDK 52, and Swift 82 tests passed. OpenAPI/contract regeneration and TypeScript generation produced no drift.
