### PR TITLE
fix: fence ChatGPT lifecycle writes by grant generation

### DIFF
--- a/apps/fountain/lib/fountain/platform_chatgpt.ex
+++ b/apps/fountain/lib/fountain/platform_chatgpt.ex
@@ -117,8 +117,10 @@ defmodule Fountain.PlatformChatGPT do
   # the row goes `expired`.
   defp expire_or_serve(row) do
     if lapsed?(row) do
-      _ = mark_expired(row)
-      {:error, :expired}
+      case mark_expired(row) do
+        :ok -> {:error, :expired}
+        :stale -> current_result(row)
+      end
     else
       decrypt(row.access_token_ciphertext)
     end
@@ -288,6 +290,11 @@ defmodule Fountain.PlatformChatGPT do
     end
   end
 
+  # `locked_platform_row/0` holds `FOR UPDATE` for the whole transaction, so
+  # the optimistic lock in `connect_changeset/2` cannot lose a race; it is
+  # there to advance `lock_version` on a reconnect, not to detect one. Two
+  # concurrent connects onto an empty table meet
+  # `platform_chatgpt_account_platform_row` instead and one is refused.
   defp store(attrs, method, actor_user_id) do
     result =
       Repo.transaction(fn ->
@@ -318,8 +325,6 @@ defmodule Fountain.PlatformChatGPT do
       {:error, _changeset} ->
         {:error, :invalid_grant}
     end
-  rescue
-    Ecto.StaleEntryError -> {:error, :stale_grant}
   end
 
   # ── refresh ──────────────────────────────────────────────────────────────
@@ -440,6 +445,7 @@ defmodule Fountain.PlatformChatGPT do
           "active" -> decrypt(current.access_token_ciphertext)
           "revoked" -> {:error, :revoked}
           "expired" -> {:error, :expired}
+          other -> {:error, {:unknown_status, other}}
         end
 
       %Account{} ->
@@ -506,6 +512,12 @@ defmodule Fountain.PlatformChatGPT do
     )
   end
 
+  # `:stale` is narrow here in a way it is not on the refresh path: nothing
+  # blocks between the read in `access_token/0` and this write, so only a
+  # reconnect landing inside those microseconds loses the fence. It is still
+  # routed through `current_result/1` rather than assumed away, because
+  # reporting `:expired` for a grant that is now active is the same class of
+  # wrong answer the fence exists to prevent.
   defp mark_expired(row) do
     {count, _} =
       current_query(row)
@@ -517,6 +529,10 @@ defmodule Fountain.PlatformChatGPT do
         event_type: "admin.platform_chatgpt.expired",
         metadata: %{"actor" => @system_actor, "kind" => row.kind, "account_id" => row.account_id}
       })
+
+      :ok
+    else
+      :stale
     end
   end
 

