### PR TITLE
ci(deployed): report safe setup diagnostics

### DIFF
--- a/deployed/ci.mjs
+++ b/deployed/ci.mjs
@@ -7,25 +7,38 @@ import { runMatrix, validateMatrix } from './matrix.mjs';
 
 const matrixSubset = profile => ({ 'matrix-canary': 'canary', 'matrix-scheduled': 'scheduled', 'matrix-full': 'full' })[profile];
 
+// Only controlled configuration messages may reach CI stderr. Parser errors
+// can quote input values; unexpected errors can contain credentials or paths.
+class SetupError extends Error {}
+function settingObject(env, name) {
+  let value;
+  try { value = JSON.parse(env[name] || '{}'); }
+  catch { throw new SetupError(`${name} must contain valid JSON`); }
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new SetupError(`${name} must be a JSON object`);
+  return value;
+}
+
 export function ciConfig(env) {
-  if (!['staging', 'production'].includes(env.SUITE_TARGET)) throw new Error('Target is not approved');
-  if (env.SUITE_ENABLED !== 'true') throw new Error('Target environment is not enabled');
-  if (!['probe', 'basic', 'execution', 'streaming', 'canary', 'secrets', 'mcp', 'webhooks', 'schedules'].includes(env.SUITE_PROFILE) && !matrixSubset(env.SUITE_PROFILE)) throw new Error('Profile is not approved');
-  const config = JSON.parse(env.SUITE_TARGET_JSON || '{}');
-  const url = new URL(config.base_url);
-  if (url.protocol !== 'https:') throw new Error('CI targets require HTTPS ingress');
+  if (!['staging', 'production'].includes(env.SUITE_TARGET)) throw new SetupError('Target is not approved');
+  if (env.SUITE_ENABLED !== 'true') throw new SetupError('Target environment is not enabled');
+  if (!['probe', 'basic', 'execution', 'streaming', 'canary', 'secrets', 'mcp', 'webhooks', 'schedules'].includes(env.SUITE_PROFILE) && !matrixSubset(env.SUITE_PROFILE)) throw new SetupError('Profile is not approved');
+  const config = settingObject(env, 'SUITE_TARGET_JSON');
+  let url;
+  try { url = new URL(config.base_url); }
+  catch { throw new SetupError('SUITE_TARGET_JSON must contain a valid base_url'); }
+  if (url.protocol !== 'https:') throw new SetupError('CI targets require HTTPS ingress');
   config.credentials = { primary: 'FOUNTAIN_SUITE_KEY', secondary: 'FOUNTAIN_SUITE_OTHER_KEY' };
   config.profiles = matrixSubset(env.SUITE_PROFILE) ? ['probe'] : env.SUITE_PROFILE === 'canary' ? ['basic', 'execution'] : [env.SUITE_PROFILE];
   // Bound exposure even if an environment variable accidentally requests a longer run.
   config.limits = { request_ms: 30000, run_ms: env.SUITE_PROFILE === 'schedules' ? 900000 : 420000, cleanup_ms: 90000, resources: 12 };
   if (config.execution) config.execution = { ...config.execution, provision_ms: 120000, turn_ms: 90000, max_turns: env.SUITE_PROFILE === 'webhooks' ? 0 : ['secrets', 'schedules'].includes(env.SUITE_PROFILE) ? 1 : 2 };
   if (env.SUITE_MODE === 'rollout') {
-    if (!config.deployment) throw new Error('Rollout requires an environment-owned deployment adapter');
+    if (!config.deployment) throw new SetupError('Rollout requires an environment-owned deployment adapter');
     config.deployment.expected_digest = env.SUITE_EXPECTED_DIGEST;
   } else if (env.SUITE_MODE === 'public') {
-    if (env.SUITE_EXPECTED_DIGEST) throw new Error('Expected digest requires rollout mode');
+    if (env.SUITE_EXPECTED_DIGEST) throw new SetupError('Expected digest requires rollout mode');
     delete config.deployment;
-  } else throw new Error('Unknown verification mode');
+  } else throw new SetupError('Unknown verification mode');
   return config;
 }
 
