### PR TITLE
ci: run only SDKs selected by the change classifier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -798,6 +798,7 @@ jobs:
       # which is also what enforces `erasableSyntaxOnly`, the setting that
       # keeps those sources runnable without a build step.
       - name: Set up Node
+        if: ${{ needs.changes.outputs.sdk_typescript != 'false' }}
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
@@ -807,6 +808,7 @@ jobs:
       # `--no-audit --no-fund`: see the typescript-sdk job, which carries the
       # measurement. Here it is only to make `npm run generate` runnable.
       - name: SDK install
+        if: ${{ needs.changes.outputs.sdk_typescript != 'false' }}
         working-directory: sdk/typescript
         run: npm ci --no-audit --no-fund
 
@@ -817,6 +819,7 @@ jobs:
       # API that drift apart. This is the arm that covers the WHOLE document;
       # the manifest checks below cover what each client reaches for by name.
       - name: SDK types match the spec
+        if: ${{ needs.changes.outputs.sdk_typescript != 'false' }}
         working-directory: sdk/typescript
         run: |
           npm run generate
@@ -833,7 +836,7 @@ jobs:
     timeout-minutes: 15
     needs: [already-tested, changes]
     if: ${{ !cancelled() && needs.already-tested.outputs.skip != 'true'
-         && needs.changes.outputs.docs_only != 'true' }}
+         && needs.changes.outputs.sdk_elixir != 'false' }}
 
     permissions:
       contents: read
@@ -905,7 +908,7 @@ jobs:
     timeout-minutes: 15
     needs: [already-tested, changes]
     if: ${{ !cancelled() && needs.already-tested.outputs.skip != 'true'
-         && needs.changes.outputs.docs_only != 'true' }}
+         && needs.changes.outputs.sdk_python != 'false' }}
 
     permissions:
       contents: read
@@ -938,7 +941,7 @@ jobs:
     timeout-minutes: 15
     needs: [already-tested, changes]
     if: ${{ !cancelled() && needs.already-tested.outputs.skip != 'true'
-         && needs.changes.outputs.docs_only != 'true' }}
+         && needs.changes.outputs.sdk_typescript != 'false' }}
 
     permissions:
       contents: read
@@ -1202,7 +1205,7 @@ jobs:
     timeout-minutes: 10
     needs: [already-tested, changes]
     if: ${{ !cancelled() && needs.already-tested.outputs.skip != 'true'
-         && needs.changes.outputs.docs_only != 'true' }}
+         && needs.changes.outputs.sdk_swift != 'false' }}
 
     permissions:
       contents: read

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -88,8 +88,9 @@ tests, compilation, contract and conformance checks. The TypeScript job owns
 installation, type checks, tests, builds, browser bundling, contract and
 conformance checks. These three extracted jobs lint fixtures before their
 tests. Swift retains its separate conformance test step.
-`CI required` requires all SDK jobs on every full plan, including main and
-merge groups. A failed, cancelled or unexpectedly skipped job fails the gate.
+`CI required` requires every selected SDK job. A failed, cancelled or
+unexpectedly skipped job fails the gate. Main runs all SDKs unless a verified
+tested tree authorizes reuse.
 
 `SDK checks` reports the SDK result even when docs-only classification or a
 previously tested tree skips every SDK leg. It validates the same probe
@@ -97,7 +98,7 @@ outputs as the full gate and rejects missing, failed or unexpectedly skipped
 jobs. `CI required` depends on this aggregate. Only the full gate publishes
 `tested-tree` evidence; passing the SDK gate cannot authorize reuse of a tree.
 
-Per-language path routing remains tracked in #1413. Register a new job in
+Register a new job in
 `gate.py`'s `FULL_JOBS` and the workflow gate's `needs` list together. For an
 SDK job, also update `SDK_JOBS` and the `sdk-checks` dependencies. Run
 `test_gate.py` and `test_sdk_gate.py` to verify their agreement and every
@@ -106,14 +107,22 @@ supported event plan.
 ## SDK path classification
 
 `changes` reports four `sdk_<language>` outputs from `sdk_changes.py`, using
