### PR TITLE
ci(deployed): require a protected environment before verification

### DIFF
--- a/.github/workflows/deployed.yml
+++ b/.github/workflows/deployed.yml
@@ -41,6 +41,9 @@ jobs:
     if: github.event_name != 'schedule' || (github.event.schedule == '23 */6 * * *' && vars.DEPLOYED_CANARY_ENABLED == 'true') || (github.event.schedule == '43 4 * * 6' && vars.DEPLOYED_MATRIX_ENABLED == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 2
+    permissions:
+      contents: read
+      actions: read
     steps:
       - name: Require approved target and main checkout
         env:
@@ -51,6 +54,14 @@ jobs:
             staging|production) ;;
             *) echo 'Target is not approved'; exit 1 ;;
           esac
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
+        with:
+          persist-credentials: false
+      - name: Require an existing environment with reviewers
+        env:
+          REQUESTED_TARGET: ${{ inputs.target || 'production' }}
+          GH_TOKEN: ${{ github.token }}
+        run: node deployed/validate-environment.mjs
   verify:
     needs: validate
     runs-on: ubuntu-latest

--- a/deployed/test/environment-preflight.test.mjs
+++ b/deployed/test/environment-preflight.test.mjs
@@ -1,0 +1,57 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { requireProtectedEnvironment } from '../validate-environment.mjs';
+
+const env = { GITHUB_REF: 'refs/heads/main', REQUESTED_TARGET: 'staging', GITHUB_REPOSITORY: 'owner/repo', GH_TOKEN: 'fixture-token' };
+const approved = type => ({ name: 'deployed-staging', protection_rules: [
+  { type: 'required_reviewers', reviewers: [{ type, reviewer: { id: 123 } }] },
+] });
+const reply = data => async () => ({ ok: true, json: async () => data });
+
+for (const [type, target] of [['User', 'staging'], ['Team', 'staging'], ['User', 'production'], ['Team', 'production']]) {
+  test(`a configured ${type} reviewer permits a read-only ${target} preflight`, async () => {
+    const calls = [];
+    const request = async (url, options) => {
+      calls.push({ url, options });
+      return reply({ ...approved(type), name: `deployed-${target}` })();
+    };
+    assert.equal(await requireProtectedEnvironment({ ...env, REQUESTED_TARGET: target }, request), `deployed-${target}`);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].url, `https://api.github.com/repos/owner/repo/environments/deployed-${target}`);
+    assert.equal(calls[0].options.method, 'GET');
+    assert.equal(calls[0].options.headers.Authorization, 'Bearer fixture-token');
+  });
+}
+
+for (const [name, metadata] of [
+  ['no metadata', null], ['wrong environment', { ...approved('User'), name: 'deployed-production' }],
+  ['no protection rules', { name: 'deployed-staging' }],
+  ['timer only', { name: 'deployed-staging', protection_rules: [{ type: 'wait_timer', wait_timer: 30 }] }],
+  ['empty reviewers', { name: 'deployed-staging', protection_rules: [{ type: 'required_reviewers', reviewers: [] }] }],
+  ['malformed reviewer', { name: 'deployed-staging', protection_rules: [{ type: 'required_reviewers', reviewers: [{}] }] }],
+]) {
+  test(`refuses ${name}`, async () => {
+    await assert.rejects(requireProtectedEnvironment(env, reply(metadata)), /configured required reviewers/);
+  });
+}
+
+for (const status of [403, 404]) {
+  test(`HTTP ${status} fails before an environment job can run`, async () => {
+    await assert.rejects(requireProtectedEnvironment(env, async () => ({ ok: false, status })), /create the environment with required reviewers/);
+  });
+}
+
+for (const changes of [{ GITHUB_REF: 'refs/heads/topic' }, { REQUESTED_TARGET: 'arbitrary' }, { GH_TOKEN: '' }]) {
+  test(`rejects invalid input ${Object.keys(changes)[0]} before any API call`, async () => {
+    let calls = 0;
+    await assert.rejects(requireProtectedEnvironment({ ...env, ...changes }, async () => { calls++; }));
+    assert.equal(calls, 0);
+  });
+}
+
+test('API and JSON errors do not print response contents or credentials', async () => {
+  for (const request of [async () => { throw new Error('private-response'); },
+    async () => ({ ok: true, json: async () => { throw new Error('private-response'); } })]) {
+    await assert.rejects(requireProtectedEnvironment(env, request), error => !/private-response|fixture-token/.test(error.message));
+  }
+});

