### PR TITLE
fix(auth): rotate principal credentials atomically on claim replay

### DIFF
--- a/apps/fountain/lib/fountain/accounts.ex
+++ b/apps/fountain/lib/fountain/accounts.ex
@@ -921,6 +921,56 @@ defmodule Fountain.Accounts do
     |> Repo.all()
   end
 
+  @doc "Active keys the account manages: its own keys and its claimed principals' credentials."
+  def list_managed_api_keys(user_id) when is_binary(user_id) do
+    user_id
+    |> managed_api_keys()
+    |> where([k], is_nil(k.revoked_at))
+    |> order_by([k], desc: k.inserted_at)
+    |> Repo.all()
+  end
+
+  @doc "Revoke an owned or claimed-principal credential, with a trail the managing owner can read."
+  def revoke_managed_api_key(user_id, key_id, opts \\ []) do
+    case user_id |> managed_api_keys() |> where([k], k.id == ^key_id) |> Repo.one() do
+      nil ->
+        {:error, :not_found}
+
+      key ->
+        with {:ok, revoked} <- revoke_api_key(key.user_id, key.id, opts) do
+          if key.user_id != user_id do
+            Audit.record(%{
+              user_id: user_id,
+              action: "api_key.revoked",
+              resource_type: "api_key",
+              resource_id: key.id,
+              actor: Keyword.get(opts, :actor, "self"),
+              request_ip: Keyword.get(opts, :request_ip),
+              metadata: %{
+                "name" => key.name,
+                "key_prefix" => key.key_prefix,
+                "principal_user_id" => key.user_id
+              }
+            })
+          end
+
+          {:ok, revoked}
+        end
+    end
+  end
+
+  defp managed_api_keys(user_id) do
+    principals =
+      from o in Fountain.Principals.Owner,
+        where: o.owner_user_id == ^user_id,
+        select: o.principal_user_id
+
+    from k in ApiKey,
+      where:
+        k.user_id == ^user_id or
+          ("principal" in k.scopes and k.user_id in subquery(principals))
+  end
+
   @doc "List all users, ordered by insertion date."
   def list_users do
     from(u in User, order_by: [asc: u.inserted_at]) |> Repo.all()

--- a/apps/fountain/lib/fountain/accounts.ex
+++ b/apps/fountain/lib/fountain/accounts.ex
@@ -730,10 +730,18 @@ defmodule Fountain.Accounts do
         key
         |> Ecto.Changeset.change(revoked_at: DateTime.utc_now() |> DateTime.truncate(:second))
         |> Repo.update()
-        |> audited_account("api_key.revoked", "api_key", opts, fn revoked ->
-          %{"name" => revoked.name, "key_prefix" => revoked.key_prefix}
-        end)
+        |> case do
+          {:ok, revoked} -> record_api_key_revoked(revoked, opts)
+          error -> error
+        end
     end
