### PR TITLE
ci: run the Elixir SDK checks in a separate job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -815,8 +815,8 @@ jobs:
             exit 1
           fi
 
-  sdk-clients:
-    name: SDK clients, CLI and plugins
+  elixir-sdk:
+    name: Elixir SDK
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     needs: [already-tested, changes]
@@ -826,18 +826,15 @@ jobs:
     permissions:
       contents: read
 
-    # No umbrella deps/_build cache and no Postgres. Everything here either is
-    # a standalone project (sdk/elixir has its own cache below, cli/ and
-    # apps/fountain_buzz/cli are Go modules) or reads the COMMITTED
-    # sdk/contract/contract.json rather than rebuilding it -- which is the
-    # whole reason that projection is committed. The one job that does rebuild
-    # it is `release-and-contract`, and it fails there if it is stale.
+    # Independent from the umbrella, Postgres and the other SDK toolchains.
     env:
       MIX_ENV: test
 
     steps:
-
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
+
+      - name: SDK conformance scenarios are well formed
+        run: python3 sdk/conformance/lint.py
 
       - name: Set up Elixir
         id: beam
@@ -847,10 +844,7 @@ jobs:
           otp-version: "28.3"
 
       # The Elixir SDK is a standalone Mix project. Keep its dependency graph
-      # and build artifacts separate from this umbrella's -- which also puts
-      # them outside the two caches above, so they need their own entry or
-      # every PR recompiles finch, mint, hpax, ex_doc and makeup from scratch
-      # on the critical path.
+      # and build artifacts separate from the umbrella's cache.
       - name: Restore Elixir SDK cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
         with:
@@ -885,30 +879,6 @@ jobs:
         working-directory: sdk/elixir
         run: MIX_ENV=dev mix hex.build
 
-      # The behavioural half (#1412). sdk/contract pins the shape of the wire;
-      # these scenarios pin what a client does with it — SSE framing, cursor
-      # resume, error mapping, terminal run states. They are one set of JSON
-      # files run by four adapters.
-      #
-      # The lint is not only a format check: it validates every fixture body
-      # against the schema sdk/contract/contract.json declares for that
-      # operation, which is what stops a scenario going green against a
-      # response the real server would never send.
-      #
-      # It runs FIRST, before any adapter. In the job this was split out of it
-      # sat directly above the three conformance runs, which is the same thing
-      # when the order is Elixir, Python, TypeScript throughout. Here the steps
-      # are grouped by language instead, so a malformed fixture would otherwise
-      # fail two adapters with a confusing message before the step that names
-      # the real problem ever ran.
-      - name: SDK conformance scenarios are well formed
-        run: python3 sdk/conformance/lint.py
-
-      # Four separate contract checks rather than a loop, so a failing log line
-      # names the client a contributor has to go and fix. Each reads the
-      # committed contract and its own manifest; none rebuilds the spec, which
-      # `release-and-contract` does. The Swift equivalent runs inside
-      # `swift test` in the swift-sdk job.
       - name: Elixir SDK contract
         working-directory: sdk/elixir
         run: mix test test/contract_test.exs
@@ -916,6 +886,28 @@ jobs:
       - name: Elixir SDK conformance
         working-directory: sdk/elixir
         run: mix test test/conformance_test.exs
+
+  sdk-clients:
+    name: Python/TypeScript SDKs, CLI and plugins
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    needs: [already-tested, changes]
+    if: ${{ !cancelled() && needs.already-tested.outputs.skip != 'true'
+         && needs.changes.outputs.docs_only != 'true' }}
+
+    permissions:
+      contents: read
+
+    # Standalone clients and Go modules read the committed wire contract.
+    # release-and-contract rebuilds it and checks for staleness.
+    steps:
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
+
+      # Validate fixture bodies against the committed contract before either
+      # SDK adapter runs. The Elixir and Swift jobs validate them independently.
+      - name: SDK conformance scenarios are well formed
+        run: python3 sdk/conformance/lint.py
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -1803,6 +1795,7 @@ jobs:
       - elixir-static
       - release-and-contract
       - sdk-clients
+      - elixir-sdk
       - swift-sdk
       - core-distribution
       - compose-fresh-clone

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -70,12 +70,25 @@ tested it.
 
 ### Sizing
 
-`MERGE_QUEUE` in `require-checks.py` carries the reasoning for each value. The
-binding constraint is the free plan's 20 concurrent GitHub-hosted jobs against
-a full CI run's 19, which is why the queue builds one group at a time and buys
-its throughput by batching up to five PRs into that one group instead.
-Revisit `max_entries_to_build` when the concurrency ceiling changes, not
-before.
+`MERGE_QUEUE` in `require-checks.py` explains the queue settings. A full CI
+run now has 20 jobs, matching the documented concurrent runner limit. The
+queue builds one group at a time and batches up to five PRs. Revisit
+`max_entries_to_build` when the concurrency limit changes.
+
+## SDK jobs
+
+The Elixir SDK runs in `elixir-sdk`, alongside the Python/TypeScript, CLI and
+plugin job (`sdk-clients`). The Swift job (`swift-sdk`) runs on Linux and
+macOS. Each reads the committed contract; `release-and-contract` checks its
+generation.
+The Elixir job owns its toolchain, cache, formatting, compilation, tests, docs,
+package dry run, contract and conformance checks. Its fixture lint runs before
+the tests. `CI required` requires it on every full plan, including main and
+merge groups. A failed, cancelled or unexpectedly skipped job fails the gate.
+
+Per-language path routing remains tracked in #1413. Register a new job in
+`gate.py`'s `FULL_JOBS` and the workflow gate's `needs` list together. Run
+`test_gate.py` to verify their agreement and every supported event plan.
 
 ## Refresh partition timings
 