@@ -37,8 +50,11 @@ export async function ciMain(env = process.env) {
   try {
     const config = ciConfig(env);
     const subset = matrixSubset(env.SUITE_PROFILE);
-    const matrix = subset ? JSON.parse(env.SUITE_MATRIX_JSON || '{}') : undefined;
-    if (matrix) validateMatrix(matrix, subset);
+    const matrix = subset ? settingObject(env, 'SUITE_MATRIX_JSON') : undefined;
+    if (matrix) {
+      try { validateMatrix(matrix, subset); }
+      catch { throw new SetupError('SUITE_MATRIX_JSON must describe a valid bounded matrix'); }
+    }
     const root = resolve(env.RUNNER_TEMP || '.', `deployed-${env.GITHUB_RUN_ID || 'local'}-${env.GITHUB_RUN_ATTEMPT || '1'}`);
     mkdirSync(root, { mode: 0o700 });
     const configPath = resolve(root, 'target.json');
@@ -56,5 +72,9 @@ export async function ciMain(env = process.env) {
 }
 if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
   try { process.exitCode = await ciMain(); }
-  catch { console.error('CI setup failed; check approved target configuration and required environment settings'); process.exitCode = 2; }
+  catch (error) {
+    console.error(error instanceof SetupError ? `CI setup failed: ${error.message}` :
+      'CI setup failed; check approved target configuration and required environment settings');
+    process.exitCode = 2;
+  }
 }

--- a/deployed/test/ci-diagnostics.test.mjs
+++ b/deployed/test/ci-diagnostics.test.mjs
@@ -1,0 +1,51 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, readdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const cli = fileURLToPath(new URL('../ci.mjs', import.meta.url));
+const secret = 'private-configuration-marker';
+const base = { SUITE_TARGET: 'staging', SUITE_ENABLED: 'true', SUITE_PROFILE: 'probe',
+  SUITE_MODE: 'public', SUITE_TARGET_JSON: '{"base_url":"https://example.test"}',
+  FOUNTAIN_SUITE_KEY: secret };
+
+for (const [name, changes, diagnostic] of [
+  ['target', { SUITE_TARGET: secret }, 'Target is not approved'],
+  ['enablement', { SUITE_ENABLED: '' }, 'Target environment is not enabled'],
+  ['profile', { SUITE_PROFILE: secret }, 'Profile is not approved'],
+  ['target JSON', { SUITE_TARGET_JSON: '{"password":"' + secret + '"' }, 'SUITE_TARGET_JSON must contain valid JSON'],
+  ['target shape', { SUITE_TARGET_JSON: '[]' }, 'SUITE_TARGET_JSON must be a JSON object'],
+  ['base URL', { SUITE_TARGET_JSON: JSON.stringify({ base_url: secret }) }, 'SUITE_TARGET_JSON must contain a valid base_url'],
+  ['HTTPS', { SUITE_TARGET_JSON: '{"base_url":"http://example.test"}' }, 'CI targets require HTTPS ingress'],
+  ['mode', { SUITE_MODE: secret }, 'Unknown verification mode'],
+  ['rollout', { SUITE_MODE: 'rollout' }, 'Rollout requires an environment-owned deployment adapter'],
+  ['matrix JSON', { SUITE_PROFILE: 'matrix-canary', SUITE_MATRIX_JSON: '{"password":"' + secret + '"' }, 'SUITE_MATRIX_JSON must contain valid JSON'],
+  ['matrix shape', { SUITE_PROFILE: 'matrix-canary', SUITE_MATRIX_JSON: 'null' }, 'SUITE_MATRIX_JSON must be a JSON object'],
+  ['matrix validation', { SUITE_PROFILE: 'matrix-canary', SUITE_MATRIX_JSON: '{}' }, 'SUITE_MATRIX_JSON must describe a valid bounded matrix'],
+]) {
+  test('CI reports the failing ' + name + ' setting without exposing configuration', () => {
+    const root = mkdtempSync(join(tmpdir(), 'fountain-ci-diagnostics-'));
+    try {
+      const result = spawnSync(process.execPath, [cli], { env: { ...base, ...changes, RUNNER_TEMP: root }, encoding: 'utf8', timeout: 5000 });
+      assert.equal(result.status, 2, result.stderr);
+      assert.ok(result.stderr.includes(diagnostic), result.stderr);
+      assert.ok(!result.stderr.includes(secret));
+      assert.deepEqual(readdirSync(root), [], 'configuration errors must precede file creation and execution');
+    } finally { rmSync(root, { recursive: true, force: true }); }
+  });
+}
+
+test('unexpected setup errors retain the generic message without private paths', () => {
+  const root = mkdtempSync(join(tmpdir(), 'fountain-ci-diagnostics-'));
+  mkdirSync(join(root, 'deployed-' + secret + '-1'));
+  try {
+    const result = spawnSync(process.execPath, [cli], { env: { ...base, RUNNER_TEMP: root, GITHUB_RUN_ID: secret }, encoding: 'utf8', timeout: 5000 });
+    assert.equal(result.status, 2);
+    assert.match(result.stderr, /CI setup failed; check approved target configuration/);
+    assert.ok(!result.stderr.includes(secret));
+    assert.ok(!result.stderr.includes(root));
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});


### PR DESCRIPTION
Every CI setup error previously printed the same generic message, so an operator could not tell whether enablement, target JSON, profile selection or rollout configuration was wrong. Report controlled configuration messages with the failing setting named. Wrap JSON and URL parser errors so their input excerpts never reach logs; unexpected failures retain the generic message.

Both target and matrix settings must be JSON objects. A matrix setting of `null` can no longer fall back to the probe profile. Setup validation still occurs before creating run files or making requests.

Separate diagnostics unit of #1697, stacked on #1962. Two files, +83/-12. Environment credentials, cleanup replay and operator enablement remain separate.

Validation: all 217 deployed-suite tests pass. Thirteen CLI subprocess cases verify actionable messages, unchanged exit code 2, no run files on configuration failures, hidden secret markers and generic handling of unexpected filesystem errors. Twelve cases fail on the parent implementation; its generic-error preservation case already passes. Full `mix precommit` passed: 5,375 core tests + 6 doctests, 144 Buzz tests and 33 Support tests, all with zero failures.


## This closes a fail-open hole, not just a message

Flagged in review and worth stating plainly, because the title reads as
diagnostics-only. On the parent commit (`3ea371ce`), `SUITE_MATRIX_JSON='null'`
with `SUITE_PROFILE=matrix-canary` parsed to `null`, so `validateMatrix` was
skipped, no `matrix.json` was written, and the job silently ran the plain
single-target suite with `profiles: ["probe"]` — exiting 0 against a healthy
target. A matrix deployment verification that verified one probe and reported
success. Reproduced at that commit during review.

`settingObject()` now rejects it.
