### PR TITLE
fix: preserve turn results after sandbox reassignment or teardown

### DIFF
--- a/apps/fountain/lib/fountain/activation.ex
+++ b/apps/fountain/lib/fountain/activation.ex
@@ -19,10 +19,9 @@ defmodule Fountain.Activation do
 
   ## The seam
 
-  `turn_replied/1` is called from `Conversations._unsafe_update_turn/2` —
-  every turn ending in the system goes through there, from the
-  ConversationServer's six endings to the orphan sweep, so a new way for a
-  turn to end is instrumented by construction rather than by remembering.
+  `turn_replied/1` is called after general turn updates, conditional
+  completion and orphan reconciliation materialize a reply. The conditional
+  paths call it after their transaction commits and skip it for stale writes.
   It is the *account's first* reply that this module cares about, so the
   function is a no-op for every later turn.
 

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -2278,8 +2278,18 @@ defmodule Fountain.Conversations do
             |> maybe_put_reply_text(current)
 
           updated = Repo.update!(changeset)
-          idle = conv |> Conversation.changeset(%{status: "idle"}) |> Repo.update!()
-          {updated, idle, is_binary(Ecto.Changeset.get_change(changeset, :reply_text))}
+
+          # A successor admitted while this actor was ending its turn keeps the
+          # conversation running. `_unsafe_idle_after_turn/1` refused this
+          # through `latest_turn?`, and that refusal has to survive the move to
+          # a writer of our own; the parent lock above is the same one turn
+          # admission takes, so nothing can be admitted between the two reads.
+          conv =
+            if Repo.exists?(newer_running_turn_query(turn.conversation_id, turn.id)),
+              do: conv,
+              else: conv |> Conversation.changeset(%{status: "idle"}) |> Repo.update!()
+
+          {updated, conv, is_binary(Ecto.Changeset.get_change(changeset, :reply_text))}
         else
           _ -> :noop
         end
@@ -2294,6 +2304,12 @@ defmodule Fountain.Conversations do
         broadcast_sidebar_update(conv.user_id)
         {:ok, updated}
     end
