### PR TITLE
fix(connections): gate creation, not revocation (#1693)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -190,13 +190,15 @@ EMAIL_FROM=noreply@fountain.example.com
 
 # ── Feature flags ────────────────────────────────────────────────────────────
 # Per-user flags via PostHog (project API key, not a personal key). Unset, every
-# flag reads off unless forced on below. When PostHog is unreachable the last
-# answer it gave is reused; with none, flags read off.
+# flag reads off unless forced on below, except the flags over a shipped feature
+# (`connections`), which read on where there is no PostHog to ask. When PostHog
+# is unreachable the last answer it gave is reused; with none, flags read off.
 # POSTHOG_PROJECT_API_KEY=
 # POSTHOG_HOST=https://us.i.posthog.com
 # Force flags on for every user without PostHog (comma-separated keys).
-# Connections also requires the credential broker and configured provider apps.
-# FEATURE_FLAGS_ON=team_comms,connections
+# Connections also requires the credential broker and configured provider apps,
+# and needs no entry here: BROKER_TENANTS is what turns it on and off.
+# FEATURE_FLAGS_ON=team_comms
 
 # ── Product analytics ────────────────────────────────────────────────────────
 # The same project key above sends product events to PostHog, from the server.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,21 @@ upgrade, is in
 
 ## [Unreleased]
 
+### Upgrade notes
+
+- **Connections needs no `FEATURE_FLAGS_ON` entry on a deployment without
+  PostHog** (#1693). Gating Connections behind the `connections` flag (#1620)
+  took the feature away from every deployment that configures no flag service,
+  because a flag nobody can answer reads off. The flag now reads **on** where
+  `POSTHOG_PROJECT_API_KEY` is unset, so an upgrade keeps the Connections page
+  and the `/api/connections`, `/api/connection-providers` and
+  `/api/secret-bindings` routes. An operator who set
+  `FEATURE_FLAGS_ON=connections` to get the feature back can drop it, and
+  nothing changes where PostHog is configured: it answers the flag as before,
+  and `FEATURE_FLAGS_ON` still wins over both. The switch that turns
+  Connections off is the broker: an account is offered the feature only while
+  `BROKER_TENANTS` names it.
+
 ### Changed
 
 - **The project moved to `github.com/managoat/fountain`** and every coordinate
@@ -108,6 +123,18 @@ upgrade, is in
   and the console's conversation lists render them as chips.
 
 ### Fixed
+
+- **An account whose `connections` flag is off can revoke what it already
+  holds** (#1693). The flag stood in front of every door, the ones that take a
+  credential away included, while the runtime kept brokering those same tokens
+  into sandboxes: revoking a connection, deleting a provider and unbinding a
+  secret each answered 404 for a credential that was still in use. The flag
+  now gates only the doors that add one, which are connecting an account,
+  defining or editing a provider, binding a secret and pointing a binding at a
+  different host. Listing, revoking, unbinding and deleting are open to every
+  account the egress broker is on for, in the console and over the API, and
+  the Gmail MCP endpoint serves a connection that already exists the way the
+  rest of the runtime does.
 
 - A teammate can be moved to a different environment or vault. Fountain retires
   the computer the old binding named, so the teammate's next message builds one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,11 +130,13 @@ upgrade, is in
   into sandboxes: revoking a connection, deleting a provider and unbinding a
   secret each answered 404 for a credential that was still in use. The flag
   now gates only the doors that add one, which are connecting an account,
-  defining or editing a provider, binding a secret and pointing a binding at a
-  different host. Listing, revoking, unbinding and deleting are open to every
-  account the egress broker is on for, in the console and over the API, and
-  the Gmail MCP endpoint serves a connection that already exists the way the
-  rest of the runtime does.
+  defining or editing a provider, binding a secret, pointing a binding at a
+  different host and enabling a binding that is disabled. Listing, revoking,
+  unbinding, deleting and disabling are open to every account the egress
+  broker is on for, in the console and over the API: `DELETE` unbinds and
+  `PATCH` with `enabled: false` and nothing else disables. The Gmail MCP
+  endpoint serves a connection that already exists the way the rest of the
+  runtime does.
 
 - A teammate can be moved to a different environment or vault. Fountain retires
   the computer the old binding named, so the teammate's next message builds one

--- a/apps/fountain/lib/fountain/connections.ex
+++ b/apps/fountain/lib/fountain/connections.ex
@@ -51,12 +51,39 @@ defmodule Fountain.Connections do
   alias Fountain.Connections.{Connection, OAuth, Platform, Provider}
   alias Managoat.McpAuth
 
-  @doc "Whether this account may use Connections and manage credential bindings."
+  @doc """
+  Whether this account may **add** a connection, a provider or a credential
+  binding.
+
+  Two things have to be true. The egress broker is on for the tenant
+  (ADR 0019) — without it a token would have to enter a sandbox in the clear.
+  And the `connections` rollout flag is on for them. Gate every door that
+  creates something on this one, and nothing else: see
+  `manageable_for?/1` for the rest.
+  """
   @spec enabled_for?(String.t()) :: boolean()
   def enabled_for?(user_id) do
     Fountain.Broker.enabled_for?(user_id) and
       Fountain.FeatureFlags.enabled?(:connections, user_id)
   end
+
+  @doc """
+  Whether this account's existing connections and bindings may be listed,
+  revoked and deleted.
+
+  The broker alone, deliberately, because that is what the runtime paths which
+  attach a token gate on (`Fountain.Conversations.Egress`). A tenant whose
+  rollout flag goes off keeps every credential that is already brokered into
+  their sandboxes, so the doors that take one away have to stay open. Behind
+  the creation gate, revocation answered 404 while the token kept flowing, and
+  the account had no way to turn off a credential that was still in use
+  (#1693).
+
+  A tenant with no rows gets an empty list rather than a 404, which is the
+  price of never having to ask "do they still hold one?" before answering.
+  """
+  @spec manageable_for?(String.t()) :: boolean()
+  def manageable_for?(user_id), do: Fountain.Broker.enabled_for?(user_id)
 
   # How close to expiry a token is considered stale. A turn may run for a
   # while on the token it started with, so refresh well ahead.

--- a/apps/fountain/lib/fountain/feature_flags.ex
+++ b/apps/fountain/lib/fountain/feature_flags.ex
@@ -16,7 +16,9 @@ defmodule Fountain.FeatureFlags do
      and a flag that was off stays off; the outage does not flip anything.
   4. **Off.** No override, no PostHog (or PostHog unreachable with nothing
      cached) → `false`. Fail closed: an unreachable flag service must never
-     turn a feature on.
+     turn a feature on. The one exception is `@on_without_posthog`, the flags
+     that gate a shipped feature rather than an unfinished one: those read on
+     where the deployment configured no PostHog at all.
 
   The lookup is bounded — `@timeout_ms` — so a slow PostHog costs a request
   at most that much once per user per `@fresh_ms`, not on every call. The
@@ -45,12 +47,27 @@ defmodule Fountain.FeatureFlags do
     openai_compat: "openai_compat"
   }
 
+  # The flags that read **on** where there is no PostHog to ask.
+  #
+  # "Off because we asked and were told no" and "off because there is nobody
+  # to ask" are different answers, and only the first one is a decision. Rule
+  # 4 above fails closed on both, which is right for a flag that gates an
+  # unfinished feature: nobody loses anything they had. It is wrong for a flag
+  # that gates a **shipped** one, because a self-host configures no PostHog —
+  # so the flag reads off there forever and the feature disappears on the
+  # upgrade that introduced the flag (#1620, #1693). A flag listed here is on
+  # for a deployment with no `POSTHOG_PROJECT_API_KEY`, and is answered by
+  # PostHog like any other wherever one is configured. `FEATURE_FLAGS_ON`
+  # still wins over both, and so does a PostHog answer of "off".
+  @on_without_posthog Map.new([:connections], &{Map.fetch!(@flags, &1), true})
+
   @doc "The PostHog key for a known flag atom."
   def key!(flag) when is_atom(flag), do: Map.fetch!(@flags, flag)
 
   @doc """
   Whether `flag` is on for `user` — a `%Fountain.Accounts.User{}`, a user id
-  string, or `nil` (no user: only static overrides apply).
+  string, or `nil` (no user: only the answers that are the same for everyone
+  apply, the static overrides and `@on_without_posthog`).
   """
   @spec enabled?(atom | String.t(), term) :: boolean
   def enabled?(flag, user) when is_atom(flag), do: enabled?(key!(flag), user)
@@ -127,11 +144,10 @@ defmodule Fountain.FeatureFlags do
   defp distinct_id(id) when is_binary(id), do: id
   defp distinct_id(_), do: nil
 
-  defp remote_enabled?(_flag, nil), do: false
-
   defp remote_enabled?(flag, distinct_id) do
-    case configured?() do
-      false -> false
+    cond do
+      not configured?() -> Map.get(@on_without_posthog, flag, false)
+      is_nil(distinct_id) -> false
       true -> Map.get(flags_for(distinct_id), flag, false) == true
     end
   end

--- a/apps/fountain/lib/fountain_web/components/layouts.ex
+++ b/apps/fountain/lib/fountain_web/components/layouts.ex
@@ -101,7 +101,8 @@ defmodule FountainWeb.Layouts do
               <.nav_link href={~p"/account/runners"} label="Runners" current={@current_path} />
               <.nav_link
                 :if={
-                  assigns[:current_user] && Fountain.Connections.enabled_for?(assigns.current_user.id)
+                  assigns[:current_user] &&
+                    Fountain.Connections.manageable_for?(assigns.current_user.id)
                 }
                 href={~p"/account/bindings"}
                 label="Credential bindings"
@@ -109,7 +110,8 @@ defmodule FountainWeb.Layouts do
               />
               <.nav_link
                 :if={
-                  assigns[:current_user] && Fountain.Connections.enabled_for?(assigns.current_user.id)
+                  assigns[:current_user] &&
+                    Fountain.Connections.manageable_for?(assigns.current_user.id)
                 }
                 href={~p"/account/connections"}
                 label="Connections"

--- a/apps/fountain/lib/fountain_web/controllers/connection_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/connection_controller.ex
@@ -108,8 +108,12 @@ defmodule FountainWeb.ConnectionController do
     end
   end
 
+  # Every action here reads or removes. None of them adds a connection —
+  # connecting an account is a browser round trip — so the gate is the broker,
+  # not the rollout flag: an account that holds connections can always list
+  # them and cut them off (#1693).
   defp require_connections(conn, _opts) do
-    if Fountain.Connections.enabled_for?(conn.assigns.current_user.id) do
+    if Fountain.Connections.manageable_for?(conn.assigns.current_user.id) do
       conn
     else
       conn

--- a/apps/fountain/lib/fountain_web/controllers/connection_provider_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/connection_provider_controller.ex
@@ -12,9 +12,11 @@ defmodule FountainWeb.ConnectionProviderController do
       DELETE /api/connection-providers/:id           — delete it and its connections
       POST   /api/connection-providers/:id/discover  — run MCP discovery again
 
-  Every route answers 404 `connections_not_enabled` for an account the
-  broker or Connections flag is not on for, like connections themselves. The client secret is
-  write-only.
+  Every route answers 404 `connections_not_enabled` for an account the broker
+  is not on for, like connections themselves. The three routes that define or
+  change a provider need the `connections` rollout flag as well; listing one
+  and deleting one do not, so an account that already has providers can always
+  see them and take them away (#1693). The client secret is write-only.
   """
 
   use FountainWeb, :controller
@@ -220,8 +222,21 @@ defmodule FountainWeb.ConnectionProviderController do
     })
   end
 
+  # Defining a provider, editing one and re-running discovery all add a way to
+  # get a credential, so they need the rollout flag. Listing and deleting are
+  # management of what is already there and ask the broker only — an action
+  # added here gets that weaker gate by default, never no gate at all (#1693).
+  @creating [:create, :update, :discover]
+
   defp require_connections(conn, _opts) do
-    if Fountain.Connections.enabled_for?(conn.assigns.current_user.id) do
+    user_id = conn.assigns.current_user.id
+
+    allowed? =
+      if action_name(conn) in @creating,
+        do: Fountain.Connections.enabled_for?(user_id),
+        else: Fountain.Connections.manageable_for?(user_id)
+
+    if allowed? do
       conn
     else
       conn

--- a/apps/fountain/lib/fountain_web/controllers/connection_provider_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/connection_provider_controller.ex
@@ -224,8 +224,12 @@ defmodule FountainWeb.ConnectionProviderController do
 
   # Defining a provider, editing one and re-running discovery all add a way to
   # get a credential, so they need the rollout flag. Listing and deleting are
-  # management of what is already there and ask the broker only — an action
-  # added here gets that weaker gate by default, never no gate at all (#1693).
+  # management of what is already there and ask the broker only (#1693).
+  #
+  # The plug covers every action, so an action left off this list gets the
+  # weaker gate rather than no gate. That default is right for one that reads
+  # or removes and wrong for one that creates: an action that adds a way to a
+  # credential belongs here in the commit that adds it.
   @creating [:create, :update, :discover]
 
   defp require_connections(conn, _opts) do

--- a/apps/fountain/lib/fountain_web/controllers/gmail_mcp_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/gmail_mcp_controller.ex
@@ -34,8 +34,13 @@ defmodule FountainWeb.GmailMcpController do
   end
 
   defp build_ctx(conv_id, connection_id, user) do
+    # A runtime path, so it gates on the broker, the way every other one does
+    # (`Fountain.Conversations.Egress`). The rollout flag decides who may
+    # connect an account, not whether a connection that exists still works:
+    # gating this on the flag stopped the tools for a tenant whose flag went
+    # off while their token kept being brokered elsewhere (#1693).
     with true <-
-           Fountain.Connections.enabled_for?(user.id) ||
+           Fountain.Broker.enabled_for?(user.id) ||
              {:error, 403, "connections are not available here"},
          %Conversations.Conversation{} = conv <- get_conv(conv_id, user),
          :ok <- agent_names?(conv, connection_id),

--- a/apps/fountain/lib/fountain_web/controllers/secret_binding_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/secret_binding_controller.ex
@@ -11,10 +11,12 @@ defmodule FountainWeb.SecretBindingController do
 
   Every route answers 404 `brokerage_not_enabled` for an account the broker is
   not on for: the feature does not exist there, and the console does not show
-  it either. Binding a secret and changing a binding need the `connections`
-  rollout flag as well, because both point a credential at a host. Listing and
-  unbinding do not: `DELETE` is how an account turns off a binding that is
-  still attaching a credential, and that door stays open (#1693).
+  it either. Binding a secret and changing one need the `connections` rollout
+  flag as well, because both point a credential at a host. The doors that take
+  a credential away do not, and an account whose flag is off keeps all of
+  them: `DELETE` unbinds, and `PATCH` with `enabled: false` and nothing else
+  disables. `enabled: true` is on the other side — it attaches the credential
+  again — as is any edit that carries another field (#1693).
   """
 
   use FountainWeb, :controller
@@ -148,13 +150,38 @@ defmodule FountainWeb.SecretBindingController do
   # ask the broker only — an account that holds bindings can always see them
   # and take them apart, which is the one thing the single gate made
   # impossible (#1693).
+  #
+  # The plug covers every action, so an action left off this list gets the
+  # weaker gate rather than no gate. That default is right for one that reads
+  # or removes and wrong for one that creates: an action that adds a way to a
+  # credential belongs here in the commit that adds it.
   @creating [:create, :update]
+
+  # `update` is the one action its name cannot classify. `enabled: false` on
+  # its own is the soft off switch, the same act as `delete` and not a new
+  # credential path, so it is the edit a flag-off account may still make. Any
+  # other field — a host, an auth shape, or `enabled: true` — points a
+  # credential at somewhere, and the console's Enable button is gated the same
+  # way (`FountainWeb.SecretBindingsLive.Index`).
+  defp creating?(conn) do
+    case action_name(conn) do
+      :update -> not disabling_only?(conn.params)
+      action -> action in @creating
+    end
+  end
+
+  defp disabling_only?(params) do
+    case Map.take(params, @fields) do
+      %{"enabled" => enabled} = attrs when map_size(attrs) == 1 -> enabled in [false, "false"]
+      _ -> false
+    end
+  end
 
   defp require_brokerage(conn, _opts) do
     user_id = conn.assigns.current_user.id
 
     allowed? =
-      if action_name(conn) in @creating,
+      if creating?(conn),
         do: Fountain.Connections.enabled_for?(user_id),
         else: Fountain.Connections.manageable_for?(user_id)
 

--- a/apps/fountain/lib/fountain_web/controllers/secret_binding_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/secret_binding_controller.ex
@@ -9,9 +9,12 @@ defmodule FountainWeb.SecretBindingController do
       PATCH  /api/secret-bindings/:id        — change one
       DELETE /api/secret-bindings/:id        — unbind
 
-  Every route answers 404 `brokerage_not_enabled` for an account the broker
-  or Connections flag is not on for: the feature does not exist there, and the console does not
-  show it either.
+  Every route answers 404 `brokerage_not_enabled` for an account the broker is
+  not on for: the feature does not exist there, and the console does not show
+  it either. Binding a secret and changing a binding need the `connections`
+  rollout flag as well, because both point a credential at a host. Listing and
+  unbinding do not: `DELETE` is how an account turns off a binding that is
+  still attaching a credential, and that door stays open (#1693).
   """
 
   use FountainWeb, :controller
@@ -140,8 +143,22 @@ defmodule FountainWeb.SecretBindingController do
 
   defp binding_attrs(params), do: Map.take(params, @fields)
 
+  # Binding a secret and editing a binding both send a credential somewhere it
+  # was not going before, so they need the rollout flag. Listing and unbinding
+  # ask the broker only — an account that holds bindings can always see them
+  # and take them apart, which is the one thing the single gate made
+  # impossible (#1693).
+  @creating [:create, :update]
+
   defp require_brokerage(conn, _opts) do
-    if Fountain.Connections.enabled_for?(conn.assigns.current_user.id) do
+    user_id = conn.assigns.current_user.id
+
+    allowed? =
+      if action_name(conn) in @creating,
+        do: Fountain.Connections.enabled_for?(user_id),
+        else: Fountain.Connections.manageable_for?(user_id)
+
+    if allowed? do
       conn
     else
       conn

--- a/apps/fountain/lib/fountain_web/live/agents_live/form.ex
+++ b/apps/fountain/lib/fountain_web/live/agents_live/form.ex
@@ -209,9 +209,12 @@ defmodule FountainWeb.AgentsLive.Form do
   end
 
   # The active connections the form can offer, only where connections exist
-  # (accounts with the Connections flag and broker on). Elsewhere the select is not rendered.
+  # (a brokered account). Elsewhere the select is not rendered. The rollout
+  # flag is not asked: naming a connection the account already holds is not
+  # connecting a new one, and an agent must stay editable after the flag goes
+  # off (#1693).
   defp connections_for(user_id) do
-    if Fountain.Connections.enabled_for?(user_id),
+    if Fountain.Connections.manageable_for?(user_id),
       do: Fountain.Connections.active_connections(user_id),
       else: []
   end

--- a/apps/fountain/lib/fountain_web/live/connections_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/connections_live/index.ex
@@ -9,8 +9,11 @@ defmodule FountainWeb.ConnectionsLive.Index do
   trip itself is `FountainWeb.ConnectionsController`; this page only links
   to it and shows what came back.
 
-  Only for accounts with the broker and Connections flag on: the nav link is hidden
-  otherwise, and a direct visit is sent to `/account`.
+  Only for accounts the broker is on for: the nav link is hidden otherwise,
+  and a direct visit is sent to `/account`. The `connections` rollout flag
+  decides whether this page can *add* anything. With it off the page still
+  lists what the account holds and still revokes and removes it, and every
+  control that would connect an account or define a provider is gone (#1693).
   """
 
   use FountainWeb, :live_view
@@ -89,11 +92,16 @@ defmodule FountainWeb.ConnectionsLive.Index do
   def mount(_params, _session, socket) do
     user = socket.assigns.current_user
 
-    if Fountain.Connections.enabled_for?(user.id) do
+    # The page opens for any brokered account, so the connections an account
+    # holds can always be seen, revoked and removed. `may_connect?` carries
+    # the rollout flag: with it off the page keeps every door that takes a
+    # credential away and hides the ones that add one (#1693).
+    if Fountain.Connections.manageable_for?(user.id) do
       {:ok,
        socket
        |> assign(:page_title, "Connections")
        |> assign(:user_id, user.id)
+       |> assign(:may_connect?, Fountain.Connections.enabled_for?(user.id))
        |> assign(:provider_form, nil)
        |> assign(:editing_id, nil)
        |> assign(:provider_errors, [])
@@ -110,9 +118,25 @@ defmodule FountainWeb.ConnectionsLive.Index do
     end
   end
 
-  # ── connections ───────────────────────────────────────────────────────────
+  # Every event that would add a way of getting a credential, refused in one
+  # place for an account without the rollout flag. The template hides these
+  # controls; a hidden control is not a gate, so the event is refused too.
+  @adding ~w(new_provider preset edit_provider validate_provider save_provider
+             mcp_preset validate_mcp discover rediscover)
 
   @impl true
+  def handle_event(event, _params, %{assigns: %{may_connect?: false}} = socket)
+      when event in @adding do
+    {:noreply,
+     put_flash(
+       socket,
+       :error,
+       "Connections are not enabled for this account. You can still revoke and remove the ones you have."
+     )}
+  end
+
+  # ── connections ───────────────────────────────────────────────────────────
+
   def handle_event("revoke", %{"id" => id}, socket) do
     user_id = socket.assigns.user_id
 
@@ -421,6 +445,14 @@ defmodule FountainWeb.ConnectionsLive.Index do
           server of yours with the token attached by the egress broker, or an access token
           brokered to the provider's hosts. No token ever enters a sandbox.
         </p>
+        <p
+          :if={!@may_connect?}
+          data-role="connect-disabled"
+          class="mt-3 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900"
+        >
+          Connecting a new account is off for this account. The connections you have keep
+          working, and you can revoke or remove any of them here.
+        </p>
       </div>
 
       <%!-- ── Providers ─────────────────────────────────────────────────── --%>
@@ -428,6 +460,7 @@ defmodule FountainWeb.ConnectionsLive.Index do
         <div class="flex items-center justify-between">
           <h2 class="text-lg font-medium">Providers</h2>
           <button
+            :if={@may_connect?}
             phx-click="new_provider"
             data-role="new-provider"
             class="rounded-md border border-[var(--color-border)] px-3 py-1.5 text-sm hover:bg-[var(--color-bg-2)]"
@@ -488,7 +521,7 @@ defmodule FountainWeb.ConnectionsLive.Index do
             </div>
             <div class="flex flex-col items-end gap-2 shrink-0">
               <a
-                :if={configured?(p) and not asks_label?(p)}
+                :if={@may_connect? and configured?(p) and not asks_label?(p)}
                 href={~p"/connections/#{p.id}/start"}
                 data-role={"connect-#{p.slug}"}
                 class="rounded-md bg-zinc-900 px-3 py-2 text-sm text-white hover:bg-zinc-700"
@@ -498,7 +531,7 @@ defmodule FountainWeb.ConnectionsLive.Index do
                   else: "an account"}
               </a>
               <form
-                :if={configured?(p) and asks_label?(p)}
+                :if={@may_connect? and configured?(p) and asks_label?(p)}
                 method="get"
                 action={~p"/connections/#{p.id}/start"}
                 class="flex gap-1"
@@ -528,14 +561,19 @@ defmodule FountainWeb.ConnectionsLive.Index do
               </span>
               <div :if={!Provider.platform?(p)} class="flex gap-2">
                 <button
-                  :if={p.kind == "mcp"}
+                  :if={@may_connect? and p.kind == "mcp"}
                   phx-click="rediscover"
                   phx-value-id={p.id}
                   class="text-xs underline"
                 >
                   Re-discover
                 </button>
-                <button phx-click="edit_provider" phx-value-id={p.id} class="text-xs underline">
+                <button
+                  :if={@may_connect?}
+                  phx-click="edit_provider"
+                  phx-value-id={p.id}
+                  class="text-xs underline"
+                >
                   Edit
                 </button>
                 <button
@@ -725,6 +763,7 @@ defmodule FountainWeb.ConnectionsLive.Index do
 
         <%!-- ── Remote MCP server ───────────────────────────────────────── --%>
         <form
+          :if={@may_connect?}
           id="mcp-discover-form"
           phx-change="validate_mcp"
           phx-submit="discover"
@@ -842,7 +881,7 @@ defmodule FountainWeb.ConnectionsLive.Index do
           </div>
           <div class="flex gap-2 shrink-0">
             <a
-              :if={c.status == "expired"}
+              :if={@may_connect? and c.status == "expired"}
               href={~p"/connections/#{c.provider_id || c.provider}/start?label=#{c.account_email}"}
               data-role="reconnect"
               class="rounded-md bg-zinc-900 px-3 py-1.5 text-sm text-white hover:bg-zinc-700"

--- a/apps/fountain/lib/fountain_web/live/secret_bindings_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/secret_bindings_live/index.ex
@@ -7,9 +7,9 @@ defmodule FountainWeb.SecretBindingsLive.Index do
   and a direct visit is sent to `/account`. The page never sees a value —
   it lists the names of the secrets the account holds anywhere, and the
   bindings on each name. The `connections` rollout flag decides whether a
-  *new* binding can be made here. With it off the page still lists the
-  bindings, still turns one off and still unbinds it, and the form is gone
-  (#1693).
+  credential can be sent anywhere new from here. With it off the page still
+  lists the bindings, still disables one and still unbinds it; the form is
+  gone, and so is the button that would enable a disabled binding (#1693).
   """
 
   use FountainWeb, :live_view
@@ -49,8 +49,15 @@ defmodule FountainWeb.SecretBindingsLive.Index do
 
   # The events that make a new binding, refused in one place for an account
   # without the rollout flag. The template hides the form; a hidden form is
-  # not a gate. `toggle` and `delete` are not here: they take a binding away,
-  # and that is exactly what must keep working.
+  # not a gate. `delete` is not here: it takes a binding away, and that is
+  # exactly what must keep working.
+  #
+  # `toggle` is not here either, and not because it is safe: it writes
+  # `enabled: not enabled`, so its name says nothing about which way it goes.
+  # Disabling is the soft off switch; enabling starts a credential flowing to
+  # a host it was not flowing to, which is the same act the API's `update`
+  # needs the flag for. A name cannot tell the two apart, so the direction of
+  # the write is gated instead, in `handle_event("toggle", ...)` below.
   @binding_new ~w(draft pick_key preset save)
 
   @impl true
@@ -145,20 +152,27 @@ defmodule FountainWeb.SecretBindingsLive.Index do
     end
   end
 
+  # Which way this one goes decides which gate it is under: disabling a binding
+  # is the off switch and stays open, enabling one attaches a credential to a
+  # host again and needs the flag (#1693).
   def handle_event("toggle", %{"id" => id}, socket) do
-    with %Binding{} = binding <- SecretBindings.get_binding(id, socket.assigns.user_id),
-         {:ok, updated} <-
-           SecretBindings.update_binding(
-             binding,
-             %{"enabled" => not binding.enabled},
-             FountainWeb.Audited.attribution(socket)
-           ) do
-      word = if updated.enabled, do: "enabled", else: "disabled"
+    binding = SecretBindings.get_binding(id, socket.assigns.user_id)
 
-      {:noreply,
-       socket |> reload() |> put_flash(:info, "#{updated.key} → #{updated.host} #{word}")}
-    else
-      _ -> {:noreply, put_flash(socket, :error, "Binding not found")}
+    cond do
+      is_nil(binding) ->
+        {:noreply, put_flash(socket, :error, "Binding not found")}
+
+      not binding.enabled and not socket.assigns.may_bind? ->
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           "New bindings are off for this account, and enabling this one would make it " <>
+             "attach #{binding.key} to #{binding.host} again."
+         )}
+
+      true ->
+        flip(socket, binding)
     end
   end
 
@@ -176,6 +190,23 @@ defmodule FountainWeb.SecretBindingsLive.Index do
   end
 
   # ── helpers ──────────────────────────────────────────────────────────────
+
+  defp flip(socket, %Binding{} = binding) do
+    case SecretBindings.update_binding(
+           binding,
+           %{"enabled" => not binding.enabled},
+           FountainWeb.Audited.attribution(socket)
+         ) do
+      {:ok, updated} ->
+        word = if updated.enabled, do: "enabled", else: "disabled"
+
+        {:noreply,
+         socket |> reload() |> put_flash(:info, "#{updated.key} → #{updated.host} #{word}")}
+
+      _ ->
+        {:noreply, put_flash(socket, :error, "Binding not found")}
+    end
+  end
 
   defp reload(socket) do
     user_id = socket.assigns.user_id
@@ -319,7 +350,11 @@ defmodule FountainWeb.SecretBindingsLive.Index do
                   <span :if={!b.enabled} class="text-zinc-500">disabled</span>
                 </td>
                 <td class="px-3 py-2 text-right whitespace-nowrap space-x-2">
-                  <.btn_secondary phx-click="toggle" phx-value-id={b.id}>
+                  <.btn_secondary
+                    :if={b.enabled or @may_bind?}
+                    phx-click="toggle"
+                    phx-value-id={b.id}
+                  >
                     {if b.enabled, do: "Disable", else: "Enable"}
                   </.btn_secondary>
                   <.btn_danger phx-click="delete" phx-value-id={b.id} data-confirm="Unbind?">

--- a/apps/fountain/lib/fountain_web/live/secret_bindings_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/secret_bindings_live/index.ex
@@ -6,7 +6,10 @@ defmodule FountainWeb.SecretBindingsLive.Index do
   Only for accounts the broker is on for: the nav link is hidden otherwise,
   and a direct visit is sent to `/account`. The page never sees a value —
   it lists the names of the secrets the account holds anywhere, and the
-  bindings on each name.
+  bindings on each name. The `connections` rollout flag decides whether a
+  *new* binding can be made here. With it off the page still lists the
+  bindings, still turns one off and still unbinds it, and the form is gone
+  (#1693).
   """
 
   use FountainWeb, :live_view
@@ -20,11 +23,15 @@ defmodule FountainWeb.SecretBindingsLive.Index do
   def mount(_params, _session, socket) do
     user = socket.assigns.current_user
 
-    if Fountain.Connections.enabled_for?(user.id) do
+    # Open for any brokered account. A binding that is attaching a credential
+    # right now has to be visible and removable whatever the rollout flag
+    # says; `may_bind?` is the flag, and it gates only the form (#1693).
+    if Fountain.Connections.manageable_for?(user.id) do
       {:ok,
        socket
        |> assign(:page_title, "Credential bindings")
        |> assign(:user_id, user.id)
+       |> assign(:may_bind?, Fountain.Connections.enabled_for?(user.id))
        |> assign(:proxy_host, Broker.proxy_host())
        |> assign(:presets, Catalog.presets())
        |> assign(:form_version, 0)
@@ -40,10 +47,26 @@ defmodule FountainWeb.SecretBindingsLive.Index do
 
   # ── events ───────────────────────────────────────────────────────────────
 
+  # The events that make a new binding, refused in one place for an account
+  # without the rollout flag. The template hides the form; a hidden form is
+  # not a gate. `toggle` and `delete` are not here: they take a binding away,
+  # and that is exactly what must keep working.
+  @binding_new ~w(draft pick_key preset save)
+
+  @impl true
+  def handle_event(event, _params, %{assigns: %{may_bind?: false}} = socket)
+      when event in @binding_new do
+    {:noreply,
+     put_flash(
+       socket,
+       :error,
+       "New bindings are off for this account. You can still disable or unbind the ones you have."
+     )}
+  end
+
   # Keeps the form's shape in step with the auth type and the preset pick,
   # so only the fields of the chosen type are shown and submitted — the
   # broker rejects a stale field from a previous choice.
-  @impl true
   def handle_event("draft", %{"binding" => attrs}, socket) do
     draft =
       Map.merge(
@@ -309,7 +332,7 @@ defmodule FountainWeb.SecretBindingsLive.Index do
         </div>
       </section>
 
-      <section :if={@unbound_keys != []} class="space-y-2">
+      <section :if={@may_bind? and @unbound_keys != []} class="space-y-2">
         <h2 class="text-lg font-medium">Secrets with no binding</h2>
         <p class="text-sm text-[var(--color-text-secondary)]">
           These reach the sandbox in the clear. Bind the ones that are credentials for a host.
@@ -329,7 +352,12 @@ defmodule FountainWeb.SecretBindingsLive.Index do
         </div>
       </section>
 
-      <section class="space-y-3">
+      <section :if={!@may_bind?} data-role="bind-disabled" class="text-sm text-amber-900">
+        New bindings are off for this account. The bindings above keep attaching their
+        secrets, and you can disable or unbind any of them.
+      </section>
+
+      <section :if={@may_bind?} class="space-y-3">
         <h2 class="text-lg font-medium">Bind a secret to a host</h2>
         <div class="flex flex-wrap gap-1 items-center text-xs">
           <span class="text-[var(--color-text-secondary)] mr-1">Start from a known service:</span>

--- a/apps/fountain/test/fountain/feature_flags_test.exs
+++ b/apps/fountain/test/fountain/feature_flags_test.exs
@@ -62,6 +62,21 @@ defmodule Fountain.FeatureFlagsTest do
     test "an unknown flag atom is a KeyError, not a silent off" do
       assert_raise KeyError, fn -> FeatureFlags.enabled?(:no_such_flag, @user_id) end
     end
+
+    # A flag over a shipped feature reads on where there is nobody to ask, or
+    # a self-host loses the feature on the upgrade that added the flag (#1693).
+    test "a flag that gates a shipped feature reads on" do
+      posthog_off()
+      assert FeatureFlags.enabled?(:connections, @user_id)
+      assert FeatureFlags.enabled?(:connections, nil)
+      refute FeatureFlags.enabled?(:team_comms, @user_id)
+    end
+
+    test "a static override still decides, in both directions" do
+      posthog_off()
+      Application.put_env(:fountain, :feature_flag_overrides, %{"connections" => false})
+      refute FeatureFlags.enabled?(:connections, @user_id)
+    end
   end
 
   describe "with PostHog" do
@@ -82,6 +97,17 @@ defmodule Fountain.FeatureFlagsTest do
     test "a flag PostHog does not mention is off" do
       stub_flags(%{"something_else" => true})
       refute FeatureFlags.enabled?(:team_comms, @user_id)
+    end
+
+    # The default is for a deployment with no flag service. Where there is one,
+    # its answer decides, including for a flag it does not mention.
+    test "PostHog's answer beats the no-PostHog default" do
+      stub_flags(%{"connections" => false})
+      refute FeatureFlags.enabled?(:connections, @user_id)
+
+      stub_flags(%{"something_else" => true})
+      FeatureFlags.reset()
+      refute FeatureFlags.enabled?(:connections, @user_id)
     end
 
     test "also reads the older /decide shape" do

--- a/apps/fountain/test/fountain_web/controllers/connections_rollout_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/connections_rollout_test.exs
@@ -1,8 +1,22 @@
 defmodule FountainWeb.ConnectionsRolloutTest do
+  @moduledoc """
+  The two gates in front of Connections, and which doors each one holds.
+
+  The broker closes everything: without it a token cannot be kept out of a
+  sandbox, so the feature does not exist for that account. The `connections`
+  rollout flag closes only the doors that **add** a way of getting a
+  credential. Everything that lists, revokes, unbinds or deletes stays open
+  for a brokered account, because a tenant whose flag goes off keeps every
+  credential already brokered into their sandboxes and has to be able to take
+  it away (#1693).
+  """
   use FountainWeb.ConnCase, async: false
 
   import Fountain.BrokerTestHelpers
   import Phoenix.LiveViewTest
+
+  alias Fountain.Connections.OAuth
+  alias Fountain.SecretBindings
 
   setup do
     user = insert_verified_user()
@@ -11,15 +25,30 @@ defmodule FountainWeb.ConnectionsRolloutTest do
     {:ok, user: user, raw: raw}
   end
 
-  for {broker, flag} <- [{true, false}, {false, true}, {false, false}] do
-    test "every management route requires broker=#{broker} and flag=#{flag}", ctx do
-      Application.put_env(
-        :fountain,
-        :broker_tenants,
-        if(unquote(broker), do: [ctx.user.id], else: [])
+  defp flag(on?),
+    do: Application.put_env(:fountain, :feature_flag_overrides, %{"connections" => on?})
+
+  defp api(raw) do
+    build_conn()
+    |> put_req_header("authorization", "Bearer " <> raw)
+    |> put_req_header("accept", "application/json")
+  end
+
+  defp binding_for(user) do
+    {:ok, binding} =
+      SecretBindings.create_binding(
+        user.id,
+        %{"key" => "STRIPE_SECRET_KEY", "host" => "api.stripe.com", "auth_type" => "bearer"},
+        actor: "ui"
       )
 
-      Application.put_env(:fountain, :feature_flag_overrides, %{"connections" => unquote(flag)})
+    binding
+  end
+
+  for flag <- [true, false] do
+    test "the broker off closes every route, with the flag #{flag}", ctx do
+      Application.put_env(:fountain, :broker_tenants, [])
+      flag(unquote(flag))
 
       routes =
         FountainWeb.Router.__routes__()
@@ -35,13 +64,7 @@ defmodule FountainWeb.ConnectionsRolloutTest do
 
       for route <- routes do
         path = Regex.replace(~r/:[a-z_]+/, route.path, Ecto.UUID.generate())
-
-        conn =
-          build_conn()
-          |> put_req_header("authorization", "Bearer " <> ctx.raw)
-          |> put_req_header("accept", "application/json")
-
-        result = dispatch(conn, @endpoint, route.verb, path, %{})
+        result = dispatch(api(ctx.raw), @endpoint, route.verb, path, %{})
 
         expected =
           if String.starts_with?(path, "/api/secret-bindings"),
@@ -53,14 +76,165 @@ defmodule FountainWeb.ConnectionsRolloutTest do
     end
   end
 
+  describe "the flag off, the broker on" do
+    test "an account that holds rows can still list and delete every one of them", ctx do
+      connection = insert_connection(ctx.user, account_email: "me@example.com")
+      provider = insert_provider(ctx.user)
+      binding = binding_for(ctx.user)
+      flag(false)
+
+      conn = api(ctx.raw)
+
+      assert %{"data" => [_]} = conn |> get("/api/connections") |> json_response(200)
+
+      assert %{"id" => _} =
+               conn |> get("/api/connections/#{connection.id}") |> json_response(200)
+
+      Req.Test.stub(OAuth, fn req -> Req.Test.json(req, %{}) end)
+      assert conn |> delete("/api/connections/#{connection.id}") |> response(204)
+
+      assert %{"data" => providers} =
+               conn |> get("/api/connection-providers") |> json_response(200)
+
+      assert Enum.any?(providers, &(&1["id"] == provider.id))
+      assert conn |> delete("/api/connection-providers/#{provider.id}") |> response(204)
+
+      assert %{"data" => [_]} = conn |> get("/api/secret-bindings") |> json_response(200)
+      assert conn |> delete("/api/secret-bindings/#{binding.id}") |> response(204)
+
+      assert SecretBindings.list_bindings(ctx.user.id) == []
+    end
+
+    test "adding one is still refused", ctx do
+      provider = insert_provider(ctx.user)
+      binding = binding_for(ctx.user)
+      flag(false)
+
+      conn = api(ctx.raw)
+
+      assert %{"error" => "connections_not_enabled"} =
+               conn
+               |> post("/api/connection-providers", provider_attrs(%{"slug" => "another"}))
+               |> json_response(404)
+
+      assert %{"error" => "connections_not_enabled"} =
+               conn
+               |> patch("/api/connection-providers/#{provider.id}", %{"name" => "Renamed"})
+               |> json_response(404)
+
+      assert %{"error" => "connections_not_enabled"} =
+               conn
+               |> post("/api/connection-providers/#{provider.id}/discover", %{})
+               |> json_response(404)
+
+      assert %{"error" => "brokerage_not_enabled"} =
+               conn
+               |> post("/api/secret-bindings", %{
+                 key: "K",
+                 host: "api.example.com",
+                 auth_type: "bearer"
+               })
+               |> json_response(404)
+
+      # A binding's host is where the credential goes, so retargeting one is
+      # adding a credential path, not managing an existing one.
+      assert %{"error" => "brokerage_not_enabled"} =
+               conn
+               |> patch("/api/secret-bindings/#{binding.id}", %{host: "api.attacker.example"})
+               |> json_response(404)
+
+      assert %{host: "api.stripe.com"} = SecretBindings.get_binding(binding.id, ctx.user.id)
+    end
+
+    test "the OAuth round trip is refused and the console says so", ctx do
+      flag(false)
+      conn = login_user(build_conn(), ctx.user)
+
+      for path <- ["/connections/google/start", "/connections/google/callback"] do
+        assert conn |> get(path) |> redirected_to() == "/account"
+      end
+    end
+
+    test "both pages open, the nav still links them, and the controls that add are gone", ctx do
+      connection = insert_connection(ctx.user, account_email: "me@example.com")
+      binding = binding_for(ctx.user)
+      flag(false)
+      conn = login_user(build_conn(), ctx.user)
+
+      html = conn |> get("/account") |> html_response(200)
+      assert html =~ "Credential bindings"
+      assert html =~ "href=\"/account/connections\""
+
+      {:ok, view, html} = live(conn, "/account/connections")
+      assert html =~ "me@example.com"
+      assert has_element?(view, "[data-role=connect-disabled]")
+      refute has_element?(view, "[data-role=new-provider]")
+      refute has_element?(view, "#mcp-discover-form")
+
+      # Revoking and removing are the doors that must never close.
+      Req.Test.stub(OAuth, fn req -> Req.Test.json(req, %{}) end)
+      html = render_click(view, "revoke", %{"id" => connection.id})
+      assert html =~ "Revoked me@example.com"
+      render_click(view, "delete", %{"id" => connection.id})
+      assert Fountain.Connections.list_connections(ctx.user.id) == []
+
+      {:ok, bindings_view, html} = live(conn, "/account/bindings")
+      assert html =~ "STRIPE_SECRET_KEY"
+      assert has_element?(bindings_view, "[data-role=bind-disabled]")
+      refute has_element?(bindings_view, "#binding-form-0")
+
+      render_click(bindings_view, "delete", %{"id" => binding.id})
+      assert SecretBindings.list_bindings(ctx.user.id) == []
+    end
+
+    test "an agent form still offers the connections the account holds", ctx do
+      insert_connection(ctx.user, account_email: "me@example.com")
+      agent = insert_agent(user_id: ctx.user.id)
+      flag(false)
+
+      {:ok, view, _html} = live(login_user(build_conn(), ctx.user), "/agents/#{agent.id}/edit")
+      view |> element("button", "+ Add server") |> render_click()
+
+      html =
+        view
+        |> element("form[phx-change=validate]")
+        |> render_change(%{
+          "agent" => %{"mcp_servers" => %{"0" => %{"name" => "gmail", "kind" => "connection"}}}
+        })
+
+      assert html =~ "me@example.com (google)"
+    end
+
+    test "an event that would add something is refused even when pushed at the page", ctx do
+      flag(false)
+      conn = login_user(build_conn(), ctx.user)
+
+      {:ok, view, _html} = live(conn, "/account/connections")
+      assert render_click(view, "new_provider", %{}) =~ "not enabled for this account"
+      refute has_element?(view, "#provider-form")
+
+      {:ok, bindings_view, _html} = live(conn, "/account/bindings")
+
+      assert render_click(bindings_view, "save", %{
+               "binding" => %{
+                 "key" => "K",
+                 "host" => "api.example.com",
+                 "auth_type" => "bearer"
+               }
+             }) =~ "New bindings are off"
+
+      assert SecretBindings.list_bindings(ctx.user.id) == []
+    end
+  end
+
   test "brokering stays visible while Connections is off, and both on opens the surface", ctx do
-    Application.put_env(:fountain, :feature_flag_overrides, %{"connections" => false})
+    flag(false)
     conn = build_conn() |> put_req_header("authorization", "Bearer " <> ctx.raw)
 
     assert %{"brokered" => true, "connections_enabled" => false} =
              conn |> get("/api/auth/me") |> json_response(200)
 
-    Application.put_env(:fountain, :feature_flag_overrides, %{"connections" => true})
+    flag(true)
 
     assert %{"brokered" => true, "connections_enabled" => true} =
              conn |> get("/api/auth/me") |> json_response(200)
@@ -68,19 +242,23 @@ defmodule FountainWeb.ConnectionsRolloutTest do
     assert %{"data" => []} = conn |> get("/api/connections") |> json_response(200)
   end
 
-  test "flag off hides navigation, redirects both pages and refuses the OAuth round trip", ctx do
-    Application.put_env(:fountain, :feature_flag_overrides, %{"connections" => false})
-    conn = login_user(build_conn(), ctx.user)
-    html = conn |> get("/account") |> html_response(200)
-    refute html =~ "Credential bindings"
-    refute html =~ "href=\"/account/connections\""
+  test "a deployment with no PostHog keeps Connections rather than losing it on upgrade", ctx do
+    # The self-host case (#1693): no override, no flag service. The upgrade
+    # that introduced the flag must not take the feature away.
+    previous = Application.get_env(:fountain, :posthog_project_api_key)
 
-    for path <- ["/account/connections", "/account/bindings"] do
-      assert {:error, {:live_redirect, %{to: "/account"}}} = live(conn, path)
-    end
+    on_exit(fn ->
+      if previous, do: Application.put_env(:fountain, :posthog_project_api_key, previous)
+      Fountain.FeatureFlags.reset()
+    end)
 
-    for path <- ["/connections/google/start", "/connections/google/callback"] do
-      assert conn |> get(path) |> redirected_to() == "/account"
-    end
+    Application.put_env(:fountain, :feature_flag_overrides, %{})
+    Application.delete_env(:fountain, :posthog_project_api_key)
+    Fountain.FeatureFlags.reset()
+
+    assert Fountain.Connections.enabled_for?(ctx.user.id)
+
+    assert %{"connections_enabled" => true} =
+             api(ctx.raw) |> get("/api/auth/me") |> json_response(200)
   end
 end

--- a/apps/fountain/test/fountain_web/controllers/connections_rollout_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/connections_rollout_test.exs
@@ -34,11 +34,14 @@ defmodule FountainWeb.ConnectionsRolloutTest do
     |> put_req_header("accept", "application/json")
   end
 
-  defp binding_for(user) do
+  defp binding_for(user, attrs \\ %{}) do
     {:ok, binding} =
       SecretBindings.create_binding(
         user.id,
-        %{"key" => "STRIPE_SECRET_KEY", "host" => "api.stripe.com", "auth_type" => "bearer"},
+        Map.merge(
+          %{"key" => "STRIPE_SECRET_KEY", "host" => "api.stripe.com", "auth_type" => "bearer"},
+          attrs
+        ),
         actor: "ui"
       )
 
@@ -144,6 +147,60 @@ defmodule FountainWeb.ConnectionsRolloutTest do
                |> json_response(404)
 
       assert %{host: "api.stripe.com"} = SecretBindings.get_binding(binding.id, ctx.user.id)
+    end
+
+    # `enabled` is the one field whose two values sit on different sides of the
+    # gate: false takes a credential off a host, true puts it back on.
+    test "a binding can be disabled but not enabled again, over the API", ctx do
+      binding = binding_for(ctx.user)
+      flag(false)
+      conn = api(ctx.raw)
+
+      assert %{"enabled" => false} =
+               conn
+               |> patch("/api/secret-bindings/#{binding.id}", %{enabled: false})
+               |> json_response(200)
+
+      assert %{"error" => "brokerage_not_enabled"} =
+               conn
+               |> patch("/api/secret-bindings/#{binding.id}", %{enabled: true})
+               |> json_response(404)
+
+      refute SecretBindings.get_binding(binding.id, ctx.user.id).enabled
+
+      # Not a loophole: a disabling that carries anything else is an edit.
+      assert %{"error" => "brokerage_not_enabled"} =
+               conn
+               |> patch("/api/secret-bindings/#{binding.id}", %{
+                 enabled: false,
+                 host: "api.attacker.example"
+               })
+               |> json_response(404)
+
+      assert %{host: "api.stripe.com"} = SecretBindings.get_binding(binding.id, ctx.user.id)
+    end
+
+    test "the console cannot enable a disabled binding either", ctx do
+      binding = binding_for(ctx.user, %{"enabled" => false})
+      flag(false)
+
+      {:ok, view, _html} = live(login_user(build_conn(), ctx.user), "/account/bindings")
+
+      # The button is gone, and the event behind it is refused.
+      refute has_element?(view, "[phx-click=toggle][phx-value-id='#{binding.id}']")
+
+      assert render_click(view, "toggle", %{"id" => binding.id}) =~ "New bindings are off"
+      refute SecretBindings.get_binding(binding.id, ctx.user.id).enabled
+    end
+
+    test "the console still disables an enabled binding", ctx do
+      binding = binding_for(ctx.user)
+      flag(false)
+
+      {:ok, view, _html} = live(login_user(build_conn(), ctx.user), "/account/bindings")
+      assert has_element?(view, "[phx-click=toggle][phx-value-id='#{binding.id}']")
+      assert render_click(view, "toggle", %{"id" => binding.id}) =~ "disabled"
+      refute SecretBindings.get_binding(binding.id, ctx.user.id).enabled
     end
 
     test "the OAuth round trip is refused and the console says so", ctx do

--- a/apps/fountain/test/fountain_web/controllers/gmail_mcp_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/gmail_mcp_controller_test.exs
@@ -35,8 +35,20 @@ defmodule FountainWeb.GmailMcpControllerTest do
     })
   end
 
-  test "the rollout flag refuses Gmail even when the broker is on", ctx do
+  # The gate here is the broker, like every other runtime path (#1693). The
+  # rollout flag decides who may connect an account; a connection that exists
+  # keeps working, and the console keeps the door that revokes it.
+  test "the rollout flag going off leaves a connection the agent names working", ctx do
     Application.put_env(:fountain, :feature_flag_overrides, %{"connections" => false})
+
+    body =
+      rpc(ctx.conn, ctx.raw_key, ctx.conv, ctx.connection, "tools/list") |> json_response(200)
+
+    assert [_ | _] = body["result"]["tools"]
+  end
+
+  test "the broker off refuses Gmail", ctx do
+    Application.put_env(:fountain, :broker_tenants, [])
     response = rpc(ctx.conn, ctx.raw_key, ctx.conv, ctx.connection, "tools/list", %{})
     assert response.status == 403
   end

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -423,15 +423,26 @@ When PostHog is unreachable, Fountain reuses the last answer it gave. With no
 answer at all, each flag reads off, so an outage never turns a feature on.
 Without PostHog you can force a flag on for each user.
 
+A flag over a feature that shipped is the exception. The `connections` flag
+reads on where you set no `POSTHOG_PROJECT_API_KEY`. A deployment with no flag
+service keeps the feature, and an upgrade does not take it away. Where you
+configure PostHog, the answer from PostHog decides.
+
 | Variable | Default | Required | Effect |
 |---|---|---|---|
 | `POSTHOG_PROJECT_API_KEY` | — | — | The PostHog *project* API key. That is the public `phc_…` token, and not a personal key. Unset, Fountain looks up no flag remotely. |
 | `POSTHOG_HOST` | `https://us.i.posthog.com` | — | The PostHog ingestion host. Use `https://eu.i.posthog.com` for EU Cloud, or an instance you host yourself. |
-| `FEATURE_FLAGS_ON` | — | — | Comma-separated flag keys, forced on for each user, such as `team_comms`, `connections` or `openai_compat`. It wins over PostHog. |
+| `FEATURE_FLAGS_ON` | — | — | Comma-separated flag keys, forced on for each user, such as `team_comms` or `openai_compat`. It wins over PostHog. |
 
 For a hosted Connections rollout, leave the global override unset. Enable
 `connections` for the intended test accounts in PostHog, with evaluation
-runtime set to `all`. Enable the credential broker too.
+runtime set to `all`. Enable the credential broker too. The broker is the
+switch that decides which accounts get the feature.
+
+The flag holds only the doors that add a credential. Those doors connect an
+account, define a provider and attach a secret to a host. An account that loses
+the flag keeps what it has. The console and the API still list it, revoke it
+and delete it.
 
 ## Product analytics
 


### PR DESCRIPTION
Closes #1693.

## The two consequences of #1620

**A self-host loses Connections on upgrade.** `FeatureFlags.remote_enabled?/2` returns false for every flag when PostHog is not configured, so a deployment with no flag service lost the Connections page and the `/api/connections`, `/api/connection-providers` and `/api/secret-bindings` routes on the upgrade that added the flag, unless the operator set `FEATURE_FLAGS_ON=connections`.

**An account with the flag off cannot revoke a credential that is still in use.** The gate stood in front of every door, the ones that take a credential away included, while the runtime paths kept gating on the broker alone and kept brokering those tokens into sandboxes. Revoking a connection, deleting a provider and unbinding a secret each answered 404. That is the security half.

## The gate split

`Fountain.Connections.enabled_for?/1` keeps its name and now answers one question only: **may this account add a credential path?** Broker plus the `connections` flag. It gates connecting an account, defining or editing a provider, running MCP discovery, binding a secret, and pointing a binding at a different host (retargeting a binding sends a credential somewhere it was not going, so it belongs on this side).

`Fountain.Connections.manageable_for?/1` is the broker alone — which is what `Conversations.Egress` and the rest of the runtime already gate on — and answers: **do this account's connections work, and may it list, revoke and delete them?** It gates every read and every removal. A brokered account with no rows gets an empty list rather than a 404, which is the price of never having to ask "do they still hold one?" before answering.

Call sites moved to the right predicate:

| Door | Gate |
|---|---|
| `GET/DELETE /api/connections*` | manageable (no action there adds one) |
| `/api/connection-providers` index, show, delete | manageable |
| `/api/connection-providers` create, update, discover | enabled |
| `/api/secret-bindings` index, presets, delete | manageable |
| `/api/secret-bindings` create, update | enabled |
| `/connections/:provider/start` and `/callback` | enabled |
| `POST /api/mcp/gmail/...` | broker, like every other runtime path |
| `/account/connections`, `/account/bindings` mount, nav links, agent-form connection list | manageable |
| The LiveView events that add (provider form, discovery, bind) | enabled, refused in the handler as well as hidden in the template |

`auth_me_controller`'s `connections_enabled` field is deliberately left on `enabled_for?` — see "Left out" below.

## The self-host default

`@on_without_posthog` in `Fountain.FeatureFlags` names the flags that gate a **shipped** feature, and those read on when `POSTHOG_PROJECT_API_KEY` is unset. "Off because we asked and were told no" and "off because there is nobody to ask" are different answers, and only the first is a decision. There was no prior notion of a default-on flag in the repo. Nothing changes where PostHog is configured (it answers the flag as before, including for a flag it does not mention), and `FEATURE_FLAGS_ON` still wins over both. The switch that turns Connections off on a self-host is `BROKER_TENANTS`.

`CHANGELOG.md` carries this as an **Upgrade notes** entry plus a Fixed entry; `.env.example` and `docs/configuration.md` are updated to match.

## How it was verified

`connections_rollout_test.exs` is rewritten around the split (10 tests), plus two in `feature_flags_test.exs` and one rewritten in `gmail_mcp_controller_test.exs`. The load-bearing test: an account with the flag off and existing connection, provider and binding rows lists and deletes all three over the API (204s), and does the same in both LiveViews.

Every fix was then reverted, the test watched to fail, and restored:

| Reverted | Test that failed |
|---|---|
| `@on_without_posthog` lookup → `false` | "a flag that gates a shipped feature reads on"; "a deployment with no PostHog keeps Connections" |
| All three controller plugs → `enabled_for?` | "an account that holds rows can still list and delete every one of them" |
| The creating half of the plugs → `manageable_for?` (guard weakened) | "adding one is still refused" |
| The LiveView mounts and the nav → `enabled_for?` | "both pages open, the nav still links them…"; "an event that would add something is refused" |
| The LiveView event guards alone | "an event that would add something is refused even when pushed at the page" |
| `agents_live/form` → `enabled_for?` | "an agent form still offers the connections the account holds" |
| The Gmail MCP gate → `enabled_for?` | "the rollout flag going off leaves a connection the agent names working" |

Also run: `mix compile --warnings-as-errors`, `mix credo --strict` on the ten changed lib files (no issues), `mix format` from `apps/fountain`, and the three prose gates (`docs-style.py`, `vale lint docs apps/*/docs`, `destink.mjs` — all clean for the pages touched; the two `docs-style` findings are pre-existing pages I did not touch). 143 tests across the connections, bindings, gmail, auth/me, agents-live, docs and egress suites pass.

## Left out, deliberately

- **`connections_enabled` on `GET /api/auth/me`** still reports `enabled_for?` (may connect). Splitting it for API clients means a second field, which drags in the OpenAPI spec, the SDK contract and four SDK regenerations — out of proportion to this fix. A client that hides its whole Connections UI on that field would still hide revoke; worth a follow-up issue.
- **Diff size.** 482 insertions / 70 deletions, over the ~400 mentioned when this was handed over. 234 of the insertions are the rewritten rollout test and 27 are the CHANGELOG; the rest is the split and its call sites, comment-heavy. Say the word and it can be cut into "feature flag default" and "gate split".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DMNzkuh8mJbde1TQvsYsqj
