### PR TITLE
fix(cli): preserve literal apply variable values

### DIFF
--- a/cli/internal/cmd/apply.go
+++ b/cli/internal/cmd/apply.go
@@ -15,14 +15,18 @@ import (
 )
 
 func init() {
+	rootCmd.AddCommand(newApplyCmd())
+}
+
+func newApplyCmd() *cobra.Command {
 	applyCmd := &cobra.Command{
 		Use:   "apply",
 		Short: "Apply resource definitions from a YAML file or directory",
 		RunE:  runApply,
 	}
 	applyCmd.Flags().StringP("file", "f", "", "path to YAML file or directory")
-	applyCmd.Flags().StringSlice("var", nil, "extra variable for ${VAR} substitution (KEY=VAL, repeatable)")
-	rootCmd.AddCommand(applyCmd)
+	applyCmd.Flags().StringArray("var", nil, "extra variable for ${VAR} substitution (KEY=VAL, repeatable)")
+	return applyCmd
 }
 
 func runApply(cmd *cobra.Command, args []string) error {
@@ -34,7 +38,7 @@ func runApply(cmd *cobra.Command, args []string) error {
 		Fatal("usage: fountain apply -f <path-to-yaml> [--var KEY=VAL ...]")
 	}
 
-	varFlags, _ := cmd.Flags().GetStringSlice("var")
+	varFlags, _ := cmd.Flags().GetStringArray("var")
 	applyVars := buildApplyVars(varFlags)
 
 	docs, err := manifest.Read(path)

--- a/cli/internal/cmd/apply_test.go
+++ b/cli/internal/cmd/apply_test.go
@@ -138,3 +138,33 @@ func TestFormatResultErrors(t *testing.T) {
 		t.Errorf("nil errors should fall back to generic message")
 	}
 }
+
+func TestApplyVarsPreserveLiteralValues(t *testing.T) {
+	cmd := newApplyCmd()
+	err := cmd.ParseFlags([]string{
+		"--var", "PAIRS=a=1,b=2",
+		"--var", "HOSTS=web1,web2",
+		"--var", `QUOTED="a,b"`,
+		"--var", "EMPTY=",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	flags, err := cmd.Flags().GetStringArray("var")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("b", "original")
+	want := buildApplyVars(nil)
+	for key, value := range map[string]string{
+		"PAIRS":  "a=1,b=2",
+		"HOSTS":  "web1,web2",
+		"QUOTED": `"a,b"`,
+		"EMPTY":  "",
+	} {
+		want[key] = value
+	}
+	if got := buildApplyVars(flags); !reflect.DeepEqual(got, want) {
+		t.Fatal("apply variables changed beyond the supplied literal KEY=VALUE pairs")
+	}
+}

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -105,8 +105,8 @@ fountain apply [flags]
 Options:
 
 ```
-  -f, --file string   path to YAML file or directory
-      --var strings   extra variable for ${VAR} substitution (KEY=VAL, repeatable)
+  -f, --file string       path to YAML file or directory
+      --var stringArray   extra variable for ${VAR} substitution (KEY=VAL, repeatable)
 ```
 
 ## `fountain auth login`


### PR DESCRIPTION
`fountain apply --var 'PAIRS=a=1,b=2'` now keeps the complete value instead of silently introducing `b=2` as another variable. The flag uses literal repeatable values, with a regression covering commas, quotes, empty values, and the existing environment merge. The generated CLI reference is refreshed.

Closes #1896.

Three files, +39/-5. Independent PR against main.

Validation: the regression fails with the old CSV flag parser; `go test ./...` and `go vet ./...` pass. Full local `mix precommit` passes: core 5,224 tests + 6 doctests, Buzz 144 tests, Support 33 tests; zero failures. Docs-style and Vale reports were reviewed (existing advisory findings); destink is clean.
