### PR TITLE
fix(conversations): fence lifecycle reclaim before teardown

### DIFF
--- a/apps/fountain/lib/fountain/agents.ex
+++ b/apps/fountain/lib/fountain/agents.ex
@@ -277,7 +277,7 @@ defmodule Fountain.Agents do
     # names it — deletion would nilify the pointer and orphan the sprite.
     # Ownership: `agent` came from the caller's scoped fetch.
     with count when is_integer(count) <-
-           Fountain.Conversations._unsafe_destroy_homes_for_agent(agent.id) do
+           Fountain.Conversations._unsafe_destroy_homes_for_agent(agent.id, opts) do
       delete_agent_row(agent, opts)
     end
   end

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -3690,7 +3690,7 @@ defmodule Fountain.Conversations do
   and provider I/O; already admitted turns may be interrupted by this forced
   operation. `_unsafe_`: the caller owns the agent.
   """
-  def _unsafe_destroy_homes_for_agent(agent_id) when is_binary(agent_id) do
+  def _unsafe_destroy_homes_for_agent(agent_id, opts \\ []) when is_binary(agent_id) do
     if Repo.in_transaction?() do
       {:error, :provider_transaction_open}
     else
@@ -3701,7 +3701,7 @@ defmodule Fountain.Conversations do
       )
       |> Repo.all()
       |> Enum.reduce_while(0, fn home, count ->
-        case _unsafe_destroy_home(home) do
+        case _unsafe_destroy_home(home, Keyword.put_new(opts, :reason, "agent_deleted")) do
           :ok -> {:cont, count + 1}
           {:error, _} = error -> {:halt, error}
         end
@@ -3710,11 +3710,11 @@ defmodule Fountain.Conversations do
   end
 
   @doc false
-  def _unsafe_destroy_home(%Sandbox{} = sandbox) do
+  def _unsafe_destroy_home(%Sandbox{} = sandbox, opts \\ []) do
     if Repo.in_transaction?() do
       {:error, :provider_transaction_open}
     else
-      with {:ok, fenced} <- fence_home_destruction(sandbox) do
+      with {:ok, fenced} <- _unsafe_fence_sandbox_for_teardown(sandbox, opts) do
         fenced = Repo.preload(fenced, :conversations)
 
         fenced.conversations
@@ -3728,7 +3728,47 @@ defmodule Fountain.Conversations do
     end
   end
 
-  defp fence_home_destruction(sandbox) do
+  @doc """
+  Commit an admission fence before a caller tears down a sandbox. No provider
+  I/O runs here. The caller owns this row and must stop actors and clean up
+  the provider after success. Already admitted turns may be forcibly stopped.
+
+  Reuses the reset fence so every existing reuse path refuses the machine,
+  retaining capacity until retirement completes. A new fence records
+  `sandbox.teardown_requested` after commit; repeats preserve its timestamp.
+  Refuses an enclosing transaction. `opts` carries actor, request_ip and reason.
+  """
+  def _unsafe_fence_sandbox_for_teardown(%Sandbox{} = sandbox, opts \\ []) do
+    if Repo.in_transaction?() do
+      {:error, :provider_transaction_open}
+    else
+      case do_fence_sandbox_for_teardown(sandbox) do
+        {:ok, {fenced, true}} ->
+          Audit.record(%{
+            user_id: fenced.user_id,
+            action: "sandbox.teardown_requested",
+            resource_type: "sandbox",
+            resource_id: fenced.id,
+            actor: Keyword.get(opts, :actor, "self"),
+            request_ip: Keyword.get(opts, :request_ip),
+            metadata: %{
+              "reason" => Keyword.get(opts, :reason, "teardown"),
+              "provider" => fenced.provider
+            }
+          })
+
+          {:ok, fenced}
+
+        {:ok, {fenced, false}} ->
+          {:ok, fenced}
+
+        {:error, _} = error ->
+          error
+      end
+    end
+  end
+
+  defp do_fence_sandbox_for_teardown(sandbox) do
     Repo.transaction(fn ->
       Repo.query!("SELECT pg_advisory_xact_lock($1, $2)", [
         @sandbox_lock_namespace,
@@ -3742,9 +3782,14 @@ defmodule Fountain.Conversations do
       # Forced teardown may stop an admitted turn, but cannot admit a new one
       # after this commit. Keep capacity until the existing teardown finishes.
       if current.status in @billable_terminal or not is_nil(current.reset_requested_at) do
-        current
+        {current, false}
       else
-        current |> Ecto.Changeset.change(reset_requested_at: DateTime.utc_now()) |> Repo.update!()
+        fenced =
+          current
+          |> Ecto.Changeset.change(reset_requested_at: DateTime.utc_now())
+          |> Repo.update!()
+
+        {fenced, true}
       end
     end)
   end

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -2118,17 +2118,27 @@ defmodule Fountain.Conversations.ConversationServer do
         "(sprite #{inspect(state.handle && state.handle.name)})"
     )
 
-    state = drop_connection(state, "reclaimed")
+    with :ok <- Lifecycle.prepare_destroy(state.sandbox_id, reason) do
+      state = drop_connection(state, "reclaimed")
 
-    Lifecycle.destroy(
-      state.conversation_id,
-      state.sandbox_id,
-      state.user_id,
-      state.handle,
-      reason
-    )
+      case Lifecycle.destroy(
+             state.conversation_id,
+             state.sandbox_id,
+             state.user_id,
+             state.handle,
+             reason
+           ) do
+        :ok -> {:stop, :normal, %{state | handle: nil}}
+        {:error, error} -> reclaim_refused(state, error)
+      end
+    else
+      {:error, error} -> reclaim_refused(state, error)
+    end
+  end
 
-    {:stop, :normal, %{state | handle: nil}}
+  defp reclaim_refused(state, error) do
+    Logger.warning("reclaim refused for conv #{state.conversation_id}: #{inspect(error)}")
+    {:noreply, state}
   end
 
   # Best-effort revoke of the per-conversation API key when this server

--- a/apps/fountain/lib/fountain/conversations/lifecycle.ex
+++ b/apps/fountain/lib/fountain/conversations/lifecycle.ex
@@ -420,6 +420,36 @@ defmodule Fountain.Conversations.Lifecycle do
   end
 
   @doc """
