### PR TITLE
fix: a tenant secret naming a credential is not platform inference

### DIFF
--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -680,18 +680,17 @@ defmodule Fountain.Conversations.ConversationServer do
 
     case SpriteEnv.load_tenant_state(conv.user_id) do
       {:ok, dek, own_creds} ->
+        # Before the selection: a tenant secret named after a credential wins
+        # in the sandbox, so it decides the source too (ADR 0053 decision 5).
+        tenant_secrets = SpriteEnv.merge_secrets(env, vault, dek)
+
         {inference_source, inference_creds} =
-          SpriteEnv.select_inference(agent, own_creds, conv.runtime)
+          SpriteEnv.select_inference(agent, own_creds, conv.runtime, tenant_secrets)
 
         bindings = Egress.bindings(conv.user_id)
 
         {merged, bindings, connection_keys} =
-          Egress.add_connection_secrets(
-            conv.user_id,
-            SpriteEnv.merge_secrets(env, vault, dek),
-            bindings,
-            agent
-          )
+          Egress.add_connection_secrets(conv.user_id, tenant_secrets, bindings, agent)
 
         {secrets, brokered} = Egress.split_brokered(conv.user_id, merged, bindings)
 

--- a/apps/fountain/lib/fountain/conversations/sprite_env.ex
+++ b/apps/fountain/lib/fountain/conversations/sprite_env.ex
@@ -57,15 +57,26 @@ defmodule Fountain.Conversations.SpriteEnv do
   `runtime` is the conversation's own (`conv.runtime`), which is what the
   sandbox is dispatched on and can differ from the agent's after an edit;
   nil falls back to the agent's.
+
+  `secrets` is this conversation's merged environment and vault secrets, the
+  same map `merge_secrets/3` returns. Only its **keys** are read: a secret
+  named after a static credential overrides that credential in the sandbox,
+  so the conversation is running on the tenant's own key and must not be
+  billed as platform inference (ADR 0053 decision 5). The values stay where
+  they are — they already reach the sandbox through the secrets path, and
+  merging them into the credentials map would change which credential the
+  runtime picks. Default `%{}` keeps the old answer for a caller with no
+  secrets to hand over.
   """
-  @spec select_inference(map() | nil, map(), String.t() | nil) ::
+  @spec select_inference(map() | nil, map(), String.t() | nil, map()) ::
           {InferenceCredentials.Source.t(), map()}
-  def select_inference(agent, own_creds, runtime \\ nil) do
+  def select_inference(agent, own_creds, runtime \\ nil, secrets \\ %{}) do
     brokered? = (agent && Fountain.Broker.enabled_for?(agent.user_id)) || false
     runtime = runtime || (agent && agent.runtime)
 
     case InferenceCredentials.select(agent && agent.model, own_creds, runtime,
-           brokered: brokered?
+           brokered: brokered?,
+           secret_keys: Map.keys(secrets)
          ) do
       {:ok, source, creds} -> {source, creds}
       {:error, :no_credential} -> {InferenceCredentials.Source.missing(), own_creds}

--- a/apps/fountain/lib/fountain/inference_credentials.ex
+++ b/apps/fountain/lib/fountain/inference_credentials.ex
@@ -175,6 +175,33 @@ defmodule Fountain.InferenceCredentials do
     |> MapSet.new()
   end
 
+  # The environment variable each static credential is exported as. A tenant
+  # secret of the same name overrides it in the sandbox (`Egress`'s gate-3
+  # split, published in `docs/concepts/secrets.md`), which is what
+  # `select/4`'s `:secret_keys` reads.
+  #
+  # The deployment's ChatGPT grant is deliberately absent: ADR 0052 decision 6
+  # reserves `CODEX_CHATGPT_ACCESS_TOKEN` so no configuration can name it.
+  # Reserve what rotates, resolve what is static (ADR 0053 decision 5).
+  # `inference_credentials_env_names_test.exs` holds this table against
+  # `Fountain.Broker.inference_keys/0`, which is where the same mapping is
+  # used to build the placeholders.
+  @env_names %{
+    anthropic_api_key: "ANTHROPIC_API_KEY",
+    claude_code_oauth_token: "CLAUDE_CODE_OAUTH_TOKEN",
+    openai_api_key: "OPENAI_API_KEY",
+    gemini_api_key: "GEMINI_API_KEY"
+  }
+
+  @doc """
+  The environment variable each static credential is exported as.
+
+  Only the four a tenant sets themselves. The managed ChatGPT grant is not
+  here: configuration may not name it (ADR 0052 decision 6).
+  """
+  @spec env_names() :: %{atom() => String.t()}
+  def env_names, do: @env_names
+
   @doc """
   The credentials that let a model's provider run: a model `provider/id`
   names a provider; any one of these credentials serves it. Unknown
