### PR TITLE
fix(principals): clamp a principal's sandbox cap to the application's own (#1687)

### DIFF
--- a/apps/fountain/lib/fountain/principals.ex
+++ b/apps/fountain/lib/fountain/principals.ex
@@ -29,8 +29,10 @@ defmodule Fountain.Principals do
     * `max_live_sandboxes` is written to `users.sandbox_limit_override`, so
       `Fountain.Quotas` needs no knowledge of principals: the override branch
       answers before the balance rule is ever consulted. Because it answers
-      first, it is clamped at creation to the application's own effective cap,
-      so a principal can never out-provision the account funding it (#1687).
+      first, it is clamped at creation to the application's own effective cap
+      under the deployment ceiling, so a principal can never out-provision the
+      account funding it — and never below one, because a zero written there is
+      a gate that funding cannot reopen (#1687).
     * `max_cost_usd` is a credit grant moved from the application's balance
       into the principal's, so budget exhaustion is `Billing.check_spend/1`
       refusing at every door that spends (ADR 0031). With credits off nothing
@@ -205,10 +207,6 @@ defmodule Fountain.Principals do
   # *before* the balance rule and the cap ceiling are ever consulted. Unclamped,
   # a full-scope key could mint principals on a cent each that out-provision the
   # account funding them, up to `SANDBOX_FLEET_CEILING` (#1687).
-  #
-  # Read by **id**, for the reason `check_application_allowed/2` gives about the
-  # balance: the `%User{}` the caller loaded carries a cached cap input that may
-  # predate its own opening credit.
   defp cast_create(%User{} = application, params) do
     %{max_ttl_seconds: max_ttl, default_ttl_seconds: default_ttl, max_grant_cents: max_grant} =
       settings()
@@ -243,10 +241,40 @@ defmodule Fountain.Principals do
              limits
              |> Map.get("max_live_sandboxes")
              |> as_integer(1)
-             |> clamp(0, Fountain.Quotas.sandbox_limit(application.id)),
+             |> clamp(0, application_cap(application)),
            metadata: Map.get(params, "metadata", %{})
          }}
     end
+  end
+
+  # What the application may hand a principal: its own effective cap, itself
+  # held to the deployment ceiling, and never below one.
+  #
+  # Read by **id**, for the reason `check_application_allowed/2` gives about
+  # the balance: the `%User{}` the caller loaded carries a cached cap input
+  # that may predate its own opening credit.
+  #
+  # `min(cap_ceiling)` because `resolve_limit/3` returns an application's *own*
+  # `sandbox_limit_override` unclamped — an admin lever of 50 under a ceiling
+  # of 20 would otherwise be inherited by every principal it opens.
+  #
+  # `max(1)` because an application with an empty balance has an effective cap
+  # of zero, and a zero written here is durable: `resolve_limit/3` answers with
+  # the override before the balance rule, no claim clears it, and only an
+  # operator can undo it. That is the 0/0 quota `Fountain.Quotas` says never to
+  # show, on a principal that funding cannot reopen. The gate is the balance
+  # (ADR 0031) — `check_spend/1` refuses a principal with no credit at every
+  # door that spends, and stops refusing the moment it has some — so a cap of
+  # one on a broke application's principal costs nothing and heals itself. An
+  # *explicit* zero is still honoured: that is an application asking for a
+  # principal that runs nothing, which the schema has always allowed.
+  defp application_cap(%User{} = application) do
+    %{cap_ceiling: ceiling} = Fountain.Quotas.settings()
+
+    application.id
+    |> Fountain.Quotas.sandbox_limit()
+    |> min(ceiling)
+    |> max(1)
   end
 
   # The application funds its principals out of its own balance, so it must

--- a/apps/fountain/lib/fountain/principals.ex
+++ b/apps/fountain/lib/fountain/principals.ex
@@ -28,7 +28,9 @@ defmodule Fountain.Principals do
 
     * `max_live_sandboxes` is written to `users.sandbox_limit_override`, so
       `Fountain.Quotas` needs no knowledge of principals: the override branch
-      answers before the balance rule is ever consulted.
+      answers before the balance rule is ever consulted. Because it answers
+      first, it is clamped at creation to the application's own effective cap,
+      so a principal can never out-provision the account funding it (#1687).
     * `max_cost_usd` is a credit grant moved from the application's balance
       into the principal's, so budget exhaustion is `Billing.check_spend/1`
       refusing at every door that spends (ADR 0031). With credits off nothing
@@ -191,13 +193,23 @@ defmodule Fountain.Principals do
           {:ok, %{claimable: ClaimableUser.t(), api_key: String.t(), claim_token: String.t()}}
           | {:error, term()}
   def create_claimable(%User{} = application, params, opts \\ []) do
-    with {:ok, attrs} <- cast_create(params),
+    with {:ok, attrs} <- cast_create(application, params),
          {:ok, claimable} <- upsert_claimable(application, attrs, opts) do
       issue_credentials(claimable, opts)
     end
   end
 
-  defp cast_create(params) do
+  # A third ceiling in the spirit of the two in `check_application_allowed/2`,
+  # bounding a leaked application key: `max_live_sandboxes` lands on
+  # `users.sandbox_limit_override`, which `Quotas.resolve_limit/3` answers with
+  # *before* the balance rule and the cap ceiling are ever consulted. Unclamped,
+  # a full-scope key could mint principals on a cent each that out-provision the
+  # account funding them, up to `SANDBOX_FLEET_CEILING` (#1687).
+  #
+  # Read by **id**, for the reason `check_application_allowed/2` gives about the
+  # balance: the `%User{}` the caller loaded carries a cached cap input that may
+  # predate its own opening credit.
+  defp cast_create(%User{} = application, params) do
     %{max_ttl_seconds: max_ttl, default_ttl_seconds: default_ttl, max_grant_cents: max_grant} =
       settings()
 
@@ -227,7 +239,11 @@ defmodule Fountain.Principals do
            expires_at: DateTime.utc_now() |> DateTime.add(ttl, :second) |> truncate(),
            grant_cents:
              limits |> Map.get("max_cost_usd") |> usd_to_cents() |> clamp(0, max_grant),
-           max_live_sandboxes: limits |> Map.get("max_live_sandboxes") |> as_integer(1) |> max(0),
+           max_live_sandboxes:
+             limits
+             |> Map.get("max_live_sandboxes")
+             |> as_integer(1)
+             |> clamp(0, Fountain.Quotas.sandbox_limit(application.id)),
            metadata: Map.get(params, "metadata", %{})
          }}
     end