+  Fence admission before the server closes its adapter or destroys the machine.
+  The caller owns the sandbox through its conversation, as in `home?/1`.
+  Refuses an enclosing transaction; a successful fence commits before returning.
+  Already-admitted turns may still be interrupted by this forced reclaim.
+  """
+  @spec prepare_destroy(String.t() | nil, :idle | :max_lifetime) :: :ok | {:error, term()}
+  def prepare_destroy(sandbox_id, reason) do
+    cond do
+      Fountain.Repo.in_transaction?() ->
+        {:error, :provider_transaction_open}
+
+      is_nil(sandbox_id) ->
+        :ok
+
+      true ->
+        with %Conversations.Sandbox{} = sandbox <- Conversations._unsafe_get_sandbox(sandbox_id),
+             {:ok, _} <-
+               Conversations._unsafe_fence_sandbox_for_teardown(sandbox,
+                 actor: "system:conversation_server",
+                 reason: to_string(reason)
+               ) do
+          :ok
+        else
+          nil -> {:error, :not_found}
+          {:error, _} = error -> error
+        end
+    end
+  end
+
+  @doc """
   Tear down the sandbox; the conversation stays `idle` and resumable (setting
   it `terminated` here would make a cost control into data loss). Serves both
   the max-lifetime ceiling and the idle bound on a provider that cannot park.
@@ -430,8 +460,16 @@ defmodule Fountain.Conversations.Lifecycle do
           String.t(),
           Handle.t() | nil,
           :idle | :max_lifetime
-        ) :: :ok
+        ) :: :ok | {:error, term()}
   def destroy(conversation_id, sandbox_id, user_id, handle, reason) do
