### PR TITLE
fix: preserve moved conversations when teardown finishes

### DIFF
--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -1243,6 +1243,34 @@ defmodule Fountain.Conversations do
   end
 
   @doc """
+  Finish an actor's termination only while the conversation is still bound to
+  its sandbox. The binding check and status write are one database statement,
+  so a reassignment during provider cleanup cannot terminate the new binding.
+
+  The actor owns both IDs. This is internal lifecycle bookkeeping; the public
+  `ConversationServer.terminate_conversation/2` records the action's audit once
+  after a successful reply. A missing or moved conversation returns a refusal.
+  """
+  def _unsafe_finish_conversation_termination(conversation_id, sandbox_id) do
+    query =
+      from(c in Conversation,
+        where: c.id == ^conversation_id and c.sandbox_id == ^sandbox_id,
+        select: c
+      )
+
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    case Repo.update_all(query, set: [status: "terminated", updated_at: now]) do
+      {1, [conv]} ->
+        broadcast_sidebar_update(conv.user_id)
+        {:ok, conv}
+
+      {0, _} ->
+        {:error, :sandbox_unavailable}
+    end
+  end
+
+  @doc """
   Re-resolve the Agent, Environment and Vault for an existing conversation,
   on the machine it is already running (#1565).
 

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -1904,11 +1904,8 @@ defmodule Fountain.Conversations.ConversationServer do
     # no stop path touches the sprite.
     state = if state.current_turn, do: interrupt_turn(state), else: state
     state = drop_connection(state, "terminated")
-    # ownership: the conditional fence verified this server-owned conversation.
-    conv = Conversations._unsafe_get_conversation!(state.conversation_id)
-    {:ok, _} = Conversations.update_conversation(conv, %{status: "terminated"})
 
-    Output.publish_stage(state.conversation_id, "terminate", "done", %{
+    finish_termination(%{state | handle: nil}, %{
       sandbox: "kept",
       reason:
         if(Lifecycle.home?(state.sandbox_id),
@@ -1916,8 +1913,6 @@ defmodule Fountain.Conversations.ConversationServer do
           else: "held_by_another_conversation"
         )
     })
-
-    {:stop, :normal, :ok, %{state | handle: nil}}
   end
 
   defp terminate_machine(state, sandbox) do
@@ -1928,11 +1923,25 @@ defmodule Fountain.Conversations.ConversationServer do
     {:ok, _} =
       Conversations.update_sandbox(sandbox, %{status: "terminated", terminated_at: now()})
 
-    # ownership: the conditional fence verified this server-owned conversation.
-    conv = Conversations._unsafe_get_conversation!(state.conversation_id)
-    {:ok, _} = Conversations.update_conversation(conv, %{status: "terminated"})
-    Output.publish_stage(state.conversation_id, "terminate", "done")
-    {:stop, :normal, :ok, state}
+    finish_termination(state, %{})
+  end
+
+  defp finish_termination(state, metadata) do
+    # Ownership: this actor's IDs came from init; the write rechecks its binding.
+    result =
+      case Conversations._unsafe_finish_conversation_termination(
+             state.conversation_id,
+             state.sandbox_id
+           ) do
+        {:ok, _} ->
+          Output.publish_stage(state.conversation_id, "terminate", "done", metadata)
+          :ok
+
+        {:error, _} = error ->
+          error
+      end
+
+    {:stop, :normal, result, state}
   end
 
   # The server's own clock stamp: the input `Lifecycle.check/4` reads. Nothing

--- a/apps/fountain/test/fountain/audit_guardrail_test.exs
+++ b/apps/fountain/test/fountain/audit_guardrail_test.exs
@@ -171,6 +171,8 @@ defmodule Fountain.AuditGuardrailTest do
   # Documented non-coverage. Mirrors the `Fountain.Audit` moduledoc; if the two
   # ever disagree, the moduledoc is the one to trust and this list is stale.
   @deliberately_silent %{
+    "Conversations._unsafe_finish_conversation_termination/2" =>
+      "internal conditional status write; terminate_conversation/2 audits the successful action once",
     "ConversationServer per-turn state" => "high-volume machine state; log_events covers it",
     "Accounts.touch_api_key/1" => "a last-used stamp on every authenticated request",
     "Runners.touch/1 and reconnects" =>

--- a/apps/fountain/test/fountain/conversations/termination_actor_fence_test.exs
+++ b/apps/fountain/test/fountain/conversations/termination_actor_fence_test.exs
@@ -107,6 +107,59 @@ defmodule Fountain.Conversations.TerminationActorFenceTest do
     refute Repo.reload!(replacement).reset_requested_at
   end
 
+  for cleanup <- [:destroy, :keep] do
+    @tag cleanup: cleanup
+    test "reassignment during #{cleanup} cleanup preserves the replacement conversation", ctx do
+      replacement = insert_sandbox(user_id: ctx.user.id, status: "ready")
+      owner = self()
+
+      reassign = fn ->
+        {:ok, moved} =
+          Conversations.update_conversation(ctx.conv, %{
+            sandbox_id: replacement.id,
+            status: "running"
+          })
+
+        send(owner, {:replacement_turn, insert_turn(moved, status: "running")})
+        :ok
+      end
+
+      if ctx.cleanup == :keep do
+        ctx.sandbox |> Ecto.Changeset.change(mode: "persistent") |> Repo.update!()
+        expect(Managoat.Sandbox, :close_stdin, fn :adapter -> reassign.() end)
+        reject(Managoat.Sandbox, :destroy, 1)
+      else
+        expect(Managoat.Sandbox, :destroy, fn handle ->
+          assert handle == ctx.handle
+          reassign.()
+        end)
+      end
+
+      assert {:stop, :normal, {:error, :sandbox_unavailable}, _} = terminate(ctx, :terminate_conv)
+      assert_received {:replacement_turn, turn}
+      assert Repo.reload!(turn) == turn
+      assert Repo.reload!(ctx.conv).sandbox_id == replacement.id
+      assert Repo.reload!(ctx.conv).status == "running"
+      assert Repo.reload!(replacement).status == "ready"
+      refute Repo.reload!(replacement).reset_requested_at
+      expected_old_status = if ctx.cleanup == :keep, do: "ready", else: "terminated"
+      assert Repo.reload!(ctx.sandbox).status == expected_old_status
+      assert termination_stages(ctx) == []
+    end
+  end
+
+  test "a conversation deleted during provider cleanup does not crash final bookkeeping", ctx do
+    expect(Managoat.Sandbox, :destroy, fn _ ->
+      Repo.delete!(ctx.conv)
+      :ok
+    end)
+
+    assert {:stop, :normal, {:error, :sandbox_unavailable}, _} = terminate(ctx, :terminate_conv)
+    assert Repo.reload(ctx.conv) == nil
+    assert Repo.reload!(ctx.sandbox).status == "terminated"
+    assert termination_stages(ctx) == []
+  end
+
   test "an enclosing transaction refuses termination before side effects", ctx do
     reject(Managoat.Sandbox, :close_stdin, 1)
     reject(Managoat.Sandbox, :destroy, 1)
@@ -136,6 +189,13 @@ defmodule Fountain.Conversations.TerminationActorFenceTest do
 
   defp terminate(ctx, message),
     do: ConversationServer.handle_call(message, {self(), make_ref()}, ctx.state)
+
+  defp termination_stages(ctx) do
+    Repo.all(
+      from e in Conversations.LogEvent,
+        where: e.conversation_id == ^ctx.conv.id and e.stage == "terminate" and e.state == "done"
+    )
+  end
 
   defp events(ctx),
     do: Audit.list_for_user(ctx.user.id, action_prefix: "sandbox.teardown_requested")

--- a/apps/fountain/test/fountain/conversations/termination_binding_isolation_test.exs
+++ b/apps/fountain/test/fountain/conversations/termination_binding_isolation_test.exs
@@ -1,0 +1,85 @@
+defmodule Fountain.Conversations.TerminationBindingIsolationTest do
+  use Fountain.DataCase, async: false
+
+  alias Fountain.Conversations
+  alias Fountain.Conversations.Conversation
+
+  test "a termination write waiting on reassignment rechecks the committed binding" do
+    Ecto.Adapters.SQL.Sandbox.unboxed_run(Repo, fn ->
+      user = insert_verified_user()
+      old = insert_sandbox(user_id: user.id, status: "ready")
+      replacement = insert_sandbox(user_id: user.id, status: "ready")
+      conv = insert_conversation(user_id: user.id, sandbox: old, status: "running")
+      owner = self()
+
+      reassign =
+        independent(fn ->
+          Repo.transaction(fn ->
+            from(c in Conversation, where: c.id == ^conv.id)
+            |> Repo.update_all(set: [sandbox_id: replacement.id])
+
+            send(owner, :binding_written)
+
+            receive do
+              :commit -> :ok
+            after
+              10_000 -> raise "reassignment release timed out"
+            end
+          end)
+        end)
+
+      try do
+        assert_receive :binding_written, 5_000
+
+        terminate =
+          independent(fn ->
+            # Ownership: this test created the actor's conversation and sandbox.
+            Conversations._unsafe_finish_conversation_termination(conv.id, old.id)
+          end)
+
+        try do
+          terminating_pid = terminate.pid
+          assert_receive {:backend, ^terminating_pid, backend}, 5_000
+          await_blocked(backend, System.monotonic_time(:millisecond) + 5_000)
+          send(reassign.pid, :commit)
+          assert {:ok, :ok} = Task.await(reassign)
+          assert {:error, :sandbox_unavailable} = Task.await(terminate)
+          assert Repo.reload!(conv).sandbox_id == replacement.id
+          assert Repo.reload!(conv).status == "running"
+        after
+          Task.shutdown(terminate, :brutal_kill)
+        end
+      after
+        Task.shutdown(reassign, :brutal_kill)
+        Repo.delete_all(from e in Fountain.Audit.Event, where: e.user_id == ^user.id)
+        Repo.delete!(user)
+        Repo.delete!(old)
+        Repo.delete!(replacement)
+      end
+    end)
+  end
+
+  defp independent(fun) do
+    owner = self()
+
+    Task.async(fn ->
+      Ecto.Adapters.SQL.Sandbox.unboxed_run(Repo, fn ->
+        %{rows: [[backend]]} = Repo.query!("SELECT pg_backend_pid()")
+        send(owner, {:backend, self(), backend})
+        fun.()
+      end)
+    end)
+  end
+
+  defp await_blocked(backend, deadline) do
+    %{rows: [[blocked]]} = Repo.query!("SELECT cardinality(pg_blocking_pids($1)) > 0", [backend])
+
+    unless blocked do
+      assert System.monotonic_time(:millisecond) < deadline,
+             "no PostgreSQL row-lock wait observed"
+
+      Process.sleep(5)
+      await_blocked(backend, deadline)
+    end
+  end
+end


### PR DESCRIPTION
A conversation reassigned while its old actor cleans up a provider or keeps a shared machine could still be marked terminated when that cleanup finished. The actor now uses a single conditional database update matching both conversation and sandbox IDs. If the binding changed or the conversation was deleted, it stops with `:sandbox_unavailable` and publishes no completed-termination stage. The public client therefore also skips its successful-termination audit.

Both destroy and keep-machine paths use the same final write. Cleanup and retirement of the old sandbox retain their existing behavior.

Stack: based on #1996. Refs #1767. This unit protects the final conversation status. Turn completion/interruption bookkeeping and durable forced-teardown recovery remain separate follow-ups.

Validation:
- 116 focused tests passed, including the existing actor/client/fallback lifecycle behavior and audit guardrails.
- Reassignment during destroy and keep-machine cleanup preserves the replacement binding, its running turn and its ready sandbox. Deletion during provider cleanup returns a refusal instead of crashing.
- A real PostgreSQL race test observes the termination statement waiting on an uncommitted reassignment, then refusing after that reassignment commits.
- The three actor regressions fail with the parent actor implementation. Removing the SQL binding predicate makes the database race test fail; restored code passes.
- Full `mix precommit` passed: Fountain 5,441 tests and 6 doctests, Buzz 144 tests, Support 33 tests; zero failures.