@@ -258,7 +285,24 @@ defmodule Fountain.InferenceCredentials do
   an `openai/` model keeps needing a key. The origin is `:platform` either
   way, so the ledger prices the turn and the daily ceiling counts it.
 
-  `opts` carries `:brokered`, whether the conversation's credentials go
+  `opts` carries `:secret_keys` (ADR 0053 decision 5), the environment
+  variable names this conversation's environment and vault define. A tenant
+  secret named after a static credential **wins in the sandbox** — `Egress`
+  says so at the gate-3 split and `docs/concepts/secrets.md` publishes it —
+  so a conversation that has one is running on the tenant's own credential
+  and must not be selected `:platform`, priced against their credits or
+  counted against the deployment's daily ceiling. Before this was read, a
+  tenant using the documented override paid for platform inference they never
+  used. Presence is all that is read: the value already reaches the sandbox
+  through the secrets path, and putting it in `creds` as well would change
+  which credential the runtime picks.
+
+  A credential row is reported ahead of a secret when an account has both.
+  Both are `origin: :own`, so nothing about billing turns on the order; the
+  scope answers "why was this not platform-paid", and the row is the more
+  specific answer because it is what Fountain itself exports.
+
+  `opts` also carries `:brokered`, whether the conversation's credentials go
   through the egress broker (`Fountain.Broker.enabled_for?/1`), default
   `true`. The grant is offered to brokered conversations only: unbrokered,
   the access token itself would land in the sandbox file, and the whole
@@ -282,6 +326,9 @@ defmodule Fountain.InferenceCredentials do
       Enum.any?(accepted, &present?(own_creds, &1)) ->
         {:ok, Source.credential(), own_creds}
 
+      shadowed?(accepted, Keyword.get(opts, :secret_keys, [])) ->
+        {:ok, Source.tenant_secret(), own_creds}
+
       true ->
         case platform_credential(provider, runtime, Keyword.get(opts, :brokered, true), opts) do
           {:ok, credential, key} -> {:ok, Source.platform(), Map.put(own_creds, credential, key)}
@@ -303,6 +350,15 @@ defmodule Fountain.InferenceCredentials do
 
   defp platform_credential(provider, _runtime, _brokered?, _opts),
     do: Fountain.PlatformInference.key_for(provider)
+
+  # Whether one of the credentials this provider accepts is defined as a
+  # tenant secret for this conversation. Names only; the values stay where
+  # they are.
+  @spec shadowed?([atom()], Enumerable.t()) :: boolean()
+  defp shadowed?(accepted, secret_keys) do
+    names = MapSet.new(secret_keys, &to_string/1)
+    Enum.any?(accepted, &MapSet.member?(names, Map.fetch!(@env_names, &1)))
+  end
 
   defp present?(creds, credential) do
     case Map.get(creds, credential) do

--- a/apps/fountain/lib/fountain/inference_credentials/source.ex
+++ b/apps/fountain/lib/fountain/inference_credentials/source.ex
@@ -14,10 +14,11 @@ defmodule Fountain.InferenceCredentials.Source do
       uses. `:platform` prices the turn against the tenant's credits and
       counts it against the deployment's daily ceiling; `:own` does neither.
     * `scope` — where the value came from. `:credential` an
-      `inference_credentials` row, `:platform` a platform key or the
-      deployment's ChatGPT grant, `:none` a provider that needs no credential
-      at all (a local model, a gateway), `:missing` a provider that needs one
-      where neither the tenant nor the deployment has it.
+      `inference_credentials` row, `:tenant_secret` an environment or vault
+      secret named after one, `:platform` a platform key or the deployment's
+      ChatGPT grant, `:none` a provider that needs no credential at all (a
+      local model, a gateway), `:missing` a provider that needs one where
+      neither the tenant nor the deployment has it.
 
   `:none` and `:missing` are both `origin: :own` and are both what `main`
   called `:own` before this struct existed, so nothing about billing moves.
@@ -26,10 +27,10 @@ defmodule Fountain.InferenceCredentials.Source do
   provider that requires one will fail inside the sandbox. Keeping them apart
   is what lets a surface say which without asking the question again.
 
