### PR TITLE
fix(sandboxes): fence admission before forced home teardown

### DIFF
--- a/apps/fountain/lib/fountain/agents.ex
+++ b/apps/fountain/lib/fountain/agents.ex
@@ -276,8 +276,13 @@ defmodule Fountain.Agents do
     # (ADR 0023 step 5). Torn down before the row goes, while `agent_id` still
     # names it — deletion would nilify the pointer and orphan the sprite.
     # Ownership: `agent` came from the caller's scoped fetch.
-    _ = Fountain.Conversations._unsafe_destroy_homes_for_agent(agent.id)
+    with count when is_integer(count) <-
+           Fountain.Conversations._unsafe_destroy_homes_for_agent(agent.id) do
+      delete_agent_row(agent, opts)
+    end
+  end
 
+  defp delete_agent_row(agent, opts) do
     # Unpin the agent's conversations from its versions before the row goes.
     # Deleting the agent cascades to `agent_versions`, and Postgres re-checks
     # `conversations.agent_version_id` while it is still setting

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -3649,28 +3649,68 @@ defmodule Fountain.Conversations do
   the sprite is destroyed and the row terminated. Best-effort per machine; a
   provider error is logged and the row still retires, so the reaper's sweep
   sees a terminal row rather than a live one nobody can find. Returns the
