### PR TITLE
fix(api): separate shared-ingress and per-key rate limits

### DIFF
--- a/apps/fountain/lib/fountain_web/plugs/tenant_api_auth.ex
+++ b/apps/fountain/lib/fountain_web/plugs/tenant_api_auth.ex
@@ -7,6 +7,10 @@ defmodule FountainWeb.Plugs.TenantAPIAuth do
   Updates `last_used_at` in an unlinked task under `Fountain.TaskSupervisor`,
   so the stamp never blocks the request and cannot take it down.
 
+  Authentication refusals share a 600/minute per-address budget, separately
+  from the pipeline's coarse pre-auth ceiling and authenticated per-key quota.
+  A full refusal budget returns 429 without blocking a valid key.
+
   Returns 401 JSON on failure. The response body includes a machine-readable
   `reason` so clients (especially in-sprite agents holding a rotated
   `$FOUNTAIN_TOKEN`) can tell a revoked key apart from one that never existed:
@@ -25,6 +29,7 @@ defmodule FountainWeb.Plugs.TenantAPIAuth do
   require Logger
 
   alias Fountain.Accounts
+  alias FountainWeb.Plugs.RateLimit
 
   def init(opts), do: opts
 
@@ -69,23 +74,30 @@ defmodule FountainWeb.Plugs.TenantAPIAuth do
       # the same answer it would get from asking for a new one. Nothing is
       # leaked by being specific — the holder owns the key.
       {:error, :unverified} ->
-        conn
-        |> put_status(:forbidden)
-        |> json(%{
-          error: "Verify your email address before using the API",
-          reason: "email_unverified"
-        })
-        |> halt()
+        refuse(
+          conn,
+          :forbidden,
+          "Verify your email address before using the API",
+          "email_unverified"
+        )
 
       _ ->
         unauthorized(conn, "Invalid or missing API key", "api_key_invalid")
     end
   end
 
-  defp unauthorized(conn, message, reason) do
-    conn
-    |> put_status(:unauthorized)
-    |> json(%{error: message, reason: reason})
-    |> halt()
+  defp unauthorized(conn, message, reason), do: refuse(conn, :unauthorized, message, reason)
+
+  defp refuse(conn, status, message, reason) do
+    conn = RateLimit.call(conn, RateLimit.init(bucket: "api-auth-failure", max: 600))
+
+    if conn.halted do
+      conn
+    else
+      conn
+      |> put_status(status)
+      |> json(%{error: message, reason: reason})
+      |> halt()
+    end
   end
 end

--- a/apps/fountain/lib/fountain_web/router.ex
+++ b/apps/fountain/lib/fountain_web/router.ex
@@ -21,21 +21,14 @@ defmodule FountainWeb.Router do
   # plugs would be one forgotten line away from an unauthenticated endpoint.
   pipeline :api do
     plug FountainWeb.Plugs.PutApiSpec, module: FountainWeb.ApiSpec
-    # RateLimit BEFORE TenantAPIAuth (#316): auth halts on failure, so with
-    # the old order the limiter only ever saw authenticated requests —
-    # unauthenticated callers got unlimited attempts, each costing a SHA-256
-    # plus an indexed api_keys lookup. This was the one auth surface without
-    # a pre-auth limit; session login, registration, password reset and
-    # POST /api/auth/token all have one.
-    plug FountainWeb.Plugs.RateLimit, bucket: "api", max: 600
+    # A coarse pre-auth ceiling protects the lookup work (#316). It is ten
+    # key budgets, so one key using its allowance does not exhaust a shared
+    # ingress address (#1771). Every attempt counts toward this ceiling.
+    plug FountainWeb.Plugs.RateLimit, bucket: "api", max: 6_000
+    # Refused authentication has its own 600/min address bucket inside auth;
+    # it cannot consume a valid key's allowance.
     plug FountainWeb.Plugs.TenantAPIAuth
-    # And AFTER it, per key (2026-09-07): the address bucket above cannot see
-    # one client's runaway loop when every app beside the server arrives
-    # through the same ingress address, and cannot stop it without stopping
-    # them all. 600 a minute per key per replica is ten a second — a
-    # transcript viewer polling `/events` once a second and holding a stream
-    # is well inside it; a client listing the account fourteen times a
-    # second (the 09-04 incident) is not.
+    # Authenticated clients keep independent 600/min budgets per replica.
     plug FountainWeb.Plugs.RateLimit, bucket: "api-key", max: 600, key: :api_key
     plug FountainWeb.Plugs.Audit
   end

--- a/apps/fountain/test/fountain_web/plugs/pre_auth_rate_limit_test.exs
+++ b/apps/fountain/test/fountain_web/plugs/pre_auth_rate_limit_test.exs
@@ -12,7 +12,7 @@ defmodule FountainWeb.PreAuthRateLimitTest do
   defp fill_api_bucket do
     RateLimit.ensure_table()
     now = System.system_time(:millisecond)
-    :ets.insert(RateLimit.table(), {{"api", self()}, now, 600})
+    :ets.insert(RateLimit.table(), {{"api", self()}, now, 6_000})
   end
 
   test "unauthenticated requests are metered — 429 wins over 401 when the bucket is full",
@@ -53,5 +53,75 @@ defmodule FountainWeb.PreAuthRateLimitTest do
       |> get(~p"/api/agents")
 
     assert conn.status == 200
