### PR TITLE
ci: reject conflict markers in tracked text files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1786,6 +1786,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
         with:
           persist-credentials: false
+      - name: Reject conflict markers
+        run: python3 scripts/conflict-markers.py
       - name: Test CI decisions
         run: python3 -m unittest discover -s scripts/ci -p 'test_*.py' -v
 

--- a/mix.exs
+++ b/mix.exs
@@ -208,6 +208,7 @@ defmodule Fountain.Umbrella.MixProject do
       "ecto.migrate": [&migrate_in_app/1],
       "ecto.rollback": [&rollback_in_app/1],
       precommit: [
+        &conflict_markers_absent/1,
         "compile --warnings-as-errors",
         &deps_unlock_unused_changes_nothing/1,
         "format --check-formatted",
@@ -218,6 +219,11 @@ defmodule Fountain.Umbrella.MixProject do
         "test"
       ]
     ]
+  end
+
+  defp conflict_markers_absent(_args) do
+    {_, status} = System.cmd("python3", ["scripts/conflict-markers.py"], into: IO.stream())
+    if status != 0, do: Mix.raise("Conflict-marker check failed")
   end
 
   # Parity with CI's `mix deps.unlock --unused && git diff --exit-code

--- a/scripts/ci/test_conflict_markers.py
+++ b/scripts/ci/test_conflict_markers.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+GATE = Path(__file__).resolve().parents[1] / "conflict-markers.py"
+
+
+class ConflictMarkersTest(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.git("init", "--quiet")
+
+    def git(self, *args):
+        return subprocess.run(["git", *args], cwd=self.root, check=True,
+                              capture_output=True)
+
+    def scan(self):
+        return subprocess.run([sys.executable, str(GATE)], cwd=self.root,
+                              capture_output=True, text=True)
+
+    def test_each_marker_is_rejected_in_tracked_files_of_any_type(self):
+        for marker in ("<" * 7 + " HEAD", "=" * 7, ">" * 7 + " theirs",
+                       "|" * 7 + " base"):
+            for name in ("CHANGELOG.md", "fixture.json", ".env.example", "extension docs.md"):
+                with self.subTest(marker=marker, name=name):
+                    path = self.root / name
+                    path.write_text("before\n" + marker + "\nafter\n")
+                    self.git("add", "--", name)
+                    result = self.scan()
+                    self.assertEqual(result.returncode, 1)
+                    self.assertIn(f"{name}:2:", result.stdout)
+                    self.git("rm", "--cached", "--", name)
+                    path.unlink()
+
+    def test_reads_working_tree_and_ignores_untracked_files(self):
+        path = self.root / "tracked.md"
+        path.write_text("clean\n")
+        self.git("add", "tracked.md")
+        path.write_text(">" * 7 + " theirs\n")
+        self.assertEqual(self.scan().returncode, 1)
+        path.write_text("clean\n")
+        (self.root / "scratch.md").write_text("<" * 7 + " HEAD\n")
+        self.assertEqual(self.scan().returncode, 0)
+
+    def test_inline_examples_and_binary_files_do_not_match(self):
+        (self.root / "guide.md").write_text('Example: ' + '>' * 7 + ' theirs\n' +
+                                           'pattern = "' + '<' * 7 + '"\n' + '=' * 80 + '\n')
+        (self.root / "image.bin").write_bytes(b"\0\n" + b">" * 7 + b" theirs\n")
+        self.git("add", ".")
+        self.assertEqual(self.scan().returncode, 0)
+
+    def test_missing_repository_fails_closed(self):
+        with tempfile.TemporaryDirectory() as other:
+            result = subprocess.run([sys.executable, str(GATE)], cwd=other,
+                                    capture_output=True, text=True)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("tree was not checked", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/conflict-markers.py
+++ b/scripts/conflict-markers.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Reject unresolved conflict markers in tracked text files in the working tree."""
+
+import subprocess
+import sys
+
+
+def main():
+    # Match complete marker tokens, including diff3's ancestor marker. Keeping
+    # the expression inside a string avoids matching this gate or its tests.
+    result = subprocess.run([
+        "git", "grep", "--no-color", "-I", "-n", "-E",
+        r"^(<{7}|={7}|>{7}|\|{7})([[:space:]]|$)", "--", ".",
+    ], check=False)
+    if result.returncode == 1:
+        print("Conflict markers: tracked text files are clean.")
+        return 0
+    if result.returncode == 0:
+        print("Resolve the conflict markers listed above before committing.", file=sys.stderr)
+        return 1
+    print("Conflict-marker scan failed; the tree was not checked.", file=sys.stderr)
+    return result.returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
A lone trailing merge-conflict marker can render as valid Markdown and reach published docs. A tracked-text scan now rejects standard Git conflict markers, including diff3 ancestors, both before local precommit compilation and in the always-required CI policy job.

Closes #1898.

Four files, +100. Independent PR against main. The scan covers every tracked text-file type, preserves inline examples and NOTICE separators, and needs no path allowlist.

Validation: all 27 CI policy tests pass, including marker fixtures in Markdown, JSON, config, and filenames with spaces. A temporary trailing marker also makes `mix precommit` fail before compilation. Full local `mix precommit` passes: core 5,224 tests + 6 doctests, Buzz 144 tests, Support 33 tests; zero failures.
