### PR TITLE
feat: renew user ChatGPT grants through bounded workers

### DIFF
--- a/apps/fountain/lib/fountain/application.ex
+++ b/apps/fountain/lib/fountain/application.ex
@@ -96,6 +96,7 @@ defmodule Fountain.Application do
         # (#1040). Supervised and unlinked, a crash here is a log line.
         {Task.Supervisor, name: Fountain.TaskSupervisor},
         Fountain.PlatformChatGPT.Refresher,
+        Fountain.ChatGPTAccounts.RefreshSupervisor,
         {DynamicSupervisor, name: Fountain.ExecutionTransportSupervisor, strategy: :one_for_one},
         FountainWeb.Plugs.RateLimit.Sweeper,
         Fountain.Conversations.Redaction,

--- a/apps/fountain/lib/fountain/chatgpt_accounts.ex
+++ b/apps/fountain/lib/fountain/chatgpt_accounts.ex
@@ -64,10 +64,11 @@ defmodule Fountain.ChatGPTAccounts do
 
   `status_for_user/1` and `credential_for_user/3` read a tenant's own grant.
   Both are scoped by the owner and neither falls through to the platform
-  row. Nothing writes a user grant yet: this foundation does not connect
-  them, coordinate refresh across nodes, or select them for conversations,
-  and a read that needs renewal returns `:refresh_required` rather than
-  invoking the platform-only refresher or a paid fallback.
+  row. Near-expiry reads renew through bounded per-grant workers and the
+  PostgreSQL refresh lock, using only the owner's encryption key. Callers
+  re-read their pinned grant after renewal; the coordinator holds no tokens.
+  User linking, conversation selection and user keepalive scheduling remain
+  unbuilt. No account API exposes this internal credential read.
   """
 
   import Ecto.Query, only: [from: 2]
@@ -75,7 +76,8 @@ defmodule Fountain.ChatGPTAccounts do
   require Logger
 
   alias Fountain.Audit
-  alias Fountain.ChatGPTAccounts.{Cipher, Grant, RefreshLock}
+  alias Fountain.Accounts.User
+  alias Fountain.ChatGPTAccounts.{Cipher, Grant, RefreshCoordinator, RefreshLock}
   alias Fountain.PlatformChatGPT.{Account, OAuth, Refresher, Tokens}
   alias Fountain.Repo
 
@@ -118,36 +120,103 @@ defmodule Fountain.ChatGPTAccounts do
   Internal server credential read for an explicitly selected user grant.
 
   The owner scopes the first query. The returned bearer and provider metadata
-  come from one row version. No refresh or paid fallback occurs here; a grant
-  within the refresh margin returns `:refresh_required`. This function is not
-  exposed by an account API or connected to conversation selection yet.
+  come from one row version. A near-expiry grant renews through the bounded
+  user coordinator, then the caller reads that same generation again. With
+  `refresh: false`, near-expiry grants return `:refresh_required`. Neither path
+  falls back to a different grant or paid inference. Only verified, claimed,
+  non-suspended owners can obtain or renew a credential.
   """
-  @spec credential_for_user(String.t(), String.t(), Ecto.UUID.t()) ::
+  @spec credential_for_user(String.t(), String.t(), Ecto.UUID.t(), keyword()) ::
           {:ok, Grant.t()} | {:error, atom()}
-  def credential_for_user(grant_id, user_id, generation)
+  def credential_for_user(grant_id, user_id, generation, opts \\ [])
       when is_binary(grant_id) and is_binary(user_id) and is_binary(generation) do
-    case Repo.one(from(a in Account, where: a.user_id == ^user_id and a.id == ^grant_id)) do
+    with {:ok, account} <- pinned_user_grant(grant_id, user_id, generation) do
+      case {user_credential(account), Keyword.get(opts, :refresh, true)} do
+        {{:error, :refresh_required}, true} ->
+          with :ok <- refresh_for_user(grant_id, user_id, generation) do
+            credential_for_user(grant_id, user_id, generation, refresh: false)
+          end
+
+        {result, _} ->
+          result
+      end
+    end
+  end
+
+  @doc "Internal renewal admission; returns only status, never a bearer."
+  @spec refresh_for_user(String.t(), String.t(), Ecto.UUID.t()) :: :ok | {:error, atom()}
+  def refresh_for_user(grant_id, user_id, generation)
+      when is_binary(grant_id) and is_binary(user_id) and is_binary(generation) do
+    with {:ok, account} <- pinned_user_grant(grant_id, user_id, generation),
+         :ok <- user_account_state(account) do
+      RefreshCoordinator.run(grant_id, user_id, generation)
+    end
+  end
+
+  @doc false
+  def refresh_serialized_for_user(grant_id, user_id, generation)
+      when is_binary(grant_id) and is_binary(user_id) and is_binary(generation) do
+    with {:ok, observed} <- pinned_user_grant(grant_id, user_id, generation),
+         :ok <- user_account_state(observed) do
+      grant_id
+      |> RefreshLock.run(fn -> refresh_user_locked(observed) end)
+      |> finish_refresh()
+    end
+  end
+
+  defp refresh_user_locked(observed) do
+    with {:ok, current} <- pinned_user_grant(observed.id, observed.user_id, observed.generation),
+         :ok <- user_account_state(current) do
+      cond do
+        current.lock_version != observed.lock_version -> :ok
+        fresh?(current) and not stale_for_keepalive?(current) -> :ok
+        true -> do_refresh(current)
+      end
+    end
+  end
+
+  defp user_credential(account) do
+    with :ok <- user_account_state(account) do
+      if fresh?(account) do
+        with {:ok, access_token} <- Cipher.decrypt_token(account, :access_token) do
+          {:ok, Grant.new(account, access_token)}
+        end
+      else
+        {:error, :refresh_required}
+      end
+    end
+  end
+
+  defp user_account_state(%Account{status: "revoked"}), do: {:error, :revoked}
+  defp user_account_state(%Account{status: "expired"}), do: {:error, :expired}
+
+  defp user_account_state(%Account{
+         status: "active",
+         kind: "chatgpt",
+         account_id: id,
+         refresh_token_ciphertext: cipher
+       })
+       when is_binary(id) and id != "" and is_binary(cipher) and byte_size(cipher) > 0,
+       do: :ok
+
+  defp user_account_state(_), do: {:error, :invalid_grant}
+
+  defp pinned_user_grant(grant_id, user_id, generation) do
+    case Repo.one(user_grant_query(grant_id, user_id)) do
       nil -> {:error, :not_connected}
-      %Account{generation: ^generation} = account -> user_credential(account)
+      %Account{generation: ^generation} = account -> {:ok, account}
       %Account{} -> {:error, :stale_grant}
     end
   end
 
-  defp user_credential(%Account{status: "revoked"}), do: {:error, :revoked}
-  defp user_credential(%Account{status: "expired"}), do: {:error, :expired}
-
-  defp user_credential(%Account{status: "active", kind: "chatgpt", account_id: id} = account)
-       when is_binary(id) and id != "" do
-    if fresh?(account) do
-      with {:ok, access_token} <- Cipher.decrypt_token(account, :access_token) do
-        {:ok, Grant.new(account, access_token)}
-      end
-    else
-      {:error, :refresh_required}
-    end
+  defp user_grant_query(grant_id, user_id) when is_binary(user_id) do
+    from(a in Account,
+      where: a.user_id == ^user_id and a.id == ^grant_id,
+      join: u in User,
+      on: u.id == a.user_id,
+      where: not u.principal and not is_nil(u.email_verified_at) and is_nil(u.suspended_at)
+    )
   end
