### PR TITLE
ci: check public GitHub links in documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,7 @@ jobs:
           # without a special case — it used to be mkdocs.yml at the repo root,
           # which needed naming twice (#1008).
           docs_touched=false
-          if printf '%s\n' "${changed}" | grep -qE '^docs/|^apps/[^/]+/docs/|^scripts/(docs-style|destink/|ci/prose-advice\.sh$)|^\.vale|^\.github/workflows/ci\.yml$'; then
+          if printf '%s\n' "${changed}" | grep -qE '^docs/|^apps/[^/]+/docs/|^scripts/(docs-style|destink/|ci/(prose-advice\.sh|check_external_links\.py|test_external_links\.py)$)|^CLAUDE\.md$|^\.vale|^\.github/workflows/ci\.yml$'; then
             docs_touched=true
           fi
 
@@ -1092,6 +1092,9 @@ jobs:
       # docs_test.exs and runs in the Elixir suite, so it needs nothing here.
       # That is what `mkdocs build --strict` used to carry, and the test is the
       # stronger of the two: MkDocs never checked anchors (#1008).
+      - name: Check public GitHub documentation links
+        run: python3 scripts/ci/check_external_links.py
+
       - name: Docs style
         run: bash scripts/ci/prose-advice.sh style python3 scripts/docs-style.py
 
@@ -1698,6 +1701,9 @@ jobs:
       # The style sheet in standards/voice-and-style.md, as wording advice. It
       # skips the backlog in scripts/docs-style-allow.txt, so a file NOT on
       # that list is checked and every new page is covered by default.
+      - name: Check public GitHub documentation links
+        run: python3 scripts/ci/check_external_links.py
+
       - name: Docs style
         run: bash scripts/ci/prose-advice.sh style python3 scripts/docs-style.py
 

--- a/docs/guides/operate/observability.md
+++ b/docs/guides/operate/observability.md
@@ -41,8 +41,7 @@ They are optional: enable the file in your Kustomization and install the
 PrometheusRule CRD and the scrapes its expressions need. A rule file alone
 does not collect metrics.
 
