### PR TITLE
ci: split SDK checks into per-SDK jobs with selective routing (#1413)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         run: bash scripts/ci/already-tested.sh
 
   changes:
-    name: Decide whether this is a docs-only change
+    name: Classify documentation and SDK changes
     # Never on push, and deliberately so. There, `already-tested` above
     # already collapses a rebased squash-merge to a few seconds, and a main
     # push that is NOT already-tested is precisely the case that must run
@@ -90,6 +90,10 @@ jobs:
       docs_touched: ${{ steps.filter.outputs.docs_touched }}
       cli_docs: ${{ steps.filter.outputs.cli_docs }}
       tree: ${{ steps.tree.outputs.tree }}
+      sdk_elixir: ${{ steps.sdks.outputs.sdk_elixir }}
+      sdk_python: ${{ steps.sdks.outputs.sdk_python }}
+      sdk_typescript: ${{ steps.sdks.outputs.sdk_typescript }}
+      sdk_swift: ${{ steps.sdks.outputs.sdk_swift }}
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
@@ -120,8 +124,10 @@ jobs:
           MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
         run: |
           set -u
+          base=""
           decide() {
             {
+              echo "diff_base=${base:-}"
               echo "docs_only=$1"
               echo "cli_docs=$2"
               echo "docs_touched=$3"
@@ -192,6 +198,12 @@ jobs:
 
           echo "docs-only — running the docs job instead of the Elixir suite"
           decide true "${cli_docs}" false
+
+      - name: Select SDKs from the same diff
+        id: sdks
+        env:
+          DIFF_BASE: ${{ steps.filter.outputs.diff_base }}
+        run: python3 scripts/ci/sdk_changes.py "$DIFF_BASE" >> "$GITHUB_OUTPUT"
 
   test:
     name: Build and Test (partition ${{ matrix.partition }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1048,6 +1048,10 @@ jobs:
         working-directory: sdk/typescript
         run: npx --yes esbuild dist/index.js --bundle --platform=browser --format=esm --outfile=/dev/null
 
+      - name: SDK packed artifact
+        working-directory: sdk/typescript
+        run: node scripts/verify-package.mjs
+
       - name: TypeScript SDK contract
         working-directory: sdk/typescript
         run: npm run verify-contract

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -815,8 +815,8 @@ jobs:
             exit 1
           fi
 
-  sdk-clients:
-    name: SDK clients, CLI and plugins
+  elixir-sdk:
+    name: Elixir SDK
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     needs: [already-tested, changes]
@@ -826,18 +826,15 @@ jobs:
     permissions:
       contents: read
 
-    # No umbrella deps/_build cache and no Postgres. Everything here either is
-    # a standalone project (sdk/elixir has its own cache below, cli/ and
-    # apps/fountain_buzz/cli are Go modules) or reads the COMMITTED
-    # sdk/contract/contract.json rather than rebuilding it -- which is the
-    # whole reason that projection is committed. The one job that does rebuild
-    # it is `release-and-contract`, and it fails there if it is stale.
+    # Independent from the umbrella, Postgres and the other SDK toolchains.
     env:
       MIX_ENV: test
 
     steps:
-
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
+
+      - name: SDK conformance scenarios are well formed
+        run: python3 sdk/conformance/lint.py
 
       - name: Set up Elixir
         id: beam
@@ -847,10 +844,7 @@ jobs:
           otp-version: "28.3"
 
       # The Elixir SDK is a standalone Mix project. Keep its dependency graph
-      # and build artifacts separate from this umbrella's -- which also puts
-      # them outside the two caches above, so they need their own entry or
-      # every PR recompiles finch, mint, hpax, ex_doc and makeup from scratch
-      # on the critical path.
+      # and build artifacts separate from the umbrella's cache.
       - name: Restore Elixir SDK cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
         with:
@@ -885,30 +879,6 @@ jobs:
         working-directory: sdk/elixir
         run: MIX_ENV=dev mix hex.build
 
-      # The behavioural half (#1412). sdk/contract pins the shape of the wire;
-      # these scenarios pin what a client does with it — SSE framing, cursor
-      # resume, error mapping, terminal run states. They are one set of JSON
-      # files run by four adapters.
-      #
-      # The lint is not only a format check: it validates every fixture body
-      # against the schema sdk/contract/contract.json declares for that
-      # operation, which is what stops a scenario going green against a
-      # response the real server would never send.
-      #
-      # It runs FIRST, before any adapter. In the job this was split out of it
-      # sat directly above the three conformance runs, which is the same thing
-      # when the order is Elixir, Python, TypeScript throughout. Here the steps
-      # are grouped by language instead, so a malformed fixture would otherwise
-      # fail two adapters with a confusing message before the step that names
-      # the real problem ever ran.
-      - name: SDK conformance scenarios are well formed
-        run: python3 sdk/conformance/lint.py
-
-      # Four separate contract checks rather than a loop, so a failing log line
-      # names the client a contributor has to go and fix. Each reads the
-      # committed contract and its own manifest; none rebuilds the spec, which
-      # `release-and-contract` does. The Swift equivalent runs inside
-      # `swift test` in the swift-sdk job.
       - name: Elixir SDK contract
         working-directory: sdk/elixir
         run: mix test test/contract_test.exs
@@ -916,6 +886,28 @@ jobs:
       - name: Elixir SDK conformance
         working-directory: sdk/elixir
         run: mix test test/conformance_test.exs
+
+  sdk-clients:
+    name: Python/TypeScript SDKs, CLI and plugins
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    needs: [already-tested, changes]
+    if: ${{ !cancelled() && needs.already-tested.outputs.skip != 'true'
+         && needs.changes.outputs.docs_only != 'true' }}
+
+    permissions:
+      contents: read
+
+    # Standalone clients and Go modules read the committed wire contract.
+    # release-and-contract rebuilds it and checks for staleness.
+    steps:
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
+
+      # Validate fixture bodies against the committed contract before either
+      # SDK adapter runs. The Elixir and Swift jobs validate them independently.
+      - name: SDK conformance scenarios are well formed
+        run: python3 sdk/conformance/lint.py
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -1803,6 +1795,7 @@ jobs:
       - elixir-static
       - release-and-contract
       - sdk-clients
+      - elixir-sdk
       - swift-sdk
       - core-distribution
       - compose-fresh-clone

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -798,6 +798,7 @@ jobs:
       # which is also what enforces `erasableSyntaxOnly`, the setting that
       # keeps those sources runnable without a build step.
       - name: Set up Node
+        if: ${{ needs.changes.outputs.sdk_typescript != 'false' }}
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
@@ -807,6 +808,7 @@ jobs:
       # `--no-audit --no-fund`: see the typescript-sdk job, which carries the
       # measurement. Here it is only to make `npm run generate` runnable.
       - name: SDK install
+        if: ${{ needs.changes.outputs.sdk_typescript != 'false' }}
         working-directory: sdk/typescript
         run: npm ci --no-audit --no-fund
 
@@ -817,6 +819,7 @@ jobs:
       # API that drift apart. This is the arm that covers the WHOLE document;
       # the manifest checks below cover what each client reaches for by name.
       - name: SDK types match the spec
+        if: ${{ needs.changes.outputs.sdk_typescript != 'false' }}
         working-directory: sdk/typescript
         run: |
           npm run generate
@@ -833,7 +836,7 @@ jobs:
     timeout-minutes: 15
     needs: [already-tested, changes]
     if: ${{ !cancelled() && needs.already-tested.outputs.skip != 'true'
-         && needs.changes.outputs.docs_only != 'true' }}
+         && needs.changes.outputs.sdk_elixir != 'false' }}
 
     permissions:
       contents: read
@@ -905,7 +908,7 @@ jobs:
     timeout-minutes: 15
     needs: [already-tested, changes]
     if: ${{ !cancelled() && needs.already-tested.outputs.skip != 'true'
-         && needs.changes.outputs.docs_only != 'true' }}
+         && needs.changes.outputs.sdk_python != 'false' }}
 
     permissions:
       contents: read
@@ -938,7 +941,7 @@ jobs:
     timeout-minutes: 15
     needs: [already-tested, changes]
     if: ${{ !cancelled() && needs.already-tested.outputs.skip != 'true'
-         && needs.changes.outputs.docs_only != 'true' }}
+         && needs.changes.outputs.sdk_typescript != 'false' }}
 
     permissions:
       contents: read
@@ -1202,7 +1205,7 @@ jobs:
     timeout-minutes: 10
     needs: [already-tested, changes]
     if: ${{ !cancelled() && needs.already-tested.outputs.skip != 'true'
-         && needs.changes.outputs.docs_only != 'true' }}
+         && needs.changes.outputs.sdk_swift != 'false' }}
 
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
   # The merge queue. Every required check must name this event or the queue
   # waits for a check that never arrives, times out and ejects the PR.
   merge_group:
@@ -78,7 +79,8 @@ jobs:
     # The queue classifies its group for the same reason a PR does: without
     # this, every docs-only merge would run the full Elixir suite on the way
     # in, which is 11% of what lands here.
-    if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group'
+         || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 5
 
@@ -134,6 +136,12 @@ jobs:
             } >> "$GITHUB_OUTPUT"
             exit 0
           }
+
+          # A manual run requests complete validation, without a diff or
+          # tree-reuse shortcut. An empty base selects every SDK too.
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            decide false false true
+          fi
 
           # A merge group already knows the commit it was stacked onto, and
           # there is no base *ref* to fetch: the group branch is transient and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -911,7 +911,7 @@ jobs:
         run: mix test test/conformance_test.exs
 
   python-sdk:
-    name: Python SDK
+    name: Python SDK (${{ matrix.python }})
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     needs: [already-tested, changes]
@@ -921,27 +921,37 @@ jobs:
     permissions:
       contents: read
 
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ["3.9", "3.13"]
+
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
 
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: ${{ matrix.python }}
+
       - name: SDK conformance scenarios are well formed
-        run: python3 sdk/conformance/lint.py
+        run: python sdk/conformance/lint.py
 
       # The Python SDK is deliberately stdlib-only, so its source tests run
-      # on the same interpreter without an install step.
+      # on the minimum and newest declared runtimes without a package install.
       - name: Python SDK tests
-        run: python3 -m unittest discover -s sdk/python/tests -v
+        run: python -m unittest discover -s sdk/python/tests -v
 
       - name: Python SDK compiles
-        run: python3 -m compileall -q sdk/python/src sdk/python/scripts
+        run: python -m compileall -q sdk/python/src sdk/python/scripts
 
       - name: Python SDK contract
         working-directory: sdk/python
-        run: python3 scripts/verify_contract.py
+        run: python scripts/verify_contract.py
 
       - name: Python SDK conformance
         working-directory: sdk/python
-        run: python3 -m unittest discover -s tests -p "test_conformance.py" -v
+        run: python -m unittest discover -s tests -p "test_conformance.py" -v
 
   typescript-sdk:
     name: TypeScript SDK

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -887,8 +887,41 @@ jobs:
         working-directory: sdk/elixir
         run: mix test test/conformance_test.exs
 
+  python-sdk:
+    name: Python SDK
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    needs: [already-tested, changes]
+    if: ${{ !cancelled() && needs.already-tested.outputs.skip != 'true'
+         && needs.changes.outputs.docs_only != 'true' }}
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
+
+      - name: SDK conformance scenarios are well formed
+        run: python3 sdk/conformance/lint.py
+
+      # The Python SDK is deliberately stdlib-only, so its source tests run
+      # on the same interpreter without an install step.
+      - name: Python SDK tests
+        run: python3 -m unittest discover -s sdk/python/tests -v
+
+      - name: Python SDK compiles
+        run: python3 -m compileall -q sdk/python/src sdk/python/scripts
+
+      - name: Python SDK contract
+        working-directory: sdk/python
+        run: python3 scripts/verify_contract.py
+
+      - name: Python SDK conformance
+        working-directory: sdk/python
+        run: python3 -m unittest discover -s tests -p "test_conformance.py" -v
+
   sdk-clients:
-    name: Python/TypeScript SDKs, CLI and plugins
+    name: TypeScript SDK, CLI and plugins
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     needs: [already-tested, changes]
@@ -904,8 +937,8 @@ jobs:
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
 
-      # Validate fixture bodies against the committed contract before either
-      # SDK adapter runs. The Elixir and Swift jobs validate them independently.
+      # Validate fixtures before the TypeScript adapter runs. The other SDK
+      # jobs validate them independently.
       - name: SDK conformance scenarios are well formed
         run: python3 sdk/conformance/lint.py
 
@@ -969,22 +1002,6 @@ jobs:
       # run against an in-process fake Fountain and need nothing installed.
       - name: Hermes plugin tests
         run: python3 -m unittest discover -s integrations/hermes/tests -v
-
-      # The Python SDK is deliberately stdlib-only, so its source tests run
-      # on the same interpreter without an install step.
-      - name: Python SDK tests
-        run: python3 -m unittest discover -s sdk/python/tests -v
-
-      - name: Python SDK compiles
-        run: python3 -m compileall -q sdk/python/src sdk/python/scripts
-
-      - name: Python SDK contract
-        working-directory: sdk/python
-        run: python3 scripts/verify_contract.py
-
-      - name: Python SDK conformance
-        working-directory: sdk/python
-        run: python3 -m unittest discover -s tests -p "test_conformance.py" -v
 
       # The TypeScript SDK (sdk/typescript). Node runs the .ts sources
       # directly, so `npm test` needs nothing but the dev dependency on tsc —
@@ -1796,6 +1813,7 @@ jobs:
       - release-and-contract
       - sdk-clients
       - elixir-sdk
+      - python-sdk
       - swift-sdk
       - core-distribution
       - compose-fresh-clone

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -792,7 +792,7 @@ jobs:
           cache: npm
           cache-dependency-path: sdk/typescript/package-lock.json
 
-      # `--no-audit --no-fund`: see the sdk-clients job, which carries the
+      # `--no-audit --no-fund`: see the typescript-sdk job, which carries the
       # measurement. Here it is only to make `npm run generate` runnable.
       - name: SDK install
         working-directory: sdk/typescript
@@ -920,8 +920,8 @@ jobs:
         working-directory: sdk/python
         run: python3 -m unittest discover -s tests -p "test_conformance.py" -v
 