+  end
+
+  @doc "Audit a committed key revocation outside the transaction that changed it."
+  def record_api_key_revoked(%ApiKey{} = key, opts \\ []) do
+    audited_account({:ok, key}, "api_key.revoked", "api_key", opts, fn revoked ->
+      %{"name" => revoked.name, "key_prefix" => revoked.key_prefix}
+    end)
   end
 
   @doc """

--- a/apps/fountain/lib/fountain/principals.ex
+++ b/apps/fountain/lib/fountain/principals.ex
@@ -588,12 +588,12 @@ defmodule Fountain.Principals do
   defp revoke_claimed_credentials(user_id) do
     query =
       from k in ApiKey,
-        where: k.user_id == ^user_id and "principal" in k.scopes and is_nil(k.revoked_at)
+        where: k.user_id == ^user_id and "principal" in k.scopes and is_nil(k.revoked_at),
+        select: k
 
-    keys = Repo.all(query)
     now = DateTime.utc_now() |> truncate()
-    Repo.update_all(query, set: [revoked_at: now])
-    Enum.map(keys, &%{&1 | revoked_at: now})
+    {_count, keys} = Repo.update_all(query, set: [revoked_at: now])
+    keys
   end
 
   defp lock_claimable(id) do

--- a/apps/fountain/lib/fountain/principals.ex
+++ b/apps/fountain/lib/fountain/principals.ex
@@ -496,14 +496,6 @@ defmodule Fountain.Principals do
   # after a claim the grant's deadline describes nothing — the principal is an
   # ordinary tenant of the account that owns it — and a key that expired at it
   # would take a live machine away from its new owner, usually within hours.
-  defp mint_principal_key(%ClaimableUser{} = claimable, opts) do
-    Accounts.create_api_key(
-      claimable.user_id,
-      key_name(claimable),
-      principal_key_opts(claimable, opts)
-    )
-  end
-
   defp principal_key_opts(claimable, opts) do
     [
       scopes: ["principal"],
@@ -527,7 +519,8 @@ defmodule Fountain.Principals do
 
   `opts` carries `:idempotency_key` plus audit attribution. Replaying a
   successful claim with the same key **and** the same claimer returns the same
-  outcome with a fresh credential; any other repeat is
+  outcome with a fresh credential and revokes the previous principal
+  credential atomically. Runtime callback keys remain valid. Any other repeat is
   `{:error, :already_claimed}`.
 
   Errors: `:not_found`, `:invalid_claim_token`, `:already_claimed`,
@@ -539,8 +532,12 @@ defmodule Fountain.Principals do
           {:ok, %{claimable: ClaimableUser.t(), api_key: String.t()}} | {:error, term()}
   def claim(id, claim_token, %User{} = claimer, opts \\ []) when is_binary(id) do
     with :ok <- check_claimer_eligible(claimer),
-         {:ok, {claimable, replay?}} <- attach_owner(id, claim_token, claimer, opts),
-         {:ok, {_key, raw}} <- mint_principal_key(claimable, opts) do
+         {:ok, {claimable, replay?, key, raw, revoked}} <-
+           claim_with_credential(id, claim_token, claimer, opts) do
+      key_opts = principal_key_opts(claimable, opts)
+      Enum.each(revoked, &Accounts.record_api_key_revoked(&1, key_opts))
+      Accounts.record_api_key_created(key, key_opts)
+
       if not replay? do
         settle_grant(claimable, opts)
         record_claim(claimable, claimer, opts)
@@ -566,13 +563,37 @@ defmodule Fountain.Principals do
   # One transaction, one row lock. The expirer takes the same lock, so a claim
   # that beats it by a millisecond is a claim, and two competing claims are one
   # success and one `:already_claimed`.
-  defp attach_owner(id, claim_token, %User{} = claimer, opts) do
+  defp claim_with_credential(id, claim_token, %User{} = claimer, opts) do
     Repo.transaction(fn ->
-      case lock_claimable(id) do
-        nil -> Repo.rollback(:not_found)
-        %ClaimableUser{} = c -> decide_claim(c, claim_token, claimer, opts)
+      current = lock_claimable(id) || Repo.rollback(:not_found)
+      {claimable, replay?} = decide_claim(current, claim_token, claimer, opts)
+      revoked = if replay?, do: revoke_claimed_credentials(claimable.user_id), else: []
+
+      {changeset, raw} =
+        Accounts.build_api_key(
+          claimable.user_id,
+          key_name(claimable),
+          principal_key_opts(claimable, opts)
+        )
+
+      case Repo.insert(changeset) do
+        {:ok, key} -> {claimable, replay?, key, raw, revoked}
+        {:error, changeset} -> Repo.rollback(changeset)
       end
     end)
+  end
+
+  # A claimed replay rotates the caller's credential, not the runtime's
+  # callback keys. The claim-row lock serializes every replay's revoke + mint.
+  defp revoke_claimed_credentials(user_id) do
+    query =
+      from k in ApiKey,
+        where: k.user_id == ^user_id and "principal" in k.scopes and is_nil(k.revoked_at)
+
+    keys = Repo.all(query)
+    now = DateTime.utc_now() |> truncate()
+    Repo.update_all(query, set: [revoked_at: now])
+    Enum.map(keys, &%{&1 | revoked_at: now})
   end
 
   defp lock_claimable(id) do

--- a/apps/fountain/lib/fountain_web/controllers/api_key_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/api_key_controller.ex
@@ -33,7 +33,7 @@ defmodule FountainWeb.ApiKeyController do
 
   def index(conn, _params) do
     user = conn.assigns.current_user
-    render(conn, :index, keys: Accounts.list_api_keys(user.id))
+    render(conn, :index, keys: Accounts.list_managed_api_keys(user.id))
   end
 
   operation(:create,
@@ -95,7 +95,7 @@ defmodule FountainWeb.ApiKeyController do
   def delete(conn, %{"id" => id}) do
     user = conn.assigns.current_user
 
-    case Accounts.revoke_api_key(user.id, id, Audited.attribution(conn)) do
+    case Accounts.revoke_managed_api_key(user.id, id, Audited.attribution(conn)) do
       {:ok, _key} ->
         send_resp(conn, :no_content, "")
 

--- a/apps/fountain/lib/fountain_web/live/api_keys_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/api_keys_live/index.ex
@@ -7,7 +7,7 @@ defmodule FountainWeb.ApiKeysLive.Index do
   @impl true
   def mount(_params, _session, socket) do
     user = socket.assigns.current_user
-    keys = Accounts.list_api_keys(user.id)
+    keys = Accounts.list_managed_api_keys(user.id)
 
     {:ok,
      socket
@@ -30,7 +30,7 @@ defmodule FountainWeb.ApiKeysLive.Index do
       {:ok, {key, raw_token}} ->
         {:noreply,
          socket
-         |> assign(:keys, Accounts.list_api_keys(socket.assigns.user_id))
+         |> assign(:keys, Accounts.list_managed_api_keys(socket.assigns.user_id))
          |> assign(:new_key, %{key: key, raw_token: raw_token})}
 
       {:error, _cs} ->
@@ -46,7 +46,7 @@ defmodule FountainWeb.ApiKeysLive.Index do
     # `revoke_api_key/3` records `api_key.revoked` itself now (#552), the same
     # move the mint made in #542 — so this surface owes the trail only who was
     # on the socket, and its own `from_socket` call had to go with it.
-    case Accounts.revoke_api_key(
+    case Accounts.revoke_managed_api_key(
            socket.assigns.user_id,
            id,
            FountainWeb.Audited.attribution(socket)
@@ -54,7 +54,7 @@ defmodule FountainWeb.ApiKeysLive.Index do
       {:ok, _revoked} ->
         {:noreply,
          socket
-         |> assign(:keys, Accounts.list_api_keys(socket.assigns.user_id))
+         |> assign(:keys, Accounts.list_managed_api_keys(socket.assigns.user_id))
          |> put_flash(:info, "Key revoked")}
 
       {:error, :not_found} ->
@@ -144,7 +144,12 @@ defmodule FountainWeb.ApiKeysLive.Index do
             :for={k <- @keys}
             class="border-b border-[var(--color-border)] last:border-0 hover:bg-[var(--color-bg-2)]"
           >
-            <td class="px-4 py-2 font-medium">{k.name}</td>
+            <td class="px-4 py-2 font-medium">
+              {k.name}
+              <span :if={k.user_id != @user_id} class="text-xs text-[var(--color-text-muted)]">
+                Principal
+              </span>
+            </td>
             <td class="px-4 py-2 font-mono text-[var(--color-text-muted)] text-xs">
               {k.key_prefix}···
             </td>

--- a/apps/fountain/test/fountain/audit_guardrail_test.exs
+++ b/apps/fountain/test/fountain/audit_guardrail_test.exs
@@ -58,6 +58,7 @@ defmodule Fountain.AuditGuardrailTest do
     {"vault delete", &__MODULE__.do_vault_delete/1, "vault.deleted"},
     {"api key mint", &__MODULE__.do_key_create/1, "api_key.created"},
     {"api key revoke", &__MODULE__.do_key_revoke/1, "api_key.revoked"},
+    {"managed principal key revoke", &__MODULE__.do_managed_key_revoke/1, "api_key.revoked"},
     {"inference credential write", &__MODULE__.do_cred_write/1, "inference_credential.write"},
     {"inference credential clear", &__MODULE__.do_cred_clear/1, "inference_credential.delete"},
     {"conversation delete", &__MODULE__.do_conv_delete/1, "conversation.deleted"},
@@ -413,6 +414,14 @@ defmodule Fountain.AuditGuardrailTest do
   def do_key_revoke(user) do
     {:ok, {key, _}} = Fountain.Accounts.create_api_key(user.id, "guard-revoke")
     {:ok, _} = Fountain.Accounts.revoke_api_key(user.id, key.id)
+  end
+
+  def do_managed_key_revoke(user) do
+    app = insert_verified_user()
+    {:ok, opened} = Principals.create_claimable(app, %{"application_id" => "audit-guard"})
+    {:ok, claimed} = Principals.claim(opened.claimable.id, opened.claim_token, user)
+    {:ok, _, key} = Fountain.Accounts.authenticate_api_key(claimed.api_key)
+    {:ok, _} = Fountain.Accounts.revoke_managed_api_key(user.id, key.id)
   end
 
   def do_cred_write(user) do

--- a/apps/fountain/test/fountain/principals_claim_replay_test.exs
+++ b/apps/fountain/test/fountain/principals_claim_replay_test.exs
@@ -138,6 +138,103 @@ defmodule Fountain.PrincipalsClaimReplayTest do
     end)
   end
 
+  test "concurrent claim replays leave one principal credential" do
+    {application, owner, opened, first} =
+      Sandbox.unboxed_run(Repo, fn ->
+        application = insert_verified_user()
+        owner = insert_verified_user()
+
+        {:ok, opened} =
+          Principals.create_claimable(application, %{"application_id" => "rotation"})
+
+        {:ok, first} =
+          Principals.claim(opened.claimable.id, opened.claim_token, owner,
+            idempotency_key: "rotate"
+          )
+
+        {application, owner, opened, first}
+      end)
+
+    on_exit(fn ->
+      Sandbox.unboxed_run(Repo, fn ->
+        ids = [application.id, owner.id, opened.claimable.user_id]
+        Repo.delete_all(from u in User, where: u.id in ^ids)
+      end)
+    end)
+
+    parent = self()
+
+    blocker =
+      Task.async(fn ->
+        Sandbox.unboxed_run(Repo, fn ->
+          Repo.transaction(fn ->
+            Repo.one!(
+              from c in ClaimableUser, where: c.id == ^opened.claimable.id, lock: "FOR UPDATE"
+            )
+
+            send(parent, :locked)
+
+            receive do
+              :release -> :ok
+            after
+              10_000 -> Repo.rollback(:test_release_timeout)
+            end
+          end)
+        end)
+      end)
+
+    assert_receive :locked, 5_000
+
+    replays =
+      for _ <- 1..2 do
+        Task.async(fn ->
+          Sandbox.unboxed_run(Repo, fn ->
+            %{rows: [[backend]]} = Repo.query!("SELECT pg_backend_pid()")
+            send(parent, {:rotation_backend, backend})
+            Principals.claim(opened.claimable.id, "", owner, idempotency_key: "rotate")
+          end)
+        end)
+      end
+
+    try do
+      for _ <- replays do
+        assert_receive {:rotation_backend, backend}, 5_000
+        assert waits_for_lock?(backend, System.monotonic_time(:millisecond) + 5_000)
+      end
+
+      send(blocker.pid, :release)
+      assert {:ok, :ok} = Task.await(blocker, 5_000)
+
+      results =
+        Enum.map(replays, fn task ->
+          assert {:ok, result} = Task.await(task, 5_000)
+          result
+        end)
+
+      Sandbox.unboxed_run(Repo, fn ->
+        assert {:error, :revoked} = Accounts.authenticate_api_key(first.api_key)
+
+        assert Enum.count(
+                 results,
+                 &match?({:ok, _, _}, Accounts.authenticate_api_key(&1.api_key))
+               ) == 1
+
+        assert Repo.aggregate(
+                 from(k in ApiKey,
+                   where:
+                     k.user_id == ^opened.claimable.user_id and "principal" in k.scopes and
+                       is_nil(k.revoked_at)
+                 ),
+                 :count
+               ) == 1
+      end)
+    after
+      send(blocker.pid, :release)
+      Task.shutdown(blocker, :brutal_kill)
+      Enum.each(replays, &Task.shutdown(&1, :brutal_kill))
+    end
+  end
+
   defp waits_for_lock?(backend, deadline) do
     waiting =
       Sandbox.unboxed_run(Repo, fn ->

--- a/apps/fountain/test/fountain/principals_test.exs
+++ b/apps/fountain/test/fountain/principals_test.exs
@@ -8,6 +8,7 @@ defmodule Fountain.PrincipalsTest do
   """
 
   use Fountain.DataCase, async: true
