### PR TITLE
fix: scope machine-gone handling to the actor sandbox

### DIFF
--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -2363,11 +2363,16 @@ defmodule Fountain.Conversations do
   first half retired its last running turn. `AutonomousTurnReaper.sweep_stuck_turns/0`
   selects running turns, and `ExecutionGuard._unsafe_recover_turn/3` returns
   `:noop` for a retired turn, so those recovery paths cannot repair that state.
-  Other paths can idle the parent: `MachineEvents.gone/4` and the lifecycle's
+  Other paths can idle the parent: `MachineEvents.gone/5` and the lifecycle's
   park and reclaim paths do so when they run.
 
   `follow_cotenants/2` sends `:machine_gone` before rebinding with `update_all`,
-  so a server that receives the cast has `gone/4`'s cleanup as a backstop.
+  so a server that receives the cast has `gone/5`'s cleanup as a backstop.
+  `gone/5` ignores a notification naming another sandbox and
+  `_unsafe_finish_machine_gone/2` answers `:noop` for a moved conversation
+  (#2006), but its idle write is deliberately not conditioned on the binding,
+  so a parent left `running` with no running turn is still released. The
+  backstop this paragraph relies on therefore survives the rebind.
   `tell_cotenants/3` skips the cast when `ConversationServer.whereis/1` misses,
   including a cross-pod registry miss, while the rebind still applies. The
   parent can then remain `running` until another cleanup path runs.
@@ -2411,13 +2416,29 @@ defmodule Fountain.Conversations do
   end
 
   @doc """
-  Finish an actor's machine-gone notification on its current binding.
+  Finish an actor's machine-gone notification, and release a stranded parent.
 
-  Lock the parent through the running-turn check and optional idle write, as
-  admission does. A moved, terminal or deleted conversation, or a newer running
-  turn, makes this a no-op. Only a running conversation changes status;
-  already-idle actors can still record the sandbox event. Publication happens
-  after commit, and this function performs no provider or actor I/O.
+  Lock the parent through the running-turn check and any idle write, as
+  admission does. A deleted conversation or a newer running turn makes this a
+  no-op. `:ok` says the notification is this actor's to narrate: the binding
+  still names the sandbox it closed and the conversation is not terminal. A
+  moved or terminal conversation answers `:noop`, so an obsolete actor emits no
+  sandbox event. Publication happens after commit, and this function performs
+  no provider or actor I/O.
+
+  The idle write is not conditioned on the binding, and that is deliberate.
+  Under the parent lock a `running` conversation with no running turn is not a
+  legitimate transient: admission inserts the running turn and sets the parent
+  `running` in one transaction under this same lock (`_unsafe_create_turn_on_sandbox/3`),
+  and the two other writers of `running` (`Reattachment` and `Connection`) both
+  have their running turn in hand. So that pair is a stuck row, and the sweeps
+  cannot repair it — `AutonomousTurnReaper.sweep_stuck_turns/0` and
+  `ExecutionGuard._unsafe_recover_turn/3` both select a running turn, and there
+  is none. `_unsafe_idle_interrupted_turn/1` declines to recheck the binding for
+  exactly this reason and names this function as its backstop (#2000); a
+  refusal here would strand the parent with nothing left to release it.
+  Releasing it is a repair, not an act of the stale actor, so it still answers
+  `:noop` and publishes nothing.
   """
   def _unsafe_finish_machine_gone(conversation_id, sandbox_id) do
     {:ok, result} =
@@ -2429,12 +2450,21 @@ defmodule Fountain.Conversations do
           from(t in Turn, where: t.conversation_id == ^conversation_id and t.status == "running")
 
         with %Conversation{} = conv <- Repo.one(conversation_query),
-             true <- conv.sandbox_id == sandbox_id and conv.status not in ["terminated", "failed"],
              false <- Repo.exists?(running_query) do
-          if conv.status == "running" do
-            {:updated, conv |> Conversation.changeset(%{status: "idle"}) |> Repo.update!()}
-          else
-            :unchanged
+          # A terminal conversation is never `running`, so this decides the
+          # answer, never the write.
+          current? = conv.sandbox_id == sandbox_id and conv.status not in ["terminated", "failed"]
+
+          cond do
+            conv.status == "running" ->
+              idled = conv |> Conversation.changeset(%{status: "idle"}) |> Repo.update!()
+              if current?, do: {:updated, idled}, else: {:released, idled}
+
+            current? ->
+              :unchanged
+
+            true ->
+              :noop
           end
         else
           _ -> :noop
@@ -2445,6 +2475,10 @@ defmodule Fountain.Conversations do
       {:updated, conv} ->
         broadcast_sidebar_update(conv.user_id)
         :ok
+
+      {:released, conv} ->
+        broadcast_sidebar_update(conv.user_id)
+        :noop
 
       :unchanged ->
         :ok

--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -2411,6 +2411,50 @@ defmodule Fountain.Conversations do
   end
 
   @doc """
+  Finish an actor's machine-gone notification on its current binding.
+
+  Lock the parent through the running-turn check and optional idle write, as
+  admission does. A moved, terminal or deleted conversation, or a newer running
+  turn, makes this a no-op. Only a running conversation changes status;
+  already-idle actors can still record the sandbox event. Publication happens
+  after commit, and this function performs no provider or actor I/O.
+  """
+  def _unsafe_finish_machine_gone(conversation_id, sandbox_id) do
+    {:ok, result} =
+      Repo.transaction(fn ->
+        conversation_query =
+          from(c in Conversation, where: c.id == ^conversation_id, lock: "FOR UPDATE")
+
+        running_query =
+          from(t in Turn, where: t.conversation_id == ^conversation_id and t.status == "running")
+
+        with %Conversation{} = conv <- Repo.one(conversation_query),
+             true <- conv.sandbox_id == sandbox_id and conv.status not in ["terminated", "failed"],
+             false <- Repo.exists?(running_query) do
+          if conv.status == "running" do
+            {:updated, conv |> Conversation.changeset(%{status: "idle"}) |> Repo.update!()}
+          else
+            :unchanged
+          end
+        else
+          _ -> :noop
+        end
+      end)
+
+    case result do
+      {:updated, conv} ->
+        broadcast_sidebar_update(conv.user_id)
+        :ok
+
+      :unchanged ->
+        :ok
+
+      :noop ->
+        :noop
+    end
+  end
+
+  @doc """
   Reconciles a turn left `running` after its server or runtime disappeared.
 
   The turn transition and the conversation's `running` to `idle` transition

--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -1495,8 +1495,20 @@ defmodule Fountain.Conversations.ConversationServer do
     MachineEvents.reset(state, sandbox_id, reason, by, message, &drop_connection/2)
   end
 
-  def handle_cast({:machine_gone, event, reason, message}, state) do
-    MachineEvents.gone(state, {event, reason, message}, &interrupt_turn/1, &drop_connection/2)
+  # Compatibility for senders deployed before the sandbox-qualified message.
+  # Roll out this receiver before migrating senders; the old tuple cannot
+  # distinguish an obsolete sandbox notification from one for this actor.
+  def handle_cast({:machine_gone, event, reason, message}, state),
+    do: handle_cast({:machine_gone, state.sandbox_id, event, reason, message}, state)
+
+  def handle_cast({:machine_gone, sandbox_id, event, reason, message}, state) do
+    MachineEvents.gone(
+      state,
+      sandbox_id,
+      {event, reason, message},
+      &interrupt_turn/1,
+      &drop_connection/2
+    )
   end
 
   # Catch-all for the same reason as the handle_call one above (#315).

--- a/apps/fountain/lib/fountain/conversations/machine_events.ex
+++ b/apps/fountain/lib/fountain/conversations/machine_events.ex
@@ -56,23 +56,41 @@ defmodule Fountain.Conversations.MachineEvents do
 
   def reset(state, _sandbox_id, _reason, _by, _message, _drop), do: {:noreply, state}
 
+  # Handle a notification for this actor's sandbox; ignore another sandbox's.
   # The server supplies its connection/turn teardown callbacks. Keeping the
   # transcript handling here leaves the actor's mailbox clauses small.
-  def gone(state, {event, reason, message}, interrupt, drop) do
+  #
+  # Cleanup runs before the guarded context transition, outside its
+  # transaction. A moved or terminal conversation, or a newer running turn,
+  # keeps its state and emits no sandbox event. The obsolete actor still stops
+  # after cleanup, because its handle is already gone with the machine.
+  def gone(
+        %{sandbox_id: sandbox_id} = state,
+        sandbox_id,
+        {event, reason, message},
+        interrupt,
+        drop
+      )
+      when is_binary(sandbox_id) do
     state = if state.current_turn, do: interrupt.(state), else: state
     state = drop.(state, event)
 
-    # ownership: the calling ConversationServer established this holder at init.
-    conv = Conversations._unsafe_get_conversation!(state.conversation_id)
-    if conv.status == "running", do: Conversations.update_conversation(conv, %{status: "idle"})
+    # Ownership: the actor supplies the sandbox whose local handle it closed.
+    case Conversations._unsafe_finish_machine_gone(state.conversation_id, sandbox_id) do
+      :ok ->
+        Output.publish_stage(state.conversation_id, "sandbox", "done", %{
+          event: event,
+          reason: reason,
+          by: "another_conversation",
+          message: message
+        })
 
-    Output.publish_stage(state.conversation_id, "sandbox", "done", %{
-      event: event,
-      reason: reason,
-      by: "another_conversation",
-      message: message
-    })
+      :noop ->
+        :ok
+    end
 
     {:stop, :normal, %{state | handle: nil}}
   end
+
+  def gone(state, _sandbox_id, _notification, _interrupt, _drop), do: {:noreply, state}
 end

--- a/apps/fountain/lib/fountain/conversations/machine_events.ex
+++ b/apps/fountain/lib/fountain/conversations/machine_events.ex
@@ -62,8 +62,11 @@ defmodule Fountain.Conversations.MachineEvents do
   #
   # Cleanup runs before the guarded context transition, outside its
   # transaction. A moved or terminal conversation, or a newer running turn,
-  # keeps its state and emits no sandbox event. The obsolete actor still stops
-  # after cleanup, because its handle is already gone with the machine.
+  # emits no sandbox event. A moved one can still be released: this is the
+  # backstop `_unsafe_idle_interrupted_turn/1` names, so the write that idles a
+  # parent stranded `running` with no running turn survives the rebind, while
+  # the transcript event does not. The obsolete actor still stops after
+  # cleanup, because its handle is already gone with the machine.
   def gone(
         %{sandbox_id: sandbox_id} = state,
         sandbox_id,

--- a/apps/fountain/test/fountain/audit_guardrail_test.exs
+++ b/apps/fountain/test/fountain/audit_guardrail_test.exs
@@ -178,7 +178,8 @@ defmodule Fountain.AuditGuardrailTest do
     "Conversations._unsafe_interrupt_turn/2 and _unsafe_idle_interrupted_turn/1" =>
       "conditional interrupt bookkeeping; its turn stage and public lifecycle action carry the trail",
     "Conversations._unsafe_finish_machine_gone/2" =>
-      "conditional actor bookkeeping; its sandbox stage records the successful notification",
+      "conditional actor bookkeeping; the sandbox stage records a current notification, and " <>
+        "releasing a parent the rebind stranded repairs machine state rather than tenant state",
     "ConversationServer per-turn state" => "high-volume machine state; log_events covers it",
     "Accounts.touch_api_key/1" => "a last-used stamp on every authenticated request",
     "Runners.touch/1 and reconnects" =>

--- a/apps/fountain/test/fountain/audit_guardrail_test.exs
+++ b/apps/fountain/test/fountain/audit_guardrail_test.exs
@@ -177,6 +177,8 @@ defmodule Fountain.AuditGuardrailTest do
       "conditional per-turn bookkeeping; the turn stage records completion outside its transaction",
     "Conversations._unsafe_interrupt_turn/2 and _unsafe_idle_interrupted_turn/1" =>
       "conditional interrupt bookkeeping; its turn stage and public lifecycle action carry the trail",
+    "Conversations._unsafe_finish_machine_gone/2" =>
+      "conditional actor bookkeeping; its sandbox stage records the successful notification",
     "ConversationServer per-turn state" => "high-volume machine state; log_events covers it",
     "Accounts.touch_api_key/1" => "a last-used stamp on every authenticated request",
     "Runners.touch/1 and reconnects" =>

--- a/apps/fountain/test/fountain/conversations/conversation_server_shared_sandbox_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_shared_sandbox_test.exs
@@ -281,6 +281,29 @@ defmodule Fountain.Conversations.ConversationServerSharedSandboxTest do
       end
     end
 
+    # `follow_cotenants/2` casts before it rebinds, so this actor's own
+    # notification lands on a row that has already moved. The transcript event
+    # is suppressed, but the parent must still be released: it is `running`
+    # with no running turn, and no sweep selects that pair (#2000).
+    test "a notification for a conversation rebound behind it still releases the parent" do
+      %{b: b, sandbox: sandbox, user: user} = shared_machine("claude")
+      replacement = insert_sandbox(user_id: user.id, status: "ready")
+      stub_happy_sprite()
+      stub_turn_boundary()
+      {pid, ref} = start(b)
+      # A lost completion left the parent running with no running turn.
+      {:ok, _} = Conversations.update_conversation(b, %{status: "running"})
+      {:ok, _} = Conversations.update_conversation(b, %{sandbox_id: replacement.id})
+
+      GenServer.cast(pid, {:machine_gone, sandbox.id, "suspended", "idle", "rebound"})
+      assert :normal = assert_stopped(ref)
+
+      released = Repo.reload!(b)
+      assert released.status == "idle"
+      assert released.sandbox_id == replacement.id
+      refute Enum.any?(sandbox_stages(b.id), &(&1["message"] == "rebound"))
+    end
+
     test "an obsolete notification leaves the replacement actor and its turn alone" do
       %{b: b, user: user} = shared_machine("claude")
       old = insert_sandbox(user_id: user.id, status: "terminated")

--- a/apps/fountain/test/fountain/conversations/conversation_server_shared_sandbox_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_shared_sandbox_test.exs
@@ -253,6 +253,109 @@ defmodule Fountain.Conversations.ConversationServerSharedSandboxTest do
       assert user_id == b.user_id
     end
 
+    for active? <- [false, true] do
+      @tag active?: active?
+      test "a qualified notification stops its #{if active?, do: "active", else: "idle"} actor",
+           ctx do
+        %{b: b, sandbox: sandbox} = shared_machine("claude")
+        stub_happy_sprite()
+        stub_turn_boundary()
+        {pid, ref} = start(b)
+
+        if ctx.active? do
+          assert :ok = GenServer.call(pid, {:send_prompt, "hi", []})
+        else
+          # The actor has no turn, but a lost completion left its parent running.
+          {:ok, _} = Conversations.update_conversation(b, %{status: "running"})
+        end
+
+        GenServer.cast(pid, {:machine_gone, sandbox.id, "suspended", "idle", "parked"})
+        assert :normal = assert_stopped(ref)
+        assert Repo.reload!(b).status == "idle"
+
+        if ctx.active? do
+          assert [%{status: "interrupted"}] = Conversations._unsafe_list_turns(b.id)
+        end
+
+        assert Enum.any?(sandbox_stages(b.id), &(&1["event"] == "suspended"))
+      end
+    end
+
+    test "an obsolete notification leaves the replacement actor and its turn alone" do
+      %{b: b, user: user} = shared_machine("claude")
+      old = insert_sandbox(user_id: user.id, status: "terminated")
+      stub_happy_sprite()
+      stub_turn_boundary()
+      {pid, _ref} = start(b)
+      assert :ok = GenServer.call(pid, {:send_prompt, "hi", []})
+      state = :sys.get_state(pid)
+      [turn] = Conversations._unsafe_list_turns(b.id)
+      turn = Repo.reload!(turn)
+      events = sandbox_stages(b.id)
+      owner = self()
+
+      Mimic.stub(Managoat.Sandbox.Sprites, :close_stdin, fn _ ->
+        send(owner, :closed)
+        :ok
+      end)
+
+      Mimic.stub(Managoat.Sandbox.Sprites, :stop_command, fn _ ->
+        send(owner, :stopped)
+        :ok
+      end)
+
+      GenServer.cast(pid, {:machine_gone, old.id, "reset", "home_reset", "obsolete"})
+      assert :sys.get_state(pid) == state
+      assert Repo.reload!(turn) == turn
+      assert Repo.reload!(b).status == "running"
+      assert sandbox_stages(b.id) == events
+      refute_received :closed
+      refute_received :stopped
+    end
+
+    for change <- [:reassigned, :terminated, :failed, :new_turn, :deleted] do
+      @tag during_cleanup: change
+      test "#{change} during machine-gone cleanup preserves the committed state", ctx do
+        %{b: b, sandbox: sandbox, user: user} = shared_machine("claude")
+        replacement = insert_sandbox(user_id: user.id, status: "ready")
+        stub_happy_sprite()
+        stub_turn_boundary()
+        {pid, ref} = start(b)
+        assert :ok = GenServer.call(pid, {:send_prompt, "hi", []})
+        [turn] = Conversations._unsafe_list_turns(b.id)
+        owner = self()
+
+        Mimic.stub(Managoat.Sandbox.Sprites, :close_stdin, fn _ ->
+          refute Repo.in_transaction?()
+
+          case ctx.during_cleanup do
+            :reassigned ->
+              Conversations.update_conversation(b, %{sandbox_id: replacement.id})
+
+            terminal when terminal in [:terminated, :failed] ->
+              Conversations.update_conversation(b, %{status: Atom.to_string(terminal)})
+
+            :new_turn ->
+              turn |> Ecto.Changeset.change(status: "completed") |> Repo.update!()
+              insert_turn(b, status: "running")
+
+            :deleted ->
+              Repo.delete!(Repo.reload!(b))
+          end
+
+          send(owner, {:persisted, Repo.reload(b), Repo.reload(turn)})
+          :ok
+        end)
+
+        GenServer.cast(pid, {:machine_gone, sandbox.id, "suspended", "idle", "stale"})
+        assert :normal = assert_stopped(ref)
+        assert_received {:persisted, persisted_conv, persisted_turn}
+        assert Repo.reload(b) == persisted_conv
+        assert Repo.reload(turn) == persisted_turn
+        refute Enum.any?(sandbox_stages(b.id), &(&1["message"] == "stale"))
+      end
+    end
+
     test "a co-tenant told the machine is gone records it and stops" do
       %{b: b} = shared_machine("claude")
       stub_happy_sprite()

--- a/apps/fountain/test/fountain/conversations/interruption_admission_isolation_test.exs
+++ b/apps/fountain/test/fountain/conversations/interruption_admission_isolation_test.exs
@@ -3,9 +3,10 @@ defmodule Fountain.Conversations.InterruptionAdmissionIsolationTest do
 
   alias Fountain.Conversations
 
-  for capacity <- [1, :unbounded] do
-    @tag capacity: capacity
-    test "a newer #{inspect(capacity)} turn keeps the interrupted conversation running", ctx do
+  for capacity <- [1, :unbounded], ending <- [:interrupt, :machine_gone] do
+    @tag capacity: capacity, ending: ending
+    test "a newer #{inspect(capacity)} turn keeps the conversation running after #{ending}",
+         ctx do
       Ecto.Adapters.SQL.Sandbox.unboxed_run(Repo, fn ->
         user = insert_verified_user()
         sandbox = insert_sandbox(user_id: user.id, status: "ready")
@@ -39,7 +40,14 @@ defmodule Fountain.Conversations.InterruptionAdmissionIsolationTest do
           ending =
             independent(fn ->
               # Ownership: finish the interrupt after its peer has stopped.
-              Conversations._unsafe_idle_interrupted_turn(turn)
+              case ctx.ending do
+                # `_unsafe_idle_interrupted_turn/1` takes no sandbox_id: #2000
+                # moved that fence into the process, since the two interrupt
+                # halves are one synchronous body and a stale actor cannot
+                # reach the second.
+                :interrupt -> Conversations._unsafe_idle_interrupted_turn(turn)
+                :machine_gone -> Conversations._unsafe_finish_machine_gone(conv.id, sandbox.id)
+              end
             end)
 
           try do

--- a/apps/fountain/test/fountain/conversations/machine_gone_binding_test.exs
+++ b/apps/fountain/test/fountain/conversations/machine_gone_binding_test.exs
@@ -1,0 +1,106 @@
+defmodule Fountain.Conversations.MachineGoneBindingTest do
+  use Fountain.DataCase, async: true
+
+  alias Fountain.Conversations
+  alias Fountain.Conversations.Conversation
+
+  # Every `during machine-gone cleanup` case in
+  # `conversation_server_shared_sandbox_test.exs` sends a prompt first, so
+  # `end_running_turn/5`'s own binding guard leaves the turn `running` and the
+  # running-turn clause below short-circuits before the other two are read.
+  # These cases reach the transaction with no running turn, which is the only
+  # way the binding and terminal clauses decide anything.
+  setup do
+    user = insert_verified_user()
+    actor = insert_sandbox(user_id: user.id, status: "terminated")
+    conv = insert_conversation(user_id: user.id, sandbox: actor, status: "running")
+    %{user: user, actor: actor, conv: conv}
+  end
+
+  defp rebind(conv, sandbox) do
+    {1, _} =
+      Repo.update_all(from(c in Conversation, where: c.id == ^conv.id),
+        set: [sandbox_id: sandbox.id]
+      )
+  end
+
+  describe "_unsafe_finish_machine_gone/2" do
+    test "idles the actor's own conversation", ctx do
+      insert_turn(ctx.conv, status: "interrupted")
+
+      assert :ok = Conversations._unsafe_finish_machine_gone(ctx.conv.id, ctx.actor.id)
+      assert Repo.reload!(ctx.conv).status == "idle"
+    end
+
+    # The binding clause. Idle is the state that isolates it: a `running`
+    # parent with no running turn is released either way (see below), so it
+    # cannot tell a present actor from a stale one.
+    test "an idle conversation that moved on is not this actor's to narrate", ctx do
+      replacement = insert_sandbox(user_id: ctx.user.id, status: "ready")
+      {:ok, _} = Conversations.update_conversation(ctx.conv, %{status: "idle"})
+      rebind(ctx.conv, replacement)
+
+      assert :noop = Conversations._unsafe_finish_machine_gone(ctx.conv.id, ctx.actor.id)
+      assert Repo.reload!(ctx.conv).status == "idle"
+    end
+
+    # The terminal clause. A terminal conversation is never `running`, so
+    # nothing else in the body would refuse it.
+    for status <- ["terminated", "failed"] do
+      @tag status: status
+      test "a #{status} conversation on the same binding is not narrated", ctx do
+        {:ok, _} = Conversations.update_conversation(ctx.conv, %{status: ctx.status})
+
+        assert :noop = Conversations._unsafe_finish_machine_gone(ctx.conv.id, ctx.actor.id)
+        assert Repo.reload!(ctx.conv).status == ctx.status
+      end
+    end
+
+    # The running-turn clause, on the actor's own binding: a successor
+    # admitted while this notification was in the mailbox keeps the parent
+    # `running`.
+    test "a running turn keeps the conversation running", ctx do
+      insert_turn(ctx.conv, status: "running")
+
+      assert :noop = Conversations._unsafe_finish_machine_gone(ctx.conv.id, ctx.actor.id)
+      assert Repo.reload!(ctx.conv).status == "running"
+    end
+
+    # The invariant every other #1767 fence rests on: a refusal must leave the
+    # row recoverable. `follow_cotenants/2` casts `:machine_gone` and then
+    # rebinds, so this actor's finish routinely reads the new binding after
+    # `_unsafe_idle_interrupted_turn/1` — which takes no `sandbox_id` (#2000) —
+    # retired the last running turn. `AutonomousTurnReaper` selects running
+    # turns and there is none, so refusing the write here strands the row for
+    # good.
+    test "a conversation that moved on with no running turn is still released", ctx do
+      replacement = insert_sandbox(user_id: ctx.user.id, status: "ready")
+      insert_turn(ctx.conv, status: "interrupted")
+      rebind(ctx.conv, replacement)
+
+      assert :noop = Conversations._unsafe_finish_machine_gone(ctx.conv.id, ctx.actor.id)
+
+      released = Repo.reload!(ctx.conv)
+      assert released.status == "idle"
+      assert released.sandbox_id == replacement.id
+    end
+
+    # The release is a repair of a stuck pair, not a licence to idle a busy
+    # conversation the actor no longer owns.
+    test "a conversation that moved on and is busy again is left running", ctx do
+      replacement = insert_sandbox(user_id: ctx.user.id, status: "ready")
+      insert_turn(ctx.conv, status: "running")
+      rebind(ctx.conv, replacement)
+
+      assert :noop = Conversations._unsafe_finish_machine_gone(ctx.conv.id, ctx.actor.id)
+      assert Repo.reload!(ctx.conv).status == "running"
+    end
+
+    test "a deleted conversation is a no-op", ctx do
+      id = ctx.conv.id
+      Repo.delete!(ctx.conv)
+
+      assert :noop = Conversations._unsafe_finish_machine_gone(id, ctx.actor.id)
+    end
+  end
+end


### PR DESCRIPTION
A delayed machine-gone notification could stop an actor on a replacement sandbox. Cleanup could also idle a reassigned conversation or one with a newer running turn. The receiver now accepts a sandbox-qualified message and ignores notifications for another sandbox. After local cleanup, a guarded transaction rechecks the persisted binding, terminal status and running turns before idling the parent or publishing the sandbox event.

The old message remains supported for rollout compatibility. Deploy this receiver before migrating senders; legacy messages cannot distinguish an obsolete sandbox from the current actor's sandbox. The guard identifies the sandbox, not a new actor generation on the same sandbox.

Stack: based on #2003. Refs #1767. The sender migration is a separate draft. Durable forced-teardown recovery remains open follow-up work.

Validation:
- All 99 focused actor, audit and PostgreSQL tests passed.
- Real actor tests cover active and idle cleanup, ignoring another sandbox, and reassignment, terminal states, a new turn or deletion during cleanup.
- Two added PostgreSQL tests hold real admission open at capacity 1 and unbounded, proving cleanup waits and preserves the new running turn.
- Restoring the old cleanup body while retaining the new message routing produces five regression failures (15 selected tests).
- The initial test run caught a preloaded-versus-unloaded association comparison in a new assertion. Both snapshots now use the same database read; the failure log was retained.

The notification handler lives in `Lifecycle.machine_gone/4`; the server supplies its local cleanup callbacks. This keeps the combined lifecycle stack within the server-size guardrail and lowers the cap from 2,762 to 2,759 lines. An initial full run caught the oversized server and a separate 60-second documentation-rendering timeout in `Lumis.highlight/2`. The size issue was corrected; the documentation test passed with the actor and guardrail checks in a 129-test recheck. Original logs were retained, and final full validation runs sequentially.

Final integration validation: all 299 targeted tests passed on the combined lifecycle tree, including documentation and the server-size guardrail. The unpublished verification branch includes #1948, #1974, #1975, #1977 and #1979, with the reset-helper conflict resolved by keeping the shared helper and adding the sandbox ID to its notification.

Full `mix precommit` passed on the final commit: Fountain 5,495 tests and 6 doctests, Buzz 144 tests, Support 33 tests; zero failures. Static analysis, Dialyzer, Sobelow and production release assembly passed. The documentation timeout did not recur in this full run.
