### PR TITLE
test(acp): cover Claude model aliases through conversations

### DIFF
--- a/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_acp_test.exs
@@ -143,6 +143,60 @@ defmodule Fountain.Conversations.ConversationServerACPTest do
     prompt_id
   end
 
+  describe "Claude model confirmation aliases (#1710)" do
+    for {model, confirmed, accepted?} <- [
+          {"claude-opus-5", "opus", true},
+          {"claude-sonnet-5", "sonnet", true},
+          {"claude-opus-5", "haiku", false}
+        ] do
+      test "#{model} confirmed as #{confirmed}", %{} do
+        model = unquote(model)
+        confirmed = unquote(confirmed)
+        user = insert_verified_user()
+        agent = insert_agent(user_id: user.id, runtime: "claude", model: "anthropic/" <> model)
+        conv = insert_conversation(agent: agent, user_id: user.id)
+        {pid, ref} = start_acp_turn(conv)
+
+        %{"id" => init_id, "method" => "initialize"} = next_write()
+        reply(pid, ref, init_id, %{"agentCapabilities" => @caps})
+        %{"id" => new_id, "method" => "session/new"} = next_write()
+
+        reply(pid, ref, new_id, %{
+          "sessionId" => "sess_1",
+          "configOptions" => [%{"id" => "model", "currentValue" => "default"}]
+        })
+
+        assert %{
+                 "id" => set_id,
+                 "method" => "session/set_config_option",
+                 "params" => %{"configId" => "model", "value" => ^model}
+               } = next_write()
+
+        reply(pid, ref, set_id, %{
+          "configOptions" => [%{"id" => "model", "currentValue" => confirmed}]
+        })
+
+        if unquote(accepted?) do
+          %{"id" => prompt_id, "method" => "session/prompt"} = next_write()
+          reply(pid, ref, prompt_id, %{"stopReason" => "end_turn"})
+          assert [turn] = Conversations._unsafe_list_turns(conv.id)
+          assert turn.status == "completed"
+          assert turn.model_selection["requested_model"] == model
+          assert turn.model_selection["effective_model"] == confirmed
+          assert turn.model_selection["source"] == "runtime"
+          %{data: [wire]} = FountainWeb.ConversationJSON.turns(%{turns: [turn]})
+          assert wire.model_selection == turn.model_selection
+        else
+          refute_receive {:wrote, _}, 50
+          assert [turn] = Conversations._unsafe_list_turns(conv.id)
+          assert turn.status == "failed"
+          assert is_nil(turn.acp_prompt_id)
+          assert turn.model_selection["error"] =~ "Runtime confirmed a different model: haiku"
+        end
+      end
+    end
+  end
+
   describe "the decision" do
     test "every shippable runtime speaks ACP; the retired flag routes nothing" do
       user = insert_verified_user()


### PR DESCRIPTION
Fountain's conversation integration tests confirmed only a verbatim model echo, leaving Claude's production `opus` and `sonnet` aliases protected only inside the ACP dependency. Drive the real peer through Claude's `session/set_config_option` response and assert that both aliases complete a turn with the requested/effective model evidence preserved in the API. A `haiku` response to an Opus request must still fail before any prompt is sent.

Regression unit of #1710. One test file, +54/-0. The independent OpenCode pinning exposure remains separate.

Validation: all 105 ACP conversation integration tests pass. Replacing alias matching with strict normalized equality inside the isolated dependency checkout makes both positive regressions fail (3 tests, 2 failures); restoring and rebuilding the original dependency returns all three to green. The mismatched-family case stays rejected. No dependency changes are committed. Full local precommit passed: 5,378 core tests + 6 doctests, 144 Buzz tests and 33 Support tests, all with zero failures.
