### PR TITLE
ci: require shipped alert fixtures on every CI plan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1779,15 +1779,21 @@ jobs:
         run: go test -count=1 ./internal/cmd -run 'TestEveryCommandIsDocumented|TestNoDocumentedCommandIsInvented|TestGeneratedCLIReferenceIsCurrent'
 
   workflow-checks:
-    name: CI policy tests
+    name: CI policy and alert tests
     runs-on: ubuntu-24.04
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
         with:
           persist-credentials: false
       - name: Test CI decisions
         run: python3 -m unittest discover -s scripts/ci -p 'test_*.py' -v
+      # This job is required even for docs-only changes and reused trees.
+      # The path-filtered Alert rules workflow alone cannot gate a merge.
+      - name: Install the alert rule evaluator
+        run: sudo apt-get update && sudo apt-get install -y prometheus python3-yaml
+      - name: Evaluate shipped alert fixtures
+        run: /usr/bin/python3 scripts/test-alerts.py
 
   gate:
     name: CI required


### PR DESCRIPTION
Alert fixtures ran only in a path-filtered workflow that the merge gate did not require. Run them in `workflow-checks`, which `CI required` already requires for every supported plan, including docs-only changes and reused trees. Allow ten minutes for the evaluator package installation and checks.

Portable CI slice of #1692: one file, +8/-2. Hosted credits fixtures and the missing-worker fix are a separate small stack in jhgaylor/home-cloud#225, on #224's email fixtures.

Validation: all 23 CI policy tests pass, including failure/cancellation/skip rejection for required jobs on each plan; all 45 shipped Prometheus expression cases pass. Full local precommit passes with four VM schedulers: 5,342 core tests plus 6 doctests, 144 Buzz tests, and 33 Support tests, with no failures.