-
-  defp user_credential(_), do: {:error, :invalid_grant}
 
   # Only a code `OAuth` itself names can reach a tenant: a reason that is not
   # one of those did not come from the paths that write this column, and the
@@ -530,6 +599,19 @@ defmodule Fountain.ChatGPTAccounts do
     {:error, :revoked}
   end
 
+  defp finish_refresh({:user_revoked, user_id, grant_id, generation, code}) do
+    Audit.record(%{
+      user_id: user_id,
+      actor: "system:chatgpt_accounts",
+      action: "chatgpt.reconnect_required",
+      resource_type: "chatgpt_grant",
+      resource_id: grant_id,
+      metadata: %{"generation" => generation, "reason" => code}
+    })
+
+    {:error, :revoked}
+  end
+
   defp finish_refresh(result), do: result
 
   defp do_refresh(current) do
@@ -539,20 +621,19 @@ defmodule Fountain.ChatGPTAccounts do
           # The rotated refresh token lands before the access token is
           # handed out: a crash between the two would otherwise leave the
           # row holding a refresh token the server has already retired.
-          swap_in(current, refresh_attrs(fresh), access)
+          with :ok <- validate_refresh_identity(current, fresh),
+               {:ok, attrs} <- refresh_attrs(current, fresh) do
+            swap_in(current, attrs, access)
+          end
 
         {:error, {:terminal, code}} ->
           case mark_revoked(current, code) do
-            :ok -> {:revoked, current.account_id, code}
+            :ok -> revoked_result(current, code)
             :stale -> current_result(current)
           end
 
         {:error, reason} ->
-          Logger.warning(
-            "platform chatgpt: refresh failed, keeping the current token: " <> inspect(reason)
-          )
-
-          {:error, reason}
+          refresh_error(current, reason)
       end
     end
   end
@@ -569,28 +650,38 @@ defmodule Fountain.ChatGPTAccounts do
       |> Repo.update_all(set: sets, inc: [lock_version: 1])
 
     case n do
-      1 -> {:ok, access}
+      1 -> refreshed_result(current, access)
       0 -> current_result(current)
     end
   end
 
   defp current_query(row) do