+  use Mimic
 
   alias Fountain.Accounts
   alias Fountain.Credits
@@ -334,14 +335,45 @@ defmodule Fountain.PrincipalsTest do
       opts = [idempotency_key: "claim_1"]
 
       {:ok, first} = Principals.claim(ctx.claimable.id, ctx.token, claimer, opts)
+      {:ok, _, first_key} = Accounts.authenticate_api_key(first.api_key)
+
+      {:ok, {callback, _}} =
+        Accounts.create_api_key(first.claimable.user_id, "callback", scopes: ["sprite"])
+
       {:ok, second} = Principals.claim(ctx.claimable.id, ctx.token, claimer, opts)
 
+      assert {:error, :revoked} = Accounts.authenticate_api_key(first.api_key)
+      assert {:ok, _, _} = Accounts.authenticate_api_key(second.api_key)
+      assert is_nil(Repo.reload!(callback).revoked_at)
+
+      assert [audit] =
+               Repo.all(
+                 from a in Fountain.Audit.Event,
+                   where: a.resource_id == ^first_key.id and a.action == "api_key.revoked"
+               )
+
+      assert audit.user_id == first.claimable.user_id
       assert first.claimable.id == second.claimable.id
       refute first.api_key == second.api_key
 
       # A different key from the same account is not a replay.
       assert {:error, :already_claimed} =
                Principals.claim(ctx.claimable.id, ctx.token, claimer, idempotency_key: "other")
