### PR TITLE
ci: validate the full plan on manual workflow dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
   # The merge queue. Every required check must name this event or the queue
   # waits for a check that never arrives, times out and ejects the PR.
   merge_group:
@@ -78,7 +79,8 @@ jobs:
     # The queue classifies its group for the same reason a PR does: without
     # this, every docs-only merge would run the full Elixir suite on the way
     # in, which is 11% of what lands here.
-    if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group'
+         || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 5
 
@@ -134,6 +136,12 @@ jobs:
             } >> "$GITHUB_OUTPUT"
             exit 0
           }
+
+          # A manual run requests complete validation, without a diff or
+          # tree-reuse shortcut. An empty base selects every SDK too.
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            decide false false true
+          fi
 
           # A merge group already knows the commit it was stacked onto, and
           # there is no base *ref* to fetch: the group branch is transient and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -491,7 +491,7 @@ retarget is now GitHub's job rather than yours, which removes the trap where a
 stale base merged cleanly into a branch that no longer existed. Land a feature
 as a stack of small chained PRs exactly as before.
 
-`scripts/ci/README.md` documents the three CI events and the queue's sizing;
+`scripts/ci/README.md` documents the four CI events and the queue's sizing;
 `gate.py`'s `PROBES` table is the authority on what each event owes.
 
 ### Coverage

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -52,7 +52,7 @@ out `check_response_timeout_minutes` and ejects it, with no red job anywhere to
 explain why. `test_every_event_the_workflow_triggers_on_is_a_plan` in
 `test_gate.py` keeps the workflow and `gate.py` from drifting apart later.
 
-Three CI events now exist, and `gate.py`'s `PROBES` table is the authority on
+Four CI events now exist, and `gate.py`'s `PROBES` table is the authority on
 what each one owes:
 
 | Event | Probes that run | What the plan means |
@@ -60,6 +60,7 @@ what each one owes:
 | `pull_request` | `changes` | Classify the diff; docs-only skips the Elixir suite |
 | `merge_group` | `changes` + `already-tested` | Classify the group, and skip it outright when its tree is one a PR run already tested |
 | `push` | `already-tested` | Main reuses the queue run (or a PR run) that tested this tree |
+| `workflow_dispatch` | `changes` | Run the complete plan, without diff-based skips or tree reuse |
 
 The queue run and main's push both look for the `tested-tree` artifact, so a
 queued merge normally costs one full run, not two: the queue runs the suite,
@@ -90,7 +91,9 @@ conformance checks. These three extracted jobs lint fixtures before their
 tests. Swift retains its separate conformance test step.
 `CI required` requires every selected SDK job. A failed, cancelled or
 unexpectedly skipped job fails the gate. Main runs all SDKs unless a verified
-tested tree authorizes reuse.
+tested tree authorizes reuse. Manual workflow dispatch always selects every
+SDK and the full server plan, including prose checks. Both gates reject a
+manual classification that attempts to skip part of that plan.
 
 `SDK checks` reports the SDK result even when docs-only classification or a
 previously tested tree skips every SDK leg. It validates the same probe

