### PR TITLE
fix(conversations): clean up retired provisioning attempts

### DIFF
--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -963,17 +963,15 @@ defmodule Fountain.Conversations.ConversationServer do
                  state.runtime_module,
                  agent,
                  sprite_env
-               ) do
-          # `build_fingerprint` records what the disk was built from, and
-          # `applied_skills` what was mounted on it, so a later reapply can
-          # answer both questions from the row rather than guessing (#1565).
-          {:ok, _} =
-            Conversations.update_sandbox(sandbox, %{
-              status: "ready",
-              build_fingerprint: Reapply.fingerprint(env),
-              applied_skills: skills
-            })
-
+               ),
+             # Record what the disk was built from only if this attempt still
+             # owns a live row. Retirement can win while provider I/O runs.
+             {:ok, _} <-
+               Conversations.update_sandbox(sandbox, %{
+                 status: "ready",
+                 build_fingerprint: Reapply.fingerprint(env),
+                 applied_skills: skills
+               }) do
           Output.publish_stage(state.conversation_id, "provision", "done")
 
           # Best-effort: snapshot the fully-provisioned state so subsequent
@@ -997,6 +995,14 @@ defmodule Fountain.Conversations.ConversationServer do
           # queue_initial_prompt/3.
           {:noreply, new_state}
         else
+          {:error, %Ecto.Changeset{errors: [status: {"sandbox is retired", []}]}} ->
+            # This handle and token belong to this attempt. Do not fail the
+            # conversation or release every session: a replacement may own it.
+            _ = Managoat.Sandbox.destroy(handle)
+            Egress.release_prepared(prepared)
+            {:ok, prepared_state} = prepared
+            {:stop, :normal, prepared_state}
+
           {:error, reason} ->
             Logger.error("provision step failed: #{inspect(reason)}")
             _ = Managoat.Sandbox.destroy(handle)

--- a/apps/fountain/test/fountain/conversations/conversation_server_broker_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_broker_test.exs
@@ -466,6 +466,106 @@ defmodule Fountain.Conversations.ConversationServerBrokerTest do
       end
     end
 