+    end
+
+    test "a failed credential mint rolls back the owner attachment and anonymous-key revocation",
+         ctx do
+      claimer = insert_verified_user()
+
+      stub(Accounts, :build_api_key, fn user_id, name, opts ->
+        {changeset, raw} = Mimic.call_original(Accounts, :build_api_key, [user_id, name, opts])
+        {Ecto.Changeset.add_error(changeset, :name, "mint refused"), raw}
+      end)
+
+      assert {:error, %Ecto.Changeset{}} = Principals.claim(ctx.claimable.id, ctx.token, claimer)
+      assert Repo.get!(ClaimableUser, ctx.claimable.id).status == "unclaimed"
+      assert is_nil(Principals.owner_id(ctx.claimable.user_id))
+      assert {:ok, _, _} = Accounts.authenticate_api_key(ctx.anon_key)
     end
 
     test "an account that cannot fund future work is refused without mutating", ctx do

--- a/apps/fountain/test/fountain_web/controllers/api_key_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/api_key_controller_test.exs
@@ -2,7 +2,71 @@ defmodule FountainWeb.ApiKeyControllerTest do
   use FountainWeb.ConnCase, async: true
   use Mimic
 
+  import Ecto.Query
+
   alias Fountain.Accounts
+  alias Fountain.Repo
+
+  defp claimed_key(owner) do
+    app = insert_verified_user()
+    {:ok, opened} = Fountain.Principals.create_claimable(app, %{"application_id" => "test-app"})
+    {:ok, claimed} = Fountain.Principals.claim(opened.claimable.id, opened.claim_token, owner)
+    {:ok, principal, key} = Accounts.authenticate_api_key(claimed.api_key)
+    {principal, key, claimed.api_key}
+  end
+
+  test "the owner lists and revokes its principal credential with an owner-visible audit", %{
+    conn: conn
+  } do
+    owner = insert_verified_user()
+    {own_key, auth} = insert_api_key(owner)
+    {principal, key, raw} = claimed_key(owner)
+    {_foreign, foreign_key, _} = claimed_key(insert_verified_user())
+    {:ok, {callback, _}} = Accounts.create_api_key(principal.id, "callback", scopes: ["sprite"])
+
+    response = conn |> authed_with_key(auth) |> get("/api/auth/api-keys") |> json_response(200)
+    ids = Enum.map(response["data"], & &1["id"])
+    assert own_key.id in ids
+    assert key.id in ids
+    refute foreign_key.id in ids
+    refute callback.id in ids
+    refute inspect(response) =~ raw
+
+    assert %{status: 204} =
+             conn |> authed_with_key(auth) |> delete("/api/auth/api-keys/#{key.id}")
+
+    assert {:error, :revoked} = Accounts.authenticate_api_key(raw)
+
+    assert [audit] =
+             Repo.all(
+               from a in Fountain.Audit.Event,
+                 where:
+                   a.user_id == ^owner.id and a.resource_id == ^key.id and
+                     a.action == "api_key.revoked"
+             )
+
+    assert audit.metadata["principal_user_id"] == principal.id
+  end
+
+  test "foreign accounts and principal credentials cannot manage a claimed key", %{conn: conn} do
+    owner = insert_verified_user()
+    {_principal, key, raw} = claimed_key(owner)
+    {_other_key, other} = insert_api_key(insert_verified_user())
+
+    assert conn
+           |> authed_with_key(other)
+           |> delete("/api/auth/api-keys/#{key.id}")
+           |> json_response(404)
+
+    assert conn |> authed_with_key(raw) |> get("/api/auth/api-keys") |> json_response(403)
+
+    assert conn
+           |> authed_with_key(raw)
+           |> delete("/api/auth/api-keys/#{key.id}")
+           |> json_response(403)
+
+    assert {:ok, _, _} = Accounts.authenticate_api_key(raw)
+  end
 
   describe "POST /api/auth/api-keys" do
     test "creates a key and returns it in full once", %{conn: conn} do

