### PR TITLE
fix: coordinate ChatGPT refresh across nodes

### DIFF
--- a/apps/fountain/lib/fountain/chatgpt_accounts.ex
+++ b/apps/fountain/lib/fountain/chatgpt_accounts.ex
@@ -56,6 +56,10 @@ defmodule Fountain.ChatGPTAccounts do
   a turn that outlives its access token fails at the proxy, because codex
   cannot refresh in this mode. The default is fifteen minutes.
 
+  Platform refresh is coordinated across nodes with a per-grant PostgreSQL
+  try-lock. Only the holder retains a database checkout across the provider
+  request; contenders release theirs between bounded retries.
+
   ## User grants
 
   `status_for_user/1` and `credential_for_user/3` read a tenant's own grant.
@@ -71,7 +75,7 @@ defmodule Fountain.ChatGPTAccounts do
   require Logger
 
   alias Fountain.Audit
-  alias Fountain.ChatGPTAccounts.{Cipher, Grant}
+  alias Fountain.ChatGPTAccounts.{Cipher, Grant, RefreshLock}
   alias Fountain.PlatformChatGPT.{Account, OAuth, Refresher, Tokens}
   alias Fountain.Repo
 
@@ -461,14 +465,48 @@ defmodule Fountain.ChatGPTAccounts do
   end
 
   @doc false
-  # The body of a refresh, run by `Fountain.PlatformChatGPT.Refresher` and
-  # by nothing else: one at a time on this node, no database lock and no
-  # connection held across the HTTP round-trip. The row is re-read here
-  # because a queued caller may find the refresh already done, and the
-  # write checks the generation, version and active state this read started
-  # from. A losing refresher may serve a winner from the same generation,
-  # but cannot overwrite or serve a replacement account.
+  # The local queue bounds platform holders to one per node. The database
+  # try-lock excludes other nodes without parking waiters on pool connections.
+  # Observe identity before waiting, then re-read under the lock: even forced
+  # refresh contenders serve a winner instead of exchanging its rotated token.
   def platform_refresh_serialized(mode) do
+    case platform_row() do
+      %Account{status: "active", refresh_token_ciphertext: cipher} = observed
+      when is_binary(cipher) ->
+        observed.id
+        |> RefreshLock.run(fn -> refresh_locked(observed, mode) end)
+        |> finish_refresh()
+
+      _ ->
+        refresh_without_exchange()
+    end
+  end
+
+  defp refresh_locked(observed, mode) do
+    case platform_row() do
+      %Account{id: id, generation: generation} = current
+      when id == observed.id and generation == observed.generation ->
+        cond do
+          current.status != "active" or current.lock_version != observed.lock_version ->
+            current_result(observed)
+
+          mode == :if_stale and fresh?(current) ->
+            Cipher.decrypt_token(current, :access_token)
+
+          true ->
+            do_refresh(current)
+        end
+
+      nil ->
+        {:error, :not_connected}
+
+      %Account{} ->
+        {:error, :stale_grant}
+    end
+  end
+
+  # Static workspace tokens do not need a refresh lock.
+  defp refresh_without_exchange do
     case platform_row() do
       nil ->
         {:error, :not_connected}
@@ -482,13 +520,17 @@ defmodule Fountain.ChatGPTAccounts do
       %Account{refresh_token_ciphertext: nil} = row ->
         Cipher.decrypt_token(row, :access_token)
 
-      row when mode == :if_stale ->
-        if fresh?(row), do: Cipher.decrypt_token(row, :access_token), else: do_refresh(row)
-
-      row ->
-        do_refresh(row)
+      %Account{} ->
+        {:error, :stale_grant}
     end
   end
+
+  defp finish_refresh({:revoked, account_id, code}) do
+    record_revocation(account_id, code)
+    {:error, :revoked}
+  end
+
+  defp finish_refresh(result), do: result
 
   defp do_refresh(current) do
     with {:ok, refresh} <- Cipher.decrypt_token(current, :refresh_token) do
@@ -501,7 +543,7 @@ defmodule Fountain.ChatGPTAccounts do
 
         {:error, {:terminal, code}} ->
           case mark_revoked(current, code) do
-            :ok -> {:error, :revoked}
+            :ok -> {:revoked, current.account_id, code}
             :stale -> current_result(current)
           end
 
@@ -598,18 +640,17 @@ defmodule Fountain.ChatGPTAccounts do
       )
 
     if count == 1 do
-      record_revocation(row, code)
       :ok
     else
       :stale
     end
   end
 
