### PR TITLE
ci: test Python SDK on declared runtime boundaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -911,7 +911,7 @@ jobs:
         run: mix test test/conformance_test.exs
 
   python-sdk:
-    name: Python SDK
+    name: Python SDK (${{ matrix.python }})
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     needs: [already-tested, changes]
@@ -921,27 +921,37 @@ jobs:
     permissions:
       contents: read
 
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ["3.9", "3.13"]
+
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
 
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: ${{ matrix.python }}
+
       - name: SDK conformance scenarios are well formed
-        run: python3 sdk/conformance/lint.py
+        run: python sdk/conformance/lint.py
 
       # The Python SDK is deliberately stdlib-only, so its source tests run
-      # on the same interpreter without an install step.
+      # on the minimum and newest declared runtimes without a package install.
       - name: Python SDK tests
-        run: python3 -m unittest discover -s sdk/python/tests -v
+        run: python -m unittest discover -s sdk/python/tests -v
 
       - name: Python SDK compiles
-        run: python3 -m compileall -q sdk/python/src sdk/python/scripts
+        run: python -m compileall -q sdk/python/src sdk/python/scripts
 
       - name: Python SDK contract
         working-directory: sdk/python
-        run: python3 scripts/verify_contract.py
+        run: python scripts/verify_contract.py
 
       - name: Python SDK conformance
         working-directory: sdk/python
-        run: python3 -m unittest discover -s tests -p "test_conformance.py" -v
+        run: python -m unittest discover -s tests -p "test_conformance.py" -v
 
   typescript-sdk:
     name: TypeScript SDK

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -72,7 +72,7 @@ tested it.
 ### Sizing
 
 `MERGE_QUEUE` in `require-checks.py` explains the queue settings. A full CI
-run now has 23 jobs, compared with the documented limit of 20 concurrent
+run now has 24 jobs, compared with the documented limit of 20 concurrent
 runners. The queue builds one group at a time and batches up to five PRs. Revisit
 `max_entries_to_build` when the concurrency limit changes.
 
@@ -85,7 +85,9 @@ macOS. Each reads the committed contract; `release-and-contract` checks its
 generation.
 The Elixir job owns its toolchain, cache, formatting, compilation, tests, docs,
 package dry run, contract and conformance checks. The Python job owns its
-tests, compilation, contract and conformance checks. The TypeScript job owns
+tests, compilation, contract and conformance checks on Python 3.9 and 3.13.
+These cover the package minimum and newest declared runtime. Both legs must
+pass; a failure does not cancel the other leg. The TypeScript job owns
 installation, type checks, tests, builds, browser bundling, contract and
 conformance checks. These three extracted jobs lint fixtures before their
 tests. Swift retains its separate conformance test step.

--- a/scripts/ci/require-checks.py
+++ b/scripts/ci/require-checks.py
@@ -19,14 +19,14 @@ def api(path, payload=None, method="PUT"):
 # Sized against this repo's measured CI, not GitHub's defaults.
 #
 # max_entries_to_build: 1 — the org is on the free plan, which allows 20
-# concurrent GitHub-hosted jobs, and ONE full CI run has 23 jobs. Speculating
+# concurrent GitHub-hosted jobs, and ONE full CI run has 24 jobs. Speculating
 # two groups deep cannot run two groups; it queues the second behind the first
 # while also starving every open PR. Raise this only after the concurrency
 # ceiling does.
 #
 # min_entries_to_merge: 2 with a 5 minute wait — batching is the only lever
 # that buys throughput under that same ceiling, because five PRs merged as one
-# group cost one 23-job run instead of five. In a burst the group fills at once
+# group cost one 24-job run instead of five. In a burst the group fills at once
 # and nothing waits; in a quiet hour a lone PR waits up to five minutes, which
 # is the hour where nobody is blocked on it.
 #