--- a/scripts/ci/gate.py
+++ b/scripts/ci/gate.py
@@ -21,6 +21,7 @@ JOBS = FULL_JOBS | {"already-tested", "changes", "workflow-checks", "docs", "doc
 # whether the tree it is about to test has already been tested.
 PROBES = {
     "pull_request": {"changes"},
+    "workflow_dispatch": {"changes"},
     "push": {"already-tested"},
     "merge_group": {"already-tested", "changes"},
 }
@@ -64,6 +65,8 @@ def _expected_plan(event, needs, jobs):
     docs_only, docs_touched, sdks = (
         _classification(needs) if "changes" in PROBES[event] else (False, True, SDK_JOBS)
     )
+    if event == "workflow_dispatch" and (docs_only or not docs_touched or sdks != SDK_JOBS):
+        raise ValueError("manual CI must select the complete plan")
     # SDK docs can select a language even when the server plan is docs-only.
     if not reuse:
         expected.update(dict.fromkeys(sdks, "success"))

--- a/scripts/ci/test_dispatch.py
+++ b/scripts/ci/test_dispatch.py
@@ -1,0 +1,77 @@
+import copy
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+
+from gate import FULL_JOBS, SDK_GATE_JOBS, SDK_JOBS, validate, validate_sdks
+from test_gate import plan
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class DispatchTest(unittest.TestCase):
+    def test_actual_classifier_selects_full_ci_without_fetching_a_base(self):
+        workflow = (ROOT / ".github/workflows/ci.yml").read_text()
+        job = workflow.split("\n  changes:\n", 1)[1].split("\n  test:\n", 1)[0]
+        self.assertIn("|| github.event_name == 'workflow_dispatch' }}", job)
+        script = job.split("        id: filter\n", 1)[1].split("        run: |\n", 1)[1]
+        script = textwrap.dedent(script.split("\n      - name:", 1)[0])
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            fake_git = root / "git"
+            fake_git.write_text('#!/bin/sh\ntouch "$GIT_CALLED"\nexit 97\n')
+            fake_git.chmod(0o755)
+            output = root / "outputs"
+            result = subprocess.run(["bash", "-e", "-c", script], cwd=root, capture_output=True, text=True,
+                                    env=dict(os.environ, GITHUB_EVENT_NAME="workflow_dispatch",
+                                             GITHUB_OUTPUT=str(output), GITHUB_BASE_REF="",
+                                             MERGE_GROUP_BASE_SHA="", GIT_CALLED=str(root / "called"),
+                                             PATH=str(root) + os.pathsep + os.environ["PATH"]))
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertFalse((root / "called").exists())
+            values = dict(line.split("=", 1) for line in output.read_text().splitlines())
+            self.assertEqual(values, {"diff_base": "", "docs_only": "false",
+                                      "cli_docs": "false", "docs_touched": "true"})
+            sdks = subprocess.check_output([sys.executable, str(ROOT / "scripts/ci/sdk_changes.py"),
+                                            values["diff_base"]], cwd=root, text=True)
+            self.assertEqual(set(sdks.splitlines()),
+                             {"sdk_" + job.removesuffix("-sdk") + "=true" for job in SDK_JOBS})
+
+    def test_both_gates_reject_partial_manual_plans(self):
+        original = plan("workflow_dispatch")
+        mutations = [("docs_only", "true"), ("docs_touched", "false")]
+        mutations += [("sdk_" + job.removesuffix("-sdk"), "false") for job in SDK_JOBS]
+        for key, value in mutations:
+            needs = copy.deepcopy(original)
+            needs["changes"]["outputs"][key] = value
+            if key == "docs_only":
+                for job in FULL_JOBS - SDK_JOBS:
+                    needs[job]["result"] = "skipped"
+                needs["docs"]["result"] = "success"
+                needs["docs-prose"]["result"] = "skipped"
+            elif key == "docs_touched":
+                needs["docs-prose"]["result"] = "skipped"
+            else:
+                needs[key.removeprefix("sdk_") + "-sdk"]["result"] = "skipped"
+            with self.subTest(key=key):
+                with self.assertRaisesRegex(ValueError, "manual CI must select the complete plan"):
+                    validate("workflow_dispatch", needs)
+                with self.assertRaisesRegex(ValueError, "manual CI must select the complete plan"):
+                    validate_sdks("workflow_dispatch", {name: state for name, state in needs.items()
+                                                       if name in SDK_GATE_JOBS})
+
+    def test_full_manual_gate_can_publish_tested_tree_evidence(self):
+        needs = plan("workflow_dispatch")
+        with tempfile.TemporaryDirectory() as directory:
+            result = subprocess.run([sys.executable, str(ROOT / "scripts/ci/gate.py")], cwd=directory,
+                                    capture_output=True, text=True,
+                                    env=dict(os.environ, GITHUB_EVENT_NAME="workflow_dispatch",
+                                             CI_NEEDS=json.dumps(needs)))
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual((Path(directory) / "tested-tree.txt").read_text(), "a" * 40 + "\n")

--- a/scripts/ci/test_gate.py
+++ b/scripts/ci/test_gate.py
@@ -6,10 +6,12 @@ import unittest
 from gate import FULL_JOBS, JOBS, PROBES, SDK_JOBS, validate
 
 
-EVENTS = ("pull_request", "push", "merge_group")
+EVENTS = ("pull_request", "push", "merge_group", "workflow_dispatch")
 
 
 def plan(event="pull_request", docs=False, touched=False, reuse=False, sdks=None):
+    if event == "workflow_dispatch":
+        docs, touched, sdks = False, True, SDK_JOBS
     if sdks is None:
         sdks = set() if docs else SDK_JOBS
     if event == "push":
@@ -61,7 +63,7 @@ class GateTest(unittest.TestCase):
         self.assertEqual(declared, set(PROBES))
 
     def test_all_supported_plans(self):
-        for event, options in [("pull_request", {}), ("pull_request", {"docs": True}),
+        for event, options in [("workflow_dispatch", {}), ("pull_request", {}), ("pull_request", {"docs": True}),
                                ("pull_request", {"touched": True}), ("push", {}),
                                ("push", {"reuse": True}), ("merge_group", {}),
                                ("merge_group", {"docs": True}), ("merge_group", {"touched": True}),
@@ -70,7 +72,7 @@ class GateTest(unittest.TestCase):
                 validate(event, plan(event, **options))
 
     def test_every_required_job_rejects_failure_cancel_and_skip(self):
-        for event, options in [("pull_request", {"touched": True}), ("pull_request", {"docs": True}),
+        for event, options in [("workflow_dispatch", {}), ("pull_request", {"touched": True}), ("pull_request", {"docs": True}),
                                ("push", {}), ("push", {"reuse": True}),
                                ("merge_group", {"touched": True}), ("merge_group", {"docs": True}),
                                ("merge_group", {"reuse": True})]:
@@ -95,7 +97,7 @@ class GateTest(unittest.TestCase):
                         validate(event, jobs)
 
     def test_missing_classification_or_tree_is_not_a_docs_skip(self):
-        for event in ("pull_request", "merge_group"):
+        for event in ("pull_request", "merge_group", "workflow_dispatch"):
             for key in ("docs_only", "docs_touched", "cli_docs", "tree"):
                 jobs = plan(event, docs=True)
                 del jobs["changes"]["outputs"][key]
@@ -130,4 +132,4 @@ class GateTest(unittest.TestCase):
 
     def test_unsupported_event_is_rejected(self):
         with self.assertRaises(ValueError):
-            validate("workflow_dispatch", plan("pull_request"))
+            validate("unknown_event", plan("pull_request"))

--- a/scripts/ci/test_sdk_gate.py
+++ b/scripts/ci/test_sdk_gate.py
@@ -13,6 +13,7 @@ from test_gate import plan
 
 
 CASES = [
+    ("workflow_dispatch", {}),
     ("pull_request", {}), ("pull_request", {"docs": True}),
     ("push", {}), ("push", {"reuse": True}),
     ("merge_group", {}), ("merge_group", {"docs": True}),


### PR DESCRIPTION
Manual CI dispatch now selects the full server and SDK plan, including prose checks. It records the checkout tree but bypasses diff-based selection and tested-tree reuse. The classifier makes this decision before attempting a base fetch.

Both aggregate gates reject a manual plan that skips server tests, prose checks or an SDK. The complete gate may write tested-tree evidence after all required jobs pass; the SDK-only gate still cannot publish whole-tree evidence.

Stack: based on #1989. Refs #1413. Minimum-runtime and native SDK check coverage remain follow-ups. No releases, merges or branch-rule changes.

Validation:
- All 45 CI policy tests passed, including the actual embedded shell classifier, SDK classifier and complete gate CLI.
- Manual dispatch participates in failed/cancelled/skipped-job and missing-probe coverage. Partial manual plans fail even when job results match the attempted reduced selection.
- The embedded-shell test verifies dispatch never invokes Git to fetch or classify a base.
- Actionlint passes with shellcheck disabled. Changed documentation passes destink and has no new repository-style findings.
- Full `mix precommit` passed: core 5,375 tests + 6 doctests, Buzz 144 tests and Support 33 tests, all with zero failures.

Timing and runner jobs:
- Manual dispatch uses the existing maximum full mixed PR plan of 23 executed jobs, with changes active and the reuse probe skipped. Existing PR/main/merge-group selection is unchanged.
- Parent #1989 completed CI in 260 seconds with 23 executed jobs. [This draft’s successful PR run](https://github.com/managoat/fountain/actions/runs/34644866883) took 248 seconds with 23 executed jobs. Single-run comparisons have different cache conditions.
- The manual event was exercised locally through the workflow shell and gate CLI; no GitHub manual run has been triggered.