--- a/apps/fountain/test/fountain/principals_test.exs
+++ b/apps/fountain/test/fountain/principals_test.exs
@@ -13,6 +13,7 @@ defmodule Fountain.PrincipalsTest do
   alias Fountain.Credits
   alias Fountain.Principals
   alias Fountain.Principals.ClaimableUser
+  alias Fountain.Quotas
 
   defp application_account, do: insert_verified_user()
 
@@ -52,10 +53,51 @@ defmodule Fountain.PrincipalsTest do
 
     test "max_live_sandboxes lands on the override the quota rule already reads" do
       app = application_account()
-      %{claimable: c} = open(app, %{"limits" => %{"max_live_sandboxes" => 3}})
+      asked = Quotas.sandbox_limit(app.id)
+      assert asked > 0
 
-      assert Accounts.get_user(c.user_id).sandbox_limit_override == 3
-      assert Fountain.Quotas.sandbox_limit(c.user_id) == 3
+      %{claimable: c} = open(app, %{"limits" => %{"max_live_sandboxes" => asked}})
+
+      assert Accounts.get_user(c.user_id).sandbox_limit_override == asked
+      assert Quotas.sandbox_limit(c.user_id) == asked
+    end
+
+    test "an unasked-for cap is still the default of one" do
+      app = application_account()
+      %{claimable: c} = open(app)
+
+      assert c.max_live_sandboxes == 1
+      assert Quotas.sandbox_limit(c.user_id) == 1
+    end
+
+    test "max_live_sandboxes cannot out-provision the account that funds it (#1687)" do
+      app = application_account()
+      app_limit = Quotas.sandbox_limit(app.id)
+      assert app_limit > 0
+
+      %{claimable: c} = open(app, %{"limits" => %{"max_live_sandboxes" => 100_000}})
+
+      assert c.max_live_sandboxes == app_limit
+      assert Accounts.get_user(c.user_id).sandbox_limit_override == app_limit
+      # The property, not the number: the override branch of `resolve_limit/3`
+      # answers before the balance rule, so an unclamped value here would let a
+      # $5 account fill `SANDBOX_FLEET_CEILING` a cent at a time.
+      assert Quotas.sandbox_limit(c.user_id) <= Quotas.sandbox_limit(app.id)
+    end
+
+    test "a richer application is still held to the deployment's cap ceiling" do
+      app = application_account()
+
+      {:ok, _} =
+        Credits.grant(app.id, 1_000_000, "grant_admin", idempotency_key: "test_rich:#{app.id}")
+
+      ceiling = Quotas.settings().cap_ceiling
+      assert Quotas.sandbox_limit(app.id) == ceiling
+
+      %{claimable: c} = open(app, %{"limits" => %{"max_live_sandboxes" => 100_000}})
+
+      assert c.max_live_sandboxes == ceiling
+      assert Quotas.sandbox_limit(c.user_id) == ceiling
     end
 
     test "the budget is moved from the application's balance into the principal's" do

