### PR TITLE
chore(deps): ignore TypeScript majors for the TypeScript SDK

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -62,8 +62,17 @@ updates:
       # Majors as a class, not 6.x alone: the peer pins the 5 line, so 6, 7 and
       # anything after it break identically. Minors and patches still arrive,
       # grouped above.
+      # `ignore` withholds security updates too, not just version updates, so a
+      # TypeScript advisory fixed only in 6.x or later would also be held back.
+      # Accepted: it is a devDependency, never shipped to SDK consumers, and the
+      # 5.x line still gets patches through the group.
       # Delete this entry when openapi-typescript declares support for a newer
-      # TypeScript major, and bump both together (#1759).
+      # TypeScript major, and bump both together (#1759). Deleting it does not
+      # restore 7.x on its own: #1557 used `@dependabot ignore this major
+      # version`, recording `typescript [>= 7.a, < 8]` in dependabot's central
+      # state, which no file here shows. Run
+      # `@dependabot show typescript ignore conditions` to see what is stored,
+      # then `@dependabot unignore typescript [>= 7.a, < 8]` to clear it.
       - dependency-name: typescript
         update-types: ["version-update:semver-major"]
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,6 +45,27 @@ updates:
     groups:
       sdk-typescript:
         update-types: [minor, patch]
+    ignore:
+      # The SDK generates `src/generated/openapi.ts` with openapi-typescript,
+      # which builds its AST through the compiler API it imports directly
+      # (`import ts from 'typescript'`, dist/lib/ts.mjs:2) and so declares
+      # `peerDependencies: {"typescript": "^5.x"}`. Every published release
+      # carries that peer, 7.7.3 through 7.13.0 (`latest`); the `next` tag is
+      # the older 7.0.0-rc.1. A TypeScript major above 5 therefore makes the
+      # tree unresolvable and `npm ci` exits 1 on ERESOLVE before typecheck,
+      # tests, build, `verify-contract`, conformance or the generated-types
+      # freshness diff get to say whether the compiler itself is fine
+      # (ci.yml `SDK install`, and sdk-publish.yml runs the same install).
+      # `--legacy-peer-deps` is not the way out: it would run a TS-5-targeting
+      # generator against the newer compiler API, and the `SDK types match the
+      # spec` step fails on any diff in the regenerated output.
+      # Majors as a class, not 6.x alone: the peer pins the 5 line, so 6, 7 and
+      # anything after it break identically. Minors and patches still arrive,
+      # grouped above.
+      # Delete this entry when openapi-typescript declares support for a newer
+      # TypeScript major, and bump both together (#1759).
+      - dependency-name: typescript
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: npm
     directory: /scripts/destink


### PR DESCRIPTION
Stops #1759 ("bump typescript from 5.9.3 to 6.0.3 in /sdk/typescript") from reopening weekly and burning a full CI run, until upstream makes the bump possible.

## Why the bump cannot land

`sdk/typescript` generates `src/generated/openapi.ts` with `openapi-typescript`, and that generator peers on the TypeScript 5 line. Measured against the registry today (2026-09-11):

```
$ npm view openapi-typescript@latest version peerDependencies
version = '7.13.0'
peerDependencies = { typescript: '^5.x' }

$ npm view openapi-typescript dist-tags --json
{ "swagger-v2": "5.4.2", "next": "7.0.0-rc.1", "latest": "7.13.0" }
```

Every published release on the current line carries the same peer, so there is no generator version to pair a TypeScript 6 bump with:

| version | `peerDependencies` |
| --- | --- |
| 7.7.3 | `{"typescript": "^5.x"}` |
| 7.8.0 | `{"typescript": "^5.x"}` |
| 7.9.0 | `{"typescript": "^5.x"}` |
| 7.9.1 | `{"typescript": "^5.x"}` |
| 7.10.0 | `{"typescript": "^5.x"}` |
| 7.10.1 | `{"typescript": "^5.x"}` |
| 7.12.0 | `{"typescript": "^5.x"}` |
| 7.13.0 (`latest`) | `{"typescript": "^5.x"}` |
| 7.0.0-rc.1 (`next`) | `{"typescript": "^5.x"}` |

The peer is load-bearing, not decorative. Unpacking the published tarball, the generator builds its AST through whichever compiler is installed:

```
$ tar -xzf openapi-typescript-7.13.0.tgz
$ head -2 package/dist/lib/ts.mjs
import { parseRef } from '@redocly/openapi-core/lib/ref-utils.js';
import ts from 'typescript';
```

Ten more `dist/` modules import it the same way. So `--legacy-peer-deps` is not an escape hatch: it would run a TS-5-targeting generator against the newer compiler API, and the output is diff-gated by the `SDK types match the spec` step, which regenerates the file and fails on any change.

The consequence in CI is that `npm ci` exits 1 on `ERESOLVE` at the `SDK install` step of both affected jobs, so every gate that would tell us whether TypeScript 6 is actually safe for this package — typecheck, tests, build, browser bundle, `verify-contract`, conformance, the freshness diff — never runs. `sdk-publish.yml` uses the same install command, so the break would surface at publish time rather than at PR time if it landed.

## What this changes

The `sdk-typescript` group is `update-types: [minor, patch]`, so a major arrives as its own ungrouped PR. The ignore condition already recorded against #1759 is `typescript [>= 7.a, < 8]`, which does not cover 6.x — hence the weekly reopen.

This adds an `ignore:` entry on the `/sdk/typescript` npm update:

```yaml
    ignore:
      - dependency-name: typescript
        update-types: ["version-update:semver-major"]
```

**Majors as a class rather than `6.x` alone**, because the peer pins the 5 line: 6, 7 and anything after it break identically, and a `6.x`-only range would just move the weekly PR to the next major. Minors and patches still arrive through the existing group, so `typescript@^5.7.0` keeps getting updated.

### How the entry was verified

Nothing in this repo lints `dependabot.yml` — which is how the sibling bug in #1866 shipped as a silent no-op — so the entry was checked directly:

- Parsed with `yaml.safe_load` and validated against the SchemaStore [`dependabot-2.0.json`](https://json.schemastore.org/dependabot-2.0.json) schema: **valid**. `update-types` is an accepted key inside `ignore`, and `version-update:semver-major` is in its enum.
- Asserted structurally that the entry lands on the `npm` + `/sdk/typescript` update and nowhere else, that the `/scripts/destink` npm entry is untouched, and that the `sdk-typescript` group still reads `[minor, patch]`.
- `5.9.3 -> 6.0.3` is a major version update by definition, so it is what this condition suppresses.

This is the **npm** ecosystem, so npm requirement semantics apply — unlike the `github-actions` block in #1866, where `versions` parses as a Bundler requirement. Using `update-types` sidesteps range spelling entirely.

## Follow-ups

- **Remove this entry when `openapi-typescript` declares support for a newer TypeScript major**, and bump both together. The comment in the file says so.
- #1759 should be closed once this merges. I have commented there with this evidence and a link here, but left the close to you.
- **#1866 is concurrently editing the `ignore:` block of the same file** (its `github-actions` entry, ~35 lines above this hunk). The two hunks are far apart and should not textually conflict, but whichever merges second may want a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UpTFaSbu4oL7XwxByqx8Mk
