### PR TITLE
fix: preserve newer turn results when a transport fails

### DIFF
--- a/apps/fountain/lib/fountain/conversations/reattachment.ex
+++ b/apps/fountain/lib/fountain/conversations/reattachment.ex
@@ -127,42 +127,25 @@ defmodule Fountain.Conversations.Reattachment do
     Logger.error("sprite command error mid-turn: #{inspect(reason)} — failing the turn")
     state = finish_runner_reconnect(state, "failed")
 
-    # ownership: current_turn belongs to the conversation this server owns.
-    {:ok, turn} =
-      Conversations._unsafe_update_turn(state.current_turn, %{
-        status: "failed",
-        ended_at: DateTime.utc_now() |> DateTime.truncate(:second)
-      })
-
-    Output.publish_stage(state.conversation_id, "turn", "failed", %{
-      turn_id: turn.id,
-      turn_number: turn.turn_number,
-      reason: "sprite connection lost: #{inspect(reason)}"
-    })
-
-    TurnMachine.finalize_tracer(state.stream_tracer)
-
-    # An ACP turn can also end here — the adapter exits, is interrupted, or its
-    # socket drops before it ever answers `session/prompt`. The peer has nothing
-    # left to drive and must not outlive the turn.
+    # Stop the failed connection's local peer before committing the turn result.
+    # Completion rechecks the actor's binding after this callback can yield.
     Connection.stop_peer(Connection.from_state(state))
-    TurnMachine.end_span(state.current_turn_span, :error, %{"error" => inspect(reason)})
 
-    TurnMachine.emit_completed(TurnMachine.from_state(state), turn.status)
+    turn =
+      TurnMachine.finish(
+        TurnMachine.from_state(state),
+        "failed",
+        %{"error" => inspect(reason)},
+        %{reason: "sprite connection lost: #{inspect(reason)}"}
+      )
 
