### PR TITLE
fix(conversations): detach wakes when a reset wins

### DIFF
--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -26,6 +26,11 @@ defmodule Fountain.Conversations.ConversationServer do
   alias Fountain.Conversations.{ProvisionWatchdog, Reapply}
   alias Fountain.Conversations.{Reattachment, Redaction, SpriteEnv, TurnLaunch, TurnMachine}
 
+  defguardp retired_or_resetting(reason)
+            when reason == :sandbox_reset_pending or
+                   (is_struct(reason, Ecto.Changeset) and
+                      reason.errors == [status: {"sandbox is retired", []}])
+
   # ── public api ────────────────────────────────────────────────────────────
 
   def start_link(args) do
@@ -1166,7 +1171,7 @@ defmodule Fountain.Conversations.ConversationServer do
 
           {:noreply, new_state}
 
-        {:error, %Ecto.Changeset{errors: [status: {"sandbox is retired", []}]}} ->
+        {:error, reason} when retired_or_resetting(reason) ->
           # Wake owns this connection's credentials, not the existing disk or
           # another connection's session. Never destroy the machine here.
           Egress.release_prepared({:ok, state})

--- a/apps/fountain/test/fountain/conversations/conversation_server_broker_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_broker_test.exs
@@ -178,7 +178,8 @@ defmodule Fountain.Conversations.ConversationServerBrokerTest do
       end
     end
 
-    for initial <- ["ready", "suspended"], terminal <- ["terminated", "failed"] do
+    for initial <- ["ready", "suspended"],
+        terminal <- ["terminated", "failed", "reset_pending"] do
       @tag initial: initial, terminal: terminal
       test "retirement during #{initial} wake preserves #{terminal} and the replacement", %{
         user: user,
@@ -224,7 +225,15 @@ defmodule Fountain.Conversations.ConversationServerBrokerTest do
         callback_id = Fountain.Repo.reload!(conv).callback_api_key_id
         assert is_binary(callback_id)
 
-        {:ok, retired} = Conversations.update_sandbox(sandbox, %{status: terminal})
+        retired =
+          if terminal == "reset_pending" do
+            sandbox
+            |> Ecto.Changeset.change(reset_requested_at: DateTime.utc_now())
+            |> Fountain.Repo.update!()
+          else
+            {:ok, retired} = Conversations.update_sandbox(sandbox, %{status: terminal})
+            retired
+          end
 
         replacement =
           insert_sandbox(user_id: user.id, status: "ready", sprite_name: "replacement")
@@ -238,8 +247,9 @@ defmodule Fountain.Conversations.ConversationServerBrokerTest do
         send(pid, :resume_wake)
 
         assert :normal = assert_stopped(ref, 5_000)
-        assert Fountain.Repo.reload!(sandbox).status == terminal
+        assert Fountain.Repo.reload!(sandbox).status == retired.status
         assert Fountain.Repo.reload!(sandbox).terminated_at == retired.terminated_at
+        assert Fountain.Repo.reload!(sandbox).reset_requested_at == retired.reset_requested_at
         assert Fountain.Repo.reload!(conv).sandbox_id == replacement.id
         assert Fountain.Repo.reload!(conv).status == "idle"
         assert Fountain.Repo.reload!(replacement).status == "ready"


### PR DESCRIPTION
When a reset fences a sandbox during wake preparation, the final ready write returns `:sandbox_reset_pending`. The callback treated that expected race as a MatchError. It now stops normally, releases only this wake's prepared credentials, and preserves the existing disk, reset fence and any replacement conversation/session. Unrelated write errors keep their existing failure behavior.

Stack: based on #1946, following the retirement callback fixes. Refs #1766 and #1767. This is the wake unit; provisioning and forced-teardown fencing remain separate work.

Validation:
- Both new ready/suspended reset-fence wake cases fail on the parent with MatchError.
- All 51 broker and wake tests passed. The new cases verify unchanged sandbox state/fence, replacement session survival, original token and callback-key revocation, and no runtime spawn or machine deletion.
- `mix precommit` passed: 5,392 core tests plus 6 doctests, 144 Buzz tests and 33 Support tests; zero failures.

No real provider or deployed environment was modified.
