### PR TITLE
feat(auth): let owners renew claimed principal credentials

### DIFF
--- a/apps/fountain/lib/fountain/accounts.ex
+++ b/apps/fountain/lib/fountain/accounts.ex
@@ -730,10 +730,18 @@ defmodule Fountain.Accounts do
         key
         |> Ecto.Changeset.change(revoked_at: DateTime.utc_now() |> DateTime.truncate(:second))
         |> Repo.update()
-        |> audited_account("api_key.revoked", "api_key", opts, fn revoked ->
-          %{"name" => revoked.name, "key_prefix" => revoked.key_prefix}
-        end)
+        |> case do
+          {:ok, revoked} -> record_api_key_revoked(revoked, opts)
+          error -> error
+        end
     end
+  end
+
+  @doc "Audit a committed key revocation outside the transaction that changed it."
+  def record_api_key_revoked(%ApiKey{} = key, opts \\ []) do
+    audited_account({:ok, key}, "api_key.revoked", "api_key", opts, fn revoked ->
+      %{"name" => revoked.name, "key_prefix" => revoked.key_prefix}
+    end)
   end
 
   @doc """

--- a/apps/fountain/lib/fountain/principals.ex
+++ b/apps/fountain/lib/fountain/principals.ex
@@ -569,18 +569,78 @@ defmodule Fountain.Principals do
       {claimable, replay?} = decide_claim(current, claim_token, claimer, opts)
       revoked = if replay?, do: revoke_claimed_credentials(claimable.user_id), else: []
 
-      {changeset, raw} =
-        Accounts.build_api_key(
-          claimable.user_id,
-          key_name(claimable),
-          principal_key_opts(claimable, opts)
-        )
-
-      case Repo.insert(changeset) do
-        {:ok, key} -> {claimable, replay?, key, raw, revoked}
-        {:error, changeset} -> Repo.rollback(changeset)
-      end
+      {key, raw} = insert_principal_key(claimable, opts)
+      {claimable, replay?, key, raw, revoked}
     end)
+  end
+
+  @doc """
+  Replace a claimed principal's credential using its current owner's authority.
+
+  Works without the original claim token or idempotency key, including after
+  expiry or revocation. The claim lock serializes renewal with claim replay.
+  Revocation and minting commit together; runtime callback keys are untouched.
+  Returns `:not_found` for a principal the account does not own.
+  """
+  @spec renew_owned_credential(binary(), binary(), keyword()) ::
+          {:ok, {ApiKey.t(), String.t()}} | {:error, term()}
+  def renew_owned_credential(owner_user_id, principal_user_id, opts \\ []) do
+    result =
+      Repo.transaction(fn ->
+        owned =
+          from o in Owner,
+            where: o.owner_user_id == ^owner_user_id,
+            select: o.principal_user_id
+
+        claimable =
+          Repo.one(
+            from c in ClaimableUser,
+              where:
+                c.user_id == ^principal_user_id and c.user_id in subquery(owned) and
+                  c.status == "claimed",
+              lock: "FOR UPDATE"
+          ) || Repo.rollback(:not_found)
+
+        revoked = revoke_claimed_credentials(claimable.user_id)
+        {key, raw} = insert_principal_key(claimable, opts)
+        {claimable, key, raw, revoked}
+      end)
+
+    with {:ok, {claimable, key, raw, revoked}} <- result do
+      key_opts = principal_key_opts(claimable, opts)
+      Enum.each(revoked, &Accounts.record_api_key_revoked(&1, key_opts))
+      Accounts.record_api_key_created(key, key_opts)
+
+      Audit.record(%{
+        user_id: owner_user_id,
+        action: "api_key.created",
+        resource_type: "api_key",
+        resource_id: key.id,
+        actor: Keyword.get(opts, :actor, "self"),
+        request_ip: Keyword.get(opts, :request_ip),
+        metadata: %{
+          "principal_user_id" => principal_user_id,
+          "key_prefix" => key.key_prefix,
+          "revoked_key_ids" => Enum.map(revoked, & &1.id)
+        }
+      })
+
+      {:ok, {key, raw}}
+    end
+  end
+
+  defp insert_principal_key(claimable, opts) do
+    {changeset, raw} =
+      Accounts.build_api_key(
+        claimable.user_id,
+        key_name(claimable),
+        principal_key_opts(claimable, opts)
+      )
+
+    case Repo.insert(changeset) do
+      {:ok, key} -> {key, raw}
+      {:error, changeset} -> Repo.rollback(changeset)
+    end
   end
 
   # A claimed replay rotates the caller's credential, not the runtime's

--- a/apps/fountain/lib/fountain/principals.ex
+++ b/apps/fountain/lib/fountain/principals.ex
@@ -496,14 +496,6 @@ defmodule Fountain.Principals do
   # after a claim the grant's deadline describes nothing — the principal is an
   # ordinary tenant of the account that owns it — and a key that expired at it
   # would take a live machine away from its new owner, usually within hours.
-  defp mint_principal_key(%ClaimableUser{} = claimable, opts) do
-    Accounts.create_api_key(
-      claimable.user_id,
-      key_name(claimable),
-      principal_key_opts(claimable, opts)
-    )
-  end
-
   defp principal_key_opts(claimable, opts) do
     [
       scopes: ["principal"],
@@ -527,7 +519,8 @@ defmodule Fountain.Principals do
 
   `opts` carries `:idempotency_key` plus audit attribution. Replaying a
   successful claim with the same key **and** the same claimer returns the same
-  outcome with a fresh credential; any other repeat is
+  outcome with a fresh credential and revokes the previous principal
+  credential atomically. Runtime callback keys remain valid. Any other repeat is
   `{:error, :already_claimed}`.
 
   Errors: `:not_found`, `:invalid_claim_token`, `:already_claimed`,
@@ -539,8 +532,12 @@ defmodule Fountain.Principals do
           {:ok, %{claimable: ClaimableUser.t(), api_key: String.t()}} | {:error, term()}
   def claim(id, claim_token, %User{} = claimer, opts \\ []) when is_binary(id) do
     with :ok <- check_claimer_eligible(claimer),
-         {:ok, {claimable, replay?}} <- attach_owner(id, claim_token, claimer, opts),
-         {:ok, {_key, raw}} <- mint_principal_key(claimable, opts) do
+         {:ok, {claimable, replay?, key, raw, revoked}} <-
+           claim_with_credential(id, claim_token, claimer, opts) do
+      key_opts = principal_key_opts(claimable, opts)
+      Enum.each(revoked, &Accounts.record_api_key_revoked(&1, key_opts))
+      Accounts.record_api_key_created(key, key_opts)
+
       if not replay? do
         settle_grant(claimable, opts)
         record_claim(claimable, claimer, opts)
@@ -566,13 +563,37 @@ defmodule Fountain.Principals do
   # One transaction, one row lock. The expirer takes the same lock, so a claim
   # that beats it by a millisecond is a claim, and two competing claims are one
   # success and one `:already_claimed`.
-  defp attach_owner(id, claim_token, %User{} = claimer, opts) do
+  defp claim_with_credential(id, claim_token, %User{} = claimer, opts) do
     Repo.transaction(fn ->
-      case lock_claimable(id) do
-        nil -> Repo.rollback(:not_found)
-        %ClaimableUser{} = c -> decide_claim(c, claim_token, claimer, opts)
+      current = lock_claimable(id) || Repo.rollback(:not_found)
+      {claimable, replay?} = decide_claim(current, claim_token, claimer, opts)
+      revoked = if replay?, do: revoke_claimed_credentials(claimable.user_id), else: []
+
+      {changeset, raw} =
+        Accounts.build_api_key(
+          claimable.user_id,
+          key_name(claimable),
+          principal_key_opts(claimable, opts)
+        )
+
+      case Repo.insert(changeset) do
+        {:ok, key} -> {claimable, replay?, key, raw, revoked}
+        {:error, changeset} -> Repo.rollback(changeset)
       end
     end)
+  end
+
+  # A claimed replay rotates the caller's credential, not the runtime's
+  # callback keys. The claim-row lock serializes every replay's revoke + mint.
+  defp revoke_claimed_credentials(user_id) do
+    query =
+      from k in ApiKey,
+        where: k.user_id == ^user_id and "principal" in k.scopes and is_nil(k.revoked_at),
+        select: k
+
+    now = DateTime.utc_now() |> truncate()
+    {_count, keys} = Repo.update_all(query, set: [revoked_at: now])
+    keys
   end
 
   defp lock_claimable(id) do

--- a/apps/fountain/test/fountain/audit_guardrail_test.exs
+++ b/apps/fountain/test/fountain/audit_guardrail_test.exs
@@ -58,6 +58,8 @@ defmodule Fountain.AuditGuardrailTest do
     {"vault delete", &__MODULE__.do_vault_delete/1, "vault.deleted"},
     {"api key mint", &__MODULE__.do_key_create/1, "api_key.created"},
     {"api key revoke", &__MODULE__.do_key_revoke/1, "api_key.revoked"},
+    {"owned principal credential renewal", &__MODULE__.do_principal_key_renewal/1,
+     "api_key.created"},
     {"managed principal key revoke", &__MODULE__.do_managed_key_revoke/1, "api_key.revoked"},
     {"inference credential write", &__MODULE__.do_cred_write/1, "inference_credential.write"},
     {"inference credential clear", &__MODULE__.do_cred_clear/1, "inference_credential.delete"},
@@ -414,6 +416,13 @@ defmodule Fountain.AuditGuardrailTest do
   def do_key_revoke(user) do
     {:ok, {key, _}} = Fountain.Accounts.create_api_key(user.id, "guard-revoke")
     {:ok, _} = Fountain.Accounts.revoke_api_key(user.id, key.id)
+  end
+
+  def do_principal_key_renewal(user) do
+    app = insert_verified_user()
+    {:ok, opened} = Principals.create_claimable(app, %{"application_id" => "audit-renewal"})
+    {:ok, claimed} = Principals.claim(opened.claimable.id, opened.claim_token, user)
+    {:ok, _} = Principals.renew_owned_credential(user.id, claimed.claimable.user_id)
   end
 
   def do_managed_key_revoke(user) do

--- a/apps/fountain/test/fountain/principals_claim_replay_test.exs
+++ b/apps/fountain/test/fountain/principals_claim_replay_test.exs
@@ -139,6 +139,14 @@ defmodule Fountain.PrincipalsClaimReplayTest do
   end
 
   test "concurrent claim replays leave one principal credential" do
+    assert_one_credential_after_rotation(:replay)
+  end
+
+  test "owner renewal and claim replay serialize their credential replacement" do
+    assert_one_credential_after_rotation(:renewal)
+  end
+
+  defp assert_one_credential_after_rotation(second_operation) do
     {application, owner, opened, first} =
       Sandbox.unboxed_run(Repo, fn ->
         application = insert_verified_user()
@@ -186,12 +194,22 @@ defmodule Fountain.PrincipalsClaimReplayTest do
     assert_receive :locked, 5_000
 
     replays =
-      for _ <- 1..2 do
+      for operation <- [:replay, second_operation] do
         Task.async(fn ->
           Sandbox.unboxed_run(Repo, fn ->
             %{rows: [[backend]]} = Repo.query!("SELECT pg_backend_pid()")
             send(parent, {:rotation_backend, backend})
-            Principals.claim(opened.claimable.id, "", owner, idempotency_key: "rotate")
+
+            case operation do
+              :replay ->
+                Principals.claim(opened.claimable.id, "", owner, idempotency_key: "rotate")
+
+              :renewal ->
+                with {:ok, {_key, raw}} <-
+                       Principals.renew_owned_credential(owner.id, opened.claimable.user_id) do
+                  {:ok, %{api_key: raw}}
+                end
+            end
           end)
         end)
       end

--- a/apps/fountain/test/fountain/principals_claim_replay_test.exs
+++ b/apps/fountain/test/fountain/principals_claim_replay_test.exs
@@ -138,6 +138,103 @@ defmodule Fountain.PrincipalsClaimReplayTest do
     end)
   end
 
+  test "concurrent claim replays leave one principal credential" do
+    {application, owner, opened, first} =
+      Sandbox.unboxed_run(Repo, fn ->
+        application = insert_verified_user()
+        owner = insert_verified_user()
+
+        {:ok, opened} =
+          Principals.create_claimable(application, %{"application_id" => "rotation"})
+
+        {:ok, first} =
+          Principals.claim(opened.claimable.id, opened.claim_token, owner,
+            idempotency_key: "rotate"
+          )
+
+        {application, owner, opened, first}
+      end)
+
+    on_exit(fn ->
+      Sandbox.unboxed_run(Repo, fn ->
+        ids = [application.id, owner.id, opened.claimable.user_id]
+        Repo.delete_all(from u in User, where: u.id in ^ids)
+      end)
+    end)
+
+    parent = self()
+
+    blocker =
+      Task.async(fn ->
+        Sandbox.unboxed_run(Repo, fn ->
+          Repo.transaction(fn ->
+            Repo.one!(
+              from c in ClaimableUser, where: c.id == ^opened.claimable.id, lock: "FOR UPDATE"
+            )
+
+            send(parent, :locked)
+
+            receive do
+              :release -> :ok
+            after
+              10_000 -> Repo.rollback(:test_release_timeout)
+            end
+          end)
+        end)
+      end)
+
+    assert_receive :locked, 5_000
+
+    replays =
+      for _ <- 1..2 do
+        Task.async(fn ->
+          Sandbox.unboxed_run(Repo, fn ->
+            %{rows: [[backend]]} = Repo.query!("SELECT pg_backend_pid()")
+            send(parent, {:rotation_backend, backend})
+            Principals.claim(opened.claimable.id, "", owner, idempotency_key: "rotate")
+          end)
+        end)
+      end
+
+    try do
+      for _ <- replays do
+        assert_receive {:rotation_backend, backend}, 5_000
+        assert waits_for_lock?(backend, System.monotonic_time(:millisecond) + 5_000)
+      end
+
+      send(blocker.pid, :release)
+      assert {:ok, :ok} = Task.await(blocker, 5_000)
+
+      results =
+        Enum.map(replays, fn task ->
+          assert {:ok, result} = Task.await(task, 5_000)
+          result
+        end)
+
+      Sandbox.unboxed_run(Repo, fn ->
+        assert {:error, :revoked} = Accounts.authenticate_api_key(first.api_key)
+
+        assert Enum.count(
+                 results,
+                 &match?({:ok, _, _}, Accounts.authenticate_api_key(&1.api_key))
+               ) == 1
+
+        assert Repo.aggregate(
+                 from(k in ApiKey,
+                   where:
+                     k.user_id == ^opened.claimable.user_id and "principal" in k.scopes and
+                       is_nil(k.revoked_at)
+                 ),
+                 :count
+               ) == 1
+      end)
+    after
+      send(blocker.pid, :release)
+      Task.shutdown(blocker, :brutal_kill)
+      Enum.each(replays, &Task.shutdown(&1, :brutal_kill))
+    end
+  end
+
   defp waits_for_lock?(backend, deadline) do
     waiting =
       Sandbox.unboxed_run(Repo, fn ->

--- a/apps/fountain/test/fountain/principals_test.exs
+++ b/apps/fountain/test/fountain/principals_test.exs
@@ -403,6 +403,110 @@ defmodule Fountain.PrincipalsTest do
     end
   end
 
+  describe "renew_owned_credential/3" do
+    setup do
+      owner = insert_verified_user()
+      opened = open(application_account())
+      {:ok, claimed} = Principals.claim(opened.claimable.id, opened.claim_token, owner)
+      {:ok, _, key} = Accounts.authenticate_api_key(claimed.api_key)
+      %{owner: owner, opened: opened, claimed: claimed, key: key}
+    end
+
+    test "the owner renews without the claim token, rotating only principal credentials", ctx do
+      principal_id = ctx.claimed.claimable.user_id
+      {:ok, {callback, _}} = Accounts.create_api_key(principal_id, "callback", scopes: ["sprite"])
+
+      assert {:ok, {key, raw}} =
+               Principals.renew_owned_credential(ctx.owner.id, principal_id,
+                 actor: "ui",
+                 request_ip: "127.0.0.1"
+               )
+
+      assert key.user_id == principal_id
+      assert key.scopes == ["principal"]
+      assert {:ok, _, _} = Accounts.authenticate_api_key(raw)
+      assert {:error, :revoked} = Accounts.authenticate_api_key(ctx.claimed.api_key)
+      assert is_nil(Repo.reload!(callback).revoked_at)
+      assert Principals.owner_id(principal_id) == ctx.owner.id
+
+      assert [audit] =
+               Repo.all(
+                 from a in Fountain.Audit.Event,
+                   where: a.user_id == ^ctx.owner.id and a.action == "api_key.created"
+               )
+
+      assert audit.resource_id == key.id
+      assert audit.actor == "ui"
+      assert audit.metadata["principal_user_id"] == principal_id
+      assert audit.metadata["revoked_key_ids"] == [ctx.key.id]
+      refute inspect(audit.metadata) =~ raw
+    end
+
+    test "expired and then explicitly revoked credentials can be replaced", ctx do
+      past = DateTime.utc_now() |> DateTime.add(-60) |> DateTime.truncate(:second)
+      ctx.key |> Ecto.Changeset.change(expires_at: past) |> Repo.update!()
+      assert {:error, :expired} = Accounts.authenticate_api_key(ctx.claimed.api_key)
+      principal_id = ctx.claimed.claimable.user_id
+
+      assert {:ok, {key, raw}} = Principals.renew_owned_credential(ctx.owner.id, principal_id)
+      assert {:ok, _, _} = Accounts.authenticate_api_key(raw)
+      {:ok, _} = Accounts.revoke_managed_api_key(ctx.owner.id, key.id)
+
+      assert {:ok, {_, replacement}} =
+               Principals.renew_owned_credential(ctx.owner.id, principal_id)
+
+      assert {:ok, _, _} = Accounts.authenticate_api_key(replacement)
+    end
+
+    test "renewal does not require a spending balance", ctx do
+      owner = ctx.owner
+
+      {:ok, _} =
+        Credits.debit(owner.id, Credits.balance(owner.id), "burn_turn",
+          idempotency_key: "renewal-drain:#{owner.id}"
+        )
+
+      assert {:error, :insufficient_credits} = Fountain.Billing.check_spend(owner.id)
+      assert {:ok, _} = Principals.renew_owned_credential(owner.id, ctx.claimed.claimable.user_id)
+    end
+
+    test "the application, another account and the principal cannot renew", ctx do
+      principal_id = ctx.claimed.claimable.user_id
+      other = insert_verified_user()
+
+      for viewer_id <- [ctx.opened.claimable.application_user_id, other.id, principal_id] do
+        assert {:error, :not_found} = Principals.renew_owned_credential(viewer_id, principal_id)
+      end
+
+      unclaimed = open(application_account())
+
+      assert {:error, :not_found} =
+               Principals.renew_owned_credential(ctx.owner.id, unclaimed.claimable.user_id)
+
+      assert {:error, :not_found} =
+               Principals.renew_owned_credential(ctx.owner.id, Ecto.UUID.generate())
+
+      assert {:ok, _, _} = Accounts.authenticate_api_key(ctx.claimed.api_key)
+    end
+
+    test "a failed mint keeps the previous credential and emits no owner creation event", ctx do
+      stub(Accounts, :build_api_key, fn user_id, name, opts ->
+        {changeset, raw} = Mimic.call_original(Accounts, :build_api_key, [user_id, name, opts])
+        {Ecto.Changeset.add_error(changeset, :name, "mint refused"), raw}
+      end)
+
+      assert {:error, %Ecto.Changeset{}} =
+               Principals.renew_owned_credential(ctx.owner.id, ctx.claimed.claimable.user_id)
+
+      assert {:ok, _, _} = Accounts.authenticate_api_key(ctx.claimed.api_key)
+
+      refute Repo.exists?(
+               from a in Fountain.Audit.Event,
+                 where: a.user_id == ^ctx.owner.id and a.action == "api_key.created"
+             )
+    end
+  end
+
   describe "billing_subject_id/1" do
     test "an ordinary account is its own subject" do
       user = insert_verified_user()

--- a/apps/fountain/test/fountain/principals_test.exs
+++ b/apps/fountain/test/fountain/principals_test.exs
@@ -8,6 +8,7 @@ defmodule Fountain.PrincipalsTest do
   """
 
   use Fountain.DataCase, async: true
