### PR TITLE
fix: preserve rebound turns when an old actor stops

### DIFF
--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -2224,33 +2224,44 @@ defmodule Fountain.Conversations do
 
   This function is unscoped because it is called by a conversation's own
   server and by the system reaper. Callers may supply audit attribution.
+
+  An actor recovering its own turn passes `:expected_sandbox_id`; the locked
+  parent having been rebound to another sandbox answers
+  `{:error, :ownership_changed}` and writes nothing. The reaper omits the key,
+  because it recovers on nobody's behalf.
   """
   def _unsafe_orphan_turn(%Turn{} = turn, why, opts \\ []) do
     # ownership: this is the existing actor's turn or a system recovery candidate.
+    recover_opts = Keyword.take(opts, [:expected_sandbox_id])
+
     result =
-      ExecutionGuard._unsafe_recover_turn(turn, fn current, conv, latest?, bounded? ->
-        now = DateTime.utc_now() |> DateTime.truncate(:second)
-        reply_text = current.reply_text || _unsafe_turn_reply_text(current)
+      ExecutionGuard._unsafe_recover_turn(
+        turn,
+        fn current, conv, latest?, bounded? ->
+          now = DateTime.utc_now() |> DateTime.truncate(:second)
+          reply_text = current.reply_text || _unsafe_turn_reply_text(current)
 
-        updates =
-          if current.status == "running",
-            do: [status: "interrupted", ended_at: now, orphaned_at: now],
-            else: [orphaned_at: now]
+          updates =
+            if current.status == "running",
+              do: [status: "interrupted", ended_at: now, orphaned_at: now],
+              else: [orphaned_at: now]
 
-        updated =
-          current
-          |> Turn.changeset(Map.new(maybe_set_reply_text(updates, reply_text)))
-          |> Repo.update!()
+          updated =
+            current
+            |> Turn.changeset(Map.new(maybe_set_reply_text(updates, reply_text)))
+            |> Repo.update!()
 
-        conversation_changed? = latest? and conv.status == "running"
+          conversation_changed? = latest? and conv.status == "running"
 
-        conv =
-          if conversation_changed?,
-            do: conv |> Conversation.changeset(%{status: "idle"}) |> Repo.update!(),
-            else: conv
+          conv =
+            if conversation_changed?,
+              do: conv |> Conversation.changeset(%{status: "idle"}) |> Repo.update!(),
+              else: conv
 
-        {updated, conv, conversation_changed?, bounded?}
-      end)
+          {updated, conv, conversation_changed?, bounded?}
+        end,
+        recover_opts
+      )
 
     case result do
       {:ok, :noop} ->

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -2021,7 +2021,11 @@ defmodule Fountain.Conversations.ConversationServer do
     _ = CallbackKey.revoke(state.conversation_id, state.callback_api_key_id)
 
     # Last and best-effort, so it cannot skip the revocation above.
-    _ = TurnMachine.orphan_on_normal_stop(reason, state.current_turn, state.conversation_id)
+    _ =
+      TurnMachine.orphan_on_normal_stop(reason, state.current_turn, state.conversation_id,
+        expected_sandbox_id: state.sandbox_id
+      )
+
     :ok
   end
 

--- a/apps/fountain/lib/fountain/conversations/execution_guard.ex
+++ b/apps/fountain/lib/fountain/conversations/execution_guard.ex
@@ -387,14 +387,27 @@ defmodule Fountain.Conversations.ExecutionGuard do
     end)
   end
 
-  @doc "Retire an orphan's execution before recovery writes, in parent/journal/turn lock order."
-  def _unsafe_recover_turn(%Turn{} = observed, writer) do
+  @doc """
+  Retire an orphan's execution before recovery writes, in parent/journal/turn lock order.
+
+  `:expected_sandbox_id` is the recovering actor's own binding. `cleanup_binding?/1`
+  already refuses a bounded turn whose journal names a sandbox the parent no
+  longer points at, but an unbounded turn has no journal row and nothing else
+  records which machine was driving it. An actor that supplies the option and
+  finds the locked parent reassigned recovers nothing: the rollback happens
+  before `retire_orphan/2`, so a stale actor writes neither the turn nor the
+  journal. Supplying `nil` is an expectation of "no sandbox", not an absent one;
+  omitting the key entirely is what the system reaper does, because it is
+  recovering on nobody's behalf.
+  """
+  def _unsafe_recover_turn(%Turn{} = observed, writer, opts \\ []) do
     transaction(fn ->
       conv = lock_parent(observed.conversation_id) || Repo.rollback(:not_found)
       execution = lock_execution_by_turn(observed.id)
       turn = lock_turn(observed.id) || Repo.rollback(:turn_missing)
       if turn.conversation_id != conv.id, do: Repo.rollback(:ownership_changed)
 
+      if rebound?(opts, conv), do: Repo.rollback(:ownership_changed)
       if execution && not cleanup_binding?(execution), do: Repo.rollback(:ownership_changed)
       running? = turn.status == "running"
       {turn, changed, event} = retire_orphan(execution, turn)
@@ -958,6 +971,13 @@ defmodule Fountain.Conversations.ExecutionGuard do
   # must still prove its tenant/name/provider binding; a surviving conversation
   # must also remain bound to it. Missing or changed sandbox identity stays
   # uncertain. Reset cannot reuse this row while its journal remains open.
+  defp rebound?(opts, conv) do
+    case Keyword.fetch(opts, :expected_sandbox_id) do
+      {:ok, expected} -> expected != conv.sandbox_id
+      :error -> false
+    end
+  end
+
   defp cleanup_binding?(execution) do
     sandbox_matches =
       Repo.exists?(

--- a/apps/fountain/lib/fountain/conversations/execution_guard.ex
+++ b/apps/fountain/lib/fountain/conversations/execution_guard.ex
@@ -971,13 +971,6 @@ defmodule Fountain.Conversations.ExecutionGuard do
   # must still prove its tenant/name/provider binding; a surviving conversation
   # must also remain bound to it. Missing or changed sandbox identity stays
   # uncertain. Reset cannot reuse this row while its journal remains open.
-  defp rebound?(opts, conv) do
-    case Keyword.fetch(opts, :expected_sandbox_id) do
-      {:ok, expected} -> expected != conv.sandbox_id
-      :error -> false
-    end
-  end
-
   defp cleanup_binding?(execution) do
     sandbox_matches =
       Repo.exists?(
@@ -994,6 +987,28 @@ defmodule Fountain.Conversations.ExecutionGuard do
       end
 
     sandbox_matches and parent_matches
+  end
+
+  # The other half of the same question, for a turn that has no journal row to
+  # ask it of. `cleanup_binding?/1` above compares the *journal's* recorded
+  # sandbox identity; this compares the *actor's* — the only record that exists
+  # when there is no `TurnExecution`.
+  #
+  # That is not a corner case. Whether a journal row exists is decided by
+  # execution limits (`resolve_turn_limits/1`), not by turn capacity, and limits
+  # ship inert: `host_ceiling/0` is `%{}` and `enforced_controls/1` is `[]`
+  # (#1773-#1793). So today every production turn takes the no-journal path and
+  # this guard is the only thing standing between a stale actor and another
+  # machine's turn. Do not delete it as exotic.
+  #
+  # An explicit `nil` is an expectation of "no sandbox" and fences; only an
+  # absent key means the caller is recovering on nobody's behalf, which is why
+  # this is `Keyword.fetch/2` and not `Keyword.get/2`.
+  defp rebound?(opts, conv) do
+    case Keyword.fetch(opts, :expected_sandbox_id) do
+      {:ok, expected} -> expected != conv.sandbox_id
+      :error -> false
+    end
   end
 
   defp current_binding?(execution) do

--- a/apps/fountain/lib/fountain/conversations/turn_machine.ex
+++ b/apps/fountain/lib/fountain/conversations/turn_machine.ex
@@ -1693,10 +1693,16 @@ defmodule Fountain.Conversations.TurnMachine do
   reattach. Best-effort by design: the caller runs this on the way out of
   `terminate/2`, and a raise here must not take the rest of that callback
   with it.
+
+  The stopping server is an actor, so it passes the sandbox it was bound to:
+  a parent rebound underneath it belongs to a successor and this recovery
+  writes nothing. `opts` is required rather than defaulted, because a caller
+  that forgets it silently recovers a turn it no longer owns.
   """