-its existing PR merge base or merge-group base. Job conditions do not yet
-consume these outputs; SDK execution stays unchanged in this prerequisite.
+its existing PR merge base or merge-group base. Each SDK job consumes its
+own output. The two gates independently validate the selection and exact job
+results. Missing or malformed outputs fail both gates; only explicit `false`
+lets a job skip.
 
 The classifier selects an SDK for its directory, documentation page or
 registered release tooling. Shared contract and conformance files select all
 SDKs. So do API implementation, build configuration and unregistered paths.
 An explicit allowlist selects none for unrelated docs, console UI, server
-tests and telemetry. Mixed changes select the union of their SDKs.
+tests and telemetry. Mixed changes select the union of their SDKs. SDK docs
+select their language even on the server docs-only path.
+
+The release job installs TypeScript dependencies and checks generated types
+only when TypeScript is selected. Server wire-contract generation and its
+freshness check remain required on every full server plan. Shared contract
+changes select all SDKs, including that generated-type check.
 
 Invalid bases, failed or empty diffs, malformed paths and undecodable names
 select every SDK. The NUL-delimited Git diff disables rename detection, so a

--- a/scripts/ci/gate.py
+++ b/scripts/ci/gate.py
@@ -40,7 +40,14 @@ def _classification(needs):
     tree = outputs.get("tree")
     if not isinstance(tree, str) or not re.fullmatch(r"[0-9a-f]{40}", tree):
         raise ValueError("checkout tree is missing or invalid")
-    return outputs["docs_only"] == "true", outputs["docs_touched"] == "true"
+    selected = set()
+    for job in SDK_JOBS:
+        value = outputs.get("sdk_" + job.removesuffix("-sdk"))
+        if value not in ("true", "false"):
+            raise ValueError("SDK classification is missing or invalid")
+        if value == "true":
+            selected.add(job)
+    return outputs["docs_only"] == "true", outputs["docs_touched"] == "true", selected
 
 
 def _expected_plan(event, needs, jobs):
@@ -54,7 +61,12 @@ def _expected_plan(event, needs, jobs):
         expected[probe] = "success"
 
     reuse = _reuse(needs) if "already-tested" in PROBES[event] else False
-    docs_only, docs_touched = _classification(needs) if "changes" in PROBES[event] else (False, True)
+    docs_only, docs_touched, sdks = (
+        _classification(needs) if "changes" in PROBES[event] else (False, True, SDK_JOBS)
+    )
+    # SDK docs can select a language even when the server plan is docs-only.
+    if not reuse:
+        expected.update(dict.fromkeys(sdks, "success"))
 
     return expected, not reuse and not docs_only, docs_only, docs_touched, reuse
 
@@ -68,16 +80,14 @@ def validate(event, needs):
     if docs_only and not reuse:
         expected["docs"] = "success"
     if full:
-        expected.update(dict.fromkeys(FULL_JOBS, "success"))
+        expected.update(dict.fromkeys(FULL_JOBS - SDK_JOBS, "success"))
     if full and docs_touched:
         expected["docs-prose"] = "success"
     _check_results(needs, expected)
 
 
 def validate_sdks(event, needs):
-    expected, full, _, _, _ = _expected_plan(event, needs, SDK_GATE_JOBS)
-    if full:
-        expected.update(dict.fromkeys(SDK_JOBS, "success"))
+    expected, _, _, _, _ = _expected_plan(event, needs, SDK_GATE_JOBS)
     _check_results(needs, expected)
 
 

--- a/scripts/ci/test_gate.py
+++ b/scripts/ci/test_gate.py
@@ -3,13 +3,17 @@ from pathlib import Path
 import re
 import unittest
 
-from gate import FULL_JOBS, JOBS, PROBES, validate
+from gate import FULL_JOBS, JOBS, PROBES, SDK_JOBS, validate
 
 
 EVENTS = ("pull_request", "push", "merge_group")
 
 
-def plan(event="pull_request", docs=False, touched=False, reuse=False):
+def plan(event="pull_request", docs=False, touched=False, reuse=False, sdks=None):
+    if sdks is None:
+        sdks = set() if docs else SDK_JOBS
+    if event == "push":
+        sdks = SDK_JOBS
     jobs = {job: {"result": "skipped", "outputs": {}} for job in JOBS}
     jobs["workflow-checks"]["result"] = "success"
     jobs["sdk-checks"]["result"] = "success"
