### PR TITLE
fix: count emitted email exceptions in the finance dashboard

### DIFF
--- a/.github/workflows/alert-rules.yml
+++ b/.github/workflows/alert-rules.yml
@@ -4,12 +4,14 @@ on:
   pull_request:
     paths:
       - deploy/k8s/prometheusrule.yaml
+      - deploy/grafana/fountain-finance.json
       - scripts/test-alerts.py
       - .github/workflows/alert-rules.yml
   push:
     branches: [main]
     paths:
       - deploy/k8s/prometheusrule.yaml
+      - deploy/grafana/fountain-finance.json
       - scripts/test-alerts.py
       - .github/workflows/alert-rules.yml
   workflow_dispatch:

--- a/deploy/grafana/fountain-finance.json
+++ b/deploy/grafana/fountain-finance.json
@@ -850,7 +850,7 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "(sum(increase(fountain_email_delivery_count{namespace=\"$namespace\", outcome=\"error\"}[1h])) or vector(0)) + (sum(increase(fountain_email_delivery_exception_count{namespace=\"$namespace\"}[1h])) or vector(0))"
+          "expr": "(sum(increase(fountain_email_delivery_count{namespace=\"$namespace\", outcome=\"error\"}[1h])) or vector(0)) + (sum(increase(fountain_email_delivery_exception{namespace=\"$namespace\"}[1h])) or vector(0))"
         }
       ]
     },

--- a/scripts/test-alerts.py
+++ b/scripts/test-alerts.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Evaluate the shipped alert expressions with promtool (requires PyYAML)."""
+import json
 from pathlib import Path
 import subprocess
 import tempfile
@@ -79,10 +80,36 @@ def conversation_cases(rules):
     return cases
 
 
+def email_dashboard_cases():
+    dashboard = json.loads((ROOT / "deploy/grafana/fountain-finance.json").read_text())
+    expression = next(target["expr"] for panel in dashboard["panels"]
+                      for target in panel.get("targets", [])
+                      if "fountain_email_delivery_exception" in target.get("expr", ""))
+    expression = expression.replace("$namespace", "fountain")
+    cases = []
+    for errors, exceptions in ((False, False), (True, False), (False, True), (True, True)):
+        inputs = []
+        for present, metric in (
+            (errors, 'fountain_email_delivery_count{namespace="fountain",outcome="error"}'),
+            (exceptions, 'fountain_email_delivery_exception{namespace="fountain"}'),
+        ):
+            if present:
+                inputs.append({"series": metric, "values": "0+0x30 1+0x90"})
+        cases.append({
+            "name": f"email dashboard: errors={errors}, exceptions={exceptions}",
+            "interval": "1m", "input_series": inputs,
+            "promql_expr_test": [{
+                "expr": expression, "eval_time": "60m",
+                "exp_samples": [{"labels": "{}", "value": int(errors) + int(exceptions)}],
+            }],
+        })
+    return cases
+
+
 def main():
     spec = yaml.safe_load((ROOT / "deploy/k8s/prometheusrule.yaml").read_text())["spec"]
     rules = {r["alert"]: r for g in spec["groups"] for r in g["rules"]}
-    cases = conversation_cases(rules)
+    cases = conversation_cases(rules) + email_dashboard_cases()
     for replicas in (1, 2, 3):
         for alert, metric, statuses in (
             ("FountainSandboxBudgetExceeded", "fountain_sandboxes_count", ("pending", "ready")),


### PR DESCRIPTION
The finance dashboard reads an email-exception counter that Fountain never emits, so exceptions display as zero. Point it at `fountain_email_delivery_exception` and evaluate the actual dashboard expression in the existing promtool fixture suite. Dashboard edits now trigger that CI job.

Part of #1691. The separate hosted-alert correction is jhgaylor/home-cloud#224; both parts are required to resolve the issue. Three files, +31/-2.

Validation: 49 Prometheus expression fixtures pass, including errors only, exceptions only, both, and no failure counters. The new cases fail against the parent dashboard. An unchanged SSE heartbeat test failed during a concurrent full run and passed all 18 focused tests with the same seed; evidence is tracked in #1934. Full local precommit rerun passes with four VM schedulers: 5,316 core tests plus 6 doctests, 144 Buzz tests, and 33 Support tests, with no failures.
