### PR TITLE
fix(auth): bound legacy principal credential expiry during rollout

### DIFF
--- a/apps/fountain/lib/fountain/principals.ex
+++ b/apps/fountain/lib/fountain/principals.ex
@@ -491,15 +491,17 @@ defmodule Fountain.Principals do
     end
   end
 
-  # The anonymous credential expires with the grant, so a leaked one dies on
-  # the same schedule as the machine it reaches. The claimed one must not:
-  # after a claim the grant's deadline describes nothing — the principal is an
-  # ordinary tenant of the account that owns it — and a key that expired at it
-  # would take a live machine away from its new owner, usually within hours.
+  # Anonymous credentials follow the grant. Claimed credentials get 30 days
+  # from issuance, independently of that old deadline. The owner can replace
+  # them from API keys in the console, including after expiry.
   defp principal_key_opts(claimable, opts) do
     [
       scopes: ["principal"],
-      expires_at: if(claimable.status == "claimed", do: nil, else: claimable.expires_at),
+      expires_at:
+        if(claimable.status == "claimed",
+          do: DateTime.utc_now() |> DateTime.add(30, :day) |> truncate(),
+          else: claimable.expires_at
+        ),
       actor: Keyword.get(opts, :actor, "api"),
       request_ip: Keyword.get(opts, :request_ip)
     ]

--- a/apps/fountain/lib/fountain_web/schemas.ex
+++ b/apps/fountain/lib/fountain_web/schemas.ex
@@ -4108,8 +4108,9 @@ defmodule FountainWeb.Schemas do
         api_key: %Schema{
           type: :string,
           description:
-            "A fresh `principal`-scoped key for the claimed principal, with no expiry. " <>
-              "The credential the application held is revoked by the claim."
+            "A fresh `principal`-scoped key that expires 30 days after issuance. " <>
+              "The claim revokes the application credential. Owners can replace the key " <>
+              "from API keys in the console, including after expiry."
         }
       },
       required: [:user, :principal_id, :status, :api_key]

--- a/apps/fountain/priv/repo/migrations/20260911142700_bound_legacy_principal_key_expiry.exs
+++ b/apps/fountain/priv/repo/migrations/20260911142700_bound_legacy_principal_key_expiry.exs
@@ -1,0 +1,43 @@
+defmodule Fountain.Repo.Migrations.BoundLegacyPrincipalKeyExpiry do
+  use Ecto.Migration
+
+  def up do
+    # An older process can still mint a NULL expiry during a rolling deploy.
+    # Give those writes the same deadline as the new issuer, without changing
+    # explicit grant deadlines or the lifetime of full/sprite credentials.
+    execute """
+    CREATE FUNCTION fountain_bound_principal_key_expiry() RETURNS trigger
+    LANGUAGE plpgsql AS $$
+    BEGIN
+      IF NEW.expires_at IS NULL AND 'principal' = ANY(NEW.scopes) THEN
+        NEW.expires_at := date_trunc('second', CURRENT_TIMESTAMP AT TIME ZONE 'UTC')
+                          + INTERVAL '30 days';
+      END IF;
+      RETURN NEW;
+    END;
+    $$
+    """
+
+    execute """
+    CREATE TRIGGER bound_principal_key_expiry
+    BEFORE INSERT OR UPDATE OF scopes, expires_at ON api_keys
+    FOR EACH ROW EXECUTE FUNCTION fountain_bound_principal_key_expiry()
+    """
+
+    # Existing active keys get a full renewal window from migration time,
+    # rather than expiring immediately because they were minted long ago.
+    execute """
+    UPDATE api_keys
+    SET expires_at = date_trunc('second', CURRENT_TIMESTAMP AT TIME ZONE 'UTC')
+                     + INTERVAL '30 days'
+    WHERE expires_at IS NULL AND revoked_at IS NULL AND 'principal' = ANY(scopes)
+    """
+  end
+
+  def down do
+    execute "DROP TRIGGER bound_principal_key_expiry ON api_keys"
+    execute "DROP FUNCTION fountain_bound_principal_key_expiry()"
+    # Retain assigned deadlines: clearing them would also immortalize keys
+    # deliberately issued with the same expiry after this migration.
+  end
+end

