### PR TITLE
fix: preserve newer work across both interrupt bookkeeping phases

### DIFF
--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -2341,9 +2341,19 @@ defmodule Fountain.Conversations do
   and `ExecutionGuard._unsafe_recover_turn/3` returns `:noop` for one, so the
   recovery backstop every other fence in #1767 leans on does not cover this
   state. Refusing to write here is therefore not "leave it to the next
-  writer"; it is a conversation stuck `running` with nothing running under it,
-  and `_unsafe_sandbox_busy_elsewhere?/4` reads that parent, so a shared
-  machine bills to `SANDBOX_MAX_LIFETIME_HOURS`.
+  writer"; it is a conversation left `running` with nothing running under it,
+  and no sweep that will ever notice.
+
+  That is the whole harm, and it is worth being exact about its edges, because
+  two larger claims about it are false. `_unsafe_sandbox_busy_elsewhere?/4`
+  does **not** read the parent's status — it queries co-tenant `turns` rows and
+  conversation `updated_at` — so a stuck parent does not by itself hold a
+  shared machine to `SANDBOX_MAX_LIFETIME_HOURS`. And the obvious producer,
+  `follow_cotenants/2`, largely rescues itself: it casts `:machine_gone`
+  *before* its `update_all`, and `MachineEvents.gone/4` idles a `running`
+  parent unconditionally. The state is still reachable — a cross-pod co-tenant
+  that Horde's `whereis` misses gets the rebind and no cast — but that is a
+  narrower window than "any sprite replacement".
 
   Two conditions gate the write, the same two `_unsafe_complete_turn/3`
   applies: `ExecutionGuard.latest_turn?/2` and a `running` parent. A turn
@@ -2351,6 +2361,17 @@ defmodule Fountain.Conversations do
   abandoned older turn left `running` does not stop this one idling it. The
   lock matches turn admission, so a concurrent admission cannot slip between
   this read and the write.
