### PR TITLE
ci: report a stable SDK aggregate check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1814,6 +1814,27 @@ jobs:
       - name: Test CI decisions
         run: python3 -m unittest discover -s scripts/ci -p 'test_*.py' -v
 
+  sdk-checks:
+    name: SDK checks
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    if: ${{ always() }}
+    needs:
+      - already-tested
+      - changes
+      - elixir-sdk
+      - python-sdk
+      - typescript-sdk
+      - swift-sdk
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
+        with:
+          persist-credentials: false
+      - name: Every selected SDK check passed
+        env:
+          CI_NEEDS: ${{ toJSON(needs) }}
+        run: python3 scripts/ci/gate.py --sdk
+
   gate:
     name: CI required
     runs-on: ubuntu-24.04
@@ -1823,6 +1844,7 @@ jobs:
       - already-tested
       - changes
       - workflow-checks
+      - sdk-checks
       - test
       - coverage
       - elixir-static

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -71,7 +71,7 @@ tested it.
 ### Sizing
 
 `MERGE_QUEUE` in `require-checks.py` explains the queue settings. A full CI
-run now has 22 jobs, compared with the documented limit of 20 concurrent
+run now has 23 jobs, compared with the documented limit of 20 concurrent
 runners. The queue builds one group at a time and batches up to five PRs. Revisit
 `max_entries_to_build` when the concurrency limit changes.
 
@@ -86,13 +86,22 @@ The Elixir job owns its toolchain, cache, formatting, compilation, tests, docs,
 package dry run, contract and conformance checks. The Python job owns its
 tests, compilation, contract and conformance checks. The TypeScript job owns
 installation, type checks, tests, builds, browser bundling, contract and
-conformance checks. Each SDK job validates fixtures before its tests.
+conformance checks. These three extracted jobs lint fixtures before their
+tests. Swift retains its separate conformance test step.
 `CI required` requires all SDK jobs on every full plan, including main and
 merge groups. A failed, cancelled or unexpectedly skipped job fails the gate.
 
+`SDK checks` reports the SDK result even when docs-only classification or a
+previously tested tree skips every SDK leg. It validates the same probe
+outputs as the full gate and rejects missing, failed or unexpectedly skipped
+jobs. `CI required` depends on this aggregate. Only the full gate publishes
+`tested-tree` evidence; passing the SDK gate cannot authorize reuse of a tree.
+
 Per-language path routing remains tracked in #1413. Register a new job in
-`gate.py`'s `FULL_JOBS` and the workflow gate's `needs` list together. Run
-`test_gate.py` to verify their agreement and every supported event plan.
+`gate.py`'s `FULL_JOBS` and the workflow gate's `needs` list together. For an
+SDK job, also update `SDK_JOBS` and the `sdk-checks` dependencies. Run
+`test_gate.py` and `test_sdk_gate.py` to verify their agreement and every
+supported event plan.
 
 ## Refresh partition timings
 