@@ -19,16 +23,19 @@ def plan(event="pull_request", docs=False, touched=False, reuse=False):
         jobs["changes"] = {"result": "success", "outputs": {
             "docs_only": str(docs).lower(), "docs_touched": str(touched).lower(),
             "cli_docs": "false", "tree": "a" * 40,
+            **{"sdk_" + job.removesuffix("-sdk"): str(job in sdks).lower() for job in SDK_JOBS},
         }}
     if reuse:
         return jobs
     if docs:
         jobs["docs"]["result"] = "success"
     else:
-        for job in FULL_JOBS:
+        for job in FULL_JOBS - SDK_JOBS:
             jobs[job]["result"] = "success"
         if touched or event == "push":
             jobs["docs-prose"]["result"] = "success"
+    for job in sdks:
+        jobs[job]["result"] = "success"
     return jobs
 
 

--- a/scripts/ci/test_sdk_routing.py
+++ b/scripts/ci/test_sdk_routing.py
@@ -1,0 +1,97 @@
+import copy
+import itertools
+from pathlib import Path
+import re
+import unittest
+
+from gate import SDK_GATE_JOBS, SDK_JOBS, validate, validate_sdks
+from sdk_changes import classify
+from test_gate import plan
+
+
+class SDKRoutingTest(unittest.TestCase):
+    def check_both(self, event, needs):
+        validate(event, needs)
+        validate_sdks(event, {name: state for name, state in needs.items() if name in SDK_GATE_JOBS})
+
+    def reject_both(self, event, needs):
+        with self.assertRaises(ValueError):
+            validate(event, needs)
+        with self.assertRaises(ValueError):
+            validate_sdks(event, {name: state for name, state in needs.items() if name in SDK_GATE_JOBS})
+
+    def test_every_sdk_subset_on_code_docs_and_reused_plans(self):
+        for event, docs, reuse, flags in itertools.product(
+                ("pull_request", "merge_group"), (False, True), (False, True),
+                itertools.product((False, True), repeat=4)):
+            if event == "pull_request" and reuse:
+                continue
+            selected = {job for job, flag in zip(sorted(SDK_JOBS), flags) if flag}
+            with self.subTest(event=event, docs=docs, reuse=reuse, selected=selected):
+                original = plan(event, docs=docs, reuse=reuse, sdks=selected)
+                self.check_both(event, original)
+                for job in SDK_JOBS:
+                    for result in ("success", "failure", "cancelled", "skipped", None):
+                        if result == original[job]["result"]:
+                            continue
+                        needs = copy.deepcopy(original)
+                        needs[job]["result"] = result
+                        self.reject_both(event, needs)
+
+    def test_missing_or_invalid_sdk_decisions_fail_even_for_reused_trees(self):
+        for event, docs, reuse, job, value in itertools.product(
+                ("pull_request", "merge_group"), (False, True), (False, True), SDK_JOBS,
+                (None, "", "TRUE", "invalid", True, False, 0, [], {})):
+            if event == "pull_request" and reuse:
+                continue
+            needs = plan(event, docs=docs, reuse=reuse)
+            key = "sdk_" + job.removesuffix("-sdk")
+            if value is None:
+                del needs["changes"]["outputs"][key]
+            else:
+                needs["changes"]["outputs"][key] = value
+            with self.subTest(event=event, docs=docs, reuse=reuse, job=job, value=value):
+                self.reject_both(event, needs)
+
+    def test_classifier_decisions_select_jobs_in_both_gates(self):
+        cases = [(["sdk/python/src/fountain/http.py"], False, {"python-sdk"}),
+                 (["docs/swift-sdk.md"], True, {"swift-sdk"}),
+                 (["docs/index.md"], True, set()),
+                 (["assets/css/tokens.css"], False, set()),
+                 (["apps/fountain/lib/fountain/telemetry.ex"], False, set()),
+                 (["sdk/conformance/matrix.json"], False, SDK_JOBS),
+                 (["apps/fountain/lib/fountain_web/router.ex"], False, SDK_JOBS),
+                 (["unregistered/path"], False, SDK_JOBS)]
+        for paths, docs, expected in cases:
+            selected = {language + "-sdk" for language in classify(paths)}
+            self.assertEqual(selected, expected)
+            for event in ("pull_request", "merge_group"):
+                self.check_both(event, plan(event, docs=docs, sdks=selected))
+
+    def test_main_still_requires_all_sdks_unless_the_tree_was_tested(self):
+        self.check_both("push", plan("push"))
+        self.check_both("push", plan("push", reuse=True))
+        for job in SDK_JOBS:
+            needs = plan("push")
+            needs[job]["result"] = "skipped"
+            self.reject_both("push", needs)
+
+    def test_job_conditions_match_the_selection_and_preserve_contract_generation(self):
+        workflow = (Path(__file__).resolve().parents[2] / ".github/workflows/ci.yml").read_text()
+        jobs = dict(re.findall(r"^  ([a-z][a-z0-9-]*):\n(.*?)(?=^  [a-z][a-z0-9-]*:|\Z)",
+                               workflow.split("\njobs:\n", 1)[1], re.M | re.S))
+        for job in SDK_JOBS:
+            language = job.removesuffix("-sdk")
+            condition = re.search(r"^    if: (.*?)(?=\n\n)", jobs[job], re.M | re.S)[1]
+            self.assertEqual(condition, "${{ !cancelled() && needs.already-tested.outputs.skip != 'true'\n"
+                             f"         && needs.changes.outputs.sdk_{language} != 'false' }}}}")
+            self.assertIn("needs: [already-tested, changes]", jobs[job])
+        release = jobs["release-and-contract"]
+        steps = dict(re.findall(r"      - name: ([^\n]+)\n(.*?)(?=      - (?:name:|uses:)|\Z)", release, re.S))
+        condition = "        if: ${{ needs.changes.outputs.sdk_typescript != 'false' }}\n"
+        for name in ("Set up Node", "SDK install", "SDK types match the spec"):
+            self.assertIn(condition, steps[name])
+        self.assertEqual(release.count(condition), 3)
+        for name in ("Validate OpenAPI spec", "SDK wire contract is current"):
+            self.assertNotIn("        if:", steps[name])
+        self.assertIn("run: scripts/sdk-contract/build.sh --check", steps["SDK wire contract is current"])