--- a/apps/fountain/lib/fountain/platform_chatgpt.ex
+++ b/apps/fountain/lib/fountain/platform_chatgpt.ex
@@ -265,13 +265,19 @@ defmodule Fountain.PlatformChatGPT do
   """
   @spec disconnect(keyword()) :: :ok
   def disconnect(opts \\ []) do
-    case platform_row() do
+    {:ok, deleted} =
+      Repo.transaction(fn ->
+        case locked_platform_row() do
+          nil -> nil
+          row -> Repo.delete!(row)
+        end
+      end)
+
+    case deleted do
       nil ->
         :ok
 
       %Account{} = row ->
-        Repo.delete!(row)
-
         Audit.record_admin(%{
           actor_user_id: Keyword.get(opts, :actor_user_id),
           event_type: "admin.platform_chatgpt.disconnected",
@@ -284,9 +290,14 @@ defmodule Fountain.PlatformChatGPT do
 
   defp store(attrs, method, actor_user_id) do
     result =
-      (platform_row() || %Account{})
-      |> Account.connect_changeset(attrs)
-      |> Repo.insert_or_update()
+      Repo.transaction(fn ->
+        case (locked_platform_row() || %Account{})
+             |> Account.connect_changeset(attrs)
+             |> Repo.insert_or_update() do
+          {:ok, account} -> account
+          {:error, changeset} -> Repo.rollback(changeset)
+        end
+      end)
 
     case result do
       {:ok, account} ->
@@ -307,6 +318,8 @@ defmodule Fountain.PlatformChatGPT do
       {:error, _changeset} ->
         {:error, :invalid_grant}
     end
+  rescue
+    Ecto.StaleEntryError -> {:error, :stale_grant}
   end
 
   # ── refresh ──────────────────────────────────────────────────────────────
@@ -341,9 +354,9 @@ defmodule Fountain.PlatformChatGPT do
   # by nothing else: one at a time on this node, no database lock and no
   # connection held across the HTTP round-trip. The row is re-read here
   # because a queued caller may find the refresh already done, and the
-  # write is a compare-and-swap on the refresh token this read started
-  # from, so a node that lost the race to another serves the winner's token
-  # rather than overwriting it.
+  # write checks the generation, version and active state this read started
+  # from. A losing refresher may serve a winner from the same generation,
+  # but cannot overwrite or serve a replacement account.
   def refresh_serialized(mode) do
     case platform_row() do
       nil ->
@@ -376,8 +389,10 @@ defmodule Fountain.PlatformChatGPT do
           swap_in(current, refresh_attrs(fresh), access)
 
         {:error, {:terminal, code}} ->
-          _ = mark_revoked(current, code)
-          {:error, :revoked}
+          case mark_revoked(current, code) do
+            :ok -> {:error, :revoked}
+            :stale -> current_result(current)
+          end
 
         {:error, reason} ->
           Logger.warning(
@@ -389,24 +404,46 @@ defmodule Fountain.PlatformChatGPT do
     end
   end
 
-  # Written only over the refresh token the read started from. Zero rows
-  # means another node rotated first: its tokens are the live ones, and the
-  # chain this node minted is simply never used.
+  # Refresh and terminal writes share a fence. A reconnect may reuse the
+  # same refresh token, and a refresh need not rotate it, so ciphertext alone
+  # is not a lifecycle version. Never serve a replacement generation here:
+  # the caller may already have pinned the old provider account metadata.
   defp swap_in(current, attrs, access) do
     sets = attrs |> Map.put(:updated_at, now()) |> Enum.to_list()
 
     {n, _} =
-      from(a in Account,
-        where:
-          a.id == ^current.id and a.refresh_token_ciphertext == ^current.refresh_token_ciphertext
-      )
-      |> Repo.update_all(set: sets)
+      current_query(current)
+      |> Repo.update_all(set: sets, inc: [lock_version: 1])
 
-    case {n, platform_row()} do
-      {1, _} -> {:ok, access}
-      {0, %Account{status: "active"} = winner} -> decrypt(winner.access_token_ciphertext)
-      {0, %Account{status: status}} -> {:error, String.to_existing_atom(status)}
-      {0, nil} -> {:error, :not_connected}
+    case n do
+      1 -> {:ok, access}
+      0 -> current_result(current)
+    end
+  end
+
+  defp current_query(row) do
+    from(a in Account,
+      where:
+        is_nil(a.user_id) and a.id == ^row.id and a.generation == ^row.generation and
+          a.lock_version == ^row.lock_version and a.status == "active"
+    )
+  end
+
+  defp current_result(previous) do
+    case platform_row() do
+      nil ->
+        {:error, :not_connected}
+
+      %Account{id: id, generation: generation} = current
+      when id == previous.id and generation == previous.generation ->
+        case current.status do
+          "active" -> decrypt(current.access_token_ciphertext)
+          "revoked" -> {:error, :revoked}
+          "expired" -> {:error, :expired}
+        end
+
+      %Account{} ->
+        {:error, :stale_grant}
     end
   end
 
@@ -441,8 +478,22 @@ defmodule Fountain.PlatformChatGPT do
   end
 
   defp mark_revoked(row, code) do
-    result = row |> Account.revoke_changeset(code) |> Repo.update()
+    {count, _} =
+      current_query(row)
+      |> Repo.update_all(
+        set: [status: "revoked", revoked_reason: code, updated_at: now()],
+        inc: [lock_version: 1]
+      )
 
+    if count == 1 do
+      record_revocation(row, code)
+      :ok
+    else
+      :stale
+    end
+  end
+
+  defp record_revocation(row, code) do
     Audit.record_admin(%{
       actor_user_id: nil,
       event_type: "admin.platform_chatgpt.revoked",
@@ -453,23 +504,27 @@ defmodule Fountain.PlatformChatGPT do
       "platform chatgpt: the auth server refused the refresh token (#{code}); " <>
         "codex conversations fall back to PLATFORM_OPENAI_API_KEY. Reconnect at /admin/inference."
     )
-
-    result
   end
 
   defp mark_expired(row) do
-    result = row |> Account.expire_changeset() |> Repo.update()
+    {count, _} =
+      current_query(row)
+      |> Repo.update_all(set: [status: "expired", updated_at: now()], inc: [lock_version: 1])
 
-    Audit.record_admin(%{
-      actor_user_id: nil,
-      event_type: "admin.platform_chatgpt.expired",
-      metadata: %{"actor" => @system_actor, "kind" => row.kind, "account_id" => row.account_id}
-    })
-
-    result
+    if count == 1 do
+      Audit.record_admin(%{
+        actor_user_id: nil,
+        event_type: "admin.platform_chatgpt.expired",
+        metadata: %{"actor" => @system_actor, "kind" => row.kind, "account_id" => row.account_id}
+      })
+    end
   end
 
   # ── helpers ──────────────────────────────────────────────────────────────
+
+  defp locked_platform_row do
+    Repo.one(from(a in Account, where: is_nil(a.user_id), lock: "FOR UPDATE"))
+  end
 
   defp platform_row(preload \\ []) do
     from(a in Account, where: is_nil(a.user_id))

--- a/apps/fountain/lib/fountain/platform_chatgpt/account.ex
+++ b/apps/fountain/lib/fountain/platform_chatgpt/account.ex
@@ -11,6 +11,10 @@ defmodule Fountain.PlatformChatGPT.Account do
   `"workspace_token"` is a static Business/Enterprise access token with no
   refresh token, which lapses on its admin-set expiry.
 
+  Reconnect changes `generation`. Normal refresh retains the generation and
+  increments `lock_version`, as do terminal lifecycle writes. These fields
+  fence stale writes; broker authorization is not yet generation-aware.
+
   There is no plaintext column and no `_unsafe_` reader: the deployment owns
   this, not a tenant, and the only writers are the admin surface and the
   refresher.
@@ -28,6 +32,8 @@ defmodule Fountain.PlatformChatGPT.Account do
   @type t :: %__MODULE__{}
   schema "platform_chatgpt_account" do
     field :user_id, :binary_id
+    field :generation, Ecto.UUID, autogenerate: true
+    field :lock_version, :integer, default: 1
     field :kind, :string
     field :refresh_token_ciphertext, :binary
     field :access_token_ciphertext, :binary
@@ -65,6 +71,8 @@ defmodule Fountain.PlatformChatGPT.Account do
     ])
     |> put_change(:status, "active")
     |> put_change(:revoked_reason, nil)
+    |> put_change(:generation, Ecto.UUID.generate())
+    |> version_existing()
     |> validate_required([:kind, :access_token_ciphertext, :last_refreshed_at])
     |> validate_inclusion(:kind, @kinds)
     |> unique_constraint(:user_id, name: :platform_chatgpt_account_platform_row)
@@ -99,4 +107,9 @@ defmodule Fountain.PlatformChatGPT.Account do
     |> change(status: "expired")
     |> validate_inclusion(:status, @statuses)
   end
+
+  defp version_existing(%{data: %{__meta__: %{state: :loaded}}} = changeset),
+    do: optimistic_lock(changeset, :lock_version)
+
+  defp version_existing(changeset), do: changeset
 end

--- a/apps/fountain/lib/fountain/platform_chatgpt/account.ex
+++ b/apps/fountain/lib/fountain/platform_chatgpt/account.ex
@@ -15,6 +15,13 @@ defmodule Fountain.PlatformChatGPT.Account do
   increments `lock_version`, as do terminal lifecycle writes. These fields
   fence stale writes; broker authorization is not yet generation-aware.
 
+  `connect_changeset/2` is the only changeset here, because it is the only
+  write that starts a new lifecycle. Refresh, revocation and expiry are
+  fenced `update_all` statements in `Fountain.PlatformChatGPT`, conditioned
+  on the generation and version the caller read. A changeset for one of them
+  would write on the primary key alone and so would skip the fence, which is
+  why the three that used to exist were removed rather than left unused.
+
   There is no plaintext column and no `_unsafe_` reader: the deployment owns
   this, not a tenant, and the only writers are the admin surface and the
   refresher.
@@ -76,36 +83,6 @@ defmodule Fountain.PlatformChatGPT.Account do
     |> validate_required([:kind, :access_token_ciphertext, :last_refreshed_at])
     |> validate_inclusion(:kind, @kinds)
     |> unique_constraint(:user_id, name: :platform_chatgpt_account_platform_row)
-  end
-
-  @doc "A refresh rotated the tokens; the claims are updated when the response carried an id_token."
-  def refresh_changeset(account, attrs) do
-    account
-    |> cast(attrs, [
-      :refresh_token_ciphertext,
-      :access_token_ciphertext,
-      :id_claims,
-      :account_id,
-      :account_email,
-      :plan_type,
-      :access_expires_at,
-      :last_refreshed_at
-    ])
-    |> validate_required([:access_token_ciphertext, :last_refreshed_at])
-  end
-
-  @doc "The auth server refused the refresh token; the reason is its error code."
-  def revoke_changeset(account, reason) when is_binary(reason) do
-    account
-    |> change(status: "revoked", revoked_reason: reason)
-    |> validate_inclusion(:status, @statuses)
-  end
-
-  @doc "A token with no refresh token lapsed."
-  def expire_changeset(account) do
-    account
-    |> change(status: "expired")
-    |> validate_inclusion(:status, @statuses)
   end
 
   defp version_existing(%{data: %{__meta__: %{state: :loaded}}} = changeset),

--- a/apps/fountain/lib/fountain/platform_chatgpt/refresher.ex
+++ b/apps/fountain/lib/fountain/platform_chatgpt/refresher.ex
@@ -11,11 +11,11 @@ defmodule Fountain.PlatformChatGPT.Refresher do
   waiters queue here instead, holding nothing: the first call refreshes,
   the rest find the row fresh when their turn comes.
 
-  Across nodes the row is the arbiter: `Fountain.PlatformChatGPT` writes the
-  rotated tokens with a compare-and-swap on the refresh token it started
-  from, and a node that loses the race serves what the winner wrote. The
-  auth server tolerates the loser's abandoned chain (measured 2026-09-08: a
-  reused refresh token forks rather than revokes).
+  Across nodes, generation/version checks prevent stale success and failure
+  writes. A loser can serve a winner from the same grant generation; it
+  cannot serve or revoke a replacement account. This still permits duplicate
+  upstream calls: deployment-wide refresh coordination is follow-up work
+  under ADR 0052, not a guarantee of this local queue.
   """
 
   use GenServer