+  end
+
+  defp newer_running_turn_query(conversation_id, turn_id) do
+    from(t in Turn,
+      where: t.conversation_id == ^conversation_id and t.id != ^turn_id and t.status == "running"
+    )
   end
 
   @doc """

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -2247,6 +2247,11 @@ defmodule Fountain.Conversations do
   another actor, is a no-op. Reply materialization shares that transaction;
   activation and sidebar publication run after it commits.
 
+  The parent only idles under the two conditions `_unsafe_idle_after_turn/1`
+  idled under: `ExecutionGuard.latest_turn?/2` and a `running` parent. The
+  journal's own condition is not carried here — see the known gap on
+  `Fountain.Conversations.TurnMachine.finish/4`.
+
   `"interrupted"` is a terminal status this writer accepts, because a bounded
   turn that its journal retires comes back through the same ending
   (`BoundedTurn.retire/2` hands `finish/4` the persisted status, ADR 0046).
@@ -2279,15 +2284,18 @@ defmodule Fountain.Conversations do
 
           updated = Repo.update!(changeset)
 
-          # A successor admitted while this actor was ending its turn keeps the
-          # conversation running. `_unsafe_idle_after_turn/1` refused this
-          # through `latest_turn?`, and that refusal has to survive the move to
-          # a writer of our own; the parent lock above is the same one turn
-          # admission takes, so nothing can be admitted between the two reads.
+          # The two preconditions `_unsafe_idle_after_turn/1` idled under, kept
+          # exactly (`ExecutionGuard.parent_write_allowed?/4`, mode `:idle`):
+          # this turn is the conversation's newest generation, and the parent
+          # is `running`. A successor admitted while this actor was ending its
+          # turn therefore keeps the conversation running, and an abandoned
+          # older turn cannot stop this one from idling it. The parent lock
+          # above is the same one turn admission takes, so nothing can be
+          # admitted between this read and the write.
           conv =
-            if Repo.exists?(newer_running_turn_query(turn.conversation_id, turn.id)),
-              do: conv,
-              else: conv |> Conversation.changeset(%{status: "idle"}) |> Repo.update!()
+            if conv.status == "running" and ExecutionGuard.latest_turn?(conv.id, turn.id),
+              do: conv |> Conversation.changeset(%{status: "idle"}) |> Repo.update!(),
+              else: conv
 
           {updated, conv, is_binary(Ecto.Changeset.get_change(changeset, :reply_text))}
         else
@@ -2304,12 +2312,6 @@ defmodule Fountain.Conversations do
         broadcast_sidebar_update(conv.user_id)
         {:ok, updated}
     end
-  end
-
-  defp newer_running_turn_query(conversation_id, turn_id) do
-    from(t in Turn,
-      where: t.conversation_id == ^conversation_id and t.id != ^turn_id and t.status == "running"
-    )
   end
 
   @doc """

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -2205,11 +2205,9 @@ defmodule Fountain.Conversations do
   @doc """
   Update a turn's row. When the update ends the turn — its status becomes
   `completed`, `failed` or `interrupted` — the assistant's text for the
-  turn is materialised into `reply_text` in the same write (#826): every
-  turn ending goes through here, from the ConversationServer's six endings
-  to the orphan sweep, so search coverage is by construction rather than
-  by each ending remembering. A turn that already carries a `reply_text`
-  keeps it.
+  turn is materialised into `reply_text` in the same write (#826). Conditional
+  completion and orphan reconciliation also materialize the reply in their
+  transactions. A turn that already carries a `reply_text` keeps it.
 
   The same write is where activation is decided (ADR 0038): a turn that ends
   carrying a reply is handed to `Fountain.Activation.turn_replied/1`, which
@@ -2238,6 +2236,63 @@ defmodule Fountain.Conversations do
 
       {:error, reason} ->
         {:error, reason}
+    end
+  end
+
+  @doc """
+  Complete a running turn only on the actor's current sandbox binding.
+
+  Lock the conversation before the turn, and commit its idle status with the
+  turn's result. A moved or terminal conversation, or a turn already ended by
+  another actor, is a no-op. Reply materialization shares that transaction;
+  activation and sidebar publication run after it commits.
+
+  `"interrupted"` is a terminal status this writer accepts, because a bounded
+  turn that its journal retires comes back through the same ending
+  (`BoundedTurn.retire/2` hands `finish/4` the persisted status, ADR 0046).
+  The two-phase interrupt the server drives itself is a different write, and
+  it keeps the conversation running until the peer has stopped.
+  """
+  def _unsafe_complete_turn(%Turn{} = turn, sandbox_id, status)
+      when status in ["completed", "failed", "interrupted"] do
+    {:ok, result} =
+      Repo.transaction(fn ->
+        conversation_query =
+          from(c in Conversation, where: c.id == ^turn.conversation_id, lock: "FOR UPDATE")
+
+        turn_query =
+          from(t in Turn,
+            where: t.id == ^turn.id and t.conversation_id == ^turn.conversation_id,
+            lock: "FOR UPDATE"
+          )
+
+        with %Conversation{} = conv <- Repo.one(conversation_query),
+             true <- conv.sandbox_id == sandbox_id and conv.status not in ["terminated", "failed"],
+             %Turn{status: "running"} = current <- Repo.one(turn_query) do
+          changeset =
+            current
+            |> Turn.changeset(%{
+              status: status,
+              ended_at: DateTime.utc_now() |> DateTime.truncate(:second)
+            })
+            |> maybe_put_reply_text(current)
+
+          updated = Repo.update!(changeset)
+          idle = conv |> Conversation.changeset(%{status: "idle"}) |> Repo.update!()
+          {updated, idle, is_binary(Ecto.Changeset.get_change(changeset, :reply_text))}
+        else
+          _ -> :noop
+        end
+      end)
+
+    case result do
+      :noop ->
+        :noop
+
+      {updated, conv, reply_materialized?} ->
+        if reply_materialized?, do: Fountain.Activation.turn_replied(updated)
+        broadcast_sidebar_update(conv.user_id)
+        {:ok, updated}
     end
   end
 

--- a/apps/fountain/lib/fountain/conversations/execution_guard.ex
+++ b/apps/fountain/lib/fountain/conversations/execution_guard.ex
@@ -429,7 +429,19 @@ defmodule Fountain.Conversations.ExecutionGuard do
     {decision.turn, changed, event}
   end
 
-  defp latest_turn?(conv_id, turn_id) do
+  @doc """
+  Is this turn the conversation's newest generation?
+
+  The predicate every parent write is gated on: a turn that is not the highest
+  `turn_number` on its conversation has been superseded, so its ending says
+  nothing about whether the conversation is still working. It is deliberately
+  ordered on `turn_number` rather than asking whether some other turn is
+  `running` — an abandoned older turn left `running` must not stop the current
+  generation from idling its parent, and a superseded turn must not idle it
+  even when nothing else is running. Callers hold the parent lock, so admission
+  cannot land between this read and the write it guards.
+  """
+  def latest_turn?(conv_id, turn_id) do
     Repo.one(
       from t in Turn,
         where: t.conversation_id == ^conv_id,

--- a/apps/fountain/lib/fountain/conversations/turn_machine.ex
+++ b/apps/fountain/lib/fountain/conversations/turn_machine.ex
@@ -86,6 +86,7 @@ defmodule Fountain.Conversations.TurnMachine do
 
   @type t :: %__MODULE__{
           conversation_id: String.t() | nil,
+          sandbox_id: String.t() | nil,
           row: Conversations.Turn.t() | nil,
           span: term() | nil,
           metrics: map() | nil,
@@ -95,6 +96,7 @@ defmodule Fountain.Conversations.TurnMachine do
         }
 
   defstruct conversation_id: nil,
+            sandbox_id: nil,
             row: nil,
             span: nil,
             metrics: nil,
@@ -113,6 +115,7 @@ defmodule Fountain.Conversations.TurnMachine do
   def from_state(state) do
     %__MODULE__{
       conversation_id: state.conversation_id,
+      sandbox_id: Map.get(state, :sandbox_id),
       row: state.current_turn,
       span: state.current_turn_span,
       metrics: state.turn_metrics,
@@ -642,54 +645,49 @@ defmodule Fountain.Conversations.TurnMachine do
   the completion metric and the conversation back to idle. What the server
   resolves first (a held permission, parked caller tools, the quiet timer)
   is the server's; what it clears after (activity) is too. Returns the turn
-  with its bookkeeping cleared.
+  with its bookkeeping cleared. A stale completion clears local bookkeeping
+  without overwriting the persisted result or emitting another completion.
   """
   @spec finish(t(), String.t(), map(), map()) :: t()
   def finish(%__MODULE__{} = turn, status, span_attrs, stage_meta) do
     # Before the turn span ends: totals land on it, abandoned tool spans close.
     finalize_tracer(turn.tracer)
 
