### PR TITLE
feat(console): recover claimed principal API keys

### DIFF
--- a/apps/fountain/lib/fountain/principals.ex
+++ b/apps/fountain/lib/fountain/principals.ex
@@ -569,18 +569,78 @@ defmodule Fountain.Principals do
       {claimable, replay?} = decide_claim(current, claim_token, claimer, opts)
       revoked = if replay?, do: revoke_claimed_credentials(claimable.user_id), else: []
 
-      {changeset, raw} =
-        Accounts.build_api_key(
-          claimable.user_id,
-          key_name(claimable),
-          principal_key_opts(claimable, opts)
-        )
-
-      case Repo.insert(changeset) do
-        {:ok, key} -> {claimable, replay?, key, raw, revoked}
-        {:error, changeset} -> Repo.rollback(changeset)
-      end
+      {key, raw} = insert_principal_key(claimable, opts)
+      {claimable, replay?, key, raw, revoked}
     end)
+  end
+
+  @doc """
+  Replace a claimed principal's credential using its current owner's authority.
+
+  Works without the original claim token or idempotency key, including after
+  expiry or revocation. The claim lock serializes renewal with claim replay.
+  Revocation and minting commit together; runtime callback keys are untouched.
+  Returns `:not_found` for a principal the account does not own.
+  """
+  @spec renew_owned_credential(binary(), binary(), keyword()) ::
+          {:ok, {ApiKey.t(), String.t()}} | {:error, term()}
+  def renew_owned_credential(owner_user_id, principal_user_id, opts \\ []) do
+    result =
+      Repo.transaction(fn ->
+        owned =
+          from o in Owner,
+            where: o.owner_user_id == ^owner_user_id,
+            select: o.principal_user_id
+
+        claimable =
+          Repo.one(
+            from c in ClaimableUser,
+              where:
+                c.user_id == ^principal_user_id and c.user_id in subquery(owned) and
+                  c.status == "claimed",
+              lock: "FOR UPDATE"
+          ) || Repo.rollback(:not_found)
+
+        revoked = revoke_claimed_credentials(claimable.user_id)
+        {key, raw} = insert_principal_key(claimable, opts)
+        {claimable, key, raw, revoked}
+      end)
+
+    with {:ok, {claimable, key, raw, revoked}} <- result do
+      key_opts = principal_key_opts(claimable, opts)
+      Enum.each(revoked, &Accounts.record_api_key_revoked(&1, key_opts))
+      Accounts.record_api_key_created(key, key_opts)
+
+      Audit.record(%{
+        user_id: owner_user_id,
+        action: "api_key.created",
+        resource_type: "api_key",
+        resource_id: key.id,
+        actor: Keyword.get(opts, :actor, "self"),
+        request_ip: Keyword.get(opts, :request_ip),
+        metadata: %{
+          "principal_user_id" => principal_user_id,
+          "key_prefix" => key.key_prefix,
+          "revoked_key_ids" => Enum.map(revoked, & &1.id)
+        }
+      })
+
+      {:ok, {key, raw}}
+    end
+  end
+
+  defp insert_principal_key(claimable, opts) do
+    {changeset, raw} =
+      Accounts.build_api_key(
+        claimable.user_id,
+        key_name(claimable),
+        principal_key_opts(claimable, opts)
+      )
+
+    case Repo.insert(changeset) do
+      {:ok, key} -> {key, raw}
+      {:error, changeset} -> Repo.rollback(changeset)
+    end
   end
 
   # A claimed replay rotates the caller's credential, not the runtime's

--- a/apps/fountain/lib/fountain_web/live/api_keys_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/api_keys_live/index.ex
@@ -3,6 +3,7 @@ defmodule FountainWeb.ApiKeysLive.Index do
   use FountainWeb, :live_view
 
   alias Fountain.Accounts
+  alias Fountain.Principals
 
   @impl true
   def mount(_params, _session, socket) do
