### PR TITLE
fix(conversations): skip park completion after retirement wins

### DIFF
--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -1176,39 +1176,46 @@ defmodule Fountain.Conversations.ConversationServer do
         {:error, reason} -> Logger.warning("runtime prepare on wake: #{inspect(reason)}")
       end
 
-      # Normally the wake path already flipped suspended → ready under the
-      # quota reservation; this covers the reaper parking the row mid-wake.
-      # Without it the row would stay `suspended` under a live server —
-      # invisible to the quota and unreachable by any reaper pass.
-      sandbox =
+      # Validate even a cached ready row: retirement may have won while the
+      # provider was waking. Only a suspended wake resets the lifetime clock.
+      attrs =
         if sandbox.status == "suspended" do
-          {:ok, s} =
-            Conversations.update_sandbox(sandbox, %{
-              status: "ready",
-              last_resumed_at: DateTime.utc_now() |> DateTime.truncate(:second)
-            })
-
-          s
+          %{
+            status: "ready",
+            last_resumed_at: DateTime.utc_now() |> DateTime.truncate(:second)
+          }
         else
-          sandbox
+          %{status: "ready"}
         end
 
-      new_state = %{
-        state
-        | handle: handle,
-          sprite_env: sprite_env,
-          sandbox_started_at: Lifecycle.clock_start(sandbox)
-      }
+      case Conversations.update_sandbox(sandbox, attrs) do
+        {:ok, sandbox} ->
+          new_state = %{
+            state
+            | handle: handle,
+              sprite_env: sprite_env,
+              sandbox_started_at: Lifecycle.clock_start(sandbox)
+          }
 
-      new_state = reattach_running_turn(%{new_state | current_turn: nil})
+          new_state = reattach_running_turn(%{new_state | current_turn: nil})
 
-      new_state =
-        Reattachment.finish_runner_reconnect(
-          new_state,
-          if(new_state.current_turn, do: "reattached", else: "turn_ended")
-        )
+          new_state =
+            Reattachment.finish_runner_reconnect(
+              new_state,
+              if(new_state.current_turn, do: "reattached", else: "turn_ended")
+            )
 
-      {:noreply, new_state}
+          {:noreply, new_state}
+
+        {:error, %Ecto.Changeset{errors: [status: {"sandbox is retired", []}]}} ->
+          # Wake owns this connection's credentials, not the existing disk or
+          # another connection's session. Never destroy the machine here.
+          Egress.release_prepared({:ok, state})
+          {:stop, :normal, state}
+
+        error ->
+          raise MatchError, term: error
+      end
     else
       {:error, :not_found} ->
         # The provider says the sandbox is gone. That is the one answer that

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -963,17 +963,15 @@ defmodule Fountain.Conversations.ConversationServer do
                  state.runtime_module,
                  agent,
                  sprite_env
-               ) do
-          # `build_fingerprint` records what the disk was built from, and
-          # `applied_skills` what was mounted on it, so a later reapply can
-          # answer both questions from the row rather than guessing (#1565).
-          {:ok, _} =
-            Conversations.update_sandbox(sandbox, %{
-              status: "ready",
-              build_fingerprint: Reapply.fingerprint(env),
-              applied_skills: skills
-            })
-
+               ),
+             # Record what the disk was built from only if this attempt still
+             # owns a live row. Retirement can win while provider I/O runs.
+             {:ok, _} <-
+               Conversations.update_sandbox(sandbox, %{
+                 status: "ready",
+                 build_fingerprint: Reapply.fingerprint(env),
+                 applied_skills: skills
+               }) do
           Output.publish_stage(state.conversation_id, "provision", "done")
 
           # Best-effort: snapshot the fully-provisioned state so subsequent
@@ -997,6 +995,14 @@ defmodule Fountain.Conversations.ConversationServer do
           # queue_initial_prompt/3.
           {:noreply, new_state}
         else