-The hosted instance adds rules in the
-[home-cloud overlay](https://github.com/jhgaylor/home-cloud/blob/main/platform/fountain-site/prometheusrule.yaml).
+The hosted instance adds the rules [listed below](#added-by-the-hosted-overlay).
 Those rules are specific to that deployment. They do not arrive with the
 portable manifest artifact. Shared rule names can also have different
 thresholds or selectors in the overlay.

--- a/scripts/ci/check_external_links.py
+++ b/scripts/ci/check_external_links.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Check public GitHub links in the manual and contributor guide, without auth."""
+from concurrent.futures import ThreadPoolExecutor
+import html
+from pathlib import Path
+import re
+import sys
+import time
+from urllib.error import HTTPError, URLError
+from urllib.parse import urldefrag, urlsplit
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+ROOT = Path(__file__).resolve().parents[2]
+# Scope network requests deliberately; examples and other vendors are not gates.
+HOSTS = {"github.com"}
+
+
+def links(markdown):
+    fence = None
+    for number, line in enumerate(markdown.splitlines(), 1):
+        marker = re.match(r"^ {0,3}(`{3,}|~{3,})", line)
+        if marker:
+            chars = marker[1]
+            if fence is None:
+                fence = chars
+            elif chars[0] == fence[0] and len(chars) >= len(fence):
+                fence = None
+            continue
+        if fence:
+            continue
+        line = re.sub(r"(`+).*?\1", "", line)
+        for match in re.finditer(r'https://[^\s<>\)\]"\']+', line):
+            url = urldefrag(html.unescape(match[0].rstrip(".,;:!?")))[0]
+            if urlsplit(url).hostname in HOSTS:
+                yield number, url
+
+
+class PublicRedirects(HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        target = urlsplit(newurl)
+        if target.scheme != "https" or target.hostname not in HOSTS:
+            raise ValueError(f"redirect left the allowed hosts: {newurl}")
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
+def check(url):
+    opener = build_opener(PublicRedirects())
+    request = Request(url, headers={"User-Agent": "Fountain-docs-link-check"})
+    for attempt in range(3):
+        try:
+            with opener.open(request, timeout=15) as response:
+                if response.status != 200:
+                    return f"HTTP {response.status}"
+                return None
+        except HTTPError as error:
+            reason = f"HTTP {error.code}"
+            if error.code != 429 and error.code < 500:
+                return reason
+        except (URLError, TimeoutError, ValueError) as error:
+            reason = str(error)
+        if attempt < 2:
+            time.sleep(2 ** attempt)
+    return reason
+
+
+def main():
+    sources = [ROOT / "CLAUDE.md"]
+    for directory in [ROOT / "docs", *sorted(ROOT.glob("apps/*/docs"))]:
+        sources.extend(sorted(directory.rglob("*.md")))
+    references = {}
+    for path in sources:
+        for number, url in links(path.read_text()):
+            references.setdefault(url, []).append(f"{path.relative_to(ROOT)}:{number}")
+    if not references:
+        raise SystemExit("No allowlisted documentation links found")
+    failed = 0
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        for url, error in zip(references, pool.map(check, references)):
+            if error:
+                failed += 1
+                print(f"{error}: {url}\n  " + ", ".join(references[url]), file=sys.stderr)
+    print(f"Checked {len(references)} public GitHub links; {failed} failed")
+    return int(failed > 0)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/test_external_links.py
+++ b/scripts/ci/test_external_links.py
@@ -1,0 +1,53 @@
+import unittest
+from unittest.mock import Mock, patch
+from urllib.error import HTTPError
+from urllib.request import Request
+
+from check_external_links import PublicRedirects, check, links
+
+
+class ExternalLinksTest(unittest.TestCase):
+    def test_links_include_references_and_autolinks_but_not_code_or_other_hosts(self):
+        source = '''[`app`](https://github.com/managoat/demos#readme)
+[app]: https://github.com/managoat/fountain
+<https://github.com/managoat/docs>
+`https://github.com/example/placeholder`
+```bash
+https://github.com/example/code
+~~~
+```
+[elsewhere](https://example.com)
+[lookalike](https://github.com.example.com/private)
+'''
+        self.assertEqual(list(links(source)), [
+            (1, "https://github.com/managoat/demos"),
+            (2, "https://github.com/managoat/fountain"),
+            (3, "https://github.com/managoat/docs"),
+        ])
+
+    def test_redirects_cannot_expand_the_host_allowlist(self):
+        handler = PublicRedirects()
+        request = Request("https://github.com/old/repo")
+        with self.assertRaises(ValueError):
+            handler.redirect_request(request, None, 302, "", {}, "http://localhost/private")
+        redirected = handler.redirect_request(request, None, 301, "", {}, "https://github.com/new/repo")
+        self.assertEqual(redirected.full_url, "https://github.com/new/repo")
+
+    @patch("check_external_links.build_opener")
+    def test_a_private_or_missing_repo_is_a_failure_without_auth(self, build):
+        build.return_value.open.side_effect = HTTPError("url", 404, "Not Found", {}, None)
+        self.assertEqual(check("https://github.com/private/repo"), "HTTP 404")
+        request = build.return_value.open.call_args.args[0]
+        self.assertFalse(request.has_header("Authorization"))
+        self.assertEqual(build.return_value.open.call_count, 1)
+
+    @patch("check_external_links.time.sleep")
+    @patch("check_external_links.build_opener")
+    def test_transient_failure_retries_then_accepts_success(self, build, sleep):
+        response = Mock(status=200)
+        context = Mock()
+        context.__enter__ = Mock(return_value=response)
+        context.__exit__ = Mock(return_value=False)
+        build.return_value.open.side_effect = [HTTPError("url", 503, "Unavailable", {}, None), context]
+        self.assertIsNone(check("https://github.com/public/repo"))
+        sleep.assert_called_once_with(1)


### PR DESCRIPTION
The app-repository links from #1698 were repaired by #1829, but documentation CI still could not detect another public link becoming private or disappearing. Check GitHub links anonymously in the manual, extension manuals, and CLAUDE.md; deduplicate URLs, exclude code examples, bound requests and retries, and reject redirects outside the host allowlist. Run this blocking check on both docs-only and mixed docs/code CI paths, including edits to the checker or contributor guide.

The first live check found one remaining 404: the observability guide linked a private home-cloud file. Point readers to the hosted-rule explanation already on that page.

Closes #1698. Four files, +148/-3.

Validation: all 27 CI policy tests pass, including four checker regressions. The first live run reported the private link; after the edit, all 76 public GitHub URLs passed. Both CI paths and source-path classification were verified. All three prose reports reviewed: two existing docs-style findings elsewhere, eight existing Vale errors with advisory wording findings, and a clean destink report. Full local precommit passes with four VM schedulers: 5,342 core tests plus 6 doctests, 144 Buzz tests, and 33 Support tests, with no failures.