--- a/scripts/ci/gate.py
+++ b/scripts/ci/gate.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 FULL_JOBS = {
     "test", "coverage", "elixir-static", "release-and-contract", "sdk-clients",
-    "swift-sdk", "core-distribution", "compose-fresh-clone", "compose-pinned-image-boot",
+    "elixir-sdk", "swift-sdk", "core-distribution", "compose-fresh-clone", "compose-pinned-image-boot",
 }
 JOBS = FULL_JOBS | {"already-tested", "changes", "workflow-checks", "docs", "docs-prose"}
 

--- a/scripts/ci/require-checks.py
+++ b/scripts/ci/require-checks.py
@@ -19,14 +19,14 @@ def api(path, payload=None, method="PUT"):
 # Sized against this repo's measured CI, not GitHub's defaults.
 #
 # max_entries_to_build: 1 — the org is on the free plan, which allows 20
-# concurrent GitHub-hosted jobs, and ONE full CI run is 19 of them. Speculating
+# concurrent GitHub-hosted jobs, and ONE full CI run is 20 of them. Speculating
 # two groups deep cannot run two groups; it queues the second behind the first
 # while also starving every open PR. Raise this only after the concurrency
 # ceiling does.
 #
 # min_entries_to_merge: 2 with a 5 minute wait — batching is the only lever
 # that buys throughput under that same ceiling, because five PRs merged as one
-# group cost one 19-job run instead of five. In a burst the group fills at once
+# group cost one 20-job run instead of five. In a burst the group fills at once
 # and nothing waits; in a quiet hour a lone PR waits up to five minutes, which
 # is the hour where nobody is blocked on it.
 #

--- a/scripts/ci/test_require_checks.py
+++ b/scripts/ci/test_require_checks.py
@@ -75,7 +75,7 @@ class RequiredChecksTest(unittest.TestCase):
         self.assertEqual(contexts, ["CI required", "Detect secrets"])
 
     def test_the_queue_cannot_outrun_the_free_plan_job_ceiling(self):
-        """One full CI run is 19 of the 20 concurrent jobs a free org gets.
+        """One full CI run is 20 of the 20 concurrent jobs a free org gets.
 
         Building more than one group at a time cannot run them in parallel; it
         only starves every open PR of runners.


### PR DESCRIPTION
The Elixir SDK's ten setup/check steps now run in their own `elixir-sdk` job, parallel with the remaining Python/TypeScript, CLI and plugin checks. The toolchain versions, cache key and commands are unchanged. Fixture lint runs before the Elixir tests. The existing `CI required` aggregate requires the new job on every full plan and rejects failures, cancellations and unexpected skips.

This is the first job-extraction unit for #1413. Per-language path routing, the remaining SDK split, minimum-runtime expansion, dispatch support and the dedicated SDK aggregate remain follow-ups. All SDK checks still run. Base: main.

Validation:
- All 23 CI policy tests passed, including supported PR, merge-group and main plans and failures/skips of every required job.
- A structured YAML comparison confirms all ten Elixir setup/check steps are preserved exactly and removed from the shared job.
- Workflow validation passes with shellcheck disabled. The five shellcheck findings from the complete linter are identical on main and this change; none is in the moved steps.
- Full `mix precommit` passed: 5,375 core tests + 6 doctests, 144 Buzz tests and 33 Support tests, all zero failures.
- [GitHub CI required](https://github.com/managoat/fountain/actions/runs/34639880793) passed, including the extracted Elixir job.

Timing and runner jobs:
- A full mixed PR plan grows from 19 to 20 jobs; the new job can run in parallel, but this unit does not claim lower total runner usage.
- Baseline [run 34637353550](https://github.com/managoat/fountain/actions/runs/34637353550/job/103388442744): the combined SDK/CLI job took 78 seconds. That application-only PR executed 18 jobs; this CI-file change also selects the docs-prose job.
- After extraction, [Elixir SDK](https://github.com/managoat/fountain/actions/runs/34639880793/job/103396732250) passed in 22 seconds and the [remaining SDK/CLI job](https://github.com/managoat/fountain/actions/runs/34639880793/job/103396732309) passed in 68 seconds. These are single-run observations with different runners/cache conditions, not a guaranteed speedup. The two job durations sum to 90 seconds versus 78 seconds before; the split prepares selective routing rather than reducing total runner time by itself.

- Overall observed workflow time, from run start to the last job completion: 266 seconds before, 252 seconds after. Executed jobs were 18 before and 20 after: the new SDK job plus the docs-prose job selected by this CI-file change.

Queue settings are unchanged; their comments now describe the 20-job full plan.
