### PR TITLE
fix(accounts): refuse teardown inside enclosing transactions

### DIFF
--- a/apps/fountain/lib/fountain/accounts/deletion.ex
+++ b/apps/fountain/lib/fountain/accounts/deletion.ex
@@ -71,9 +71,10 @@ defmodule Fountain.Accounts.Deletion do
       an admin path should pass something identifying.
     * `:request_ip` — passed through to the audit event.
 
-  Returns `{:ok, summary}`. Nothing aborts before destruction: there is no
-  subscription to cancel first (ADR 0031), and the Stripe customer stays for
-  the refund trail.
+  Returns `{:ok, summary}` or an error. An enclosing database transaction is
+  refused before any teardown: actor and provider calls must run outside its
+  locks. There is no subscription to cancel first (ADR 0031), and the Stripe
+  customer stays for the refund trail.
 
   A claimable principal this account owns (ADR 0044) goes with it. The
   ownership row cascades either way, so the alternative is not "keep it" but
@@ -83,6 +84,14 @@ defmodule Fountain.Accounts.Deletion do
   """
   @spec delete_user(User.t(), keyword()) :: {:ok, map()} | {:error, term()}
   def delete_user(%User{} = user, opts \\ []) do
+    if Repo.in_transaction?() do
+      {:error, :provider_transaction_open}
+    else
+      do_delete_user(user, opts)
+    end
+  end
+
+  defp do_delete_user(user, opts) do
     delete_owned_principals(user, opts)
     sprites = destroy_sprites(user)
 
@@ -144,7 +153,8 @@ defmodule Fountain.Accounts.Deletion do
 
   @doc """
   Stop every sandbox a tenant is running, and return how many sprites were
-  destroyed.
+  destroyed. Refuses an enclosing database transaction before stopping actors
+  or calling a provider.
 
   Ask a live ConversationServer to tear itself down where one exists, so the
   sprite goes through the same path as a user-initiated terminate. Otherwise
@@ -155,10 +165,18 @@ defmodule Fountain.Accounts.Deletion do
   keeps the rows. Duplicating this would be duplicating the part that costs
   money when it is wrong.
   """
-  @spec destroy_sprites(User.t() | binary()) :: non_neg_integer()
+  @spec destroy_sprites(User.t() | binary()) :: non_neg_integer() | {:error, term()}
   def destroy_sprites(%User{id: user_id}), do: destroy_sprites(user_id)
 
   def destroy_sprites(user_id) when is_binary(user_id) do
+    if Repo.in_transaction?() do
+      {:error, :provider_transaction_open}
+    else
+      do_destroy_sprites(user_id)
+    end
+  end
+
+  defp do_destroy_sprites(user_id) do
     conv_ids =
       Conversations.list_conversations(user_id)
       |> Enum.filter(&(ConversationServer.whereis(&1.id) != nil))

--- a/apps/fountain/lib/fountain/agents.ex
+++ b/apps/fountain/lib/fountain/agents.ex
@@ -277,7 +277,7 @@ defmodule Fountain.Agents do
     # names it — deletion would nilify the pointer and orphan the sprite.
     # Ownership: `agent` came from the caller's scoped fetch.
     with count when is_integer(count) <-
-           Fountain.Conversations._unsafe_destroy_homes_for_agent(agent.id) do
+           Fountain.Conversations._unsafe_destroy_homes_for_agent(agent.id, opts) do
       delete_agent_row(agent, opts)
     end
   end

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -3690,7 +3690,7 @@ defmodule Fountain.Conversations do
   and provider I/O; already admitted turns may be interrupted by this forced
   operation. `_unsafe_`: the caller owns the agent.
   """
-  def _unsafe_destroy_homes_for_agent(agent_id) when is_binary(agent_id) do
+  def _unsafe_destroy_homes_for_agent(agent_id, opts \\ []) when is_binary(agent_id) do
     if Repo.in_transaction?() do
       {:error, :provider_transaction_open}
     else
