### PR TITLE
test(conversations): prove termination and attachment commit order

### DIFF
--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -3737,12 +3737,17 @@ defmodule Fountain.Conversations do
   retaining capacity until retirement completes. A new fence records
   `sandbox.teardown_requested` after commit; repeats preserve its timestamp.
   Refuses an enclosing transaction. `opts` carries actor, request_ip and reason.
+
+  With a terminating_conversation_id, first lock and verify that conversation's
+  current attachment and owner. A persistent home or another live conversation
+  returns {:error, :sandbox_kept} without a new fence. The sandbox row stays
+  locked through this decision and the fence, serializing supported attachments.
   """
   def _unsafe_fence_sandbox_for_teardown(%Sandbox{} = sandbox, opts \\ []) do
     if Repo.in_transaction?() do
       {:error, :provider_transaction_open}
     else
-      case do_fence_sandbox_for_teardown(sandbox) do
+      case do_fence_sandbox_for_teardown(sandbox, Keyword.get(opts, :terminating_conversation_id)) do
         {:ok, {fenced, true}} ->
           Audit.record(%{
             user_id: fenced.user_id,
@@ -3768,16 +3773,24 @@ defmodule Fountain.Conversations do
     end
   end
 
-  defp do_fence_sandbox_for_teardown(sandbox) do
+  defp do_fence_sandbox_for_teardown(sandbox, ending_id) do
     Repo.transaction(fn ->
       Repo.query!("SELECT pg_advisory_xact_lock($1, $2)", [
         @sandbox_lock_namespace,
         :erlang.phash2(sandbox.id)
       ])
 
+      # Match admission's advisory -> conversation -> sandbox lock order.
+      lock_terminating_conversation(sandbox, ending_id)
+
       current =
         Repo.one(from s in Sandbox, where: s.id == ^sandbox.id, lock: "FOR UPDATE") ||
           Repo.rollback(:not_found)
+
+      if not is_nil(ending_id) and
+           (current.mode == "persistent" or _unsafe_sandbox_held_by_other?(current.id, ending_id)) do
+        Repo.rollback(:sandbox_kept)
+      end
 
       # Forced teardown may stop an admitted turn, but cannot admit a new one
       # after this commit. Keep capacity until the existing teardown finishes.
@@ -3792,6 +3805,18 @@ defmodule Fountain.Conversations do
         {fenced, true}
       end
     end)
+  end
+
+  defp lock_terminating_conversation(_sandbox, nil), do: :ok
+
+  defp lock_terminating_conversation(sandbox, ending_id) when is_binary(ending_id) do
+    Repo.one(
+      from c in Conversation,
+        where:
+          c.id == ^ending_id and c.sandbox_id == ^sandbox.id and c.user_id == ^sandbox.user_id,
+        select: c.id,
+        lock: "FOR UPDATE"
+    ) || Repo.rollback(:sandbox_unavailable)
   end
 
   # Destroy the sprite behind a home and retire its row. Best-effort on the

--- a/apps/fountain/test/fountain/conversations/termination_attach_order_test.exs
+++ b/apps/fountain/test/fountain/conversations/termination_attach_order_test.exs
@@ -1,0 +1,165 @@
+defmodule Fountain.Conversations.TerminationAttachOrderTest do
+  use Fountain.DataCase, async: false
+  use Mimic
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Fountain.{Audit, Conversations}
+
+  for first <- [:termination, :attachment] do
+    test "#{first} wins the race between termination and a new co-tenant" do
+      assert_order(unquote(first))
+    end
+  end
+
+  defp assert_order(first) do
+    Sandbox.unboxed_run(Repo, fn ->
+      user = insert_active_user()
+      env = insert_env(user_id: user.id)
+      agent = insert_agent(user_id: user.id, runtime: "claude", environment_id: env.id)
+
+      sandbox =
+        insert_sandbox(
+          user_id: user.id,
+          agent_id: agent.id,
+          environment_id: env.id,
+          mode: "ephemeral",
+          status: "ready"
+        )
+
+      conv = insert_conversation(user_id: user.id, agent: agent, sandbox: sandbox, status: "idle")
+
+      operation = fn
+        :termination ->
+          Conversations._unsafe_fence_sandbox_for_teardown(sandbox,
+            terminating_conversation_id: conv.id,
+            reason: "conversation_terminated"
+          )
+
+        :attachment ->
+          Conversations.start_conversation(%{
+            "user_id" => user.id,
+            "agent_id" => agent.id,
+            "sandbox_id" => sandbox.id
+          })
+      end
+
+      owner = self()
+      winner = independent(first, fn -> operation.(first) end, owner, true)
+
+      try do
+        assert_receive {:locked, winner_pid}, 5_000
+        assert winner_pid == winner.pid
+        second = if first == :termination, do: :attachment, else: :termination
+        waiter = independent(second, fn -> operation.(second) end, owner, false)
+
+        try do
+          assert_receive {:backend, ^first, holder}, 5_000
+          assert_receive {:backend, ^second, blocked}, 5_000
+          refute holder == blocked
+          await_blocked(blocked, holder, System.monotonic_time(:millisecond) + 5_000)
+          assert conversation_count(user.id) == 1
+          refute Repo.reload!(sandbox).reset_requested_at
+          send(winner.pid, :continue)
+
+          if first == :termination do
+            assert {:ok, fenced} = Task.await(winner, 5_000)
+            assert fenced.reset_requested_at
+            assert {:error, :sandbox_reset_pending} = Task.await(waiter, 5_000)
+            assert conversation_count(user.id) == 1
+            assert [_] = Audit.list_for_user(user.id, action_prefix: "sandbox.teardown_requested")
+          else
+            assert {:ok, attached} = Task.await(winner, 5_000)
+            assert attached.sandbox_id == sandbox.id
+            assert {:error, :sandbox_kept} = Task.await(waiter, 5_000)
+            assert conversation_count(user.id) == 2
+            refute Repo.reload!(sandbox).reset_requested_at
+            assert Audit.list_for_user(user.id, action_prefix: "sandbox.teardown_requested") == []
+          end
+
+          assert Repo.reload!(sandbox).status == "ready"
+          assert Repo.reload!(conv).status == "idle"
+
+          assert Repo.aggregate(
+                   from(t in Conversations.Turn, where: t.conversation_id == ^conv.id),
+                   :count
+                 ) == 0
+        after
+          stop(waiter)
+        end
+      after
+        stop(winner)
+        Repo.delete_all(from c in Conversations.Conversation, where: c.user_id == ^user.id)
+        Repo.delete_all(from s in Conversations.Sandbox, where: s.id == ^sandbox.id)
+        Repo.delete_all(from a in Audit.Event, where: a.user_id == ^user.id)
+        Repo.delete_all(from u in Fountain.Accounts.User, where: u.id == ^user.id)
+      end
+    end)
+  end
+
+  defp conversation_count(user_id) do
+    Repo.aggregate(from(c in Conversations.Conversation, where: c.user_id == ^user_id), :count)
+  end
+
+  defp stop(task) do
+    Task.shutdown(task, :brutal_kill)
+    :telemetry.detach({__MODULE__, task.pid})
+  end
+
+  defp independent(role, fun, owner, pause?) do
+    Task.async(fn ->
+      Sandbox.unboxed_run(Repo, fn ->
+        %{rows: [[backend]]} = Repo.query!("SELECT pg_backend_pid()")
+        send(owner, {:backend, role, backend})
+        handler = {__MODULE__, self()}
+
+        if pause? do
+          :ok =
+            :telemetry.attach(
+              handler,
+              [:fountain, :repo, :query],
+              &__MODULE__.after_query/4,
+              {self(), owner, handler, role}
+            )
+        end
+
+        reject(Managoat.Sandbox, :destroy, 1)
+
+        try do
+          fun.()
+        after
+          :telemetry.detach(handler)
+        end
+      end)
+    end)
+  end
+
+  def after_query(_, _, %{query: query}, {worker, owner, handler, role}) do
+    target? =
+      query =~ ~s(FROM "sandboxes") and (role == :termination or query =~ "FOR SHARE")
+
+    if self() == worker and target? do
+      :telemetry.detach(handler)
+      send(owner, {:locked, self()})
+
+      receive do
+        :continue -> :ok
+      after
+        10_000 -> send(owner, :lock_release_timed_out)
+      end
+    end
+  end
+
+  def after_query(_, _, _, _), do: :ok
+
+  defp await_blocked(waiter, holder, deadline) do
+    %{rows: [[blocked]]} = Repo.query!("SELECT $2 = ANY(pg_blocking_pids($1))", [waiter, holder])
+
+    unless blocked do
+      assert System.monotonic_time(:millisecond) < deadline,
+             "no wait on the winning PostgreSQL connection observed"
+
+      Process.sleep(5)
+      await_blocked(waiter, holder, deadline)
+    end
+  end
+end

--- a/apps/fountain/test/fountain/conversations/termination_fence_policy_test.exs
+++ b/apps/fountain/test/fountain/conversations/termination_fence_policy_test.exs
@@ -1,0 +1,100 @@
+defmodule Fountain.Conversations.TerminationFencePolicyTest do
+  use Fountain.DataCase, async: true
+  use Mimic
+
+  alias Fountain.{Audit, Conversations}
+
+  setup do
+    user = insert_verified_user()
+    agent = insert_agent(user_id: user.id)
+    sandbox = insert_sandbox(user_id: user.id, agent_id: agent.id, status: "ready")
+    conv = insert_conversation(user_id: user.id, agent: agent, sandbox: sandbox, status: "idle")
+    reject(Managoat.Sandbox.Sprites, :destroy, 1)
+    %{user: user, agent: agent, sandbox: sandbox, conv: conv}
+  end
+
+  test "a persistent home stays available when its only conversation ends", ctx do
+    ctx.sandbox |> Ecto.Changeset.change(mode: "persistent") |> Repo.update!()
+    assert {:error, :sandbox_kept} = fence(ctx)
+    refute Repo.reload!(ctx.sandbox).reset_requested_at
+    assert events(ctx) == []
+  end
+
+  test "another live conversation keeps an ephemeral machine available", ctx do
+    insert_conversation(
+      user_id: ctx.user.id,
+      agent: ctx.agent,
+      sandbox: ctx.sandbox,
+      status: "idle"
+    )
+
+    assert {:error, :sandbox_kept} = fence(ctx)
+    refute Repo.reload!(ctx.sandbox).reset_requested_at
+    assert events(ctx) == []
+  end
+
+  test "terminal co-tenants do not keep the last conversation's machine", ctx do
+    insert_conversation(
+      user_id: ctx.user.id,
+      agent: ctx.agent,
+      sandbox: ctx.sandbox,
+      status: "terminated"
+    )
+
+    insert_conversation(
+      user_id: ctx.user.id,
+      agent: ctx.agent,
+      sandbox: ctx.sandbox,
+      status: "failed"
+    )
+
+    assert {:ok, fenced} = fence(ctx)
+    assert fenced.reset_requested_at
+    assert fenced.status == "ready"
+    assert [event] = events(ctx)
+    assert event.actor == "ui"
+    assert event.metadata["reason"] == "conversation_terminated"
+
+    assert {:error, :sandbox_unavailable} =
+             Conversations._unsafe_create_turn_on_sandbox(
+               %{conversation_id: ctx.conv.id, turn_number: 1, status: "running", prompt: "late"},
+               ctx.sandbox.id,
+               :unbounded
+             )
+  end
+
+  test "a stale actor cannot fence a conversation that moved to another machine", ctx do
+    replacement = insert_sandbox(user_id: ctx.user.id, status: "ready")
+    {:ok, _} = Conversations.update_conversation(ctx.conv, %{sandbox_id: replacement.id})
+    assert {:error, :sandbox_unavailable} = fence(ctx)
+    refute Repo.reload!(ctx.sandbox).reset_requested_at
+    refute Repo.reload!(replacement).reset_requested_at
+    assert events(ctx) == []
+  end
+
+  test "a different tenant's conversation cannot authorize this conditional fence", ctx do
+    other = insert_verified_user()
+    foreign = insert_conversation(user_id: other.id)
+    assert {:error, :sandbox_unavailable} = fence(%{ctx | conv: foreign})
+    refute Repo.reload!(ctx.sandbox).reset_requested_at
+    assert events(ctx) == []
+  end
+
+  test "a missing terminating conversation refuses without mutation", ctx do
+    Repo.delete!(ctx.conv)
+    assert {:error, :sandbox_unavailable} = fence(ctx)
+    refute Repo.reload!(ctx.sandbox).reset_requested_at
+    assert events(ctx) == []
+  end
+
+  defp fence(ctx) do
+    Conversations._unsafe_fence_sandbox_for_teardown(ctx.sandbox,
+      terminating_conversation_id: ctx.conv.id,
+      actor: "ui",
+      reason: "conversation_terminated"
+    )
+  end
+
+  defp events(ctx),
+    do: Audit.list_for_user(ctx.user.id, action_prefix: "sandbox.teardown_requested")
+end


### PR DESCRIPTION
Conditional termination must decide whether the machine is still shared at the same database boundary that fences admission. Two PostgreSQL regressions now race that decision against the real public start_conversation attachment path, in both commit orderings.

If termination wins, attachment waits and then returns sandbox_reset_pending without inserting a conversation. If attachment wins, termination waits for its commit and returns sandbox_kept without a fence or teardown request event. The existing conversation remains idle and the provider is not touched.

Stack: based on #1978. Refs #1767. This verifies the context protocol; conversation actor integration is separate.

Validation:
- Both cases pass with independent PostgreSQL connections, telemetry pauses after the actual sandbox row queries, and pg_blocking_pids evidence of the waiter/holder relationship.
- Weakening the sandbox lock to FOR KEY SHARE makes both fail: the winning fence no longer blocks attachment, and a winning attachment is followed by an incorrect fence.
- Restoring the lock passes all 29 concurrent attachment, conditional fence, attachment API and teardown-fence tests.
- Committed fixture counts for users, sandboxes, conversations and turns were all zero after the mutation run.
- Full `mix precommit` passed: 5,415 core tests plus 6 doctests, 144 Buzz tests and 33 Support tests, all with zero failures.

No real provider or deployed environment was modified.