+  use Mimic
 
   alias Fountain.Accounts
   alias Fountain.Credits
@@ -334,14 +335,45 @@ defmodule Fountain.PrincipalsTest do
       opts = [idempotency_key: "claim_1"]
 
       {:ok, first} = Principals.claim(ctx.claimable.id, ctx.token, claimer, opts)
+      {:ok, _, first_key} = Accounts.authenticate_api_key(first.api_key)
+
+      {:ok, {callback, _}} =
+        Accounts.create_api_key(first.claimable.user_id, "callback", scopes: ["sprite"])
+
       {:ok, second} = Principals.claim(ctx.claimable.id, ctx.token, claimer, opts)
 
+      assert {:error, :revoked} = Accounts.authenticate_api_key(first.api_key)
+      assert {:ok, _, _} = Accounts.authenticate_api_key(second.api_key)
+      assert is_nil(Repo.reload!(callback).revoked_at)
+
+      assert [audit] =
+               Repo.all(
+                 from a in Fountain.Audit.Event,
+                   where: a.resource_id == ^first_key.id and a.action == "api_key.revoked"
+               )
+
+      assert audit.user_id == first.claimable.user_id
       assert first.claimable.id == second.claimable.id
       refute first.api_key == second.api_key
 
       # A different key from the same account is not a replay.
       assert {:error, :already_claimed} =
                Principals.claim(ctx.claimable.id, ctx.token, claimer, idempotency_key: "other")
