### PR TITLE
fix(accounts): let owners manage claimed principal credentials

### DIFF
--- a/apps/fountain/lib/fountain/accounts.ex
+++ b/apps/fountain/lib/fountain/accounts.ex
@@ -921,6 +921,56 @@ defmodule Fountain.Accounts do
     |> Repo.all()
   end
 
+  @doc "Active keys the account manages: its own keys and its claimed principals' credentials."
+  def list_managed_api_keys(user_id) when is_binary(user_id) do
+    user_id
+    |> managed_api_keys()
+    |> where([k], is_nil(k.revoked_at))
+    |> order_by([k], desc: k.inserted_at)
+    |> Repo.all()
+  end
+
+  @doc "Revoke an owned or claimed-principal credential, with a trail the managing owner can read."
+  def revoke_managed_api_key(user_id, key_id, opts \\ []) do
+    case user_id |> managed_api_keys() |> where([k], k.id == ^key_id) |> Repo.one() do
+      nil ->
+        {:error, :not_found}
+
+      key ->
+        with {:ok, revoked} <- revoke_api_key(key.user_id, key.id, opts) do
+          if key.user_id != user_id do
+            Audit.record(%{
+              user_id: user_id,
+              action: "api_key.revoked",
+              resource_type: "api_key",
+              resource_id: key.id,
+              actor: Keyword.get(opts, :actor, "self"),
+              request_ip: Keyword.get(opts, :request_ip),
+              metadata: %{
+                "name" => key.name,
+                "key_prefix" => key.key_prefix,
+                "principal_user_id" => key.user_id
+              }
+            })
+          end
+
+          {:ok, revoked}
+        end
+    end
+  end
+
+  defp managed_api_keys(user_id) do
+    principals =
+      from o in Fountain.Principals.Owner,
+        where: o.owner_user_id == ^user_id,
+        select: o.principal_user_id
+
+    from k in ApiKey,
+      where:
+        k.user_id == ^user_id or
+          ("principal" in k.scopes and k.user_id in subquery(principals))
+  end
+
   @doc "List all users, ordered by insertion date."
   def list_users do
     from(u in User, order_by: [asc: u.inserted_at]) |> Repo.all()

--- a/apps/fountain/lib/fountain_web/controllers/api_key_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/api_key_controller.ex
@@ -33,7 +33,7 @@ defmodule FountainWeb.ApiKeyController do
 
   def index(conn, _params) do
     user = conn.assigns.current_user
