### PR TITLE
docs(conversations): record how the server size pin moves through a stack

### DIFF
--- a/apps/fountain/test/fountain/conversations/conversation_server_size_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_size_test.exs
@@ -6,9 +6,9 @@ defmodule Fountain.Conversations.ConversationServerSizeTest do
 
   Tracker #1369 refactors the server by subtraction: each sub-issue moves a
   function family into a module under `Fountain.Conversations.*` and lowers
-  `@pin` to the file's new length in the same PR. The pin is the file's line
-  count on `main` at the last move, so a change that makes the file longer
-  fails here and has to say why.
+  `@pin` to the file's new length in the PR that lands on `main` (see below
+  for a stack). The pin is the file's line count on `main` at the last move,
+  so a change that makes the file longer fails here and has to say why.
 
   The shape is the docs-style allowlist that only shrinks (#911): the number
   is not a target, it is a record of where the file is, and the only edit it
@@ -18,8 +18,9 @@ defmodule Fountain.Conversations.ConversationServerSizeTest do
   a number measured against a branch is stale the moment any link below it
   grows the file, which is what review rounds do. #1565 lowered it mid-stack to
   the tip's exact length, left zero headroom, and went red two rounds later
-  when a fix four PRs down added lines. Land the shrink first, then lower the
-  pin in a follow-up, when the number has stopped moving.
+  when a fix four PRs down added lines. That lowering was backed out before
+  merge. Land the shrink first, then lower the pin in a follow-up, when the
+  number has stopped moving.
 
   That is what this pin is mid-way through. #1749 and #1751 each lowered it
   to their own tip's exact length while the #1766/#1767 campaign was in


### PR DESCRIPTION
Clarifies when the ConversationServer size limit should be lowered: in the PR that lands the reduction on main, with separate guidance for a stack still in flight. It also records that #1565’s earlier mid-stack lowering was backed out before merge.

The diff changes only the test module’s documentation. It preserves main’s `@pin 2549`, the existing test assertion, and the newer campaign/headroom explanation. This addresses the earlier review’s concern about accidentally raising the limit.

Rebased onto main at `859f60c75989f46c33482f7e11a6a0f9ed0583cc`, resolving the overlapping documentation edits. The server at that base is 2,518 lines.

Validation on the rebased change:
- Existing size-limit test run directly through ExUnit on Elixir 1.19.2 / OTP 28.3: 1 test, 0 failures.
- Elixir formatting check and `git diff --check`: passed.
- Local `mix precommit` was attempted but could not proceed because the isolated worktree has no dependencies installed. Fresh PR CI on `cedef0a5` passed all expected jobs, including all six test partitions, coverage, static analysis, release/API contract checks, `CI required`, and secret scanning.

Refs #1565, #1891, #2032.