-  defp record_revocation(row, code) do
+  defp record_revocation(account_id, code) do
     Audit.record_admin(%{
       actor_user_id: nil,
       event_type: "admin.platform_chatgpt.revoked",
-      metadata: %{"actor" => @system_actor, "reason" => code, "account_id" => row.account_id}
+      metadata: %{"actor" => @system_actor, "reason" => code, "account_id" => account_id}
     })
 
     Logger.warning(

--- a/apps/fountain/lib/fountain/chatgpt_accounts/refresh_lock.ex
+++ b/apps/fountain/lib/fountain/chatgpt_accounts/refresh_lock.ex
@@ -10,6 +10,15 @@ defmodule Fountain.ChatGPTAccounts.RefreshLock do
   The callback must re-read the grant and fence its writes. It must not take
   a grant row lock before contacting the provider or emit best-effort audit
   events inside the transaction. Its result is returned only after commit.
+  `run/3` must not itself be called inside a transaction: the lock would
+  attach to the enclosing one and outlive the callback by however long that
+  transaction runs. The one caller is `Fountain.PlatformChatGPT.Refresher`,
+  which holds none.
+
+  Whatever the callback does upstream has to finish inside
+  `@transaction_timeout`, which is a wall clock over the whole checkout
+  rather than a per-query budget. `Fountain.PlatformChatGPT.OAuth.refresh/1`
+  sizes its HTTP timeouts against this number and explains the arithmetic.
   A provider rotation followed by a crash before commit still needs reconnect:
   database exclusion cannot make an external token exchange atomic.
   """
@@ -21,6 +30,10 @@ defmodule Fountain.ChatGPTAccounts.RefreshLock do
   @namespace 52_001
   @wait_timeout 5_000
   @transaction_timeout 20_000
+
+  @doc "The wall clock the holder's whole checkout runs under, in milliseconds."
+  @spec transaction_timeout_ms() :: pos_integer()
+  def transaction_timeout_ms, do: @transaction_timeout
 
   @doc false
   def run(grant_id, fun, opts \\ []) when is_binary(grant_id) and is_function(fun, 0) do

--- a/apps/fountain/lib/fountain/chatgpt_accounts/refresh_lock.ex
+++ b/apps/fountain/lib/fountain/chatgpt_accounts/refresh_lock.ex
@@ -1,0 +1,72 @@
+defmodule Fountain.ChatGPTAccounts.RefreshLock do
+  @moduledoc """
+  Cross-node exclusion for a grant's upstream refresh.
+
+  Only the holder keeps a database checkout across the provider request.
+  Contenders try a transaction-scoped advisory lock and release the checkout
+  before backing off. The transaction releases its lock on commit, rollback,
+  connection loss or worker death; no session lock can leak into the pool.
+
+  The callback must re-read the grant and fence its writes. It must not take
+  a grant row lock before contacting the provider or emit best-effort audit
+  events inside the transaction. Its result is returned only after commit.
+  A provider rotation followed by a crash before commit still needs reconnect:
+  database exclusion cannot make an external token exchange atomic.
+  """
+
+  alias Fountain.Repo
+
+  # Separate from connection, admission and quota locks. Hash collisions only
+  # serialize unrelated grants; they cannot weaken mutual exclusion.
+  @namespace 52_001
+  @wait_timeout 5_000
+  @transaction_timeout 20_000
+
+  @doc false
+  def run(grant_id, fun, opts \\ []) when is_binary(grant_id) and is_function(fun, 0) do
+    deadline = monotonic_ms() + Keyword.get(opts, :wait_timeout, @wait_timeout)
+    timeout = Keyword.get(opts, :transaction_timeout, @transaction_timeout)
+    attempt(:erlang.phash2(grant_id), fun, deadline, timeout)
+  rescue
+    DBConnection.ConnectionError -> {:error, :refresh_unavailable}
+  end
+
+  defp attempt(key, fun, deadline, timeout) do
+    result =
+      Repo.transaction(
+        fn ->
+          case Repo.query!("SELECT pg_try_advisory_xact_lock($1, $2)", [@namespace, key]) do
+            %{rows: [[true]]} -> {:acquired, fun.()}
+            %{rows: [[false]]} -> :busy
+          end
+        end,
+        timeout: timeout
+      )
+
+    case result do
+      {:ok, {:acquired, result}} ->
+        result
+
+      {:ok, :busy} ->
+        # This event is outside the transaction, as is the bounded backoff.
+        :telemetry.execute([:fountain, :chatgpt, :refresh_lock, :contention], %{count: 1}, %{})
+        retry(key, fun, deadline, timeout)
+
+      {:error, _reason} ->
+        {:error, :refresh_unavailable}
+    end
+  end
+
+  defp retry(key, fun, deadline, timeout) do
+    remaining = deadline - monotonic_ms()
+
+    if remaining > 0 do
+      Process.sleep(min(remaining, 25 + :rand.uniform(50)))
+      attempt(key, fun, deadline, timeout)
+    else
+      {:error, :refresh_busy}
+    end
+  end
+
+  defp monotonic_ms, do: System.monotonic_time(:millisecond)
+end

--- a/apps/fountain/lib/fountain/platform_chatgpt/oauth.ex
+++ b/apps/fountain/lib/fountain/platform_chatgpt/oauth.ex
@@ -35,6 +35,40 @@ defmodule Fountain.PlatformChatGPT.OAuth do
   @doc "Codex's OAuth client id."
   def client_id, do: @client_id
 
+  @refresh_connect_timeout 2_000
+  @refresh_pool_timeout 1_000
+  @refresh_receive_timeout 3_000
+  @refresh_request_timeout 12_000
+
+  defp refresh_finch_options do
+    [
+      conn_opts: [transport_opts: [timeout: @refresh_connect_timeout]],
+      protocols: [:http1],
+      pool_timeout: @refresh_pool_timeout,
+      receive_timeout: @refresh_receive_timeout,
+      request_timeout: @refresh_request_timeout
+    ]
+  end
+
+  @doc """
+  The longest `refresh/1` can take before it gives up, in milliseconds.
+
+  A **sum**, not a maximum. `:request_timeout` is checked between receives
+  and each receive may then block for a full `:receive_timeout`, so a call
+  that exhausts the first can still spend the second on one last receive,
+  on top of connecting and waiting for a pool slot.
+
+  `Fountain.ChatGPTAccounts.RefreshLock` holds a database checkout for the
+  whole exchange, so this number has to stay under its transaction budget.
+  `Fountain.ChatGPTRefreshCoordinationTest` asserts exactly that, because
+  the two are set in different modules and the arithmetic is not obvious.
+  """
+  @spec refresh_timeout_ceiling_ms() :: pos_integer()
+  def refresh_timeout_ceiling_ms do
+    @refresh_request_timeout + @refresh_receive_timeout + @refresh_connect_timeout +
+      @refresh_pool_timeout
+  end
+
   @doc """
   The error codes that mean the refresh token will never work again, and so
   the only ones a stored `revoked_reason` can hold. Callers that show a
@@ -51,9 +85,21 @@ defmodule Fountain.PlatformChatGPT.OAuth do
   """
   @spec refresh(String.t()) :: {:ok, tokens()} | {:error, {:terminal, String.t()} | term()}
   def refresh(refresh_token) when is_binary(refresh_token) do
-    # Leave headroom inside the refresh lock's 20-second transaction budget.
-    # Finch's complete-response timeout applies to HTTP/1, so pin that protocol
-    # for this small token exchange. A slow drip must not hold the DB forever.
+    # This call runs inside `Fountain.ChatGPTAccounts.RefreshLock`'s
+    # 20-second transaction, holding a database checkout for its whole
+    # duration, so its worst case has to be provably smaller than that.
+    #
+    # `:request_timeout` alone does not bound it. Finch checks it *between*
+    # receives and each receive may then block for a full `:receive_timeout`
+    # (finch 0.23.0, `http1/conn.ex:298` guards before the `recv` at `:313`),
+    # so the ceiling is the two added together, not the larger of them.
+    # Measured: a provider dripping for 11s and then going silent took 22.8s
+    # under 12/12 and the pool force-disconnected the connection mid-flight.
+    # 12 + 3 + 2 + 1 = 18s leaves the transaction two seconds of headroom.
+    #
+    # `:request_timeout` applies to HTTP/1 only, hence the protocol pin. It
+    # is scoped to this exchange: Req starts a separate Finch instance named
+    # by a hash of these options, so the shared pool keeps its own settings.
     post(
       "/oauth/token",
       %{
@@ -61,13 +107,7 @@ defmodule Fountain.PlatformChatGPT.OAuth do
         grant_type: "refresh_token",
         refresh_token: refresh_token
       },
-      finch: [
-        conn_opts: [transport_opts: [timeout: 2_000]],
-        protocols: [:http1],
-        pool_timeout: 1_000,
-        receive_timeout: 12_000,
-        request_timeout: 12_000
-      ],
+      finch: refresh_finch_options(),
       retry: false
     )
     |> token_response()

--- a/apps/fountain/lib/fountain/platform_chatgpt/oauth.ex
+++ b/apps/fountain/lib/fountain/platform_chatgpt/oauth.ex
@@ -51,11 +51,25 @@ defmodule Fountain.PlatformChatGPT.OAuth do
   """
   @spec refresh(String.t()) :: {:ok, tokens()} | {:error, {:terminal, String.t()} | term()}
   def refresh(refresh_token) when is_binary(refresh_token) do
-    post("/oauth/token", %{
-      client_id: @client_id,
-      grant_type: "refresh_token",
-      refresh_token: refresh_token
-    })
+    # Leave headroom inside the refresh lock's 20-second transaction budget.
+    # Finch's complete-response timeout applies to HTTP/1, so pin that protocol
+    # for this small token exchange. A slow drip must not hold the DB forever.
+    post(
+      "/oauth/token",
+      %{
+        client_id: @client_id,
+        grant_type: "refresh_token",
+        refresh_token: refresh_token
+      },
+      finch: [
+        conn_opts: [transport_opts: [timeout: 2_000]],
+        protocols: [:http1],
+        pool_timeout: 1_000,
+        receive_timeout: 12_000,
+        request_timeout: 12_000
+      ],
+      retry: false
+    )
     |> token_response()
   end
 
@@ -161,7 +175,7 @@ defmodule Fountain.PlatformChatGPT.OAuth do
   defp error_code(%{"error" => %{"type" => code}}) when is_binary(code), do: code
   defp error_code(_body), do: "unknown"
 
-  defp post(path, json) do
+  defp post(path, json, opts \\ []) do
     [
       url: base_url() <> path,
       json: json,
@@ -170,6 +184,7 @@ defmodule Fountain.PlatformChatGPT.OAuth do
       retry: false
     ]
     |> Keyword.merge(Application.get_env(:fountain, :platform_chatgpt_req_options, []))
+    |> Keyword.merge(opts)
     |> Req.new()
     |> Req.post()
     |> case do

--- a/apps/fountain/lib/fountain/platform_chatgpt/oauth.ex
+++ b/apps/fountain/lib/fountain/platform_chatgpt/oauth.ex
@@ -37,8 +37,8 @@ defmodule Fountain.PlatformChatGPT.OAuth do
 
   @refresh_connect_timeout 2_000
   @refresh_pool_timeout 1_000
-  @refresh_receive_timeout 3_000
-  @refresh_request_timeout 12_000
+  @refresh_receive_timeout 6_000
+  @refresh_request_timeout 9_000
 
   defp refresh_finch_options do
     [
@@ -95,7 +95,14 @@ defmodule Fountain.PlatformChatGPT.OAuth do
     # so the ceiling is the two added together, not the larger of them.
     # Measured: a provider dripping for 11s and then going silent took 22.8s
     # under 12/12 and the pool force-disconnected the connection mid-flight.
-    # 12 + 3 + 2 + 1 = 18s leaves the transaction two seconds of headroom.
+    # 9 + 6 + 2 + 1 = 18s leaves the transaction two seconds of headroom.
+    #
+    # Split that way round because `:receive_timeout` bounds the *first*
+    # receive as well as the gaps: finch enters `receive_response([], ...)`
+    # straight after the send (`http1/conn.ex:130`), so it is how long the
+    # auth server has to begin answering at all. `:request_timeout` covers
+    # the body, and this body is a few hundred bytes. Six seconds of server
+    # think time and nine for the whole response beats the reverse.
     #
     # `:request_timeout` applies to HTTP/1 only, hence the protocol pin. It
     # is scoped to this exchange: Req starts a separate Finch instance named

--- a/apps/fountain/lib/fountain/platform_chatgpt/refresher.ex
+++ b/apps/fountain/lib/fountain/platform_chatgpt/refresher.ex
@@ -5,17 +5,16 @@ defmodule Fountain.PlatformChatGPT.Refresher do
 
   A refresh is an HTTP round-trip, and every conversation on the deployment
   shares the one grant, so when it goes stale every turn and every launch
-  wants to refresh it at the same moment. Holding a database lock across
-  that round-trip, the way `Fountain.Connections` does per connection, would
-  park every waiter on a checked-out connection and drain the pool. So the
-  waiters queue here instead, holding nothing: the first call refreshes,
-  the rest find the row fresh when their turn comes.
+  wants to refresh it at the same moment. Waiters queue here, holding no
+  database connection: the first call refreshes, the rest find the row fresh
+  when their turn comes.
 
-  Across nodes, generation/version checks prevent stale success and failure
-  writes. A loser can serve a winner from the same grant generation; it
-  cannot serve or revoke a replacement account. This still permits duplicate
-  upstream calls: deployment-wide refresh coordination is follow-up work
-  under ADR 0052, not a guarantee of this local queue.
+  Across nodes, a per-grant PostgreSQL try-lock excludes concurrent upstream
+  requests. Only the holder keeps a checkout; contenders release theirs
+  between bounded retries. Generation/version checks still fence reconnect
+  and disconnect while the provider call is in flight. The transaction is
+  bounded to 20 seconds and contention to 5 seconds. Per-user queues and
+  fleet-wide user keepalive scheduling remain unbuilt under ADR 0052.
   """
 
   use GenServer

--- a/apps/fountain/lib/fountain_web/telemetry.ex
+++ b/apps/fountain/lib/fountain_web/telemetry.ex
@@ -121,6 +121,13 @@ defmodule FountainWeb.Telemetry do
         tags: [:event_type],
         description: "Admin audit events rejected at write time (lost trail rows)"
       ),
+      # The only signal that two servers raced for the same ChatGPT grant's
+      # refresh. Contention is expected and harmless; a rate that climbs with
+      # replica count is how "the lock is doing real work" becomes visible.
+      counter("fountain.chatgpt.refresh_lock.contention.count",
+        event_name: [:fountain, :chatgpt, :refresh_lock, :contention],
+        description: "Refreshers that found another node holding the grant lock"
+      ),
       # Any non-zero value here means billing data is being lost (#503) —
       # record_usage/5 swallows failures by contract, so this counter is the
       # only signal that distinguishes "no usage" from "metering broken".

--- a/apps/fountain/test/fountain/chatgpt_refresh_coordination_test.exs
+++ b/apps/fountain/test/fountain/chatgpt_refresh_coordination_test.exs
@@ -254,18 +254,27 @@ defmodule Fountain.ChatGPTRefreshCoordinationTest do
   # pool for the next checkout to inherit.
   test "the lock is scoped to the transaction, not left on the pooled connection" do
     grant_id = Ecto.UUID.generate()
-    assert {:ok, :done} = RefreshLock.run(grant_id, fn -> {:ok, :done} end)
-    assert advisory_locks_held() == 0
 
-    # A rollback and a raise unwind by different routes; neither may strand a
-    # lock on the connection they borrowed.
-    assert {:error, :refresh_unavailable} =
-             RefreshLock.run(grant_id, fn -> Repo.rollback(:failed) end)
+    # `Repo.checkout/1` pins one connection for the whole body, so the lock
+    # and the `pg_backend_pid()` that looks for it are the same backend. Two
+    # connections in this pool and a free choice of either made the check
+    # miss a real session lock roughly half the time. This is a checkout and
+    # not a transaction, so `run/3`'s "never inside a transaction" contract
+    # still holds -- the xact lock has an enclosing transaction of its own.
+    Repo.checkout(fn ->
+      assert {:ok, :done} = RefreshLock.run(grant_id, fn -> {:ok, :done} end)
+      assert advisory_locks_held() == 0
 
-    assert advisory_locks_held() == 0
+      # A rollback and a raise unwind by different routes; neither may strand
+      # a lock on the connection they borrowed.
+      assert {:error, :refresh_unavailable} =
+               RefreshLock.run(grant_id, fn -> Repo.rollback(:failed) end)
 
-    assert catch_throw(RefreshLock.run(grant_id, fn -> throw(:boom) end)) == :boom
-    assert advisory_locks_held() == 0
+      assert advisory_locks_held() == 0
+
+      assert catch_throw(RefreshLock.run(grant_id, fn -> throw(:boom) end)) == :boom
+      assert advisory_locks_held() == 0
+    end)
   end
 
   test "rollback releases the lock without returning the callback's success" do
@@ -326,8 +335,15 @@ defmodule Fountain.ChatGPTRefreshCoordinationTest do
       started = System.monotonic_time(:millisecond)
       assert {:error, {:token, _timeout}} = PlatformChatGPT.refresh_serialized(:if_stale)
       elapsed = System.monotonic_time(:millisecond) - started
-      assert elapsed >= 11_000
-      assert elapsed < 19_000
+      # Chunks arrive every 250ms, so `:receive_timeout` never fires and
+      # `:request_timeout` is what ends this. Bound it by the thing that
+      # actually matters rather than by a copy of the constant: the whole
+      # exchange has to finish inside the transaction holding the
+      # connection. The lower bound only says it waited on the provider
+      # instead of failing fast.
+      assert elapsed >= 1_000
+      assert elapsed < Fountain.PlatformChatGPT.OAuth.refresh_timeout_ceiling_ms()
+      assert elapsed < RefreshLock.transaction_timeout_ms()
       current = Repo.get!(Account, original.id)
       assert current.lock_version == original.lock_version
       assert current.status == "active"
@@ -359,9 +375,9 @@ defmodule Fountain.ChatGPTRefreshCoordinationTest do
     end)
   end
 
-  # Every checkout in this pool ran `RefreshLock.run/3`, so any advisory lock
-  # still held by whichever connection answers is one that outlived its
-  # transaction. `pg_backend_pid()` scopes the count to this connection.
+  # Counts only locks held by the backend answering this query, which is why
+  # the caller pins the connection first: on a free choice between two, the
+  # query can land on the one that never ran the lock and see zero.
   defp advisory_locks_held do
     %{rows: [[held]]} =
       Repo.query!(

--- a/apps/fountain/test/fountain/chatgpt_refresh_coordination_test.exs
+++ b/apps/fountain/test/fountain/chatgpt_refresh_coordination_test.exs
@@ -180,7 +180,10 @@ defmodule Fountain.ChatGPTRefreshCoordinationTest do
       end
 
       # One of just two connections remains usable despite six waiters.
-      assert %{rows: [[1]]} = Repo.query!("SELECT 1", [], timeout: 1_000)
+      # The timeout only has to be long enough to distinguish "a connection
+      # is free" from "both are pinned"; a loaded runner should not have to
+      # answer in a second to prove that.
+      assert %{rows: [[1]]} = Repo.query!("SELECT 1", [], timeout: 5_000)
 
       assert {:ok, :other_grant} =
                RefreshLock.run(Ecto.UUID.generate(), fn -> {:ok, :other_grant} end)
@@ -222,6 +225,47 @@ defmodule Fountain.ChatGPTRefreshCoordinationTest do
     holder = hold_lock(ctx.repo, grant_id)
     Task.shutdown(holder, :brutal_kill)
     assert {:ok, :recovered} = RefreshLock.run(grant_id, fn -> {:ok, :recovered} end)
+  end
+
+  # The holder keeps a database checkout for the whole provider exchange, so
+  # the exchange has to be unable to outlast the transaction. Measured once
+  # at 12/12: a provider that dripped for 11s and then went silent took 22.8s
+  # and the pool force-disconnected the connection underneath it -- and the
+  # dangerous case is not that one but the next, where the rotation lands at
+  # ~21s, the connection is already gone, and the refresh token has moved
+  # upstream with nothing able to commit it locally.
+  #
+  # The numbers live in two modules and the ceiling is a sum rather than a
+  # maximum, which is how the first version got it wrong. Neither fact is
+  # visible from either file alone, so assert the relationship here.
+  test "the provider exchange cannot outlast the transaction that holds the connection" do
+    assert Fountain.PlatformChatGPT.OAuth.refresh_timeout_ceiling_ms() <
+             RefreshLock.transaction_timeout_ms()
+  end
+
+  # The moduledoc's strongest claim is that no session lock can leak into the
+  # pool, and until this test nothing observed it: swapping
+  # `pg_try_advisory_xact_lock` for `pg_try_advisory_lock` left all twelve
+  # tests green. "worker death" passes either way because DBConnection drops
+  # the whole connection when the client dies, and "rollback" passes because
+  # advisory locks are re-entrant within one session. Both prove the lock is
+  # released, neither proves it was scoped to the transaction. This asks the
+  # connection itself, after the transaction has ended and it is back in the
+  # pool for the next checkout to inherit.
+  test "the lock is scoped to the transaction, not left on the pooled connection" do
+    grant_id = Ecto.UUID.generate()
+    assert {:ok, :done} = RefreshLock.run(grant_id, fn -> {:ok, :done} end)
+    assert advisory_locks_held() == 0
+
+    # A rollback and a raise unwind by different routes; neither may strand a
+    # lock on the connection they borrowed.
+    assert {:error, :refresh_unavailable} =
+             RefreshLock.run(grant_id, fn -> Repo.rollback(:failed) end)
+
+    assert advisory_locks_held() == 0
+
+    assert catch_throw(RefreshLock.run(grant_id, fn -> throw(:boom) end)) == :boom
+    assert advisory_locks_held() == 0
   end
 
   test "rollback releases the lock without returning the callback's success" do
@@ -313,6 +357,18 @@ defmodule Fountain.ChatGPTRefreshCoordinationTest do
       Repo.put_dynamic_repo(repo)
       fun.()
     end)
+  end
+
+  # Every checkout in this pool ran `RefreshLock.run/3`, so any advisory lock
+  # still held by whichever connection answers is one that outlived its
+  # transaction. `pg_backend_pid()` scopes the count to this connection.
+  defp advisory_locks_held do
+    %{rows: [[held]]} =
+      Repo.query!(
+        "SELECT count(*) FROM pg_locks WHERE locktype = 'advisory' AND pid = pg_backend_pid()"
+      )
+
+    held
   end
 
   defp hold_lock(repo, grant_id) do

--- a/apps/fountain/test/fountain/chatgpt_refresh_coordination_test.exs
+++ b/apps/fountain/test/fountain/chatgpt_refresh_coordination_test.exs
@@ -1,0 +1,340 @@
+defmodule Fountain.ChatGPTRefreshCoordinationTest do
+  # Committed rows, a real two-connection pool and a shared provider stub.
+  # SQL sandbox sharing cannot establish cross-node exclusion.
+  use ExUnit.Case, async: false
+  use Mimic
+
+  import Ecto.Query
+  import Fountain.ChatGPTFixtures
+
+  alias Fountain.Audit.AdminEvent
+  alias Fountain.ChatGPTAccounts.RefreshLock
+  alias Fountain.Crypto
+  alias Fountain.PlatformChatGPT
+  alias Fountain.PlatformChatGPT.Account
+  alias Fountain.Repo
+
+  @contention [:fountain, :chatgpt, :refresh_lock, :contention]
+
+  setup_all do
+    repo =
+      start_supervised!({Repo, name: nil, pool: DBConnection.ConnectionPool, pool_size: 2})
+
+    %{repo: repo}
+  end
+
+  setup %{repo: repo} do
+    previous_repo = Repo.put_dynamic_repo(repo)
+    account_id = "refresh-coordination-#{Ecto.UUID.generate()}"
+    owner = self()
+    handler_id = "refresh-lock-test-#{account_id}"
+
+    :ok = :telemetry.attach(handler_id, @contention, &__MODULE__.on_contention/4, owner)
+
+    on_exit(fn ->
+      :telemetry.detach(handler_id)
+      # The module's pool outlives each test's cleanup.
+      Repo.put_dynamic_repo(repo)
+      Repo.delete_all(from(a in Account, where: a.account_id == ^account_id))
+
+      Repo.delete_all(
+        from(e in AdminEvent, where: fragment("?->>'account_id'", e.metadata) == ^account_id)
+      )
+
+      Repo.put_dynamic_repo(previous_repo)
+    end)
+
+    %{repo: repo, account_id: account_id}
+  end
+
+  @doc false
+  def on_contention(_event, _measurements, _metadata, owner) do
+    send(owner, {:contending, self(), Repo.checked_out?()})
+  end
+
+  for mode <- [:if_stale, :force] do
+    test "independent #{mode} refreshers exchange once and serve the committed winner", ctx do
+      account = connect!(%{access_token: access_token(60), account_id: ctx.account_id})
+      winner = access_token(7_200, %{"winner" => true})
+      owner = self()
+
+      stub_auth(%{
+        "/oauth/token" => fn body ->
+          %{rows: [[backend]]} = Repo.query!("SELECT pg_backend_pid()")
+          send(owner, {:upstream, self(), backend, body["refresh_token"]})
+          await_release()
+          {200, %{"access_token" => winner, "refresh_token" => "rt_winner"}}
+        end
+      })
+
+      holder = independent(ctx.repo, fn -> PlatformChatGPT.refresh_serialized(unquote(mode)) end)
+
+      try do
+        assert_receive {:upstream, holder_pid, holder_backend, "rt_original"}, 2_000
+        assert holder_pid == holder.pid
+
+        waiter =
+          independent(ctx.repo, fn -> PlatformChatGPT.refresh_serialized(unquote(mode)) end)
+
+        try do
+          assert_receive {:contending, waiter_pid, false}, 2_000
+          assert waiter_pid == waiter.pid
+          %{rows: [[free_backend]]} = Repo.query!("SELECT pg_backend_pid()")
+          refute free_backend == holder_backend
+          # The holder has no row lock and has not committed new tokens yet.
+          assert Repo.get!(Account, account.id).lock_version == account.lock_version
+          send(holder.pid, :release)
+          assert {:ok, ^winner} = Task.await(holder)
+          assert {:ok, ^winner} = Task.await(waiter)
+          refute_received {:upstream, _, _, _}
+          current = Repo.get!(Account, account.id)
+          assert current.lock_version == account.lock_version + 1
+          assert current.generation == account.generation
+          assert {:ok, "rt_winner"} = Crypto.decrypt_platform(current.refresh_token_ciphertext)
+        after
+          Task.shutdown(waiter, :brutal_kill)
+        end
+      after
+        Task.shutdown(holder, :brutal_kill)
+      end
+    end
+  end
+
+  for mutation <- [:disconnect, :reconnect], response <- [:success, :terminal] do
+    test "#{mutation} commits during an independent refresh's #{response} response", ctx do
+      original = connect!(%{access_token: access_token(60), account_id: ctx.account_id})
+      owner = self()
+
+      stub_auth(%{
+        "/oauth/token" => fn _ ->
+          send(owner, :refreshing)
+          await_release()
+
+          case unquote(response) do
+            :success -> {200, %{"access_token" => access_token(), "refresh_token" => "rt_late"}}
+            :terminal -> {400, %{"error" => "invalid_grant"}}
+          end
+        end
+      })
+
+      holder = independent(ctx.repo, fn -> PlatformChatGPT.refresh_serialized(:if_stale) end)
+
+      try do
+        assert_receive :refreshing, 2_000
+
+        case unquote(mutation) do
+          :disconnect ->
+            assert :ok = PlatformChatGPT.disconnect()
+
+          :reconnect ->
+            replacement = connect!(%{account_id: ctx.account_id})
+            refute replacement.generation == original.generation
+        end
+
+        send(holder.pid, :release)
+
+        case unquote(mutation) do
+          :disconnect ->
+            assert {:error, :not_connected} = Task.await(holder)
+            refute Repo.get(Account, original.id)
+
+          :reconnect ->
+            assert {:error, :stale_grant} = Task.await(holder)
+            current = Repo.get!(Account, original.id)
+            assert current.status == "active"
+
+            assert {:ok, "rt_original"} =
+                     Crypto.decrypt_platform(current.refresh_token_ciphertext)
+        end
+
+        refute Repo.exists?(
+                 from(e in AdminEvent,
+                   where:
+                     e.event_type == "admin.platform_chatgpt.revoked" and
+                       fragment("?->>'account_id'", e.metadata) == ^ctx.account_id
+                 )
+               )
+      after
+        Task.shutdown(holder, :brutal_kill)
+      end
+    end
+  end
+
+  test "many contenders release pool capacity and stop at their wait deadline", ctx do
+    grant_id = Ecto.UUID.generate()
+    holder = hold_lock(ctx.repo, grant_id)
+
+    waiters =
+      for _ <- 1..6 do
+        independent(ctx.repo, fn ->
+          RefreshLock.run(grant_id, fn -> flunk("contender acquired held lock") end,
+            wait_timeout: 250
+          )
+        end)
+      end
+
+    try do
+      for waiter <- waiters do
+        pid = waiter.pid
+        assert_receive {:contending, ^pid, false}, 2_000
+      end
+
+      # One of just two connections remains usable despite six waiters.
+      assert %{rows: [[1]]} = Repo.query!("SELECT 1", [], timeout: 1_000)
+
+      assert {:ok, :other_grant} =
+               RefreshLock.run(Ecto.UUID.generate(), fn -> {:ok, :other_grant} end)
+
+      for waiter <- waiters, do: assert({:error, :refresh_busy} = Task.await(waiter))
+      assert Task.yield(holder, 0) == nil
+    after
+      for waiter <- waiters, do: Task.shutdown(waiter, :brutal_kill)
+      send(holder.pid, :release)
+      Task.shutdown(holder, 1_000)
+    end
+  end
+
+  test "revocation is committed before its best-effort audit", ctx do
+    account = connect!(%{access_token: access_token(60), account_id: ctx.account_id})
+    stub_refusal()
+
+    expect(Fountain.Audit, :record_admin, fn attrs ->
+      refute Repo.in_transaction?()
+      assert attrs.event_type == "admin.platform_chatgpt.revoked"
+
+      committed =
+        ctx.repo
+        |> independent(fn -> Repo.get!(Account, account.id) end)
+        |> Task.await()
+
+      assert committed.status == "revoked"
+      assert committed.lock_version == account.lock_version + 1
+      # Audit loss cannot roll back the already committed revocation.
+      {:error, :unavailable}
+    end)
+
+    assert {:error, :revoked} = PlatformChatGPT.refresh_serialized(:if_stale)
+    assert Repo.get!(Account, account.id).status == "revoked"
+  end
+
+  test "worker death releases the transaction lock for another connection", ctx do
+    grant_id = Ecto.UUID.generate()
+    holder = hold_lock(ctx.repo, grant_id)
+    Task.shutdown(holder, :brutal_kill)
+    assert {:ok, :recovered} = RefreshLock.run(grant_id, fn -> {:ok, :recovered} end)
+  end
+
+  test "rollback releases the lock without returning the callback's success" do
+    grant_id = Ecto.UUID.generate()
+
+    assert {:error, :refresh_unavailable} =
+             RefreshLock.run(grant_id, fn -> Repo.rollback(:failed) end)
+
+    assert {:ok, :recovered} = RefreshLock.run(grant_id, fn -> {:ok, :recovered} end)
+  end
+
+  @tag capture_log: true
+  test "transaction deadline cannot return a token from an uncommitted refresh" do
+    grant_id = Ecto.UUID.generate()
+
+    assert {:error, :refresh_unavailable} =
+             RefreshLock.run(
+               grant_id,
+               fn ->
+                 Process.sleep(150)
+                 {:ok, "uncommitted"}
+               end,
+               transaction_timeout: 50
+             )
+
+    assert {:ok, :recovered} = RefreshLock.run(grant_id, fn -> {:ok, :recovered} end)
+  end
+
+  test "a provider dripping response chunks cannot keep the refresh transaction open", ctx do
+    original = connect!(%{access_token: access_token(60), account_id: ctx.account_id})
+    {:ok, listener} = :gen_tcp.listen(0, [:binary, active: false, ip: {127, 0, 0, 1}])
+    {:ok, port} = :inet.port(listener)
+    old_url = Application.fetch_env(:fountain, :platform_chatgpt_auth_url)
+    old_options = Application.fetch_env(:fountain, :platform_chatgpt_req_options)
+    Application.put_env(:fountain, :platform_chatgpt_auth_url, "http://127.0.0.1:#{port}")
+    Application.put_env(:fountain, :platform_chatgpt_req_options, [])
+
+    on_exit(fn ->
+      restore_env(:platform_chatgpt_auth_url, old_url)
+      restore_env(:platform_chatgpt_req_options, old_options)
+    end)
+
+    server =
+      Task.async(fn ->
+        {:ok, socket} = :gen_tcp.accept(listener)
+        {:ok, _request} = :gen_tcp.recv(socket, 0, 2_000)
+
+        :ok =
+          :gen_tcp.send(
+            socket,
+            "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nContent-Type: application/json\r\n\r\n"
+          )
+
+        drip(socket)
+      end)
+
+    try do
+      started = System.monotonic_time(:millisecond)
+      assert {:error, {:token, _timeout}} = PlatformChatGPT.refresh_serialized(:if_stale)
+      elapsed = System.monotonic_time(:millisecond) - started
+      assert elapsed >= 11_000
+      assert elapsed < 19_000
+      current = Repo.get!(Account, original.id)
+      assert current.lock_version == original.lock_version
+      assert current.status == "active"
+      assert {:ok, :released} = RefreshLock.run(original.id, fn -> {:ok, :released} end)
+    after
+      Task.shutdown(server, :brutal_kill)
+      :gen_tcp.close(listener)
+    end
+  end
+
+  defp drip(socket) do
+    case :gen_tcp.send(socket, "1\r\n \r\n") do
+      :ok ->
+        Process.sleep(250)
+        drip(socket)
+
+      {:error, _} ->
+        :gen_tcp.close(socket)
+    end
+  end
+
+  defp restore_env(key, {:ok, value}), do: Application.put_env(:fountain, key, value)
+  defp restore_env(key, :error), do: Application.delete_env(:fountain, key)
+
+  defp independent(repo, fun) do
+    Task.async(fn ->
+      Repo.put_dynamic_repo(repo)
+      fun.()
+    end)
+  end
+
+  defp hold_lock(repo, grant_id) do
+    owner = self()
+
+    holder =
+      independent(repo, fn ->
+        RefreshLock.run(grant_id, fn ->
+          send(owner, :holding)
+          await_release()
+        end)
+      end)
+
+    assert_receive :holding, 2_000
+    holder
+  end
+
+  defp await_release do
+    receive do
+      :release -> :ok
+    after
+      5_000 -> raise "refresh barrier timed out"
+    end
+  end
+end

--- a/apps/fountain/test/fountain_web/metrics_test.exs
+++ b/apps/fountain/test/fountain_web/metrics_test.exs
@@ -181,6 +181,9 @@ defmodule FountainWeb.MetricsTest do
         # Audit.record_admin/1 rejection path (#451) — exercised by
         # Fountain.AuditTest's rejected-write telemetry test
         [:fountain, :audit, :admin_record_rejected],
+        # RefreshLock.attempt/4 contention path — exercised by
+        # Fountain.ChatGPTRefreshCoordinationTest's contender tests
+        [:fountain, :chatgpt, :refresh_lock, :contention],
         # Billing.record_usage/5 swallow path (#503) — exercised by
         # Fountain.UsageMeteringTest's dropped-usage telemetry test
         [:fountain, :usage, :dropped],


### PR DESCRIPTION
Two servers can currently exchange the same platform ChatGPT refresh token at once. Generation/version checks protect the stored row, but cannot prevent duplicate upstream exchanges. This change serializes those exchanges with a per-grant PostgreSQL try-lock and serves the committed winner to concurrent refreshers, including forced keepalives.

#2011 and #2012 are merged. This PR is based directly on main and implements the next part of ADR #2010: coordinated platform ChatGPT refresh.

- Use a transaction-scoped advisory lock: the holder retains one checkout; contenders release theirs before bounded, jittered retries. Commit, rollback, worker death and connection loss release the lock without leaving a session lock in the pool. The existing local platform queue limits holders to one per node.
- Re-read generation, version, status and expiry after acquisition. Preserve conditional writes; disconnect and reconnect acquire no refresh lock and can commit while the provider request is in flight. Return rotated credentials only after commit and record terminal revocation's best-effort audit afterward.
- Bound each transaction to 20 seconds, the contention retry window to 5 seconds, and the HTTP exchange with connection/pool/complete-response timeouts. Pin this small exchange to HTTP/1 because the installed Finch version's complete-response timeout applies to that protocol.

Validation:

- 12 new regressions use committed rows and a separate two-connection PostgreSQL pool. They cover concurrent normal/forced refresh, pool capacity with six contenders, unrelated grants, reconnect/disconnect during success/terminal responses, worker death, rollback, transaction expiry, audit ordering/failure, and an actual TCP provider that indefinitely drips unfinished response chunks.
- Ran the two concurrent-refresher regressions against the previous context: both failed with a second upstream request using the original refresh token. Both pass with this change. The local slow-response provider times out at approximately 12 seconds and leaves the grant active and unchanged.
- Full `mix precommit` passed before rebasing onto the reviewed base: compile, formatting, Credo, Dialyzer, Sobelow, production release assembly, 5,481 core tests plus 6 doctests, 144 Buzz tests and 33 Support tests; zero failures, 2 skipped and 7 excluded core cases.
- After rebasing: all 74 affected platform, tenant, lifecycle, admin and new concurrency tests passed on `328ab11e`. The precommit compile, format, Credo, Dialyzer, Sobelow and production release gates also passed on this revision, with the same 74 affected tests passed again by the precommit alias.

The initial concurrency run failed during fixture teardown because ExUnit stopped a per-test pool before cleanup. Moving the pool to module supervision fixed teardown; the behavior assertions had passed. No test was weakened or removed.

This is platform adoption of the lock primitive. User refresh, local queues keyed by user grant, batched user keepalive, and broker request authorization remain follow-up work; user linking remains unavailable. All refresh owners must run the new locking code for deployment-wide exclusion. An upstream rotation followed by a crash before database commit still requires reconnect; this does not provide an atomic exchange with the provider.

## Review follow-ups (`6f8715d4`), rebased onto #2012's `bd018066`

**The HTTP ceiling was 27s against a 20s transaction budget.** `:request_timeout` does not bound a call on its own -- finch 0.23.0 checks it *between* receives (`http1/conn.ex:298`) and the receive that follows may block a full `:receive_timeout` (`:313`), so the two add rather than the larger winning: 12 + 12 + 2 + 1. Reproduced on this branch's own drip harness, changed only to go silent after 11s: 22.8s elapsed with the pool force-disconnecting the connection mid-request. That failure is safe by itself; the reachable bad case is a provider that *completes* the rotation at ~21s, finds the connection gone, cannot commit `swap_in`, and leaves the refresh token rotated upstream with the grant dead until an admin reconnects. Before this branch no connection was held across the exchange at all. `receive_timeout: 3_000` makes it 18 < 20; the existing drip test sends a chunk every 250ms and is unaffected.

**The arithmetic is now pinned, not the wall clock.** The numbers live in two modules and the ceiling is a sum, not a maximum -- neither fact is visible from either file alone, which is how it was wrong to begin with. `OAuth.refresh_timeout_ceiling_ms/0` and `RefreshLock.transaction_timeout_ms/0` make the relationship assertable and a test asserts it. Verified by reverting: at the old `12_000` it fails with `left: 27000, right: 20000`.

**Nothing distinguished a transaction-scoped lock from a session-scoped one.** Swapping `pg_try_advisory_xact_lock` for `pg_try_advisory_lock` left all twelve tests green. "worker death" passes either way because DBConnection drops the whole connection when the client dies brutally; "rollback" passes because advisory locks are re-entrant within a session. Both prove release, neither proves scope. The new test asks the connection itself once the transaction has ended and it is back in the pool, across a clean return, a rollback and a raise. Verified by reverting: the session variant fails it with `left: 3, right: 0`, and it is the only failure.

**Minors, all three taken.** The contention counter is now in `FountainWeb.Telemetry` (without an entry it reached nothing but the test's own handler); the pool-capacity probe's timeout goes 1s to 5s, since it only has to tell "a connection is free" from "both are pinned"; and the moduledoc now says `run/3` must not be called inside a transaction.

Local gates on this head: 97 tests across the coordination, tenant, platform, lifecycle, inference-credential, admin-LiveView and telemetry suites, 0 failures; `mix format --check-formatted` clean; `mix compile --warnings-as-errors` clean; `MIX_ENV=dev mix credo --strict` no issues.

## Landing validation

Rebased only this PR’s three commits onto main `6e632dde8e4f93b1ae62e6ac5f642cf51d19e936` after #2012 merged. `git range-diff` reports all three patches unchanged. The lock, OAuth, refresher, context, and concurrency-test files are byte-identical to approved head `5f993b64`; the telemetry module and metrics test differ only by main’s existing CA-install metric additions. New head: `9c90ff9b`.

`mix precommit` passed on Elixir 1.19.2 / OTP 28.3 with the ten affected ChatGPT, inference, admin, and telemetry test files and a dedicated test database: **134 tests, zero failures**, plus compilation, formatting, strict Credo, Dialyzer (zero errors), Sobelow, and production release assembly. `git diff --check` passed. This local run selected the affected tests; fresh PR and merge-queue CI provide the complete suite against main.