@@ -14,6 +15,7 @@ defmodule FountainWeb.ApiKeysLive.Index do
      |> assign(:page_title, "API keys")
      |> assign(:user_id, user.id)
      |> assign(:keys, keys)
+     |> assign(:principals, Principals.list_owned(user.id))
      |> assign(:new_key, nil)}
   end
 
@@ -35,6 +37,23 @@ defmodule FountainWeb.ApiKeysLive.Index do
 
       {:error, _cs} ->
         {:noreply, put_flash(socket, :error, "Failed to create API key")}
+    end
+  end
+
+  def handle_event("renew_principal_key", %{"principal_id" => id}, socket) do
+    with {:ok, principal_id} <- Ecto.UUID.cast(id),
+         {:ok, {key, raw_token}} <-
+           Principals.renew_owned_credential(
+             socket.assigns.user_id,
+             principal_id,
+             FountainWeb.Audited.attribution(socket)
+           ) do
+      {:noreply,
+       socket
+       |> assign(:keys, Accounts.list_managed_api_keys(socket.assigns.user_id))
+       |> assign(:new_key, %{key: key, raw_token: raw_token})}
+    else
+      _ -> {:noreply, put_flash(socket, :error, "Could not replace principal key")}
     end
   end
 
@@ -117,6 +136,32 @@ defmodule FountainWeb.ApiKeysLive.Index do
           />
         </div>
         <.button type="submit">Create key</.button>
+      </form>
+
+      <form
+        :if={@principals != []}
+        id="renew-principal-key"
+        phx-submit="renew_principal_key"
+        class="space-y-3 rounded border border-[var(--color-border)] p-4"
+      >
+        <label for="principal-id" class="block font-medium">Replace a principal key</label>
+        <p class="text-sm text-[var(--color-text-secondary)]">
+          Create a new key for a principal you own. Its previous key will stop working.
+          You can also replace an expired or revoked key here.
+        </p>
+        <select
+          id="principal-id"
+          name="principal_id"
+          class="w-full rounded border border-[var(--color-border)] bg-[var(--color-bg-1)] p-2 text-sm"
+        >
+          <option :for={id <- @principals} value={id}>{id}</option>
+        </select>
+        <.button
+          type="submit"
+          variant="secondary"
+        >
+          Replace principal key
+        </.button>
       </form>
 
       <div

--- a/apps/fountain/test/fountain/audit_guardrail_test.exs
+++ b/apps/fountain/test/fountain/audit_guardrail_test.exs
@@ -58,6 +58,8 @@ defmodule Fountain.AuditGuardrailTest do
     {"vault delete", &__MODULE__.do_vault_delete/1, "vault.deleted"},
     {"api key mint", &__MODULE__.do_key_create/1, "api_key.created"},
     {"api key revoke", &__MODULE__.do_key_revoke/1, "api_key.revoked"},
+    {"owned principal credential renewal", &__MODULE__.do_principal_key_renewal/1,
+     "api_key.created"},
     {"managed principal key revoke", &__MODULE__.do_managed_key_revoke/1, "api_key.revoked"},
     {"inference credential write", &__MODULE__.do_cred_write/1, "inference_credential.write"},
     {"inference credential clear", &__MODULE__.do_cred_clear/1, "inference_credential.delete"},
@@ -414,6 +416,13 @@ defmodule Fountain.AuditGuardrailTest do
   def do_key_revoke(user) do
     {:ok, {key, _}} = Fountain.Accounts.create_api_key(user.id, "guard-revoke")
     {:ok, _} = Fountain.Accounts.revoke_api_key(user.id, key.id)
+  end
+
+  def do_principal_key_renewal(user) do
+    app = insert_verified_user()
+    {:ok, opened} = Principals.create_claimable(app, %{"application_id" => "audit-renewal"})
+    {:ok, claimed} = Principals.claim(opened.claimable.id, opened.claim_token, user)
+    {:ok, _} = Principals.renew_owned_credential(user.id, claimed.claimable.user_id)
   end
 
   def do_managed_key_revoke(user) do

