### PR TITLE
A reset refused by a bounded execution answers 409, not a bare 422

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -221,6 +221,15 @@ upgrade, is in
 
 ### Fixed
 
+- **A reset refused by a bounded execution says so** (ADR 0046). Deleting a
+  sandbox while a bounded turn still owed a remote stop answered `422` with an
+  empty body, because `:execution_fenced` had no `FallbackController` clause
+  and fell through to the unmapped-atom net, logging a warning on every
+  refusal. It now answers `409 execution_fenced` with a message, beside the
+  two refusals it sits next to — and unlike `sandbox_mid_turn` (wait for the
+  turn) and `sandbox_reset_pending` (contact the operator), this one clears on
+  its own once the obligation ages out, which the message says.
+
 - **An account whose `connections` flag is off can revoke what it already
   holds** (#1693). The flag stood in front of every door, the ones that take a
   credential away included, while the runtime kept brokering those same tokens

--- a/apps/fountain/lib/fountain/conversations/turn.ex
+++ b/apps/fountain/lib/fountain/conversations/turn.ex
@@ -97,6 +97,12 @@ defmodule Fountain.Conversations.Turn do
   An `"accounting"`-only map (a runtime that reported its scope but no counts)
   is *not* a stamp: that is a real end-of-turn record, and a second one must
   still be refused.
+
+  An **empty** map is a stamp by this test, because every key it has is in the
+  set. That is a widening rather than a decision, and it is safe twice over:
+  `Managoat.ACP.Usage.normalize/1` returns `nil` or a map carrying both
+  counters, so no runtime produces one; and a row holding `%{}` debited
+  nothing, so accepting a later figure over it debits exactly once.
   """
   @spec inference_stamp_only?(map()) :: boolean()
   def inference_stamp_only?(%{} = usage), do: Map.keys(usage) -- @inference_stamp_keys == []

--- a/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
@@ -375,6 +375,27 @@ defmodule FountainWeb.FallbackController do
     })
   end
 
+  # A third reason a reset is refused, distinct from the two above (ADR 0046).
+  # `:sandbox_mid_turn` is a turn that is running and ends by itself;
+  # `:sandbox_reset_pending` is a delete this server asked for and never had
+  # confirmed; this is a bounded turn whose remote command was never confirmed
+  # stopped. Unlike the other two it clears on its own — the deadline
+  # coordinator writes an obligation nothing can resolve off after a cutoff —
+  # so the caller is told to wait rather than to fetch an operator.
+  #
+  # Without this clause the atom reached the unmapped-atom safety net: a 422
+  # carrying no message at all, plus a warning log on every refusal.
+  def call(conn, {:error, :execution_fenced}) do
+    conn
+    |> put_status(:conflict)
+    |> json(%{
+      error: "execution_fenced",
+      message:
+        "a bounded turn on this sandbox has remote work that was never confirmed " <>
+          "stopped; this clears on its own once the obligation ages out, then send again"
+    })
+  end
+
   # Sandbox files (ADR 0039). A read never wakes a parked sandbox: 409 with
   # the status, and the caller decides whether a prompt is worth the wake.
   def call(conn, {:error, {:sandbox_not_ready, status}}) do

--- a/apps/fountain/test/fountain_web/controllers/sandbox_reset_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/sandbox_reset_controller_test.exs
@@ -4,6 +4,7 @@ defmodule FountainWeb.SandboxResetControllerTest do
   use Mimic
 
   alias Fountain.Conversations
+  alias Fountain.Repo
 
   setup do
     user = insert_active_user()
@@ -63,6 +64,39 @@ defmodule FountainWeb.SandboxResetControllerTest do
   test "409 sandbox_mid_turn while a conversation on it runs a turn", ctx do
     insert_turn(ctx.conv, status: "running")
     assert %{"error" => "sandbox_mid_turn"} = ctx |> reset(ctx.home.id) |> json_response(409)
+    assert Conversations._unsafe_get_sandbox!(ctx.home.id).status == "ready"
+  end
+
+  test "409 execution_fenced while a bounded turn owes a remote stop", ctx do
+    # ADR 0046: the turn has ended locally, so `:sandbox_mid_turn` does not
+    # apply, but a session was named and its termination was never confirmed,
+    # so the journal still owes a remote stop. Before this had a
+    # FallbackController clause the atom fell through to the unmapped-atom net
+    # and the caller got a 422 carrying no message.
+    alias Fountain.Conversations.ExecutionGuard
+
+    turn = insert_turn(ctx.conv, status: "running")
+    connection_id = Ecto.UUID.generate()
+
+    {:ok, execution} =
+      ExecutionGuard._unsafe_register(
+        turn.id,
+        connection_id,
+        DateTime.add(DateTime.utc_now(), 60, :second)
+      )
+
+    # Without these two the journal stops on its own at the failed write —
+    # nothing was ever spawned, so nothing is owed and the reset succeeds.
+    {:ok, _} = ExecutionGuard._unsafe_claim_spawn(execution.id)
+    {:ok, _} = ExecutionGuard._unsafe_bind_identity(execution.id, connection_id, "sess-1")
+    {:ok, _} = Conversations._unsafe_update_turn(turn, %{status: "failed"})
+
+    assert Repo.get!(Fountain.Conversations.TurnExecution, execution.id).state == "ready"
+
+    assert %{"error" => "execution_fenced", "message" => message} =
+             ctx |> reset(ctx.home.id) |> json_response(409)
+
+    assert message =~ "never confirmed"
     assert Conversations._unsafe_get_sandbox!(ctx.home.id).status == "ready"
   end
 

--- a/decisions/0046-durable-turn-deadlines.md
+++ b/decisions/0046-durable-turn-deadlines.md
@@ -167,11 +167,36 @@ publish a control the server cannot honour, and an SDK version bump publishes
 on merge. That surface belongs in the PR that first enforces a control, which
 is also the PR that deletes this paragraph.
 
-`managoat_sandbox 0.3.0` supplies confirmed remote termination. Provider identity
-notifications await [Sprites #33](https://github.com/superfly/sprites-ex/pull/33),
-tracked through release and exact pinning in
+`managoat_sandbox 0.3.0` supplies confirmed remote termination.
+[Sprites #33](https://github.com/superfly/sprites-ex/pull/33) supplies provider
+identity notifications; it merged on 2026-09-08, so this is no longer an
+outstanding external dependency. Release and exact pinning are tracked in
 [Review Loop #109](https://github.com/managoat/review-loop/issues/109).
 Do not activate deadline claims using an unpublished or floating SDK dependency.
+
+### Activation is global, and that is what blocks turning this on
+
+The only lever that makes a turn bounded is `FOUNTAIN_EXECUTION_LIMITS`, a
+single host-wide ceiling, plus the per-account `users.execution_limits`. There
+is no per-provider scope for either. `_unsafe_register_bounded/3` rolls back
+`:provider_not_supported` for any sandbox whose provider is not `sprites`, and
+it does so **inside the admission transaction** — so the turn does not open at
+all. `bounded_lifecycle_test`'s "an unsupported provider cannot retain an
+admitted turn" is the statement of it: zero turns created.
+
+A deployment running E2B, Daytona or self-hosted runners alongside Sprites
+therefore cannot set the host ceiling without breaking turn admission for every
+conversation not on Sprites, and `config/runtime.exs` validates only the JSON
+shape, so nothing warns the operator. The per-account ceiling is usable only
+for an account that never touches another provider, and nothing checks that
+either.
+
+**Consequence: the feature cannot safely be activated on a mixed-provider
+deployment.** Per-provider activation granularity is tracked as follow-up under
+[#1864](https://github.com/managoat/fountain/issues/1864) and is not in scope
+for the PRs that build the journal. Until it exists, treat the host ceiling as
+unsettable in production and the per-account ceiling as Sprites-only. The PR
+that adds the granularity deletes this section.
 
 ## Validation scope
 


### PR DESCRIPTION
`:execution_fenced` reached API callers through the unmapped-atom safety net: a **422 with no body at all**, plus a warning log on every refusal. It is the third reason `reset_sandbox/2` refuses (ADR 0046), and it should read like the other two.

It now answers `409 execution_fenced` with a message, beside `sandbox_mid_turn` and `sandbox_reset_pending`. The message carries what separates it from both: a running turn ends by itself and a pending reset wants an operator, but an unconfirmed remote stop clears on its own once the deadline coordinator ages the obligation out — so the caller waits rather than fetching anyone.

Both defects are live on `main` today, after #1744 and #1745 landed. This does not touch the held #1746–#1752.

## The regression is the interesting part

It builds a journal that genuinely owes a stop: claim the spawn, bind an identity, then fail the turn, which lands the row on `ready`. Without those two steps `complete/3` takes the "no spawn was ever submitted" path straight to `stopped`, nothing is owed, and the reset succeeds — my first draft passed against the unfixed code. Reverting the clause turns the 409 back into a 422, which is what the test exists to catch.

## ADR 0046 corrections

- **Sprites #33 merged on 2026-09-08.** It was still written as an outstanding external dependency for provider identity notifications.
- **The activation blocker is now stated.** `FOUNTAIN_EXECUTION_LIMITS` is a single host-wide ceiling with no per-provider scope, and `_unsafe_register_bounded/3` rolls back `:provider_not_supported` *inside the admission transaction*. So setting it on a deployment that also runs E2B, Daytona or self-hosted runners stops those conversations opening a turn at all; `runtime.exs` validates only the JSON shape and nothing warns the operator. The per-account ceiling is usable only for an account that never touches another provider, unchecked. Per-provider granularity is follow-up under #1864 — until it lands, the host ceiling is unsettable in production and the per-account one is Sprites-only.

## Validation

- `sandbox_reset_controller_test`: 7 tests, 0 failures; the new one fails (422) with the clause reverted.
- Controllers + sandbox reset suites: 1,178 tests, 0 failures.
- `mix format --check-formatted` and `mix compile --warnings-as-errors` clean; `okf validate decisions` reports `valid: true`; the index needs no refresh (frontmatter unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9reKpmXUUJf4eUMULogie