--- a/deployed/validate-environment.mjs
+++ b/deployed/validate-environment.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Runs before a job names an environment: GitHub otherwise creates a missing
+// environment without protection rules when the job first references it.
+export async function requireProtectedEnvironment(env, request = fetch) {
+  if (env.GITHUB_REF !== 'refs/heads/main') throw new Error('Verification requires main');
+  if (!['staging', 'production'].includes(env.REQUESTED_TARGET)) throw new Error('Target is not approved');
+  if (!/^[\w.-]+\/[\w.-]+$/.test(env.GITHUB_REPOSITORY || '') || !env.GH_TOKEN) throw new Error('Environment preflight requires repository read credentials');
+  const name = `deployed-${env.REQUESTED_TARGET}`;
+  const api = (env.GITHUB_API_URL || 'https://api.github.com').replace(/\/$/, '');
+  let response;
+  try {
+    response = await request(`${api}/repos/${env.GITHUB_REPOSITORY}/environments/${name}`, {
+      method: 'GET',
+      headers: { Accept: 'application/vnd.github+json', 'X-GitHub-Api-Version': '2026-03-10', Authorization: `Bearer ${env.GH_TOKEN}` },
+      signal: AbortSignal.timeout(15000),
+    });
+  } catch {
+    throw new Error(`Cannot inspect ${name}; check GitHub API access before verification`);
+  }
+  if (!response.ok) throw new Error(`Cannot read ${name} (HTTP ${response.status}); create the environment with required reviewers before verification`);
+  let environment;
+  try { environment = await response.json(); }
+  catch { throw new Error(`Invalid environment metadata for ${name}`); }
+  const protectedTarget = environment?.name === name && Array.isArray(environment.protection_rules) &&
+    environment.protection_rules.some(rule => rule?.type === 'required_reviewers' &&
+      Array.isArray(rule.reviewers) && rule.reviewers.some(entry =>
+        ['User', 'Team'].includes(entry?.type) && Number.isInteger(entry.reviewer?.id) && entry.reviewer.id > 0));
+  if (!protectedTarget) throw new Error(`${name} must have configured required reviewers before verification`);
+  return name;
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try { console.log(`Environment preflight passed: ${await requireProtectedEnvironment(process.env)}`); }
+  catch (error) { console.error(error.message); process.exitCode = 2; }
+}


### PR DESCRIPTION
A deployed verification job can cause GitHub to create a missing target environment without reviewers. Add a read-only preflight in the existing validation job, before the verification job references its environment. Both manual and enabled scheduled runs must find the expected environment with at least one configured user or team reviewer; missing environments, API failures and incomplete protection metadata stop the run.

Small unit of #1697. This does not create environments, enable schedules, configure credentials or run the suite against a deployment. Cleanup replay, account funding and setup diagnostics remain separate. Current read-only inspection finds only `github-pages` and `pypi`, so deployed targets must still be configured by an operator.

The validation job receives only the additional `actions: read` permission required by GitHub's [Get an environment endpoint](https://docs.github.com/en/rest/deployments/environments#get-an-environment). The verification job's permissions stay unchanged.

Validation: All 204 deployed-suite tests pass, including 16 new preflight cases for staging/production, user/team reviewers, missing or malformed protection, API failures and invalid inputs. `actionlint` passes the changed workflow. Three files, +106/-0. Full `mix precommit` passed: 5,375 core tests + 6 doctests, 144 Buzz tests and 33 Support tests, all with zero failures.
