### PR TITLE
fix(billing): stamp the inference source at turn start (#1685)

### DIFF
--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -1759,11 +1759,25 @@ defmodule Fountain.Conversations do
   differs per runtime (a per-call delta, a thread total, a per-step figure).
   A second call for the same turn would double-count the conversation, so
   it refuses when the turn already carries a usage.
+
+  The one usage map that is not an end-of-turn record is the turn-start
+  inference stamp (#1685): it carries no token figure, so it has counted
+  towards nothing and there is nothing to double. This write merges over it
+  — the stamp's keys are the two `TurnMachine.with_inference/2` writes here
+  as well, so a turn that answers its prompt ends with the map it would have
+  carried with no stamp at all.
   """
   def _unsafe_record_turn_usage(%Turn{}, nil), do: :ok
-  def _unsafe_record_turn_usage(%Turn{usage: %{}}, _usage), do: {:error, :already_recorded}
 
-  def _unsafe_record_turn_usage(%Turn{} = turn, %{} = usage) do
+  def _unsafe_record_turn_usage(%Turn{usage: %{} = recorded} = turn, %{} = usage) do
+    if Turn.inference_stamp_only?(recorded),
+      do: write_turn_usage(turn, Map.merge(recorded, usage)),
+      else: {:error, :already_recorded}
+  end
+
+  def _unsafe_record_turn_usage(%Turn{} = turn, %{} = usage), do: write_turn_usage(turn, usage)
+
+  defp write_turn_usage(%Turn{} = turn, %{} = usage) do
     # `usage` is whatever the runtime reported. The map is stored as it came,
     # but the counters it increments are bigints: a string or an object here
     # used to raise inside the transaction and take the turn's usage

--- a/apps/fountain/lib/fountain/conversations/turn.ex
+++ b/apps/fountain/lib/fountain/conversations/turn.ex
@@ -40,6 +40,10 @@ defmodule Fountain.Conversations.Turn do
     # never summed from the live `usage_update`s (their meaning differs per
     # runtime). Optional "accounting" preserves adapter scope/version/completeness;
     # it may be the only key when token counts are unknown. nil when nothing was reported.
+    #
+    # Two more keys, written at turn start rather than at its end (#1685):
+    # "inference" (and, on a platform turn, "model") — see
+    # `inference_stamp_only?/1`.
     field :usage, :map
     # ACP selection evidence, distinct from the agent's saved configuration.
     field :model_selection, :map
@@ -56,6 +60,32 @@ defmodule Fountain.Conversations.Turn do
 
   def statuses, do: @statuses
   def origins, do: @origins
+
+  # The two keys the turn-start inference stamp writes (#1685). Both are also
+  # written by `TurnMachine.with_inference/2` at the end of a turn that
+  # answers its prompt, which is why the late write merges over the early one
+  # rather than colliding with it.
+  @inference_stamp_keys ~w(inference model)
+
+  @doc """
+  Whether this `usage` map is the turn-start inference stamp and nothing else
+  (#1685) — the turn ran on a known inference source, and no token figure has
+  been recorded for it.
+
+  Such a row exists so the platform-inference pass can see the turn at all: a
+  turn that ends any way other than a `session/prompt` response never reaches
+  `{:done, ...}`, and before #1685 left no trace of whose key it spent. It is
+  not an end-of-turn usage record, so the two places that treat a usage map as
+  one — the "already recorded" refusal in
+  `Conversations._unsafe_record_turn_usage/2` and the API's turn `usage` field
+  — ask this first.
+
+  An `"accounting"`-only map (a runtime that reported its scope but no counts)
+  is *not* a stamp: that is a real end-of-turn record, and a second one must
+  still be refused.
+  """
+  @spec inference_stamp_only?(map()) :: boolean()
+  def inference_stamp_only?(%{} = usage), do: Map.keys(usage) -- @inference_stamp_keys == []
 
   def changeset(turn, attrs) do
     turn

--- a/apps/fountain/lib/fountain/conversations/turn_machine.ex
+++ b/apps/fountain/lib/fountain/conversations/turn_machine.ex
@@ -247,7 +247,7 @@ defmodule Fountain.Conversations.TurnMachine do
     end
   end
 
-  def handle(%__MODULE__{} = turn, {:model_selected, requested, effective, source}, _ctx) do
+  def handle(%__MODULE__{} = turn, {:model_selected, requested, effective, source}, ctx) do
     selection = %{
       requested_model: requested,
       effective_model: effective,
@@ -255,7 +255,7 @@ defmodule Fountain.Conversations.TurnMachine do
       status: "selected"
     }
 
-    turn = record_model_selection(turn, selection)
+    turn = record_model_selection(turn, selection, ctx)
 
     publish_stage(
       turn.conversation_id,
@@ -273,7 +273,7 @@ defmodule Fountain.Conversations.TurnMachine do
     handle(turn, {:failed, {:model_selection_failed, requested, detail}}, ctx)
   end
 
-  def handle(%__MODULE__{} = turn, {:failed, {:model_selection_failed, requested, detail}}, _ctx) do
+  def handle(%__MODULE__{} = turn, {:failed, {:model_selection_failed, requested, detail}}, ctx) do
     message =
       "Could not select model #{requested}: #{detail}. No prompt was sent. " <>
         "Choose a model available in this runtime, or refresh its model catalog and check account access."
@@ -285,7 +285,7 @@ defmodule Fountain.Conversations.TurnMachine do
       error: message
     }
 
-    turn = record_model_selection(turn, selection)
+    turn = record_model_selection(turn, selection, ctx)
 
     publish_stage(
       turn.conversation_id,
@@ -754,11 +754,41 @@ defmodule Fountain.Conversations.TurnMachine do
 
   defp put_model(usage, _source, _model), do: usage
 
-  defp record_model_selection(%__MODULE__{row: nil} = turn, _selection), do: turn
+  defp record_model_selection(%__MODULE__{row: nil} = turn, _selection, _ctx), do: turn
 
-  defp record_model_selection(turn, selection) do
-    {:ok, row} = Conversations._unsafe_update_turn(turn.row, %{model_selection: selection})
+  defp record_model_selection(turn, selection, ctx) do
+    attrs = stamp_inference(%{model_selection: selection}, turn.row, ctx)
+    {:ok, row} = Conversations._unsafe_update_turn(turn.row, attrs)
     %{turn | row: row}
+  end
+
+  # The inference stamp, written at turn start rather than only at the end
+  # (#1685).
+  #
+  # `Managoat.ACP.Peer` reports `:model_selected` from `send_prompt/1`,
+  # immediately before it writes `session/prompt`, so this runs once per ACP
+  # turn at the moment tokens are about to be spent. Before #1685 the stamp
+  # was applied only in the `{:done, ...}` clause, which a turn reaches only
+  # when the prompt is *answered*: an adapter exit, a sandbox deadline, a
+  # server restart, an interrupt or a runtime that reports no usage all left
+  # a turn that spent Fountain's key with no record that it had.
+  #
+  # `with_inference/2` decides the source, exactly as the end-of-turn write
+  # does — one derivation, so the two writes cannot disagree. What it returns
+  # for an empty map is the stamp alone, and `%{}` on a deployment holding no
+  # platform key, which is what keeps a self-hosted install's turn rows
+  # unchanged.
+  #
+  # The end-of-turn write merges its token figures over this (see
+  # `Conversations._unsafe_record_turn_usage/2`), so a turn that does answer
+  # its prompt ends with the same map it carried before #1685.
+  defp stamp_inference(attrs, %{usage: usage}, _ctx) when is_map(usage), do: attrs
+
+  defp stamp_inference(attrs, _row, ctx) do
+    case with_inference(%{}, ctx) do
+      stamp when map_size(stamp) > 0 -> Map.put(attrs, :usage, stamp)
+      _ -> attrs
+    end
   end
 
   @spec record_usage(t(), map() | nil) :: :ok

--- a/apps/fountain/lib/fountain/conversations/turn_machine.ex
+++ b/apps/fountain/lib/fountain/conversations/turn_machine.ex
@@ -255,7 +255,9 @@ defmodule Fountain.Conversations.TurnMachine do
       status: "selected"
     }
 
-    turn = record_model_selection(turn, selection, ctx)
+    # The only report that precedes a prompt going out, so the only one that
+    # stamps (#1685).
+    turn = record_model_selection(turn, selection, inference_stamp(turn.row, ctx))
 
     publish_stage(
       turn.conversation_id,
@@ -273,7 +275,7 @@ defmodule Fountain.Conversations.TurnMachine do
     handle(turn, {:failed, {:model_selection_failed, requested, detail}}, ctx)
   end
 
-  def handle(%__MODULE__{} = turn, {:failed, {:model_selection_failed, requested, detail}}, ctx) do
+  def handle(%__MODULE__{} = turn, {:failed, {:model_selection_failed, requested, detail}}, _ctx) do
     message =
       "Could not select model #{requested}: #{detail}. No prompt was sent. " <>
         "Choose a model available in this runtime, or refresh its model catalog and check account access."
@@ -285,7 +287,10 @@ defmodule Fountain.Conversations.TurnMachine do
       error: message
     }
 
-    turn = record_model_selection(turn, selection, ctx)
+    # No inference stamp: every peer source of this report is in
+    # `phase: :setting_model`, strictly before `send_prompt/1`, so the turn
+    # spent nothing — as the message above says.
+    turn = record_model_selection(turn, selection, %{})
 
     publish_stage(
       turn.conversation_id,
@@ -754,24 +759,34 @@ defmodule Fountain.Conversations.TurnMachine do
 
   defp put_model(usage, _source, _model), do: usage
 
-  defp record_model_selection(%__MODULE__{row: nil} = turn, _selection, _ctx), do: turn
+  # `extra` is whatever else belongs in the same write — the inference stamp,
+  # and nothing else so far. One update, so a turn cannot carry the stamp
+  # without the selection that earned it.
+  defp record_model_selection(%__MODULE__{row: nil} = turn, _selection, _extra), do: turn
 
-  defp record_model_selection(turn, selection, ctx) do
-    attrs = stamp_inference(%{model_selection: selection}, turn.row, ctx)
+  defp record_model_selection(turn, selection, extra) do
+    attrs = Map.put(extra, :model_selection, selection)
     {:ok, row} = Conversations._unsafe_update_turn(turn.row, attrs)
     %{turn | row: row}
   end
 
   # The inference stamp, written at turn start rather than only at the end
-  # (#1685).
+  # (#1685). Returns the `usage` attribute to merge into the selection write,
+  # or `%{}` when there is nothing to stamp.
   #
-  # `Managoat.ACP.Peer` reports `:model_selected` from `send_prompt/1`,
-  # immediately before it writes `session/prompt`, so this runs once per ACP
-  # turn at the moment tokens are about to be spent. Before #1685 the stamp
-  # was applied only in the `{:done, ...}` clause, which a turn reaches only
-  # when the prompt is *answered*: an adapter exit, a sandbox deadline, a
-  # server restart, an interrupt or a runtime that reports no usage all left
-  # a turn that spent Fountain's key with no record that it had.
+  # **Only from the `:model_selected` report.** `Managoat.ACP.Peer` sends that
+  # one from `send_prompt/1`, immediately before it writes `session/prompt`,
+  # so it is the one report that means "tokens are about to be spent". Its
+  # sibling `:model_selection_failed` is raised in `phase: :setting_model`,
+  # strictly earlier, and stamping there would mark a turn that spent nothing
+  # — indistinguishable afterwards from one that died mid-inference, which is
+  # the question #1916 has to answer.
+  #
+  # Before #1685 the stamp was applied only in the `{:done, ...}` clause,
+  # which a turn reaches only when the prompt is *answered*: an adapter exit,
+  # a sandbox deadline, a server restart, an interrupt or a runtime that
+  # reports no usage all left a turn that spent Fountain's key with no record
+  # that it had.
   #
   # `with_inference/2` decides the source, exactly as the end-of-turn write
   # does — one derivation, so the two writes cannot disagree. What it returns
@@ -782,12 +797,12 @@ defmodule Fountain.Conversations.TurnMachine do
   # The end-of-turn write merges its token figures over this (see
   # `Conversations._unsafe_record_turn_usage/2`), so a turn that does answer
   # its prompt ends with the same map it carried before #1685.
-  defp stamp_inference(attrs, %{usage: usage}, _ctx) when is_map(usage), do: attrs
+  defp inference_stamp(%{usage: usage}, _ctx) when is_map(usage), do: %{}
 
-  defp stamp_inference(attrs, _row, ctx) do
+  defp inference_stamp(_row, ctx) do
     case with_inference(%{}, ctx) do
-      stamp when map_size(stamp) > 0 -> Map.put(attrs, :usage, stamp)
-      _ -> attrs
+      stamp when map_size(stamp) > 0 -> %{usage: stamp}
+      _ -> %{}
     end
   end
 

--- a/apps/fountain/lib/fountain_web/controllers/conversation_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/conversation_json.ex
@@ -191,8 +191,22 @@ defmodule FountainWeb.ConversationJSON do
       # The end-of-turn figure as the runtime reported it (#827); null when
       # it reported none or the turn predates the column.
       model_selection: t.model_selection,
-      usage: t.usage && usage_data(t.usage)
+      usage: turn_usage(t.usage)
     }
+  end
+
+  @doc """
+  A turn's `usage` field for the API: the end-of-turn figure, or null.
+
+  Null covers the turn-start inference stamp (#1685) as well as a missing
+  column. That stamp says whose key the turn runs on and carries no token
+  figure, so reporting it here would answer "how many tokens did this turn
+  spend" with a zero nobody measured.
+  """
+  def turn_usage(nil), do: nil
+
+  def turn_usage(%{} = usage) do
+    if Turn.inference_stamp_only?(usage), do: nil, else: usage_data(usage)
   end
 
   @doc "Stored token counts and adapter accounting claims; absent counts remain absent in qualified reports."

--- a/apps/fountain/lib/fountain_web/controllers/team_json.ex
+++ b/apps/fountain/lib/fountain_web/controllers/team_json.ex
@@ -53,7 +53,7 @@ defmodule FountainWeb.TeamJSON do
       prompt: turn.prompt,
       status: turn.status,
       inserted_at: turn.inserted_at,
-      usage: turn.usage && ConversationJSON.usage_data(turn.usage)
+      usage: ConversationJSON.turn_usage(turn.usage)
     }
   end
 

--- a/apps/fountain/test/fountain/conversations/conversation_server_platform_inference_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_platform_inference_test.exs
@@ -226,6 +226,27 @@ defmodule Fountain.Conversations.ConversationServerPlatformInferenceTest do
       assert stored(other).usage["inference"] == "platform"
     end
 
+    test "a failed model selection stamps nothing: no prompt went out", %{
+      machine: m,
+      row: row
+    } do
+      ctx = platform_ctx()
+
+      # Every peer source of this report is in `phase: :setting_model`,
+      # strictly before `send_prompt/1`. The turn spent no tokens, and a
+      # stamp here would be indistinguishable afterwards from a turn that
+      # died mid-inference.
+      assert {_m, [{:finish, "failed", _, _}, {:drop_connection, "failed"}]} =
+               TurnMachine.handle(
+                 m,
+                 {:failed, {:model_selection_failed, ctx.model, "no such model"}},
+                 ctx
+               )
+
+      assert is_nil(stored(row).usage)
+      assert stored(row).model_selection["status"] == "failed"
+    end
+
     test "a turn on the tenant's own key is not stamped as a platform one", %{
       machine: m,
       row: row

--- a/apps/fountain/test/fountain/conversations/conversation_server_platform_inference_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_platform_inference_test.exs
@@ -172,6 +172,120 @@ defmodule Fountain.Conversations.ConversationServerPlatformInferenceTest do
     end
   end
 
+  # #1685. The mark above is applied in the `{:done, ...}` clause, which a
+  # turn reaches only when its prompt is *answered*. Production over seven
+  # days: 26 turns carried the mark and 319 ended with no usage map at all —
+  # whichever of those ran on the platform key spent it invisibly. The stamp
+  # is therefore written at turn start, where `Managoat.ACP.Peer` reports
+  # `:model_selected` immediately before it writes `session/prompt`.
+  describe "the mark at turn start (#1685)" do
+    setup %{user: user, agent: agent} do
+      conv = insert_conversation(user_id: user.id, agent: agent)
+      row = insert_turn(conv, status: "running", started_at: DateTime.utc_now())
+
+      machine = %TurnMachine{
+        conversation_id: conv.id,
+        row: row,
+        metrics:
+          TurnMachine.start_metrics("claude", :sprites, System.monotonic_time(:millisecond))
+      }
+
+      {:ok, conv: conv, row: row, machine: machine}
+    end
+
+    test "a turn whose adapter dies before the response still says whose key ran it", %{
+      machine: m,
+      row: row
+    } do
+      {_m, []} = select_model(m, platform_ctx())
+
+      # No `{:done, ...}` ever arrives: the adapter exits, the sandbox hits
+      # its deadline, or the server restarts.
+      assert stored(row).usage == %{
+               "inference" => "platform",
+               "model" => "anthropic/claude-opus-5"
+             }
+    end
+
+    test "so does one that is interrupted", %{machine: m, row: row} do
+      {m, []} = select_model(m, platform_ctx())
+
+      TurnMachine.mark_interrupted(m)
+
+      assert stored(row).status == "interrupted"
+      assert stored(row).usage["inference"] == "platform"
+    end
+
+    test "so does one that fails before it can report anything", %{machine: m, conv: conv} do
+      other = insert_turn(conv, status: "running")
+      {_m, []} = select_model(%{m | row: other}, platform_ctx())
+
+      TurnMachine.fail_before_start(other, conv.id, "spawn", "boom", 1)
+
+      assert stored(other).status == "failed"
+      assert stored(other).usage["inference"] == "platform"
+    end
+
+    test "a turn on the tenant's own key is not stamped as a platform one", %{
+      machine: m,
+      row: row
+    } do
+      ctx = %{platform_ctx() | inference: :own}
+      {_m, []} = select_model(m, ctx)
+
+      assert stored(row).usage == %{"inference" => "own"}
+      refute stored(row).usage["inference"] == "platform"
+    end
+
+    test "a deployment holding no platform key stamps nothing at all", %{machine: m, row: row} do
+      Application.delete_env(:fountain, :platform_anthropic_api_key)
+
+      {_m, []} = select_model(m, platform_ctx())
+      assert is_nil(stored(row).usage)
+    end
+
+    test "a turn that does answer its prompt ends with the map it had before the stamp", %{
+      machine: m,
+      conv: conv,
+      row: row
+    } do
+      ctx = platform_ctx()
+      {m, []} = select_model(m, ctx)
+
+      assert {_m, [{:finish, "completed", _, _}]} =
+               TurnMachine.handle(m, {:done, "end_turn", %{"input" => 5, "output" => 3}}, ctx)
+
+      assert stored(row).usage == TurnMachine.with_inference(%{"input" => 5, "output" => 3}, ctx)
+
+      # And the conversation's running sums moved once, not twice.
+      assert %{usage_input_tokens: 5, usage_output_tokens: 3} =
+               Conversations._unsafe_get_conversation!(conv.id)
+    end
+
+    test "the API reports no token figure for a turn carrying only the stamp" do
+      assert FountainWeb.ConversationJSON.turn_usage(%{
+               "inference" => "platform",
+               "model" => "anthropic/claude-opus-5"
+             }) == nil
+
+      assert FountainWeb.ConversationJSON.turn_usage(%{
+               "inference" => "platform",
+               "model" => "anthropic/claude-opus-5",
+               "input" => 5,
+               "output" => 3
+             }) == %{input: 5, output: 3}
+    end
+  end
+
+  defp platform_ctx, do: %{inference: :platform, model: "anthropic/claude-opus-5"}
+
+  # What `Managoat.ACP.Peer` reports from `send_prompt/1`, just before it
+  # writes `session/prompt`.
+  defp select_model(machine, ctx),
+    do: TurnMachine.handle(machine, {:model_selected, ctx.model, ctx.model, "runtime"}, ctx)
+
+  defp stored(row), do: Fountain.Repo.get!(Conversations.Turn, row.id)
+
   defp stub_turn_boundary do
     test = self()
     ref = make_ref()

--- a/apps/fountain/test/fountain/conversations/turn_usage_test.exs
+++ b/apps/fountain/test/fountain/conversations/turn_usage_test.exs
@@ -45,4 +45,48 @@ defmodule Fountain.Conversations.TurnUsageTest do
     assert %{usage_input_tokens: 1, usage_output_tokens: 1} =
              Conversations._unsafe_get_conversation!(conv.id)
   end
+
+  describe "over the turn-start inference stamp (#1685)" do
+    test "the end-of-turn figure merges over the stamp instead of being refused", %{conv: conv} do
+      t = insert_turn(conv, prompt: "one", status: "completed")
+
+      {:ok, t} =
+        Conversations._unsafe_update_turn(t, %{
+          usage: %{"inference" => "platform", "model" => "anthropic/claude-opus-5"}
+        })
+
+      assert {:ok, recorded} =
+               Conversations._unsafe_record_turn_usage(t, %{
+                 "input" => 100,
+                 "output" => 20,
+                 "inference" => "platform",
+                 "model" => "anthropic/claude-opus-5"
+               })
+
+      # Byte for byte the map this turn carried before the stamp existed.
+      assert recorded.usage == %{
+               "input" => 100,
+               "output" => 20,
+               "inference" => "platform",
+               "model" => "anthropic/claude-opus-5"
+             }
+
+      # Counted once, not once per write.
+      assert %{usage_input_tokens: 100, usage_output_tokens: 20} =
+               Conversations._unsafe_get_conversation!(conv.id)
+
+      assert {:error, :already_recorded} =
+               Conversations._unsafe_record_turn_usage(recorded, %{"input" => 100, "output" => 20})
+    end
+
+    test "an accounting-only map is an end-of-turn record, not a stamp", %{conv: conv} do
+      t = insert_turn(conv, prompt: "one", status: "completed")
+      accounting = %{"accounting" => %{"scope" => "session", "complete" => false}}
+
+      assert {:ok, t} = Conversations._unsafe_record_turn_usage(t, accounting)
+
+      assert {:error, :already_recorded} =
+               Conversations._unsafe_record_turn_usage(t, %{"input" => 1, "output" => 1})
+    end
+  end
 end

--- a/ee/lib/fountain/workers/credit_pricer.ex
+++ b/ee/lib/fountain/workers/credit_pricer.ex
@@ -243,10 +243,29 @@ defmodule Fountain.Workers.CreditPricer do
   # (ADR 0022) costs Fountain no sandbox time and still spends Fountain's
   # inference key when the tenant has none of their own.
   #
-  # `usage ->> 'inference' = 'platform'` is the whole selector: the
+  # `usage ->> 'inference' = 'platform'` is the source selector: the
   # ConversationServer stamps that key only on a turn whose credentials came
   # from `Fountain.PlatformInference`, so a deployment that holds no platform
   # key has no matching row and this query is a cheap miss.
+  #
+  # A turn figure has to be there too. Since #1685 the stamp is written at
+  # turn start, so a platform turn that never answered its prompt — an
+  # adapter exit, a sandbox deadline, a restart, an interrupt — carries the
+  # source with no token count. `cost_cents/1` prices such a row at zero and
+  # writes no ledger row, and *that* is still the behaviour: what a turn with
+  # unknown tokens should cost has not been decided (#1685 follow-up).
+  #
+  # `jsonb_typeof` before anything else, for the reason `Conversations`
+  # gives over the same column: `usage` is whatever the runtime reported, and
+  # nothing validates its shape on the way in.
+  #
+  # It is excluded from the page rather than filtered out of it because the
+  # pass stops on a page that wrote nothing. Those turns outnumber the
+  # answered ones by better than ten to one in production, so leaving them in
+  # would let a full page of unpriceable rows hold the cursor still and starve
+  # the priceable turns behind them — a worse billing bug than the one the
+  # stamp fixes. The rows are on disk and queryable by the same selector when
+  # the pricing decision lands.
   defp unpriced_inference_turns(floor) do
     from(t in Turn,
       join: c in Conversation,
@@ -257,6 +276,14 @@ defmodule Fountain.Workers.CreditPricer do
       where: not is_nil(t.ended_at),
       where: t.ended_at >= ^floor,
       where: fragment("? ->> 'inference' = 'platform'", t.usage),
+      where:
+        fragment(
+          "(jsonb_typeof(? -> 'input') = 'number' or jsonb_typeof(? -> 'output') = 'number' or jsonb_typeof(? -> 'cache_read') = 'number' or jsonb_typeof(? -> 'cache_write') = 'number')",
+          t.usage,
+          t.usage,
+          t.usage,
+          t.usage
+        ),
       where: not is_nil(c.user_id),
       order_by: [asc: t.ended_at],
       limit: @batch,

--- a/ee/test/fountain/credits_inference_test.exs
+++ b/ee/test/fountain/credits_inference_test.exs
@@ -43,6 +43,30 @@ defmodule Fountain.Credits.InferenceTest do
     })
   end
 
+  # Turns carrying the #1685 turn-start stamp and nothing else, in bulk: the
+  # page-boundary test needs more of them than the pricer's page holds.
+  defp stamp_only_turns(conv, count) do
+    at = ~U[2026-08-02 10:00:00Z]
+    stamp = %{"inference" => "platform", "model" => "anthropic/claude-opus-5"}
+
+    rows =
+      for n <- 1..count do
+        %{
+          id: Ecto.UUID.generate(),
+          conversation_id: conv.id,
+          turn_number: n,
+          prompt: "stamped",
+          status: "failed",
+          started_at: at,
+          ended_at: at,
+          usage: stamp,
+          inserted_at: at
+        }
+      end
+
+    Repo.insert_all(Fountain.Conversations.Turn, rows)
+  end
+
   defp conv_for(user, provider \\ "sprites") do
     sandbox = insert_sandbox(user_id: user.id, provider: provider, status: "ready")
     insert_conversation(user_id: user.id, sandbox: sandbox)
@@ -237,6 +261,48 @@ defmodule Fountain.Credits.InferenceTest do
 
       assert %{inference: 0} = CreditPricer.run(since: @since, now: @now)
       assert Credits.list_entries(user.id) == []
+    end
+
+    test "a turn carrying only the turn-start stamp burns nothing" do
+      user = insert_empty_user()
+      conv = conv_for(user)
+
+      # #1685: the stamp says whose key ran the turn, and no token figure was
+      # ever reported for it. What a turn with unknown tokens should cost is
+      # an open decision, so for now it costs nothing.
+      platform_turn(conv, %{"inference" => "platform", "model" => "anthropic/claude-opus-5"})
+
+      assert %{inference: 0} = CreditPricer.run(since: @since, now: @now)
+      assert Credits.list_entries(user.id) == []
+    end
+
+    test "a full page of stamp-only turns does not starve the priceable turn behind them" do
+      user = insert_empty_user()
+      conv = conv_for(user)
+
+      # One more than the pricer's page, every one of them older than the
+      # turn that can be priced. The pass stops on a page that wrote nothing,
+      # so a selector that admitted these would never reach the last turn —
+      # and in production they outnumber the answered turns ten to one.
+      stamp_only_turns(conv, 501)
+
+      turn =
+        platform_turn(
+          conv,
+          %{
+            "inference" => "platform",
+            "model" => "anthropic/claude-opus-5",
+            "input" => 10_000_000
+          },
+          started_at: ~U[2026-08-02 18:00:00Z]
+        )
+
+      assert %{inference: 1} = CreditPricer.run(since: @since, now: @now)
+
+      assert [entry] =
+               user.id |> Credits.list_entries() |> Enum.filter(&(&1.reason == "burn_inference"))
+
+      assert entry.resource_id == turn.id
     end
 
     test "an open turn is not priced until it closes" do


### PR DESCRIPTION
## The mechanism

A turn on the platform inference key that ended any way other than a
`session/prompt` response spent Fountain's tokens with no ledger row, and did
not count toward `PLATFORM_INFERENCE_DAILY_CENTS`.

The `inference: platform` stamp was applied only inside
`TurnMachine.handle({:done, ...})` (`turn_machine.ex`, `record_usage(turn,
with_inference(usage, ctx))`), which a turn reaches only when its prompt is
*answered*. `Conversations._unsafe_record_turn_usage(turn, nil)` is a no-op,
so an adapter exit before the response, a sandbox deadline, a
ConversationServer restart, an interrupt without a `cancelled` stop reason, or
a runtime that reports no usage all left the turn with no usage map at all.
`CreditPricer.unpriced_inference_turns/1` selects on
`usage ->> 'inference' = 'platform'`, and `Billing.platform_inference_spend_today/1`
reads the ledger those rows produce, so none of it was visible to either.

Production, trailing 7 days: 26 turns carried the stamp; 319 ended with no
usage map (204 completed, 65 interrupted, 50 failed). Same shape as #1459
(gemini), but for every runtime.

## The fix

The stamp now goes on the row at turn start, from the `{:model_selected, …}`
report alone. `Managoat.ACP.Peer` sends that one from `send_prompt/1`,
immediately before it writes `session/prompt`, so it lands exactly once per
ACP turn at the moment tokens are about to be spent.

**Its sibling `{:model_selection_failed, …}` does not stamp.** All three peer
sources of that report are in `phase: :setting_model`, strictly before
`send_prompt/1` — the clause's own message says "No prompt was sent." — so the
turn spent nothing. An earlier revision of this PR stamped there too; review
caught it. Those rows are inert today (they price at zero, are excluded from
the pricer's page, render `usage: null`) but they are durable and land in
exactly the population #1916 exists to price, where nothing downstream could
tell "died mid-inference" from "never prompted". Production over 30 days: 13
failed selections against 905 successful.

`record_model_selection/3` takes the extra attributes to write rather than the
ctx, so the stamp travels in the same update as the selection that earned it
and only the one clause supplies it.

Two things keep the early and late writes from fighting:

- `with_inference/2` derives the source for both, so they cannot disagree, and
  it is still gated on `PlatformInference.enabled?()` — a deployment holding
  no platform key stamps nothing and its turn rows are byte-for-byte what they
  were.
- `_unsafe_record_turn_usage/2` **merges** the end-of-turn figure over a
  stamp-only map instead of refusing it. The stamp holds no token count, so it
  has contributed to no conversation sum and there is nothing to double. A
  turn that answers its prompt ends with exactly the usage map it has today.
  An `"accounting"`-only map is *not* a stamp — that is a real end-of-turn
  record, and a second one is still `{:error, :already_recorded}`.

The API keeps reporting `usage: null` for a turn carrying only the stamp
(`ConversationJSON.turn_usage/1`, used by the turns endpoint and the team
view): it holds no token figure, and `{input: 0, output: 0}` would be a number
nobody measured.

## The pricing decision — deliberately not made

`Credits.InferenceRates.cost_cents/1` prices a stamp-only row at zero, so it
writes no `burn_inference` row and contributes nothing to the daily ceiling.
**That is unchanged, on purpose.** "Visible to the pricer as a zero-token
platform turn" and "priced at a floor" are different decisions with different
money attached, and picking a floor means picking a number nobody has chosen.
Filed as **#1916** with what the decision has to answer.

One change to the pricer was needed to avoid trading one billing bug for a
worse one. `unpriced_inference_turns/1` now also requires a numeric token key.
The inference pass stops on a page that wrote nothing, and these turns
outnumber the answered ones better than ten to one in production — leaving
them in the selector would let a full page of unpriceable rows hold the cursor
still and starve the priceable turns behind them. The rows are on disk and
selectable by the same `usage ->> 'inference'` selector whenever #1916 lands;
whatever prices them re-admits them with a cursor that advances, or runs as a
pass of its own.

The ledger rules are untouched: still idempotent per row, still never summed
on a gate.

## Verification

Ten new tests, then **reverted the fix and watched them fail**:

- `conversation_server_platform_inference_test.exs` — a platform turn whose
  adapter dies before the response, one that is interrupted, and one that
  fails before it can report anything all still carry
  `usage->>'inference' = 'platform'`; a BYO-credential turn is stamped `own`
  and never `platform`; a **failed model selection stamps nothing at all**; a
  deployment with no platform key stamps nothing; a
  normally-completing platform turn's final usage map equals
  `with_inference(%{"input" => 5, "output" => 3}, ctx)` and the conversation's
  sums move once; the API reports null for a stamp-only map.
- `turn_usage_test.exs` — the end-of-turn figure merges over the stamp rather
  than being refused, counts once, and a genuine second record is still
  refused; an `"accounting"`-only map is not treated as a stamp.
- `credits_inference_test.exs` — a stamp-only turn burns nothing; a full page
  of stamp-only turns (501, one more than the pricer's batch, all older) does
  not starve the priceable turn behind them.

With the fix reverted, 7 of the 10 fail; the failed-selection test was verified
separately by putting the stamp back on that clause, which fails it alone. The other two assert behaviour that is
*unchanged* by design (the self-hosted no-stamp case and the pricing decision
left open), so they pass either way — those two were checked by mutating the
guard instead: making `stamp_inference/3` bypass `with_inference/2` and making
`inference_stamp_only?/1` return `true` unconditionally fails 8 tests,
including the pre-existing "a second figure for the same turn is refused".

Also run green: `turn_machine_test.exs`, `conversation_controller_test.exs`,
`team_controller_test.exs`, `conversations_usage_test.exs`,
`dashboard_live_test.exs`, `audit_guardrail_test.exs`,
`platform_inference_test.exs`, `schema_controller_guard_test.exs`,
`credits_test.exs`. Plus `mix compile --warnings-as-errors`,
`mix credo --strict` on the six changed lib files (no issues), and
`mix format --check-formatted` at both the root and `apps/fountain`.

## Left out

- No backfill of the 319 existing rows: nothing knows what they spent.
- No change to `Billing.platform_inference_spend_today/1` — it reads the
  ledger, and no new ledger rows are written here.
- The OpenAPI schema is unchanged; `usage` was already nullable.

Refs #1685 — deliberately not `Closes`. This PR makes those turns
**attributable**: the source is on the row, and the 319-a-week that answered
nothing are now queryable as platform turns. It does not make them **billed**,
which is the symptom in the issue's title, because what they should cost is the
open decision in #1916. #1685 should stay open until that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DMNzkuh8mJbde1TQvsYsqj