--- a/apps/fountain/test/fountain/principals_claim_replay_test.exs
+++ b/apps/fountain/test/fountain/principals_claim_replay_test.exs
@@ -139,6 +139,14 @@ defmodule Fountain.PrincipalsClaimReplayTest do
   end
 
   test "concurrent claim replays leave one principal credential" do
+    assert_one_credential_after_rotation(:replay)
+  end
+
+  test "owner renewal and claim replay serialize their credential replacement" do
+    assert_one_credential_after_rotation(:renewal)
+  end
+
+  defp assert_one_credential_after_rotation(second_operation) do
     {application, owner, opened, first} =
       Sandbox.unboxed_run(Repo, fn ->
         application = insert_verified_user()
@@ -186,12 +194,22 @@ defmodule Fountain.PrincipalsClaimReplayTest do
     assert_receive :locked, 5_000
 
     replays =
-      for _ <- 1..2 do
+      for operation <- [:replay, second_operation] do
         Task.async(fn ->
           Sandbox.unboxed_run(Repo, fn ->
             %{rows: [[backend]]} = Repo.query!("SELECT pg_backend_pid()")
             send(parent, {:rotation_backend, backend})
-            Principals.claim(opened.claimable.id, "", owner, idempotency_key: "rotate")
+
+            case operation do
+              :replay ->
+                Principals.claim(opened.claimable.id, "", owner, idempotency_key: "rotate")
+
+              :renewal ->
+                with {:ok, {_key, raw}} <-
+                       Principals.renew_owned_credential(owner.id, opened.claimable.user_id) do
+                  {:ok, %{api_key: raw}}
+                end
+            end
           end)
         end)
       end

--- a/apps/fountain/test/fountain/principals_test.exs
+++ b/apps/fountain/test/fountain/principals_test.exs
@@ -403,6 +403,110 @@ defmodule Fountain.PrincipalsTest do
     end
   end
 
+  describe "renew_owned_credential/3" do
+    setup do
+      owner = insert_verified_user()
+      opened = open(application_account())
+      {:ok, claimed} = Principals.claim(opened.claimable.id, opened.claim_token, owner)
+      {:ok, _, key} = Accounts.authenticate_api_key(claimed.api_key)
+      %{owner: owner, opened: opened, claimed: claimed, key: key}
+    end
+
+    test "the owner renews without the claim token, rotating only principal credentials", ctx do
+      principal_id = ctx.claimed.claimable.user_id
+      {:ok, {callback, _}} = Accounts.create_api_key(principal_id, "callback", scopes: ["sprite"])
+
+      assert {:ok, {key, raw}} =
+               Principals.renew_owned_credential(ctx.owner.id, principal_id,
+                 actor: "ui",
+                 request_ip: "127.0.0.1"
+               )
+
+      assert key.user_id == principal_id
+      assert key.scopes == ["principal"]
+      assert {:ok, _, _} = Accounts.authenticate_api_key(raw)
+      assert {:error, :revoked} = Accounts.authenticate_api_key(ctx.claimed.api_key)
+      assert is_nil(Repo.reload!(callback).revoked_at)
+      assert Principals.owner_id(principal_id) == ctx.owner.id
+
+      assert [audit] =
+               Repo.all(
+                 from a in Fountain.Audit.Event,
+                   where: a.user_id == ^ctx.owner.id and a.action == "api_key.created"
+               )
+
+      assert audit.resource_id == key.id
+      assert audit.actor == "ui"
+      assert audit.metadata["principal_user_id"] == principal_id
+      assert audit.metadata["revoked_key_ids"] == [ctx.key.id]
+      refute inspect(audit.metadata) =~ raw
+    end
+
+    test "expired and then explicitly revoked credentials can be replaced", ctx do
+      past = DateTime.utc_now() |> DateTime.add(-60) |> DateTime.truncate(:second)
+      ctx.key |> Ecto.Changeset.change(expires_at: past) |> Repo.update!()
+      assert {:error, :expired} = Accounts.authenticate_api_key(ctx.claimed.api_key)
+      principal_id = ctx.claimed.claimable.user_id
+
+      assert {:ok, {key, raw}} = Principals.renew_owned_credential(ctx.owner.id, principal_id)
+      assert {:ok, _, _} = Accounts.authenticate_api_key(raw)
+      {:ok, _} = Accounts.revoke_managed_api_key(ctx.owner.id, key.id)
+
+      assert {:ok, {_, replacement}} =
+               Principals.renew_owned_credential(ctx.owner.id, principal_id)
+
+      assert {:ok, _, _} = Accounts.authenticate_api_key(replacement)
+    end
+
+    test "renewal does not require a spending balance", ctx do
+      owner = ctx.owner
+
+      {:ok, _} =
+        Credits.debit(owner.id, Credits.balance(owner.id), "burn_turn",
+          idempotency_key: "renewal-drain:#{owner.id}"
+        )
+
+      assert {:error, :insufficient_credits} = Fountain.Billing.check_spend(owner.id)
+      assert {:ok, _} = Principals.renew_owned_credential(owner.id, ctx.claimed.claimable.user_id)
+    end
+
+    test "the application, another account and the principal cannot renew", ctx do
+      principal_id = ctx.claimed.claimable.user_id
+      other = insert_verified_user()
+
+      for viewer_id <- [ctx.opened.claimable.application_user_id, other.id, principal_id] do
+        assert {:error, :not_found} = Principals.renew_owned_credential(viewer_id, principal_id)
+      end
+
+      unclaimed = open(application_account())
+
+      assert {:error, :not_found} =
+               Principals.renew_owned_credential(ctx.owner.id, unclaimed.claimable.user_id)
+
+      assert {:error, :not_found} =
+               Principals.renew_owned_credential(ctx.owner.id, Ecto.UUID.generate())
+
+      assert {:ok, _, _} = Accounts.authenticate_api_key(ctx.claimed.api_key)
+    end
+
+    test "a failed mint keeps the previous credential and emits no owner creation event", ctx do
+      stub(Accounts, :build_api_key, fn user_id, name, opts ->
+        {changeset, raw} = Mimic.call_original(Accounts, :build_api_key, [user_id, name, opts])
+        {Ecto.Changeset.add_error(changeset, :name, "mint refused"), raw}
+      end)
+
+      assert {:error, %Ecto.Changeset{}} =
+               Principals.renew_owned_credential(ctx.owner.id, ctx.claimed.claimable.user_id)
+
+      assert {:ok, _, _} = Accounts.authenticate_api_key(ctx.claimed.api_key)
+
+      refute Repo.exists?(
+               from a in Fountain.Audit.Event,
+                 where: a.user_id == ^ctx.owner.id and a.action == "api_key.created"
+             )
+    end
+  end
+
   describe "billing_subject_id/1" do
     test "an ordinary account is its own subject" do
       user = insert_verified_user()

--- a/apps/fountain/test/fountain_web/live/api_keys_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/api_keys_live_test.exs
@@ -22,6 +22,59 @@ defmodule FountainWeb.ApiKeysLiveTest do
     refute render(view) =~ "principal:console-test"
   end
 
+  test "owners can replace revoked principal keys and see the new secret once", %{conn: conn} do
+    owner = insert_verified_user()
+    app = insert_verified_user()
+
+    {:ok, opened} =
+      Fountain.Principals.create_claimable(app, %{"application_id" => "renew-console"})
+
+    {:ok, claimed} = Fountain.Principals.claim(opened.claimable.id, opened.claim_token, owner)
+    {:ok, _, key} = Accounts.authenticate_api_key(claimed.api_key)
+    {:ok, _} = Accounts.revoke_managed_api_key(owner.id, key.id)
+    {:ok, view, _html} = conn |> login_user(owner) |> live(~p"/api-keys")
+    assert has_element?(view, "#renew-principal-key option[value='#{claimed.claimable.user_id}']")
+
+    view
+    |> form("#renew-principal-key", principal_id: claimed.claimable.user_id)
+    |> render_submit()
+
+    raw =
+      view
+      |> element("#new-api-key")
+      |> render()
+      |> LazyHTML.from_fragment()
+      |> LazyHTML.text()
+      |> String.trim()
+
+    assert {:ok, principal, new_key} = Accounts.authenticate_api_key(raw)
+    assert principal.id == claimed.claimable.user_id
+    assert new_key.scopes == ["principal"]
+    assert render(view) =~ new_key.key_prefix
+    view |> element("button[phx-click=dismiss_new_key]") |> render_click()
+    refute render(view) =~ raw
+
+    view |> form("#renew-principal-key", principal_id: principal.id) |> render_submit()
+    assert {:error, :revoked} = Accounts.authenticate_api_key(raw)
+  end
+
+  test "principal renewal rejects forged ownership and malformed ids", %{conn: conn} do
+    owner = insert_verified_user()
+    app = insert_verified_user()
+    {:ok, opened} = Fountain.Principals.create_claimable(app, %{"application_id" => "foreign"})
+    {:ok, claimed} = Fountain.Principals.claim(opened.claimable.id, opened.claim_token, owner)
+    {:ok, view, _html} = conn |> login_user(app) |> live(~p"/api-keys")
+    refute has_element?(view, "#renew-principal-key")
+
+    for id <- [claimed.claimable.user_id, "not-a-uuid"] do
+      html = render_submit(view, "renew_principal_key", %{"principal_id" => id})
+      assert html =~ "Could not replace principal key"
+      refute html =~ claimed.api_key
+    end
+
+    assert {:ok, _, _} = Accounts.authenticate_api_key(claimed.api_key)
+  end
+
   describe "ApiKeysLive.Index — rendering" do
     test "shows existing active keys", %{conn: conn} do
       user = insert_verified_user()

--- a/decisions/0044-claimable-principals.md
+++ b/decisions/0044-claimable-principals.md
@@ -123,7 +123,12 @@ abandoning what it already has.
    unique per application; the claim key is stored on success. Replaying either
    with the same key returns the same principal and mints a **fresh**
    credential, because the secret from the first response was never stored.
-   That is also the rotation path for a claimed principal's credential.
+   Claim replay revokes the previous principal credential atomically with the
+   new mint. An owner can also renew by principal id without the original
+   token or idempotency key, even after credential expiry or revocation.
+   Renewal takes the same claim-row lock and leaves runtime callback keys
+   alone. It records the new key and replaced key ids in the owner's audit
+   trail after commit.
 
 **The API is four routes**, all behind `:require_full_scope`:
 `POST /api/claimable-users`, `GET /api/claimable-users/:id`,


### PR DESCRIPTION
A principal owner can revoke a key, but cannot regain access from the console afterward. Add a replacement-key form populated from owned principal IDs, so it remains available when every previous key is revoked or expired. The context replaces the credential atomically; the console refreshes key metadata and reveals the new secret once in the existing modal.

Console unit of #1688, stacked on #1951. Two files, +98/-0. Bounded expiry follows separately.

Validation: all 13 focused console tests pass, including recovery after revocation, one-time secret dismissal, effective replacement, and forged-owner/malformed-ID refusals. A real Chromium session recovered a revoked credential, authenticated with its replacement, replaced it again, verified the previous credential returns HTTP 401 and the new one HTTP 200, and checked that the form fits a 390px viewport. Browser fixtures used a separate database and were deleted afterward. Full local precommit passed: 5,392 core tests + 6 doctests, 144 Buzz tests and 33 Support tests, all with zero failures.