--- a/apps/fountain/priv/repo/migrations/20260912020000_version_chatgpt_grants.exs
+++ b/apps/fountain/priv/repo/migrations/20260912020000_version_chatgpt_grants.exs
@@ -1,0 +1,33 @@
+defmodule Fountain.Repo.Migrations.VersionChatgptGrants do
+  use Ecto.Migration
+
+  def up do
+    # No released writer creates tenant grants yet. Their encryption cannot
+    # safely be inferred from an owner column added for future use.
+    execute("""
+    DO $$ BEGIN
+      IF EXISTS (SELECT 1 FROM platform_chatgpt_account WHERE user_id IS NOT NULL) THEN
+        RAISE EXCEPTION 'Unexpected tenant ChatGPT grants: inspect ownership and encryption before migrating';
+      END IF;
+    END $$;
+    """)
+
+    alter table(:platform_chatgpt_account) do
+      add :generation, :uuid, null: false, default: fragment("gen_random_uuid()")
+      add :lock_version, :bigint, null: false, default: 1
+    end
+
+    create constraint(:platform_chatgpt_account, :chatgpt_grant_positive_version,
+             check: "lock_version > 0"
+           )
+  end
+
+  def down do
+    drop constraint(:platform_chatgpt_account, :chatgpt_grant_positive_version)
+
+    alter table(:platform_chatgpt_account) do
+      remove :lock_version
+      remove :generation
+    end
+  end
+end