+          {:error, %Ecto.Changeset{errors: [status: {"sandbox is retired", []}]}} ->
+            # This handle and token belong to this attempt. Do not fail the
+            # conversation or release every session: a replacement may own it.
+            _ = Managoat.Sandbox.destroy(handle)
+            Egress.release_prepared(prepared)
+            {:ok, prepared_state} = prepared
+            {:stop, :normal, prepared_state}
+
           {:error, reason} ->
             Logger.error("provision step failed: #{inspect(reason)}")
             _ = Managoat.Sandbox.destroy(handle)

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -840,7 +840,18 @@ defmodule Fountain.Conversations.ConversationServer do
 
   defp do_fresh_provision(state, conv, sandbox, agent, env, secrets) do
     try do
-      do_fresh_provision_inner(state, conv, sandbox, agent, env, secrets)
+      case Conversations.update_sandbox(sandbox, %{status: "starting"}) do
+        {:ok, _} ->
+          do_fresh_provision_inner(state, conv, sandbox, agent, env, secrets)
+
+        {:error, %Ecto.Changeset{errors: [status: {"sandbox is retired", []}]}} ->
+          # No resources were created yet. Leave the winning retirement and
+          # any replacement conversation alone, without announcing a start.
+          {:stop, :normal, state}
+
+        error ->
+          raise MatchError, term: error
+      end
     rescue
       exception ->
         stack = __STACKTRACE__
@@ -859,13 +870,11 @@ defmodule Fountain.Conversations.ConversationServer do
   end
 
   defp do_fresh_provision_inner(state, conv, sandbox, agent, env, secrets) do
-    # The row only ever becomes `starting` right here, so finding it already
-    # `starting` means an earlier attempt was interrupted mid-provision — a
+    # Finding the original snapshot already `starting` means an earlier
+    # attempt was interrupted mid-provision — a
     # deploy or a Horde rebalance killed the server while it was blocked in
     # this function. The sprite it was building is most likely still there.
     interrupted? = sandbox.status == "starting"