### PR DESCRIPTION
CI now runs only the SDKs selected by the change classifier. For example, a Python SDK edit runs Python, a console UI edit skips all SDK legs, and a public API or shared conformance change runs all four. SDK documentation selects its language even when the server uses the docs-only plan.

Both `SDK checks` and `CI required` independently validate every selection and exact job result. Missing or malformed decisions fail the gates; only explicit `false` skips an SDK job. Main still runs all SDKs unless the existing tested-tree proof authorizes reuse.

The release job also skips TypeScript dependency installation and type generation when TypeScript is unselected. OpenAPI validation and wire-contract generation/freshness checks remain required on every full server plan.

Stack: based on #1988. Refs #1413. Minimum-runtime expansion and workflow dispatch remain follow-ups. No release or branch-rule changes.

Validation:
- All 42 CI policy tests passed. Every SDK subset is checked on PR and merge-group code/docs/reuse plans, including invalid outputs and failed/cancelled/unexpectedly skipped jobs.
- Workflow assertions cover all four job conditions and the three TypeScript-only release steps; server contract generation remains unconditional within its job.
- A mutation that required every SDK regardless of selection caused 61 failing cases in the routing tests.
- Actionlint passes with shellcheck disabled. Changed documentation passes destink and has no new repository-style findings.
- Full `mix precommit` passed: core 5,375 tests + 6 doctests, Buzz 144 tests and Support 33 tests, all with zero failures.

Timing and runner jobs:
- CI policy changes conservatively select all SDKs, so this draft retains the maximum full mixed PR plan of 23 jobs. Parent #1988 completed CI in 242 seconds with 23 executed jobs. [This draft’s successful run](https://github.com/managoat/fountain/actions/runs/34644486691) took 260 seconds with 23 executed jobs. Single-run comparisons have different cache conditions and do not establish a speedup.
- Replaying historical diffs through the classifier selects 0 SDK runner legs for the credential-form UI change (`81f8de00`, previously 5), 1 for a TypeScript dependency change (`7ed0d7fb`, previously 5), and all 5 for a public API change (`c730774e`). Swift has two OS legs. These are classifier replays, not measured GitHub skip runs; no runtime savings are inferred from them.