--- a/apps/fountain/test/fountain/platform_chatgpt_lifecycle_test.exs
+++ b/apps/fountain/test/fountain/platform_chatgpt_lifecycle_test.exs
@@ -1,0 +1,135 @@
+defmodule Fountain.PlatformChatGPTLifecycleTest do
+  # The refresher and shared Req stub are global processes.
+  use Fountain.DataCase, async: false
+
+  import Fountain.ChatGPTFixtures
+
+  alias Fountain.Audit.AdminEvent
+  alias Fountain.Crypto
+  alias Fountain.PlatformChatGPT
+  alias Fountain.PlatformChatGPT.Account
+
+  test "reconnect changes generation; refresh changes only the write version" do
+    first = connect!(%{access_token: access_token(60)})
+    assert first.lock_version == 1
+    assert {:ok, _} = Ecto.UUID.cast(first.generation)
+    stub_refresh()
+
+    assert {:ok, _} = PlatformChatGPT.access_token()
+    refreshed = Repo.get!(Account, first.id)
+    assert refreshed.generation == first.generation
+    assert refreshed.lock_version == first.lock_version + 1
+
+    replacement = connect!()
+    assert replacement.id == first.id
+    refute replacement.generation == first.generation
+    assert replacement.lock_version == refreshed.lock_version + 1
+  end
+
+  test "late terminal refusal cannot revoke a reconnected grant or emit a revocation event" do
+    first = connect!(%{access_token: access_token(60)})
+
+    stub_auth(%{
+      "/oauth/token" => fn _ ->
+        connect!(%{account_id: "replacement", refresh_token: "rt_original"})
+        {400, %{"error" => "invalid_grant"}}
+      end
+    })
+
+    assert {:error, :stale_grant} = PlatformChatGPT.access_token()
+    replacement = Repo.get!(Account, first.id)
+    assert replacement.status == "active"
+    assert replacement.account_id == "replacement"
+    assert replacement.revoked_reason == nil
+    assert revoked_events() == []
+  end
+
+  test "late refresh success cannot serve or overwrite a different account generation" do
+    first = connect!(%{access_token: access_token(60)})
+    replacement_token = access_token(7_200, %{"replacement" => true})
+
+    stub_auth(%{
+      "/oauth/token" => fn _ ->
+        connect!(%{access_token: replacement_token, account_id: "replacement"})
+        {200, %{"access_token" => access_token(7_200), "refresh_token" => "late_rotation"}}
+      end
+    })
+
+    assert {:error, :stale_grant} = PlatformChatGPT.access_token()
+    current = Repo.get!(Account, first.id)
+    assert {:ok, ^replacement_token} = Crypto.decrypt_platform(current.access_token_ciphertext)
+    assert current.account_id == "replacement"
+    assert {:ok, "rt_original"} = Crypto.decrypt_platform(current.refresh_token_ciphertext)
+  end
+
+  for response <- [:success, :terminal] do
+    test "disconnect fences an in-flight #{response} response" do
+      first = connect!(%{access_token: access_token(60)})
+
+      stub_auth(%{
+        "/oauth/token" => fn _ ->
+          assert :ok = PlatformChatGPT.disconnect()
+
+          case unquote(response) do
+            :success -> {200, %{"access_token" => access_token(), "refresh_token" => "late"}}
+            :terminal -> {400, %{"error" => "invalid_grant"}}
+          end
+        end
+      })
+
+      assert {:error, :not_connected} = PlatformChatGPT.access_token()
+      refute Repo.get(Account, first.id)
+      assert revoked_events() == []
+      replacement = connect!()
+      refute replacement.id == first.id
+      refute replacement.generation == first.generation
+    end
+  end
+
+  test "terminal failure advances the write version without replacing the generation" do
+    first = connect!(%{access_token: access_token(60)})
+    stub_refusal()
+    assert {:error, :revoked} = PlatformChatGPT.access_token()
+    current = Repo.get!(Account, first.id)
+    assert current.generation == first.generation
+    assert current.lock_version == first.lock_version + 1
+  end
+
+  for response <- [:success, :terminal] do
+    test "a stale #{response} cannot undo a refresh that kept the same refresh token" do
+      first = connect!(%{access_token: access_token(60)})
+      winner = access_token(7_200, %{"winner" => true})
+      counter = start_supervised!({Agent, fn -> 0 end})
+
+      stub_auth(%{
+        "/oauth/token" => fn _ ->
+          case Agent.get_and_update(counter, &{&1, &1 + 1}) do
+            0 ->
+              assert {:ok, ^winner} = PlatformChatGPT.refresh_serialized(:force)
+
+              case unquote(response) do
+                :success -> {200, %{"access_token" => access_token(7_200, %{"late" => true})}}
+                :terminal -> {400, %{"error" => "invalid_grant"}}
+              end
+
+            1 ->
+              {200, %{"access_token" => winner}}
+          end
+        end
+      })
+
+      assert {:ok, ^winner} = PlatformChatGPT.access_token()
+      current = Repo.get!(Account, first.id)
+      assert current.status == "active"
+      assert current.generation == first.generation
+      assert current.lock_version == first.lock_version + 1
+      assert current.refresh_token_ciphertext == first.refresh_token_ciphertext
+      assert {:ok, ^winner} = Crypto.decrypt_platform(current.access_token_ciphertext)
+      assert revoked_events() == []
+    end
+  end
+
+  defp revoked_events do
+    Repo.all(from(e in AdminEvent, where: e.event_type == "admin.platform_chatgpt.revoked"))
+  end
+end