-  sdk-clients:
-    name: TypeScript SDK, CLI and plugins
+  typescript-sdk:
+    name: TypeScript SDK
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     needs: [already-tested, changes]
@@ -931,16 +931,85 @@ jobs:
     permissions:
       contents: read
 
-    # Standalone clients and Go modules read the committed wire contract.
-    # release-and-contract rebuilds it and checks for staleness.
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
+
+      - name: SDK conformance scenarios are well formed
+        run: python3 sdk/conformance/lint.py
+
+      # The TypeScript SDK (sdk/typescript). Node runs the .ts sources
+      # directly, so `npm test` needs nothing but the dev dependency on tsc —
+      # which is also what enforces `erasableSyntaxOnly`, the setting that
+      # keeps those sources runnable without a build step.
+      - name: Set up Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: sdk/typescript/package-lock.json
+
+      # `--no-audit` is the whole reason this step is not the longest in CI.
+      # `npm ci` runs a vulnerability audit by default, which is one POST to
+      # registry.npmjs.org/-/npm/v1/security/advisories/bulk — and that request
+      # stalls from Actions runners rather than failing fast. Measured on this
+      # lockfile: 35 packages, every tarball fetched in 325ms from a warm
+      # cache, and then `reify:audit Completed in 300202ms`. The step was
+      # taking 88s to 302s depending on how far into npm's 5-minute timeout the
+      # request got, on every PR, and it made this job 426s against 171s for
+      # the slowest test partition. With the flag it is under 5s.
+      #
+      # Nothing is lost, because nothing was gated: `npm ci` does not fail on
+      # advisories, so this could only ever print "found 0 vulnerabilities"
+      # into a log. What DOES watch these packages is dependabot, which was
+      # given its two npm ecosystems in the same change that added this flag --
+      # before that the audit line was the only npm advisory signal in the
+      # repository, and it was one nobody could act on. `--no-fund` suppresses
+      # the funding notice for the same reason: it is output, not a check.
+      - name: SDK install
+        working-directory: sdk/typescript
+        run: npm ci --no-audit --no-fund
+
+      - name: SDK typecheck
+        working-directory: sdk/typescript
+        run: npm run typecheck
+
+      - name: SDK tests
+        working-directory: sdk/typescript
+        run: npm test
+
+      - name: SDK build
+        working-directory: sdk/typescript
+        run: npm run build
+
+      # Eleven browser applications are built on this API, so the SDK's default
+      # entry has to bundle for a browser — no Node built-ins reachable from it.
+      - name: SDK bundles for the browser
+        working-directory: sdk/typescript
+        run: npx --yes esbuild dist/index.js --bundle --platform=browser --format=esm --outfile=/dev/null
+
+      - name: TypeScript SDK contract
+        working-directory: sdk/typescript
+        run: npm run verify-contract
+
+      - name: TypeScript SDK conformance
+        working-directory: sdk/typescript
+        run: npm run conformance
+
+  cli-plugins:
+    name: CLI and plugins
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    needs: [already-tested, changes]
+    if: ${{ !cancelled() && needs.already-tested.outputs.skip != 'true'
+         && needs.changes.outputs.docs_only != 'true' }}
+
+    permissions:
+      contents: read
+
+    # Go CLIs and plugins have no dependency on an SDK build.
     steps:
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
-
-      # Validate fixtures before the TypeScript adapter runs. The other SDK
-      # jobs validate them independently.
-      - name: SDK conformance scenarios are well formed
-        run: python3 sdk/conformance/lint.py
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -1003,66 +1072,13 @@ jobs:
       - name: Hermes plugin tests
         run: python3 -m unittest discover -s integrations/hermes/tests -v
 
-      # The TypeScript SDK (sdk/typescript). Node runs the .ts sources
-      # directly, so `npm test` needs nothing but the dev dependency on tsc —
-      # which is also what enforces `erasableSyntaxOnly`, the setting that
-      # keeps those sources runnable without a build step.
       - name: Set up Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-          cache: npm
