### PR TITLE
ci: test Elixir SDK on its minimum supported runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -839,7 +839,7 @@ jobs:
           fi
 
   elixir-sdk:
-    name: Elixir SDK
+    name: Elixir SDK (${{ matrix.elixir }} / OTP ${{ matrix.otp }})
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     needs: [already-tested, changes]
@@ -853,6 +853,15 @@ jobs:
     env:
       MIX_ENV: test
 
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - elixir: "1.15.8"
+            otp: "26.2.5.21"
+          - elixir: "1.19.2"
+            otp: "28.3"
+
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
 
@@ -863,8 +872,8 @@ jobs:
         id: beam
         uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1.24.1
         with:
-          elixir-version: "1.19.2"
-          otp-version: "28.3"
+          elixir-version: ${{ matrix.elixir }}
+          otp-version: ${{ matrix.otp }}
 
       # The Elixir SDK is a standalone Mix project. Keep its dependency graph
       # and build artifacts separate from the umbrella's cache.
@@ -882,7 +891,10 @@ jobs:
         working-directory: sdk/elixir
         run: MIX_ENV=dev mix deps.get
 
+      # Formatter output changes across Elixir versions. The current
+      # toolchain owns style; both pairs check runtime compatibility.
       - name: Elixir SDK formatting
+        if: ${{ matrix.elixir == '1.19.2' }}
         working-directory: sdk/elixir
         run: mix format --check-formatted
 

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -72,7 +72,7 @@ tested it.
 ### Sizing
 
 `MERGE_QUEUE` in `require-checks.py` explains the queue settings. A full mixed
-PR runs 25 jobs; a full merge group runs 26 because both probes run. The
+PR runs 26 jobs; a full merge group runs 27 because both probes run. The
 documented limit is 20 concurrent runners. The queue builds one group at a
 time and batches up to five PRs. Revisit
 `max_entries_to_build` when the concurrency limit changes.
@@ -85,7 +85,10 @@ The Elixir, Python and TypeScript SDKs run in `elixir-sdk`, `python-sdk` and
 macOS. Each reads the committed contract; `release-and-contract` checks its
 generation.
 The Elixir job owns its toolchain, cache, formatting, compilation, tests, docs,
-package dry run, contract and conformance checks. The Python job owns its
+package dry run, contract and conformance checks. It tests Elixir 1.15.8
+with OTP 26.2.5.21 and Elixir 1.19.2 with OTP 28.3. Formatting uses 1.19.2
+because formatter output differs between versions; all remaining checks run
+on both pairs. The Python job owns its
 tests, compilation, contract and conformance checks on Python 3.9 and 3.13.
 These cover the package minimum and newest declared runtime. Both legs must
 pass; a failure does not cancel the other leg. The TypeScript job owns

--- a/scripts/ci/require-checks.py
+++ b/scripts/ci/require-checks.py
@@ -19,15 +19,15 @@ def api(path, payload=None, method="PUT"):
 # Sized against this repo's measured CI, not GitHub's defaults.
 #
 # max_entries_to_build: 1 — the org is on the free plan, which allows 20
-# concurrent GitHub-hosted jobs. A full mixed PR runs 25 jobs; a merge group
-# runs 26 because both probes run. Speculating
+# concurrent GitHub-hosted jobs. A full mixed PR runs 26 jobs; a merge group
+# runs 27 because both probes run. Speculating
 # two groups deep cannot run two groups; it queues the second behind the first
 # while also starving every open PR. Raise this only after the concurrency
 # ceiling does.
 #
 # min_entries_to_merge: 2 with a 5 minute wait — batching is the only lever
 # that buys throughput under that same ceiling, because five PRs merged as one
-# group cost one 26-job run instead of five. In a burst the group fills at once
+# group cost one 27-job run instead of five. In a burst the group fills at once
 # and nothing waits; in a quiet hour a lone PR waits up to five minutes, which
 # is the hour where nobody is blocked on it.
 #

