### PR TITLE
ci: test the built Python SDK wheel in isolation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -949,11 +949,8 @@ jobs:
       - name: SDK conformance scenarios are well formed
         run: python sdk/conformance/lint.py
 
-      # The Python SDK is deliberately stdlib-only, so its source tests run
-      # on the minimum and newest declared runtimes without a package install.
-      - name: Python SDK tests
-        run: python -m unittest discover -s sdk/python/tests -v
-
+      # The SDK has no runtime dependencies. Check source syntax and wire
+      # assumptions, then exercise the built distribution below.
       - name: Python SDK compiles
         run: python -m compileall -q sdk/python/src sdk/python/scripts
 
@@ -964,6 +961,15 @@ jobs:
       - name: Python SDK conformance
         working-directory: sdk/python
         run: python -m unittest discover -s tests -p "test_conformance.py" -v
+
+      - name: Python SDK build tool
+        run: python -m pip install --disable-pip-version-check build
+
+      - name: Python SDK package dry run
+        run: python -m build --outdir "$RUNNER_TEMP/python-sdk-dist" sdk/python
+
+      - name: Python SDK installed wheel
+        run: python sdk/python/scripts/verify_wheel.py "$RUNNER_TEMP"/python-sdk-dist/*.whl
 
   typescript-sdk:
     name: TypeScript SDK (${{ matrix.node }})

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -90,6 +90,11 @@ with OTP 26.2.5.21 and Elixir 1.19.2 with OTP 28.3. Formatting uses 1.19.2
 because formatter output differs between versions; all remaining checks run
 on both pairs. The Python job owns its
 tests, compilation, contract and conformance checks on Python 3.9 and 3.13.
+Both legs also build an sdist and wheel, install the wheel in a fresh virtual
+environment and run the SDK regression suite against that installed package.
+This replaces the full source-tree test run; separate contract and conformance
+steps retain their focused diagnostics.
+The verifier checks the type marker, package version and every SDK import path.
 These cover the package minimum and newest declared runtime. Both legs must
 pass; a failure does not cancel the other leg. The TypeScript job owns
 installation, type checks, tests, builds, browser bundling, contract and

--- a/scripts/ci/test_python_sdk_matrix.py
+++ b/scripts/ci/test_python_sdk_matrix.py
@@ -7,7 +7,7 @@ ROOT = Path(__file__).resolve().parents[2]
 
 
 class PythonSDKMatrixTest(unittest.TestCase):
-    def test_supported_runtime_boundaries_run_all_existing_checks(self):
+    def test_supported_runtime_boundaries_run_complete_sdk_checks(self):
         metadata = (ROOT / "sdk/python/pyproject.toml").read_text()
         minimum = re.search(r'requires-python = ">=([0-9.]+)"', metadata)[1]
         declared = re.findall(r'Programming Language :: Python :: ([0-9]+\.[0-9]+)"', metadata)
@@ -22,10 +22,12 @@ class PythonSDKMatrixTest(unittest.TestCase):
         self.assertIn("python-version: ${{ matrix.python }}", job)
         self.assertLess(job.index("name: Set up Python"), job.index("python sdk/conformance/lint.py"))
         for command in ("python sdk/conformance/lint.py",
-                        "python -m unittest discover -s sdk/python/tests -v",
                         "python -m compileall -q sdk/python/src sdk/python/scripts",
                         "python scripts/verify_contract.py",
-                        'python -m unittest discover -s tests -p "test_conformance.py" -v'):
+                        'python -m unittest discover -s tests -p "test_conformance.py" -v',
+                        'python -m pip install --disable-pip-version-check build',
+                        'python -m build --outdir "$RUNNER_TEMP/python-sdk-dist" sdk/python',
+                        'python sdk/python/scripts/verify_wheel.py "$RUNNER_TEMP"/python-sdk-dist/*.whl'):
             self.assertIn("run: " + command, job)
         # No step-level condition can drop a check on the minimum runtime.
         self.assertNotIn("        if:", job)

--- a/sdk/python/scripts/verify_wheel.py
+++ b/sdk/python/scripts/verify_wheel.py
@@ -1,0 +1,57 @@
+"""Install a built wheel in isolation and exercise it with the SDK regression suite."""
+
+import argparse
+from pathlib import Path
+import subprocess
+import tempfile
+import venv
+
+
+RUN_TESTS = """
+from importlib.metadata import version
+from pathlib import Path
+import sys
+import unittest
+
+# Import before discovery: existing tests add src/ to sys.path, but this
+# package and its submodules must resolve from the installed wheel.
+import fountain
+
+package = Path(fountain.__file__).resolve().parent
+if not package.is_relative_to(Path(sys.prefix).resolve()):
+    raise RuntimeError("Fountain did not load from the isolated environment")
+if not (package / "py.typed").is_file():
+    raise RuntimeError("The wheel omitted its py.typed marker")
+if fountain.__version__ != version("fountain-agent-sdk"):
+    raise RuntimeError("Installed package and SDK versions differ")
+print("Testing installed SDK from " + str(package), flush=True)
+suite = unittest.defaultTestLoader.discover(sys.argv[1])
+if not suite.countTestCases():
+    raise RuntimeError("No SDK regression tests were discovered")
+result = unittest.TextTestRunner(verbosity=2).run(suite)
+for name, module in list(sys.modules.items()):
+    if name == "fountain" or name.startswith("fountain."):
+        if not Path(module.__file__).resolve().is_relative_to(package):
+            raise RuntimeError("Test imported SDK source outside the wheel: " + name)
+sys.exit(0 if result.wasSuccessful() else 1)
+"""
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("wheel", type=Path)
+    args = parser.parse_args()
+    wheel = args.wheel.resolve()
+    sdk = Path(__file__).resolve().parents[1]
+    with tempfile.TemporaryDirectory(prefix="fountain-wheel-") as directory:
+        environment = Path(directory) / "venv"
+        venv.EnvBuilder(with_pip=True).create(environment)
+        python = environment / ("Scripts/python.exe" if (environment / "Scripts").exists() else "bin/python")
+        subprocess.run([str(python), "-I", "-m", "pip", "install", "--no-index", "--no-deps",
+                        "--disable-pip-version-check", str(wheel)], check=True, cwd=directory)
+        subprocess.run([str(python), "-I", "-c", RUN_TESTS, str(sdk / "tests")],
+                       check=True, cwd=directory)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Python SDK CI now builds an sdist and wheel on both supported runtime legs, installs the wheel into a fresh virtual environment, and runs all existing SDK regression tests against the installed package. This replaces the full source-tree run. Separate contract and conformance steps retain their focused diagnostics.

The verifier imports the installed package before discovering tests, then checks every loaded SDK module stays inside that package. It also verifies the type marker and distribution version. Installation uses only the local wheel, with no dependency resolution or registry access, and temporary environments are removed on success or failure.

Stack: based on #1993. Refs #1413. No SDK source, version or publishing changes. Remaining formatting and other SDK package/docs checks stay separate.

Validation:
- Python 3.9.6 and 3.13.15 each built an sdist/wheel and passed all 43 SDK tests against an isolated wheel install.
- Damaged wheels missing py.typed or a runtime module were rejected even when source files were supplied through PYTHONPATH; temporary environments were removed.
- A fixture without any checkout SDK sources ran all 43 real tests, propagated one deliberately failing extra test and cleaned its environment.
- All 48 CI policy tests passed. Actionlint passes with shellcheck disabled; changed docs pass destink and have no new repository-style findings.
- Full `mix precommit` passed: core 5,375 tests + 6 doctests, Buzz 144 tests and Support 33 tests, all with zero failures.

Timing and runner jobs:
- Job selection and counts are unchanged: a full mixed PR/manual plan has 26 jobs, and a full merge group has 27.
- Parent #1993 completed CI in 244 seconds with 26 executed jobs. This draft completed CI successfully in 273 seconds with 26 executed jobs. Python 3.9 took 41 seconds; Python 3.13 took 30 seconds (run 34648421953). Single-run comparisons have different cache conditions.
