### PR TITLE
fix: remove the committed deps symlink

### DIFF
--- a/deps
+++ b/deps
@@ -1,1 +1,0 @@
-/private/tmp/claude-501/-Users-jake-dev-BinaryBourbon-fountain/9b86f823-5f5f-46ba-b9d9-dd55978fc91f/scratchpad/wt1744/deps


### PR DESCRIPTION
#1748 committed a root `deps` symlink pointing at a scratchpad worktree on one machine:

```
deps -> /private/tmp/claude-501/-Users-jake-dev-BinaryBourbon-fountain/9b86f823-.../scratchpad/wt1744/deps
```

`/deps/` is in `.gitignore`, so the tree was never meant to be tracked; the symlink slipped past because git records it as a file entry, not a directory.

Every checkout but the one it was made on gets a dangling link where mix expects the dependency tree, and `mix deps.get` then writes through it into `/private/tmp` rather than the repo. Nothing goes red — the path is created on demand and the build succeeds against it — which is why it survived a full CI run.

```
$ git ls-tree origin/main deps
120000 blob c220e189dd8fd10449d71c1c1f101c6c783e1a82	deps
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ReRhgGKTWxrNuAUAe22C3L