+    for terminal <- ["terminated", "failed"] do
+      @tag terminal: terminal
+      test "retirement during provision preserves the #{terminal} row and replacement", %{
+        user: user,
+        agent: agent,
+        terminal: terminal
+      } do
+        conv = insert_conversation(user_id: user.id, agent: agent, sandbox_api_access: "owner")
+        sandbox = Conversations._unsafe_get_sandbox!(conv.sandbox_id)
+        test = self()
+        handle = stub_happy_sprite(sandbox.sprite_name)
+        stub(Fountain.Broker, :preflight, fn -> :ok end)
+        stub(Fountain.Broker, :ca_pem, fn -> {:ok, "PEM"} end)
+
+        stub(Fountain.Broker, :prepare, fn id, secrets, bindings, opts ->
+          {:ok, session} = Fountain.Broker.Native.prepare(id, secrets, bindings, opts)
+          send(test, {:original_token, session.token})
+          {:ok, session}
+        end)
+
+        stub(Fountain.Conversations.Provisioning, :install_packages, fn _h, _e, _se, _id ->
+          send(test, {:provision_paused, self()})
+          receive do: (:resume_provision -> :ok)
+        end)
+
+        stub(Managoat.Sandbox.Sprites, :destroy, fn destroyed ->
+          send(test, {:destroyed, destroyed})
+          :ok
+        end)
+
+        reject(Managoat.Sandbox.Sprites, :spawn, 4)
+
+        {:ok, pid} =
+          GenServer.start(ConversationServer,
+            conversation_id: conv.id,
+            sandbox_id: sandbox.id,
+            runtime_module: Managoat.Runtimes.Testing.FakeRuntime
+          )
+
+        ref = Process.monitor(pid)
+        on_exit(fn -> if Process.alive?(pid), do: Process.exit(pid, :kill) end)
+        assert_receive {:provision_paused, ^pid}, 5_000
+        assert_receive {:original_token, original}
+        callback_id = Fountain.Repo.reload!(conv).callback_api_key_id
+        assert is_binary(callback_id)
+
+        {:ok, retired} = Conversations.update_sandbox(sandbox, %{status: terminal})
+
+        replacement =
+          insert_sandbox(user_id: user.id, status: "ready", sprite_name: "replacement")
+
+        {:ok, _} =
+          Conversations.update_conversation(conv, %{sandbox_id: replacement.id, status: "idle"})
+
+        {:ok, replacement_session} =
+          Fountain.Broker.Native.prepare(conv.id, %{}, %{}, user_id: user.id)
+
+        ConversationServer.queue_initial_prompt(pid, "must never run")
+        send(pid, :resume_provision)
+
+        assert :normal = assert_stopped(ref, 5_000)
+        assert Fountain.Repo.reload!(sandbox).status == terminal
+        assert Fountain.Repo.reload!(sandbox).terminated_at == retired.terminated_at
+        assert Fountain.Repo.reload!(conv).status == "idle"
+        assert Fountain.Repo.reload!(conv).sandbox_id == replacement.id
+        assert Fountain.Repo.reload!(replacement).status == "ready"
+        assert_receive {:destroyed, ^handle}
+        refute_received {:destroyed, _}
+        assert :error = Fountain.Broker.Native.Sessions.lookup(original)
+        assert {:ok, _} = Fountain.Broker.Native.Sessions.lookup(replacement_session.token)
+        assert Fountain.Repo.get(Fountain.Accounts.ApiKey, callback_id).revoked_at
+        refute Enum.any?(stage_events(conv.id, "provision"), &(&1.state in ["done", "failed"]))
+      end
+    end
+
+    test "an unrelated ready-write error still fails provisioning", %{user: user, agent: agent} do
+      conv = insert_conversation(user_id: user.id, agent: agent)
+      stub_happy_sprite()
+      stub(Fountain.Broker, :preflight, fn -> :ok end)
+      stub(Fountain.Broker, :ca_pem, fn -> {:ok, "PEM"} end)
+      stub(Fountain.Broker, :prepare, fn _c, _b, _bindings, _opts -> {:ok, @session} end)
+
+      stub(Conversations, :update_sandbox, fn sandbox, attrs ->
+        if attrs[:status] == "ready" do
+          {:error,
+           Ecto.Changeset.change(sandbox)
+           |> Ecto.Changeset.add_error(:build_fingerprint, "invalid")}
+        else
+          Mimic.call_original(Conversations, :update_sandbox, [sandbox, attrs])
+        end
+      end)
+
+      {_pid, ref, :stopped} = start_server(conv)
+      assert :normal = assert_stopped(ref)
+      assert Conversations._unsafe_get_sandbox!(conv.sandbox_id).status == "failed"
+      assert Fountain.Repo.reload!(conv).status == "failed"
+      assert Enum.any?(stage_events(conv.id, "provision"), &(&1.state == "failed"))
+      refute Enum.any?(stage_events(conv.id, "provision"), &(&1.state == "done"))
+    end
+
     test "terminating the conversation releases the vault", %{user: user, agent: agent} do
       conv = insert_conversation(user_id: user.id, agent: agent)
       test = self()


### PR DESCRIPTION
A sandbox retired while provisioning could reject the final ready write, raise a MatchError, and then mark the conversation failed—even after it had moved to a replacement sandbox. Handle that retirement rejection explicitly: destroy the handle this attempt created, revoke only its prepared broker session, and stop normally with its callback-key state. Leave the retired row and replacement conversation untouched, and emit no provision success or new turn.

First small unit of #1766: provisioning completion only. Wake completion follows in a separate stacked PR; admission before provisioning remains separate. Two files, +117/-11.

Validation: deterministic provider pauses reproduce both terminated and failed retirement on the parent (2 tests, 2 failures). The fix preserves replacement sandbox/session rows, revokes the stale callback key and broker token, destroys only the stale handle, and never starts the queued prompt. All 34 focused broker, fingerprint, provision deadline and callback-revocation tests pass, including an unrelated database rejection that still fails provisioning. Full local precommit passed: 5,378 core tests + 6 doctests, 144 Buzz tests and 33 Support tests, all with zero failures.
