### PR TITLE
refactor(permissions): centralize reserved policy validation

### DIFF
--- a/apps/fountain/lib/fountain/agents/agent.ex
+++ b/apps/fountain/lib/fountain/agents/agent.ex
@@ -280,28 +280,10 @@ defmodule Fountain.Agents.Agent do
     end)
   end
 
-  # `ask_timeout` names no tool, so it is validated on its own rather than as
-  # a verdict (#1635). Seconds, positive, and bounded above by
-  # `PermissionPolicy.max_ask_timeout_seconds/0` — a year, which is not the
-  # idle bound in disguise but the point past which the deadline no longer
-  # fits in a `timestamp`. The message names the bound, because a refusal
-  # that only says "not a positive number" about 1e15 reads as a lie.
   defp reserved_errors(policy) do
-    case Map.fetch(policy, "ask_timeout") do
-      {:ok, value} ->
-        if PermissionPolicy.valid_ask_timeout?(value) do
-          []
-        else
-          [
-            permission_policy:
-              "ask_timeout: #{inspect(value)} is not a positive number of seconds " <>
-                "no greater than #{PermissionPolicy.max_ask_timeout_seconds()}"
-          ]
-        end
-
-      :error ->
-        []
-    end
+    Enum.map(PermissionPolicy.reserved_errors(policy), fn {key, message} ->
+      {:permission_policy, "#{key}: #{message}"}
+    end)
   end
 
   # A policy the runtime will never consult is refused rather than stored. The

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -3816,16 +3816,10 @@ defmodule Fountain.Conversations do
     end
   end
 
-  # `ask_timeout` is seconds, not a verdict (#1635).
   defp validate_reserved_keys(policy) do
-    case Map.fetch(policy, "ask_timeout") do
-      {:ok, value} ->
-        if PermissionPolicy.valid_ask_timeout?(value),
-          do: :ok,
-          else: {:error, :permission_policy_invalid}
-
-      :error ->
-        :ok
+    case PermissionPolicy.reserved_errors(policy) do
+      [] -> :ok
+      _errors -> {:error, :permission_policy_invalid}
     end
   end
 

--- a/apps/fountain/lib/fountain/permission_policy.ex
+++ b/apps/fountain/lib/fountain/permission_policy.ex
@@ -90,6 +90,28 @@ defmodule Fountain.PermissionPolicy do
   @spec reserved_keys() :: [String.t()]
   def reserved_keys, do: @reserved
 
+  @doc "Validation errors for every reserved key present in a policy."
+  @spec reserved_errors(map()) :: [{String.t(), String.t()}]
+  def reserved_errors(policy) when is_map(policy) do
+    policy
+    |> Map.take(@reserved)
+    |> Enum.flat_map(fn {key, value} ->
+      case reserved_error(key, value) do
+        nil -> []
+        message -> [{key, message}]
+      end
+    end)
+  end
+
+  # Every reserved key needs a clause here. No catch-all: adding a key without
+  # its validator must fail the reserved-key guardrail, never accept its value.
+  defp reserved_error(@ask_timeout, value) do
+    unless valid_ask_timeout?(value) do
+      "#{inspect(value)} is not a positive number of seconds " <>
+        "no greater than #{max_ask_timeout_seconds()}"
+    end
+  end
+
   @doc "Whether `key` names something other than a tool."
   @spec reserved?(term()) :: boolean()
   def reserved?(key), do: key in @reserved

--- a/apps/fountain/test/fountain/permission_policy_test.exs
+++ b/apps/fountain/test/fountain/permission_policy_test.exs
@@ -42,6 +42,35 @@ defmodule Fountain.PermissionPolicyTest do
     end
   end
 
+  describe "reserved_errors/1" do
+    test "every reserved key has a validator that rejects an invalid value" do
+      for key <- PermissionPolicy.reserved_keys() do
+        assert [{^key, message}] = PermissionPolicy.reserved_errors(%{key => nil})
+        assert is_binary(message) and message != ""
+      end
+    end
+
+    test "omitted keys and tool verdicts belong to their own validation" do
+      assert PermissionPolicy.reserved_errors(%{}) == []
+      assert PermissionPolicy.reserved_errors(%{"execute" => "not a verdict"}) == []
+    end
+
+    test "ask_timeout accepts bounded seconds and preserves its error message" do
+      max = PermissionPolicy.max_ask_timeout_seconds()
+
+      for value <- [1, "60", max, to_string(max)] do
+        assert PermissionPolicy.reserved_errors(%{"ask_timeout" => value}) == []
+      end
+
+      for value <- [nil, 0, -1, "soon", 1.5, %{}, max + 1] do
+        assert PermissionPolicy.reserved_errors(%{"ask_timeout" => value}) == [
+                 {"ask_timeout",
+                  "#{inspect(value)} is not a positive number of seconds no greater than #{max}"}
+               ]
+      end
+    end
+  end
+
   describe "seconds/1" do
     test "reads a positive integer or a string of one" do
       assert PermissionPolicy.seconds(3600) == 3600


### PR DESCRIPTION
Agent changesets and conversation launch validation now share the reserved-key validators in `Fountain.PermissionPolicy`. Every declared reserved key is checked before it can disappear from tool-verdict validation; a missing validator fails the guardrail instead of silently accepting arbitrary values.

Closes #1900.

Four files, +57/-30. Independent PR against main. Existing ask_timeout bounds, agent error messages, and conversation error tuples are preserved. This adds no new policy key.

Validation: all 22 policy unit tests pass, including the guardrail for every reserved key. All 132 targeted policy/agent/conversation-launch tests pass. Full local `mix precommit` passes: core 5,227 tests + 6 doctests, Buzz 144 tests, Support 33 tests; zero failures.