+
+  Deliberately **no sandbox-binding condition**, unlike every other #1767
+  fence. The binding is still checked — but by the process rather than the
+  query, and more tightly: `interrupted?` appears in neither `from_state/1`
+  nor `into_state/2`, so it cannot survive a mailbox round-trip, and the two
+  halves are one synchronous body separated only by `stop_acp_peer/1`, a
+  bounded one-second `GenServer.stop`. `state.sandbox_id` is written once at
+  init. A stale actor therefore cannot reach here at all, whereas an SQL
+  binding check *would* refuse the legitimate rebind-between-halves case and
+  strand the parent. Note the cost of that reasoning: it holds because of this
+  one caller's shape, and nothing enforces that a second caller keeps it.
 
   The actor's sandbox binding is deliberately **not** a third condition, which
   is why this takes no `sandbox_id`. `_unsafe_complete_turn/3` and

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -2334,57 +2334,43 @@ defmodule Fountain.Conversations do
   @doc """
   Release the conversation `TurnMachine.mark_interrupted/1` left running.
 
-  The second half of the two-phase interrupt. The first half retired the turn
-  and deliberately left the parent `running` so the peer could stop under it,
-  which makes this the **only** writer that will ever idle it: a turn that is
-  no longer `running` is invisible to `AutonomousTurnReaper.sweep_stuck_turns/0`,
-  and `ExecutionGuard._unsafe_recover_turn/3` returns `:noop` for one, so the
-  recovery backstop every other fence in #1767 leans on does not cover this
-  state. Refusing to write here is therefore not "leave it to the next
-  writer"; it is a conversation left `running` with nothing running under it,
-  and no sweep that will ever notice.
+  Caller requirement: call only from `TurnMachine.close_interrupted/1` after
+  its matching `mark_interrupted/1` successfully retired the turn. The public
+  `_unsafe_` helper does not enforce this requirement for another caller.
 
-  That is the whole harm, and it is worth being exact about its edges, because
-  two larger claims about it are false. `_unsafe_sandbox_busy_elsewhere?/4`
-  does **not** read the parent's status — it queries co-tenant `turns` rows and
-  conversation `updated_at` — so a stuck parent does not by itself hold a
-  shared machine to `SANDBOX_MAX_LIFETIME_HOURS`. And the obvious producer,
-  `follow_cotenants/2`, largely rescues itself: it casts `:machine_gone`
-  *before* its `update_all`, and `MachineEvents.gone/4` idles a `running`
-  parent unconditionally. The state is still reachable — a cross-pod co-tenant
-  that Horde's `whereis` misses gets the rebind and no cast — but that is a
-  narrower window than "any sprite replacement".
+  The binding check belongs to that successful mark: `_unsafe_interrupt_turn/2`
+  checks the actor's sandbox binding under the parent lock, and only success
+  sets `interrupted?`. `close_interrupted/1` calls this helper only when that
+  flag is true. Neither `from_state/1` nor `into_state/2` carries the flag, so
+  it cannot survive a mailbox round-trip. `ConversationServer.interrupt_turn/1`
+  runs both halves synchronously, separated only by `stop_acp_peer/1`, whose
+  `GenServer.stop/3` has a one-second timeout. The server's `sandbox_id` is set
+  at init and never changed. An actor already stale at the mark cannot reach
+  this write; a rebind after a successful mark can still reach it.
 
-  Two conditions gate the write, the same two `_unsafe_complete_turn/3`
-  applies: `ExecutionGuard.latest_turn?/2` and a `running` parent. A turn
-  superseded while the peer was stopping keeps the conversation running; an
-  abandoned older turn left `running` does not stop this one idling it. The
-  lock matches turn admission, so a concurrent admission cannot slip between
-  this read and the write.
+  This half deliberately takes no `sandbox_id` and does not repeat the binding
+  check. It writes no turn result. Under the parent and turn locks, it requires
+  a `running` parent, an `interrupted` turn and `ExecutionGuard.latest_turn?/2`.
+  A successor admitted while the peer was stopping prevents the idle write;
+  an older turn left `running` does not. Admission inserts its turn and sets
+  the parent `running` in the same transaction under the same parent lock, so
+  it cannot slip between this check and the write.
 
-  Deliberately **no sandbox-binding condition**, unlike every other #1767
-  fence. The binding is still checked — but by the process rather than the
-  query, and more tightly: `interrupted?` appears in neither `from_state/1`
-  nor `into_state/2`, so it cannot survive a mailbox round-trip, and the two
-  halves are one synchronous body separated only by `stop_acp_peer/1`, a
-  bounded one-second `GenServer.stop`. `state.sandbox_id` is written once at
-  init. A stale actor therefore cannot reach here at all, whereas an SQL
-  binding check *would* refuse the legitimate rebind-between-halves case and
-  strand the parent. Note the cost of that reasoning: it holds because of this
-  one caller's shape, and nothing enforces that a second caller keeps it.
+  Rechecking the binding here could leave the parent `running` after the
+  first half retired its last running turn. `AutonomousTurnReaper.sweep_stuck_turns/0`
+  selects running turns, and `ExecutionGuard._unsafe_recover_turn/3` returns
+  `:noop` for a retired turn, so those recovery paths cannot repair that state.
+  Other paths can idle the parent: `MachineEvents.gone/4` and the lifecycle's
+  park and reclaim paths do so when they run.
 
-  The actor's sandbox binding is deliberately **not** a third condition, which
-  is why this takes no `sandbox_id`. `_unsafe_complete_turn/3` and
-  `_unsafe_fence_sandbox_for_teardown/2` fence on the binding because they
-  write a *result*, and a stale actor must not overwrite the owner's. This
-  writes no turn row at all. Its only write releases a `running` status that
-  this actor itself set moments ago and that nothing else can clear, and it
-  writes it only when the locked parent proves there is no work: the turn is
-  terminal and `latest_turn?/2` says no successor has been admitted. A
-  conversation can be rebound under a live server without any actor
-  changing — `follow_cotenants/2` moves every co-tenant of a replaced sprite
-  with one unlocked `update_all` (ADR 0023 gate 5) — so a binding condition
-  here would strand exactly the conversations that shared a machine.
+  `follow_cotenants/2` sends `:machine_gone` before rebinding with `update_all`,
+  so a server that receives the cast has `gone/4`'s cleanup as a backstop.
+  `tell_cotenants/3` skips the cast when `ConversationServer.whereis/1` misses,
+  including a cross-pod registry miss, while the rebind still applies. The
+  parent can then remain `running` until another cleanup path runs.
+  `_unsafe_sandbox_busy_elsewhere?/4` reads co-tenant turns and `updated_at`
+  for conversations without turns, not the parent's status; a stuck parent
+  alone does not keep the shared sandbox busy or extend its billing lifetime.
 
   Known gap: a turn no longer `interrupted` writes nothing, and nothing
   overwrites a terminal turn today, so that arm has no live producer (#2054

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -2306,7 +2306,7 @@ defmodule Fountain.Conversations do
           # admitted between this read and the write.
           #
           # The interrupt path passes `idle?: false` and idles later, through
-          # `_unsafe_idle_interrupted_turn/2`, which asks the same two
+          # `_unsafe_idle_interrupted_turn/1`, which asks the same two
           # questions once the peer has stopped.
           updated_conv =
             if idle? and conv.status == "running" and
@@ -2332,25 +2332,44 @@ defmodule Fountain.Conversations do
   end
 
   @doc """
-  Idle the interrupted turn's conversation after its peer has stopped.
+  Release the conversation `TurnMachine.mark_interrupted/1` left running.
 
-  The second half of the interrupt `TurnMachine.mark_interrupted/1` began.
-  That half deliberately left the parent `running` so the peer could stop
-  under it, which makes this the only writer that will idle it. Recheck the
-  actor's binding and the interrupted turn under the parent lock, then apply
-  the same two idle preconditions `_unsafe_complete_turn/3` applies:
-  `ExecutionGuard.latest_turn?/2` and a `running` parent. A turn superseded
-  while the peer was stopping keeps the conversation running; an abandoned
-  older turn left `running` does not stop this one idling it. The lock
-  matches turn admission, so a concurrent admission cannot slip between this
-  check and the idle write. No turn row is changed here.
+  The second half of the two-phase interrupt. The first half retired the turn
+  and deliberately left the parent `running` so the peer could stop under it,
+  which makes this the **only** writer that will ever idle it: a turn that is
+  no longer `running` is invisible to `AutonomousTurnReaper.sweep_stuck_turns/0`,
+  and `ExecutionGuard._unsafe_recover_turn/3` returns `:noop` for one, so the
+  recovery backstop every other fence in #1767 leans on does not cover this
+  state. Refusing to write here is therefore not "leave it to the next
+  writer"; it is a conversation stuck `running` with nothing running under it,
+  and `_unsafe_sandbox_busy_elsewhere?/4` reads that parent, so a shared
+  machine bills to `SANDBOX_MAX_LIFETIME_HOURS`.
 
