### PR TITLE
fix(accounts): fence admission before tenant compute teardown

### DIFF
--- a/apps/fountain/lib/fountain/accounts/deletion.ex
+++ b/apps/fountain/lib/fountain/accounts/deletion.ex
@@ -93,8 +93,14 @@ defmodule Fountain.Accounts.Deletion do
 
   defp do_delete_user(user, opts) do
     delete_owned_principals(user, opts)
-    sprites = destroy_sprites(user)
 
+    with sprites when is_integer(sprites) <-
+           destroy_sprites(user, Keyword.put_new(opts, :reason, "account_deleted")) do
+      delete_user_row(user, sprites, opts)
+    end
+  end
+
+  defp delete_user_row(user, sprites, opts) do
     Audit.record(%{
       user_id: user.id,
       action: "account.deleted",
@@ -154,7 +160,10 @@ defmodule Fountain.Accounts.Deletion do
   @doc """
   Stop every sandbox a tenant is running, and return how many sprites were
   destroyed. Refuses an enclosing database transaction before stopping actors
-  or calling a provider.
+  or calling a provider. Known machines are admission-fenced before actor
+  shutdown; machines found afterward are fenced before provider deletion.
+  Forced cleanup may interrupt already-admitted turns. Options carry actor,
+  request_ip and a reason for the committed teardown request.
 
   Ask a live ConversationServer to tear itself down where one exists, so the
   sprite goes through the same path as a user-initiated terminate. Otherwise
@@ -165,18 +174,35 @@ defmodule Fountain.Accounts.Deletion do
   keeps the rows. Duplicating this would be duplicating the part that costs
   money when it is wrong.
   """
-  @spec destroy_sprites(User.t() | binary()) :: non_neg_integer() | {:error, term()}
-  def destroy_sprites(%User{id: user_id}), do: destroy_sprites(user_id)
+  @spec destroy_sprites(User.t() | binary(), keyword()) :: non_neg_integer() | {:error, term()}
+  def destroy_sprites(user, opts \\ [])
+  def destroy_sprites(%User{id: user_id}, opts), do: destroy_sprites(user_id, opts)
 
-  def destroy_sprites(user_id) when is_binary(user_id) do
+  def destroy_sprites(user_id, opts) when is_binary(user_id) do
     if Repo.in_transaction?() do
       {:error, :provider_transaction_open}
     else
-      do_destroy_sprites(user_id)
+      opts = Keyword.put_new(opts, :reason, "compute_stopped")
+
+      with :ok <- fence_sprites(user_id, opts) do
+        do_destroy_sprites(user_id, opts)
+      end
     end
   end
 
-  defp do_destroy_sprites(user_id) do
+  defp fence_sprites(user_id, opts) do
+    # ownership: live_sandboxes/1 scopes every row to this caller-owned user_id.
+    user_id
+    |> live_sandboxes()
+    |> Enum.reduce_while(:ok, fn sandbox, :ok ->
+      case Conversations._unsafe_fence_sandbox_for_teardown(sandbox, opts) do
+        {:ok, _} -> {:cont, :ok}
+        {:error, _} = error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp do_destroy_sprites(user_id, opts) do
     conv_ids =
       Conversations.list_conversations(user_id)
       |> Enum.filter(&(ConversationServer.whereis(&1.id) != nil))
@@ -194,10 +220,29 @@ defmodule Fountain.Accounts.Deletion do
       end
     end)
 
+    # Actors may have retired a row or created another machine while stopping.
+    # Re-read and fence each remaining row before touching its provider.
+    # ownership: live_sandboxes/1 scopes these fresh rows to the same user_id.
+    user_id
+    |> live_sandboxes()
+    |> Enum.reduce_while(0, fn sandbox, count ->
+      case Conversations._unsafe_fence_sandbox_for_teardown(sandbox, opts) do
+        {:ok, %{status: status} = fenced} when status in @non_terminal ->
+          {:cont, count + if(destroy_sprite(fenced), do: 1, else: 0)}
+
+        {:ok, _retired} ->
+          {:cont, count}
+
+        {:error, _} = error ->
+          {:halt, error}
+      end
+    end)
+  end
+
+  defp live_sandboxes(user_id) do
     Sandbox
     |> where([s], s.user_id == ^user_id and s.status in ^@non_terminal)
     |> Repo.all()
-    |> Enum.count(&destroy_sprite/1)
   end
 
   defp destroy_sprite(%Sandbox{sprite_name: name} = sandbox) when is_binary(name) do

--- a/apps/fountain/lib/fountain/accounts/deletion.ex
+++ b/apps/fountain/lib/fountain/accounts/deletion.ex
@@ -16,7 +16,10 @@ defmodule Fountain.Accounts.Deletion do
      cascade takes `conversations` with it, and after that nothing links a
      sandbox to the user who was paying for it. Failures here are logged rather
      than fatal: `SandboxReaper` reconciles anything missed on its next run,
-     which is exactly the case it exists for.
+     which is exactly the case it exists for. An enclosing transaction is the
+     one thing that refuses, and it refuses before any teardown starts
+     (`delete_user/2`); a single machine's fence being refused mid-run is
+     logged and the run carries on.
 
   2. **Record the audit event.** Before the delete, and carrying the email and
      user id in `metadata` — `audit_events.user_id` is `SET NULL` on delete, so
@@ -184,20 +187,39 @@ defmodule Fountain.Accounts.Deletion do
     else
       opts = Keyword.put_new(opts, :reason, "compute_stopped")
 
+      # `audit_events.user_id` and `sandboxes.user_id` are both nilified by the
+      # delete that follows, so an event carrying only the column would survive
+      # as an anonymous row pointing at an anonymous sandbox. Denormalise the
+      # tenant into the metadata, as `account.deleted` already does (step 2).
+      opts = Keyword.put_new(opts, :metadata, %{"user_id" => user_id})
+
       with :ok <- fence_sprites(user_id, opts) do
         do_destroy_sprites(user_id, opts)
       end
     end
   end
 
+  # A refused fence is logged and the run continues, because the alternative
+  # strands the row it refused on: a halt here leaves `reset_requested_at` set
+  # on a `ready` sandbox whose account is still there, and every `SandboxReaper`
+  # pass filters that row out — `release_stuck_sandboxes/0` and
+  # `sweep_abandoned_sandboxes/0` both require `is_nil(reset_requested_at)`, the
+  # dead-sprite pass wants a terminal status, and the untracked sweep counts the
+  # sprite as known. It would keep burning a `Quotas.active_sandboxes/0` slot
+  # and the fleet ceiling with nothing left able to reclaim it. ADR 0009
+  # decision 2 makes sprite teardown best-effort for this reason, and #1767
+  # asks that failed cleanup stay recoverable by reconciliation.
   defp fence_sprites(user_id, opts) do
     # ownership: live_sandboxes/1 scopes every row to this caller-owned user_id.
     user_id
     |> live_sandboxes()
-    |> Enum.reduce_while(:ok, fn sandbox, :ok ->
+    |> Enum.each(fn sandbox ->
       case Conversations._unsafe_fence_sandbox_for_teardown(sandbox, opts) do
-        {:ok, _} -> {:cont, :ok}
-        {:error, _} = error -> {:halt, error}
+        {:ok, _} ->
+          :ok
+
+        {:error, reason} ->
+          Logger.warning("account deletion: fencing #{sandbox.id} refused: #{inspect(reason)}")
       end
     end)
   end
@@ -233,8 +255,9 @@ defmodule Fountain.Accounts.Deletion do
         {:ok, _retired} ->
           {:cont, count}
 
-        {:error, _} = error ->
-          {:halt, error}
+        {:error, reason} ->
+          Logger.warning("account deletion: late fence refused: #{inspect(reason)}")
+          {:cont, count}
       end
     end)
   end

--- a/apps/fountain/lib/fountain/accounts/deletion.ex
+++ b/apps/fountain/lib/fountain/accounts/deletion.ex
@@ -150,7 +150,13 @@ defmodule Fountain.Accounts.Deletion do
   defp delete_owned_principals(%User{id: owner_id}, opts) do
     for principal_id <- Fountain.Principals.list_owned(owner_id),
         %User{} = principal <- [Repo.get(User, principal_id)] do
-      delete_user(principal, Keyword.put(opts, :actor, "system:owner_deleted"))
+      case delete_user(principal, Keyword.put(opts, :actor, "system:owner_deleted")) do
+        {:ok, _} ->
+          :ok
+
+        {:error, reason} ->
+          Logger.warning("account deletion: owned principal #{principal_id}: #{inspect(reason)}")
+      end
     end
 
     :ok

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -3736,7 +3736,9 @@ defmodule Fountain.Conversations do
   Reuses the reset fence so every existing reuse path refuses the machine,
   retaining capacity until retirement completes. A new fence records
   `sandbox.teardown_requested` after commit; repeats preserve its timestamp.
-  Refuses an enclosing transaction. `opts` carries actor, request_ip and reason.
+  Refuses an enclosing transaction. `opts` carries actor, request_ip, reason and
+  `:metadata` — extra keys merged into the event, for a caller whose own delete
+  is about to nilify `user_id` on both the event and the sandbox it names.
 
   With a terminating_conversation_id, first lock and verify that conversation's
   current attachment and owner. A persistent home or another live conversation
@@ -3756,10 +3758,14 @@ defmodule Fountain.Conversations do
             resource_id: fenced.id,
             actor: Keyword.get(opts, :actor, "self"),
             request_ip: Keyword.get(opts, :request_ip),
-            metadata: %{
-              "reason" => Keyword.get(opts, :reason, "teardown"),
-              "provider" => fenced.provider
-            }
+            metadata:
+              Map.merge(
+                %{
+                  "reason" => Keyword.get(opts, :reason, "teardown"),
+                  "provider" => fenced.provider
+                },
+                Keyword.get(opts, :metadata, %{})
+              )
           })
 
           {:ok, fenced}

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -3756,7 +3756,10 @@ defmodule Fountain.Conversations do
             action: "sandbox.teardown_requested",
             resource_type: "sandbox",
             resource_id: fenced.id,