-  `origin` and `scope` are not the same question. ADR 0053 decision 5 adds
-  `:tenant_secret`, an environment or vault secret naming a credential, which
-  is `origin: :own` and needs to stay distinguishable from a credential row
-  for anything that reports where a turn ran.
+  `origin` and `scope` are not the same question. `:tenant_secret` — an
+  environment or vault secret named after a credential, which overrides it in
+  the sandbox — is `origin: :own` and has to stay distinguishable from a
+  credential row for anything that reports where a turn ran.
 
   **There is deliberately no `kind`.** A field naming the credential atom that
   served the turn would have to guess how the runtime chose between an
@@ -44,7 +45,7 @@ defmodule Fountain.InferenceCredentials.Source do
   """
 
   @type origin :: :own | :platform
-  @type scope :: :credential | :platform | :none | :missing
+  @type scope :: :credential | :tenant_secret | :platform | :none | :missing
 
   @type t :: %__MODULE__{origin: origin(), scope: scope()}
 
@@ -54,6 +55,16 @@ defmodule Fountain.InferenceCredentials.Source do
   @doc "The tenant's own credential row served this conversation."
   @spec credential() :: t()
   def credential, do: %__MODULE__{origin: :own, scope: :credential}
+
+  @doc """
+  An environment or vault secret named after a credential served it.
+
+  It overrides the credential in the sandbox whether or not the account also
+  holds a row, so the deployment is not paying for the turn — which is the
+  whole reason this scope exists (ADR 0053 decision 5).
+  """
+  @spec tenant_secret() :: t()
+  def tenant_secret, do: %__MODULE__{origin: :own, scope: :tenant_secret}
 
   @doc """
   The model's provider needs no credential — a local model, a gateway, or a

--- a/apps/fountain/test/fountain/conversations/conversation_server_platform_inference_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_platform_inference_test.exs
@@ -90,6 +90,45 @@ defmodule Fountain.Conversations.ConversationServerPlatformInferenceTest do
       assert state.inference_source == Source.credential()
       assert state.env_credentials == %{anthropic_api_key: "sk-ant-tenant-key"}
     end
+
+    # ADR 0053 decision 5. The vault value wins in the sandbox environment
+    # (`Egress`'s gate-3 split; `docs/concepts/secrets.md` publishes it) but
+    # selection could not see it, so this conversation took the platform key,
+    # was stamped `"platform"`, priced against the tenant's credits and
+    # counted against the deployment's daily ceiling -- on a turn the
+    # tenant's own key served. Live on the hosted deployment, which has held
+    # platform keys since 2026-09-03.
+    test "a vault secret naming the credential is the tenant's own key, not the platform's", %{
+      user: user,
+      agent: agent
+    } do
+      vault = insert_vault(user_id: user.id)
+
+      # The case stubs `load_tenant_key/1` to an all-zero DEK, so the row has
+      # to be written under the same one or the server cannot decrypt it and
+      # the secret never reaches the merge.
+      {:ok, _} =
+        Fountain.Vaults.upsert_secret(
+          vault,
+          %{"key" => "ANTHROPIC_API_KEY", "value" => "sk-ant-from-the-vault"},
+          <<0::256>>
+        )
+
+      conv = insert_conversation(user_id: user.id, agent: agent, vault_id: vault.id)
+
+      stub_happy_sprite()
+      _ref = stub_turn_boundary()
+
+      {pid, _mon, :alive} = start_server(conv, initial_prompt: "hello")
+      on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+
+      state = :sys.get_state(pid)
+      assert state.inference_source == Source.tenant_secret()
+
+      # And so the turn is not billed as platform inference.
+      assert TurnMachine.with_inference(%{"input" => 5}, TurnMachine.ctx(state)) ==
+               %{"input" => 5, "inference" => "own"}
+    end
   end
 
   describe "the brokered path (ADR 0019 gate 3)" do

--- a/apps/fountain/test/fountain/conversations/sprite_env_inference_test.exs
+++ b/apps/fountain/test/fountain/conversations/sprite_env_inference_test.exs
@@ -88,4 +88,56 @@ defmodule Fountain.Conversations.SpriteEnvInferenceTest do
                SpriteEnv.select_inference(agent_on(user, @anthropic), %{})
     end
   end
