### PR TITLE
refactor: select/4 returns a credential source, not an atom

### DIFF
--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -504,7 +504,7 @@ defmodule Fountain.Conversations.ConversationServer do
       # What the runtime's default_env/2 is handed (gate 3): the real
       # credentials, or placeholders when the conversation is brokered.
       env_credentials: %{},
-      # #1388; see `SpriteEnv.select_inference/2`, which decides both.
+      # #1388, ADR 0053: the `InferenceCredentials.Source` that ran this one.
       inference_source: nil,
       inference_model: nil,
       broker: nil,

--- a/apps/fountain/lib/fountain/conversations/sprite_env.ex
+++ b/apps/fountain/lib/fountain/conversations/sprite_env.ex
@@ -43,15 +43,23 @@ defmodule Fountain.Conversations.SpriteEnv do
   runtime's `default_env/2`, the redaction register — is untouched by the
   feature existing at all.
 
+  The first element is a `Fountain.InferenceCredentials.Source` (ADR 0053
+  decision 2), which the server holds for the conversation's lifetime and the
+  turn's usage stamp is derived from.
+
   `:no_credential` keeps the behaviour that predates platform keys: the
   conversation provisions anyway, and the provider's own auth failure lands
-  on the transcript rather than a refusal invented here.
+  on the transcript rather than a refusal invented here. Nothing served the
+  turn and the deployment is not paying for it, so the source is
+  `Source.missing/0` — `origin: :own`, exactly what this case resolved to
+  before the struct existed.
 
   `runtime` is the conversation's own (`conv.runtime`), which is what the
   sandbox is dispatched on and can differ from the agent's after an edit;
   nil falls back to the agent's.
   """
-  @spec select_inference(map() | nil, map(), String.t() | nil) :: {:own | :platform, map()}
+  @spec select_inference(map() | nil, map(), String.t() | nil) ::
+          {InferenceCredentials.Source.t(), map()}
   def select_inference(agent, own_creds, runtime \\ nil) do
     brokered? = (agent && Fountain.Broker.enabled_for?(agent.user_id)) || false
     runtime = runtime || (agent && agent.runtime)
@@ -60,7 +68,7 @@ defmodule Fountain.Conversations.SpriteEnv do
            brokered: brokered?
          ) do
       {:ok, source, creds} -> {source, creds}
-      {:error, :no_credential} -> {:own, own_creds}
+      {:error, :no_credential} -> {InferenceCredentials.Source.missing(), own_creds}
     end
   end
 

--- a/apps/fountain/lib/fountain/conversations/turn_machine.ex
+++ b/apps/fountain/lib/fountain/conversations/turn_machine.ex
@@ -51,6 +51,7 @@ defmodule Fountain.Conversations.TurnMachine do
 
   alias Fountain.{Agents, Conversations}
   alias Fountain.Conversations.{Conversation, Labels}
+  alias Fountain.InferenceCredentials.Source
   alias Fountain.PermissionPolicy
 
   @typedoc "What the peer reports about a turn, with the command ref already matched."
@@ -61,14 +62,15 @@ defmodule Fountain.Conversations.TurnMachine do
   connection family's predicate, read by the server), `:runtime_module`
   (the OAuth clause is Claude-only), `:oauth_switched?` (the server
   swaps the env before the call; the machine words the message), and the
-  pair the usage stamp needs — `:inference` (`:own` | `:platform`, whose key
-  ran this turn, #1388) and `:model` (what it ran).
+  pair the usage stamp needs — `:inference` (the
+  `Fountain.InferenceCredentials.Source` whose key ran this turn, #1388 and
+  ADR 0053) and `:model` (what it ran).
   """
   @type ctx :: %{
           optional(:autonomous?) => boolean(),
           optional(:runtime_module) => module(),
           optional(:oauth_switched?) => boolean(),
-          optional(:inference) => :own | :platform | nil,
+          optional(:inference) => Fountain.InferenceCredentials.Source.t() | nil,
           optional(:model) => String.t() | nil
         }
 
@@ -877,12 +879,12 @@ defmodule Fountain.Conversations.TurnMachine do
   @spec with_inference(map() | nil, ctx()) :: map() | nil
   def with_inference(usage, ctx) when is_map(usage) do
     case Map.get(ctx, :inference) do
-      :platform ->
+      %Source{origin: :platform} ->
         usage
         |> Map.put("inference", "platform")
         |> put_model(:platform, Map.get(ctx, :model))
 
