### PR TITLE
fix: stamp platform inference from the selected credential source

### DIFF
--- a/apps/fountain/lib/fountain/conversations/turn_machine.ex
+++ b/apps/fountain/lib/fountain/conversations/turn_machine.ex
@@ -776,10 +776,11 @@ defmodule Fountain.Conversations.TurnMachine do
   platform turn, `"model"`, which is what `Workers.CreditPricer` prices
   against the rate card.
 
-  **Only stamped on a deployment that holds a platform key at all.** With
-  none configured there is no question to answer, and an unstamped map is
-  byte-for-byte the map every turn has always carried, which is what keeps a
-  self-hosted install (and the tests that assert on it) unchanged.
+  Platform turns are stamped from the credential source selected for the
+  turn, including a ChatGPT grant without any platform API key. A later
+  configuration change cannot erase the source that served the turn.
+  Tenant-owned turns retain their legacy shape when no platform API key is
+  configured.
 
   The `"model"` key is deliberately absent on an `"own"` turn: nothing prices
   it, so recording it would put a configuration detail in a column that
@@ -788,14 +789,15 @@ defmodule Fountain.Conversations.TurnMachine do
   @spec with_inference(map() | nil, ctx()) :: map() | nil
   def with_inference(usage, ctx) when is_map(usage) do
     case Map.get(ctx, :inference) do
-      source when source in [:own, :platform] ->
-        if Fountain.PlatformInference.enabled?() do
-          usage
-          |> Map.put("inference", Atom.to_string(source))
-          |> put_model(source, Map.get(ctx, :model))
-        else
-          usage
-        end
+      :platform ->
+        usage
+        |> Map.put("inference", "platform")
+        |> put_model(:platform, Map.get(ctx, :model))
+
+      :own ->
+        if Fountain.PlatformInference.enabled?(),
+          do: Map.put(usage, "inference", "own"),
+          else: usage
 
       _ ->
         usage
@@ -840,9 +842,8 @@ defmodule Fountain.Conversations.TurnMachine do
   #
   # `with_inference/2` decides the source, exactly as the end-of-turn write
   # does — one derivation, so the two writes cannot disagree. What it returns
-  # for an empty map is the stamp alone, and `%{}` on a deployment holding no
-  # platform key, which is what keeps a self-hosted install's turn rows
-  # unchanged.
+  # for an empty map is the stamp alone, and `%{}` for tenant-owned turns on
+  # a deployment holding no platform API key, keeping those rows unchanged.
   #
   # The end-of-turn write merges its token figures over this (see
   # `Conversations._unsafe_record_turn_usage/2`), so a turn that does answer

--- a/apps/fountain/test/fountain/conversations/conversation_server_platform_inference_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_platform_inference_test.exs
@@ -20,7 +20,9 @@ defmodule Fountain.Conversations.ConversationServerPlatformInferenceTest do
             :broker_listen_port,
             :broker_proxy_url,
             :broker_tenants,
-            :platform_anthropic_api_key
+            :platform_anthropic_api_key,
+            :platform_openai_api_key,
+            :platform_gemini_api_key
           ],
           do: {key, Application.get_env(:fountain, key)}
 
@@ -258,10 +260,10 @@ defmodule Fountain.Conversations.ConversationServerPlatformInferenceTest do
       refute stored(row).usage["inference"] == "platform"
     end
 
-    test "a deployment holding no platform key stamps nothing at all", %{machine: m, row: row} do
+    test "an own-credential turn without platform keys stamps nothing", %{machine: m, row: row} do
       Application.delete_env(:fountain, :platform_anthropic_api_key)
 
-      {_m, []} = select_model(m, platform_ctx())
+      {_m, []} = select_model(m, %{platform_ctx() | inference: :own})
       assert is_nil(stored(row).usage)
     end
 
@@ -296,6 +298,48 @@ defmodule Fountain.Conversations.ConversationServerPlatformInferenceTest do
                "output" => 3
              }) == %{input: 5, output: 3}
     end
+  end
+
+  test "a grant-only deployment stamps the completed codex turn", %{user: user} do
+    for key <- [:platform_anthropic_api_key, :platform_openai_api_key, :platform_gemini_api_key],
+        do: Application.delete_env(:fountain, key)
+
+    Fountain.ChatGPTFixtures.connect!()
+    assert Fountain.PlatformChatGPT.active?()
+    refute Fountain.PlatformInference.enabled?()
+    model = "openai/gpt-6-astra"
+
+    assert {:ok, :platform = source, credentials} =
+             Fountain.InferenceCredentials.select(model, %{}, "codex", refresh: false)
+
+    assert Map.has_key?(credentials, :codex_chatgpt_access_token)
+    agent = insert_agent(user_id: user.id, runtime: "codex", model: model)
+    conv = insert_conversation(user_id: user.id, agent: agent)
+    row = insert_turn(conv, status: "running", started_at: DateTime.utc_now())
+
+    machine = %TurnMachine{
+      conversation_id: conv.id,
+      row: row,
+      metrics: TurnMachine.start_metrics("codex", :runner, System.monotonic_time(:millisecond))
+    }
+
+    ctx = %{inference: source, model: model}
+    {machine, []} = select_model(machine, ctx)
+    assert stored(row).usage == %{"inference" => "platform", "model" => model}
+
+    {machine, [{:finish, status, attrs, metadata}]} =
+      TurnMachine.handle(machine, {:done, "end_turn", %{"input" => 5, "output" => 3}}, ctx)
+
+    TurnMachine.finish(machine, status, attrs, metadata)
+
+    assert stored(row).status == "completed"
+
+    assert stored(row).usage == %{
+             "inference" => "platform",
+             "model" => model,
+             "input" => 5,
+             "output" => 3
+           }
   end
 
   defp platform_ctx, do: %{inference: :platform, model: "anthropic/claude-opus-5"}