-  @spec orphan_on_normal_stop(term(), Conversations.Turn.t() | nil, String.t() | nil) :: :ok
-  def orphan_on_normal_stop(:normal, turn, conversation_id) when not is_nil(turn) do
-    _ = Conversations._unsafe_orphan_turn(turn, "server_terminated_normally")
+  @spec orphan_on_normal_stop(term(), Conversations.Turn.t() | nil, String.t() | nil, keyword()) ::
+          :ok
+  def orphan_on_normal_stop(:normal, turn, conversation_id, opts) when not is_nil(turn) do
+    _ = Conversations._unsafe_orphan_turn(turn, "server_terminated_normally", opts)
     :ok
   rescue
     error ->
@@ -1708,5 +1714,5 @@ defmodule Fountain.Conversations.TurnMachine do
       :ok
   end
 
-  def orphan_on_normal_stop(_reason, _turn, _conversation_id), do: :ok
+  def orphan_on_normal_stop(_reason, _turn, _conversation_id, _opts), do: :ok
 end

--- a/apps/fountain/test/fountain/conversations/orphan_binding_isolation_test.exs
+++ b/apps/fountain/test/fountain/conversations/orphan_binding_isolation_test.exs
@@ -1,0 +1,142 @@
+defmodule Fountain.Conversations.OrphanBindingIsolationTest do
+  use Fountain.DataCase, async: false
+
+  alias Fountain.Conversations
+  alias Fountain.Conversations.Conversation
+
+  @moduledoc """
+  The actor's binding check and the reassignment that invalidates it serialize.
+
+  `ExecutionGuard._unsafe_recover_turn/3` takes `FOR UPDATE` on the parent
+  before it compares `:expected_sandbox_id`, so the comparison and every write
+  that follows it happen under one lock. These two tests run the pair in both
+  orders against a real PostgreSQL backend and assert the lock wait is real,
+  which a same-connection sandbox test cannot show.
+  """
+
+  for first <- [:reassignment, :orphan] do
+    @tag first: first
+    test "#{first} serializes orphan bookkeeping with reassignment", %{first: first} do
+      Ecto.Adapters.SQL.Sandbox.unboxed_run(Repo, fn ->
+        user = insert_verified_user()
+        old = insert_sandbox(user_id: user.id, status: "ready")
+        replacement = insert_sandbox(user_id: user.id, status: "ready")
+        conv = insert_conversation(user_id: user.id, sandbox: old, status: "running")
+        turn = insert_turn(conv, status: "running")
+        owner = self()
+        handler = {__MODULE__, make_ref()}
+
+        # Pause inside the real recovery transaction after its turn update. This
+        # proves the parent lock remains held through the write, without wrapping
+        # the public function (and its audit) in an artificial outer transaction.
+        :telemetry.attach(handler, [:fountain, :repo, :query], &__MODULE__.pause_orphan/4, owner)
+
+        orphan = fn ->
+          # Internal actor reconciliation; the fixture belongs to this test's tenant.
+          Conversations._unsafe_orphan_turn(turn, "binding_race", expected_sandbox_id: old.id)
+        end
+
+        reassign = fn ->
+          Conversations.update_conversation(conv, %{sandbox_id: replacement.id})
+        end
+
+        leading =
+          independent(fn ->
+            if first == :orphan do
+              Process.put(:pause_orphan_binding_test, true)
+              orphan.()
+            else
+              Repo.transaction(fn ->
+                from(c in Conversation, where: c.id == ^conv.id)
+                |> Repo.update_all(set: [sandbox_id: replacement.id])
+
+                hold(owner)
+              end)
+            end
+          end)
+
+        try do
+          assert_receive :write_held, 5_000
+          trailing = independent(if first == :orphan, do: reassign, else: orphan)
+
+          try do
+            trailing_pid = trailing.pid
+            assert_receive {:backend, ^trailing_pid, backend}, 5_000
+            await_blocked(backend, System.monotonic_time(:millisecond) + 5_000)
+            send(leading.pid, :commit)
+            leading_result = Task.await(leading)
+            trailing_result = Task.await(trailing)
+
+            if first == :orphan do
+              assert {:ok, _, _} = leading_result
+              assert {:ok, _} = trailing_result
+              assert Repo.reload(turn).status == "interrupted"
+              assert Repo.reload(turn).orphaned_at
+            else
+              assert {:ok, :ok} = leading_result
+              # The stale actor loses the same way #1751's journal mismatch
+              # loses, and for the same reason: it no longer owns the parent.
+              assert {:error, :ownership_changed} = trailing_result
+              assert Repo.reload(turn).status == "running"
+              assert Repo.reload(turn).orphaned_at == nil
+            end
+
+            assert Repo.reload(conv).sandbox_id == replacement.id
+            assert Repo.reload(conv).status == if(first == :orphan, do: "idle", else: "running")
+          after
+            Task.shutdown(trailing, :brutal_kill)
+          end
+        after
+          Task.shutdown(leading, :brutal_kill)
+          :telemetry.detach(handler)
+          Repo.delete_all(from e in Fountain.Audit.Event, where: e.user_id == ^user.id)
+          Repo.delete!(user)
+          Repo.delete!(old)
+          Repo.delete!(replacement)
+        end
+      end)
+    end
+  end
+
+  def pause_orphan(_event, _measurements, metadata, owner) do
+    if Process.get(:pause_orphan_binding_test) &&
+         String.starts_with?(metadata.query, ~s(UPDATE "turns")) do
+      Process.delete(:pause_orphan_binding_test)
+      hold(owner)
+    end
+  end
+
+  defp hold(owner) do
+    send(owner, :write_held)
+
+    receive do
+      :commit -> :ok
+    after
+      10_000 -> raise "binding write release timed out"
+    end
+  end
+
+  defp independent(fun) do
+    owner = self()
+
+    Task.async(fn ->
+      Ecto.Adapters.SQL.Sandbox.unboxed_run(Repo, fn ->
+        %{rows: [[backend]]} = Repo.query!("SELECT pg_backend_pid()")
+        send(owner, {:backend, self(), backend})
+        fun.()
+      end)
+    end)
+  end
+
+  defp await_blocked(backend, deadline) do
+    %{rows: [[blocked]]} = Repo.query!("SELECT cardinality(pg_blocking_pids($1)) > 0", [backend])
+
+    unless blocked do
+      assert System.monotonic_time(:millisecond) < deadline,
+             "no PostgreSQL row-lock wait observed"
+
+      Process.sleep(5)
+      await_blocked(backend, deadline)
+    end
+  end
+end

