### PR TITLE
fix: verify extension applications in the bundled image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -261,7 +261,7 @@ jobs:
       # plain (#879 shipped exactly that). Nothing in the test suite can see
       # inside the image, so the image itself is asked, offline and read-only,
       # the way the pods run it.
-      - name: The image can highlight code
+      - name: The image contains extensions and can highlight code
         env:
           SHA: ${{ env.SRC_SHA }}
         run: |
@@ -274,6 +274,14 @@ jobs:
             -e PHX_HOST=example.test -e PUBLIC_URL="https://example.test" \
             -e RESEND_API_KEY=re_dummy -e EMAIL_FROM="fountain@example.test" \
             "${IMAGE}:sha-${SHA}" /app/bin/fountain_server eval '
+              for app <- [:fountain_buzz, :fountain_support] do
+                case :code.lib_dir(app) do
+                  path when is_list(path) ->
+                    unless File.dir?(path), do: raise("bundled image missing #{app}")
+                  {:error, _} ->
+                    raise "bundled image missing #{app}"
+                end
+              end
               {:ok, _} = Application.ensure_all_started(:lumis)
               html = Managoat.Docs.Markdown.to_trusted_html("```ts\nconst x = 1;\n```")
               IO.puts("spans=#{length(Regex.scan(~r/<span style="color/, html))}")

--- a/docs/guides/operate/upgrade.md
+++ b/docs/guides/operate/upgrade.md
@@ -54,6 +54,24 @@ a bundled image made, so a move back finds your rows where you left them.
 Releases v0.2.1 and earlier are older than the image tags. They exist as
 `sha-` tags alone.
 
+## Build your own image
+
+`BUNDLE_EXTENSIONS` is a build argument, defaulting to `true`. It selects the
+release's applications and extension executables when Docker builds the image.
+Setting it on a running container does not change its distribution.
+
+```bash
+# Bundled: Fountain, Buzz and Support.
+docker build --build-arg BUNDLE_EXTENSIONS=true -t fountain:bundled .
+
+# Core: Fountain without first-party extensions.
+docker build --build-arg BUNDLE_EXTENSIONS=false -t fountain:core .
+```
+
+For a release built directly from the source tree, use
+`BUNDLE_EXTENSIONS=false MIX_ENV=prod mix release fountain_server` to select
+core. Omit the variable, or set it to `true`, to bundle the extensions.
+
 ## Take a new version
 
 The compose file reads `FOUNTAIN_IMAGE_TAG` from `.env`, and


### PR DESCRIPTION
The main image workflow checked highlighting but never verified the pushed bundled image contained its extension applications. Its existing offline, read-only release eval now requires both Buzz and Support. Document the `BUNDLE_EXTENSIONS` Docker argument, source-release environment variable, default, and build-time effect in the operator upgrade guide.

Closes #1696. Two files, +27/-1.

Validation: workflow YAML parses and its shell passes `bash -n`; all 23 CI policy tests pass. The exact eval passes against an assembled bundled release (5 highlighted spans) and fails independently when either extension is removed from the release code path. All three prose reports reviewed: docs-style has two existing findings outside the changed page; destink is clean; Vale's advisory report has existing errors and wording suggestions. The pushed Linux image check will run in the main build workflow after merge.

Full local precommit passes: 5,316 core tests plus 6 doctests, 144 Buzz tests, and 33 Support tests, with no failures.