+    end
+
+    test "a failed credential mint rolls back the owner attachment and anonymous-key revocation",
+         ctx do
+      claimer = insert_verified_user()
+
+      stub(Accounts, :build_api_key, fn user_id, name, opts ->
+        {changeset, raw} = Mimic.call_original(Accounts, :build_api_key, [user_id, name, opts])
+        {Ecto.Changeset.add_error(changeset, :name, "mint refused"), raw}
+      end)
+
+      assert {:error, %Ecto.Changeset{}} = Principals.claim(ctx.claimable.id, ctx.token, claimer)
+      assert Repo.get!(ClaimableUser, ctx.claimable.id).status == "unclaimed"
+      assert is_nil(Principals.owner_id(ctx.claimable.user_id))
+      assert {:ok, _, _} = Accounts.authenticate_api_key(ctx.anon_key)
     end
 
     test "an account that cannot fund future work is refused without mutating", ctx do

--- a/decisions/0044-claimable-principals.md
+++ b/decisions/0044-claimable-principals.md
@@ -123,7 +123,12 @@ abandoning what it already has.
    unique per application; the claim key is stored on success. Replaying either
    with the same key returns the same principal and mints a **fresh**
    credential, because the secret from the first response was never stored.
-   That is also the rotation path for a claimed principal's credential.
+   Claim replay revokes the previous principal credential atomically with the
+   new mint. An owner can also renew by principal id without the original
+   token or idempotency key, even after credential expiry or revocation.
+   Renewal takes the same claim-row lock and leaves runtime callback keys
+   alone. It records the new key and replaced key ids in the owner's audit
+   trail after commit.
 
 **The API is four routes**, all behind `:require_full_scope`:
 `POST /api/claimable-users`, `GET /api/claimable-users/:id`,


### PR DESCRIPTION
Owners who claimed without an idempotency key had no way to renew a lost or expired principal credential. Add an owner-scoped renewal operation addressed by principal id. It reads persisted ownership, takes the same claim-row lock as replay, and commits revocation plus replacement together. Renewal preserves runtime callback credentials, permits recovery without a spending balance, and records the new key and replaced key ids in the owner's audit trail after commit.

Context unit of #1688, stacked on #1950. Five files, +210/-14, including the ADR 0044 amendment and required audit guardrail. The console entry point and bounded expiry are separate small units.

Validation: all 135 focused principal, independent PostgreSQL race and audit-guardrail tests pass. Coverage includes no-token recovery after expiry/revocation, foreign-account/application/principal refusals, mint-failure rollback without a false audit, and concurrent owner renewal versus claim replay leaving one active credential. The decisions bundle validates and its regenerated index is unchanged; six existing trust-metadata warnings concern other ADRs. Full local precommit passed: 5,390 core tests + 6 doctests, 144 Buzz tests and 33 Support tests, all with zero failures.