--- a/apps/fountain/test/fountain/conversations/turn_parent_test.exs
+++ b/apps/fountain/test/fountain/conversations/turn_parent_test.exs
@@ -235,6 +235,40 @@ defmodule Fountain.Conversations.TurnParentTest do
     assert Repo.get!(Turn, next.id).status == "running"
   end
 
+  test "an actor cannot recover an unbounded turn whose parent was rebound" do
+    user = insert_verified_user()
+    old = insert_sandbox(user_id: user.id, status: "ready")
+    replacement = insert_sandbox(user_id: user.id, status: "ready")
+    conv = insert_conversation(user_id: user.id, sandbox: old, status: "running")
+    turn = insert_turn(conv, status: "running")
+
+    {:ok, _} = Conversations.update_conversation(conv, %{sandbox_id: replacement.id})
+
+    # No journal row, so `cleanup_binding?/1` has nothing to compare: the
+    # actor's own `:expected_sandbox_id` is the only record of the binding.
+    assert {:error, :ownership_changed} =
+             Conversations._unsafe_orphan_turn(turn, "rebound", expected_sandbox_id: old.id)
+
+    assert Repo.get!(Turn, turn.id).status == "running"
+    assert Repo.get!(Conversation, conv.id).status == "running"
+  end
+
+  test "an actor expecting no sandbox cannot recover a bound parent" do
+    user = insert_verified_user()
+    sandbox = insert_sandbox(user_id: user.id, status: "ready")
+    conv = insert_conversation(user_id: user.id, sandbox: sandbox, status: "running")
+    turn = insert_turn(conv, status: "running")
+
+    # An explicit nil is an expectation of "no sandbox", not an absent one.
+    assert {:error, :ownership_changed} =
+             Conversations._unsafe_orphan_turn(turn, "unbound_actor", expected_sandbox_id: nil)
+
+    assert Repo.get!(Turn, turn.id).status == "running"
+
+    # The reaper omits the key entirely and still recovers.
+    assert {:ok, %{status: "interrupted"}, _} = Conversations._unsafe_orphan_turn(turn, "reaper")
+  end
+
   test "legacy recovery closes its old turn without idling a newer running generation" do
     conv = insert_conversation(user_id: insert_verified_user().id, status: "running")
     old = insert_turn(conv, status: "running")

