### PR TITLE
fix: serialize principal credential replay with claims

### DIFF
--- a/apps/fountain/lib/fountain/accounts.ex
+++ b/apps/fountain/lib/fountain/accounts.ex
@@ -668,45 +668,46 @@ defmodule Fountain.Accounts do
   @spec create_api_key(binary(), String.t(), keyword()) ::
           {:ok, {ApiKey.t(), String.t()}} | {:error, Ecto.Changeset.t()}
   def create_api_key(user_id, name, opts \\ []) when is_binary(user_id) and is_binary(name) do
-    raw = "ftn_" <> Base.encode16(:crypto.strong_rand_bytes(32), case: :lower)
-    key_hash = hash_key(raw)
-    key_prefix = String.slice(raw, 0, 8)
+    {changeset, raw} = build_api_key(user_id, name, opts)
 
-    %ApiKey{}
-    |> ApiKey.changeset(%{
-      user_id: user_id,
-      name: name,
-      key_hash: key_hash,
-      key_prefix: key_prefix,
-      scopes: Keyword.get(opts, :scopes, ["full"]),
-      expires_at: Keyword.get(opts, :expires_at)
-    })
-    |> Repo.insert()
-    |> case do
-      {:ok, key} ->
-        Audit.record(%{
-          user_id: user_id,
-          action: "api_key.created",
-          resource_type: "api_key",
-          resource_id: key.id,
-          actor: Keyword.get(opts, :actor, "self"),
-          request_ip: Keyword.get(opts, :request_ip),
-          # Name, scopes and prefix identify *which* key without being the
-          # key: the prefix is already stored in the clear and is what the
-          # settings UI shows, so it is the handle a reader can match a
-          # trail row against a listed key by.
-          metadata: %{
-            "name" => key.name,
-            "scopes" => key.scopes,
-            "key_prefix" => key.key_prefix
-          }
-        })
-
-        {:ok, {key, raw}}
-
-      {:error, cs} ->
-        {:error, cs}
+    with {:ok, key} <- Repo.insert(changeset) do
+      record_api_key_created(key, opts)
+      {:ok, {key, raw}}
     end
