### PR TITLE
fix: guard startup failure by actor sandbox binding

### DIFF
--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -2245,7 +2245,8 @@ defmodule Fountain.Conversations do
   Lock the conversation before the turn, and commit its idle status with the
   turn's result. A moved or terminal conversation, or a turn already ended by
   another actor, is a no-op. Reply materialization shares that transaction;
-  activation and sidebar publication run after it commits.
+  activation and sidebar publication run after it commits. The optional
+  `:exit_code` is persisted atomically with the result.
 
   The parent only idles under the two conditions `_unsafe_idle_after_turn/1`
   idled under: `ExecutionGuard.latest_turn?/2` and a `running` parent. The
@@ -2258,9 +2259,9 @@ defmodule Fountain.Conversations do
   The two-phase interrupt the server drives itself is a different write, and
   it keeps the conversation running until the peer has stopped.
   """
-  def _unsafe_complete_turn(%Turn{} = turn, sandbox_id, status)
+  def _unsafe_complete_turn(%Turn{} = turn, sandbox_id, status, opts \\ [])
       when status in ["completed", "failed", "interrupted"] do
-    end_running_turn(turn, sandbox_id, status, true)
+    end_running_turn(turn, sandbox_id, status, true, Map.new(Keyword.take(opts, [:exit_code])))
   end
 
   @doc """
@@ -2271,7 +2272,7 @@ defmodule Fountain.Conversations do
   def _unsafe_interrupt_turn(%Turn{} = turn, sandbox_id),
     do: end_running_turn(turn, sandbox_id, "interrupted", false)
 
-  defp end_running_turn(turn, sandbox_id, status, idle?) do
+  defp end_running_turn(turn, sandbox_id, status, idle?, attrs \\ %{}) do
     {:ok, result} =
       Repo.transaction(fn ->
         conversation_query =
@@ -2288,10 +2289,12 @@ defmodule Fountain.Conversations do
              %Turn{status: "running"} = current <- Repo.one(turn_query) do
           changeset =
             current
-            |> Turn.changeset(%{
-              status: status,
-              ended_at: DateTime.utc_now() |> DateTime.truncate(:second)
-            })
+            |> Turn.changeset(
+              Map.merge(attrs, %{
+                status: status,
+                ended_at: DateTime.utc_now() |> DateTime.truncate(:second)
+              })
+            )
             |> maybe_put_reply_text(current)
 
           updated = Repo.update!(changeset)

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -2232,7 +2232,14 @@ defmodule Fountain.Conversations.ConversationServer do
         log_output(acc, stream, data)
       end)
 
-    TurnMachine.fail_before_start(turn, state.conversation_id, what, detail, exit_code)
+    TurnMachine.fail_before_start(
+      turn,
+      state.conversation_id,
+      state.sandbox_id,
+      what,
+      detail,
+      exit_code
+    )
 
     state = %{state | current_turn: nil, turn_session_retry: nil}
 

