### PR TITLE
test(events): observe cursor advancement across filtered rows

### DIFF
--- a/apps/fountain/test/fountain_web/controllers/events_stream_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/events_stream_test.exs
@@ -177,6 +177,41 @@ defmodule FountainWeb.EventsStreamTest do
       assert conn.resp_body =~ "from-new"
     end
 
+    @tag :filtered_cursor_regression
+    test "filtered rows advance the durable cursor and stale notifications do not rescan them", %{
+      user: user,
+      raw_key: key
+    } do
+      conv = insert_conversation(user_id: user.id, status: "idle")
+      old = insert_log_event(conv, %{kind: "output", stream: "stdout", data: "old"})
+      await_stream_start(user.id)
+      task = stream_async(key, "/api/events/stream?streams=stage")
+      allow(Fountain.Conversations, self(), task.pid)
+      assert_receive {:stream_discovery, pid}, 2_000
+      hidden = insert_log_event(conv, %{kind: "output", stream: "stderr", data: "filtered-out"})
+      parent = self()
+
+      expect(Fountain.Conversations, :list_user_log_events, fn user_id, after_id ->
+        assert user_id == user.id
+        assert after_id == old.id
+        Mimic.call_original(Fountain.Conversations, :list_user_log_events, [user_id, after_id])
+      end)
+
+      expect(Fountain.Conversations, :list_user_log_events, fn user_id, after_id ->
+        assert user_id == user.id
+        assert after_id == hidden.id
+        send(parent, :advanced_filtered_cursor)
+        Mimic.call_original(Fountain.Conversations, :list_user_log_events, [user_id, after_id])
+      end)
+
+      send(pid, :continue_discovery)
+      assert_receive :advanced_filtered_cursor, 2_000
+      send(pid, {:log_event, hidden})
+      conn = Task.await(task, 5_000)
+      refute conn.resp_body =~ "filtered-out"
+      refute conn.resp_body =~ "event: log"
+    end
+
     @tag :discovery_regression
     test "a fast failure before discovery is replayed before a newer followed event", %{
       user: user,


### PR DESCRIPTION
The account-stream tests filtered out rows but did not observe the database cursor moving past them. Assert the next durable-feed read starts after the filtered row, and that a stale notification does not query or emit that row again. The request uses real database pages and the existing asynchronous SSE harness.

Regression-only unit of #1706: one test file, +35/-0. The independent transaction commit-order bug is addressed in a separate child PR.

Validation: all ten account-stream tests pass. Temporarily retaining the old cursor on filtered rows makes the new test fail at its next database read; restoring production code returns it to green. No production change is committed. Full `mix precommit` passed: 5,376 core tests + 6 doctests, 144 Buzz tests and 33 Support tests, all with zero failures.