-    {:ok, row} =
-      Conversations._unsafe_update_turn(turn.row, %{
-        status: status,
-        ended_at: now()
-      })
+    # Ownership: the server supplies its binding, and the context locks and rechecks it.
+    case Conversations._unsafe_complete_turn(turn.row, turn.sandbox_id, status) do
+      {:ok, row} ->
+        stage_meta = Map.merge(stage_meta, %{turn_id: row.id, turn_number: row.turn_number})
 
-    stage_meta = Map.merge(stage_meta, %{turn_id: row.id, turn_number: row.turn_number})
+        # A service-enforced limit sets both: `limit_reason` names which limit,
+        # and `stop_reason` is the field every existing transcript reader
+        # already switches on. The conversations app and the team app live
+        # outside this repo (ADR 0034), so a new field alone would render as an
+        # unexplained failure in both until each one shipped.
+        stage_meta =
+          if row.limit_reason,
+            do:
+              stage_meta
+              |> Map.put(:limit_reason, row.limit_reason)
+              |> Map.put(:stop_reason, row.limit_reason),
+            else: stage_meta
 
-    # A service-enforced limit sets both: `limit_reason` names which limit, and
-    # `stop_reason` is the field every existing transcript reader already
-    # switches on. The conversations app and the team app live outside this
-    # repo (ADR 0034), so a new field alone would render as an unexplained
-    # failure in both until each one shipped.
-    stage_meta =
-      if row.limit_reason,
-        do:
-          stage_meta
-          |> Map.put(:limit_reason, row.limit_reason)
-          |> Map.put(:stop_reason, row.limit_reason),
-        else: stage_meta
+        publish_stage(
+          turn.conversation_id,
+          "turn",
+          # `row.status`, not `status`: a turn the execution journal fenced has
+          # had its requested status dropped, so the persisted row is the only
+          # honest source of what actually happened (ADR 0046). `stage_meta`
+          # already carries turn_id/turn_number from the merge above.
+          if(row.status == "completed", do: "done", else: "failed"),
+          Map.merge(stage_meta, waiting_meta(row))
+        )
 