-  number of homes torn down. `_unsafe_`: the caller owns the agent.
+  number of homes torn down, or a fencing error. Refuses an enclosing database
+  transaction before any teardown. Admission is fenced before actor shutdown
+  and provider I/O; already admitted turns may be interrupted by this forced
+  operation. `_unsafe_`: the caller owns the agent.
   """
   def _unsafe_destroy_homes_for_agent(agent_id) when is_binary(agent_id) do
-    from(s in Sandbox,
-      where:
-        s.agent_id == ^agent_id and s.mode == "persistent" and
-          s.status not in ["terminated", "failed"]
-    )
-    |> Repo.all()
-    |> Enum.map(&_unsafe_destroy_home/1)
-    |> length()
+    if Repo.in_transaction?() do
+      {:error, :provider_transaction_open}
+    else
+      from(s in Sandbox,
+        where:
+          s.agent_id == ^agent_id and s.mode == "persistent" and
+            s.status not in ["terminated", "failed"]
+      )
+      |> Repo.all()
+      |> Enum.reduce_while(0, fn home, count ->
+        case _unsafe_destroy_home(home) do
+          :ok -> {:cont, count + 1}
+          {:error, _} = error -> {:halt, error}
+        end
+      end)
+    end
   end
 
   @doc false
   def _unsafe_destroy_home(%Sandbox{} = sandbox) do
-    sandbox = Repo.preload(sandbox, :conversations)
+    if Repo.in_transaction?() do
+      {:error, :provider_transaction_open}
+    else
+      with {:ok, fenced} <- fence_home_destruction(sandbox) do
+        fenced = Repo.preload(fenced, :conversations)
 
-    sandbox.conversations
-    |> Enum.reject(&(&1.status in ["terminated", "failed"]))
-    |> Enum.each(&ConversationServer.terminate_conversation(&1.id, actor: "system:home_reset"))
+        fenced.conversations
+        |> Enum.reject(&(&1.status in ["terminated", "failed"]))
+        |> Enum.each(
+          &ConversationServer.terminate_conversation(&1.id, actor: "system:home_reset")
+        )
 
-    _unsafe_retire_home(sandbox)
+        _unsafe_retire_home(fenced)
+      end
+    end
+  end
+
+  defp fence_home_destruction(sandbox) do
+    Repo.transaction(fn ->
+      Repo.query!("SELECT pg_advisory_xact_lock($1, $2)", [
+        @sandbox_lock_namespace,
+        :erlang.phash2(sandbox.id)
+      ])
+
+      current =
+        Repo.one(from s in Sandbox, where: s.id == ^sandbox.id, lock: "FOR UPDATE") ||
+          Repo.rollback(:not_found)
+
+      # Forced teardown may stop an admitted turn, but cannot admit a new one
+      # after this commit. Keep capacity until the existing teardown finishes.
+      if current.status in @billable_terminal or not is_nil(current.reset_requested_at) do
+        current
+      else
+        current |> Ecto.Changeset.change(reset_requested_at: DateTime.utc_now()) |> Repo.update!()
+      end
+    end)
   end
 
   # Destroy the sprite behind a home and retire its row. Best-effort on the

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -795,7 +795,7 @@ defmodule Fountain.Conversations.ConversationServer do
         {:ok, _} ->
           do_fresh_provision_inner(state, conv, sandbox, agent, env, secrets)
 
-        {:error, %Ecto.Changeset{errors: [status: {"sandbox is retired", []}]}} ->
+        {:error, reason} when retired_or_resetting(reason) ->
           # No resources were created yet. Leave the winning retirement and
           # any replacement conversation alone, without announcing a start.
           {:stop, :normal, state}
@@ -955,7 +955,7 @@ defmodule Fountain.Conversations.ConversationServer do
           # queue_initial_prompt/3.
           {:noreply, new_state}
         else
-          {:error, %Ecto.Changeset{errors: [status: {"sandbox is retired", []}]}} ->
+          {:error, reason} when retired_or_resetting(reason) ->
             # This handle and token belong to this attempt. Do not fail the
             # conversation or release every session: a replacement may own it.
             _ = Managoat.Sandbox.destroy(handle)

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -26,6 +26,11 @@ defmodule Fountain.Conversations.ConversationServer do
   alias Fountain.Conversations.{ProvisionWatchdog, Reapply}
   alias Fountain.Conversations.{Reattachment, Redaction, SpriteEnv, TurnLaunch, TurnMachine}
 
+  defguardp retired_or_resetting(reason)
+            when reason == :sandbox_reset_pending or
+                   (is_struct(reason, Ecto.Changeset) and
+                      reason.errors == [status: {"sandbox is retired", []}])
+
   # ── public api ────────────────────────────────────────────────────────────
 
   def start_link(args) do
@@ -1166,7 +1171,7 @@ defmodule Fountain.Conversations.ConversationServer do
 
           {:noreply, new_state}
 
-        {:error, %Ecto.Changeset{errors: [status: {"sandbox is retired", []}]}} ->
+        {:error, reason} when retired_or_resetting(reason) ->
           # Wake owns this connection's credentials, not the existing disk or
           # another connection's session. Never destroy the machine here.
           Egress.release_prepared({:ok, state})

--- a/apps/fountain/test/fountain/conversations/conversation_server_broker_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_broker_test.exs
@@ -178,7 +178,8 @@ defmodule Fountain.Conversations.ConversationServerBrokerTest do
       end
     end
 
-    for initial <- ["ready", "suspended"], terminal <- ["terminated", "failed"] do
+    for initial <- ["ready", "suspended"],
+        terminal <- ["terminated", "failed", "reset_pending"] do
       @tag initial: initial, terminal: terminal
       test "retirement during #{initial} wake preserves #{terminal} and the replacement", %{
         user: user,
@@ -224,7 +225,15 @@ defmodule Fountain.Conversations.ConversationServerBrokerTest do
         callback_id = Fountain.Repo.reload!(conv).callback_api_key_id
         assert is_binary(callback_id)
 
-        {:ok, retired} = Conversations.update_sandbox(sandbox, %{status: terminal})
+        retired =
+          if terminal == "reset_pending" do
+            sandbox
+            |> Ecto.Changeset.change(reset_requested_at: DateTime.utc_now())
+            |> Fountain.Repo.update!()
+          else
+            {:ok, retired} = Conversations.update_sandbox(sandbox, %{status: terminal})
+            retired
+          end
 
         replacement =
           insert_sandbox(user_id: user.id, status: "ready", sprite_name: "replacement")
@@ -238,8 +247,9 @@ defmodule Fountain.Conversations.ConversationServerBrokerTest do
         send(pid, :resume_wake)
 
         assert :normal = assert_stopped(ref, 5_000)
-        assert Fountain.Repo.reload!(sandbox).status == terminal
+        assert Fountain.Repo.reload!(sandbox).status == retired.status
         assert Fountain.Repo.reload!(sandbox).terminated_at == retired.terminated_at
+        assert Fountain.Repo.reload!(sandbox).reset_requested_at == retired.reset_requested_at
         assert Fountain.Repo.reload!(conv).sandbox_id == replacement.id
         assert Fountain.Repo.reload!(conv).status == "idle"
         assert Fountain.Repo.reload!(replacement).status == "ready"

--- a/apps/fountain/test/fountain/conversations/conversation_server_broker_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_broker_test.exs
@@ -592,7 +592,7 @@ defmodule Fountain.Conversations.ConversationServerBrokerTest do
       end
     end
 
-    for terminal <- ["terminated", "failed"] do
+    for terminal <- ["terminated", "failed", "reset_pending"] do
       @tag terminal: terminal
       test "retirement during provision preserves the #{terminal} row and replacement", %{
         user: user,
@@ -638,7 +638,16 @@ defmodule Fountain.Conversations.ConversationServerBrokerTest do
         callback_id = Fountain.Repo.reload!(conv).callback_api_key_id
         assert is_binary(callback_id)
 
-        {:ok, retired} = Conversations.update_sandbox(sandbox, %{status: terminal})
+        retired =
+          if terminal == "reset_pending" do
+            sandbox
+            |> Fountain.Repo.reload!()
+            |> Ecto.Changeset.change(reset_requested_at: DateTime.utc_now())
+            |> Fountain.Repo.update!()
+          else
+            {:ok, retired} = Conversations.update_sandbox(sandbox, %{status: terminal})
+            retired
+          end
 
         replacement =
           insert_sandbox(user_id: user.id, status: "ready", sprite_name: "replacement")
@@ -653,8 +662,9 @@ defmodule Fountain.Conversations.ConversationServerBrokerTest do
         send(pid, :resume_provision)
 
         assert :normal = assert_stopped(ref, 5_000)
-        assert Fountain.Repo.reload!(sandbox).status == terminal
+        assert Fountain.Repo.reload!(sandbox).status == retired.status
         assert Fountain.Repo.reload!(sandbox).terminated_at == retired.terminated_at
+        assert Fountain.Repo.reload!(sandbox).reset_requested_at == retired.reset_requested_at
         assert Fountain.Repo.reload!(conv).status == "idle"
         assert Fountain.Repo.reload!(conv).sandbox_id == replacement.id
         assert Fountain.Repo.reload!(replacement).status == "ready"

--- a/apps/fountain/test/fountain/conversations/conversation_server_provision_retirement_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_provision_retirement_test.exs
@@ -1,7 +1,7 @@
 defmodule Fountain.Conversations.ConversationServerProvisionRetirementTest do
   use Fountain.ConversationServerCase
 
-  for terminal <- ["terminated", "failed"] do
+  for terminal <- ["terminated", "failed", "reset_pending"] do
     test "retirement to #{terminal} before starting does not provision or fail the replacement" do
       stub_happy_sprite()
       user = insert_verified_user()
@@ -34,14 +34,24 @@ defmodule Fountain.Conversations.ConversationServerProvisionRetirementTest do
       on_exit(fn -> if Process.alive?(pid), do: Process.exit(pid, :kill) end)
       assert_receive {:starting_paused, ^pid}, 5_000
 
-      {:ok, retired} = Conversations.update_sandbox(sandbox, %{status: unquote(terminal)})
+      retired =
+        if unquote(terminal) == "reset_pending" do
+          sandbox
+          |> Ecto.Changeset.change(reset_requested_at: DateTime.utc_now())
+          |> Fountain.Repo.update!()
+        else
+          {:ok, retired} = Conversations.update_sandbox(sandbox, %{status: unquote(terminal)})
+          retired
+        end
+
       replacement = insert_sandbox(user_id: user.id, status: "ready")
       {:ok, _} = Conversations.update_conversation(conv, %{sandbox_id: replacement.id})
       send(pid, :resume_starting)
 
       assert :normal = assert_stopped(ref, 5_000)
-      assert Fountain.Repo.reload!(sandbox).status == unquote(terminal)
+      assert Fountain.Repo.reload!(sandbox).status == retired.status
       assert Fountain.Repo.reload!(sandbox).terminated_at == retired.terminated_at
+      assert Fountain.Repo.reload!(sandbox).reset_requested_at == retired.reset_requested_at
       assert Fountain.Repo.reload!(conv).status == "idle"
       assert Fountain.Repo.reload!(conv).sandbox_id == replacement.id
       assert Fountain.Repo.reload!(replacement).status == "ready"

--- a/apps/fountain/test/fountain/conversations/forced_home_fence_test.exs
+++ b/apps/fountain/test/fountain/conversations/forced_home_fence_test.exs
@@ -1,0 +1,90 @@
+defmodule Fountain.Conversations.ForcedHomeFenceTest do
+  use Fountain.DataCase, async: true
+  use Mimic
+
+  alias Fountain.{Agents, Conversations}
+  alias Fountain.Conversations.ConversationServer
+
+  setup do
+    user = insert_verified_user()
+    agent = insert_agent(user_id: user.id)
+
+    home =
+      insert_sandbox(user_id: user.id, agent_id: agent.id, mode: "persistent", status: "ready")
+
+    conv = insert_conversation(user_id: user.id, agent: agent, sandbox: home, status: "idle")
+    %{user: user, agent: agent, home: home, conv: conv}
+  end
+
+  for capacity <- [1, :unbounded] do
+    test "agent deletion fences #{inspect(capacity)} admission before provider deletion", ctx do
+      expect(Managoat.Sandbox.Sprites, :destroy, fn handle ->
+        assert handle.name == ctx.home.sprite_name
+        refute Repo.in_transaction?()
+        assert Repo.reload!(ctx.home).reset_requested_at
+        assert Repo.reload!(ctx.home).status == "ready"
+        assert Fountain.Quotas.active_sandbox_count(ctx.user.id) == 1
+        assert {:error, :sandbox_unavailable} = admit(ctx, unquote(capacity))
+        :ok
+      end)
+
+      assert {:ok, _} = Agents.delete_agent(ctx.agent)
+      assert Repo.get(Agents.Agent, ctx.agent.id) == nil
+      assert Repo.reload!(ctx.home).status == "terminated"
+      assert Repo.reload!(ctx.conv).status == "terminated"
+      assert Fountain.Quotas.active_sandbox_count(ctx.user.id) == 0
+
+      assert Repo.aggregate(
+               from(t in Conversations.Turn, where: t.conversation_id == ^ctx.conv.id),
+               :count
+             ) == 0
+    end
+  end
+
+  test "the fence commits before existing conversation actors are stopped", ctx do
+    expect(ConversationServer, :terminate_conversation, fn id, opts ->
+      refute Repo.in_transaction?()
+      assert id == ctx.conv.id
+      assert Repo.reload!(ctx.home).reset_requested_at
+      assert {:error, :sandbox_unavailable} = admit(ctx, :unbounded)
+      Mimic.call_original(ConversationServer, :terminate_conversation, [id, opts])
+    end)
+
+    expect(Managoat.Sandbox.Sprites, :destroy, fn _ -> :ok end)
+    assert :ok = Conversations._unsafe_destroy_home(ctx.home)
+    assert Repo.reload!(ctx.conv).status == "terminated"
+  end
+
+  for operation <- [:agent, :home] do
+    test "an enclosing transaction refuses #{operation} teardown before any side effect", ctx do
+      reject(Managoat.Sandbox.Sprites, :destroy, 1)
+      reject(ConversationServer, :terminate_conversation, 2)
+
+      assert {:ok, {:error, :provider_transaction_open}} =
+               Repo.transaction(fn ->
+                 case unquote(operation) do
+                   :agent -> Agents.delete_agent(ctx.agent)
+                   :home -> Conversations._unsafe_destroy_home(ctx.home)
+                 end
+               end)
+
+      assert Repo.get(Agents.Agent, ctx.agent.id)
+      refute Repo.reload!(ctx.home).reset_requested_at
+      assert Repo.reload!(ctx.home).status == "ready"
+      assert Repo.reload!(ctx.conv).status == "idle"
+    end
+  end
+
+  defp admit(ctx, capacity) do
+    Conversations._unsafe_create_turn_on_sandbox(
+      %{
+        conversation_id: ctx.conv.id,
+        turn_number: 1,
+        status: "running",
+        prompt: "late"
+      },
+      ctx.home.id,
+      capacity
+    )
+  end
+end


### PR DESCRIPTION
Deleting an agent could terminate its conversations and destroy its home while another connection still admitted a new turn. Forced home teardown now commits the existing admission fence under the sandbox advisory and row locks before actor shutdown or provider I/O. The fenced row keeps its quota slot until teardown completes. Already admitted turns can still be interrupted by this explicitly forced operation.

Teardown refuses an enclosing database transaction before side effects. Agent deletion propagates fencing errors instead of deleting the agent row after a refused teardown. Existing best-effort handling of provider deletion errors is unchanged.

Stack: based on #1971, including graceful wake/provision callback handling when a fence wins. Refs #1767. Other retirement/reassignment paths still need the remaining audit; this does not close the issue.

Validation:
- All five new regressions fail against the parent: missing fences before actor/provider work and unsafe teardown inside enclosing transactions.
- All 108 forced-home, agent, reset and orphaned-home tests passed. Coverage checks bounded/unbounded admission refusal, quota retention during provider deletion, actor shutdown ordering, completed row state and agent retention on refusal.
- Full `mix precommit` passed: 5,399 core tests plus 6 doctests, 144 Buzz tests and 33 Support tests, all with zero failures. The first full run exposed missing extension tables in the isolated local database; after applying the umbrella migrations, the complete gate passed with no code change.

No real provider or deployed environment was modified.
