### PR TITLE
fix: complete broker stage after CA installation succeeds

### DIFF
--- a/apps/fountain/lib/fountain/conversations/egress.ex
+++ b/apps/fountain/lib/fountain/conversations/egress.ex
@@ -243,9 +243,10 @@ defmodule Fountain.Conversations.Egress do
   def sandbox_env(session), do: Broker.sandbox_env(session)
 
   @doc """
-  Mint (or re-mint) the conversation's proxy session, publishing the
-  `broker` stage around it. The caller decides whether the conversation is
-  brokered at all (`brokered?/1`) and holds the session that comes back.
+  Mint the conversation's proxy session and start the `broker` stage.
+  The stage completes only after `install_ca/3` establishes trust in the
+  sandbox. The caller decides whether the conversation is brokered at all
+  (`brokered?/1`) and holds the session that comes back.
   """
   @spec prepare(String.t(), map(), Broker.bindings(), keyword()) ::
           {:ok, map()} | {:error, term()}
@@ -256,11 +257,6 @@ defmodule Fountain.Conversations.Egress do
 
     case Broker.prepare(conversation_id, brokered, bindings, opts) do
       {:ok, session} ->
-        publish_stage(conversation_id, "broker", "done", %{
-          vault: session.vault,
-          expires_at: session.expires_at
-        })
-
         {:ok, session}
 
       {:error, reason} ->
@@ -485,8 +481,16 @@ defmodule Fountain.Conversations.Egress do
   @spec install_ca(session(), Managoat.Sandbox.Handle.t(), String.t()) :: :ok | {:error, term()}
   def install_ca(nil, _handle, _conversation_id), do: :ok
 
-  def install_ca(_session, handle, conversation_id),
-    do: Provisioning.install_broker_ca(handle, conversation_id)
+  def install_ca(session, handle, conversation_id) do
+    with :ok <- Provisioning.install_broker_ca(handle, conversation_id) do
+      publish_stage(conversation_id, "broker", "done", %{
+        vault: session.vault,
+        expires_at: session.expires_at
+      })
+
+      :ok
+    end
+  end
 
   # Every session of the conversation goes when its sandbox does. Still off
   # the caller's path: deleting rows is local and cannot fail the way a call

--- a/apps/fountain/test/fountain/conversations/egress_test.exs
+++ b/apps/fountain/test/fountain/conversations/egress_test.exs
@@ -297,7 +297,7 @@ defmodule Fountain.Conversations.EgressTest do
   end
 
   describe "the session" do
-    test "prepare/4 publishes the broker stage around the mint", %{user: user} do
+    test "the broker stage completes only after CA installation", %{user: user} do
       broker_on([user.id])
       conv = insert_conversation(user_id: user.id)
 
@@ -315,7 +315,36 @@ defmodule Fountain.Conversations.EgressTest do
                  user_id: user.id
                )
 
-      assert [{"started", %{"keys" => ["GITHUB_TOKEN"]}}, {"done", %{"vault" => "c-test"}}] =
+      assert [{"started", %{"keys" => ["GITHUB_TOKEN"]}}] = stages(conv.id, "broker")
+      handle = %Handle{provider: :sprites, name: "s"}
+
+      stub(Fountain.Conversations.Provisioning, :install_broker_ca, fn ^handle, id ->
+        assert id == conv.id
+        assert [{"started", _}] = stages(conv.id, "broker")
+        :ok
+      end)
+
+      assert :ok = Egress.install_ca(@session, handle, conv.id)
+      assert [{"started", _}, {"done", %{"vault" => "c-test"}}] = stages(conv.id, "broker")
+    end
+
+    test "a failed CA command never leaves a completed broker stage", %{user: user} do
+      conv = insert_conversation(user_id: user.id)
+      handle = %Handle{provider: :sprites, name: "s"}
+      stub(Broker, :prepare, fn _id, _b, _bi, _o -> {:ok, @session} end)
+      stub(Broker, :ca_pem, fn -> {:ok, "PEM"} end)
+      stub(Managoat.Sandbox.Sprites, :write_file, fn _h, _p, _data, _opts -> :ok end)
+
+      stub(Managoat.Sandbox.Sprites, :exec, fn _h, "bash", _args, _opts ->
+        {:ok, "trust installation failed", 1}
+      end)
+
+      assert {:ok, session} = Egress.prepare(conv.id, %{}, %{}, user_id: user.id)
+
+      assert {:error, {:broker, :ca_install_exit, 1, _}} =
+               Egress.install_ca(session, handle, conv.id)
+
+      assert [{"started", _}, {"failed", %{"reason" => "ca_install_exit", "exit_code" => 1}}] =
                stages(conv.id, "broker")
     end
 
@@ -389,12 +418,11 @@ defmodule Fountain.Conversations.EgressTest do
       assert Egress.sandbox_env(@session) == Broker.sandbox_env(@session)
     end
 
-    test "install_ca/3 installs only when there is a session" do
+    test "install_ca/3 emits no broker stage without a session", %{user: user} do
+      conv = insert_conversation(user_id: user.id)
       handle = %Handle{provider: :sprites, name: "s"}
-      assert :ok = Egress.install_ca(nil, handle, "c")
-
-      stub(Fountain.Conversations.Provisioning, :install_broker_ca, fn ^handle, "c" -> :ok end)
-      assert :ok = Egress.install_ca(@session, handle, "c")
+      assert :ok = Egress.install_ca(nil, handle, conv.id)
+      assert stages(conv.id, "broker") == []
     end
   end
 


### PR DESCRIPTION
Broker setup currently reports `done` as soon as its proxy session is minted, even if installing the CA then fails. Complete the stage only after sandbox trust installation succeeds; preserve the existing failure event and completion metadata.

First small unit of #1671: two files, +49/-17. The CA-installation metric, ratio alert and production regression investigation remain separate; this PR does not claim to resolve the September 6 root cause.

Validation: 72 focused tests passed (one Linux-only trust-store case skipped on macOS). Restoring the parent implementation makes two stage-order regressions fail; restoring this change returns all 21 egress tests to green. Full `mix precommit` passed: 5,376 core tests + 6 doctests, 144 Buzz tests and 33 Support tests, all with zero failures.
