### PR TITLE
ci: run the TypeScript SDK checks in a separate job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -792,7 +792,7 @@ jobs:
           cache: npm
           cache-dependency-path: sdk/typescript/package-lock.json
 
-      # `--no-audit --no-fund`: see the sdk-clients job, which carries the
+      # `--no-audit --no-fund`: see the typescript-sdk job, which carries the
       # measurement. Here it is only to make `npm run generate` runnable.
       - name: SDK install
         working-directory: sdk/typescript
@@ -920,8 +920,8 @@ jobs:
         working-directory: sdk/python
         run: python3 -m unittest discover -s tests -p "test_conformance.py" -v
 
-  sdk-clients:
-    name: TypeScript SDK, CLI and plugins
+  typescript-sdk:
+    name: TypeScript SDK
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     needs: [already-tested, changes]
@@ -931,16 +931,85 @@ jobs:
     permissions:
       contents: read
 
-    # Standalone clients and Go modules read the committed wire contract.
-    # release-and-contract rebuilds it and checks for staleness.
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
+
+      - name: SDK conformance scenarios are well formed
+        run: python3 sdk/conformance/lint.py
+
+      # The TypeScript SDK (sdk/typescript). Node runs the .ts sources
+      # directly, so `npm test` needs nothing but the dev dependency on tsc —
+      # which is also what enforces `erasableSyntaxOnly`, the setting that
+      # keeps those sources runnable without a build step.
+      - name: Set up Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: sdk/typescript/package-lock.json
+
+      # `--no-audit` is the whole reason this step is not the longest in CI.
+      # `npm ci` runs a vulnerability audit by default, which is one POST to
+      # registry.npmjs.org/-/npm/v1/security/advisories/bulk — and that request
+      # stalls from Actions runners rather than failing fast. Measured on this
+      # lockfile: 35 packages, every tarball fetched in 325ms from a warm
+      # cache, and then `reify:audit Completed in 300202ms`. The step was
+      # taking 88s to 302s depending on how far into npm's 5-minute timeout the
+      # request got, on every PR, and it made this job 426s against 171s for
+      # the slowest test partition. With the flag it is under 5s.
+      #
+      # Nothing is lost, because nothing was gated: `npm ci` does not fail on
+      # advisories, so this could only ever print "found 0 vulnerabilities"
+      # into a log. What DOES watch these packages is dependabot, which was
+      # given its two npm ecosystems in the same change that added this flag --
+      # before that the audit line was the only npm advisory signal in the
+      # repository, and it was one nobody could act on. `--no-fund` suppresses
+      # the funding notice for the same reason: it is output, not a check.
+      - name: SDK install
+        working-directory: sdk/typescript
+        run: npm ci --no-audit --no-fund
+
+      - name: SDK typecheck
+        working-directory: sdk/typescript
+        run: npm run typecheck
+
+      - name: SDK tests
+        working-directory: sdk/typescript
+        run: npm test
+
+      - name: SDK build
+        working-directory: sdk/typescript
+        run: npm run build
+
+      # Eleven browser applications are built on this API, so the SDK's default
+      # entry has to bundle for a browser — no Node built-ins reachable from it.
+      - name: SDK bundles for the browser
+        working-directory: sdk/typescript
+        run: npx --yes esbuild dist/index.js --bundle --platform=browser --format=esm --outfile=/dev/null
+
+      - name: TypeScript SDK contract
+        working-directory: sdk/typescript
+        run: npm run verify-contract
+
+      - name: TypeScript SDK conformance
+        working-directory: sdk/typescript
+        run: npm run conformance
+
+  cli-plugins:
+    name: CLI and plugins
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    needs: [already-tested, changes]
+    if: ${{ !cancelled() && needs.already-tested.outputs.skip != 'true'
+         && needs.changes.outputs.docs_only != 'true' }}
+
+    permissions:
+      contents: read
+
+    # Go CLIs and plugins have no dependency on an SDK build.
     steps:
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
-
-      # Validate fixtures before the TypeScript adapter runs. The other SDK
-      # jobs validate them independently.
-      - name: SDK conformance scenarios are well formed
-        run: python3 sdk/conformance/lint.py
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -1003,66 +1072,13 @@ jobs:
       - name: Hermes plugin tests
         run: python3 -m unittest discover -s integrations/hermes/tests -v
 
-      # The TypeScript SDK (sdk/typescript). Node runs the .ts sources
-      # directly, so `npm test` needs nothing but the dev dependency on tsc —
-      # which is also what enforces `erasableSyntaxOnly`, the setting that
-      # keeps those sources runnable without a build step.
       - name: Set up Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-          cache: npm