-    from(a in Account,
+    query =
+      if is_nil(row.user_id),
+        do: from(a in Account, where: is_nil(a.user_id)),
+        else: user_grant_query(row.id, row.user_id)
+
+    from(a in query,
       where:
-        is_nil(a.user_id) and a.id == ^row.id and a.generation == ^row.generation and
+        a.id == ^row.id and a.generation == ^row.generation and
           a.lock_version == ^row.lock_version and a.status == "active"
     )
   end
 
   defp current_result(previous) do
-    case platform_row() do
+    row =
+      if is_nil(previous.user_id),
+        do: platform_row(),
+        else: Repo.one(user_grant_query(previous.id, previous.user_id))
+
+    case row do
       nil ->
         {:error, :not_connected}
 
       %Account{id: id, generation: generation} = current
       when id == previous.id and generation == previous.generation ->
         case current.status do
-          "active" -> Cipher.decrypt_token(current, :access_token)
+          "active" -> current_active_result(current)
           "revoked" -> {:error, :revoked}
           "expired" -> {:error, :expired}
           other -> {:error, {:unknown_status, other}}
@@ -601,21 +692,68 @@ defmodule Fountain.ChatGPTAccounts do
     end
   end
 
-  defp refresh_attrs(%{access_token: access} = fresh) do
+  defp current_active_result(%Account{user_id: nil} = account),
+    do: Cipher.decrypt_token(account, :access_token)
+
+  defp current_active_result(account), do: user_account_state(account)
+
+  defp refreshed_result(%Account{user_id: nil}, access), do: {:ok, access}
+  defp refreshed_result(%Account{}, _access), do: :ok
+
+  defp revoked_result(%Account{user_id: nil} = account, code),
+    do: {:revoked, account.account_id, code}
+
+  defp revoked_result(account, code),
+    do: {:user_revoked, account.user_id, account.id, account.generation, code}
+
+  defp refresh_error(%Account{user_id: nil}, reason) do
+    Logger.warning(
+      "platform chatgpt: refresh failed, keeping the current token: " <> inspect(reason)
+    )
+
+    {:error, reason}
+  end
+
+  defp refresh_error(%Account{}, _reason) do
+    # Provider bodies can echo tokens. Neither queue replies nor logs carry
+    # that response; callers get a stable retryable error instead.
+    :telemetry.execute([:fountain, :chatgpt, :refresh, :failure], %{count: 1}, %{scope: :user})
+    {:error, :refresh_failed}
+  end
+
+  defp validate_refresh_identity(%Account{user_id: nil}, _fresh), do: :ok
+  defp validate_refresh_identity(_account, %{id_token: nil}), do: :ok
+
+  defp validate_refresh_identity(account, fresh) do
+    case fresh[:id_token] && Tokens.claims(fresh[:id_token]) do
+      nil ->
+        :ok
+
+      {:ok, claims} ->
+        same_user =
+          is_nil(account.id_claims["user_id"]) or
+            claims["user_id"] == account.id_claims["user_id"]
+
+        if claims["account_id"] == account.account_id and same_user,
+          do: :ok,
+          else: {:error, :account_mismatch}
+
+      _ ->
+        {:error, :account_mismatch}
+    end
+  end
+
+  defp refresh_attrs(current, fresh) do
+    with {:ok, encrypted} <- Cipher.encrypt_refresh_tokens(current, fresh) do
+      {:ok, Map.merge(refresh_metadata(fresh), encrypted)}
+    end
+  end
+
+  defp refresh_metadata(%{access_token: access} = fresh) do
     base = %{
-      access_token_ciphertext: Cipher.encrypt_platform_token(access),
       access_expires_at: Tokens.expires_at(access),
       last_refreshed_at: now()
     }
-
-    base =
-      case fresh[:refresh_token] do
-        rotated when is_binary(rotated) and rotated != "" ->
-          Map.put(base, :refresh_token_ciphertext, Cipher.encrypt_platform_token(rotated))
-
-        _ ->
-          base
-      end
 
     case fresh[:id_token] && Tokens.claims(fresh[:id_token]) do
       {:ok, claims} ->

--- a/apps/fountain/lib/fountain/chatgpt_accounts/cipher.ex
+++ b/apps/fountain/lib/fountain/chatgpt_accounts/cipher.ex
@@ -10,6 +10,40 @@ defmodule Fountain.ChatGPTAccounts.Cipher do
   # field-specific AAD, preventing token-field swaps and cross-owner copies.
   def encrypt_platform_token(token) when is_binary(token), do: Crypto.encrypt_platform(token)
 
+  @doc false
+  def encrypt_refresh_tokens(%Account{} = account, %{access_token: access} = tokens)
+      when is_binary(access) do
+    fields =
+      case tokens[:refresh_token] do
+        refresh when is_binary(refresh) and refresh != "" ->
+          %{access_token: access, refresh_token: refresh}
+
+        _ ->
+          %{access_token: access}
+      end
+
+    encrypt_fields(account.user_id, fields)
+  end
+
+  defp encrypt_fields(nil, fields) do
+    {:ok,
+     Map.new(fields, fn {field, token} ->
+       {ciphertext_field(field), encrypt_platform_token(token)}
+     end)}
+  end
+
+  defp encrypt_fields(user_id, fields) when is_binary(user_id) do
+    with {:ok, dek} <- Crypto.load_tenant_key(user_id) do
+      {:ok,
+       Map.new(fields, fn {field, token} ->
+         {ciphertext_field(field), Crypto.encrypt(token, dek, aad(user_id, field))}
+       end)}
+    end
+  end
+
+  defp ciphertext_field(:access_token), do: :access_token_ciphertext
+  defp ciphertext_field(:refresh_token), do: :refresh_token_ciphertext
+
   @spec encrypt_user_tokens(String.t(), map()) :: {:ok, map()} | {:error, atom()}
   def encrypt_user_tokens(user_id, %{access_token: access, refresh_token: refresh})
       when is_binary(user_id) and is_binary(access) and is_binary(refresh) do

--- a/apps/fountain/lib/fountain/chatgpt_accounts/refresh_coordinator.ex
+++ b/apps/fountain/lib/fountain/chatgpt_accounts/refresh_coordinator.ex
@@ -1,0 +1,137 @@
+defmodule Fountain.ChatGPTAccounts.RefreshCoordinator do
+  @moduledoc """
+  Bounded, node-local coalescing of user-grant refresh requests.
+
+  Workers receive only owner/grant/generation IDs and return only status.
+  Every caller re-reads its own pinned credential after renewal. No bearer,
+  encryption key or provider response is cached in the coordinator.
+
+  Same-generation callers share a worker. Other grants can run concurrently,
+  up to the supervisor's bound; excess work receives `:refresh_busy`. Each
+  grant has at most 128 waiting callers and every worker has a deadline.
+  PostgreSQL exclusion remains the cross-node authority.
+  """
+
+  use GenServer
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: Keyword.get(opts, :name, __MODULE__))
+  end
+
+  @doc false
+  def run(grant_id, user_id, generation, server \\ __MODULE__)
+      when is_binary(grant_id) and is_binary(user_id) and is_binary(generation) do
+    GenServer.call(server, {:refresh, {user_id, grant_id, generation}}, 30_000)
+  catch
+    :exit, _ -> {:error, :refresh_unavailable}
+  end
+
+  @impl true
+  def init(opts) do
+    {:ok,
+     %{
+       tasks: Keyword.fetch!(opts, :task_supervisor),
+       worker: Keyword.get(opts, :worker, Fountain.ChatGPTAccounts),
+       max_concurrency: Keyword.get(opts, :max_concurrency, 4),
+       max_waiters: Keyword.get(opts, :max_waiters, 128),
+       timeout: Keyword.get(opts, :worker_timeout, 27_000),
+       jobs: %{},
+       callers: %{}
+     }}
+  end
+
+  @impl true
+  def handle_call({:refresh, key}, from, state) do
+    case Map.fetch(state.jobs, key) do
+      {:ok, job} when map_size(job.waiters) < state.max_waiters ->
+        {:noreply, add_waiter(state, key, from)}
+
+      :error when map_size(state.jobs) < state.max_concurrency ->
+        start_worker(state, key, from)
+
+      _ ->
+        {:reply, {:error, :refresh_busy}, state}
+    end
+  end
+
+  @impl true
+  def handle_info({ref, result}, state) when is_reference(ref) do
+    case find_worker(state, ref) do
+      {key, _job} -> {:noreply, finish(state, key, safe_result(result))}
+      nil -> {:noreply, state}
+    end
+  end
+
+  def handle_info({:DOWN, ref, :process, _pid, _reason}, state) do
+    case find_worker(state, ref) do
+      {key, _job} -> {:noreply, finish(state, key, {:error, :refresh_unavailable})}
+      nil -> {:noreply, remove_waiter(state, ref)}
+    end
+  end
+
+  def handle_info({:refresh_timeout, ref}, state) do
+    case find_worker(state, ref) do
+      {key, job} ->
+        Task.shutdown(job.task, :brutal_kill)
+        {:noreply, finish(state, key, {:error, :refresh_timeout})}
+
+      nil ->
+        {:noreply, state}
+    end
+  end
+
+  defp start_worker(state, {user_id, grant_id, generation} = key, from) do
+    task =
+      Task.Supervisor.async_nolink(state.tasks, state.worker, :refresh_serialized_for_user, [
+        grant_id,
+        user_id,
+        generation
+      ])
+
+    timer = Process.send_after(self(), {:refresh_timeout, task.ref}, state.timeout)
+    state = put_in(state.jobs[key], %{task: task, timer: timer, waiters: %{}})
+    {:noreply, add_waiter(state, key, from)}
+  rescue
+    # The Task.Supervisor also enforces the cap while a worker is terminating.
+    RuntimeError -> {:reply, {:error, :refresh_busy}, state}
+  end
+
+  defp add_waiter(state, key, {pid, _tag} = from) do
+    ref = Process.monitor(pid)
+    state = put_in(state.jobs[key].waiters[ref], from)
+    put_in(state.callers[ref], key)
+  end
+
+  defp remove_waiter(state, ref) do
+    case Map.pop(state.callers, ref) do
+      {nil, _} ->
+        state
+
+      {key, callers} ->
+        # Keep a started exchange alive even if all callers leave: killing it
+        # after upstream rotation could lose the only valid refresh token.
+        state = update_in(state.jobs[key].waiters, &Map.delete(&1, ref))
+        %{state | callers: callers}
+    end
+  end
+
+  defp finish(state, key, result) do
+    {job, jobs} = Map.pop(state.jobs, key)
+    Process.cancel_timer(job.timer)
+    Process.demonitor(job.task.ref, [:flush])
+
+    for {ref, from} <- job.waiters do
+      Process.demonitor(ref, [:flush])
+      GenServer.reply(from, result)
+    end
+
+    %{state | jobs: jobs, callers: Map.drop(state.callers, Map.keys(job.waiters))}
+  end
+
+  defp find_worker(state, ref),
+    do: Enum.find(state.jobs, fn {_key, job} -> job.task.ref == ref end)
+
+  defp safe_result(:ok), do: :ok
+  defp safe_result({:error, reason}) when is_atom(reason), do: {:error, reason}
+  defp safe_result(_), do: {:error, :refresh_unavailable}
+end

--- a/apps/fountain/lib/fountain/chatgpt_accounts/refresh_lock.ex
+++ b/apps/fountain/lib/fountain/chatgpt_accounts/refresh_lock.ex
@@ -12,8 +12,8 @@ defmodule Fountain.ChatGPTAccounts.RefreshLock do
   events inside the transaction. Its result is returned only after commit.
   `run/3` must not itself be called inside a transaction: the lock would
   attach to the enclosing one and outlive the callback by however long that
-  transaction runs. The one caller is `Fountain.PlatformChatGPT.Refresher`,
-  which holds none.
+  transaction runs. The platform refresher and user refresh workers call it
+  without an enclosing transaction.
 
   Whatever the callback does upstream has to finish inside
   `@transaction_timeout`, which is a wall clock over the whole checkout