+  end
+
+  test "a noisy key cannot consume a quiet key's quota through their shared address" do
+    user = insert_verified_user()
+    {noisy, noisy_key} = insert_api_key(user)
+    {quiet, quiet_key} = insert_api_key(user)
+    now = System.system_time(:millisecond)
+    RateLimit.ensure_table()
+
+    :ets.insert(RateLimit.table(), [
+      {{"api", self()}, now, 600},
+      {{"api-key", noisy.id, self()}, now, 600}
+    ])
+
+    assert get(authed_with_key(build_conn(), noisy_key), ~p"/api/agents").status == 429
+    assert get(authed_with_key(build_conn(), quiet_key), ~p"/api/agents").status == 200
+
+    :ets.insert(RateLimit.table(), {{"api-key", quiet.id, self()}, now, 599})
+    assert get(authed_with_key(build_conn(), quiet_key), ~p"/api/agents").status == 200
+    assert get(authed_with_key(build_conn(), quiet_key), ~p"/api/agents").status == 429
+  end
+
+  test "failed authentication retains 600 attempts without blocking a valid key" do
+    user = insert_verified_user()
+    {_key, raw_key} = insert_api_key(user)
+    RateLimit.ensure_table()
+
+    :ets.insert(
+      RateLimit.table(),
+      {{"api-auth-failure", self()}, System.system_time(:millisecond), 599}
+    )
+
+    assert get(build_conn(), ~p"/api/agents").status == 401
+    refused = get(build_conn(), ~p"/api/agents")
+    assert refused.status == 429
+    assert get_resp_header(refused, "retry-after") != []
+    assert get(authed_with_key(build_conn(), raw_key), ~p"/api/agents").status == 200
+  end
+
+  test "unverified keys share the authentication-refusal budget" do
+    user = insert_user()
+    {_key, raw_key} = insert_api_key(user)
+    RateLimit.ensure_table()
+
+    :ets.insert(
+      RateLimit.table(),
+      {{"api-auth-failure", self()}, System.system_time(:millisecond), 599}
+    )
+
+    assert get(authed_with_key(build_conn(), raw_key), ~p"/api/agents").status == 403
+    assert get(authed_with_key(build_conn(), raw_key), ~p"/api/agents").status == 429
+  end
+
+  test "the intentional aggregate ceiling also bounds authenticated traffic" do
+    user = insert_verified_user()
+    {_key, raw_key} = insert_api_key(user)
+    fill_api_bucket()
+    assert get(authed_with_key(build_conn(), raw_key), ~p"/api/agents").status == 429
+  end
+
+  test "the pipeline accepts forwarding only from a trusted proxy" do
+    direct = %{build_conn() | remote_ip: {198, 51, 100, 9}}
+    direct = direct |> put_req_header("x-forwarded-for", "203.0.113.7") |> get(~p"/api/agents")
+    assert direct.status == 401
+    assert direct.remote_ip == {198, 51, 100, 9}
+
+    proxied = %{build_conn() | remote_ip: {10, 42, 0, 1}}
+    proxied = proxied |> put_req_header("x-forwarded-for", "203.0.113.7") |> get(~p"/api/agents")
+    assert proxied.status == 401
+    assert proxied.remote_ip == {203, 0, 113, 7}
   end
 end

--- a/docs/api.md
+++ b/docs/api.md
@@ -124,6 +124,21 @@ The [generated reference](/api/docs) defines required scopes and refusals.
 
 ## Rate limiting
 
+The resource API uses fixed one-minute windows, independently on each server
+replica:
+
+- Each authenticated API key has a 600-request allowance.
+- Failed authentication has a separate 600-request allowance per client address.
+- A coarse ceiling allows 6,000 total attempts per client address before
+  authentication. It includes failed authentication and requests over a key's
+  quota. Exhausting it blocks every key at that address until its window resets.
+
+Each key retains its individual allowance behind a shared ingress. All keys
+count toward the coarse ceiling. Forwarded client addresses are accepted only from configured
+`TRUSTED_PROXIES`; a direct caller cannot choose an address through headers.
+These counters are per replica, so distributing requests across replicas can
+multiply an allowance. Individual operations can impose additional limits.
+
 Honor `Retry-After` when a request is rate limited. Avoid immediate retry
 loops. A lost response to a mutation does not prove that the mutation failed;
 reconcile the resource before you repeat an operation that could spend money.


### PR DESCRIPTION
The pre-auth address limit was the same size as one API key's quota, so one client behind a shared ingress could exhaust the address before another client's first request. Separate the budgets: 600 authenticated requests per key per minute, 600 authentication refusals per client address, and an intentional 6,000-attempt pre-auth address ceiling. The aggregate includes rejected attempts and can still block all keys at the address when exhausted. All counters remain per replica.

Closes #1771. Four files, +117/-27. Document both the aggregate tradeoff and trusted-proxy behavior in the API guide.

Validation: the actual router-pipeline regression fails on the parent with a quiet key receiving 429. All 53 focused pipeline, authentication, limiter, and client-IP tests pass with the fix, covering key quota boundaries, failed/missing/unverified authentication, aggregate exhaustion, and forwarding accepted only from a trusted proxy. All three prose reports reviewed: existing docs-style findings, advisory Vale findings, and clean destink. Full local precommit passed: 5,372 core tests + 6 doctests, 144 Buzz tests and 33 Support tests, all with zero failures.