--- a/apps/fountain/test/fountain_web/live/api_keys_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/api_keys_live_test.exs
@@ -5,6 +5,23 @@ defmodule FountainWeb.ApiKeysLiveTest do
 
   alias Fountain.Accounts
 
+  test "the owner can revoke a claimed principal from the console", %{conn: conn} do
+    owner = insert_verified_user()
+    app = insert_verified_user()
+
+    {:ok, opened} =
+      Fountain.Principals.create_claimable(app, %{"application_id" => "console-test"})
+
+    {:ok, claimed} = Fountain.Principals.claim(opened.claimable.id, opened.claim_token, owner)
+    {:ok, _, key} = Accounts.authenticate_api_key(claimed.api_key)
+    {:ok, view, html} = conn |> login_user(owner) |> live(~p"/api-keys")
+    assert html =~ "principal:console-test"
+    assert html =~ "Principal"
+    view |> element("button[phx-click=revoke][phx-value-id='#{key.id}']") |> render_click()
+    assert {:error, :revoked} = Accounts.authenticate_api_key(claimed.api_key)
+    refute render(view) =~ "principal:console-test"
+  end
+
   describe "ApiKeysLive.Index — rendering" do
     test "shows existing active keys", %{conn: conn} do
       user = insert_verified_user()


### PR DESCRIPTION
Replaying a successful claim left both the previous and new principal credentials active. Serialize the revoke and mint under the claim-row lock, so concurrent claim replays leave one usable principal credential. A failed first mint now rolls back ownership attachment and anonymous-key revocation together. Runtime callback credentials survive replay; credential audit records are written after commit.

Rotation unit of #1688, stacked on #1949. Four files, +176/-18. Owner renewal and bounded expiry follow as separate small units.

Validation: three regressions fail on the parent: retained old credentials, ownership committed despite a failed mint, and multiple active credentials after concurrent replay. The race uses independent PostgreSQL connections and verifies both operations wait on the claim lock. All 175 focused principal, race, API, console, scope and audit-guardrail tests pass; the final update-returning refinement also passes all 48 principal/race tests. Full local precommit passed: 5,383 core tests + 6 doctests, 144 Buzz tests and 33 Support tests, all with zero failures.