+    # The server prepares before closing its adapter. Check again here for
+    # direct callers; an existing fence adds no second request event.
+    with :ok <- prepare_destroy(sandbox_id, reason) do
+      do_destroy(conversation_id, sandbox_id, user_id, handle, reason)
+    end
+  end
+
+  defp do_destroy(conversation_id, sandbox_id, user_id, handle, reason) do
     if handle, do: _ = Managoat.Sandbox.destroy(handle)
     Egress.release(user_id, conversation_id)
 

--- a/apps/fountain/test/fountain/audit_guardrail_test.exs
+++ b/apps/fountain/test/fountain/audit_guardrail_test.exs
@@ -74,6 +74,7 @@ defmodule Fountain.AuditGuardrailTest do
      "conversation.execution_allowance_narrowed"},
     {"sandbox reset", &__MODULE__.do_sandbox_reset/1, "sandbox.reset"},
     {"pending sandbox reset retry", &__MODULE__.do_pending_reset_retry/1, "sandbox.reset"},
+    {"sandbox teardown fence", &__MODULE__.do_teardown_fence/1, "sandbox.teardown_requested"},
     {"role change", &__MODULE__.do_role_change/1, "account.role_changed"},
     {"sandbox limit change", &__MODULE__.do_limit_change/1, "account.sandbox_limit_changed"},
     {"suspend", &__MODULE__.do_suspend/1, "account.suspended"},
@@ -229,6 +230,7 @@ defmodule Fountain.AuditGuardrailTest do
           {Vaults, :delete_vault, 2},
           {InferenceCredentials, :put_credential, 5},
           {Conversations, :start_conversation, 2},
+          {Conversations, :_unsafe_fence_sandbox_for_teardown, 2},
           {Conversations, :delete_conversation, 2},
           {Fountain.Team.Comms, :provision_contact, 4},
           {Fountain.Team.Comms, :update_contact, 4},
@@ -486,6 +488,11 @@ defmodule Fountain.AuditGuardrailTest do
     agent = insert_agent(user_id: user.id)
     conv = insert_conversation(user_id: user.id, agent: agent, status: "idle")
     {:ok, _} = Conversations.reapply_conversation(conv)
+  end
+
+  def do_teardown_fence(user) do
+    sandbox = insert_sandbox(user_id: user.id, status: "ready")
+    {:ok, _} = Conversations._unsafe_fence_sandbox_for_teardown(sandbox)
   end
 
   def do_sandbox_reset(user) do

