### PR TITLE
fix(conversations): preserve reset fences during provisioning

### DIFF
--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -795,7 +795,7 @@ defmodule Fountain.Conversations.ConversationServer do
         {:ok, _} ->
           do_fresh_provision_inner(state, conv, sandbox, agent, env, secrets)
 
-        {:error, %Ecto.Changeset{errors: [status: {"sandbox is retired", []}]}} ->
+        {:error, reason} when retired_or_resetting(reason) ->
           # No resources were created yet. Leave the winning retirement and
           # any replacement conversation alone, without announcing a start.
           {:stop, :normal, state}
@@ -955,7 +955,7 @@ defmodule Fountain.Conversations.ConversationServer do
           # queue_initial_prompt/3.
           {:noreply, new_state}
         else
-          {:error, %Ecto.Changeset{errors: [status: {"sandbox is retired", []}]}} ->
+          {:error, reason} when retired_or_resetting(reason) ->
             # This handle and token belong to this attempt. Do not fail the
             # conversation or release every session: a replacement may own it.
             _ = Managoat.Sandbox.destroy(handle)

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -26,6 +26,11 @@ defmodule Fountain.Conversations.ConversationServer do
   alias Fountain.Conversations.{ProvisionWatchdog, Reapply}
   alias Fountain.Conversations.{Reattachment, Redaction, SpriteEnv, TurnLaunch, TurnMachine}
 
+  defguardp retired_or_resetting(reason)
+            when reason == :sandbox_reset_pending or
+                   (is_struct(reason, Ecto.Changeset) and
+                      reason.errors == [status: {"sandbox is retired", []}])
+
   # ── public api ────────────────────────────────────────────────────────────
 
   def start_link(args) do
@@ -1166,7 +1171,7 @@ defmodule Fountain.Conversations.ConversationServer do
 
           {:noreply, new_state}
 
-        {:error, %Ecto.Changeset{errors: [status: {"sandbox is retired", []}]}} ->
+        {:error, reason} when retired_or_resetting(reason) ->
           # Wake owns this connection's credentials, not the existing disk or
           # another connection's session. Never destroy the machine here.
           Egress.release_prepared({:ok, state})

--- a/apps/fountain/test/fountain/conversations/conversation_server_broker_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_broker_test.exs
@@ -178,7 +178,8 @@ defmodule Fountain.Conversations.ConversationServerBrokerTest do
       end
     end
 