-  Known gap: this refuses to write when the parent has been rebound to
-  another sandbox, and when the turn is no longer `interrupted`. Neither
-  leaves a `running` parent that nothing else will idle — see
-  `Fountain.Conversations.TurnMachine.close_interrupted/1`.
+  Two conditions gate the write, the same two `_unsafe_complete_turn/3`
+  applies: `ExecutionGuard.latest_turn?/2` and a `running` parent. A turn
+  superseded while the peer was stopping keeps the conversation running; an
+  abandoned older turn left `running` does not stop this one idling it. The
+  lock matches turn admission, so a concurrent admission cannot slip between
+  this read and the write.
+
+  The actor's sandbox binding is deliberately **not** a third condition, which
+  is why this takes no `sandbox_id`. `_unsafe_complete_turn/3` and
+  `_unsafe_fence_sandbox_for_teardown/2` fence on the binding because they
+  write a *result*, and a stale actor must not overwrite the owner's. This
+  writes no turn row at all. Its only write releases a `running` status that
+  this actor itself set moments ago and that nothing else can clear, and it
+  writes it only when the locked parent proves there is no work: the turn is
+  terminal and `latest_turn?/2` says no successor has been admitted. A
+  conversation can be rebound under a live server without any actor
+  changing — `follow_cotenants/2` moves every co-tenant of a replaced sprite
+  with one unlocked `update_all` (ADR 0023 gate 5) — so a binding condition
+  here would strand exactly the conversations that shared a machine.
+
+  Known gap: a turn no longer `interrupted` writes nothing, and nothing
+  overwrites a terminal turn today, so that arm has no live producer (#2054
+  gap 2).
   """
-  def _unsafe_idle_interrupted_turn(%Turn{} = turn, sandbox_id) do
+  def _unsafe_idle_interrupted_turn(%Turn{} = turn) do
     {:ok, result} =
       Repo.transaction(fn ->
         conversation_query =
@@ -2362,10 +2381,9 @@ defmodule Fountain.Conversations do
             lock: "FOR UPDATE"
           )
 
-        with %Conversation{} = conv <- Repo.one(conversation_query),
-             true <- conv.sandbox_id == sandbox_id and conv.status not in ["terminated", "failed"],
+        with %Conversation{status: "running"} = conv <- Repo.one(conversation_query),
              %Turn{status: "interrupted"} <- Repo.one(turn_query),
-             true <- conv.status == "running" and ExecutionGuard.latest_turn?(conv.id, turn.id) do
+             true <- ExecutionGuard.latest_turn?(conv.id, turn.id) do
           conv |> Conversation.changeset(%{status: "idle"}) |> Repo.update!()
         else
           _ -> :noop

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -2260,6 +2260,18 @@ defmodule Fountain.Conversations do
   """
   def _unsafe_complete_turn(%Turn{} = turn, sandbox_id, status)
       when status in ["completed", "failed", "interrupted"] do