--- a/apps/fountain/lib/fountain/conversations/turn_machine.ex
+++ b/apps/fountain/lib/fountain/conversations/turn_machine.ex
@@ -1406,7 +1406,8 @@ defmodule Fountain.Conversations.TurnMachine do
   or the runtime exited before the prompt reached its stdin (#603). Both
   leave nothing running, so both end the same way — the turn `failed` with
   the reason, a `turn`/`failed` stage event, and the conversation back to
-  "idle".
+  "idle". A reassigned or terminal conversation, or an already-ended turn,
+  preserves its persisted result and emits no failure stage.
 
   `exit_code` is what the runtime managed to say before it went (#608); the
   spawn-failure path has none, since there was never a process. `detail` is
@@ -1421,30 +1422,29 @@ defmodule Fountain.Conversations.TurnMachine do
   @spec fail_before_start(
           Conversations.Turn.t(),
           String.t(),
+          String.t() | nil,
           String.t(),
           String.t(),
           integer() | nil
         ) ::
           :ok
-  def fail_before_start(turn, conversation_id, what, detail, exit_code) do
-    {:ok, _} =
-      Conversations._unsafe_update_turn(turn, %{
-        status: "failed",
-        exit_code: exit_code,
-        ended_at: now()
-      })
+  def fail_before_start(turn, conversation_id, sandbox_id, what, detail, exit_code) do
+    # The server owns this turn and supplies its captured sandbox binding.
+    case Conversations._unsafe_complete_turn(turn, sandbox_id, "failed", exit_code: exit_code) do
+      {:ok, _} ->
+        publish_stage(conversation_id, "turn", "failed", %{
+          turn_id: turn.id,
+          reason: detail,
+          exit_code: exit_code
+        })
 
-    publish_stage(conversation_id, "turn", "failed", %{
-      turn_id: turn.id,
-      reason: detail,
-      exit_code: exit_code
-    })
-
-    # The conversation was set to "running" just before the spawn attempt;
-    # without this it stays "running" in the API and UI until some later turn
-    # completes, even though nothing is executing. The :exit and :interrupt
-    # handlers both do the same reset.
-    {:ok, _} = Conversations._unsafe_idle_after_turn(turn)
+      # The conversation was set to "running" just before the spawn attempt;
+      # `_unsafe_complete_turn/4` idles it in the same transaction as the
+      # turn's result. A refused write leaves both alone: the conversation
+      # belongs to whichever actor the parent now points at.
+      :noop ->
+        :ok
+    end
 
     # The turn never started; close the span we just opened so it doesn't leak.
     if exit_code, do: OpenTelemetry.Tracer.set_attribute("exit_code", exit_code)

--- a/apps/fountain/test/fountain/audit_guardrail_test.exs
+++ b/apps/fountain/test/fountain/audit_guardrail_test.exs
@@ -173,7 +173,7 @@ defmodule Fountain.AuditGuardrailTest do
   @deliberately_silent %{
     "Conversations._unsafe_finish_conversation_termination/2" =>
       "internal conditional status write; terminate_conversation/2 audits the successful action once",
-    "Conversations._unsafe_complete_turn/3" =>
+    "Conversations._unsafe_complete_turn/4" =>
       "conditional per-turn bookkeeping; the turn stage records completion outside its transaction",
     "Conversations._unsafe_interrupt_turn/2 and _unsafe_idle_interrupted_turn/1" =>
       "conditional interrupt bookkeeping; its turn stage and public lifecycle action carry the trail",

--- a/apps/fountain/test/fountain/conversations/conversation_server_platform_inference_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_platform_inference_test.exs
@@ -263,7 +263,7 @@ defmodule Fountain.Conversations.ConversationServerPlatformInferenceTest do
       other = insert_turn(conv, status: "running")
       {_m, []} = select_model(%{m | row: other}, platform_ctx())
 
-      TurnMachine.fail_before_start(other, conv.id, "spawn", "boom", 1)
+      TurnMachine.fail_before_start(other, conv.id, conv.sandbox_id, "spawn", "boom", 1)
 
       assert stored(other).status == "failed"
       assert stored(other).usage["inference"] == "platform"

--- a/apps/fountain/test/fountain/conversations/conversation_server_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_test.exs
@@ -949,6 +949,40 @@ defmodule Fountain.Conversations.ConversationServerTest do
       GenServer.stop(pid)
     end
 
+    test "a spawn failure after reassignment leaves the replacement binding running", %{
+      conv: conv
+    } do
+      stub_happy_sprite()
+      replacement = insert_sandbox(user_id: conv.user_id, status: "ready")
+
+      Mimic.stub(Managoat.Sandbox.Sprites, :spawn, fn _h, _cmd, _args, _opts ->
+        {:ok, _} =
+          Conversations.update_conversation(conv, %{sandbox_id: replacement.id, status: "running"})
+
+        {:error, :econnrefused}
+      end)
+
+      {pid, _ref, :alive} = start_server(conv, initial_prompt: "hello")
+      _ = :sys.get_state(pid)
+
+      assert [turn] = Conversations._unsafe_list_turns(conv.id)
+      assert turn.status == "running"
+      assert turn.ended_at == nil
+      assert turn.exit_code == nil
+      current = Conversations._unsafe_get_conversation!(conv.id)
+      assert current.sandbox_id == replacement.id
+      assert current.status == "running"
+
+      refute Repo.exists?(
+               from e in Fountain.Conversations.LogEvent,
+                 where:
+                   e.conversation_id == ^conv.id and e.stage == "turn" and e.state == "failed"
+             )
+
+      GenServer.stop(pid)
+      assert Repo.reload!(turn).status == "running"
+    end
+
     test "a runtime that exits before the prompt is written fails the turn (#603)", %{conv: conv} do
       # The real adapter write path against a real command process that stops
       # :normal on the write, which is what Sprites.Command does the moment the

--- a/apps/fountain/test/fountain/conversations/turn_completion_binding_isolation_test.exs
+++ b/apps/fountain/test/fountain/conversations/turn_completion_binding_isolation_test.exs
@@ -4,9 +4,9 @@ defmodule Fountain.Conversations.TurnCompletionBindingIsolationTest do
   alias Fountain.Conversations
   alias Fountain.Conversations.Conversation
 
-  for first <- [:reassignment, :completion] do
-    @tag first: first
-    test "#{first} serializes turn completion with reassignment", %{first: first} do
+  for first <- [:reassignment, :completion], outcome <- [:completion, :startup_failure] do
+    @tag first: first, outcome: outcome
+    test "#{first} serializes #{outcome} with reassignment", %{first: first, outcome: outcome} do
       Ecto.Adapters.SQL.Sandbox.unboxed_run(Repo, fn ->
         user = insert_verified_user()
         old = insert_sandbox(user_id: user.id, status: "ready")
@@ -28,7 +28,11 @@ defmodule Fountain.Conversations.TurnCompletionBindingIsolationTest do
 
         complete = fn ->
           # Internal actor completion; the fixture belongs to this test's tenant.
-          Conversations._unsafe_complete_turn(turn, old.id, "completed")
+          if outcome == :startup_failure do
+            Conversations._unsafe_complete_turn(turn, old.id, "failed", exit_code: 17)
+          else
+            Conversations._unsafe_complete_turn(turn, old.id, "completed")
+          end
         end
 
         reassign = fn ->
@@ -65,13 +69,18 @@ defmodule Fountain.Conversations.TurnCompletionBindingIsolationTest do
             if first == :completion do
               assert {:ok, _} = leading_result
               assert {:ok, _} = trailing_result
-              assert Repo.reload(turn).status == "completed"
+
+              assert Repo.reload(turn).status ==
+                       if(outcome == :startup_failure, do: "failed", else: "completed")
+
+              assert Repo.reload(turn).exit_code == if(outcome == :startup_failure, do: 17)
               assert Repo.reload(turn).ended_at
             else
               assert {:ok, :ok} = leading_result
               assert :noop = trailing_result
               assert Repo.reload(turn).status == "running"
               assert Repo.reload(turn).ended_at == nil
+              assert Repo.reload(turn).exit_code == nil
             end
 
             assert Repo.reload(conv).sandbox_id == replacement.id

--- a/apps/fountain/test/fountain/conversations/turn_machine_test.exs
+++ b/apps/fountain/test/fountain/conversations/turn_machine_test.exs
@@ -816,17 +816,94 @@ defmodule Fountain.Conversations.TurnMachineTest do
   end
 
   describe "a turn that never started" do
-    test "fail_before_start/5 fails the row with the detail, and idles a running conversation",
+    test "fail_before_start/6 fails the row with the detail, and idles a running conversation",
          %{conv: conv, row: row} do
       {:ok, _} = Conversations.update_conversation(conv, %{status: "running"})
       detail = TurnMachine.failure_detail(:command_exited, 1)
       assert detail == ":command_exited (runtime exited 1)"
 
-      assert :ok = TurnMachine.fail_before_start(row, conv.id, "prompt write failed", detail, 1)
+      assert :ok =
+               TurnMachine.fail_before_start(
+                 row,
+                 conv.id,
+                 conv.sandbox_id,
+                 "prompt write failed",
+                 detail,
+                 1
+               )
 
       assert %{status: "failed", exit_code: 1} = Fountain.Repo.get!(Conversations.Turn, row.id)
       assert [{"failed", %{"reason" => ^detail, "exit_code" => 1}}] = stages(conv.id, "turn")
       assert Conversations._unsafe_get_conversation!(conv.id).status == "idle"
+    end
+
+    test "startup failure materializes a reply and accepts a missing exit code", ctx do
+      insert_log_event(ctx.conv, turn_id: ctx.row.id, stream: "acp", data: @update_line)
+
+      assert :ok =
+               TurnMachine.fail_before_start(
+                 ctx.row,
+                 ctx.conv.id,
+                 ctx.conv.sandbox_id,
+                 "spawn",
+                 "boom",
+                 nil
+               )
+
+      assert %{status: "failed", exit_code: nil, reply_text: "hi", ended_at: %DateTime{}} =
+               Fountain.Repo.reload!(ctx.row)
+
+      assert Fountain.Repo.reload!(ctx.user).onboarding_completed_at
+      assert [{"failed", %{"exit_code" => nil}}] = stages(ctx.conv.id, "turn")
+    end
+
+    for stale <- [:reassigned, :terminated, :failed, :completed, :interrupted, :deleted] do
+      @tag stale: stale
+      test "a #{stale} startup failure preserves persisted state without a failure stage", ctx do
+        insert_log_event(ctx.conv, turn_id: ctx.row.id, stream: "acp", data: @update_line)
+
+        case ctx.stale do
+          :reassigned ->
+            replacement = insert_sandbox(user_id: ctx.user.id)
+
+            Conversations.update_conversation(ctx.conv, %{
+              sandbox_id: replacement.id,
+              status: "running"
+            })
+
+          terminal when terminal in [:terminated, :failed] ->
+            Conversations.update_conversation(ctx.conv, %{status: Atom.to_string(terminal)})
+
+          ended when ended in [:completed, :interrupted] ->
+            ctx.row
+            |> Ecto.Changeset.change(status: Atom.to_string(ended), exit_code: 0)
+            |> Fountain.Repo.update!()
+
+            Conversations.update_conversation(ctx.conv, %{status: "running"})
+            insert_turn(ctx.conv, status: "running")
+
+          :deleted ->
+            Fountain.Repo.delete!(ctx.conv)
+        end
+
+        persisted_turn = Fountain.Repo.get(Conversations.Turn, ctx.row.id)
+        persisted_conv = Fountain.Repo.get(Conversations.Conversation, ctx.conv.id)
+
+        assert :ok =
+                 TurnMachine.fail_before_start(
+                   ctx.row,
+                   ctx.conv.id,
+                   ctx.conv.sandbox_id,
+                   "spawn",
+                   "boom",
+                   1
+                 )
+
+        assert Fountain.Repo.get(Conversations.Turn, ctx.row.id) == persisted_turn
+        assert Fountain.Repo.get(Conversations.Conversation, ctx.conv.id) == persisted_conv
+        assert stages(ctx.conv.id, "turn") == []
+        refute Fountain.Repo.reload!(ctx.user).onboarding_completed_at
+      end
     end
 
     test "failure_detail/2 without an exit code is the inspected reason alone" do

--- a/apps/fountain/test/fountain/conversations/turn_parent_test.exs
+++ b/apps/fountain/test/fountain/conversations/turn_parent_test.exs
@@ -392,7 +392,17 @@ defmodule Fountain.Conversations.TurnParentTest do
   test "session preparation and a late pre-start failure cannot change a successor", c do
     {next, _} = successor(c)
     assert {:error, :execution_fenced} = TurnMachine.session_plan(c.turn, nil)
-    assert :ok = TurnMachine.fail_before_start(c.turn, c.conv.id, "spawn", "late failure", 1)
+
+    assert :ok =
+             TurnMachine.fail_before_start(
+               c.turn,
+               c.conv.id,
+               c.conv.sandbox_id,
+               "spawn",
+               "late failure",
+               1
+             )
+
     assert Repo.get!(Conversation, c.conv.id).status == "running"
     assert Repo.get!(Conversation, c.conv.id).runtime_session_id == "original-session"
     assert Repo.get!(Turn, next.id).status == "running"


### PR DESCRIPTION
A delayed spawn failure could overwrite an already-ended turn or idle a conversation after reassignment. Startup failure now supplies the actor's sandbox binding to the guarded completion transaction. The transaction writes the exit code, result and idle status together; stale failures preserve the database state and emit no failure stage. The local span still closes on either outcome.

Stack: based on #2001. Refs #1767. This unit covers startup-failure bookkeeping; command-exit handling and durable forced-teardown recovery remain separate follow-ups.

Validation:
- 169 focused tests and 59 server tests passed, including audit guardrails, reply activation and inference attribution.
- Regressions cover reassignment, terminal conversations, ended turns followed by a new turn, deletion, and reassignment inside the actual server spawn callback.
- Two added PostgreSQL tests verify both lock orderings with the failure exit code committed atomically.
- Replacing the handler with its parent implementation makes seven regressions fail (13 selected tests); the fixed handler is restored.
- Full `mix precommit` passed: Fountain 5,475 tests and 6 doctests, Buzz 144 tests, Support 33 tests; zero failures. Static analysis, Dialyzer, Sobelow and production release assembly passed.

Integration validation: this change and the command-exit follow-up merged cleanly into the unpublished verification branch containing #1948, #1974, #1975, #1977 and #1979. All 223 targeted lifecycle tests passed on that combined tree.