+  end
+
+  @doc "Build a key changeset and plaintext without persistence; transactional callers audit after commit."
+  def build_api_key(user_id, name, opts \\ []) do
+    raw = "ftn_" <> Base.encode16(:crypto.strong_rand_bytes(32), case: :lower)
+
+    changeset =
+      ApiKey.changeset(%ApiKey{}, %{
+        user_id: user_id,
+        name: name,
+        key_hash: hash_key(raw),
+        key_prefix: String.slice(raw, 0, 8),
+        scopes: Keyword.get(opts, :scopes, ["full"]),
+        expires_at: Keyword.get(opts, :expires_at)
+      })
+
+    {changeset, raw}
+  end
+
+  @doc "Record a committed key mint; call outside the transaction that inserted it."
+  def record_api_key_created(%ApiKey{} = key, opts \\ []) do
+    Audit.record(%{
+      user_id: key.user_id,
+      action: "api_key.created",
+      resource_type: "api_key",
+      resource_id: key.id,
+      actor: Keyword.get(opts, :actor, "self"),
+      request_ip: Keyword.get(opts, :request_ip),
+      metadata: %{
+        "name" => key.name,
+        "scopes" => key.scopes,
+        "key_prefix" => key.key_prefix
+      }
+    })
   end
 
   @doc """

--- a/apps/fountain/lib/fountain/principals.ex
+++ b/apps/fountain/lib/fountain/principals.ex
@@ -457,22 +457,38 @@ defmodule Fountain.Principals do
     # Claim and expiry revoke keys under this same lock. The earlier replay
     # lookup is only a snapshot: recheck after the lock, and hold it through
     # both credential writes so a claim cannot miss a newly minted key.
-    Repo.transaction(fn ->
-      token = new_token()
+    result =
+      Repo.transaction(fn ->
+        token = new_token()
 
-      with %ClaimableUser{} = current <- lock_claimable(claimable.id),
-           {:ok, current} <- still_open(current),
-           {:ok, {_key, raw}} <- mint_principal_key(current, opts),
-           {:ok, current} <-
-             current
-             |> Ecto.Changeset.change(claim_token_hash: hash_token(token))
-             |> Repo.update() do
-        %{claimable: current, api_key: raw, claim_token: token}
-      else
-        nil -> Repo.rollback(:not_found)
-        {:error, reason} -> Repo.rollback(reason)
-      end
-    end)
+        with %ClaimableUser{} = current <- lock_claimable(claimable.id),
+             {:ok, current} <- still_open(current),
+             {changeset, raw} =
+               Accounts.build_api_key(
+                 current.user_id,
+                 key_name(current),
+                 principal_key_opts(current, opts)
+               ),
+             {:ok, key} <- Repo.insert(changeset),
+             {:ok, current} <-
+               current
+               |> Ecto.Changeset.change(claim_token_hash: hash_token(token))
+               |> Repo.update() do
+          {%{claimable: current, api_key: raw, claim_token: token}, key}
+        else
+          nil -> Repo.rollback(:not_found)
+          {:error, reason} -> Repo.rollback(reason)
+        end
+      end)
+
+    case result do
+      {:ok, {credentials, key}} ->
+        Accounts.record_api_key_created(key, principal_key_opts(claimable, opts))
+        {:ok, credentials}
+
+      {:error, _} = error ->
+        error
+    end
   end
 
   # The anonymous credential expires with the grant, so a leaked one dies on
@@ -481,14 +497,20 @@ defmodule Fountain.Principals do
   # ordinary tenant of the account that owns it — and a key that expired at it
   # would take a live machine away from its new owner, usually within hours.
   defp mint_principal_key(%ClaimableUser{} = claimable, opts) do
-    expires_at = if claimable.status == "claimed", do: nil, else: claimable.expires_at
+    Accounts.create_api_key(
+      claimable.user_id,
+      key_name(claimable),
+      principal_key_opts(claimable, opts)
+    )
+  end
 
-    Accounts.create_api_key(claimable.user_id, key_name(claimable),
+  defp principal_key_opts(claimable, opts) do
+    [
       scopes: ["principal"],
-      expires_at: expires_at,
+      expires_at: if(claimable.status == "claimed", do: nil, else: claimable.expires_at),
       actor: Keyword.get(opts, :actor, "api"),
       request_ip: Keyword.get(opts, :request_ip)
-    )
+    ]
   end
 
   defp key_name(%ClaimableUser{status: "claimed", application_id: app}), do: "principal:#{app}"

--- a/apps/fountain/lib/fountain/principals.ex
+++ b/apps/fountain/lib/fountain/principals.ex
@@ -454,15 +454,25 @@ defmodule Fountain.Principals do
   # the claim token's hash is rewritten, so a replayed create hands back a
   # usable pair rather than two values the caller can do nothing with.
   defp issue_credentials(%ClaimableUser{} = claimable, opts) do
-    token = new_token()
+    # Claim and expiry revoke keys under this same lock. The earlier replay
+    # lookup is only a snapshot: recheck after the lock, and hold it through
+    # both credential writes so a claim cannot miss a newly minted key.
+    Repo.transaction(fn ->
+      token = new_token()
 
-    with {:ok, {_key, raw}} <- mint_principal_key(claimable, opts),
-         {:ok, claimable} <-
-           claimable
-           |> Ecto.Changeset.change(claim_token_hash: hash_token(token))
-           |> Repo.update() do
-      {:ok, %{claimable: claimable, api_key: raw, claim_token: token}}
-    end
+      with %ClaimableUser{} = current <- lock_claimable(claimable.id),
+           {:ok, current} <- still_open(current),
+           {:ok, {_key, raw}} <- mint_principal_key(current, opts),
+           {:ok, current} <-
+             current
+             |> Ecto.Changeset.change(claim_token_hash: hash_token(token))
+             |> Repo.update() do
+        %{claimable: current, api_key: raw, claim_token: token}
+      else
+        nil -> Repo.rollback(:not_found)
+        {:error, reason} -> Repo.rollback(reason)
+      end
+    end)
   end
 
   # The anonymous credential expires with the grant, so a leaked one dies on

--- a/apps/fountain/test/fountain/principals_claim_replay_test.exs
+++ b/apps/fountain/test/fountain/principals_claim_replay_test.exs
@@ -2,6 +2,7 @@ defmodule Fountain.PrincipalsClaimReplayTest do
   # Real independent transactions must see committed fixtures. Keep them out
   # of concurrent DataCase suites and delete only this test's accounts.
   use ExUnit.Case, async: false
+  use Mimic
 
   import Ecto.Query
   import Fountain.Factory
@@ -91,6 +92,50 @@ defmodule Fountain.PrincipalsClaimReplayTest do
       Task.shutdown(claim, :brutal_kill)
       Task.shutdown(replay, :brutal_kill)
     end
+  end
+
+  test "credential audit runs after commit and cannot abort the credential transaction" do
+    application = Sandbox.unboxed_run(Repo, fn -> insert_verified_user() end)
+
+    on_exit(fn ->
+      Sandbox.unboxed_run(Repo, fn ->
+        principal_ids =
+          Repo.all(
+            from c in ClaimableUser,
+              where: c.application_user_id == ^application.id,
+              select: c.user_id
+          )
+
+        Repo.delete_all(from u in User, where: u.id in ^[application.id | principal_ids])
+      end)
+    end)
+
+    stub(Fountain.Audit, :record, fn attrs ->
+      if attrs.action == "api_key.created" do
+        refute Repo.in_transaction?()
+        # The real audit recorder rescues a failed insert. That must not
+        # invalidate the transaction that committed the working credentials.
+        {:error, :audit_unavailable}
+      else
+        Mimic.call_original(Fountain.Audit, :record, [attrs])
+      end
+    end)
+
+    Sandbox.unboxed_run(Repo, fn ->
+      assert {:ok, first} =
+               Principals.create_claimable(application, %{"application_id" => "audit"},
+                 idempotency_key: "audit"
+               )
+
+      assert {:ok, replay} =
+               Principals.create_claimable(application, %{"application_id" => "audit"},
+                 idempotency_key: "audit"
+               )
+
+      assert first.claimable.id == replay.claimable.id
+      assert {:ok, _, _} = Accounts.authenticate_api_key(replay.api_key)
+      assert Repo.get!(ClaimableUser, replay.claimable.id).claim_token_hash
+    end)
   end
 
   defp waits_for_lock?(backend, deadline) do

--- a/apps/fountain/test/fountain/principals_claim_replay_test.exs
+++ b/apps/fountain/test/fountain/principals_claim_replay_test.exs
@@ -1,0 +1,117 @@
+defmodule Fountain.PrincipalsClaimReplayTest do
+  # Real independent transactions must see committed fixtures. Keep them out
+  # of concurrent DataCase suites and delete only this test's accounts.
+  use ExUnit.Case, async: false
+
+  import Ecto.Query
+  import Fountain.Factory
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Fountain.Accounts
+  alias Fountain.Accounts.{ApiKey, User}
+  alias Fountain.Principals
+  alias Fountain.Principals.ClaimableUser
+  alias Fountain.Repo
+
+  test "a create replay cannot mint application credentials after a claim revokes them" do
+    {application, claimer, grant} =
+      Sandbox.unboxed_run(Repo, fn ->
+        application = insert_verified_user()
+        claimer = insert_verified_user()
+
+        {:ok, grant} =
+          Principals.create_claimable(application, %{"application_id" => "race"},
+            idempotency_key: "claim-replay-race"
+          )
+
+        {application, claimer, grant}
+      end)
+
+    on_exit(fn ->
+      Sandbox.unboxed_run(Repo, fn ->
+        ids = [grant.claimable.user_id, application.id, claimer.id]
+        Repo.delete_all(from u in User, where: u.id in ^ids)
+      end)
+    end)
+
+    parent = self()
+
+    claim =
+      Task.async(fn ->
+        Sandbox.unboxed_run(Repo, fn ->
+          Repo.transaction(fn ->
+            result = Principals.claim(grant.claimable.id, grant.claim_token, claimer)
+            send(parent, {:claim_before_commit, result})
+
+            receive do
+              :commit -> result
+            after
+              10_000 -> Repo.rollback(:test_commit_timeout)
+            end
+          end)
+        end)
+      end)
+
+    assert_receive {:claim_before_commit, {:ok, claimed}}, 5_000
+
+    replay =
+      Task.async(fn ->
+        Sandbox.unboxed_run(Repo, fn ->
+          %{rows: [[backend]]} = Repo.query!("SELECT pg_backend_pid()")
+          send(parent, {:replay_backend, backend})
+
+          Principals.create_claimable(application, %{"application_id" => "race"},
+            idempotency_key: "claim-replay-race"
+          )
+        end)
+      end)
+
+    try do
+      assert_receive {:replay_backend, backend}, 5_000
+      assert waits_for_lock?(backend, System.monotonic_time(:millisecond) + 5_000)
+      send(claim.pid, :commit)
+      assert {:ok, {:ok, ^claimed}} = Task.await(claim, 5_000)
+      assert {:error, :already_claimed} = Task.await(replay, 5_000)
+
+      Sandbox.unboxed_run(Repo, fn ->
+        assert Repo.get!(ClaimableUser, grant.claimable.id).claim_token_hash == nil
+        assert {:ok, _, _} = Accounts.authenticate_api_key(claimed.api_key)
+        assert {:error, _} = Accounts.authenticate_api_key(grant.api_key)
+
+        keys =
+          Repo.all(
+            from k in ApiKey,
+              where: k.user_id == ^grant.claimable.user_id and is_nil(k.revoked_at)
+          )
+
+        assert length(keys) == 1
+      end)
+    after
+      send(claim.pid, :commit)
+      Task.shutdown(claim, :brutal_kill)
+      Task.shutdown(replay, :brutal_kill)
+    end
+  end
+
+  defp waits_for_lock?(backend, deadline) do
+    waiting =
+      Sandbox.unboxed_run(Repo, fn ->
+        Repo.query!(
+          "SELECT wait_event_type = 'Lock' FROM pg_stat_activity WHERE pid = $1",
+          [backend]
+        ).rows == [[true]]
+      end)
+
+    cond do
+      waiting ->
+        true
+
+      System.monotonic_time(:millisecond) >= deadline ->
+        false
+
+      true ->
+        Process.sleep(10)
+        waits_for_lock?(backend, deadline)
+    end
+  end
+end


### PR DESCRIPTION
Replaying a claimable principal's create could issue application credentials after a concurrent claim revoked the old ones. Re-read the persisted grant under the claim lock and hold that lock through both credential writes, refusing replay after claim, release or expiry.

Key construction is separated from persistence and audit recording so the credential transaction contains only database writes. Record creation after commit: a failed best-effort audit cannot abort issuance. Ordinary key creation uses the same builder and recorder. Three files, +243/-48, including deterministic concurrency and audit-boundary regressions.

Closes #1689. The independent PostgreSQL-connection race fails on the parent and passes with the lock. The audit regression fails on the earlier draft's in-transaction mint and passes after correction; an unavailable audit recorder leaves committed credentials usable. All 125 focused principal, replay-race and audit-guardrail tests pass. Full local precommit after the audit correction and rebase onto current main passed: 5,377 core tests + 6 doctests, 144 Buzz tests and 33 Support tests, all with zero failures.