--- a/apps/fountain/test/fountain/platform_chatgpt_lifecycle_test.exs
+++ b/apps/fountain/test/fountain/platform_chatgpt_lifecycle_test.exs
@@ -129,6 +129,24 @@ defmodule Fountain.PlatformChatGPTLifecycleTest do
     end
   end
 
+  test "expiry advances the write version without replacing the generation" do
+    {:ok, first} =
+      PlatformChatGPT.connect_workspace_token("wst_static", nil, account_id: "acct_ws")
+
+    Repo.get!(Account, first.id)
+    |> Ecto.Changeset.change(access_expires_at: seconds_from_now(-60))
+    |> Repo.update!()
+
+    assert {:error, :expired} = PlatformChatGPT.access_token()
+    current = Repo.get!(Account, first.id)
+    assert current.status == "expired"
+    assert current.generation == first.generation
+    assert current.lock_version == first.lock_version + 1
+  end
+
+  defp seconds_from_now(n),
+    do: DateTime.utc_now() |> DateTime.add(n, :second) |> DateTime.truncate(:second)
+
   defp revoked_events do
     Repo.all(from(e in AdminEvent, where: e.event_type == "admin.platform_chatgpt.revoked"))
   end


### PR DESCRIPTION
A refresh response can arrive after an admin reconnects or disconnects the ChatGPT account. The old terminal-error path could revoke a replacement, and a refresh that did not rotate its refresh token could be overwritten by an older response. Fence refresh success, revocation, and expiry writes with grant ID, generation, version, and active state. Reconnect changes generation; normal refresh advances only the write version. A stale caller cannot receive a replacement account's bearer.