--- a/scripts/ci/gate.py
+++ b/scripts/ci/gate.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Validate the complete CI plan before publishing the stable required check."""
 
+import argparse
 import json
 import os
 import re
@@ -11,7 +12,9 @@ FULL_JOBS = {
     "test", "coverage", "elixir-static", "release-and-contract", "cli-plugins", "typescript-sdk",
     "elixir-sdk", "python-sdk", "swift-sdk", "core-distribution", "compose-fresh-clone", "compose-pinned-image-boot",
 }
-JOBS = FULL_JOBS | {"already-tested", "changes", "workflow-checks", "docs", "docs-prose"}
+SDK_JOBS = {"elixir-sdk", "python-sdk", "typescript-sdk", "swift-sdk"}
+SDK_GATE_JOBS = SDK_JOBS | {"already-tested", "changes"}
+JOBS = FULL_JOBS | {"already-tested", "changes", "workflow-checks", "docs", "docs-prose", "sdk-checks"}
 
 # Which probes are expected to have run, per event. A merge group is the only
 # plan that runs both: the queue classifies the diff like a PR *and* asks
@@ -34,34 +37,51 @@ def _classification(needs):
     outputs = needs["changes"].get("outputs", {})
     if any(outputs.get(key) not in {"true", "false"} for key in ("docs_only", "docs_touched", "cli_docs")):
         raise ValueError("change classification is missing or invalid")
-    if not re.fullmatch(r"[0-9a-f]{40}", outputs.get("tree", "")):
+    tree = outputs.get("tree")
+    if not isinstance(tree, str) or not re.fullmatch(r"[0-9a-f]{40}", tree):
         raise ValueError("checkout tree is missing or invalid")
     return outputs["docs_only"] == "true", outputs["docs_touched"] == "true"
 
 
-def validate(event, needs):
+def _expected_plan(event, needs, jobs):
     if event not in PROBES:
         raise ValueError(f"unsupported CI event: {event}")
-    if set(needs) != JOBS:
-        raise ValueError(f"CI dependencies differ: missing={JOBS - set(needs)}, extra={set(needs) - JOBS}")
+    if set(needs) != jobs:
+        raise ValueError(f"CI dependencies differ: missing={jobs - set(needs)}, extra={set(needs) - jobs}")
 
-    expected = dict.fromkeys(JOBS, "skipped")
-    expected["workflow-checks"] = "success"
+    expected = dict.fromkeys(jobs, "skipped")
     for probe in PROBES[event]:
         expected[probe] = "success"
 
     reuse = _reuse(needs) if "already-tested" in PROBES[event] else False
     docs_only, docs_touched = _classification(needs) if "changes" in PROBES[event] else (False, True)
 
-    full = not reuse and not docs_only
-    # A docs-only plan still owes the docs job; a reused tree owes nothing,
-    # because the identical tree already passed every gate this plan names.
+    return expected, not reuse and not docs_only, docs_only, docs_touched, reuse
+
+
+def validate(event, needs):
+    expected, full, docs_only, docs_touched, reuse = _expected_plan(event, needs, JOBS)
+    expected["workflow-checks"] = "success"
+    expected["sdk-checks"] = "success"
+    # Docs-only still owes docs. Reused trees skip the workload jobs, while
+    # both aggregate checks validate that the selected plan was followed.
     if docs_only and not reuse:
         expected["docs"] = "success"
     if full:
         expected.update(dict.fromkeys(FULL_JOBS, "success"))
     if full and docs_touched:
         expected["docs-prose"] = "success"
+    _check_results(needs, expected)
+
+
+def validate_sdks(event, needs):
+    expected, full, _, _, _ = _expected_plan(event, needs, SDK_GATE_JOBS)
+    if full:
+        expected.update(dict.fromkeys(SDK_JOBS, "success"))
+    _check_results(needs, expected)
+
+
+def _check_results(needs, expected):
     errors = [f"{job}: expected {result}, got {needs[job].get('result')}"
               for job, result in sorted(expected.items()) if needs[job].get("result") != result]
     if errors:
@@ -69,10 +89,17 @@ def validate(event, needs):
 
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--sdk", action="store_true", help="validate only the SDK job plan")
+    args = parser.parse_args()
     needs = json.loads(os.environ["CI_NEEDS"])
     event = os.environ["GITHUB_EVENT_NAME"]
-    validate(event, needs)
-    # Main is the only event that consumes evidence rather than publishing it.
-    if event != "push":
-        Path("tested-tree.txt").write_text(needs["changes"]["outputs"]["tree"] + "\n")
-    print("Every job required by this CI plan passed.")
+    if args.sdk:
+        validate_sdks(event, needs)
+        print("Every SDK job required by this CI plan passed.")
+    else:
+        validate(event, needs)
+        # Only complete CI may publish evidence for main's tested-tree shortcut.
+        if event != "push":
+            Path("tested-tree.txt").write_text(needs["changes"]["outputs"]["tree"] + "\n")
+        print("Every job required by this CI plan passed.")

--- a/scripts/ci/require-checks.py
+++ b/scripts/ci/require-checks.py
@@ -19,14 +19,14 @@ def api(path, payload=None, method="PUT"):
 # Sized against this repo's measured CI, not GitHub's defaults.
 #
 # max_entries_to_build: 1 — the org is on the free plan, which allows 20
-# concurrent GitHub-hosted jobs, and ONE full CI run has 22 jobs. Speculating
+# concurrent GitHub-hosted jobs, and ONE full CI run has 23 jobs. Speculating
 # two groups deep cannot run two groups; it queues the second behind the first
 # while also starving every open PR. Raise this only after the concurrency
 # ceiling does.
 #
 # min_entries_to_merge: 2 with a 5 minute wait — batching is the only lever
 # that buys throughput under that same ceiling, because five PRs merged as one
-# group cost one 22-job run instead of five. In a burst the group fills at once
+# group cost one 23-job run instead of five. In a burst the group fills at once
 # and nothing waits; in a quiet hour a lone PR waits up to five minutes, which
 # is the hour where nobody is blocked on it.
 #

--- a/scripts/ci/test_gate.py
+++ b/scripts/ci/test_gate.py
@@ -12,6 +12,7 @@ EVENTS = ("pull_request", "push", "merge_group")
 def plan(event="pull_request", docs=False, touched=False, reuse=False):
     jobs = {job: {"result": "skipped", "outputs": {}} for job in JOBS}
     jobs["workflow-checks"]["result"] = "success"
+    jobs["sdk-checks"]["result"] = "success"
     if "already-tested" in PROBES[event]:
         jobs["already-tested"] = {"result": "success", "outputs": {"skip": str(reuse).lower()}}
     if "changes" in PROBES[event]:

--- a/scripts/ci/test_require_checks.py
+++ b/scripts/ci/test_require_checks.py
@@ -75,7 +75,7 @@ class RequiredChecksTest(unittest.TestCase):
         self.assertEqual(contexts, ["CI required", "Detect secrets"])
 
     def test_the_queue_cannot_outrun_the_free_plan_job_ceiling(self):
-        """One full CI run has 22 jobs; the documented concurrency limit is 20.
+        """One full CI run has 23 jobs; the documented concurrency limit is 20.
 
         Building more than one group at a time cannot run them in parallel; it
         only starves every open PR of runners.

--- a/scripts/ci/test_sdk_gate.py
+++ b/scripts/ci/test_sdk_gate.py
@@ -1,0 +1,107 @@
+import copy
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import tempfile
+import unittest
+
+from gate import SDK_GATE_JOBS, SDK_JOBS, validate_sdks
+from test_gate import plan
+
+
+CASES = [
+    ("pull_request", {}), ("pull_request", {"docs": True}),
+    ("push", {}), ("push", {"reuse": True}),
+    ("merge_group", {}), ("merge_group", {"docs": True}),
+    ("merge_group", {"reuse": True}),
+]
+
+
+def sdk_plan(event, **options):
+    return {name: state for name, state in plan(event, **options).items()
+            if name in SDK_GATE_JOBS}
+
+
+class SdkGateTest(unittest.TestCase):
+    def test_workflow_reports_the_stable_check_even_when_legs_are_skipped(self):
+        root = Path(__file__).resolve().parents[2]
+        workflow = (root / ".github/workflows/ci.yml").read_text()
+        job = workflow.split("\n  sdk-checks:\n", 1)[1].split("\n  gate:\n", 1)[0]
+        self.assertIn("    name: SDK checks\n", job)
+        self.assertIn("    if: ${{ always() }}\n", job)
+        self.assertIn("run: python3 scripts/ci/gate.py --sdk", job)
+        dependencies = job.split("    needs:\n", 1)[1].split("    steps:\n", 1)[0]
+        self.assertEqual(set(re.findall(r"^      - (.*)$", dependencies, re.M)), SDK_GATE_JOBS)
+        self.assertEqual(SDK_JOBS, {"elixir-sdk", "python-sdk", "typescript-sdk", "swift-sdk"})
+
+    def test_full_docs_and_reused_plans_pass(self):
+        for event, options in CASES:
+            with self.subTest(event=event, options=options):
+                validate_sdks(event, sdk_plan(event, **options))
+
+    def test_no_failed_cancelled_missing_or_unexpectedly_skipped_result_passes(self):
+        for event, options in CASES:
+            original = sdk_plan(event, **options)
+            for name, state in original.items():
+                for result in ("success", "failure", "cancelled", "skipped", None):
+                    if result == state["result"]:
+                        continue
+                    with self.subTest(event=event, options=options, job=name, result=result):
+                        needs = copy.deepcopy(original)
+                        needs[name]["result"] = result
+                        with self.assertRaises(ValueError):
+                            validate_sdks(event, needs)
+
+    def test_missing_or_extra_dependencies_are_not_a_complete_sdk_plan(self):
+        for event, options in CASES:
+            for name in SDK_GATE_JOBS:
+                needs = sdk_plan(event, **options)
+                del needs[name]
+                with self.assertRaises(ValueError):
+                    validate_sdks(event, needs)
+            needs = sdk_plan(event, **options)
+            needs["unregistered-sdk"] = {"result": "success"}
+            with self.assertRaises(ValueError):
+                validate_sdks(event, needs)
+
+    def test_invalid_probe_outputs_cannot_authorize_skipping_sdks(self):
+        for event, options in CASES:
+            original = sdk_plan(event, **options)
+            for name in ("changes", "already-tested"):
+                for key in original[name]["outputs"]:
+                    for value in (None, "invalid"):
+                        needs = copy.deepcopy(original)
+                        needs[name]["outputs"][key] = value
+                        with self.subTest(event=event, probe=name, key=key, value=value):
+                            with self.assertRaises(ValueError):
+                                validate_sdks(event, needs)
+        with self.assertRaises(ValueError):
+            validate_sdks("unknown_event", sdk_plan("pull_request"))
+
+    def test_sdk_cli_never_publishes_whole_tree_reuse_evidence(self):
+        script = Path(__file__).with_name("gate.py").resolve()
+        for event, options in CASES:
+            with tempfile.TemporaryDirectory() as workdir:
+                env = dict(os.environ, GITHUB_EVENT_NAME=event,
+                           CI_NEEDS=json.dumps(sdk_plan(event, **options)))
+                result = subprocess.run([sys.executable, str(script), "--sdk"], cwd=workdir,
+                                        env=env, text=True, capture_output=True)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertFalse((Path(workdir) / "tested-tree.txt").exists())
+
+    def test_sdk_cli_exits_nonzero_for_a_failed_leg(self):
+        needs = sdk_plan("pull_request")
+        needs["typescript-sdk"]["result"] = "failure"
+        script = Path(__file__).with_name("gate.py").resolve()
+        with tempfile.TemporaryDirectory() as workdir:
+            result = subprocess.run(
+                [sys.executable, str(script), "--sdk"], cwd=workdir,
+                env=dict(os.environ, GITHUB_EVENT_NAME="pull_request", CI_NEEDS=json.dumps(needs)),
+                text=True, capture_output=True,
+            )
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("typescript-sdk: expected success, got failure", result.stderr)
+            self.assertFalse((Path(workdir) / "tested-tree.txt").exists())


### PR DESCRIPTION
CI now reports a stable `SDK checks` aggregate after the four SDK jobs, including when docs-only classification or verified tree reuse skips every SDK leg. It validates the selected job plan and refuses missing results, failures, cancellations and unexpected skips. `CI required` depends on the aggregate and continues validating the complete plan independently.

Both gates share probe validation. The SDK-only CLI mode never writes `tested-tree.txt`; only a complete successful CI plan can publish evidence for reuse. Null checkout-tree outputs now produce the existing invalid-tree diagnostic.

Stack: based on #1986. Refs #1413. Path routing, minimum-runtime expansion and workflow dispatch remain follow-ups. Required branch rules are unchanged.

Validation:
- All 30 CI policy tests passed, covering PR, merge-group and main plans; docs-only and reused trees; invalid probes; failed/cancelled/skipped jobs; exact workflow dependencies; and the actual CLI exit/evidence behavior.
- A mutation that ignored SDK results produced 169 failing subcases; restoring validation returned the full policy suite to green.
- Workflow validation passes with shellcheck disabled. Changed documentation has no new repository-style findings and passes destink.
- Full `mix precommit` passed: core 5,375 tests + 6 doctests, Buzz 144 tests and Support 33 tests, all with zero failures.

Timing and runner jobs:
- A full mixed PR plan grows from 22 to 23 jobs. Docs-only and reused plans also run this small aggregate so the stable result is always reported.
- Parent #1986 completed CI in 255 seconds with 22 executed jobs. [This draft’s successful run](https://github.com/managoat/fountain/actions/runs/34642601251) took 273 seconds with 23 executed jobs; [SDK checks](https://github.com/managoat/fountain/actions/runs/34642601251/job/103406486608) took 6 seconds. These are single-run observations with different cache conditions, not a guaranteed speedup.