@@ -3701,7 +3701,7 @@ defmodule Fountain.Conversations do
       )
       |> Repo.all()
       |> Enum.reduce_while(0, fn home, count ->
-        case _unsafe_destroy_home(home) do
+        case _unsafe_destroy_home(home, Keyword.put_new(opts, :reason, "agent_deleted")) do
           :ok -> {:cont, count + 1}
           {:error, _} = error -> {:halt, error}
         end
@@ -3710,11 +3710,11 @@ defmodule Fountain.Conversations do
   end
 
   @doc false
-  def _unsafe_destroy_home(%Sandbox{} = sandbox) do
+  def _unsafe_destroy_home(%Sandbox{} = sandbox, opts \\ []) do
     if Repo.in_transaction?() do
       {:error, :provider_transaction_open}
     else
-      with {:ok, fenced} <- fence_home_destruction(sandbox) do
+      with {:ok, fenced} <- _unsafe_fence_sandbox_for_teardown(sandbox, opts) do
         fenced = Repo.preload(fenced, :conversations)
 
         fenced.conversations
@@ -3728,7 +3728,47 @@ defmodule Fountain.Conversations do
     end
   end
 
-  defp fence_home_destruction(sandbox) do
+  @doc """
+  Commit an admission fence before a caller tears down a sandbox. No provider
+  I/O runs here. The caller owns this row and must stop actors and clean up
+  the provider after success. Already admitted turns may be forcibly stopped.
+
+  Reuses the reset fence so every existing reuse path refuses the machine,
+  retaining capacity until retirement completes. A new fence records
+  `sandbox.teardown_requested` after commit; repeats preserve its timestamp.
+  Refuses an enclosing transaction. `opts` carries actor, request_ip and reason.
+  """
+  def _unsafe_fence_sandbox_for_teardown(%Sandbox{} = sandbox, opts \\ []) do
+    if Repo.in_transaction?() do
+      {:error, :provider_transaction_open}
+    else
+      case do_fence_sandbox_for_teardown(sandbox) do
+        {:ok, {fenced, true}} ->
+          Audit.record(%{
+            user_id: fenced.user_id,
+            action: "sandbox.teardown_requested",
+            resource_type: "sandbox",
+            resource_id: fenced.id,
+            actor: Keyword.get(opts, :actor, "self"),
+            request_ip: Keyword.get(opts, :request_ip),
+            metadata: %{
+              "reason" => Keyword.get(opts, :reason, "teardown"),
+              "provider" => fenced.provider
+            }
+          })
+
+          {:ok, fenced}
+
+        {:ok, {fenced, false}} ->
+          {:ok, fenced}
+
+        {:error, _} = error ->
+          error
+      end
+    end
+  end
+
+  defp do_fence_sandbox_for_teardown(sandbox) do
     Repo.transaction(fn ->
       Repo.query!("SELECT pg_advisory_xact_lock($1, $2)", [
         @sandbox_lock_namespace,
@@ -3742,9 +3782,14 @@ defmodule Fountain.Conversations do
       # Forced teardown may stop an admitted turn, but cannot admit a new one
       # after this commit. Keep capacity until the existing teardown finishes.
       if current.status in @billable_terminal or not is_nil(current.reset_requested_at) do
-        current
+        {current, false}
       else
-        current |> Ecto.Changeset.change(reset_requested_at: DateTime.utc_now()) |> Repo.update!()
+        fenced =
+          current
+          |> Ecto.Changeset.change(reset_requested_at: DateTime.utc_now())
+          |> Repo.update!()
+
+        {fenced, true}
       end
     end)
   end

--- a/apps/fountain/test/fountain/accounts/deletion_transaction_test.exs
+++ b/apps/fountain/test/fountain/accounts/deletion_transaction_test.exs
@@ -1,0 +1,36 @@
+defmodule Fountain.Accounts.DeletionTransactionTest do
+  use Fountain.DataCase, async: true
+  use Mimic
+
+  alias Fountain.Accounts.{Deletion, User}
+  alias Fountain.Conversations.ConversationServer
+
+  for operation <- [:delete_user, :destroy_user_sprites, :destroy_id_sprites] do
+    test "#{operation} refuses an enclosing transaction before teardown" do
+      user = insert_verified_user()
+      agent = insert_agent(user_id: user.id)
+      sandbox = insert_sandbox(user_id: user.id, agent_id: agent.id, status: "ready")
+      conv = insert_conversation(user_id: user.id, agent: agent, sandbox: sandbox, status: "idle")
+      events = Fountain.Audit.list_for_user(user.id)
+
+      stub(ConversationServer, :whereis, fn _ -> self() end)
+      reject(ConversationServer, :terminate_conversation, 2)
+      reject(Managoat.Sandbox.Sprites, :destroy, 1)
+
+      assert {:ok, {:error, :provider_transaction_open}} =
+               Repo.transaction(fn ->
+                 case unquote(operation) do
+                   :delete_user -> Deletion.delete_user(user)
+                   :destroy_user_sprites -> Deletion.destroy_sprites(user)
+                   :destroy_id_sprites -> Deletion.destroy_sprites(user.id)
+                 end
+               end)
+
+      assert Repo.get(User, user.id)
+      assert Repo.reload!(agent)
+      assert Repo.reload!(sandbox).status == "ready"
+      assert Repo.reload!(conv).status == "idle"
+      assert Fountain.Audit.list_for_user(user.id) == events
+    end
+  end
+end

--- a/apps/fountain/test/fountain/audit_guardrail_test.exs
+++ b/apps/fountain/test/fountain/audit_guardrail_test.exs
@@ -74,6 +74,7 @@ defmodule Fountain.AuditGuardrailTest do
      "conversation.execution_allowance_narrowed"},
     {"sandbox reset", &__MODULE__.do_sandbox_reset/1, "sandbox.reset"},
     {"pending sandbox reset retry", &__MODULE__.do_pending_reset_retry/1, "sandbox.reset"},
+    {"sandbox teardown fence", &__MODULE__.do_teardown_fence/1, "sandbox.teardown_requested"},
     {"role change", &__MODULE__.do_role_change/1, "account.role_changed"},
     {"sandbox limit change", &__MODULE__.do_limit_change/1, "account.sandbox_limit_changed"},
     {"suspend", &__MODULE__.do_suspend/1, "account.suspended"},
@@ -229,6 +230,7 @@ defmodule Fountain.AuditGuardrailTest do
           {Vaults, :delete_vault, 2},
           {InferenceCredentials, :put_credential, 5},
           {Conversations, :start_conversation, 2},
+          {Conversations, :_unsafe_fence_sandbox_for_teardown, 2},
           {Conversations, :delete_conversation, 2},
           {Fountain.Team.Comms, :provision_contact, 4},
           {Fountain.Team.Comms, :update_contact, 4},
@@ -486,6 +488,11 @@ defmodule Fountain.AuditGuardrailTest do
     agent = insert_agent(user_id: user.id)
     conv = insert_conversation(user_id: user.id, agent: agent, status: "idle")
     {:ok, _} = Conversations.reapply_conversation(conv)
+  end
+
+  def do_teardown_fence(user) do
+    sandbox = insert_sandbox(user_id: user.id, status: "ready")
+    {:ok, _} = Conversations._unsafe_fence_sandbox_for_teardown(sandbox)
   end
 
   def do_sandbox_reset(user) do

--- a/apps/fountain/test/fountain/conversations/teardown_fence_test.exs
+++ b/apps/fountain/test/fountain/conversations/teardown_fence_test.exs
@@ -1,0 +1,104 @@
+defmodule Fountain.Conversations.TeardownFenceTest do
+  use Fountain.DataCase, async: true
+  use Mimic
+
+  alias Fountain.{Agents, Audit, Conversations}
+
+  setup do
+    user = insert_verified_user()
+    agent = insert_agent(user_id: user.id)
+
+    home =
+      insert_sandbox(user_id: user.id, agent_id: agent.id, mode: "persistent", status: "ready")
+
+    %{user: user, agent: agent, home: home}
+  end
+
+  test "records the first fence after commit with caller attribution", ctx do
+    reject(Managoat.Sandbox.Sprites, :destroy, 1)
+
+    expect(Audit, :record, fn attrs ->
+      refute Repo.in_transaction?()
+      assert Repo.reload!(ctx.home).reset_requested_at
+      Mimic.call_original(Audit, :record, [attrs])
+    end)
+
+    assert {:ok, fenced} =
+             Conversations._unsafe_fence_sandbox_for_teardown(ctx.home,
+               actor: "ui",
+               request_ip: "192.0.2.1",
+               reason: "agent_deleted"
+             )
+
+    assert fenced.status == "ready"
+    assert Fountain.Quotas.active_sandbox_count(ctx.user.id) == 1
+    assert [event] = events(ctx)
+    assert event.actor == "ui"
+    assert event.request_ip == "192.0.2.1"
+    assert event.resource_type == "sandbox"
+    assert event.resource_id == ctx.home.id
+    assert event.metadata == %{"reason" => "agent_deleted", "provider" => ctx.home.provider}
+
+    assert {:ok, repeated} = Conversations._unsafe_fence_sandbox_for_teardown(ctx.home)
+    assert repeated.reset_requested_at == fenced.reset_requested_at
+    assert [^event] = events(ctx)
+  end
+
+  for status <- ["terminated", "failed"] do
+    test "a #{status} sandbox needs no new fence or request event", ctx do
+      ctx.home |> Ecto.Changeset.change(status: unquote(status)) |> Repo.update!()
+      reject(Audit, :record, 1)
+      reject(Managoat.Sandbox.Sprites, :destroy, 1)
+
+      assert {:ok, retired} = Conversations._unsafe_fence_sandbox_for_teardown(ctx.home)
+      assert retired.status == unquote(status)
+      refute retired.reset_requested_at
+      assert events(ctx) == []
+    end
+  end
+
+  test "an existing reset fence keeps its timestamp without another request event", ctx do
+    requested_at = DateTime.add(DateTime.utc_now(), -60)
+    ctx.home |> Ecto.Changeset.change(reset_requested_at: requested_at) |> Repo.update!()
+    reject(Audit, :record, 1)
+    reject(Managoat.Sandbox.Sprites, :destroy, 1)
+
+    assert {:ok, fenced} = Conversations._unsafe_fence_sandbox_for_teardown(ctx.home)
+    assert fenced.reset_requested_at == requested_at
+    assert events(ctx) == []
+  end
+
+  test "a missing sandbox returns an error without an audit or provider call", ctx do
+    Repo.delete!(ctx.home)
+    reject(Audit, :record, 1)
+    reject(Managoat.Sandbox.Sprites, :destroy, 1)
+    assert {:error, :not_found} = Conversations._unsafe_fence_sandbox_for_teardown(ctx.home)
+    assert events(ctx) == []
+  end
+
+  test "an enclosing transaction cannot create a fence or audit event", ctx do
+    reject(Audit, :record, 1)
+    reject(Managoat.Sandbox.Sprites, :destroy, 1)
+
+    assert {:ok, {:error, :provider_transaction_open}} =
+             Repo.transaction(fn ->
+               Conversations._unsafe_fence_sandbox_for_teardown(ctx.home)
+             end)
+
+    refute Repo.reload!(ctx.home).reset_requested_at
+    assert events(ctx) == []
+  end
+
+  test "agent deletion forwards attribution to its home teardown request", ctx do
+    expect(Managoat.Sandbox.Sprites, :destroy, fn _ -> :ok end)
+    assert {:ok, _} = Agents.delete_agent(ctx.agent, actor: "ui", request_ip: "192.0.2.2")
+    assert [event] = events(ctx)
+    assert event.actor == "ui"
+    assert event.request_ip == "192.0.2.2"
+    assert event.metadata["reason"] == "agent_deleted"
+  end
+
+  defp events(ctx) do
+    Audit.list_for_user(ctx.user.id, action_prefix: "sandbox.teardown_requested")
+  end
+end


### PR DESCRIPTION
Account deletion and tenant compute cleanup could stop actors and delete provider machines inside a caller's database transaction. They now return {:error, :provider_transaction_open} before teardown when an enclosing transaction is open. The guard covers account deletion, including its owned principals, and both user/id forms of destroy_sprites/1.

Calls outside a transaction keep their existing deletion and best-effort provider behavior. The documented return contract now includes refusal. This is the transaction-boundary prerequisite for committing admission fences before account cleanup in a separate small PR.

Stack: based on #1973. Refs #1767; admission-fence adoption is separate.

Validation:
- All three new regressions fail on the parent. Provider and actor calls are rejected by the local test stubs.
- All 68 focused transaction-boundary, account deletion, principal and console deletion tests passed. Refusal preserves user, agent, sandbox, conversation and audit state.
- Full `mix precommit` passed: 5,410 core tests plus 6 doctests, 144 Buzz tests and 33 Support tests, all with zero failures.

No real provider or deployed environment was modified.