--- a/apps/fountain/test/fountain/conversations/lifecycle_fence_test.exs
+++ b/apps/fountain/test/fountain/conversations/lifecycle_fence_test.exs
@@ -1,0 +1,167 @@
+defmodule Fountain.Conversations.LifecycleFenceTest do
+  # The server callback reads application-wide lifecycle bounds.
+  use Fountain.DataCase, async: false
+  use Mimic
+
+  alias Fountain.{Audit, Conversations}
+  alias Fountain.Conversations.{ConversationServer, Lifecycle}
+
+  setup do
+    bounds = [sandbox_idle_timeout_minutes: 1, sandbox_max_lifetime_hours: 0]
+    previous = Enum.map(bounds, fn {key, _} -> {key, Application.fetch_env(:fountain, key)} end)
+    Enum.each(bounds, fn {key, value} -> Application.put_env(:fountain, key, value) end)
+
+    on_exit(fn ->
+      Enum.each(previous, fn
+        {key, {:ok, value}} -> Application.put_env(:fountain, key, value)
+        {key, :error} -> Application.delete_env(:fountain, key)
+      end)
+    end)
+
+    user = insert_verified_user()
+    sandbox = insert_sandbox(user_id: user.id, status: "ready")
+    conv = insert_conversation(user_id: user.id, sandbox: sandbox, status: "idle")
+    handle = Managoat.Sandbox.build_handle(:sprites, sandbox.sprite_name)
+
+    state = %{
+      conversation_id: conv.id,
+      sandbox_id: sandbox.id,
+      user_id: user.id,
+      handle: handle,
+      sandbox_started_at: DateTime.utc_now(),
+      last_activity_at: DateTime.add(DateTime.utc_now(), -120),
+      current_turn: nil,
+      acp_peer: nil,
+      acp_peer_mon: nil,
+      current_command: :adapter,
+      current_command_ref: nil,
+      autonomous_quiet: nil
+    }
+
+    stub(Managoat.Sandbox, :supports?, fn :sprites, :suspend -> false end)
+    %{user: user, sandbox: sandbox, conv: conv, handle: handle, state: state}
+  end
+
+  for capacity <- [1, :unbounded] do
+    test "reclaim fences #{inspect(capacity)} admission before provider destruction", ctx do
+      expect(Managoat.Sandbox, :destroy, fn handle ->
+        assert handle == ctx.handle
+        refute Repo.in_transaction?()
+        assert Repo.reload!(ctx.sandbox).reset_requested_at
+        assert Repo.reload!(ctx.sandbox).status == "ready"
+        assert Fountain.Quotas.active_sandbox_count(ctx.user.id) == 1
+        assert {:error, :sandbox_unavailable} = admit(ctx, unquote(capacity))
+        :ok
+      end)
+
+      assert :ok = Lifecycle.destroy(ctx.conv.id, ctx.sandbox.id, ctx.user.id, ctx.handle, :idle)
+      assert Repo.reload!(ctx.sandbox).status == "terminated"
+      assert Fountain.Quotas.active_sandbox_count(ctx.user.id) == 0
+
+      assert Repo.aggregate(
+               from(t in Conversations.Turn, where: t.conversation_id == ^ctx.conv.id),
+               :count
+             ) == 0
+
+      assert [event] =
+               Audit.list_for_user(ctx.user.id, action_prefix: "sandbox.teardown_requested")
+
+      assert event.actor == "system:conversation_server"
+      assert event.metadata["reason"] == "idle"
+    end
+  end
+
+  test "the server fences before closing its adapter and records one request", ctx do
+    expect(Managoat.Sandbox, :close_stdin, fn :adapter ->
+      refute Repo.in_transaction?()
+      assert Repo.reload!(ctx.sandbox).reset_requested_at
+      assert {:error, :sandbox_unavailable} = admit(ctx, :unbounded)
+      :ok
+    end)
+
+    expect(Managoat.Sandbox, :stop_command, fn :adapter -> :ok end)
+    expect(Managoat.Sandbox, :destroy, fn _ -> :ok end)
+
+    assert {:stop, :normal, stopped} = ConversationServer.handle_info(:lifecycle_check, ctx.state)
+    assert stopped.current_command == nil
+    assert stopped.handle == nil
+    assert [_] = Audit.list_for_user(ctx.user.id, action_prefix: "sandbox.teardown_requested")
+  end
+
+  for sandbox? <- [true, false] do
+    test "an enclosing transaction refuses destruction with sandbox=#{sandbox?}", ctx do
+      reject(Managoat.Sandbox, :destroy, 1)
+      sandbox_id = if unquote(sandbox?), do: ctx.sandbox.id
+
+      assert {:ok, {:error, :provider_transaction_open}} =
+               Repo.transaction(fn ->
+                 Lifecycle.destroy(ctx.conv.id, sandbox_id, ctx.user.id, ctx.handle, :idle)
+               end)
+
+      assert Repo.reload!(ctx.sandbox).status == "ready"
+      refute Repo.reload!(ctx.sandbox).reset_requested_at
+    end
+  end
+
+  test "a refused server reclaim retains its adapter and does not report completion", ctx do
+    reject(Managoat.Sandbox, :close_stdin, 1)
+    reject(Managoat.Sandbox, :destroy, 1)
+
+    assert {:ok, {:noreply, unchanged}} =
+             Repo.transaction(fn ->
+               ConversationServer.handle_info(:lifecycle_check, ctx.state)
+             end)
+
+    assert unchanged == ctx.state
+    refute Repo.reload!(ctx.sandbox).reset_requested_at
+
+    refute Repo.exists?(
+             from(e in Conversations.LogEvent,
+               where:
+                 e.conversation_id == ^ctx.conv.id and e.stage == "sandbox" and e.state == "done"
+             )
+           )
+  end
+
+  test "a missing sandbox refuses preparation without touching the adapter", ctx do
+    Repo.delete!(ctx.sandbox)
+    reject(Managoat.Sandbox, :close_stdin, 1)
+    reject(Managoat.Sandbox, :destroy, 1)
+    assert {:noreply, unchanged} = ConversationServer.handle_info(:lifecycle_check, ctx.state)
+    assert unchanged == ctx.state
+  end
+
+  test "a refusal after adapter shutdown keeps the fenced machine for retry", ctx do
+    expect(Conversations, :_unsafe_fence_sandbox_for_teardown, fn sandbox, opts ->
+      Mimic.call_original(Conversations, :_unsafe_fence_sandbox_for_teardown, [sandbox, opts])
+    end)
+
+    expect(Conversations, :_unsafe_fence_sandbox_for_teardown, fn _, _ -> {:error, :not_found} end)
+
+    expect(Managoat.Sandbox, :close_stdin, fn :adapter -> :ok end)
+    expect(Managoat.Sandbox, :stop_command, fn :adapter -> :ok end)
+    reject(Managoat.Sandbox, :destroy, 1)
+
+    assert {:noreply, retry} = ConversationServer.handle_info(:lifecycle_check, ctx.state)
+    assert retry.current_command == nil
+    assert retry.handle == ctx.handle
+    assert Repo.reload!(ctx.sandbox).reset_requested_at
+    assert Repo.reload!(ctx.sandbox).status == "ready"
+    assert Fountain.Quotas.active_sandbox_count(ctx.user.id) == 1
+
+    refute Repo.exists?(
+             from(e in Conversations.LogEvent,
+               where:
+                 e.conversation_id == ^ctx.conv.id and e.stage == "sandbox" and e.state == "done"
+             )
+           )
+  end
+
+  defp admit(ctx, capacity) do
+    Conversations._unsafe_create_turn_on_sandbox(
+      %{conversation_id: ctx.conv.id, turn_number: 1, status: "running", prompt: "late"},
+      ctx.sandbox.id,
+      capacity
+    )
+  end
+end