-    render(conn, :index, keys: Accounts.list_api_keys(user.id))
+    render(conn, :index, keys: Accounts.list_managed_api_keys(user.id))
   end
 
   operation(:create,
@@ -95,7 +95,7 @@ defmodule FountainWeb.ApiKeyController do
   def delete(conn, %{"id" => id}) do
     user = conn.assigns.current_user
 
-    case Accounts.revoke_api_key(user.id, id, Audited.attribution(conn)) do
+    case Accounts.revoke_managed_api_key(user.id, id, Audited.attribution(conn)) do
       {:ok, _key} ->
         send_resp(conn, :no_content, "")
 

--- a/apps/fountain/lib/fountain_web/live/api_keys_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/api_keys_live/index.ex
@@ -7,7 +7,7 @@ defmodule FountainWeb.ApiKeysLive.Index do
   @impl true
   def mount(_params, _session, socket) do
     user = socket.assigns.current_user
-    keys = Accounts.list_api_keys(user.id)
+    keys = Accounts.list_managed_api_keys(user.id)
 
     {:ok,
      socket
@@ -30,7 +30,7 @@ defmodule FountainWeb.ApiKeysLive.Index do
       {:ok, {key, raw_token}} ->
         {:noreply,
          socket
-         |> assign(:keys, Accounts.list_api_keys(socket.assigns.user_id))
+         |> assign(:keys, Accounts.list_managed_api_keys(socket.assigns.user_id))
          |> assign(:new_key, %{key: key, raw_token: raw_token})}
 
       {:error, _cs} ->
@@ -46,7 +46,7 @@ defmodule FountainWeb.ApiKeysLive.Index do
     # `revoke_api_key/3` records `api_key.revoked` itself now (#552), the same
     # move the mint made in #542 — so this surface owes the trail only who was
     # on the socket, and its own `from_socket` call had to go with it.
-    case Accounts.revoke_api_key(
+    case Accounts.revoke_managed_api_key(
            socket.assigns.user_id,
            id,
            FountainWeb.Audited.attribution(socket)
@@ -54,7 +54,7 @@ defmodule FountainWeb.ApiKeysLive.Index do
       {:ok, _revoked} ->
         {:noreply,
          socket
-         |> assign(:keys, Accounts.list_api_keys(socket.assigns.user_id))
+         |> assign(:keys, Accounts.list_managed_api_keys(socket.assigns.user_id))
          |> put_flash(:info, "Key revoked")}
 
       {:error, :not_found} ->
@@ -144,7 +144,12 @@ defmodule FountainWeb.ApiKeysLive.Index do
             :for={k <- @keys}
             class="border-b border-[var(--color-border)] last:border-0 hover:bg-[var(--color-bg-2)]"
           >
-            <td class="px-4 py-2 font-medium">{k.name}</td>
+            <td class="px-4 py-2 font-medium">
+              {k.name}
+              <span :if={k.user_id != @user_id} class="text-xs text-[var(--color-text-muted)]">
+                Principal
+              </span>
+            </td>
             <td class="px-4 py-2 font-mono text-[var(--color-text-muted)] text-xs">
               {k.key_prefix}···
             </td>

--- a/apps/fountain/test/fountain/audit_guardrail_test.exs
+++ b/apps/fountain/test/fountain/audit_guardrail_test.exs
@@ -58,6 +58,7 @@ defmodule Fountain.AuditGuardrailTest do
     {"vault delete", &__MODULE__.do_vault_delete/1, "vault.deleted"},
     {"api key mint", &__MODULE__.do_key_create/1, "api_key.created"},
     {"api key revoke", &__MODULE__.do_key_revoke/1, "api_key.revoked"},
+    {"managed principal key revoke", &__MODULE__.do_managed_key_revoke/1, "api_key.revoked"},
     {"inference credential write", &__MODULE__.do_cred_write/1, "inference_credential.write"},
     {"inference credential clear", &__MODULE__.do_cred_clear/1, "inference_credential.delete"},
     {"conversation delete", &__MODULE__.do_conv_delete/1, "conversation.deleted"},
@@ -413,6 +414,14 @@ defmodule Fountain.AuditGuardrailTest do
   def do_key_revoke(user) do
     {:ok, {key, _}} = Fountain.Accounts.create_api_key(user.id, "guard-revoke")
     {:ok, _} = Fountain.Accounts.revoke_api_key(user.id, key.id)
+  end
+
+  def do_managed_key_revoke(user) do
+    app = insert_verified_user()
+    {:ok, opened} = Principals.create_claimable(app, %{"application_id" => "audit-guard"})
+    {:ok, claimed} = Principals.claim(opened.claimable.id, opened.claim_token, user)
+    {:ok, _, key} = Fountain.Accounts.authenticate_api_key(claimed.api_key)
+    {:ok, _} = Fountain.Accounts.revoke_managed_api_key(user.id, key.id)
   end
 
   def do_cred_write(user) do

--- a/apps/fountain/test/fountain_web/controllers/api_key_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/api_key_controller_test.exs
@@ -2,7 +2,71 @@ defmodule FountainWeb.ApiKeyControllerTest do
   use FountainWeb.ConnCase, async: true
   use Mimic
 
+  import Ecto.Query
+
   alias Fountain.Accounts
+  alias Fountain.Repo
+
+  defp claimed_key(owner) do
+    app = insert_verified_user()
+    {:ok, opened} = Fountain.Principals.create_claimable(app, %{"application_id" => "test-app"})
+    {:ok, claimed} = Fountain.Principals.claim(opened.claimable.id, opened.claim_token, owner)
+    {:ok, principal, key} = Accounts.authenticate_api_key(claimed.api_key)
+    {principal, key, claimed.api_key}
+  end
+
+  test "the owner lists and revokes its principal credential with an owner-visible audit", %{
+    conn: conn
+  } do
+    owner = insert_verified_user()
+    {own_key, auth} = insert_api_key(owner)
+    {principal, key, raw} = claimed_key(owner)
+    {_foreign, foreign_key, _} = claimed_key(insert_verified_user())
+    {:ok, {callback, _}} = Accounts.create_api_key(principal.id, "callback", scopes: ["sprite"])
+
+    response = conn |> authed_with_key(auth) |> get("/api/auth/api-keys") |> json_response(200)
+    ids = Enum.map(response["data"], & &1["id"])
+    assert own_key.id in ids
+    assert key.id in ids
+    refute foreign_key.id in ids
+    refute callback.id in ids
+    refute inspect(response) =~ raw
+
+    assert %{status: 204} =
+             conn |> authed_with_key(auth) |> delete("/api/auth/api-keys/#{key.id}")
+
+    assert {:error, :revoked} = Accounts.authenticate_api_key(raw)
+
+    assert [audit] =
+             Repo.all(
+               from a in Fountain.Audit.Event,
+                 where:
+                   a.user_id == ^owner.id and a.resource_id == ^key.id and
+                     a.action == "api_key.revoked"
+             )
+
+    assert audit.metadata["principal_user_id"] == principal.id
+  end
+
+  test "foreign accounts and principal credentials cannot manage a claimed key", %{conn: conn} do
+    owner = insert_verified_user()
+    {_principal, key, raw} = claimed_key(owner)
+    {_other_key, other} = insert_api_key(insert_verified_user())
+
+    assert conn
+           |> authed_with_key(other)
+           |> delete("/api/auth/api-keys/#{key.id}")
+           |> json_response(404)
+
+    assert conn |> authed_with_key(raw) |> get("/api/auth/api-keys") |> json_response(403)
+
+    assert conn
+           |> authed_with_key(raw)
+           |> delete("/api/auth/api-keys/#{key.id}")
+           |> json_response(403)
+
+    assert {:ok, _, _} = Accounts.authenticate_api_key(raw)
+  end
 
   describe "POST /api/auth/api-keys" do
     test "creates a key and returns it in full once", %{conn: conn} do

--- a/apps/fountain/test/fountain_web/live/api_keys_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/api_keys_live_test.exs
@@ -5,6 +5,23 @@ defmodule FountainWeb.ApiKeysLiveTest do
 
   alias Fountain.Accounts
 
+  test "the owner can revoke a claimed principal from the console", %{conn: conn} do
+    owner = insert_verified_user()
+    app = insert_verified_user()
+
+    {:ok, opened} =
+      Fountain.Principals.create_claimable(app, %{"application_id" => "console-test"})
+
+    {:ok, claimed} = Fountain.Principals.claim(opened.claimable.id, opened.claim_token, owner)
+    {:ok, _, key} = Accounts.authenticate_api_key(claimed.api_key)
+    {:ok, view, html} = conn |> login_user(owner) |> live(~p"/api-keys")
+    assert html =~ "principal:console-test"
+    assert html =~ "Principal"
+    view |> element("button[phx-click=revoke][phx-value-id='#{key.id}']") |> render_click()
+    assert {:error, :revoked} = Accounts.authenticate_api_key(claimed.api_key)
+    refute render(view) =~ "principal:console-test"
+  end
+
   describe "ApiKeysLive.Index — rendering" do
     test "shows existing active keys", %{conn: conn} do
       user = insert_verified_user()


### PR DESCRIPTION
A claimed principal's credential belonged to the principal user, so its owner could neither find nor revoke it. Add explicit management queries for the owner's own keys and principal-scoped credentials of its claimed principals, then use them in the existing API and console. Revocation records an owner-visible audit event identifying the principal. The console marks principal credentials.

Owner-management unit of #1688, stacked on #1930 so subsequent rotation and renewal changes share the credential transaction boundary. Six files, +152/-7, including the audit guardrail. Expiry and claim replay rotation remain separate. Existing tenant-only helpers and principal key-management scope restrictions remain; callback credentials are excluded from the owner's additional key view.

Validation: API and console regressions fail on the parent (27 tests, 2 failures). All 127 focused API, LiveView, scope and audit-guardrail tests pass, covering foreign-account and principal self-management refusals, callback exclusion, metadata-only listing, effective revocation and owner auditing. Full local precommit passed: 5,381 core tests + 6 doctests, 144 Buzz tests and 33 Support tests, all with zero failures.
