### PR TITLE
fix(inference): keep provider credentials out of shared sandbox env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,19 @@ upgrade, is in
   enable credits. With only the old variable set, credits remain off by default.
   The hosted home-cloud deployment already uses `CREDITS_ENABLED`.
 
+- **The inference credential no longer reaches `/home/sprite/.env`** (ADR 0053
+  decision 4, #2018). A sandbox carries several conversations and each can run
+  on a different credential, so a value in that shared file would be whichever
+  conversation provisioned last. Every process still receives the credential
+  through its own environment, the `setup_script` included. What stops working
+  is `source .env` in a **later** shell as a way to recover a provider key: a
+  script that re-reads the file for `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`,
+  `GEMINI_API_KEY`, `GOOGLE_GENERATIVE_AI_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN`
+  finds nothing there now. This also applies when these names are supplied
+  as environment or vault secrets, not just through a credential set. Read
+  them from the script's own environment instead. The proxy variables have
+  worked this way since the broker landed.
+
 - **Connections needs no `FEATURE_FLAGS_ON` entry on a deployment without
   PostHog** (#1693). Gating Connections behind the `connections` flag (#1620)
   took the feature away from every deployment that configures no flag service,

--- a/apps/fountain/lib/fountain/conversations/identity.ex
+++ b/apps/fountain/lib/fountain/conversations/identity.ex
@@ -52,16 +52,16 @@ defmodule Fountain.Conversations.Identity do
   # cross-conversation read of a credential that brokers another tenant's
   # vault. `Fountain.Broker.process_only_keys/0` names the variables.
   #
-  # The inference credential is per-conversation for the same reason (ADR 0053
-  # decision 4). Which credential runs a conversation is decided per
-  # conversation by `InferenceCredentials.select/4`, and a sandbox carries
-  # several of them (ADR 0023), so a value on the shared disk is a
-  # cross-conversation read of whichever conversation last provisioned.
-  # `InferenceCredentials.env_names/0` names the four; the managed ChatGPT
-  # grant is not among them and never reaches the env file at all.
-  @process_only [@tag_key, "FOUNTAIN_TOKEN", "TRACEPARENT"] ++
+  # Inference auth inputs are per-conversation (ADR 0053 decision 4),
+  # including tenant env/vault secrets with a supported name or alias.
+  # Unbrokered values are bearer material; broker placeholders are harmless
+  # fixed strings, but neither needs to persist in the shared env file.
+  # The managed ChatGPT path also emits a placeholder into the process env.
+  # Strip its reserved name defensively along with the static credentials.
+  # Runtime-owned auth files require separate isolation (decision 6).
+  @process_only [@tag_key, "FOUNTAIN_TOKEN", "TRACEPARENT", "CODEX_CHATGPT_ACCESS_TOKEN"] ++
                   Fountain.Broker.process_only_keys() ++
-                  Map.values(Fountain.InferenceCredentials.env_names())
+                  (Fountain.InferenceCredentials.env_aliases() |> Map.values() |> List.flatten())
 
   @tag_re ~r/(?:^|\s)FOUNTAIN_CONVERSATION_ID=([0-9a-fA-F-]{36})(?:\s|$)/
 
@@ -77,7 +77,7 @@ defmodule Fountain.Conversations.Identity do
 
   @doc """
   The subset of a sprite env that belongs on the machine's disk: everything
-  except the per-conversation identity.
+  except the per-conversation identity and inference auth inputs.
   """
   @spec disk_env([{String.t(), String.t()}]) :: [{String.t(), String.t()}]
   def disk_env(sprite_env) when is_list(sprite_env) do

--- a/apps/fountain/lib/fountain/conversations/identity.ex
+++ b/apps/fountain/lib/fountain/conversations/identity.ex
@@ -20,9 +20,11 @@ defmodule Fountain.Conversations.Identity do
       pairs before the env file is written; the same pairs still reach every
       spawn through `env:`, so the agent's tools inherit them exactly as
       before. What a `source .env` in a setup script loses is the callback
-      token, which it had no business holding — the file is for environment
-      and vault values, which are the same for every conversation on the
-      machine.
+      token and the inference credential, neither of which the file had any
+      business holding — it is for environment and vault values, which are
+      the same for every conversation on the machine. Both still reach the
+      setup script itself: `Provisioning.run_setup_script/4` execs with
+      `env: sprite_env`, the whole list.
 
     * **A session inherits its conversation.** `tag_command/3` wraps the spawn as
       `env FOUNTAIN_CONVERSATION_ID=<id> <cmd> <args…>`. The process gets the
@@ -49,7 +51,17 @@ defmodule Fountain.Conversations.Identity do
   # 0019 §5), so it is per-conversation too: on disk it would be a
   # cross-conversation read of a credential that brokers another tenant's
   # vault. `Fountain.Broker.process_only_keys/0` names the variables.
-  @process_only [@tag_key, "FOUNTAIN_TOKEN", "TRACEPARENT"] ++ Fountain.Broker.process_only_keys()
+  #
+  # The inference credential is per-conversation for the same reason (ADR 0053
+  # decision 4). Which credential runs a conversation is decided per
+  # conversation by `InferenceCredentials.select/4`, and a sandbox carries
+  # several of them (ADR 0023), so a value on the shared disk is a
+  # cross-conversation read of whichever conversation last provisioned.
+  # `InferenceCredentials.env_names/0` names the four; the managed ChatGPT
+  # grant is not among them and never reaches the env file at all.
+  @process_only [@tag_key, "FOUNTAIN_TOKEN", "TRACEPARENT"] ++
+                  Fountain.Broker.process_only_keys() ++
+                  Map.values(Fountain.InferenceCredentials.env_names())
 
   @tag_re ~r/(?:^|\s)FOUNTAIN_CONVERSATION_ID=([0-9a-fA-F-]{36})(?:\s|$)/
 

--- a/apps/fountain/lib/fountain/conversations/provisioning.ex
+++ b/apps/fountain/lib/fountain/conversations/provisioning.ex
@@ -61,7 +61,7 @@ defmodule Fountain.Conversations.Provisioning do
   Written with mode 600, and `chmod 600` again after the write as defense
   in depth — other sandbox users (if any) must not be able to read tokens.
   """
-  def write_env_file(_handle, sprite_env) when sprite_env in [nil, []], do: :ok
+  def write_env_file(handle, nil), do: write_env_file(handle, [])
 
   def write_env_file(handle, sprite_env) do
     body = render_env_file(sprite_env)

--- a/apps/fountain/lib/fountain/conversations/provisioning.ex
+++ b/apps/fountain/lib/fountain/conversations/provisioning.ex
@@ -52,10 +52,11 @@ defmodule Fountain.Conversations.Provisioning do
   the variables. Mirrors the legacy AoD's `env_file.py`.
 
   The per-conversation identity — `FOUNTAIN_TOKEN`, `FOUNTAIN_CONVERSATION_ID`,
-  `TRACEPARENT` — is not in this file: callers pass the env through
+  `TRACEPARENT`, the broker proxy address and the inference credential — is
+  not in this file: callers pass the env through
   `Fountain.Conversations.Identity.disk_env/1` first. The file is shared by
   every conversation on the machine; the identity reaches each process as
-  spawn env instead.
+  spawn env instead, `run_setup_script/4` included.
 
   Written with mode 600, and `chmod 600` again after the write as defense
   in depth — other sandbox users (if any) must not be able to read tokens.

--- a/apps/fountain/lib/fountain/inference_credentials.ex
+++ b/apps/fountain/lib/fountain/inference_credentials.ex
@@ -203,6 +203,22 @@ defmodule Fountain.InferenceCredentials do
   def env_names, do: @env_names
 
   @doc """
+  Every supported runtime name for each static credential, canonical name first.
+
+  OpenCode's Google adapter exports `GOOGLE_GENERATIVE_AI_API_KEY` for the
+  same credential Gemini exports as `GEMINI_API_KEY`. Selection and shared
+  env-file filtering use this inventory; `env_names/0` names broker bindings.
+  Managed ChatGPT tokens are reserved configuration, not static aliases.
+  """
+  @spec env_aliases() :: %{atom() => [String.t()]}
+  def env_aliases do
+    Map.new(@env_names, fn
+      {:gemini_api_key, name} -> {:gemini_api_key, [name, "GOOGLE_GENERATIVE_AI_API_KEY"]}
+      {credential, name} -> {credential, [name]}
+    end)
+  end
+
+  @doc """
   The credentials that let a model's provider run: a model `provider/id`
   names a provider; any one of these credentials serves it. Unknown
   providers (a local model, a gateway) need none — Fountain cannot know.

--- a/apps/fountain/test/fountain/conversations/identity_test.exs
+++ b/apps/fountain/test/fountain/conversations/identity_test.exs
@@ -2,6 +2,7 @@ defmodule Fountain.Conversations.IdentityTest do
   use ExUnit.Case, async: true
 
   alias Fountain.Conversations.Identity
+  alias Fountain.InferenceCredentials
   alias Managoat.Sandbox.Session
 
   @conv "0b0f6e1a-4d4c-4c1a-9a2b-3c4d5e6f7a8b"
@@ -10,7 +11,6 @@ defmodule Fountain.Conversations.IdentityTest do
   describe "disk_env/1" do
     test "strips the per-conversation identity and keeps everything else" do
       env = [
-        {"ANTHROPIC_API_KEY", "sk-1"},
         {"FOUNTAIN_BASE_URL", "https://f.example"},
         {"FOUNTAIN_TOKEN", "fk_secret"},
         {"FOUNTAIN_CONVERSATION_ID", @conv},
@@ -20,11 +20,31 @@ defmodule Fountain.Conversations.IdentityTest do
       ]
 
       assert Identity.disk_env(env) == [
-               {"ANTHROPIC_API_KEY", "sk-1"},
                {"FOUNTAIN_BASE_URL", "https://f.example"},
                {"SANDBOX_URL", "https://sb.example"},
                {"GITHUB_TOKEN", "ghp_x"}
              ]
+    end
+
+    # ADR 0053 decision 4. Which credential runs a conversation is a
+    # per-conversation decision and a sandbox carries several conversations
+    # (ADR 0023), so a value in the shared file is a cross-conversation read
+    # of whichever one provisioned last. A tenant secret of the same name is
+    # not the credential and is not stripped: it belongs to the environment
+    # or vault, which is what the file is for, and it is the same for every
+    # conversation that attaches them.
+    test "keeps every inference credential off the disk" do
+      env =
+        Enum.map(InferenceCredentials.env_names(), fn {_cred, name} -> {name, "value-#{name}"} end)
+
+      assert Identity.disk_env(env) == []
+    end
+
+    test "the managed ChatGPT grant is not one of them: it never reaches the env list" do
+      # ADR 0052 decision 6 keeps `CODEX_CHATGPT_ACCESS_TOKEN` out of
+      # configuration entirely, so `disk_env/1` has no opinion about it and
+      # must not grow one here by accident.
+      refute "CODEX_CHATGPT_ACCESS_TOKEN" in Identity.process_only_keys()
     end
 
     test "an empty env stays empty" do

--- a/apps/fountain/test/fountain/conversations/identity_test.exs
+++ b/apps/fountain/test/fountain/conversations/identity_test.exs
@@ -2,7 +2,6 @@ defmodule Fountain.Conversations.IdentityTest do
   use ExUnit.Case, async: true
 
   alias Fountain.Conversations.Identity
-  alias Fountain.InferenceCredentials
   alias Managoat.Sandbox.Session
 
   @conv "0b0f6e1a-4d4c-4c1a-9a2b-3c4d5e6f7a8b"
@@ -26,25 +25,20 @@ defmodule Fountain.Conversations.IdentityTest do
              ]
     end
 
-    # ADR 0053 decision 4. Which credential runs a conversation is a
-    # per-conversation decision and a sandbox carries several conversations
-    # (ADR 0023), so a value in the shared file is a cross-conversation read
-    # of whichever one provisioned last. A tenant secret of the same name is
-    # not the credential and is not stripped: it belongs to the environment
-    # or vault, which is what the file is for, and it is the same for every
-    # conversation that attaches them.
-    test "keeps every inference credential off the disk" do
-      env =
-        Enum.map(InferenceCredentials.env_names(), fn {_cred, name} -> {name, "value-#{name}"} end)
+    # Filtering is by name, so credentials supplied through an environment
+    # or vault receive the same process-only treatment as credential sets.
+    test "keeps canonical and runtime alias inference names off the disk" do
+      names = ~w(ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN OPENAI_API_KEY
+                 GEMINI_API_KEY GOOGLE_GENERATIVE_AI_API_KEY)
+      env = Enum.map(names, &{&1, "value-#{&1}"})
 
       assert Identity.disk_env(env) == []
     end
 
-    test "the managed ChatGPT grant is not one of them: it never reaches the env list" do
-      # ADR 0052 decision 6 keeps `CODEX_CHATGPT_ACCESS_TOKEN` out of
-      # configuration entirely, so `disk_env/1` has no opinion about it and
-      # must not grow one here by accident.
-      refute "CODEX_CHATGPT_ACCESS_TOKEN" in Identity.process_only_keys()
+    test "keeps managed ChatGPT token inputs and broker placeholders off disk" do
+      for value <- ["managed-bearer", Fountain.Broker.placeholder("CODEX_CHATGPT_ACCESS_TOKEN")] do
+        assert Identity.disk_env([{"CODEX_CHATGPT_ACCESS_TOKEN", value}]) == []
+      end
     end
 
     test "an empty env stays empty" do

--- a/apps/fountain/test/fountain/conversations/inference_process_env_test.exs
+++ b/apps/fountain/test/fountain/conversations/inference_process_env_test.exs
@@ -1,0 +1,79 @@
+defmodule Fountain.Conversations.InferenceProcessEnvTest do
+  use Fountain.DataCase, async: true
+
+  alias Fountain.Conversations.{Identity, Provisioning, Redaction, SpriteEnv}
+  alias Fountain.{Environments, Vaults}
+  alias Managoat.Runtimes.{Claude, Codex, Gemini, OpenCode}
+
+  @names ~w(ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN OPENAI_API_KEY
+            GEMINI_API_KEY GOOGLE_GENERATIVE_AI_API_KEY)
+
+  test "each pinned runtime exports its credential to the process but not the shared file" do
+    cases = [
+      {Claude, "anthropic/claude", :anthropic_api_key, "ANTHROPIC_API_KEY"},
+      {Claude, "anthropic/claude", :claude_code_oauth_token, "CLAUDE_CODE_OAUTH_TOKEN"},
+      {Codex, "openai/gpt", :openai_api_key, "OPENAI_API_KEY"},
+      {Gemini, "google/gemini", :gemini_api_key, "GEMINI_API_KEY"},
+      {OpenCode, "anthropic/claude", :anthropic_api_key, "ANTHROPIC_API_KEY"},
+      {OpenCode, "openai/gpt", :openai_api_key, "OPENAI_API_KEY"},
+      {OpenCode, "google/gemini", :gemini_api_key, "GOOGLE_GENERATIVE_AI_API_KEY"}
+    ]
+
+    for {runtime, model, credential, name} <- cases do
+      sprite_env = build(%{model: model}, nil, %{}, runtime, %{credential => "runtime-bearer"})
+      assert {name, "runtime-bearer"} in sprite_env
+      assert_disk_excludes_auth(sprite_env)
+    end
+  end
+
+  test "environment and vault credentials and aliases remain process inputs only" do
+    user = insert_verified_user()
+    {:ok, dek} = Fountain.Crypto.load_tenant_key(user.id)
+    env = insert_env(user_id: user.id)
+    vault = insert_vault(user_id: user.id)
+
+    for name <- @names do
+      assert {:ok, _} =
+               Environments.upsert_secret(env, %{"key" => name, "value" => "env-bearer"}, dek)
+
+      assert {:ok, _} =
+               Vaults.upsert_secret(vault, %{"key" => name, "value" => "vault-bearer"}, dek)
+    end
+
+    for {selected_vault, expected} <- [{nil, "env-bearer"}, {vault, "vault-bearer"}] do
+      secrets = SpriteEnv.merge_secrets(env, selected_vault, dek)
+      sprite_env = build(nil, env, Map.put(secrets, "TOOL_SECRET", "tool-value"), Claude, %{})
+      for name <- @names, do: assert({name, expected} in sprite_env)
+      assert {"TOOL_SECRET", "tool-value"} in Identity.disk_env(sprite_env)
+      assert_disk_excludes_auth(sprite_env)
+    end
+  end
+
+  test "the managed broker placeholder reaches Codex's process environment only" do
+    placeholder = Fountain.Broker.placeholder("CODEX_CHATGPT_ACCESS_TOKEN")
+    sprite_env = build(nil, nil, %{}, Codex, %{codex_chatgpt_access_token: placeholder})
+    assert {"CODEX_CHATGPT_ACCESS_TOKEN", placeholder} in sprite_env
+    assert_disk_excludes_auth(sprite_env)
+  end
+
+  defp build(agent, env, secrets, runtime, credentials) do
+    conv_id = Ecto.UUID.generate()
+    on_exit(fn -> Redaction.delete(conv_id) end)
+
+    SpriteEnv.build(agent, env, secrets,
+      runtime_module: runtime,
+      env_credentials: credentials,
+      callback_token: nil,
+      conversation_id: conv_id,
+      sandbox_id: nil
+    )
+  end
+
+  defp assert_disk_excludes_auth(sprite_env) do
+    body = sprite_env |> Identity.disk_env() |> Provisioning.render_env_file()
+
+    for name <- ["CODEX_CHATGPT_ACCESS_TOKEN" | @names] do
+      refute body =~ "#{name}="
+    end
+  end
+end

--- a/apps/fountain/test/fountain/conversations/provisioning_test.exs
+++ b/apps/fountain/test/fountain/conversations/provisioning_test.exs
@@ -630,6 +630,23 @@ defmodule Fountain.Conversations.ProvisioningTest do
       end)
     end
 