--- a/apps/fountain/test/fountain/workers/autonomous_turn_reaper_test.exs
+++ b/apps/fountain/test/fountain/workers/autonomous_turn_reaper_test.exs
@@ -135,6 +135,7 @@ defmodule Fountain.Workers.AutonomousTurnReaperTest do
       assert :ok =
                ConversationServer.terminate(:normal, %{
                  conversation_id: conv.id,
+                 sandbox_id: conv.sandbox_id,
                  callback_api_key_id: nil,
                  current_turn: turn
                })
@@ -144,12 +145,41 @@ defmodule Fountain.Workers.AutonomousTurnReaperTest do
       assert Repo.reload(conv).status == "idle"
     end
 
+    test "an old actor leaves a rebound conversation and its turn untouched" do
+      {user, conv, turn} = running_turn()
+      replacement = insert_sandbox(user_id: user.id, status: "ready")
+      {:ok, _} = Conversations.update_conversation(conv, %{sandbox_id: replacement.id})
+      Phoenix.PubSub.subscribe(Fountain.PubSub, "conv:#{conv.id}")
+
+      # The turn is unbounded, so it carries no journal row and #1751's
+      # `cleanup_binding?` has nothing to compare. The actor's own binding is
+      # the only record of which machine was driving it.
+      assert :ok =
+               ConversationServer.terminate(:normal, %{
+                 conversation_id: conv.id,
+                 sandbox_id: conv.sandbox_id,
+                 callback_api_key_id: nil,
+                 current_turn: turn
+               })
+
+      assert Repo.reload(turn) == turn
+      assert Repo.reload(conv).sandbox_id == replacement.id
+      assert Repo.reload(conv).status == "running"
+      refute_receive {:log_event, %{stage: "reattach"}}
+
+      refute Enum.any?(
+               Audit.list_recent_for_user(user.id),
+               &(&1.action == "conversation.turn.orphaned")
+             )
+    end
+
     test "a supervisor shutdown leaves the turn available for reattach" do
       {_user, conv, turn} = running_turn()
 
       assert :ok =
                ConversationServer.terminate(:shutdown, %{
                  conversation_id: conv.id,
+                 sandbox_id: conv.sandbox_id,
                  callback_api_key_id: nil,
                  current_turn: turn
                })


### PR DESCRIPTION
A normally stopping conversation actor could orphan its running turn and mark the conversation idle after another process moved that conversation to a different sandbox. Normal shutdown now supplies the actor’s sandbox ID. Orphan reconciliation locks the conversation row and checks that binding before writing either the turn or the conversation; a mismatch produces no turn, status, stage or audit writes.

The parent lock remains held through both conditional writes. Existing system-reaper calls retain their unbound behavior, and completed turns remain a no-op. Audit and event publication remain outside the transaction.

Stack: based on #1983. Refs #1767. This unit protects normal-stop bookkeeping across sandbox reassignment. Same-sandbox replacement actor ownership and durable forced-teardown recovery remain separate follow-ups.

Validation:
- 146 focused tests passed, including normal shutdown, existing reaper/turn-machine behavior and audit guardrails.
- Two real PostgreSQL connection tests observe row-lock waits in both race orders. Reassignment first preserves the running turn; orphaning first finishes before reassignment commits.
- Running the new tests against the parent implementation produced the three expected regression failures; restoring this change passed all focused tests.
- Full `mix precommit` passed: Fountain 5,437 tests and 6 doctests, Buzz 144 tests, Support 33 tests; zero failures.