-            actor: Keyword.get(opts, :actor, "self"),
+            # ADR 0013 keeps `admin:<operator_id>` for account deletion alone,
+            # so an operator reaping a machine from /admin/sandboxes records
+            # the plain `admin` the vocabulary allows here.
+            actor: teardown_actor(Keyword.get(opts, :actor, "self")),
             request_ip: Keyword.get(opts, :request_ip),
             metadata:
               Map.merge(
@@ -3778,6 +3781,9 @@ defmodule Fountain.Conversations do
       end
     end
   end
+
+  defp teardown_actor("admin:" <> _), do: "admin"
+  defp teardown_actor(actor), do: actor
 
   defp do_fence_sandbox_for_teardown(sandbox, ending_id) do
     Repo.transaction(fn ->

--- a/apps/fountain/lib/fountain/principals.ex
+++ b/apps/fountain/lib/fountain/principals.ex
@@ -786,7 +786,7 @@ defmodule Fountain.Principals do
       end)
 
     with {:ok, closed} <- result do
-      stop_compute(closed.user_id)
+      stop_compute(closed.user_id, opts)
       settle_grant(closed, opts)
 
       record(closed, action, opts, %{
@@ -928,9 +928,14 @@ defmodule Fountain.Principals do
 
   # ── helpers ─────────────────────────────────────────────────────────────────
 
-  defp stop_compute(user_id) do
-    Deletion.destroy_sprites(user_id)
-    :ok
+  defp stop_compute(user_id, opts) do
+    case Deletion.destroy_sprites(user_id, Keyword.put_new(opts, :reason, "principal_closed")) do
+      {:error, reason} ->
+        Logger.warning("stopping compute for principal #{user_id} refused: #{inspect(reason)}")
+
+      _count ->
+        :ok
+    end
   rescue
     e ->
       Logger.warning("stopping compute for principal #{user_id} failed: #{inspect(e)}")

--- a/apps/fountain/test/fountain/accounts/deletion_fence_test.exs
+++ b/apps/fountain/test/fountain/accounts/deletion_fence_test.exs
@@ -1,0 +1,188 @@
+defmodule Fountain.Accounts.DeletionFenceTest do
+  use Fountain.DataCase, async: true
+  use Mimic
+
+  alias Fountain.Accounts.{Deletion, User}
+  alias Fountain.{Audit, Conversations, Principals}
+  alias Fountain.Conversations.ConversationServer
+
+  setup do
+    user = insert_verified_user()
+    sandbox = insert_sandbox(user_id: user.id, status: "ready")
+    conv = insert_conversation(user_id: user.id, sandbox: sandbox, status: "idle")
+    stub(ConversationServer, :whereis, fn _ -> nil end)
+    %{user: user, sandbox: sandbox, conv: conv}
+  end
+
+  for capacity <- [1, :unbounded] do
+    test "account deletion fences #{inspect(capacity)} admission before provider deletion", ctx do
+      expect(Managoat.Sandbox.Sprites, :destroy, fn _ ->
+        refute Repo.in_transaction?()
+        assert Repo.reload!(ctx.sandbox).reset_requested_at
+        assert Fountain.Quotas.active_sandbox_count(ctx.user.id) == 1
+        assert {:error, :sandbox_unavailable} = admit(ctx, unquote(capacity))
+        assert [event] = events(ctx.user.id)
+        assert event.actor == "ui"
+        assert event.request_ip == "192.0.2.1"
+        assert event.metadata["reason"] == "account_deleted"
+        :ok
+      end)
+
+      assert {:ok, %{sprites_destroyed: 1}} =
+               Deletion.delete_user(ctx.user, actor: "ui", request_ip: "192.0.2.1")
+
+      refute Repo.get(User, ctx.user.id)
+      assert Repo.reload!(ctx.sandbox).status == "terminated"
+    end
+  end
+
+  test "all known machines are fenced before the first actor is stopped", ctx do
+    other = insert_sandbox(user_id: ctx.user.id, status: "ready")
+    stub(ConversationServer, :whereis, fn _ -> self() end)
+
+    expect(ConversationServer, :terminate_conversation, fn id, _ ->
+      # Cleanup catches actor failures, so assert this snapshot after it returns.
+      send(
+        self(),
+        {:actor_boundary, id, Repo.in_transaction?(),
+         Repo.reload!(ctx.sandbox).reset_requested_at, Repo.reload!(other).reset_requested_at}
+      )
+
+      :ok
+    end)
+
+    expect(Managoat.Sandbox.Sprites, :destroy, 2, fn _ -> :ok end)
+    assert Deletion.destroy_sprites(ctx.user) == 2
+    assert_received {:actor_boundary, id, false, %DateTime{}, %DateTime{}}
+    assert id == ctx.conv.id
+    assert length(events(ctx.user.id)) == 2
+  end
+
+  test "a machine found after actor shutdown is also fenced before provider deletion", ctx do
+    stub(ConversationServer, :whereis, fn _ -> self() end)
+
+    expect(ConversationServer, :terminate_conversation, fn _, _ ->
+      late = insert_sandbox(user_id: ctx.user.id, status: "ready")
+      send(self(), {:late_sandbox, late.id})
+      :ok
+    end)
+
+    expect(Managoat.Sandbox.Sprites, :destroy, 2, fn handle ->
+      sandbox = Repo.get_by!(Conversations.Sandbox, sprite_name: handle.name)
+      refute Repo.in_transaction?()
+      assert sandbox.reset_requested_at
+      :ok
+    end)
+
+    assert Deletion.destroy_sprites(ctx.user.id) == 2
+    assert_received {:late_sandbox, late_id}
+    assert Repo.get!(Conversations.Sandbox, late_id).status == "terminated"
+    assert length(events(ctx.user.id)) == 2
+  end
+
+  test "a refused fence retains the account and stops before actor or provider work", ctx do
+    expect(Conversations, :_unsafe_fence_sandbox_for_teardown, fn _, _ ->
+      {:error, :fixture_refusal}
+    end)
+
+    reject(ConversationServer, :terminate_conversation, 2)
+    reject(Managoat.Sandbox.Sprites, :destroy, 1)
+    assert {:error, :fixture_refusal} = Deletion.delete_user(ctx.user)
+    assert Repo.get(User, ctx.user.id)
+    assert Repo.reload!(ctx.sandbox).status == "ready"
+    refute Repo.reload!(ctx.sandbox).reset_requested_at
+    assert events(ctx.user.id) == []
+    assert Audit.list_for_user(ctx.user.id, action_prefix: "account.deleted") == []
+  end
+
+  test "principal cleanup forwards the closing caller's attribution", ctx do
+    assert {:ok, %{claimable: claimable}} =
+             Principals.create_claimable(ctx.user, %{"application_id" => "fence-test"})
+
+    sandbox = insert_sandbox(user_id: claimable.user_id, status: "ready")
+
+    expect(Managoat.Sandbox.Sprites, :destroy, fn _ ->
+      assert Repo.reload!(sandbox).reset_requested_at
+      refute Repo.in_transaction?()
+      :ok
+    end)
+
+    assert {:ok, _} =
+             Principals.release(claimable,
+               actor: "system:principal_sweep",
+               request_ip: "192.0.2.2"
+             )
+
+    assert [event] = events(claimable.user_id)
+    assert event.actor == "system:principal_sweep"
+    assert event.request_ip == "192.0.2.2"
+    assert event.metadata["reason"] == "principal_closed"
+    assert Repo.reload!(sandbox).status == "terminated"
+    refute Repo.reload!(ctx.sandbox).reset_requested_at
+  end
+
+  test "provider failure still retires the fenced row and counts no confirmed deletion", ctx do
+    expect(Managoat.Sandbox.Sprites, :destroy, fn _ -> {:error, :unavailable} end)
+    assert Deletion.destroy_sprites(ctx.user) == 0
+    assert Repo.reload!(ctx.sandbox).status == "terminated"
+    assert Repo.reload!(ctx.sandbox).reset_requested_at
+    assert Fountain.Quotas.active_sandbox_count(ctx.user.id) == 0
+  end
+
+  test "an actor-retired machine is not destroyed or counted again", ctx do
+    stub(ConversationServer, :whereis, fn _ -> self() end)
+
+    expect(ConversationServer, :terminate_conversation, fn _, _ ->
+      {:ok, _} = Conversations.update_sandbox(ctx.sandbox, %{status: "terminated"})
+      :ok
+    end)
+
+    reject(Managoat.Sandbox.Sprites, :destroy, 1)
+    assert Deletion.destroy_sprites(ctx.user) == 0
+    assert [_] = events(ctx.user.id)
+  end
+
+  test "refusing a newly discovered machine's fence retains the account", ctx do
+    stub(ConversationServer, :whereis, fn _ -> self() end)
+
+    expect(ConversationServer, :terminate_conversation, fn _, _ ->
+      late = insert_sandbox(user_id: ctx.user.id, status: "ready")
+      send(self(), {:late_sandbox, late.id})
+      :ok
+    end)
+
+    stub(Conversations, :_unsafe_fence_sandbox_for_teardown, fn sandbox, opts ->
+      if sandbox.id == ctx.sandbox.id do
+        Mimic.call_original(Conversations, :_unsafe_fence_sandbox_for_teardown, [sandbox, opts])
+      else
+        {:error, :late_fence_refused}
+      end
+    end)
+
+    stub(Managoat.Sandbox.Sprites, :destroy, fn handle ->
+      send(self(), {:destroyed, handle.name})
+      :ok
+    end)
+
+    assert {:error, :late_fence_refused} = Deletion.delete_user(ctx.user)
+    assert_received {:late_sandbox, late_id}
+    late = Repo.get!(Conversations.Sandbox, late_id)
+    late_name = late.sprite_name
+    refute_received {:destroyed, ^late_name}
+    refute late.reset_requested_at
+    assert late.status == "ready"
+    assert Repo.get(User, ctx.user.id)
+    assert Audit.list_for_user(ctx.user.id, action_prefix: "account.deleted") == []
+  end
+
+  defp admit(ctx, capacity) do
+    Conversations._unsafe_create_turn_on_sandbox(
+      %{conversation_id: ctx.conv.id, turn_number: 1, status: "running", prompt: "late"},
+      ctx.sandbox.id,
+      capacity
+    )
+  end
+
+  defp events(user_id),
+    do: Audit.list_for_user(user_id, action_prefix: "sandbox.teardown_requested")
+end

--- a/apps/fountain/test/fountain/accounts/deletion_fence_test.exs
+++ b/apps/fountain/test/fountain/accounts/deletion_fence_test.exs
@@ -210,6 +210,14 @@ defmodule Fountain.Accounts.DeletionFenceTest do
     assert event.metadata["reason"] == "account_deleted"
   end
 
+  test "an operator's teardown records the plain admin actor (ADR 0013)", ctx do
+    expect(Managoat.Sandbox.Sprites, :destroy, fn _ -> :ok end)
+
+    assert Deletion.destroy_sprites(ctx.user, actor: "admin:operator-7") == 1
+    assert [event] = events(ctx.user.id)
+    assert event.actor == "admin"
+  end
+
   defp admit(ctx, capacity) do
     Conversations._unsafe_create_turn_on_sandbox(
       %{conversation_id: ctx.conv.id, turn_number: 1, status: "running", prompt: "late"},

--- a/apps/fountain/test/fountain/accounts/deletion_fence_test.exs
+++ b/apps/fountain/test/fountain/accounts/deletion_fence_test.exs
@@ -4,6 +4,7 @@ defmodule Fountain.Accounts.DeletionFenceTest do
 
   alias Fountain.Accounts.{Deletion, User}
   alias Fountain.{Audit, Conversations, Principals}
+  import Ecto.Query, only: [where: 3]
   alias Fountain.Conversations.ConversationServer
 
   setup do
@@ -80,19 +81,24 @@ defmodule Fountain.Accounts.DeletionFenceTest do
     assert length(events(ctx.user.id)) == 2
   end
 
-  test "a refused fence retains the account and stops before actor or provider work", ctx do
-    expect(Conversations, :_unsafe_fence_sandbox_for_teardown, fn _, _ ->
+  test "a refused fence is logged and the account is still deleted", ctx do
+    # Halting here would strand this row: `reset_requested_at` set on a `ready`
+    # sandbox whose account survives is invisible to every SandboxReaper pass
+    # and keeps burning a quota slot forever. ADR 0009 decision 2 keeps sprite
+    # teardown best-effort for exactly this reason.
+    stub(Conversations, :_unsafe_fence_sandbox_for_teardown, fn _, _ ->
       {:error, :fixture_refusal}
     end)
 
-    reject(ConversationServer, :terminate_conversation, 2)
-    reject(Managoat.Sandbox.Sprites, :destroy, 1)
-    assert {:error, :fixture_refusal} = Deletion.delete_user(ctx.user)
-    assert Repo.get(User, ctx.user.id)
-    assert Repo.reload!(ctx.sandbox).status == "ready"
-    refute Repo.reload!(ctx.sandbox).reset_requested_at
-    assert events(ctx.user.id) == []
-    assert Audit.list_for_user(ctx.user.id, action_prefix: "account.deleted") == []
+    log =
+      ExUnit.CaptureLog.capture_log(fn ->
+        assert {:ok, %{sprites_destroyed: 0}} = Deletion.delete_user(ctx.user)
+      end)
+
+    assert log =~ "fencing #{ctx.sandbox.id} refused"
+    assert log =~ ":fixture_refusal"
+    refute Repo.get(User, ctx.user.id)
+    assert deleted_event(ctx.user.id)
   end
 
   test "principal cleanup forwards the closing caller's attribution", ctx do
@@ -164,15 +170,44 @@ defmodule Fountain.Accounts.DeletionFenceTest do
       :ok
     end)
 
-    assert {:error, :late_fence_refused} = Deletion.delete_user(ctx.user)
+    log =
+      ExUnit.CaptureLog.capture_log(fn ->
+        assert {:ok, %{sprites_destroyed: 1}} = Deletion.delete_user(ctx.user)
+      end)
+
+    # The refusal is recorded and skipped; the machine that did fence is still
+    # destroyed, and the account still goes.
+    assert log =~ "late fence refused"
+    assert log =~ ":late_fence_refused"
     assert_received {:late_sandbox, late_id}
     late = Repo.get!(Conversations.Sandbox, late_id)
     late_name = late.sprite_name
     refute_received {:destroyed, ^late_name}
     refute late.reset_requested_at
     assert late.status == "ready"
-    assert Repo.get(User, ctx.user.id)
-    assert Audit.list_for_user(ctx.user.id, action_prefix: "account.deleted") == []
+    original_name = ctx.sandbox.sprite_name
+    assert_received {:destroyed, ^original_name}
+    refute Repo.get(User, ctx.user.id)
+    assert deleted_event(ctx.user.id)
+  end
+
+  test "the teardown event still names the tenant after the delete nilifies the column", ctx do
+    expect(Managoat.Sandbox.Sprites, :destroy, fn _ -> :ok end)
+
+    assert {:ok, _} = Deletion.delete_user(ctx.user)
+    refute Repo.get(User, ctx.user.id)
+
+    # `audit_events.user_id` and `sandboxes.user_id` are both nilified by the
+    # delete, so the column cannot answer whose machine this was. The metadata
+    # can, the same way `account.deleted` carries email and user id (#1977).
+    event =
+      Fountain.Audit.Event
+      |> where([e], e.action == "sandbox.teardown_requested")
+      |> Repo.one!()
+
+    assert is_nil(event.user_id)
+    assert event.metadata["user_id"] == ctx.user.id
+    assert event.metadata["reason"] == "account_deleted"
   end
 
   defp admit(ctx, capacity) do
@@ -185,4 +220,14 @@ defmodule Fountain.Accounts.DeletionFenceTest do
 
   defp events(user_id),
     do: Audit.list_for_user(user_id, action_prefix: "sandbox.teardown_requested")
+
+  # After the delete, `audit_events.user_id` is nil, so `list_for_user/2` can no
+  # longer find the row. The tenant only survives in the denormalised metadata,
+  # which is the whole point of recording it there.
+  defp deleted_event(user_id) do
+    Fountain.Audit.Event
+    |> where([e], e.action == "account.deleted")
+    |> Repo.all()
+    |> Enum.find(&(&1.metadata["user_id"] == user_id))
+  end
 end

--- a/apps/fountain/test/fountain/audit_guardrail_test.exs
+++ b/apps/fountain/test/fountain/audit_guardrail_test.exs
@@ -75,6 +75,8 @@ defmodule Fountain.AuditGuardrailTest do
     {"sandbox reset", &__MODULE__.do_sandbox_reset/1, "sandbox.reset"},
     {"pending sandbox reset retry", &__MODULE__.do_pending_reset_retry/1, "sandbox.reset"},
     {"sandbox teardown fence", &__MODULE__.do_teardown_fence/1, "sandbox.teardown_requested"},
+    {"account compute teardown", &__MODULE__.do_account_compute_teardown/1,
+     "sandbox.teardown_requested"},
     {"role change", &__MODULE__.do_role_change/1, "account.role_changed"},
     {"sandbox limit change", &__MODULE__.do_limit_change/1, "account.sandbox_limit_changed"},
     {"suspend", &__MODULE__.do_suspend/1, "account.suspended"},
@@ -231,6 +233,7 @@ defmodule Fountain.AuditGuardrailTest do
           {InferenceCredentials, :put_credential, 5},
           {Conversations, :start_conversation, 2},
           {Conversations, :_unsafe_fence_sandbox_for_teardown, 2},
+          {Fountain.Accounts.Deletion, :destroy_sprites, 2},
           {Conversations, :delete_conversation, 2},
           {Fountain.Team.Comms, :provision_contact, 4},
           {Fountain.Team.Comms, :update_contact, 4},
@@ -488,6 +491,12 @@ defmodule Fountain.AuditGuardrailTest do
     agent = insert_agent(user_id: user.id)
     conv = insert_conversation(user_id: user.id, agent: agent, status: "idle")
     {:ok, _} = Conversations.reapply_conversation(conv)
+  end
+
+  def do_account_compute_teardown(user) do
+    insert_sandbox(user_id: user.id, status: "ready")
+    stub(Managoat.Sandbox.Sprites, :destroy, fn _ -> :ok end)
+    1 = Fountain.Accounts.Deletion.destroy_sprites(user)
   end
 
   def do_teardown_fence(user) do


### PR DESCRIPTION
Account and principal cleanup could stop actors and delete machines while new turns were still admitted. Cleanup now commits admission fences for the known machines before actor shutdown, then re-reads the remaining rows and fences each before provider deletion. Account deletion propagates fencing errors and retains the account instead of reporting a completed deletion.

Teardown requests preserve caller actor/request IP and distinguish account deletion from principal closure. Repeated fences produce no duplicate request event. The existing provider count remains the number of confirmed direct deletions: actor-retired rows are skipped, and provider failures still retire their rows for the existing reaper to reconcile. Principal closure keeps its existing post-commit best-effort cleanup and now logs fencing refusals.

Stack: based on #1976. Refs #1767. Already-admitted turns may be interrupted by forced cleanup. This does not introduce an atomic account-wide barrier against concurrently creating new resources.

Validation:
- All seven initial regressions fail on the parent.
- All 149 focused account, principal and audit-guardrail tests passed. New coverage includes bounded/unbounded admission, actor/provider ordering, newly discovered machines, initial/late fence refusal, attribution, quota retention and provider-count behavior.
- Moving the initial fence after teardown makes the two actor-boundary regressions fail. Restoring the implementation passes all nine new cases.
- Full `mix precommit` passed: 5,420 core tests plus 6 doctests, 144 Buzz tests and 33 Support tests, all with zero failures.

No real provider or deployed environment was modified.