--- a/apps/fountain/test/fountain/principals_test.exs
+++ b/apps/fountain/test/fountain/principals_test.exs
@@ -85,6 +85,59 @@ defmodule Fountain.PrincipalsTest do
       assert Quotas.sandbox_limit(c.user_id) <= Quotas.sandbox_limit(app.id)
     end
 
+    test "an application's empty balance cannot mint a principal funding cannot revive" do
+      app = application_account()
+
+      # Drain the opening credit: the application's own cap is now zero, and
+      # `check_application_allowed/2` still lets it open an unfunded principal
+      # because the balance check only runs for a grant above zero.
+      {:ok, _} =
+        Credits.debit(app.id, Credits.balance(app.id), "burn_turn",
+          idempotency_key: "test_drain:#{app.id}"
+        )
+
+      assert Quotas.sandbox_limit(app.id) == 0
+
+      %{claimable: c, claim_token: token} = open(app)
+
+      # Not zero. `resolve_limit/3` answers with the override before the
+      # balance rule, so a zero here would outlive every later credit.
+      assert c.max_live_sandboxes == 1
+
+      {:ok, _} = Principals.claim(c.id, token, insert_verified_user())
+
+      {:ok, _} =
+        Credits.grant(c.user_id, 100_000, "grant_admin",
+          idempotency_key: "test_fund:#{c.user_id}"
+        )
+
+      assert Fountain.Credits.gate(c.user_id) == :ok
+      assert Quotas.sandbox_limit(c.user_id) > 0
+    end
+
+    test "an explicitly requested cap of zero is still honoured" do
+      app = application_account()
+      %{claimable: c} = open(app, %{"limits" => %{"max_live_sandboxes" => 0}})
+
+      # The floor stops the *clamp* zeroing a cap, not an application asking
+      # for a principal that runs nothing.
+      assert c.max_live_sandboxes == 0
+    end
+
+    test "an application's admin override does not reach its principals" do
+      app = application_account()
+      ceiling = Quotas.settings().cap_ceiling
+      {:ok, app} = Accounts.update_sandbox_limit(app, ceiling + 30, actor: "admin")
+
+      # `resolve_limit/3` returns an override unclamped, so without the
+      # `min(cap_ceiling)` the principal would inherit the operator's lever.
+      assert Quotas.sandbox_limit(app.id) == ceiling + 30
+
+      %{claimable: c} = open(app, %{"limits" => %{"max_live_sandboxes" => 100_000}})
+
+      assert c.max_live_sandboxes == ceiling
+    end
+
     test "a richer application is still held to the deployment's cap ceiling" do
       app = application_account()
 

