### PR TITLE
fix(auth): expire claimed principal credentials after 30 days

### DIFF
--- a/apps/fountain/lib/fountain/principals.ex
+++ b/apps/fountain/lib/fountain/principals.ex
@@ -491,15 +491,17 @@ defmodule Fountain.Principals do
     end
   end
 
-  # The anonymous credential expires with the grant, so a leaked one dies on
-  # the same schedule as the machine it reaches. The claimed one must not:
-  # after a claim the grant's deadline describes nothing — the principal is an
-  # ordinary tenant of the account that owns it — and a key that expired at it
-  # would take a live machine away from its new owner, usually within hours.
+  # Anonymous credentials follow the grant. Claimed credentials get 30 days
+  # from issuance, independently of that old deadline. The owner can replace
+  # them from API keys in the console, including after expiry.
   defp principal_key_opts(claimable, opts) do
     [
       scopes: ["principal"],
-      expires_at: if(claimable.status == "claimed", do: nil, else: claimable.expires_at),
+      expires_at:
+        if(claimable.status == "claimed",
+          do: DateTime.utc_now() |> DateTime.add(30, :day) |> truncate(),
+          else: claimable.expires_at
+        ),
       actor: Keyword.get(opts, :actor, "api"),
       request_ip: Keyword.get(opts, :request_ip)
     ]

--- a/apps/fountain/lib/fountain_web/live/api_keys_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/api_keys_live/index.ex
@@ -3,6 +3,7 @@ defmodule FountainWeb.ApiKeysLive.Index do
   use FountainWeb, :live_view
 
   alias Fountain.Accounts
+  alias Fountain.Principals
 
   @impl true
   def mount(_params, _session, socket) do
@@ -14,6 +15,7 @@ defmodule FountainWeb.ApiKeysLive.Index do
      |> assign(:page_title, "API keys")
      |> assign(:user_id, user.id)
      |> assign(:keys, keys)
+     |> assign(:principals, Principals.list_owned(user.id))
      |> assign(:new_key, nil)}
   end
 
@@ -35,6 +37,23 @@ defmodule FountainWeb.ApiKeysLive.Index do
 
       {:error, _cs} ->
         {:noreply, put_flash(socket, :error, "Failed to create API key")}
+    end
+  end
+
+  def handle_event("renew_principal_key", %{"principal_id" => id}, socket) do
+    with {:ok, principal_id} <- Ecto.UUID.cast(id),
+         {:ok, {key, raw_token}} <-
+           Principals.renew_owned_credential(
+             socket.assigns.user_id,
+             principal_id,
+             FountainWeb.Audited.attribution(socket)
+           ) do
+      {:noreply,
+       socket
+       |> assign(:keys, Accounts.list_managed_api_keys(socket.assigns.user_id))
+       |> assign(:new_key, %{key: key, raw_token: raw_token})}
+    else
+      _ -> {:noreply, put_flash(socket, :error, "Could not replace principal key")}
     end
   end
 
@@ -117,6 +136,32 @@ defmodule FountainWeb.ApiKeysLive.Index do
           />
         </div>
         <.button type="submit">Create key</.button>
+      </form>
+
+      <form
+        :if={@principals != []}
+        id="renew-principal-key"
+        phx-submit="renew_principal_key"
+        class="space-y-3 rounded border border-[var(--color-border)] p-4"
+      >
+        <label for="principal-id" class="block font-medium">Replace a principal key</label>
+        <p class="text-sm text-[var(--color-text-secondary)]">
+          Create a new key for a principal you own. Its previous key will stop working.
+          You can also replace an expired or revoked key here.
+        </p>
+        <select
+          id="principal-id"
+          name="principal_id"
+          class="w-full rounded border border-[var(--color-border)] bg-[var(--color-bg-1)] p-2 text-sm"
+        >
+          <option :for={id <- @principals} value={id}>{id}</option>
+        </select>
+        <.button
+          type="submit"
+          variant="secondary"
+        >
+          Replace principal key
+        </.button>
       </form>
 
       <div

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -4108,8 +4108,9 @@ defmodule FountainWeb.Schemas do
         api_key: %Schema{
           type: :string,
           description:
-            "A fresh `principal`-scoped key for the claimed principal, with no expiry. " <>
-              "The credential the application held is revoked by the claim."
+            "A fresh `principal`-scoped key that expires 30 days after issuance. " <>
+              "The claim revokes the application credential. Owners can replace the key " <>
+              "from API keys in the console, including after expiry."
         }
       },
       required: [:user, :principal_id, :status, :api_key]