-          cache-dependency-path: sdk/typescript/package-lock.json
 
       - name: Deployed-instance runner tests
         run: node --test deployed/test/*.test.mjs
-
-      # `--no-audit` is the whole reason this step is not the longest in CI.
-      # `npm ci` runs a vulnerability audit by default, which is one POST to
-      # registry.npmjs.org/-/npm/v1/security/advisories/bulk — and that request
-      # stalls from Actions runners rather than failing fast. Measured on this
-      # lockfile: 35 packages, every tarball fetched in 325ms from a warm
-      # cache, and then `reify:audit Completed in 300202ms`. The step was
-      # taking 88s to 302s depending on how far into npm's 5-minute timeout the
-      # request got, on every PR, and it made this job 426s against 171s for
-      # the slowest test partition. With the flag it is under 5s.
-      #
-      # Nothing is lost, because nothing was gated: `npm ci` does not fail on
-      # advisories, so this could only ever print "found 0 vulnerabilities"
-      # into a log. What DOES watch these packages is dependabot, which was
-      # given its two npm ecosystems in the same change that added this flag --
-      # before that the audit line was the only npm advisory signal in the
-      # repository, and it was one nobody could act on. `--no-fund` suppresses
-      # the funding notice for the same reason: it is output, not a check.
-      - name: SDK install
-        working-directory: sdk/typescript
-        run: npm ci --no-audit --no-fund
-
-      - name: SDK typecheck
-        working-directory: sdk/typescript
-        run: npm run typecheck
-
-      - name: SDK tests
-        working-directory: sdk/typescript
-        run: npm test
-
-      - name: SDK build
-        working-directory: sdk/typescript
-        run: npm run build
-
-      # Eleven browser applications are built on this API, so the SDK's default
-      # entry has to bundle for a browser — no Node built-ins reachable from it.
-      - name: SDK bundles for the browser
-        working-directory: sdk/typescript
-        run: npx --yes esbuild dist/index.js --bundle --platform=browser --format=esm --outfile=/dev/null
-
-      - name: TypeScript SDK contract
-        working-directory: sdk/typescript
-        run: npm run verify-contract
-
-      - name: TypeScript SDK conformance
-        working-directory: sdk/typescript
-        run: npm run conformance
 
   docs-prose:
     name: Docs prose gates
@@ -1152,7 +1168,7 @@ jobs:
           cache: npm
           cache-dependency-path: scripts/destink/package-lock.json
 
-      # `--no-audit --no-fund`: see the sdk-clients job. The audit request
+      # `--no-audit --no-fund`: see the typescript-sdk job. The audit request
       # stalls for minutes from a runner and can only ever print.
       - name: Install the prose checker
         run: npm ci --prefix scripts/destink --no-audit --no-fund
@@ -1811,7 +1827,8 @@ jobs:
       - coverage
       - elixir-static
       - release-and-contract
-      - sdk-clients
+      - cli-plugins
+      - typescript-sdk
       - elixir-sdk
       - python-sdk
       - swift-sdk

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -949,11 +949,8 @@ jobs:
       - name: SDK conformance scenarios are well formed
         run: python sdk/conformance/lint.py
 
-      # The Python SDK is deliberately stdlib-only, so its source tests run
-      # on the minimum and newest declared runtimes without a package install.
-      - name: Python SDK tests
-        run: python -m unittest discover -s sdk/python/tests -v
-
+      # The SDK has no runtime dependencies. Check source syntax and wire
+      # assumptions, then exercise the built distribution below.
       - name: Python SDK compiles
         run: python -m compileall -q sdk/python/src sdk/python/scripts
 
@@ -964,6 +961,15 @@ jobs:
       - name: Python SDK conformance
         working-directory: sdk/python
         run: python -m unittest discover -s tests -p "test_conformance.py" -v
+
+      - name: Python SDK build tool
+        run: python -m pip install --disable-pip-version-check build
+
+      - name: Python SDK package dry run
+        run: python -m build --outdir "$RUNNER_TEMP/python-sdk-dist" sdk/python
+
+      - name: Python SDK installed wheel
+        run: python sdk/python/scripts/verify_wheel.py "$RUNNER_TEMP"/python-sdk-dist/*.whl
 
   typescript-sdk:
     name: TypeScript SDK (${{ matrix.node }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -954,7 +954,7 @@ jobs:
         run: python -m unittest discover -s tests -p "test_conformance.py" -v
 
   typescript-sdk:
-    name: TypeScript SDK
+    name: TypeScript SDK (${{ matrix.node }})
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     needs: [already-tested, changes]
@@ -964,20 +964,24 @@ jobs:
     permissions:
       contents: read
 
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ["20.19.0", "24"]
+
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
 
       - name: SDK conformance scenarios are well formed
         run: python3 sdk/conformance/lint.py
 
-      # The TypeScript SDK (sdk/typescript). Node runs the .ts sources
-      # directly, so `npm test` needs nothing but the dev dependency on tsc —
-      # which is also what enforces `erasableSyntaxOnly`, the setting that
-      # keeps those sources runnable without a build step.
+      # Node 24 runs the TypeScript test sources directly. The minimum
+      # runtime runs JavaScript compiled from those same tests. Both legs
+      # typecheck, build and verify the SDK contract and browser bundle.
       - name: Set up Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 24
+          node-version: ${{ matrix.node }}
           cache: npm
           cache-dependency-path: sdk/typescript/package-lock.json
 
@@ -1006,7 +1010,13 @@ jobs:
         working-directory: sdk/typescript
         run: npm run typecheck
 
+      - name: SDK tests on the minimum runtime
+        if: ${{ matrix.node == '20.19.0' }}
+        working-directory: sdk/typescript
+        run: node scripts/test-compiled.mjs
+
       - name: SDK tests
+        if: ${{ matrix.node == '24' }}
         working-directory: sdk/typescript
         run: npm test
 
@@ -1024,7 +1034,13 @@ jobs:
         working-directory: sdk/typescript
         run: npm run verify-contract
 
+      - name: TypeScript SDK conformance on the minimum runtime
+        if: ${{ matrix.node == '20.19.0' }}
+        working-directory: sdk/typescript
+        run: node scripts/test-compiled.mjs --conformance
+
       - name: TypeScript SDK conformance
+        if: ${{ matrix.node == '24' }}
         working-directory: sdk/typescript
         run: npm run conformance
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1814,6 +1814,27 @@ jobs:
       - name: Test CI decisions
         run: python3 -m unittest discover -s scripts/ci -p 'test_*.py' -v
 
+  sdk-checks:
+    name: SDK checks
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    if: ${{ always() }}
+    needs:
+      - already-tested
+      - changes
+      - elixir-sdk
+      - python-sdk
+      - typescript-sdk
+      - swift-sdk
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
+        with:
+          persist-credentials: false
+      - name: Every selected SDK check passed
+        env:
+          CI_NEEDS: ${{ toJSON(needs) }}
+        run: python3 scripts/ci/gate.py --sdk
+
   gate:
     name: CI required
     runs-on: ubuntu-24.04
@@ -1823,6 +1844,7 @@ jobs:
       - already-tested
       - changes
       - workflow-checks
+      - sdk-checks
       - test
       - coverage
       - elixir-static

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -839,7 +839,7 @@ jobs:
           fi
 
   elixir-sdk:
-    name: Elixir SDK
+    name: Elixir SDK (${{ matrix.elixir }} / OTP ${{ matrix.otp }})
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     needs: [already-tested, changes]
@@ -853,6 +853,15 @@ jobs:
     env:
       MIX_ENV: test
 
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - elixir: "1.15.8"
+            otp: "26.2.5.21"
+          - elixir: "1.19.2"
+            otp: "28.3"
+
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
 
@@ -863,8 +872,8 @@ jobs:
         id: beam
         uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1.24.1
         with:
-          elixir-version: "1.19.2"
-          otp-version: "28.3"
+          elixir-version: ${{ matrix.elixir }}
+          otp-version: ${{ matrix.otp }}
 
       # The Elixir SDK is a standalone Mix project. Keep its dependency graph
       # and build artifacts separate from the umbrella's cache.
@@ -882,7 +891,10 @@ jobs:
         working-directory: sdk/elixir
         run: MIX_ENV=dev mix deps.get
 
+      # Formatter output changes across Elixir versions. The current
+      # toolchain owns style; both pairs check runtime compatibility.
       - name: Elixir SDK formatting
+        if: ${{ matrix.elixir == '1.19.2' }}
         working-directory: sdk/elixir
         run: mix format --check-formatted
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -491,7 +491,7 @@ retarget is now GitHub's job rather than yours, which removes the trap where a
 stale base merged cleanly into a branch that no longer existed. Land a feature
 as a stack of small chained PRs exactly as before.
 
-`scripts/ci/README.md` documents the three CI events and the queue's sizing;
+`scripts/ci/README.md` documents the four CI events and the queue's sizing;
 `gate.py`'s `PROBES` table is the authority on what each event owes.
 
 ### Coverage

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -72,7 +72,7 @@ tested it.
 ### Sizing
 
 `MERGE_QUEUE` in `require-checks.py` explains the queue settings. A full CI
-run now has 23 jobs, compared with the documented limit of 20 concurrent
+run now has 24 jobs, compared with the documented limit of 20 concurrent
 runners. The queue builds one group at a time and batches up to five PRs. Revisit
 `max_entries_to_build` when the concurrency limit changes.
 
@@ -85,7 +85,9 @@ macOS. Each reads the committed contract; `release-and-contract` checks its
 generation.
 The Elixir job owns its toolchain, cache, formatting, compilation, tests, docs,
 package dry run, contract and conformance checks. The Python job owns its
-tests, compilation, contract and conformance checks. The TypeScript job owns
+tests, compilation, contract and conformance checks on Python 3.9 and 3.13.
+These cover the package minimum and newest declared runtime. Both legs must
+pass; a failure does not cancel the other leg. The TypeScript job owns
 installation, type checks, tests, builds, browser bundling, contract and
 conformance checks. These three extracted jobs lint fixtures before their
 tests. Swift retains its separate conformance test step.

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -103,6 +103,28 @@ SDK job, also update `SDK_JOBS` and the `sdk-checks` dependencies. Run
 `test_gate.py` and `test_sdk_gate.py` to verify their agreement and every
 supported event plan.
 
+## SDK path classification
+
+`changes` reports four `sdk_<language>` outputs from `sdk_changes.py`, using
+its existing PR merge base or merge-group base. Job conditions do not yet
+consume these outputs; SDK execution stays unchanged in this prerequisite.
+
+The classifier selects an SDK for its directory, documentation page or
+registered release tooling. Shared contract and conformance files select all
+SDKs. So do API implementation, build configuration and unregistered paths.
+An explicit allowlist selects none for unrelated docs, console UI, server
+tests and telemetry. Mixed changes select the union of their SDKs.
+
+Invalid bases, failed or empty diffs, malformed paths and undecodable names
+select every SDK. The NUL-delimited Git diff disables rename detection, so a
+move out of an SDK still selects its former owner. Outputs contain only fixed
+keys and boolean values.
+
+Register a new language in `LANGUAGES` and `OWNED_FILES`, expose its workflow
+output, and add routing fixtures in `test_sdk_changes.py`. Register SDK docs
+and checked snippets before the unrelated-docs allowlist. Keep contract
+triggers outside that allowlist; uncertainty must select every SDK.
+
 ## Refresh partition timings
 
 Each partition records all module timings with eight concurrent cases, matching

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -70,12 +70,25 @@ tested it.
 
 ### Sizing
 
-`MERGE_QUEUE` in `require-checks.py` carries the reasoning for each value. The
-binding constraint is the free plan's 20 concurrent GitHub-hosted jobs against
-a full CI run's 19, which is why the queue builds one group at a time and buys
-its throughput by batching up to five PRs into that one group instead.
-Revisit `max_entries_to_build` when the concurrency ceiling changes, not
-before.
+`MERGE_QUEUE` in `require-checks.py` explains the queue settings. A full CI
+run now has 20 jobs, matching the documented concurrent runner limit. The
+queue builds one group at a time and batches up to five PRs. Revisit
+`max_entries_to_build` when the concurrency limit changes.
+
+## SDK jobs
+
+The Elixir SDK runs in `elixir-sdk`, alongside the Python/TypeScript, CLI and
+plugin job (`sdk-clients`). The Swift job (`swift-sdk`) runs on Linux and
+macOS. Each reads the committed contract; `release-and-contract` checks its
+generation.
+The Elixir job owns its toolchain, cache, formatting, compilation, tests, docs,
+package dry run, contract and conformance checks. Its fixture lint runs before
+the tests. `CI required` requires it on every full plan, including main and
+merge groups. A failed, cancelled or unexpectedly skipped job fails the gate.
+
+Per-language path routing remains tracked in #1413. Register a new job in
+`gate.py`'s `FULL_JOBS` and the workflow gate's `needs` list together. Run
+`test_gate.py` to verify their agreement and every supported event plan.
 
 ## Refresh partition timings
 

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -72,7 +72,7 @@ tested it.
 ### Sizing
 
 `MERGE_QUEUE` in `require-checks.py` explains the queue settings. A full mixed
-PR runs 25 jobs; a full merge group runs 26 because both probes run. The
+PR runs 26 jobs; a full merge group runs 27 because both probes run. The
 documented limit is 20 concurrent runners. The queue builds one group at a
 time and batches up to five PRs. Revisit
 `max_entries_to_build` when the concurrency limit changes.
@@ -85,7 +85,10 @@ The Elixir, Python and TypeScript SDKs run in `elixir-sdk`, `python-sdk` and
 macOS. Each reads the committed contract; `release-and-contract` checks its
 generation.
 The Elixir job owns its toolchain, cache, formatting, compilation, tests, docs,
-package dry run, contract and conformance checks. The Python job owns its
+package dry run, contract and conformance checks. It tests Elixir 1.15.8
+with OTP 26.2.5.21 and Elixir 1.19.2 with OTP 28.3. Formatting uses 1.19.2
+because formatter output differs between versions; all remaining checks run
+on both pairs. The Python job owns its
 tests, compilation, contract and conformance checks on Python 3.9 and 3.13.
 These cover the package minimum and newest declared runtime. Both legs must
 pass; a failure does not cancel the other leg. The TypeScript job owns

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -101,6 +101,10 @@ installation, type checks, tests, builds, browser bundling, contract and
 conformance checks on Node 20.19.0 and 24. The minimum runtime runs compiled
 JavaScript from the same test sources in a temporary fixture tree. Node 24
 retains native TypeScript tests. Both legs build the SDK and browser bundle.
+They also pack and install the npm artifact in a temporary consumer project.
+That project typechecks against the published declarations and exercises the
+Node and browser entry points with a fake fetch implementation. It also bundles
+that consumer for a browser, checking the package export conditions.
 These three extracted jobs lint fixtures before their
 tests. Swift retains its separate conformance test step.
 `CI required` requires every selected SDK job. A failed, cancelled or

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -90,6 +90,11 @@ with OTP 26.2.5.21 and Elixir 1.19.2 with OTP 28.3. Formatting uses 1.19.2
 because formatter output differs between versions; all remaining checks run
 on both pairs. The Python job owns its
 tests, compilation, contract and conformance checks on Python 3.9 and 3.13.
+Both legs also build an sdist and wheel, install the wheel in a fresh virtual
+environment and run the SDK regression suite against that installed package.
+This replaces the full source-tree test run; separate contract and conformance
+steps retain their focused diagnostics.
+The verifier checks the type marker, package version and every SDK import path.
 These cover the package minimum and newest declared runtime. Both legs must
 pass; a failure does not cancel the other leg. The TypeScript job owns
 installation, type checks, tests, builds, browser bundling, contract and

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -71,7 +71,7 @@ tested it.
 ### Sizing
 
 `MERGE_QUEUE` in `require-checks.py` explains the queue settings. A full CI
-run now has 22 jobs, compared with the documented limit of 20 concurrent
+run now has 23 jobs, compared with the documented limit of 20 concurrent
 runners. The queue builds one group at a time and batches up to five PRs. Revisit
 `max_entries_to_build` when the concurrency limit changes.
 
@@ -86,13 +86,22 @@ The Elixir job owns its toolchain, cache, formatting, compilation, tests, docs,
 package dry run, contract and conformance checks. The Python job owns its
 tests, compilation, contract and conformance checks. The TypeScript job owns
 installation, type checks, tests, builds, browser bundling, contract and
-conformance checks. Each SDK job validates fixtures before its tests.
+conformance checks. These three extracted jobs lint fixtures before their
+tests. Swift retains its separate conformance test step.
 `CI required` requires all SDK jobs on every full plan, including main and
 merge groups. A failed, cancelled or unexpectedly skipped job fails the gate.
 
+`SDK checks` reports the SDK result even when docs-only classification or a
+previously tested tree skips every SDK leg. It validates the same probe
+outputs as the full gate and rejects missing, failed or unexpectedly skipped
+jobs. `CI required` depends on this aggregate. Only the full gate publishes
+`tested-tree` evidence; passing the SDK gate cannot authorize reuse of a tree.
+
 Per-language path routing remains tracked in #1413. Register a new job in
-`gate.py`'s `FULL_JOBS` and the workflow gate's `needs` list together. Run
-`test_gate.py` to verify their agreement and every supported event plan.
+`gate.py`'s `FULL_JOBS` and the workflow gate's `needs` list together. For an
+SDK job, also update `SDK_JOBS` and the `sdk-checks` dependencies. Run
+`test_gate.py` and `test_sdk_gate.py` to verify their agreement and every
+supported event plan.
 
 ## Refresh partition timings
 

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -71,19 +71,20 @@ tested it.
 ### Sizing
 
 `MERGE_QUEUE` in `require-checks.py` explains the queue settings. A full CI
-run now has 20 jobs, matching the documented concurrent runner limit. The
-queue builds one group at a time and batches up to five PRs. Revisit
+run now has 21 jobs, compared with the documented limit of 20 concurrent
+runners. The queue builds one group at a time and batches up to five PRs. Revisit
 `max_entries_to_build` when the concurrency limit changes.
 
 ## SDK jobs
 
-The Elixir SDK runs in `elixir-sdk`, alongside the Python/TypeScript, CLI and
-plugin job (`sdk-clients`). The Swift job (`swift-sdk`) runs on Linux and
+The Elixir and Python SDKs run in `elixir-sdk` and `python-sdk`, alongside
+the TypeScript, CLI and plugin job (`sdk-clients`). The Swift job (`swift-sdk`) runs on Linux and
 macOS. Each reads the committed contract; `release-and-contract` checks its
 generation.
 The Elixir job owns its toolchain, cache, formatting, compilation, tests, docs,
-package dry run, contract and conformance checks. Its fixture lint runs before
-the tests. `CI required` requires it on every full plan, including main and
+package dry run, contract and conformance checks. The Python job owns its
+tests, compilation, contract and conformance checks. Both jobs validate
+fixtures before their tests. `CI required` requires both on every full plan, including main and
 merge groups. A failed, cancelled or unexpectedly skipped job fails the gate.
 
 Per-language path routing remains tracked in #1413. Register a new job in

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -88,8 +88,9 @@ tests, compilation, contract and conformance checks. The TypeScript job owns
 installation, type checks, tests, builds, browser bundling, contract and
 conformance checks. These three extracted jobs lint fixtures before their
 tests. Swift retains its separate conformance test step.
-`CI required` requires all SDK jobs on every full plan, including main and
-merge groups. A failed, cancelled or unexpectedly skipped job fails the gate.
+`CI required` requires every selected SDK job. A failed, cancelled or
+unexpectedly skipped job fails the gate. Main runs all SDKs unless a verified
+tested tree authorizes reuse.
 
 `SDK checks` reports the SDK result even when docs-only classification or a
 previously tested tree skips every SDK leg. It validates the same probe
@@ -97,7 +98,7 @@ outputs as the full gate and rejects missing, failed or unexpectedly skipped
 jobs. `CI required` depends on this aggregate. Only the full gate publishes
 `tested-tree` evidence; passing the SDK gate cannot authorize reuse of a tree.
 
-Per-language path routing remains tracked in #1413. Register a new job in
+Register a new job in
 `gate.py`'s `FULL_JOBS` and the workflow gate's `needs` list together. For an
 SDK job, also update `SDK_JOBS` and the `sdk-checks` dependencies. Run
 `test_gate.py` and `test_sdk_gate.py` to verify their agreement and every
@@ -106,14 +107,22 @@ supported event plan.
 ## SDK path classification
 
 `changes` reports four `sdk_<language>` outputs from `sdk_changes.py`, using
-its existing PR merge base or merge-group base. Job conditions do not yet
-consume these outputs; SDK execution stays unchanged in this prerequisite.
+its existing PR merge base or merge-group base. Each SDK job consumes its
+own output. The two gates independently validate the selection and exact job
+results. Missing or malformed outputs fail both gates; only explicit `false`
+lets a job skip.
 
 The classifier selects an SDK for its directory, documentation page or
 registered release tooling. Shared contract and conformance files select all
 SDKs. So do API implementation, build configuration and unregistered paths.
 An explicit allowlist selects none for unrelated docs, console UI, server
-tests and telemetry. Mixed changes select the union of their SDKs.
+tests and telemetry. Mixed changes select the union of their SDKs. SDK docs
+select their language even on the server docs-only path.
+
+The release job installs TypeScript dependencies and checks generated types
+only when TypeScript is selected. Server wire-contract generation and its
+freshness check remain required on every full server plan. Shared contract
+changes select all SDKs, including that generated-type check.
 
 Invalid bases, failed or empty diffs, malformed paths and undecodable names
 select every SDK. The NUL-delimited Git diff disables rename detection, so a

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -71,20 +71,23 @@ tested it.
 ### Sizing
 
 `MERGE_QUEUE` in `require-checks.py` explains the queue settings. A full CI
-run now has 21 jobs, compared with the documented limit of 20 concurrent
+run now has 22 jobs, compared with the documented limit of 20 concurrent
 runners. The queue builds one group at a time and batches up to five PRs. Revisit
 `max_entries_to_build` when the concurrency limit changes.
 
 ## SDK jobs
 
-The Elixir and Python SDKs run in `elixir-sdk` and `python-sdk`, alongside
-the TypeScript, CLI and plugin job (`sdk-clients`). The Swift job (`swift-sdk`) runs on Linux and
+The Elixir, Python and TypeScript SDKs run in `elixir-sdk`, `python-sdk` and
+`typescript-sdk`. The Go CLI, Hermes plugin and deployed-runner checks run in
+`cli-plugins`. The Swift job (`swift-sdk`) runs on Linux and
 macOS. Each reads the committed contract; `release-and-contract` checks its
 generation.
 The Elixir job owns its toolchain, cache, formatting, compilation, tests, docs,
 package dry run, contract and conformance checks. The Python job owns its
-tests, compilation, contract and conformance checks. Both jobs validate
-fixtures before their tests. `CI required` requires both on every full plan, including main and
+tests, compilation, contract and conformance checks. The TypeScript job owns
+installation, type checks, tests, builds, browser bundling, contract and
+conformance checks. Each SDK job validates fixtures before its tests.
+`CI required` requires all SDK jobs on every full plan, including main and
 merge groups. A failed, cancelled or unexpectedly skipped job fails the gate.
 
 Per-language path routing remains tracked in #1413. Register a new job in

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -52,7 +52,7 @@ out `check_response_timeout_minutes` and ejects it, with no red job anywhere to
 explain why. `test_every_event_the_workflow_triggers_on_is_a_plan` in
 `test_gate.py` keeps the workflow and `gate.py` from drifting apart later.
 
-Three CI events now exist, and `gate.py`'s `PROBES` table is the authority on
+Four CI events now exist, and `gate.py`'s `PROBES` table is the authority on
 what each one owes:
 
 | Event | Probes that run | What the plan means |
@@ -60,6 +60,7 @@ what each one owes:
 | `pull_request` | `changes` | Classify the diff; docs-only skips the Elixir suite |
 | `merge_group` | `changes` + `already-tested` | Classify the group, and skip it outright when its tree is one a PR run already tested |
 | `push` | `already-tested` | Main reuses the queue run (or a PR run) that tested this tree |
+| `workflow_dispatch` | `changes` | Run the complete plan, without diff-based skips or tree reuse |
 
 The queue run and main's push both look for the `tested-tree` artifact, so a
 queued merge normally costs one full run, not two: the queue runs the suite,
@@ -90,7 +91,9 @@ conformance checks. These three extracted jobs lint fixtures before their
 tests. Swift retains its separate conformance test step.
 `CI required` requires every selected SDK job. A failed, cancelled or
 unexpectedly skipped job fails the gate. Main runs all SDKs unless a verified
-tested tree authorizes reuse.
+tested tree authorizes reuse. Manual workflow dispatch always selects every
+SDK and the full server plan, including prose checks. Both gates reject a
+manual classification that attempts to skip part of that plan.
 
 `SDK checks` reports the SDK result even when docs-only classification or a
 previously tested tree skips every SDK leg. It validates the same probe

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -71,9 +71,10 @@ tested it.
 
 ### Sizing
 
-`MERGE_QUEUE` in `require-checks.py` explains the queue settings. A full CI
-run now has 24 jobs, compared with the documented limit of 20 concurrent
-runners. The queue builds one group at a time and batches up to five PRs. Revisit
+`MERGE_QUEUE` in `require-checks.py` explains the queue settings. A full mixed
+PR runs 25 jobs; a full merge group runs 26 because both probes run. The
+documented limit is 20 concurrent runners. The queue builds one group at a
+time and batches up to five PRs. Revisit
 `max_entries_to_build` when the concurrency limit changes.
 
 ## SDK jobs
@@ -89,7 +90,10 @@ tests, compilation, contract and conformance checks on Python 3.9 and 3.13.
 These cover the package minimum and newest declared runtime. Both legs must
 pass; a failure does not cancel the other leg. The TypeScript job owns
 installation, type checks, tests, builds, browser bundling, contract and
-conformance checks. These three extracted jobs lint fixtures before their
+conformance checks on Node 20.19.0 and 24. The minimum runtime runs compiled
+JavaScript from the same test sources in a temporary fixture tree. Node 24
+retains native TypeScript tests. Both legs build the SDK and browser bundle.
+These three extracted jobs lint fixtures before their
 tests. Swift retains its separate conformance test step.
 `CI required` requires every selected SDK job. A failed, cancelled or
 unexpectedly skipped job fails the gate. Main runs all SDKs unless a verified

--- a/scripts/ci/gate.py
+++ b/scripts/ci/gate.py
@@ -40,7 +40,14 @@ def _classification(needs):
     tree = outputs.get("tree")
     if not isinstance(tree, str) or not re.fullmatch(r"[0-9a-f]{40}", tree):
         raise ValueError("checkout tree is missing or invalid")
-    return outputs["docs_only"] == "true", outputs["docs_touched"] == "true"
+    selected = set()
+    for job in SDK_JOBS:
+        value = outputs.get("sdk_" + job.removesuffix("-sdk"))
+        if value not in ("true", "false"):
+            raise ValueError("SDK classification is missing or invalid")
+        if value == "true":
+            selected.add(job)
+    return outputs["docs_only"] == "true", outputs["docs_touched"] == "true", selected
 
 
 def _expected_plan(event, needs, jobs):
@@ -54,7 +61,12 @@ def _expected_plan(event, needs, jobs):
         expected[probe] = "success"
 
     reuse = _reuse(needs) if "already-tested" in PROBES[event] else False
-    docs_only, docs_touched = _classification(needs) if "changes" in PROBES[event] else (False, True)
+    docs_only, docs_touched, sdks = (
+        _classification(needs) if "changes" in PROBES[event] else (False, True, SDK_JOBS)
+    )
+    # SDK docs can select a language even when the server plan is docs-only.
+    if not reuse:
+        expected.update(dict.fromkeys(sdks, "success"))
 
     return expected, not reuse and not docs_only, docs_only, docs_touched, reuse
 
@@ -68,16 +80,14 @@ def validate(event, needs):
     if docs_only and not reuse:
         expected["docs"] = "success"
     if full:
-        expected.update(dict.fromkeys(FULL_JOBS, "success"))
+        expected.update(dict.fromkeys(FULL_JOBS - SDK_JOBS, "success"))
     if full and docs_touched:
         expected["docs-prose"] = "success"
     _check_results(needs, expected)
 
 
 def validate_sdks(event, needs):
-    expected, full, _, _, _ = _expected_plan(event, needs, SDK_GATE_JOBS)
-    if full:
-        expected.update(dict.fromkeys(SDK_JOBS, "success"))
+    expected, _, _, _, _ = _expected_plan(event, needs, SDK_GATE_JOBS)
     _check_results(needs, expected)
 
 

--- a/scripts/ci/gate.py
+++ b/scripts/ci/gate.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 
 FULL_JOBS = {
-    "test", "coverage", "elixir-static", "release-and-contract", "sdk-clients",
+    "test", "coverage", "elixir-static", "release-and-contract", "cli-plugins", "typescript-sdk",
     "elixir-sdk", "python-sdk", "swift-sdk", "core-distribution", "compose-fresh-clone", "compose-pinned-image-boot",
 }
 JOBS = FULL_JOBS | {"already-tested", "changes", "workflow-checks", "docs", "docs-prose"}

--- a/scripts/ci/gate.py
+++ b/scripts/ci/gate.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 FULL_JOBS = {
     "test", "coverage", "elixir-static", "release-and-contract", "sdk-clients",
-    "swift-sdk", "core-distribution", "compose-fresh-clone", "compose-pinned-image-boot",
+    "elixir-sdk", "swift-sdk", "core-distribution", "compose-fresh-clone", "compose-pinned-image-boot",
 }
 JOBS = FULL_JOBS | {"already-tested", "changes", "workflow-checks", "docs", "docs-prose"}
 

--- a/scripts/ci/gate.py
+++ b/scripts/ci/gate.py
@@ -21,6 +21,7 @@ JOBS = FULL_JOBS | {"already-tested", "changes", "workflow-checks", "docs", "doc
 # whether the tree it is about to test has already been tested.
 PROBES = {
     "pull_request": {"changes"},
+    "workflow_dispatch": {"changes"},
     "push": {"already-tested"},
     "merge_group": {"already-tested", "changes"},
 }
@@ -64,6 +65,8 @@ def _expected_plan(event, needs, jobs):
     docs_only, docs_touched, sdks = (
         _classification(needs) if "changes" in PROBES[event] else (False, True, SDK_JOBS)
     )
+    if event == "workflow_dispatch" and (docs_only or not docs_touched or sdks != SDK_JOBS):
+        raise ValueError("manual CI must select the complete plan")
     # SDK docs can select a language even when the server plan is docs-only.
     if not reuse:
         expected.update(dict.fromkeys(sdks, "success"))

--- a/scripts/ci/gate.py
+++ b/scripts/ci/gate.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Validate the complete CI plan before publishing the stable required check."""
 
+import argparse
 import json
 import os
 import re
@@ -11,7 +12,9 @@ FULL_JOBS = {
     "test", "coverage", "elixir-static", "release-and-contract", "cli-plugins", "typescript-sdk",
     "elixir-sdk", "python-sdk", "swift-sdk", "core-distribution", "compose-fresh-clone", "compose-pinned-image-boot",
 }
-JOBS = FULL_JOBS | {"already-tested", "changes", "workflow-checks", "docs", "docs-prose"}
+SDK_JOBS = {"elixir-sdk", "python-sdk", "typescript-sdk", "swift-sdk"}
+SDK_GATE_JOBS = SDK_JOBS | {"already-tested", "changes"}
+JOBS = FULL_JOBS | {"already-tested", "changes", "workflow-checks", "docs", "docs-prose", "sdk-checks"}
 
 # Which probes are expected to have run, per event. A merge group is the only
 # plan that runs both: the queue classifies the diff like a PR *and* asks
@@ -34,34 +37,51 @@ def _classification(needs):
     outputs = needs["changes"].get("outputs", {})
     if any(outputs.get(key) not in {"true", "false"} for key in ("docs_only", "docs_touched", "cli_docs")):
         raise ValueError("change classification is missing or invalid")
-    if not re.fullmatch(r"[0-9a-f]{40}", outputs.get("tree", "")):
+    tree = outputs.get("tree")
+    if not isinstance(tree, str) or not re.fullmatch(r"[0-9a-f]{40}", tree):
         raise ValueError("checkout tree is missing or invalid")
     return outputs["docs_only"] == "true", outputs["docs_touched"] == "true"
 
 
-def validate(event, needs):
+def _expected_plan(event, needs, jobs):
     if event not in PROBES:
         raise ValueError(f"unsupported CI event: {event}")
-    if set(needs) != JOBS:
-        raise ValueError(f"CI dependencies differ: missing={JOBS - set(needs)}, extra={set(needs) - JOBS}")
+    if set(needs) != jobs:
+        raise ValueError(f"CI dependencies differ: missing={jobs - set(needs)}, extra={set(needs) - jobs}")
 
-    expected = dict.fromkeys(JOBS, "skipped")
-    expected["workflow-checks"] = "success"
+    expected = dict.fromkeys(jobs, "skipped")
     for probe in PROBES[event]:
         expected[probe] = "success"
 
     reuse = _reuse(needs) if "already-tested" in PROBES[event] else False
     docs_only, docs_touched = _classification(needs) if "changes" in PROBES[event] else (False, True)
 
-    full = not reuse and not docs_only
-    # A docs-only plan still owes the docs job; a reused tree owes nothing,
-    # because the identical tree already passed every gate this plan names.
+    return expected, not reuse and not docs_only, docs_only, docs_touched, reuse
+
+
+def validate(event, needs):
+    expected, full, docs_only, docs_touched, reuse = _expected_plan(event, needs, JOBS)
+    expected["workflow-checks"] = "success"
+    expected["sdk-checks"] = "success"
+    # Docs-only still owes docs. Reused trees skip the workload jobs, while
+    # both aggregate checks validate that the selected plan was followed.
     if docs_only and not reuse:
         expected["docs"] = "success"
     if full:
         expected.update(dict.fromkeys(FULL_JOBS, "success"))
     if full and docs_touched:
         expected["docs-prose"] = "success"
+    _check_results(needs, expected)
+
+
+def validate_sdks(event, needs):
+    expected, full, _, _, _ = _expected_plan(event, needs, SDK_GATE_JOBS)
+    if full:
+        expected.update(dict.fromkeys(SDK_JOBS, "success"))
+    _check_results(needs, expected)
+
+
+def _check_results(needs, expected):
     errors = [f"{job}: expected {result}, got {needs[job].get('result')}"
               for job, result in sorted(expected.items()) if needs[job].get("result") != result]
     if errors:
@@ -69,10 +89,17 @@ def validate(event, needs):
 
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--sdk", action="store_true", help="validate only the SDK job plan")
+    args = parser.parse_args()
     needs = json.loads(os.environ["CI_NEEDS"])
     event = os.environ["GITHUB_EVENT_NAME"]
-    validate(event, needs)
-    # Main is the only event that consumes evidence rather than publishing it.
-    if event != "push":
-        Path("tested-tree.txt").write_text(needs["changes"]["outputs"]["tree"] + "\n")
-    print("Every job required by this CI plan passed.")
+    if args.sdk:
+        validate_sdks(event, needs)
+        print("Every SDK job required by this CI plan passed.")
+    else:
+        validate(event, needs)
+        # Only complete CI may publish evidence for main's tested-tree shortcut.
+        if event != "push":
+            Path("tested-tree.txt").write_text(needs["changes"]["outputs"]["tree"] + "\n")
+        print("Every job required by this CI plan passed.")

--- a/scripts/ci/gate.py
+++ b/scripts/ci/gate.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 FULL_JOBS = {
     "test", "coverage", "elixir-static", "release-and-contract", "sdk-clients",
-    "elixir-sdk", "swift-sdk", "core-distribution", "compose-fresh-clone", "compose-pinned-image-boot",
+    "elixir-sdk", "python-sdk", "swift-sdk", "core-distribution", "compose-fresh-clone", "compose-pinned-image-boot",
 }
 JOBS = FULL_JOBS | {"already-tested", "changes", "workflow-checks", "docs", "docs-prose"}
 

--- a/scripts/ci/require-checks.py
+++ b/scripts/ci/require-checks.py
@@ -19,14 +19,14 @@ def api(path, payload=None, method="PUT"):
 # Sized against this repo's measured CI, not GitHub's defaults.
 #
 # max_entries_to_build: 1 — the org is on the free plan, which allows 20
-# concurrent GitHub-hosted jobs, and ONE full CI run has 23 jobs. Speculating
+# concurrent GitHub-hosted jobs, and ONE full CI run has 24 jobs. Speculating
 # two groups deep cannot run two groups; it queues the second behind the first
 # while also starving every open PR. Raise this only after the concurrency
 # ceiling does.
 #
 # min_entries_to_merge: 2 with a 5 minute wait — batching is the only lever
 # that buys throughput under that same ceiling, because five PRs merged as one
-# group cost one 23-job run instead of five. In a burst the group fills at once
+# group cost one 24-job run instead of five. In a burst the group fills at once
 # and nothing waits; in a quiet hour a lone PR waits up to five minutes, which
 # is the hour where nobody is blocked on it.
 #

--- a/scripts/ci/require-checks.py
+++ b/scripts/ci/require-checks.py
@@ -19,15 +19,15 @@ def api(path, payload=None, method="PUT"):
 # Sized against this repo's measured CI, not GitHub's defaults.
 #
 # max_entries_to_build: 1 — the org is on the free plan, which allows 20
-# concurrent GitHub-hosted jobs. A full mixed PR runs 25 jobs; a merge group
-# runs 26 because both probes run. Speculating
+# concurrent GitHub-hosted jobs. A full mixed PR runs 26 jobs; a merge group
+# runs 27 because both probes run. Speculating
 # two groups deep cannot run two groups; it queues the second behind the first
 # while also starving every open PR. Raise this only after the concurrency
 # ceiling does.
 #
 # min_entries_to_merge: 2 with a 5 minute wait — batching is the only lever
 # that buys throughput under that same ceiling, because five PRs merged as one
-# group cost one 26-job run instead of five. In a burst the group fills at once
+# group cost one 27-job run instead of five. In a burst the group fills at once
 # and nothing waits; in a quiet hour a lone PR waits up to five minutes, which
 # is the hour where nobody is blocked on it.
 #

--- a/scripts/ci/require-checks.py
+++ b/scripts/ci/require-checks.py
@@ -19,14 +19,14 @@ def api(path, payload=None, method="PUT"):
 # Sized against this repo's measured CI, not GitHub's defaults.
 #
 # max_entries_to_build: 1 — the org is on the free plan, which allows 20
-# concurrent GitHub-hosted jobs, and ONE full CI run has 21 jobs. Speculating
+# concurrent GitHub-hosted jobs, and ONE full CI run has 22 jobs. Speculating
 # two groups deep cannot run two groups; it queues the second behind the first
 # while also starving every open PR. Raise this only after the concurrency
 # ceiling does.
 #
 # min_entries_to_merge: 2 with a 5 minute wait — batching is the only lever
 # that buys throughput under that same ceiling, because five PRs merged as one
-# group cost one 21-job run instead of five. In a burst the group fills at once
+# group cost one 22-job run instead of five. In a burst the group fills at once
 # and nothing waits; in a quiet hour a lone PR waits up to five minutes, which
 # is the hour where nobody is blocked on it.
 #

--- a/scripts/ci/require-checks.py
+++ b/scripts/ci/require-checks.py
@@ -19,14 +19,14 @@ def api(path, payload=None, method="PUT"):
 # Sized against this repo's measured CI, not GitHub's defaults.
 #
 # max_entries_to_build: 1 — the org is on the free plan, which allows 20
-# concurrent GitHub-hosted jobs, and ONE full CI run has 22 jobs. Speculating
+# concurrent GitHub-hosted jobs, and ONE full CI run has 23 jobs. Speculating
 # two groups deep cannot run two groups; it queues the second behind the first
 # while also starving every open PR. Raise this only after the concurrency
 # ceiling does.
 #
 # min_entries_to_merge: 2 with a 5 minute wait — batching is the only lever
 # that buys throughput under that same ceiling, because five PRs merged as one
-# group cost one 22-job run instead of five. In a burst the group fills at once
+# group cost one 23-job run instead of five. In a burst the group fills at once
 # and nothing waits; in a quiet hour a lone PR waits up to five minutes, which
 # is the hour where nobody is blocked on it.
 #

--- a/scripts/ci/require-checks.py
+++ b/scripts/ci/require-checks.py
@@ -19,14 +19,15 @@ def api(path, payload=None, method="PUT"):
 # Sized against this repo's measured CI, not GitHub's defaults.
 #
 # max_entries_to_build: 1 — the org is on the free plan, which allows 20
-# concurrent GitHub-hosted jobs, and ONE full CI run has 24 jobs. Speculating
+# concurrent GitHub-hosted jobs. A full mixed PR runs 25 jobs; a merge group
+# runs 26 because both probes run. Speculating
 # two groups deep cannot run two groups; it queues the second behind the first
 # while also starving every open PR. Raise this only after the concurrency
 # ceiling does.
 #
 # min_entries_to_merge: 2 with a 5 minute wait — batching is the only lever
 # that buys throughput under that same ceiling, because five PRs merged as one
-# group cost one 24-job run instead of five. In a burst the group fills at once
+# group cost one 26-job run instead of five. In a burst the group fills at once
 # and nothing waits; in a quiet hour a lone PR waits up to five minutes, which
 # is the hour where nobody is blocked on it.
 #

--- a/scripts/ci/require-checks.py
+++ b/scripts/ci/require-checks.py
@@ -19,14 +19,14 @@ def api(path, payload=None, method="PUT"):
 # Sized against this repo's measured CI, not GitHub's defaults.
 #
 # max_entries_to_build: 1 — the org is on the free plan, which allows 20
-# concurrent GitHub-hosted jobs, and ONE full CI run is 19 of them. Speculating
+# concurrent GitHub-hosted jobs, and ONE full CI run is 20 of them. Speculating
 # two groups deep cannot run two groups; it queues the second behind the first
 # while also starving every open PR. Raise this only after the concurrency
 # ceiling does.
 #
 # min_entries_to_merge: 2 with a 5 minute wait — batching is the only lever
 # that buys throughput under that same ceiling, because five PRs merged as one
-# group cost one 19-job run instead of five. In a burst the group fills at once
+# group cost one 20-job run instead of five. In a burst the group fills at once
 # and nothing waits; in a quiet hour a lone PR waits up to five minutes, which
 # is the hour where nobody is blocked on it.
 #

--- a/scripts/ci/require-checks.py
+++ b/scripts/ci/require-checks.py
@@ -19,14 +19,14 @@ def api(path, payload=None, method="PUT"):
 # Sized against this repo's measured CI, not GitHub's defaults.
 #
 # max_entries_to_build: 1 — the org is on the free plan, which allows 20
-# concurrent GitHub-hosted jobs, and ONE full CI run is 20 of them. Speculating
+# concurrent GitHub-hosted jobs, and ONE full CI run has 21 jobs. Speculating
 # two groups deep cannot run two groups; it queues the second behind the first
 # while also starving every open PR. Raise this only after the concurrency
 # ceiling does.
 #
 # min_entries_to_merge: 2 with a 5 minute wait — batching is the only lever
 # that buys throughput under that same ceiling, because five PRs merged as one
-# group cost one 20-job run instead of five. In a burst the group fills at once
+# group cost one 21-job run instead of five. In a burst the group fills at once
 # and nothing waits; in a quiet hour a lone PR waits up to five minutes, which
 # is the hour where nobody is blocked on it.
 #

--- a/scripts/ci/sdk_changes.py
+++ b/scripts/ci/sdk_changes.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Select SDKs from a Git diff; unknown paths or unreadable diffs select all."""
+
+import re
+import subprocess
+import sys
+
+
+LANGUAGES = frozenset({"elixir", "python", "typescript", "swift"})
+# SDK-local docs and tooling take precedence over the unrelated-path allowlist.
+OWNED_FILES = {
+    "elixir": {"docs/elixir-sdk.md", "scripts/elixir-sdk-release.exs",
+               ".github/workflows/elixir-sdk-publish.yml",
+               ".github/workflows/elixir-sdk-release-gate.yml"},
+    "python": {"docs/python-sdk.md", ".github/workflows/python-sdk-publish.yml",
+               ".github/workflows/python-sdk-release-gate.yml"},
+    "typescript": {"docs/sdk.md", "scripts/sdk-release.mjs", "scripts/sdk-publish-tag.mjs",
+                   "scripts/sdk-publish-tag.test.mjs", ".github/workflows/sdk-publish.yml",
+                   ".github/workflows/sdk-release-gate.yml"},
+    "swift": {"docs/swift-sdk.md", "Package.swift", "Package.resolved", ".swift-format"},
+}
+UNRELATED_PREFIXES = (
+    "docs/", "decisions/", "assets/", "apps/fountain/assets/",
+    "apps/fountain/lib/fountain_web/live/", "apps/fountain/lib/fountain_web/components/",
+    "apps/fountain/test/", "apps/fountain_buzz/test/", "apps/fountain_support/test/",
+)
+UNRELATED_FILES = {
+    "apps/fountain/lib/fountain/telemetry.ex", "apps/fountain/lib/fountain/telemetry_tick.ex",
+    "apps/fountain/lib/fountain_web/telemetry.ex",
+}
+
+
+def classify(paths):
+    selected = set()
+    if not paths:
+        return LANGUAGES
+    for path in paths:
+        if (not path or path.startswith("/") or re.search(r"[\x00-\x1f\x7f]", path)
+                or any(part in {"", ".", ".."} for part in path.split("/"))):
+            return LANGUAGES
+        owner = next((language for language in LANGUAGES
+                      if path.startswith(f"sdk/{language}/") or path in OWNED_FILES[language]), None)
+        if owner:
+            selected.add(owner)
+        elif path not in UNRELATED_FILES and not path.startswith(UNRELATED_PREFIXES):
+            # Shared contract/conformance, API implementation, build config,
+            # CI policy and every unregistered path require every SDK.
+            return LANGUAGES
+    return frozenset(selected)
+
+
+def from_git(base):
+    if not re.fullmatch(r"[0-9a-f]{40}", base):
+        return LANGUAGES
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--no-ext-diff", "--no-textconv", "--no-renames",
+             "--name-only", "-z", base, "HEAD", "--"],
+            check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        ).stdout
+        if not result or not result.endswith(b"\0"):
+            return LANGUAGES
+        return classify(result[:-1].decode("utf-8").split("\0"))
+    except (OSError, subprocess.CalledProcessError, UnicodeDecodeError):
+        return LANGUAGES
+
+
+if __name__ == "__main__":
+    selected = from_git(sys.argv[1]) if len(sys.argv) == 2 else LANGUAGES
+    # Only fixed keys and boolean values reach GITHUB_OUTPUT, never file names.
+    for language in sorted(LANGUAGES):
+        print(f"sdk_{language}={str(language in selected).lower()}")

--- a/scripts/ci/test_dispatch.py
+++ b/scripts/ci/test_dispatch.py
@@ -1,0 +1,77 @@
+import copy
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+
+from gate import FULL_JOBS, SDK_GATE_JOBS, SDK_JOBS, validate, validate_sdks
+from test_gate import plan
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class DispatchTest(unittest.TestCase):
+    def test_actual_classifier_selects_full_ci_without_fetching_a_base(self):
+        workflow = (ROOT / ".github/workflows/ci.yml").read_text()
+        job = workflow.split("\n  changes:\n", 1)[1].split("\n  test:\n", 1)[0]
+        self.assertIn("|| github.event_name == 'workflow_dispatch' }}", job)
+        script = job.split("        id: filter\n", 1)[1].split("        run: |\n", 1)[1]
+        script = textwrap.dedent(script.split("\n      - name:", 1)[0])
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            fake_git = root / "git"
+            fake_git.write_text('#!/bin/sh\ntouch "$GIT_CALLED"\nexit 97\n')
+            fake_git.chmod(0o755)
+            output = root / "outputs"
+            result = subprocess.run(["bash", "-e", "-c", script], cwd=root, capture_output=True, text=True,
+                                    env=dict(os.environ, GITHUB_EVENT_NAME="workflow_dispatch",
+                                             GITHUB_OUTPUT=str(output), GITHUB_BASE_REF="",
+                                             MERGE_GROUP_BASE_SHA="", GIT_CALLED=str(root / "called"),
+                                             PATH=str(root) + os.pathsep + os.environ["PATH"]))
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertFalse((root / "called").exists())
+            values = dict(line.split("=", 1) for line in output.read_text().splitlines())
+            self.assertEqual(values, {"diff_base": "", "docs_only": "false",
+                                      "cli_docs": "false", "docs_touched": "true"})
+            sdks = subprocess.check_output([sys.executable, str(ROOT / "scripts/ci/sdk_changes.py"),
+                                            values["diff_base"]], cwd=root, text=True)
+            self.assertEqual(set(sdks.splitlines()),
+                             {"sdk_" + job.removesuffix("-sdk") + "=true" for job in SDK_JOBS})
+
+    def test_both_gates_reject_partial_manual_plans(self):
+        original = plan("workflow_dispatch")
+        mutations = [("docs_only", "true"), ("docs_touched", "false")]
+        mutations += [("sdk_" + job.removesuffix("-sdk"), "false") for job in SDK_JOBS]
+        for key, value in mutations:
+            needs = copy.deepcopy(original)
+            needs["changes"]["outputs"][key] = value
+            if key == "docs_only":
+                for job in FULL_JOBS - SDK_JOBS:
+                    needs[job]["result"] = "skipped"
+                needs["docs"]["result"] = "success"
+                needs["docs-prose"]["result"] = "skipped"
+            elif key == "docs_touched":
+                needs["docs-prose"]["result"] = "skipped"
+            else:
+                needs[key.removeprefix("sdk_") + "-sdk"]["result"] = "skipped"
+            with self.subTest(key=key):
+                with self.assertRaisesRegex(ValueError, "manual CI must select the complete plan"):
+                    validate("workflow_dispatch", needs)
+                with self.assertRaisesRegex(ValueError, "manual CI must select the complete plan"):
+                    validate_sdks("workflow_dispatch", {name: state for name, state in needs.items()
+                                                       if name in SDK_GATE_JOBS})
+
+    def test_full_manual_gate_can_publish_tested_tree_evidence(self):
+        needs = plan("workflow_dispatch")
+        with tempfile.TemporaryDirectory() as directory:
+            result = subprocess.run([sys.executable, str(ROOT / "scripts/ci/gate.py")], cwd=directory,
+                                    capture_output=True, text=True,
+                                    env=dict(os.environ, GITHUB_EVENT_NAME="workflow_dispatch",
+                                             CI_NEEDS=json.dumps(needs)))
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual((Path(directory) / "tested-tree.txt").read_text(), "a" * 40 + "\n")

--- a/scripts/ci/test_elixir_sdk_matrix.py
+++ b/scripts/ci/test_elixir_sdk_matrix.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+import re
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class ElixirSDKMatrixTest(unittest.TestCase):
+    def test_minimum_runtime_and_current_formatter_keep_complete_sdk_checks(self):
+        project = (ROOT / "sdk/elixir/mix.exs").read_text()
+        minimum = re.search(r'elixir: "~> ([0-9.]+)"', project)[1]
+        workflow = (ROOT / ".github/workflows/ci.yml").read_text()
+        job = workflow.split("\n  elixir-sdk:\n", 1)[1].split("\n  python-sdk:\n", 1)[0]
+        pairs = re.findall(r'          - elixir: "([0-9.]+)"\n            otp: "([0-9.]+)"', job)
+        self.assertTrue(any(version.startswith(minimum + ".") for version, _ in pairs))
+        self.assertIn(("1.19.2", "28.3"), pairs)
+        self.assertIn("fail-fast: false", job)
+        self.assertIn("elixir-version: ${{ matrix.elixir }}", job)
+        self.assertIn("otp-version: ${{ matrix.otp }}", job)
+        self.assertIn("steps.beam.outputs.otp-version", job)
+        self.assertIn("steps.beam.outputs.elixir-version", job)
+        steps = dict(re.findall(r"      - name: ([^\n]+)\n(.*?)(?=      - (?:name:|uses:)|\Z)", job, re.S))
+        self.assertIn("if: ${{ matrix.elixir == '1.19.2' }}", steps["Elixir SDK formatting"])
+        self.assertIn("run: mix format --check-formatted", steps["Elixir SDK formatting"])
+        for name in ("Elixir SDK dependencies", "Elixir SDK compile", "Elixir SDK tests",
+                     "Elixir SDK documentation", "Elixir SDK package dry run",
+                     "Elixir SDK contract", "Elixir SDK conformance"):
+            self.assertNotIn("        if:", steps[name])

--- a/scripts/ci/test_gate.py
+++ b/scripts/ci/test_gate.py
@@ -6,10 +6,12 @@ import unittest
 from gate import FULL_JOBS, JOBS, PROBES, SDK_JOBS, validate
 
 
-EVENTS = ("pull_request", "push", "merge_group")
+EVENTS = ("pull_request", "push", "merge_group", "workflow_dispatch")
 
 
 def plan(event="pull_request", docs=False, touched=False, reuse=False, sdks=None):
+    if event == "workflow_dispatch":
+        docs, touched, sdks = False, True, SDK_JOBS
     if sdks is None:
         sdks = set() if docs else SDK_JOBS
     if event == "push":
@@ -61,7 +63,7 @@ class GateTest(unittest.TestCase):
         self.assertEqual(declared, set(PROBES))
 
     def test_all_supported_plans(self):
-        for event, options in [("pull_request", {}), ("pull_request", {"docs": True}),
+        for event, options in [("workflow_dispatch", {}), ("pull_request", {}), ("pull_request", {"docs": True}),
                                ("pull_request", {"touched": True}), ("push", {}),
                                ("push", {"reuse": True}), ("merge_group", {}),
                                ("merge_group", {"docs": True}), ("merge_group", {"touched": True}),
@@ -70,7 +72,7 @@ class GateTest(unittest.TestCase):
                 validate(event, plan(event, **options))
 
     def test_every_required_job_rejects_failure_cancel_and_skip(self):
-        for event, options in [("pull_request", {"touched": True}), ("pull_request", {"docs": True}),
+        for event, options in [("workflow_dispatch", {}), ("pull_request", {"touched": True}), ("pull_request", {"docs": True}),
                                ("push", {}), ("push", {"reuse": True}),
                                ("merge_group", {"touched": True}), ("merge_group", {"docs": True}),
                                ("merge_group", {"reuse": True})]:
@@ -95,7 +97,7 @@ class GateTest(unittest.TestCase):
                         validate(event, jobs)
 
     def test_missing_classification_or_tree_is_not_a_docs_skip(self):
-        for event in ("pull_request", "merge_group"):
+        for event in ("pull_request", "merge_group", "workflow_dispatch"):
             for key in ("docs_only", "docs_touched", "cli_docs", "tree"):
                 jobs = plan(event, docs=True)
                 del jobs["changes"]["outputs"][key]
@@ -130,4 +132,4 @@ class GateTest(unittest.TestCase):
 
     def test_unsupported_event_is_rejected(self):
         with self.assertRaises(ValueError):
-            validate("workflow_dispatch", plan("pull_request"))
+            validate("unknown_event", plan("pull_request"))

--- a/scripts/ci/test_gate.py
+++ b/scripts/ci/test_gate.py
@@ -12,6 +12,7 @@ EVENTS = ("pull_request", "push", "merge_group")
 def plan(event="pull_request", docs=False, touched=False, reuse=False):
     jobs = {job: {"result": "skipped", "outputs": {}} for job in JOBS}
     jobs["workflow-checks"]["result"] = "success"
+    jobs["sdk-checks"]["result"] = "success"
     if "already-tested" in PROBES[event]:
         jobs["already-tested"] = {"result": "success", "outputs": {"skip": str(reuse).lower()}}
     if "changes" in PROBES[event]:

--- a/scripts/ci/test_gate.py
+++ b/scripts/ci/test_gate.py
@@ -3,13 +3,17 @@ from pathlib import Path
 import re
 import unittest
 
-from gate import FULL_JOBS, JOBS, PROBES, validate
+from gate import FULL_JOBS, JOBS, PROBES, SDK_JOBS, validate
 
 
 EVENTS = ("pull_request", "push", "merge_group")
 
 
-def plan(event="pull_request", docs=False, touched=False, reuse=False):
+def plan(event="pull_request", docs=False, touched=False, reuse=False, sdks=None):
+    if sdks is None:
+        sdks = set() if docs else SDK_JOBS
+    if event == "push":
+        sdks = SDK_JOBS
     jobs = {job: {"result": "skipped", "outputs": {}} for job in JOBS}
     jobs["workflow-checks"]["result"] = "success"
     jobs["sdk-checks"]["result"] = "success"
@@ -19,16 +23,19 @@ def plan(event="pull_request", docs=False, touched=False, reuse=False):
         jobs["changes"] = {"result": "success", "outputs": {
             "docs_only": str(docs).lower(), "docs_touched": str(touched).lower(),
             "cli_docs": "false", "tree": "a" * 40,
+            **{"sdk_" + job.removesuffix("-sdk"): str(job in sdks).lower() for job in SDK_JOBS},
         }}
     if reuse:
         return jobs
     if docs:
         jobs["docs"]["result"] = "success"
     else:
-        for job in FULL_JOBS:
+        for job in FULL_JOBS - SDK_JOBS:
             jobs[job]["result"] = "success"
         if touched or event == "push":
             jobs["docs-prose"]["result"] = "success"
+    for job in sdks:
+        jobs[job]["result"] = "success"
     return jobs
 
 

--- a/scripts/ci/test_python_sdk_matrix.py
+++ b/scripts/ci/test_python_sdk_matrix.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+import re
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class PythonSDKMatrixTest(unittest.TestCase):
+    def test_supported_runtime_boundaries_run_all_existing_checks(self):
+        metadata = (ROOT / "sdk/python/pyproject.toml").read_text()
+        minimum = re.search(r'requires-python = ">=([0-9.]+)"', metadata)[1]
+        declared = re.findall(r'Programming Language :: Python :: ([0-9]+\.[0-9]+)"', metadata)
+        newest = max(declared, key=lambda version: tuple(map(int, version.split("."))))
+        workflow = (ROOT / ".github/workflows/ci.yml").read_text()
+        job = workflow.split("\n  python-sdk:\n", 1)[1].split("\n  typescript-sdk:\n", 1)[0]
+        versions = re.findall(r'"([0-9.]+)"', re.search(r"        python: \[(.*)\]", job)[1])
+        self.assertIn(minimum, versions)
+        self.assertIn(newest, versions)
+        self.assertIn("fail-fast: false", job)
+        self.assertIn("name: Python SDK (${{ matrix.python }})", job)
+        self.assertIn("python-version: ${{ matrix.python }}", job)
+        self.assertLess(job.index("name: Set up Python"), job.index("python sdk/conformance/lint.py"))
+        for command in ("python sdk/conformance/lint.py",
+                        "python -m unittest discover -s sdk/python/tests -v",
+                        "python -m compileall -q sdk/python/src sdk/python/scripts",
+                        "python scripts/verify_contract.py",
+                        'python -m unittest discover -s tests -p "test_conformance.py" -v'):
+            self.assertIn("run: " + command, job)
+        # No step-level condition can drop a check on the minimum runtime.
+        self.assertNotIn("        if:", job)

--- a/scripts/ci/test_python_sdk_matrix.py
+++ b/scripts/ci/test_python_sdk_matrix.py
@@ -7,7 +7,7 @@ ROOT = Path(__file__).resolve().parents[2]
 
 
 class PythonSDKMatrixTest(unittest.TestCase):
-    def test_supported_runtime_boundaries_run_all_existing_checks(self):
+    def test_supported_runtime_boundaries_run_complete_sdk_checks(self):
         metadata = (ROOT / "sdk/python/pyproject.toml").read_text()
         minimum = re.search(r'requires-python = ">=([0-9.]+)"', metadata)[1]
         declared = re.findall(r'Programming Language :: Python :: ([0-9]+\.[0-9]+)"', metadata)
@@ -22,10 +22,12 @@ class PythonSDKMatrixTest(unittest.TestCase):
         self.assertIn("python-version: ${{ matrix.python }}", job)
         self.assertLess(job.index("name: Set up Python"), job.index("python sdk/conformance/lint.py"))
         for command in ("python sdk/conformance/lint.py",
-                        "python -m unittest discover -s sdk/python/tests -v",
                         "python -m compileall -q sdk/python/src sdk/python/scripts",
                         "python scripts/verify_contract.py",
-                        'python -m unittest discover -s tests -p "test_conformance.py" -v'):
+                        'python -m unittest discover -s tests -p "test_conformance.py" -v',
+                        'python -m pip install --disable-pip-version-check build',
+                        'python -m build --outdir "$RUNNER_TEMP/python-sdk-dist" sdk/python',
+                        'python sdk/python/scripts/verify_wheel.py "$RUNNER_TEMP"/python-sdk-dist/*.whl'):
             self.assertIn("run: " + command, job)
         # No step-level condition can drop a check on the minimum runtime.
         self.assertNotIn("        if:", job)

--- a/scripts/ci/test_require_checks.py
+++ b/scripts/ci/test_require_checks.py
@@ -75,7 +75,7 @@ class RequiredChecksTest(unittest.TestCase):
         self.assertEqual(contexts, ["CI required", "Detect secrets"])
 
     def test_the_queue_cannot_outrun_the_free_plan_job_ceiling(self):
-        """A full merge group has 26 jobs; the documented concurrency limit is 20.
+        """A full merge group has 27 jobs; the documented concurrency limit is 20.
 
         Building more than one group at a time cannot run them in parallel; it
         only starves every open PR of runners.

--- a/scripts/ci/test_require_checks.py
+++ b/scripts/ci/test_require_checks.py
@@ -75,7 +75,7 @@ class RequiredChecksTest(unittest.TestCase):
         self.assertEqual(contexts, ["CI required", "Detect secrets"])
 
     def test_the_queue_cannot_outrun_the_free_plan_job_ceiling(self):
-        """One full CI run is 20 of the 20 concurrent jobs a free org gets.
+        """One full CI run has 21 jobs; the documented concurrency limit is 20.
 
         Building more than one group at a time cannot run them in parallel; it
         only starves every open PR of runners.

--- a/scripts/ci/test_require_checks.py
+++ b/scripts/ci/test_require_checks.py
@@ -75,7 +75,7 @@ class RequiredChecksTest(unittest.TestCase):
         self.assertEqual(contexts, ["CI required", "Detect secrets"])
 
     def test_the_queue_cannot_outrun_the_free_plan_job_ceiling(self):
-        """One full CI run is 19 of the 20 concurrent jobs a free org gets.
+        """One full CI run is 20 of the 20 concurrent jobs a free org gets.
 
         Building more than one group at a time cannot run them in parallel; it
         only starves every open PR of runners.

--- a/scripts/ci/test_require_checks.py
+++ b/scripts/ci/test_require_checks.py
@@ -75,7 +75,7 @@ class RequiredChecksTest(unittest.TestCase):
         self.assertEqual(contexts, ["CI required", "Detect secrets"])
 
     def test_the_queue_cannot_outrun_the_free_plan_job_ceiling(self):
-        """One full CI run has 23 jobs; the documented concurrency limit is 20.
+        """One full CI run has 24 jobs; the documented concurrency limit is 20.
 
         Building more than one group at a time cannot run them in parallel; it
         only starves every open PR of runners.

--- a/scripts/ci/test_require_checks.py
+++ b/scripts/ci/test_require_checks.py
@@ -75,7 +75,7 @@ class RequiredChecksTest(unittest.TestCase):
         self.assertEqual(contexts, ["CI required", "Detect secrets"])
 
     def test_the_queue_cannot_outrun_the_free_plan_job_ceiling(self):
-        """One full CI run has 24 jobs; the documented concurrency limit is 20.
+        """A full merge group has 26 jobs; the documented concurrency limit is 20.
 
         Building more than one group at a time cannot run them in parallel; it
         only starves every open PR of runners.

--- a/scripts/ci/test_require_checks.py
+++ b/scripts/ci/test_require_checks.py
@@ -75,7 +75,7 @@ class RequiredChecksTest(unittest.TestCase):
         self.assertEqual(contexts, ["CI required", "Detect secrets"])
 
     def test_the_queue_cannot_outrun_the_free_plan_job_ceiling(self):
-        """One full CI run has 21 jobs; the documented concurrency limit is 20.
+        """One full CI run has 22 jobs; the documented concurrency limit is 20.
 
         Building more than one group at a time cannot run them in parallel; it
         only starves every open PR of runners.

--- a/scripts/ci/test_require_checks.py
+++ b/scripts/ci/test_require_checks.py
@@ -75,7 +75,7 @@ class RequiredChecksTest(unittest.TestCase):
         self.assertEqual(contexts, ["CI required", "Detect secrets"])
 
     def test_the_queue_cannot_outrun_the_free_plan_job_ceiling(self):
-        """One full CI run has 22 jobs; the documented concurrency limit is 20.
+        """One full CI run has 23 jobs; the documented concurrency limit is 20.
 
         Building more than one group at a time cannot run them in parallel; it
         only starves every open PR of runners.

--- a/scripts/ci/test_sdk_changes.py
+++ b/scripts/ci/test_sdk_changes.py
@@ -1,0 +1,117 @@
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from sdk_changes import LANGUAGES, OWNED_FILES, classify, from_git
+
+
+SCRIPT = Path(__file__).with_name("sdk_changes.py").resolve()
+
+
+class SDKChangesTest(unittest.TestCase):
+    def test_sdk_sources_docs_and_owned_tooling(self):
+        for language in LANGUAGES:
+            for path in {f"sdk/{language}/src/client", f"sdk/{language}/README.md",
+                         f"sdk/{language}/new-tool"} | OWNED_FILES[language]:
+                with self.subTest(path=path):
+                    self.assertEqual(classify([path]), {language})
+
+    def test_public_contract_shared_fixtures_and_uncertainty_fan_out(self):
+        for path in (
+            "sdk/contract/contract.json", "sdk/contract/manifests/python.json",
+            "sdk/conformance/scenarios/new.json", "scripts/sdk-contract/build.py",
+            "apps/fountain/lib/fountain_web/schemas.ex",
+            "apps/fountain/lib/fountain_web/router.ex",
+            "apps/fountain/lib/fountain_web/controllers/api/agent_controller.ex",
+            "apps/fountain/lib/fountain_web/plugs/auth.ex",
+            "apps/fountain/lib/mix/tasks/openapi.export.ex",
+            "apps/fountain/lib/fountain/agents.ex", "config/config.exs", "mix.lock",
+            "ee/lib/fountain_web/controllers/api/credits_controller.ex",
+            "apps/fountain_buzz/lib/fountain_buzz_web/router.ex",
+            ".github/workflows/ci.yml", "scripts/ci/sdk_changes.py", "sdk/new-language/client",
+            "new-directory/unknown", "README.md",
+        ):
+            with self.subTest(path=path):
+                self.assertEqual(classify(["docs/index.md", path]), LANGUAGES)
+
+    def test_unrelated_paths_and_mixed_sdk_changes(self):
+        paths = ["docs/index.md", "decisions/0001-template.md", "assets/css/tokens.css",
+                 "apps/fountain/lib/fountain_web/live/dashboard_live/index.ex",
+                 "apps/fountain/lib/fountain_web/components/core_components.ex",
+                 "apps/fountain/lib/fountain/telemetry_tick.ex",
+                 "apps/fountain/test/fountain/agents_test.exs"]
+        self.assertEqual(classify(paths), set())
+        self.assertEqual(classify(paths + ["sdk/python/test.py", "sdk/swift/README.md"]),
+                         {"python", "swift"})
+        self.assertEqual(classify(["docs/sdk.md"]), {"typescript"})
+
+    def test_empty_and_ambiguous_paths_select_all(self):
+        self.assertEqual(classify([]), LANGUAGES)
+        for path in ("", "/docs/index.md", "docs/../config/config.exs", "docs//index.md",
+                     "docs/./index.md", "docs/file\nname", "docs/file\rname", "docs/file\x7f"):
+            with self.subTest(path=path):
+                self.assertEqual(classify([path]), LANGUAGES)
+
+    def test_unreadable_diff_selects_all(self):
+        for output in (b"", b"docs/index.md", b"docs/\xff\0"):
+            with self.subTest(output=output), patch("sdk_changes.subprocess.run") as run:
+                run.return_value.stdout = output
+                self.assertEqual(from_git("a" * 40), LANGUAGES)
+        with patch("sdk_changes.subprocess.run", side_effect=OSError):
+            self.assertEqual(from_git("a" * 40), LANGUAGES)
+
+    def test_actual_git_diff_handles_deletions_renames_and_output_safety(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            def git(*args):
+                return subprocess.check_output(["git", *args], cwd=root, stderr=subprocess.DEVNULL).decode().strip()
+            def write(path):
+                target = root / path
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_text("fixture\n")
+            def commit():
+                git("add", "-A")
+                git("-c", "user.name=SDK test", "-c", "user.email=sdk@example.invalid",
+                    "-c", "commit.gpgsign=false", "commit", "-qm", "fixture")
+                return git("rev-parse", "HEAD")
+            def selection(base):
+                result = subprocess.check_output([sys.executable, str(SCRIPT), base], cwd=root).decode()
+                values = dict(line.split("=") for line in result.splitlines())
+                self.assertEqual(set(values), {f"sdk_{language}" for language in LANGUAGES})
+                self.assertLessEqual(set(values.values()), {"true", "false"})
+                return {language for language in LANGUAGES if values[f"sdk_{language}"] == "true"}
+            git("init", "-q")
+            write("sdk/python/client.py")
+            base = commit()
+            git("mv", "sdk/python/client.py", "sdk/python/renamed.py")
+            commit()
+            self.assertEqual(selection(base), {"python"})
+            base = git("rev-parse", "HEAD")
+            write("docs/index.md")
+            git("mv", "sdk/python/renamed.py", "docs/renamed.py")
+            commit()
+            self.assertEqual(selection(base), {"python"})
+            base = git("rev-parse", "HEAD")
+            os.remove(root / "docs/index.md")
+            commit()
+            self.assertEqual(selection(base), set())
+            base = git("rev-parse", "HEAD")
+            write("docs/file\nsdk_python=false")
+            commit()
+            self.assertEqual(selection(base), LANGUAGES)
+            for bad_base in ("", "--output=unsafe", "a" * 40, git("rev-parse", "HEAD")):
+                with self.subTest(base=bad_base):
+                    self.assertEqual(selection(bad_base), LANGUAGES)
+
+    def test_workflow_exposes_decisions_from_the_classified_base(self):
+        workflow = (SCRIPT.parents[2] / ".github/workflows/ci.yml").read_text()
+        changes = workflow.split("\n  changes:\n", 1)[1].split("\n  test:\n", 1)[0]
+        for language in LANGUAGES:
+            self.assertIn(f"sdk_{language}: ${{{{ steps.sdks.outputs.sdk_{language} }}}}", changes)
+        self.assertIn('echo "diff_base=${base:-}"', changes)
+        self.assertIn("DIFF_BASE: ${{ steps.filter.outputs.diff_base }}", changes)
+        self.assertIn('python3 scripts/ci/sdk_changes.py "$DIFF_BASE" >> "$GITHUB_OUTPUT"', changes)

--- a/scripts/ci/test_sdk_gate.py
+++ b/scripts/ci/test_sdk_gate.py
@@ -1,0 +1,107 @@
+import copy
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import tempfile
+import unittest
+
+from gate import SDK_GATE_JOBS, SDK_JOBS, validate_sdks
+from test_gate import plan
+
+
+CASES = [
+    ("pull_request", {}), ("pull_request", {"docs": True}),
+    ("push", {}), ("push", {"reuse": True}),
+    ("merge_group", {}), ("merge_group", {"docs": True}),
+    ("merge_group", {"reuse": True}),
+]
+
+
+def sdk_plan(event, **options):
+    return {name: state for name, state in plan(event, **options).items()
+            if name in SDK_GATE_JOBS}
+
+
+class SdkGateTest(unittest.TestCase):
+    def test_workflow_reports_the_stable_check_even_when_legs_are_skipped(self):
+        root = Path(__file__).resolve().parents[2]
+        workflow = (root / ".github/workflows/ci.yml").read_text()
+        job = workflow.split("\n  sdk-checks:\n", 1)[1].split("\n  gate:\n", 1)[0]
+        self.assertIn("    name: SDK checks\n", job)
+        self.assertIn("    if: ${{ always() }}\n", job)
+        self.assertIn("run: python3 scripts/ci/gate.py --sdk", job)
+        dependencies = job.split("    needs:\n", 1)[1].split("    steps:\n", 1)[0]
+        self.assertEqual(set(re.findall(r"^      - (.*)$", dependencies, re.M)), SDK_GATE_JOBS)
+        self.assertEqual(SDK_JOBS, {"elixir-sdk", "python-sdk", "typescript-sdk", "swift-sdk"})
+
+    def test_full_docs_and_reused_plans_pass(self):
+        for event, options in CASES:
+            with self.subTest(event=event, options=options):
+                validate_sdks(event, sdk_plan(event, **options))
+
+    def test_no_failed_cancelled_missing_or_unexpectedly_skipped_result_passes(self):
+        for event, options in CASES:
+            original = sdk_plan(event, **options)
+            for name, state in original.items():
+                for result in ("success", "failure", "cancelled", "skipped", None):
+                    if result == state["result"]:
+                        continue
+                    with self.subTest(event=event, options=options, job=name, result=result):
+                        needs = copy.deepcopy(original)
+                        needs[name]["result"] = result
+                        with self.assertRaises(ValueError):
+                            validate_sdks(event, needs)
+
+    def test_missing_or_extra_dependencies_are_not_a_complete_sdk_plan(self):
+        for event, options in CASES:
+            for name in SDK_GATE_JOBS:
+                needs = sdk_plan(event, **options)
+                del needs[name]
+                with self.assertRaises(ValueError):
+                    validate_sdks(event, needs)
+            needs = sdk_plan(event, **options)
+            needs["unregistered-sdk"] = {"result": "success"}
+            with self.assertRaises(ValueError):
+                validate_sdks(event, needs)
+
+    def test_invalid_probe_outputs_cannot_authorize_skipping_sdks(self):
+        for event, options in CASES:
+            original = sdk_plan(event, **options)
+            for name in ("changes", "already-tested"):
+                for key in original[name]["outputs"]:
+                    for value in (None, "invalid"):
+                        needs = copy.deepcopy(original)
+                        needs[name]["outputs"][key] = value
+                        with self.subTest(event=event, probe=name, key=key, value=value):
+                            with self.assertRaises(ValueError):
+                                validate_sdks(event, needs)
+        with self.assertRaises(ValueError):
+            validate_sdks("unknown_event", sdk_plan("pull_request"))
+
+    def test_sdk_cli_never_publishes_whole_tree_reuse_evidence(self):
+        script = Path(__file__).with_name("gate.py").resolve()
+        for event, options in CASES:
+            with tempfile.TemporaryDirectory() as workdir:
+                env = dict(os.environ, GITHUB_EVENT_NAME=event,
+                           CI_NEEDS=json.dumps(sdk_plan(event, **options)))
+                result = subprocess.run([sys.executable, str(script), "--sdk"], cwd=workdir,
+                                        env=env, text=True, capture_output=True)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertFalse((Path(workdir) / "tested-tree.txt").exists())
+
+    def test_sdk_cli_exits_nonzero_for_a_failed_leg(self):
+        needs = sdk_plan("pull_request")
+        needs["typescript-sdk"]["result"] = "failure"
+        script = Path(__file__).with_name("gate.py").resolve()
+        with tempfile.TemporaryDirectory() as workdir:
+            result = subprocess.run(
+                [sys.executable, str(script), "--sdk"], cwd=workdir,
+                env=dict(os.environ, GITHUB_EVENT_NAME="pull_request", CI_NEEDS=json.dumps(needs)),
+                text=True, capture_output=True,
+            )
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("typescript-sdk: expected success, got failure", result.stderr)
+            self.assertFalse((Path(workdir) / "tested-tree.txt").exists())

--- a/scripts/ci/test_sdk_gate.py
+++ b/scripts/ci/test_sdk_gate.py
@@ -13,6 +13,7 @@ from test_gate import plan
 
 
 CASES = [
+    ("workflow_dispatch", {}),
     ("pull_request", {}), ("pull_request", {"docs": True}),
     ("push", {}), ("push", {"reuse": True}),
     ("merge_group", {}), ("merge_group", {"docs": True}),

--- a/scripts/ci/test_sdk_routing.py
+++ b/scripts/ci/test_sdk_routing.py
@@ -1,0 +1,97 @@
+import copy
+import itertools
+from pathlib import Path
+import re
+import unittest
+
+from gate import SDK_GATE_JOBS, SDK_JOBS, validate, validate_sdks
+from sdk_changes import classify
+from test_gate import plan
+
+
+class SDKRoutingTest(unittest.TestCase):
+    def check_both(self, event, needs):
+        validate(event, needs)
+        validate_sdks(event, {name: state for name, state in needs.items() if name in SDK_GATE_JOBS})
+
+    def reject_both(self, event, needs):
+        with self.assertRaises(ValueError):
+            validate(event, needs)
+        with self.assertRaises(ValueError):
+            validate_sdks(event, {name: state for name, state in needs.items() if name in SDK_GATE_JOBS})
+
+    def test_every_sdk_subset_on_code_docs_and_reused_plans(self):
+        for event, docs, reuse, flags in itertools.product(
+                ("pull_request", "merge_group"), (False, True), (False, True),
+                itertools.product((False, True), repeat=4)):
+            if event == "pull_request" and reuse:
+                continue
+            selected = {job for job, flag in zip(sorted(SDK_JOBS), flags) if flag}
+            with self.subTest(event=event, docs=docs, reuse=reuse, selected=selected):
+                original = plan(event, docs=docs, reuse=reuse, sdks=selected)
+                self.check_both(event, original)
+                for job in SDK_JOBS:
+                    for result in ("success", "failure", "cancelled", "skipped", None):
+                        if result == original[job]["result"]:
+                            continue
+                        needs = copy.deepcopy(original)
+                        needs[job]["result"] = result
+                        self.reject_both(event, needs)
+
+    def test_missing_or_invalid_sdk_decisions_fail_even_for_reused_trees(self):
+        for event, docs, reuse, job, value in itertools.product(
+                ("pull_request", "merge_group"), (False, True), (False, True), SDK_JOBS,
+                (None, "", "TRUE", "invalid", True, False, 0, [], {})):
+            if event == "pull_request" and reuse:
+                continue
+            needs = plan(event, docs=docs, reuse=reuse)
+            key = "sdk_" + job.removesuffix("-sdk")
+            if value is None:
+                del needs["changes"]["outputs"][key]
+            else:
+                needs["changes"]["outputs"][key] = value
+            with self.subTest(event=event, docs=docs, reuse=reuse, job=job, value=value):
+                self.reject_both(event, needs)
+
+    def test_classifier_decisions_select_jobs_in_both_gates(self):
+        cases = [(["sdk/python/src/fountain/http.py"], False, {"python-sdk"}),
+                 (["docs/swift-sdk.md"], True, {"swift-sdk"}),
+                 (["docs/index.md"], True, set()),
+                 (["assets/css/tokens.css"], False, set()),
+                 (["apps/fountain/lib/fountain/telemetry.ex"], False, set()),
+                 (["sdk/conformance/matrix.json"], False, SDK_JOBS),
+                 (["apps/fountain/lib/fountain_web/router.ex"], False, SDK_JOBS),
+                 (["unregistered/path"], False, SDK_JOBS)]
+        for paths, docs, expected in cases:
+            selected = {language + "-sdk" for language in classify(paths)}
+            self.assertEqual(selected, expected)
+            for event in ("pull_request", "merge_group"):
+                self.check_both(event, plan(event, docs=docs, sdks=selected))
+
+    def test_main_still_requires_all_sdks_unless_the_tree_was_tested(self):
+        self.check_both("push", plan("push"))
+        self.check_both("push", plan("push", reuse=True))
+        for job in SDK_JOBS:
+            needs = plan("push")
+            needs[job]["result"] = "skipped"
+            self.reject_both("push", needs)
+
+    def test_job_conditions_match_the_selection_and_preserve_contract_generation(self):
+        workflow = (Path(__file__).resolve().parents[2] / ".github/workflows/ci.yml").read_text()
+        jobs = dict(re.findall(r"^  ([a-z][a-z0-9-]*):\n(.*?)(?=^  [a-z][a-z0-9-]*:|\Z)",
+                               workflow.split("\njobs:\n", 1)[1], re.M | re.S))
+        for job in SDK_JOBS:
+            language = job.removesuffix("-sdk")
+            condition = re.search(r"^    if: (.*?)(?=\n\n)", jobs[job], re.M | re.S)[1]
+            self.assertEqual(condition, "${{ !cancelled() && needs.already-tested.outputs.skip != 'true'\n"
+                             f"         && needs.changes.outputs.sdk_{language} != 'false' }}}}")
+            self.assertIn("needs: [already-tested, changes]", jobs[job])
+        release = jobs["release-and-contract"]
+        steps = dict(re.findall(r"      - name: ([^\n]+)\n(.*?)(?=      - (?:name:|uses:)|\Z)", release, re.S))
+        condition = "        if: ${{ needs.changes.outputs.sdk_typescript != 'false' }}\n"
+        for name in ("Set up Node", "SDK install", "SDK types match the spec"):
+            self.assertIn(condition, steps[name])
+        self.assertEqual(release.count(condition), 3)
+        for name in ("Validate OpenAPI spec", "SDK wire contract is current"):
+            self.assertNotIn("        if:", steps[name])
+        self.assertIn("run: scripts/sdk-contract/build.sh --check", steps["SDK wire contract is current"])

--- a/scripts/ci/test_typescript_sdk_matrix.py
+++ b/scripts/ci/test_typescript_sdk_matrix.py
@@ -26,5 +26,6 @@ class TypeScriptSDKMatrixTest(unittest.TestCase):
                               ("TypeScript SDK conformance on the minimum runtime", "node scripts/test-compiled.mjs --conformance")):
             self.assertIn("if: ${{ matrix.node == '" + minimum + ".0' }}", steps[name])
             self.assertIn("run: " + command, steps[name])
-        for name in ("SDK install", "SDK typecheck", "SDK build", "SDK bundles for the browser", "TypeScript SDK contract"):
+        self.assertIn("run: node scripts/verify-package.mjs", steps["SDK packed artifact"])
+        for name in ("SDK install", "SDK typecheck", "SDK build", "SDK bundles for the browser", "SDK packed artifact", "TypeScript SDK contract"):
             self.assertNotIn("        if:", steps[name])

--- a/scripts/ci/test_typescript_sdk_matrix.py
+++ b/scripts/ci/test_typescript_sdk_matrix.py
@@ -1,0 +1,30 @@
+import json
+from pathlib import Path
+import re
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class TypeScriptSDKMatrixTest(unittest.TestCase):
+    def test_minimum_runtime_uses_compiled_tests_and_current_keeps_native_typescript(self):
+        package = json.loads((ROOT / "sdk/typescript/package.json").read_text())
+        minimum = package["engines"]["node"].removeprefix(">=")
+        workflow = (ROOT / ".github/workflows/ci.yml").read_text()
+        job = workflow.split("\n  typescript-sdk:\n", 1)[1].split("\n  cli-plugins:\n", 1)[0]
+        versions = re.findall(r'"([0-9.]+)"', re.search(r"        node: \[(.*)\]", job)[1])
+        self.assertIn(minimum + ".0", versions)
+        self.assertIn("24", versions)
+        self.assertIn("fail-fast: false", job)
+        self.assertIn("node-version: ${{ matrix.node }}", job)
+        steps = dict(re.findall(r"      - name: ([^\n]+)\n(.*?)(?=      - (?:name:|uses:)|\Z)", job, re.S))
+        for name, command in (("SDK tests", "npm test"), ("TypeScript SDK conformance", "npm run conformance")):
+            self.assertIn("if: ${{ matrix.node == '24' }}", steps[name])
+            self.assertIn("run: " + command, steps[name])
+        for name, command in (("SDK tests on the minimum runtime", "node scripts/test-compiled.mjs"),
+                              ("TypeScript SDK conformance on the minimum runtime", "node scripts/test-compiled.mjs --conformance")):
+            self.assertIn("if: ${{ matrix.node == '" + minimum + ".0' }}", steps[name])
+            self.assertIn("run: " + command, steps[name])
+        for name in ("SDK install", "SDK typecheck", "SDK build", "SDK bundles for the browser", "TypeScript SDK contract"):
+            self.assertNotIn("        if:", steps[name])

--- a/sdk/python/scripts/verify_wheel.py
+++ b/sdk/python/scripts/verify_wheel.py
@@ -1,0 +1,57 @@
+"""Install a built wheel in isolation and exercise it with the SDK regression suite."""
+
+import argparse
+from pathlib import Path
+import subprocess
+import tempfile
+import venv
+
+
+RUN_TESTS = """
+from importlib.metadata import version
+from pathlib import Path
+import sys
+import unittest
+
+# Import before discovery: existing tests add src/ to sys.path, but this
+# package and its submodules must resolve from the installed wheel.
+import fountain
+
+package = Path(fountain.__file__).resolve().parent
+if not package.is_relative_to(Path(sys.prefix).resolve()):
+    raise RuntimeError("Fountain did not load from the isolated environment")
+if not (package / "py.typed").is_file():
+    raise RuntimeError("The wheel omitted its py.typed marker")
+if fountain.__version__ != version("fountain-agent-sdk"):
+    raise RuntimeError("Installed package and SDK versions differ")
+print("Testing installed SDK from " + str(package), flush=True)
+suite = unittest.defaultTestLoader.discover(sys.argv[1])
+if not suite.countTestCases():
+    raise RuntimeError("No SDK regression tests were discovered")
+result = unittest.TextTestRunner(verbosity=2).run(suite)
+for name, module in list(sys.modules.items()):
+    if name == "fountain" or name.startswith("fountain."):
+        if not Path(module.__file__).resolve().is_relative_to(package):
+            raise RuntimeError("Test imported SDK source outside the wheel: " + name)
+sys.exit(0 if result.wasSuccessful() else 1)
+"""
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("wheel", type=Path)
+    args = parser.parse_args()
+    wheel = args.wheel.resolve()
+    sdk = Path(__file__).resolve().parents[1]
+    with tempfile.TemporaryDirectory(prefix="fountain-wheel-") as directory:
+        environment = Path(directory) / "venv"
+        venv.EnvBuilder(with_pip=True).create(environment)
+        python = environment / ("Scripts/python.exe" if (environment / "Scripts").exists() else "bin/python")
+        subprocess.run([str(python), "-I", "-m", "pip", "install", "--no-index", "--no-deps",
+                        "--disable-pip-version-check", str(wheel)], check=True, cwd=directory)
+        subprocess.run([str(python), "-I", "-c", RUN_TESTS, str(sdk / "tests")],
+                       check=True, cwd=directory)
+
+
+if __name__ == "__main__":
+    main()

--- a/sdk/typescript/scripts/test-compiled.mjs
+++ b/sdk/typescript/scripts/test-compiled.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+// Exercise the same tests on runtimes that cannot execute TypeScript directly.
+import { cpSync, mkdirSync, mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { execFileSync, spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const sdk = join(dirname(fileURLToPath(import.meta.url)), "..");
+const mode = process.argv.slice(2);
+if (mode.length > 1 || (mode.length === 1 && mode[0] !== "--conformance")) {
+  throw new Error("usage: node scripts/test-compiled.mjs [--conformance]");
+}
+const temporary = mkdtempSync(join(tmpdir(), "fountain-sdk-tests-"));
+const output = join(temporary, "sdk", "typescript");
+try {
+  mkdirSync(output, { recursive: true });
+  execFileSync(process.execPath, [join(sdk, "node_modules/typescript/lib/tsc.js"),
+    "-p", join(sdk, "tsconfig.json"), "--outDir", output], { cwd: sdk, stdio: "inherit" });
+  // Keep the tests' relative fixture paths and source/package inspections.
+  cpSync(join(sdk, "src"), join(output, "src"), { recursive: true });
+  cpSync(join(sdk, "package.json"), join(output, "package.json"));
+  for (const fixtures of ["conformance", "contract"]) {
+    cpSync(join(sdk, "..", fixtures), join(temporary, "sdk", fixtures), { recursive: true });
+  }
+  const tests = mode.length ? ["conformance.test.js"]
+    : readdirSync(join(output, "test")).filter(name => name.endsWith(".test.js")).sort();
+  if (!tests.length) throw new Error("No compiled SDK tests found");
+  const result = spawnSync(process.execPath, ["--test", ...tests.map(name => join(output, "test", name))],
+    { cwd: output, stdio: "inherit" });
+  if (result.error) throw result.error;
+  process.exitCode = result.status ?? 1;
+} finally {
+  rmSync(temporary, { recursive: true, force: true });
+}

--- a/sdk/typescript/scripts/verify-package.mjs
+++ b/sdk/typescript/scripts/verify-package.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+// Pack the built SDK, then typecheck and run a consumer outside the checkout.
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const sdk = join(dirname(fileURLToPath(import.meta.url)), "..");
+const { name } = JSON.parse(readFileSync(join(sdk, "package.json"), "utf8"));
+const temporary = mkdtempSync(join(tmpdir(), "fountain-package-"));
+try {
+  const packed = JSON.parse(execFileSync("npm", ["pack", "--json", "--offline", "--ignore-scripts",
+    "--pack-destination", temporary], { cwd: sdk, encoding: "utf8", stdio: ["ignore", "pipe", "inherit"] }));
+  if (packed.length !== 1 || !packed[0].filename) throw new Error("Expected one SDK tarball");
+  const consumer = join(temporary, "consumer");
+  mkdirSync(consumer);
+  writeFileSync(join(consumer, "package.json"), JSON.stringify({ private: true, type: "module" }));
+  // The SDK promises no runtime dependencies; the local tarball is sufficient.
+  execFileSync("npm", ["install", "--offline", "--ignore-scripts", "--no-audit", "--no-fund",
+    "--package-lock=false", "--no-save", join(temporary, packed[0].filename)],
+    { cwd: consumer, stdio: "inherit" });
+  writeFileSync(join(consumer, "consumer.ts"), `
+import Fountain, { type Agent } from ${JSON.stringify(name)};
+import BrowserFountain from ${JSON.stringify(name + "/browser")};
+
+async function verify(Client: typeof Fountain) {
+  let calls = 0;
+  const client = new Client({
+    baseUrl: "https://package.invalid", apiKey: "package-test",
+    fetch: async (input, init) => {
+      const request = new Request(input, init);
+      if (request.url !== "https://package.invalid/api/agents" || request.method !== "GET"
+          || request.headers.get("authorization") !== "Bearer package-test") {
+        throw new Error("The installed SDK made an unexpected request");
+      }
+      calls++;
+      return new Response(JSON.stringify({ data: [] }), { headers: { "content-type": "application/json" } });
+    },
+  });
+  const agents: Agent[] = await client.agents.list();
+  if (calls !== 1 || agents.length !== 0) throw new Error("The installed SDK returned an unexpected collection");
+}
+await verify(Fountain);
+await verify(BrowserFountain);
+`);
+  // No project paths alias or skipLibCheck: resolve the published declarations.
+  execFileSync(process.execPath, [join(sdk, "node_modules/typescript/lib/tsc.js"), "--strict",
+    "--target", "ES2022", "--lib", "ES2022,DOM", "--module", "NodeNext",
+    "--moduleResolution", "NodeNext", "consumer.ts"], { cwd: consumer, stdio: "inherit" });
+  execFileSync(process.execPath, ["consumer.js"], { cwd: consumer, stdio: "inherit" });
+  execFileSync("npx", ["--yes", "esbuild", "consumer.ts", "--bundle", "--platform=browser",
+    "--format=esm", "--outfile=consumer.bundle.js"], { cwd: consumer, stdio: "inherit" });
+  console.log("Packed SDK declarations, entry points and browser bundle passed consumer checks.");
+} finally {
+  rmSync(temporary, { recursive: true, force: true });
+}


### PR DESCRIPTION
Collapsed stack for #1413: splits the monolithic `sdk-clients` CI job into
per-SDK jobs, adds a stable aggregate check, a path classifier with selective
routing, runtime-boundary matrices and packaging tests.

Originally cut as twelve chained PRs (#1984-#1995). Each was reviewed and
approved individually; this PR carries all twelve commits so the combination
gets one full CI run against current `main` instead of twelve serial
merge-queue builds. The individual PRs stay open until this merges, then close
as superseded.

| PR | Commit |
|---|---|
| #1984 | run the Elixir SDK checks in a separate job |
| #1985 | run the Python SDK checks in a separate job |
| #1986 | run the TypeScript SDK checks in a separate job |
| #1987 | report a stable SDK aggregate check |
| #1988 | classify SDK paths before enabling selective jobs |
| #1989 | run only SDKs selected by the change classifier |
| #1990 | validate the full plan on manual workflow dispatch |
| #1991 | test Python SDK on declared runtime boundaries |
| #1992 | test TypeScript SDK on the minimum Node runtime |
| #1993 | test Elixir SDK on its minimum supported runtime |
| #1994 | test the built Python SDK wheel in isolation |
| #1995 | validate the packed TypeScript SDK in a consumer project |

`main` moved 36 commits since the stack was cut, including three CI changes
(#1927, #1939, #1940). The merge is clean and the CI policy suite passes on the
merged tree (56 tests), with both sides' workflow changes intact.

Known follow-ups, none blocking:

- A docs-only edit to `docs/swift-sdk.md` now starts the two-runner `swift-sdk`
  matrix including `macos-15`; no step in that job reads the page.
- Full-run concurrency goes from ~21 to 26-27 legs against the free plan's
  20-concurrent ceiling. `require-checks.py`'s `max_entries_to_build: 1`
  reasoning and `decisions/0050` still cite the old count.
- `CLAUDE.md:424` still documents a single `sdk-clients` job;
  `scripts/ci/README.md:88` and `ci.yml:908` claim `swift-sdk` validates
  conformance fixtures, which it does not.
- `ee/test/` is missing from `sdk_changes.py`'s `UNRELATED_PREFIXES` (fail-open).
  Any fix must be `ee/test/` specifically, never `ee/` — `ee/lib/fountain_web/**`
  must keep fanning out because it can move the OpenAPI document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HD7jxhmpwc8fAbWAHby4PE