+    test "empty process-filtered env overwrites any credential left in the shared file" do
+      handle = sandbox_handle("s")
+      stub(Sprites, :filesystem, fn _sprite, _root -> :fake_fs end)
+
+      expect(Sprites.Filesystem, :write, 2, fn :fake_fs, _path, body, _opts ->
+        assert body == "\n"
+        :ok
+      end)
+
+      stub_chmod_exec()
+
+      only_credentials = Fountain.Conversations.Identity.disk_env([{"OPENAI_API_KEY", "old-key"}])
+      assert only_credentials == []
+      assert :ok = Provisioning.write_env_file(handle, only_credentials)
+      assert :ok = Provisioning.write_env_file(handle, nil)
+    end
+
     test "write_env_file survives one transport failure on the file write" do
       {:ok, counter} = Agent.start_link(fn -> 0 end)
       handle = sandbox_handle("s")

--- a/apps/fountain/test/fountain/inference_credentials_env_names_test.exs
+++ b/apps/fountain/test/fountain/inference_credentials_env_names_test.exs
@@ -31,9 +31,22 @@ defmodule Fountain.InferenceCredentialsEnvNamesTest do
     end
   end
 
+  test "runtime aliases retain the canonical broker name first" do
+    assert InferenceCredentials.env_aliases() == %{
+             anthropic_api_key: ["ANTHROPIC_API_KEY"],
+             claude_code_oauth_token: ["CLAUDE_CODE_OAUTH_TOKEN"],
+             openai_api_key: ["OPENAI_API_KEY"],
+             gemini_api_key: ["GEMINI_API_KEY", "GOOGLE_GENERATIVE_AI_API_KEY"]
+           }
+
+    for {credential, [canonical | _]} <- InferenceCredentials.env_aliases() do
+      assert InferenceCredentials.env_names()[credential] == canonical
+    end
+  end
+
   # ADR 0052 decision 6: configuration may neither name the managed grant nor
   # embed its placeholder, so it is not a credential a tenant secret can
-  # shadow. Reserve what rotates, resolve what is static.
+  # shadow. Protect managed credentials; resolve ordinary tenant overrides.
   test "the managed ChatGPT grant is not one of them" do
     names = InferenceCredentials.env_names()
 


### PR DESCRIPTION
Provider credentials written to a shared sandbox `.env` can be read by other conversations. Keep supported credential names and aliases, including the Google runtime alias and managed Codex token, in process environments only. Empty environment writes also replace stale shared-file contents.

The upgrade note is included in this first behavioral slice: scripts that re-source `.env` must use their inherited process environment for provider credentials.

Validation: compilation with warnings as errors; 72 focused tests passed, one existing Linux-only check skipped on macOS.

Base: main. Part of #2018; next #2028.
