### PR TITLE
fix(conversations): fence termination without a running actor

### DIFF
--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -334,26 +334,10 @@ defmodule Fountain.Conversations.ConversationServer do
               {:error, :not_running}
 
             conv ->
-              now = DateTime.utc_now() |> DateTime.truncate(:second)
-              {:ok, _} = Conversations.update_conversation(conv, %{status: "terminated"})
-
-              # A sandbox handed on to a successor conversation
-              # (`release_conversation/2`) is that conversation's computer now,
-              # and a home is the agent's (ADR 0023); terminating this thread
-              # must not take either down.
-              sandbox_id = conv.sandbox_id
-
-              # ownership: sandbox_id comes from that same authorized conversation.
-              if is_binary(sandbox_id) and
-                   not Conversations._unsafe_sandbox_kept_on_terminate?(sandbox_id, conv.id) do
-                sb = Conversations._unsafe_get_sandbox!(sandbox_id)
-
-                if sb.status not in ["terminated", "failed"] do
-                  Conversations.update_sandbox(sb, %{status: "terminated", terminated_at: now})
-                end
+              with {:ok, terminated} <-
+                     Conversations.update_conversation(conv, %{status: "terminated"}) do
+                Lifecycle.retire_terminated_sandbox(terminated, opts)
               end
-
-              :ok
           end
 
         pid ->