--- a/scripts/ci/test_elixir_sdk_matrix.py
+++ b/scripts/ci/test_elixir_sdk_matrix.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+import re
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class ElixirSDKMatrixTest(unittest.TestCase):
+    def test_minimum_runtime_and_current_formatter_keep_complete_sdk_checks(self):
+        project = (ROOT / "sdk/elixir/mix.exs").read_text()
+        minimum = re.search(r'elixir: "~> ([0-9.]+)"', project)[1]
+        workflow = (ROOT / ".github/workflows/ci.yml").read_text()
+        job = workflow.split("\n  elixir-sdk:\n", 1)[1].split("\n  python-sdk:\n", 1)[0]
+        pairs = re.findall(r'          - elixir: "([0-9.]+)"\n            otp: "([0-9.]+)"', job)
+        self.assertTrue(any(version.startswith(minimum + ".") for version, _ in pairs))
+        self.assertIn(("1.19.2", "28.3"), pairs)
+        self.assertIn("fail-fast: false", job)
+        self.assertIn("elixir-version: ${{ matrix.elixir }}", job)
+        self.assertIn("otp-version: ${{ matrix.otp }}", job)
+        self.assertIn("steps.beam.outputs.otp-version", job)
+        self.assertIn("steps.beam.outputs.elixir-version", job)
+        steps = dict(re.findall(r"      - name: ([^\n]+)\n(.*?)(?=      - (?:name:|uses:)|\Z)", job, re.S))
+        self.assertIn("if: ${{ matrix.elixir == '1.19.2' }}", steps["Elixir SDK formatting"])
+        self.assertIn("run: mix format --check-formatted", steps["Elixir SDK formatting"])
+        for name in ("Elixir SDK dependencies", "Elixir SDK compile", "Elixir SDK tests",
+                     "Elixir SDK documentation", "Elixir SDK package dry run",
+                     "Elixir SDK contract", "Elixir SDK conformance"):
+            self.assertNotIn("        if:", steps[name])

--- a/scripts/ci/test_require_checks.py
+++ b/scripts/ci/test_require_checks.py
@@ -75,7 +75,7 @@ class RequiredChecksTest(unittest.TestCase):
         self.assertEqual(contexts, ["CI required", "Detect secrets"])
 
     def test_the_queue_cannot_outrun_the_free_plan_job_ceiling(self):
-        """A full merge group has 26 jobs; the documented concurrency limit is 20.
+        """A full merge group has 27 jobs; the documented concurrency limit is 20.
 
         Building more than one group at a time cannot run them in parallel; it
         only starves every open PR of runners.


### PR DESCRIPTION
The Elixir SDK now checks its minimum supported minor version alongside the current toolchain: Elixir 1.15.8 with OTP 26.2.5.21, and Elixir 1.19.2 with OTP 28.3. Both pairs compile with warnings as errors, run tests, build docs and packages, and verify contract/conformance behavior. Their caches already include both toolchain versions, and fail-fast is disabled.

Formatting stays on Elixir 1.19.2 because the 1.15 formatter produces different layout for existing guards and other expressions. Minimum-runtime compatibility therefore does not impose conflicting formatting rules.

Stack: based on #1992. Refs #1413. Remaining native formatting/docs/package coverage for the other SDKs stays separate. SDK source, package versions, dependency versions and queue settings are unchanged.

Validation:
- Both toolchains passed 52 SDK tests, the separate contract test and 24 conformance scenarios, warnings-as-errors compilation, docs generation and package creation. Current-toolchain formatting also passed.
- Minimum checks ran in a disposable official Elixir container pinned by digest, with CA certificates installed and read-only source mounts. The exact OTP patch version and its Ubuntu CI build availability were verified.
- The initial minimum-formatter failure is retained as evidence for keeping formatting on the current toolchain. No source was reformatted.
- All 48 CI policy tests passed, including minimum-version agreement, toolchain-specific cache keys and both pairs retaining all non-format checks.
- Actionlint passes with shellcheck disabled. Changed documentation passes destink and has no new repository-style findings.
- Full `mix precommit` passed: core 5,375 tests + 6 doctests, Buzz 144 tests and Support 33 tests, all with zero failures.

Timing and runner jobs:
- Full mixed PR/manual plans grow from 25 to 26 jobs; full merge groups grow from 26 to 27 because both probes run. An unselected Elixir change still skips both legs.
- Parent #1992 completed CI in 264 seconds with 25 executed jobs. [This draft’s successful CI run](https://github.com/managoat/fountain/actions/runs/34647386372) took 244 seconds with 26 executed jobs. [Elixir SDK (1.19.2 / OTP 28.3)](https://github.com/managoat/fountain/actions/runs/34647386372/job/103421362138) took 24 seconds; [Elixir SDK (1.15.8 / OTP 26.2.5.21)](https://github.com/managoat/fountain/actions/runs/34647386372/job/103421362161) took 50 seconds. Single-run comparisons have different cache conditions.
