### PR TITLE
ci: test TypeScript SDK on the minimum Node runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -954,7 +954,7 @@ jobs:
         run: python -m unittest discover -s tests -p "test_conformance.py" -v
 
   typescript-sdk:
-    name: TypeScript SDK
+    name: TypeScript SDK (${{ matrix.node }})
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     needs: [already-tested, changes]
@@ -964,20 +964,24 @@ jobs:
     permissions:
       contents: read
 
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ["20.19.0", "24"]
+
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
 
       - name: SDK conformance scenarios are well formed
         run: python3 sdk/conformance/lint.py
 
-      # The TypeScript SDK (sdk/typescript). Node runs the .ts sources
-      # directly, so `npm test` needs nothing but the dev dependency on tsc —
-      # which is also what enforces `erasableSyntaxOnly`, the setting that
-      # keeps those sources runnable without a build step.
+      # Node 24 runs the TypeScript test sources directly. The minimum
+      # runtime runs JavaScript compiled from those same tests. Both legs
+      # typecheck, build and verify the SDK contract and browser bundle.
       - name: Set up Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 24
+          node-version: ${{ matrix.node }}
           cache: npm
           cache-dependency-path: sdk/typescript/package-lock.json
 
@@ -1006,7 +1010,13 @@ jobs:
         working-directory: sdk/typescript
         run: npm run typecheck
 
+      - name: SDK tests on the minimum runtime
+        if: ${{ matrix.node == '20.19.0' }}
+        working-directory: sdk/typescript
+        run: node scripts/test-compiled.mjs
+
       - name: SDK tests
+        if: ${{ matrix.node == '24' }}
         working-directory: sdk/typescript
         run: npm test
 
@@ -1024,7 +1034,13 @@ jobs:
         working-directory: sdk/typescript
         run: npm run verify-contract
 
+      - name: TypeScript SDK conformance on the minimum runtime
+        if: ${{ matrix.node == '20.19.0' }}
+        working-directory: sdk/typescript
+        run: node scripts/test-compiled.mjs --conformance
+
       - name: TypeScript SDK conformance
+        if: ${{ matrix.node == '24' }}
         working-directory: sdk/typescript
         run: npm run conformance
 

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -71,9 +71,10 @@ tested it.
 
 ### Sizing
 
-`MERGE_QUEUE` in `require-checks.py` explains the queue settings. A full CI
-run now has 24 jobs, compared with the documented limit of 20 concurrent
-runners. The queue builds one group at a time and batches up to five PRs. Revisit
+`MERGE_QUEUE` in `require-checks.py` explains the queue settings. A full mixed
+PR runs 25 jobs; a full merge group runs 26 because both probes run. The
+documented limit is 20 concurrent runners. The queue builds one group at a
+time and batches up to five PRs. Revisit
 `max_entries_to_build` when the concurrency limit changes.
 
 ## SDK jobs
@@ -89,7 +90,10 @@ tests, compilation, contract and conformance checks on Python 3.9 and 3.13.
 These cover the package minimum and newest declared runtime. Both legs must
 pass; a failure does not cancel the other leg. The TypeScript job owns
 installation, type checks, tests, builds, browser bundling, contract and
-conformance checks. These three extracted jobs lint fixtures before their
+conformance checks on Node 20.19.0 and 24. The minimum runtime runs compiled
+JavaScript from the same test sources in a temporary fixture tree. Node 24
+retains native TypeScript tests. Both legs build the SDK and browser bundle.
+These three extracted jobs lint fixtures before their
 tests. Swift retains its separate conformance test step.
 `CI required` requires every selected SDK job. A failed, cancelled or
 unexpectedly skipped job fails the gate. Main runs all SDKs unless a verified

--- a/scripts/ci/require-checks.py
+++ b/scripts/ci/require-checks.py
@@ -19,14 +19,15 @@ def api(path, payload=None, method="PUT"):
 # Sized against this repo's measured CI, not GitHub's defaults.
 #
 # max_entries_to_build: 1 — the org is on the free plan, which allows 20