+
+  # ADR 0053 decision 5. A tenant secret named after a credential overrides it
+  # in the sandbox — `Egress`'s gate-3 split says so and
+  # `docs/concepts/secrets.md` publishes it — but selection could not see it,
+  # so the deployment's key was selected, the turn was stamped `"platform"`,
+  # priced against the tenant's credits and counted against the daily ceiling,
+  # while the tenant's own secret served every one of them.
+  describe "select_inference/4 with a tenant secret shadowing a credential" do
+    test "is :own, not :platform, even with a platform key configured", %{user: user} do
+      Application.put_env(:fountain, :platform_anthropic_api_key, "sk-platform")
+      secrets = %{"ANTHROPIC_API_KEY" => "sk-from-the-vault"}
+
+      assert {%Source{origin: :own, scope: :tenant_secret}, creds} =
+               SpriteEnv.select_inference(agent_on(user, @anthropic), %{}, nil, secrets)
+
+      # Presence only: the value already reaches the sandbox through the
+      # secrets path, and merging it here would change which credential the
+      # runtime exports.
+      assert creds == %{}
+    end
+
+    test "an OAuth token by name counts for anthropic too", %{user: user} do
+      Application.put_env(:fountain, :platform_anthropic_api_key, "sk-platform")
+      secrets = %{"CLAUDE_CODE_OAUTH_TOKEN" => "oauth-from-the-vault"}
+
+      assert {%Source{scope: :tenant_secret}, %{}} =
+               SpriteEnv.select_inference(agent_on(user, @anthropic), %{}, nil, secrets)
+    end
+
+    test "a secret for another provider does not shadow this one", %{user: user} do
+      Application.put_env(:fountain, :platform_anthropic_api_key, "sk-platform")
+      secrets = %{"OPENAI_API_KEY" => "sk-openai", "UNRELATED" => "x"}
+
+      assert {%Source{origin: :platform}, _} =
+               SpriteEnv.select_inference(agent_on(user, @anthropic), %{}, nil, secrets)
+    end
+
+    test "with no platform key it is still :own rather than :missing", %{user: user} do
+      secrets = %{"ANTHROPIC_API_KEY" => "sk-from-the-vault"}
+
+      assert {%Source{origin: :own, scope: :tenant_secret}, %{}} =
+               SpriteEnv.select_inference(agent_on(user, @anthropic), %{}, nil, secrets)
+    end
+
+    test "a credential row is reported ahead of a secret when both exist", %{user: user} do
+      own = %{anthropic_api_key: "sk-row"}
+      secrets = %{"ANTHROPIC_API_KEY" => "sk-from-the-vault"}
+
+      assert {%Source{origin: :own, scope: :credential}, ^own} =
+               SpriteEnv.select_inference(agent_on(user, @anthropic), own, nil, secrets)
+    end
+  end
 end

