### PR TITLE
ci: classify SDK paths before enabling selective jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         run: bash scripts/ci/already-tested.sh
 
   changes:
-    name: Decide whether this is a docs-only change
+    name: Classify documentation and SDK changes
     # Never on push, and deliberately so. There, `already-tested` above
     # already collapses a rebased squash-merge to a few seconds, and a main
     # push that is NOT already-tested is precisely the case that must run
@@ -90,6 +90,10 @@ jobs:
       docs_touched: ${{ steps.filter.outputs.docs_touched }}
       cli_docs: ${{ steps.filter.outputs.cli_docs }}
       tree: ${{ steps.tree.outputs.tree }}
+      sdk_elixir: ${{ steps.sdks.outputs.sdk_elixir }}
+      sdk_python: ${{ steps.sdks.outputs.sdk_python }}
+      sdk_typescript: ${{ steps.sdks.outputs.sdk_typescript }}
+      sdk_swift: ${{ steps.sdks.outputs.sdk_swift }}
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
@@ -120,8 +124,10 @@ jobs:
           MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
         run: |
           set -u
+          base=""
           decide() {
             {
+              echo "diff_base=${base:-}"
               echo "docs_only=$1"
               echo "cli_docs=$2"
               echo "docs_touched=$3"
@@ -192,6 +198,12 @@ jobs:
 
           echo "docs-only — running the docs job instead of the Elixir suite"
           decide true "${cli_docs}" false
+
+      - name: Select SDKs from the same diff
+        id: sdks
+        env:
+          DIFF_BASE: ${{ steps.filter.outputs.diff_base }}
+        run: python3 scripts/ci/sdk_changes.py "$DIFF_BASE" >> "$GITHUB_OUTPUT"
 
   test:
     name: Build and Test (partition ${{ matrix.partition }})

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -103,6 +103,28 @@ SDK job, also update `SDK_JOBS` and the `sdk-checks` dependencies. Run
 `test_gate.py` and `test_sdk_gate.py` to verify their agreement and every
 supported event plan.
 
+## SDK path classification
+
+`changes` reports four `sdk_<language>` outputs from `sdk_changes.py`, using
+its existing PR merge base or merge-group base. Job conditions do not yet
+consume these outputs; SDK execution stays unchanged in this prerequisite.
+
+The classifier selects an SDK for its directory, documentation page or
+registered release tooling. Shared contract and conformance files select all
+SDKs. So do API implementation, build configuration and unregistered paths.
+An explicit allowlist selects none for unrelated docs, console UI, server
+tests and telemetry. Mixed changes select the union of their SDKs.
+
+Invalid bases, failed or empty diffs, malformed paths and undecodable names
+select every SDK. The NUL-delimited Git diff disables rename detection, so a
+move out of an SDK still selects its former owner. Outputs contain only fixed
+keys and boolean values.
+
+Register a new language in `LANGUAGES` and `OWNED_FILES`, expose its workflow
+output, and add routing fixtures in `test_sdk_changes.py`. Register SDK docs
+and checked snippets before the unrelated-docs allowlist. Keep contract
+triggers outside that allowlist; uncertainty must select every SDK.
+
 ## Refresh partition timings
 
 Each partition records all module timings with eight concurrent cases, matching

--- a/scripts/ci/sdk_changes.py
+++ b/scripts/ci/sdk_changes.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Select SDKs from a Git diff; unknown paths or unreadable diffs select all."""
+
+import re
+import subprocess
+import sys
+
+
+LANGUAGES = frozenset({"elixir", "python", "typescript", "swift"})
+# SDK-local docs and tooling take precedence over the unrelated-path allowlist.
+OWNED_FILES = {
+    "elixir": {"docs/elixir-sdk.md", "scripts/elixir-sdk-release.exs",
+               ".github/workflows/elixir-sdk-publish.yml",
+               ".github/workflows/elixir-sdk-release-gate.yml"},
+    "python": {"docs/python-sdk.md", ".github/workflows/python-sdk-publish.yml",
+               ".github/workflows/python-sdk-release-gate.yml"},
+    "typescript": {"docs/sdk.md", "scripts/sdk-release.mjs", "scripts/sdk-publish-tag.mjs",
+                   "scripts/sdk-publish-tag.test.mjs", ".github/workflows/sdk-publish.yml",
+                   ".github/workflows/sdk-release-gate.yml"},
+    "swift": {"docs/swift-sdk.md", "Package.swift", "Package.resolved", ".swift-format"},
+}
+UNRELATED_PREFIXES = (
+    "docs/", "decisions/", "assets/", "apps/fountain/assets/",
+    "apps/fountain/lib/fountain_web/live/", "apps/fountain/lib/fountain_web/components/",
+    "apps/fountain/test/", "apps/fountain_buzz/test/", "apps/fountain_support/test/",
+)
+UNRELATED_FILES = {
+    "apps/fountain/lib/fountain/telemetry.ex", "apps/fountain/lib/fountain/telemetry_tick.ex",
+    "apps/fountain/lib/fountain_web/telemetry.ex",
+}
+
+
+def classify(paths):
+    selected = set()
+    if not paths:
+        return LANGUAGES
+    for path in paths:
+        if (not path or path.startswith("/") or re.search(r"[\x00-\x1f\x7f]", path)
+                or any(part in {"", ".", ".."} for part in path.split("/"))):
+            return LANGUAGES
+        owner = next((language for language in LANGUAGES
+                      if path.startswith(f"sdk/{language}/") or path in OWNED_FILES[language]), None)
+        if owner:
+            selected.add(owner)
+        elif path not in UNRELATED_FILES and not path.startswith(UNRELATED_PREFIXES):
+            # Shared contract/conformance, API implementation, build config,
+            # CI policy and every unregistered path require every SDK.
+            return LANGUAGES
+    return frozenset(selected)
+
+
+def from_git(base):
+    if not re.fullmatch(r"[0-9a-f]{40}", base):
+        return LANGUAGES
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--no-ext-diff", "--no-textconv", "--no-renames",
+             "--name-only", "-z", base, "HEAD", "--"],
+            check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        ).stdout
+        if not result or not result.endswith(b"\0"):
+            return LANGUAGES
+        return classify(result[:-1].decode("utf-8").split("\0"))
+    except (OSError, subprocess.CalledProcessError, UnicodeDecodeError):
+        return LANGUAGES
+
+
+if __name__ == "__main__":
+    selected = from_git(sys.argv[1]) if len(sys.argv) == 2 else LANGUAGES
+    # Only fixed keys and boolean values reach GITHUB_OUTPUT, never file names.
+    for language in sorted(LANGUAGES):
+        print(f"sdk_{language}={str(language in selected).lower()}")

--- a/scripts/ci/test_sdk_changes.py
+++ b/scripts/ci/test_sdk_changes.py
@@ -1,0 +1,117 @@
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from sdk_changes import LANGUAGES, OWNED_FILES, classify, from_git
+
+
+SCRIPT = Path(__file__).with_name("sdk_changes.py").resolve()
+
+
+class SDKChangesTest(unittest.TestCase):
+    def test_sdk_sources_docs_and_owned_tooling(self):
+        for language in LANGUAGES:
+            for path in {f"sdk/{language}/src/client", f"sdk/{language}/README.md",
+                         f"sdk/{language}/new-tool"} | OWNED_FILES[language]:
+                with self.subTest(path=path):
+                    self.assertEqual(classify([path]), {language})
+
+    def test_public_contract_shared_fixtures_and_uncertainty_fan_out(self):
+        for path in (
+            "sdk/contract/contract.json", "sdk/contract/manifests/python.json",
+            "sdk/conformance/scenarios/new.json", "scripts/sdk-contract/build.py",
+            "apps/fountain/lib/fountain_web/schemas.ex",
+            "apps/fountain/lib/fountain_web/router.ex",
+            "apps/fountain/lib/fountain_web/controllers/api/agent_controller.ex",
+            "apps/fountain/lib/fountain_web/plugs/auth.ex",
+            "apps/fountain/lib/mix/tasks/openapi.export.ex",
+            "apps/fountain/lib/fountain/agents.ex", "config/config.exs", "mix.lock",
+            "ee/lib/fountain_web/controllers/api/credits_controller.ex",
+            "apps/fountain_buzz/lib/fountain_buzz_web/router.ex",
+            ".github/workflows/ci.yml", "scripts/ci/sdk_changes.py", "sdk/new-language/client",
+            "new-directory/unknown", "README.md",
+        ):
+            with self.subTest(path=path):
+                self.assertEqual(classify(["docs/index.md", path]), LANGUAGES)
+
+    def test_unrelated_paths_and_mixed_sdk_changes(self):
+        paths = ["docs/index.md", "decisions/0001-template.md", "assets/css/tokens.css",
+                 "apps/fountain/lib/fountain_web/live/dashboard_live/index.ex",
+                 "apps/fountain/lib/fountain_web/components/core_components.ex",
+                 "apps/fountain/lib/fountain/telemetry_tick.ex",
+                 "apps/fountain/test/fountain/agents_test.exs"]
+        self.assertEqual(classify(paths), set())
+        self.assertEqual(classify(paths + ["sdk/python/test.py", "sdk/swift/README.md"]),
+                         {"python", "swift"})
+        self.assertEqual(classify(["docs/sdk.md"]), {"typescript"})
+
+    def test_empty_and_ambiguous_paths_select_all(self):
+        self.assertEqual(classify([]), LANGUAGES)
+        for path in ("", "/docs/index.md", "docs/../config/config.exs", "docs//index.md",
+                     "docs/./index.md", "docs/file\nname", "docs/file\rname", "docs/file\x7f"):
+            with self.subTest(path=path):
+                self.assertEqual(classify([path]), LANGUAGES)
+
+    def test_unreadable_diff_selects_all(self):
+        for output in (b"", b"docs/index.md", b"docs/\xff\0"):
+            with self.subTest(output=output), patch("sdk_changes.subprocess.run") as run:
+                run.return_value.stdout = output
+                self.assertEqual(from_git("a" * 40), LANGUAGES)
+        with patch("sdk_changes.subprocess.run", side_effect=OSError):
+            self.assertEqual(from_git("a" * 40), LANGUAGES)
+
+    def test_actual_git_diff_handles_deletions_renames_and_output_safety(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            def git(*args):
+                return subprocess.check_output(["git", *args], cwd=root, stderr=subprocess.DEVNULL).decode().strip()
+            def write(path):
+                target = root / path
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_text("fixture\n")
+            def commit():
+                git("add", "-A")
+                git("-c", "user.name=SDK test", "-c", "user.email=sdk@example.invalid",
+                    "-c", "commit.gpgsign=false", "commit", "-qm", "fixture")
+                return git("rev-parse", "HEAD")
+            def selection(base):
+                result = subprocess.check_output([sys.executable, str(SCRIPT), base], cwd=root).decode()
+                values = dict(line.split("=") for line in result.splitlines())
+                self.assertEqual(set(values), {f"sdk_{language}" for language in LANGUAGES})
+                self.assertLessEqual(set(values.values()), {"true", "false"})
+                return {language for language in LANGUAGES if values[f"sdk_{language}"] == "true"}
+            git("init", "-q")
+            write("sdk/python/client.py")
+            base = commit()
+            git("mv", "sdk/python/client.py", "sdk/python/renamed.py")
+            commit()
+            self.assertEqual(selection(base), {"python"})
+            base = git("rev-parse", "HEAD")
+            write("docs/index.md")
+            git("mv", "sdk/python/renamed.py", "docs/renamed.py")
+            commit()
+            self.assertEqual(selection(base), {"python"})
+            base = git("rev-parse", "HEAD")
+            os.remove(root / "docs/index.md")
+            commit()
+            self.assertEqual(selection(base), set())
+            base = git("rev-parse", "HEAD")
+            write("docs/file\nsdk_python=false")
+            commit()
+            self.assertEqual(selection(base), LANGUAGES)
+            for bad_base in ("", "--output=unsafe", "a" * 40, git("rev-parse", "HEAD")):
+                with self.subTest(base=bad_base):
+                    self.assertEqual(selection(bad_base), LANGUAGES)
+
+    def test_workflow_exposes_decisions_from_the_classified_base(self):
+        workflow = (SCRIPT.parents[2] / ".github/workflows/ci.yml").read_text()
+        changes = workflow.split("\n  changes:\n", 1)[1].split("\n  test:\n", 1)[0]
+        for language in LANGUAGES:
+            self.assertIn(f"sdk_{language}: ${{{{ steps.sdks.outputs.sdk_{language} }}}}", changes)
+        self.assertIn('echo "diff_base=${base:-}"', changes)
+        self.assertIn("DIFF_BASE: ${{ steps.filter.outputs.diff_base }}", changes)
+        self.assertIn('python3 scripts/ci/sdk_changes.py "$DIFF_BASE" >> "$GITHUB_OUTPUT"', changes)


### PR DESCRIPTION
CI now reports a separate selection for each SDK using the existing PR or merge-group diff base. An SDK directory, its documentation page or registered release tooling selects that language. Shared contract/conformance, API implementation, build configuration and unknown paths select all four. An explicit allowlist selects none for unrelated docs, console UI, server tests and telemetry.

This prerequisite reports decisions without changing SDK job execution. The following draft will apply them in job conditions and both aggregate gates. Keeping classification separate makes the allowlist and failure behavior reviewable on their own.

The Git diff uses NUL-delimited paths and disables rename detection so moving a file out of an SDK still selects its former owner. Missing/invalid bases, unreadable or empty diffs, malformed paths and undecodable names select all SDKs. Only fixed boolean outputs are emitted.

Stack: based on #1987. Refs #1413. Selective execution, minimum-runtime expansion and workflow dispatch remain follow-ups. No release or branch-rule changes.

Validation:
- All 37 CI policy tests passed, including real Git renames, deletions, invalid bases and filenames containing an attempted output injection.
- Enabling rename detection in an isolated test copy made the rename regression fail.
- Actionlint passes with shellcheck disabled. Changed documentation passes destink and has no new repository-style findings.
- Full `mix precommit` passed: core 5,375 tests + 6 doctests, Buzz 144 tests and Support 33 tests, all with zero failures.

Timing and runner jobs:
- Job selection and the maximum full mixed PR plan remain unchanged at 23 jobs; this adds one small classification step to the existing changes job.
- Parent #1987 completed CI in 273 seconds with 23 executed jobs. [This draft’s successful run](https://github.com/managoat/fountain/actions/runs/34643756044) took 242 seconds with 23 executed jobs. The SDK classification step completed within the same reported second in [the changes job](https://github.com/managoat/fountain/actions/runs/34643756044/job/103409482813). Single-run comparisons have different cache conditions and do not establish a speedup.