--- a/apps/fountain/priv/repo/migrations/20260911142700_bound_legacy_principal_key_expiry.exs
+++ b/apps/fountain/priv/repo/migrations/20260911142700_bound_legacy_principal_key_expiry.exs
@@ -2,6 +2,11 @@ defmodule Fountain.Repo.Migrations.BoundLegacyPrincipalKeyExpiry do
   use Ecto.Migration
 
   def up do
+    # CREATE TRIGGER takes SHARE ROW EXCLUSIVE: reads may continue, but writes
+    # wait. Bound contention and commit the DDL before the separate backfill.
+    execute("SET LOCAL lock_timeout = '5s'")
+    execute("SET LOCAL statement_timeout = '30s'")
+
     # An older process can still mint a NULL expiry during a rolling deploy.
     # Give those writes the same deadline as the new issuer, without changing
     # explicit grant deadlines or the lifetime of full/sprite credentials.
@@ -10,7 +15,7 @@ defmodule Fountain.Repo.Migrations.BoundLegacyPrincipalKeyExpiry do
     LANGUAGE plpgsql AS $$
     BEGIN
       IF NEW.expires_at IS NULL AND 'principal' = ANY(NEW.scopes) THEN
-        NEW.expires_at := date_trunc('second', CURRENT_TIMESTAMP AT TIME ZONE 'UTC')
+        NEW.expires_at := date_trunc('second', clock_timestamp() AT TIME ZONE 'UTC')
                           + INTERVAL '30 days';
       END IF;
       RETURN NEW;