--- a/apps/fountain/test/fountain/inference_credentials_env_names_test.exs
+++ b/apps/fountain/test/fountain/inference_credentials_env_names_test.exs
@@ -1,0 +1,44 @@
+defmodule Fountain.InferenceCredentialsEnvNamesTest do
+  @moduledoc """
+  `InferenceCredentials.env_names/0` against `Broker.inference_keys/0`.
+
+  Two tables map a credential to the environment variable it is exported as:
+  the broker's, which builds the gate-3 placeholders, and this context's,
+  which decides whether a tenant secret shadows a credential (ADR 0053
+  decision 5). A disagreement is silent in both directions — a name only this
+  one knows is a placeholder nobody substitutes, and a name only the broker
+  knows is an override selection cannot see, which is the bug decision 5
+  exists to fix. Hold them together here rather than merging them: the broker
+  carries hosts and the managed grant, and this context must not carry either.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Fountain.Broker
+  alias Fountain.InferenceCredentials
+  alias Fountain.InferenceCredentials.Credential
+
+  test "every static credential has a name, and it is the broker's" do
+    names = InferenceCredentials.env_names()
+    broker = Broker.inference_keys()
+
+    assert Map.keys(names) |> Enum.sort() == Enum.sort(Credential.providers())
+
+    for {credential, name} <- names do
+      assert Map.get(broker, name) == credential,
+             "#{name} maps to #{inspect(credential)} here and " <>
+               "#{inspect(Map.get(broker, name))} in Fountain.Broker"
+    end
+  end
+
+  # ADR 0052 decision 6: configuration may neither name the managed grant nor
+  # embed its placeholder, so it is not a credential a tenant secret can
+  # shadow. Reserve what rotates, resolve what is static.
+  test "the managed ChatGPT grant is not one of them" do
+    names = InferenceCredentials.env_names()
+
+    refute Map.has_key?(names, :codex_chatgpt_access_token)
+    refute "CODEX_CHATGPT_ACCESS_TOKEN" in Map.values(names)
+    assert Map.has_key?(Broker.inference_keys(), "CODEX_CHATGPT_ACCESS_TOKEN")
+  end
+end


### PR DESCRIPTION
**Base: #2022.** ADR 0053 decision 5. Tracker #2018.

**This one is live on production.**

## The bug

A vault or environment secret named `ANTHROPIC_API_KEY` wins over the
account's inference credential in the sandbox. `Conversations.Egress` says so
at the gate-3 split (`egress.ex:223-226`) and `docs/concepts/secrets.md:212`
publishes the rule.

Selection could not see it. `InferenceCredentials.select/4` reads the
decrypted `inference_credentials` row and nothing else, so on a deployment
holding platform keys — the hosted one, since 2026-09-03 — a tenant using the
documented override got:

- the platform key selected,
- the turn stamped `"platform"` by `TurnMachine.with_inference/2`,
- the tokens priced against **their own credits** by `CreditPricer`,
- the spend counted against `PLATFORM_INFERENCE_DAILY_CENTS`,

while their own secret served every one of those turns.

#1941 (merged earlier today) fixed an adjacent facet — stamping a platform
turn when the deployment holds no platform API key. It does not reach this
one, because the stamp is still derived from a selection that cannot see the
secret.

ADR 0052 decision 4 already mandates the fix: *"Environment/vault API-key
overrides must resolve into the same explicit source decision."*

## The fix

`select/4` takes `:secret_keys` and resolves `Source.tenant_secret/0`, which
is `origin: :own` — so nothing is priced and nothing is counted.
`ConversationServer` merges the environment and vault *before* selecting
instead of after; those two calls were already independent, so it is a
reorder, and it takes the file from 2646 lines to 2645.

Three deliberate choices:

- **Presence only, not the value.** The value already reaches the sandbox
  through the secrets path. Merging it into the credentials map would change
  which credential the runtime exports, which is a different change with a
  different blast radius.
- **A credential row is reported ahead of a secret** when an account has
  both. Both are `origin: :own` so no billing turns on the order; the scope
  answers "why was this not platform-paid" and the row is the more specific
  answer, because it is what Fountain itself exports.
- **The managed ChatGPT grant is excluded.** ADR 0052 decision 6 reserves
  `CODEX_CHATGPT_ACCESS_TOKEN` so no configuration may name it, and a
  rotating grant cannot be overridden without breaking custody. *Reserve what
  rotates, resolve what is static.*

## The second table

`@env_names` duplicates a credential → environment-variable mapping
`Fountain.Broker` already holds (minus the grant, and minus the hosts). They
are held together by `inference_credentials_env_names_test.exs` rather than
merged, because a disagreement is silent in both directions: a name only this
table knows is a placeholder nobody substitutes, and a name only the broker
knows is an override selection cannot see — which is this bug again.

## Verification

- 114 tests across the eight files touching selection, pricing or the sandbox
  environment. Zero failures.
- **End to end through a real `ConversationServer`**: a vault secret, a
  platform key configured, and the server resolves `:tenant_secret` and the
  turn stamps `"own"`. (Note for reviewers: the secret has to be written under
  the all-zero DEK `ConversationServerCase` stubs `load_tenant_key/1` to, or
  the server cannot decrypt it and the case silently proves nothing — the
  first draft of this test did exactly that.)
- **Revert-checked**: dropping the `shadowed?/2` clause fails exactly the
  three tenant-secret tests and leaves the two negative cases (a secret for
  another provider; a credential row present too) green.
- `mix credo --strict` clean over 851 files. `mix format` under mise clean.
- `conversation_server.ex` is 2645 lines against a pin of 2646. The pin is
  left alone: lowering it inside a stack that is still in review is how the
  #1565 stack went red on a number it set itself.

## Stack

| # | PR | What |
|---|---|---|
| 1 | #2019 | ADR 0053 + index |
| 2 | #2022 | `select/4` returns a source struct |
| 3 | **this** | a tenant secret resolves the source to `:own` |
| 4 | | the door gate stops refusing those launches on the platform ceiling |
| 5 | | inference pairs move off the shared `.env` |
| 6 | | `inference_credentials` gains `name` + `is_default`; 1:N |
| 7 | | `agents.inference_credential_id` + allowlist |
| 8 | | `conversations.inference_credential_id` per-launch override |
| 9 | | API, OpenAPI, contract, TS SDK |
| 10 | | console |
| 11 | | an owner may write a credential on a principal it owns |
| 12 | | docs, CHANGELOG, SDK bump |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxYdSf5CzmQq1RLWFXxeGd