--- a/apps/fountain/lib/fountain/conversations/lifecycle.ex
+++ b/apps/fountain/lib/fountain/conversations/lifecycle.ex
@@ -334,6 +334,52 @@ defmodule Fountain.Conversations.Lifecycle do
   end
 
   @doc """
+  Retire the machine of an authorized, terminated conversation with no actor.
+  The conditional fence preserves homes and other live co-tenants, and blocks
+  new attachments before the terminal write. No provider I/O runs here; the
+  reaper handles terminal rows. The caller owns the conversation lifecycle
+  audit; the fence records teardown intent using the supplied attribution.
+  """
+  def retire_terminated_sandbox(%{sandbox_id: nil}, _opts), do: :ok
+
+  def retire_terminated_sandbox(conv, opts) do
+    opts =
+      opts
+      |> Keyword.put(:terminating_conversation_id, conv.id)
+      |> Keyword.put_new(:reason, "conversation_terminated")
+
+    # ownership: this sandbox belongs to the conversation authorized by the caller.
+    case Conversations._unsafe_get_sandbox(conv.sandbox_id) do
+      nil ->
+        {:error, :sandbox_unavailable}
+
+      sandbox ->
+        # ownership: the authorized conversation supplies this sandbox; the fence rechecks binding.
+        case Conversations._unsafe_fence_sandbox_for_teardown(sandbox, opts) do
+          {:ok, %{status: status}} when status in ["terminated", "failed"] ->
+            :ok
+
+          {:ok, fenced} ->
+            now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+            with {:ok, _} <-
+                   Conversations.update_sandbox(fenced, %{
+                     status: "terminated",
+                     terminated_at: now
+                   }) do
+              :ok
+            end
+
+          {:error, :sandbox_kept} ->
+            :ok
+
+          {:error, _} = error ->
+            error
+        end
+    end
+  end
+
+  @doc """
   What the max-lifetime ceiling does to this machine, the suspend call
   included.
 

--- a/apps/fountain/test/fountain/conversations/termination_fallback_test.exs
+++ b/apps/fountain/test/fountain/conversations/termination_fallback_test.exs
@@ -1,0 +1,98 @@
+defmodule Fountain.Conversations.TerminationFallbackTest do
+  use Fountain.DataCase, async: true
+  use Mimic
+
+  alias Fountain.{Audit, Conversations}
+  alias Fountain.Conversations.ConversationServer
+
+  setup do
+    user = insert_verified_user()
+    agent = insert_agent(user_id: user.id)
+    sandbox = insert_sandbox(user_id: user.id, agent_id: agent.id, status: "ready")
+    conv = insert_conversation(user_id: user.id, agent: agent, sandbox: sandbox, status: "idle")
+    assert ConversationServer.whereis(conv.id) == nil
+    %{user: user, agent: agent, sandbox: sandbox, conv: conv}
+  end
+
+  test "fences attachments before retiring the row and attributes the intent", ctx do
+    expect(Conversations, :update_sandbox, fn sandbox, attrs ->
+      refute Repo.in_transaction?()
+      assert Repo.reload!(sandbox).reset_requested_at
+      assert {:error, :sandbox_reset_pending} = attach(ctx)
+      Mimic.call_original(Conversations, :update_sandbox, [sandbox, attrs])
+    end)
+
+    assert :ok = terminate(ctx)
+    assert Repo.reload!(ctx.sandbox).status == "terminated"
+    assert Repo.reload!(ctx.conv).status == "terminated"
+    assert [intent] = events(ctx, "sandbox.teardown_requested")
+    assert intent.actor == "ui"
+    assert intent.request_ip == "192.0.2.5"
+    assert intent.metadata["reason"] == "conversation_terminated"
+    assert [_] = events(ctx, "conversation.terminated")
+  end
+
+  test "an attachment that wins before the fence keeps the sandbox", ctx do
+    expect(Conversations, :_unsafe_fence_sandbox_for_teardown, fn sandbox, opts ->
+      assert {:ok, successor} = attach(ctx)
+      assert successor.sandbox_id == sandbox.id
+      Mimic.call_original(Conversations, :_unsafe_fence_sandbox_for_teardown, [sandbox, opts])
+    end)
+
+    assert :ok = terminate(ctx)
+    assert Repo.reload!(ctx.conv).status == "terminated"
+    assert Repo.reload!(ctx.sandbox).status == "ready"
+    refute Repo.reload!(ctx.sandbox).reset_requested_at
+    assert events(ctx, "sandbox.teardown_requested") == []
+  end
+
+  test "a fence refusal leaves the machine available and records no completed termination", ctx do
+    expect(Conversations, :_unsafe_fence_sandbox_for_teardown, fn _, _ ->
+      {:error, :sandbox_unavailable}
+    end)
+
+    assert {:error, :sandbox_unavailable} = terminate(ctx)
+    assert Repo.reload!(ctx.conv).status == "terminated"
+    assert Repo.reload!(ctx.sandbox).status == "ready"
+    assert events(ctx, "conversation.terminated") == []
+  end
+
+  test "a retirement write error is returned with the admission fence intact", ctx do
+    expect(Conversations, :update_sandbox, fn _, _ -> {:error, :write_refused} end)
+    assert {:error, :write_refused} = terminate(ctx)
+    assert Repo.reload!(ctx.sandbox).status == "ready"
+    assert Repo.reload!(ctx.sandbox).reset_requested_at
+    assert [_] = events(ctx, "sandbox.teardown_requested")
+    assert events(ctx, "conversation.terminated") == []
+  end
+
+  test "a persistent machine remains available without a teardown intent", ctx do
+    Repo.update!(Ecto.Changeset.change(ctx.sandbox, mode: "persistent"))
+    assert :ok = terminate(ctx)
+    assert Repo.reload!(ctx.sandbox).status == "ready"
+    refute Repo.reload!(ctx.sandbox).reset_requested_at
+    assert events(ctx, "sandbox.teardown_requested") == []
+  end
+
+  test "an already failed sandbox keeps its terminal state", ctx do
+    Repo.update!(Ecto.Changeset.change(ctx.sandbox, status: "failed"))
+    assert :ok = terminate(ctx)
+    assert Repo.reload!(ctx.conv).status == "terminated"
+    assert Repo.reload!(ctx.sandbox).status == "failed"
+    assert events(ctx, "sandbox.teardown_requested") == []
+  end
+
+  defp terminate(ctx),
+    do:
+      ConversationServer.terminate_conversation(ctx.conv.id, actor: "ui", request_ip: "192.0.2.5")
+
+  defp attach(ctx) do
+    Conversations.start_conversation(%{
+      "user_id" => ctx.user.id,
+      "agent_id" => ctx.agent.id,
+      "sandbox_id" => ctx.sandbox.id
+    })
+  end
+
+  defp events(ctx, action), do: Audit.list_for_user(ctx.user.id, action_prefix: action)
+end


### PR DESCRIPTION
When termination finds no running actor, the fallback now commits the shared conditional teardown fence before retiring the sandbox row. A home or an attachment that wins the fence decision keeps its machine; attachments after the fence are refused. The teardown intent carries caller attribution. Fence and retirement-write errors now propagate instead of producing a completed-termination audit.

The conversation row still becomes terminal first. If the later sandbox operation fails, that thread stays ended, and the error tells the caller machine retirement did not complete. This preserves the existing ordering; it does not claim an atomic multi-row termination. No provider I/O runs in the fallback: terminal rows remain the reaper's cleanup responsibility.

The helper lives in the existing lifecycle module so ConversationServer stays under its fixed size guard.

Stack: based on #1981. Refs #1767. The conditional fence's real two-connection attachment ordering is separately covered by #1979.

Validation:
- Four new regression cases fail on the parent code (missing fence, conditional retention, and error propagation).
- 100 focused fallback, client, actor, audit, server and attachment tests passed before the lifecycle extraction.
- 103 lifecycle, fallback, size and audit-guard tests passed after extraction.
- Full `mix precommit` passed: 5,432 core tests + 6 doctests, 144 Buzz tests and 33 Support tests, all zero failures.

No deployed environment or real provider was modified.