@@ -23,18 +28,12 @@ defmodule Fountain.Repo.Migrations.BoundLegacyPrincipalKeyExpiry do
     BEFORE INSERT OR UPDATE OF scopes, expires_at ON api_keys
     FOR EACH ROW EXECUTE FUNCTION fountain_bound_principal_key_expiry()
     """
-
-    # Existing active keys get a full renewal window from migration time,
-    # rather than expiring immediately because they were minted long ago.
-    execute """
-    UPDATE api_keys
-    SET expires_at = date_trunc('second', CURRENT_TIMESTAMP AT TIME ZONE 'UTC')
-                     + INTERVAL '30 days'
-    WHERE expires_at IS NULL AND revoked_at IS NULL AND 'principal' = ANY(scopes)
-    """
   end
 
   def down do
+    execute("SET LOCAL lock_timeout = '5s'")
+    execute("SET LOCAL statement_timeout = '30s'")
+
     execute "DROP TRIGGER bound_principal_key_expiry ON api_keys"
     execute "DROP FUNCTION fountain_bound_principal_key_expiry()"
     # Retain assigned deadlines: clearing them would also immortalize keys

--- a/apps/fountain/priv/repo/migrations/20260912102741_backfill_legacy_principal_key_expiry.exs
+++ b/apps/fountain/priv/repo/migrations/20260912102741_backfill_legacy_principal_key_expiry.exs
@@ -1,0 +1,29 @@
+defmodule Fountain.Repo.Migrations.BackfillLegacyPrincipalKeyExpiry do
+  use Ecto.Migration
+
+  def up do
+    execute("SET LOCAL lock_timeout = '5s'")
+    execute("SET LOCAL statement_timeout = '30s'")
+
+    # The trigger committed in the preceding migration already bounds new
+    # writes. This scan holds only the UPDATE's ROW EXCLUSIVE table lock, so
+    # unrelated writes and authentication reads can continue. Fail and retry
+    # if contention or the scan exceeds the budgets; a failed run rolls back
+    # completely and leaves this migration pending.
+    #
+    # Existing active keys get a full renewal window from this statement,
+    # rather than expiring immediately because they were minted long ago.
+    execute """
+    UPDATE api_keys
+    SET expires_at = date_trunc('second', statement_timestamp() AT TIME ZONE 'UTC')
+                     + INTERVAL '30 days'
+    WHERE expires_at IS NULL AND revoked_at IS NULL AND 'principal' = ANY(scopes)
+    """
+  end
+
+  def down do
+    # Retain assigned deadlines: clearing them would also immortalize keys
+    # deliberately issued with the same expiry after this migration.
+    :ok
+  end
+end

--- a/apps/fountain/test/fountain/principal_key_expiry_test.exs
+++ b/apps/fountain/test/fountain/principal_key_expiry_test.exs
@@ -6,12 +6,13 @@ defmodule Fountain.PrincipalKeyExpiryTest do
 
   test "a legacy writer's principal key with no expiry receives 30 days" do
     user = insert_verified_user()
+    earliest = database_deadline()
     {:ok, {key, raw}} = Accounts.create_api_key(user.id, "legacy", scopes: ["principal"])
 
     # The old issuer did not send an expiry or request that generated value
     # back. Authentication and management read the persisted deadline.
     persisted = Repo.reload!(key)
-    assert_deadline(persisted)
+    assert_deadline(persisted, earliest)
     assert {:ok, _, authenticated} = Accounts.authenticate_api_key(raw)
     assert authenticated.expires_at == persisted.expires_at
   end
@@ -35,15 +36,18 @@ defmodule Fountain.PrincipalKeyExpiryTest do
     user = insert_verified_user()
     {:ok, {key, _}} = Accounts.create_api_key(user.id, "changed")
 
+    earliest = database_deadline()
+
     from(k in ApiKey, where: k.id == ^key.id)
     |> Repo.update_all(set: [scopes: ["principal"]])
 
-    assert_deadline(Repo.reload!(key))
+    assert_deadline(Repo.reload!(key), earliest)
+    earliest = database_deadline()
 
     from(k in ApiKey, where: k.id == ^key.id)
     |> Repo.update_all(set: [expires_at: nil])
 
-    assert_deadline(Repo.reload!(key))
+    assert_deadline(Repo.reload!(key), earliest)
   end
 
   test "ordinary key use does not extend an expired principal credential" do
@@ -58,9 +62,30 @@ defmodule Fountain.PrincipalKeyExpiryTest do
     assert {:error, :expired} = Accounts.authenticate_api_key(raw)
   end
 
-  defp assert_deadline(key) do
+  test "a legacy write gets its full window even in an older transaction" do
+    user = insert_verified_user()
+    # Advance beyond the transaction's timestamp(0) second. This is the clock
+    # behavior under test, not a wait for an asynchronous side effect.
+    Repo.query!("SELECT pg_sleep(1.1)")
+    earliest = database_deadline()
+    {:ok, {key, _}} = Accounts.create_api_key(user.id, "delayed", scopes: ["principal"])
+
+    assert_deadline(Repo.reload!(key), earliest)
+  end
+
+  defp database_deadline do
+    %{rows: [[deadline]]} =
+      Repo.query!("""
+      SELECT date_trunc('second', clock_timestamp() AT TIME ZONE 'UTC') + INTERVAL '30 days'
+      """)
+
+    DateTime.from_naive!(deadline, "Etc/UTC")
+  end
+
+  defp assert_deadline(key, earliest) do
+    latest = database_deadline()
     assert %DateTime{} = key.expires_at
-    remaining = DateTime.diff(key.expires_at, DateTime.utc_now(), :second)
-    assert remaining in (30 * 86_400 - 5)..(30 * 86_400)
+    assert DateTime.compare(key.expires_at, earliest) in [:eq, :gt]
+    assert DateTime.compare(key.expires_at, latest) in [:eq, :lt]
   end
 end

--- a/apps/fountain/test/fountain/principal_key_expiry_test.exs
+++ b/apps/fountain/test/fountain/principal_key_expiry_test.exs
@@ -1,0 +1,66 @@
+defmodule Fountain.PrincipalKeyExpiryTest do
+  use Fountain.DataCase, async: true
+
+  alias Fountain.Accounts
+  alias Fountain.Accounts.ApiKey
+
+  test "a legacy writer's principal key with no expiry receives 30 days" do
+    user = insert_verified_user()
+    {:ok, {key, raw}} = Accounts.create_api_key(user.id, "legacy", scopes: ["principal"])
+
+    # The old issuer did not send an expiry or request that generated value
+    # back. Authentication and management read the persisted deadline.
+    persisted = Repo.reload!(key)
+    assert_deadline(persisted)
+    assert {:ok, _, authenticated} = Accounts.authenticate_api_key(raw)
+    assert authenticated.expires_at == persisted.expires_at
+  end
+
+  test "explicit principal deadlines and unbounded non-principal keys are preserved" do
+    user = insert_verified_user()
+    deadline = DateTime.utc_now() |> DateTime.add(60) |> DateTime.truncate(:second)
+
+    {:ok, {key, _}} =
+      Accounts.create_api_key(user.id, "anonymous", scopes: ["principal"], expires_at: deadline)
+
+    assert Repo.reload!(key).expires_at == deadline
+
+    for scope <- ["full", "sprite"] do
+      {:ok, {other, _}} = Accounts.create_api_key(user.id, scope, scopes: [scope])
+      assert is_nil(Repo.reload!(other).expires_at)
+    end
+  end
+
+  test "an old update cannot clear a principal deadline or add principal scope without one" do
+    user = insert_verified_user()
+    {:ok, {key, _}} = Accounts.create_api_key(user.id, "changed")
+
+    from(k in ApiKey, where: k.id == ^key.id)
+    |> Repo.update_all(set: [scopes: ["principal"]])
+
+    assert_deadline(Repo.reload!(key))
+
+    from(k in ApiKey, where: k.id == ^key.id)
+    |> Repo.update_all(set: [expires_at: nil])
+
+    assert_deadline(Repo.reload!(key))
+  end
+
+  test "ordinary key use does not extend an expired principal credential" do
+    user = insert_verified_user()
+    past = DateTime.utc_now() |> DateTime.add(-60) |> DateTime.truncate(:second)
+
+    {:ok, {key, raw}} =
+      Accounts.create_api_key(user.id, "expired", scopes: ["principal"], expires_at: past)
+
+    Accounts.touch_api_key(raw)
+    assert Repo.reload!(key).expires_at == past
+    assert {:error, :expired} = Accounts.authenticate_api_key(raw)
+  end
+
+  defp assert_deadline(key) do
+    assert %DateTime{} = key.expires_at
+    remaining = DateTime.diff(key.expires_at, DateTime.utc_now(), :second)
+    assert remaining in (30 * 86_400 - 5)..(30 * 86_400)
+  end
+end

--- a/apps/fountain/test/fountain/principals_test.exs
+++ b/apps/fountain/test/fountain/principals_test.exs
@@ -24,6 +24,12 @@ defmodule Fountain.PrincipalsTest do
     result
   end
 
+  defp assert_claimed_key_lifetime(key) do
+    assert %DateTime{} = key.expires_at
+    remaining = DateTime.diff(key.expires_at, DateTime.utc_now(), :second)
+    assert remaining in (30 * 86_400 - 5)..(30 * 86_400)
+  end
+
   describe "create_claimable/3" do
     test "opens a principal that is a real, isolated tenant" do
       app = application_account()
@@ -292,7 +298,7 @@ defmodule Fountain.PrincipalsTest do
       assert key.scopes == ["principal"]
       # Not the grant's deadline: that described the anonymous session, and a
       # key expiring at it would take a live machine off its new owner.
-      assert is_nil(key.expires_at)
+      assert_claimed_key_lifetime(key)
     end
 
     test "the anonymous credential expires with the grant", ctx do
@@ -343,7 +349,8 @@ defmodule Fountain.PrincipalsTest do
       {:ok, second} = Principals.claim(ctx.claimable.id, ctx.token, claimer, opts)
 
       assert {:error, :revoked} = Accounts.authenticate_api_key(first.api_key)
-      assert {:ok, _, _} = Accounts.authenticate_api_key(second.api_key)
+      assert {:ok, _, renewed} = Accounts.authenticate_api_key(second.api_key)
+      assert_claimed_key_lifetime(renewed)
       assert is_nil(Repo.reload!(callback).revoked_at)
 
       assert [audit] =
@@ -424,6 +431,7 @@ defmodule Fountain.PrincipalsTest do
 
       assert key.user_id == principal_id
       assert key.scopes == ["principal"]
+      assert_claimed_key_lifetime(key)
       assert {:ok, _, _} = Accounts.authenticate_api_key(raw)
       assert {:error, :revoked} = Accounts.authenticate_api_key(ctx.claimed.api_key)
       assert is_nil(Repo.reload!(callback).revoked_at)

--- a/decisions/0044-claimable-principals.md
+++ b/decisions/0044-claimable-principals.md
@@ -132,10 +132,17 @@ abandoning what it already has.
    independently of the anonymous grant deadline. The owner's API keys page
    can replace them before or after expiry. Existing active principal keys
    with no expiry get a 30-day renewal window when migrated. A database
-   trigger supplies the same deadline when an older writer inserts a
-   principal key without one during rollout. Explicit deadlines and keys
-   without principal scope are unaffected. Rolling back the trigger retains
-   deadlines already assigned.
+   trigger permanently enforces a finite expiry when a writer inserts a
+   principal key or updates its scope/expiry without supplying a deadline.
+   It supplies 30 days from the write's wall-clock time, including for older
+   writers during rollout. Explicit deadlines and keys without principal
+   scope are unaffected. Issuers must still set and return their deadline
+   explicitly: an insert without `RETURNING expires_at` does not see the
+   trigger's generated value in its returned struct. Intentionally permitting
+   non-expiring principal credentials would require changing this database
+   policy. Trigger installation commits before the legacy backfill, with
+   bounded lock and statement timeouts on both migrations. Rolling back
+   retains deadlines already assigned.
 
 **The API is four routes**, all behind `:require_full_scope`:
 `POST /api/claimable-users`, `GET /api/claimable-users/:id`,

--- a/decisions/0044-claimable-principals.md
+++ b/decisions/0044-claimable-principals.md
@@ -128,7 +128,9 @@ abandoning what it already has.
    token or idempotency key, even after credential expiry or revocation.
    Renewal takes the same claim-row lock and leaves runtime callback keys
    alone. It records the new key and replaced key ids in the owner's audit
-   trail after commit.
+   trail after commit. Claimed credentials expire 30 days after each issuance,
+   independently of the anonymous grant deadline. The owner's API keys page
+   can replace them before or after expiry.
 
 **The API is four routes**, all behind `:require_full_scope`:
 `POST /api/claimable-users`, `GET /api/claimable-users/:id`,

--- a/decisions/0044-claimable-principals.md
+++ b/decisions/0044-claimable-principals.md
@@ -130,7 +130,12 @@ abandoning what it already has.
    alone. It records the new key and replaced key ids in the owner's audit
    trail after commit. Claimed credentials expire 30 days after each issuance,
    independently of the anonymous grant deadline. The owner's API keys page
-   can replace them before or after expiry.
+   can replace them before or after expiry. Existing active principal keys
+   with no expiry get a 30-day renewal window when migrated. A database
+   trigger supplies the same deadline when an older writer inserts a
+   principal key without one during rollout. Explicit deadlines and keys
+   without principal scope are unaffected. Rolling back the trigger retains
+   deadlines already assigned.
 
 **The API is four routes**, all behind `:require_full_scope`:
 `POST /api/claimable-users`, `GET /api/claimable-users/:id`,

--- a/sdk/typescript/src/generated/openapi.ts
+++ b/sdk/typescript/src/generated/openapi.ts
@@ -3487,7 +3487,7 @@ export interface components {
          * @description The result of a claim. The principal's resources are untouched: the same sandbox, agent, environment, vault and conversations, under the same ids.
          */
         ClaimedPrincipal: {
-            /** @description A fresh `principal`-scoped key for the claimed principal, with no expiry. The credential the application held is revoked by the claim. */
+            /** @description A fresh `principal`-scoped key that expires 30 days after issuance. The claim revokes the application credential. Owners can replace the key from API keys in the console, including after expiry. */
             api_key: string;
             /** Format: date-time */
             claimed_at?: string;


### PR DESCRIPTION
Existing principal credentials can remain non-expiring after the issuer is fixed, and an older process can still write a NULL expiry during deployment. A database backstop assigns a write-time 30-day deadline to principal-scoped writes that omit one. A separate migration gives active legacy credentials a full 30-day recovery window. Explicit deadlines, full/sprite keys and ordinary last-used updates retain their behavior. Rollback retains assigned deadlines.

Final unit of #1688, stacked on #1953. Owners have the replacement form from #1952 before expiry is introduced. Closes #1688 with the preceding owner management, atomic rotation, renewal and issuance units.

Trigger DDL commits before the backfill. Both migrations have 5-second lock and 30-second statement budgets, so contention fails and can be retried. ADR 0044 documents the permanent finite-expiry backstop.

Validation of the repaired migration on PostgreSQL 17: DDL and backfill each failed at the configured 5-second lock timeout under contention; reads remained available during trigger installation, and unrelated reads/writes continued during the separate backfill. A 90-day-old active key received migration-time grace; explicit/full/sprite/revoked exceptions were preserved. Old transactions and a non-UTC session used write-time deadlines. Rollback retained deadlines and a failed backfill succeeded after its blocker was removed. Focused ExUnit and fresh CI results will be recorded before merge.