### PR TITLE
ci: run the Python SDK checks in a separate job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -887,8 +887,41 @@ jobs:
         working-directory: sdk/elixir
         run: mix test test/conformance_test.exs
 
+  python-sdk:
+    name: Python SDK
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    needs: [already-tested, changes]
+    if: ${{ !cancelled() && needs.already-tested.outputs.skip != 'true'
+         && needs.changes.outputs.docs_only != 'true' }}
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
+
+      - name: SDK conformance scenarios are well formed
+        run: python3 sdk/conformance/lint.py
+
+      # The Python SDK is deliberately stdlib-only, so its source tests run
+      # on the same interpreter without an install step.
+      - name: Python SDK tests
+        run: python3 -m unittest discover -s sdk/python/tests -v
+
+      - name: Python SDK compiles
+        run: python3 -m compileall -q sdk/python/src sdk/python/scripts
+
+      - name: Python SDK contract
+        working-directory: sdk/python
+        run: python3 scripts/verify_contract.py
+
+      - name: Python SDK conformance
+        working-directory: sdk/python
+        run: python3 -m unittest discover -s tests -p "test_conformance.py" -v
+
   sdk-clients:
-    name: Python/TypeScript SDKs, CLI and plugins
+    name: TypeScript SDK, CLI and plugins
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     needs: [already-tested, changes]
@@ -904,8 +937,8 @@ jobs:
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
 
-      # Validate fixture bodies against the committed contract before either
-      # SDK adapter runs. The Elixir and Swift jobs validate them independently.
+      # Validate fixtures before the TypeScript adapter runs. The other SDK
+      # jobs validate them independently.
       - name: SDK conformance scenarios are well formed
         run: python3 sdk/conformance/lint.py
 
@@ -969,22 +1002,6 @@ jobs:
       # run against an in-process fake Fountain and need nothing installed.
       - name: Hermes plugin tests
         run: python3 -m unittest discover -s integrations/hermes/tests -v
-
-      # The Python SDK is deliberately stdlib-only, so its source tests run
-      # on the same interpreter without an install step.
-      - name: Python SDK tests
-        run: python3 -m unittest discover -s sdk/python/tests -v
-
-      - name: Python SDK compiles
-        run: python3 -m compileall -q sdk/python/src sdk/python/scripts
-
-      - name: Python SDK contract
-        working-directory: sdk/python
-        run: python3 scripts/verify_contract.py
-
-      - name: Python SDK conformance
-        working-directory: sdk/python
-        run: python3 -m unittest discover -s tests -p "test_conformance.py" -v
 
       # The TypeScript SDK (sdk/typescript). Node runs the .ts sources
       # directly, so `npm test` needs nothing but the dev dependency on tsc —
@@ -1796,6 +1813,7 @@ jobs:
       - release-and-contract
       - sdk-clients
       - elixir-sdk
+      - python-sdk
       - swift-sdk
       - core-distribution
       - compose-fresh-clone

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -71,19 +71,20 @@ tested it.
 ### Sizing
 
 `MERGE_QUEUE` in `require-checks.py` explains the queue settings. A full CI
-run now has 20 jobs, matching the documented concurrent runner limit. The
-queue builds one group at a time and batches up to five PRs. Revisit
+run now has 21 jobs, compared with the documented limit of 20 concurrent
+runners. The queue builds one group at a time and batches up to five PRs. Revisit
 `max_entries_to_build` when the concurrency limit changes.
 
 ## SDK jobs
 
-The Elixir SDK runs in `elixir-sdk`, alongside the Python/TypeScript, CLI and
-plugin job (`sdk-clients`). The Swift job (`swift-sdk`) runs on Linux and
+The Elixir and Python SDKs run in `elixir-sdk` and `python-sdk`, alongside
+the TypeScript, CLI and plugin job (`sdk-clients`). The Swift job (`swift-sdk`) runs on Linux and
 macOS. Each reads the committed contract; `release-and-contract` checks its
 generation.
 The Elixir job owns its toolchain, cache, formatting, compilation, tests, docs,
-package dry run, contract and conformance checks. Its fixture lint runs before
-the tests. `CI required` requires it on every full plan, including main and
+package dry run, contract and conformance checks. The Python job owns its
+tests, compilation, contract and conformance checks. Both jobs validate
+fixtures before their tests. `CI required` requires both on every full plan, including main and
 merge groups. A failed, cancelled or unexpectedly skipped job fails the gate.
 
 Per-language path routing remains tracked in #1413. Register a new job in