-      :own ->
+      %Source{origin: :own} ->
         if Fountain.PlatformInference.enabled?(),
           do: Map.put(usage, "inference", "own"),
           else: usage
@@ -1042,11 +1044,11 @@ defmodule Fountain.Conversations.TurnMachine do
   # gate: a live server outlives the ceiling it started under exactly as it
   # outlives the balance, so the same backstop shape applies. A turn on the
   # tenant's own key is never touched by it.
-  @spec gate(String.t(), :own | :platform | nil) :: :ok | {:error, term()}
+  @spec gate(String.t(), Source.t() | nil) :: :ok | {:error, term()}
   def gate(user_id, inference \\ nil) do
     with :ok <- Fountain.Accounts.check_not_suspended(user_id),
          :ok <- Fountain.Billing.check_spend(user_id) do
-      if inference == :platform,
+      if Source.platform?(inference),
         do: Fountain.PlatformInference.check_ceiling(),
         else: :ok
     end

--- a/apps/fountain/lib/fountain/inference_credentials.ex
+++ b/apps/fountain/lib/fountain/inference_credentials.ex
@@ -17,6 +17,7 @@ defmodule Fountain.InferenceCredentials do
   alias Fountain.Audit
   alias Fountain.Crypto
   alias Fountain.InferenceCredentials.Credential
+  alias Fountain.InferenceCredentials.Source
   alias Fountain.Repo
 
   @providers Credential.providers()
@@ -226,14 +227,15 @@ defmodule Fountain.InferenceCredentials do
   decision 3). **This is the whole selection rule**, and it is one function so
   that the two paths a credential reaches a sandbox by cannot disagree.
 
-    * `{:ok, :own, creds}` — the tenant has a credential the model's provider
-      accepts, or the provider needs none. `creds` is what came in, untouched.
-    * `{:ok, :platform, creds}` — the tenant has none and this deployment
-      holds a platform key for that provider. `creds` is what came in with the
-      platform key merged in under the provider's credential, so everything
-      downstream — the broker split, the runtime's `default_env/2`, the
-      redaction register — treats it as exactly what it is: a credential for
-      that provider.
+    * `{:ok, %Source{origin: :own}, creds}` — the tenant has a credential the
+      model's provider accepts, or the provider needs none. `creds` is what
+      came in, untouched. The source's `scope` says which of the two it was.
+    * `{:ok, %Source{origin: :platform}, creds}` — the tenant has none and
+      this deployment holds a platform key for that provider. `creds` is what
+      came in with the platform key merged in under the provider's credential,
+      so everything downstream — the broker split, the runtime's
+      `default_env/2`, the redaction register — treats it as exactly what it
+      is: a credential for that provider.
     * `{:error, :no_credential}` — neither. The caller keeps today's
       behaviour, which is to provision anyway and let the runtime report the
       provider's own auth failure on the transcript.