+    end_running_turn(turn, sandbox_id, status, true)
+  end
+
+  @doc """
+  Mark an actor-owned turn interrupted while retaining the conversation's
+  status until the peer has stopped. Uses the same binding and terminal guards
+  as completion, with reply activation after commit.
+  """
+  def _unsafe_interrupt_turn(%Turn{} = turn, sandbox_id),
+    do: end_running_turn(turn, sandbox_id, "interrupted", false)
+
+  defp end_running_turn(turn, sandbox_id, status, idle?) do
     {:ok, result} =
       Repo.transaction(fn ->
         conversation_query =
@@ -2292,12 +2304,17 @@ defmodule Fountain.Conversations do
           # older turn cannot stop this one from idling it. The parent lock
           # above is the same one turn admission takes, so nothing can be
           # admitted between this read and the write.
-          conv =
-            if conv.status == "running" and ExecutionGuard.latest_turn?(conv.id, turn.id),
-              do: conv |> Conversation.changeset(%{status: "idle"}) |> Repo.update!(),
-              else: conv
+          #
+          # The interrupt path passes `idle?: false` and idles later, through
+          # `_unsafe_idle_interrupted_turn/2`, which asks the same two
+          # questions once the peer has stopped.
+          updated_conv =
+            if idle? and conv.status == "running" and
+                 ExecutionGuard.latest_turn?(conv.id, turn.id),
+               do: conv |> Conversation.changeset(%{status: "idle"}) |> Repo.update!(),
+               else: conv
 
-          {updated, conv, is_binary(Ecto.Changeset.get_change(changeset, :reply_text))}
+          {updated, updated_conv, is_binary(Ecto.Changeset.get_change(changeset, :reply_text))}
         else
           _ -> :noop
         end
@@ -2309,8 +2326,59 @@ defmodule Fountain.Conversations do
 
       {updated, conv, reply_materialized?} ->
         if reply_materialized?, do: Fountain.Activation.turn_replied(updated)
-        broadcast_sidebar_update(conv.user_id)
+        if idle?, do: broadcast_sidebar_update(conv.user_id)
         {:ok, updated}
+    end
+  end
+
+  @doc """
+  Idle the interrupted turn's conversation after its peer has stopped.
+
+  The second half of the interrupt `TurnMachine.mark_interrupted/1` began.
+  That half deliberately left the parent `running` so the peer could stop
+  under it, which makes this the only writer that will idle it. Recheck the
+  actor's binding and the interrupted turn under the parent lock, then apply
+  the same two idle preconditions `_unsafe_complete_turn/3` applies:
+  `ExecutionGuard.latest_turn?/2` and a `running` parent. A turn superseded
+  while the peer was stopping keeps the conversation running; an abandoned
+  older turn left `running` does not stop this one idling it. The lock
+  matches turn admission, so a concurrent admission cannot slip between this
+  check and the idle write. No turn row is changed here.
+
+  Known gap: this refuses to write when the parent has been rebound to
+  another sandbox, and when the turn is no longer `interrupted`. Neither
+  leaves a `running` parent that nothing else will idle — see
+  `Fountain.Conversations.TurnMachine.close_interrupted/1`.
+  """
+  def _unsafe_idle_interrupted_turn(%Turn{} = turn, sandbox_id) do
+    {:ok, result} =
+      Repo.transaction(fn ->
+        conversation_query =
+          from(c in Conversation, where: c.id == ^turn.conversation_id, lock: "FOR UPDATE")
+
+        turn_query =
+          from(t in Turn,
+            where: t.id == ^turn.id and t.conversation_id == ^turn.conversation_id,
+            lock: "FOR UPDATE"
+          )
+
+        with %Conversation{} = conv <- Repo.one(conversation_query),
+             true <- conv.sandbox_id == sandbox_id and conv.status not in ["terminated", "failed"],
+             %Turn{status: "interrupted"} <- Repo.one(turn_query),
+             true <- conv.status == "running" and ExecutionGuard.latest_turn?(conv.id, turn.id) do
+          conv |> Conversation.changeset(%{status: "idle"}) |> Repo.update!()
+        else
+          _ -> :noop
+        end
+      end)
+
+    case result do
+      %Conversation{} = conv ->
+        broadcast_sidebar_update(conv.user_id)
+        :ok
+
+      :noop ->
+        :noop
     end
   end
 

--- a/apps/fountain/lib/fountain/conversations/turn_machine.ex
+++ b/apps/fountain/lib/fountain/conversations/turn_machine.ex
@@ -728,8 +728,15 @@ defmodule Fountain.Conversations.TurnMachine do
   The interrupt's first half: the row `interrupted`, the stage, the tracer
   closed. The server stops the peer between the halves, as it always did,
   then `close_interrupted/1` ends the span, emits the metric and conditionally
-  idles the conversation. A stale mark emits neither a stage nor a metric;
-  reassignment or a newer running turn between halves prevents the idle write.
+  idles the conversation. A stale mark emits neither a stage nor a metric, and
+  closing it writes nothing.
+
+  This half leaves the parent `running` on purpose, so the peer stops under a
+  conversation that still says it is working. Nothing but the second half can
+  clear that, because a retired turn is invisible to every recovery sweep, so
+  the second half rechecks the generation rather than this actor's binding
+  (`Conversations._unsafe_idle_interrupted_turn/1`). A successor admitted
+  while the peer was stopping is what keeps the conversation running.
   """
   @spec mark_interrupted(t()) :: t()
   def mark_interrupted(%__MODULE__{} = turn) do
@@ -759,8 +766,11 @@ defmodule Fountain.Conversations.TurnMachine do
 
     if turn.interrupted? do
       emit_completed(turn, "interrupted")
-      # Ownership: mark_interrupted verified this actor; recheck after peer shutdown.
-      Conversations._unsafe_idle_interrupted_turn(turn.row, turn.sandbox_id)
+      # Ownership: mark_interrupted verified this actor's binding and retired
+      # the turn under it. This half releases the parent that half left
+      # running, and is the only writer that can — see its docstring for why
+      # it rechecks the generation rather than the binding.
+      Conversations._unsafe_idle_interrupted_turn(turn.row)
     end
 
     %{

--- a/apps/fountain/lib/fountain/conversations/turn_machine.ex
+++ b/apps/fountain/lib/fountain/conversations/turn_machine.ex
@@ -87,6 +87,7 @@ defmodule Fountain.Conversations.TurnMachine do
   @type t :: %__MODULE__{
           conversation_id: String.t() | nil,
           sandbox_id: String.t() | nil,
+          interrupted?: boolean(),
           row: Conversations.Turn.t() | nil,
           span: term() | nil,
           metrics: map() | nil,
@@ -97,6 +98,7 @@ defmodule Fountain.Conversations.TurnMachine do
 
   defstruct conversation_id: nil,
             sandbox_id: nil,
+            interrupted?: false,
             row: nil,
             span: nil,
             metrics: nil,
@@ -725,36 +727,51 @@ defmodule Fountain.Conversations.TurnMachine do
   @doc """
   The interrupt's first half: the row `interrupted`, the stage, the tracer
   closed. The server stops the peer between the halves, as it always did,
-  then `close_interrupted/1` ends the span, emits the metric and sets the
-  conversation idle.
+  then `close_interrupted/1` ends the span, emits the metric and conditionally
+  idles the conversation. A stale mark emits neither a stage nor a metric;
+  reassignment or a newer running turn between halves prevents the idle write.
   """
   @spec mark_interrupted(t()) :: t()
   def mark_interrupted(%__MODULE__{} = turn) do
-    {:ok, _turn} =
-      Conversations._unsafe_update_turn(turn.row, %{
-        status: "interrupted",
-        ended_at: now()
-      })
+    # Ownership: the actor's binding is checked with the parent and turn locked.
+    applied? =
+      case Conversations._unsafe_interrupt_turn(turn.row, turn.sandbox_id) do
+        {:ok, _} ->
+          publish_stage(turn.conversation_id, "turn", "interrupted", %{
+            turn_id: turn.row.id,
+            turn_number: turn.row.turn_number
+          })
 
-    publish_stage(turn.conversation_id, "turn", "interrupted", %{
-      turn_id: turn.row.id,
-      turn_number: turn.row.turn_number
-    })
+          true
 
-    # Finalize stream tracer: close any tool spans still open (abandoned calls).
+        :noop ->
+          false
+      end
+
+    # Finalize local spans even when another actor owns the persisted result.
     finalize_tracer(turn.tracer)
-    turn
+    %{turn | interrupted?: applied?}
   end
 
   @spec close_interrupted(t()) :: t()
   def close_interrupted(%__MODULE__{} = turn) do
     end_span(turn.span, :error, %{"outcome" => "interrupted"})
 
-    emit_completed(turn, "interrupted")
+    if turn.interrupted? do
+      emit_completed(turn, "interrupted")
+      # Ownership: mark_interrupted verified this actor; recheck after peer shutdown.
+      Conversations._unsafe_idle_interrupted_turn(turn.row, turn.sandbox_id)
+    end
 
-    {:ok, _} = Conversations._unsafe_idle_after_turn(turn.row)
-
-    %{turn | row: nil, span: nil, metrics: nil, tracer: nil, session_retry: nil}
+    %{
+      turn
+      | row: nil,
+        span: nil,
+        metrics: nil,
+        tracer: nil,
+        session_retry: nil,
+        interrupted?: false
+    }
   end
 
   @doc "Release local measurements for a fenced worker without changing its persisted turn."

--- a/apps/fountain/lib/fountain/conversations/turn_machine.ex
+++ b/apps/fountain/lib/fountain/conversations/turn_machine.ex
@@ -732,9 +732,9 @@ defmodule Fountain.Conversations.TurnMachine do
   closing it writes nothing.
 
   This half leaves the parent `running` on purpose, so the peer stops under a
-  conversation that still says it is working. Nothing but the second half can
-  clear that, because a retired turn is invisible to every recovery sweep, so
-  the second half rechecks the generation rather than this actor's binding
+  conversation that still says it is working. Turn recovery skips retired
+  turns, so this pair must finish its own parent cleanup. The second half
+  rechecks the generation rather than this actor's binding
   (`Conversations._unsafe_idle_interrupted_turn/1`). A successor admitted
   while the peer was stopping is what keeps the conversation running.
   """
@@ -768,8 +768,8 @@ defmodule Fountain.Conversations.TurnMachine do
       emit_completed(turn, "interrupted")
       # Ownership: mark_interrupted verified this actor's binding and retired
       # the turn under it. This half releases the parent that half left
-      # running, and is the only writer that can — see its docstring for why
-      # it rechecks the generation rather than the binding.
+      # running. See its docstring for the caller requirement and why it
+      # rechecks the generation rather than the binding.
       Conversations._unsafe_idle_interrupted_turn(turn.row)
     end
 

--- a/apps/fountain/test/fountain/audit_guardrail_test.exs
+++ b/apps/fountain/test/fountain/audit_guardrail_test.exs
@@ -175,6 +175,8 @@ defmodule Fountain.AuditGuardrailTest do
       "internal conditional status write; terminate_conversation/2 audits the successful action once",
     "Conversations._unsafe_complete_turn/3" =>
       "conditional per-turn bookkeeping; the turn stage records completion outside its transaction",
+    "Conversations._unsafe_interrupt_turn/2 and _unsafe_idle_interrupted_turn/2" =>
+      "conditional interrupt bookkeeping; its turn stage and public lifecycle action carry the trail",
     "ConversationServer per-turn state" => "high-volume machine state; log_events covers it",
     "Accounts.touch_api_key/1" => "a last-used stamp on every authenticated request",
     "Runners.touch/1 and reconnects" =>

--- a/apps/fountain/test/fountain/audit_guardrail_test.exs
+++ b/apps/fountain/test/fountain/audit_guardrail_test.exs
@@ -175,7 +175,7 @@ defmodule Fountain.AuditGuardrailTest do
       "internal conditional status write; terminate_conversation/2 audits the successful action once",
     "Conversations._unsafe_complete_turn/3" =>
       "conditional per-turn bookkeeping; the turn stage records completion outside its transaction",
-    "Conversations._unsafe_interrupt_turn/2 and _unsafe_idle_interrupted_turn/2" =>
+    "Conversations._unsafe_interrupt_turn/2 and _unsafe_idle_interrupted_turn/1" =>
       "conditional interrupt bookkeeping; its turn stage and public lifecycle action carry the trail",
     "ConversationServer per-turn state" => "high-volume machine state; log_events covers it",
     "Accounts.touch_api_key/1" => "a last-used stamp on every authenticated request",

--- a/apps/fountain/test/fountain/conversations/conversation_server_platform_inference_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_platform_inference_test.exs
@@ -187,6 +187,7 @@ defmodule Fountain.Conversations.ConversationServerPlatformInferenceTest do
 
       machine = %TurnMachine{
         conversation_id: conv.id,
+        sandbox_id: conv.sandbox_id,
         row: row,
         metrics:
           TurnMachine.start_metrics("claude", :sprites, System.monotonic_time(:millisecond))

--- a/apps/fountain/test/fountain/conversations/interruption_admission_isolation_test.exs
+++ b/apps/fountain/test/fountain/conversations/interruption_admission_isolation_test.exs
@@ -1,0 +1,106 @@
+defmodule Fountain.Conversations.InterruptionAdmissionIsolationTest do
+  use Fountain.DataCase, async: false
+
+  alias Fountain.Conversations
+
+  for capacity <- [1, :unbounded] do
+    @tag capacity: capacity
+    test "a newer #{inspect(capacity)} turn keeps the interrupted conversation running", ctx do
+      Ecto.Adapters.SQL.Sandbox.unboxed_run(Repo, fn ->
+        user = insert_verified_user()
+        sandbox = insert_sandbox(user_id: user.id, status: "ready")
+        conv = insert_conversation(user_id: user.id, sandbox: sandbox, status: "running")
+        turn = insert_turn(conv, status: "running")
+        # Ownership: these fixtures are the actor's own conversation and machine.
+        assert {:ok, _} = Conversations._unsafe_interrupt_turn(turn, sandbox.id)
+        handler = {__MODULE__, make_ref()}
+
+        :telemetry.attach(
+          handler,
+          [:fountain, :repo, :query],
+          &__MODULE__.pause_admission/4,
+          self()
+        )
+
+        admission =
+          independent(fn ->
+            Process.put(:pause_interrupt_admission_test, true)
+            # Ownership: exercise real admission for this actor's fixture.
+            Conversations._unsafe_create_turn_on_sandbox(
+              %{conversation_id: conv.id, turn_number: 2, status: "running", prompt: "next"},
+              sandbox.id,
+              ctx.capacity
+            )
+          end)
+
+        try do
+          assert_receive :turn_inserted, 5_000
+
+          ending =
+            independent(fn ->
+              # Ownership: finish the interrupt after its peer has stopped.
+              Conversations._unsafe_idle_interrupted_turn(turn, sandbox.id)
+            end)
+
+          try do
+            ending_pid = ending.pid
+            assert_receive {:backend, ^ending_pid, backend}, 5_000
+            await_blocked(backend, System.monotonic_time(:millisecond) + 5_000)
+            send(admission.pid, :commit)
+            assert {:ok, next_turn} = Task.await(admission)
+            assert :noop = Task.await(ending)
+            assert Repo.reload!(conv).status == "running"
+            assert Repo.reload!(next_turn).status == "running"
+            assert Repo.reload!(turn).status == "interrupted"
+          after
+            Task.shutdown(ending, :brutal_kill)
+          end
+        after
+          Task.shutdown(admission, :brutal_kill)
+          :telemetry.detach(handler)
+          Repo.delete_all(from e in Fountain.Audit.Event, where: e.user_id == ^user.id)
+          Repo.delete!(user)
+          Repo.delete!(sandbox)
+        end
+      end)
+    end
+  end
+
+  def pause_admission(_event, _measurements, metadata, owner) do
+    if Process.get(:pause_interrupt_admission_test) &&
+         String.starts_with?(metadata.query, ~s(INSERT INTO "turns")) do
+      Process.delete(:pause_interrupt_admission_test)
+      send(owner, :turn_inserted)
+
+      receive do
+        :commit -> :ok
+      after
+        10_000 -> raise "admission release timed out"
+      end
+    end
+  end
+
+  defp independent(fun) do
+    owner = self()
+
+    Task.async(fn ->
+      Ecto.Adapters.SQL.Sandbox.unboxed_run(Repo, fn ->
+        %{rows: [[backend]]} = Repo.query!("SELECT pg_backend_pid()")
+        send(owner, {:backend, self(), backend})
+        fun.()
+      end)
+    end)
+  end
+
+  defp await_blocked(backend, deadline) do
+    %{rows: [[blocked]]} = Repo.query!("SELECT cardinality(pg_blocking_pids($1)) > 0", [backend])
+
+    unless blocked do
+      assert System.monotonic_time(:millisecond) < deadline,
+             "no PostgreSQL row-lock wait observed"
+
+      Process.sleep(5)
+      await_blocked(backend, deadline)
+    end
+  end
+end

--- a/apps/fountain/test/fountain/conversations/interruption_admission_isolation_test.exs
+++ b/apps/fountain/test/fountain/conversations/interruption_admission_isolation_test.exs
@@ -39,7 +39,7 @@ defmodule Fountain.Conversations.InterruptionAdmissionIsolationTest do
           ending =
             independent(fn ->
               # Ownership: finish the interrupt after its peer has stopped.
-              Conversations._unsafe_idle_interrupted_turn(turn, sandbox.id)
+              Conversations._unsafe_idle_interrupted_turn(turn)
             end)
 
           try do

--- a/apps/fountain/test/fountain/conversations/turn_machine_test.exs
+++ b/apps/fountain/test/fountain/conversations/turn_machine_test.exs
@@ -616,10 +616,6 @@ defmodule Fountain.Conversations.TurnMachineTest do
         assert marked.interrupted?
 
         case ctx.between do
-          :reassigned ->
-            replacement = insert_sandbox(user_id: ctx.user.id)
-            Conversations.update_conversation(ctx.conv, %{sandbox_id: replacement.id})
-
           :terminated ->
             Conversations.update_conversation(ctx.conv, %{status: "terminated"})
 
@@ -643,14 +639,10 @@ defmodule Fountain.Conversations.TurnMachineTest do
       end
     end
 
-    # The first half retires the turn, which puts the conversation beyond every
-    # recovery sweep: `AutonomousTurnReaper` selects `status == "running"` turns
-    # and `ExecutionGuard._unsafe_recover_turn/3` no-ops on a retired one. So
-    # the second half must release the parent it left running even when the
-    # binding moved under it — `follow_cotenants/2` rebinds every co-tenant of
-    # a replaced sprite with one unlocked `update_all`, with no actor change at
-    # all (ADR 0023 gate 5). Fencing this write on the binding stranded exactly
-    # those conversations `running` with nothing running under them.
+    # The first half retires the turn, so turn recovery cannot idle its parent.
+    # A rebind can arrive while the peer stops. The matching second half must
+    # still finish cleanup when this remains the latest turn, without relying
+    # on a later machine-gone cast or lifecycle cleanup to idle the parent.
     test "a rebind between the interrupt halves still releases the parent", ctx do
       Conversations.update_conversation(ctx.conv, %{status: "running"})
       marked = TurnMachine.mark_interrupted(ctx.machine)

--- a/apps/fountain/test/fountain/conversations/turn_machine_test.exs
+++ b/apps/fountain/test/fountain/conversations/turn_machine_test.exs
@@ -540,6 +540,8 @@ defmodule Fountain.Conversations.TurnMachineTest do
       {:ok, _} = Conversations.update_conversation(conv, %{status: "running"})
 
       marked = TurnMachine.mark_interrupted(m)
+      assert marked.interrupted?
+      assert Fountain.Repo.reload!(conv).status == "running"
       assert marked.row == row
       assert Fountain.Repo.get!(Conversations.Turn, row.id).status == "interrupted"
       assert [{"interrupted", %{"turn_id" => _}}] = stages(conv.id, "turn")
@@ -547,6 +549,98 @@ defmodule Fountain.Conversations.TurnMachineTest do
       assert %TurnMachine{row: nil, metrics: nil} = TurnMachine.close_interrupted(marked)
       assert Conversations._unsafe_get_conversation!(conv.id).status == "idle"
       assert_receive {:telemetry, [:fountain, :turn, :completed], _, %{status: "interrupted"}}
+    end
+
+    # The interrupt is a second door onto the writer that materialises
+    # `reply_text`, and materialising it is what activates an account (#1392).
+    # `_unsafe_interrupt_turn/2` passes `idle?: false`, so the activation call
+    # must not be gated on the idle write the way the sidebar broadcast beside
+    # it is: an interrupted first reply is still a first reply, and nothing
+    # recovers it later. `_unsafe_backfill_reply_texts/0` writes the column
+    # without calling `Activation.turn_replied/1`, and `maybe_put_reply_text/2`
+    # only re-derives on a later write a terminal row may never get (#2055).
+    test "an interrupted first reply activates the account", ctx do
+      insert_log_event(ctx.conv, turn_id: ctx.row.id, stream: "acp", data: @update_line)
+      refute Fountain.Repo.reload!(ctx.user).onboarding_completed_at
+
+      TurnMachine.mark_interrupted(ctx.machine)
+
+      assert Fountain.Repo.reload!(ctx.row).reply_text == "hi"
+      assert Fountain.Repo.reload!(ctx.user).onboarding_completed_at
+    end
+
+    for stale <- [:reassigned, :terminated, :completed, :interrupted] do
+      @tag stale: stale
+      test "a #{stale} turn is not interrupted by the stale actor", ctx do
+        attach_telemetry([[:fountain, :turn, :completed]])
+
+        case ctx.stale do
+          :reassigned ->
+            replacement = insert_sandbox(user_id: ctx.user.id)
+
+            Conversations.update_conversation(ctx.conv, %{
+              sandbox_id: replacement.id,
+              status: "running"
+            })
+
+          :terminated ->
+            Conversations.update_conversation(ctx.conv, %{status: "terminated"})
+
+          status ->
+            ctx.row
+            |> Ecto.Changeset.change(status: Atom.to_string(status))
+            |> Fountain.Repo.update!()
+        end
+
+        persisted_turn = Fountain.Repo.reload!(ctx.row)
+        persisted_conv = Fountain.Repo.get!(Conversations.Conversation, ctx.conv.id)
+        marked = TurnMachine.mark_interrupted(ctx.machine)
+        refute marked.interrupted?
+
+        assert %TurnMachine{row: nil, metrics: nil, interrupted?: false} =
+                 TurnMachine.close_interrupted(marked)
+
+        assert Fountain.Repo.reload!(ctx.row) == persisted_turn
+        assert Fountain.Repo.get!(Conversations.Conversation, ctx.conv.id) == persisted_conv
+        assert stages(ctx.conv.id, "turn") == []
+        refute_receive {:telemetry, [:fountain, :turn, :completed], _, _}, 50
+      end
+    end
+
+    for change <- [:reassigned, :terminated, :new_turn, :deleted] do
+      @tag between: change
+      test "#{change} between interrupt halves keeps the newer conversation state", ctx do
+        attach_telemetry([[:fountain, :turn, :completed]])
+        Conversations.update_conversation(ctx.conv, %{status: "running"})
+        marked = TurnMachine.mark_interrupted(ctx.machine)
+        assert marked.interrupted?
+
+        case ctx.between do
+          :reassigned ->
+            replacement = insert_sandbox(user_id: ctx.user.id)
+            Conversations.update_conversation(ctx.conv, %{sandbox_id: replacement.id})
+
+          :terminated ->
+            Conversations.update_conversation(ctx.conv, %{status: "terminated"})
+
+          :new_turn ->
+            insert_turn(ctx.conv, status: "running")
+
+          :deleted ->
+            Fountain.Repo.delete!(ctx.conv)
+        end
+
+        persisted_conv = Fountain.Repo.get(Conversations.Conversation, ctx.conv.id)
+        prior_stages = stages(ctx.conv.id, "turn")
+
+        assert %TurnMachine{row: nil, metrics: nil, interrupted?: false} =
+                 TurnMachine.close_interrupted(marked)
+
+        assert Fountain.Repo.get(Conversations.Conversation, ctx.conv.id) == persisted_conv
+        assert stages(ctx.conv.id, "turn") == prior_stages
+        assert_receive {:telemetry, [:fountain, :turn, :completed], _, %{status: "interrupted"}}
+        refute_receive {:telemetry, [:fountain, :turn, :completed], _, _}, 50
+      end
     end
   end
 

--- a/apps/fountain/test/fountain/conversations/turn_machine_test.exs
+++ b/apps/fountain/test/fountain/conversations/turn_machine_test.exs
@@ -607,7 +607,7 @@ defmodule Fountain.Conversations.TurnMachineTest do
       end
     end
 
-    for change <- [:reassigned, :terminated, :new_turn, :deleted] do
+    for change <- [:terminated, :new_turn, :deleted] do
       @tag between: change
       test "#{change} between interrupt halves keeps the newer conversation state", ctx do
         attach_telemetry([[:fountain, :turn, :completed]])
@@ -641,6 +641,78 @@ defmodule Fountain.Conversations.TurnMachineTest do
         assert_receive {:telemetry, [:fountain, :turn, :completed], _, %{status: "interrupted"}}
         refute_receive {:telemetry, [:fountain, :turn, :completed], _, _}, 50
       end
+    end
+
+    # The first half retires the turn, which puts the conversation beyond every
+    # recovery sweep: `AutonomousTurnReaper` selects `status == "running"` turns
+    # and `ExecutionGuard._unsafe_recover_turn/3` no-ops on a retired one. So
+    # the second half must release the parent it left running even when the
+    # binding moved under it — `follow_cotenants/2` rebinds every co-tenant of
+    # a replaced sprite with one unlocked `update_all`, with no actor change at
+    # all (ADR 0023 gate 5). Fencing this write on the binding stranded exactly
+    # those conversations `running` with nothing running under them.
+    test "a rebind between the interrupt halves still releases the parent", ctx do
+      Conversations.update_conversation(ctx.conv, %{status: "running"})
+      marked = TurnMachine.mark_interrupted(ctx.machine)
+      assert marked.interrupted?
+      assert Fountain.Repo.reload!(ctx.conv).status == "running"
+
+      replacement = insert_sandbox(user_id: ctx.user.id)
+      Conversations.update_conversation(ctx.conv, %{sandbox_id: replacement.id})
+
+      TurnMachine.close_interrupted(marked)
+
+      assert Fountain.Repo.reload!(ctx.conv).status == "idle"
+      assert Fountain.Repo.reload!(ctx.conv).sandbox_id == replacement.id
+      assert Fountain.Repo.reload!(ctx.row).status == "interrupted"
+    end
+
+    # The predicate is `latest_turn?/2`, not "no other turn is running". An
+    # older turn abandoned `running` — which the stale-actor arm of
+    # `_unsafe_interrupt_turn/2` manufactures — must not pin the parent.
+    test "an abandoned older turn does not stop the interrupt idling the parent", ctx do
+      abandoned = insert_turn(ctx.conv, status: "running", started_at: DateTime.utc_now())
+      newest = insert_turn(ctx.conv, status: "running", started_at: DateTime.utc_now())
+      assert abandoned.turn_number < newest.turn_number
+      Conversations.update_conversation(ctx.conv, %{status: "running"})
+
+      machine = %{ctx.machine | row: newest}
+
+      machine |> TurnMachine.mark_interrupted() |> TurnMachine.close_interrupted()
+
+      assert Fountain.Repo.reload!(ctx.conv).status == "idle"
+      assert Fountain.Repo.reload!(abandoned).status == "running"
+    end
+
+    # `_unsafe_idle_interrupted_turn/1` idles a `running` parent, nothing else.
+    # A `pending` conversation completing an interrupt was going `idle` here.
+    for status <- ["pending", "idle"] do
+      @tag parent: status
+      test "the interrupt leaves a #{status} conversation alone", ctx do
+        marked = TurnMachine.mark_interrupted(%{ctx.machine | row: ctx.row})
+
+        ctx.conv
+        |> Ecto.Changeset.change(status: ctx.parent)
+        |> Fountain.Repo.update!()
+
+        TurnMachine.close_interrupted(marked)
+
+        assert Fountain.Repo.reload!(ctx.conv).status == ctx.parent
+      end
+    end
+
+    # Ours to release means ours: a turn another writer moved off `interrupted`
+    # is no longer the one this half retired, so it writes nothing.
+    test "a turn moved off interrupted between the halves is not released", ctx do
+      Conversations.update_conversation(ctx.conv, %{status: "running"})
+      marked = TurnMachine.mark_interrupted(ctx.machine)
+      assert marked.interrupted?
+
+      ctx.row |> Ecto.Changeset.change(status: "completed") |> Fountain.Repo.update!()
+
+      TurnMachine.close_interrupted(marked)
+
+      assert Fountain.Repo.reload!(ctx.conv).status == "running"
     end
   end
 


### PR DESCRIPTION
A stale interrupt could overwrite a turn after reassignment, and its later idle write could overwrite a conversation whose next turn had already started. Both interrupt bookkeeping phases now check the actor's sandbox binding. The first phase conditionally marks a running turn interrupted while retaining the conversation status; the second locks the parent and checks the interrupted turn plus the absence of newer running work before idling it.

The existing adapter/peer shutdown order is preserved. A stale mark publishes no interruption stage or completion metric. A successful mark records its completion metric once even if reassignment or new work subsequently prevents the idle write. Reply materialization and activation use the same guarded transaction helper as normal completion.

Stack: based on #1999. Refs #1767. Transport-failure bookkeeping and durable forced-teardown recovery remain separate follow-ups.

Validation:
- All 309 focused tests passed, covering the turn machine, real ACP flows, metrics, platform inference, activation, search, termination actors and audit guardrails.
- Eight regressions cover stale marks and changes between interrupt halves, including reassignment, terminal/deleted conversations and newer running work.
- Two real PostgreSQL tests exercise actual bounded/unbounded turn admission while final interrupt bookkeeping waits on the parent lock. The newly admitted turn and conversation both remain running.
- Substituting the original unconditional writes produced the ten expected regression failures. Restoring the guards passed the tests.
- Full `mix precommit` passed: Fountain 5,460 tests and 6 doctests, Buzz 144 tests, Support 33 tests; zero failures.
