### PR TITLE
fix(sandboxes): lock availability through turn admission

### DIFF
--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -1705,6 +1705,9 @@ defmodule Fountain.Conversations do
           Repo.rollback(:configuration_changed)
         end
 
+        # Row-only retirement writers do not take the admission advisory
+        # lock. Hold their row through insertion too: a committed retirement
+        # refuses admission, while a later forced retirement follows the turn.
         attached? =
           Repo.exists?(
             from c in Conversation,
@@ -1712,7 +1715,8 @@ defmodule Fountain.Conversations do
               on: s.id == c.sandbox_id,
               where:
                 c.id == ^conv_id and s.id == ^sandbox_id and c.user_id == s.user_id and
-                  s.status not in ["terminated", "failed"] and is_nil(s.reset_requested_at)
+                  s.status not in ["terminated", "failed"] and is_nil(s.reset_requested_at),
+              lock: "FOR SHARE"
           )
 
         unless attached?, do: Repo.rollback(:sandbox_unavailable)

--- a/apps/fountain/test/fountain/conversations/reset_admission_order_test.exs
+++ b/apps/fountain/test/fountain/conversations/reset_admission_order_test.exs
@@ -1,0 +1,183 @@
+defmodule Fountain.Conversations.ResetAdmissionOrderTest do
+  use Fountain.DataCase, async: false
+  use Mimic
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Fountain.Conversations
+
+  for first <- [:reset, :admission], capacity <- [1, :unbounded] do
+    test "#{first} wins against #{inspect(capacity)} admission on independent connections" do
+      assert_order(unquote(first), unquote(capacity))
+    end
+  end
+
+  defp assert_order(first, capacity) do
+    Sandbox.unboxed_run(Repo, fn ->
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+
+      home =
+        insert_sandbox(user_id: user.id, agent_id: agent.id, mode: "persistent", status: "ready")
+
+      conv =
+        insert_conversation(
+          user_id: user.id,
+          agent: agent,
+          sandbox: home,
+          status: "idle",
+          runtime_session_id: "before-reset"
+        )
+
+      owner = self()
+
+      operation = fn
+        :reset ->
+          Conversations.reset_sandbox(home)
+
+        :admission ->
+          Conversations._unsafe_create_turn_on_sandbox(
+            %{
+              conversation_id: conv.id,
+              turn_number: 1,
+              status: "running",
+              prompt: "race"
+            },
+            home.id,
+            capacity
+          )
+      end
+
+      winner = independent(first, fn -> operation.(first) end, owner, true)
+
+      try do
+        assert_receive {:locked, winner_pid}, 5_000
+        assert winner_pid == winner.pid
+        second = if first == :reset, do: :admission, else: :reset
+        waiter = independent(second, fn -> operation.(second) end, owner, false)
+
+        try do
+          assert_receive {:backend, ^first, winner_backend}, 5_000
+          assert_receive {:backend, ^second, waiter_backend}, 5_000
+          refute winner_backend == waiter_backend
+
+          await_blocked(
+            waiter_backend,
+            winner_backend,
+            System.monotonic_time(:millisecond) + 5_000
+          )
+
+          assert Repo.aggregate(
+                   from(t in Conversations.Turn, where: t.conversation_id == ^conv.id),
+                   :count
+                 ) == 0
+
+          refute_received {:destroying, _, _}
+          send(winner.pid, :continue)
+
+          if first == :reset do
+            assert_receive {:destroying, reset_pid, false}, 5_000
+            assert reset_pid == winner.pid
+            assert {:error, :sandbox_unavailable} = Task.await(waiter, 5_000)
+            assert Repo.reload!(home).reset_requested_at
+            assert Repo.reload!(home).status == "ready"
+            assert Repo.reload!(conv).runtime_session_id == nil
+
+            assert Repo.aggregate(
+                     from(t in Conversations.Turn, where: t.conversation_id == ^conv.id),
+                     :count
+                   ) == 0
+
+            send(winner.pid, :destroy)
+            assert {:ok, %{status: "terminated"}} = Task.await(winner, 5_000)
+          else
+            assert {:ok, turn} = Task.await(winner, 5_000)
+            assert {:error, :sandbox_mid_turn} = Task.await(waiter, 5_000)
+            assert Repo.get!(Conversations.Turn, turn.id).status == "running"
+            assert Repo.reload!(home).status == "ready"
+            refute Repo.reload!(home).reset_requested_at
+            assert Repo.reload!(conv).runtime_session_id == "before-reset"
+            refute_received {:destroying, _, _}
+          end
+        after
+          stop(waiter)
+        end
+      after
+        stop(winner)
+        Repo.delete_all(from c in Conversations.Conversation, where: c.user_id == ^user.id)
+        Repo.delete_all(from s in Conversations.Sandbox, where: s.id == ^home.id)
+        Repo.delete_all(from a in Fountain.Audit.Event, where: a.user_id == ^user.id)
+        Repo.delete_all(from u in Fountain.Accounts.User, where: u.id == ^user.id)
+      end
+    end)
+  end
+
+  defp stop(task) do
+    Task.shutdown(task, :brutal_kill)
+    :telemetry.detach({__MODULE__, task.pid})
+  end
+
+  defp independent(role, fun, owner, pause?) do
+    Task.async(fn ->
+      Sandbox.unboxed_run(Repo, fn ->
+        %{rows: [[backend]]} = Repo.query!("SELECT pg_backend_pid()")
+        send(owner, {:backend, role, backend})
+        handler = {__MODULE__, self()}
+
+        if pause? do
+          :ok =
+            :telemetry.attach(
+              handler,
+              [:fountain, :repo, :query],
+              &__MODULE__.after_query/4,
+              {self(), owner, handler}
+            )
+        end
+
+        stub(Managoat.Sandbox.Sprites, :destroy, fn _ ->
+          send(owner, {:destroying, self(), Repo.in_transaction?()})
+
+          receive do
+            :destroy -> :ok
+          after
+            10_000 -> raise "provider release timed out"
+          end
+        end)
+
+        try do
+          fun.()
+        after
+          :telemetry.detach(handler)
+        end
+      end)
+    end)
+  end
+
+  # Ecto emits this synchronously after the real PostgreSQL lock is acquired.
+  # Pause only the selected connection; the competing call executes normally.
+  def after_query(_, _, %{query: query, params: [4316, _]}, {worker, owner, handler}) do
+    if self() == worker and query == "SELECT pg_advisory_xact_lock($1, $2)" do
+      :telemetry.detach(handler)
+      send(owner, {:locked, self()})
+
+      receive do
+        :continue -> :ok
+      after
+        10_000 -> send(owner, :lock_release_timed_out)
+      end
+    end
+  end
+
+  def after_query(_, _, _, _), do: :ok
+
+  defp await_blocked(waiter, holder, deadline) do
+    %{rows: [[blocked]]} = Repo.query!("SELECT $2 = ANY(pg_blocking_pids($1))", [waiter, holder])
+
+    unless blocked do
+      assert System.monotonic_time(:millisecond) < deadline,
+             "no wait on the winning PostgreSQL connection observed"
+
+      Process.sleep(5)
+      await_blocked(waiter, holder, deadline)
+    end
+  end
+end

