### PR TITLE
perf(billing): index platform inference spend by time

### DIFF
--- a/apps/fountain/priv/repo/migrations/20260911111500_index_platform_inference_spend.exs
+++ b/apps/fountain/priv/repo/migrations/20260911111500_index_platform_inference_spend.exs
@@ -1,0 +1,16 @@
+defmodule Fountain.Repo.Migrations.IndexPlatformInferenceSpend do
+  use Ecto.Migration
+
+  # The deployment-wide daily ceiling reads this slice before every platform
+  # inference turn. Tenant-leading indexes cannot serve that aggregate.
+  # Build without blocking ledger writes, retaining the advisory migration lock.
+  @disable_ddl_transaction true
+
+  def change do
+    create index(:credit_ledger, [:inserted_at],
+             where: "reason = 'burn_inference'",
+             name: :credit_ledger_inference_inserted_at_index,
+             concurrently: true
+           )
+  end
+end


### PR DESCRIPTION
The deployment-wide inference ceiling queries today's `burn_inference` ledger entries before platform-funded work. The existing tenant-leading indexes cannot serve that query. This adds a partial index on `inserted_at` for that reason, built concurrently while retaining the advisory migration lock.

Closes #1708. One file, 16 lines; independent PR against main.

Validation: rollback and concurrent rebuild preserved 30,000 committed fixture rows. PostgreSQL selected the new index for the billing query, the index was valid/ready, and the returned spend matched the fixture count. Full local `mix precommit` passes: core 5,281 tests + 6 doctests, Buzz 144 tests, Support 33 tests; zero failures.
