### PR TITLE
fix(sandbox-files): redact before the caller's byte cap, not after

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,19 @@ upgrade, is in
   compatible endpoint is unchanged: it still synthesizes a caption for an
   image-only message, because clients of that dialect cannot always send one.
 
+- **`truncated` on a sandbox file or diff now means "this is not the whole
+  thing", not "the cap was reached"** (#1907). On
+  `GET /api/sandboxes/:id/file` and `GET /api/sandboxes/:id/diff` it is still
+  true when the file or diff is longer than `max_bytes`, and it is now also
+  true when redaction grew what was read past that cap — which happens when
+  `[REDACTED]` is longer than the value it stands in for. So a file that fits
+  `max_bytes` can come back `truncated: true` with its content cut. The
+  widening errs safe: `truncated: false` still means the bytes are complete,
+  which is the direction a caller depends on, and the new true case tells a
+  caller to ask for more. The field has been published since SDK 1.15.0; its
+  description changed with it, in the OpenAPI document and in the generated
+  TypeScript types.
+
 ### Added
 
 - **An `acp` runtime launches a named command, so a deterministic program can
@@ -550,6 +563,29 @@ upgrade, is in
   outbound WebSocket client to one known host, and Fountain serves HTTP with
   **Bandit, not Cowboy**, so cowlib is not on the inbound request path.
   Tracking upstream; `mix hex.audit` reports them and does not fail the build.
