### PR TITLE
fix(deployed): retry fixture cleanup after failed verification

### DIFF
--- a/.github/workflows/deployed.yml
+++ b/.github/workflows/deployed.yml
@@ -65,7 +65,7 @@ jobs:
   verify:
     needs: validate
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 75 # Step caps total 71 minutes, including setup and both uploads.
     environment: deployed-${{ inputs.target || 'production' }}
     env:
       SUITE_TARGET: ${{ inputs.target || 'production' }}
@@ -82,17 +82,21 @@ jobs:
       FOUNTAIN_RECEIVER_ADMIN_KEY: ${{ secrets.FOUNTAIN_RECEIVER_ADMIN_KEY }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
+        timeout-minutes: 2
         with:
           persist-credentials: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        timeout-minutes: 2
         with:
           node-version: 24
       - name: Start scheduled monitor
+        timeout-minutes: 1
         if: github.event_name == 'schedule'
         env:
           SUITE_MONITOR_URL: ${{ secrets[github.event.schedule == '43 4 * * 6' && 'SUITE_MATRIX_MONITOR_URL' || 'SUITE_MONITOR_URL'] }}
         run: node deployed/monitor.mjs in_progress
       - name: Configure deployment observer
+        timeout-minutes: 2
         if: inputs.mode == 'rollout'
         env:
           SUITE_KUBECONFIG: ${{ secrets.SUITE_KUBECONFIG }}
@@ -108,15 +112,17 @@ jobs:
           kubectl version --client
       - name: Verify public ingress and clean fixtures
         id: suite
-        timeout-minutes: 52 # Leave time for evidence and a fresh cleanup process.
+        timeout-minutes: 52
         run: node deployed/ci.mjs
       - name: Finish scheduled monitor
+        timeout-minutes: 1
         if: always() && github.event_name == 'schedule'
         env:
           SUITE_MONITOR_URL: ${{ secrets[github.event.schedule == '43 4 * * 6' && 'SUITE_MATRIX_MONITOR_URL' || 'SUITE_MONITOR_URL'] }}
           MONITOR_STATUS: ${{ steps.suite.outcome == 'success' && 'ok' || 'error' }}
         run: node deployed/monitor.mjs "$MONITOR_STATUS"
       - name: Retain redacted evidence and cleanup manifests
+        timeout-minutes: 2
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -127,12 +133,13 @@ jobs:
       - name: Retry interrupted or failed fixture cleanup
         id: cleanup
         if: always() && (steps.suite.outcome == 'failure' || steps.suite.outcome == 'cancelled')
-        timeout-minutes: 4
+        timeout-minutes: 6 # Two minutes admitting work, then cleanup and receiver finalizers.
         run: |
           root="$RUNNER_TEMP/deployed-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
-          node deployed/cleanup-replay.mjs --config "$root/target.json" \
+          node deployed/cleanup-replay.mjs --allow-empty --config "$root/target.json" \
             --results "$root/results" --out "$root/cleanup-replay"
       - name: Retain cleanup retry evidence and updated manifests
+        timeout-minutes: 2
         if: always() && steps.cleanup.outcome != 'skipped'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -143,5 +150,6 @@ jobs:
           retention-days: 30
           if-no-files-found: warn
       - name: Remove deployment credentials
+        timeout-minutes: 1
         if: always()
         run: rm -f "$RUNNER_TEMP/suite-kubeconfig"

--- a/.github/workflows/deployed.yml
+++ b/.github/workflows/deployed.yml
@@ -108,6 +108,7 @@ jobs:
           kubectl version --client
       - name: Verify public ingress and clean fixtures
         id: suite
+        timeout-minutes: 52 # Leave time for evidence and a fresh cleanup process.
         run: node deployed/ci.mjs
       - name: Finish scheduled monitor
         if: always() && github.event_name == 'schedule'
@@ -121,6 +122,24 @@ jobs:
         with:
           name: deployed-${{ env.SUITE_TARGET }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/deployed-${{ github.run_id }}-${{ github.run_attempt }}/results/
+          retention-days: 30
+          if-no-files-found: warn
+      - name: Retry interrupted or failed fixture cleanup
+        id: cleanup
+        if: always() && (steps.suite.outcome == 'failure' || steps.suite.outcome == 'cancelled')
+        timeout-minutes: 4
+        run: |
+          root="$RUNNER_TEMP/deployed-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
+          node deployed/cleanup-replay.mjs --config "$root/target.json" \
+            --results "$root/results" --out "$root/cleanup-replay"
+      - name: Retain cleanup retry evidence and updated manifests
+        if: always() && steps.cleanup.outcome != 'skipped'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: deployed-cleanup-${{ env.SUITE_TARGET }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            ${{ runner.temp }}/deployed-${{ github.run_id }}-${{ github.run_attempt }}/results/
+            ${{ runner.temp }}/deployed-${{ github.run_id }}-${{ github.run_attempt }}/cleanup-replay/
           retention-days: 30
           if-no-files-found: warn
       - name: Remove deployment credentials

--- a/deployed/README.md
+++ b/deployed/README.md
@@ -198,6 +198,31 @@ node deployed/cli.mjs cleanup --config /tmp/fountain-target.json \
   --manifest /tmp/fountain-run-001/cleanup.json --out /tmp/fountain-cleanup-001
 ```
 
+For a normal run or a matrix, replay all manifests from its results directory:
+
+```bash
+node deployed/cleanup-replay.mjs --config /tmp/fountain-target.json \
+  --results /tmp/fountain-run-001 --out /tmp/fountain-cleanup-batch-001
+```
+
+The output directory must be new and outside the source results. Replay checks
+up to seventeen manifests, continues after a failed manifest, and records each
+outcome in `replay.json`. After three minutes, replay attempts no more manifests;
+the current runner retains its separate cleanup deadline. Any failed or
+unattempted manifest keeps the batch nonzero. Keep the original target file,
+credentials and receiver sidecars with the manifests for recovery.
+
+In CI, verification has a 52-minute step timeout within the 60-minute job.
+After a failed or interrupted suite step, the workflow uploads the original
+evidence, then starts a fresh cleanup process with a four-minute step timeout.
+It uploads updated manifests and replay evidence under a separate
+`deployed-cleanup-...` artifact, preserving the original `deployed-...` artifact.
+A successful retry does not change the failed verification verdict.
+[GitHub cancellation](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-cancellation)
+can terminate the job before these final steps finish. A hard job timeout or
+runner loss can prevent upload and replay. This step cannot recover journals
+lost with the runner.
+
 Use the same target and account. Cleanup has its own deadline, tolerates
 already deleted resources, and runs in reverse creation order. A lost create
 response can be reconciled by an exact unique name. When an intent has no

--- a/deployed/README.md
+++ b/deployed/README.md
@@ -207,17 +207,34 @@ node deployed/cleanup-replay.mjs --config /tmp/fountain-target.json \
 
 The output directory must be new and outside the source results. Replay checks
 up to seventeen manifests, continues after a failed manifest, and records each
-outcome in `replay.json`. After three minutes, replay attempts no more manifests;
+outcome in `replay.json`. After two minutes, replay attempts no more manifests;
 the current runner retains its separate cleanup deadline. Any failed or
 unattempted manifest keeps the batch nonzero. Keep the original target file,
 credentials and receiver sidecars with the manifests for recovery.
 
-In CI, verification has a 52-minute step timeout within the 60-minute job.
+SIGINT, SIGTERM and the admission deadline immediately record a stop reason and
+mark the active entry `interrupted`. The active cleanup retains its own deadline;
+later entries remain `not_run`. If cleanup finishes, its final result replaces
+the interrupted entry, but the batch remains unsuccessful. A forced process
+kill can still prevent completion; an interrupted entry is not proof of cleanup.
+
+In CI, verification has a 52-minute step timeout within a 75-minute job.
 After a failed or interrupted suite step, the workflow uploads the original
-evidence, then starts a fresh cleanup process with a four-minute step timeout.
+evidence, then starts a fresh cleanup process with a six-minute step timeout.
+Replay admits work for two minutes; a CI manifest can then need its 90-second
+fixture cleanup and a separate 90-second receiver cleanup. The six-minute cap
+leaves another minute for process and evidence overhead. Setup, monitors and both
+artifact uploads have explicit step limits; all step limits total 71 minutes,
+leaving four minutes of job overhead. Increasing the job limit does not increase
+the verification step or inference budgets.
 It uploads updated manifests and replay evidence under a separate
 `deployed-cleanup-...` artifact, preserving the original `deployed-...` artifact.
 A successful retry does not change the failed verification verdict.
+CI passes `--allow-empty`: a setup failure before any manifest was written
+produces a successful replay step with `status: "no_manifests"` and no API calls,
+even when the target file or results directory was never created. This records
+that no cleanup was attempted. Invalid evidence still fails; manual replay
+without this flag rejects missing or empty results.
 [GitHub cancellation](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-cancellation)
 can terminate the job before these final steps finish. A hard job timeout or
 runner loss can prevent upload and replay. This step cannot recover journals

--- a/deployed/test/cleanup-workflow.test.mjs
+++ b/deployed/test/cleanup-workflow.test.mjs
@@ -1,0 +1,73 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, writeFileSync, mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+import { ciConfig } from '../ci.mjs';
+import { REPLAY_START_MS } from '../cleanup-replay.mjs';
+
+const root = fileURLToPath(new URL('../..', import.meta.url));
+const workflow = readFileSync(join(root, '.github/workflows/deployed.yml'), 'utf8');
+const [job, body] = workflow.split('\n  verify:\n')[1].split('\n    steps:\n');
+const steps = body.split(/\n(?=      - )/).filter(step => step.trim());
+const cleanup = steps.find(step => step.includes('        id: cleanup\n'));
+const script = cleanup.split('        run: |\n')[1].replace(/^          /gm, '');
+const base = { SUITE_TARGET: 'staging', SUITE_ENABLED: 'true', SUITE_PROFILE: 'probe', SUITE_MODE: 'public',
+  SUITE_TARGET_JSON: '{"base_url":"https://example.test"}', FOUNTAIN_SUITE_KEY: 'local-test-key' };
+
+test('workflow budgets include setup, fixture and receiver cleanup, and both artifact uploads', () => {
+  const jobMs = Number(job.match(/    timeout-minutes: (\d+)/)[1]) * 60000;
+  let stepsMs = 0;
+  for (const step of steps) {
+    const cap = step.match(/        timeout-minutes: (\d+)/);
+    assert.ok(cap, `Unbounded verification step: ${step.split('\n')[0]}`);
+    stepsMs += Number(cap[1]) * 60000;
+  }
+  assert.ok(jobMs >= stepsMs + 2 * 60000, 'Keep job overhead beyond the sum of every step cap');
+  const cleanupMs = Number(cleanup.match(/        timeout-minutes: (\d+)/)[1]) * 60000;
+  const fixtureMs = ciConfig(base).limits.cleanup_ms;
+  assert.ok(cleanupMs >= REPLAY_START_MS + 2 * fixtureMs + 60000,
+    'An admitted CI manifest needs fixture cleanup, receiver cleanup and process/evidence overhead');
+});
+
+for (const [name, target, hasResults] of [
+  ['before the run root exists', '{malformed', false],
+  ['after target validation in the runner', '{"base_url":"https://example.test","unknown_field":true}', true],
+]) {
+  test(`workflow cleanup after setup failure ${name} reports no manifests`, () => {
+    const temp = mkdtempSync(join(tmpdir(), 'fountain-cleanup-workflow-'));
+    try {
+      const env = { ...process.env, ...base, SUITE_TARGET_JSON: target, RUNNER_TEMP: temp, GITHUB_RUN_ID: '123', GITHUB_RUN_ATTEMPT: '2' };
+      const runRoot = join(temp, 'deployed-123-2');
+      const suite = spawnSync(process.execPath, ['deployed/ci.mjs'], { cwd: root, env, encoding: 'utf8', timeout: 10000 });
+      assert.equal(suite.status, 2, suite.stderr);
+      const result = join(runRoot, 'results/result.json');
+      assert.equal(existsSync(result), hasResults);
+      const original = hasResults ? readFileSync(result, 'utf8') : undefined;
+      const replay = spawnSync('bash', ['-e', '-o', 'pipefail', '-c', script], { cwd: root, env, encoding: 'utf8', timeout: 10000 });
+      assert.equal(replay.status, 0, replay.stderr);
+      assert.equal(replay.stderr, '');
+      assert.equal(JSON.parse(readFileSync(join(runRoot, 'cleanup-replay/replay.json'))).status, 'no_manifests');
+      if (hasResults) assert.equal(readFileSync(result, 'utf8'), original, 'Replay must retain the original failed verdict');
+    } finally { rmSync(temp, { recursive: true, force: true }); }
+  });
+}
+
+test('workflow allow-empty does not suppress a failed manifest', () => {
+  const temp = mkdtempSync(join(tmpdir(), 'fountain-cleanup-workflow-'));
+  try {
+    const env = { ...process.env, ...base, SUITE_TARGET_JSON: '{"base_url":"https://example.test","unknown_field":true}',
+      RUNNER_TEMP: temp, GITHUB_RUN_ID: '123', GITHUB_RUN_ATTEMPT: '2' };
+    const runRoot = join(temp, 'deployed-123-2');
+    const suite = spawnSync(process.execPath, ['deployed/ci.mjs'], { cwd: root, env, encoding: 'utf8', timeout: 10000 });
+    assert.equal(suite.status, 2);
+    writeFileSync(join(runRoot, 'results/cleanup.json'), '{}');
+    const replay = spawnSync('bash', ['-e', '-o', 'pipefail', '-c', script], { cwd: root, env, encoding: 'utf8', timeout: 10000 });
+    assert.equal(replay.status, 3, replay.stderr);
+    const report = JSON.parse(readFileSync(join(runRoot, 'cleanup-replay/replay.json')));
+    assert.equal(report.status, 'cleanup_failed');
+    assert.equal(report.entries[0].status, 'failed');
+  } finally { rmSync(temp, { recursive: true, force: true }); }
+});


### PR DESCRIPTION
A failed or interrupted deployed verification step now gets a fresh cleanup process after the workflow uploads its original manifests. Updated journals and retry reports use a separate artifact name; a successful retry cannot turn failed verification green.

Verification retains a 52-minute step cap. Replay gets six minutes: two minutes admitting manifests, up to 90 seconds of fixture cleanup and 90 seconds of receiver cleanup, plus a minute for process/evidence overhead. Setup, monitors, both uploads and credential removal have explicit caps. The 75-minute job accommodates their combined 71-minute budget with four minutes of overhead; verification and inference budgets do not increase.

CI uses the replay command's explicit `--allow-empty` mode. Setup failures with no journals produce `no_manifests` evidence and no API calls, while unsafe evidence and failed manifests remain failures. The README explains interruption evidence, budgets and manual recovery.

#1965 is merged. This PR is based on main and contains only the workflow, operator instructions and workflow regression tests. Refs #1697.

Recovery remains best effort on the existing runner. Cancellation, hard timeout or runner loss can prevent finalizers and uploads. Protected environments, credentials, a comped canary account and recovery of lost journals remain enablement work under #1697.

Validation:
- [Fresh PR CI against main](https://github.com/managoat/fountain/actions/runs/34721489565) passed after rebasing onto the merged #1965. Checkout logs confirm head `9e666719` was merged into main `d7db94fb`. The deployed source and workflow are unchanged by the rebase.
- All 236 deployed Node tests passed again after rebasing onto main, including the workflow's actual cleanup shell command after setup failures before and after run-directory creation, failure preservation and timeout-budget checks.
- All 57 CI policy tests passed again after rebasing onto main.
- `actionlint .github/workflows/deployed.yml` passed.
- `mix precommit` passed on the final stacked tree with the pinned Elixir/Erlang toolchain and an isolated test database: 5,598 core tests plus 6 doctests, 144 Buzz tests and 33 Support tests; zero failures (core: 2 skipped, 7 excluded). The application code is identical in both PRs.

No deployed workflow was dispatched, environment enabled or live fixture modified.
