### PR TITLE
feat(conversations): preserve held machines in termination fences

### DIFF
--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -3737,12 +3737,17 @@ defmodule Fountain.Conversations do
   retaining capacity until retirement completes. A new fence records
   `sandbox.teardown_requested` after commit; repeats preserve its timestamp.
   Refuses an enclosing transaction. `opts` carries actor, request_ip and reason.
+
+  With a terminating_conversation_id, first lock and verify that conversation's
+  current attachment and owner. A persistent home or another live conversation
+  returns {:error, :sandbox_kept} without a new fence. The sandbox row stays
+  locked through this decision and the fence, serializing supported attachments.
   """
   def _unsafe_fence_sandbox_for_teardown(%Sandbox{} = sandbox, opts \\ []) do
     if Repo.in_transaction?() do
       {:error, :provider_transaction_open}
     else
-      case do_fence_sandbox_for_teardown(sandbox) do
+      case do_fence_sandbox_for_teardown(sandbox, Keyword.get(opts, :terminating_conversation_id)) do
         {:ok, {fenced, true}} ->
           Audit.record(%{
             user_id: fenced.user_id,
@@ -3768,16 +3773,24 @@ defmodule Fountain.Conversations do
     end
   end
 
-  defp do_fence_sandbox_for_teardown(sandbox) do
+  defp do_fence_sandbox_for_teardown(sandbox, ending_id) do
     Repo.transaction(fn ->
       Repo.query!("SELECT pg_advisory_xact_lock($1, $2)", [
         @sandbox_lock_namespace,
         :erlang.phash2(sandbox.id)
       ])
 
+      # Match admission's advisory -> conversation -> sandbox lock order.
+      lock_terminating_conversation(sandbox, ending_id)
+
       current =
         Repo.one(from s in Sandbox, where: s.id == ^sandbox.id, lock: "FOR UPDATE") ||
           Repo.rollback(:not_found)
+
+      if not is_nil(ending_id) and
+           (current.mode == "persistent" or _unsafe_sandbox_held_by_other?(current.id, ending_id)) do
+        Repo.rollback(:sandbox_kept)
+      end
 
       # Forced teardown may stop an admitted turn, but cannot admit a new one
       # after this commit. Keep capacity until the existing teardown finishes.
@@ -3792,6 +3805,18 @@ defmodule Fountain.Conversations do
         {fenced, true}
       end
     end)
+  end
+
+  defp lock_terminating_conversation(_sandbox, nil), do: :ok
+
+  defp lock_terminating_conversation(sandbox, ending_id) when is_binary(ending_id) do
+    Repo.one(
+      from c in Conversation,
+        where:
+          c.id == ^ending_id and c.sandbox_id == ^sandbox.id and c.user_id == ^sandbox.user_id,
+        select: c.id,
+        lock: "FOR UPDATE"
+    ) || Repo.rollback(:sandbox_unavailable)
   end
 
   # Destroy the sprite behind a home and retire its row. Best-effort on the

--- a/apps/fountain/test/fountain/conversations/termination_fence_policy_test.exs
+++ b/apps/fountain/test/fountain/conversations/termination_fence_policy_test.exs
@@ -1,0 +1,100 @@
+defmodule Fountain.Conversations.TerminationFencePolicyTest do
+  use Fountain.DataCase, async: true
+  use Mimic
+
+  alias Fountain.{Audit, Conversations}
+
+  setup do
+    user = insert_verified_user()
+    agent = insert_agent(user_id: user.id)
+    sandbox = insert_sandbox(user_id: user.id, agent_id: agent.id, status: "ready")
+    conv = insert_conversation(user_id: user.id, agent: agent, sandbox: sandbox, status: "idle")
+    reject(Managoat.Sandbox.Sprites, :destroy, 1)
+    %{user: user, agent: agent, sandbox: sandbox, conv: conv}
+  end
+
+  test "a persistent home stays available when its only conversation ends", ctx do
+    ctx.sandbox |> Ecto.Changeset.change(mode: "persistent") |> Repo.update!()
+    assert {:error, :sandbox_kept} = fence(ctx)
+    refute Repo.reload!(ctx.sandbox).reset_requested_at
+    assert events(ctx) == []
+  end
+
+  test "another live conversation keeps an ephemeral machine available", ctx do
+    insert_conversation(
+      user_id: ctx.user.id,
+      agent: ctx.agent,
+      sandbox: ctx.sandbox,
+      status: "idle"
+    )
+
+    assert {:error, :sandbox_kept} = fence(ctx)
+    refute Repo.reload!(ctx.sandbox).reset_requested_at
+    assert events(ctx) == []
+  end
+
+  test "terminal co-tenants do not keep the last conversation's machine", ctx do
+    insert_conversation(
+      user_id: ctx.user.id,
+      agent: ctx.agent,
+      sandbox: ctx.sandbox,
+      status: "terminated"
+    )
+
+    insert_conversation(
+      user_id: ctx.user.id,
+      agent: ctx.agent,
+      sandbox: ctx.sandbox,
+      status: "failed"
+    )
+
+    assert {:ok, fenced} = fence(ctx)
+    assert fenced.reset_requested_at
+    assert fenced.status == "ready"
+    assert [event] = events(ctx)
+    assert event.actor == "ui"
+    assert event.metadata["reason"] == "conversation_terminated"
+
+    assert {:error, :sandbox_unavailable} =
+             Conversations._unsafe_create_turn_on_sandbox(
+               %{conversation_id: ctx.conv.id, turn_number: 1, status: "running", prompt: "late"},
+               ctx.sandbox.id,
+               :unbounded
+             )
+  end
+
+  test "a stale actor cannot fence a conversation that moved to another machine", ctx do
+    replacement = insert_sandbox(user_id: ctx.user.id, status: "ready")
+    {:ok, _} = Conversations.update_conversation(ctx.conv, %{sandbox_id: replacement.id})
+    assert {:error, :sandbox_unavailable} = fence(ctx)
+    refute Repo.reload!(ctx.sandbox).reset_requested_at
+    refute Repo.reload!(replacement).reset_requested_at
+    assert events(ctx) == []
+  end
+
+  test "a different tenant's conversation cannot authorize this conditional fence", ctx do
+    other = insert_verified_user()
+    foreign = insert_conversation(user_id: other.id)
+    assert {:error, :sandbox_unavailable} = fence(%{ctx | conv: foreign})
+    refute Repo.reload!(ctx.sandbox).reset_requested_at
+    assert events(ctx) == []
+  end
+
+  test "a missing terminating conversation refuses without mutation", ctx do
+    Repo.delete!(ctx.conv)
+    assert {:error, :sandbox_unavailable} = fence(ctx)
+    refute Repo.reload!(ctx.sandbox).reset_requested_at
+    assert events(ctx) == []
+  end
+
+  defp fence(ctx) do
+    Conversations._unsafe_fence_sandbox_for_teardown(ctx.sandbox,
+      terminating_conversation_id: ctx.conv.id,
+      actor: "ui",
+      reason: "conversation_terminated"
+    )
+  end
+
+  defp events(ctx),
+    do: Audit.list_for_user(ctx.user.id, action_prefix: "sandbox.teardown_requested")
+end


### PR DESCRIPTION
Explicit conversation termination must preserve persistent homes and machines another live conversation still holds. The shared teardown fence now accepts a terminating_conversation_id to enforce that rule under the existing admission lock protocol.

The conditional path takes the sandbox advisory lock, verifies and locks the conversation's current owner/attachment, then locks the sandbox before checking the retention rule and writing the fence. Persistent or shared machines return {:error, :sandbox_kept} without mutation or an audit event; stale, missing or foreign conversation bindings return {:error, :sandbox_unavailable}. Calls without this option keep their existing forced-teardown behavior.

Stack: based on #1973. Refs #1767. This is the context prerequisite; conversation actor integration and concurrent attachment coverage are separate small units.

Validation:
- Five of the six new cases fail on the parent; its existing unconditional fence already passes the last-conversation case.
- All 98 conditional fence, teardown fence, forced-home and audit-guardrail tests passed. Tests check stale row input, retained machines, refused bindings, attributed audit events and admission refusal after a successful fence.
- Full `mix precommit` passed: 5,413 core tests plus 6 doctests, 144 Buzz tests and 33 Support tests, all with zero failures.

No actor or provider I/O runs in the fence transaction. No real provider or deployed environment was modified.
