### PR TITLE
fix(conversations): fence explicit actor termination before teardown

### DIFF
--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -3737,12 +3737,17 @@ defmodule Fountain.Conversations do
   retaining capacity until retirement completes. A new fence records
   `sandbox.teardown_requested` after commit; repeats preserve its timestamp.
   Refuses an enclosing transaction. `opts` carries actor, request_ip and reason.
+
+  With a terminating_conversation_id, first lock and verify that conversation's
+  current attachment and owner. A persistent home or another live conversation
+  returns {:error, :sandbox_kept} without a new fence. The sandbox row stays
+  locked through this decision and the fence, serializing supported attachments.
   """
   def _unsafe_fence_sandbox_for_teardown(%Sandbox{} = sandbox, opts \\ []) do
     if Repo.in_transaction?() do
       {:error, :provider_transaction_open}
     else
-      case do_fence_sandbox_for_teardown(sandbox) do
+      case do_fence_sandbox_for_teardown(sandbox, Keyword.get(opts, :terminating_conversation_id)) do
         {:ok, {fenced, true}} ->
           Audit.record(%{
             user_id: fenced.user_id,
@@ -3768,16 +3773,24 @@ defmodule Fountain.Conversations do
     end
   end
 
-  defp do_fence_sandbox_for_teardown(sandbox) do
+  defp do_fence_sandbox_for_teardown(sandbox, ending_id) do
     Repo.transaction(fn ->
       Repo.query!("SELECT pg_advisory_xact_lock($1, $2)", [
         @sandbox_lock_namespace,
         :erlang.phash2(sandbox.id)
       ])
 
+      # Match admission's advisory -> conversation -> sandbox lock order.
+      lock_terminating_conversation(sandbox, ending_id)
+
       current =
         Repo.one(from s in Sandbox, where: s.id == ^sandbox.id, lock: "FOR UPDATE") ||
           Repo.rollback(:not_found)
+
+      if not is_nil(ending_id) and
+           (current.mode == "persistent" or _unsafe_sandbox_held_by_other?(current.id, ending_id)) do
+        Repo.rollback(:sandbox_kept)
+      end
 
       # Forced teardown may stop an admitted turn, but cannot admit a new one
       # after this commit. Keep capacity until the existing teardown finishes.
@@ -3792,6 +3805,18 @@ defmodule Fountain.Conversations do
         {fenced, true}
       end
     end)
+  end
+
+  defp lock_terminating_conversation(_sandbox, nil), do: :ok
+
+  defp lock_terminating_conversation(sandbox, ending_id) when is_binary(ending_id) do
+    Repo.one(
+      from c in Conversation,
+        where:
+          c.id == ^ending_id and c.sandbox_id == ^sandbox.id and c.user_id == ^sandbox.user_id,
+        select: c.id,
+        lock: "FOR UPDATE"
+    ) || Repo.rollback(:sandbox_unavailable)
   end
 
   # Destroy the sprite behind a home and retire its row. Best-effort on the

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -1383,44 +1383,16 @@ defmodule Fountain.Conversations.ConversationServer do
     {:reply, reply, Pending.into_state(state, pending)}
   end
 
-  def handle_call(:terminate_conv, _from, state) do
-    kept? =
-      Conversations._unsafe_sandbox_kept_on_terminate?(state.sandbox_id, state.conversation_id)
+  # Keep the legacy request during rollout; callers can adopt attribution
+  # only after all nodes understand the tuple form.
+  def handle_call(:terminate_conv, from, state),
+    do: handle_call({:terminate_conv, []}, from, state)
 
-    if kept? do
-      # The machine is shared, or it is the agent's home (ADR 0023): end this
-      # conversation and leave the sprite — the same guard the no-server path
-      # applies in terminate_conversation/2. A turn of ours still running is
-      # cut first, since nothing would be left to drive it; `handle: nil` so
-      # no stop path touches the sprite.
-      state = if state.current_turn, do: interrupt_turn(state), else: state
-      state = drop_connection(state, "terminated")
-      conv = Conversations._unsafe_get_conversation!(state.conversation_id)
-      {:ok, _} = Conversations.update_conversation(conv, %{status: "terminated"})
-
-      Output.publish_stage(state.conversation_id, "terminate", "done", %{
-        sandbox: "kept",
-        reason:
-          if(Lifecycle.home?(state.sandbox_id),
-            do: "persistent_home",
-            else: "held_by_another_conversation"
-          )
-      })
-
-      {:stop, :normal, :ok, %{state | handle: nil}}
-    else
-      state = drop_connection(state, "terminated")
-      if state.handle, do: _ = Managoat.Sandbox.destroy(state.handle)
-      Egress.release(state.user_id, state.conversation_id)
-      sandbox = Conversations._unsafe_get_sandbox!(state.sandbox_id)
-
-      {:ok, _} =
-        Conversations.update_sandbox(sandbox, %{status: "terminated", terminated_at: now()})
-
-      conv = Conversations._unsafe_get_conversation!(state.conversation_id)
-      {:ok, _} = Conversations.update_conversation(conv, %{status: "terminated"})
-      Output.publish_stage(state.conversation_id, "terminate", "done")
-      {:stop, :normal, :ok, state}
+  def handle_call({:terminate_conv, opts}, _from, state) when is_list(opts) do
+    case prepare_termination(state, opts) do
+      {:ok, sandbox} -> terminate_machine(state, sandbox)
+      {:error, :sandbox_kept} -> terminate_kept_machine(state)
+      {:error, _} = error -> {:reply, error, state}
     end
   end
 
@@ -1905,6 +1877,62 @@ defmodule Fountain.Conversations.ConversationServer do
   # from the shared-sandbox reattach fix and moves with it.
   defp fail_transport(state, reason),
     do: Reattachment.fail_transport(Pending.resolve_held(state, "turn_ended"), reason)
+
+  defp prepare_termination(state, opts) do
+    opts =
+      opts
+      |> Keyword.put(:terminating_conversation_id, state.conversation_id)
+      |> Keyword.put_new(:reason, "conversation_terminated")
+
+    # ownership: init/1 established this actor's conversation and sandbox.
+    case Conversations._unsafe_get_sandbox(state.sandbox_id) do
+      nil ->
+        {:error, :sandbox_unavailable}
+
+      sandbox ->
+        # ownership: the conditional fence rechecks this actor's parent and owner.
+        Conversations._unsafe_fence_sandbox_for_teardown(sandbox, opts)
+    end
+  end
+
+  defp terminate_kept_machine(state) do
+    # The machine is shared, or it is the agent's home (ADR 0023): end this
+    # conversation and leave the sprite — the same guard the no-server path
+    # applies in terminate_conversation/2. A turn of ours still running is
+    # cut first, since nothing would be left to drive it; `handle: nil` so
+    # no stop path touches the sprite.
+    state = if state.current_turn, do: interrupt_turn(state), else: state
+    state = drop_connection(state, "terminated")
+    # ownership: the conditional fence verified this server-owned conversation.
+    conv = Conversations._unsafe_get_conversation!(state.conversation_id)
+    {:ok, _} = Conversations.update_conversation(conv, %{status: "terminated"})
+
+    Output.publish_stage(state.conversation_id, "terminate", "done", %{
+      sandbox: "kept",
+      reason:
+        if(Lifecycle.home?(state.sandbox_id),
+          do: "persistent_home",
+          else: "held_by_another_conversation"
+        )
+    })
+
+    {:stop, :normal, :ok, %{state | handle: nil}}
+  end
+
+  defp terminate_machine(state, sandbox) do
+    state = drop_connection(state, "terminated")
+    if state.handle, do: _ = Managoat.Sandbox.destroy(state.handle)
+    Egress.release(state.user_id, state.conversation_id)
+
+    {:ok, _} =
+      Conversations.update_sandbox(sandbox, %{status: "terminated", terminated_at: now()})
+
+    # ownership: the conditional fence verified this server-owned conversation.
+    conv = Conversations._unsafe_get_conversation!(state.conversation_id)
+    {:ok, _} = Conversations.update_conversation(conv, %{status: "terminated"})
+    Output.publish_stage(state.conversation_id, "terminate", "done")
+    {:stop, :normal, :ok, state}
+  end
 
   # The server's own clock stamp: the input `Lifecycle.check/4` reads. Nothing
   # but this process writes it.

--- a/apps/fountain/test/fountain/conversations/termination_actor_fence_test.exs
+++ b/apps/fountain/test/fountain/conversations/termination_actor_fence_test.exs
@@ -1,0 +1,150 @@
+defmodule Fountain.Conversations.TerminationActorFenceTest do
+  use Fountain.DataCase, async: true
+  use Mimic
+
+  alias Fountain.{Audit, Conversations}
+  alias Fountain.Conversations.ConversationServer
+
+  setup do
+    user = insert_verified_user()
+    agent = insert_agent(user_id: user.id)
+    sandbox = insert_sandbox(user_id: user.id, agent_id: agent.id, status: "ready")
+    conv = insert_conversation(user_id: user.id, agent: agent, sandbox: sandbox, status: "idle")
+    handle = Managoat.Sandbox.build_handle(:sprites, sandbox.sprite_name)
+
+    state = %{
+      conversation_id: conv.id,
+      sandbox_id: sandbox.id,
+      user_id: user.id,
+      handle: handle,
+      current_turn: nil,
+      acp_peer: nil,
+      acp_peer_mon: nil,
+      current_command: :adapter,
+      current_command_ref: nil,
+      autonomous_quiet: nil
+    }
+
+    stub(Managoat.Sandbox, :close_stdin, fn :adapter -> :ok end)
+    stub(Managoat.Sandbox, :stop_command, fn :adapter -> :ok end)
+    %{user: user, agent: agent, sandbox: sandbox, conv: conv, handle: handle, state: state}
+  end
+
+  for capacity <- [1, :unbounded] do
+    test "legacy termination fences #{inspect(capacity)} admission before adapter/provider work",
+         ctx do
+      expect(Managoat.Sandbox, :close_stdin, fn :adapter ->
+        refute Repo.in_transaction?()
+        assert Repo.reload!(ctx.sandbox).reset_requested_at
+        :ok
+      end)
+
+      expect(Managoat.Sandbox, :destroy, fn handle ->
+        assert handle == ctx.handle
+        refute Repo.in_transaction?()
+        assert Repo.reload!(ctx.sandbox).reset_requested_at
+        assert Fountain.Quotas.active_sandbox_count(ctx.user.id) == 1
+        assert {:error, :sandbox_unavailable} = admit(ctx, unquote(capacity))
+        :ok
+      end)
+
+      assert {:stop, :normal, :ok, stopped} = terminate(ctx, :terminate_conv)
+      assert stopped.current_command == nil
+      assert Repo.reload!(ctx.conv).status == "terminated"
+      assert Repo.reload!(ctx.sandbox).status == "terminated"
+      assert Fountain.Quotas.active_sandbox_count(ctx.user.id) == 0
+      assert [event] = events(ctx)
+      assert event.actor == "self"
+      assert event.metadata["reason"] == "conversation_terminated"
+    end
+  end
+
+  test "the attributed request records the caller on the committed fence", ctx do
+    expect(Managoat.Sandbox, :destroy, fn _ -> :ok end)
+
+    assert {:stop, :normal, :ok, _} =
+             terminate(ctx, {:terminate_conv, [actor: "ui", request_ip: "192.0.2.3"]})
+
+    assert [event] = events(ctx)
+    assert event.actor == "ui"
+    assert event.request_ip == "192.0.2.3"
+  end
+
+  for retained <- [:persistent, :shared] do
+    test "#{retained} machines are kept without an admission fence", ctx do
+      case unquote(retained) do
+        :persistent ->
+          ctx.sandbox |> Ecto.Changeset.change(mode: "persistent") |> Repo.update!()
+
+        :shared ->
+          insert_conversation(
+            user_id: ctx.user.id,
+            agent: ctx.agent,
+            sandbox: ctx.sandbox,
+            status: "idle"
+          )
+      end
+
+      reject(Managoat.Sandbox, :destroy, 1)
+      assert {:stop, :normal, :ok, stopped} = terminate(ctx, :terminate_conv)
+      assert stopped.handle == nil
+      assert Repo.reload!(ctx.conv).status == "terminated"
+      assert Repo.reload!(ctx.sandbox).status == "ready"
+      refute Repo.reload!(ctx.sandbox).reset_requested_at
+      assert events(ctx) == []
+    end
+  end
+
+  test "a moved conversation refuses before touching the old adapter or machine", ctx do
+    replacement = insert_sandbox(user_id: ctx.user.id, status: "ready")
+    {:ok, _} = Conversations.update_conversation(ctx.conv, %{sandbox_id: replacement.id})
+    reject(Managoat.Sandbox, :close_stdin, 1)
+    reject(Managoat.Sandbox, :destroy, 1)
+    assert {:reply, {:error, :sandbox_unavailable}, unchanged} = terminate(ctx, :terminate_conv)
+    assert unchanged == ctx.state
+    assert Repo.reload!(ctx.conv).status == "idle"
+    refute Repo.reload!(ctx.sandbox).reset_requested_at
+    refute Repo.reload!(replacement).reset_requested_at
+  end
+
+  test "an enclosing transaction refuses termination before side effects", ctx do
+    reject(Managoat.Sandbox, :close_stdin, 1)
+    reject(Managoat.Sandbox, :destroy, 1)
+
+    assert {:ok, {:reply, {:error, :provider_transaction_open}, unchanged}} =
+             Repo.transaction(fn -> terminate(ctx, :terminate_conv) end)
+
+    assert unchanged == ctx.state
+    assert Repo.reload!(ctx.conv).status == "idle"
+    refute Repo.reload!(ctx.sandbox).reset_requested_at
+  end
+
+  test "a missing machine returns refusal without closing the adapter", ctx do
+    Repo.delete!(ctx.sandbox)
+    reject(Managoat.Sandbox, :close_stdin, 1)
+    reject(Managoat.Sandbox, :destroy, 1)
+    assert {:reply, {:error, :sandbox_unavailable}, unchanged} = terminate(ctx, :terminate_conv)
+    assert unchanged == ctx.state
+  end
+
+  test "a provider error still retires the fenced row for reconciliation", ctx do
+    expect(Managoat.Sandbox, :destroy, fn _ -> {:error, :unavailable} end)
+    assert {:stop, :normal, :ok, _} = terminate(ctx, :terminate_conv)
+    assert Repo.reload!(ctx.sandbox).status == "terminated"
+    assert Repo.reload!(ctx.sandbox).reset_requested_at
+  end
+
+  defp terminate(ctx, message),
+    do: ConversationServer.handle_call(message, {self(), make_ref()}, ctx.state)
+
+  defp events(ctx),
+    do: Audit.list_for_user(ctx.user.id, action_prefix: "sandbox.teardown_requested")
+
+  defp admit(ctx, capacity) do
+    Conversations._unsafe_create_turn_on_sandbox(
+      %{conversation_id: ctx.conv.id, turn_number: 1, status: "running", prompt: "late"},
+      ctx.sandbox.id,
+      capacity
+    )
+  end
+end

--- a/apps/fountain/test/fountain/conversations/termination_fence_policy_test.exs
+++ b/apps/fountain/test/fountain/conversations/termination_fence_policy_test.exs
@@ -1,0 +1,100 @@
+defmodule Fountain.Conversations.TerminationFencePolicyTest do
+  use Fountain.DataCase, async: true
+  use Mimic
+
+  alias Fountain.{Audit, Conversations}
+
+  setup do
+    user = insert_verified_user()
+    agent = insert_agent(user_id: user.id)
+    sandbox = insert_sandbox(user_id: user.id, agent_id: agent.id, status: "ready")
+    conv = insert_conversation(user_id: user.id, agent: agent, sandbox: sandbox, status: "idle")
+    reject(Managoat.Sandbox.Sprites, :destroy, 1)
+    %{user: user, agent: agent, sandbox: sandbox, conv: conv}
+  end
+
+  test "a persistent home stays available when its only conversation ends", ctx do
+    ctx.sandbox |> Ecto.Changeset.change(mode: "persistent") |> Repo.update!()
+    assert {:error, :sandbox_kept} = fence(ctx)
+    refute Repo.reload!(ctx.sandbox).reset_requested_at
+    assert events(ctx) == []
+  end
+
+  test "another live conversation keeps an ephemeral machine available", ctx do
+    insert_conversation(
+      user_id: ctx.user.id,
+      agent: ctx.agent,
+      sandbox: ctx.sandbox,
+      status: "idle"
+    )
+
+    assert {:error, :sandbox_kept} = fence(ctx)
+    refute Repo.reload!(ctx.sandbox).reset_requested_at
+    assert events(ctx) == []
+  end
+
+  test "terminal co-tenants do not keep the last conversation's machine", ctx do
+    insert_conversation(
+      user_id: ctx.user.id,
+      agent: ctx.agent,
+      sandbox: ctx.sandbox,
+      status: "terminated"
+    )
+
+    insert_conversation(
+      user_id: ctx.user.id,
+      agent: ctx.agent,
+      sandbox: ctx.sandbox,
+      status: "failed"
+    )
+
+    assert {:ok, fenced} = fence(ctx)
+    assert fenced.reset_requested_at
+    assert fenced.status == "ready"
+    assert [event] = events(ctx)
+    assert event.actor == "ui"
+    assert event.metadata["reason"] == "conversation_terminated"
+
+    assert {:error, :sandbox_unavailable} =
+             Conversations._unsafe_create_turn_on_sandbox(
+               %{conversation_id: ctx.conv.id, turn_number: 1, status: "running", prompt: "late"},
+               ctx.sandbox.id,
+               :unbounded
+             )
+  end
+
+  test "a stale actor cannot fence a conversation that moved to another machine", ctx do
+    replacement = insert_sandbox(user_id: ctx.user.id, status: "ready")
+    {:ok, _} = Conversations.update_conversation(ctx.conv, %{sandbox_id: replacement.id})
+    assert {:error, :sandbox_unavailable} = fence(ctx)
+    refute Repo.reload!(ctx.sandbox).reset_requested_at
+    refute Repo.reload!(replacement).reset_requested_at
+    assert events(ctx) == []
+  end
+
+  test "a different tenant's conversation cannot authorize this conditional fence", ctx do
+    other = insert_verified_user()
+    foreign = insert_conversation(user_id: other.id)
+    assert {:error, :sandbox_unavailable} = fence(%{ctx | conv: foreign})
+    refute Repo.reload!(ctx.sandbox).reset_requested_at
+    assert events(ctx) == []
+  end
+
+  test "a missing terminating conversation refuses without mutation", ctx do
+    Repo.delete!(ctx.conv)
+    assert {:error, :sandbox_unavailable} = fence(ctx)
+    refute Repo.reload!(ctx.sandbox).reset_requested_at
+    assert events(ctx) == []
+  end
+
+  defp fence(ctx) do
+    Conversations._unsafe_fence_sandbox_for_teardown(ctx.sandbox,
+      terminating_conversation_id: ctx.conv.id,
+      actor: "ui",
+      reason: "conversation_terminated"
+    )
+  end
+
+  defp events(ctx),
+    do: Audit.list_for_user(ctx.user.id, action_prefix: "sandbox.teardown_requested")
+end


### PR DESCRIPTION
Explicit actor termination could close its adapter and destroy a machine while another connection admitted a turn. The actor now prepares the conditional admission fence first. An unshared ephemeral machine is fenced before adapter/provider work; persistent or shared machines keep the existing keep-machine path. A stale, missing or refused binding returns an error with the actor state intact.

The actor accepts both the legacy :terminate_conv message and an attributed {:terminate_conv, opts} form. Public callers still send the legacy request in this PR, so they retain the context's default fence attribution. Deploy this handler support before a separate caller migration starts forwarding attribution across nodes. Conversation termination's existing outer audit remains unchanged.

Stack: based on #1978. Refs #1767. Already-admitted work can be interrupted by this forced operation. Provider deletion remains best-effort, with terminal rows left for reconciliation when deletion fails.

Validation:
- Nine new cases produce seven failures on the parent; its two existing keep-machine cases pass.
- All 58 focused actor-fence, shared-sandbox, reprovision, broker and forced-home tests passed. Coverage includes bounded/unbounded admission, adapter/provider ordering, caller attribution, retention, stale/missing bindings, enclosing transactions and provider failure.
- Full `mix precommit` passed: 5,422 core tests plus 6 doctests, 144 Buzz tests and 33 Support tests, all with zero failures.

No real provider or deployed environment was modified.