-
-    {:ok, _} = Conversations.update_sandbox(sandbox, %{status: "starting"})
 
     Output.publish_stage(
       state.conversation_id,

--- a/apps/fountain/lib/fountain/conversations/lifecycle.ex
+++ b/apps/fountain/lib/fountain/conversations/lifecycle.ex
@@ -366,24 +366,34 @@ defmodule Fountain.Conversations.Lifecycle do
   """
   @spec park(String.t(), String.t() | nil, Handle.t() | nil, :idle | :max_lifetime) :: :ok
   def park(conversation_id, sandbox_id, handle, reason) do
-    if sandbox_id do
-      # Ownership: as home?/1 above.
-      sandbox = Conversations._unsafe_get_sandbox!(sandbox_id)
+    case park_row(sandbox_id) do
+      :ok -> finish_park(conversation_id, sandbox_id, handle, reason)
+      :skipped -> :ok
+    end
+  end
 
-      # A machine whose reset is unconfirmed is on its way out, not parking.
-      # `update_sandbox/2` lets a retiring write through the fence but refuses
-      # `suspended`, and this clause matches `{:ok, _}`. The reaper's own park
-      # pass filters the same rows; there is no checkpoint worth taking of a
-      # disk that is meant to be gone.
-      if sandbox.status not in ["terminated", "failed"] and
-           is_nil(sandbox.reset_requested_at) do
-        # A home's disk is kept at its quietest moment, where the provider
-        # can (ADR 0023, #1073). Best-effort: the park goes ahead either way.
-        HomeCheckpoint.on_park(sandbox)
-        {:ok, _} = Conversations.update_sandbox(sandbox, %{status: "suspended"})
+  defp park_row(nil), do: :ok
+
+  defp park_row(sandbox_id) do
+    # Ownership: as home?/1 above. Recheck after the provider checkpoint:
+    # retirement or a reset fence can win while that call is in flight.
+    sandbox = Conversations._unsafe_get_sandbox!(sandbox_id)
+
+    if sandbox.status in ["terminated", "failed"] or not is_nil(sandbox.reset_requested_at) do
+      :skipped
+    else
+      HomeCheckpoint.on_park(sandbox)
+
+      case Conversations.update_sandbox(sandbox, %{status: "suspended"}) do
+        {:ok, _} -> :ok
+        {:error, %Ecto.Changeset{errors: [status: {"sandbox is retired", []}]}} -> :skipped
+        {:error, :sandbox_reset_pending} -> :skipped
+        error -> raise MatchError, term: error
       end
     end
+  end
 
+  defp finish_park(conversation_id, sandbox_id, handle, reason) do
     # The conversation stays idle and resumable; the sprite stays parked.
     conv = Conversations._unsafe_get_conversation!(conversation_id)
     if conv.status == "running", do: Conversations.update_conversation(conv, %{status: "idle"})

--- a/apps/fountain/test/fountain/conversations/conversation_server_broker_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_broker_test.exs
@@ -178,6 +178,122 @@ defmodule Fountain.Conversations.ConversationServerBrokerTest do
       end
     end
 
+    for initial <- ["ready", "suspended"], terminal <- ["terminated", "failed"] do
+      @tag initial: initial, terminal: terminal
+      test "retirement during #{initial} wake preserves #{terminal} and the replacement", %{
+        user: user,
+        conv: conv,
+        sandbox: sandbox,
+        initial: initial,
+        terminal: terminal
+      } do
+        configure_broker([user.id])
+        {:ok, sandbox} = Conversations.update_sandbox(sandbox, %{status: initial})
+        test = self()
+
+        stub(Fountain.Broker, :prepare, fn id, secrets, bindings, opts ->
+          {:ok, session} = Fountain.Broker.Native.prepare(id, secrets, bindings, opts)
+          send(test, {:original_token, session.token})
+          {:ok, session}
+        end)
+
+        stub(Fountain.Conversations.Provisioning, :prepare_runtime_sprite, fn _h,
+                                                                              _r,
+                                                                              _m,
+                                                                              _a,
+                                                                              _e ->
+          send(test, {:wake_paused, self()})
+          receive do: (:resume_wake -> :ok)
+        end)
+
+        reject(Managoat.Sandbox.Sprites, :destroy, 1)
+        reject(Managoat.Sandbox.Sprites, :list_sessions, 1)
+        reject(Managoat.Sandbox.Sprites, :spawn, 4)
+
+        {:ok, pid} =
+          GenServer.start(ConversationServer,
+            conversation_id: conv.id,
+            sandbox_id: sandbox.id,
+            runtime_module: Managoat.Runtimes.Testing.FakeRuntime
+          )
+
+        ref = Process.monitor(pid)
+        on_exit(fn -> if Process.alive?(pid), do: Process.exit(pid, :kill) end)
+        assert_receive {:wake_paused, ^pid}, 5_000
+        assert_receive {:original_token, original}
+        callback_id = Fountain.Repo.reload!(conv).callback_api_key_id
+        assert is_binary(callback_id)
+
+        {:ok, retired} = Conversations.update_sandbox(sandbox, %{status: terminal})
+
+        replacement =
+          insert_sandbox(user_id: user.id, status: "ready", sprite_name: "replacement")
+
+        {:ok, _} = Conversations.update_conversation(conv, %{sandbox_id: replacement.id})
+
+        {:ok, replacement_session} =
+          Fountain.Broker.Native.prepare(conv.id, %{}, %{}, user_id: user.id)
+
+        ConversationServer.queue_initial_prompt(pid, "must never run")
+        send(pid, :resume_wake)
+
+        assert :normal = assert_stopped(ref, 5_000)
+        assert Fountain.Repo.reload!(sandbox).status == terminal
+        assert Fountain.Repo.reload!(sandbox).terminated_at == retired.terminated_at
+        assert Fountain.Repo.reload!(conv).sandbox_id == replacement.id
+        assert Fountain.Repo.reload!(conv).status == "idle"
+        assert Fountain.Repo.reload!(replacement).status == "ready"
+        assert :error = Fountain.Broker.Native.Sessions.lookup(original)
+        assert {:ok, _} = Fountain.Broker.Native.Sessions.lookup(replacement_session.token)
+        assert Fountain.Repo.get(Fountain.Accounts.ApiKey, callback_id).revoked_at
+        refute Enum.any?(stage_events(conv.id, "reattach"), &(&1.state == "done"))
+      end
+    end
+
+    for initial <- ["ready", "suspended"] do
+      test "an ordinary #{initial} wake succeeds and preserves the lifetime rule", %{
+        conv: conv,
+        sandbox: sandbox
+      } do
+        resumed = DateTime.add(DateTime.utc_now(), -600) |> DateTime.truncate(:second)
+
+        {:ok, _} =
+          Conversations.update_sandbox(sandbox, %{
+            status: unquote(initial),
+            last_resumed_at: resumed
+          })
+
+        {pid, _ref, :alive} = start_server(conv)
+        on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+
+        current = Fountain.Repo.reload!(sandbox)
+        assert current.status == "ready"
+
+        if unquote(initial) == "ready",
+          do: assert(current.last_resumed_at == resumed),
+          else: assert(DateTime.compare(current.last_resumed_at, resumed) == :gt)
+
+        assert Enum.any?(stage_events(conv.id, "reattach"), &(&1.state == "done"))
+      end
+    end
+
+    test "an unrelated ready-write rejection is not treated as retirement", %{
+      conv: conv,
+      sandbox: sandbox
+    } do
+      rejection =
+        {:error,
+         Ecto.Changeset.change(sandbox) |> Ecto.Changeset.add_error(:status, "other failure")}
+
+      stub(Conversations, :update_sandbox, fn _row, _attrs -> rejection end)
+
+      {_pid, ref, :stopped} = start_server(conv)
+      assert {%MatchError{term: ^rejection}, _stack} = assert_stopped(ref)
+      assert Fountain.Repo.reload!(sandbox).status == "ready"
+      assert Fountain.Repo.reload!(conv).status == "idle"
+      refute Enum.any?(stage_events(conv.id, "reattach"), &(&1.state == "done"))
+    end
+
     test "a removed tenant gets its limited environment policy back", %{conv: conv, env: env} do
       configure_broker(["someone-else"])
 

--- a/apps/fountain/test/fountain/conversations/conversation_server_broker_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_broker_test.exs
@@ -466,6 +466,106 @@ defmodule Fountain.Conversations.ConversationServerBrokerTest do
       end
     end
 
+    for terminal <- ["terminated", "failed"] do
+      @tag terminal: terminal
+      test "retirement during provision preserves the #{terminal} row and replacement", %{
+        user: user,
+        agent: agent,
+        terminal: terminal
+      } do
+        conv = insert_conversation(user_id: user.id, agent: agent, sandbox_api_access: "owner")
+        sandbox = Conversations._unsafe_get_sandbox!(conv.sandbox_id)
+        test = self()
+        handle = stub_happy_sprite(sandbox.sprite_name)
+        stub(Fountain.Broker, :preflight, fn -> :ok end)
+        stub(Fountain.Broker, :ca_pem, fn -> {:ok, "PEM"} end)
+
+        stub(Fountain.Broker, :prepare, fn id, secrets, bindings, opts ->
+          {:ok, session} = Fountain.Broker.Native.prepare(id, secrets, bindings, opts)
+          send(test, {:original_token, session.token})
+          {:ok, session}
+        end)
+
+        stub(Fountain.Conversations.Provisioning, :install_packages, fn _h, _e, _se, _id ->
+          send(test, {:provision_paused, self()})
+          receive do: (:resume_provision -> :ok)
+        end)
+
+        stub(Managoat.Sandbox.Sprites, :destroy, fn destroyed ->
+          send(test, {:destroyed, destroyed})
+          :ok
+        end)
+
+        reject(Managoat.Sandbox.Sprites, :spawn, 4)
+
+        {:ok, pid} =
+          GenServer.start(ConversationServer,
+            conversation_id: conv.id,
+            sandbox_id: sandbox.id,
+            runtime_module: Managoat.Runtimes.Testing.FakeRuntime
+          )
+
+        ref = Process.monitor(pid)
+        on_exit(fn -> if Process.alive?(pid), do: Process.exit(pid, :kill) end)
+        assert_receive {:provision_paused, ^pid}, 5_000
+        assert_receive {:original_token, original}
+        callback_id = Fountain.Repo.reload!(conv).callback_api_key_id
+        assert is_binary(callback_id)
+
+        {:ok, retired} = Conversations.update_sandbox(sandbox, %{status: terminal})
+
+        replacement =
+          insert_sandbox(user_id: user.id, status: "ready", sprite_name: "replacement")
+
+        {:ok, _} =
+          Conversations.update_conversation(conv, %{sandbox_id: replacement.id, status: "idle"})
+
+        {:ok, replacement_session} =
+          Fountain.Broker.Native.prepare(conv.id, %{}, %{}, user_id: user.id)
+
+        ConversationServer.queue_initial_prompt(pid, "must never run")
+        send(pid, :resume_provision)
+
+        assert :normal = assert_stopped(ref, 5_000)
+        assert Fountain.Repo.reload!(sandbox).status == terminal
+        assert Fountain.Repo.reload!(sandbox).terminated_at == retired.terminated_at
+        assert Fountain.Repo.reload!(conv).status == "idle"
+        assert Fountain.Repo.reload!(conv).sandbox_id == replacement.id
+        assert Fountain.Repo.reload!(replacement).status == "ready"
+        assert_receive {:destroyed, ^handle}
+        refute_received {:destroyed, _}
+        assert :error = Fountain.Broker.Native.Sessions.lookup(original)
+        assert {:ok, _} = Fountain.Broker.Native.Sessions.lookup(replacement_session.token)
+        assert Fountain.Repo.get(Fountain.Accounts.ApiKey, callback_id).revoked_at
+        refute Enum.any?(stage_events(conv.id, "provision"), &(&1.state in ["done", "failed"]))
+      end
+    end
+
+    test "an unrelated ready-write error still fails provisioning", %{user: user, agent: agent} do
+      conv = insert_conversation(user_id: user.id, agent: agent)
+      stub_happy_sprite()
+      stub(Fountain.Broker, :preflight, fn -> :ok end)
+      stub(Fountain.Broker, :ca_pem, fn -> {:ok, "PEM"} end)
+      stub(Fountain.Broker, :prepare, fn _c, _b, _bindings, _opts -> {:ok, @session} end)
+
+      stub(Conversations, :update_sandbox, fn sandbox, attrs ->
+        if attrs[:status] == "ready" do
+          {:error,
+           Ecto.Changeset.change(sandbox)
+           |> Ecto.Changeset.add_error(:build_fingerprint, "invalid")}
+        else
+          Mimic.call_original(Conversations, :update_sandbox, [sandbox, attrs])
+        end
+      end)
+
+      {_pid, ref, :stopped} = start_server(conv)
+      assert :normal = assert_stopped(ref)
+      assert Conversations._unsafe_get_sandbox!(conv.sandbox_id).status == "failed"
+      assert Fountain.Repo.reload!(conv).status == "failed"
+      assert Enum.any?(stage_events(conv.id, "provision"), &(&1.state == "failed"))
+      refute Enum.any?(stage_events(conv.id, "provision"), &(&1.state == "done"))
+    end
+
     test "terminating the conversation releases the vault", %{user: user, agent: agent} do
       conv = insert_conversation(user_id: user.id, agent: agent)
       test = self()

--- a/apps/fountain/test/fountain/conversations/conversation_server_provision_retirement_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_provision_retirement_test.exs
@@ -1,0 +1,52 @@
+defmodule Fountain.Conversations.ConversationServerProvisionRetirementTest do
+  use Fountain.ConversationServerCase
+
+  for terminal <- ["terminated", "failed"] do
+    test "retirement to #{terminal} before starting does not provision or fail the replacement" do
+      stub_happy_sprite()
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id, runtime: "gemini")
+      conv = insert_conversation(user_id: user.id, agent: agent, status: "idle")
+      sandbox = Conversations._unsafe_get_sandbox!(conv.sandbox_id)
+      test = self()
+
+      stub(Conversations, :update_sandbox, fn row, attrs ->
+        if attrs[:status] == "starting" do
+          send(test, {:starting_paused, self()})
+          receive do: (:resume_starting -> :ok)
+        end
+
+        Mimic.call_original(Conversations, :update_sandbox, [row, attrs])
+      end)
+
+      reject(Managoat.Sandbox.Sprites, :create, 2)
+      reject(Managoat.Sandbox.Sprites, :destroy, 1)
+      reject(Fountain.Broker, :prepare, 4)
+
+      {:ok, pid} =
+        GenServer.start(ConversationServer,
+          conversation_id: conv.id,
+          sandbox_id: sandbox.id,
+          runtime_module: Managoat.Runtimes.Testing.FakeRuntime
+        )
+
+      ref = Process.monitor(pid)
+      on_exit(fn -> if Process.alive?(pid), do: Process.exit(pid, :kill) end)
+      assert_receive {:starting_paused, ^pid}, 5_000
+
+      {:ok, retired} = Conversations.update_sandbox(sandbox, %{status: unquote(terminal)})
+      replacement = insert_sandbox(user_id: user.id, status: "ready")
+      {:ok, _} = Conversations.update_conversation(conv, %{sandbox_id: replacement.id})
+      send(pid, :resume_starting)
+
+      assert :normal = assert_stopped(ref, 5_000)
+      assert Fountain.Repo.reload!(sandbox).status == unquote(terminal)
+      assert Fountain.Repo.reload!(sandbox).terminated_at == retired.terminated_at
+      assert Fountain.Repo.reload!(conv).status == "idle"
+      assert Fountain.Repo.reload!(conv).sandbox_id == replacement.id
+      assert Fountain.Repo.reload!(replacement).status == "ready"
+      assert is_nil(Fountain.Repo.reload!(conv).callback_api_key_id)
+      refute Enum.any?(Conversations._unsafe_list_log_events(conv.id), &(&1.stage == "provision"))
+    end
+  end
+end

--- a/apps/fountain/test/fountain/conversations/lifecycle_actions_test.exs
+++ b/apps/fountain/test/fountain/conversations/lifecycle_actions_test.exs
@@ -204,9 +204,73 @@ defmodule Fountain.Conversations.LifecycleActionsTest do
 
       assert Lifecycle.park(ctx.conv.id, sandbox.id, handle(), :idle) == :ok
       assert Repo.reload(sandbox).status == "failed"
-      # The conversation and the stream still get the news.
-      assert Repo.reload(ctx.conv).status == "idle"
-      assert [{"done", _}] = stages(ctx.conv.id, "sandbox")
+      assert Repo.reload(ctx.conv).status == "running"
+      assert stages(ctx.conv.id, "sandbox") == []
+    end
+
+    for terminal <- ["terminated", "failed"] do
+      @tag park_retirement: true
+      test "retirement to #{terminal} during checkpoint does not park the replacement", ctx do
+        {:ok, home} = Conversations.update_sandbox(ctx.sandbox, %{mode: "persistent"})
+        test = self()
+
+        stub(Managoat.Sandbox, :supports?, fn :sprites, :checkpoint -> true end)
+
+        stub(Managoat.Sandbox, :create_checkpoint, fn _handle, _opts ->
+          send(test, {:checkpoint_paused, self()})
+          receive do: (:resume_checkpoint -> {:ok, "checkpoint"})
+        end)
+
+        pid =
+          spawn(fn ->
+            receive do
+              :park ->
+                result =
+                  try do
+                    Lifecycle.park(ctx.conv.id, home.id, handle(), :idle)
+                  rescue
+                    error -> {:raised, error}
+                  end
+
+                send(test, {:park_result, result})
+            end
+          end)
+
+        on_exit(fn -> if Process.alive?(pid), do: Process.exit(pid, :kill) end)
+        Ecto.Adapters.SQL.Sandbox.allow(Repo, self(), pid)
+        Mimic.allow(Managoat.Sandbox, self(), pid)
+        send(pid, :park)
+        assert_receive {:checkpoint_paused, ^pid}, 5_000
+
+        {:ok, retired} = Conversations.update_sandbox(home, %{status: unquote(terminal)})
+        replacement = insert_sandbox(user_id: ctx.user.id, status: "ready")
+        {:ok, _} = Conversations.update_conversation(ctx.conv, %{sandbox_id: replacement.id})
+        send(pid, :resume_checkpoint)
+
+        assert_receive {:park_result, :ok}, 5_000
+        assert Repo.reload!(home).status == unquote(terminal)
+        assert Repo.reload!(home).terminated_at == retired.terminated_at
+        assert Repo.reload!(ctx.conv).sandbox_id == replacement.id
+        assert Repo.reload!(ctx.conv).status == "running"
+        assert Repo.reload!(replacement).status == "ready"
+        assert stages(ctx.conv.id, "sandbox") == []
+      end
+    end
+
+    test "unrelated park-write errors still raise", ctx do
+      rejection =
+        {:error,
+         Ecto.Changeset.change(ctx.sandbox) |> Ecto.Changeset.add_error(:status, "other failure")}
+
+      stub(Conversations, :update_sandbox, fn _row, _attrs -> rejection end)
+
+      assert_raise MatchError, fn ->
+        Lifecycle.park(ctx.conv.id, ctx.sandbox.id, handle(), :idle)
+      end
+
+      assert Repo.reload!(ctx.sandbox).status == "ready"
+      assert Repo.reload!(ctx.conv).status == "running"
+      assert stages(ctx.conv.id, "sandbox") == []
     end
 
     test "a conversation that is not running keeps its status", ctx do


### PR DESCRIPTION
A home checkpoint can finish after another operation retires the sandbox. The subsequent suspended write then rejects retirement revival, but Lifecycle.park/4 assumed success and raised. Handle the rejection explicitly and skip park completion: preserve the terminal row and replacement conversation, emit no suspension event, and notify no co-tenants. A row already terminal or reset-fenced also skips completion. Other database errors still raise. The conversation actor already drops its connection before calling park and stops normally afterward.

Final small unit of #1766, stacked on #1945 (the starting transition). Two files, +91/-17. The stack handles provisioning completion, ready/suspended wake completion, the starting transition and the audited park caller. Closes #1766 when the stack lands.

Validation: two deterministic checkpoint-provider pauses reproduce MatchError on the parent after failed/terminated retirement. With the fix, the park returns normally and preserves the replacement's running conversation and ready sandbox without a suspension event. All 78 focused lifecycle, reset, checkpoint, lifetime and shared-sandbox tests pass, including ordinary parking and unrelated database errors. Full local precommit passed: 5,390 core tests + 6 doctests, 144 Buzz tests and 33 Support tests, all with zero failures.