-    publish_stage(
-      turn.conversation_id,
-      "turn",
-      # `row.status`, not `status`: a turn the execution journal fenced has had
-      # its requested status dropped, so the persisted row is the only honest
-      # source of what actually happened (ADR 0046). `stage_meta` already
-      # carries turn_id/turn_number from the merge above.
-      if(row.status == "completed", do: "done", else: "failed"),
-      Map.merge(stage_meta, waiting_meta(row))
-    )
+        end_span(turn.span, if(row.status == "completed", do: :ok, else: :error), span_attrs)
+        emit_completed(turn, row.status)
 
-    end_span(
-      turn.span,
-      if(row.status == "completed", do: :ok, else: :error),
-      span_attrs
-    )
-
-    emit_completed(turn, row.status)
-
-    {:ok, _} = Conversations._unsafe_idle_after_turn(row)
+      :noop ->
+        end_span(turn.span, :error, %{"outcome" => "completion_ignored"})
+    end
 
     %{turn | row: nil, span: nil, metrics: nil, tracer: nil, session_retry: nil}
   end

--- a/apps/fountain/lib/fountain/conversations/turn_machine.ex
+++ b/apps/fountain/lib/fountain/conversations/turn_machine.ex
@@ -115,7 +115,7 @@ defmodule Fountain.Conversations.TurnMachine do
   def from_state(state) do
     %__MODULE__{
       conversation_id: state.conversation_id,
-      sandbox_id: Map.get(state, :sandbox_id),
+      sandbox_id: state.sandbox_id,
       row: state.current_turn,
       span: state.current_turn_span,
       metrics: state.turn_metrics,
@@ -647,6 +647,16 @@ defmodule Fountain.Conversations.TurnMachine do
   is the server's; what it clears after (activity) is too. Returns the turn
   with its bookkeeping cleared. A stale completion clears local bookkeeping
   without overwriting the persisted result or emitting another completion.
+
+  Known gap: the write goes to `Conversations._unsafe_complete_turn/3`, which
+  takes the parent lock itself rather than going through
+  `ExecutionGuard._unsafe_write_turn/3`, so completion no longer consults the
+  execution journal (#1732). The journal's expiry, `uncertain_spawn` and
+  `:execution_not_started` conditions do not apply at this ending, and a
+  fenced turn does not idle its parent. This is inert while
+  `ExecutionLimits.enforced_controls/1` returns `[]`, because no
+  `turn_executions` row is written at all; re-plumbing completion through the
+  guard is tracked separately.
   """
   @spec finish(t(), String.t(), map(), map()) :: t()
   def finish(%__MODULE__{} = turn, status, span_attrs, stage_meta) do
@@ -674,10 +684,13 @@ defmodule Fountain.Conversations.TurnMachine do
         publish_stage(
           turn.conversation_id,
           "turn",
-          # `row.status`, not `status`: a turn the execution journal fenced has
-          # had its requested status dropped, so the persisted row is the only
-          # honest source of what actually happened (ADR 0046). `stage_meta`
-          # already carries turn_id/turn_number from the merge above.
+          # `row` is what was persisted, and reading the stage off it rather
+          # than off `status` keeps the transcript honest about the write that
+          # actually landed. Nothing between the changeset and the update in
+          # `_unsafe_complete_turn/3` can make the two differ today — the
+          # journal fence that once could is no longer in this path (see the
+          # known gap above). `stage_meta` already carries
+          # turn_id/turn_number from the merge above.
           if(row.status == "completed", do: "done", else: "failed"),
           Map.merge(stage_meta, waiting_meta(row))
         )

--- a/apps/fountain/test/fountain/audit_guardrail_test.exs
+++ b/apps/fountain/test/fountain/audit_guardrail_test.exs
@@ -173,6 +173,8 @@ defmodule Fountain.AuditGuardrailTest do
   @deliberately_silent %{
     "Conversations._unsafe_finish_conversation_termination/2" =>
       "internal conditional status write; terminate_conversation/2 audits the successful action once",
+    "Conversations._unsafe_complete_turn/3" =>
+      "conditional per-turn bookkeeping; the turn stage records completion outside its transaction",
     "ConversationServer per-turn state" => "high-volume machine state; log_events covers it",
     "Accounts.touch_api_key/1" => "a last-used stamp on every authenticated request",
     "Runners.touch/1 and reconnects" =>

--- a/apps/fountain/test/fountain/conversations/conversation_server_platform_inference_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_platform_inference_test.exs
@@ -319,6 +319,7 @@ defmodule Fountain.Conversations.ConversationServerPlatformInferenceTest do
 
     machine = %TurnMachine{
       conversation_id: conv.id,
+      sandbox_id: conv.sandbox_id,
       row: row,
       metrics: TurnMachine.start_metrics("codex", :runner, System.monotonic_time(:millisecond))
     }

--- a/apps/fountain/test/fountain/conversations/deadline_events_test.exs
+++ b/apps/fountain/test/fountain/conversations/deadline_events_test.exs
@@ -147,7 +147,13 @@ defmodule Fountain.Conversations.DeadlineEventsTest do
   test "late completion and interruption cannot replace or duplicate the deadline event", c do
     expire(c)
     original = event(c)
-    machine = %TurnMachine{conversation_id: c.conv.id, row: c.turn}
+
+    machine = %TurnMachine{
+      conversation_id: c.conv.id,
+      sandbox_id: c.conv.sandbox_id,
+      row: c.turn
+    }
+
     TurnMachine.finish(machine, "completed", %{}, %{stop_reason: "end_turn"})
     TurnMachine.mark_interrupted(machine)
     expire(c)

--- a/apps/fountain/test/fountain/conversations/turn_completion_binding_isolation_test.exs
+++ b/apps/fountain/test/fountain/conversations/turn_completion_binding_isolation_test.exs
@@ -1,0 +1,137 @@
+defmodule Fountain.Conversations.TurnCompletionBindingIsolationTest do
+  use Fountain.DataCase, async: false
+
+  alias Fountain.Conversations
+  alias Fountain.Conversations.Conversation
+
+  for first <- [:reassignment, :completion] do
+    @tag first: first
+    test "#{first} serializes turn completion with reassignment", %{first: first} do
+      Ecto.Adapters.SQL.Sandbox.unboxed_run(Repo, fn ->
+        user = insert_verified_user()
+        old = insert_sandbox(user_id: user.id, status: "ready")
+        replacement = insert_sandbox(user_id: user.id, status: "ready")
+        conv = insert_conversation(user_id: user.id, sandbox: old, status: "running")
+        turn = insert_turn(conv, status: "running")
+        owner = self()
+        handler = {__MODULE__, make_ref()}
+
+        # Pause inside the real completion transaction after its turn update. This
+        # proves the parent lock remains held through the write, without wrapping
+        # the public function (and its audit) in an artificial outer transaction.
+        :telemetry.attach(
+          handler,
+          [:fountain, :repo, :query],
+          &__MODULE__.pause_completion/4,
+          owner
+        )
+
+        complete = fn ->
+          # Internal actor completion; the fixture belongs to this test's tenant.
+          Conversations._unsafe_complete_turn(turn, old.id, "completed")
+        end
+
+        reassign = fn ->
+          Conversations.update_conversation(conv, %{sandbox_id: replacement.id})
+        end
+
+        leading =
+          independent(fn ->
+            if first == :completion do
+              Process.put(:pause_completion_binding_test, true)
+              complete.()
+            else
+              Repo.transaction(fn ->
+                from(c in Conversation, where: c.id == ^conv.id)
+                |> Repo.update_all(set: [sandbox_id: replacement.id])
+
+                hold(owner)
+              end)
+            end
+          end)
+
+        try do
+          assert_receive :write_held, 5_000
+          trailing = independent(if first == :completion, do: reassign, else: complete)
+
+          try do
+            trailing_pid = trailing.pid
+            assert_receive {:backend, ^trailing_pid, backend}, 5_000
+            await_blocked(backend, System.monotonic_time(:millisecond) + 5_000)
+            send(leading.pid, :commit)
+            leading_result = Task.await(leading)
+            trailing_result = Task.await(trailing)
+
+            if first == :completion do
+              assert {:ok, _} = leading_result
+              assert {:ok, _} = trailing_result
+              assert Repo.reload(turn).status == "completed"
+              assert Repo.reload(turn).ended_at
+            else
+              assert {:ok, :ok} = leading_result
+              assert :noop = trailing_result
+              assert Repo.reload(turn).status == "running"
+              assert Repo.reload(turn).ended_at == nil
+            end
+
+            assert Repo.reload(conv).sandbox_id == replacement.id
+
+            assert Repo.reload(conv).status ==
+                     if(first == :completion, do: "idle", else: "running")
+          after
+            Task.shutdown(trailing, :brutal_kill)
+          end
+        after
+          Task.shutdown(leading, :brutal_kill)
+          :telemetry.detach(handler)
+          Repo.delete_all(from e in Fountain.Audit.Event, where: e.user_id == ^user.id)
+          Repo.delete!(user)
+          Repo.delete!(old)
+          Repo.delete!(replacement)
+        end
+      end)
+    end
+  end
+
+  def pause_completion(_event, _measurements, metadata, owner) do
+    if Process.get(:pause_completion_binding_test) &&
+         String.starts_with?(metadata.query, ~s(UPDATE "turns")) do
+      Process.delete(:pause_completion_binding_test)
+      hold(owner)
+    end
+  end
+
+  defp hold(owner) do
+    send(owner, :write_held)
+
+    receive do
+      :commit -> :ok
+    after
+      10_000 -> raise "binding write release timed out"
+    end
+  end
+
+  defp independent(fun) do
+    owner = self()
+
+    Task.async(fn ->
+      Ecto.Adapters.SQL.Sandbox.unboxed_run(Repo, fn ->
+        %{rows: [[backend]]} = Repo.query!("SELECT pg_backend_pid()")
+        send(owner, {:backend, self(), backend})
+        fun.()
+      end)
+    end)
+  end
+
+  defp await_blocked(backend, deadline) do
+    %{rows: [[blocked]]} = Repo.query!("SELECT cardinality(pg_blocking_pids($1)) > 0", [backend])
+
+    unless blocked do
+      assert System.monotonic_time(:millisecond) < deadline,
+             "no PostgreSQL row-lock wait observed"
+
+      Process.sleep(5)
+      await_blocked(backend, deadline)
+    end
+  end
+end

--- a/apps/fountain/test/fountain/conversations/turn_machine_test.exs
+++ b/apps/fountain/test/fountain/conversations/turn_machine_test.exs
@@ -499,6 +499,17 @@ defmodule Fountain.Conversations.TurnMachineTest do
       end
     end
 
+    test "a successor admitted mid-completion keeps the conversation running", ctx do
+      Conversations.update_conversation(ctx.conv, %{status: "running"})
+      successor = insert_turn(ctx.conv, status: "running")
+
+      TurnMachine.finish(ctx.machine, "completed", %{}, %{})
+
+      assert Fountain.Repo.reload!(ctx.row).status == "completed"
+      assert Fountain.Repo.reload!(ctx.conv).status == "running"
+      assert Fountain.Repo.reload!(successor).status == "running"
+    end
+
     test "completion materializes a reply and activates the account", ctx do
       insert_log_event(ctx.conv, turn_id: ctx.row.id, stream: "acp", data: @update_line)
       TurnMachine.finish(ctx.machine, "completed", %{}, %{})

--- a/apps/fountain/test/fountain/conversations/turn_machine_test.exs
+++ b/apps/fountain/test/fountain/conversations/turn_machine_test.exs
@@ -18,6 +18,7 @@ defmodule Fountain.Conversations.TurnMachineTest do
 
     machine = %TurnMachine{
       conversation_id: conv.id,
+      sandbox_id: conv.sandbox_id,
       row: row,
       metrics: TurnMachine.start_metrics("claude", :runner, System.monotonic_time(:millisecond))
     }
@@ -60,6 +61,7 @@ defmodule Fountain.Conversations.TurnMachineTest do
     test "round-trip the server's turn fields and nothing else", %{row: row} do
       state = %{
         conversation_id: "c",
+        sandbox_id: "s",
         current_turn: row,
         current_turn_span: :span,
         turn_metrics: %{a: 1},
@@ -72,6 +74,7 @@ defmodule Fountain.Conversations.TurnMachineTest do
       machine = TurnMachine.from_state(state)
 
       assert %TurnMachine{
+               sandbox_id: "s",
                row: ^row,
                span: :span,
                metrics: %{a: 1},
@@ -450,6 +453,57 @@ defmodule Fountain.Conversations.TurnMachineTest do
                       }}
 
       assert conv_id == conv.id
+    end
+
+    for stale <- [:reassigned, :terminated, :failed, :completed, :interrupted, :deleted] do
+      @tag stale: stale
+      test "a #{stale} completion preserves the persisted result without duplicate events", ctx do
+        attach_telemetry([[:fountain, :turn, :completed]])
+        insert_log_event(ctx.conv, turn_id: ctx.row.id, stream: "acp", data: @update_line)
+
+        case ctx.stale do
+          :reassigned ->
+            replacement = insert_sandbox(user_id: ctx.user.id)
+
+            Conversations.update_conversation(ctx.conv, %{
+              sandbox_id: replacement.id,
+              status: "running"
+            })
+
+          terminal when terminal in [:terminated, :failed] ->
+            Conversations.update_conversation(ctx.conv, %{status: Atom.to_string(terminal)})
+
+          ended when ended in [:completed, :interrupted] ->
+            ctx.row
+            |> Ecto.Changeset.change(status: Atom.to_string(ended))
+            |> Fountain.Repo.update!()
+
+            Conversations.update_conversation(ctx.conv, %{status: "running"})
+            insert_turn(ctx.conv, status: "running")
+
+          :deleted ->
+            Fountain.Repo.delete!(ctx.conv)
+        end
+
+        persisted_turn = Fountain.Repo.get(Conversations.Turn, ctx.row.id)
+        persisted_conv = Fountain.Repo.get(Conversations.Conversation, ctx.conv.id)
+
+        assert %TurnMachine{row: nil, span: nil, metrics: nil, tracer: nil} =
+                 TurnMachine.finish(ctx.machine, "completed", %{}, %{})
+
+        assert Fountain.Repo.get(Conversations.Turn, ctx.row.id) == persisted_turn
+        assert Fountain.Repo.get(Conversations.Conversation, ctx.conv.id) == persisted_conv
+        assert stages(ctx.conv.id, "turn") == []
+        refute Fountain.Repo.reload!(ctx.user).onboarding_completed_at
+        refute_receive {:telemetry, [:fountain, :turn, :completed], _, _}, 50
+      end
+    end
+
+    test "completion materializes a reply and activates the account", ctx do
+      insert_log_event(ctx.conv, turn_id: ctx.row.id, stream: "acp", data: @update_line)
+      TurnMachine.finish(ctx.machine, "completed", %{}, %{})
+      assert Fountain.Repo.reload!(ctx.row).reply_text == "hi"
+      assert Fountain.Repo.reload!(ctx.user).onboarding_completed_at
     end
 
     test "a failed status is the failed stage, and no metric without metrics", %{

--- a/apps/fountain/test/fountain/conversations/turn_parent_actor_test.exs
+++ b/apps/fountain/test/fountain/conversations/turn_parent_actor_test.exs
@@ -82,6 +82,13 @@ defmodule Fountain.Conversations.TurnParentActorTest do
 
     send(pid, :continue)
     assert %{current_turn: nil} = :sys.get_state(pid)
+    # Two guards refuse this write independently — the turn is already
+    # `interrupted`, and a successor holds the highest `turn_number` — so the
+    # parent assertion below survives either one alone. Asserting the old
+    # turn's own result too puts the turn-status guard on the hook by itself:
+    # drop it and the late `completed` lands here even though the parent is
+    # still correctly held `running` by `latest_turn?`.
+    assert Repo.get!(Turn, turn.id).status == "interrupted"
     assert Conversations._unsafe_get_conversation!(conv.id).status == "running"
     assert Repo.get!(Turn, next.id).status == "running"
     assert Repo.get!(TurnExecution, next_execution.id).state == "active"

--- a/apps/fountain/test/fountain/conversations/turn_parent_actor_test.exs
+++ b/apps/fountain/test/fountain/conversations/turn_parent_actor_test.exs
@@ -43,7 +43,11 @@ defmodule Fountain.Conversations.TurnParentActorTest do
        %{pid: pid, turn: turn, execution: execution, conv: conv, ref: ref} do
     test = self()
 
-    stub(Conversations, :_unsafe_update_turn, fn row, attrs ->
+    # The barrier sits on the terminal writer the completion path actually
+    # uses. `finish/4` routes its write through `_unsafe_complete_turn/3`
+    # (#1999), so stubbing `_unsafe_update_turn/2` here would hold nothing
+    # open and the race this test asserts on would never be arranged.
+    stub(Conversations, :_unsafe_complete_turn, fn row, sandbox_id, status ->
       if self() == pid and row.id == turn.id do
         send(test, :after_dispatch_before_write)
 
@@ -54,7 +58,7 @@ defmodule Fountain.Conversations.TurnParentActorTest do
         end
       end
 
-      Mimic.call_original(Conversations, :_unsafe_update_turn, [row, attrs])
+      Mimic.call_original(Conversations, :_unsafe_complete_turn, [row, sandbox_id, status])
     end)
 
     send(pid, {:acp, ref, {:done, "end_turn", nil}})

--- a/apps/fountain/test/fountain/conversations/turn_parent_test.exs
+++ b/apps/fountain/test/fountain/conversations/turn_parent_test.exs
@@ -28,7 +28,8 @@ defmodule Fountain.Conversations.TurnParentTest do
     %{conv: conv, turn: turn, execution: execution, sandbox: sandbox}
   end
 
-  defp machine(c), do: %TurnMachine{conversation_id: c.conv.id, row: c.turn}
+  defp machine(c),
+    do: %TurnMachine{conversation_id: c.conv.id, sandbox_id: c.conv.sandbox_id, row: c.turn}
 
   defp actor(c),
     do: %{
@@ -51,12 +52,52 @@ defmodule Fountain.Conversations.TurnParentTest do
     {next, execution}
   end
 
-  test "stale completion cannot idle a successor admitted after cancellation", c do
+  # Named for the mechanism that actually refuses this write. `successor/1`
+  # cancels before it admits, so the stale actor's turn is already
+  # `interrupted` when its completion lands and the writer refuses on the
+  # turn's own status, before any parent decision is reached. The refusal that
+  # depends on the successor existing is the `latest_turn?` pair below.
+  test "a completion whose turn another actor already ended writes nothing", c do
     {next, execution} = successor(c)
+    assert Repo.get!(Turn, c.turn.id).status == "interrupted"
+
     TurnMachine.finish(machine(c), "completed", %{}, %{})
+
+    assert Repo.get!(Turn, c.turn.id).status == "interrupted"
     assert Repo.get!(Conversation, c.conv.id).status == "running"
     assert Repo.get!(Turn, next.id).status == "running"
     assert Repo.get!(TurnExecution, execution.id).state == "active"
+  end
+
+  test "a superseded turn cannot idle the parent once its successor has ended too", c do
+    insert_turn(c.conv,
+      status: "completed",
+      ended_at: DateTime.utc_now() |> DateTime.truncate(:second)
+    )
+
+    TurnMachine.finish(machine(c), "completed", %{}, %{})
+
+    assert Repo.get!(Turn, c.turn.id).status == "completed"
+    assert Repo.get!(Conversation, c.conv.id).status == "running"
+  end
+
+  test "an abandoned older turn cannot stop the newest one idling the parent", c do
+    newest = insert_turn(c.conv, status: "running")
+
+    TurnMachine.finish(%{machine(c) | row: newest}, "completed", %{}, %{})
+
+    assert Repo.get!(Turn, c.turn.id).status == "running"
+    assert Repo.get!(Turn, newest.id).status == "completed"
+    assert Repo.get!(Conversation, c.conv.id).status == "idle"
+  end
+
+  test "a completion cannot idle a parent that is not running", c do
+    c.conv |> Ecto.Changeset.change(status: "pending") |> Repo.update!()
+
+    TurnMachine.finish(machine(c), "completed", %{}, %{})
+
+    assert Repo.get!(Turn, c.turn.id).status == "completed"
+    assert Repo.get!(Conversation, c.conv.id).status == "pending"
   end
 
   test "the interrupt's delayed second half cannot idle a successor", c do


### PR DESCRIPTION
A late actor completion could overwrite an already-ended turn or set a moved/terminated conversation back to idle. Turn completion now carries the actor's sandbox binding and locks the conversation before the current turn. It only writes while the binding still matches, the conversation is nonterminal and the turn is running; the turn result and idle status commit together.

A stale completion clears the actor's local turn state and span without another completion stage or metric. Successful completion still materializes reply text and activates the account after commit. The context reads the current turn under lock so persisted permission and reply fields survive.

Stack: based on #1998. Refs #1767. This unit covers `TurnMachine.finish/4`. The split interrupt path, earlier permission/usage updates and forced-teardown recovery remain separate follow-ups.

Validation:
- All 287 focused tests passed, including turn-machine, real ACP, turn metrics, platform-inference, activation, search, audit guardrails and PostgreSQL race tests.
- Six stale-completion regressions cover reassignment, terminated/failed conversations, completed/interrupted turns with a newer running turn, and deletion. They all fail with the parent finish implementation.
- Real PostgreSQL tests observe row-lock waits in both orders against reassignment. Removing the binding check makes the reassignment-first test fail; restored code passes.
- Reply materialization and account activation remain covered, alongside the server's ACP completion and turn-metric tests.
- Full `mix precommit` passed: Fountain 5,450 tests and 6 doctests, Buzz 144 tests, Support 33 tests; zero failures.
