### PR TITLE
fix: stop recommending refused models in shipped instructions

### DIFF
--- a/apps/fountain/priv/external_skills/fountain/SKILL.md
+++ b/apps/fountain/priv/external_skills/fountain/SKILL.md
@@ -225,7 +225,7 @@ metadata:
   name: researcher
 spec:
   runtime: claude
-  model: anthropic/claude-sonnet-4-6
+  model: anthropic/claude-sonnet-5
   environment: my-project            # resolved to environment_id at apply time
   system: "You are a research assistant. Cite primary sources."
   skills: [fountain]                 # mounts an additional skill into the sprite

--- a/apps/fountain/priv/help/agents.md
+++ b/apps/fountain/priv/help/agents.md
@@ -4,7 +4,7 @@ An **Agent** is a named configuration for a single coding-agent CLI. It bundles 
 
 - a **runtime** (`claude` / `codex` / `gemini` / `opencode`) — which binary runs in the sprite, or `acp` to run a command of your own
 - a **runtime_command** — the shell line the `acp` runtime launches, required there and rejected on the others
-- a **model** (`anthropic/claude-sonnet-4-6`, `openai/gpt-5.3-codex`, `google/gemini-3.1-pro-preview`, etc.); the `acp` runtime needs none
+- a **model** (`anthropic/claude-sonnet-5`, `openai/gpt-6-astra`, `google/gemini-3.1-pro-preview`, etc.); the `acp` runtime needs none
 - an optional **system prompt** (`system`)
 - an optional **environment** reference (`environment_id` or `environment` by name) — the sprite shape to provision
 - optional **skills** — names of bundled skills to mount into the sprite
@@ -20,7 +20,7 @@ curl -s -X POST "$FOUNTAIN_BASE_URL/api/agents" \
   -d '{
     "name": "researcher",
     "runtime": "claude",
-    "model": "anthropic/claude-sonnet-4-6",
+    "model": "anthropic/claude-sonnet-5",
     "system": "You are a research assistant. Cite primary sources.",
     "skills": ["fountain"],
     "mcp_servers": {
@@ -75,8 +75,8 @@ Use `$${VAR}` only when the MCP server (or some downstream process the runtime s
 
 | runtime | CLI | model format | auth |
 | --- | --- | --- | --- |
-| claude | `claude` | `anthropic/claude-sonnet-4-6` | `CLAUDE_CODE_OAUTH_TOKEN` (preferred) or `ANTHROPIC_API_KEY` |
-| codex | `codex` | `openai/gpt-5.3-codex` | `OPENAI_API_KEY` (consumed via `codex login --with-api-key` at provision time) |
+| claude | `claude` | `anthropic/claude-sonnet-5` | `CLAUDE_CODE_OAUTH_TOKEN` (preferred) or `ANTHROPIC_API_KEY` |
+| codex | `codex` | `openai/gpt-6-astra` | `OPENAI_API_KEY` (consumed via `codex login --with-api-key` at provision time) |
 | gemini | `gemini` | `google/gemini-3.1-pro-preview` | `GEMINI_API_KEY` |
 | opencode | `opencode` | `provider/model` (anthropic / openai / google) | per provider |
 

--- a/apps/fountain/priv/help/manifest.md
+++ b/apps/fountain/priv/help/manifest.md
@@ -105,7 +105,7 @@ metadata:
   name: researcher
 spec:
   runtime: claude
-  model: anthropic/claude-sonnet-4-6
+  model: anthropic/claude-sonnet-5
   environment: my-project        # ← resolved to environment_id at apply time
   system: You are a research assistant.
   skills: [aod]

--- a/apps/fountain/priv/help/quickstart.md
+++ b/apps/fountain/priv/help/quickstart.md
@@ -44,7 +44,7 @@ curl -s -X POST "$FOUNTAIN_BASE_URL/api/agents" \
   -d '{
     "name":"hello",
     "runtime":"claude",
-    "model":"anthropic/claude-sonnet-4-6"
+    "model":"anthropic/claude-sonnet-5"
   }'
 ```
 

--- a/apps/fountain/test/fountain/instruction_models_test.exs
+++ b/apps/fountain/test/fountain/instruction_models_test.exs
@@ -1,0 +1,21 @@
+defmodule Fountain.InstructionModelsTest do
+  use ExUnit.Case, async: true
+
+  test "shipped help and skills never recommend adapter-refused models" do
+    root = Application.app_dir(:fountain, "priv")
+    help = Path.wildcard(Path.join(root, "help/*.md"))
+    skills = Path.wildcard(Path.join(root, "external_skills/**/SKILL.md"))
+    assert help != []
+    assert skills != []
+
+    refused =
+      for path <- help ++ skills,
+          content = File.read!(path),
+          {model, observed} <- Fountain.RefusedModels.all(),
+          String.contains?(content, model) do
+        {Path.relative_to(path, root), model, observed}
+      end
+
+    assert refused == [], "Shipped instructions name refused models: #{inspect(refused)}"
+  end
+end

--- a/apps/fountain/test/support/refused_models.ex
+++ b/apps/fountain/test/support/refused_models.ex
@@ -28,8 +28,9 @@ defmodule Fountain.RefusedModels do
   one agent every verified account owns (ADR 0038 decision 4), and so the
   highest-stakes of the three.
 
-  Surfaces still outside its reach are tracked on #1727: the shipped `fountain`
-  skill manifest, the `/help` pages and the OpenAPI field description.
+  Shipped skill manifests and `/help` pages are scanned together by
+  `Fountain.InstructionModelsTest`. The remaining surface tracked on #1727 is
+  the OpenAPI field description.
 
   ## Membership in the catalog is the stronger check
 


### PR DESCRIPTION
The shipped agent skill and help pages recommend models that the pinned adapters refuse before a turn starts. Replace those examples with the catalog's `anthropic/claude-sonnet-5` and `openai/gpt-6-astra`, and scan every shipped help page and skill against the shared refusal registry.

First small slice of #1727: instruction content and its guard. The OpenAPI description and generated SDK are handled in a separate dependent draft. Six files, +31/-9.

Validation: the content scan reproduces the refused examples on the parent; all 11 focused instruction, help, and catalog tests pass. Full local precommit passes: 5,317 core tests plus 6 doctests, 144 Buzz tests, and 33 Support tests, with no failures.