--- a/ee/test/fountain/credits_chatgpt_inference_test.exs
+++ b/ee/test/fountain/credits_chatgpt_inference_test.exs
@@ -1,0 +1,74 @@
+defmodule Fountain.Credits.ChatGPTInferenceTest do
+  # Platform credentials are deployment-wide application config and one DB row.
+  use Fountain.DataCase, async: false
+
+  alias Fountain.{Billing, Credits, InferenceCredentials, PlatformInference}
+  alias Fountain.Conversations.TurnMachine
+  alias Fountain.Credits.InferenceRates
+  alias Fountain.Workers.CreditPricer
+
+  setup do
+    keys = [:platform_anthropic_api_key, :platform_openai_api_key, :platform_gemini_api_key]
+    previous = Enum.map(keys, &{&1, Application.get_env(:fountain, &1)})
+    Enum.each(keys, &Application.delete_env(:fountain, &1))
+
+    on_exit(fn ->
+      for {key, value} <- previous do
+        if is_nil(value),
+          do: Application.delete_env(:fountain, key),
+          else: Application.put_env(:fountain, key, value)
+      end
+    end)
+
+    Fountain.ChatGPTFixtures.connect!()
+    refute PlatformInference.enabled?()
+    :ok
+  end
+
+  test "a grant-only turn is debited once and counted in daily spend; own credentials are not" do
+    model = "openai/gpt-6-astra"
+    {:ok, source, _} = InferenceCredentials.select(model, %{}, "codex", refresh: false)
+    assert source == :platform
+
+    usage =
+      TurnMachine.with_inference(%{"input" => 1_000_000, "output" => 0}, %{
+        inference: source,
+        model: model
+      })
+
+    user = insert_empty_user()
+    agent = insert_agent(user_id: user.id, runtime: "codex", model: model)
+    conv = insert_conversation(user_id: user.id, agent: agent)
+    now = DateTime.utc_now()
+    turn = insert_turn(conv, status: "completed", started_at: now, ended_at: now, usage: usage)
+    before = Billing.platform_inference_spend_today(now)
+
+    assert %{inference: 1} = CreditPricer.run(since: DateTime.add(now, -60), now: now)
+    [entry] = Credits.list_entries(user.id) |> Enum.filter(&(&1.reason == "burn_inference"))
+    cost = InferenceRates.cost_cents(usage)
+    assert cost > 0
+    assert entry.amount_cents == -cost
+    assert entry.resource_id == turn.id
+    assert entry.metadata["model"] == model
+    assert Billing.platform_inference_spend_today(now) == before + cost
+
+    {:ok, :own = source, _} =
+      InferenceCredentials.select(model, %{openai_api_key: "tenant-key"}, "codex", refresh: false)
+
+    own_usage =
+      TurnMachine.with_inference(%{"input" => 1_000_000}, %{inference: source, model: model})
+
+    assert own_usage == %{"input" => 1_000_000}
+
+    insert_turn(conv,
+      turn_number: 2,
+      status: "completed",
+      started_at: now,
+      ended_at: now,
+      usage: own_usage
+    )
+
+    assert %{inference: 0} = CreditPricer.run(since: DateTime.add(now, -60), now: now)
+    assert Billing.platform_inference_spend_today(now) == before + cost
+  end
+end


### PR DESCRIPTION
A deployment using only its ChatGPT grant selected a platform credential but omitted the inference stamp because no platform API key was configured. The pricer consequently wrote no inference debit, and daily platform spend missed the turn. Stamp platform usage from the credential source selected for the turn; keep tenant-owned usage behavior unchanged.

Closes #1765. Three files, +137/-18. This includes the turn-start stamp and completed-turn usage through the same function.

Validation: a real local active grant with no platform API keys reproduces both missing turn metadata and a zero-debit pricer pass on the parent. With the fix, all 64 focused turn tests and 24 billing tests pass. The billing regression verifies a debit, daily spend, idempotency, and no inference charge for the tenant's own credential. This is local grant-only verification; ADR 0047's separate recorded production measurement is unchanged.

Full local precommit passes with four VM schedulers: 5,366 core tests plus 6 doctests, 144 Buzz tests, and 33 Support tests, with no failures.
