### PR TITLE
alert: detect broker CA installation failure ratios by provider

### DIFF
--- a/deploy/k8s/prometheusrule.yaml
+++ b/deploy/k8s/prometheusrule.yaml
@@ -199,6 +199,26 @@ spec:
             summary: "Fountain conversation stages are failing"
             description: "Stage {{ $labels.stage }} failed more than twice in 30 minutes. Inspect conversation stages and provider health."
 
+        - alert: FountainBrokerCAInstallFailureRate
+          # Actual conversation trust setup only: proxy requests and health
+          # probes never emit this metric. Five attempts suppress idle noise.
+          expr: |
+            (
+              round(
+                sum by (provider) (increase(fountain_broker_ca_install_count{namespace="fountain", outcome="exit"}[1h]))
+                / sum by (provider) (increase(fountain_broker_ca_install_count{namespace="fountain"}[1h])),
+                0.000001
+              ) > 0.10
+            )
+            and
+            sum by (provider) (increase(fountain_broker_ca_install_count{namespace="fountain"}[1h])) >= 5
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: 'Broker CA installation failures exceed 10% for {{ $labels.provider }}'
+            description: 'More than 10% of at least five conversation CA setup attempts failed with a nonzero installer exit over the last hour. Inspect broker stage failures and sandbox provider/base-image changes.'
+
         - alert: FountainTurnFailureRate
           # Histogram counts are events, so sum across replicas. Require ten
           # terminal turns per provider to avoid paging on one failed attempt.

--- a/docs/guides/operate/observability.md
+++ b/docs/guides/operate/observability.md
@@ -60,6 +60,7 @@ thresholds or selectors in the overlay.
 | `FountainDatabasePoolSaturated` | Requests wait for database connections. |
 | `FountainProvisionFailures` | Sandbox provision attempts fail. |
 | `FountainStageFailures` | A stage after provisioning fails more than twice in 30 minutes. |
+| `FountainBrokerCAInstallFailureRate` | More than 10% of at least five conversation CA setups fail with an installer exit per provider over one hour, sustained for ten minutes. |
 | `FountainTurnFailureRate` | More than 25% of at least ten terminal turns fail per provider over 30 minutes. |
 | `FountainReattachFailures` | A conversation reattach fails within the last hour. |
 | `FountainTurnFirstOutputSlow` | Observed first-output p95 exceeds 30 seconds for 15 minutes, with at least ten samples per window. |

--- a/scripts/test-alerts.py
+++ b/scripts/test-alerts.py
@@ -28,7 +28,8 @@ def conversation_cases(rules):
         })
 
     names = ("FountainStageFailures", "FountainTurnFailureRate",
-             "FountainReattachFailures", "FountainTurnFirstOutputSlow")
+             "FountainReattachFailures", "FountainTurnFirstOutputSlow",
+             "FountainBrokerCAInstallFailureRate")
     for alert in names:
         case(alert + ": no series", alert, [])
 
@@ -42,6 +43,29 @@ def conversation_cases(rules):
         case("reattach fails=" + str(fails), "FountainReattachFailures", [
             series("fountain_stage_count", 'stage="reattach",status="failed"',
                    "0+0x30 1+0x89" if fails else "0+0x120")], "{}" if fails else None)
+
+    for name, failed, done, unavailable, fires in (
+        ("healthy, no failure series", None, "0+1x120", None, False),
+        ("idle", "0+0x120", "0+0x120", None, False),
+        ("too little traffic", "0+0.02x120", None, None, False),
+        ("exactly 10 percent", "0+1x120", "0+9x120", None, False),
+        ("18 percent fail", "0+0.18x120", "0+0.82x120", None, True),
+        ("all fail, no success series", "0+1x120", None, None, True),
+        ("transport failure is not an installer exit", None, None, "0+1x120", False),
+        ("counter reset", "0+0.18x29 0+0.18x90", "0+0.82x29 0+0.82x90", None, True),
+    ):
+        inputs = [series("fountain_broker_ca_install_count",
+                         f'provider="sprites",outcome="{outcome}"', values)
+                  for outcome, values in (("exit", failed), ("ok", done),
+                                          ("unreachable", unavailable)) if values is not None]
+        # A busy healthy provider and proxy/health request traffic cannot
+        # dilute the failing provider's conversation setup ratio.
+        inputs.append(series("fountain_broker_ca_install_count",
+                             'provider="e2b",outcome="ok"', "0+1000x120"))
+        inputs.append(series("fountain_broker_request_count",
+                             'outcome="passthrough"', "0+1000x120"))
+        case("broker CA: " + name, "FountainBrokerCAInstallFailureRate", inputs,
+             '{provider="sprites"}' if fires else None)
 
     count = "fountain_turn_completed_duration_ms_count"
     for name, failed, done, fires in (


### PR DESCRIPTION
Add `FountainBrokerCAInstallFailureRate` to the portable rules: nonzero CA installer exits exceed 10% of actual conversation CA setups for a provider over one hour, with at least five attempts and ten minutes pending. A busy healthy provider cannot dilute another provider's failures, and proxy/health traffic never enters the denominator. Document the rule in the operations guide.

Third small unit of #1671, stacked on #1957. Three files, +46/-1. This supplies the portable alert; the hosted configuration and September 6 root-cause investigation remain separate.

Validation: promtool validates all 22 rules and passes all 54 expression cases, including nine new CA cases for missing/idle series, low volume, exactly 10%, the observed 18%, all failures, transport failures, counter resets and provider isolation. The documentation/metric focused suite passes all 50 tests. Full `mix precommit` passed: 5,377 core tests + 6 doctests, 144 Buzz tests and 33 Support tests, all with zero failures. Prose checks find no new errors; the existing two repository style findings remain elsewhere, and destink passes the edited page.