--- a/apps/fountain/test/fountain/conversations/teardown_fence_test.exs
+++ b/apps/fountain/test/fountain/conversations/teardown_fence_test.exs
@@ -1,0 +1,104 @@
+defmodule Fountain.Conversations.TeardownFenceTest do
+  use Fountain.DataCase, async: true
+  use Mimic
+
+  alias Fountain.{Agents, Audit, Conversations}
+
+  setup do
+    user = insert_verified_user()
+    agent = insert_agent(user_id: user.id)
+
+    home =
+      insert_sandbox(user_id: user.id, agent_id: agent.id, mode: "persistent", status: "ready")
+
+    %{user: user, agent: agent, home: home}
+  end
+
+  test "records the first fence after commit with caller attribution", ctx do
+    reject(Managoat.Sandbox.Sprites, :destroy, 1)
+
+    expect(Audit, :record, fn attrs ->
+      refute Repo.in_transaction?()
+      assert Repo.reload!(ctx.home).reset_requested_at
+      Mimic.call_original(Audit, :record, [attrs])
+    end)
+
+    assert {:ok, fenced} =
+             Conversations._unsafe_fence_sandbox_for_teardown(ctx.home,
+               actor: "ui",
+               request_ip: "192.0.2.1",
+               reason: "agent_deleted"
+             )
+
+    assert fenced.status == "ready"
+    assert Fountain.Quotas.active_sandbox_count(ctx.user.id) == 1
+    assert [event] = events(ctx)
+    assert event.actor == "ui"
+    assert event.request_ip == "192.0.2.1"
+    assert event.resource_type == "sandbox"
+    assert event.resource_id == ctx.home.id
+    assert event.metadata == %{"reason" => "agent_deleted", "provider" => ctx.home.provider}
+
+    assert {:ok, repeated} = Conversations._unsafe_fence_sandbox_for_teardown(ctx.home)
+    assert repeated.reset_requested_at == fenced.reset_requested_at
+    assert [^event] = events(ctx)
+  end
+
+  for status <- ["terminated", "failed"] do
+    test "a #{status} sandbox needs no new fence or request event", ctx do
+      ctx.home |> Ecto.Changeset.change(status: unquote(status)) |> Repo.update!()
+      reject(Audit, :record, 1)
+      reject(Managoat.Sandbox.Sprites, :destroy, 1)
+
+      assert {:ok, retired} = Conversations._unsafe_fence_sandbox_for_teardown(ctx.home)
+      assert retired.status == unquote(status)
+      refute retired.reset_requested_at
+      assert events(ctx) == []
+    end
+  end
+
+  test "an existing reset fence keeps its timestamp without another request event", ctx do
+    requested_at = DateTime.add(DateTime.utc_now(), -60)
+    ctx.home |> Ecto.Changeset.change(reset_requested_at: requested_at) |> Repo.update!()
+    reject(Audit, :record, 1)
+    reject(Managoat.Sandbox.Sprites, :destroy, 1)
+
+    assert {:ok, fenced} = Conversations._unsafe_fence_sandbox_for_teardown(ctx.home)
+    assert fenced.reset_requested_at == requested_at
+    assert events(ctx) == []
+  end
+
+  test "a missing sandbox returns an error without an audit or provider call", ctx do
+    Repo.delete!(ctx.home)
+    reject(Audit, :record, 1)
+    reject(Managoat.Sandbox.Sprites, :destroy, 1)
+    assert {:error, :not_found} = Conversations._unsafe_fence_sandbox_for_teardown(ctx.home)
+    assert events(ctx) == []
+  end
+
+  test "an enclosing transaction cannot create a fence or audit event", ctx do
+    reject(Audit, :record, 1)
+    reject(Managoat.Sandbox.Sprites, :destroy, 1)
+
+    assert {:ok, {:error, :provider_transaction_open}} =
+             Repo.transaction(fn ->
+               Conversations._unsafe_fence_sandbox_for_teardown(ctx.home)
+             end)
+
+    refute Repo.reload!(ctx.home).reset_requested_at
+    assert events(ctx) == []
+  end
+
+  test "agent deletion forwards attribution to its home teardown request", ctx do
+    expect(Managoat.Sandbox.Sprites, :destroy, fn _ -> :ok end)
+    assert {:ok, _} = Agents.delete_agent(ctx.agent, actor: "ui", request_ip: "192.0.2.2")
+    assert [event] = events(ctx)
+    assert event.actor == "ui"
+    assert event.request_ip == "192.0.2.2"
+    assert event.metadata["reason"] == "agent_deleted"
+  end
+
+  defp events(ctx) do
+    Audit.list_for_user(ctx.user.id, action_prefix: "sandbox.teardown_requested")
+  end
+end


