### PR TITLE
fix(agents): snapshot persisted fields after stale-struct edits

### DIFF
--- a/apps/fountain/lib/fountain/agents.ex
+++ b/apps/fountain/lib/fountain/agents.ex
@@ -164,7 +164,10 @@ defmodule Fountain.Agents do
     result =
       if snapshot_needed?(changeset) do
         Repo.transaction(fn ->
-          with {:ok, updated} <- Repo.update(changeset),
+          # The caller may hold an older struct. RETURNING snapshots the
+          # persisted row, including fields changed by another edit, while
+          # this update holds the row lock through the version insert.
+          with {:ok, updated} <- Repo.update(changeset, returning: true),
                {:ok, _} <-
                  Repo.insert(version_changeset(updated, next_version_number(updated.id))) do
             updated

--- a/apps/fountain/test/fountain/agents_test.exs
+++ b/apps/fountain/test/fountain/agents_test.exs
@@ -217,6 +217,25 @@ defmodule Fountain.AgentsTest do
       assert length(Agents.list_agent_versions(agent.id, user.id)) == 2
     end
 
+    test "an edit from a stale agent snapshots the persisted configuration" do
+      user = insert_verified_user()
+      original = insert_agent(user_id: user.id, system: "original instructions")
+
+      assert {:ok, _} = Agents.update_agent(original, %{system: "revised instructions"})
+      assert {:ok, updated} = Agents.update_agent(original, %{description: "a second edit"})
+
+      persisted = Agents.get_agent(original.id, user.id)
+      assert persisted.system == "revised instructions"
+      assert persisted.description == "a second edit"
+      assert Agents.snapshot_config(updated) == Agents.snapshot_config(persisted)
+
+      assert [v3, v2, v1] = Agents.list_agent_versions(original.id, user.id)
+      assert {v3.version, v2.version, v1.version} == {3, 2, 1}
+      assert v3.config == Agents.snapshot_config(persisted)
+      assert v2.config["system"] == "revised instructions"
+      assert v1.config["system"] == "original instructions"
+    end
+
     test "a rejected update writes no version" do
       user = insert_verified_user()
       agent = insert_agent(user_id: user.id)


### PR DESCRIPTION
An edit made from a previously fetched agent struct can write a version that omits another edit already saved in the database. For example, saving new instructions and then changing the description through the original struct preserves both fields in the agent row but records the old instructions in its newest version. Request the complete persisted row with PostgreSQL `RETURNING` before inserting the version in the same transaction.

Small prerequisite for #1052: two files, +23/-1. Resource deletion and allowed-reference cleanup remain separate. This adds no query and preserves the transaction and post-commit audit boundaries.

Validation: the regression fails on the parent implementation and passes with this change. All 71 agent context, version API and version LiveView tests pass. Full `mix precommit` passed: 5,376 core tests + 6 doctests, 144 Buzz tests and 33 Support tests, all with zero failures.
