### PR TITLE
fix: untrack the deps symlink and ignore it by name (#2035)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # The directory Mix will write compiled artifacts to.
-/_build/
+/_build
 
 # If you run "mix test --cover", coverage assets end up here. Unanchored: in an
 # umbrella the reports land in apps/*/cover/ as well as at the root, and while
@@ -8,13 +8,16 @@
 cover/
 
 # Local build outputs (CLI binaries in CI, `mix openapi.export` locally).
-/dist/
+/dist
 
-# The directory Mix downloads your dependencies sources to.
-/deps/
+# The directory Mix downloads your dependencies sources to. No trailing slash
+# on these: a `dir/` pattern matches a directory only, so a SYMLINK named
+# `deps` was not ignored and a `git add -A` in a worktree staged one onto
+# main, pointing at a local scratchpad path (#2035).
+/deps
 
 # Where 3rd-party dependencies like ExDoc output generated docs.
-/doc/
+/doc
 
 # Ignore .fetch files in case you like to edit your project deps locally.
 /.fetch
@@ -26,7 +29,7 @@ erl_crash.dump
 *.ez
 
 # Temporary files, for example, from tests.
-/tmp/
+/tmp
 
 # ExUnit's `@tag :tmp_dir` writes under the app that runs the test, not the
 # umbrella root, and the behavioural CA install test uses one.

--- a/deps
+++ b/deps
@@ -1,1 +1,0 @@
-/private/tmp/claude-501/-Users-jake-dev-BinaryBourbon-fountain/9b86f823-5f5f-46ba-b9d9-dd55978fc91f/scratchpad/wt1744/deps


### PR DESCRIPTION
Closes #2035.

`deps` was a **tracked symlink on `main`** (mode `120000`) whose content is an absolute path inside one machine's session scratchpad:

```
/private/tmp/claude-501/-Users-jake-dev-BinaryBourbon-fountain/9b86f823-.../scratchpad/wt1744/deps
```

So every fresh clone, new worktree and CI checkout materialises a dangling symlink where `mix deps.get` expects to write. On the machine that created it, it resolves into **another agent session's worktree**, which that session can delete at any moment. It was the only tracked symlink in the repository.

## Why `.gitignore` did not stop it

`/deps/` is a **directory-only** pattern — the trailing slash is what makes it so. A symlink named `deps` is not a directory, so git never ignored it and a `git add -A` in a worktree staged it silently. It arrived with #1748, where `deps | 1 +` sits among ten real files and reads as noise in the stat.

## This change

- `git rm --cached deps` — untrack the blob. The working-tree symlink is left alone; `deps` is regenerated by `mix deps.get` as always.
- Drop the trailing slash from `/_build/`, `/deps/`, `/dist/`, `/doc/` and `/tmp/` so each matches a symlink as well as a directory, with a comment recording why.

Verified after the change: `git check-ignore -v deps` reports `.gitignore:17:/deps`, so the same symlink can no longer be staged.

No product change and no user-visible behaviour, so no CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZ1bttgnwKARvoanaiMy3z