--- a/apps/fountain/lib/fountain/chatgpt_accounts/refresh_supervisor.ex
+++ b/apps/fountain/lib/fountain/chatgpt_accounts/refresh_supervisor.ex
@@ -1,0 +1,25 @@
+defmodule Fountain.ChatGPTAccounts.RefreshSupervisor do
+  @moduledoc false
+  use Supervisor
+
+  alias Fountain.ChatGPTAccounts.RefreshCoordinator
+
+  def start_link(opts \\ []), do: Supervisor.start_link(__MODULE__, opts, name: __MODULE__)
+
+  @impl true
+  def init(_opts) do
+    # Leave room for the platform refresher and ordinary queries. The user
+    # coordinator rejects excess work rather than parking it in the DB pool.
+    pool_size = Keyword.get(Fountain.Repo.config(), :pool_size, 10)
+    concurrency = min(4, max(1, pool_size - 2))
+
+    children = [
+      {Task.Supervisor, name: Fountain.ChatGPTAccounts.RefreshTasks, max_children: concurrency},
+      {RefreshCoordinator,
+       task_supervisor: Fountain.ChatGPTAccounts.RefreshTasks, max_concurrency: concurrency}
+    ]
+
+    # A coordinator restart must kill its old workers before admitting more.
+    Supervisor.init(children, strategy: :one_for_all)
+  end
+end

--- a/apps/fountain/lib/fountain/platform_chatgpt/account.ex
+++ b/apps/fountain/lib/fountain/platform_chatgpt/account.ex
@@ -7,7 +7,7 @@ defmodule Fountain.PlatformChatGPT.Account do
   `id_claims` holds the non-secret claims codex reads from its `id_token`.
 
   `kind` says what the row holds: `"chatgpt"` is a ChatGPT sign-in with a
-  rotating refresh token that `Fountain.PlatformChatGPT` owns;
+  rotating refresh token managed server-side by `Fountain.ChatGPTAccounts`;
   `"workspace_token"` is a static Business/Enterprise access token with no
   refresh token, which lapses on its admin-set expiry.
 
@@ -23,7 +23,7 @@ defmodule Fountain.PlatformChatGPT.Account do
   why the three that used to exist were removed rather than left unused.
 
   There is no plaintext column. User linking is not yet built; the current
