### PR TITLE
fix(deployed): replay cleanup across run manifests

### DIFF
--- a/deployed/cleanup-replay.mjs
+++ b/deployed/cleanup-replay.mjs
@@ -1,12 +1,14 @@
 #!/usr/bin/env node
 import { lstatSync, readdirSync, mkdirSync } from 'node:fs';
-import { resolve, join, relative, sep } from 'node:path';
+import { resolve, join, relative, sep, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { parseArgs } from 'node:util';
 import { run } from './lib/runner.mjs';
 import { atomicJson } from './lib/fixtures.mjs';
 
-function manifests(root) {
+export const REPLAY_START_MS = 120000;
+
+function manifests(root, allowEmpty) {
   const found = [];
   let visited = 0;
   function visit(path, depth) {
@@ -17,51 +19,79 @@ function manifests(root) {
       for (const name of readdirSync(path).sort()) visit(join(path, name), depth + 1);
     } else if (stat.isFile() && path.endsWith(sep + 'cleanup.json')) found.push(path);
   }
-  if (!lstatSync(root).isDirectory()) throw new Error('Expected a cleanup evidence directory');
+  const stat = lstatSync(root, { throwIfNoEntry: false });
+  if (!stat && allowEmpty) return found;
+  if (!stat?.isDirectory()) throw new Error('Expected a cleanup evidence directory');
   visit(root, 0);
   // The full matrix has sixteen cells plus its preflight run.
-  if (!found.length || found.length > 17) throw new Error('Expected between one and seventeen cleanup manifests');
+  if ((!found.length && !allowEmpty) || found.length > 17) throw new Error('Expected between one and seventeen cleanup manifests');
   return found;
 }
 
 export async function replayCleanup({ configPath, resultsRoot, out, env = process.env,
-  signal = AbortSignal.timeout(180000), execute = run }) {
+  signal, allowEmpty = false, execute = run }) {
+  const deadline = AbortSignal.timeout(REPLAY_START_MS);
+  signal = signal ? AbortSignal.any([signal, deadline]) : deadline;
   resultsRoot = resolve(resultsRoot); out = resolve(out); configPath = resolve(configPath);
   if (out === resultsRoot || out.startsWith(resultsRoot + sep)) throw new Error('Keep replay evidence outside the source results');
-  if (!lstatSync(configPath).isFile() || lstatSync(configPath).isSymbolicLink()) throw new Error('Expected a regular target configuration');
-  const files = manifests(resultsRoot); // Validate the entire tree before any API call.
+  const files = manifests(resultsRoot, allowEmpty); // Validate the entire tree before any API call.
+  if (files.length && !lstatSync(configPath).isFile()) throw new Error('Expected a regular target configuration');
+  // CI can fail before it creates the run root or target file. An empty report
+  // records the absence of journals; it does not assert that cleanup passed.
+  if (!files.length) mkdirSync(dirname(out), { recursive: true, mode: 0o700 });
   mkdirSync(out, { mode: 0o700 });
   const report = { version: 1, status: 'running', entries: files.map(path => ({ manifest: relative(resultsRoot, path), status: 'not_run' })) };
   const save = () => atomicJson(join(out, 'replay.json'), report);
   save();
-  for (const [index, manifestPath] of files.entries()) {
-    if (signal.aborted) break;
-    const entry = report.entries[index];
-    entry.status = 'running'; save();
-    try {
-      // Supplying manifestPath always selects cleanup mode. The runner retains
-      // its owner/target/resource checks and fresh bounded cleanup signal.
-      entry.code = await execute({ configPath, manifestPath, out: join(out, `manifest-${index}`), env, signal, log() {} });
-      entry.status = entry.code === 0 ? 'passed' : 'failed';
-    } catch {
-      entry.status = 'failed'; // Never copy raw configuration or response errors.
+  const interrupted = () => {
+    report.status = 'cleanup_failed';
+    report.stop_reason = signal.reason?.name === 'TimeoutError' ? 'deadline' : 'interrupted';
+    for (const entry of report.entries.filter(entry => entry.status === 'running')) entry.status = 'interrupted';
+    save(); // Persist before waiting for cleanup; a subsequent hard kill may win.
+  };
+  signal.addEventListener('abort', interrupted, { once: true });
+  try {
+    if (signal.aborted) interrupted();
+    for (const [index, manifestPath] of files.entries()) {
+      if (signal.aborted) break;
+      const entry = report.entries[index];
+      entry.status = 'running'; save();
+      try {
+        // Supplying manifestPath always selects cleanup mode. The runner retains
+        // its owner/target/resource checks and fresh bounded cleanup signal.
+        entry.code = await execute({ configPath, manifestPath, out: join(out, `manifest-${index}`), env, signal, log() {} });
+        entry.status = entry.code === 0 ? 'passed' : 'failed';
+      } catch {
+        entry.status = 'failed'; // Never copy raw configuration or response errors.
+        entry.error = 'execution_threw';
+      }
+      save(); // One bad manifest must not prevent other run-owned cleanup.
     }
-    save(); // One bad manifest must not prevent other run-owned cleanup.
+    report.status = signal.aborted ? 'cleanup_failed' : !files.length ? 'no_manifests' :
+      report.entries.every(entry => entry.status === 'passed') ? 'passed' : 'cleanup_failed';
+    save();
+    return ['passed', 'no_manifests'].includes(report.status) ? 0 : 3;
+  } finally {
+    signal.removeEventListener('abort', interrupted);
   }
-  report.status = report.entries.every(entry => entry.status === 'passed') ? 'passed' : 'cleanup_failed';
-  save();
-  return report.status === 'passed' ? 0 : 3;
 }
 
 if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const controller = new AbortController();
+  const cancel = () => controller.abort(new Error('Interrupted'));
+  process.on('SIGINT', cancel); process.on('SIGTERM', cancel);
   try {
     const { values, positionals } = parseArgs({ allowPositionals: true, options: {
       config: { type: 'string' }, results: { type: 'string' }, out: { type: 'string' },
+      'allow-empty': { type: 'boolean', default: false },
     } });
     if (positionals.length || !values.config || !values.results || !values.out) throw new Error('Missing cleanup replay arguments');
-    process.exitCode = await replayCleanup({ configPath: values.config, resultsRoot: values.results, out: values.out });
+    process.exitCode = await replayCleanup({ configPath: values.config, resultsRoot: values.results, out: values.out,
+      allowEmpty: values['allow-empty'], signal: controller.signal });
   } catch {
     console.error('Cleanup replay setup failed; retain the original manifests and inspect the target configuration and evidence paths');
     process.exitCode = 2;
+  } finally {
+    process.off('SIGINT', cancel); process.off('SIGTERM', cancel);
   }
 }

--- a/deployed/cleanup-replay.mjs
+++ b/deployed/cleanup-replay.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+import { lstatSync, readdirSync, mkdirSync } from 'node:fs';
+import { resolve, join, relative, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseArgs } from 'node:util';
+import { run } from './lib/runner.mjs';
+import { atomicJson } from './lib/fixtures.mjs';
+
+function manifests(root) {
+  const found = [];
+  let visited = 0;
+  function visit(path, depth) {
+    if (++visited > 512 || depth > 4) throw new Error('Cleanup evidence exceeds traversal bounds');
+    const stat = lstatSync(path);
+    if (stat.isSymbolicLink()) throw new Error('Cleanup evidence must not contain symbolic links');
+    if (stat.isDirectory()) {
+      for (const name of readdirSync(path).sort()) visit(join(path, name), depth + 1);
+    } else if (stat.isFile() && path.endsWith(sep + 'cleanup.json')) found.push(path);
+  }
+  if (!lstatSync(root).isDirectory()) throw new Error('Expected a cleanup evidence directory');
+  visit(root, 0);
+  // The full matrix has sixteen cells plus its preflight run.
+  if (!found.length || found.length > 17) throw new Error('Expected between one and seventeen cleanup manifests');
+  return found;
+}
+
+export async function replayCleanup({ configPath, resultsRoot, out, env = process.env,
+  signal = AbortSignal.timeout(180000), execute = run }) {
+  resultsRoot = resolve(resultsRoot); out = resolve(out); configPath = resolve(configPath);
+  if (out === resultsRoot || out.startsWith(resultsRoot + sep)) throw new Error('Keep replay evidence outside the source results');
+  if (!lstatSync(configPath).isFile() || lstatSync(configPath).isSymbolicLink()) throw new Error('Expected a regular target configuration');
+  const files = manifests(resultsRoot); // Validate the entire tree before any API call.
+  mkdirSync(out, { mode: 0o700 });
+  const report = { version: 1, status: 'running', entries: files.map(path => ({ manifest: relative(resultsRoot, path), status: 'not_run' })) };
+  const save = () => atomicJson(join(out, 'replay.json'), report);
+  save();
+  for (const [index, manifestPath] of files.entries()) {
+    if (signal.aborted) break;
+    const entry = report.entries[index];
+    entry.status = 'running'; save();
+    try {
+      // Supplying manifestPath always selects cleanup mode. The runner retains
+      // its owner/target/resource checks and fresh bounded cleanup signal.
+      entry.code = await execute({ configPath, manifestPath, out: join(out, `manifest-${index}`), env, signal, log() {} });
+      entry.status = entry.code === 0 ? 'passed' : 'failed';
+    } catch {
+      entry.status = 'failed'; // Never copy raw configuration or response errors.
+    }
+    save(); // One bad manifest must not prevent other run-owned cleanup.
+  }
+  report.status = report.entries.every(entry => entry.status === 'passed') ? 'passed' : 'cleanup_failed';
+  save();
+  return report.status === 'passed' ? 0 : 3;
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    const { values, positionals } = parseArgs({ allowPositionals: true, options: {
+      config: { type: 'string' }, results: { type: 'string' }, out: { type: 'string' },
+    } });
+    if (positionals.length || !values.config || !values.results || !values.out) throw new Error('Missing cleanup replay arguments');
+    process.exitCode = await replayCleanup({ configPath: values.config, resultsRoot: values.results, out: values.out });
+  } catch {
+    console.error('Cleanup replay setup failed; retain the original manifests and inspect the target configuration and evidence paths');
+    process.exitCode = 2;
+  }
+}

--- a/deployed/test/cleanup-replay.test.mjs
+++ b/deployed/test/cleanup-replay.test.mjs
@@ -1,0 +1,104 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, symlinkSync, existsSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { replayCleanup } from '../cleanup-replay.mjs';
+
+function workspace(t) {
+  const dir = mkdtempSync(join(tmpdir(), 'fountain-cleanup-replay-'));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  const resultsRoot = join(dir, 'results'); mkdirSync(resultsRoot);
+  const configPath = join(dir, 'target.json'); writeFileSync(configPath, '{}');
+  return { dir, configPath, resultsRoot, out: join(dir, 'replay') };
+}
+function journal(root, cell, baseUrl, ownerId) {
+  const dir = join(root, cell); mkdirSync(dir, { recursive: true });
+  const runId = randomUUID();
+  const resource = { kind: 'environment', id: randomUUID(), name: `suite-${runId}-environment-0`, state: 'created' };
+  writeFileSync(join(dir, 'cleanup.json'), JSON.stringify({ version: 1, run_id: runId, base_url: baseUrl, owner_id: ownerId, resources: [resource] }));
+  return resource;
+}
+
+test('real cleanup continues after foreign-owner rejection and replay is idempotent', async t => {
+  const w = workspace(t); const ownerId = randomUUID(); const key = randomUUID();
+  const resources = new Map(); const requests = []; const deleted = [];
+  const server = createServer((req, res) => {
+    requests.push([req.method, req.url]);
+    assert.equal(req.headers.authorization, `Bearer ${key}`);
+    let status = 404; let body = { error: 'not_found' };
+    if (req.url === '/api/auth/me') {
+      status = 200; body = { id: ownerId, email: 'test@example.test', email_verified: true, role: 'user' };
+    } else if (req.url.startsWith('/api/environments/')) {
+      const id = req.url.split('/').at(-1);
+      if (resources.has(id)) {
+        if (req.method === 'DELETE') { deleted.push(id); resources.delete(id); status = 204; body = undefined; }
+        else { status = 200; body = { data: resources.get(id) }; }
+      }
+    }
+    res.writeHead(status, { 'content-type': 'application/json' }); res.end(body && JSON.stringify(body));
+  });
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  t.after(async () => { server.closeAllConnections(); await new Promise(resolve => server.close(resolve)); });
+  const baseUrl = `http://127.0.0.1:${server.address().port}`;
+  writeFileSync(w.configPath, JSON.stringify({ base_url: baseUrl, credentials: { primary: 'SUITE_TEST_KEY' }, profiles: ['probe'] }));
+  const foreign = journal(w.resultsRoot, 'a-foreign', baseUrl, randomUUID());
+  const valid = [journal(w.resultsRoot, '', baseUrl, ownerId), journal(w.resultsRoot, 'z-cell', baseUrl, ownerId)];
+  for (const r of [foreign, ...valid]) resources.set(r.id, r);
+  const options = { ...w, env: { SUITE_TEST_KEY: key } };
+  assert.equal(await replayCleanup(options), 3);
+  assert.deepEqual(deleted, valid.map(r => r.id));
+  assert.ok(resources.has(foreign.id));
+  assert.ok(!requests.some(([, url]) => url.includes(foreign.id)));
+  assert.ok(requests.every(([method, url]) => method === 'GET' || (method === 'DELETE' && url.startsWith('/api/environments/'))));
+  const reportText = readFileSync(join(w.out, 'replay.json'), 'utf8');
+  assert.deepEqual(JSON.parse(reportText).entries.map(e => e.status), ['failed', 'passed', 'passed']);
+  assert.ok(!reportText.includes(key));
+  assert.equal(await replayCleanup({ ...options, out: join(w.dir, 'again') }), 3);
+  assert.equal(deleted.length, 2);
+  // Once the invalid journal is corrected, a complete replay can pass.
+  const foreignPath = join(w.resultsRoot, 'a-foreign', 'cleanup.json');
+  const corrected = JSON.parse(readFileSync(foreignPath)); corrected.owner_id = ownerId;
+  writeFileSync(foreignPath, JSON.stringify(corrected));
+  assert.equal(await replayCleanup({ ...options, out: join(w.dir, 'complete') }), 0);
+  assert.deepEqual(deleted, [...valid.map(r => r.id), foreign.id]);
+});
+
+for (const scenario of ['empty', 'symlink', 'config symlink', 'too many', 'too deep', 'nested output']) {
+  test(`rejects ${scenario} before any execution or output creation`, async t => {
+    const w = workspace(t);
+    if (scenario !== 'empty') journal(w.resultsRoot, '', 'https://example.test', randomUUID());
+    if (scenario === 'symlink') symlinkSync(w.configPath, join(w.resultsRoot, 'linked'));
+    if (scenario === 'config symlink') { symlinkSync(w.configPath, join(w.dir, 'linked-config')); w.configPath = join(w.dir, 'linked-config'); }
+    if (scenario === 'too many') for (let i = 0; i < 17; i++) journal(w.resultsRoot, `cell-${i}`, 'https://example.test', randomUUID());
+    if (scenario === 'too deep') journal(w.resultsRoot, 'a/b/c/d/e', 'https://example.test', randomUUID());
+    if (scenario === 'nested output') w.out = join(w.resultsRoot, 'replay');
+    let calls = 0;
+    await assert.rejects(replayCleanup({ ...w, execute: async () => { calls++; } }));
+    assert.equal(calls, 0); assert.equal(existsSync(w.out), false);
+  });
+}
+
+test('aborted replay records untouched manifests and cannot claim success', async t => {
+  const w = workspace(t); journal(w.resultsRoot, '', 'https://example.test', randomUUID());
+  let calls = 0;
+  assert.equal(await replayCleanup({ ...w, signal: AbortSignal.abort(), execute: async () => { calls++; } }), 3);
+  assert.equal(calls, 0);
+  assert.equal(JSON.parse(readFileSync(join(w.out, 'replay.json'))).entries[0].status, 'not_run');
+});
+
+test('thrown errors stay private and do not prevent later cleanup', async t => {
+  const w = workspace(t);
+  for (const cell of ['a', 'b']) journal(w.resultsRoot, cell, 'https://example.test', randomUUID());
+  const secret = randomUUID(); let calls = 0;
+  assert.equal(await replayCleanup({ ...w, execute: async ({ signal, manifestPath }) => {
+    assert.equal(signal.aborted, false); assert.ok(manifestPath.endsWith('cleanup.json'));
+    if (++calls === 1) throw new Error(secret);
+    return 0;
+  } }), 3);
+  const report = readFileSync(join(w.out, 'replay.json'), 'utf8');
+  assert.equal(calls, 2); assert.ok(!report.includes(secret));
+  assert.deepEqual(JSON.parse(report).entries.map(e => e.status), ['failed', 'passed']);
+});

--- a/deployed/test/cleanup-replay.test.mjs
+++ b/deployed/test/cleanup-replay.test.mjs
@@ -5,6 +5,10 @@ import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, symlinkSync, exist
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { fileURLToPath } from 'node:url';
 import { replayCleanup } from '../cleanup-replay.mjs';
 
 function workspace(t) {
@@ -101,4 +105,101 @@ test('thrown errors stay private and do not prevent later cleanup', async t => {
   const report = readFileSync(join(w.out, 'replay.json'), 'utf8');
   assert.equal(calls, 2); assert.ok(!report.includes(secret));
   assert.deepEqual(JSON.parse(report).entries.map(e => e.status), ['failed', 'passed']);
+  assert.equal(JSON.parse(report).entries[0].error, 'execution_threw');
 });
+
+function cli(t, w, extra = [], env = {}) {
+  const child = spawn(process.execPath, [fileURLToPath(new URL('../cleanup-replay.mjs', import.meta.url)),
+    '--config', w.configPath, '--results', w.resultsRoot, '--out', w.out, ...extra], {
+    env: { ...process.env, ...env }, stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const exited = once(child, 'exit');
+  let stderr = '';
+  child.stderr.on('data', data => { stderr += data; });
+  t.after(() => { if (child.exitCode === null && child.signalCode === null) child.kill('SIGKILL'); });
+  return { child, exited, stderr: () => stderr };
+}
+
+for (const missingRoot of [false, true]) {
+  test(`CI empty replay records no_manifests with missing root=${missingRoot}`, async t => {
+    const w = workspace(t);
+    rmSync(w.configPath);
+    if (missingRoot) {
+      rmSync(w.resultsRoot, { recursive: true });
+      w.resultsRoot = join(w.dir, 'not-created', 'results');
+      w.out = join(w.dir, 'not-created', 'replay');
+    } else writeFileSync(join(w.resultsRoot, 'result.json'), JSON.stringify({ status: 'setup_failed' }));
+    const child = cli(t, w, ['--allow-empty']);
+    assert.deepEqual(await child.exited, [0, null]);
+    assert.equal(child.stderr(), '');
+    assert.deepEqual(JSON.parse(readFileSync(join(w.out, 'replay.json'))), { version: 1, status: 'no_manifests', entries: [] });
+  });
+}
+
+test('allow-empty still rejects unsafe evidence and missing config with a manifest', async t => {
+  const w = workspace(t);
+  symlinkSync(w.configPath, join(w.resultsRoot, 'linked'));
+  await assert.rejects(replayCleanup({ ...w, allowEmpty: true }), /symbolic links/);
+  rmSync(join(w.resultsRoot, 'linked'));
+  journal(w.resultsRoot, '', 'https://example.test', randomUUID());
+  rmSync(w.configPath);
+  await assert.rejects(replayCleanup({ ...w, allowEmpty: true }));
+  assert.equal(existsSync(w.out), false);
+});
+
+for (const signal of ['SIGINT', 'SIGTERM', 'deadline']) {
+  test(`${signal} during real cleanup persists interruption and lets the active cleanup finish`, { timeout: 15000 }, async t => {
+    const w = workspace(t); const ownerId = randomUUID(); const key = randomUUID();
+    let beginDelete;
+    const deleting = new Promise(resolve => { beginDelete = resolve; });
+    const requests = [];
+    let resource;
+    const server = createServer((req, res) => {
+      requests.push([req.method, req.url]);
+      assert.equal(req.headers.authorization, `Bearer ${key}`);
+      if (req.url === '/api/auth/me') {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ id: ownerId, email: 'test@example.test', email_verified: true, role: 'user' }));
+      } else if (req.method === 'DELETE') {
+        beginDelete(() => { res.writeHead(204); res.end(); });
+      } else {
+        res.writeHead(200, { 'content-type': 'application/json' }); res.end(JSON.stringify({ data: resource }));
+      }
+    });
+    await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+    t.after(async () => { server.closeAllConnections(); await new Promise(resolve => server.close(resolve)); });
+    const baseUrl = `http://127.0.0.1:${server.address().port}`;
+    writeFileSync(w.configPath, JSON.stringify({ base_url: baseUrl, credentials: { primary: 'SUITE_TEST_KEY' }, profiles: ['probe'], limits: { cleanup_ms: 5000 } }));
+    resource = journal(w.resultsRoot, 'a', baseUrl, ownerId);
+    const untouched = journal(w.resultsRoot, 'z', baseUrl, ownerId);
+    const env = { SUITE_TEST_KEY: key };
+    const controller = new AbortController();
+    const child = signal === 'deadline' ? undefined : cli(t, w, [], env);
+    const completed = child ? child.exited : replayCleanup({ ...w, env, signal: controller.signal });
+    const finishDelete = await deleting;
+    if (child) child.child.kill(signal);
+    else {
+      const deadline = AbortSignal.timeout(20);
+      deadline.addEventListener('abort', () => controller.abort(deadline.reason), { once: true });
+    }
+    let interrupted;
+    for (let i = 0; i < 100; i++) {
+      interrupted = JSON.parse(readFileSync(join(w.out, 'replay.json')));
+      if (interrupted.stop_reason) break;
+      await sleep(10);
+    }
+    assert.equal(interrupted.status, 'cleanup_failed');
+    assert.equal(interrupted.stop_reason, signal === 'deadline' ? 'deadline' : 'interrupted');
+    assert.deepEqual(interrupted.entries.map(entry => entry.status), ['interrupted', 'not_run']);
+    finishDelete();
+    assert.deepEqual(await completed, child ? [3, null] : 3);
+    const report = JSON.parse(readFileSync(join(w.out, 'replay.json')));
+    assert.equal(report.status, 'cleanup_failed');
+    assert.deepEqual(report.entries.map(entry => entry.status), ['failed', 'not_run']);
+    assert.equal(report.entries[0].code, 130);
+    assert.equal(JSON.parse(readFileSync(join(w.resultsRoot, 'a/cleanup.json'))).resources[0].state, 'cleaned');
+    assert.equal(JSON.parse(readFileSync(join(w.resultsRoot, 'z/cleanup.json'))).resources[0].state, 'created');
+    assert.ok(!requests.some(([, url]) => url.includes(untouched.id)));
+    assert.equal(requests.filter(([, url]) => url === '/api/auth/me').length, 1);
+  });
+}


### PR DESCRIPTION
Adds a bounded batch cleanup command for normal runs and the sixteen-cell matrix plus preflight. Each manifest is checked by the existing runner for target, account and resource ownership before cleanup. A rejected manifest does not prevent attempts for the remaining journals, and no verification profile or inference starts.

Replay stops admitting manifests after two minutes. SIGINT, SIGTERM and deadline expiry immediately persist the stop reason and mark active work interrupted, then let its independently bounded cleanup finish. Later entries stay unattempted and the aggregate remains nonzero. Exceptions receive a fixed classification without exposing private errors.

The CLI remains strict about missing or empty evidence by default. Its explicit `--allow-empty` option lets CI record `no_manifests` without requiring a target file when setup failed before any journal was written. Unsafe evidence and actual failed manifests still fail. Original journals are updated in place, so retain their artifact before replay.

Based on main after #1964; #1966 wires this command into the workflow and adds operator documentation. Refs #1697. This does not enable the suite or recover evidence lost with a runner.

Validation:
- [Fresh CI](https://github.com/managoat/fountain/actions/runs/34688485256) passed on the merge checkout with main.
- All 232 deployed Node tests passed, including subprocess SIGINT/SIGTERM during real HTTP cleanup, deadline expiry, continued cleanup after owner rejection, idempotence, empty CI runs and invalid evidence rejection.
- `mix precommit` passed on the final stacked tree with the pinned Elixir/Erlang toolchain and an isolated test database: 5,598 core tests plus 6 doctests, 144 Buzz tests and 33 Support tests; zero failures (core: 2 skipped, 7 excluded). The application code is identical in both PRs.

No deployed workflow was dispatched or live fixture modified.
