### PR TITLE
fix: the door gate asks what the provision will answer

### DIFF
--- a/apps/fountain/lib/fountain/conversations.ex
+++ b/apps/fountain/lib/fountain/conversations.ex
@@ -3325,7 +3325,11 @@ defmodule Fountain.Conversations do
          # Whose inference key would run this (#1388): refused only when it
          # would be Fountain's and the deployment has spent its day. A door
          # with no platform key configured runs no query here.
-         :ok <- Fountain.PlatformInference.gate(user_id, agent.model, agent.runtime),
+         :ok <-
+           Fountain.PlatformInference.gate(user_id, agent.model, agent.runtime,
+             environment_id: env_id || agent.environment_id,
+             vault_id: vault_id
+           ),
          # A persistent launch lands on the identity's home when there is one
          # (ADR 0023 gate 6): `{:home, sandbox}` leaves the `with` and attaches
          # below. Only when there is none does a machine get provisioned, and
@@ -4312,7 +4316,11 @@ defmodule Fountain.Conversations do
          # Whose inference key would run this (#1388): refused only when it
          # would be Fountain's and the deployment has spent its day. A door
          # with no platform key configured runs no query here.
-         :ok <- Fountain.PlatformInference.gate(user_id, agent.model, agent.runtime),
+         :ok <-
+           Fountain.PlatformInference.gate(user_id, agent.model, agent.runtime,
+             environment_id: env_id || agent.environment_id,
+             vault_id: vault_id
+           ),
          %Sandbox{} = sandbox <- get_sandbox(sandbox_id, user_id) || {:error, :sandbox_not_found},
          :ok <- check_sandbox_api_attach(sandbox, attrs["sandbox_api_access"]),
          :ok <- check_attachable(sandbox, agent, vault_id, env_id),
@@ -5224,7 +5232,9 @@ defmodule Fountain.Conversations do
                  Fountain.PlatformInference.gate(
                    conv.user_id,
                    agent.model,
-                   conv.runtime
+                   conv.runtime,
+                   environment_id: conv.environment_id || agent.environment_id,
+                   vault_id: conv.vault_id
                  ),
                {:ok, _} <- wake_suspended_sandbox(conv.user_id, sandbox_id) do
             case start_conversation_server(conv, sandbox_id, runtime_module, initial_prompt) do
@@ -5533,7 +5543,9 @@ defmodule Fountain.Conversations do
            Fountain.PlatformInference.gate(
              conv.user_id,
              agent.model,
-             conv.runtime
+             conv.runtime,
+             environment_id: conv.environment_id || agent.environment_id,
+             vault_id: conv.vault_id
            ),
          # A fresh sandbox is a fresh placement decision — re-resolve from
          # the agent, so a conversation whose old sandbox died can migrate

--- a/apps/fountain/lib/fountain/inference_credentials.ex
+++ b/apps/fountain/lib/fountain/inference_credentials.ex
@@ -244,10 +244,66 @@ defmodule Fountain.InferenceCredentials do
   True also when the model's provider needs none at all (a local model, a
   gateway): there is nothing missing, which is the same answer
   `missing_for_model/2` gives.