-  application writers remain the admin surface and platform refresher.
+  application writers are the admin surface and the owner-scoped refreshers.
   """
 
   use Ecto.Schema

--- a/apps/fountain/test/fountain/chatgpt_accounts_test.exs
+++ b/apps/fountain/test/fountain/chatgpt_accounts_test.exs
@@ -192,7 +192,11 @@ defmodule Fountain.ChatGPTAccountsTest do
           {%{status: "active", account_id: nil}, :invalid_grant}
         ] do
       Account |> Repo.get!(grant.id) |> change(attrs) |> Repo.update!()
-      assert {:error, ^reason} = read(grant, owner)
+
+      assert {:error, ^reason} =
+               ChatGPTAccounts.credential_for_user(grant.id, owner.id, grant.generation,
+                 refresh: false
+               )
     end
   end
 
@@ -200,7 +204,11 @@ defmodule Fountain.ChatGPTAccountsTest do
     owner = insert_verified_user()
     expiry = Fountain.PlatformChatGPT.Tokens.expires_at(access_token(60))
     grant = user_grant(owner, %{access_expires_at: expiry})
-    assert {:error, :refresh_required} = read(grant, owner)
+
+    assert {:error, :refresh_required} =
+             ChatGPTAccounts.credential_for_user(grant.id, owner.id, grant.generation,
+               refresh: false
+             )
   end
 
   test "encryption refuses an owner without a tenant key" do

--- a/apps/fountain/test/fountain/chatgpt_refresh_coordinator_test.exs
+++ b/apps/fountain/test/fountain/chatgpt_refresh_coordinator_test.exs
@@ -1,0 +1,187 @@
+defmodule Fountain.ChatGPTRefreshCoordinatorTest do
+  use ExUnit.Case, async: true
+
+  alias Fountain.ChatGPTAccounts.RefreshCoordinator
+
+  defmodule Worker do
+    def refresh_serialized_for_user(grant_id, user_id, generation) do
+      [owner, _] = String.split(grant_id, "/", parts: 2)
+      owner = owner |> String.to_charlist() |> :erlang.list_to_pid()
+      send(owner, {:started, self(), user_id, generation})
+
+      receive do
+        {:finish, result} -> result
+        :crash -> raise "synthetic refresh worker failure"
+      after
+        5_000 -> raise "test worker barrier timed out"
+      end
+    end
+  end
+
+  setup tags do
+    tasks = start_supervised!({Task.Supervisor, max_children: 2})
+
+    server =
+      start_supervised!(
+        {RefreshCoordinator,
+         name: nil,
+         task_supervisor: tasks,
+         worker: Worker,
+         max_concurrency: 2,
+         max_waiters: Map.get(tags, :max_waiters, 128),
+         worker_timeout: Map.get(tags, :worker_timeout, 2_000)}
+      )
+
+    %{
+      server: server,
+      tasks: tasks,
+      grant: "#{:erlang.pid_to_list(self())}/#{Ecto.UUID.generate()}"
+    }
+  end
+
+  test "same-grant callers share a worker; the queue never stores its credential", ctx do
+    callers = for _ <- 1..8, do: call(ctx)
+    assert_receive {:started, worker, "owner", "generation"}
+    await_waiters(ctx.server, 8)
+    refute_received {:started, _, _, _}
+    send(worker, {:finish, :ok})
+    for caller <- callers, do: assert(:ok = Task.await(caller))
+    assert :sys.get_state(ctx.server).jobs == %{}
+    assert :sys.get_state(ctx.server).callers == %{}
+  end
+
+  test "another owner or generation cannot join an existing grant's worker", ctx do
+    first = call(ctx)
+    assert_receive {:started, first_worker, "owner", "generation"}
+    second = call(ctx, "other-owner", "generation")
+    assert_receive {:started, second_worker, "other-owner", "generation"}
+    refute first_worker == second_worker
+    send(second_worker, {:finish, :ok})
+    assert :ok = Task.await(second)
+    replacement = call(ctx, "owner", "new-generation")
+    assert_receive {:started, replacement_worker, "owner", "new-generation"}
+    send(first_worker, {:finish, {:error, :stale_grant}})
+    send(replacement_worker, {:finish, :ok})
+    assert {:error, :stale_grant} = Task.await(first)
+    assert :ok = Task.await(replacement)
+  end
+
+  test "the concurrency cap refuses excess grants and frees capacity on completion", ctx do
+    first = call(ctx)
+    assert_receive {:started, first_worker, _, _}
+    second_ctx = %{ctx | grant: ctx.grant <> "-second"}
+    second = call(second_ctx)
+    assert_receive {:started, second_worker, _, _}
+    third_ctx = %{ctx | grant: ctx.grant <> "-third"}
+    assert {:error, :refresh_busy} = Task.await(call(third_ctx))
+    refute_received {:started, _, _, _}
+    send(first_worker, {:finish, :ok})
+    assert :ok = Task.await(first)
+    third = call(third_ctx)
+    assert_receive {:started, third_worker, _, _}
+    send(second_worker, {:finish, :ok})
+    send(third_worker, {:finish, :ok})
+    assert :ok = Task.await(second)
+    assert :ok = Task.await(third)
+  end
+
+  test "the task supervisor cap also refuses admission without crashing the coordinator", ctx do
+    blockers =
+      for _ <- 1..2 do
+        {:ok, pid} = Task.Supervisor.start_child(ctx.tasks, fn -> Process.sleep(:infinity) end)
+        pid
+      end
+
+    assert {:error, :refresh_busy} = Task.await(call(ctx))
+    assert Process.alive?(ctx.server)
+    assert :sys.get_state(ctx.server).jobs == %{}
+    for pid <- blockers, do: Task.Supervisor.terminate_child(ctx.tasks, pid)
+    caller = call(ctx)
+    assert_receive {:started, worker, _, _}
+    send(worker, {:finish, :ok})
+    assert :ok = Task.await(caller)
+  end
+
+  @tag max_waiters: 2
+  test "waiting callers are capped, and departed callers release their slots", ctx do
+    first = call(ctx)
+    assert_receive {:started, worker, _, _}
+    second = call(ctx)
+    await_waiters(ctx.server, 2)
+    assert {:error, :refresh_busy} = Task.await(call(ctx))
+    Task.shutdown(second, :brutal_kill)
+    await_waiters(ctx.server, 1)
+    third = call(ctx)
+    await_waiters(ctx.server, 2)
+    send(worker, {:finish, :ok})
+    assert :ok = Task.await(first)
+    assert :ok = Task.await(third)
+  end
+
+  test "an exchange survives its last caller leaving and a later caller joins it", ctx do
+    first = call(ctx)
+    assert_receive {:started, worker, _, _}
+    Task.shutdown(first, :brutal_kill)
+    await_waiters(ctx.server, 0)
+    assert Process.alive?(worker)
+    second = call(ctx)
+    await_waiters(ctx.server, 1)
+    refute_received {:started, _, _, _}
+    send(worker, {:finish, :ok})
+    assert :ok = Task.await(second)
+  end
+
+  @tag capture_log: true
+  test "a worker crash releases callers and permits a fresh attempt", ctx do
+    first = call(ctx)
+    assert_receive {:started, worker, _, _}
+    second = call(ctx)
+    await_waiters(ctx.server, 2)
+    send(worker, :crash)
+    assert {:error, :refresh_unavailable} = Task.await(first)
+    assert {:error, :refresh_unavailable} = Task.await(second)
+    assert Process.alive?(ctx.server)
+    third = call(ctx)
+    assert_receive {:started, replacement, _, _}
+    send(replacement, {:finish, :ok})
+    assert :ok = Task.await(third)
+  end
+
+  @tag worker_timeout: 100
+  test "the deadline kills a stuck worker and releases its callers", ctx do
+    first = call(ctx)
+    assert_receive {:started, worker, _, _}
+    monitor = Process.monitor(worker)
+    assert {:error, :refresh_timeout} = Task.await(first)
+    assert_receive {:DOWN, ^monitor, :process, ^worker, _}
+    assert :sys.get_state(ctx.server).jobs == %{}
+    second = call(ctx)
+    assert_receive {:started, replacement, _, _}
+    send(replacement, {:finish, :ok})
+    assert :ok = Task.await(second)
+  end
+
+  test "unexpected worker values cannot be returned as credentials or provider bodies", ctx do
+    for result <- [{:ok, "synthetic-bearer"}, {:error, %{"echo" => "synthetic-refresh"}}] do
+      caller = call(ctx)
+      assert_receive {:started, worker, _, _}
+      send(worker, {:finish, result})
+      assert {:error, :refresh_unavailable} = Task.await(caller)
+      refute inspect(:sys.get_state(ctx.server)) =~ "synthetic"
+    end
+  end
+
+  defp call(ctx, user_id \\ "owner", generation \\ "generation") do
+    Task.async(fn -> RefreshCoordinator.run(ctx.grant, user_id, generation, ctx.server) end)
+  end
+
+  defp await_waiters(server, count, deadline \\ nil) do
+    deadline = deadline || System.monotonic_time(:millisecond) + 1_000
+
+    if map_size(:sys.get_state(server).callers) != count do
+      assert System.monotonic_time(:millisecond) < deadline, "waiter count did not reach #{count}"
+      Process.sleep(5)
+      await_waiters(server, count, deadline)
+    end
+  end
+end

--- a/apps/fountain/test/fountain/chatgpt_user_refresh_isolation_test.exs
+++ b/apps/fountain/test/fountain/chatgpt_user_refresh_isolation_test.exs
@@ -1,0 +1,272 @@
+defmodule Fountain.ChatGPTUserRefreshIsolationTest do
+  # Independent, committed transactions prove the tenant fences and lock.
+  use ExUnit.Case, async: false
+  use Mimic
+
+  import Ecto.Query
+  import Ecto.Changeset
+  import Fountain.ChatGPTFixtures
+
+  alias Fountain.Accounts.{User, UserDataKey}
+  alias Fountain.Audit.{AdminEvent, Event}
+  alias Fountain.ChatGPTAccounts
+  alias Fountain.ChatGPTAccounts.{Cipher, Grant}
+  alias Fountain.Crypto
+  alias Fountain.PlatformChatGPT
+  alias Fountain.PlatformChatGPT.Account
+  alias Fountain.Repo
+
+  setup_all do
+    %{repo: start_supervised!({Repo, name: nil, pool: DBConnection.ConnectionPool, pool_size: 4})}
+  end
+
+  setup %{repo: repo} do
+    Repo.put_dynamic_repo(repo)
+    users = for _ <- 1..2, do: insert_owner()
+    ids = Enum.map(users, & &1.id)
+    platform_id = "user-refresh-platform-#{Ecto.UUID.generate()}"
+    handler = "user-refresh-isolation-#{Ecto.UUID.generate()}"
+
+    :ok =
+      :telemetry.attach(
+        handler,
+        [:fountain, :chatgpt, :refresh_lock, :contention],
+        &__MODULE__.contending/4,
+        self()
+      )
+
+    on_exit(fn ->
+      :telemetry.detach(handler)
+      Repo.put_dynamic_repo(repo)
+      Repo.delete_all(from(e in Event, where: e.user_id in ^ids))
+
+      Repo.delete_all(
+        from(a in Account, where: a.user_id in ^ids or a.account_id == ^platform_id)
+      )
+
+      Repo.delete_all(from(u in User, where: u.id in ^ids))
+
+      Repo.delete_all(
+        from(e in AdminEvent, where: fragment("?->>'account_id'", e.metadata) == ^platform_id)
+      )
+    end)
+
+    %{users: users, platform_id: platform_id}
+  end
+
+  @doc false
+  def contending(_event, _measurements, _metadata, owner),
+    do: send(owner, {:contending, self(), Repo.checked_out?()})
+
+  test "two users and the platform renew independently while a same-grant contender waits", ctx do
+    [first_user, second_user] = ctx.users
+    first = user_grant!(first_user.id, %{refresh_token: "rt_first", account_id: "acct-first"})
+    second = user_grant!(second_user.id, %{refresh_token: "rt_second", account_id: "acct-second"})
+
+    platform =
+      connect!(%{
+        access_token: access_token(60),
+        refresh_token: "rt_platform",
+        account_id: ctx.platform_id
+      })
+
+    owner = self()
+
+    stub_auth(%{
+      "/oauth/token" => fn body ->
+        token = body["refresh_token"]
+        send(owner, {:upstream, self(), token})
+        barrier()
+
+        {200,
+         %{
+           "access_token" => access_token(7_200, %{"source" => token}),
+           "refresh_token" => token <> "-rotated"
+         }}
+      end
+    })
+
+    holder = refresh(ctx.repo, first)
+
+    try do
+      assert_receive {:upstream, holder_pid, "rt_first"}, 2_000
+      waiter = refresh(ctx.repo, first)
+      second_holder = refresh(ctx.repo, second)
+
+      platform_holder =
+        independent(ctx.repo, fn -> PlatformChatGPT.refresh_serialized(:if_stale) end)
+
+      try do
+        assert_receive {:contending, waiter_pid, false}, 2_000
+        assert waiter_pid == waiter.pid
+        assert_receive {:upstream, second_pid, "rt_second"}, 2_000
+        assert_receive {:upstream, platform_pid, "rt_platform"}, 2_000
+        send(second_pid, :release)
+        send(platform_pid, :release)
+        assert :ok = Task.await(second_holder)
+        assert {:ok, _platform_access} = Task.await(platform_holder)
+        assert Task.yield(holder, 0) == nil
+        send(holder_pid, :release)
+        assert :ok = Task.await(holder)
+        assert :ok = Task.await(waiter)
+        refute_received {:upstream, _, _}
+
+        for {original, refresh} <- [{first, "rt_first"}, {second, "rt_second"}] do
+          current = Repo.get!(Account, original.id)
+          assert current.lock_version == original.lock_version + 1
+          assert current.generation == original.generation
+          assert {:ok, rotated} = Cipher.decrypt_token(current, :refresh_token)
+          assert rotated == refresh <> "-rotated"
+
+          assert {:ok, %Grant{} = grant} =
+                   ChatGPTAccounts.credential_for_user(
+                     current.id,
+                     current.user_id,
+                     current.generation,
+                     refresh: false
+                   )
+
+          assert grant.source.account_id == original.account_id
+          assert grant.source.owner_scope == {:user, original.user_id}
+          assert grant.source.lock_version == current.lock_version
+          assert {:ok, access} = Cipher.decrypt_token(current, :access_token)
+          assert grant.access_token == access
+        end
+
+        assert Repo.get!(Account, platform.id).lock_version == platform.lock_version + 1
+      after
+        for task <- [waiter, second_holder, platform_holder],
+            do: Task.shutdown(task, :brutal_kill)
+      end
+    after
+      Task.shutdown(holder, :brutal_kill)
+    end
+  end
+
+  for mutation <- [:disconnect, :reconnect, :suspend], response <- [:success, :terminal] do
+    test "#{mutation} commits while an independent user #{response} response is pending", ctx do
+      user = hd(ctx.users)
+      account = user_grant!(user.id)
+      owner = self()
+
+      stub_auth(%{
+        "/oauth/token" => fn _ ->
+          send(owner, :refreshing)
+          barrier()
+
+          case unquote(response) do
+            :success ->
+              {200, %{"access_token" => access_token(7_200), "refresh_token" => "rt_late"}}
+
+            :terminal ->
+              {400, %{"error" => "invalid_grant"}}
+          end
+        end
+      })
+
+      holder = refresh(ctx.repo, account)
+
+      try do
+        assert_receive :refreshing, 2_000
+        mutate(unquote(mutation), user, account)
+        send(holder.pid, :release)
+        expected = if unquote(mutation) == :reconnect, do: :stale_grant, else: :not_connected
+        assert {:error, ^expected} = Task.await(holder)
+
+        case Repo.get(Account, account.id) do
+          nil ->
+            :ok
+
+          current ->
+            assert current.status == "active"
+            assert current.refresh_token_ciphertext == account.refresh_token_ciphertext
+        end
+
+        refute Repo.exists?(
+                 from(e in Event,
+                   where: e.action == "chatgpt.reconnect_required" and e.user_id == ^user.id
+                 )
+               )
+      after
+        Task.shutdown(holder, :brutal_kill)
+      end
+    end
+  end
+
+  test "tenant revocation commits before its best-effort audit", ctx do
+    account = user_grant!(hd(ctx.users).id)
+    stub_refusal()
+
+    expect(Fountain.Audit, :record, fn attrs ->
+      refute Repo.in_transaction?()
+      assert attrs.user_id == account.user_id
+
+      committed =
+        ctx.repo |> independent(fn -> Repo.get!(Account, account.id) end) |> Task.await()
+
+      assert committed.status == "revoked"
+      assert committed.lock_version == account.lock_version + 1
+      {:error, :unavailable}
+    end)
+
+    assert {:error, :revoked} =
+             ChatGPTAccounts.refresh_serialized_for_user(
+               account.id,
+               account.user_id,
+               account.generation
+             )
+
+    assert Repo.get!(Account, account.id).status == "revoked"
+  end
+
+  defp mutate(:disconnect, _user, account), do: Repo.delete!(account)
+
+  defp mutate(:reconnect, _user, account),
+    do: account |> Account.connect_changeset(%{}) |> Repo.update!()
+
+  defp mutate(:suspend, user, _account),
+    do:
+      user
+      |> change(suspended_at: DateTime.utc_now() |> DateTime.truncate(:second))
+      |> Repo.update!()
+
+  defp insert_owner do
+    user =
+      Repo.insert!(%User{
+        email: "refresh-#{Ecto.UUID.generate()}@example.test",
+        email_verified_at: DateTime.utc_now() |> DateTime.truncate(:second)
+      })
+
+    Repo.insert!(%UserDataKey{
+      user_id: user.id,
+      wrapped_key: Crypto.wrap_dek(Crypto.generate_dek())
+    })
+
+    user
+  end
+
+  defp refresh(repo, account),
+    do:
+      independent(repo, fn ->
+        ChatGPTAccounts.refresh_serialized_for_user(
+          account.id,
+          account.user_id,
+          account.generation
+        )
+      end)
+
+  defp independent(repo, fun) do
+    Task.async(fn ->
+      Repo.put_dynamic_repo(repo)
+      fun.()
+    end)
+  end
+
+  defp barrier do
+    receive do
+      :release -> :ok
+    after
+      5_000 -> raise "user refresh barrier timed out"
+    end
+  end
+end

--- a/apps/fountain/test/fountain/chatgpt_user_refresh_test.exs
+++ b/apps/fountain/test/fountain/chatgpt_user_refresh_test.exs
@@ -1,0 +1,234 @@
+defmodule Fountain.ChatGPTUserRefreshTest do
+  # The application coordinator and Req provider stub are shared processes.
+  use Fountain.DataCase, async: false
+  use Mimic
+
+  import Fountain.ChatGPTFixtures
+  import ExUnit.CaptureLog
+
+  alias Fountain.Audit.{AdminEvent, Event}
+  alias Fountain.ChatGPTAccounts
+  alias Fountain.ChatGPTAccounts.{Cipher, Grant, RefreshCoordinator}
+  alias Fountain.Crypto
+  alias Fountain.PlatformChatGPT.Account
+
+  test "a stale credential renews with its owner's DEK and returns the committed source" do
+    user = insert_verified_user()
+    account = user_grant!(user.id)
+    access = access_token(7_200, %{"renewed" => true})
+
+    stub_refresh(%{
+      expect_refresh: "rt_user",
+      access_token: access,
+      id_token: id_token(%{account_id: account.account_id})
+    })
+
+    assert {:ok, %Grant{} = grant} = credential(account)
+    assert grant.access_token == access
+    assert grant.source.owner_scope == {:user, user.id}
+    assert grant.source.generation == account.generation
+    assert grant.source.lock_version == account.lock_version + 1
+    current = Repo.get!(Account, account.id)
+    assert {:ok, "rt_rotated"} = Cipher.decrypt_token(current, :refresh_token)
+    assert :error = Crypto.decrypt_platform(current.refresh_token_ciphertext)
+    refute inspect(grant) =~ access
+    refute inspect(:sys.get_state(RefreshCoordinator)) =~ access
+  end
+
+  test "omitted rotation preserves the encrypted refresh token" do
+    account = user_grant!(insert_verified_user().id)
+    access = access_token(7_200)
+    stub_auth(%{"/oauth/token" => fn _ -> {200, %{"access_token" => access}} end})
+    assert {:ok, %Grant{access_token: ^access}} = credential(account)
+
+    assert Repo.get!(Account, account.id).refresh_token_ciphertext ==
+             account.refresh_token_ciphertext
+  end
+
+  test "simultaneous callers share one exchange and re-read their own credential" do
+    account = user_grant!(insert_verified_user().id)
+    owner = self()
+    access = access_token(7_200)
+
+    stub_auth(%{
+      "/oauth/token" => fn _ ->
+        send(owner, {:upstream, self()})
+        receive do: (:release -> :ok)
+        {200, %{"access_token" => access, "refresh_token" => "rt_rotated"}}
+      end
+    })
+
+    callers = for _ <- 1..6, do: Task.async(fn -> credential(account) end)
+    assert_receive {:upstream, worker}, 2_000
+    await_waiters(6)
+    refute_received {:upstream, _}
+    send(worker, :release)
+
+    for caller <- callers do
+      assert {:ok, %Grant{access_token: ^access, source: source}} = Task.await(caller)
+      assert source.grant_id == account.id
+      assert source.lock_version == account.lock_version + 1
+    end
+
+    refute_received {:upstream, _}
+  end
+
+  test "another owner, the platform row and a stale generation cannot initiate refresh" do
+    user = insert_verified_user()
+    other = insert_verified_user()
+    account = user_grant!(user.id)
+    platform = connect!(%{access_token: access_token(60)})
+    stub_auth(%{})
+
+    assert {:error, :not_connected} =
+             ChatGPTAccounts.refresh_for_user(account.id, other.id, account.generation)
+
+    assert {:error, :not_connected} =
+             ChatGPTAccounts.refresh_for_user(platform.id, user.id, platform.generation)
+
+    assert {:error, :stale_grant} =
+             ChatGPTAccounts.refresh_for_user(account.id, user.id, Ecto.UUID.generate())
+
+    assert_raise FunctionClauseError, fn ->
+      ChatGPTAccounts.refresh_for_user(account.id, nil, account.generation)
+    end
+
+    assert Repo.get!(Account, account.id).lock_version == account.lock_version
+  end
+
+  for attrs <- [
+        %{principal: true},
+        %{email_verified_at: nil},
+        %{suspended_at: ~U[2026-09-01 00:00:00Z]}
+      ] do
+    test "ineligible owner #{inspect(attrs)} cannot read or refresh a grant" do
+      user = insert_verified_user()
+      account = user_grant!(user.id, %{access_token: access_token(7_200)})
+      user |> change(unquote(Macro.escape(attrs))) |> Repo.update!()
+      stub_auth(%{})
+      assert {:error, :not_connected} = credential(account)
+
+      assert {:error, :not_connected} =
+               ChatGPTAccounts.refresh_for_user(account.id, user.id, account.generation)
+    end
+  end
+
+  test "transient provider errors retain the grant without echoing response secrets" do
+    account = user_grant!(insert_verified_user().id)
+    secret = "synthetic-provider-echo"
+
+    stub_auth(%{
+      "/oauth/token" => fn _ ->
+        {503, %{"error" => "unavailable", "error_description" => secret}}
+      end
+    })
+
+    log = capture_log(fn -> assert {:error, :refresh_failed} = credential(account) end)
+    refute log =~ secret
+    assert Repo.get!(Account, account.id) == account
+    refute Repo.exists?(from(e in Event, where: e.action == "chatgpt.reconnect_required"))
+  end
+
+  test "terminal refusal writes only a tenant reconnect-required event" do
+    account = user_grant!(insert_verified_user().id)
+    stub_refusal("invalid_grant")
+    assert {:error, :revoked} = credential(account)
+    current = Repo.get!(Account, account.id)
+    assert current.status == "revoked"
+    assert current.generation == account.generation
+    assert current.lock_version == account.lock_version + 1
+    event = Repo.one!(from(e in Event, where: e.action == "chatgpt.reconnect_required"))
+    assert event.user_id == account.user_id
+    assert event.actor == "system:chatgpt_accounts"
+    assert event.resource_id == account.id
+    assert event.metadata == %{"reason" => "invalid_grant", "generation" => account.generation}
+
+    refute Repo.exists?(
+             from(e in AdminEvent, where: e.event_type == "admin.platform_chatgpt.revoked")
+           )
+
+    assert {:error, :revoked} = credential(account)
+
+    assert Repo.aggregate(
+             from(e in Event, where: e.action == "chatgpt.reconnect_required"),
+             :count
+           ) == 1
+  end
+
+  for response <- [:success, :terminal] do
+    test "reconnect fences a late user #{response} response" do
+      account = user_grant!(insert_verified_user().id)
+
+      stub_auth(%{
+        "/oauth/token" => fn _ ->
+          account |> Account.connect_changeset(%{}) |> Repo.update!()
+
+          case unquote(response) do
+            :success ->
+              {200, %{"access_token" => access_token(7_200), "refresh_token" => "rt_late"}}
+
+            :terminal ->
+              {400, %{"error" => "invalid_grant"}}
+          end
+        end
+      })
+
+      assert {:error, :stale_grant} = credential(account)
+      current = Repo.get!(Account, account.id)
+      assert current.status == "active"
+      assert current.lock_version == account.lock_version + 1
+      assert current.refresh_token_ciphertext == account.refresh_token_ciphertext
+      refute Repo.exists?(from(e in Event, where: e.action == "chatgpt.reconnect_required"))
+    end
+  end
+
+  test "refresh cannot change the pinned provider account or provider user" do
+    account = user_grant!(insert_verified_user().id)
+
+    for claims <- [
+          %{account_id: "another-account"},
+          %{account_id: account.account_id, user_id: "another-user"}
+        ] do
+      stub_refresh(%{expect_refresh: "rt_user", id_token: id_token(claims)})
+      assert {:error, :account_mismatch} = credential(account)
+      assert Repo.get!(Account, account.id) == account
+    end
+  end
+
+  test "wrong key refuses renewal before contacting the provider" do
+    account = user_grant!(insert_verified_user().id)
+    stub_auth(%{})
+    key = Repo.get_by!(Fountain.Accounts.UserDataKey, user_id: account.user_id)
+    key |> change(wrapped_key: Crypto.wrap_dek(Crypto.generate_dek())) |> Repo.update!()
+    assert {:error, :undecryptable} = credential(account)
+    assert Repo.get!(Account, account.id) == account
+  end
+
+  test "renewal skips a recent grant but renews an idle grant with a still-fresh bearer" do
+    account = user_grant!(insert_verified_user().id, %{access_token: access_token(7_200)})
+    stub_auth(%{})
+    assert :ok = ChatGPTAccounts.refresh_for_user(account.id, account.user_id, account.generation)
+    account |> change(last_refreshed_at: ~U[2020-01-01 00:00:00Z]) |> Repo.update!()
+
+    stub_refresh(%{
+      expect_refresh: "rt_user",
+      id_token: id_token(%{account_id: account.account_id})
+    })
+
+    assert :ok = ChatGPTAccounts.refresh_for_user(account.id, account.user_id, account.generation)
+    assert Repo.get!(Account, account.id).lock_version == account.lock_version + 1
+  end
+
+  defp credential(account),
+    do: ChatGPTAccounts.credential_for_user(account.id, account.user_id, account.generation)
+
+  defp await_waiters(count, deadline \\ nil) do
+    deadline = deadline || System.monotonic_time(:millisecond) + 2_000
+
+    if map_size(:sys.get_state(RefreshCoordinator).callers) != count do
+      assert System.monotonic_time(:millisecond) < deadline
+      Process.sleep(5)
+      await_waiters(count, deadline)
+    end
+  end
+end

--- a/apps/fountain/test/fountain_web/metrics_test.exs
+++ b/apps/fountain/test/fountain_web/metrics_test.exs
@@ -181,8 +181,8 @@ defmodule FountainWeb.MetricsTest do
         # Audit.record_admin/1 rejection path (#451) — exercised by
         # Fountain.AuditTest's rejected-write telemetry test
         [:fountain, :audit, :admin_record_rejected],
-        # RefreshLock.attempt/4 contention path — exercised by
-        # Fountain.ChatGPTRefreshCoordinationTest's contender tests
+        # ChatGPTAccounts.RefreshLock.attempt/4, when another refresher owns
+        # the grant lock — exercised by ChatGPTRefreshCoordinationTest.
         [:fountain, :chatgpt, :refresh_lock, :contention],
         # Billing.record_usage/5 swallow path (#503) — exercised by
         # Fountain.UsageMeteringTest's dropped-usage telemetry test

--- a/apps/fountain/test/support/chatgpt_fixtures.ex
+++ b/apps/fountain/test/support/chatgpt_fixtures.ex
@@ -63,6 +63,36 @@ defmodule Fountain.ChatGPTFixtures do
     account
   end
 
+  @doc "A directly inserted user fixture; application linking remains unbuilt."
+  def user_grant!(user_id, opts \\ %{}) do
+    alias Fountain.ChatGPTAccounts.Cipher
+    alias Fountain.PlatformChatGPT.{Account, Tokens}
+
+    access = Map.get(opts, :access_token, access_token(60))
+    account_id = Map.get(opts, :account_id, "acct-user")
+
+    {:ok, encrypted} =
+      Cipher.encrypt_user_tokens(user_id, %{
+        access_token: access,
+        refresh_token: Map.get(opts, :refresh_token, "rt_user")
+      })
+
+    attrs =
+      Map.merge(encrypted, %{
+        kind: "chatgpt",
+        account_id: account_id,
+        plan_type: "pro",
+        id_claims: %{"account_id" => account_id, "user_id" => "user_1", "plan_type" => "pro"},
+        access_expires_at: Tokens.expires_at(access),
+        last_refreshed_at:
+          Map.get(opts, :last_refreshed_at, DateTime.utc_now() |> DateTime.truncate(:second))
+      })
+
+    %Account{user_id: user_id}
+    |> Account.connect_changeset(attrs)
+    |> Fountain.Repo.insert!()
+  end
+
   @doc """
   Stub `auth.openai.com`. `handlers` maps a request path to a function of
   the decoded JSON body returning `{status, body}`; a path with no handler


