### PR TITLE
fix: guard command exit by actor sandbox binding

### DIFF
--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -1715,37 +1715,36 @@ defmodule Fountain.Conversations.ConversationServer do
   defp handle_execution_info({:exit, %{ref: ref}, code}, %{current_command_ref: ref} = state) do
     turn = state.current_turn
 
-    {:ok, turn} =
-      Conversations._unsafe_update_turn(turn, %{
-        status: if(code == 0, do: "completed", else: "failed"),
-        exit_code: code,
-        ended_at: now()
-      })
-
-    Output.publish_stage(state.conversation_id, "turn", "done", %{
-      turn_id: turn.id,
-      turn_number: turn.turn_number,
-      exit_code: code
-    })
-
     # Finalize stream tracer: close any tool spans still open (abandoned calls).
     TurnMachine.finalize_tracer(state.stream_tracer)
 
-    # An ACP turn can also end here — the adapter exits, is interrupted, or its
-    # socket drops before it ever answers `session/prompt`. The peer has nothing
-    # left to drive and must not outlive the turn.
+    # An ACP adapter can exit before answering session/prompt. Attempt local
+    # peer cleanup before rechecking ownership: its callback may change the
+    # conversation while this actor waits for it to stop.
     stop_acp_peer(state)
 
-    # Close the OTel turn span we opened in kick_turn.
-    TurnMachine.end_span(
-      state.current_turn_span,
-      if(code == 0, do: :ok, else: :error),
-      %{"exit_code" => code}
-    )
+    status = if(code == 0, do: "completed", else: "failed")
 
-    emit_turn_completed(state, turn.status)
+    # Ownership: this actor supplies the sandbox binding captured at startup.
+    case Conversations._unsafe_complete_turn(turn, state.sandbox_id, status, exit_code: code) do
+      {:ok, ended} ->
+        Output.publish_stage(state.conversation_id, "turn", "done", %{
+          turn_id: ended.id,
+          turn_number: ended.turn_number,
+          exit_code: code
+        })
 