+
+  `opts` may name a launch's `:environment_id` and `:vault_id`. With either,
+  a secret of theirs named after a credential the provider accepts counts as
+  the tenant's own, because it is what will serve the conversation (ADR 0053
+  decision 5). With neither — every caller that has no launch in hand — this
+  is exactly the row question it has always been, and runs no extra query.
   """
-  @spec has_own?(binary(), String.t() | nil) :: boolean()
-  def has_own?(user_id, model) when is_binary(user_id),
-    do: is_nil(missing_for_model(user_id, model))
+  @spec has_own?(binary(), String.t() | nil, keyword()) :: boolean()
+  def has_own?(user_id, model, opts \\ []) when is_binary(user_id) do
+    case missing_for_model(user_id, model) do
+      nil -> true
+      {_provider, accepted} -> shadowed?(accepted, secret_keys(user_id, opts))
+    end
+  end
+
+  @doc """
+  Which of the static credential names this launch's environment or vault
+  defines.
+
+  Names, never values, and only the four `env_names/0` knows: this answers
+  "would a tenant secret serve this conversation", which is what keeps a
+  tenant who brought their own key off the platform ledger and out of the
+  deployment's daily ceiling.
+
+  Scoped by joining the owning row to `user_id`, so an id belonging to
+  another tenant contributes nothing rather than leaking the fact that it
+  exists. Both ids absent is the common case and runs no query.
+  """
+  @spec secret_keys(binary(), keyword()) :: [String.t()]
+  def secret_keys(user_id, opts \\ []) when is_binary(user_id) do
+    env_id = Keyword.get(opts, :environment_id)
+    vault_id = Keyword.get(opts, :vault_id)
+    names = Map.values(@env_names)
+
+    env_keys =
+      if env_id do
+        Repo.all(
+          from s in Fountain.Environments.Secret,
+            join: e in assoc(s, :environment),
+            where: e.user_id == ^user_id and s.environment_id == ^env_id and s.key in ^names,
+            select: s.key
+        )
+      else
+        []
+      end
+
+    vault_keys =
+      if vault_id do
+        Repo.all(
+          from s in Fountain.Vaults.VaultSecret,
+            join: v in assoc(s, :vault),
+            where: v.user_id == ^user_id and s.vault_id == ^vault_id and s.key in ^names,
+            select: s.key
+        )
+      else
+        []
+      end
+
+    Enum.uniq(env_keys ++ vault_keys)
+  end
 
   @doc """
   Which credential a conversation on `model` runs on (#1388, ADR 0038

--- a/apps/fountain/lib/fountain/platform_inference.ex
+++ b/apps/fountain/lib/fountain/platform_inference.ex
@@ -334,14 +334,22 @@ defmodule Fountain.PlatformInference do
   `runtime` is the agent's: a codex agent on an `openai` model may run on the
   deployment's ChatGPT grant instead of a key (ADR 0047), which the ceiling
   counts the same way.
+
+  `opts` names this launch's `:environment_id` and `:vault_id` so question 2
+  asks what the provision will answer. A secret of theirs named after a
+  credential serves the conversation instead of the platform key (ADR 0053
+  decision 5), so without them this door refused a tenant running on their
+  own key once the deployment had spent its day. The extra read happens only
+  when the first question already said yes and the account holds no row, so
+  a deployment with no platform key still costs nothing here.
   """
-  @spec gate(binary(), String.t() | nil, String.t() | nil) ::
+  @spec gate(binary(), String.t() | nil, String.t() | nil, keyword()) ::
           :ok | {:error, :platform_inference_unavailable}
-  def gate(user_id, model, runtime \\ nil) when is_binary(user_id) do
+  def gate(user_id, model, runtime \\ nil, opts \\ []) when is_binary(user_id) do
     provider = Managoat.Runtimes.Model.provider(model)
 
     if serves?(provider, runtime, Fountain.Broker.enabled_for?(user_id)) and
-         not Fountain.InferenceCredentials.has_own?(user_id, model) do
+         not Fountain.InferenceCredentials.has_own?(user_id, model, opts) do
       check_ceiling()
     else
       :ok

--- a/apps/fountain/test/fountain/platform_inference_test.exs
+++ b/apps/fountain/test/fountain/platform_inference_test.exs
@@ -12,6 +12,7 @@ defmodule Fountain.PlatformInferenceTest do
   import Ecto.Query, only: [from: 2]
 
   alias Fountain.Credits
+  alias Fountain.Environments
   alias Fountain.InferenceCredentials
   alias Fountain.InferenceCredentials.Source
   alias Fountain.PlatformInference
@@ -283,6 +284,69 @@ defmodule Fountain.PlatformInferenceTest do
       assert PlatformInference.gate(user.id, "anthropic/claude-opus-5") == :ok
       # And the same account without the key would have been refused.
       assert PlatformInference.gate(insert_verified_user().id, "anthropic/claude-opus-5") ==
+               {:error, :platform_inference_unavailable}
+    end
+
+    # ADR 0053 decision 5. A vault or environment secret named after a
+    # credential serves the conversation instead of the platform key, so a
+    # tenant who brought one was being refused on a ceiling they were not
+    # spending against. The launch's ids are what make the door ask the
+    # question the provision answers.
+    test "a tenant whose vault names the credential is not refused either", %{user: user} do
+      with_platform_key()
+      Application.put_env(:fountain, :platform_inference_daily_cents, 0)
+      burn_inference(user, 500)
+
+      vault = insert_vault(user_id: user.id)
+      insert_vault_secret(vault, key: "ANTHROPIC_API_KEY", value: "sk-from-the-vault")
+
+      assert PlatformInference.gate(user.id, "anthropic/claude-opus-5", nil, vault_id: vault.id) ==
+               :ok
+
+      # The same launch without the vault, and the same vault under another
+      # tenant, are both still refused.
+      assert PlatformInference.gate(user.id, "anthropic/claude-opus-5") ==
+               {:error, :platform_inference_unavailable}
+
+      assert PlatformInference.gate(
+               insert_verified_user().id,
+               "anthropic/claude-opus-5",
+               nil,
+               vault_id: vault.id
+             ) == {:error, :platform_inference_unavailable}
+    end
+
+    test "an environment naming the credential counts too, and an unrelated key does not",
+         %{user: user} do
+      with_platform_key()
+      Application.put_env(:fountain, :platform_inference_daily_cents, 0)
+      burn_inference(user, 500)
+
+      env = insert_env(user_id: user.id)
+      {:ok, dek} = Fountain.Crypto.load_tenant_key(user.id)
+      {:ok, _} = Environments.upsert_secret(env, %{"key" => "UNRELATED", "value" => "x"}, dek)
+
+      assert PlatformInference.gate(user.id, "anthropic/claude-opus-5", nil,
+               environment_id: env.id
+             ) == {:error, :platform_inference_unavailable}
+
+      {:ok, _} =
+        Environments.upsert_secret(env, %{"key" => "ANTHROPIC_API_KEY", "value" => "sk-e"}, dek)
+
+      assert PlatformInference.gate(user.id, "anthropic/claude-opus-5", nil,
+               environment_id: env.id
+             ) == :ok
+    end
+
+    test "a secret for another provider does not excuse this one", %{user: user} do
+      with_platform_key()
+      Application.put_env(:fountain, :platform_inference_daily_cents, 0)
+      burn_inference(user, 500)
+
+      vault = insert_vault(user_id: user.id)
+      insert_vault_secret(vault, key: "OPENAI_API_KEY", value: "sk-openai")
+
+      assert PlatformInference.gate(user.id, "anthropic/claude-opus-5", nil, vault_id: vault.id) ==
                {:error, :platform_inference_unavailable}
     end
 


### PR DESCRIPTION
**Base: #2023.** ADR 0053 decision 5, second half. Tracker #2018.

## The bug

`PlatformInference.gate/3` refuses a conversation when three things are true:
the deployment holds a key for the model's provider, the tenant holds none of
their own, and the day is spent.

Question two read the `inference_credentials` row alone. So a tenant whose
vault or environment supplies the credential — which is what actually serves
the conversation, and what #2023 just taught selection to see — was refused at
the door on a ceiling they were not spending against. Same root cause as
#2023, opposite symptom: that one over-bills them, this one locks them out.

## The fix

`gate/4` takes the launch's `:environment_id` and `:vault_id`;
`InferenceCredentials.has_own?/3` consults them. All four doors pass what they
have:

| door | source |
|---|---|
| `start_conversation` | the `env_id` / `vault_id` already resolved in the same `with` |
| the attach path | same |
| wake from suspended | `conv.environment_id \|\| agent.environment_id`, `conv.vault_id` |
| re-provision after a dead sandbox | same |

The `\|\| agent.environment_id` fallback is not invented here — it is exactly
how `ConversationServer` resolves the environment at provision
(`conversation_server.ex:733`), so the door asks the question the provision
answers.

`InferenceCredentials.secret_keys/2` is the read: names, never values, only
the four `env_names/0` knows, and joined to `user_id` so an id belonging to
another tenant contributes nothing rather than leaking that it exists.

**It stays cheap.** The read happens only inside the branch that was about to
refuse — the deployment holds a key for this provider *and* the account holds
no row. A deployment with no platform key still costs one primary-key read and
nothing else, which is what the gate's docstring promises and what makes the
feature free for a self-hoster.

## Verification

- 27 tests in `platform_inference_test.exs`, zero failures. Three are new: a
  vault naming the credential, an environment naming it, and a secret for
  another provider (still refused). The environment case asserts the refusal
  *first* with only an unrelated key in that environment, then adds
  `ANTHROPIC_API_KEY` and asserts `:ok` — so it is pinned on the name and not
  on the row existing.
- Cross-tenant: the same vault id presented by a second account is still
  refused.
- **Revert-checked**: dropping `opts` from the `has_own?` call fails the vault
  and environment tests and leaves the other-provider one green.
- `mix credo --strict` clean over 851 files; `mix format` under mise clean.

## One thing reviewers should know

`test/fountain/conversations/execution_transport_test.exs` fails on this
branch. **It also fails on clean `origin/main` at `97bcf1a6` with `--seed 0`**,
with a superset of the same failures, and which of its three tests fail varies
run to run. It is a wall-clock flake in code that landed today (#1748-#1752),
now filed as #2024 with the mechanism. Nothing in this stack touches that file
or anything it exercises.

## Stack

| # | PR | What |
|---|---|---|
| 1 | #2019 | ADR 0053 + index |
| 2 | #2022 | `select/4` returns a source struct |
| 3 | #2023 | a tenant secret resolves the source to `:own` |
| 4 | **this** | the door gate stops refusing those launches |
| 5 | | inference pairs move off the shared `.env` |
| 6 | | `inference_credentials` gains `name` + `is_default`; 1:N |
| 7 | | `agents.inference_credential_id` + allowlist |
| 8 | | `conversations.inference_credential_id` per-launch override |
| 9 | | API, OpenAPI, contract, TS SDK |
| 10 | | console |
| 11 | | an owner may write a credential on a principal it owns |
| 12 | | docs, CHANGELOG, SDK bump |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxYdSf5CzmQq1RLWFXxeGd