-# concurrent GitHub-hosted jobs, and ONE full CI run has 24 jobs. Speculating
+# concurrent GitHub-hosted jobs. A full mixed PR runs 25 jobs; a merge group
+# runs 26 because both probes run. Speculating
 # two groups deep cannot run two groups; it queues the second behind the first
 # while also starving every open PR. Raise this only after the concurrency
 # ceiling does.
 #
 # min_entries_to_merge: 2 with a 5 minute wait — batching is the only lever
 # that buys throughput under that same ceiling, because five PRs merged as one
-# group cost one 24-job run instead of five. In a burst the group fills at once
+# group cost one 26-job run instead of five. In a burst the group fills at once
 # and nothing waits; in a quiet hour a lone PR waits up to five minutes, which
 # is the hour where nobody is blocked on it.
 #

--- a/scripts/ci/test_require_checks.py
+++ b/scripts/ci/test_require_checks.py
@@ -75,7 +75,7 @@ class RequiredChecksTest(unittest.TestCase):
         self.assertEqual(contexts, ["CI required", "Detect secrets"])
 
     def test_the_queue_cannot_outrun_the_free_plan_job_ceiling(self):
-        """One full CI run has 24 jobs; the documented concurrency limit is 20.
+        """A full merge group has 26 jobs; the documented concurrency limit is 20.
 
         Building more than one group at a time cannot run them in parallel; it
         only starves every open PR of runners.

--- a/scripts/ci/test_typescript_sdk_matrix.py
+++ b/scripts/ci/test_typescript_sdk_matrix.py
@@ -1,0 +1,30 @@
+import json
+from pathlib import Path
+import re
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class TypeScriptSDKMatrixTest(unittest.TestCase):
+    def test_minimum_runtime_uses_compiled_tests_and_current_keeps_native_typescript(self):
+        package = json.loads((ROOT / "sdk/typescript/package.json").read_text())
+        minimum = package["engines"]["node"].removeprefix(">=")
+        workflow = (ROOT / ".github/workflows/ci.yml").read_text()
+        job = workflow.split("\n  typescript-sdk:\n", 1)[1].split("\n  cli-plugins:\n", 1)[0]
+        versions = re.findall(r'"([0-9.]+)"', re.search(r"        node: \[(.*)\]", job)[1])
+        self.assertIn(minimum + ".0", versions)
+        self.assertIn("24", versions)
+        self.assertIn("fail-fast: false", job)
+        self.assertIn("node-version: ${{ matrix.node }}", job)
+        steps = dict(re.findall(r"      - name: ([^\n]+)\n(.*?)(?=      - (?:name:|uses:)|\Z)", job, re.S))
+        for name, command in (("SDK tests", "npm test"), ("TypeScript SDK conformance", "npm run conformance")):
+            self.assertIn("if: ${{ matrix.node == '24' }}", steps[name])
+            self.assertIn("run: " + command, steps[name])
+        for name, command in (("SDK tests on the minimum runtime", "node scripts/test-compiled.mjs"),
+                              ("TypeScript SDK conformance on the minimum runtime", "node scripts/test-compiled.mjs --conformance")):
+            self.assertIn("if: ${{ matrix.node == '" + minimum + ".0' }}", steps[name])
+            self.assertIn("run: " + command, steps[name])
+        for name in ("SDK install", "SDK typecheck", "SDK build", "SDK bundles for the browser", "TypeScript SDK contract"):
+            self.assertNotIn("        if:", steps[name])