### PR DESCRIPTION
Lifecycle reclaim could close its adapter and destroy the provider machine while another connection admitted a turn. Reclaim now commits the shared teardown fence before adapter shutdown and provider deletion, retaining the quota slot until retirement finishes. Its request event names `system:conversation_server` and the reclaim reason.

The server prepares the fence before dropping its connection. `Lifecycle.destroy/5` also checks the fence so direct callers obey the same boundary; the repeated check preserves the timestamp and emits no duplicate request event. A refused fence keeps the server available for the next lifecycle check and does not publish a successful reclaim. Enclosing transactions are refused before destruction, including the legacy path without a sandbox row.

Stack: based on #1973. Refs #1767. Already-admitted turns may still be interrupted by forced reclaim. Existing best-effort provider deletion behavior remains in place; account cleanup and park behavior are separate paths.

Validation:
- All six initial regressions fail against the parent: missing fences at provider/adapter boundaries and destruction inside enclosing transactions.
- All 55 focused lifecycle action, server lifetime and shared-sandbox tests passed. Coverage includes bounded/unbounded refusal, quota retention, one attributed request event, missing rows, enclosing transactions, and retry state when a fence check fails after adapter shutdown.
- Full `mix precommit` passed: 5,415 core tests plus 6 doctests, 144 Buzz tests and 33 Support tests, all with zero failures.

No real provider or deployed environment was modified.