--- a/scripts/ci/test_python_sdk_matrix.py
+++ b/scripts/ci/test_python_sdk_matrix.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+import re
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class PythonSDKMatrixTest(unittest.TestCase):
+    def test_supported_runtime_boundaries_run_all_existing_checks(self):
+        metadata = (ROOT / "sdk/python/pyproject.toml").read_text()
+        minimum = re.search(r'requires-python = ">=([0-9.]+)"', metadata)[1]
+        declared = re.findall(r'Programming Language :: Python :: ([0-9]+\.[0-9]+)"', metadata)
+        newest = max(declared, key=lambda version: tuple(map(int, version.split("."))))
+        workflow = (ROOT / ".github/workflows/ci.yml").read_text()
+        job = workflow.split("\n  python-sdk:\n", 1)[1].split("\n  typescript-sdk:\n", 1)[0]
+        versions = re.findall(r'"([0-9.]+)"', re.search(r"        python: \[(.*)\]", job)[1])
+        self.assertIn(minimum, versions)
+        self.assertIn(newest, versions)
+        self.assertIn("fail-fast: false", job)
+        self.assertIn("name: Python SDK (${{ matrix.python }})", job)
+        self.assertIn("python-version: ${{ matrix.python }}", job)
+        self.assertLess(job.index("name: Set up Python"), job.index("python sdk/conformance/lint.py"))
+        for command in ("python sdk/conformance/lint.py",
+                        "python -m unittest discover -s sdk/python/tests -v",
+                        "python -m compileall -q sdk/python/src sdk/python/scripts",
+                        "python scripts/verify_contract.py",
+                        'python -m unittest discover -s tests -p "test_conformance.py" -v'):
+            self.assertIn("run: " + command, job)
+        # No step-level condition can drop a check on the minimum runtime.
+        self.assertNotIn("        if:", job)

--- a/scripts/ci/test_require_checks.py
+++ b/scripts/ci/test_require_checks.py
@@ -75,7 +75,7 @@ class RequiredChecksTest(unittest.TestCase):
         self.assertEqual(contexts, ["CI required", "Detect secrets"])
 
     def test_the_queue_cannot_outrun_the_free_plan_job_ceiling(self):
-        """One full CI run has 23 jobs; the documented concurrency limit is 20.
+        """One full CI run has 24 jobs; the documented concurrency limit is 20.
 
         Building more than one group at a time cannot run them in parallel; it
         only starves every open PR of runners.


### PR DESCRIPTION
The Python SDK CI job now tests Python 3.9 and 3.13, the package minimum and newest declared runtime. Each leg runs fixture lint, tests, compilation, contract and conformance checks. Fail-fast is disabled so both results remain visible, and the existing SDK aggregate requires the whole matrix to pass.

The interpreter is selected before fixture lint, using the setup-python action already pinned in the Python publish workflow. SDK source, dependencies, release behavior and path selection are unchanged. Queue sizing comments now account for the extra leg; queue settings are unchanged.

Stack: based on #1990. Refs #1413. Packaging/format coverage and the other SDKs’ runtime gaps remain separate follow-ups.

Validation:
- Python 3.9.6 and 3.13.15 each passed all 43 SDK tests, shared fixture lint (24 scenarios), compilation and the contract check (67 operations, 41 schemas, 4 enums).
- All 46 CI policy tests passed, including a check that the minimum and newest runtime declared in pyproject.toml remain covered and both run every existing check.
- Actionlint passes with shellcheck disabled. Changed documentation passes destink and has no new repository-style findings.
- Full `mix precommit` passed: core 5,375 tests + 6 doctests, Buzz 144 tests and Support 33 tests, all with zero failures.

Timing and runner jobs:
- A full mixed PR or manual plan grows from 23 to 24 executed jobs. Changes that do not select Python still skip the entire matrix.
- Parent #1990 completed CI in 248 seconds with 23 executed jobs. [This draft’s successful CI run](https://github.com/managoat/fountain/actions/runs/34645529559) took 254 seconds with 24 executed jobs. [Python 3.9](https://github.com/managoat/fountain/actions/runs/34645529559/job/103415319751) took 29 seconds and [Python 3.13](https://github.com/managoat/fountain/actions/runs/34645529559/job/103415319740) took 23 seconds. Single-run comparisons have different cache conditions.