### PR DESCRIPTION
Near-expiry user ChatGPT grants currently return `:refresh_required`. This adds owner-scoped renewal through bounded workers, then re-reads the caller's pinned generation to return a matching bearer and source snapshot. It never falls through to platform or paid inference.

#2011–#2013 are merged. This PR is based directly on main. User linking, conversation selection, and account API/UI integration remain unbuilt. Keepalive scheduling follows separately in #2015.

- Coalesce callers by owner, grant ID and generation. Admit at most four user workers per node (fewer with a small DB pool), cap each grant at 128 waiters, and apply a 27-second worker deadline. The task supervisor enforces the cap too; coordinator restart tears down its workers. An exchange may finish after its last caller leaves so a rotated token can still be persisted.
- Workers and queue replies carry IDs/status only. After renewal each caller reads its own generation again; no bearer, key or provider response is cached by the coordinator.
- Share platform/user encryption and conditional-write mechanics without mixing ownership. Keep omitted refresh-token rotations intact; reject a changed provider account or user identity. First reads and writes require a verified, claimed, non-suspended owner.
- Re-read under the PostgreSQL refresh lock and fence writes by owner, ID, generation, version and active state. Transient provider errors become a stable retryable error without logging or returning the body. Terminal refusal emits one tenant `chatgpt.reconnect_required` event after commit, with no admin fallback event.

