### PR TITLE
feat(metrics): count conversation broker CA installation outcomes

### DIFF
--- a/apps/fountain/lib/fountain/conversations/egress.ex
+++ b/apps/fountain/lib/fountain/conversations/egress.ex
@@ -482,7 +482,17 @@ defmodule Fountain.Conversations.Egress do
   def install_ca(nil, _handle, _conversation_id), do: :ok
 
   def install_ca(session, handle, conversation_id) do
-    with :ok <- Provisioning.install_broker_ca(handle, conversation_id) do
+    result = Provisioning.install_broker_ca(handle, conversation_id)
+
+    # Only a conversation's trust setup reaches this path. Broker health
+    # probes and session refreshes do not contribute to the failure ratio.
+    Fountain.Telemetry.event(
+      [:broker, :ca_install],
+      %{provider: handle.provider, outcome: ca_install_outcome(result)},
+      %{count: 1}
+    )
+
+    with :ok <- result do
       publish_stage(conversation_id, "broker", "done", %{
         vault: session.vault,
         expires_at: session.expires_at
@@ -491,6 +501,11 @@ defmodule Fountain.Conversations.Egress do
       :ok
     end
   end
+
+  defp ca_install_outcome(:ok), do: "ok"
+  defp ca_install_outcome({:error, {:broker, :ca_install_exit, _, _}}), do: "exit"
+  defp ca_install_outcome({:error, {:broker, :ca_install, _}}), do: "unreachable"
+  defp ca_install_outcome({:error, _}), do: "unavailable"
 
   # Every session of the conversation goes when its sandbox does. Still off
   # the caller's path: deleting rows is local and cannot fail the way a call

--- a/apps/fountain/lib/fountain_web/telemetry.ex
+++ b/apps/fountain/lib/fountain_web/telemetry.ex
@@ -108,6 +108,12 @@ defmodule FountainWeb.Telemetry do
         tags: [:stage, :status],
         description: "Conversation stage transitions by stage and status"
       ),
+      counter("fountain.broker.ca_install.count",
+        event_name: [:fountain, :broker, :ca_install],
+        tags: [:provider, :outcome],
+        description:
+          "Conversation CA installations by provider and outcome (ok, exit, unreachable, unavailable)"
+      ),
       # Any non-zero value here means a privilege-trail row was silently
       # dropped (#451) — alert-worthy, not informational.
       counter("fountain.audit.admin_record_rejected.count",

--- a/apps/fountain/test/fountain/conversations/egress_test.exs
+++ b/apps/fountain/test/fountain/conversations/egress_test.exs
@@ -418,12 +418,54 @@ defmodule Fountain.Conversations.EgressTest do
       assert Egress.sandbox_env(@session) == Broker.sandbox_env(@session)
     end
 
+    test "the exported CA counter records one bounded outcome per conversation setup", %{
+      user: user
+    } do
+      metric =
+        Enum.find(FountainWeb.Telemetry.prometheus_metrics(), fn metric ->
+          metric.name == [:fountain, :broker, :ca_install, :count]
+        end)
+
+      assert metric.tags == [:provider, :outcome]
+      broker_on([user.id])
+      handler = {__MODULE__, make_ref()}
+      :ok = :telemetry.attach(handler, metric.event_name, &__MODULE__.forward_ca_metric/4, self())
+      on_exit(fn -> :telemetry.detach(handler) end)
+      conv = insert_conversation(user_id: user.id)
+      handle = %Handle{provider: :sprites, name: "s"}
+
+      assert :ok = Egress.install_ca(nil, handle, conv.id)
+      stub(Broker, :prepare, fn _id, _b, _bi, _o -> {:ok, @session} end)
+      assert {:ok, @session} = Egress.prepare(conv.id, %{}, %{}, user_id: user.id)
+      assert {:ok, @session, _} = Egress.reprepare(conv.id, %{}, %{}, [], user_id: user.id)
+      refute_received {:ca_metric, _, _}
+
+      for {result, outcome} <- [
+            {:ok, "ok"},
+            {{:error, {:broker, :ca_install_exit, 1, "sensitive output"}}, "exit"},
+            {{:error, {:broker, :ca_install, :timeout}}, "unreachable"},
+            {{:error, :ca_unavailable}, "unavailable"}
+          ] do
+        stub(Fountain.Conversations.Provisioning, :install_broker_ca, fn ^handle, _id ->
+          result
+        end)
+
+        assert Egress.install_ca(@session, handle, conv.id) == result
+        assert_received {:ca_metric, %{count: 1}, %{provider: :sprites, outcome: ^outcome}}
+        refute_received {:ca_metric, _, _}
+      end
+    end
+
     test "install_ca/3 emits no broker stage without a session", %{user: user} do
       conv = insert_conversation(user_id: user.id)
       handle = %Handle{provider: :sprites, name: "s"}
       assert :ok = Egress.install_ca(nil, handle, conv.id)
       assert stages(conv.id, "broker") == []
     end
+  end
+
+  def forward_ca_metric(_event, measurements, metadata, pid) do
+    send(pid, {:ca_metric, measurements, metadata})
   end
 
   describe "release/2" do

--- a/apps/fountain/test/fountain_web/metrics_test.exs
+++ b/apps/fountain/test/fountain_web/metrics_test.exs
@@ -194,6 +194,9 @@ defmodule FountainWeb.MetricsTest do
         [:fountain, :sandboxes],
         [:fountain, :sandboxes_by_provider],
         [:fountain, :oban_queue],
+        # Conversations.Egress.install_ca/3; all outcomes and non-install
+        # paths are exercised by EgressTest.
+        [:fountain, :broker, :ca_install],
         # Fountain.Broker.Native.emit_telemetry/0 (#1170) — exercised
         # directly by Fountain.BrokerNativeTest, since the poller is off in
         # test and these are emitted only on the native backend


### PR DESCRIPTION
Broker stage events cannot provide a reliable CA-installation failure denominator. Emit one `fountain_broker_ca_install_count` sample after each conversation trust-setup attempt, labeled only by provider and the bounded outcome (`ok`, `exit`, `unreachable`, `unavailable`). Session minting, refreshes, unbrokered conversations and proxy/health requests do not increment it.

Second small unit of #1671, stacked on #1956. Four files, +67/-1. The ratio alert is a separate child PR; identifying the September 6 production regression remains open.

Validation: 43 focused tests pass, covering all four outcomes, excluded paths, the exported metric subscription and producer inventory. Full `mix precommit` passed: 5,377 core tests + 6 doctests, 144 Buzz tests and 33 Support tests, all with zero failures.