-    # ownership: state.conversation_id is the server's bound conversation.
-    conv = Conversations._unsafe_get_conversation!(state.conversation_id)
-    {:ok, _} = Conversations.update_conversation(conv, %{status: "idle"})
+    state = TurnMachine.into_state(state, turn)
 
     {:noreply,
      %{
        %{state | last_activity_at: DateTime.utc_now()}
        | current_command: nil,
          current_command_ref: nil,
-         current_turn: nil,
-         current_turn_span: nil,
-         turn_metrics: nil,
-         stream_tracer: nil,
          runner_reconnect: nil,
          runner_replay: nil,
          acp_peer: nil,

--- a/apps/fountain/test/fountain/conversations/reattachment_failure_test.exs
+++ b/apps/fountain/test/fountain/conversations/reattachment_failure_test.exs
@@ -1,0 +1,154 @@
+defmodule Fountain.Conversations.ReattachmentFailureTest do
+  use Fountain.DataCase, async: false
+
+  alias Fountain.Conversations
+  alias Fountain.Conversations.{Reattachment, TurnMachine}
+
+  defmodule Peer do
+    use GenServer
+    def start_link(on_stop), do: GenServer.start_link(__MODULE__, on_stop)
+    def init(on_stop), do: {:ok, on_stop}
+    def terminate(:normal, on_stop), do: on_stop.()
+    def terminate(_reason, _on_stop), do: :ok
+  end
+
+  setup do
+    user = insert_verified_user()
+    conv = insert_conversation(user_id: user.id, status: "running")
+    turn = insert_turn(conv, status: "running")
+    owner = self()
+    handler = {__MODULE__, make_ref()}
+
+    :telemetry.attach(
+      handler,
+      [:fountain, :turn, :completed],
+      fn event, _, meta, _ ->
+        if meta.conv_id == conv.id, do: send(owner, {event, meta})
+      end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler) end)
+    %{user: user, conv: conv, turn: turn}
+  end
+
+  test "stops the local peer before committing failure and preserves its stage and metric", ctx do
+    owner = self()
+
+    state =
+      state(ctx, fn ->
+        refute Repo.in_transaction?()
+        send(owner, {:peer_stopped, Repo.reload!(ctx.turn).status})
+      end)
+
+    assert {:noreply, cleared} = Reattachment.fail_transport(state, :closed)
+    assert_received {:peer_stopped, "running"}
+    refute Process.alive?(state.acp_peer)
+    assert Repo.reload!(ctx.turn).status == "failed"
+    assert Repo.reload!(ctx.conv).status == "idle"
+    assert [event] = stages(ctx)
+    assert event.state == "failed"
+    assert Jason.decode!(event.data)["reason"] == "sprite connection lost: :closed"
+    assert_receive {[:fountain, :turn, :completed], %{status: "failed"}}
+    assert_cleared(cleared)
+  end
+
+  for change <- [:reassigned, :completed, :terminated, :deleted] do
+    @tag during_stop: change
+    test "#{change} during peer shutdown preserves the persisted result", ctx do
+      replacement = insert_sandbox(user_id: ctx.user.id)
+
+      state =
+        state(ctx, fn ->
+          case ctx.during_stop do
+            :reassigned ->
+              Conversations.update_conversation(ctx.conv, %{sandbox_id: replacement.id})
+
+            :completed ->
+              ctx.turn |> Ecto.Changeset.change(status: "completed") |> Repo.update!()
+              insert_turn(ctx.conv, status: "running")
+
+            :terminated ->
+              Conversations.update_conversation(ctx.conv, %{status: "terminated"})
+
+            :deleted ->
+              Repo.delete!(ctx.conv)
+          end
+        end)
+
+      assert {:noreply, cleared} = Reattachment.fail_transport(state, :closed)
+      refute Process.alive?(state.acp_peer)
+      assert_cleared(cleared)
+      assert stages(ctx) == []
+      refute_receive {[:fountain, :turn, :completed], _}, 50
+
+      case ctx.during_stop do
+        :deleted ->
+          assert Repo.reload(ctx.conv) == nil
+          assert Repo.reload(ctx.turn) == nil
+
+        :terminated ->
+          assert Repo.reload!(ctx.conv).status == "terminated"
+          assert Repo.reload!(ctx.turn).status == "running"
+
+        :completed ->
+          assert Repo.reload!(ctx.conv).status == "running"
+          assert Repo.reload!(ctx.turn).status == "completed"
+
+        :reassigned ->
+          assert Repo.reload!(ctx.conv).sandbox_id == replacement.id
+          assert Repo.reload!(ctx.conv).status == "running"
+          assert Repo.reload!(ctx.turn).status == "running"
+      end
+    end
+  end
+
+  defp state(ctx, on_stop) do
+    peer = start_supervised!(Supervisor.child_spec({Peer, on_stop}, restart: :temporary))
+    Ecto.Adapters.SQL.Sandbox.allow(Repo, self(), peer)
+
+    %{
+      conversation_id: ctx.conv.id,
+      sandbox_id: ctx.conv.sandbox_id,
+      current_turn: ctx.turn,
+      current_turn_span: nil,
+      turn_metrics:
+        TurnMachine.start_metrics("claude", :runner, System.monotonic_time(:millisecond)),
+      stream_tracer: nil,
+      turn_session_retry: nil,
+      replay_dedup: MapSet.new(),
+      current_command: :closed_transport,
+      current_command_ref: make_ref(),
+      autonomous_quiet: nil,
+      acp_peer: peer,
+      acp_peer_mon: Process.monitor(peer),
+      runner_reconnect: nil,
+      runner_replay: %{},
+      last_activity_at: DateTime.utc_now()
+    }
+  end
+
+  defp assert_cleared(state) do
+    for field <- [
+          :current_turn,
+          :current_turn_span,
+          :turn_metrics,
+          :stream_tracer,
+          :current_command,
+          :current_command_ref,
+          :acp_peer,
+          :acp_peer_mon,
+          :runner_reconnect,
+          :runner_replay
+        ] do
+      assert state[field] == nil
+    end
+  end
+
+  defp stages(ctx) do
+    Repo.all(
+      from e in Conversations.LogEvent,
+        where: e.conversation_id == ^ctx.conv.id and e.stage == "turn"
+    )
+  end
+end


### PR DESCRIPTION
Transport failure handling could overwrite a turn or idle its conversation after reassignment, termination or another actor's completion. It now uses `TurnMachine.finish/4` and its guarded transaction instead of separate unconditional updates.

The existing local peer-stop attempt runs before committing the turn result, so completion also rechecks changes made during that callback. Successful failures retain their stage reason, span cleanup, completion metric and cleared connection state. Stale failures clear local state without changing the persisted result or emitting another turn-completion event. The peer stop retains its existing best-effort behavior.

Stack: based on #2000. Refs #1767. Earlier pending-permission/usage writes, startup-failure bookkeeping and durable forced-teardown recovery remain separate follow-ups.

Validation:
- All 288 focused tests passed, including real ACP, turn metrics, platform inference, termination actors and audit guardrails.
- Five new tests use a real local GenServer peer. They verify ordering and change the binding/result/terminal state or delete the conversation during shutdown.
- All five tests fail against the parent failure handler and pass with this change.
- Full `mix precommit` passed: Fountain 5,465 tests and 6 doctests, Buzz 144 tests, Support 33 tests; zero failures.

Integration validation: this stack merged cleanly in a temporary worktree with #1948, #1974, #1975, #1977 and #1979, including main at `4fc85151`. All 182 targeted lifecycle tests passed. Full `mix precommit` on the combined tree passed 5,510 Fountain tests and 6 doctests, 144 Buzz tests and 33 Support tests with zero failures. The draft PRs remain separate; the integration branch was not published.