+- **A sandbox file read could return a fragment of a secret, at a byte offset
+  the caller chose** (#1907). `GET /api/sandboxes/:id/file` and
+  `GET /api/sandboxes/:id/diff` capped their output in the shell with
+  `head -c` and redacted in Elixir over whatever survived the cut. Redaction
+  matches a value's own bytes, so a cut through one left a prefix that matched
+  nothing and travelled on in the clear. On `/file` the cut lands at
+  `max_bytes`, which the caller sends, so this was not an occasional boundary
+  artifact that depended on where a value happened to sit: the caller decided
+  where the boundary fell relative to a value, and could walk it. Reading the
+  sandbox's `.env` that way is exactly what ADR 0039 decision 5 says is
+  prevented, and the reader need not be the tenant whose vault values
+  redaction protects — a `full`-scope key includes one issued to a
+  third-party OAuth app the user authorized. Both endpoints now ask their
+  script for enough bytes past the cap that a value lying across it arrives
+  whole (one less than the longest known value, which is the widest one can
+  straddle it), redact that, and only then cut the result down to what was
+  asked for. That last cut is taken in the bytes the script produced rather
+  than in the redacted text, because a value replaced by a shorter
+  `[REDACTED]` moves every byte behind it forward and could otherwise carry
+  an unmatched fragment back inside the cap. `/git-status` was never affected:
+  it drops a record its cap bisected rather than returning it. The change to
+  what `truncated` reports is under **Changed** above. Present since `/file`
+  and `max_bytes` shipped with ADR 0039, and published in SDK 1.15.0.
 
 ## [0.16.0] - 2026-09-03
 

--- a/apps/fountain/lib/fountain/sandbox_files.ex
+++ b/apps/fountain/lib/fountain/sandbox_files.ex
@@ -223,6 +223,10 @@ defmodule Fountain.SandboxFiles do
   itself when it is valid UTF-8 (`encoding: "utf-8"`) and base64 otherwise
   (`encoding: "base64"`); `size` is the whole file and `truncated` says
   whether `content` stopped short of it.
+
+  Redaction runs before the cap, never after: `max_bytes` is the caller's to
+  choose, so a cut taken first would let them place it inside a value and
+  read the piece in front of it (#1907).
   """
   @spec read(Sandbox.t(), String.t(), keyword()) ::
           {:ok,
@@ -239,16 +243,23 @@ defmodule Fountain.SandboxFiles do
 
     with :ok <- ready?(sandbox),
          {:ok, absolute} <- resolve_path(sandbox, path),
-         {:ok, output} <- run(sandbox, read_script(), [Integer.to_string(max_bytes), absolute]),
+         values = secret_values(sandbox),
+         # `overlap/1` bytes past the cap, so a secret lying across it is
+         # whole when redaction runs; `redact_to_cap/3` cuts back down.
+         {:ok, output} <-
+           run(sandbox, read_script(), [
+             Integer.to_string(max_bytes + overlap(values)),
+             absolute
+           ]),
          {:ok, size, bytes} <- parse_read(output) do
-      bytes = redact(sandbox, bytes)
+      {bytes, capped?} = redact_to_cap(values, bytes, max_bytes)
       {encoding, content} = encode(bytes)
 
       {:ok,
        %{
          path: absolute,
          size: size,
-         truncated: size > max_bytes,
+         truncated: size > max_bytes or capped?,
          encoding: encoding,
          content: content
        }}
@@ -280,27 +291,23 @@ defmodule Fountain.SandboxFiles do
     with :ok <- ready?(sandbox),
          {:ok, ref} <- validate_ref(ref),
          {:ok, absolute} <- resolve_path(sandbox, path),
-         # One byte past the cap tells truncation from an exact fit.
+         values = secret_values(sandbox),
+         # One byte past the cap tells truncation from an exact fit, and
+         # `overlap/1` past that is what lets redaction see a secret lying
+         # across the cap whole.
          {:ok, output} <-
            run(
              sandbox,
              diff_script(),
              [
                absolute,
-               Integer.to_string(max_bytes + 1),
+               Integer.to_string(max_bytes + 1 + overlap(values)),
                ref || "",
                if(staged, do: "1", else: "0")
              ] ++ roots(sandbox)
            ),
          {:ok, root, bytes} <- parse_diff(output) do
-      truncated = byte_size(bytes) > max_bytes
-
-      values = secret_values(sandbox)
-
-      text =
-        bytes
-        |> binary_part(0, min(byte_size(bytes), max_bytes))
-        |> then(&redact_with(values, &1))
+      {text, capped?} = redact_to_cap(values, bytes, max_bytes)
 
       {:ok,
        %{
@@ -312,7 +319,7 @@ defmodule Fountain.SandboxFiles do
          staged: staged,
          ref: ref,
          diff: to_text(text),
-         truncated: truncated
+         truncated: byte_size(bytes) > max_bytes or capped?
        }}
     end
   end
@@ -754,8 +761,8 @@ defmodule Fountain.SandboxFiles do
   defp redact(%Sandbox{} = sandbox, bytes) when is_binary(bytes),
     do: redact_with(secret_values(sandbox), bytes)
 
-  # `secret_values/1` reads the vault and the environment, so a caller with
-  # many strings to redact looks them up once and replaces many times.
+  # `secret_values/1` reads the vault and the environment, so a caller that
+  # needs the values for something else too looks them up once.
   defp redact_with([], bytes), do: bytes
 
   defp redact_with(values, bytes),
@@ -771,6 +778,53 @@ defmodule Fountain.SandboxFiles do
         renamed_from: change.renamed_from && to_text(redact_with(values, change.renamed_from))
     }
   end
+
+  # Redaction has to see a secret whole: `:binary.replace/4` matches the
+  # value's own bytes, so a cut through one leaves a prefix that matches
+  # nothing and travels on in the clear. The scripts cut first, with
+  # `head -c`, and on `read/3` the cut lands at `max_bytes` — which the
+  # caller chooses, making an incidental boundary case a repeatable one
+  # (#1907). So the scripts are asked for `overlap/1` bytes past the cap,
+  # redaction runs over that, and only then is the result cut to the cap.
+  #
+  # Returns the bytes and whether that last cut dropped anything, which it
+  # can when a value is shorter than the placeholder standing in for it.
+  defp redact_to_cap(values, bytes, max_bytes) do
+    kept = binary_part(bytes, 0, cut_at(values, bytes, max_bytes))
+    redacted = redact_with(values, kept)
+
+    if byte_size(redacted) > max_bytes,
+      do: {binary_part(redacted, 0, max_bytes), true},
+      else: {redacted, false}
+  end
+
+  # How much of `bytes` survives into redaction: the cap, carried forward to
+  # the end of a value lying across it. At most one value can, because
+  # matches do not overlap, and `:binary.matches/2` picks the same ones
+  # `:binary.replace/4` will.
+  #
+  # Cutting at the cap instead is the defect. Cutting *after* redacting is
+  # not the fix either: an earlier value replaced by a shorter placeholder
+  # shifts the bytes behind it, which can pull an unmatched fragment out of
+  # the overlap and back inside the cap.
+  defp cut_at([], bytes, max_bytes), do: min(byte_size(bytes), max_bytes)
+
+  defp cut_at(values, bytes, max_bytes) do
+    limit = min(byte_size(bytes), max_bytes)
+
+    bytes
+    |> :binary.matches(values)
+    |> Enum.find_value(limit, fn {start, length} ->
+      if start < limit and start + length > limit, do: start + length
+    end)
+  end
+
+  # How far past the cap a value can lie across it: one byte less than the
+  # longest, which `secret_values/1` sorts to the front. Ask a script for
+  # that many bytes more and any value with a byte inside the cap arrives
+  # whole.
+  defp overlap([]), do: 0
+  defp overlap([longest | _]), do: byte_size(longest) - 1
 
   # The identity's own values (what `.env` on that disk holds) plus what any
   # live server registered — the latter covers the inference credential and

--- a/apps/fountain/lib/fountain/sandbox_files.ex
+++ b/apps/fountain/lib/fountain/sandbox_files.ex
@@ -222,7 +222,8 @@ defmodule Fountain.SandboxFiles do
   #{@default_max_bytes}, at most #{@max_max_bytes}). `content` is the text
   itself when it is valid UTF-8 (`encoding: "utf-8"`) and base64 otherwise
   (`encoding: "base64"`); `size` is the whole file and `truncated` says
-  whether `content` stopped short of it.
+  whether `content` is short of it — because the file is longer than
+  `max_bytes`, or because redaction grew what was read past the cap.
 
   Redaction runs before the cap, never after: `max_bytes` is the caller's to
   choose, so a cut taken first would let them place it inside a value and

--- a/apps/fountain/lib/fountain_web/controllers/sandbox_files_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/sandbox_files_controller.ex
@@ -79,7 +79,8 @@ defmodule FountainWeb.SandboxFilesController do
         "vault is replaced with `[REDACTED]`, as in the transcript. `content` is the text " <>
         "when it is valid UTF-8 (`encoding: utf-8`) and base64 otherwise " <>
         "(`encoding: base64`). `size` is the whole file; `truncated` says whether `content` " <>
-        "stopped at `max_bytes`. Full scope.",
+        "is short of it, which happens when the file is longer than `max_bytes` and also " <>
+        "when redaction grows what was read past that cap. Full scope.",
     parameters: [
       sandbox_id: [in: :path, type: :string, required: true],
       path: Keyword.put(@path_param, :required, true),

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -200,7 +200,10 @@ defmodule FountainWeb.Schemas do
         size: %Schema{type: :integer, description: "The whole file, in bytes."},
         truncated: %Schema{
           type: :boolean,
-          description: "True when `content` stopped at `max_bytes` before the end of the file."
+          description:
+            "True when `content` is not the whole file: either the file is longer than " <>
+              "`max_bytes`, or redaction grew what was read past it. False means `content` " <>
+              "is everything."
         },
         encoding: %Schema{
           type: :string,
@@ -240,7 +243,9 @@ defmodule FountainWeb.Schemas do
         diff: %Schema{type: :string, description: "Unified diff, no colour."},
         truncated: %Schema{
           type: :boolean,
-          description: "True when `diff` stopped at `max_bytes` before the end."
+          description:
+            "True when `diff` is not the whole diff: either it is longer than `max_bytes`, " <>
+              "or redaction grew what was read past it. False means `diff` is everything."
         }
       },
       required: [:path, :repo_root, :staged, :diff, :truncated]

--- a/apps/fountain/test/fountain/sandbox_files_test.exs
+++ b/apps/fountain/test/fountain/sandbox_files_test.exs
@@ -8,6 +8,12 @@ defmodule Fountain.SandboxFilesTest do
 
   @home "/home/sprite"
 
+  # A value that shares not one character with the text around it or with
+  # `[REDACTED]`, so "no fragment of it survived" can be asserted byte by
+  # byte rather than by eye.
+  @straddled "QQWWZZ11223344556677"
+  @straddle_body "p=" <> @straddled <> "|xyz|"
+
   setup do
     user = insert_verified_user()
     agent = insert_agent(user_id: user.id, runtime: "claude")
@@ -178,7 +184,9 @@ defmodule Fountain.SandboxFilesTest do
 
       expect_script(fn _, script, args ->
         assert script =~ "head -c"
-        assert args == ["262144", @home <> "/.env"]
+        # The cap plus the overlap: one byte less than the longest value,
+        # `sk-live-abcdef`, so a value lying across the cap arrives whole.
+        assert args == ["#{262_144 + 13}", @home <> "/.env"]
         {:ok, "#{byte_size(body)}\n" <> b64(body), 0}
       end)
 
@@ -597,6 +605,171 @@ defmodule Fountain.SandboxFilesTest do
                   %{path: "dump-[REDACTED].json", renamed_from: "old-[REDACTED].json"}
                 ]
               }} = SandboxFiles.status(sandbox, nil)
+    end
+  end
+
+  # Redaction matches a value's own bytes, so a cut through one leaves a
+  # prefix that matches nothing. The cut `head -c` makes is at `max_bytes`,
+  # which the caller picks, so a caller that could move it across a value
+  # could read the value out a piece at a time (#1907).
+  describe "the caller's cap runs after redaction, not before (#1907)" do
+    setup ctx do
+      {:ok, dek} = Crypto.load_tenant_key(ctx.user.id)
+      env = insert_env(user_id: ctx.user.id)
+      {:ok, _} = Environments.upsert_secret(env, %{"key" => "TOKEN", "value" => @straddled}, dek)
+
+      sandbox =
+        insert_sandbox(
+          user_id: ctx.user.id,
+          status: "ready",
+          environment_id: env.id,
+          agent_id: ctx.agent.id
+        )
+
+      {:ok, secret_sandbox: sandbox}
+    end
+
+    test "read/3: no max_bytes anywhere across the value yields a fragment of it", ctx do
+      body = @straddle_body
+
+      for max_bytes <- 1..byte_size(body) do
+        expect_script(fn _, _, [n, _] ->
+          n = String.to_integer(n)
+          # The script is asked past the cap; it still cuts at what it is asked.
+          assert n == max_bytes + byte_size(@straddled) - 1
+          {:ok, "#{byte_size(body)}\n" <> b64(binary_part(body, 0, min(n, byte_size(body)))), 0}
+        end)
+
+        assert {:ok, %{content: content, encoding: "utf-8"}} =
+                 SandboxFiles.read(ctx.secret_sandbox, "f", max_bytes: max_bytes)
+
+        assert byte_size(content) <= max_bytes,
+               "max_bytes=#{max_bytes} answered #{byte_size(content)} bytes"
+
+        for k <- 1..byte_size(@straddled) do
+          fragment = binary_part(@straddled, 0, k)
+
+          refute String.contains?(content, fragment),
+                 "max_bytes=#{max_bytes} leaked #{inspect(fragment)} in #{inspect(content)}"
+        end
+      end
+    end
+
+    test "read/3: a cap past the value replaces it whole", ctx do
+      body = @straddle_body
+      expect_script(fn _, _, _ -> {:ok, "#{byte_size(body)}\n" <> b64(body), 0} end)
+
+      assert {:ok, %{content: "p=[REDACTED]|xyz|", truncated: false}} =
+               SandboxFiles.read(ctx.secret_sandbox, "f")
+    end
+
+    test "diff/3: the same walk, one byte further out for the exact-fit probe", ctx do
+      conv =
+        insert_conversation(
+          user_id: ctx.user.id,
+          agent: ctx.agent,
+          sandbox: ctx.sandbox,
+          status: "running"
+        )
+
+      Fountain.Conversations.Redaction.put(conv.id, [{"TOKEN", @straddled}])
+      on_exit(fn -> Fountain.Conversations.Redaction.delete(conv.id) end)
+
+      body = @straddle_body
+
+      for max_bytes <- 1..byte_size(body) do
+        expect_script(fn _, _, [_, n, _, _ | _] ->
+          n = String.to_integer(n)
+          assert n == max_bytes + 1 + byte_size(@straddled) - 1
+          {:ok, diff_output("/r", binary_part(body, 0, min(n, byte_size(body)))), 0}
+        end)
+
+        assert {:ok, %{diff: diff}} = SandboxFiles.diff(ctx.sandbox, nil, max_bytes: max_bytes)
+
+        assert byte_size(diff) <= max_bytes,
+               "max_bytes=#{max_bytes} answered #{byte_size(diff)} bytes"
+
+        for k <- 1..byte_size(@straddled) do
+          fragment = binary_part(@straddled, 0, k)
+
+          refute String.contains?(diff, fragment),
+                 "max_bytes=#{max_bytes} leaked #{inspect(fragment)} in #{inspect(diff)}"
+        end
+      end
+    end
+
+    test "a value replaced earlier does not pull a fragment back inside the cap", ctx do
+      {:ok, dek} = Crypto.load_tenant_key(ctx.user.id)
+      env = insert_env(user_id: ctx.user.id)
+      long = String.duplicate("L", 30)
+      {:ok, _} = Environments.upsert_secret(env, %{"key" => "LONG", "value" => long}, dek)
+      {:ok, _} = Environments.upsert_secret(env, %{"key" => "TOKEN", "value" => @straddled}, dek)
+
+      sandbox =
+        insert_sandbox(
+          user_id: ctx.user.id,
+          status: "ready",
+          environment_id: env.id,
+          agent_id: ctx.agent.id
+        )
+
+      # `long` comes first and is three times the placeholder, so replacing
+      # it moves everything behind it twenty bytes closer to the cap. That is
+      # why the cut is taken in the bytes the script produced and not in the
+      # redacted text: redacting the whole overlap and cutting afterwards
+      # would carry an unmatched piece of the second value back inside.
+      body = long <> "|" <> @straddled <> "|xyz|"
+
+      for max_bytes <- 1..byte_size(body) do
+        expect_script(fn _, _, [n, _] ->
+          n = String.to_integer(n)
+          assert n == max_bytes + byte_size(long) - 1
+          {:ok, "#{byte_size(body)}\n" <> b64(binary_part(body, 0, min(n, byte_size(body)))), 0}
+        end)
+
+        assert {:ok, %{content: content}} = SandboxFiles.read(sandbox, "f", max_bytes: max_bytes)
+
+        assert byte_size(content) <= max_bytes,
+               "max_bytes=#{max_bytes} answered #{byte_size(content)} bytes"
+
+        for k <- 1..byte_size(@straddled) do
+          fragment = binary_part(@straddled, 0, k)
+
+          refute String.contains?(content, fragment),
+                 "max_bytes=#{max_bytes} leaked #{inspect(fragment)} in #{inspect(content)}"
+        end
+      end
+    end
+
+    test "the cap holds when the placeholder is longer than the value it replaces", ctx do
+      {:ok, dek} = Crypto.load_tenant_key(ctx.user.id)
+      env = insert_env(user_id: ctx.user.id)
+      {:ok, _} = Environments.upsert_secret(env, %{"key" => "T", "value" => "12345678"}, dek)
+
+      sandbox =
+        insert_sandbox(
+          user_id: ctx.user.id,
+          status: "ready",
+          environment_id: env.id,
+          agent_id: ctx.agent.id
+        )
+
+      # Exactly `max_bytes` on disk, so the only thing that can push the
+      # answer past the cap is `[REDACTED]` being longer than the value.
+      body = "ab12345678cd"
+
+      expect_script(fn _, _, [n, _] ->
+        assert n == "#{12 + 7}"
+        {:ok, "#{byte_size(body)}\n" <> b64(body), 0}
+      end)
+
+      assert {:ok, %{content: content, truncated: truncated}} =
+               SandboxFiles.read(sandbox, "f", max_bytes: 12)
+
+      assert content == "ab[REDACTED]"
+      assert byte_size(content) == 12
+      # The file fits the cap, so only the cut back down makes this true.
+      assert truncated
     end
   end
 end

--- a/apps/fountain/test/fountain_web/controllers/sandbox_files_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/sandbox_files_controller_test.exs
@@ -166,7 +166,9 @@ defmodule FountainWeb.SandboxFilesControllerTest do
         |> json_response(200)
         |> Map.fetch!("data")
 
-      assert_received {:exec_args, ["1000", @home <> "/.git/config"]}
+      # 1000 plus the overlap, one byte less than `ghp_0123456789`, so a value
+      # lying across the cap is whole when redaction runs (#1907).
+      assert_received {:exec_args, ["1013", @home <> "/.git/config"]}
 
       assert data == %{
                "path" => @home <> "/.git/config",

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -261,7 +261,9 @@ export class Fountain {
   /**
    * One file on a sandbox. `content` is the text when `encoding` is `utf-8`
    * and base64 otherwise; `size` is the whole file and `truncated` says
-   * whether `content` stopped at `maxBytes` (default 256 KiB, at most 4 MiB).
+   * whether `content` is short of it. That is true when the file is longer
+   * than `maxBytes` (default 256 KiB, at most 4 MiB), and also when redaction
+   * grows what was read past that cap.
    */
   async sandboxFile(id: string, path: string, opts: { maxBytes?: number } = {}): Promise<SandboxFile> {
     return this.api.data<SandboxFile>("GET", `/api/sandboxes/${id}/file`, {

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -1709,7 +1709,7 @@ export interface paths {
         };
         /**
          * Read a file on a sandbox
-         * @description The bytes of one file, redacted: every value of the sandbox's environment and vault is replaced with `[REDACTED]`, as in the transcript. `content` is the text when it is valid UTF-8 (`encoding: utf-8`) and base64 otherwise (`encoding: base64`). `size` is the whole file; `truncated` says whether `content` stopped at `max_bytes`. Full scope.
+         * @description The bytes of one file, redacted: every value of the sandbox's environment and vault is replaced with `[REDACTED]`, as in the transcript. `content` is the text when it is valid UTF-8 (`encoding: utf-8`) and base64 otherwise (`encoding: base64`). `size` is the whole file; `truncated` says whether `content` is short of it, which happens when the file is longer than `max_bytes` and also when redaction grows what was read past that cap. Full scope.
          */
         get: operations["FountainWeb.SandboxFilesController.show"];
         put?: never;
@@ -4354,7 +4354,7 @@ export interface components {
             repo_root: string;
             /** @description True when the index was diffed (`--cached`). */
             staged: boolean;
-            /** @description True when `diff` stopped at `max_bytes` before the end. */
+            /** @description True when `diff` is not the whole diff: either it is longer than `max_bytes`, or redaction grew what was read past it. False means `diff` is everything. */
             truncated: boolean;
         };
         /** SandboxDiffResponse */
@@ -4387,7 +4387,7 @@ export interface components {
             path: string;
             /** @description The whole file, in bytes. */
             size: number;
-            /** @description True when `content` stopped at `max_bytes` before the end of the file. */
+            /** @description True when `content` is not the whole file: either the file is longer than `max_bytes`, or redaction grew what was read past it. False means `content` is everything. */
             truncated: boolean;
         };
         /** SandboxFileResponse */


### PR DESCRIPTION
Fixes #1907

## The defect

`Fountain.SandboxFiles` applied its output caps in the **shell**, with
`head -c`, and redacted in Elixir over whatever survived the cut.
`redact_with/2` is `:binary.replace/4` against the sandbox's known secret
values, so it only matches a value that is present whole. A cut that lands
inside a value leaves a prefix that matches nothing, and that prefix goes
into the response.

On `GET /api/sandboxes/:id/file` the cut position is the caller's: `read/3`
takes `max_bytes` from `params["max_bytes"]`, clamps it to 1…4 MiB, and
hands it to `head -c "$n"`. So this is not an occasional boundary artifact
that depends on where a value happens to sit — the caller decides where the
boundary falls relative to a value, and can put it anywhere. A read of the
sandbox's `.env` is exactly what ADR 0039 decision 5 and the module's own
moduledoc say is prevented, and it matters who holds the key: a full-scope
token includes one issued to a third-party OAuth app the user authorized,
a different principal from the tenant whose vault values redaction protects.

This is on `main` and published in SDK 1.15.0. `/file`, `max_bytes` and this
ordering all shipped in the original ADR 0039 PR.

## The fix

Each script is asked for `overlap/1` bytes past the cap, redaction runs over
that, and only then is the result cut down to what the caller asked for.

`overlap/1` is one byte less than the longest known value, which
`secret_values/1` already sorts to the front. That width is exact rather
than generous: a value of length `L` with at least one byte inside the cap
starts at `max_bytes - 1` at the latest, so it ends at `max_bytes + L - 1`
at the latest. Anything wider buys nothing; anything narrower leaves the
worst case short.

The cut back down is taken in **the bytes the script produced**, not in the
redacted text, and that distinction is load-bearing. Redacting the whole
overlap window and then trimming the result to `max_bytes` looks equivalent
and is not: a value replaced by a shorter placeholder moves every byte
behind it closer to the front, which can carry a fragment out of the overlap
region and back inside the cap, unmatched. So `cut_at/3` finds the value
lying across the cap (at most one can, since matches do not overlap), keeps
up to its end so it is present whole, redacts, and caps the result. There is
a test for this variant specifically, and it is the only one of the three
that catches it.

Cutting a `[REDACTED]` marker in half is possible and is harmless — a
marker fragment carries nothing.

`truncated` now also reports the cut back down, which can happen when
`[REDACTED]` is longer than the value it replaces.

**Both caps that exist on `main` are fixed** — `read/3` and `diff/3` — since
one helper serves both. `diff/3` had the same shape twice over: the shell
cut at `max_bytes + 1`, and the Elixir `binary_part/3` before it also ran
ahead of redaction.

`/git-status` is not affected: `status_records/1` drops a record the cap cut
in half rather than returning it.

The ordering of redaction against `to_text/1` is untouched. Redaction still
runs first, because recoding first would rewrite a non-ASCII value's bytes
out of its own match (`é` = `C3 A9` → `C3 83 C2 A9`) and stop redacting it
entirely.

## Verified by reverting

Three reverts, each run against the new tests.

**A. The whole fix reverted** (`git checkout origin/main -- sandbox_files.ex`)
— 4 failures. Each fires on the overlap the script is asked for, before the
leak assertions are reached:

```
code:  assert n == max_bytes + byte_size(@straddled) - 1
left:  1
right: 20
```

**B. The overlap kept, the cut restored to `max_bytes` before redaction**
(`cut_at/3` returns `min(byte_size(bytes), max_bytes)`) — the vulnerable
ordering with the new shape. 3 failures, now on the leak itself:

```
1) diff/3: the same walk, one byte further out for the exact-fit probe
   max_bytes=3 leaked "Q" in "p=Q"

2) a value replaced earlier does not pull a fragment back inside the cap
   max_bytes=32 leaked "Q" in "[REDACTED]|Q"

3) read/3: no max_bytes anywhere across the value yields a fragment of it
   max_bytes=3 leaked "Q" in "p=Q"
```

**C. The overlap kept, the whole window redacted and the *result* trimmed**
(`cut_at/3` returns `byte_size(bytes)`) — the plausible-looking wrong fix.
1 failure, and only the shift test sees it, which is why that test is there:

```
1) a value replaced earlier does not pull a fragment back inside the cap
   max_bytes=12 leaked "Q" in "[REDACTED]|Q"
```

The fixed tree: `52 tests, 0 failures` over
`sandbox_files_test.exs`, `sandbox_files_controller_test.exs` and
`redaction_test.exs`.

## The tests

The straddle is constructed, not hoped for. The value shares not one
character with the text around it or with `[REDACTED]`, so each walk asserts
that **no prefix of it, down to a single byte, appears anywhere in the
response** — at every `max_bytes` from 1 to the length of the file, for both
`read/3` and `diff/3`. Each step also pins `byte_size(content) <= max_bytes`,
so the overlap cannot quietly return more than was asked for, and a separate
test pins the cap on a file that fits it exactly and is grown past it by the
placeholder.

## Overlap with #1596

#1596 is in the merge queue and edits the same module. It rewrites `diff/3`'s
`run` call (adding `roots/1` to the argv), the `redact/2` clause, and the
`# ── redaction ──` section, and it adds a `head -c 4096` cap of its own on
git's stderr. **These lines conflict**, and whichever of the two lands second
needs a rebase. Two notes for whoever does it:

- I used `redact_with(values, bytes)` with #1596's argument order on purpose,
  so the two definitions are the same function.
- The diagnostic cap `head -c 4096` does not exist on `main` — it arrives
  with #1596. It is fixed-width and not caller-steerable, so it is a
  different severity, but it has the same shape and after #1596 merges it is
  the one remaining uncovered cap in the module. Worth its own issue rather
  than a rebase note.

`max_max_bytes/0` and `default_max_bytes/0` are untouched, so the wire shape
does not move and `sdk/contract/contract.json` does not diff. The `truncated`
**descriptions** did change (see the rebase comment below), so
`sdk/typescript/src/generated/openapi.ts` is regenerated; the PR carries
`sdk-no-release` rather than a version bump.

## Checks

From `apps/fountain` on the mise-pinned toolchain: `mix format --check-formatted`,
`mix compile --warnings-as-errors`, `mix credo --strict` (798 files, no
issues), and the three test files above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UpTFaSbu4oL7XwxByqx8Mk