@@ -267,8 +269,7 @@ defmodule Fountain.InferenceCredentials do
   auth server.
   """
   @spec select(String.t() | nil, %{atom() => String.t()}, String.t() | nil, keyword()) ::
-          {:ok, :own, %{atom() => String.t()}}
-          | {:ok, :platform, %{atom() => String.t()}}
+          {:ok, Source.t(), %{atom() => String.t()}}
           | {:error, :no_credential}
   def select(model, own_creds, runtime \\ nil, opts \\ []) when is_map(own_creds) do
     provider = Managoat.Runtimes.Model.provider(model)
@@ -276,14 +277,14 @@ defmodule Fountain.InferenceCredentials do
 
     cond do
       accepted == [] ->
-        {:ok, :own, own_creds}
+        {:ok, Source.none(), own_creds}
 
       Enum.any?(accepted, &present?(own_creds, &1)) ->
-        {:ok, :own, own_creds}
+        {:ok, Source.credential(), own_creds}
 
       true ->
         case platform_credential(provider, runtime, Keyword.get(opts, :brokered, true), opts) do
-          {:ok, credential, key} -> {:ok, :platform, Map.put(own_creds, credential, key)}
+          {:ok, credential, key} -> {:ok, Source.platform(), Map.put(own_creds, credential, key)}
           :none -> {:error, :no_credential}
         end
     end

--- a/apps/fountain/lib/fountain/inference_credentials/source.ex
+++ b/apps/fountain/lib/fountain/inference_credentials/source.ex
@@ -1,0 +1,90 @@
+defmodule Fountain.InferenceCredentials.Source do
+  @moduledoc """
+  Which credential served a conversation, and where it came from (ADR 0053
+  decision 2).
+
+  `Fountain.InferenceCredentials.select/4` returns one of these instead of a
+  bare `:own | :platform`. The conversation holds it for its lifetime and the
+  turn's usage stamp is derived from it, so the answer to "whose key paid for
+  this turn" is decided once and read everywhere.
+
+  Two fields, because two fields have readers:
+
+    * `origin` — the billing question, in the vocabulary the ledger already
+      uses. `:platform` prices the turn against the tenant's credits and
+      counts it against the deployment's daily ceiling; `:own` does neither.
+    * `scope` — where the value came from. `:credential` an
+      `inference_credentials` row, `:platform` a platform key or the
+      deployment's ChatGPT grant, `:none` a provider that needs no credential
+      at all (a local model, a gateway), `:missing` a provider that needs one
+      where neither the tenant nor the deployment has it.
+
+  `:none` and `:missing` are both `origin: :own` and are both what `main`
+  called `:own` before this struct existed, so nothing about billing moves.
+  They are separate because they are opposite answers to "is anything wrong
+  here": a local model needs no key, and a conversation with no key for a
+  provider that requires one will fail inside the sandbox. Keeping them apart
+  is what lets a surface say which without asking the question again.
+
+  `origin` and `scope` are not the same question. ADR 0053 decision 5 adds
+  `:tenant_secret`, an environment or vault secret naming a credential, which
+  is `origin: :own` and needs to stay distinguishable from a credential row
+  for anything that reports where a turn ran.
+
+  **There is deliberately no `kind`.** A field naming the credential atom that
+  served the turn would have to guess how the runtime chose between an
+  account's credentials, and the runtimes disagree: `Managoat.Runtimes.Claude`
+  prefers `CLAUDE_CODE_OAUTH_TOKEN` and never exports the API key beside it,
+  while `Managoat.Runtimes.OpenCode` reads only the API key for the same
+  provider. Any derivation here would state the wrong credential for an
+  account holding both. It belongs to whichever change first needs to bill or
+  report per credential, with a derivation that matches the runtime. ADR 0052
+  decision 4 adds `grant_id` and `generation` to this struct for the same
+  reason: a field arrives with its reader.
+  """
+
+  @type origin :: :own | :platform
+  @type scope :: :credential | :platform | :none | :missing
+
+  @type t :: %__MODULE__{origin: origin(), scope: scope()}
+
+  @enforce_keys [:origin, :scope]
+  defstruct [:origin, :scope]
+
+  @doc "The tenant's own credential row served this conversation."
+  @spec credential() :: t()
+  def credential, do: %__MODULE__{origin: :own, scope: :credential}
+
+  @doc """
+  The model's provider needs no credential — a local model, a gateway, or a
+  provider Fountain does not know. Nothing is missing and nothing is
+  platform-paid.
+  """
+  @spec none() :: t()
+  def none, do: %__MODULE__{origin: :own, scope: :none}
+
+  @doc "This deployment's platform key, or its ChatGPT grant, served it."
+  @spec platform() :: t()
+  def platform, do: %__MODULE__{origin: :platform, scope: :platform}
+
+  @doc """
+  The model's provider needs a credential and nobody has one.
+
+  The conversation still provisions — that predates platform keys and is
+  deliberate, because the provider's own auth error on the transcript says
+  more than a refusal invented here. `origin: :own` because the deployment is
+  not paying for a turn nothing served.
+  """
+  @spec missing() :: t()
+  def missing, do: %__MODULE__{origin: :own, scope: :missing}
+
+  @doc """
+  Whether the deployment pays for this conversation's inference.
+
+  The one question the ledger and the daily ceiling ask. Written here so a
+  call site reads what it means rather than comparing an atom.
+  """
+  @spec platform?(t() | nil) :: boolean()
+  def platform?(%__MODULE__{origin: :platform}), do: true
+  def platform?(_), do: false
+end

--- a/apps/fountain/test/fountain/conversations/conversation_server_platform_inference_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_platform_inference_test.exs
@@ -7,6 +7,7 @@ defmodule Fountain.Conversations.ConversationServerPlatformInferenceTest do
   use Fountain.ConversationServerCase
 
   alias Fountain.Conversations.TurnMachine
+  alias Fountain.InferenceCredentials.Source
 
   @session %{vault: "c-test", token: "av_sess_conv", expires_at: nil}
   @platform_key "sk-ant-platform-key"
@@ -86,7 +87,7 @@ defmodule Fountain.Conversations.ConversationServerPlatformInferenceTest do
       on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
 
       state = :sys.get_state(pid)
-      assert state.inference_source == :own
+      assert state.inference_source == Source.credential()
       assert state.env_credentials == %{anthropic_api_key: "sk-ant-tenant-key"}
     end
   end
@@ -144,13 +145,13 @@ defmodule Fountain.Conversations.ConversationServerPlatformInferenceTest do
       on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
 
       state = :sys.get_state(pid)
-      assert state.inference_source == :platform
+      assert state.inference_source == Source.platform()
       assert state.inference_model == "anthropic/claude-opus-5"
       assert state.env_credentials.anthropic_api_key == @platform_key
     end
 
     test "usage says which key ran the turn, and names the model on a platform turn" do
-      ctx = %{inference: :platform, model: "anthropic/claude-opus-5"}
+      ctx = %{inference: Source.platform(), model: "anthropic/claude-opus-5"}
 
       assert TurnMachine.with_inference(%{"input" => 5, "output" => 3}, ctx) ==
                %{
@@ -160,7 +161,7 @@ defmodule Fountain.Conversations.ConversationServerPlatformInferenceTest do
                  "model" => "anthropic/claude-opus-5"
                }
 
-      assert TurnMachine.with_inference(%{"input" => 5}, %{ctx | inference: :own}) ==
+      assert TurnMachine.with_inference(%{"input" => 5}, %{ctx | inference: Source.credential()}) ==
                %{"input" => 5, "inference" => "own"}
 
       assert TurnMachine.with_inference(nil, ctx) == nil
@@ -169,7 +170,7 @@ defmodule Fountain.Conversations.ConversationServerPlatformInferenceTest do
     test "with no platform key configured the usage map is untouched" do
       Application.delete_env(:fountain, :platform_anthropic_api_key)
 
-      ctx = %{inference: :own, model: "anthropic/claude-opus-5"}
+      ctx = %{inference: Source.credential(), model: "anthropic/claude-opus-5"}
       assert TurnMachine.with_inference(%{"input" => 5}, ctx) == %{"input" => 5}
     end
   end
@@ -253,7 +254,7 @@ defmodule Fountain.Conversations.ConversationServerPlatformInferenceTest do
       machine: m,
       row: row
     } do
-      ctx = %{platform_ctx() | inference: :own}
+      ctx = %{platform_ctx() | inference: Source.credential()}
       {_m, []} = select_model(m, ctx)
 
       assert stored(row).usage == %{"inference" => "own"}
@@ -263,7 +264,7 @@ defmodule Fountain.Conversations.ConversationServerPlatformInferenceTest do
     test "an own-credential turn without platform keys stamps nothing", %{machine: m, row: row} do
       Application.delete_env(:fountain, :platform_anthropic_api_key)
 
-      {_m, []} = select_model(m, %{platform_ctx() | inference: :own})
+      {_m, []} = select_model(m, %{platform_ctx() | inference: Source.credential()})
       assert is_nil(stored(row).usage)
     end
 
@@ -309,7 +310,7 @@ defmodule Fountain.Conversations.ConversationServerPlatformInferenceTest do
     refute Fountain.PlatformInference.enabled?()
     model = "openai/gpt-6-astra"
 
-    assert {:ok, :platform = source, credentials} =
+    assert {:ok, %Fountain.InferenceCredentials.Source{origin: :platform} = source, credentials} =
              Fountain.InferenceCredentials.select(model, %{}, "codex", refresh: false)
 
     assert Map.has_key?(credentials, :codex_chatgpt_access_token)
@@ -343,7 +344,7 @@ defmodule Fountain.Conversations.ConversationServerPlatformInferenceTest do
            }
   end
 
-  defp platform_ctx, do: %{inference: :platform, model: "anthropic/claude-opus-5"}
+  defp platform_ctx, do: %{inference: Source.platform(), model: "anthropic/claude-opus-5"}
 
   # What `Managoat.ACP.Peer` reports from `send_prompt/1`, just before it
   # writes `session/prompt`.

--- a/apps/fountain/test/fountain/conversations/sprite_env_inference_test.exs
+++ b/apps/fountain/test/fountain/conversations/sprite_env_inference_test.exs
@@ -1,0 +1,91 @@
+defmodule Fountain.Conversations.SpriteEnvInferenceTest do
+  @moduledoc """
+  `SpriteEnv.select_inference/3` and the source it resolves (ADR 0053).
+
+  `async: false`, and in its own module rather than beside the rest of
+  `SpriteEnvTest`: the platform keys live in the global application
+  environment, so a module that writes them races every module that reads
+  them, and a module that only reads them races anything that writes (#1214).
+  """
+
+  use Fountain.DataCase, async: false
+
+  alias Fountain.Conversations.SpriteEnv
+  alias Fountain.InferenceCredentials.Source
+
+  @anthropic "anthropic/claude-opus-5"
+
+  setup do
+    previous =
+      for key <- [:platform_anthropic_api_key, :platform_openai_api_key, :platform_gemini_api_key],
+          do: {key, Application.get_env(:fountain, key)}
+
+    for {key, _} <- previous, do: Application.delete_env(:fountain, key)
+
+    on_exit(fn ->
+      for {key, value} <- previous do
+        if is_nil(value),
+          do: Application.delete_env(:fountain, key),
+          else: Application.put_env(:fountain, key, value)
+      end
+    end)
+
+    %{user: insert_verified_user()}
+  end
+
+  defp agent_on(user, model), do: insert_agent(user_id: user.id, runtime: "claude", model: model)
+
+  describe "select_inference/3" do
+    test "the tenant's own credential is scope :credential", %{user: user} do
+      own = %{anthropic_api_key: "sk-tenant"}
+
+      assert {%Source{origin: :own, scope: :credential}, ^own} =
+               SpriteEnv.select_inference(agent_on(user, @anthropic), own)
+    end
+
+    test "the deployment's key is :platform, merged in under the provider's credential",
+         %{user: user} do
+      Application.put_env(:fountain, :platform_anthropic_api_key, "sk-platform")
+
+      assert {%Source{origin: :platform, scope: :platform}, creds} =
+               SpriteEnv.select_inference(agent_on(user, @anthropic), %{})
+
+      assert creds.anthropic_api_key == "sk-platform"
+    end
+
+    test "the tenant's own credential still wins over a configured platform key", %{user: user} do
+      Application.put_env(:fountain, :platform_anthropic_api_key, "sk-platform")
+      own = %{anthropic_api_key: "sk-tenant"}
+
+      assert {%Source{origin: :own}, ^own} =
+               SpriteEnv.select_inference(agent_on(user, @anthropic), own)
+    end
+  end
+
+  # The two halves of what used to be one `:own`. Both keep `origin: :own`, so
+  # neither is platform-paid and the usage stamp is byte-for-byte what it was.
+  # They are separate because they are opposite answers to "is anything wrong
+  # here", and only the source can tell a surface which.
+  describe "select_inference/3 with no credential anywhere" do
+    # A bare map, not a persisted agent: `Agent.changeset/2` refuses a model
+    # whose provider is not one of the three Fountain holds a credential for
+    # (#554), so no row can carry `ollama/`. `select_inference/3` takes a map
+    # by contract and the case is still reachable — a provider that stops
+    # being known, or a gateway model reaching selection by another door.
+    test "a provider that needs none is :none", %{user: user} do
+      agent = %{user_id: user.id, runtime: "opencode", model: "ollama/llama3"}
+
+      assert {%Source{origin: :own, scope: :none}, %{}} = SpriteEnv.select_inference(agent, %{})
+    end
+
+    test "a conversation with no agent needs none either" do
+      assert {%Source{origin: :own, scope: :none}, %{}} = SpriteEnv.select_inference(nil, %{})
+    end
+
+    test "a provider that needs one nobody has is :missing, and still provisions",
+         %{user: user} do
+      assert {%Source{origin: :own, scope: :missing}, %{}} =
+               SpriteEnv.select_inference(agent_on(user, @anthropic), %{})
+    end
+  end
+end

--- a/apps/fountain/test/fountain/platform_chatgpt_test.exs
+++ b/apps/fountain/test/fountain/platform_chatgpt_test.exs
@@ -22,6 +22,7 @@ defmodule Fountain.PlatformChatGPTTest do
   alias Fountain.Conversations.Egress
   alias Fountain.Crypto
   alias Fountain.InferenceCredentials
+  alias Fountain.InferenceCredentials.Source
   alias Fountain.PlatformChatGPT
   alias Fountain.PlatformChatGPT.Account
   alias Fountain.PlatformInference
@@ -144,7 +145,7 @@ defmodule Fountain.PlatformChatGPTTest do
       # No stub for /oauth/token: a refresh here would raise.
       assert PlatformChatGPT.credential(refresh: false) == {:ok, stale}
 
-      assert {:ok, :platform, %{codex_chatgpt_access_token: ^stale}} =
+      assert {:ok, %Source{origin: :platform}, %{codex_chatgpt_access_token: ^stale}} =
                InferenceCredentials.select("openai/gpt-5.5-codex", %{}, "codex", refresh: false)
 
       stub_refusal()
@@ -394,10 +395,11 @@ defmodule Fountain.PlatformChatGPTTest do
       connect!(%{access_token: access})
 
       assert InferenceCredentials.select("openai/gpt-5.5-codex", %{}, "codex") ==
-               {:ok, :platform, %{codex_chatgpt_access_token: access}}
+               {:ok, Source.platform(), %{codex_chatgpt_access_token: access}}
 
       # The tenant's other credentials survive the merge.
-      assert {:ok, :platform, %{anthropic_api_key: "sk-ant", codex_chatgpt_access_token: ^access}} =
+      assert {:ok, %Source{origin: :platform},
+              %{anthropic_api_key: "sk-ant", codex_chatgpt_access_token: ^access}} =
                InferenceCredentials.select(
                  "openai/gpt-5.5-codex",
                  %{anthropic_api_key: "sk-ant"},
@@ -414,13 +416,15 @@ defmodule Fountain.PlatformChatGPTTest do
       Application.put_env(:fountain, :platform_openai_api_key, "sk-platform")
 
       assert InferenceCredentials.select("openai/gpt-5.5-codex", %{}, "codex", brokered: false) ==
-               {:ok, :platform, %{openai_api_key: "sk-platform"}}
+               {:ok, Source.platform(), %{openai_api_key: "sk-platform"}}
     end
 
     test "the tenant's own OpenAI key always wins" do
       connect!()
       own = %{openai_api_key: "sk-mine"}
-      assert {:ok, :own, ^own} = InferenceCredentials.select("openai/gpt-5.5-codex", own, "codex")
+
+      assert {:ok, %Source{origin: :own, scope: :credential}, ^own} =
+               InferenceCredentials.select("openai/gpt-5.5-codex", own, "codex")
     end
 
     test "opencode on an openai model never takes the grant" do
@@ -432,10 +436,10 @@ defmodule Fountain.PlatformChatGPTTest do
       Application.put_env(:fountain, :platform_openai_api_key, "sk-platform")
 
       assert InferenceCredentials.select("openai/gpt-5.5", %{}, "opencode") ==
-               {:ok, :platform, %{openai_api_key: "sk-platform"}}
+               {:ok, Source.platform(), %{openai_api_key: "sk-platform"}}
 
       assert InferenceCredentials.select("openai/gpt-5.5", %{}) ==
-               {:ok, :platform, %{openai_api_key: "sk-platform"}}
+               {:ok, Source.platform(), %{openai_api_key: "sk-platform"}}
     end
 
     test "a revoked grant falls through to the platform key, and to nothing" do
@@ -444,7 +448,7 @@ defmodule Fountain.PlatformChatGPTTest do
       Application.put_env(:fountain, :platform_openai_api_key, "sk-platform")
 
       assert InferenceCredentials.select("openai/gpt-5.5-codex", %{}, "codex") ==
-               {:ok, :platform, %{openai_api_key: "sk-platform"}}
+               {:ok, Source.platform(), %{openai_api_key: "sk-platform"}}
 
       Application.delete_env(:fountain, :platform_openai_api_key)
 

--- a/apps/fountain/test/fountain/platform_inference_test.exs
+++ b/apps/fountain/test/fountain/platform_inference_test.exs
@@ -13,6 +13,7 @@ defmodule Fountain.PlatformInferenceTest do
 
   alias Fountain.Credits
   alias Fountain.InferenceCredentials
+  alias Fountain.InferenceCredentials.Source
   alias Fountain.PlatformInference
 
   setup do
@@ -92,7 +93,7 @@ defmodule Fountain.PlatformInferenceTest do
       assert PlatformInference.key_for("google") == {:ok, :gemini_api_key, "AIza-stored"}
 
       assert InferenceCredentials.select("google/gemini-3.1-pro-preview", %{}) ==
-               {:ok, :platform, %{gemini_api_key: "AIza-stored"}}
+               {:ok, Source.platform(), %{gemini_api_key: "AIza-stored"}}
 
       :ok = PlatformInference.clear_key("google")
       refute PlatformInference.enabled?()
@@ -199,21 +200,25 @@ defmodule Fountain.PlatformInferenceTest do
       with_platform_key()
       own = %{anthropic_api_key: "sk-tenant"}
 
-      assert {:ok, :own, ^own} = InferenceCredentials.select("anthropic/claude-opus-5", own)
+      assert {:ok, %Source{origin: :own, scope: :credential}, ^own} =
+               InferenceCredentials.select("anthropic/claude-opus-5", own)
     end
 
     test "an OAuth token is a credential for anthropic and wins too" do
       with_platform_key()
       own = %{claude_code_oauth_token: "oauth"}
 
-      assert {:ok, :own, ^own} = InferenceCredentials.select("anthropic/claude-opus-5", own)
+      assert {:ok, %Source{origin: :own, scope: :credential}, ^own} =
+               InferenceCredentials.select("anthropic/claude-opus-5", own)
     end
 
     test "the platform key is merged in, leaving the tenant's other credentials alone" do
       with_platform_key()
       own = %{openai_api_key: "sk-tenant-openai"}
 
-      assert {:ok, :platform, creds} = InferenceCredentials.select("anthropic/claude-opus-5", own)
+      assert {:ok, %Source{origin: :platform}, creds} =
+               InferenceCredentials.select("anthropic/claude-opus-5", own)
+
       assert creds.anthropic_api_key == "sk-platform"
       assert creds.openai_api_key == "sk-tenant-openai"
     end
@@ -227,14 +232,17 @@ defmodule Fountain.PlatformInferenceTest do
     test "a provider that needs no credential is :own, whatever is configured" do
       with_platform_key()
 
-      assert {:ok, :own, %{}} = InferenceCredentials.select("ollama/llama3", %{})
-      assert {:ok, :own, %{}} = InferenceCredentials.select(nil, %{})
+      assert {:ok, %Source{origin: :own, scope: :none}, %{}} =
+               InferenceCredentials.select("ollama/llama3", %{})
+
+      assert {:ok, %Source{origin: :own, scope: :none}, %{}} =
+               InferenceCredentials.select(nil, %{})
     end
 
     test "an empty-string credential is not a credential" do
       with_platform_key()
 
-      assert {:ok, :platform, creds} =
+      assert {:ok, %Source{origin: :platform}, creds} =
                InferenceCredentials.select("anthropic/claude-opus-5", %{anthropic_api_key: ""})
 
       assert creds.anthropic_api_key == "sk-platform"

--- a/ee/test/fountain/credits_chatgpt_inference_test.exs
+++ b/ee/test/fountain/credits_chatgpt_inference_test.exs
@@ -5,6 +5,7 @@ defmodule Fountain.Credits.ChatGPTInferenceTest do
   alias Fountain.{Billing, Credits, InferenceCredentials, PlatformInference}
   alias Fountain.Conversations.TurnMachine
   alias Fountain.Credits.InferenceRates
+  alias Fountain.InferenceCredentials.Source
   alias Fountain.Workers.CreditPricer
 
   setup do
@@ -28,7 +29,7 @@ defmodule Fountain.Credits.ChatGPTInferenceTest do
   test "a grant-only turn is debited once and counted in daily spend; own credentials are not" do
     model = "openai/gpt-6-astra"
     {:ok, source, _} = InferenceCredentials.select(model, %{}, "codex", refresh: false)
-    assert source == :platform
+    assert source == Source.platform()
 
     usage =
       TurnMachine.with_inference(%{"input" => 1_000_000, "output" => 0}, %{
@@ -52,7 +53,7 @@ defmodule Fountain.Credits.ChatGPTInferenceTest do
     assert entry.metadata["model"] == model
     assert Billing.platform_inference_spend_today(now) == before + cost
 
-    {:ok, :own = source, _} =
+    {:ok, %Source{origin: :own} = source, _} =
       InferenceCredentials.select(model, %{openai_api_key: "tenant-key"}, "codex", refresh: false)
 
     own_usage =


### PR DESCRIPTION
**Base: #2019.** ADR 0053 decision 2. Tracker #2018.

A pure refactor with one deliberate vocabulary split. No turn changes how it
is billed, gated or stamped.

## Why now, and why not inside the ChatGPT stack

`InferenceCredentials.select/4` answered `:own | :platform` — one bit for two
questions: *who pays*, and *what actually served the turn*. ADR 0052 decision
4 requires the second ("extend selection to return source identity") and is
unbuilt; #2011-#2015 and #2017 build decisions 1, 3 and 6 and do not touch
`inference_credentials.ex`, `platform_inference.ex`, `sprite_env.ex` or
`turn_machine.ex`. ADR 0053 needs the same thing for a different reason — a
tenant secret that serves a turn the deployment is billed for. Cutting the
struct once, here, means the grant work adds `grant_id` and `generation` to
it instead of landing a second selection refactor beside this stack.

## What it is

```elixir
%Fountain.InferenceCredentials.Source{origin: :own | :platform, scope: ...}
```

`origin` is the billing question in the vocabulary the ledger already uses,
so `TurnMachine.with_inference/2` stamps and `TurnMachine.gate/2` checks the
daily ceiling on exactly the turns they did before. `scope` says where the
value came from: `:credential`, `:platform`, `:none`, `:missing`.

## The one thing that is not a rename

`{:error, :no_credential}` and "this provider needs no credential" both
collapsed into `:own` at `SpriteEnv.select_inference/3`. They are now
`:missing` and `:none`.

Both keep `origin: :own`, so neither is platform-paid and neither turn's
usage map moves — but they are opposite answers to "is anything wrong here".
A local model needs no key; a conversation with no key for a provider that
requires one will fail inside the sandbox. Only the source can tell a surface
which, and decision 5 needs the distinction to report where a turn ran.

## No `kind` field

A field naming the credential atom that served the turn would be wrong for an
account holding both an Anthropic key and an OAuth token: `Runtimes.Claude`
prefers `CLAUDE_CODE_OAUTH_TOKEN` and deliberately never exports the API key
beside it, while `Runtimes.OpenCode` reads only the API key for the same
provider. No derivation in this context is right for both, so the field waits
for a reader that needs it and a derivation that matches the runtime. The
module doc says so, and the ADR does too.

## Verification

- `test/fountain/platform_inference_test.exs`,
  `test/fountain/platform_chatgpt_test.exs`,
  `test/fountain/conversations/conversation_server_platform_inference_test.exs`,
  `ee/test/fountain/credits_chatgpt_inference_test.exs`,
  `ee/test/fountain/credits_inference_test.exs` — 94 tests, 0 failures.
- New `sprite_env_inference_test.exs` (6 tests) over `select_inference/3`, one
  per scope. `async: false` and in its own module rather than beside
  `SpriteEnvTest`: the platform keys are global application env, so a module
  that writes them races every module that reads them (#1214).
- **Revert-checked**: collapsing `Source.missing/0` back into `Source.none/0`
  fails exactly the `:missing` test and nothing else, so the distinction is
  actually asserted.
- `mix credo --strict` clean over 849 files. `mix format` (under mise, from
  `apps/fountain`) clean.
- Swept `apps`, `ee`, `sdk` and `cli` for consumers of the old tuple shape —
  none remain.

Full suite is queued behind another session's stack on this box; I will post
the result on this PR.

## Stack

| # | PR | What |
|---|---|---|
| 1 | #2019 | ADR 0053 + index |
| 2 | **this** | `select/4` returns a source struct |
| 3 | | env/vault secret resolves the source to `:own` (P1, mis-bills on prod) |
| 4 | | inference pairs move off the shared `.env` |
| 5 | | `inference_credentials` gains `name` + `is_default`; 1:N |
| 6 | | `agents.inference_credential_id` + allowlist |
| 7 | | `conversations.inference_credential_id` per-launch override |
| 8 | | API, OpenAPI, contract, TS SDK |
| 9 | | console |
| 10 | | an owner may write a credential on a principal it owns |
| 11 | | docs, CHANGELOG, SDK bump |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxYdSf5CzmQq1RLWFXxeGd