Validation:

- 31 new tests cover coalescing, capacity/waiter limits, worker crash/deadline, caller departure, token redaction, owner/DEK isolation, omitted rotation, source identity, transient and terminal failures, and eligibility. Real independent PostgreSQL connections prove two users and the platform renew separately, same-grant callers issue one exchange, disconnect/reconnect/suspension commit during provider I/O, and tenant audit runs after commit.
- The stale-user-credential test fails on the previous context with `:refresh_required`, and passes with this implementation. The initial synthetic coordinator fixture used Elixir's inspected PID form where Erlang's PID form was required; fixing that fixture made its tests pass. Precommit also identified one call-layout formatting correction, which was applied.
- Full `mix precommit` before rebasing: compile, formatting, Credo, Dialyzer, Sobelow, production release assembly, 5,514 core tests plus 6 doctests, 144 Buzz tests and 33 Support tests, zero failures (2 skipped / 7 excluded core cases).
- After rebasing onto the reviewed timeout/diagnostic fixes: all precommit static/release gates and 108 affected tests passed on `65aa52d8`, with zero failures.

- CI follow-up: the reviewed base added the refresh-lock contention metric but omitted its producer from the metrics test inventory. Registered the existing `RefreshLock.attempt/4` producer; its emission is already exercised by the independent-connection concurrency tests. The previously failing partition now passes all 772 tests and exports coverage on `757bfe02`.

The platform's existing local queue stays separate. PostgreSQL remains the cross-node authority; upstream rotation followed by a crash before commit still requires reconnect. `refresh: false` supports internal reads that must not initiate renewal.

## Landing validation

Rebased this PR’s two commits onto main `2fd1ee2785488ecaf26d3b3827bd01bfec5b22c2` after #2013 merged. Main had extracted the application child list into `children/0`; the conflict was resolved by retaining that structure and adding `Fountain.ChatGPTAccounts.RefreshSupervisor` immediately after the platform refresher. The application file is exactly main plus that one child. All other reviewed implementation is preserved; the metrics test also retains main’s existing CA-install metric entry. New head: `3f84c8ee`.

`mix precommit` passed on Elixir 1.19.2 / OTP 28.3 with fourteen affected ChatGPT, inference, admin, telemetry, and application-ordering test files on a dedicated database: **175 tests, zero failures**, plus compilation, formatting, strict Credo, Dialyzer (zero errors), Sobelow, and production release assembly. `git diff --check` passed. This local run selected the affected tests; fresh PR and merge-queue CI provide the complete suite against main.