-          cache-dependency-path: sdk/typescript/package-lock.json
 
       - name: Deployed-instance runner tests
         run: node --test deployed/test/*.test.mjs
-
-      # `--no-audit` is the whole reason this step is not the longest in CI.
-      # `npm ci` runs a vulnerability audit by default, which is one POST to
-      # registry.npmjs.org/-/npm/v1/security/advisories/bulk — and that request
-      # stalls from Actions runners rather than failing fast. Measured on this
-      # lockfile: 35 packages, every tarball fetched in 325ms from a warm
-      # cache, and then `reify:audit Completed in 300202ms`. The step was
-      # taking 88s to 302s depending on how far into npm's 5-minute timeout the
-      # request got, on every PR, and it made this job 426s against 171s for
-      # the slowest test partition. With the flag it is under 5s.
-      #
-      # Nothing is lost, because nothing was gated: `npm ci` does not fail on
-      # advisories, so this could only ever print "found 0 vulnerabilities"
-      # into a log. What DOES watch these packages is dependabot, which was
-      # given its two npm ecosystems in the same change that added this flag --
-      # before that the audit line was the only npm advisory signal in the
-      # repository, and it was one nobody could act on. `--no-fund` suppresses
-      # the funding notice for the same reason: it is output, not a check.
-      - name: SDK install
-        working-directory: sdk/typescript
-        run: npm ci --no-audit --no-fund
-
-      - name: SDK typecheck
-        working-directory: sdk/typescript
-        run: npm run typecheck
-
-      - name: SDK tests
-        working-directory: sdk/typescript
-        run: npm test
-
-      - name: SDK build
-        working-directory: sdk/typescript
-        run: npm run build
-
-      # Eleven browser applications are built on this API, so the SDK's default
-      # entry has to bundle for a browser — no Node built-ins reachable from it.
-      - name: SDK bundles for the browser
-        working-directory: sdk/typescript
-        run: npx --yes esbuild dist/index.js --bundle --platform=browser --format=esm --outfile=/dev/null
-
-      - name: TypeScript SDK contract
-        working-directory: sdk/typescript
-        run: npm run verify-contract
-
-      - name: TypeScript SDK conformance
-        working-directory: sdk/typescript
-        run: npm run conformance
 
   docs-prose:
     name: Docs prose gates
@@ -1152,7 +1168,7 @@ jobs:
           cache: npm
           cache-dependency-path: scripts/destink/package-lock.json
 
-      # `--no-audit --no-fund`: see the sdk-clients job. The audit request
+      # `--no-audit --no-fund`: see the typescript-sdk job. The audit request
       # stalls for minutes from a runner and can only ever print.
       - name: Install the prose checker
         run: npm ci --prefix scripts/destink --no-audit --no-fund
@@ -1811,7 +1827,8 @@ jobs:
       - coverage
       - elixir-static
       - release-and-contract
-      - sdk-clients
+      - cli-plugins
+      - typescript-sdk
       - elixir-sdk
       - python-sdk
       - swift-sdk

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -71,20 +71,23 @@ tested it.
 ### Sizing
 
 `MERGE_QUEUE` in `require-checks.py` explains the queue settings. A full CI
-run now has 21 jobs, compared with the documented limit of 20 concurrent
+run now has 22 jobs, compared with the documented limit of 20 concurrent
 runners. The queue builds one group at a time and batches up to five PRs. Revisit
 `max_entries_to_build` when the concurrency limit changes.
 
 ## SDK jobs
 
-The Elixir and Python SDKs run in `elixir-sdk` and `python-sdk`, alongside
-the TypeScript, CLI and plugin job (`sdk-clients`). The Swift job (`swift-sdk`) runs on Linux and
+The Elixir, Python and TypeScript SDKs run in `elixir-sdk`, `python-sdk` and
+`typescript-sdk`. The Go CLI, Hermes plugin and deployed-runner checks run in
+`cli-plugins`. The Swift job (`swift-sdk`) runs on Linux and
 macOS. Each reads the committed contract; `release-and-contract` checks its
 generation.
 The Elixir job owns its toolchain, cache, formatting, compilation, tests, docs,
 package dry run, contract and conformance checks. The Python job owns its
-tests, compilation, contract and conformance checks. Both jobs validate
-fixtures before their tests. `CI required` requires both on every full plan, including main and
+tests, compilation, contract and conformance checks. The TypeScript job owns
+installation, type checks, tests, builds, browser bundling, contract and
+conformance checks. Each SDK job validates fixtures before its tests.
+`CI required` requires all SDK jobs on every full plan, including main and
 merge groups. A failed, cancelled or unexpectedly skipped job fails the gate.
 
 Per-language path routing remains tracked in #1413. Register a new job in

--- a/scripts/ci/gate.py
+++ b/scripts/ci/gate.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 
 FULL_JOBS = {
-    "test", "coverage", "elixir-static", "release-and-contract", "sdk-clients",
+    "test", "coverage", "elixir-static", "release-and-contract", "cli-plugins", "typescript-sdk",
     "elixir-sdk", "python-sdk", "swift-sdk", "core-distribution", "compose-fresh-clone", "compose-pinned-image-boot",
 }
 JOBS = FULL_JOBS | {"already-tested", "changes", "workflow-checks", "docs", "docs-prose"}

--- a/scripts/ci/require-checks.py
+++ b/scripts/ci/require-checks.py
@@ -19,14 +19,14 @@ def api(path, payload=None, method="PUT"):
 # Sized against this repo's measured CI, not GitHub's defaults.
 #
 # max_entries_to_build: 1 — the org is on the free plan, which allows 20
-# concurrent GitHub-hosted jobs, and ONE full CI run has 21 jobs. Speculating
+# concurrent GitHub-hosted jobs, and ONE full CI run has 22 jobs. Speculating
 # two groups deep cannot run two groups; it queues the second behind the first
 # while also starving every open PR. Raise this only after the concurrency
 # ceiling does.
 #
 # min_entries_to_merge: 2 with a 5 minute wait — batching is the only lever
 # that buys throughput under that same ceiling, because five PRs merged as one
-# group cost one 21-job run instead of five. In a burst the group fills at once
+# group cost one 22-job run instead of five. In a burst the group fills at once
 # and nothing waits; in a quiet hour a lone PR waits up to five minutes, which
 # is the hour where nobody is blocked on it.
 #

--- a/scripts/ci/test_require_checks.py
+++ b/scripts/ci/test_require_checks.py
@@ -75,7 +75,7 @@ class RequiredChecksTest(unittest.TestCase):
         self.assertEqual(contexts, ["CI required", "Detect secrets"])
 
     def test_the_queue_cannot_outrun_the_free_plan_job_ceiling(self):
-        """One full CI run has 21 jobs; the documented concurrency limit is 20.
+        """One full CI run has 22 jobs; the documented concurrency limit is 20.
 
         Building more than one group at a time cannot run them in parallel; it
         only starves every open PR of runners.


### PR DESCRIPTION
The TypeScript SDK's eight setup/check steps now run in `typescript-sdk`, parallel with the other SDKs. Its Node version, npm cache and commands are preserved. The remaining `cli-plugins` job keeps the Go CLIs, Hermes plugin and deployed-runner tests; it still installs Node for the deployed runner but no longer restores an SDK npm cache. The three extracted SDK jobs lint conformance fixtures independently; Swift retains its existing conformance tests.

`CI required` requires the new job and the renamed CLI job on every full plan, rejecting failures, cancellations and unexpected skips. Required branch checks are the stable aggregate and Detect secrets, so the old shared job name is not a branch-protection requirement.

Stack: based on #1985. Refs #1413. This completes the separation into one job per SDK; path routing, minimum-runtime expansion, dispatch support and the dedicated SDK aggregate remain follow-ups. All SDK checks still run.

Validation:
- All 23 CI policy tests pass. Structured YAML comparison confirms all eight TypeScript setup/check steps are preserved exactly; deployed-runner tests retain their Node setup in the CLI job.
- On Node 24.21.0: 109 tests passed; type checking, build, wire-contract verification, all 24 conformance scenarios and browser bundling passed.
- Workflow validation passes with shellcheck disabled. Changed documentation has no new repository-style findings and passes destink.
- Full `mix precommit` passed: 5,375 core tests + 6 doctests, 144 Buzz tests and 33 Support tests, all zero failures.

Timing and runner jobs:
- A full mixed PR plan grows from 21 to 22 jobs. The split prepares selective routing; it does not claim lower total runner usage.
- Parent [run 34640688693](https://github.com/managoat/fountain/actions/runs/34640688693) completed in 267 seconds with 21 executed jobs; its remaining TypeScript/CLI job took 43 seconds. After extraction, [TypeScript SDK](https://github.com/managoat/fountain/actions/runs/34641315620/job/103401470332) passed in 18 seconds and [CLI/plugins](https://github.com/managoat/fountain/actions/runs/34641315620/job/103401469970) passed in 39 seconds. The successful workflow took 255 seconds with 22 executed jobs. These are single-run observations with different runner/cache conditions.

Queue settings are unchanged; their comments now describe the 22-job full plan.