Reconnect and disconnect serialize their existing-row mutations in short transactions. The additive migration backfills generation/version for the platform account and refuses unexpected tenant rows so their encryption cannot be silently reinterpreted.

First foundation slice for ADR 0052 (#2010). Deployment-wide refresh coordination, broker issuance/request revocation, and user linking remain follow-up work; this PR does not claim those guarantees.

Validation:
- 53 focused lifecycle, platform-account, admin LiveView, and Codex sandbox tests passed.
- Migration smoke check passed: platform ciphertext preservation, defaults, rollback, unexpected tenant-row rejection, and successful migration after correction.
- Full `mix precommit` passed: compile, formatting, Credo, Dialyzer, Sobelow, release assembly, 5,457 core tests plus 6 doctests, 144 Buzz tests, and 33 Support tests; zero failures (2 core tests skipped, 7 excluded).

## Behaviour change worth naming

`access_token/0` can now answer `{:error, :stale_grant}`: a reconnect that lands while a refresh is in flight no longer serves the replacement account's bearer, because the caller may already have pinned the old account's metadata. Both callers degrade safely -- `InferenceCredentials.platform_credential/4` maps it to `:none` and falls through to `PLATFORM_OPENAI_API_KEY`, and `Egress.refresh_platform_chatgpt/2` keeps the token it holds -- so nothing crashes, but that conversation runs on the platform key rather than the subscription. That is ADR 0047 decision 6's "at the next conversation, not within a turn", and it is deliberate: the `Refresher` moduledoc's old promise that "a node that loses the race serves what the winner wrote" no longer holds, and the moduledoc now says so.

## Review follow-ups (316bdebc)

- Removed `Account.revoke_changeset/2`, `expire_changeset/1` and `refresh_changeset/2`. The first two lost their callers when the terminal writes moved onto fenced `update_all`; the third had none before. Each writes on the primary key alone, so leaving them left the most discoverable writers in the module unfenced.
- `mark_expired/1` now reports `:ok | :stale` like `mark_revoked/2`, and `expire_or_serve/1` routes a lost fence through `current_result/1` rather than reporting `:expired` for a grant a reconnect just made active.
- Dropped the `rescue Ecto.StaleEntryError` in `store/3`: `locked_platform_row/0` holds `FOR UPDATE` for the whole transaction, so the optimistic lock cannot lose and the rescue could not fire.
- `current_result/1` no longer raises on a status outside the three literals; the column has no CHECK constraint.
- New test: expiry advances `lock_version` without replacing the generation.

**Correction to the line above, from the second review.** I originally wrote that this test "fails when `mark_expired/1` writes on the primary key alone". That is wrong, and I have re-run it to confirm: my revert-check dropped the fence *and* `inc: [lock_version: 1]` together, so the test failed on the missing version bump. A primary-key-only `update_all` that still increments leaves 9 tests, 0 failures. The test proves the expiry write is versioned, not that it is fenced.

What is actually covered: reverting `current_query/1` itself fails 4 of the 9 lifecycle tests, so the fence predicate is well guarded. What is not covered is `mark_expired/1`'s *use* of it, and the new `:stale -> current_result(row)` branch, which no test reaches -- there is no I/O boundary in that window to hook, unlike the refresh path. Recorded rather than papered over.