--- a/sdk/typescript/scripts/test-compiled.mjs
+++ b/sdk/typescript/scripts/test-compiled.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+// Exercise the same tests on runtimes that cannot execute TypeScript directly.
+import { cpSync, mkdirSync, mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { execFileSync, spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const sdk = join(dirname(fileURLToPath(import.meta.url)), "..");
+const mode = process.argv.slice(2);
+if (mode.length > 1 || (mode.length === 1 && mode[0] !== "--conformance")) {
+  throw new Error("usage: node scripts/test-compiled.mjs [--conformance]");
+}
+const temporary = mkdtempSync(join(tmpdir(), "fountain-sdk-tests-"));
+const output = join(temporary, "sdk", "typescript");
+try {
+  mkdirSync(output, { recursive: true });
+  execFileSync(process.execPath, [join(sdk, "node_modules/typescript/lib/tsc.js"),
+    "-p", join(sdk, "tsconfig.json"), "--outDir", output], { cwd: sdk, stdio: "inherit" });
+  // Keep the tests' relative fixture paths and source/package inspections.
+  cpSync(join(sdk, "src"), join(output, "src"), { recursive: true });
+  cpSync(join(sdk, "package.json"), join(output, "package.json"));
+  for (const fixtures of ["conformance", "contract"]) {
+    cpSync(join(sdk, "..", fixtures), join(temporary, "sdk", fixtures), { recursive: true });
+  }
+  const tests = mode.length ? ["conformance.test.js"]
+    : readdirSync(join(output, "test")).filter(name => name.endsWith(".test.js")).sort();
+  if (!tests.length) throw new Error("No compiled SDK tests found");
+  const result = spawnSync(process.execPath, ["--test", ...tests.map(name => join(output, "test", name))],
+    { cwd: output, stdio: "inherit" });
+  if (result.error) throw result.error;
+  process.exitCode = result.status ?? 1;
+} finally {
+  rmSync(temporary, { recursive: true, force: true });
+}


### PR DESCRIPTION
The TypeScript SDK now runs on Node 20.19.0, its declared minimum, as well as Node 24. The minimum leg compiles the existing test sources to JavaScript in a temporary fixture tree. Node 24 retains native TypeScript tests. Both legs run typechecking, builds, browser bundling, contract checks and conformance.

The compiled-test helper preserves relative fixture paths and source/package inspections, forwards a failing test exit status and removes its temporary tree in a finally block. It adds no package dependency or shipped SDK code. Fail-fast is disabled so both runtime results remain visible.

Stack: based on #1991. Refs #1413. Elixir minimum-runtime and remaining native formatting/docs/package coverage stay separate follow-ups. No release or queue-setting changes.

Validation:
- Node 20.19.0 and Node 24.21.0 each passed 109 SDK tests, the separate 24-scenario conformance check, typechecking, build, contract verification (73 operations, 49 schemas, 5 enums) and browser bundling.
- An injected failing test in an isolated SDK copy returned exit 1 and left no temporary fixture tree.
- All 47 CI policy tests passed, including minimum-version agreement with package.json, retained Node 24 native checks and unconditional build/contract checks on both legs.
- Actionlint passes with shellcheck disabled. Changed documentation passes destink and has no new repository-style findings. The SDK release guard confirms no release is required.
- Full `mix precommit` passed: core 5,375 tests + 6 doctests, Buzz 144 tests and Support 33 tests, all with zero failures.

Timing and runner jobs:
- Full mixed PR/manual plans grow from 24 to 25 jobs. Full merge groups grow from 25 to 26 because both probes run; queue-sizing comments now distinguish these counts. Unselected TypeScript changes still skip both matrix legs.
- Parent #1991 completed CI in 254 seconds with 24 executed jobs. [This draft’s successful CI run](https://github.com/managoat/fountain/actions/runs/34646356505) took 264 seconds with 25 executed jobs. [TypeScript SDK (24)](https://github.com/managoat/fountain/actions/runs/34646356505/job/103418013146) took 23 seconds; [TypeScript SDK (20.19.0)](https://github.com/managoat/fountain/actions/runs/34646356505/job/103418013253) took 25 seconds. Single-run comparisons have different cache conditions.