-    {:ok, _} = Conversations._unsafe_idle_after_turn(turn)
+        TurnMachine.end_span(
+          state.current_turn_span,
+          if(code == 0, do: :ok, else: :error),
+          %{"exit_code" => code}
+        )
+
+        emit_turn_completed(state, ended.status)
+
+      :noop ->
+        TurnMachine.end_span(state.current_turn_span, :error, %{"outcome" => "completion_ignored"})
+    end
 
     {:noreply,
      %{

--- a/apps/fountain/test/fountain/conversations/command_exit_binding_test.exs
+++ b/apps/fountain/test/fountain/conversations/command_exit_binding_test.exs
@@ -1,0 +1,176 @@
+defmodule Fountain.Conversations.CommandExitBindingTest do
+  use Fountain.DataCase, async: false
+
+  alias Fountain.Conversations
+  alias Fountain.Conversations.{ConversationServer, TurnMachine}
+
+  defmodule Peer do
+    use GenServer
+    def start_link(on_stop), do: GenServer.start_link(__MODULE__, on_stop)
+    def init(on_stop), do: {:ok, on_stop}
+    def terminate(:normal, on_stop), do: on_stop.()
+    def terminate(_reason, _on_stop), do: :ok
+  end
+
+  setup do
+    user = insert_verified_user()
+    conv = insert_conversation(user_id: user.id, status: "running")
+    turn = insert_turn(conv, status: "running")
+    owner = self()
+    handler = {__MODULE__, make_ref()}
+
+    :telemetry.attach(
+      handler,
+      [:fountain, :turn, :completed],
+      fn event, _, meta, _ ->
+        if meta.conv_id == conv.id, do: send(owner, {event, meta})
+      end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler) end)
+    %{user: user, conv: conv, turn: turn}
+  end
+
+  for code <- [0, 17] do
+    @tag code: code
+    test "exit #{code} stops the local peer before committing its result and metric", ctx do
+      owner = self()
+
+      state =
+        state(ctx, fn ->
+          refute Repo.in_transaction?()
+          send(owner, {:peer_stopped, Repo.reload!(ctx.turn).status})
+        end)
+
+      assert {:noreply, cleared} =
+               ConversationServer.handle_info(
+                 {:exit, %{ref: state.current_command_ref}, ctx.code},
+                 state
+               )
+
+      assert_received {:peer_stopped, "running"}
+      refute Process.alive?(state.acp_peer)
+      assert Repo.reload!(ctx.turn).status == if(ctx.code == 0, do: "completed", else: "failed")
+      assert Repo.reload!(ctx.turn).exit_code == ctx.code
+      assert Repo.reload!(ctx.turn).ended_at
+      assert Repo.reload!(ctx.conv).status == "idle"
+      assert [event] = stages(ctx)
+      assert event.state == "done"
+      assert Jason.decode!(event.data)["exit_code"] == ctx.code
+      expected_status = if(ctx.code == 0, do: "completed", else: "failed")
+      assert_receive {[:fountain, :turn, :completed], %{status: ^expected_status}}
+      assert_cleared(cleared)
+    end
+  end
+
+  for change <- [:reassigned, :completed, :terminated, :deleted], code <- [0, 17] do
+    @tag during_stop: change, code: code
+    test "exit #{code} with #{change} during peer shutdown preserves the persisted result", ctx do
+      replacement = insert_sandbox(user_id: ctx.user.id)
+
+      state =
+        state(ctx, fn ->
+          case ctx.during_stop do
+            :reassigned ->
+              Conversations.update_conversation(ctx.conv, %{sandbox_id: replacement.id})
+
+            :completed ->
+              ctx.turn
+              |> Ecto.Changeset.change(status: "completed", exit_code: 23)
+              |> Repo.update!()
+
+              insert_turn(ctx.conv, status: "running")
+
+            :terminated ->
+              Conversations.update_conversation(ctx.conv, %{status: "terminated"})
+
+            :deleted ->
+              Repo.delete!(ctx.conv)
+          end
+        end)
+
+      assert {:noreply, cleared} =
+               ConversationServer.handle_info(
+                 {:exit, %{ref: state.current_command_ref}, ctx.code},
+                 state
+               )
+
+      refute Process.alive?(state.acp_peer)
+      assert_cleared(cleared)
+
+      if ctx.during_stop in [:reassigned, :terminated] do
+        assert Repo.reload!(ctx.turn).exit_code == nil
+        assert Repo.reload!(ctx.turn).ended_at == nil
+      end
+
+      assert stages(ctx) == []
+      refute_receive {[:fountain, :turn, :completed], _}, 50
+
+      case ctx.during_stop do
+        :deleted ->
+          assert Repo.reload(ctx.conv) == nil
+          assert Repo.reload(ctx.turn) == nil
+
+        :terminated ->
+          assert Repo.reload!(ctx.conv).status == "terminated"
+          assert Repo.reload!(ctx.turn).status == "running"
+
+        :completed ->
+          assert Repo.reload!(ctx.conv).status == "running"
+          assert Repo.reload!(ctx.turn).status == "completed"
+          assert Repo.reload!(ctx.turn).exit_code == 23
+
+        :reassigned ->
+          assert Repo.reload!(ctx.conv).sandbox_id == replacement.id
+          assert Repo.reload!(ctx.conv).status == "running"
+          assert Repo.reload!(ctx.turn).status == "running"
+      end
+    end
+  end
+
+  defp state(ctx, on_stop) do
+    peer = start_supervised!(Supervisor.child_spec({Peer, on_stop}, restart: :temporary))
+    Ecto.Adapters.SQL.Sandbox.allow(Repo, self(), peer)
+
+    %{
+      conversation_id: ctx.conv.id,
+      sandbox_id: ctx.conv.sandbox_id,
+      current_turn: ctx.turn,
+      current_turn_span: nil,
+      turn_metrics:
+        TurnMachine.start_metrics("claude", :runner, System.monotonic_time(:millisecond)),
+      stream_tracer: nil,
+      turn_session_retry: nil,
+      replay_dedup: MapSet.new(),
+      autonomous_quiet: nil,
+      current_command: :closed_transport,
+      current_command_ref: make_ref(),
+      acp_peer: peer,
+      acp_peer_mon: Process.monitor(peer),
+      last_activity_at: DateTime.utc_now()
+    }
+  end
+
+  defp assert_cleared(state) do
+    for field <- [
+          :current_turn,
+          :current_turn_span,
+          :turn_metrics,
+          :stream_tracer,
+          :current_command,
+          :current_command_ref,
+          :acp_peer,
+          :acp_peer_mon
+        ] do
+      assert state[field] == nil
+    end
+  end
+
+  defp stages(ctx) do
+    Repo.all(
+      from e in Conversations.LogEvent,
+        where: e.conversation_id == ^ctx.conv.id and e.stage == "turn"
+    )
+  end
+end


### PR DESCRIPTION
An adapter's exit could overwrite a turn or idle its conversation after reassignment, termination or another actor's completion. The command-exit handler now commits through the existing guarded completion transaction, including its exit code.

The existing local peer-stop attempt runs before that transaction, so changes made during shutdown are rechecked. Applied exits retain their existing `turn/done` event, exit-code metadata and completion metric. Stale exits clear local state and close the span without changing the persisted result or publishing duplicate completion events. Peer shutdown retains its existing best-effort behavior.

Stack: based on #2002. Refs #1767. Machine-gone notifications and durable forced-teardown recovery remain separate follow-ups.

Validation:
- All 80 focused tests passed, including the real server lifecycle and turn metrics suites.
- Ten new tests use a real local GenServer peer and cover both zero/nonzero exit codes, with reassignment, another completion, termination or deletion during peer shutdown.
- All ten new tests fail against the parent handler and pass with this change.
- The first test run exposed a missing `autonomous_quiet` field in the new hand-built fixture. Adding the field required by `Connection.from_state/1` fixed that setup error; the failed log was retained.
- Both this change and #2002 merged cleanly into the unpublished verification branch containing #1948, #1974, #1975, #1977 and #1979. All 223 targeted lifecycle tests passed on the combined tree.
- Full `mix precommit` passed: Fountain 5,485 tests and 6 doctests, Buzz 144 tests, Support 33 tests; zero failures. Static analysis, Dialyzer, Sobelow and production release assembly passed.