--- a/scripts/ci/gate.py
+++ b/scripts/ci/gate.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 FULL_JOBS = {
     "test", "coverage", "elixir-static", "release-and-contract", "sdk-clients",
-    "elixir-sdk", "swift-sdk", "core-distribution", "compose-fresh-clone", "compose-pinned-image-boot",
+    "elixir-sdk", "python-sdk", "swift-sdk", "core-distribution", "compose-fresh-clone", "compose-pinned-image-boot",
 }
 JOBS = FULL_JOBS | {"already-tested", "changes", "workflow-checks", "docs", "docs-prose"}
 

--- a/scripts/ci/require-checks.py
+++ b/scripts/ci/require-checks.py
@@ -19,14 +19,14 @@ def api(path, payload=None, method="PUT"):
 # Sized against this repo's measured CI, not GitHub's defaults.
 #
 # max_entries_to_build: 1 — the org is on the free plan, which allows 20
-# concurrent GitHub-hosted jobs, and ONE full CI run is 20 of them. Speculating
+# concurrent GitHub-hosted jobs, and ONE full CI run has 21 jobs. Speculating
 # two groups deep cannot run two groups; it queues the second behind the first
 # while also starving every open PR. Raise this only after the concurrency
 # ceiling does.
 #
 # min_entries_to_merge: 2 with a 5 minute wait — batching is the only lever
 # that buys throughput under that same ceiling, because five PRs merged as one
-# group cost one 20-job run instead of five. In a burst the group fills at once
+# group cost one 21-job run instead of five. In a burst the group fills at once
 # and nothing waits; in a quiet hour a lone PR waits up to five minutes, which
 # is the hour where nobody is blocked on it.
 #

--- a/scripts/ci/test_require_checks.py
+++ b/scripts/ci/test_require_checks.py
@@ -75,7 +75,7 @@ class RequiredChecksTest(unittest.TestCase):
         self.assertEqual(contexts, ["CI required", "Detect secrets"])
 
     def test_the_queue_cannot_outrun_the_free_plan_job_ceiling(self):
-        """One full CI run is 20 of the 20 concurrent jobs a free org gets.
+        """One full CI run has 21 jobs; the documented concurrency limit is 20.
 
         Building more than one group at a time cannot run them in parallel; it
         only starves every open PR of runners.


### PR DESCRIPTION
The Python SDK's four checks now run in a separate `python-sdk` job, parallel with the TypeScript, CLI and plugin job. It keeps the same runner and commands, uses the runner's Python as before, and validates conformance fixtures before the tests. `CI required` requires the new job on every full plan and rejects failures, cancellations and unexpected skips.

Stack: based on #1984. Refs #1413. This is the Python job-extraction unit; path routing, minimum-runtime expansion and the dedicated SDK aggregate remain follow-ups. All SDK checks still run.

Validation:
- All 23 CI policy tests pass. A structured YAML comparison confirms all four Python check steps are preserved exactly and removed from the shared job.
- All 43 Python SDK tests pass, including conformance. Fixture validation covers 24 scenarios; the wire-contract check covers 67 operations, 41 schemas and 4 enums. Compilation passes.
- Workflow validation passes with shellcheck disabled; changed documentation has no new repository-style findings and passes destink.
- Full `mix precommit` passed: 5,375 core tests + 6 doctests, 144 Buzz tests and 33 Support tests, all zero failures.

Timing and runner jobs:
- A full mixed PR plan grows from 20 to 21 jobs. This split prepares independent routing; it does not claim lower total runner usage.
- Parent [run 34639880793](https://github.com/managoat/fountain/actions/runs/34639880793) completed in 252 seconds with 20 executed jobs; its remaining SDK/CLI job took 68 seconds. After extraction, [Python SDK](https://github.com/managoat/fountain/actions/runs/34640688693/job/103399363194) passed in 22 seconds and the [remaining TypeScript/CLI job](https://github.com/managoat/fountain/actions/runs/34640688693/job/103399363415) passed in 43 seconds. The successful workflow took 267 seconds with 21 executed jobs. These are single-run observations with different runner/cache conditions.

Queue settings are unchanged; their comments now describe the 21-job full plan.