-    for initial <- ["ready", "suspended"], terminal <- ["terminated", "failed"] do
+    for initial <- ["ready", "suspended"],
+        terminal <- ["terminated", "failed", "reset_pending"] do
       @tag initial: initial, terminal: terminal
       test "retirement during #{initial} wake preserves #{terminal} and the replacement", %{
         user: user,
@@ -224,7 +225,15 @@ defmodule Fountain.Conversations.ConversationServerBrokerTest do
         callback_id = Fountain.Repo.reload!(conv).callback_api_key_id
         assert is_binary(callback_id)
 
-        {:ok, retired} = Conversations.update_sandbox(sandbox, %{status: terminal})
+        retired =
+          if terminal == "reset_pending" do
+            sandbox
+            |> Ecto.Changeset.change(reset_requested_at: DateTime.utc_now())
+            |> Fountain.Repo.update!()
+          else
+            {:ok, retired} = Conversations.update_sandbox(sandbox, %{status: terminal})
+            retired
+          end
 
         replacement =
           insert_sandbox(user_id: user.id, status: "ready", sprite_name: "replacement")
@@ -238,8 +247,9 @@ defmodule Fountain.Conversations.ConversationServerBrokerTest do
         send(pid, :resume_wake)
 
         assert :normal = assert_stopped(ref, 5_000)
-        assert Fountain.Repo.reload!(sandbox).status == terminal
+        assert Fountain.Repo.reload!(sandbox).status == retired.status
         assert Fountain.Repo.reload!(sandbox).terminated_at == retired.terminated_at
+        assert Fountain.Repo.reload!(sandbox).reset_requested_at == retired.reset_requested_at
         assert Fountain.Repo.reload!(conv).sandbox_id == replacement.id
         assert Fountain.Repo.reload!(conv).status == "idle"
         assert Fountain.Repo.reload!(replacement).status == "ready"

--- a/apps/fountain/test/fountain/conversations/conversation_server_broker_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_broker_test.exs
@@ -592,7 +592,7 @@ defmodule Fountain.Conversations.ConversationServerBrokerTest do
       end
     end
 
-    for terminal <- ["terminated", "failed"] do
+    for terminal <- ["terminated", "failed", "reset_pending"] do
       @tag terminal: terminal
       test "retirement during provision preserves the #{terminal} row and replacement", %{
         user: user,
@@ -638,7 +638,16 @@ defmodule Fountain.Conversations.ConversationServerBrokerTest do
         callback_id = Fountain.Repo.reload!(conv).callback_api_key_id
         assert is_binary(callback_id)
 
-        {:ok, retired} = Conversations.update_sandbox(sandbox, %{status: terminal})
+        retired =
+          if terminal == "reset_pending" do
+            sandbox
+            |> Fountain.Repo.reload!()
+            |> Ecto.Changeset.change(reset_requested_at: DateTime.utc_now())
+            |> Fountain.Repo.update!()
+          else
+            {:ok, retired} = Conversations.update_sandbox(sandbox, %{status: terminal})
+            retired
+          end
 
         replacement =
           insert_sandbox(user_id: user.id, status: "ready", sprite_name: "replacement")
@@ -653,8 +662,9 @@ defmodule Fountain.Conversations.ConversationServerBrokerTest do
         send(pid, :resume_provision)
 
         assert :normal = assert_stopped(ref, 5_000)
-        assert Fountain.Repo.reload!(sandbox).status == terminal
+        assert Fountain.Repo.reload!(sandbox).status == retired.status
         assert Fountain.Repo.reload!(sandbox).terminated_at == retired.terminated_at
+        assert Fountain.Repo.reload!(sandbox).reset_requested_at == retired.reset_requested_at
         assert Fountain.Repo.reload!(conv).status == "idle"
         assert Fountain.Repo.reload!(conv).sandbox_id == replacement.id
         assert Fountain.Repo.reload!(replacement).status == "ready"

--- a/apps/fountain/test/fountain/conversations/conversation_server_provision_retirement_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_provision_retirement_test.exs
@@ -1,7 +1,7 @@
 defmodule Fountain.Conversations.ConversationServerProvisionRetirementTest do
   use Fountain.ConversationServerCase
 
-  for terminal <- ["terminated", "failed"] do
+  for terminal <- ["terminated", "failed", "reset_pending"] do
     test "retirement to #{terminal} before starting does not provision or fail the replacement" do
       stub_happy_sprite()
       user = insert_verified_user()
@@ -34,14 +34,24 @@ defmodule Fountain.Conversations.ConversationServerProvisionRetirementTest do
       on_exit(fn -> if Process.alive?(pid), do: Process.exit(pid, :kill) end)
       assert_receive {:starting_paused, ^pid}, 5_000
 
-      {:ok, retired} = Conversations.update_sandbox(sandbox, %{status: unquote(terminal)})
+      retired =
+        if unquote(terminal) == "reset_pending" do
+          sandbox
+          |> Ecto.Changeset.change(reset_requested_at: DateTime.utc_now())
+          |> Fountain.Repo.update!()
+        else
+          {:ok, retired} = Conversations.update_sandbox(sandbox, %{status: unquote(terminal)})
+          retired
+        end
+
       replacement = insert_sandbox(user_id: user.id, status: "ready")
       {:ok, _} = Conversations.update_conversation(conv, %{sandbox_id: replacement.id})
       send(pid, :resume_starting)
 
       assert :normal = assert_stopped(ref, 5_000)
-      assert Fountain.Repo.reload!(sandbox).status == unquote(terminal)
+      assert Fountain.Repo.reload!(sandbox).status == retired.status
       assert Fountain.Repo.reload!(sandbox).terminated_at == retired.terminated_at
+      assert Fountain.Repo.reload!(sandbox).reset_requested_at == retired.reset_requested_at
       assert Fountain.Repo.reload!(conv).status == "idle"
       assert Fountain.Repo.reload!(conv).sandbox_id == replacement.id
       assert Fountain.Repo.reload!(replacement).status == "ready"


### PR DESCRIPTION
Provisioning now treats a winning reset fence like a winning retirement at both the starting write and the final ready write. Before startup, it exits without creating resources. After provisioning, it releases this attempt's handle and credentials without marking the fenced sandbox or replacement conversation failed.

Stack: based on #1970, reusing its reset/retirement rejection guard. Refs #1766 and #1767. This is the provisioning unit; forced-teardown fencing remains separate work.

Validation:
- Both new startup/completion fence cases fail on the parent.
- All 64 broker, provisioning-retirement and lifecycle tests passed, including original callback-key revocation and replacement-session survival. Unrelated write failures still follow their existing failure paths.
- A test fixture now rereads the persisted starting row before setting its fence, so state preservation is checked against the current database value.
- `mix precommit` passed: 5,394 core tests plus 6 doctests, 144 Buzz tests and 33 Support tests; zero failures.

No real provider or deployed environment was modified.