--- a/apps/fountain/test/fountain/principals_test.exs
+++ b/apps/fountain/test/fountain/principals_test.exs
@@ -24,6 +24,12 @@ defmodule Fountain.PrincipalsTest do
     result
   end
 
+  defp assert_claimed_key_lifetime(key) do
+    assert %DateTime{} = key.expires_at
+    remaining = DateTime.diff(key.expires_at, DateTime.utc_now(), :second)
+    assert remaining in (30 * 86_400 - 5)..(30 * 86_400)
+  end
+
   describe "create_claimable/3" do
     test "opens a principal that is a real, isolated tenant" do
       app = application_account()
@@ -292,7 +298,7 @@ defmodule Fountain.PrincipalsTest do
       assert key.scopes == ["principal"]
       # Not the grant's deadline: that described the anonymous session, and a
       # key expiring at it would take a live machine off its new owner.
-      assert is_nil(key.expires_at)
+      assert_claimed_key_lifetime(key)
     end
 
     test "the anonymous credential expires with the grant", ctx do
@@ -343,7 +349,8 @@ defmodule Fountain.PrincipalsTest do
       {:ok, second} = Principals.claim(ctx.claimable.id, ctx.token, claimer, opts)
 
       assert {:error, :revoked} = Accounts.authenticate_api_key(first.api_key)
-      assert {:ok, _, _} = Accounts.authenticate_api_key(second.api_key)
+      assert {:ok, _, renewed} = Accounts.authenticate_api_key(second.api_key)
+      assert_claimed_key_lifetime(renewed)
       assert is_nil(Repo.reload!(callback).revoked_at)
 
       assert [audit] =
@@ -424,6 +431,7 @@ defmodule Fountain.PrincipalsTest do
 
       assert key.user_id == principal_id
       assert key.scopes == ["principal"]
+      assert_claimed_key_lifetime(key)
       assert {:ok, _, _} = Accounts.authenticate_api_key(raw)
       assert {:error, :revoked} = Accounts.authenticate_api_key(ctx.claimed.api_key)
       assert is_nil(Repo.reload!(callback).revoked_at)

--- a/apps/fountain/test/fountain_web/live/api_keys_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/api_keys_live_test.exs
@@ -22,6 +22,59 @@ defmodule FountainWeb.ApiKeysLiveTest do
     refute render(view) =~ "principal:console-test"
   end
 
