### PR TITLE
fix(conversations): guard and attribute termination requests

### DIFF
--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -301,6 +301,9 @@ defmodule Fountain.Conversations.ConversationServer do
   sprite. If not, just mark the DB rows terminated so the user can still
   clean up dead conversations after a server restart.
 
+  An enclosing database transaction is refused before contacting the actor or
+  updating rows, so teardown cannot escape a caller's rollback.
+
   Named `terminate_conversation` rather than `terminate`: taking `opts` for
   audit attribution (#545) would have made this `terminate/2`, which is the
   OTP callback below. Two different meanings under one name in one module was
@@ -309,12 +312,16 @@ defmodule Fountain.Conversations.ConversationServer do
   the client half gets the unambiguous name.
   """
   def terminate_conversation(conv_id, opts \\ []) do
-    # ownership: callers established this conversation's tenant. Cleanup must
-    # survive a blocked actor, failed provider teardown, or subsequent deletion.
-    case Fountain.Conversations.ExecutionGuard._unsafe_interrupt(conv_id) do
-      {:ok, _} -> terminate_after_retirement(conv_id, opts)
-      {:error, :not_found} -> {:error, :not_running}
-      {:error, _} = error -> error
+    if Fountain.Repo.in_transaction?() do
+      {:error, :provider_transaction_open}
+    else
+      # ownership: callers established this conversation's tenant. Cleanup must
+      # survive a blocked actor, failed provider teardown, or subsequent deletion.
+      case Fountain.Conversations.ExecutionGuard._unsafe_interrupt(conv_id) do
+        {:ok, _} -> terminate_after_retirement(conv_id, opts)
+        {:error, :not_found} -> {:error, :not_running}
+        {:error, _} = error -> error
+      end
     end
   end
 
@@ -336,6 +343,7 @@ defmodule Fountain.Conversations.ConversationServer do
               # must not take either down.
               sandbox_id = conv.sandbox_id
 
+              # ownership: sandbox_id comes from that same authorized conversation.
               if is_binary(sandbox_id) and
                    not Conversations._unsafe_sandbox_kept_on_terminate?(sandbox_id, conv.id) do
                 sb = Conversations._unsafe_get_sandbox!(sandbox_id)
@@ -349,7 +357,16 @@ defmodule Fountain.Conversations.ConversationServer do
           end
 
         pid ->
-          call_server(pid, :terminate_conv)
+          # This pid is routinely on another pod, and mid-deploy some pods
+          # predate the tuple clause: they answer the catch-all with
+          # `:unknown_call`, which would leave the sprite running and billing.
+          # Retry the bare atom they understand. Only that catch-all produces
+          # `:unknown_call` here and it has no side effects, so no double
+          # terminate; #1980 keeps the mirror clause for old-pod callers.
+          case call_server(pid, {:terminate_conv, Keyword.take(opts, [:actor, :request_ip])}) do
+            {:error, :unknown_call} -> call_server(pid, :terminate_conv)
+            other -> other
+          end
       end
 
     audit_lifecycle(conv_id, "conversation.terminated", result, opts)

--- a/apps/fountain/test/fountain/conversations/termination_client_test.exs
+++ b/apps/fountain/test/fountain/conversations/termination_client_test.exs
@@ -1,0 +1,133 @@
+defmodule Fountain.Conversations.TerminationClientTest do
+  use Fountain.DataCase, async: true
+
+  alias Fountain.Audit
+  alias Fountain.Conversations.ConversationServer
+
+  defmodule Probe do
+    use GenServer
+
+    def start_link(args), do: GenServer.start_link(__MODULE__, args)
+
+    def init({owner, reply, conv_id}) do
+      {:ok, _} = Horde.Registry.register(Fountain.ConversationRegistry, conv_id, nil)
+      {:ok, {owner, reply}}
+    end
+
+    def handle_call(message, _from, {owner, reply} = state) do
+      send(owner, {:termination_request, self(), message})
+
+      # A function reply lets a test answer by message shape, which is how a
+      # pod predating the tuple clause behaves.
+      case reply do
+        fun when is_function(fun, 1) -> {:reply, fun.(message), state}
+        term -> {:reply, term, state}
+      end
+    end
+  end
+
+  setup do
+    user = insert_verified_user()
+    sandbox = insert_sandbox(user_id: user.id, status: "ready")
+    conv = insert_conversation(user_id: user.id, sandbox: sandbox, status: "idle")
+    %{user: user, sandbox: sandbox, conv: conv}
+  end
+
+  test "forwards attribution to the actor and keeps the outer lifecycle audit", ctx do
+    pid = probe(ctx.conv.id, :ok)
+    opts = [actor: "ui", request_ip: "192.0.2.4"]
+    assert :ok = ConversationServer.terminate_conversation(ctx.conv.id, opts)
+    assert_received {:termination_request, ^pid, {:terminate_conv, ^opts}}
+    assert [event] = events(ctx)
+    assert event.actor == "ui"
+    assert event.request_ip == "192.0.2.4"
+  end
+
+  test "an actor refusal is returned without a completed-termination audit", ctx do
+    probe(ctx.conv.id, {:error, :sandbox_unavailable})
+
+    assert {:error, :sandbox_unavailable} =
+             ConversationServer.terminate_conversation(ctx.conv.id, actor: "ui")
+
+    assert events(ctx) == []
+  end
+
+  for live? <- [true, false] do
+    test "an enclosing transaction refuses termination with live_actor=#{live?}", ctx do
+      if unquote(live?), do: probe(ctx.conv.id, :ok)
+
+      assert {:ok, {:error, :provider_transaction_open}} =
+               Repo.transaction(fn ->
+                 ConversationServer.terminate_conversation(ctx.conv.id, actor: "ui")
+               end)
+
+      refute_received {:termination_request, _, _}
+      assert Repo.reload!(ctx.conv).status == "idle"
+      assert Repo.reload!(ctx.sandbox).status == "ready"
+      assert events(ctx) == []
+    end
+  end
+
+  describe "rolling deploy" do
+    # A pod that predates #1980 has no `{:terminate_conv, opts}` clause, so the
+    # tuple reaches the `handle_call/3` catch-all and comes back
+    # `{:error, :unknown_call}`. Without the retry the sprite keeps running.
+    test "retries the bare atom when the actor pod does not know the tuple", ctx do
+      pid =
+        probe(ctx.conv.id, fn
+          {:terminate_conv, _opts} -> {:error, :unknown_call}
+          :terminate_conv -> :ok
+        end)
+
+      assert :ok = ConversationServer.terminate_conversation(ctx.conv.id, actor: "ui")
+
+      assert_received {:termination_request, ^pid, {:terminate_conv, _}}
+      assert_received {:termination_request, ^pid, :terminate_conv}
+
+      # The outer audit gates on `result == :ok`, so it only survives the
+      # fallback if the retry actually succeeded.
+      assert [event] = events(ctx)
+      assert event.actor == "ui"
+    end
+
+    test "does not retry when the actor pod understands the tuple", ctx do
+      probe(ctx.conv.id, :ok)
+      assert :ok = ConversationServer.terminate_conversation(ctx.conv.id, actor: "ui")
+      assert_received {:termination_request, _, {:terminate_conv, _}}
+      refute_received {:termination_request, _, :terminate_conv}
+    end
+
+    test "does not retry on an ordinary refusal", ctx do
+      probe(ctx.conv.id, {:error, :sandbox_unavailable})
+
+      assert {:error, :sandbox_unavailable} =
+               ConversationServer.terminate_conversation(ctx.conv.id, actor: "ui")
+
+      assert_received {:termination_request, _, {:terminate_conv, _}}
+      refute_received {:termination_request, _, :terminate_conv}
+      assert events(ctx) == []
+    end
+
+    test "forwards only attribution keys to the actor", ctx do
+      pid = probe(ctx.conv.id, :ok)
+
+      assert :ok =
+               ConversationServer.terminate_conversation(ctx.conv.id,
+                 actor: "ui",
+                 request_ip: "192.0.2.9",
+                 audit: false
+               )
+
+      assert_received {:termination_request, ^pid, {:terminate_conv, forwarded}}
+      assert Enum.sort(Keyword.keys(forwarded)) == [:actor, :request_ip]
+    end
+  end
+
+  defp probe(conv_id, reply) do
+    pid = start_supervised!({Probe, {self(), reply, conv_id}})
+    assert ConversationServer.whereis(conv_id) == pid
+    pid
+  end
+
+  defp events(ctx), do: Audit.list_for_user(ctx.user.id, action_prefix: "conversation.terminated")
+end


### PR DESCRIPTION
The termination client now refuses an enclosing database transaction before contacting an actor or updating the no-server fallback rows. It also forwards caller options to the actor, so the committed teardown fence receives the same actor and request IP as the existing conversation-termination audit. Actor refusals remain errors and produce no completed-termination audit.

Rollout prerequisite: deploy #1980 across the actor nodes before rolling out this caller change. This PR sends the attributed tuple that #1980 introduces; older handlers do not accept it. The existing public function signature is unchanged.

Stack: based on #1980. Refs #1767.

Validation:
- The corrected parent test uses a real local registry and a supervised stand-in actor: three of four cases fail, demonstrating dropped attribution and transaction leakage with or without an actor.
- All 149 focused client, actor, shared-sandbox, controller, audit and call-timeout tests passed.
- `mix precommit` passed: 5,426 core tests + 6 doctests, 144 Buzz tests and 33 Support tests, all zero failures.

No real provider or deployed environment was modified.
