### PR TITLE
fix(conversations): recheck absolute transport deadlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -271,6 +271,10 @@ upgrade, is in
 
 ### Fixed
 
+- Bounded execution transports recheck their absolute deadline before retiring
+  a turn. A timer that wakes early no longer interrupts a valid turn or hides
+  its eventual wall-time-limit outcome.
+
 - Sandbox `/diff` returns 422 when Git fails after repository discovery,
   instead of reporting an empty diff. Intentional byte-cap truncation still
   succeeds (#1904).

--- a/apps/fountain/lib/fountain/conversations/execution_transport.ex
+++ b/apps/fountain/lib/fountain/conversations/execution_transport.ex
@@ -81,8 +81,7 @@ defmodule Fountain.Conversations.ExecutionTransport do
     Process.flag(:trap_exit, true)
     execution = Keyword.fetch!(opts, :execution)
     owner = Keyword.fetch!(opts, :owner)
-    remaining = max(DateTime.diff(execution.deadline_at, DateTime.utc_now(), :millisecond), 0)
-    Process.send_after(self(), :deadline, remaining)
+    remaining = schedule_deadline(execution)
     Process.send_after(self(), :drain_end, remaining + 30_000)
 
     {:ok,
@@ -200,10 +199,28 @@ defmodule Fountain.Conversations.ExecutionTransport do
   end
 
   def handle_info(:retire, state), do: {:noreply, retire(state)}
-  def handle_info(:deadline, state), do: {:noreply, retire(state)}
+
+  def handle_info(:deadline, state) do
+    # A relative timer is only a wakeup hint. Rounding or a clock adjustment
+    # must not retire a still-valid journal as an ordinary interruption.
+    if DateTime.compare(DateTime.utc_now(), state.execution.deadline_at) == :lt do
+      schedule_deadline(state.execution)
+      {:noreply, state}
+    else
+      {:noreply, retire(state)}
+    end
+  end
+
   def handle_info(:retry_retire, state), do: {:noreply, request_retirement(state)}
   def handle_info(:drain_end, state), do: {:stop, :normal, state}
   def handle_info(_message, state), do: {:noreply, state}
+
+  defp schedule_deadline(execution) do
+    microseconds = DateTime.diff(execution.deadline_at, DateTime.utc_now(), :microsecond)
+    milliseconds = max(div(microseconds + 999, 1_000), 0)
+    Process.send_after(self(), :deadline, milliseconds)
+    milliseconds
+  end
 
   defp complete_job(%{kind: :spawn}, {:ok, %Command{provider: :sprites} = command}, state) do
     buffered = Enum.reverse(state.buffer)

--- a/apps/fountain/test/fountain/conversations/execution_transport_test.exs
+++ b/apps/fountain/test/fountain/conversations/execution_transport_test.exs
@@ -88,6 +88,22 @@ defmodule Fountain.Conversations.ExecutionTransportTest do
     assert :ok = ExecutionTransport.write(pid, "initialize")
   end
 
+  test "an early deadline wake keeps the admitted command writable", c do
+    execution = register(c)
+    {pid, ref} = launch(execution, &identify/2)
+    assert {:ok, %Command{ref: ^ref}} = ExecutionTransport.await_ready(pid)
+
+    # A relative millisecond timer can arrive just before the absolute
+    # deadline. Deliver that wake deterministically instead of racing clocks.
+    send(pid, :deadline)
+    assert :sys.get_state(pid).phase == :ready
+    assert row(execution).state == "active"
+    assert Repo.get!(Turn, execution.turn_id).status == "running"
+
+    expect(Sandbox, :write_stdin, fn %Command{ref: ^ref}, "initialize" -> :ok end)
+    assert :ok = ExecutionTransport.write(pid, "initialize")
+  end
+
   test "stdout and another command's control metadata cannot bind identity", c do
     execution = register(c)
 


### PR DESCRIPTION
An execution transport’s relative timer can wake just before its absolute deadline because the remaining time was rounded down to milliseconds. The handler immediately retired the journal, allowing a still-valid turn to be persisted as `interrupted` rather than eventually failing with `wall_time_limit`.

The handler now rechecks the absolute deadline and reschedules early wakes. Scheduling rounds up to the next millisecond. Actual expiry still uses the existing guarded retirement path; explicit close and failure handling retain their interruption semantics.

A deterministic regression delivers an early wake, verifies the journal and turn remain active, and exercises the real writer afterward. It fails against the old handler and passes with the fix. The complete transport and bounded-lifecycle modules pass **37 tests, 0 failures**, including actual independent deadline expiry.

Full `mix precommit` passed on OTP 28.3 / Elixir 1.19.2: compile, formatting, strict Credo, Dialyzer (zero errors), Sobelow, production release assembly, and all suites: **6 doctests + 5,615 core tests, 144 Buzz tests, 33 Support tests; zero failures** (2 skipped, 7 excluded). The full run used the original failing CI seed 495260 with max_cases 4 and unchanged assertions/timeouts.

Discovered while landing #1914: [required CI failure](https://github.com/managoat/fountain/actions/runs/34688178958/job/103538898924). The transport, guard, actor helper and failing lifecycle test were identical on that PR’s merge tree and main. This prerequisite fixes that inherited behavior rather than changing the expected terminal outcome in the test.