+  test "owners can replace revoked principal keys and see the new secret once", %{conn: conn} do
+    owner = insert_verified_user()
+    app = insert_verified_user()
+
+    {:ok, opened} =
+      Fountain.Principals.create_claimable(app, %{"application_id" => "renew-console"})
+
+    {:ok, claimed} = Fountain.Principals.claim(opened.claimable.id, opened.claim_token, owner)
+    {:ok, _, key} = Accounts.authenticate_api_key(claimed.api_key)
+    {:ok, _} = Accounts.revoke_managed_api_key(owner.id, key.id)
+    {:ok, view, _html} = conn |> login_user(owner) |> live(~p"/api-keys")
+    assert has_element?(view, "#renew-principal-key option[value='#{claimed.claimable.user_id}']")
+
+    view
+    |> form("#renew-principal-key", principal_id: claimed.claimable.user_id)
+    |> render_submit()
+
+    raw =
+      view
+      |> element("#new-api-key")
+      |> render()
+      |> LazyHTML.from_fragment()
+      |> LazyHTML.text()
+      |> String.trim()
+
+    assert {:ok, principal, new_key} = Accounts.authenticate_api_key(raw)
+    assert principal.id == claimed.claimable.user_id
+    assert new_key.scopes == ["principal"]
+    assert render(view) =~ new_key.key_prefix
+    view |> element("button[phx-click=dismiss_new_key]") |> render_click()
+    refute render(view) =~ raw
+
+    view |> form("#renew-principal-key", principal_id: principal.id) |> render_submit()
+    assert {:error, :revoked} = Accounts.authenticate_api_key(raw)
+  end
+
+  test "principal renewal rejects forged ownership and malformed ids", %{conn: conn} do
+    owner = insert_verified_user()
+    app = insert_verified_user()
+    {:ok, opened} = Fountain.Principals.create_claimable(app, %{"application_id" => "foreign"})
+    {:ok, claimed} = Fountain.Principals.claim(opened.claimable.id, opened.claim_token, owner)
+    {:ok, view, _html} = conn |> login_user(app) |> live(~p"/api-keys")
+    refute has_element?(view, "#renew-principal-key")
+
+    for id <- [claimed.claimable.user_id, "not-a-uuid"] do
+      html = render_submit(view, "renew_principal_key", %{"principal_id" => id})
+      assert html =~ "Could not replace principal key"
+      refute html =~ claimed.api_key
+    end
+
+    assert {:ok, _, _} = Accounts.authenticate_api_key(claimed.api_key)
+  end
+
   describe "ApiKeysLive.Index — rendering" do
     test "shows existing active keys", %{conn: conn} do
       user = insert_verified_user()

--- a/decisions/0044-claimable-principals.md
+++ b/decisions/0044-claimable-principals.md
@@ -128,7 +128,9 @@ abandoning what it already has.
    token or idempotency key, even after credential expiry or revocation.
    Renewal takes the same claim-row lock and leaves runtime callback keys
    alone. It records the new key and replaced key ids in the owner's audit
-   trail after commit.
+   trail after commit. Claimed credentials expire 30 days after each issuance,
+   independently of the anonymous grant deadline. The owner's API keys page
+   can replace them before or after expiry.
 
 **The API is four routes**, all behind `:require_full_scope`:
 `POST /api/claimable-users`, `GET /api/claimable-users/:id`,

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -3487,7 +3487,7 @@ export interface components {
          * @description The result of a claim. The principal's resources are untouched: the same sandbox, agent, environment, vault and conversations, under the same ids.
          */
         ClaimedPrincipal: {
-            /** @description A fresh `principal`-scoped key for the claimed principal, with no expiry. The credential the application held is revoked by the claim. */
+            /** @description A fresh `principal`-scoped key that expires 30 days after issuance. The claim revokes the application credential. Owners can replace the key from API keys in the console, including after expiry. */
             api_key: string;
             /** Format: date-time */
             claimed_at?: string;


### PR DESCRIPTION
Claimed principal credentials had no expiry. Give each initial claim, claim replay and owner renewal a 30-day credential lifetime, independent of the anonymous grant deadline. Owners can recover from expiry through the console replacement form in #1952. Update ADR 0044 and the public API description to state that lifetime.

Issuance unit of #1688, stacked on #1952. Five files, +25/-12. A separate migration unit covers existing non-expiring credentials and older processes during rollout.

Validation: the parent fails all three new lifetime assertions (initial claim, replay, renewal). All 68 focused principal, independent-connection race and claim-controller tests pass; all 50 principal tests pass again after the parent check. The generated wire contract is unchanged: 173 operations and 201 schemas. The SDK change is only a regenerated description comment, so this PR uses sdk-no-release and does not change an SDK version. The decisions bundle validates and its regenerated index is unchanged. Full local precommit passed: 5,392 core tests + 6 doctests, 144 Buzz tests and 33 Support tests, all with zero failures.