--- a/decisions/0044-claimable-principals.md
+++ b/decisions/0044-claimable-principals.md
@@ -95,7 +95,13 @@ abandoning what it already has.
    application, a `grant_application` on the principal), and writes
    `max_live_sandboxes` to `users.sandbox_limit_override`. So budget
    exhaustion is `Billing.check_spend/1` refusing at every door that spends
-   (ADR 0031), and concurrency is `Fountain.Quotas` unchanged. Releasing an
+   (ADR 0031), and concurrency is `Fountain.Quotas` unchanged. Both asks are
+   clamped to what the application itself has: `max_cost_usd` to
+   `max_grant_cents`, and `max_live_sandboxes` to the application's own
+   effective `Quotas.sandbox_limit/1` under `SANDBOX_CAP_CEILING`, never below
+   one. The override branch of `resolve_limit/3` answers before the balance
+   rule, so an unclamped cap would out-provision the account funding it and a
+   zero one would be a gate no later credit could reopen (#1687). Releasing an
    unclaimed principal expires its remaining lot and refunds the application.
 
 4. **After a claim, the owner's ledger funds the work.**

--- a/docs/build/anonymous-visitors.md
+++ b/docs/build/anonymous-visitors.md
@@ -53,6 +53,13 @@ curl -sX POST https://your-fountain/api/claimable-users \
 Keep `api_key` and `claim_token` in the visitor's session. Fountain stores only
 their hashes and shows them once.
 
+Fountain reduces a limit that your application cannot supply. The deployment
+maximum bounds `expires_in`. The maximum grant bounds `max_cost_usd`. Your
+application's own sandbox cap bounds `max_live_sandboxes`, and the deployment
+ceiling bounds that cap. A principal thus never runs more sandboxes than the
+account that pays for it. Read `max_live_sandboxes` in the response for the
+value in force.
+
 Now use `api_key` as any other Fountain key. Make an agent, start a
 conversation, watch the events stream. The computer is live before the visitor
 has an account.


### PR DESCRIPTION
## Mechanism

`Fountain.Principals.cast_create/1` read `limits.max_live_sandboxes` off the
request, floored it at zero, and wrote it to `users.sandbox_limit_override`
(`principals.ex:328`). `Quotas.resolve_limit/3` answers with that override
*first*:

```elixir
defp resolve_limit(override, _balance, _comped) when is_integer(override), do: override
```

so neither the balance rule nor `SANDBOX_CAP_CEILING` ever ran for a
principal. Any full-scope key could open principals with
`max_cost_usd: 0.01` and `max_live_sandboxes: 100000` and take
`SANDBOX_FLEET_CEILING` a cent at a time. `sandbox_limit_override` was an
admin-only lever (`accounts.ex:1044`) until #1564 taught the principals route
to write it, and nothing re-bounded it on the way.

## The fix

`cast_create/2` now takes the application and clamps the cap to what that
account may actually hand on — the issue's preferred option, in the same
`clamp(0, ceiling)` shape `grant_cents` already uses against
`max_grant_cents`:

```elixir
max_live_sandboxes:
  limits
  |> Map.get("max_live_sandboxes")
  |> as_integer(1)
  |> clamp(0, application_cap(application)),

defp application_cap(%User{} = application) do
  %{cap_ceiling: ceiling} = Fountain.Quotas.settings()

  application.id
  |> Fountain.Quotas.sandbox_limit()
  |> min(ceiling)
  |> max(1)
end
```

Each of the three steps exists for a different failure, and the comment above
the function says which:

- **the application's own cap** is the fix for the reported bug: a principal
  can never out-provision the account funding it. Read by **id**, not off the
  `%User{}` the caller passed, for the reason `check_application_allowed/2`
  already gives about a struct's cached balance.
- **`min(cap_ceiling)`** because `resolve_limit/3` returns an application's
  *own* `sandbox_limit_override` unclamped. An admin lever of 50 under a
  ceiling of 20 would otherwise be inherited by every principal it opens. (An
  earlier revision of this PR claimed the ceiling came along for free; that
  was only true of the balance-derived branch. Review caught it.)
- **`max(1)`** because `check_application_allowed/2` only checks the balance
  for a grant above zero, so a drained application asking `max_cost_usd: 0`
  passes it with an effective cap of 0. A zero written to the override is
  *durable* — `resolve_limit/3` answers with it before the balance rule, no
  claim clears it, only an operator can undo it — so that principal would
  report 0/0 even after being claimed and funded, with `Credits.gate` saying
  `:ok`. That is the 0/0 quota `quotas.ex:124` and `:244` say never to show,
  and it would be a regression, since the cap defaulted to 1 before this
  branch. The gate is the balance (ADR 0031): `check_spend/1` refuses an
  unfunded principal at every door that spends and stops refusing once it has
  credit, so a floor of 1 costs nothing and heals itself.

An **explicitly** requested `0` is still honoured, with a test pinning it:
that is an application asking for a principal that runs nothing, which
`ClaimableUser.changeset/2` has always permitted. The floor bounds the clamp,
not the caller.

Nothing else moves: the audit event already records `max_live_sandboxes`, and
it now records the clamped value — the one that took effect.

## Behaviour change worth knowing

A verified account holds the $5 opening credit, so its own cap is 2. An
application asking for more than it can itself run now gets its own number
rather than the number it asked for. The existing pass-through test asked for
3 and asserted 3 — it was asserting the bug — and now asks for the
application's own cap and asserts that.

## Verification

`apps/fountain` on the mise-pinned toolchain (Elixir 1.19.2 / OTP 28):

- `MIX_ENV=test mix compile --warnings-as-errors` — clean
- `mix credo --strict` on the changed files (from the umbrella root; credo is
  not a dep of `apps/fountain`) — no issues
- `mix format --check-formatted` — clean
- principals + principals_ceiling + quotas + quotas_fleet_ceiling +
  claimable_user_controller + audit_guardrail — **168 tests, 0 failures**
- `docs_test.exs` — 29/29 after the docs edit
- `okf validate decisions` valid, regenerated index unchanged
- vale on the edited page: 44 → 52 `STE.Vocabulary` suggestions (advisory;
  the added words are ones the page already uses), **0 errors, 0 warnings**
  on the six gating rules

**Every guard was verified by reverting the line it guards**, not the whole
change:

| Reverted | Failing test | Measured |
|---|---|---|
| the clamp (`\|> max(0)` back) | `cannot out-provision the account that funds it` | `left: 100000, right: 2` |
| the clamp, richly funded | `still held to the deployment's cap ceiling` | `left: 100000, right: 20` |
| `\|> max(1)` | `empty balance cannot mint a principal funding cannot revive` | `left: 0, right: 1` |
| `\|> min(ceiling)` | `admin override does not reach its principals` | `left: 50, right: 20` |

The zero-balance test walks the whole sequence: drain the application with a
`burn_turn` debit, open a principal, claim it, fund it 100,000 cents, then
assert `Credits.gate == :ok` **and** `Quotas.sandbox_limit > 0`.

Two further tests pass either way by design — the pass-through and the
default of one — and guard against the clamp becoming "always the
application's cap".

## Documented

ADR 0044 decision 3 and `docs/build/anonymous-visitors.md` now say the asked
limits are bounded by what the application itself holds.

## Not fixed here

**The aggregate.** A $5 account can still open 500 principals at 2 slots each,
so ~1,000 slots, bounded only by `SANDBOX_FLEET_CEILING` and
`max_outstanding_per_application`. Per-principal clamping cannot reach that;
it needs an aggregate over a tenant's live principals, or a cap funded from
the *remaining* balance rather than the whole of it. Out of scope for a P1
clamp, but it is the next question this area asks.

**The OpenAPI request schema** documents neither this clamp nor the
pre-existing `max_cost_usd` one. Adding a description there regenerates the
spec and the SDK contract artifact; the two clamps are worth documenting
together in a follow-up.

Closes #1687

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DMNzkuh8mJbde1TQvsYsqj