--- a/apps/fountain/test/fountain/conversations/retirement_admission_order_test.exs
+++ b/apps/fountain/test/fountain/conversations/retirement_admission_order_test.exs
@@ -1,0 +1,181 @@
+defmodule Fountain.Conversations.RetirementAdmissionOrderTest do
+  use Fountain.DataCase, async: false
+  use Mimic
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Fountain.Conversations
+
+  for first <- [:retirement, :admission], capacity <- [1, :unbounded] do
+    test "#{first} wins the retirement race with #{inspect(capacity)} capacity" do
+      assert_order(unquote(first), unquote(capacity))
+    end
+  end
+
+  defp assert_order(first, capacity) do
+    Sandbox.unboxed_run(Repo, fn ->
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+
+      home =
+        insert_sandbox(user_id: user.id, agent_id: agent.id, mode: "persistent", status: "ready")
+
+      conv =
+        insert_conversation(
+          user_id: user.id,
+          agent: agent,
+          sandbox: home,
+          status: "idle",
+          runtime_session_id: "before-retirement"
+        )
+
+      owner = self()
+
+      operation = fn
+        :retirement ->
+          Conversations.update_sandbox(home, %{status: "terminated"})
+
+        :admission ->
+          Conversations._unsafe_create_turn_on_sandbox(
+            %{
+              conversation_id: conv.id,
+              turn_number: 1,
+              status: "running",
+              prompt: "race"
+            },
+            home.id,
+            capacity
+          )
+      end
+
+      winner = independent(first, fn -> operation.(first) end, owner, true)
+
+      try do
+        assert_receive {:locked, winner_pid}, 5_000
+        assert winner_pid == winner.pid
+        second = if first == :retirement, do: :admission, else: :retirement
+        waiter = independent(second, fn -> operation.(second) end, owner, false)
+
+        try do
+          assert_receive {:backend, ^first, winner_backend}, 5_000
+          assert_receive {:backend, ^second, waiter_backend}, 5_000
+          refute winner_backend == waiter_backend
+
+          await_blocked(
+            waiter_backend,
+            winner_backend,
+            System.monotonic_time(:millisecond) + 5_000
+          )
+
+          assert Repo.aggregate(
+                   from(t in Conversations.Turn, where: t.conversation_id == ^conv.id),
+                   :count
+                 ) == 0
+
+          refute_received {:destroying, _, _}
+          send(winner.pid, :continue)
+
+          if first == :retirement do
+            assert {:ok, %{status: "terminated"}} = Task.await(winner, 5_000)
+            assert {:error, :sandbox_unavailable} = Task.await(waiter, 5_000)
+
+            assert Repo.aggregate(
+                     from(t in Conversations.Turn, where: t.conversation_id == ^conv.id),
+                     :count
+                   ) == 0
+          else
+            assert {:ok, turn} = Task.await(winner, 5_000)
+            assert {:ok, %{status: "terminated"}} = Task.await(waiter, 5_000)
+            assert Repo.get!(Conversations.Turn, turn.id).status == "running"
+          end
+
+          assert Repo.reload!(home).status == "terminated"
+          refute_received {:destroying, _, _}
+        after
+          stop(waiter)
+        end
+      after
+        stop(winner)
+        Repo.delete_all(from c in Conversations.Conversation, where: c.user_id == ^user.id)
+        Repo.delete_all(from s in Conversations.Sandbox, where: s.id == ^home.id)
+        Repo.delete_all(from a in Fountain.Audit.Event, where: a.user_id == ^user.id)
+        Repo.delete_all(from u in Fountain.Accounts.User, where: u.id == ^user.id)
+      end
+    end)
+  end
+
+  defp stop(task) do
+    Task.shutdown(task, :brutal_kill)
+    :telemetry.detach({__MODULE__, task.pid})
+  end
+
+  defp independent(role, fun, owner, pause?) do
+    Task.async(fn ->
+      Sandbox.unboxed_run(Repo, fn ->
+        %{rows: [[backend]]} = Repo.query!("SELECT pg_backend_pid()")
+        send(owner, {:backend, role, backend})
+        handler = {__MODULE__, self()}
+
+        if pause? do
+          :ok =
+            :telemetry.attach(
+              handler,
+              [:fountain, :repo, :query],
+              &__MODULE__.after_query/4,
+              {self(), owner, handler, role}
+            )
+        end
+
+        stub(Managoat.Sandbox.Sprites, :destroy, fn _ ->
+          send(owner, {:destroying, self(), Repo.in_transaction?()})
+
+          receive do
+            :destroy -> :ok
+          after
+            10_000 -> raise "provider release timed out"
+          end
+        end)
+
+        try do
+          fun.()
+        after
+          :telemetry.detach(handler)
+        end
+      end)
+    end)
+  end
+
+  # Pause after the actual row query, not after the advisory lock: a writer
+  # that only locks the sandbox row must wait for the admission insert too.
+  def after_query(_, _, %{query: query}, {worker, owner, handler, role}) do
+    target? =
+      case role do
+        :retirement -> query =~ ~s(FROM "sandboxes") and query =~ "FOR UPDATE"
+        :admission -> query =~ ~s(INNER JOIN "sandboxes")
+      end
+
+    if self() == worker and target? do
+      :telemetry.detach(handler)
+      send(owner, {:locked, self()})
+
+      receive do
+        :continue -> :ok
+      after
+        10_000 -> send(owner, :lock_release_timed_out)
+      end
+    end
+  end
+
+  def after_query(_, _, _, _), do: :ok
+
+  defp await_blocked(waiter, holder, deadline) do
+    %{rows: [[blocked]]} = Repo.query!("SELECT $2 = ANY(pg_blocking_pids($1))", [waiter, holder])
+
+    unless blocked do
+      assert System.monotonic_time(:millisecond) < deadline,
+             "no wait on the winning PostgreSQL connection observed"
+
+      Process.sleep(5)
+      await_blocked(waiter, holder, deadline)
+    end
+  end
+end


### PR DESCRIPTION
A sandbox retirement could commit between turn admission's availability check and its insert, because retirement writes take a row lock while admission only held the sandbox advisory lock. Admission now also keeps the joined sandbox row share-locked through insertion. If retirement commits first, no turn is inserted; if admission wins, a forced row retirement waits until that turn commits.

Stack: based on #1968. Refs #1767. This unit coordinates the database availability check with row-based retirement writers. A forced retirement can still retire a previously admitted turn; its caller remains responsible for stopping the actor and cleaning up the provider. Paths that destroy the provider before persisting a refusal state and the remaining reassignment audit are separate follow-ups, so this does not close #1767.

Validation:
- All four new real PostgreSQL regressions fail on the parent because the competing backend does not wait; both winner orderings with capacity `1` and `:unbounded` pass with the row lock.
- All 44 retirement-order, reset-order, existing reset and saved-allowance admission tests passed.
- Explicit cleanup verified zero users, sandboxes, conversations and turns afterward.
- `mix precommit` passed: 5,383 core tests plus 6 doctests, 144 Buzz tests and 33 Support tests; zero failures.

No real provider was called. The change adds a shared row lock to the existing transaction, with no provider I/O or audit writes under it.
