### PR TITLE
fix(comms): surface unidentified provider-accepted sends

### DIFF
--- a/apps/fountain/lib/fountain/team/comms/mcp.ex
+++ b/apps/fountain/lib/fountain/team/comms/mcp.ex
@@ -21,7 +21,7 @@ defmodule Fountain.Team.Comms.Mcp do
     * `:phone`   — the AgentPhone client module (default
                    `Fountain.Team.Comms.AgentPhone`)
     * `:audit`   — optional `(tool_name, summary_map) -> any` called after a
-                   successful send, for the audit trail
+                   provider-accepted send, including unidentified responses
   """
 
   alias Fountain.Team.Contact
@@ -231,12 +231,8 @@ defmodule Fountain.Team.Comms.Mcp do
         |> put_present("html", present(args["html"]))
 
       case mail(ctx).send_message(c.email_inbox_id, body) do
-        {:ok, %{"message_id" => mid} = resp} ->
-          audit(ctx, "email_send", %{"recipients" => length(to), "provider_message_id" => mid})
-          ok(id, %{message_id: mid, thread_id: resp["thread_id"]})
-
-        {:ok, other} ->
-          ok(id, other)
+        {:ok, resp} ->
+          finish_send(id, "email_send", ctx, resp, %{"recipients" => length(to)})
 
         {:error, reason} ->
           tool_error(id, "email_send failed: #{describe(reason)}")
@@ -256,16 +252,8 @@ defmodule Fountain.Team.Comms.Mcp do
         |> put_present("reply_all", if(args["reply_all"] == true, do: true))
 
       case mail(ctx).reply_to_message(c.email_inbox_id, message_id, body) do
-        {:ok, %{"message_id" => mid} = resp} ->
-          audit(ctx, "email_reply", %{
-            "reply_all" => args["reply_all"] == true,
-            "provider_message_id" => mid
-          })
-
-          ok(id, %{message_id: mid, thread_id: resp["thread_id"]})
-
-        {:ok, other} ->
-          ok(id, other)
+        {:ok, resp} ->
+          finish_send(id, "email_reply", ctx, resp, %{"reply_all" => args["reply_all"] == true})
 
         {:error, reason} ->
           tool_error(id, "email_reply failed: #{describe(reason)}")
@@ -321,12 +309,8 @@ defmodule Fountain.Team.Comms.Mcp do
       payload = %{"number_id" => c.phone_number_id, "to_number" => to, "body" => body}
 
       case phone(ctx).send_message(payload) do
-        {:ok, %{"id" => mid} = resp} ->
-          audit(ctx, "sms_send", %{"provider_message_id" => mid})
-          ok(id, %{message_id: mid, status: resp["status"], channel: resp["channel"]})
-
-        {:ok, other} ->
-          ok(id, other)
+        {:ok, resp} ->
+          finish_send(id, "sms_send", ctx, resp, %{})
 
         {:error, reason} ->
           tool_error(id, "sms_send failed: #{describe(reason)}")
@@ -417,6 +401,35 @@ defmodule Fountain.Team.Comms.Mcp do
 
   defp phone_contact(%{contact: %Contact{} = c}) do
     if Contact.phone?(c), do: {:ok, c}, else: {:error, "this teammate has no phone number"}
+  end
+
+  # Acceptance without an identifier is an ambiguous external effect. Keep
+  # the audit/metering callback informed, but never invent an id or invite a
+  # blind retry: the provider may already have delivered the message (#1520).
+  defp finish_send(id, tool, ctx, response, summary) do
+    id_field = if tool == "sms_send", do: "id", else: "message_id"
+    mid = if is_map(response), do: response[id_field]
+
+    if is_binary(mid) and String.trim(mid) != "" do
+      audit(ctx, tool, Map.put(summary, "provider_message_id", mid))
+
+      payload =
+        if tool == "sms_send" do
+          %{message_id: mid, status: response["status"], channel: response["channel"]}
+        else
+          %{message_id: mid, thread_id: response["thread_id"]}
+        end
+
+      ok(id, payload)
+    else
+      audit(ctx, tool, Map.put(summary, "outcome", "unidentified"))
+
+      tool_error(
+        id,
+        "#{tool}: the message may have been sent, but the provider returned no usable message ID. " <>
+          "Do not retry automatically; check the provider's records first."
+      )
+    end
   end
 
   defp audit(%{audit: audit}, tool, summary) when is_function(audit, 2), do: audit.(tool, summary)

--- a/apps/fountain/lib/fountain_web/controllers/team_comms_mcp_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/team_comms_mcp_controller.ex
@@ -104,6 +104,10 @@ defmodule FountainWeb.TeamCommsMcpController do
   # is no longer what anything prices from, which is the whole point — that
   # conflation is what made a dropped event a free message.
   defp record_message(user, contact, channel, event_type, summary, metadata) do
+    # Unidentified acceptance still reaches the product trail, explicitly
+    # labeled so it can be reconciled without fabricating a billable id.
+    metadata = Map.merge(metadata, Map.take(summary, ["outcome"]))
+
     case summary["provider_message_id"] do
       id when is_binary(id) and id != "" ->
         case Fountain.Team.Comms.record_message(%{

--- a/apps/fountain/test/fountain/team/comms/mcp_test.exs
+++ b/apps/fountain/test/fountain/team/comms/mcp_test.exs
@@ -101,6 +101,17 @@ defmodule Fountain.Team.Comms.McpTest do
     end
   end
 
+  defmodule UnidentifiedProvider do
+    def send_message(_), do: response()
+    def send_message(_, _), do: response()
+    def reply_to_message(_, _, _), do: response()
+
+    defp response do
+      send(self(), :provider_send)
+      {:ok, Process.get(:unidentified_comms_response)}
+    end
+  end
+
   @contact %Contact{
     id: "c1",
     email_address: "ada@agentmail.to",
@@ -173,6 +184,53 @@ defmodule Fountain.Team.Comms.McpTest do
       assert :noreply = handle(%{"method" => "notifications/initialized"}, ctx())
       assert %{"error" => %{"code" => -32_601}} = handle(%{"id" => 3, "method" => "nope"}, ctx())
       assert %{"result" => %{}} = handle(%{"id" => 4, "method" => "ping"}, ctx())
+    end
+  end
+
+  for {tool, args} <- [
+        {"email_send",
+         %{"to" => "private@example.com", "subject" => "private", "text" => "body"}},
+        {"email_reply", %{"message_id" => "original", "text" => "body"}},
+        {"sms_send", %{"to" => "+15550001111", "body" => "body"}}
+      ] do
+    @tag :unidentified_send
+    test "#{tool} audits unidentified acceptance and refuses to report success" do
+      tool = unquote(tool)
+      args = unquote(Macro.escape(args))
+      test = self()
+
+      ctx =
+        ctx(%{
+          mail: UnidentifiedProvider,
+          phone: UnidentifiedProvider,
+          audit: fn name, summary -> send(test, {:audit, name, summary}) end
+        })
+
+      for response <- [
+            nil,
+            [],
+            %{},
+            %{"message_id" => nil, "id" => nil},
+            %{"message_id" => "", "id" => ""},
+            %{"message_id" => "  ", "id" => "  "},
+            %{"message_id" => 123, "id" => 123},
+            %{"unexpected" => "private-provider-response"}
+          ] do
+        Process.put(:unidentified_comms_response, response)
+        result = call(tool, args, ctx)["result"]
+        assert result["isError"]
+        assert [%{"text" => message}] = result["content"]
+        assert message =~ "may have been sent"
+        assert message =~ "Do not retry automatically"
+        refute message =~ "private-provider-response"
+        assert_received :provider_send
+        refute_received :provider_send
+        assert_received {:audit, ^tool, summary}
+        assert summary["outcome"] == "unidentified"
+        refute Map.has_key?(summary, "provider_message_id")
+        refute inspect(summary) =~ "private"
+        refute_received {:audit, _, _}
+      end
     end
   end
 

--- a/apps/fountain/test/fountain_web/controllers/team_comms_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/team_comms_controller_test.exs
@@ -377,6 +377,51 @@ defmodule FountainWeb.TeamCommsControllerTest do
       refute inspect(event.metadata) =~ "+15550001111"
     end
 
+    @tag :unidentified_send
+    test "an unidentified send reaches the audit and usage trail without a fabricated charge", %{
+      conn: conn,
+      raw_key: key,
+      conv: conv,
+      user: user,
+      contact: contact
+    } do
+      Req.Test.stub(AgentPhone, fn conn ->
+        Req.Test.json(conn, %{"status" => "queued", "unexpected" => "private-provider-response"})
+      end)
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          body =
+            rpc(conn, key, conv.id, %{
+              "id" => 3,
+              "method" => "tools/call",
+              "params" => %{
+                "name" => "sms_send",
+                "arguments" => %{"to" => "+15550001111", "body" => "private body"}
+              }
+            })
+            |> json_response(200)
+
+          assert body["result"]["isError"]
+        end)
+
+      assert log =~ "returned no provider message id"
+      assert log =~ "it will not be billed"
+      refute log =~ "private-provider-response"
+
+      [audit] =
+        user.id
+        |> Fountain.Audit.list_recent_for_user(20)
+        |> Enum.filter(&(&1.action == "team.contact.sent"))
+
+      assert audit.resource_id == contact.id
+      assert audit.metadata["outcome"] == "unidentified"
+      refute inspect(audit.metadata) =~ "private"
+      [usage] = usage_events(user.id, "comms_sms_sent")
+      assert usage.metadata["outcome"] == "unidentified"
+      refute Fountain.Repo.get_by(Fountain.Team.CommsMessage, contact_id: contact.id)
+    end
+
     test "a read is not metered — only messages on the wire cost", %{
       conn: conn,
       raw_key: key,


### PR DESCRIPTION
When a comms provider accepted a send without a message ID, the tool reported success and skipped its audit/metering callback. Route every accepted email send, email reply and SMS send through one completion path. A missing, blank or invalid ID now produces an explicit MCP tool error: the message may already have been sent, so check the provider records before retrying.

The chosen policy is to refuse an unidentifiable success, rather than fabricate a billable provider ID. The existing audit and usage paths still record the accepted request, labeled `outcome: unidentified`, and the existing error log makes the billing gap visible. These requests remain unbilled until they can be reconciled; ordinary identified successes keep their response and billing behavior. Provider response contents, recipients and message bodies stay out of the audit metadata.

Closes #1520. Four files, +143/-23.

Validation: all 42 focused tests pass. Three protocol regressions exercise eight unidentified response shapes each, with one send and one audit callback per call. The authenticated controller regression verifies the tool error, audit row, labeled usage event, explicit error log and absence of a fabricated comms billing row. All four regressions fail on the parent implementation. Full `mix precommit` passed: 5,379 core tests + 6 doctests, 144 Buzz tests and 33 Support tests, all with zero failures.
